### PR TITLE
VAULT-6371 Fix issue with lease quotas on read requests that generate leases

### DIFF
--- a/changelog/15735.txt
+++ b/changelog/15735.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-quotas/lease-count: Fix lease-count quotas on non-auth mounts not properly being enforced
+quotas/lease-count: Fix lease-count quotas on mounts not properly being enforced when the lease generating request is a read
 ```

--- a/changelog/15735.txt
+++ b/changelog/15735.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+quotas/lease-count: Fix lease-count quotas on non-auth mounts not properly being enforced
+```

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -493,6 +493,10 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 		return nil, err
 	}
 
+	// MountPoint will not always be set at this point, so we ensure the req contains it
+	// as it is depended on by some functionality (e.g. quotas)
+	req.MountPoint = c.router.MatchingMount(ctx, req.Path)
+
 	// Decrement the wait group when our request is done
 	if waitGroup != nil {
 		defer waitGroup.Done()


### PR DESCRIPTION
The crux of the issue here was that lease quota checks get routed differently to rate limit checks. In the case of lease quota checks, the MountPoint was not always present on the logical.Request. In essence, when searching for an applicable quota to apply to the request, it would not correctly find the applicable quota as it uses the MountPoint as part of searching for applicable quotas. It seems to apply only to endpoints that generate a lease on Read.

Lease quotas now apply properly on quotas based on mounts that when generating a lease on a Read:
```
violethynes@violethynes-C02CW1WWMD6R vault-enterprise % vault read mysql-database/creds/my-role
Error reading mysql-database/creds/my-role: Error making API request.

URL: GET http://127.0.0.1:8200/v1/mysql-database/creds/my-role
Code: 429. Errors:

* 1 error occurred:
	* request path "mysql-database/creds/my-role": lease count quota exceeded

```

Tests added as part of enterprise PR.