### PR TITLE
UI/vault 6212/multiple issuer pki changes

### DIFF
--- a/changelog/15464.txt
+++ b/changelog/15464.txt
@@ -1,0 +1,3 @@
+```release-note:changes
+ui: pki issuer delete capabilities have been removed from the UI and reserved for the API and CLI
+```

--- a/ui/app/adapters/pki-ca-certificate.js
+++ b/ui/app/adapters/pki-ca-certificate.js
@@ -68,6 +68,6 @@ export default ApplicationAdapter.extend({
 
   deleteRecord(store, type, snapshot) {
     const backend = snapshot.attr('backend');
-    return this.ajax(`/v1/${backend}/root`, 'DELETE');
+    return this.ajax(`/v1/${backend}/issuer/default`, 'DELETE');
   },
 });

--- a/ui/app/adapters/pki-ca-certificate.js
+++ b/ui/app/adapters/pki-ca-certificate.js
@@ -65,9 +65,4 @@ export default ApplicationAdapter.extend({
   updateRecord() {
     return this.createRecordOrUpdate(...arguments);
   },
-
-  deleteRecord(store, type, snapshot) {
-    const backend = snapshot.attr('backend');
-    return this.ajax(`/v1/${backend}/issuer/default`, 'DELETE');
-  },
 });

--- a/ui/app/components/config-pki-ca.js
+++ b/ui/app/components/config-pki-ca.js
@@ -153,28 +153,6 @@ export default Component.extend({
           this.set('loading', false);
         });
     },
