### PR TITLE
docs: fix typo in jwt k8 provider

### DIFF
--- a/website/content/docs/auth/jwt/oidc_providers.mdx
+++ b/website/content/docs/auth/jwt/oidc_providers.mdx
@@ -431,7 +431,7 @@ log in.
    ```bash
    vault write auth/jwt/role/my-role \
       role_type="jwt" \
-      bound_audiences="${ISSUER}" \
+      bound_audiences="https://kubernetes.default.svc" \
       user_claim="sub" \
       bound_subject="system:serviceaccount:default:default" \
       policies="default" \


### PR DESCRIPTION
A small typo was found in the JWT auth documentation for Kubernetes. In the example given, the ISSUER env is set to the address of the OIDC well-known endpoint. This should instead be `https://kubernetes.default.svc`.