### PR TITLE
Clarification for local mounts in the context of DR

### DIFF
--- a/changelog/16218.txt
+++ b/changelog/16218.txt
@@ -1,0 +1,1 @@
+docs: Clarify the behaviour of local mounts in the context of DR replication

--- a/changelog/16218.txt
+++ b/changelog/16218.txt
@@ -1,1 +1,3 @@
+```release-note:improvement
 docs: Clarify the behaviour of local mounts in the context of DR replication
+```

--- a/website/content/docs/enterprise/replication.mdx
+++ b/website/content/docs/enterprise/replication.mdx
@@ -122,6 +122,8 @@ original primary on the election of the DR secondary.
 DR is designed to be a mechanism to protect against catastrophic failure of entire clusters.
 They do not forward service read or write requests until they are elected and become a new primary.
 
+-> **Note**: Unlike with Performance Replication, local secret engines, auth methods and audit devices are replicated to a DR secondary.
+
 
 For more information on the capabilities of performance and disaster recovery replication, see the Vault Replication [API Documentation](/api-docs/system/replication).
 


### PR DESCRIPTION
The docs were unclear on this point, so @russparsloe and I looked into it.

Local mounts are indeed replicated to DR secondaries.

This is the opposite of what it says on https://developer.hashicorp.com/vault/tutorials/enterprise/performance-replication#disaster-recovery 
> Local backend mounts are not replicated and their use will require existing DR mechanisms if DR is necessary in your implementation.
So that page will also need updating


The following were all configured on a DR primary, then replicated over to a DR secondary. That DR secondary was then promoted to a primary.

```
$ vault audit list -detailed
Path     Type    Description    Replication    Options
----     ----    -----------    -----------    -------
file/    file    n/a            local          file_path=stdout

$ vault secrets list -detailed
Path                  Plugin       Accessor              Default TTL    Max TTL    Force No Cache    Replication    Seal Wrap    External Entropy Access    Options           Description                                                UUID
----                  ------       --------              -----------    -------    --------------    -----------    ---------    -----------------------    -------           -----------                                                ----
kv2_on_dr_primary/    kv           kv_9847c57c           system         system     false             local          false        false                      map[version:2]    n/a                                                        732afa5e-993a-4e38-aac1-91e37bd59489

$ vault auth list -detailed
Path                       Plugin      Accessor                  Default TTL    Max TTL    Token Type         Replication    Seal Wrap    External Entropy Access    Options    Description                UUID
----                       ------      --------                  -----------    -------    ----------         -----------    ---------    -----------------------    -------    -----------                ----
userpass_on_dr_primary/    userpass    auth_userpass_3a9fe18b    system         system     default-service    local          false        false                      map[]      n/a                        dd328f8f-0b87-c730-d45d-193614835acb
```