### PR TITLE
Chore (dev portal): update learn nav data links 

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1328,7 +1328,7 @@
   },
   {
     "title": "Troubleshoot",
-    "href": "https://learn.hashicorp.com/tutorials/vault/troubleshooting-vault"
+    "href": "/vault/tutorials/monitoring/troubleshooting-vault"
   },
   {
     "divider": true

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -12,11 +12,11 @@
     "routes": [
       {
         "title": "CLI Quick Start",
-        "href": "https://learn.hashicorp.com/collections/vault/getting-started"
+        "href": "/vault/tutorials/getting-started"
       },
       {
         "title": "HCP Quick Start",
-        "href": "https://learn.hashicorp.com/collections/vault/cloud"
+        "href": "/vault/tutorials/cloud"
       },
       {
         "title": "Developer Quick Start",


### PR DESCRIPTION
This PR updates external Learn links in the sidebar data to reference dev portal paths. @BRKalow let me know if this should be handled in dev portal instead of on this branch. 