### PR TITLE
MFA Login Enforcement Acceptance Tests

### DIFF
--- a/ui/app/models/mfa-login-enforcement.js
+++ b/ui/app/models/mfa-login-enforcement.js
@@ -43,7 +43,6 @@ export default class MfaLoginEnforcementModel extends Model {
   }
 
   async prepareTargets() {
-    const mountableMethods = methods(); // use for icon lookup
     let authMethods;
     const targets = [];
 
@@ -62,23 +61,18 @@ export default class MfaLoginEnforcementModel extends Model {
         return this.auth_method_accessors.includes(model.accessor);
       });
       targets.addObjects(
-        selectedAuthMethods.map((method) => {
-          const mount = mountableMethods.findBy('type', method.type);
-          const icon = mount.glyph || mount.type;
-          return {
-            icon,
-            link: 'vault.cluster.access.method',
-            linkModels: [method.path.slice(0, -1)],
-            title: method.path,
-            subTitle: method.accessor,
-          };
-        })
+        selectedAuthMethods.map((method) => ({
+          icon: this.iconForMount(method.type),
+          link: 'vault.cluster.access.method',
+          linkModels: [method.path.slice(0, -1)],
+          title: method.path,
+          subTitle: method.accessor,
+        }))
       );
     }
 
     this.auth_method_types.forEach((type) => {
-      const mount = mountableMethods.findBy('type', type);
-      const icon = mount.glyph || mount.type;
+      const icon = this.iconForMount(type);
       const mountCount = authMethods.filterBy('type', type).length;
       targets.addObject({
         key: 'auth_method_types',
@@ -102,5 +96,11 @@ export default class MfaLoginEnforcementModel extends Model {
     }
 
     return targets;
+  }
+
+  iconForMount(type) {
+    const mountableMethods = methods();
+    const mount = mountableMethods.findBy('type', type);
+    return mount ? mount.glyph || mount.type : 'token';
   }
 }

--- a/ui/app/serializers/mfa-login-enforcement.js
+++ b/ui/app/serializers/mfa-login-enforcement.js
@@ -31,6 +31,10 @@ export default class MfaLoginEnforcementSerializer extends ApplicationSerializer
   }
   serialize() {
     const json = super.serialize(...arguments);
+    // empty arrays are being removed from serialized json
+    // ensure that they are sent to the server, otherwise removing items will not be persisted
+    json.auth_method_accessors = json.auth_method_accessors || [];
+    json.auth_method_types = json.auth_method_types || [];
     return this.transformHasManyKeys(json, 'server');
   }
 }

--- a/ui/app/templates/components/mfa/login-enforcement-list-item.hbs
+++ b/ui/app/templates/components/mfa/login-enforcement-list-item.hbs
@@ -1,9 +1,13 @@
-<LinkedBlock class="list-item-row" @params={{array "vault.cluster.access.mfa.enforcements.enforcement" @model.id}}>
+<LinkedBlock
+  class="list-item-row"
+  @params={{array "vault.cluster.access.mfa.enforcements.enforcement" @model.id}}
+  data-test-list-item={{@model.name}}
+>
   <div class="level is-mobile">
     <div class="level-left">
       <div>
         <Icon @name="lock" />
-        <span class="has-text-weight-semibold has-text-black">
+        <span class="has-text-weight-semibold has-text-black" data-test-list-item-title={{@model.name}}>
           {{@model.name}}
         </span>
       </div>
@@ -14,12 +18,20 @@
           <nav class="menu">
             <ul class="menu-list">
               <li>
-                <LinkTo @route="vault.cluster.access.mfa.enforcements.enforcement" @model={{@model.name}}>
+                <LinkTo
+                  @route="vault.cluster.access.mfa.enforcements.enforcement"
+                  @model={{@model.name}}
+                  data-test-list-item-link="details"
+                >
                   Details
                 </LinkTo>
               </li>
               <li>
-                <LinkTo @route="vault.cluster.access.mfa.enforcements.enforcement.edit" @model={{@model.name}}>
+                <LinkTo
+                  @route="vault.cluster.access.mfa.enforcements.enforcement.edit"
+                  @model={{@model.name}}
+                  data-test-list-item-link="edit"
+                >
                   Edit
                 </LinkTo>
               </li>

--- a/ui/app/templates/components/mfa/method-list-item.hbs
+++ b/ui/app/templates/components/mfa/method-list-item.hbs
@@ -1,4 +1,8 @@
-<LinkedBlock class="list-item-row" @params={{array "vault.cluster.access.mfa.methods.method" @model.id}}>
+<LinkedBlock
+  class="list-item-row"
+  @params={{array "vault.cluster.access.mfa.methods.method" @model.id}}
+  data-test-mfa-method-list-item={{@model.id}}
+>
   <div class="level is-mobile">
     <div class="level-left">
       <div class="is-flex-row">
