### PR TITLE
Add missing nil check to FIPS EA verification

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -426,7 +426,7 @@ func (c *ServerCommand) parseConfig() (*server.Config, []configutil.ConfigError,
 		}
 	}
 
-	if config.Entropy != nil && config.Entropy.Mode == configutil.EntropyAugmentation && constants.IsFIPS() {
+	if config != nil && config.Entropy != nil && config.Entropy.Mode == configutil.EntropyAugmentation && constants.IsFIPS() {
 		c.UI.Warn("WARNING: Entropy Augmentation is not supported in FIPS 140-2 Inside mode; disabling from server configuration!\n")
 		config.Entropy = nil
 	}


### PR DESCRIPTION
This was causing failures when running `vault server -dev`:

> ```
> panic: runtime error: invalid memory address or nil pointer dereference
> [signal SIGSEGV: segmentation violation code=0x2 addr=0x20 pc=0x105c41c1c]
>
> goroutine 1 [running]:
> github.com/hashicorp/vault/command.(*ServerCommand).parseConfig(0x140005a2180)
> 	.../vault/command/server.go:429 +0x5c
> ```

Interestingly, we do not have a test case for running the dev
sever.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

This was broken in: https://github.com/hashicorp/vault/pull/15858 