### PR TITLE
Start of implementation of the plumbing for role resolution logic on auth mounts

### DIFF
--- a/builtin/credential/approle/path_login.go
+++ b/builtin/credential/approle/path_login.go
@@ -75,21 +75,9 @@ func (b *backend) pathLoginResolveRole(ctx context.Context, req *logical.Request
 
 	roleName := roleIDIndex.Name
 
-	roleLock := b.roleLock(roleName)
-	roleLock.RLock()
-
-	role, err := b.roleEntry(ctx, req.Storage, roleName)
-	roleLock.RUnlock()
-	if err != nil {
-		return nil, err
-	}
-	if role == nil {
-		return logical.ErrorResponse("invalid role ID"), nil
-	}
-
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"role": role.name,
+			"role": roleName,
 		},
 	}, nil
 }

--- a/builtin/credential/approle/path_login.go
+++ b/builtin/credential/approle/path_login.go
@@ -33,6 +33,9 @@ func pathLogin(b *backend) *framework.Path {
 			logical.AliasLookaheadOperation: &framework.PathOperation{
 				Callback: b.pathLoginUpdateAliasLookahead,
 			},
+			logical.ResolveRoleOperation: &framework.PathOperation{
+				Callback: b.pathLoginResolveRole,
+			},
 		},
 		HelpSynopsis:    pathLoginHelpSys,
 		HelpDescription: pathLoginHelpDesc,
@@ -50,6 +53,43 @@ func (b *backend) pathLoginUpdateAliasLookahead(ctx context.Context, req *logica
 			Alias: &logical.Alias{
 				Name: roleID,
 			},
+		},
+	}, nil
+}
+
+func (b *backend) pathLoginResolveRole(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// RoleID must be supplied during every login
+	roleID := strings.TrimSpace(data.Get("role_id").(string))
+	if roleID == "" {
+		return logical.ErrorResponse("missing role_id"), nil
+	}
+
+	// Look for the storage entry that maps the roleID to role
+	roleIDIndex, err := b.roleIDEntry(ctx, req.Storage, roleID)
+	if err != nil {
+		return nil, err
+	}
+	if roleIDIndex == nil {
+		return logical.ErrorResponse("invalid role ID"), nil
+	}
+
+	roleName := roleIDIndex.Name
+
+	roleLock := b.roleLock(roleName)
+	roleLock.RLock()
+
+	role, err := b.roleEntry(ctx, req.Storage, roleName)
+	roleLock.RUnlock()
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return logical.ErrorResponse("invalid role ID"), nil
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"role": role.name,
 		},
 	}, nil
 }

--- a/builtin/credential/approle/path_login.go
+++ b/builtin/credential/approle/path_login.go
@@ -75,11 +75,7 @@ func (b *backend) pathLoginResolveRole(ctx context.Context, req *logical.Request
 
 	roleName := roleIDIndex.Name
 
-	return &logical.Response{
-		Data: map[string]interface{}{
-			"role": roleName,
-		},
-	}, nil
+	return logical.ResolveRoleResponse(roleName)
 }
 
 // Returns the Auth object indicating the authentication and authorization information

--- a/builtin/credential/approle/path_login_test.go
+++ b/builtin/credential/approle/path_login_test.go
@@ -301,3 +301,56 @@ func generateRenewRequest(s logical.Storage, auth *logical.Auth) *logical.Reques
 
 	return renewReq
 }
