### PR TITLE
[VAULT-5887] TypeInt64 support added to OpenApi Spec generation

### DIFF
--- a/changelog/15104.txt
+++ b/changelog/15104.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sdk: Fix OpenApi spec generator to properly convert TypeInt64 to OAS supported int64
+```

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -613,6 +613,9 @@ func convertType(t FieldType) schemaType {
 		ret.format = "lowercase"
 	case TypeInt:
 		ret.baseType = "integer"
+	case TypeInt64:
+		ret.baseType = "integer"
+		ret.format = "int64"
 	case TypeDurationSecond, TypeSignedDurationSecond:
 		ret.baseType = "integer"
 		ret.format = "seconds"

--- a/sdk/framework/openapi_test.go
+++ b/sdk/framework/openapi_test.go
@@ -356,6 +356,10 @@ func TestOpenAPI_Paths(t *testing.T) {
 					Description:   "a header value",
 					AllowedValues: []interface{}{"a", "b", "c"},
 				},
+				"maximum": {
+					Type:        TypeInt64,
+					Description: "a maximum value",
+				},
 				"format": {
 					Type:        TypeString,
 					Description: "a query param",

--- a/sdk/framework/testdata/operations.json
+++ b/sdk/framework/testdata/operations.json
@@ -113,6 +113,11 @@
             "type": "string",
             "description": "a header value",
             "enum": ["a", "b", "c"]
+          },
+          "maximum" : {
+            "type": "integer",
+            "description": "a maximum value",
+            "format": "int64"
           }
         }
       }


### PR DESCRIPTION
`framework.TypeInt64` was not caught when converting to OpenApi types and would result in a confusing warning when calling `/v1/sys/internal/specs/openapi`

Verified by building Vault and generating an OpenApi spec and verifying we don't have any unknown formats in our spec. 