### PR TITLE
Vault documentation: updated docs to include a note about seal requirement

### DIFF
--- a/website/content/docs/concepts/seal.mdx
+++ b/website/content/docs/concepts/seal.mdx
@@ -81,6 +81,8 @@ access to the root key shards.
 
 ## Auto Unseal
 
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information. 
+
 Auto Unseal was developed to aid in reducing the operational complexity of
 keeping the unseal key secure. This feature delegates the responsibility of
 securing the unseal key from users to a trusted device or service. At startup

--- a/website/content/docs/concepts/seal.mdx
+++ b/website/content/docs/concepts/seal.mdx
@@ -81,7 +81,7 @@ access to the root key shards.
 
 ## Auto Unseal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information. 
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, the seal provider (HSM or cloud KMS) must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information. 
 
 Auto Unseal was developed to aid in reducing the operational complexity of
 keeping the unseal key secure. This feature delegates the responsibility of

--- a/website/content/docs/concepts/seal.mdx
+++ b/website/content/docs/concepts/seal.mdx
@@ -81,7 +81,7 @@ access to the root key shards.
 
 ## Auto Unseal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information. 
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information. 
 
 Auto Unseal was developed to aid in reducing the operational complexity of
 keeping the unseal key secure. This feature delegates the responsibility of

--- a/website/content/docs/concepts/seal.mdx
+++ b/website/content/docs/concepts/seal.mdx
@@ -81,7 +81,7 @@ access to the root key shards.
 
 ## Auto Unseal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information. 
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information. 
 
 Auto Unseal was developed to aid in reducing the operational complexity of
 keeping the unseal key secure. This feature delegates the responsibility of

--- a/website/content/docs/configuration/seal/alicloudkms.mdx
+++ b/website/content/docs/configuration/seal/alicloudkms.mdx
@@ -10,6 +10,9 @@ description: >-
 
 # `alicloudkms` Seal
 
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+
+
 The AliCloud KMS seal configures Vault to use AliCloud KMS as the seal wrapping mechanism.
 The AliCloud KMS seal is activated by one of the following:
 

--- a/website/content/docs/configuration/seal/alicloudkms.mdx
+++ b/website/content/docs/configuration/seal/alicloudkms.mdx
@@ -10,7 +10,7 @@ description: >-
 
 # `alicloudkms` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, the KMS service must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
 
 
 The AliCloud KMS seal configures Vault to use AliCloud KMS as the seal wrapping mechanism.

--- a/website/content/docs/configuration/seal/alicloudkms.mdx
+++ b/website/content/docs/configuration/seal/alicloudkms.mdx
@@ -10,7 +10,7 @@ description: >-
 
 # `alicloudkms` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
 
 
 The AliCloud KMS seal configures Vault to use AliCloud KMS as the seal wrapping mechanism.

--- a/website/content/docs/configuration/seal/awskms.mdx
+++ b/website/content/docs/configuration/seal/awskms.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # `awskms` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, the KMS service must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
 
 The AWS KMS seal configures Vault to use AWS KMS as the seal wrapping mechanism.
 The AWS KMS seal is activated by one of the following:

--- a/website/content/docs/configuration/seal/awskms.mdx
+++ b/website/content/docs/configuration/seal/awskms.mdx
@@ -8,6 +8,8 @@ description: |-
 
 # `awskms` Seal
 
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+
 The AWS KMS seal configures Vault to use AWS KMS as the seal wrapping mechanism.
 The AWS KMS seal is activated by one of the following:
 

--- a/website/content/docs/configuration/seal/awskms.mdx
+++ b/website/content/docs/configuration/seal/awskms.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # `awskms` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
 
 The AWS KMS seal configures Vault to use AWS KMS as the seal wrapping mechanism.
 The AWS KMS seal is activated by one of the following:

--- a/website/content/docs/configuration/seal/azurekeyvault.mdx
+++ b/website/content/docs/configuration/seal/azurekeyvault.mdx
@@ -10,7 +10,7 @@ description: >-
 
 # `azurekeyvault` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
 
 The Azure Key Vault seal configures Vault to use Azure Key Vault as the seal
 wrapping mechanism. The Azure Key Vault seal is activated by one of the following:

--- a/website/content/docs/configuration/seal/azurekeyvault.mdx
+++ b/website/content/docs/configuration/seal/azurekeyvault.mdx
@@ -10,6 +10,8 @@ description: >-
 
 # `azurekeyvault` Seal
 
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+
 The Azure Key Vault seal configures Vault to use Azure Key Vault as the seal
 wrapping mechanism. The Azure Key Vault seal is activated by one of the following:
 

--- a/website/content/docs/configuration/seal/azurekeyvault.mdx
+++ b/website/content/docs/configuration/seal/azurekeyvault.mdx
@@ -10,7 +10,7 @@ description: >-
 
 # `azurekeyvault` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, the KMS service must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
 
 The Azure Key Vault seal configures Vault to use Azure Key Vault as the seal
 wrapping mechanism. The Azure Key Vault seal is activated by one of the following:

--- a/website/content/docs/configuration/seal/gcpckms.mdx
+++ b/website/content/docs/configuration/seal/gcpckms.mdx
@@ -10,7 +10,7 @@ description: >-
 
 # `gcpckms` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information. 
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information. 
 
 The GCP Cloud KMS seal configures Vault to use GCP Cloud KMS as the seal
 wrapping mechanism. The GCP Cloud KMS seal is activated by one of the following:

