### PR TITLE
Document agent injecting PKI CAs

### DIFF
--- a/website/content/docs/agent/template.mdx
+++ b/website/content/docs/agent/template.mdx
@@ -68,7 +68,7 @@ To fetch the issuing CA for this mount, use:
 
 ```
 {{- with secret "pki/cert/ca" -}}
-{{ "" | or ( .Data.certificate ) }}
+{{ .Data.certificate }}
 {{- end -}}
 ```
 


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

Resolves: #13533 


The only thing I'm not sure of is the `"" | or (...)` syntax. I believe its helpful when the PKI CA isn't yet configured or the request errs for some reason, but I'm not sure of the syntax. 

See: https://docs.tetrate.io/service-bridge/1.4.x/en-us/operations/vault/istiod-ca#configure-tsb-controlplane-crd for where I found this example. 


There's also a `website/content/docs/platform/k8s/injector/examples.mdx` page, but I don't know enough to add a full-working example there. 