### PR TITLE
Clarify KU/EKU parameters on sign-verbatim

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -696,18 +696,29 @@ have access.**
 - `csr` `(string: <required>)` - Specifies the PEM-encoded CSR.
 
 - `key_usage` `(list: ["DigitalSignature", "KeyAgreement", "KeyEncipherment"])` -
-  Specifies the allowed key usage constraint on issued certificates. Valid
+  Specifies the default key usage constraint on the issued certificate. Valid
   values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - simply
   drop the `KeyUsage` part of the value. Values are not case-sensitive. To
   specify no key usage constraints, set this to an empty list.
 
+~> Note: previous versions of this document incorrectly called this a constraint;
+   this value is only used as a default when the `KeyUsage` extension is missing
+   from the CSR.
+
 - `ext_key_usage` `(list: [])` -
-  Specifies the allowed extended key usage constraint on issued certificates. Valid
+  Specifies the default extended key usage constraint on the issued certificate. Valid
   values can be found at https://golang.org/pkg/crypto/x509/#ExtKeyUsage - simply
   drop the `ExtKeyUsage` part of the value. Values are not case-sensitive. To
   specify no key usage constraints, set this to an empty list.
 
+~> Note: previous versions of this document incorrectly called this a constraint;
+   this value is only used as a default when the `ExtendedKeyUsage` extension is
+   missing from the CSR.
+
 - `ext_key_usage_oids` `(string: "")` - A comma-separated string or list of extended key usage oids.
+
+~> Note: This value is only used as a default when the `ExtendedKeyUsage`
+   extension is missing from the CSR.
 
 - `ttl` `(string: "")` - Specifies the requested Time To Live. Cannot be greater
   than the engine's `max_ttl` value. If not provided, the engine's `ttl` value

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -699,7 +699,7 @@ have access.**
   Specifies the default key usage constraint on the issued certificate. Valid
   values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - simply
   drop the `KeyUsage` part of the value. Values are not case-sensitive. To
-  specify no key usage constraints, set this to an empty list.
+  specify no default key usage constraints, set this to an empty list.
 
 ~> Note: previous versions of this document incorrectly called this a constraint;
    this value is only used as a default when the `KeyUsage` extension is missing
@@ -709,7 +709,7 @@ have access.**
   Specifies the default extended key usage constraint on the issued certificate. Valid
   values can be found at https://golang.org/pkg/crypto/x509/#ExtKeyUsage - simply
   drop the `ExtKeyUsage` part of the value. Values are not case-sensitive. To
-  specify no key usage constraints, set this to an empty list.
+  specify no key default usage constraints, set this to an empty list.
 
 ~> Note: previous versions of this document incorrectly called this a constraint;
    this value is only used as a default when the `ExtendedKeyUsage` extension is


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

This resolves #[13364](https://github.com/hashicorp/vault/issues/13364) with a documentation update. In particular, modifying the behavior of `sign-verbatim` at this point in time is not possible, so we attempt to clarify the documentation.

Resolves: #13364