### PR TITLE
Consistent consul secrets parameter names

### DIFF
--- a/builtin/logical/consul/backend_test.go
+++ b/builtin/logical/consul/backend_test.go
@@ -174,7 +174,6 @@ func testBackendRenewRevoke(t *testing.T, version string) {
 	if err := mapstructure.Decode(resp.Data, &d); err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("Generated token: %s", d.Token)
 
 	// Build a client and verify that the credentials work
 	consulapiConfig := consulapi.DefaultConfig()
@@ -185,7 +184,6 @@ func testBackendRenewRevoke(t *testing.T, version string) {
 		t.Fatal(err)
 	}
 
-	t.Logf("Verifying that the generated token works...")
 	_, err = client.KV().Put(&consulapi.KVPair{
 		Key:   "foo",
 		Value: []byte("bar"),
@@ -210,7 +208,6 @@ func testBackendRenewRevoke(t *testing.T, version string) {
 		t.Fatal(err)
 	}
 
-	t.Logf("Verifying that the generated token does not work...")
 	_, err = client.KV().Put(&consulapi.KVPair{
 		Key:   "foo",
 		Value: []byte("bar"),
@@ -271,7 +268,6 @@ func testBackendRenewRevoke14(t *testing.T, version string, policiesParam string
 	}
 	roleResp, err := b.HandleRequest(context.Background(), read)
 
-	t.Logf("Response consul_policies '%s' should match '[test]'", roleResp.Data["consul_policies"])
 	expectExtract := roleResp.Data["consul_policies"]
 	respExtract := roleResp.Data[policiesParam]
 	if respExtract != nil {
@@ -303,7 +299,6 @@ func testBackendRenewRevoke14(t *testing.T, version string, policiesParam string
 	if err := mapstructure.Decode(resp.Data, &d); err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("Generated token: %s with accessor %s", d.Token, d.Accessor)
 
 	// Build a client and verify that the credentials work
 	consulapiConfig := consulapi.DefaultNonPooledConfig()
@@ -314,7 +309,6 @@ func testBackendRenewRevoke14(t *testing.T, version string, policiesParam string
 		t.Fatal(err)
 	}
 
-	t.Log("Verifying that the generated token works...")
 	_, err = client.Catalog(), nil
 	if err != nil {
 		t.Fatal(err)
@@ -348,7 +342,6 @@ func testBackendRenewRevoke14(t *testing.T, version string, policiesParam string
 		Datacenter: "DC1",
 	}
 
-	t.Log("Verifying that the generated token does not exist...")
 	_, _, err = mgmtclient.ACL().TokenRead(d.Accessor, q)
 	if err == nil {
 		t.Fatal("err: expected error")
@@ -425,7 +418,6 @@ func TestBackend_LocalToken(t *testing.T) {
 	if err := mapstructure.Decode(resp.Data, &d); err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("Generated token: %s with accessor %s", d.Token, d.Accessor)
 
 	if d.Local {
 		t.Fatalf("requested global token, got local one")
@@ -440,7 +432,6 @@ func TestBackend_LocalToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Log("Verifying that the generated token works...")
 	_, err = client.Catalog(), nil
 	if err != nil {
 		t.Fatal(err)
@@ -462,7 +453,6 @@ func TestBackend_LocalToken(t *testing.T) {
 	if err := mapstructure.Decode(resp.Data, &d); err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("Generated token: %s with accessor %s", d.Token, d.Accessor)
 
 	if !d.Local {
 		t.Fatalf("requested local token, got global one")
@@ -477,7 +467,6 @@ func TestBackend_LocalToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Log("Verifying that the generated token works...")
 	_, err = client.Catalog(), nil
 	if err != nil {
 		t.Fatal(err)
@@ -805,7 +794,6 @@ func TestBackend_Roles(t *testing.T) {
 	if err := mapstructure.Decode(resp.Data, &d); err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("Generated consul_roles token: %s with accessor %s", d.Token, d.Accessor)
 
 	// Build a client and verify that the credentials work
 	consulapiConfig := consulapi.DefaultNonPooledConfig()
@@ -816,7 +804,6 @@ func TestBackend_Roles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Log("Verifying that the generated token works...")
 	_, err = client.Catalog(), nil
 	if err != nil {
 		t.Fatal(err)
@@ -850,7 +837,6 @@ func TestBackend_Roles(t *testing.T) {
 		Datacenter: "DC1",
 	}
 
-	t.Log("Verifying that the generated token does not exist...")
 	_, _, err = mgmtclient.ACL().TokenRead(d.Accessor, q)
 	if err == nil {
 		t.Fatal("err: expected error")
@@ -936,7 +922,6 @@ func testBackendEntNamespace(t *testing.T) {
 	if err := mapstructure.Decode(resp.Data, &d); err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("Generated namespace '%s' token: %s with accessor %s", d.ConsulNamespace, d.Token, d.Accessor)
 
 	if d.ConsulNamespace != "ns1" {
 		t.Fatalf("Failed to access namespace")
@@ -951,7 +936,6 @@ func testBackendEntNamespace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Log("Verifying that the generated token works...")
 	_, err = client.Catalog(), nil
 	if err != nil {
 		t.Fatal(err)
@@ -986,7 +970,6 @@ func testBackendEntNamespace(t *testing.T) {
 		Namespace:  "ns1",
 	}
 
-	t.Log("Verifying that the generated token does not exist...")
 	_, _, err = mgmtclient.ACL().TokenRead(d.Accessor, q)
 	if err == nil {
 		t.Fatal("err: expected error")
@@ -1056,7 +1039,6 @@ func testBackendEntPartition(t *testing.T) {
 	if err := mapstructure.Decode(resp.Data, &d); err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("Generated partition '%s' token: %s with accessor %s", d.Partition, d.Token, d.Accessor)
 
 	if d.Partition != "part1" {
 		t.Fatalf("Failed to access partition")
@@ -1071,7 +1053,6 @@ func testBackendEntPartition(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Log("Verifying that the generated token works...")
 	_, err = client.Catalog(), nil
 	if err != nil {
 		t.Fatal(err)
@@ -1106,7 +1087,6 @@ func testBackendEntPartition(t *testing.T) {
 		Partition:  "test1",
 	}
 
-	t.Log("Verifying that the generated token does not exist...")
 	_, _, err = mgmtclient.ACL().TokenRead(d.Accessor, q)
 	if err == nil {
 		t.Fatal("err: expected error")
@@ -1295,7 +1275,6 @@ func TestBackendRenewRevokeRolesAndIdentities(t *testing.T) {
 		if err := mapstructure.Decode(resp.Data, &d); err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("Generated token: %s with accessor %s", d.Token, d.Accessor)
 
 		// Build a client and verify that the credentials work
 		consulapiConfig := consulapi.DefaultNonPooledConfig()
@@ -1306,7 +1285,6 @@ func TestBackendRenewRevokeRolesAndIdentities(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		t.Log("Verifying that the generated token works...")
 		_, err = client.Catalog(), nil
 		if err != nil {
 			t.Fatal(err)
@@ -1338,7 +1316,6 @@ func TestBackendRenewRevokeRolesAndIdentities(t *testing.T) {
 			Datacenter: "DC1",
 		}
 
-		t.Log("Verifying that the generated token does not exist...")
 		_, _, err = mgmtclient.ACL().TokenRead(d.Accessor, q)
 		if err == nil {
 			t.Fatal("err: expected error")

--- a/builtin/logical/consul/backend_test.go
+++ b/builtin/logical/consul/backend_test.go
@@ -99,7 +99,14 @@ func TestBackend_Renew_Revoke(t *testing.T) {
 				testBackendRenewRevoke(t, "1.4.4")
 			})
 
-			testBackendRenewRevoke14(t, "")
+			t.Run("param-policies", func(t *testing.T) {
+				t.Parallel()
+				testBackendRenewRevoke14(t, "", "policies")
+			})
+			t.Run("param-consul_policies", func(t *testing.T) {
+				t.Parallel()
+				testBackendRenewRevoke14(t, "", "consul_policies")
+			})
 		})
 	})
 }
@@ -209,7 +216,7 @@ func testBackendRenewRevoke(t *testing.T, version string) {
 	}
 }
 
-func testBackendRenewRevoke14(t *testing.T, version string) {
+func testBackendRenewRevoke14(t *testing.T, version string, policiesParam string) {
 	config := logical.TestBackendConfig()
 	config.StorageView = &logical.InmemStorage{}
 	b, err := Factory(context.Background(), config)
@@ -238,8 +245,8 @@ func testBackendRenewRevoke14(t *testing.T, version string) {
 
 	req.Path = "roles/test"
 	req.Data = map[string]interface{}{
-		"consul_policies": []string{"test"},
-		"lease":           "6h",
+		policiesParam: []string{"test"},
+		"lease":       "6h",
 	}
 	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {

--- a/builtin/logical/consul/backend_test.go
+++ b/builtin/logical/consul/backend_test.go
@@ -238,8 +238,8 @@ func testBackendRenewRevoke14(t *testing.T, version string) {
 
 	req.Path = "roles/test"
 	req.Data = map[string]interface{}{
-		"policies": []string{"test"},
-		"lease":    "6h",
+		"consul_policies": []string{"test"},
+		"lease":           "6h",
 	}
 	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
@@ -350,9 +350,9 @@ func TestBackend_LocalToken(t *testing.T) {
 
 	req.Path = "roles/test"
 	req.Data = map[string]interface{}{
-		"policies": []string{"test"},
-		"ttl":      "6h",
-		"local":    false,
+		"consul_policies": []string{"test"},
+		"ttl":             "6h",
+		"local":           false,
 	}
 	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
@@ -361,9 +361,9 @@ func TestBackend_LocalToken(t *testing.T) {
 
 	req.Path = "roles/test_local"
 	req.Data = map[string]interface{}{
-		"policies": []string{"test"},
-		"ttl":      "6h",
-		"local":    true,
+		"consul_policies": []string{"test"},
+		"ttl":             "6h",
+		"local":           true,
 	}
 	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
@@ -869,7 +869,7 @@ func testBackendEntNamespace(t *testing.T) {
 	// Create the role in namespace "ns1"
 	req.Path = "roles/test-ns"
 	req.Data = map[string]interface{}{
-		"policies":         []string{"ns-test"},
+		"consul_policies":  []string{"ns-test"},
 		"lease":            "6h",
 		"consul_namespace": "ns1",
 	}
@@ -989,9 +989,9 @@ func testBackendEntPartition(t *testing.T) {
 	// Create the role in partition "part1"
 	req.Path = "roles/test-part"
 	req.Data = map[string]interface{}{
-		"policies":  []string{"part-test"},
-		"lease":     "6h",
-		"partition": "part1",
+		"consul_policies": []string{"part-test"},
+		"lease":           "6h",
+		"partition":       "part1",
 	}
 	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
@@ -1120,9 +1120,9 @@ func TestBackendRenewRevokeRolesAndIdentities(t *testing.T) {
 		"role and policies": {
 			"rp",
 			map[string]interface{}{
-				"policies":     []string{"test"},
-				"consul_roles": []string{"role-test"},
-				"lease":        "6h",
+				"consul_policies": []string{"test"},
+				"consul_roles":    []string{"role-test"},
+				"lease":           "6h",
 			},
 		},
 		"service identity": {
@@ -1135,7 +1135,7 @@ func TestBackendRenewRevokeRolesAndIdentities(t *testing.T) {
 		"service identity and policies": {
 			"sip",
 			map[string]interface{}{
-				"policies":           []string{"test"},
+				"consul_policies":    []string{"test"},
 				"service_identities": "service1",
 				"lease":              "6h",
 			},
@@ -1151,7 +1151,7 @@ func TestBackendRenewRevokeRolesAndIdentities(t *testing.T) {
 		"service identity and role and policies": {
 			"sirp",
 			map[string]interface{}{
-				"policies":           []string{"test"},
+				"consul_policies":    []string{"test"},
 				"consul_roles":       []string{"role-test"},
 				"service_identities": "service1",
 				"lease":              "6h",
@@ -1167,7 +1167,7 @@ func TestBackendRenewRevokeRolesAndIdentities(t *testing.T) {
 		"node identity and policies": {
 			"nip",
 			map[string]interface{}{
-				"policies":        []string{"test"},
+				"consul_policies": []string{"test"},
 				"node_identities": []string{"node1:dc1"},
 				"lease":           "6h",
 			},
@@ -1183,10 +1183,10 @@ func TestBackendRenewRevokeRolesAndIdentities(t *testing.T) {
 		"node identity and role and policies": {
 			"nirp",
 			map[string]interface{}{
-				"consul_roles":       []string{"role-test"},
-				"service_identities": "service1",
-				"node_identities":    []string{"node1:dc1"},
-				"lease":              "6h",
+				"consul_policies": []string{"test"},
+				"consul_roles":    []string{"role-test"},
+				"node_identities": []string{"node1:dc1"},
+				"lease":           "6h",
 			},
 		},
 		"node identity and service identity": {
@@ -1200,7 +1200,7 @@ func TestBackendRenewRevokeRolesAndIdentities(t *testing.T) {
 		"node identity and service identity and policies": {
 			"nisip",
 			map[string]interface{}{
-				"policies":           []string{"test"},
+				"consul_policies":    []string{"test"},
 				"service_identities": "service1",
 				"node_identities":    []string{"node1:dc1"},
 				"lease":              "6h",
@@ -1218,7 +1218,7 @@ func TestBackendRenewRevokeRolesAndIdentities(t *testing.T) {
 		"node identity and service identity and role and policies": {
 			"nisirp",
 			map[string]interface{}{
-				"policies":           []string{"test"},
+				"consul_policies":    []string{"test"},
 				"consul_roles":       []string{"role-test"},
 				"service_identities": "service1",
 				"node_identities":    []string{"node1:dc1"},

--- a/builtin/logical/consul/path_roles.go
+++ b/builtin/logical/consul/path_roles.go
@@ -48,7 +48,7 @@ using Consul 1.4.`,
 or "consul_roles" are required for Consul 1.5 and above.`,
 			},
 
-			"local": {
+			"consul_local": {
 				Type: framework.TypeBool,
 				Description: `Indicates that the token should not be replicated globally 
 and instead be local to the current datacenter. Available in Consul 1.4 and above.`,
@@ -62,12 +62,12 @@ a 'management' token, the "policy", "policies", and "consul_roles" parameters ar
 required. Defaults to 'client'.`,
 			},
 
-			"ttl": {
+			"consul_ttl": {
 				Type:        framework.TypeDurationSecond,
 				Description: "TTL for the Consul token created from the role.",
 			},
 
-			"max_ttl": {
+			"consul_max_ttl": {
 				Type:        framework.TypeDurationSecond,
 				Description: "Max TTL for the Consul token created from the role.",
 			},
@@ -144,10 +144,10 @@ func (b *backend) pathRolesRead(ctx context.Context, req *logical.Request, d *fr
 	resp := &logical.Response{
 		Data: map[string]interface{}{
 			"lease":            int64(roleConfigData.TTL.Seconds()),
-			"ttl":              int64(roleConfigData.TTL.Seconds()),
-			"max_ttl":          int64(roleConfigData.MaxTTL.Seconds()),
+			"consul_ttl":       int64(roleConfigData.TTL.Seconds()),
+			"consul_max_ttl":   int64(roleConfigData.MaxTTL.Seconds()),
 			"token_type":       roleConfigData.TokenType,
-			"local":            roleConfigData.Local,
+			"consul_local":     roleConfigData.Local,
 			"consul_namespace": roleConfigData.ConsulNamespace,
 			"consul_partition": roleConfigData.Partition,
 		},
@@ -198,7 +198,7 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 	}
 
 	var ttl time.Duration
-	ttlRaw, ok := d.GetOk("ttl")
+	ttlRaw, ok := d.GetOk("consul_ttl")
 	if ok {
 		ttl = time.Second * time.Duration(ttlRaw.(int))
 	} else {
@@ -215,7 +215,7 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 	}
 
 	name := d.Get("name").(string)
-	local := d.Get("local").(bool)
+	local := d.Get("consul_local").(bool)
 	namespace := d.Get("consul_namespace").(string)
 	partition := d.Get("consul_partition").(string)
 	entry, err := logical.StorageEntryJSON("policy/"+name, roleConfig{
@@ -257,9 +257,9 @@ type roleConfig struct {
 	ServiceIdentities []string      `json:"consul_service_identities"`
 	NodeIdentities    []string      `json:"consul_node_identities"`
 	TTL               time.Duration `json:"lease"`
-	MaxTTL            time.Duration `json:"max_ttl"`
+	MaxTTL            time.Duration `json:"consul_max_ttl"`
 	TokenType         string        `json:"token_type"`
-	Local             bool          `json:"local"`
+	Local             bool          `json:"consul_local"`
 	ConsulNamespace   string        `json:"consul_namespace"`
 	Partition         string        `json:"consul_partition"`
 }

--- a/builtin/logical/consul/path_roles.go
+++ b/builtin/logical/consul/path_roles.go
@@ -35,7 +35,7 @@ func pathRoles(b *backend) *framework.Path {
 for 'client' tokens. Required for Consul pre-1.4.`,
 			},
 
-			"policies": {
+			"consul_policies": {
 				Type: framework.TypeCommaStringSlice,
 				Description: `List of policies to attach to the token. Either "policies"
 or "consul_roles" are required for Consul 1.5 and above, or just "policies" if
@@ -84,19 +84,19 @@ required. Defaults to 'client'.`,
 created within. Defaults to 'default'. Available in Consul 1.7 and above.`,
 			},
 
-			"partition": {
+			"consul_partition": {
 				Type: framework.TypeString,
 				Description: `Indicates which admin partition that the token
 will be created within. Defaults to 'default'. Available in Consul 1.11 and above.`,
 			},
 
-			"service_identities": {
+			"consul_service_identities": {
 				Type: framework.TypeStringSlice,
 				Description: `List of Service Identities to attach to the
 token, separated by semicolons. Available in Consul 1.5 or above.`,
 			},
 
-			"node_identities": {
+			"consul_node_identities": {
 				Type: framework.TypeStringSlice,
 				Description: `List of Node Identities to attach to the
 token. Available in Consul 1.8.1 or above.`,
@@ -149,23 +149,23 @@ func (b *backend) pathRolesRead(ctx context.Context, req *logical.Request, d *fr
 			"token_type":       roleConfigData.TokenType,
 			"local":            roleConfigData.Local,
 			"consul_namespace": roleConfigData.ConsulNamespace,
-			"partition":        roleConfigData.Partition,
+			"consul_partition": roleConfigData.Partition,
 		},
 	}
 	if roleConfigData.Policy != "" {
 		resp.Data["policy"] = base64.StdEncoding.EncodeToString([]byte(roleConfigData.Policy))
 	}
 	if len(roleConfigData.Policies) > 0 {
-		resp.Data["policies"] = roleConfigData.Policies
+		resp.Data["consul_policies"] = roleConfigData.Policies
 	}
 	if len(roleConfigData.ConsulRoles) > 0 {
 		resp.Data["consul_roles"] = roleConfigData.ConsulRoles
 	}
 	if len(roleConfigData.ServiceIdentities) > 0 {
-		resp.Data["service_identities"] = roleConfigData.ServiceIdentities
+		resp.Data["consul_service_identities"] = roleConfigData.ServiceIdentities
 	}
 	if len(roleConfigData.NodeIdentities) > 0 {
-		resp.Data["node_identities"] = roleConfigData.NodeIdentities
+		resp.Data["consul_node_identities"] = roleConfigData.NodeIdentities
 	}
 
 	return resp, nil
@@ -174,10 +174,10 @@ func (b *backend) pathRolesRead(ctx context.Context, req *logical.Request, d *fr
 func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	tokenType := d.Get("token_type").(string)
 	policy := d.Get("policy").(string)
-	policies := d.Get("policies").([]string)
+	policies := d.Get("consul_policies").([]string)
 	roles := d.Get("consul_roles").([]string)
-	serviceIdentities := d.Get("service_identities").([]string)
-	nodeIdentities := d.Get("node_identities").([]string)
+	serviceIdentities := d.Get("consul_service_identities").([]string)
+	nodeIdentities := d.Get("consul_node_identities").([]string)
 
 	switch tokenType {
 	case "client":
@@ -217,7 +217,7 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 	name := d.Get("name").(string)
 	local := d.Get("local").(bool)
 	namespace := d.Get("consul_namespace").(string)
-	partition := d.Get("partition").(string)
+	partition := d.Get("consul_partition").(string)
 	entry, err := logical.StorageEntryJSON("policy/"+name, roleConfig{
 		Policy:            string(policyRaw),
 		Policies:          policies,
@@ -252,14 +252,14 @@ func (b *backend) pathRolesDelete(ctx context.Context, req *logical.Request, d *
 
 type roleConfig struct {
 	Policy            string        `json:"policy"`
-	Policies          []string      `json:"policies"`
+	Policies          []string      `json:"consul_policies"`
 	ConsulRoles       []string      `json:"consul_roles"`
-	ServiceIdentities []string      `json:"service_identities"`
-	NodeIdentities    []string      `json:"node_identities"`
+	ServiceIdentities []string      `json:"consul_service_identities"`
+	NodeIdentities    []string      `json:"consul_node_identities"`
 	TTL               time.Duration `json:"lease"`
 	MaxTTL            time.Duration `json:"max_ttl"`
 	TokenType         string        `json:"token_type"`
 	Local             bool          `json:"local"`
 	ConsulNamespace   string        `json:"consul_namespace"`
-	Partition         string        `json:"partition"`
+	Partition         string        `json:"consul_partition"`
 }

--- a/builtin/logical/consul/path_roles.go
+++ b/builtin/logical/consul/path_roles.go
@@ -35,7 +35,6 @@ func pathRoles(b *backend) *framework.Path {
 				Type: framework.TypeString,
 				Description: `Policy document, base64 encoded. Required
 for 'client' tokens. Required for Consul pre-1.4.`,
-				Deprecated: true,
 			},
 
 			"token_type": {
@@ -44,18 +43,18 @@ for 'client' tokens. Required for Consul pre-1.4.`,
 				Description: `Which type of token to create: 'client' or 'management'. If
 a 'management' token, the "policy", "policies", and "consul_roles" parameters are not
 required. Defaults to 'client'.`,
-				Deprecated: true,
 			},
 
 			"policies": {
 				Type:        framework.TypeCommaStringSlice,
 				Description: `Use "consul_policies" instead.`,
+				Deprecated:  true,
 			},
 
 			"consul_policies": {
 				Type: framework.TypeCommaStringSlice,
-				Description: `List of policies to attach to the token. Either "policies"
-or "consul_roles" are required for Consul 1.5 and above, or just "policies" if
+				Description: `List of policies to attach to the token. Either "consul_policies"
+or "consul_roles" are required for Consul 1.5 and above, or just "consul_policies" if
 using Consul 1.4.`,
 			},
 
@@ -152,6 +151,7 @@ func (b *backend) pathRolesRead(ctx context.Context, req *logical.Request, d *fr
 	// Generate the response
 	resp := &logical.Response{
 		Data: map[string]interface{}{
+			"lease":            int64(roleConfigData.TTL.Seconds()),
 			"ttl":              int64(roleConfigData.TTL.Seconds()),
 			"max_ttl":          int64(roleConfigData.MaxTTL.Seconds()),
 			"token_type":       roleConfigData.TokenType,

--- a/builtin/logical/consul/path_token.go
+++ b/builtin/logical/consul/path_token.go
@@ -125,7 +125,7 @@ func (b *backend) pathTokenRead(ctx context.Context, req *logical.Request, d *fr
 	s := b.Secret(SecretTokenType).Response(map[string]interface{}{
 		"token":            token.SecretID,
 		"accessor":         token.AccessorID,
-		"local":            token.Local,
+		"consul_local":     token.Local,
 		"consul_namespace": token.Namespace,
 		"consul_partition": token.Partition,
 	}, map[string]interface{}{

--- a/builtin/logical/consul/path_token.go
+++ b/builtin/logical/consul/path_token.go
@@ -125,9 +125,9 @@ func (b *backend) pathTokenRead(ctx context.Context, req *logical.Request, d *fr
 	s := b.Secret(SecretTokenType).Response(map[string]interface{}{
 		"token":            token.SecretID,
 		"accessor":         token.AccessorID,
-		"consul_local":     token.Local,
+		"local":            token.Local,
 		"consul_namespace": token.Namespace,
-		"consul_partition": token.Partition,
+		"partition":        token.Partition,
 	}, map[string]interface{}{
 		"token":   token.AccessorID,
 		"role":    role,

--- a/builtin/logical/consul/path_token.go
+++ b/builtin/logical/consul/path_token.go
@@ -127,7 +127,7 @@ func (b *backend) pathTokenRead(ctx context.Context, req *logical.Request, d *fr
 		"accessor":         token.AccessorID,
 		"local":            token.Local,
 		"consul_namespace": token.Namespace,
-		"partition":        token.Partition,
+		"consul_partition": token.Partition,
 	}, map[string]interface{}{
 		"token":   token.AccessorID,
 		"role":    role,

--- a/builtin/logical/consul/path_token_test.go
+++ b/builtin/logical/consul/path_token_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
-func Test_parseServiceIdentities(t *testing.T) {
+func TestToken_parseServiceIdentities(t *testing.T) {
 	tests := []struct {
 		name string
 		args []string
@@ -58,7 +58,7 @@ func Test_parseServiceIdentities(t *testing.T) {
 	}
 }
 
-func Test_parseNodeIdentities(t *testing.T) {
+func TestToken_parseNodeIdentities(t *testing.T) {
 	tests := []struct {
 		name string
 		args []string

--- a/changelog/15400.txt
+++ b/changelog/15400.txt
@@ -1,0 +1,3 @@
+```release-note:deprecation
+secrets/consul: Deprecate parameter "policies" in favor of "consul_policies" for consistency
+```


### PR DESCRIPTION
### Description
With the Consul secrets engine improvements, several new parameters were added. Roles for example, but since Vault uses the term roles already, the parameter was named `consul_roles`. Similarly, the parameter for Consul namespaces was named `consul_namespace`. For example:

`$ vault write consul/roles/my-role consul_roles="role1"`
and
`$ vault write -namespace="ns1" consul/roles/my-role consul_namespace="ns2"`

This has created an inconsistent naming convention for the parameters. A counterexample to the above is policies, as both Consul and Vault use them, yet the parameter is simply named `policies` without the "consul_" prefix:
`$ vault write consul/roles/my-role policies="global-management"`

### Solution
We could consider renaming the parameters to be consistent, and if so decide which parameters would get renamed.
This draft PR changes most of the remaining parameters for configuring Vault roles to use with Consul. They are listed below:
* `local` -> `consul_local`
* `policies` -> `consul_policies`
* `partition` -> `consul_partition`
* `ttl` -> `consul_ttl`
* `max_ttl` -> `consul_max_ttl`
* `service_identities` -> `consul_service_identities`
* `node_identities` -> `consul_node_identities`

As you can see, some of these become particularly long-winded which may not be good UX:
`$ vault write consul/roles/my-role consul_local=true consul_ttl=1h consul_max_ttl=2h consul_service_identities="myserv-1:dc1"`

Perhaps only a subset of these could be changed yet still make it feel more consistent?
