### PR TITLE
Glimmerize mount-backend-form

### DIFF
--- a/ui/app/components/mount-backend-form.js
+++ b/ui/app/components/mount-backend-form.js
@@ -78,7 +78,7 @@ export default class MountBackendForm extends Component {
     // change it here to match the new type
     let isUnchanged = list.findBy('type', currentPath);
     if (!currentPath || isUnchanged) {
-      mount.set('path', type);
+      mount.path = type;
     }
   }
 

--- a/ui/app/components/mount-backend-form.js
+++ b/ui/app/components/mount-backend-form.js
@@ -1,80 +1,74 @@
 import Ember from 'ember';
 import { inject as service } from '@ember/service';
-import { computed } from '@ember/object';
-import Component from '@ember/component';
+import { action, setProperties } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { methods } from 'vault/helpers/mountable-auth-methods';
 import { engines, KMIP, TRANSFORM, KEYMGMT } from 'vault/helpers/mountable-secret-engines';
 import { waitFor } from '@ember/test-waiters';
 
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+/**
+ * @module MountBackendForm
+ * The `MountBackendForm` is ARG TODO
+ *
+ * @example ```js
+ *   <MountBackendForm @mountType="secret" @onMountSuccess={{this.onMountSuccess}} />```
+ *
+ * @param {function} onMountSuccess - A function that transitions once the Mount has been successfully posted.
+ * @param {string} [mountType=auth] - The type of backend we want to mount.
+ *
+ */
+
 const METHODS = methods();
 const ENGINES = engines();
 
