### PR TITLE
Increase the allowed concurrent gRPC streams

### DIFF
--- a/changelog/16327.txt
+++ b/changelog/16327.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Increase the allowed concurrent gRPC streams over the cluster port.
+```

--- a/vault/cluster/cluster.go
+++ b/vault/cluster/cluster.go
@@ -75,15 +75,13 @@ type Listener struct {
 }
 
 func NewListener(networkLayer NetworkLayer, cipherSuites []uint16, logger log.Logger, idleTimeout time.Duration) *Listener {
-	maxStreams := math.MaxUint32
+	var maxStreams uint32 = math.MaxUint32
 	if override := os.Getenv("VAULT_GRPC_MAX_STREAMS"); override != "" {
-		i, err := strconv.Atoi(override)
+		i, err := strconv.ParseUint(override, 10, 32)
 		if err != nil {
-			logger.Warn("vault grpc max streams override must be an integer", "value", override)
-		} else if i < 0 || i > math.MaxUint32 {
-			logger.Warn("vault grpc max streams override out of range", "value", i)
+			logger.Warn("vault grpc max streams override must be an uint32 integer", "value", override)
 		} else {
-			maxStreams = i
+			maxStreams = uint32(i)
 			logger.Info("overriding grpc max streams", "value", i)
 		}
 	}
@@ -99,7 +97,7 @@ func NewListener(networkLayer NetworkLayer, cipherSuites []uint16, logger log.Lo
 
 		// By default this is 250 which can be too small on high traffic
 		// clusters with many forwarded or replication gRPC connections.
-		MaxConcurrentStreams: uint32(maxStreams),
+		MaxConcurrentStreams: maxStreams,
 	}
 
 	return &Listener{

--- a/vault/cluster/cluster.go
+++ b/vault/cluster/cluster.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"net/url"
 	"os"
@@ -81,6 +82,10 @@ func NewListener(networkLayer NetworkLayer, cipherSuites []uint16, logger log.Lo
 		// Our forwarding connections heartbeat regularly so anything else we
 		// want to go away/get cleaned up pretty rapidly
 		IdleTimeout: idleTimeout,
+
+		// By default this is 250 which can be too small on high traffic
+		// clusters with many forwarded or replication gRPC connections.
+		MaxConcurrentStreams: math.MaxUint32,
 	}
 
 	return &Listener{

--- a/vault/cluster/cluster.go
+++ b/vault/cluster/cluster.go
@@ -75,7 +75,6 @@ type Listener struct {
 }
 
 func NewListener(networkLayer NetworkLayer, cipherSuites []uint16, logger log.Logger, idleTimeout time.Duration) *Listener {
-
 	maxStreams := math.MaxUint32
 	if override := os.Getenv("VAULT_GRPC_MAX_STREAMS"); override != "" {
 		i, err := strconv.Atoi(override)


### PR DESCRIPTION
By default `http2.Server` allows for 250 concurrent streams per host. This limit can cause bottlenecks on clusters with many forwarded requests/rpcs. This changes the default to match what the gRPC library uses: `MaxUint32`. 