### PR TITLE
Allow callers to choose the entropy source for the random endpoints.

### DIFF
--- a/builtin/logical/transit/path_random.go
+++ b/builtin/logical/transit/path_random.go
@@ -44,8 +44,8 @@ func (b *backend) pathRandom() *framework.Path {
 	}
 }
 
-func (b *backend) pathRandomWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	return random.HandleRandomAPI(ctx, req, d, b.GetRandomReader())
+func (b *backend) pathRandomWrite(_ context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	return random.HandleRandomAPI(d, b.GetRandomReader())
 }
 
 const pathRandomHelpSyn = `Generate random bytes`

--- a/builtin/logical/transit/path_random.go
+++ b/builtin/logical/transit/path_random.go
@@ -2,21 +2,10 @@ package transit
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/base64"
-	"encoding/hex"
-	"fmt"
-	"github.com/hashicorp/vault/sdk/helper/xor"
-	"io"
-	"k8s.io/utils/strings/slices"
-	"strconv"
-
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/helper/random"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
-
-const maxBytes = 128 * 1024
 
 func (b *backend) pathRandom() *framework.Path {
 	return &framework.Path{
@@ -42,7 +31,7 @@ func (b *backend) pathRandom() *framework.Path {
 			"source": {
 				Type:        framework.TypeString,
 				Default:     "platform",
-				Description: `Which system to source entropy from, ether "platform", "seal", or "all".`,
+				Description: `Which system to source random data from, ether "platform", "seal", or "all".`,
 			},
 		},
 
@@ -56,100 +45,7 @@ func (b *backend) pathRandom() *framework.Path {
 }
 
 func (b *backend) pathRandomWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	bytes := 0
-
-	//Parsing is convoluted here, but allows operators to ACL both bytes and entropy source
-	maybeUrlBytes := d.Raw["urlbytes"]
-	maybeSource := d.Raw["source"]
-	source := "platform"
-	var err error
-	if maybeSource == "" {
-		bytes = d.Get("bytes").(int)
-	} else if maybeUrlBytes == "" && slices.Contains([]string{"", "platform", "seal", "all"}, maybeSource.(string)) {
-		source = maybeSource.(string)
-		bytes = d.Get("bytes").(int)
-	} else if maybeUrlBytes == "" {
-		bytes, err = strconv.Atoi(maybeSource.(string))
-		if err != nil {
-			return logical.ErrorResponse(fmt.Sprintf("error parsing url-set byte count: %s", err)), nil
-		}
-	} else {
-		source = maybeSource.(string)
-		bytes, err = strconv.Atoi(maybeUrlBytes.(string))
-		if err != nil {
-			return logical.ErrorResponse(fmt.Sprintf("error parsing url-set byte count: %s", err)), nil
-		}
-	}
-	format := d.Get("format").(string)
-
-	if bytes < 1 {
-		return logical.ErrorResponse(`"bytes" cannot be less than 1`), nil
-	}
-
-	if bytes > maxBytes {
-		return logical.ErrorResponse(`"bytes" should be less than %d`, maxBytes), nil
-	}
-
-	switch format {
-	case "hex":
-	case "base64":
-	default:
-		return logical.ErrorResponse("unsupported encoding format %q; must be \"hex\" or \"base64\"", format), nil
-	}
-
-	var randBytes []byte
-	var warning string
-	switch source {
-	case "", "platform":
-		randBytes, err = uuid.GenerateRandomBytes(bytes)
-		if err != nil {
-			return nil, err
-		}
-	case "seal":
-		if rand.Reader == b.GetRandomReader() {
-			warning = "no seal/entropy augmentation available, using platform entropy source"
-		}
-		randBytes = make([]byte, bytes)
-		_, err = io.ReadFull(b.GetRandomReader(), randBytes)
-		if err != nil {
-			return nil, err
-		}
-	case "all":
-		sealBytes := make([]byte, bytes)
-		_, err = io.ReadFull(b.GetRandomReader(), sealBytes)
-		if err != nil {
-			return nil, err
-		}
-		randBytes, err = uuid.GenerateRandomBytes(bytes)
-		if err != nil {
-			return nil, err
-		}
-		randBytes, err = xor.XORBytes(sealBytes, randBytes)
-		if err != nil {
-			return nil, err
-		}
-	default:
-		return logical.ErrorResponse("unsupported entropy source %q; must be \"platform\" or \"seal\", or \"all\"", source), nil
-	}
-
-	var retStr string
-	switch format {
-	case "hex":
-		retStr = hex.EncodeToString(randBytes)
-	case "base64":
-		retStr = base64.StdEncoding.EncodeToString(randBytes)
-	}
-
-	// Generate the response
-	resp := &logical.Response{
-		Data: map[string]interface{}{
-			"random_bytes": retStr,
-		},
-	}
-	if warning != "" {
-		resp.Warnings = []string{warning}
-	}
-	return resp, nil
+	return random.HandleRandomAPI(ctx, req, d, b.GetRandomReader())
 }
 
 const pathRandomHelpSyn = `Generate random bytes`

--- a/builtin/logical/transit/path_random_test.go
+++ b/builtin/logical/transit/path_random_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"github.com/hashicorp/vault/helper/random"
 	"reflect"
 	"testing"
 
@@ -116,7 +117,7 @@ func TestTransit_Random(t *testing.T) {
 		doRequest(req, true, "", 0)
 
 		req.Data["format"] = "hex"
-		req.Data["bytes"] = maxBytes + 1
+		req.Data["bytes"] = random.APIMaxBytes + 1
 
 		doRequest(req, true, "", 0)
 	}

--- a/builtin/logical/transit/path_random_test.go
+++ b/builtin/logical/transit/path_random_test.go
@@ -5,10 +5,10 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"github.com/hashicorp/vault/helper/random"
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/vault/helper/random"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 

--- a/builtin/logical/transit/path_random_test.go
+++ b/builtin/logical/transit/path_random_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -81,24 +82,42 @@ func TestTransit_Random(t *testing.T) {
 		}
 	}
 
