### PR TITLE
Vault documentation: Updated socket documentation to modify warning

### DIFF
--- a/website/content/docs/audit/socket.mdx
+++ b/website/content/docs/audit/socket.mdx
@@ -8,12 +8,9 @@ description: The "socket" audit device writes audit writes to a TCP or UDP socke
 
 The `socket` audit device writes to a TCP, UDP, or UNIX socket.
 
-~> **Warning:** Due to the nature of the underlying protocols used in this
-device there exists a case when the connection to a socket is lost a single
-audit entry could be omitted from the logs and the request will still succeed.
-Using this device in conjunction with another audit device will help to improve
-accuracy, but the socket device should not be used if strong guarantees are
-needed for audit logs.
+~> **Warning:** The loss of audit logs may occur when using the UDP socket audit type. Because UDP socket audit type is connectionless, meaning the UDP endpoint becomes unavailable, it’s possible that any number of audit logs written to it may get lost, even though the request will still succeed. Vault does not provide an indication for the loss of audit logs. Therefore, we recommend using your device in conjunction with a secondary “non-socket” audit device to ensure accuracy and to guarantee that audit logs will not be lost.
+
+~> **Warning:** When using a TCP socket audit type, and connection loss to the socket occurs, a single audit entry may be omitted from the audit entry. The request from the TCP socket audit type will succeed despite the omission of the audit entry.
 
 ## Enabling
 
@@ -35,7 +32,7 @@ $ vault audit enable socket address=127.0.0.1:9090 socket_type=tcp
   `127.0.0.1:9090` or `/tmp/audit.sock`.
 
 - `socket_type` `(string: "tcp")` - The socket type to use, any type compatible
-  with <a href="https://golang.org/pkg/net/#Dial">net.Dial</a> is acceptable. It's 
+  with <a href="https://golang.org/pkg/net/#Dial">net.Dial</a> is acceptable. It's
   important to note if TCP is used and the destination socket becomes unavailable
   Vault may become unresponsive per [Blocked Audit Devices](docs/audit/#blocked-audit-devices).
 


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/inbox/1200328878163177/1202045039438053/1202263945417782), the following socket documentation was updated to clarify the warning about the use of UDP and TCP socket audit types.

Socket Audit Devices :mag: [Deploy Preview]()