### PR TITLE
docs/postgres: replaces lib/pq with pgx

### DIFF
--- a/website/content/docs/configuration/storage/cockroachdb.mdx
+++ b/website/content/docs/configuration/storage/cockroachdb.mdx
@@ -33,8 +33,8 @@ uses that driver to interact with the database.
 
 - `connection_url` `(string: <required>)` – Specifies the connection string to
   use to authenticate and connect to CockroachDB. A full list of supported
-  parameters can be found in [the pgx library documentation][pgxlib]. For example
-  connection string URLs, see the examples section below.
+  parameters can be found in the [pgx library][pgxlib] and [PostgreSQL connection string][pg_conn_docs]
+  documentation. For example connection string URLs, see the examples section below.
 
 - `table` `(string: "vault_kv_store")` – Specifies the name of the table in
   which to write Vault data. If this table does not exist Vault will attempt to create it.
@@ -63,4 +63,5 @@ storage "cockroachdb" {
 ```
 
 [cockroachdb]: https://www.cockroachlabs.com/
-[pgxlib]: https://pkg.go.dev/github.com/jackc/pgx/v4#hdr-Establishing_a_Connection
+[pgxlib]: https://pkg.go.dev/github.com/jackc/pgx/stdlib
+[pg_conn_docs]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING

--- a/website/content/docs/configuration/storage/cockroachdb.mdx
+++ b/website/content/docs/configuration/storage/cockroachdb.mdx
@@ -33,7 +33,7 @@ uses that driver to interact with the database.
 
 - `connection_url` `(string: <required>)` – Specifies the connection string to
   use to authenticate and connect to CockroachDB. A full list of supported
-  parameters can be found in [the pq library documentation][pglib]. For example
+  parameters can be found in [the pgx library documentation][pgxlib]. For example
   connection string URLs, see the examples section below.
 
 - `table` `(string: "vault_kv_store")` – Specifies the name of the table in
@@ -63,4 +63,4 @@ storage "cockroachdb" {
 ```
 
 [cockroachdb]: https://www.cockroachlabs.com/
-[pglib]: https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
+[pgxlib]: https://pkg.go.dev/github.com/jackc/pgx/v4#hdr-Establishing_a_Connection

--- a/website/content/docs/configuration/storage/postgresql.mdx
+++ b/website/content/docs/configuration/storage/postgresql.mdx
@@ -92,7 +92,7 @@ LANGUAGE plpgsql;
 - `connection_url` `(string: <required>)` – Specifies the connection string to
   use to authenticate and connect to PostgreSQL. The connection URL can also be
   set using the `VAULT_PG_CONNECTION_URL` environment variable. A full list of supported
-  parameters can be found in [the pq library documentation][pglib]. For example
+  parameters can be found in [the pgx library documentation][pgxlib]. For example
   connection string URLs, see the examples section below.
 
 - `table` `(string: "vault_kv_store")` – Specifies the name of the table in
@@ -137,4 +137,4 @@ storage "postgresql" {
 
 [golang_setmaxidleconns]: https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns
 [postgresql]: https://www.postgresql.org/
-[pglib]: https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
+[pgxlib]: https://pkg.go.dev/github.com/jackc/pgx/v4#hdr-Establishing_a_Connection

--- a/website/content/docs/configuration/storage/postgresql.mdx
+++ b/website/content/docs/configuration/storage/postgresql.mdx
@@ -92,8 +92,8 @@ LANGUAGE plpgsql;
 - `connection_url` `(string: <required>)` – Specifies the connection string to
   use to authenticate and connect to PostgreSQL. The connection URL can also be
   set using the `VAULT_PG_CONNECTION_URL` environment variable. A full list of supported
-  parameters can be found in [the pgx library documentation][pgxlib]. For example
-  connection string URLs, see the examples section below.
+  parameters can be found in the [pgx library][pgxlib] and [PostgreSQL connection string][pg_conn_docs]
+  documentation. For example connection string URLs, see the examples section below.
 
 - `table` `(string: "vault_kv_store")` – Specifies the name of the table in
   which to write Vault data. This table must already exist (Vault will not
@@ -137,4 +137,5 @@ storage "postgresql" {
 
 [golang_setmaxidleconns]: https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns
 [postgresql]: https://www.postgresql.org/
-[pgxlib]: https://pkg.go.dev/github.com/jackc/pgx/v4#hdr-Establishing_a_Connection
+[pgxlib]: https://pkg.go.dev/github.com/jackc/pgx/stdlib
+[pg_conn_docs]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING

--- a/website/content/docs/secrets/databases/postgresql.mdx
+++ b/website/content/docs/secrets/databases/postgresql.mdx
@@ -17,12 +17,10 @@ Roles](/docs/secrets/databases#static-roles).
 See the [database secrets engine](/docs/secrets/databases) docs for
 more information about setting up the database secrets engine.
 
-The PostgreSQL secrets engine uses
-[pgx](https://pkg.go.dev/github.com/jackc/pgx/v4), the same database
-library as the [PostgreSQL storage
-backend](/docs/configuration/storage/postgresql). Connection string
-options, including SSL options, can be found
-[here](https://pkg.go.dev/github.com/jackc/pgx/v4#hdr-Establishing_a_Connection)
+The PostgreSQL secrets engine uses [pgx](https://pkg.go.dev/github.com/jackc/pgx/v4),
+the same database library as the [PostgreSQL storage backend](/docs/configuration/storage/postgresql).
+Connection string options, including SSL options, can be found in the [pgx library][pgxlib]
+and [PostgreSQL connection string][pg_conn_docs] documentation.
 
 ## Capabilities
 
@@ -92,3 +90,6 @@ plugin API](/api-docs/secret/databases/postgresql) page.
 
 For more information on the database secrets engine's HTTP API please see the
 [Database secrets engine API](/api-docs/secret/databases) page.
+
+[pgxlib]: https://pkg.go.dev/github.com/jackc/pgx/stdlib
+[pg_conn_docs]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING

--- a/website/content/docs/secrets/databases/postgresql.mdx
+++ b/website/content/docs/secrets/databases/postgresql.mdx
@@ -18,11 +18,11 @@ See the [database secrets engine](/docs/secrets/databases) docs for
 more information about setting up the database secrets engine.
 
 The PostgreSQL secrets engine uses
-[pq](https://pkg.go.dev/github.com/lib/pq?tab=doc), the same database
+[pgx](https://pkg.go.dev/github.com/jackc/pgx/v4), the same database
 library as the [PostgreSQL storage
 backend](/docs/configuration/storage/postgresql). Connection string
 options, including SSL options, can be found
-[here](https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters)
+[here](https://pkg.go.dev/github.com/jackc/pgx/v4#hdr-Establishing_a_Connection)
 
 ## Capabilities
 

--- a/website/content/docs/secrets/databases/postgresql.mdx
+++ b/website/content/docs/secrets/databases/postgresql.mdx
@@ -17,10 +17,10 @@ Roles](/docs/secrets/databases#static-roles).
 See the [database secrets engine](/docs/secrets/databases) docs for
 more information about setting up the database secrets engine.
 
-The PostgreSQL secrets engine uses [pgx](https://pkg.go.dev/github.com/jackc/pgx/v4),
-the same database library as the [PostgreSQL storage backend](/docs/configuration/storage/postgresql).
-Connection string options, including SSL options, can be found in the [pgx library][pgxlib]
-and [PostgreSQL connection string][pg_conn_docs] documentation.
+The PostgreSQL secrets engine uses [pgx][pgxlib], the same database library as the
+[PostgreSQL storage backend](/docs/configuration/storage/postgresql). Connection string
+options, including SSL options, can be found in the [pgx][pgxlib] and
+[PostgreSQL connection string][pg_conn_docs] documentation.
 
 ## Capabilities
 


### PR DESCRIPTION
This PR updates documentation that was referencing the [lib/pq](https://github.com/lib/pq) package which is being replaced by [jackc/pgx](https://github.com/jackc/pgx).

Related PR: https://github.com/hashicorp/vault/pull/15343