### PR TITLE
Add warning on missing AIA info fields

### DIFF
--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -108,6 +108,14 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 		Data: map[string]interface{}{},
 	}
 
+	entries, err := getURLs(ctx, req)
+	if err == nil && len(entries.OCSPServers) == 0 && len(entries.IssuingCertificates) == 0 && len(entries.CRLDistributionPoints) == 0 {
+		// If the operator hasn't configured any of the URLs prior to
+		// generating this issuer, we should add a warning to the response,
+		// informing them they might want to do so and re-generate the issuer.
+		resp.AddWarning("This mount hasn't configured any authority access information fields; this may make it harder for systems to find missing certificates in the chain or to validate revocation status of certificates. Consider updating /config/urls with this information.")
+	}
+
 	switch format {
 	case "pem":
 		resp.Data["csr"] = csrb.CSR

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -178,6 +178,13 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 		resp.AddWarning("This issuer certificate was generated without a Subject; this makes it likely that issuing leaf certs with this certificate will cause TLS validation libraries to reject this certificate.")
 	}
 
+	if len(parsedBundle.Certificate.OCSPServer) == 0 && len(parsedBundle.Certificate.IssuingCertificateURL) == 0 && len(parsedBundle.Certificate.CRLDistributionPoints) == 0 {
+		// If the operator hasn't configured any of the URLs prior to
+		// generating this issuer, we should add a warning to the response,
+		// informing them they might want to do so and re-generate the issuer.
+		resp.AddWarning("This mount hasn't configured any authority access information fields; this may make it harder for systems to find missing certificates in the chain or to validate revocation status of certificates. Consider updating /config/urls with this information.")
+	}
+
 	switch format {
 	case "pem":
 		resp.Data["certificate"] = cb.Certificate
@@ -366,6 +373,13 @@ func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.R
 		// our certificate's ASN.1 content, so let's just assume it holds
 		// and move on.
 		resp.AddWarning("This issuer certificate was generated without a Subject; this makes it likely that issuing leaf certs with this certificate will cause TLS validation libraries to reject this certificate.")
+	}
+
+	if len(parsedBundle.Certificate.OCSPServer) == 0 && len(parsedBundle.Certificate.IssuingCertificateURL) == 0 && len(parsedBundle.Certificate.CRLDistributionPoints) == 0 {
+		// If the operator hasn't configured any of the URLs prior to
+		// generating this issuer, we should add a warning to the response,
+		// informing them they might want to do so and re-generate the issuer.
+		resp.AddWarning("This mount hasn't configured any authority access information fields; this may make it harder for systems to find missing certificates in the chain or to validate revocation status of certificates. Consider updating /config/urls with this information.")
 	}
 
 	switch format {

--- a/changelog/15509.txt
+++ b/changelog/15509.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Warn on missing AIA access information when generating issuers (config/urls).
+```


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

```
$ vault write pki/root/generate/exported common_name="not-empty" issuer_name=unknown-2 
WARNING! The following warnings were returned from Vault:

  * This mount hasn't configured any authority access information fields;
  this may make it harder for systems to find missing certificates in the
  chain or to validate revocation status of certificates. Consider updating
  /config/urls with this information.
```

