### PR TITLE
website: fix internal redirect links

### DIFF
--- a/website/content/api-docs/auth/jwt.mdx
+++ b/website/content/api-docs/auth/jwt.mdx
@@ -41,7 +41,7 @@ set.
 - `bound_issuer` `(string: <optional>)` - The value against which to match the `iss` claim in a JWT.
 - `jwt_supported_algs` `(comma-separated string, or array of strings: <optional>)` - A list of supported signing algorithms. Defaults to [RS256] for OIDC roles. Defaults to all [available algorithms](https://github.com/hashicorp/cap/blob/main/jwt/algs.go) for JWT roles.
 - `default_role` `(string: <optional>)` - The default role to use if none is provided during login.
-- `provider_config` `(map: <optional>)` - Configuration options for provider-specific handling. Providers with specific handling include: Azure, Google. The options are described in each provider's section in [OIDC Provider Setup](/docs/auth/jwt_oidc_providers).
+- `provider_config` `(map: <optional>)` - Configuration options for provider-specific handling. Providers with specific handling include: Azure, Google. The options are described in each provider's section in [OIDC Provider Setup](/docs/auth/jwt/oidc_providers).
 - `namespace_in_state` `(bool: true)` - Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs.
 
 ### Sample Payload
@@ -301,7 +301,7 @@ Obtain an authorization URL from Vault to start an OIDC login flow.
 - `role` `(string: <optional>)` - Name of the role against which the login is being
   attempted. Defaults to configured `default_role` if not provided.
 - `redirect_uri` `(string: <required>)` - Path to the callback to complete the login. This will be
-  of the form, "https://.../oidc/callback" where the leading portion is dependent on your Vault
+  of the form, "https&#x3A;//.../oidc/callback" where the leading portion is dependent on your Vault
   server location, port, and the mount of the JWT plugin. This must be configured with Vault and the
   provider. See [Redirect URIs](/docs/auth/jwt#redirect-uris) for more information.
 

--- a/website/content/api-docs/index.mdx
+++ b/website/content/api-docs/index.mdx
@@ -190,7 +190,7 @@ To retrieve the help for any API within Vault, including mounted backends, auth
 methods, etc. then append `?help=1` to any URL. If you have valid permission to
 access the path, then the help text will be return a markdown-formatted block in the `help` attribute of the response.
 
-Additionally, with the [OpenAPI generation](/api/system/internal-specs-openapi) in Vault, you will get back a small
+Additionally, with the [OpenAPI generation](/api-docs/system/internal-specs-openapi) in Vault, you will get back a small
 OpenAPI document in the `openapi` attribute. This document is relevant for the path you're looking up and any paths under it - also note paths in the OpenAPI document are relative to the initial path queried.
 
 Example request:

--- a/website/content/api-docs/secret/cassandra.mdx
+++ b/website/content/api-docs/secret/cassandra.mdx
@@ -9,12 +9,12 @@ description: This is the API documentation for the Vault Cassandra secrets engin
 ~> **Deprecation Note:** This backend is deprecated in favor of the
 combined databases backend added in v0.7.1. See the API documentation for
 the new implementation of this backend at
-[Cassandra database plugin HTTP API](/api/secret/databases/cassandra).
+[Cassandra database plugin HTTP API](/api-docs/secret/databases/cassandra).
 
 This is the API documentation for the Vault Cassandra secrets engine. For
 general information about the usage and operation of the Cassandra backend,
 please see the
-[Vault Cassandra backend documentation](/docs/secrets/cassandra).
+[Vault Cassandra backend documentation](/docs/secrets/databases/cassandra).
 
 This documentation assumes the Cassandra backend is mounted at the `/cassandra`
 path in Vault. Since it is possible to enable secrets engines at any location,
@@ -195,7 +195,7 @@ $ curl \
 
 This endpoint deletes the role definition.
 
-| Method   | Path                     |
+| Method   | Path                     |                 |
 | :------- | :----------------------- | --------------- |
 | `DELETE` | `/cassandra/roles/:name` | `204 (no body)` |
 

--- a/website/content/api-docs/secret/identity/mfa/duo.mdx
+++ b/website/content/api-docs/secret/identity/mfa/duo.mdx
@@ -10,7 +10,7 @@ description: >-
 This endpoint defines an MFA method of type Duo.
 
 | Method | Path                           |
-| :----- |:-------------------------------|
+| :----- | :----------------------------- |
 | `POST` | `/identity/mfa/method/duo/:id` |
 
 ### Parameters
@@ -26,7 +26,9 @@ This endpoint defines an MFA method of type Duo.
 - `api_hostname` `(string: <required>)` - API hostname for Duo.
 
 - `push_info` `(string)` - Push information for Duo.
+
 -
+
 - `use_passcode` `(bool: false)` - If true, the user is reminded to use the passcode upon MFA validation.
 
 ### Sample Payload
@@ -64,7 +66,7 @@ This endpoint queries the MFA configuration of Duo type for a given method
 ID.
 
 | Method | Path                           |
-| :----- |:-------------------------------|
+| :----- | :----------------------------- |
 | `GET`  | `/identity/mfa/method/duo/:id` |
 
 ### Parameters
@@ -101,10 +103,10 @@ $ curl \
 ## Delete Duo MFA Method
 
 This endpoint deletes a Duo MFA method. MFA methods can only be deleted if they're not currently in use
-by a [login enforcement](/api/secret/identity/mfa/login-enforcement).
+by a [login enforcement](/api-docs/secret/identity/mfa/login-enforcement).
 
 | Method   | Path                           |
-| :------- |:-------------------------------|
+| :------- | :----------------------------- |
 | `DELETE` | `/identity/mfa/method/duo/:id` |
 
 ### Parameters
@@ -126,7 +128,7 @@ $ curl \
 This endpoint lists Duo MFA methods that are visible in the current namespace or in parent namespaces.
 
 | Method | Path                       |
-|:-------|:---------------------------|
+| :----- | :------------------------- |
 | `LIST` | `/identity/mfa/method/duo` |
 
 ### Sample Request

--- a/website/content/api-docs/secret/identity/mfa/index.mdx
+++ b/website/content/api-docs/secret/identity/mfa/index.mdx
@@ -9,18 +9,18 @@ description: >-
 
 ## Supported MFA types.
 
-- [TOTP](/api/secret/identity/mfa/totp)
+- [TOTP](/api-docs/secret/identity/mfa/totp)
 
-- [Okta](/api/secret/identity/mfa/okta)
+- [Okta](/api-docs/secret/identity/mfa/okta)
 
-- [Duo](/api/secret/identity/mfa/duo)
+- [Duo](/api-docs/secret/identity/mfa/duo)
 
-- [PingID](/api/secret/identity/mfa/pingid)
+- [PingID](/api-docs/secret/identity/mfa/pingid)
 
 ## Other
 
-- [Login Enforcement](/api/secret/identity/mfa/login-enforcement)
-- [MFA Validate](/api/system/mfa/validate)
+- [Login Enforcement](/api-docs/secret/identity/mfa/login-enforcement)
+- [MFA Validate](/api-docs/system/mfa/validate)
 
 While the above endpoints are available in both the open source and Enterprise versions of Vault,
 they are namespace aware. MFA methods and login enforcements created in one namespace are separate from other

--- a/website/content/api-docs/secret/identity/mfa/okta.mdx
+++ b/website/content/api-docs/secret/identity/mfa/okta.mdx
@@ -10,7 +10,7 @@ description: >-
 This endpoint defines an MFA method of type Okta.
 
 | Method | Path                            |
-| :----- |:--------------------------------|
+| :----- | :------------------------------ |
 | `POST` | `/identity/mfa/method/okta/:id` |
 
 ### Parameters
@@ -61,7 +61,7 @@ This endpoint queries the MFA configuration of Okta type for a given method
 name.
 
 | Method | Path                            |
-| :----- |:--------------------------------|
+| :----- | :------------------------------ |
 | `GET`  | `/identity/mfa/method/okta/:id` |
 
 ### Parameters
@@ -96,10 +96,10 @@ $ curl \
 ## Delete Okta MFA Method
 
 This endpoint deletes a Okta MFA method. The MFA methods can only be deleted if they're not currently in use
-by a [login enforcement](/api/secret/identity/mfa/login-enforcement).
+by a [login enforcement](/api-docs/secret/identity/mfa/login-enforcement).
 
 | Method   | Path                            |
-| :------- |:--------------------------------|
+| :------- | :------------------------------ |
 | `DELETE` | `/identity/mfa/method/okta/:id` |
 
 ### Parameters
@@ -121,7 +121,7 @@ $ curl \
 This endpoint lists Okta MFA methods that are visible in the current namespace or in parent namespaces.
 
 | Method | Path                        |
-|:-------|:----------------------------|
+| :----- | :-------------------------- |
 | `LIST` | `/identity/mfa/method/okta` |
 
 ### Sample Request

--- a/website/content/api-docs/secret/identity/mfa/pingid.mdx
+++ b/website/content/api-docs/secret/identity/mfa/pingid.mdx
@@ -10,7 +10,7 @@ description: >-
 This endpoint defines an MFA method of type PingID.
 
 | Method | Path                              |
-| :----- |:----------------------------------|
+| :----- | :-------------------------------- |
 | `POST` | `/identity/mfa/method/pingid/:id` |
 
 ### Parameters
@@ -54,7 +54,7 @@ This endpoint queries the MFA configuration of PingID type for a given method
 name.
 
 | Method | Path                              |
-| :----- |:----------------------------------|
+| :----- | :-------------------------------- |
 | `GET`  | `/identity/mfa/method/pingid/:id` |
 
 ### Parameters
@@ -90,10 +90,10 @@ $ curl \
 ## Delete PingID MFA Method
 
 This endpoint deletes a PingID MFA method. MFA methods can only be deleted if they're not currently in use
-by a [login enforcement](/api/secret/identity/mfa/login-enforcement).
+by a [login enforcement](/api-docs/secret/identity/mfa/login-enforcement).
 
 | Method   | Path                              |
-| :------- |:----------------------------------|
+| :------- | :-------------------------------- |
 | `DELETE` | `/identity/mfa/method/pingid/:id` |
 
 ### Parameters
@@ -115,7 +115,7 @@ $ curl \
 This endpoint lists PingID MFA methods that are visible in the current namespace or in parent namespaces.
 
 | Method | Path                          |
-|:-------|:------------------------------|
+| :----- | :---------------------------- |
 | `LIST` | `/identity/mfa/method/pingid` |
 
 ### Sample Request

--- a/website/content/api-docs/secret/identity/mfa/totp.mdx
+++ b/website/content/api-docs/secret/identity/mfa/totp.mdx
@@ -10,7 +10,7 @@ description: >-
 This endpoint defines an MFA method of type TOTP.
 
 | Method | Path                            |
-| :----- |:--------------------------------|
+| :----- | :------------------------------ |
 | `POST` | `/identity/mfa/method/totp/:id` |
 
 ### Parameters
@@ -65,7 +65,7 @@ This endpoint queries the MFA configuration of TOTP type for a given method
 ID.
 
 | Method | Path                            |
-| :----- |:--------------------------------|
+| :----- | :------------------------------ |
 | `GET`  | `/identity/mfa/method/totp/:id` |
 
 ### Parameters
@@ -104,10 +104,10 @@ $ curl \
 ## Delete TOTP MFA Method
 
 This endpoint deletes a TOTP MFA method.  MFA methods can only be deleted if they're not currently in use
-by a [login enforcement](/api/secret/identity/mfa/login-enforcement).
+by a [login enforcement](/api-docs/secret/identity/mfa/login-enforcement).
 
 | Method   | Path                            |
-| :------- |:--------------------------------|
+| :------- | :------------------------------ |
 | `DELETE` | `/identity/mfa/method/totp/:id` |
 
 ### Parameters
@@ -128,8 +128,8 @@ $ curl \
 
 This endpoint lists TOTP MFA methods that are visible in the current namespace or in parent namespaces.
 
-| Method | Path                            |
-|:-------|:--------------------------------|
+| Method | Path                        |
+| :----- | :-------------------------- |
 | `LIST` | `/identity/mfa/method/totp` |
 
 ### Sample Request
@@ -162,7 +162,7 @@ doesn't exist already, using the configuration stored under the given MFA
 method ID.
 
 | Method | Path                                 |
-|:-------|:-------------------------------------|
+| :----- | :----------------------------------- |
 | `POST` | `/identity/mfa/method/totp/generate` |
 
 ### Parameters
@@ -204,8 +204,8 @@ This endpoint can be used to generate a TOTP MFA secret. Unlike the `generate`
 API which stores the generated secret on the entity ID of the calling token,
 the `admin-generate` API stores the generated secret on the given entity ID.
 
-| Method | Path                                             |
-| :----- |:-------------------------------------------------|
+| Method | Path                                       |
+| :----- | :----------------------------------------- |
 | `POST` | `/identity/mfa/method/totp/admin-generate` |
 
 ### Parameters
@@ -255,7 +255,7 @@ and the `generate` or `admin-generate` APIs should be used to regenerate a new
 secret.
 
 | Method | Path                                      |
-| :----- |:------------------------------------------|
+| :----- | :---------------------------------------- |
 | `POST` | `/identity/mfa/method/totp/admin-destroy` |
 
 ### Parameters

--- a/website/content/api-docs/secret/kv/index.mdx
+++ b/website/content/api-docs/secret/kv/index.mdx
@@ -10,6 +10,6 @@ This backend can be run in one of two versions. Each of which have a distinct AP
 Choose the version below you are running. For more information on the KV secrets
 engine see the [Vault kv documentation](/docs/secrets/kv).
 
-- [KV Version 1 API](/api/secret/kv/kv-v1)
+- [KV Version 1 API](/api-docs/secret/kv/kv-v1)
 
-- [KV Version 2 API](/api/secret/kv/kv-v2)
+- [KV Version 2 API](/api-docs/secret/kv/kv-v2)

--- a/website/content/api-docs/system/mfa/index.mdx
+++ b/website/content/api-docs/system/mfa/index.mdx
@@ -12,10 +12,10 @@ description: >-
 
 ## Supported MFA types.
 
-- [TOTP](/api/system/mfa/totp)
+- [TOTP](/api-docs/system/mfa/totp)
 
-- [Okta](/api/system/mfa/okta)
+- [Okta](/api-docs/system/mfa/okta)
 
-- [Duo](/api/system/mfa/duo)
+- [Duo](/api-docs/system/mfa/duo)
 
-- [PingID](/api/system/mfa/pingid)
+- [PingID](/api-docs/system/mfa/pingid)

--- a/website/content/api-docs/system/mounts.mdx
+++ b/website/content/api-docs/system/mounts.mdx
@@ -199,7 +199,7 @@ $ curl \
 
 This endpoint disables the mount point specified in the URL.
 
-| Method   | Path                |
+| Method   | Path                |                    |
 | :------- | :------------------ | ------------------ |
 | `DELETE` | `/sys/mounts/:path` | `204 (empty body)` |
 
@@ -224,7 +224,7 @@ simple as increasing the timeout (in the event of timeout errors).
 
 For recovery situations where the secret was manually removed from the
 secrets backing service, one can force a secrets engine disable in Vault by
-performing a [force revoke](https://www.vaultproject.io/api/system/leases#revoke-force)
+performing a [force revoke](/api-docs/system/leases)
 on the mount prefix, followed by a secrets disable when that completes. 
 If the underlying secrets were not manually cleaned up, this method might result
 in dangling credentials. This is meant for extreme circumstances.
@@ -236,7 +236,6 @@ This endpoint returns the configuration of a specific secret engine.
 | Method | Path                |
 | :----- | :------------------ |
 | `GET`  | `/sys/mounts/:path` |
-
 
 ### Sample Request
 

--- a/website/content/docs/auth/jwt/index.mdx
+++ b/website/content/docs/auth/jwt/index.mdx
@@ -113,7 +113,7 @@ not required to be set:
 The OIDC authentication flow has been successfully tested with a number of providers. A full
 guide to configuring OAuth/OIDC applications is beyond the scope of Vault documentation, but a
 collection of provider configuration steps has been collected to help get started:
-[OIDC Provider Setup](/docs/auth/jwt_oidc_providers)
+[OIDC Provider Setup](/docs/auth/jwt/oidc_providers)
 
 ### OIDC Configuration Troubleshooting
 
@@ -138,15 +138,20 @@ EOF
 ```
 
 - Monitor Vault's log output. Important information about OIDC validation failures will be emitted.
+
 - Ensure Redirect URIs are correct in Vault and on the provider. They need to match exactly. Check:
   http/https, 127.0.0.1/localhost, port numbers, whether trailing slashes are present.
+
 - Start simple. The only claim configuration a role requires is `user_claim`. After authentication is
   known to work, you can add additional claims bindings and metadata copying.
+
 - `bound_audiences` is optional for OIDC roles and typically not required. OIDC providers will use
   the client_id as the audience and OIDC validation expects this.
+
 - Check your provider for what scopes are required in order to receive all
   of the information you need. The scopes "profile" and "groups" often need to be
   requested, and can be added by setting `oidc_scopes="profile,groups"` on the role.
+
 - If you're seeing claim-related errors in logs, review the provider's docs very carefully to see
   how they're naming and structuring their claims. Depending on the provider, you may be able to
   construct a simple `curl` implicit grant request to obtain a JWT that you can inspect. An example
@@ -159,6 +164,7 @@ EOF
   be helpful when debugging provider setup and verifying that the received claims are what you expect.
   Since claims data is logged verbatim and may contain sensitive information, this option should not be
   used in production.
+
 - Azure requires some additional configuration when a user is a member of more
   than 200 groups, described in [Azure-specific handling
   configuration](/docs/auth/jwt_oidc_providers#azure-specific-handling-configuration)
@@ -229,46 +235,46 @@ Auth methods must be configured in advance before users or machines can
 authenticate. These steps are usually completed by an operator or configuration
 management tool.
 
-1.  Enable the JWT auth method. Either the "jwt" or "oidc" name may be used. The
-    backend will be mounted at the chosen name.
+1. Enable the JWT auth method. Either the "jwt" or "oidc" name may be used. The
+   backend will be mounted at the chosen name.
 
-    ```text
-    $ vault auth enable jwt
-      or
-    $ vault auth enable oidc
-    ```
+   ```text
+   $ vault auth enable jwt
+     or
+   $ vault auth enable oidc
+   ```
 
-1.  Use the `/config` endpoint to configure Vault. To support JWT roles, either local keys, a JWKS URL, or an OIDC
-    Discovery URL must be present. For OIDC roles, OIDC Discovery URL, OIDC Client ID and OIDC Client Secret are required. For the
-    list of available configuration options, please see the [API documentation](/api-docs/auth/jwt).
+1. Use the `/config` endpoint to configure Vault. To support JWT roles, either local keys, a JWKS URL, or an OIDC
+   Discovery URL must be present. For OIDC roles, OIDC Discovery URL, OIDC Client ID and OIDC Client Secret are required. For the
+   list of available configuration options, please see the [API documentation](/api-docs/auth/jwt).
 
-    ```text
-    $ vault write auth/jwt/config \
-        oidc_discovery_url="https://myco.auth0.com/" \
-        oidc_client_id="m5i8bj3iofytj" \
-        oidc_client_secret="f4ubv72nfiu23hnsj" \
-        default_role="demo"
-    ```
+   ```text
+   $ vault write auth/jwt/config \
+       oidc_discovery_url="https://myco.auth0.com/" \
+       oidc_client_id="m5i8bj3iofytj" \
+       oidc_client_secret="f4ubv72nfiu23hnsj" \
+       default_role="demo"
+   ```
 
-1.  Create a named role:
+1. Create a named role:
 
-    ```text
-    vault write auth/jwt/role/demo \
-        allowed_redirect_uris="http://localhost:8250/oidc/callback" \
-        bound_subject="r3qX9DljwFIWhsiqwFiu38209F10atW6@clients" \
-        bound_audiences="https://vault.plugin.auth.jwt.test" \
-        user_claim="https://vault/user" \
-        groups_claim="https://vault/groups" \
-        policies=webapps \
-        ttl=1h
-    ```
+   ```text
+   vault write auth/jwt/role/demo \
+       allowed_redirect_uris="http://localhost:8250/oidc/callback" \
+       bound_subject="r3qX9DljwFIWhsiqwFiu38209F10atW6@clients" \
+       bound_audiences="https://vault.plugin.auth.jwt.test" \
+       user_claim="https://vault/user" \
+       groups_claim="https://vault/groups" \
+       policies=webapps \
+       ttl=1h
+   ```
 
-    This role authorizes JWTs with the given subject and audience claims, gives
-    it the `webapps` policy, and uses the given user/groups claims to set up
-    Identity aliases.
+   This role authorizes JWTs with the given subject and audience claims, gives
+   it the `webapps` policy, and uses the given user/groups claims to set up
+   Identity aliases.
 
-    For the complete list of configuration options, please see the API
-    documentation.
+   For the complete list of configuration options, please see the API
+   documentation.
 
 ### Bound Claims
 

--- a/website/content/docs/commands/operator/generate-root.mdx
+++ b/website/content/docs/commands/operator/generate-root.mdx
@@ -27,7 +27,7 @@ An unseal key may be provided directly on the command line as an argument to the
 command. If key is specified as "-", the command will read from stdin. If a TTY
 is available, the command will prompt for text.
 
-Please see the [generate root guide](/guides/operations/generate-root) for
+Please see the [generate root guide](https://learn.hashicorp.com/tutorials/vault/generate-root) for
 step-by-step instructions.
 
 ## Examples

--- a/website/content/docs/commands/operator/rekey.mdx
+++ b/website/content/docs/commands/operator/rekey.mdx
@@ -21,7 +21,7 @@ An unseal key may be provided directly on the command line as an argument to the
 command. If key is specified as "-", the command will read from stdin. If a TTY
 is available, the command will prompt for text.
 
-Please see the [rotating and rekeying](/guides/operations/rekeying-and-rotating) for
+Please see the [rotating and rekeying](https://learn.hashicorp.com/tutorials/vault/rekeying-and-rotating) for
 step-by-step instructions.
 
 ## Examples
@@ -154,7 +154,7 @@ flags](/docs/commands) included on all commands.
 - `-backup` `(bool: false)` - Store a backup of the current PGP encrypted unseal
   keys in Vault's core. The encrypted values can be recovered in the event of
   failure or discarded after success. See the -backup-delete and
-  -backup-retrieve options for more information. This option only applies when
+  \-backup-retrieve options for more information. This option only applies when
   the existing unseal keys were PGP encrypted.
 
 - `-backup-delete` `(bool: false)` - Delete any stored backup unseal keys.

--- a/website/content/docs/concepts/dev-server.mdx
+++ b/website/content/docs/concepts/dev-server.mdx
@@ -50,7 +50,7 @@ flags or by specifying a configuration file):
 
 The dev server should be used for experimentation with Vault features, such
 as different auth methods, secrets engines, audit devices, etc.
-If you're new to Vault, you may want to pick up with [Your First Secret](/intro/getting-started/first-secret) in our getting started guide.
+If you're new to Vault, you may want to pick up with [Your First Secret](https://learn.hashicorp.com/vault/getting-started/first-secret) in our getting started guide.
 
 In addition to experimentation, the dev server is very easy to automate
 for development environments.

--- a/website/content/docs/concepts/policies.mdx
+++ b/website/content/docs/concepts/policies.mdx
@@ -181,10 +181,10 @@ also match `"secret/foobar"`. Specifically, when there are potentially multiple
 matching policy paths, `P1` and `P2`, the following matching criteria is applied:
 
 1. If the first wildcard (`+`) or glob (`*`) occurs earlier in `P1`, `P1` is lower priority
-2. If `P1` ends in `*` and `P2` doesn't, `P1` is lower priority
-3. If `P1` has more `+` (wildcard) segments, `P1` is lower priority
-4. If `P1` is shorter, it is lower priority
-5. If `P1` is smaller lexicographically, it is lower priority
+1. If `P1` ends in `*` and `P2` doesn't, `P1` is lower priority
+1. If `P1` has more `+` (wildcard) segments, `P1` is lower priority
+1. If `P1` is shorter, it is lower priority
+1. If `P1` is smaller lexicographically, it is lower priority
 
 For example, given the two paths, `"secret/*"` and `"secret/+/+/foo/*"`, the first
 wildcard appears in the same place, both end in `*` and the latter has two wildcard
@@ -256,19 +256,19 @@ injected, and currently the `path` keys in policies allow injection.
 
 ### Parameters
 
-| Name                                                                             | Description                                                                            |
-| :------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------- |
-| `identity.entity.id`                                                             | The entity's ID                                                                        |
-| `identity.entity.name`                                                           | The entity's name                                                                      |
-| `identity.entity.metadata.<metadata key>`                                        | Metadata associated with the entity for the given key                                  |
-| `identity.entity.aliases.<mount accessor>.id`                                    | Entity alias ID for the given mount                                                    |
-| `identity.entity.aliases.<mount accessor>.name`                                  | Entity alias name for the given mount                                                  |
-| `identity.entity.aliases.<mount accessor>.metadata.<metadata key>`               | Metadata associated with the alias for the given mount and metadata key                |
-| `identity.entity.aliases.<mount accessor>.custom_metadata.<custom_metadata key>` | Custom metadata associated with the alias for the given mount and custom metadata key  |
-| `identity.groups.ids.<group id>.name`                                            | The group name for the given group ID                                                  |
-| `identity.groups.names.<group name>.id`                                          | The group ID for the given group name                                                  |
-| `identity.groups.ids.<group id>.metadata.<metadata key>`                         | Metadata associated with the group for the given key                                   |
-| `identity.groups.names.<group name>.metadata.<metadata key>`                     | Metadata associated with the group for the given key                                   |
+| Name                                                                             | Description                                                                           |
+| :------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------ |
+| `identity.entity.id`                                                             | The entity's ID                                                                       |
+| `identity.entity.name`                                                           | The entity's name                                                                     |
+| `identity.entity.metadata.<metadata key>`                                        | Metadata associated with the entity for the given key                                 |
+| `identity.entity.aliases.<mount accessor>.id`                                    | Entity alias ID for the given mount                                                   |
+| `identity.entity.aliases.<mount accessor>.name`                                  | Entity alias name for the given mount                                                 |
+| `identity.entity.aliases.<mount accessor>.metadata.<metadata key>`               | Metadata associated with the alias for the given mount and metadata key               |
+| `identity.entity.aliases.<mount accessor>.custom_metadata.<custom_metadata key>` | Custom metadata associated with the alias for the given mount and custom metadata key |
+| `identity.groups.ids.<group id>.name`                                            | The group name for the given group ID                                                 |
+| `identity.groups.names.<group name>.id`                                          | The group ID for the given group name                                                 |
+| `identity.groups.ids.<group id>.metadata.<metadata key>`                         | Metadata associated with the group for the given key                                  |
+| `identity.groups.names.<group name>.metadata.<metadata key>`                     | Metadata associated with the group for the given key                                  |
 
 ### Examples
 
@@ -334,7 +334,7 @@ path take precedence over permissions on parameters.
 
 ### Parameter Constraints
 
--> **Note:**: The `allowed_parameters`, `denied_parameters`, and `required_parameters` fields are not supported for policies used with the version 2 kv store.
+\-> **Note:**: The `allowed_parameters`, `denied_parameters`, and `required_parameters` fields are not supported for policies used with the version 2 kv store.
 
 See the [API Specification](/api-docs/secret/kv/kv-v2) for more information.
 
@@ -596,8 +596,8 @@ $ curl \
 
 For more information, please read:
 
-- [Production Hardening](/guides/operations/production)
-- [Generating a Root Token](/guides/operations/generate-root)
+- [Production Hardening](https://learn.hashicorp.com/tutorials/vault/production-hardening)
+- [Generating a Root Token](https://learn.hashicorp.com/tutorials/vault/generate-root)
 
 ## Managing Policies
 

--- a/website/content/docs/concepts/tokens.mdx
+++ b/website/content/docs/concepts/tokens.mdx
@@ -29,7 +29,6 @@ holder is allowed to do within Vault. Other mapped information includes
 metadata that can be viewed and is added to the audit log, such as creation
 time, last renewal time, and more.
 
-
 Read on for a deeper dive into token concepts.
 
 ## Token Types
@@ -59,9 +58,9 @@ there are only three ways to create root tokens:
 
 1. The initial root token generated at `vault operator init` time -- this token has no
    expiration
-2. By using another root token; a root token with an expiration cannot create a
+1. By using another root token; a root token with an expiration cannot create a
    root token that never expires
-3. By using `vault operator generate-root` ([example](/guides/operations/generate-root))
+1. By using `vault operator generate-root` ([example](https://learn.hashicorp.com/tutorials/vault/generate-root))
    with the permission of a quorum of unseal key holders
 
 Root tokens are useful in development but should be extremely carefully guarded
@@ -90,10 +89,10 @@ Often this behavior is not desired, so users with appropriate access can create
 token tree. These orphan tokens can be created:
 
 1. Via `write` access to the `auth/token/create-orphan` endpoint
-2. By having `sudo` or `root` access to the `auth/token/create`
+1. By having `sudo` or `root` access to the `auth/token/create`
    and setting the `no_parent` parameter to `true`
-3. Via token store roles
-4. By logging in with any other (non-`token`) auth method
+1. Via token store roles
+1. By logging in with any other (non-`token`) auth method
 
 Users with appropriate permissions can also use the `auth/token/revoke-orphan`
 endpoint, which revokes the given token but rather than revoke the rest of the
@@ -107,9 +106,9 @@ accessor is a value that acts as a reference to a token and can only be used to
 perform limited actions:
 
 1. Look up a token's properties (not including the actual token ID)
-2. Look up a token's capabilities on a path
-3. Renew the token
-4. Revoke the token
+1. Look up a token's capabilities on a path
+1. Renew the token
+1. Revoke the token
 
 The token _making the call_, _not_ the token associated with the accessor, must
 have appropriate permissions for these functions.
@@ -158,11 +157,11 @@ token's information is looked up. It is based on a combination of factors:
 
 1. The system max TTL, which is 32 days but can be changed in Vault's
    configuration file.
-2. The max TTL set on a mount using [mount
+1. The max TTL set on a mount using [mount
    tuning](/api-docs/system/mounts). This value
    is allowed to override the system max TTL -- it can be longer or shorter,
    and if set this value will be respected.
-3. A value suggested by the auth method that issued the token. This
+1. A value suggested by the auth method that issued the token. This
    might be configured on a per-role, per-group, or per-user basis. This value
    is allowed to be less than the mount max TTL (or, if not set, the system max
    TTL), but it is not allowed to be longer.
@@ -193,8 +192,8 @@ can be created in a few ways:
 
 1. By having `sudo` capability or a `root` token with the `auth/token/create`
    endpoint
-2. By using token store roles
-3. By using an auth method that supports issuing these, such as
+1. By using token store roles
+1. By using an auth method that supports issuing these, such as
    AppRole
 
 At issue time, the TTL of a periodic token will be equal to the configured

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -5,4 +5,4 @@ page_title: Documentation
 
 # Documentation
 
-Welcome to the Vault documentation! This documentation is more of a reference guide for all available features and options of Vault. If you're just getting started with Vault, please start with the [introduction](/docs/what-is-vault) instead, and work your way up to the [Getting Started](/intro/getting-started/install) guide.
+Welcome to the Vault documentation! This documentation is more of a reference guide for all available features and options of Vault. If you're just getting started with Vault, please start with the [introduction](/docs/what-is-vault) instead, and work your way up to the [Getting Started](https://learn.hashicorp.com/tutorials/vault/getting-started-install) guide.

--- a/website/content/docs/internals/telemetry.mdx
+++ b/website/content/docs/internals/telemetry.mdx
@@ -105,9 +105,9 @@ These metrics represent operational aspects of the running Vault instance.
 | `vault.core.step_down`                              | Duration of time taken by cluster leadership step downs. This should be monitored and alerted on for overall cluster leadership status.                                                                                                                                                                                                                                                                                                     | ms           | summary |
 | `vault.core.unseal`                                 | Duration of time taken by unseal operations                                                                                                                                                                                                                                                                                                                                                                                                 | ms           | summary |
 | `vault.core.unsealed`                               | Has value 1 when Vault is unsealed, and 0 when Vault is sealed.                                                                                                                                                                                                                                                                                                                                                                             | bool         | gauge   |
-| `vault.metrics.collection` (cluster,gauge)          | Time taken to collect usage gauges, labelled by gauge type.                                                                                                                                                                                                                                                                                                                                                                                 | summary      |
-| `vault.metrics.collection.interval` (cluster,gauge) | Current value of usage gauge collection interval.                                                                                                                                                                                                                                                                                                                                                                                           | summary      |
-| `vault.metrics.collection.error` (cluster,gauge)    | Errors while collection usage gauges, labeled by gauge type.                                                                                                                                                                                                                                                                                                                                                                                | counter      |
+| `vault.metrics.collection` (cluster,gauge)          | Time taken to collect usage gauges, labelled by gauge type.                                                                                                                                                                                                                                                                                                                                                                                 | summary      |         |
+| `vault.metrics.collection.interval` (cluster,gauge) | Current value of usage gauge collection interval.                                                                                                                                                                                                                                                                                                                                                                                           | summary      |         |
+| `vault.metrics.collection.error` (cluster,gauge)    | Errors while collection usage gauges, labeled by gauge type.                                                                                                                                                                                                                                                                                                                                                                                | counter      |         |
 | `vault.rollback.attempt.<mountpoint>`               | Time taken to perform a rollback operation on the given mount point. The mount point name has its forward slashes `/` replaced by `-`. For example, a rollback operation on the `auth/token` backend would be reportes as `vault.rollback.attempt.auth-token-`.                                                                                                                                                                             | ms           | summary |
 | `vault.route.create.<mountpoint>`                   | Time taken to dispatch a create operation to a backend, and for that backend to process it. The mount point name has its forward slashes `/` replaced by `-`. For example, a create operation to `ns1/secret/` would have corresponding metric `vault.route.create.ns1-secret-`. The number of samples of this metric, and the corresponding ones for other operations below, indicates how many operations were performed per mount point. | ms           | summary |
 | `vault.route.delete.<mountpoint>`                   | Time taken to dispatch a delete operation to a backend, and for that backend to process it.                                                                                                                                                                                                                                                                                                                                                 | ms           | summary |
@@ -497,7 +497,7 @@ indicate flapping leadership.
 
 ## Integrated Storage (Raft) Automated Snapshots
 
-These metrics related to the Enterprise feature [Raft Automated Snapshots](/docs/enterprise/automated-raft-snapshots).
+These metrics related to the Enterprise feature [Raft Automated Snapshots](/docs/enterprise/automated-integrated-storage-snapshots).
 
 | Metric                                      | Description                                                                                   | Unit       | Type    |
 | :------------------------------------------ | :-------------------------------------------------------------------------------------------- | :--------- | :------ |
@@ -527,25 +527,47 @@ These metrics related to the Enterprise feature [Raft Automated Snapshots](/docs
 | `snapshot_config_name` | For automated snapshots, the name of the configuration                                                                                                                                                                                                | `config1`               |
 
 [secrets-engines]: /docs/secrets
+
 [storage-backends]: /docs/configuration/storage
+
 [telemetry-stanza]: /docs/configuration/telemetry
+
 [cubbyhole-secrets-engine]: /docs/secrets/cubbyhole
+
 [kv-secrets-engine]: /docs/secrets/kv
+
 [ldap-auth-backend]: /docs/auth/ldap
+
 [token-auth-backend]: /docs/auth/token
+
 [azure-storage-backend]: /docs/configuration/storage/azure
+
 [cassandra-storage-backend]: /docs/configuration/storage/cassandra
+
 [cockroachdb-storage-backend]: /docs/configuration/storage/cockroachdb
+
 [consul-storage-backend]: /docs/configuration/storage/consul
+
 [couchdb-storage-backend]: /docs/configuration/storage/couchdb
+
 [dynamodb-storage-backend]: /docs/configuration/storage/dynamodb
+
 [etcd-storage-backend]: /docs/configuration/storage/etcd
+
 [gcs-storage-backend]: /docs/configuration/storage/google-cloud-storage
+
 [spanner-storage-backend]: /docs/configuration/storage/google-cloud-spanner
+
 [mssql-storage-backend]: /docs/configuration/storage/mssql
+
 [mysql-storage-backend]: /docs/configuration/storage/mysql
+
 [postgresql-storage-backend]: /docs/configuration/storage/postgresql
+
 [s3-storage-backend]: /docs/configuration/storage/s3
+
 [swift-storage-backend]: /docs/configuration/storage/swift
+
 [zookeeper-storage-backend]: /docs/configuration/storage/zookeeper
+
 [integrated-storage]: /docs/configuration/storage/raft

--- a/website/content/docs/partnerships.mdx
+++ b/website/content/docs/partnerships.mdx
@@ -18,7 +18,7 @@ Vault is an Identity-based security solution that leverages trusted sources of i
 
 Vault has a secure [plugin](/docs/plugins) architecture. Vault’s plugins are completely separate, standalone applications that Vault executes and communicates with over RPC. This means the plugin process does not share the same memory space as Vault and therefore can only access the interfaces and arguments given to it.
 
-Vault plugins can be built-in and bundled with the Vault binary, or be external that has to be manually mounted. Built-in plugins are developed by HashiCorp, while external plugins can be developed by HashiCorp, technology partners, or the community. There is a curated collection of all plugins, both built-in and external, located on the [Plugin Portal](/docs/plugin-portal).
+Vault plugins can be built-in and bundled with the Vault binary, or be external that has to be manually mounted. Built-in plugins are developed by HashiCorp, while external plugins can be developed by HashiCorp, technology partners, or the community. There is a curated collection of all plugins, both built-in and external, located on the [Plugin Portal](/docs/plugins/plugin-portal).
 
 The diagram below depicts the key Vault integration categories and types.
 
@@ -32,7 +32,7 @@ Main Vault categories for partners to integrate with include:
 
 HSM (Hardware Security Module) are specific types of runtime integrations and provide an added level of security and compliance. The HSM communicates with Vault using the PKCS#11 protocol, thereby resulting in the integration to primarily involve verification of the operation of the functionality. You can find more information about Vault's HSM support [here](/docs/enterprise/hsm).
 
--> **Note:** Integrations related Vault’s [storage](/docs/concepts/storage) backend, [auto auth](/docs/agent/autoauth), and [auto unseal](/docs/concepts/seal#auto-unseal) functionality are not encouraged. Please reach out to [technologypartners@hashicorp.com](mailto:technologypartners@hashicorp.com) for any questions related to this.
+\-> **Note:** Integrations related Vault’s [storage](/docs/concepts/storage) backend, [auto auth](/docs/agent/autoauth), and [auto unseal](/docs/concepts/seal#auto-unseal) functionality are not encouraged. Please reach out to [technologypartners@hashicorp.com](mailto:technologypartners@hashicorp.com) for any questions related to this.
 
 **Audit/Monitoring & Compliance**: Audit/Monitoring and Compliance are components in Vault that keep a detailed log of all requests and responses to Vault. Because every operation with Vault is an API request/response, the audit log contains every authenticated interaction with Vault, including errors. Vault supports multiple audit devices to support your business use case. You can find more information about Vault Audit Devices [here](/docs/audit/).
 
@@ -67,12 +67,12 @@ The Vault integration development process is divided into six steps. By followin
 
 ![Development Process](/img/integration-program-devprocess.png)
 
-1.  Engage: Initial contact between vendor and HashiCorp
-2.  Enable: Information and articles to aid with the development of the integration
-3.  Develop and Test: Integration development and testing process
-4.  Review: HashiCorp verification of integration (iterative process)
-5.  Release: Verified integration made available and listed on the HashiCorp website once the HashiCorp technology partnership agreement has been executed
-6.  Support: Ongoing maintenance and support of the integration by the partner.
+1. Engage: Initial contact between vendor and HashiCorp
+1. Enable: Information and articles to aid with the development of the integration
+1. Develop and Test: Integration development and testing process
+1. Review: HashiCorp verification of integration (iterative process)
+1. Release: Verified integration made available and listed on the HashiCorp website once the HashiCorp technology partnership agreement has been executed
+1. Support: Ongoing maintenance and support of the integration by the partner.
 
 ### 1. Engage
 
@@ -150,7 +150,7 @@ Once the integration has been verified, the partner is requested to sign the Has
 
 At this stage, it is expected that the integration is fully complete, the necessary documentation has been written, and HashiCorp has reviewed the integration.
 
-For Auth or Secret Engine plugins specifically, once the plugin has been validated by HashiCorp, it is recommended the plugin be hosted on Github so it can more easily be downloaded and installed within Vault. We also encourage partners to list their plugin on the [Vault Plugin Portal](/docs/plugin-portal). This is in addition to the listing of the plugin on the technology partners’ dedicated HashiCorp partner page. To have the plugin listed on the portal page, please do a pull request via the “edit in GitHub” link on the bottom of the page and add the plugin in the partner section.
+For Auth or Secret Engine plugins specifically, once the plugin has been validated by HashiCorp, it is recommended the plugin be hosted on Github so it can more easily be downloaded and installed within Vault. We also encourage partners to list their plugin on the [Vault Plugin Portal](/docs/plugins/plugin-portal). This is in addition to the listing of the plugin on the technology partners’ dedicated HashiCorp partner page. To have the plugin listed on the portal page, please do a pull request via the “edit in GitHub” link on the bottom of the page and add the plugin in the partner section.
 
 For HCP Vault validations, the partner will be issued an HCP Vault Verified badge and will have this displayed on their partner page.
 

--- a/website/content/docs/secrets/databases/elasticdb.mdx
+++ b/website/content/docs/secrets/databases/elasticdb.mdx
@@ -104,78 +104,78 @@ Now, Elasticsearch is configured and ready to be used with Vault.
 
 ## Setup
 
-1.  Enable the database secrets engine if it is not already enabled:
+1. Enable the database secrets engine if it is not already enabled:
 
-    ```text
-    $ vault secrets enable database
-    Success! Enabled the database secrets engine at: database/
-    ```
+   ```text
+   $ vault secrets enable database
+   Success! Enabled the database secrets engine at: database/
+   ```
 
-    By default, the secrets engine will enable at the name of the engine. To
-    enable the secrets engine at a different path, use the `-path` argument.
+   By default, the secrets engine will enable at the name of the engine. To
+   enable the secrets engine at a different path, use the `-path` argument.
 
-1.  Configure Vault with the proper plugin and connection information:
+1. Configure Vault with the proper plugin and connection information:
 
-    ```text
-    $ vault write database/config/my-elasticsearch-database \
-        plugin_name="elasticsearch-database-plugin" \
-        allowed_roles="internally-defined-role,externally-defined-role" \
-        username=vault \
-        password=myPa55word \
-        url=http://localhost:9200 \
-        ca_cert=/usr/share/ca-certificates/extra/elastic-stack-ca.crt.pem \
-        client_cert=$ES_HOME/config/certs/elastic-certificates.crt.pem \
-        client_key=$ES_HOME/config/certs/elastic-certificates.key.pem
-    ```
+   ```text
+   $ vault write database/config/my-elasticsearch-database \
+       plugin_name="elasticsearch-database-plugin" \
+       allowed_roles="internally-defined-role,externally-defined-role" \
+       username=vault \
+       password=myPa55word \
+       url=http://localhost:9200 \
+       ca_cert=/usr/share/ca-certificates/extra/elastic-stack-ca.crt.pem \
+       client_cert=$ES_HOME/config/certs/elastic-certificates.crt.pem \
+       client_key=$ES_HOME/config/certs/elastic-certificates.key.pem
+   ```
 
-1.  Configure a role that maps a name in Vault to a role definition in Elasticsearch.
-    This is considered the most secure type of role because nobody can perform
-    a privilege escalation by editing a role's privileges out-of-band in
-    Elasticsearch:
+1. Configure a role that maps a name in Vault to a role definition in Elasticsearch.
+   This is considered the most secure type of role because nobody can perform
+   a privilege escalation by editing a role's privileges out-of-band in
+   Elasticsearch:
 
-    ```text
-    $ vault write database/roles/internally-defined-role \
-          db_name=my-elasticsearch-database \
-          creation_statements='{"elasticsearch_role_definition": {"indices": [{"names":["*"], "privileges":["read"]}]}}' \
-          default_ttl="1h" \
-          max_ttl="24h"
-    Success! Data written to: database/roles/internally-defined-role
-    ```
+   ```text
+   $ vault write database/roles/internally-defined-role \
+         db_name=my-elasticsearch-database \
+         creation_statements='{"elasticsearch_role_definition": {"indices": [{"names":["*"], "privileges":["read"]}]}}' \
+         default_ttl="1h" \
+         max_ttl="24h"
+   Success! Data written to: database/roles/internally-defined-role
+   ```
 
-1.  Alternatively, configure a role that maps a name in Vault to a pre-existing
-    role definition in Elasticsearch:
+1. Alternatively, configure a role that maps a name in Vault to a pre-existing
+   role definition in Elasticsearch:
 
-    ```text
-    $ vault write database/roles/externally-defined-role \
-          db_name=my-elasticsearch-database \
-          creation_statements='{"elasticsearch_roles": ["pre-existing-role-in-elasticsearch"]}' \
-          default_ttl="1h" \
-          max_ttl="24h"
-    Success! Data written to: database/roles/externally-defined-role
-    ```
+   ```text
+   $ vault write database/roles/externally-defined-role \
+         db_name=my-elasticsearch-database \
+         creation_statements='{"elasticsearch_roles": ["pre-existing-role-in-elasticsearch"]}' \
+         default_ttl="1h" \
+         max_ttl="24h"
+   Success! Data written to: database/roles/externally-defined-role
+   ```
 
 ## Usage
 
 After the secrets engine is configured and a user/machine has a Vault token with
 the proper permission, it can generate credentials.
 
-1.  Generate a new credential by reading from the `/creds` endpoint with the name
-    of the role:
+1. Generate a new credential by reading from the `/creds` endpoint with the name
+   of the role:
 
-    ```text
-    $ vault read database/creds/my-role
-    Key                Value
-    ---                -----
-    lease_id           database/creds/my-role/2f6a614c-4aa2-7b19-24b9-ad944a8d4de6
-    lease_duration     1h
-    lease_renewable    true
-    password           0ZsueAP-dqCNGZo35M0n
-    username           v-vaultuser-my-role-AgIViC5TdQHBdeiCxae0-1602541724
-    ```
+   ```text
+   $ vault read database/creds/my-role
+   Key                Value
+   ---                -----
+   lease_id           database/creds/my-role/2f6a614c-4aa2-7b19-24b9-ad944a8d4de6
+   lease_duration     1h
+   lease_renewable    true
+   password           0ZsueAP-dqCNGZo35M0n
+   username           v-vaultuser-my-role-AgIViC5TdQHBdeiCxae0-1602541724
+   ```
 
 ## API
 
-The full list of configurable options can be seen in the [Elasticsearch database plugin API](/api-docs/secret/databases/elasticdb.html) page.
+The full list of configurable options can be seen in the [Elasticsearch database plugin API](/api-docs/secret/databases/elasticdb) page.
 
 For more information on the database secrets engine's HTTP API please see the
 [Database secrets engine API](/api-docs/secret/databases) page.

--- a/website/content/docs/secrets/databases/mysql-maria.mdx
+++ b/website/content/docs/secrets/databases/mysql-maria.mdx
@@ -35,57 +35,57 @@ more information about setting up the database secrets engine.
 
 ## Setup
 
-1.  Enable the database secrets engine if it is not already enabled:
+1. Enable the database secrets engine if it is not already enabled:
 
-    ```text
-    $ vault secrets enable database
-    Success! Enabled the database secrets engine at: database/
-    ```
+   ```text
+   $ vault secrets enable database
+   Success! Enabled the database secrets engine at: database/
+   ```
 
-    By default, the secrets engine will enable at the name of the engine. To
-    enable the secrets engine at a different path, use the `-path` argument.
+   By default, the secrets engine will enable at the name of the engine. To
+   enable the secrets engine at a different path, use the `-path` argument.
 
-1.  Configure Vault with the proper plugin and connection information:
+1. Configure Vault with the proper plugin and connection information:
 
-    ```text
-    $ vault write database/config/my-mysql-database \
-        plugin_name=mysql-database-plugin \
-        connection_url="{{username}}:{{password}}@tcp(127.0.0.1:3306)/" \
-        allowed_roles="my-role" \
-        username="vaultuser" \
-        password="vaultpass"
-    ```
+   ```text
+   $ vault write database/config/my-mysql-database \
+       plugin_name=mysql-database-plugin \
+       connection_url="{{username}}:{{password}}@tcp(127.0.0.1:3306)/" \
+       allowed_roles="my-role" \
+       username="vaultuser" \
+       password="vaultpass"
+   ```
 
-1.  Configure a role that maps a name in Vault to an SQL statement to execute to
-    create the database credential:
+1. Configure a role that maps a name in Vault to an SQL statement to execute to
+   create the database credential:
 
-    ```text
-    $ vault write database/roles/my-role \
-        db_name=my-mysql-database \
-        creation_statements="CREATE USER '{{name}}'@'%' IDENTIFIED BY '{{password}}';GRANT SELECT ON *.* TO '{{name}}'@'%';" \
-        default_ttl="1h" \
-        max_ttl="24h"
-    Success! Data written to: database/roles/my-role
-    ```
+   ```text
+   $ vault write database/roles/my-role \
+       db_name=my-mysql-database \
+       creation_statements="CREATE USER '{{name}}'@'%' IDENTIFIED BY '{{password}}';GRANT SELECT ON *.* TO '{{name}}'@'%';" \
+       default_ttl="1h" \
+       max_ttl="24h"
+   Success! Data written to: database/roles/my-role
+   ```
 
 ## Usage
 
 After the secrets engine is configured and a user/machine has a Vault token with
 the proper permission, it can generate credentials.
 
-1.  Generate a new credential by reading from the `/creds` endpoint with the name
-    of the role:
+1. Generate a new credential by reading from the `/creds` endpoint with the name
+   of the role:
 
-    ```text
-    $ vault read database/creds/my-role
-    Key                Value
-    ---                -----
-    lease_id           database/creds/my-role/2f6a614c-4aa2-7b19-24b9-ad944a8d4de6
-    lease_duration     1h
-    lease_renewable    true
-    password           yY-57n3X5UQhxnmFRP3f
-    username           v_vaultuser_my-role_crBWVqVh2Hc1
-    ```
+   ```text
+   $ vault read database/creds/my-role
+   Key                Value
+   ---                -----
+   lease_id           database/creds/my-role/2f6a614c-4aa2-7b19-24b9-ad944a8d4de6
+   lease_duration     1h
+   lease_renewable    true
+   password           yY-57n3X5UQhxnmFRP3f
+   username           v_vaultuser_my-role_crBWVqVh2Hc1
+   ```
 
 ## Client x509 Certificate Authentication
 
@@ -155,7 +155,7 @@ $ vault write database/config/my-mysql-database \
 ```
 
 For a guide in root credential rotation, see [Database Root Credential
-Rotation](/guides/secret-mgmt/db-root-rotation).
+Rotation](https://learn.hashicorp.com/vault/secrets-management/db-root-rotation).
 
 ## API
 

--- a/website/content/docs/use-cases.mdx
+++ b/website/content/docs/use-cases.mdx
@@ -8,7 +8,7 @@ description: >-
 
 # Use Cases
 
-Before understanding use cases, it's useful to know [what Vault is](/intro).
+Before understanding use cases, it's useful to know [what Vault is](https://learn.hashicorp.com/collections/vault/getting-started).
 This page lists some concrete use cases for Vault, but the possible use cases are
 much broader than what we cover.
 


### PR DESCRIPTION
Fix links which point at redirects defined in `website/redirects.js`

The formatting changes are a result of us running the content through a parser and re-stringifying it from an AST. Functionally nothing should change.