### PR TITLE
Cleanup and simplify lock usage in database plugin

### DIFF
--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -66,6 +66,8 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 
 func Backend(conf *logical.BackendConfig) *databaseBackend {
 	var b databaseBackend
+	// set this just in case, since we sometimes call this from tests without Factory
+	b.ctx, b.cancelQueue = context.WithCancel(context.Background())
 	b.Backend = &framework.Backend{
 		Help: strings.TrimSpace(backendHelp),
 

--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -348,7 +348,9 @@ func (b *databaseBackend) CloseIfShutdown(db *dbPluginInstance, err error) {
 // and cancels any rotation queue loading operation.
 func (b *databaseBackend) clean(_ context.Context) {
 	// kill the queue and terminate the background ticker
-	b.cancelQueue()
+	if b.cancelQueue != nil {
+		b.cancelQueue()
+	}
 
 	connections := b.connClear()
 	for _, db := range connections {

--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -104,7 +104,7 @@ func Backend(conf *logical.BackendConfig) *databaseBackend {
 }
 
 type databaseBackend struct {
-	// used to synchronize access to the connections map
+	// connLock is used to synchronize access to the connections map
 	connLock sync.RWMutex
 	// connections holds configured database connections by config name
 	connections map[string]*dbPluginInstance

--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -144,8 +144,8 @@ func (b *databaseBackend) connPop(name string) *dbPluginInstance {
 func (b *databaseBackend) connPopIfEqual(name, id string) *dbPluginInstance {
 	b.connLock.Lock()
 	defer b.connLock.Unlock()
-	dbi := b.connections[name]
-	if dbi.id == id {
+	dbi, ok := b.connections[name]
+	if ok && dbi.id == id {
 		delete(b.connections, name)
 		return dbi
 	}

--- a/builtin/logical/database/path_config_connection.go
+++ b/builtin/logical/database/path_config_connection.go
@@ -344,16 +344,14 @@ func (b *databaseBackend) connectionWriteHandler() framework.OperationFunc {
 
 		b.Logger().Debug("created database object", "name", name, "plugin_name", config.PluginName)
 
-		b.Lock()
-		defer b.Unlock()
-
 		// Close and remove the old connection
-		b.clearConnection(name)
-
-		b.connections[name] = &dbPluginInstance{
+		oldConn := b.connPut(name, &dbPluginInstance{
 			database: dbw,
 			name:     name,
 			id:       id,
+		})
+		if oldConn != nil {
+			oldConn.Close()
 		}
 
 		err = storeConfig(ctx, req.Storage, name, config)

--- a/builtin/logical/database/path_rotate_credentials.go
+++ b/builtin/logical/database/path_rotate_credentials.go
@@ -78,10 +78,6 @@ func (b *databaseBackend) pathRotateRootCredentialsUpdate() framework.OperationF
 			return nil, err
 		}
 
-		// Take out the backend lock since we are swapping out the connection
-		b.Lock()
-		defer b.Unlock()
-
 		// Take the write lock on the instance
 		dbi.Lock()
 		defer dbi.Unlock()
@@ -93,7 +89,7 @@ func (b *databaseBackend) pathRotateRootCredentialsUpdate() framework.OperationF
 				b.Logger().Error("error closing the database plugin connection", "err", err)
 			}
 			// Even on error, still remove the connection
-			delete(b.connections, name)
+			b.ClearConnection(name)
 		}()
 
 		generator, err := newPasswordGenerator(nil)

--- a/builtin/logical/database/path_rotate_credentials.go
+++ b/builtin/logical/database/path_rotate_credentials.go
@@ -83,7 +83,6 @@ func (b *databaseBackend) pathRotateRootCredentialsUpdate() framework.OperationF
 		unlocked := false
 		unlock := func() {
 			if !unlocked {
-				// set to true before unlocking to avoid race condition
 				unlocked = true
 				dbi.Unlock()
 			}

--- a/builtin/logical/database/path_rotate_credentials.go
+++ b/builtin/logical/database/path_rotate_credentials.go
@@ -89,7 +89,8 @@ func (b *databaseBackend) pathRotateRootCredentialsUpdate() framework.OperationF
 				b.Logger().Error("error closing the database plugin connection", "err", err)
 			}
 			// Even on error, still remove the connection
-			b.ClearConnection(name)
+			// do it in a goroutine since it may also try to grab dbi.Lock()
+			go b.ClearConnection(name)
 		}()
 
 		generator, err := newPasswordGenerator(nil)

--- a/builtin/logical/database/path_rotate_credentials.go
+++ b/builtin/logical/database/path_rotate_credentials.go
@@ -83,8 +83,9 @@ func (b *databaseBackend) pathRotateRootCredentialsUpdate() framework.OperationF
 		unlocked := false
 		defer func() {
 			if !unlocked {
-				dbi.Unlock()
+				// set to true before unlocking to avoid race condition
 				unlocked = true
+				dbi.Unlock()
 			}
 		}()
 		defer func() {
@@ -96,8 +97,9 @@ func (b *databaseBackend) pathRotateRootCredentialsUpdate() framework.OperationF
 			// Even on error, still remove the connection
 			// be careful with a deadlock here
 			if !unlocked {
-				dbi.Unlock()
+				// set to true before unlocking to avoid race condition
 				unlocked = true
+				dbi.Unlock()
 			}
 			b.ClearConnection(name)
 		}()

--- a/builtin/logical/database/path_rotate_credentials.go
+++ b/builtin/logical/database/path_rotate_credentials.go
@@ -96,7 +96,7 @@ func (b *databaseBackend) pathRotateRootCredentialsUpdate() framework.OperationF
 				b.Logger().Error("error closing the database plugin connection", "err", err)
 			}
 			// Even on error, still remove the connection
-			// be careful with a deadlock here
+			// ClearConnectionId also will grab the lock, so we need to release it here to prevent deadlock.
 			unlock()
 			b.ClearConnectionId(name, dbi.id)
 		}()

--- a/builtin/logical/database/rotation.go
+++ b/builtin/logical/database/rotation.go
@@ -645,7 +645,9 @@ func (b *databaseBackend) pushItem(item *queue.Item) error {
 	select {
 	case <-b.ctx.Done():
 	default:
-		return b.credRotationQueue.Push(item)
+		if b.credRotationQueue != nil {
+			return b.credRotationQueue.Push(item)
+		}
 	}
 	b.Logger().Warn("no queue found during push item")
 	return nil

--- a/builtin/logical/database/rotation.go
+++ b/builtin/logical/database/rotation.go
@@ -643,7 +643,7 @@ func (b *databaseBackend) loadStaticWALs(ctx context.Context, s logical.Storage)
 // operate in go-routines, and could be accessing the queue concurrently
 func (b *databaseBackend) pushItem(item *queue.Item) error {
 	select {
-	case <-b.ctx.Done():
+	case <-b.queueCtx.Done():
 	default:
 		return b.credRotationQueue.Push(item)
 	}
@@ -656,7 +656,7 @@ func (b *databaseBackend) pushItem(item *queue.Item) error {
 // operate in go-routines, and could be accessing the queue concurrently
 func (b *databaseBackend) popFromRotationQueue() (*queue.Item, error) {
 	select {
-	case <-b.ctx.Done():
+	case <-b.queueCtx.Done():
 	default:
 		return b.credRotationQueue.Pop()
 	}
@@ -668,7 +668,7 @@ func (b *databaseBackend) popFromRotationQueue() (*queue.Item, error) {
 // operate in go-routines, and could be accessing the queue concurrently
 func (b *databaseBackend) popFromRotationQueueByKey(name string) (*queue.Item, error) {
 	select {
-	case <-b.ctx.Done():
+	case <-b.queueCtx.Done():
 	default:
 		item, err := b.credRotationQueue.PopByKey(name)
 		if err != nil {

--- a/builtin/logical/database/rotation.go
+++ b/builtin/logical/database/rotation.go
@@ -645,9 +645,7 @@ func (b *databaseBackend) pushItem(item *queue.Item) error {
 	select {
 	case <-b.ctx.Done():
 	default:
-		if b.credRotationQueue != nil {
-			return b.credRotationQueue.Push(item)
-		}
+		return b.credRotationQueue.Push(item)
 	}
 	b.Logger().Warn("no queue found during push item")
 	return nil


### PR DESCRIPTION
Following up from discussions in #15923 and #15933, I wanted to split
out a separate PR that drastically reduced the complexity of the use of
the databaseBackend lock. We no longer need it at all for the
`credRotationQueue`, and we can move it to be solely used in a few,
small connections map management functions.