### PR TITLE
Vault documentation: updated learn link

### DIFF
--- a/website/content/docs/platform/k8s/index.mdx
+++ b/website/content/docs/platform/k8s/index.mdx
@@ -46,7 +46,7 @@ There are several ways to try Vault with Kubernetes in different environments.
 
 ### Guides
 
-- [Vault Installation to Minikube via Helm](https://learn.hashicorp.com/tutorials/vault/kubernetes-minikube?in=vault/kubernetes) covers installing Vault locally using Minikube and the official Helm chart.
+- [Vault Installation to Minikube via Helm](https://learn.hashicorp.com/tutorials/vault/kubernetes-minikube-consul?in=vault/kubernetes) covers installing Vault locally using Minikube and the official Helm chart.
 
 - [Vault Installation to Red Hat OpenShift via Helm](https://learn.hashicorp.com/tutorials/vault/kubernetes-openshift?in=vault/kubernetes) covers installing Vault using Helm on Red Hat's OpenShift platform.
 


### PR DESCRIPTION
Per Jonathan's request, the link to **Vault Installation to Minikube via Helm** tutorial needed to be updated.

:mag: [Deploy Preview](https://vault-git-docs-update-learn-link-hashicorp.vercel.app/docs/platform/k8s#guides)