### PR TITLE
secrets/mongodbatlas: adds missing organization_id to API docs

### DIFF
--- a/website/content/api-docs/secret/mongodbatlas.mdx
+++ b/website/content/api-docs/secret/mongodbatlas.mdx
@@ -57,7 +57,14 @@ either the MongoDB Atlas Organization or Project level with the designated role(
 ### Parameters
 
 - `name` `(string <required>)` - Unique identifier name of the role name
-- `project_id` `(string <required>)` - Unique identifier for the organization to which the target API Key belongs. Use the /orgs endpoint to retrieve all organizations to which the authenticated user has access.
+- `organization_id` `(string <required>)` - Unique identifier for the organization to which
+  the target API Key belongs. Use the [orgs endpoint](https://www.mongodb.com/docs/atlas/reference/api/organization-get-all/)
+  to retrieve all organizations to which the authenticated user has access. Required if
+  `project_id` is not set.
+- `project_id` `(string <required>)` - Unique identifier for the project to which the target
+  API Key belongs. Use the [projects endpoint](https://www.mongodb.com/docs/atlas/reference/api/project-get-all/)
+  to retrieve all organizations to which the authenticated user has access. Required if
+  `organization_id` is not set.
 - `roles` `(list [string] <required>)` - List of roles that the API Key needs to have. If the roles array is provided:
 
   -> **IMPORTANT:** Provide at least one role. Make sure all roles must be valid for the Organization or Project.


### PR DESCRIPTION
This PR adds the missing [`organization_id`](https://github.com/hashicorp/vault-plugin-secrets-mongodbatlas/blob/main/path_roles.go#L30) parameter to the MongoDB Atlas secrets engine API docs.