### PR TITLE
auth/oidc: Adds documentation for SecureAuth IdP

### DIFF
--- a/changelog/16274.txt
+++ b/changelog/16274.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+auth/oidc: Adds support for group membership parsing when using SecureAuth as an OIDC provider.
+```

--- a/website/content/api-docs/auth/jwt.mdx
+++ b/website/content/api-docs/auth/jwt.mdx
@@ -43,7 +43,7 @@ set.
 - `bound_issuer` `(string: <optional>)` - The value against which to match the `iss` claim in a JWT.
 - `jwt_supported_algs` `(comma-separated string, or array of strings: <optional>)` - A list of supported signing algorithms. Defaults to [RS256] for OIDC roles. Defaults to all [available algorithms](https://github.com/hashicorp/cap/blob/main/jwt/algs.go) for JWT roles.
 - `default_role` `(string: <optional>)` - The default role to use if none is provided during login.
-- `provider_config` `(map: <optional>)` - Configuration options for provider-specific handling. Providers with specific handling include: Azure, Google. The options are described in each provider's section in [OIDC Provider Setup](/docs/auth/jwt/oidc-providers).
+- `provider_config` `(map: <optional>)` - Configuration options for provider-specific handling. Providers with specific handling include: Azure, Google, SecureAuth. The options are described in each provider's section in [OIDC Provider Setup](/docs/auth/jwt/oidc-providers).
 - `namespace_in_state` `(bool: true)` - Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs.
 
 ### Sample Payload

--- a/website/content/docs/auth/jwt/oidc-providers/index.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/index.mdx
@@ -23,3 +23,4 @@ and additions may be submitted via the [Vault Github repository](https://github.
 - [Keycloak](/docs/auth/jwt/oidc-providers/keycloak)
 - [Kubernetes](/docs/auth/jwt/oidc-providers/kubernetes)
 - [Okta](/docs/auth/jwt/oidc-providers/kubernetes)
+- [SecureAuth](/docs/auth/jwt/oidc-providers/secureauth)

--- a/website/content/docs/auth/jwt/oidc-providers/secureauth.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/secureauth.mdx
@@ -1,0 +1,34 @@
+---
+layout: docs
+page_title: OIDC Provider Setup - Auth Methods - SecureAuth
+description: OIDC provider configuration for SecureAuth
+---
+
+## SecureAuth
+
+The [SecureAuth](https://www.secureauth.com/) identity provider returns group membership
+claims as a comma-separated list of strings (e.g. `groups: "group-1,group-2"`) instead
+of a list of strings.
+
+To properly obtain group membership when using SecureAuth as the identity provider for
+Vault's OIDC Auth Method, the `secureauth` provider must be explicitly configured as
+shown below.
+
+```shell
+vault write auth/oidc/config -<<"EOH"
+{
+   "oidc_client_id": "your_client_id",
+   "oidc_client_secret": "your_client_secret",
+   "default_role": "your_default_role",
+   "oidc_discovery_url": "https://idp.sasp.gosecureauth.com/your_secure_auth",
+   "provider_config": {
+      "provider": "secureauth"
+   }
+}
+EOH
+```
+
+This will instruct the OIDC Auth Method to parse the comma-separated groups claims string
+into individual groups. Note that the role's [`groups_claim`](/api-docs/auth/jwt#groups_claim)
+value must be properly configured to target the groups claim for your SecureAuth identity
+provider.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1262,6 +1262,10 @@
               {
                 "title": "Okta",
                 "path": "auth/jwt/oidc-providers/okta"
+              },
+              {
+                "title": "SecureAuth",
+                "path": "auth/jwt/oidc-providers/secureauth"
               }
             ]
           }


### PR DESCRIPTION
This PR documents the SecureAuth OIDC provider configuration following the recent addition from hashicorp/vault-plugin-auth-jwt#196.