### PR TITLE
Add warning about EA in FIPS mode

### DIFF
--- a/changelog/15858.txt
+++ b/changelog/15858.txt
@@ -1,0 +1,3 @@
+```release-note:change
+core/fips: Disable and warn about entropy augmentation in FIPS 140-2 Inside mode
+```

--- a/command/server.go
+++ b/command/server.go
@@ -34,6 +34,7 @@ import (
 	config2 "github.com/hashicorp/vault/command/config"
 	"github.com/hashicorp/vault/command/server"
 	"github.com/hashicorp/vault/helper/builtinplugins"
+	"github.com/hashicorp/vault/helper/constants"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
 	vaulthttp "github.com/hashicorp/vault/http"
@@ -424,6 +425,12 @@ func (c *ServerCommand) parseConfig() (*server.Config, []configutil.ConfigError,
 			config = config.Merge(current)
 		}
 	}
+
+	if config.Entropy != nil && config.Entropy.Mode == configutil.EntropyAugmentation && constants.IsFIPS() {
+		c.UI.Warn("WARNING: Entropy Augmentation is not supported in FIPS 140-2 Inside mode; disabling from server configuration!\n")
+		config.Entropy = nil
+	}
+
 	return config, configErrors, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>

---

[Per docs](https://www.vaultproject.io/docs/configuration/entropy-augmentation#requirements) entropy augmentation does not work with FIPS 140-2. Add a warning to server startup and disable the config.