### PR TITLE
Fix listing_visibility value documentation

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -5149,7 +5149,7 @@ This path responds to the following HTTP methods.
 		"This function can be used to generate high-entropy random bytes.",
 	},
 	"listing_visibility": {
-		"Determines the visibility of the mount in the UI-specific listing endpoint. Accepted value are 'unauth' and ''.",
+		"Determines the visibility of the mount in the UI-specific listing endpoint. Accepted value are 'unauth' and 'hidden', with the empty default ('') behaving like 'hidden'.",
 		"",
 	},
 	"passthrough_request_headers": {

--- a/website/content/api-docs/system/auth.mdx
+++ b/website/content/api-docs/system/auth.mdx
@@ -90,7 +90,8 @@ For example, enable the "foo" auth method will make it accessible at
     HMAC'd by audit devices in the response data object.
 
   - `listing_visibility` `(string: "")` - Specifies whether to show this mount
-    in the UI-specific listing endpoint.
+    in the UI-specific listing endpoint. Valid values are `"unauth"` or `"hidden"`,
+    with the default `""` being equivalent to `"hidden"`.
 
   - `passthrough_request_headers` `(array: [])` - List of headers to whitelist
     and pass from the request to the plugin.
@@ -294,7 +295,8 @@ can be achieved without `sudo` via `sys/mounts/auth/[auth-path]/tune`._
   that will not be HMAC'd by audit devices in the response data object.
 
 - `listing_visibility` `(string: "")` - Specifies whether to show this mount
-  in the UI-specific listing endpoint. Valid values are `"unauth"` or `""`.
+  in the UI-specific listing endpoint. Valid values are `"unauth"` or `"hidden"`,
+  with the default `""` being equivalent to `"hidden"`.
 
 - `passthrough_request_headers` `(array: [])` - List of headers to whitelist
   and pass from the request to the plugin.


### PR DESCRIPTION
- Fixes the documentation on `/sys/auth` to match `/sys/mounts`,
- Fix the path-help value as well, though I don't know where this particular one shows up.

See also: #15209. 