### PR TITLE
Adding Vault HydrantID Pki Plugin

### DIFF
--- a/website/content/docs/plugins/plugin-portal.mdx
+++ b/website/content/docs/plugins/plugin-portal.mdx
@@ -134,9 +134,10 @@ Plugin authors who wish to have their plugins listed may file a submission via a
 - [AWS Cognito](https://github.com/WealthWizardsEngineering/vault-plugin-secrets-cognito)
 - [Ethereum](https://github.com/immutability-io/vault-ethereum)
 - [GitHub](https://github.com/martinbaillie/vault-plugin-secrets-github)
+- [HydrantID PKI Plugin](https://github.com/PaddyPowerBetfair/vault-plugin-hydrant-pki)
 - [HSM PKI Plugin](https://github.com/mode51software/vaultplugin-hsmpki)
 - [OAuth 2.0/OIDC](https://github.com/puppetlabs/vault-plugin-secrets-oauthapp)
 - [Jenkins](https://github.com/circa10a/vault-plugin-secrets-jenkins)
 
 [github-issue]: https://github.com/hashicorp/vault/issues/new?assignees=&labels=ecosystem%2Fplugin&template=plugin-submission.md&title=%5BPlugin+Portal%5D+Plugin+Submission+-+%3CPLUGIN+NAME%3E
-[plugin-portal-mdx]: https://github.com/hashicorp/vault/blob/main/website/content/docs/plugin-portal.mdx
+[plugin-portal-mdx]: https://github.com/hashicorp/vault/blob/main/website/content/docs/plugins/plugin-portal.mdx


### PR DESCRIPTION
repository: https://github.com/PaddyPowerBetfair/vault-plugin-hydrant-pki
raised issue: #16011
also updated docs (link to page for PR)