### PR TITLE
Parse ha_storage in config 

### DIFF
--- a/changelog/15900.txt
+++ b/changelog/15900.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fixes parsing boolean values for ha_storage backends in config
+```

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -802,9 +802,23 @@ func parseHAStorage(result *Config, list *ast.ObjectList, name string) error {
 		key = item.Keys[0].Token.Value().(string)
 	}
 
-	var m map[string]string
-	if err := hcl.DecodeObject(&m, item.Val); err != nil {
+	var config map[string]interface{}
+	if err := hcl.DecodeObject(&config, item.Val); err != nil {
 		return multierror.Prefix(err, fmt.Sprintf("%s.%s:", name, key))
+	}
+
+	m := make(map[string]string)
+	for key, val := range config {
+		valStr, ok := val.(string)
+		if ok {
+			m[key] = valStr
+			continue
+		}
+		valBytes, err := json.Marshal(val)
+		if err != nil {
+			return err
+		}
+		m[key] = string(valBytes)
 	}
 
 	// Pull out the redirect address since it's common to all backends

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -48,6 +48,10 @@ func TestParseSeals(t *testing.T) {
 	testParseSeals(t)
 }
 
+func TestParseStorage(t *testing.T) {
+	testParseStorageTemplate(t)
+}
+
 func TestUnknownFieldValidation(t *testing.T) {
 	testUnknownFieldValidation(t)
 }

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -900,6 +900,49 @@ EOF
 	}
 }
 
+func testParseStorageTemplate(t *testing.T) {
+	config, err := ParseConfig(`
+storage "consul" {
+
+	disable_registration = false
+	path = "tmp/"
+
+}
+ha_storage "consul" {
+	tls_skip_verify = true
+	scheme = "http"
+	max_parallel = 128
+}
+
+`, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &Config{
+		Storage: &Storage{
+			Type: "consul",
+			Config: map[string]string{
+				"disable_registration": "false",
+				"path":                 "tmp/",
+			},
+		},
+		HAStorage: &Storage{
+			Type: "consul",
+			Config: map[string]string{
+				"tls_skip_verify": "true",
+				"scheme":          "http",
+				"max_parallel":    "128",
+			},
+		},
+		SharedConfig: &configutil.SharedConfig{},
+	}
+	config.Prune()
+	if diff := deep.Equal(config, expected); diff != nil {
+		t.Fatal(diff)
+	}
+}
+
 func testParseSeals(t *testing.T) {
 	config, err := LoadConfigFile("./test-fixtures/config_seals.hcl")
 	if err != nil {
@@ -1013,6 +1056,7 @@ func testLoadConfigFileLeaseMetrics(t *testing.T) {
 			Config: map[string]string{
 				"bar": "baz",
 			},
+
 			DisableClustering: true,
 		},
 


### PR DESCRIPTION
https://github.com/hashicorp/vault/issues/14043
The gh issue is specific to zookeeper but this is applicable for all ha_storage backends 
When providing boolean options to an ha_storage backend (ex. tls_enabled, tls_skip_verify) vault cannot parse them. It only accepts string values for boolean fields i.e; "true" and "false"

The parsing works well for storage backends. Therefore, changed the parsing similar to parsing values for storage backend 