### PR TITLE
Use backendUUID instead of mount points for managed keys (OSS)

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -172,7 +172,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 	b.tidyCASGuard = new(uint32)
 	b.tidyStatus = &tidyStatus{state: tidyStatusInactive}
 	b.storage = conf.StorageView
-	b.backendUuid = conf.BackendUUID
+	b.backendUUID = conf.BackendUUID
 
 	b.pkiStorageVersion.Store(0)
 
@@ -183,7 +183,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 type backend struct {
 	*framework.Backend
 
-	backendUuid       string
+	backendUUID       string
 	storage           logical.Storage
 	crlLifetime       time.Duration
 	revokeStorageLock sync.RWMutex

--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func (b *backend) getGenerationParams(ctx context.Context, storage logical.Storage, data *framework.FieldData, mountPoint string) (exported bool, format string, role *roleEntry, errorResp *logical.Response) {
+func (b *backend) getGenerationParams(ctx context.Context, storage logical.Storage, data *framework.FieldData) (exported bool, format string, role *roleEntry, errorResp *logical.Response) {
 	exportedStr := data.Get("exported").(string)
 	switch exportedStr {
 	case "exported":
@@ -37,8 +37,7 @@ func (b *backend) getGenerationParams(ctx context.Context, storage logical.Stora
 			`the "format" path parameter must be "pem", "der", or "pem_bundle"`)
 		return
 	}
-	mkc := newManagedKeyContext(ctx, b, mountPoint)
-	keyType, keyBits, err := getKeyTypeAndBitsForRole(mkc, storage, data)
+	keyType, keyBits, err := getKeyTypeAndBitsForRole(ctx, b, storage, data)
 	if err != nil {
 		errorResp = logical.ErrorResponse(err.Error())
 		return
@@ -80,7 +79,7 @@ func generateCABundle(ctx context.Context, b *backend, input *inputBundle, data 
 		if err != nil {
 			return nil, err
 		}
-		return generateManagedKeyCABundle(ctx, b, input, keyId, data, randomSource)
+		return generateManagedKeyCABundle(ctx, b, keyId, data, randomSource)
 	}
 
 	if existingKeyRequested(input) {
@@ -99,7 +98,7 @@ func generateCABundle(ctx context.Context, b *backend, input *inputBundle, data 
 			if err != nil {
 				return nil, err
 			}
-			return generateManagedKeyCABundle(ctx, b, input, keyId, data, randomSource)
+			return generateManagedKeyCABundle(ctx, b, keyId, data, randomSource)
 		}
 
 		return certutil.CreateCertificateWithKeyGenerator(data, randomSource, existingKeyGeneratorFromBytes(keyEntry))
@@ -115,7 +114,7 @@ func generateCSRBundle(ctx context.Context, b *backend, input *inputBundle, data
 			return nil, err
 		}
 
-		return generateManagedKeyCSRBundle(ctx, b, input, keyId, data, addBasicConstraints, randomSource)
+		return generateManagedKeyCSRBundle(ctx, b, keyId, data, addBasicConstraints, randomSource)
 	}
 
 	if existingKeyRequested(input) {
@@ -134,7 +133,7 @@ func generateCSRBundle(ctx context.Context, b *backend, input *inputBundle, data
 			if err != nil {
 				return nil, err
 			}
-			return generateManagedKeyCSRBundle(ctx, b, input, keyId, data, addBasicConstraints, randomSource)
+			return generateManagedKeyCSRBundle(ctx, b, keyId, data, addBasicConstraints, randomSource)
 		}
 
 		return certutil.CreateCSRWithKeyGenerator(data, addBasicConstraints, randomSource, existingKeyGeneratorFromBytes(key))
@@ -143,14 +142,14 @@ func generateCSRBundle(ctx context.Context, b *backend, input *inputBundle, data
 	return certutil.CreateCSRWithRandomSource(data, addBasicConstraints, randomSource)
 }
 
-func parseCABundle(ctx context.Context, b *backend, req *logical.Request, bundle *certutil.CertBundle) (*certutil.ParsedCertBundle, error) {
+func parseCABundle(ctx context.Context, b *backend, bundle *certutil.CertBundle) (*certutil.ParsedCertBundle, error) {
 	if bundle.PrivateKeyType == certutil.ManagedPrivateKey {
-		return parseManagedKeyCABundle(ctx, b, req, bundle)
+		return parseManagedKeyCABundle(ctx, b, bundle)
 	}
 	return bundle.ToParsedCertBundle()
 }
 
-func getKeyTypeAndBitsForRole(mkc managedKeyContext, storage logical.Storage, data *framework.FieldData) (string, int, error) {
+func getKeyTypeAndBitsForRole(ctx context.Context, b *backend, storage logical.Storage, data *framework.FieldData) (string, int, error) {
 	exportedStr := data.Get("exported").(string)
 	var keyType string
 	var keyBits int
@@ -179,7 +178,7 @@ func getKeyTypeAndBitsForRole(mkc managedKeyContext, storage logical.Storage, da
 			return "", 0, errors.New("unable to determine managed key id" + err.Error())
 		}
 
-		pubKeyManagedKey, err := getManagedKeyPublicKey(mkc, keyId)
+		pubKeyManagedKey, err := getManagedKeyPublicKey(ctx, b, keyId)
 		if err != nil {
 			return "", 0, errors.New("failed to lookup public key from managed key: " + err.Error())
 		}
@@ -187,7 +186,7 @@ func getKeyTypeAndBitsForRole(mkc managedKeyContext, storage logical.Storage, da
 	}
 
 	if existingKeyRequestedFromFieldData(data) {
-		existingPubKey, err := getExistingPublicKey(mkc, storage, data)
+		existingPubKey, err := getExistingPublicKey(ctx, b, storage, data)
 		if err != nil {
 			return "", 0, errors.New("failed to lookup public key from existing key: " + err.Error())
 		}
@@ -198,20 +197,20 @@ func getKeyTypeAndBitsForRole(mkc managedKeyContext, storage logical.Storage, da
 	return string(privateKeyType), keyBits, err
 }
 
-func getExistingPublicKey(mkc managedKeyContext, s logical.Storage, data *framework.FieldData) (crypto.PublicKey, error) {
+func getExistingPublicKey(ctx context.Context, b *backend, s logical.Storage, data *framework.FieldData) (crypto.PublicKey, error) {
 	keyRef, err := getKeyRefWithErr(data)
 	if err != nil {
 		return nil, err
 	}
-	id, err := resolveKeyReference(mkc.ctx, s, keyRef)
+	id, err := resolveKeyReference(ctx, s, keyRef)
 	if err != nil {
 		return nil, err
 	}
-	key, err := fetchKeyById(mkc.ctx, s, id)
+	key, err := fetchKeyById(ctx, s, id)
 	if err != nil {
 		return nil, err
 	}
-	return getPublicKey(mkc, key)
+	return getPublicKey(ctx, b, key)
 }
 
 func getKeyTypeAndBitsFromPublicKeyForRole(pubKey crypto.PublicKey) (certutil.PrivateKeyType, int, error) {

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -121,7 +121,7 @@ func fetchCAInfoByIssuerId(ctx context.Context, b *backend, req *logical.Request
 		return nil, errutil.InternalError{Err: fmt.Sprintf("error while attempting to use issuer %v: %v", issuerId, err)}
 	}
 
-	parsedBundle, err := parseCABundle(ctx, b, req, bundle)
+	parsedBundle, err := parseCABundle(ctx, b, bundle)
 	if err != nil {
 		return nil, errutil.InternalError{Err: err.Error()}
 	}

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -133,11 +133,10 @@ func TestBackend_CRL_EnableDisable(t *testing.T) {
 func TestBackend_Secondary_CRL_Rebuilding(t *testing.T) {
 	ctx := context.Background()
 	b, s := createBackendWithStorage(t)
-	mkc := newManagedKeyContext(ctx, b, "test")
 
 	// Write out the issuer/key to storage without going through the api call as replication would.
 	bundle := genCertBundle(t, b, s)
-	issuer, _, err := writeCaBundle(mkc, s, bundle, "", "")
+	issuer, _, err := writeCaBundle(ctx, b, s, bundle, "", "")
 	require.NoError(t, err)
 
 	// Just to validate, before we call the invalidate function, make sure our CRL has not been generated
@@ -157,11 +156,10 @@ func TestBackend_Secondary_CRL_Rebuilding(t *testing.T) {
 func TestCrlRebuilder(t *testing.T) {
 	ctx := context.Background()
 	b, s := createBackendWithStorage(t)
-	mkc := newManagedKeyContext(ctx, b, "test")
 
 	// Write out the issuer/key to storage without going through the api call as replication would.
 	bundle := genCertBundle(t, b, s)
-	_, _, err := writeCaBundle(mkc, s, bundle, "", "")
+	_, _, err := writeCaBundle(ctx, b, s, bundle, "", "")
 	require.NoError(t, err)
 
 	req := &logical.Request{Storage: s}

--- a/builtin/logical/pki/key_util.go
+++ b/builtin/logical/pki/key_util.go
@@ -12,22 +12,8 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-type managedKeyContext struct {
-	ctx        context.Context
-	b          *backend
-	mountPoint string
-}
-
-func newManagedKeyContext(ctx context.Context, b *backend, mountPoint string) managedKeyContext {
-	return managedKeyContext{
-		ctx:        ctx,
-		b:          b,
-		mountPoint: mountPoint,
-	}
-}
-
-func comparePublicKey(ctx managedKeyContext, key *keyEntry, publicKey crypto.PublicKey) (bool, error) {
-	publicKeyForKeyEntry, err := getPublicKey(ctx, key)
+func comparePublicKey(ctx context.Context, b *backend, key *keyEntry, publicKey crypto.PublicKey) (bool, error) {
+	publicKeyForKeyEntry, err := getPublicKey(ctx, b, key)
 	if err != nil {
 		return false, err
 	}
@@ -35,13 +21,13 @@ func comparePublicKey(ctx managedKeyContext, key *keyEntry, publicKey crypto.Pub
 	return certutil.ComparePublicKeysAndType(publicKeyForKeyEntry, publicKey)
 }
 
-func getPublicKey(mkc managedKeyContext, key *keyEntry) (crypto.PublicKey, error) {
+func getPublicKey(ctx context.Context, b *backend, key *keyEntry) (crypto.PublicKey, error) {
 	if key.PrivateKeyType == certutil.ManagedPrivateKey {
 		keyId, err := extractManagedKeyId([]byte(key.PrivateKey))
 		if err != nil {
 			return nil, err
 		}
-		return getManagedKeyPublicKey(mkc, keyId)
+		return getManagedKeyPublicKey(ctx, b, keyId)
 	}
 
 	signer, _, _, err := getSignerFromKeyEntryBytes(key)
@@ -81,24 +67,6 @@ func getSignerFromBytes(keyBytes []byte) (crypto.Signer, certutil.BlockType, *pe
 	return signer, blk, pemBlock, nil
 }
 
-func getManagedKeyPublicKey(mkc managedKeyContext, keyId managedKeyId) (crypto.PublicKey, error) {
-	// Determine key type and key bits from the managed public key
-	var pubKey crypto.PublicKey
-	err := withManagedPKIKey(mkc.ctx, mkc.b, keyId, mkc.mountPoint, func(ctx context.Context, key logical.ManagedSigningKey) error {
-		var myErr error
-		pubKey, myErr = key.GetPublicKey(ctx)
-		if myErr != nil {
-			return myErr
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, errors.New("failed to lookup public key from managed key: " + err.Error())
-	}
-	return pubKey, nil
-}
-
 func getPublicKeyFromBytes(keyBytes []byte) (crypto.PublicKey, error) {
 	signer, _, _, err := getSignerFromBytes(keyBytes)
 	if err != nil {
@@ -108,7 +76,7 @@ func getPublicKeyFromBytes(keyBytes []byte) (crypto.PublicKey, error) {
 	return signer.Public(), nil
 }
 
-func importKeyFromBytes(mkc managedKeyContext, s logical.Storage, keyValue string, keyName string) (*keyEntry, bool, error) {
+func importKeyFromBytes(ctx context.Context, b *backend, s logical.Storage, keyValue string, keyName string) (*keyEntry, bool, error) {
 	signer, _, _, err := getSignerFromBytes([]byte(keyValue))
 	if err != nil {
 		return nil, false, err
@@ -118,7 +86,7 @@ func importKeyFromBytes(mkc managedKeyContext, s logical.Storage, keyValue strin
 		return nil, false, errors.New("unsupported private key type within pem bundle")
 	}
 
-	key, existed, err := importKey(mkc, s, keyValue, keyName, privateKeyType)
+	key, existed, err := importKey(ctx, b, s, keyValue, keyName, privateKeyType)
 	if err != nil {
 		return nil, false, err
 	}

--- a/builtin/logical/pki/managed_key_util.go
+++ b/builtin/logical/pki/managed_key_util.go
@@ -4,35 +4,35 @@ package pki
 
 import (
 	"context"
+	"crypto"
 	"errors"
 	"io"
 
 	"github.com/hashicorp/vault/sdk/helper/certutil"
-	"github.com/hashicorp/vault/sdk/logical"
 )
 
 var errEntOnly = errors.New("managed keys are supported within enterprise edition only")
 
-func generateManagedKeyCABundle(ctx context.Context, b *backend, input *inputBundle, keyId managedKeyId, data *certutil.CreationBundle, randomSource io.Reader) (bundle *certutil.ParsedCertBundle, err error) {
+func generateManagedKeyCABundle(ctx context.Context, b *backend, keyId managedKeyId, data *certutil.CreationBundle, randomSource io.Reader) (bundle *certutil.ParsedCertBundle, err error) {
 	return nil, errEntOnly
 }
 
-func generateManagedKeyCSRBundle(ctx context.Context, b *backend, input *inputBundle, keyId managedKeyId, data *certutil.CreationBundle, addBasicConstraints bool, randomSource io.Reader) (bundle *certutil.ParsedCSRBundle, err error) {
+func generateManagedKeyCSRBundle(ctx context.Context, b *backend, keyId managedKeyId, data *certutil.CreationBundle, addBasicConstraints bool, randomSource io.Reader) (bundle *certutil.ParsedCSRBundle, err error) {
 	return nil, errEntOnly
 }
 
-func parseManagedKeyCABundle(ctx context.Context, b *backend, req *logical.Request, bundle *certutil.CertBundle) (*certutil.ParsedCertBundle, error) {
+func getManagedKeyPublicKey(ctx context.Context, b *backend, keyId managedKeyId) (crypto.PublicKey, error) {
 	return nil, errEntOnly
 }
 
-func withManagedPKIKey(ctx context.Context, b *backend, keyId managedKeyId, mountPoint string, f logical.ManagedSigningKeyConsumer) error {
-	return errEntOnly
+func parseManagedKeyCABundle(ctx context.Context, b *backend, bundle *certutil.CertBundle) (*certutil.ParsedCertBundle, error) {
+	return nil, errEntOnly
 }
 
 func extractManagedKeyId(privateKeyBytes []byte) (UUIDKey, error) {
 	return "", errEntOnly
 }
 
-func createKmsKeyBundle(mkc managedKeyContext, keyId managedKeyId) (certutil.KeyBundle, certutil.PrivateKeyType, error) {
+func createKmsKeyBundle(ctx context.Context, b *backend, keyId managedKeyId) (certutil.KeyBundle, certutil.PrivateKeyType, error) {
 	return certutil.KeyBundle{}, certutil.UnknownPrivateKey, errEntOnly
 }

--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -63,7 +63,7 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 		data.Raw["exported"] = "existing"
 	}
 
-	exported, format, role, errorResp := b.getGenerationParams(ctx, req.Storage, data, req.MountPoint)
+	exported, format, role, errorResp := b.getGenerationParams(ctx, req.Storage, data)
 	if errorResp != nil {
 		return errorResp, nil
 	}
@@ -130,7 +130,7 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 		}
 	}
 
-	myKey, _, err := importKey(newManagedKeyContext(ctx, b, req.MountPoint), req.Storage, csrb.PrivateKey, keyName, csrb.PrivateKeyType)
+	myKey, _, err := importKey(ctx, b, req.Storage, csrb.PrivateKey, keyName, csrb.PrivateKeyType)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -181,10 +181,9 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 		return logical.ErrorResponse("private keys found in the PEM bundle but not allowed by the path; use /issuers/import/bundle"), nil
 	}
 
-	mkc := newManagedKeyContext(ctx, b, req.MountPoint)
 	for keyIndex, keyPem := range keys {
 		// Handle import of private key.
-		key, existing, err := importKeyFromBytes(mkc, req.Storage, keyPem, "")
+		key, existing, err := importKeyFromBytes(ctx, b, req.Storage, keyPem, "")
 		if err != nil {
 			return logical.ErrorResponse(fmt.Sprintf("Error parsing key %v: %v", keyIndex, err)), nil
 		}
@@ -195,7 +194,7 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 	}
 
 	for certIndex, certPem := range issuers {
-		cert, existing, err := importIssuer(mkc, req.Storage, certPem, "")
+		cert, existing, err := importIssuer(ctx, b, req.Storage, certPem, "")
 		if err != nil {
 			return logical.ErrorResponse(fmt.Sprintf("Error parsing issuer %v: %v\n%v", certIndex, err, certPem)), nil
 		}

--- a/builtin/logical/pki/path_manage_keys.go
+++ b/builtin/logical/pki/path_manage_keys.go
@@ -83,7 +83,6 @@ func (b *backend) pathGenerateKeyHandler(ctx context.Context, req *logical.Reque
 		return nil, err
 	}
 
-	mkc := newManagedKeyContext(ctx, b, req.MountPoint)
 	exportPrivateKey := false
 	var keyBundle certutil.KeyBundle
 	var actualPrivateKeyType certutil.PrivateKeyType
@@ -113,7 +112,7 @@ func (b *backend) pathGenerateKeyHandler(ctx context.Context, req *logical.Reque
 			return nil, err
 		}
 
-		keyBundle, actualPrivateKeyType, err = createKmsKeyBundle(mkc, keyId)
+		keyBundle, actualPrivateKeyType, err = createKmsKeyBundle(ctx, b, keyId)
 		if err != nil {
 			return nil, err
 		}
@@ -126,7 +125,7 @@ func (b *backend) pathGenerateKeyHandler(ctx context.Context, req *logical.Reque
 		return nil, err
 	}
 
-	key, _, err := importKey(mkc, req.Storage, privateKeyPemString, keyName, keyBundle.PrivateKeyType)
+	key, _, err := importKey(ctx, b, req.Storage, privateKeyPemString, keyName, keyBundle.PrivateKeyType)
 	if err != nil {
 		return nil, err
 	}
@@ -194,8 +193,7 @@ func (b *backend) pathImportKeyHandler(ctx context.Context, req *logical.Request
 	keyValue := keyValueInterface.(string)
 	keyName := data.Get(keyNameParam).(string)
 
-	mkc := newManagedKeyContext(ctx, b, req.MountPoint)
-	key, existed, err := importKeyFromBytes(mkc, req.Storage, keyValue, keyName)
+	key, existed, err := importKeyFromBytes(ctx, b, req.Storage, keyValue, keyName)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -108,7 +108,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 		return logical.ErrorResponse("Can not create root CA until migration has completed"), nil
 	}
 
-	exported, format, role, errorResp := b.getGenerationParams(ctx, req.Storage, data, req.MountPoint)
+	exported, format, role, errorResp := b.getGenerationParams(ctx, req.Storage, data)
 	if errorResp != nil {
 		return errorResp, nil
 	}
@@ -204,7 +204,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 	}
 
 	// Store it as the CA bundle
-	myIssuer, myKey, err := writeCaBundle(newManagedKeyContext(ctx, b, req.MountPoint), req.Storage, cb, issuerName, keyName)
+	myIssuer, myKey, err := writeCaBundle(ctx, b, req.Storage, cb, issuerName, keyName)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -222,7 +222,7 @@ func deleteKey(ctx context.Context, s logical.Storage, id keyID) (bool, error) {
 	return wasDefault, s.Delete(ctx, keyPrefix+id.String())
 }
 
-func importKey(mkc managedKeyContext, s logical.Storage, keyValue string, keyName string, keyType certutil.PrivateKeyType) (*keyEntry, bool, error) {
+func importKey(ctx context.Context, b *backend, s logical.Storage, keyValue string, keyName string, keyType certutil.PrivateKeyType) (*keyEntry, bool, error) {
 	// importKey imports the specified PEM-format key (from keyValue) into
 	// the new PKI storage format. The first return field is a reference to
 	// the new key; the second is whether or not the key already existed
@@ -237,7 +237,7 @@ func importKey(mkc managedKeyContext, s logical.Storage, keyValue string, keyNam
 	// Before we can import a known key, we first need to know if the key
 	// exists in storage already. This means iterating through all known
 	// keys and comparing their private value against this value.
-	knownKeys, err := listKeys(mkc.ctx, s)
+	knownKeys, err := listKeys(ctx, s)
 	if err != nil {
 		return nil, false, err
 	}
@@ -249,7 +249,7 @@ func importKey(mkc managedKeyContext, s logical.Storage, keyValue string, keyNam
 		if err != nil {
 			return nil, false, errutil.InternalError{Err: fmt.Sprintf("failed extracting managed key uuid from key: %v", err)}
 		}
-		pkForImportingKey, err = getManagedKeyPublicKey(mkc, managedKeyUUID)
+		pkForImportingKey, err = getManagedKeyPublicKey(ctx, b, managedKeyUUID)
 		if err != nil {
 			return nil, false, err
 		}
@@ -261,11 +261,11 @@ func importKey(mkc managedKeyContext, s logical.Storage, keyValue string, keyNam
 	}
 
 	for _, identifier := range knownKeys {
-		existingKey, err := fetchKeyById(mkc.ctx, s, identifier)
+		existingKey, err := fetchKeyById(ctx, s, identifier)
 		if err != nil {
 			return nil, false, err
 		}
-		areEqual, err := comparePublicKey(mkc, existingKey, pkForImportingKey)
+		areEqual, err := comparePublicKey(ctx, b, existingKey, pkForImportingKey)
 		if err != nil {
 			return nil, false, err
 		}
@@ -286,7 +286,7 @@ func importKey(mkc managedKeyContext, s logical.Storage, keyValue string, keyNam
 	result.PrivateKeyType = keyType
 
 	// Finally, we can write the key to storage.
-	if err := writeKey(mkc.ctx, s, result); err != nil {
+	if err := writeKey(ctx, s, result); err != nil {
 		return nil, false, err
 	}
 
@@ -294,14 +294,14 @@ func importKey(mkc managedKeyContext, s logical.Storage, keyValue string, keyNam
 	// one of them has a missing KeyId link, and if so, point it back to
 	// ourselves. We fetch the list of issuers up front, even when don't need
 	// it, to give ourselves a better chance of succeeding below.
-	knownIssuers, err := listIssuers(mkc.ctx, s)
+	knownIssuers, err := listIssuers(ctx, s)
 	if err != nil {
 		return nil, false, err
 	}
 
 	// Now, for each issuer, try and compute the issuer<->key link if missing.
 	for _, identifier := range knownIssuers {
-		existingIssuer, err := fetchIssuerById(mkc.ctx, s, identifier)
+		existingIssuer, err := fetchIssuerById(ctx, s, identifier)
 		if err != nil {
 			return nil, false, err
 		}
@@ -329,7 +329,7 @@ func importKey(mkc managedKeyContext, s logical.Storage, keyValue string, keyNam
 			// These public keys are equal, so this key entry must be the
 			// corresponding private key to this issuer; update it accordingly.
 			existingIssuer.KeyID = result.ID
-			if err := writeIssuer(mkc.ctx, s, existingIssuer); err != nil {
+			if err := writeIssuer(ctx, s, existingIssuer); err != nil {
 				return nil, false, err
 			}
 		}
@@ -337,12 +337,12 @@ func importKey(mkc managedKeyContext, s logical.Storage, keyValue string, keyNam
 
 	// If there was no prior default value set and/or we had no known
 	// keys when we started, set this key as default.
-	keyDefaultSet, err := isDefaultKeySet(mkc.ctx, s)
+	keyDefaultSet, err := isDefaultKeySet(ctx, s)
 	if err != nil {
 		return nil, false, err
 	}
 	if len(knownKeys) == 0 || !keyDefaultSet {
-		if err = updateDefaultKeyId(mkc.ctx, s, result.ID); err != nil {
+		if err = updateDefaultKeyId(ctx, s, result.ID); err != nil {
 			return nil, false, err
 		}
 	}
@@ -495,7 +495,7 @@ func deleteIssuer(ctx context.Context, s logical.Storage, id issuerID) (bool, er
 	return wasDefault, s.Delete(ctx, issuerPrefix+id.String())
 }
 
-func importIssuer(ctx managedKeyContext, s logical.Storage, certValue string, issuerName string) (*issuerEntry, bool, error) {
+func importIssuer(ctx context.Context, b *backend, s logical.Storage, certValue string, issuerName string) (*issuerEntry, bool, error) {
 	// importIssuers imports the specified PEM-format certificate (from
 	// certValue) into the new PKI storage format. The first return field is a
 	// reference to the new issuer; the second is whether or not the issuer
@@ -533,13 +533,13 @@ func importIssuer(ctx managedKeyContext, s logical.Storage, certValue string, is
 	// Before we can import a known issuer, we first need to know if the issuer
 	// exists in storage already. This means iterating through all known
 	// issuers and comparing their private value against this value.
-	knownIssuers, err := listIssuers(ctx.ctx, s)
+	knownIssuers, err := listIssuers(ctx, s)
 	if err != nil {
 		return nil, false, err
 	}
 
 	for _, identifier := range knownIssuers {
-		existingIssuer, err := fetchIssuerById(ctx.ctx, s, identifier)
+		existingIssuer, err := fetchIssuerById(ctx, s, identifier)
 		if err != nil {
 			return nil, false, err
 		}
@@ -576,7 +576,7 @@ func importIssuer(ctx managedKeyContext, s logical.Storage, certValue string, is
 	// one of them a public key matching this certificate, and if so, update our
 	// link accordingly. We fetch the list of keys up front, even may not need
 	// it, to give ourselves a better chance of succeeding below.
-	knownKeys, err := listKeys(ctx.ctx, s)
+	knownKeys, err := listKeys(ctx, s)
 	if err != nil {
 		return nil, false, err
 	}
@@ -585,12 +585,12 @@ func importIssuer(ctx managedKeyContext, s logical.Storage, certValue string, is
 	// writing issuer to storage as we won't need to update the key, only
 	// the issuer.
 	for _, identifier := range knownKeys {
-		existingKey, err := fetchKeyById(ctx.ctx, s, identifier)
+		existingKey, err := fetchKeyById(ctx, s, identifier)
 		if err != nil {
 			return nil, false, err
 		}
 
-		equal, err := comparePublicKey(ctx, existingKey, issuerCert.PublicKey)
+		equal, err := comparePublicKey(ctx, b, existingKey, issuerCert.PublicKey)
 		if err != nil {
 			return nil, false, err
 		}
@@ -607,18 +607,18 @@ func importIssuer(ctx managedKeyContext, s logical.Storage, certValue string, is
 
 	// Finally, rebuild the chains. In this process, because the provided
 	// reference issuer is non-nil, we'll save this issuer to storage.
-	if err := rebuildIssuersChains(ctx.ctx, s, &result); err != nil {
+	if err := rebuildIssuersChains(ctx, s, &result); err != nil {
 		return nil, false, err
 	}
 
 	// If there was no prior default value set and/or we had no known
 	// issuers when we started, set this issuer as default.
-	issuerDefaultSet, err := isDefaultIssuerSet(ctx.ctx, s)
+	issuerDefaultSet, err := isDefaultIssuerSet(ctx, s)
 	if err != nil {
 		return nil, false, err
 	}
 	if len(knownIssuers) == 0 || !issuerDefaultSet {
-		if err = updateDefaultIssuerId(ctx.ctx, s, result.ID); err != nil {
+		if err = updateDefaultIssuerId(ctx, s, result.ID); err != nil {
 			return nil, false, err
 		}
 	}
@@ -828,19 +828,19 @@ func fetchCertBundleByIssuerId(ctx context.Context, s logical.Storage, id issuer
 	return issuer, &bundle, nil
 }
 
-func writeCaBundle(mkc managedKeyContext, s logical.Storage, caBundle *certutil.CertBundle, issuerName string, keyName string) (*issuerEntry, *keyEntry, error) {
-	myKey, _, err := importKey(mkc, s, caBundle.PrivateKey, keyName, caBundle.PrivateKeyType)
+func writeCaBundle(ctx context.Context, b *backend, s logical.Storage, caBundle *certutil.CertBundle, issuerName string, keyName string) (*issuerEntry, *keyEntry, error) {
+	myKey, _, err := importKey(ctx, b, s, caBundle.PrivateKey, keyName, caBundle.PrivateKeyType)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	myIssuer, _, err := importIssuer(mkc, s, caBundle.Certificate, issuerName)
+	myIssuer, _, err := importIssuer(ctx, b, s, caBundle.Certificate, issuerName)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	for _, cert := range caBundle.CAChain {
-		if _, _, err = importIssuer(mkc, s, cert, ""); err != nil {
+		if _, _, err = importIssuer(ctx, b, s, cert, ""); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -81,8 +81,7 @@ func migrateStorage(ctx context.Context, b *backend, s logical.Storage) error {
 
 	b.Logger().Info("performing PKI migration to new keys/issuers layout")
 	if migrationInfo.legacyBundle != nil {
-		mkc := newManagedKeyContext(ctx, b, b.backendUuid)
-		anIssuer, aKey, err := writeCaBundle(mkc, s, migrationInfo.legacyBundle, "current", "current")
+		anIssuer, aKey, err := writeCaBundle(ctx, b, s, migrationInfo.legacyBundle, "current", "current")
 		if err != nil {
 			return err
 		}

--- a/builtin/logical/pki/storage_test.go
+++ b/builtin/logical/pki/storage_test.go
@@ -93,7 +93,6 @@ func Test_IssuerRoundTrip(t *testing.T) {
 
 func Test_KeysIssuerImport(t *testing.T) {
 	b, s := createBackendWithStorage(t)
-	mkc := newManagedKeyContext(ctx, b, "test")
 
 	issuer1, key1 := genIssuerAndKey(t, b, s)
 	issuer2, key2 := genIssuerAndKey(t, b, s)
@@ -104,21 +103,21 @@ func Test_KeysIssuerImport(t *testing.T) {
 	issuer1.ID = ""
 	issuer1.KeyID = ""
 
-	key1Ref1, existing, err := importKey(mkc, s, key1.PrivateKey, "key1", key1.PrivateKeyType)
+	key1Ref1, existing, err := importKey(ctx, b, s, key1.PrivateKey, "key1", key1.PrivateKeyType)
 	require.NoError(t, err)
 	require.False(t, existing)
 	require.Equal(t, strings.TrimSpace(key1.PrivateKey), strings.TrimSpace(key1Ref1.PrivateKey))
 
 	// Make sure if we attempt to re-import the same private key, no import/updates occur.
 	// So the existing flag should be set to true, and we do not update the existing Name field.
-	key1Ref2, existing, err := importKey(mkc, s, key1.PrivateKey, "ignore-me", key1.PrivateKeyType)
+	key1Ref2, existing, err := importKey(ctx, b, s, key1.PrivateKey, "ignore-me", key1.PrivateKeyType)
 	require.NoError(t, err)
 	require.True(t, existing)
 	require.Equal(t, key1.PrivateKey, key1Ref1.PrivateKey)
 	require.Equal(t, key1Ref1.ID, key1Ref2.ID)
 	require.Equal(t, key1Ref1.Name, key1Ref2.Name)
 
-	issuer1Ref1, existing, err := importIssuer(mkc, s, issuer1.Certificate, "issuer1")
+	issuer1Ref1, existing, err := importIssuer(ctx, b, s, issuer1.Certificate, "issuer1")
 	require.NoError(t, err)
 	require.False(t, existing)
 	require.Equal(t, strings.TrimSpace(issuer1.Certificate), strings.TrimSpace(issuer1Ref1.Certificate))
@@ -127,7 +126,7 @@ func Test_KeysIssuerImport(t *testing.T) {
 
 	// Make sure if we attempt to re-import the same issuer, no import/updates occur.
 	// So the existing flag should be set to true, and we do not update the existing Name field.
-	issuer1Ref2, existing, err := importIssuer(mkc, s, issuer1.Certificate, "ignore-me")
+	issuer1Ref2, existing, err := importIssuer(ctx, b, s, issuer1.Certificate, "ignore-me")
 	require.NoError(t, err)
 	require.True(t, existing)
 	require.Equal(t, strings.TrimSpace(issuer1.Certificate), strings.TrimSpace(issuer1Ref1.Certificate))
@@ -142,7 +141,7 @@ func Test_KeysIssuerImport(t *testing.T) {
 	require.NoError(t, err)
 
 	// Same double import tests as above, but make sure if the previous was created through writeIssuer not importIssuer.
-	issuer2Ref, existing, err := importIssuer(mkc, s, issuer2.Certificate, "ignore-me")
+	issuer2Ref, existing, err := importIssuer(ctx, b, s, issuer2.Certificate, "ignore-me")
 	require.NoError(t, err)
 	require.True(t, existing)
 	require.Equal(t, strings.TrimSpace(issuer2.Certificate), strings.TrimSpace(issuer2Ref.Certificate))
@@ -151,7 +150,7 @@ func Test_KeysIssuerImport(t *testing.T) {
 	require.Equal(t, issuer2.KeyID, issuer2Ref.KeyID)
 
 	// Same double import tests as above, but make sure if the previous was created through writeKey not importKey.
-	key2Ref, existing, err := importKey(mkc, s, key2.PrivateKey, "ignore-me", key2.PrivateKeyType)
+	key2Ref, existing, err := importKey(ctx, b, s, key2.PrivateKey, "ignore-me", key2.PrivateKeyType)
 	require.NoError(t, err)
 	require.True(t, existing)
 	require.Equal(t, key2.PrivateKey, key2Ref.PrivateKey)
@@ -196,7 +195,7 @@ func genCertBundle(t *testing.T, b *backend, s logical.Storage) *certutil.CertBu
 			"ttl":      3600,
 		},
 	}
-	_, _, role, respErr := b.getGenerationParams(ctx, s, apiData, "/pki")
+	_, _, role, respErr := b.getGenerationParams(ctx, s, apiData)
 	require.Nil(t, respErr)
 
 	input := &inputBundle{

--- a/sdk/logical/managed_key.go
+++ b/sdk/logical/managed_key.go
@@ -40,17 +40,17 @@ type (
 type ManagedKeySystemView interface {
 	// WithManagedKeyByName retrieves an instantiated managed key for consumption by the given function.  The
 	// provided key can only be used within the scope of that function call
-	WithManagedKeyByName(ctx context.Context, keyName, mountPoint string, f ManagedKeyConsumer) error
+	WithManagedKeyByName(ctx context.Context, keyName, backendUUID string, f ManagedKeyConsumer) error
 	// WithManagedKeyByUUID retrieves an instantiated managed key for consumption by the given function.  The
 	// provided key can only be used within the scope of that function call
-	WithManagedKeyByUUID(ctx context.Context, keyUuid, mountPoint string, f ManagedKeyConsumer) error
+	WithManagedKeyByUUID(ctx context.Context, keyUuid, backendUUID string, f ManagedKeyConsumer) error
 
 	// WithManagedSigningKeyByName retrieves an instantiated managed signing key for consumption by the given function,
 	// with the same semantics as WithManagedKeyByName
-	WithManagedSigningKeyByName(ctx context.Context, keyName, mountPoint string, f ManagedSigningKeyConsumer) error
+	WithManagedSigningKeyByName(ctx context.Context, keyName, backendUUID string, f ManagedSigningKeyConsumer) error
 	// WithManagedSigningKeyByUUID retrieves an instantiated managed signing key for consumption by the given function,
 	// with the same semantics as WithManagedKeyByUUID
-	WithManagedSigningKeyByUUID(ctx context.Context, keyUuid, mountPoint string, f ManagedSigningKeyConsumer) error
+	WithManagedSigningKeyByUUID(ctx context.Context, keyUuid, backendUUID string, f ManagedSigningKeyConsumer) error
 }
 
 type ManagedAsymmetricKey interface {


### PR DESCRIPTION
 - Remove all references to mount point within PKI
 - Leverage the mount's backend UUID now instead of a mount point for all managed key lookups.