### PR TITLE
Vault CLI: show detailed information with ListResponseWithInfo

### DIFF
--- a/changelog/15417.txt
+++ b/changelog/15417.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+command: Support the optional '-detailed' flag to be passed to 'vault list' command to show ListResponseWithInfo data. Also supports the VAULT_DETAILED_LISTS env var.
+```

--- a/changelog/15417.txt
+++ b/changelog/15417.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-command: Support the optional '-detailed' flag to be passed to 'vault list' command to show ListResponseWithInfo data. Also supports the VAULT_DETAILED_LISTS env var.
+command: Support the optional '-detailed' flag to be passed to 'vault list' command to show ListResponseWithInfo data. Also supports the VAULT_DETAILED env var.
 ```

--- a/command/base.go
+++ b/command/base.go
@@ -56,6 +56,7 @@ type BaseCommand struct {
 
 	flagFormat           string
 	flagField            string
+	flagDetailed         bool
 	flagOutputCurlString bool
 	flagOutputPolicy     bool
 	flagNonInteractive   bool
@@ -304,6 +305,7 @@ const (
 	FlagSetHTTP
 	FlagSetOutputField
 	FlagSetOutputFormat
+	FlagSetOutputDetailed
 )
 
 // flagSet creates the flags for this command. The result is cached on the
@@ -496,11 +498,11 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 
 		}
 
