### PR TITLE
docs/database/elasticsearch: use_old_xpack option

### DIFF
--- a/website/content/api-docs/secret/databases/elasticdb.mdx
+++ b/website/content/api-docs/secret/databases/elasticdb.mdx
@@ -34,6 +34,7 @@ has a number of parameters to further configure a connection.
 - `tls_server_name` `(string: "")` - This, if set, is used to set the SNI host when connecting via TLS.
 - `insecure` `(bool: false)` - Not recommended. Default to `false`. Can be set to `true` to disable certificate verification.
 - `username_template` `(string)` - [Template](/docs/concepts/username-templating) describing how dynamic usernames are generated.
+- `use_old_xpack` `(bool: false)` - Can be set to `true` to use the `/_xpack/security` base API path when managing Elasticsearch. May be required for Elasticsearch server versions prior to 6.
 
 ### Sample Payload
 

--- a/website/content/docs/upgrading/upgrade-to-1.11.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.11.x.mdx
@@ -1,0 +1,20 @@
+---
+layout: docs
+page_title: Upgrading to Vault 1.11.x - Guides
+description: |-
+  This page contains the list of deprecations and important or breaking changes
+  for Vault 1.11.x. Please read it carefully.
+---
+
+# Overview
+
+This page contains the list of deprecations and important or breaking changes
+for Vault 1.11.x compared to 1.10. Please read it carefully.
+
+## Elasticsearch Database Secrets Engine
+
+The Elaticsearch Database Secrets Engine now uses the new `/_security` base API
+path instead of `/_xpack/security` when managing Elasticsearch. If users are on
+an Elasticsearch version prior to 6, they will need to switch back to the old
+API path by setting the [bool config option](/api-docs/secret/databases/elasticdb#use_old_xpack)
+`use_old_xpack=true`.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1562,6 +1562,10 @@
         "path": "upgrading/plugins"
       },
       {
+        "title": "Upgrade to 1.11.x",
+        "path": "upgrading/upgrade-to-1.11.x"
+      },
+      {
         "title": "Upgrade to 1.10.x",
         "path": "upgrading/upgrade-to-1.10.x"
       },


### PR DESCRIPTION
Update elasticsearch db secrets engine docs for the `use_old_xpack` option being introduced in https://github.com/hashicorp/vault-plugin-database-elasticsearch/pull/37. Also include an upgrade note.