### PR TITLE
Use new -mount syntax for all KV subcommands in 1.11 docs

### DIFF
--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -206,7 +206,7 @@ Note that if an argument is supplied in a @key=value format, Vault will treat th
 kv pair with the key being `@key`, not a file called `key=value`. This also means that Vault
 does not support filenames with `=` in them.
 
-### Mount flag syntax (KV)
+## Mount flag syntax (KV)
 
 All `kv` commands can alternatively refer to the path to the KV secrets engine using a flag-based syntax like `$ vault kv get -mount=secret password` 
 instead of `$ vault kv get secret/password`. The mount flag syntax was created to mitigate confusion caused by the fact that for KV v2 secrets, 

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -210,7 +210,7 @@ does not support filenames with `=` in them.
 
 All `kv` commands can alternatively refer to the path to the KV secrets engine using a flag-based syntax like `$ vault kv get -mount=secret password` 
 instead of `$ vault kv get secret/password`. The mount flag syntax was created to mitigate confusion caused by the fact that for KV v2 secrets, 
-their full path (used in policies and raw API calls) actually contains a nested `/data/` element (e.g. `secret/data/password`) which can be easily forgotten when using 
+their full path (used in policies and raw API calls) actually contains a nested `/data/` element (e.g. `secret/data/password`) which can be easily overlooked when using 
 the above KV v1-like syntax `secret/password`. To avoid this confusion, all KV-specific docs pages will use the `-mount` flag.
 
 ## Exit Codes

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -206,6 +206,13 @@ Note that if an argument is supplied in a @key=value format, Vault will treat th
 kv pair with the key being `@key`, not a file called `key=value`. This also means that Vault
 does not support filenames with `=` in them.
 
+### Mount flag syntax (KV)
+
+All `kv` commands can alternatively refer to the path to the KV secrets engine using a flag-based syntax like `$ vault kv get -mount=secret password` 
+instead of `$ vault kv get secret/password`. The mount flag syntax was created to mitigate confusion caused by the fact that for KV v2 secrets, 
+their full path (used in policies and raw API calls) actually contains a nested `/data/` element (e.g. `secret/data/password`) which can be easily forgotten when using 
+the above KV v1-like syntax `secret/password`. To avoid this confusion, all KV-specific docs pages will use the `-mount` flag.
+
 ## Exit Codes
 
 The Vault CLI aims to be consistent and well-behaved unless documented

--- a/website/content/docs/commands/kv/delete.mdx
+++ b/website/content/docs/commands/kv/delete.mdx
@@ -40,7 +40,7 @@ included on all commands.
 - `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
   If specified, the next argument will be interpreted as the secret path. If 
   this flag is not specified, the next argument will be interpreted as the 
-  combined mount path and secret path, with /data/ automatically appended between
+  combined mount path and secret path, with /data/ automatically inserted for 
   KV v2 secrets.
 
 - `-versions` `([]int: <required>)` - The versions to be deleted. The versioned

--- a/website/content/docs/commands/kv/delete.mdx
+++ b/website/content/docs/commands/kv/delete.mdx
@@ -19,15 +19,15 @@ normal get requests.
 Delete the latest version of the key "creds":
 
 ```shell-session
-$ vault kv delete secret/creds
+$ vault kv delete -mount=secret creds
 Success! Data deleted (if it existed) at: secret/creds
 ```
 
 **[K/V Version 2]** Delete version 11 of key "creds":
 
 ```shell-session
-$ vault kv delete -versions=11 secret/creds
-Success! Data deleted (if it existed) at: secret/creds
+$ vault kv delete -mount=secret -versions=11 creds
+Success! Data deleted (if it existed) at: secret/data/creds
 ```
 
 ## Usage
@@ -37,8 +37,14 @@ included on all commands.
 
 ### Command Options
 
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /data/ automatically appended between
+  KV v2 secrets.
+
 - `-versions` `([]int: <required>)` - The versions to be deleted. The versioned
   data will not be deleted, but it will no longer be returned in normal get
   requests.
 
-~> **NOTE:** This command option is only for K/V v2.
+~> **NOTE:** The `-versions` command option is only for K/V v2.

--- a/website/content/docs/commands/kv/destroy.mdx
+++ b/website/content/docs/commands/kv/destroy.mdx
@@ -40,7 +40,7 @@ included on all commands.
 - `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
   If specified, the next argument will be interpreted as the secret path. If 
   this flag is not specified, the next argument will be interpreted as the 
