### PR TITLE
Correct alphabetical ordering for docs sidebar

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1015,6 +1015,23 @@
         "path": "secrets/gcpkms"
       },
       {
+        "title": "Identity",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "secrets/identity"
+          },
+          {
+            "title": "Identity Tokens",
+            "path": "secrets/identity/identity-token"
+          },
+          {
+            "title": "OIDC Identity Provider",
+            "path": "secrets/identity/oidc-provider"
+          }
+        ]
+      },
+      {
         "title": "Key Management <sup>ENTERPRISE</sup>",
         "routes": [
           {
@@ -1053,23 +1070,6 @@
           {
             "title": "K/V Version 2",
             "path": "secrets/kv/kv-v2"
-          }
-        ]
-      },
-      {
-        "title": "Identity",
-        "routes": [
-          {
-            "title": "Overview",
-            "path": "secrets/identity"
-          },
-          {
-            "title": "Identity Tokens",
-            "path": "secrets/identity/identity-token"
-          },
-          {
-            "title": "OIDC Identity Provider",
-            "path": "secrets/identity/oidc-provider"
           }
         ]
       },


### PR DESCRIPTION
Puts `Identity` before the K entries under secret engines:

<img width="249" alt="image" src="https://user-images.githubusercontent.com/4488707/169533137-682a5edc-1d64-4ceb-b5bb-bb52e5de0cbf.png">
