### PR TITLE
fix: upgrade vault-plugin-database-mongodbatlas to v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-oci v0.10.0
 	github.com/hashicorp/vault-plugin-database-couchbase v0.7.0
 	github.com/hashicorp/vault-plugin-database-elasticsearch v0.10.0
-	github.com/hashicorp/vault-plugin-database-mongodbatlas v0.6.0
+	github.com/hashicorp/vault-plugin-database-mongodbatlas v0.7.0
 	github.com/hashicorp/vault-plugin-database-snowflake v0.5.0
 	github.com/hashicorp/vault-plugin-mock v0.16.1
 	github.com/hashicorp/vault-plugin-secrets-ad v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -991,8 +991,8 @@ github.com/hashicorp/vault-plugin-database-couchbase v0.7.0 h1:p//NCrYPF7AlCFtwK
 github.com/hashicorp/vault-plugin-database-couchbase v0.7.0/go.mod h1:Xw7uSxLWTzyWRHZhOBoc51cBC2nmNc7ekPgaaKK7UWI=
 github.com/hashicorp/vault-plugin-database-elasticsearch v0.10.0 h1:zjgO/peqT419K7w1BQWTnepj6cuBkv2qYpkSqp01t3A=
 github.com/hashicorp/vault-plugin-database-elasticsearch v0.10.0/go.mod h1:OMEQaNXsITksICGgkWW2y9/Nekv/cPKdqGOcMW5uUdI=
-github.com/hashicorp/vault-plugin-database-mongodbatlas v0.6.0 h1:5ZpDMHF0Im6KjuvxV8P6R1leidfh0rkLBD0VGz4nvd4=
-github.com/hashicorp/vault-plugin-database-mongodbatlas v0.6.0/go.mod h1:e3HTaMD+aRWHBVctX/M39OaARQA8ux9TvdWDU0dJaoc=
+github.com/hashicorp/vault-plugin-database-mongodbatlas v0.7.0 h1:TAyYn8/rWn+OeeiYAqlACV4q7A5YYDv3vVqucHTJgxE=
+github.com/hashicorp/vault-plugin-database-mongodbatlas v0.7.0/go.mod h1:e3HTaMD+aRWHBVctX/M39OaARQA8ux9TvdWDU0dJaoc=
 github.com/hashicorp/vault-plugin-database-snowflake v0.5.0 h1:/7Rdtscy+zzn1lL3chaBe/v6+qublD0qhlPyLm9rR+4=
 github.com/hashicorp/vault-plugin-database-snowflake v0.5.0/go.mod h1:OmWVT0/Ll1z0XHdr6QjdsB7/zvRBR5OIB5/hDs6Xh4A=
 github.com/hashicorp/vault-plugin-mock v0.16.1 h1:5QQvSUHxDjEEbrd2REOeacqyJnCLPD51IQzy71hx8P0=


### PR DESCRIPTION
This PR updates vault-plugin-database-mongodbatlas to [v0.7.0](https://github.com/hashicorp/vault-plugin-database-mongodbatlas/releases/tag/v0.7.0)

Steps
```
go get github.com/hashicorp/vault-plugin-database-mongodbatlas@v0.7.0
go mod tidy
```