### PR TITLE
Add integration tests for aliased PKI paths (root/rotate, root/replace)

### DIFF
--- a/builtin/logical/pki/integation_test.go
+++ b/builtin/logical/pki/integation_test.go
@@ -1,0 +1,228 @@
+package pki
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_RotateRootUsesNext(t *testing.T) {
+	b, s := createBackendWithStorage(t)
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "root/rotate/internal",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"common_name": "test.com",
+		},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "failed rotate root")
+	require.NotNil(t, resp, "got nil response from rotate root")
+	require.False(t, resp.IsError(), "got an error from rotate root: %#v", resp)
+
+	issuerId1 := resp.Data["issuer_id"].(issuerID)
+	issuerName1 := resp.Data["issuer_name"]
+
+	require.NotEmpty(t, issuerId1, "issuer id was empty on initial rotate root command")
+	require.Equal(t, "next", issuerName1, "expected an issuer name of next on initial rotate root command")
+
+	// Call it again, we should get a new issuer id, but since next issuer_name is used we should get a blank value.
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "root/rotate/internal",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"common_name": "test.com",
+		},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "failed rotate root")
+	require.NotNil(t, resp, "got nil response from rotate root")
+	require.False(t, resp.IsError(), "got an error from rotate root: %#v", resp)
+
+	issuerId2 := resp.Data["issuer_id"].(issuerID)
+	issuerName2 := resp.Data["issuer_name"]
+
+	require.NotEmpty(t, issuerId2, "issuer id was empty on second rotate root command")
+	require.NotEqual(t, issuerId1, issuerId2, "should have been different issuer ids")
+	require.Empty(t, issuerName2, "expected a blank issuer name on the second rotate root command")
+
+	// Call it again, making sure we can use our own name if desired.
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "root/rotate/internal",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"common_name": "test.com",
+			"issuer_name": "next-cert",
+		},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "failed rotate root")
+	require.NotNil(t, resp, "got nil response from rotate root")
+	require.False(t, resp.IsError(), "got an error from rotate root: %#v", resp)
+
+	issuerId3 := resp.Data["issuer_id"].(issuerID)
+	issuerName3 := resp.Data["issuer_name"]
+
+	require.NotEmpty(t, issuerId3, "issuer id was empty on third rotate root command")
+	require.NotEqual(t, issuerId3, issuerId1, "should have been different issuer id from initial")
+	require.NotEqual(t, issuerId3, issuerId2, "should have been different issuer id from second call")
+	require.Equal(t, "next-cert", issuerName3, "expected an issuer name that we specified on third rotate root command")
+}
+
+func TestIntegration_ReplaceRootNormal(t *testing.T) {
+	b, s := createBackendWithStorage(t)
+
+	// generate roots
+	genTestRootCa(t, b, s)
+	issuerId2, _ := genTestRootCa(t, b, s)
+
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "root/replace",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"default": issuerId2.String(),
+		},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "failed replacing root")
+	require.NotNil(t, resp, "got nil response from replacing root")
+	require.False(t, resp.IsError(), "got an error from replacing root: %#v", resp)
+
+	replacedIssuer := resp.Data["default"]
+	require.Equal(t, issuerId2, replacedIssuer, "expected return value to match issuer we set")
+
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation:  logical.ReadOperation,
+		Path:       "config/issuers",
+		Storage:    s,
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "failed replacing root")
+	require.NotNil(t, resp, "got nil response from replacing root")
+	require.False(t, resp.IsError(), "got an error from replacing root: %#v", resp)
+
+	defaultIssuer := resp.Data["default"]
+	require.Equal(t, issuerId2, defaultIssuer, "expected default issuer to be updated")
+}
+
+func TestIntegration_ReplaceRootDefaultsToNext(t *testing.T) {
+	b, s := createBackendWithStorage(t)
+
+	// generate roots
+	genTestRootCa(t, b, s)
+	issuerId2, _ := genTestRootCaWithIssuerName(t, b, s, "next")
+
+	// Do not specify the default value to replace.
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation:  logical.UpdateOperation,
+		Path:       "root/replace",
+		Storage:    s,
+		Data:       map[string]interface{}{},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "failed replacing root")
+	require.NotNil(t, resp, "got nil response from replacing root")
+	require.False(t, resp.IsError(), "got an error from replacing root: %#v", resp)
+
+	replacedIssuer := resp.Data["default"]
+	require.Equal(t, issuerId2, replacedIssuer, "expected return value to match the 'next' issuer we set")
+
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation:  logical.ReadOperation,
+		Path:       "config/issuers",
+		Storage:    s,
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "failed replacing root")
+	require.NotNil(t, resp, "got nil response from replacing root")
+	require.False(t, resp.IsError(), "got an error from replacing root: %#v", resp)
+
+	defaultIssuer := resp.Data["default"]
+	require.Equal(t, issuerId2, defaultIssuer, "expected default issuer to be updated")
+}
+
+func TestIntegration_ReplaceRootBadIssuer(t *testing.T) {
+	b, s := createBackendWithStorage(t)
+
+	// generate roots
+	genTestRootCa(t, b, s)
+	genTestRootCa(t, b, s)
+
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "root/replace",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"default": "a-bad-issuer-id",
+		},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "failed replacing root, should have been an error in the response.")
+	require.NotNil(t, resp, "got nil response from replacing root")
+	require.True(t, resp.IsError(), "did not get an error from replacing root: %#v", resp)
+
+	// Make sure we trap replacing with default.
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "root/replace",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"default": "default",
+		},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "failed replacing root, should have been an error in the response.")
+	require.NotNil(t, resp, "got nil response from replacing root")
+	require.True(t, resp.IsError(), "did not get an error from replacing root: %#v", resp)
+
+	// Make sure we trap replacing with blank string.
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "root/replace",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"default": "",
+		},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "failed replacing root, should have been an error in the response.")
+	require.NotNil(t, resp, "got nil response from replacing root")
+	require.True(t, resp.IsError(), "did not get an error from replacing root: %#v", resp)
+}
+
+func genTestRootCa(t *testing.T, b *backend, s logical.Storage) (issuerID, keyID) {
+	return genTestRootCaWithIssuerName(t, b, s, "")
+}
+
+func genTestRootCaWithIssuerName(t *testing.T, b *backend, s logical.Storage, issuerName string) (issuerID, keyID) {
+	data := map[string]interface{}{
+		"common_name": "test.com",
+	}
+	if len(issuerName) > 0 {
+		data["issuer_name"] = issuerName
+	}
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation:  logical.UpdateOperation,
+		Path:       "issuers/generate/root/internal",
+		Storage:    s,
+		Data:       data,
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "failed generating root ca")
+	require.NotNil(t, resp, "got nil response from generating root ca")
+	require.False(t, resp.IsError(), "got an error from generating root ca: %#v", resp)
+
+	issuerId := resp.Data["issuer_id"].(issuerID)
+	keyId := resp.Data["key_id"].(keyID)
+
+	require.NotEmpty(t, issuerId, "returned issuer id was empty")
+	require.NotEmpty(t, keyId, "returned key id was empty")
+
+	return issuerId, keyId
+}

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -231,6 +231,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 	resp.Data["issuer_id"] = myIssuer.ID
 	resp.Data["issuer_name"] = myIssuer.Name
 	resp.Data["key_id"] = myKey.ID
