### PR TITLE
Docs: API generate-recovery-token unhidden.

### DIFF
--- a/website/data/api-docs-nav-data.json
+++ b/website/data/api-docs-nav-data.json
@@ -415,8 +415,7 @@
       },
       {
         "title": "<code>/sys/generate-recovery-token</code>",
-        "path": "system/generate-recovery-token",
-        "hidden": true
+        "path": "system/generate-recovery-token"
       },
       {
         "title": "<code>/sys/generate-root</code>",


### PR DESCRIPTION
Re-done former conflicting:  [Docs: API generate-recovery-token - unhide #12264](https://github.com/hashicorp/vault/pull/12264)

<img width="1504" alt="api_generate-recovery-token" src="https://user-images.githubusercontent.com/974854/128245145-b490d64c-62e7-49e7-893f-93c98aad9e4b.png">