### PR TITLE
Rebuild CRLs on secondary performance clusters post migration and on new/updated issuers

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -328,13 +328,13 @@ func (b *backend) invalidate(ctx context.Context, key string) {
 		// This is for a secondary cluster to pick up that the migration has completed
 		// and reset its compatibility mode and rebuild the CRL locally.
 		b.updatePkiStorageVersion(ctx)
-		b.crlBuilder.requestRebuildOnActiveNode(b)
+		b.crlBuilder.requestRebuildIfActiveNode(b)
 	case strings.HasPrefix(key, issuerPrefix):
 		// If an issuer has changed on the primary, we need to schedule an update of our CRL,
 		// the primary cluster would have done it already, but the CRL is cluster specific so
 		// force a rebuild of ours.
 		if !b.useLegacyBundleCaStorage() {
-			b.crlBuilder.requestRebuildOnActiveNode(b)
+			b.crlBuilder.requestRebuildIfActiveNode(b)
 		} else {
 			b.Logger().Debug("Ignoring invalidation updates for issuer as the PKI migration has yet to complete.")
 		}

--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func (b *backend) getGenerationParams(ctx context.Context, data *framework.FieldData, mountPoint string) (exported bool, format string, role *roleEntry, errorResp *logical.Response) {
+func (b *backend) getGenerationParams(ctx context.Context, storage logical.Storage, data *framework.FieldData, mountPoint string) (exported bool, format string, role *roleEntry, errorResp *logical.Response) {
 	exportedStr := data.Get("exported").(string)
 	switch exportedStr {
 	case "exported":
@@ -39,7 +39,7 @@ func (b *backend) getGenerationParams(ctx context.Context, data *framework.Field
 		return
 	}
 
-	keyType, keyBits, err := getKeyTypeAndBitsForRole(ctx, b, data, mountPoint)
+	keyType, keyBits, err := getKeyTypeAndBitsForRole(ctx, b, storage, data, mountPoint)
 	if err != nil {
 		errorResp = logical.ErrorResponse(err.Error())
 		return
@@ -114,7 +114,7 @@ func parseCABundle(ctx context.Context, b *backend, req *logical.Request, bundle
 	return bundle.ToParsedCertBundle()
 }
 
-func getKeyTypeAndBitsForRole(ctx context.Context, b *backend, data *framework.FieldData, mountPoint string) (string, int, error) {
+func getKeyTypeAndBitsForRole(ctx context.Context, b *backend, storage logical.Storage, data *framework.FieldData, mountPoint string) (string, int, error) {
 	exportedStr := data.Get("exported").(string)
 	var keyType string
 	var keyBits int
@@ -146,7 +146,7 @@ func getKeyTypeAndBitsForRole(ctx context.Context, b *backend, data *framework.F
 	}
 
 	if existingKeyRequestedFromFieldData(data) {
-		existingPubKey, err := getExistingPublicKey(ctx, b.storage, data)
+		existingPubKey, err := getExistingPublicKey(ctx, storage, data)
 		if err != nil {
 			return "", 0, errors.New("failed to lookup public key from existing key: " + err.Error())
 		}

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -139,7 +139,7 @@ func fetchCAInfo(ctx context.Context, b *backend, req *logical.Request, issuerRe
 func fetchCertBundle(ctx context.Context, b *backend, s logical.Storage, issuerRef string) (*issuerEntry, *certutil.CertBundle, error) {
 	if b.useLegacyBundleCaStorage() {
 		// We have not completed the migration so attempt to load the bundle from the legacy location
-		b.Logger().Info("Using legacy CA bundle")
+		b.Logger().Info("Using legacy CA bundle as PKI migration has not completed.")
 		return getLegacyCertBundle(ctx, s)
 	}
 
@@ -175,7 +175,7 @@ func fetchCertBySerial(ctx context.Context, b *backend, req *logical.Request, pr
 		if err = b.crlBuilder.rebuildIfForced(ctx, b, req); err != nil {
 			return nil, err
 		}
-		path, err = resolveIssuerCRLPath(ctx, req.Storage, defaultRef)
+		path, err = resolveIssuerCRLPath(ctx, b, req.Storage, defaultRef)
 		if err != nil {
 			return nil, err
 		}

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -156,7 +156,7 @@ func fetchCertBundle(ctx context.Context, b *backend, s logical.Storage, issuerR
 //
 // Support for fetching CA certificates was removed, due to the new issuers
 // changes.
-func fetchCertBySerial(ctx context.Context, req *logical.Request, prefix, serial string) (*logical.StorageEntry, error) {
+func fetchCertBySerial(ctx context.Context, b *backend, req *logical.Request, prefix, serial string) (*logical.StorageEntry, error) {
 	var path, legacyPath string
 	var err error
 	var certEntry *logical.StorageEntry
@@ -171,6 +171,9 @@ func fetchCertBySerial(ctx context.Context, req *logical.Request, prefix, serial
 		legacyPath = "revoked/" + colonSerial
 		path = "revoked/" + hyphenSerial
 	case serial == "crl":
+		if err = b.crlBuilder.rebuildIfForced(ctx, b, req); err != nil {
+			return nil, err
+		}
 		path, err = resolveIssuerCRLPath(ctx, req.Storage, defaultRef)
 		if err != nil {
 			return nil, err

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -139,6 +139,7 @@ func fetchCAInfo(ctx context.Context, b *backend, req *logical.Request, issuerRe
 func fetchCertBundle(ctx context.Context, b *backend, s logical.Storage, issuerRef string) (*issuerEntry, *certutil.CertBundle, error) {
 	if b.useLegacyBundleCaStorage() {
 		// We have not completed the migration so attempt to load the bundle from the legacy location
+		b.Logger().Info("Using legacy CA bundle")
 		return getLegacyCertBundle(ctx, s)
 	}
 

--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPki_FetchCertBySerial(t *testing.T) {
-	storage := &logical.InmemStorage{}
+	b, storage := createBackendWithStorage(t)
 
 	cases := map[string]struct {
 		Req    *logical.Request
@@ -46,7 +46,7 @@ func TestPki_FetchCertBySerial(t *testing.T) {
 			t.Fatalf("error writing to storage on %s colon-based storage path: %s", name, err)
 		}
 
-		certEntry, err := fetchCertBySerial(context.Background(), tc.Req, tc.Prefix, tc.Serial)
+		certEntry, err := fetchCertBySerial(context.Background(), b, tc.Req, tc.Prefix, tc.Serial)
 		if err != nil {
 			t.Fatalf("error on %s for colon-based storage path: %s", name, err)
 		}
@@ -81,7 +81,7 @@ func TestPki_FetchCertBySerial(t *testing.T) {
 			t.Fatalf("error writing to storage on %s hyphen-based storage path: %s", name, err)
 		}
 
-		certEntry, err := fetchCertBySerial(context.Background(), tc.Req, tc.Prefix, tc.Serial)
+		certEntry, err := fetchCertBySerial(context.Background(), b, tc.Req, tc.Prefix, tc.Serial)
 		if err != nil || certEntry == nil {
 			t.Fatalf("error on %s for hyphen-based storage path: err: %v, entry: %v", name, err, certEntry)
 		}

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -128,12 +128,57 @@ func TestBackend_CRL_EnableDisable(t *testing.T) {
 	require.NotEqual(t, crlCreationTime1, crlCreationTime2)
 }
 
-func getCrlCertificateList(t *testing.T, client *api.Client) pkix.TBSCertificateList {
-	resp, err := client.Logical().ReadWithContext(context.Background(), "pki/cert/crl")
+func TestBackend_Secondary_CRL_Rebuilding(t *testing.T) {
+	ctx := context.Background()
+	b, s := createBackendWithStorage(t)
+
+	// Write out the issuer/key to storage without going through the api call as replication would.
+	bundle := genCertBundle(t, b)
+	issuer, _, err := writeCaBundle(ctx, s, bundle, "", "")
 	require.NoError(t, err)
 
+	// Just to validate, before we call the invalidate function, make sure our CRL has not been generated
+	// and we get a nil response
+	resp := requestCrlFromBackend(t, s, b)
+	require.Nil(t, resp.Data["http_raw_body"])
+
+	// This should force any calls from now on to rebuild our CRL even a read
+	b.invalidate(ctx, issuerPrefix+issuer.ID.String())
+
+	// Perform the read operation again, we should have a valid CRL now...
+	resp = requestCrlFromBackend(t, s, b)
+	crl := parseCrlPemBytes(t, resp.Data["http_raw_body"].([]byte))
+	require.Equal(t, 0, len(crl.RevokedCertificates))
+}
+
+func requestCrlFromBackend(t *testing.T, s logical.Storage, b *backend) *logical.Response {
+	crlReq := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "crl/pem",
+		Storage:   s,
+	}
+	resp, err := b.HandleRequest(context.Background(), crlReq)
+	require.NoError(t, err, "crl req failed with an error")
+	require.NotNil(t, resp, "crl response was nil with no error")
+	require.False(t, resp.IsError(), "crl error response: %v", resp)
+	return resp
+}
+
+func getCrlCertificateList(t *testing.T, client *api.Client) pkix.TBSCertificateList {
+	resp, err := client.Logical().ReadWithContext(context.Background(), "pki/cert/crl")
+	require.NoError(t, err, "crl req failed with an error")
+	require.NotNil(t, resp, "crl response was nil with no error")
+
 	crlPem := resp.Data["certificate"].(string)
-	certList, err := x509.ParseCRL([]byte(crlPem))
+	return parseCrlPemString(t, crlPem)
+}
+
+func parseCrlPemString(t *testing.T, crlPem string) pkix.TBSCertificateList {
+	return parseCrlPemBytes(t, []byte(crlPem))
+}
+
+func parseCrlPemBytes(t *testing.T, crlPem []byte) pkix.TBSCertificateList {
+	certList, err := x509.ParseCRL(crlPem)
 	require.NoError(t, err)
 	return certList.TBSCertList
 }

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -133,7 +133,7 @@ func TestBackend_Secondary_CRL_Rebuilding(t *testing.T) {
 	b, s := createBackendWithStorage(t)
 
 	// Write out the issuer/key to storage without going through the api call as replication would.
-	bundle := genCertBundle(t, b)
+	bundle := genCertBundle(t, b, s)
 	issuer, _, err := writeCaBundle(ctx, s, bundle, "", "")
 	require.NoError(t, err)
 

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -60,8 +60,8 @@ func (cb *crlBuilder) rebuild(ctx context.Context, b *backend, request *logical.
 	return cb._doRebuild(ctx, b, request, forceNew, _ignoreForceFlag)
 }
 
-// requestRebuildOnActiveNode will schedule a rebuild of the CRL from the next read or write api call assuming we are the active node of a cluster
-func (cb *crlBuilder) requestRebuildOnActiveNode(b *backend) {
+// requestRebuildIfActiveNode will schedule a rebuild of the CRL from the next read or write api call assuming we are the active node of a cluster
+func (cb *crlBuilder) requestRebuildIfActiveNode(b *backend) {
 	// Only schedule us on active nodes, ignoring secondary nodes, the active can/should rebuild the CRL.
 	if b.System().ReplicationState().HasState(consts.ReplicationPerformanceStandby) ||
 		b.System().ReplicationState().HasState(consts.ReplicationDRSecondary) {

--- a/builtin/logical/pki/path_config_crl.go
+++ b/builtin/logical/pki/path_config_crl.go
@@ -118,7 +118,7 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 
 	if oldDisable != config.Disable {
 		// It wasn't disabled but now it is, rotate
-		crlErr := buildCRLs(ctx, b, req, true)
+		crlErr := b.crlBuilder.rebuild(ctx, b, req, true)
 		if crlErr != nil {
 			switch crlErr.(type) {
 			case errutil.UserError:

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -248,7 +248,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 		goto reply
 	}
 
-	certEntry, funcErr = fetchCertBySerial(ctx, req, req.Path, serial)
+	certEntry, funcErr = fetchCertBySerial(ctx, b, req, req.Path, serial)
 	if funcErr != nil {
 		switch funcErr.(type) {
 		case errutil.UserError:
@@ -276,7 +276,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 		certificate = []byte(strings.TrimSpace(string(pem.EncodeToMemory(&block))))
 	}
 
-	revokedEntry, funcErr = fetchCertBySerial(ctx, req, "revoked/", serial)
+	revokedEntry, funcErr = fetchCertBySerial(ctx, b, req, "revoked/", serial)
 	if funcErr != nil {
 		switch funcErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -400,6 +400,10 @@ func (b *backend) pathGetIssuerCRL(ctx context.Context, req *logical.Request, da
 		return logical.ErrorResponse("missing issuer reference"), nil
 	}
 
+	if err := b.crlBuilder.rebuildIfForced(ctx, b, req); err != nil {
+		return nil, err
+	}
+
 	crlPath, err := resolveIssuerCRLPath(ctx, req.Storage, issuerName)
 	if err != nil {
 		return nil, err

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -404,7 +404,7 @@ func (b *backend) pathGetIssuerCRL(ctx context.Context, req *logical.Request, da
 		return nil, err
 	}
 
-	crlPath, err := resolveIssuerCRLPath(ctx, req.Storage, issuerName)
+	crlPath, err := resolveIssuerCRLPath(ctx, b, req.Storage, issuerName)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -58,7 +58,7 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 		data.Raw["exported"] = "existing"
 	}
 
-	exported, format, role, errorResp := b.getGenerationParams(ctx, data, req.MountPoint)
+	exported, format, role, errorResp := b.getGenerationParams(ctx, req.Storage, data, req.MountPoint)
 	if errorResp != nil {
 		return errorResp, nil
 	}

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -209,7 +209,7 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 	}
 
 	if len(createdIssuers) > 0 {
-		err := buildCRLs(ctx, b, req, true)
+		err := b.crlBuilder.rebuild(ctx, b, req, true)
 		if err != nil {
 			return nil, err
 		}

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -80,7 +80,7 @@ func (b *backend) pathRotateCRLRead(ctx context.Context, req *logical.Request, _
 	b.revokeStorageLock.RLock()
 	defer b.revokeStorageLock.RUnlock()
 
-	crlErr := buildCRLs(ctx, b, req, false)
+	crlErr := b.crlBuilder.rebuild(ctx, b, req, false)
 	if crlErr != nil {
 		switch crlErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -91,7 +91,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 		return logical.ErrorResponse("Can not create root CA until migration has completed"), nil
 	}
 
-	exported, format, role, errorResp := b.getGenerationParams(ctx, data, req.MountPoint)
+	exported, format, role, errorResp := b.getGenerationParams(ctx, req.Storage, data, req.MountPoint)
 	if errorResp != nil {
 		return errorResp, nil
 	}

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -205,7 +205,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 	}
 
 	// Build a fresh CRL
-	err = buildCRLs(ctx, b, req, true)
+	err = b.crlBuilder.rebuild(ctx, b, req, true)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -225,7 +225,7 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 				}
 
 				if rebuildCRL {
-					if err := buildCRLs(ctx, b, req, false); err != nil {
+					if err := b.crlBuilder.rebuild(ctx, b, req, false); err != nil {
 						return err
 					}
 				}

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -643,7 +643,11 @@ func resolveIssuerReference(ctx context.Context, s logical.Storage, reference st
 	return IssuerRefNotFound, errutil.UserError{Err: fmt.Sprintf("unable to find PKI issuer for reference: %v", reference)}
 }
 
-func resolveIssuerCRLPath(ctx context.Context, s logical.Storage, reference string) (string, error) {
+func resolveIssuerCRLPath(ctx context.Context, b *backend, s logical.Storage, reference string) (string, error) {
+	if b.useLegacyBundleCaStorage() {
+		return "crl", nil
+	}
+
 	issuer, err := resolveIssuerReference(ctx, s, reference)
 	if err != nil {
 		return "crl", err

--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -64,7 +64,7 @@ func getMigrationInfo(ctx context.Context, s logical.Storage) (migrationInfo, er
 	return migrationInfo, nil
 }
 
-func migrateStorage(ctx context.Context, s logical.Storage, logger log.Logger) error {
+func migrateStorage(ctx context.Context, cb *crlBuilder, s logical.Storage, logger log.Logger) error {
 	migrationInfo, err := getMigrationInfo(ctx, s)
 	if err != nil {
 		return err
@@ -87,6 +87,8 @@ func migrateStorage(ctx context.Context, s logical.Storage, logger log.Logger) e
 	} else {
 		logger.Debug("No legacy CA certs found, no migration required.")
 	}
+
+	cb.requestRebuild()
 
 	// We always want to write out this log entry as the secondary clusters leverage this path to wake up
 	// if they were upgraded prior to the primary cluster's migration occurred.

--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -89,7 +89,7 @@ func migrateStorage(ctx context.Context, b *backend, s logical.Storage) error {
 
 	// Since we do not have all the mount information available we must schedule
 	// the CRL to be rebuilt at a later time.
-	b.crlBuilder.requestRebuildOnActiveNode(b)
+	b.crlBuilder.requestRebuildIfActiveNode(b)
 
 	// We always want to write out this log entry as the secondary clusters leverage this path to wake up
 	// if they were upgraded prior to the primary cluster's migration occurred.

--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -128,7 +128,7 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 	require.Equal(t, &issuerConfigEntry{DefaultIssuerId: issuerId}, issuersConfig)
 
 	// Make sure if we attempt to re-run the migration nothing happens...
-	err = migrateStorage(ctx, s, b.Logger())
+	err = migrateStorage(ctx, b.crlBuilder, s, b.Logger())
 	require.NoError(t, err)
 	logEntry2, err := getLegacyBundleMigrationLog(ctx, s)
 	require.NoError(t, err)

--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -64,7 +64,7 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 	b.pkiStorageVersion.Store(0)
 	require.True(t, b.useLegacyBundleCaStorage(), "pre migration we should have been told to use legacy storage.")
 
-	bundle := genCertBundle(t, b)
+	bundle := genCertBundle(t, b, s)
 	json, err := logical.StorageEntryJSON(legacyCertBundlePath, bundle)
 	require.NoError(t, err)
 	err = s.Put(ctx, json)
@@ -128,7 +128,7 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 	require.Equal(t, &issuerConfigEntry{DefaultIssuerId: issuerId}, issuersConfig)
 
 	// Make sure if we attempt to re-run the migration nothing happens...
-	err = migrateStorage(ctx, b.crlBuilder, s, b.Logger())
+	err = migrateStorage(ctx, b, s)
 	require.NoError(t, err)
 	logEntry2, err := getLegacyBundleMigrationLog(ctx, s)
 	require.NoError(t, err)


### PR DESCRIPTION
 - Hook into the backend invalidation function so that secondaries are notified of
   new/updated issuer or migrations occuring on the primary cluster. Upon notification
   schedule a CRL rebuild to take place upon the next process to read/update the CRL
   or within the periodic function if no request comes in.