+
+func TestAppRole_RoleResolve(t *testing.T) {
+	var resp *logical.Response
+	var err error
+	b, storage := createBackendWithStorage(t)
+
+	role := "role1"
+	createRole(t, b, storage, role, "a,b,c")
+	roleRoleIDReq := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "role/role1/role-id",
+		Storage:   storage,
+	}
+	resp, err = b.HandleRequest(context.Background(), roleRoleIDReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+	roleID := resp.Data["role_id"]
+
+	roleSecretIDReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "role/role1/secret-id",
+		Storage:   storage,
+	}
+	resp, err = b.HandleRequest(context.Background(), roleSecretIDReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+	secretID := resp.Data["secret_id"]
+
+	loginData := map[string]interface{}{
+		"role_id":   roleID,
+		"secret_id": secretID,
+	}
+	loginReq := &logical.Request{
+		Operation: logical.ResolveRoleOperation,
+		Path:      "login",
+		Storage:   storage,
+		Data:      loginData,
+		Connection: &logical.Connection{
+			RemoteAddr: "127.0.0.1",
+		},
+	}
+
+	resp, err = b.HandleRequest(context.Background(), loginReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	if resp.Data["role"] != role {
+		t.Fatalf("Role was not as expected. Expected %s, received %s", role, resp.Data["role"])
+	}
+}

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -365,6 +365,7 @@ const (
 	ListOperation                     = "list"
 	HelpOperation                     = "help"
 	AliasLookaheadOperation           = "alias-lookahead"
+	ResolveRoleOperation              = "resolve-role"
 
 	// The operations below are called globally, the path is less relevant.
 	RevokeOperation   Operation = "revoke"

--- a/sdk/logical/response.go
+++ b/sdk/logical/response.go
@@ -310,3 +310,12 @@ func (w *StatusHeaderResponseWriter) setCustomResponseHeaders(status int) {
 }
 
 var _ WrappingResponseWriter = &StatusHeaderResponseWriter{}
+
+// ResolveRoleResponse returns a standard response to be returned by functions handling a ResolveRoleOperation
+func ResolveRoleResponse(roleName string) (*Response, error) {
+	return &Response{
+		Data: map[string]interface{}{
+			"role": roleName,
+		},
+	}, nil
+}

--- a/vault/logical_system_quotas.go
+++ b/vault/logical_system_quotas.go
@@ -69,6 +69,11 @@ func (b *SystemBackend) quotasPaths() []*framework.Path {
 global quota. For example namespace1/ adds a quota to a full namespace,
 namespace1/auth/userpass adds a quota to userpass in namespace1.`,
 				},
+				"role": {
+					Type: framework.TypeString,
+					Description: `Login role to apply this quota to. Note that when set, path must be configured
+to a valid auth method with a concept of roles.`,
+				},
 				"rate": {
 					Type: framework.TypeFloat,
 					Description: `The maximum number of requests in a given interval to be allowed by the quota rule.
@@ -205,6 +210,26 @@ func (b *SystemBackend) handleRateLimitQuotasUpdate() framework.OperationFunc {
 		}
 		if quotaByFactors != nil && quotaByFactors.QuotaName() != name {
 			return logical.ErrorResponse("quota rule with similar properties exists under the name %q", quotaByFactors.QuotaName()), nil
+		}
+
+		role := d.Get("role").(string)
+		// If this is a quota with a role, ensure the backend supports role resolution
+		if role != "" {
+			if pathSuffix != "" {
+				return logical.ErrorResponse("Quotas cannot contain both a path suffix and a role. If a role is provided, path must be a valid auth mount with a concept of roles"), nil
+			}
+			authBackend := b.Core.router.MatchingBackend(namespace.ContextWithNamespace(ctx, ns), mountPath)
+			if authBackend == nil || authBackend.Type() != logical.TypeCredential {
+				return logical.ErrorResponse("Mount path '%s' is not a valid auth method and therefore unsuitable for use with role-based quotas", mountPath), nil
+			}
+			//We will always error as we aren't supplying real data, but we're looking for "unsupported operation" in particular
+			_, err := authBackend.HandleRequest(ctx, &logical.Request{
+				Path:      "login",
+				Operation: logical.ResolveRoleOperation,
+			})
+			if err != nil && (err == logical.ErrUnsupportedOperation || err == logical.ErrUnsupportedPath) {
+				return logical.ErrorResponse("Mount path '%s' does not support use with role-based quotas", mountPath), nil
+			}
 		}
 
 		// If a quota already exists, fetch and update it.

--- a/vault/logical_system_quotas.go
+++ b/vault/logical_system_quotas.go
@@ -222,7 +222,7 @@ func (b *SystemBackend) handleRateLimitQuotasUpdate() framework.OperationFunc {
 			if authBackend == nil || authBackend.Type() != logical.TypeCredential {
 				return logical.ErrorResponse("Mount path '%s' is not a valid auth method and therefore unsuitable for use with role-based quotas", mountPath), nil
 			}
-			//We will always error as we aren't supplying real data, but we're looking for "unsupported operation" in particular
+			// We will always error as we aren't supplying real data, but we're looking for "unsupported operation" in particular
 			_, err := authBackend.HandleRequest(ctx, &logical.Request{
 				Path:      "login",
 				Operation: logical.ResolveRoleOperation,


### PR DESCRIPTION
This PR is meant as a start to the role resolution logic for role based quotas. This PR doesn't add any new functionality (hence no changelog), but acts as a basis for the role resolution required for role based quotas.

At this point, I'm hoping most for feedback relating to approach (and sanity checks) before I continue with the implementation for the other auth methods in implementing their Operation to get the role information. The new logic for rate limit quotas can be considered an example of how it might work in the creation of both types of quota.

Left to do:
- Adding the `ResolveRoleOperation` to all auth methods that support roles
- Adding the `role` field to the Quota structs, and using it as part of retrieving/creating quotas
- Performing the `ResolveRoleOperation` when checking if a quota applies (likely somewhere in the `applyQuota` flow for login requests)

It's also unclear how much of this should be done as part of the 'plumbing' Jira (VAULT-6612) and which should be done as part of the implementation of the quota features - so I'm also looking for feedback on that. Regardless, after review/iteration/this approach is agreed upon, this will be merged before the next bits of work.

After this change, the following requests fail (assuming approle is enabled):
`vault write sys/quotas/rate-limit/path-suffix-rate rate=2 interval="1m" path="/auth/approle/login" role="abc"`
`vault write sys/quotas/rate-limit/path-suffix-rate rate=2 interval="1m" path="/auth/token" role="abc"`
`vault write sys/quotas/rate-limit/path-suffix-rate rate=2 interval="1m" path="" role="abc"`

And this one succeeds (notably, the quota does not actually apply only to the role, as of right now):
`vault write sys/quotas/rate-limit/path-suffix-rate rate=2 interval="1m" path="/auth/approle/" role="abc"`
