### PR TITLE
Remove gox in favor of go build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ EXTENDED_TEST_TIMEOUT=60m
 INTEG_TEST_TIMEOUT=120m
 VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
 EXTERNAL_TOOLS_CI=\
-	github.com/mitchellh/gox \
 	golang.org/x/tools/cmd/goimports
 EXTERNAL_TOOLS=\
 	github.com/client9/misspell/cmd/misspell
@@ -202,10 +201,10 @@ fmtcheck:
 fmt:
 	find . -name '*.go' | grep -v pb.go | grep -v vendor | xargs gofumpt -w
 
-semgrep: 
+semgrep:
 	semgrep --include '*.go' --exclude 'vendor' -a -f tools/semgrep .
 
-semgrep-ci: 
+semgrep-ci:
 	semgrep --error --include '*.go' --exclude 'vendor' -f tools/semgrep/ci .
 
 assetcheck:

--- a/changelog/16353.txt
+++ b/changelog/16353.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: remove gox
+```

--- a/go.mod
+++ b/go.mod
@@ -143,7 +143,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/mitchellh/go-wordwrap v1.0.0
-	github.com/mitchellh/gox v1.0.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mitchellh/reflectwalk v1.0.2
 	github.com/natefinch/atomic v0.0.0-20150920032501-a62ce929ffcc
@@ -329,7 +328,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/miekg/dns v1.1.41 // indirect
 	github.com/mitchellh/hashstructure v1.0.0 // indirect
-	github.com/mitchellh/iochan v1.0.0 // indirect
 	github.com/mitchellh/pointerstructure v1.2.0 // indirect
 	github.com/moby/sys/mount v0.2.0 // indirect
 	github.com/moby/sys/mountinfo v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -978,7 +978,6 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
@@ -1324,11 +1323,8 @@ github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
-github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
-github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
 github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
 github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
-github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/make.bat
+++ b/make.bat
@@ -7,7 +7,7 @@ REM If no target is provided, default to test.
 if [%1]==[] goto test
 
 set _TARGETS=bin,bootstrap,dev,generate,test,testacc,testrace,vet
-set _EXTERNAL_TOOLS=github.com/mitchellh/gox,github.com/kardianos/govendor
+set _EXTERNAL_TOOLS=github.com/kardianos/govendor
 
 REM Run target.
 for %%a in (%_TARGETS%) do (if x%1==x%%a goto %%a)
@@ -82,7 +82,7 @@ REM any common errors.
 
 	go tool vet 2>nul
 	if %ERRORLEVEL% equ 3 go get golang.org/x/tools/cmd/vet
-	
+
 	set _vetExitCode=0
 	set _VAULT_PKG_DIRS=%TEMP%\vault-pkg-dirs.txt
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,21 +23,6 @@ GIT_DIRTY="$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)"
 
 BUILD_DATE=$("$SOURCE_DIR"/build_date.sh)
 
-# If its dev mode, only build for ourself
-if [ "${VAULT_DEV_BUILD}x" != "x" ] && [ "${XC_OSARCH}x" == "x" ]; then
-    XC_OS=$(${GO_CMD} env GOOS)
-    XC_ARCH=$(${GO_CMD} env GOARCH)
-    XC_OSARCH=$(${GO_CMD} env GOOS)/$(${GO_CMD} env GOARCH)
-elif [ "${XC_OSARCH}x" != "x" ]; then
-    IFS='/' read -ra SPLITXC <<< "${XC_OSARCH}"
-	DEV_PLATFORM="./pkg/${SPLITXC[0]}_${SPLITXC[1]}"
-fi
-
-# Determine the arch/os combos we're building for
-XC_ARCH=${XC_ARCH:-"386 amd64"}
-XC_OS=${XC_OS:-linux darwin windows freebsd openbsd netbsd solaris}
-XC_OSARCH=${XC_OSARCH:-"linux/386 linux/amd64 linux/arm linux/arm64 darwin/386 darwin/amd64 darwin/arm64 windows/386 windows/amd64 freebsd/386 freebsd/amd64 freebsd/arm openbsd/386 openbsd/amd64 openbsd/arm netbsd/386 netbsd/amd64 solaris/amd64"}
-
 GOPATH=${GOPATH:-$(${GO_CMD} env GOPATH)}
 case $(uname) in
     CYGWIN*)
@@ -52,43 +37,18 @@ rm -rf pkg/*
 mkdir -p bin/
 
 # Build!
-# If GOX_PARALLEL_BUILDS is set, it will be used to add a "-parallel=${GOX_PARALLEL_BUILDS}" gox parameter
 echo "==> Building..."
-gox \
-    -osarch="${XC_OSARCH}" \
+${GO_CMD} build \
     -gcflags "${GCFLAGS}" \
-    -ldflags "${LD_FLAGS}-X github.com/hashicorp/vault/sdk/version.GitCommit='${GIT_COMMIT}${GIT_DIRTY}' -X github.com/hashicorp/vault/sdk/version.BuildDate=${BUILD_DATE}" \
-    -output "pkg/{{.OS}}_{{.Arch}}/vault" \
-    ${GOX_PARALLEL_BUILDS+-parallel="${GOX_PARALLEL_BUILDS}"} \
-    -tags="${BUILD_TAGS}" \
-    -gocmd="${GO_CMD}" \
+    -ldflags "${LD_FLAGS} -X github.com/hashicorp/vault/sdk/version.GitCommit='${GIT_COMMIT}${GIT_DIRTY}' -X github.com/hashicorp/vault/sdk/version.BuildDate=${BUILD_DATE}" \
+    -o "bin/vault" \
+    -tags "${BUILD_TAGS}" \
     .
 
 # Move all the compiled things to the $GOPATH/bin
 OLDIFS=$IFS
 IFS=: MAIN_GOPATH=($GOPATH)
 IFS=$OLDIFS
-
-# Copy our OS/Arch to the bin/ directory
-DEV_PLATFORM=${DEV_PLATFORM:-"./pkg/$(${GO_CMD} env GOOS)_$(${GO_CMD} env GOARCH)"}
-for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
-    cp ${F} bin/
-    rm -f ${MAIN_GOPATH}/bin/vault
-    cp ${F} ${MAIN_GOPATH}/bin/
-done
-
-if [ "${VAULT_DEV_BUILD}x" = "x" ]; then
-    # Zip and copy to the dist dir
-    echo "==> Packaging..."
-    for PLATFORM in $(find ./pkg -mindepth 1 -maxdepth 1 -type d); do
-        OSARCH=$(basename ${PLATFORM})
-        echo "--> ${OSARCH}"
-
-        pushd $PLATFORM >/dev/null 2>&1
-        zip ../${OSARCH}.zip ./*
-        popd >/dev/null 2>&1
-    done
-fi
 
 # Done!
 echo

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -50,6 +50,9 @@ OLDIFS=$IFS
 IFS=: MAIN_GOPATH=($GOPATH)
 IFS=$OLDIFS
 
+rm -f ${MAIN_GOPATH}/bin/vault
+cp bin/vault ${MAIN_GOPATH}/bin/
+
 # Done!
 echo
 echo "==> Results:"

--- a/scripts/cross/Dockerfile
+++ b/scripts/cross/Dockerfile
@@ -31,7 +31,6 @@ ENV GOROOT /goroot
 ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH
 
 RUN go get golang.org/x/tools/cmd/goimports
-RUN go get github.com/mitchellh/gox
 
 RUN mkdir -p /gopath/src/github.com/hashicorp/vault
 WORKDIR /gopath/src/github.com/hashicorp/vault

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,6 +1,5 @@
 # Multi-stage builder to avoid polluting users environment with wrong
-# architecture binaries.  Since this binary is used in an alpine container,
-# we're explicitly compiling for 'linux/amd64'
+# architecture binaries.
 ARG VERSION=1.17.12
 
 FROM golang:${VERSION} AS builder
@@ -12,7 +11,7 @@ WORKDIR /go/src/github.com/hashicorp/vault
 COPY . .
 
 RUN make bootstrap \
-  && CGO_ENABLED=$CGO_ENABLED BUILD_TAGS="${BUILD_TAGS}" VAULT_DEV_BUILD=1 XC_OSARCH='linux/amd64' sh -c "'./scripts/build.sh'"
+  && CGO_ENABLED=$CGO_ENABLED BUILD_TAGS="${BUILD_TAGS}" VAULT_DEV_BUILD=1 sh -c "'./scripts/build.sh'"
 
 # Docker Image
 
@@ -27,7 +26,7 @@ RUN addgroup vault && \
 RUN set -eux; \
     apk add --no-cache ca-certificates libcap su-exec dumb-init tzdata
 
-COPY --from=builder /go/bin/vault /bin/vault
+COPY --from=builder /go/src/github.com/hashicorp/vault/bin/vault /bin/vault
 
 # /vault/logs is made available to use as a location to store audit logs, if
 # desired; /vault/file is made available to use as a location with the file

--- a/scripts/docker/Dockerfile.ui
+++ b/scripts/docker/Dockerfile.ui
@@ -1,6 +1,5 @@
 # Multi-stage builder to avoid polluting users environment with wrong
-# architecture binaries.  Since this binary is used in an alpine container,
-# we're explicitly compiling for 'linux/amd64'
+# architecture binaries. This file only currently works for linux/amd64.
 FROM debian:buster AS builder
 
 ARG VERSION=1.17.12
@@ -38,7 +37,7 @@ ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH
 WORKDIR /go/src/github.com/hashicorp/vault
 COPY . .
 RUN make bootstrap static-dist \
-  && CGO_ENABLED=$CGO_ENABLED BUILD_TAGS="${BUILD_TAGS} ui" VAULT_DEV_BUILD=1 XC_OSARCH='linux/amd64' sh -c "'./scripts/build.sh'"
+  && CGO_ENABLED=$CGO_ENABLED BUILD_TAGS="${BUILD_TAGS} ui" VAULT_DEV_BUILD=1 GOOS=linux GOARCH=amd64 sh -c "'./scripts/build.sh'"
 
 # Docker Image
 
@@ -53,7 +52,7 @@ RUN addgroup vault && \
 RUN set -eux; \
     apk add --no-cache ca-certificates libcap su-exec dumb-init tzdata
 
-COPY --from=builder /go/bin/vault /bin/vault
+COPY --from=builder /go/src/github.com/hashicorp/vault/bin/vault /bin/vault
 
 # /vault/logs is made available to use as a location to store audit logs, if
 # desired; /vault/file is made available to use as a location with the file

--- a/scripts/windows/build.bat
+++ b/scripts/windows/build.bat
@@ -62,11 +62,9 @@ del /f "%_GO_ENV_TMP_FILE%" 2>nul
 :build
 REM Build!
 echo ==^> Building...
-gox^
- -os="%_XC_OS%"^
- -arch="%_XC_ARCH%"^
+go build^
  -ldflags "-X github.com/hashicorp/vault/sdk/version.GitCommit=%_GIT_COMMIT%%_GIT_DIRTY% -X github.com/hashicorp/vault/sdk/version.BuildDate=%_BUILD_DATE%"^
- -output "pkg/{{.OS}}_{{.Arch}}/vault"^
+ -o "bin/vault.exe"^
  .
 
 if %ERRORLEVEL% equ 1 set %_EXITCODE%=1
@@ -86,14 +84,6 @@ del /f "%_GO_ENV_TMP_FILE%" 2>nul
 go env GOOS >"%_GO_ENV_TMP_FILE%"
 set /p _GOOS=<"%_GO_ENV_TMP_FILE%"
 del /f "%_GO_ENV_TMP_FILE%" 2>nul
-
-REM Copy our OS/Arch to the bin/ directory
-set _DEV_PLATFORM=pkg\%_GOOS%_%_GOARCH%
-
-for /r %%f in (%_DEV_PLATFORM%) do (
-	copy /b /y %%f bin\ >nul
-	copy /b /y %%f %_GOPATH%\bin\ >nul
-)
 
 REM TODO(ceh): package dist
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -11,7 +11,6 @@
 package tools
 
 //go:generate go install golang.org/x/tools/cmd/goimports
-//go:generate go install github.com/mitchellh/gox
 //go:generate go install github.com/client9/misspell/cmd/misspell
 //go:generate go install mvdan.cc/gofumpt
 //go:generate go install google.golang.org/protobuf/cmd/protoc-gen-go
@@ -19,8 +18,6 @@ package tools
 //go:generate go install github.com/favadi/protoc-go-inject-tag
 import (
 	_ "golang.org/x/tools/cmd/goimports"
-
-	_ "github.com/mitchellh/gox"
 
 	_ "github.com/client9/misspell/cmd/misspell"
 


### PR DESCRIPTION
`gox` hasn't had a release to update it in many years, so is missing
support for many modern systems, like `darwin/arm64`.

In any case, we only use it for dev builds, where we don't even use
the ability of it to build for multiple platforms. Release builds use
`go build` now.

So, this switches to `go build` everywhere.

I pulled this down and tested it in Windows as well. (Side note: I
couldn't get `gox` to work in Windows, so couldn't build before this
change.)