### PR TITLE
PKI: Do not error out on unknown issuers/keys on delete api calls.

### DIFF
--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -400,14 +400,14 @@ func (b *backend) pathDeleteIssuer(ctx context.Context, req *logical.Request, da
 
 	ref, err := resolveIssuerReference(ctx, req.Storage, issuerName)
 	if err != nil {
+		// Return as if we deleted it if we fail to lookup the issuer.
+		if ref == IssuerRefNotFound {
+			return &logical.Response{}, nil
+		}
 		return nil, err
 	}
-	if ref == "" {
-		return logical.ErrorResponse("unable to resolve issuer id for reference: " + issuerName), nil
-	}
 
-	var response *logical.Response
-	response = &logical.Response{}
+	response := &logical.Response{}
 
 	issuer, err := fetchIssuerById(ctx, req.Storage, ref)
 	if err != nil {

--- a/builtin/logical/pki/path_fetch_keys.go
+++ b/builtin/logical/pki/path_fetch_keys.go
@@ -248,10 +248,11 @@ func (b *backend) pathDeleteKeyHandler(ctx context.Context, req *logical.Request
 
 	keyId, err := resolveKeyReference(ctx, req.Storage, keyRef)
 	if err != nil {
+		if keyId == KeyRefNotFound {
+			// We failed to lookup the key, we should ignore any error here and reply as if it was deleted.
+			return nil, nil
+		}
 		return nil, err
-	}
-	if keyId == "" {
-		return logical.ErrorResponse("unable to resolve key id for reference" + keyRef), nil
 	}
 
 	keyInUse, issuerId, err := isKeyInUse(keyId.String(), ctx, req.Storage)


### PR DESCRIPTION
 - No longer error out when we fail to lookup the passed in issuer_ref or key_ref values on delete apis.
 - Add more key related unit tests