@@ -25,12 +29,20 @@
           <nav class="menu">
             <ul class="menu-list">
               <li>
-                <LinkTo @route="vault.cluster.access.mfa.methods.method" @model={{@model.id}}>
+                <LinkTo
+                  @route="vault.cluster.access.mfa.methods.method"
+                  @model={{@model.id}}
+                  data-test-mfa-method-menu-link="details"
+                >
                   Details
                 </LinkTo>
               </li>
               <li>
-                <LinkTo @route="vault.cluster.access.mfa.methods.method.edit" @model={{@model.id}}>
+                <LinkTo
+                  @route="vault.cluster.access.mfa.methods.method.edit"
+                  @model={{@model.id}}
+                  data-test-mfa-method-menu-link="edit"
+                >
                   Edit
                 </LinkTo>
               </li>

--- a/ui/app/templates/components/mfa/nav.hbs
+++ b/ui/app/templates/components/mfa/nav.hbs
@@ -1,10 +1,10 @@
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
   <nav class="tabs">
     <ul>
-      <LinkTo @route="vault.cluster.access.mfa.methods">
+      <LinkTo @route="vault.cluster.access.mfa.methods" data-test-tab="methods">
         Methods
       </LinkTo>
-      <LinkTo @route="vault.cluster.access.mfa.enforcements">
+      <LinkTo @route="vault.cluster.access.mfa.enforcements" data-test-tab="enforcements">
         Enforcements
       </LinkTo>
     </ul>

--- a/ui/app/templates/vault/cluster/access.hbs
+++ b/ui/app/templates/vault/cluster/access.hbs
@@ -16,7 +16,7 @@
         <LinkTo
           @route="vault.cluster.access.mfa.methods"
           @current-when="vault.cluster.access.mfa.methods vault.cluster.access.mfa.enforcements vault.cluster.access.mfa.index"
-          data-test-link={{true}}
+          data-test-link="mfa"
         >
           Multi-factor authentication
         </LinkTo>

--- a/ui/app/templates/vault/cluster/access/mfa/enforcements/enforcement/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/enforcements/enforcement/index.hbs
@@ -21,10 +21,18 @@
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
   <nav class="tabs" aria-label="Enforcement tabs">
     <ul>
-      <LinkTo @route="vault.cluster.access.mfa.enforcements.enforcement" @query={{hash tab="targets"}}>
+      <LinkTo
+        @route="vault.cluster.access.mfa.enforcements.enforcement"
+        @query={{hash tab="targets"}}
+        data-test-tab="targets"
+      >
         Targets
       </LinkTo>
-      <LinkTo @route="vault.cluster.access.mfa.enforcements.enforcement" @query={{hash tab="methods"}}>
+      <LinkTo
+        @route="vault.cluster.access.mfa.enforcements.enforcement"
+        @query={{hash tab="methods"}}
+        data-test-tab="methods"
+      >
         Methods
       </LinkTo>
     </ul>
@@ -32,11 +40,19 @@
 </div>
 <Toolbar>
   <ToolbarActions>
-    <button class="toolbar-link" onclick={{action (mut this.showDeleteConfirmation) true}} type="button">
+    <button
+      class="toolbar-link"
+      onclick={{action (mut this.showDeleteConfirmation) true}}
+      type="button"
+      data-test-enforcement-delete
+    >
       Delete
     </button>
     <div class="toolbar-separator"></div>
-    <ToolbarLink @params={{array "vault.cluster.access.mfa.enforcements.enforcement.edit" this.model.id}}>
+    <ToolbarLink
+      @params={{array "vault.cluster.access.mfa.enforcements.enforcement.edit" this.model.id}}
+      data-test-enforcement-edit={{true}}
+    >
       Edit enforcement
     </ToolbarLink>
   </ToolbarActions>
