### PR TITLE
Use `badge` for `<sup>` tags in nav data JSON files

### DIFF
--- a/website/data/api-docs-nav-data.json
+++ b/website/data/api-docs-nav-data.json
@@ -182,7 +182,10 @@
         ]
       },
       {
-        "title": "Key Management <sup>ENTERPRISE</sup>",
+        "title": "Key Management",
+        "badge": {
+          "text": "ENTERPRISE"
+        },
         "routes": [
           {
             "title": "Overview",
@@ -220,7 +223,10 @@
         ]
       },
       {
-        "title": "KMIP <sup>ENTERPRISE</sup>",
+        "title": "KMIP",
+        "badge": {
+          "text": "ENTERPRISE"
+        },
         "path": "secret/kmip"
       },
       {
@@ -260,7 +266,10 @@
         "path": "secret/totp"
       },
       {
-        "title": "Transform <sup>ENTERPRISE</sup>",
+        "title": "Transform",
+        "badge": {
+          "text": "ENTERPRISE"
+        },
         "path": "secret/transform"
       },
       {
@@ -345,7 +354,10 @@
         "path": "auth/userpass"
       },
       {
-        "title": "App ID <sup>DEPRECATED</sup>",
+        "title": "App ID",
+        "badge": {
+          "text": "DEPRECATED"
+        },
         "path": "auth/app-id"
       }
     ]
@@ -479,7 +491,10 @@
         "path": "system/license"
       },
       {
-        "title": "<code>/sys/managed-keys <sup>ENT</sup></code>",
+        "title": "<code>/sys/managed-keys</code>",
+        "badge": {
+          "text": "ENT"
+        },
         "path": "system/managed-keys"
       },
       {

--- a/website/data/api-docs-nav-data.json
+++ b/website/data/api-docs-nav-data.json
@@ -184,7 +184,9 @@
       {
         "title": "Key Management",
         "badge": {
-          "text": "ENTERPRISE"
+          "text": "ENTERPRISE",
+          "type": "outlined",
+          "color": "neutral"
         },
         "routes": [
           {
@@ -225,7 +227,9 @@
       {
         "title": "KMIP",
         "badge": {
-          "text": "ENTERPRISE"
+          "text": "ENTERPRISE",
+          "type": "outlined",
+          "color": "neutral"
         },
         "path": "secret/kmip"
       },
@@ -268,7 +272,9 @@
       {
         "title": "Transform",
         "badge": {
-          "text": "ENTERPRISE"
+          "text": "ENTERPRISE",
+          "type": "outlined",
+          "color": "neutral"
         },
         "path": "secret/transform"
       },
@@ -356,7 +362,9 @@
       {
         "title": "App ID",
         "badge": {
-          "text": "DEPRECATED"
+          "text": "DEPRECATED",
+          "type": "outlined",
+          "color": "neutral"
         },
         "path": "auth/app-id"
       }
@@ -493,7 +501,9 @@
       {
         "title": "<code>/sys/managed-keys</code>",
         "badge": {
-          "text": "ENT"
+          "text": "ENT",
+          "type": "outlined",
+          "color": "neutral"
         },
         "path": "system/managed-keys"
       },

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -245,7 +245,10 @@
             "path": "configuration/seal/ocikms"
           },
           {
-            "title": "HSM PKCS11 <sup>ENT</sup>",
+            "title": "HSM PKCS11",
+            "badge": {
+              "text": "ENT"
+            },
             "path": "configuration/seal/pkcs11"
           },
           {
@@ -389,11 +392,17 @@
         "path": "configuration/log-requests-level"
       },
       {
-        "title": "<code>Entropy Augmentation</code> <sup>ENT</sup>",
+        "title": "<code>Entropy Augmentation</code>",
+        "badge": {
+          "text": "ENT"
+        },
         "path": "configuration/entropy-augmentation"
       },
       {
-        "title": "<code>kms_library</code> <sup>ENT</sup>",
+        "title": "<code>kms_library</code>",
+        "badge": {
+          "text": "ENT"
+        },
         "path": "configuration/kms-library"
       }
     ]
@@ -1032,7 +1041,10 @@
         ]
       },
       {
-        "title": "Key Management <sup>ENTERPRISE</sup>",
+        "title": "Key Management",
+        "badge": {
+          "text": "ENTERPRISE"
+        },
         "routes": [
           {
             "title": "Overview",
@@ -1070,7 +1082,10 @@
         ]
       },
       {
-        "title": "KMIP <sup>ENTERPRISE</sup>",
+        "title": "KMIP",
+        "badge": {
+          "text": "ENTERPRISE"
+        },
         "path": "secrets/kmip"
       },
       {
@@ -1152,7 +1167,10 @@
         "path": "secrets/totp"
       },
       {
-        "title": "Transform <sup>ENTERPRISE</sup>",
+        "title": "Transform",
+        "badge": {
+          "text": "ENTERPRISE"
+        },
         "routes": [
           {
             "title": "Overview",
@@ -1163,7 +1181,10 @@
             "path": "secrets/transform/ff3-tweak-details"
           },
           {
-            "title": "Tokenization Transform <sup>ENTERPRISE</sup>",
+            "title": "Tokenization Transform",
+            "badge": {
+              "text": "ENTERPRISE"
+            },
             "path": "secrets/transform/tokenization"
           }
         ]
@@ -1279,7 +1300,10 @@
         "divider": true
       },
       {
-        "title": "App ID <sup>DEPRECATED</sup>",
+        "title": "App ID",
+        "badge": {
+          "text": "DEPRECATED"
+        },
         "path": "auth/app-id"
       }
     ]

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -247,7 +247,9 @@
           {
             "title": "HSM PKCS11",
             "badge": {
-              "text": "ENT"
+              "text": "ENT",
+              "type": "outlined",
+              "color": "neutral"
             },
             "path": "configuration/seal/pkcs11"
           },
