### PR TITLE
ssh: Fix template regex test for defaultExtensions to allow additional text

### DIFF
--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -1480,6 +1480,8 @@ func TestBackend_DefExtTemplatingEnabled(t *testing.T) {
 		"default_extensions_template": true,
 		"default_extensions": map[string]interface{}{
 			"login@foobar.com": "{{identity.entity.aliases." + userpassAccessor + ".name}}",
+			"login@foobar2.com": "{{identity.entity.aliases." + userpassAccessor + ".name}}, " +
+				"{{identity.entity.aliases." + userpassAccessor + ".name}}_foobar",
 		},
 	})
 	if err != nil {
@@ -1505,7 +1507,8 @@ func TestBackend_DefExtTemplatingEnabled(t *testing.T) {
 	}
 
 	defaultExtensionPermissions := map[string]string{
-		"login@foobar.com": testUserName,
+		"login@foobar.com":  testUserName,
+		"login@foobar2.com": fmt.Sprintf("%s, %s_foobar", testUserName, testUserName),
 	}
 
 	err = validateSSHCertificate(parsedKey.(*ssh.Certificate), sshKeyID, ssh.UserCert, []string{"tuber"}, map[string]string{}, defaultExtensionPermissions, 16*time.Hour)

--- a/builtin/logical/ssh/path_issue_sign.go
+++ b/builtin/logical/ssh/path_issue_sign.go
@@ -24,6 +24,8 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+var containsTemplateRegex = regexp.MustCompile(`{{.+?}}`)
+
 var ecCurveBitsToAlgoName = map[int]string{
 	256: ssh.KeyAlgoECDSA256,
 	384: ssh.KeyAlgoECDSA384,
@@ -149,7 +151,7 @@ func (b *backend) calculateValidPrincipals(data *framework.FieldData, req *logic
 	for _, principal := range strutil.RemoveDuplicates(strutil.ParseStringSlice(principalsAllowedByRole, ","), false) {
 		if role.AllowedUsersTemplate {
 			// Look for templating markers {{ .* }}
-			matched, _ := regexp.MatchString(`{{.+?}}`, principal)
+			matched := containsTemplateRegex.MatchString(principal)
 			if matched {
 				if req.EntityID != "" {
 					// Retrieve principal based on template + entityID from request.
@@ -313,7 +315,7 @@ func (b *backend) calculateExtensions(data *framework.FieldData, req *logical.Re
 	if role.DefaultExtensionsTemplate {
 		for extensionKey, extensionValue := range role.DefaultExtensions {
 			// Look for templating markers {{ .* }}
-			matched, _ := regexp.MatchString(`^{{.+?}}$`, extensionValue)
+			matched := containsTemplateRegex.MatchString(extensionValue)
 			if matched {
 				if req.EntityID != "" {
 					// Retrieve extension value based on template + entityID from request.


### PR DESCRIPTION
 - The regex to identify if our defaultExtensions contains a template was
   a little too greedy, requiring the entire field to be just the regex. Allow
   additional text within the value field to be added