### PR TITLE
Vault documentation: applied new guidelines to code blocks

### DIFF
--- a/website/content/docs/auth/approle.mdx
+++ b/website/content/docs/auth/approle.mdx
@@ -245,12 +245,12 @@ details.
 
 ## Code Example
 
-The following code snippet demonstrates AppRole authentication with response
+The following example demonstrates AppRole authentication with response
 wrapping.
 
-<CodeTabs heading="AppRole auth with response wrap">
+<CodeTabs>
 
-<CodeBlockConfig lineNumbers>
+<CodeBlockConfig>
 
 ```go
 package main
@@ -329,7 +329,7 @@ func getSecretWithAppRole() (string, error) {
 
 </CodeBlockConfig>
 
-<CodeBlockConfig lineNumbers>
+<CodeBlockConfig>
 
 ```cs
 using System;

--- a/website/content/docs/auth/aws.mdx
+++ b/website/content/docs/auth/aws.mdx
@@ -747,11 +747,11 @@ details.
 
 ## Code Example
 
-The following code snippet uses the AWS (IAM) auth method to authenticate with Vault.
+The following example uses the AWS (IAM) auth method to authenticate with Vault.
 
-<CodeTabs heading="AWS auth example">
+<CodeTabs>
 
-<CodeBlockConfig lineNumbers>
+<CodeBlockConfig>
 
 ```go
 package main
@@ -813,7 +813,7 @@ func getSecretWithAWSAuthIAM() (string, error) {
 ```
 </CodeBlockConfig>
 
-<CodeBlockConfig lineNumbers>
+<CodeBlockConfig>
 
 ```cs
 using System;

--- a/website/content/docs/auth/aws.mdx
+++ b/website/content/docs/auth/aws.mdx
@@ -747,7 +747,7 @@ details.
 
 ## Code Example
 
-The following example uses the AWS (IAM) auth method to authenticate with Vault.
+The following example demonstrates the AWS (IAM) auth method to authenticate with Vault.
 
 <CodeTabs>
 

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -16,9 +16,9 @@ signed by Azure Active Directory for the configured tenant.
 This method supports authentication for system-assigned and user-assigned
 managed identities. See [Azure Managed Service Identity (MSI)](https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview) for more information about these resources.
 
-~> System-assigned identities are unique to every virtual machine in Azure. If the 
-virtual machines using Azure auth are recreated frequently, using system-assigned 
-identities could result in a lot of Vault entities. For environments with high ephemeral 
+~> System-assigned identities are unique to every virtual machine in Azure. If the
+virtual machines using Azure auth are recreated frequently, using system-assigned
+identities could result in a lot of Vault entities. For environments with high ephemeral
 workloads, user-assigned identities are recommended.
 
 ## Prerequisites:
@@ -215,12 +215,12 @@ The Azure Auth Plugin has a full HTTP API. Please see the [API documentation](/a
 
 ## Code Example
 
-The following code snippet demonstrates the Azure auth method to authenticate
+The following example demonstrates the Azure auth method to authenticate
 with Vault.
 
-<CodeTabs heading="azure auth example">
+<CodeTabs>
 
-<CodeBlockConfig lineNumbers>
+<CodeBlockConfig>
 
 ```go
 package main
@@ -283,7 +283,7 @@ func getSecretWithAzureAuth() (string, error) {
 ```
 </CodeBlockConfig>
 
-<CodeBlockConfig lineNumbers>
+<CodeBlockConfig>
 
 ```cs
 using System;

--- a/website/content/docs/auth/gcp.mdx
+++ b/website/content/docs/auth/gcp.mdx
@@ -366,12 +366,12 @@ The GCP Auth Plugin has a full HTTP API. Please see the
 
 ## Code Example
 
-The following code snippet demonstrates the Google Cloud auth method to authenticate
+The following example demonstrates the Google Cloud auth method to authenticate
 with Vault.
 
-<CodeTabs heading="gcp auth example">
+<CodeTabs>
 
-<CodeBlockConfig lineNumbers>
+<CodeBlockConfig>
 
 ```go
 package main
@@ -451,7 +451,7 @@ func getSecretWithGCPAuthIAM() (string, error) {
 
 </CodeBlockConfig>
 
-<CodeBlockConfig lineNumbers>
+<CodeBlockConfig>
 
 ```cs
 using System;
@@ -471,7 +471,7 @@ using Data = Google.Apis.Iam.v1.Data;
 
 namespace Examples
 {
-    public class GCPAuthExample 
+    public class GCPAuthExample
     {
         /// <summary>
         /// Fetches a key-value secret (kv-v2) after authenticating to Vault via GCP IAM,
@@ -498,18 +498,18 @@ namespace Examples
             }
 
             var jwt = SignJWT();
- 
+
             IAuthMethodInfo authMethod = new GoogleCloudAuthMethodInfo(roleName, jwt);
             var vaultClientSettings = new VaultClientSettings(vaultAddr, authMethod);
 
-            IVaultClient vaultClient = new VaultClient(vaultClientSettings); 
+            IVaultClient vaultClient = new VaultClient(vaultClientSettings);
 
             // We can retrieve the secret after creating our VaultClient object
             Secret<SecretData> kv2Secret = null;
             kv2Secret = vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(path: "/creds").Result;
-            
+
             var password = kv2Secret.Data.Data["password"];
-            
+
             return password.ToString();
         }
 
@@ -529,7 +529,7 @@ namespace Examples
             });
 
             string svcEmail = $"{svcAcctName}@{gcpProjName}.iam.gserviceaccount.com";
