### PR TITLE
Include default information in LIST keys, issuers

### DIFF
--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -39,6 +39,11 @@ func (b *backend) pathListIssuersHandler(ctx context.Context, req *logical.Reque
 		return nil, err
 	}
 
+	config, err := getIssuersConfig(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+
 	// For each issuer, we need not only the identifier (as returned by
 	// listIssuers), but also the name of the issuer. This means we have to
 	// fetch the actual issuer object as well.
@@ -51,6 +56,7 @@ func (b *backend) pathListIssuersHandler(ctx context.Context, req *logical.Reque
 		responseKeys = append(responseKeys, string(identifier))
 		responseInfo[string(identifier)] = map[string]interface{}{
 			"issuer_name": issuer.Name,
+			"is_default":  identifier == config.DefaultIssuerId,
 		}
 	}
 

--- a/builtin/logical/pki/path_fetch_keys.go
+++ b/builtin/logical/pki/path_fetch_keys.go
@@ -44,6 +44,11 @@ func (b *backend) pathListKeysHandler(ctx context.Context, req *logical.Request,
 		return nil, err
 	}
 
+	config, err := getKeysConfig(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, identifier := range entries {
 		key, err := fetchKeyById(ctx, req.Storage, identifier)
 		if err != nil {
@@ -53,6 +58,8 @@ func (b *backend) pathListKeysHandler(ctx context.Context, req *logical.Request,
 		responseKeys = append(responseKeys, string(identifier))
 		responseInfo[string(identifier)] = map[string]interface{}{
 			keyNameParam: key.Name,
+			"is_default": identifier == config.DefaultKeyId,
+			"key_type":   key.PrivateKeyType,
 		}
 
 	}


### PR DESCRIPTION
This shows whether the specified key or issuer is default, along with
the private key type in the case of a `LIST /keys` (authenticated) call.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`