### PR TITLE
Add support notes, Entropy Augmentation notes, RH repo

### DIFF
--- a/website/content/docs/configuration/entropy-augmentation.mdx
+++ b/website/content/docs/configuration/entropy-augmentation.mdx
@@ -17,7 +17,9 @@ block in Vault's configuration file.
 
 ## Requirements
 
-A valid Vault Enterprise license is required for Entropy Augmentation
+A valid Vault Enterprise license is required for Entropy Augmentation.
+
+~> **Warning** This feature does not work with FIPS 140-2 Inside variants of Vault.
 
 Additionally, the following software packages and enterprise modules are required for sourcing entropy
 via the [PKCS11 seal](/docs/configuration/seal/pkcs11):

--- a/website/content/docs/configuration/entropy-augmentation.mdx
+++ b/website/content/docs/configuration/entropy-augmentation.mdx
@@ -19,7 +19,7 @@ block in Vault's configuration file.
 
 A valid Vault Enterprise license is required for Entropy Augmentation.
 
-~> **Warning** This feature does not work with FIPS 140-2 Inside variants of Vault.
+~> **Warning** This feature is not available with FIPS 140-2 Inside variants of Vault.
 
 Additionally, the following software packages and enterprise modules are required for sourcing entropy
 via the [PKCS11 seal](/docs/configuration/seal/pkcs11):

--- a/website/content/docs/enterprise/entropy-augmentation.mdx
+++ b/website/content/docs/enterprise/entropy-augmentation.mdx
@@ -10,7 +10,7 @@ description: |-
 
 -> **Note**: This feature requires [Vault Enterprise Plus](https://www.hashicorp.com/products/vault/).
 
-~> **Warning** This feature does not work with FIPS 140-2 Inside variants of Vault.
+~> **Warning** This feature is not available with FIPS 140-2 Inside variants of Vault.
 
 Vault Enterprise features a mechanism to sample entropy (or randomness for
 cryptographic operations) from external cryptographic modules via the [seals](/docs/configuration/seal)

--- a/website/content/docs/enterprise/entropy-augmentation.mdx
+++ b/website/content/docs/enterprise/entropy-augmentation.mdx
@@ -10,6 +10,8 @@ description: |-
 
 -> **Note**: This feature requires [Vault Enterprise Plus](https://www.hashicorp.com/products/vault/).
 
+~> **Warning** This feature does not work with FIPS 140-2 Inside variants of Vault.
+
 Vault Enterprise features a mechanism to sample entropy (or randomness for
 cryptographic operations) from external cryptographic modules via the [seals](/docs/configuration/seal)
 interface. While the system entropy used by Vault is more than capable of

--- a/website/content/docs/enterprise/fips/fips1402.mdx
+++ b/website/content/docs/enterprise/fips/fips1402.mdx
@@ -40,6 +40,10 @@ A non-exhaustive list of potential compliance issues include:
  - Using FF3-1/FPE in Transform Secrets Engine, or
  - Using a Derived Key (using HKDF) for Agent auto-authing or the Transit
    Secrets Engine.
+ - Using **Entropy Augmentation**: because BoringCrypto uses its internal,
+   FIPS 140-2 approved RNG, it cannot mix entropy from other sources.
+   Attempting to use EA with FIPS 140-2 HSM enabled binaries will result
+   in failures such as `panic: boringcrypto: invalid code execution`.
 
 Hashicorp can only provide general guidance regarding using Vault Enterprise
 in a FIPS-compliant manner. We are not a NIST-certified testing laboratory
@@ -55,12 +59,26 @@ from the following sources:
    container repository.
  - From the [AWS ECR `hashicorp/vault-enterprise-fips`](https://gallery.ecr.aws/hashicorp/vault-enterprise-fips)
    container repository.
+ - From the [Red Hat Access `hashicorp/vault-enterprise-fips`](https://catalog.redhat.com/software/containers/hashicorp/vault-enterprise-fips/628d50e37ff70c66a88517ea)
+   container repository.
 
 ~> **Note**: When pulling the FIPS UBI-based images, note that they are
    ultimately designed for OpenShift certification; consider either adding
    the `--user root --cap-add IPC_LOCK` options, to allow Vault to enable
    mlock, or use the `--env SKIP_SETCAP=1` option, to disable mlock
    completely, as appropriate for your environment.
+
+### Usage Restrictions
+
+Hashicorp **does not** support in-place migrations from non-FIPS Inside
+versions of Vault to FIPS Inside versions of Vault, regardless of version.
+A fresh cluster installation is required to receive support. Any issues found
+during in-place migrations will not be addressed by Hashicorp.
+
+Entropy Augmentation **does not** work with FIPS 140-2 Inside. The internal
+BoringCrypto RNG is FIPS 140-2 certified and does not accept entropy from
+other sources. Attempting to use Entropy Augmentation will result in failures
+at runtime such as `panic: boringcrypto: invalid code execution`.
 
 ## Technical Details
 

--- a/website/content/docs/enterprise/fips/fips1402.mdx
+++ b/website/content/docs/enterprise/fips/fips1402.mdx
@@ -72,8 +72,7 @@ from the following sources:
 
 Hashicorp **does not** support in-place migrations from non-FIPS Inside
 versions of Vault to FIPS Inside versions of Vault, regardless of version.
-A fresh cluster installation is required to receive support. Any issues found
-during in-place migrations will not be addressed by Hashicorp.
+A fresh cluster installation is required to receive support.
 
 Entropy Augmentation **does not** work with FIPS 140-2 Inside. The internal
 BoringCrypto RNG is FIPS 140-2 certified and does not accept entropy from


### PR DESCRIPTION
This adds a known-panic w.r.t. Entropy Augmentation due to restrictions
in how BoringCrypto's RNG works. Additionally adds the RH Access
container repository and adds a note about restricted support scenarios.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`