### PR TITLE
Add Transit BYOK wrapping key endpoint

### DIFF
--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -48,7 +48,6 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*backend, error)
 			b.pathRotate(),
 			b.pathRewrap(),
 			b.pathWrappingKey(),
-			b.pathImport(),
 			b.pathKeys(),
 			b.pathListKeys(),
 			b.pathExportKeys(),

--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -49,6 +48,7 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*backend, error)
 			b.pathRotate(),
 			b.pathRewrap(),
 			b.pathWrappingKey(),
+			b.pathImport(),
 			b.pathKeys(),
 			b.pathListKeys(),
 			b.pathExportKeys(),
@@ -155,33 +155,6 @@ func (b *backend) GetPolicy(ctx context.Context, polReq keysutil.PolicyRequest, 
 		return p, false, err
 	}
 	return p, true, nil
-}
-
-func (b *backend) GetWrappingKey(ctx context.Context, storage logical.Storage, keyName string, rand io.Reader) (*keysutil.Policy, error) {
-	// Load it from storage
-	p, err := keysutil.LoadPolicy(ctx, storage, path.Join("import", keyName))
-	if err != nil {
-		return nil, err
-	}
-
-	if p == nil {
-		p = &keysutil.Policy{
-			Name:                 keyName,
-			Type:                 keysutil.KeyType_RSA4096,
-			Derived:              false,
-			Exportable:           false,
-			AllowPlaintextBackup: false,
-			AutoRotatePeriod:     0,
-			StoragePrefix:        "import/",
-		}
-
-		err = p.Rotate(ctx, storage, rand)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return p, nil
 }
 
 func (b *backend) invalidate(ctx context.Context, key string) {

--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -46,6 +46,7 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*backend, error)
 			b.pathConfig(),
 			b.pathRotate(),
 			b.pathRewrap(),
+			b.pathWrappingKey(),
 			b.pathKeys(),
 			b.pathListKeys(),
 			b.pathExportKeys(),

--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -37,7 +37,6 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*backend, error)
 			SealWrapStorage: []string{
 				"archive/",
 				"policy/",
-				"import/",
 			},
 		},
 

--- a/builtin/logical/transit/path_wrapping_key.go
+++ b/builtin/logical/transit/path_wrapping_key.go
@@ -5,12 +5,13 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/hashicorp/vault/sdk/framework"
-	"github.com/hashicorp/vault/sdk/helper/keysutil"
-	"github.com/hashicorp/vault/sdk/logical"
 	"io"
 	"path"
 	"strconv"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/keysutil"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 const WrappingKeyName = "wrapping-key"
@@ -92,6 +93,8 @@ func generateWrappingKey(ctx context.Context, storage logical.Storage, rand io.R
 	return p, nil
 }
 
-const pathWrappingKeyHelpSyn = "Returns the public key to use for wrapping imported keys"
-const pathWrappingKeyHelpDesc = "This path is used to retrieve the RSA-4096 wrapping key" +
-	"for wrapping keys that are being imported into transit."
+const (
+	pathWrappingKeyHelpSyn  = "Returns the public key to use for wrapping imported keys"
+	pathWrappingKeyHelpDesc = "This path is used to retrieve the RSA-4096 wrapping key" +
+		"for wrapping keys that are being imported into transit."
+)

--- a/builtin/logical/transit/path_wrapping_key.go
+++ b/builtin/logical/transit/path_wrapping_key.go
@@ -6,12 +6,11 @@ import (
 	"encoding/pem"
 	"fmt"
 	"github.com/hashicorp/vault/sdk/framework"
-	"github.com/hashicorp/vault/sdk/helper/keysutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"strconv"
 )
 
