### PR TITLE
Use assumed role to authenticate on Vault

### DIFF
--- a/api/auth/aws/aws.go
+++ b/api/auth/aws/aws.go
@@ -271,3 +271,11 @@ func WithRegion(region string) LoginOption {
 		return nil
 	}
 }
+
+func WithCredentials(id, secret, token string) LoginOption {
+	return func(a *AWSAuth) error {
+		credentials := credentials.NewStaticCredentials(id, secret, token)
+		a.creds = credentials
+		return nil
+	}
+}


### PR DESCRIPTION
https://github.com/hashicorp/vault/issues/15317

The changes are simple. I would like to allow pass secrets and create credentials structure by myself (https://github.com/aws/aws-sdk-go/blob/main/aws/credentials/credentials.go#L209)

In result, this function (https://github.com/aws/aws-sdk-go/blob/main/aws/credentials/static_provider.go#L25) should create credentials structure and I pass it the AWSAuth structure.