### PR TITLE
ssh: Do not convert errors into logical.ErrorResponse in issue path

### DIFF
--- a/builtin/logical/ssh/path_issue.go
+++ b/builtin/logical/ssh/path_issue.go
@@ -113,7 +113,10 @@ func (b *backend) pathIssueCertificate(ctx context.Context, req *logical.Request
 
 	response, err := b.pathSignIssueCertificateHelper(ctx, req, data, role, userPublicKey)
 	if err != nil {
-		return logical.ErrorResponse(err.Error()), nil
+		return nil, err
+	}
+	if response.IsError() {
+		return response, nil
 	}
 
 	// Additional to sign response

--- a/builtin/logical/ssh/path_sign.go
+++ b/builtin/logical/ssh/path_sign.go
@@ -92,10 +92,5 @@ func (b *backend) pathSignCertificate(ctx context.Context, req *logical.Request,
 		return logical.ErrorResponse(fmt.Sprintf("public_key failed to meet the key requirements: %s", err)), nil
 	}
 
-	response, err := b.pathSignIssueCertificateHelper(ctx, req, data, role, userPublicKey)
-	if err != nil {
-		return response, err
-	}
-
-	return response, nil
+	return b.pathSignIssueCertificateHelper(ctx, req, data, role, userPublicKey)
 }


### PR DESCRIPTION
Do not wrap all errors into logical.ErrorResponse as I believe that switches the return code from a 5XX to a 4XX. Also if the `pathSignIssueCertificateHelper` returns an error response value, do not add data to it.