### PR TITLE
docs/k8s: updated helm doc for short-lived SA tokens

### DIFF
--- a/website/content/docs/platform/k8s/helm/examples/kubernetes-auth.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/kubernetes-auth.mdx
@@ -14,33 +14,19 @@ In this example, we will walk through how to set up the [Kubernetes Auth Method]
 
 This assumes the following commands will be run inside a Vault pod running in Kubernetes.
 
-You will optionally need the following variables:
-
-```bash
-# JWT is a service account token that has access to the Kubernetes TokenReview API
-# You can retrieve this from inside a pod at: /var/run/secrets/kubernetes.io/serviceaccount/token
-JWT=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-
-# Address of Kubernetes itself as viewed from inside a running pod
-KUBERNETES_HOST=https://${KUBERNETES_PORT_443_TCP_ADDR}:443
-
-# Kubernetes internal CA
-KUBERNETES_CA_CERT=$(cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt)
-```
-
 Exec into the Vault pod:
 
 ```bash
-kubectl exec -it vault-0 /bin/sh
+kubectl exec -it vault-0 -- /bin/sh
 ```
 
-Then run the following command to configure the Kubernetes Auth Method:
+If you didn't set `server.dev.enabled=true`, you'll need to log in to Vault first using `vault login`.
+Then run the following commands to configure the Kubernetes Auth Method:
 
 ```bash
+vault auth enable kubernetes
 vault write auth/kubernetes/config \
-   token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-   kubernetes_host=https://${KUBERNETES_PORT_443_TCP_ADDR}:443 \
-   kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    kubernetes_host=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT
 ```
 
 From here you can continue to configure Vault from the [Kubernetes Auth Method](/vault/docs/auth/kubernetes) documentation.


### PR DESCRIPTION
Helm docs still have example for Kubernetes Auth Method that store the SA token in configuration https://www.vaultproject.io/docs/platform/k8s/helm/examples/kubernetes-auth. Update the example to allow rotated tokens to be reloaded automatically.

xref #15390

Signed-off-by: Tero Saarni <tero.saarni@est.tech>