-	// Test defaults
-	doRequest(req, false, "base64", 32)
+	for _, source := range []string{"", "platform", "seal", "all"} {
+		req.Data["source"] = source
+		req.Data["bytes"] = 32
+		req.Data["format"] = "base64"
+		req.Path = "random"
+		// Test defaults
+		doRequest(req, false, "base64", 32)
 
-	// Test size selection in the path
-	req.Path = "random/24"
-	req.Data["format"] = "hex"
-	doRequest(req, false, "hex", 24)
+		// Test size selection in the path
+		req.Path = "random/24"
+		req.Data["format"] = "hex"
+		doRequest(req, false, "hex", 24)
 
-	// Test bad input/format
-	req.Path = "random"
-	req.Data["format"] = "base92"
-	doRequest(req, true, "", 0)
+		if source != "" {
+			// Test source selection in the path
+			req.Path = fmt.Sprintf("random/%s", source)
+			req.Data["format"] = "hex"
+			doRequest(req, false, "hex", 32)
 
-	req.Data["format"] = "hex"
-	req.Data["bytes"] = -1
-	doRequest(req, true, "", 0)
+			req.Path = fmt.Sprintf("random/%s/24", source)
+			req.Data["format"] = "hex"
+			doRequest(req, false, "hex", 24)
+		}
 
-	req.Data["format"] = "hex"
-	req.Data["bytes"] = maxBytes + 1
-	doRequest(req, true, "", 0)
+		// Test bad input/format
+		req.Path = "random"
+		req.Data["format"] = "base92"
+		doRequest(req, true, "", 0)
+
+		req.Data["format"] = "hex"
+		req.Data["bytes"] = -1
+		doRequest(req, true, "", 0)
+
+		req.Data["format"] = "hex"
+		req.Data["bytes"] = maxBytes + 1
+
+		doRequest(req, true, "", 0)
+	}
 }

--- a/changelog/15213.txt
+++ b/changelog/15213.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-core,transit: Allow callers to choose entropy source including entropy augmentation sources for the sys/tools/random and transit/random endpoints.
+core,transit: Allow callers to choose random byte source including entropy augmentation sources for the sys/tools/random and transit/random endpoints.
 ```

--- a/changelog/15213.txt
+++ b/changelog/15213.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core,transit: Allow callers to choose entropy source including entropy augmentation sources for the sys/tools/random and transit/random endpoints.
+```

--- a/helper/random/random_api.go
+++ b/helper/random/random_api.go
@@ -1,24 +1,24 @@
 package random
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"io"
+	"strconv"
+
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/xor"
 	"github.com/hashicorp/vault/sdk/logical"
-	"io"
-	"strconv"
 )
 
 const APIMaxBytes = 128 * 1024
 
