### PR TITLE
secrets/k8s: updates API docs for kubernetes_host env var

### DIFF
--- a/website/content/api-docs/secret/kubernetes.mdx
+++ b/website/content/api-docs/secret/kubernetes.mdx
@@ -27,9 +27,9 @@ Kubernetes API and authenticate with it.
 
 ### Parameters
 
-- `kubernetes_host` `(string: "https://$KUBERNETES_SERVICE_HOST:KUBERNETES_SERVICE_PORT")` -
+- `kubernetes_host` `(string: "https://$KUBERNETES_SERVICE_HOST:KUBERNETES_SERVICE_PORT_HTTPS")` -
   Kubernetes API URL to connect to. Must be specified if the standard pod environment
-  variables `KUBERNETES_SERVICE_HOST` or `KUBERNETES_SERVICE_PORT` are not set.
+  variables `KUBERNETES_SERVICE_HOST` or `KUBERNETES_SERVICE_PORT_HTTPS` are not set.
 - `kubernetes_ca_cert` `(string: "")` - PEM encoded CA certificate to verify the
   Kubernetes API server certificate. Defaults to the local pod's CA certificate
   at `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` if found, or


### PR DESCRIPTION
This PR updates the API docs for the `kubernetes_host` field to reference the env var that's used in the code at [path_config.go#L18](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/blob/main/path_config.go#L18).