### PR TITLE
Specify the size of the ephemeral key for transit imports

### DIFF
--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -102,7 +102,7 @@ To import key material into an existing key, see the `import_version/` endpoint.
   create. This is specified as part of the URL.
 
 - `ciphertext` `(string: <required>)` - A base64-encoded string that contains
-two values: an ephemeral AES key wrapped using the wrapping key
+two values: an ephemeral 256-bit AES key wrapped using the wrapping key
 returned by Vault and the encryption of the import key material under the
 provided AES key. The wrapped AES key should be the first 512 bytes of the
 ciphertext, and the encrypted key material should be the remaining bytes.
@@ -189,7 +189,7 @@ Vault can import new key material from an external source.
   create. This is specified as part of the URL.
 
 - `ciphertext` `(string: <required>)` - A base64-encoded string that contains
-two values: an ephemeral AES key wrapped using the wrapping key
+two values: an ephemeral 256-bit AES key wrapped using the wrapping key
 returned by Vault and the encryption of the import key material under the
 provided AES key. The wrapped AES key should be the first 512 bytes of the
 ciphertext, and the encrypted key material should be the remaining bytes.

--- a/website/content/docs/secrets/transit.mdx
+++ b/website/content/docs/secrets/transit.mdx
@@ -260,7 +260,7 @@ two possible scenarios:
 - If the HSM supports the CKM_RSA_AES_KEY_WRAP mechanism, that can be used to wrap the
 target key using the wrapping key.
 
-- Otherwise, two mechanisms can be combined to wrap the target key. First, an AES key should
+- Otherwise, two mechanisms can be combined to wrap the target key. First, a 256-bit AES key should
 be generated and then used to wrap the target key using the CKM_AES_KEY_WRAP_KWP mechanism.
 Then the AES key should be wrapped under the wrapping key using the CKM_RSA_PKCS_OAEP mechanism
 using MGF1 and either SHA-1, SHA-224, SHA-256, SHA-384, or SHA-512.
@@ -274,7 +274,7 @@ The ciphertext bytes should be base64-encoded.
 If the target key is not stored in an HSM or KMS, the following steps can be used to construct
 the ciphertext for the input of the `import` endpoint:
 
-- Generate an ephemeral AES key.
+- Generate an ephemeral 256-bit AES key.
 
 - Wrap the target key using the ephemeral AES key with AES-KWP.
 


### PR DESCRIPTION
The docs currently describe using an AES key for wrapping, but don't specify the key size