### PR TITLE
Fix revoking certificates in pre-migration state within PKI

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -707,30 +707,7 @@ func generateCSR(t *testing.T, csrTemplate *x509.CertificateRequest, keyType str
 }
 
 func generateCSRSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[string]interface{}) []logicaltest.TestStep {
-	csrTemplate := x509.CertificateRequest{
-		Subject: pkix.Name{
-			Country:      []string{"MyCountry"},
-			PostalCode:   []string{"MyPostalCode"},
-			SerialNumber: "MySerialNumber",
-			CommonName:   "my@example.com",
-		},
-		DNSNames: []string{
-			"name1.example.com",
-			"name2.example.com",
-			"name3.example.com",
-		},
-		EmailAddresses: []string{
-			"name1@example.com",
-			"name2@example.com",
-			"name3@example.com",
-		},
-		IPAddresses: []net.IP{
-			net.ParseIP("::ff:1:2:3:4"),
-			net.ParseIP("::ff:5:6:7:8"),
-		},
-	}
-
-	_, _, csrPem := generateCSR(t, &csrTemplate, "rsa", 2048)
+	csrTemplate, csrPem := generateTestCsr(t, certutil.RSAPrivateKey, 2048)
 
 	ret := []logicaltest.TestStep{
 		{
@@ -818,6 +795,34 @@ func generateCSRSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 		},
 	}
 	return ret
+}
+
+func generateTestCsr(t *testing.T, keyType certutil.PrivateKeyType, keyBits int) (x509.CertificateRequest, string) {
+	csrTemplate := x509.CertificateRequest{
+		Subject: pkix.Name{
+			Country:      []string{"MyCountry"},
+			PostalCode:   []string{"MyPostalCode"},
+			SerialNumber: "MySerialNumber",
+			CommonName:   "my@example.com",
+		},
+		DNSNames: []string{
+			"name1.example.com",
+			"name2.example.com",
+			"name3.example.com",
+		},
+		EmailAddresses: []string{
+			"name1@example.com",
+			"name2@example.com",
+			"name3@example.com",
+		},
+		IPAddresses: []net.IP{
+			net.ParseIP("::ff:1:2:3:4"),
+			net.ParseIP("::ff:5:6:7:8"),
+		},
+	}
+
+	_, _, csrPem := generateCSR(t, &csrTemplate, string(keyType), keyBits)
+	return csrTemplate, csrPem
 }
 
 // Generates steps to test out various role permutations

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -80,9 +80,32 @@ func getFormat(data *framework.FieldData) string {
 	return format
 }
 
