### PR TITLE
Vault documentation: added content for network guidance for KMIP

### DIFF
--- a/website/content/docs/secrets/kmip.mdx
+++ b/website/content/docs/secrets/kmip.mdx
@@ -18,6 +18,8 @@ services and applications to perform cryptographic operations without having to
 manage cryptographic material, otherwise known as managed objects, by delegating
 its storage and lifecycle to a key management server.
 
+Vault's KMIP secrets engine listens on a separate port from the standard Vault listener. Each Vault server in a Vault cluster configured with a KMIP secrets engine uses the same listener configuration. The KMIP listener defaults to port 5696 and is configurable to alternative ports, for example, if there are multiple KMIP secrets engine mounts configured.  KMIP clients connect and authenticate to this KMIP secrets engine listener port using generated TLS certificates. KMIP clients may connect directly to any of the Vault servers on the configured KMIP port. A layer 4 tcp load balancer may be used in front of the Vault server's KMIP ports. The load balancer should support long-lived connections and it may use a round robin routing algorithm as Vault servers will forward to the primary Vault server, if necessary.
+
 ## KMIP Conformance
 
 Vault implements version 1.4 of the following Key Management Interoperability Protocol Profiles:


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/563192436488770/1202431086811911/f), a concepts paragraph was added to provide network guidance for KMIP.

:mag: [Deploy Preview](https://vault-git-docs-kmip-doc-update-hashicorp.vercel.app/docs/secrets/kmip)