### PR TITLE
fix: crash if datadog telemetry is down

### DIFF
--- a/changelog/16055.txt
+++ b/changelog/16055.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/metrics: Fixed crash issue during Datadog telemetry setup if it can't connect to the server.
+```

--- a/internalshared/configutil/datadog_sink.go
+++ b/internalshared/configutil/datadog_sink.go
@@ -1,0 +1,111 @@
+package configutil
+
+import (
+	"github.com/armon/go-metrics"
+	"github.com/armon/go-metrics/datadog"
+	"github.com/mitchellh/cli"
+)
+
+type DatadogSink struct {
+	tags              []string
+	addr              string
+	hostName          string
+	propagateHostname bool
+	sink              *datadog.DogStatsdSink
+	logger            cli.Ui
+}
+
+func NewDatadogSink(addr string, hostName string, logger cli.Ui) (*DatadogSink, error) {
+	return &DatadogSink{
+		addr:              addr,
+		hostName:          hostName,
+		propagateHostname: false,
+		logger:            logger,
+	}, nil
+}
+
+func (s *DatadogSink) SetTags(tags []string) {
+	s.tags = tags
+	sink := s.getSink()
+	if sink == nil {
+		return
+	}
+	sink.SetTags(tags)
+}
+
+func (s *DatadogSink) EnableHostNamePropagation() {
+	s.propagateHostname = true
+	sink := s.getSink()
+	if sink == nil {
+		return
+	}
+	sink.EnableHostNamePropagation()
+}
+
+// Implementation of methods in the MetricSink interface
+
+func (s *DatadogSink) SetGauge(key []string, val float32) {
+	s.SetGaugeWithLabels(key, val, nil)
+}
+
+func (s *DatadogSink) IncrCounter(key []string, val float32) {
+	s.IncrCounterWithLabels(key, val, nil)
+}
+
+func (s *DatadogSink) EmitKey(key []string, val float32) {
+}
+
+func (s *DatadogSink) AddSample(key []string, val float32) {
+	s.AddSampleWithLabels(key, val, nil)
+}
+
+func (s *DatadogSink) getSink() *datadog.DogStatsdSink {
+	if s.sink != nil {
+		return s.sink
+	}
+
+	sink, err := datadog.NewDogStatsdSink(s.addr, s.hostName)
+	if err != nil {
+		s.logger.Warn("failed to connect to datadog: " + err.Error())
+		return nil
+	}
+	sink.SetTags(s.tags)
+	if s.propagateHostname {
+		sink.EnableHostNamePropagation()
+	}
+
+	s.sink = sink
+	return sink
+}
+
+func (s *DatadogSink) SetGaugeWithLabels(key []string, val float32, labels []metrics.Label) {
+	sink := s.getSink()
+	if sink == nil {
+		return
+	}
+	sink.SetGaugeWithLabels(key, val, labels)
+}
+
+func (s *DatadogSink) IncrCounterWithLabels(key []string, val float32, labels []metrics.Label) {
+	sink := s.getSink()
+	if sink == nil {
+		return
+	}
+	sink.IncrCounterWithLabels(key, val, labels)
+}
+
+func (s *DatadogSink) AddSampleWithLabels(key []string, val float32, labels []metrics.Label) {
+	sink := s.getSink()
+	if sink == nil {
+		return
+	}
+	sink.IncrCounterWithLabels(key, val, labels)
+}
+
+func (s *DatadogSink) Shutdown() {
+	sink := s.getSink()
+	if sink == nil {
+		return
+	}
+	sink.Shutdown()
+}

--- a/internalshared/configutil/datadog_sink.go
+++ b/internalshared/configutil/datadog_sink.go
@@ -15,13 +15,13 @@ type DatadogSink struct {
 	logger            cli.Ui
 }
 
-func NewDatadogSink(addr string, hostName string, logger cli.Ui) (*DatadogSink, error) {
+func NewDatadogSink(addr string, hostName string, logger cli.Ui) *DatadogSink {
 	return &DatadogSink{
 		addr:              addr,
 		hostName:          hostName,
 		propagateHostname: false,
 		logger:            logger,
-	}, nil
+	}
 }
 
 func (s *DatadogSink) SetTags(tags []string) {

--- a/internalshared/configutil/datadog_sink_test.go
+++ b/internalshared/configutil/datadog_sink_test.go
@@ -1,0 +1,61 @@
+package configutil
+
+import (
+	"strings"
+	"testing"
+)
+
+type mockUi struct {
+	t        *testing.T
+	warnings []string
+	errors   []string
+	infos    []string
+}
+
+func (m mockUi) Ask(_ string) (string, error) {
+	m.t.FailNow()
+	return "", nil
+}
+
+func (m mockUi) AskSecret(_ string) (string, error) {
+	m.t.FailNow()
+	return "", nil
+}
+func (m *mockUi) Output(s string) {}
+func (m *mockUi) Info(s string) {
+	m.infos = append(m.infos, s)
+	m.t.Log(s)
+}
+func (m *mockUi) Error(s string) {
+	m.errors = append(m.infos, s)
+	m.t.Log(s)
+}
+func (m *mockUi) Warn(s string) {
+	m.warnings = append(m.infos, s)
+	m.t.Log(s)
+}
+
+func TestDatadogSink(t *testing.T) {
+	ui := mockUi{t: t}
+	datadog := NewDatadogSink("", "", &ui)
+
+	if datadog == nil {
+		t.Fatalf("result can not be nil")
+	}
+
+	_ = datadog.getSink()
+	_ = datadog.getSink()
+	_ = datadog.getSink()
+
+	if len(ui.warnings) == 0 {
+		t.Fatalf("no warnings logged")
+	}
+
+	if len(ui.warnings) > 1 || len(ui.errors) > 0 || len(ui.infos) > 0 {
+		t.Fatalf("excess logging")
+	}
+
+	if !strings.HasPrefix(ui.warnings[0], "failed to connect to datadog:") {
+		t.Fatalf("incorrect message logged")
+	}
+}

--- a/internalshared/configutil/telemetry.go
+++ b/internalshared/configutil/telemetry.go
@@ -350,10 +350,7 @@ func SetupTelemetry(opts *SetupTelemetryOpts) (*metrics.InmemSink, *metricsutil.
 			tags = opts.Config.DogStatsDTags
 		}
 
-		sink, err := NewDatadogSink(opts.Config.DogStatsDAddr, metricsConf.HostName, opts.Ui)
-		if err != nil {
-			return nil, nil, false, fmt.Errorf("failed to start DogStatsD sink: %w", err)
-		}
+		sink := NewDatadogSink(opts.Config.DogStatsDAddr, metricsConf.HostName, opts.Ui)
 		sink.SetTags(tags)
 		fanout = append(fanout, sink)
 	}

--- a/internalshared/configutil/telemetry.go
+++ b/internalshared/configutil/telemetry.go
@@ -11,7 +11,6 @@ import (
 	monitoring "cloud.google.com/go/monitoring/apiv3"
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/circonus"
-	"github.com/armon/go-metrics/datadog"
 	"github.com/armon/go-metrics/prometheus"
 	stackdriver "github.com/google/go-metrics-stackdriver"
 	stackdrivervault "github.com/google/go-metrics-stackdriver/vault"
@@ -351,7 +350,7 @@ func SetupTelemetry(opts *SetupTelemetryOpts) (*metrics.InmemSink, *metricsutil.
 			tags = opts.Config.DogStatsDTags
 		}
 
-		sink, err := datadog.NewDogStatsdSink(opts.Config.DogStatsDAddr, metricsConf.HostName)
+		sink, err := NewDatadogSink(opts.Config.DogStatsDAddr, metricsConf.HostName, opts.Ui)
 		if err != nil {
 			return nil, nil, false, fmt.Errorf("failed to start DogStatsD sink: %w", err)
 		}


### PR DESCRIPTION
Vault is dependent on the dogstatsd service in our cluster, and crashes in a loop at startup if that service is unavailable.

Relates to https://github.com/hashicorp/vault/issues/8463