### PR TITLE
Fix ubi-docker-entrypoint.sh->docker-entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,8 +143,8 @@ EXPOSE 8200
 #
 # For production derivatives of this container, you shoud add the IPC_LOCK
 # capability so that Vault can mlock memory.
-COPY .release/docker/ubi-docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["ubi-docker-entrypoint.sh"]
+COPY .release/docker/ubi-docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 # Use the Vault user as the default user for starting this container.
 USER vault


### PR DESCRIPTION
It is believed to break the helm chart; see also:

https://github.com/hashicorp/vault/pull/15272#discussion_r873927744

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`