### PR TITLE
Remove unsupported fields for DB roles show page

### DIFF
--- a/changelog/15573.txt
+++ b/changelog/15573.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-**UI**: Fixed unsupported revocation statements field for DB roles
+ui: Fixed unsupported revocation statements field for DB roles
 ```

--- a/changelog/15573.txt
+++ b/changelog/15573.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+**UI**: Fixed unsupported revocation statements field for DB roles
+```

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -3,7 +3,7 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
-import { getRoleFields, getStatementFields } from '../../utils/database-helpers';
+import { getRoleFields } from 'vault/utils/database-helpers';
 
 export default Model.extend({
   idPrefix: 'role/',
@@ -92,8 +92,7 @@ export default Model.extend({
   get showFields() {
     let fields = ['name', 'database', 'type'];
     fields = fields.concat(getRoleFields(this.type)).concat(['creation_statements']);
-    const plugin = this.database + '-database-plugin';
-    if (getStatementFields(this.type, plugin).includes('revocation_statements')) {
+    if (this.database != 'elasticsearch') {
       fields = fields.concat(['revocation_statements']);
     }
     return expandAttributeMeta(this, fields);

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -92,8 +92,8 @@ export default Model.extend({
   get showFields() {
     let fields = ['name', 'database', 'type'];
     fields = fields.concat(getRoleFields(this.type)).concat(['creation_statements']);
-    const plugin = this.database+'-database-plugin';
-    if(getStatementFields(this.type, plugin).includes('revocation_statements')){
+    const plugin = this.database + '-database-plugin';
+    if (getStatementFields(this.type, plugin).includes('revocation_statements')) {
       fields = fields.concat(['revocation_statements']);
     }
     return expandAttributeMeta(this, fields);

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -92,7 +92,8 @@ export default Model.extend({
   get showFields() {
     let fields = ['name', 'database', 'type'];
     fields = fields.concat(getRoleFields(this.type)).concat(['creation_statements']);
-    if (this.database != 'elasticsearch') {
+    // elasticsearch does not support revocation statements: https://www.vaultproject.io/api-docs/secret/databases/elasticdb#parameters-1
+    if (this.database[0] !== 'elasticsearch') {
       fields = fields.concat(['revocation_statements']);
     }
     return expandAttributeMeta(this, fields);

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -3,7 +3,7 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
-import { getRoleFields } from '../../utils/database-helpers';
+import { getRoleFields, getStatementFields } from '../../utils/database-helpers';
 
 export default Model.extend({
   idPrefix: 'role/',
@@ -91,7 +91,11 @@ export default Model.extend({
 
   get showFields() {
     let fields = ['name', 'database', 'type'];
-    fields = fields.concat(getRoleFields(this.type)).concat(['creation_statements', 'revocation_statements']);
+    fields = fields.concat(getRoleFields(this.type)).concat(['creation_statements']);
+    const plugin = this.database+'-database-plugin';
+    if(getStatementFields(this.type, plugin).includes('revocation_statements')){
+      fields = fields.concat(['revocation_statements']);
+    }
     return expandAttributeMeta(this, fields);
   },
 


### PR DESCRIPTION
Removed unsupported field of `revocation_statements` for DB roles for `elasticsearch` database