### PR TITLE
Remove structs, mapstructure from PKI storage

### DIFF
--- a/builtin/logical/pki/path_config_crl.go
+++ b/builtin/logical/pki/path_config_crl.go
@@ -12,7 +12,7 @@ import (
 
 // CRLConfig holds basic CRL configuration information
 type crlConfig struct {
-	Expiry  string `json:"expiry" mapstructure:"expiry"`
+	Expiry  string `json:"expiry"`
 	Disable bool   `json:"disable"`
 }
 

--- a/builtin/logical/pki/path_config_urls.go
+++ b/builtin/logical/pki/path_config_urls.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/asaskevich/govalidator"
-	"github.com/fatih/structs"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -105,7 +104,11 @@ func (b *backend) pathReadURL(ctx context.Context, req *logical.Request, _ *fram
 	}
 
 	resp := &logical.Response{
-		Data: structs.New(entries).Map(),
+		Data: map[string]interface{}{
+			"issuing_certificates":    entries.IssuingCertificates,
+			"crl_distribution_points": entries.CRLDistributionPoints,
+			"ocsp_servers":            entries.OCSPServers,
+		},
 	}
 
 	return resp, nil

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -1037,60 +1037,60 @@ func parseExtKeyUsages(role *roleEntry) certutil.CertExtKeyUsage {
 type roleEntry struct {
 	LeaseMax                      string        `json:"lease_max"`
 	Lease                         string        `json:"lease"`
-	DeprecatedMaxTTL              string        `json:"max_ttl" mapstructure:"max_ttl"`
-	DeprecatedTTL                 string        `json:"ttl" mapstructure:"ttl"`
-	TTL                           time.Duration `json:"ttl_duration" mapstructure:"ttl_duration"`
-	MaxTTL                        time.Duration `json:"max_ttl_duration" mapstructure:"max_ttl_duration"`
-	AllowLocalhost                bool          `json:"allow_localhost" mapstructure:"allow_localhost"`
-	AllowedBaseDomain             string        `json:"allowed_base_domain" mapstructure:"allowed_base_domain"`
+	DeprecatedMaxTTL              string        `json:"max_ttl"`
+	DeprecatedTTL                 string        `json:"ttl"`
+	TTL                           time.Duration `json:"ttl_duration"`
+	MaxTTL                        time.Duration `json:"max_ttl_duration"`
+	AllowLocalhost                bool          `json:"allow_localhost"`
+	AllowedBaseDomain             string        `json:"allowed_base_domain"`
 	AllowedDomainsOld             string        `json:"allowed_domains,omitempty"`
-	AllowedDomains                []string      `json:"allowed_domains_list" mapstructure:"allowed_domains"`
+	AllowedDomains                []string      `json:"allowed_domains_list"`
 	AllowedDomainsTemplate        bool          `json:"allowed_domains_template"`
 	AllowBaseDomain               bool          `json:"allow_base_domain"`
-	AllowBareDomains              bool          `json:"allow_bare_domains" mapstructure:"allow_bare_domains"`
-	AllowTokenDisplayName         bool          `json:"allow_token_displayname" mapstructure:"allow_token_displayname"`
-	AllowSubdomains               bool          `json:"allow_subdomains" mapstructure:"allow_subdomains"`
-	AllowGlobDomains              bool          `json:"allow_glob_domains" mapstructure:"allow_glob_domains"`
-	AllowWildcardCertificates     *bool         `json:"allow_wildcard_certificates,omitempty" mapstructure:"allow_wildcard_certificates"`
-	AllowAnyName                  bool          `json:"allow_any_name" mapstructure:"allow_any_name"`
-	EnforceHostnames              bool          `json:"enforce_hostnames" mapstructure:"enforce_hostnames"`
-	AllowIPSANs                   bool          `json:"allow_ip_sans" mapstructure:"allow_ip_sans"`
-	ServerFlag                    bool          `json:"server_flag" mapstructure:"server_flag"`
-	ClientFlag                    bool          `json:"client_flag" mapstructure:"client_flag"`
-	CodeSigningFlag               bool          `json:"code_signing_flag" mapstructure:"code_signing_flag"`
-	EmailProtectionFlag           bool          `json:"email_protection_flag" mapstructure:"email_protection_flag"`
-	UseCSRCommonName              bool          `json:"use_csr_common_name" mapstructure:"use_csr_common_name"`
-	UseCSRSANs                    bool          `json:"use_csr_sans" mapstructure:"use_csr_sans"`
-	KeyType                       string        `json:"key_type" mapstructure:"key_type"`
-	KeyBits                       int           `json:"key_bits" mapstructure:"key_bits"`
-	SignatureBits                 int           `json:"signature_bits" mapstructure:"signature_bits"`
-	MaxPathLength                 *int          `json:",omitempty" mapstructure:"max_path_length"`
+	AllowBareDomains              bool          `json:"allow_bare_domains"`
+	AllowTokenDisplayName         bool          `json:"allow_token_displayname"`
+	AllowSubdomains               bool          `json:"allow_subdomains"`
+	AllowGlobDomains              bool          `json:"allow_glob_domains"`
+	AllowWildcardCertificates     *bool         `json:"allow_wildcard_certificates,omitempty"`
+	AllowAnyName                  bool          `json:"allow_any_name"`
+	EnforceHostnames              bool          `json:"enforce_hostnames"`
+	AllowIPSANs                   bool          `json:"allow_ip_sans"`
+	ServerFlag                    bool          `json:"server_flag"`
+	ClientFlag                    bool          `json:"client_flag"`
+	CodeSigningFlag               bool          `json:"code_signing_flag"`
+	EmailProtectionFlag           bool          `json:"email_protection_flag"`
+	UseCSRCommonName              bool          `json:"use_csr_common_name"`
+	UseCSRSANs                    bool          `json:"use_csr_sans"`
+	KeyType                       string        `json:"key_type"`
+	KeyBits                       int           `json:"key_bits"`
+	SignatureBits                 int           `json:"signature_bits"`
+	MaxPathLength                 *int          `json:",omitempty"`
 	KeyUsageOld                   string        `json:"key_usage,omitempty"`
-	KeyUsage                      []string      `json:"key_usage_list" mapstructure:"key_usage"`
-	ExtKeyUsage                   []string      `json:"extended_key_usage_list" mapstructure:"extended_key_usage"`
+	KeyUsage                      []string      `json:"key_usage_list"`
+	ExtKeyUsage                   []string      `json:"extended_key_usage_list"`
 	OUOld                         string        `json:"ou,omitempty"`
-	OU                            []string      `json:"ou_list" mapstructure:"ou"`
+	OU                            []string      `json:"ou_list"`
 	OrganizationOld               string        `json:"organization,omitempty"`
-	Organization                  []string      `json:"organization_list" mapstructure:"organization"`
-	Country                       []string      `json:"country" mapstructure:"country"`
-	Locality                      []string      `json:"locality" mapstructure:"locality"`
-	Province                      []string      `json:"province" mapstructure:"province"`
-	StreetAddress                 []string      `json:"street_address" mapstructure:"street_address"`
-	PostalCode                    []string      `json:"postal_code" mapstructure:"postal_code"`
+	Organization                  []string      `json:"organization_list"`
+	Country                       []string      `json:"country"`
+	Locality                      []string      `json:"locality"`
+	Province                      []string      `json:"province"`
+	StreetAddress                 []string      `json:"street_address"`
+	PostalCode                    []string      `json:"postal_code"`
 	GenerateLease                 *bool         `json:"generate_lease,omitempty"`
-	NoStore                       bool          `json:"no_store" mapstructure:"no_store"`
-	RequireCN                     bool          `json:"require_cn" mapstructure:"require_cn"`
-	CNValidations                 []string      `json:"cn_validations" mapstructure:"cn_validations"`
-	AllowedOtherSANs              []string      `json:"allowed_other_sans" mapstructure:"allowed_other_sans"`
-	AllowedSerialNumbers          []string      `json:"allowed_serial_numbers" mapstructure:"allowed_serial_numbers"`
-	AllowedURISANs                []string      `json:"allowed_uri_sans" mapstructure:"allowed_uri_sans"`
+	NoStore                       bool          `json:"no_store"`
+	RequireCN                     bool          `json:"require_cn"`
+	CNValidations                 []string      `json:"cn_validations"`
+	AllowedOtherSANs              []string      `json:"allowed_other_sans"`
+	AllowedSerialNumbers          []string      `json:"allowed_serial_numbers"`
+	AllowedURISANs                []string      `json:"allowed_uri_sans"`
 	AllowedURISANsTemplate        bool          `json:"allowed_uri_sans_template"`
-	PolicyIdentifiers             []string      `json:"policy_identifiers" mapstructure:"policy_identifiers"`
-	ExtKeyUsageOIDs               []string      `json:"ext_key_usage_oids" mapstructure:"ext_key_usage_oids"`
-	BasicConstraintsValidForNonCA bool          `json:"basic_constraints_valid_for_non_ca" mapstructure:"basic_constraints_valid_for_non_ca"`
-	NotBeforeDuration             time.Duration `json:"not_before_duration" mapstructure:"not_before_duration"`
-	NotAfter                      string        `json:"not_after" mapstructure:"not_after"`
-	Issuer                        string        `json:"issuer" mapstructure:"issuer"`
+	PolicyIdentifiers             []string      `json:"policy_identifiers"`
+	ExtKeyUsageOIDs               []string      `json:"ext_key_usage_oids"`
+	BasicConstraintsValidForNonCA bool          `json:"basic_constraints_valid_for_non_ca"`
+	NotBeforeDuration             time.Duration `json:"not_before_duration"`
+	NotAfter                      string        `json:"not_after"`
+	Issuer                        string        `json:"issuer"`
 }
 
 func (r *roleEntry) ToResponseData() map[string]interface{} {

--- a/builtin/logical/pki/path_roles_test.go
+++ b/builtin/logical/pki/path_roles_test.go
@@ -8,12 +8,10 @@ import (
 	"encoding/pem"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/go-errors/errors"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,22 +57,21 @@ func TestPki_RoleGenerateLease(t *testing.T) {
 		t.Fatalf("generate_lease should not be set by default")
 	}
 
-	// Update values due to switching of ttl type
-	resp.Data["ttl_duration"] = resp.Data["ttl"]
-	resp.Data["ttl"] = (time.Duration(resp.Data["ttl"].(int64)) * time.Second).String()
-	resp.Data["max_ttl_duration"] = resp.Data["max_ttl"]
-	resp.Data["max_ttl"] = (time.Duration(resp.Data["max_ttl"].(int64)) * time.Second).String()
-	// role.GenerateLease will be nil after the decode
-	var role roleEntry
-	err = mapstructure.Decode(resp.Data, &role)
-	if err != nil {
+	// To test upgrade of generate_lease, we read the storage entry,
+	// modify it to remove generate_lease, and rewrite it.
+	entry, err := storage.Get(context.Background(), "role/testrole")
+	if err != nil || entry == nil {
 		t.Fatal(err)
 	}
 
-	// Make it explicit
+	var role roleEntry
+	if err := entry.DecodeJSON(&role); err != nil {
+		t.Fatal(err)
+	}
+
 	role.GenerateLease = nil
 
-	entry, err := logical.StorageEntryJSON("role/testrole", role)
+	entry, err = logical.StorageEntryJSON("role/testrole", role)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,26 +154,23 @@ func TestPki_RoleKeyUsage(t *testing.T) {
 		t.Fatalf("key_usage should have 2 values")
 	}
 
-	// Update values due to switching of ttl type
-	resp.Data["ttl_duration"] = resp.Data["ttl"]
-	resp.Data["ttl"] = (time.Duration(resp.Data["ttl"].(int64)) * time.Second).String()
-	resp.Data["max_ttl_duration"] = resp.Data["max_ttl"]
-	resp.Data["max_ttl"] = (time.Duration(resp.Data["max_ttl"].(int64)) * time.Second).String()
-	// Check that old key usage value is nil
-	var role roleEntry
-	err = mapstructure.Decode(resp.Data, &role)
-	if err != nil {
+	// To test the upgrade of KeyUsageOld into KeyUsage, we read
+	// the storage entry, modify it to set KUO and unset KU, and
+	// rewrite it.
+	entry, err := storage.Get(context.Background(), "role/testrole")
+	if err != nil || entry == nil {
 		t.Fatal(err)
 	}
-	if role.KeyUsageOld != "" {
-		t.Fatalf("old key usage storage value should be blank")
+
+	var role roleEntry
+	if err := entry.DecodeJSON(&role); err != nil {
+		t.Fatal(err)
 	}
 
-	// Make it explicit
 	role.KeyUsageOld = "KeyEncipherment,DigitalSignature"
 	role.KeyUsage = nil
 
-	entry, err := logical.StorageEntryJSON("role/testrole", role)
+	entry, err = logical.StorageEntryJSON("role/testrole", role)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,31 +249,23 @@ func TestPki_RoleOUOrganizationUpgrade(t *testing.T) {
 		t.Fatalf("organization should have 2 values")
 	}
 
-	// Update values due to switching of ttl type
-	resp.Data["ttl_duration"] = resp.Data["ttl"]
-	resp.Data["ttl"] = (time.Duration(resp.Data["ttl"].(int64)) * time.Second).String()
-	resp.Data["max_ttl_duration"] = resp.Data["max_ttl"]
-	resp.Data["max_ttl"] = (time.Duration(resp.Data["max_ttl"].(int64)) * time.Second).String()
-	// Check that old key usage value is nil
-	var role roleEntry
-	err = mapstructure.Decode(resp.Data, &role)
-	if err != nil {
+	// To test upgrade of O/OU, we read the storage entry, modify it to set
+	// the old O/OU value over the new one, and rewrite it.
+	entry, err := storage.Get(context.Background(), "role/testrole")
+	if err != nil || entry == nil {
 		t.Fatal(err)
 	}
-	if role.OUOld != "" {
-		t.Fatalf("old ou storage value should be blank")
-	}
-	if role.OrganizationOld != "" {
-		t.Fatalf("old organization storage value should be blank")
-	}
 
-	// Make it explicit
+	var role roleEntry
+	if err := entry.DecodeJSON(&role); err != nil {
+		t.Fatal(err)
+	}
 	role.OUOld = "abc,123"
 	role.OU = nil
 	role.OrganizationOld = "org1,org2"
 	role.Organization = nil
 
-	entry, err := logical.StorageEntryJSON("role/testrole", role)
+	entry, err = logical.StorageEntryJSON("role/testrole", role)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -362,26 +348,21 @@ func TestPki_RoleAllowedDomains(t *testing.T) {
 		t.Fatalf("allowed_domains should have 2 values")
 	}
 
-	// Update values due to switching of ttl type
-	resp.Data["ttl_duration"] = resp.Data["ttl"]
-	resp.Data["ttl"] = (time.Duration(resp.Data["ttl"].(int64)) * time.Second).String()
-	resp.Data["max_ttl_duration"] = resp.Data["max_ttl"]
-	resp.Data["max_ttl"] = (time.Duration(resp.Data["max_ttl"].(int64)) * time.Second).String()
-	// Check that old key usage value is nil
-	var role roleEntry
-	err = mapstructure.Decode(resp.Data, &role)
-	if err != nil {
+	// To test upgrade of allowed_domains, we read the storage entry,
+	// set the old one, and rewrite it.
+	entry, err := storage.Get(context.Background(), "role/testrole")
+	if err != nil || entry == nil {
 		t.Fatal(err)
 	}
-	if role.AllowedDomainsOld != "" {
-		t.Fatalf("old allowed_domains storage value should be blank")
-	}
 
-	// Make it explicit
+	var role roleEntry
+	if err := entry.DecodeJSON(&role); err != nil {
+		t.Fatal(err)
+	}
 	role.AllowedDomainsOld = "foobar.com,*example.com"
 	role.AllowedDomains = nil
 
-	entry, err := logical.StorageEntryJSON("role/testrole", role)
+	entry, err = logical.StorageEntryJSON("role/testrole", role)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -56,10 +56,10 @@ const (
 )
 
 type keyEntry struct {
-	ID             keyID                   `json:"id" structs:"id" mapstructure:"id"`
-	Name           string                  `json:"name" structs:"name" mapstructure:"name"`
-	PrivateKeyType certutil.PrivateKeyType `json:"private_key_type" structs:"private_key_type" mapstructure:"private_key_type"`
-	PrivateKey     string                  `json:"private_key" structs:"private_key" mapstructure:"private_key"`
+	ID             keyID                   `json:"id"`
+	Name           string                  `json:"name"`
+	PrivateKeyType certutil.PrivateKeyType `json:"private_key_type"`
+	PrivateKey     string                  `json:"private_key"`
 }
 
 func (e keyEntry) getManagedKeyUUID() (UUIDKey, error) {
@@ -136,28 +136,28 @@ func NewIssuerUsageFromNames(names []string) (issuerUsage, error) {
 }
 
 type issuerEntry struct {
-	ID                   issuerID                  `json:"id" structs:"id" mapstructure:"id"`
-	Name                 string                    `json:"name" structs:"name" mapstructure:"name"`
-	KeyID                keyID                     `json:"key_id" structs:"key_id" mapstructure:"key_id"`
-	Certificate          string                    `json:"certificate" structs:"certificate" mapstructure:"certificate"`
-	CAChain              []string                  `json:"ca_chain" structs:"ca_chain" mapstructure:"ca_chain"`
-	ManualChain          []issuerID                `json:"manual_chain" structs:"manual_chain" mapstructure:"manual_chain"`
-	SerialNumber         string                    `json:"serial_number" structs:"serial_number" mapstructure:"serial_number"`
-	LeafNotAfterBehavior certutil.NotAfterBehavior `json:"not_after_behavior" structs:"not_after_behavior" mapstructure:"not_after_behavior"`
-	Usage                issuerUsage               `json:"usage" structs:"usage" mapstructure:"usage"`
+	ID                   issuerID                  `json:"id"`
+	Name                 string                    `json:"name"`
+	KeyID                keyID                     `json:"key_id"`
+	Certificate          string                    `json:"certificate"`
+	CAChain              []string                  `json:"ca_chain"`
+	ManualChain          []issuerID                `json:"manual_chain"`
+	SerialNumber         string                    `json:"serial_number"`
+	LeafNotAfterBehavior certutil.NotAfterBehavior `json:"not_after_behavior"`
+	Usage                issuerUsage               `json:"usage"`
 }
 
 type localCRLConfigEntry struct {
-	IssuerIDCRLMap map[issuerID]crlID `json:"issuer_id_crl_map" structs:"issuer_id_crl_map" mapstructure:"issuer_id_crl_map"`
-	CRLNumberMap   map[crlID]int64    `json:"crl_number_map" structs:"crl_number_map" mapstructure:"crl_number_map"`
+	IssuerIDCRLMap map[issuerID]crlID `json:"issuer_id_crl_map"`
+	CRLNumberMap   map[crlID]int64    `json:"crl_number_map"`
 }
 
 type keyConfigEntry struct {
-	DefaultKeyId keyID `json:"default" structs:"default" mapstructure:"default"`
+	DefaultKeyId keyID `json:"default"`
 }
 
 type issuerConfigEntry struct {
-	DefaultIssuerId issuerID `json:"default" structs:"default" mapstructure:"default"`
+	DefaultIssuerId issuerID `json:"default"`
 }
 
 type storageContext struct {

--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -21,11 +21,11 @@ const (
 )
 
 type legacyBundleMigrationLog struct {
-	Hash             string    `json:"hash" structs:"hash" mapstructure:"hash"`
-	Created          time.Time `json:"created" structs:"created" mapstructure:"created"`
-	CreatedIssuer    issuerID  `json:"issuer_id" structs:"issuer_id" mapstructure:"issuer_id"`
-	CreatedKey       keyID     `json:"key_id" structs:"key_id" mapstructure:"key_id"`
-	MigrationVersion int       `json:"migrationVersion" structs:"migrationVersion" mapstructure:"migrationVersion"`
+	Hash             string    `json:"hash"`
+	Created          time.Time `json:"created"`
+	CreatedIssuer    issuerID  `json:"issuer_id"`
+	CreatedKey       keyID     `json:"key_id"`
+	MigrationVersion int       `json:"migrationVersion"`
 }
 
 type migrationInfo struct {


### PR DESCRIPTION
`structs` and `mapstructure` aren't really used within Vault much any more,
so we should start removing them. Luckily there was only one externally
accessible place where structs was used (AIA URLs config) so that was
easy to remove. The rest is mostly structure tag changes.

`path_roles_tests.go` relied on `mapstructure` in some places that broke,
but otherwise `backend_test.go` hasn't yet been modified to remove the
dependency on `mapstructure`. These didn't break as the underlying
CertBundle didn't get `mapstructure` support removed (as its in the SDK).

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`