### PR TITLE
Revert UI: replace localStorage with sessionStorage

### DIFF
--- a/changelog/15769.txt
+++ b/changelog/15769.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Revert using localStorage in favor of sessionStorage
+```

--- a/ui/app/lib/local-storage.js
+++ b/ui/app/lib/local-storage.js
@@ -1,18 +1,18 @@
 export default {
   getItem(key) {
-    var item = window.sessionStorage.getItem(key);
+    var item = window.localStorage.getItem(key);
     return item && JSON.parse(item);
   },
 
   setItem(key, val) {
-    window.sessionStorage.setItem(key, JSON.stringify(val));
+    window.localStorage.setItem(key, JSON.stringify(val));
   },
 
   removeItem(key) {
-    return window.sessionStorage.removeItem(key);
+    return window.localStorage.removeItem(key);
   },
 
   keys() {
-    return Object.keys(window.sessionStorage);
+    return Object.keys(window.localStorage);
   },
 };

--- a/ui/app/lib/token-storage.js
+++ b/ui/app/lib/token-storage.js
@@ -7,7 +7,7 @@ export default function (type) {
   }
   let storage;
   try {
-    localStorageWrapper.getItem('test');
+    window.localStorage.getItem('test');
     storage = localStorageWrapper;
   } catch (e) {
     storage = memoryStorage;

--- a/ui/tests/acceptance/enterprise-control-groups-test.js
+++ b/ui/tests/acceptance/enterprise-control-groups-test.js
@@ -173,7 +173,7 @@ module('Acceptance | Enterprise | control groups', function (hooks) {
     await authPage.login(context.userToken);
     await settled();
     if (shouldStoreToken) {
-      sessionStorage.setItem(
+      localStorage.setItem(
         storageKey(accessor, 'kv/foo'),
         JSON.stringify({
           accessor,

--- a/ui/tests/acceptance/redirect-to-test.js
+++ b/ui/tests/acceptance/redirect-to-test.js
@@ -47,7 +47,7 @@ module('Acceptance | redirect_to query param functionality', function (hooks) {
     // normally we'd use the auth.logout helper to visit the route and reset the app, but in this case that
     // also routes us to the auth page, and then all of the transitions from the auth page get redirected back
     // to the auth page resulting in no redirect_to query param being set
-    sessionStorage.clear();
+    localStorage.clear();
   });
   test('redirect to a route after authentication', async function (assert) {
     let url = '/vault/secrets/secret/create';


### PR DESCRIPTION
In #14054 we moved from localStorage to using sessionStorage in an effort to make the Vault UI auth sessions tab-specific rather than browser-wide. However, after hearing from the community we are going to revisit our approach to browser security and revert this change for now.