### PR TITLE
Remove 1.11-only mount flag syntax

### DIFF
--- a/website/content/docs/secrets/kv/kv-v2.mdx
+++ b/website/content/docs/secrets/kv/kv-v2.mdx
@@ -165,17 +165,12 @@ After the secrets engine is configured and a user/machine has a Vault token with
 the proper permission, it can generate credentials. The `kv` secrets engine
 allows for writing keys with arbitrary values.
 
-The path-like KV-v1 syntax for referencing a secret (`secret/foo`) can still
-be used in KV-v2, but we recommend using the `-mount=secret` flag syntax to
-avoid mistaking it for the actual path to the secret (`secret/data/foo` is the
-real path).
-
 ### Writing/Reading arbitrary data
 
 1. Write arbitrary data:
 
    ```shell-session
-   $ vault kv put -mount=secret my-secret foo=a bar=b
+   $ vault kv put secret/my-secret foo=a bar=b
    Key              Value
    ---              -----
    created_time     2019-06-19T17:20:22.985303Z
@@ -188,7 +183,7 @@ real path).
 1. Read arbitrary data:
 
    ```shell-session
-   $ vault kv get -mount=secret my-secret
+   $ vault kv get secret/my-secret
    ====== Metadata ======
    Key              Value
    ---              -----
@@ -213,7 +208,7 @@ real path).
    cas parameter.
 
    ```shell-session
-   $ vault kv put -mount=secret -cas=1 my-secret foo=aa bar=bb
+   $ vault kv put -cas=1 secret/my-secret foo=aa bar=bb
    Key              Value
    ---              -----
    created_time     2019-06-19T17:22:23.369372Z
@@ -226,7 +221,7 @@ real path).
 1. Reading now will return the newest version of the data:
 
    ```shell-session
-   $ vault kv get -mount=secret my-secret
+   $ vault kv get secret/my-secret
    ====== Metadata ======
    Key              Value
    ---              -----
@@ -256,7 +251,7 @@ real path).
    the read to perform a check-and-set operation in the subsequent write.
 
    ```shell-session
-   $ vault kv patch -mount=secret -cas=2 my-secret bar=bbb
+   $ vault kv patch -cas=2 secret/my-secret bar=bbb
    Key              Value
    ---              -----
    created_time     2019-06-19T17:23:49.199802Z
@@ -273,7 +268,7 @@ real path).
    Perform a patch using the `patch` method:
 
    ```shell-session
-   $ vault kv patch -mount=secret -method=patch -cas=2 my-secret bar=bbb
+   $ vault kv patch -method=patch -cas=2 secret/my-secret bar=bbb
    Key              Value
    ---              -----
    created_time     2019-06-19T17:23:49.199802Z
@@ -286,7 +281,7 @@ real path).
    Perform a patch using the read-then-write method:
 
    ```shell-session
-   $ vault kv patch -mount=secret -method=rw my-secret bar=bbb
+   $ vault kv patch -method=rw secret/my-secret bar=bbb
    Key              Value
    ---              -----
    created_time     2019-06-19T17:23:49.199802Z
@@ -300,7 +295,7 @@ real path).
    only the specified fields were updated:
 
    ```shell-session
-   $ vault kv get -mount=secret my-secret
+   $ vault kv get secret/my-secret
    ====== Metadata ======
    Key              Value
    ---              -----
@@ -320,7 +315,7 @@ real path).
 3. Previous versions can be accessed with the `-version` flag:
 
    ```shell-session
-   $ vault kv get -mount=secret -version=1 my-secret
+   $ vault kv get -version=1 secret/my-secret
    ====== Metadata ======
    Key              Value
    ---              -----
@@ -357,17 +352,17 @@ See the commands below for more information:
    takes a `-versions` flag to delete prior versions:
 
    ```shell-session
-   $ vault kv delete -mount=secret my-secret
+   $ vault kv delete secret/my-secret
    Success! Data deleted (if it existed) at: secret/data/my-secret
    ```
 
 1. Versions can be undeleted:
 
    ```shell-session
