### PR TITLE
Add DR Metric scraping capability to debug command

### DIFF
--- a/builtin/logical/transit/path_random.go
+++ b/builtin/logical/transit/path_random.go
@@ -2,6 +2,7 @@ package transit
 
 import (
 	"context"
+
 	"github.com/hashicorp/vault/helper/random"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"

--- a/changelog/15316.txt
+++ b/changelog/15316.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-cli: vault debug can now collect metrics from a DR Secondary cluster if unauthenticated metrics access is enabled
+cli/debug: added support for retrieving metrics from DR clusters if `unauthenticated_metrics_access` is enabled
 ```

--- a/changelog/15316.txt
+++ b/changelog/15316.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: vault debug can now collect metrics from a DR Secondary cluster if unauthenticated metrics access is enabled
+```

--- a/command/debug.go
+++ b/command/debug.go
@@ -58,6 +58,7 @@ type debugIndex struct {
 	Version                int                    `json:"version"`
 	VaultAddress           string                 `json:"vault_address"`
 	ClientVersion          string                 `json:"client_version"`
+	ServerVersion          string                 `json:"server_version"`
 	Timestamp              time.Time              `json:"timestamp"`
 	DurationSeconds        int                    `json:"duration_seconds"`
 	IntervalSeconds        int                    `json:"interval_seconds"`
@@ -245,6 +246,7 @@ func (c *DebugCommand) Run(args []string) int {
 	c.UI.Output("==> Starting debug capture...")
 	c.UI.Info(fmt.Sprintf("         Vault Address: %s", c.debugIndex.VaultAddress))
 	c.UI.Info(fmt.Sprintf("        Client Version: %s", c.debugIndex.ClientVersion))
+	c.UI.Info(fmt.Sprintf("        Server Version: %s", c.debugIndex.ServerVersion))
 	c.UI.Info(fmt.Sprintf("              Duration: %s", c.flagDuration))
 	c.UI.Info(fmt.Sprintf("              Interval: %s", c.flagInterval))
 	c.UI.Info(fmt.Sprintf("      Metrics Interval: %s", c.flagMetricsInterval))
@@ -412,8 +414,19 @@ func (c *DebugCommand) preflight(rawArgs []string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to create client to connect to Vault: %s", err)
 	}
-	if _, err := client.Sys().Health(); err != nil {
+	serverHealth, err := client.Sys().Health()
+	if err != nil {
 		return "", fmt.Errorf("unable to connect to the server: %s", err)
+	}
+
+	// Check if server is DR Secondary and we need to further
+	// ignore any targets due to endpoint restrictions
+	if serverHealth.ReplicationDRMode == "secondary" {
+		invalidDRTargets := strutil.Difference(c.flagTargets, c.validDRSecondaryTargets(), true)
+		if len(invalidDRTargets) != 0 {
+			c.UI.Info(fmt.Sprintf("Ignoring invalid targets for DR Secondary: %s", strings.Join(invalidDRTargets, ", ")))
+			c.flagTargets = strutil.Difference(c.flagTargets, invalidDRTargets, true)
+		}
 	}
 	c.cachedClient = client
 
@@ -469,6 +482,7 @@ func (c *DebugCommand) preflight(rawArgs []string) (string, error) {
 	c.debugIndex = &debugIndex{
 		VaultAddress:           client.Address(),
 		ClientVersion:          version.GetVersion().VersionNumber(),
+		ServerVersion:          serverHealth.Version,
 		Compress:               c.flagCompress,
 		DurationSeconds:        int(c.flagDuration.Seconds()),
 		IntervalSeconds:        int(c.flagInterval.Seconds()),
@@ -485,6 +499,10 @@ func (c *DebugCommand) preflight(rawArgs []string) (string, error) {
 
 func (c *DebugCommand) defaultTargets() []string {
 	return []string{"config", "host", "requests", "metrics", "pprof", "replication-status", "server-status", "log"}
+}
+
+func (c *DebugCommand) validDRSecondaryTargets() []string {
+	return []string{"metrics", "replication-status", "server-status"}
 }
 
 func (c *DebugCommand) captureStaticTargets() error {
@@ -685,21 +703,6 @@ func (c *DebugCommand) collectMetrics(ctx context.Context) {
 
 		c.logger.Info("capturing metrics", "count", idxCount)
 		idxCount++
-
-		healthStatus, err := c.cachedClient.Sys().Health()
-		if err != nil {
-			c.captureError("metrics", err)
-			continue
-		}
-
-		// Check replication status. We skip on processing metrics if we're one
-		// a DR node, though non-perf standbys will fail if they aren't using
-		// unauthenticated_metrics_access.
-		switch {
-		case healthStatus.ReplicationDRMode == "secondary":
-			c.logger.Info("skipping metrics capture on DR secondary node")
-			continue
-		}
 
 		// Perform metrics request
 		r := c.cachedClient.NewRequest("GET", "/v1/sys/metrics")

--- a/website/content/docs/commands/debug.mdx
+++ b/website/content/docs/commands/debug.mdx
@@ -58,7 +58,7 @@ Additionally, host information is not available on the OpenBSD platform due to
 library limitations in fetching the data without enabling `cgo`.
 
 [Enterprise] Telemetry can be gathered from a DR Secondary active node via the
-`metrics` target if [unauthenticated metrics access](docs/configuration/listener/tcp#unauthenticated_metrics_access) is enabled.
+`metrics` target if [unauthenticated metrics access](/docs/configuration/listener/tcp#unauthenticated_metrics_access) is enabled.
 
 ## Output Layout
 

--- a/website/content/docs/commands/debug.mdx
+++ b/website/content/docs/commands/debug.mdx
@@ -58,7 +58,7 @@ Additionally, host information is not available on the OpenBSD platform due to
 library limitations in fetching the data without enabling `cgo`.
 
 [Enterprise] Telemetry can be gathered from a DR Secondary active node via the
-`metrics` target if [unauthenticated metrics access](/docs/configuration/listener/tcp#unauthenticated_metrics_access) is enabled.
+`metrics` target if [unauthenticated_metrics_access](/docs/configuration/listener/tcp#unauthenticated_metrics_access) is enabled.
 
 ## Output Layout
 

--- a/website/content/docs/commands/debug.mdx
+++ b/website/content/docs/commands/debug.mdx
@@ -57,6 +57,9 @@ pertains to the local node and the request should not be forwarded.
 Additionally, host information is not available on the OpenBSD platform due to
 library limitations in fetching the data without enabling `cgo`.
 
+[Enterprise] Telemetry can be gathered from a DR Secondary active node via the
+`metrics` target if [unauthenticated metrics access](docs/configuration/listener/tcp#unauthenticated_metrics_access) is enabled.
+
 ## Output Layout
 
 The output of the bundled information, once decompressed, is contained within a


### PR DESCRIPTION
This PR adds the ability for `vault debug` to scrape telemetry data from a DR Secondary cluster if `unauthenticated_metrics_access` is enabled on the listener. Debug will also skip targets that are invalid against any DR Secondaries to avoid expected error noise.

Example:
```
❯ ./vault debug -duration=10s
Overwriting interval value "30s" to the duration value "10s"
Ignoring invalid targets for DR Secondary: config, host, log, pprof, requests
==> Starting debug capture...
         Vault Address: http://127.0.0.1:8202
        Client Version: 1.11.0-dev1
        Server Version: 1.10.0+ent
              Duration: 10s
              Interval: 10s
      Metrics Interval: 10s
               Targets: metrics, replication-status, server-status
                Output: vault-debug-2022-05-06T14-50-27Z.tar.gz

==> Capturing static information...

==> Capturing dynamic information...
2022-05-06T10:50:27.686-0400 [INFO]  capturing server status: count=0
2022-05-06T10:50:27.686-0400 [INFO]  capturing metrics: count=0
2022-05-06T10:50:27.686-0400 [INFO]  capturing replication status: count=0
2022-05-06T10:50:37.688-0400 [INFO]  capturing replication status: count=1
2022-05-06T10:50:37.688-0400 [INFO]  capturing server status: count=1
2022-05-06T10:50:37.689-0400 [INFO]  capturing metrics: count=1
Finished capturing information, bundling files...
Success! Bundle written to: vault-debug-2022-05-06T14-50-27Z.tar.gz
```