### PR TITLE
Add unauthed JSON fetching of CRLs, Issuers

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -77,6 +77,13 @@ func Backend(conf *logical.BackendConfig) *backend {
 				"ca",
 				"crl/pem",
 				"crl",
+				"issuer/+/crl/der",
+				"issuer/+/crl/pem",
+				"issuer/+/crl",
+				"issuer/+/pem",
+				"issuer/+/der",
+				"issuer/+/json",
+				"issuers",
 			},
 
 			LocalStorage: []string{

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -4034,7 +4034,7 @@ func getParsedCrl(t *testing.T, client *api.Client, mountPoint string) *pkix.Cer
 }
 
 func getParsedCrlForIssuer(t *testing.T, client *api.Client, mountPoint string, issuer string) *pkix.CertificateList {
-	path := fmt.Sprintf("/v1/%v/issuer/%v/crl", mountPoint, issuer)
+	path := fmt.Sprintf("/v1/%v/issuer/%v/crl/der", mountPoint, issuer)
 	crl := getParsedCrlAtPath(t, client, path)
 
 	// Now fetch the issuer as well and verify the certificate

--- a/builtin/logical/pki/ca_test.go
+++ b/builtin/logical/pki/ca_test.go
@@ -290,23 +290,29 @@ func runSteps(t *testing.T, rootB, intB *backend, client *api.Client, rootName, 
 		prevToken := client.Token()
 		client.SetToken("")
 
-		// cert/ca path
-		{
-			resp, err := client.Logical().Read(rootName + "cert/ca")
+		// cert/ca and issuer/default/json path
+		for _, path := range []string{"cert/ca", "issuer/default/json"} {
+			resp, err := client.Logical().Read(rootName + path)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if resp == nil {
 				t.Fatal("nil response")
 			}
-			if diff := deep.Equal(resp.Data["certificate"].(string), caCert); diff != nil {
+			expected := caCert
+			if path == "issuer/default/json" {
+				// Preserves the new line.
+				expected += "\n"
+			}
+			if diff := deep.Equal(resp.Data["certificate"].(string), expected); diff != nil {
 				t.Fatal(diff)
 			}
 		}
-		// ca/pem path (raw string)
-		{
+
+		// ca/pem and issuer/default/pem path (raw string)
+		for _, path := range []string{"ca/pem", "issuer/default/pem"} {
 			req := &logical.Request{
-				Path:      "ca/pem",
+				Path:      path,
 				Operation: logical.ReadOperation,
 				Storage:   rootB.storage,
 			}
@@ -317,7 +323,12 @@ func runSteps(t *testing.T, rootB, intB *backend, client *api.Client, rootName, 
 			if resp == nil {
 				t.Fatal("nil response")
 			}
-			if diff := deep.Equal(resp.Data["http_raw_body"].([]byte), []byte(caCert)); diff != nil {
+			expected := []byte(caCert)
+			if path == "issuer/default/pem" {
+				// Preserves the new line.
+				expected = []byte(caCert + "\n")
+			}
+			if diff := deep.Equal(resp.Data["http_raw_body"].([]byte), expected); diff != nil {
 				t.Fatal(diff)
 			}
 			if resp.Data["http_content_type"].(string) != "application/pem-certificate-chain" {
@@ -325,10 +336,10 @@ func runSteps(t *testing.T, rootB, intB *backend, client *api.Client, rootName, 
 			}
 		}
 
-		// ca (raw DER bytes)
-		{
+		// ca and issuer/default/der (raw DER bytes)
+		for _, path := range []string{"ca", "issuer/default/der"} {
 			req := &logical.Request{
-				Path:      "ca",
+				Path:      path,
 				Operation: logical.ReadOperation,
 				Storage:   rootB.storage,
 			}
@@ -521,9 +532,16 @@ func runSteps(t *testing.T, rootB, intB *backend, client *api.Client, rootName, 
 		}
 
 		// Fetch the CRL and make sure it shows up
-		{
+		for path, derPemOrJSON := range map[string]int{
+			"crl":                    0,
+			"issuer/default/crl/der": 0,
+			"crl/pem":                1,
+			"issuer/default/crl/pem": 1,
+			"cert/crl":               2,
+			"issuer/default/crl":     3,
+		} {
 			req := &logical.Request{
-				Path:      "crl",
+				Path:      path,
 				Operation: logical.ReadOperation,
 				Storage:   rootB.storage,
 			}
@@ -534,7 +552,25 @@ func runSteps(t *testing.T, rootB, intB *backend, client *api.Client, rootName, 
 			if resp == nil {
 				t.Fatal("nil response")
 			}
-			crlBytes := resp.Data["http_raw_body"].([]byte)
+
+			var crlBytes []byte
+			if derPemOrJSON == 2 {
+				// Old endpoint
+				crlBytes = []byte(resp.Data["certificate"].(string))
+			} else if derPemOrJSON == 3 {
+				// New endpoint
+				crlBytes = []byte(resp.Data["crl"].(string))
+			} else {
+				// DER or PEM
+				crlBytes = resp.Data["http_raw_body"].([]byte)
+			}
+
+			if derPemOrJSON >= 1 {
+				// Do for both PEM and JSON endpoints
+				pemBlock, _ := pem.Decode(crlBytes)
+				crlBytes = pemBlock.Bytes
+			}
+
 			certList, err := x509.ParseCRL(crlBytes)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
We make the `GET /issuer/:issuer_ref/crl` endpoint return the JSON-wrapped CRL now, with `/pem` and `/der` being required suffixes for "bare" fetches.

We similarly add a `GET /issuer/:issuer_ref/json` endpoint for the JSON-wrapped issuer certificate _without_ the extra data of `GET /issuer/:issuer_ref` (chain information, &c).

Lastly, we make the various fetch endpoints unauthenticated, allowing arbitrary systems to list, fetch the issuer's certs and corresponding CRLs.

Since this is a new endpoint, I figured it was time to put the CRL in a field named `crl` rather than `certificate`. :-) 