### PR TITLE
Fix location of not_before_duration on ssh docs

### DIFF
--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -250,6 +250,9 @@ This endpoint creates or updates a named role.
   migrate to `rsa-sha2-256` or `default` if the role was created with an
   explicit `algorithm_signer=rsa-sha` parameter or has been migrated to such.
 
+- `not_before_duration` `(duration: "30s")` - Specifies the duration by which
+  to backdate the `ValidAfter` property.
+
 ### Sample Payload
 
 ```json
@@ -838,8 +841,6 @@ to the restrictions contained in the role named in the endpoint.
 
 - `extensions` `(map<string|string>: "")` – Specifies a map of the extensions
   that the certificate should be signed for. Defaults to none.
-
-- `not_before_duration` `(duration: "30s")` – Specifies the duration by which to backdate the `ValidAfter` property.
 
 ### Sample Payload
 


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`