### PR TITLE
VAULT-5885: Fix erroneous success message in case of two-phase MFA, and provide MFA information in table format

### DIFF
--- a/changelog/15428.txt
+++ b/changelog/15428.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-auth: Fixed erroneous success message when using vault login in case of two-phase MFA, and fixed MFA information missing from table format when using vault login.
+auth: Fixed erroneous success message and token info when using vault login in case of two-phase MFA, and fixed MFA information missing from table format when using vault login.
 ```

--- a/changelog/15428.txt
+++ b/changelog/15428.txt
@@ -1,3 +1,9 @@
 ```release-note:bug
-auth: Fixed erroneous success message and token info when using vault login in case of two-phase MFA, and fixed MFA information missing from table format when using vault login.
+auth: Fixed erroneous success message when using vault login in case of two-phase MFA
+```
+```release-note:bug
+auth: Fixed erroneous token information being displayed when using vault login in case of two-phase MFA
+```
+```release-note:bug
+auth: Fixed two-phase MFA information missing from table format when using vault login
 ```

--- a/changelog/15428.txt
+++ b/changelog/15428.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+login/mfa: Fixed erroneous success message in case of two-phase MFA, and fixed MFA information missing from table format.
+```

--- a/changelog/15428.txt
+++ b/changelog/15428.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-login/mfa: Fixed erroneous success message when using vault login in case of two-phase MFA, and fixed MFA information missing from table format when using vault login.
+auth: Fixed erroneous success message when using vault login in case of two-phase MFA, and fixed MFA information missing from table format when using vault login.
 ```

--- a/changelog/15428.txt
+++ b/changelog/15428.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-login/mfa: Fixed erroneous success message in case of two-phase MFA, and fixed MFA information missing from table format.
+login/mfa: Fixed erroneous success message when using vault login in case of two-phase MFA, and fixed MFA information missing from table format when using vault login.
 ```

--- a/command/format.go
+++ b/command/format.go
@@ -385,23 +385,6 @@ func (t TableFormatter) OutputSecret(ui cli.Ui, secret *api.Secret) error {
 	}
 
 	if secret.Auth != nil {
-		out = append(out, fmt.Sprintf("token %s %s", hopeDelim, secret.Auth.ClientToken))
-		out = append(out, fmt.Sprintf("token_accessor %s %s", hopeDelim, secret.Auth.Accessor))
-		// If the lease duration is 0, it's likely a root token, so output the
-		// duration as "infinity" to clear things up.
-		if secret.Auth.LeaseDuration == 0 {
-			out = append(out, fmt.Sprintf("token_duration %s %s", hopeDelim, "∞"))
-		} else {
-			out = append(out, fmt.Sprintf("token_duration %s %v", hopeDelim, humanDurationInt(secret.Auth.LeaseDuration)))
-		}
-		out = append(out, fmt.Sprintf("token_renewable %s %t", hopeDelim, secret.Auth.Renewable))
-		out = append(out, fmt.Sprintf("token_policies %s %q", hopeDelim, secret.Auth.TokenPolicies))
-		out = append(out, fmt.Sprintf("identity_policies %s %q", hopeDelim, secret.Auth.IdentityPolicies))
-		out = append(out, fmt.Sprintf("policies %s %q", hopeDelim, secret.Auth.Policies))
-		for k, v := range secret.Auth.Metadata {
-			out = append(out, fmt.Sprintf("token_meta_%s %s %v", k, hopeDelim, v))
-		}
-
 		if secret.Auth.MFARequirement != nil {
 			out = append(out, fmt.Sprintf("mfa_request_id %s %s", hopeDelim, secret.Auth.MFARequirement.MFARequestID))
 
@@ -410,6 +393,23 @@ func (t TableFormatter) OutputSecret(ui cli.Ui, secret *api.Secret) error {
 					out = append(out, fmt.Sprintf("mfa_constraint_%s_%s_id %s %s", k, constraint.Type, hopeDelim, constraint.ID))
 					out = append(out, fmt.Sprintf("mfa_constraint_%s_%s_uses_passcode %s %t", k, constraint.Type, hopeDelim, constraint.UsesPasscode))
 				}
+			}
+		} else { // Token information only makes sense if no further MFA requirement (i.e. if we actually have a token)
+			out = append(out, fmt.Sprintf("token %s %s", hopeDelim, secret.Auth.ClientToken))
+			out = append(out, fmt.Sprintf("token_accessor %s %s", hopeDelim, secret.Auth.Accessor))
+			// If the lease duration is 0, it's likely a root token, so output the
+			// duration as "infinity" to clear things up.
+			if secret.Auth.LeaseDuration == 0 {
+				out = append(out, fmt.Sprintf("token_duration %s %s", hopeDelim, "∞"))
+			} else {
+				out = append(out, fmt.Sprintf("token_duration %s %v", hopeDelim, humanDurationInt(secret.Auth.LeaseDuration)))
+			}
+			out = append(out, fmt.Sprintf("token_renewable %s %t", hopeDelim, secret.Auth.Renewable))
+			out = append(out, fmt.Sprintf("token_policies %s %q", hopeDelim, secret.Auth.TokenPolicies))
+			out = append(out, fmt.Sprintf("identity_policies %s %q", hopeDelim, secret.Auth.IdentityPolicies))
+			out = append(out, fmt.Sprintf("policies %s %q", hopeDelim, secret.Auth.Policies))
+			for k, v := range secret.Auth.Metadata {
+				out = append(out, fmt.Sprintf("token_meta_%s %s %v", k, hopeDelim, v))
 			}
 		}
 	}

