### PR TITLE
prevent deleting MFA method through an invalid path

### DIFF
--- a/changelog/15482.txt
+++ b/changelog/15482.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth: Prevent deleting a valid MFA method ID using the endpoint for a different MFA method type
+```

--- a/vault/external_tests/mfa/login_mfa_test.go
+++ b/vault/external_tests/mfa/login_mfa_test.go
@@ -187,6 +187,12 @@ func TestLoginMFA_Method_CRUD(t *testing.T) {
 				t.Fatal("expected response id to match existing method id but it didn't")
 			}
 
+			// delete with invalid path should fail
+			_, err = client.Logical().Delete(invalidPath)
+			if err == nil {
+				t.Fatal("expected deleting an MFA method ID with invalid path to fail")
+			}
+
 			// delete it
 			_, err = client.Logical().Delete(myNewPath)
 			if err != nil {

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -221,7 +221,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Summary:  "Update or create a configuration for the given MFA method",
 				},
 				logical.DeleteOperation: &framework.PathOperation{
-					Callback: i.handleMFAMethodDelete,
+					Callback: i.handleMFAMethodTOTPDelete,
 					Summary:  "Delete a configuration for the given MFA method",
 				},
 			},
@@ -335,7 +335,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Summary:  "Update or create a configuration for the given MFA method",
 				},
 				logical.DeleteOperation: &framework.PathOperation{
-					Callback: i.handleMFAMethodDelete,
+					Callback: i.handleMFAMethodOKTADelete,
 					Summary:  "Delete a configuration for the given MFA method",
 				},
 			},
@@ -391,7 +391,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Summary:  "Update or create a configuration for the given MFA method",
 				},
 				logical.DeleteOperation: &framework.PathOperation{
-					Callback: i.handleMFAMethodDelete,
+					Callback: i.handleMFAMethodDUODelete,
 					Summary:  "Delete a configuration for the given MFA method",
 				},
 			},
@@ -431,7 +431,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Summary:  "Update or create a configuration for the given MFA method",
 				},
 				logical.DeleteOperation: &framework.PathOperation{
-					Callback: i.handleMFAMethodDelete,
+					Callback: i.handleMFAMethodPingIDDelete,
 					Summary:  "Delete a configuration for the given MFA method",
 				},
 			},


### PR DESCRIPTION
Related to [VAULT-5993](https://hashicorp.atlassian.net/browse/VAULT-5993)
Prevent deleting a valid MFA method ID using the endpoint for a different MFA method type