### PR TITLE
bump vault-plugin-secrets-kv to v0.12.1

### DIFF
--- a/changelog/15792.txt
+++ b/changelog/15792.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/kv: Fix issue preventing the ability to reset the `delete_version_after` key metadata field to 0s via HTTP `PATCH`.
+```

--- a/go.mod
+++ b/go.mod
@@ -112,7 +112,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-gcp v0.13.0
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.12.0
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.1
-	github.com/hashicorp/vault-plugin-secrets-kv v0.12.0
+	github.com/hashicorp/vault-plugin-secrets-kv v0.12.1
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.8.0
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -899,7 +899,6 @@ github.com/hashicorp/go-secure-stdlib/mlock v0.1.2/go.mod h1:zq93CJChV6L9QTfGKtf
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.2/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.4/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
-github.com/hashicorp/go-secure-stdlib/parseutil v0.1.5/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 h1:om4Al8Oy7kCm/B86rLCLah4Dt5Aa0Fr5rYBG60OzwHQ=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/password v0.1.1 h1:6JzmBqXprakgFEHwBgdchsjaA9x3GyjdI568bXKxa60=
@@ -1010,8 +1009,8 @@ github.com/hashicorp/vault-plugin-secrets-gcpkms v0.12.0 h1:MXqB1waq3L18eUhTZ7ng
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.12.0/go.mod h1:6DPwGu8oGR1sZRpjwkcAnrQZWQuAJ/Ph+rQHfUo1Yf4=
 github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.1 h1:KiYpZpQv7X7Tm9wHUvboC2CyquwmjMhrPU2DvTcPC8o=
 github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.1/go.mod h1:aF9rgE2pGvWpyS/ijVrd817aA4Sf1I+dpLaKgshAPyQ=
-github.com/hashicorp/vault-plugin-secrets-kv v0.12.0 h1:8qQ8ANzQf2p8m6qkcYeOhe5jYV5Lse7GtpNHg88u0M4=
-github.com/hashicorp/vault-plugin-secrets-kv v0.12.0/go.mod h1:9V2Ecim3m/qw+YAQelUeFADqZ1GVo8xwoLqfKsqh9pI=
+github.com/hashicorp/vault-plugin-secrets-kv v0.12.1 h1:Nef6kmnCQQRRdYzA52diUnx4r8HPwoh1oP9FCHB2hrg=
+github.com/hashicorp/vault-plugin-secrets-kv v0.12.1/go.mod h1:9V2Ecim3m/qw+YAQelUeFADqZ1GVo8xwoLqfKsqh9pI=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0 h1:EDyX/utLxEKGETeGAyWe4QNoKwIfCw6VpEzKLb8zudc=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0/go.mod h1:PLx2vxXukfsKsDRo/PlG4fxmJ1d+H2h82wT3vf4buuI=
 github.com/hashicorp/vault-plugin-secrets-openldap v0.8.0 h1:WJk5wRg861RlTd8xN6To/sRw3SnEUzqXpWml98GPZks=


### PR DESCRIPTION
Upgrading `vault-plugin-secrets-kv` to `v0.12.1` includes the bug fix described in https://github.com/hashicorp/vault-plugin-secrets-kv/pull/62.