### PR TITLE
return bad request instead of server error for identity group cycle detection

### DIFF
--- a/changelog/15912.txt
+++ b/changelog/15912.txt
@@ -1,3 +1,3 @@
-```release-note:improvement
+```release-note:change
 identity: a request to `/identity/group` that includes `member_group_ids` that contains a cycle will now be responded to with a 400 rather than 500
 ```

--- a/changelog/15912.txt
+++ b/changelog/15912.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+identity: a request to `/identity/group` that includes `member_group_ids` that contains a cycle will now be responded to with a 400 rather than 500
+```

--- a/vault/identity_store_groups.go
+++ b/vault/identity_store_groups.go
@@ -255,6 +255,10 @@ func (i *IdentityStore) handleGroupUpdateCommon(ctx context.Context, req *logica
 
 	err = i.sanitizeAndUpsertGroup(ctx, group, nil, memberGroupIDs)
 	if err != nil {
+		if errStr := err.Error(); strings.HasPrefix(err.Error(), errCycleDetectedPrefix) {
+			return logical.ErrorResponse(errStr), nil
+		}
+
 		return nil, err
 	}
 

--- a/vault/identity_store_groups.go
+++ b/vault/identity_store_groups.go
@@ -255,7 +255,7 @@ func (i *IdentityStore) handleGroupUpdateCommon(ctx context.Context, req *logica
 
 	err = i.sanitizeAndUpsertGroup(ctx, group, nil, memberGroupIDs)
 	if err != nil {
-		if errStr := err.Error(); strings.HasPrefix(err.Error(), errCycleDetectedPrefix) {
+		if errStr := err.Error(); strings.HasPrefix(errStr, errCycleDetectedPrefix) {
 			return logical.ErrorResponse(errStr), nil
 		}
 

--- a/vault/identity_store_groups_test.go
+++ b/vault/identity_store_groups_test.go
@@ -1253,7 +1253,7 @@ func TestIdentityStore_GroupHierarchyCases(t *testing.T) {
 	groupUpdateReq.Data = kubeGroupData
 	kubeGroupData["member_group_ids"] = []string{engGroupID}
 	resp, err = is.HandleRequest(ctx, groupUpdateReq)
-	if err == nil {
+	if err != nil || resp == nil || !resp.IsError() {
 		t.Fatalf("expected an error response")
 	}
 

--- a/vault/identity_store_groups_test.go
+++ b/vault/identity_store_groups_test.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 	"strings"
@@ -1389,5 +1390,93 @@ func TestIdentityStore_GroupHierarchyCases(t *testing.T) {
 	}
 	if len(inheritedGroups) != 0 {
 		t.Fatalf("bad: length of inheritedGroups; expected: 0, actual: %d", len(inheritedGroups))
+	}
+}
+
+func TestIdentityStore_GroupCycleDetection(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(nil)
+
+	group1Name := "group1"
+	group2Name := "group2"
+	group3Name := "group3"
+
+	resp, err := c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "group",
+		Operation: logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"name": group1Name,
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("failed to create group %q, err: %v, resp: %#v", group1Name, err, resp)
+	}
+
+	group1Id := resp.Data["id"].(string)
+
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "group",
+		Operation: logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"name": group2Name,
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("failed to create group %q, err: %v, resp: %#v", group2Name, err, resp)
+	}
+
+	group2Id := resp.Data["id"].(string)
+
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "group",
+		Operation: logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"name": group3Name,
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("failed to create group %q, err: %v, resp: %#v", group3Name, err, resp)
+	}
+
+	group3Id := resp.Data["id"].(string)
+
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "group",
+		Operation: logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"name":             group1Name,
+			"member_group_ids": []string{},
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("failed to update group %q, err: %v, resp: %#v", group1Name, err, resp)
+	}
+
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "group",
+		Operation: logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"name":             group2Name,
+			"member_group_ids": []string{group3Id},
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("failed to update group %q, err: %v, resp: %#v", group2Name, err, resp)
+	}
+
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "group",
+		Operation: logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"name":             group3Name,
+			"member_group_ids": []string{group1Id, group2Id},
+		},
+	})
+
+	if err != nil || resp == nil {
+		t.Fatalf("unexpected group update error for group %q, err: %v, resp: %#v", group3Name, err, resp)
+	}
+	if !resp.IsError() || resp.Error().Error() != fmt.Sprintf("%s %q", errCycleDetectedPrefix, group2Id) {
+		t.Fatalf("expected update to group %q to fail due to cycle, resp: %#v", group3Id, resp)
 	}
 }

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -24,6 +24,7 @@ import (
 
 var (
 	errDuplicateIdentityName = errors.New("duplicate identity name")
+	errCycleDetectedPrefix   = "cyclic relationship detected for member group ID"
 	tmpSuffix                = ".tmp"
 )
 
@@ -1578,7 +1579,7 @@ func (i *IdentityStore) sanitizeAndUpsertGroup(ctx context.Context, group *ident
 				return fmt.Errorf("failed to perform cyclic relationship detection for member group ID %q", memberGroupID)
 			}
 			if cycleDetected {
-				return fmt.Errorf("cyclic relationship detected for member group ID %q", memberGroupID)
+				return fmt.Errorf("%s %q", errCycleDetectedPrefix, memberGroupID)
 			}
 		}
 
@@ -2157,7 +2158,7 @@ func (i *IdentityStore) detectCycleDFS(visited map[string]bool, startingGroupID,
 			return false, fmt.Errorf("failed to perform cycle detection at member group ID %q", memberGroup.ID)
 		}
 		if cycleDetected {
-			return true, fmt.Errorf("cycle detected at member group ID %q", memberGroup.ID)
+			return true, nil
 		}
 	}
 


### PR DESCRIPTION
Providing `member_group_ids` that contains a cycle for an identity group to `identity/group/name/<name>` will currently result in a 500 response. This should instead be a 400 response stating that a cycle was detected.

**Reproduction steps:**

Create groups:

```
ID_Group_0=`vault write -format=json identity/group/name/Group_0 | jq -r ".data.id"
ID_Group_1=`vault write -format=json identity/group/name/Group_1 | jq -r ".data.id"
ID_Group_2=`vault write -format=json identity/group/name/Group_2  | jq -r ".data.id"
```

Specify group IDs for `Group_0` and `Group_1`:
```
vault write identity/group/name/Group_0 member_group_ids= 
vault write identity/group/name/Group_1 member_group_ids=$ID_Group_2 
```

Specify group IDs for `Group_2` will fail due to cycle:
```
vault write identity/group/name/Group_2 member_group_ids=$ID_Group_0,$ID_Group_1 

Error writing data to identity/group/name/Group_2: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/identity/group/name/Group_2
Code: 500. Errors:

1 error occurred:
	* failed to perform cyclic relationship detection for member group ID "c5ac421e-0748-8b7e-466b-5a951542c2f8"
```

This PR introduces improved error handling such that an error caused by a cycle detection can be handled more specifically by a request handler. This allows for returning a `logical.ErrorResponse` rather than bubbling up the error to Vault's response handling logic and resulting in a 500 as so:

```
vault write identity/group/name/Group_2 member_group_ids=$ID_Group_0,$ID_Group_1 

Error writing data to identity/group/name/Group_2: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/identity/group/name/Group_2
Code: 400. Errors:

* cyclic relationship detected for member group ID "752b6146-2cc3-b3f5-8ab6-9feea4da98b5"
```

