### PR TITLE
Propagate context within UnwrapWithContext func

### DIFF
--- a/api/logical.go
+++ b/api/logical.go
@@ -323,7 +323,7 @@ func (c *Logical) UnwrapWithContext(ctx context.Context, wrappingToken string) (
 		c.c.SetToken(wrappingToken)
 	}
 
-	secret, err = c.Read(wrappedResponseLocation)
+	secret, err = c.ReadWithContext(ctx, wrappedResponseLocation)
 	if err != nil {
 		return nil, errwrap.Wrapf(fmt.Sprintf("error reading %q: {{err}}", wrappedResponseLocation), err)
 	}


### PR DESCRIPTION
Within `UnwrapWithContext(...)` we are calling `Logical().Read(...)` instead of the context-aware `Logical().ReadWithContext(ctx, ...)`, so the context is not propagated. A quick fix to correct this issue.