### PR TITLE
auth/oidc: documents user claim constraint for optional google workspace config

### DIFF
--- a/website/content/docs/auth/jwt/oidc_providers.mdx
+++ b/website/content/docs/auth/jwt/oidc_providers.mdx
@@ -270,6 +270,12 @@ vault write auth/oidc/config -<<EOF
 EOF
 ```
 
+#### Role
+
+The [user_claim](/api-docs/auth/jwt#user_claim) value of the role must be set to
+one of either `sub` or `email` for the Google Workspace group and user information
+queries to succeed.
+
 Example role:
 
 ```


### PR DESCRIPTION
This PR documents that only the `sub` and `email` claims can be used as the `user_claim` value for roles configured to use the [Google Workspace](https://www.vaultproject.io/docs/auth/jwt/oidc_providers#optional-google-specific-configuration) groups and user info feature. 

See #15330 for more details on this constraint.