### PR TITLE
KMSE key delete fails silently

### DIFF
--- a/ui/app/controllers/vault/cluster/secrets/backend/list.js
+++ b/ui/app/controllers/vault/cluster/secrets/backend/list.js
@@ -40,13 +40,19 @@ export default Controller.extend(ListController, BackendCrumbMixin, WithNavToNea
 
     delete(item, type) {
       const name = item.id;
-      item.destroyRecord().then(() => {
-        this.flashMessages.success(`${name} was successfully deleted.`);
-        this.send('reload');
-        if (type === 'secret') {
-          this.navToNearestAncestor.perform(name);
-        }
-      });
+      item
+        .destroyRecord()
+        .then(() => {
+          this.flashMessages.success(`${name} was successfully deleted.`);
+          this.send('reload');
+          if (type === 'secret') {
+            this.navToNearestAncestor.perform(name);
+          }
+        })
+        .catch((e) => {
+          const error = e.errors ? e.errors.join('. ') : e.message;
+          this.flashMessages.danger(error);
+        });
     },
   },
 });


### PR DESCRIPTION
This was noticed when attempting to delete a KMSE key that was distributed to a provider. The delete action for secret backend list items was not doing anything with the error thrown from the Ember Data adapter. This PR is to update that action to display the error in a flash message.