-export default Component.extend({
-  store: service(),
-  wizard: service(),
-  flashMessages: service(),
-  version: service(),
+export default class MountBackendForm extends Component {
+  @service store;
+  @service wizard;
+  @service flashMessages;
+  @service version;
 
-  /*
-   * @param Function
-   * @public
-   *
-   * Optional param to call a function upon successfully mounting a backend
-   *
-   */
-  onMountSuccess() {},
-  /*
-   * @param String
-   * @public
-   * the type of backend we want to mount
-   * defaults to `auth`
-   *
-   */
-  mountType: 'auth',
-
-  /*
-   *
-   * @param DS.Model
-   * @private
-   * Ember Data model corresponding to the `mountType`.
-   * Created and set during `init`
-   *
-   */
-  mountModel: null,
-
-  showEnable: false,
+  get mountType() {
+    return this.args.mountType || 'auth';
+  }
+  @tracked mountModel = null;
+  @tracked showEnable = false;
 
   // validation related properties
-  modelValidations: null,
-  invalidFormAlert: null,
+  @tracked modelValidations = null;
+  @tracked invalidFormAlert = null;
 
-  mountIssue: false,
+  @tracked mountIssue = false;
 
-  init() {
-    this._super(...arguments);
-    const type = this.mountType;
+  @tracked errors = '';
+  @tracked errorMessage = '';
+
+  constructor() {
+    super(...arguments);
+    const type = this.args.mountType || 'auth';
     const modelType = type === 'secret' ? 'secret-engine' : 'auth-method';
     const model = this.store.createRecord(modelType);
-    this.set('mountModel', model);
-  },
+    this.mountModel = model;
+  }
 
-  mountTypes: computed('engines', 'mountType', function () {
+  get mountTypes() {
     return this.mountType === 'secret' ? this.engines : METHODS;
-  }),
+  }
 
-  engines: computed('version.{features[],isEnterprise}', function () {
+  get engines() {
     if (this.version.isEnterprise) {
       return ENGINES.concat([KMIP, TRANSFORM, KEYMGMT]);
     }
     return ENGINES;
-  }),
+  }
 
   willDestroy() {
-    this._super(...arguments);
     // if unsaved, we want to unload so it doesn't show up in the auth mount list
+    super.willDestroy(...arguments);
     this.mountModel.rollbackAttributes();
-  },
+  }
 
   checkPathChange(type) {
     let mount = this.mountModel;
@@ -86,112 +80,113 @@ export default Component.extend({
     if (!currentPath || isUnchanged) {
       mount.set('path', type);
     }
-  },
+  }
 
   checkModelValidity(model) {
     const { isValid, state, invalidFormMessage } = model.validate();
-    this.setProperties({
+    setProperties(this, {
       modelValidations: state,
       invalidFormAlert: invalidFormMessage,
     });
 
     return isValid;
-  },
+  }
 
-  mountBackend: task(
-    waitFor(function* () {
-      const mountModel = this.mountModel;
-      const { type, path } = mountModel;
-      // only submit form if validations pass
-      if (!this.checkModelValidity(mountModel)) {
-        return;
-      }
-      let capabilities = null;
-      try {
-        capabilities = yield this.store.findRecord('capabilities', `${path}/config`);
-      } catch (err) {
-        if (Ember.testing) {
-          //captures mount-backend-form component test
-          yield mountModel.save();
-          let mountType = this.mountType;
-          mountType = mountType === 'secret' ? `${mountType}s engine` : `${mountType} method`;
-          this.flashMessages.success(`Successfully mounted the ${type} ${mountType} at ${path}.`);
-          yield this.onMountSuccess(type, path);
-          return;
-        } else {
-          throw err;
-        }
-      }
-
-      let changedAttrKeys = Object.keys(mountModel.changedAttributes());
-      let updatesConfig =
-        changedAttrKeys.includes('casRequired') ||
-        changedAttrKeys.includes('deleteVersionAfter') ||
-        changedAttrKeys.includes('maxVersions');
-
-      try {
-        yield mountModel.save();
-      } catch (err) {
-        if (err.httpStatus === 403) {
-          this.mountIssue = true;
-          this.flashMessages.danger(
-            'You do not have access to the sys/mounts endpoint. The secret engine was not mounted.'
-          );
-          return;
-        }
-        if (err.errors) {
-          let errors = err.errors.map((e) => {
-            if (typeof e === 'object') return e.title || e.message || JSON.stringify(e);
-            return e;
-          });
-          this.set('errors', errors);
-        } else if (err.message) {
-          this.set('errorMessage', err.message);
-        } else {
-          this.set('errorMessage', 'An error occurred, check the vault logs.');
-        }
-        return;
-      }
-      // mountModel must be after the save
-      if (mountModel.isV2KV && updatesConfig && !capabilities.get('canUpdate')) {
-        // config error is not thrown from secret-engine adapter, so handling here
-        this.flashMessages.warning(
-          'You do not have access to the config endpoint. The secret engine was mounted, but the configuration settings were not saved.'
-        );
-        // remove the config data from the model otherwise it will save it even if the network request failed.
-        [this.mountModel.maxVersions, this.mountModel.casRequired, this.mountModel.deleteVersionAfter] = [
-          0,
-          false,
-          0,
-        ];
-      }
-      let mountType = this.mountType;
-      mountType = mountType === 'secret' ? `${mountType}s engine` : `${mountType} method`;
-      this.flashMessages.success(`Successfully mounted the ${type} ${mountType} at ${path}.`);
-      yield this.onMountSuccess(type, path);
+  @task
+  @waitFor
+  *mountBackend() {
+    const mountModel = this.mountModel;
+    const { type, path } = mountModel;
+    // only submit form if validations pass
+    if (!this.checkModelValidity(mountModel)) {
       return;
-    })
-  ).drop(),
-
-  actions: {
-    onKeyUp(name, value) {
-      this.mountModel.set(name, value);
-    },
-
-    onTypeChange(path, value) {
-      if (path === 'type') {
-        this.wizard.set('componentState', value);
-        this.checkPathChange(value);
-      }
-    },
-
-    toggleShowEnable(value) {
-      this.set('showEnable', value);
-      if (value === true && this.wizard.featureState === 'idle') {
-        this.wizard.transitionFeatureMachine(this.wizard.featureState, 'CONTINUE', this.mountModel.type);
+    }
+    let capabilities = null;
+    try {
+      capabilities = yield this.store.findRecord('capabilities', `${path}/config`);
+    } catch (err) {
+      if (Ember.testing) {
+        //captures mount-backend-form component test
+        yield mountModel.save();
+        let mountType = this.mountType;
+        mountType = mountType === 'secret' ? `${mountType}s engine` : `${mountType} method`;
+        this.flashMessages.success(`Successfully mounted the ${type} ${mountType} at ${path}.`);
+        yield this.args.onMountSuccess(type, path);
+        return;
       } else {
-        this.wizard.transitionFeatureMachine(this.wizard.featureState, 'RESET', this.mountModel.type);
+        throw err;
       }
-    },
-  },
-});
+    }
+
+    let changedAttrKeys = Object.keys(mountModel.changedAttributes());
+    let updatesConfig =
+      changedAttrKeys.includes('casRequired') ||
+      changedAttrKeys.includes('deleteVersionAfter') ||
+      changedAttrKeys.includes('maxVersions');
+
+    try {
+      yield mountModel.save();
+    } catch (err) {
+      if (err.httpStatus === 403) {
+        this.mountIssue = true;
+        this.flashMessages.danger(
+          'You do not have access to the sys/mounts endpoint. The secret engine was not mounted.'
+        );
+        return;
+      }
+      if (err.errors) {
+        let errors = err.errors.map((e) => {
+          if (typeof e === 'object') return e.title || e.message || JSON.stringify(e);
+          return e;
+        });
+        this.errors = errors;
+      } else if (err.message) {
+        this.errorMessage = err.message;
+      } else {
+        this.errorMessage = 'An error occurred, check the vault logs.';
+      }
+      return;
+    }
+    // mountModel must be after the save
+    if (mountModel.isV2KV && updatesConfig && !capabilities.get('canUpdate')) {
+      // config error is not thrown from secret-engine adapter, so handling here
+      this.flashMessages.warning(
+        'You do not have access to the config endpoint. The secret engine was mounted, but the configuration settings were not saved.'
+      );
+      // remove the config data from the model otherwise it will save it even if the network request failed.
+      [this.mountModel.maxVersions, this.mountModel.casRequired, this.mountModel.deleteVersionAfter] = [
+        0,
+        false,
+        0,
+      ];
+    }
+    let mountType = this.mountType;
+    mountType = mountType === 'secret' ? `${mountType}s engine` : `${mountType} method`;
+    this.flashMessages.success(`Successfully mounted the ${type} ${mountType} at ${path}.`);
+    yield this.args.onMountSuccess(type, path);
+    return;
+  }
+
+  @action
+  onKeyUp(name, value) {
+    this.mountModel.set(name, value);
+  }
+
+  @action
+  onTypeChange(path, value) {
+    if (path === 'type') {
+      this.wizard.set('componentState', value);
+      this.checkPathChange(value);
+    }
+  }
+
+  @action
+  toggleShowEnable(value) {
+    this.showEnable = value;
+    if (value === true && this.wizard.featureState === 'idle') {
+      this.wizard.transitionFeatureMachine(this.wizard.featureState, 'CONTINUE', this.mountModel.type);
+    } else {
+      this.wizard.transitionFeatureMachine(this.wizard.featureState, 'RESET', this.mountModel.type);
+    }
+  }
+}

--- a/ui/app/components/mount-backend-form.js
+++ b/ui/app/components/mount-backend-form.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { action, setProperties } from '@ember/object';
 import { task } from 'ember-concurrency';
@@ -6,12 +8,9 @@ import { methods } from 'vault/helpers/mountable-auth-methods';
 import { engines, KMIP, TRANSFORM, KEYMGMT } from 'vault/helpers/mountable-secret-engines';
 import { waitFor } from '@ember/test-waiters';
 
-import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-
 /**
  * @module MountBackendForm
- * The `MountBackendForm` is ARG TODO
+ * The `MountBackendForm` is used to mount either a secret or auth backend.
  *
  * @example ```js
  *   <MountBackendForm @mountType="secret" @onMountSuccess={{this.onMountSuccess}} />```
@@ -33,6 +32,7 @@ export default class MountBackendForm extends Component {
   get mountType() {
     return this.args.mountType || 'auth';
   }
+
   @tracked mountModel = null;
   @tracked showEnable = false;
 

--- a/ui/app/templates/components/mount-backend-form.hbs
+++ b/ui/app/templates/components/mount-backend-form.hbs
@@ -18,19 +18,19 @@
     </h1>
   </p.levelLeft>
 </PageHeader>
-<form {{action (perform this.mountBackend) on="submit"}}>
+<form {{on "submit" (perform this.mountBackend)}}>
   <div class="box is-sideless is-fullwidth is-marginless">
     <NamespaceReminder @mode="enable" @noun={{if (eq this.mountType "auth") "Auth Method" "Secret Engine"}} />
     <MessageError @model={{this.model}} @errorMessage={{this.errorMessage}} @errors={{this.errors}} />
     {{#if this.showEnable}}
       <FormFieldGroups
         @model={{this.mountModel}}
-        @onChange={{action "onTypeChange"}}
+        @onChange={{this.onTypeChange}}
         @renderGroup="default"
         @modelValidations={{this.modelValidations}}
-        @onKeyUp={{action "onKeyUp"}}
+        @onKeyUp={{this.onKeyUp}}
       />
-      <FormFieldGroups @model={{this.mountModel}} @onChange={{action "onTypeChange"}} @renderGroup="Method Options" />
+      <FormFieldGroups @model={{this.mountModel}} @onChange={{this.onTypeChange}} @renderGroup="Method Options" />
     {{else}}
       {{#each (array "generic" "cloud" "infra") as |category|}}
         <h3 class="title box-radio-header">
@@ -38,6 +38,7 @@
         </h3>
         <div class="box-radio-container">
           {{#each (filter-by "category" category this.mountTypes) as |type|}}
+            {{! ARG TODO work on the onRadioChange }}
             <BoxRadio
               @displayName={{type.displayName}}
               @type={{type.type}}
@@ -77,7 +78,7 @@
         </button>
       </div>
       <div class="control">
-        <button data-test-mount-back type="button" class="button" onclick={{action "toggleShowEnable" false}}>
+        <button data-test-mount-back type="button" class="button" {{on "click" (fn this.toggleShowEnable false)}}>
           Back
         </button>
       </div>
@@ -91,7 +92,7 @@
         data-test-mount-next
         type="button"
         class="button is-primary"
-        onclick={{action "toggleShowEnable" true}}
+        {{on "click" (fn this.toggleShowEnable true)}}
         disabled={{not this.mountModel.type}}
       >
         Next

--- a/ui/app/templates/components/mount-backend-form.hbs
+++ b/ui/app/templates/components/mount-backend-form.hbs
@@ -38,14 +38,13 @@
         </h3>
         <div class="box-radio-container">
           {{#each (filter-by "category" category this.mountTypes) as |type|}}
-            {{! ARG TODO work on the onRadioChange }}
             <BoxRadio
               @displayName={{type.displayName}}
               @type={{type.type}}
               @glyph={{or type.glyph type.type}}
               @groupValue={{this.mountModel.type}}
               @groupName="mount-type"
-              @onRadioChange={{queue (action (mut this.mountModel.type)) (action "onTypeChange" "type")}}
+              @onRadioChange={{queue (fn (mut this.mountModel.type)) (fn this.onTypeChange "type")}}
               @disabled={{if type.requiredFeature (not (has-feature type.requiredFeature)) false}}
               @tooltipMessage={{if
                 (or (eq type.type "transform") (eq type.type "kmip") (eq type.type "keymgmt"))


### PR DESCRIPTION
This PR glimmerizes the mount-backend-form component. I went ahead and tackled this one because we will be working in this component for the upcoming PKI work. It will make it a little easier for the future work having this component updated. Specifically, having tracked properties instead of computed.