+	resp.Data["key_name"] = myKey.Name
 
 	// Also store it as just the certificate identified by serial number, so it
 	// can be revoked

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -229,6 +229,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 		return nil, err
 	}
 	resp.Data["issuer_id"] = myIssuer.ID
+	resp.Data["issuer_name"] = myIssuer.Name
 	resp.Data["key_id"] = myKey.ID
 
 	// Also store it as just the certificate identified by serial number, so it

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1204,6 +1204,14 @@ use the values set via `config/urls`.
   for more details about managed keys](#managed-keys). This parameter is part
   of the request URL.
 
+- `issuer_name` `(string: "")` - Provides a name to the specified issuer. The
+  name must be unique across all issuers and not be the reserved value
+  `default`.
+
+- `key_name` `(string: "")` - When a new key is created with this request,
+  optionally specifies the name for this. The global ref `default` may not
+  be used as a name.
+
 - `common_name` `(string: <required>)` - Specifies the requested CN for the
   certificate. If more than one `common_name` is desired, specify the
   alternative names in the `alt_names` list.
@@ -1349,9 +1357,14 @@ $ curl \
   "lease_duration": 0,
   "renewable": false,
   "data": {
+    "expiration": "1654105687",
     "certificate": "-----BEGIN CERTIFICATE-----\nMIIDzDCCAragAwIBAgIUOd0ukLcjH43TfTHFG9qE0FtlMVgwCwYJKoZIhvcNAQEL\n...\numkqeYeO30g1uYvDuWLXVA==\n-----END CERTIFICATE-----\n",
     "issuing_ca": "-----BEGIN CERTIFICATE-----\nMIIDzDCCAragAwIBAgIUOd0ukLcjH43TfTHFG9qE0FtlMVgwCwYJKoZIhvcNAQEL\n...\numkqeYeO30g1uYvDuWLXVA==\n-----END CERTIFICATE-----\n",
-    "serial_number": "39:dd:2e:90:b7:23:1f:8d:d3:7d:31:c5:1b:da:84:d0:5b:65:31:58"
+    "serial_number": "39:dd:2e:90:b7:23:1f:8d:d3:7d:31:c5:1b:da:84:d0:5b:65:31:58",
+    "issuer_id": "7b493f17-6c08-ff73-cf1a-99bfcc448a73",
+    "issuer_name": "",
+    "key_id": "22b82e37-529d-7251-7d78-3862bfd069ac",
+    "key_name": ""
   },
   "auth": null
 }


### PR DESCRIPTION
 - Add tests for the two api endpoints
 - Also return the issuer_name and key_name fields within the generate root api response
 - Update api-docs for Generate Root to match what we return as api response and the params we accept.