### PR TITLE
Add various missing PKI related changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,10 @@ endpoints in favor of [autoloaded licenses](https://www.vaultproject.io/docs/ent
 
 FEATURES:
 
-* **Allows Multiple Issuer Certificates to enable Non-Disruptive
-Intermediate/Root Certificate Rotation**: This introduces /keys and /issuers
-endpoints to allow import, generation and configuration of any number of keys
-or issuers that can be used to issue and revoke certificates.  Keys and Issuers
-can be referred to by (a) a unique UUID; (b) a name; (c) “default”.  If an
-issuer existed prior to this feature, that issuer will be tagged by a migration
-as “default” to allow backwards compatible calls which don’t specify an issuer.
-Creation of new roles will assume an issuer of “default” unless otherwise
-specified.  This default can be configured at /config/issuers and /config/keys. [[GH-15277](https://github.com/hashicorp/vault/pull/15277)]
+* **Non-Disruptive Intermediate/Root Certificate Rotation**: This allows
+import, generation and configuration of any number of keys and/or issuers
+within a PKI mount, providing operators to ability to rotate certificates
+in place without affecting existing client configurations. [[GH-15277](https://github.com/hashicorp/vault/pull/15277)]
 * api/command: Global -output-policy flag to determine minimum required policy HCL for a given operation [[GH-14899](https://github.com/hashicorp/vault/pull/14899)]
 * nomad: Bootstrap Nomad ACL system if no token is provided [[GH-12451](https://github.com/hashicorp/vault/pull/12451)]
 * storage/dynamodb: Added `AWS_DYNAMODB_REGION` environment variable. [[GH-15054](https://github.com/hashicorp/vault/pull/15054)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ FEATURES:
 
 * **Non-Disruptive Intermediate/Root Certificate Rotation**: This allows
 import, generation and configuration of any number of keys and/or issuers
-within a PKI mount, providing operators to ability to rotate certificates
+within a PKI mount, providing operators the ability to rotate certificates
 in place without affecting existing client configurations. [[GH-15277](https://github.com/hashicorp/vault/pull/15277)]
 * api/command: Global -output-policy flag to determine minimum required policy HCL for a given operation [[GH-14899](https://github.com/hashicorp/vault/pull/14899)]
 * nomad: Bootstrap Nomad ACL system if no token is provided [[GH-12451](https://github.com/hashicorp/vault/pull/12451)]

--- a/changelog/14975.txt
+++ b/changelog/14975.txt
@@ -1,0 +1,5 @@
+```release-note:change
+secrets/pki: existing Generate Root (pki/root/generate/:type),
+Set Signed Intermediate (/pki/intermediate/set-signed) APIs will
+add new issuers/keys to a mount instead of warning that an existing CA exists
+```

--- a/changelog/15004.txt
+++ b/changelog/15004.txt
@@ -1,0 +1,4 @@
+```release-note:change
+secrets/pki: existing Delete Root API (pki/root) will now delete all issuers
+and keys within the mount path.
+```

--- a/changelog/15100.txt
+++ b/changelog/15100.txt
@@ -1,0 +1,4 @@
+```release-note:change
+secrets/pki: Existing CRL API (/pki/crl) now returns an X.509 v2 CRL instead
+of a v1 CRL.
+```

--- a/changelog/15152.txt
+++ b/changelog/15152.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+secrets/pki: Allow operators to control the issuing certificate behavior when
+the requested TTL is beyond the NotAfter value of the signing certificate
+```

--- a/changelog/15155.txt
+++ b/changelog/15155.txt
@@ -1,0 +1,5 @@
+```release-note:change
+secrets/pki: The `ca_chain` response field within issuing (/pki/issue/:role)
+and signing APIs will now include the root CA certificate if the mount is
+aware of it.
+```

--- a/changelog/15179.txt
+++ b/changelog/15179.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+secrets/pki: CRLs on performance secondary clusters are now automatically
+rebuilt upon changes to the list of issuers.
+```

--- a/changelog/15211.txt
+++ b/changelog/15211.txt
@@ -1,0 +1,6 @@
+```release-note:change
+secrets/pki: A new aliased api path (/pki/issuer/:issuer_ref/sign-self-issued)
+providing the same functionality as the existing API(/pki/root/sign-self-issued)
+does not require sudo capabilities but the latter still requires it in an
+effort to maintain backwards compatibility.
+```

--- a/changelog/15277.txt
+++ b/changelog/15277.txt
@@ -1,6 +1,6 @@
 ```release-note:feature
 **Non-Disruptive Intermediate/Root Certificate Rotation**: This allows
 import, generation and configuration of any number of keys and/or issuers
-within a PKI mount, providing operators to ability to rotate certificates
+within a PKI mount, providing operators the ability to rotate certificates
 in place without affecting existing client configurations.
 ```

--- a/changelog/15277.txt
+++ b/changelog/15277.txt
@@ -1,11 +1,6 @@
 ```release-note:feature
-**Allows Multiple Issuer Certificates to enable Non-Disruptive
-Intermediate/Root Certificate Rotation**: This introduces /keys and /issuers
-endpoints to allow import, generation and configuration of any number of keys
-or issuers that can be used to issue and revoke certificates.  Keys and Issuers
-can be referred to by (a) a unique UUID; (b) a name; (c) “default”.  If an
-issuer existed prior to this feature, that issuer will be tagged by a migration
-as “default” to allow backwards compatible calls which don’t specify an issuer.
-Creation of new roles will assume an issuer of “default” unless otherwise
-specified.  This default can be configured at /config/issuers and /config/keys.
+**Non-Disruptive Intermediate/Root Certificate Rotation**: This allows
+import, generation and configuration of any number of keys and/or issuers
+within a PKI mount, providing operators to ability to rotate certificates
+in place without affecting existing client configurations.
 ```


### PR DESCRIPTION
Add various changelog entries to call out changes that occurred as part of the PKI rotation project to existing behaviors.