-  combined mount path and secret path, with /data/ automatically appended between
+  combined mount path and secret path, with /data/ automatically inserted for 
   KV v2 secrets.
 
 - `-versions` `([]int: <required>)` - The versions to destroy. Their data will

--- a/website/content/docs/commands/kv/destroy.mdx
+++ b/website/content/docs/commands/kv/destroy.mdx
@@ -20,7 +20,7 @@ taken.
 Destroy version 11 of the key "creds":
 
 ```shell-session
-$ vault kv destroy -versions=11 secret/creds
+$ vault kv destroy -mount=secret -versions=11 creds
 Success! Data written to: secret/destroy/creds
 ```
 
@@ -36,6 +36,12 @@ included on all commands.
   `VAULT_FORMAT` environment variable.
 
 ### Command Options
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /data/ automatically appended between
+  KV v2 secrets.
 
 - `-versions` `([]int: <required>)` - The versions to destroy. Their data will
   be permanently deleted.

--- a/website/content/docs/commands/kv/get.mdx
+++ b/website/content/docs/commands/kv/get.mdx
@@ -73,7 +73,7 @@ my-long-passcode
 - `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
   If specified, the next argument will be interpreted as the secret path. If 
   this flag is not specified, the next argument will be interpreted as the 
-  combined mount path and secret path, with /data/ automatically appended between
+  combined mount path and secret path, with /data/ automatically inserted for 
   KV v2 secrets.
 
 - `-version` `(int: 0)` - Specifies the version to return. If not set the

--- a/website/content/docs/commands/kv/get.mdx
+++ b/website/content/docs/commands/kv/get.mdx
@@ -18,14 +18,18 @@ with the name but has no data, nothing is returned.
 Retrieve the data of the key "creds":
 
 ```shell-session
-$ vault kv get secret/creds
-====== Metadata ======
-Key              Value
----              -----
-created_time     2019-06-06T06:03:26.595978Z
-deletion_time    n/a
-destroyed        false
-version          5
+$ vault kv get -mount=secret creds
+== Secret Path ==
+secret/data/creds
+
+======= Metadata =======
+Key                Value
+---                -----
+created_time       2022-06-15T20:23:40.067093Z
+custom_metadata    <nil>
+deletion_time      n/a
+destroyed          false
+version            1
 
 ====== Data ======
 Key         Value
@@ -37,7 +41,7 @@ If K/V Version 1 secrets engine is enabled at "secret", the output has no
 metadata since there is no versioning information associated with the data:
 
 ```shell-session
-$ vault kv get secret/creds
+$ vault kv get -mount=secret creds
 ====== Data ======
 Key         Value
 ---         -----
@@ -47,14 +51,11 @@ passcode    my-long-passcode
 Return only the "creds" "passcode" key:
 
 ```shell-session
-$ vault kv get -field=passcode secret/creds
+$ vault kv get -mount=secret -field=passcode creds
 my-long-passcode
 ```
 
 ## Usage
-
-There are no flags beyond the [standard set of flags](/docs/commands)
-included on all commands.
 
 ### Output Options
 
@@ -68,6 +69,12 @@ included on all commands.
   `VAULT_FORMAT` environment variable.
 
 ### Command Options
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /data/ automatically appended between
+  KV v2 secrets.
 
 - `-version` `(int: 0)` - Specifies the version to return. If not set the
   latest version is returned.

--- a/website/content/docs/commands/kv/index.mdx
+++ b/website/content/docs/commands/kv/index.mdx
@@ -12,32 +12,51 @@ The `kv` command groups subcommands for interacting with Vault's key/value
 secrets engine (both [K/V Version 1](/docs/secrets/kv/kv-v1) and [K/V
 Version 2](/docs/secrets/kv/kv-v2).
 
+## Syntax
+
+Option flags for a given subcommand are provided after the subcommand but before the arguments.
+
+The path to where the secrets engine is mounted can be indicated with the `-mount` flag, such as `vault kv get -mount=secret creds`.
+
+~> A `flag provided but not defined: -mount` error means you are using an older version of Vault from before the 
+mount flag syntax was introduced. Upgrade to at least Vault 1.11, or refer to previous versions of the docs 
+which use the old syntax to refer to the mount path (`secret/hello` instead of `-mount=secret hello`).
+
 ## Examples
 
 Create or update the key named "creds" in the K/V Version 2 enabled at "secret"
 with the value "passcode=my-long-passcode":
 
 ```shell-session
