### PR TITLE
database plugin: Invalidate queue should cancel context first

### DIFF
--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -286,12 +286,15 @@ func (b *databaseBackend) GetConnectionWithConfig(ctx context.Context, name stri
 
 // invalidateQueue cancels any background queue loading and destroys the queue.
 func (b *databaseBackend) invalidateQueue() {
-	b.Lock()
-	defer b.Unlock()
-
+	// cancel context before grabbing lock to start closing any open connections
+	// this is safe to do without the lock since it is only written to once in initialization
+	// and can be canceled multiple times safely
 	if b.cancelQueue != nil {
 		b.cancelQueue()
 	}
+	b.Lock()
+	defer b.Unlock()
+
 	b.credRotationQueue = nil
 }
 


### PR DESCRIPTION
To signal to any credentials rotating goroutines that they should cancel
pending operations, which reduces lock contention.