### PR TITLE
Refactor PKI tests for speed

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -49,6 +49,57 @@ import (
 
 var stepCount = 0
 
+// From builtin/credential/cert/test-fixtures/root/rootcacert.pem
+const (
+	rootCACertPEM = `-----BEGIN CERTIFICATE-----
+MIIDPDCCAiSgAwIBAgIUb5id+GcaMeMnYBv3MvdTGWigyJ0wDQYJKoZIhvcNAQEL
+BQAwFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wHhcNMTYwMjI5MDIyNzI5WhcNMjYw
+MjI2MDIyNzU5WjAWMRQwEgYDVQQDEwtleGFtcGxlLmNvbTCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAOxTMvhTuIRc2YhxZpmPwegP86cgnqfT1mXxi1A7
+Q7qax24Nqbf00I3oDMQtAJlj2RB3hvRSCb0/lkF7i1Bub+TGxuM7NtZqp2F8FgG0
+z2md+W6adwW26rlxbQKjmRvMn66G9YPTkoJmPmxt2Tccb9+apmwW7lslL5j8H48x
+AHJTMb+PMP9kbOHV5Abr3PT4jXUPUr/mWBvBiKiHG0Xd/HEmlyOEPeAThxK+I5tb
+6m+eB+7cL9BsvQpy135+2bRAxUphvFi5NhryJ2vlAvoJ8UqigsNK3E28ut60FAoH
+SWRfFUFFYtfPgTDS1yOKU/z/XMU2giQv2HrleWt0mp4jqBUCAwEAAaOBgTB/MA4G
+A1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSdxLNP/ocx
+7HK6JT3/sSAe76iTmzAfBgNVHSMEGDAWgBSdxLNP/ocx7HK6JT3/sSAe76iTmzAc
+BgNVHREEFTATggtleGFtcGxlLmNvbYcEfwAAATANBgkqhkiG9w0BAQsFAAOCAQEA
+wHThDRsXJunKbAapxmQ6bDxSvTvkLA6m97TXlsFgL+Q3Jrg9HoJCNowJ0pUTwhP2
+U946dCnSCkZck0fqkwVi4vJ5EQnkvyEbfN4W5qVsQKOFaFVzep6Qid4rZT6owWPa
+cNNzNcXAee3/j6hgr6OQ/i3J6fYR4YouYxYkjojYyg+CMdn6q8BoV0BTsHdnw1/N
+ScbnBHQIvIZMBDAmQueQZolgJcdOuBLYHe/kRy167z8nGg+PUFKIYOL8NaOU1+CJ
+t2YaEibVq5MRqCbRgnd9a2vG0jr5a3Mn4CUUYv+5qIjP3hUusYenW1/EWtn1s/gk
+zehNe5dFTjFpylg1o6b8Ow==
+-----END CERTIFICATE-----`
+	rootCAKeyPEM = `-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEA7FMy+FO4hFzZiHFmmY/B6A/zpyCep9PWZfGLUDtDuprHbg2p
+t/TQjegMxC0AmWPZEHeG9FIJvT+WQXuLUG5v5MbG4zs21mqnYXwWAbTPaZ35bpp3
+BbbquXFtAqOZG8yfrob1g9OSgmY+bG3ZNxxv35qmbBbuWyUvmPwfjzEAclMxv48w
+/2Rs4dXkBuvc9PiNdQ9Sv+ZYG8GIqIcbRd38cSaXI4Q94BOHEr4jm1vqb54H7twv
+0Gy9CnLXfn7ZtEDFSmG8WLk2GvIna+UC+gnxSqKCw0rcTby63rQUCgdJZF8VQUVi
+18+BMNLXI4pT/P9cxTaCJC/YeuV5a3SaniOoFQIDAQABAoIBAQCoGZJC84JnnIgb
+ttZNWuWKBXbCJcDVDikOQJ9hBZbqsFg1X0CfGmQS3MHf9Ubc1Ro8zVjQh15oIEfn
+8lIpdzTeXcpxLdiW8ix3ekVJF20F6pnXY8ZP6UnTeOwamXY6QPZAtb0D9UXcvY+f
+nw+IVRD6082XS0Rmzu+peYWVXDy+FDN+HJRANBcdJZz8gOmNBIe0qDWx1b85d/s8
+2Kk1Wwdss1IwAGeSddTSwzBNaaHdItZaMZOqPW1gRyBfVSkcUQIE6zn2RKw2b70t
+grkIvyRcTdfmiKbqkkJ+eR+ITOUt0cBZSH4cDjlQA+r7hulvoBpQBRj068Toxkcc
+bTagHaPBAoGBAPWPGVkHqhTbJ/DjmqDIStxby2M1fhhHt4xUGHinhUYjQjGOtDQ9
+0mfaB7HObudRiSLydRAVGAHGyNJdQcTeFxeQbovwGiYKfZSA1IGpea7dTxPpGEdN
+ksA0pzSp9MfKzX/MdLuAkEtO58aAg5YzsgX9hDNxo4MhH/gremZhEGZlAoGBAPZf
+lqdYvAL0fjHGJ1FUEalhzGCGE9PH2iOqsxqLCXK7bDbzYSjvuiHkhYJHAOgVdiW1
+lB34UHHYAqZ1VVoFqJ05gax6DE2+r7K5VV3FUCaC0Zm3pavxchU9R/TKP82xRrBj
+AFWwdgDTxUyvQEmgPR9sqorftO71Iz2tiwyTpIfxAoGBAIhEMLzHFAse0rtKkrRG
+ccR27BbRyHeQ1Lp6sFnEHKEfT8xQdI/I/snCpCJ3e/PBu2g5Q9z416mktiyGs8ib
+thTNgYsGYnxZtfaCx2pssanoBcn2wBJRae5fSapf5gY49HDG9MBYR7qCvvvYtSzU
+4yWP2ZzyotpRt3vwJKxLkN5BAoGAORHpZvhiDNkvxj3da7Rqpu7VleJZA2y+9hYb
+iOF+HcqWhaAY+I+XcTRrTMM/zYLzLEcEeXDEyao86uwxCjpXVZw1kotvAC9UqbTO
+tnr3VwRkoxPsV4kFYTAh0+1pnC8dbcxxDmhi3Uww3tOVs7hfkEDuvF6XnebA9A+Y
+LyCgMzECgYEA6cCU8QODOivIKWFRXucvWckgE6MYDBaAwe6qcLsd1Q/gpE2e3yQc
+4RB3bcyiPROLzMLlXFxf1vSNJQdIaVfrRv+zJeGIiivLPU8+Eq4Lrb+tl1LepcOX
+OzQeADTSCn5VidOfjDkIst9UXjMlrFfV9/oJEw5Eiqa6lkNPCGDhfA8=
+-----END RSA PRIVATE KEY-----`
+)
+
 func TestPKI_RequireCN(t *testing.T) {
 	b, s := createBackendWithStorage(t)
 
@@ -2258,22 +2309,10 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 }
 
 func TestBackend_Root_Idempotency(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		LogicalBackends: map[string]logical.Factory{
-			"pki": Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-	client := cluster.Cores[0].Client
-
-	mountPKIEndpoint(t, client, "pki")
+	b, s := createBackendWithStorage(t)
 
 	// This is a change within 1.11, we are no longer idempotent across generate/internal calls.
-	resp, err := client.Logical().Write("pki/root/generate/internal", map[string]interface{}{
+	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"common_name": "myvault.com",
 	})
 	require.NoError(t, err)
@@ -2281,13 +2320,13 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 	keyId1 := resp.Data["key_id"]
 	issuerId1 := resp.Data["issuer_id"]
 
-	resp, err = client.Logical().Read("pki/cert/ca_chain")
+	resp, err = CBRead(b, s, "cert/ca_chain")
 	require.NoError(t, err, "error reading ca_chain: %v", err)
 
 	r1Data := resp.Data
 
 	// Calling generate/internal should generate a new CA as well.
-	resp, err = client.Logical().Write("pki/root/generate/internal", map[string]interface{}{
+	resp, err = CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"common_name": "myvault.com",
 	})
 	require.NoError(t, err)
@@ -2300,7 +2339,7 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 	require.NotEqual(t, issuerId1, issuerId2)
 
 	// Now because the issued CA's have no links, the call to ca_chain should return the same data (ca chain from default)
-	resp, err = client.Logical().Read("pki/cert/ca_chain")
+	resp, err = CBRead(b, s, "cert/ca_chain")
 	require.NoError(t, err, "error reading ca_chain: %v", err)
 
 	r2Data := resp.Data
@@ -2309,14 +2348,14 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 	}
 
 	// Now let's validate that the import bundle is idempotent.
-	pemBundleRootCA := string(cluster.CACertPEM) + string(cluster.CAKeyPEM)
-	resp, err = client.Logical().Write("pki/config/ca", map[string]interface{}{
+	pemBundleRootCA := rootCACertPEM + "\n" + rootCAKeyPEM
+	resp, err = CBWrite(b, s, "config/ca", map[string]interface{}{
 		"pem_bundle": pemBundleRootCA,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp, "expected ca info")
-	firstImportedKeys := resp.Data["imported_keys"].([]interface{})
-	firstImportedIssuers := resp.Data["imported_issuers"].([]interface{})
+	firstImportedKeys := resp.Data["imported_keys"].([]string)
+	firstImportedIssuers := resp.Data["imported_issuers"].([]string)
 
 	require.NotContains(t, firstImportedKeys, keyId1)
 	require.NotContains(t, firstImportedKeys, keyId2)
@@ -2324,7 +2363,7 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 	require.NotContains(t, firstImportedIssuers, issuerId2)
 
 	// Performing this again should result in no key/issuer ids being imported/generated.
-	resp, err = client.Logical().Write("pki/config/ca", map[string]interface{}{
+	resp, err = CBWrite(b, s, "config/ca", map[string]interface{}{
 		"pem_bundle": pemBundleRootCA,
 	})
 	require.NoError(t, err)
@@ -2335,22 +2374,22 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 	require.Nil(t, secondImportedKeys)
 	require.Nil(t, secondImportedIssuers)
 
-	resp, err = client.Logical().Delete("pki/root")
+	resp, err = CBDelete(b, s, "root")
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, 1, len(resp.Warnings))
 
 	// Make sure we can delete twice...
-	resp, err = client.Logical().Delete("pki/root")
+	resp, err = CBDelete(b, s, "root")
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, 1, len(resp.Warnings))
 
-	_, err = client.Logical().Read("pki/cert/ca_chain")
+	_, err = CBRead(b, s, "cert/ca_chain")
 	require.Error(t, err, "expected an error fetching deleted ca_chain")
 
 	// We should be able to import the same ca bundle as before and get a different key/issuer ids
-	resp, err = client.Logical().Write("pki/config/ca", map[string]interface{}{
+	resp, err = CBWrite(b, s, "config/ca", map[string]interface{}{
 		"pem_bundle": pemBundleRootCA,
 	})
 	require.NoError(t, err)
@@ -2364,7 +2403,7 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 	require.NotEqual(t, postDeleteImportedKeys, firstImportedKeys)
 	require.NotEqual(t, postDeleteImportedIssuers, firstImportedIssuers)
 
-	resp, err = client.Logical().Read("pki/cert/ca_chain")
+	resp, err = CBRead(b, s, "cert/ca_chain")
 	require.NoError(t, err)
 
 	caChainPostDelete := resp.Data

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -193,31 +193,9 @@ func TestPKI_DeviceCert(t *testing.T) {
 }
 
 func TestBackend_InvalidParameter(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		LogicalBackends: map[string]logical.Factory{
-			"pki": Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
+	b, s := createBackendWithStorage(t)
 
-	client := cluster.Cores[0].Client
-	var err error
-	err = client.Sys().Mount("pki", &api.MountInput{
-		Type: "pki",
-		Config: api.MountConfigInput{
-			DefaultLeaseTTL: "16h",
-			MaxLeaseTTL:     "32h",
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = client.Logical().Write("pki/root/generate/internal", map[string]interface{}{
+	_, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"common_name": "myvault.com",
 		"not_after":   "9999-12-31T23:59:59Z",
 		"ttl":         "25h",
@@ -226,7 +204,7 @@ func TestBackend_InvalidParameter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = client.Logical().Write("pki/root/generate/internal", map[string]interface{}{
+	_, err = CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"common_name": "myvault.com",
 		"not_after":   "9999-12-31T23:59:59",
 	})

--- a/builtin/logical/pki/chain_test.go
+++ b/builtin/logical/pki/chain_test.go
@@ -14,37 +14,6 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func CBReq(b *backend, s logical.Storage, operation logical.Operation, path string, data map[string]interface{}) (*logical.Response, error) {
-	resp, err := b.HandleRequest(context.Background(), &logical.Request{
-		Operation:  operation,
-		Path:       path,
-		Data:       data,
-		Storage:    s,
-		MountPoint: "pki/",
-	})
-	if err != nil || resp == nil {
-		return resp, err
-	}
-
-	if msg, ok := resp.Data["error"]; ok && msg != nil && len(msg.(string)) > 0 {
-		return resp, fmt.Errorf("%s", msg)
-	}
-
-	return resp, nil
-}
-
-func CBRead(b *backend, s logical.Storage, path string) (*logical.Response, error) {
-	return CBReq(b, s, logical.ReadOperation, path, make(map[string]interface{}))
-}
-
-func CBWrite(b *backend, s logical.Storage, path string, data map[string]interface{}) (*logical.Response, error) {
-	return CBReq(b, s, logical.UpdateOperation, path, data)
-}
-
-func CBDelete(b *backend, s logical.Storage, path string) (*logical.Response, error) {
-	return CBReq(b, s, logical.DeleteOperation, path, make(map[string]interface{}))
-}
-
 // For speed, all keys are ECDSA.
 type CBGenerateKey struct {
 	Name string

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -5,36 +5,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault/api"
-	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/hashicorp/vault/vault"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBackend_CRL_EnableDisable(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		LogicalBackends: map[string]logical.Factory{
-			"pki": Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
+	b, s := createBackendWithStorage(t)
 
-	client := cluster.Cores[0].Client
-	var err error
-	err = client.Sys().Mount("pki", &api.MountInput{
-		Type: "pki",
-		Config: api.MountConfigInput{
-			DefaultLeaseTTL: "16h",
-			MaxLeaseTTL:     "60h",
-		},
-	})
-
-	resp, err := client.Logical().Write("pki/root/generate/internal", map[string]interface{}{
+	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"ttl":         "40h",
 		"common_name": "myvault.com",
 	})
@@ -43,7 +21,7 @@ func TestBackend_CRL_EnableDisable(t *testing.T) {
 	}
 	caSerial := resp.Data["serial_number"]
 
-	_, err = client.Logical().Write("pki/roles/test", map[string]interface{}{
+	_, err = CBWrite(b, s, "roles/test", map[string]interface{}{
 		"allow_bare_domains": true,
 		"allow_subdomains":   true,
 		"allowed_domains":    "foobar.com",
@@ -55,7 +33,7 @@ func TestBackend_CRL_EnableDisable(t *testing.T) {
 
 	serials := make(map[int]string)
 	for i := 0; i < 6; i++ {
-		resp, err := client.Logical().Write("pki/issue/test", map[string]interface{}{
+		resp, err := CBWrite(b, s, "issue/test", map[string]interface{}{
 			"common_name": "test.foobar.com",
 		})
 		if err != nil {
@@ -65,7 +43,7 @@ func TestBackend_CRL_EnableDisable(t *testing.T) {
 	}
 
 	test := func(numRevokedExpected int, expectedSerials ...string) {
-		certList := getCrlCertificateList(t, client, "pki")
+		certList := getParsedCrlFromBackend(t, b, s, "crl").TBSCertList
 		lenList := len(certList.RevokedCertificates)
 		if lenList != numRevokedExpected {
 			t.Fatalf("expected %d revoked certificates, found %d", numRevokedExpected, lenList)
@@ -77,14 +55,14 @@ func TestBackend_CRL_EnableDisable(t *testing.T) {
 	}
 
 	revoke := func(serialIndex int) {
-		resp, err = client.Logical().Write("pki/revoke", map[string]interface{}{
+		resp, err = CBWrite(b, s, "revoke", map[string]interface{}{
 			"serial_number": serials[serialIndex],
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		resp, err = client.Logical().Write("pki/revoke", map[string]interface{}{
+		resp, err = CBWrite(b, s, "revoke", map[string]interface{}{
 			"serial_number": caSerial,
 		})
 		if err == nil {
@@ -93,7 +71,7 @@ func TestBackend_CRL_EnableDisable(t *testing.T) {
 	}
 
 	toggle := func(disabled bool) {
-		_, err = client.Logical().Write("pki/config/crl", map[string]interface{}{
+		_, err = CBWrite(b, s, "config/crl", map[string]interface{}{
 			"disable": disabled,
 		})
 		if err != nil {
@@ -121,12 +99,12 @@ func TestBackend_CRL_EnableDisable(t *testing.T) {
 	test(6)
 
 	// The rotate command should reset the update time of the CRL.
-	crlCreationTime1 := getCrlCertificateList(t, client, "pki").ThisUpdate
+	crlCreationTime1 := getParsedCrlFromBackend(t, b, s, "crl").TBSCertList.ThisUpdate
 	time.Sleep(1 * time.Second)
-	_, err = client.Logical().Read("pki/crl/rotate")
+	_, err = CBRead(b, s, "crl/rotate")
 	require.NoError(t, err)
 
-	crlCreationTime2 := getCrlCertificateList(t, client, "pki").ThisUpdate
+	crlCreationTime2 := getParsedCrlFromBackend(t, b, s, "crl").TBSCertList.ThisUpdate
 	require.NotEqual(t, crlCreationTime1, crlCreationTime2)
 }
 

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -284,6 +284,10 @@ func CBWrite(b *backend, s logical.Storage, path string, data map[string]interfa
 	return CBReq(b, s, logical.UpdateOperation, path, data)
 }
 
+func CBList(b *backend, s logical.Storage, path string) (*logical.Response, error) {
+	return CBReq(b, s, logical.ListOperation, path, make(map[string]interface{}))
+}
+
 func CBDelete(b *backend, s logical.Storage, path string) (*logical.Response, error) {
 	return CBReq(b, s, logical.DeleteOperation, path, make(map[string]interface{}))
 }

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -240,6 +240,19 @@ func getParsedCrlAtPath(t *testing.T, client *api.Client, path string) *pkix.Cer
 	return crl
 }
 
+func getParsedCrlFromBackend(t *testing.T, b *backend, s logical.Storage, path string) *pkix.CertificateList {
+	resp, err := CBRead(b, s, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	crl, err := x509.ParseDERCRL(resp.Data[logical.HTTPRawBody].([]byte))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return crl
+}
+
 // Direct storage backend helpers (b, s := createBackendWithStorage(t)) which
 // are mostly compatible with client.Logical() operations. The main difference
 // is that the JSON round-tripping hasn't occurred, so values are as the


### PR DESCRIPTION
I've personally introduced a number of slow tests to the PKI backend. :-) Here's an attempt at trying to fix that a bit.

See individual commits for individual test speed up counts on my machine. There's definitely more to do but this is a start. :-)

Before: github.com/hashicorp/vault/builtin/logical/pki	355.430s
After: github.com/hashicorp/vault/builtin/logical/pki	151.182s

Edit: add some more refactors. This gets us down by over half! 