### PR TITLE
agent/auto-auth: Add `min_backoff` to set first backoff value

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -802,7 +802,7 @@ func (c *AgentCommand) Run(args []string) int {
 			Logger:                       c.logger.Named("auth.handler"),
 			Client:                       clonedClient,
 			WrapTTL:                      config.AutoAuth.Method.WrapTTL,
-			InitialBackoff:               config.AutoAuth.Method.InitialBackoff,
+			MinBackoff:                   config.AutoAuth.Method.MinBackoff,
 			MaxBackoff:                   config.AutoAuth.Method.MaxBackoff,
 			EnableReauthOnNewCredentials: config.AutoAuth.EnableReauthOnNewCredentials,
 			EnableTemplateTokenCh:        enableTokenCh,

--- a/command/agent.go
+++ b/command/agent.go
@@ -802,6 +802,7 @@ func (c *AgentCommand) Run(args []string) int {
 			Logger:                       c.logger.Named("auth.handler"),
 			Client:                       clonedClient,
 			WrapTTL:                      config.AutoAuth.Method.WrapTTL,
+			InitialBackoff:               config.AutoAuth.Method.InitialBackoff,
 			MaxBackoff:                   config.AutoAuth.Method.MaxBackoff,
 			EnableReauthOnNewCredentials: config.AutoAuth.EnableReauthOnNewCredentials,
 			EnableTemplateTokenCh:        enableTokenCh,

--- a/command/agent/auth/auth.go
+++ b/command/agent/auth/auth.go
@@ -396,10 +396,6 @@ func (b *agentBackoff) next() {
 }
 
 func (b *agentBackoff) reset(initialBackoff time.Duration) {
-	if initialBackoff <= 0 {
-		initialBackoff = defaultInitialBackoff
-	}
-
 	b.current = initialBackoff
 }
 

--- a/command/agent/auth/auth_test.go
+++ b/command/agent/auth/auth_test.go
@@ -109,10 +109,10 @@ consumption:
 
 func TestAgentBackoff(t *testing.T) {
 	max := 1024 * time.Second
-	backoff := newAgentBackoff(max)
+	backoff := newAgentBackoff(defaultInitialBackoff, max)
 
 	// Test initial value
-	if backoff.current != initialBackoff {
+	if backoff.current != defaultInitialBackoff {
 		t.Fatalf("expected 1s initial backoff, got: %v", backoff.current)
 	}
 
@@ -138,8 +138,59 @@ func TestAgentBackoff(t *testing.T) {
 	}
 
 	// Test reset
-	backoff.reset()
-	if backoff.current != initialBackoff {
+	backoff.reset(defaultInitialBackoff)
+	if backoff.current != defaultInitialBackoff {
 		t.Fatalf("expected 1s backoff after reset, got: %v", backoff.current)
+	}
+}
+
+func TestAgentInitialBackoffCustom(t *testing.T) {
+	type test struct {
+		initialBackoff time.Duration
+		want           time.Duration
+	}
+
+	tests := []test{
+		{initialBackoff: 0 * time.Second, want: 1 * time.Second},
+		{initialBackoff: 1 * time.Second, want: 1 * time.Second},
+		{initialBackoff: 5 * time.Second, want: 5 * time.Second},
+		{initialBackoff: 10 * time.Second, want: 10 * time.Second},
+	}
+
+	for _, test := range tests {
+		max := 1024 * time.Second
+		backoff := newAgentBackoff(test.initialBackoff, max)
+
+		// Test initial value
+		if backoff.current != test.want {
+			t.Fatalf("expected %d initial backoff, got: %v", test.want, backoff.current)
+		}
+
+		// Test that backoff values are in expected range (75-100% of 2*previous)
+		for i := 0; i < 5; i++ {
+			old := backoff.current
+			backoff.next()
+
+			expMax := 2 * old
+			expMin := 3 * expMax / 4
+
+			if backoff.current < expMin || backoff.current > expMax {
+				t.Fatalf("expected backoff in range %v to %v, got: %v", expMin, expMax, backoff)
+			}
+		}
+
+		// Test that backoff is capped
+		for i := 0; i < 100; i++ {
+			backoff.next()
+			if backoff.current > max {
+				t.Fatalf("backoff exceeded max of 100s: %v", backoff)
+			}
+		}
+
+		// Test reset
+		backoff.reset(test.initialBackoff)
+		if backoff.current != test.want {
+			t.Fatalf("expected %d backoff after reset, got: %v", test.want, backoff.current)
+		}
 	}
 }

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -108,14 +108,16 @@ type AutoAuth struct {
 
 // Method represents the configuration for the authentication backend
 type Method struct {
-	Type          string
-	MountPath     string        `hcl:"mount_path"`
-	WrapTTLRaw    interface{}   `hcl:"wrap_ttl"`
-	WrapTTL       time.Duration `hcl:"-"`
-	MaxBackoffRaw interface{}   `hcl:"max_backoff"`
-	MaxBackoff    time.Duration `hcl:"-"`
-	Namespace     string        `hcl:"namespace"`
-	Config        map[string]interface{}
+	Type              string
+	MountPath         string        `hcl:"mount_path"`
+	WrapTTLRaw        interface{}   `hcl:"wrap_ttl"`
+	WrapTTL           time.Duration `hcl:"-"`
+	InitialBackoffRaw interface{}   `hcl:"initial_backoff"`
+	InitialBackoff    time.Duration `hcl:"-"`
+	MaxBackoffRaw     interface{}   `hcl:"max_backoff"`
+	MaxBackoff        time.Duration `hcl:"-"`
+	Namespace         string        `hcl:"namespace"`
+	Config            map[string]interface{}
 }
 
 // Sink defines a location to write the authenticated token
@@ -468,6 +470,14 @@ func parseAutoAuth(result *Config, list *ast.ObjectList) error {
 			return err
 		}
 		result.AutoAuth.Method.MaxBackoffRaw = nil
+	}
+
+	if result.AutoAuth.Method.InitialBackoffRaw != nil {
+		var err error
+		if result.AutoAuth.Method.InitialBackoff, err = parseutil.ParseDurationSecond(result.AutoAuth.Method.InitialBackoffRaw); err != nil {
+			return err
+		}
+		result.AutoAuth.Method.InitialBackoffRaw = nil
 	}
 
 	return nil

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -108,16 +108,16 @@ type AutoAuth struct {
 
 // Method represents the configuration for the authentication backend
 type Method struct {
-	Type              string
-	MountPath         string        `hcl:"mount_path"`
-	WrapTTLRaw        interface{}   `hcl:"wrap_ttl"`
-	WrapTTL           time.Duration `hcl:"-"`
-	InitialBackoffRaw interface{}   `hcl:"initial_backoff"`
-	InitialBackoff    time.Duration `hcl:"-"`
-	MaxBackoffRaw     interface{}   `hcl:"max_backoff"`
-	MaxBackoff        time.Duration `hcl:"-"`
-	Namespace         string        `hcl:"namespace"`
-	Config            map[string]interface{}
+	Type          string
+	MountPath     string        `hcl:"mount_path"`
+	WrapTTLRaw    interface{}   `hcl:"wrap_ttl"`
+	WrapTTL       time.Duration `hcl:"-"`
+	MinBackoffRaw interface{}   `hcl:"min_backoff"`
+	MinBackoff    time.Duration `hcl:"-"`
+	MaxBackoffRaw interface{}   `hcl:"max_backoff"`
+	MaxBackoff    time.Duration `hcl:"-"`
+	Namespace     string        `hcl:"namespace"`
+	Config        map[string]interface{}
 }
 
 // Sink defines a location to write the authenticated token
@@ -472,12 +472,12 @@ func parseAutoAuth(result *Config, list *ast.ObjectList) error {
 		result.AutoAuth.Method.MaxBackoffRaw = nil
 	}
 
-	if result.AutoAuth.Method.InitialBackoffRaw != nil {
+	if result.AutoAuth.Method.MinBackoffRaw != nil {
 		var err error
-		if result.AutoAuth.Method.InitialBackoff, err = parseutil.ParseDurationSecond(result.AutoAuth.Method.InitialBackoffRaw); err != nil {
+		if result.AutoAuth.Method.MinBackoff, err = parseutil.ParseDurationSecond(result.AutoAuth.Method.MinBackoffRaw); err != nil {
 			return err
 		}
-		result.AutoAuth.Method.InitialBackoffRaw = nil
+		result.AutoAuth.Method.MinBackoffRaw = nil
 	}
 
 	return nil

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -290,6 +290,49 @@ func TestLoadConfigFile_Method_Wrapping(t *testing.T) {
 	}
 }
 
+func TestLoadConfigFile_Method_InitialBackoff(t *testing.T) {
+	config, err := LoadConfig("./test-fixtures/config-method-initial-backoff.hcl")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := &Config{
+		SharedConfig: &configutil.SharedConfig{
+			PidFile: "./pidfile",
+		},
+		AutoAuth: &AutoAuth{
+			Method: &Method{
+				Type:           "aws",
+				MountPath:      "auth/aws",
+				WrapTTL:        5 * time.Minute,
+				InitialBackoff: 5 * time.Second,
+				MaxBackoff:     2 * time.Minute,
+				Config: map[string]interface{}{
+					"role": "foobar",
+				},
+			},
+			Sinks: []*Sink{
+				{
+					Type: "file",
+					Config: map[string]interface{}{
+						"path": "/tmp/file-foo",
+					},
+				},
+			},
+		},
+		Vault: &Vault{
+			Retry: &Retry{
+				NumRetries: 12,
+			},
+		},
+	}
+
+	config.Prune()
+	if diff := deep.Equal(config, expected); diff != nil {
+		t.Fatal(diff)
+	}
+}
+
 func TestLoadConfigFile_AgentCache_NoAutoAuth(t *testing.T) {
 	config, err := LoadConfig("./test-fixtures/config-cache-no-auto_auth.hcl")
 	if err != nil {

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -302,11 +302,11 @@ func TestLoadConfigFile_Method_InitialBackoff(t *testing.T) {
 		},
 		AutoAuth: &AutoAuth{
 			Method: &Method{
-				Type:           "aws",
-				MountPath:      "auth/aws",
-				WrapTTL:        5 * time.Minute,
-				InitialBackoff: 5 * time.Second,
-				MaxBackoff:     2 * time.Minute,
+				Type:       "aws",
+				MountPath:  "auth/aws",
+				WrapTTL:    5 * time.Minute,
+				MinBackoff: 5 * time.Second,
+				MaxBackoff: 2 * time.Minute,
 				Config: map[string]interface{}{
 					"role": "foobar",
 				},

--- a/command/agent/config/test-fixtures/config-method-initial-backoff.hcl
+++ b/command/agent/config/test-fixtures/config-method-initial-backoff.hcl
@@ -8,7 +8,7 @@ auto_auth {
 			role = "foobar"
 		}
 		max_backoff = "2m"
-        initial_backoff = "5s"
+        min_backoff = "5s"
 	}
 
 	sink {

--- a/command/agent/config/test-fixtures/config-method-initial-backoff.hcl
+++ b/command/agent/config/test-fixtures/config-method-initial-backoff.hcl
@@ -1,0 +1,20 @@
+pid_file = "./pidfile"
+
+auto_auth {
+	method {
+		type = "aws"
+		wrap_ttl = 300
+		config = {
+			role = "foobar"
+		}
+		max_backoff = "2m"
+        initial_backoff = "5s"
+	}
+
+	sink {
+		type = "file"
+		config = {
+			path = "/tmp/file-foo"
+		}
+	}
+}

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -311,6 +311,9 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 		Enabled:  &enabled,
 	}
 
+	// Sync Consul Template's retry with user set auto-auth initial backoff value.
+	// This is helpful if Auto Auth cannot get a new token and CT is trying to fetch
+	// secrets.
 	if sc.AgentConfig.AutoAuth != nil && sc.AgentConfig.AutoAuth.Method != nil {
 		if sc.AgentConfig.AutoAuth.Method.InitialBackoff > 0 {
 			conf.Vault.Retry.Backoff = &sc.AgentConfig.AutoAuth.Method.InitialBackoff

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -315,8 +315,8 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 	// This is helpful if Auto Auth cannot get a new token and CT is trying to fetch
 	// secrets.
 	if sc.AgentConfig.AutoAuth != nil && sc.AgentConfig.AutoAuth.Method != nil {
-		if sc.AgentConfig.AutoAuth.Method.InitialBackoff > 0 {
-			conf.Vault.Retry.Backoff = &sc.AgentConfig.AutoAuth.Method.InitialBackoff
+		if sc.AgentConfig.AutoAuth.Method.MinBackoff > 0 {
+			conf.Vault.Retry.Backoff = &sc.AgentConfig.AutoAuth.Method.MinBackoff
 		}
 	}
 

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -311,6 +311,12 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 		Enabled:  &enabled,
 	}
 
+	if sc.AgentConfig.AutoAuth != nil && sc.AgentConfig.AutoAuth.Method != nil {
+		if sc.AgentConfig.AutoAuth.Method.InitialBackoff > 0 {
+			conf.Vault.Retry.Backoff = &sc.AgentConfig.AutoAuth.Method.InitialBackoff
+		}
+	}
+
 	conf.Finalize()
 
 	// setup log level from TemplateServer config

--- a/website/content/docs/agent/autoauth/index.mdx
+++ b/website/content/docs/agent/autoauth/index.mdx
@@ -138,8 +138,13 @@ These are common configuration values that live within the `method` block:
   structure. Values can be an integer number of seconds or a stringish value
   like `5m`.
 
+- `min_backoff` `(string or integer: "1s")` - The initial backoff time Agent 
+  will delay before retrying after a failed auth attempt. The backoff will start 
+  at the configured value and double (with some randomness) after successive 
+  failures, capped by `max_backoff.`
+
 - `max_backoff` `(string or integer: "5m")` - The maximum time Agent will delay
-  before retrying after a failed auth attempt. The backoff will start at 1 second
+  before retrying after a failed auth attempt. The backoff will start at `min_backoff` 
   and double (with some randomness) after successive failures, capped by `max_backoff.`
 
 - `config` `(object: required)` - Configuration of the method itself. See the


### PR DESCRIPTION
This adds a new config to Agent's auto-auth.method's stanza: `min_backoff`.

Agent's auto-auth has an initial hardcoded retry duration of 1 second, which grows after each failed retry. I'm making this value configurable because there may be instances you want to retry faster/slower. While writing this feature I found that the SDK client used by auto-auth has it's own built in retry logic. I disabled that retry logic (set MaxRetries to 0) because the auto-auth code has its own backoff function and we were effectively doubling our retry attempts.

Templating also relies on auto-auth and has it's own retry logic. I found an instance where Vault failed to get a token but the templating server tried to fetch secrets. This resulted in yet another variation of retries and more requests to Vault. To combat this, I synced the Template server's initial backoff value to that of auto-auths.

Example config:

```
auto_auth = {
  method = {
    config = {
      role_id_file_path = "/tmp/agent/roleid"
      secret_id_file_path = "/tmp/agent/secretid"
    }

    type = "approle"
    min_backoff = "5s"
    max_backoff = "30s"
  }

  sink = {
    config = {
      path = "/tmp/file-foo"
    }
    type = "file"
  }
}

exit_after_auth = false

template = {
  contents = "{{ with secret \"secret/hashiconf\" }}{{ .Data | toJSONPretty }}{{ end }}"
  destination = "/tmp/agent/kv"
}

vault = {
  address = "http://127.0.0.1:8200"
}
```