### PR TITLE
Use manual_chain for cross-signed intermediates

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1831,7 +1831,11 @@ do so, import a new issuer and a new `issuer_id` will be assigned.
    issuer's reference. Subsequent references _should_ validate previous
    entries, terminating with a root certificate. _Ideally_ a single linear
    chain would come first (from this issuer to a single root certificate)
-   before any parallel, alternate chains appear.
+   before any parallel, alternate chains appear.<br /><br />
+   This field is especially useful for cross-signed intermediates within
+   Vault. Because each cross-signed intermediate will only know of the
+   one root, but issuance should serve both, update the issuers' entries
+   with the desired `manual_chain` value.
 
 - `usage` `([]string: read-only,issuing-certificates,crl-signing)` - Allowed
   usages for this issuer. Valid options are:

--- a/website/content/docs/secrets/pki/considerations.mdx
+++ b/website/content/docs/secrets/pki/considerations.mdx
@@ -19,6 +19,7 @@ generating the CA to use with this secrets engine.
    - [Always Configure a Default Issuer](#always-configure-a-default-issuer)
    - [Key Types Matter](#key-types-matter)
  - [Use a CA Hierarchy](#use-a-ca-hierarchy)
+   - [Cross-Signed Intermediates](#cross-signed-intermediates)
  - [Keep certificate lifetimes short, for CRL's sake](#keep-certificate-lifetimes-short-for-crls-sake)
    - [NotAfter Behavior on Leaf Certificates](#notafter-behavior-on-leaf-certificates)
    - [Cluster Performance and Quantity of Leaf Certificates](#cluster-performance-and-quantity-of-leaf-certificates)
@@ -143,6 +144,22 @@ Roles](/api-docs/secret/pki#allowed_domains) and the [`permitted_dns_domains`
 parameter to set the Name Constraints extension](/api-docs/secret/pki#permitted_dns_domains)
 on root and intermediate generation. This allows for several layers of
 separation of concerns between TLS-based services.
+
+### Cross-Signed Intermediates
+
+When cross-signing intermediates from two separate roots, two separate
+intermediate issuers will exist within the Vault PKI mount. In order to
+correctly serve the cross-signed chain on issuance requests, the
+`manual_chain` override is required on either or both intermediates. This
+can be constructed in the following order:
+
+ - this issuer (`self`)
+ - this root
+ - the other copy of this intermediate
+ - the other root
+
+All requests to this issuer for signing will now present the full cross-signed
+chain.
 
 ## Keep certificate lifetimes short, for CRL's sake
 


### PR DESCRIPTION
This adds a note that manual_chain is required for cross-signed
intermediates, as Vault will not automatically associate the
cross-signed pair during chain construction. During issuance, the chain
is used verbatim from the issuer, so no chain detection will be used
then.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`