### PR TITLE
Vault documentation: updated all references from Learn to Tutorial

### DIFF
--- a/website/content/docs/concepts/integrated-storage/autopilot.mdx
+++ b/website/content/docs/concepts/integrated-storage/autopilot.mdx
@@ -75,7 +75,7 @@ in Vault 1.8.0), managed independently of their primary. The [Autopilot
 API](/api-docs/system/storage/raftautopilot) uses DR operation tokens for
 authorization.
 
-## Learn
+## Tutorial
 
 Refer to [Integrated Storage
 Autopilot](https://learn.hashicorp.com/tutorials/vault/raft-autopilot) for a

--- a/website/content/docs/concepts/password-policies.mdx
+++ b/website/content/docs/concepts/password-policies.mdx
@@ -316,7 +316,7 @@ are generated from must be no longer than 256 characters.
 #### Parameters
 
 - `charset` `(string: <required>)` – A string representation of the character set that this rule observes.
-  Accepts UTF-8 compatible strings. All characters within the string must be printable.  
+  Accepts UTF-8 compatible strings. All characters within the string must be printable.
   Please note that the JSON output returned may be escaped for the special and control characters such as <,>,& etc as per the JSON specification.
 - `min-chars` `(int: 0)` - Specifies a minimum number of characters required from the charset specified in
   this rule. For example: if `min-chars = 2`, the password must have at least 2 characters from `charset`.
@@ -360,7 +360,7 @@ This policy generates 8 character passwords from the charset `abcde01234` and re
 character from `01234` to be in it, but does not require any characters from `abcde`. The password
 `04031945` may result from this policy, even though no alphabetical characters are in it.
 
-## Learn
+## Tutorial
 
 Refer to [User Configurable Password Generation for Secret
 Engines](https://learn.hashicorp.com/vault/secrets-management/password-policies)

--- a/website/content/docs/concepts/policies.mdx
+++ b/website/content/docs/concepts/policies.mdx
@@ -746,7 +746,7 @@ However, the _contents_ of policies are parsed in real-time whenever the token i
 As a result, if a policy is modified, the modified rules will be in force the
 next time a token, with that policy attached, is used to make a call to Vault.
 
-## Learn
+## Tutorial
 
 Refer to the following tutorials for further learning:
 

--- a/website/content/docs/concepts/resource-quotas.mdx
+++ b/website/content/docs/concepts/resource-quotas.mdx
@@ -61,7 +61,7 @@ resource quotas by updating the `rate_limit_exempt_paths` configuration field.
 - `/v1/sys/seal-status`
 - `/v1/sys/unseal`
 
-## Learn
+## Tutorial
 
 Refer to [Protecting Vault with Resource
 Quotas](https://learn.hashicorp.com/vault/security/resource-quotas) for a

--- a/website/content/docs/concepts/username-templating.mdx
+++ b/website/content/docs/concepts/username-templating.mdx
@@ -150,7 +150,7 @@ Each of these values are passed to `printf "v_%s_%s_%s_%s"` which prepends them 
 each field. This results in `v_token-wi_my_custo_abcdefghijklmnopqrst_1234567890`. This value is then passed to
 `truncate 45` where the last 6 characters are removed which results in `v_token-wi_my_custo_abcdefghijklmnopqrst_1234`.
 
-## Learn
+## Tutorial
 
 Refer to the following tutorials for step-by-step instructions.
 

--- a/website/content/docs/configuration/seal/gcpckms.mdx
+++ b/website/content/docs/configuration/seal/gcpckms.mdx
@@ -114,7 +114,7 @@ rotation is supported for CKMS since the key information. Old keys version must 
 disabled or deleted and are used to decrypt older data. Any new or updated data will be
 encrypted with the primary key version.
 
-## Learn
+## Tutorial
 
 Refer to the [Auto-unseal using GCP Cloud KMS](https://learn.hashicorp.com/vault/operations/autounseal-gcp-kms)
 guide for a step-by-step tutorial.

--- a/website/content/docs/configuration/storage/index.mdx
+++ b/website/content/docs/configuration/storage/index.mdx
@@ -89,7 +89,7 @@ migrate to Integrated Storage, read the following tutorials:
 1. [Storage Migration tutorial - Consul to Integrated
    Storage](https://learn.hashicorp.com/tutorials/vault/raft-migration)
 
-## Learn
+## Tutorial
 
 Refer to the [Integrated
 Storage](https://learn.hashicorp.com/collections/vault/raft) tutorials

--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -199,7 +199,7 @@ storage "raft" {
 
 ## Tutorial
 
-Refer to [Integrated
-Storage](https://learn.hashicorp.com/collections/vault/raft) for tutorials on Integrated Storage.
+Refer to the [Integrated
+Storage](https://learn.hashicorp.com/collections/vault/raft) series of tutorials to learn more about implementing Vault using Integrated Storage.
 
 [raft]: https://raft.github.io/ 'The Raft Consensus Algorithm'

--- a/website/content/docs/enterprise/lease-count-quotas.mdx
+++ b/website/content/docs/enterprise/lease-count-quotas.mdx
@@ -43,7 +43,7 @@ Vault also allows the inspection into the state of lease count quotas in a Vault
 cluster through various [metrics](/docs/internals/telemetry#Resource-Quota-Metrics)
 exposed and through enabling optional audit logging.
 
-## Learn
+## Tutorial
 
 Refer to [Protecting Vault with Resource
 Quotas](https://learn.hashicorp.com/vault/security/resource-quotas) for a

--- a/website/content/docs/enterprise/replication.mdx
+++ b/website/content/docs/enterprise/replication.mdx
@@ -218,7 +218,7 @@ generation until it is used.
 Once a secondary is activated, its cluster information is stored safely behind
 its encrypted barrier.
 
-## Learn
+## Tutorial
 
 Refer to the following tutorials replication setup and best practices:
 

--- a/website/content/docs/platform/aws/lambda-extension.mdx
+++ b/website/content/docs/platform/aws/lambda-extension.mdx
@@ -307,6 +307,6 @@ $ aws lambda publish-layer-version \
      --region "${REGION}"
 ```
 
-## Learn
+## Tutorial
 
 For step-by-step instructions, refer to the [Vault AWS Lambda Extension](https://learn.hashicorp.com/tutorials/vault/aws-lambda) tutorial for details on how to create an AWS Lambda function and use the Vault Lambda Extension to authenticate with Vault.

--- a/website/content/docs/platform/k8s/injector/index.mdx
+++ b/website/content/docs/platform/k8s/injector/index.mdx
@@ -188,7 +188,7 @@ The configuration map must contain either one or both of the following files:
 
 An example of mounting a Vault Agent configmap [can be found here](/docs/platform/k8s/injector/examples#configmap-example).
 
-## Learn
+## Tutorial
 
 Refer to the [Injecting Secrets into Kubernetes Pods via Vault Helm
 Sidecar](https://learn.hashicorp.com/vault/getting-started-k8s/sidecar) guide

--- a/website/content/docs/secrets/consul.mdx
+++ b/website/content/docs/secrets/consul.mdx
@@ -175,7 +175,7 @@ This requires you to have an external process to rotate tokens. At this time, th
 is to rotate the tokens manually by creating a new token using the `vault read consul/creds/my-role` command. Once
 the token is synchronized with Consul, apply the token to the agents using the Consul API or CLI.
 
-## Learn
+## tutorials
 
 Refer to [Administer Consul Access Control Tokens with
 Vault](https://learn.hashicorp.com/tutorials/consul/vault-consul-secrets) for a

--- a/website/content/docs/secrets/consul.mdx
+++ b/website/content/docs/secrets/consul.mdx
@@ -175,7 +175,7 @@ This requires you to have an external process to rotate tokens. At this time, th
 is to rotate the tokens manually by creating a new token using the `vault read consul/creds/my-role` command. Once
 the token is synchronized with Consul, apply the token to the agents using the Consul API or CLI.
 
-## tutorials
+## Tutorial
 
 Refer to [Administer Consul Access Control Tokens with
 Vault](https://learn.hashicorp.com/tutorials/consul/vault-consul-secrets) for a

--- a/website/content/docs/secrets/databases/index.mdx
+++ b/website/content/docs/secrets/databases/index.mdx
@@ -212,8 +212,7 @@ password='your#StrongPassword%' \
 disable_escaping="true"
 ```
 
-## Learn
-
+## Tutorial
 Refer to the following step-by-step tutorials for more information:
 
 - [Secrets as a Service: Dynamic Secrets](https://learn.hashicorp.com/vault/secrets-management/sm-dynamic-secrets)

--- a/website/content/docs/secrets/databases/mongodb.mdx
+++ b/website/content/docs/secrets/databases/mongodb.mdx
@@ -98,7 +98,7 @@ from MongoDB with the exception that the Vault parameters are the contents of th
 the two options are independent of each other. See the [MongoDB Configuration Options](https://docs.mongodb.com/manual/reference/program/mongo/)
 for more information.
 
-## Learn
+## Tutorial
 
 Refer to [Database Secrets Engine with
 MongoDB](https://learn.hashicorp.com/tutorials/vault/database-mongodb) for a

--- a/website/content/docs/secrets/kmip.mdx
+++ b/website/content/docs/secrets/kmip.mdx
@@ -232,7 +232,7 @@ operation_all
 operation_none
 ```
 
-## Learn
+## Tutorial
 
 Refer to the [KMIP Secrets Engine](https://learn.hashicorp.com/vault/secrets-management/kmip-engine)
 guide for a step-by-step tutorial.

--- a/website/content/docs/secrets/nomad.mdx
+++ b/website/content/docs/secrets/nomad.mdx
@@ -110,7 +110,7 @@ Create Index = 138
 Modify Index = 138
 ```
 
-## Learn
+## Tutorial
 
 Refer to [Generate Nomad Tokens with HashiCorp
 Vault](https://learn.hashicorp.com/tutorials/nomad/vault-nomad-secrets) for a

--- a/website/content/docs/secrets/pki/index.mdx
+++ b/website/content/docs/secrets/pki/index.mdx
@@ -40,7 +40,7 @@ The PKI Secrets Engine documentation is split into the following pieces:
  - [Rotation Primitives](/docs/secrets/pki/rotation-primitives) - A document
    which explains different types of certificates used to achieve rotation.
 
-## Learn
+## Tutorial
 
 Refer to the [Build Your Own Certificate Authority (CA)](https://learn.hashicorp.com/vault/secrets-management/sm-pki-engine)
 guide for a step-by-step tutorial.

--- a/website/content/docs/secrets/terraform.mdx
+++ b/website/content/docs/secrets/terraform.mdx
@@ -158,7 +158,7 @@ Please see the [Terraform Cloud API
 Token documentation for more
 information](https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html).
 
-## Learn
+## Tutorial
 
 Refer to [Terraform Cloud Secrets
 Engine](https://learn.hashicorp.com/tutorials/vault/terraform-secrets-engine)

--- a/website/content/docs/secrets/transform/tokenization.mdx
+++ b/website/content/docs/secrets/transform/tokenization.mdx
@@ -160,7 +160,7 @@ Keys can be rotated to a new version, with backward compatibility for
 decoding. Encoding is always performed with the newest key version. Keys versions
 can be tidied as well. For more information, see the [transform api docs](../../../api-docs/secret/transform).
 
-## Learn
+## Tutorial
 
 Refer to [Tokenize Data with Transform Secrets
 Engine](https://learn.hashicorp.com/tutorials/vault/tokenization) for a


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/inbox/1200328878163177/1202303978180687/1202307649954451), a number of files have been updated to replace references to **Learn** with **Tutorial**. 

These files were not listed the original query list, and therefore, were missed: https://docs.google.com/spreadsheets/d/1dDR-jsL9iqQcd8WAQWsuEGGs2bXyks5Cw5ku5TfC-HA/edit#gid=1279078251