### PR TITLE
Store migrated issuer, key ID in migration log

### DIFF
--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -40,6 +40,8 @@ func Test_migrateStorageEmptyStorage(t *testing.T) {
 		"Hash value (%s) should not have been empty", logEntry.Hash)
 	require.True(t, startTime.Before(logEntry.Created),
 		"created log entry time (%v) was before our start time(%v)?", logEntry.Created, startTime)
+	require.Empty(t, logEntry.CreatedIssuer)
+	require.Empty(t, logEntry.CreatedKey)
 
 	require.False(t, b.useLegacyBundleCaStorage(), "post migration we are still told to use legacy storage")
 
@@ -91,6 +93,8 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 		"Hash value (%s) should not have been empty", logEntry.Hash)
 	require.True(t, startTime.Before(logEntry.Created),
 		"created log entry time (%v) was before our start time(%v)?", logEntry.Created, startTime)
+	require.Equal(t, logEntry.CreatedIssuer, issuerIds[0])
+	require.Equal(t, logEntry.CreatedKey, keyIds[0])
 
 	issuerId := issuerIds[0]
 	keyId := keyIds[0]


### PR DESCRIPTION
If necessary, this will let us correlate migrated values afterwards.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

@sgmiller and @stevendpclark I think we talked about this but never got around to doing it. I think it was supposed to be done around the same time as adding the (present) issuer to the certificate storage entry, but because that didn't happen (wasn't a fat format), this didn't happen either.

I opted to add it to the log, even though there's no (present) way of returning the log info to the user, rather than to the issuers config. Thoughts?