### PR TITLE
Prep for 1.12

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -10,10 +10,10 @@ project "vault" {
     repository = "vault"
     release_branches = [
       "main",
-      "release/1.7.x",
       "release/1.8.x",
       "release/1.9.x",
       "release/1.10.x",
+      "release/1.11.x",
     ]
   }
 }

--- a/sdk/version/version_base.go
+++ b/sdk/version/version_base.go
@@ -11,7 +11,7 @@ var (
 	// Whether cgo is enabled or not; set at build time
 	CgoEnabled bool
 
-	Version           = "1.11.0"
+	Version           = "1.12.0"
 	VersionPrerelease = "dev1"
 	VersionMetadata   = ""
 )


### PR DESCRIPTION
- Increased SDK `Version` to `1.12.0`
- Removed 1.7.x branch and added 1.11.x branch in `.releases/ci.hcl`