### PR TITLE
identity/oidc: allow filtering the list providers response by an allowed_client_id

### DIFF
--- a/changelog/16181.txt
+++ b/changelog/16181.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+identity/oidc: allows filtering the list providers response by an allowed_client_id
+```

--- a/http/logical.go
+++ b/http/logical.go
@@ -178,6 +178,8 @@ func buildLogicalRequestNoAuth(perfStandby bool, w http.ResponseWriter, r *http.
 			path += "/"
 		}
 
+		data = parseQuery(r.URL.Query())
+
 	case "OPTIONS", "HEAD":
 	default:
 		return nil, nil, http.StatusMethodNotAllowed, nil

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -372,8 +372,8 @@ func oidcProviderPaths(i *IdentityStore) []*framework.Path {
 			Fields: map[string]*framework.FieldSchema{
 				"allowed_client_id": {
 					Type: framework.TypeString,
-					Description: "Filters the set of returned OIDC providers to those " +
-						"that allow the given value in their set of allowed_client_ids.",
+					Description: "Filters the list of OIDC providers to those " +
+						"that allow the given client ID in their set of allowed_client_ids.",
 					Query: true,
 				},
 			},

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -3353,7 +3353,6 @@ func TestOIDC_Path_OIDC_Provider_List(t *testing.T) {
 func TestOIDC_Path_OIDC_Provider_List_Filter(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	ctx := namespace.RootContext(nil)
-	s := new(logical.InmemStorage)
 
 	// Create providers with different allowed_client_ids values
 	providers := []struct {
@@ -3371,7 +3370,7 @@ func TestOIDC_Path_OIDC_Provider_List_Filter(t *testing.T) {
 		resp, err := c.identityStore.HandleRequest(ctx, &logical.Request{
 			Path:      "oidc/provider/" + p.name,
 			Operation: logical.CreateOperation,
-			Storage:   s,
+			Storage:   c.identityStore.view,
 			Data: map[string]interface{}{
 				"allowed_client_ids": p.allowedClientIDs,
 			},
@@ -3387,32 +3386,32 @@ func TestOIDC_Path_OIDC_Provider_List_Filter(t *testing.T) {
 		{
 			name:              "list providers with client_id filter subset 1",
 			clientIDFilter:    "abc",
-			expectedProviders: []string{"p0", "p1", "p2", "p3"},
+			expectedProviders: []string{"default", "p0", "p1", "p2", "p3"},
 		},
 		{
 			name:              "list providers with client_id filter subset 2",
 			clientIDFilter:    "def",
-			expectedProviders: []string{"p0", "p2", "p3"},
+			expectedProviders: []string{"default", "p0", "p2", "p3"},
 		},
 		{
 			name:              "list providers with client_id filter subset 3",
 			clientIDFilter:    "ghi",
-			expectedProviders: []string{"p0", "p3", "p4"},
+			expectedProviders: []string{"default", "p0", "p3", "p4"},
 		},
 		{
 			name:              "list providers with client_id filter subset 4",
 			clientIDFilter:    "jkl",
-			expectedProviders: []string{"p0", "p5"},
+			expectedProviders: []string{"default", "p0", "p5"},
 		},
 		{
 			name:              "list providers with client_id filter only matching glob",
 			clientIDFilter:    "globmatch_only",
-			expectedProviders: []string{"p0"},
+			expectedProviders: []string{"default", "p0"},
 		},
 		{
 			name:              "list providers with empty client_id filter returns all",
 			clientIDFilter:    "",
-			expectedProviders: []string{"p0", "p1", "p2", "p3", "p4", "p5"},
+			expectedProviders: []string{"default", "p0", "p1", "p2", "p3", "p4", "p5"},
 		},
 	}
 	for _, tc := range tests {
@@ -3421,7 +3420,7 @@ func TestOIDC_Path_OIDC_Provider_List_Filter(t *testing.T) {
 			resp, err := c.identityStore.HandleRequest(ctx, &logical.Request{
 				Path:      "oidc/provider",
 				Operation: logical.ListOperation,
-				Storage:   s,
+				Storage:   c.identityStore.view,
 				Data: map[string]interface{}{
 					"allowed_client_id": tc.clientIDFilter,
 				},

--- a/website/content/api-docs/secret/identity/oidc-provider.mdx
+++ b/website/content/api-docs/secret/identity/oidc-provider.mdx
@@ -84,6 +84,11 @@ This endpoint returns a list of all OIDC providers.
 | :----- | :------------------------------ |
 | `LIST` | `/identity/oidc/provider`           |
 
+### Query Parameters
+
+- `allowed_client_id` `(string: <optional>)` – Filters the list of OIDC providers to those
+  that allow the given client ID in their set of [allowed_client_ids](/api-docs/secret/identity/oidc-provider#allowed_client_ids).
+
 ### Sample Request
 
 ```shell-session


### PR DESCRIPTION
### Overview

This PR allows filtering the [list providers](https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#list-providers) response by an `allowed_client_id` value. The list of providers returned will be those that allow the given client ID in their [`allowed_client_ids`](https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#allowed_client_ids) field. This is useful for a UI workflow where suggesting an issuer to use along with client application creation.

Example:
```sh
$ curl -H "X-Vault-Token: ..." -X LIST http://127.0.0.1:8200/v1/identity/oidc/provider?allowed_client_id="<client_id>"
```

### Testing

I've added tests to this PR which exercise the list filtering capability.