-$ vault kv put secret/creds passcode=my-long-passcode
-Key              Value
----              -----
-created_time     2019-06-28T15:53:30.395814Z
-deletion_time    n/a
-destroyed        false
-version          1
+$ vault kv put -mount=secret creds passcode=my-long-passcode
+== Secret Path ==
+secret/data/creds
+
+======= Metadata =======
+Key                Value
+---                -----
+created_time       2022-06-15T20:14:17.107852Z
+custom_metadata    <nil>
+deletion_time      n/a
+destroyed          false
+version            1
 ```
 
 Read this value back:
 
 ```shell-session
-$ vault kv get secret/creds
-====== Metadata ======
-Key              Value
----              -----
-created_time     2019-06-28T15:53:30.395814Z
-deletion_time    n/a
-destroyed        false
-version          1
+$ vault kv get -mount=secret creds
+== Secret Path ==
+secret/data/creds
+
+======= Metadata =======
+Key                Value
+---                -----
+created_time       2022-06-15T20:14:17.107852Z
+custom_metadata    <nil>
+deletion_time      n/a
+destroyed          false
+version            1
 
 ====== Data ======
 Key         Value
@@ -48,22 +67,26 @@ passcode    my-long-passcode
 Get metadata for the key named "creds":
 
 ```shell-session
-$ vault kv metadata get secret/creds
+$ vault kv metadata get -mount=secret creds
+=== Metadata Path ===
+secret/metadata/creds
+
 ========== Metadata ==========
 Key                     Value
 ---                     -----
 cas_required            false
-created_time            2019-06-28T15:53:30.395814Z
+created_time            2022-06-15T20:14:17.107852Z
 current_version         1
+custom_metadata         <nil>
 delete_version_after    0s
 max_versions            0
 oldest_version          0
-updated_time            2019-06-28T15:53:30.395814Z
+updated_time            2022-06-15T20:14:17.107852Z
 
 ====== Version 1 ======
 Key              Value
 ---              -----
-created_time     2019-06-28T15:53:30.395814Z
+created_time     2022-06-15T20:14:17.107852Z
 deletion_time    n/a
 destroyed        false
 ```
