### PR TITLE
Backport agent/template: fix exec parsing error for templates (#16231)

### DIFF
--- a/changelog/16231.txt
+++ b/changelog/16231.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent/template: Fix parsing error for the exec stanza
+```

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -640,17 +640,22 @@ func parseTemplates(result *Config, list *ast.ObjectList) error {
 			return errors.New("error converting config")
 		}
 
-		// flatten the wait field. The initial "wait" value, if given, is a
+		// flatten the wait or exec fields. The initial "wait" or "exec" value, if given, is a
 		// []map[string]interface{}, but we need it to be map[string]interface{}.
 		// Consul Template has a method flattenKeys that walks all of parsed and
 		// flattens every key. For Vault Agent, we only care about the wait input.
-		// Only one wait stanza is supported, however Consul Template does not error
+		// Only one wait/exec stanza is supported, however Consul Template does not error
 		// with multiple instead it flattens them down, with last value winning.
-		// Here we take the last element of the parsed["wait"] slice to keep
+		// Here we take the last element of the parsed["wait"] or parsed["exec"] slice to keep
 		// consistency with Consul Template behavior.
 		wait, ok := parsed["wait"].([]map[string]interface{})
 		if ok {
 			parsed["wait"] = wait[len(wait)-1]
+		}
+
+		exec, ok := parsed["exec"].([]map[string]interface{})
+		if ok {
+			parsed["exec"] = exec[len(exec)-1]
 		}
 
 		var tc ctconfig.TemplateConfig

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -685,6 +685,10 @@ func TestLoadConfigFile_Template(t *testing.T) {
 					Perms:          pointerutil.FileModePtr(0o655),
 					RightDelim:     pointerutil.StringPtr(">>"),
 					SandboxPath:    pointerutil.StringPtr("/path/on/disk/where"),
+					Exec: &ctconfig.ExecConfig{
+						Command: []string{"foo"},
+						Timeout: pointerutil.TimeDurationPtr("10s"),
+					},
 
 					Wait: &ctconfig.WaitConfig{
 						Min: pointerutil.TimeDurationPtr("10s"),

--- a/command/agent/config/test-fixtures/config-template-full.hcl
+++ b/command/agent/config/test-fixtures/config-template-full.hcl
@@ -46,4 +46,9 @@ template {
     min = "10s"
     max = "40s"
   }
+
+  exec {
+    command = ["foo"]
+    timeout = "10s"
+  }
 }


### PR DESCRIPTION
* agent/template: fix exec parsing error for templates

* changelog