### PR TITLE
Backport: Fix bug where id not existing in multiplexing map causes panic (#16094)

### DIFF
--- a/changelog/16094.txt
+++ b/changelog/16094.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/multiplexing: Fix panic when id doesn't exist in connection map
+```

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -148,7 +148,10 @@ func (c *PluginCatalog) cleanupExternalPlugin(name, id string) error {
 		return fmt.Errorf("plugin client not found")
 	}
 
-	pc := extPlugin.connections[id]
+	pc, ok := extPlugin.connections[id]
+	if !ok {
+		return fmt.Errorf("plugin connection not found")
+	}
 
 	delete(extPlugin.connections, id)
 	if !extPlugin.multiplexingSupport {


### PR DESCRIPTION
* multiplexing: guard against connection panic

* changelog

* Update vault/plugin_catalog.go

Co-authored-by: Calvin Leung Huang <1883212+calvn@users.noreply.github.com>

Co-authored-by: Calvin Leung Huang <1883212+calvn@users.noreply.github.com>