### PR TITLE
Add new KMIP backend operation parameters to API documentation.

### DIFF
--- a/website/content/api-docs/secret/kmip.mdx
+++ b/website/content/api-docs/secret/kmip.mdx
@@ -255,18 +255,26 @@ Creates or updates a role.
   `Add Attribute` operation.
 - `operation_create` (`bool: false`) - Grant permission to use the KMIP
   `Create` operation.
+- `operation_decrypt` (`bool: false`) - Grant permission to use the KMIP
+  `Decrypt` operation.
 - `operation_destroy` (`bool: false`) - Grant permission to use the KMIP
   `Destroy` operation.
 - `operation_discover_versions` (`bool: false`) - Grant permission to use the KMIP
-  `Discover Version` operation.
+  `Discover Versions` operation.
+- `operation_encrypt` (`bool: false`) - Grant permission to use the KMIP
+  `Encrypt` operation.
 - `operation_get` (`bool: false`) - Grant permission to use the KMIP
   `Get` operation.
 - `operation_get_attribute_list` (`bool: false`) - Grant permission to use the KMIP
   `Get Attribute List` operation.
 - `operation_get_attributes` (`bool: false`) - Grant permission to use the KMIP
   `Get Attributes` operation.
+- `operation_import` (`bool: false`) - Grant permission to use the KMIP
+  `Import` operation.
 - `operation_locate` (`bool: false`) - Grant permission to use the KMIP
   `Locate` operation.
+- `operation_query` (`bool: false`) - Grant permission to use the KMIP
+  `Query` operation.
 - `operation_register` (`bool: false`) - Grant permission to use the KMIP
   `Register` operation.
 - `operation_rekey` (`bool: false`) - Grant permission to use the KMIP
@@ -281,12 +289,16 @@ Creates or updates a role.
   "operation_activate": true,
   "operation_add_attribute": true,
   "operation_create": true,
+  "operation_decrypt": true,
   "operation_destroy": true,
   "operation_discover_versions": true,
+  "operation_encrypt": true,
   "operation_get": true,
   "operation_get_attribute_list": true,
   "operation_get_attributes": true,
+  "operation_import": true,
   "operation_locate": true,
+  "operation_query": true,
   "operation_register": true,
   "operation_rekey": true,
   "operation_revoke": true
@@ -333,12 +345,16 @@ $ curl \
     "operation_activate": true,
     "operation_add_attribute": true,
     "operation_create": true,
+    "operation_decrypt": true,
     "operation_destroy": true,
     "operation_discover_versions": true,
+    "operation_encrypt": true,
     "operation_get": true,
     "operation_get_attribute_list": true,
     "operation_get_attributes": true,
+    "operation_import": true,
     "operation_locate": true,
+    "operation_query": true,
     "operation_register": true,
     "operation_rekey": true,
     "operation_revoke": true


### PR DESCRIPTION
The KMIP backend has four new parameters for the API call to create or update a
role:

  - operation_decrypt
  - operation_encrypt
  - operation_import
  - operation_query