### PR TITLE
Remove fingerprinting for images

### DIFF
--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -21,6 +21,9 @@ const appConfig = {
     sourceDirs: ['node_modules/@hashicorp/structure-icons/dist', 'public'],
     rootURL: '/ui/',
   },
+  fingerprint: {
+    exclude: ['images/'],
+  },
   assetLoader: {
     generateURI: function (filePath) {
       return `${config.rootURL.replace(/\/$/, '')}${filePath}`;


### PR DESCRIPTION
By default, ember build fingerprint all the static assets such as
'js', 'css', 'png', 'jpg', 'gif', 'map' during compilation. As a result the image
referenced in mfa landing page was not loading in binary. For now, exclude fingerprinting
for all the files which exists under images directory.