### PR TITLE
Add PKI Caching Layer

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -379,6 +379,15 @@ func (b *backend) invalidate(ctx context.Context, key string) {
 		} else {
 			b.Logger().Debug("Ignoring invalidation updates for issuer as the PKI migration has yet to complete.")
 		}
+
+		// Now invalidate our issuer cache so we can pick up any updates.
+		b.issuerCache.Invalidate(nil)
+	case strings.HasPrefix(key, keyPrefix):
+		// Now invalidate our key and issuer caches so we can pick up any
+		// updates. We update the issuer cache because we cache issuers'
+		// parsed bundles, which contains key data.
+		b.keyCache.Invalidate(nil)
+		b.issuerCache.Invalidate(nil)
 	}
 }
 

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -177,6 +177,9 @@ func Backend(conf *logical.BackendConfig) *backend {
 	b.pkiStorageVersion.Store(0)
 
 	b.crlBuilder = &crlBuilder{}
+
+	b.keyCache = InitKeyStorageCache()
+
 	return &b
 }
 
@@ -197,6 +200,9 @@ type backend struct {
 
 	// Write lock around issuers and keys.
 	issuersLock sync.RWMutex
+
+	// Issuer caching layer for performance
+	keyCache *keyStorageCache
 }
 
 type (

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -179,6 +179,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 	b.crlBuilder = &crlBuilder{}
 
 	b.keyCache = InitKeyStorageCache()
+	b.issuerCache = InitIssuerStorageCache()
 
 	return &b
 }
@@ -202,7 +203,8 @@ type backend struct {
 	issuersLock sync.RWMutex
 
 	// Issuer caching layer for performance
-	keyCache *keyStorageCache
+	keyCache    *keyStorageCache
+	issuerCache *issuerStorageCache
 }
 
 type (

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -102,40 +102,6 @@ func (sc *storageContext) fetchCAInfo(issuerRef string, usage issuerUsage) (*cer
 	return sc.fetchCAInfoByIssuerId(issuerId, usage)
 }
 
-// fetchCAInfoByIssuerId will fetch the CA info, will return an error if no ca info exists for the given issuerId.
-// This does support the loading using the legacyBundleShimID
-func (sc *storageContext) fetchCAInfoByIssuerId(issuerId issuerID, usage issuerUsage) (*certutil.CAInfoBundle, error) {
-	entry, _, parsedBundle, err := sc.fetchParsedCertBundleByIssuerId(issuerId)
-	if err != nil {
-		switch err.(type) {
-		case errutil.UserError:
-			return nil, err
-		case errutil.InternalError:
-			return nil, err
-		default:
-			return nil, errutil.InternalError{Err: fmt.Sprintf("error fetching CA info: %v", err)}
-		}
-	}
-
-	if err := entry.EnsureUsage(usage); err != nil {
-		return nil, errutil.InternalError{Err: fmt.Sprintf("error while attempting to use issuer %v: %v", issuerId, err)}
-	}
-
-	caInfo := &certutil.CAInfoBundle{
-		ParsedCertBundle:     *parsedBundle,
-		URLs:                 nil,
-		LeafNotAfterBehavior: entry.LeafNotAfterBehavior,
-	}
-
-	entries, err := getURLs(sc.Context, sc.Storage)
-	if err != nil {
-		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch URL information: %v", err)}
-	}
-	caInfo.URLs = entries
-
-	return caInfo, nil
-}
-
 // Allows fetching certificates from the backend; it handles the slightly
 // separate pathing for CRL, and revoked certificates.
 //

--- a/builtin/logical/pki/path_config_urls.go
+++ b/builtin/logical/pki/path_config_urls.go
@@ -139,7 +139,11 @@ func (b *backend) pathWriteURL(ctx context.Context, req *logical.Request, data *
 		}
 	}
 
