### PR TITLE
Add signature_bits to sign-intermediate, sign-verbatim

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2132,13 +2132,17 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 		t.Fatal("pem csr is empty")
 	}
 
+	signVerbatimData := map[string]interface{}{
+		"csr": pemCSR,
+	}
+	if keyType == "rsa" {
+		signVerbatimData["signature_bits"] = 512
+	}
 	resp, err = b.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.UpdateOperation,
-		Path:      "sign-verbatim",
-		Storage:   storage,
-		Data: map[string]interface{}{
-			"csr": pemCSR,
-		},
+		Operation:  logical.UpdateOperation,
+		Path:       "sign-verbatim",
+		Storage:    storage,
+		Data:       signVerbatimData,
 		MountPoint: "pki/",
 	})
 	if resp != nil && resp.IsError() {

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -574,6 +574,7 @@ func generateURLSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 			Data: map[string]interface{}{
 				"common_name":         "intermediate.cert.com",
 				"csr":                 csrPem2048,
+				"signature_bits":      512,
 				"format":              "der",
 				"not_before_duration": "2h",
 			},
@@ -597,13 +598,15 @@ func generateURLSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 
 				switch {
 				case !reflect.DeepEqual(expected.IssuingCertificates, cert.IssuingCertificateURL):
-					return fmt.Errorf("expected\n%#v\ngot\n%#v\n", expected.IssuingCertificates, cert.IssuingCertificateURL)
+					return fmt.Errorf("IssuingCertificateURL:\nexpected\n%#v\ngot\n%#v\n", expected.IssuingCertificates, cert.IssuingCertificateURL)
 				case !reflect.DeepEqual(expected.CRLDistributionPoints, cert.CRLDistributionPoints):
-					return fmt.Errorf("expected\n%#v\ngot\n%#v\n", expected.CRLDistributionPoints, cert.CRLDistributionPoints)
+					return fmt.Errorf("CRLDistributionPoints:\nexpected\n%#v\ngot\n%#v\n", expected.CRLDistributionPoints, cert.CRLDistributionPoints)
 				case !reflect.DeepEqual(expected.OCSPServers, cert.OCSPServer):
-					return fmt.Errorf("expected\n%#v\ngot\n%#v\n", expected.OCSPServers, cert.OCSPServer)
+					return fmt.Errorf("OCSPServer:\nexpected\n%#v\ngot\n%#v\n", expected.OCSPServers, cert.OCSPServer)
 				case !reflect.DeepEqual([]string{"intermediate.cert.com"}, cert.DNSNames):
-					return fmt.Errorf("expected\n%#v\ngot\n%#v\n", []string{"intermediate.cert.com"}, cert.DNSNames)
+					return fmt.Errorf("DNSNames\nexpected\n%#v\ngot\n%#v\n", []string{"intermediate.cert.com"}, cert.DNSNames)
+				case !reflect.DeepEqual(x509.SHA512WithRSA, cert.SignatureAlgorithm):
+					return fmt.Errorf("Signature Algorithm:\nexpected\n%#v\ngot\n%#v\n", x509.SHA512WithRSA, cert.SignatureAlgorithm)
 				}
 
 				if math.Abs(float64(time.Now().Add(-2*time.Hour).Unix()-cert.NotBefore.Unix())) > 10 {

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -139,6 +139,18 @@ this value to an empty list.`,
 		Description: `A comma-separated string or list of extended key usage oids.`,
 	}
 
+	ret.Fields["signature_bits"] = &framework.FieldSchema{
+		Type:    framework.TypeInt,
+		Default: 0,
+		Description: `The number of bits to use in the signature
+algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384, and 512 for
+SHA-2-512. Defaults to 0 to automatically detect based on key length
+(SHA-2-256 for RSA keys, and matching the curve size for NIST P-Curves).`,
+		DisplayAttrs: &framework.DisplayAttributes{
+			Value: 0,
+		},
+	}
+
 	return ret
 }
 
@@ -198,6 +210,7 @@ func (b *backend) pathSignVerbatim(ctx context.Context, req *logical.Request, da
 		KeyUsage:                  data.Get("key_usage").([]string),
 		ExtKeyUsage:               data.Get("ext_key_usage").([]string),
 		ExtKeyUsageOIDs:           data.Get("ext_key_usage_oids").([]string),
+		SignatureBits:             data.Get("signature_bits").(int),
 	}
 	*entry.AllowWildcardCertificates = true
 

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -286,6 +286,7 @@ func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.R
 		AllowWildcardCertificates: new(bool),
 		EnforceHostnames:          false,
 		KeyType:                   "any",
+		SignatureBits:             data.Get("signature_bits").(int),
 		AllowedOtherSANs:          []string{"*"},
 		AllowedSerialNumbers:      []string{"*"},
 		AllowedURISANs:            []string{"*"},

--- a/builtin/logical/pki/path_sign_issuers.go
+++ b/builtin/logical/pki/path_sign_issuers.go
@@ -55,6 +55,18 @@ the non-repudiation flag;
 into the issued certificate.`,
 	}
 
+	fields["signature_bits"] = &framework.FieldSchema{
+		Type:    framework.TypeInt,
+		Default: 0,
+		Description: `The number of bits to use in the signature
+algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384, and 512 for
+SHA-2-512. Defaults to 0 to automatically detect based on key length
+(SHA-2-256 for RSA keys, and matching the curve size for NIST P-Curves).`,
+		DisplayAttrs: &framework.DisplayAttributes{
+			Value: 0,
+		},
+	}
+
 	return path
 }
 

--- a/changelog/16124.txt
+++ b/changelog/16124.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secret/pki: Add signature_bits to sign-intermediate, sign-verbatim endpoints
+```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -751,6 +751,16 @@ have access.**
   `YYYY-MM-ddTHH:MM:SSZ`. Supports the Y10K end date for IEEE 802.1AR-2018
   standard devices, `9999-12-31T23:59:59Z`.
 
+- `signature_bits` `(int: 0)` - Specifies the number of bits to use in
+  the signature algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384,
+  and 512 for SHA-2-512. Defaults to 0 to automatically detect based
+  on key length (SHA-2-256 for RSA keys, and matching the curve size
+  for NIST P-Curves).
+
+~> **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
+   `signature_bits` value; only RSA issuers will change signature types
+   based on this parameter.
+
 #### Sample Payload
 
 ```json

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -561,6 +561,16 @@ when signing an externally-owned intermediate.
   `YYYY-MM-ddTHH:MM:SSZ`. Supports the Y10K end date for IEEE 802.1AR-2018
   standard devices, `9999-12-31T23:59:59Z`.
 
+- `signature_bits` `(int: 0)` - Specifies the number of bits to use in
+  the signature algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384,
+  and 512 for SHA-2-512. Defaults to 0 to automatically detect based
+  on key length (SHA-2-256 for RSA keys, and matching the curve size
+  for NIST P-Curves).
+
+~> **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
+   `signature_bits` value; only RSA issuers will change signature types
+   based on this parameter.
+
 #### Sample Payload
 
 ```json


### PR DESCRIPTION
Both of these two signing requests lacked the `signature_bits` parameter, prohibiting callers from modifying the signature size on RSA key sizes. 

Notably, this parameter is present on root generation and role based signing. Since this parameter might change from request to request, I opted not to pull it out of the role and instead use the API-provided value. 