### PR TITLE
UI: KeyMgmt Secret Engine

### DIFF
--- a/builtin/logical/transit/path_random.go
+++ b/builtin/logical/transit/path_random.go
@@ -2,6 +2,7 @@ package transit
 
 import (
 	"context"
+
 	"github.com/hashicorp/vault/helper/random"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"

--- a/changelog/15512.txt
+++ b/changelog/15512.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+**KeyMgmt UI**: Add UI support for managing the Key Management Secrets Engine
+```

--- a/ui/app/adapters/keymgmt/key.js
+++ b/ui/app/adapters/keymgmt/key.js
@@ -123,7 +123,7 @@ export default class KeymgmtKeyAdapter extends ApplicationAdapter {
     let provider, distribution;
     if (!recordOnly) {
       provider = await this.getProvider(backend, id);
-      if (provider) {
+      if (provider && !provider.permissionsError) {
         distribution = await this.getDistribution(backend, provider, id);
       }
     }

--- a/ui/app/adapters/keymgmt/key.js
+++ b/ui/app/adapters/keymgmt/key.js
@@ -42,12 +42,6 @@ export default class KeymgmtKeyAdapter extends ApplicationAdapter {
     return url;
   }
 
-  urlForDeleteRecord(store, type, snapshot) {
-    const name = snapshot.attr('name');
-    const backend = snapshot.attr('backend');
-    return this.url(backend, name);
-  }
-
   _updateKey(backend, name, serialized) {
     // Only these two attributes are allowed to be updated
     let data = pickKeys(serialized, ['deletion_allowed', 'min_enabled_version']);

--- a/ui/app/components/keymgmt/distribute.js
+++ b/ui/app/components/keymgmt/distribute.js
@@ -39,6 +39,7 @@ export default class KeymgmtDistribute extends Component {
   @tracked isNewKey = false;
   @tracked providerType;
   @tracked formData;
+  @tracked formErrors;
 
   constructor() {
     super(...arguments);
@@ -196,7 +197,7 @@ export default class KeymgmtDistribute extends Component {
         this.args.onClose();
       })
       .catch((e) => {
-        this.flashMessages.danger(`Error distributing key: ${e.errors}`);
+        this.formErrors = `Error distributing key: ${e.errors}`;
       });
   }
 

--- a/ui/app/components/keymgmt/distribute.js
+++ b/ui/app/components/keymgmt/distribute.js
@@ -201,10 +201,15 @@ export default class KeymgmtDistribute extends Component {
   }
 
   @action
-  handleProvider(evt) {
-    this.formData.provider = evt.target.value;
-    if (evt.target.value) {
-      this.getProviderType(evt.target.value);
+  handleProvider(selection) {
+    let providerName = selection[0];
+    if (typeof selection === 'string') {
+      // Handles case if no list permissions and fallback component is used
+      providerName = selection;
+    }
+    this.formData.provider = providerName;
+    if (providerName) {
+      this.getProviderType(providerName);
     }
   }
   @action

--- a/ui/app/components/keymgmt/distribute.js
+++ b/ui/app/components/keymgmt/distribute.js
@@ -263,5 +263,10 @@ export default class KeymgmtDistribute extends Component {
       }
     }
     yield this.distributeKey(backend, data);
+    // Reload key to get dist info
+    yield this.store.queryRecord(`keymgmt/key`, {
+      backend: this.args.backend,
+      id: this.keyModel.name,
+    });
   }
 }

--- a/ui/app/components/keymgmt/key-edit.js
+++ b/ui/app/components/keymgmt/key-edit.js
@@ -54,7 +54,6 @@ export default class KeymgmtKeyEdit extends Component {
     const { model } = this.args;
     try {
       yield model.save();
-      yield model.reload();
       this.router.transitionTo(SHOW_ROUTE, model.name);
     } catch (error) {
       let errorMessage = error;

--- a/ui/app/components/keymgmt/key-edit.js
+++ b/ui/app/components/keymgmt/key-edit.js
@@ -57,7 +57,17 @@ export default class KeymgmtKeyEdit extends Component {
       yield model.reload();
       this.router.transitionTo(SHOW_ROUTE, model.name);
     } catch (error) {
-      this.flashMessages.danger(error.errors.join('. '));
+      let errorMessage = error;
+      if (error.errors) {
+        // if errors come directly from API they will be in this shape
+        errorMessage = error.errors.join('. ');
+      }
+      this.flashMessages.danger(errorMessage);
+      if (!error.errors) {
+        // If error was custom from save, only partial fail
+        // so it's safe to show the key
+        this.router.transitionTo(SHOW_ROUTE, model.name);
+      }
     }
   }
 

--- a/ui/app/components/keymgmt/provider-edit.js
+++ b/ui/app/components/keymgmt/provider-edit.js
@@ -70,6 +70,7 @@ export default class KeymgmtProviderEdit extends Component {
     event.preventDefault();
     const { isValid, state } = await this.args.model.validate();
     if (isValid) {
+      this.modelValidations = null;
       this.saveTask.perform();
     } else {
       this.modelValidations = state;

--- a/ui/app/helpers/mountable-secret-engines.js
+++ b/ui/app/helpers/mountable-secret-engines.js
@@ -21,7 +21,7 @@ export const KEYMGMT = {
   value: 'keymgmt',
   type: 'keymgmt',
   glyph: 'key',
-  category: 'generic',
+  category: 'cloud',
   requiredFeature: 'Key Management Secrets Engine',
 };
 

--- a/ui/app/models/keymgmt/provider.js
+++ b/ui/app/models/keymgmt/provider.js
@@ -78,7 +78,6 @@ export default class KeymgmtProviderModel extends Model {
     }[this.provider];
   }
   get showFields() {
-    // TODO: fields shown depend on type
     const attrs = expandAttributeMeta(this, ['name', 'created', 'keyCollection']);
     attrs.splice(1, 0, { hasBlock: true, label: 'Type', value: this.typeName, icon: this.icon });
     const l = this.keys.length;

--- a/ui/app/models/keymgmt/provider.js
+++ b/ui/app/models/keymgmt/provider.js
@@ -55,8 +55,6 @@ export default class KeymgmtProviderModel extends Model {
   })
   keyCollection;
 
-  @attr('date') created;
-
   idPrefix = 'provider/';
   type = 'provider';
 
@@ -78,7 +76,7 @@ export default class KeymgmtProviderModel extends Model {
     }[this.provider];
   }
   get showFields() {
-    const attrs = expandAttributeMeta(this, ['name', 'created', 'keyCollection']);
+    const attrs = expandAttributeMeta(this, ['name', 'keyCollection']);
     attrs.splice(1, 0, { hasBlock: true, label: 'Type', value: this.typeName, icon: this.icon });
     const l = this.keys.length;
     const value = l
@@ -114,7 +112,10 @@ export default class KeymgmtProviderModel extends Model {
   }
 
   async fetchKeys(page) {
-    if (this.canListKeys) {
+    if (this.canListKeys === false) {
+      this.keys = [];
+    } else {
+      // try unless capabilities returns false
       try {
         this.keys = await this.store.lazyPaginatedQuery('keymgmt/key', {
           backend: 'keymgmt',
@@ -128,8 +129,6 @@ export default class KeymgmtProviderModel extends Model {
           throw error;
         }
       }
-    } else {
-      this.keys = [];
     }
   }
 

--- a/ui/app/models/keymgmt/provider.js
+++ b/ui/app/models/keymgmt/provider.js
@@ -45,7 +45,7 @@ export default class KeymgmtProviderModel extends Model {
     label: 'Type',
     subText: 'Choose the provider type.',
     possibleValues: ['azurekeyvault', 'awskms', 'gcpckms'],
-    defaultValue: 'azurekeyvault',
+    noDefault: true,
   })
   provider;
 
@@ -78,6 +78,7 @@ export default class KeymgmtProviderModel extends Model {
     }[this.provider];
   }
   get showFields() {
+    // TODO: fields shown depend on type
     const attrs = expandAttributeMeta(this, ['name', 'created', 'keyCollection']);
     attrs.splice(1, 0, { hasBlock: true, label: 'Type', value: this.typeName, icon: this.icon });
     const l = this.keys.length;
@@ -90,13 +91,18 @@ export default class KeymgmtProviderModel extends Model {
     return attrs;
   }
   get credentialProps() {
+    if (!this.provider) return [];
     return CRED_PROPS[this.provider];
   }
   get credentialFields() {
     const [creds, fields] = this.credentialProps.reduce(
       ([creds, fields], prop) => {
         creds[prop] = null;
-        fields.push({ name: `credentials.${prop}`, type: 'string', options: { label: prop } });
+        let field = { name: `credentials.${prop}`, type: 'string', options: { label: prop } };
+        if (prop === 'service_account_file') {
+          field.options.subText = 'The path to a Google service account key file, not the file itself.';
+        }
+        fields.push(field);
         return [creds, fields];
       },
       [{}, []]

--- a/ui/app/templates/components/input-search.hbs
+++ b/ui/app/templates/components/input-search.hbs
@@ -1,6 +1,13 @@
 <div class="field is-grouped">
   <div class="control is-expanded">
+    {{#if @label}}
+      <label for={{@id}} class="is-label">{{@label}}</label>
+    {{/if}}
+    {{#if @subText}}
+      <p class="sub-text">{{@subText}}</p>
+    {{/if}}
     <Input
+      id={{@id}}
       class="input"
       @type="text"
       @value={{this.searchInput}}

--- a/ui/app/templates/components/keymgmt/distribute.hbs
+++ b/ui/app/templates/components/keymgmt/distribute.hbs
@@ -71,8 +71,8 @@
           @passObject={{false}}
           @inputValue={{this.formData.provider}}
           @subText="Select a provider in Vault. If it doesn’t exist yet, you’ll need to add it first."
-          @label="Provider"
-          @subLabel=""
+          @label=""
+          @subLabel="Provider"
           @fallbackComponent="input-search"
           @selectLimit="1"
           @backend={{@backend}}

--- a/ui/app/templates/components/keymgmt/distribute.hbs
+++ b/ui/app/templates/components/keymgmt/distribute.hbs
@@ -1,5 +1,5 @@
 {{#if @backend}}
-  <form {{on "submit" this.createDistribution}} class="form-section" data-test-keymgmt-distribution-form>
+  <form {{on "submit" (perform this.createDistribution)}} class="form-section" data-test-keymgmt-distribution-form>
     {{#unless @key}}
       <div class="field" data-test-keymgmt-dist-key>
         <SearchSelect
@@ -140,11 +140,15 @@
       <div class="control">
         <button
           type="submit"
-          disabled={{or this.validationErrorCount}}
+          disabled={{or this.validationErrorCount this.createDistribution.isRunning}}
           class="button is-primary"
           data-test-secret-save={{true}}
         >
-          {{if (or (not @key) this.isNewKey) "Add key" "Distribute key"}}
+          {{#if this.createDistribution.isRunning}}
+            <span class="loader is-inline-block"></span>
+          {{else}}
+            {{if (or (not @key) this.isNewKey) "Add key" "Distribute key"}}
+          {{/if}}
         </button>
       </div>
       <div class="control">

--- a/ui/app/templates/components/keymgmt/distribute.hbs
+++ b/ui/app/templates/components/keymgmt/distribute.hbs
@@ -133,11 +133,14 @@
       </div>
     </fieldset>
 
+    {{#if this.formErrors}}
+      <AlertBanner @type="danger" @message={{this.formErrors}} data-test-keymgmt-distribute-error />
+    {{/if}}
     <div class="field is-grouped box is-fullwidth is-bottomless">
       <div class="control">
         <button
           type="submit"
-          disabled={{or this.validationErrorCount this.error}}
+          disabled={{or this.validationErrorCount}}
           class="button is-primary"
           data-test-secret-save={{true}}
         >

--- a/ui/app/templates/components/keymgmt/distribute.hbs
+++ b/ui/app/templates/components/keymgmt/distribute.hbs
@@ -64,35 +64,29 @@
 
     {{#unless @provider}}
       <div class="field">
-        <label class="is-label" for="provider">Provider</label>
-        <p class="sub-text">Select a provider in Vault. If it doesn’t exist yet, you’ll need to add it first.</p>
-        <div class="control is-expanded">
-          <div class="select is-fullwidth">
-            <select
-              name="provider"
-              id="provider"
-              {{on "change" this.handleProvider}}
-              class={{if this.validMatchError.provider "has-error-border"}}
-              data-test-keymgmt-dist-provider
-            >
-              <option value="">
-                Select provider
-              </option>
-              {{#each @providers as |val|}}
-                <option selected={{eq @model.provider val}} value={{val}}>
-                  {{val}}
-                </option>
-              {{/each}}
-            </select>
-          </div>
-        </div>
-        {{#if this.validMatchError.provider}}
-          <AlertInline @paddingTop={{true}} @sizeSmall={{true}} @type="danger" data-test-keymgmt-error="provider">
-            {{this.validMatchError.provider}}
-            To check compatibility,
-            <DocLink class="doc-link-subtle" @path="/docs/secrets/key-management#compatibility">refer to this table</DocLink>.
-          </AlertInline>
-        {{/if}}
+        <SearchSelect
+          @id="provider"
+          @models={{array "keymgmt/provider"}}
+          @onChange={{this.handleProvider}}
+          @passObject={{false}}
+          @inputValue={{this.formData.provider}}
+          @subText="Select a provider in Vault. If it doesn’t exist yet, you’ll need to add it first."
+          @label="Provider"
+          @subLabel=""
+          @fallbackComponent="input-search"
+          @selectLimit="1"
+          @backend={{@backend}}
+          @disallowNewItems={{true}}
+          data-test-keymgmt-dist-provider
+        >
+          {{#if this.validMatchError.provider}}
+            <AlertInline @paddingTop={{true}} @sizeSmall={{true}} @type="danger" data-test-keymgmt-error="provider">
+              {{this.validMatchError.provider}}
+              To check compatibility,
+              <DocLink class="doc-link-subtle" @path="/docs/secrets/key-management#compatibility">refer to this table</DocLink>.
+            </AlertInline>
+          {{/if}}
+        </SearchSelect>
       </div>
     {{/unless}}
 

--- a/ui/app/templates/components/keymgmt/key-edit.hbs
+++ b/ui/app/templates/components/keymgmt/key-edit.hbs
@@ -199,7 +199,7 @@
         </EmptyState>
       {{else}}
         <InfoTableRow @label="Distributed" @value={{@model.provider}}>
-          <LinkTo @route="vault.cluster.secrets.backend.show" @model={{concat "kms/" @model.provider}}>
+          <LinkTo @route="vault.cluster.secrets.backend.show" @model={{@model.provider}} @query={{hash itemType="provider"}}>
             <Icon @name="check-circle-fill" class="has-text-success" />{{@model.provider}}
           </LinkTo>
         </InfoTableRow>

--- a/ui/app/templates/components/keymgmt/key-edit.hbs
+++ b/ui/app/templates/components/keymgmt/key-edit.hbs
@@ -156,7 +156,7 @@
     {{/each}}
   {{else}}
     <div class="has-top-margin-xl has-bottom-margin-s">
-      <h2 class="title has-border-bottom-light is-5">Key Details</h2>
+      <h2 class="title is-5 has-border-bottom-light">Key Details</h2>
       {{#each @model.showFields as |attr|}}
         <InfoTableRow
           @alwaysRender={{true}}
@@ -168,23 +168,10 @@
       {{/each}}
     </div>
     <div class="has-top-margin-xl has-bottom-margin-s">
-      <h2 class="title has-border-bottom-light is-5 {{unless @model.provider.canListKeys 'is-borderless is-marginless'}}">
+      <h2 class="title is-5 {{if @model.distribution 'has-border-bottom-light' 'is-borderless'}}">
         Distribution Details
       </h2>
-      {{#if (not @model.provider)}}
-        <EmptyState
-          @title="Key not distributed"
-          @message="When this key is distributed to a destination, those details will appear here."
-          data-test-keymgmt-dist-empty-state
-        >
-          {{#if @model.canListProviders}}
-            <button type="button" class="link" {{on "click" (fn (mut this.isDistributing) true)}}>
-              Distribute key
-              <Icon @name="chevron-right" />
-            </button>
-          {{/if}}
-        </EmptyState>
-      {{else if (not @model.provider.canListKeys)}}
+      {{#if @model.provider.permissionsError}}
         <EmptyState
           @title="You are not authorized"
           @subTitle="Error 403"
@@ -197,6 +184,19 @@
           }}
           @icon="minus-circle"
         />
+      {{else if (is-empty-value @model.provider)}}
+        <EmptyState
+          @title="Key not distributed"
+          @message="When this key is distributed to a destination, those details will appear here."
+          data-test-keymgmt-dist-empty-state
+        >
+          {{#if @model.canListProviders}}
+            <button type="button" class="link" {{on "click" (fn (mut this.isDistributing) true)}}>
+              Distribute key
+              <Icon @name="chevron-right" />
+            </button>
+          {{/if}}
+        </EmptyState>
       {{else}}
         <InfoTableRow @label="Distributed" @value={{@model.provider}}>
           <LinkTo @route="vault.cluster.secrets.backend.show" @model={{concat "kms/" @model.provider}}>
@@ -222,7 +222,13 @@
           <EmptyState
             @title="You are not authorized"
             @subTitle="Error 403"
-            @message="You must be granted permissions to view distribution details for this key. Ask your administrator if you think you should have access to GET /keymgmt/keymgmt/key/example."
+            @message={{concat
+              "You must be granted permissions to view distribution details for this key. Ask your administrator if you think you should have access to GET /"
+              @model.backend
+              "/key/"
+              @model.name
+              "/kms."
+            }}
             @icon="minus-circle"
           />
         {{/if}}

--- a/ui/app/templates/components/keymgmt/key-edit.hbs
+++ b/ui/app/templates/components/keymgmt/key-edit.hbs
@@ -24,7 +24,7 @@
     <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless" data-test-keymgmt-key-toolbar>
       <nav class="tabs">
         <ul>
-          <li class={{if (not-eq @tab "versions") "is-active"}}>
+          <li class={{if (not-eq @tab "versions") "active"}}>
             <LinkTo
               @route="vault.cluster.secrets.backend.show"
               @model={{@model.id}}
@@ -34,7 +34,7 @@
               Details
             </LinkTo>
           </li>
-          <li class={{if (eq @tab "versions") "is-active"}}>
+          <li class={{if (eq @tab "versions") "active"}}>
             <LinkTo
               @route="vault.cluster.secrets.backend.show"
               @model={{@model.id}}
@@ -49,6 +49,16 @@
     </div>
     <Toolbar>
       <ToolbarActions>
+        {{#unless @model.distribution}}
+          <button
+            type="button"
+            class="toolbar-link"
+            {{on "click" (fn (mut this.isDistributing) true)}}
+            data-test-keymgmt-key-distribute
+          >
+            Distribute key
+          </button>
+        {{/unless}}
         {{#if @model.canDelete}}
           <button
             type="button"
@@ -63,10 +73,11 @@
         {{#if @model.provider}}
           <ConfirmAction
             @buttonClasses="toolbar-link"
-            @onConfirmAction={{this.removeKey}}
+            @onConfirmAction={{perform this.removeKey}}
             @confirmTitle="Remove this key?"
             @confirmMessage="This will remove all versions of the key from the KMS provider. The key will stay in Vault."
             @confirmButtonText="Remove"
+            @isRunning={{this.removeKey.isRunning}}
             data-test-keymgmt-key-remove
           >
             Remove key
@@ -77,10 +88,11 @@
         {{/if}}
         <ConfirmAction
           @buttonClasses="toolbar-link"
-          @onConfirmAction={{fn this.rotateKey @model.id}}
+          @onConfirmAction={{perform this.rotateKey}}
           @confirmTitle="Rotate this key?"
           @confirmMessage="After rotation, all key actions will default to using the newest version of the key."
           @confirmButtonText="Rotate"
+          @isRunning={{this.rotateKey.isRunning}}
           data-test-keymgmt-key-rotate
         >
           Rotate key

--- a/ui/app/templates/components/keymgmt/provider-edit.hbs
+++ b/ui/app/templates/components/keymgmt/provider-edit.hbs
@@ -98,8 +98,15 @@
                   Provider configuration
                 </h2>
               </div>
+              {{#if @model.provider}}
+                {{! Only show last field if provider selected }}
+                <FormField @attr={{attr}} @model={{@model}} @modelValidations={{this.modelValidations}} />
+              {{else}}
+                <EmptyState @title="No provider selected" @message="Select a provider in order to configure it." />
+              {{/if}}
+            {{else}}
+              <FormField @attr={{attr}} @model={{@model}} @modelValidations={{this.modelValidations}} />
             {{/if}}
-            <FormField @attr={{attr}} @model={{@model}} @modelValidations={{this.modelValidations}} />
           {{/each}}
         {{/if}}
         {{#unless this.isCreating}}

--- a/ui/app/templates/components/keymgmt/provider-edit.hbs
+++ b/ui/app/templates/components/keymgmt/provider-edit.hbs
@@ -23,13 +23,13 @@
     <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
       <nav class="tabs">
         <ul>
-          <li class={{unless this.viewingKeys "is-active"}} data-test-kms-provider-tab="details">
+          <li class={{unless this.viewingKeys "active"}} data-test-kms-provider-tab="details">
             <LinkTo @route="vault.cluster.secrets.backend.show" @model={{@model.id}} @query={{hash tab=""}}>
               Details
             </LinkTo>
           </li>
           {{#if @model.canListKeys}}
-            <li class={{if this.viewingKeys "is-active"}} data-test-kms-provider-tab="keys">
+            <li class={{if this.viewingKeys "active"}} data-test-kms-provider-tab="keys">
               <LinkTo @route="vault.cluster.secrets.backend.show" @model={{@model.id}} @query={{hash tab="keys"}}>
                 Keys
               </LinkTo>

--- a/ui/lib/core/addon/components/confirm-action.js
+++ b/ui/lib/core/addon/components/confirm-action.js
@@ -33,6 +33,7 @@ export default Component.extend({
   cancelButtonText: 'Cancel',
   horizontalPosition: 'auto-right',
   verticalPosition: 'below',
+  isRunning: false,
   disabled: false,
   showConfirm: false,
   onConfirmAction: null,

--- a/ui/lib/core/addon/templates/components/confirm-action.hbs
+++ b/ui/lib/core/addon/templates/components/confirm-action.hbs
@@ -32,12 +32,16 @@
         <div class="confirm-action-options">
           <button
             type="button"
-            disabled={{this.disabled}}
+            disabled={{or this.disabled this.isRunning}}
             class="link is-destroy"
             data-test-confirm-button="true"
             {{action "onConfirm"}}
           >
-            {{this.confirmButtonText}}
+            {{#if this.isRunning}}
+              <span class="loader is-inline-block"></span>
+            {{else}}
+              {{this.confirmButtonText}}
+            {{/if}}
           </button>
           <button type="button" class="link" data-test-confirm-cancel-button="true" {{action d.actions.close}}>
             {{this.cancelButtonText}}

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -2,6 +2,7 @@
   {{component
     this.fallbackComponent
     label=(or this.label this.subLabel)
+    subText=this.subText
     onChange=(action "onChange")
     inputValue=this.inputValue
     helpText=this.helpText

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -1,11 +1,12 @@
 {{#if this.shouldUseFallback}}
   {{component
     this.fallbackComponent
-    label=this.label
+    label=(or this.label this.subLabel)
     onChange=(action "onChange")
     inputValue=this.inputValue
     helpText=this.helpText
     placeHolder=this.placeHolder
+    id=this.id
   }}
 {{else}}
   <label class={{if this.labelClass this.labelClass "title is-4"}} data-test-field-label>

--- a/ui/tests/integration/components/keymgmt/distribute-test.js
+++ b/ui/tests/integration/components/keymgmt/distribute-test.js
@@ -104,7 +104,6 @@ module('Integration | Component | keymgmt/distribute', function (hooks) {
     assert.dom(SELECTORS.operationsSection).hasAttribute('disabled');
     // Select
     await clickTrigger();
-    await settled();
     assert.equal(ssComponent.options.length, 3, 'shows all provider options');
     await typeInSearch('aws');
     await ssComponent.selectOption();
@@ -113,9 +112,7 @@ module('Integration | Component | keymgmt/distribute', function (hooks) {
     // Remove selection
     await ssComponent.deleteButtons.objectAt(0).click();
     // Select Azure
-    await settled();
     await clickTrigger();
-    await settled();
     await typeInSearch('azure');
     await ssComponent.selectOption();
     // await select(SELECTORS.providerInput, 'provider-azure');
@@ -131,7 +128,6 @@ module('Integration | Component | keymgmt/distribute', function (hooks) {
     assert.dom(SELECTORS.keyTypeSection).doesNotExist('Key Type section is not rendered by default');
     // Add new item on search-select
     await clickTrigger();
-    await settled();
     await typeInSearch('new-key');
     await ssComponent.selectOption();
     assert.dom(SELECTORS.keyTypeSection).exists('Key Type selector is shown');
@@ -144,17 +140,14 @@ module('Integration | Component | keymgmt/distribute', function (hooks) {
     assert.dom(SELECTORS.providerInput).doesNotExist('Provider input is hidden');
     // Select existing key
     await clickTrigger();
-    await settled();
     await ssComponent.selectOption();
     await settled();
     assert.dom(SELECTORS.inlineError).exists({ count: 1 }, 'only shows single error');
     assert.dom(SELECTORS.errorKey).exists('Shows error on key selector when key/provider mismatch');
     // Remove selection
     await ssComponent.deleteButtons.objectAt(0).click();
-    await settled();
     // Select new key
     await clickTrigger();
-    await settled();
     await typeInSearch('new-key');
     await ssComponent.selectOption();
     await select(SELECTORS.keyTypeSection, 'ecdsa-p256');
@@ -169,11 +162,8 @@ module('Integration | Component | keymgmt/distribute', function (hooks) {
     assert.dom(SELECTORS.providerInput).exists('Provider input shown');
     assert.dom(SELECTORS.keySection).doesNotExist('Key input not shown');
     await clickTrigger();
-    await settled();
     await typeInSearch('azure');
-    await settled();
     await ssComponent.selectOption();
-    await settled();
     assert.dom(SELECTORS.inlineError).exists({ count: 1 }, 'only shows single error');
     assert.dom(SELECTORS.errorProvider).exists('Shows error due to key/provider mismatch');
   });

--- a/ui/tests/integration/components/keymgmt/distribute-test.js
+++ b/ui/tests/integration/components/keymgmt/distribute-test.js
@@ -78,6 +78,17 @@ module('Integration | Component | keymgmt/distribute', function (hooks) {
           }),
         ];
       });
+      this.get('/v1/keymgmt/kms', (response) => {
+        return [
+          response,
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            data: {
+              keys: ['provider-aws', 'provider-azure', 'provider-gcp'],
+            },
+          }),
+        ];
+      });
     });
   });
 
@@ -85,26 +96,35 @@ module('Integration | Component | keymgmt/distribute', function (hooks) {
     this.server.shutdown();
   });
 
-  test('it does not allow operation selection until valid key and provider selected', async function (assert) {
+  test('it does not allow operation selection until valid key/provider combo selected', async function (assert) {
+    assert.expect(6);
     await render(
-      hbs`<Keymgmt::Distribute @backend="keymgmt" @providers={{providers}} @onClose={{fn (mut this.onClose)}} />`
+      hbs`<Keymgmt::Distribute @backend="keymgmt" @key="example-1" @providers={{providers}} @onClose={{fn (mut this.onClose)}} />`
     );
     assert.dom(SELECTORS.operationsSection).hasAttribute('disabled');
+    // Select
     await clickTrigger();
     await settled();
-    assert.equal(ssComponent.options.length, 3, 'shows all key options');
+    assert.equal(ssComponent.options.length, 3, 'shows all provider options');
+    await typeInSearch('aws');
     await ssComponent.selectOption();
     await settled();
-    assert.dom(SELECTORS.operationsSection).hasAttribute('disabled');
-    await select(SELECTORS.providerInput, 'provider-aws');
-    await settled();
     assert.dom(SELECTORS.operationsSection).doesNotHaveAttribute('disabled');
-    await select(SELECTORS.providerInput, 'provider-azure');
+    // Remove selection
+    await ssComponent.deleteButtons.objectAt(0).click();
+    // Select Azure
+    await settled();
+    await clickTrigger();
+    await settled();
+    await typeInSearch('azure');
+    await ssComponent.selectOption();
+    // await select(SELECTORS.providerInput, 'provider-azure');
     assert.dom(SELECTORS.operationsSection).hasAttribute('disabled');
     assert.dom(SELECTORS.inlineError).exists({ count: 1 }, 'only shows single error');
     assert.dom(SELECTORS.errorProvider).exists('Shows key/provider match error on provider');
   });
   test('it shows key type select field if new key created', async function (assert) {
+    assert.expect(2);
     await render(
       hbs`<Keymgmt::Distribute @backend="keymgmt" @providers={{providers}} @onClose={{fn (mut this.onClose)}} />`
     );
@@ -117,6 +137,7 @@ module('Integration | Component | keymgmt/distribute', function (hooks) {
     assert.dom(SELECTORS.keyTypeSection).exists('Key Type selector is shown');
   });
   test('it hides the provider field if passed from the parent', async function (assert) {
+    assert.expect(5);
     await render(
       hbs`<Keymgmt::Distribute @backend="keymgmt" @provider="provider-azure" @onClose={{fn (mut this.onClose)}} />`
     );
@@ -141,15 +162,19 @@ module('Integration | Component | keymgmt/distribute', function (hooks) {
     assert.dom(SELECTORS.errorNewKey).exists('Shows error on key type');
   });
   test('it hides the key field if passed from the parent', async function (assert) {
+    assert.expect(4);
     await render(
       hbs`<Keymgmt::Distribute @backend="keymgmt" @providers={{providers}} @key="example-1" @onClose={{fn (mut this.onClose)}} />`
     );
     assert.dom(SELECTORS.providerInput).exists('Provider input shown');
     assert.dom(SELECTORS.keySection).doesNotExist('Key input not shown');
-    await select(SELECTORS.providerInput, 'provider-azure');
+    await clickTrigger();
+    await settled();
+    await typeInSearch('azure');
+    await settled();
+    await ssComponent.selectOption();
+    await settled();
     assert.dom(SELECTORS.inlineError).exists({ count: 1 }, 'only shows single error');
     assert.dom(SELECTORS.errorProvider).exists('Shows error due to key/provider mismatch');
-    await select(SELECTORS.providerInput, 'provider-aws');
-    assert.dom(SELECTORS.inlineError).doesNotExist('Error goes away when key/provider compatible');
   });
 });

--- a/ui/tests/integration/components/keymgmt/key-edit-test.js
+++ b/ui/tests/integration/components/keymgmt/key-edit-test.js
@@ -29,12 +29,12 @@ module('Integration | Component | keymgmt/key-edit', function (hooks) {
     this.tab = '';
   });
 
+  // TODO: Add capabilities tests
   test('it renders show view as default', async function (assert) {
     assert.expect(8);
     await render(hbs`<Keymgmt::KeyEdit @model={{model}} @tab={{tab}} /><div id="modal-wormhole" />`);
     assert.dom('[data-test-secret-header]').hasText('Unicorns', 'Shows key name');
     assert.dom('[data-test-keymgmt-key-toolbar]').exists('Subnav toolbar exists');
-    // TODO: Add capabilities tests
     assert.dom('[data-test-tab="Details"]').exists('Details tab exists');
     assert.dom('[data-test-tab="Versions"]').exists('Versions tab exists');
     assert.dom('[data-test-keymgmt-key-destroy]').isDisabled('Destroy button is disabled');

--- a/ui/tests/integration/components/keymgmt/key-edit-test.js
+++ b/ui/tests/integration/components/keymgmt/key-edit-test.js
@@ -30,6 +30,7 @@ module('Integration | Component | keymgmt/key-edit', function (hooks) {
   });
 
   test('it renders show view as default', async function (assert) {
+    assert.expect(8);
     await render(hbs`<Keymgmt::KeyEdit @model={{model}} @tab={{tab}} /><div id="modal-wormhole" />`);
     assert.dom('[data-test-secret-header]').hasText('Unicorns', 'Shows key name');
     assert.dom('[data-test-keymgmt-key-toolbar]').exists('Subnav toolbar exists');
@@ -47,6 +48,7 @@ module('Integration | Component | keymgmt/key-edit', function (hooks) {
   });
 
   test('it renders the correct elements on edit view', async function (assert) {
+    assert.expect(4);
     let model = EmberObject.create({
       name: 'Unicorns',
       id: 'Unicorns',
@@ -62,6 +64,7 @@ module('Integration | Component | keymgmt/key-edit', function (hooks) {
   });
 
   test('it renders the correct elements on create view', async function (assert) {
+    assert.expect(4);
     let model = EmberObject.create({});
     this.set('mode', 'create');
     this.set('model', model);


### PR DESCRIPTION
This is the final piece of work to enable Key Management Secrets Engine management in the UI

**Enable KeyMgmt Secret Engine**
![keymgmt-enable](https://user-images.githubusercontent.com/82459713/169348928-e6dffab6-9e7b-4cea-8dcf-ed3342cdde50.gif)

**Create provider form with validation**
![keymgmt-provider-form](https://user-images.githubusercontent.com/82459713/169348940-18aa87ef-58d1-4f52-94f4-e07c43363f22.gif)

**Creating a key**
![keymgmt-key-form](https://user-images.githubusercontent.com/82459713/169348955-a0bec6de-f24f-497e-89b8-a345c805ca55.gif)

**Key Rotation**
![keymgmt-rotate-key](https://user-images.githubusercontent.com/82459713/169348983-267f9cff-55e4-4563-9589-0db4a8003d45.gif)

**Distribution works from both key and provider**
![keymgmt-distribute-key](https://user-images.githubusercontent.com/82459713/169349072-f57a64e7-cfa5-47e1-92ae-458acadd9bf3.gif)
![keymgmt-distribute-provider](https://user-images.githubusercontent.com/82459713/169349076-8998b25a-b1da-4d1d-bf47-9a2c50d950c3.gif)

Previous work that this builds off of:
https://github.com/hashicorp/vault/pull/13638
https://github.com/hashicorp/vault/pull/13797
https://github.com/hashicorp/vault/pull/13840