-const WrappingKeyName = "import-wrapping-key"
+const WrappingKeyName = "wrapping-key"
 
 func (b *backend) pathWrappingKey() *framework.Path {
 	return &framework.Path{
@@ -25,14 +24,7 @@ func (b *backend) pathWrappingKey() *framework.Path {
 }
 
 func (b *backend) pathWrappingKeyRead(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
-	polReq := keysutil.PolicyRequest{
-		Upsert:  true,
-		Storage: req.Storage,
-		Name:    WrappingKeyName,
-		KeyType: keysutil.KeyType_RSA4096,
-	}
-
-	p, _, err := b.GetPolicy(ctx, polReq, b.GetRandomReader())
+	p, err := b.lm.GetWrappingKey(ctx, req.Storage, WrappingKeyName, b.GetRandomReader())
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/transit/path_wrapping_key.go
+++ b/builtin/logical/transit/path_wrapping_key.go
@@ -1,0 +1,72 @@
+package transit
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/keysutil"
+	"github.com/hashicorp/vault/sdk/logical"
+	"strconv"
+)
+
+const WrappingKeyName = "import-wrapping-key"
+
+func (b *backend) pathWrappingKey() *framework.Path {
+	return &framework.Path{
+		Pattern: "wrapping_key",
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ReadOperation: b.pathWrappingKeyRead,
+		},
+		HelpSynopsis:    pathWrappingKeyHelpSyn,
+		HelpDescription: pathWrappingKeyHelpDesc,
+	}
+}
+
+func (b *backend) pathWrappingKeyRead(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	polReq := keysutil.PolicyRequest{
+		Upsert:  true,
+		Storage: req.Storage,
+		Name:    WrappingKeyName,
+		KeyType: keysutil.KeyType_RSA4096,
+	}
+
+	p, _, err := b.GetPolicy(ctx, polReq, b.GetRandomReader())
+	if err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, fmt.Errorf("error generating wrapping key: returned policy was nil")
+	}
+	if b.System().CachingDisabled() {
+		p.Unlock()
+	}
+
+	rsaPublicKey := p.Keys[strconv.Itoa(p.LatestVersion)]
+
+	derBytes, err := x509.MarshalPKIXPublicKey(rsaPublicKey.RSAKey.Public())
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling RSA public key: %w", err)
+	}
+	pemBlock := &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: derBytes,
+	}
+	pemBytes := pem.EncodeToMemory(pemBlock)
+	if pemBytes == nil || len(pemBytes) == 0 {
+		return nil, fmt.Errorf("failed to PEM-encode RSA public key")
+	}
+
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			"public_key": string(pemBytes),
+		},
+	}
+
+	return resp, nil
+}
+
+const pathWrappingKeyHelpSyn = "Returns the public key to use for wrapping imported keys"
+const pathWrappingKeyHelpDesc = "This path is used to retrieve the RSA-4096 wrapping key" +
+	"for wrapping keys that are being imported into transit."

--- a/builtin/logical/transit/path_wrapping_key.go
+++ b/builtin/logical/transit/path_wrapping_key.go
@@ -48,9 +48,9 @@ func (b *backend) pathWrappingKeyRead(ctx context.Context, req *logical.Request,
 		p.Unlock()
 	}
 
-	rsaPublicKey := p.Keys[strconv.Itoa(p.LatestVersion)]
+	wrappingKey := p.Keys[strconv.Itoa(p.LatestVersion)]
 
-	derBytes, err := x509.MarshalPKIXPublicKey(rsaPublicKey.RSAKey.Public())
+	derBytes, err := x509.MarshalPKIXPublicKey(wrappingKey.RSAKey.Public())
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling RSA public key: %w", err)
 	}

