### PR TITLE
Vault documentation: added another install option to the installation doc

### DIFF
--- a/website/content/docs/install.mdx
+++ b/website/content/docs/install.mdx
@@ -9,18 +9,20 @@ description: |-
 
 There are several approaches to installing Vault:
 
-1. Install a [Linux package](#linux-package)
+1. Install from a [Package Manager](#package-manager)
 
 1. Use a [precompiled binary](#precompiled-binaries)
 
 1. Install [from source](#compiling-from-source)
+
+1. [Helm for Kubernetes](https://www.vaultproject.io/docs/platform/k8s/helm)
 
 Installing a Linux package is the easiest. If you develop or deploy on another
 platform, the precompiled binary will be easiest. We provide downloads over TLS
 along with SHA256 sums to verify the binary. We also distribute a PGP signature
 with the SHA256 sums that can be verified.
 
-## Linux Package
+## Package Manager
 
 We build and sign official packages for Ubuntu, Debian, Fedora, RHEL, Amazon
 Linux, and other distributions. Follow the instructions at [HashiCorp


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/1200328878173626/1202184441417085), Helm for Kubernetes was added as another option to install Vault.

:mag: [Deploy Preview](https://vault-git-docs-vault-install-updates-hashicorp.vercel.app/docs/install)