### PR TITLE
OIDC/Kubernetes docs: Improve instructions for setting bound_audiences

### DIFF
--- a/website/content/docs/auth/jwt/oidc_providers.mdx
+++ b/website/content/docs/auth/jwt/oidc_providers.mdx
@@ -487,8 +487,8 @@ metadata:
 spec:
   # automountServiceAccountToken is redundant in this example because the
   # mountPath used overlaps with the default path. The overlap stops the default
-  # admission injected token from being created. You can this option to ensure
-  # only a single token is mounted if you choose a different mount path.
+  # admission injected token from being created. You can use this option to
+  # ensure only a single token is mounted if you choose a different mount path.
   automountServiceAccountToken: false
   containers:
     - name: nginx


### PR DESCRIPTION
Adds instructions for finding the correct `bound_audiences` value to use when using a default token and the Kubernetes cluster has been configured with non-default values for its API audiences. Previously, there was only a small throwaway comment with no help for the non-default scenario, but this is a very common scenario as several managed Kubernetes offerings configure the audience differently from the issuer.

Relates to https://github.com/hashicorp/vault-plugin-auth-jwt/issues/206.