### PR TITLE
Document additional FIPS restrictions

### DIFF
--- a/website/content/docs/enterprise/fips/fips1402.mdx
+++ b/website/content/docs/enterprise/fips/fips1402.mdx
@@ -70,6 +70,8 @@ from the following sources:
 
 ### Usage Restrictions
 
+#### Migration Restrictions
+
 Hashicorp **does not** support in-place migrations from non-FIPS Inside
 versions of Vault to FIPS Inside versions of Vault, regardless of version.
 A fresh cluster installation is required to receive support. We generally
@@ -89,10 +91,33 @@ reasons:
 Combined, we suggest leaving the existing cluster in place, and carefully
 consider migration of specific workloads to the FIPS-backed cluster.
 
+#### Entropy Augmentation Restrictions
+
 Entropy Augmentation **does not** work with FIPS 140-2 Inside. The internal
 BoringCrypto RNG is FIPS 140-2 certified and does not accept entropy from
 other sources. Attempting to use Entropy Augmentation will result in failures
 at runtime such as `panic: boringcrypto: invalid code execution`.
+
+#### TLS Restrictions
+
+Vault Enterprise's FIPS modifications include restrictions to supported TLS
+cipher suites and key information. Only the following cipher suites are
+allowed:
+
+ - `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`,
+ - `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`,
+ - `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`,
+ - `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`,
+ - `TLS_RSA_WITH_AES_128_GCM_SHA256`, and
+ - `TLS_RSA_WITH_AES_256_GCM_SHA384`.
+
+Additionally, only the following key types are allowed in TLS chains of trust:
+
+ - RSA 2048, 3072, 4096, 7680, and 8192-bit;
+ - ECDSA P-256, P-384, and P-521.
+
+Finally, only TLSv1.2 or higher is supported in FIPS mode. These are in line
+with recent NIST guidance and recommendations.
 
 ## Technical Details
 


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`


This documents some additional restrictions around TLS cipher suites from Go's restriction sets (plus our more permissive P521/RSA support).