### PR TITLE
Correct drift between ENT and OSS

### DIFF
--- a/builtin/credential/aws/path_config_rotate_root_test.go
+++ b/builtin/credential/aws/path_config_rotate_root_test.go
@@ -21,7 +21,6 @@ func TestPathConfigRotateRoot(t *testing.T) {
 					SecretAccessKey: aws.String("buzz2"),
 				},
 			},
-			DeleteAccessKeyOutput: &iam.DeleteAccessKeyOutput{},
 			GetUserOutput: &iam.GetUserOutput{
 				User: &iam.User{
 					UserName: aws.String("ellen"),

--- a/command/operator_diagnose.go
+++ b/command/operator_diagnose.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/term"
 
 	wrapping "github.com/hashicorp/go-kms-wrapping"
-	"github.com/hashicorp/vault/helper/constants"
 
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/hashicorp/consul/api"
@@ -22,6 +21,7 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/reloadutil"
 	uuid "github.com/hashicorp/go-uuid"
 	cserver "github.com/hashicorp/vault/command/server"
+	"github.com/hashicorp/vault/helper/constants"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/internalshared/configutil"
 	"github.com/hashicorp/vault/internalshared/listenerutil"

--- a/helper/identity/sentinel.go
+++ b/helper/identity/sentinel.go
@@ -74,6 +74,7 @@ func (a *Alias) SentinelKeys() []string {
 	return []string{
 		"id",
 		"mount_type",
+		"mount_accessor",
 		"mount_path",
 		"meta",
 		"metadata",

--- a/plugins/database/mssql/mssql.go
+++ b/plugins/database/mssql/mssql.go
@@ -427,5 +427,5 @@ SET @stmt = 'IF EXISTS (SELECT name FROM [master].[sys].[server_principals] WHER
 EXEC (@stmt)`
 
 const alterLoginSQL = `
-ALTER LOGIN [{{username}}] WITH PASSWORD = '{{password}}' 
+ALTER LOGIN [{{username}}] WITH PASSWORD = '{{password}}'
 `

--- a/sdk/version/version_base.go
+++ b/sdk/version/version_base.go
@@ -13,5 +13,5 @@ var (
 
 	Version           = "1.12.0"
 	VersionPrerelease = "dev1"
-	VersionMetadata   = ""
+	VersionMetadata   = "ent"
 )

--- a/sdk/version/version_base.go
+++ b/sdk/version/version_base.go
@@ -13,5 +13,5 @@ var (
 
 	Version           = "1.12.0"
 	VersionPrerelease = "dev1"
-	VersionMetadata   = "ent"
+	VersionMetadata   = ""
 )

--- a/vault/cluster.go
+++ b/vault/cluster.go
@@ -218,13 +218,12 @@ func (c *Core) setupCluster(ctx context.Context) error {
 
 		// Create a certificate
 		if c.localClusterCert.Load().([]byte) == nil {
-			c.logger.Debug("generating local cluster certificate")
-
 			host, err := uuid.GenerateUUID()
 			if err != nil {
 				return err
 			}
 			host = fmt.Sprintf("fw-%s", host)
+			c.logger.Debug("generating local cluster certificate", "host", host)
 			template := &x509.Certificate{
 				Subject: pkix.Name{
 					CommonName: host,

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -779,7 +779,8 @@ func (c *Core) periodicCheckKeyUpgrades(ctx context.Context, stopCh chan struct{
 				// keys (e.g. from replication being activated) and we need to seal to
 				// be unsealed again.
 				entry, _ := c.barrier.Get(ctx, poisonPillPath)
-				if entry != nil && len(entry.Value) > 0 {
+				entryDR, _ := c.barrier.Get(ctx, poisonPillDRPath)
+				if (entry != nil && len(entry.Value) > 0) || (entryDR != nil && len(entryDR.Value) > 0) {
 					c.logger.Warn("encryption keys have changed out from underneath us (possibly due to replication enabling), must be unsealed again")
 					// If we are using raft storage we do not want to shut down
 					// raft during replication secondary enablement. This will


### PR DESCRIPTION
This brings OSS files in this repo in line with changes that have been made to these files in the ENT repo, but were never backported here.