### PR TITLE
Add warning on missing tidy targets

### DIFF
--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -243,7 +243,12 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 	}()
 
 	resp := &logical.Response{}
-	resp.AddWarning("Tidy operation successfully started. Any information from the operation will be printed to Vault's server logs.")
+	if !tidyCertStore && !tidyRevokedCerts && !tidyRevocationList {
+		resp.AddWarning("No targets to tidy; specify tidy_cert_store=true or tidy_revoked_certs=true to start a tidy operation.")
+	} else {
+		resp.AddWarning("Tidy operation successfully started. Any information from the operation will be printed to Vault's server logs.")
+	}
+
 	return logical.RespondWithStatusCode(resp, req, http.StatusAccepted)
 }
 


### PR DESCRIPTION
When tidy is called without arguments, we kick off a tidy operation with
no targets. This results in nothing being done, though the user might
reasonably expect some results.

Throw a warning in this case, so the user knows not to expect anything.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`