### PR TITLE
Add issuer usage restrictions

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2660,7 +2660,7 @@ func TestBackend_SignSelfIssued(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signingBundle, err := fetchCAInfo(context.Background(), b, &logical.Request{Storage: storage}, defaultRef)
+	signingBundle, err := fetchCAInfo(context.Background(), b, &logical.Request{Storage: storage}, defaultRef, ReadOnlyUsage)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -80,7 +80,7 @@ func getFormat(data *framework.FieldData) string {
 }
 
 // fetchCAInfo will fetch the CA info, will return an error if no ca info exists.
-func fetchCAInfo(ctx context.Context, b *backend, req *logical.Request, issuerRef string) (*certutil.CAInfoBundle, error) {
+func fetchCAInfo(ctx context.Context, b *backend, req *logical.Request, issuerRef string, usage issuerUsage) (*certutil.CAInfoBundle, error) {
 	entry, bundle, err := fetchCertBundle(ctx, b, req.Storage, issuerRef)
 	if err != nil {
 		switch err.(type) {
@@ -91,6 +91,10 @@ func fetchCAInfo(ctx context.Context, b *backend, req *logical.Request, issuerRe
 		default:
 			return nil, errutil.InternalError{Err: fmt.Sprintf("error fetching CA info: %v", err)}
 		}
+	}
+
+	if err := entry.EnsureUsage(usage); err != nil {
+		return nil, errutil.InternalError{Err: fmt.Sprintf("error while attempting to use issuer %v: %v", issuerRef, err)}
 	}
 
 	if bundle == nil {

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -206,7 +206,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 
 	// Prefer fetchCAInfo to fetchCertBySerial for CA certificates.
 	if serial == "ca_chain" || serial == "ca" {
-		caInfo, err := fetchCAInfo(ctx, b, req, defaultRef)
+		caInfo, err := fetchCAInfo(ctx, b, req, defaultRef, ReadOnlyUsage)
 		if err != nil {
 			switch err.(type) {
 			case errutil.UserError:

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -262,7 +262,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 	}
 
 	var caErr error
-	signingBundle, caErr := fetchCAInfo(ctx, b, req, issuerName)
+	signingBundle, caErr := fetchCAInfo(ctx, b, req, issuerName, IssuanceUsage)
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -276,7 +276,7 @@ func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.R
 	}
 
 	var caErr error
-	signingBundle, caErr := fetchCAInfo(ctx, b, req, issuerName)
+	signingBundle, caErr := fetchCAInfo(ctx, b, req, issuerName, IssuanceUsage)
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:
@@ -417,7 +417,7 @@ func (b *backend) pathIssuerSignSelfIssued(ctx context.Context, req *logical.Req
 	}
 
 	var caErr error
-	signingBundle, caErr := fetchCAInfo(ctx, b, req, issuerName)
+	signingBundle, caErr := fetchCAInfo(ctx, b, req, issuerName, IssuanceUsage)
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -13,7 +13,10 @@ import (
 // This allows us to record the version of the migration code within the log entry
 // in case we find out in the future that something was horribly wrong with the migration,
 // and we need to perform it again...
-const latestMigrationVersion = 1
+const (
+	latestMigrationVersion = 1
+	legacyBundleShimID     = issuerID("legacy-entry-shim-id")
+)
 
 type legacyBundleMigrationLog struct {
 	Hash             string    `json:"hash" structs:"hash" mapstructure:"hash"`
@@ -173,8 +176,11 @@ func getLegacyCertBundle(ctx context.Context, s logical.Storage) (*issuerEntry, 
 	// Fake a storage entry with backwards compatibility in mind. We only need
 	// the fields in the CAInfoBundle; everything else doesn't matter.
 	issuer := &issuerEntry{
+		ID:                   legacyBundleShimID,
+		Name:                 "legacy-entry-shim",
 		LeafNotAfterBehavior: certutil.ErrNotAfterBehavior,
 	}
+	issuer.Usage.ToggleUsage(IssuanceUsage, CRLSigningUsage)
 
 	return issuer, cb, nil
 }


### PR DESCRIPTION
~Built on top of #15254; will be rebased when that merges.~

This handles adding usage restrictions to issuers, limiting if they can be used for signing certs and CRLs (separately). 

We updated the legacy bundle shim (showing it can be used for both), the issuer update/fetch paths, and mostly enforce the constraint in `fetchCAInfo`. When fetching a cert (not for signing certs or CRLs), we use `false, false` as arguments.

I'm wondering if we want to make this an actual usage vector set? Or if separate flags are better? Seems like its all just about the same amount of work, minus the arguments to `fetchCAInfo`, which is an internal function. 