### PR TITLE
UI Remove recent instances of sessionStorage

### DIFF
--- a/changelog/16170.txt
+++ b/changelog/16170.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: OIDC login type uses localStorage instead of sessionStorage
+```

--- a/ui/app/services/auth.js
+++ b/ui/app/services/auth.js
@@ -377,8 +377,8 @@ export default Service.extend({
   },
 
   async authSuccess(options, response) {
-    // persist selectedAuth to sessionStorage to rehydrate auth form on logout
-    sessionStorage.setItem('selectedAuth', options.selectedAuth);
+    // persist selectedAuth to localStorage to rehydrate auth form on logout
+    localStorage.setItem('selectedAuth', options.selectedAuth);
     const authData = await this.persistAuthData(options, response, this.namespaceService.path);
     await this.permissions.getPaths.perform();
     return authData;
@@ -397,8 +397,8 @@ export default Service.extend({
   },
 
   getAuthType() {
-    // check sessionStorage first
-    const selectedAuth = sessionStorage.getItem('selectedAuth');
+    // check localStorage first
+    const selectedAuth = localStorage.getItem('selectedAuth');
     if (selectedAuth) return selectedAuth;
     // fallback to authData which discerns backend type from token
     return this.authData ? this.authData.backend.type : null;

--- a/ui/tests/acceptance/oidc-auth-method-test.js
+++ b/ui/tests/acceptance/oidc-auth-method-test.js
@@ -19,7 +19,7 @@ module('Acceptance | oidc auth method', function (hooks) {
       auth: { client_token: 'root' },
     }));
     // ensure clean state
-    sessionStorage.removeItem('selectedAuth');
+    localStorage.removeItem('selectedAuth');
   });
   hooks.afterEach(function () {
     this.openStub.restore();

--- a/ui/tests/pages/auth.js
+++ b/ui/tests/pages/auth.js
@@ -16,7 +16,7 @@ export default create({
     await this.logout();
     await settled();
     // clear session storage to ensure we have a clean state
-    window.sessionStorage.clear();
+    window.localStorage.clear();
     await this.visit({ with: 'token' });
     await settled();
     if (token) {
@@ -31,8 +31,8 @@ export default create({
     // make sure we're always logged out and logged back in
     await this.logout();
     await settled();
-    // clear session storage to ensure we have a clean state
-    window.sessionStorage.clear();
+    // clear local storage to ensure we have a clean state
+    window.localStorage.clear();
     await this.visit({ with: 'username' });
     await settled();
     await this.usernameInput(username);


### PR DESCRIPTION
This PR removes remaining references to sessionStorage. Here's what happened:

1. We swapped localStorage in favor of sessionStorage in #14054 
2. OIDC bugfix in #14545 used sessionStorage because that's what was standard at the time
3. Team realized the move to sessionStorage was a mistake, and reverted 14054 in #15769 
4. Changes from 14545 are still present in 1.11 onward, and this PR is to fix that. 