-func HandleRandomAPI(ctx context.Context, req *logical.Request, d *framework.FieldData, additionalSource io.Reader) (*logical.Response, error) {
+func HandleRandomAPI(d *framework.FieldData, additionalSource io.Reader) (*logical.Response, error) {
 	bytes := 0
-	//Parsing is convoluted here, but allows operators to ACL both source and byte count
+	// Parsing is convoluted here, but allows operators to ACL both source and byte count
 	maybeUrlBytes := d.Raw["urlbytes"]
 	maybeSource := d.Raw["source"]
 	source := "platform"

--- a/helper/random/random_api.go
+++ b/helper/random/random_api.go
@@ -1,0 +1,115 @@
+package random
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/xor"
+	"github.com/hashicorp/vault/sdk/logical"
+	"io"
+	"strconv"
+)
+
+const APIMaxBytes = 128 * 1024
+
+func HandleRandomAPI(ctx context.Context, req *logical.Request, d *framework.FieldData, additionalSource io.Reader) (*logical.Response, error) {
+	bytes := 0
+	//Parsing is convoluted here, but allows operators to ACL both source and byte count
+	maybeUrlBytes := d.Raw["urlbytes"]
+	maybeSource := d.Raw["source"]
+	source := "platform"
+	var err error
+	if maybeSource == "" {
+		bytes = d.Get("bytes").(int)
+	} else if maybeUrlBytes == "" && isValidSource(maybeSource.(string)) {
+		source = maybeSource.(string)
+		bytes = d.Get("bytes").(int)
+	} else if maybeUrlBytes == "" {
+		bytes, err = strconv.Atoi(maybeSource.(string))
+		if err != nil {
+			return logical.ErrorResponse(fmt.Sprintf("error parsing url-set byte count: %s", err)), nil
+		}
+	} else {
+		source = maybeSource.(string)
+		bytes, err = strconv.Atoi(maybeUrlBytes.(string))
+		if err != nil {
+			return logical.ErrorResponse(fmt.Sprintf("error parsing url-set byte count: %s", err)), nil
+		}
+	}
+	format := d.Get("format").(string)
+
+	if bytes < 1 {
+		return logical.ErrorResponse(`"bytes" cannot be less than 1`), nil
+	}
+
+	if bytes > APIMaxBytes {
+		return logical.ErrorResponse(`"bytes" should be less than %d`, APIMaxBytes), nil
+	}
+
+	switch format {
+	case "hex":
+	case "base64":
+	default:
+		return logical.ErrorResponse("unsupported encoding format %q; must be \"hex\" or \"base64\"", format), nil
+	}
+
+	var randBytes []byte
+	var warning string
+	switch source {
+	case "", "platform":
+		randBytes, err = uuid.GenerateRandomBytes(bytes)
+		if err != nil {
+			return nil, err
+		}
+	case "seal":
+		if rand.Reader == additionalSource {
+			warning = "no seal/entropy augmentation available, using platform entropy source"
+		}
+		randBytes, err = uuid.GenerateRandomBytesWithReader(bytes, additionalSource)
+	case "all":
+		var sealBytes []byte
+		sealBytes, err = uuid.GenerateRandomBytesWithReader(bytes, additionalSource)
+		if err == nil {
+			randBytes, err = uuid.GenerateRandomBytes(bytes)
+			if err == nil {
+				randBytes, err = xor.XORBytes(sealBytes, randBytes)
+			}
+		}
+	default:
+		return logical.ErrorResponse("unsupported entropy source %q; must be \"platform\" or \"seal\", or \"all\"", source), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var retStr string
+	switch format {
+	case "hex":
+		retStr = hex.EncodeToString(randBytes)
+	case "base64":
+		retStr = base64.StdEncoding.EncodeToString(randBytes)
+	}
+
+	// Generate the response
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			"random_bytes": retStr,
+		},
+	}
+	if warning != "" {
+		resp.Warnings = []string{warning}
+	}
+	return resp, nil
+}
+
+func isValidSource(s string) bool {
+	switch s {
+	case "", "platform", "seal", "all":
+		return true
+	}
+	return false
+}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3609,8 +3609,8 @@ func (b *SystemBackend) pathHashWrite(ctx context.Context, req *logical.Request,
 	return resp, nil
 }
 
