### PR TITLE
go get sdk v0.5.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 	github.com/hashicorp/vault/api v1.7.2
 	github.com/hashicorp/vault/api/auth/approle v0.1.0
 	github.com/hashicorp/vault/api/auth/userpass v0.1.0
-	github.com/hashicorp/vault/sdk v0.5.1
+	github.com/hashicorp/vault/sdk v0.5.2
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/jackc/pgx/v4 v4.15.0
 	github.com/jcmturner/gokrb5/v8 v8.4.2


### PR DESCRIPTION
We cut a new SDK `v0.5.2` from `HEAD` of `release/1.11.x`. This PR bumps to that version:

```
❯ go get github.com/hashicorp/vault/sdk@sdk/v0.5.2
go: upgraded github.com/hashicorp/vault/sdk v0.5.1 => v0.5.2
```