### PR TITLE
Add back metadata.json

### DIFF
--- a/ui/metadata.json
+++ b/ui/metadata.json
@@ -1,0 +1,7 @@
+
+{
+  "versions": {
+    "main": "https://vault-storybook.vercel.app/"
+  }
+}
+

--- a/ui/metadata.json
+++ b/ui/metadata.json
@@ -1,4 +1,3 @@
-
 {
   "versions": {
     "main": "https://vault-storybook.vercel.app/"


### PR DESCRIPTION
Adds back a file which the UI no longer needs but turned out to break the main vault build. 

The file was removed in #15074 and we'll need to investigate how to safely remove this file in the future