-	return nil, writeURLs(ctx, req.Storage, entries)
+	// Because we cache the CAInfo bundle, we have to invalidate the issuer
+	// cache here as well.
+	return nil, b.issuerCache.Invalidate(func() error {
+		return writeURLs(ctx, req.Storage, entries)
+	})
 }
 
 const pathConfigURLsHelpSyn = `

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -791,7 +791,7 @@ func (sc *storageContext) fetchParsedCertBundleByIssuerId(id issuerID) (entry *i
 			return nil, nil, nil, err
 		}
 	} else {
-		entry, bundle, parsedBundle, err = sc.Backend.issuerCache.fetchIssuerInfoById(sc.Context, sc.Storage, sc.Backend, id)
+		entry, bundle, parsedBundle, _, err = sc.Backend.issuerCache.fetchIssuerInfoById(sc.Context, sc.Storage, sc.Backend, id)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -190,8 +190,9 @@ func (sc *storageContext) writeKey(key keyEntry) error {
 		return err
 	}
 
-	sc.Backend.keyCache.Invalidate()
-	return sc.Storage.Put(sc.Context, json)
+	return sc.Backend.keyCache.Invalidate(func() error {
+		return sc.Storage.Put(sc.Context, json)
+	})
 }
 
 func (sc *storageContext) deleteKey(id keyID) (bool, error) {
@@ -209,8 +210,9 @@ func (sc *storageContext) deleteKey(id keyID) (bool, error) {
 		}
 	}
 
-	sc.Backend.keyCache.Invalidate()
-	return wasDefault, sc.Storage.Delete(sc.Context, keyPrefix+id.String())
+	return wasDefault, sc.Backend.keyCache.Invalidate(func() error {
+		return sc.Storage.Delete(sc.Context, keyPrefix+id.String())
+	})
 }
 
 func (sc *storageContext) importKey(keyValue string, keyName string, keyType certutil.PrivateKeyType) (*keyEntry, bool, error) {
@@ -447,8 +449,9 @@ func (sc *storageContext) writeIssuer(issuer *issuerEntry) error {
 		return err
 	}
 
-	sc.Backend.issuerCache.Invalidate()
-	return sc.Storage.Put(sc.Context, json)
+	return sc.Backend.issuerCache.Invalidate(func() error {
+		return sc.Storage.Put(sc.Context, json)
+	})
 }
 
 func (sc *storageContext) deleteIssuer(id issuerID) (bool, error) {
@@ -466,8 +469,9 @@ func (sc *storageContext) deleteIssuer(id issuerID) (bool, error) {
 		}
 	}
 
-	sc.Backend.issuerCache.Invalidate()
-	return wasDefault, sc.Storage.Delete(sc.Context, issuerPrefix+id.String())
+	return wasDefault, sc.Backend.issuerCache.Invalidate(func() error {
+		return sc.Storage.Delete(sc.Context, issuerPrefix+id.String())
+	})
 }
 
 func (sc *storageContext) importIssuer(certValue string, issuerName string) (*issuerEntry, bool, error) {

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -776,28 +776,7 @@ func (sc *storageContext) fetchCertBundleByIssuerId(id issuerID, loadKey bool) (
 		return issuer, bundle, err
 	}
 
-	issuer, err := sc.fetchIssuerById(id)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var bundle certutil.CertBundle
-	bundle.Certificate = issuer.Certificate
-	bundle.CAChain = issuer.CAChain
-	bundle.SerialNumber = issuer.SerialNumber
-
-	// Fetch the key if it exists. Sometimes we don't need the key immediately.
-	if loadKey && issuer.KeyID != keyID("") {
-		key, err := sc.fetchKeyById(issuer.KeyID)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		bundle.PrivateKeyType = key.PrivateKeyType
-		bundle.PrivateKey = key.PrivateKey
-	}
-
-	return issuer, &bundle, nil
+	return sc.Backend.issuerCache.fetchCertBundleByIssuerId(sc.Context, sc.Storage, sc.Backend, id, loadKey)
 }
 
 func (sc *storageContext) writeCaBundle(caBundle *certutil.CertBundle, issuerName string, keyName string) (*issuerEntry, *keyEntry, error) {

--- a/builtin/logical/pki/storage_cache_issuers.go
+++ b/builtin/logical/pki/storage_cache_issuers.go
@@ -37,11 +37,17 @@ func InitIssuerStorageCache() *issuerStorageCache {
 	return &ret
 }
 
-func (c *issuerStorageCache) Invalidate() {
+func (c *issuerStorageCache) Invalidate(op func() error) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
 	c.invalid = true
+
+	if op != nil {
+		return op()
+	}
+
+	return nil
 }
 
 func (c *issuerStorageCache) reloadOnInvalidation(ctx context.Context, s logical.Storage) error {

--- a/builtin/logical/pki/storage_cache_issuers.go
+++ b/builtin/logical/pki/storage_cache_issuers.go
@@ -1,0 +1,253 @@
+package pki
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+type issuerStorageCache struct {
+	lock      sync.RWMutex
+	invalid   bool
+	idSet     map[issuerID]bool
+	nameIDMap map[string]issuerID
+	entries   *lru.Cache
+	bundles   *lru.Cache
+}
+
+func InitIssuerStorageCache() *issuerStorageCache {
+	var ret issuerStorageCache
+	ret.invalid = true
+
+	var err error
+
+	ret.entries, err = lru.New(32)
+	if err != nil {
+		panic(err)
+	}
+
+	ret.bundles, err = lru.New(32)
+	if err != nil {
+		panic(err)
+	}
+
+	return &ret
+}
+
+func (c *issuerStorageCache) Invalidate() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.invalid = true
+}
+
+func (c *issuerStorageCache) reloadOnInvalidation(ctx context.Context, s logical.Storage) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if !c.invalid {
+		return nil
+	}
+
+	c.idSet = make(map[issuerID]bool)
+	c.nameIDMap = make(map[string]issuerID)
+
+	// Clear the LRU; this is necessary as some entries/bundles might've been deleted.
+	c.entries.Purge()
+	c.bundles.Purge()
+
+	// List all issuers which exist.
+	strList, err := s.List(ctx, issuerPrefix)
+	if err != nil {
+		return err
+	}
+
+	// Reset the issuer and name caches, populating the LRU.
+	for _, issuerIdStr := range strList {
+		issuerId := issuerID(issuerIdStr)
+
+		// Fetch the specified issuer; it might've been deleted since the
+		// list and thus returns an empty entry.
+		rawEntry, err := s.Get(ctx, issuerPrefix+issuerIdStr)
+		if err != nil {
+			return err
+		}
+		if rawEntry == nil {
+			continue
+		}
+
+		var entry issuerEntry
+		if err := rawEntry.DecodeJSON(&entry); err != nil {
+			return err
+		}
+
+		c.idSet[issuerId] = true
+		if len(entry.Name) > 0 {
+			c.nameIDMap[entry.Name] = issuerId
+		}
+
+		// Greedily add this entry to the LRU. We don't add bundles here.
+		c.entries.Add(issuerId, &entry)
+	}
+
+	c.invalid = false
+	return nil
+}
+
+func (c *issuerStorageCache) listIssuers(ctx context.Context, s logical.Storage) ([]issuerID, error) {
+	needUnlock := true
+	c.lock.RLock()
+	defer func() {
+		if needUnlock {
+			c.lock.RUnlock()
+		}
+	}()
+
+	if c.invalid {
+		// Release our read lock so we can race to grab a write lock.
+		c.lock.RUnlock()
+		needUnlock = false
+
+		if err := c.reloadOnInvalidation(ctx, s); err != nil {
+			return nil, err
+		}
+
+		// Now re-read-lock.
+		c.lock.RLock()
+		needUnlock = true
+	}
+
+	// Now we can service the request as expected.
+	result := make([]issuerID, 0, len(c.idSet))
+	for entry := range c.idSet {
+		result = append(result, entry)
+	}
+
+	return result, nil
+}
+
+func (c *issuerStorageCache) issuerWithID(ctx context.Context, s logical.Storage, id issuerID) (bool, error) {
+	needUnlock := true
+	c.lock.RLock()
+	defer func() {
+		if needUnlock {
+			c.lock.RUnlock()
+		}
+	}()
+
+	if c.invalid {
+		// Release our read lock so we can race to grab a write lock.
+		c.lock.RUnlock()
+		needUnlock = false
+
+		if err := c.reloadOnInvalidation(ctx, s); err != nil {
+			return false, err
+		}
+
+		// Now re-read-lock.
+		c.lock.RLock()
+		needUnlock = true
+	}
+
+	present, ok := c.idSet[id]
+	return ok && present, nil
+}
+
+func (c *issuerStorageCache) issuerWithName(ctx context.Context, s logical.Storage, name string) (issuerID, error) {
+	needUnlock := true
+	c.lock.RLock()
+	defer func() {
+		if needUnlock {
+			c.lock.RUnlock()
+		}
+	}()
+
+	if c.invalid {
+		// Release our read lock so we can race to grab a write lock.
+		c.lock.RUnlock()
+		needUnlock = false
+
+		if err := c.reloadOnInvalidation(ctx, s); err != nil {
+			return IssuerRefNotFound, err
+		}
+
+		// Now re-read-lock.
+		c.lock.RLock()
+		needUnlock = true
+	}
+
+	issuerId, ok := c.nameIDMap[name]
+	if !ok {
+		return IssuerRefNotFound, fmt.Errorf("unable to find PKI issuer for reference: %v", name)
+	}
+
+	return issuerId, nil
+}
+
+func (c *issuerStorageCache) fetchIssuerById(ctx context.Context, s logical.Storage, issuerId issuerID) (*issuerEntry, error) {
+	needUnlock := true
+
+	c.lock.RLock()
+	defer func() {
+		if needUnlock {
+			c.lock.RUnlock()
+		}
+	}()
+
+	if c.invalid {
+		// Release our read lock so we can race to grab a write lock.
+		c.lock.RUnlock()
+		needUnlock = false
+
+		if err := c.reloadOnInvalidation(ctx, s); err != nil {
+			return nil, err
+		}
+
+		// Now re-read-lock.
+		c.lock.RLock()
+		needUnlock = true
+	}
+
+	// Now we can service the request as expected.
+	if haveId, ok := c.idSet[issuerId]; !ok || !haveId {
+		return nil, fmt.Errorf("pki issuer id %v does not exist", issuerId)
+	}
+
+	if entry, ok := c.entries.Get(issuerId); ok && entry != nil {
+		e := entry.(*issuerEntry)
+		return e, nil
+	}
+
+	// Otherwise, if it doesn't exist, fetch it and add it to the LRU. We
+	// once again have to upgrade our read lock to a write lock.
+	c.lock.RUnlock()
+	needUnlock = false
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	rawEntry, err := s.Get(ctx, issuerPrefix+issuerId.String())
+	if err != nil {
+		return nil, err
+	}
+	if rawEntry == nil {
+		return nil, fmt.Errorf("pki issuer id %s does not exist", issuerId)
+	}
+
+	var entry issuerEntry
+	if err := rawEntry.DecodeJSON(&entry); err != nil {
+		return nil, err
+	}
+
+	c.idSet[issuerId] = true
+	if len(entry.Name) > 0 {
+		c.nameIDMap[entry.Name] = issuerId
+	}
+
+	// Add this entry to the LRU.
+	c.entries.Add(issuerId, &entry)
+	copiedEntry := entry
+	return &copiedEntry, nil
+}

--- a/builtin/logical/pki/storage_cache_issuers.go
+++ b/builtin/logical/pki/storage_cache_issuers.go
@@ -6,16 +6,18 @@ import (
 	"sync"
 
 	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
 type issuerStorageCache struct {
-	lock      sync.RWMutex
-	invalid   bool
-	idSet     map[issuerID]bool
-	nameIDMap map[string]issuerID
-	entries   *lru.Cache
-	bundles   *lru.Cache
+	lock          sync.RWMutex
+	invalid       bool
+	idSet         map[issuerID]bool
+	nameIDMap     map[string]issuerID
+	entries       *lru.Cache
+	bundles       *lru.Cache
+	parsedBundles *lru.Cache
 }
 
 func InitIssuerStorageCache() *issuerStorageCache {
@@ -30,6 +32,11 @@ func InitIssuerStorageCache() *issuerStorageCache {
 	}
 
 	ret.bundles, err = lru.New(32)
+	if err != nil {
+		panic(err)
+	}
+
+	ret.parsedBundles, err = lru.New(32)
 	if err != nil {
 		panic(err)
 	}
@@ -64,6 +71,7 @@ func (c *issuerStorageCache) reloadOnInvalidation(ctx context.Context, s logical
 	// Clear the LRU; this is necessary as some entries/bundles might've been deleted.
 	c.entries.Purge()
 	c.bundles.Purge()
+	c.parsedBundles.Purge()
 
 	// List all issuers which exist.
 	strList, err := s.List(ctx, issuerPrefix)
@@ -193,7 +201,19 @@ func (c *issuerStorageCache) issuerWithName(ctx context.Context, s logical.Stora
 	return issuerId, nil
 }
 
-func (c *issuerStorageCache) fetchIssuerById(ctx context.Context, s logical.Storage, issuerId issuerID) (*issuerEntry, error) {
+func (c *issuerStorageCache) fetchIssuerInfoById(ctx context.Context, s logical.Storage, b *backend, issuerId issuerID) (*issuerEntry, *certutil.CertBundle, *certutil.ParsedCertBundle, error) {
+	// This method is more complex than the keys counterpart. Here, we handle
+	// the logic for all three types of calls:
+	//
+	// 1. Issuer entry only,
+	// 2. CertBundle as well,
+	// 3. Upgrading all the way to a ParsedCertBundle.
+	//
+	// When present, we use the keyStorageCache to give us a version of the
+	// bundle with the key pre-loaded and cache this, rather than potentially
+	// storing a half-built bundle. This allows us to remove the private key
+	// bits if they're not desired, rather than attempting to update the LRU
+	// cache entry with new key material.
 	needUnlock := true
 
 	c.lock.RLock()
@@ -209,7 +229,7 @@ func (c *issuerStorageCache) fetchIssuerById(ctx context.Context, s logical.Stor
 		needUnlock = false
 
 		if err := c.reloadOnInvalidation(ctx, s); err != nil {
-			return nil, err
+			return nil, nil, nil, err
 		}
 
 		// Now re-read-lock.
@@ -219,41 +239,120 @@ func (c *issuerStorageCache) fetchIssuerById(ctx context.Context, s logical.Stor
 
 	// Now we can service the request as expected.
 	if haveId, ok := c.idSet[issuerId]; !ok || !haveId {
-		return nil, fmt.Errorf("pki issuer id %v does not exist", issuerId)
+		return nil, nil, nil, fmt.Errorf("pki issuer id %v does not exist", issuerId)
 	}
 
-	if entry, ok := c.entries.Get(issuerId); ok && entry != nil {
+	entry, entryOk := c.entries.Get(issuerId)
+	if b == nil && entryOk && entry != nil {
+		// We can exit fast if we don't need the bundle. This only occurs when
+		// the keyStorageCache value is nil.
 		e := entry.(*issuerEntry)
-		return e, nil
+		return e, nil, nil, nil
 	}
 
-	// Otherwise, if it doesn't exist, fetch it and add it to the LRU. We
-	// once again have to upgrade our read lock to a write lock.
-	c.lock.RUnlock()
-	needUnlock = false
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	bundle, bundleOk := c.bundles.Get(issuerId)
+	parsedBundle, parsedOk := c.parsedBundles.Get(issuerId)
+	if bundleOk && bundle != nil && parsedOk && parsedBundle != nil {
+		// If everything was loaded from cache, we're good.
+		e := entry.(*issuerEntry)
+		n := bundle.(*certutil.CertBundle)
+		p := parsedBundle.(*certutil.ParsedCertBundle)
+		return e, n, p, nil
+	}
 
-	rawEntry, err := s.Get(ctx, issuerPrefix+issuerId.String())
+	if !entryOk || entry == nil {
+		// Otherwise, if the entry doesn't exist, fetch it and add it to the
+		// LRU. We once again have to upgrade our read lock to a write lock.
+		c.lock.RUnlock()
+		needUnlock = false
+		c.lock.Lock()
+		defer c.lock.Unlock()
+
+		rawEntry, err := s.Get(ctx, issuerPrefix+issuerId.String())
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if rawEntry == nil {
+			return nil, nil, nil, fmt.Errorf("pki issuer id %s does not exist", issuerId)
+		}
+
+		var storedEntry issuerEntry
+		if err := rawEntry.DecodeJSON(&storedEntry); err != nil {
+			return nil, nil, nil, err
+		}
+
+		c.idSet[issuerId] = true
+		if len(storedEntry.Name) > 0 {
+			c.nameIDMap[storedEntry.Name] = issuerId
+		}
+
+		// Add this entry to the LRU.
+		c.entries.Add(issuerId, &storedEntry)
+		copiedEntry := storedEntry
+		entry = &copiedEntry
+	}
+
+	e := entry.(*issuerEntry)
+	// If we don't have a key storage cache, don't bother building the cert
+	// bundle entries.
+	if b == nil {
+		return e, nil, nil, nil
+	}
+
+	// Finally, we can finish building the cert bundle entries. Since we
+	// either:
+	//
+	// 1. Missed a key entry and thus needed to invalidate our LRU copies,
+	// 2. Missed either cert/parse copies,
+	//
+	// we always have to do this from scratch.
+	var rawBundle certutil.CertBundle
+	rawBundle.Certificate = e.Certificate
+	rawBundle.CAChain = e.CAChain
+	rawBundle.SerialNumber = e.SerialNumber
+	if e.KeyID != keyID("") {
+		keyEntry, err := b.keyCache.fetchKeyById(ctx, s, e.KeyID)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		rawBundle.PrivateKeyType = keyEntry.PrivateKeyType
+		rawBundle.PrivateKey = keyEntry.PrivateKey
+	}
+
+	c.bundles.Add(issuerId, &rawBundle)
+	copiedBundle := rawBundle
+	bundle = &copiedBundle
+	n := bundle.(*certutil.CertBundle)
+
+	rawParsedBundle, err := parseCABundle(ctx, b, n)
 	if err != nil {
-		return nil, err
-	}
-	if rawEntry == nil {
-		return nil, fmt.Errorf("pki issuer id %s does not exist", issuerId)
+		return nil, nil, nil, err
 	}
 
-	var entry issuerEntry
-	if err := rawEntry.DecodeJSON(&entry); err != nil {
-		return nil, err
+	c.parsedBundles.Add(issuerId, rawParsedBundle)
+	copiedParsedBundle := *rawParsedBundle
+	parsedBundle = &copiedParsedBundle
+
+	p := parsedBundle.(*certutil.ParsedCertBundle)
+	return e, n, p, nil
+}
+
+func (c *issuerStorageCache) fetchIssuerById(ctx context.Context, s logical.Storage, issuerId issuerID) (*issuerEntry, error) {
+	entry, _, _, err := c.fetchIssuerInfoById(ctx, s, nil, issuerId)
+	return entry, err
+}
+
+func (c *issuerStorageCache) fetchCertBundleByIssuerId(ctx context.Context, s logical.Storage, b *backend, issuerId issuerID, loadKey bool) (*issuerEntry, *certutil.CertBundle, error) {
+	entry, bundle, _, err := c.fetchIssuerInfoById(ctx, s, b, issuerId)
+
+	if err != nil && !loadKey {
+		bundle.PrivateKey = ""
 	}
 
-	c.idSet[issuerId] = true
-	if len(entry.Name) > 0 {
-		c.nameIDMap[entry.Name] = issuerId
-	}
+	return entry, bundle, err
+}
 
-	// Add this entry to the LRU.
-	c.entries.Add(issuerId, &entry)
-	copiedEntry := entry
-	return &copiedEntry, nil
+func (c *issuerStorageCache) fetchParsedBundleByIssuerId(ctx context.Context, s logical.Storage, b *backend, issuerId issuerID, loadKey bool) (*issuerEntry, *certutil.CertBundle, *certutil.ParsedCertBundle, error) {
+	return c.fetchIssuerInfoById(ctx, s, b, issuerId)
 }

--- a/builtin/logical/pki/storage_cache_keys.go
+++ b/builtin/logical/pki/storage_cache_keys.go
@@ -30,11 +30,17 @@ func InitKeyStorageCache() *keyStorageCache {
 	return &ret
 }
 
-func (c *keyStorageCache) Invalidate() {
+func (c *keyStorageCache) Invalidate(op func() error) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
 	c.invalid = true
+
+	if op != nil {
+		return op()
+	}
+
+	return nil
 }
 
 func (c *keyStorageCache) reloadOnInvalidation(ctx context.Context, s logical.Storage) error {

--- a/builtin/logical/pki/storage_cache_keys.go
+++ b/builtin/logical/pki/storage_cache_keys.go
@@ -1,0 +1,245 @@
+package pki
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+type keyStorageCache struct {
+	lock      sync.RWMutex
+	invalid   bool
+	idSet     map[keyID]bool
+	nameIDMap map[string]keyID
+	entries   *lru.Cache
+}
+
+func InitKeyStorageCache() *keyStorageCache {
+	var ret keyStorageCache
+	ret.invalid = true
+
+	var err error
+	ret.entries, err = lru.New(32)
+	if err != nil {
+		panic(err)
+	}
+
+	return &ret
+}
+
+func (c *keyStorageCache) Invalidate() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.invalid = true
+}
+
+func (c *keyStorageCache) reloadOnInvalidation(ctx context.Context, s logical.Storage) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if !c.invalid {
+		return nil
+	}
+
+	c.idSet = make(map[keyID]bool)
+	c.nameIDMap = make(map[string]keyID)
+
+	// Clear the LRU; this is necessary as some entries might've been deleted.
+	c.entries.Purge()
+
+	// List all keys which exist.
+	strList, err := s.List(ctx, keyPrefix)
+	if err != nil {
+		return err
+	}
+
+	// Reset the key and name caches, populating the LRU.
+	for _, keyIdStr := range strList {
+		keyId := keyID(keyIdStr)
+
+		// Fetch the specified key; it might've been deleted since the
+		// list and thus returns an empty entry.
+		rawEntry, err := s.Get(ctx, keyPrefix+keyIdStr)
+		if err != nil {
+			return err
+		}
+		if rawEntry == nil {
+			continue
+		}
+
+		var entry keyEntry
+		if err := rawEntry.DecodeJSON(&entry); err != nil {
+			return err
+		}
+
+		c.idSet[keyId] = true
+		if len(entry.Name) > 0 {
+			c.nameIDMap[entry.Name] = keyId
+		}
+
+		// Greedily add this entry to the LRU.
+		c.entries.Add(keyId, &entry)
+	}
+
+	c.invalid = false
+	return nil
+}
+
+func (c *keyStorageCache) listKeys(ctx context.Context, s logical.Storage) ([]keyID, error) {
+	needUnlock := true
+	c.lock.RLock()
+	defer func() {
+		if needUnlock {
+			c.lock.RUnlock()
+		}
+	}()
+
+	if c.invalid {
+		// Release our read lock so we can race to grab a write lock.
+		c.lock.RUnlock()
+		needUnlock = false
+
+		if err := c.reloadOnInvalidation(ctx, s); err != nil {
+			return nil, err
+		}
+
+		// Now re-read-lock.
+		c.lock.RLock()
+		needUnlock = true
+	}
+
+	// Now we can service the request as expected.
+	result := make([]keyID, 0, len(c.idSet))
+	for entry := range c.idSet {
+		result = append(result, entry)
+	}
+
+	return result, nil
+}
+
+func (c *keyStorageCache) keyWithID(ctx context.Context, s logical.Storage, id keyID) (bool, error) {
+	needUnlock := true
+	c.lock.RLock()
+	defer func() {
+		if needUnlock {
+			c.lock.RUnlock()
+		}
+	}()
+
+	if c.invalid {
+		// Release our read lock so we can race to grab a write lock.
+		c.lock.RUnlock()
+		needUnlock = false
+
+		if err := c.reloadOnInvalidation(ctx, s); err != nil {
+			return false, err
+		}
+
+		// Now re-read-lock.
+		c.lock.RLock()
+		needUnlock = true
+	}
+
+	present, ok := c.idSet[id]
+	return ok && present, nil
+}
+
+func (c *keyStorageCache) keyWithName(ctx context.Context, s logical.Storage, name string) (keyID, error) {
+	needUnlock := true
+	c.lock.RLock()
+	defer func() {
+		if needUnlock {
+			c.lock.RUnlock()
+		}
+	}()
+
+	if c.invalid {
+		// Release our read lock so we can race to grab a write lock.
+		c.lock.RUnlock()
+		needUnlock = false
+
+		if err := c.reloadOnInvalidation(ctx, s); err != nil {
+			return KeyRefNotFound, err
+		}
+
+		// Now re-read-lock.
+		c.lock.RLock()
+		needUnlock = true
+	}
+
+	keyId, ok := c.nameIDMap[name]
+	if !ok || len(keyId) == 0 {
+		return KeyRefNotFound, fmt.Errorf("unable to find PKI key for reference: %v", name)
+	}
+
+	return keyId, nil
+}
+
+func (c *keyStorageCache) fetchKeyById(ctx context.Context, s logical.Storage, keyId keyID) (*keyEntry, error) {
+	needUnlock := true
+
+	c.lock.RLock()
+	defer func() {
+		if needUnlock {
+			c.lock.RUnlock()
+		}
+	}()
+
+	if c.invalid {
+		// Release our read lock so we can race to grab a write lock.
+		c.lock.RUnlock()
+		needUnlock = false
+
+		if err := c.reloadOnInvalidation(ctx, s); err != nil {
+			return nil, err
+		}
+
+		// Now re-read-lock.
+		c.lock.RLock()
+		needUnlock = true
+	}
+
+	// Now we can service the request as expected.
+	if haveId, ok := c.idSet[keyId]; !ok || !haveId {
+		return nil, fmt.Errorf("pki key id %v does not exist", keyId)
+	}
+
+	if entry, ok := c.entries.Get(keyId); ok && entry != nil {
+		e := entry.(*keyEntry)
+		return e, nil
+	}
+
+	// Otherwise, if it doesn't exist, fetch it and add it to the LRU. We
+	// once again have to upgrade our read lock to a write lock.
+	c.lock.RUnlock()
+	needUnlock = false
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	rawEntry, err := s.Get(ctx, keyPrefix+keyId.String())
+	if err != nil {
+		return nil, err
+	}
+	if rawEntry == nil {
+		return nil, fmt.Errorf("pki key id %s does not exist", keyId)
+	}
+
+	var entry keyEntry
+	if err := rawEntry.DecodeJSON(&entry); err != nil {
+		return nil, err
+	}
+
+	c.idSet[keyId] = true
+	if len(entry.Name) > 0 {
+		c.nameIDMap[entry.Name] = keyId
+	}
+
+	// Add this entry to the LRU.
+	c.entries.Add(keyId, &entry)
+	copiedEntry := entry
+	return &copiedEntry, nil
+}


### PR DESCRIPTION
This PR adds a PKI caching layer.

We cache the following things: 

 - Key Entries, IDs, and Names
 - Issuer Entries, IDs, and Names
 - Issuer Cert Bundles, Parsed Cert Bundles, and CAInfoBundles

The latter allows us to fast-path the signing process in the optimal case, avoiding all storage reads to load the issuer. Previously we'd have to:

 - Resolve the reference to an ID
 - Read the entry
 - Parse the entry into a bundle
 - Parse the bundle into a parsed bundle
 - Fetch the URLs
 - Build the CAInfoBundle

Now that's all handled as part of two calls (the one for resolution remains and one for fetching the info bundle) that are both cached in a LRU cache for the optimal case.

---

Using my `raftvault` script and a `benchmark-vault` invocation, I get numbers like:

Vault 1.10.4

```
op         count    mean        95th%       99th%       successRatio
pki issue  1131860  2.760386ms  5.614354ms  7.650496ms  100.00%
```

Vault 1.11.0-rc1

```
op         count    mean        95th%       99th%       successRatio
pki issue  962404  3.258479ms  6.803232ms  9.422979ms  100.00%
```

Vault 1.12 Main

```
op         count    mean        95th%       99th%       successRatio
pki issue  997797  3.147056ms  6.429387ms  8.719978ms  100.00%
```

This Branch

```
op         count    mean        95th%       99th%       successRatio
pki issue  1218442  2.547024ms  5.120058ms  6.941694ms  100.00%
```

```
$ source raftvault && go build . && time ./benchmark-vault -workers=32 -duration=100s -vault_addr=$VAULT_ADDR -vault_token=$VAULT_TOKEN -pki_config_json=configs/pki/all-nostore-ec-256.json -pki_setup_delay=20ms -pct_pki_issue=100
```

This gives us a net ~7% improvement over 1.10 (which lacked multiple issuers but did incur parsing overhead) and a ~22-27% over 1.11.0-rc1 (with multiple storage calls and parsing overhead). Numbers may vary.