### PR TITLE
possibly forward cached MFA auth response to leader

### DIFF
--- a/changelog/15469.txt
+++ b/changelog/15469.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth: forward cached MFA auth response to the leader using RPC instead of forwarding all login requests
+```

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1517,12 +1517,6 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 					}
 				}
 			} else if len(matchedMfaEnforcementList) > 0 && len(req.MFACreds) == 0 {
-				// two-phase login MFA requests should be forwarded
-				// to the active node, as the validation should only
-				// happen in that node
-				if c.perfStandby {
-					return nil, nil, logical.ErrPerfStandbyPleaseForward
-				}
 				mfaRequestID, err := uuid.GenerateUUID()
 				if err != nil {
 					return nil, nil, err
@@ -1552,7 +1546,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 					TimeOfStorage:         time.Now(),
 					RequestID:             mfaRequestID,
 				}
-				err = c.SaveMFAResponseAuth(respAuth)
+				err = possiblyForwardSaveCachedAuthResponse(ctx, c, respAuth)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/vault/request_handling_util.go
+++ b/vault/request_handling_util.go
@@ -59,3 +59,12 @@ var errCreateEntityUnimplemented = "create entity unimplemented in the server"
 func possiblyForwardEntityCreation(ctx context.Context, c *Core, inErr error, auth *logical.Auth, entity *identity.Entity) (*identity.Entity, error) {
 	return entity, inErr
 }
+
+func possiblyForwardSaveCachedAuthResponse(ctx context.Context, c *Core, respAuth *MFACachedAuthResponse) error {
+	err := c.SaveMFAResponseAuth(respAuth)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR is the OSS part of this [one](https://github.com/hashicorp/vault-enterprise/pull/2749).
It removes the logic for forwarding all login requests from a perfStandby node to the active node. Instead, it enables forwarding cached MFA auth response to the leader so that MFA validation works. 