### PR TITLE
Clarify that the returned chain is used everywhere

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1838,7 +1838,11 @@ do so, import a new issuer and a new `issuer_id` will be assigned.
    This field is especially useful for cross-signed intermediates within
    Vault. Because each cross-signed intermediate will only know of the
    one root, but issuance should serve both, update the issuers' entries
-   with the desired `manual_chain` value.
+   with the desired `manual_chain` value.<br /><br />
+   The CA Chain returned by a GET to the issuer configuration is the same
+   chain presented during signing and (if this issuer is the default) on
+   the `/ca_chain` path. Setting `manual_chain` thus allows controlling
+   the presented chain as desired.
 
 - `usage` `([]string: read-only,issuing-certificates,crl-signing)` - Allowed
   usages for this issuer. Valid options are:


### PR DESCRIPTION
The returned chain on the issuer is presented both for signing request
responses and (if the default issuer) on the `/ca_chain` path. Overriding
the issuers' automatically constructed chain with a `manual_chain` allows
removal of the root CA if desired.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`