### PR TITLE
Convert not_before_duration to seconds before returning it

### DIFF
--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -757,7 +757,7 @@ func (b *backend) parseRole(role *sshRole) (map[string]interface{}, error) {
 			"default_extensions_template": role.DefaultExtensionsTemplate,
 			"allowed_user_key_lengths":    role.AllowedUserKeyTypesLengths,
 			"algorithm_signer":            role.AlgorithmSigner,
-			"not_before_duration":         role.NotBeforeDuration,
+			"not_before_duration":         int64(role.NotBeforeDuration.Seconds()),
 		}
 	case KeyTypeDynamic:
 		result = map[string]interface{}{

--- a/changelog/15559.txt
+++ b/changelog/15559.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/ssh: Convert role field not_before_duration to seconds before returning it
+```


### PR DESCRIPTION
# Description
Found a bug in an improvement that was merged to main the other day (#15250).
The SSH Role field `not_before_duration` field is returned in nanoseconds instead of seconds (as expected).
The following requests fixes this issue by converting the value of the fields to seconds before returning it.

## Screenshots of the bug (`not_before_duration` meant to be 30 seconds)
![ui](https://user-images.githubusercontent.com/37577952/169618031-d4c04fb3-b3b4-46d7-96f4-0d4ac5c365be.png)
![cli](https://user-images.githubusercontent.com/37577952/169618035-e5131bf9-54d8-4f32-bd27-039389528ee0.png)

PS: The screenshots are a bit bigger than expected.

## Others
Not sure if it's worth creating an issue for this.

@cipherboy 
Sorry for pinging, just thought it would be faster since you have context of what was done.
