### PR TITLE
Make KV structs public so the KV helper methods show in godoc

### DIFF
--- a/api/kv.go
+++ b/api/kv.go
@@ -30,8 +30,8 @@ type KVSecret struct {
 //
 // Learn more about the KV secrets engine here:
 // https://www.vaultproject.io/docs/secrets/kv
-func (c *Client) KVv1(mountPath string) *kvv1 {
-	return &kvv1{c: c, mountPath: mountPath}
+func (c *Client) KVv1(mountPath string) *KVv1 {
+	return &KVv1{c: c, mountPath: mountPath}
 }
 
 // KVv2 is used to return a client for reads and writes against
@@ -45,6 +45,6 @@ func (c *Client) KVv1(mountPath string) *kvv1 {
 //
 // Learn more about the KV secrets engine here:
 // https://www.vaultproject.io/docs/secrets/kv
-func (c *Client) KVv2(mountPath string) *kvv2 {
-	return &kvv2{c: c, mountPath: mountPath}
+func (c *Client) KVv2(mountPath string) *KVv2 {
+	return &KVv2{c: c, mountPath: mountPath}
 }

--- a/api/kv_v1.go
+++ b/api/kv_v1.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 )
 
-type kvv1 struct {
+type KVv1 struct {
 	c         *Client
 	mountPath string
 }
 
 // Get returns a secret from the KV v1 secrets engine.
-func (kv *kvv1) Get(ctx context.Context, secretPath string) (*KVSecret, error) {
+func (kv *KVv1) Get(ctx context.Context, secretPath string) (*KVSecret, error) {
 	pathToRead := fmt.Sprintf("%s/%s", kv.mountPath, secretPath)
 
 	secret, err := kv.c.Logical().ReadWithContext(ctx, pathToRead)
@@ -33,7 +33,7 @@ func (kv *kvv1) Get(ctx context.Context, secretPath string) (*KVSecret, error) {
 // KV v1 secrets engine.
 //
 // If the secret already exists, it will be overwritten.
-func (kv *kvv1) Put(ctx context.Context, secretPath string, data map[string]interface{}) error {
+func (kv *KVv1) Put(ctx context.Context, secretPath string, data map[string]interface{}) error {
 	pathToWriteTo := fmt.Sprintf("%s/%s", kv.mountPath, secretPath)
 
 	_, err := kv.c.Logical().WriteWithContext(ctx, pathToWriteTo, data)
@@ -45,7 +45,7 @@ func (kv *kvv1) Put(ctx context.Context, secretPath string, data map[string]inte
 }
 
 // Delete deletes a secret from the KV v1 secrets engine.
-func (kv *kvv1) Delete(ctx context.Context, secretPath string) error {
+func (kv *KVv1) Delete(ctx context.Context, secretPath string) error {
 	pathToDelete := fmt.Sprintf("%s/%s", kv.mountPath, secretPath)
 
 	_, err := kv.c.Logical().DeleteWithContext(ctx, pathToDelete)

--- a/api/kv_v2.go
+++ b/api/kv_v2.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-type kvv2 struct {
+type KVv2 struct {
 	c         *Client
 	mountPath string
 }
@@ -107,7 +107,7 @@ func WithMergeMethod(method string) KVOption {
 // If the latest version has been deleted, an error will not be thrown, but
 // the Data field on the returned secret will be nil, and the Metadata field
 // will contain the deletion time.
-func (kv *kvv2) Get(ctx context.Context, secretPath string) (*KVSecret, error) {
+func (kv *KVv2) Get(ctx context.Context, secretPath string) (*KVSecret, error) {
 	pathToRead := fmt.Sprintf("%s/data/%s", kv.mountPath, secretPath)
 
 	secret, err := kv.c.Logical().ReadWithContext(ctx, pathToRead)
@@ -140,7 +140,7 @@ func (kv *kvv2) Get(ctx context.Context, secretPath string) (*KVSecret, error) {
 //
 // GetVersionsAsList can provide a list of available versions sorted by
 // version number, while the response from GetMetadata contains them as a map.
-func (kv *kvv2) GetVersion(ctx context.Context, secretPath string, version int) (*KVSecret, error) {
+func (kv *KVv2) GetVersion(ctx context.Context, secretPath string, version int) (*KVSecret, error) {
 	pathToRead := fmt.Sprintf("%s/data/%s", kv.mountPath, secretPath)
 
 	queryParams := map[string][]string{"version": {strconv.Itoa(version)}}
@@ -167,7 +167,7 @@ func (kv *kvv2) GetVersion(ctx context.Context, secretPath string, version int) 
 }
 
 // GetVersionsAsList returns a subset of the metadata for each version of the secret, sorted by version number.
-func (kv *kvv2) GetVersionsAsList(ctx context.Context, secretPath string) ([]KVVersionMetadata, error) {
+func (kv *KVv2) GetVersionsAsList(ctx context.Context, secretPath string) ([]KVVersionMetadata, error) {
 	pathToRead := fmt.Sprintf("%s/metadata/%s", kv.mountPath, secretPath)
 
 	secret, err := kv.c.Logical().ReadWithContext(ctx, pathToRead)
@@ -194,7 +194,7 @@ func (kv *kvv2) GetVersionsAsList(ctx context.Context, secretPath string) ([]KVV
 
 // GetMetadata returns the full metadata for a given secret, including a map of
 // its existing versions and their respective creation/deletion times, etc.
-func (kv *kvv2) GetMetadata(ctx context.Context, secretPath string) (*KVMetadata, error) {
+func (kv *KVv2) GetMetadata(ctx context.Context, secretPath string) (*KVMetadata, error) {
 	pathToRead := fmt.Sprintf("%s/metadata/%s", kv.mountPath, secretPath)
 
 	secret, err := kv.c.Logical().ReadWithContext(ctx, pathToRead)
@@ -219,7 +219,7 @@ func (kv *kvv2) GetMetadata(ctx context.Context, secretPath string) (*KVMetadata
 // If the secret already exists, a new version will be created
 // and the previous version can be accessed with the GetVersion method.
 // GetMetadata can provide a list of available versions.
-func (kv *kvv2) Put(ctx context.Context, secretPath string, data map[string]interface{}, opts ...KVOption) (*KVSecret, error) {
+func (kv *KVv2) Put(ctx context.Context, secretPath string, data map[string]interface{}, opts ...KVOption) (*KVSecret, error) {
 	pathToWriteTo := fmt.Sprintf("%s/data/%s", kv.mountPath, secretPath)
 
 	wrappedData := map[string]interface{}{
@@ -274,7 +274,7 @@ func (kv *kvv2) Put(ctx context.Context, secretPath string, data map[string]inte
 // To only partially replace the values of these metadata fields, use PatchMetadata.
 //
 // This method can also be used to create a new secret with just metadata and no secret data yet.
-func (kv *kvv2) PutMetadata(ctx context.Context, secretPath string, metadata KVMetadataPutInput) error {
+func (kv *KVv2) PutMetadata(ctx context.Context, secretPath string, metadata KVMetadataPutInput) error {
 	pathToWriteTo := fmt.Sprintf("%s/metadata/%s", kv.mountPath, secretPath)
 
 	const (
@@ -308,7 +308,7 @@ func (kv *kvv2) PutMetadata(ctx context.Context, secretPath string, metadata KVM
 // only be able to use the old "rw" (read-then-write) style of partial update,
 // whereas newer Vault servers can use the default value of "patch" if the
 // client token's policy has the "patch" capability.
-func (kv *kvv2) Patch(ctx context.Context, secretPath string, newData map[string]interface{}, opts ...KVOption) (*KVSecret, error) {
+func (kv *KVv2) Patch(ctx context.Context, secretPath string, newData map[string]interface{}, opts ...KVOption) (*KVSecret, error) {
 	// determine patch method
 	var patchMethod string
 	var ok bool
@@ -349,7 +349,7 @@ func (kv *kvv2) Patch(ctx context.Context, secretPath string, newData map[string
 // PatchMetadata can be used to replace just a subset of a secret's
 // metadata fields at a time, as opposed to PutMetadata which is used to
 // completely replace all fields on the previous metadata.
-func (kv *kvv2) PatchMetadata(ctx context.Context, secretPath string, metadata KVMetadataPatchInput) error {
+func (kv *KVv2) PatchMetadata(ctx context.Context, secretPath string, metadata KVMetadataPatchInput) error {
 	pathToWriteTo := fmt.Sprintf("%s/metadata/%s", kv.mountPath, secretPath)
 
 	md, err := toMetadataMap(metadata)
@@ -367,7 +367,7 @@ func (kv *kvv2) PatchMetadata(ctx context.Context, secretPath string, metadata K
 
 // Delete deletes the most recent version of a secret from the KV v2
 // secrets engine. To delete an older version, use DeleteVersions.
-func (kv *kvv2) Delete(ctx context.Context, secretPath string) error {
+func (kv *KVv2) Delete(ctx context.Context, secretPath string) error {
 	pathToDelete := fmt.Sprintf("%s/data/%s", kv.mountPath, secretPath)
 
 	_, err := kv.c.Logical().DeleteWithContext(ctx, pathToDelete)
@@ -380,7 +380,7 @@ func (kv *kvv2) Delete(ctx context.Context, secretPath string) error {
 
 // DeleteVersions deletes the specified versions of a secret from the KV v2
 // secrets engine. To delete the latest version of a secret, just use Delete.
-func (kv *kvv2) DeleteVersions(ctx context.Context, secretPath string, versions []int) error {
+func (kv *KVv2) DeleteVersions(ctx context.Context, secretPath string, versions []int) error {
 	// verb and path are different when trying to delete past versions
 	pathToDelete := fmt.Sprintf("%s/delete/%s", kv.mountPath, secretPath)
 
@@ -405,7 +405,7 @@ func (kv *kvv2) DeleteVersions(ctx context.Context, secretPath string, versions 
 
 // DeleteMetadata deletes all versions and metadata of the secret at the
 // given path.
-func (kv *kvv2) DeleteMetadata(ctx context.Context, secretPath string) error {
+func (kv *KVv2) DeleteMetadata(ctx context.Context, secretPath string) error {
 	pathToDelete := fmt.Sprintf("%s/metadata/%s", kv.mountPath, secretPath)
 
 	_, err := kv.c.Logical().DeleteWithContext(ctx, pathToDelete)
@@ -420,7 +420,7 @@ func (kv *kvv2) DeleteMetadata(ctx context.Context, secretPath string) error {
 // so that it can be fetched again with Get requests.
 //
 // A list of existing versions can be retrieved using the GetVersionsAsList method.
-func (kv *kvv2) Undelete(ctx context.Context, secretPath string, versions []int) error {
+func (kv *KVv2) Undelete(ctx context.Context, secretPath string, versions []int) error {
 	pathToUndelete := fmt.Sprintf("%s/undelete/%s", kv.mountPath, secretPath)
 
 	data := map[string]interface{}{
@@ -440,7 +440,7 @@ func (kv *kvv2) Undelete(ctx context.Context, secretPath string, versions []int)
 // action will be taken.
 //
 // A list of existing versions can be retrieved using the GetVersionsAsList method.
-func (kv *kvv2) Destroy(ctx context.Context, secretPath string, versions []int) error {
+func (kv *KVv2) Destroy(ctx context.Context, secretPath string, versions []int) error {
 	pathToDestroy := fmt.Sprintf("%s/destroy/%s", kv.mountPath, secretPath)
 
 	data := map[string]interface{}{
@@ -458,7 +458,7 @@ func (kv *kvv2) Destroy(ctx context.Context, secretPath string, versions []int) 
 // Rollback can be used to roll a secret back to a previous
 // non-deleted/non-destroyed version. That previous version becomes the
 // next/newest version for the path.
-func (kv *kvv2) Rollback(ctx context.Context, secretPath string, toVersion int) (*KVSecret, error) {
+func (kv *KVv2) Rollback(ctx context.Context, secretPath string, toVersion int) (*KVSecret, error) {
 	// First, do a read to get the current version for check-and-set
 	latest, err := kv.Get(ctx, secretPath)
 	if err != nil {


### PR DESCRIPTION
The new KV helper methods (Get, PutMetadata, etc.) are not that useful if users cannot find them, and various usability studies we've done have shown that many users rely on the [godoc](https://pkg.go.dev/github.com/hashicorp/vault/api) page for discovery of the api package's functionality.

Since the kvv1 and kvv2 structs are private, their methods do not show in the godoc.

By changing them to public but keeping their fields private, we still force users to go through our constructor method (`client.KVv1(mountPath)` and `client.KVv2(mountPath)`) to initiate the structs, but their methods will now be displayed in the godoc.

This also matches how the similarly-designed `Logical` and `Auth` struct work today.