### PR TITLE
Fix UBI setting environment variable

### DIFF
--- a/.release/docker/ubi-docker-entrypoint.sh
+++ b/.release/docker/ubi-docker-entrypoint.sh
@@ -41,7 +41,7 @@ fi
 # Due to OpenShift environment compatibility, we have to allow group write
 # access to the Vault configuration. This requires us to disable the stricter
 # file permissions checks introduced in Vault v1.11.0.
-export VAULT_DISABLE_FILE_PERMISSIONS_CHECK=1
+export VAULT_DISABLE_FILE_PERMISSIONS_CHECK=true
 
 # If the user is trying to run Vault directly with some arguments, then
 # pass them to Vault.


### PR DESCRIPTION
The `VAULT_DISABLE_FILE_PERMISSIONS_CHECK` presently only takes the value `true` and doesn't use `ParseBool`; change the behavior to match most other environment variables (since it is new), but also update the UBI image to use the literal `true`. 

---

@akshya96 If this will be reverted, I'm happy to remove the updates to the config. But since its still here, I figured I'd aim for consistency. I think, if you wanted to avoid a complete revert and allow users to manually enable the feature, you could update this new code to just set `skipCheckPermissions := true` by default and then just update the docs. 

My 2c. 