### PR TITLE
Clarify LIST /certs doesn't include imports

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1054,6 +1054,11 @@ This endpoint returns a list of the current certificates by serial number only.
 The response does not include the [special serial numbers](#read-certificate-serial-param-values)
 (`ca`, `ca_chain`, and `crl`) that can be used with `/pki/cert/:serial`.
 
+This includes only certificates issued by this mount with `no_store=false`.
+While root generation does create entries here, importing certificates
+(including both roots and intermediates) will not cause the imported
+certificate's serial number to appear in this list.
+
 ~> Note: The endpoint to list all certificates is authenticated. This is to
    prevent automated enumeration of issued certificates for internal services;
    however, this information should generally be considered non-sensitive and


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

This behavior isn't new and has existed for a while (even before the rotation changes). Since the dos were heavily restructured in 1.11, I'm going to avoid backporting this to 1.10 though. 