### PR TITLE
[VAULT-5813] Remove duplicate sha_256 in SystemCatalogRequest OAS

### DIFF
--- a/changelog/15163.txt
+++ b/changelog/15163.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sdk: Fix OpenApi spec generator to remove duplicate sha_256 parameter
+```

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -336,6 +336,8 @@ func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix st
 				}
 
 				for name, field := range bodyFields {
+					// Removing this field from the spec as it is deprecated in favor of using "sha256"
+					// The duplicate sha_256 and sha256 in these paths cause issues with codegen
 					if name == "sha_256" && strings.Contains(path, "plugins/catalog/") {
 						continue
 					}

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -336,7 +336,7 @@ func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix st
 				}
 
 				for name, field := range bodyFields {
-					if name == "sha_256" {
+					if name == "sha_256" && strings.Contains(path, "plugins/catalog/") {
 						continue
 					}
 

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -336,6 +336,10 @@ func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix st
 				}
 
 				for name, field := range bodyFields {
+					if name == "sha_256" {
+						continue
+					}
+
 					openapiField := convertType(field.Type)
 					if field.Required {
 						s.Required = append(s.Required, name)


### PR DESCRIPTION
Currently, there is a duplicate `sha256` and `sha_256` field in the OpenApi Spec for SystemCatalogRequest. This causes issues for codegen because they get mapped to the same variable name. We're removing the `sha_256` in the OpenApi spec to avoid this. 