### PR TITLE
MFA Login Enforcements Auth Method Target Bug

### DIFF
--- a/ui/app/components/mfa-login-enforcement-form.js
+++ b/ui/app/components/mfa-login-enforcement-form.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { methods } from 'vault/helpers/mountable-auth-methods';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 
@@ -32,7 +31,6 @@ export default class MfaLoginEnforcementForm extends Component {
     { label: 'Group', type: 'identity/group', key: 'identity_groups' },
     { label: 'Entity', type: 'identity/entity', key: 'identity_entities' },
   ];
-  authMethods = methods();
   searchSelectOptions = null;
 
   @tracked name;
@@ -43,6 +41,7 @@ export default class MfaLoginEnforcementForm extends Component {
     options: [],
     selected: [],
   };
+  @tracked authMethods = [];
   @tracked modelErrors;
 
   constructor() {
@@ -51,6 +50,8 @@ export default class MfaLoginEnforcementForm extends Component {
     this.flattenTargets();
     // eagerly fetch identity groups and entities for use as search select options
     this.resetTargetState();
+    // only auth method types that have mounts can be selected as targets -- fetch from sys/auth and map by type
+    this.fetchAuthMethods();
   }
 
   async flattenTargets() {
@@ -80,6 +81,10 @@ export default class MfaLoginEnforcementForm extends Component {
         options: [...options[this.selectedTargetType]],
       };
     }
+  }
+  async fetchAuthMethods() {
+    const mounts = (await this.store.findAll('auth-method')).toArray();
+    this.authMethods = mounts.mapBy('type');
   }
 
   get selectedTarget() {

--- a/ui/tests/integration/components/mfa-login-enforcement-form-test.js
+++ b/ui/tests/integration/components/mfa-login-enforcement-form-test.js
@@ -191,7 +191,7 @@ module('Integration | Component | mfa-login-enforcement-form', function (hooks) 
       },
     }));
     this.model.auth_method_accessors.addObject('auth_userpass_1234');
-    this.model.auth_method_types.addObject('alicloud');
+    this.model.auth_method_types.addObject('userpass');
     const [entity] = (await this.store.query('identity/entity', {})).toArray();
     this.model.identity_entities.addObject(entity);
     const [group] = (await this.store.query('identity/group', {})).toArray();
@@ -212,7 +212,7 @@ module('Integration | Component | mfa-login-enforcement-form', function (hooks) 
         key: 'auth_method_accessors',
         type: 'accessor',
       },
-      { label: 'Authentication method', value: 'alicloud', key: 'auth_method_types', type: 'method' },
+      { label: 'Authentication method', value: 'userpass', key: 'auth_method_types', type: 'method' },
       { label: 'Group', value: 'bar group 1234', key: 'identity_groups', type: 'identity/group' },
       { label: 'Entity', value: 'foo entity 1234', key: 'identity_entities', type: 'identity/entity' },
     ];
@@ -240,7 +240,7 @@ module('Integration | Component | mfa-login-enforcement-form', function (hooks) 
         await click('.ember-power-select-option');
       } else {
         const key = target.label === 'Authentication method' ? 'auth-method' : 'accessor';
-        const value = target.label === 'Authentication method' ? 'alicloud' : 'auth_userpass_1234';
+        const value = target.label === 'Authentication method' ? 'userpass' : 'auth_userpass_1234';
         await fillIn(`[data-test-mlef-select="${key}"] select`, value);
       }
       await click('[data-test-mlef-add-target]');


### PR DESCRIPTION
When selecting an auth method type to add as a target an error was being returned for types that are not currently mounted. The list now represents only auth types that are mounted.

![image](https://user-images.githubusercontent.com/24611656/169587276-2a43accd-3626-4097-a89d-96947174f326.png)
