### PR TITLE
OIDC Adapters and Serializers

### DIFF
--- a/ui/app/adapters/named-path.js
+++ b/ui/app/adapters/named-path.js
@@ -1,0 +1,31 @@
+/**
+ * base adapter for resources that are saved to a path whose unique identifier is name
+ * save requests are made to the same endpoint and the resource is either created if not found or updated
+ * */
+import ApplicationAdapter from './application';
+
+export default class NamedPathAdapter extends ApplicationAdapter {
+  namespace = 'v1';
+  saveMethod = 'POST'; // override when extending if PUT is used rather than POST
+
+  _saveRecord(store, { modelName }, snapshot) {
+    // since the response is empty return the serialized data rather than nothing
+    const data = store.serializerFor(modelName).serialize(snapshot);
+    return this.ajax(this.urlForUpdateRecord(snapshot.attr('name'), modelName, snapshot), this.saveMethod, {
+      data,
+    }).then(() => data);
+  }
+  // create does not return response similar to PUT request
+  createRecord() {
+    return this._saveRecord(...arguments);
+  }
+  // update uses same endpoint and method as create
+  updateRecord() {
+    return this._saveRecord(...arguments);
+  }
+  // GET request with list=true as query param
+  query(store, type, query) {
+    const url = this.urlForQuery(query, type.modelName);
+    return this.ajax(url, 'GET', { data: { list: true } });
+  }
+}

--- a/ui/app/adapters/oidc/assignment.js
+++ b/ui/app/adapters/oidc/assignment.js
@@ -1,0 +1,7 @@
+import NamedPathAdapter from '../named-path';
+
+export default class OidcAssignmentAdapter extends NamedPathAdapter {
+  pathForType() {
+    return 'identity/oidc/assignment';
+  }
+}

--- a/ui/app/adapters/oidc/client.js
+++ b/ui/app/adapters/oidc/client.js
@@ -1,0 +1,7 @@
+import NamedPathAdapter from '../named-path';
+
+export default class OidcClientAdapter extends NamedPathAdapter {
+  pathForType() {
+    return 'identity/oidc/client';
+  }
+}

--- a/ui/app/adapters/oidc/key.js
+++ b/ui/app/adapters/oidc/key.js
@@ -1,0 +1,11 @@
+import NamedPathAdapter from '../named-path';
+
+export default class OidcKeyAdapter extends NamedPathAdapter {
+  pathForType() {
+    return 'identity/oidc/key';
+  }
+  rotate(name, verification_ttl) {
+    const data = verification_ttl ? { verification_ttl } : {};
+    return this.ajax(`${this.urlForUpdateRecord(name, 'oidc/key')}/rotate`, 'POST', { data });
+  }
+}

--- a/ui/app/adapters/oidc/provider.js
+++ b/ui/app/adapters/oidc/provider.js
@@ -1,0 +1,7 @@
+import NamedPathAdapter from '../named-path';
+
+export default class OidcProviderAdapter extends NamedPathAdapter {
+  pathForType() {
+    return 'identity/oidc/provider';
+  }
+}

--- a/ui/app/adapters/oidc/scope.js
+++ b/ui/app/adapters/oidc/scope.js
@@ -1,0 +1,7 @@
+import NamedPathAdapter from '../named-path';
+
+export default class OidcScopeAdapter extends NamedPathAdapter {
+  pathForType() {
+    return 'identity/oidc/scope';
+  }
+}

--- a/ui/app/models/oidc/provider.js
+++ b/ui/app/models/oidc/provider.js
@@ -2,7 +2,7 @@ import Model, { attr, hasMany } from '@ember-data/model';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 
 export default class OidcProviderModel extends Model {
-  @hasMany('identity/oidc/scope') scopes_supported;
+  @hasMany('oidc/scope') scopes_supported;
   @attr('string') name;
   @attr('string', {
     label: 'Issuer URL',

--- a/ui/app/serializers/oidc/assignment.js
+++ b/ui/app/serializers/oidc/assignment.js
@@ -1,0 +1,5 @@
+import ApplicationSerializer from '../application';
+
+export default class OidcAssignmentSerializer extends ApplicationSerializer {
+  primaryKey = 'name';
+}

--- a/ui/app/serializers/oidc/client.js
+++ b/ui/app/serializers/oidc/client.js
@@ -1,0 +1,5 @@
+import ApplicationSerializer from '../application';
+
+export default class OidcClientSerializer extends ApplicationSerializer {
+  primaryKey = 'name';
+}

--- a/ui/app/serializers/oidc/key.js
+++ b/ui/app/serializers/oidc/key.js
@@ -1,0 +1,5 @@
+import ApplicationSerializer from '../application';
+
+export default class OidcKeySerializer extends ApplicationSerializer {
+  primaryKey = 'name';
+}

--- a/ui/app/serializers/oidc/provider.js
+++ b/ui/app/serializers/oidc/provider.js
@@ -1,0 +1,5 @@
+import ApplicationSerializer from '../application';
+
+export default class OidcProviderSerializer extends ApplicationSerializer {
+  primaryKey = 'name';
+}

--- a/ui/app/serializers/oidc/scope.js
+++ b/ui/app/serializers/oidc/scope.js
@@ -1,0 +1,5 @@
+import ApplicationSerializer from '../application';
+
+export default class OidcScopeSerializer extends ApplicationSerializer {
+  primaryKey = 'name';
+}

--- a/ui/tests/unit/adapters/oidc/assignment-test.js
+++ b/ui/tests/unit/adapters/oidc/assignment-test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import testHelper from './test-helper';
+
+module('Unit | Adapter | oidc/assignment', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.modelName = 'oidc/assignment';
+    this.data = {
+      name: 'foo-assignment',
+      group_ids: ['my-group'],
+      entity_ids: ['my-entity'],
+    };
+    this.path = '/identity/oidc/assignment/foo-assignment';
+  });
+
+  testHelper(test);
+});

