### PR TITLE
Expand NotAfter limit enforcement behavior

### DIFF
--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -440,7 +440,7 @@ func buildCRL(ctx context.Context, b *backend, req *logical.Request, forceNew bo
 	revokedCerts = revoked
 
 WRITE:
-	bundle, caErr := fetchCertBundleByIssuerId(ctx, req.Storage, thisIssuerId, true /* need the signing key */)
+	_, bundle, caErr := fetchCertBundleByIssuerId(ctx, req.Storage, thisIssuerId, true /* need the signing key */)
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -860,8 +860,6 @@ type roleEntry struct {
 	NotBeforeDuration             time.Duration `json:"not_before_duration" mapstructure:"not_before_duration"`
 	NotAfter                      string        `json:"not_after" mapstructure:"not_after"`
 	Issuer                        string        `json:"issuer" mapstructure:"issuer"`
-	// Used internally for signing intermediates
-	AllowExpirationPastCA bool
 }
 
 func (r *roleEntry) ToResponseData() map[string]interface{} {

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -240,7 +240,6 @@ func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.R
 		AllowedOtherSANs:          []string{"*"},
 		AllowedSerialNumbers:      []string{"*"},
 		AllowedURISANs:            []string{"*"},
-		AllowExpirationPastCA:     true,
 		NotAfter:                  data.Get("not_after").(string),
 	}
 	*role.AllowWildcardCertificates = true
@@ -261,6 +260,11 @@ func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.R
 				"error fetching CA certificate: %s", caErr)}
 		}
 	}
