### PR TITLE
api: make ListPlugins parse only known plugin types

### DIFF
--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -100,23 +100,24 @@ func (c *Sys) ListPluginsWithContext(ctx context.Context, i *ListPluginsInput) (
 		PluginsByType: make(map[consts.PluginType][]string),
 	}
 	if i.Type == consts.PluginTypeUnknown {
-		for pluginTypeStr, pluginsRaw := range secret.Data {
-			pluginType, err := consts.ParsePluginType(pluginTypeStr)
-			if err != nil {
-				return nil, err
+		for _, pluginType := range consts.PluginTypes {
+			pluginsRaw, ok := secret.Data[pluginType.String()]
+			if !ok {
+				continue
 			}
 
 			pluginsIfc, ok := pluginsRaw.([]interface{})
 			if !ok {
-				return nil, fmt.Errorf("unable to parse plugins for %q type", pluginTypeStr)
+				return nil, fmt.Errorf("unable to parse plugins for %q type", pluginType.String())
 			}
 
-			plugins := make([]string, len(pluginsIfc))
-			for i, nameIfc := range pluginsIfc {
+			plugins := make([]string, 0, len(pluginsIfc))
+			for _, nameIfc := range pluginsIfc {
 				name, ok := nameIfc.(string)
 				if !ok {
+					continue
 				}
-				plugins[i] = name
+				plugins = append(plugins, name)
 			}
 			result.PluginsByType[pluginType] = plugins
 		}

--- a/api/sys_plugins_test.go
+++ b/api/sys_plugins_test.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/helper/consts"
+)
+
+func TestListPlugins(t *testing.T) {
+	mockVaultServer := httptest.NewServer(http.HandlerFunc(mockVaultHandler))
+	defer mockVaultServer.Close()
+
+	cfg := DefaultConfig()
+	cfg.Address = mockVaultServer.URL
+	client, err := NewClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := client.Sys().ListPluginsWithContext(context.Background(), &ListPluginsInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPlugins := map[consts.PluginType][]string{
+		consts.PluginTypeCredential: {"alicloud"},
+		consts.PluginTypeDatabase:   {"cassandra-database-plugin"},
+		consts.PluginTypeSecrets:    {"ad", "alicloud"},
+	}
+
+	for pluginType, expected := range expectedPlugins {
+		actualPlugins := resp.PluginsByType[pluginType]
+		if len(expected) != len(actualPlugins) {
+			t.Fatal("Wrong number of plugins", expected, actualPlugins)
+		}
+		for i := range actualPlugins {
+			if expected[i] != actualPlugins[i] {
+				t.Fatalf("Expected %q but got %q", expected[i], actualPlugins[i])
+			}
+		}
+	}
+}
+
+func mockVaultHandler(w http.ResponseWriter, _ *http.Request) {
+	_, _ = w.Write([]byte(listUntypedResponse))
+}
+
+const listUntypedResponse = `{
+  "request_id": "82601a91-cd7a-718f-feca-f573449cc1bb",
+  "lease_id": "",
+  "renewable": false,
+  "lease_duration": 0,
+  "data": {
+    "auth": [
+      "alicloud"
+    ],
+    "database": [
+      "cassandra-database-plugin"
+    ],
+    "secret": [
+      "ad",
+      "alicloud"
+    ],
+    "some_other_unexpected_key": [
+      {
+        "objectKey": "objectValue"
+      },
+      {
+        "arbitraryData": 7
+      }
+    ]
+  },
+  "wrap_info": null,
+  "warnings": null,
+  "auth": null
+}`

--- a/changelog/15434.txt
+++ b/changelog/15434.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: make ListPlugins parse only known plugin types
+```


### PR DESCRIPTION
Currently, adding a new type to the top-level keys of response data will break client code if it's not a plugin type that the client already knows about. This PR makes it only iterate over known plugin types instead to make it more resilient to any future changes.