### PR TITLE
add OSS noop check for valid ent storage

### DIFF
--- a/command/server_util.go
+++ b/command/server_util.go
@@ -5,7 +5,10 @@ import (
 	"github.com/hashicorp/vault/vault"
 )
 
-var adjustCoreConfigForEnt = adjustCoreConfigForEntNoop
+var (
+	adjustCoreConfigForEnt = adjustCoreConfigForEntNoop
+	checkStorageTypeForEnt = checkStorageTypeForEntNoop
+)
 
 func adjustCoreConfigForEntNoop(config *server.Config, coreConfig *vault.CoreConfig) {
 }
@@ -14,4 +17,8 @@ var getFIPSInfoKey = getFIPSInfoKeyNoop
 
 func getFIPSInfoKeyNoop() string {
 	return ""
+}
+
+func checkStorageTypeForEntNoop(coreConfig *vault.CoreConfig) error {
+	return nil
 }


### PR DESCRIPTION
Vault Enterprise will need to ensure that a supported storage backend is configured upon startup. This PR includes the OSS pieces to support that check within the `vault server` command.