### PR TITLE
api/monitor: Adding log format to monitor command and debug

### DIFF
--- a/api/sys_monitor.go
+++ b/api/sys_monitor.go
@@ -5,17 +5,25 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+
+	"github.com/hashicorp/vault/sdk/helper/logging"
 )
 
 // Monitor returns a channel that outputs strings containing the log messages
 // coming from the server.
-func (c *Sys) Monitor(ctx context.Context, logLevel string) (chan string, error) {
+func (c *Sys) Monitor(ctx context.Context, logLevel string, logFormat string) (chan string, error) {
 	r := c.c.NewRequest(http.MethodGet, "/v1/sys/monitor")
 
 	if logLevel == "" {
 		r.Params.Add("log_level", "info")
 	} else {
 		r.Params.Add("log_level", logLevel)
+	}
+
+	if logFormat == "" || logFormat == logging.UnspecifiedFormat.String() {
+		r.Params.Add("log_format", "standard")
+	} else {
+		r.Params.Add("log_format", logFormat)
 	}
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/changelog/15536.txt
+++ b/changelog/15536.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+api/monitor: Add log_format option to allow for logs to be emitted in JSON format
+```
+
+```release-note:improvement
+command/debug: Add log_format flag to allow for logs to be emitted in JSON format
+```

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -741,7 +741,8 @@ func (b *SystemBackend) handleRekeyRetrieve(
 	ctx context.Context,
 	req *logical.Request,
 	data *framework.FieldData,
-	recovery bool) (*logical.Response, error) {
+	recovery bool,
+) (*logical.Response, error) {
 	backup, err := b.Core.RekeyRetrieveBackup(ctx, recovery)
 	if err != nil {
 		return nil, fmt.Errorf("unable to look up backed-up keys: %w", err)
@@ -792,7 +793,8 @@ func (b *SystemBackend) handleRekeyDelete(
 	ctx context.Context,
 	req *logical.Request,
 	data *framework.FieldData,
-	recovery bool) (*logical.Response, error) {
+	recovery bool,
+) (*logical.Response, error) {
 	err := b.Core.RekeyDeleteBackup(ctx, recovery)
 	if err != nil {
 		return nil, fmt.Errorf("error during deletion of backed-up keys: %w", err)
@@ -1082,7 +1084,8 @@ func (b *SystemBackend) handleReadMount(ctx context.Context, req *logical.Reques
 
 // used to intercept an HTTPCodedError so it goes back to callee
 func handleError(
-	err error) (*logical.Response, error) {
+	err error,
+) (*logical.Response, error) {
 	if strings.Contains(err.Error(), logical.ErrReadOnly.Error()) {
 		return logical.ErrorResponse(err.Error()), err
 	}
@@ -1097,7 +1100,8 @@ func handleError(
 // Performs a similar function to handleError, but upon seeing a ReadOnlyError
 // will actually strip it out to prevent forwarding
 func handleErrorNoReadOnlyForward(
-	err error) (*logical.Response, error) {
+	err error,
+) (*logical.Response, error) {
 	if strings.Contains(err.Error(), logical.ErrReadOnly.Error()) {
 		return nil, fmt.Errorf("operation could not be completed as storage is read-only")
 	}
@@ -2007,7 +2011,8 @@ func (b *SystemBackend) handleRevokeForce(ctx context.Context, req *logical.Requ
 
 // handleRevokePrefixCommon is used to revoke a prefix with many LeaseIDs
 func (b *SystemBackend) handleRevokePrefixCommon(ctx context.Context,
-	req *logical.Request, data *framework.FieldData, force, sync bool) (*logical.Response, error) {
+	req *logical.Request, data *framework.FieldData, force, sync bool,
+) (*logical.Response, error) {
 	// Get all the options
 	prefix := data.Get("prefix").(string)
 
@@ -3239,6 +3244,14 @@ func (b *SystemBackend) handleMonitor(ctx context.Context, req *logical.Request,
 		return logical.ErrorResponse("unknown log level"), nil
 	}
 
+	lf := data.Get("log_format").(string)
+	lowerLogFormat := strings.ToLower(lf)
+
+	validFormats := []string{"standard", "json"}
+	if !strutil.StrListContains(validFormats, lowerLogFormat) {
+		return logical.ErrorResponse("unknown log format"), nil
+	}
+
 	flusher, ok := w.ResponseWriter.(http.Flusher)
 	if !ok {
 		// http.ResponseWriter is wrapped in wrapGenericHandler, so let's
@@ -3253,7 +3266,7 @@ func (b *SystemBackend) handleMonitor(ctx context.Context, req *logical.Request,
 		}
 	}
 
-	isJson := b.Core.LogFormat() == "json"
+	isJson := b.Core.LogFormat() == "json" || lf == "json"
 	logger := b.Core.Logger().(log.InterceptLogger)
 
 	mon, err := monitor.NewMonitor(512, logger, &log.LoggerOptions{

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -1392,6 +1392,7 @@ func (b *SystemBackend) monitorPath() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Output format of logs. Supported values are \"standard\" and \"json\". The default is \"standard\".",
 				Query:       true,
+				Default:     "standard",
 			},
 		},
 		Callbacks: map[logical.Operation]framework.OperationFunc{

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -1388,6 +1388,11 @@ func (b *SystemBackend) monitorPath() *framework.Path {
 				Description: "Log level to view system logs at. Currently supported values are \"trace\", \"debug\", \"info\", \"warn\", \"error\".",
 				Query:       true,
 			},
+			"log_format": {
+				Type:        framework.TypeString,
+				Description: "Output format of logs. Supported values are \"standard\" and \"json\". The default is \"standard\".",
+				Query:       true,
+			},
 		},
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.ReadOperation: b.handleMonitor,

--- a/website/content/api-docs/system/monitor.mdx
+++ b/website/content/api-docs/system/monitor.mdx
@@ -26,7 +26,7 @@ default, this is text.
 - `log_level` `(string: "info")` – Specifies the log level to use when streaming logs. This defaults to `info`
   if not specified.
 
-- `log_format` `(string: "standard")` – Specifies the log format to emit when streaming logs. This defaults to `standard`
+- `log_format` `(string: "standard")` – Specifies the log format to emit when streaming logs. Supported values are "standard" and "json". The default is `standard`.
 if not specified.
 
 ### Sample Request

--- a/website/content/api-docs/system/monitor.mdx
+++ b/website/content/api-docs/system/monitor.mdx
@@ -26,6 +26,9 @@ default, this is text.
 - `log_level` `(string: "info")` – Specifies the log level to use when streaming logs. This defaults to `info`
   if not specified.
 
+- `log_format` `(string: "standard")` – Specifies the log format to emit when streaming logs. This defaults to `standard`
+if not specified.
+
 ### Sample Request
 
 ```shell-session

--- a/website/content/docs/commands/debug.mdx
+++ b/website/content/docs/commands/debug.mdx
@@ -138,6 +138,10 @@ flags](/docs/commands) included on all commands.
 - `-interval` `(int or time string: "30s")` - The polling interval at which to
   collect profiling data and server state. The default is 30s.
 
+- `-log-format` `(string: "standard")` - Log format to be captured if "log"
+  target specified. Supported values are "standard" and "json". The default is
+  "standard".
+
 - `-metrics-interval` `(int or time string: "10s")` - The polling interval at
   which to collect metrics data. The default is 10s.
 

--- a/website/content/docs/commands/monitor.mdx
+++ b/website/content/docs/commands/monitor.mdx
@@ -41,3 +41,7 @@ flags](/docs/commands) included on all commands.
 - `-log-level` `(string: "info")` - Monitor the Vault server at this log level.
   Valid log levels are (in order of detail) "trace", "debug", "info",
   "warn", "error". If this option is not specified, "info" is used.
+
+- `-log-format` `(string: "standard")` - Format to emit logs.
+  Valid formats are "standard", and "json". 
+  If this option is not specified, "standard" is used.


### PR DESCRIPTION
Adding log_format flag to monitor endpoint as well as debug command. This will allow the option for vault logs being emitted via monitor to come through as JSON format. The default behavior is to emit in the standard log format.

Usage:
`vault monitor -log-level=DEBUG -log-format=JSON`

`curl -H "X-Vault-Request: true" -H "X-Vault-Token: $(vault print token)" http://127.0.0.1:8200/v1/sys/monitor?log_format=json&log_level=trace`

`vault debug -target=log -log-format=json`