### PR TITLE
docs/oidc: adds missing steps for Google Workspace configuration

### DIFF
--- a/website/content/docs/auth/jwt/oidc_providers.mdx
+++ b/website/content/docs/auth/jwt/oidc_providers.mdx
@@ -214,6 +214,8 @@ To set up the Google-specific handling, you'll need:
 - A Google Workspace account with the [super admin role](https://support.google.com/a/answer/2405986?hl=en)
   for granting domain-wide delegation API client access.
 - The ability to create a service account in [Google Cloud Platform](https://console.developers.google.com/iam-admin/serviceaccounts).
+- To enable the [Admin SDK API](https://console.developers.google.com/apis/api/admin.googleapis.com/overview).
+- An OAuth 2.0 application with an [external user type](https://support.google.com/cloud/answer/10311615#user-type).
 
 The Google-specific handling that's used to fetch Google Workspace groups and user information in Vault uses
 [Google Workspace Domain-Wide Delegation of Authority](https://developers.google.com/admin-sdk/directory/v1/guides/delegation)


### PR DESCRIPTION
This PR adds missing steps to the documentation for configuring OIDC auth with the Google workspace integration. I ran into these issues when setting up the configuration in a new GCP project.