### PR TITLE
Use the incoming request version to populate follower state

### DIFF
--- a/physical/raft/raft_autopilot.go
+++ b/physical/raft/raft_autopilot.go
@@ -195,6 +195,7 @@ type EchoRequestUpdate struct {
 	Term            uint64
 	DesiredSuffrage string
 	UpgradeVersion  string
+	SDKVersion      string
 	RedundancyZone  string
 }
 
@@ -212,7 +213,7 @@ func NewFollowerStates() *FollowerStates {
 	}
 }
 
-// Update the peer information in the follower states
+// Update the peer information in the follower states. Note that this function runs on the active node.
 func (s *FollowerStates) Update(req *EchoRequestUpdate) {
 	s.l.Lock()
 	defer s.l.Unlock()
@@ -230,7 +231,7 @@ func (s *FollowerStates) Update(req *EchoRequestUpdate) {
 	state.LastTerm = req.Term
 	state.DesiredSuffrage = req.DesiredSuffrage
 	state.LastHeartbeat = time.Now()
-	state.Version = version.GetVersion().Version
+	state.Version = req.SDKVersion
 	state.UpgradeVersion = req.UpgradeVersion
 	state.RedundancyZone = req.RedundancyZone
 }

--- a/vault/request_forwarding_rpc.go
+++ b/vault/request_forwarding_rpc.go
@@ -98,6 +98,7 @@ func (s *forwardedRequestRPCServer) Echo(ctx context.Context, in *EchoRequest) (
 			AppliedIndex:    in.RaftAppliedIndex,
 			Term:            in.RaftTerm,
 			DesiredSuffrage: in.RaftDesiredSuffrage,
+			SDKVersion:      in.SdkVersion,
 			UpgradeVersion:  in.RaftUpgradeVersion,
 			RedundancyZone:  in.RaftRedundancyZone,
 		})


### PR DESCRIPTION
Otherwise, any raft node that is on a version less than 1.12.0 (when the autopilot ENT changes were made) will have its version show up as whatever the current SDK version of the active node is.

I'm skipping the changelog on this since a bug fix to an unreleased feature.