### PR TITLE
Use single-core clusters for api integration tests

### DIFF
--- a/vault/external_tests/api/api_integration_test.go
+++ b/vault/external_tests/api/api_integration_test.go
@@ -60,6 +60,7 @@ func testVaultServerCoreConfig(t testing.TB, coreConfig *vault.CoreConfig) (*api
 
 	cluster := vault.NewTestCluster(benchhelpers.TBtoT(t), coreConfig, &vault.TestClusterOptions{
 		HandlerFunc: http.Handler,
+		NumCores:    1,
 	})
 	cluster.Start()
 


### PR DESCRIPTION
These tests only ever talk to a single node anyway, they run with lots of parallelism, and we'll get better performance and predictability this way.