### PR TITLE
Vault documentation: added disable parameter to seal stanza-related doc pages

### DIFF
--- a/website/content/docs/concepts/seal.mdx
+++ b/website/content/docs/concepts/seal.mdx
@@ -81,7 +81,7 @@ access to the root key shards.
 
 ## Auto Unseal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, the seal provider (HSM or cloud KMS) must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information. 
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, the seal provider (HSM or cloud KMS) must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
 
 Auto Unseal was developed to aid in reducing the operational complexity of
 keeping the unseal key secure. This feature delegates the responsibility of
@@ -130,8 +130,7 @@ available during the migration. For example, migration from Auto Unseal to Shami
 seal will require that the service backing the Auto Unseal is accessible during
 the migration.
 
-~> **NOTE**: Seal migration from Auto Unseal to Auto Unseal of the same type (e.g. AWSKMS to AWSKMS with a different key) is supported since Vault 1.6.0.
-Seal migration from One Auto Unseal type (AWS KMS) to different Auto Unseal type (HSM, Azure KMS, etc.) is also supported on older versions as well.
+~> **NOTE**: Seal migration from Auto Unseal to Auto Unseal of the same type is supported since Vault 1.6.0. However, there is a current limitation that prevents migrating from AWSKMS to AWSKMS; all other seal migrations of the same type are supported. Seal migration from One Auto Unseal type (AWS KMS) to different Auto Unseal type (HSM, Azure KMS, etc.) is also supported on older versions as well.
 
 ### Migration post Vault 1.5.1
 

--- a/website/content/docs/configuration/seal/alicloudkms.mdx
+++ b/website/content/docs/configuration/seal/alicloudkms.mdx
@@ -61,6 +61,10 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
   and decryption. May also be specified by the `VAULT_ALICLOUDKMS_SEAL_KEY_ID`
   environment variable.
 
+- `disabled` `(string: "")`: Set this to `true` if Vault is migrating from an auto seal configuration. Otherwise, set to `false`.
+
+Refer to the [Seal Migration](/docs/concepts/seal#seal-migration) documentation for more information about the seal migration process.
+
 ## Authentication
 
 Authentication-related values must be provided, either as environment

--- a/website/content/docs/configuration/seal/awskms.mdx
+++ b/website/content/docs/configuration/seal/awskms.mdx
@@ -59,11 +59,15 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
   and decryption. May also be specified by the `VAULT_AWSKMS_SEAL_KEY_ID`
   environment variable.
 
+- `disabled` `(string: "")`: Set this to `true` if Vault is migrating from an auto seal configuration. Otherwise, set to `false`.
+
 - `endpoint` `(string: "")`: The KMS API endpoint to be used to make AWS KMS
   requests. May also be specified by the `AWS_KMS_ENDPOINT` environment
   variable. This is useful, for example, when connecting to KMS over a [VPC
   Endpoint](https://docs.aws.amazon.com/kms/latest/developerguide/kms-vpc-endpoint.html).
   If not set, Vault will use the default API endpoint for your region.
+
+Refer to the [Seal Migration](/docs/concepts/seal#seal-migration) documentation for more information about the seal migration process.
 
 ## Authentication
 

--- a/website/content/docs/configuration/seal/azurekeyvault.mdx
+++ b/website/content/docs/configuration/seal/azurekeyvault.mdx
@@ -63,6 +63,11 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
   May also be specified in the `AZURE_AD_RESOURCE` environment variable.
   Needs to be changed to connect to Azure's Managed HSM KeyVault instance type.
 
+- `disabled` `(string: "")`: Set this to `true` if Vault is migrating from an auto seal configuration. Otherwise, set to `false`.
+
+Refer to the [Seal Migration](/docs/concepts/seal#seal-migration) documentation for more information about the seal migration process.
+
+
 ## Authentication
 
 Authentication-related values must be provided, either as environment

--- a/website/content/docs/configuration/seal/gcpckms.mdx
+++ b/website/content/docs/configuration/seal/gcpckms.mdx
@@ -10,7 +10,7 @@ description: >-
 
 # `gcpckms` Seal
 
--> **Note:** The Seal Wrap functionality is enabled by default. For this reason, the KMS service must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information. 
+-> **Note:** The Seal Wrap functionality is enabled by default. For this reason, the KMS service must be available throughout Vault's runtime and not just during the unseal process. Refer to the [Seal Wrap](/docs/enterprise/sealwrap) documenation for more information.
 
 The GCP Cloud KMS seal configures Vault to use GCP Cloud KMS as the seal
 wrapping mechanism. The GCP Cloud KMS seal is activated by one of the following:
@@ -59,6 +59,10 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
 - `crypto_key` `(string: <required>)`: The GCP CKMS crypto key to use for
   encryption and decryption. May also be specified by the
   `VAULT_GCPCKMS_SEAL_CRYPTO_KEY` environment variable.
+
+- `disabled` `(string: "")`: Set this to `true` if Vault is migrating from an auto seal configuration. Otherwise, set to `false`.
+
+Refer to the [Seal Migration](/docs/concepts/seal#seal-migration) documentation for more information about the seal migration process.
 
 ## Authentication &amp; Permissions
 

--- a/website/content/docs/configuration/seal/ocikms.mdx
+++ b/website/content/docs/configuration/seal/ocikms.mdx
@@ -49,6 +49,10 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
 - `auth_type_api_key` `(boolean: false)`: Specifies if using API key to authenticate to OCI KMS service.
   If it is `false`, Vault authenticates using the instance principal from the compute instance. See Authentication section for details. Default is `false`.
 
+- `disabled` `(string: "")`: Set this to `true` if Vault is migrating from an auto seal configuration. Otherwise, set to `false`.
+
+Refer to the [Seal Migration](/docs/concepts/seal#seal-migration) documentation for more information about the seal migration process.
+
 ## Authentication
 
 Authentication-related values must be provided, either as environment

--- a/website/content/docs/configuration/seal/pkcs11.mdx
+++ b/website/content/docs/configuration/seal/pkcs11.mdx
@@ -152,6 +152,10 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
   variable. This key is mainly to work around a limitation within AWS's CloudHSM v5
   pkcs11 implementation.
 
+- `disabled` `(string: "")`: Set this to `true` if Vault is migrating from an auto seal configuration. Otherwise, set to `false`.
+
+Refer to the [Seal Migration](/docs/concepts/seal#seal-migration) documentation for more information about the seal migration process.
+  
 ### Mechanism Specific Flags
 
 - `rsa_encrypt_local` `(string: "false")`: For HSMs that do not support encryption

--- a/website/content/docs/configuration/seal/transit.mdx
+++ b/website/content/docs/configuration/seal/transit.mdx
@@ -87,6 +87,10 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
   transmissions to and from the Vault server. This may also be specified using the
   `VAULT_SKIP_VERIFY` environment variable.
 
+- `disabled` `(string: "")`: Set this to `true` if Vault is migrating from an auto seal configuration. Otherwise, set to `false`.
+
+Refer to the [Seal Migration](/docs/concepts/seal#seal-migration) documentation for more information about the seal migration process.
+
 ## Authentication
 
 Authentication-related values must be provided, either as environment


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/1200328878173626/1202157875971193) and my conversation w/ Kevin, a number of pages mentioning the seal stanza have been updated to include the missing `disable` parameter. I modified the wording based on Kevin's initial suggestion so please let me know if the description for `disable` needs to be modified. Thanks.

