### PR TITLE
VAULT-6131 OpenAPI schema now includes /auth/token endpoints when explicit permission has been granted

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3711,7 +3711,11 @@ func (b *SystemBackend) pathInternalUIMountsRead(ctx context.Context, req *logic
 		}
 
 		if isAuthed {
-			return hasMountAccess(ctx, acl, me.Namespace().Path+me.Path)
+			if me.Table == "auth" {
+				return hasMountAccess(ctx, acl, me.Namespace().Path+me.Table+"/"+me.Path)
+			} else {
+				return hasMountAccess(ctx, acl, me.Namespace().Path+me.Path)
+			}
 		}
 
 		return false


### PR DESCRIPTION
Previously, this code path was checking for ACLs for "/token/" when it should have been checking for "/auth/token". The `Core.mounts.Entries` and `Core.auth.Entries` both get checked by `hasAccess`,  and while the `MountEntry` for `mounts` was simply `mounts`, which should not be prepended to e.g. `/sys/`, `auth` does need to be prepended for `/auth/token` etc.

Blanket access (e.g. access to `/auth/token/*`) goes down a different code path, which is why this issue was not seen in that case.

The OpenAPI schema now contains information about the `/auth/token/` endpoints if explicit permission is granted to at least one of them (same behaviour as other endpoints).