### PR TITLE
Update michaelklishin/rabbit-hole to v2.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/mattn/go-colorable v0.1.12
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mholt/archiver/v3 v3.5.1
-	github.com/michaelklishin/rabbit-hole/v2 v2.11.0
+	github.com/michaelklishin/rabbit-hole/v2 v2.12.0
 	github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a
 	github.com/mitchellh/cli v1.1.2
 	github.com/mitchellh/copystructure v1.2.0


### PR DESCRIPTION
michaelklishin/rabbit-hole#219 as opened to report the following checksum error:

go: downloading github.com/michaelklishin/rabbit-hole/v2 v2.11.0
verifying github.com/michaelklishin/rabbit-hole/v2@v2.11.0: checksum mismatch
downloaded: h1:P3fq6xFRZ8FWOCsjgrAW4FezfIpyc1bcKIp1Qkf/egk=
go.sum: h1:v/Jtrr0FY82pITY3VFhIDaXCllPCTGpGCIM2U505Row=

which resulted in v2.12.0 being released to address the issue. This PR updates
to v2.12.0.