@@ -71,14 +94,18 @@ destroyed        false
 Get a specific version of the key named "creds":
 
 ```shell-session
-$ vault kv get -version=1 secret/creds
-====== Metadata ======
-Key              Value
----              -----
-created_time     2019-06-28T15:53:30.395814Z
-deletion_time    n/a
-destroyed        false
-version          1
+$ vault kv get -mount=secret -version=1 creds
+== Secret Path ==
+secret/data/creds
+
+======= Metadata =======
+Key                Value
+---                -----
+created_time       2022-06-15T20:14:17.107852Z
+custom_metadata    <nil>
+deletion_time      n/a
+destroyed          false
+version            1
 
 ====== Data ======
 Key         Value

--- a/website/content/docs/commands/kv/index.mdx
+++ b/website/content/docs/commands/kv/index.mdx
@@ -18,9 +18,13 @@ Option flags for a given subcommand are provided after the subcommand but before
 
 The path to where the secrets engine is mounted can be indicated with the `-mount` flag, such as `vault kv get -mount=secret creds`.
 
+The deprecated path-like syntax can also be used (e.g. `vault kv get secret/creds`), but this should be avoided
+for KV v2, as the fact that it is not actually the full API path to the secret 
+(secret/data/foo) can cause confusion.
+
 ~> A `flag provided but not defined: -mount` error means you are using an older version of Vault from before the 
 mount flag syntax was introduced. Upgrade to at least Vault 1.11, or refer to previous versions of the docs 
-which use the old syntax to refer to the mount path (`secret/hello` instead of `-mount=secret hello`).
+which only use the old syntax to refer to the mount path.
 
 ## Examples
 

--- a/website/content/docs/commands/kv/index.mdx
+++ b/website/content/docs/commands/kv/index.mdx
@@ -14,15 +14,15 @@ Version 2](/docs/secrets/kv/kv-v2).
 
 ## Syntax
 
-Option flags for a given subcommand are provided after the subcommand but before the arguments.
+Option flags for a given subcommand are provided after the subcommand, but before the arguments.
 
 The path to where the secrets engine is mounted can be indicated with the `-mount` flag, such as `vault kv get -mount=secret creds`.
 
 The deprecated path-like syntax can also be used (e.g. `vault kv get secret/creds`), but this should be avoided
-for KV v2, as the fact that it is not actually the full API path to the secret 
-(secret/data/foo) can cause confusion.
+for KV v2, because it is not actually the full API path to the secret 
+(secret/data/foo) and may cause confusion.
 
-~> A `flag provided but not defined: -mount` error means you are using an older version of Vault from before the 
+~> A `flag provided but not defined: -mount` error means you are using an older version of Vault before the 
 mount flag syntax was introduced. Upgrade to at least Vault 1.11, or refer to previous versions of the docs 
 which only use the old syntax to refer to the mount path.
 

--- a/website/content/docs/commands/kv/metadata.mdx
+++ b/website/content/docs/commands/kv/metadata.mdx
@@ -159,5 +159,5 @@ be applied to new versions.
 - `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
   If specified, the next argument will be interpreted as the secret path. If 
   this flag is not specified, the next argument will be interpreted as the 
-  combined mount path and secret path, with /data/ automatically appended between
+  combined mount path and secret path, with /data/ automatically inserted for 
   KV v2 secrets.

--- a/website/content/docs/commands/kv/metadata.mdx
+++ b/website/content/docs/commands/kv/metadata.mdx
@@ -38,7 +38,7 @@ provided key.
 Deletes all versions and metadata of the key "creds":
 
 ```shell-session
-$ vault kv metadata delete secret/creds
+$ vault kv metadata delete -mount=secret creds
 Success! Data deleted (if it existed) at: secret/metadata/creds
 ```
 
@@ -52,7 +52,10 @@ the given key name. If no key exists with that name, an error is returned.
 Retrieves the metadata of the key name, "creds":
 
 ```shell-session
-$ vault kv metadata get secret/creds
+$ vault kv metadata get -mount=secret creds
+=== Metadata Path ===
+secret/metadata/creds
+
 ========== Metadata ==========
 Key                     Value
 ---                     -----
@@ -91,14 +94,14 @@ secrets engine or to update key configuration for a specified key.
 Create a key in the K/V v2 with no data at the key "creds":
 
 ```shell-session
-$ vault kv metadata put secret/creds
+$ vault kv metadata put -mount=secret creds
 Success! Data written to: secret/metadata/creds
 ```
 
 Set the maximum number of versions to keep for the key "creds":
 
 ```shell-session
-$ vault kv metadata put -max-versions=5 secret/creds
+$ vault kv metadata put -mount=secret -max-versions=5 creds
 Success! Data written to: secret/metadata/creds
 ```
 
@@ -109,7 +112,7 @@ permanently deleted.
 Require Check-and-Set for the key "creds":
 
 ```shell-session
-$ vault kv metadata put -cas-required secret/creds
+$ vault kv metadata put -mount=secret -cas-required creds
 ```
 
 **NOTE:** When check-and-set is required, the key will require the `cas`
@@ -119,7 +122,7 @@ configuration will be used.
 Set the length of time before a version is deleted for the key "creds":
 
 ```shell-session
