### PR TITLE
change rotation_period to algorithm

### DIFF
--- a/website/content/docs/concepts/oidc-provider.mdx
+++ b/website/content/docs/concepts/oidc-provider.mdx
@@ -172,7 +172,7 @@ creation time will use the `default` key.
 
 The `default` key will have the following configuration:
 
-- `rotation_period` - `RS256`
+- `algorithm` - `RS256`
 - `allowed_client_ids` - `*`
 - `rotation_period` - `24h`
 - `verification_ttl` - `24h`


### PR DESCRIPTION
Fix default config listed [here](https://www.vaultproject.io/docs/concepts/oidc-provider#keys). The first attr says `rotation_period` but this should read: `algorithm` ([key docs](https://www.vaultproject.io/api-docs/secret/identity/tokens#algorithm))
<img width="400" alt="Screen Shot 2022-06-17 at 1 18 46 PM" src="https://user-images.githubusercontent.com/68122737/174395814-23df77f0-b54f-4ae9-8122-39e39a198b84.png">
