### PR TITLE
Limit SSCT WAL Check to Perf Standbys

### DIFF
--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1945,6 +1945,12 @@ func (c *Core) checkSSCTokenInternal(ctx context.Context, token string, isPerfSt
 	if err != nil {
 		return "", err
 	}
+
+	// Disregard SSCT on perf-standbys for non-raft storage
+	if c.perfStandby && c.getRaftBackend() == nil {
+		return plainToken.Random, nil
+	}
+
 	ep := int(plainToken.IndexEpoch)
 	if ep < c.tokenStore.GetSSCTokensGenerationCounter() {
 		return plainToken.Random, nil


### PR DESCRIPTION
ensure that ssct wal check only occurs for non-raft storage on perf standbys

Port of https://github.com/hashicorp/vault-enterprise/pull/2947