### PR TITLE
Quick Bug Fix: missing database icon on overview page

### DIFF
--- a/ui/app/routes/vault/cluster/secrets/backend/overview.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/overview.js
@@ -54,6 +54,7 @@ export default Route.extend({
       roleCapabilities,
       staticRoleCapabilities,
       connectionCapabilities,
+      icon: backend,
     });
   },
   setupController(controller, model) {

--- a/ui/app/routes/vault/cluster/secrets/backend/overview.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/overview.js
@@ -54,7 +54,7 @@ export default Route.extend({
       roleCapabilities,
       staticRoleCapabilities,
       connectionCapabilities,
-      icon: backend,
+      icon: 'database',
     });
   },
   setupController(controller, model) {


### PR DESCRIPTION
The Overview page, unlike the Roles, or the Configuration page on secret engines doest not use the secret-engine model. It makes its own and this model is missing the icon param. Thus, the icon was not showing on the overview page even if it was showing on all the other tabs. I added it in.

I ran into this during the PKI R&D work.

The hardcoded value works here because the Overview page is only used for the database secret-engine. This will be changed in the PKI work which will also use the overview page. However, because each overview will be very different (make different request, need a different model), I am going to distinguish theses by renaming them overview-database and overview-pki. There is also a hard coded value already in this route for engineType on row 52.

**Before:**
![image](https://user-images.githubusercontent.com/6618863/172944609-e20f18c3-7a15-486e-9a87-8951a15ca818.png)

**After:**
![image](https://user-images.githubusercontent.com/6618863/172944561-bc63bfcd-2878-49fc-8333-cf3eed9b9be6.png)
