### PR TITLE
secret/pki: Return correct algorithm type from key fetch API for managed keys

### DIFF
--- a/builtin/logical/pki/managed_key_util.go
+++ b/builtin/logical/pki/managed_key_util.go
@@ -36,3 +36,7 @@ func extractManagedKeyId(privateKeyBytes []byte) (UUIDKey, error) {
 func createKmsKeyBundle(ctx context.Context, b *backend, keyId managedKeyId) (certutil.KeyBundle, certutil.PrivateKeyType, error) {
 	return certutil.KeyBundle{}, certutil.UnknownPrivateKey, errEntOnly
 }
+
+func getManagedKeyInfo(ctx context.Context, b *backend, keyId managedKeyId) (*managedKeyInfo, error) {
+	return nil, errEntOnly
+}

--- a/builtin/logical/pki/path_fetch_keys.go
+++ b/builtin/logical/pki/path_fetch_keys.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/vault/sdk/helper/errutil"
+
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -146,13 +148,31 @@ func (b *backend) pathGetKeyHandler(ctx context.Context, req *logical.Request, d
 		return nil, err
 	}
 
-	return &logical.Response{
-		Data: map[string]interface{}{
-			keyIdParam:   key.ID,
-			keyNameParam: key.Name,
-			keyTypeParam: key.PrivateKeyType,
-		},
-	}, nil
+	respData := map[string]interface{}{
+		keyIdParam:   key.ID,
+		keyNameParam: key.Name,
+		keyTypeParam: string(key.PrivateKeyType),
+	}
+
+	if key.isManagedPrivateKey() {
+		managedKeyUUID, err := key.getManagedKeyUUID()
+		if err != nil {
+			return nil, errutil.InternalError{Err: fmt.Sprintf("failed extracting managed key uuid from key id %s (%s): %v", key.ID, key.Name, err)}
+		}
+
+		keyInfo, err := getManagedKeyInfo(ctx, b, managedKeyUUID)
+		if err != nil {
+			return nil, errutil.InternalError{Err: fmt.Sprintf("failed fetching managed key info from key id %s (%s): %v", key.ID, key.Name, err)}
+		}
+
+		// To remain consistent across the api responses (mainly generate root/intermediate calls), return the actual
+		// type of key, not that it is a managed key.
+		respData[keyTypeParam] = string(keyInfo.keyType)
+		respData[managedKeyIdArg] = string(keyInfo.uuid)
+		respData[managedKeyNameArg] = string(keyInfo.name)
+	}
+
+	return &logical.Response{Data: respData}, nil
 }
 
 func (b *backend) pathUpdateKeyHandler(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -2,9 +2,12 @@ package pki
 
 import (
 	"context"
+	"crypto"
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/hashicorp/vault/sdk/helper/certutil"
 
 	"github.com/hashicorp/vault/sdk/logical"
 
@@ -72,6 +75,13 @@ func (u UUIDKey) String() string {
 
 func (n NameKey) String() string {
 	return string(n)
+}
+
+type managedKeyInfo struct {
+	publicKey crypto.PublicKey
+	keyType   certutil.PrivateKeyType
+	name      NameKey
+	uuid      UUIDKey
 }
 
 // getManagedKeyId returns a NameKey or a UUIDKey, whichever was specified in the


### PR DESCRIPTION
Fix an issue that key_type field returned from the key fetch API had the ManagedPrivateKey value instead of the real algorithm of the managed key.

Also return additional information about the managed key such as the managed key name and it's UUID.