### PR TITLE
Fix for gh-11612 (empty namespace flag)

### DIFF
--- a/changelog/15503.txt
+++ b/changelog/15503.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+command: allow empty string to be supplied as -ns and -namespace flags to target root namespace
+```

--- a/command/base.go
+++ b/command/base.go
@@ -157,7 +157,10 @@ func (c *BaseCommand) Client() (*api.Client, error) {
 	if c.flagNS != notSetValue {
 		c.flagNamespace = c.flagNS
 	}
-	if c.flagNamespace != notSetValue {
+	// Set namespace only if it was passed in AND hasn't been set to the root
+	// namespace (""). If we are explicitly passed "" then just omit the setting
+	// of the namespace and follow the default behavior
+	if c.flagNamespace != notSetValue && c.flagNamespace != "" {
 		client.SetNamespace(namespace.Canonicalize(c.flagNamespace))
 	}
 	if c.flagPolicyOverride {

--- a/command/base_test.go
+++ b/command/base_test.go
@@ -4,6 +4,9 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/vault/sdk/helper/consts"
+	"github.com/stretchr/testify/assert"
 )
 
 func getDefaultCliHeaders(t *testing.T) http.Header {
@@ -13,6 +16,83 @@ func getDefaultCliHeaders(t *testing.T) http.Header {
 		t.Fatal(err)
 	}
 	return cli.Headers()
+}
+
+func TestClient_NamespaceFlagSetToValue(t *testing.T) {
+	bc := &BaseCommand{}
+	bc.flagSet(FlagSetHTTP)
+	bc.flagNamespace = "juan"
+	cli, err := bc.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := cli.Headers()
+	v := h.Get(consts.NamespaceHeaderName)
+
+	// Expect the `namespace.Canonicalize` method will add a trailing slash
+	assert.Equal(t, "juan/", v, "Expected namespace not found")
+}
+
+func TestClient_NSFlagSetToValue(t *testing.T) {
+	bc := &BaseCommand{}
+	bc.flagSet(FlagSetHTTP)
+	bc.flagNS = "juan"
+	cli, err := bc.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := cli.Headers()
+	v := h.Get(consts.NamespaceHeaderName)
+
+	assert.Equal(t, "juan/", v, "Expected ns not found")
+}
+
+func TestClient_NSFlagSetToValueAndNamespaceFlagSetToDifferentValue(t *testing.T) {
+	bc := &BaseCommand{}
+	bc.flagSet(FlagSetHTTP)
+	bc.flagNS = "juan"
+	bc.flagNamespace = "john"
+	cli, err := bc.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := cli.Headers()
+	v := h.Get(consts.NamespaceHeaderName)
+
+	assert.Equal(t, "juan/", v, "Expected ns not found")
+}
+
+func TestClient_NSFlagSetToEmptyString(t *testing.T) {
+	bc := &BaseCommand{}
+	bc.flagSet(FlagSetHTTP)
+	bc.flagNS = ""
+	cli, err := bc.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := cli.Headers()
+	v := h.Get(consts.NamespaceHeaderName)
+
+	assert.Equal(t, "", v, "Expected ns was configured rather than ignored")
+}
+
+func TestClient_NamespaceFlagSetToEmptyString(t *testing.T) {
+	bc := &BaseCommand{}
+	bc.flagSet(FlagSetHTTP)
+	bc.flagNamespace = ""
+	cli, err := bc.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := cli.Headers()
+	v := h.Get(consts.NamespaceHeaderName)
+
+	assert.Equal(t, "", v, "Expected namespace was configured rather than ignored")
 }
 
 func TestClient_FlagHeader(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-metrics-stackdriver v0.2.0
+	github.com/google/tink/go v1.4.0
 	github.com/hashicorp/cap v0.1.1
 	github.com/hashicorp/consul-template v0.29.0
 	github.com/hashicorp/consul/api v1.12.0
@@ -274,7 +275,6 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/tink/go v1.4.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect


### PR DESCRIPTION
Allow CLI flag to be passed as an empty string to override VAULT_NAMESPACE environment variables if configured.

Should fix: https://github.com/hashicorp/vault/issues/11612