### PR TITLE
Import SDK 1.10.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	github.com/hashicorp/vault/api v1.5.0
 	github.com/hashicorp/vault/api/auth/approle v0.1.0
 	github.com/hashicorp/vault/api/auth/userpass v0.1.0
-	github.com/hashicorp/vault/sdk v0.4.2-0.20220513130519-057103fba822
+	github.com/hashicorp/vault/sdk v0.4.2-0.20220613145733-58617421f364
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/jcmturner/gokrb5/v8 v8.4.2
 	github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f


### PR DESCRIPTION
Ran the following

```
❯ go get github.com/hashicorp/vault/sdk@release/1.10.x
go: upgraded github.com/hashicorp/vault/sdk v0.4.2-0.20220513130519-057103fba822 => v0.4.2-0.20220613145733-58617421f364
❯ go mod tidy
```