### PR TITLE
builtin/transit add pss_salt_length parameter

### DIFF
--- a/builtin/logical/transit/path_sign_verify.go
+++ b/builtin/logical/transit/path_sign_verify.go
@@ -131,6 +131,11 @@ Options are 'pss' or 'pkcs1v15'. Defaults to 'pss'`,
 				Default:     "asn1",
 				Description: `The method by which to marshal the signature. The default is 'asn1' which is used by openssl and X.509. It can also be set to 'jws' which is used for JWT signatures; setting it to this will also cause the encoding of the signature to be url-safe base64 instead of using standard base64 encoding. Currently only valid for ECDSA P-256 key types".`,
 			},
+			"pss_salt_length": {
+				Type:        framework.TypeInt,
+				Default:     0,
+				Description: `The Salt Length used for RSA-PSS-Signatures. Applies only to RSA key types. The default is 0 which delegates salt length choice to the underlying cryptographic library.`,
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -217,6 +222,11 @@ Options are 'pss' or 'pkcs1v15'. Defaults to 'pss'`,
 				Default:     "asn1",
 				Description: `The method by which to unmarshal the signature when verifying. The default is 'asn1' which is used by openssl and X.509; can also be set to 'jws' which is used for JWT signatures in which case the signature is also expected to be url-safe base64 encoding instead of standard base64 encoding. Currently only valid for ECDSA P-256 key types".`,
 			},
+			"pss_salt_length": {
+				Type:        framework.TypeInt,
+				Default:     0,
+				Description: `The Salt Length used for RSA-PSS-Signatures. Applies only to RSA key types. The default is 0 which delegates salt length choice to the underlying cryptographic library.`,
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -238,6 +248,7 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 			hashAlgorithmStr = d.Get("algorithm").(string)
 		}
 	}
+	pssSaltLength := d.Get("pss_salt_length").(int)
 
 	hashAlgorithm, ok := keysutil.HashTypeMap[hashAlgorithmStr]
 	if !ok {
@@ -330,7 +341,7 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 			}
 		}
 