--- a/command/format.go
+++ b/command/format.go
@@ -401,6 +401,17 @@ func (t TableFormatter) OutputSecret(ui cli.Ui, secret *api.Secret) error {
 		for k, v := range secret.Auth.Metadata {
 			out = append(out, fmt.Sprintf("token_meta_%s %s %v", k, hopeDelim, v))
 		}
+
+		if secret.Auth.MFARequirement != nil {
+			out = append(out, fmt.Sprintf("mfa_request_id %s %s", hopeDelim, secret.Auth.MFARequirement.MFARequestID))
+
+			for k, constraintSet := range secret.Auth.MFARequirement.MFAConstraints {
+				for _, constraint := range constraintSet.Any {
+					out = append(out, fmt.Sprintf("mfa_constraint_%s_%s_id %s %s", k, constraint.Type, hopeDelim, constraint.ID))
+					out = append(out, fmt.Sprintf("mfa_constraint_%s_%s_uses_passcode %s %t", k, constraint.Type, hopeDelim, constraint.UsesPasscode))
+				}
+			}
+		}
 	}
 
 	if secret.WrapInfo != nil {


### PR DESCRIPTION
Two issues have been fixed:
- The success message being erroneously reported during a two-phase MFA flow
- The MFA information being missing during a two-phase MFA flow unless -format=json was provided

Two-step MFA will now look something like this:
```
violethynes@violethynes-C02CW1WWMD6R Repositories % vault login -method userpass username=alice password=kQ3BlE+5M1libWJc
A login request was issued that is subject to MFA validation. Please make sure
to validate the login by sending another request to sys/mfa/validate endpoint.

WARNING! The VAULT_TOKEN environment variable is set! The value of this
variable will take precedence; if this is unwanted please unset VAULT_TOKEN or
update its value accordingly.

WARNING! The following warnings were returned from Vault:

  * A login request was issued that is subject to MFA validation. Please
  make sure to validate the login by sending another request to mfa/validate
  endpoint.

Key                                        Value
---                                        -----
mfa_request_id                             20424e2f-e963-b23d-00de-01f41209fbf9
mfa_constraint_l22_pingid_id               ac25e939-4b7e-41ec-db50-bc65da01a642
mfa_constraint_l22_pingid_uses_passcode    false
mfa_constraint_l22_totp_id                 34dade06-351a-e576-537e-0c7d5b0e6d84
mfa_constraint_l22_totp_uses_passcode      true
```