### PR TITLE
Vault documentation: added code sample to kv1 and kv2 docs for stored certificates

### DIFF
--- a/website/content/docs/secrets/kv/kv-v1.mdx
+++ b/website/content/docs/secrets/kv/kv-v1.mdx
@@ -98,6 +98,30 @@ my-value            s3cr3t
 ttl                 30m
 ```
 
+## Certificates
+
+If you wish to store, distribute, and update certificate values using the KV secrets engine, the example below demonstrates setting up a KV secret field to the public key from a configured KV secrets engine.
+
+```
+$ vault kv put kv/mypubkey public_key="$(vault read -format=json kv/keys/test | jq -r '.data.keys."1".public_key' | base64)"
+Success! Data written to: kv/mypubkey
+$ vault kv get -format=json kv/mypubkey | jq -r .data.public_key | base64 -d
+-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAzSTv7BXYQUD1Gekpp+lu
+rOVY3Z2LGaXUJTeLQbqVbINVanGiZQsa9IRXL1rKtvSQhlpYhAy47AvGwSj8wITD
+7XhGn4iFiH7+bTTRQPqgEeF8xUKNFqw8zRp0cAl0I/UfLqCjI9+kWAb1Pnw5JHnm
+mNXkTcnmKYupYT9pSZoo/ymnIWmzHiMxmsEjNOHdLyeEycSTCSd/mEG2y7bTlaMx
+LN8e2Z1sKo4lT5SX/9Fiax1AQw8rAJ436iCg4Yd/UPx3T2o6rNvg+C6uY6YwXneB
+KRbZlK7UmJVmi0UXfHW6NV+4g3CIC8FIM1bMfF+JojUG9av9PHJta0YoRJOZ7kNW
+Nx88nzORspMwznjuGqmhuw1UaN5GTl57wWFmRxeBF30Mo8MV+/uRtRkwa/9MEEyo
+Zru8jo01WmZuJe1tTGAuzaopogC5BcuQdogKaPKoaIWgU/TBq3DQhZBaVWUk6Tle
+YF8h52v2LofRMxe2Zad8DmyLZ61xpuCTk54wBBD5o8qCa7BBUN5khUliGitITfH4
+5qQA4oIB1RBjM748FKu4veZb1EDJVl6JXwioMsl7fue8UNv5DzdxD2d2Rk5JxNj6
+9sGK95Y7hh01QX2irF/DyufaNwKu35ZUs1EmRf6SnjEkTM329ZrdHAH6hw3SNgTs
+7ma6Kv4ETs238EkvRicXH3cCAwEAAQ==
+-----END PUBLIC KEY-----
+```
+
 ## Tutorial
 
 Refer to the [Static Secrets: Key/Value Secrets

--- a/website/content/docs/secrets/kv/kv-v2.mdx
+++ b/website/content/docs/secrets/kv/kv-v2.mdx
@@ -207,11 +207,11 @@ real path).
 
 1. Write another version, the previous version will still be accessible. The
    `-cas` flag can optionally be passed to perform a check-and-set operation. If
-   not set the write will be allowed. In order for a write to be successful, `cas` must be set to 
-  the current version of the secret. If set to 0 a write will only be allowed if 
-  the key doesn’t exist as unset keys do not have any version information. Also 
+   not set the write will be allowed. In order for a write to be successful, `cas` must be set to
+  the current version of the secret. If set to 0 a write will only be allowed if
+  the key doesn’t exist as unset keys do not have any version information. Also
   remember that soft deletes do not remove any underlying version data from storage.
-  In order to write to a soft deleted key, the cas parameter must match the key's 
+  In order to write to a soft deleted key, the cas parameter must match the key's
   current version.
 
    ```shell-session
@@ -541,6 +541,30 @@ See the commands below for more information:
    $ vault kv metadata delete -mount=secret my-secret
    Success! Data deleted (if it existed) at: secret/metadata/my-secret
    ```
+
+## Certificates
+
+If you wish to store, distribute, and update certificate values using the KV secrets engine, the example below demonstrates setting up a KV secret field to the public key from a configured KV secrets engine.
+
+```
+$ vault kv put kv/mypubkey public_key="$(vault read -format=json kv/keys/test | jq -r '.data.keys."1".public_key' | base64)"
+Success! Data written to: kv/mypubkey
+$ vault kv get -format=json kv/mypubkey | jq -r .data.public_key | base64 -d
+-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAzSTv7BXYQUD1Gekpp+lu
+rOVY3Z2LGaXUJTeLQbqVbINVanGiZQsa9IRXL1rKtvSQhlpYhAy47AvGwSj8wITD
+7XhGn4iFiH7+bTTRQPqgEeF8xUKNFqw8zRp0cAl0I/UfLqCjI9+kWAb1Pnw5JHnm
+mNXkTcnmKYupYT9pSZoo/ymnIWmzHiMxmsEjNOHdLyeEycSTCSd/mEG2y7bTlaMx
+LN8e2Z1sKo4lT5SX/9Fiax1AQw8rAJ436iCg4Yd/UPx3T2o6rNvg+C6uY6YwXneB
+KRbZlK7UmJVmi0UXfHW6NV+4g3CIC8FIM1bMfF+JojUG9av9PHJta0YoRJOZ7kNW
+Nx88nzORspMwznjuGqmhuw1UaN5GTl57wWFmRxeBF30Mo8MV+/uRtRkwa/9MEEyo
+Zru8jo01WmZuJe1tTGAuzaopogC5BcuQdogKaPKoaIWgU/TBq3DQhZBaVWUk6Tle
+YF8h52v2LofRMxe2Zad8DmyLZ61xpuCTk54wBBD5o8qCa7BBUN5khUliGitITfH4
+5qQA4oIB1RBjM748FKu4veZb1EDJVl6JXwioMsl7fue8UNv5DzdxD2d2Rk5JxNj6
+9sGK95Y7hh01QX2irF/DyufaNwKu35ZUs1EmRf6SnjEkTM329ZrdHAH6hw3SNgTs
+7ma6Kv4ETs238EkvRicXH3cCAwEAAQ==
+-----END PUBLIC KEY-----
+```
 
 ## Tutorial
 


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/563192436488770/1202431378969795/f), a new code sample was added to both the kv1 and kv2 docs to demonstrate how to store, distribute, and update certificates using the kv secrets engine.

- KV Secrets Engine - Version 1 :mag: [Deploy Preview](https://vault-git-docs-update-kv-docs-hashicorp.vercel.app/docs/secrets/kv/kv-v1#certificates)
- KV Secrets Engine - Version 2 :mag: [Deploy Preview](https://vault-git-docs-update-kv-docs-hashicorp.vercel.app/docs/secrets/kv/kv-v2#certificates)