### PR TITLE
move unused GetCoreConfigInternal to common file to prevent ent panics

### DIFF
--- a/vault/core_util.go
+++ b/vault/core_util.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/command/server"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/license"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -69,16 +68,6 @@ func (c *Core) barrierViewForNamespace(namespaceId string) (*BarrierView, error)
 	}
 
 	return c.systemBarrierView, nil
-}
-
-// GetCoreConfigInternal returns the server configuration
-// in struct format.
-func (c *Core) GetCoreConfigInternal() *server.Config {
-	conf := c.rawConfig.Load()
-	if conf == nil {
-		return nil
-	}
-	return conf.(*server.Config)
 }
 
 func (c *Core) teardownReplicationResolverHandler() {}

--- a/vault/core_util_common.go
+++ b/vault/core_util_common.go
@@ -4,8 +4,19 @@ import (
 	"context"
 
 	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/command/server"
 	"github.com/hashicorp/vault/sdk/logical"
 )
+
+// GetCoreConfigInternal returns the server configuration
+// in struct format.
+func (c *Core) GetCoreConfigInternal() *server.Config {
+	conf := c.rawConfig.Load()
+	if conf == nil {
+		return nil
+	}
+	return conf.(*server.Config)
+}
 
 func (c *Core) loadHeaderHMACKey(ctx context.Context) error {
 	ent, err := c.barrier.Get(ctx, indexHeaderHMACKeyPath)


### PR DESCRIPTION
Ent panics example: https://app.circleci.com/pipelines/github/hashicorp/vault-enterprise/14763/workflows/902539e0-28b5-4ab9-ba65-79ba36803243/jobs/391102