### PR TITLE
Dynamic parameter for mountpaths

### DIFF
--- a/changelog/15835.txt
+++ b/changelog/15835.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api/sys/internal/specs/dynamic: Adding a new endpoint to support dynamic mountpath parameters in the openapi spec
+```

--- a/changelog/15835.txt
+++ b/changelog/15835.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-api/sys/internal/specs/dynamic: Adding a new endpoint to support dynamic mountpath parameters in the openapi spec
+api/sys/internal/specs/openapi: support a new "dynamic" query parameter to generate generic mountpaths
 ```

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -527,10 +528,16 @@ func (b *Backend) handleRootHelp(req *logical.Request) (*logical.Response, error
 	// the request, the type will be used as part of the request/response body
 	// names in the OAS document.
 	requestResponsePrefix := req.GetString("requestResponsePrefix")
+	dynamicPaths := fmt.Sprintf("%v",req.Data["dynamicPaths"])
+	dynmaic, err := strconv.ParseBool(dynamicPaths)
+
+	if err != nil {
+		b.Logger().Warn("Help")
+	}
 
 	// Build OpenAPI response for the entire backend
 	doc := NewOASDocument()
-	if err := documentPaths(b, requestResponsePrefix, doc); err != nil {
+	if err := documentPaths(b, requestResponsePrefix, dynmaic, doc); err != nil {
 		b.Logger().Warn("error generating OpenAPI", "error", err)
 	}
 

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -528,7 +528,7 @@ func (b *Backend) handleRootHelp(req *logical.Request) (*logical.Response, error
 	// the request, the type will be used as part of the request/response body
 	// names in the OAS document.
 	requestResponsePrefix := req.GetString("requestResponsePrefix")
-	dynamicPaths := fmt.Sprintf("%v",req.Data["dynamicPaths"])
+	dynamicPaths := fmt.Sprintf("%v", req.Data["dynamicPaths"])
 	dynamic, _ := strconv.ParseBool(dynamicPaths)
 
 	// Build OpenAPI response for the entire backend

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -529,15 +529,11 @@ func (b *Backend) handleRootHelp(req *logical.Request) (*logical.Response, error
 	// names in the OAS document.
 	requestResponsePrefix := req.GetString("requestResponsePrefix")
 	dynamicPaths := fmt.Sprintf("%v",req.Data["dynamicPaths"])
-	dynmaic, err := strconv.ParseBool(dynamicPaths)
-
-	if err != nil {
-		b.Logger().Warn("Help")
-	}
+	dynamic, _ := strconv.ParseBool(dynamicPaths)
 
 	// Build OpenAPI response for the entire backend
 	doc := NewOASDocument()
-	if err := documentPaths(b, requestResponsePrefix, dynmaic, doc); err != nil {
+	if err := documentPaths(b, requestResponsePrefix, dynamic, doc); err != nil {
 		b.Logger().Warn("error generating OpenAPI", "error", err)
 	}
 

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -527,11 +528,17 @@ func (b *Backend) handleRootHelp(req *logical.Request) (*logical.Response, error
 	// the request, the type will be used as part of the request/response body
 	// names in the OAS document.
 	requestResponsePrefix := req.GetString("requestResponsePrefix")
-	genericPaths := req.Get("genericPaths").(bool)
+
+	genericPaths := fmt.Sprintf("%v", req.Data["genericPaths"])
+	generic, err := strconv.ParseBool(genericPaths)
+
+	if err != nil {
+		generic = false
+	}
 
 	// Build OpenAPI response for the entire backend
 	doc := NewOASDocument()
-	if err := documentPaths(b, requestResponsePrefix, genericPaths, doc); err != nil {
+	if err := documentPaths(b, requestResponsePrefix, generic, doc); err != nil {
 		b.Logger().Warn("error generating OpenAPI", "error", err)
 	}
 

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -528,12 +528,12 @@ func (b *Backend) handleRootHelp(req *logical.Request) (*logical.Response, error
 	// the request, the type will be used as part of the request/response body
 	// names in the OAS document.
 	requestResponsePrefix := req.GetString("requestResponsePrefix")
-	dynamicPaths := fmt.Sprintf("%v", req.Data["dynamicPaths"])
-	dynamic, _ := strconv.ParseBool(dynamicPaths)
+	genericPaths := fmt.Sprintf("%v", req.Data["genericPaths"])
+	generic, _ := strconv.ParseBool(genericPaths)
 
 	// Build OpenAPI response for the entire backend
 	doc := NewOASDocument()
-	if err := documentPaths(b, requestResponsePrefix, dynamic, doc); err != nil {
+	if err := documentPaths(b, requestResponsePrefix, generic, doc); err != nil {
 		b.Logger().Warn("error generating OpenAPI", "error", err)
 	}
 

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -529,6 +529,7 @@ func (b *Backend) handleRootHelp(req *logical.Request) (*logical.Response, error
 	requestResponsePrefix := req.GetString("requestResponsePrefix")
 
 	genericMountPaths, ok := req.Get("genericMountPaths").(bool)
+
 	if !ok {
 		genericMountPaths = false
 	}

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -528,6 +528,11 @@ func (b *Backend) handleRootHelp(req *logical.Request) (*logical.Response, error
 	// names in the OAS document.
 	requestResponsePrefix := req.GetString("requestResponsePrefix")
 
+	// Generic paths will primarily be used for code generation purposes.
+	// This will result in a dynamic mount path being placed instead of
+	// a hardcoded default path. For example /auth/approle/login would be replaced
+	// with /auth/{mountPath}/login. This will be replaced for all secrets
+	// engines and auth methods that are enabled.
 	genericMountPaths, ok := req.Get("genericMountPaths").(bool)
 
 	if !ok {

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -529,16 +528,14 @@ func (b *Backend) handleRootHelp(req *logical.Request) (*logical.Response, error
 	// names in the OAS document.
 	requestResponsePrefix := req.GetString("requestResponsePrefix")
 
-	genericPaths := fmt.Sprintf("%v", req.Data["genericPaths"])
-	generic, err := strconv.ParseBool(genericPaths)
-
-	if err != nil {
-		generic = false
+	genericMountPaths, ok := req.Get("genericMountPaths").(bool)
+	if !ok {
+		genericMountPaths = false
 	}
 
 	// Build OpenAPI response for the entire backend
 	doc := NewOASDocument()
-	if err := documentPaths(b, requestResponsePrefix, generic, doc); err != nil {
+	if err := documentPaths(b, requestResponsePrefix, genericMountPaths, doc); err != nil {
 		b.Logger().Warn("error generating OpenAPI", "error", err)
 	}
 

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -528,12 +527,11 @@ func (b *Backend) handleRootHelp(req *logical.Request) (*logical.Response, error
 	// the request, the type will be used as part of the request/response body
 	// names in the OAS document.
 	requestResponsePrefix := req.GetString("requestResponsePrefix")
-	genericPaths := fmt.Sprintf("%v", req.Data["genericPaths"])
-	generic, _ := strconv.ParseBool(genericPaths)
+	genericPaths := req.Get("genericPaths").(bool)
 
 	// Build OpenAPI response for the entire backend
 	doc := NewOASDocument()
-	if err := documentPaths(b, requestResponsePrefix, generic, doc); err != nil {
+	if err := documentPaths(b, requestResponsePrefix, genericPaths, doc); err != nil {
 		b.Logger().Warn("error generating OpenAPI", "error", err)
 	}
 

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -528,16 +528,12 @@ func (b *Backend) handleRootHelp(req *logical.Request) (*logical.Response, error
 	// names in the OAS document.
 	requestResponsePrefix := req.GetString("requestResponsePrefix")
 
-	// Generic paths will primarily be used for code generation purposes.
-	// This will result in a dynamic mount path being placed instead of
-	// a hardcoded default path. For example /auth/approle/login would be replaced
+	// Generic mount paths will primarily be used for code generation purposes.
+	// This will result in dynamic mount paths being placed instead of
+	// hardcoded default paths. For example /auth/approle/login would be replaced
 	// with /auth/{mountPath}/login. This will be replaced for all secrets
 	// engines and auth methods that are enabled.
-	genericMountPaths, ok := req.Get("genericMountPaths").(bool)
-
-	if !ok {
-		genericMountPaths = false
-	}
+	genericMountPaths, _ := req.Get("genericMountPaths").(bool)
 
 	// Build OpenAPI response for the entire backend
 	doc := NewOASDocument()

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -265,18 +265,20 @@ func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix st
 		// Body fields will be added to individual operations.
 		pathFields, bodyFields := splitFields(p.Fields, path)
 
-		// Add mount path as a parameter
-		p := OASParameter{
-			Name:        "mountPath",
-			Description: "Path that the backend was mounted at",
-			In:          "path",
-			Schema: &OASSchema{
-				Type:         "string",
-			},
-			Required:   true,
-		}
+		if dynamicPaths {
+			// Add mount path as a parameter
+			p := OASParameter{
+				Name:        "mountPath",
+				Description: "Path that the backend was mounted at",
+				In:          "path",
+				Schema: &OASSchema{
+					Type: "string",
+				},
+				Required: true,
+			}
 
-		pi.Parameters = append(pi.Parameters, p)
+			pi.Parameters = append(pi.Parameters, p)
+		}
 
 		for name, field := range pathFields {
 			location := "path"

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -223,8 +223,6 @@ func documentPaths(backend *Backend, requestResponsePrefix string, dynamicPaths 
 	return nil
 }
 
-// Set requestResponsePrefix = {mountPath}
-// Add parameter for {mountPath}
 // documentPath parses a framework.Path into one or more OpenAPI paths.
 func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix string, dynamicPaths bool, backendType logical.BackendType, doc *OASDocument) error {
 	var sudoPaths []string

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -213,9 +213,9 @@ var (
 )
 
 // documentPaths parses all paths in a framework.Backend into OpenAPI paths.
-func documentPaths(backend *Backend, requestResponsePrefix string, genericPaths bool, doc *OASDocument) error {
+func documentPaths(backend *Backend, requestResponsePrefix string, genericMountPaths bool, doc *OASDocument) error {
 	for _, p := range backend.Paths {
-		if err := documentPath(p, backend.SpecialPaths(), requestResponsePrefix, genericPaths, backend.BackendType, doc); err != nil {
+		if err := documentPath(p, backend.SpecialPaths(), requestResponsePrefix, genericMountPaths, backend.BackendType, doc); err != nil {
 			return err
 		}
 	}
@@ -224,7 +224,7 @@ func documentPaths(backend *Backend, requestResponsePrefix string, genericPaths 
 }
 
 // documentPath parses a framework.Path into one or more OpenAPI paths.
-func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix string, genericPaths bool, backendType logical.BackendType, doc *OASDocument) error {
+func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix string, genericMountPaths bool, backendType logical.BackendType, doc *OASDocument) error {
 	var sudoPaths []string
 	var unauthPaths []string
 
@@ -263,7 +263,7 @@ func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix st
 		// Body fields will be added to individual operations.
 		pathFields, bodyFields := splitFields(p.Fields, path)
 
-		if genericPaths && requestResponsePrefix != "system" && requestResponsePrefix != "identity" {
+		if genericMountPaths && requestResponsePrefix != "system" && requestResponsePrefix != "identity" {
 			// Add mount path as a parameter
 			p := OASParameter{
 				Name:        "mountPath",

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -263,7 +263,7 @@ func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix st
 		// Body fields will be added to individual operations.
 		pathFields, bodyFields := splitFields(p.Fields, path)
 
-		if dynamicPaths {
+		if dynamicPaths && requestResponsePrefix != "system" && requestResponsePrefix != "identity" {
 			// Add mount path as a parameter
 			p := OASParameter{
 				Name:        "mountPath",

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -213,9 +213,9 @@ var (
 )
 
 // documentPaths parses all paths in a framework.Backend into OpenAPI paths.
-func documentPaths(backend *Backend, requestResponsePrefix string, dynamicPaths bool, doc *OASDocument) error {
+func documentPaths(backend *Backend, requestResponsePrefix string, genericPaths bool, doc *OASDocument) error {
 	for _, p := range backend.Paths {
-		if err := documentPath(p, backend.SpecialPaths(), requestResponsePrefix, dynamicPaths, backend.BackendType, doc); err != nil {
+		if err := documentPath(p, backend.SpecialPaths(), requestResponsePrefix, genericPaths, backend.BackendType, doc); err != nil {
 			return err
 		}
 	}
@@ -224,7 +224,7 @@ func documentPaths(backend *Backend, requestResponsePrefix string, dynamicPaths 
 }
 
 // documentPath parses a framework.Path into one or more OpenAPI paths.
-func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix string, dynamicPaths bool, backendType logical.BackendType, doc *OASDocument) error {
+func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix string, genericPaths bool, backendType logical.BackendType, doc *OASDocument) error {
 	var sudoPaths []string
 	var unauthPaths []string
 
@@ -263,7 +263,7 @@ func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix st
 		// Body fields will be added to individual operations.
 		pathFields, bodyFields := splitFields(p.Fields, path)
 
-		if dynamicPaths && requestResponsePrefix != "system" && requestResponsePrefix != "identity" {
+		if genericPaths && requestResponsePrefix != "system" && requestResponsePrefix != "identity" {
 			// Add mount path as a parameter
 			p := OASParameter{
 				Name:        "mountPath",

--- a/sdk/framework/openapi_test.go
+++ b/sdk/framework/openapi_test.go
@@ -271,7 +271,7 @@ func TestOpenAPI_SpecialPaths(t *testing.T) {
 			Root:            test.rootPaths,
 			Unauthenticated: test.unauthPaths,
 		}
-		err := documentPath(&path, sp, "kv", logical.TypeLogical, doc)
+		err := documentPath(&path, sp, "kv", false, logical.TypeLogical, doc)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -519,11 +519,11 @@ func TestOpenAPI_OperationID(t *testing.T) {
 
 	for _, context := range []string{"", "bar"} {
 		doc := NewOASDocument()
-		err := documentPath(path1, nil, "kv", logical.TypeLogical, doc)
+		err := documentPath(path1, nil, "kv", false, logical.TypeLogical, doc)
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = documentPath(path2, nil, "kv", logical.TypeLogical, doc)
+		err = documentPath(path2, nil, "kv", false, logical.TypeLogical, doc)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -583,7 +583,7 @@ func TestOpenAPI_CustomDecoder(t *testing.T) {
 	}
 
 	docOrig := NewOASDocument()
-	err := documentPath(p, nil, "kv", logical.TypeLogical, docOrig)
+	err := documentPath(p, nil, "kv", false, logical.TypeLogical, docOrig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -646,7 +646,7 @@ func testPath(t *testing.T, path *Path, sp *logical.Paths, expectedJSON string) 
 	t.Helper()
 
 	doc := NewOASDocument()
-	if err := documentPath(path, sp, "kv", logical.TypeLogical, doc); err != nil {
+	if err := documentPath(path, sp, "kv", false, logical.TypeLogical, doc); err != nil {
 		t.Fatal(err)
 	}
 	doc.CreateOperationIDs("")

--- a/sdk/framework/path.go
+++ b/sdk/framework/path.go
@@ -311,7 +311,7 @@ func (p *Path) helpCallback(b *Backend) OperationFunc {
 
 		// Build OpenAPI response for this path
 		doc := NewOASDocument()
-		if err := documentPath(p, b.SpecialPaths(), requestResponsePrefix, b.BackendType, doc); err != nil {
+		if err := documentPath(p, b.SpecialPaths(), requestResponsePrefix, true, b.BackendType, doc); err != nil {
 			b.Logger().Warn("error generating OpenAPI", "error", err)
 		}
 

--- a/sdk/framework/path.go
+++ b/sdk/framework/path.go
@@ -311,7 +311,7 @@ func (p *Path) helpCallback(b *Backend) OperationFunc {
 
 		// Build OpenAPI response for this path
 		doc := NewOASDocument()
-		if err := documentPath(p, b.SpecialPaths(), requestResponsePrefix, true, b.BackendType, doc); err != nil {
+		if err := documentPath(p, b.SpecialPaths(), requestResponsePrefix, false, b.BackendType, doc); err != nil {
 			b.Logger().Warn("error generating OpenAPI", "error", err)
 		}
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4080,10 +4080,10 @@ func (b *SystemBackend) pathInternalOpenApiDynamic(ctx context.Context, req *log
 					}
 				}
 
-				if mount != "sys/" && mount != "identity" {
+				if mount != "sys/" && mount != "identity/" {
 					doc.Paths["/"+mountPrefix+"{mountPath}/"+path] = obj
 				} else {
-					doc.Paths["/"+mountPrefix+"{mountPath}/"+path] = obj
+					doc.Paths["/"+mountPrefix+mount+path] = obj
 				}
 			}
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4026,7 +4026,7 @@ func (b *SystemBackend) pathInternalOpenApiDynamic(ctx context.Context, req *log
 			req := &logical.Request{
 				Operation: logical.HelpOperation,
 				Storage:   req.Storage,
-				Data:      map[string]interface{}{"requestResponsePrefix": pluginType},
+				Data:      map[string]interface{}{"requestResponsePrefix": pluginType, "dynamicPaths": true},
 			}
 
 			resp, err := backend.HandleRequest(ctx, req)
@@ -4080,7 +4080,11 @@ func (b *SystemBackend) pathInternalOpenApiDynamic(ctx context.Context, req *log
 					}
 				}
 
-				doc.Paths["/"+mountPrefix+mount+path] = obj
+				if mount != "sys/" && mount != "identity" {
+					doc.Paths["/"+mountPrefix+"{mountPath}/"+path] = obj
+				} else {
+					doc.Paths["/"+mountPrefix+"{mountPath}/"+path] = obj
+				}
 			}
 
 			// Merge backend schema components
@@ -4146,7 +4150,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 			req := &logical.Request{
 				Operation: logical.HelpOperation,
 				Storage:   req.Storage,
-				Data:      map[string]interface{}{"requestResponsePrefix": pluginType},
+				Data:      map[string]interface{}{"requestResponsePrefix": pluginType, "dynamicPaths": false},
 			}
 
 			resp, err := backend.HandleRequest(ctx, req)

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -117,6 +117,7 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 				"wrapping/pubkey",
 				"replication/status",
 				"internal/specs/openapi",
+				"internal/specs/dynamic",
 				"internal/ui/mounts",
 				"internal/ui/mounts/*",
 				"internal/ui/namespaces",
@@ -3991,6 +3992,126 @@ func (b *SystemBackend) pathInternalUIResultantACL(ctx context.Context, req *log
 
 	resp.Data["exact_paths"] = exact
 	resp.Data["glob_paths"] = glob
+
+	return resp, nil
+}
+
+func (b *SystemBackend) pathInternalOpenApiDynamic(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	// Limit output to authorized paths
+	resp, err := b.pathInternalUIMountsRead(ctx, req, d)
+	if err != nil {
+		return nil, err
+	}
+
+	context := d.Get("context").(string)
+
+	// Set up target document and convert to map[string]interface{} which is what will
+	// be received from plugin backends.
+	doc := framework.NewOASDocument()
+
+	procMountGroup := func(group, mountPrefix string) error {
+		for mount, entry := range resp.Data[group].(map[string]interface{}) {
+
+			var pluginType string
+			if t, ok := entry.(map[string]interface{})["type"]; ok {
+				pluginType = t.(string)
+			}
+
+			backend := b.Core.router.MatchingBackend(ctx, mountPrefix+mount)
+
+			if backend == nil {
+				continue
+			}
+
+			req := &logical.Request{
+				Operation: logical.HelpOperation,
+				Storage:   req.Storage,
+				Data:      map[string]interface{}{"requestResponsePrefix": pluginType},
+			}
+
+			resp, err := backend.HandleRequest(ctx, req)
+			if err != nil {
+				return err
+			}
+
+			var backendDoc *framework.OASDocument
+
+			// Normalize response type, which will be different if received
+			// from an external plugin.
+			switch v := resp.Data["openapi"].(type) {
+			case *framework.OASDocument:
+				backendDoc = v
+			case map[string]interface{}:
+				backendDoc, err = framework.NewOASDocumentFromMap(v)
+				if err != nil {
+					return err
+				}
+			default:
+				continue
+			}
+
+			// Prepare to add tags to default builtins that are
+			// type "unknown" and won't already be tagged.
+			var tag string
+			switch mountPrefix + mount {
+			case "cubbyhole/", "secret/":
+				tag = "secrets"
+			case "sys/":
+				tag = "system"
+			case "auth/token/":
+				tag = "auth"
+			case "identity/":
+				tag = "identity"
+			}
+
+			// Merge backend paths with existing document
+			for path, obj := range backendDoc.Paths {
+				path := strings.TrimPrefix(path, "/")
+
+				// Add tags to all of the operations if necessary
+				if tag != "" {
+					for _, op := range []*framework.OASOperation{obj.Get, obj.Post, obj.Delete} {
+						// TODO: a special override for identity is used used here because the backend
+						// is currently categorized as "secret", which will likely change. Also of interest
+						// is removing all tag handling here and providing the mount information to OpenAPI.
+						if op != nil && (len(op.Tags) == 0 || tag == "identity") {
+							op.Tags = []string{tag}
+						}
+					}
+				}
+
+				doc.Paths["/"+mountPrefix+mount+path] = obj
+			}
+
+			// Merge backend schema components
+			for e, schema := range backendDoc.Components.Schemas {
+				doc.Components.Schemas[e] = schema
+			}
+		}
+		return nil
+	}
+
+	if err := procMountGroup("secret", ""); err != nil {
+		return nil, err
+	}
+	if err := procMountGroup("auth", "auth/"); err != nil {
+		return nil, err
+	}
+
+	doc.CreateOperationIDs(context)
+
+	buf, err := json.Marshal(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	resp = &logical.Response{
+		Data: map[string]interface{}{
+			logical.HTTPStatusCode:  200,
+			logical.HTTPRawBody:     buf,
+			logical.HTTPContentType: "application/json",
+		},
+	}
 
 	return resp, nil
 }

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4008,7 +4008,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 	// be received from plugin backends.
 	doc := framework.NewOASDocument()
 
-	genericPaths := d.Get("genericPaths").(bool)
+	genericPaths := d.Get("generic_paths").(bool)
 
 	procMountGroup := func(group, mountPrefix string) error {
 		for mount, entry := range resp.Data[group].(map[string]interface{}) {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4008,7 +4008,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 	// be received from plugin backends.
 	doc := framework.NewOASDocument()
 
-	dynamic := d.Get("dynamic").(bool)
+	genericPaths := d.Get("genericPaths").(bool)
 
 	procMountGroup := func(group, mountPrefix string) error {
 		for mount, entry := range resp.Data[group].(map[string]interface{}) {
@@ -4027,7 +4027,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 			req := &logical.Request{
 				Operation: logical.HelpOperation,
 				Storage:   req.Storage,
-				Data:      map[string]interface{}{"requestResponsePrefix": pluginType, "dynamicPaths": dynamic},
+				Data:      map[string]interface{}{"requestResponsePrefix": pluginType, "genericPaths": genericPaths},
 			}
 
 			resp, err := backend.HandleRequest(ctx, req)
@@ -4081,7 +4081,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 					}
 				}
 
-				if dynamic && mount != "sys/" && mount != "identity/" {
+				if genericPaths && mount != "sys/" && mount != "identity/" {
 					doc.Paths["/"+mountPrefix+"{mountPath}/"+path] = obj
 				} else {
 					doc.Paths["/"+mountPrefix+mount+path] = obj

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4008,7 +4008,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 	// be received from plugin backends.
 	doc := framework.NewOASDocument()
 
-	genericMountPaths := d.Get("generic_mount_paths").(bool)
+	genericMountPaths, _ := d.Get("generic_mount_paths").(bool)
 
 	procMountGroup := func(group, mountPrefix string) error {
 		for mount, entry := range resp.Data[group].(map[string]interface{}) {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4008,7 +4008,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 	// be received from plugin backends.
 	doc := framework.NewOASDocument()
 
-	genericPaths := d.Get("generic_paths").(bool)
+	genericMountPaths := d.Get("generic_paths").(bool)
 
 	procMountGroup := func(group, mountPrefix string) error {
 		for mount, entry := range resp.Data[group].(map[string]interface{}) {
@@ -4027,7 +4027,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 			req := &logical.Request{
 				Operation: logical.HelpOperation,
 				Storage:   req.Storage,
-				Data:      map[string]interface{}{"requestResponsePrefix": pluginType, "genericPaths": genericPaths},
+				Data:      map[string]interface{}{"requestResponsePrefix": pluginType, "genericMountPaths": genericMountPaths},
 			}
 
 			resp, err := backend.HandleRequest(ctx, req)
@@ -4081,7 +4081,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 					}
 				}
 
-				if genericPaths && mount != "sys/" && mount != "identity/" {
+				if genericMountPaths && mount != "sys/" && mount != "identity/" {
 					s := fmt.Sprintf("/%s{mountPath}/%s", mountPrefix, path)
 					doc.Paths[s] = obj
 				} else {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4082,7 +4082,8 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 				}
 
 				if genericPaths && mount != "sys/" && mount != "identity/" {
-					doc.Paths["/"+mountPrefix+"{mountPath}/"+path] = obj
+					s := fmt.Sprintf("/%s{mountPath}/%s", mountPrefix, path)
+					doc.Paths[s] = obj
 				} else {
 					doc.Paths["/"+mountPrefix+mount+path] = obj
 				}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4008,7 +4008,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 	// be received from plugin backends.
 	doc := framework.NewOASDocument()
 
-	genericMountPaths := d.Get("generic_paths").(bool)
+	genericMountPaths := d.Get("generic_mount_paths").(bool)
 
 	procMountGroup := func(group, mountPrefix string) error {
 		for mount, entry := range resp.Data[group].(map[string]interface{}) {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -117,7 +117,6 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 				"wrapping/pubkey",
 				"replication/status",
 				"internal/specs/openapi",
-				"internal/specs/dynamic",
 				"internal/ui/mounts",
 				"internal/ui/mounts/*",
 				"internal/ui/namespaces",
@@ -3996,130 +3995,6 @@ func (b *SystemBackend) pathInternalUIResultantACL(ctx context.Context, req *log
 	return resp, nil
 }
 
-func (b *SystemBackend) pathInternalOpenApiDynamic(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	// Limit output to authorized paths
-	resp, err := b.pathInternalUIMountsRead(ctx, req, d)
-	if err != nil {
-		return nil, err
-	}
-
-	context := d.Get("context").(string)
-
-	// Set up target document and convert to map[string]interface{} which is what will
-	// be received from plugin backends.
-	doc := framework.NewOASDocument()
-
-	procMountGroup := func(group, mountPrefix string) error {
-		for mount, entry := range resp.Data[group].(map[string]interface{}) {
-
-			var pluginType string
-			if t, ok := entry.(map[string]interface{})["type"]; ok {
-				pluginType = t.(string)
-			}
-
-			backend := b.Core.router.MatchingBackend(ctx, mountPrefix+mount)
-
-			if backend == nil {
-				continue
-			}
-
-			req := &logical.Request{
-				Operation: logical.HelpOperation,
-				Storage:   req.Storage,
-				Data:      map[string]interface{}{"requestResponsePrefix": pluginType, "dynamicPaths": true},
-			}
-
-			resp, err := backend.HandleRequest(ctx, req)
-			if err != nil {
-				return err
-			}
-
-			var backendDoc *framework.OASDocument
-
-			// Normalize response type, which will be different if received
-			// from an external plugin.
-			switch v := resp.Data["openapi"].(type) {
-			case *framework.OASDocument:
-				backendDoc = v
-			case map[string]interface{}:
-				backendDoc, err = framework.NewOASDocumentFromMap(v)
-				if err != nil {
-					return err
-				}
-			default:
-				continue
-			}
-
-			// Prepare to add tags to default builtins that are
-			// type "unknown" and won't already be tagged.
-			var tag string
-			switch mountPrefix + mount {
-			case "cubbyhole/", "secret/":
-				tag = "secrets"
-			case "sys/":
-				tag = "system"
-			case "auth/token/":
-				tag = "auth"
-			case "identity/":
-				tag = "identity"
-			}
-
-			// Merge backend paths with existing document
-			for path, obj := range backendDoc.Paths {
-				path := strings.TrimPrefix(path, "/")
-
-				// Add tags to all of the operations if necessary
-				if tag != "" {
-					for _, op := range []*framework.OASOperation{obj.Get, obj.Post, obj.Delete} {
-						// TODO: a special override for identity is used used here because the backend
-						// is currently categorized as "secret", which will likely change. Also of interest
-						// is removing all tag handling here and providing the mount information to OpenAPI.
-						if op != nil && (len(op.Tags) == 0 || tag == "identity") {
-							op.Tags = []string{tag}
-						}
-					}
-				}
-
-				if mount != "sys/" && mount != "identity/" {
-					doc.Paths["/"+mountPrefix+"{mountPath}/"+path] = obj
-				} else {
-					doc.Paths["/"+mountPrefix+mount+path] = obj
-				}
-			}
-
-			// Merge backend schema components
-			for e, schema := range backendDoc.Components.Schemas {
-				doc.Components.Schemas[e] = schema
-			}
-		}
-		return nil
-	}
-
-	if err := procMountGroup("secret", ""); err != nil {
-		return nil, err
-	}
-	if err := procMountGroup("auth", "auth/"); err != nil {
-		return nil, err
-	}
-
-	doc.CreateOperationIDs(context)
-
-	buf, err := json.Marshal(doc)
-	if err != nil {
-		return nil, err
-	}
-
-	resp = &logical.Response{
-		Data: map[string]interface{}{
-			logical.HTTPStatusCode:  200,
-			logical.HTTPRawBody:     buf,
-			logical.HTTPContentType: "application/json",
-		},
-	}
-
-	return resp, nil
-}
-
 func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	// Limit output to authorized paths
 	resp, err := b.pathInternalUIMountsRead(ctx, req, d)
@@ -4133,6 +4008,8 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 	// be received from plugin backends.
 	doc := framework.NewOASDocument()
 
+	dynamic := d.Get("dynamic").(bool)
+
 	procMountGroup := func(group, mountPrefix string) error {
 		for mount, entry := range resp.Data[group].(map[string]interface{}) {
 
@@ -4150,7 +4027,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 			req := &logical.Request{
 				Operation: logical.HelpOperation,
 				Storage:   req.Storage,
-				Data:      map[string]interface{}{"requestResponsePrefix": pluginType, "dynamicPaths": false},
+				Data:      map[string]interface{}{"requestResponsePrefix": pluginType, "dynamicPaths": dynamic},
 			}
 
 			resp, err := backend.HandleRequest(ctx, req)
@@ -4204,7 +4081,11 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 					}
 				}
 
-				doc.Paths["/"+mountPrefix+mount+path] = obj
+				if dynamic && mount != "sys/" && mount != "identity/" {
+					doc.Paths["/"+mountPrefix+"{mountPath}/"+path] = obj
+				} else {
+					doc.Paths["/"+mountPrefix+mount+path] = obj
+				}
 			}
 
 			// Merge backend schema components

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -916,6 +916,28 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 			},
 		},
 		{
+			Pattern: "internal/specs/dynamic",
+			Fields: map[string]*framework.FieldSchema{
+				"context": {
+					Type:        framework.TypeString,
+					Description: "Context string appended to every operationId",
+				},
+			},
+			Callbacks: map[logical.Operation]framework.OperationFunc{
+				logical.ReadOperation: b.pathInternalOpenApiDynamic,
+				logical.UpdateOperation: b.pathInternalOpenApiDynamic,
+			},
+		},
+		{
+			Pattern: "internal/specs/dynamic",
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathInternalOpenApiDynamic,
+					Summary:  "Generate an OpenAPI 3 document of all mounted paths.",
+				},
+			},
+		},
+		{
 			Pattern: "internal/ui/feature-flags",
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -925,7 +925,6 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 			},
 			Callbacks: map[logical.Operation]framework.OperationFunc{
 				logical.ReadOperation: b.pathInternalOpenApiDynamic,
-				logical.UpdateOperation: b.pathInternalOpenApiDynamic,
 			},
 		},
 		{

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -900,6 +900,11 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 					Type:        framework.TypeString,
 					Description: "Context string appended to every operationId",
 				},
+				"dynamic": {
+					Type:        framework.TypeBool,
+					Description: "Use dynamic mount paths",
+					Query:       true,
+				},
 			},
 			Callbacks: map[logical.Operation]framework.OperationFunc{
 				logical.ReadOperation:   b.pathInternalOpenAPI,
@@ -911,27 +916,6 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
 					Callback: b.pathInternalOpenAPI,
-					Summary:  "Generate an OpenAPI 3 document of all mounted paths.",
-				},
-			},
-		},
-		{
-			Pattern: "internal/specs/dynamic",
-			Fields: map[string]*framework.FieldSchema{
-				"context": {
-					Type:        framework.TypeString,
-					Description: "Context string appended to every operationId",
-				},
-			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.ReadOperation: b.pathInternalOpenApiDynamic,
-			},
-		},
-		{
-			Pattern: "internal/specs/dynamic",
-			Operations: map[logical.Operation]framework.OperationHandler{
-				logical.ReadOperation: &framework.PathOperation{
-					Callback: b.pathInternalOpenApiDynamic,
 					Summary:  "Generate an OpenAPI 3 document of all mounted paths.",
 				},
 			},

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -904,6 +904,7 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 					Type:        framework.TypeBool,
 					Description: "Use generic mount paths",
 					Query:       true,
+					Default:     false,
 				},
 			},
 			Callbacks: map[logical.Operation]framework.OperationFunc{

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -900,9 +900,9 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 					Type:        framework.TypeString,
 					Description: "Context string appended to every operationId",
 				},
-				"dynamic": {
+				"genericPaths": {
 					Type:        framework.TypeBool,
-					Description: "Use dynamic mount paths",
+					Description: "Use generic mount paths",
 					Query:       true,
 				},
 			},

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -900,7 +900,7 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 					Type:        framework.TypeString,
 					Description: "Context string appended to every operationId",
 				},
-				"generic_paths": {
+				"generic_mount_paths": {
 					Type:        framework.TypeBool,
 					Description: "Use generic mount paths",
 					Query:       true,

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -900,7 +900,7 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 					Type:        framework.TypeString,
 					Description: "Context string appended to every operationId",
 				},
-				"genericPaths": {
+				"generic_paths": {
 					Type:        framework.TypeBool,
 					Description: "Use generic mount paths",
 					Query:       true,

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -3408,7 +3408,7 @@ func TestSystemBackend_InternalUIMount(t *testing.T) {
 	}
 }
 
-func TestSystemBackend_OASDynamic(t *testing.T) {
+func TestSystemBackend_OASDynamicMount(t *testing.T) {
 	_, b, rootToken := testCoreSystemBackend(t)
 	var oapi map[string]interface{}
 
@@ -3453,9 +3453,9 @@ func TestSystemBackend_OASDynamic(t *testing.T) {
 		}
 	}
 
-	// Simple sanity check of response size (which is much larger than most
+	// Simple check of response size (which is much larger than most
 	// Vault responses), mainly to catch mass omission of expected path data.
-	minLen := 70000
+	const minLen = 70000
 	if len(body) < minLen {
 		t.Fatalf("response size too small; expected: min %d, actual: %d", minLen, len(body))
 	}
@@ -3538,9 +3538,9 @@ func TestSystemBackend_OpenAPI(t *testing.T) {
 		}
 	}
 
-	// Simple sanity check of response size (which is much larger than most
+	// Simple check of response size (which is much larger than most
 	// Vault responses), mainly to catch mass omission of expected path data.
-	minLen := 70000
+	const minLen = 70000
 	if len(body) < minLen {
 		t.Fatalf("response size too small; expected: min %d, actual: %d", minLen, len(body))
 	}

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -3408,13 +3408,13 @@ func TestSystemBackend_InternalUIMount(t *testing.T) {
 	}
 }
 
-func TestSystemBackend_OASDynamicMount(t *testing.T) {
+func TestSystemBackend_OASGenericMount(t *testing.T) {
 	_, b, rootToken := testCoreSystemBackend(t)
 	var oapi map[string]interface{}
 
 	// Check that default paths are present with a root token
 	req := logical.TestRequest(t, logical.ReadOperation, "internal/specs/openapi")
-	req.Data["dynamic"] = true
+	req.Data["genericPaths"] = true
 	req.ClientToken = rootToken
 	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
 	if err != nil {

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -3414,7 +3414,7 @@ func TestSystemBackend_OASGenericMount(t *testing.T) {
 
 	// Check that default paths are present with a root token
 	req := logical.TestRequest(t, logical.ReadOperation, "internal/specs/openapi")
-	req.Data["generic_paths"] = true
+	req.Data["generic_mount_paths"] = true
 	req.ClientToken = rootToken
 	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
 	if err != nil {

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -3414,7 +3414,7 @@ func TestSystemBackend_OASGenericMount(t *testing.T) {
 
 	// Check that default paths are present with a root token
 	req := logical.TestRequest(t, logical.ReadOperation, "internal/specs/openapi")
-	req.Data["genericPaths"] = true
+	req.Data["generic_paths"] = true
 	req.ClientToken = rootToken
 	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
 	if err != nil {

--- a/website/content/api-docs/system/internal-specs-openapi.mdx
+++ b/website/content/api-docs/system/internal-specs-openapi.mdx
@@ -35,10 +35,11 @@ This endpoint returns a single OpenAPI document describing all paths visible to 
 
 - `generic_mount_paths` `(bool: false)` – Used to specify whether to use generic mount paths. If set, the mount paths will be replaced with a dynamic parameter: `{mountPath}`
 
+
 ### Sample Request
 
 ```shell-session
-$ curl http://127.0.0.1:8200/v1/sys/internal/specs/openapi
+$ curl http://127.0.0.1:8200/v1/sys/internal/specs/openapi?generic_mount_paths=false
 ```
 
 ### Sample Response

--- a/website/content/api-docs/system/internal-specs-openapi.mdx
+++ b/website/content/api-docs/system/internal-specs-openapi.mdx
@@ -33,7 +33,7 @@ This endpoint returns a single OpenAPI document describing all paths visible to 
 
 ### Parameters
 
-- `generic_mount_paths` `(bool: false)` – Used to specify whether to use a generic mount path. If set, the mount path will be replaced with a dynamic parameter: `{mountPath}`
+- `generic_mount_paths` `(bool: false)` – Used to specify whether to use generic mount paths. If set, the mount paths will be replaced with a dynamic parameter: `{mountPath}`
 
 ### Sample Request
 

--- a/website/content/api-docs/system/internal-specs-openapi.mdx
+++ b/website/content/api-docs/system/internal-specs-openapi.mdx
@@ -33,7 +33,7 @@ This endpoint returns a single OpenAPI document describing all paths visible to 
 
 ### Parameters
 
-- `generic_paths` `(bool: false)` – Used to specify whether to use a generic mount path. If set, the mount path will be replaced with a dynamic parameter: `{mountPath}`
+- `generic_mount_paths` `(bool: false)` – Used to specify whether to use a generic mount path. If set, the mount path will be replaced with a dynamic parameter: `{mountPath}`
 
 ### Sample Request
 

--- a/website/content/api-docs/system/internal-specs-openapi.mdx
+++ b/website/content/api-docs/system/internal-specs-openapi.mdx
@@ -31,6 +31,10 @@ This endpoint returns a single OpenAPI document describing all paths visible to 
 | :----- | :---------------------------- |
 | `GET`  | `/sys/internal/specs/openapi` |
 
+### Parameters
+
+- `generic_paths` `(bool: false)` – Used to specify whether to use a generic mount path. If set, the mount path will be replaced with a dynamic parameter: `{mountPath}`
+
 ### Sample Request
 
 ```shell-session


### PR DESCRIPTION
This query parameter will be primarily for DevEx and code generation usage. The idea is to replace hard coded mount paths in the OpenApi spec with a dynamic parameter i.e. `{mountPath}`.

When the new call is made to `/sys/internal/specs/openapi?generic_paths=true` the resulting OpenApi spec will have 

`"paths": {
    "/auth/{mountPath}/login/": {
      "description": "",
      "parameters": [
        {
          "name": "mountPath",
          "description": "Path that the backend was mounted at",
          "in": "path",
          "schema": {
            "type": "string"
          },
          "required": true
        }
      ],`

The resulting generated code will allow users of the client library to pass through a mount path that would've otherwise been hardcoded as e.g. `approle`
