### PR TITLE
Fix deletion of issuers, CRLs

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -81,7 +81,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 
 			LocalStorage: []string{
 				"revoked/",
-				"crl",
+				legacyCRLPath,
 				"crls/",
 				"certs/",
 			},

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -171,7 +171,7 @@ func fetchCertBySerial(ctx context.Context, b *backend, req *logical.Request, pr
 	case strings.HasPrefix(prefix, "revoked/"):
 		legacyPath = "revoked/" + colonSerial
 		path = "revoked/" + hyphenSerial
-	case serial == "crl":
+	case serial == legacyCRLPath:
 		if err = b.crlBuilder.rebuildIfForced(ctx, b, req); err != nil {
 			return nil, err
 		}

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -179,14 +179,14 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 			contentType = "application/pkix-cert"
 		}
 	case req.Path == "crl" || req.Path == "crl/pem":
-		serial = "crl"
+		serial = legacyCRLPath
 		contentType = "application/pkix-crl"
 		if req.Path == "crl/pem" {
 			pemType = "X509 CRL"
 			contentType = "application/x-pem-file"
 		}
 	case req.Path == "cert/crl":
-		serial = "crl"
+		serial = legacyCRLPath
 		pemType = "X509 CRL"
 	case strings.HasSuffix(req.Path, "/pem") || strings.HasSuffix(req.Path, "/raw"):
 		serial = data.Get("serial").(string)

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -79,8 +79,13 @@ func (b *backend) pathCADeleteRoot(ctx context.Context, req *logical.Request, _ 
 		}
 	}
 
-	// Delete legacy CA bundle; but don't error if it doesn't exist.
+	// Delete legacy CA bundle.
 	if err := req.Storage.Delete(ctx, legacyCertBundlePath); err != nil {
+		return nil, err
+	}
+
+	// Delete legacy CRL bundle.
+	if err := req.Storage.Delete(ctx, legacyCRLPath); err != nil {
 		return nil, err
 	}
 

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -23,6 +23,7 @@ const (
 
 	legacyMigrationBundleLogKey = "config/legacyMigrationBundleLog"
 	legacyCertBundlePath        = "config/ca_bundle"
+	legacyCRLPath               = "crl"
 )
 
 type keyID string
@@ -650,19 +651,19 @@ func resolveIssuerCRLPath(ctx context.Context, b *backend, s logical.Storage, re
 
 	issuer, err := resolveIssuerReference(ctx, s, reference)
 	if err != nil {
-		return "crl", err
+		return legacyCRLPath, err
 	}
 
 	crlConfig, err := getLocalCRLConfig(ctx, s)
 	if err != nil {
-		return "crl", err
+		return legacyCRLPath, err
 	}
 
 	if crlId, ok := crlConfig.IssuerIDCRLMap[issuer]; ok && len(crlId) > 0 {
 		return fmt.Sprintf("crls/%v", crlId), nil
 	}
 
-	return "crl", fmt.Errorf("unable to find CRL for issuer: id:%v/ref:%v", issuer, reference)
+	return legacyCRLPath, fmt.Errorf("unable to find CRL for issuer: id:%v/ref:%v", issuer, reference)
 }
 
 // Builds a certutil.CertBundle from the specified issuer identifier,


### PR DESCRIPTION
Apparently I had this branch sitting around but haven't proposed it yet? :-D 

We:

 - Delete the legacy CRL entry when we call `DELETE /root`.
 - When deleting an issuer, remove its corresponding CRL entry on next rebuild. This means CRLs will persist (on disk) until next CRL rebuild, even if all issuers using that CRL have been removed. I think this is fine. 
 - Fix bug where chain is incorrect after deletion. :-) Oops. 