### PR TITLE
Benchmark chain building

### DIFF
--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -40,7 +40,7 @@ func createBackendWithStorage(t testing.TB) (*backend, logical.Storage) {
 	return b, config.StorageView
 }
 
-func mountPKIEndpoint(t *testing.T, client *api.Client, path string) {
+func mountPKIEndpoint(t testing.TB, client *api.Client, path string) {
 	var err error
 	err = client.Sys().Mount(path, &api.MountInput{
 		Type: "pki",

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Setup helpers
-func createBackendWithStorage(t *testing.T) (*backend, logical.Storage) {
+func createBackendWithStorage(t testing.TB) (*backend, logical.Storage) {
 	config := logical.TestBackendConfig()
 	config.StorageView = &logical.InmemStorage{}
 


### PR DESCRIPTION
Per request in #15277... :-)

I ended up having to rewrite the code to use `createBackendWithStorage` rather than creating clusters as it was way too slow.

Results:

```
$ go test -v -run=BenchmarkChainBuilding -bench=. github.com/hashicorp/vault/builtin/logical/pki -cpuprofile profile.out
goos: linux
goarch: amd64
pkg: github.com/hashicorp/vault/builtin/logical/pki
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
BenchmarkChainBuilding
BenchmarkChainBuilding/test-case-0
BenchmarkChainBuilding/test-case-0-16         	     596	   2122381 ns/op
BenchmarkChainBuilding/test-case-1
BenchmarkChainBuilding/test-case-1-16         	    1105	   1099540 ns/op
BenchmarkChainBuilding/test-case-2
BenchmarkChainBuilding/test-case-2-16         	     495	   2341228 ns/op
BenchmarkChainBuilding/test-case-3
BenchmarkChainBuilding/test-case-3-16         	     480	   2469348 ns/op
BenchmarkChainBuilding/test-case-4
BenchmarkChainBuilding/test-case-4-16         	    1536	    758453 ns/op
BenchmarkChainBuilding/test-case-5
BenchmarkChainBuilding/test-case-5-16         	   49120	     24237 ns/op
BenchmarkChainBuilding/test-case-6
BenchmarkChainBuilding/test-case-6-16         	   10000	    125839 ns/op
BenchmarkChainBuilding/test-case-7
BenchmarkChainBuilding/test-case-7-16         	    5127	    236430 ns/op
BenchmarkChainBuilding/test-case-8
BenchmarkChainBuilding/test-case-8-16         	    2370	    507779 ns/op
```

Test cases are from the chain building tests, the call to `rebuildIssuersChains` is just benchmarked afterwards. 