### PR TITLE
Fix format errors in PKI tests

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -4159,7 +4159,7 @@ func RoleIssuanceRegressionHelper(t *testing.T, b *backend, s logical.Storage, i
 						}
 
 						resp, err = CBWrite(b, s, "issue/"+role, map[string]interface{}{
-							"common_name": test.CommonName,
+							"common_name":          test.CommonName,
 							"exclude_cn_from_sans": true,
 						})
 


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

--

What I get for using auto-merge after resolving conflicts :-D 