### PR TITLE
Disabling client side rate limiting in Okta login MFA client

### DIFF
--- a/changelog/15369.txt
+++ b/changelog/15369.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+mfa/okta: disable client side rate limiting causing delays in push notifications
+```

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -1825,6 +1825,8 @@ func (c *Core) validateOkta(ctx context.Context, mConfig *mfa.Config, username s
 	} else {
 		client = okta.NewClient(cleanhttp.DefaultClient(), oktaConfig.OrgName, oktaConfig.APIToken, oktaConfig.Production)
 	}
+	// Disable client side rate limiting
+	client.RateRemainingFloor = 0
 
 	var filterOpts *okta.UserListFilterOptions
 	if oktaConfig.PrimaryEmail {


### PR DESCRIPTION
The behavior of the login MFA is currently limited due to the client side rate limiting happening in the SDK. This SDK is older and there may be a change in the API behavior that is not fully accounted for in this client. 