### PR TITLE
Fix unknown type parameter during CA generation

### DIFF
--- a/ui/app/adapters/pki-ca-certificate.js
+++ b/ui/app/adapters/pki-ca-certificate.js
@@ -32,6 +32,11 @@ export default ApplicationAdapter.extend({
       data = { certificate: snapshot.attr('certificate') };
     } else {
       data = serializer.serialize(snapshot, requestType);
+
+      // The type parameter is serialized but is part of the URL. This means
+      // we'll get an unknown parameter warning back from the server if we
+      // send it. Remove it instead.
+      delete data['type'];
     }
 
     return this.ajax(this.url(snapshot, action), 'POST', { data }).then((response) => {

--- a/ui/app/adapters/pki-ca-certificate.js
+++ b/ui/app/adapters/pki-ca-certificate.js
@@ -36,7 +36,7 @@ export default ApplicationAdapter.extend({
       // The type parameter is serialized but is part of the URL. This means
       // we'll get an unknown parameter warning back from the server if we
       // send it. Remove it instead.
-      delete data['type'];
+      delete data.type;
     }
 
     return this.ajax(this.url(snapshot, action), 'POST', { data }).then((response) => {


### PR DESCRIPTION
When generating a new PKI CA from the Web UI, the UI incorrectly sends
the type parameter in the POST body. The server will now warn on unknown
parameters, resulting in the UI surfacing that up to the caller. Since
the type is part of the URL, we don't need to duplicate it in the POST
body, so elide it.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

Marking no-changelog as this is part of the server warning feature new in 1.11 and while affecting earlier versions, didn't cause a warning. 

Before:

![image](https://user-images.githubusercontent.com/914030/168127754-3671f2a3-ed58-4382-83ee-e9d902e2126f.png)


After:

![image](https://user-images.githubusercontent.com/914030/168127844-21a3694a-f3c2-4636-8767-0acb5aa348e3.png)
