### PR TITLE
secrets/db: fix structpb conversion for external plugins using alternative cred types

### DIFF
--- a/sdk/database/dbplugin/v5/database.go
+++ b/sdk/database/dbplugin/v5/database.go
@@ -79,7 +79,7 @@ const SupportedCredentialTypesKey = "supported_credential_types"
 // supported by the database plugin. It can be used by database plugins
 // to communicate what CredentialType values it supports managing.
 func (ir InitializeResponse) SetSupportedCredentialTypes(credTypes []CredentialType) {
-	sct := make([]string, 0, len(credTypes))
+	sct := make([]interface{}, 0, len(credTypes))
 	for _, t := range credTypes {
 		sct = append(sct, t.String())
 	}

--- a/sdk/database/dbplugin/v5/grpc_client.go
+++ b/sdk/database/dbplugin/v5/grpc_client.go
@@ -81,8 +81,17 @@ func (c gRPCClient) NewUser(ctx context.Context, req NewUserRequest) (NewUserRes
 }
 
 func newUserReqToProto(req NewUserRequest) (*proto.NewUserRequest, error) {
-	if req.Password == "" {
-		return nil, fmt.Errorf("missing password")
+	switch req.CredentialType {
+	case CredentialTypePassword:
+		if req.Password == "" {
+			return nil, fmt.Errorf("missing password credential")
+		}
+	case CredentialTypeRSAPrivateKey:
+		if len(req.PublicKey) == 0 {
+			return nil, fmt.Errorf("missing public key credential")
+		}
+	default:
+		return nil, fmt.Errorf("unknown credential type")
 	}
 
 	expiration, err := ptypes.TimestampProto(req.Expiration)


### PR DESCRIPTION
This PR fixes an issue that occurs in the `map[string]interface{}` to [`structpb.Struct`](https://pkg.go.dev/google.golang.org/protobuf/types/known/structpb#Struct) conversion at [dbplugin/v5/marshalling.go#L24](https://github.com/hashicorp/vault/blob/main/sdk/database/dbplugin/v5/marshalling.go#L24). The issue is that [`NewStruct`](https://pkg.go.dev/google.golang.org/protobuf/types/known/structpb#NewStruct) can only convert `[]interface{}` for list types. We were using `[]string` to allow plugins to communicate supported credential types in the initialization response which resulted in the following error:

```
* error creating database object: unable to initialize: rpc error: code = Internal desc = failed to marshal new config to JSON: proto: invalid type: []string
```

This only occurs in plugins that run external to Vault _and_ take advantage of new credential type support. The only database plugin that does so is Snowflake. See [snowflake.go#L111-L114](https://github.com/hashicorp/vault-plugin-database-snowflake/blob/main/snowflake.go#L111-L114) for how this is set on the plugin side.

Additionally, this improves some validation around the public key credential for dynamic users.