### PR TITLE
use provided namespace for wrapping lookup cubbyhole request

### DIFF
--- a/changelog/15583.txt
+++ b/changelog/15583.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core (enterprise): Fix bug where wrapping token lookup does not work within namespaces.
+```


### PR DESCRIPTION
Wrapping and unwrapping works in namespaces, but a lookup operation always throws an error.

Example of proper functioning within root namespace:

```
❯ vault write -format=json sys/wrapping/wrap foo=bar | jq .wrap_info.token
"hvs.CAESIIKmFRNNJnGtpY204WMmkfoaLndJkBd0ZG4ZVtaan81lGh4KHGh2cy41cGxKYURDeGRwWlpaaTNYTWNSdmRuWFg"

❯ vault write sys/wrapping/lookup token=hvs.CAESIIKmFRNNJnGtpY204WMmkfoaLndJkBd0ZG4ZVtaan81lGh4KHGh2cy41cGxKYURDeGRwWlpaaTNYTWNSdmRuWFg
Key              Value
---              -----
creation_path    sys/wrapping/wrap
creation_time    2022-05-24T17:00:57.64062-04:00
creation_ttl     5m

❯ vault write -format=json sys/wrapping/unwrap token=hvs.CAESIIKmFRNNJnGtpY204WMmkfoaLndJkBd0ZG4ZVtaan81lGh4KHGh2cy41cGxKYURDeGRwWlpaaTNYTWNSdmRuWFg
{
  "foo": "bar"
}
```

Example of error within a child namespace `ns1`:

```
❯ vault namespace create ns1

❯ VAULT_NAMESPACE=ns1 vault write -format=json sys/wrapping/wrap foo=bar | jq .wrap_info.token
"hvs.CAESILNnfxufSwP8Nhoiv3fwE5govVuMae8BT_dlSQlOjykgGiQKImh2cy5ZelFEN0RFTndXZFpGRWlxdHR3d0hIUjIudzEzeXI"

❯ VAULT_NAMESPACE=ns1 vault write sys/wrapping/lookup token=hvs.CAESILNnfxufSwP8Nhoiv3fwE5govVuMae8BT_dlSQlOjykgGiQKImh2cy5ZelFEN0RFTndXZFpGRWlxdHR3d0hIUjIudzEzeXI

Error writing data to sys/wrapping/lookup: Error making API request.

URL: PUT https://127.0.0.1:8200/v1/sys/wrapping/lookup
Code: 400. Errors:

* no information found; wrapping token may be from a previous Vault version

❯ VAULT_NAMESPACE=ns1 vault write -format=json sys/wrapping/unwrap token=hvs.CAESILNnfxufSwP8Nhoiv3fwE5govVuMae8BT_dlSQlOjykgGiQKImh2cy5ZelFEN0RFTndXZFpGRWlxdHR3d0hIUjIudzEzeXI | jq .data
{
  "foo": "bar"
}
```

The underlying `logical.ReadOperation` request to `cubbyhole/wrapinfo` for API calls to `sys/wrapping/lookup` is not provided the requested namespace. This PR fixes that by providing that `logical.ReadOperation` request with a context with the requested namespace through use of `namespace.ContextWithNamespace`.

An enterprise test validating this fix will be provided in a separate PR.
