### PR TITLE
Named path adapter findRecord override

### DIFF
--- a/ui/app/adapters/named-path.js
+++ b/ui/app/adapters/named-path.js
@@ -23,6 +23,16 @@ export default class NamedPathAdapter extends ApplicationAdapter {
   updateRecord() {
     return this._saveRecord(...arguments);
   }
+  // if backend does not return name in response Ember Data will throw an error for pushing a record with no id
+  // use the id (name) supplied to findRecord to set property on response data
+  findRecord(store, type, name) {
+    return super.findRecord(...arguments).then((resp) => {
+      if (!resp.data.name) {
+        resp.data.name = name;
+      }
+      return resp;
+    });
+  }
   // GET request with list=true as query param
   query(store, type, query) {
     const url = this.urlForQuery(query, type.modelName);


### PR DESCRIPTION
In order to prevent Ember Data from throwing an error if the backend does no return the name property in the response data, a findRecord override was added in the `NamedPathAdapter` to set the property with the id (name) supplied to the findRecord store method. 