### PR TITLE
Fix handling of username_as_alias during LDAP authentication

### DIFF
--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -198,8 +198,8 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username stri
 	if usernameAsAlias {
 		return username, policies, ldapResponse, allGroups, nil
 	}
-	
-	entityAliasAttribute, err = ldapClient.GetUserAliasAttributeValue(cfg.ConfigEntry, c, username)
+
+	entityAliasAttribute, err := ldapClient.GetUserAliasAttributeValue(cfg.ConfigEntry, c, username)
 	if err != nil {
 		return "", nil, logical.ErrorResponse(err.Error()), nil, nil
 	}

--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -195,15 +195,16 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username stri
 	// Policies from each group may overlap
 	policies = strutil.RemoveDuplicates(policies, true)
 
-	entityAliasAttribute := username
-	if !usernameAsAlias {
-		entityAliasAttribute, err = ldapClient.GetUserAliasAttributeValue(cfg.ConfigEntry, c, username)
-		if err != nil {
-			return "", nil, logical.ErrorResponse(err.Error()), nil, nil
-		}
-		if entityAliasAttribute == "" {
-			return "", nil, logical.ErrorResponse("missing entity alias attribute value"), nil, nil
-		}
+	if usernameAsAlias {
+		return username, policies, ldapResponse, allGroups, nil
+	}
+	
+	entityAliasAttribute, err = ldapClient.GetUserAliasAttributeValue(cfg.ConfigEntry, c, username)
+	if err != nil {
+		return "", nil, logical.ErrorResponse(err.Error()), nil, nil
+	}
+	if entityAliasAttribute == "" {
+		return "", nil, logical.ErrorResponse("missing entity alias attribute value"), nil, nil
 	}
 
 	return entityAliasAttribute, policies, ldapResponse, allGroups, nil

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -618,6 +618,31 @@ func TestBackend_basic_authbind_userfilter(t *testing.T) {
 			testAccStepLoginFailure(t, "hermes conrad", "hermes"),
 		},
 	})
+
+	// If UserAttr returns multiple attributes that can be used as alias then
+	// we return an error...
+	cfg.UserAttr = "employeeType"
+	cfg.UserFilter = "(cn={{.Username}})"
+	cfg.UsernameAsAlias = false
+	logicaltest.Test(t, logicaltest.TestCase{
+		CredentialBackend: b,
+		Steps: []logicaltest.TestStep{
+			testAccStepConfigUrl(t, cfg),
+			testAccStepLoginFailure(t, "hermes conrad", "hermes"),
+		},
+	})
+
+	// ...unless username_as_alias has been set in which case we don't care
+	// about the alias returned by the LDAP server and always use the username
+	cfg.UsernameAsAlias = true
+	logicaltest.Test(t, logicaltest.TestCase{
+		CredentialBackend: b,
+		Steps: []logicaltest.TestStep{
+			testAccStepConfigUrl(t, cfg),
+			testAccStepLoginNoAttachedPolicies(t, "hermes conrad", "hermes"),
+		},
+	})
+
 }
 
 func TestBackend_basic_authbind_metadata_name(t *testing.T) {
@@ -805,6 +830,7 @@ func testAccStepConfigUrl(t *testing.T, cfg *ldaputil.ConfigEntry) logicaltest.T
 			"case_sensitive_names": true,
 			"token_policies":       "abc,xyz",
 			"request_timeout":      cfg.RequestTimeout,
+			"username_as_alias":    cfg.UsernameAsAlias,
 		},
 	}
 }

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -642,7 +642,6 @@ func TestBackend_basic_authbind_userfilter(t *testing.T) {
 			testAccStepLoginNoAttachedPolicies(t, "hermes conrad", "hermes"),
 		},
 	})
-
 }
 
 func TestBackend_basic_authbind_metadata_name(t *testing.T) {

--- a/builtin/credential/ldap/path_login.go
+++ b/builtin/credential/ldap/path_login.go
@@ -73,7 +73,7 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, d *framew
 	username := d.Get("username").(string)
 	password := d.Get("password").(string)
 
-	effectiveUsername, policies, resp, groupNames, err := b.Login(ctx, req, username, password)
+	effectiveUsername, policies, resp, groupNames, err := b.Login(ctx, req, username, password, cfg.UsernameAsAlias)
 	// Handle an internal error
 	if err != nil {
 		return nil, err
@@ -101,10 +101,6 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, d *framew
 				"name": username,
 			},
 		},
-	}
-
-	if cfg.UsernameAsAlias {
-		auth.Alias.Name = username
 	}
 
 	cfg.PopulateTokenAuth(auth)
@@ -139,7 +135,7 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, d *f
 	username := req.Auth.Metadata["username"]
 	password := req.Auth.InternalData["password"].(string)
 
-	_, loginPolicies, resp, groupNames, err := b.Login(ctx, req, username, password)
+	_, loginPolicies, resp, groupNames, err := b.Login(ctx, req, username, password, cfg.UsernameAsAlias)
 	if err != nil || (resp != nil && resp.IsError()) {
 		return resp, err
 	}

--- a/changelog/15525.txt
+++ b/changelog/15525.txt
@@ -1,3 +1,8 @@
 ```release-note:bug
-auth/ldap: A bug during login has been fixed when `username_as_alias` is set.
+auth/ldap: The logic for setting the entity alias when `username_as_alias` is set
+has been fixed. The previous behavior would make a request to the LDAP server to
+get `user_attr` before discarding it and using the username instead. This would
+make it impossible for a user to connect if this attribute was missing or had
+multiple values, even though it would not be used anyway. This has been fixed
+and the username is now used without making superfluous LDAP searches.
 ```

--- a/changelog/15525.txt
+++ b/changelog/15525.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/ldap: A bug during login has been fixed when `username_as_alias` is set.
+```

--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -244,7 +244,7 @@ func (c *Client) GetUserAliasAttributeValue(cfg *ConfigEntry, conn Connection, u
 		}
 
 		if len(result.Entries[0].Attributes) != 1 {
-			return aliasAttributeValue, errwrap.Wrapf("LDAP attribute missing for entity alias mapping{{err}}", err)
+			return aliasAttributeValue, fmt.Errorf("LDAP attribute missing for entity alias mapping")
 		}
 
 		if len(result.Entries[0].Attributes[0].Values) != 1 {


### PR DESCRIPTION
There is a bug that was introduced in the LDAP authentication method by https://github.com/hashicorp/vault/pull/11000.
It was thought to be backward compatible but has broken a number of users. Later
a new parameter `username_as_alias` was introduced in https://github.com/hashicorp/vault/pull/14324
to make it possible for operators to restore the previous behavior.
The way it is currently working is not completely backward compatible thought
because when username_as_alias is set, a call to GetUserAliasAttributeValue() will
first be made, then this value is completely discarded in pathLogin() and replaced
by the username as expected.

This is an issue because it makes useless calls to the LDAP server and will break
backward compatibility if one of the constraints in GetUserAliasAttributeValue()
is not respected, even though the resulting value will be discarded anyway.

In order to maintain backward compatibility here we have to only call
GetUserAliasAttributeValue() if necessary.

Since this change of behavior was introduced in 1.9, this fix will need to be
backported to the 1.9, 1.10 and 1.11 branches.