### PR TITLE
Handle issuer, keys locking

### DIFF
--- a/builtin/logical/pki/path_config_ca.go
+++ b/builtin/logical/pki/path_config_ca.go
@@ -110,6 +110,11 @@ func (b *backend) pathCAIssuersRead(ctx context.Context, req *logical.Request, _
 }
 
 func (b *backend) pathCAIssuersWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Since we're planning on updating issuers here, grab the lock so we've
+	// got a consistent view.
+	b.issuersLock.Lock()
+	defer b.issuersLock.Unlock()
+
 	newDefault := data.Get(defaultRef).(string)
 	if len(newDefault) == 0 || newDefault == defaultRef {
 		return logical.ErrorResponse("Invalid issuer specification; must be non-empty and can't be 'default'."), nil
@@ -200,6 +205,11 @@ func (b *backend) pathKeyDefaultRead(ctx context.Context, req *logical.Request, 
 }
 
 func (b *backend) pathKeyDefaultWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Since we're planning on updating keys here, grab the lock so we've
+	// got a consistent view.
+	b.issuersLock.Lock()
+	defer b.issuersLock.Unlock()
+
 	newDefault := data.Get(defaultRef).(string)
 	if len(newDefault) == 0 || newDefault == defaultRef {
 		return logical.ErrorResponse("Invalid key specification; must be non-empty and can't be 'default'."), nil

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -27,6 +27,10 @@ func pathListIssuers(b *backend) *framework.Path {
 }
 
 func (b *backend) pathListIssuersHandler(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Can not list issuers until migration has completed"), nil
+	}
+
 	var responseKeys []string
 	responseInfo := make(map[string]interface{})
 
@@ -122,6 +126,10 @@ func (b *backend) pathGetIssuer(ctx context.Context, req *logical.Request, data 
 		return b.pathGetRawIssuer(ctx, req, data)
 	}
 
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Can not get issuer until migration has completed"), nil
+	}
+
 	issuerName := getIssuerRef(data)
 	if len(issuerName) == 0 {
 		return logical.ErrorResponse("missing issuer reference"), nil
@@ -163,6 +171,10 @@ func (b *backend) pathUpdateIssuer(ctx context.Context, req *logical.Request, da
 	// got a consistent view.
 	b.issuersLock.Lock()
 	defer b.issuersLock.Unlock()
+
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Can not update issuer until migration has completed"), nil
+	}
 
 	issuerName := getIssuerRef(data)
 	if len(issuerName) == 0 {
@@ -282,6 +294,10 @@ func (b *backend) pathUpdateIssuer(ctx context.Context, req *logical.Request, da
 }
 
 func (b *backend) pathGetRawIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Can not get issuer until migration has completed"), nil
+	}
+
 	issuerName := getIssuerRef(data)
 	if len(issuerName) == 0 {
 		return logical.ErrorResponse("missing issuer reference"), nil
@@ -333,6 +349,10 @@ func (b *backend) pathDeleteIssuer(ctx context.Context, req *logical.Request, da
 	// got a consistent view.
 	b.issuersLock.Lock()
 	defer b.issuersLock.Unlock()
+
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Can not delete issuer until migration has completed"), nil
+	}
 
 	issuerName := getIssuerRef(data)
 	if len(issuerName) == 0 {
@@ -405,6 +425,10 @@ func buildPathGetIssuerCRL(b *backend, pattern string) *framework.Path {
 }
 
 func (b *backend) pathGetIssuerCRL(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Can not get issuer's CRL until migration has completed"), nil
+	}
+
 	issuerName := getIssuerRef(data)
 	if len(issuerName) == 0 {
 		return logical.ErrorResponse("missing issuer reference"), nil

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -159,6 +159,11 @@ func (b *backend) pathGetIssuer(ctx context.Context, req *logical.Request, data 
 }
 
 func (b *backend) pathUpdateIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Since we're planning on updating issuers here, grab the lock so we've
+	// got a consistent view.
+	b.issuersLock.Lock()
+	defer b.issuersLock.Unlock()
+
 	issuerName := getIssuerRef(data)
 	if len(issuerName) == 0 {
 		return logical.ErrorResponse("missing issuer reference"), nil
@@ -324,6 +329,11 @@ func (b *backend) pathGetRawIssuer(ctx context.Context, req *logical.Request, da
 }
 
 func (b *backend) pathDeleteIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Since we're planning on updating issuers here, grab the lock so we've
+	// got a consistent view.
+	b.issuersLock.Lock()
+	defer b.issuersLock.Unlock()
+
 	issuerName := getIssuerRef(data)
 	if len(issuerName) == 0 {
 		return logical.ErrorResponse("missing issuer reference"), nil

--- a/builtin/logical/pki/path_fetch_keys.go
+++ b/builtin/logical/pki/path_fetch_keys.go
@@ -141,6 +141,11 @@ func (b *backend) pathGetKeyHandler(ctx context.Context, req *logical.Request, d
 }
 
 func (b *backend) pathUpdateKeyHandler(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Since we're planning on updating keys here, grab the lock so we've
+	// got a consistent view.
+	b.issuersLock.Lock()
+	defer b.issuersLock.Unlock()
+
 	keyRef := data.Get(keyRefParam).(string)
 	if len(keyRef) == 0 {
 		return logical.ErrorResponse("missing key reference"), nil
@@ -189,6 +194,11 @@ func (b *backend) pathUpdateKeyHandler(ctx context.Context, req *logical.Request
 }
 
 func (b *backend) pathDeleteKeyHandler(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Since we're planning on updating issuers here, grab the lock so we've
+	// got a consistent view.
+	b.issuersLock.Lock()
+	defer b.issuersLock.Unlock()
+
 	keyRef := data.Get(keyRefParam).(string)
 	if len(keyRef) == 0 {
 		return logical.ErrorResponse("missing key reference"), nil

--- a/builtin/logical/pki/path_fetch_keys.go
+++ b/builtin/logical/pki/path_fetch_keys.go
@@ -32,6 +32,10 @@ their identifier and their name (if set).`
 )
 
 func (b *backend) pathListKeysHandler(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Can not list keys until migration has completed"), nil
+	}
+
 	var responseKeys []string
 	responseInfo := make(map[string]interface{})
 
@@ -113,6 +117,10 @@ the certificate.
 )
 
 func (b *backend) pathGetKeyHandler(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Can not get keys until migration has completed"), nil
+	}
+
 	keyRef := data.Get(keyRefParam).(string)
 	if len(keyRef) == 0 {
 		return logical.ErrorResponse("missing key reference"), nil
@@ -145,6 +153,10 @@ func (b *backend) pathUpdateKeyHandler(ctx context.Context, req *logical.Request
 	// got a consistent view.
 	b.issuersLock.Lock()
 	defer b.issuersLock.Unlock()
+
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Can not update keys until migration has completed"), nil
+	}
 
 	keyRef := data.Get(keyRefParam).(string)
 	if len(keyRef) == 0 {
@@ -198,6 +210,10 @@ func (b *backend) pathDeleteKeyHandler(ctx context.Context, req *logical.Request
 	// got a consistent view.
 	b.issuersLock.Lock()
 	defer b.issuersLock.Unlock()
+
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Can not delete keys until migration has completed"), nil
+	}
 
 	keyRef := data.Get(keyRefParam).(string)
 	if len(keyRef) == 0 {

--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -45,6 +45,11 @@ appended to the bundle.`,
 }
 
 func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Since we're planning on updating issuers here, grab the lock so we've
+	// got a consistent view.
+	b.issuersLock.Lock()
+	defer b.issuersLock.Unlock()
+
 	var err error
 
 	if b.useLegacyBundleCaStorage() {

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -107,6 +107,11 @@ secret-key (optional) and certificates.`,
 }
 
 func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Since we're planning on updating issuers here, grab the lock so we've
+	// got a consistent view.
+	b.issuersLock.Lock()
+	defer b.issuersLock.Unlock()
+
 	keysAllowed := strings.HasSuffix(req.Path, "bundle") || req.Path == "config/ca"
 
 	if b.useLegacyBundleCaStorage() {

--- a/builtin/logical/pki/path_manage_keys.go
+++ b/builtin/logical/pki/path_manage_keys.go
@@ -49,6 +49,11 @@ const (
 )
 
 func (b *backend) pathGenerateKeyHandler(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Since we're planning on updating issuers here, grab the lock so we've
+	// got a consistent view.
+	b.issuersLock.Lock()
+	defer b.issuersLock.Unlock()
+
 	keyName, err := getKeyName(ctx, req.Storage, data)
 	if err != nil { // Fail Immediately if Key Name is in Use, etc...
 		return nil, err
@@ -144,6 +149,11 @@ If name is set, that will be set on the key.`
 )
 
 func (b *backend) pathImportKeyHandler(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Since we're planning on updating issuers here, grab the lock so we've
+	// got a consistent view.
+	b.issuersLock.Lock()
+	defer b.issuersLock.Unlock()
+
 	keyValueInterface, isOk := data.GetOk("pem_bundle")
 	if !isOk {
 		return logical.ErrorResponse("keyValue must be set"), nil

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -54,26 +54,28 @@ func (b *backend) pathCADeleteRoot(ctx context.Context, req *logical.Request, _ 
 	b.issuersLock.Lock()
 	defer b.issuersLock.Unlock()
 
-	issuers, err := listIssuers(ctx, req.Storage)
-	if err != nil {
-		return nil, err
-	}
-
-	keys, err := listKeys(ctx, req.Storage)
-	if err != nil {
-		return nil, err
-	}
-
-	// Delete all issuers and keys. Ignore deleting the default since we're
-	// explicitly deleting everything.
-	for _, issuer := range issuers {
-		if _, err = deleteIssuer(ctx, req.Storage, issuer); err != nil {
+	if !b.useLegacyBundleCaStorage() {
+		issuers, err := listIssuers(ctx, req.Storage)
+		if err != nil {
 			return nil, err
 		}
-	}
-	for _, key := range keys {
-		if _, err = deleteKey(ctx, req.Storage, key); err != nil {
+
+		keys, err := listKeys(ctx, req.Storage)
+		if err != nil {
 			return nil, err
+		}
+
+		// Delete all issuers and keys. Ignore deleting the default since we're
+		// explicitly deleting everything.
+		for _, issuer := range issuers {
+			if _, err = deleteIssuer(ctx, req.Storage, issuer); err != nil {
+				return nil, err
+			}
+		}
+		for _, key := range keys {
+			if _, err = deleteKey(ctx, req.Storage, key); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -49,6 +49,11 @@ func pathDeleteRoot(b *backend) *framework.Path {
 }
 
 func (b *backend) pathCADeleteRoot(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	// Since we're planning on updating issuers here, grab the lock so we've
+	// got a consistent view.
+	b.issuersLock.Lock()
+	defer b.issuersLock.Unlock()
+
 	issuers, err := listIssuers(ctx, req.Storage)
 	if err != nil {
 		return nil, err
@@ -85,6 +90,11 @@ func (b *backend) pathCADeleteRoot(ctx context.Context, req *logical.Request, _ 
 }
 
 func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Since we're planning on updating issuers here, grab the lock so we've
+	// got a consistent view.
+	b.issuersLock.Lock()
+	defer b.issuersLock.Unlock()
+
 	var err error
 
 	if b.useLegacyBundleCaStorage() {


### PR DESCRIPTION
We need a write lock around writes to ensure serialization of
modifications. We use a single lock for both issuer and key
updates, in part because certain operations (like deletion) will
potentially affect both.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

Also updated to make sure we grab the issuers lock. 