### PR TITLE
VAULT-5095 Update docs to reflect that child namespaces do not inherit parent quotas

### DIFF
--- a/website/content/api-docs/system/lease-count-quotas.mdx
+++ b/website/content/api-docs/system/lease-count-quotas.mdx
@@ -29,7 +29,7 @@ that can either be a namespace or mount.
   `userpass` in `namespace1`. Updating this field on an existing quota can have
   "moving" effects. For example, updating `auth/userpass` to
   `namespace1/auth/userpass` moves this quota from being a global mount quota to a
-  namespace specific mount quota. Quotas on a namespace are not inherited by child
+  namespace specific mount quota. Quotas on a non-root namespace are not inherited by child
   namespaces.
 - `max_leases` `(int: 0)` - Maximum number of leases allowed by the quota rule.
 

--- a/website/content/api-docs/system/lease-count-quotas.mdx
+++ b/website/content/api-docs/system/lease-count-quotas.mdx
@@ -29,7 +29,8 @@ that can either be a namespace or mount.
   `userpass` in `namespace1`. Updating this field on an existing quota can have
   "moving" effects. For example, updating `auth/userpass` to
   `namespace1/auth/userpass` moves this quota from being a global mount quota to a
-  namespace specific mount quota.
+  namespace specific mount quota. Quotas on a namespace are not inherited by child
+  namespaces.
 - `max_leases` `(int: 0)` - Maximum number of leases allowed by the quota rule.
 
 ### Sample Payload

--- a/website/content/api-docs/system/rate-limit-quotas.mdx
+++ b/website/content/api-docs/system/rate-limit-quotas.mdx
@@ -27,7 +27,8 @@ either be a namespace or mount.
   `userpass` in `namespace1`. Updating this field on an existing quota can have
   "moving" effects. For example, updating `auth/userpass` to
   `namespace1/auth/userpass` moves this quota from being a global mount quota to a
-  namespace specific mount quota. **Note, namespaces are supported in Enterprise only**.
+  namespace specific mount quota. Quotas on a namespace are not inherited by child
+  namespaces. **Note, namespaces are supported in Enterprise only**.
 - `rate` `(float: 0.0)` - The maximum number of requests in a given interval to
   be allowed by the quota rule. The `rate` must be positive.
 - `interval` `(string: "")` - The duration to enforce rate limiting for (default `"1s"`).

--- a/website/content/api-docs/system/rate-limit-quotas.mdx
+++ b/website/content/api-docs/system/rate-limit-quotas.mdx
@@ -27,7 +27,7 @@ either be a namespace or mount.
   `userpass` in `namespace1`. Updating this field on an existing quota can have
   "moving" effects. For example, updating `auth/userpass` to
   `namespace1/auth/userpass` moves this quota from being a global mount quota to a
-  namespace specific mount quota. Quotas on a namespace are not inherited by child
+  namespace specific mount quota. Quotas on a non-root namespace are not inherited by child
   namespaces. **Note, namespaces are supported in Enterprise only**.
 - `rate` `(float: 0.0)` - The maximum number of requests in a given interval to
   be allowed by the quota rule. The `rate` must be positive.

--- a/website/content/docs/enterprise/lease-count-quotas.mdx
+++ b/website/content/docs/enterprise/lease-count-quotas.mdx
@@ -25,10 +25,8 @@ the lease counters will be shared, regardless of which node in the Vault cluster
 receives lease generation requests. Lease quotas can be imposed across Vault's API,
 or scoped down to API pertaining to specific namespaces or specific mounts.
 
-Lease count quotas defined in a namespace will be inherited by all the child
-namespaces. By extension, this means that a quota that is defined in the `root`
-namespace is inherited by all namespaces and mounts, essentially to the entire
-Vault API.
+A quota that is defined in the `root` namespace is inherited by all namespaces
+and mounts, essentially to the entire Vault API.
 
 Lease count quotas defined on a namespace will take precedence over the inherited
 quotas. Lease count quotas defined for a mount will take precedence over inherited


### PR DESCRIPTION
We made a decision on Slack: https://hashicorp.slack.com/archives/CMRSLF924/p1654718659650829

To update the docs instead of fix this issue as it's ultimately a breaking change if we were to enable this behaviour now.

I wasn't sure about the additions in the API docs but it felt like the best place to put the information and I felt it was important that this was documented as it could seem unintuitive (as root namespace quotas do get inherited)