-func (b *SystemBackend) pathRandomWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	return random.HandleRandomAPI(ctx, req, d, b.Core.secureRandomReader)
+func (b *SystemBackend) pathRandomWrite(_ context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	return random.HandleRandomAPI(d, b.Core.secureRandomReader)
 }
 
 func hasMountAccess(ctx context.Context, acl *ACL, path string) bool {

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -873,6 +873,12 @@ func (b *SystemBackend) toolsPaths() []*framework.Path {
 					Default:     "base64",
 					Description: `Encoding format to use. Can be "hex" or "base64". Defaults to "base64".`,
 				},
+
+				"source": {
+					Type:        framework.TypeString,
+					Default:     "platform",
+					Description: `Which system to source entropy from, ether "platform", "seal", or "all".`,
+				},
 			},
 
 			Callbacks: map[logical.Operation]framework.OperationFunc{

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -855,7 +855,7 @@ func (b *SystemBackend) toolsPaths() []*framework.Path {
 		},
 
 		{
-			Pattern: "tools/random" + framework.OptionalParamRegex("urlbytes"),
+			Pattern: "tools/random(/" + framework.GenericNameRegex("source") + ")?" + framework.OptionalParamRegex("urlbytes"),
 			Fields: map[string]*framework.FieldSchema{
 				"urlbytes": {
 					Type:        framework.TypeString,

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -877,7 +877,7 @@ func (b *SystemBackend) toolsPaths() []*framework.Path {
 				"source": {
 					Type:        framework.TypeString,
 					Default:     "platform",
-					Description: `Which system to source entropy from, ether "platform", "seal", or "all".`,
+					Description: `Which system to source random data from, ether "platform", "seal", or "all".`,
 				},
 			},
 

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -3159,7 +3159,7 @@ func TestSystemBackend_ToolsRandom(t *testing.T) {
 		req.Data["source"] = source
 		req.Data["bytes"] = 32
 		req.Data["format"] = "base64"
-		req.Path = "random"
+		req.Path = "tools/random"
 		// Test defaults
 		doRequest(req, false, "base64", 32)
 

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -664,10 +664,10 @@ This endpoint returns high-quality random bytes of the specified length.
 - `format` `(string: "base64")` – Specifies the output encoding. Valid options
   are `hex` or `base64`.
 
-- `source` `(string: "platform")` - Specifies the source of the requested entropy.
-  `platform`, the default, sources entropy from the platform's entropy source. 
+- `source` `(string: "platform")` - Specifies the source of the requested bytes.
+  `platform`, the default, sources bytes from the platform's entropy source. 
   `seal` sources from entropy augmentation (enterprise only).
-  `all` mixes entropy from all available sources.
+  `all` mixes bytes from all available sources.
 
 ### Sample Payload
 

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -652,9 +652,9 @@ $ curl \
 
 This endpoint returns high-quality random bytes of the specified length.
 
-| Method | Path                       |
-| :----- | :------------------------- |
-| `POST` | `/transit/random(/:bytes)` |
+| Method | Path                                 |
+| :----- | :----------------------------------- |
+| `POST` | `/transit/random(/:source)(/:bytes)` |
 
 ### Parameters
 
@@ -663,6 +663,11 @@ This endpoint returns high-quality random bytes of the specified length.
 
 - `format` `(string: "base64")` – Specifies the output encoding. Valid options
   are `hex` or `base64`.
+
+- `source` `(string: "platform")` - Specifies the source of the requested entropy.
+  `platform`, the default, sources entropy from the platform's entropy source. 
+  `seal` sources from entropy augmentation (enterprise only).
+  `all` mixes entropy from all available sources.
 
 ### Sample Payload
 

--- a/website/content/api-docs/system/tools.mdx
+++ b/website/content/api-docs/system/tools.mdx
@@ -12,9 +12,9 @@ The `/sys/tools` endpoints are a general set of tools.
 
 This endpoint returns high-quality random bytes of the specified length.
 
-| Method | Path                         |
-| :----- | :--------------------------- |
-| `POST` | `/sys/tools/random(/:bytes)` |
+| Method | Path                                   |
+| :----- | :------------------------------------- |
+| `POST` | `/sys/tools/random(/:source)(/:bytes)` |
 
 ### Parameters
 
@@ -23,6 +23,11 @@ This endpoint returns high-quality random bytes of the specified length.
 
 - `format` `(string: "base64")` – Specifies the output encoding. Valid options
   are `hex` or `base64`.
+
+- `source` `(string: "platform")` - Specifies the source of the requested entropy.
+  `platform`, the default, sources entropy from the platform's entropy source. 
+  `seal` sources from entropy augmentation (enterprise only).
+  `all` mixes entropy from all available sources.
 
 ### Sample Payload
 

--- a/website/content/api-docs/system/tools.mdx
+++ b/website/content/api-docs/system/tools.mdx
@@ -24,10 +24,10 @@ This endpoint returns high-quality random bytes of the specified length.
 - `format` `(string: "base64")` – Specifies the output encoding. Valid options
   are `hex` or `base64`.
 
-- `source` `(string: "platform")` - Specifies the source of the requested entropy.
-  `platform`, the default, sources entropy from the platform's entropy source. 
+- `source` `(string: "platform")` - Specifies the source of the requested bytes.
+  `platform`, the default, sources bytes from the platform's entropy source. 
   `seal` sources from entropy augmentation (enterprise only).
-  `all` mixes entropy from all available sources.
+  `all` mixes bytes from all available sources.
 
 ### Sample Payload
 


### PR DESCRIPTION
They can choose "platform" to get the status quo behavior, "seal" to get
entropy augmentation, or "all" to get an XORed combination of both.

Addresses VAULT-5850.