### PR TITLE
Document PKI root rotation, replacement paths

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1307,6 +1307,7 @@ use the values set via `config/urls`.
 | :----- | :--------------------------------- |
 | `POST` | `/pki/root/generate/:type`         |
 | `POST` | `/pki/issuers/generate/root/:type` |
+| `POST` | `/pki/root/rotate/:type`           |
 
 #### Parameters
 
@@ -1320,7 +1321,8 @@ use the values set via `config/urls`.
 
 - `issuer_name` `(string: "")` - Provides a name to the specified issuer. The
   name must be unique across all issuers and not be the reserved value
-  `default`.
+  `default`. When no value is supplied and the path is `/pki/root/rotate/:type`,
+  the default value of `"next"` will be used.
 
 - `key_name` `(string: "")` - When a new key is created with this request,
   optionally specifies the name for this. The global ref `default` may not
@@ -2629,11 +2631,13 @@ This endpoint allows setting the value of the default issuer.
 | Method | Path                  |
 | :----- | :-------------------- |
 | `POST` | `/pki/config/issuers` |
+| `POST` | `/pki/root/replace`   |
 
 #### Parameters
 
 - `default` `(string: "")` - Specifies the default issuer (by reference;
-  either a name or an ID).
+  either a name or an ID). When no value is specified and the path is
+  `/pki/root/replace`, the default value of `"next"` will be used.
 
 #### Sample Payload
 


### PR DESCRIPTION
See also: https://discuss.hashicorp.com/t/missing-pki-secret-engine-api-documentation-for-root-rotate-and-root-replace-endpoints/41215

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`