### PR TITLE
docs/plugin-portal: adds missing HashiCorp supported plugins

### DIFF
--- a/website/content/docs/plugins/plugin-portal.mdx
+++ b/website/content/docs/plugins/plugin-portal.mdx
@@ -63,6 +63,7 @@ exists within the Vault repository, the plugin can be built as instructed in
 - [Oracle Database](https://github.com/hashicorp/vault-plugin-database-oracle) <Tag title='external' color='yellow' />
 - [PostgreSQL](/api-docs/secret/databases/postgresql)
 - [Redshift](/api-docs/secret/databases/redshift)
+- [Snowflake](https://github.com/hashicorp/vault-plugin-database-snowflake)
 
 </Columns>
 
@@ -78,7 +79,9 @@ exists within the Vault repository, the plugin can be built as instructed in
 - [Google Cloud Platform (GCP)](https://github.com/hashicorp/vault-plugin-secrets-gcp)
 - [GCP KMS](https://github.com/hashicorp/vault-plugin-secrets-gcpkms)
 - [KMIP](/api-docs/secret/kmip) <sup>ENTERPRISE</sup>
+- [Key Management](/api-docs/secret/key-management) <sup>ENTERPRISE</sup>
 - [Key/Value (KV)](https://github.com/hashicorp/vault-plugin-secrets-kv)
+- [Kubernetes](https://github.com/hashicorp/vault-plugin-secrets-kubernetes)
 - [MongoDB Atlas](https://github.com/hashicorp/vault-plugin-secrets-mongodbatlas)
 - [Nomad](/api-docs/secret/nomad)
 - [OpenLDAP](https://github.com/hashicorp/vault-plugin-secrets-openldap)


### PR DESCRIPTION
This PR adds a few HashiCorp supported plugins to the plugin portal documentation.