-		if bit&(FlagSetOutputField|FlagSetOutputFormat) != 0 {
-			f := set.NewFlagSet("Output Options")
+		if bit&(FlagSetOutputField|FlagSetOutputFormat|FlagSetOutputDetailed) != 0 {
+			outputSet := set.NewFlagSet("Output Options")
 
 			if bit&FlagSetOutputField != 0 {
-				f.StringVar(&StringVar{
+				outputSet.StringVar(&StringVar{
 					Name:       "field",
 					Target:     &c.flagField,
 					Default:    "",
@@ -513,7 +515,7 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 			}
 
 			if bit&FlagSetOutputFormat != 0 {
-				f.StringVar(&StringVar{
+				outputSet.StringVar(&StringVar{
 					Name:       "format",
 					Target:     &c.flagFormat,
 					Default:    "table",
@@ -521,6 +523,16 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 					Completion: complete.PredictSet("table", "json", "yaml", "pretty"),
 					Usage: `Print the output in the given format. Valid formats
 						are "table", "json", "yaml", or "pretty".`,
+				})
+			}
+
+			if bit&FlagSetOutputDetailed != 0 {
+				outputSet.BoolVar(&BoolVar{
+					Name:    "detailed",
+					Target:  &c.flagDetailed,
+					Default: false,
+					EnvVar:  EnvVaultDetailed,
+					Usage:   "Enables additional metadata during some operations",
 				})
 			}
 		}

--- a/command/commands.go
+++ b/command/commands.go
@@ -80,6 +80,8 @@ const (
 	// EnvVaultLicensePath is an env var used in Vault Enterprise to provide a
 	// path to a license file on disk
 	EnvVaultLicensePath = "VAULT_LICENSE_PATH"
+	// EnvVaultDetailed is to output detailed information (e.g., ListResponseWithInfo).
+	EnvVaultDetailed = `VAULT_DETAILED`
 
 	// DisableSSCTokens is an env var used to disable index bearing
 	// token functionality

--- a/command/format.go
+++ b/command/format.go
@@ -103,6 +103,23 @@ func (j JsonFormatter) Output(ui cli.Ui, secret *api.Secret, data interface{}) e
 	if err != nil {
 		return err
 	}
+
+	if secret != nil {
+		if rawShouldListWithInfo, ok := secret.Data[doListWithInfoConstant]; ok {
+			shouldListWithInfo := rawShouldListWithInfo.(bool)
+			delete(secret.Data, doListWithInfoConstant)
+
+			// Show the raw JSON of the LIST call, rather than only the
+			// list of keys.
+			if shouldListWithInfo {
+				b, err = j.Format(secret)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
 	ui.Output(string(b))
 	return nil
 }

--- a/command/list.go
+++ b/command/list.go
@@ -131,8 +131,10 @@ func (c *ListCommand) Run(args []string) int {
 		return 2
 	}
 
-	// Hijack the secret's data to show the list with information.
-	secret.Data[doListWithInfoConstant] = c.flagDetailed
+	switch ui := c.UI.(type) {
+	case *VaultUI:
+		ui.detailed = c.flagDetailed
+	}
 
 	return OutputList(c.UI, secret)
 }

--- a/command/list.go
+++ b/command/list.go
@@ -15,8 +15,6 @@ var (
 
 type ListCommand struct {
 	*BaseCommand
-
-	flagDetailed bool
 }
 
 func (c *ListCommand) Synopsis() string {
@@ -44,17 +42,7 @@ Usage: vault list [options] PATH
 }
 
 func (c *ListCommand) Flags() *FlagSets {
-	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
-	f := set.NewFlagSet("List Options")
-
-	f.BoolVar(&BoolVar{
-		Name:    "detailed",
-		Target:  &c.flagDetailed,
-		Default: false,
-		EnvVar:  "VAULT_DETAILED_LISTS",
-		Usage:   "Enables additional metadata during some LIST operations",
-	})
-
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat | FlagSetOutputDetailed)
 	return set
 }
 
@@ -129,11 +117,6 @@ func (c *ListCommand) Run(args []string) int {
 	if !ok {
 		c.UI.Error(fmt.Sprintf("No entries found at %s", path))
 		return 2
-	}
-
-	switch ui := c.UI.(type) {
-	case *VaultUI:
-		ui.detailed = c.flagDetailed
 	}
 
 	return OutputList(c.UI, secret)

--- a/command/main.go
+++ b/command/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 
@@ -25,8 +26,10 @@ type VaultUI struct {
 
 // setupEnv parses args and may replace them and sets some env vars to known
 // values based on format options
-func setupEnv(args []string) (retArgs []string, format string, outputCurlString bool, outputPolicy bool) {
+func setupEnv(args []string) (retArgs []string, format string, detailed bool, outputCurlString bool, outputPolicy bool) {
+	var err error
 	var nextArgFormat bool
+	var haveDetailed bool
 
 	for _, arg := range args {
 		if nextArgFormat {
@@ -65,6 +68,28 @@ func setupEnv(args []string) (retArgs []string, format string, outputCurlString 
 		if arg == "-format" || arg == "--format" {
 			nextArgFormat = true
 		}
+
+		// Parse a given flag here, which overrides the env var
+		if strings.HasPrefix(arg, "--detailed=") {
+			detailed, err = strconv.ParseBool(strings.TrimPrefix(arg, "--detailed="))
+			if err != nil {
+				detailed = false
+			}
+			haveDetailed = true
+		}
+		if strings.HasPrefix(arg, "-detailed=") {
+			detailed, err = strconv.ParseBool(strings.TrimPrefix(arg, "-detailed="))
+			if err != nil {
+				detailed = false
+			}
+			haveDetailed = true
+		}
+		// For backwards compat, it could be specified without an equal sign to enable
+		// detailed output.
+		if arg == "-detailed" || arg == "--detailed" {
+			detailed = true
+			haveDetailed = true
+		}
 	}
 
 	envVaultFormat := os.Getenv(EnvVaultFormat)
@@ -78,7 +103,16 @@ func setupEnv(args []string) (retArgs []string, format string, outputCurlString 
 		format = "table"
 	}
 
-	return args, format, outputCurlString, outputPolicy
+	envVaultDetailed := os.Getenv(EnvVaultDetailed)
+	// If we did not parse a value, fetch the env var
+	if !haveDetailed && envVaultDetailed != "" {
+		detailed, err = strconv.ParseBool(envVaultDetailed)
+		if err != nil {
+			detailed = false
+		}
+	}
+
+	return args, format, detailed, outputCurlString, outputPolicy
 }
 
 type RunOptions struct {
@@ -101,9 +135,10 @@ func RunCustom(args []string, runOpts *RunOptions) int {
 	}
 
 	var format string
+	var detailed bool
 	var outputCurlString bool
 	var outputPolicy bool
-	args, format, outputCurlString, outputPolicy = setupEnv(args)
+	args, format, detailed, outputCurlString, outputPolicy = setupEnv(args)
 
 	// Don't use color if disabled
 	useColor := true
@@ -146,7 +181,8 @@ func RunCustom(args []string, runOpts *RunOptions) int {
 				ErrorWriter: uiErrWriter,
 			},
 		},
-		format: format,
+		format:   format,
+		detailed: detailed,
 	}
 
 	serverCmdUi := &VaultUI{

--- a/command/main.go
+++ b/command/main.go
@@ -19,7 +19,8 @@ import (
 
 type VaultUI struct {
 	cli.Ui
-	format string
+	format   string
+	detailed bool
 }
 
 // setupEnv parses args and may replace them and sets some env vars to known

--- a/command/operator_unseal_test.go
+++ b/command/operator_unseal_test.go
@@ -167,7 +167,7 @@ func TestOperatorUnsealCommand_Format(t *testing.T) {
 		Client: client,
 	}
 
-	args, format, _, _ := setupEnv([]string{"operator", "unseal", "-format", "json"})
+	args, format, _, _, _ := setupEnv([]string{"operator", "unseal", "-format", "json"})
 	if format != "json" {
 		t.Fatalf("expected %q, got %q", "json", format)
 	}

--- a/command/version_history_test.go
+++ b/command/version_history_test.go
@@ -57,7 +57,7 @@ func TestVersionHistoryCommand_JsonOutput(t *testing.T) {
 		Client: client,
 	}
 
-	args, format, _, _ := setupEnv([]string{"version-history", "-format", "json"})
+	args, format, _, _, _ := setupEnv([]string{"version-history", "-format", "json"})
 	if format != "json" {
 		t.Fatalf("expected format to be %q, actual %q", "json", format)
 	}


### PR DESCRIPTION
This adds the ability (via switch `-detailed`) to show the additional metadata returned by endpoints which use the `ListResponseWithInfo` format helper. We add support for both table and JSON formatted response printing. 

See the individual commit messages for examples of each. 

---

An unofficial survey of endpoints returns:

 - PKI: `/issuers` and `/keys`, which are new to 1.11
 - SSH: `/roles`, which has been around for a while. It returns the `key_type` field.
 
A few other uses:

```
vault/identity_store_entities.go:666:			resp := logical.ListResponseWithInfo(keys, entityInfo)
vault/identity_store_entities.go:717:	return logical.ListResponseWithInfo(keys, entityInfo), nil
vault/identity_store_groups.go:533:	return logical.ListResponseWithInfo(keys, groupInfo), nil
vault/identity_store_util.go:2485:	return logical.ListResponseWithInfo(aliasIDs, aliasInfo), nil
vault/logical_system.go:4385:	return logical.ListResponseWithInfo(respKeys, respKeyInfo), nil
vault/login_mfa.go:191:	return logical.ListResponseWithInfo(keys, configInfo), nil
vault/login_mfa.go:746:	return logical.ListResponseWithInfo(keys, configInfo), nil
```