### PR TITLE
fix docs typo - couple to few

### DIFF
--- a/website/content/docs/agent/index.mdx
+++ b/website/content/docs/agent/index.mdx
@@ -213,7 +213,7 @@ Here are the options for the `retry` stanza:
   A value of `-1` disables retries. The environment variable `VAULT_MAX_RETRIES`
   overrides this setting.
 
-There are a couple of subtleties to be aware of here. First, requests originating
+There are a few subtleties to be aware of here. First, requests originating
 from the proxy cache will only be retried if they resulted in specific HTTP
 result codes: any 50x code except 501 ("not implemented"), as well as 412
 ("precondition failed"); 412 is used in Vault Enterprise 1.7+ to indicate a


### PR DESCRIPTION
just a little typo fix - we say couple but there are three items