### PR TITLE
Fix flaky test

### DIFF
--- a/ui/app/helpers/-date-base.js
+++ b/ui/app/helpers/-date-base.js
@@ -1,10 +1,15 @@
 import { run } from '@ember/runloop';
 import Helper from '@ember/component/helper';
+import Ember from 'ember';
 
 export default Helper.extend({
   disableInterval: false,
 
   compute(value, { interval }) {
+    if (Ember.testing) {
+      // issues with flaky test, suspect it has to the do with the run loop not being cleared as intended farther down.
+      return;
+    }
     if (this.disableInterval) {
       return;
     }


### PR DESCRIPTION
While testing, I don't believe the setTimeout written into the date-base helper is working as intended for testing. So higher up I check for testing and return, essentially ignoring the interval. 