### PR TITLE
AutoMTLS for secrets/auth plugins

### DIFF
--- a/api/plugin_helpers.go
+++ b/api/plugin_helpers.go
@@ -17,6 +17,10 @@ import (
 )
 
 var (
+	// PluginAutoMTLSEnv is used to ensure AutoMTLS is used. This will override
+	// setting a TLSProviderFunc for a plugin.
+	PluginAutoMTLSEnv = "VAULT_PLUGIN_AUTOMTLS"
+
 	// PluginMetadataModeEnv is an ENV name used to disable TLS communication
 	// to bootstrap mounting plugins.
 	PluginMetadataModeEnv = "VAULT_PLUGIN_METADATA_MODE"
@@ -120,7 +124,7 @@ func VaultPluginTLSProvider(apiTLSConfig *TLSConfig) func() (*tls.Config, error)
 // VaultPluginTLSProviderContext is run inside a plugin and retrieves the response
 // wrapped TLS certificate from vault. It returns a configured TLS Config.
 func VaultPluginTLSProviderContext(ctx context.Context, apiTLSConfig *TLSConfig) func() (*tls.Config, error) {
-	if os.Getenv(PluginMetadataModeEnv) == "true" {
+	if os.Getenv(PluginAutoMTLSEnv) == "true" || os.Getenv(PluginMetadataModeEnv) == "true" {
 		return nil
 	}
 

--- a/api/plugin_helpers.go
+++ b/api/plugin_helpers.go
@@ -17,8 +17,8 @@ import (
 )
 
 var (
-	// PluginAutoMTLSEnv is used to ensure AutoMTLS is used. This will override
-	// setting a TLSProviderFunc for a plugin.
+	// PluginAutoMTLSEnv ensures AutoMTLS is used. This overrides setting a
+	// TLSProviderFunc for a plugin.
 	PluginAutoMTLSEnv = "VAULT_PLUGIN_AUTOMTLS"
 
 	// PluginMetadataModeEnv is an ENV name used to disable TLS communication

--- a/builtin/plugin/backend.go
+++ b/builtin/plugin/backend.go
@@ -65,8 +65,13 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*PluginBackend, 
 	paths := raw.SpecialPaths()
 	btype := raw.Type()
 
-	// Cleanup meta plugin backend
-	raw.Cleanup(ctx)
+	// HACK: Cast to BackendPluginClient
+	if bpc, ok := raw.(*bplugin.BackendPluginClient); ok {
+		if bpc.NegotiatedVersion() < 5 {
+			// Cleanup meta plugin backend
+			raw.Cleanup(ctx)
+		}
+	}
 
 	// Initialize b.Backend with dummy backend since plugin
 	// backends will need to be lazy loaded.

--- a/builtin/plugin/backend.go
+++ b/builtin/plugin/backend.go
@@ -71,23 +71,18 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*PluginBackend, 
 
 		return &b, nil
 	}
+
+	// Setup the backend so we can inspect the SpecialPaths and Type
 	err = raw.Setup(ctx, conf)
 	if err != nil {
 		raw.Cleanup(ctx)
 		return nil, err
 	}
-	// Get SpecialPaths and BackendType
 	paths := raw.SpecialPaths()
 	btype := raw.Type()
 
-	// If the plugin doesn't support AutoMTLS, we will kill the meta plugin so
-	// that it can be lazy loaded. This is done to avoid a setup-unwrap cycle.
-	if bpc, ok := raw.(*bplugin.BackendPluginClient); ok {
-		if !bpc.AutoMTLSSupported() {
-			// Cleanup meta plugin backend
-			raw.Cleanup(ctx)
-		}
-	}
+	// Cleanup meta plugin backend
+	raw.Cleanup(ctx)
 
 	// Initialize b.Backend with dummy backend since plugin
 	// backends will need to be lazy loaded.

--- a/builtin/plugin/backend.go
+++ b/builtin/plugin/backend.go
@@ -9,6 +9,7 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 
+	"github.com/hashicorp/go-multierror"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -51,13 +52,16 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*PluginBackend, 
 
 	sys := conf.System
 
+	merr := &multierror.Error{}
 	// NewBackend with isMetadataMode set to false
 	raw, err := bplugin.NewBackend(ctx, name, pluginType, sys, conf, false, true)
 	if err != nil {
+		merr = multierror.Append(merr, err)
 		// NewBackend with isMetadataMode set to true
 		raw, err = bplugin.NewBackend(ctx, name, pluginType, sys, conf, true, false)
 		if err != nil {
-			return nil, err
+			merr = multierror.Append(merr, err)
+			return nil, merr
 		}
 	} else {
 		b.Backend = raw

--- a/builtin/plugin/backend.go
+++ b/builtin/plugin/backend.go
@@ -76,7 +76,8 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*PluginBackend, 
 	paths := raw.SpecialPaths()
 	btype := raw.Type()
 
-	// HACK: Cast to BackendPluginClient
+	// If the plugin doesn't support AutoMTLS, we will kill the meta plugin so
+	// that it can be lazy loaded. This is done to avoid a setup-unwrap cycle.
 	if bpc, ok := raw.(*bplugin.BackendPluginClient); ok {
 		if !bpc.AutoMTLSSupported() {
 			// Cleanup meta plugin backend

--- a/builtin/plugin/backend.go
+++ b/builtin/plugin/backend.go
@@ -78,7 +78,7 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*PluginBackend, 
 
 	// HACK: Cast to BackendPluginClient
 	if bpc, ok := raw.(*bplugin.BackendPluginClient); ok {
-		if bpc.NegotiatedVersion() < 5 {
+		if !bpc.AutoMTLSSupported() {
 			// Cleanup meta plugin backend
 			raw.Cleanup(ctx)
 		}

--- a/builtin/plugin/backend_lazyLoad_test.go
+++ b/builtin/plugin/backend_lazyLoad_test.go
@@ -59,7 +59,7 @@ func testLazyLoad(t *testing.T, methodWrapper func() error) *PluginBackend {
 	}
 
 	// this is a dummy plugin that hasn't really been loaded yet
-	orig, err := plugin.NewBackend(ctx, "test-plugin", consts.PluginTypeSecrets, sysView, config, true)
+	orig, err := plugin.NewBackend(ctx, "test-plugin", consts.PluginTypeSecrets, sysView, config, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/changelog/15671.txt
+++ b/changelog/15671.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugins: Use AutoMTLS for secrets engines and auth methods run as external plugins.
+```

--- a/sdk/helper/pluginutil/env.go
+++ b/sdk/helper/pluginutil/env.go
@@ -8,6 +8,10 @@ import (
 )
 
 var (
+	// PluginAutoMTLSEnv is used to ensure AutoMTLS is used. This will override
+	// setting a TLSProviderFunc for a plugin.
+	PluginAutoMTLSEnv = "VAULT_PLUGIN_AUTOMTLS"
+
 	// PluginMlockEnabled is the ENV name used to pass the configuration for
 	// enabling mlock
 	PluginMlockEnabled = "VAULT_PLUGIN_MLOCK_ENABLED"

--- a/sdk/helper/pluginutil/multiplexing.go
+++ b/sdk/helper/pluginutil/multiplexing.go
@@ -9,6 +9,8 @@ import (
 	status "google.golang.org/grpc/status"
 )
 
+const MultiplexingCtxKey string = "multiplex_id"
+
 type PluginMultiplexingServerImpl struct {
 	UnimplementedPluginMultiplexingServer
 

--- a/sdk/helper/pluginutil/run_config.go
+++ b/sdk/helper/pluginutil/run_config.go
@@ -54,6 +54,10 @@ func (rc runConfig) makeConfig(ctx context.Context) (*plugin.ClientConfig, error
 	metadataEnv := fmt.Sprintf("%s=%t", PluginMetadataModeEnv, rc.IsMetadataMode)
 	cmd.Env = append(cmd.Env, metadataEnv)
 
+	automtlsEnv := fmt.Sprintf("%s=%t", PluginAutoMTLSEnv, rc.AutoMTLS)
+	cmd.Env = append(cmd.Env, automtlsEnv)
+	rc.Logger.Debug("makeConfig", "rc.AutoMTLS", rc.AutoMTLS)
+
 	var clientTLSConfig *tls.Config
 	if !rc.AutoMTLS && !rc.IsMetadataMode {
 		// Get a CA TLS Certificate

--- a/sdk/helper/pluginutil/run_config.go
+++ b/sdk/helper/pluginutil/run_config.go
@@ -22,6 +22,7 @@ type PluginClientConfig struct {
 	IsMetadataMode  bool
 	AutoMTLS        bool
 	MLock           bool
+	Wrapper         RunnerUtil
 }
 
 type runConfig struct {
@@ -33,8 +34,6 @@ type runConfig struct {
 	// Initialized with what's in PluginRunner.Env, but can be added to
 	env []string
 
-	wrapper RunnerUtil
-
 	PluginClientConfig
 }
 
@@ -43,7 +42,7 @@ func (rc runConfig) makeConfig(ctx context.Context) (*plugin.ClientConfig, error
 	cmd.Env = append(cmd.Env, rc.env...)
 
 	// Add the mlock setting to the ENV of the plugin
-	if rc.MLock || (rc.wrapper != nil && rc.wrapper.MlockEnabled()) {
+	if rc.MLock || (rc.Wrapper != nil && rc.Wrapper.MlockEnabled()) {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", PluginMlockEnabled, "true"))
 	}
 	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", PluginVaultVersionEnv, version.GetVersion().Version))
@@ -56,7 +55,6 @@ func (rc runConfig) makeConfig(ctx context.Context) (*plugin.ClientConfig, error
 
 	automtlsEnv := fmt.Sprintf("%s=%t", PluginAutoMTLSEnv, rc.AutoMTLS)
 	cmd.Env = append(cmd.Env, automtlsEnv)
-	rc.Logger.Debug("makeConfig", "rc.AutoMTLS", rc.AutoMTLS)
 
 	var clientTLSConfig *tls.Config
 	if !rc.AutoMTLS && !rc.IsMetadataMode {
@@ -74,7 +72,7 @@ func (rc runConfig) makeConfig(ctx context.Context) (*plugin.ClientConfig, error
 
 		// Use CA to sign a server cert and wrap the values in a response wrapped
 		// token.
-		wrapToken, err := wrapServerConfig(ctx, rc.wrapper, certBytes, key)
+		wrapToken, err := wrapServerConfig(ctx, rc.Wrapper, certBytes, key)
 		if err != nil {
 			return nil, err
 		}
@@ -124,7 +122,7 @@ func Env(env ...string) RunOpt {
 
 func Runner(wrapper RunnerUtil) RunOpt {
 	return func(rc *runConfig) {
-		rc.wrapper = wrapper
+		rc.Wrapper = wrapper
 	}
 }
 

--- a/sdk/helper/pluginutil/run_config_test.go
+++ b/sdk/helper/pluginutil/run_config_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"reflect"
 	"testing"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/vault/sdk/helper/wrapping"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMakeConfig(t *testing.T) {
@@ -78,6 +78,7 @@ func TestMakeConfig(t *testing.T) {
 						"initial=true",
 						fmt.Sprintf("%s=%s", PluginVaultVersionEnv, version.GetVersion().Version),
 						fmt.Sprintf("%s=%t", PluginMetadataModeEnv, true),
+						fmt.Sprintf("%s=%t", PluginAutoMTLSEnv, false),
 					},
 				),
 				SecureConfig: &plugin.SecureConfig{
@@ -143,6 +144,7 @@ func TestMakeConfig(t *testing.T) {
 						fmt.Sprintf("%s=%t", PluginMlockEnabled, true),
 						fmt.Sprintf("%s=%s", PluginVaultVersionEnv, version.GetVersion().Version),
 						fmt.Sprintf("%s=%t", PluginMetadataModeEnv, false),
+						fmt.Sprintf("%s=%t", PluginAutoMTLSEnv, false),
 						fmt.Sprintf("%s=%s", PluginUnwrapTokenEnv, "testtoken"),
 					},
 				),
@@ -205,6 +207,7 @@ func TestMakeConfig(t *testing.T) {
 						"initial=true",
 						fmt.Sprintf("%s=%s", PluginVaultVersionEnv, version.GetVersion().Version),
 						fmt.Sprintf("%s=%t", PluginMetadataModeEnv, true),
+						fmt.Sprintf("%s=%t", PluginAutoMTLSEnv, true),
 					},
 				),
 				SecureConfig: &plugin.SecureConfig{
@@ -266,6 +269,7 @@ func TestMakeConfig(t *testing.T) {
 						"initial=true",
 						fmt.Sprintf("%s=%s", PluginVaultVersionEnv, version.GetVersion().Version),
 						fmt.Sprintf("%s=%t", PluginMetadataModeEnv, false),
+						fmt.Sprintf("%s=%t", PluginAutoMTLSEnv, true),
 					},
 				),
 				SecureConfig: &plugin.SecureConfig{
@@ -290,7 +294,7 @@ func TestMakeConfig(t *testing.T) {
 				Return(test.responseWrapInfo, test.responseWrapInfoErr)
 			mockWrapper.On("MlockEnabled").
 				Return(test.mlockEnabled)
-			test.rc.wrapper = mockWrapper
+			test.rc.Wrapper = mockWrapper
 			defer mockWrapper.AssertNumberOfCalls(t, "ResponseWrapData", test.responseWrapInfoTimes)
 			defer mockWrapper.AssertNumberOfCalls(t, "MlockEnabled", test.mlockEnabledTimes)
 
@@ -318,9 +322,7 @@ func TestMakeConfig(t *testing.T) {
 			}
 			config.TLSConfig = nil
 
-			if !reflect.DeepEqual(config, test.expectedConfig) {
-				t.Fatalf("Actual config: %#v\nExpected config: %#v", config, test.expectedConfig)
-			}
+			require.Equal(t, config, test.expectedConfig)
 		})
 	}
 }

--- a/sdk/helper/pluginutil/runner.go
+++ b/sdk/helper/pluginutil/runner.go
@@ -64,6 +64,19 @@ func (r *PluginRunner) Run(ctx context.Context, wrapper RunnerUtil, pluginSets m
 		Env(env...),
 		Logger(logger),
 		MetadataMode(false),
+	)
+}
+
+// RunAutoMTLS takes a wrapper RunnerUtil instance along with the go-plugin parameters and
+// returns a configured plugin.Client with TLS Configured via go-plugin's AutoMTLS.
+func (r *PluginRunner) RunAutoMTLS(ctx context.Context, wrapper RunnerUtil, pluginSets map[int]plugin.PluginSet, hs plugin.HandshakeConfig, env []string, logger log.Logger) (*plugin.Client, error) {
+	return r.RunConfig(ctx,
+		Runner(wrapper),
+		PluginSets(pluginSets),
+		HandshakeConfig(hs),
+		Env(env...),
+		Logger(logger),
+		MetadataMode(false),
 		AutoMTLS(true),
 	)
 }

--- a/sdk/helper/pluginutil/runner.go
+++ b/sdk/helper/pluginutil/runner.go
@@ -64,6 +64,7 @@ func (r *PluginRunner) Run(ctx context.Context, wrapper RunnerUtil, pluginSets m
 		Env(env...),
 		Logger(logger),
 		MetadataMode(false),
+		AutoMTLS(true),
 	)
 }
 

--- a/sdk/helper/pluginutil/runner.go
+++ b/sdk/helper/pluginutil/runner.go
@@ -38,8 +38,6 @@ type PluginClient interface {
 	plugin.ClientProtocol
 }
 
-const MultiplexingCtxKey string = "multiplex_id"
-
 // PluginRunner defines the metadata needed to run a plugin securely with
 // go-plugin.
 type PluginRunner struct {

--- a/sdk/helper/pluginutil/runner.go
+++ b/sdk/helper/pluginutil/runner.go
@@ -65,20 +65,6 @@ func (r *PluginRunner) Run(ctx context.Context, wrapper RunnerUtil, pluginSets m
 	)
 }
 
-// RunAutoMTLS takes a wrapper RunnerUtil instance along with the go-plugin parameters and
-// returns a configured plugin.Client with TLS Configured via go-plugin's AutoMTLS.
-func (r *PluginRunner) RunAutoMTLS(ctx context.Context, wrapper RunnerUtil, pluginSets map[int]plugin.PluginSet, hs plugin.HandshakeConfig, env []string, logger log.Logger) (*plugin.Client, error) {
-	return r.RunConfig(ctx,
-		Runner(wrapper),
-		PluginSets(pluginSets),
-		HandshakeConfig(hs),
-		Env(env...),
-		Logger(logger),
-		MetadataMode(false),
-		AutoMTLS(true),
-	)
-}
-
 // RunMetadataMode returns a configured plugin.Client that will dispense a plugin
 // in metadata mode. The PluginMetadataModeEnv is passed in as part of the Cmd to
 // plugin.Client, and consumed by the plugin process on api.VaultPluginTLSProvider.

--- a/sdk/helper/pluginutil/tls.go
+++ b/sdk/helper/pluginutil/tls.go
@@ -15,6 +15,8 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 )
 
+const BackendPluginAutoMTLSMinVersion int = 5
+
 // generateCert is used internally to create certificates for the plugin
 // client and server.
 func generateCert() ([]byte, *ecdsa.PrivateKey, error) {

--- a/sdk/helper/pluginutil/tls.go
+++ b/sdk/helper/pluginutil/tls.go
@@ -15,8 +15,6 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 )
 
-const BackendPluginAutoMTLSMinVersion int = 5
-
 // generateCert is used internally to create certificates for the plugin
 // client and server.
 func generateCert() ([]byte, *ecdsa.PrivateKey, error) {

--- a/sdk/plugin/plugin.go
+++ b/sdk/plugin/plugin.go
@@ -23,12 +23,6 @@ type BackendPluginClient struct {
 	logical.Backend
 }
 
-// AutoMTLSSupported inspects the go-plugin client's negotiated version. This
-// allows us to determine if a given client supports AutoMTLS
-func (b *BackendPluginClient) AutoMTLSSupported() bool {
-	return b.client.NegotiatedVersion() >= pluginutil.BackendPluginAutoMTLSMinVersion
-}
-
 // Cleanup calls the RPC client's Cleanup() func and also calls
 // the go-plugin's client Kill() func
 func (b *BackendPluginClient) Cleanup(ctx context.Context) {

--- a/sdk/plugin/plugin.go
+++ b/sdk/plugin/plugin.go
@@ -100,6 +100,7 @@ func NewPluginClient(ctx context.Context, sys pluginutil.RunnerUtil, pluginRunne
 	}
 
 	namedLogger := logger.Named(pluginRunner.Name)
+	namedLogger.Debug("sdk NewPluginClient", "isMetadataMode", isMetadataMode)
 
 	var client *plugin.Client
 	var err error

--- a/sdk/plugin/plugin.go
+++ b/sdk/plugin/plugin.go
@@ -64,7 +64,6 @@ func NewBackend(ctx context.Context, pluginName string, pluginType consts.Plugin
 			}
 		}
 	} else {
-		// create a backendPluginClient instance
 		config := pluginutil.PluginClientConfig{
 			Name:           pluginName,
 			PluginType:     pluginType,
@@ -110,10 +109,10 @@ func NewPluginClient(ctx context.Context, pluginRunner *pluginutil.PluginRunner,
 
 	var client *plugin.Client
 	var err error
-	if config.IsMetadataMode {
-		client, err = pluginRunner.RunMetadataMode(ctx, config.Wrapper, pluginSet, handshakeConfig, []string{}, config.Logger)
-	} else if config.AutoMTLS {
+	if config.AutoMTLS {
 		client, err = pluginRunner.RunAutoMTLS(ctx, config.Wrapper, pluginSet, handshakeConfig, []string{}, config.Logger)
+	} else if config.IsMetadataMode {
+		client, err = pluginRunner.RunMetadataMode(ctx, config.Wrapper, pluginSet, handshakeConfig, []string{}, config.Logger)
 	} else {
 		client, err = pluginRunner.Run(ctx, config.Wrapper, pluginSet, handshakeConfig, []string{}, config.Logger)
 	}

--- a/sdk/plugin/plugin.go
+++ b/sdk/plugin/plugin.go
@@ -24,6 +24,11 @@ type BackendPluginClient struct {
 	logical.Backend
 }
 
+// HACK: Exposed negotiated version
+func (b *BackendPluginClient) NegotiatedVersion() int {
+	return b.client.NegotiatedVersion()
+}
+
 // Cleanup calls the RPC client's Cleanup() func and also calls
 // the go-plugin's client Kill() func
 func (b *BackendPluginClient) Cleanup(ctx context.Context) {
@@ -84,6 +89,12 @@ func NewPluginClient(ctx context.Context, sys pluginutil.RunnerUtil, pluginRunne
 		4: {
 			"backend": &GRPCBackendPlugin{
 				MetadataMode: isMetadataMode,
+			},
+		},
+		5: {
+			"backend": &GRPCBackendPlugin{
+				MetadataMode:      false,
+				AutoMTLSSupported: true,
 			},
 		},
 	}

--- a/sdk/plugin/plugin.go
+++ b/sdk/plugin/plugin.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/go-multierror"
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/pluginutil"
@@ -109,40 +108,19 @@ func pluginSet(autoMTLS, metadataMode bool) map[int]plugin.PluginSet {
 }
 
 func NewPluginClient(ctx context.Context, pluginRunner *pluginutil.PluginRunner, config pluginutil.PluginClientConfig) (logical.Backend, error) {
-	var client *plugin.Client
-	var err error
-	merr := &multierror.Error{}
 	ps := pluginSet(config.AutoMTLS, config.IsMetadataMode)
 
-	// Best effort attempt to run with the version 5 plugin set which supports
-	// autoMTLS if that's the set returned
-	client, err = pluginRunner.RunConfig(ctx,
+	client, err := pluginRunner.RunConfig(ctx,
 		pluginutil.Runner(config.Wrapper),
 		pluginutil.PluginSets(ps),
 		pluginutil.HandshakeConfig(handshakeConfig),
 		pluginutil.Env(),
 		pluginutil.Logger(config.Logger),
-		pluginutil.MetadataMode(config.IsMetadataMode && !config.AutoMTLS),
+		pluginutil.MetadataMode(config.IsMetadataMode),
 		pluginutil.AutoMTLS(config.AutoMTLS),
 	)
-	// This is the fallback: If we error with a v5 plugin set then try again,
-	// but force the old plugin set
-	if config.AutoMTLS && err != nil {
-		merr = multierror.Append(merr, err)
-
-		ps = pluginSet(false, config.IsMetadataMode)
-		client, err = pluginRunner.RunConfig(ctx,
-			pluginutil.Runner(config.Wrapper),
-			pluginutil.PluginSets(ps),
-			pluginutil.HandshakeConfig(handshakeConfig),
-			pluginutil.Env(),
-			pluginutil.Logger(config.Logger),
-			pluginutil.MetadataMode(config.IsMetadataMode),
-		)
-	}
 	if err != nil {
-		merr = multierror.Append(merr, err)
-		return nil, merr
+		return nil, err
 	}
 
 	// Connect via RPC

--- a/sdk/plugin/serve.go
+++ b/sdk/plugin/serve.go
@@ -55,6 +55,13 @@ func Serve(opts *ServeOpts) error {
 				Logger:  logger,
 			},
 		},
+		5: {
+			"backend": &GRPCBackendPlugin{
+				Factory:           opts.BackendFactoryFunc,
+				Logger:            logger,
+				AutoMTLSSupported: true,
+			},
+		},
 	}
 
 	err := pluginutil.OptionallyEnableMlock()

--- a/sdk/plugin/serve.go
+++ b/sdk/plugin/serve.go
@@ -37,12 +37,13 @@ func Serve(opts *ServeOpts) error {
 		})
 	}
 
-	// pluginMap is the map of plugins we can dispense.
+	// pluginSets is the map of plugins we can dispense.
 	pluginSets := map[int]plugin.PluginSet{
 		// Version 3 used to supports both protocols. We want to keep it around
 		// since it's possible old plugins built against this version will still
 		// work with gRPC. There is currently no difference between version 3
 		// and version 4.
+		// AutoMTLS is not supported by versions lower than 5.
 		3: {
 			"backend": &GRPCBackendPlugin{
 				Factory: opts.BackendFactoryFunc,

--- a/vault/logical_system_integ_test.go
+++ b/vault/logical_system_integ_test.go
@@ -31,257 +31,306 @@ const (
 	expectedEnvValue = "BAR"
 )
 
-func TestSystemBackend_Plugin_secret_v4(t *testing.T) {
-	cluster := testSystemBackendMockV4(t, 1, 1, logical.TypeLogical)
-	defer cluster.Cleanup()
+// logicalVersionMap is a map of version to test plugin
+var logicalVersionMap = map[string]string{
+	"v4": "TestBackend_PluginMain_V4_Logical",
+	"v5": "TestBackend_PluginMainLogical",
+}
 
-	core := cluster.Cores[0]
-
-	// Make a request to lazy load the plugin
-	req := logical.TestRequest(t, logical.ReadOperation, "mock-0/internal")
-	req.ClientToken = core.Client.Token()
-	resp, err := core.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if resp == nil {
-		t.Fatalf("bad: response should not be nil")
-	}
-
-	// Seal the cluster
-	cluster.EnsureCoresSealed(t)
-
-	// Unseal the cluster
-	barrierKeys := cluster.BarrierKeys
-	for _, core := range cluster.Cores {
-		for _, key := range barrierKeys {
-			_, err := core.Unseal(vault.TestKeyCopy(key))
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-		if core.Sealed() {
-			t.Fatal("should not be sealed")
-		}
-		// Wait for active so post-unseal takes place
-		// If it fails, it means unseal process failed
-		vault.TestWaitActive(t, core.Core)
-	}
+// credentialVersionMap is a map of version to test plugin
+var credentialVersionMap = map[string]string{
+	"v4": "TestBackend_PluginMain_V4_Credentials",
+	"v5": "TestBackend_PluginMainCredentials",
 }
 
 func TestSystemBackend_Plugin_secret(t *testing.T) {
-	cluster := testSystemBackendMock(t, 1, 1, logical.TypeLogical)
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0]
-
-	// Make a request to lazy load the plugin
-	req := logical.TestRequest(t, logical.ReadOperation, "mock-0/internal")
-	req.ClientToken = core.Client.Token()
-	resp, err := core.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if resp == nil {
-		t.Fatalf("bad: response should not be nil")
+	testCases := []struct {
+		pluginVersion string
+	}{
+		{
+			pluginVersion: "v5",
+		},
+		{
+			pluginVersion: "v4",
+		},
 	}
 
-	// Seal the cluster
-	cluster.EnsureCoresSealed(t)
+	for _, tc := range testCases {
+		t.Run(tc.pluginVersion, func(t *testing.T) {
+			cluster := testSystemBackendMock(t, 1, 1, logical.TypeLogical, tc.pluginVersion)
+			defer cluster.Cleanup()
 
-	// Unseal the cluster
-	barrierKeys := cluster.BarrierKeys
-	for _, core := range cluster.Cores {
-		for _, key := range barrierKeys {
-			_, err := core.Unseal(vault.TestKeyCopy(key))
+			core := cluster.Cores[0]
+
+			// Make a request to lazy load the plugin
+			req := logical.TestRequest(t, logical.ReadOperation, "mock-0/internal")
+			req.ClientToken = core.Client.Token()
+			resp, err := core.HandleRequest(namespace.RootContext(nil), req)
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("err: %v", err)
 			}
-		}
-		if core.Sealed() {
-			t.Fatal("should not be sealed")
-		}
-		// Wait for active so post-unseal takes place
-		// If it fails, it means unseal process failed
-		vault.TestWaitActive(t, core.Core)
+			if resp == nil {
+				t.Fatalf("bad: response should not be nil")
+			}
+
+			// Seal the cluster
+			cluster.EnsureCoresSealed(t)
+
+			// Unseal the cluster
+			barrierKeys := cluster.BarrierKeys
+			for _, core := range cluster.Cores {
+				for _, key := range barrierKeys {
+					_, err := core.Unseal(vault.TestKeyCopy(key))
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				if core.Sealed() {
+					t.Fatal("should not be sealed")
+				}
+				// Wait for active so post-unseal takes place
+				// If it fails, it means unseal process failed
+				vault.TestWaitActive(t, core.Core)
+			}
+		})
 	}
 }
 
 func TestSystemBackend_Plugin_auth(t *testing.T) {
-	cluster := testSystemBackendMock(t, 1, 1, logical.TypeCredential)
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0]
-
-	// Make a request to lazy load the plugin
-	req := logical.TestRequest(t, logical.ReadOperation, "auth/mock-0/internal")
-	req.ClientToken = core.Client.Token()
-	resp, err := core.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if resp == nil {
-		t.Fatalf("bad: response should not be nil")
+	testCases := []struct {
+		pluginVersion string
+	}{
+		{
+			pluginVersion: "v5",
+		},
+		{
+			pluginVersion: "v4",
+		},
 	}
 
-	// Seal the cluster
-	cluster.EnsureCoresSealed(t)
+	for _, tc := range testCases {
+		t.Run(tc.pluginVersion, func(t *testing.T) {
+			cluster := testSystemBackendMock(t, 1, 1, logical.TypeCredential, tc.pluginVersion)
+			defer cluster.Cleanup()
 
-	// Unseal the cluster
-	barrierKeys := cluster.BarrierKeys
-	for _, core := range cluster.Cores {
-		for _, key := range barrierKeys {
-			_, err := core.Unseal(vault.TestKeyCopy(key))
+			core := cluster.Cores[0]
+
+			// Make a request to lazy load the plugin
+			req := logical.TestRequest(t, logical.ReadOperation, "auth/mock-0/internal")
+			req.ClientToken = core.Client.Token()
+			resp, err := core.HandleRequest(namespace.RootContext(nil), req)
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("err: %v", err)
 			}
-		}
-		if core.Sealed() {
-			t.Fatal("should not be sealed")
-		}
-		// Wait for active so post-unseal takes place
-		// If it fails, it means unseal process failed
-		vault.TestWaitActive(t, core.Core)
+			if resp == nil {
+				t.Fatalf("bad: response should not be nil")
+			}
+
+			// Seal the cluster
+			cluster.EnsureCoresSealed(t)
+
+			// Unseal the cluster
+			barrierKeys := cluster.BarrierKeys
+			for _, core := range cluster.Cores {
+				for _, key := range barrierKeys {
+					_, err := core.Unseal(vault.TestKeyCopy(key))
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				if core.Sealed() {
+					t.Fatal("should not be sealed")
+				}
+				// Wait for active so post-unseal takes place
+				// If it fails, it means unseal process failed
+				vault.TestWaitActive(t, core.Core)
+			}
+		})
 	}
 }
 
 func TestSystemBackend_Plugin_MissingBinary(t *testing.T) {
-	cluster := testSystemBackendMock(t, 1, 1, logical.TypeLogical)
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0]
-
-	// Make a request to lazy load the plugin
-	req := logical.TestRequest(t, logical.ReadOperation, "mock-0/internal")
-	req.ClientToken = core.Client.Token()
-	resp, err := core.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if resp == nil {
-		t.Fatalf("bad: response should not be nil")
+	testCases := []struct {
+		pluginVersion string
+	}{
+		{
+			pluginVersion: "v5",
+		},
+		{
+			pluginVersion: "v4",
+		},
 	}
 
-	// Seal the cluster
-	cluster.EnsureCoresSealed(t)
+	for _, tc := range testCases {
+		t.Run(tc.pluginVersion, func(t *testing.T) {
+			cluster := testSystemBackendMock(t, 1, 1, logical.TypeLogical, tc.pluginVersion)
+			defer cluster.Cleanup()
 
-	// Simulate removal of the plugin binary. Use os.Args to determine file name
-	// since that's how we create the file for catalog registration in the test
-	// helper.
-	pluginFileName := filepath.Base(os.Args[0])
-	err = os.Remove(filepath.Join(cluster.TempDir, pluginFileName))
-	if err != nil {
-		t.Fatal(err)
-	}
+			core := cluster.Cores[0]
 
-	// Unseal the cluster
-	cluster.UnsealCores(t)
+			// Make a request to lazy load the plugin
+			req := logical.TestRequest(t, logical.ReadOperation, "mock-0/internal")
+			req.ClientToken = core.Client.Token()
+			resp, err := core.HandleRequest(namespace.RootContext(nil), req)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if resp == nil {
+				t.Fatalf("bad: response should not be nil")
+			}
 
-	// Make a request against on tune after it is removed
-	req = logical.TestRequest(t, logical.ReadOperation, "sys/mounts/mock-0/tune")
-	req.ClientToken = core.Client.Token()
-	resp, err = core.HandleRequest(namespace.RootContext(nil), req)
-	if err == nil {
-		t.Fatalf("expected error")
+			// Seal the cluster
+			cluster.EnsureCoresSealed(t)
+
+			// Simulate removal of the plugin binary. Use os.Args to determine file name
+			// since that's how we create the file for catalog registration in the test
+			// helper.
+			pluginFileName := filepath.Base(os.Args[0])
+			err = os.Remove(filepath.Join(cluster.TempDir, pluginFileName))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Unseal the cluster
+			cluster.UnsealCores(t)
+
+			// Make a request against on tune after it is removed
+			req = logical.TestRequest(t, logical.ReadOperation, "sys/mounts/mock-0/tune")
+			req.ClientToken = core.Client.Token()
+			resp, err = core.HandleRequest(namespace.RootContext(nil), req)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+		})
 	}
 }
 
 func TestSystemBackend_Plugin_MismatchType(t *testing.T) {
-	cluster := testSystemBackendMock(t, 1, 1, logical.TypeLogical)
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0]
-
-	// Add a credential backend with the same name
-	vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeCredential, "TestBackend_PluginMainCredentials", []string{}, "")
-
-	// Make a request to lazy load the now-credential plugin
-	// and expect an error
-	req := logical.TestRequest(t, logical.ReadOperation, "mock-0/internal")
-	req.ClientToken = core.Client.Token()
-	_, err := core.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil {
-		t.Fatalf("adding a same-named plugin of a different type should be no problem: %s", err)
+	testCases := []struct {
+		pluginVersion string
+	}{
+		{
+			pluginVersion: "v5",
+		},
+		{
+			pluginVersion: "v4",
+		},
 	}
 
-	// Sleep a bit before cleanup is called
-	time.Sleep(1 * time.Second)
+	for _, tc := range testCases {
+		t.Run(tc.pluginVersion, func(t *testing.T) {
+			cluster := testSystemBackendMock(t, 1, 1, logical.TypeLogical, tc.pluginVersion)
+			defer cluster.Cleanup()
+
+			core := cluster.Cores[0]
+
+			// Add a credential backend with the same name
+			vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeCredential, "TestBackend_PluginMainCredentials", []string{}, "")
+
+			// Make a request to lazy load the now-credential plugin
+			// and expect an error
+			req := logical.TestRequest(t, logical.ReadOperation, "mock-0/internal")
+			req.ClientToken = core.Client.Token()
+			_, err := core.HandleRequest(namespace.RootContext(nil), req)
+			if err != nil {
+				t.Fatalf("adding a same-named plugin of a different type should be no problem: %s", err)
+			}
+
+			// Sleep a bit before cleanup is called
+			time.Sleep(1 * time.Second)
+		})
+	}
 }
 
 func TestSystemBackend_Plugin_CatalogRemoved(t *testing.T) {
 	t.Run("secret", func(t *testing.T) {
-		testPlugin_CatalogRemoved(t, logical.TypeLogical, false)
+		testPlugin_CatalogRemoved(t, logical.TypeLogical, false, logicalVersionMap)
 	})
 
 	t.Run("auth", func(t *testing.T) {
-		testPlugin_CatalogRemoved(t, logical.TypeCredential, false)
+		testPlugin_CatalogRemoved(t, logical.TypeCredential, false, credentialVersionMap)
 	})
 
 	t.Run("secret-mount-existing", func(t *testing.T) {
-		testPlugin_CatalogRemoved(t, logical.TypeLogical, true)
+		testPlugin_CatalogRemoved(t, logical.TypeLogical, true, logicalVersionMap)
 	})
 
 	t.Run("auth-mount-existing", func(t *testing.T) {
-		testPlugin_CatalogRemoved(t, logical.TypeCredential, true)
+		testPlugin_CatalogRemoved(t, logical.TypeCredential, true, credentialVersionMap)
 	})
 }
 
-func testPlugin_CatalogRemoved(t *testing.T, btype logical.BackendType, testMount bool) {
-	cluster := testSystemBackendMock(t, 1, 1, btype)
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0]
-
-	// Remove the plugin from the catalog
-	req := logical.TestRequest(t, logical.DeleteOperation, "sys/plugins/catalog/database/mock-plugin")
-	req.ClientToken = core.Client.Token()
-	resp, err := core.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%v resp:%#v", err, resp)
+func testPlugin_CatalogRemoved(t *testing.T, btype logical.BackendType, testMount bool, versionMap map[string]string) {
+	testCases := []struct {
+		pluginVersion string
+	}{
+		{
+			pluginVersion: "v5",
+		},
+		{
+			pluginVersion: "v4",
+		},
 	}
 
-	// Seal the cluster
-	cluster.EnsureCoresSealed(t)
+	for _, tc := range testCases {
+		t.Run(tc.pluginVersion, func(t *testing.T) {
+			cluster := testSystemBackendMock(t, 1, 1, logical.TypeLogical, tc.pluginVersion)
+			defer cluster.Cleanup()
 
-	// Unseal the cluster
-	barrierKeys := cluster.BarrierKeys
-	for _, core := range cluster.Cores {
-		for _, key := range barrierKeys {
-			_, err := core.Unseal(vault.TestKeyCopy(key))
-			if err != nil {
-				t.Fatal(err)
+			core := cluster.Cores[0]
+
+			// Remove the plugin from the catalog
+			req := logical.TestRequest(t, logical.DeleteOperation, "sys/plugins/catalog/database/mock-plugin")
+			req.ClientToken = core.Client.Token()
+			resp, err := core.HandleRequest(namespace.RootContext(nil), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%v resp:%#v", err, resp)
 			}
-		}
-		if core.Sealed() {
-			t.Fatal("should not be sealed")
-		}
-	}
 
-	// Wait for active so post-unseal takes place
-	// If it fails, it means unseal process failed
-	vault.TestWaitActive(t, core.Core)
+			// Seal the cluster
+			cluster.EnsureCoresSealed(t)
 
-	if testMount {
-		// Mount the plugin at the same path after plugin is re-added to the catalog
-		// and expect an error due to existing path.
-		var err error
-		switch btype {
-		case logical.TypeLogical:
-			// Add plugin back to the catalog
-			vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeSecrets, "TestBackend_PluginMainLogical", []string{}, "")
-			_, err = core.Client.Logical().Write("sys/mounts/mock-0", map[string]interface{}{
-				"type": "test",
-			})
-		case logical.TypeCredential:
-			// Add plugin back to the catalog
-			vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeCredential, "TestBackend_PluginMainCredentials", []string{}, "")
-			_, err = core.Client.Logical().Write("sys/auth/mock-0", map[string]interface{}{
-				"type": "test",
-			})
-		}
-		if err == nil {
-			t.Fatal("expected error when mounting on existing path")
-		}
+			// Unseal the cluster
+			barrierKeys := cluster.BarrierKeys
+			for _, core := range cluster.Cores {
+				for _, key := range barrierKeys {
+					_, err := core.Unseal(vault.TestKeyCopy(key))
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				if core.Sealed() {
+					t.Fatal("should not be sealed")
+				}
+			}
+
+			// Wait for active so post-unseal takes place
+			// If it fails, it means unseal process failed
+			vault.TestWaitActive(t, core.Core)
+
+			if testMount {
+				// Mount the plugin at the same path after plugin is re-added to the catalog
+				// and expect an error due to existing path.
+				var err error
+				switch btype {
+				case logical.TypeLogical:
+					// Add plugin back to the catalog
+					vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeSecrets, logicalVersionMap[tc.pluginVersion], []string{}, "")
+					_, err = core.Client.Logical().Write("sys/mounts/mock-0", map[string]interface{}{
+						"type": "test",
+					})
+				case logical.TypeCredential:
+					// Add plugin back to the catalog
+					vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeCredential, credentialVersionMap[tc.pluginVersion], []string{}, "")
+					_, err = core.Client.Logical().Write("sys/auth/mock-0", map[string]interface{}{
+						"type": "test",
+					})
+				}
+				if err == nil {
+					t.Fatal("expected error when mounting on existing path")
+				}
+			}
+		})
 	}
 }
 
@@ -316,168 +365,215 @@ func TestSystemBackend_Plugin_continueOnError(t *testing.T) {
 }
 
 func testPlugin_continueOnError(t *testing.T, btype logical.BackendType, mismatch bool, mountPoint string, pluginType consts.PluginType) {
-	cluster := testSystemBackendMock(t, 1, 1, btype)
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0]
-
-	// Get the registered plugin
-	req := logical.TestRequest(t, logical.ReadOperation, fmt.Sprintf("sys/plugins/catalog/%s/mock-plugin", pluginType))
-	req.ClientToken = core.Client.Token()
-	resp, err := core.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || resp == nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%v resp:%#v", err, resp)
+	testCases := []struct {
+		pluginVersion string
+	}{
+		{
+			pluginVersion: "v5",
+		},
+		{
+			pluginVersion: "v4",
+		},
 	}
 
-	command, ok := resp.Data["command"].(string)
-	if !ok || command == "" {
-		t.Fatal("invalid command")
-	}
+	for _, tc := range testCases {
+		t.Run(tc.pluginVersion, func(t *testing.T) {
+			cluster := testSystemBackendMock(t, 1, 1, btype, tc.pluginVersion)
+			defer cluster.Cleanup()
 
-	// Trigger a sha256 mismatch or missing plugin error
-	if mismatch {
-		req = logical.TestRequest(t, logical.UpdateOperation, fmt.Sprintf("sys/plugins/catalog/%s/mock-plugin", pluginType))
-		req.Data = map[string]interface{}{
-			"sha256":  "d17bd7334758e53e6fbab15745d2520765c06e296f2ce8e25b7919effa0ac216",
-			"command": filepath.Base(command),
-		}
-		req.ClientToken = core.Client.Token()
-		resp, err = core.HandleRequest(namespace.RootContext(nil), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%v resp:%#v", err, resp)
-		}
-	} else {
-		err := os.Remove(filepath.Join(cluster.TempDir, filepath.Base(command)))
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
+			core := cluster.Cores[0]
 
-	// Seal the cluster
-	cluster.EnsureCoresSealed(t)
-
-	// Unseal the cluster
-	barrierKeys := cluster.BarrierKeys
-	for _, core := range cluster.Cores {
-		for _, key := range barrierKeys {
-			_, err := core.Unseal(vault.TestKeyCopy(key))
-			if err != nil {
-				t.Fatal(err)
+			// Get the registered plugin
+			req := logical.TestRequest(t, logical.ReadOperation, fmt.Sprintf("sys/plugins/catalog/%s/mock-plugin", pluginType))
+			req.ClientToken = core.Client.Token()
+			resp, err := core.HandleRequest(namespace.RootContext(nil), req)
+			if err != nil || resp == nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%v resp:%#v", err, resp)
 			}
-		}
-		if core.Sealed() {
-			t.Fatal("should not be sealed")
-		}
-	}
 
-	// Wait for active so post-unseal takes place
-	// If it fails, it means unseal process failed
-	vault.TestWaitActive(t, core.Core)
+			command, ok := resp.Data["command"].(string)
+			if !ok || command == "" {
+				t.Fatal("invalid command")
+			}
 
-	// Re-add the plugin to the catalog
-	switch btype {
-	case logical.TypeLogical:
-		vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeSecrets, "TestBackend_PluginMainLogical", []string{}, cluster.TempDir)
-	case logical.TypeCredential:
-		vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeCredential, "TestBackend_PluginMainCredentials", []string{}, cluster.TempDir)
-	}
+			// Trigger a sha256 mismatch or missing plugin error
+			if mismatch {
+				req = logical.TestRequest(t, logical.UpdateOperation, fmt.Sprintf("sys/plugins/catalog/%s/mock-plugin", pluginType))
+				req.Data = map[string]interface{}{
+					"sha256":  "d17bd7334758e53e6fbab15745d2520765c06e296f2ce8e25b7919effa0ac216",
+					"command": filepath.Base(command),
+				}
+				req.ClientToken = core.Client.Token()
+				resp, err = core.HandleRequest(namespace.RootContext(nil), req)
+				if err != nil || (resp != nil && resp.IsError()) {
+					t.Fatalf("err:%v resp:%#v", err, resp)
+				}
+			} else {
+				err := os.Remove(filepath.Join(cluster.TempDir, filepath.Base(command)))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	// Reload the plugin
-	req = logical.TestRequest(t, logical.UpdateOperation, "sys/plugins/reload/backend")
-	req.Data = map[string]interface{}{
-		"plugin": "mock-plugin",
-	}
-	req.ClientToken = core.Client.Token()
-	resp, err = core.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%v resp:%#v", err, resp)
-	}
+			// Seal the cluster
+			cluster.EnsureCoresSealed(t)
 
-	// Make a request to lazy load the plugin
-	var reqPath string
-	switch btype {
-	case logical.TypeLogical:
-		reqPath = "mock-0/internal"
-	case logical.TypeCredential:
-		reqPath = "auth/mock-0/internal"
-	}
+			// Unseal the cluster
+			barrierKeys := cluster.BarrierKeys
+			for _, core := range cluster.Cores {
+				for _, key := range barrierKeys {
+					_, err := core.Unseal(vault.TestKeyCopy(key))
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				if core.Sealed() {
+					t.Fatal("should not be sealed")
+				}
+			}
 
-	req = logical.TestRequest(t, logical.ReadOperation, reqPath)
-	req.ClientToken = core.Client.Token()
-	resp, err = core.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if resp == nil {
-		t.Fatalf("bad: response should not be nil")
+			// Wait for active so post-unseal takes place
+			// If it fails, it means unseal process failed
+			vault.TestWaitActive(t, core.Core)
+
+			// Re-add the plugin to the catalog
+			switch btype {
+			case logical.TypeLogical:
+				plugin := logicalVersionMap[tc.pluginVersion]
+				vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeSecrets, plugin, []string{}, cluster.TempDir)
+			case logical.TypeCredential:
+				plugin := credentialVersionMap[tc.pluginVersion]
+				vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeCredential, plugin, []string{}, cluster.TempDir)
+			}
+
+			// Reload the plugin
+			req = logical.TestRequest(t, logical.UpdateOperation, "sys/plugins/reload/backend")
+			req.Data = map[string]interface{}{
+				"plugin": "mock-plugin",
+			}
+			req.ClientToken = core.Client.Token()
+			resp, err = core.HandleRequest(namespace.RootContext(nil), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%v resp:%#v", err, resp)
+			}
+
+			// Make a request to lazy load the plugin
+			var reqPath string
+			switch btype {
+			case logical.TypeLogical:
+				reqPath = "mock-0/internal"
+			case logical.TypeCredential:
+				reqPath = "auth/mock-0/internal"
+			}
+
+			req = logical.TestRequest(t, logical.ReadOperation, reqPath)
+			req.ClientToken = core.Client.Token()
+			resp, err = core.HandleRequest(namespace.RootContext(nil), req)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if resp == nil {
+				t.Fatalf("bad: response should not be nil")
+			}
+		})
 	}
 }
 
 func TestSystemBackend_Plugin_autoReload(t *testing.T) {
-	cluster := testSystemBackendMock(t, 1, 1, logical.TypeLogical)
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0]
-
-	// Update internal value
-	req := logical.TestRequest(t, logical.UpdateOperation, "mock-0/internal")
-	req.ClientToken = core.Client.Token()
-	req.Data["value"] = "baz"
-	resp, err := core.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if resp != nil {
-		t.Fatalf("bad: %v", resp)
+	testCases := []struct {
+		pluginVersion string
+	}{
+		{
+			pluginVersion: "v5",
+		},
+		{
+			pluginVersion: "v4",
+		},
 	}
 
-	// Call errors/rpc endpoint to trigger reload
-	req = logical.TestRequest(t, logical.ReadOperation, "mock-0/errors/rpc")
-	req.ClientToken = core.Client.Token()
-	resp, err = core.HandleRequest(namespace.RootContext(nil), req)
-	if err == nil {
-		t.Fatalf("expected error from error/rpc request")
-	}
+	for _, tc := range testCases {
+		t.Run(tc.pluginVersion, func(t *testing.T) {
+			cluster := testSystemBackendMock(t, 1, 1, logical.TypeLogical, tc.pluginVersion)
+			defer cluster.Cleanup()
 
-	// Check internal value to make sure it's reset
-	req = logical.TestRequest(t, logical.ReadOperation, "mock-0/internal")
-	req.ClientToken = core.Client.Token()
-	resp, err = core.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if resp == nil {
-		t.Fatalf("bad: response should not be nil")
-	}
-	if resp.Data["value"].(string) == "baz" {
-		t.Fatal("did not expect backend internal value to be 'baz'")
+			core := cluster.Cores[0]
+
+			// Update internal value
+			req := logical.TestRequest(t, logical.UpdateOperation, "mock-0/internal")
+			req.ClientToken = core.Client.Token()
+			req.Data["value"] = "baz"
+			resp, err := core.HandleRequest(namespace.RootContext(nil), req)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if resp != nil {
+				t.Fatalf("bad: %v", resp)
+			}
+
+			// Call errors/rpc endpoint to trigger reload
+			req = logical.TestRequest(t, logical.ReadOperation, "mock-0/errors/rpc")
+			req.ClientToken = core.Client.Token()
+			resp, err = core.HandleRequest(namespace.RootContext(nil), req)
+			if err == nil {
+				t.Fatalf("expected error from error/rpc request")
+			}
+
+			// Check internal value to make sure it's reset
+			req = logical.TestRequest(t, logical.ReadOperation, "mock-0/internal")
+			req.ClientToken = core.Client.Token()
+			resp, err = core.HandleRequest(namespace.RootContext(nil), req)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if resp == nil {
+				t.Fatalf("bad: response should not be nil")
+			}
+			if resp.Data["value"].(string) == "baz" {
+				t.Fatal("did not expect backend internal value to be 'baz'")
+			}
+		})
 	}
 }
 
 func TestSystemBackend_Plugin_SealUnseal(t *testing.T) {
-	cluster := testSystemBackendMock(t, 1, 1, logical.TypeLogical)
-	defer cluster.Cleanup()
-
-	// Seal the cluster
-	cluster.EnsureCoresSealed(t)
-
-	// Unseal the cluster
-	barrierKeys := cluster.BarrierKeys
-	for _, core := range cluster.Cores {
-		for _, key := range barrierKeys {
-			_, err := core.Unseal(vault.TestKeyCopy(key))
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-		if core.Sealed() {
-			t.Fatal("should not be sealed")
-		}
+	testCases := []struct {
+		pluginVersion string
+	}{
+		{
+			pluginVersion: "v5",
+		},
+		{
+			pluginVersion: "v4",
+		},
 	}
 
-	// Wait for active so post-unseal takes place
-	// If it fails, it means unseal process failed
-	vault.TestWaitActive(t, cluster.Cores[0].Core)
+	for _, tc := range testCases {
+		t.Run(tc.pluginVersion, func(t *testing.T) {
+			cluster := testSystemBackendMock(t, 1, 1, logical.TypeLogical, tc.pluginVersion)
+			defer cluster.Cleanup()
+
+			// Seal the cluster
+			cluster.EnsureCoresSealed(t)
+
+			// Unseal the cluster
+			barrierKeys := cluster.BarrierKeys
+			for _, core := range cluster.Cores {
+				for _, key := range barrierKeys {
+					_, err := core.Unseal(vault.TestKeyCopy(key))
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				if core.Sealed() {
+					t.Fatal("should not be sealed")
+				}
+			}
+
+			// Wait for active so post-unseal takes place
+			// If it fails, it means unseal process failed
+			vault.TestWaitActive(t, cluster.Cores[0].Core)
+		})
+	}
 }
 
 func TestSystemBackend_Plugin_reload(t *testing.T) {
@@ -524,127 +620,69 @@ func TestSystemBackend_Plugin_reload(t *testing.T) {
 
 // Helper func to test different reload methods on plugin reload endpoint
 func testSystemBackend_PluginReload(t *testing.T, reqData map[string]interface{}, backendType logical.BackendType) {
-	cluster := testSystemBackendMock(t, 1, 2, backendType)
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0]
-	client := core.Client
-
-	pathPrefix := "mock-"
-	if backendType == logical.TypeCredential {
-		pathPrefix = "auth/" + pathPrefix
+	testCases := []struct {
+		pluginVersion string
+	}{
+		{
+			pluginVersion: "v5",
+		},
+		{
+			pluginVersion: "v4",
+		},
 	}
-	for i := 0; i < 2; i++ {
-		// Update internal value in the backend
-		resp, err := client.Logical().Write(fmt.Sprintf("%s%d/internal", pathPrefix, i), map[string]interface{}{
-			"value": "baz",
+
+	for _, tc := range testCases {
+		t.Run(tc.pluginVersion, func(t *testing.T) {
+			cluster := testSystemBackendMock(t, 1, 2, backendType, tc.pluginVersion)
+			defer cluster.Cleanup()
+
+			core := cluster.Cores[0]
+			client := core.Client
+
+			pathPrefix := "mock-"
+			if backendType == logical.TypeCredential {
+				pathPrefix = "auth/" + pathPrefix
+			}
+			for i := 0; i < 2; i++ {
+				// Update internal value in the backend
+				resp, err := client.Logical().Write(fmt.Sprintf("%s%d/internal", pathPrefix, i), map[string]interface{}{
+					"value": "baz",
+				})
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
+				if resp != nil {
+					t.Fatalf("bad: %v", resp)
+				}
+			}
+
+			// Perform plugin reload
+			resp, err := client.Logical().Write("sys/plugins/reload/backend", reqData)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if resp == nil {
+				t.Fatalf("bad: %v", resp)
+			}
+			if resp.Data["reload_id"] == nil {
+				t.Fatal("no reload_id in response")
+			}
+
+			for i := 0; i < 2; i++ {
+				// Ensure internal backed value is reset
+				resp, err := client.Logical().Read(fmt.Sprintf("%s%d/internal", pathPrefix, i))
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
+				if resp == nil {
+					t.Fatalf("bad: response should not be nil")
+				}
+				if resp.Data["value"].(string) == "baz" {
+					t.Fatal("did not expect backend internal value to be 'baz'")
+				}
+			}
 		})
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		if resp != nil {
-			t.Fatalf("bad: %v", resp)
-		}
 	}
-
-	// Perform plugin reload
-	resp, err := client.Logical().Write("sys/plugins/reload/backend", reqData)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if resp == nil {
-		t.Fatalf("bad: %v", resp)
-	}
-	if resp.Data["reload_id"] == nil {
-		t.Fatal("no reload_id in response")
-	}
-
-	for i := 0; i < 2; i++ {
-		// Ensure internal backed value is reset
-		resp, err := client.Logical().Read(fmt.Sprintf("%s%d/internal", pathPrefix, i))
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		if resp == nil {
-			t.Fatalf("bad: response should not be nil")
-		}
-		if resp.Data["value"].(string) == "baz" {
-			t.Fatal("did not expect backend internal value to be 'baz'")
-		}
-	}
-}
-
-// testSystemBackendMockV4 returns a systemBackend with the desired number
-// of mounted mock plugin backends. numMounts alternates between different
-// ways of providing the plugin_name.
-//
-// The mounts are mounted at sys/mounts/mock-[numMounts] or sys/auth/mock-[numMounts]
-func testSystemBackendMockV4(t *testing.T, numCores, numMounts int, backendType logical.BackendType) *vault.TestCluster {
-	coreConfig := &vault.CoreConfig{
-		LogicalBackends: map[string]logical.Factory{
-			"plugin": plugin.Factory,
-		},
-		CredentialBackends: map[string]logical.Factory{
-			"plugin": plugin.Factory,
-		},
-	}
-
-	// Create a tempdir, cluster.Cleanup will clean up this directory
-	tempDir, err := ioutil.TempDir("", "vault-test-cluster")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc:        vaulthttp.Handler,
-		KeepStandbysSealed: true,
-		NumCores:           numCores,
-		TempDir:            tempDir,
-	})
-	cluster.Start()
-
-	core := cluster.Cores[0]
-	vault.TestWaitActive(t, core.Core)
-	client := core.Client
-
-	os.Setenv(pluginutil.PluginCACertPEMEnv, cluster.CACertPEMFile)
-
-	switch backendType {
-	case logical.TypeLogical:
-		vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeSecrets, "TestBackend_PluginMainLogicalV4", []string{}, tempDir)
-		for i := 0; i < numMounts; i++ {
-			// Alternate input styles for plugin_name on every other mount
-			options := map[string]interface{}{
-				"type": "mock-plugin",
-			}
-			resp, err := client.Logical().Write(fmt.Sprintf("sys/mounts/mock-%d", i), options)
-			if err != nil {
-				t.Fatalf("err: %v", err)
-			}
-			if resp != nil {
-				t.Fatalf("bad: %v", resp)
-			}
-		}
-	case logical.TypeCredential:
-		vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeCredential, "TestBackend_PluginMainCredentials", []string{}, tempDir)
-		for i := 0; i < numMounts; i++ {
-			// Alternate input styles for plugin_name on every other mount
-			options := map[string]interface{}{
-				"type": "mock-plugin",
-			}
-			resp, err := client.Logical().Write(fmt.Sprintf("sys/auth/mock-%d", i), options)
-			if err != nil {
-				t.Fatalf("err: %v", err)
-			}
-			if resp != nil {
-				t.Fatalf("bad: %v", resp)
-			}
-		}
-	default:
-		t.Fatal("unknown backend type provided")
-	}
-
-	return cluster
 }
 
 // testSystemBackendMock returns a systemBackend with the desired number
@@ -652,7 +690,7 @@ func testSystemBackendMockV4(t *testing.T, numCores, numMounts int, backendType 
 // ways of providing the plugin_name.
 //
 // The mounts are mounted at sys/mounts/mock-[numMounts] or sys/auth/mock-[numMounts]
-func testSystemBackendMock(t *testing.T, numCores, numMounts int, backendType logical.BackendType) *vault.TestCluster {
+func testSystemBackendMock(t *testing.T, numCores, numMounts int, backendType logical.BackendType, pluginVersion string) *vault.TestCluster {
 	coreConfig := &vault.CoreConfig{
 		LogicalBackends: map[string]logical.Factory{
 			"plugin": plugin.Factory,
@@ -684,7 +722,8 @@ func testSystemBackendMock(t *testing.T, numCores, numMounts int, backendType lo
 
 	switch backendType {
 	case logical.TypeLogical:
-		vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeSecrets, "TestBackend_PluginMainLogical", []string{}, tempDir)
+		plugin := logicalVersionMap[pluginVersion]
+		vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeSecrets, plugin, []string{}, tempDir)
 		for i := 0; i < numMounts; i++ {
 			// Alternate input styles for plugin_name on every other mount
 			options := map[string]interface{}{
@@ -699,7 +738,8 @@ func testSystemBackendMock(t *testing.T, numCores, numMounts int, backendType lo
 			}
 		}
 	case logical.TypeCredential:
-		vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeCredential, "TestBackend_PluginMainCredentials", []string{}, tempDir)
+		plugin := credentialVersionMap[pluginVersion]
+		vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeCredential, plugin, []string{}, tempDir)
 		for i := 0; i < numMounts; i++ {
 			// Alternate input styles for plugin_name on every other mount
 			options := map[string]interface{}{
@@ -770,7 +810,7 @@ func testSystemBackend_SingleCluster_Env(t *testing.T, env []string) *vault.Test
 	return cluster
 }
 
-func TestBackend_PluginMainLogicalV4(t *testing.T) {
+func TestBackend_PluginMain_V4_Logical(t *testing.T) {
 	args := []string{}
 	// don't run as a standalone unit test
 	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
@@ -791,6 +831,8 @@ func TestBackend_PluginMainLogicalV4(t *testing.T) {
 	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
 	flags.Parse(args)
+
+	// V4 does not support AutoMTLS so we set a TLSConfig via TLSProviderFunc
 	tlsConfig := apiClientMeta.GetTLSConfig()
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
 
@@ -825,6 +867,43 @@ func TestBackend_PluginMainLogical(t *testing.T) {
 
 	err := lplugin.Serve(&lplugin.ServeOpts{
 		BackendFactoryFunc: factoryFunc,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBackend_PluginMain_V4_Credentials(t *testing.T) {
+	args := []string{}
+	// don't run as a standalone unit test
+	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+		return
+	}
+
+	// don't run as a V5 plugin
+	if os.Getenv(pluginutil.PluginAutoMTLSEnv) == "true" {
+		return
+	}
+
+	caPEM := os.Getenv(pluginutil.PluginCACertPEMEnv)
+	if caPEM == "" {
+		t.Fatal("CA cert not passed in")
+	}
+	args = append(args, fmt.Sprintf("--ca-cert=%s", caPEM))
+
+	apiClientMeta := &api.PluginAPIClientMeta{}
+	flags := apiClientMeta.FlagSet()
+	flags.Parse(args)
+
+	// V4 does not support AutoMTLS so we set a TLSConfig via TLSProviderFunc
+	tlsConfig := apiClientMeta.GetTLSConfig()
+	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
+
+	factoryFunc := mock.FactoryType(logical.TypeCredential)
+
+	err := lplugin.Serve(&lplugin.ServeOpts{
+		BackendFactoryFunc: factoryFunc,
+		TLSProviderFunc:    tlsProviderFunc,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/vault/logical_system_integ_test.go
+++ b/vault/logical_system_integ_test.go
@@ -296,18 +296,6 @@ func testPlugin_continueOnError(t *testing.T, btype logical.BackendType, mismatc
 		t.Fatal("invalid command")
 	}
 
-	// Mount credential type plugins
-	switch btype {
-	case logical.TypeCredential:
-		vault.TestAddTestPlugin(t, core.Core, mountPoint, consts.PluginTypeCredential, "TestBackend_PluginMainCredentials", []string{}, cluster.TempDir)
-		_, err = core.Client.Logical().Write(fmt.Sprintf("sys/auth/%s", mountPoint), map[string]interface{}{
-			"type": "mock-plugin",
-		})
-		if err != nil {
-			t.Fatalf("err:%v", err)
-		}
-	}
-
 	// Trigger a sha256 mismatch or missing plugin error
 	if mismatch {
 		req = logical.TestRequest(t, logical.UpdateOperation, fmt.Sprintf("sys/plugins/catalog/%s/mock-plugin", pluginType))
@@ -673,7 +661,7 @@ func testSystemBackend_SingleCluster_Env(t *testing.T, env []string) *vault.Test
 
 func TestBackend_PluginMainLogical(t *testing.T) {
 	args := []string{}
-	if os.Getenv(pluginutil.PluginUnwrapTokenEnv) == "" && os.Getenv(pluginutil.PluginMetadataModeEnv) != "true" {
+	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
@@ -686,14 +674,11 @@ func TestBackend_PluginMainLogical(t *testing.T) {
 	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
 	flags.Parse(args)
-	tlsConfig := apiClientMeta.GetTLSConfig()
-	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
 
 	factoryFunc := mock.FactoryType(logical.TypeLogical)
 
 	err := lplugin.Serve(&lplugin.ServeOpts{
 		BackendFactoryFunc: factoryFunc,
-		TLSProviderFunc:    tlsProviderFunc,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -702,7 +687,7 @@ func TestBackend_PluginMainLogical(t *testing.T) {
 
 func TestBackend_PluginMainCredentials(t *testing.T) {
 	args := []string{}
-	if os.Getenv(pluginutil.PluginUnwrapTokenEnv) == "" && os.Getenv(pluginutil.PluginMetadataModeEnv) != "true" {
+	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
@@ -715,14 +700,11 @@ func TestBackend_PluginMainCredentials(t *testing.T) {
 	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
 	flags.Parse(args)
-	tlsConfig := apiClientMeta.GetTLSConfig()
-	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
 
 	factoryFunc := mock.FactoryType(logical.TypeCredential)
 
 	err := lplugin.Serve(&lplugin.ServeOpts{
 		BackendFactoryFunc: factoryFunc,
-		TLSProviderFunc:    tlsProviderFunc,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -751,14 +733,11 @@ func TestBackend_PluginMainEnv(t *testing.T) {
 	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
 	flags.Parse(args)
-	tlsConfig := apiClientMeta.GetTLSConfig()
-	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
 
 	factoryFunc := mock.FactoryType(logical.TypeLogical)
 
 	err := lplugin.Serve(&lplugin.ServeOpts{
 		BackendFactoryFunc: factoryFunc,
-		TLSProviderFunc:    tlsProviderFunc,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -326,7 +326,7 @@ func (c *PluginCatalog) getPluginTypeFromUnknown(ctx context.Context, logger log
 	merr = multierror.Append(merr, err)
 
 	// Attempt to run as backend plugin
-	client, err := backendplugin.NewPluginClient(ctx, nil, plugin, log.NewNullLogger(), true)
+	client, err := backendplugin.NewPluginClient(ctx, nil, plugin, log.NewNullLogger(), true, false)
 	if err == nil {
 		err := client.Setup(ctx, &logical.BackendConfig{})
 		if err != nil {

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -349,22 +349,7 @@ func (c *PluginCatalog) getBackendPluginType(ctx context.Context, pluginRunner *
 	// Attempt to run as backend V5 plugin
 	c.logger.Debug("attempting to load backend plugin", "name", pluginRunner.Name)
 	client, err := backendplugin.NewPluginClient(ctx, pluginRunner, config)
-	if err == nil {
-		err := client.Setup(ctx, &logical.BackendConfig{})
-		if err != nil {
-			return consts.PluginTypeUnknown, err
-		}
-
-		backendType := client.Type()
-		client.Cleanup(ctx)
-
-		switch backendType {
-		case logical.TypeCredential:
-			return consts.PluginTypeCredential, nil
-		case logical.TypeLogical:
-			return consts.PluginTypeSecrets, nil
-		}
-	} else {
+	if err != nil {
 		merr = multierror.Append(merr, err)
 		c.logger.Debug("failed to dispense v5 backend plugin", "name", pluginRunner.Name, "error", err)
 		config.AutoMTLS = false

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -325,8 +325,13 @@ func (c *PluginCatalog) getPluginTypeFromUnknown(ctx context.Context, logger log
 	}
 	merr = multierror.Append(merr, err)
 
-	// Attempt to run as backend plugin
-	client, err := backendplugin.NewPluginClient(ctx, nil, plugin, log.NewNullLogger(), true, false)
+	config := pluginutil.PluginClientConfig{
+		Name:           plugin.Name,
+		Logger:         log.NewNullLogger(),
+		IsMetadataMode: true,
+	}
+	c.logger.Debug("attempting to load backend plugin", "name", plugin.Name)
+	client, err := backendplugin.NewPluginClient(ctx, plugin, config)
 	if err == nil {
 		err := client.Setup(ctx, &logical.BackendConfig{})
 		if err != nil {


### PR DESCRIPTION
Use go-plugin's AutoMTLS feature for secrets/auth plugins. This will require a version bump (v5) for the PluginSet that go-plugin can dispense.

This change is transparent to vault plugin developers. To take advantage of AutoMTLS, a vault operator must recompile their plugin.

Note that MetadataMode is _not_ used for plugin registration for plugins compiled with these changes.