### PR TITLE
Fix copy/paste typo in PKI key generation docs

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1190,7 +1190,7 @@ used.
 
 #### Parameters
 
-- `type` `(string: <required>)` - Specifies the type of the root to
+- `type` `(string: <required>)` - Specifies the type of the key to
   create. If `exported`, the private key will be returned in the response; if
   `internal` the private key will not be returned and _cannot be retrieved
   later_; `kms` is also supported: [see below for more details about managed


### PR DESCRIPTION
As caught by Ivana, thank you!

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`