### PR TITLE
[MFA] Remove the callout note about Ent

### DIFF
--- a/website/content/api-docs/system/mfa/index.mdx
+++ b/website/content/api-docs/system/mfa/index.mdx
@@ -8,7 +8,8 @@ description: >-
 
 # `/sys/mfa`
 
-~> **Enterprise Only** – These endpoints require Vault Enterprise.
+The `/sys/mfa` endpoint focuses on managing Multi-factor Authentication (MFA)
+behaviors in Vault Enterprise MFA.
 
 ## Supported MFA types.
 


### PR DESCRIPTION
🔍 [Deploy Preview](https://vault-git-docs-remove-ent-callout-hashicorp.vercel.app/api-docs/system/mfa)
🧵 [Slack thread](https://hashicorp.slack.com/archives/C8DK5PR0B/p1657710439909609)

As of Vault 1.10, the MFA support is available in OSS.  So, this PR removes the callout note about Vault Ent requirement. 

![image](https://user-images.githubusercontent.com/7660718/178775426-44694fd9-90e9-4e06-abeb-f1da68ea8853.png)
