### PR TITLE
VAULT-8463 Vault no longer crashes if telemetry is not working

### DIFF
--- a/internalshared/configutil/telemetry.go
+++ b/internalshared/configutil/telemetry.go
@@ -353,10 +353,11 @@ func SetupTelemetry(opts *SetupTelemetryOpts) (*metrics.InmemSink, *metricsutil.
 
 		sink, err := datadog.NewDogStatsdSink(opts.Config.DogStatsDAddr, metricsConf.HostName)
 		if err != nil {
-			return nil, nil, false, fmt.Errorf("failed to start DogStatsD sink: %w", err)
+			opts.Ui.Error(fmt.Sprintf("failed to start DogStatsD sink: %s", err))
+		} else {
+			sink.SetTags(tags)
+			fanout = append(fanout, sink)
 		}
-		sink.SetTags(tags)
-		fanout = append(fanout, sink)
 	}
 
 	// Configure the stackdriver sink


### PR DESCRIPTION
Issue https://github.com/hashicorp/vault/issues/8463

If it was not possible to connect to DogStats, then the service will still start.

The rest of the fixes are needed in the repository https://github.com/DataDog/datadog-go

