### PR TITLE
Use KV helpers in docs and dev quickstart guide

### DIFF
--- a/website/content/docs/auth/approle.mdx
+++ b/website/content/docs/auth/approle.mdx
@@ -296,7 +296,7 @@ func getSecretWithAppRole() (string, error) {
 		return "", fmt.Errorf("unable to initialize AppRole auth method: %w", err)
 	}
 
-	authInfo, err := client.Auth().Login(context.TODO(), appRoleAuth)
+	authInfo, err := client.Auth().Login(context.Background(), appRoleAuth)
 	if err != nil {
 		return "", fmt.Errorf("unable to login to AppRole auth method: %w", err)
 	}
@@ -304,23 +304,17 @@ func getSecretWithAppRole() (string, error) {
 		return "", fmt.Errorf("no auth info was returned after login")
 	}
 
-	// get secret
-	secret, err := client.Logical().Read("kv-v2/data/creds")
+	// get secret from the default mount path for KV v2 in dev mode, "secret"
+	secret, err := client.KVv2("secret").Get(context.Background(), "creds")
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret: %w", err)
 	}
 
-	data, ok := secret.Data["data"].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
-	}
-
 	// data map can contain more than one key-value pair,
 	// in this case we're just grabbing one of them
-	key := "password"
-	value, ok := data[key].(string)
+	value, ok := secret.Data["password"].(string)
 	if !ok {
-		return "", fmt.Errorf("value type assertion failed: %T %#v", data[key], data[key])
+		return "", fmt.Errorf("value type assertion failed: %T %#v", secret.Data["password"], secret.Data["password"])
 	}
 
 	return value, nil

--- a/website/content/docs/auth/aws.mdx
+++ b/website/content/docs/auth/aws.mdx
@@ -793,7 +793,7 @@ func getSecretWithAWSAuthIAM() (string, error) {
 		return "", fmt.Errorf("unable to initialize AWS auth method: %w", err)
 	}
 
-	authInfo, err := client.Auth().Login(context.TODO(), awsAuth)
+	authInfo, err := client.Auth().Login(context.Background(), awsAuth)
 	if err != nil {
 		return "", fmt.Errorf("unable to login to AWS auth method: %w", err)
 	}
@@ -801,23 +801,17 @@ func getSecretWithAWSAuthIAM() (string, error) {
 		return "", fmt.Errorf("no auth info was returned after login")
 	}
 
-	// get secret
-	secret, err := client.Logical().Read("kv-v2/data/creds")
+	// get secret from the default mount path for KV v2 in dev mode, "secret"
+	secret, err := client.KVv2("secret").Get(context.Background(), "creds")
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret: %w", err)
 	}
 
-	data, ok := secret.Data["data"].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
-	}
-
 	// data map can contain more than one key-value pair,
 	// in this case we're just grabbing one of them
-	key := "password"
-	value, ok := data[key].(string)
+	value, ok := secret.Data["password"].(string)
 	if !ok {
-		return "", fmt.Errorf("value type assertion failed: %T %#v", data[key], data[key])
+		return "", fmt.Errorf("value type assertion failed: %T %#v", secret.Data["password"], secret.Data["password"])
 	}
 
 	return value, nil

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -250,7 +250,7 @@ func getSecretWithAzureAuth() (string, error) {
 		return "", fmt.Errorf("unable to initialize Azure auth method: %w", err)
 	}
 
-	authInfo, err := client.Auth().Login(context.TODO(), azureAuth)
+	authInfo, err := client.Auth().Login(context.Background(), azureAuth)
 	if err != nil {
 		return "", fmt.Errorf("unable to login to Azure auth method: %w", err)
 	}
@@ -258,23 +258,17 @@ func getSecretWithAzureAuth() (string, error) {
 		return "", fmt.Errorf("no auth info was returned after login")
 	}
 
-	// get secret
-	secret, err := client.Logical().Read("kv-v2/data/creds")
+	// get secret from the default mount path for KV v2 in dev mode, "secret"
+	secret, err := client.KVv2("secret").Get(context.Background(), "creds")
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret: %w", err)
 	}
 
-	data, ok := secret.Data["data"].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
-	}
-
 	// data map can contain more than one key-value pair,
 	// in this case we're just grabbing one of them
