### PR TITLE
Add deprecated tags to token_type and policy

### DIFF
--- a/builtin/logical/consul/path_roles.go
+++ b/builtin/logical/consul/path_roles.go
@@ -35,6 +35,7 @@ func pathRoles(b *backend) *framework.Path {
 				Type: framework.TypeString,
 				Description: `Policy document, base64 encoded. Required
 for 'client' tokens. Required for Consul pre-1.4.`,
+				Deprecated: true,
 			},
 
 			"token_type": {
@@ -43,6 +44,7 @@ for 'client' tokens. Required for Consul pre-1.4.`,
 				Description: `Which type of token to create: 'client' or 'management'. If
 a 'management' token, the "policy", "policies", and "consul_roles" parameters are not
 required. Defaults to 'client'.`,
+				Deprecated: true,
 			},
 
 			"policies": {

--- a/changelog/15550.txt
+++ b/changelog/15550.txt
@@ -1,0 +1,3 @@
+```release-note:deprecation
+secrets/consul: Deprecate old parameters "token_type" and "policy"
+```


### PR DESCRIPTION
Adding deprecated tags to the fields `token_type` and `policy` as they were long-ago deprecated in Consul and no longer supported in new versions. Documentation and explanation of this change will be added in the neat future separately.