### PR TITLE
Replicate member_entity_ids and policies in identity/group across nodes identically

### DIFF
--- a/changelog/16088.txt
+++ b/changelog/16088.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/identity: Replicate member_entity_ids and policies in identity/group across nodes identically
+```

--- a/vault/external_tests/identity/identity_test.go
+++ b/vault/external_tests/identity/identity_test.go
@@ -628,8 +628,20 @@ func assertMember(t *testing.T, client *api.Client, entityID, groupName, groupID
 		t.Fatal(err)
 	}
 	groupMap := secret.Data
+
+	groupEntityMembers, ok := groupMap["member_entity_ids"].([]interface{})
+	if !ok && expectFound {
+		t.Fatalf("expected member_entity_ids not to be nil")
+	}
+
+	// if type assertion fails and expectFound is false, groupEntityMembers
+	// is nil, then let's just return, nothing to be done!
+	if !ok && !expectFound {
+		return
+	}
+
 	found := false
-	for _, entityIDRaw := range groupMap["member_entity_ids"].([]interface{}) {
+	for _, entityIDRaw := range groupEntityMembers {
 		if entityIDRaw.(string) == entityID {
 			found = true
 		}

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -1473,19 +1473,23 @@ func (i *IdentityStore) sanitizeAndUpsertGroup(ctx context.Context, group *ident
 	}
 
 	// Remove duplicate entity IDs and check if all IDs are valid
-	group.MemberEntityIDs = strutil.RemoveDuplicates(group.MemberEntityIDs, false)
-	for _, entityID := range group.MemberEntityIDs {
-		entity, err := i.MemDBEntityByID(entityID, false)
-		if err != nil {
-			return fmt.Errorf("failed to validate entity ID %q: %w", entityID, err)
-		}
-		if entity == nil {
-			return fmt.Errorf("invalid entity ID %q", entityID)
+	if group.MemberEntityIDs != nil {
+		group.MemberEntityIDs = strutil.RemoveDuplicates(group.MemberEntityIDs, false)
+		for _, entityID := range group.MemberEntityIDs {
+			entity, err := i.MemDBEntityByID(entityID, false)
+			if err != nil {
+				return fmt.Errorf("failed to validate entity ID %q: %w", entityID, err)
+			}
+			if entity == nil {
+				return fmt.Errorf("invalid entity ID %q", entityID)
+			}
 		}
 	}
 
 	// Remove duplicate policies
-	group.Policies = strutil.RemoveDuplicates(group.Policies, false)
+	if group.Policies != nil {
+		group.Policies = strutil.RemoveDuplicates(group.Policies, false)
+	}
 
 	txn := i.db.Txn(true)
 	defer txn.Abort()


### PR DESCRIPTION
Addresses https://hashicorp.atlassian.net/browse/VAULT-2282
Example of reading an identity/group from a standby node:

`{
  "request_id": "4015c4c6-ee28-eec9-a42d-a0be91970dbc",
  "lease_id": "",
  "lease_duration": 0,
  "renewable": false,
  "data": {
    "alias": {},
    "creation_time": "2022-06-21T05:56:12.378602Z",
    "id": "6a769520-f4b5-59a1-d7d7-21a650c91343",
    "last_update_time": "2022-06-21T05:56:12.378602Z",
    "member_entity_ids": null,
    "member_group_ids": [
      "66bcfa57-8aab-04c8-d9ed-263bb5d2e6b0",
      "b7919faf-0a16-6acd-9e4d-82ac6db946bc"
    ],
    "metadata": null,
    "modify_index": 1,
    "name": "testgroup3",
    "namespace_id": "root",
    "parent_group_ids": null,
    "policies": [
      "default"
    ],
    "type": "internal"
  },
  "warnings": [
    "Endpoint ignored these unrecognized parameters: [-format]"
  ]
}`

A group is marshalled and persisted in the leader node and then replicated to standby nodes. In standby node, memDB is populated after unmarshalling the group entry. However, member_entity_ids is an initialized empty slice when marshalled, but become a nil entry upon unmarshalling. This creates an inconsistency on the way active/standby nodes return the results. 

To fix that, it was noticed that `member_entity_ids` field is nil, then passed into `strutil.RemoveDuplicates` function so that the duplicated entries be removed. That function returns an initialized empty slice regardless of the `nil` argument. The fix simply checks if the `member_entity_ids` field is not nil before passing it to that function. A test is going to be added to the ENT repo. Further details can be found in the ticket.