### PR TITLE
Vault documentation: updated upgrade guide to include a raft-related known issue

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.10.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.10.x.mdx
@@ -77,9 +77,9 @@ naming collisions could result unexpected default behavior. Additionally, we rec
 the corresponding details in the OIDC provider [concepts](/docs/concepts/oidc-provider) document
 to understand how the built-in resources are used in the system.
 
-@include 'raft-panic-old-tls-key.mdx'
-
 ## Known Issues
+
+@include 'raft-panic-old-tls-key.mdx'
 
 ### Single Vault follower restart causes election even with established quorum
 
@@ -109,4 +109,3 @@ set to `unauth`.
 There is a workaround for this error that will allow you to sign in to Vault using the OIDC
 auth method. Select the "Other" tab instead of selecting the specific OIDC auth mount tab.
 From there, select "OIDC" from the "Method" select box and proceed to sign in to Vault.
-

--- a/website/content/docs/upgrading/upgrade-to-1.8.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.8.x.mdx
@@ -49,19 +49,26 @@ Notes](https://golang.org/doc/go1.16) for full details. Of particular note:
 
 ## Known Issues
 
-- MSSQL integrations (storage and secrets engine) will crash with a "panic: not implemented" error
-  ([#12830](https://github.com/hashicorp/vault/issues/12830)). This affects Vault versions
+@include 'raft-panic-old-tls-key.mdx'
+
+### MSSQL integrations
+
+MSSQL integrations (storage and secrets engine) will crash with a "panic: not implemented" error ([#12830](https://github.com/hashicorp/vault/issues/12830)). This affects Vault versions
   1.8.0 and up. It will be fixed in the next minor update.
-- Vault Enterprise binaries for `arm64` architectures will crash immediately when using production-ready storage backends.  This issue is addressed in Vault 1.8.1.
-- AWS Auth using the [EC2 method](https://www.vaultproject.io/docs/auth/aws#ec2-auth-method)
-  fails with the error `failed to verify the signature`. This effects 1.8.0 and 1.8.1 and there
-  is not a workaround. The issue was fixed in Vault 1.8.2.
-- Configuration files in RedHat packages for Vault were not properly flagged as
-  config files for `fpm`, causing user-edited files on disk to be replaced with
-  the defaults when a new package was installed. This
-  [issue](https://github.com/hashicorp/vault/issues/12275) affects RedHat
-  packages for Vault 1.8.0 and the 1.8.1-0 package, and is fixed in 1.8.1-1 and up.
-- The introduction of `/gcp/roleset/:roleset/token` and `/gcp/roleset/:roleset/key` could inadvertently give
-  users the ability to generate tokens and key if globs are used in policies. To avoid issues like this,
-  globs should be avoided in policies to help adhere to the principle of least privilege. See the
-  [roleset documentation](/docs/secrets/gcp#rolesets) for more information.
+
+### Vault Enterprise binaries
+
+Vault Enterprise binaries for `arm64` architectures will crash immediately when using production-ready storage backends.  This issue is addressed in Vault 1.8.1.
+
+### AWS auth
+
+AWS Auth using the [EC2 method](https://www.vaultproject.io/docs/auth/aws#ec2-auth-method) fails with the error `failed to verify the signature`. This effects 1.8.0 and 1.8.1 and there is not a workaround. The issue was fixed in Vault 1.8.2.
+
+### Configuration files in RedHat packages
+
+Configuration files in RedHat packages for Vault were not properly flagged as config files for `fpm`, causing user-edited files on disk to be replaced with
+the defaults when a new package was installed. This [issue](https://github.com/hashicorp/vault/issues/12275) affects RedHat packages for Vault 1.8.0 and the 1.8.1-0 package, and is fixed in 1.8.1-1 and up.
+
+### Introduction of rolesets
+
+The introduction of `/gcp/roleset/:roleset/token` and `/gcp/roleset/:roleset/key` could inadvertently give users the ability to generate tokens and key if globs are used in policies. To avoid issues like this, globs should be avoided in policies to help adhere to the principle of least privilege. See the [roleset documentation](/docs/secrets/gcp#rolesets) for more information.

--- a/website/content/docs/upgrading/upgrade-to-1.9.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.9.x.mdx
@@ -97,9 +97,10 @@ See [this blog post](https://go.dev/blog/tls-cipher-suites) for more information
 
 @include 'pki-forwarding-bug.mdx'
 
-@include 'raft-panic-old-tls-key.mdx'
 
 ## Known Issues
+
+@include 'raft-panic-old-tls-key.mdx'
 
 ### Identity Token Backend Key Rotations
 


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/1201712347646323/1202192521515795), the following upgrade guides were updated to include the **Integrated Storage panic related to old TLS key** known issue.

Upgrading to Vault 1.10.x (:mag: [Deploy Preview](https://vault-1ykw3az95-hashicorp.vercel.app/docs/upgrading/upgrade-to-1.10.x#integrated-storage-panic-related-to-old-tls-key))
Upgrading to Vault 1.9.x (:mag: [Deploy Preview](https://vault-1ykw3az95-hashicorp.vercel.app/docs/upgrading/upgrade-to-1.9.x#integrated-storage-panic-related-to-old-tls-key))
Upgrading to Vault 1.8.x (:mag: [Deploy Preview](https://vault-1ykw3az95-hashicorp.vercel.app/docs/upgrading/upgrade-to-1.8.x#integrated-storage-panic-related-to-old-tls-key-1))