### PR TITLE
Clone things to prevent races.

### DIFF
--- a/changelog/15123.txt
+++ b/changelog/15123.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Fix some identity data races found by Go race detector (no known impact yet).
+```

--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -786,7 +786,7 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 			return errors.New("to_entity_id should not be present in from_entity_ids"), nil
 		}
 
-		fromEntity, err := i.MemDBEntityByID(fromEntityID, false)
+		fromEntity, err := i.MemDBEntityByID(fromEntityID, true)
 		if err != nil {
 			return nil, err
 		}

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -667,7 +667,7 @@ func (i *IdentityStore) processLocalAlias(ctx context.Context, lAlias *logical.A
 		return nil, fmt.Errorf("mount accessor %q is not local", lAlias.MountAccessor)
 	}
 
-	alias, err := i.MemDBAliasByFactors(lAlias.MountAccessor, lAlias.Name, false, false)
+	alias, err := i.MemDBAliasByFactors(lAlias.MountAccessor, lAlias.Name, true, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
An example of one of the races is here: https://app.circleci.com/pipelines/github/hashicorp/vault-enterprise/12932/workflows/33d46609-5096-4018-9f06-a73a258ced2e/jobs/375638

While testing the fix for that (the one in identity_store_util) by running untilfail against TestReplicationApi_ApproleLocal_MultiNodeMultiLogin, I found this race:

```
WARNING: DATA RACE
Write at 0x00c0026c4308 by goroutine 435:
  github.com/hashicorp/vault/vault.(*IdentityStore).mergeEntity()
      /Users/ncc/hc/vault-enterprise/vault/identity_store_entities.go:804 +0x14c0
  github.com/hashicorp/vault/vault.(*IdentityStore).upsertEntityInTxn()
      /Users/ncc/hc/vault-enterprise/vault/identity_store_util.go:597 +0x12f8
  github.com/hashicorp/vault/vault.(*IdentityStore).processLocalAlias()
      /Users/ncc/hc/vault-enterprise/vault/identity_store_util.go:732 +0xd00
  github.com/hashicorp/vault/vault.(*replicationServiceHandler).RegisterLocalAliasRequest()
      /Users/ncc/hc/vault-enterprise/vault/replication_rpc_ent.go:914 +0x3c4
  github.com/hashicorp/vault/vault.(*standbyReplicationServiceHandler).RegisterLocalAliasRequest()
      <autogenerated>:1 +0x5c
  github.com/hashicorp/vault/vault._Replication_RegisterLocalAliasRequest_Handler()
      /Users/ncc/hc/vault-enterprise/vault/replication_services_ent_grpc.pb.go:641 +0x1f4
  google.golang.org/grpc.(*Server).processUnaryRPC()
      /Users/ncc/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1282 +0xf00
  google.golang.org/grpc.(*Server).handleStream()
      /Users/ncc/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1616 +0xc00
  google.golang.org/grpc.(*Server).serveStreams.func1.2()
      /Users/ncc/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:921 +0xa4

Previous read at 0x00c0026c4308 by goroutine 285:
  google.golang.org/protobuf/internal/impl.appendStringNoZeroValidateUTF8()
      /Users/ncc/go/pkg/mod/google.golang.org/protobuf@v1.27.1/internal/impl/codec_gen.go:5021 +0x54
  google.golang.org/protobuf/internal/impl.(*MessageInfo).marshalAppendPointer()
      /Users/ncc/go/pkg/mod/google.golang.org/protobuf@v1.27.1/internal/impl/encode.go:139 +0x30c
  google.golang.org/protobuf/internal/impl.(*MessageInfo).marshal()
      /Users/ncc/go/pkg/mod/google.golang.org/protobuf@v1.27.1/internal/impl/encode.go:107 +0xac
  google.golang.org/protobuf/internal/impl.(*MessageInfo).marshal-fm()
      <autogenerated>:1 +0x84
  google.golang.org/protobuf/proto.MarshalOptions.marshal()
      /Users/ncc/go/pkg/mod/google.golang.org/protobuf@v1.27.1/proto/encode.go:163 +0x2bc
  google.golang.org/protobuf/proto.MarshalOptions.MarshalAppend()
      /Users/ncc/go/pkg/mod/google.golang.org/protobuf@v1.27.1/proto/encode.go:122 +0x78
  github.com/golang/protobuf/proto.marshalAppend()
      /Users/ncc/go/pkg/mod/github.com/golang/protobuf@v1.5.2/proto/wire.go:40 +0x90
  github.com/golang/protobuf/proto.Marshal()
      /Users/ncc/go/pkg/mod/github.com/golang/protobuf@v1.5.2/proto/wire.go:23 +0x4c
  github.com/hashicorp/vault/helper/identity.(*Alias).Clone()
      /Users/ncc/hc/vault-enterprise/helper/identity/identity.go:63 +0x1c
  github.com/hashicorp/vault/vault.(*IdentityStore).MemDBAliasByFactorsInTxn()
      /Users/ncc/hc/vault-enterprise/vault/identity_store_util.go:977 +0x1f8
  github.com/hashicorp/vault/vault.(*IdentityStore).MemDBAliasByFactors()
      /Users/ncc/hc/vault-enterprise/vault/identity_store_util.go:941 +0xd0
  github.com/hashicorp/vault/vault.(*IdentityStore).processLocalAlias()
      /Users/ncc/hc/vault-enterprise/vault/identity_store_util.go:670 +0x11c
  github.com/hashicorp/vault/vault.(*replicationServiceHandler).RegisterLocalAliasRequest()
      /Users/ncc/hc/vault-enterprise/vault/replication_rpc_ent.go:914 +0x3c4
  github.com/hashicorp/vault/vault.(*standbyReplicationServiceHandler).RegisterLocalAliasRequest()
      <autogenerated>:1 +0x5c
  github.com/hashicorp/vault/vault._Replication_RegisterLocalAliasRequest_Handler()
  google.golang.org/grpc.(*Server).processUnaryRPC() 
      /Users/ncc/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1282 +0xf00 
  google.golang.org/grpc.(*Server).handleStream() 
      /Users/ncc/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1616 +0xc00 
  google.golang.org/grpc.(*Server).serveStreams.func1.2() 
      /Users/ncc/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:921 +0xa4 

```