-	key := "password"
-	value, ok := data[key].(string)
+	value, ok := secret.Data["password"].(string)
 	if !ok {
-		return "", fmt.Errorf("value type assertion failed: %T %#v", data[key], data[key])
+		return "", fmt.Errorf("value type assertion failed: %T %#v", secret.Data["password"], secret.Data["password"])
 	}
 
 	return value, nil

--- a/website/content/docs/auth/gcp.mdx
+++ b/website/content/docs/auth/gcp.mdx
@@ -448,23 +448,17 @@ func getSecretWithGCPAuthIAM() (string, error) {
 		return "", fmt.Errorf("login response did not return client token")
 	}
 
-	// get secret
-	secret, err := client.Logical().Read("kv-v2/data/creds")
+	// get secret from the default mount path for KV v2 in dev mode, "secret"
+	secret, err := client.KVv2("secret").Get(context.Background(), "creds")
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret: %w", err)
 	}
 
-	data, ok := secret.Data["data"].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
-	}
-
 	// data map can contain more than one key-value pair,
 	// in this case we're just grabbing one of them
-	key := "password"
-	value, ok := data[key].(string)
+	value, ok := secret.Data["password"].(string)
 	if !ok {
-		return "", fmt.Errorf("value type assertion failed: %T %#v", data[key], data[key])
+		return "", fmt.Errorf("value type assertion failed: %T %#v", secret.Data["password"], secret.Data["password"])
 	}
 
 	return value, nil

--- a/website/content/docs/auth/kubernetes.mdx
+++ b/website/content/docs/auth/kubernetes.mdx
@@ -376,23 +376,17 @@ func getSecretWithKubernetesAuth() (string, error) {
 		return "", fmt.Errorf("no auth info was returned after login")
 	}
 
-	// get secret from Vault
-	secret, err := client.Logical().Read("kv-v2/data/creds")
+	// get secret from Vault, from the default mount path for KV v2 in dev mode, "secret"
+	secret, err := client.KVv2("secret").Get(context.Background(), "creds")
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret: %w", err)
 	}
 
-	data, ok := secret.Data["data"].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
-	}
-
 	// data map can contain more than one key-value pair,
 	// in this case we're just grabbing one of them
-	key := "password"
-	value, ok := data[key].(string)
+	value, ok := secret.Data["password"].(string)
 	if !ok {
-		return "", fmt.Errorf("value type assertion failed: %T %#v", data[key], data[key])
+		return "", fmt.Errorf("value type assertion failed: %T %#v", secret.Data["password"], secret.Data["password"])
 	}
 
 	return value, nil

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -253,13 +253,11 @@ We'll use the Vault client we just initialized to write a secret to Vault, like 
 
 ```go
 secretData := map[string]interface{}{
-    "data": map[string]interface{}{
-        "password": "Hashi123",
-    },
+    "password": "Hashi123",
 }
 
 
-_, err = client.Logical().Write("secret/data/my-secret-password", secretData)
+_, err = client.KVv2("secret").Put(context.Background(), "my-secret-password", secretData)
 if err != nil {
     log.Fatalf("unable to write secret: %v", err)
 }
@@ -342,20 +340,14 @@ Underneath the line where you wrote a secret to Vault, let's add a few more line
 <CodeBlockConfig lineNumbers>
 
 ```go
-secret, err := client.Logical().Read("secret/data/my-secret-password")
+secret, err := client.KVv2("secret").Get(context.Background(), "my-secret-password")
 if err != nil {
     log.Fatalf("unable to read secret: %v", err)
 }
 
-data, ok := secret.Data["data"].(map[string]interface{})
+value, ok := secret.Data["password"].(string)
 if !ok {
-    log.Fatalf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
-}
-
-key := "password"
-value, ok := data[key].(string)
-if !ok {
-    log.Fatalf("value type assertion failed: %T %#v", data[key], data[key])
+log.Fatalf("value type assertion failed: %T %#v", secret.Data["password"], secret.Data["password"])
 }
 ```
 


### PR DESCRIPTION
This PR updates the example snippets in the docs and dev quickstart guide to use the new KV helper methods (matching what we'll have in the hashicorp/vault-examples repo).