### PR TITLE
Update GCP auth docs for GCE identity token login

### DIFF
--- a/website/content/docs/auth/gcp.mdx
+++ b/website/content/docs/auth/gcp.mdx
@@ -348,30 +348,30 @@ Read more on the
 
 GCE tokens **can only be generated from a GCE instance**.
 
-1.  As of version 1.11, Vault can automatically discover the identity token on a GCE/GKE instance. This simplifies
-  authenticating to Vault like so:
+1.  Vault can automatically discover the identity token on a GCE/GKE instance. This simplifies
+    authenticating to Vault like so:
 
-  ```shell-session
-  $ vault login \
-    -method=gcp \
-    role="my-vault-role"
-  ```
+    ```shell-session
+    $ vault login \
+      -method=gcp \
+      role="my-vault-role"
+    ```
 
 1.  The JWT token can also be obtained from the `"service-accounts/default/identity"` endpoint for a
-  instance's metadata server.
+    instance's metadata server.
 
-  #### curl Example
+    #### Curl example
 
-  ```shell-session
-  ROLE="my-gce-role"
+    ```shell-session
+    ROLE="my-gce-role"
 
-  $ curl \
-    --header "Metadata-Flavor: Google" \
-    --get \
-    --data-urlencode "audience=http://vault/${ROLE}" \
-    --data-urlencode "format=full" \
-    "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity"
-  ```
+    $ curl \
+      --header "Metadata-Flavor: Google" \
+      --get \
+      --data-urlencode "audience=http://vault/${ROLE}" \
+      --data-urlencode "format=full" \
+      "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity"
+    ```
 
 ## API
 

--- a/website/content/docs/auth/gcp.mdx
+++ b/website/content/docs/auth/gcp.mdx
@@ -354,7 +354,7 @@ GCE tokens **can only be generated from a GCE instance**.
     ```shell-session
     $ vault login \
       -method=gcp \
-      role="my-vault-role"
+      role="my-gce-role"
     ```
 
 1.  The JWT token can also be obtained from the `"service-accounts/default/identity"` endpoint for a

--- a/website/content/docs/auth/gcp.mdx
+++ b/website/content/docs/auth/gcp.mdx
@@ -75,7 +75,7 @@ management tool.
 
 1. Enable the Google Cloud auth method:
 
-   ```text
+   ```shell-session
    $ vault auth enable gcp
    ```
 
@@ -94,7 +94,7 @@ management tool.
 
    For an `iam`-type role:
 
-   ```text
+   ```shell-session
    $ vault write auth/gcp/role/my-iam-role \
        type="iam" \
        policies="dev,prod" \
@@ -103,7 +103,7 @@ management tool.
 
    For a `gce`-type role:
 
-   ```text
+   ```shell-session
    $ vault write auth/gcp/role/my-gce-role \
        type="gce" \
        policies="dev,prod" \
@@ -312,14 +312,14 @@ role. This defaults to 15 minutes and cannot be more than 1 hour.
 One you have all this information, the JWT token can be signed using curl and
 [oauth2l](https://github.com/google/oauth2l):
 
-```text
+```shell-session
 ROLE="my-role"
 SERVICE_ACCOUNT="service-account@my-project.iam.gserviceaccount.com"
 OAUTH_TOKEN="$(oauth2l header cloud-platform)"
 EXPIRATION="<your_token_expiration>"
 JWT_CLAIM="{\\\"aud\\\":\\\"vault/${ROLE}\\\", \\\"sub\\\": \\\"${SERVICE_ACCOUNT}\\\", \\\"exp\\\": ${EXPIRATION}}"
 
-curl \
+$ curl \
   --header "${OAUTH_TOKEN}" \
   --header "Content-Type: application/json" \
   --request POST \
@@ -346,22 +346,32 @@ Read more on the
 
 ### GCE
 
-GCE tokens **can only be generated from a GCE instance**. The JWT token can be
-obtained from the `service-accounts/default/identity` endpoint for a
-instance's metadata server.
+GCE tokens **can only be generated from a GCE instance**.
 
-#### curl Example
+1.  As of version 1.11, Vault can automatically discover the identity token on a GCE/GKE instance. This simplifies
+  authenticating to Vault like so:
 
-```text
-ROLE="my-gce-role"
+  ```shell-session
+  $ vault login \
+    -method=gcp \
+    role="my-vault-role"
+  ```
 
-curl \
-  --header "Metadata-Flavor: Google" \
-  --get \
-  --data-urlencode "audience=http://vault/${ROLE}" \
-  --data-urlencode "format=full" \
-  "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity"
-```
+1.  The JWT token can also be obtained from the `"service-accounts/default/identity"` endpoint for a
+  instance's metadata server.
+
+  #### curl Example
+
+  ```shell-session
+  ROLE="my-gce-role"
+
+  $ curl \
+    --header "Metadata-Flavor: Google" \
+    --get \
+    --data-urlencode "audience=http://vault/${ROLE}" \
+    --data-urlencode "format=full" \
+    "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity"
+  ```
 
 ## API
 


### PR DESCRIPTION
Adds to and updates gcp auth docs for feature added in 1.11 to allow easier login when running Vault on a GCE/GKE instance.