### PR TITLE
secrets/kubernetes: update to v0.1.1

### DIFF
--- a/changelog/15655.txt
+++ b/changelog/15655.txt
@@ -1,0 +1,3 @@
+```release-note:change
+secrets/kubernetes: Split `additional_metadata` into `extra_annotations` and `extra_labels` parameters
+```

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-azure v0.13.0
 	github.com/hashicorp/vault-plugin-secrets-gcp v0.13.0
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.12.0
-	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.0
+	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.1
 	github.com/hashicorp/vault-plugin-secrets-kv v0.12.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -1007,8 +1007,8 @@ github.com/hashicorp/vault-plugin-secrets-gcp v0.13.0 h1:GDh70QU8yG/ObIRfKjhxfMQ
 github.com/hashicorp/vault-plugin-secrets-gcp v0.13.0/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.12.0 h1:MXqB1waq3L18eUhTZ7ng14MbjOiAlwANgZCVUwoLBXo=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.12.0/go.mod h1:6DPwGu8oGR1sZRpjwkcAnrQZWQuAJ/Ph+rQHfUo1Yf4=
-github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.0 h1:/uhsqc9MH2ymJUiFGDKpbjPw8ZCAzURG5T97UM1pBNE=
-github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.0/go.mod h1:aF9rgE2pGvWpyS/ijVrd817aA4Sf1I+dpLaKgshAPyQ=
+github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.1 h1:KiYpZpQv7X7Tm9wHUvboC2CyquwmjMhrPU2DvTcPC8o=
+github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.1/go.mod h1:aF9rgE2pGvWpyS/ijVrd817aA4Sf1I+dpLaKgshAPyQ=
 github.com/hashicorp/vault-plugin-secrets-kv v0.12.0 h1:8qQ8ANzQf2p8m6qkcYeOhe5jYV5Lse7GtpNHg88u0M4=
 github.com/hashicorp/vault-plugin-secrets-kv v0.12.0/go.mod h1:9V2Ecim3m/qw+YAQelUeFADqZ1GVo8xwoLqfKsqh9pI=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0 h1:EDyX/utLxEKGETeGAyWe4QNoKwIfCw6VpEzKLb8zudc=


### PR DESCRIPTION
Updates vault-plugin-secrets-kubernetes to [v0.1.1](https://github.com/hashicorp/vault/pull/new/k8s-secrets-0.1.1)

```console
go get github.com/hashicorp/vault-plugin-secrets-kubernetes@v0.1.1
go mod tidy
```