-// fetchCAInfo will fetch the CA info, will return an error if no ca info exists.
+// fetchCAInfo will fetch the CA info, will return an error if no ca info exists, this does NOT support
+// loading using the legacyBundleShimID and should be used with care. This should be called only once
+// within the request path otherwise you run the risk of a race condition with the issuer migration on perf-secondaries.
 func fetchCAInfo(ctx context.Context, b *backend, req *logical.Request, issuerRef string, usage issuerUsage) (*certutil.CAInfoBundle, error) {
-	entry, bundle, err := fetchCertBundle(ctx, b, req.Storage, issuerRef)
+	var issuerId issuerID
+
+	if b.useLegacyBundleCaStorage() {
+		// We have not completed the migration so attempt to load the bundle from the legacy location
+		b.Logger().Info("Using legacy CA bundle as PKI migration has not completed.")
+		issuerId = legacyBundleShimID
+	} else {
+		var err error
+		issuerId, err = resolveIssuerReference(ctx, req.Storage, issuerRef)
+		if err != nil {
+			// Usually a bad label from the user or mis-configured default.
+			return nil, errutil.UserError{Err: err.Error()}
+		}
+	}
+
+	return fetchCAInfoByIssuerId(ctx, b, req, issuerId, usage)
+}
+
+// fetchCAInfoByIssuerId will fetch the CA info, will return an error if no ca info exists for the given issuerId.
+// This does support the loading using the legacyBundleShimID
+func fetchCAInfoByIssuerId(ctx context.Context, b *backend, req *logical.Request, issuerId issuerID, usage issuerUsage) (*certutil.CAInfoBundle, error) {
+	entry, bundle, err := fetchCertBundleByIssuerId(ctx, req.Storage, issuerId, true)
 	if err != nil {
 		switch err.(type) {
 		case errutil.UserError:
@@ -95,11 +118,7 @@ func fetchCAInfo(ctx context.Context, b *backend, req *logical.Request, issuerRe
 	}
 
 	if err := entry.EnsureUsage(usage); err != nil {
-		return nil, errutil.InternalError{Err: fmt.Sprintf("error while attempting to use issuer %v: %v", issuerRef, err)}
-	}
-
-	if bundle == nil {
-		return nil, errutil.UserError{Err: "no CA information is present"}
+		return nil, errutil.InternalError{Err: fmt.Sprintf("error while attempting to use issuer %v: %v", issuerId, err)}
 	}
 
 	parsedBundle, err := parseCABundle(ctx, b, req, bundle)
@@ -111,7 +130,7 @@ func fetchCAInfo(ctx context.Context, b *backend, req *logical.Request, issuerRe
 		return nil, errutil.InternalError{Err: "stored CA information not able to be parsed"}
 	}
 	if parsedBundle.PrivateKey == nil {
-		return nil, errutil.UserError{Err: fmt.Sprintf("unable to fetch corresponding key for issuer %v; unable to use this issuer for signing", issuerRef)}
+		return nil, errutil.UserError{Err: fmt.Sprintf("unable to fetch corresponding key for issuer %v; unable to use this issuer for signing", issuerId)}
 	}
 
 	caInfo := &certutil.CAInfoBundle{
@@ -134,27 +153,6 @@ func fetchCAInfo(ctx context.Context, b *backend, req *logical.Request, issuerRe
 	caInfo.URLs = entries
 
 	return caInfo, nil
-}
-
-// fetchCertBundle is our flex point to load either the legacy ca bundle if migration has yet to be
-// performed or load the bundle from the new key/issuer storage. Any function that needs a bundle
-// should load it using this method to maintain compatibility on secondary nodes for which their
-// primary's have not upgraded yet.
-// NOTE: This function can return a nil, nil response.
-func fetchCertBundle(ctx context.Context, b *backend, s logical.Storage, issuerRef string) (*issuerEntry, *certutil.CertBundle, error) {
-	if b.useLegacyBundleCaStorage() {
-		// We have not completed the migration so attempt to load the bundle from the legacy location
-		b.Logger().Info("Using legacy CA bundle as PKI migration has not completed.")
-		return getLegacyCertBundle(ctx, s)
-	}
-
-	id, err := resolveIssuerReference(ctx, s, issuerRef)
-	if err != nil {
-		// Usually a bad label from the user or misconfigured default.
-		return nil, nil, errutil.UserError{Err: err.Error()}
-	}
-
-	return fetchCertBundleByIssuerId(ctx, s, id, true)
 }
 
 // Allows fetching certificates from the backend; it handles the slightly

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -125,7 +125,7 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 	}
 
 	for _, issuer := range issuers {
-		signingBundle, caErr := fetchCAInfo(ctx, b, req, issuer.String(), ReadOnlyUsage)
+		signingBundle, caErr := fetchCAInfoByIssuerId(ctx, b, req, issuer, ReadOnlyUsage)
 		if caErr != nil {
 			switch caErr.(type) {
 			case errutil.UserError:
@@ -306,7 +306,7 @@ func buildCRLs(ctx context.Context, b *backend, req *logical.Request, forceNew b
 	for _, issuer := range issuers {
 		// We don't strictly need this call, but by requesting the bundle, the
 		// legacy path is automatically ignored.
-		thisEntry, _, err := fetchCertBundle(ctx, b, req.Storage, issuer.String())
+		thisEntry, _, err := fetchCertBundleByIssuerId(ctx, req.Storage, issuer, false)
 		if err != nil {
 			return fmt.Errorf("error building CRLs: unable to fetch specified issuer (%v): %v", issuer, err)
 		}
@@ -510,7 +510,7 @@ func getRevokedCertEntries(ctx context.Context, req *logical.Request, issuerIDCe
 
 		// If we have a CertificateIssuer field on the revocation entry,
 		// prefer it to manually checking each issuer signature, assuming it
-		// appears valid. Its highly unlikely for two different issuers
+		// appears valid. It's highly unlikely for two different issuers
 		// to have the same id (after the first was deleted).
 		if len(revInfo.CertificateIssuer) > 0 {
 			issuerId := revInfo.CertificateIssuer
@@ -596,17 +596,7 @@ func buildCRL(ctx context.Context, b *backend, req *logical.Request, forceNew bo
 	revokedCerts = revoked
 
 WRITE:
-	_, bundle, caErr := fetchCertBundleByIssuerId(ctx, req.Storage, thisIssuerId, true /* need the signing key */)
-	if caErr != nil {
-		switch caErr.(type) {
-		case errutil.UserError:
-			return errutil.UserError{Err: fmt.Sprintf("could not fetch the CA certificate: %s", caErr)}
-		default:
-			return errutil.InternalError{Err: fmt.Sprintf("error fetching CA certificate: %s", caErr)}
-		}
-	}
-
-	signingBundle, caErr := parseCABundle(ctx, b, req, bundle)
+	signingBundle, caErr := fetchCAInfoByIssuerId(ctx, b, req, thisIssuerId, CRLSigningUsage)
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/path_config_ca.go
+++ b/builtin/logical/pki/path_config_ca.go
@@ -97,6 +97,10 @@ func pathReplaceRoot(b *backend) *framework.Path {
 }
 
 func (b *backend) pathCAIssuersRead(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Cannot read defaults until migration has completed"), nil
+	}
+
 	config, err := getIssuersConfig(ctx, req.Storage)
 	if err != nil {
 		return logical.ErrorResponse("Error loading issuers configuration: " + err.Error()), nil
@@ -114,6 +118,10 @@ func (b *backend) pathCAIssuersWrite(ctx context.Context, req *logical.Request, 
 	// got a consistent view.
 	b.issuersLock.Lock()
 	defer b.issuersLock.Unlock()
+
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Cannot update defaults until migration has completed"), nil
+	}
 
 	newDefault := data.Get(defaultRef).(string)
 	if len(newDefault) == 0 || newDefault == defaultRef {
@@ -192,6 +200,10 @@ func pathConfigKeys(b *backend) *framework.Path {
 }
 
 func (b *backend) pathKeyDefaultRead(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Cannot read key defaults until migration has completed"), nil
+	}
+
 	config, err := getKeysConfig(ctx, req.Storage)
 	if err != nil {
 		return logical.ErrorResponse("Error loading keys configuration: " + err.Error()), nil
@@ -209,6 +221,10 @@ func (b *backend) pathKeyDefaultWrite(ctx context.Context, req *logical.Request,
 	// got a consistent view.
 	b.issuersLock.Lock()
 	defer b.issuersLock.Unlock()
+
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("Cannot update key defaults until migration has completed"), nil
+	}
 
 	newDefault := data.Get(defaultRef).(string)
 	if len(newDefault) == 0 || newDefault == defaultRef {

--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -174,12 +174,14 @@ func getLegacyCertBundle(ctx context.Context, s logical.Storage) (*issuerEntry, 
 		return nil, nil, err
 	}
 
-	// Fake a storage entry with backwards compatibility in mind. We only need
-	// the fields in the CAInfoBundle; everything else doesn't matter.
+	// Fake a storage entry with backwards compatibility in mind.
 	issuer := &issuerEntry{
 		ID:                   legacyBundleShimID,
 		KeyID:                legacyBundleShimKeyID,
 		Name:                 "legacy-entry-shim",
+		Certificate:          cb.Certificate,
+		CAChain:              cb.CAChain,
+		SerialNumber:         cb.SerialNumber,
 		LeafNotAfterBehavior: certutil.ErrNotAfterBehavior,
 	}
 	issuer.Usage.ToggleUsage(IssuanceUsage, CRLSigningUsage)

--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -107,7 +107,10 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 	require.Equal(t, bundle.SerialNumber, issuer.SerialNumber)
 	require.Equal(t, strings.TrimSpace(bundle.Certificate), strings.TrimSpace(issuer.Certificate))
 	require.Equal(t, keyId, issuer.KeyID)
-	// FIXME: Add tests for CAChain...
+	require.Empty(t, issuer.ManualChain)
+	require.Equal(t, []string{bundle.Certificate + "\n"}, issuer.CAChain)
+	require.Equal(t, AllIssuerUsages, issuer.Usage)
+	require.Equal(t, certutil.ErrNotAfterBehavior, issuer.LeafNotAfterBehavior)
 
 	require.Equal(t, keyId, key.ID)
 	require.Equal(t, strings.TrimSpace(bundle.PrivateKey), strings.TrimSpace(key.PrivateKey))
@@ -138,4 +141,250 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 	require.Equal(t, logEntry.Hash, logEntry2.Hash)
 
 	require.False(t, b.useLegacyBundleCaStorage(), "post migration we are still told to use legacy storage")
+}
+
+func TestExpectedOpsWork_PreMigration(t *testing.T) {
+	ctx := context.Background()
+	b, s := createBackendWithStorage(t)
+	// Reset the version the helper above set to 1.
+	b.pkiStorageVersion.Store(0)
+	require.True(t, b.useLegacyBundleCaStorage(), "pre migration we should have been told to use legacy storage.")
+
+	bundle := genCertBundle(t, b, s)
+	json, err := logical.StorageEntryJSON(legacyCertBundlePath, bundle)
+	require.NoError(t, err)
+	err = s.Put(ctx, json)
+	require.NoError(t, err)
+
+	// generate role
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "roles/allow-all",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"allow_any_name": "true",
+			"no_store":       "false",
+		},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "error from creating role")
+	require.Nil(t, resp, "got non-nil response object from creating role")
+
+	// List roles
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation:  logical.ListOperation,
+		Path:       "roles",
+		Storage:    s,
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "error from listing roles")
+	require.NotNil(t, resp, "got nil response object from listing roles")
+	require.False(t, resp.IsError(), "got error response from listing roles: %#v", resp)
+	require.Contains(t, resp.Data["keys"], "allow-all", "failed to list our roles")
+
+	// Read roles
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation:  logical.ReadOperation,
+		Path:       "roles/allow-all",
+		Storage:    s,
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "error from reading role")
+	require.NotNil(t, resp, "got nil response object from reading role")
+	require.False(t, resp.IsError(), "got error response from reading role: %#v", resp)
+	require.NotEmpty(t, resp.Data, "data map should not have been empty of reading role")
+
+	// Issue a cert from our legacy bundle.
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "issue/allow-all",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"common_name": "test.com",
+			"ttl":         "60s",
+		},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "error issue on allow-all")
+	require.NotNil(t, resp, "got nil response object from issue allow-all")
+	require.False(t, resp.IsError(), "got error response from issue on allow-all: %#v", resp)
+	serialNum := resp.Data["serial_number"].(string)
+	require.NotEmpty(t, serialNum)
+
+	// Make sure we can list
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation:  logical.ListOperation,
+		Path:       "certs",
+		Storage:    s,
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "error listing certs")
+	require.NotNil(t, resp, "got nil response object from listing certs")
+	require.False(t, resp.IsError(), "got error response from listing certs: %#v", resp)
+	require.Contains(t, resp.Data["keys"], serialNum, "failed to list our cert")
+
+	// Revoke the cert now.
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "revoke",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"serial_number": serialNum,
+		},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "error revoking cert")
+	require.NotNil(t, resp, "got nil response object from revoke cert")
+	require.False(t, resp.IsError(), "got error response from revoke cert: %#v", resp)
+
+	// Check our CRL includes the revoked cert.
+	resp = requestCrlFromBackend(t, s, b)
+	crl := parseCrlPemBytes(t, resp.Data["http_raw_body"].([]byte))
+	requireSerialNumberInCRL(t, crl, serialNum)
+
+	// Set CRL config
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/crl",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"expiry":  "72h",
+			"disable": "false",
+		},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "error setting CRL config")
+	require.Nil(t, resp, "got non-nil response setting CRL config")
+
+	// Set URL config
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/urls",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"ocsp_servers": []string{"https://localhost:8080"},
+		},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "error setting URL config")
+	require.Nil(t, resp, "got non-nil response setting URL config")
+
+	// Make sure we can fetch the old values...
+	for _, path := range []string{"ca/pem", "ca_chain", "cert/" + serialNum, "cert/ca", "cert/crl", "cert/ca_chain", "config/crl", "config/urls"} {
+		resp, err = b.HandleRequest(context.Background(), &logical.Request{
+			Operation:  logical.ReadOperation,
+			Path:       path,
+			Storage:    s,
+			MountPoint: "pki/",
+		})
+		require.NoError(t, err, "error reading cert %s", path)
+		require.NotNil(t, resp, "got nil response object from reading cert %s", path)
+		require.False(t, resp.IsError(), "got error response from reading cert %s: %#v", path, resp)
+	}
+
+	// Sign CSR
+	_, csr := generateTestCsr(t, certutil.ECPrivateKey, 224)
+	for _, path := range []string{"sign/allow-all", "root/sign-intermediate", "sign-verbatim"} {
+		resp, err = b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      path,
+			Storage:   s,
+			Data: map[string]interface{}{
+				"csr": csr,
+			},
+			MountPoint: "pki/",
+		})
+		require.NoError(t, err, "error signing csr from path %s", path)
+		require.NotNil(t, resp, "got nil response object from path %s", path)
+		require.NotEmpty(t, resp.Data, "data map response was empty from path %s", path)
+	}
+
+	// Sign self-issued
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "root/sign-self-issued",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"certificate": csr,
+		},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "error signing csr from path root/sign-self-issued")
+	require.NotNil(t, resp, "got nil response object from path root/sign-self-issued")
+	require.NotEmpty(t, resp.Data, "data map response was empty from path root/sign-self-issued")
+
+	// Delete Role
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation:  logical.DeleteOperation,
+		Path:       "roles/allow-all",
+		Storage:    s,
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "error deleting role")
+	require.Nil(t, resp, "got non-nil response object from deleting role")
+
+	// Delete Root
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation:  logical.DeleteOperation,
+		Path:       "root",
+		Storage:    s,
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "error deleting root")
+	require.NotNil(t, resp, "got nil response object from deleting root")
+	require.NotEmpty(t, resp.Warnings, "expected warnings set on delete root")
+
+	///////////////////////////////
+	// Legacy calls we expect to fail when in migration mode
+	///////////////////////////////
+	requireFailInMigration(t, b, s, logical.UpdateOperation, "config/ca")
+	requireFailInMigration(t, b, s, logical.UpdateOperation, "intermediate/generate/internal")
+	requireFailInMigration(t, b, s, logical.UpdateOperation, "intermediate/set-signed")
+	requireFailInMigration(t, b, s, logical.UpdateOperation, "root/generate/internal")
+
+	///////////////////////////////
+	// New apis should be unavailable
+	///////////////////////////////
+	requireFailInMigration(t, b, s, logical.ListOperation, "issuers")
+	requireFailInMigration(t, b, s, logical.UpdateOperation, "issuers/generate/root/internal")
+	requireFailInMigration(t, b, s, logical.UpdateOperation, "issuers/generate/intermediate/internal")
+	requireFailInMigration(t, b, s, logical.UpdateOperation, "issuers/import/cert")
+	requireFailInMigration(t, b, s, logical.ReadOperation, "issuer/default/json")
+	requireFailInMigration(t, b, s, logical.ReadOperation, "issuer/default/crl/pem")
+	requireFailInMigration(t, b, s, logical.UpdateOperation, "issuer/test-role")
+
+	// The following calls work as they are shared handlers with existing paths.
+	// requireFailInMigration(t, b, s, logical.UpdateOperation, "issuer/default/issue/test-role")
+	// requireFailInMigration(t, b, s, logical.UpdateOperation, "issuer/default/sign/test-role")
+	// requireFailInMigration(t, b, s, logical.UpdateOperation, "issuer/default/sign-verbatim")
+	// requireFailInMigration(t, b, s, logical.UpdateOperation, "issuer/default/sign-self-issued")
+
+	requireFailInMigration(t, b, s, logical.UpdateOperation, "root/replace")
+	requireFailInMigration(t, b, s, logical.UpdateOperation, "root/rotate/internal")
+	requireFailInMigration(t, b, s, logical.UpdateOperation, "intermediate/cross-sign")
+
+	requireFailInMigration(t, b, s, logical.UpdateOperation, "config/issuers")
+	requireFailInMigration(t, b, s, logical.ReadOperation, "config/issuers")
+
+	requireFailInMigration(t, b, s, logical.ListOperation, "keys")
+	requireFailInMigration(t, b, s, logical.UpdateOperation, "keys/generate/internal")
+	requireFailInMigration(t, b, s, logical.UpdateOperation, "keys/import")
+	requireFailInMigration(t, b, s, logical.ReadOperation, "key/default")
+	requireFailInMigration(t, b, s, logical.UpdateOperation, "config/keys")
+	requireFailInMigration(t, b, s, logical.ReadOperation, "config/keys")
+}
+
+// requireFailInMigration validate that we fail the operation with the appropriate error message to the end-user
+func requireFailInMigration(t *testing.T, b *backend, s logical.Storage, operation logical.Operation, path string) {
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation:  operation,
+		Path:       path,
+		Storage:    s,
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "error from op:%s path:%s", operation, path)
+	require.NotNil(t, resp, "got nil response from op:%s path:%s", operation, path)
+	require.True(t, resp.IsError(), "error flag was not set from op:%s path:%s resp: %#v", operation, path, resp)
+	require.Contains(t, resp.Error().Error(), "migration has completed",
+		"error message did not contain migration test for op:%s path:%s resp: %#v", operation, path, resp)
 }


### PR DESCRIPTION
This PR addresses some issues found when testing revoking certificates in a pre-migration state. The first commit addresses that issue and the second adds a suite of tests that validate all apis' behaviour within the pre-migration state, so it will be harder to regress them in the future. 

As part of the test suite some fixes were needed, mainly adding some missing assertions within the codebase that we aren't in legacy storage mode and one issue with a defined operation.

This PR was built on top of the many in-flight, so the following PRs will need to be merged prior to this one I believe.

#15285, #15289, #15303, #15306, #15315, #15319, #15322, #15325, #15336