### PR TITLE
Use Get lookup within PKI resolveXXX functions instead of list iterations

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -332,7 +332,7 @@ func (b *backend) updatePkiStorageVersion(ctx context.Context) {
 		b.Logger().Info("PKI migration is required, reading cert bundle from legacy ca location")
 		b.pkiStorageVersion.Store(0)
 	} else {
-		b.Logger().Debug("PKI migration completed, reading cert bundle from key/issuer storage")
+		b.Logger().Debug("PKI migration previously completed, reading cert bundle from key/issuer storage")
 		b.pkiStorageVersion.Store(1)
 	}
 }

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -24,6 +24,9 @@ const (
 	legacyMigrationBundleLogKey = "config/legacyMigrationBundleLog"
 	legacyCertBundlePath        = "config/ca_bundle"
 	legacyCRLPath               = "crl"
+
+	// Used as a quick sanity check for a reference id lookups...
+	uuidLength = 36
 )
 
 type keyID string
@@ -412,19 +415,22 @@ func resolveKeyReference(ctx context.Context, s logical.Storage, reference strin
 		return config.DefaultKeyId, nil
 	}
 
-	keys, err := listKeys(ctx, s)
-	if err != nil {
-		return keyID("list-error"), err
-	}
-
-	// Cheaper to list keys and check if an id is a match...
-	for _, keyId := range keys {
-		if keyId == keyID(reference) {
-			return keyId, nil
+	// Lookup by a direct get first to see if our reference is an ID, this is quick and cached.
+	if len(reference) == uuidLength {
+		entry, err := s.Get(ctx, keyPrefix+reference)
+		if err != nil {
+			return keyID("key-read"), err
+		}
+		if entry != nil {
+			return keyID(reference), nil
 		}
 	}
 
 	// ... than to pull all keys from storage.
+	keys, err := listKeys(ctx, s)
+	if err != nil {
+		return keyID("list-error"), err
+	}
 	for _, keyId := range keys {
 		key, err := fetchKeyById(ctx, s, keyId)
 		if err != nil {
@@ -717,19 +723,23 @@ func resolveIssuerReference(ctx context.Context, s logical.Storage, reference st
 		return config.DefaultIssuerId, nil
 	}
 
+	// Lookup by a direct get first to see if our reference is an ID, this is quick and cached.
+	if len(reference) == uuidLength {
+		entry, err := s.Get(ctx, issuerPrefix+reference)
+		if err != nil {
+			return issuerID("issuer-read"), err
+		}
+		if entry != nil {
+			return issuerID(reference), nil
+		}
+	}
+
+	// ... than to pull all issuers from storage.
 	issuers, err := listIssuers(ctx, s)
 	if err != nil {
 		return issuerID("list-error"), err
 	}
 
-	// Cheaper to list issuers and check if an id is a match...
-	for _, issuerId := range issuers {
-		if issuerId == issuerID(reference) {
-			return issuerId, nil
-		}
-	}
-
-	// ... than to pull all issuers from storage.
 	for _, issuerId := range issuers {
 		issuer, err := fetchIssuerById(ctx, s, issuerId)
 		if err != nil {


### PR DESCRIPTION
 - Leverage a Get lookup operation to see if our reference field is a UUID
   instead of listing all key/issuers and iterating over the list.
 - This should be faster and we get a cached lookup possibly if it was a
   UUID entry that we previously loaded.
 - Address some small feedback about migration wording as well.