### PR TITLE
Update CA Chain to report entire chain

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1773,7 +1773,7 @@ func TestBackend_PathFetchValidRaw(t *testing.T) {
 	}
 	rootCaAsPem := resp.Data["certificate"].(string)
 
-	// The ca_chain call at least for now does not return the root CA authority
+	// Chain should contain the root.
 	resp, err = b.HandleRequest(context.Background(), &logical.Request{
 		Operation:  logical.ReadOperation,
 		Path:       "ca_chain",
@@ -1785,7 +1785,9 @@ func TestBackend_PathFetchValidRaw(t *testing.T) {
 	if resp != nil && resp.IsError() {
 		t.Fatalf("failed read ca_chain, %#v", resp)
 	}
-	require.Equal(t, []byte{}, resp.Data[logical.HTTPRawBody], "ca_chain response should have been empty")
+	if strings.Count(string(resp.Data[logical.HTTPRawBody].([]byte)), rootCaAsPem) != 1 {
+		t.Fatalf("expected raw chain to contain the root cert")
+	}
 
 	// The ca/pem should return us the actual CA...
 	resp, err = b.HandleRequest(context.Background(), &logical.Request{

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -205,17 +205,6 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 		}
 
 		if serial == "ca_chain" {
-			caChain := caInfo.GetCAChain()
-			var certStr string
-			for _, ca := range caChain {
-				block := pem.Block{
-					Type:  "CERTIFICATE",
-					Bytes: ca.Bytes,
-				}
-				certStr = strings.Join([]string{certStr, strings.TrimSpace(string(pem.EncodeToMemory(&block)))}, "\n")
-			}
-			certificate = []byte(strings.TrimSpace(certStr))
-
 			rawChain := caInfo.GetFullChain()
 			var chainStr string
 			for _, ca := range rawChain {
@@ -226,6 +215,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 				chainStr = strings.Join([]string{chainStr, strings.TrimSpace(string(pem.EncodeToMemory(&block)))}, "\n")
 			}
 			fullChain = []byte(strings.TrimSpace(chainStr))
+			certificate = fullChain
 		} else if serial == "ca" {
 			certificate = caInfo.Certificate.Raw
 


### PR DESCRIPTION
This merges the `ca_chain` JSON field (of the `/certs/ca_chain` path) with
the regular `certificate` field, returning the root of trust always. This
also affects the non-JSON (raw) endpoints as well.

We return the default issuer's chain here, rather than all known issuers
(as that may not form a strict chain).

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`