### PR TITLE
Synchronize access to database plugin gauge process close

### DIFF
--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -1535,6 +1535,8 @@ func TestBackend_AsyncClose(t *testing.T) {
 	done := make(chan bool)
 	go func() {
 		b.Cleanup(context.Background())
+		// check that clean can be called twice safely
+		b.Cleanup(context.Background())
 		done <- true
 	}()
 	select {


### PR DESCRIPTION
And only call it once.

This fixes a panic that can happen when the plugin `Cleanup` is called
twice.