### PR TITLE
auth/gcp: adds documentation for custom endpoint overrides

### DIFF
--- a/website/content/api-docs/auth/gcp.mdx
+++ b/website/content/api-docs/auth/gcp.mdx
@@ -29,19 +29,11 @@ to confirm signed JWTs passed in during login.
 
 ### Parameters
 
-- `credentials` `(string: "")` - A JSON string containing the contents
-  of a GCP credentials file. The credentials file must have the following
-  [permissions](https://cloud.google.com/compute/docs/access/iam):
-
-  ```
-  iam.serviceAccounts.get
-  iam.serviceAccountKeys.get
-  ```
-
-  If this value is empty, Vault will try to use [Application Default
-  Credentials][gcp-adc] from the machine on which the Vault server is running.
-
-  The project must have the `iam.googleapis.com` API [enabled](https://console.cloud.google.com/flows/enableapi?apiid=iam.googleapis.com).
+- `credentials` `(string: "")` - A JSON string containing the contents of a GCP
+  service account credentials file. The service account associated with the credentials
+  file must have the following [permissions](/docs/auth/gcp#required-gcp-permissions).
+  If this value is empty, Vault will try to use [Application Default Credentials][gcp-adc]
+  from the machine on which the Vault server is running.
 
 - `iam_alias` `(string: "role_id")` - Must be either `unique_id` or `role_id`.
   If `unique_id` is specified, the service account's unique ID will be used for
@@ -73,6 +65,21 @@ to confirm signed JWTs passed in during login.
   **Only select fields that will have a low rate of change** for your `gce_alias` because
   each change triggers a storage write and can have a performance impact at scale.
   Only used if role `type` is `gce`.
+
+- `custom_endpoint` `(map<string|string>: <optional>)` - Specifies overrides to
+  [service endpoints](https://cloud.google.com/apis/design/glossary#api_service_endpoint)
+  used when making API requests. This allows specific requests made during authentication
+  to target alternative service endpoints for use in [Private Google Access](https://cloud.google.com/vpc/docs/configure-private-google-access)
+  environments.
+
+  Overrides are set at the subdomain level using the following keys:
+  - `api` - Replaces the service endpoint used in API requests to `https://www.googleapis.com`.
+  - `iam` - Replaces the service endpoint used in API requests to `https://iam.googleapis.com`.
+  - `crm` - Replaces the service endpoint used in API requests to `https://cloudresourcemanager.googleapis.com`.
+  - `compute` - Replaces the service endpoint used in API requests to `https://compute.googleapis.com`.
+
+  The value provided for a given key generally take the form of `scheme://host:port`. The
+  `scheme://` and `:port` portions are optional and may be omitted.
 
 ### Sample Payload
 

--- a/website/content/api-docs/auth/gcp.mdx
+++ b/website/content/api-docs/auth/gcp.mdx
@@ -78,8 +78,8 @@ to confirm signed JWTs passed in during login.
   - `crm` - Replaces the service endpoint used in API requests to `https://cloudresourcemanager.googleapis.com`.
   - `compute` - Replaces the service endpoint used in API requests to `https://compute.googleapis.com`.
 
-  The value provided for a given key generally take the form of `scheme://host:port`. The
-  `scheme://` and `:port` portions are optional and may be omitted.
+  The endpoint value provided for a given key has the form of `scheme://host:port`.
+  The `scheme://` and `:port` portions of the endpoint value are optional.
 
 ### Sample Payload
 

--- a/website/content/docs/auth/gcp.mdx
+++ b/website/content/docs/auth/gcp.mdx
@@ -144,15 +144,28 @@ https://www.googleapis.com/auth/cloud-platform
 
 ### Required GCP Permissions
 
+#### Enabled GCP APIs
+
+The GCP project must have the following APIs enabled:
+
+- [iam.googleapis.com](https://console.cloud.google.com/flows/enableapi?apiid=iam.googleapis.com)
+  for `iam` and `gce` type roles.
+- [compute.googleapis.com](https://console.cloud.google.com/flows/enableapi?apiid=compute.googleapis.com)
+  for `gce` type roles.
+- [cloudresourcemanager.googleapis.com](https://console.cloud.google.com/flows/enableapi?apiid=cloudresourcemanager.googleapis.com)
+  for `iam` and `gce` type roles that set [`add_group_aliases`](/api-docs/auth/gcp#add_group_aliases) to true.
+
 #### Vault Server Permissions
 
-**For `iam`-type Vault roles**, Vault can be given the following roles:
+**For `iam`-type Vault roles**, the service account [`credentials`](/api-docs/auth/gcp#credentials)
+given to Vault can have the following role:
 
 ```text
 roles/iam.serviceAccountKeyAdmin
 ```
 
-**For `gce`-type Vault roles**, Vault can be given the following roles:
+**For `gce`-type Vault roles**, the service account [`credentials`](/api-docs/auth/gcp#credentials)
+given to Vault can have the following role:
 
 ```text
 roles/compute.viewer


### PR DESCRIPTION
This PR adds documentation for the custom endpoint configuration added to the GCP auth method in https://github.com/hashicorp/vault-plugin-auth-gcp/pull/126.

Additionally, it consolidates documentation around service account permissions and GCP APIs that need to be enabled for specific configs.