-            string name = $"projects/-/serviceAccounts/{svcEmail}";  
+            string name = $"projects/-/serviceAccounts/{svcEmail}";
 
             TimeSpan currentTime = (DateTime.UtcNow - new DateTime(1970, 1, 1));
             int expiration = (int)(currentTime.TotalSeconds) + 900;
@@ -545,7 +545,7 @@ namespace Examples
             ProjectsResource.ServiceAccountsResource.SignJwtRequest request = iamService.Projects.ServiceAccounts.SignJwt(requestBody, name);
 
             Data.SignJwtResponse response = request.Execute();
-            
+
             return JsonConvert.SerializeObject(response.SignedJwt).Replace("\"", "");
         }
 

--- a/website/content/docs/auth/kubernetes.mdx
+++ b/website/content/docs/auth/kubernetes.mdx
@@ -332,12 +332,12 @@ The Kubernetes Auth Plugin has a full HTTP API. Please see the
 
 ## Code Example
 
-The following code snippet demonstrates the Kubernetes auth method to authenticate
+The following example demonstrates the Kubernetes auth method to authenticate
 with Vault.
 
-<CodeTabs heading="kubernetes auth example">
+<CodeTabs>
 
-<CodeBlockConfig lineNumbers>
+<CodeBlockConfig>
 
 ```go
 package main
@@ -408,7 +408,7 @@ func getSecretWithKubernetesAuth() (string, error) {
 ```
 </CodeBlockConfig>
 
-<CodeBlockConfig lineNumbers>
+<CodeBlockConfig>
 
 ```cs
 using System;
@@ -420,7 +420,7 @@ using VaultSharp.V1.Commons;
 
 namespace Examples
 {
-    public class KubernetesAuthExample 
+    public class KubernetesAuthExample
     {
         const string DefaultTokenPath = "path/to/service-account-token";
 
@@ -442,19 +442,19 @@ namespace Examples
 
             // Get the path to service account token or fall back on default path
             string pathToToken = String.IsNullOrEmpty(Environment.GetEnvironmentVariable("SA_TOKEN_PATH")) ? DefaultTokenPath : Environment.GetEnvironmentVariable("SA_TOKEN_PATH");
-            string jwt = File.ReadAllText(pathToToken); 
+            string jwt = File.ReadAllText(pathToToken);
 
             IAuthMethodInfo authMethod = new KubernetesAuthMethodInfo(roleName, jwt);
             var vaultClientSettings = new VaultClientSettings(vaultAddr, authMethod);
 
-            IVaultClient vaultClient = new VaultClient(vaultClientSettings); 
+            IVaultClient vaultClient = new VaultClient(vaultClientSettings);
 
             // We can retrieve the secret after creating our VaultClient object
             Secret<SecretData> kv2Secret = null;
             kv2Secret = vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(path: "/creds").Result;
-            
+
             var password = kv2Secret.Data.Data["password"];
-            
+
             return password.ToString();
         }
     }


### PR DESCRIPTION
Laura worked w/ writers and education team members to come up with guidance on using code tabs and tabs for` codeblocks`. Based on these guidelines, I have modified the following code samples for each content page. One question that remains is if we should remove the code comments that appear within the code themselves and make them part of the text as opposed to burying them within the code.

- AppRole Auth Method (:mag:[Deploy Preview](https://vault-git-docs-code-sample-updates-hashicorp.vercel.app/docs/auth/approle#code-example))
- AWS Auth Method (:mag:[Deploy Preview](https://vault-git-docs-code-sample-updates-hashicorp.vercel.app/docs/auth/aws#code-example))
- Azure Auth Method (:mag:[Deploy Preview](https://vault-git-docs-code-sample-updates-hashicorp.vercel.app/docs/auth/azure#code-example))
- Google Cloud Auth Method (:mag:[Deploy Preview](https://vault-git-docs-code-sample-updates-hashicorp.vercel.app/docs/auth/gcp#code-example))
- Kubernetes Auth Method (:mag:[Deploy Preview](https://vault-git-docs-code-sample-updates-hashicorp.vercel.app/docs/auth/kubernetes#code-example))
