### PR TITLE
Fix bug where id not existing in multiplexing map causes panic

### DIFF
--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -157,6 +157,10 @@ func (c *PluginCatalog) cleanupExternalPlugin(name, id string) error {
 		return fmt.Errorf("plugin client not found")
 	}
 
+	if _, ok := extPlugin.connections[id]; !ok {
+		return fmt.Errorf("plugin connection not found")
+	}
+
 	pc := extPlugin.connections[id]
 
 	delete(extPlugin.connections, id)


### PR DESCRIPTION
Guarding against a potential panic if the id does not exist in the connections map. I haven't tracked down why this would occur yet, but this will at least prevent a panic.