### PR TITLE
Remove reference to stored license

### DIFF
--- a/changelog/15513.txt
+++ b/changelog/15513.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Remove stored license references
+```

--- a/ui/app/serializers/license.js
+++ b/ui/app/serializers/license.js
@@ -3,10 +3,12 @@ import ApplicationSerializer from './application';
 export default ApplicationSerializer.extend({
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
     let transformedPayload = { autoloaded: payload.data.autoloading_used, license_id: 'no-license' };
-    transformedPayload = {
-      ...transformedPayload,
-      ...payload.data.autoloaded,
-    };
+    if (payload.data.autoloaded) {
+      transformedPayload = {
+        ...transformedPayload,
+        ...payload.data.autoloaded,
+      };
+    }
     transformedPayload.id = transformedPayload.license_id;
     return this._super(store, primaryModelClass, transformedPayload, id, requestType);
   },

--- a/ui/app/serializers/license.js
+++ b/ui/app/serializers/license.js
@@ -3,17 +3,10 @@ import ApplicationSerializer from './application';
 export default ApplicationSerializer.extend({
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
     let transformedPayload = { autoloaded: payload.data.autoloading_used, license_id: 'no-license' };
-    if (payload.data.autoloaded) {
-      transformedPayload = {
-        ...transformedPayload,
-        ...payload.data.autoloaded,
-      };
-    } else if (payload.data.stored) {
-      transformedPayload = {
-        ...transformedPayload,
-        ...payload.data.stored,
-      };
-    }
+    transformedPayload = {
+      ...transformedPayload,
+      ...payload.data.autoloaded,
+    };
     transformedPayload.id = transformedPayload.license_id;
     return this._super(store, primaryModelClass, transformedPayload, id, requestType);
   },

--- a/ui/app/templates/components/license-info.hbs
+++ b/ui/app/templates/components/license-info.hbs
@@ -13,18 +13,7 @@
       to
       {{date-format @expirationTime "MMM dd, yyyy hh:mm:ss a"}}
     </InfoTableRow>
-    <InfoTableRow @label="License state" @value={{if @autoloaded "Autoloaded" "Stored"}} data-test-detail-row>
-      {{#if @autoloaded}}
-        Autoloaded
-      {{else}}
-        Stored
-        <Icon @name="alert-triangle-fill" class="has-text-highlight" />
-        <span class="is-size-8">
-          Stored licenses will be deprecated in a future version of Vault. We recommend autoloading your license. Read more
-          <a href="https://www.vaultproject.io/docs/enterprise/license" rel="noreferrer noopener" target="_blank">here</a>.
-        </span>
-      {{/if}}
-    </InfoTableRow>
+    <InfoTableRow @label="License state" @value={{"Autoloaded"}} data-test-detail-row />
   </div>
 </section>
 

--- a/ui/mirage/handlers/base.js
+++ b/ui/mirage/handlers/base.js
@@ -35,13 +35,6 @@ export default function (server) {
     return {
       data: {
         autoloading_used: false,
-        stored: {
-          expiration_time: EXPIRY_DATE,
-          features: ['DR Replication', 'Namespaces', 'Lease Count Quotas', 'Automated Snapshots'],
-          license_id: '0eca7ef8-ebc0-f875-315e-3cc94a7870cf',
-          performance_standby_count: 0,
-          start_time: '2020-04-28T00:00:00Z',
-        },
         persisted_autoload: {
           expiration_time: EXPIRY_DATE,
           features: ['DR Replication', 'Namespaces', 'Lease Count Quotas', 'Automated Snapshots'],

--- a/ui/tests/integration/components/license-info-test.js
+++ b/ui/tests/integration/components/license-info-test.js
@@ -49,31 +49,6 @@ module('Integration | Component | license info', function (hooks) {
     assert.equal(row.rowValue, 'Autoloaded', 'Shows autoloaded status');
   });
 
-  test('it renders properly for stored license', async function (assert) {
-    const now = Date.now();
-    this.set('licenseId', 'test');
-    this.set('expirationTime', addMinutes(now, 30));
-    this.set('autoloaded', false);
-    this.set('startTime', now);
-    this.set('features', ['HSM', 'Namespaces']);
-    await render(
-      hbs`<LicenseInfo
-        @licenseId={{this.licenseId}}
-        @expirationTime={{this.expirationTime}}
-        @startTime={{this.startTime}}
-        @features={{this.features}}
-        @autoloaded={{false}}
-      />`
-    );
-    let row = component.detailRows.filterBy('rowName', 'License state')[0];
-    assert.ok(
-      row.rowValue.includes(
-        'Stored licenses will be deprecated in a future version of Vault. We recommend autoloading your license.'
-      ),
-      'Stored license includes recommendation to autoload'
-    );
-  });
-
   test('it renders Performance Standby as inactive if count is 0', async function (assert) {
     const now = Date.now();
     this.set('licenseId', 'temporary');


### PR DESCRIPTION
- Stored license was deprecated in 1.8 and from 1.11 all licenses will be
auto loaded.