### PR TITLE
Add role patching test case

### DIFF
--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -231,6 +231,9 @@ func (b *backend) pathUpdateIssuer(ctx context.Context, req *logical.Request, da
 		// When the new name is in use but isn't this name, throw an error.
 		return logical.ErrorResponse(err.Error()), nil
 	}
+	if len(newName) > 0 && !nameMatcher.MatchString(newName) {
+		return logical.ErrorResponse("new key name outside of valid character limits"), nil
+	}
 
 	newPath := data.Get("manual_chain").([]string)
 	rawLeafBehavior := data.Get("leaf_not_after_behavior").(string)
@@ -373,6 +376,9 @@ func (b *backend) pathPatchIssuer(ctx context.Context, req *logical.Request, dat
 		if err == errIssuerNameInUse && issuer.Name != newName {
 			// When the new name is in use but isn't this name, throw an error.
 			return logical.ErrorResponse(err.Error()), nil
+		}
+		if len(newName) > 0 && !nameMatcher.MatchString(newName) {
+			return logical.ErrorResponse("new key name outside of valid character limits"), nil
 		}
 		if newName != issuer.Name {
 			oldName = issuer.Name

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1676,13 +1676,18 @@ modes are set on this issuer.
 Note that it is not possible to change the certificate of this issuer; to
 do so, import a new issuer and a new `issuer_id` will be assigned.
 
-| Method | Path                      |
-| :----- | :------------------------ |
-| `POST` | `/pki/issuer/:issuer_ref` |
+| Method  | Path                      |
+| :------ | :------------------------ |
+| `POST`  | `/pki/issuer/:issuer_ref` |
+| `PATCH` | `/pki/issuer/:issuer_ref` |
 
 ~> **Note** `POST`ing to this endpoint causes Vault to overwrite the previous
    contents of the issuer, using the provided request data (and any defaults
-   for elided parameters). It does not update only the provided fields.
+   for elided parameters). It does not update only the provided fields.<br /><br />
+   Since Vault 1.11.0, Vault supports the PATCH operation to this endpoint,
+   using the [JSON patch format](https://datatracker.ietf.org/doc/html/rfc6902)
+   supported by KVv2, allowing update of specific fields. Note that
+   `vault write` uses `POST`.
 
 #### Parameters
 
@@ -2018,14 +2023,19 @@ multiple roles nearly any issuing policy can be accommodated. `server_flag`,
 requests a certificate that is not allowed by the CN policy in the role, the
 request is denied.
 
-| Method | Path               |
-| :----- | :----------------- |
-| `POST` | `/pki/roles/:name` |
+| Method  | Path               |
+| :------ | :----------------- |
+| `POST`  | `/pki/roles/:name` |
+| `PATCH` | `/pki/roles/:name` |
 
 ~> **Note** `POST`ing to this endpoint when the role already exists causes
    Vault to overwrite the contents of the role, using the provided request
    data (and any defaults for elided parameters). It does not update only
-   the provided fields.
+   the provided fields.<br /><br />
+   Since Vault 1.11.0, Vault supports the PATCH operation to this endpoint,
+   using the [JSON patch format](https://datatracker.ietf.org/doc/html/rfc6902)
+   supported by KVv2, allowing update of specific fields. Note that
+   `vault write` uses `POST`.
 
 #### Parameters
 


### PR DESCRIPTION
This updates almost all fields individually in a role, with the exceptions of (key_type, key_bits, and signature_bits) due to inter-dependencies between them. 

Also, fixes a bug spotted by @stevendpclark during review of #15510, where both Update and Patch issuer didn't validate the new name. 