### PR TITLE
auth/oidc: adds documentation for JSON pointer user claim

### DIFF
--- a/website/content/api-docs/auth/jwt.mdx
+++ b/website/content/api-docs/auth/jwt.mdx
@@ -113,6 +113,9 @@ entities attempting to login. At least one of the bound values must be set.
 - `user_claim` `(string: <required>)` - The claim to use to uniquely identify
   the user; this will be used as the name for the Identity entity alias created
   due to a successful login. The claim value must be a string.
+- `user_claim_json_pointer` `(bool: false)` - Specifies if the `user_claim` value uses
+  [JSON pointer](/docs/auth/jwt#claim-specifications-and-json-pointer) syntax for
+  referencing claims. By default, the `user_claim` value will not use JSON pointer.
 - `clock_skew_leeway` `(int or string: <optional>)` - The amount of leeway to add to all claims to
   account for clock skew, in seconds. Defaults to `60` seconds if set to `0` and can be disabled
   if set to `-1`. Accepts an integer number of seconds, or a Go duration format string. Only applicable

--- a/website/content/docs/auth/jwt/index.mdx
+++ b/website/content/docs/auth/jwt/index.mdx
@@ -321,9 +321,10 @@ Note: the metadata key name "role" is reserved and may not be used for claim map
 
 ### Claim Specifications and JSON Pointer
 
-Some parameters (e.g. `bound_claims`, `groups_claim`, `claim_mappings`) are used to point to data within the JWT. If
-the desired key is at the top of level of the JWT, the name can be provided directly. If it is nested at a
-lower level, a JSON Pointer may be used.
+Some parameters (e.g. `bound_claims`, `groups_claim`, `claim_mappings`, `user_claim`) are
+used to point to data within the JWT. If the desired key is at the top of level of the JWT,
+the name can be provided directly. If it is nested at a lower level, a JSON Pointer may be
+used.
 
 Assume the following JSON data to be referenced:
 


### PR DESCRIPTION
This PR adds documentation for using JSON pointer in the `user_claim` parameter for JWT/OIDC auth.

Related PR: https://github.com/hashicorp/vault-plugin-auth-jwt/pull/204