### PR TITLE
Allow explicit issuer override on roles

### DIFF
--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -206,6 +207,11 @@ func (b *backend) pathSignVerbatim(ctx context.Context, req *logical.Request, da
 			*entry.GenerateLease = *role.GenerateLease
 		}
 		entry.NoStore = role.NoStore
+		entry.Issuer = role.Issuer
+	}
+
+	if len(entry.Issuer) == 0 {
+		entry.Issuer = defaultRef
 	}
 
 	return b.pathIssueSignCert(ctx, req, data, entry, true, true)
@@ -218,9 +224,29 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 		return nil, logical.ErrReadOnly
 	}
 
-	issuerName := getIssuerRef(data)
-	if len(issuerName) == 0 {
-		return logical.ErrorResponse("missing issuer reference"), nil
+	// We prefer the issuer from the role in two cases:
+	//
+	// 1. On the legacy sign-verbatim paths, as we always provision an issuer
+	//    in both the role and role-less cases, and
+	// 2. On the legacy sign/:role or issue/:role paths, as the issuer was
+	//    set on the role directly (either via upgrade or not). Note that
+	//    the updated issuer/:ref/{sign,issue}/:role path is not affected,
+	//    and we instead pull the issuer out of the path instead (which
+	//    allows users with access to those paths to manually choose their
+	//    issuer in desired scenarios).
+	var issuerName string
+	if strings.HasPrefix(req.Path, "sign-verbatim/") || strings.HasPrefix(req.Path, "sign/") || strings.HasPrefix(req.Path, "issue/") {
+		issuerName = role.Issuer
+		if len(issuerName) == 0 {
+			issuerName = defaultRef
+		}
+	} else {
+		// Otherwise, we must have a newer API which requires an issuer
+		// reference. Fetch it in this case
+		issuerName = getIssuerRef(data)
+		if len(issuerName) == 0 {
+			return logical.ErrorResponse("missing issuer reference"), nil
+		}
 	}
 
 	format := getFormat(data)


### PR DESCRIPTION
When a role is used to generate a certificate (such as with the `sign/`
and `issue/` legacy paths or the legacy `sign-verbatim/` paths), we prefer
that issuer to the one on the request. This allows operators to set an
issuer (other than default) for requests to be issued against,
effectively making the change no different from the users' perspective
as it is "just" a different role name.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`