### PR TITLE
docs: fix typo in example custom db plugin

### DIFF
--- a/website/content/docs/secrets/databases/custom.mdx
+++ b/website/content/docs/secrets/databases/custom.mdx
@@ -126,7 +126,7 @@ package main
 
 import (
 	"github.com/hashicorp/vault/api"
-	dbplugin "github.com/hashicorp/vault/sdk/database/v5"
+	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 )
 
 func main() {


### PR DESCRIPTION
I noticed when copy-pasting that it didn't compile. :)