+
+	// Since we are signing an intermediate, we explicitly want to override
+	// the leaf NotAfterBehavior to permit issuing intermediates longer than
+	// the life of this issuer.
+	signingBundle.LeafNotAfterBehavior = certutil.PermitNotAfterBehavior
 
 	useCSRValues := data.Get("use_csr_values").(bool)
 

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -56,13 +56,14 @@ type keyEntry struct {
 }
 
 type issuerEntry struct {
-	ID           issuerID   `json:"id" structs:"id" mapstructure:"id"`
-	Name         string     `json:"name" structs:"name" mapstructure:"name"`
-	KeyID        keyID      `json:"key_id" structs:"key_id" mapstructure:"key_id"`
-	Certificate  string     `json:"certificate" structs:"certificate" mapstructure:"certificate"`
-	CAChain      []string   `json:"ca_chain" structs:"ca_chain" mapstructure:"ca_chain"`
-	ManualChain  []issuerID `json:"manual_chain" structs:"manual_chain" mapstructure:"manual_chain"`
-	SerialNumber string     `json:"serial_number" structs:"serial_number" mapstructure:"serial_number"`
+	ID                   issuerID                  `json:"id" structs:"id" mapstructure:"id"`
+	Name                 string                    `json:"name" structs:"name" mapstructure:"name"`
+	KeyID                keyID                     `json:"key_id" structs:"key_id" mapstructure:"key_id"`
+	Certificate          string                    `json:"certificate" structs:"certificate" mapstructure:"certificate"`
+	CAChain              []string                  `json:"ca_chain" structs:"ca_chain" mapstructure:"ca_chain"`
+	ManualChain          []issuerID                `json:"manual_chain" structs:"manual_chain" mapstructure:"manual_chain"`
+	SerialNumber         string                    `json:"serial_number" structs:"serial_number" mapstructure:"serial_number"`
+	LeafNotAfterBehavior certutil.NotAfterBehavior `json:"not_after_behavior" structs:"not_after_behavior" mapstructure:"not_after_behavior"`
 }
 
 type localCRLConfigEntry struct {
@@ -440,6 +441,7 @@ func importIssuer(ctx context.Context, s logical.Storage, certValue string, issu
 	result.ID = genIssuerId()
 	result.Name = issuerName
 	result.Certificate = certValue
+	result.LeafNotAfterBehavior = certutil.ErrNotAfterBehavior
 
 	// We shouldn't add CSRs or multiple certificates in this
 	countCertificates := strings.Count(result.Certificate, "-BEGIN ")
@@ -659,10 +661,10 @@ func resolveIssuerCRLPath(ctx context.Context, s logical.Storage, reference stri
 
 // Builds a certutil.CertBundle from the specified issuer identifier,
 // optionally loading the key or not.
-func fetchCertBundleByIssuerId(ctx context.Context, s logical.Storage, id issuerID, loadKey bool) (*certutil.CertBundle, error) {
+func fetchCertBundleByIssuerId(ctx context.Context, s logical.Storage, id issuerID, loadKey bool) (*issuerEntry, *certutil.CertBundle, error) {
 	issuer, err := fetchIssuerById(ctx, s, id)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var bundle certutil.CertBundle
@@ -674,14 +676,14 @@ func fetchCertBundleByIssuerId(ctx context.Context, s logical.Storage, id issuer
 	if loadKey && issuer.KeyID != keyID("") {
 		key, err := fetchKeyById(ctx, s, issuer.KeyID)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		bundle.PrivateKeyType = key.PrivateKeyType
 		bundle.PrivateKey = key.PrivateKey
 	}
 
-	return &bundle, nil
+	return issuer, &bundle, nil
 }
 
 func writeCaBundle(ctx context.Context, s logical.Storage, caBundle *certutil.CertBundle, issuerName string, keyName string) (*issuerEntry, *keyEntry, error) {

--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -112,7 +112,7 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 	require.Equal(t, bundle.PrivateKeyType, key.PrivateKeyType)
 
 	// Make sure we kept the old bundle
-	certBundle, err := getLegacyCertBundle(ctx, s)
+	_, certBundle, err := getLegacyCertBundle(ctx, s)
 	require.NoError(t, err)
 	require.Equal(t, bundle, certBundle)
 

--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/require"
 )
@@ -96,6 +97,7 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 	issuer, err := fetchIssuerById(ctx, s, issuerId)
 	require.NoError(t, err)
 	require.Equal(t, "current", issuer.Name) // RFC says we should import with Name=current
+	require.Equal(t, certutil.ErrNotAfterBehavior, issuer.LeafNotAfterBehavior)
 
 	key, err := fetchKeyById(ctx, s, keyId)
 	require.NoError(t, err)

--- a/sdk/helper/certutil/certutil_test.go
+++ b/sdk/helper/certutil/certutil_test.go
@@ -896,6 +896,20 @@ func TestComparePublicKeysAndType(t *testing.T) {
 	}
 }
 
+func TestNotAfterValues(t *testing.T) {
+	if ErrNotAfterBehavior != 0 {
+		t.Fatalf("Expected ErrNotAfterBehavior=%v to have value 0", ErrNotAfterBehavior)
+	}
+
+	if TruncateNotAfterBehavior != 1 {
+		t.Fatalf("Expected TruncateNotAfterBehavior=%v to have value 1", TruncateNotAfterBehavior)
+	}
+
+	if PermitNotAfterBehavior != 2 {
+		t.Fatalf("Expected PermitNotAfterBehavior=%v to have value 2", PermitNotAfterBehavior)
+	}
+}
+
 func genRsaKey(t *testing.T) *rsa.PrivateKey {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -675,9 +675,18 @@ type URLEntries struct {
 	OCSPServers           []string `json:"ocsp_servers" structs:"ocsp_servers" mapstructure:"ocsp_servers"`
 }
 
+type NotAfterBehavior int
+
+const (
+	ErrNotAfterBehavior NotAfterBehavior = iota
+	TruncateNotAfterBehavior
+	PermitNotAfterBehavior
+)
+
 type CAInfoBundle struct {
 	ParsedCertBundle
-	URLs *URLEntries
+	URLs                 *URLEntries
+	LeafNotAfterBehavior NotAfterBehavior
 }
 
 func (b *CAInfoBundle) GetCAChain() []*CertBlock {


### PR DESCRIPTION
Vault previously strictly enforced `NotAfter`/`ttl` values on certificate
requests, erring if the requested TTL extended past the `NotAfter` date of
the issuer. In the event of issuing an intermediate, this behavior was
ignored, instead permitting the issuance.

Users generally do not think to check their issuer's `NotAfter` date when
requesting a certificate; thus this behavior was generally surprising.

[Per RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.5) however, issuers need to maintain status information
throughout the life cycle of the issued cert. If this leaf cert were to
be issued for a longer duration than the parent issuer, the CA must
still maintain revocation information past its expiration.

Thus, we add an option to the issuer to change the desired behavior:

 - `err`, to err out,
 - `permit`, to permit the longer `NotAfter` date, or
 - `truncate`, to silently truncate the expiration to the issuer's
   `NotAfter` date.

Since expiration of certificates in the system's trust store are not
generally validated (when validating an arbitrary leaf, e.g., during TLS
validation), permit should generally only be used in that case. However,
browsers usually validate intermediate's validity periods, and thus
truncate should likely be used (as with permit, the leaf's chain will
not validate towards the end of the issuance period).

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`