### PR TITLE
Vault-6037 making filesystem permissions check opt-in

### DIFF
--- a/changelog/15452.txt
+++ b/changelog/15452.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: renaming the environment variable VAULT_DISABLE_FILE_PERMISSIONS_CHECK to VAULT_ENABLE_FILE_PERMISSIONS_CHECK and adjusting the logic
+```

--- a/command/operator_diagnose_test.go
+++ b/command/operator_diagnose_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/vault/diagnose"
 	"github.com/mitchellh/cli"
 )
@@ -479,7 +478,6 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				t.Parallel()
 				client, closer := testVaultServer(t)
 				defer closer()
-				os.Setenv(consts.VaultDisableFilePermissionsCheckEnv, "true")
 				cmd := testOperatorDiagnoseCommand(t)
 				cmd.client = client
 

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -368,7 +368,16 @@ func LoadConfig(path string) (*Config, error) {
 
 	if fi.IsDir() {
 		// check permissions on the config directory
-		if os.Getenv(consts.VaultEnableFilePermissionsCheckEnv) == "true" {
+		var enableFilePermissionsCheck bool
+		if enableFilePermissionsCheckEnv := os.Getenv(consts.VaultEnableFilePermissionsCheckEnv); enableFilePermissionsCheckEnv != "" {
+			var err error
+			enableFilePermissionsCheck, err = strconv.ParseBool(enableFilePermissionsCheckEnv)
+			if err != nil {
+				return nil, errors.New("Error parsing the environment variable VAULT_ENABLE_FILE_PERMISSIONS_CHECK")
+			}
+		}
+
+		if enableFilePermissionsCheck {
 			err = osutil.OwnerPermissionsMatch(path, 0, 0)
 			if err != nil {
 				return nil, err
@@ -409,7 +418,16 @@ func LoadConfigFile(path string) (*Config, error) {
 		return nil, err
 	}
 
-	if os.Getenv(consts.VaultEnableFilePermissionsCheckEnv) == "true" {
+	var enableFilePermissionsCheck bool
+	if enableFilePermissionsCheckEnv := os.Getenv(consts.VaultEnableFilePermissionsCheckEnv); enableFilePermissionsCheckEnv != "" {
+		var err error
+		enableFilePermissionsCheck, err = strconv.ParseBool(enableFilePermissionsCheckEnv)
+		if err != nil {
+			return nil, errors.New("Error parsing the environment variable VAULT_ENABLE_FILE_PERMISSIONS_CHECK")
+		}
+	}
+
+	if enableFilePermissionsCheck {
 		// check permissions of the config file
 		err = osutil.OwnerPermissionsMatch(path, 0, 0)
 		if err != nil {

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -368,7 +368,7 @@ func LoadConfig(path string) (*Config, error) {
 
 	if fi.IsDir() {
 		// check permissions on the config directory
-		if os.Getenv(consts.VaultDisableFilePermissionsCheckEnv) != "true" {
+		if os.Getenv(consts.VaultEnableFilePermissionsCheckEnv) == "true" {
 			err = osutil.OwnerPermissionsMatch(path, 0, 0)
 			if err != nil {
 				return nil, err
@@ -409,7 +409,7 @@ func LoadConfigFile(path string) (*Config, error) {
 		return nil, err
 	}
 
-	if os.Getenv(consts.VaultDisableFilePermissionsCheckEnv) != "true" {
+	if os.Getenv(consts.VaultEnableFilePermissionsCheckEnv) == "true" {
 		// check permissions of the config file
 		err = osutil.OwnerPermissionsMatch(path, 0, 0)
 		if err != nil {

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/physical"
 	physInmem "github.com/hashicorp/vault/sdk/physical/inmem"
 	"github.com/mitchellh/cli"
@@ -116,7 +115,6 @@ func TestServer_ReloadListener(t *testing.T) {
 	defer os.RemoveAll(td)
 
 	wg := &sync.WaitGroup{}
-	os.Setenv(consts.VaultDisableFilePermissionsCheckEnv, "true")
 	// Setup initial certs
 	inBytes, _ := ioutil.ReadFile(wd + "reload_foo.pem")
 	ioutil.WriteFile(td+"/reload_cert.pem", inBytes, 0o777)

--- a/http/plugin_test.go
+++ b/http/plugin_test.go
@@ -31,7 +31,6 @@ func getPluginClusterAndCore(t testing.TB, logger log.Logger) (*vault.TestCluste
 	if err != nil {
 		t.Fatal(err)
 	}
-	os.Setenv(consts.VaultDisableFilePermissionsCheckEnv, "true")
 
 	coreConfig := &vault.CoreConfig{
 		Physical:   inm,

--- a/sdk/helper/consts/consts.go
+++ b/sdk/helper/consts/consts.go
@@ -33,5 +33,5 @@ const (
 	// resolving replicaiton addresses
 	ReplicationResolverALPN = "replication_resolver_v1"
 
-	VaultDisableFilePermissionsCheckEnv = "VAULT_DISABLE_FILE_PERMISSIONS_CHECK"
+	VaultEnableFilePermissionsCheckEnv = "VAULT_ENABLE_FILE_PERMISSIONS_CHECK"
 )

--- a/vault/core.go
+++ b/vault/core.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -3270,7 +3271,16 @@ func (c *Core) GetHAPeerNodesCached() []PeerNode {
 }
 
 func (c *Core) CheckPluginPerms(pluginName string) (err error) {
-	if c.pluginDirectory != "" && os.Getenv(consts.VaultEnableFilePermissionsCheckEnv) == "true" {
+	var enableFilePermissionsCheck bool
+	if enableFilePermissionsCheckEnv := os.Getenv(consts.VaultEnableFilePermissionsCheckEnv); enableFilePermissionsCheckEnv != "" {
+		var err error
+		enableFilePermissionsCheck, err = strconv.ParseBool(enableFilePermissionsCheckEnv)
+		if err != nil {
+			return errors.New("Error parsing the environment variable VAULT_ENABLE_FILE_PERMISSIONS_CHECK")
+		}
+	}
+
+	if c.pluginDirectory != "" && enableFilePermissionsCheck {
 		err = osutil.OwnerPermissionsMatch(c.pluginDirectory, c.pluginFileUid, c.pluginFilePermissions)
 		if err != nil {
 			return err

--- a/vault/core.go
+++ b/vault/core.go
@@ -3270,7 +3270,7 @@ func (c *Core) GetHAPeerNodesCached() []PeerNode {
 }
 
 func (c *Core) CheckPluginPerms(pluginName string) (err error) {
-	if c.pluginDirectory != "" && os.Getenv(consts.VaultDisableFilePermissionsCheckEnv) != "true" {
+	if c.pluginDirectory != "" && os.Getenv(consts.VaultEnableFilePermissionsCheckEnv) == "true" {
 		err = osutil.OwnerPermissionsMatch(c.pluginDirectory, c.pluginFileUid, c.pluginFilePermissions)
 		if err != nil {
 			return err

--- a/vault/logical_system_integ_test.go
+++ b/vault/logical_system_integ_test.go
@@ -529,8 +529,6 @@ func testSystemBackendMock(t *testing.T, numCores, numMounts int, backendType lo
 		},
 	}
 
-	os.Setenv(consts.VaultDisableFilePermissionsCheckEnv, "true")
-
 	// Create a tempdir, cluster.Cleanup will clean up this directory
 	tempDir, err := ioutil.TempDir("", "vault-test-cluster")
 	if err != nil {
@@ -603,7 +601,6 @@ func testSystemBackend_SingleCluster_Env(t *testing.T, env []string) *vault.Test
 			"test": plugin.Factory,
 		},
 	}
-	os.Setenv(consts.VaultDisableFilePermissionsCheckEnv, "true")
 	// Create a tempdir, cluster.Cleanup will clean up this directory
 	tempDir, err := ioutil.TempDir("", "vault-test-cluster")
 	if err != nil {


### PR DESCRIPTION
https://hashicorp.atlassian.net/browse/VAULT-6037
Making this change opt-in, by renaming the environment variable VAULT_DISABLE_FILE_PERMISSIONS_CHECK to VAULT_ENABLE_FILE_PERMISSIONS_CHECK and adjusting the logic 