### PR TITLE
MFA Push Methods Login Update

### DIFF
--- a/ui/app/components/mfa-form.js
+++ b/ui/app/components/mfa-form.js
@@ -15,9 +15,10 @@ import { numberToWord } from 'vault/helpers/number-to-word';
  * @param {string} clusterId - id of selected cluster
  * @param {object} authData - data from initial auth request -- { mfa_requirement, backend, data }
  * @param {function} onSuccess - fired when passcode passes validation
+ * @param {function} onError - fired for multi-method or non-passcode method validation errors
  */
 
-export const VALIDATION_ERROR =
+export const TOTP_VALIDATION_ERROR =
   'The passcode failed to validate. If you entered the correct passcode, contact your administrator.';
 
 export default class MfaForm extends Component {
@@ -25,6 +26,18 @@ export default class MfaForm extends Component {
 
   @tracked countdown;
   @tracked error;
+  @tracked codeDelayMessage;
+
+  constructor() {
+    super(...arguments);
+    // trigger validation immediately when passcode is not required
+    const passcodeOrSelect = this.constraints.filter((constraint) => {
+      return constraint.methods.length > 1 || constraint.methods.findBy('uses_passcode');
+    });
+    if (!passcodeOrSelect.length) {
+      this.validate.perform();
+    }
+  }
 
   get constraints() {
     return this.args.authData.mfa_requirement.mfa_constraints;
@@ -66,19 +79,26 @@ export default class MfaForm extends Component {
       });
       this.args.onSuccess(response);
     } catch (error) {
-      const codeUsed = (error.errors || []).find((e) => e.includes('code already used;'));
-      if (codeUsed) {
-        // parse validity period from error string to initialize countdown
-        const seconds = parseInt(codeUsed.split('in ')[1].split(' seconds')[0]);
-        this.newCodeDelay.perform(seconds);
+      const errors = error.errors || [];
+      const codeUsed = errors.find((e) => e.includes('code already used;'));
+      const rateLimit = errors.find((e) => e.includes('maximum TOTP validation attempts'));
+      const delayMessage = codeUsed || rateLimit;
+
+      if (delayMessage) {
+        const reason = codeUsed ? 'This code has already been used' : 'Maximum validation attempts exceeded';
+        this.codeDelayMessage = `${reason}. Please wait until a new code is available.`;
+        this.newCodeDelay.perform(delayMessage);
+      } else if (this.singlePasscode) {
+        this.error = TOTP_VALIDATION_ERROR;
       } else {
-        this.error = VALIDATION_ERROR;
+        this.args.onError(this.auth.handleError(error));
       }
     }
   }
 
-  @task *newCodeDelay(timePeriod) {
-    this.countdown = timePeriod;
+  @task *newCodeDelay(message) {
+    // parse validity period from error string to initialize countdown
+    this.countdown = parseInt(message.match(/(\d\w seconds)/)[0].split(' ')[0]);
     while (this.countdown) {
       yield timeout(1000);
       this.countdown--;

--- a/ui/app/controllers/vault/cluster/auth.js
+++ b/ui/app/controllers/vault/cluster/auth.js
@@ -69,8 +69,7 @@ export default Controller.extend({
   actions: {
     onAuthResponse(authResponse, backend, data) {
       const { mfa_requirement } = authResponse;
-      // mfa methods handled by the backend are validated immediately in the auth service
-      // if the user must choose between methods or enter passcodes further action is required
+      // if an mfa requirement exists further action is required
       if (mfa_requirement) {
         this.set('mfaAuthData', { mfa_requirement, backend, data });
       } else {
@@ -81,8 +80,10 @@ export default Controller.extend({
       this.authSuccess(authResponse);
     },
     onMfaErrorDismiss() {
-      this.set('mfaAuthData', null);
-      this.auth.set('mfaErrors', null);
+      this.setProperties({
+        mfaAuthData: null,
+        mfaErrors: null,
+      });
     },
   },
 });

--- a/ui/app/services/auth.js
+++ b/ui/app/services/auth.js
@@ -335,14 +335,11 @@ export default Service.extend({
     // convert to array of objects and add necessary properties to satisfy the view
     if (mfa_requirement) {
       const { mfa_request_id, mfa_constraints } = mfa_requirement;
-      let requiresAction; // if multiple constraints or methods or passcode input is needed further action will be required
       const constraints = [];
       for (let key in mfa_constraints) {
         const methods = mfa_constraints[key].any;
         const isMulti = methods.length > 1;
-        if (isMulti || methods.findBy('uses_passcode')) {
-          requiresAction = true;
-        }
+
         // friendly label for display in MfaForm
         methods.forEach((m) => {
           const typeFormatted = m.type === 'totp' ? m.type.toUpperCase() : capitalize(m.type);
@@ -357,7 +354,6 @@ export default Service.extend({
 
       return {
         mfa_requirement: { mfa_request_id, mfa_constraints: constraints },
-        requiresAction,
       };
     }
     return {};
@@ -366,23 +362,10 @@ export default Service.extend({
   async authenticate(/*{clusterId, backend, data, selectedAuth}*/) {
     const [options] = arguments;
     const adapter = this.clusterAdapter();
+    const resp = await adapter.authenticate(options);
 
-    let resp = await adapter.authenticate(options);
-    const { mfa_requirement, requiresAction } = this._parseMfaResponse(resp.auth?.mfa_requirement);
-
-    if (mfa_requirement) {
-      if (requiresAction) {
-        return { mfa_requirement };
-      }
-      // silently make request to validate endpoint when passcode is not required
-      try {
-        resp = await adapter.mfaValidate(mfa_requirement);
-      } catch (e) {
-        // it's not clear in the auth-form component whether mfa validation is taking place for non-totp method
-        // since mfa errors display a screen rather than flash message handle separately
-        this.set('mfaErrors', this.handleError(e));
-        throw e;
-      }
+    if (resp.auth?.mfa_requirement) {
+      return this._parseMfaResponse(resp.auth?.mfa_requirement);
     }
 
     return this.authSuccess(options, resp.auth || resp.data);

--- a/ui/app/templates/components/mfa-form.hbs
+++ b/ui/app/templates/components/mfa-form.hbs
@@ -45,7 +45,7 @@
               {{! template-lint-enable no-autofocus-attribute}}
             </div>
           {{else if (eq constraint.methods.length 1)}}
-            <p class="has-text-grey-400">
+            <p class="has-text-grey-400" data-test-mfa-push-instruction>
               Check device for push notification
             </p>
           {{/if}}
@@ -53,11 +53,7 @@
       </div>
       {{#if this.newCodeDelay.isRunning}}
         <div>
-          <AlertInline
-            @type="danger"
-            @sizeSmall={{true}}
-            @message="This code is invalid. Please wait until a new code is available."
-          />
+          <AlertInline @type="danger" @sizeSmall={{true}} @message={{this.codeDelayMessage}} />
         </div>
       {{/if}}
       <button

--- a/ui/app/templates/vault/cluster/auth.hbs
+++ b/ui/app/templates/vault/cluster/auth.hbs
@@ -1,4 +1,4 @@
-<SplashPage @hasAltContent={{this.auth.mfaErrors}} as |Page|>
+<SplashPage @hasAltContent={{this.mfaErrors}} as |Page|>
   <Page.altContent>
     <div class="has-top-margin-xxl" data-test-mfa-error>
       <EmptyState
@@ -6,7 +6,7 @@
         @message="Multi-factor authentication is required, but failed. Go back and try again, or contact your administrator."
         @icon="alert-circle"
         @bottomBorder={{true}}
-        @subTitle={{join ". " this.auth.mfaErrors}}
+        @subTitle={{join ". " this.mfaErrors}}
         class="is-box-shadowless"
       >
         <button type="button" class="button is-ghost is-transparent" {{on "click" (action "onMfaErrorDismiss")}}>
@@ -99,7 +99,12 @@
   {{/unless}}
   <Page.content>
     {{#if this.mfaAuthData}}
-      <MfaForm @clusterId={{this.model.id}} @authData={{this.mfaAuthData}} @onSuccess={{action "onMfaSuccess"}} />
+      <MfaForm
+        @clusterId={{this.model.id}}
+        @authData={{this.mfaAuthData}}
+        @onSuccess={{action "onMfaSuccess"}}
+        @onError={{fn (mut this.mfaErrors)}}
+      />
     {{else}}
       <AuthForm
         @wrappedToken={{this.wrappedToken}}

--- a/ui/tests/acceptance/mfa-login-test.js
+++ b/ui/tests/acceptance/mfa-login-test.js
@@ -1,10 +1,11 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { click, currentRouteName, fillIn, visit } from '@ember/test-helpers';
+import { click, currentRouteName, fillIn, visit, waitUntil, find } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import ENV from 'vault/config/environment';
+import { validationHandler } from '../../mirage/handlers/mfa-login';
 
-module('Acceptance | mfa', function (hooks) {
+module('Acceptance | mfa-login', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -56,7 +57,27 @@ module('Acceptance | mfa', function (hooks) {
   });
 
   test('it should handle single mfa constraint with push method', async function (assert) {
-    assert.expect(1);
+    assert.expect(6);
+
+    server.post('/sys/mfa/validate', async (schema, req) => {
+      await waitUntil(() => find('[data-test-mfa-description]'));
+      assert
+        .dom('[data-test-mfa-description]')
+        .hasText(
+          'Multi-factor authentication is enabled for your account.',
+          'Mfa form displays with correct description'
+        );
+      assert.dom('[data-test-mfa-label]').hasText('Okta push notification', 'Correct method renders');
+      assert
+        .dom('[data-test-mfa-push-instruction]')
+        .hasText('Check device for push notification', 'Push notification instruction renders');
+      assert.dom('[data-test-mfa-validate]').isDisabled('Button is disabled while validating');
+      assert
+        .dom('[data-test-mfa-validate]')
+        .hasClass('is-loading', 'Loading class applied to button while validating');
+      return validationHandler(schema, req);
+    });
+
     await login('mfa-b');
     didLogin(assert);
   });


### PR DESCRIPTION
Feedback from the mfa login project indicated that it may be confusing to have different workflows for push only mfa requirements versus passcode or multi-method requirements. As originally implemented, push only requirements would result in mfa validation being handled behind the scenes on the main login screen. After 5 seconds a message would be displayed to indicate that the user _may_ need to check their device for a push notification.

To address the feedback and unify the experience, all login attempts with mfa requirements will be transitioned to the mfa form where validation will begin automatically and the user will see a message indicating the method(s) that must be satisfied.

![image](https://user-images.githubusercontent.com/24611656/165806775-81c1d490-c17a-4673-b82e-a2df2cfb6194.png).

In addition, to accommodate rate limiting errors which were introduced in #14864, the validation error response handling was updated to parse the new message and display the countdown in the same manner as a code that has already been used.

![image](https://user-images.githubusercontent.com/24611656/165807999-662cc534-ed1e-40f3-b30f-e3760c79fe81.png)
