### PR TITLE
auth/gcp: updates plugin to v0.13.0

### DIFF
--- a/changelog/15592.txt
+++ b/changelog/15592.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+auth/gcp: Vault CLI now infers the service account email when running on Google Cloud 
+```
+```release-note:improvement
+auth/gcp: Enable the Google service endpoints used by the underlying client to be customized 
+```

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-discover v0.0.0-20210818145131-c573d69da192
-	github.com/hashicorp/go-gcp-common v0.7.0
+	github.com/hashicorp/go-gcp-common v0.7.1-0.20220519220342-94aabf4c4c87
 	github.com/hashicorp/go-hclog v1.1.0
 	github.com/hashicorp/go-kms-wrapping v0.7.0
 	github.com/hashicorp/go-memdb v1.3.2
@@ -96,7 +96,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-azure v0.10.0
 	github.com/hashicorp/vault-plugin-auth-centrify v0.11.0
 	github.com/hashicorp/vault-plugin-auth-cf v0.11.0
-	github.com/hashicorp/vault-plugin-auth-gcp v0.7.1-0.20220405202915-ab4f0f6abd2b
+	github.com/hashicorp/vault-plugin-auth-gcp v0.13.0
 	github.com/hashicorp/vault-plugin-auth-jwt v0.12.1
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.6.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -834,8 +834,8 @@ github.com/hashicorp/go-discover v0.0.0-20210818145131-c573d69da192/go.mod h1:3/
 github.com/hashicorp/go-gatedio v0.5.0 h1:Jm1X5yP4yCqqWj5L1TgW7iZwCVPGtVc+mro5r/XX7Tg=
 github.com/hashicorp/go-gatedio v0.5.0/go.mod h1:Lr3t8L6IyxD3DAeaUxGcgl2JnRUpWMCsmBl4Omu/2t4=
 github.com/hashicorp/go-gcp-common v0.5.0/go.mod h1:IDGUI2N/OS3PiU4qZcXJeWKPI6O/9Y8hOrbSiMcqyYw=
-github.com/hashicorp/go-gcp-common v0.7.0 h1:DF2liDG2N71MYt5SN0FJRPdBjxeqx9wfM/PnF7a8Fqk=
-github.com/hashicorp/go-gcp-common v0.7.0/go.mod h1:RuZi18562/z30wxOzpjeRrGcmk9Ro/rBzixaSZDhIhY=
+github.com/hashicorp/go-gcp-common v0.7.1-0.20220519220342-94aabf4c4c87 h1:ZFwYpI67zQ2G73zrij1LXhuubprduZORoClazMJ/cb8=
+github.com/hashicorp/go-gcp-common v0.7.1-0.20220519220342-94aabf4c4c87/go.mod h1:RuZi18562/z30wxOzpjeRrGcmk9Ro/rBzixaSZDhIhY=
 github.com/hashicorp/go-hclog v0.9.1/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
@@ -972,8 +972,8 @@ github.com/hashicorp/vault-plugin-auth-centrify v0.11.0 h1:W1Al8Kw4VvXm/mtDdzgBa
 github.com/hashicorp/vault-plugin-auth-centrify v0.11.0/go.mod h1:3fDbIVdwA/hkOVhwktKHDX5lo4DqIUUVbBdwQNNvxHw=
 github.com/hashicorp/vault-plugin-auth-cf v0.11.0 h1:W8KkpZv8AHM9eMYrTgCmc9aKac/KORzby7Go0I0MpQ8=
 github.com/hashicorp/vault-plugin-auth-cf v0.11.0/go.mod h1:4HM4amMEcCyoLZNNjyz5AYILIlhMLTErxrinM3Vopy4=
-github.com/hashicorp/vault-plugin-auth-gcp v0.7.1-0.20220405202915-ab4f0f6abd2b h1:nrHWBFZOvSmjnrQmoCZ9GQXs2awypQhxpMI82JCVEM8=
-github.com/hashicorp/vault-plugin-auth-gcp v0.7.1-0.20220405202915-ab4f0f6abd2b/go.mod h1:M5FmdM8Af2X/DNQPPIIkXXKEboy6hqXwN/67tiwl/m8=
+github.com/hashicorp/vault-plugin-auth-gcp v0.13.0 h1:tEnviQV4EqHi+JlqJ369RAJGxXXgq+9s1JP6HBjl348=
+github.com/hashicorp/vault-plugin-auth-gcp v0.13.0/go.mod h1:tHtTF/qQmrRrY5DEOxWxoW/y5Wk9VoHsBOC339RO3d8=
 github.com/hashicorp/vault-plugin-auth-jwt v0.12.1 h1:F8aNPecN7Bihyndku9g1XrGOy4ioQM8JE+Uhg/e8nFY=
 github.com/hashicorp/vault-plugin-auth-jwt v0.12.1/go.mod h1:+WL5kaq/0L5OROsA31X15U8yTIX4GTEv1rTLA9d15eo=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.6.0 h1:5GiKYqA8NTW9QPA1gahok2CVTKwa50lccB30i3GLffk=


### PR DESCRIPTION
This PR updates vault-plugin-auth-gcp to [v0.13.0](https://github.com/hashicorp/vault-plugin-auth-gcp/releases/tag/v0.13.0).

```
go get github.com/hashicorp/vault-plugin-auth-gcp@v0.13.0
go mod tidy
```