### PR TITLE
Allow issuer/:issuer_ref/sign-verbatim/:role, add error on missing role

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -267,7 +267,7 @@ func (b *backend) metricsWrap(callType string, roleMode int, ofunc roleOperation
 			if err != nil {
 				return nil, err
 			}
-			if role == nil && roleMode == roleRequired {
+			if role == nil && (roleMode == roleRequired || role == roleOptional) {
 				return logical.ErrorResponse(fmt.Sprintf("unknown role: %s", roleName)), nil
 			}
 			labels = []metrics.Label{{"role", roleName}}

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -267,7 +267,7 @@ func (b *backend) metricsWrap(callType string, roleMode int, ofunc roleOperation
 			if err != nil {
 				return nil, err
 			}
-			if role == nil && (roleMode == roleRequired || role == roleOptional) {
+			if role == nil && (roleMode == roleRequired || len(roleName) > 0) {
 				return logical.ErrorResponse(fmt.Sprintf("unknown role: %s", roleName)), nil
 			}
 			labels = []metrics.Label{{"role", roleName}}

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -79,7 +79,7 @@ func buildPathSign(b *backend, pattern string) *framework.Path {
 }
 
 func pathIssuerSignVerbatim(b *backend) *framework.Path {
-	pattern := "issuer/" + framework.GenericNameRegex(issuerRefParam) + "/sign-verbatim"
+	pattern := "issuer/" + framework.GenericNameRegex(issuerRefParam) + "/sign-verbatim" + framework.OptionalParamRegex("role")
 	return buildPathIssuerSignVerbatim(b, pattern)
 }
 

--- a/changelog/15543.txt
+++ b/changelog/15543.txt
@@ -1,0 +1,3 @@
+```release-note:change
+secrets/pki: Err on unknown role during sign-verbatim.
+```


### PR DESCRIPTION
In #15277, we missed that the new `/issuer/issuer_ref/sign-verbatim` path lacked a role-allowed variant (like `/sign-verbatim/:role` does). Add the missing parameter.

Additionally, I noticed that `sign-verbatim` (since early versions), wouldn't warn or err on a missing role when one was requested. Since we don't currently err, we can't now err, so add a warning instead. 