### PR TITLE
Return the signed ca in the ca_chain response field within sign-intermediate api call.

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -4150,6 +4150,10 @@ func runFullCAChainTest(t *testing.T, keyType string) {
 	rootCaCert := parseCert(t, rootCert)
 	intermediaryCaCert := parseCert(t, intermediateCert)
 	requireSignedBy(t, intermediaryCaCert, rootCaCert.PublicKey)
+	intermediateCaChain := intermediateSignedData["ca_chain"].([]interface{})
+
+	require.Equal(t, parseCert(t, intermediateCaChain[0].(string)), intermediaryCaCert, "intermediate signed cert should have been part of ca_chain")
+	require.Equal(t, parseCert(t, intermediateCaChain[1].(string)), rootCaCert, "root cert should have been part of ca_chain")
 
 	resp, err = client.Logical().Write("pki-intermediate/intermediate/set-signed", map[string]interface{}{
 		"certificate": intermediateCert + "\n" + rootCert + "\n",

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -383,32 +383,30 @@ func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.R
 		resp.AddWarning("This mount hasn't configured any authority access information fields; this may make it harder for systems to find missing certificates in the chain or to validate revocation status of certificates. Consider updating /config/urls with this information.")
 	}
 
+	caChain := append([]string{cb.Certificate}, cb.CAChain...)
+
 	switch format {
 	case "pem":
 		resp.Data["certificate"] = cb.Certificate
 		resp.Data["issuing_ca"] = signingCB.Certificate
-		if cb.CAChain != nil && len(cb.CAChain) > 0 {
-			resp.Data["ca_chain"] = cb.CAChain
-		}
+		resp.Data["ca_chain"] = caChain
 
 	case "pem_bundle":
 		resp.Data["certificate"] = cb.ToPEMBundle()
 		resp.Data["issuing_ca"] = signingCB.Certificate
-		if cb.CAChain != nil && len(cb.CAChain) > 0 {
-			resp.Data["ca_chain"] = cb.CAChain
-		}
+		resp.Data["ca_chain"] = caChain
 
 	case "der":
 		resp.Data["certificate"] = base64.StdEncoding.EncodeToString(parsedBundle.CertificateBytes)
 		resp.Data["issuing_ca"] = base64.StdEncoding.EncodeToString(signingBundle.CertificateBytes)
 
-		var caChain []string
+		var derCaChain []string
+		derCaChain = append(derCaChain, base64.StdEncoding.EncodeToString(parsedBundle.CertificateBytes))
 		for _, caCert := range parsedBundle.CAChain {
-			caChain = append(caChain, base64.StdEncoding.EncodeToString(caCert.Bytes))
+			derCaChain = append(derCaChain, base64.StdEncoding.EncodeToString(caCert.Bytes))
 		}
-		if caChain != nil && len(caChain) > 0 {
-			resp.Data["ca_chain"] = cb.CAChain
-		}
+		resp.Data["ca_chain"] = derCaChain
+
 	default:
 		return nil, fmt.Errorf("unsupported format argument: %s", format)
 	}

--- a/changelog/15524.txt
+++ b/changelog/15524.txt
@@ -1,0 +1,4 @@
+```release-note:change
+secrets/pki: the signed CA certificate from the sign-intermediate api will now appear within the ca_chain
+response field along with the issuer's ca chain.
+```


### PR DESCRIPTION
 - When signing a CA certificate we should include it along with the issuers CA chain in the response.