-   $ vault kv undelete -mount=secret -versions=2 my-secret
+   $ vault kv undelete -versions=2 secret/my-secret
    Success! Data written to: secret/undelete/my-secret
 
-   $ vault kv get -mount=secret my-secret
+   $ vault kv get secret/my-secret
    ====== Metadata ======
    Key              Value
    ---              -----
@@ -386,7 +381,7 @@ See the commands below for more information:
 1. Destroying a version permanently deletes the underlying data:
 
    ```shell-session
-   $ vault kv destroy -mount=secret -versions=2 my-secret
+   $ vault kv destroy -versions=2 secret/my-secret
    Success! Data written to: secret/destroy/my-secret
    ```
 
@@ -401,7 +396,7 @@ See the commands below for more information:
 1. All metadata and versions for a key can be viewed:
 
    ```shell-session
-   $ vault kv metadata get -mount=secret my-secret
+   $ vault kv metadata get secret/my-secret
    ========== Metadata ==========
    Key                     Value
    ---                     -----
@@ -432,7 +427,7 @@ See the commands below for more information:
 1. The metadata settings for a key can be configured:
 
    ```shell-session
-   $ vault kv metadata put -mount=secret -max-versions 2 -delete-version-after="3h25m19s" my-secret
+   $ vault kv metadata put -max-versions 2 -delete-version-after="3h25m19s" secret/my-secret
    Success! Data written to: secret/metadata/my-secret
    ```
 
@@ -440,7 +435,7 @@ See the commands below for more information:
    changes will be applied on next write:
 
    ```shell-session
-   $ vault kv put -mount=secret my-secret my-value=newer-s3cr3t
+   $ vault kv put secret/my-secret my-value=newer-s3cr3t
    Key              Value
    ---              -----
    created_time     2019-06-19T17:31:16.662563Z
@@ -454,7 +449,7 @@ See the commands below for more information:
    are cleaned up:
 
    ```shell-session
-   $ vault kv metadata get -mount=secret my-secret
+   $ vault kv metadata get secret/my-secret
    ========== Metadata ==========
    Key                     Value
    ---                     -----
@@ -489,10 +484,10 @@ See the commands below for more information:
    The `vault kv metadata put` command can be used to fully overwrite the value of `custom_metadata`:
 
    ```shell-session
-   $ vault kv metadata put -mount=secret -custom-metadata=foo=abc -custom-metadata=bar=123 my-secret
+   $ vault kv metadata put -custom-metadata=foo=abc -custom-metadata=bar=123 secret/my-secret
    Success! Data written to: secret/metadata/my-secret
 
-   $ vault kv get -mount=secret my-secret
+   $ vault kv get secret/my-secret
    ====== Metadata ======
    Key              Value
    ---              -----
@@ -513,10 +508,10 @@ See the commands below for more information:
    The following invocation will update `custom_metadata` sub-field `foo` but leave `bar` untouched:
 
    ```shell-session
-   $ vault kv metadata patch -mount=secret -custom-metadata=foo=def my-secret
+   $ vault kv metadata patch -custom-metadata=foo=def secret/my-secret
    Success! Data written to: secret/metadata/my-secret
 
-   $ vault kv get -mount=secret my-secret
+   $ vault kv get secret/my-secret
    ====== Metadata ======
    Key              Value
    ---              -----
@@ -536,7 +531,7 @@ See the commands below for more information:
 1. Permanently delete all metadata and versions for a key:
 
    ```shell-session
-   $ vault kv metadata delete -mount=secret my-secret
+   $ vault kv metadata delete secret/my-secret
    Success! Data deleted (if it existed) at: secret/metadata/my-secret
    ```
 


### PR DESCRIPTION
This is a manual fix of a previous cherry-pick commit that accidentally pulled these 1.11-specific docs changes into the 1.10.x docs.