### PR TITLE
secrets/k8s: fix api docs for generated_role_rules json

### DIFF
--- a/website/content/api-docs/secret/kubernetes.mdx
+++ b/website/content/api-docs/secret/kubernetes.mdx
@@ -210,7 +210,7 @@ Or to define the same rules as JSON:
 ```json
 {
   "allowed_kubernetes_namespaces": "*",
-  "generated_role_rules": "'rules': [{'apiGroups': ['],'resources': ['pods'],'verbs': ['list']}]"
+  "generated_role_rules": "'rules': [{'apiGroups': [''],'resources': ['pods'],'verbs': ['list']}]"
 }
 ```
 


### PR DESCRIPTION
This PR fixes a sample JSON payload for `generated_role_rules` in the k8s secrets API docs.