### PR TITLE
UI: Fix metadata tab not showing given policy

### DIFF
--- a/changelog/15824.txt
+++ b/changelog/15824.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix issue where metadata tab is hidden even though policy grants access
+```

--- a/ui/app/components/secret-edit.js
+++ b/ui/app/components/secret-edit.js
@@ -78,8 +78,9 @@ export default class SecretEdit extends Component {
       if (!context.args.model || !context.isV2) {
         return;
       }
-      let backend = context.args.model.backend;
-      let path = `${backend}/metadata/`;
+      const backend = context.args.model.backend;
+      const id = context.args.model.id;
+      const path = `${backend}/metadata/${id}`;
       return {
         id: path,
       };

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -559,7 +559,7 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await logout.visit();
     await authPage.login(userToken);
     await settled();
-    await showPage.visit({ backend: enginePath, id: secretPath });
+    await visit(`/vault/secrets/${enginePath}/show/${secretPath}`);
     assert.dom('[data-test-empty-state-title]').hasText('You do not have permission to read this secret.');
     assert.dom('[data-test-secret-metadata-tab]').exists('Metadata tab exists');
     await editPage.metadataTab();

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -29,6 +29,18 @@ let writeSecret = async function (backend, path, key, val) {
   return editPage.createSecret(path, key, val);
 };
 
+let deleteEngine = async function (enginePath, assert) {
+  await logout.visit();
+  await authPage.login();
+  await consoleComponent.runCommands([`delete sys/mounts/${enginePath}`]);
+  const response = consoleComponent.lastLogOutput;
+  assert.equal(
+    response,
+    `Success! Data deleted (if it existed) at: sys/mounts/${enginePath}`,
+    'Engine successfully deleted'
+  );
+};
+
 module('Acceptance | secrets/secret/create', function (hooks) {
   setupApplicationTest(hooks);
 
@@ -528,18 +540,17 @@ module('Acceptance | secrets/secret/create', function (hooks) {
   });
 
   test('version 2 with no access to data but access to metadata shows metadata tab', async function (assert) {
+    assert.expect(5);
     let enginePath = 'kv-metadata-access-only';
-    let secretPath = 'kv-metadata-access-only-secret-name';
+    let secretPath = 'nested/kv-metadata-access-only-secret-name';
     const V2_POLICY = `
-      path "${enginePath}/metadata/*" {
-        capabilities = ["read", "update", "list"]
+      path "${enginePath}/metadata/nested/*" {
+        capabilities = ["read", "update"]
       }
     `;
     await consoleComponent.runCommands([
       `write sys/mounts/${enginePath} type=kv options=version=2`,
       `write sys/policies/acl/kv-v2-degrade policy=${btoa(V2_POLICY)}`,
-      // delete any kv previously written here so that tests can be re-run
-      `delete ${enginePath}/metadata/${secretPath}`,
       'write -field=client_token auth/token/create policies=kv-v2-degrade',
     ]);
 
@@ -548,15 +559,15 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await logout.visit();
     await authPage.login(userToken);
     await settled();
-    await click(`[data-test-auth-backend-link=${enginePath}]`);
-
-    await click(`[data-test-secret-link="${secretPath}"]`);
-
+    await showPage.visit({ backend: enginePath, id: secretPath });
     assert.dom('[data-test-empty-state-title]').hasText('You do not have permission to read this secret.');
+    assert.dom('[data-test-secret-metadata-tab]').exists('Metadata tab exists');
     await editPage.metadataTab();
     await settled();
     assert.dom('[data-test-empty-state-title]').hasText('No custom metadata');
     assert.dom('[data-test-add-custom-metadata]').exists('it shows link to edit metadata');
+
+    await deleteEngine(enginePath, assert);
   });
 
   test('version 2: with metadata no read or list but with delete access and full access to the data endpoint', async function (assert) {


### PR DESCRIPTION
This PR fixes the path what capabilities are checked against when evaluating whether to show the metadata tab on KV v2 secrets engine. Since metadata is only ever connected to a secret with an ID, we need to provide the ID on that capability path so that it is checked for each specific secret view. 

Repro steps for the bug are excellently outlined in issue #15347 
