### PR TITLE
fix raft tls key rotation panic when rotation time in past

### DIFF
--- a/changelog/15156.txt
+++ b/changelog/15156.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+rafft: fix Raft TLS key rotation panic that occurs if active key is more than 24 hours old
+```

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -500,7 +500,6 @@ func (c *Core) raftTLSRotatePhased(ctx context.Context, logger hclog.Logger, raf
 		ticker := time.NewTicker(time.Until(nextRotationTime))
 		defer ticker.Stop()
 		for {
-			ticker.Reset(time.Until(nextRotationTime))
 			select {
 			case <-keyCheckInterval.C:
 				err := checkCommitted()
@@ -516,6 +515,8 @@ func (c *Core) raftTLSRotatePhased(ctx context.Context, logger hclog.Logger, raf
 				} else {
 					nextRotationTime = getNextRotationTime(next)
 				}
+
+				ticker.Reset(time.Until(nextRotationTime))
 
 			case <-stopCh:
 				return

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -485,7 +485,7 @@ func (c *Core) raftTLSRotatePhased(ctx context.Context, logger hclog.Logger, raf
 		}
 
 		// push out to ensure proposed time does not elapse
-		return next.Add(1 * time.Minute)
+		return next.Add(10 * time.Second)
 	}
 
 	// Start the process in a go routine

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -473,18 +473,19 @@ func (c *Core) raftTLSRotatePhased(ctx context.Context, logger hclog.Logger, raf
 		return errors.New("no active raft TLS key found")
 	}
 
-	getNextRotationTime := func(proposedNext time.Time) time.Time {
+	getNextRotationTime := func(next time.Time) time.Time {
 		now := time.Now()
 
 		// active key's CreatedTime + raftTLSRotationPeriod might be in
 		// the past (meaning it is ready to be rotated) which will cause
 		// NewTicker to panic when used with time.Until, prevent this by
 		// pushing out rotation time into very near future
-		if proposedNext.Before(now) {
+		if next.Before(now) {
 			return now.Add(1 * time.Minute)
 		}
 
-		return proposedNext
+		// push out to ensure proposed time does not elapse
+		return next.Add(1 * time.Minute)
 	}
 
 	// Start the process in a go routine


### PR DESCRIPTION
Raft TLS key rotation will panic if the active key's creation time is more than 24 hours the past. Calculating the duration using `time.Until` will produce a negative value which causes time.NewTicker` to panic. This PR introduces a fix for this issue by creating a ticker with a duration equal to 1 minute to effectively cause rotation to occur immediately.

Fixes: https://github.com/hashicorp/vault/issues/15147