### PR TITLE
Vault documentation: added relevant link to tutorial from audit device page

### DIFF
--- a/website/content/docs/audit/index.mdx
+++ b/website/content/docs/audit/index.mdx
@@ -89,6 +89,10 @@ audit logs are critically important and ignoring blocked requests opens
 an avenue for attack. Be absolutely certain that your audit devices cannot
 block.
 
+## Tutorial
+
+Refer to [Blocked Audit Devices](https://learn.hashicorp.com/tutorials/vault/blocked-audit-devices) for a step-by-step tutorial.
+
 ## API
 
 Audit devices also have a full HTTP API. Please see the [Audit device API


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/563192436488770/1202383293623144), a link to the relevant block audit device tutorial was added to the audit device page.

:mag: [Deploy Preview](https://vault-git-docs-add-tutorial-link-hashicorp.vercel.app/docs/audit#tutorial)