-		sig, err := p.Sign(ver, context, input, hashAlgorithm, sigAlgorithm, marshaling)
+		sig, err := p.Sign(ver, context, input, hashAlgorithm, sigAlgorithm, marshaling, pssSaltLength)
 		if err != nil {
 			if batchInputRaw != nil {
 				response[i].Error = err.Error()

--- a/builtin/logical/transit/path_sign_verify_test.go
+++ b/builtin/logical/transit/path_sign_verify_test.go
@@ -2,8 +2,12 @@ package transit
 
 import (
 	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"math/big"
 	"strconv"
 	"strings"
 	"testing"
@@ -699,4 +703,238 @@ func TestTransit_SignVerify_ED25519(t *testing.T) {
 	outcome[1].requestOk = true
 	outcome[1].valid = false
 	verifyRequest(req, false, outcome, "bar", goodsig, true)
+}
+
+func TestTransit_SignVerify_RSAPSS(t *testing.T) {
+	b, storage := createBackendWithSysView(t)
+
+	//create RSA Key
+	req := &logical.Request{
+		Storage:   storage,
+		Operation: logical.UpdateOperation,
+		Path:      "keys/foo",
+		Data: map[string]interface{}{
+			"type": "rsa-3072",
+		},
+	}
+	_, err := b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _, err := b.GetPolicy(context.Background(), keysutil.PolicyRequest{
+		Storage: storage,
+		Name:    "foo",
+	}, b.GetRandomReader())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the RSA key to a known value
+	keyEntry := p.Keys[strconv.Itoa(p.LatestVersion)]
+	d := &big.Int{}
+	d.UnmarshalText([]byte("1202968648230909168045620068417760275295456979639745012353765236549290010690691905232434050345715329321148006148161911242113887010813816466646948037232556705436709826907988822128130749416941720054147815158540411664237526359829784722708437312431113835967495963181332704211806465233209363666530087956398936068027950806184656645868580282142708603503463009125869540065719450773247999180553084327731820344258433172141828990096131150165738737489869763947541855698613277701043218701250253493792267496965291335622150101989283719195285427737832201644492380250469887304294943179455031543357697328739719758686609441455951441833631993398836568668540418920917619195944820633703763280429714796664544305449572971742629712279365509653320628674969017623395860862203981513701363328423779752796189206869111835384413950280733911285492340511256734352674630934319556427684747862695675766069427830877256824237554222845196827379299919432194942144473"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prime1 := &big.Int{}
+	err = prime1.UnmarshalText([]byte("2055662681415640757527037964786977991821510354423402187146841519469586519238092913775083064402486556051237843029367172508018550980898416475664728551997413582059604037474338986870339870718709679882961395993989214128499165904389954550732462092150776361615542970227027371350074370268495466991086366718529590405085824584855391251864782854458716354893872754315376044606226143266734976714763503600335290996275953717131880996301086793047310442708072514030450850488551751"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prime2 := &big.Int{}
+	err = prime2.UnmarshalText([]byte("2155338210536045375345461329945095769089640047457940302875938444864355576790859924695523433820262936343393526707386360465750814035695569282097499936405507048127441171817791800992189812299302833657366046017230614262203396538000510758997141512210577333647931181430496330608397833397098973276033750722515264792258002587897982676420464615298870584510171052786328379200394276816247444638334698383524148609230657368382216986985533157927862442013874101932275115356587027"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	N := &big.Int{}
+	err = N.UnmarshalText([]byte("4430648325228115889974474678200222275038685178973247660707469501389840363641445172148928310526421576807917100086101336241115983647729857804576881730701925862886683821853931855446291161320563645452887791505297457527207753458703192164333081721074401903327064344105597473076832657749176242925333391839862710637875003483473296762970054285196509708205375701308424864970611197332041931117000533190207952675152575857179894713045416836484883648357513471947288445370350593212533398640673311877931678397838305041906210088270200886267736677296839706550629699361980127001576113365321878051556656462048787180983865155995976862145691440916151868326704094676484075067961203015485370448193132673395545691929211260967925112935845280679371059652028613973186835951092078768057547173601361986909326965500543006815882540522111841040396486895287727002078916720900659021612983110731417503963681431384865409248735458853095156697497092310531424734277"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rsaKeyEntry := rsa.PrivateKey{
+		PublicKey: rsa.PublicKey{
+			N: N,
+			E: 65537,
+		},
+		Primes:      []*big.Int{prime1, prime2},
+		D:           d,
+		Precomputed: rsa.PrecomputedValues{},
+	}
+	rsaKeyEntry.Precompute()
+	keyEntry.RSAKey = &rsaKeyEntry
+	keyEntry.RSAKey.Precompute()
+	p.Keys[strconv.Itoa(p.LatestVersion)] = keyEntry
+
+	if err = p.Persist(context.Background(), storage); err != nil {
+		t.Fatal(err)
+	}
+
+	//"the quick brown fox"
+	inputDataB64 := "dGhlIHF1aWNrIGJyb3duIGZveA=="
+
+	req.Data = map[string]interface{}{
+		"input": inputDataB64,
+	}
+	signRequest := func(req *logical.Request, errExpected bool, postpath string) string {
+		t.Helper()
+		req.Path = "sign/foo" + postpath
+		resp, err := b.HandleRequest(context.Background(), req)
+		if err != nil && !errExpected {
+			t.Fatal(err)
+		}
+		if resp == nil {
+			t.Fatal("expected non-nil response")
+		}
+		if errExpected {
+			if !resp.IsError() {
+				t.Fatalf("bad: should have gotten error response: %#v", *resp)
+			}
+			return ""
+		}
+		if resp.IsError() {
+			t.Fatalf("bad: got error response: %#v", *resp)
+		}
+		value, ok := resp.Data["signature"]
+		if !ok {
+			t.Fatalf("no signature key found in returned data, got resp data %#v", resp.Data)
+		}
+		return value.(string)
+	}
+	verifyRequest := func(req *logical.Request, errExpected bool, postpath, sig string) {
+		t.Helper()
+		req.Path = "verify/foo" + postpath
+		req.Data["signature"] = sig
+		resp, err := b.HandleRequest(context.Background(), req)
+		if err != nil {
+			if errExpected {
+				return
+			}
+			t.Fatalf("got error: %v, sig was %v", err, sig)
+		}
+		if resp == nil {
+			t.Fatal("expected non-nil response")
+		}
+		if resp.IsError() {
+			if errExpected {
+				return
+			}
+			t.Fatalf("bad: got error response: %#v", *resp)
+		}
+		value, ok := resp.Data["valid"]
+		if !ok {
+			t.Fatalf("no valid key found in returned data, got resp data %#v", resp.Data)
+		}
+		if !value.(bool) && !errExpected {
+			t.Fatalf("verification failed; req was %#v, resp is %#v", *req, *resp)
+		} else if value.(bool) && errExpected {
+			t.Fatalf("expected error and didn't get one; req was %#v, resp is %#v", *req, *resp)
+		}
+	}
+	//get a signature with default settings
+	sig := signRequest(req, false, "/sha2-256")
+	verifyRequest(req, false, "", sig)
+
+	// Test a bad signature
+	verifyRequest(req, true, "/sha2-256", sig[0:len(sig)-2])
+
+	//check if a new signature is different (because of the salt)
+	oldSig := sig
+	sig = signRequest(req, false, "/sha2-256")
+
+	if oldSig == sig {
+		t.Errorf("Two PSS signatures should be different\n")
+	}
+
+	//now do some pkcs1v15 signatures
+	req.Data["signature_algorithm"] = "pkcs1v15"
+
+	sig = signRequest(req, false, "/sha2-256")
+	verifyRequest(req, false, "", sig)
+	oldSig = sig
+	if oldSig != sig {
+		t.Errorf("Two RSA PKCS1#1.5 signatures should be equal\n")
+	}
+	//verify PSS locally - focus on salt length
+	req.Data["signature_algorithm"] = "pss"
+	req.Data["pss_salt_length"] = "0" //default but explicitly set here
+
+	sig = signRequest(req, false, "/sha2-256")
+
+	inputRaw, err := base64.StdEncoding.DecodeString(inputDataB64)
+	if err != nil {
+		t.Error(err)
+	}
+	inputHash := sha256.Sum256(inputRaw)
+
+	rawSig := getRawSig(sig)
+
+	//verify with PSSOptions == nil
+	err = rsa.VerifyPSS(&rsaKeyEntry.PublicKey, crypto.SHA256, inputHash[:], rawSig, nil)
+	if err != nil {
+		t.Errorf("PSS verification should succeed but error %v\n", err)
+	}
+
+	//verify with a salt length of "0"
+	err = rsa.VerifyPSS(&rsaKeyEntry.PublicKey, crypto.SHA256, inputHash[:], rawSig, &rsa.PSSOptions{SaltLength: 0})
+	if err != nil {
+		t.Errorf("PSS verification should succeed but error %v\n", err)
+	}
+	//verify with a salt length of "350" which should be calculated by go stdlib
+	err = rsa.VerifyPSS(&rsaKeyEntry.PublicKey, crypto.SHA256, inputHash[:], rawSig, &rsa.PSSOptions{SaltLength: 350})
+	if err != nil {
+		t.Errorf("PSS verification should succeed but error %v\n", err)
+	}
+	//verify with a salt length of "200" which should be wrong and error
+	err = rsa.VerifyPSS(&rsaKeyEntry.PublicKey, crypto.SHA256, inputHash[:], rawSig, &rsa.PSSOptions{SaltLength: 200})
+	if err == nil {
+		t.Errorf("PSS verification should not succeed, but did\n")
+	}
+
+	// This does not work because it returns a "nil" response with an error attached
+	// The underlying cause is that the crypto/rsa Package just returns a
+	// errors.New("crypto/rsa: key size too small for PSS signature")
+	// for a salt that's to big. That is not really a "testable" error
+	// Alternatives: Salt Size Check in helpers/keysutil/policy.go
+	// Direct check for the erorr string "crypto/rsa: key size too small for PSS signature"
+	// in builtin/logical/transit/path_sign_verify.go
+
+	//sign with an explicit salt length of 1000 which should not work (Salt is too large)
+	//req.Data["pss_salt_length"] = "1000"
+	//_ = signRequest(req, true, "/sha2-256")
+
+	// common value used, Salt Length == Hash Length, see
+	// i.e. TLS 1.3 specification
+	// https://datatracker.ietf.org/doc/html/rfc8446 page 43
+	req.Data["pss_salt_length"] = "32"
+
+	sig = signRequest(req, false, "/sha2-256")
+	verifyRequest(req, false, "/sha2-256", sig)
+
+	//let crypto/rsa verify
+	rawSig = getRawSig(sig)
+	//verify with PSSOptions == nil - should error
+	err = rsa.VerifyPSS(&rsaKeyEntry.PublicKey, crypto.SHA256, inputHash[:], rawSig, &rsa.PSSOptions{SaltLength: 34})
+	if err == nil {
+		t.Errorf("PSS verification should error beause of salt length mismatch\n")
+	}
+	//verify with saltLength = 32
+	err = rsa.VerifyPSS(&rsaKeyEntry.PublicKey, crypto.SHA256, inputHash[:], rawSig, &rsa.PSSOptions{SaltLength: 32})
+	if err != nil {
+		t.Errorf("PSS verification should succeed but error %v\n", err)
+	}
+
+	//let vault verify
+	verifyRequest(req, false, "/sha2-256", sig)
+	delete(req.Data, "pss_salt_length")
+	verifyRequest(req, false, "/sha2-256", sig)
+
+}
+
+func getRawSig(vaultSig string) []byte {
+	raw, err := base64.StdEncoding.DecodeString(strings.Split(vaultSig, ":")[2])
+	if err != nil {
+		panic(err)
+	}
+	return raw
 }

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -1025,7 +1025,7 @@ func (p *Policy) HMACKey(version int) ([]byte, error) {
 	return keyEntry.HMACKey, nil
 }
 
-func (p *Policy) Sign(ver int, context, input []byte, hashAlgorithm HashType, sigAlgorithm string, marshaling MarshalingType) (*SigningResult, error) {
+func (p *Policy) Sign(ver int, context, input []byte, hashAlgorithm HashType, sigAlgorithm string, marshaling MarshalingType, pssSaltLength int) (*SigningResult, error) {
 	if !p.Type.SigningSupported() {
 		return nil, fmt.Errorf("message signing not supported for key type %v", p.Type)
 	}
@@ -1169,7 +1169,13 @@ func (p *Policy) Sign(ver int, context, input []byte, hashAlgorithm HashType, si
 
 		switch sigAlgorithm {
 		case "pss":
-			sig, err = rsa.SignPSS(rand.Reader, key, algo, input, nil)
+			var pssOpts *rsa.PSSOptions = nil
+			if pssSaltLength != 0 {
+				pssOpts = &rsa.PSSOptions{
+					SaltLength: pssSaltLength,
+				}
+			}
+			sig, err = rsa.SignPSS(rand.Reader, key, algo, input, pssOpts)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This change adds the ability to pass a Paramter of type integer called
`pss_salt_length` which defaults to 0. This parameter gets passed
to golangs crypto/rsa SignPSS(.., *rsa.PSSOptions). The value 0 is also
the "special" value PSSSaltLengthAuto, equivalent to current vault
default.

I have not run Integration tests as I was very scared of "incurring real costs" :).

Also, running all unit tests has been difficult as I do not have access to Docker on my Development Machine. I have however run all the builtin/transit unittests including my newly written RSA test)

We are currently very close to getting internal processes ready to sign a CLA. (Organization being https://github.com/datev)

https://support.hashicorp.com Ticket number: 77957