### PR TITLE
Refactor enterprise PKI managed key code (OSS)

### DIFF
--- a/builtin/logical/pki/managed_key_util.go
+++ b/builtin/logical/pki/managed_key_util.go
@@ -13,25 +13,18 @@ import (
 
 var errEntOnly = errors.New("managed keys are supported within enterprise edition only")
 
-func generateCABundle(_ context.Context, _ *backend, input *inputBundle, data *certutil.CreationBundle, randomSource io.Reader) (*certutil.ParsedCertBundle, error) {
-	if kmsRequested(input) {
-		return nil, errEntOnly
-	}
-	return certutil.CreateCertificateWithRandomSource(data, randomSource)
+func generateManagedKeyCABundle(_ context.Context, _ *backend, _ *inputBundle, _ *certutil.CreationBundle, _ io.Reader) (*certutil.ParsedCertBundle, error) {
+	return nil, errEntOnly
 }
 
-func generateCSRBundle(_ context.Context, _ *backend, input *inputBundle, data *certutil.CreationBundle, addBasicConstraints bool, randomSource io.Reader) (*certutil.ParsedCSRBundle, error) {
-	if kmsRequested(input) {
-		return nil, errEntOnly
-	}
-
-	return certutil.CreateCSRWithRandomSource(data, addBasicConstraints, randomSource)
+func generateManagedKeyCSRBundle(_ context.Context, _ *backend, _ *inputBundle, _ *certutil.CreationBundle, _ bool, _ io.Reader) (*certutil.ParsedCSRBundle, error) {
+	return nil, errEntOnly
 }
 
-func parseCABundle(_ context.Context, _ *backend, _ *logical.Request, bundle *certutil.CertBundle) (*certutil.ParsedCertBundle, error) {
-	return bundle.ToParsedCertBundle()
+func parseManagedKeyCABundle(_ context.Context, _ *backend, _ *logical.Request, _ *certutil.CertBundle) (*certutil.ParsedCertBundle, error) {
+	return nil, errEntOnly
 }
 
-func withManagedPKIKey(_ context.Context, _ *backend, _ keyId, _ string, _ logical.ManagedSigningKeyConsumer) error {
+func withManagedPKIKey(_ context.Context, _ *backend, _ managedKeyId, _ string, _ logical.ManagedSigningKeyConsumer) error {
 	return errEntOnly
 }

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -30,7 +30,7 @@ func kmsRequested(input *inputBundle) bool {
 	return exportedStr.(string) == "kms"
 }
 
-type keyId interface {
+type managedKeyId interface {
 	String() string
 }
 
@@ -49,13 +49,13 @@ func (n NameKey) String() string {
 
 // getManagedKeyId returns a NameKey or a UUIDKey, whichever was specified in the
 // request API data.
-func getManagedKeyId(data *framework.FieldData) (keyId, error) {
+func getManagedKeyId(data *framework.FieldData) (managedKeyId, error) {
 	name, UUID, err := getManagedKeyNameOrUUID(data)
 	if err != nil {
 		return nil, err
 	}
 
-	var keyId keyId = NameKey(name)
+	var keyId managedKeyId = NameKey(name)
 	if len(UUID) > 0 {
 		keyId = UUIDKey(UUID)
 	}


### PR DESCRIPTION
 - As part of the PKI rotation project we need to hook into some of the functions
   that were factored out for managed keys in regards to key handling within the
   CA bundles.
 - Refactor the codebase so that we only extract managed key stuff from oss/ent
   and not additional business logic.