### PR TITLE
Developer Quickstart docs improvements

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -4,5 +4,6 @@ Vault API
 This provides the `github.com/hashicorp/vault/api` package which contains code useful for interacting with a Vault server.
 
 For examples of how to use this module, see the [vault-examples](https://github.com/hashicorp/vault-examples) repo.
+For a step-by-step walkthrough on using these client libraries, see the [developer quickstart](https://www.vaultproject.io/docs/get-started/developer-qs).
 
 [![GoDoc](https://godoc.org/github.com/hashicorp/vault/api?status.png)](https://godoc.org/github.com/hashicorp/vault/api)

--- a/website/content/api-docs/libraries.mdx
+++ b/website/content/api-docs/libraries.mdx
@@ -11,7 +11,8 @@ description: >-
 The programming libraries listed on this page can be used to consume the API more conveniently.
 Some are officially maintained while others are provided by the community.
 
-For copy-pastable examples of how to use these libraries, see the [vault-examples](https://github.com/hashicorp/vault-examples) repo.
+For a step-by-step walkthrough on using these client libraries, see the [developer quickstart](https://www.vaultproject.io/docs/get-started/developer-qs).
+For copy-pastable code examples, see the [vault-examples](https://github.com/hashicorp/vault-examples) repo.
 
 ## Official
 

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -8,6 +8,14 @@ description: Learn how to store and retrieve your first secret.
 
 This quick start will explore how to use Vault client libraries inside your application code to store and retrieve your first secret value. Vault takes the security burden away from developers by providing a secure, centralized secret store for an application’s sensitive data: credentials, certificates, encryption keys, and more.
 
+The complete code samples for the steps below are available here:
+
+- [Go](https://github.com/hashicorp/vault-examples/blob/main/examples/_quick-start/go/example.go)
+- [Ruby](https://github.com/hashicorp/vault-examples/blob/main/examples/_quick-start/ruby/example.rb)
+- [C#](https://github.com/hashicorp/vault-examples/blob/main/examples/_quick-start/dotnet/Example.cs)
+- [Python](https://github.com/hashicorp/vault-examples/blob/main/examples/_quick-start/python/example.py)
+- [Java (Spring)](https://github.com/hashicorp/vault-examples/blob/main/examples/_quick-start/java/Example.java)
+
 For an out-of-the-box runnable demo application showcasing these concepts and more, see the hello-vault repositories ([Go](https://github.com/hashicorp/hello-vault-go), [C#](https://github.com/hashicorp/hello-vault-dotnet) and [Java/Spring Boot](https://github.com/hashicorp/hello-vault-spring)).
 
 ## Prerequisites
@@ -469,14 +477,6 @@ System.out.println("Access granted!");
 If the secret was fetched successfully, you should see the `Access granted!` message after you run the code. If not, check to see if you provided the correct path to your secret.
 
 **That's it! You've just written and retrieved your first Vault secret!**
-
-The complete code samples for the steps you've just performed in this quick start are available here:
-
-- [Go](https://github.com/hashicorp/vault-examples/blob/main/examples/_quick-start/go/example.go)
-- [Ruby](https://github.com/hashicorp/vault-examples/blob/main/examples/_quick-start/ruby/example.rb)
-- [C#](https://github.com/hashicorp/vault-examples/blob/main/examples/_quick-start/dotnet/Example.cs)
-- [Python](https://github.com/hashicorp/vault-examples/blob/main/examples/_quick-start/python/example.py)
-- [Java (Spring)](https://github.com/hashicorp/vault-examples/blob/main/examples/_quick-start/java/Example.java)
 
 # Additional examples
 


### PR DESCRIPTION
- Make the dev quick start link readily available on the client library documentation page
- Move the full code samples to the top of the dev quickstart page so that they're easily accessible.
- Update the api/readme to have a link to the dev quickstart