### PR TITLE
Address PKI to properly support managed keys

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -165,6 +165,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 	b.tidyCASGuard = new(uint32)
 	b.tidyStatus = &tidyStatus{state: tidyStatusInactive}
 	b.storage = conf.StorageView
+	b.backendUuid = conf.BackendUUID
 
 	b.pkiStorageVersion.Store(0)
 
@@ -175,6 +176,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 type backend struct {
 	*framework.Backend
 
+	backendUuid       string
 	storage           logical.Storage
 	crlLifetime       time.Duration
 	revokeStorageLock sync.RWMutex

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -131,10 +131,11 @@ func TestBackend_CRL_EnableDisable(t *testing.T) {
 func TestBackend_Secondary_CRL_Rebuilding(t *testing.T) {
 	ctx := context.Background()
 	b, s := createBackendWithStorage(t)
+	mkc := newManagedKeyContext(ctx, b, "test")
 
 	// Write out the issuer/key to storage without going through the api call as replication would.
 	bundle := genCertBundle(t, b, s)
-	issuer, _, err := writeCaBundle(ctx, s, bundle, "", "")
+	issuer, _, err := writeCaBundle(mkc, s, bundle, "", "")
 	require.NoError(t, err)
 
 	// Just to validate, before we call the invalidate function, make sure our CRL has not been generated

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -8,6 +8,7 @@ const (
 	keyRefParam    = "key_ref"
 	keyIdParam     = "key_id"
 	keyTypeParam   = "key_type"
+	keyBitsParam   = "key_bits"
 )
 
 // addIssueAndSignCommonFields adds fields common to both CA and non-CA issuing

--- a/builtin/logical/pki/key_util.go
+++ b/builtin/logical/pki/key_util.go
@@ -1,0 +1,116 @@
+package pki
+
+import (
+	"context"
+	"crypto"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"github.com/hashicorp/vault/sdk/helper/certutil"
+	"github.com/hashicorp/vault/sdk/helper/errutil"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+type managedKeyContext struct {
+	ctx        context.Context
+	b          *backend
+	mountPoint string
+}
+
+func newManagedKeyContext(ctx context.Context, b *backend, mountPoint string) managedKeyContext {
+	return managedKeyContext{
+		ctx:        ctx,
+		b:          b,
+		mountPoint: mountPoint,
+	}
+}
+
+func comparePublicKey(ctx managedKeyContext, key *keyEntry, publicKey crypto.PublicKey) (bool, error) {
+	publicKeyForKeyEntry, err := getPublicKey(ctx, key)
+	if err != nil {
+		return false, err
+	}
+
+	return certutil.ComparePublicKeysAndType(publicKeyForKeyEntry, publicKey)
+}
+
+func getPublicKey(mkc managedKeyContext, key *keyEntry) (crypto.PublicKey, error) {
+	if key.PrivateKeyType == certutil.ManagedPrivateKey {
+		keyId, err := extractManagedKeyId([]byte(key.PrivateKey))
+		if err != nil {
+			return nil, err
+		}
+		return getManagedKeyPublicKey(mkc, keyId)
+	}
+
+	signer, _, _, err := getSignerFromKeyEntryBytes(key)
+	if err != nil {
+		return nil, err
+	}
+	return signer.Public(), nil
+}
+
+func getSignerFromKeyEntryBytes(key *keyEntry) (crypto.Signer, certutil.BlockType, *pem.Block, error) {
+	if key.PrivateKeyType == certutil.UnknownPrivateKey {
+		return nil, certutil.UnknownBlock, nil, errutil.InternalError{Err: fmt.Sprintf("unsupported unknown private key type for key: %s (%s)", key.ID, key.Name)}
+	}
+
+	if key.PrivateKeyType == certutil.ManagedPrivateKey {
+		return nil, certutil.UnknownBlock, nil, errutil.InternalError{Err: fmt.Sprintf("can not get a signer from a managed key: %s (%s)", key.ID, key.Name)}
+	}
+
+	bytes, blockType, blk, err := getSignerFromBytes([]byte(key.PrivateKey))
+	if err != nil {
+		return nil, certutil.UnknownBlock, nil, errutil.InternalError{Err: fmt.Sprintf("failed parsing key entry bytes for key id: %s (%s): %s", key.ID, key.Name, err.Error())}
+	}
+
+	return bytes, blockType, blk, nil
+}
+
+func getSignerFromBytes(keyBytes []byte) (crypto.Signer, certutil.BlockType, *pem.Block, error) {
+	pemBlock, _ := pem.Decode(keyBytes)
+	if pemBlock == nil {
+		return nil, certutil.UnknownBlock, pemBlock, errutil.InternalError{Err: "no data found in PEM block"}
+	}
+
+	signer, blk, err := certutil.ParseDERKey(pemBlock.Bytes)
+	if err != nil {
+		return nil, certutil.UnknownBlock, pemBlock, errutil.InternalError{Err: fmt.Sprintf("failed to parse PEM block: %s", err.Error())}
+	}
+	return signer, blk, pemBlock, nil
+}
+
+func getManagedKeyPublicKey(mkc managedKeyContext, keyId managedKeyId) (crypto.PublicKey, error) {
+	// Determine key type and key bits from the managed public key
+	var pubKey crypto.PublicKey
+	err := withManagedPKIKey(mkc.ctx, mkc.b, keyId, mkc.mountPoint, func(ctx context.Context, key logical.ManagedSigningKey) error {
+		var myErr error
+		pubKey, myErr = key.GetPublicKey(ctx)
+		if myErr != nil {
+			return myErr
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, errors.New("failed to lookup public key from managed key: " + err.Error())
+	}
+	return pubKey, nil
+}
+
+func importKeyFromBytes(mkc managedKeyContext, s logical.Storage, keyValue string, keyName string) (*keyEntry, bool, error) {
+	signer, _, _, err := getSignerFromBytes([]byte(keyValue))
+	if err != nil {
+		return nil, false, err
+	}
+	privateKeyType := certutil.GetPrivateKeyTypeFromSigner(signer)
+	if privateKeyType == certutil.UnknownPrivateKey {
+		return nil, false, errors.New("unsupported private key type within pem bundle")
+	}
+
+	key, existed, err := importKey(mkc, s, keyValue, keyName, privateKeyType)
+	if err != nil {
+		return nil, false, err
+	}
+	return key, existed, nil
+}

--- a/builtin/logical/pki/key_util.go
+++ b/builtin/logical/pki/key_util.go
@@ -6,6 +6,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -96,6 +97,15 @@ func getManagedKeyPublicKey(mkc managedKeyContext, keyId managedKeyId) (crypto.P
 		return nil, errors.New("failed to lookup public key from managed key: " + err.Error())
 	}
 	return pubKey, nil
+}
+
+func getPublicKeyFromBytes(keyBytes []byte) (crypto.PublicKey, error) {
+	signer, _, _, err := getSignerFromBytes(keyBytes)
+	if err != nil {
+		return nil, errutil.InternalError{Err: fmt.Sprintf("failed parsing key bytes: %s", err.Error())}
+	}
+
+	return signer.Public(), nil
 }
 
 func importKeyFromBytes(mkc managedKeyContext, s logical.Storage, keyValue string, keyName string) (*keyEntry, bool, error) {

--- a/builtin/logical/pki/managed_key_util.go
+++ b/builtin/logical/pki/managed_key_util.go
@@ -13,18 +13,26 @@ import (
 
 var errEntOnly = errors.New("managed keys are supported within enterprise edition only")
 
-func generateManagedKeyCABundle(_ context.Context, _ *backend, _ *inputBundle, _ *certutil.CreationBundle, _ io.Reader) (*certutil.ParsedCertBundle, error) {
+func generateManagedKeyCABundle(ctx context.Context, b *backend, input *inputBundle, keyId managedKeyId, data *certutil.CreationBundle, randomSource io.Reader) (bundle *certutil.ParsedCertBundle, err error) {
 	return nil, errEntOnly
 }
 
-func generateManagedKeyCSRBundle(_ context.Context, _ *backend, _ *inputBundle, _ *certutil.CreationBundle, _ bool, _ io.Reader) (*certutil.ParsedCSRBundle, error) {
+func generateManagedKeyCSRBundle(ctx context.Context, b *backend, input *inputBundle, keyId managedKeyId, data *certutil.CreationBundle, addBasicConstraints bool, randomSource io.Reader) (bundle *certutil.ParsedCSRBundle, err error) {
 	return nil, errEntOnly
 }
 
-func parseManagedKeyCABundle(_ context.Context, _ *backend, _ *logical.Request, _ *certutil.CertBundle) (*certutil.ParsedCertBundle, error) {
+func parseManagedKeyCABundle(ctx context.Context, b *backend, req *logical.Request, bundle *certutil.CertBundle) (*certutil.ParsedCertBundle, error) {
 	return nil, errEntOnly
 }
 
-func withManagedPKIKey(_ context.Context, _ *backend, _ managedKeyId, _ string, _ logical.ManagedSigningKeyConsumer) error {
+func withManagedPKIKey(ctx context.Context, b *backend, keyId managedKeyId, mountPoint string, f logical.ManagedSigningKeyConsumer) error {
 	return errEntOnly
+}
+
+func extractManagedKeyId(privateKeyBytes []byte) (UUIDKey, error) {
+	return "", errEntOnly
+}
+
+func createKmsKeyBundle(mkc managedKeyContext, keyId managedKeyId) (certutil.KeyBundle, certutil.PrivateKeyType, error) {
+	return certutil.KeyBundle{}, certutil.UnknownPrivateKey, errEntOnly
 }

--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -130,7 +130,7 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 		}
 	}
 
-	myKey, _, err := importKey(ctx, req.Storage, csrb.PrivateKey, keyName)
+	myKey, _, err := importKey(newManagedKeyContext(ctx, b, req.MountPoint), req.Storage, csrb.PrivateKey, keyName, csrb.PrivateKeyType)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -181,9 +181,10 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 		return logical.ErrorResponse("private keys found in the PEM bundle but not allowed by the path; use /issuers/import/bundle"), nil
 	}
 
+	mkc := newManagedKeyContext(ctx, b, req.MountPoint)
 	for keyIndex, keyPem := range keys {
 		// Handle import of private key.
-		key, existing, err := importKey(ctx, req.Storage, keyPem, "")
+		key, existing, err := importKeyFromBytes(mkc, req.Storage, keyPem, "")
 		if err != nil {
 			return logical.ErrorResponse(fmt.Sprintf("Error parsing key %v: %v", keyIndex, err)), nil
 		}
@@ -194,7 +195,7 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 	}
 
 	for certIndex, certPem := range issuers {
-		cert, existing, err := importIssuer(ctx, req.Storage, certPem, "")
+		cert, existing, err := importIssuer(mkc, req.Storage, certPem, "")
 		if err != nil {
 			return logical.ErrorResponse(fmt.Sprintf("Error parsing issuer %v: %v\n%v", certIndex, err, certPem)), nil
 		}

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -199,7 +199,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 	}
 
 	// Store it as the CA bundle
-	myIssuer, myKey, err := writeCaBundle(ctx, req.Storage, cb, issuerName, keyName)
+	myIssuer, myKey, err := writeCaBundle(newManagedKeyContext(ctx, b, req.MountPoint), req.Storage, cb, issuerName, keyName)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -218,11 +218,6 @@ func importKey(mkc managedKeyContext, s logical.Storage, keyValue string, keyNam
 	result.PrivateKey = keyValue
 	result.PrivateKeyType = keyType
 
-	keyPublic, err := getPublicKey(mkc, &result)
-	if err != nil {
-		return nil, false, err
-	}
-
 	// Finally, we can write the key to storage.
 	if err := writeKey(mkc.ctx, s, result); err != nil {
 		return nil, false, err
@@ -258,7 +253,7 @@ func importKey(mkc managedKeyContext, s logical.Storage, keyValue string, keyNam
 			return nil, false, err
 		}
 
-		equal, err := certutil.ComparePublicKeysAndType(cert.PublicKey, keyPublic)
+		equal, err := certutil.ComparePublicKeysAndType(cert.PublicKey, pkForImportingKey)
 		if err != nil {
 			return nil, false, err
 		}

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -2,7 +2,6 @@ package pki
 
 import (
 	"context"
-	"crypto"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -55,6 +54,17 @@ type keyEntry struct {
 	PrivateKey     string                  `json:"private_key" structs:"private_key" mapstructure:"private_key"`
 }
 
+func (e keyEntry) getManagedKeyUUID() (UUIDKey, error) {
+	if !e.isManagedPrivateKey() {
+		return "", errutil.InternalError{Err: "getManagedKeyId called on a key id %s (%s) "}
+	}
+	return extractManagedKeyId([]byte(e.PrivateKey))
+}
+
+func (e keyEntry) isManagedPrivateKey() bool {
+	return e.PrivateKeyType == certutil.ManagedPrivateKey
+}
+
 type issuerEntry struct {
 	ID                   issuerID                  `json:"id" structs:"id" mapstructure:"id"`
 	Name                 string                    `json:"name" structs:"name" mapstructure:"name"`
@@ -77,11 +87,6 @@ type keyConfigEntry struct {
 
 type issuerConfigEntry struct {
 	DefaultIssuerId issuerID `json:"default" structs:"default" mapstructure:"default"`
-}
-
-func (k keyEntry) GetSigner() (crypto.Signer, error) {
-	signer, _, err := certutil.ParsePEMKey(k.PrivateKey)
-	return signer, err
 }
 
 func listKeys(ctx context.Context, s logical.Storage) ([]keyID, error) {
@@ -149,7 +154,7 @@ func deleteKey(ctx context.Context, s logical.Storage, id keyID) (bool, error) {
 	return wasDefault, s.Delete(ctx, keyPrefix+id.String())
 }
 
-func importKey(ctx context.Context, s logical.Storage, keyValue string, keyName string) (*keyEntry, bool, error) {
+func importKey(mkc managedKeyContext, s logical.Storage, keyValue string, keyName string, keyType certutil.PrivateKeyType) (*keyEntry, bool, error) {
 	// importKey imports the specified PEM-format key (from keyValue) into
 	// the new PKI storage format. The first return field is a reference to
 	// the new key; the second is whether or not the key already existed
@@ -164,22 +169,13 @@ func importKey(ctx context.Context, s logical.Storage, keyValue string, keyName 
 	// Before we can import a known key, we first need to know if the key
 	// exists in storage already. This means iterating through all known
 	// keys and comparing their private value against this value.
-	knownKeys, err := listKeys(ctx, s)
-	if err != nil {
-		return nil, false, err
-	}
-
-	// Before we return below, we need to iterate over _all_ issuers and see if
-	// one of them has a missing KeyId link, and if so, point it back to
-	// ourselves. We fetch the list of issuers up front, even when don't need
-	// it, to give ourselves a better chance of succeeding below.
-	knownIssuers, err := listIssuers(ctx, s)
+	knownKeys, err := listKeys(mkc.ctx, s)
 	if err != nil {
 		return nil, false, err
 	}
 
 	for _, identifier := range knownKeys {
-		existingKey, err := fetchKeyById(ctx, s, identifier)
+		existingKey, err := fetchKeyById(mkc.ctx, s, identifier)
 		if err != nil {
 			return nil, false, err
 		}
@@ -197,25 +193,30 @@ func importKey(ctx context.Context, s logical.Storage, keyValue string, keyName 
 	result.ID = genKeyId()
 	result.Name = keyName
 	result.PrivateKey = keyValue
+	result.PrivateKeyType = keyType
 
-	// Extracting the signer is necessary for two reasons: first, to get the
-	// public key for comparison with existing issuers; second, to get the
-	// corresponding private key type.
-	keySigner, err := result.GetSigner()
+	keyPublic, err := getPublicKey(mkc, &result)
 	if err != nil {
 		return nil, false, err
 	}
-	keyPublic := keySigner.Public()
-	result.PrivateKeyType = certutil.GetPrivateKeyTypeFromSigner(keySigner)
 
 	// Finally, we can write the key to storage.
-	if err := writeKey(ctx, s, result); err != nil {
+	if err := writeKey(mkc.ctx, s, result); err != nil {
+		return nil, false, err
+	}
+
+	// Before we return below, we need to iterate over _all_ issuers and see if
+	// one of them has a missing KeyId link, and if so, point it back to
+	// ourselves. We fetch the list of issuers up front, even when don't need
+	// it, to give ourselves a better chance of succeeding below.
+	knownIssuers, err := listIssuers(mkc.ctx, s)
+	if err != nil {
 		return nil, false, err
 	}
 
 	// Now, for each issuer, try and compute the issuer<->key link if missing.
 	for _, identifier := range knownIssuers {
-		existingIssuer, err := fetchIssuerById(ctx, s, identifier)
+		existingIssuer, err := fetchIssuerById(mkc.ctx, s, identifier)
 		if err != nil {
 			return nil, false, err
 		}
@@ -243,7 +244,7 @@ func importKey(ctx context.Context, s logical.Storage, keyValue string, keyName 
 			// These public keys are equal, so this key entry must be the
 			// corresponding private key to this issuer; update it accordingly.
 			existingIssuer.KeyID = result.ID
-			if err := writeIssuer(ctx, s, existingIssuer); err != nil {
+			if err := writeIssuer(mkc.ctx, s, existingIssuer); err != nil {
 				return nil, false, err
 			}
 		}
@@ -251,12 +252,12 @@ func importKey(ctx context.Context, s logical.Storage, keyValue string, keyName 
 
 	// If there was no prior default value set and/or we had no known
 	// keys when we started, set this key as default.
-	keyDefaultSet, err := isDefaultKeySet(ctx, s)
+	keyDefaultSet, err := isDefaultKeySet(mkc.ctx, s)
 	if err != nil {
 		return nil, false, err
 	}
 	if len(knownKeys) == 0 || !keyDefaultSet {
-		if err = updateDefaultKeyId(ctx, s, result.ID); err != nil {
+		if err = updateDefaultKeyId(mkc.ctx, s, result.ID); err != nil {
 			return nil, false, err
 		}
 	}
@@ -384,7 +385,7 @@ func deleteIssuer(ctx context.Context, s logical.Storage, id issuerID) (bool, er
 	return wasDefault, s.Delete(ctx, issuerPrefix+id.String())
 }
 
-func importIssuer(ctx context.Context, s logical.Storage, certValue string, issuerName string) (*issuerEntry, bool, error) {
+func importIssuer(ctx managedKeyContext, s logical.Storage, certValue string, issuerName string) (*issuerEntry, bool, error) {
 	// importIssuers imports the specified PEM-format certificate (from
 	// certValue) into the new PKI storage format. The first return field is a
 	// reference to the new issuer; the second is whether or not the issuer
@@ -409,7 +410,7 @@ func importIssuer(ctx context.Context, s logical.Storage, certValue string, issu
 	// Before we can import a known issuer, we first need to know if the issuer
 	// exists in storage already. This means iterating through all known
 	// issuers and comparing their private value against this value.
-	knownIssuers, err := listIssuers(ctx, s)
+	knownIssuers, err := listIssuers(ctx.ctx, s)
 	if err != nil {
 		return nil, false, err
 	}
@@ -418,13 +419,13 @@ func importIssuer(ctx context.Context, s logical.Storage, certValue string, issu
 	// one of them a public key matching this certificate, and if so, update our
 	// link accordingly. We fetch the list of keys up front, even may not need
 	// it, to give ourselves a better chance of succeeding below.
-	knownKeys, err := listKeys(ctx, s)
+	knownKeys, err := listKeys(ctx.ctx, s)
 	if err != nil {
 		return nil, false, err
 	}
 
 	for _, identifier := range knownIssuers {
-		existingIssuer, err := fetchIssuerById(ctx, s, identifier)
+		existingIssuer, err := fetchIssuerById(ctx.ctx, s, identifier)
 		if err != nil {
 			return nil, false, err
 		}
@@ -470,18 +471,12 @@ func importIssuer(ctx context.Context, s logical.Storage, certValue string, issu
 	// writing issuer to storage as we won't need to update the key, only
 	// the issuer.
 	for _, identifier := range knownKeys {
-		existingKey, err := fetchKeyById(ctx, s, identifier)
+		existingKey, err := fetchKeyById(ctx.ctx, s, identifier)
 		if err != nil {
 			return nil, false, err
 		}
 
-		// Fetch the signer for its Public() value.
-		signer, err := existingKey.GetSigner()
-		if err != nil {
-			return nil, false, err
-		}
-
-		equal, err := certutil.ComparePublicKeysAndType(issuerCert.PublicKey, signer.Public())
+		equal, err := comparePublicKey(ctx, existingKey, issuerCert.PublicKey)
 		if err != nil {
 			return nil, false, err
 		}
@@ -498,18 +493,18 @@ func importIssuer(ctx context.Context, s logical.Storage, certValue string, issu
 
 	// Finally, rebuild the chains. In this process, because the provided
 	// reference issuer is non-nil, we'll save this issuer to storage.
-	if err := rebuildIssuersChains(ctx, s, &result); err != nil {
+	if err := rebuildIssuersChains(ctx.ctx, s, &result); err != nil {
 		return nil, false, err
 	}
 
 	// If there was no prior default value set and/or we had no known
 	// issuers when we started, set this issuer as default.
-	issuerDefaultSet, err := isDefaultIssuerSet(ctx, s)
+	issuerDefaultSet, err := isDefaultIssuerSet(ctx.ctx, s)
 	if err != nil {
 		return nil, false, err
 	}
 	if len(knownIssuers) == 0 || !issuerDefaultSet {
-		if err = updateDefaultIssuerId(ctx, s, result.ID); err != nil {
+		if err = updateDefaultIssuerId(ctx.ctx, s, result.ID); err != nil {
 			return nil, false, err
 		}
 	}
@@ -692,19 +687,19 @@ func fetchCertBundleByIssuerId(ctx context.Context, s logical.Storage, id issuer
 	return issuer, &bundle, nil
 }
 
-func writeCaBundle(ctx context.Context, s logical.Storage, caBundle *certutil.CertBundle, issuerName string, keyName string) (*issuerEntry, *keyEntry, error) {
-	myKey, _, err := importKey(ctx, s, caBundle.PrivateKey, keyName)
+func writeCaBundle(mkc managedKeyContext, s logical.Storage, caBundle *certutil.CertBundle, issuerName string, keyName string) (*issuerEntry, *keyEntry, error) {
+	myKey, _, err := importKey(mkc, s, caBundle.PrivateKey, keyName, caBundle.PrivateKeyType)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	myIssuer, _, err := importIssuer(ctx, s, caBundle.Certificate, issuerName)
+	myIssuer, _, err := importIssuer(mkc, s, caBundle.Certificate, issuerName)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	for _, cert := range caBundle.CAChain {
-		if _, _, err = importIssuer(ctx, s, cert, ""); err != nil {
+		if _, _, err = importIssuer(mkc, s, cert, ""); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -77,7 +77,8 @@ func migrateStorage(ctx context.Context, b *backend, s logical.Storage) error {
 
 	b.Logger().Info("performing PKI migration to new keys/issuers layout")
 	if migrationInfo.legacyBundle != nil {
-		anIssuer, aKey, err := writeCaBundle(ctx, s, migrationInfo.legacyBundle, "current", "current")
+		mkc := newManagedKeyContext(ctx, b, b.backendUuid)
+		anIssuer, aKey, err := writeCaBundle(mkc, s, migrationInfo.legacyBundle, "current", "current")
 		if err != nil {
 			return err
 		}

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -1229,16 +1229,19 @@ func GetPublicKeySize(key crypto.PublicKey) int {
 	return -1
 }
 
-func GetKeyBundleFromKeyGenerator(keyType string, keyBits int, keyGenerator KeyGenerator) (KeyBundle, error) {
+// CreateKeyBundle create a KeyBundle struct object which includes a generated key
+// of keyType with keyBits leveraging the randomness from randReader.
+func CreateKeyBundle(keyType string, keyBits int, randReader io.Reader) (KeyBundle, error) {
+	return CreateKeyBundleWithKeyGenerator(keyType, keyBits, randReader, generatePrivateKey)
+}
+
+// CreateKeyBundleWithKeyGenerator create a KeyBundle struct object which includes
+// a generated key of keyType with keyBits leveraging the randomness from randReader and
+// delegates the actual key generation to keyGenerator
+func CreateKeyBundleWithKeyGenerator(keyType string, keyBits int, randReader io.Reader, keyGenerator KeyGenerator) (KeyBundle, error) {
 	result := KeyBundle{}
-
-	if keyGenerator == nil {
-		keyGenerator = generatePrivateKey
-	}
-
-	if err := keyGenerator(keyType, keyBits, &result, nil); err != nil {
+	if err := keyGenerator(keyType, keyBits, &result, randReader); err != nil {
 		return result, err
 	}
-
 	return result, nil
 }


### PR DESCRIPTION
This is just a draft PR for now so that people can see the various changes that were required to get this to work within managed keys and for others to work off of.

The main massive change was to the importKey behaviour where now we tell it the type of key it really is on the inbound instead of it trying to determine what it is for itself. This was mainly done as within that function it did not really have the context needed to determine if it was a managed key or not.

Another rather large amount of change was to support a managed key within the context of an existing key.