### PR TITLE
updates `leasId` to `leaseId`

### DIFF
--- a/changelog/15685.txt
+++ b/changelog/15685.txt
@@ -1,0 +1,3 @@
+```release-note:bug 
+ui: Updated `leasId` to `leaseId` in the "Copy Credentials" section of "Generate AWS Credentials"
+```

--- a/ui/app/models/aws-credential.js
+++ b/ui/app/models/aws-credential.js
@@ -69,7 +69,7 @@ export default Model.extend({
       accessKey: this.accessKey,
       secretKey: this.secretKey,
       securityToken: this.securityToken,
-      leasId: this.leaseId,
+      leaseId: this.leaseId,
     };
     const propsWithVals = Object.keys(props).reduce((ret, prop) => {
       if (props[prop]) {


### PR DESCRIPTION
Hello maintainers! 👋🏼 

While working on some demos with the AWS backend, I noticed that in the _Generate AWS Credentials_ screen, when clicking on the blue _Copy credentials_ button, the following payload is copied:

```json
{
"accessKey": "AKIAIOSFODNN7EXAMPLE",
"secretKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
"leasId": "aws/creds/consumer/L0mkTBzIsjki3jojjgrcICVo.at2AD"
}
```

I believe that `leasId` ought to be `leaseId`, in line with `this.leaseId`.