### PR TITLE
Ignore crt builds on docs branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches-ignore:
       - docs/**
+      - backport/docs/**
 
 env:
   PKG_NAME: "vault"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: build
 
-on: [ workflow_dispatch, push ]
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - docs/**
 
 env:
   PKG_NAME: "vault"


### PR DESCRIPTION
Similar to https://github.com/hashicorp/vault/blob/main/.circleci/config/commands/exit-if-ui-or-docs-branch.yml, ignore CRT builds if it's just a docs change.

I also pushed these changes to a docs/ branch to test: https://github.com/hashicorp/vault/compare/docs/ignore-crt-builds-on-docs-branches?expand=1