### PR TITLE
Set OutputCurlString and OutputPolicy on client whether single or double hyphen in flag

### DIFF
--- a/command/main.go
+++ b/command/main.go
@@ -47,12 +47,12 @@ func setupEnv(args []string) (retArgs []string, format string, detailed bool, ou
 			break
 		}
 
-		if arg == "-output-curl-string" {
+		if arg == "-output-curl-string" || arg == "--output-curl-string" {
 			outputCurlString = true
 			continue
 		}
 
-		if arg == "-output-policy" {
+		if arg == "-output-policy" || arg == "--output-policy" {
 			outputPolicy = true
 			continue
 		}


### PR DESCRIPTION
This part of the code currently relies on a hard-coded check that certain flags were provided. However, many users are probably accustomed to the double-hyphen style of flag, so let's accept both.