### PR TITLE
Refactor PKI storage calls to take a shared struct

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2602,7 +2602,8 @@ func TestBackend_SignSelfIssued(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signingBundle, err := fetchCAInfo(context.Background(), b, &logical.Request{Storage: storage}, defaultRef, ReadOnlyUsage)
+	sc := b.makeStorageContext(context.Background(), storage)
+	signingBundle, err := sc.fetchCAInfo(defaultRef, ReadOnlyUsage)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func (b *backend) getGenerationParams(ctx context.Context, storage logical.Storage, data *framework.FieldData) (exported bool, format string, role *roleEntry, errorResp *logical.Response) {
+func getGenerationParams(sc *storageContext, data *framework.FieldData) (exported bool, format string, role *roleEntry, errorResp *logical.Response) {
 	exportedStr := data.Get("exported").(string)
 	switch exportedStr {
 	case "exported":
@@ -37,7 +37,8 @@ func (b *backend) getGenerationParams(ctx context.Context, storage logical.Stora
 			`the "format" path parameter must be "pem", "der", or "pem_bundle"`)
 		return
 	}
-	keyType, keyBits, err := getKeyTypeAndBitsForRole(ctx, b, storage, data)
+
+	keyType, keyBits, err := sc.getKeyTypeAndBitsForRole(data)
 	if err != nil {
 		errorResp = logical.ErrorResponse(err.Error())
 		return
@@ -75,7 +76,10 @@ func (b *backend) getGenerationParams(ctx context.Context, storage logical.Stora
 	return
 }
 
-func generateCABundle(ctx context.Context, b *backend, input *inputBundle, data *certutil.CreationBundle, randomSource io.Reader) (*certutil.ParsedCertBundle, error) {
+func generateCABundle(sc *storageContext, input *inputBundle, data *certutil.CreationBundle, randomSource io.Reader) (*certutil.ParsedCertBundle, error) {
+	ctx := sc.Context
+	b := sc.Backend
+
 	if kmsRequested(input) {
 		keyId, err := getManagedKeyId(input.apiData)
 		if err != nil {
@@ -90,7 +94,7 @@ func generateCABundle(ctx context.Context, b *backend, input *inputBundle, data 
 			return nil, err
 		}
 
-		keyEntry, err := getExistingKeyFromRef(ctx, input.req.Storage, keyRef)
+		keyEntry, err := sc.getExistingKeyFromRef(keyRef)
 		if err != nil {
 			return nil, err
 		}
@@ -109,7 +113,10 @@ func generateCABundle(ctx context.Context, b *backend, input *inputBundle, data 
 	return certutil.CreateCertificateWithRandomSource(data, randomSource)
 }
 
-func generateCSRBundle(ctx context.Context, b *backend, input *inputBundle, data *certutil.CreationBundle, addBasicConstraints bool, randomSource io.Reader) (*certutil.ParsedCSRBundle, error) {
+func generateCSRBundle(sc *storageContext, input *inputBundle, data *certutil.CreationBundle, addBasicConstraints bool, randomSource io.Reader) (*certutil.ParsedCSRBundle, error) {
+	ctx := sc.Context
+	b := sc.Backend
+
 	if kmsRequested(input) {
 		keyId, err := getManagedKeyId(input.apiData)
 		if err != nil {
@@ -125,7 +132,7 @@ func generateCSRBundle(ctx context.Context, b *backend, input *inputBundle, data
 			return nil, err
 		}
 
-		key, err := getExistingKeyFromRef(ctx, input.req.Storage, keyRef)
+		key, err := sc.getExistingKeyFromRef(keyRef)
 		if err != nil {
 			return nil, err
 		}
@@ -151,7 +158,7 @@ func parseCABundle(ctx context.Context, b *backend, bundle *certutil.CertBundle)
 	return bundle.ToParsedCertBundle()
 }
 
-func getKeyTypeAndBitsForRole(ctx context.Context, b *backend, storage logical.Storage, data *framework.FieldData) (string, int, error) {
+func (sc *storageContext) getKeyTypeAndBitsForRole(data *framework.FieldData) (string, int, error) {
 	exportedStr := data.Get("exported").(string)
 	var keyType string
 	var keyBits int
@@ -180,7 +187,7 @@ func getKeyTypeAndBitsForRole(ctx context.Context, b *backend, storage logical.S
 			return "", 0, errors.New("unable to determine managed key id" + err.Error())
 		}
 
-		pubKeyManagedKey, err := getManagedKeyPublicKey(ctx, b, keyId)
+		pubKeyManagedKey, err := getManagedKeyPublicKey(sc.Context, sc.Backend, keyId)
 		if err != nil {
 			return "", 0, errors.New("failed to lookup public key from managed key: " + err.Error())
 		}
@@ -188,7 +195,7 @@ func getKeyTypeAndBitsForRole(ctx context.Context, b *backend, storage logical.S
 	}
 
 	if existingKeyRequestedFromFieldData(data) {
-		existingPubKey, err := getExistingPublicKey(ctx, b, storage, data)
+		existingPubKey, err := sc.getExistingPublicKey(data)
 		if err != nil {
 			return "", 0, errors.New("failed to lookup public key from existing key: " + err.Error())
 		}
@@ -199,20 +206,20 @@ func getKeyTypeAndBitsForRole(ctx context.Context, b *backend, storage logical.S
 	return string(privateKeyType), keyBits, err
 }
 
-func getExistingPublicKey(ctx context.Context, b *backend, s logical.Storage, data *framework.FieldData) (crypto.PublicKey, error) {
+func (sc *storageContext) getExistingPublicKey(data *framework.FieldData) (crypto.PublicKey, error) {
 	keyRef, err := getKeyRefWithErr(data)
 	if err != nil {
 		return nil, err
 	}
-	id, err := resolveKeyReference(ctx, s, keyRef)
+	id, err := sc.resolveKeyReference(keyRef)
 	if err != nil {
 		return nil, err
 	}
-	key, err := fetchKeyById(ctx, s, id)
+	key, err := sc.fetchKeyById(id)
 	if err != nil {
 		return nil, err
 	}
-	return getPublicKey(ctx, b, key)
+	return getPublicKey(sc.Context, sc.Backend, key)
 }
 
 func getKeyTypeAndBitsFromPublicKeyForRole(pubKey crypto.PublicKey) (certutil.PrivateKeyType, int, error) {
@@ -233,12 +240,12 @@ func getKeyTypeAndBitsFromPublicKeyForRole(pubKey crypto.PublicKey) (certutil.Pr
 	return keyType, keyBits, nil
 }
 
-func getExistingKeyFromRef(ctx context.Context, s logical.Storage, keyRef string) (*keyEntry, error) {
-	keyId, err := resolveKeyReference(ctx, s, keyRef)
+func (sc *storageContext) getExistingKeyFromRef(keyRef string) (*keyEntry, error) {
+	keyId, err := sc.resolveKeyReference(keyRef)
 	if err != nil {
 		return nil, err
 	}
-	return fetchKeyById(ctx, s, keyId)
+	return sc.fetchKeyById(keyId)
 }
 
 func existingKeyGeneratorFromBytes(key *keyEntry) certutil.KeyGenerator {

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -83,29 +83,29 @@ func getFormat(data *framework.FieldData) string {
 // fetchCAInfo will fetch the CA info, will return an error if no ca info exists, this does NOT support
 // loading using the legacyBundleShimID and should be used with care. This should be called only once
 // within the request path otherwise you run the risk of a race condition with the issuer migration on perf-secondaries.
-func fetchCAInfo(ctx context.Context, b *backend, req *logical.Request, issuerRef string, usage issuerUsage) (*certutil.CAInfoBundle, error) {
+func (sc *storageContext) fetchCAInfo(issuerRef string, usage issuerUsage) (*certutil.CAInfoBundle, error) {
 	var issuerId issuerID
 
-	if b.useLegacyBundleCaStorage() {
+	if sc.Backend.useLegacyBundleCaStorage() {
 		// We have not completed the migration so attempt to load the bundle from the legacy location
-		b.Logger().Info("Using legacy CA bundle as PKI migration has not completed.")
+		sc.Backend.Logger().Info("Using legacy CA bundle as PKI migration has not completed.")
 		issuerId = legacyBundleShimID
 	} else {
 		var err error
-		issuerId, err = resolveIssuerReference(ctx, req.Storage, issuerRef)
+		issuerId, err = sc.resolveIssuerReference(issuerRef)
 		if err != nil {
 			// Usually a bad label from the user or mis-configured default.
 			return nil, errutil.UserError{Err: err.Error()}
 		}
 	}
 
-	return fetchCAInfoByIssuerId(ctx, b, req, issuerId, usage)
+	return sc.fetchCAInfoByIssuerId(issuerId, usage)
 }
 
 // fetchCAInfoByIssuerId will fetch the CA info, will return an error if no ca info exists for the given issuerId.
 // This does support the loading using the legacyBundleShimID
-func fetchCAInfoByIssuerId(ctx context.Context, b *backend, req *logical.Request, issuerId issuerID, usage issuerUsage) (*certutil.CAInfoBundle, error) {
-	entry, bundle, err := fetchCertBundleByIssuerId(ctx, req.Storage, issuerId, true)
+func (sc *storageContext) fetchCAInfoByIssuerId(issuerId issuerID, usage issuerUsage) (*certutil.CAInfoBundle, error) {
+	entry, bundle, err := sc.fetchCertBundleByIssuerId(issuerId, true)
 	if err != nil {
 		switch err.(type) {
 		case errutil.UserError:
@@ -121,7 +121,7 @@ func fetchCAInfoByIssuerId(ctx context.Context, b *backend, req *logical.Request
 		return nil, errutil.InternalError{Err: fmt.Sprintf("error while attempting to use issuer %v: %v", issuerId, err)}
 	}
 
-	parsedBundle, err := parseCABundle(ctx, b, bundle)
+	parsedBundle, err := parseCABundle(sc.Context, sc.Backend, bundle)
 	if err != nil {
 		return nil, errutil.InternalError{Err: err.Error()}
 	}
@@ -139,7 +139,7 @@ func fetchCAInfoByIssuerId(ctx context.Context, b *backend, req *logical.Request
 		LeafNotAfterBehavior: entry.LeafNotAfterBehavior,
 	}
 
-	entries, err := getURLs(ctx, req)
+	entries, err := getURLs(sc.Context, sc.Storage)
 	if err != nil {
 		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch URL information: %v", err)}
 	}
@@ -171,7 +171,8 @@ func fetchCertBySerial(ctx context.Context, b *backend, req *logical.Request, pr
 		if err = b.crlBuilder.rebuildIfForced(ctx, b, req); err != nil {
 			return nil, err
 		}
-		path, err = resolveIssuerCRLPath(ctx, b, req.Storage, defaultRef)
+		sc := b.makeStorageContext(ctx, req.Storage)
+		path, err = sc.resolveIssuerCRLPath(defaultRef)
 		if err != nil {
 			return nil, err
 		}
@@ -641,13 +642,15 @@ func validateSerialNumber(data *inputBundle, serialNumber string) string {
 	}
 }
 
-func generateCert(ctx context.Context,
-	b *backend,
+func generateCert(sc *storageContext,
 	input *inputBundle,
 	caSign *certutil.CAInfoBundle,
 	isCA bool,
 	randomSource io.Reader) (*certutil.ParsedCertBundle, error,
 ) {
+	ctx := sc.Context
+	b := sc.Backend
+
 	if input.role == nil {
 		return nil, errutil.InternalError{Err: "no role found in data bundle"}
 	}
@@ -670,7 +673,7 @@ func generateCert(ctx context.Context,
 
 		if data.SigningBundle == nil {
 			// Generating a self-signed root certificate
-			entries, err := getURLs(ctx, input.req)
+			entries, err := getURLs(ctx, sc.Storage)
 			if err != nil {
 				return nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch URL information: %v", err)}
 			}
@@ -684,7 +687,7 @@ func generateCert(ctx context.Context,
 		}
 	}
 
-	parsedBundle, err := generateCABundle(ctx, b, input, data, randomSource)
+	parsedBundle, err := generateCABundle(sc, input, data, randomSource)
 	if err != nil {
 		return nil, err
 	}
@@ -694,7 +697,9 @@ func generateCert(ctx context.Context,
 
 // N.B.: This is only meant to be used for generating intermediate CAs.
 // It skips some sanity checks.
-func generateIntermediateCSR(ctx context.Context, b *backend, input *inputBundle, randomSource io.Reader) (*certutil.ParsedCSRBundle, error) {
+func generateIntermediateCSR(sc *storageContext, input *inputBundle, randomSource io.Reader) (*certutil.ParsedCSRBundle, error) {
+	b := sc.Backend
+
 	creation, err := generateCreationBundle(b, input, nil, nil)
 	if err != nil {
 		return nil, err
@@ -704,7 +709,7 @@ func generateIntermediateCSR(ctx context.Context, b *backend, input *inputBundle
 	}
 
 	addBasicConstraints := input.apiData != nil && input.apiData.Get("add_basic_constraints").(bool)
-	parsedBundle, err := generateCSRBundle(ctx, b, input, creation, addBasicConstraints, randomSource)
+	parsedBundle, err := generateCSRBundle(sc, input, creation, addBasicConstraints, randomSource)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/chain_test.go
+++ b/builtin/logical/pki/chain_test.go
@@ -1605,9 +1605,10 @@ func BenchmarkChainBuilding(benchies *testing.B) {
 
 			// Run the benchmark.
 			ctx := context.Background()
+			sc := b.makeStorageContext(ctx, s)
 			bench.StartTimer()
 			for n := 0; n < bench.N; n++ {
-				rebuildIssuersChains(ctx, s, nil)
+				sc.rebuildIssuersChains(nil)
 			}
 		})
 	}

--- a/builtin/logical/pki/config_util.go
+++ b/builtin/logical/pki/config_util.go
@@ -1,14 +1,11 @@
 package pki
 
 import (
-	"context"
 	"strings"
-
-	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func isDefaultKeySet(ctx context.Context, s logical.Storage) (bool, error) {
-	config, err := getKeysConfig(ctx, s)
+func (sc *storageContext) isDefaultKeySet() (bool, error) {
+	config, err := sc.getKeysConfig()
 	if err != nil {
 		return false, err
 	}
@@ -16,8 +13,8 @@ func isDefaultKeySet(ctx context.Context, s logical.Storage) (bool, error) {
 	return strings.TrimSpace(config.DefaultKeyId.String()) != "", nil
 }
 
-func isDefaultIssuerSet(ctx context.Context, s logical.Storage) (bool, error) {
-	config, err := getIssuersConfig(ctx, s)
+func (sc *storageContext) isDefaultIssuerSet() (bool, error) {
+	config, err := sc.getIssuersConfig()
 	if err != nil {
 		return false, err
 	}
@@ -25,14 +22,14 @@ func isDefaultIssuerSet(ctx context.Context, s logical.Storage) (bool, error) {
 	return strings.TrimSpace(config.DefaultIssuerId.String()) != "", nil
 }
 
-func updateDefaultKeyId(ctx context.Context, s logical.Storage, id keyID) error {
-	config, err := getKeysConfig(ctx, s)
+func (sc *storageContext) updateDefaultKeyId(id keyID) error {
+	config, err := sc.getKeysConfig()
 	if err != nil {
 		return err
 	}
 
 	if config.DefaultKeyId != id {
-		return setKeysConfig(ctx, s, &keyConfigEntry{
+		return sc.setKeysConfig(&keyConfigEntry{
 			DefaultKeyId: id,
 		})
 	}
@@ -40,14 +37,14 @@ func updateDefaultKeyId(ctx context.Context, s logical.Storage, id keyID) error 
 	return nil
 }
 
-func updateDefaultIssuerId(ctx context.Context, s logical.Storage, id issuerID) error {
-	config, err := getIssuersConfig(ctx, s)
+func (sc *storageContext) updateDefaultIssuerId(id issuerID) error {
+	config, err := sc.getIssuersConfig()
 	if err != nil {
 		return err
 	}
 
 	if config.DefaultIssuerId != id {
-		return setIssuersConfig(ctx, s, &issuerConfigEntry{
+		return sc.setIssuersConfig(&issuerConfigEntry{
 			DefaultIssuerId: id,
 		})
 	}

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -180,10 +180,11 @@ func crlEnableDisableTestForBackend(t *testing.T, b *backend, s logical.Storage,
 func TestBackend_Secondary_CRL_Rebuilding(t *testing.T) {
 	ctx := context.Background()
 	b, s := createBackendWithStorage(t)
+	sc := b.makeStorageContext(ctx, s)
 
 	// Write out the issuer/key to storage without going through the api call as replication would.
 	bundle := genCertBundle(t, b, s)
-	issuer, _, err := writeCaBundle(ctx, b, s, bundle, "", "")
+	issuer, _, err := sc.writeCaBundle(bundle, "", "")
 	require.NoError(t, err)
 
 	// Just to validate, before we call the invalidate function, make sure our CRL has not been generated
@@ -203,10 +204,11 @@ func TestBackend_Secondary_CRL_Rebuilding(t *testing.T) {
 func TestCrlRebuilder(t *testing.T) {
 	ctx := context.Background()
 	b, s := createBackendWithStorage(t)
+	sc := b.makeStorageContext(ctx, s)
 
 	// Write out the issuer/key to storage without going through the api call as replication would.
 	bundle := genCertBundle(t, b, s)
-	_, _, err := writeCaBundle(ctx, b, s, bundle, "", "")
+	_, _, err := sc.writeCaBundle(bundle, "", "")
 	require.NoError(t, err)
 
 	req := &logical.Request{Storage: s}

--- a/builtin/logical/pki/key_util.go
+++ b/builtin/logical/pki/key_util.go
@@ -9,11 +9,10 @@ import (
 
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
-	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func comparePublicKey(ctx context.Context, b *backend, key *keyEntry, publicKey crypto.PublicKey) (bool, error) {
-	publicKeyForKeyEntry, err := getPublicKey(ctx, b, key)
+func comparePublicKey(sc *storageContext, key *keyEntry, publicKey crypto.PublicKey) (bool, error) {
+	publicKeyForKeyEntry, err := getPublicKey(sc.Context, sc.Backend, key)
 	if err != nil {
 		return false, err
 	}
@@ -76,7 +75,7 @@ func getPublicKeyFromBytes(keyBytes []byte) (crypto.PublicKey, error) {
 	return signer.Public(), nil
 }
 
-func importKeyFromBytes(ctx context.Context, b *backend, s logical.Storage, keyValue string, keyName string) (*keyEntry, bool, error) {
+func importKeyFromBytes(sc *storageContext, keyValue string, keyName string) (*keyEntry, bool, error) {
 	signer, _, _, err := getSignerFromBytes([]byte(keyValue))
 	if err != nil {
 		return nil, false, err
@@ -86,7 +85,7 @@ func importKeyFromBytes(ctx context.Context, b *backend, s logical.Storage, keyV
 		return nil, false, errors.New("unsupported private key type within pem bundle")
 	}
 
-	key, existed, err := importKey(ctx, b, s, keyValue, keyName, privateKeyType)
+	key, existed, err := sc.importKey(keyValue, keyName, privateKeyType)
 	if err != nil {
 		return nil, false, err
 	}

--- a/builtin/logical/pki/path_config_ca.go
+++ b/builtin/logical/pki/path_config_ca.go
@@ -101,7 +101,8 @@ func (b *backend) pathCAIssuersRead(ctx context.Context, req *logical.Request, _
 		return logical.ErrorResponse("Cannot read defaults until migration has completed"), nil
 	}
 
-	config, err := getIssuersConfig(ctx, req.Storage)
+	sc := b.makeStorageContext(ctx, req.Storage)
+	config, err := sc.getIssuersConfig()
 	if err != nil {
 		return logical.ErrorResponse("Error loading issuers configuration: " + err.Error()), nil
 	}
@@ -128,7 +129,8 @@ func (b *backend) pathCAIssuersWrite(ctx context.Context, req *logical.Request, 
 		return logical.ErrorResponse("Invalid issuer specification; must be non-empty and can't be 'default'."), nil
 	}
 
-	parsedIssuer, err := resolveIssuerReference(ctx, req.Storage, newDefault)
+	sc := b.makeStorageContext(ctx, req.Storage)
+	parsedIssuer, err := sc.resolveIssuerReference(newDefault)
 	if err != nil {
 		return logical.ErrorResponse("Error resolving issuer reference: " + err.Error()), nil
 	}
@@ -139,7 +141,7 @@ func (b *backend) pathCAIssuersWrite(ctx context.Context, req *logical.Request, 
 		},
 	}
 
-	entry, err := fetchIssuerById(ctx, req.Storage, parsedIssuer)
+	entry, err := sc.fetchIssuerById(parsedIssuer)
 	if err != nil {
 		return logical.ErrorResponse("Unable to fetch issuer: " + err.Error()), nil
 	}
@@ -150,7 +152,7 @@ func (b *backend) pathCAIssuersWrite(ctx context.Context, req *logical.Request, 
 		b.Logger().Error(msg)
 	}
 
-	err = updateDefaultIssuerId(ctx, req.Storage, parsedIssuer)
+	err = sc.updateDefaultIssuerId(parsedIssuer)
 	if err != nil {
 		return logical.ErrorResponse("Error updating issuer configuration: " + err.Error()), nil
 	}
@@ -204,7 +206,8 @@ func (b *backend) pathKeyDefaultRead(ctx context.Context, req *logical.Request, 
 		return logical.ErrorResponse("Cannot read key defaults until migration has completed"), nil
 	}
 
-	config, err := getKeysConfig(ctx, req.Storage)
+	sc := b.makeStorageContext(ctx, req.Storage)
+	config, err := sc.getKeysConfig()
 	if err != nil {
 		return logical.ErrorResponse("Error loading keys configuration: " + err.Error()), nil
 	}
@@ -231,12 +234,13 @@ func (b *backend) pathKeyDefaultWrite(ctx context.Context, req *logical.Request,
 		return logical.ErrorResponse("Invalid key specification; must be non-empty and can't be 'default'."), nil
 	}
 
-	parsedKey, err := resolveKeyReference(ctx, req.Storage, newDefault)
+	sc := b.makeStorageContext(ctx, req.Storage)
+	parsedKey, err := sc.resolveKeyReference(newDefault)
 	if err != nil {
 		return logical.ErrorResponse("Error resolving issuer reference: " + err.Error()), nil
 	}
 
-	err = updateDefaultKeyId(ctx, req.Storage, parsedKey)
+	err = sc.updateDefaultKeyId(parsedKey)
 	if err != nil {
 		return logical.ErrorResponse("Error updating issuer configuration: " + err.Error()), nil
 	}

--- a/builtin/logical/pki/path_config_urls.go
+++ b/builtin/logical/pki/path_config_urls.go
@@ -58,8 +58,8 @@ func validateURLs(urls []string) string {
 	return ""
 }
 
-func getURLs(ctx context.Context, req *logical.Request) (*certutil.URLEntries, error) {
-	entry, err := req.Storage.Get(ctx, "urls")
+func getURLs(ctx context.Context, storage logical.Storage) (*certutil.URLEntries, error) {
+	entry, err := storage.Get(ctx, "urls")
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func getURLs(ctx context.Context, req *logical.Request) (*certutil.URLEntries, e
 	return entries, nil
 }
 
-func writeURLs(ctx context.Context, req *logical.Request, entries *certutil.URLEntries) error {
+func writeURLs(ctx context.Context, storage logical.Storage, entries *certutil.URLEntries) error {
 	entry, err := logical.StorageEntryJSON("urls", entries)
 	if err != nil {
 		return err
@@ -90,7 +90,7 @@ func writeURLs(ctx context.Context, req *logical.Request, entries *certutil.URLE
 		return fmt.Errorf("unable to marshal entry into JSON")
 	}
 
-	err = req.Storage.Put(ctx, entry)
+	err = storage.Put(ctx, entry)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func writeURLs(ctx context.Context, req *logical.Request, entries *certutil.URLE
 }
 
 func (b *backend) pathReadURL(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
-	entries, err := getURLs(ctx, req)
+	entries, err := getURLs(ctx, req.Storage)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (b *backend) pathReadURL(ctx context.Context, req *logical.Request, _ *fram
 }
 
 func (b *backend) pathWriteURL(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	entries, err := getURLs(ctx, req)
+	entries, err := getURLs(ctx, req.Storage)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func (b *backend) pathWriteURL(ctx context.Context, req *logical.Request, data *
 		}
 	}
 
-	return nil, writeURLs(ctx, req, entries)
+	return nil, writeURLs(ctx, req.Storage, entries)
 }
 
 const pathConfigURLsHelpSyn = `

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -206,7 +206,8 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 
 	// Prefer fetchCAInfo to fetchCertBySerial for CA certificates.
 	if serial == "ca_chain" || serial == "ca" {
-		caInfo, err := fetchCAInfo(ctx, b, req, defaultRef, ReadOnlyUsage)
+		sc := b.makeStorageContext(ctx, req.Storage)
+		caInfo, err := sc.fetchCAInfo(defaultRef, ReadOnlyUsage)
 		if err != nil {
 			switch err.(type) {
 			case errutil.UserError:

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -279,7 +279,8 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 	}
 
 	var caErr error
-	signingBundle, caErr := fetchCAInfo(ctx, b, req, issuerName, IssuanceUsage)
+	sc := b.makeStorageContext(ctx, req.Storage)
+	signingBundle, caErr := sc.fetchCAInfo(issuerName, IssuanceUsage)
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:
@@ -301,7 +302,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 	if useCSR {
 		parsedBundle, err = signCert(b, input, signingBundle, false, useCSRValues)
 	} else {
-		parsedBundle, err = generateCert(ctx, b, input, signingBundle, false, rand.Reader)
+		parsedBundle, err = generateCert(sc, input, signingBundle, false, rand.Reader)
 	}
 	if err != nil {
 		switch err.(type) {

--- a/builtin/logical/pki/path_manage_keys.go
+++ b/builtin/logical/pki/path_manage_keys.go
@@ -80,7 +80,8 @@ func (b *backend) pathGenerateKeyHandler(ctx context.Context, req *logical.Reque
 		return logical.ErrorResponse("Can not generate keys until migration has completed"), nil
 	}
 
-	keyName, err := getKeyName(ctx, req.Storage, data)
+	sc := b.makeStorageContext(ctx, req.Storage)
+	keyName, err := getKeyName(sc, data)
 	if err != nil { // Fail Immediately if Key Name is in Use, etc...
 		return logical.ErrorResponse(err.Error()), nil
 	}
@@ -127,7 +128,7 @@ func (b *backend) pathGenerateKeyHandler(ctx context.Context, req *logical.Reque
 		return nil, err
 	}
 
-	key, _, err := importKey(ctx, b, req.Storage, privateKeyPemString, keyName, keyBundle.PrivateKeyType)
+	key, _, err := sc.importKey(privateKeyPemString, keyName, keyBundle.PrivateKeyType)
 	if err != nil {
 		return nil, err
 	}
@@ -188,8 +189,9 @@ func (b *backend) pathImportKeyHandler(ctx context.Context, req *logical.Request
 		return logical.ErrorResponse("Cannot import keys until migration has completed"), nil
 	}
 
+	sc := b.makeStorageContext(ctx, req.Storage)
 	pemBundle := data.Get("pem_bundle").(string)
-	keyName, err := getKeyName(ctx, req.Storage, data)
+	keyName, err := getKeyName(sc, data)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
@@ -212,7 +214,7 @@ func (b *backend) pathImportKeyHandler(ctx context.Context, req *logical.Request
 		return logical.ErrorResponse("only a single key can be present within the pem_bundle for importing"), nil
 	}
 
-	key, existed, err := importKeyFromBytes(ctx, b, req.Storage, keys[0], keyName)
+	key, existed, err := importKeyFromBytes(sc, keys[0], keyName)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}

--- a/builtin/logical/pki/path_manage_keys_test.go
+++ b/builtin/logical/pki/path_manage_keys_test.go
@@ -409,9 +409,10 @@ func TestPKI_PathManageKeys_ImportKeyRejectsMultipleKeys(t *testing.T) {
 	require.True(t, resp.IsError(), "should have received an error response importing a pem bundle with more than 1 key")
 
 	ctx := context.Background()
-	keys, _ := listKeys(ctx, s)
+	sc := b.makeStorageContext(ctx, s)
+	keys, _ := sc.listKeys()
 	for _, keyId := range keys {
-		id, _ := fetchKeyById(ctx, s, keyId)
+		id, _ := sc.fetchKeyById(keyId)
 		t.Logf("%s:%s", id.ID, id.Name)
 	}
 }

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -794,7 +794,8 @@ func validateRole(b *backend, entry *roleEntry, ctx context.Context, s logical.S
 	}
 	// Check that the issuers reference set resolves to something
 	if !b.useLegacyBundleCaStorage() {
-		issuerId, err := resolveIssuerReference(ctx, s, entry.Issuer)
+		sc := b.makeStorageContext(ctx, s)
+		issuerId, err := sc.resolveIssuerReference(entry.Issuer)
 		if err != nil {
 			if issuerId == IssuerRefNotFound {
 				resp = &logical.Response{}

--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -89,7 +89,8 @@ func migrateStorage(ctx context.Context, b *backend, s logical.Storage) error {
 		migrationName := fmt.Sprintf("current-%d", time.Now().Unix())
 
 		b.Logger().Info("performing PKI migration to new keys/issuers layout")
-		anIssuer, aKey, err := writeCaBundle(ctx, b, s, migrationInfo.legacyBundle, migrationName, migrationName)
+		sc := b.makeStorageContext(ctx, s)
+		anIssuer, aKey, err := sc.writeCaBundle(migrationInfo.legacyBundle, migrationName, migrationName)
 		if err != nil {
 			return err
 		}

--- a/builtin/logical/pki/storage_test.go
+++ b/builtin/logical/pki/storage_test.go
@@ -14,14 +14,15 @@ import (
 var ctx = context.Background()
 
 func Test_ConfigsRoundTrip(t *testing.T) {
-	_, s := createBackendWithStorage(t)
+	b, s := createBackendWithStorage(t)
+	sc := b.makeStorageContext(ctx, s)
 
 	// Verify we handle nothing stored properly
-	keyConfigEmpty, err := getKeysConfig(ctx, s)
+	keyConfigEmpty, err := sc.getKeysConfig()
 	require.NoError(t, err)
 	require.Equal(t, &keyConfigEntry{}, keyConfigEmpty)
 
-	issuerConfigEmpty, err := getIssuersConfig(ctx, s)
+	issuerConfigEmpty, err := sc.getIssuersConfig()
 	require.NoError(t, err)
 	require.Equal(t, &issuerConfigEntry{}, issuerConfigEmpty)
 
@@ -33,59 +34,60 @@ func Test_ConfigsRoundTrip(t *testing.T) {
 		DefaultIssuerId: genIssuerId(),
 	}
 
-	err = setKeysConfig(ctx, s, origKeyConfig)
+	err = sc.setKeysConfig(origKeyConfig)
 	require.NoError(t, err)
-	err = setIssuersConfig(ctx, s, origIssuerConfig)
+	err = sc.setIssuersConfig(origIssuerConfig)
 	require.NoError(t, err)
 
-	keyConfig, err := getKeysConfig(ctx, s)
+	keyConfig, err := sc.getKeysConfig()
 	require.NoError(t, err)
 	require.Equal(t, origKeyConfig, keyConfig)
 
-	issuerConfig, err := getIssuersConfig(ctx, s)
+	issuerConfig, err := sc.getIssuersConfig()
 	require.NoError(t, err)
 	require.Equal(t, origIssuerConfig, issuerConfig)
 }
 
 func Test_IssuerRoundTrip(t *testing.T) {
 	b, s := createBackendWithStorage(t)
+	sc := b.makeStorageContext(ctx, s)
 	issuer1, key1 := genIssuerAndKey(t, b, s)
 	issuer2, key2 := genIssuerAndKey(t, b, s)
 
 	// We get an error when issuer id not found
-	_, err := fetchIssuerById(ctx, s, issuer1.ID)
+	_, err := sc.fetchIssuerById(issuer1.ID)
 	require.Error(t, err)
 
 	// We get an error when key id not found
-	_, err = fetchKeyById(ctx, s, key1.ID)
+	_, err = sc.fetchKeyById(key1.ID)
 	require.Error(t, err)
 
 	// Now write out our issuers and keys
-	err = writeKey(ctx, s, key1)
+	err = sc.writeKey(key1)
 	require.NoError(t, err)
-	err = writeIssuer(ctx, s, &issuer1)
-	require.NoError(t, err)
-
-	err = writeKey(ctx, s, key2)
-	require.NoError(t, err)
-	err = writeIssuer(ctx, s, &issuer2)
+	err = sc.writeIssuer(&issuer1)
 	require.NoError(t, err)
 
-	fetchedKey1, err := fetchKeyById(ctx, s, key1.ID)
+	err = sc.writeKey(key2)
+	require.NoError(t, err)
+	err = sc.writeIssuer(&issuer2)
 	require.NoError(t, err)
 
-	fetchedIssuer1, err := fetchIssuerById(ctx, s, issuer1.ID)
+	fetchedKey1, err := sc.fetchKeyById(key1.ID)
+	require.NoError(t, err)
+
+	fetchedIssuer1, err := sc.fetchIssuerById(issuer1.ID)
 	require.NoError(t, err)
 
 	require.Equal(t, &key1, fetchedKey1)
 	require.Equal(t, &issuer1, fetchedIssuer1)
 
-	keys, err := listKeys(ctx, s)
+	keys, err := sc.listKeys()
 	require.NoError(t, err)
 
 	require.ElementsMatch(t, []keyID{key1.ID, key2.ID}, keys)
 
-	issuers, err := listIssuers(ctx, s)
+	issuers, err := sc.listIssuers()
 	require.NoError(t, err)
 
 	require.ElementsMatch(t, []issuerID{issuer1.ID, issuer2.ID}, issuers)
@@ -93,6 +95,7 @@ func Test_IssuerRoundTrip(t *testing.T) {
 
 func Test_KeysIssuerImport(t *testing.T) {
 	b, s := createBackendWithStorage(t)
+	sc := b.makeStorageContext(ctx, s)
 
 	issuer1, key1 := genIssuerAndKey(t, b, s)
 	issuer2, key2 := genIssuerAndKey(t, b, s)
@@ -103,21 +106,21 @@ func Test_KeysIssuerImport(t *testing.T) {
 	issuer1.ID = ""
 	issuer1.KeyID = ""
 
-	key1Ref1, existing, err := importKey(ctx, b, s, key1.PrivateKey, "key1", key1.PrivateKeyType)
+	key1Ref1, existing, err := sc.importKey(key1.PrivateKey, "key1", key1.PrivateKeyType)
 	require.NoError(t, err)
 	require.False(t, existing)
 	require.Equal(t, strings.TrimSpace(key1.PrivateKey), strings.TrimSpace(key1Ref1.PrivateKey))
 
 	// Make sure if we attempt to re-import the same private key, no import/updates occur.
 	// So the existing flag should be set to true, and we do not update the existing Name field.
-	key1Ref2, existing, err := importKey(ctx, b, s, key1.PrivateKey, "ignore-me", key1.PrivateKeyType)
+	key1Ref2, existing, err := sc.importKey(key1.PrivateKey, "ignore-me", key1.PrivateKeyType)
 	require.NoError(t, err)
 	require.True(t, existing)
 	require.Equal(t, key1.PrivateKey, key1Ref1.PrivateKey)
 	require.Equal(t, key1Ref1.ID, key1Ref2.ID)
 	require.Equal(t, key1Ref1.Name, key1Ref2.Name)
 
-	issuer1Ref1, existing, err := importIssuer(ctx, b, s, issuer1.Certificate, "issuer1")
+	issuer1Ref1, existing, err := sc.importIssuer(issuer1.Certificate, "issuer1")
 	require.NoError(t, err)
 	require.False(t, existing)
 	require.Equal(t, strings.TrimSpace(issuer1.Certificate), strings.TrimSpace(issuer1Ref1.Certificate))
@@ -126,7 +129,7 @@ func Test_KeysIssuerImport(t *testing.T) {
 
 	// Make sure if we attempt to re-import the same issuer, no import/updates occur.
 	// So the existing flag should be set to true, and we do not update the existing Name field.
-	issuer1Ref2, existing, err := importIssuer(ctx, b, s, issuer1.Certificate, "ignore-me")
+	issuer1Ref2, existing, err := sc.importIssuer(issuer1.Certificate, "ignore-me")
 	require.NoError(t, err)
 	require.True(t, existing)
 	require.Equal(t, strings.TrimSpace(issuer1.Certificate), strings.TrimSpace(issuer1Ref1.Certificate))
@@ -134,14 +137,14 @@ func Test_KeysIssuerImport(t *testing.T) {
 	require.Equal(t, key1Ref1.ID, issuer1Ref2.KeyID)
 	require.Equal(t, issuer1Ref1.Name, issuer1Ref2.Name)
 
-	err = writeIssuer(ctx, s, &issuer2)
+	err = sc.writeIssuer(&issuer2)
 	require.NoError(t, err)
 
-	err = writeKey(ctx, s, key2)
+	err = sc.writeKey(key2)
 	require.NoError(t, err)
 
 	// Same double import tests as above, but make sure if the previous was created through writeIssuer not importIssuer.
-	issuer2Ref, existing, err := importIssuer(ctx, b, s, issuer2.Certificate, "ignore-me")
+	issuer2Ref, existing, err := sc.importIssuer(issuer2.Certificate, "ignore-me")
 	require.NoError(t, err)
 	require.True(t, existing)
 	require.Equal(t, strings.TrimSpace(issuer2.Certificate), strings.TrimSpace(issuer2Ref.Certificate))
@@ -150,7 +153,7 @@ func Test_KeysIssuerImport(t *testing.T) {
 	require.Equal(t, issuer2.KeyID, issuer2Ref.KeyID)
 
 	// Same double import tests as above, but make sure if the previous was created through writeKey not importKey.
-	key2Ref, existing, err := importKey(ctx, b, s, key2.PrivateKey, "ignore-me", key2.PrivateKeyType)
+	key2Ref, existing, err := sc.importKey(key2.PrivateKey, "ignore-me", key2.PrivateKeyType)
 	require.NoError(t, err)
 	require.True(t, existing)
 	require.Equal(t, key2.PrivateKey, key2Ref.PrivateKey)
@@ -195,7 +198,8 @@ func genCertBundle(t *testing.T, b *backend, s logical.Storage) *certutil.CertBu
 			"ttl":      3600,
 		},
 	}
-	_, _, role, respErr := b.getGenerationParams(ctx, s, apiData)
+	sc := b.makeStorageContext(ctx, s)
+	_, _, role, respErr := getGenerationParams(sc, apiData)
 	require.Nil(t, respErr)
 
 	input := &inputBundle{
@@ -207,7 +211,7 @@ func genCertBundle(t *testing.T, b *backend, s logical.Storage) *certutil.CertBu
 		apiData: apiData,
 		role:    role,
 	}
-	parsedCertBundle, err := generateCert(ctx, b, input, nil, true, b.GetRandomReader())
+	parsedCertBundle, err := generateCert(sc, input, nil, true, b.GetRandomReader())
 
 	require.NoError(t, err)
 	certBundle, err := parsedCertBundle.ToCertBundle()

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -1,15 +1,12 @@
 package pki
 
 import (
-	"context"
 	"crypto"
 	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/hashicorp/vault/sdk/helper/certutil"
-
-	"github.com/hashicorp/vault/sdk/logical"
 
 	"github.com/hashicorp/vault/sdk/framework"
 
@@ -141,7 +138,7 @@ func getManagedKeyNameOrUUID(data *framework.FieldData) (name string, UUID strin
 	return keyName, keyUUID, nil
 }
 
-func getIssuerName(ctx context.Context, s logical.Storage, data *framework.FieldData) (string, error) {
+func getIssuerName(sc *storageContext, data *framework.FieldData) (string, error) {
 	issuerName := ""
 	issuerNameIface, ok := data.GetOk("issuer_name")
 	if ok {
@@ -154,7 +151,7 @@ func getIssuerName(ctx context.Context, s logical.Storage, data *framework.Field
 		if !nameMatcher.MatchString(issuerName) {
 			return issuerName, errutil.UserError{Err: "issuer name contained invalid characters"}
 		}
-		issuerId, err := resolveIssuerReference(ctx, s, issuerName)
+		issuerId, err := sc.resolveIssuerReference(issuerName)
 		if err == nil {
 			return issuerName, errIssuerNameInUse
 		}
@@ -166,7 +163,7 @@ func getIssuerName(ctx context.Context, s logical.Storage, data *framework.Field
 	return issuerName, nil
 }
 
-func getKeyName(ctx context.Context, s logical.Storage, data *framework.FieldData) (string, error) {
+func getKeyName(sc *storageContext, data *framework.FieldData) (string, error) {
 	keyName := ""
 	keyNameIface, ok := data.GetOk(keyNameParam)
 	if ok {
@@ -179,7 +176,7 @@ func getKeyName(ctx context.Context, s logical.Storage, data *framework.FieldDat
 		if !nameMatcher.MatchString(keyName) {
 			return "", errutil.UserError{Err: "key name contained invalid characters"}
 		}
-		keyId, err := resolveKeyReference(ctx, s, keyName)
+		keyId, err := sc.resolveKeyReference(keyName)
 		if err == nil {
 			return "", errKeyNameInUse
 		}


### PR DESCRIPTION
This will allow us to refactor the storage functions to take additional
parameters (or backend-inferred values) in the future. In particular, as
we look towards adding a storage cache layer, we'll need to add this to
the backend, which is now accessible from all storage functions.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

There has admittedly been a little bit of scope creep in order to make things consistent. But I believe at the top-level handler, we'll now fetch the new storage context struct once and pass that down the chain for use. 