### PR TITLE
Upgrade CircleCI machine image (#15215)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,8 @@ jobs:
           make test-ui-browserstack
         name: Run Browserstack Tests
   build-go-dev:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     shell: /usr/bin/env bash -euo pipefail -c
     working_directory: /home/circleci/go/src/github.com/hashicorp/vault
     steps:
@@ -113,6 +114,7 @@ jobs:
           rm -f "go${GO_VERSION}.linux-amd64.tar.gz"
           GOPATH="/home/circleci/go"
           mkdir $GOPATH 2>/dev/null || { sudo mkdir $GOPATH && sudo chmod 777 $GOPATH; }
+          mkdir $GOPATH/bin 2>/dev/null || { sudo mkdir $GOPATH/bin && sudo chmod 777 $GOPATH/bin; }
           echo "export GOPATH='$GOPATH'" >> "$BASH_ENV"
           echo "export PATH='$PATH:$GOPATH/bin:/usr/local/go/bin'" >> "$BASH_ENV"
           echo "export GOPROXY=off" >> "$BASH_ENV"
@@ -757,7 +759,8 @@ jobs:
     - CIRCLECI_CLI_VERSION: 0.1.5546
     - GO_TAGS: ''
   pre-flight-checks:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     shell: /usr/bin/env bash -euo pipefail -c
     working_directory: /home/circleci/go/src/github.com/hashicorp/vault
     steps:
@@ -771,6 +774,7 @@ jobs:
           rm -f "go${GO_VERSION}.linux-amd64.tar.gz"
           GOPATH="/home/circleci/go"
           mkdir $GOPATH 2>/dev/null || { sudo mkdir $GOPATH && sudo chmod 777 $GOPATH; }
+          mkdir $GOPATH/bin 2>/dev/null || { sudo mkdir $GOPATH/bin && sudo chmod 777 $GOPATH/bin; }
           echo "export GOPATH='$GOPATH'" >> "$BASH_ENV"
           echo "export PATH='$PATH:$GOPATH/bin:/usr/local/go/bin'" >> "$BASH_ENV"
           echo "export GOPROXY=https://proxy.golang.org,direct" >> "$BASH_ENV"
@@ -801,7 +805,11 @@ jobs:
           BASE: https://github.com/CircleCI-Public/circleci-cli/releases/download
         name: Install CircleCI CLI
     - run:
-        command: make ci-verify
+        command: |
+          set -x
+          . $BASH_ENV
+          make ci-verify
+        name: Verify CircleCI
     - add_ssh_keys:
         fingerprints:
         - 0e:03:77:f4:e2:c3:56:c2:53:6a:03:e1:31:91:2f:06

--- a/.circleci/config/commands/setup-go.yml
+++ b/.circleci/config/commands/setup-go.yml
@@ -24,6 +24,7 @@ steps:
         rm -f "go${GO_VERSION}.linux-amd64.tar.gz"
         GOPATH="/home/circleci/go"
         mkdir $GOPATH 2>/dev/null || { sudo mkdir $GOPATH && sudo chmod 777 $GOPATH; }
+        mkdir $GOPATH/bin 2>/dev/null || { sudo mkdir $GOPATH/bin && sudo chmod 777 $GOPATH/bin; }
         echo "export GOPATH='$GOPATH'" >> "$BASH_ENV"
         echo "export PATH='$PATH:$GOPATH/bin:/usr/local/go/bin'" >> "$BASH_ENV"
         echo "export GOPROXY=<<parameters.GOPROXY>>" >> "$BASH_ENV"

--- a/.circleci/config/executors/@executors.yml
+++ b/.circleci/config/executors/@executors.yml
@@ -1,5 +1,6 @@
 go-machine:
-  machine: true
+  machine:
+    image: ubuntu-2004:202201-02
   shell: /usr/bin/env bash -euo pipefail -c
   environment:
     CIRCLECI_CLI_VERSION: 0.1.5546  # Pin CircleCI CLI to patch version (ex: 1.2.3)

--- a/.circleci/config/jobs/pre-flight-checks.yml
+++ b/.circleci/config/jobs/pre-flight-checks.yml
@@ -24,6 +24,11 @@ steps:
         . $BASH_ENV
         which circleci
         circleci version
-  - run: make ci-verify
+  - run:
+      name: Verify CircleCI
+      command: |
+        set -x
+        . $BASH_ENV
+        make ci-verify
   - configure-git
   - refresh_go_mod_cache


### PR DESCRIPTION
* Upgrade CircleCI machine image

* setting the path for ci-verify

* create GOPATH/bin
This is because CI failed with
cp: cannot create regular file '/home/circleci/go/bin/': Not a directory

* Update .circleci/config/jobs/pre-flight-checks.yml

Co-authored-by: Tom Proctor <tomhjp@users.noreply.github.com>

* updating config.yml

* source BASH_ENV

Co-authored-by: Tom Proctor <tomhjp@users.noreply.github.com>