### PR TITLE
docs: Improve sample commands for querying k8s API

### DIFF
--- a/website/content/docs/auth/jwt/oidc_providers.mdx
+++ b/website/content/docs/auth/jwt/oidc_providers.mdx
@@ -339,11 +339,7 @@ Configuration steps:
 1. Find the issuer URL of the cluster.
 
    ```bash
-   kubectl proxy &
-   ISSUER="$(curl --fail --silent --show-error 127.0.0.1:8001/.well-known/openid-configuration | jq -r '.issuer')"
-
-   # Kill the background proxy process when you're done
-   kill %%
+   ISSUER="$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')"
    ```
 
 1. Enable and configure JWT auth in Vault.
@@ -395,16 +391,10 @@ Configuration steps:
 
    ```bash
    # 1. Find the issuer URL of the cluster.
-   kubectl proxy &
-   ISSUER="$(curl --fail --silent --show-error 127.0.0.1:8001/.well-known/openid-configuration | jq -r '.issuer')"
+   ISSUER="$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')"
 
    # 2. Query the jwks_uri specified in /.well-known/openid-configuration
-   # NB: You may need to run this from a pod within the cluster if the $ISSUER
-   # URL is not available outside the cluster.
-   curl "$(curl --fail --silent --show-error "${ISSUER}/.well-known/openid-configuration" | jq -r '.jwks_uri')"
-
-   # Kill the background proxy process when you're done
-   kill %%
+   kubectl get --raw "$(kubectl get --raw /.well-known/openid-configuration | jq -r '.jwks_uri' | sed -r 's/.*\.[^\/]+(.*)/\1/')"
    ```
 
 1. Convert the keys from JWK format to PEM. You can use a CLI tool or an online

--- a/website/content/docs/auth/jwt/oidc_providers.mdx
+++ b/website/content/docs/auth/jwt/oidc_providers.mdx
@@ -394,7 +394,7 @@ Configuration steps:
    ISSUER="$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')"
 
    # 2. Query the jwks_uri specified in /.well-known/openid-configuration
-   kubectl get --raw "$(kubectl get --raw /.well-known/openid-configuration | jq -r '.jwks_uri' | sed -r 's/.*\.[^\/]+(.*)/\1/')"
+   kubectl get --raw "$(kubectl get --raw /.well-known/openid-configuration | jq -r '.jwks_uri' | sed -r 's/.*\.[^/]+(.*)/\1/')"
    ```
 
 1. Convert the keys from JWK format to PEM. You can use a CLI tool or an online

--- a/website/content/docs/auth/kubernetes.mdx
+++ b/website/content/docs/auth/kubernetes.mdx
@@ -262,28 +262,18 @@ unable to check this value directly, you can run the following and look for the
 `"iss"` field to find the required value:
 
 ```bash
-kubectl proxy &
-curl --silent http://127.0.0.1:8001/api/v1/namespaces/default/serviceaccounts/default/token \
-  -H "Content-Type: application/json" \
-  -X POST \
-  -d '{"apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest"}' \
+echo '{"apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest"}' \
+  | kubectl create -f- --raw /api/v1/namespaces/default/serviceaccounts/default/token \
   | jq -r '.status.token' \
   | cut -d . -f2 \
   | base64 -D
-
-# Kill the background proxy process when you're done
-kill %%
 ```
 
 Most clusters will also have that information available at the
 `.well-known/openid-configuration` endpoint:
 
 ```bash
-kubectl proxy &
-curl --silent http://127.0.0.1:8001/.well-known/openid-configuration | jq -r .issuer
-
-# Kill the background proxy process when you're done
-kill %%
+kubectl get --raw /.well-known/openid-configuration | jq -r .issuer
 ```
 
 This value is then used when configuring Kubernetes auth, e.g.:


### PR DESCRIPTION
I learned about the `--raw` option recently, which helps avoid the complications of running the proxy in the background for sample commands that interact with the k8s API.