### PR TITLE
Updated base64 encoding of ciphertext for Transit BYOK import.

### DIFF
--- a/builtin/logical/transit/path_import.go
+++ b/builtin/logical/transit/path_import.go
@@ -198,7 +198,7 @@ func (b *backend) pathImportWrite(ctx context.Context, req *logical.Request, d *
 		return nil, errors.New("the import path cannot be used with an existing key; use import-version to rotate an existing imported key")
 	}
 
-	ciphertext, err := base64.RawURLEncoding.DecodeString(ciphertextString)
+	ciphertext, err := base64.StdEncoding.DecodeString(ciphertextString)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +251,7 @@ func (b *backend) pathImportVersionWrite(ctx context.Context, req *logical.Reque
 	}
 	defer p.Unlock()
 
-	ciphertext, err := base64.RawURLEncoding.DecodeString(ciphertextString)
+	ciphertext, err := base64.StdEncoding.DecodeString(ciphertextString)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/transit/path_import_test.go
+++ b/builtin/logical/transit/path_import_test.go
@@ -551,7 +551,7 @@ func wrapTargetKeyForImport(t *testing.T, wrappingKey *rsa.PublicKey, targetKey 
 
 	// Combined wrapped keys into a single blob and base64 encode
 	wrappedKeys := append(ephKeyWrapped, targetKeyWrapped...)
-	return base64.RawURLEncoding.EncodeToString(wrappedKeys)
+	return base64.StdEncoding.EncodeToString(wrappedKeys)
 }
 
 func generateKey(keyType string) (interface{}, error) {


### PR DESCRIPTION
# Summary
This updates the Transit BYOK import ciphertext to be standard base64 encoding as used in other input fields across Vault.