### PR TITLE
KMSE distribute key bug

### DIFF
--- a/ui/app/components/keymgmt/distribute.js
+++ b/ui/app/components/keymgmt/distribute.js
@@ -194,6 +194,10 @@ export default class KeymgmtDistribute extends Component {
       .distribute(backend, provider, key, { purpose, protection })
       .then(() => {
         this.flashMessages.success(`Successfully distributed key ${key} to ${provider}`);
+        // update keys on provider model
+        this.store.clearDataset('keymgmt/key');
+        const providerModel = this.store.peekRecord('keymgmt/provider', provider);
+        providerModel.fetchKeys(providerModel.keys?.meta?.currentPage || 1);
         // move wizard forward if tutorial is in progress
         this.updateWizard('featureState');
         this.args.onClose();

--- a/ui/app/models/keymgmt/provider.js
+++ b/ui/app/models/keymgmt/provider.js
@@ -118,7 +118,7 @@ export default class KeymgmtProviderModel extends Model {
       // try unless capabilities returns false
       try {
         this.keys = await this.store.lazyPaginatedQuery('keymgmt/key', {
-          backend: 'keymgmt',
+          backend: this.backend,
           provider: this.name,
           responsePath: 'data.keys',
           page,

--- a/ui/app/templates/components/keymgmt/distribute.hbs
+++ b/ui/app/templates/components/keymgmt/distribute.hbs
@@ -100,7 +100,14 @@
       <p class="sub-text">The types of operations this key can perform in the provider.</p>
       {{#each this.operations as |op|}}
         <div class="b-checkbox">
-          <Input @type="checkbox" id={{op}} class="styled" @checked={{false}} {{on "input" this.handleOperation}} />
+          <Input
+            @type="checkbox"
+            id={{op}}
+            class="styled"
+            @checked={{false}}
+            {{on "input" this.handleOperation}}
+            data-test-operation={{op}}
+          />
           <label for={{op}}>{{capitalize op}}</label>
         </div>
       {{/each}}
@@ -114,6 +121,7 @@
           id="protection-hsm"
           name="hsm"
           class="radio"
+          data-test-protection="hsm"
           @value="hsm"
           @groupValue={{this.formData.protection}}
           @onChange={{fn (mut this.formData.protection)}}
@@ -125,6 +133,7 @@
           id="protection-software"
           name="software"
           class="radio"
+          data-test-protection="software"
           @value="software"
           @groupValue={{this.formData.protection}}
           @onChange={{fn (mut this.formData.protection)}}

--- a/ui/app/templates/components/keymgmt/provider-edit.hbs
+++ b/ui/app/templates/components/keymgmt/provider-edit.hbs
@@ -68,7 +68,12 @@
             <div class="toolbar-separator"></div>
           {{/if}}
           {{#if (or @model.canListKeys @model.canCreateKeys)}}
-            <button type="button" class="toolbar-link" {{on "click" (fn (mut this.isDistributing) true)}}>
+            <button
+              type="button"
+              class="toolbar-link"
+              {{on "click" (fn (mut this.isDistributing) true)}}
+              data-test-distribute-key
+            >
               Distribute key
               <Icon @name="chevron-right" />
             </button>

--- a/ui/tests/acceptance/enterprise-kmse-test.js
+++ b/ui/tests/acceptance/enterprise-kmse-test.js
@@ -6,7 +6,7 @@ import logout from 'vault/tests/pages/logout';
 import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-module('Acceptance | Enterprise | kmse', function (hooks) {
+module('Acceptance | Enterprise | keymgmt', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 

--- a/ui/tests/acceptance/enterprise-kmse-test.js
+++ b/ui/tests/acceptance/enterprise-kmse-test.js
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { click, fillIn } from '@ember/test-helpers';
+import authPage from 'vault/tests/pages/auth';
+import logout from 'vault/tests/pages/logout';
+import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Acceptance | kmse', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    await logout.visit();
+    return authPage.login();
+  });
+
+  test('it should add new key and distribute to provider', async function (assert) {
+    const path = `keymgmt-${Date.now()}`;
+    this.server.post(`/${path}/key/test-key`, () => ({}));
+    this.server.put(`/${path}/kms/test-keyvault/key/test-key`, () => ({}));
+
+    await mountSecrets.enable('keymgmt', path);
+    await click('[data-test-secret-create]');
+    await fillIn('[data-test-input="provider"]', 'azurekeyvault');
+    await fillIn('[data-test-input="name"]', 'test-keyvault');
+    await fillIn('[data-test-input="keyCollection"]', 'test-keycollection');
+    await fillIn('[data-test-input="credentials.client_id"]', '123');
+    await fillIn('[data-test-input="credentials.client_secret"]', '456');
+    await fillIn('[data-test-input="credentials.tenant_id"]', '789');
+    await click('[data-test-kms-provider-submit]');
+    await click('[data-test-distribute-key]');
+    await click('[data-test-component="search-select"] .ember-basic-dropdown-trigger');
+    await fillIn('.ember-power-select-search-input', 'test-key');
+    await click('.ember-power-select-option');
+    await fillIn('[data-test-keymgmt-dist-keytype]', 'rsa-2048');
+    await click('[data-test-operation="encrypt"]');
+    await fillIn('[data-test-protection="hsm"]', 'hsm');
+
+    this.server.get(`/${path}/kms/test-keyvault/key`, () => ({ data: { keys: ['test-key'] } }));
+    await click('[data-test-secret-save]');
+    await click('[data-test-kms-provider-tab="keys"] a');
+    assert.dom('[data-test-secret-link="test-key"]').exists('Key is listed under keys tab of provider');
+  });
+});

--- a/ui/tests/acceptance/enterprise-kmse-test.js
+++ b/ui/tests/acceptance/enterprise-kmse-test.js
@@ -6,7 +6,7 @@ import logout from 'vault/tests/pages/logout';
 import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-module('Acceptance | kmse', function (hooks) {
+module('Acceptance | Enterprise | kmse', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 

--- a/ui/tests/integration/components/keymgmt/provider-edit-test.js
+++ b/ui/tests/integration/components/keymgmt/provider-edit-test.js
@@ -27,6 +27,7 @@ module('Integration | Component | keymgmt/provider-edit', function (hooks) {
           name: 'foo-bar',
           provider: 'azurekeyvault',
           keyCollection: 'keyvault-1',
+          backend: 'keymgmt',
         },
       },
     });
@@ -42,7 +43,7 @@ module('Integration | Component | keymgmt/provider-edit', function (hooks) {
   });
 
   test('it should render show view', async function (assert) {
-    assert.expect(12);
+    assert.expect(16);
 
     // override capability getters
     Object.defineProperties(this.model, {
@@ -50,6 +51,7 @@ module('Integration | Component | keymgmt/provider-edit', function (hooks) {
       canListKeys: { value: true },
     });
 
+    this.server.post('/sys/capabilities-self', () => ({}));
     this.server.get('/keymgmt/kms/foo-bar/key', () => {
       return {
         data: {


### PR DESCRIPTION
When distributing a key to a provider via the _Distribute key_ action in the provider toolbar the key was not appearing in the _Keys_ tab of the provider view until after a refresh. This fixes that and adds a test for the workflow. 