### PR TITLE
Add HashiBox to community tools

### DIFF
--- a/website/content/api-docs/relatedtools.mdx
+++ b/website/content/api-docs/relatedtools.mdx
@@ -33,5 +33,6 @@ The following list of tools is maintained by the community of Vault users; Hashi
 - [Vault-CRD](https://vault.koudingspawn.de/) - Synchronize secrets stored in HashiCorp Vault to Kubernetes Secrets for better GitOps without secrets stored in git manifest files.
 - [nc-vault-env](https://github.com/namecheap/nc-vault-env) - JS CLI tool that fetches secrets in parallel, puts them into the environment and then `exec`s the process that needs them. Supports auth token renewal, multiple auth backends, verbose logging and dummy mode.
 - [vsh](https://github.com/fishi0x01/vsh) - Interactive shell with tab-completion. Allows recursive operations on paths. Allows migration of secrets between both KV versions.
+- [HashiBox](https://github.com/nunchistudio/hashibox) - Vagrant environment to simulate highly-available cloud with Consul, Nomad, Vault, and optional support for Waypoint. OSS & Enterprise supported.
 
 Want to add your own project, or one that you use? Additions are welcome via [pull requests](https://github.com/hashicorp/vault/blob/main/website/content/api-docs/relatedtools.mdx).


### PR DESCRIPTION
This PR adds [HashiBox](https://github.com/nunchistudio/hashibox) to the community tools.

HashiBox is a local environment to simulate a highly-available cloud with [Consul](https://www.consul.io/), [Nomad](https://www.nomadproject.io/), and [Vault](https://www.vaultproject.io/). OSS and Enterprise versions of each product are supported.