### PR TITLE
Small refactor of mount entry manipulation

### DIFF
--- a/vault/logical_system_quotas.go
+++ b/vault/logical_system_quotas.go
@@ -193,15 +193,9 @@ func (b *SystemBackend) handleRateLimitQuotasUpdate() framework.OperationFunc {
 				return logical.ErrorResponse("invalid mount path %q", mountPath), nil
 			}
 
-			var newMountPath string
-			if me.Table == mountTableType {
-				newMountPath = me.Path
-			} else {
-				newMountPath = me.Table + "/" + me.Path
-			}
-
-			pathSuffix = strings.TrimSuffix(strings.TrimPrefix(mountPath, newMountPath), "/")
-			mountPath = newMountPath
+			mountAPIPath := me.APIPathNoNamespace()
+			pathSuffix = strings.TrimSuffix(strings.TrimPrefix(mountPath, mountAPIPath), "/")
+			mountPath = mountAPIPath
 		}
 		// Disallow creation of new quota that has properties similar to an
 		// existing quota.

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -391,6 +391,15 @@ func (e *MountEntry) APIPath() string {
 	return e.namespace.Path + path
 }
 
+// APIPathNoNamespace returns the API Path without the namespace for the given mount entry
+func (e *MountEntry) APIPathNoNamespace() string {
+	path := e.Path
+	if e.Table == credentialTableType {
+		path = credentialRoutePrefix + path
+	}
+	return path
+}
+
 // SyncCache syncs tunable configuration values to the cache. In the case of
 // cached values, they should be retrieved via synthesizedConfigCache.Load()
 // instead of accessing them directly through MountConfig.


### PR DESCRIPTION
Will be used in the PR for path suffix bassed lease-count quotas also. All Ent tests pass.

This seemed to be the nicest refactor to this section possible (the rest is very small, and error handling is done for the MountEntry), and also seems to be much more in line with the normal way to get API paths.