@@ -44,7 +60,12 @@
 
 {{#if (eq this.tab "targets")}}
   {{#each @model.targets as |target|}}
-    <LinkedBlock class="list-item-row" @disabled={{not target.link}} @params={{union (array target.link) target.linkModels}}>
+    <LinkedBlock
+      class="list-item-row"
+      @disabled={{not target.link}}
+      @params={{union (array target.link) target.linkModels}}
+      data-test-target={{target.title}}
+    >
       <div class="level is-mobile">
         <div class="level-left">
           <div>
@@ -66,7 +87,7 @@
                 <nav class="menu" aria-label="Enforcement target more menu">
                   <ul class="menu-list">
                     <li>
-                      <LinkTo @route={{target.link}} @models={{target.linkModels}}>
+                      <LinkTo @route={{target.link}} @models={{target.linkModels}} data-test-target-link={{target.title}}>
                         Details
                       </LinkTo>
                     </li>

--- a/ui/app/templates/vault/cluster/access/mfa/enforcements/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/enforcements/index.hbs
@@ -10,7 +10,11 @@
 
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink @type="add" @params={{array "vault.cluster.access.mfa.enforcements.create"}}>
+    <ToolbarLink
+      @type="add"
+      @params={{array "vault.cluster.access.mfa.enforcements.create"}}
+      data-test-enforcement-create={{true}}
+    >
       New enforcement
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/mirage/factories/mfa-login-enforcement.js
+++ b/ui/mirage/factories/mfa-login-enforcement.js
@@ -31,11 +31,16 @@ export default Factory.extend({
       const method = methods.length ? methods[Math.floor(Math.random() * methods.length)] : null;
       record.update('mfa_method_ids', method ? [method.id] : []);
     }
-    const keys = ['auth_method_accessors', 'auth_method_types', 'identity_group_ids', 'identity_entity_ids'];
-    keys.forEach((key) => {
-      if (!record[key]) {
-        record.update(key, key === 'auth_method_types' ? ['userpass'] : []);
+    const targets = {
+      auth_method_accessors: ['auth_userpass_bb95c2b1'],
+      auth_method_types: ['userpass'],
+      identity_group_ids: ['34db6b52-591e-bc22-8af0-4add5e167326'],
+      identity_entity_ids: ['f831667b-7392-7a1c-c0fc-33d48cb1c57d'],
+    };
+    for (const key in targets) {
+      if (!record.key) {
+        record.update(key, targets[key]);
       }
-    });
+    }
   },
 });

--- a/ui/mirage/handlers/mfa-config.js
+++ b/ui/mirage/handlers/mfa-config.js
@@ -168,4 +168,34 @@ export default function (server) {
     schema.db.mfaLoginEnforcements.remove({ name });
     return {};
   });
+  // endpoints for target selection
+  server.get('/identity/group/id', () => ({
+    data: {
+      key_info: { '34db6b52-591e-bc22-8af0-4add5e167326': { name: 'test-group' } },
+      keys: ['34db6b52-591e-bc22-8af0-4add5e167326'],
+    },
+  }));
+  server.get('/identity/group/id/:id', () => ({
+    data: {
+      id: '34db6b52-591e-bc22-8af0-4add5e167326',
+      name: 'test-group',
+    },
+  }));
+  server.get('/identity/entity/id', () => ({
+    data: {
+      key_info: { 'f831667b-7392-7a1c-c0fc-33d48cb1c57d': { name: 'test-entity' } },
+      keys: ['f831667b-7392-7a1c-c0fc-33d48cb1c57d'],
+    },
+  }));
+  server.get('/identity/entity/id/:id', () => ({
+    data: {
+      id: 'f831667b-7392-7a1c-c0fc-33d48cb1c57d',
+      name: 'test-entity',
+    },
+  }));
+  server.get('/sys/auth', () => ({
+    data: {
+      'userpass/': { accessor: 'auth_userpass_bb95c2b1', type: 'userpass' },
+    },
+  }));
 }

--- a/ui/tests/acceptance/mfa-login-enforcement-test.js
+++ b/ui/tests/acceptance/mfa-login-enforcement-test.js
@@ -1,0 +1,215 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { click, currentRouteName, fillIn, visit } from '@ember/test-helpers';
+import authPage from 'vault/tests/pages/auth';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import ENV from 'vault/config/environment';
+
+module('Acceptance | mfa-login-enforcement', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.before(function () {
+    ENV['ember-cli-mirage'].handler = 'mfaConfig';
+  });
+  hooks.beforeEach(function () {
+    return authPage.login();
+  });
+  hooks.after(function () {
+    ENV['ember-cli-mirage'].handler = null;
+  });
+
+  test('it should create login enforcement', async function (assert) {
+    await visit('/ui/vault/access');
+    await click('[data-test-link="mfa"]');
+    await click('[data-test-tab="enforcements"]');
+    await click('[data-test-enforcement-create]');
+
+    assert.dom('[data-test-mleh-title]').hasText('New enforcement', 'Title renders');
+    await click('[data-test-mlef-save]');
+    assert
+      .dom('[data-test-inline-error-message]')
+      .exists({ count: 3 }, 'Validation error messages are displayed');
+
+    await click('[data-test-mlef-cancel]');
+    assert.equal(
+      currentRouteName(),
+      'vault.cluster.access.mfa.enforcements.index',
+      'Cancel transitions to enforcements list'
+    );
+    await click('[data-test-enforcement-create]');
+    await click('.breadcrumb a');
+    assert.equal(
+      currentRouteName(),
+      'vault.cluster.access.mfa.enforcements.index',
+      'Breadcrumb transitions to enforcements list'
+    );
+    await click('[data-test-enforcement-create]');
+
+    await fillIn('[data-test-mlef-input="name"]', 'foo');
+    await click('[data-test-component="search-select"] .ember-basic-dropdown-trigger');
+    await click('.ember-power-select-option');
+    await fillIn('[data-test-mount-accessor-select]', 'auth_userpass_bb95c2b1');
+    await click('[data-test-mlef-add-target]');
+    await click('[data-test-mlef-save]');
+    assert.equal(
+      currentRouteName(),
+      'vault.cluster.access.mfa.enforcements.enforcement.index',
+      'Route transitions to enforcement on save success'
+    );
+  });
+
+  test('it should list login enforcements', async function (assert) {
+    await visit('/vault/access/mfa/enforcements');
+    assert.dom('[data-test-tab="enforcements"]').hasClass('active', 'Enforcements tab is active');
+    assert.dom('.toolbar-link').exists({ count: 1 }, 'Correct number of toolbar links render');
+    assert
+      .dom('[data-test-enforcement-create]')
+      .includesText('New enforcement', 'New enforcement link renders');
+
+    await click('[data-test-enforcement-create]');
+    assert.equal(
+      currentRouteName(),
+      'vault.cluster.access.mfa.enforcements.create',
+      'New enforcement link transitions to create route'
+    );
+    await click('[data-test-mlef-cancel]');
+
+    const enforcements = this.server.db.mfaLoginEnforcements.where({});
+    const item = enforcements[0];
+    assert.dom('[data-test-list-item]').exists({ count: enforcements.length }, 'Enforcements list renders');
+    assert
+      .dom(`[data-test-list-item="${item.name}"] svg`)
+      .hasClass('flight-icon-lock', 'Lock icon renders for list item');
+    assert.dom(`[data-test-list-item-title="${item.name}"]`).hasText(item.name, 'Enforcement name renders');
+
+    await click('[data-test-popup-menu-trigger]');
+    await click('[data-test-list-item-link="details"]');
+    assert.equal(
+      currentRouteName(),
+      'vault.cluster.access.mfa.enforcements.enforcement.index',
+      'Details more menu action transitions to enforcement route'
+    );
+    await click('.breadcrumb a');
+    await click('[data-test-popup-menu-trigger]');
+    await click('[data-test-list-item-link="edit"]');
+    assert.equal(
+      currentRouteName(),
+      'vault.cluster.access.mfa.enforcements.enforcement.edit',
+      'Edit more menu action transitions to enforcement edit route'
+    );
+  });
+
+  test('it should display login enforcement', async function (assert) {
+    await visit('/vault/access/mfa/enforcements');
+    const enforcement = this.server.db.mfaLoginEnforcements.where({})[0];
+    await click(`[data-test-list-item="${enforcement.name}"]`);
+    // heading
+    assert.dom('h1').includesText(enforcement.name, 'Name renders in title');
+    assert.dom('h1 svg').hasClass('flight-icon-lock', 'Lock icon renders in title');
+    assert.dom('[data-test-tab="targets"]').hasClass('active', 'Targets tab is active by default');
+    assert.dom('[data-test-target]').exists({ count: 4 }, 'Targets render in list');
+    // targets tab
+    const targets = {
+      accessor: ['userpass/', 'auth_userpass_bb95c2b1', '/ui/vault/access/userpass'],
+      method: ['userpass', 'All userpass mounts (1)'],
+      entity: [
+        'test-entity',
+        'f831667b-7392-7a1c-c0fc-33d48cb1c57d',
+        '/ui/vault/access/identity/entities/f831667b-7392-7a1c-c0fc-33d48cb1c57d/details',
+      ],
+      group: [
+        'test-group',
+        '34db6b52-591e-bc22-8af0-4add5e167326',
+        '/ui/vault/access/identity/groups/34db6b52-591e-bc22-8af0-4add5e167326/details',
+      ],
+    };
+    for (const key in targets) {
+      const t = targets[key];
+      const selector = `[data-test-target="${t[0]}"]`;
+      assert.dom(selector).includesText(`${t[0]} ${t[1]}`, `Target text renders for ${key} type`);
+      if (key !== 'method') {
+        await click(`${selector} [data-test-popup-menu-trigger]`);
+        assert
+          .dom(`[data-test-target-link="${t[0]}"]`)
+          .hasAttribute('href', t[2], `Details link renders for ${key} type`);
+      } else {
+        assert.dom(`${selector} [data-test-popup-menu-trigger]`).doesNotExist('Method type has no link');
+      }
+    }
+    // methods tab
+    await click('[data-test-tab="methods"]');
+    assert.dom('[data-test-tab="methods"]').hasClass('active', 'Methods tab is active');
+    const method = this.owner.lookup('service:store').peekRecord('mfa-method', enforcement.mfa_method_ids[0]);
+    assert
+      .dom(`[data-test-mfa-method-list-item="${method.id}"]`)
+      .includesText(
+        `${method.name} ${method.id} Namespace: ${method.namespace_id}`,
+        'Method list item renders'
+      );
+    await click('[data-test-popup-menu-trigger]');
+    assert
+      .dom(`[data-test-mfa-method-menu-link="details"]`)
+      .hasAttribute('href', `/ui/vault/access/mfa/methods/${method.id}`, `Details link renders for method`);
+    assert
+      .dom(`[data-test-mfa-method-menu-link="edit"]`)
+      .hasAttribute('href', `/ui/vault/access/mfa/methods/${method.id}/edit`, `Edit link renders for method`);
+    // toolbar
+    assert
+      .dom('[data-test-enforcement-edit]')
+      .hasAttribute(
+        'href',
+        `/ui/vault/access/mfa/enforcements/${enforcement.name}/edit`,
+        'Toolbar edit action has link to edit route'
+      );
+    await click('[data-test-enforcement-delete]');
+    assert.dom('[data-test-confirm-button]').isDisabled('Delete button disabled with no confirmation');
+    await fillIn('[data-test-confirmation-modal-input]', enforcement.name);
+    await click('[data-test-confirm-button]');
+    assert.equal(
+      currentRouteName(),
+      'vault.cluster.access.mfa.enforcements.index',
+      'Route transitions to enforcements list on delete success'
+    );
+  });
+
+  test('it should edit login enforcement', async function (assert) {
+    await visit('/vault/access/mfa/enforcements');
+    const enforcement = this.server.db.mfaLoginEnforcements.where({})[0];
+    await click('[data-test-popup-menu-trigger]');
+    await click('[data-test-list-item-link="edit"]');
+
+    assert.dom('h1').hasText('Update enforcement', 'Title renders');
+    assert.dom('[data-test-mlef-input="name"]').hasValue(enforcement.name, 'Name input is populated');
+    assert.dom('[data-test-mlef-input="name"]').isDisabled('Name is disabled and cannot be changed');
+
+    const method = this.owner.lookup('service:store').peekRecord('mfa-method', enforcement.mfa_method_ids[0]);
+    assert
+      .dom('[data-test-selected-option]')
+      .includesText(`${method.name} ${method.id}`, 'Selected mfa method renders');
+    assert
+      .dom('[data-test-mlef-target="Authentication mount"]')
+      .includesText('Authentication mount auth_userpass_bb95c2b1', 'Accessor target populates');
+    assert
+      .dom('[data-test-mlef-target="Authentication method"]')
+      .includesText('Authentication method userpass', 'Method target populates');
+    assert
+      .dom('[data-test-mlef-target="Group"]')
+      .includesText('Group test-group 34db6b52-591e-bc22-8af0-4add5e167326', 'Group target populates');
+    assert
+      .dom('[data-test-mlef-target="Entity"]')
+      .includesText('Entity test-entity f831667b-7392-7a1c-c0fc-33d48cb1c57d', 'Entity target populates');
+
+    await click('[data-test-mlef-remove-target="Entity"]');
+    await click('[data-test-mlef-remove-target="Group"]');
+    await click('[data-test-mlef-remove-target="Authentication method"]');
+    await click('[data-test-mlef-save]');
+
+    assert.equal(
+      currentRouteName(),
+      'vault.cluster.access.mfa.enforcements.enforcement.index',
+      'Route transitions to enforcement on save success'
+    );
+    assert.dom('[data-test-target]').exists({ count: 1 }, 'Targets were successfully removed on save');
+  });
+});


### PR DESCRIPTION
- adds acceptance tests for mfa config login enforcement workflows
- fixes bug setting icon for token mount when preparing login enforcement targets
- fixes bug with removing `auth_method_accessors` or `auth_method_types` not saving