### PR TITLE
Fix typo in the docs

### DIFF
--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -516,7 +516,7 @@ and consider if they're appropriate for your deployment.
       Default mode of the mounted files.
 
     ```yaml
-    Volumes:
+    extraVolumes:
       - type: 'secret'
         name: 'vault-certs'
         path: '/etc/pki'


### PR DESCRIPTION
It's very confusing, `Volumes` are very similar to `volumes` and can cause confusion 😄