### PR TITLE
fix: upgrade vault-plugin-database-snowflake to v0.5.0

### DIFF
--- a/changelog/15608.txt
+++ b/changelog/15608.txt
@@ -1,3 +1,0 @@
-```release-note:feature
-**Snowflake Database Plugin**: Adds support for managing Snowflake users with RSA key pair credentials.
-```

--- a/changelog/15608.txt
+++ b/changelog/15608.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+**Snowflake Database Plugin**: Adds support for managing Snowflake users with RSA key pair credentials.
+```

--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,7 @@ require (
 	github.com/hashicorp/vault-plugin-database-couchbase v0.6.0
 	github.com/hashicorp/vault-plugin-database-elasticsearch v0.10.0
 	github.com/hashicorp/vault-plugin-database-mongodbatlas v0.6.0
-	github.com/hashicorp/vault-plugin-database-snowflake v0.4.1
+	github.com/hashicorp/vault-plugin-database-snowflake v0.5.0
 	github.com/hashicorp/vault-plugin-mock v0.16.1
 	github.com/hashicorp/vault-plugin-secrets-ad v0.13.0
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.11.1

--- a/go.sum
+++ b/go.sum
@@ -990,8 +990,8 @@ github.com/hashicorp/vault-plugin-database-elasticsearch v0.10.0 h1:zjgO/peqT419
 github.com/hashicorp/vault-plugin-database-elasticsearch v0.10.0/go.mod h1:OMEQaNXsITksICGgkWW2y9/Nekv/cPKdqGOcMW5uUdI=
 github.com/hashicorp/vault-plugin-database-mongodbatlas v0.6.0 h1:5ZpDMHF0Im6KjuvxV8P6R1leidfh0rkLBD0VGz4nvd4=
 github.com/hashicorp/vault-plugin-database-mongodbatlas v0.6.0/go.mod h1:e3HTaMD+aRWHBVctX/M39OaARQA8ux9TvdWDU0dJaoc=
-github.com/hashicorp/vault-plugin-database-snowflake v0.4.1 h1:xj1w5sODSfoyVjuQdwAwz4duPSCZguiyIHi/8WcMXi0=
-github.com/hashicorp/vault-plugin-database-snowflake v0.4.1/go.mod h1:BgcYquqjHAJ8AufsoBoz3bgsR2qyD2Yx99IaG6eOWzw=
+github.com/hashicorp/vault-plugin-database-snowflake v0.5.0 h1:/7Rdtscy+zzn1lL3chaBe/v6+qublD0qhlPyLm9rR+4=
+github.com/hashicorp/vault-plugin-database-snowflake v0.5.0/go.mod h1:OmWVT0/Ll1z0XHdr6QjdsB7/zvRBR5OIB5/hDs6Xh4A=
 github.com/hashicorp/vault-plugin-mock v0.16.1 h1:5QQvSUHxDjEEbrd2REOeacqyJnCLPD51IQzy71hx8P0=
 github.com/hashicorp/vault-plugin-mock v0.16.1/go.mod h1:83G4JKlOwUtxVourn5euQfze3ZWyXcUiLj2wqrKSDIM=
 github.com/hashicorp/vault-plugin-secrets-ad v0.13.0 h1:hULVZaireW8XXg7ZWbPp3Qk4nrCPnMfhlE7soiYBzHU=


### PR DESCRIPTION
This PR updates vault-plugin-database-snowflake to [v0.5.0](https://github.com/hashicorp/vault-plugin-database-snowflake/releases/tag/v0.5.0)

Steps
```
go get github.com/hashicorp/vault-plugin-database-snowflake@v0.5.0
go mod tidy
```