### PR TITLE
Add region reference

### DIFF
--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -122,7 +122,7 @@ needs to be supplied along with 'identity' parameter.`,
 			"region": {
 				Type: framework.TypeString,
 				Description: `The AWS region to which the request should be directed to. Defaults to 
-'us-east-1', can be adjusted if necessary for regions such as 'us-gov-west-1','us-gov-east-1'.`
+'us-east-1', can be adjusted if necessary for regions such as 'us-gov-west-1','us-gov-east-1'.`,
 			},			
 		},
 

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -119,6 +119,11 @@ binary.`,
 				Description: `Base64 encoded SHA256 RSA signature of the instance identity document. This
 needs to be supplied along with 'identity' parameter.`,
 			},
+			"region": {
+				Type: framework.TypeString,
+				Description: `The AWS region to which the request should be directed to. Defaults to 
+'us-east-1', can be adjusted if necessary for regions such as 'us-gov-west-1','us-gov-east-1'.`
+			},			
 		},
 
 		Operations: map[logical.Operation]framework.OperationHandler{

--- a/website/content/docs/auth/aws.mdx
+++ b/website/content/docs/auth/aws.mdx
@@ -674,6 +674,10 @@ If the region is specified as `auto`, the Vault CLI will determine the region ba
 on standard AWS credentials precedence as described earlier. Whichever method is used,
 be sure the designated region corresponds to that of the STS endpoint you're using.
 
+-> **Note on GovCloud:** If you are making use of AWS GovCloud and setting the `sts_endpoint`
+and `sts_region` role parameters to `us-gov-west-1` / `us-gov-east-1` then you should include
+the `region` argument in your login request with a matching value, i.e. `region=us-gov-west-1`.
+
 An example of how to generate the required request values for the `login` method
 can be found found in the [vault cli
 source code](https://github.com/hashicorp/vault/blob/main/builtin/credential/aws/cli.go).


### PR DESCRIPTION
The contents here appears to get called when `vault path-help auth/aws/login` is called, and we don't have an example for `region` so it should be added - ref https://www.vaultproject.io/docs/auth/aws#perform-the-login-operation