### PR TITLE
Update terraform secrets to v0.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-kv v0.12.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.8.0
-	github.com/hashicorp/vault-plugin-secrets-terraform v0.4.0
+	github.com/hashicorp/vault-plugin-secrets-terraform v0.5.0
 	github.com/hashicorp/vault-testing-stepwise v0.1.2
 	github.com/hashicorp/vault/api v1.6.0
 	github.com/hashicorp/vault/api/auth/approle v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1015,8 +1015,8 @@ github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0 h1:EDyX/utLxEKGETe
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0/go.mod h1:PLx2vxXukfsKsDRo/PlG4fxmJ1d+H2h82wT3vf4buuI=
 github.com/hashicorp/vault-plugin-secrets-openldap v0.8.0 h1:WJk5wRg861RlTd8xN6To/sRw3SnEUzqXpWml98GPZks=
 github.com/hashicorp/vault-plugin-secrets-openldap v0.8.0/go.mod h1:XC7R76jZiuD50ENel+I1/Poz5phaEQg9d6Dko8DF3Ts=
-github.com/hashicorp/vault-plugin-secrets-terraform v0.4.0 h1:D7hFUGbPM25Pl5bDXoTv86D6fzjoUyKtbCm5aKvrDb4=
-github.com/hashicorp/vault-plugin-secrets-terraform v0.4.0/go.mod h1:GzYAJYytgbNNyT3S7rspz1cLE53E1oajFbEtaDUlVGU=
+github.com/hashicorp/vault-plugin-secrets-terraform v0.5.0 h1:NbQW1Z2+oIn8v4jjqLBbxDas0Uw0bzV74da4BQsdRow=
+github.com/hashicorp/vault-plugin-secrets-terraform v0.5.0/go.mod h1:GzYAJYytgbNNyT3S7rspz1cLE53E1oajFbEtaDUlVGU=
 github.com/hashicorp/vault-testing-stepwise v0.1.1/go.mod h1:3vUYn6D0ZadvstNO3YQQlIcp7u1a19MdoOC0NQ0yaOE=
 github.com/hashicorp/vault-testing-stepwise v0.1.2 h1:3obC/ziAPGnsz2IQxr5e4Ayb7tu7WL6pm6mmZ5gwhhs=
 github.com/hashicorp/vault-testing-stepwise v0.1.2/go.mod h1:TeU6B+5NqxUjto+Zey+QQEH1iywuHn0ciHZNYh4q3uI=


### PR DESCRIPTION
Updates Terraform secrets engine to v0.5.0.
```
go get github.com/hashicorp/vault-plugin-secrets-terraform@v0.5.0
go mod tidy
```