### PR TITLE
pki/sign-verbatim uses role not before duration

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2178,9 +2178,10 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 
 	// create a role entry; we use this to check that sign-verbatim when used with a role is still honoring TTLs
 	roleData := map[string]interface{}{
-		"ttl":      "4h",
-		"max_ttl":  "8h",
-		"key_type": keyType,
+		"ttl":                 "4h",
+		"max_ttl":             "8h",
+		"key_type":            keyType,
+		"not_before_duration": "2h",
 	}
 	resp, err = b.HandleRequest(context.Background(), &logical.Request{
 		Operation:  logical.UpdateOperation,

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2248,7 +2248,10 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 	}
 	cert := certs[0]
 	if math.Abs(float64(time.Now().Add(12*time.Hour).Unix()-cert.NotAfter.Unix())) < 10 {
-		t.Fatalf("sign-verbatim did not properly cap validity period on signed CSR")
+		t.Fatalf("sign-verbatim did not properly cap validity period (notAfter) on signed CSR: was %v vs requested %v but should've been %v", cert.NotAfter, time.Now().Add(12*time.Hour), time.Now().Add(8*time.Hour))
+	}
+	if math.Abs(float64(time.Now().Add(-2*time.Hour).Unix()-cert.NotBefore.Unix())) > 10 {
+		t.Fatalf("sign-verbatim did not properly cap validity period (notBefore) on signed CSR: was %v vs expected %v", cert.NotBefore, time.Now().Add(-2*time.Hour))
 	}
 
 	// Now check signing a certificate using the not_after input using the Y10K value

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -212,6 +212,9 @@ func (b *backend) pathSignVerbatim(ctx context.Context, req *logical.Request, da
 		if role.GenerateLease != nil {
 			*entry.GenerateLease = *role.GenerateLease
 		}
+		if role.NotBeforeDuration > 0 {
+			entry.NotBeforeDuration = role.NotBeforeDuration
+		}
 		entry.NoStore = role.NoStore
 		entry.Issuer = role.Issuer
 	}

--- a/changelog/15429.txt
+++ b/changelog/15429.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-secrets/pki: pki/sign-verbatim uses not_before_duration defined role
+secrets/pki: Add support for pki/sign-verbatim use the not_before_duration field defined in the role
 ```

--- a/changelog/15429.txt
+++ b/changelog/15429.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: pki/sign-verbatim uses not_before_duration defined role
+```

--- a/changelog/15429.txt
+++ b/changelog/15429.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-secrets/pki: Add support for pki/sign-verbatim use the not_before_duration field defined in the role
+secrets/pki: Have pki/sign-verbatim use the not_before_duration field defined in the role
 ```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -686,8 +686,7 @@ have access.**
    path and takes the value `default`.
 
 - `name` `(string: "")` - Specifies a role. If set, the following parameters
-  from the role will have effect: `ttl`, `max_ttl`, `generate_lease`, and
-  `no_store`.
+  from the role will have effect: `ttl`, `max_ttl`, `generate_lease`, `no_store` and `not_before_duration`.
 
 - `csr` `(string: <required>)` - Specifies the PEM-encoded CSR.
 

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1969,10 +1969,10 @@ request is denied.
 
 - `ttl` `(string: "")` - Specifies the Time To Live value to be used for the
   validity period of the requested certificate, provided as a string duration
-  with time suffix. Hour is the largest suffix. If not set, uses the system
-  default value or the value of `max_ttl`, whichever is shorter. See
-  `not_after` as an alternative for setting an absolute end date (rather
-  than a relative one).
+  with time suffix. Hour is the largest suffix. The value specified is strictly
+  used for future validity. If not set, uses the system default value or the
+  value of `max_ttl`, whichever is shorter. See `not_after` as an alternative
+  for setting an absolute end date (rather than a relative one).
 
 - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
   string duration with time suffix. Hour is the largest suffix. If not set,
@@ -2208,7 +2208,9 @@ request is denied.
 - `basic_constraints_valid_for_non_ca` `(bool: false)` - Mark Basic Constraints
   valid when issuing non-CA certificates.
 
-- `not_before_duration` `(duration: "30s")` - Specifies the duration by which to backdate the NotBefore property.
+- `not_before_duration` `(duration: "30s")` - Specifies the duration by which to
+  backdate the NotBefore property. This value has no impact in the validity period
+  of the requested certificate, specified in the `ttl` field.
 
 - `not_after` `(string)` - Set the Not After field of the certificate with
   specified date value. The value format should be given in UTC format


### PR DESCRIPTION
## Description
pki/sign-verbatim uses `not_before_duration` defined role.
Related to issue: #10174