### PR TITLE
Provide more warnings to users for deprecated or unrecognized paremeters

### DIFF
--- a/api/kv_v2.go
+++ b/api/kv_v2.go
@@ -146,7 +146,7 @@ func (kv *KVv2) GetVersion(ctx context.Context, secretPath string, version int) 
 	if err != nil {
 		return nil, err
 	}
-	if secret == nil {
+	if secret == nil || secret.IsOnlyWarnings() {
 		return nil, fmt.Errorf("%w: for version %d at %s", ErrSecretNotFound, version, pathToRead)
 	}
 

--- a/api/secret.go
+++ b/api/secret.go
@@ -268,6 +268,24 @@ func (s *Secret) TokenTTL() (time.Duration, error) {
 	return ttl, nil
 }
 
+// IsOnlyWarnings return whether the secret is "essentially nil", other than
+// for it returning attached warnings.
+func (s *Secret) IsOnlyWarnings() bool {
+	if s != nil &&
+		len(s.Warnings) > 0 &&
+		len(s.Data) == 0 &&
+		s.LeaseDuration == 0 &&
+		s.LeaseID == "" &&
+		!s.Renewable &&
+		s.Auth == nil &&
+		s.WrapInfo == nil {
+
+		return true
+	}
+
+	return false
+}
+
 // SecretWrapInfo contains wrapping information if we have it. If what is
 // contained is an authentication token, the accessor for the token will be
 // available in WrappedAccessor.

--- a/api/secret.go
+++ b/api/secret.go
@@ -268,7 +268,7 @@ func (s *Secret) TokenTTL() (time.Duration, error) {
 	return ttl, nil
 }
 
-// IsOnlyWarnings return whether the secret is "essentially nil", other than
+// IsOnlyWarnings returns whether the secret is "essentially nil", other than
 // for it returning attached warnings.
 func (s *Secret) IsOnlyWarnings() bool {
 	if s != nil &&

--- a/builtin/credential/approle/path_role_test.go
+++ b/builtin/credential/approle/path_role_test.go
@@ -2115,7 +2115,7 @@ func TestAppRole_RoleWithTokenTypeCRUD(t *testing.T) {
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
-	if 0 == len(resp.Warnings) {
+	if len(resp.Warnings) == 0 {
 		t.Fatalf("bad:\nexpected warning in resp:%#v\n", resp.Warnings)
 	}
 
@@ -2215,7 +2215,7 @@ func TestAppRole_RoleWithTokenTypeCRUD(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("expected a nil response")
 	}
 }

--- a/builtin/credential/aws/path_role_test.go
+++ b/builtin/credential/aws/path_role_test.go
@@ -703,7 +703,7 @@ func TestAwsEc2_RoleCrud(t *testing.T) {
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("resp: %#v, err: %v", resp, err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("failed to delete role entry")
 	}
 
@@ -713,7 +713,7 @@ func TestAwsEc2_RoleCrud(t *testing.T) {
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("resp: %#v, err: %v", resp, err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatal("expected nil")
 	}
 }

--- a/builtin/logical/aws/secret_access_keys_test.go
+++ b/builtin/logical/aws/secret_access_keys_test.go
@@ -139,7 +139,7 @@ func TestReadConfig_DefaultTemplate(t *testing.T) {
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("bad: resp: %#v\nerr:%s", resp, err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatal("expected a nil response")
 	}
 
@@ -183,7 +183,7 @@ func TestReadConfig_CustomTemplate(t *testing.T) {
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("bad: resp: %#v\nerr:%s", resp, err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatal("expected a nil response")
 	}
 

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -81,6 +81,7 @@ func TestBackend_StaticRole_Rotate_basic(t *testing.T) {
 	}
 
 	data = map[string]interface{}{
+		"name":                "plugin-role-test",
 		"db_name":             "plugin-test",
 		"rotation_statements": testRoleStaticUpdate,
 		"username":            dbUser,
@@ -140,12 +141,10 @@ func TestBackend_StaticRole_Rotate_basic(t *testing.T) {
 	}
 
 	// Trigger rotation
-	data = map[string]interface{}{"name": "plugin-role-test"}
 	req = &logical.Request{
 		Operation: logical.UpdateOperation,
 		Path:      "rotate-role/plugin-role-test",
 		Storage:   config.StorageView,
-		Data:      data,
 	}
 	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
 	if err != nil || (resp != nil && resp.IsError()) {

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -81,7 +81,6 @@ func TestBackend_StaticRole_Rotate_basic(t *testing.T) {
 	}
 
 	data = map[string]interface{}{
-		"name":                "plugin-role-test",
 		"db_name":             "plugin-test",
 		"rotation_statements": testRoleStaticUpdate,
 		"username":            dbUser,

--- a/builtin/logical/rabbitmq/path_role_create_test.go
+++ b/builtin/logical/rabbitmq/path_role_create_test.go
@@ -42,7 +42,6 @@ func TestBackend_RoleCreate_DefaultUsernameTemplate(t *testing.T) {
 	}
 
 	roleData := map[string]interface{}{
-		"name": "foo",
 		"tags": "bar",
 	}
 	roleReq := &logical.Request{
@@ -56,7 +55,7 @@ func TestBackend_RoleCreate_DefaultUsernameTemplate(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr:%s", resp, err)
 	}
 	if resp != nil {
-		t.Fatal("expected a nil response")
+		t.Fatalf("expected a nil response: (%#v)", resp)
 	}
 
 	credsReq := &logical.Request{
@@ -114,11 +113,10 @@ func TestBackend_RoleCreate_CustomUsernameTemplate(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr:%s", resp, err)
 	}
 	if resp != nil {
-		t.Fatal("expected a nil response")
+		t.Fatalf("expected a nil response: (%#v)", resp)
 	}
 
 	roleData := map[string]interface{}{
-		"name": "foo",
 		"tags": "bar",
 	}
 	roleReq := &logical.Request{

--- a/changelog/15837.txt
+++ b/changelog/15837.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Provide more warnings to users when ignored, replaced, or deprecated parameters are provided
+```

--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -203,7 +203,7 @@ func (c *KVPutCommand) Run(args []string) int {
 	}
 
 	// If the response has only warnings, we still want to print output
-	if secret == nil || checkWarningResponse(secret) {
+	if secret == nil || secret.IsOnlyWarnings() {
 		// Don't output anything unless using the "table" format
 		if Format(c.UI) == "table" {
 			c.UI.Info(fmt.Sprintf("Success! Data written to: %s", fullPath))

--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -201,11 +201,14 @@ func (c *KVPutCommand) Run(args []string) int {
 		}
 		return 2
 	}
-	if secret == nil {
+
+	// If the response has only warnings, we still want to print output
+	if secret == nil || checkWarningResponse(secret) {
 		// Don't output anything unless using the "table" format
 		if Format(c.UI) == "table" {
 			c.UI.Info(fmt.Sprintf("Success! Data written to: %s", fullPath))
 		}
+
 		return 0
 	}
 

--- a/command/kv_test.go
+++ b/command/kv_test.go
@@ -262,7 +262,7 @@ func TestKVPutCommand(t *testing.T) {
 		}
 		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
 		if !strings.Contains(combined, "Success!") {
-			t.Errorf("expected %q to contain %q", combined, "created_time")
+			t.Errorf("expected %q to contain %q", combined, "Success!")
 		}
 
 		ui, rcmd := testReadCommand(t)

--- a/command/write.go
+++ b/command/write.go
@@ -147,6 +147,7 @@ func (c *WriteCommand) Run(args []string) int {
 		return 2
 	}
 
+	// If the response has only warnings, we still want to print output
 	hasWarnings := checkWarningResponse(secret)
 	if secret == nil || hasWarnings {
 		// Don't output anything unless using the "table" format

--- a/command/write.go
+++ b/command/write.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/hashicorp/vault/api"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
 )
@@ -148,7 +147,7 @@ func (c *WriteCommand) Run(args []string) int {
 	}
 
 	// If the response has only warnings, we still want to print output
-	hasWarnings := checkWarningResponse(secret)
+	hasWarnings := secret.IsOnlyWarnings()
 	if secret == nil || hasWarnings {
 		// Don't output anything unless using the "table" format
 		if Format(c.UI) == "table" {
@@ -180,21 +179,4 @@ func (c *WriteCommand) Run(args []string) int {
 	}
 
 	return OutputSecret(c.UI, secret)
-}
-
-// Checks for a response that only contains warnings and nothing else.
-func checkWarningResponse(secret *api.Secret) bool {
-	if secret != nil &&
-		len(secret.Warnings) > 0 &&
-		len(secret.Data) == 0 &&
-		secret.LeaseDuration == 0 &&
-		secret.Renewable == false &&
-		secret.LeaseID == "" &&
-		secret.Auth == nil &&
-		secret.WrapInfo == nil {
-
-		return true
-	}
-
-	return false
 }

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -318,6 +318,8 @@ func (b *Backend) HandleRequest(ctx context.Context, req *logical.Request) (*log
 	return resp, nil
 }
 
+// Builds the list of warnings in the response from the give list of string
+// values with its corresponding warning text.
 func handleRequestCheckWarnings(resp **logical.Response, list []string, warning string) {
 	if len(list) > 0 {
 		if *resp == nil {

--- a/sdk/logical/response.go
+++ b/sdk/logical/response.go
@@ -108,6 +108,24 @@ func (r *Response) Error() error {
 	return nil
 }
 
+// IsOnlyWarnings return whether the secret is "essentially nil", other than
+// for it returning attached warnings.
+func (r *Response) IsOnlyWarnings() bool {
+	if r != nil &&
+		len(r.Warnings) > 0 &&
+		len(r.Data) == 0 &&
+		r.Redirect == "" &&
+		r.Headers == nil &&
+		r.Auth == nil &&
+		r.Secret == nil &&
+		r.WrapInfo == nil {
+
+		return true
+	}
+
+	return false
+}
+
 // HelpResponse is used to format a help response
 func HelpResponse(text string, seeAlso []string, oapiDoc interface{}) *Response {
 	return &Response{

--- a/sdk/logical/response.go
+++ b/sdk/logical/response.go
@@ -108,22 +108,14 @@ func (r *Response) Error() error {
 	return nil
 }
 
-// IsOnlyWarnings return whether the secret is "essentially nil", other than
+// IsOnlyWarnings returns whether the secret is "essentially nil", other than
 // for it returning attached warnings.
 func (r *Response) IsOnlyWarnings() bool {
-	if r != nil &&
-		len(r.Warnings) > 0 &&
-		len(r.Data) == 0 &&
-		r.Redirect == "" &&
-		r.Headers == nil &&
-		r.Auth == nil &&
-		r.Secret == nil &&
-		r.WrapInfo == nil {
-
-		return true
-	}
-
-	return false
+	return r != nil &&
+		len(r.Warnings) > 0 && len(r.Data) == 0 &&
+		r.Redirect == "" && r.Headers == nil &&
+		r.Auth == nil && r.Secret == nil &&
+		r.WrapInfo == nil
 }
 
 // HelpResponse is used to format a help response

--- a/vault/core_metrics_test.go
+++ b/vault/core_metrics_test.go
@@ -79,7 +79,7 @@ func TestCoreMetrics_KvSecretGauge(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		if resp != nil {
+		if resp != nil && !resp.IsOnlyWarnings() {
 			t.Fatalf("bad: %#v", resp)
 		}
 	}

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -171,7 +171,7 @@ func TestCore_UseSSCTokenToggleOn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -226,7 +226,7 @@ func TestCore_UseNonSSCTokenToggleOff(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -559,7 +559,7 @@ func TestCore_HandleRequest_Lease(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -605,7 +605,7 @@ func TestCore_HandleRequest_Lease_MaxLength(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -651,7 +651,7 @@ func TestCore_HandleRequest_Lease_DefaultLength(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -848,7 +848,7 @@ func TestCore_HandleRequest_PermissionAllowed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 }
@@ -1058,7 +1058,8 @@ func TestCore_HandleRequest_AuditTrail(t *testing.T) {
 	if len(noop.RespReq) != 2 || !reflect.DeepEqual(noop.RespReq[1], req) {
 		t.Fatalf("Bad: %#v", noop.RespReq[1])
 	}
-	if len(noop.Resp) != 2 || !reflect.DeepEqual(noop.Resp[1], resp) {
+	if len(noop.Resp) != 2 ||
+		(!reflect.DeepEqual(noop.Resp[1], resp) && !noop.Resp[1].IsOnlyWarnings()) {
 		t.Fatalf("Bad: %#v", noop.Resp[1])
 	}
 }
@@ -1140,7 +1141,8 @@ func TestCore_HandleRequest_AuditTrail_noHMACKeys(t *testing.T) {
 	if len(noop.RespReq) != 2 || !reflect.DeepEqual(noop.RespReq[1], req) {
 		t.Fatalf("Bad: %#v", noop.RespReq[1])
 	}
-	if len(noop.Resp) != 2 || !reflect.DeepEqual(noop.Resp[1], resp) {
+	if len(noop.Resp) != 2 ||
+		(!reflect.DeepEqual(noop.Resp[1], resp) && !noop.Resp[1].IsOnlyWarnings()) {
 		t.Fatalf("Bad: %#v", noop.Resp[1])
 	}
 
@@ -2202,7 +2204,7 @@ func TestCore_RenewSameLease(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -2377,7 +2379,7 @@ path "secret/*" {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 

--- a/vault/identity_store_group_aliases_test.go
+++ b/vault/identity_store_group_aliases_test.go
@@ -332,7 +332,7 @@ func TestIdentityStore_GroupAliases_CRUD(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr: %v\n", resp, err)
 	}
 
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("failed to delete group alias")
 	}
 }

--- a/vault/logical_cubbyhole_test.go
+++ b/vault/logical_cubbyhole_test.go
@@ -26,7 +26,7 @@ func TestCubbyholeBackend_Write(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %v", resp)
 	}
 
@@ -177,7 +177,7 @@ func TestCubbyholeIsolation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %v", resp)
 	}
 
@@ -209,7 +209,7 @@ func TestCubbyholeIsolation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %v", resp)
 	}
 

--- a/vault/logical_passthrough_test.go
+++ b/vault/logical_passthrough_test.go
@@ -33,7 +33,7 @@ func TestPassthroughBackend_Write(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		if resp != nil {
+		if resp != nil && !resp.IsOnlyWarnings() {
 			t.Fatalf("bad: %v", resp)
 		}
 

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -1068,7 +1068,7 @@ func TestSystemBackend_leases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -1118,7 +1118,7 @@ func TestSystemBackend_leases_list(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -1227,7 +1227,7 @@ func TestSystemBackend_leases_list(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -1278,7 +1278,7 @@ func TestSystemBackend_renew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -1318,7 +1318,7 @@ func TestSystemBackend_renew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -1450,7 +1450,7 @@ func TestSystemBackend_revoke(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -1604,7 +1604,7 @@ func TestSystemBackend_revokePrefix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -1656,7 +1656,7 @@ func TestSystemBackend_revokePrefix_origUrl(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 

--- a/vault/request_handling_test.go
+++ b/vault/request_handling_test.go
@@ -43,7 +43,7 @@ func TestRequestHandling_Wrapping(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -103,7 +103,7 @@ func TestRequestHandling_LoginWrapping(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -383,7 +383,7 @@ func TestRequestHandling_LoginMetric(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 
@@ -441,7 +441,7 @@ func TestRequestHandling_SecretLeaseMetric(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("bad: %#v", resp)
 	}
 

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -3171,7 +3171,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("expected a nil response")
 	}
 
@@ -3237,7 +3237,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("expected a nil response")
 	}
 
@@ -4020,7 +4020,7 @@ func TestTokenStore_RolePeriod(t *testing.T) {
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("expected a nil response")
 	}
 
@@ -4201,7 +4201,7 @@ func TestTokenStore_RoleExplicitMaxTTL(t *testing.T) {
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("expected a nil response")
 	}
 
@@ -4348,7 +4348,7 @@ func TestTokenStore_RoleExplicitMaxTTL(t *testing.T) {
 		req.Data = map[string]interface{}{
 			"increment": 300,
 		}
-		resp, err = core.HandleRequest(namespace.RootContext(nil), req)
+		_, err = core.HandleRequest(namespace.RootContext(nil), req)
 		if err == nil {
 			t.Fatalf("expected error")
 		}
@@ -4474,7 +4474,7 @@ func TestTokenStore_RoleTokenFields(t *testing.T) {
 		if err != nil || (resp != nil && resp.IsError()) {
 			t.Fatalf("err: %v\nresp: %#v", err, resp)
 		}
-		if resp != nil {
+		if resp != nil && !resp.IsOnlyWarnings() {
 			t.Fatalf("expected a nil response")
 		}
 
@@ -4586,8 +4586,8 @@ func TestTokenStore_RoleTokenFields(t *testing.T) {
 		if resp == nil {
 			t.Fatalf("expected a non-nil response")
 		}
-		if len(resp.Warnings) != 3 {
-			t.Fatalf("expected 3 warnings, got %#v", resp.Warnings)
+		if len(resp.Warnings) != 4 {
+			t.Fatalf("expected 4 warnings, got %#v", resp.Warnings)
 		}
 
 		req = logical.TestRequest(t, logical.ReadOperation, "roles/test")
@@ -4644,7 +4644,7 @@ func TestTokenStore_Periodic(t *testing.T) {
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("expected a nil response")
 	}
 
@@ -4900,7 +4900,7 @@ func TestTokenStore_Periodic_ExplicitMax(t *testing.T) {
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
-	if resp != nil {
+	if resp != nil && !resp.IsOnlyWarnings() {
 		t.Fatalf("expected a nil response")
 	}
 
@@ -4980,7 +4980,7 @@ func TestTokenStore_Periodic_ExplicitMax(t *testing.T) {
 		if err != nil || (resp != nil && resp.IsError()) {
 			t.Fatalf("err: %v\nresp: %#v", err, resp)
 		}
-		if resp != nil {
+		if resp != nil && !resp.IsOnlyWarnings() {
 			t.Fatalf("expected a nil response")
 		}
 


### PR DESCRIPTION
## Summary

This PR is to showcase Vault providing more warnings when users provide unrecognized or deprecated parameters in requests. Currently, warnings are only given when the request generates a response (e.g. a `vault read` but not a `vault write`). This change adds a response to requests that previously didn't have one, like `vault write`, but only when there are warnings to provide.

A secondary positive impact of this change is that it aids with troubleshooting. For example, if you have a typo in a command, e.g. `vault write consul/roles/management consul_polices="global-management"`, it will warn that "consul_polices" is unrecognized, pointing out to the user that they misspelled the word "policies".

&nbsp;

## Examples using Consul secrets engine

Just an unrecognized parameter:
```
❯ vault write consul/roles/management \
   consul_policies="global-management" \
   not-a-real-parameter="does not exist"

WARNING! The following warnings were returned from Vault:

  * Endpoint ignored these unrecognized parameters: [not-a-real-parameter]
```

Just a deprecated parameter:
```
❯ vault write consul/roles/oldtoken \
   policy="$(base64 <<< 'key "" { policy = "read" }')"

WARNING! The following warnings were returned from Vault:

  * Endpoint received these deprecated parameters which may be removed in future Vault releases: [policy]
```

Both deprecated parameters and unrecognized parameters:
```
❯ vault write consul/roles/oldtoken \
   not-a-real-parameter="doesn't exist" \
   token_type="client" \
   policy="$(base64 <<< 'key "" { policy = "read" }')"

WARNING! The following warnings were returned from Vault:

  * Endpoint received these deprecated parameters which may be removed in future Vault releases: [policy token_type]

  * Endpoint ignored these unrecognized parameters: [not-a-real-parameter]
```