### PR TITLE
Add warning on keyless default issuer

### DIFF
--- a/builtin/logical/pki/path_config_ca.go
+++ b/builtin/logical/pki/path_config_ca.go
@@ -83,16 +83,29 @@ func (b *backend) pathCAIssuersWrite(ctx context.Context, req *logical.Request, 
 		return logical.ErrorResponse("Error resolving issuer reference: " + err.Error()), nil
 	}
 
+	response := &logical.Response{
+		Data: map[string]interface{}{
+			"default": parsedIssuer,
+		},
+	}
+
+	entry, err := fetchIssuerById(ctx, req.Storage, parsedIssuer)
+	if err != nil {
+		return logical.ErrorResponse("Unable to fetch issuer: " + err.Error()), nil
+	}
+
+	if len(entry.KeyID) == 0 {
+		msg := "This selected default issuer has no key associated with it. Some operations like issuing certificates and signing CRLs will be unavailable with the requested default issuer until a key is imported or the default issuer is changed."
+		response.AddWarning(msg)
+		b.Logger().Error(msg)
+	}
+
 	err = updateDefaultIssuerId(ctx, req.Storage, parsedIssuer)
 	if err != nil {
 		return logical.ErrorResponse("Error updating issuer configuration: " + err.Error()), nil
 	}
 
-	return &logical.Response{
-		Data: map[string]interface{}{
-			"default": parsedIssuer,
-		},
-	}, nil
+	return response, nil
 }
 
 const pathConfigIssuersHelpSyn = `Read and set the default issuer certificate for signing.`


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---


```
[cipherboy@xps15 pki]$ vault write pki/config/issuers default=5a3ae525-d25f-57e6-9cf5-b7acb4c8db9b
WARNING! The following warnings were returned from Vault:

  * This issuer has no key associated with it. Some operations like issuing
  certificates and signing CRLs will be unavailable with the requested default
  issuer.

Key        Value
---        -----
default    5a3ae525-d25f-57e6-9cf5-b7acb4c8db9b

[cipherboy@xps15 vault]$ vault write pki/issuers/import/cert pem_bundle=@$HOME/root-no-key.pem
WARNING! The following warnings were returned from Vault:

  * The default issuer has no key associated with it. Some operations like
  issuing certificates and signing CRLs will be unavailable with the requested
  default issuer until a key is imported or the default issuer is changed.

Key                 Value
---                 -----
imported_issuers    [5f7bafc5-ddf8-6e7c-2e62-dbb19ba43d20]
imported_keys       <nil>
mapping             map[5f7bafc5-ddf8-6e7c-2e62-dbb19ba43d20:]

```