### PR TITLE
UI/mfa small bugs

### DIFF
--- a/ui/app/routes/vault/cluster/access/mfa/enforcements/index.js
+++ b/ui/app/routes/vault/cluster/access/mfa/enforcements/index.js
@@ -1,25 +1,14 @@
 import Route from '@ember/routing/route';
 
 export default class MfaEnforcementsRoute extends Route {
-  queryParams = {
-    page: {
-      refreshModel: true,
-    },
-  };
-
-  model(params) {
-    return this.store
-      .lazyPaginatedQuery('mfa-login-enforcement', {
-        responsePath: 'data.keys',
-        page: params.page || 1,
-      })
-      .catch((err) => {
-        if (err.httpStatus === 404) {
-          return [];
-        } else {
-          throw err;
-        }
-      });
+  model() {
+    return this.store.query('mfa-login-enforcement', {}).catch((err) => {
+      if (err.httpStatus === 404) {
+        return [];
+      } else {
+        throw err;
+      }
+    });
   }
   setupController(controller, model) {
     controller.set('model', model);

--- a/ui/app/routes/vault/cluster/access/mfa/methods/index.js
+++ b/ui/app/routes/vault/cluster/access/mfa/methods/index.js
@@ -4,26 +4,16 @@ import { inject as service } from '@ember/service';
 export default class MfaMethodsRoute extends Route {
   @service router;
 
-  queryParams = {
-    page: {
-      refreshModel: true,
-    },
-  };
-
-  model(params) {
-    return this.store
-      .lazyPaginatedQuery('mfa-method', {
-        responsePath: 'data.keys',
-        page: params.page || 1,
-      })
-      .catch((err) => {
-        if (err.httpStatus === 404) {
-          return [];
-        } else {
-          throw err;
-        }
-      });
+  model() {
+    return this.store.query('mfa-method', {}).catch((err) => {
+      if (err.httpStatus === 404) {
+        return [];
+      } else {
+        throw err;
+      }
+    });
   }
+
   afterModel(model) {
     if (model.length === 0) {
       this.router.transitionTo('vault.cluster.access.mfa');

--- a/ui/app/templates/vault/cluster/access/mfa/enforcements/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/enforcements/index.hbs
@@ -16,17 +16,10 @@
   </ToolbarActions>
 </Toolbar>
 
-{{#if this.model.meta.total}}
+{{#if (gt this.model.length 0)}}
   {{#each this.model as |item|}}
     <Mfa::LoginEnforcementListItem @model={{item}} />
   {{/each}}
 {{else}}
   <EmptyState @title="No enforcements found." @message="Add a new one to get started." />
-{{/if}}
-{{#if (gt this.model.meta.lastPage 1)}}
-  <ListPagination
-    @page={{this.model.meta.currentPage}}
-    @lastPage={{this.model.meta.lastPage}}
-    @link="vault.cluster.access.mfa.enforcements"
-  />
 {{/if}}

--- a/ui/app/templates/vault/cluster/access/mfa/methods/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/index.hbs
@@ -20,4 +20,6 @@
   {{#each this.model as |item|}}
     <Mfa::MethodListItem @model={{item}} />
   {{/each}}
+{{else}}
+  <EmptyState @title="No methods found." @message="Add a new one to get started." />
 {{/if}}

--- a/ui/app/templates/vault/cluster/access/mfa/methods/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/index.hbs
@@ -16,15 +16,8 @@
   </ToolbarActions>
 </Toolbar>
 
-{{#if this.model.meta.total}}
+{{#if (gt this.model.length 0)}}
   {{#each this.model as |item|}}
     <Mfa::MethodListItem @model={{item}} />
   {{/each}}
-{{/if}}
-{{#if (gt this.model.meta.lastPage 1)}}
-  <ListPagination
-    @page={{this.model.meta.currentPage}}
-    @lastPage={{this.model.meta.lastPage}}
-    @link={{concat "vault.cluster.access.mfa.methods"}}
-  />
 {{/if}}


### PR DESCRIPTION
This PR address the issue where, because of lazyPaginatedQuery, the list views for methods and enforcements were not being updated after deleting a method and/or enforcement. It appears the is issue is lazyPaginatedQuery does not use the store for its internal record and so was caching and therefore not calling the query again after the transition. We removed this so no pagination now happens, but neither does the bug.