### PR TITLE
Fix typo in allowed_uri_sans_template doctype

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -2137,7 +2137,7 @@ request is denied.
   a JSON string slice. Values can contain glob patterns (e.g.
   `spiffe://hostname/*`).
 
-- `allowed_uri_sans_template` `()bool: false)` - When set, `allowed_uri_sans`
+- `allowed_uri_sans_template` `(bool: false)` - When set, `allowed_uri_sans`
   may contain templates, as with [ACL Path Templating](/docs/concepts/policies).
   Non-templated domains are also still permitted.
 


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`