### PR TITLE
Add caching for CRT Go builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      # cache/restore go mod
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Setup go
         uses: actions/setup-go@v2
         with:
@@ -120,7 +129,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
+      # cache/restore go mod
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Setup go
         uses: actions/setup-go@v2
         with:
@@ -195,7 +212,15 @@ jobs:
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:
       - uses: actions/checkout@v2
-
+      # cache/restore go mod
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/Library/Caches/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Setup go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Adds caching to the CRT Go builds based on the recommended config from here: https://github.com/actions/cache/blob/14c4fd4871149762bbba2312aaf4b031861333d5/examples.md#go---modules

Purely added for speed/DX, as I noticed the checks take quite a long time on PRs.