### PR TITLE
Return errors on short PEM bundles (keys, issuers)

### DIFF
--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -150,7 +150,7 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 		// encoding has been applied. Detect this and give a better warning
 		// than "provided PEM block contained no data" in this case. This is
 		// because the PEM headers contain 5*4 + 6 + 4 + 2 + 2 = 34 characters
-		// minimum (four dashes, "BEGIN" + space + at least one character
+		// minimum (five dashes, "BEGIN" + space + at least one character
 		// identifier, "END" + space + at least one character identifier, and
 		// a pair of new lines). That would leave 41 bytes for Base64 data,
 		// meaning at most a 30-byte DER certificate.

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -144,6 +144,21 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 		keysAllowed = false
 		pemBundle = certificate
 	}
+	if len(pemBundle) < 75 {
+		// It is almost nearly impossible to store a complete certificate in
+		// less than 75 bytes. It is definitely impossible to do so when PEM
+		// encoding has been applied. Detect this and give a better warning
+		// than "provided PEM block contained no data" in this case. This is
+		// because the PEM headers contain 5*4 + 6 + 4 + 2 + 2 = 34 characters
+		// minimum (four dashes, "BEGIN" + space + at least one character
+		// identifier, "END" + space + at least one character identifier, and
+		// a pair of new lines). That would leave 41 bytes for Base64 data,
+		// meaning at most a 30-byte DER certificate.
+		//
+		// However, < 75 bytes is probably a good length for a file path so
+		// suggest that is the case.
+		return logical.ErrorResponse("provided data for import was too short; perhaps a path was passed to the API rather than the contents of a PEM file"), nil
+	}
 
 	var createdKeys []string
 	var createdIssuers []string

--- a/builtin/logical/pki/path_manage_keys.go
+++ b/builtin/logical/pki/path_manage_keys.go
@@ -194,6 +194,23 @@ func (b *backend) pathImportKeyHandler(ctx context.Context, req *logical.Request
 		return logical.ErrorResponse(err.Error()), nil
 	}
 
+	if len(pemBundle) < 64 {
+		// It is almost nearly impossible to store a complete key in
+		// less than 64 bytes. It is definitely impossible to do so when PEM
+		// encoding has been applied. Detect this and give a better warning
+		// than "provided PEM block contained no data" in this case. This is
+		// because the PEM headers contain 5*4 + 6 + 4 + 2 + 2 = 34 characters
+		// minimum (four dashes, "BEGIN" + space + at least one character
+		// identifier, "END" + space + at least one character identifier, and
+		// a pair of new lines). That would leave 30 bytes for Base64 data,
+		// meaning at most a 22-byte DER key. Even with a 128-bit key, 6 bytes
+		// is not sufficient for the required ASN.1 structure and OID encoding.
+		//
+		// However, < 64 bytes is probably a good length for a file path so
+		// suggest that is the case.
+		return logical.ErrorResponse("provided data for import was too short; perhaps a path was passed to the API rather than the contents of a PEM file"), nil
+	}
+
 	pemBytes := []byte(pemBundle)
 	var pemBlock *pem.Block
 

--- a/builtin/logical/pki/path_manage_keys.go
+++ b/builtin/logical/pki/path_manage_keys.go
@@ -200,7 +200,7 @@ func (b *backend) pathImportKeyHandler(ctx context.Context, req *logical.Request
 		// encoding has been applied. Detect this and give a better warning
 		// than "provided PEM block contained no data" in this case. This is
 		// because the PEM headers contain 5*4 + 6 + 4 + 2 + 2 = 34 characters
-		// minimum (four dashes, "BEGIN" + space + at least one character
+		// minimum (five dashes, "BEGIN" + space + at least one character
 		// identifier, "END" + space + at least one character identifier, and
 		// a pair of new lines). That would leave 30 bytes for Base64 data,
 		// meaning at most a 22-byte DER key. Even with a 128-bit key, 6 bytes


### PR DESCRIPTION
When users pass the path of the bundle to the API, rather than the
contents of the bundle (say, by omitting the `@` symbol on a Vault CLI
request), give a better error message indicating to the user what the
potential problem might be. While a larger bound for certificates was
given (75 bytes, likely 100 would be fine as well), a smaller bound had
to be chosen for keys as there's less standard DER encoding data around
them.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`