### PR TITLE
Fix a keysutil policy lock

### DIFF
--- a/builtin/logical/transit/path_import.go
+++ b/builtin/logical/transit/path_import.go
@@ -156,7 +156,7 @@ func (b *backend) pathImportWrite(ctx context.Context, req *logical.Request, d *
 		AllowImportedKeyRotation: allowRotation,
 	}
 
-	switch keyType {
+	switch strings.ToLower(keyType) {
 	case "aes128-gcm96":
 		polReq.KeyType = keysutil.KeyType_AES128_GCM96
 	case "aes256-gcm96":

--- a/sdk/helper/keysutil/lock_manager.go
+++ b/sdk/helper/keysutil/lock_manager.go
@@ -464,6 +464,7 @@ func (lm *LockManager) ImportPolicy(ctx context.Context, req PolicyRequest, key 
 	// finished before we load from storage.
 	lock := locksutil.LockForKey(lm.keyLocks, req.Name)
 	lock.Lock()
+	defer lock.Unlock()
 
 	// Load it from storage
 	p, err = lm.getPolicyFromStorage(ctx, req.Storage, req.Name)
@@ -493,8 +494,6 @@ func (lm *LockManager) ImportPolicy(ctx context.Context, req PolicyRequest, key 
 	if lm.useCache {
 		lm.cache.Store(req.Name, p)
 	}
-
-	lock.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
# Summary
This fixes a couple issues:
- Defers a policy unlock in keysutil that could cause single policy deadlocks when an import fails.
- Updates Transit import endpoint to accept different capitalizations of key type for convenience.