### PR TITLE
Backport 1.10.x: docs: update agent sections around auto-auth, caching, and templating…

### DIFF
--- a/website/content/docs/agent/autoauth/index.mdx
+++ b/website/content/docs/agent/autoauth/index.mdx
@@ -139,8 +139,10 @@ These are common configuration values that live within the `method` block:
   like `5m`.
 
 - `max_backoff` `(string or integer: "5m")` - The maximum time Agent will delay
-  before retrying after a failed auth attempt. The backoff will start at 1 second
-  and double (with some randomness) after successive failures, capped by `max_backoff.`
+  before retrying after a failed auth attempt. The backoff will start at
+  1 second and double (with some randomness) after successive failures,
+  capped by `max_backoff.` `max_backoff` is the duration between retries, and
+  **not** the duration that retries will be performed before giving up.
 
 - `config` `(object: required)` - Configuration of the method itself. See the
   sidebar for information about each method.
@@ -183,3 +185,29 @@ These configuration values are common to all Sinks:
 
 - `config` `(object: required)` - Configuration of the sink itself. See the
   sidebar for information about each sink.
+
+### Auto Auth Example
+
+```hcl
+# Other Vault Agent configuration blocks
+# ...
+
+auto_auth {
+  method {
+    type = "approle"
+
+    config = {
+      role_id_file_path = "/etc/vault/roleid"
+      secret_id_file_path = "/etc/vault/secretid"
+    }
+  }
+
+  sink {
+    type = "file"
+
+    config = {
+      path = "/tmp/file-foo"
+    }
+  }
+}
+```

--- a/website/content/docs/agent/autoauth/methods/approle.mdx
+++ b/website/content/docs/agent/autoauth/methods/approle.mdx
@@ -23,7 +23,7 @@ cached.
 - `secret_id_file_path` `(string: optional)` - The path to the file with secret
   ID.
   If not set, only the `role-id` will be used.
-  In that case, the AppRole should have `bind_secret_id` set to `false` otherwise 
+  In that case, the AppRole should have `bind_secret_id` set to `false` otherwise
   Vault Agent wouldn't be able to login.
 
 - `remove_secret_id_file_after_reading` `(bool: optional, defaults to true)` -
@@ -39,10 +39,10 @@ cached.
 
 ## Example Configuration
 
