### PR TITLE
Log less around the current status of the PKI migration

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -344,10 +344,8 @@ func (b *backend) updatePkiStorageVersion(ctx context.Context, grabIssuersLock b
 	}
 
 	if info.isRequired {
-		b.Logger().Info("PKI migration is required, reading cert bundle from legacy ca location")
 		b.pkiStorageVersion.Store(0)
 	} else {
-		b.Logger().Debug("PKI migration previously completed, reading cert bundle from key/issuer storage")
 		b.pkiStorageVersion.Store(1)
 	}
 }
@@ -360,6 +358,7 @@ func (b *backend) invalidate(ctx context.Context, key string) {
 		// as a go routine to not block this call due to the lock grabbing
 		// within updatePkiStorageVersion.
 		go func() {
+			b.Logger().Info("Detected a migration completed, resetting pki storage version")
 			b.updatePkiStorageVersion(ctx, true)
 			b.crlBuilder.requestRebuildIfActiveNode(b)
 		}()

--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -77,29 +77,26 @@ func migrateStorage(ctx context.Context, b *backend, s logical.Storage) error {
 
 	if !migrationInfo.isRequired {
 		// No migration was deemed to be required.
-		b.Logger().Debug("existing migration found and was considered valid, skipping migration.")
 		return nil
 	}
 
 	var issuerIdentifier issuerID
 	var keyIdentifier keyID
-	b.Logger().Info("performing PKI migration to new keys/issuers layout")
 	if migrationInfo.legacyBundle != nil {
+		b.Logger().Info("performing PKI migration to new keys/issuers layout")
 		anIssuer, aKey, err := writeCaBundle(ctx, b, s, migrationInfo.legacyBundle, "current", "current")
 		if err != nil {
 			return err
 		}
-		b.Logger().Debug("Migration generated the following ids and set them as defaults",
+		b.Logger().Info("Migration generated the following ids and set them as defaults",
 			"issuer id", anIssuer.ID, "key id", aKey.ID)
 		issuerIdentifier = anIssuer.ID
 		keyIdentifier = aKey.ID
-	} else {
-		b.Logger().Debug("No legacy CA certs found, no migration required.")
-	}
 
-	// Since we do not have all the mount information available we must schedule
-	// the CRL to be rebuilt at a later time.
-	b.crlBuilder.requestRebuildIfActiveNode(b)
+		// Since we do not have all the mount information available we must schedule
+		// the CRL to be rebuilt at a later time.
+		b.crlBuilder.requestRebuildIfActiveNode(b)
+	}
 
 	// We always want to write out this log entry as the secondary clusters leverage this path to wake up
 	// if they were upgraded prior to the primary cluster's migration occurred.
@@ -114,7 +111,6 @@ func migrateStorage(ctx context.Context, b *backend, s logical.Storage) error {
 		return err
 	}
 
-	b.Logger().Info("successfully completed migration to new keys/issuers layout")
 	return nil
 }
 


### PR DESCRIPTION
 - No point in writing any logs if no previous bundle exists
 - Only log output and schedule a CRL rebuild is we actually migrated something
 - Do not log on PKI storage version set/checks.


Logs when needing to migration an existing bundle

```
2022-05-16T17:19:12.085-0400 [INFO]  secrets.pki.pki_e3586de1: performing PKI migration to new keys/issuers layout
2022-05-16T17:19:12.086-0400 [INFO]  secrets.pki.pki_e3586de1: Migration generated the following ids and set them as defaults: issuer id=691b8102-1e26-ddc3-a891-5ac8145ce081 key id=7396a3a8-f72a-4eaf-e6fc-547f295a45d9
2022-05-16T17:19:12.086-0400 [INFO]  secrets.pki.pki_e3586de1: Scheduling PKI CRL rebuild.
```

There are no logs printed out if there isn't an existing bundle.

We output the following on non-active nodes when a migration has completed.
```
2022-05-16T17:19:12.485-0400 [INFO]  secrets.pki.pki_e3586de1: Detected a migration completed, resetting pki storage version
```
