### PR TITLE
Add change release note for Kubernetes auth

### DIFF
--- a/changelog/15584.txt
+++ b/changelog/15584.txt
@@ -1,3 +1,6 @@
 ```release-note:bug
 auth/kubernetes: Fix error code when using the wrong service account
 ```
+```release-note:change
+auth/kubernetes: If `kubernetes_ca_cert` is unset, and there is no pod-local CA available, an error will be surfaced when writing config instead of waiting for login.
+```


### PR DESCRIPTION
Adds a change release note for the API behaviour change. In 1.10 and earlier, configs that rely on auto-loading a CA from disk, but don't have a CA cert in the default location would have failed when trying to login. Now we fail earlier, when writing to the config endpoint instead.