### PR TITLE
clarify lazy revoke prefix if not sync

### DIFF
--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -1095,6 +1095,9 @@ func (m *ExpirationManager) RevokeByToken(ctx context.Context, te *logical.Token
 	return nil
 }
 
+// revoke all leases under `prefix`
+// if sync == true, revoke immediately. otherwise, mark the lease as expiring
+// `now` and let the expiration manager queue it for revocation.
 func (m *ExpirationManager) revokePrefixCommon(ctx context.Context, prefix string, force, sync bool) error {
 	if m.inRestoreMode() {
 		m.restoreRequestLock.Lock()


### PR DESCRIPTION
this doc exists for the sync flag, but now it's in code too