### PR TITLE
Document additional entropy augmentation usage locations

### DIFF
--- a/website/content/docs/enterprise/entropy-augmentation.mdx
+++ b/website/content/docs/enterprise/entropy-augmentation.mdx
@@ -43,7 +43,10 @@ and include the following:
 - JWT token wrapping keys
 - Root tokens
 - DR operation tokens
-- [Transit](/docs/secrets/transit) backend key generation
+- [Transit](/docs/secrets/transit) backend key generation and `/random` endpoint (`/random` only on Vault 1.11+)
+- [PKI](/docs/secrets/pki) issuer key generation, but not for leaf certificate private keys
+- [`/sys/tools/random`](/api-docs/system/tools#generate-random-bytes) endpoint (Vault 1.11+)
+- [SSH](/docs/secrets/ssh) CA key generation, but not for key pair generation
 
 ## Enabling/Disabling
 


### PR DESCRIPTION
I noticed the docs page already had some Entropy Augmentation uses, so this adds some missing ones to it.