### PR TITLE
GOPATH is being set incorrectly in latest CircleCI machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - v1.4-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
+        - v1.5-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
         name: Restore exact go modules cache
     - attach_workspace:
         at: .
@@ -187,7 +187,7 @@ jobs:
         - go-test-cache-date-v1-{{ checksum "/tmp/go-cache-key" }}
     - restore_cache:
         keys:
-        - v1.4-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
+        - v1.5-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
         name: Restore exact go modules cache
     - run:
         command: |
@@ -423,7 +423,7 @@ jobs:
         - go-test-cache-date-v1-{{ checksum "/tmp/go-cache-key" }}
     - restore_cache:
         keys:
-        - v1.4-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
+        - v1.5-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
         name: Restore exact go modules cache
     - run:
         command: |
@@ -610,7 +610,7 @@ jobs:
         - go-test-cache-date-v1-{{ checksum "/tmp/go-cache-key" }}
     - restore_cache:
         keys:
-        - v1.4-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
+        - v1.5-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
         name: Restore exact go modules cache
     - run:
         command: |
@@ -845,12 +845,14 @@ jobs:
           git config --global url."git@github.com:".insteadOf https://github.com/
     - restore_cache:
         keys:
-        - v1.4-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
-        - v1.4-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}
-        - v1.4-{{checksum "go.sum"}}
+        - v1.5-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
+        - v1.5-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}
+        - v1.5-{{checksum "go.sum"}}
         name: Restore closest matching go modules cache
     - run:
         command: |
+          # set GOPATH explicitly to download to the right cache
+          export GOPATH=/home/circleci/go
           # go list ./... forces downloading some additional versions of modules that 'go mod
           # download' misses. We need this because we make use of go list itself during
           # code generation in later builds that rely on this module cache.
@@ -867,7 +869,7 @@ jobs:
           }
         name: Verify downloading modules did not modify any files
     - save_cache:
-        key: v1.4-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
+        key: v1.5-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
         name: Save go modules cache
         paths:
         - /home/circleci/go/pkg/mod
@@ -914,7 +916,7 @@ jobs:
         - go-test-cache-date-v1-{{ checksum "/tmp/go-cache-key" }}
     - restore_cache:
         keys:
-        - v1.4-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
+        - v1.5-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
         name: Restore exact go modules cache
     - run:
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -852,7 +852,7 @@ jobs:
     - run:
         command: |
           # set GOPATH explicitly to download to the right cache
-          export GOPATH=/home/circleci/go
+          export GOPATH=$HOME/go
           # go list ./... forces downloading some additional versions of modules that 'go mod
           # download' misses. We need this because we make use of go list itself during
           # code generation in later builds that rely on this module cache.

--- a/.circleci/config/commands/@caches.yml
+++ b/.circleci/config/commands/@caches.yml
@@ -41,7 +41,7 @@ refresh_go_mod_cache:
         name: go mod download
         command: |
           # set GOPATH explicitly to download to the right cache
-          export GOPATH=/home/circleci/go
+          export GOPATH=$HOME/go
           # go list ./... forces downloading some additional versions of modules that 'go mod
           # download' misses. We need this because we make use of go list itself during
           # code generation in later builds that rely on this module cache.

--- a/.circleci/config/commands/@caches.yml
+++ b/.circleci/config/commands/@caches.yml
@@ -18,9 +18,9 @@ restore_go_mod_cache_permissive:
     - restore_cache:
         name: Restore closest matching go modules cache
         keys:
-          - &gocachekey v1.4-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
-          -             v1.4-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}
-          -             v1.4-{{checksum "go.sum"}}
+          - &gocachekey v1.5-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}-{{checksum "api/go.sum"}}
+          -             v1.5-{{checksum "go.sum"}}-{{checksum "sdk/go.sum"}}
+          -             v1.5-{{checksum "go.sum"}}
 restore_go_mod_cache:
   steps:
     - restore_cache:
@@ -40,6 +40,8 @@ refresh_go_mod_cache:
     - run:
         name: go mod download
         command: |
+          # set GOPATH explicitly to download to the right cache
+          export GOPATH=/home/circleci/go
           # go list ./... forces downloading some additional versions of modules that 'go mod
           # download' misses. We need this because we make use of go list itself during
           # code generation in later builds that rely on this module cache.


### PR DESCRIPTION
For some reason, GOPATH is being overridden in the `go mod download`
step after the latest machine image update in #15215.

This causes all of the modules to be downloaded to the
`/home/circleci/.go_workspace` cache instead of `/home/circleci/go` like
we require for the build (which will otherwise fail since we build with
`GOPROXY=off`).

Without this fix, the build will start to fail once the existing cache
is no longer used (after the root `go.mod`) is updated.