### PR TITLE
Fix Learn->Tutorial in internal PKI docs

### DIFF
--- a/website/content/docs/secrets/pki/considerations.mdx
+++ b/website/content/docs/secrets/pki/considerations.mdx
@@ -370,7 +370,7 @@ For these personas, we suggest the following ACLs, in condensed, tabular form:
 | `/root/replace` | Write | Yes | | | | |
 
 
-## Learn
+## Tutorial
 
 Refer to the [Build Your Own Certificate Authority (CA)](https://learn.hashicorp.com/vault/secrets-management/sm-pki-engine)
 guide for a step-by-step tutorial.

--- a/website/content/docs/secrets/pki/quick-start-intermediate-ca.mdx
+++ b/website/content/docs/secrets/pki/quick-start-intermediate-ca.mdx
@@ -257,7 +257,7 @@ The CA Chain returns all the intermediate authorities in the trust chain. The ro
 authority is not included since that will usually be trusted by the underlying
 OS.
 
-## Learn
+## Tutorial
 
 Refer to the [Build Your Own Certificate Authority (CA)](https://learn.hashicorp.com/vault/secrets-management/sm-pki-engine)
 guide for a step-by-step tutorial.

--- a/website/content/docs/secrets/pki/quick-start-root-ca.mdx
+++ b/website/content/docs/secrets/pki/quick-start-root-ca.mdx
@@ -214,7 +214,7 @@ restricted in the credentials they are allowed to read.
 If you get stuck at any time, simply run `vault path-help pki` or with a
 subpath for interactive help output.
 
-## Learn
+## Tutorial
 
 Refer to the [Build Your Own Certificate Authority (CA)](https://learn.hashicorp.com/vault/secrets-management/sm-pki-engine)
 guide for a step-by-step tutorial.

--- a/website/content/docs/secrets/pki/rotation-primitives.mdx
+++ b/website/content/docs/secrets/pki/rotation-primitives.mdx
@@ -409,7 +409,7 @@ CA with that serial. This does not work when using a reissuance primitive as the
 are technically the same authority and thus this authority must issue
 certificates with unique serial numbers.
 
-## Learn
+## Tutorial
 
 Refer to the [Build Your Own Certificate Authority (CA)](https://learn.hashicorp.com/vault/secrets-management/sm-pki-engine)
 guide for a step-by-step tutorial.

--- a/website/content/docs/secrets/pki/setup.mdx
+++ b/website/content/docs/secrets/pki/setup.mdx
@@ -105,7 +105,7 @@ the proper permission, it can generate credentials.
     role definition). The issuing CA and trust chain is also returned for
     automation simplicity.
 
-## Learn
+## Tutorial
 
 Refer to the [Build Your Own Certificate Authority (CA)](https://learn.hashicorp.com/vault/secrets-management/sm-pki-engine)
 guide for a step-by-step tutorial.


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

The PKI tutorials were split into multiple parts, so it makes sense to update all consistently.

This one won't need backports as its only in the 1.11 branch. 