### PR TITLE
Replace deprecated ioutil pkg with os & io

### DIFF
--- a/api/auth/azure/azure.go
+++ b/api/auth/azure/azure.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -172,7 +172,7 @@ func (a *AzureAuth) getJWT() (string, error) {
 	}
 	defer resp.Body.Close()
 
-	responseBytes, err := ioutil.ReadAll(resp.Body)
+	responseBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("error reading response body from Azure token endpoint: %w", err)
 	}
@@ -219,7 +219,7 @@ func getMetadata() (metadataJSON, error) {
 	}
 	defer resp.Body.Close()
 
-	responseBytes, err := ioutil.ReadAll(resp.Body)
+	responseBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return metadataJSON{}, fmt.Errorf("error reading response body from metadata endpoint: %w", err)
 	}

--- a/api/auth/gcp/gcp.go
+++ b/api/auth/gcp/gcp.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -178,7 +178,7 @@ func (a *GCPAuth) getJWTFromMetadataService(vaultAddress string) (string, error)
 	defer resp.Body.Close()
 
 	// get jwt from response
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	jwt := string(body)
 	if err != nil {
 		return "", fmt.Errorf("error reading response from metadata service: %w", err)

--- a/api/request.go
+++ b/api/request.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -73,13 +72,13 @@ func (r *Request) ToHTTP() (*http.Request, error) {
 		// No body
 
 	case r.BodyBytes != nil:
-		req.Request.Body = ioutil.NopCloser(bytes.NewReader(r.BodyBytes))
+		req.Request.Body = io.NopCloser(bytes.NewReader(r.BodyBytes))
 
 	default:
 		if c, ok := r.Body.(io.ReadCloser); ok {
 			req.Request.Body = c
 		} else {
-			req.Request.Body = ioutil.NopCloser(r.Body)
+			req.Request.Body = io.NopCloser(r.Body)
 		}
 	}
 

--- a/api/response.go
+++ b/api/response.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -41,7 +40,7 @@ func (r *Response) Error() error {
 	}
 
 	r.Body.Close()
-	r.Body = ioutil.NopCloser(bodyBuf)
+	r.Body = io.NopCloser(bodyBuf)
 	ns := r.Header.Get(consts.NamespaceHeaderName)
 
 	// Build up the error object

--- a/api/ssh_agent.go
+++ b/api/ssh_agent.go
@@ -5,14 +5,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 
 	"github.com/hashicorp/errwrap"
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
-	multierror "github.com/hashicorp/go-multierror"
-	rootcerts "github.com/hashicorp/go-rootcerts"
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-rootcerts"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/vault/sdk/helper/hclutil"
@@ -139,7 +138,7 @@ func (c *SSHHelperConfig) NewClient() (*Client, error) {
 // Vault address is a required parameter.
 // Mount point defaults to "ssh".
 func LoadSSHHelperConfig(path string) (*SSHHelperConfig, error) {
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, multierror.Prefix(err, "ssh_helper:")
 	}

--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sync"
 	"time"
@@ -197,7 +196,7 @@ func (c *Sys) RaftSnapshotWithContext(ctx context.Context, snapWriter io.Writer)
 	dup := io.TeeReader(resp.Body, wPipe)
 	go func() {
 		defer func() {
-			io.Copy(ioutil.Discard, rPipe)
+			io.Copy(io.Discard, rPipe)
 			rPipe.Close()
 			wg.Done()
 		}()
@@ -218,7 +217,7 @@ func (c *Sys) RaftSnapshotWithContext(ctx context.Context, snapWriter io.Writer)
 				continue
 			}
 			var b []byte
-			b, err = ioutil.ReadAll(t)
+			b, err = io.ReadAll(t)
 			if err != nil || len(b) == 0 {
 				return
 			}

--- a/audit/format_test.go
+++ b/audit/format_test.go
@@ -3,7 +3,6 @@ package audit
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/helper/salt"
@@ -41,7 +40,7 @@ func TestFormatRequestErrors(t *testing.T) {
 		AuditFormatWriter: &noopFormatWriter{},
 	}
 
-	if err := formatter.FormatRequest(context.Background(), ioutil.Discard, config, &logical.LogInput{}); err == nil {
+	if err := formatter.FormatRequest(context.Background(), io.Discard, config, &logical.LogInput{}); err == nil {
 		t.Fatal("expected error due to nil request")
 	}
 
@@ -59,7 +58,7 @@ func TestFormatResponseErrors(t *testing.T) {
 		AuditFormatWriter: &noopFormatWriter{},
 	}
 
-	if err := formatter.FormatResponse(context.Background(), ioutil.Discard, config, &logical.LogInput{}); err == nil {
+	if err := formatter.FormatResponse(context.Background(), io.Discard, config, &logical.LogInput{}); err == nil {
 		t.Fatal("expected error due to nil request")
 	}
 

--- a/builtin/audit/file/backend_test.go
+++ b/builtin/audit/file/backend_test.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -22,7 +21,7 @@ func TestAuditFile_fileModeNew(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	path, err := ioutil.TempDir("", "vault-test_audit_file-file_mode_new")
+	path, err := os.MkdirTemp("", "vault-test_audit_file-file_mode_new")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +54,7 @@ func TestAuditFile_fileModeNew(t *testing.T) {
 }
 
 func TestAuditFile_fileModeExisting(t *testing.T) {
-	f, err := ioutil.TempFile("", "test")
+	f, err := os.CreateTemp("", "test")
 	if err != nil {
 		t.Fatalf("Failure to create test file.")
 	}
@@ -94,7 +93,7 @@ func TestAuditFile_fileModeExisting(t *testing.T) {
 }
 
 func TestAuditFile_fileMode0000(t *testing.T) {
-	f, err := ioutil.TempFile("", "test")
+	f, err := os.CreateTemp("", "test")
 	if err != nil {
 		t.Fatalf("Failure to create test file. The error is %v", err)
 	}

--- a/builtin/credential/aws/backend_test.go
+++ b/builtin/credential/aws/backend_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -1490,7 +1490,7 @@ func buildCallerIdentityLoginData(request *http.Request, roleName string) (map[s
 	if err != nil {
 		return nil, err
 	}
-	requestBody, err := ioutil.ReadAll(request.Body)
+	requestBody, err := io.ReadAll(request.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -9,7 +9,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -21,11 +21,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/errwrap"
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/go-secure-stdlib/awsutil"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/builtin/credential/aws/pkcs7"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/cidrutil"
@@ -1740,7 +1740,7 @@ func submitCallerIdentityRequest(ctx context.Context, maxRetries int, method, en
 	}
 
 	// we check for status code afterwards to also print out response body
-	responseBody, err := ioutil.ReadAll(response.Body)
+	responseBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/credential/aws/pkcs7/sign_test.go
+++ b/builtin/credential/aws/pkcs7/sign_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/big"
 	"os"
@@ -93,11 +92,11 @@ func TestSign(t *testing.T) {
 func TestDSASignAndVerifyWithOpenSSL(t *testing.T) {
 	content := []byte("Hello World")
 	// write the content to a temp file
-	tmpContentFile, err := ioutil.TempFile("", "TestDSASignAndVerifyWithOpenSSL_content")
+	tmpContentFile, err := os.CreateTemp("", "TestDSASignAndVerifyWithOpenSSL_content")
 	if err != nil {
 		t.Fatal(err)
 	}
-	ioutil.WriteFile(tmpContentFile.Name(), content, 0o755)
+	os.WriteFile(tmpContentFile.Name(), content, 0o755)
 
 	block, _ := pem.Decode([]byte(dsaPublicCert))
 	if block == nil {
@@ -109,11 +108,11 @@ func TestDSASignAndVerifyWithOpenSSL(t *testing.T) {
 	}
 
 	// write the signer cert to a temp file
-	tmpSignerCertFile, err := ioutil.TempFile("", "TestDSASignAndVerifyWithOpenSSL_signer")
+	tmpSignerCertFile, err := os.CreateTemp("", "TestDSASignAndVerifyWithOpenSSL_signer")
 	if err != nil {
 		t.Fatal(err)
 	}
-	ioutil.WriteFile(tmpSignerCertFile.Name(), dsaPublicCert, 0o755)
+	os.WriteFile(tmpSignerCertFile.Name(), dsaPublicCert, 0o755)
 
 	priv := dsa.PrivateKey{
 		PublicKey: dsa.PublicKey{
@@ -139,11 +138,11 @@ func TestDSASignAndVerifyWithOpenSSL(t *testing.T) {
 	}
 
 	// write the signature to a temp file
-	tmpSignatureFile, err := ioutil.TempFile("", "TestDSASignAndVerifyWithOpenSSL_signature")
+	tmpSignatureFile, err := os.CreateTemp("", "TestDSASignAndVerifyWithOpenSSL_signature")
 	if err != nil {
 		t.Fatal(err)
 	}
-	ioutil.WriteFile(tmpSignatureFile.Name(), pem.EncodeToMemory(&pem.Block{Type: "PKCS7", Bytes: signed}), 0o755)
+	os.WriteFile(tmpSignatureFile.Name(), pem.EncodeToMemory(&pem.Block{Type: "PKCS7", Bytes: signed}), 0o755)
 
 	// call openssl to verify the signature on the content using the root
 	opensslCMD := exec.Command("openssl", "smime", "-verify", "-noverify",
@@ -238,7 +237,7 @@ func TestDegenerateCertificate(t *testing.T) {
 
 // writes the cert to a temporary file and tests that openssl can read it.
 func testOpenSSLParse(t *testing.T, certBytes []byte) {
-	tmpCertFile, err := ioutil.TempFile("", "testCertificate")
+	tmpCertFile, err := os.CreateTemp("", "testCertificate")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/credential/aws/pkcs7/verify_test_dsa.go
+++ b/builtin/credential/aws/pkcs7/verify_test_dsa.go
@@ -5,7 +5,6 @@ package pkcs7
 import (
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -68,27 +67,27 @@ A ship in port is safe,
 but that's not what ships are built for.
 -- Grace Hopper`)
 	// write the content to a temp file
-	tmpContentFile, err := ioutil.TempFile("", "TestDSASignWithOpenSSLAndVerify_content")
+	tmpContentFile, err := os.CreateTemp("", "TestDSASignWithOpenSSLAndVerify_content")
 	if err != nil {
 		t.Fatal(err)
 	}
-	ioutil.WriteFile(tmpContentFile.Name(), content, 0o755)
+	os.WriteFile(tmpContentFile.Name(), content, 0o755)
 
 	// write the signer cert to a temp file
-	tmpSignerCertFile, err := ioutil.TempFile("", "TestDSASignWithOpenSSLAndVerify_signer")
+	tmpSignerCertFile, err := os.CreateTemp("", "TestDSASignWithOpenSSLAndVerify_signer")
 	if err != nil {
 		t.Fatal(err)
 	}
-	ioutil.WriteFile(tmpSignerCertFile.Name(), dsaPublicCert, 0o755)
+	os.WriteFile(tmpSignerCertFile.Name(), dsaPublicCert, 0o755)
 
 	// write the signer key to a temp file
-	tmpSignerKeyFile, err := ioutil.TempFile("", "TestDSASignWithOpenSSLAndVerify_key")
+	tmpSignerKeyFile, err := os.CreateTemp("", "TestDSASignWithOpenSSLAndVerify_key")
 	if err != nil {
 		t.Fatal(err)
 	}
-	ioutil.WriteFile(tmpSignerKeyFile.Name(), dsaPrivateKey, 0o755)
+	os.WriteFile(tmpSignerKeyFile.Name(), dsaPrivateKey, 0o755)
 
-	tmpSignedFile, err := ioutil.TempFile("", "TestDSASignWithOpenSSLAndVerify_signature")
+	tmpSignedFile, err := os.CreateTemp("", "TestDSASignWithOpenSSLAndVerify_signature")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +102,7 @@ but that's not what ships are built for.
 	}
 
 	// verify the signed content
-	pemSignature, err := ioutil.ReadFile(tmpSignedFile.Name())
+	pemSignature, err := os.ReadFile(tmpSignedFile.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	mathrand "math/rand"
 	"net"
@@ -29,12 +28,12 @@ import (
 
 	"golang.org/x/net/http2"
 
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/go-cleanhttp"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	vaulthttp "github.com/hashicorp/vault/http"
 
-	rootcerts "github.com/hashicorp/go-rootcerts"
+	"github.com/hashicorp/go-rootcerts"
 	"github.com/hashicorp/vault/builtin/logical/pki"
 	logicaltest "github.com/hashicorp/vault/helper/testhelpers/logical"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -63,7 +62,7 @@ const (
 
 func generateTestCertAndConnState(t *testing.T, template *x509.Certificate) (string, tls.ConnectionState, error) {
 	t.Helper()
-	tempDir, err := ioutil.TempDir("", "vault-cert-auth-test-")
+	tempDir, err := os.MkdirTemp("", "vault-cert-auth-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +96,7 @@ func generateTestCertAndConnState(t *testing.T, template *x509.Certificate) (str
 		Type:  "CERTIFICATE",
 		Bytes: caBytes,
 	}
-	err = ioutil.WriteFile(filepath.Join(tempDir, "ca_cert.pem"), pem.EncodeToMemory(caCertPEMBlock), 0o755)
+	err = os.WriteFile(filepath.Join(tempDir, "ca_cert.pem"), pem.EncodeToMemory(caCertPEMBlock), 0o755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +108,7 @@ func generateTestCertAndConnState(t *testing.T, template *x509.Certificate) (str
 		Type:  "EC PRIVATE KEY",
 		Bytes: marshaledCAKey,
 	}
-	err = ioutil.WriteFile(filepath.Join(tempDir, "ca_key.pem"), pem.EncodeToMemory(caKeyPEMBlock), 0o755)
+	err = os.WriteFile(filepath.Join(tempDir, "ca_key.pem"), pem.EncodeToMemory(caKeyPEMBlock), 0o755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +125,7 @@ func generateTestCertAndConnState(t *testing.T, template *x509.Certificate) (str
 		Type:  "CERTIFICATE",
 		Bytes: certBytes,
 	}
-	err = ioutil.WriteFile(filepath.Join(tempDir, "cert.pem"), pem.EncodeToMemory(certPEMBlock), 0o755)
+	err = os.WriteFile(filepath.Join(tempDir, "cert.pem"), pem.EncodeToMemory(certPEMBlock), 0o755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +137,7 @@ func generateTestCertAndConnState(t *testing.T, template *x509.Certificate) (str
 		Type:  "EC PRIVATE KEY",
 		Bytes: marshaledKey,
 	}
-	err = ioutil.WriteFile(filepath.Join(tempDir, "key.pem"), pem.EncodeToMemory(keyPEMBlock), 0o755)
+	err = os.WriteFile(filepath.Join(tempDir, "key.pem"), pem.EncodeToMemory(keyPEMBlock), 0o755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -371,7 +370,7 @@ func TestBackend_PermittedDNSDomainsIntermediateCA(t *testing.T) {
 
 	// Create temporary files for CA cert, client cert and client cert key.
 	// This is used to configure TLS in the api client.
-	caCertFile, err := ioutil.TempFile("", "caCert")
+	caCertFile, err := os.CreateTemp("", "caCert")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -383,7 +382,7 @@ func TestBackend_PermittedDNSDomainsIntermediateCA(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	leafCertFile, err := ioutil.TempFile("", "leafCert")
+	leafCertFile, err := os.CreateTemp("", "leafCert")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -395,7 +394,7 @@ func TestBackend_PermittedDNSDomainsIntermediateCA(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	leafCertKeyFile, err := ioutil.TempFile("", "leafCertKey")
+	leafCertKeyFile, err := os.CreateTemp("", "leafCertKey")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -520,7 +519,7 @@ func TestBackend_NonCAExpiry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	caCertFile, err := ioutil.TempFile("", "caCert")
+	caCertFile, err := os.CreateTemp("", "caCert")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -534,7 +533,7 @@ func TestBackend_NonCAExpiry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	caKeyFile, err := ioutil.TempFile("", "caKey")
+	caKeyFile, err := os.CreateTemp("", "caKey")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -590,7 +589,7 @@ func TestBackend_NonCAExpiry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	issuedCertFile, err := ioutil.TempFile("", "issuedCert")
+	issuedCertFile, err := os.CreateTemp("", "issuedCert")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -604,7 +603,7 @@ func TestBackend_NonCAExpiry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	issuedKeyFile, err := ioutil.TempFile("", "issuedKey")
+	issuedKeyFile, err := os.CreateTemp("", "issuedKey")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -687,7 +686,7 @@ func TestBackend_RegisteredNonCA_CRL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	nonCACert, err := ioutil.ReadFile(testCertPath1)
+	nonCACert, err := os.ReadFile(testCertPath1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -732,7 +731,7 @@ func TestBackend_RegisteredNonCA_CRL(t *testing.T) {
 	}
 
 	// Register a CRL containing the issued client certificate used above.
-	issuedCRL, err := ioutil.ReadFile(testIssuedCertCRL)
+	issuedCRL, err := os.ReadFile(testIssuedCertCRL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -770,7 +769,7 @@ func TestBackend_CRLs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	clientCA1, err := ioutil.ReadFile(testRootCACertPath1)
+	clientCA1, err := os.ReadFile(testRootCACertPath1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -828,7 +827,7 @@ func TestBackend_CRLs(t *testing.T) {
 	}
 
 	// Register a CRL containing the issued client certificate used above.
-	issuedCRL, err := ioutil.ReadFile(testIssuedCertCRL)
+	issuedCRL, err := os.ReadFile(testIssuedCertCRL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -857,7 +856,7 @@ func TestBackend_CRLs(t *testing.T) {
 	}
 
 	// Register a different client CA certificate.
-	clientCA2, err := ioutil.ReadFile(testRootCACertPath2)
+	clientCA2, err := os.ReadFile(testRootCACertPath2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -881,7 +880,7 @@ func TestBackend_CRLs(t *testing.T) {
 	}
 
 	// Register a CRL containing the root CA certificate used above.
-	rootCRL, err := ioutil.ReadFile(testRootCertCRL)
+	rootCRL, err := os.ReadFile(testRootCertCRL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -918,17 +917,17 @@ func testFactory(t *testing.T) logical.Backend {
 // Test the certificates being registered to the backend
 func TestBackend_CertWrites(t *testing.T) {
 	// CA cert
-	ca1, err := ioutil.ReadFile("test-fixtures/root/rootcacert.pem")
+	ca1, err := os.ReadFile("test-fixtures/root/rootcacert.pem")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	// Non CA Cert
-	ca2, err := ioutil.ReadFile("test-fixtures/keys/cert.pem")
+	ca2, err := os.ReadFile("test-fixtures/keys/cert.pem")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	// Non CA cert without TLS web client authentication
-	ca3, err := ioutil.ReadFile("test-fixtures/noclientauthcert.pem")
+	ca3, err := os.ReadFile("test-fixtures/noclientauthcert.pem")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -952,7 +951,7 @@ func TestBackend_basic_CA(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error testing connection state: %v", err)
 	}
-	ca, err := ioutil.ReadFile("test-fixtures/root/rootcacert.pem")
+	ca, err := os.ReadFile("test-fixtures/root/rootcacert.pem")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -983,11 +982,11 @@ func TestBackend_Basic_CRLs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error testing connection state: %v", err)
 	}
-	ca, err := ioutil.ReadFile("test-fixtures/root/rootcacert.pem")
+	ca, err := os.ReadFile("test-fixtures/root/rootcacert.pem")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	crl, err := ioutil.ReadFile("test-fixtures/root/root.crl")
+	crl, err := os.ReadFile("test-fixtures/root/root.crl")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1012,7 +1011,7 @@ func TestBackend_basic_singleCert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error testing connection state: %v", err)
 	}
-	ca, err := ioutil.ReadFile("test-fixtures/root/rootcacert.pem")
+	ca, err := os.ReadFile("test-fixtures/root/rootcacert.pem")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1037,7 +1036,7 @@ func TestBackend_common_name_singleCert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error testing connection state: %v", err)
 	}
-	ca, err := ioutil.ReadFile("test-fixtures/root/rootcacert.pem")
+	ca, err := os.ReadFile("test-fixtures/root/rootcacert.pem")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1066,7 +1065,7 @@ func TestBackend_ext_singleCert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error testing connection state: %v", err)
 	}
-	ca, err := ioutil.ReadFile("test-fixtures/root/rootcacert.pem")
+	ca, err := os.ReadFile("test-fixtures/root/rootcacert.pem")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1140,7 +1139,7 @@ func TestBackend_dns_singleCert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error testing connection state: %v", err)
 	}
-	ca, err := ioutil.ReadFile(filepath.Join(tempDir, "ca_cert.pem"))
+	ca, err := os.ReadFile(filepath.Join(tempDir, "ca_cert.pem"))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1187,7 +1186,7 @@ func TestBackend_email_singleCert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error testing connection state: %v", err)
 	}
-	ca, err := ioutil.ReadFile(filepath.Join(tempDir, "ca_cert.pem"))
+	ca, err := os.ReadFile(filepath.Join(tempDir, "ca_cert.pem"))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1219,7 +1218,7 @@ func TestBackend_organizationalUnit_singleCert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error testing connection state: %v", err)
 	}
-	ca, err := ioutil.ReadFile("test-fixtures/root/rootcawoucert.pem")
+	ca, err := os.ReadFile("test-fixtures/root/rootcawoucert.pem")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1268,7 +1267,7 @@ func TestBackend_uri_singleCert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error testing connection state: %v", err)
 	}
-	ca, err := ioutil.ReadFile(filepath.Join(tempDir, "ca_cert.pem"))
+	ca, err := os.ReadFile(filepath.Join(tempDir, "ca_cert.pem"))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1296,7 +1295,7 @@ func TestBackend_mixed_constraints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error testing connection state: %v", err)
 	}
-	ca, err := ioutil.ReadFile("test-fixtures/root/rootcacert.pem")
+	ca, err := os.ReadFile("test-fixtures/root/rootcacert.pem")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1344,7 +1343,7 @@ func TestBackend_validCIDR(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error testing connection state: %v", err)
 	}
-	ca, err := ioutil.ReadFile("test-fixtures/root/rootcacert.pem")
+	ca, err := os.ReadFile("test-fixtures/root/rootcacert.pem")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1426,7 +1425,7 @@ func TestBackend_invalidCIDR(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error testing connection state: %v", err)
 	}
-	ca, err := ioutil.ReadFile("test-fixtures/root/rootcacert.pem")
+	ca, err := os.ReadFile("test-fixtures/root/rootcacert.pem")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1866,7 +1865,7 @@ func Test_Renew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error testing connection state: %v", err)
 	}
-	ca, err := ioutil.ReadFile("test-fixtures/root/rootcacert.pem")
+	ca, err := os.ReadFile("test-fixtures/root/rootcacert.pem")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -14,7 +14,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"hash"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -194,7 +194,7 @@ func getParsedCrlForIssuer(t *testing.T, client *api.Client, mountPoint string, 
 	}
 	defer resp.Body.Close()
 
-	certBytes, err := ioutil.ReadAll(resp.Body)
+	certBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -225,7 +225,7 @@ func getParsedCrlAtPath(t *testing.T, client *api.Client, path string) *pkix.Cer
 	}
 	defer resp.Body.Close()
 
-	crlBytes, err := ioutil.ReadAll(resp.Body)
+	crlBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/builtin/logical/rabbitmq/path_role_create.go
+++ b/builtin/logical/rabbitmq/path_role_create.go
@@ -3,7 +3,7 @@ package rabbitmq
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/template"
@@ -103,7 +103,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 		}
 	}()
 	if !isIn200s(resp.StatusCode) {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("error creating user %s - %d: %s", username, resp.StatusCode, body)
 	}
 
@@ -118,7 +118,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 			b.Logger().Error(fmt.Sprintf("deleting %s due to permissions being in an unknown state, but failed: %s", username, err))
 		}
 		if !isIn200s(resp.StatusCode) {
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			b.Logger().Error(fmt.Sprintf("deleting %s due to permissions being in an unknown state, but error deleting: %d: %s", username, resp.StatusCode, body))
 		}
 	}()
@@ -141,7 +141,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 				}
 			}()
 			if !isIn200s(resp.StatusCode) {
-				body, _ := ioutil.ReadAll(resp.Body)
+				body, _ := io.ReadAll(resp.Body)
 				return fmt.Errorf("error updating vhost permissions for %s - %d: %s", vhost, resp.StatusCode, body)
 			}
 			return nil
@@ -170,7 +170,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 					}
 				}()
 				if !isIn200s(resp.StatusCode) {
-					body, _ := ioutil.ReadAll(resp.Body)
+					body, _ := io.ReadAll(resp.Body)
 					return fmt.Errorf("error updating vhost permissions for %s - %d: %s", vhost, resp.StatusCode, body)
 				}
 				return nil

--- a/builtin/logical/ssh/communicator.go
+++ b/builtin/logical/ssh/communicator.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -296,7 +295,7 @@ func scpUploadFile(dst string, src io.Reader, w io.Writer, r *bufio.Reader, fi *
 	} else {
 		// Create a temporary file where we can copy the contents of the src
 		// so that we can determine the length, since SCP is length-prefixed.
-		tf, err := ioutil.TempFile("", "vault-ssh-upload")
+		tf, err := os.CreateTemp("", "vault-ssh-upload")
 		if err != nil {
 			return fmt.Errorf("error creating temporary file for upload: %w", err)
 		}

--- a/command/agent.go
+++ b/command/agent.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -1043,7 +1042,7 @@ func getServiceAccountJWT(tokenFile string) (string, error) {
 	if len(tokenFile) == 0 {
 		tokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 	}
-	token, err := ioutil.ReadFile(tokenFile)
+	token, err := os.ReadFile(tokenFile)
 	if err != nil {
 		return "", err
 	}

--- a/command/agent/alicloud_end_to_end_test.go
+++ b/command/agent/alicloud_end_to_end_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -12,8 +11,8 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials/providers"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/sts"
-	hclog "github.com/hashicorp/go-hclog"
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-uuid"
 	vaultalicloud "github.com/hashicorp/vault-plugin-auth-alicloud"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agent/auth"
@@ -111,7 +110,7 @@ func TestAliCloudEndToEnd(t *testing.T) {
 		}
 	}()
 
-	tmpFile, err := ioutil.TempFile("", "auth.tokensink.test.")
+	tmpFile, err := os.CreateTemp("", "auth.tokensink.test.")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/command/agent/approle_end_to_end_test.go
+++ b/command/agent/approle_end_to_end_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -35,8 +34,8 @@ func TestAppRoleEndToEnd(t *testing.T) {
 		{false, true, false, true},
 		{true, true, false, true},
 
-		//bindSecretID=false, wrong secret provided => token expected
-		//(vault ignores the supplied secret_id if bind_secret_id=false)
+		// bindSecretID=false, wrong secret provided => token expected
+		// (vault ignores the supplied secret_id if bind_secret_id=false)
 		{false, false, false, true},
 		{true, false, false, true},
 
@@ -146,7 +145,7 @@ func testAppRoleEndToEnd(t *testing.T, removeSecretIDFile bool, bindSecretID boo
 	}
 	roleID2 := resp.Data["role_id"].(string)
 
-	rolef, err := ioutil.TempFile("", "auth.role-id.test.")
+	rolef, err := os.CreateTemp("", "auth.role-id.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +154,7 @@ func testAppRoleEndToEnd(t *testing.T, removeSecretIDFile bool, bindSecretID boo
 	defer os.Remove(role)
 	t.Logf("input role_id_file_path: %s", role)
 	if bindSecretID {
-		secretf, err := ioutil.TempFile("", "auth.secret-id.test.")
+		secretf, err := os.CreateTemp("", "auth.secret-id.test.")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -168,7 +167,7 @@ func testAppRoleEndToEnd(t *testing.T, removeSecretIDFile bool, bindSecretID boo
 	}
 	// We close these right away because we're just basically testing
 	// permissions and finding a usable file name
-	ouf, err := ioutil.TempFile("", "auth.tokensink.test.")
+	ouf, err := os.CreateTemp("", "auth.tokensink.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,7 +184,7 @@ func testAppRoleEndToEnd(t *testing.T, removeSecretIDFile bool, bindSecretID boo
 	}
 	if !bindSecretID && !secretIDLess {
 		logger.Trace("agent is providing an invalid secret that should be ignored")
-		secretf, err := ioutil.TempFile("", "auth.secret-id.test.")
+		secretf, err := os.CreateTemp("", "auth.secret-id.test.")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -193,7 +192,7 @@ func testAppRoleEndToEnd(t *testing.T, removeSecretIDFile bool, bindSecretID boo
 		secretf.Close()
 		defer os.Remove(secretFromAgent)
 		// if the token is empty, auth.approle would fail reporting the error
-		if err := ioutil.WriteFile(secretFromAgent, []byte("wrong-secret"), 0o600); err != nil {
+		if err := os.WriteFile(secretFromAgent, []byte("wrong-secret"), 0o600); err != nil {
 			t.Fatal(err)
 		} else {
 			logger.Trace("wrote secret_id_file_path with wrong-secret", "path", secretFromAgent)
@@ -280,14 +279,14 @@ func testAppRoleEndToEnd(t *testing.T, removeSecretIDFile bool, bindSecretID boo
 		t.Fatal("expected notexist err")
 	}
 
-	if err := ioutil.WriteFile(role, []byte(roleID1), 0o600); err != nil {
+	if err := os.WriteFile(role, []byte(roleID1), 0o600); err != nil {
 		t.Fatal(err)
 	} else {
 		logger.Trace("wrote test role 1", "path", role)
 	}
 
 	if bindSecretID {
-		if err := ioutil.WriteFile(secret, []byte(secretID1), 0o600); err != nil {
+		if err := os.WriteFile(secret, []byte(secretID1), 0o600); err != nil {
 			t.Fatal(err)
 		} else {
 			logger.Trace("wrote test secret 1", "path", secret)
@@ -305,7 +304,7 @@ func testAppRoleEndToEnd(t *testing.T, removeSecretIDFile bool, bindSecretID boo
 				}
 				return ""
 			}
-			val, err := ioutil.ReadFile(out)
+			val, err := os.ReadFile(out)
 			if err == nil {
 				os.Remove(out)
 				if len(val) == 0 {
@@ -359,14 +358,14 @@ func testAppRoleEndToEnd(t *testing.T, removeSecretIDFile bool, bindSecretID boo
 	}
 
 	// Write new values
-	if err := ioutil.WriteFile(role, []byte(roleID2), 0o600); err != nil {
+	if err := os.WriteFile(role, []byte(roleID2), 0o600); err != nil {
 		t.Fatal(err)
 	} else {
 		logger.Trace("wrote test role 2", "path", role)
 	}
 
 	if bindSecretID {
-		if err := ioutil.WriteFile(secret, []byte(secretID2), 0o600); err != nil {
+		if err := os.WriteFile(secret, []byte(secretID2), 0o600); err != nil {
 			t.Fatal(err)
 		} else {
 			logger.Trace("wrote test secret 2", "path", secret)
@@ -408,8 +407,8 @@ func TestAppRoleWithWrapping(t *testing.T) {
 		// default behaviour => token expected
 		{true, false, true},
 
-		//bindSecretID=false, wrong secret provided, wrapping_path provided => token not expected
-		//(wrapping token is not valid or does not exist)
+		// bindSecretID=false, wrong secret provided, wrapping_path provided => token not expected
+		// (wrapping token is not valid or does not exist)
 		{false, false, false},
 
 		// bindSecretID=false, no secret provided, wrapping_path provided but ignored => token expected
@@ -488,7 +487,7 @@ func testAppRoleWithWrapping(t *testing.T, bindSecretID bool, secretIDLess bool,
 	}
 	roleID1 := resp.Data["role_id"].(string)
 
-	rolef, err := ioutil.TempFile("", "auth.role-id.test.")
+	rolef, err := os.CreateTemp("", "auth.role-id.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -498,7 +497,7 @@ func testAppRoleWithWrapping(t *testing.T, bindSecretID bool, secretIDLess bool,
 	t.Logf("input role_id_file_path: %s", role)
 
 	if bindSecretID {
-		secretf, err := ioutil.TempFile("", "auth.secret-id.test.")
+		secretf, err := os.CreateTemp("", "auth.secret-id.test.")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -512,7 +511,7 @@ func testAppRoleWithWrapping(t *testing.T, bindSecretID bool, secretIDLess bool,
 
 	// We close these right away because we're just basically testing
 	// permissions and finding a usable file name
-	ouf, err := ioutil.TempFile("", "auth.tokensink.test.")
+	ouf, err := os.CreateTemp("", "auth.tokensink.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -529,7 +528,7 @@ func testAppRoleWithWrapping(t *testing.T, bindSecretID bool, secretIDLess bool,
 	}
 	if !bindSecretID && !secretIDLess {
 		logger.Trace("agent is providing an invalid secret that should be ignored")
-		secretf, err := ioutil.TempFile("", "auth.secret-id.test.")
+		secretf, err := os.CreateTemp("", "auth.secret-id.test.")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -537,7 +536,7 @@ func testAppRoleWithWrapping(t *testing.T, bindSecretID bool, secretIDLess bool,
 		secretf.Close()
 		defer os.Remove(secretFromAgent)
 		// if the token is empty, auth.approle would fail reporting the error
-		if err := ioutil.WriteFile(secretFromAgent, []byte("wrong-secret"), 0o600); err != nil {
+		if err := os.WriteFile(secretFromAgent, []byte("wrong-secret"), 0o600); err != nil {
 			t.Fatal(err)
 		} else {
 			logger.Trace("wrote secret_id_file_path with wrong-secret", "path", secretFromAgent)
@@ -624,7 +623,7 @@ func testAppRoleWithWrapping(t *testing.T, bindSecretID bool, secretIDLess bool,
 		t.Fatal("expected notexist err")
 	}
 
-	if err := ioutil.WriteFile(role, []byte(roleID1), 0o600); err != nil {
+	if err := os.WriteFile(role, []byte(roleID1), 0o600); err != nil {
 		t.Fatal(err)
 	} else {
 		logger.Trace("wrote test role 1", "path", role)
@@ -633,7 +632,7 @@ func testAppRoleWithWrapping(t *testing.T, bindSecretID bool, secretIDLess bool,
 	if bindSecretID {
 		logger.Trace("WRITING TO auth.secret-id.test.", "secret", secret, "secretID1", secretID1)
 
-		if err := ioutil.WriteFile(secret, []byte(secretID1), 0o600); err != nil {
+		if err := os.WriteFile(secret, []byte(secretID1), 0o600); err != nil {
 			t.Fatal(err)
 		} else {
 			logger.Trace("wrote test secret 1", "path", secret)
@@ -651,7 +650,7 @@ func testAppRoleWithWrapping(t *testing.T, bindSecretID bool, secretIDLess bool,
 				}
 				return ""
 			}
-			val, err := ioutil.ReadFile(out)
+			val, err := os.ReadFile(out)
 			if err == nil {
 				os.Remove(out)
 				if len(val) == 0 {
@@ -713,7 +712,7 @@ func testAppRoleWithWrapping(t *testing.T, bindSecretID bool, secretIDLess bool,
 			t.Fatal(err)
 		}
 		secretID2 := resp.WrapInfo.Token
-		if err := ioutil.WriteFile(secret, []byte(secretID2), 0o600); err != nil {
+		if err := os.WriteFile(secret, []byte(secretID2), 0o600); err != nil {
 			t.Fatal(err)
 		} else {
 			logger.Trace("wrote test secret 2", "path", secret)

--- a/command/agent/auth/approle/approle.go
+++ b/command/agent/auth/approle/approle.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agent/auth"
@@ -89,7 +88,7 @@ func NewApproleAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 
 func (a *approleMethod) Authenticate(ctx context.Context, client *api.Client) (string, http.Header, map[string]interface{}, error) {
 	if _, err := os.Stat(a.roleIDFilePath); err == nil {
-		roleID, err := ioutil.ReadFile(a.roleIDFilePath)
+		roleID, err := os.ReadFile(a.roleIDFilePath)
 		if err != nil {
 			if a.cachedRoleID == "" {
 				return "", nil, nil, fmt.Errorf("error reading role ID file and no cached role ID known: %w", err)
@@ -117,7 +116,7 @@ func (a *approleMethod) Authenticate(ctx context.Context, client *api.Client) (s
 	}
 
 	if _, err := os.Stat(a.secretIDFilePath); err == nil {
-		secretID, err := ioutil.ReadFile(a.secretIDFilePath)
+		secretID, err := os.ReadFile(a.secretIDFilePath)
 		if err != nil {
 			if a.cachedSecretID == "" {
 				return "", nil, nil, fmt.Errorf("error reading secret ID file and no cached secret ID known: %w", err)

--- a/command/agent/auth/azure/azure.go
+++ b/command/agent/auth/azure/azure.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agent/auth"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
@@ -191,7 +191,7 @@ func getMetadataInfo(ctx context.Context, endpoint, resource, objectID, clientID
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading metadata from %s: %w", endpoint, err)
 	}

--- a/command/agent/auth/cf/cf.go
+++ b/command/agent/auth/cf/cf.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -47,7 +46,7 @@ func (p *cfMethod) Authenticate(ctx context.Context, client *api.Client) (string
 	if pathToClientCert == "" {
 		return "", nil, nil, fmt.Errorf("missing %q value", cf.EnvVarInstanceCertificate)
 	}
-	certBytes, err := ioutil.ReadFile(pathToClientCert)
+	certBytes, err := os.ReadFile(pathToClientCert)
 	if err != nil {
 		return "", nil, nil, err
 	}

--- a/command/agent/auth/gcp/gcp.go
+++ b/command/agent/auth/gcp/gcp.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-gcp-common/gcputil"
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agent/auth"
@@ -148,7 +148,7 @@ func (g *gcpMethod) Authenticate(ctx context.Context, client *api.Client) (retPa
 				return
 			}
 			defer resp.Body.Close()
-			jwtBytes, err := ioutil.ReadAll(resp.Body)
+			jwtBytes, err := io.ReadAll(resp.Body)
 			if err != nil {
 				retErr = fmt.Errorf("error reading instance token response body: %w", err)
 				return

--- a/command/agent/auth/jwt/jwt.go
+++ b/command/agent/auth/jwt/jwt.go
@@ -5,14 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agent/auth"
 )
@@ -165,7 +164,7 @@ func (j *jwtMethod) ingressToken() {
 
 	// Check that the path refers to a file.
 	// If it's a symlink, it could still be a symlink to a directory,
-	// but ioutil.ReadFile below will return a descriptive error.
+	// but os.ReadFile below will return a descriptive error.
 	switch mode := fi.Mode(); {
 	case mode.IsRegular():
 		// regular file
@@ -176,7 +175,7 @@ func (j *jwtMethod) ingressToken() {
 		return
 	}
 
-	token, err := ioutil.ReadFile(j.path)
+	token, err := os.ReadFile(j.path)
 	if err != nil {
 		j.logger.Error("failed to read jwt file", "error", err)
 		return

--- a/command/agent/auth/jwt/jwt_test.go
+++ b/command/agent/auth/jwt/jwt_test.go
@@ -2,7 +2,6 @@ package jwt
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -21,18 +20,18 @@ func TestIngressToken(t *testing.T) {
 		symlinked = "symlinked"
 	)
 
-	rootDir, err := ioutil.TempDir("", "vault-agent-jwt-auth-test")
+	rootDir, err := os.MkdirTemp("", "vault-agent-jwt-auth-test")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %s", err)
 	}
 	defer os.RemoveAll(rootDir)
 
 	setupTestDir := func() string {
-		testDir, err := ioutil.TempDir(rootDir, "")
+		testDir, err := os.MkdirTemp(rootDir, "")
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(path.Join(testDir, file), []byte("test"), 0o644)
+		err = os.WriteFile(path.Join(testDir, file), []byte("test"), 0o644)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/command/agent/auth/kubernetes/kubernetes.go
+++ b/command/agent/auth/kubernetes/kubernetes.go
@@ -5,12 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agent/auth"
 )
@@ -120,7 +119,7 @@ func (k *kubernetesMethod) readJWT() (string, error) {
 	}
 	defer data.Close()
 
-	contentBytes, err := ioutil.ReadAll(data)
+	contentBytes, err := io.ReadAll(data)
 	if err != nil {
 		return "", err
 	}

--- a/command/agent/auto_auth_preload_token_end_to_end_test.go
+++ b/command/agent/auto_auth_preload_token_end_to_end_test.go
@@ -2,12 +2,11 @@ package agent
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
 	"github.com/hashicorp/vault/command/agent/auth"
@@ -70,7 +69,7 @@ func TestTokenPreload_UsingAutoAuth(t *testing.T) {
 	}
 	roleID1 := resp.Data["role_id"].(string)
 
-	rolef, err := ioutil.TempFile("", "auth.role-id.test.")
+	rolef, err := os.CreateTemp("", "auth.role-id.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +78,7 @@ func TestTokenPreload_UsingAutoAuth(t *testing.T) {
 	defer os.Remove(role)
 	t.Logf("input role_id_file_path: %s", role)
 
-	secretf, err := ioutil.TempFile("", "auth.secret-id.test.")
+	secretf, err := os.CreateTemp("", "auth.secret-id.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,13 +94,13 @@ func TestTokenPreload_UsingAutoAuth(t *testing.T) {
 		"secret_id_file_path": secret,
 	}
 
-	if err := ioutil.WriteFile(role, []byte(roleID1), 0o600); err != nil {
+	if err := os.WriteFile(role, []byte(roleID1), 0o600); err != nil {
 		t.Fatal(err)
 	} else {
 		logger.Trace("wrote test role 1", "path", role)
 	}
 
-	if err := ioutil.WriteFile(secret, []byte(secretID1), 0o600); err != nil {
+	if err := os.WriteFile(secret, []byte(secretID1), 0o600); err != nil {
 		t.Fatal(err)
 	} else {
 		logger.Trace("wrote test secret 1", "path", secret)
@@ -139,7 +138,7 @@ func TestTokenPreload_UsingAutoAuth(t *testing.T) {
 
 	ah := auth.NewAuthHandler(ahConfig)
 
-	tmpFile, err := ioutil.TempFile("", "auth.tokensink.test.")
+	tmpFile, err := os.CreateTemp("", "auth.tokensink.test.")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/command/agent/aws_end_to_end_test.go
+++ b/command/agent/aws_end_to_end_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -11,8 +10,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
-	hclog "github.com/hashicorp/go-hclog"
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/api"
 	vaultaws "github.com/hashicorp/vault/builtin/credential/aws"
 	"github.com/hashicorp/vault/command/agent/auth"
@@ -124,7 +123,7 @@ func TestAWSEndToEnd(t *testing.T) {
 		}
 	}()
 
-	tmpFile, err := ioutil.TempFile("", "auth.tokensink.test.")
+	tmpFile, err := os.CreateTemp("", "auth.tokensink.test.")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/command/agent/cache/cacheboltdb/bolt_test.go
+++ b/command/agent/cache/cacheboltdb/bolt_test.go
@@ -3,7 +3,6 @@ package cacheboltdb
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -31,7 +30,7 @@ func getTestKeyManager(t *testing.T) keymanager.KeyManager {
 func TestBolt_SetGet(t *testing.T) {
 	ctx := context.Background()
 
-	path, err := ioutil.TempDir("", "bolt-test")
+	path, err := os.MkdirTemp("", "bolt-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 
@@ -57,7 +56,7 @@ func TestBolt_SetGet(t *testing.T) {
 func TestBoltDelete(t *testing.T) {
 	ctx := context.Background()
 
-	path, err := ioutil.TempDir("", "bolt-test")
+	path, err := os.MkdirTemp("", "bolt-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 
@@ -89,7 +88,7 @@ func TestBoltDelete(t *testing.T) {
 func TestBoltClear(t *testing.T) {
 	ctx := context.Background()
 
-	path, err := ioutil.TempDir("", "bolt-test")
+	path, err := os.MkdirTemp("", "bolt-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 
@@ -137,7 +136,7 @@ func TestBoltClear(t *testing.T) {
 func TestBoltSetAutoAuthToken(t *testing.T) {
 	ctx := context.Background()
 
-	path, err := ioutil.TempDir("", "bolt-test")
+	path, err := os.MkdirTemp("", "bolt-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 
@@ -207,11 +206,11 @@ func TestDBFileExists(t *testing.T) {
 			var tmpPath string
 			var err error
 			if tc.mkDir {
-				tmpPath, err = ioutil.TempDir("", "test-db-path")
+				tmpPath, err = os.MkdirTemp("", "test-db-path")
 				require.NoError(t, err)
 			}
 			if tc.createFile {
-				err = ioutil.WriteFile(path.Join(tmpPath, DatabaseFileName), []byte("test-db-path"), 0o600)
+				err = os.WriteFile(path.Join(tmpPath, DatabaseFileName), []byte("test-db-path"), 0o600)
 				require.NoError(t, err)
 			}
 			exists, err := DBFileExists(tmpPath)
@@ -241,7 +240,7 @@ func Test_SetGetRetrievalToken(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			path, err := ioutil.TempDir("", "bolt-test")
+			path, err := os.MkdirTemp("", "bolt-test")
 			require.NoError(t, err)
 			defer os.RemoveAll(path)
 
@@ -267,7 +266,7 @@ func Test_SetGetRetrievalToken(t *testing.T) {
 func TestBolt_MigrateFromV1ToV2Schema(t *testing.T) {
 	ctx := context.Background()
 
-	path, err := ioutil.TempDir("", "bolt-test")
+	path, err := os.MkdirTemp("", "bolt-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 
@@ -339,7 +338,7 @@ func TestBolt_MigrateFromV1ToV2Schema(t *testing.T) {
 func TestBolt_MigrateFromInvalidToV2Schema(t *testing.T) {
 	ctx := context.Background()
 
-	path, err := ioutil.TempDir("", "bolt-test")
+	path, err := os.MkdirTemp("", "bolt-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 

--- a/command/agent/cache/handler.go
+++ b/command/agent/cache/handler.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -36,7 +35,7 @@ func Handler(ctx context.Context, logger hclog.Logger, proxier Proxier, inmemSin
 		}
 
 		// Parse and reset body.
-		reqBody, err := ioutil.ReadAll(r.Body)
+		reqBody, err := io.ReadAll(r.Body)
 		if err != nil {
 			logger.Error("failed to read request body")
 			logical.RespondError(w, http.StatusInternalServerError, errors.New("failed to read request body"))
@@ -45,7 +44,7 @@ func Handler(ctx context.Context, logger hclog.Logger, proxier Proxier, inmemSin
 		if r.Body != nil {
 			r.Body.Close()
 		}
-		r.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
+		r.Body = io.NopCloser(bytes.NewReader(reqBody))
 		req := &SendRequest{
 			Token:       token,
 			Request:     r,
@@ -197,7 +196,7 @@ func sanitizeAutoAuthTokenResponse(ctx context.Context, logger hclog.Logger, inm
 	if resp.Response.Body != nil {
 		resp.Response.Body.Close()
 	}
-	resp.Response.Body = ioutil.NopCloser(bytes.NewReader(bodyBytes))
+	resp.Response.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 	resp.Response.ContentLength = int64(len(bodyBytes))
 
 	// Serialize and re-read the response

--- a/command/agent/cache/lease_cache.go
+++ b/command/agent/cache/lease_cache.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -410,7 +409,7 @@ func (c *LeaseCache) Send(ctx context.Context, req *SendRequest) (*SendResponse,
 	if resp.Response.Body != nil {
 		resp.Response.Body.Close()
 	}
-	resp.Response.Body = ioutil.NopCloser(bytes.NewReader(resp.ResponseBody))
+	resp.Response.Body = io.NopCloser(bytes.NewReader(resp.ResponseBody))
 
 	// Set the index's Response
 	index.Response = respBytes.Bytes()
@@ -554,7 +553,7 @@ func computeIndexID(req *SendRequest) (string, error) {
 	}
 
 	// Reset the request body after it has been closed by Write
-	req.Request.Body = ioutil.NopCloser(bytes.NewReader(req.RequestBody))
+	req.Request.Body = io.NopCloser(bytes.NewReader(req.RequestBody))
 
 	// Append req.Token into the byte slice. This is needed since auto-auth'ed
 	// requests sets the token directly into SendRequest.Token

--- a/command/agent/cache/lease_cache_test.go
+++ b/command/agent/cache/lease_cache_test.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,7 +14,7 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agent/cache/cacheboltdb"
@@ -702,7 +701,7 @@ func setupBoltStorage(t *testing.T) (tempCacheDir string, boltStorage *cachebolt
 	km, err := keymanager.NewPassthroughKeyManager(nil)
 	require.NoError(t, err)
 
-	tempCacheDir, err = ioutil.TempDir("", "agent-cache-test")
+	tempCacheDir, err = os.MkdirTemp("", "agent-cache-test")
 	require.NoError(t, err)
 	boltStorage, err = cacheboltdb.NewBoltStorage(&cacheboltdb.BoltStorageConfig{
 		Path:    tempCacheDir,

--- a/command/agent/cache/proxy.go
+++ b/command/agent/cache/proxy.go
@@ -3,7 +3,7 @@ package cache
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -54,12 +54,12 @@ func NewSendResponse(apiResponse *api.Response, responseBody []byte) (*SendRespo
 	}
 
 	// If a response body is separately provided we set that as the SendResponse.ResponseBody,
-	// otherwise we will do an ioutil.ReadAll to extract the response body from apiResponse.
+	// otherwise we will do an io.ReadAll to extract the response body from apiResponse.
 	switch {
 	case len(responseBody) > 0:
 		resp.ResponseBody = responseBody
 	case apiResponse.Body != nil:
-		respBody, err := ioutil.ReadAll(apiResponse.Body)
+		respBody, err := io.ReadAll(apiResponse.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -67,7 +67,7 @@ func NewSendResponse(apiResponse *api.Response, responseBody []byte) (*SendRespo
 		apiResponse.Body.Close()
 
 		// Re-set the response body after reading from the Reader
-		apiResponse.Body = ioutil.NopCloser(bytes.NewReader(respBody))
+		apiResponse.Body = io.NopCloser(bytes.NewReader(respBody))
 
 		resp.ResponseBody = respBody
 	}

--- a/command/agent/cache/testing.go
+++ b/command/agent/cache/testing.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"strings"
@@ -55,7 +55,7 @@ func newTestSendResponse(status int, body string) *SendResponse {
 	resp.Response.Header.Set("Date", time.Now().Format(http.TimeFormat))
 
 	if body != "" {
-		resp.Response.Body = ioutil.NopCloser(strings.NewReader(body))
+		resp.Response.Body = io.NopCloser(strings.NewReader(body))
 		resp.ResponseBody = []byte(body)
 	}
 

--- a/command/agent/cache_end_to_end_test.go
+++ b/command/agent/cache_end_to_end_test.go
@@ -3,14 +3,13 @@ package agent
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
@@ -122,7 +121,7 @@ func TestCache_UsingAutoAuthToken(t *testing.T) {
 	}
 	roleID1 := resp.Data["role_id"].(string)
 
-	rolef, err := ioutil.TempFile("", "auth.role-id.test.")
+	rolef, err := os.CreateTemp("", "auth.role-id.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +130,7 @@ func TestCache_UsingAutoAuthToken(t *testing.T) {
 	defer os.Remove(role)
 	t.Logf("input role_id_file_path: %s", role)
 
-	secretf, err := ioutil.TempFile("", "auth.secret-id.test.")
+	secretf, err := os.CreateTemp("", "auth.secret-id.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +141,7 @@ func TestCache_UsingAutoAuthToken(t *testing.T) {
 
 	// We close these right away because we're just basically testing
 	// permissions and finding a usable file name
-	ouf, err := ioutil.TempFile("", "auth.tokensink.test.")
+	ouf, err := os.CreateTemp("", "auth.tokensink.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -265,13 +264,13 @@ func TestCache_UsingAutoAuthToken(t *testing.T) {
 		t.Fatal("expected notexist err")
 	}
 
-	if err := ioutil.WriteFile(role, []byte(roleID1), 0o600); err != nil {
+	if err := os.WriteFile(role, []byte(roleID1), 0o600); err != nil {
 		t.Fatal(err)
 	} else {
 		logger.Trace("wrote test role 1", "path", role)
 	}
 
-	if err := ioutil.WriteFile(secret, []byte(secretID1), 0o600); err != nil {
+	if err := os.WriteFile(secret, []byte(secretID1), 0o600); err != nil {
 		t.Fatal(err)
 	} else {
 		logger.Trace("wrote test secret 1", "path", secret)
@@ -283,7 +282,7 @@ func TestCache_UsingAutoAuthToken(t *testing.T) {
 			if time.Now().After(timeout) {
 				t.Fatal("did not find a written token after timeout")
 			}
-			val, err := ioutil.ReadFile(out)
+			val, err := os.ReadFile(out)
 			if err == nil {
 				os.Remove(out)
 				if len(val) == 0 {

--- a/command/agent/cert_end_to_end_test.go
+++ b/command/agent/cert_end_to_end_test.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/vault/builtin/logical/pki"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/vault/api"
 	vaultcert "github.com/hashicorp/vault/builtin/credential/cert"
@@ -104,7 +103,7 @@ func testCertEndToEnd(t *testing.T, withCertRoleName, ahWrapping bool) {
 		t.Fatal(err)
 	}
 
-	ouf, err := ioutil.TempFile("", "auth.tokensink.test.")
+	ouf, err := os.CreateTemp("", "auth.tokensink.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +112,7 @@ func testCertEndToEnd(t *testing.T, withCertRoleName, ahWrapping bool) {
 	os.Remove(out)
 	t.Logf("output: %s", out)
 
-	dhpathf, err := ioutil.TempFile("", "auth.dhpath.test.")
+	dhpathf, err := os.CreateTemp("", "auth.dhpath.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +127,7 @@ func testCertEndToEnd(t *testing.T, withCertRoleName, ahWrapping bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(dhpath, mPubKey, 0o600); err != nil {
+	if err := os.WriteFile(dhpath, mPubKey, 0o600); err != nil {
 		t.Fatal(err)
 	} else {
 		logger.Trace("wrote dh param file", "path", dhpath)
@@ -228,7 +227,7 @@ func testCertEndToEnd(t *testing.T, withCertRoleName, ahWrapping bool) {
 			if time.Now().After(timeout) {
 				t.Fatal("did not find a written token after timeout")
 			}
-			val, err := ioutil.ReadFile(out)
+			val, err := os.ReadFile(out)
 			if err == nil {
 				os.Remove(out)
 				if len(val) == 0 {
@@ -408,7 +407,7 @@ func TestCertEndToEnd_CertsInConfig(t *testing.T) {
 
 	// Create temporary files for CA cert, client cert and client cert key.
 	// This is used to configure TLS in the api client.
-	caCertFile, err := ioutil.TempFile("", "caCert")
+	caCertFile, err := os.CreateTemp("", "caCert")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -420,7 +419,7 @@ func TestCertEndToEnd_CertsInConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	leafCertFile, err := ioutil.TempFile("", "leafCert")
+	leafCertFile, err := os.CreateTemp("", "leafCert")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +431,7 @@ func TestCertEndToEnd_CertsInConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	leafCertKeyFile, err := ioutil.TempFile("", "leafCertKey")
+	leafCertKeyFile, err := os.CreateTemp("", "leafCertKey")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -511,7 +510,7 @@ func TestCertEndToEnd_CertsInConfig(t *testing.T) {
 	// /////////////
 
 	// Use TempFile to get us a generated file name to use for the sink.
-	ouf, err := ioutil.TempFile("", "auth.tokensink.test.")
+	ouf, err := os.CreateTemp("", "auth.tokensink.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -565,7 +564,7 @@ func TestCertEndToEnd_CertsInConfig(t *testing.T) {
 
 		// Attempt to read the sink file until we get a token or the timeout is
 		// reached.
-		val, err := ioutil.ReadFile(out)
+		val, err := os.ReadFile(out)
 		if err == nil {
 			os.Remove(out)
 			if len(val) == 0 {

--- a/command/agent/cf_end_to_end_test.go
+++ b/command/agent/cf_end_to_end_test.go
@@ -2,12 +2,11 @@ package agent
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	credCF "github.com/hashicorp/vault-plugin-auth-cf"
 	"github.com/hashicorp/vault-plugin-auth-cf/testing/certificates"
 	cfAPI "github.com/hashicorp/vault-plugin-auth-cf/testing/cf"
@@ -122,7 +121,7 @@ func TestCFEndToEnd(t *testing.T) {
 		}
 	}()
 
-	tmpFile, err := ioutil.TempFile("", "auth.tokensink.test.")
+	tmpFile, err := os.CreateTemp("", "auth.tokensink.test.")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -165,7 +164,7 @@ func LoadConfig(path string) (*Config, error) {
 	}
 
 	// Read the file
-	d, err := ioutil.ReadFile(path)
+	d, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/command/agent/jwt_end_to_end_test.go
+++ b/command/agent/jwt_end_to_end_test.go
@@ -3,12 +3,11 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	vaultjwt "github.com/hashicorp/vault-plugin-auth-jwt"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agent/auth"
@@ -83,7 +82,7 @@ func testJWTEndToEnd(t *testing.T, ahWrapping bool) {
 
 	// We close these right away because we're just basically testing
 	// permissions and finding a usable file name
-	inf, err := ioutil.TempFile("", "auth.jwt.test.")
+	inf, err := os.CreateTemp("", "auth.jwt.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +91,7 @@ func testJWTEndToEnd(t *testing.T, ahWrapping bool) {
 	os.Remove(in)
 	t.Logf("input: %s", in)
 
-	ouf, err := ioutil.TempFile("", "auth.tokensink.test.")
+	ouf, err := os.CreateTemp("", "auth.tokensink.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +100,7 @@ func testJWTEndToEnd(t *testing.T, ahWrapping bool) {
 	os.Remove(out)
 	t.Logf("output: %s", out)
 
-	dhpathf, err := ioutil.TempFile("", "auth.dhpath.test.")
+	dhpathf, err := os.CreateTemp("", "auth.dhpath.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +115,7 @@ func testJWTEndToEnd(t *testing.T, ahWrapping bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(dhpath, mPubKey, 0o600); err != nil {
+	if err := os.WriteFile(dhpath, mPubKey, 0o600); err != nil {
 		t.Fatal(err)
 	} else {
 		logger.Trace("wrote dh param file", "path", dhpath)
@@ -225,7 +224,7 @@ func testJWTEndToEnd(t *testing.T, ahWrapping bool) {
 
 	// Get a token
 	jwtToken, _ := GetTestJWT(t)
-	if err := ioutil.WriteFile(in, []byte(jwtToken), 0o600); err != nil {
+	if err := os.WriteFile(in, []byte(jwtToken), 0o600); err != nil {
 		t.Fatal(err)
 	} else {
 		logger.Trace("wrote test jwt", "path", in)
@@ -237,7 +236,7 @@ func testJWTEndToEnd(t *testing.T, ahWrapping bool) {
 			if time.Now().After(timeout) {
 				t.Fatal("did not find a written token after timeout")
 			}
-			val, err := ioutil.ReadFile(out)
+			val, err := os.ReadFile(out)
 			if err == nil {
 				os.Remove(out)
 				if len(val) == 0 {
@@ -336,7 +335,7 @@ func testJWTEndToEnd(t *testing.T, ahWrapping bool) {
 	// Get another token to test the backend pushing the need to authenticate
 	// to the handler
 	jwtToken, _ = GetTestJWT(t)
-	if err := ioutil.WriteFile(in, []byte(jwtToken), 0o600); err != nil {
+	if err := os.WriteFile(in, []byte(jwtToken), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/command/agent/sink/file/file_sink_test.go
+++ b/command/agent/sink/file/file_sink_test.go
@@ -2,13 +2,12 @@ package file
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
-	hclog "github.com/hashicorp/go-hclog"
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/command/agent/sink"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 )
@@ -18,7 +17,7 @@ const (
 )
 
 func testFileSink(t *testing.T, log hclog.Logger) (*sink.SinkConfig, string) {
-	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("%s.", fileServerTestDir))
+	tmpDir, err := os.MkdirTemp("", fmt.Sprintf("%s.", fileServerTestDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +70,7 @@ func TestFileSink(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fileBytes, err := ioutil.ReadFile(path)
+	fileBytes, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +81,7 @@ func TestFileSink(t *testing.T) {
 }
 
 func testFileSinkMode(t *testing.T, log hclog.Logger) (*sink.SinkConfig, string) {
-	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("%s.", fileServerTestDir))
+	tmpDir, err := os.MkdirTemp("", fmt.Sprintf("%s.", fileServerTestDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +132,7 @@ func TestFileSinkMode(t *testing.T) {
 		t.Fatalf("wrong file mode was detected at %s", path)
 	}
 
-	fileBytes, err := ioutil.ReadFile(path)
+	fileBytes, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/command/agent/sink/file/sink_test.go
+++ b/command/agent/sink/file/sink_test.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/command/agent/sink"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 )
@@ -55,7 +54,7 @@ func TestSinkServer(t *testing.T) {
 	}
 
 	for _, path := range []string{path1, path2} {
-		fileBytes, err := ioutil.ReadFile(fmt.Sprintf("%s/token", path))
+		fileBytes, err := os.ReadFile(fmt.Sprintf("%s/token", path))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/command/agent/sink/sink.go
+++ b/command/agent/sink/sink.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"sync/atomic"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/dhutil"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
@@ -181,7 +180,7 @@ func (s *SinkConfig) encryptToken(token string) (string, error) {
 				}
 				return "", errors.New("no dh parameters file found, and no cached pub key")
 			}
-			fileBytes, err := ioutil.ReadFile(s.DHPath)
+			fileBytes, err := os.ReadFile(s.DHPath)
 			if err != nil {
 				return "", fmt.Errorf("error reading file for dh parameters: %w", err)
 			}

--- a/command/agent/testing.go
+++ b/command/agent/testing.go
@@ -6,13 +6,12 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/logical"
-	jose "gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
@@ -61,7 +60,7 @@ func GetTestJWT(t *testing.T) (string, *ecdsa.PrivateKey) {
 }
 
 func readToken(fileName string) (*logical.HTTPWrapInfo, error) {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, err
 	}

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -3,7 +3,7 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	vaultjwt "github.com/hashicorp/vault-plugin-auth-jwt"
 	logicalKv "github.com/hashicorp/vault-plugin-secrets-kv"
 	"github.com/hashicorp/vault/api"
@@ -96,7 +96,7 @@ func TestAgent_Cache_UnixListener(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	inf, err := ioutil.TempFile("", "auth.jwt.test.")
+	inf, err := os.CreateTemp("", "auth.jwt.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestAgent_Cache_UnixListener(t *testing.T) {
 	os.Remove(in)
 	t.Logf("input: %s", in)
 
-	sink1f, err := ioutil.TempFile("", "sink1.jwt.test.")
+	sink1f, err := os.CreateTemp("", "sink1.jwt.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestAgent_Cache_UnixListener(t *testing.T) {
 	os.Remove(sink1)
 	t.Logf("sink1: %s", sink1)
 
-	sink2f, err := ioutil.TempFile("", "sink2.jwt.test.")
+	sink2f, err := os.CreateTemp("", "sink2.jwt.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func TestAgent_Cache_UnixListener(t *testing.T) {
 	os.Remove(sink2)
 	t.Logf("sink2: %s", sink2)
 
-	conff, err := ioutil.TempFile("", "conf.jwt.test.")
+	conff, err := os.CreateTemp("", "conf.jwt.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,13 +133,13 @@ func TestAgent_Cache_UnixListener(t *testing.T) {
 	t.Logf("config: %s", conf)
 
 	jwtToken, _ := agent.GetTestJWT(t)
-	if err := ioutil.WriteFile(in, []byte(jwtToken), 0600); err != nil {
+	if err := os.WriteFile(in, []byte(jwtToken), 0600); err != nil {
 		t.Fatal(err)
 	} else {
 		logger.Trace("wrote test jwt", "path", in)
 	}
 
-	socketff, err := ioutil.TempFile("", "cache.socket.")
+	socketff, err := os.CreateTemp("", "cache.socket.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +183,7 @@ cache {
 `
 
 	config = fmt.Sprintf(config, in, sink1, sink2, socketf)
-	if err := ioutil.WriteFile(conf, []byte(config), 0600); err != nil {
+	if err := os.WriteFile(conf, []byte(config), 0600); err != nil {
 		t.Fatal(err)
 	} else {
 		logger.Trace("wrote test config", "path", conf)
@@ -285,7 +285,7 @@ func testAgentExitAfterAuth(t *testing.T, viaFlag bool) {
 		t.Fatal(err)
 	}
 
-	inf, err := ioutil.TempFile("", "auth.jwt.test.")
+	inf, err := os.CreateTemp("", "auth.jwt.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +294,7 @@ func testAgentExitAfterAuth(t *testing.T, viaFlag bool) {
 	os.Remove(in)
 	t.Logf("input: %s", in)
 
-	sink1f, err := ioutil.TempFile("", "sink1.jwt.test.")
+	sink1f, err := os.CreateTemp("", "sink1.jwt.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,7 +303,7 @@ func testAgentExitAfterAuth(t *testing.T, viaFlag bool) {
 	os.Remove(sink1)
 	t.Logf("sink1: %s", sink1)
 
-	sink2f, err := ioutil.TempFile("", "sink2.jwt.test.")
+	sink2f, err := os.CreateTemp("", "sink2.jwt.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -312,7 +312,7 @@ func testAgentExitAfterAuth(t *testing.T, viaFlag bool) {
 	os.Remove(sink2)
 	t.Logf("sink2: %s", sink2)
 
-	conff, err := ioutil.TempFile("", "conf.jwt.test.")
+	conff, err := os.CreateTemp("", "conf.jwt.test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -322,7 +322,7 @@ func testAgentExitAfterAuth(t *testing.T, viaFlag bool) {
 	t.Logf("config: %s", conf)
 
 	jwtToken, _ := agent.GetTestJWT(t)
-	if err := ioutil.WriteFile(in, []byte(jwtToken), 0o600); err != nil {
+	if err := os.WriteFile(in, []byte(jwtToken), 0o600); err != nil {
 		t.Fatal(err)
 	} else {
 		logger.Trace("wrote test jwt", "path", in)
@@ -361,7 +361,7 @@ auto_auth {
 `
 
 	config = fmt.Sprintf(config, exitAfterAuthTemplText, in, sink1, sink2)
-	if err := ioutil.WriteFile(conf, []byte(config), 0o600); err != nil {
+	if err := os.WriteFile(conf, []byte(config), 0o600); err != nil {
 		t.Fatal(err)
 	} else {
 		logger.Trace("wrote test config", "path", conf)
@@ -393,7 +393,7 @@ auto_auth {
 		t.Fatal("timeout reached while waiting for agent to exit")
 	}
 
-	sink1Bytes, err := ioutil.ReadFile(sink1)
+	sink1Bytes, err := os.ReadFile(sink1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +401,7 @@ auto_auth {
 		t.Fatal("got no output from sink 1")
 	}
 
-	sink2Bytes, err := ioutil.ReadFile(sink2)
+	sink2Bytes, err := os.ReadFile(sink2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -437,9 +437,9 @@ func TestAgent_RequireRequestHeader(t *testing.T) {
 		return cli
 	}
 
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	// Start the server and agent
-	//----------------------------------------------------
+	// ----------------------------------------------------
 
 	// Start a vault server
 	logger := logging.NewVaultLogger(hclog.Trace)
@@ -568,9 +568,9 @@ listener "tcp" {
 		wg.Wait()
 	}()
 
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	// Perform the tests
-	//----------------------------------------------------
+	// ----------------------------------------------------
 
 	// Test against a listener configuration that omits
 	// 'require_request_header', with the header missing from the request.
@@ -652,9 +652,9 @@ listener "tcp" {
 
 // TestAgent_Template tests rendering templates
 func TestAgent_Template_Basic(t *testing.T) {
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	// Start the server and agent
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	logger := logging.NewVaultLogger(hclog.Trace)
 	cluster := vault.NewTestCluster(t,
 		&vault.CoreConfig{
@@ -751,7 +751,7 @@ func TestAgent_Template_Basic(t *testing.T) {
 
 	// make a temp directory to hold renders. Each test will create a temp dir
 	// inside this one
-	tmpDirRoot, err := ioutil.TempDir("", "agent-test-renders")
+	tmpDirRoot, err := os.MkdirTemp("", "agent-test-renders")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -781,7 +781,7 @@ func TestAgent_Template_Basic(t *testing.T) {
 	for tcname, tc := range testCases {
 		t.Run(tcname, func(t *testing.T) {
 			// create temp dir for this test run
-			tmpDir, err := ioutil.TempDir(tmpDirRoot, tcname)
+			tmpDir, err := os.MkdirTemp(tmpDirRoot, tcname)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -790,7 +790,7 @@ func TestAgent_Template_Basic(t *testing.T) {
 			var templatePaths []string
 			for i := 0; i < tc.templateCount; i++ {
 				fileName := filepath.Join(tmpDir, fmt.Sprintf("render_%d.tmpl", i))
-				if err := ioutil.WriteFile(fileName, []byte(templateContents(i)), 0o600); err != nil {
+				if err := os.WriteFile(fileName, []byte(templateContents(i)), 0o600); err != nil {
 					t.Fatal(err)
 				}
 				templatePaths = append(templatePaths, fileName)
@@ -892,9 +892,9 @@ auto_auth {
 					// early for shutdown if we do have all the files
 					// rendered
 
-					//----------------------------------------------------
+					// ----------------------------------------------------
 					// Perform the tests
-					//----------------------------------------------------
+					// ----------------------------------------------------
 
 					if numFiles := testListFiles(t, tmpDir, ".json"); numFiles != len(templatePaths) {
 						err = fmt.Errorf("expected (%d) templates, got (%d)", len(templatePaths), numFiles)
@@ -904,7 +904,7 @@ auto_auth {
 					for i := range templatePaths {
 						fileName := filepath.Join(tmpDir, fmt.Sprintf("render_%d.json", i))
 						var c []byte
-						c, err = ioutil.ReadFile(fileName)
+						c, err = os.ReadFile(fileName)
 						if err != nil {
 							continue
 						}
@@ -921,7 +921,7 @@ auto_auth {
 
 			for i := 0; i < tc.templateCount; i++ {
 				fileName := filepath.Join(tmpDir, fmt.Sprintf("render_%d.tmpl", i))
-				if err := ioutil.WriteFile(fileName, []byte(templateContents(i)+"{}"), 0o600); err != nil {
+				if err := os.WriteFile(fileName, []byte(templateContents(i)+"{}"), 0o600); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -934,7 +934,7 @@ auto_auth {
 func testListFiles(t *testing.T, dir, extension string) int {
 	t.Helper()
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -955,9 +955,9 @@ func testListFiles(t *testing.T, dir, extension string) int {
 // generate a random number of secrets, but all using the same source. This test
 // reproduces https://github.com/hashicorp/vault/issues/7883
 func TestAgent_Template_ExitCounter(t *testing.T) {
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	// Start the server and agent
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	logger := logging.NewVaultLogger(hclog.Trace)
 	cluster := vault.NewTestCluster(t,
 		&vault.CoreConfig{
@@ -1064,14 +1064,14 @@ func TestAgent_Template_ExitCounter(t *testing.T) {
 
 	// make a temp directory to hold renders. Each test will create a temp dir
 	// inside this one
-	tmpDirRoot, err := ioutil.TempDir("", "agent-test-renders")
+	tmpDirRoot, err := os.MkdirTemp("", "agent-test-renders")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDirRoot)
 
 	// create temp dir for this test run
-	tmpDir, err := ioutil.TempDir(tmpDirRoot, "agent-test")
+	tmpDir, err := os.MkdirTemp(tmpDirRoot, "agent-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1149,11 +1149,11 @@ exit_after_auth = true
 
 	wg.Wait()
 
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	// Perform the tests
-	//----------------------------------------------------
+	// ----------------------------------------------------
 
-	files, err := ioutil.ReadDir(tmpDir)
+	files, err := os.ReadDir(tmpDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1216,7 +1216,7 @@ func request(t *testing.T, client *api.Client, req *api.Request, expectedStatusC
 		t.Fatalf("expected status code %d, not %d", expectedStatusCode, resp.StatusCode)
 	}
 
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1235,7 +1235,7 @@ func request(t *testing.T, client *api.Client, req *api.Request, expectedStatusC
 // makeTempFile creates a temp file and populates it.
 func makeTempFile(t *testing.T, name, contents string) string {
 	t.Helper()
-	f, err := ioutil.TempFile("", name)
+	f, err := os.CreateTemp("", name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1269,9 +1269,9 @@ func (h *handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 // TestAgent_Template_Retry verifies that the template server retries requests
 // based on retry configuration.
 func TestAgent_Template_Retry(t *testing.T) {
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	// Start the server and agent
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	logger := logging.NewVaultLogger(hclog.Trace)
 	var h handler
 	cluster := vault.NewTestCluster(t,
@@ -1328,7 +1328,7 @@ func TestAgent_Template_Retry(t *testing.T) {
 
 	// make a temp directory to hold renders. Each test will create a temp dir
 	// inside this one
-	tmpDirRoot, err := ioutil.TempDir("", "agent-test-renders")
+	tmpDirRoot, err := os.MkdirTemp("", "agent-test-renders")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1376,14 +1376,14 @@ func TestAgent_Template_Retry(t *testing.T) {
 			h.failCount = 6
 
 			// create temp dir for this test run
-			tmpDir, err := ioutil.TempDir(tmpDirRoot, tcname)
+			tmpDir, err := os.MkdirTemp(tmpDirRoot, tcname)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			// make some template files
 			templatePath := filepath.Join(tmpDir, "render_0.tmpl")
-			if err := ioutil.WriteFile(templatePath, []byte(templateContents(0)), 0o600); err != nil {
+			if err := os.WriteFile(templatePath, []byte(templateContents(0)), 0o600); err != nil {
 				t.Fatal(err)
 			}
 			templateConfig := fmt.Sprintf(templateConfigString, templatePath, tmpDir, "render_0.json")
@@ -1446,9 +1446,9 @@ template_config {
 					// early for shutdown if we do have all the files
 					// rendered
 
-					//----------------------------------------------------
+					// ----------------------------------------------------
 					// Perform the tests
-					//----------------------------------------------------
+					// ----------------------------------------------------
 
 					if numFiles := testListFiles(t, tmpDir, ".json"); numFiles != 1 {
 						err = fmt.Errorf("expected 1 template, got (%d)", numFiles)
@@ -1457,7 +1457,7 @@ template_config {
 
 					fileName := filepath.Join(tmpDir, "render_0.json")
 					var c []byte
-					c, err = ioutil.ReadFile(fileName)
+					c, err = os.ReadFile(fileName)
 					if err != nil {
 						continue
 					}
@@ -1556,9 +1556,9 @@ auto_auth {
 }
 
 func TestAgent_Cache_Retry(t *testing.T) {
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	// Start the server and agent
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	logger := logging.NewVaultLogger(hclog.Trace)
 	var h handler
 	cluster := vault.NewTestCluster(t,
@@ -1710,9 +1710,9 @@ vault {
 }
 
 func TestAgent_TemplateConfig_ExitOnRetryFailure(t *testing.T) {
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	// Start the server and agent
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	logger := logging.NewVaultLogger(hclog.Trace)
 	cluster := vault.NewTestCluster(t,
 		&vault.CoreConfig{
@@ -1764,7 +1764,7 @@ func TestAgent_TemplateConfig_ExitOnRetryFailure(t *testing.T) {
 
 	// make a temp directory to hold renders. Each test will create a temp dir
 	// inside this one
-	tmpDirRoot, err := ioutil.TempDir("", "agent-test-renders")
+	tmpDirRoot, err := os.MkdirTemp("", "agent-test-renders")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1868,7 +1868,7 @@ func TestAgent_TemplateConfig_ExitOnRetryFailure(t *testing.T) {
 	for tcName, tc := range testCases {
 		t.Run(tcName, func(t *testing.T) {
 			// create temp dir for this test run
-			tmpDir, err := ioutil.TempDir(tmpDirRoot, tcName)
+			tmpDir, err := os.MkdirTemp(tmpDirRoot, tcName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1966,9 +1966,9 @@ vault {
 					// early for shutdown if we do have all the files
 					// rendered
 
-					//----------------------------------------------------
+					// ----------------------------------------------------
 					// Perform the tests
-					//----------------------------------------------------
+					// ----------------------------------------------------
 
 					if numFiles := testListFiles(t, tmpDir, ".json"); numFiles != 1 {
 						err = fmt.Errorf("expected 1 template, got (%d)", numFiles)
@@ -1977,7 +1977,7 @@ vault {
 
 					fileName := filepath.Join(tmpDir, "render_0.json")
 					var c []byte
-					c, err = ioutil.ReadFile(fileName)
+					c, err = os.ReadFile(fileName)
 					if err != nil {
 						continue
 					}
@@ -2014,9 +2014,9 @@ vault {
 }
 
 func TestAgent_Metrics(t *testing.T) {
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	// Start the server and agent
-	//----------------------------------------------------
+	// ----------------------------------------------------
 
 	// Start a vault server
 	logger := logging.NewVaultLogger(hclog.Trace)
@@ -2097,9 +2097,9 @@ listener "tcp" {
 }
 
 func TestAgent_Quit(t *testing.T) {
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	// Start the server and agent
-	//----------------------------------------------------
+	// ----------------------------------------------------
 	logger := logging.NewVaultLogger(hclog.Error)
 	cluster := vault.NewTestCluster(t,
 		&vault.CoreConfig{

--- a/command/audit_enable_test.go
+++ b/command/audit_enable_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -166,7 +165,7 @@ func TestAuditEnableCommand_Run(t *testing.T) {
 		client, closer := testVaultServerAllBackends(t)
 		defer closer()
 
-		files, err := ioutil.ReadDir("../builtin/audit")
+		files, err := os.ReadDir("../builtin/audit")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/command/auth_enable_test.go
+++ b/command/auth_enable_test.go
@@ -1,7 +1,7 @@
 package command
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -170,7 +170,7 @@ func TestAuthEnableCommand_Run(t *testing.T) {
 		client, closer := testVaultServerAllBackends(t)
 		defer closer()
 
-		files, err := ioutil.ReadDir("../builtin/credential")
+		files, err := os.ReadDir("../builtin/credential")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -182,7 +182,7 @@ func TestAuthEnableCommand_Run(t *testing.T) {
 			}
 		}
 
-		modFile, err := ioutil.ReadFile("../go.mod")
+		modFile, err := os.ReadFile("../go.mod")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/command/base.go
+++ b/command/base.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -557,7 +556,7 @@ func NewFlagSets(ui cli.Ui) *FlagSets {
 
 	// Errors and usage are controlled by the CLI.
 	mainSet.Usage = func() {}
-	mainSet.SetOutput(ioutil.Discard)
+	mainSet.SetOutput(io.Discard)
 
 	return &FlagSets{
 		flagSets:    make([]*FlagSet, 0, 6),

--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -4,14 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
 	kvbuilder "github.com/hashicorp/go-secure-stdlib/kv-builder"
 	"github.com/hashicorp/vault/api"
 	"github.com/kr/text"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/ryanuber/columnize"
@@ -282,7 +282,7 @@ func humanDurationInt(i interface{}) interface{} {
 func parseFlagFile(raw string) (string, error) {
 	// check if the provided argument should be read from file
 	if len(raw) > 0 && raw[0] == '@' {
-		contents, err := ioutil.ReadFile(raw[1:])
+		contents, err := os.ReadFile(raw[1:])
 		if err != nil {
 			return "", fmt.Errorf("error reading file: %w", err)
 		}

--- a/command/base_helpers_test.go
+++ b/command/base_helpers_test.go
@@ -3,7 +3,6 @@ package command
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -53,7 +52,7 @@ func TestParseArgsData(t *testing.T) {
 	t.Run("file_full", func(t *testing.T) {
 		t.Parallel()
 
-		f, err := ioutil.TempFile("", "vault")
+		f, err := os.CreateTemp("", "vault")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -74,7 +73,7 @@ func TestParseArgsData(t *testing.T) {
 	t.Run("file_value", func(t *testing.T) {
 		t.Parallel()
 
-		f, err := ioutil.TempFile("", "vault")
+		f, err := os.CreateTemp("", "vault")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -165,7 +164,7 @@ func TestParseFlagFile(t *testing.T) {
 	t.Parallel()
 
 	content := "some raw content"
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "TestParseFlagFile")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "TestParseFlagFile")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %v", err)
 	}

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -2,13 +2,12 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/vault/sdk/helper/hclutil"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 )
 
 const (
@@ -59,7 +58,7 @@ func LoadConfig(path string) (*DefaultConfig, error) {
 		return nil, fmt.Errorf("error expanding config path %q: %w", path, err)
 	}
 
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}

--- a/command/debug.go
+++ b/command/debug.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -371,7 +371,7 @@ func (c *DebugCommand) generateIndex() error {
 	}
 
 	// Write out file
-	if err := ioutil.WriteFile(filepath.Join(c.flagOutput, "index.json"), bytes, 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(c.flagOutput, "index.json"), bytes, 0o600); err != nil {
 		return fmt.Errorf("error generating index file; %s", err)
 	}
 
@@ -774,7 +774,7 @@ func (c *DebugCommand) collectPprof(ctx context.Context) {
 					return
 				}
 
-				err = ioutil.WriteFile(filepath.Join(dirName, target+".prof"), data, 0o600)
+				err = os.WriteFile(filepath.Join(dirName, target+".prof"), data, 0o600)
 				if err != nil {
 					c.captureError("pprof."+target, err)
 				}
@@ -792,7 +792,7 @@ func (c *DebugCommand) collectPprof(ctx context.Context) {
 				return
 			}
 
-			err = ioutil.WriteFile(filepath.Join(dirName, "goroutines.txt"), data, 0o600)
+			err = os.WriteFile(filepath.Join(dirName, "goroutines.txt"), data, 0o600)
 			if err != nil {
 				c.captureError("pprof.goroutines-text", err)
 			}
@@ -816,7 +816,7 @@ func (c *DebugCommand) collectPprof(ctx context.Context) {
 				return
 			}
 
-			err = ioutil.WriteFile(filepath.Join(dirName, "profile.prof"), data, 0o600)
+			err = os.WriteFile(filepath.Join(dirName, "profile.prof"), data, 0o600)
 			if err != nil {
 				c.captureError("pprof.profile", err)
 			}
@@ -832,7 +832,7 @@ func (c *DebugCommand) collectPprof(ctx context.Context) {
 				return
 			}
 
-			err = ioutil.WriteFile(filepath.Join(dirName, "trace.out"), data, 0o600)
+			err = os.WriteFile(filepath.Join(dirName, "trace.out"), data, 0o600)
 			if err != nil {
 				c.captureError("pprof.trace", err)
 			}
@@ -968,7 +968,7 @@ func (c *DebugCommand) persistCollection(collection []map[string]interface{}, ou
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(c.flagOutput, outFile), bytes, 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(c.flagOutput, outFile), bytes, 0o600); err != nil {
 		return err
 	}
 
@@ -1004,7 +1004,7 @@ func pprofTarget(ctx context.Context, client *api.Client, target string, params 
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -1024,7 +1024,7 @@ func pprofProfile(ctx context.Context, client *api.Client, duration time.Duratio
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -1044,7 +1044,7 @@ func pprofTrace(ctx context.Context, client *api.Client, duration time.Duration)
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -32,7 +31,7 @@ func testDebugCommand(tb testing.TB) (*cli.MockUi, *DebugCommand) {
 func TestDebugCommand_Run(t *testing.T) {
 	t.Parallel()
 
-	testDir, err := ioutil.TempDir("", "vault-debug")
+	testDir, err := os.MkdirTemp("", "vault-debug")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +133,7 @@ func TestDebugCommand_Archive(t *testing.T) {
 
 			// Create temp dirs for each test case since os.Stat and tgz.Walk
 			// (called down below) exhibits raciness otherwise.
-			testDir, err := ioutil.TempDir("", "vault-debug")
+			testDir, err := os.MkdirTemp("", "vault-debug")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -255,7 +254,7 @@ func TestDebugCommand_CaptureTargets(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			testDir, err := ioutil.TempDir("", "vault-debug")
+			testDir, err := os.MkdirTemp("", "vault-debug")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -318,7 +317,7 @@ func TestDebugCommand_CaptureTargets(t *testing.T) {
 }
 
 func TestDebugCommand_Pprof(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "vault-debug")
+	testDir, err := os.MkdirTemp("", "vault-debug")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -376,7 +375,7 @@ func TestDebugCommand_Pprof(t *testing.T) {
 func TestDebugCommand_IndexFile(t *testing.T) {
 	t.Parallel()
 
-	testDir, err := ioutil.TempDir("", "vault-debug")
+	testDir, err := os.MkdirTemp("", "vault-debug")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -406,7 +405,7 @@ func TestDebugCommand_IndexFile(t *testing.T) {
 		t.Fatalf("expected %d to be %d", code, exp)
 	}
 
-	content, err := ioutil.ReadFile(filepath.Join(outputPath, "index.json"))
+	content, err := os.ReadFile(filepath.Join(outputPath, "index.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -423,7 +422,7 @@ func TestDebugCommand_IndexFile(t *testing.T) {
 func TestDebugCommand_TimingChecks(t *testing.T) {
 	t.Parallel()
 
-	testDir, err := ioutil.TempDir("", "vault-debug")
+	testDir, err := os.MkdirTemp("", "vault-debug")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -578,7 +577,7 @@ func TestDebugCommand_OutputExists(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			testDir, err := ioutil.TempDir("", "vault-debug")
+			testDir, err := os.MkdirTemp("", "vault-debug")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -632,7 +631,7 @@ func TestDebugCommand_OutputExists(t *testing.T) {
 func TestDebugCommand_PartialPermissions(t *testing.T) {
 	t.Parallel()
 
-	testDir, err := ioutil.TempDir("", "vault-debug")
+	testDir, err := os.MkdirTemp("", "vault-debug")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -741,7 +740,7 @@ func TestDebugCommand_InsecureUmask(t *testing.T) {
 			// set insecure umask
 			defer syscall.Umask(syscall.Umask(0))
 
-			testDir, err := ioutil.TempDir("", "vault-debug")
+			testDir, err := os.MkdirTemp("", "vault-debug")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/command/operator_diagnose_test.go
+++ b/command/operator_diagnose_test.go
@@ -5,7 +5,7 @@ package command
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -19,7 +19,7 @@ func testOperatorDiagnoseCommand(tb testing.TB) *OperatorDiagnoseCommand {
 
 	ui := cli.NewMockUi()
 	return &OperatorDiagnoseCommand{
-		diagnose: diagnose.New(ioutil.Discard),
+		diagnose: diagnose.New(io.Discard),
 		BaseCommand: &BaseCommand{
 			UI: ui,
 		},

--- a/command/operator_migrate.go
+++ b/command/operator_migrate.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"sort"
@@ -308,7 +307,7 @@ func (c *OperatorMigrateCommand) loadMigratorConfig(path string) (*migratorConfi
 		return nil, fmt.Errorf("location is a directory, not a file")
 	}
 
-	d, err := ioutil.ReadFile(path)
+	d, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/command/operator_migrate_test.go
+++ b/command/operator_migrate_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -112,7 +111,7 @@ func TestMigration(t *testing.T) {
 		cmd := new(OperatorMigrateCommand)
 
 		cfgName := filepath.Join(os.TempDir(), testhelpers.RandomWithPrefix("migrator"))
-		ioutil.WriteFile(cfgName, []byte(`
+		os.WriteFile(cfgName, []byte(`
 storage_source "src_type" {
   path = "src_path"
 }
@@ -145,7 +144,7 @@ storage_destination "dest_type" {
 		}
 
 		verifyBad := func(cfg string) {
-			ioutil.WriteFile(cfgName, []byte(cfg), 0o644)
+			os.WriteFile(cfgName, []byte(cfg), 0o644)
 			_, err := cmd.loadMigratorConfig(cfgName)
 			if err == nil {
 				t.Fatalf("expected error but none received from: %v", cfg)

--- a/command/operator_unseal_test.go
+++ b/command/operator_unseal_test.go
@@ -3,7 +3,7 @@ package command
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -33,7 +33,7 @@ func TestOperatorUnsealCommand_Run(t *testing.T) {
 
 		ui, cmd := testOperatorUnsealCommand(t)
 		cmd.client = client
-		cmd.testOutput = ioutil.Discard
+		cmd.testOutput = io.Discard
 
 		code := cmd.Run(nil)
 		if exp := 1; code != exp {
@@ -65,7 +65,7 @@ func TestOperatorUnsealCommand_Run(t *testing.T) {
 
 		ui, cmd := testOperatorUnsealCommand(t)
 		cmd.client = client
-		cmd.testOutput = ioutil.Discard
+		cmd.testOutput = io.Discard
 
 		// Reset and check output
 		code := cmd.Run([]string{
@@ -95,7 +95,7 @@ func TestOperatorUnsealCommand_Run(t *testing.T) {
 		for _, key := range keys {
 			ui, cmd := testOperatorUnsealCommand(t)
 			cmd.client = client
-			cmd.testOutput = ioutil.Discard
+			cmd.testOutput = io.Discard
 
 			// Reset and check output
 			code := cmd.Run([]string{

--- a/command/pgp_test.go
+++ b/command/pgp_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/hex"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"regexp"
 	"sort"
@@ -18,7 +18,7 @@ import (
 )
 
 func getPubKeyFiles(t *testing.T) (string, []string, error) {
-	tempDir, err := ioutil.TempDir("", "vault-test")
+	tempDir, err := os.MkdirTemp("", "vault-test")
 	if err != nil {
 		t.Fatalf("Error creating temporary directory: %s", err)
 	}
@@ -34,7 +34,7 @@ func getPubKeyFiles(t *testing.T) (string, []string, error) {
 	if err != nil {
 		t.Fatalf("Error decoding bytes for public key 1: %s", err)
 	}
-	err = ioutil.WriteFile(pubFiles[0], pub1Bytes, 0o755)
+	err = os.WriteFile(pubFiles[0], pub1Bytes, 0o755)
 	if err != nil {
 		t.Fatalf("Error writing pub key 1 to temp file: %s", err)
 	}
@@ -42,7 +42,7 @@ func getPubKeyFiles(t *testing.T) (string, []string, error) {
 	if err != nil {
 		t.Fatalf("Error decoding bytes for public key 2: %s", err)
 	}
-	err = ioutil.WriteFile(pubFiles[1], pub2Bytes, 0o755)
+	err = os.WriteFile(pubFiles[1], pub2Bytes, 0o755)
 	if err != nil {
 		t.Fatalf("Error writing pub key 2 to temp file: %s", err)
 	}
@@ -50,11 +50,11 @@ func getPubKeyFiles(t *testing.T) (string, []string, error) {
 	if err != nil {
 		t.Fatalf("Error decoding bytes for public key 3: %s", err)
 	}
-	err = ioutil.WriteFile(pubFiles[2], pub3Bytes, 0o755)
+	err = os.WriteFile(pubFiles[2], pub3Bytes, 0o755)
 	if err != nil {
 		t.Fatalf("Error writing pub key 3 to temp file: %s", err)
 	}
-	err = ioutil.WriteFile(pubFiles[3], []byte(pgpkeys.TestAAPubKey1), 0o755)
+	err = os.WriteFile(pubFiles[3], []byte(pgpkeys.TestAAPubKey1), 0o755)
 	if err != nil {
 		t.Fatalf("Error writing aa pub key 1 to temp file: %s", err)
 	}

--- a/command/plugin_test.go
+++ b/command/plugin_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +17,7 @@ import (
 func testPluginDir(tb testing.TB) (string, func(tb testing.TB)) {
 	tb.Helper()
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -42,7 +41,7 @@ func testPluginCreate(tb testing.TB, dir, name string) (string, string) {
 	tb.Helper()
 
 	pth := dir + "/" + name
-	if err := ioutil.WriteFile(pth, nil, 0o755); err != nil {
+	if err := os.WriteFile(pth, nil, 0o755); err != nil {
 		tb.Fatal(err)
 	}
 

--- a/command/policy_fmt.go
+++ b/command/policy_fmt.go
@@ -2,14 +2,14 @@ package command
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/hcl/hcl/printer"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/vault"
 	"github.com/mitchellh/cli"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/posener/complete"
 )
 
@@ -82,7 +82,7 @@ func (c *PolicyFmtCommand) Run(args []string) int {
 
 	// Read the entire contents into memory - it would be nice if we could use
 	// a buffer, but hcl wants the full contents.
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error reading source file: %s", err))
 		return 1
@@ -103,7 +103,7 @@ func (c *PolicyFmtCommand) Run(args []string) int {
 	}
 
 	// Write them back out
-	if err := ioutil.WriteFile(path, result, 0o644); err != nil {
+	if err := os.WriteFile(path, result, 0o644); err != nil {
 		c.UI.Error(fmt.Sprintf("Error writing result: %s", err))
 		return 1
 	}

--- a/command/policy_fmt_test.go
+++ b/command/policy_fmt_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -81,7 +80,7 @@ path "secret" {
 }
 `)
 
-		f, err := ioutil.TempFile("", "")
+		f, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -110,7 +109,7 @@ path "secret" {
 }
 `) + "\n"
 
-		contents, err := ioutil.ReadFile(f.Name())
+		contents, err := os.ReadFile(f.Name())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -124,7 +123,7 @@ path "secret" {
 
 		policy := `dafdaf`
 
-		f, err := ioutil.TempFile("", "")
+		f, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -159,7 +158,7 @@ path "secret" {
 
 		policy := `banana "foo" {}`
 
-		f, err := ioutil.TempFile("", "")
+		f, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -194,7 +193,7 @@ path "secret" {
 
 		policy := `path "secret/" { capabilities = ["bogus"] }`
 
-		f, err := ioutil.TempFile("", "")
+		f, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/command/policy_write_test.go
+++ b/command/policy_write_test.go
@@ -3,7 +3,6 @@ package command
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -92,7 +91,7 @@ func TestPolicyWriteCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		policy := testPolicyWritePolicyContents(t)
-		f, err := ioutil.TempFile("", "vault-policy-write")
+		f, err := os.CreateTemp("", "vault-policy-write")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/command/secrets_enable_test.go
+++ b/command/secrets_enable_test.go
@@ -1,7 +1,7 @@
 package command
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -204,7 +204,7 @@ func TestSecretsEnableCommand_Run(t *testing.T) {
 		client, closer := testVaultServerAllBackends(t)
 		defer closer()
 
-		files, err := ioutil.ReadDir("../builtin/logical")
+		files, err := os.ReadDir("../builtin/logical")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -219,7 +219,7 @@ func TestSecretsEnableCommand_Run(t *testing.T) {
 			}
 		}
 
-		modFile, err := ioutil.ReadFile("../go.mod")
+		modFile, err := os.ReadFile("../go.mod")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/command/server.go
+++ b/command/server.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -1960,7 +1959,7 @@ func (c *ServerCommand) enableThreeNodeDevCluster(base *vault.CoreConfig, info m
 		return 1
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(testCluster.TempDir, "root_token"), []byte(testCluster.RootToken), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(testCluster.TempDir, "root_token"), []byte(testCluster.RootToken), 0o600); err != nil {
 		c.UI.Error(fmt.Sprintf("Error writing token to tempfile: %s", err))
 		return 1
 	}

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -409,7 +408,7 @@ func CheckConfig(c *Config, e error) (*Config, error) {
 // LoadConfigFile loads the configuration from the given file.
 func LoadConfigFile(path string) (*Config, error) {
 	// Read the file
-	d, err := ioutil.ReadFile(path)
+	d, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/command/server/listener_tcp_test.go
+++ b/command/server/listener_tcp_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -38,14 +37,14 @@ func TestTCPListener_tls(t *testing.T) {
 	wd, _ := os.Getwd()
 	wd += "/test-fixtures/reload/"
 
-	td, err := ioutil.TempDir("", fmt.Sprintf("vault-test-%d", rand.New(rand.NewSource(time.Now().Unix())).Int63()))
+	td, err := os.MkdirTemp("", fmt.Sprintf("vault-test-%d", rand.New(rand.NewSource(time.Now().Unix())).Int63()))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(td)
 
 	// Setup initial certs
-	inBytes, _ := ioutil.ReadFile(wd + "reload_ca.pem")
+	inBytes, _ := os.ReadFile(wd + "reload_ca.pem")
 	certPool := x509.NewCertPool()
 	ok := certPool.AppendCertsFromPEM(inBytes)
 	if !ok {
@@ -119,14 +118,14 @@ func TestTCPListener_tls13(t *testing.T) {
 	wd, _ := os.Getwd()
 	wd += "/test-fixtures/reload/"
 
-	td, err := ioutil.TempDir("", fmt.Sprintf("vault-test-%d", rand.New(rand.NewSource(time.Now().Unix())).Int63()))
+	td, err := os.MkdirTemp("", fmt.Sprintf("vault-test-%d", rand.New(rand.NewSource(time.Now().Unix())).Int63()))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(td)
 
 	// Setup initial certs
-	inBytes, _ := ioutil.ReadFile(wd + "reload_ca.pem")
+	inBytes, _ := os.ReadFile(wd + "reload_ca.pem")
 	certPool := x509.NewCertPool()
 	ok := certPool.AppendCertsFromPEM(inBytes)
 	if !ok {

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -11,7 +11,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -108,7 +107,7 @@ func TestServer_ReloadListener(t *testing.T) {
 	wd, _ := os.Getwd()
 	wd += "/server/test-fixtures/reload/"
 
-	td, err := ioutil.TempDir("", "vault-test-")
+	td, err := os.MkdirTemp("", "vault-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,15 +115,15 @@ func TestServer_ReloadListener(t *testing.T) {
 
 	wg := &sync.WaitGroup{}
 	// Setup initial certs
-	inBytes, _ := ioutil.ReadFile(wd + "reload_foo.pem")
-	ioutil.WriteFile(td+"/reload_cert.pem", inBytes, 0o777)
-	inBytes, _ = ioutil.ReadFile(wd + "reload_foo.key")
-	ioutil.WriteFile(td+"/reload_key.pem", inBytes, 0o777)
+	inBytes, _ := os.ReadFile(wd + "reload_foo.pem")
+	os.WriteFile(td+"/reload_cert.pem", inBytes, 0o777)
+	inBytes, _ = os.ReadFile(wd + "reload_foo.key")
+	os.WriteFile(td+"/reload_key.pem", inBytes, 0o777)
 
 	relhcl := strings.Replace(reloadHCL, "TMPDIR", td, -1)
-	ioutil.WriteFile(td+"/reload.hcl", []byte(relhcl), 0o777)
+	os.WriteFile(td+"/reload.hcl", []byte(relhcl), 0o777)
 
-	inBytes, _ = ioutil.ReadFile(wd + "reload_ca.pem")
+	inBytes, _ = os.ReadFile(wd + "reload_ca.pem")
 	certPool := x509.NewCertPool()
 	ok := certPool.AppendCertsFromPEM(inBytes)
 	if !ok {
@@ -173,11 +172,11 @@ func TestServer_ReloadListener(t *testing.T) {
 	}
 
 	relhcl = strings.Replace(reloadHCL, "TMPDIR", td, -1)
-	inBytes, _ = ioutil.ReadFile(wd + "reload_bar.pem")
-	ioutil.WriteFile(td+"/reload_cert.pem", inBytes, 0o777)
-	inBytes, _ = ioutil.ReadFile(wd + "reload_bar.key")
-	ioutil.WriteFile(td+"/reload_key.pem", inBytes, 0o777)
-	ioutil.WriteFile(td+"/reload.hcl", []byte(relhcl), 0o777)
+	inBytes, _ = os.ReadFile(wd + "reload_bar.pem")
+	os.WriteFile(td+"/reload_cert.pem", inBytes, 0o777)
+	inBytes, _ = os.ReadFile(wd + "reload_bar.key")
+	os.WriteFile(td+"/reload_key.pem", inBytes, 0o777)
+	os.WriteFile(td+"/reload.hcl", []byte(relhcl), 0o777)
 
 	cmd.SighupCh <- struct{}{}
 	select {
@@ -270,7 +269,7 @@ func TestServer(t *testing.T) {
 			t.Parallel()
 
 			ui, cmd := testServerCommand(t)
-			f, err := ioutil.TempFile("", "")
+			f, err := os.CreateTemp("", "")
 			if err != nil {
 				t.Fatalf("error creating temp dir: %v", err)
 			}

--- a/command/ssh.go
+++ b/command/ssh.go
@@ -3,7 +3,6 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -363,7 +362,7 @@ func (c *SSHCommand) Run(args []string) int {
 // handleTypeCA is used to handle SSH logins using the "CA" key type.
 func (c *SSHCommand) handleTypeCA(username, ip, port string, sshArgs []string) int {
 	// Read the key from disk
-	publicKey, err := ioutil.ReadFile(c.flagPublicKeyPath)
+	publicKey, err := os.ReadFile(c.flagPublicKeyPath)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("failed to read public key %s: %s",
 			c.flagPublicKeyPath, err))
@@ -717,14 +716,14 @@ func (c *SSHCommand) writeTemporaryFile(name string, data []byte, perms os.FileM
 	// default closer to prevent panic
 	closer := func() error { return nil }
 
-	f, err := ioutil.TempFile("", name)
+	f, err := os.CreateTemp("", name)
 	if err != nil {
 		return "", errors.Wrap(err, "creating temporary file"), closer
 	}
 
 	closer = func() error { return os.Remove(f.Name()) }
 
-	if err := ioutil.WriteFile(f.Name(), data, perms); err != nil {
+	if err := os.WriteFile(f.Name(), data, perms); err != nil {
 		return "", errors.Wrap(err, "writing temporary key"), closer
 	}
 

--- a/command/token/helper_external_test.go
+++ b/command/token/helper_external_test.go
@@ -3,7 +3,6 @@ package token
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -70,7 +69,7 @@ func helperPath(s ...string) string {
 func helperEnv() []string {
 	var env []string
 
-	tf, err := ioutil.TempFile("", "vault")
+	tf, err := os.CreateTemp("", "vault")
 	if err != nil {
 		panic(err)
 	}

--- a/command/token/helper_internal_test.go
+++ b/command/token/helper_internal_test.go
@@ -1,7 +1,6 @@
 package token
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +17,7 @@ func TestCommand(t *testing.T) {
 }
 
 func TestInternalHelperFilePerms(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", t.Name())
+	tmpDir, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/helper/fairshare/jobmanager.go
+++ b/helper/fairshare/jobmanager.go
@@ -3,14 +3,14 @@ package fairshare
 import (
 	"container/list"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"sync"
 	"time"
 
 	"github.com/armon/go-metrics"
 	log "github.com/hashicorp/go-hclog"
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 )
@@ -47,7 +47,7 @@ type JobManager struct {
 // NewJobManager creates a job manager, with an optional name
 func NewJobManager(name string, numWorkers int, l log.Logger, metricSink *metricsutil.ClusterMetricSink) *JobManager {
 	if l == nil {
-		l = logging.NewVaultLoggerWithWriter(ioutil.Discard, log.NoLevel)
+		l = logging.NewVaultLoggerWithWriter(io.Discard, log.NoLevel)
 	}
 	if name == "" {
 		guid, err := uuid.GenerateUUID()

--- a/helper/fairshare/workerpool.go
+++ b/helper/fairshare/workerpool.go
@@ -2,11 +2,11 @@ package fairshare
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sync"
 
 	log "github.com/hashicorp/go-hclog"
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 )
 
@@ -132,7 +132,7 @@ func (d *dispatcher) stop() {
 // worker pool
 func createDispatcher(name string, numWorkers int, l log.Logger) *dispatcher {
 	if l == nil {
-		l = logging.NewVaultLoggerWithWriter(ioutil.Discard, log.NoLevel)
+		l = logging.NewVaultLoggerWithWriter(io.Discard, log.NoLevel)
 	}
 	if numWorkers <= 0 {
 		numWorkers = 1

--- a/helper/forwarding/util.go
+++ b/helper/forwarding/util.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -72,7 +71,7 @@ func GenerateForwardedRequest(req *http.Request) (*Request, error) {
 		}
 	}
 
-	body, err := ioutil.ReadAll(reader)
+	body, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/helper/pgpkeys/flag_test.go
+++ b/helper/pgpkeys/flag_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -25,7 +24,7 @@ func TestPubKeyFilesFlag_implements(t *testing.T) {
 }
 
 func TestPubKeyFilesFlagSetBinary(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "vault-test")
+	tempDir, err := os.MkdirTemp("", "vault-test")
 	if err != nil {
 		t.Fatalf("Error creating temporary directory: %s", err)
 	}
@@ -36,7 +35,7 @@ func TestPubKeyFilesFlagSetBinary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error decoding bytes for public key 1: %s", err)
 	}
-	err = ioutil.WriteFile(tempDir+"/pubkey1", pub1Bytes, 0o755)
+	err = os.WriteFile(tempDir+"/pubkey1", pub1Bytes, 0o755)
 	if err != nil {
 		t.Fatalf("Error writing pub key 1 to temp file: %s", err)
 	}
@@ -44,7 +43,7 @@ func TestPubKeyFilesFlagSetBinary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error decoding bytes for public key 2: %s", err)
 	}
-	err = ioutil.WriteFile(tempDir+"/pubkey2", pub2Bytes, 0o755)
+	err = os.WriteFile(tempDir+"/pubkey2", pub2Bytes, 0o755)
 	if err != nil {
 		t.Fatalf("Error writing pub key 2 to temp file: %s", err)
 	}
@@ -52,7 +51,7 @@ func TestPubKeyFilesFlagSetBinary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error decoding bytes for public key 3: %s", err)
 	}
-	err = ioutil.WriteFile(tempDir+"/pubkey3", pub3Bytes, 0o755)
+	err = os.WriteFile(tempDir+"/pubkey3", pub3Bytes, 0o755)
 	if err != nil {
 		t.Fatalf("Error writing pub key 3 to temp file: %s", err)
 	}
@@ -75,21 +74,21 @@ func TestPubKeyFilesFlagSetBinary(t *testing.T) {
 }
 
 func TestPubKeyFilesFlagSetB64(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "vault-test")
+	tempDir, err := os.MkdirTemp("", "vault-test")
 	if err != nil {
 		t.Fatalf("Error creating temporary directory: %s", err)
 	}
 	defer os.RemoveAll(tempDir)
 
-	err = ioutil.WriteFile(tempDir+"/pubkey1", []byte(pubKey1), 0o755)
+	err = os.WriteFile(tempDir+"/pubkey1", []byte(pubKey1), 0o755)
 	if err != nil {
 		t.Fatalf("Error writing pub key 1 to temp file: %s", err)
 	}
-	err = ioutil.WriteFile(tempDir+"/pubkey2", []byte(pubKey2), 0o755)
+	err = os.WriteFile(tempDir+"/pubkey2", []byte(pubKey2), 0o755)
 	if err != nil {
 		t.Fatalf("Error writing pub key 2 to temp file: %s", err)
 	}
-	err = ioutil.WriteFile(tempDir+"/pubkey3", []byte(pubKey3), 0o755)
+	err = os.WriteFile(tempDir+"/pubkey3", []byte(pubKey3), 0o755)
 	if err != nil {
 		t.Fatalf("Error writing pub key 3 to temp file: %s", err)
 	}
@@ -112,13 +111,13 @@ func TestPubKeyFilesFlagSetB64(t *testing.T) {
 }
 
 func TestPubKeyFilesFlagSetKeybase(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "vault-test")
+	tempDir, err := os.MkdirTemp("", "vault-test")
 	if err != nil {
 		t.Fatalf("Error creating temporary directory: %s", err)
 	}
 	defer os.RemoveAll(tempDir)
 
-	err = ioutil.WriteFile(tempDir+"/pubkey2", []byte(pubKey2), 0o755)
+	err = os.WriteFile(tempDir+"/pubkey2", []byte(pubKey2), 0o755)
 	if err != nil {
 		t.Fatalf("Error writing pub key 2 to temp file: %s", err)
 	}

--- a/helper/testhelpers/docker/testhelpers.go
+++ b/helper/testhelpers/docker/testhelpers.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"strconv"
@@ -144,7 +144,7 @@ func (d *Runner) StartService(ctx context.Context, connect ServiceAdapter) (*Ser
 				Details:    true,
 			})
 			if err == nil {
-				b, err := ioutil.ReadAll(rc)
+				b, err := io.ReadAll(rc)
 				if err != nil {
 					d.RunOptions.LogConsumer(fmt.Sprintf("error reading container logs, err=%v, read: %s", err, string(b)))
 				} else {
@@ -250,7 +250,7 @@ func (d *Runner) Start(ctx context.Context) (*types.ContainerJSON, []string, err
 	}
 	resp, _ := d.DockerAPI.ImageCreate(ctx, cfg.Image, opts)
 	if resp != nil {
-		_, _ = ioutil.ReadAll(resp)
+		_, _ = io.ReadAll(resp)
 	}
 
 	c, err := d.DockerAPI.ContainerCreate(ctx, cfg, hostConfig, netConfig, nil, cfg.Hostname)

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/url"
 	"sync/atomic"
@@ -678,7 +678,7 @@ func SysMetricsReq(client *api.Client, cluster *vault.TestCluster, unauth bool) 
 	if err != nil {
 		return nil, err
 	}
-	bodyBytes, err := ioutil.ReadAll(resp.Response.Body)
+	bodyBytes, err := io.ReadAll(resp.Response.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/helper/testhelpers/teststorage/teststorage.go
+++ b/helper/testhelpers/teststorage/teststorage.go
@@ -2,7 +2,6 @@ package teststorage
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -50,7 +49,7 @@ func MakeInmemNonTransactionalBackend(t testing.T, logger hclog.Logger) *vault.P
 }
 
 func MakeFileBackend(t testing.T, logger hclog.Logger) *vault.PhysicalBackendBundle {
-	path, err := ioutil.TempDir("", "vault-integ-file-")
+	path, err := os.MkdirTemp("", "vault-integ-file-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +80,7 @@ func MakeFileBackend(t testing.T, logger hclog.Logger) *vault.PhysicalBackendBun
 
 func MakeRaftBackend(t testing.T, coreIdx int, logger hclog.Logger, extraConf map[string]interface{}) *vault.PhysicalBackendBundle {
 	nodeID := fmt.Sprintf("core-%d", coreIdx)
-	raftDir, err := ioutil.TempDir("", "vault-raft-")
+	raftDir, err := os.MkdirTemp("", "vault-raft-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/helper/testhelpers/teststorage/teststorage_reusable.go
+++ b/helper/testhelpers/teststorage/teststorage_reusable.go
@@ -2,10 +2,9 @@ package teststorage
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	raftlib "github.com/hashicorp/raft"
 	"github.com/hashicorp/vault/physical/raft"
 	"github.com/hashicorp/vault/sdk/physical"
@@ -158,7 +157,7 @@ func MakeReusableRaftHAStorage(t testing.T, logger hclog.Logger, numCores int, b
 }
 
 func makeRaftDir(t testing.T) string {
-	raftDir, err := ioutil.TempDir("", "vault-raft-")
+	raftDir, err := os.MkdirTemp("", "vault-raft-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/http/forwarding_bench_test.go
+++ b/http/forwarding_bench_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -31,7 +30,7 @@ func BenchmarkHTTP_Forwarding_Stress(b *testing.B) {
 
 	cluster := vault.NewTestCluster(benchhelpers.TBtoT(b), coreConfig, &vault.TestClusterOptions{
 		HandlerFunc: Handler,
-		Logger:      logging.NewVaultLoggerWithWriter(ioutil.Discard, log.Error),
+		Logger:      logging.NewVaultLoggerWithWriter(io.Discard, log.Error),
 	})
 	cluster.Start()
 	defer cluster.Cleanup()

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/textproto"
@@ -828,7 +828,7 @@ func TestHandler_Parse_Form(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.Body = ioutil.NopCloser(strings.NewReader(values.Encode()))
+	req.Body = io.NopCloser(strings.NewReader(values.Encode()))
 	req.Header.Set("x-vault-token", cluster.RootToken)
 	req.Header.Set("content-type", "application/x-www-form-urlencoded")
 	resp, err := c.Do(req)

--- a/http/logical_test.go
+++ b/http/logical_test.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -154,7 +154,7 @@ func TestLogical_StandbyRedirect(t *testing.T) {
 	testResponseStatus(t, resp, 307)
 	logger.Debug("307 test one stopping")
 
-	//// READ to standby
+	// // READ to standby
 	resp = testHttpGet(t, root, addr2+"/v1/auth/token/lookup-self")
 	var actual map[string]interface{}
 	var nilWarnings interface{}
@@ -193,7 +193,7 @@ func TestLogical_StandbyRedirect(t *testing.T) {
 		t.Fatal(diff)
 	}
 
-	//// DELETE to standby
+	// // DELETE to standby
 	resp = testHttpDeleteDisableRedirect(t, root, addr2+"/v1/secret/foo")
 	logger.Debug("307 test two starting")
 	testResponseStatus(t, resp, 307)
@@ -381,7 +381,7 @@ func TestLogical_RespondWithStatusCode(t *testing.T) {
 		t.Fatalf("Bad Status code: %d", w.Code)
 	}
 
-	bodyRaw, err := ioutil.ReadAll(w.Body)
+	bodyRaw, err := io.ReadAll(w.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -534,7 +534,7 @@ func TestLogical_AuditPort(t *testing.T) {
 		t.Fatalf("kv-v2 mount attempt failed - err: %#v\n", err)
 	}
 
-	auditLogFile, err := ioutil.TempFile("", "auditport")
+	auditLogFile, err := os.CreateTemp("", "auditport")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/http/plugin_test.go
+++ b/http/plugin_test.go
@@ -2,7 +2,7 @@ package http
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"sync"
@@ -146,7 +146,7 @@ func TestPlugin_MockRawResponse(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/http/sys_health_test.go
+++ b/http/sys_health_test.go
@@ -1,7 +1,7 @@
 package http
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -267,7 +267,7 @@ func TestSysHealth_head(t *testing.T) {
 			t.Fatalf("HEAD %v expected code %d, got %d.", queryurl, tt.code, resp.StatusCode)
 		}
 
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatalf("err on %v: %s", queryurl, err)
 		}

--- a/http/util.go
+++ b/http/util.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -53,12 +53,12 @@ func rateLimitQuotaWrapping(handler http.Handler, core *vault.Core) http.Handler
 		mountPath := strings.TrimPrefix(core.MatchingMount(r.Context(), path), ns.Path)
 
 		// Clone body, so we do not close the request body reader
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, errors.New("failed to read request body"))
 			return
 		}
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+		r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 		quotaResp, err := core.ApplyRateLimitQuota(r.Context(), &quotas.Request{
 			Type:          quotas.TypeRateLimit,

--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -2,7 +2,7 @@ package configutil
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
@@ -46,7 +46,7 @@ type SharedConfig struct {
 // LoadConfigFile loads the configuration from the given file.
 func LoadConfigFile(path string) (*SharedConfig, error) {
 	// Read the file
-	d, err := ioutil.ReadFile(path)
+	d, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func LoadConfigFile(path string) (*SharedConfig, error) {
 
 func LoadConfigKMSes(path string) ([]*KMS, error) {
 	// Read the file
-	d, err := ioutil.ReadFile(path)
+	d, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internalshared/listenerutil/listener.go
+++ b/internalshared/listenerutil/listener.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	osuser "os/user"
@@ -164,7 +163,7 @@ Please see https://tools.ietf.org/html/rfc7540#appendix-A for further informatio
 		tlsConf.ClientAuth = tls.RequireAndVerifyClientCert
 		if l.TLSClientCAFile != "" {
 			caPool := x509.NewCertPool()
-			data, err := ioutil.ReadFile(l.TLSClientCAFile)
+			data, err := os.ReadFile(l.TLSClientCAFile)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to read tls_client_ca_file: %w", err)
 			}

--- a/internalshared/listenerutil/listener_test.go
+++ b/internalshared/listenerutil/listener_test.go
@@ -1,7 +1,6 @@
 package listenerutil
 
 import (
-	"io/ioutil"
 	"os"
 	osuser "os/user"
 	"strconv"
@@ -10,7 +9,7 @@ import (
 
 func TestUnixSocketListener(t *testing.T) {
 	t.Run("ids", func(t *testing.T) {
-		socket, err := ioutil.TempFile("", "socket")
+		socket, err := os.CreateTemp("", "socket")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -54,7 +53,7 @@ func TestUnixSocketListener(t *testing.T) {
 		}
 	})
 	t.Run("names", func(t *testing.T) {
-		socket, err := ioutil.TempFile("", "socket")
+		socket, err := os.CreateTemp("", "socket")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/physical/azure/azure.go
+++ b/physical/azure/azure.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"sort"
@@ -231,7 +231,7 @@ func (a *AzureBackend) Get(ctx context.Context, key string) (*physical.Entry, er
 	reader := res.Body(azblob.RetryReaderOptions{})
 	defer reader.Close()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 
 	ent := &physical.Entry{
 		Key:   key,

--- a/physical/cassandra/cassandra.go
+++ b/physical/cassandra/cassandra.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"time"
 
-	metrics "github.com/armon/go-metrics"
+	"github.com/armon/go-metrics"
 	"github.com/gocql/gocql"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
@@ -166,7 +166,7 @@ func setupCassandraTLS(conf map[string]string, cluster *gocql.ClusterConfig) err
 
 	tlsConfig := &tls.Config{}
 	if pemBundlePath, ok := conf["pem_bundle_file"]; ok {
-		pemBundleData, err := ioutil.ReadFile(pemBundlePath)
+		pemBundleData, err := os.ReadFile(pemBundlePath)
 		if err != nil {
 			return fmt.Errorf("error reading pem bundle from %q: %w", pemBundlePath, err)
 		}
@@ -179,7 +179,7 @@ func setupCassandraTLS(conf map[string]string, cluster *gocql.ClusterConfig) err
 			return err
 		}
 	} else if pemJSONPath, ok := conf["pem_json_file"]; ok {
-		pemJSONData, err := ioutil.ReadFile(pemJSONPath)
+		pemJSONData, err := os.ReadFile(pemJSONPath)
 		if err != nil {
 			return fmt.Errorf("error reading json bundle from %q: %w", pemJSONPath, err)
 		}

--- a/physical/couchdb/couchdb.go
+++ b/physical/couchdb/couchdb.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	metrics "github.com/armon/go-metrics"
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	"github.com/armon/go-metrics"
+	"github.com/hashicorp/go-cleanhttp"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/physical"
 )
@@ -111,7 +111,7 @@ func (m *couchDBClient) get(key string) (*physical.Entry, error) {
 	} else if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GET returned %q", resp.Status)
 	}
-	bs, err := ioutil.ReadAll(resp.Body)
+	bs, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (m *couchDBClient) list(prefix string) ([]couchDBListItem, error) {
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/physical/couchdb/couchdb_test.go
+++ b/physical/couchdb/couchdb_test.go
@@ -3,7 +3,7 @@ package couchdb
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -133,7 +133,7 @@ func setupCouchDB(ctx context.Context, host string, port int) (docker.ServiceCon
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusCreated {
-			bs, _ := ioutil.ReadAll(resp.Body)
+			bs, _ := io.ReadAll(resp.Body)
 			return nil, fmt.Errorf("failed to create database: %s %s\n", resp.Status, string(bs))
 		}
 	}
@@ -152,7 +152,7 @@ func setupCouchDB(ctx context.Context, host string, port int) (docker.ServiceCon
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			bs, _ := ioutil.ReadAll(resp.Body)
+			bs, _ := io.ReadAll(resp.Body)
 			return nil, fmt.Errorf("Failed to create admin user: %s %s\n", resp.Status, string(bs))
 		}
 	}

--- a/physical/foundationdb/foundationdb_test.go
+++ b/physical/foundationdb/foundationdb_test.go
@@ -5,13 +5,12 @@ package foundationdb
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-uuid"
 
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/directory"
@@ -19,7 +18,7 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/physical"
 
-	dockertest "gopkg.in/ory-am/dockertest.v3"
+	"gopkg.in/ory-am/dockertest.v3"
 )
 
 func connectToFoundationDB(clusterFile string) (*fdb.Database, error) {
@@ -143,7 +142,7 @@ func prepareFoundationDBTestDirectory(t *testing.T, topDir string) (func(), stri
 		t.Fatalf("foundationdb: could not start container: %s", err)
 	}
 
-	tmpFile, err := ioutil.TempFile("", topDir)
+	tmpFile, err := os.CreateTemp("", topDir)
 	if err != nil {
 		t.Fatalf("foundationdb: could not create temporary file for cluster file: %s", err)
 	}

--- a/physical/gcs/gcs.go
+++ b/physical/gcs/gcs.go
@@ -5,16 +5,16 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
-	metrics "github.com/armon/go-metrics"
+	"github.com/armon/go-metrics"
 	log "github.com/hashicorp/go-hclog"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/vault/sdk/helper/useragent"
 	"github.com/hashicorp/vault/sdk/physical"
 
@@ -228,7 +228,7 @@ func (b *Backend) Get(ctx context.Context, key string) (retEntry *physical.Entry
 		}
 	}()
 
-	value, err := ioutil.ReadAll(r)
+	value, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read value into a string: %w", err)
 	}

--- a/physical/mysql/mysql.go
+++ b/physical/mysql/mysql.go
@@ -7,9 +7,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -20,8 +20,8 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
 
-	metrics "github.com/armon/go-metrics"
-	mysql "github.com/go-sql-driver/mysql"
+	"github.com/armon/go-metrics"
+	"github.com/go-sql-driver/mysql"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault/sdk/physical"
 )
@@ -756,7 +756,7 @@ func (i *MySQLLock) Unlock() error {
 func setupMySQLTLSConfig(tlsCaFile string) error {
 	rootCertPool := x509.NewCertPool()
 
-	pem, err := ioutil.ReadFile(tlsCaFile)
+	pem, err := os.ReadFile(tlsCaFile)
 	if err != nil {
 		return err
 	}

--- a/physical/oci/oci.go
+++ b/physical/oci/oci.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strconv"
@@ -172,7 +172,7 @@ func (o *Backend) Put(ctx context.Context, entry *physical.Entry) error {
 		BucketName:         &o.bucketName,
 		ObjectName:         &entry.Key,
 		ContentLength:      &size,
-		PutObjectBody:      ioutil.NopCloser(bytes.NewReader(entry.Value)),
+		PutObjectBody:      io.NopCloser(bytes.NewReader(entry.Value)),
 		OpcMeta:            nil,
 		OpcClientRequestId: &opcClientRequestId,
 	}
@@ -230,7 +230,7 @@ func (o *Backend) Get(ctx context.Context, key string) (*physical.Entry, error) 
 		return nil, fmt.Errorf("failed to read Value: %w", err)
 	}
 
-	body, err := ioutil.ReadAll(resp.Content)
+	body, err := io.ReadAll(resp.Content)
 	if err != nil {
 		metrics.IncrCounter(metricGetFailed, 1)
 		return nil, fmt.Errorf("failed to decode Value into bytes: %w", err)

--- a/physical/oci/oci_ha.go
+++ b/physical/oci/oci_ha.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -398,7 +398,7 @@ func (l *Lock) get(ctx context.Context) (*LockRecord, string, error) {
 
 	defer response.RawResponse.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Content)
+	body, err := io.ReadAll(response.Content)
 	if err != nil {
 		metrics.IncrCounter(metricGetFailed, 1)
 		l.backend.logger.Error("Error reading content", "err", err)
@@ -487,7 +487,7 @@ func (l *Lock) writeLock() (bool, error) {
 		BucketName:         &l.backend.lockBucketName,
 		ObjectName:         &l.key,
 		ContentLength:      &size,
-		PutObjectBody:      ioutil.NopCloser(bytes.NewReader(newLockRecordJson)),
+		PutObjectBody:      io.NopCloser(bytes.NewReader(newLockRecordJson)),
 		OpcMeta:            nil,
 		OpcClientRequestId: &opcClientRequestId,
 	}

--- a/physical/raft/fsm_test.go
+++ b/physical/raft/fsm_test.go
@@ -2,22 +2,21 @@ package raft
 
 import (
 	"context"
-	fmt "fmt"
-	"io/ioutil"
+	"fmt"
 	"math/rand"
 	"os"
 	"sort"
 	"testing"
 
 	"github.com/go-test/deep"
-	proto "github.com/golang/protobuf/proto"
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/golang/protobuf/proto"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/vault/sdk/physical"
 )
 
 func getFSM(t testing.TB) (*FSM, string) {
-	raftDir, err := ioutil.TempDir("", "vault-raft-")
+	raftDir, err := os.MkdirTemp("", "vault-raft-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -319,7 +318,7 @@ func NewRaftBackend(conf map[string]string, logger log.Logger) (physical.Backend
 
 		// If not set in the config check the "node-id" file.
 		if len(localID) == 0 {
-			localIDRaw, err := ioutil.ReadFile(filepath.Join(path, "node-id"))
+			localIDRaw, err := os.ReadFile(filepath.Join(path, "node-id"))
 			switch {
 			case err == nil:
 				if len(localIDRaw) > 0 {
@@ -339,7 +338,7 @@ func NewRaftBackend(conf map[string]string, logger log.Logger) (physical.Backend
 				return nil, err
 			}
 
-			if err := ioutil.WriteFile(filepath.Join(path, "node-id"), []byte(id), 0o600); err != nil {
+			if err := os.WriteFile(filepath.Join(path, "node-id"), []byte(id), 0o600); err != nil {
 				return nil, err
 			}
 

--- a/physical/raft/raft_test.go
+++ b/physical/raft/raft_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -27,7 +26,7 @@ import (
 )
 
 func getRaft(t testing.TB, bootstrap bool, noStoreState bool) (*RaftBackend, string) {
-	raftDir, err := ioutil.TempDir("", "vault-raft-")
+	raftDir, err := os.MkdirTemp("", "vault-raft-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,7 +225,7 @@ func TestRaft_Backend(t *testing.T) {
 }
 
 func TestRaft_ParseAutopilotUpgradeVersion(t *testing.T) {
-	raftDir, err := ioutil.TempDir("", "vault-raft-")
+	raftDir, err := os.MkdirTemp("", "vault-raft-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -519,15 +518,15 @@ func TestRaft_Recovery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ioutil.WriteFile(filepath.Join(filepath.Join(dir1, raftState), "peers.json"), peersJSONBytes, 0o644)
+	err = os.WriteFile(filepath.Join(filepath.Join(dir1, raftState), "peers.json"), peersJSONBytes, 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ioutil.WriteFile(filepath.Join(filepath.Join(dir2, raftState), "peers.json"), peersJSONBytes, 0o644)
+	err = os.WriteFile(filepath.Join(filepath.Join(dir2, raftState), "peers.json"), peersJSONBytes, 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ioutil.WriteFile(filepath.Join(filepath.Join(dir4, raftState), "peers.json"), peersJSONBytes, 0o644)
+	err = os.WriteFile(filepath.Join(filepath.Join(dir4, raftState), "peers.json"), peersJSONBytes, 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -688,7 +687,7 @@ func BenchmarkDB_Snapshot(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			pe.Key = fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprintf("%s-%d", testName, i))))
-			s.writeTo(ctx, discardCloser{Writer: ioutil.Discard}, discardCloser{Writer: ioutil.Discard})
+			s.writeTo(ctx, discardCloser{Writer: io.Discard}, discardCloser{Writer: io.Discard})
 		}
 	}
 

--- a/physical/raft/snapshot.go
+++ b/physical/raft/snapshot.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -191,7 +190,7 @@ func (f *BoltSnapshotStore) openFromFSM() (*raft.SnapshotMeta, io.ReadCloser, er
 	}()
 
 	// Compute the size
-	n, err := io.Copy(ioutil.Discard, metaReadCloser)
+	n, err := io.Copy(io.Discard, metaReadCloser)
 	if err != nil {
 		f.logger.Error("failed to read state file", "error", err)
 		metaReadCloser.Close()
@@ -265,7 +264,7 @@ func (f *BoltSnapshotStore) openFromFile(id string) (*raft.SnapshotMeta, io.Read
 	filename := filepath.Join(f.path, id, databaseFilename)
 	installer := &boltSnapshotInstaller{
 		meta:       meta,
-		ReadCloser: ioutil.NopCloser(strings.NewReader(filename)),
+		ReadCloser: io.NopCloser(strings.NewReader(filename)),
 		filename:   filename,
 	}
 
@@ -274,7 +273,7 @@ func (f *BoltSnapshotStore) openFromFile(id string) (*raft.SnapshotMeta, io.Read
 
 // ReapSnapshots reaps all snapshots.
 func (f *BoltSnapshotStore) ReapSnapshots() error {
-	snapshots, err := ioutil.ReadDir(f.path)
+	snapshots, err := os.ReadDir(f.path)
 	switch {
 	case err == nil:
 	case os.IsNotExist(err):

--- a/physical/raft/snapshot_test.go
+++ b/physical/raft/snapshot_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash/crc64"
 	"io"
-	"io/ioutil"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -15,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
@@ -189,7 +188,7 @@ func TestRaft_Snapshot_Index(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	io.Copy(ioutil.Discard, reader)
+	io.Copy(io.Discard, reader)
 
 	if meta.Index != index.Index {
 		t.Fatalf("indexes did not match, got %d expected %d", meta.Index, index.Index)
@@ -214,7 +213,7 @@ func TestRaft_Snapshot_Index(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	io.Copy(ioutil.Discard, reader)
+	io.Copy(io.Discard, reader)
 
 	// Make sure the meta data has updated to the new values
 	if meta.Index != 203 {
@@ -492,7 +491,7 @@ func TestRaft_Snapshot_Take_Restore(t *testing.T) {
 		}
 	}
 
-	snapFile, cleanup, metadata, err := raft1.WriteSnapshotToTemp(ioutil.NopCloser(recorder.Body), nil)
+	snapFile, cleanup, metadata, err := raft1.WriteSnapshotToTemp(io.NopCloser(recorder.Body), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -530,13 +529,13 @@ func TestRaft_Snapshot_Take_Restore(t *testing.T) {
 }
 
 func TestBoltSnapshotStore_CreateSnapshotMissingParentDir(t *testing.T) {
-	parent, err := ioutil.TempDir("", "raft")
+	parent, err := os.MkdirTemp("", "raft")
 	if err != nil {
 		t.Fatalf("err: %v ", err)
 	}
 	defer os.RemoveAll(parent)
 
-	dir, err := ioutil.TempDir(parent, "raft")
+	dir, err := os.MkdirTemp(parent, "raft")
 	if err != nil {
 		t.Fatalf("err: %v ", err)
 	}
@@ -573,13 +572,13 @@ func TestBoltSnapshotStore_CreateSnapshotMissingParentDir(t *testing.T) {
 
 func TestBoltSnapshotStore_Listing(t *testing.T) {
 	// Create a test dir
-	parent, err := ioutil.TempDir("", "raft")
+	parent, err := os.MkdirTemp("", "raft")
 	if err != nil {
 		t.Fatalf("err: %v ", err)
 	}
 	defer os.RemoveAll(parent)
 
-	dir, err := ioutil.TempDir(parent, "raft")
+	dir, err := os.MkdirTemp(parent, "raft")
 	if err != nil {
 		t.Fatalf("err: %v ", err)
 	}
@@ -638,13 +637,13 @@ func TestBoltSnapshotStore_Listing(t *testing.T) {
 
 func TestBoltSnapshotStore_CreateInstallSnapshot(t *testing.T) {
 	// Create a test dir
-	parent, err := ioutil.TempDir("", "raft")
+	parent, err := os.MkdirTemp("", "raft")
 	if err != nil {
 		t.Fatalf("err: %v ", err)
 	}
 	defer os.RemoveAll(parent)
 
-	dir, err := ioutil.TempDir(parent, "raft")
+	dir, err := os.MkdirTemp(parent, "raft")
 	if err != nil {
 		t.Fatalf("err: %v ", err)
 	}
@@ -820,7 +819,7 @@ func TestBoltSnapshotStore_CreateInstallSnapshot(t *testing.T) {
 
 func TestBoltSnapshotStore_CancelSnapshot(t *testing.T) {
 	// Create a test dir
-	dir, err := ioutil.TempDir("", "raft")
+	dir, err := os.MkdirTemp("", "raft")
 	if err != nil {
 		t.Fatalf("err: %v ", err)
 	}
@@ -879,7 +878,7 @@ func TestBoltSnapshotStore_BadPerm(t *testing.T) {
 
 	// Create a temp dir
 	var dir1 string
-	dir1, err = ioutil.TempDir("", "raft")
+	dir1, err = os.MkdirTemp("", "raft")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -887,7 +886,7 @@ func TestBoltSnapshotStore_BadPerm(t *testing.T) {
 
 	// Create a sub dir and remove all permissions
 	var dir2 string
-	dir2, err = ioutil.TempDir(dir1, "badperm")
+	dir2, err = os.MkdirTemp(dir1, "badperm")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -909,7 +908,7 @@ func TestBoltSnapshotStore_BadPerm(t *testing.T) {
 
 func TestBoltSnapshotStore_CloseFailure(t *testing.T) {
 	// Create a test dir
-	dir, err := ioutil.TempDir("", "raft")
+	dir, err := os.MkdirTemp("", "raft")
 	if err != nil {
 		t.Fatalf("err: %v ", err)
 	}

--- a/physical/zookeeper/zookeeper.go
+++ b/physical/zookeeper/zookeeper.go
@@ -5,8 +5,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/vault/sdk/physical"
 
-	metrics "github.com/armon/go-metrics"
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-secure-stdlib/tlsutil"
 	"github.com/samuel/go-zookeeper/zk"
 )
@@ -278,7 +278,7 @@ func customTLSDial(conf map[string]string, machines string) zk.Dialer {
 		if tlsCaFile, ok := conf["tls_ca_file"]; ok {
 			caPool := x509.NewCertPool()
 
-			data, err := ioutil.ReadFile(tlsCaFile)
+			data, err := os.ReadFile(tlsCaFile)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read ZK CA file: %w", err)
 			}

--- a/plugins/database/cassandra/connection_producer_test.go
+++ b/plugins/database/cassandra/connection_producer_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -202,7 +202,7 @@ func assertNewUser(t *testing.T, db *Cassandra, sslOpts *gocql.SslOptions) {
 func loadServerCA(t *testing.T, file string) *tls.Config {
 	t.Helper()
 
-	pemData, err := ioutil.ReadFile(file)
+	pemData, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	pool := x509.NewCertPool()
@@ -217,7 +217,7 @@ func loadServerCA(t *testing.T, file string) *tls.Config {
 func loadFile(t *testing.T, filename string) string {
 	t.Helper()
 
-	contents, err := ioutil.ReadFile(filename)
+	contents, err := os.ReadFile(filename)
 	require.NoError(t, err)
 	return string(contents)
 }

--- a/plugins/database/mongodb/connection_producer_test.go
+++ b/plugins/database/mongodb/connection_producer_test.go
@@ -3,7 +3,6 @@ package mongodb
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	paths "path"
@@ -15,7 +14,7 @@ import (
 
 	"github.com/hashicorp/vault/helper/testhelpers/certhelpers"
 	"github.com/hashicorp/vault/helper/testhelpers/mongodb"
-	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
+	"github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/ory/dockertest"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -151,7 +150,7 @@ net:
 }
 
 func makeTempDir(t *testing.T) (confDir string) {
-	confDir, err := ioutil.TempDir(".", "mongodb-test-data")
+	confDir, err := os.MkdirTemp(".", "mongodb-test-data")
 	if err != nil {
 		t.Fatalf("Unable to make temp directory: %s", err)
 	}
@@ -313,7 +312,7 @@ func (r roles) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
 func writeFile(t *testing.T, filename string, data []byte, perms os.FileMode) {
 	t.Helper()
 
-	err := ioutil.WriteFile(filename, data, perms)
+	err := os.WriteFile(filename, data, perms)
 	if err != nil {
 		t.Fatalf("Unable to write to file [%s]: %s", filename, err)
 	}

--- a/plugins/database/mysql/connection_producer_test.go
+++ b/plugins/database/mysql/connection_producer_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 	paths "path"
 	"path/filepath"
@@ -14,7 +13,7 @@ import (
 
 	"github.com/hashicorp/vault/helper/testhelpers/certhelpers"
 	"github.com/hashicorp/vault/sdk/database/helper/dbutil"
-	dockertest "github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3"
 )
 
 func Test_addTLStoDSN(t *testing.T) {
@@ -169,7 +168,7 @@ ssl-key=/etc/mysql/server-key.pem`
 }
 
 func makeTempDir(t *testing.T) (confDir string) {
-	confDir, err := ioutil.TempDir(".", "mysql-test-data")
+	confDir, err := os.MkdirTemp(".", "mysql-test-data")
 	if err != nil {
 		t.Fatalf("Unable to make temp directory: %s", err)
 	}
@@ -309,7 +308,7 @@ func setUpX509User(t *testing.T, db *sql.DB, cert certhelpers.Certificate) (user
 func writeFile(t *testing.T, filename string, data []byte, perms os.FileMode) {
 	t.Helper()
 
-	err := ioutil.WriteFile(filename, data, perms)
+	err := os.WriteFile(filename, data, perms)
 	if err != nil {
 		t.Fatalf("Unable to write to file [%s]: %s", filename, err)
 	}

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"regexp"
 	"sort"
@@ -415,7 +414,7 @@ func (b *Backend) Logger() log.Logger {
 		return b.logger
 	}
 
-	return logging.NewVaultLoggerWithWriter(ioutil.Discard, log.NoLevel)
+	return logging.NewVaultLoggerWithWriter(io.Discard, log.NoLevel)
 }
 
 // System returns the backend's system view.

--- a/sdk/framework/openapi_test.go
+++ b/sdk/framework/openapi_test.go
@@ -3,7 +3,7 @@ package framework
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -686,7 +686,7 @@ func getPathOp(pi *OASPathItem, op string) *OASOperation {
 }
 
 func expected(name string) string {
-	data, err := ioutil.ReadFile(filepath.Join("testdata", name+".json"))
+	data, err := os.ReadFile(filepath.Join("testdata", name+".json"))
 	if err != nil {
 		panic(err)
 	}

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/url"
@@ -1185,7 +1184,7 @@ func signCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertBun
 }
 
 func NewCertPool(reader io.Reader) (*x509.CertPool, error) {
-	pemBlock, err := ioutil.ReadAll(reader)
+	pemBlock, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/physical/file/file_test.go
+++ b/sdk/physical/file/file_test.go
@@ -3,7 +3,6 @@ package file
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestFileBackend_Base64URLEncoding(t *testing.T) {
-	backendPath, err := ioutil.TempDir("", "vault")
+	backendPath, err := os.MkdirTemp("", "vault")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -134,7 +133,7 @@ func TestFileBackend_Base64URLEncoding(t *testing.T) {
 }
 
 func TestFileBackend_ValidatePath(t *testing.T) {
-	dir, err := ioutil.TempDir("", "vault")
+	dir, err := os.MkdirTemp("", "vault")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -158,7 +157,7 @@ func TestFileBackend_ValidatePath(t *testing.T) {
 }
 
 func TestFileBackend(t *testing.T) {
-	dir, err := ioutil.TempDir("", "vault")
+	dir, err := os.MkdirTemp("", "vault")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/sdk/plugin/logger_test.go
+++ b/sdk/plugin/logger_test.go
@@ -3,13 +3,13 @@ package plugin
 import (
 	"bufio"
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/rpc"
 	"strings"
 	"testing"
 
 	hclog "github.com/hashicorp/go-hclog"
-	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 )
 
@@ -100,7 +100,7 @@ func TestLogger_isLevels(t *testing.T) {
 	client, server := plugin.TestRPCConn(t)
 	defer client.Close()
 
-	l := logging.NewVaultLoggerWithWriter(ioutil.Discard, hclog.Trace)
+	l := logging.NewVaultLoggerWithWriter(io.Discard, hclog.Trace)
 
 	server.RegisterName("Plugin", &LoggerServer{
 		logger: l,
@@ -144,7 +144,7 @@ func TestLogger_setLevel(t *testing.T) {
 	client, server := plugin.TestRPCConn(t)
 	defer client.Close()
 
-	l := hclog.New(&hclog.LoggerOptions{Output: ioutil.Discard})
+	l := hclog.New(&hclog.LoggerOptions{Output: io.Discard})
 
 	server.RegisterName("Plugin", &LoggerServer{
 		logger: l,

--- a/serviceregistration/kubernetes/client/config.go
+++ b/serviceregistration/kubernetes/client/config.go
@@ -3,7 +3,6 @@ package client
 import (
 	"bytes"
 	"crypto/x509"
-	"io/ioutil"
 	"net"
 	"os"
 
@@ -51,12 +50,12 @@ func inClusterConfig() (*Config, error) {
 		return nil, ErrNotInCluster
 	}
 
-	token, err := ioutil.ReadFile(TokenFile)
+	token, err := os.ReadFile(TokenFile)
 	if err != nil {
 		return nil, err
 	}
 
-	caBytes, err := ioutil.ReadFile(RootCAFile)
+	caBytes, err := os.ReadFile(RootCAFile)
 	if err != nil {
 		return nil, err
 	}

--- a/serviceregistration/kubernetes/testing/testserver.go
+++ b/serviceregistration/kubernetes/testing/testserver.go
@@ -3,7 +3,6 @@ package testing
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -101,7 +100,7 @@ func Server(t *testing.T) (testState *State, testConf *Conf, closeFunc func()) {
 	}
 
 	// Plant our token in a place where it can be read for the config.
-	tmpToken, err := ioutil.TempFile("", "token")
+	tmpToken, err := os.CreateTemp("", "token")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +117,7 @@ func Server(t *testing.T) (testState *State, testConf *Conf, closeFunc func()) {
 	}
 	testConf.PathToTokenFile = tmpToken.Name()
 
-	tmpCACrt, err := ioutil.TempFile("", "ca.crt")
+	tmpCACrt, err := os.CreateTemp("", "ca.crt")
 	if err != nil {
 		closeFunc()
 		t.Fatal(err)
@@ -239,7 +238,7 @@ func parsePath(urlPath string) (namespace, podName string, err error) {
 }
 
 func readFile(fileName string) (string, error) {
-	b, err := ioutil.ReadFile(pathToFiles + fileName)
+	b, err := os.ReadFile(pathToFiles + fileName)
 	if err != nil {
 		return "", err
 	}

--- a/vault/diagnose/tls_verification.go
+++ b/vault/diagnose/tls_verification.go
@@ -7,7 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -132,7 +132,7 @@ func ParseTLSInformation(certFilePath string) ([]*x509.Certificate, []*x509.Cert
 	leafCerts := []*x509.Certificate{}
 	interCerts := []*x509.Certificate{}
 	rootCerts := []*x509.Certificate{}
-	data, err := ioutil.ReadFile(certFilePath)
+	data, err := os.ReadFile(certFilePath)
 	if err != nil {
 		return leafCerts, interCerts, rootCerts, fmt.Errorf("Failed to read certificate file: %w.", err)
 	}

--- a/vault/external_tests/api/feature_flag_ext_test.go
+++ b/vault/external_tests/api/feature_flag_ext_test.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -49,7 +49,7 @@ func TestFeatureFlags(t *testing.T) {
 		}
 		defer resp.Body.Close()
 
-		httpRespBody, err := ioutil.ReadAll(resp.Body)
+		httpRespBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/vault/external_tests/kv/kv_patch_test.go
+++ b/vault/external_tests/kv/kv_patch_test.go
@@ -3,8 +3,8 @@ package kv
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -147,7 +147,7 @@ func TestKV_Patch_Audit(t *testing.T) {
 		t.Fatalf("kv-v2 mount attempt failed - err: %#v\n", err)
 	}
 
-	auditLogFile, err := ioutil.TempFile("", "httppatch")
+	auditLogFile, err := os.CreateTemp("", "httppatch")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/external_tests/metrics/core_metrics_int_test.go
+++ b/vault/external_tests/metrics/core_metrics_int_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -135,7 +135,7 @@ func TestLeaderReElectionMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	bodyBytes, err := ioutil.ReadAll(respo.Response.Body)
+	bodyBytes, err := io.ReadAll(respo.Response.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func TestLeaderReElectionMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	bodyBytes, err = ioutil.ReadAll(respo.Response.Body)
+	bodyBytes, err = io.ReadAll(respo.Response.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/external_tests/pprof/pprof_test.go
+++ b/vault/external_tests/pprof/pprof_test.go
@@ -3,7 +3,7 @@ package pprof
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -95,7 +95,7 @@ func TestSysPprof(t *testing.T) {
 		}
 		defer resp.Body.Close()
 
-		httpRespBody, err := ioutil.ReadAll(resp.Body)
+		httpRespBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -154,7 +154,7 @@ func TestSysPprof_MaxRequestDuration(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	httpRespBody, err := ioutil.ReadAll(resp.Body)
+	httpRespBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestSysPprof_Standby(t *testing.T) {
 		}
 		defer resp.Body.Close()
 
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		return string(data), err
 	}
 

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -565,7 +564,7 @@ func TestRaft_SnapshotAPI_MidstreamFailure(t *testing.T) {
 
 	var readErr error
 	go func() {
-		snap, readErr = ioutil.ReadAll(r)
+		snap, readErr = io.ReadAll(r)
 		wg.Done()
 	}()
 
@@ -679,7 +678,7 @@ func TestRaft_SnapshotAPI_RekeyRotate_Backward(t *testing.T) {
 			}
 			defer resp.Body.Close()
 
-			snap, err := ioutil.ReadAll(resp.Body)
+			snap, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -879,7 +878,7 @@ func TestRaft_SnapshotAPI_RekeyRotate_Forward(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			snap, err := ioutil.ReadAll(resp.Body)
+			snap, err := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			if err != nil {
 				t.Fatal(err)
@@ -936,7 +935,7 @@ func TestRaft_SnapshotAPI_RekeyRotate_Forward(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			snap2, err := ioutil.ReadAll(resp.Body)
+			snap2, err := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			if err != nil {
 				t.Fatal(err)
@@ -1066,7 +1065,7 @@ func TestRaft_SnapshotAPI_DifferentCluster(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	snap, err := ioutil.ReadAll(resp.Body)
+	snap, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		t.Fatal(err)

--- a/vault/logical_system_integ_test.go
+++ b/vault/logical_system_integ_test.go
@@ -2,7 +2,6 @@ package vault_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -564,7 +563,7 @@ func testSystemBackendMock(t *testing.T, numCores, numMounts int, backendType lo
 	}
 
 	// Create a tempdir, cluster.Cleanup will clean up this directory
-	tempDir, err := ioutil.TempDir("", "vault-test-cluster")
+	tempDir, err := os.MkdirTemp("", "vault-test-cluster")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -636,7 +635,7 @@ func testSystemBackend_SingleCluster_Env(t *testing.T, env []string) *vault.Test
 		},
 	}
 	// Create a tempdir, cluster.Cleanup will clean up this directory
-	tempDir, err := ioutil.TempDir("", "vault-test-cluster")
+	tempDir, err := os.MkdirTemp("", "vault-test-cluster")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -17,7 +16,7 @@ import (
 
 	"github.com/fatih/structs"
 	"github.com/go-test/deep"
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/audit"
 	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/helper/builtinplugins"
@@ -2948,7 +2947,7 @@ func TestSystemBackend_PluginCatalog_CRUD(t *testing.T) {
 	}
 
 	// Set a plugin
-	file, err := ioutil.TempFile(os.TempDir(), "temp")
+	file, err := os.CreateTemp(os.TempDir(), "temp")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"image/png"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -2056,7 +2056,7 @@ func (c *Core) validatePingID(ctx context.Context, mConfig *mfa.Config, username
 		req = req.WithContext(ctx)
 		req.Method = "POST"
 		req.URL = reqURL
-		req.Body = ioutil.NopCloser(bytes.NewBufferString(signedToken))
+		req.Body = io.NopCloser(bytes.NewBufferString(signedToken))
 		if req.Header == nil {
 			req.Header = make(http.Header)
 		}

--- a/vault/plugin_catalog_test.go
+++ b/vault/plugin_catalog_test.go
@@ -3,7 +3,6 @@ package vault
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -51,7 +50,7 @@ func TestPluginCatalog_CRUD(t *testing.T) {
 	}
 
 	// Set a plugin, test overwriting a builtin plugin
-	file, err := ioutil.TempFile(os.TempDir(), "temp")
+	file, err := os.CreateTemp(os.TempDir(), "temp")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +141,7 @@ func TestPluginCatalog_List(t *testing.T) {
 	}
 
 	// Set a plugin, test overwriting a builtin plugin
-	file, err := ioutil.TempFile(os.TempDir(), "temp")
+	file, err := os.CreateTemp(os.TempDir(), "temp")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	mathrand "math/rand"
 	"net"
@@ -1197,7 +1196,7 @@ func NewTestLogger(t testing.T) *TestLogger {
 	// We send nothing on the regular logger, that way we can later deregister
 	// the sink to stop logging during cluster cleanup.
 	logger := log.NewInterceptLogger(&log.LoggerOptions{
-		Output:            ioutil.Discard,
+		Output:            io.Discard,
 		IndependentLevels: true,
 	})
 	sink := log.NewSinkAdapter(&log.LoggerOptions{
@@ -1277,7 +1276,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		}
 		testCluster.TempDir = opts.TempDir
 	} else {
-		tempDir, err := ioutil.TempDir("", "vault-test-cluster-")
+		tempDir, err := os.MkdirTemp("", "vault-test-cluster-")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1330,7 +1329,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 	}
 	testCluster.CACertPEM = pem.EncodeToMemory(caCertPEMBlock)
 	testCluster.CACertPEMFile = filepath.Join(testCluster.TempDir, "ca_cert.pem")
-	err = ioutil.WriteFile(testCluster.CACertPEMFile, testCluster.CACertPEM, 0o755)
+	err = os.WriteFile(testCluster.CACertPEMFile, testCluster.CACertPEM, 0o755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1343,7 +1342,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		Bytes: marshaledCAKey,
 	}
 	testCluster.CAKeyPEM = pem.EncodeToMemory(caKeyPEMBlock)
-	err = ioutil.WriteFile(filepath.Join(testCluster.TempDir, "ca_key.pem"), testCluster.CAKeyPEM, 0o755)
+	err = os.WriteFile(filepath.Join(testCluster.TempDir, "ca_key.pem"), testCluster.CAKeyPEM, 0o755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1433,11 +1432,11 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 
 		certFile := filepath.Join(testCluster.TempDir, fmt.Sprintf("node%d_port_%d_cert.pem", i+1, ln.Addr().(*net.TCPAddr).Port))
 		keyFile := filepath.Join(testCluster.TempDir, fmt.Sprintf("node%d_port_%d_key.pem", i+1, ln.Addr().(*net.TCPAddr).Port))
-		err = ioutil.WriteFile(certFile, certInfoSlice[i].certPEM, 0o755)
+		err = os.WriteFile(certFile, certInfoSlice[i].certPEM, 0o755)
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(keyFile, certInfoSlice[i].keyPEM, 0o755)
+		err = os.WriteFile(keyFile, certInfoSlice[i].keyPEM, 0o755)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1982,7 +1981,7 @@ func (tc *TestCluster) initCores(t testing.T, opts *TestClusterOptions, addAudit
 	tc.RootToken = root
 
 	// Write root token and barrier keys
-	err := ioutil.WriteFile(filepath.Join(tc.TempDir, "root_token"), []byte(root), 0o755)
+	err := os.WriteFile(filepath.Join(tc.TempDir, "root_token"), []byte(root), 0o755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1993,7 +1992,7 @@ func (tc *TestCluster) initCores(t testing.T, opts *TestClusterOptions, addAudit
 			buf.WriteRune('\n')
 		}
 	}
-	err = ioutil.WriteFile(filepath.Join(tc.TempDir, "barrier_keys"), buf.Bytes(), 0o755)
+	err = os.WriteFile(filepath.Join(tc.TempDir, "barrier_keys"), buf.Bytes(), 0o755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2003,7 +2002,7 @@ func (tc *TestCluster) initCores(t testing.T, opts *TestClusterOptions, addAudit
 			buf.WriteRune('\n')
 		}
 	}
-	err = ioutil.WriteFile(filepath.Join(tc.TempDir, "recovery_keys"), buf.Bytes(), 0o755)
+	err = os.WriteFile(filepath.Join(tc.TempDir, "recovery_keys"), buf.Bytes(), 0o755)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/website/content/docs/agent/index.mdx
+++ b/website/content/docs/agent/index.mdx
@@ -42,7 +42,7 @@ func getSecretWithAppRole() (string, error) {
     config := vault.DefaultConfig()
 
     client := vault.NewClient(config)
-    wrappingToken := ioutil.ReadFile("path/to/wrapping-token")
+    wrappingToken := os.ReadFile("path/to/wrapping-token")
     unwrappedToken := client.Logical().Unwrap(strings.TrimSuffix(string(wrappingToken), "\n"))
 
     secretID := unwrappedToken.Data["secret_id"]
@@ -145,7 +145,7 @@ These are the currently-available general configuration option:
   token was retrieved and all sinks successfully wrote it
 
 - `disable_idle_connections` `(string array: [])` - A list of strings that disables idle connections for various features in Vault Agent.
-  Valid values include: `auto-auth`, `caching` and `templating`. Can also be configured by setting the `VAULT_AGENT_DISABLE_IDLE_CONNECTIONS` 
+  Valid values include: `auto-auth`, `caching` and `templating`. Can also be configured by setting the `VAULT_AGENT_DISABLE_IDLE_CONNECTIONS`
   environment variable as a comma separated string. This environment variable will override any values found in a configuration file.
 
 - `template` <code>([template][template]: <optional\>)</code> - Specifies options used for templating Vault secrets to files.


### PR DESCRIPTION
As of Go 1.16, the same functionality is now provided by package io or
package os, and those implementations should be preferred in new code.

So replacing all usage of ioutil pkg with io & os.

NOTE: I am sure I still have imports that need to be fixed which I will be continuing to work, and so keeping this PR in draft status for now.