-An example configuration, using approle to enable [auto-auth](/docs/agent/autoauth) 
+An example configuration, using approle to enable [auto-auth](/docs/agent/autoauth)
 and creating both a plaintext token sink and a [response-wrapped token sink file](/docs/agent/autoauth#wrap_ttl), follows:
 
-```python
+```hcl
 pid_file = "./pidfile"
 
 vault {

--- a/website/content/docs/agent/caching/index.mdx
+++ b/website/content/docs/agent/caching/index.mdx
@@ -58,27 +58,12 @@ existing Vault token in the request and instead uses the auto-auth token.
 
 ## Persistent Cache
 
-Vault Agent can restore tokens and leases from a persistent cache file created by a previous
-Vault Agent process. The persistent cache is a BoltDB file that includes tuples encrypted
-by a generated encryption key. The encrypted tuples include the Vault token used to retrieve
-secrets, leases for tokens/secrets, and secret values.
+Vault Agent can restore tokens and leases from a persistent cache file created
+by a previous Vault Agent process.
 
--> **Note:** Vault Agent Caching persistent cache will only restore _leased_ secrets. Secrets
-that are not renewable, such as KV v2, will not be persisted.
-
-In order to use Vault Agent persistent cache, auto-auth must be used. During the restoration
-of the cache, Vault Agent will pre-populate auto-auth with the persisted token. This token
-is required to renew restored leases. If the token has expired, the cached leases will be evicted and
-secrets will need to be retrieved from Vault.
-
-If Vault Agent templating is enabled alongside of the persistent cache, Vault Agent will automatically
-route templating requests through the cache. This ensures template requests are cached and restored properly.
-
-At the time of this writing, Vault Agent persistent cache is only supported in a Kubernetes
-environment. In the future the persistent cache will be expanded to include other environments.
-
-For more information about the Vault Agent persistent cache, see the sidebar for specific persistent
-cache types.
+Refer to the [Vault Agent Persistent
+Caching](/docs/agent/caching/persistent-caches) page for more information on
+this functionality.
 
 ## Cache Evictions
 
@@ -264,78 +249,14 @@ options.
 
 ### Example Configuration
 
-An example configuration, with very contrived values, follows:
+Here is an example of a cache configuration.
 
-```javascript
-auto_auth {
-  method {
-    type = "aws"
-    wrap_ttl = 300
-    config = {
-      role = "foobar"
-    }
-  }
-
-  sink {
-    type = "file"
-    config = {
-      path = "/tmp/file-foo"
-    }
-  }
-}
+```hcl
+# Other Vault Agent configuration blocks
+# ...
 
 cache {
   use_auto_auth_token = true
-}
-
-listener "unix" {
-  address = "/path/to/socket"
-  tls_disable = true
-}
-
-listener "tcp" {
-  address = "127.0.0.1:8200"
-  tls_disable = true
-}
-
-vault {
-  address = "http://127.0.0.1:8200"
-}
-```
-
-### Persistent Cache Example Configuration
-
-An example configuration, with very contrived values, follows:
-
-```javascript
-auto_auth {
-  method "kubernetes" {
-    config = {
-      role = "foobar"
-    }
-  }
-
-  sink "file" {
-    config = {
-      path = "/tmp/file-foo"
-    }
-  }
-}
-
-cache {
-  use_auto_auth_token = true
-  persist "kubernetes" {
-    path = "/vault/agent-cache"
-  }
-}
-
-listener "tcp" {
-  address = "127.0.0.1:8200"
-  tls_disable = true
-}
-
-vault {
-  address = "http://127.0.0.1:8200"
 }
 ```
 

--- a/website/content/docs/agent/caching/persistent-caches/index.mdx
+++ b/website/content/docs/agent/caching/persistent-caches/index.mdx
@@ -1,9 +1,47 @@
 ---
 layout: docs
-page_title: Vault Agent Persistent Cache Types
-description: Persistent Cache Types for Vault Agent Caching
+page_title: Vault Agent Persistent Caching
+description: Vault Agent Caching
 ---
 
-# Vault Agent Persistent Cache Types
+# Vault Agent Persistent Caching
+
+Vault Agent can restore tokens and leases from a persistent cache file created
+by a previous Vault Agent process. The persistent cache is a BoltDB file that
+includes tuples encrypted by a generated encryption key. The encrypted tuples
+include the Vault token used to retrieve secrets, leases for tokens/secrets, and
+secret values.
+
+-> **Note:** Vault Agent Persistent Caching will only restore _leased_
+secrets. Secrets that are not renewable, such as KV v2, will not be persisted.
+
+In order to use Vault Agent persistent cache, auto-auth must be used. If the
+auto-auth token has expired by the time the cache is restored, the cache will
+be invalidated and secrets will need to be re-fetched from Vault.
+
+If Vault Agent templating is enabled alongside of the persistent cache, Vault
+Agent will automatically route templating requests through the cache. This
+ensures template requests are cached and restored properly.
+
+-> **Note** Vault Agent persistent cache is currently supported only in a
+Kubernetes environment.
+
+## Vault Agent Persistent Cache Types
 
 Please see the sidebar for available types and their usage/configuration.
+
+## Persistent Cache Example Configuration
+
+Here is an example of a persistent cache configuration.
+
+```hcl
+# Other Vault Agent configuration blocks
+# ...
+
+cache {
+  use_auto_auth_token = true
+  persist "kubernetes" {
+    path = "/vault/agent-cache"
+  }
+}
+```

--- a/website/content/docs/agent/index.mdx
+++ b/website/content/docs/agent/index.mdx
@@ -289,7 +289,7 @@ Configuration](#example-configuration) section for an example configuration.)
 
 An example configuration, with very contrived values, follows:
 
-```python
+```hcl
 pid_file = "./pidfile"
 
 vault {
@@ -332,6 +332,10 @@ cache {
 listener "unix" {
   address = "/path/to/socket"
   tls_disable = true
+
+  agent_api {
+    enable_quit = true
+  }
 }
 
 listener "tcp" {

--- a/website/content/docs/agent/template.mdx
+++ b/website/content/docs/agent/template.mdx
@@ -9,7 +9,7 @@ description: >-
 # Vault Agent Templates
 
 Vault Agent's Template functionality allows Vault secrets to be rendered to files
-using [Consul Template markup](https://github.com/hashicorp/consul-template/blob/v0.27.1/docs/templating-language.md).
+using [Consul Template markup][consul-templating-language].
 
 ## Functionality
 
@@ -32,14 +32,18 @@ for a short while (including some randomness to help prevent thundering herd
 scenarios) and retry. On success, secrets defined in the templates will be
 retrieved from Vault and rendered locally.
 
-## Templating Language Resources
+## Templating Language
+
+The template output content can be provided directly as part of the `contents`
+option in a `template` stanza or as a separate `.ctmpl` file and specified in
+the `source` option of a `template` stanza.
 
 The following links contain additional resources for the templating language used by Vault Agent templating.
 
-- [Consul Templating Documentation](https://github.com/hashicorp/consul-template/blob/v0.27.1/docs/templating-language.md)
+- [Consul Templating Documentation][consul-templating-language]
 - [Go Templating Language Documentation](https://pkg.go.dev/text/template#pkg-overview)
 
-## Example Template
+### Template Language Example
 
 Template with Vault Agent requires the use of the `secret` [function from Consul
 Template](https://github.com/hashicorp/consul-template/blob/master/docs/templating-language.md#secret).
@@ -54,7 +58,7 @@ KV store:
 
 ## Global Configurations
 
-The top level `template_config` block has the following configuration entries that affect 
+The top level `template_config` block has the following configuration entries that affect
 all templates:
 
 - `exit_on_retry_failure` `(bool: false)` - This option configures Vault Agent
@@ -66,9 +70,9 @@ failures.
   This setting will not change how often Vault Agent Templating renders leased
   secrets.
 
-### Example
+### `template_config` Stanza Example
 
-```python
+```hcl
 template_config {
   exit_on_retry_failure = true
   static_secret_render_interval = "10m"
@@ -99,7 +103,11 @@ value of `exit_on_retry_failure`.
 
 ## Template Configurations
 
-The top level `template` block has multiple configurations entries:
+The top level `template` block has multiple configuration entries. The
+parameters found in the template configuration section in the consul-template
+[documentation
+page](https://github.com/hashicorp/consul-template/blob/main/docs/configuration.md#templates)
+can be used here:
 
 - `source` `(string: "")` - Path on disk to use as the input template. This
   option is required if not using the `contents` option.
@@ -116,12 +124,18 @@ The top level `template` block has multiple configurations entries:
   template is rendered. The command will only run if the resulting template changes.
   The command must return within 30s (configurable), and it must have a successful
   exit code. Vault Agent is not a replacement for a process monitor or init system.
+  This is deprecated in favor of the `exec` option.
 - `command_timeout` `(duration: 30s)` - This is the maximum amount of time to
-  wait for the optional command to return.
+  wait for the optional command to return. This is deprecated in favor of the
+  `exec` option.
 - `error_on_missing_key` `(bool: false)` - Exit with an error when accessing
   a struct or map field/key that does notexist. The default behavior will print `<no value>`
   when accessing a field that does not exist. It is highly recommended you set this
   to "true".
+- `exec` `(object: optional)` - The exec block executes a command when the
+  template is rendered and the output has changed. The block parameters are
+  `command` `(string slice: required)` and `timeout` `(string: optional, defaults
+  to 30s)`.
 - `perms` `(string: "")` - This is the permission to render the file. If
   this option is left unspecified, Vault Agent will attempt to match the permissions
   of the file that already exists at the destination path. If no file exists at that
@@ -143,9 +157,9 @@ The top level `template` block has multiple configurations entries:
   a new template to disk and triggering a command, separated by a colon (`:`).
 
 
-### Example
+### Example `template` Stanza
 
-```python
+```hcl
 template {
   source      = "/tmp/agent/template.ctmpl"
   destination = "/tmp/agent/render.txt"
@@ -194,36 +208,18 @@ using the certificates `validTo` field.
 This does not apply to certificates generated with `generate_lease: true`. If set
 Vault Agent template will apply the non-renewable, leased secret rules.
 
-## Auto Auth and Templating Example
+-> **Note** When Agent's auto-auth re-authenticates, due to a token expiry for
+example, it generates a new token for Agent's use. This triggers a template
+server restart, which fetches and re-renders a new set of certificates even if
+existing certificates are valid.
 
-The following demonstrates configuring Vault Agent to template secrets using the
-AppRole Auth method:
+## Templating Configuration Example
 
-```python
-pid_file = "./pidfile"
+The following demonstrates Vault Agent Templates configuration blocks.
 
-vault {
-  address = "https://127.0.0.1:8200"
-}
-
-auto_auth {
-  method {
-    type = "approle"
-
-    config = {
-      role_id_file_path = "/etc/vault/roleid"
-      secret_id_file_path = "/etc/vault/secretid"
-    }
-  }
-
-  sink {
-    type = "file"
-
-    config = {
-      path = "/tmp/file-foo"
-    }
-  }
-}
+```hcl
+# Other Vault Agent configuration blocks
+# ...
 
 template_config {
   static_secret_render_interval = "10m"
@@ -234,4 +230,11 @@ template {
   source      = "/tmp/agent/template.ctmpl"
   destination = "/tmp/agent/render.txt"
 }
+
+template {
+  contents     = "{{ with secret \"secret/my-secret\" }}{{ .Data.data.foo }}{{ end }}"
+  destination  = "/tmp/agent/render-content.txt"
+}
 ```
+
+[consul-templating-language]: https://github.com/hashicorp/consul-template/blob/v0.28.1/docs/templating-language.md


### PR DESCRIPTION
… (#15195)

Manual backport of #15195, minus the mention of the `min_backoff` parameter.
Closes #15239