### PR TITLE
PKI: Only set issuers with an associated key as default on import

### DIFF
--- a/builtin/logical/pki/integation_test.go
+++ b/builtin/logical/pki/integation_test.go
@@ -196,6 +196,102 @@ func TestIntegration_ReplaceRootBadIssuer(t *testing.T) {
 	require.True(t, resp.IsError(), "did not get an error from replacing root: %#v", resp)
 }
 
+func TestIntegration_SetSignedWithBackwardsPemBundles(t *testing.T) {
+	rootBackend, rootStorage := createBackendWithStorage(t)
+	intBackend, intStorage := createBackendWithStorage(t)
+
+	// generate root
+	resp, err := rootBackend.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "issuers/generate/root/internal",
+		Storage:   rootStorage,
+		Data: map[string]interface{}{
+			"common_name": "test.com",
+		},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "failed generating root ca")
+	require.NotNil(t, resp, "got nil response from generating root ca")
+	require.False(t, resp.IsError(), "got an error from generating root ca: %#v", resp)
+	rootCert := resp.Data["certificate"].(string)
+
+	// generate intermediate
+	resp, err = intBackend.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "issuers/generate/intermediate/internal",
+		Storage:   intStorage,
+		Data: map[string]interface{}{
+			"common_name": "test.com",
+		},
+		MountPoint: "pki-int/",
+	})
+	require.NoError(t, err, "failed generating int ca")
+	require.NotNil(t, resp, "got nil response from generating int ca")
+	require.False(t, resp.IsError(), "got an error from generating int ca: %#v", resp)
+	intCsr := resp.Data["csr"].(string)
+
+	// sign csr
+	resp, err = rootBackend.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "root/sign-intermediate",
+		Storage:   rootStorage,
+		Data: map[string]interface{}{
+			"csr":    intCsr,
+			"format": "pem_bundle",
+		},
+		MountPoint: "pki/",
+	})
+	require.NoError(t, err, "failed generating root ca")
+	require.NotNil(t, resp, "got nil response from generating root ca")
+	require.False(t, resp.IsError(), "got an error from generating root ca: %#v", resp)
+
+	intCert := resp.Data["certificate"].(string)
+
+	// Send in the chain backwards now and make sure we link intCert as default.
+	resp, err = intBackend.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "intermediate/set-signed",
+		Storage:   intStorage,
+		Data: map[string]interface{}{
+			"certificate": rootCert + "\n" + intCert + "\n",
+		},
+		MountPoint: "pki-int/",
+	})
+	require.NoError(t, err, "failed generating root ca")
+	require.NotNil(t, resp, "got nil response from generating root ca")
+	require.False(t, resp.IsError(), "got an error from generating root ca: %#v", resp)
+
+	// setup role
+	resp, err = intBackend.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "roles/example",
+		Storage:   intStorage,
+		Data: map[string]interface{}{
+			"allowed_domains":  "example.com",
+			"allow_subdomains": "true",
+			"max_ttl":          "1h",
+		},
+		MountPoint: "pki-int/",
+	})
+	require.NoError(t, err, "failed setting up role example")
+	require.Nil(t, resp, "got non-nil response from setting up role example: %#v", resp)
+
+	// Issue cert
+	resp, err = intBackend.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "issue/example",
+		Storage:   intStorage,
+		Data: map[string]interface{}{
+			"common_name": "test.example.com",
+			"ttl":         "5m",
+		},
+		MountPoint: "pki-int/",
+	})
+	require.NoError(t, err, "failed issuing a leaf cert from int ca")
+	require.NotNil(t, resp, "got nil response issuing a leaf cert from int ca")
+	require.False(t, resp.IsError(), "got an error issuing a leaf cert from int ca: %#v", resp)
+}
+
 func genTestRootCa(t *testing.T, b *backend, s logical.Storage) (issuerID, keyID) {
 	return genTestRootCaWithIssuerName(t, b, s, "")
 }


### PR DESCRIPTION
 - Do not set the first issuer we attempt to import as the default issuer unless
   it has a corresponding key.
 - Add the ability to set a default issuer if none exist and we import it's corresponding key after the fact.
 - Add a warning to an end-user if we imported multiple issuers with keys and we
   choose one of them as the default value.