--- a/website/content/docs/configuration/seal/gcpckms.mdx
+++ b/website/content/docs/configuration/seal/gcpckms.mdx
@@ -10,7 +10,7 @@ description: >-
 
 # `gcpckms` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information. 
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, the KMS service must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information. 
 
 The GCP Cloud KMS seal configures Vault to use GCP Cloud KMS as the seal
 wrapping mechanism. The GCP Cloud KMS seal is activated by one of the following:

--- a/website/content/docs/configuration/seal/gcpckms.mdx
+++ b/website/content/docs/configuration/seal/gcpckms.mdx
@@ -10,6 +10,8 @@ description: >-
 
 # `gcpckms` Seal
 
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information. 
+
 The GCP Cloud KMS seal configures Vault to use GCP Cloud KMS as the seal
 wrapping mechanism. The GCP Cloud KMS seal is activated by one of the following:
 

--- a/website/content/docs/configuration/seal/ocikms.mdx
+++ b/website/content/docs/configuration/seal/ocikms.mdx
@@ -8,6 +8,8 @@ description: |-
 
 # `ocikms` Seal
 
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+
 The OCI KMS seal configures Vault to use OCI KMS as the seal wrapping mechanism.
 The OCI KMS seal is activated by one of the following:
 

--- a/website/content/docs/configuration/seal/ocikms.mdx
+++ b/website/content/docs/configuration/seal/ocikms.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # `ocikms` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, the KMS service must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
 
 The OCI KMS seal configures Vault to use OCI KMS as the seal wrapping mechanism.
 The OCI KMS seal is activated by one of the following:

--- a/website/content/docs/configuration/seal/ocikms.mdx
+++ b/website/content/docs/configuration/seal/ocikms.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # `ocikms` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
 
 The OCI KMS seal configures Vault to use OCI KMS as the seal wrapping mechanism.
 The OCI KMS seal is activated by one of the following:

--- a/website/content/docs/configuration/seal/pkcs11.mdx
+++ b/website/content/docs/configuration/seal/pkcs11.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # `pkcs11` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
 
 The PKCS11 seal configures Vault to use an HSM with PKCS11 as the seal wrapping
 mechanism. Vault Enterprise's HSM PKCS11 support is activated by one of the

--- a/website/content/docs/configuration/seal/pkcs11.mdx
+++ b/website/content/docs/configuration/seal/pkcs11.mdx
@@ -8,6 +8,8 @@ description: |-
 
 # `pkcs11` Seal
 
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+
 The PKCS11 seal configures Vault to use an HSM with PKCS11 as the seal wrapping
 mechanism. Vault Enterprise's HSM PKCS11 support is activated by one of the
 following:

--- a/website/content/docs/configuration/seal/pkcs11.mdx
+++ b/website/content/docs/configuration/seal/pkcs11.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # `pkcs11` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, the KMS service must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
 
 The PKCS11 seal configures Vault to use an HSM with PKCS11 as the seal wrapping
 mechanism. Vault Enterprise's HSM PKCS11 support is activated by one of the

--- a/website/content/docs/configuration/seal/pkcs11.mdx
+++ b/website/content/docs/configuration/seal/pkcs11.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # `pkcs11` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, the KMS service must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
 
 The PKCS11 seal configures Vault to use an HSM with PKCS11 as the seal wrapping
 mechanism. Vault Enterprise's HSM PKCS11 support is activated by one of the

--- a/website/content/docs/configuration/seal/transit.mdx
+++ b/website/content/docs/configuration/seal/transit.mdx
@@ -8,6 +8,8 @@ description: |-
 
 # `transit` Seal
 
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+
 The Transit seal configures Vault to use Vault's Transit Secret Engine as the
 autoseal mechanism.
 The Transit seal is activated by one of the following:

--- a/website/content/docs/configuration/seal/transit.mdx
+++ b/website/content/docs/configuration/seal/transit.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # `transit` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughtout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
 
 The Transit seal configures Vault to use Vault's Transit Secret Engine as the
 autoseal mechanism.

--- a/website/content/docs/configuration/seal/transit.mdx
+++ b/website/content/docs/configuration/seal/transit.mdx
@@ -8,8 +8,6 @@ description: |-
 
 # `transit` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, seal/HSM must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
-
 The Transit seal configures Vault to use Vault's Transit Secret Engine as the
 autoseal mechanism.
 The Transit seal is activated by one of the following:


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/1201712347646323/1202120573507890), the following documents were updated to include a note about seal/HSM requirement. 

- Auto Unseal (:mag: [Deploy Preview](https://vault-git-docs-update-seal-hashicorp.vercel.app/docs/concepts/seal#auto-unseal))
- `alicloudkms` Seal (:mag: [Deploy Preview](https://vault-git-docs-update-seal-hashicorp.vercel.app/docs/configuration/seal/alicloudkms))
- `awkms` Seal (:mag: [Deploy Preview](https://vault-git-docs-update-seal-hashicorp.vercel.app/docs/configuration/seal/awskms))
- `azurekeyvault` Seal (:mag: [Deploy Preview](https://vault-git-docs-update-seal-hashicorp.vercel.app/docs/configuration/seal/azurekeyvault))
- `gcpckms` Seal  (:mag: [Deploy Preview](https://vault-git-docs-update-seal-hashicorp.vercel.app/docs/configuration/seal/gcpckms))
- `ocikms Seal`  (:mag: [Deploy Preview](https://vault-git-docs-update-seal-hashicorp.vercel.app/docs/configuration/seal/ocikms))
- `pkcs11` Seal (:mag: [Deploy Preview](https://vault-git-docs-update-seal-hashicorp.vercel.app/docs/configuration/seal/pkcs11)
- `transit Seal`  (:mag: [Deploy Preview](https://vault-git-docs-update-seal-hashicorp.vercel.app/docs/configuration/seal/transit))
