### PR TITLE
Return names for leaf_not_after_behavior responses

### DIFF
--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -156,6 +156,10 @@ func (b *backend) pathGetIssuer(ctx context.Context, req *logical.Request, data 
 		return nil, err
 	}
 
+	return respondReadIssuer(issuer)
+}
+
+func respondReadIssuer(issuer *issuerEntry) (*logical.Response, error) {
 	var respManualChain []string
 	for _, entity := range issuer.ManualChain {
 		respManualChain = append(respManualChain, string(entity))
@@ -169,7 +173,7 @@ func (b *backend) pathGetIssuer(ctx context.Context, req *logical.Request, data 
 			"certificate":             issuer.Certificate,
 			"manual_chain":            respManualChain,
 			"ca_chain":                issuer.CAChain,
-			"leaf_not_after_behavior": issuer.LeafNotAfterBehavior,
+			"leaf_not_after_behavior": issuer.LeafNotAfterBehavior.String(),
 			"usage":                   issuer.Usage.Names(),
 		},
 	}, nil
@@ -299,23 +303,7 @@ func (b *backend) pathUpdateIssuer(ctx context.Context, req *logical.Request, da
 		}
 	}
 
-	var respManualChain []string
-	for _, entity := range issuer.ManualChain {
-		respManualChain = append(respManualChain, string(entity))
-	}
-
-	return &logical.Response{
-		Data: map[string]interface{}{
-			"issuer_id":               issuer.ID,
-			"issuer_name":             issuer.Name,
-			"key_id":                  issuer.KeyID,
-			"certificate":             issuer.Certificate,
-			"manual_chain":            respManualChain,
-			"ca_chain":                issuer.CAChain,
-			"leaf_not_after_behavior": issuer.LeafNotAfterBehavior,
-			"usage":                   issuer.Usage.Names(),
-		},
-	}, nil
+	return respondReadIssuer(issuer)
 }
 
 func (b *backend) pathGetRawIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -689,6 +689,20 @@ const (
 	PermitNotAfterBehavior
 )
 
+var notAfterBehaviorNames = map[NotAfterBehavior]string{
+	ErrNotAfterBehavior:      "err",
+	TruncateNotAfterBehavior: "truncate",
+	PermitNotAfterBehavior:   "permit",
+}
+
+func (n NotAfterBehavior) String() string {
+	if name, ok := notAfterBehaviorNames[n]; ok && len(name) > 0 {
+		return name
+	}
+
+	return "unknown"
+}
+
 type CAInfoBundle struct {
 	ParsedCertBundle
 	URLs                 *URLEntries


### PR DESCRIPTION
Previously we'd return the raw enum value, which the entity accessing
the API wouldn't have any easy way of translating back into string
values. Return the string value directly instead.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`