--- a/builtin/logical/transit/path_wrapping_key.go
+++ b/builtin/logical/transit/path_wrapping_key.go
@@ -76,6 +76,6 @@ func (b *backend) pathWrappingKeyRead(ctx context.Context, req *logical.Request,
 
 const (
 	pathWrappingKeyHelpSyn  = "Returns the public key to use for wrapping imported keys"
-	pathWrappingKeyHelpDesc = "This path is used to retrieve the RSA-4096 wrapping key" +
+	pathWrappingKeyHelpDesc = "This path is used to retrieve the RSA-4096 wrapping key " +
 		"for wrapping keys that are being imported into transit."
 )

--- a/builtin/logical/transit/path_wrapping_key_test.go
+++ b/builtin/logical/transit/path_wrapping_key_test.go
@@ -1,0 +1,98 @@
+package transit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// TODO: Replace these with the real values. - schultz
+const (
+	pubKeyStoragePath  = "/path/to/public/wrapping/key"
+	privKeyStoragePath = "/path/to/private/wrapping/key"
+)
+
+func TestTransit_WrappingKey(t *testing.T) {
+	// Set up shared backend for subtests
+	var b *backend
+	storage := &logical.InmemStorage{}
+	sysView := logical.TestSystemView()
+	b, _ = Backend(
+		context.Background(),
+		&logical.BackendConfig{
+			StorageView: storage,
+			System:      sysView,
+		},
+	)
+
+	// Ensure the key does not exist before requesting it.
+	pubKeyEntry, err := storage.Get(context.Background(), pubKeyStoragePath)
+	if err != nil {
+		t.Fatalf("error retrieving public wrapping key from storage: %s", err)
+	}
+	if pubKeyEntry != nil {
+		t.Fatal("public wrapping key unexpectedly exists")
+	}
+
+	privKeyEntry, err := storage.Get(context.Background(), privKeyStoragePath)
+	if err != nil {
+		t.Fatalf("error retrieving private wrapping key from storage: %s", err)
+	}
+	if privKeyEntry != nil {
+		t.Fatal("private wrapping key unexpectedly exists")
+	}
+
+	// Generate the key pair by requesting the public key.
+	req := &logical.Request{
+		Storage:   storage,
+		Operation: logical.ReadOperation,
+		Path:      "wrapping_key",
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected request error: %s", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+	// TODO: Save public key from response. - schultz
+	pubKey := ""
+
+	// TODO: Ensure only public key is returned in response. - schultz
+
+	// Ensure the key exists in storage and that the public key matches what was returned.
+	pubKeyEntry, err = storage.Get(context.Background(), pubKeyStoragePath)
+	if err != nil {
+		t.Fatalf("error retrieving public wrapping key from storage: %s", err)
+	}
+	if pubKeyEntry == nil {
+		t.Fatal("expected non-nil public wrapping key")
+	}
+	if string(pubKeyEntry.Value) != pubKey {
+		t.Fatal("returned public wrapping key does not match value in storage")
+	}
+
+	privKeyEntry, err = storage.Get(context.Background(), privKeyStoragePath)
+	if err != nil {
+		t.Fatalf("error retrieving private wrapping key from storage: %s", err)
+	}
+	if privKeyEntry == nil {
+		t.Fatal("expected non-nil private wrapping key")
+	}
+
+	// Request the wrapping key again to ensure it isn't regenerated.
+	req = &logical.Request{
+		Storage:   storage,
+		Operation: logical.ReadOperation,
+		Path:      "wrapping_key",
+	}
+	resp, err = b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected request error: %s", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+	// TODO: Compare response body to previously returned public key. - schultz
+}

--- a/builtin/logical/transit/path_wrapping_key_test.go
+++ b/builtin/logical/transit/path_wrapping_key_test.go
@@ -13,19 +13,10 @@ const (
 
 func TestTransit_WrappingKey(t *testing.T) {
 	// Set up shared backend for subtests
-	var b *backend
-	storage := &logical.InmemStorage{}
-	sysView := logical.TestSystemView()
-	b, _ = Backend(
-		context.Background(),
-		&logical.BackendConfig{
-			StorageView: storage,
-			System:      sysView,
-		},
-	)
+	b, s := createBackendWithStorage(t)
 
 	// Ensure the key does not exist before requesting it.
-	keyEntry, err := storage.Get(context.Background(), storagePath)
+	keyEntry, err := s.Get(context.Background(), storagePath)
 	if err != nil {
 		t.Fatalf("error retrieving wrapping key from storage: %s", err)
 	}
@@ -35,7 +26,7 @@ func TestTransit_WrappingKey(t *testing.T) {
 
 	// Generate the key pair by requesting the public key.
 	req := &logical.Request{
-		Storage:   storage,
+		Storage:   s,
 		Operation: logical.ReadOperation,
 		Path:      "wrapping_key",
 	}
@@ -50,7 +41,7 @@ func TestTransit_WrappingKey(t *testing.T) {
 
 	// Request the wrapping key again to ensure it isn't regenerated.
 	req = &logical.Request{
-		Storage:   storage,
+		Storage:   s,
 		Operation: logical.ReadOperation,
 		Path:      "wrapping_key",
 	}

--- a/builtin/logical/transit/path_wrapping_key_test.go
+++ b/builtin/logical/transit/path_wrapping_key_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	storagePath = "import/policy/" + WrappingKeyName
+	storagePath = "policy/import/" + WrappingKeyName
 )
 
 func TestTransit_WrappingKey(t *testing.T) {

--- a/builtin/logical/transit/path_wrapping_key_test.go
+++ b/builtin/logical/transit/path_wrapping_key_test.go
@@ -2,6 +2,9 @@ package transit
 
 import (
 	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/logical"
@@ -37,7 +40,18 @@ func TestTransit_WrappingKey(t *testing.T) {
 	if resp == nil || resp.Data == nil || resp.Data["public_key"] == nil {
 		t.Fatal("expected non-nil response")
 	}
-	pubKey := resp.Data["public_key"]
+	pubKeyPEM := resp.Data["public_key"]
+
+	// Ensure the returned key is a 4096-bit RSA key.
+	pubKeyBlock, _ := pem.Decode([]byte(pubKeyPEM.(string)))
+	rawPubKey, err := x509.ParsePKIXPublicKey(pubKeyBlock.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse public wrapping key: %s", err)
+	}
+	wrappingKey, ok := rawPubKey.(*rsa.PublicKey)
+	if !ok || wrappingKey.Size() != 512 {
+		t.Fatal("public wrapping key is not a 4096-bit RSA key")
+	}
 
 	// Request the wrapping key again to ensure it isn't regenerated.
 	req = &logical.Request{
@@ -52,7 +66,7 @@ func TestTransit_WrappingKey(t *testing.T) {
 	if resp == nil || resp.Data == nil || resp.Data["public_key"] == nil {
 		t.Fatal("expected non-nil response")
 	}
-	if resp.Data["public_key"] != pubKey {
+	if resp.Data["public_key"] != pubKeyPEM {
 		t.Fatal("wrapping key public component changed between requests")
 	}
 }

--- a/sdk/helper/keysutil/lock_manager.go
+++ b/sdk/helper/keysutil/lock_manager.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -266,40 +265,6 @@ func (lm *LockManager) BackupPolicy(ctx context.Context, storage logical.Storage
 	}
 
 	return backup, nil
-}
-
-func (lm *LockManager) GetWrappingKey(ctx context.Context, storage logical.Storage, keyName string, rand io.Reader) (*Policy, error) {
-	// This ensures that any other process writing the actual storage will be
-	// finished before we load from storage.
-	lock := locksutil.LockForKey(lm.keyLocks, keyName)
-	lock.Lock()
-	defer lock.Unlock()
-
-	// Load it from storage
-	p, err := LoadPolicy(ctx, storage, path.Join("import", "policy", keyName))
-	if err != nil {
-		return nil, err
-	}
-
-	if p == nil {
-		p = &Policy{
-			l:                    new(sync.RWMutex),
-			Name:                 keyName,
-			Type:                 KeyType_RSA4096,
-			Derived:              false,
-			Exportable:           false,
-			AllowPlaintextBackup: false,
-			AutoRotatePeriod:     0,
-			StoragePrefix:        "import/",
-		}
-
-		err = p.Rotate(ctx, storage, rand)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return p, nil
 }
 
 // When the function returns, if caching was disabled, the Policy's lock must


### PR DESCRIPTION
# Overview
Transit BYOK outlines a key import process that makes use of a shared public wrapping key. This key is generated lazily on first request to the endpoint and is used for subsequent imports. The key is stored in seal wrap storage, makes use of the `keysutil` policy management framework, and the private key will never leave the Vault cryptographic barrier.

# Testing
- Unit tests are included that cover the endpoint
- The first request to the endpoint should generate a 4096-bit RSA key and return its public component
- Subsequent requests to the endpoint should return the same public key