### PR TITLE
remove token type

### DIFF
--- a/ui/app/components/mount-accessor-select.js
+++ b/ui/app/components/mount-accessor-select.js
@@ -8,6 +8,7 @@ export default Component.extend({
   // Public API
   //value for the external mount selector
   value: null,
+  filterToken: false,
   noDefault: false,
   onChange: () => {},
 

--- a/ui/app/templates/components/mfa-login-enforcement-form.hbs
+++ b/ui/app/templates/components/mfa-login-enforcement-form.hbs
@@ -87,6 +87,7 @@
             @showAccessor={{true}}
             @noDefault={{true}}
             @onChange={{this.setTargetValue}}
+            @filterToken={{true}}
             data-test-mlef-select="accessor"
           />
         {{else if (eq this.selectedTargetType "method")}}

--- a/ui/app/templates/components/mount-accessor-select.hbs
+++ b/ui/app/templates/components/mount-accessor-select.hbs
@@ -20,10 +20,13 @@
           <option value="">Select one</option>
         {{/if}}
         {{#each this.authMethods.last.value as |method|}}
-          <option selected={{eq this.value method.accessor}} value={{method.accessor}}>
-            {{method.path}}
-            ({{if this.showAccessor method.accessor method.type}})
-          </option>
+          {{! token type does not need to be authorized via MFA }}
+          {{#if (not-eq method.id "token")}}
+            <option selected={{eq this.value method.accessor}} value={{method.accessor}}>
+              {{method.path}}
+              ({{if this.showAccessor method.accessor method.type}})
+            </option>
+          {{/if}}
         {{/each}}
       </select>
     </div>

--- a/ui/app/templates/components/mount-accessor-select.hbs
+++ b/ui/app/templates/components/mount-accessor-select.hbs
@@ -21,7 +21,14 @@
         {{/if}}
         {{#each this.authMethods.last.value as |method|}}
           {{! token type does not need to be authorized via MFA }}
-          {{#if (not-eq method.id "token")}}
+          {{#if this.filterToken}}
+            {{#if (not-eq method.id "token")}}
+              <option selected={{eq this.value method.accessor}} value={{method.accessor}}>
+                {{method.path}}
+                ({{if this.showAccessor method.accessor method.type}})
+              </option>
+            {{/if}}
+          {{else}}
             <option selected={{eq this.value method.accessor}} value={{method.accessor}}>
               {{method.path}}
               ({{if this.showAccessor method.accessor method.type}})


### PR DESCRIPTION
According to the backend: >Vault login with a token doesn’t actually talk to vault, it’s just shorthand for “copy this token into my token helper, by default into ~/.vault-token”.  I would omit it (token) from the enforcement options, auth/token with mfa is more of a step-up mfa (ent mfa) thing.

This PR filters it out as an option in the template.