### PR TITLE
When database plugin Clean is called, close connections in goroutines

### DIFF
--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -52,7 +52,7 @@ func addToGauge(dbType, version string, amount int32) {
 	if _, ok := gauges[gaugeName]; !ok {
 		createGauge(gaugeName)
 	}
-	val := atomic.AddInt32(gauges[gaugeName], int32(amount))
+	val := atomic.AddInt32(gauges[gaugeName], amount)
 	metrics.SetGaugeWithLabels(gaugeKey, float32(val), labels)
 }
 

--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -293,12 +293,12 @@ func (b *databaseBackend) addConnectionsCounter(dbw databaseVersionWrapper, amou
 	if err != nil {
 		b.Logger().Debug("Error getting database type", "err", err)
 		dbType = "unknown"
-	} 
-	version := 5
-	if dbw.isV4() {
-		version = 4
 	}
-	
+	version := "5"
+	if dbw.isV4() {
+		version = "4"
+	}
+
 	labels := []metrics.Label{{"type", dbType}, {"version", version}}
 	metrics.IncrCounterWithLabels([]string{"secrets", "database", "backend", "connections", "count"}, float32(amount), labels)
 }

--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -289,19 +289,17 @@ func (b *databaseBackend) GetConnectionWithConfig(ctx context.Context, name stri
 // addConnectionsCounter is used to keep metrics on how many and what types of databases we have open
 func (b *databaseBackend) addConnectionsCounter(dbw databaseVersionWrapper, amount int) {
 	// keep track of what databases we open
-	labels := make([]metrics.Label, 0, 2)
 	dbType, err := dbw.Type()
-	if err == nil {
-		labels = append(labels, metrics.Label{Name: "type", Value: dbType})
-	} else {
+	if err != nil {
 		b.Logger().Debug("Error getting database type", "err", err)
-		labels = append(labels, metrics.Label{Name: "type", Value: "unknown"})
-	}
+		dbType = "unknown"
+	} 
+	version := 5
 	if dbw.isV4() {
-		labels = append(labels, metrics.Label{Name: "version", Value: "4"})
-	} else {
-		labels = append(labels, metrics.Label{Name: "version", Value: "5"})
+		version = 4
 	}
+	
+	labels := []metrics.Label{{"type", dbType}, {"version", version}}
 	metrics.IncrCounterWithLabels([]string{"secrets", "database", "backend", "connections", "count"}, float32(amount), labels)
 }
 

--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -1494,6 +1494,9 @@ func (h hangingPlugin) Close() error {
 var _ dbplugin.Database = (*hangingPlugin)(nil)
 
 func TestBackend_PluginMain_Hanging(t *testing.T) {
+	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+		return
+	}
 	v5.Serve(&hangingPlugin{})
 }
 

--- a/builtin/logical/database/mocks_test.go
+++ b/builtin/logical/database/mocks_test.go
@@ -36,8 +36,7 @@ func (m *mockNewDatabase) DeleteUser(ctx context.Context, req v5.DeleteUserReque
 }
 
 func (m *mockNewDatabase) Type() (string, error) {
-	args := m.Called()
-	return args.String(0), args.Error(1)
+	return "mock", nil
 }
 
 func (m *mockNewDatabase) Close() error {

--- a/builtin/logical/database/mocks_test.go
+++ b/builtin/logical/database/mocks_test.go
@@ -36,7 +36,8 @@ func (m *mockNewDatabase) DeleteUser(ctx context.Context, req v5.DeleteUserReque
 }
 
 func (m *mockNewDatabase) Type() (string, error) {
-	return "mock", nil
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
 }
 
 func (m *mockNewDatabase) Close() error {

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -1379,6 +1379,7 @@ func setupMockDB(b *databaseBackend) *mockNewDatabase {
 	mockDB := &mockNewDatabase{}
 	mockDB.On("Initialize", mock.Anything, mock.Anything).Return(v5.InitializeResponse{}, nil)
 	mockDB.On("Close").Return(nil)
+	mockDB.On("Type").Return("mock", nil)
 	dbw := databaseVersionWrapper{
 		v5: mockDB,
 	}


### PR DESCRIPTION
We are seeing long pre-seal times when nodes are being shut down, which
seems to be delays in releasing the global stateLock, which further
seems to be delayed by cleaning up the builtin database plugin.

The database plugin `Clean()` eventually calls, synchronously, `Close()`
on every database instance that has been loaded. The database instance
`Close()` calls can take a long time to complete (e.g.,
[mongo](https://github.com/hashicorp/vault/blob/v1.10.3/plugins/database/mongodb/connection_producer.go#L132)
can take up to a minute to close its client before it will return).

So, instead, we change the `Clean()` method to close all of the database
instances in goroutines so they will be closed more quickly and won't
block the release of the global stateLock. This should be safe because
`Clean()` will only be called when the plugin is being unloaded, and so
the connections will no longer be used.

In addition, this adds metrics tracking how many of each type of
databases are being used by the builtin database plugin.