### PR TITLE
Fix incorrect HSM mechanisms in transit BYOK docs

### DIFF
--- a/website/content/docs/secrets/transit.mdx
+++ b/website/content/docs/secrets/transit.mdx
@@ -257,11 +257,11 @@ as described below. In the below, the target key refers to the key being importe
 If the key is being imported from an HSM that supports PKCS#11, there are
 two possible scenarios:
 
-- If the HSM supports the CKM_AES_KEY_WRAP_KWP mechanism, that can be used to wrap the
+- If the HSM supports the CKM_RSA_AES_KEY_WRAP mechanism, that can be used to wrap the
 target key using the wrapping key.
 
 - Otherwise, two mechanisms can be combined to wrap the target key. First, an AES key should
-be generated and then used to wrap the target key using the CKM_AES_KEY_WRAP_PAD mechanism.
+be generated and then used to wrap the target key using the CKM_AES_KEY_WRAP_KWP mechanism.
 Then the AES key should be wrapped under the wrapping key using the CKM_RSA_PKCS_OAEP mechanism
 using MGF1 and either SHA-1, SHA-224, SHA-256, SHA-384, or SHA-512.
 


### PR DESCRIPTION
This fixes incorrect HSM mechanisms in the documentation for importing transit keys (from #15817 ).