### PR TITLE
Enable use of auto_auth_token without auto_auth

### DIFF
--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -229,10 +229,7 @@ func LoadConfig(path string) (*Config, error) {
 		}
 
 		if result.Cache.UseAutoAuthToken {
-			if result.AutoAuth == nil {
-				return nil, fmt.Errorf("cache.use_auto_auth_token is true but auto_auth not configured")
-			}
-			if result.AutoAuth.Method.WrapTTL > 0 {
+			if result.AutoAuth != nil && result.AutoAuth.Method.WrapTTL > 0 {
 				return nil, fmt.Errorf("cache.use_auto_auth_token is true and auto_auth uses wrapping")
 			}
 		}

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -372,9 +372,9 @@ func TestLoadConfigFile_Bad_AgentCache_InconsisentAutoAuth(t *testing.T) {
 }
 
 func TestLoadConfigFile_Bad_AgentCache_ForceAutoAuthNoMethod(t *testing.T) {
-	_, err := LoadConfig("./test-fixtures/bad-config-cache-inconsistent-auto_auth.hcl")
+	_, err := LoadConfig("./test-fixtures/bad-config-cache-force-auto_auth.hcl")
 	if err == nil {
-		t.Fatal("LoadConfig should return an error when use_auto_auth_token=true and no auto_auth section present")
+		t.Fatal("LoadConfig should return an error when use_auto_auth_token=force and no auto_auth section present")
 	}
 }
 

--- a/command/agent/config/test-fixtures/config-cache-auto_auth_token-no-auto_auth.hcl
+++ b/command/agent/config/test-fixtures/config-cache-auto_auth_token-no-auto_auth.hcl
@@ -1,0 +1,12 @@
+pid_file = "./pidfile"
+
+cache {
+  use_auto_auth_token = true
+}
+
+listener "tcp" {
+    address = "127.0.0.1:8300"
+    tls_disable = true
+}
+
+


### PR DESCRIPTION
Update config parsing so that we can use auto_auth tokens without configuring
auto_auth.

This enhancement makes agent configuration easier to use by default by
leveraging the tokens automatically generated by the inmemSink. This
functionality can still be overridden by providing a token to the agent.

Addresses https://github.com/hashicorp/vault/issues/14200.