### PR TITLE
docs: add note about requiring 3.6+ helm

### DIFF
--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -6,7 +6,7 @@ description: This section documents configuration options for the Vault Helm cha
 
 # Configuration
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 The chart is highly customizable using
 [Helm configuration values](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing).

--- a/website/content/docs/platform/k8s/helm/enterprise.mdx
+++ b/website/content/docs/platform/k8s/helm/enterprise.mdx
@@ -11,6 +11,8 @@ You can use this Helm chart to deploy Vault Enterprise by following a few extra 
 
 ~> **Note:** As of Vault Enterprise 1.8, the license must be specified via HCL configuration or environment variables on startup, unless the Vault cluster was created with an older Vault version and the license was stored. More information is available in the [Vault Enterprise License docs](/docs/enterprise/license).
 
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
+
 ## Vault Enterprise 1.8+
 
 ### License Install

--- a/website/content/docs/platform/k8s/helm/examples/development.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/development.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Development
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 The below `values.yaml` can be used to set up a single development Vault server.
 

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Highly Available Vault Enterprise Disaster Recovery Clusters with Integrated Storage (Raft)
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 The following is an example of creating a disaster recovery cluster using Vault Helm.
 

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Highly Available Vault Enterprise Performance Clusters with Integrated Storage (Raft)
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 The following is an example of creating a performance cluster using Vault Helm.
 

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Highly Available Vault Enterprise Cluster with Integrated Storage (Raft)
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 Integrated Storage (raft) can be enabled using the `server.ha.raft.enabled` value:
 

--- a/website/content/docs/platform/k8s/helm/examples/external.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/external.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # External Vault
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 The below `values.yaml` can be used to set up an external vault server or
 cluster.

--- a/website/content/docs/platform/k8s/helm/examples/ha-with-consul.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/ha-with-consul.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Highly Available Vault Cluster with Consul
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 The below `values.yaml` can be used to set up a five server Vault cluster using
 Consul as a highly available storage backend, Google Cloud KMS for Auto Unseal.

--- a/website/content/docs/platform/k8s/helm/examples/ha-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/ha-with-raft.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Highly Available Vault Cluster with Integrated Storage (Raft)
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 Integrated storage (raft) can be enabled using the `server.ha.raft.enabled` value:
 

--- a/website/content/docs/platform/k8s/helm/examples/index.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/index.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Helm Chart Examples
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 These are a collection of examples of common configurations for Vault using the Helm chart.
 

--- a/website/content/docs/platform/k8s/helm/examples/injector-tls.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/injector-tls.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Vault Agent Injector TLS Configuration
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 The following instructions demonstrate how to manually configure the Vault Agent Injector
 with self-signed certificates.

--- a/website/content/docs/platform/k8s/helm/examples/kubernetes-auth.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/kubernetes-auth.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Bootstrapping Kubernetes Auth Method
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 In this example, we will walk through how to set up the [Kubernetes Auth Method](/docs/auth/kubernetes).
 

--- a/website/content/docs/platform/k8s/helm/examples/standalone-audit.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/standalone-audit.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Standalone Server with Audit Storage
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 The below `values.yaml` can be used to set up a single server Vault cluster with
 auditing enabled.

--- a/website/content/docs/platform/k8s/helm/examples/standalone-load-balanced-ui.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/standalone-load-balanced-ui.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Standalone Server with Load Balanced UI
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 The below `values.yaml` can be used to set up a single server Vault cluster with a LoadBalancer to allow external access to the UI and API.
 

--- a/website/content/docs/platform/k8s/helm/examples/standalone-tls.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/standalone-tls.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Standalone Server with TLS
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 This example can be used to set up a single server Vault cluster using TLS.
 

--- a/website/content/docs/platform/k8s/helm/index.mdx
+++ b/website/content/docs/platform/k8s/helm/index.mdx
@@ -8,7 +8,7 @@ description: >-
 
 # Helm Chart
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 The [Vault Helm chart](https://github.com/hashicorp/vault-helm)
 is the recommended way to install and configure Vault on Kubernetes.

--- a/website/content/docs/platform/k8s/helm/openshift.mdx
+++ b/website/content/docs/platform/k8s/helm/openshift.mdx
@@ -9,6 +9,8 @@ description: >-
 
 # Run Vault on OpenShift
 
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
+
 The following documentation describes installing, running, and using
 Vault and **Vault Agent Injector** on OpenShift.
 
@@ -27,7 +29,7 @@ The following are required to install Vault and Vault Agent Injector
 on OpenShift:
 
 - Cluster Admin privileges to bind the `auth-delegator` role to Vault's service account
-- Helm v3
+- Helm v3.6+
 - OpenShift 4.X
 - Vault Helm v0.6.0+
 - Vault K8s v0.4.0+

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -12,7 +12,7 @@ description: >-
 Vault works with Kubernetes in various modes: `dev`, `standalone`, `ha`,
 and `external`.
 
-~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3.6+ with this chart.
 
 ## Helm Chart
 


### PR DESCRIPTION
Adds a note about vault-helm requiring Helm 3.6+. Users may run into errors during installation if using older versions:
```
Error: parse error at (vault/templates/_helpers.tpl:38): unclosed action
```