-    deleteCA() {
-      this.set('loading', true);
-      const model = this.model;
-      const backend = model.get('backend');
-      //TODO Is there better way to do this? This forces the saved state so Ember Data will make a server call.
-      model.send('pushedData');
-      model
-        .destroyRecord()
-        .then(() => {
-          this.flashMessages.success(
-            `The default issuer for ${backend} has been deleted. Its key material was preserved; to restore the issuer, import the public certificate.`
-          );
-        })
-        .catch((e) => {
-          this.set('errors', e.errors);
-        })
-        .finally(() => {
-          this.set('loading', false);
-          this.send('refresh');
-          this.createOrReplaceModel();
-        });
-    },
     refresh() {
       this.setProperties({
         setSignedIntermediate: false,

--- a/ui/app/components/config-pki-ca.js
+++ b/ui/app/components/config-pki-ca.js
@@ -140,15 +140,10 @@ export default Component.extend({
       const isUpload = this.model.uploadPemBundle;
       model
         .save({ adapterOptions: { method } })
-        .then((m) => {
+        .then(() => {
           if (method === 'setSignedIntermediate' || isUpload) {
             this.send('refresh');
             this.flashMessages.success('The certificate for this backend has been updated.');
-          } else if (!m.get('certificate') && !m.get('csr')) {
-            // if there's no certificate, it wasn't generated and the generation was a noop
-            this.flashMessages.warning(
-              'You tried to generate a new root CA, but one currently exists. To replace the existing one, delete it first and then generate again.'
-            );
           }
         })
         .catch((e) => {
@@ -168,7 +163,7 @@ export default Component.extend({
         .destroyRecord()
         .then(() => {
           this.flashMessages.success(
-            `The CA key for ${backend} has been deleted. The old CA certificate will still be accessible for reading until a new certificate/key is generated or uploaded.`
+            `The default issuer for ${backend} has been deleted. Its key material was preserved; to restore the issuer, import the public certificate.`
           );
         })
         .finally(() => {

--- a/ui/app/components/config-pki-ca.js
+++ b/ui/app/components/config-pki-ca.js
@@ -166,6 +166,9 @@ export default Component.extend({
             `The default issuer for ${backend} has been deleted. Its key material was preserved; to restore the issuer, import the public certificate.`
           );
         })
+        .catch((e) => {
+          this.set('errors', e.errors);
+        })
         .finally(() => {
           this.set('loading', false);
           this.send('refresh');

--- a/ui/app/components/config-pki-ca.js
+++ b/ui/app/components/config-pki-ca.js
@@ -52,7 +52,7 @@ export default Component.extend({
    * @param DS.Model
    * @public
    *
-   * a `pki-config` model - passed in in the component useage
+   * a `pki-config` model - passed in in the component usage
    *
    */
   config: null,

--- a/ui/app/components/config-pki.js
+++ b/ui/app/components/config-pki.js
@@ -20,7 +20,7 @@ export default Component.extend({
    * @param DS.Model
    * @public
    *
-   * a `pki-config` model - passed in in the component useage
+   * a `pki-config` model - passed in in the component usage
    *
    */
   config: null,

--- a/ui/app/models/pki-ca-certificate.js
+++ b/ui/app/models/pki-ca-certificate.js
@@ -1,8 +1,6 @@
 import { attr } from '@ember-data/model';
-import { and } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import Certificate from './pki-certificate';
-import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 
 export default Certificate.extend({
   DISPLAY_FIELDS: computed(function () {
@@ -151,7 +149,4 @@ export default Certificate.extend({
 
     return groups;
   }),
-
-  deletePath: lazyCapabilities(apiPath`${'backend'}/root`, 'backend'),
-  canDeleteRoot: and('deletePath.canDelete', 'deletePath.canSudo'),
 });

--- a/ui/app/styles/components/popup-menu.scss
+++ b/ui/app/styles/components/popup-menu.scss
@@ -8,7 +8,7 @@
     box-shadow: $box-shadow, $box-shadow-middle;
     padding: 0;
     position: relative;
-    width: 200px;
+    width: 210px;
   }
 
   &.is-wide > .box {

--- a/ui/app/templates/components/config-pki-ca.hbs
+++ b/ui/app/templates/components/config-pki-ca.hbs
@@ -237,17 +237,24 @@
         Set signed intermediate
       </button>
     </div>
-    <div class="control">
-      {{#if this.model.canDeleteRoot}}
-        <ConfirmAction
-          @buttonClasses="button"
-          @confirmTitle="Delete default issuer?"
-          @confirmMessage="The default issuer certificate will be deleted, but its key material preserved."
-          @onConfirmAction={{action "deleteCA"}}
-        >
-          Delete
-        </ConfirmAction>
-      {{/if}}
-    </div>
+    {{#unless this.needsConfig}}
+      <div class="control">
+        <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
+          <T.Trigger data-test-tooltip-trigger tabindex="-1">
+            <button type="button" class="button is-primary" disabled={{true}}>
+              Delete
+            </button>
+          </T.Trigger>
+          <T.Content @defaultClass="tool-tip smaller-font">
+            <div class="box" data-test-hover-copy-tooltip-text>
+              Deleting a CA is only available via the CLI and API.
+              <DocLink @path="/api-docs/secret/pki#delete-issuer" class="doc-link-subtle">
+                Learn more
+              </DocLink>
+            </div>
+          </T.Content>
+        </ToolTip>
+      </div>
+    {{/unless}}
   </div>
 {{/if}}

--- a/ui/app/templates/components/config-pki-ca.hbs
+++ b/ui/app/templates/components/config-pki-ca.hbs
@@ -4,7 +4,11 @@
     {{#if this.needsConfig}}
       Configure CA Certificate
     {{else}}
-      Add CA Certificate
+      {{#if this.model.certificate}}
+        Generated Certificate
+      {{else}}
+        Add CA Certificate
+      {{/if}}
     {{/if}}
   </h2>
   {{#if (or this.model.certificate this.model.csr)}}
@@ -59,13 +63,6 @@
   {{else}}
     <form {{action "saveCA" on="submit"}} data-test-generate-root-cert="true">
       <NamespaceReminder @mode="save" @noun="PKI change" />
-      {{#if this.model.uploadPemBundle}}
-        <AlertBanner
-          @type="warning"
-          @message="If you have already set a certificate and key, they will be overridden with the successful saving of a new PEM bundle."
-          data-test-warning
-        />
-      {{/if}}
       <FormFieldGroupsLoop @model={{this.model}} @mode={{this.mode}} />
       <div class="field is-grouped is-grouped-split box is-fullwidth is-bottomless">
         <div class="field is-grouped">
@@ -84,18 +81,6 @@
               Cancel
             </button>
           </div>
-        </div>
-        <div class="control">
-          {{#if this.model.canDeleteRoot}}
-            <ConfirmAction
-              @buttonClasses="button"
-              @confirmTitle="Delete default issuer?"
-              @confirmMessage="The default issuer certificate will be deleted, but its key material preserved."
-              @onConfirmAction={{action "deleteCA"}}
-            >
-              Delete
-            </ConfirmAction>
-          {{/if}}
         </div>
       </div>
     </form>
@@ -251,6 +236,18 @@
       >
         Set signed intermediate
       </button>
+    </div>
+    <div class="control">
+      {{#if this.model.canDeleteRoot}}
+        <ConfirmAction
+          @buttonClasses="button"
+          @confirmTitle="Delete default issuer?"
+          @confirmMessage="The default issuer certificate will be deleted, but its key material preserved."
+          @onConfirmAction={{action "deleteCA"}}
+        >
+          Delete
+        </ConfirmAction>
+      {{/if}}
     </div>
   </div>
 {{/if}}

--- a/ui/app/templates/components/config-pki-ca.hbs
+++ b/ui/app/templates/components/config-pki-ca.hbs
@@ -4,7 +4,7 @@
     {{#if this.needsConfig}}
       Configure CA Certificate
     {{else}}
-      Replace CA Certificate
+      Add CA Certificate
     {{/if}}
   </h2>
   {{#if (or this.model.certificate this.model.csr)}}
@@ -89,8 +89,8 @@
           {{#if this.model.canDeleteRoot}}
             <ConfirmAction
               @buttonClasses="button"
-              @confirmTitle="Delete this CA key?"
-              @confirmMessage="This CA certificate will still be available for reading until a new certificate/key is generated or uploaded."
+              @confirmTitle="Delete default issuer?"
+              @confirmMessage="The default issuer certificate will be deleted, but its key material preserved."
               @onConfirmAction={{action "deleteCA"}}
             >
               Delete
@@ -231,7 +231,7 @@
         {{#if this.needsConfig}}
           Configure CA
         {{else}}
-          Replace CA
+          Add CA
         {{/if}}
       </button>
     </div>

--- a/ui/tests/integration/components/config-pki-ca-test.js
+++ b/ui/tests/integration/components/config-pki-ca-test.js
@@ -74,7 +74,7 @@ module('Integration | Component | config pki ca', function (hooks) {
     this.set('config', c);
     await render(hbs`{{config-pki-ca config=config}}`);
     assert.notOk(component.hasTitle, 'no title in the default state');
-    assert.equal(component.replaceCAText, 'Replace CA');
+    assert.equal(component.replaceCAText, 'Add CA');
     assert.equal(component.downloadLinks.length, 3, 'shows download links');
   });
 });


### PR DESCRIPTION
### UI updates to accommodate backend changes in #15277 
- copy changes from "Replace CA" to "Add" 
- disabling delete (for 1.11 all delete capabilities will only be available via CLI and API) 
<hr>
<img width="343" alt="Screen Shot 2022-05-17 at 2 20 17 PM" src="https://user-images.githubusercontent.com/68122737/168912017-2fd5b67d-a68f-4330-9db7-a681bef7e445.png">
<img width="540" alt="Screen Shot 2022-05-17 at 2 20 42 PM" src="https://user-images.githubusercontent.com/68122737/168912069-98ae6086-e97d-4d0b-8fe6-b709412a4205.png">