@@ -394,14 +396,18 @@
       {
         "title": "<code>Entropy Augmentation</code>",
         "badge": {
-          "text": "ENT"
+          "text": "ENT",
+          "type": "outlined",
+          "color": "neutral"
         },
         "path": "configuration/entropy-augmentation"
       },
       {
         "title": "<code>kms_library</code>",
         "badge": {
-          "text": "ENT"
+          "text": "ENT",
+          "type": "outlined",
+          "color": "neutral"
         },
         "path": "configuration/kms-library"
       }
@@ -1043,7 +1049,9 @@
       {
         "title": "Key Management",
         "badge": {
-          "text": "ENTERPRISE"
+          "text": "ENTERPRISE",
+          "type": "outlined",
+          "color": "neutral"
         },
         "routes": [
           {
@@ -1084,7 +1092,9 @@
       {
         "title": "KMIP",
         "badge": {
-          "text": "ENTERPRISE"
+          "text": "ENTERPRISE",
+          "type": "outlined",
+          "color": "neutral"
         },
         "path": "secrets/kmip"
       },
@@ -1169,7 +1179,9 @@
       {
         "title": "Transform",
         "badge": {
-          "text": "ENTERPRISE"
+          "text": "ENTERPRISE",
+          "type": "outlined",
+          "color": "neutral"
         },
         "routes": [
           {
@@ -1183,7 +1195,9 @@
           {
             "title": "Tokenization Transform",
             "badge": {
-              "text": "ENTERPRISE"
+              "text": "ENTERPRISE",
+              "type": "outlined",
+              "color": "neutral"
             },
             "path": "secrets/transform/tokenization"
           }
@@ -1302,7 +1316,9 @@
       {
         "title": "App ID",
         "badge": {
-          "text": "DEPRECATED"
+          "text": "DEPRECATED",
+          "type": "outlined",
+          "color": "neutral"
         },
         "path": "auth/app-id"
       }


### PR DESCRIPTION
Replaces the `<sup>` tags in nav data JSON files with a `badge` property. This is a new feature in DevDot, introduced in https://github.com/hashicorp/dev-portal/pull/562. Each badge has `type="outlined"` and `color="neutral"`.

Asana task: https://app.asana.com/0/1202114367927919/1202405210286703/f