### PR TITLE
Prevent revoking all issuer certificates

### DIFF
--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -191,7 +191,9 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 		// Add a little wiggle room because leases are stored with a second
 		// granularity
 		if cert.NotAfter.Before(time.Now().Add(2 * time.Second)) {
-			return nil, nil
+			response := &logical.Response{}
+			response.AddWarning(fmt.Sprintf("certificate with serial %s already expired; refusing to add to CRL", serial))
+			return response, nil
 		}
 
 		// Compatibility: Don't revoke CAs if they had leases. New CAs going

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -747,7 +747,7 @@ func resolveIssuerReference(ctx context.Context, s logical.Storage, reference st
 
 func resolveIssuerCRLPath(ctx context.Context, b *backend, s logical.Storage, reference string) (string, error) {
 	if b.useLegacyBundleCaStorage() {
-		return "crl", nil
+		return legacyCRLPath, nil
 	}
 
 	issuer, err := resolveIssuerReference(ctx, s, reference)

--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -16,6 +16,7 @@ import (
 const (
 	latestMigrationVersion = 1
 	legacyBundleShimID     = issuerID("legacy-entry-shim-id")
+	legacyBundleShimKeyID  = keyID("legacy-entry-shim-key-id")
 )
 
 type legacyBundleMigrationLog struct {
@@ -177,6 +178,7 @@ func getLegacyCertBundle(ctx context.Context, s logical.Storage) (*issuerEntry, 
 	// the fields in the CAInfoBundle; everything else doesn't matter.
 	issuer := &issuerEntry{
 		ID:                   legacyBundleShimID,
+		KeyID:                legacyBundleShimKeyID,
 		Name:                 "legacy-entry-shim",
 		LeafNotAfterBehavior: certutil.ErrNotAfterBehavior,
 	}


### PR DESCRIPTION
We prevent the revocation of issuer certificates via the `/revoke` endpoint. This is because the endpoint lacks enough specificity in the case where multiple issuers have the same serial number. 

Along the way, we handle two cases where we failed to address performance replication concerns. 

We also add a warning when revoking a certificate that's already expired. :-) 

---

My inclination is not to merge this until after #15277 has merged. 