### PR TITLE
Update openldap secrets to v0.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.1
 	github.com/hashicorp/vault-plugin-secrets-kv v0.12.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0
-	github.com/hashicorp/vault-plugin-secrets-openldap v0.7.1
+	github.com/hashicorp/vault-plugin-secrets-openldap v0.8.0
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.4.0
 	github.com/hashicorp/vault-testing-stepwise v0.1.2
 	github.com/hashicorp/vault/api v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1013,8 +1013,8 @@ github.com/hashicorp/vault-plugin-secrets-kv v0.12.0 h1:8qQ8ANzQf2p8m6qkcYeOhe5j
 github.com/hashicorp/vault-plugin-secrets-kv v0.12.0/go.mod h1:9V2Ecim3m/qw+YAQelUeFADqZ1GVo8xwoLqfKsqh9pI=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0 h1:EDyX/utLxEKGETeGAyWe4QNoKwIfCw6VpEzKLb8zudc=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0/go.mod h1:PLx2vxXukfsKsDRo/PlG4fxmJ1d+H2h82wT3vf4buuI=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.7.1 h1:6ekVGKaTLgtJWTUaCeVMXNyoiuSkBlFdb+rtmHWQzOM=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.7.1/go.mod h1:XC7R76jZiuD50ENel+I1/Poz5phaEQg9d6Dko8DF3Ts=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.8.0 h1:WJk5wRg861RlTd8xN6To/sRw3SnEUzqXpWml98GPZks=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.8.0/go.mod h1:XC7R76jZiuD50ENel+I1/Poz5phaEQg9d6Dko8DF3Ts=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.4.0 h1:D7hFUGbPM25Pl5bDXoTv86D6fzjoUyKtbCm5aKvrDb4=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.4.0/go.mod h1:GzYAJYytgbNNyT3S7rspz1cLE53E1oajFbEtaDUlVGU=
 github.com/hashicorp/vault-testing-stepwise v0.1.1/go.mod h1:3vUYn6D0ZadvstNO3YQQlIcp7u1a19MdoOC0NQ0yaOE=


### PR DESCRIPTION
Updates OpenLDAP secrets engine to v0.8.0.

```
go get github.com/hashicorp/vault-plugin-secrets-openldap@v0.8.0
go mod tidy
```