### PR TITLE
Fix minor typos and change terminology slightly in database secrets engines docs

### DIFF
--- a/builtin/logical/cassandra/test-fixtures/cassandra.yaml
+++ b/builtin/logical/cassandra/test-fixtures/cassandra.yaml
@@ -529,7 +529,7 @@ memtable_allocation_type: heap_buffers
 # new space for cdc-tracked tables has been made available. Default to 250ms
 # cdc_free_space_check_interval_ms: 250
 
-# A fixed memory pool size in MB for for SSTable index summaries. If left
+# A fixed memory pool size in MB for SSTable index summaries. If left
 # empty, this will default to 5% of the heap size. If the memory usage of
 # all index summaries exceeds this limit, SSTables with low read rates will
 # shrink their index summaries in order to meet this limit.  However, this

--- a/website/content/api-docs/secret/databases/hanadb.mdx
+++ b/website/content/api-docs/secret/databases/hanadb.mdx
@@ -44,9 +44,9 @@ has a number of parameters to further configure a connection.
 
 - `password` `(string: "")` - The root credential password used in the connection URL.
 
-- `disable_escaping` `(boolean: false)` - Turns off the escaping of symbol characters inside of the username
+- `disable_escaping` `(boolean: false)` - Turns off the escaping of special characters inside of the username
   and password fields. See the [databases secrets engine docs](/docs/secrets/databases#disable-character-escaping)
-  for for information. Defaults to `false`.
+  for more information. Defaults to `false`.
 
 ### Sample Payload
 

--- a/website/content/api-docs/secret/databases/index.mdx
+++ b/website/content/api-docs/secret/databases/index.mdx
@@ -84,7 +84,7 @@ are supported and any additional details about them.
   configuration. This is typically used in the `connection_url` field via the templating
   directive `{{password}}`.
 
-- `disable_escaping` `(boolean: false)` - Determines whether symbol characters in the
+- `disable_escaping` `(boolean: false)` - Determines whether special characters in the
   username and password fields will be escaped. Useful for alternate connection string
   formats like ADO. More information regarding this parameter can be found on the
   [databases secrets engine docs.](/docs/secrets/databases#disable-character-escaping)
@@ -130,7 +130,7 @@ $ vault write database/config/mssql \
     plugin_name="mssql-database-plugin" \
     connection_url='server=localhost;port=1433;user id={{username}};password={{password}};database=mssql;' \
     username="vaultuser" \
-    password='#secret(password)' \
+    password='your#StrongPassword%' \
     disable_escaping="true"
 ```
 

--- a/website/content/api-docs/secret/databases/mssql.mdx
+++ b/website/content/api-docs/secret/databases/mssql.mdx
@@ -51,9 +51,9 @@ has a number of parameters to further configure a connection.
   [Contained Database](https://docs.microsoft.com/en-us/sql/relational-databases/databases/contained-databases?view=sql-server-ver15),
   like AzureSQL.
 
-- `disable_escaping` `(boolean: false)` - Turns off the escaping of symbol characters inside of the username
+- `disable_escaping` `(boolean: false)` - Turns off the escaping of special characters inside of the username
   and password fields. See the [databases secrets engine docs](/docs/secrets/databases#disable-character-escaping)
-  for for information. Defaults to `false`.
+  for more information. Defaults to `false`.
 
 <details>
 <summary><b>Default Username Template</b></summary>

--- a/website/content/api-docs/secret/databases/mysql-maria.mdx
+++ b/website/content/api-docs/secret/databases/mysql-maria.mdx
@@ -53,9 +53,9 @@ has a number of parameters to further configure a connection.
 - `username_template` `(string)` - [Template](/docs/concepts/username-templating) describing how
   dynamic usernames are generated.
 
-- `disable_escaping` `(boolean: false)` - Turns off the escaping of symbol characters inside of the username
+- `disable_escaping` `(boolean: false)` - Turns off the escaping of special characters inside of the username
   and password fields. See the [databases secrets engine docs](/docs/secrets/databases#disable-character-escaping)
-  for for information. Defaults to `false`.
+  for more information. Defaults to `false`.
 
 **Default Username Templates:**
 

--- a/website/content/api-docs/secret/databases/oracle.mdx
+++ b/website/content/api-docs/secret/databases/oracle.mdx
@@ -44,9 +44,9 @@ has a number of parameters to further configure a connection.
 - `username_template` `(string)` - [Template](/docs/concepts/username-templating) describing how
   dynamic usernames are generated.
 
-- `disable_escaping` `(boolean: false)` - Turns off the escaping of symbol characters inside of the username
+- `disable_escaping` `(boolean: false)` - Turns off the escaping of special characters inside of the username
   and password fields. See the [databases secrets engine docs](/docs/secrets/databases#disable-character-escaping)
-  for for information. Defaults to `false`.
+  for more information. Defaults to `false`.
 
 <details>
 <summary><b>Default Username Template</b></summary>

--- a/website/content/api-docs/secret/databases/postgresql.mdx
+++ b/website/content/api-docs/secret/databases/postgresql.mdx
@@ -49,9 +49,9 @@ has a number of parameters to further configure a connection.
 - `username_template` `(string)` - [Template](/docs/concepts/username-templating) describing how
   dynamic usernames are generated.
 
-- `disable_escaping` `(boolean: false)` - Turns off the escaping of symbol characters inside of the username
+- `disable_escaping` `(boolean: false)` - Turns off the escaping of special characters inside of the username
   and password fields. See the [databases secrets engine docs](/docs/secrets/databases#disable-character-escaping)
-  for for information. Defaults to `false`.
+  for more information. Defaults to `false`.
 
 <details>
 <summary><b>Default Username Template</b></summary>

--- a/website/content/api-docs/secret/databases/redshift.mdx
+++ b/website/content/api-docs/secret/databases/redshift.mdx
@@ -46,9 +46,9 @@ has a number of parameters to further configure a connection.
 
 - `username_template` `(string)` - [Template](/docs/concepts/username-templating) describing how dynamic usernames are generated.
 
-- `disable_escaping` `(boolean: false)` - Turns off the escaping of symbol characters inside of the username
+- `disable_escaping` `(boolean: false)` - Turns off the escaping of special characters inside of the username
   and password fields. See the [databases secrets engine docs](/docs/secrets/databases#disable-character-escaping)
-  for for information. Defaults to `false`.
+  for more information. Defaults to `false`.
 
 ### Sample Payload
 

--- a/website/content/api-docs/secret/databases/snowflake.mdx
+++ b/website/content/api-docs/secret/databases/snowflake.mdx
@@ -46,9 +46,9 @@ has a number of parameters to further configure a connection.
 
 - `username_template` `(string)` - [Template](/docs/concepts/username-templating) describing how dynamic usernames are generated.
 
-- `disable_escaping` `(boolean: false)` - Turns off the escaping of symbol characters inside of the username
+- `disable_escaping` `(boolean: false)` - Turns off the escaping of special characters inside of the username
   and password fields. See the [databases secrets engine docs](/docs/secrets/databases#disable-character-escaping)
-  for for information. Defaults to `false`.
+  for more information. Defaults to `false`.
 
 ### Sample Payload
 

--- a/website/content/docs/secrets/databases/index.mdx
+++ b/website/content/docs/secrets/databases/index.mdx
@@ -200,7 +200,7 @@ fields. This is necessary for some alternate connection string formats, such as 
 SQL. See the [databases secrets engine API docs](/api-docs/secret/databases#common-fields) and reference
 individual plugin documentation to determine support for this parameter.
 
-For example, when the password contains URL-escaped characters like `%` or `#` they will
+For example, when the password contains URL-escaped characters like `#` or `%` they will
 remain as so instead of becoming `%23` and `%25` respectively.
 
 ```shell-session
@@ -208,7 +208,7 @@ $ vault write database/config/my-mssql-database \
 plugin_name="mssql-database-plugin" \
 connection_url='server=localhost;port=1433;user id={{username}};password={{password}};database=mydb;' \
 username="root" \
-password='your#Strong(!)Password%' \
+password='your#StrongPassword%' \
 disable_escaping="true"
 ```
 


### PR DESCRIPTION
Change terminology from "symbol characters" to "special characters" as they may not all be symbols. Also fix several instances of the typo "for for". 