### PR TITLE
Only use additional entropy source when configured within transit and sys random calls

### DIFF
--- a/helper/random/random_api.go
+++ b/helper/random/random_api.go
@@ -71,10 +71,10 @@ func HandleRandomAPI(d *framework.FieldData, additionalSource io.Reader) (*logic
 		}
 		randBytes, err = uuid.GenerateRandomBytesWithReader(bytes, additionalSource)
 	case "all":
-		var sealBytes []byte
-		sealBytes, err = uuid.GenerateRandomBytesWithReader(bytes, additionalSource)
-		if err == nil {
-			randBytes, err = uuid.GenerateRandomBytes(bytes)
+		randBytes, err = uuid.GenerateRandomBytes(bytes)
+		if err == nil && rand.Reader != additionalSource {
+			var sealBytes []byte
+			sealBytes, err = uuid.GenerateRandomBytesWithReader(bytes, additionalSource)
 			if err == nil {
 				randBytes, err = xor.XORBytes(sealBytes, randBytes)
 			}


### PR DESCRIPTION
- When an end-user specifies the all source type within
   transit/random and sys/tools/random, only use the additional source
   if we are actually configured with an external entropy source

Addresses: VAULT-6415