### PR TITLE
vault documentation: updated examples to use volumes

### DIFF
--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -516,7 +516,7 @@ and consider if they're appropriate for your deployment.
       Default mode of the mounted files.
 
     ```yaml
-    extraVolumes:
+    Volumes:
       - type: 'secret'
         name: 'vault-certs'
         path: '/etc/pki'

--- a/website/content/docs/platform/k8s/helm/examples/ha-with-consul.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/ha-with-consul.mdx
@@ -20,7 +20,7 @@ server:
     GOOGLE_PROJECT: myproject
     GOOGLE_APPLICATION_CREDENTIALS: /vault/userconfig/my-gcp-iam/myproject-creds.json
 
-  extraVolumes:
+  Volumes:
     - type: secret
       name: my-gcp-iam
 

--- a/website/content/docs/platform/k8s/helm/examples/ha-with-consul.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/ha-with-consul.mdx
@@ -20,9 +20,16 @@ server:
     GOOGLE_PROJECT: myproject
     GOOGLE_APPLICATION_CREDENTIALS: /vault/userconfig/my-gcp-iam/myproject-creds.json
 
-  Volumes:
-    - type: secret
-      name: my-gcp-iam
+  volumes:
+    - name: userconfig-my-gcp-iam
+      secret:
+        defaultMode: 420
+        secretName: my-gcp-iam
+
+  volumeMounts:
+    - mountPath: /vault/userconfig/my-gcp-iam
+      name: userconfig-my-gcp-iam
+      readOnly: true
 
   affinity: |
     podAntiAffinity:

--- a/website/content/docs/platform/k8s/helm/examples/standalone-tls.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/standalone-tls.mdx
@@ -184,7 +184,7 @@ server:
   extraEnvironmentVars:
     VAULT_CACERT: /vault/userconfig/vault-server-tls/vault.ca
 
-  extraVolumes:
+  Volumes:
     - type: secret
       name: vault-server-tls # Matches the ${SECRET_NAME} from above
 

--- a/website/content/docs/platform/k8s/helm/examples/standalone-tls.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/standalone-tls.mdx
@@ -184,9 +184,16 @@ server:
   extraEnvironmentVars:
     VAULT_CACERT: /vault/userconfig/vault-server-tls/vault.ca
 
-  Volumes:
-    - type: secret
-      name: vault-server-tls # Matches the ${SECRET_NAME} from above
+  volumes:
+    - name: userconfig-vault-server-tls
+      secret:
+        defaultMode: 420
+        secretName: vault-server-tls # Matches the ${SECRET_NAME} from above
+
+  volumeMounts:
+    - mountPath: /vault/userconfig/vault-server-tls
+      name: userconfig-vault-server-tls
+      readOnly: true
 
   standalone:
     enabled: true

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -252,7 +252,7 @@ server:
     GOOGLE_PROJECT: <PROJECT NAME>
     GOOGLE_APPLICATION_CREDENTIALS: /vault/userconfig/kms-creds/credentials.json
 
-  extraVolumes:
+  Volumes:
     - type: 'secret'
       name: 'kms-creds'
 
@@ -502,8 +502,8 @@ to the Vault startup command:
 
 ```shell-session
 $ helm install vault hashicorp/vault \
-  --set='server.extraVolumes[0].type=secret' \
-  --set='server.extraVolumes[0].name=vault-storage-config' \
+  --set='server.Volumes[0].type=secret' \
+  --set='server.Volumes[0].name=vault-storage-config' \
   --set='server.extraArgs=-config=/vault/userconfig/vault-storage-config/config.hcl'
 ```
 

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -509,8 +509,12 @@ to the Vault startup command:
 
 ```shell-session
 $ helm install vault hashicorp/vault \
-  --set='server.Volumes[0].type=secret' \
-  --set='server.Volumes[0].name=vault-storage-config' \
+  --set='server.volumes[0].name=userconfig-vault-storage-config' \
+  --set='server.volumes[0].secret.defaultMode=420' \
+  --set='server.volumes[0].secret.secretName=vault-storage-config' \
+  --set='server.volumeMounts[0].mountPath=/vault/userconfig/vault-storage-config' \
+  --set='server.volumeMounts[0].name=userconfig-vault-storage-config' \
+  --set='server.volumeMounts[0].readOnly=true' \
   --set='server.extraArgs=-config=/vault/userconfig/vault-storage-config/config.hcl'
 ```
 

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -252,9 +252,16 @@ server:
     GOOGLE_PROJECT: <PROJECT NAME>
     GOOGLE_APPLICATION_CREDENTIALS: /vault/userconfig/kms-creds/credentials.json
 
-  Volumes:
-    - type: 'secret'
-      name: 'kms-creds'
+  volumes:
+    - name: userconfig-kms-creds
+      secret:
+        defaultMode: 420
+        secretName: kms-creds
+
+  volumeMounts:
+    - mountPath: /vault/userconfig/kms-creds
+      name: userconfig-kms-creds
+      readOnly: true
 
   ha:
     enabled: true


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/563192436488770/1202424480411259/f) task, the following documentation have been amended to remove `extraVolumes` from the configuration examples since it's been deprecated and replaced with `Volumes`.

- Configuration: :mag: [Deploy Preview](https://vault-git-docs-update-k8s-examples-hashicorp.vercel.app/docs/platform/k8s/helm/configuration)
- HA Vault Cluster with Consul: :mag: [Deploy Preview](https://vault-git-docs-update-k8s-examples-hashicorp.vercel.app/docs/platform/k8s/helm/examples/ha-with-consul)
- Standalone Server with TLS: :mag: [Deploy Preview](https://vault-git-docs-update-k8s-examples-hashicorp.vercel.app/docs/platform/k8s/helm/examples/standalone-tls)
- Run Vault on Kubernetes: :mag: [Deploy Preview](https://vault-git-docs-update-k8s-examples-hashicorp.vercel.app/docs/platform/k8s/helm/run)