### PR TITLE
docs: fix typo in configurations.mdx

### DIFF
--- a/website/content/docs/platform/k8s/csi/configurations.mdx
+++ b/website/content/docs/platform/k8s/csi/configurations.mdx
@@ -128,4 +128,4 @@ structure is illustrated in the [examples](/docs/platform/k8s/csi/examples).
 
     ~> `secretArgs` are sent as part of the HTTP request body. Therefore, they are only effective for HTTP PUT/POST requests, for instance,
         the [request used to generate a new certificate](https://www.vaultproject.io/api-docs/secret/pki#generate-certificate).
-        To supply additional parameters for secrets retrieved via HTTP GET, include optional URI paramters in [`secretPath`](#secretpath).
+        To supply additional parameters for secrets retrieved via HTTP GET, include optional URI parameters in [`secretPath`](#secretpath).


### PR DESCRIPTION
paramters -> parameters