### PR TITLE
PKI read legacy CA bundle prior to migration

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -281,18 +281,7 @@ func TestBackend_InvalidParameter(t *testing.T) {
 
 func TestBackend_CSRValues(t *testing.T) {
 	initTest.Do(setCerts)
-	defaultLeaseTTLVal := time.Hour * 24
-	maxLeaseTTLVal := time.Hour * 24 * 32
-	b, err := Factory(context.Background(), &logical.BackendConfig{
-		Logger: nil,
-		System: &logical.StaticSystemView{
-			DefaultLeaseTTLVal: defaultLeaseTTLVal,
-			MaxLeaseTTLVal:     maxLeaseTTLVal,
-		},
-	})
-	if err != nil {
-		t.Fatalf("Unable to create backend: %s", err)
-	}
+	b, _ := createBackendWithStorage(t)
 
 	testCase := logicaltest.TestCase{
 		LogicalBackend: b,
@@ -308,18 +297,7 @@ func TestBackend_CSRValues(t *testing.T) {
 
 func TestBackend_URLsCRUD(t *testing.T) {
 	initTest.Do(setCerts)
-	defaultLeaseTTLVal := time.Hour * 24
-	maxLeaseTTLVal := time.Hour * 24 * 32
-	b, err := Factory(context.Background(), &logical.BackendConfig{
-		Logger: nil,
-		System: &logical.StaticSystemView{
-			DefaultLeaseTTLVal: defaultLeaseTTLVal,
-			MaxLeaseTTLVal:     maxLeaseTTLVal,
-		},
-	})
-	if err != nil {
-		t.Fatalf("Unable to create backend: %s", err)
-	}
+	b, _ := createBackendWithStorage(t)
 
 	testCase := logicaltest.TestCase{
 		LogicalBackend: b,
@@ -354,18 +332,8 @@ func TestBackend_Roles(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			initTest.Do(setCerts)
-			defaultLeaseTTLVal := time.Hour * 24
-			maxLeaseTTLVal := time.Hour * 24 * 32
-			b, err := Factory(context.Background(), &logical.BackendConfig{
-				Logger: nil,
-				System: &logical.StaticSystemView{
-					DefaultLeaseTTLVal: defaultLeaseTTLVal,
-					MaxLeaseTTLVal:     maxLeaseTTLVal,
-				},
-			})
-			if err != nil {
-				t.Fatalf("Unable to create backend: %s", err)
-			}
+			b, _ := createBackendWithStorage(t)
+
 			testCase := logicaltest.TestCase{
 				LogicalBackend: b,
 				Steps: []logicaltest.TestStep{
@@ -1749,13 +1717,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 }
 
 func TestBackend_PathFetchValidRaw(t *testing.T) {
-	config := logical.TestBackendConfig()
-	storage := &logical.InmemStorage{}
-	config.StorageView = storage
-
-	b := Backend(config)
-	err := b.Setup(context.Background(), config)
-	require.NoError(t, err)
+	b, storage := createBackendWithStorage(t)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -1884,15 +1846,7 @@ func TestBackend_PathFetchValidRaw(t *testing.T) {
 
 func TestBackend_PathFetchCertList(t *testing.T) {
 	// create the backend
-	config := logical.TestBackendConfig()
-	storage := &logical.InmemStorage{}
-	config.StorageView = storage
-
-	b := Backend(config)
-	err := b.Setup(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	b, storage := createBackendWithStorage(t)
 
 	// generate root
 	rootData := map[string]interface{}{
@@ -2034,15 +1988,7 @@ func TestBackend_SignVerbatim(t *testing.T) {
 
 func runTestSignVerbatim(t *testing.T, keyType string) {
 	// create the backend
-	config := logical.TestBackendConfig()
-	storage := &logical.InmemStorage{}
-	config.StorageView = storage
-
-	b := Backend(config)
-	err := b.Setup(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	b, storage := createBackendWithStorage(t)
 
 	// generate root
 	rootData := map[string]interface{}{
@@ -2479,15 +2425,7 @@ func TestBackend_SignIntermediate_AllowedPastCA(t *testing.T) {
 
 func TestBackend_SignSelfIssued(t *testing.T) {
 	// create the backend
-	config := logical.TestBackendConfig()
-	storage := &logical.InmemStorage{}
-	config.StorageView = storage
-
-	b := Backend(config)
-	err := b.Setup(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	b, storage := createBackendWithStorage(t)
 
 	// generate root
 	rootData := map[string]interface{}{
@@ -2626,15 +2564,7 @@ func TestBackend_SignSelfIssued(t *testing.T) {
 // require_matching_certificate_algorithms flag.
 func TestBackend_SignSelfIssued_DifferentTypes(t *testing.T) {
 	// create the backend
-	config := logical.TestBackendConfig()
-	storage := &logical.InmemStorage{}
-	config.StorageView = storage
-
-	b := Backend(config)
-	err := b.Setup(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	b, storage := createBackendWithStorage(t)
 
 	// generate root
 	rootData := map[string]interface{}{

--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -48,7 +48,7 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 	var err error
 
 	if b.useLegacyBundleCaStorage() {
-		return logical.ErrorResponse("Can not create intermediary until migration has completed"), nil
+		return logical.ErrorResponse("Can not create intermediate until migration has completed"), nil
 	}
 
 	exported, format, role, errorResp := b.getGenerationParams(ctx, data, req.MountPoint)

--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -47,6 +47,10 @@ appended to the bundle.`,
 func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	var err error
 
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Can not create intermediary until migration has completed"), nil
+	}
+
 	exported, format, role, errorResp := b.getGenerationParams(ctx, data, req.MountPoint)
 	if errorResp != nil {
 		return errorResp, nil

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -96,6 +96,10 @@ secret-key (optional) and certificates.`,
 func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	keysAllowed := strings.HasSuffix(req.Path, "bundle") || req.Path == "config/ca"
 
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Can not import issuers until migration has completed"), nil
+	}
+
 	var pemBundle string
 	var certificate string
 	rawPemBundle, bundleOk := data.GetOk("pem_bundle")

--- a/builtin/logical/pki/path_roles_test.go
+++ b/builtin/logical/pki/path_roles_test.go
@@ -20,6 +20,8 @@ func createBackendWithStorage(t *testing.T) (*backend, logical.Storage) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Assume for our tests we have performed the migration already.
+	b.pkiStorageVersion.Store(1)
 	return b, config.StorageView
 }
 

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -87,6 +87,10 @@ func (b *backend) pathCADeleteRoot(ctx context.Context, req *logical.Request, da
 func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	var err error
 
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Can not create root CA until migration has completed"), nil
+	}
+
 	exported, format, role, errorResp := b.getGenerationParams(ctx, data, req.MountPoint)
 	if errorResp != nil {
 		return errorResp, nil

--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -16,55 +16,88 @@ import (
 // and we need to perform it again...
 const latestMigrationVersion = 1
 
-type legacyBundleMigration struct {
+type legacyBundleMigrationLog struct {
 	Hash             string    `json:"hash" structs:"hash" mapstructure:"hash"`
 	Created          time.Time `json:"created" structs:"created" mapstructure:"created"`
 	MigrationVersion int       `json:"migrationVersion" structs:"migrationVersion" mapstructure:"migrationVersion"`
 }
 
+type migrationInfo struct {
+	isRequired       bool
+	legacyBundle     *certutil.CertBundle
+	legacyBundleHash string
+	migrationLog     *legacyBundleMigrationLog
+}
+
+func getMigrationInfo(ctx context.Context, s logical.Storage) (migrationInfo, error) {
+	migrationInfo := migrationInfo{
+		isRequired:       false,
+		legacyBundle:     nil,
+		legacyBundleHash: "",
+	}
+	var err error
+
+	migrationInfo.legacyBundle, err = getLegacyCertBundle(ctx, s)
+	if err != nil {
+		return migrationInfo, err
+	}
+
+	if migrationInfo.legacyBundle == nil {
+		return migrationInfo, nil
+	}
+
+	migrationInfo.migrationLog, err = getLegacyBundleMigrationLog(ctx, s)
+	if err != nil {
+		return migrationInfo, err
+	}
+
+	migrationInfo.legacyBundleHash, err = computeHashOfLegacyBundle(migrationInfo.legacyBundle)
+	if err != nil {
+		return migrationInfo, err
+	}
+
+	if migrationInfo.migrationLog != nil {
+		// At this point we have already migrated something previously.
+		if migrationInfo.migrationLog.Hash == migrationInfo.legacyBundleHash &&
+			migrationInfo.migrationLog.MigrationVersion == latestMigrationVersion {
+			return migrationInfo, nil
+		}
+	}
+
+	migrationInfo.isRequired = true
+	return migrationInfo, nil
+}
+
 func migrateStorage(ctx context.Context, req *logical.InitializationRequest, logger log.Logger) error {
 	s := req.Storage
-	legacyBundle, err := getLegacyCertBundle(ctx, s)
+	migrationInfo, err := getMigrationInfo(ctx, req.Storage)
 	if err != nil {
 		return err
 	}
 
-	if legacyBundle == nil {
-		// No legacy certs to migrate, we are done...
-		logger.Debug("No legacy certs found, no migration required.")
-		return nil
-	}
-
-	migrationEntry, err := getLegacyBundleMigrationLog(ctx, s)
-	if err != nil {
-		return err
-	}
-	hash, err := computeHashOfLegacyBundle(legacyBundle)
-	if err != nil {
-		return err
-	}
-
-	if migrationEntry != nil {
-		// At this point we have already migrated something previously.
-		if migrationEntry.Hash == hash &&
-			migrationEntry.MigrationVersion == latestMigrationVersion {
+	if !migrationInfo.isRequired {
+		if migrationInfo.legacyBundle == nil {
+			// No legacy certs to migrate, we are done...
+			logger.Debug("No legacy certs found, no migration required.")
+		}
+		if migrationInfo.migrationLog != nil {
 			// The hashes are the same, no need to try and re-import...
 			logger.Debug("existing migration hash found and matched legacy bundle, skipping migration.")
-			return nil
 		}
+		return nil
 	}
 
 	logger.Info("performing PKI migration to new keys/issuers layout")
 
-	anIssuer, aKey, err := writeCaBundle(ctx, s, legacyBundle, "current", "current")
+	anIssuer, aKey, err := writeCaBundle(ctx, s, migrationInfo.legacyBundle, "current", "current")
 	if err != nil {
 		return err
 	}
 	logger.Debug("Migration generated the following ids and set them as defaults",
 		"issuer id", anIssuer.ID, "key id", aKey.ID)
 
-	err = setLegacyBundleMigrationLog(ctx, s, &legacyBundleMigration{
-		Hash:             hash,
+	err = setLegacyBundleMigrationLog(ctx, s, &legacyBundleMigrationLog{
+		Hash:             migrationInfo.legacyBundleHash,
 		Created:          time.Now(),
 		MigrationVersion: latestMigrationVersion,
 	})
@@ -90,7 +123,7 @@ func computeHashOfLegacyBundle(bundle *certutil.CertBundle) (string, error) {
 	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
-func getLegacyBundleMigrationLog(ctx context.Context, s logical.Storage) (*legacyBundleMigration, error) {
+func getLegacyBundleMigrationLog(ctx context.Context, s logical.Storage) (*legacyBundleMigrationLog, error) {
 	entry, err := s.Get(ctx, legacyMigrationBundleLogKey)
 	if err != nil {
 		return nil, err
@@ -100,7 +133,7 @@ func getLegacyBundleMigrationLog(ctx context.Context, s logical.Storage) (*legac
 		return nil, nil
 	}
 
-	lbm := &legacyBundleMigration{}
+	lbm := &legacyBundleMigrationLog{}
 	err = entry.DecodeJSON(lbm)
 	if err != nil {
 		// If we can't decode our bundle, lets scrap it and assume a blank value,
@@ -110,7 +143,7 @@ func getLegacyBundleMigrationLog(ctx context.Context, s logical.Storage) (*legac
 	return lbm, nil
 }
 
-func setLegacyBundleMigrationLog(ctx context.Context, s logical.Storage, lbm *legacyBundleMigration) error {
+func setLegacyBundleMigrationLog(ctx context.Context, s logical.Storage, lbm *legacyBundleMigrationLog) error {
 	json, err := logical.StorageEntryJSON(legacyMigrationBundleLogKey, lbm)
 	if err != nil {
 		return err

--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -11,11 +11,16 @@ import (
 )
 
 func Test_migrateStorageEmptyStorage(t *testing.T) {
+	startTime := time.Now()
 	ctx := context.Background()
 	b, s := createBackendWithStorage(t)
-	request := &logical.InitializationRequest{Storage: s}
 
-	err := migrateStorage(ctx, request, b.Logger())
+	// Reset the version the helper above set to 1.
+	b.pkiStorageVersion.Store(0)
+	require.True(t, b.useLegacyBundleCaStorage(), "pre migration we should have been told to use legacy storage.")
+
+	request := &logical.InitializationRequest{Storage: s}
+	err := b.initialize(ctx, request)
 	require.NoError(t, err)
 
 	issuerIds, err := listIssuers(ctx, s)
@@ -28,13 +33,35 @@ func Test_migrateStorageEmptyStorage(t *testing.T) {
 
 	logEntry, err := getLegacyBundleMigrationLog(ctx, s)
 	require.NoError(t, err)
-	require.Nil(t, logEntry)
+	require.NotNil(t, logEntry)
+	require.Equal(t, latestMigrationVersion, logEntry.MigrationVersion)
+	require.True(t, len(strings.TrimSpace(logEntry.Hash)) > 0,
+		"Hash value (%s) should not have been empty", logEntry.Hash)
+	require.True(t, startTime.Before(logEntry.Created),
+		"created log entry time (%v) was before our start time(%v)?", logEntry.Created, startTime)
+
+	require.False(t, b.useLegacyBundleCaStorage(), "post migration we are still told to use legacy storage")
+
+	// Make sure we can re-run the migration without issues
+	request = &logical.InitializationRequest{Storage: s}
+	err = b.initialize(ctx, request)
+	require.NoError(t, err)
+	logEntry2, err := getLegacyBundleMigrationLog(ctx, s)
+	require.NoError(t, err)
+	require.NotNil(t, logEntry2)
+
+	// Make sure the hash and created times have not changed.
+	require.Equal(t, logEntry.Created, logEntry2.Created)
+	require.Equal(t, logEntry.Hash, logEntry2.Hash)
 }
 
 func Test_migrateStorageSimpleBundle(t *testing.T) {
 	startTime := time.Now()
 	ctx := context.Background()
 	b, s := createBackendWithStorage(t)
+	// Reset the version the helper above set to 1.
+	b.pkiStorageVersion.Store(0)
+	require.True(t, b.useLegacyBundleCaStorage(), "pre migration we should have been told to use legacy storage.")
 
 	bundle := genCertBundle(t, b)
 	json, err := logical.StorageEntryJSON(legacyCertBundlePath, bundle)
@@ -43,8 +70,8 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 	require.NoError(t, err)
 
 	request := &logical.InitializationRequest{Storage: s}
-
-	err = migrateStorage(ctx, request, b.Logger())
+	err = b.initialize(ctx, request)
+	require.NoError(t, err)
 	require.NoError(t, err)
 
 	issuerIds, err := listIssuers(ctx, s)
@@ -99,7 +126,7 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 	require.Equal(t, &issuerConfigEntry{DefaultIssuerId: issuerId}, issuersConfig)
 
 	// Make sure if we attempt to re-run the migration nothing happens...
-	err = migrateStorage(ctx, request, b.Logger())
+	err = migrateStorage(ctx, s, b.Logger())
 	require.NoError(t, err)
 	logEntry2, err := getLegacyBundleMigrationLog(ctx, s)
 	require.NoError(t, err)
@@ -107,4 +134,6 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 
 	require.Equal(t, logEntry.Created, logEntry2.Created)
 	require.Equal(t, logEntry.Hash, logEntry2.Hash)
+
+	require.False(t, b.useLegacyBundleCaStorage(), "post migration we are still told to use legacy storage")
 }

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -191,7 +191,7 @@ func getKeyRef(data *framework.FieldData) string {
 
 func extractRef(data *framework.FieldData, paramName string) string {
 	value := strings.TrimSpace(data.Get(paramName).(string))
-	if strings.ToLower(value) == defaultRef {
+	if strings.EqualFold(value, defaultRef) {
 		return defaultRef
 	}
 	return value


### PR DESCRIPTION
When the new Vault version starts up and becomes the leader node on a secondary performance cluster it should be able to still support certificate issue/revoke and list commands even when the storage was not migrated.

### Known limitations

The new api on the secondary does not return the proper information in regards to issuers and keys as we don't fallback for those api calls.

### Testing performed

- Started up a primary and secondary performance clusters on 1.10 setting up a full CA within two separate mounts. 
- Upgraded the secondary performance cluster and verified that I could issue a new certificate from it as well as revoking a cert. 
- Upgraded the primary and verified that the new issuers api started working without restarting Vault on the secondary performance cluster. 