-$ vault kv metadata put -delete-version-after="3h25m19s" secret/creds
+$ vault kv metadata put -mount=secret -delete-version-after="3h25m19s" creds
 ```
 
 **NOTE:** If not set, the backend's configured Delete-Version-After is used. If
@@ -152,3 +155,9 @@ be applied to new versions.
 - `custom-metadata` `(string: "")` - Specifies a key-value pair for the
   `custom_metadata` field. This can be specified multiple times to add multiple
   pieces of metadata.
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /data/ automatically appended between
+  KV v2 secrets.

--- a/website/content/docs/commands/kv/patch.mdx
+++ b/website/content/docs/commands/kv/patch.mdx
@@ -87,5 +87,5 @@ $ echo "abcd1234" | vault kv patch -mount=secret foo bar=-
 - `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
   If specified, the next argument will be interpreted as the secret path. If 
   this flag is not specified, the next argument will be interpreted as the 
-  combined mount path and secret path, with /data/ automatically appended between
+  combined mount path and secret path, with /data/ automatically inserted for 
   KV v2 secrets.

--- a/website/content/docs/commands/kv/patch.mdx
+++ b/website/content/docs/commands/kv/patch.mdx
@@ -23,7 +23,11 @@ If you wish to add an additional key-value (`ttl=48h`) to the existing data at
 the key "creds":
 
 ```shell-session
-$ vault kv patch secret/creds ttl=48h
+$ vault kv patch -mount=secret creds ttl=48h
+== Secret Path ==
+secret/data/creds
+
+======= Metadata =======
 Key              Value
 ---              -----
 created_time     2019-06-06T16:46:22.090654Z
@@ -36,20 +40,20 @@ version          6
 the data you wish to add in order to accomplish the same result.
 
 ```shell-session
-$ vault kv put secret/creds ttl=48h passcode=my-long-passcode
+$ vault kv put -mount=secret creds ttl=48h passcode=my-long-passcode
 ```
 
 The data can also be consumed from a file on disk by prefixing with the "@"
 symbol. For example:
 
 ```shell-session
-$ vault kv patch secret/creds @data.json
+$ vault kv patch -mount=secret creds @data.json
 ```
 
 Or it can be read from stdin using the "-" symbol:
 
 ```shell-session
-$ echo "abcd1234" | vault kv patch secret/foo bar=-
+$ echo "abcd1234" | vault kv patch -mount=secret foo bar=-
 ```
 
 ## Usage
@@ -79,3 +83,9 @@ $ echo "abcd1234" | vault kv patch secret/foo bar=-
   version of the secret. This flag will be ignored for the `rw` method.
   Instead, its value will be derived from fetching the current version of the
   secret.
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /data/ automatically appended between
+  KV v2 secrets.

--- a/website/content/docs/commands/kv/put.mdx
+++ b/website/content/docs/commands/kv/put.mdx
@@ -25,20 +25,20 @@ policy granting the "update" capability.
 Writes the data to the key "creds":
 
 ```shell-session
-$ vault kv put secret/creds passcode=my-long-passcode
+$ vault kv put -mount=secret creds passcode=my-long-passcode
 ```
 
 The data can also be consumed from a file on disk by prefixing with the "@"
 symbol. For example:
 
 ```shell-session
-$ vault kv put secret/foo @data.json
+$ vault kv put -mount=secret foo @data.json
 ```
 
 Or it can be read from stdin using the "-" symbol:
 
 ```shell-session
-$ echo "abcd1234" | vault kv put secret/foo bar=-
+$ echo "abcd1234" | vault kv put -mount=secret foo bar=-
 ```
 
 ## Usage
@@ -66,3 +66,9 @@ included on all commands.
   remember that soft deletes do not remove any underlying version data from storage.
   In order to write to a soft deleted key, the cas parameter must match the key's 
   current version. The default is -1.
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /data/ automatically appended between
+  KV v2 secrets.

--- a/website/content/docs/commands/kv/put.mdx
+++ b/website/content/docs/commands/kv/put.mdx
@@ -70,5 +70,5 @@ included on all commands.
 - `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
   If specified, the next argument will be interpreted as the secret path. If 
   this flag is not specified, the next argument will be interpreted as the 
-  combined mount path and secret path, with /data/ automatically appended between
+  combined mount path and secret path, with /data/ automatically inserted for 
   KV v2 secrets.

