### PR TITLE
Expand Azure Auth Method docs

### DIFF
--- a/changelog/15312.txt
+++ b/changelog/15312.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Azure Auth Method: Extend documentation to include details on the VM and VMSS workflows.
+```

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -460,7 +460,7 @@ If one or more of these restrictions are supplied and the vmss_name is supplied,
 
 1. Vault reaches out to the Azure API and checks that the VMSS exists. It uses the subscription id and resource group mandatory fields to make this call.  If the VMSS does exist it pulls metadata. If the VMSS does not exist in that subscription and resource group login fails.
 2. Vault checks `bound_scale_sets` restrictions if configured. Login fails if the scale set is not in the list.
-3. Vault checks that the VM has a managed identity. If it does not login fails.
+3. Vault checks that the VMSS has a managed identity. If it does not login fails.
 4. Vault checks that the managed identity in the JWT matches the managed identity on the VM. If it does not login fails.
 5. Vault checks `bound_subscription_ids` restrictions if configured. Login fails if the subscription is not in the list.
 6. Vault checks `bound_resource_groups` restrictions if configured. Login fails if the resource group is not in the list.

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -401,7 +401,7 @@ namespace Examples
 This section provides more details about the authentication flows and associated restrictions that can be supplied to the the role definition.
   
 There are 3 core flows and associated methods of restricting a role in the Azure Auth Method:
-- JWT Flow: Identity based restrictions that use claims from the JWT.
+- JWT Flow: Identity-based restrictions that use claims from the JWT.
 - VM Flow: Virtual Machine (VM) based restrictions that use data from the Virtual Machine.
 - VMSS Flow: Virtual Machine Scale Set (VMSS) based restrictions that use data from the Virtual Machine Scale Set.
   

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -405,7 +405,7 @@ There are 3 core flows and associated methods of restricting a role in the Azure
 - VM Flow: Virtual Machine (VM) based restrictions that use data from the Virtual Machine.
 - VMSS Flow: Virtual Machine Scale Set (VMSS)-based restrictions that use data from the Virtual Machine Scale Set.
   
-The VM and VMSS based restrictions can only be used for those resource types. If using Azure Kubernetes Service, Azure Container Instance or some other resource type that supports a managed identity, you cannot apply the restrictions applicable to VM and VMSS.
+The VM and VMSS-based restrictions can only be used for those resource types. If using Azure Kubernetes Service, Azure Container Instance, or some other resource type that supports a managed identity, you cannot apply the restrictions applicable to VM and VMSS.
   
 The restrictions that apply only to VM or VMSS are:
 - Locations `bound_locations`.

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -390,3 +390,73 @@ namespace Examples
 </CodeBlockConfig>
 
 </CodeTabs>
+  
+## Authentication Flows and Role Restrictions
+  
+This section provides more details about the authentication flows and associated restrictions that be supplied in the the role definition.
+  
+There are 3 core flows and associated methods of restricting a role in the Azure Auth Method:
+- Identity based restrictions that use claims from the JWT.
+- Virtual Machine (VM) based restrictions that use data from the Virtual Machine.
+- Virtual Machine Scale Set (VMSS) based restrictions that use data from the Scale Set.
+  
+The VM and VMSS based restrictions can only be used for those resource types. If using Azure Kubernetes Service, Azure Container Instance or some other resource type that supports a managed identity, you cannot apply the restrictions applicable to VM and VMSS.
+  
+The restrictions that apply only to VM or VMSS are:
+- Locations `bound_locations`.
+- Subscriptions `bound_subscription_ids`.
+- Resource groups `bound_resource_groups`.
+- Scale sets `bound_scale_sets`. (VMSS only).
+  
+The restrictions that apply to any resource type come from the JWT and these are:
+- Service principals `bound_service_principal_ids`.
+- Azure AD groups `bound_group_ids`.
+  
+If any of the restrictions for VM or VMSS are applied, then the `vm_name` or `vmss_name` parameters of the [login method](/api-docs/auth/azure#login) become mandatory. These restrictions are optional for VM and VMSS, it is not mandatory to apply any of them.
+
+### JWT Flow
+The JWT flow happens in all cases and there are some optional restrictions that can be applied to it. The JWT flow happens prior to the optional VM and VMSS flows. The optional restrictions are:
+- Principal Ids `bound_principal_ids`.
+- Azure AD Group Ids `bound_group_ids`.
+  
+The JWT flow is:
+1. Vault validates the JWT with Azure. If the JWT is not valid, login fails.
+2. Vault validates the JWT is still valid according to its Not Before time claim. If the ‘time before’ claim is  later than the current time, login fails.
+3. Vault checks Service Principal Ids restrictions if configured. Login fails if the service principal id from the JWT is not in the list. Note that Service Principal Ids restriction can be set to a single `*` record too and this check will be skipped.
+4. Vault checks Azure AD Group Ids restrictions if configured. Login fails if at least one of the groups claims from the JWT are not in the list. Note that Azure AD Group Ids restriction can be set to a single `*` record too and this check will be skipped.
+
+### VM Flow
+The VM flow is only applicable to virtual machines outside of a VMSS, this flow will not work for machines inside a scale set, which must use the VMSS flow. The VM flow can be used if any of these restrictions are applied:
+- Locations `bound_locations`.
+- Subscriptions `bound_subscription_ids`.
+- Resource groups `bound_resource_groups`.
+  
+If none of these restrictions are supplied then the vm_name field will be ignored on login.
+  
+If one or more of these restrictions are supplied and the vm_name is supplied, then the follow checks will happen:
+1. Vault reaches out to the Azure API and checks that the VM exists. It uses the subscription id and resource group mandatory fields to make this call.  If the VM does exist it pulls metadata. If the VM does not exist in that subscription and resource group login fails.
+2. Vault checks that the VM has a managed identity. If it does not login fails.
+3. Vault checks that the `bound_scale_sets` is not populated on the role. If it is, login fails.
+4. Vault checks that the managed identity in the JWT matches the managed identity on the VM. If it does not login fails.
+5. Vault checks `bound_subscription_ids` restrictions if configured. Login fails if the subscription is not in the list.
+6. Vault checks `bound_resource_groups` restrictions if configured. Login fails if the resource group is not in the list.
+7. Vault checks `bound_locations` restrictions if configured. Login fails if the location is not in the list.
+
+### VMSS Flow
+The VMSS flow is only applicable to virtual machines inside a VMSS, this flow will not work for machines outside a scale set, which must use the VM flow. The VMSS flow can be used if any of these restrictions are applied:
+- Locations `bound_locations`.
+- Subscriptions `bound_subscription_ids`.
+- Resource groups `bound_resource_groups`.
+- Scale sets `bound_scale_sets`.
+  
+If none of these restrictions are supplied then the vmss_name field will be ignored on login.
+  
+If one or more of these restrictions are supplied and the vmss_name is supplied, then the follow checks will happen:
+
+1. Vault reaches out to the Azure API and checks that the VMSS exists. It uses the subscription id and resource group mandatory fields to make this call.  If the VMSS does exist it pulls metadata. If the VMSS does not exist in that subscription and resource group login fails.
+2. Vault checks `bound_scale_sets` restrictions if configured. Login fails if the scale set is not in the list.
+3. Vault checks that the VM has a managed identity. If it does not login fails.
+4. Vault checks that the managed identity in the JWT matches the managed identity on the VM. If it does not login fails.
+5. Vault checks `bound_subscription_ids` restrictions if configured. Login fails if the subscription is not in the list.
+6. Vault checks `bound_resource_groups` restrictions if configured. Login fails if the resource group is not in the list.
+7. Vault checks `bound_locations` restrictions if configured. Login fails if the location is not in the list.

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -402,7 +402,7 @@ This section provides more details about the authentication flows and associated
   
 There are 3 core flows and associated methods of restricting a role in the Azure Auth Method:
 - JWT Flow: Identity-based restrictions that use claims from the JWT.
-- VM Flow: Virtual Machine (VM) based restrictions that use data from the Virtual Machine.
+- VM Flow: Virtual Machine (VM)-based restrictions that use data from the virtual machine.
 - VMSS Flow: Virtual Machine Scale Set (VMSS)-based restrictions that use data from the Virtual Machine Scale Set.
   
 The VM and VMSS-based restrictions can only be used for those resource types. If using Azure Kubernetes Service, Azure Container Instance, or some other resource type that supports a managed identity, you cannot apply the restrictions applicable to VM and VMSS.
@@ -417,51 +417,51 @@ The restrictions that apply to any resource type come from the JWT and these are
 - Service principals `bound_service_principal_ids`.
 - Azure AD groups `bound_group_ids`.
   
-If any of the restrictions for VM or VMSS are applied, then the `vm_name` or `vmss_name` parameters of the [login method](/api-docs/auth/azure#login) become mandatory. These restrictions are optional for VM and VMSS, it is not mandatory to apply any of them.
+If any of the restrictions for VM or VMSS are applied, then the `vm_name` or `vmss_name` parameters of the [login method](/api-docs/auth/azure#login) become mandatory. These restrictions are optional for VM and VMSS; it is not mandatory to apply any of them.
 
 ### JWT Flow
-The JWT flow happens in all cases and there are some optional restrictions that can be applied to it. The JWT flow happens prior to the optional VM and VMSS flows. The optional restrictions are:
+The JWT flow occurs in all cases and there are some optional restrictions that can be applied to it. The JWT flow happens prior to the optional VM and VMSS flows. The optional restrictions are:
 - Principal Ids `bound_principal_ids`.
 - Azure AD Group Ids `bound_group_ids`.
   
 The JWT flow is:
 1. Vault validates the JWT with Azure. If the JWT is not valid, login fails.
-2. Vault validates the JWT is still valid according to its `NotBefore` time claim. If the ‘NotBefore’ claim is later than the current time, login fails.
-3. Vault checks Service Principal Ids restrictions if configured. Login fails if the service principal id from the JWT is not in the list. Note that Service Principal Ids restriction can be set to a single `*` record too and this check will be skipped.
-4. Vault checks Azure AD Group Ids restrictions if configured. Login fails if at least one of the groups claims from the JWT are not in the list. Note that Azure AD Group Ids restriction can be set to a single `*` record too and this check will be skipped.
+2. Vault validates the JWT is still valid according to its `NotBefore` time claim. If the `NotBefore’`claim is later than the current time, login fails.
+3. Vault checks Service Principal Ids restrictions if it is configured. Login fails if the service principal id from the JWT is not on the list. Note that Service Principal Ids restriction can be set to a single `*` record too and this check will be skipped.
+4. Vault checks Azure AD Group Ids restrictions if it is configured. Login fails if at least one of the groups claims from the JWT are not on the list. Note that Azure AD Group Ids restriction can be set to a single `*` record too and this check will be skipped.
 
 ### VM Flow
-The VM flow is only applicable to virtual machines outside of a VMSS, this flow will not work for machines inside a scale set, which must use the VMSS flow. The VM flow can be used if any of these restrictions are applied:
+The VM flow is only applicable to virtual machines outside of a VMSS. This flow will not work for machines inside a scale set, which must use the VMSS flow. The VM flow can be used if any of these restrictions are applied:
 - Locations `bound_locations`.
 - Subscriptions `bound_subscription_ids`.
 - Resource groups `bound_resource_groups`.
   
-If none of these restrictions are supplied then the vm_name field will be ignored on login.
+If none of these restrictions are supplied, then the vm_name field will be ignored on login.
   
-If one or more of these restrictions are supplied and the vm_name is supplied, then the follow checks will happen:
-1. Vault reaches out to the Azure API and checks that the VM exists. It uses the subscription id and resource group mandatory fields to make this call.  If the VM does exist it pulls metadata. If the VM does not exist in that subscription and resource group login fails.
-2. Vault checks that the VM has a managed identity. If it does not login fails.
+If one or more of these restrictions are supplied and the vm_name is supplied, then the follow checks will take place:
+1. Vault reaches out to the Azure API and checks that the VM exists. It uses the subscription id and resource group mandatory fields to make this call.  If the VM does exist, it pulls the metadata. If the VM does not exist in that subscription and resource group, login fails.
+2. Vault checks that the VM has a managed identity. If it does not, login fails.
 3. Vault checks that the `bound_scale_sets` is not populated on the role. If it is, login fails.
-4. Vault checks that the managed identity in the JWT matches the managed identity on the VM. If it does not login fails.
-5. Vault checks `bound_subscription_ids` restrictions if configured. Login fails if the subscription is not in the list.
-6. Vault checks `bound_resource_groups` restrictions if configured. Login fails if the resource group is not in the list.
-7. Vault checks `bound_locations` restrictions if configured. Login fails if the location is not in the list.
+4. Vault checks that the managed identity in the JWT matches the managed identity on the VM. If it does not, login fails.
+5. Vault checks `bound_subscription_ids` restrictions if it is configured. Login fails if the subscription is not on the list.
+6. Vault checks `bound_resource_groups` restrictions if it is configured. Login fails if the resource group is not on the list.
+7. Vault checks `bound_locations` restrictions if it is configured. Login fails if the location is not on the list.
 
 ### VMSS Flow
-The VMSS flow is only applicable to virtual machines inside a VMSS, this flow will not work for machines outside a scale set, which must use the VM flow. The VMSS flow can be used if any of these restrictions are applied:
+The VMSS flow is only applicable to virtual machines inside a VMSS. This flow will not work for machines outside a scale set, which must use the VM flow. The VMSS flow can be used if any of these restrictions are applied:
 - Locations `bound_locations`.
 - Subscriptions `bound_subscription_ids`.
 - Resource groups `bound_resource_groups`.
 - Scale sets `bound_scale_sets`.
   
-If none of these restrictions are supplied then the vmss_name field will be ignored on login.
+If none of these restrictions are supplied, then the vmss_name field will be ignored on login.
   
-If one or more of these restrictions are supplied and the vmss_name is supplied, then the follow checks will happen:
+If one or more of these restrictions are supplied and the vmss_name is supplied, then the following checks will occur:
 
-1. Vault reaches out to the Azure API and checks that the VMSS exists. It uses the subscription id and resource group mandatory fields to make this call.  If the VMSS does exist it pulls metadata. If the VMSS does not exist in that subscription and resource group login fails.
-2. Vault checks `bound_scale_sets` restrictions if configured. Login fails if the scale set is not in the list.
-3. Vault checks that the VMSS has a managed identity. If it does not login fails.
-4. Vault checks that the managed identity in the JWT matches the managed identity on the VM. If it does not login fails.
-5. Vault checks `bound_subscription_ids` restrictions if configured. Login fails if the subscription is not in the list.
-6. Vault checks `bound_resource_groups` restrictions if configured. Login fails if the resource group is not in the list.
-7. Vault checks `bound_locations` restrictions if configured. Login fails if the location is not in the list.
+1. Vault reaches out to the Azure API and checks that the VMSS exists. It uses the subscription id and resource group mandatory fields to make this call.  If the VMSS does exist, it pulls the metadata. If the VMSS does not exist in that subscription and resource group, login fails.
+2. Vault checks `bound_scale_sets` restrictions if configured. Login fails if the scale set is not on the list.
+3. Vault checks that the VMSS has a managed identity. If it does not, login fails.
+4. Vault checks that the managed identity in the JWT matches the managed identity on the VM. If it does not, login fails.
+5. Vault checks `bound_subscription_ids` restrictions if it is configured. Login fails if the subscription is not on the list.
+6. Vault checks `bound_resource_groups` restrictions if it is configured. Login fails if the resource group is not on the list.
+7. Vault checks `bound_locations` restrictions if it is configured. Login fails if the location is not on the list.

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -407,13 +407,13 @@ There are 3 core flows and associated methods of restricting a role in the Azure
   
 The VM and VMSS-based restrictions can only be used for those resource types. If using Azure Kubernetes Service, Azure Container Instance, or some other resource type that supports a managed identity, you cannot apply the restrictions applicable to VM and VMSS.
   
-The restrictions that apply only to VM or VMSS are:
+The restrictions that apply only to VM or VMSS resource types are:
 - Locations `bound_locations`.
 - Subscriptions `bound_subscription_ids`.
 - Resource groups `bound_resource_groups`.
 - Scale sets `bound_scale_sets`. (VMSS only).
   
-The restrictions that apply to any resource type come from the JWT and these are:
+The restrictions that apply to any resource type are sourced from the JWT, these are:
 - Service principals `bound_service_principal_ids`.
 - Azure AD groups `bound_group_ids`.
   
@@ -427,8 +427,8 @@ The JWT flow occurs in all cases and there are some optional restrictions that c
 The JWT flow is:
 1. Vault validates the JWT with Azure. If the JWT is not valid, login fails.
 2. Vault validates the JWT is still valid according to its `NotBefore` time claim. If the `NotBefore’`claim is later than the current time, login fails.
-3. Vault checks Service Principal Ids restrictions if it is configured. Login fails if the service principal id from the JWT is not on the list. Note that Service Principal Ids restriction can be set to a single `*` record too and this check will be skipped.
-4. Vault checks Azure AD Group Ids restrictions if it is configured. Login fails if at least one of the groups claims from the JWT are not on the list. Note that Azure AD Group Ids restriction can be set to a single `*` record too and this check will be skipped.
+3. Vault checks `bound_principal_ids` restrictions if it is configured. Login fails if the service principal id from the JWT is not on the list. Note that Service Principal Ids restriction can be set to a single `*` record too and this check will be skipped.
+4. Vault checks `bound_group_ids` restrictions if it is configured. Login fails if at least one of the groups claims from the JWT are not on the list. Note that Azure AD Group Ids restriction can be set to a single `*` record too and this check will be skipped.
 
 ### VM Flow
 The VM flow is only applicable to virtual machines outside of a VMSS. This flow will not work for machines inside a scale set, which must use the VMSS flow. The VM flow can be used if any of these restrictions are applied:
@@ -438,7 +438,8 @@ The VM flow is only applicable to virtual machines outside of a VMSS. This flow 
   
 If none of these restrictions are supplied, then the vm_name field will be ignored on login.
   
-If one or more of these restrictions are supplied and the vm_name is supplied, then the follow checks will take place:
+If one or more of these restrictions are supplied and the vm_name is supplied, then the following checks will take place:
+  
 1. Vault reaches out to the Azure API and checks that the VM exists. It uses the subscription id and resource group mandatory fields to make this call.  If the VM does exist, it pulls the metadata. If the VM does not exist in that subscription and resource group, login fails.
 2. Vault checks that the VM has a managed identity. If it does not, login fails.
 3. Vault checks that the `bound_scale_sets` is not populated on the role. If it is, login fails.

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -29,7 +29,12 @@ The following documentation assumes that the method has been
 - A configured [Azure AD application](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-integrating-applications) which is used as the resource for generating MSI access tokens.
 - Client credentials (shared secret) for accessing the Azure Resource Manager with read access to compute endpoints. See [Azure AD Service to Service Client Credentials](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-service-to-service)
 
-Required Azure API permissions to be granted to Vault user:
+Required Azure API permissions to be granted to the Vault Service Principal:
+
+- `GroupMember.Read.All`
+- Admin consent is required for this permission.
+
+Optional Azure API permissions to be granted to the Vault Service Principal to use VM resource restrictions:
 
 - `Microsoft.Compute/virtualMachines/*/read`
 - `Microsoft.Compute/virtualMachineScaleSets/*/read`

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -396,9 +396,9 @@ namespace Examples
 This section provides more details about the authentication flows and associated restrictions that be supplied in the the role definition.
   
 There are 3 core flows and associated methods of restricting a role in the Azure Auth Method:
-- Identity based restrictions that use claims from the JWT.
-- Virtual Machine (VM) based restrictions that use data from the Virtual Machine.
-- Virtual Machine Scale Set (VMSS) based restrictions that use data from the Scale Set.
+- JWT Flow: Identity based restrictions that use claims from the JWT.
+- VM Flow: Virtual Machine (VM) based restrictions that use data from the Virtual Machine.
+- VMSS Flow: Virtual Machine Scale Set (VMSS) based restrictions that use data from the Virtual Machine Scale Set.
   
 The VM and VMSS based restrictions can only be used for those resource types. If using Azure Kubernetes Service, Azure Container Instance or some other resource type that supports a managed identity, you cannot apply the restrictions applicable to VM and VMSS.
   
@@ -421,7 +421,7 @@ The JWT flow happens in all cases and there are some optional restrictions that 
   
 The JWT flow is:
 1. Vault validates the JWT with Azure. If the JWT is not valid, login fails.
-2. Vault validates the JWT is still valid according to its Not Before time claim. If the ‘time before’ claim is  later than the current time, login fails.
+2. Vault validates the JWT is still valid according to its `NotBefore` time claim. If the ‘NotBefore’ claim is later than the current time, login fails.
 3. Vault checks Service Principal Ids restrictions if configured. Login fails if the service principal id from the JWT is not in the list. Note that Service Principal Ids restriction can be set to a single `*` record too and this check will be skipped.
 4. Vault checks Azure AD Group Ids restrictions if configured. Login fails if at least one of the groups claims from the JWT are not in the list. Note that Azure AD Group Ids restriction can be set to a single `*` record too and this check will be skipped.
 

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -403,7 +403,7 @@ This section provides more details about the authentication flows and associated
 There are 3 core flows and associated methods of restricting a role in the Azure Auth Method:
 - JWT Flow: Identity-based restrictions that use claims from the JWT.
 - VM Flow: Virtual Machine (VM) based restrictions that use data from the Virtual Machine.
-- VMSS Flow: Virtual Machine Scale Set (VMSS) based restrictions that use data from the Virtual Machine Scale Set.
+- VMSS Flow: Virtual Machine Scale Set (VMSS)-based restrictions that use data from the Virtual Machine Scale Set.
   
 The VM and VMSS based restrictions can only be used for those resource types. If using Azure Kubernetes Service, Azure Container Instance or some other resource type that supports a managed identity, you cannot apply the restrictions applicable to VM and VMSS.
   

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -398,7 +398,7 @@ namespace Examples
   
 ## Authentication Flows and Role Restrictions
   
-This section provides more details about the authentication flows and associated restrictions that be supplied in the the role definition.
+This section provides more details about the authentication flows and associated restrictions that can be supplied to the the role definition.
   
 There are 3 core flows and associated methods of restricting a role in the Azure Auth Method:
 - JWT Flow: Identity based restrictions that use claims from the JWT.


### PR DESCRIPTION
Expand the Azure Auth Method docs to cover common customer questions about the restrictions, permissions and login parameters which are missing from the existing docs.