### PR TITLE
docs: add note about upndomain for AD secret engine

### DIFF
--- a/website/content/api-docs/secret/ad.mdx
+++ b/website/content/api-docs/secret/ad.mdx
@@ -53,7 +53,7 @@ text that fulfills those requirements. `{{PASSWORD}}` must appear exactly once a
 - `binddn` (string, required) - Distinguished name of object to bind when performing user and group search. Example: `cn=vault,ou=Users,dc=example,dc=com`
 - `bindpass` (string, required) - Password to use along with `binddn` when performing user search.
 - `userdn` (string, optional) - Base DN under which to perform user search. Example: `ou=Users,dc=example,dc=com`
-- `upndomain` (string, optional) - userPrincipalDomain used to construct the UPN string for the authenticating user. The constructed UPN will appear as `[username]@UPNDomain`. Example: `example.com`, which will cause vault to bind as `username@example.com`.
+- `upndomain` (string, optional) - The domain (userPrincipalDomain) used to construct a UPN string for authentication. The constructed UPN will appear as `[binddn]@UPNDomain`. Example: if `upndomain=example.com` and `binddn=admin`, the UPN string `admin@example.com` will be used to login to Active Directory.
 
 ### Other parameters
 


### PR DESCRIPTION
Documentation clarifying related to https://github.com/hashicorp/vault-plugin-secrets-ad/issues/84, where `upndomain` can cause confusion while configuring the AD secret engine when used with `binddn`. 