--- a/ui/tests/unit/adapters/oidc/client-test.js
+++ b/ui/tests/unit/adapters/oidc/client-test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import testHelper from './test-helper';
+
+module('Unit | Adapter | oidc/client', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.modelName = 'oidc/client';
+    this.data = {
+      name: 'foo-client',
+      key: 'test-key',
+      access_token_ttl: '30m',
+      id_token_ttl: '1h',
+    };
+    this.path = '/identity/oidc/client/foo-client';
+  });
+
+  testHelper(test);
+});

--- a/ui/tests/unit/adapters/oidc/key-test.js
+++ b/ui/tests/unit/adapters/oidc/key-test.js
@@ -1,0 +1,33 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import testHelper from './test-helper';
+
+module('Unit | Adapter | oidc/key', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.modelName = 'oidc/key';
+    this.data = {
+      name: 'foo-key',
+      rotation_period: '12h',
+      verification_ttl: 43200,
+    };
+    this.path = '/identity/oidc/key/foo-key';
+  });
+
+  testHelper(test);
+
+  test('it should make request to correct endpoint on rotate', async function (assert) {
+    assert.expect(1);
+
+    this.server.post(`${this.path}/rotate`, (schema, req) => {
+      const json = JSON.parse(req.requestBody);
+      assert.equal(json.verification_ttl, '30m', 'request made to correct endpoint on rotate');
+    });
+
+    await this.store.adapterFor('oidc/key').rotate(this.data.name, '30m');
+  });
+});

--- a/ui/tests/unit/adapters/oidc/provider-test.js
+++ b/ui/tests/unit/adapters/oidc/provider-test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import testHelper from './test-helper';
+
+module('Unit | Adapter | oidc/provider', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.modelName = 'oidc/provider';
+    this.data = {
+      name: 'foo-provider',
+      allowed_client_ids: ['*'],
+      scopes_supported: [],
+    };
+    this.path = '/identity/oidc/provider/foo-provider';
+  });
+
+  testHelper(test);
+});

--- a/ui/tests/unit/adapters/oidc/scope-test.js
+++ b/ui/tests/unit/adapters/oidc/scope-test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import testHelper from './test-helper';
+
+module('Unit | Adapter | oidc/key', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.modelName = 'oidc/scope';
+    this.data = {
+      name: 'foo-scope',
+      template: '{ "groups": {{identity.entity.groups.names}} }',
+      description: 'A simple scope example.',
+    };
+    this.path = '/identity/oidc/scope/foo-scope';
+  });
+
+  testHelper(test);
+});

--- a/ui/tests/unit/adapters/oidc/test-helper.js
+++ b/ui/tests/unit/adapters/oidc/test-helper.js
@@ -1,0 +1,47 @@
+export default (test) => {
+  test('it should make request to correct endpoint on save', async function (assert) {
+    assert.expect(2);
+
+    this.server.post(this.path, () => {
+      assert.ok(true, 'request made to correct endpoint on save');
+    });
+
+    const model = this.store.createRecord(this.modelName, this.data);
+    await model.save();
+    await model.save();
+  });
+
+  test('it should make request to correct endpoint on find', async function (assert) {
+    assert.expect(1);
+
+    this.server.get(this.path, () => {
+      assert.ok(true, 'request is made to correct endpoint on find');
+      return { data: this.data };
+    });
+
+    this.store.findRecord(this.modelName, this.data.name);
+  });
+
+  test('it should make request to correct endpoint on query', async function (assert) {
+    assert.expect(1);
+
+    this.server.get(`/identity/${this.modelName}`, (schema, req) => {
+      assert.equal(req.queryParams.list, 'true', 'request is made to correct endpoint on query');
+      return { data: { keys: [this.data.name] } };
+    });
+
+    this.store.query(this.modelName, {});
+  });
+
+  test('it should make request to correct endpoint on delete', async function (assert) {
+    assert.expect(1);
+
+    this.server.get(this.path, () => ({ data: this.data }));
+    this.server.delete(this.path, () => {
+      assert.ok(true, 'request made to correct endpoint on delete');
+    });
+
+    const model = await this.store.findRecord(this.modelName, this.data.name);
+    await model.destroyRecord();
+  });
+};


### PR DESCRIPTION
- adds named-path adapter for resources that follow that pattern
- adds adapters for oidc resources with tests
- adds serializers for oidc resources
- fixes issue with supported_scopes relationship on oidc/provider model (stumbled upon this while running tests)

I added minimal serializers for now since it's tough to determine what else is needed until the forms and views are wired up. I wouldn't necessarily add tests for adapters unless there was some unique logic to them but since I added the `named-path` adapter I wanted to be sure that the requests were hitting the correct endpoints based on the docs.