### PR TITLE
Fix a generic PKI description for key_name and issuer_name fields

### DIFF
--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -356,7 +356,7 @@ func addIssuerRefNameFields(fields map[string]*framework.FieldSchema) map[string
 func addIssuerNameField(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
 	fields["issuer_name"] = &framework.FieldSchema{
 		Type: framework.TypeString,
-		Description: `Provide a name to the generated issuer, the name
+		Description: `Provide a name to the generated or existing issuer, the name
 must be unique across all issuers and not be the reserved value 'default'`,
 	}
 	return fields
@@ -382,9 +382,8 @@ func addKeyRefNameFields(fields map[string]*framework.FieldSchema) map[string]*f
 func addKeyNameField(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
 	fields[keyNameParam] = &framework.FieldSchema{
 		Type: framework.TypeString,
-		Description: `Provide a name for the key that will be generated,
-the name must be unique across all keys and not be the reserved value
-'default'`,
+		Description: `Provide a name to the generated or existing key, the name
+must be unique across all keys and not be the reserved value 'default'`,
 	}
 
 	return fields


### PR DESCRIPTION
 - The field could be used to be applied to keys/issuers being generated or to update the name on existing values.