### PR TITLE
Add list of granting policies audit logs

### DIFF
--- a/changelog/15457.txt
+++ b/changelog/15457.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+audit: Add a policy_results block into the audit log that contains the set of
+policies that granted this request access.
+```

--- a/sdk/logical/auth.go
+++ b/sdk/logical/auth.go
@@ -8,7 +8,8 @@ import (
 )
 
 // Auth is the resulting authentication information that is part of
-// Response for credential backends.
+// Response for credential backends. It's also attached to Request objects and
+// defines the authentication used for the request. This value is audit logged.
 type Auth struct {
 	LeaseOptions
 
@@ -101,10 +102,25 @@ type Auth struct {
 	// Orphan is set if the token does not have a parent
 	Orphan bool `json:"orphan"`
 
+	// PolicyResults is the set of policies that grant the token access to the
+	// requesting path.
+	PolicyResults *PolicyResults `json:"policy_results"`
+
 	// MFARequirement
 	MFARequirement *MFARequirement `json:"mfa_requirement"`
 }
 
 func (a *Auth) GoString() string {
 	return fmt.Sprintf("*%#v", *a)
+}
+
+type PolicyResults struct {
+	Allowed          bool         `json:"allowed"`
+	GrantingPolicies []PolicyInfo `json:"granting_policies"`
+}
+
+type PolicyInfo struct {
+	Name        string `json:"name"`
+	NamespaceId string `json:"namespace_id"`
+	Type        string `json:"type"`
 }

--- a/vault/acl.go
+++ b/vault/acl.go
@@ -40,11 +40,12 @@ type PolicyCheckOpts struct {
 }
 
 type AuthResults struct {
-	ACLResults  *ACLResults
-	Allowed     bool
-	RootPrivs   bool
-	DeniedError bool
-	Error       *multierror.Error
+	ACLResults      *ACLResults
+	SentinelResults *SentinelResults
+	Allowed         bool
+	RootPrivs       bool
+	DeniedError     bool
+	Error           *multierror.Error
 }
 
 type ACLResults struct {
@@ -54,6 +55,11 @@ type ACLResults struct {
 	MFAMethods         []string
 	ControlGroup       *ControlGroup
 	CapabilitiesBitmap uint32
+	GrantingPolicies   []logical.PolicyInfo
+}
+
+type SentinelResults struct {
+	GrantingPolicies []logical.PolicyInfo
 }
 
 // NewACL is used to construct a policy based ACL from a set of policies.
@@ -126,6 +132,10 @@ func NewACL(ctx context.Context, policies []*Policy) (*ACL, error) {
 				if err != nil {
 					return nil, fmt.Errorf("error cloning ACL permissions: %w", err)
 				}
+
+				// Store this policy name as the policy that permits these
+				// capabilities
+				clonedPerms.GrantingPoliciesMap = addGrantingPoliciesToMap(nil, policy, clonedPerms.CapabilitiesBitmap)
 				switch {
 				case pc.HasSegmentWildcards:
 					a.segmentWildcardPaths[pc.Path] = clonedPerms
@@ -155,6 +165,7 @@ func NewACL(ctx context.Context, policies []*Policy) (*ACL, error) {
 				// Insert the capabilities in this new policy into the existing
 				// value
 				existingPerms.CapabilitiesBitmap = existingPerms.CapabilitiesBitmap | pc.Permissions.CapabilitiesBitmap
+				existingPerms.GrantingPoliciesMap = addGrantingPoliciesToMap(existingPerms.GrantingPoliciesMap, policy, pc.Permissions.CapabilitiesBitmap)
 			}
 
 			// Note: In these stanzas, we're preferring minimum lifetimes. So
@@ -326,6 +337,11 @@ func (a *ACL) AllowOperation(ctx context.Context, req *logical.Request, capCheck
 		ret.Allowed = true
 		ret.RootPrivs = true
 		ret.IsRoot = true
+		ret.GrantingPolicies = []logical.PolicyInfo{{
+			Name:        "root",
+			NamespaceId: "root",
+			Type:        "acl",
+		}}
 		return
 	}
 	op := req.Operation
@@ -397,25 +413,33 @@ CHECK:
 	ret.MFAMethods = permissions.MFAMethods
 	ret.ControlGroup = permissions.ControlGroup
 
+	var grantingPolicies []logical.PolicyInfo
 	operationAllowed := false
 	switch op {
 	case logical.ReadOperation:
 		operationAllowed = capabilities&ReadCapabilityInt > 0
+		grantingPolicies = permissions.GrantingPoliciesMap[ReadCapabilityInt]
 	case logical.ListOperation:
 		operationAllowed = capabilities&ListCapabilityInt > 0
+		grantingPolicies = permissions.GrantingPoliciesMap[ListCapabilityInt]
 	case logical.UpdateOperation:
 		operationAllowed = capabilities&UpdateCapabilityInt > 0
+		grantingPolicies = permissions.GrantingPoliciesMap[UpdateCapabilityInt]
 	case logical.DeleteOperation:
 		operationAllowed = capabilities&DeleteCapabilityInt > 0
+		grantingPolicies = permissions.GrantingPoliciesMap[DeleteCapabilityInt]
 	case logical.CreateOperation:
 		operationAllowed = capabilities&CreateCapabilityInt > 0
+		grantingPolicies = permissions.GrantingPoliciesMap[CreateCapabilityInt]
 	case logical.PatchOperation:
 		operationAllowed = capabilities&PatchCapabilityInt > 0
+		grantingPolicies = permissions.GrantingPoliciesMap[PatchCapabilityInt]
 
 	// These three re-use UpdateCapabilityInt since that's the most appropriate
 	// capability/operation mapping
 	case logical.RevokeOperation, logical.RenewOperation, logical.RollbackOperation:
 		operationAllowed = capabilities&UpdateCapabilityInt > 0
+		grantingPolicies = permissions.GrantingPoliciesMap[UpdateCapabilityInt]
 
 	default:
 		return
@@ -424,6 +448,8 @@ CHECK:
 	if !operationAllowed {
 		return
 	}
+
+	ret.GrantingPolicies = grantingPolicies
 
 	if permissions.MaxWrappingTTL > 0 {
 		if req.WrapInfo == nil || req.WrapInfo.TTL > permissions.MaxWrappingTTL {

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/hclutil"
 	"github.com/hashicorp/vault/sdk/helper/identitytpl"
+	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/mitchellh/copystructure"
 )
 
@@ -161,14 +162,15 @@ type IdentityFactor struct {
 }
 
 type ACLPermissions struct {
-	CapabilitiesBitmap uint32
-	MinWrappingTTL     time.Duration
-	MaxWrappingTTL     time.Duration
-	AllowedParameters  map[string][]interface{}
-	DeniedParameters   map[string][]interface{}
-	RequiredParameters []string
-	MFAMethods         []string
-	ControlGroup       *ControlGroup
+	CapabilitiesBitmap  uint32
+	MinWrappingTTL      time.Duration
+	MaxWrappingTTL      time.Duration
+	AllowedParameters   map[string][]interface{}
+	DeniedParameters    map[string][]interface{}
+	RequiredParameters  []string
+	MFAMethods          []string
+	ControlGroup        *ControlGroup
+	GrantingPoliciesMap map[uint32][]logical.PolicyInfo
 }
 
 func (p *ACLPermissions) Clone() (*ACLPermissions, error) {
@@ -225,7 +227,41 @@ func (p *ACLPermissions) Clone() (*ACLPermissions, error) {
 		ret.ControlGroup = clonedControlGroup.(*ControlGroup)
 	}
 
+	switch {
+	case p.GrantingPoliciesMap == nil:
+	case len(p.GrantingPoliciesMap) == 0:
+		ret.GrantingPoliciesMap = make(map[uint32][]logical.PolicyInfo)
+	default:
+		clonedGrantingPoliciesMap, err := copystructure.Copy(p.GrantingPoliciesMap)
+		if err != nil {
+			return nil, err
+		}
+		ret.GrantingPoliciesMap = clonedGrantingPoliciesMap.(map[uint32][]logical.PolicyInfo)
+	}
+
 	return ret, nil
+}
+
+func addGrantingPoliciesToMap(m map[uint32][]logical.PolicyInfo, policy *Policy, capabilitiesBitmap uint32) map[uint32][]logical.PolicyInfo {
+	if m == nil {
+		m = make(map[uint32][]logical.PolicyInfo)
+	}
+
+	// For all possible policies, check if the provided capabilities include
+	// them
+	for _, capability := range cap2Int {
+		if capabilitiesBitmap&capability == 0 {
+			continue
+		}
+
+		m[capability] = append(m[capability], logical.PolicyInfo{
+			Name:        policy.Name,
+			NamespaceId: policy.namespace.ID,
+			Type:        "acl",
+		})
+	}
+
+	return m
 }
 
 // ParseACLPolicy is used to parse the specified ACL rules into an


### PR DESCRIPTION
This PR adds a policy results block to the audit log output. This block contains a list of the policy or policies that actually granted the permissions needed for the request. 

Example Audit Logs:
```
    "policy_results": {
      "allowed": true,
      "granting_policies": [
        {
          "name": "admin",
          "namespace_id": "root",
          "type": "acl"
        },
        {
          "name": "always-pass1",
          "namespace_id": "root",
          "type": "rgp"
        },
        {
          "name": "always-pass-ns1",
          "namespace_id": "root",
          "type": "egp"
        }
      ]
    },
```
The policy_results block is also a more explicit way to detect a request failed due to being unauthorized:
```
    "policy_results": {
      "allowed": false
    },
```