### PR TITLE
Vault documentation: reorganized docs by moving recovery key description

### DIFF
--- a/website/content/docs/commands/operator/init.mdx
+++ b/website/content/docs/commands/operator/init.mdx
@@ -119,3 +119,5 @@ flags](/docs/commands) included on all commands.
 
 - `-stored-shares` `(int: 0)` - Number of unseal keys to store on an HSM. This
   must be equal to `-key-shares`.
+
+Refer to the [Seal/Unseal](/docs/concepts/seal#auto-unseal) documentation to learn more about recovery keys.

--- a/website/content/docs/commands/operator/init.mdx
+++ b/website/content/docs/commands/operator/init.mdx
@@ -120,4 +120,6 @@ flags](/docs/commands) included on all commands.
 - `-stored-shares` `(int: 0)` - Number of unseal keys to store on an HSM. This
   must be equal to `-key-shares`.
 
-Refer to the [Seal/Unseal](/docs/concepts/seal#auto-unseal) documentation to learn more about recovery keys.
+-> **Recovery keys:** Refer to the
+ [Seal/Unseal](/docs/concepts/seal#recovery-key) documentation to learn more
+ about recovery keys.

--- a/website/content/docs/concepts/seal.mdx
+++ b/website/content/docs/concepts/seal.mdx
@@ -126,8 +126,7 @@ keys for this purpose, rather than the barrier unseal keys, is automatic.
 ### Initialization
 
 When initializing, the split is performed according to the following CLI flags
-and their API equivalents in the
-[/sys/init](/api-docs/system/init) endpoint:
+and their API equivalents in the [/sys/init](/api-docs/system/init) endpoint:
 
 - `recovery-shares`: The number of shares into which to split the recovery
   key. This value is equivalent to the `recovery_shares` value in the API
@@ -141,7 +140,7 @@ and their API equivalents in the
   an array, not a string.
 
 Additionally, Vault will refuse to initialize if the option has not been set to
-generate a key but no key is found. See
+generate a key, and no key is found. See
 [Configuration](/docs/configuration/seal/pkcs11) for more details.
 
 ### Rekeying

--- a/website/content/docs/concepts/seal.mdx
+++ b/website/content/docs/concepts/seal.mdx
@@ -112,6 +112,60 @@ would be provided with Shamir. The process remains the same.
 For a list of examples and supported providers, please see the
 [seal documentation](/docs/configuration/seal).
 
+## Recovery Key
+
+When Vault is initialized while using an HSM or KMS, rather than unseal keys being
+returned to the operator, recovery keys are returned. These are generated from
+an internal recovery key that is split via Shamir's Secret Sharing, similar to
+Vault's treatment of unseal keys when running without an HSM or KMS.
+
+Details about initialization and rekeying follow. When performing an operation
+that uses recovery keys, such as `generate-root`, selection of the recovery
+keys for this purpose, rather than the barrier unseal keys, is automatic.
+
+### Initialization
+
+When initializing, the split is performed according to the following CLI flags
+and their API equivalents in the
+[/sys/init](/api-docs/system/init) endpoint:
+
+- `recovery-shares`: The number of shares into which to split the recovery
+  key. This value is equivalent to the `recovery_shares` value in the API
+  endpoint.
+- `recovery-threshold`: The threshold of shares required to reconstruct the
+  recovery key. This value is equivalent to the `recovery_threshold` value in
+  the API endpoint.
+- `recovery-pgp-keys`: The PGP keys to use to encrypt the returned recovery
+  key shares. This value is equivalent to the `recovery_pgp_keys` value in the
+  API endpoint, although as with `pgp_keys` the object in the API endpoint is
+  an array, not a string.
+
+Additionally, Vault will refuse to initialize if the option has not been set to
+generate a key but no key is found. See
+[Configuration](/docs/configuration/seal/pkcs11) for more details.
+
+### Rekeying
+
+#### Unseal Key
+
+Vault's unseal key can be rekeyed using a normal `vault operator rekey`
+operation from the CLI or the matching API calls. The rekey operation is
+authorized by meeting the threshold of recovery keys. After rekeying, the new
+barrier key is wrapped by the HSM or KMS and stored like the previous key; it is not
+returned to the users that submitted their recovery keys.
+
+#### Recovery Key
+
+The recovery key can be rekeyed to change the number of shares/threshold or to
+target different key holders via different PGP keys. When using the Vault CLI,
+this is performed by using the `-target=recovery` flag to `vault operator rekey`.
+
+Via the API, the rekey operation is performed with the same parameters as the
+[normal `/sys/rekey`
+endpoint](/api-docs/system/rekey); however, the
+API prefix for this operation is at `/sys/rekey-recovery-key` rather than
+`/sys/rekey`.
+
 ## Recovery Key Rekeying
 
 Recovery keys can be rekeyed to change the number of shares or thresholds.

--- a/website/content/docs/concepts/seal.mdx
+++ b/website/content/docs/concepts/seal.mdx
@@ -114,10 +114,10 @@ For a list of examples and supported providers, please see the
 
 ## Recovery Key
 
-When Vault is initialized while using an HSM or KMS, rather than unseal keys being
-returned to the operator, recovery keys are returned. These are generated from
-an internal recovery key that is split via Shamir's Secret Sharing, similar to
-Vault's treatment of unseal keys when running without an HSM or KMS.
+When Vault is initialized while using an HSM or KMS, rather than unseal keys
+being returned to the operator, recovery keys are returned. These are generated
+from an internal recovery key that is split via Shamir's Secret Sharing, similar
+to Vault's treatment of unseal keys when running without an HSM or KMS.
 
 Details about initialization and rekeying follow. When performing an operation
 that uses recovery keys, such as `generate-root`, selection of the recovery
@@ -164,12 +164,6 @@ Via the API, the rekey operation is performed with the same parameters as the
 endpoint](/api-docs/system/rekey); however, the
 API prefix for this operation is at `/sys/rekey-recovery-key` rather than
 `/sys/rekey`.
-
-## Recovery Key Rekeying
-
-Recovery keys can be rekeyed to change the number of shares or thresholds.
-When using the Vault CLI, this is performed by using the `-target=recovery` flag
-to `vault operator rekey`.
 
 ## Seal Migration
 

--- a/website/content/docs/enterprise/hsm/behavior.mdx
+++ b/website/content/docs/enterprise/hsm/behavior.mdx
@@ -20,9 +20,11 @@ functionality.
 
 When using an HSM, because the HSM automatically unseals the barrier but
 recovery operations should still have human oversight, Vault instead uses two
-sets of keys: unseal keys and recovery keys.
+sets of keys: unseal keys and recovery keys. 
 
-Refer to the [Seal/Unseal](/docs/concepts/seal#auto-unseal) documentation to learn more about recovery keys.
+-> **Recovery keys:** Refer to the
+ [Seal/Unseal](/docs/concepts/seal#recovery-key) documentation to learn more
+ about recovery keys.
 
 ## Unseal (Root) Key
 

--- a/website/content/docs/enterprise/hsm/behavior.mdx
+++ b/website/content/docs/enterprise/hsm/behavior.mdx
@@ -22,7 +22,9 @@ When using an HSM, because the HSM automatically unseals the barrier but
 recovery operations should still have human oversight, Vault instead uses two
 sets of keys: unseal keys and recovery keys.
 
-## Unseal (Master) Key
+Refer to the [Seal/Unseal](/docs/concepts/seal#auto-unseal) documentation to learn more about recovery keys.
+
+## Unseal (Root) Key
 
 Vault usually generates a root key and splits it using [Shamir's Secret
 Sharing](https://en.wikipedia.org/wiki/Shamir%27s_Secret_Sharing) to prevent a
@@ -33,66 +35,12 @@ information about Vault's security model
 When using an HSM, Vault instead stores the root key, encrypted by the HSM,
 into its internal storage. As a result, during an `init` command, the number of
 key shares, threshold, and stored shares are required to be set to `1`, meaning
-to not split the root key, so that the single key share is itself the master
+to not split the root key, so that the single key share is itself the root
 key. (Vault does not do this automatically as it generally prefers to error
 rather than change parameters set by an operator.)
 
 Both rekeying the root key and rotation of the underlying data
 encryption key are supported when using an HSM.
-
-## Recovery Key
-
-When Vault is initialized while using an HSM, rather than unseal keys being
-returned to the operator, recovery keys are returned. These are generated from
-an internal recovery key that is split via Shamir's Secret Sharing, similar to
-Vault's treatment of unseal keys when running without an HSM.
-
-Details about initialization and rekeying follow. When performing an operation
-that uses recovery keys, such as `generate-root`, selection of the recovery
-keys for this purpose, rather than the barrier unseal keys, is automatic.
-
-### Initialization
-
-When initializing, the split is performed according to the following CLI flags
-and their API equivalents in the
-[/sys/init](/api-docs/system/init) endpoint:
-
-- `recovery-shares`: The number of shares into which to split the recovery
-  key. This value is equivalent to the `recovery_shares` value in the API
-  endpoint.
-- `recovery-threshold`: The threshold of shares required to reconstruct the
-  recovery key. This value is equivalent to the `recovery_threshold` value in
-  the API endpoint.
-- `recovery-pgp-keys`: The PGP keys to use to encrypt the returned recovery
-  key shares. This value is equivalent to the `recovery_pgp_keys` value in the
-  API endpoint, although as with `pgp_keys` the object in the API endpoint is
-  an array, not a string.
-
-Additionally, Vault will refuse to initialize if the option has not been set to
-generate a key but no key is found. See
-[Configuration](/docs/configuration/seal/pkcs11) for more details.
-
-### Rekeying
-
-#### Unseal Key
-
-Vault's unseal key can be rekeyed using a normal `vault operator rekey`
-operation from the CLI or the matching API calls. The rekey operation is
-authorized by meeting the threshold of recovery keys. After rekeying, the new
-barrier key is wrapped by the HSM and stored like the previous key; it is not
-returned to the users that submitted their recovery keys.
-
-#### Recovery Key
-
-The recovery key can be rekeyed to change the number of shares/threshold or to
-target different key holders via different PGP keys. When using the Vault CLI,
-this is performed by using the `-target=recovery` flag to `vault operator rekey`.
-
-Via the API, the rekey operation is performed with the same parameters as the
-[normal `/sys/rekey`
-endpoint](/api-docs/system/rekey); however, the
-API prefix for this operation is at `/sys/rekey-recovery-key` rather than
-`/sys/rekey`.
 
 ## Performance and Availability
 


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/563192436488770/1202302893205879/f), the following actions were taken:

- The recovery key description was moved from the [HSM](https://www.vaultproject.io/docs/enterprise/hsm/behavior) doc to the [Auto-unseal](https://www.vaultproject.io/docs/concepts/seal#auto-unseal) doc.
- A cross-link to the [Auto-unseal](https://www.vaultproject.io/docs/concepts/seal#auto-unseal) doc was added from the [HSM](https://www.vaultproject.io/docs/enterprise/hsm/behavior)  and [operator init](https://www.vaultproject.io/docs/commands/operator/init) docs.

HSM :mag: [Deploy Preview](https://vault-git-docs-recovery-keys-update-hashicorp.vercel.app/docs/enterprise/hsm/behavior)
Auto-Unseal :mag: [Deploy Preview](https://vault-git-docs-recovery-keys-update-hashicorp.vercel.app/docs/concepts/seal)
Init :mag: [Deploy Preview](https://vault-git-docs-recovery-keys-update-hashicorp.vercel.app/docs/commands/operator/init)