### PR TITLE
removing prem/pro references as part of removing some build targets

### DIFF
--- a/sdk/plugin/grpc_system_test.go
+++ b/sdk/plugin/grpc_system_test.go
@@ -215,7 +215,7 @@ func TestSystem_GRPC_pluginEnv(t *testing.T) {
 	sys.PluginEnvironment = &logical.PluginEnvironment{
 		VaultVersion:           "0.10.42",
 		VaultVersionPrerelease: "dev",
-		VaultVersionMetadata:   "prem",
+		VaultVersionMetadata:   "ent",
 	}
 	client, _ := plugin.TestGRPCConn(t, func(s *grpc.Server) {
 		pb.RegisterSystemViewServer(s, &gRPCSystemViewServer{

--- a/vault/diagnose/constants.go
+++ b/vault/diagnose/constants.go
@@ -5,7 +5,7 @@ const (
 	AutoloadedLicenseValidationError   = "Autoloaded license validation failed due to error: "
 	LicenseAutoloadingError            = "License could not be autoloaded: "
 	StoredLicenseNoAutoloadingWarning  = "Vault is using a stored license, which is deprecated! Vault should use autoloaded licenses instead."
-	NoStoredOrAutoloadedLicenseWarning = "No autoloaded or stored license could be detected. If the binary is not a pro/prem binary, this means Vault does not have access to a license at all."
+	NoStoredOrAutoloadedLicenseWarning = "No autoloaded or stored license could be detected."
 	LicenseExpiredError                = "Autoloaded license is expired."
 	LicenseExpiryThresholdWarning      = "Autoloaded license will expire "
 	LicenseTerminatedError             = "Autoloaded license is terminated."

--- a/website/content/docs/enterprise/performance-standby.mdx
+++ b/website/content/docs/enterprise/performance-standby.mdx
@@ -78,7 +78,7 @@ Seal Type                              shamir
 Sealed                                 false
 Total Shares                           1
 Threshold                              1
-Version                                0.11.0+prem
+Version                                0.11.0+ent
 Cluster Name                           vault-cluster-d040e74c
 Cluster ID                             9f82e03b-71fb-97a6-9c5a-46fa6715d6e4
 HA Enabled                             true

--- a/website/content/docs/platform/k8s/helm/enterprise.mdx
+++ b/website/content/docs/platform/k8s/helm/enterprise.mdx
@@ -9,7 +9,7 @@ description: >-
 
 You can use this Helm chart to deploy Vault Enterprise by following a few extra steps around licensing.
 
-~> **Note:** As of Vault Enterprise 1.8, the license must be specified via HCL configuration or environment variables on startup, unless the Vault cluster was created with an older Vault version and the license was stored, or the Vault Enterprise binary has the license baked in (`prem` or `pro` version tags). More information is available in the [Vault Enterprise License docs](/docs/enterprise/license).
+~> **Note:** As of Vault Enterprise 1.8, the license must be specified via HCL configuration or environment variables on startup, unless the Vault cluster was created with an older Vault version and the license was stored. More information is available in the [Vault Enterprise License docs](/docs/enterprise/license).
 
 ## Vault Enterprise 1.8+
 


### PR DESCRIPTION
This PR aims to remove refrences to prem and pro build targets. Those targets are going to be removed on the ENT side.