### PR TITLE
UI: Better default transit auto-rotation

### DIFF
--- a/changelog/15474.txt
+++ b/changelog/15474.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Default auto-rotation period in transit is 30 days
+```

--- a/ui/app/templates/components/transit-form-create.hbs
+++ b/ui/app/templates/components/transit-form-create.hbs
@@ -8,7 +8,7 @@
     </div>
     <div class="field">
       <TtlPicker2
-        @initialValue="1h"
+        @initialValue="30d"
         @initialEnabled={{false}}
         @label="Auto-rotation period"
         @helperTextDisabled="Key will never be automatically rotated"

--- a/ui/app/templates/components/transit-form-edit.hbs
+++ b/ui/app/templates/components/transit-form-edit.hbs
@@ -18,7 +18,7 @@
     </div>
     <div class="field">
       <TtlPicker2
-        @initialValue={{or @key.autoRotatePeriod "1h"}}
+        @initialValue={{or @key.autoRotatePeriod "30d"}}
         @initialEnabled={{not (eq @key.autoRotatePeriod "0s")}}
         @label="Auto-rotation period"
         @helperTextDisabled="Key will never be automatically rotated"

--- a/ui/lib/core/addon/components/ttl-picker2.js
+++ b/ui/lib/core/addon/components/ttl-picker2.js
@@ -74,7 +74,14 @@ export default TtlForm.extend({
 
     if (typeOf(value) === 'number') {
       // if the passed value is a number, assume unit is seconds
-      time = value;
+      if (value % secondsMap.d === 0) {
+        unit = 'd';
+      } else if (value % secondsMap.h === 0) {
+        unit = 'h';
+      } else if (value % secondsMap.m === 0) {
+        unit = 'm';
+      }
+      time = convertFromSeconds(value, unit);
     } else {
       try {
         const seconds = Duration.parse(value).seconds();

--- a/ui/lib/core/addon/components/ttl-picker2.js
+++ b/ui/lib/core/addon/components/ttl-picker2.js
@@ -74,6 +74,7 @@ export default TtlForm.extend({
 
     if (typeOf(value) === 'number') {
       // if the passed value is a number, assume unit is seconds
+      // then check if the value can be converted into a larger unit
       if (value % secondsMap.d === 0) {
         unit = 'd';
       } else if (value % secondsMap.h === 0) {

--- a/ui/tests/integration/components/ttl-picker2-test.js
+++ b/ui/tests/integration/components/ttl-picker2-test.js
@@ -232,4 +232,17 @@ module('Integration | Component | ttl-picker2', function (hooks) {
     assert.dom('[data-test-ttl-value]').hasValue('1000', 'time value is converted');
     assert.dom('[data-test-select="ttl-unit"]').hasValue('m', 'unit value is m (minutes)');
   });
+
+  test('it converts to the largest round unit on init when no unit provided', async function (assert) {
+    await render(hbs`
+      <TtlPicker2
+        @label="convertunits"
+        @onChange={{onChange}}
+        @initialValue={{86400}}
+        @initialEnabled="true"
+      />
+    `);
+    assert.dom('[data-test-ttl-value]').hasValue('1', 'time value is converted');
+    assert.dom('[data-test-select="ttl-unit"]').hasValue('d', 'unit value is d (days)');
+  });
 });


### PR DESCRIPTION
Update the default transit auto-rotation from `1h` to `30d`, to represent a more reasonable default value for keys.

<img width="1336" alt="Screen Shot 2022-05-17 at 11 08 41 AM" src="https://user-images.githubusercontent.com/82459713/168858095-a4ec61a8-9198-4aef-ab06-c05f8a6986fa.png">
 