### PR TITLE
Throw SSCT Error In Some Cases

### DIFF
--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -589,8 +589,12 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 				token, err = c.CheckSSCToken(ctx, token.(string), c.isLoginRequest(ctx, req), c.perfStandby)
 
 				// If we receive an error from CheckSSCToken, we can assume the token is bad somehow, and the client
-				// should receive a 403 bad token error like they do for all other invalid tokens.
+				// should receive a 403 bad token error like they do for all other invalid tokens, unless the error
+				// specifies that we should forward the request or retry the request.
 				if err != nil {
+					if strings.Contains(err.Error(), logical.ErrPerfStandbyPleaseForward.Error()) || strings.Contains(err.Error(), logical.ErrMissingRequiredState.Error()) {
+						return nil, err
+					}
 					return logical.ErrorResponse("bad token"), logical.ErrPermissionDenied
 				}
 				req.Data["token"] = token

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -592,7 +592,7 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 				// should receive a 403 bad token error like they do for all other invalid tokens, unless the error
 				// specifies that we should forward the request or retry the request.
 				if err != nil {
-					if strings.Contains(err.Error(), logical.ErrPerfStandbyPleaseForward.Error()) || strings.Contains(err.Error(), logical.ErrMissingRequiredState.Error()) {
+					if errors.Is(err, logical.ErrPerfStandbyPleaseForward) || errors.Is(err, logical.ErrMissingRequiredState) {
 						return nil, err
 					}
 					return logical.ErrorResponse("bad token"), logical.ErrPermissionDenied


### PR DESCRIPTION
Regarding the changes here https://github.com/hashicorp/vault/pull/16112/files, I think we should throw the `RequestForwarding` error as well as the `MissingRequiredState` error, as in these cases we want the server to forward the request and throw a 412 respectively. 