### PR TITLE
VAULT-4306 Ensure /raft/bootstrap/challenge call ignores erroneous namespaces set

### DIFF
--- a/changelog/15519.txt
+++ b/changelog/15519.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+raft: /raft/bootstrap/challenge call now properly ignores $VAULT_NAMESPACE environment variable when set on server attempting to join a raft cluster
+```

--- a/changelog/15519.txt
+++ b/changelog/15519.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-raft: /raft/bootstrap/challenge call now properly ignores $VAULT_NAMESPACE environment variable when set on server attempting to join a raft cluster
+storage/raft: joining a node to a cluster now ignores any VAULT_NAMESPACE environment variable set on the server process
 ```

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -777,6 +777,8 @@ func (c *Core) getRaftChallenge(leaderInfo *raft.LeaderJoinInfo) (*raftInformati
 	if err != nil {
 		return nil, fmt.Errorf("failed to create api client: %w", err)
 	}
+	// Clearing namespace, as this client should only ever be using the root namespace
+	apiClient.ClearNamespace()
 
 	// Attempt to join the leader by requesting for the bootstrap challenge
 	secret, err := apiClient.Logical().Write("sys/storage/raft/bootstrap/challenge", map[string]interface{}{


### PR DESCRIPTION
This ensures servers started on an environment where $VAULT_NAMESPACE is set do not use such a variable when making this kind of call, causing an error.

Notably, this file seems to be the only place where stripping the namespace makes sense (other API clients come from a CLI/api client call, where the namespace makes sense), which is why I did not make it a configuration item for ApiClient or similar. If it becomes a more general need, it makes sense to make the configuration change then, but it didn't make sense to me to add a new configuration item or method for what appears to be a snowflake.