### PR TITLE
UI/ fix firefox not recognizing csv export

### DIFF
--- a/changelog/15364.txt
+++ b/changelog/15364.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fix firefox inability to recognize file format of client count csv export
+```

--- a/ui/app/services/download-csv.js
+++ b/ui/app/services/download-csv.js
@@ -8,7 +8,8 @@ import Service from '@ember/service';
 
 export default class DownloadCsvService extends Service {
   download(filename, content) {
-    let formattedFilename = filename?.replace(/\s+/g, '-') || 'vault-data.csv';
+    // even though Blob type 'text/csv' is specified below, some browsers (ex. Firefox) require the filename has an explicit extension
+    let formattedFilename = `${filename?.replace(/\s+/g, '-')}.csv` || 'vault-data.csv';
     let { document, URL } = window;
     let downloadElement = document.createElement('a');
     downloadElement.download = formattedFilename;


### PR DESCRIPTION
Without the explicit `.csv` extension in the filename, Firefox doesn't recognize the download file type.