### PR TITLE
remove GetCoreConfigInternal from logger API tests

### DIFF
--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -4681,7 +4681,6 @@ func TestSystemBackend_Loggers(t *testing.T) {
 			t.Parallel()
 
 			core, b, _ := testCoreSystemBackend(t)
-			config := core.GetCoreConfigInternal()
 
 			req := &logical.Request{
 				Path:      "loggers",
@@ -4721,7 +4720,7 @@ func TestSystemBackend_Loggers(t *testing.T) {
 			}
 
 			for _, logger := range core.allLoggers {
-				if !validateLevel(config.LogLevel, logger) {
+				if !validateLevel(core.logLevel, logger) {
 					t.Errorf("expected level of logger %q to match original config", logger.Name())
 				}
 			}
@@ -4817,7 +4816,6 @@ func TestSystemBackend_LoggersByName(t *testing.T) {
 			t.Parallel()
 
 			core, b, _ := testCoreSystemBackend(t)
-			config := core.GetCoreConfigInternal()
 
 			req := &logical.Request{
 				Path:      fmt.Sprintf("loggers/%s", tc.logger),
@@ -4841,7 +4839,7 @@ func TestSystemBackend_LoggersByName(t *testing.T) {
 
 			if !tc.expectWriteError {
 				for _, logger := range core.allLoggers {
-					if logger.Name() != tc.logger && !validateLevel(config.LogLevel, logger) {
+					if logger.Name() != tc.logger && !validateLevel(core.logLevel, logger) {
 						t.Errorf("expected level of logger %q to be unchanged", logger.Name())
 					}
 
@@ -4872,7 +4870,7 @@ func TestSystemBackend_LoggersByName(t *testing.T) {
 
 			if !tc.expectDeleteError {
 				for _, logger := range core.allLoggers {
-					if !validateLevel(config.LogLevel, logger) {
+					if !validateLevel(core.logLevel, logger) {
 						t.Errorf("expected level of logger %q to match original config", logger.Name())
 					}
 				}


### PR DESCRIPTION
Use `Core.logLevel` instead of the `LogLevel` from `GetCoreConfigInternal` in logger API tests as it is what is actually configured for the core.