--- a/website/content/docs/commands/kv/rollback.mdx
+++ b/website/content/docs/commands/kv/rollback.mdx
@@ -22,7 +22,7 @@ overwritten data.
 Restores the version 2 of the data at key "creds":
 
 ```shell-session
-$ vault kv rollback -version=2 secret/creds
+$ vault kv rollback -mount=secret -version=2 creds
 Key              Value
 ---              -----
 created_time     2019-06-06T17:07:19.299831Z
@@ -43,6 +43,12 @@ included on all commands.
   `VAULT_FORMAT` environment variable.
 
 ### Command Options
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /data/ automatically appended between
+  KV v2 secrets.
 
 - `-version` `(int: 0)` - Specifies the version number that should be made
   current again.

--- a/website/content/docs/commands/kv/rollback.mdx
+++ b/website/content/docs/commands/kv/rollback.mdx
@@ -47,7 +47,7 @@ included on all commands.
 - `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
   If specified, the next argument will be interpreted as the secret path. If 
   this flag is not specified, the next argument will be interpreted as the 
-  combined mount path and secret path, with /data/ automatically appended between
+  combined mount path and secret path, with /data/ automatically inserted for 
   KV v2 secrets.
 
 - `-version` `(int: 0)` - Specifies the version number that should be made

--- a/website/content/docs/commands/kv/undelete.mdx
+++ b/website/content/docs/commands/kv/undelete.mdx
@@ -21,7 +21,7 @@ returned on get requests.
 Undelete version 3 of the key "creds":
 
 ```shell-session
-$ vault kv undelete -versions=3 secret/creds
+$ vault kv undelete -mount=secret -versions=3 creds
 Success! Data written to: secret/undelete/creds
 ```
 
@@ -38,5 +38,11 @@ included on all commands.
 
 ### Command Options
 
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /data/ automatically appended between
+  KV v2 secrets.
+  
 - `-versions` `([]int: <required>)` - Specifies the version number that should
   be made current again.

--- a/website/content/docs/commands/kv/undelete.mdx
+++ b/website/content/docs/commands/kv/undelete.mdx
@@ -41,8 +41,8 @@ included on all commands.
 - `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
   If specified, the next argument will be interpreted as the secret path. If 
   this flag is not specified, the next argument will be interpreted as the 
-  combined mount path and secret path, with /data/ automatically appended between
+  combined mount path and secret path, with /data/ automatically inserted for 
   KV v2 secrets.
-  
+
 - `-versions` `([]int: <required>)` - Specifies the version number that should
   be made current again.

--- a/website/content/docs/commands/read.mdx
+++ b/website/content/docs/commands/read.mdx
@@ -49,7 +49,7 @@ Since K/V secrets engine is a commonly used feature, Vault CLI provides the
 path using the `kv` CLI command:
 
 ```shell-session
-$ vault kv get secret/customers
+$ vault kv get -mount=secret customers
 ```
 
 -> **Comparison:** All three commands retrieve the same data, but display the


### PR DESCRIPTION
I have updated all docs pages dealing with the KV CLI to use the new `-mount` flag syntax, which was created to mitigate confusion caused by the previous syntax for interacting with KV secrets in the CLI.

These docs pages will now match the text produced by calling a vault kv subcommand with the `-help` flag.

## Background
This syntax is optional, allowing users to do `vault kv get -mount=secret foo` instead of the old `vault kv get secret/foo`. While the old way may look prettier, it turned out this syntax caused a lot of confusion for new users, who quickly run into issues caused by the fact that `secret/foo` looks like a path but is not actually the real path to the secret for KV v2 (`secret/data/foo`). The real path is used by policies and the API, so users fresh off the Getting Started guide often don't understand why their policies or CLI commands don't work when they try to use the same "path" for both.

## Caveats
I continued to use the old syntax on the index page for CLI commands in general, since that page is aimed at showcasing concepts that are true across all Vault CLI commands. This mount flag syntax only works for the kv subcommands, so I didn't want to muddy the message of that page. So, on that page I call out the existence of this flag in a KV-specific paragraph down below, but otherwise leave those examples alone.