### PR TITLE
fix bug with allowed_users_template and add allowed_domains_template for SSH role

### DIFF
--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -322,6 +322,31 @@ func TestBackend_AllowedUsers(t *testing.T) {
 	}
 }
 
+func TestBackend_AllowedDomainsTemplate(t *testing.T) {
+	testAllowedDomainsTemplate := "{{ identity.entity.metadata.ssh_username }}.example.com"
+	expectedValidPrincipal := "foo." + testUserName + ".example.com"
+	testAllowedPrincipalsTemplate(
+		t, testAllowedDomainsTemplate,
+		expectedValidPrincipal,
+		map[string]string{
+			"ssh_username": testUserName,
+		},
+		map[string]interface{}{
+			"key_type":                 testCaKeyType,
+			"algorithm_signer":         "rsa-sha2-256",
+			"allow_host_certificates":  true,
+			"allow_subdomains":         true,
+			"allowed_domains":          testAllowedDomainsTemplate,
+			"allowed_domains_template": true,
+		},
+		map[string]interface{}{
+			"cert_type":        "host",
+			"public_key":       testCAPublicKey,
+			"valid_principals": expectedValidPrincipal,
+		},
+	)
+}
+
 func TestBackend_AllowedUsersTemplate(t *testing.T) {
 	testAllowedUsersTemplate(t,
 		"{{ identity.entity.metadata.ssh_username }}",
@@ -2093,9 +2118,9 @@ func testDefaultUserTemplate(t *testing.T, testDefaultUserTemplate string,
 	}
 }
 
-func testAllowedUsersTemplate(t *testing.T, testAllowedUsersTemplate string,
+func testAllowedPrincipalsTemplate(t *testing.T, testAllowedDomainsTemplate string,
 	expectedValidPrincipal string, testEntityMetadata map[string]string,
-) {
+	roleConfigPayload map[string]interface{}, signingPayload map[string]interface{}) {
 	cluster, userpassToken := getSshCaTestCluster(t, testUserName)
 	defer cluster.Cleanup()
 	client := cluster.Cores[0].Client
@@ -2115,22 +2140,14 @@ func testAllowedUsersTemplate(t *testing.T, testAllowedUsersTemplate string,
 		t.Fatal(err)
 	}
 
-	_, err = client.Logical().Write("ssh/roles/my-role", map[string]interface{}{
-		"key_type":                testCaKeyType,
-		"allow_user_certificates": true,
-		"allowed_users":           testAllowedUsersTemplate,
-		"allowed_users_template":  true,
-	})
+	_, err = client.Logical().Write("ssh/roles/my-role", roleConfigPayload)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// sign SSH key as userpass user
 	client.SetToken(userpassToken)
-	signResponse, err := client.Logical().Write("ssh/sign/my-role", map[string]interface{}{
-		"public_key":       testCAPublicKey,
-		"valid_principals": expectedValidPrincipal,
-	})
+	signResponse, err := client.Logical().Write("ssh/sign/my-role", signingPayload)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2149,6 +2166,24 @@ func testAllowedUsersTemplate(t *testing.T, testAllowedUsersTemplate string,
 				actualPrincipals, []string{expectedValidPrincipal}),
 		)
 	}
+}
+
+func testAllowedUsersTemplate(t *testing.T, testAllowedUsersTemplate string,
+	expectedValidPrincipal string, testEntityMetadata map[string]string) {
+	testAllowedPrincipalsTemplate(
+		t, testAllowedUsersTemplate,
+		expectedValidPrincipal, testEntityMetadata,
+		map[string]interface{}{
+			"key_type":                testCaKeyType,
+			"allow_user_certificates": true,
+			"allowed_users":           testAllowedUsersTemplate,
+			"allowed_users_template":  true,
+		},
+		map[string]interface{}{
+			"public_key":       testCAPublicKey,
+			"valid_principals": expectedValidPrincipal,
+		},
+	)
 }
 
 func configCaStep(caPublicKey, caPrivateKey string) logicaltest.TestStep {

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -48,6 +48,7 @@ type sshRole struct {
 	AllowedUsers               string            `mapstructure:"allowed_users" json:"allowed_users"`
 	AllowedUsersTemplate       bool              `mapstructure:"allowed_users_template" json:"allowed_users_template"`
 	AllowedDomains             string            `mapstructure:"allowed_domains" json:"allowed_domains"`
+	AllowedDomainsTemplate     bool              `mapstructure:"allowed_domains_template" json:"allowed_domains_template"`
 	KeyOptionSpecs             string            `mapstructure:"key_option_specs" json:"key_option_specs"`
 	MaxTTL                     string            `mapstructure:"max_ttl" json:"max_ttl"`
 	TTL                        string            `mapstructure:"ttl" json:"ttl"`
@@ -222,6 +223,15 @@ func pathRoles(b *backend) *framework.Path {
 				If this option is not specified, client can request for a signed certificate for any
 				valid host. If only certain domains are allowed, then this list enforces it.
 				`,
+			},
+			"allowed_domains_template": {
+				Type: framework.TypeBool,
+				Description: `
+				[Not applicable for Dynamic type] [Not applicable for OTP type] [Optional for CA type]
+				If set, Allowed domains can be specified using identity template policies.
+				Non-templated domains are also permitted.
+				`,
+				Default: false,
 			},
 			"key_option_specs": {
 				Type: framework.TypeString,
@@ -567,6 +577,7 @@ func (b *backend) createCARole(allowedUsers, defaultUser, signer string, data *f
 		AllowedUsers:              allowedUsers,
 		AllowedUsersTemplate:      data.Get("allowed_users_template").(bool),
 		AllowedDomains:            data.Get("allowed_domains").(string),
+		AllowedDomainsTemplate:    data.Get("allowed_domains_template").(bool),
 		DefaultUser:               defaultUser,
 		DefaultUserTemplate:       data.Get("default_user_template").(bool),
 		AllowBareDomains:          data.Get("allow_bare_domains").(bool),
@@ -750,6 +761,7 @@ func (b *backend) parseRole(role *sshRole) (map[string]interface{}, error) {
 			"allowed_users":               role.AllowedUsers,
 			"allowed_users_template":      role.AllowedUsersTemplate,
 			"allowed_domains":             role.AllowedDomains,
+			"allowed_domains_template":    role.AllowedDomainsTemplate,
 			"default_user":                role.DefaultUser,
 			"default_user_template":       role.DefaultUserTemplate,
 			"ttl":                         int64(ttl.Seconds()),

--- a/changelog/16056.txt
+++ b/changelog/16056.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/ssh: Add allowed_domains_template to allow templating of allowed_domains.
+```

--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -146,13 +146,17 @@ This endpoint creates or updates a named role.
   Use with caution. N.B.: if the type is `ca`, an empty list does not allow any user;
   instead you must use `*` to enable this behavior.
 
-- `allowed_users_template` `(bool: false)` - If set, allowed_users can be specified
+- `allowed_users_template` `(bool: false)` - If set, `allowed_users` can be specified
   using identity template policies. Non-templated users are also permitted.
 
 - `allowed_domains` `(string: "")` – The list of domains for which a client can
   request a host certificate. If this option is explicitly set to `"*"`, then
   credentials can be created for any domain. See also `allow_bare_domains` and
   `allow_subdomains`.
+
+- `allowed_domains_template` `(bool: false)` - If set, `allowed_domains` can be
+  specified using identity template policies. Non-templated domains are also
+  permitted.
 
 - `key_option_specs` `(string: "")` – Specifies a comma separated option
   specification which will be prefixed to RSA keys in the remote host's


### PR DESCRIPTION
This implements the `allowed_domains_template` field when configuring SSH roles on the SSH secret engine (as explained in issue #10943). It also fixes an issue that `allowed_users_template` actually affected the domain templating. I also directly added the documentation for it.