### PR TITLE
Root issuers lack CA Chain + Chain Building Bug Fix

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -1318,6 +1318,7 @@ func generateCreationBundle(b *backend, data *inputBundle, caSign *certutil.CAIn
 			PolicyIdentifiers:             data.role.PolicyIdentifiers,
 			BasicConstraintsValidForNonCA: data.role.BasicConstraintsValidForNonCA,
 			NotBeforeDuration:             data.role.NotBeforeDuration,
+			ForceAppendCaChain:            caSign != nil,
 		},
 		SigningBundle: caSign,
 		CSR:           csr,

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -1167,7 +1167,7 @@ func signCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertBun
 		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to parse created certificate: %s", err)}
 	}
 
-	result.CAChain = data.SigningBundle.GetCAChain()
+	result.CAChain = data.SigningBundle.GetFullChain()
 
 	return result, nil
 }

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -704,13 +704,7 @@ func (b *CAInfoBundle) GetCAChain() []*CertBlock {
 		(len(b.Certificate.AuthorityKeyId) == 0 &&
 			!bytes.Equal(b.Certificate.RawIssuer, b.Certificate.RawSubject)) {
 
-		chain = append(chain, &CertBlock{
-			Certificate: b.Certificate,
-			Bytes:       b.CertificateBytes,
-		})
-		if b.CAChain != nil && len(b.CAChain) > 0 {
-			chain = append(chain, b.CAChain...)
-		}
+		chain = b.GetFullChain()
 	}
 
 	return chain
@@ -771,6 +765,7 @@ type CreationParameters struct {
 	PolicyIdentifiers             []string
 	BasicConstraintsValidForNonCA bool
 	SignatureBits                 int
+	ForceAppendCaChain            bool
 
 	// Only used when signing a CA cert
 	UseCSRValues        bool


### PR DESCRIPTION
As noted on the review of #15277, root issuers' issuance calls would result in an empty `ca_chain` response field.

We want this field to be populated, so make a few changes to CertUtil towards that.

However, in the process, we uncovered a bug with chain building logic, causing issuance to fail. Add issuance tests to the chain building and ensure stable sort order. It turns out we'd prefer the cross-signed roots over the actual self-signed roots when building the chain, which'd cause CertUtil's validation to fail. We also should prefer the longest cycle over shorter ones. 