### PR TITLE
Add database plugin metrics around connections

### DIFF
--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -68,7 +68,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		[]metricsutil.Label{},
 		b.collectPluginInstanceGaugeValues,
 		metrics.Default(),
-		configutil.UsageGaugeDefaultPeriod, // TODO: we seem to have no way to access the actual configured values for these?
+		configutil.UsageGaugeDefaultPeriod, // TODO: add config settings for these, or add plumbing to the main config settings
 		configutil.MaximumGaugeCardinalityDefault,
 		b.logger)
 	if err != nil {

--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -172,6 +172,9 @@ type databaseBackend struct {
 	// concurrent requests are not modifying the same role and possibly causing
 	// issues with the priority queue.
 	roleLocks []*locksutil.LockEntry
+
+	// the running gauge collection process
+	gaugeCollectionProcess *metricsutil.GaugeCollectionProcess
 }
 
 func (b *databaseBackend) connGet(name string) *dbPluginInstance {
@@ -410,6 +413,9 @@ func (b *databaseBackend) clean(_ context.Context) {
 	connections := b.connClear()
 	for _, db := range connections {
 		go db.Close()
+	}
+	if b.gaugeCollectionProcess != nil {
+		b.gaugeCollectionProcess.Stop()
 	}
 }
 

--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -62,7 +62,8 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	go b.initQueue(b.queueCtx, conf, conf.System.ReplicationState())
 
 	// collect metrics on number of plugin instances
-	pluginInstanceGaugeProcess, err := metricsutil.NewGaugeCollectionProcess(
+	var err error
+	b.gaugeCollectionProcess, err = metricsutil.NewGaugeCollectionProcess(
 		[]string{"secrets", "database", "backend", "pluginInstances", "count"},
 		[]metricsutil.Label{},
 		b.collectPluginInstanceGaugeValues,
@@ -73,7 +74,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	if err != nil {
 		return nil, err
 	}
-	go pluginInstanceGaugeProcess.Run()
+	go b.gaugeCollectionProcess.Run()
 	return b, nil
 }
 

--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -1461,6 +1461,87 @@ func TestBackend_ConnectionURL_redacted(t *testing.T) {
 	}
 }
 
+type hangingPlugin struct{}
+
+func (h hangingPlugin) Initialize(_ context.Context, req v5.InitializeRequest) (v5.InitializeResponse, error) {
+	return v5.InitializeResponse{
+		Config: req.Config,
+	}, nil
+}
+
+func (h hangingPlugin) NewUser(_ context.Context, _ v5.NewUserRequest) (v5.NewUserResponse, error) {
+	return v5.NewUserResponse{}, nil
+}
+
+func (h hangingPlugin) UpdateUser(_ context.Context, _ v5.UpdateUserRequest) (v5.UpdateUserResponse, error) {
+	return v5.UpdateUserResponse{}, nil
+}
+
+func (h hangingPlugin) DeleteUser(_ context.Context, _ v5.DeleteUserRequest) (v5.DeleteUserResponse, error) {
+	return v5.DeleteUserResponse{}, nil
+}
+
+func (h hangingPlugin) Type() (string, error) {
+	return "hanging", nil
+}
+
+func (h hangingPlugin) Close() error {
+	time.Sleep(1000 * time.Second)
+	return nil
+}
+
+var _ v5.Database = (*hangingPlugin)(nil)
+
+func TestBackend_PluginMain_Hanging(t *testing.T) {
+	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+		return
+	}
+	v5.Serve(&hangingPlugin{})
+}
+
+func TestBackend_Closes_Cleanly_Even_If_Plugin_Hangs(t *testing.T) {
+	cluster, sys := getCluster(t)
+	vault.TestAddTestPlugin(t, cluster.Cores[0].Core, "hanging-plugin", consts.PluginTypeDatabase, "TestBackend_PluginMain_Hanging", []string{}, "")
+	t.Cleanup(cluster.Cleanup)
+
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+	config.System = sys
+
+	b, err := Factory(context.Background(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Configure a connection
+	data := map[string]interface{}{
+		"connection_url": "doesn't matter",
+		"plugin_name":    "hanging-plugin",
+		"allowed_roles":  []string{"plugin-role-test"},
+	}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/hang",
+		Storage:   config.StorageView,
+		Data:      data,
+	}
+	_, err = b.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	timeout := time.NewTimer(750 * time.Millisecond)
+	done := make(chan bool)
+	go func() {
+		b.Cleanup(context.Background())
+		done <- true
+	}()
+	select {
+	case <-timeout.C:
+		t.Error("Hanging plugin caused Close() to take longer than 750ms")
+	case <-done:
+	}
+}
+
 func testCredsExist(t *testing.T, resp *logical.Response, connURL string) bool {
 	t.Helper()
 	var d struct {

--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -1499,7 +1499,9 @@ func TestBackend_PluginMain_Hanging(t *testing.T) {
 	v5.Serve(&hangingPlugin{})
 }
 
-func TestBackend_Closes_Cleanly_Even_If_Plugin_Hangs(t *testing.T) {
+func TestBackend_AsyncClose(t *testing.T) {
+	// Test that having a plugin that takes a LONG time to close will not cause the cleanup function to take
+	// longer than 750ms.
 	cluster, sys := getCluster(t)
 	vault.TestAddTestPlugin(t, cluster.Cores[0].Core, "hanging-plugin", consts.PluginTypeDatabase, "TestBackend_PluginMain_Hanging", []string{}, "")
 	t.Cleanup(cluster.Cleanup)

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -1379,6 +1379,7 @@ func setupMockDB(b *databaseBackend) *mockNewDatabase {
 	mockDB := &mockNewDatabase{}
 	mockDB.On("Initialize", mock.Anything, mock.Anything).Return(v5.InitializeResponse{}, nil)
 	mockDB.On("Close").Return(nil)
+	mockDB.On("Type").Return("mock", nil)
 	dbw := databaseVersionWrapper{
 		v5: mockDB,
 	}

--- a/helper/metricsutil/gauge_process_test.go
+++ b/helper/metricsutil/gauge_process_test.go
@@ -147,10 +147,13 @@ func TestGauge_StartDelay(t *testing.T) {
 	sink := BlackholeSink()
 	sink.GaugeInterval = 2 * time.Hour
 
-	p, err := sink.newGaugeCollectionProcessWithClock(
+	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
 		[]Label{{"gauge", "test"}},
 		c.EmptyCollectionFunction,
+		sink,
+		sink.GaugeInterval,
+		sink.MaxGaugeCardinality,
 		log.Default(),
 		s,
 	)
@@ -209,10 +212,13 @@ func TestGauge_StoppedDuringInitialDelay(t *testing.T) {
 	sink := BlackholeSink()
 	sink.GaugeInterval = 2 * time.Hour
 
-	p, err := sink.newGaugeCollectionProcessWithClock(
+	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
 		[]Label{{"gauge", "test"}},
 		c.EmptyCollectionFunction,
+		sink,
+		sink.GaugeInterval,
+		sink.MaxGaugeCardinality,
 		log.Default(),
 		s,
 	)
@@ -235,10 +241,13 @@ func TestGauge_StoppedAfterInitialDelay(t *testing.T) {
 	sink := BlackholeSink()
 	sink.GaugeInterval = 2 * time.Hour
 
-	p, err := sink.newGaugeCollectionProcessWithClock(
+	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
 		[]Label{{"gauge", "test"}},
 		c.EmptyCollectionFunction,
+		sink,
+		sink.GaugeInterval,
+		sink.MaxGaugeCardinality,
 		log.Default(),
 		s,
 	)
@@ -274,10 +283,13 @@ func TestGauge_Backoff(t *testing.T) {
 		return []GaugeLabelValues{}, nil
 	}
 
-	p, err := sink.newGaugeCollectionProcessWithClock(
+	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
 		[]Label{{"gauge", "test"}},
 		f,
+		sink,
+		sink.GaugeInterval,
+		sink.MaxGaugeCardinality,
 		log.Default(),
 		s,
 	)
@@ -300,10 +312,13 @@ func TestGauge_RestartTimer(t *testing.T) {
 	sink := BlackholeSink()
 	sink.GaugeInterval = 2 * time.Hour
 
-	p, err := sink.newGaugeCollectionProcessWithClock(
+	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
 		[]Label{{"gauge", "test"}},
 		c.EmptyCollectionFunction,
+		sink,
+		sink.GaugeInterval,
+		sink.MaxGaugeCardinality,
 		log.Default(),
 		s,
 	)
@@ -370,10 +385,13 @@ func TestGauge_InterruptedStreaming(t *testing.T) {
 	sink.MaxGaugeCardinality = 500
 	sink.GaugeInterval = 2 * time.Hour
 
-	p, err := sink.newGaugeCollectionProcessWithClock(
+	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
 		[]Label{{"gauge", "test"}},
 		nil, // shouldn't be called
+		sink,
+		sink.GaugeInterval,
+		sink.MaxGaugeCardinality,
 		log.Default(),
 		s,
 	)
@@ -445,10 +463,13 @@ func TestGauge_MaximumMeasurements(t *testing.T) {
 
 	// Advance time by 0.5% of duration
 	advance := time.Duration(int(0.005 * float32(sink.GaugeInterval)))
-	p, err := sink.newGaugeCollectionProcessWithClock(
+	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
 		[]Label{{"gauge", "test"}},
 		c.makeFunctionForValues(values, s, advance),
+		sink,
+		sink.GaugeInterval,
+		sink.MaxGaugeCardinality,
 		log.Default(),
 		s,
 	)
@@ -524,10 +545,13 @@ func TestGauge_MeasurementError(t *testing.T) {
 		return values, errors.New("test error")
 	}
 
-	p, err := sink.newGaugeCollectionProcessWithClock(
+	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
 		[]Label{{"gauge", "test"}},
 		f,
+		sink,
+		sink.GaugeInterval,
+		sink.MaxGaugeCardinality,
 		log.Default(),
 		s,
 	)

--- a/helper/metricsutil/wrapped_metrics.go
+++ b/helper/metricsutil/wrapped_metrics.go
@@ -49,6 +49,8 @@ type Metrics interface {
 
 var _ Metrics = &ClusterMetricSink{}
 
+// SinkWrapper implements `metricsutil.Metrics` using an instance of
+// armon/go-metrics `MetricSink` as the underlying implementation.
 type SinkWrapper struct {
 	metrics.MetricSink
 }

--- a/helper/metricsutil/wrapped_metrics.go
+++ b/helper/metricsutil/wrapped_metrics.go
@@ -5,7 +5,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	metrics "github.com/armon/go-metrics"
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/vault/helper/namespace"
 )
 
@@ -48,6 +48,23 @@ type Metrics interface {
 }
 
 var _ Metrics = &ClusterMetricSink{}
+
+type SinkWrapper struct {
+	metrics.MetricSink
+}
+
+func (s SinkWrapper) AddDurationWithLabels(key []string, d time.Duration, labels []Label) {
+	val := float32(d) / float32(time.Millisecond)
+	s.MetricSink.AddSampleWithLabels(key, val, labels)
+}
+
+func (s SinkWrapper) MeasureSinceWithLabels(key []string, start time.Time, labels []Label) {
+	elapsed := time.Now().Sub(start)
+	val := float32(elapsed) / float32(time.Millisecond)
+	s.MetricSink.AddSampleWithLabels(key, val, labels)
+}
+
+var _ Metrics = SinkWrapper{}
 
 // Convenience alias
 type Label = metrics.Label


### PR DESCRIPTION
This is a replacement for #15923 that takes into account recent lock
cleanup.

I went ahead and added back in the hanging plugin test, which I meant to
add in #15944 but forgot.

I tested this by spinning up a statsd sink in the tests and verifying I
got a stream of metrics:

```
$ nc -u -l 8125 | grep backend
test.swenson-Q9Q0L72D39.secrets.database.backend.connections.count.pgx.5.:1.000000|g
test.swenson-Q9Q0L72D39.secrets.database.backend.connections.count.pgx.5.:0.000000|g
test.swenson-Q9Q0L72D39.secrets.database.backend.connections.count.pgx.5.:1.000000|g
test.swenson-Q9Q0L72D39.secrets.database.backend.connections.count.pgx.5.:0.000000|g
```