### PR TITLE
Don't show the signature for git commits in the build_date script

### DIFF
--- a/scripts/build_date.sh
+++ b/scripts/build_date.sh
@@ -3,4 +3,4 @@
 DATE_FORMAT="%Y-%m-%dT%H:%M:%SZ"
 
 # we're using this for build date because it's stable across platform builds
-git show -s --format=%cd --date=format:"$DATE_FORMAT" HEAD
+git show --no-show-signature -s --format=%cd --date=format:"$DATE_FORMAT" HEAD


### PR DESCRIPTION
# Summary
Users who have git configured to show commit signatures by default were unable to build using `make dev` due to the `build_date` script producing invalid, multi-line `LDFLAGS` that included git signatures. This explicitly ignores commit signatures to obtain the date as the script intends.

## Repro Steps
- Configure git to always show commit signatures in log output
```
[log]
  showSignature=true
```
- Run `make dev`

### Expected Behavior
Compilation succeeds and produces a binary.

### Actual Behavior
Compilation fails with `link` usage output:
```
$ make dev                                                                                                                                              [main]
==> Checking that build is using go version >= 1.17.9...
==> Using go version 1.18.1...
==> Removing old directory...
==> Building...
Number of parallel builds: 9

-->    darwin/arm64: github.com/hashicorp/vault

1 errors occurred:
--> darwin/arm64 error: exit status 2
Stderr: # github.com/hashicorp/vault
usage: link [options] main.o
...
```

