### PR TITLE
Vault documentation: updated sys-mfa api doc

### DIFF
--- a/website/content/api-docs/system/mfa/index.mdx
+++ b/website/content/api-docs/system/mfa/index.mdx
@@ -11,7 +11,7 @@ description: >-
 The `/sys/mfa` endpoint focuses on managing Multi-factor Authentication (MFA)
 behaviors in Vault Enterprise MFA.
 
-## Supported MFA types.
+## Supported MFA types
 
 - [TOTP](/api/system/mfa/totp)
 
@@ -20,3 +20,19 @@ behaviors in Vault Enterprise MFA.
 - [Duo](/api/system/mfa/duo)
 
 - [PingID](/api/system/mfa/pingid)
+
+## Step-up Enterprise MFA
+
+[Vault Enterprise](/docs/enterprise/mfa) allows MFA for login and access to
+sensitive resources in Vault.  The Step-up Enterprise MFA expects the method
+creator to specify a name for the method; Login MFA does not, and instead
+returns an ID when a method is created. Although MFA methods supported with Step-up Enterprise MFA are supported with the Login MFA, they use different API endpoints.
+
+- Step-up Enterprise MFA: `sys/mfa/method/:type/:/name`
+- Login MFA: `identity/mfa/method/:type`
+
+~> **Note:** While the `sys/mfa` endpoint is supported for both OSS and Vault Enterprise, `sys/mfa/method/:type/:/name` is only supported for Vault Enterprise.
+
+Refer to the [Login MFA
+FAQ](/docs/auth/login-mfa/faq#q-are-there-new-mfa-api-endpoints-introduced-as-part-of-the-new-vault-version-1-10-mfa-for-login-functionality) document
+for more details.


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/563192436488770/1202600007772275/f), the sys-mfa API doc now includes a new section called **Step-up Enterprise MFA** and attempts to distinguish the different API endpoints, as well as points out an endpoint that is only supported for Vault Enterprise.

:mag: [Deploy Preview](https://vault-git-docs-update-sys-mfa-hashicorp.vercel.app/api-docs/system/mfa)