### PR TITLE
Option to show radio button in form field

### DIFF
--- a/ui/app/models/mfa-method.js
+++ b/ui/app/models/mfa-method.js
@@ -137,18 +137,21 @@ export default class MfaMethod extends Model {
   qr_size;
   @attr('string', {
     label: 'Algorithm',
+    editType: 'radio',
     possibleValues: ['SHA1', 'SHA256', 'SHA512'],
     subText: 'The hashing algorithm used to generate the TOTP code.',
   })
   algorithm;
   @attr('number', {
     label: 'Digits',
+    editType: 'radio',
     possibleValues: [6, 8],
     subText: 'The number digits in the generated TOTP code.',
   })
   digits;
   @attr('number', {
     label: 'Skew',
+    editType: 'radio',
     possibleValues: [0, 1],
     subText: 'The number of delay periods allowed when validating a TOTP token.',
   })

--- a/ui/app/models/mfa-method.js
+++ b/ui/app/models/mfa-method.js
@@ -145,14 +145,14 @@ export default class MfaMethod extends Model {
   @attr('number', {
     label: 'Digits',
     editType: 'radio',
-    possibleValues: [6, 8],
+    possibleValues: ['6', '8'],
     subText: 'The number digits in the generated TOTP code.',
   })
   digits;
   @attr('number', {
     label: 'Skew',
     editType: 'radio',
-    possibleValues: [0, 1],
+    possibleValues: ['0', '1'],
     subText: 'The number of delay periods allowed when validating a TOTP token.',
   })
   skew;

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -27,12 +27,12 @@
             <RadioButton
               class="radio"
               name={{@attr.name}}
-              id={{or val.value val}}
+              id={{dasherize (or val.value val)}}
               @value={{or val.value val}}
               @onChange={{this.setAndBroadcast}}
               @groupValue={{(get @model this.valuePath)}}
             />
-            <label for={{or val.value val}} class="has-left-margin-xs">
+            <label for={{dasherize (or val.value val)}} class="has-left-margin-xs">
               {{or val.value val}}
             </label>
           </div>

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -20,22 +20,42 @@
     {{/unless}}
   {{/unless}}
   {{#if @attr.options.possibleValues}}
-    <div class="control is-expanded">
-      <div class="select is-fullwidth">
-        <select name={{@attr.name}} id={{@attr.name}} onchange={{this.onChangeWithEvent}} data-test-input={{@attr.name}}>
-          {{#if @attr.options.noDefault}}
-            <option value="">
-              Select one
-            </option>
-          {{/if}}
-          {{#each (path-or-array @attr.options.possibleValues @model) as |val|}}
-            <option selected={{eq (get @model this.valuePath) (or val.value val)}} value={{or val.value val}}>
-              {{or val.displayName val}}
-            </option>
-          {{/each}}
-        </select>
+    {{#if (eq @attr.options.editType "radio")}}
+      <div class="control columns is-gapless" data-test-radio-input>
+        {{#each (path-or-array @attr.options.possibleValues @model) as |val|}}
+          <div class="column is-1 is-flex-center has-text-grey">
+            <RadioButton
+              class="radio"
+              name={{@attr.name}}
+              id={{or val.value val}}
+              @value={{or val.value val}}
+              @onChange={{this.setAndBroadcast}}
+              @groupValue={{(get @model this.valuePath)}}
+            />
+            <label for={{or val.value val}} class="has-left-margin-xs">
+              {{or val.value val}}
+            </label>
+          </div>
+        {{/each}}
       </div>
-    </div>
+    {{else}}
+      <div class="control is-expanded">
+        <div class="select is-fullwidth">
+          <select name={{@attr.name}} id={{@attr.name}} onchange={{this.onChangeWithEvent}} data-test-input={{@attr.name}}>
+            {{#if @attr.options.noDefault}}
+              <option value="">
+                Select one
+              </option>
+            {{/if}}
+            {{#each (path-or-array @attr.options.possibleValues @model) as |val|}}
+              <option selected={{eq (get @model this.valuePath) (or val.value val)}} value={{or val.value val}}>
+                {{or val.displayName val}}
+              </option>
+            {{/each}}
+          </select>
+        </div>
+      </div>
+    {{/if}}
   {{else if (and (eq @attr.type "string") (eq @attr.options.editType "boolean"))}}
     <div class="b-checkbox">
       <input

--- a/ui/lib/core/addon/components/ttl-picker2.js
+++ b/ui/lib/core/addon/components/ttl-picker2.js
@@ -68,7 +68,7 @@ export default TtlForm.extend({
 
     let time = 30;
     let unit = 's';
-    let setEnable = this.enableTTL;
+    let setEnable = this.hideToggle || this.enableTTL;
     if (!!enable || typeOf(enable) === 'boolean') {
       // This allows non-boolean values passed in to be evaluated for truthiness
       setEnable = !!enable;
@@ -128,7 +128,7 @@ export default TtlForm.extend({
   handleChange() {
     let { time, unit, enableTTL, seconds } = this;
     const ttl = {
-      enabled: enableTTL,
+      enabled: this.hideToggle || enableTTL,
       seconds,
       timeString: time + unit,
       goSafeTimeString: goSafeConvertFromSeconds(seconds, unit),

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -121,6 +121,27 @@ module('Integration | Component | form field', function (hooks) {
     assert.ok(spy.calledWith('foo', expectedSeconds), 'onChange called with correct args');
   });
 
+  test('it renders: editType ttl without toggle', async function (assert) {
+    let [model, spy] = await setup.call(this, createAttr('foo', null, { editType: 'ttl', hideToggle: true }));
+    await component.fields.objectAt(0).select('h').change();
+    await component.fields.objectAt(0).ttlTime('3');
+    const expectedSeconds = `${3 * 3600}s`;
+    assert.equal(model.get('foo'), expectedSeconds);
+    assert.ok(spy.calledWith('foo', expectedSeconds), 'onChange called with correct args');
+  });
+
+  test('it renders: radio buttons for possible values', async function (assert) {
+    let [model, spy] = await setup.call(
+      this,
+      createAttr('foo', null, { editType: 'radio', possibleValues: ['SHA1', 'SHA256'] })
+    );
+    assert.ok(component.hasRadio, 'renders radio buttons');
+    const selectedValue = 'SHA256';
+    await component.selectRadioInput(selectedValue);
+    assert.equal(model.get('foo'), selectedValue);
+    assert.ok(spy.calledWith('foo', selectedValue), 'onChange called with correct args');
+  });
+
   test('it renders: editType stringArray', async function (assert) {
     let [model, spy] = await setup.call(this, createAttr('foo', 'string', { editType: 'stringArray' }));
     assert.ok(component.hasStringList, 'renders the string-list component');

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -1,6 +1,7 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
+import { dasherize } from '@ember/string';
 import { render, click, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { create } from 'ember-cli-page-object';
@@ -137,7 +138,7 @@ module('Integration | Component | form field', function (hooks) {
     );
     assert.ok(component.hasRadio, 'renders radio buttons');
     const selectedValue = 'SHA256';
-    await component.selectRadioInput(selectedValue);
+    await component.selectRadioInput(dasherize(selectedValue));
     assert.equal(model.get('foo'), selectedValue);
     assert.ok(spy.calledWith('foo', selectedValue), 'onChange called with correct args');
   });

--- a/ui/tests/pages/components/form-field.js
+++ b/ui/tests/pages/components/form-field.js
@@ -25,6 +25,11 @@ export default {
   hasTooltip: isPresent('[data-test-component=info-tooltip]'),
   tooltipTrigger: focusable('[data-test-tool-tip-trigger]'),
   tooltipContent: text('[data-test-help-text]'),
+  hasRadio: isPresent('[data-test-radio-input]'),
+  radioButtons: collection('input[type=radio]', {
+    select: clickable(),
+    id: attribute('id'),
+  }),
 
   fields: collection('[data-test-field]', {
     clickLabel: clickable('label'),
@@ -41,6 +46,9 @@ export default {
     inputChecked: attribute('checked', 'input[type=checkbox]'),
     selectValue: value('select'),
   }),
+  selectRadioInput: async function (value) {
+    return this.radioButtons.filterBy('id', value)[0].select();
+  },
   fillInTextarea: async function (name, value) {
     return this.fields
       .filter((field) => {


### PR DESCRIPTION
- For possible values, now we can render either dropdown or radio buttons
- Drop down will be used for larger data set, whereas radio buttons should
  be used when we have only couple of options (example totp mfa)
- Added test for radio button functionality
- Added missing test for ttl without toggle

<img width="1739" alt="Screen Shot 2022-05-27 at 11 40 14 AM" src="https://user-images.githubusercontent.com/2932708/171280151-1fd2f526-2398-4811-8fae-6a014ebffcdc.png">

