### PR TITLE
[VAULT-14990] Support retrieving kv secret paths with trailing spaces

### DIFF
--- a/changelog/15188.txt
+++ b/changelog/15188.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: kv get command now honors trailing spaces to retrieve secrets
+```

--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -38,18 +38,6 @@ func sanitizePath(s string) string {
 	return ensureNoTrailingSlash(ensureNoLeadingSlash(s))
 }
 
-// hasTrailingSpace checks to see if there is trailing space
-func hasTrailingSpace(s string) bool {
-	return strings.HasSuffix(s, " ")
-}
-
-// hasTrailingSlash boolean checks if a trailing slash exists
-func hasTrailingSlash(s string) bool {
-	s = strings.TrimSuffix(s, " ")
-
-	return strings.HasSuffix(s, "/")
-}
-
 // ensureTrailingSlash ensures the given string has a trailing slash.
 func ensureTrailingSlash(s string) string {
 	s = strings.TrimSpace(s)

--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -38,7 +38,6 @@ func sanitizePath(s string) string {
 	return ensureNoTrailingSlash(ensureNoLeadingSlash(s))
 }
 
-
 // hasTrailingSpace checks to see if there is trailing space
 func hasTrailingSpace(s string) bool {
 	x := strings.TrimSuffix(s, " ")

--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -38,6 +38,15 @@ func sanitizePath(s string) string {
 	return ensureNoTrailingSlash(ensureNoLeadingSlash(s))
 }
 
+// hasTrailingSpace checks to see if there is trailing space
+func hasTrailingSpace(s string) bool {
+	x := strings.TrimSpace(s)
+	if x != s {
+		return true
+	}
+	return false
+}
+
 // ensureTrailingSlash ensures the given string has a trailing slash.
 func ensureTrailingSlash(s string) string {
 	s = strings.TrimSpace(s)

--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -52,7 +52,7 @@ func hasTrailingSpace(s string) bool {
 func hasTrailingSlash(s string) bool {
 	s = strings.TrimSpace(s)
 
-	if s[len(s) - 1] == '/' {
+	if s[len(s)-1] == '/' {
 		return true
 	}
 

--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -40,20 +40,14 @@ func sanitizePath(s string) string {
 
 // hasTrailingSpace checks to see if there is trailing space
 func hasTrailingSpace(s string) bool {
-	x := strings.TrimSuffix(s, " ")
-
-	return x != s
+	return strings.HasSuffix(s, " ")
 }
 
 // hasTrailingSlash boolean checks if a trailing slash exists
 func hasTrailingSlash(s string) bool {
 	s = strings.TrimSuffix(s, " ")
 
-	if s[len(s)-1] == '/' {
-		return true
-	}
-
-	return false
+	return strings.HasSuffix(s, "/")
 }
 
 // ensureTrailingSlash ensures the given string has a trailing slash.

--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -41,15 +41,13 @@ func sanitizePath(s string) string {
 // hasTrailingSpace checks to see if there is trailing space
 func hasTrailingSpace(s string) bool {
 	x := strings.TrimSuffix(s, " ")
-	if x != s {
-		return true
-	}
-	return false
+
+	return x != s
 }
 
 // hasTrailingSlash boolean checks if a trailing slash exists
 func hasTrailingSlash(s string) bool {
-	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, " ")
 
 	if s[len(s)-1] == '/' {
 		return true

--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -38,12 +38,24 @@ func sanitizePath(s string) string {
 	return ensureNoTrailingSlash(ensureNoLeadingSlash(s))
 }
 
+
 // hasTrailingSpace checks to see if there is trailing space
 func hasTrailingSpace(s string) bool {
-	x := strings.TrimSpace(s)
+	x := strings.TrimSuffix(s, " ")
 	if x != s {
 		return true
 	}
+	return false
+}
+
+// hasTrailingSlash boolean checks if a trailing slash exists
+func hasTrailingSlash(s string) bool {
+	s = strings.TrimSpace(s)
+
+	if s[len(s) - 1] == '/' {
+		return true
+	}
+
 	return false
 }
 

--- a/command/kv_get.go
+++ b/command/kv_get.go
@@ -134,7 +134,13 @@ func (c *KVGetCommand) Run(args []string) int {
 	} else {
 		// In this case, this arg is a path-like combination of mountPath/secretPath.
 		// (e.g. "secret/foo")
+		origPath := args[0]
 		partialPath = sanitizePath(args[0])
+
+		if hasTrailingSpace(origPath) {
+			partialPath = partialPath + " "
+		}
+
 		mountPath, v2, err = isKVv2(partialPath, client)
 		if err != nil {
 			c.UI.Error(err.Error())

--- a/command/kv_get.go
+++ b/command/kv_get.go
@@ -124,12 +124,7 @@ func (c *KVGetCommand) Run(args []string) int {
 	// Parse the paths and grab the KV version
 	if mountFlagSyntax {
 		// In this case, this arg is the secret path (e.g. "foo").
-		origPath := args[0]
-		partialPath = sanitizePath(args[0])
-
-		if hasTrailingSpace(origPath) && !hasTrailingSlash(origPath) {
-			partialPath = partialPath + " "
-		}
+		partialPath = args[0]
 
 		mountPath = sanitizePath(c.flagMount)
 		_, v2, err = isKVv2(mountPath, client)
@@ -140,12 +135,7 @@ func (c *KVGetCommand) Run(args []string) int {
 	} else {
 		// In this case, this arg is a path-like combination of mountPath/secretPath.
 		// (e.g. "secret/foo")
-		origPath := args[0]
-		partialPath = sanitizePath(args[0])
-
-		if hasTrailingSpace(origPath) && !hasTrailingSlash(origPath) {
-			partialPath = partialPath + " "
-		}
+		partialPath = args[0]
 
 		mountPath, v2, err = isKVv2(partialPath, client)
 		if err != nil {

--- a/command/kv_get.go
+++ b/command/kv_get.go
@@ -124,7 +124,13 @@ func (c *KVGetCommand) Run(args []string) int {
 	// Parse the paths and grab the KV version
 	if mountFlagSyntax {
 		// In this case, this arg is the secret path (e.g. "foo").
+		origPath := args[0]
 		partialPath = sanitizePath(args[0])
+
+		if hasTrailingSpace(origPath) && !hasTrailingSlash(origPath) {
+			partialPath = partialPath + " "
+		}
+
 		mountPath = sanitizePath(c.flagMount)
 		_, v2, err = isKVv2(mountPath, client)
 		if err != nil {
@@ -137,7 +143,7 @@ func (c *KVGetCommand) Run(args []string) int {
 		origPath := args[0]
 		partialPath = sanitizePath(args[0])
 
-		if hasTrailingSpace(origPath) {
+		if hasTrailingSpace(origPath) && !hasTrailingSlash(origPath) {
 			partialPath = partialPath + " "
 		}
 


### PR DESCRIPTION
Currently you can create secret paths with trailing spaces with the api in KV. We sanitize those in the cli, which means you cannot retrieve the secret path you previously created. 

- Update the CLI to allow you to retrieve secret paths with trailing spaces: `vault kv get "secret/test "`. The trailing space will not be removed.
