### PR TITLE
Always return PKI configs for CRLs, URLs

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -143,13 +143,6 @@ func fetchCAInfoByIssuerId(ctx context.Context, b *backend, req *logical.Request
 	if err != nil {
 		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch URL information: %v", err)}
 	}
-	if entries == nil {
-		entries = &certutil.URLEntries{
-			IssuingCertificates:   []string{},
-			CRLDistributionPoints: []string{},
-			OCSPServers:           []string{},
-		}
-	}
 	caInfo.URLs = entries
 
 	return caInfo, nil
@@ -632,13 +625,6 @@ func generateCert(ctx context.Context,
 			entries, err := getURLs(ctx, input.req)
 			if err != nil {
 				return nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch URL information: %v", err)}
-			}
-			if entries == nil {
-				entries = &certutil.URLEntries{
-					IssuingCertificates:   []string{},
-					CRLDistributionPoints: []string{},
-					OCSPServers:           []string{},
-				}
 			}
 			data.Params.URLs = entries
 

--- a/builtin/logical/pki/path_config_crl.go
+++ b/builtin/logical/pki/path_config_crl.go
@@ -54,11 +54,15 @@ func (b *backend) CRL(ctx context.Context, s logical.Storage) (*crlConfig, error
 	if err != nil {
 		return nil, err
 	}
-	if entry == nil {
-		return nil, nil
-	}
 
 	var result crlConfig
+	result.Expiry = b.crlLifetime.String()
+	result.Disable = false
+
+	if entry == nil {
+		return &result, nil
+	}
+
 	if err := entry.DecodeJSON(&result); err != nil {
 		return nil, err
 	}
@@ -70,9 +74,6 @@ func (b *backend) pathCRLRead(ctx context.Context, req *logical.Request, _ *fram
 	config, err := b.CRL(ctx, req.Storage)
 	if err != nil {
 		return nil, err
-	}
-	if config == nil {
-		return nil, nil
 	}
 
 	return &logical.Response{
@@ -87,9 +88,6 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 	config, err := b.CRL(ctx, req.Storage)
 	if err != nil {
 		return nil, err
-	}
-	if config == nil {
-		config = &crlConfig{}
 	}
 
 	if expiryRaw, ok := d.GetOk("expiry"); ok {

--- a/builtin/logical/pki/path_config_urls.go
+++ b/builtin/logical/pki/path_config_urls.go
@@ -63,16 +63,22 @@ func getURLs(ctx context.Context, req *logical.Request) (*certutil.URLEntries, e
 	if err != nil {
 		return nil, err
 	}
-	if entry == nil {
-		return nil, nil
+
+	entries := &certutil.URLEntries{
+		IssuingCertificates:   []string{},
+		CRLDistributionPoints: []string{},
+		OCSPServers:           []string{},
 	}
 
-	var entries certutil.URLEntries
-	if err := entry.DecodeJSON(&entries); err != nil {
+	if entry == nil {
+		return entries, nil
+	}
+
+	if err := entry.DecodeJSON(entries); err != nil {
 		return nil, err
 	}
 
-	return &entries, nil
+	return entries, nil
 }
 
 func writeURLs(ctx context.Context, req *logical.Request, entries *certutil.URLEntries) error {
@@ -97,9 +103,6 @@ func (b *backend) pathReadURL(ctx context.Context, req *logical.Request, _ *fram
 	if err != nil {
 		return nil, err
 	}
-	if entries == nil {
-		return nil, nil
-	}
 
 	resp := &logical.Response{
 		Data: structs.New(entries).Map(),
@@ -112,13 +115,6 @@ func (b *backend) pathWriteURL(ctx context.Context, req *logical.Request, data *
 	entries, err := getURLs(ctx, req)
 	if err != nil {
 		return nil, err
-	}
-	if entries == nil {
-		entries = &certutil.URLEntries{
-			IssuingCertificates:   []string{},
-			CRLDistributionPoints: []string{},
-			OCSPServers:           []string{},
-		}
 	}
 
 	if urlsInt, ok := data.GetOk("issuing_certificates"); ok {

--- a/changelog/15470.txt
+++ b/changelog/15470.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Always return CRLs, URLs configurations, even if using the default value.
+```


### PR DESCRIPTION
Vault currently returns a `nil` response when the default CRL and URL configuration is being used. This doesn't really make sense, especially in the CRL case, as this default CRL config actually has 72h expiration (and isn't disabled). 

Instead, always return config structs for both of these two configs. This matches the behavior introduced in the multi-issuer changes  where `config/issuers` and `config/keys` always returns structs (even if empty of values).