### PR TITLE
BUG: MFA permissions fix

### DIFF
--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -43,6 +43,7 @@ const API_PATHS_TO_ROUTE_PARAMS = {
   'sys/leases/lookup': { route: 'vault.cluster.access.leases', models: [] },
   'sys/namespaces': { route: 'vault.cluster.access.namespaces', models: [] },
   'sys/control-group/': { route: 'vault.cluster.access.control-groups', models: [] },
+  'identity/mfa/method': { route: 'vault.cluster.access.mfa', models: [] },
 };
 
 /*


### PR DESCRIPTION
I ran into this bug when using the following policy. (Policy is needed for mfa-end-user flow). It appears main app route was searching for `identity/mfa/method` but couldn't find it. In the MFA work, this API_PATH had been added to the permission.js file but not to the API_PATHS_TO_ROUTE_PARAMS, so it was returning null and causing an error. I can't say I understand this service entirely, but this does fix the issue.

```
path "identity/*" {
    capabilities = ["create", "read", "update", "delete", "list"]
}
```