### PR TITLE
clone vault agent client with headers

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -793,7 +793,7 @@ func (c *AgentCommand) Run(args []string) int {
 
 		// Auth Handler is going to set its own retry values, so we want to
 		// work on a copy of the client to not affect other subsystems.
-		clonedClient, err := c.client.Clone()
+		clonedClient, err := c.client.CloneWithHeaders()
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error cloning client for auth handler: %v", err))
 			return 1


### PR DESCRIPTION
https://github.com/hashicorp/vault/pull/15204 introduced a change in which the Vault client is cloned for the auth handler. The headers are not cloned, however, which results in headers like `X-Vault-Namespace` being dropped. This PR changes the `Clone` call to a `CloneWithHeaders`.