### PR TITLE
Fix the contribution guide link

### DIFF
--- a/website/content/docs/what-is-vault.mdx
+++ b/website/content/docs/what-is-vault.mdx
@@ -83,5 +83,5 @@ HashiCorp Cloud Platform (HCP) Vault is a hosted version of Vault, which is oper
 We welcome questions, suggestions, and contributions from the community.
 
 * Ask questions in [HashiCorp Discuss](https://discuss.hashicorp.com/c/vault/30).
-* Read our [contributing guide](https://github.com/hashicorp/tutorials/blob/main/CONTRIBUTING.md).
+* Read our [contributing guide](https://github.com/hashicorp/vault/blob/main/CONTRIBUTING.md).
 * [Submit an issue](https://github.com/hashicorp/vault/issues/new/choose) for bugs and feature requests.


### PR DESCRIPTION
The link for **contributing guide** should be pointing to the vault repo. 

🔍 [Deploy preview](https://vault-git-docs-update-community-links-hashicorp.vercel.app/docs/what-is-vault#community)


