### PR TITLE
Fix linter issues in policy.go & acl.go

### DIFF
--- a/vault/acl.go
+++ b/vault/acl.go
@@ -250,9 +250,7 @@ func NewACL(ctx context.Context, policies []*Policy) (*ACL, error) {
 				if existingPerms.MFAMethods == nil {
 					existingPerms.MFAMethods = pc.Permissions.MFAMethods
 				} else {
-					for _, method := range pc.Permissions.MFAMethods {
-						existingPerms.MFAMethods = append(existingPerms.MFAMethods, method)
-					}
+					existingPerms.MFAMethods = append(existingPerms.MFAMethods, pc.Permissions.MFAMethods...)
 				}
 				existingPerms.MFAMethods = strutil.RemoveDuplicates(existingPerms.MFAMethods, false)
 			}
@@ -264,9 +262,7 @@ func NewACL(ctx context.Context, policies []*Policy) (*ACL, error) {
 					if existingPerms.ControlGroup == nil {
 						existingPerms.ControlGroup = pc.Permissions.ControlGroup
 					} else {
-						for _, authz := range pc.Permissions.ControlGroup.Factors {
-							existingPerms.ControlGroup.Factors = append(existingPerms.ControlGroup.Factors, authz)
-						}
+						existingPerms.ControlGroup.Factors = append(existingPerms.ControlGroup.Factors, pc.Permissions.ControlGroup.Factors...)
 					}
 				}
 			}

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -101,7 +101,7 @@ func TestACL_Capabilities(t *testing.T) {
 	t.Run("root-ns", func(t *testing.T) {
 		t.Parallel()
 		policy := []*Policy{{Name: "root"}}
-		ctx := namespace.RootContext(nil)
+		ctx := namespace.RootContext(context.Background())
 		acl, err := NewACL(ctx, policy)
 		if err != nil {
 			t.Fatalf("err: %v", err)
@@ -159,7 +159,7 @@ func testACLRoot(t *testing.T, ns *namespace.Namespace) {
 	// Create the root policy ACL. Always create on root namespace regardless of
 	// which namespace to ACL check on.
 	policy := []*Policy{{Name: "root"}}
-	acl, err := NewACL(namespace.RootContext(nil), policy)
+	acl, err := NewACL(namespace.RootContext(context.Background()), policy)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -293,7 +293,7 @@ func TestACL_Layered(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		acl, err := NewACL(namespace.RootContext(nil), []*Policy{policy1, policy2})
+		acl, err := NewACL(namespace.RootContext(context.Background()), []*Policy{policy1, policy2})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -830,7 +830,7 @@ func TestACL_CreationRace(t *testing.T) {
 				if time.Now().After(stopTime) {
 					return
 				}
-				_, err := NewACL(namespace.RootContext(nil), []*Policy{policy})
+				_, err := NewACL(namespace.RootContext(context.Background()), []*Policy{policy})
 				if err != nil {
 					t.Fatalf("err: %v", err)
 				}
@@ -1179,7 +1179,6 @@ var permissionsPolicy = `
 name = "dev"
 path "dev/*" {
 	policy = "write"
-	
 	allowed_parameters = {
 		"zip" = []
 	}
@@ -1269,7 +1268,6 @@ var valuePermissionsPolicy = `
 name = "op"
 path "dev/*" {
 	policy = "write"
-	
 	allowed_parameters = {
 		"allow" = ["good"]
 	}

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -821,7 +821,7 @@ func TestACL_CreationRace(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	errors := make(chan error)
+	errs := make(chan error)
 	stopTime := time.Now().Add(20 * time.Second)
 
 	for i := 0; i < 50; i++ {
@@ -834,7 +834,7 @@ func TestACL_CreationRace(t *testing.T) {
 				}
 				_, err := NewACL(namespace.RootContext(context.Background()), []*Policy{policy})
 				if err != nil {
-					errors <- fmt.Errorf("goroutine %d: %w", i, err)
+					errs <- fmt.Errorf("goroutine %d: %w", i, err)
 				}
 			}
 		}(i)
@@ -842,10 +842,10 @@ func TestACL_CreationRace(t *testing.T) {
 
 	go func() {
 		wg.Wait()
-		close(errors)
+		close(errs)
 	}()
 
-	for err := range errors {
+	for err := range errs {
 		t.Fatalf("err: %v", err)
 	}
 }

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -825,7 +826,7 @@ func TestACL_CreationRace(t *testing.T) {
 
 	for i := 0; i < 50; i++ {
 		wg.Add(1)
-		go func() {
+		go func(i int) {
 			defer wg.Done()
 			for {
 				if time.Now().After(stopTime) {
@@ -833,10 +834,10 @@ func TestACL_CreationRace(t *testing.T) {
 				}
 				_, err := NewACL(namespace.RootContext(context.Background()), []*Policy{policy})
 				if err != nil {
-					errors <- err
+					errors <- fmt.Errorf("goroutine %d: %w", i, err)
 				}
 			}
-		}()
+		}(i)
 	}
 
 	go func() {

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -438,15 +438,15 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 
 		if pc.AllowedParametersHCL != nil {
 			pc.Permissions.AllowedParameters = make(map[string][]interface{}, len(pc.AllowedParametersHCL))
-			for key, val := range pc.AllowedParametersHCL {
-				pc.Permissions.AllowedParameters[strings.ToLower(key)] = val
+			for k, v := range pc.AllowedParametersHCL {
+				pc.Permissions.AllowedParameters[strings.ToLower(k)] = v
 			}
 		}
 		if pc.DeniedParametersHCL != nil {
 			pc.Permissions.DeniedParameters = make(map[string][]interface{}, len(pc.DeniedParametersHCL))
 
-			for key, val := range pc.DeniedParametersHCL {
-				pc.Permissions.DeniedParameters[strings.ToLower(key)] = val
+			for k, v := range pc.DeniedParametersHCL {
+				pc.Permissions.DeniedParameters[strings.ToLower(k)] = v
 			}
 		}
 		if pc.MinWrappingTTLHCL != nil {
@@ -465,9 +465,7 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 		}
 		if pc.MFAMethodsHCL != nil {
 			pc.Permissions.MFAMethods = make([]string, len(pc.MFAMethodsHCL))
-			for idx, item := range pc.MFAMethodsHCL {
-				pc.Permissions.MFAMethods[idx] = item
-			}
+			copy(pc.Permissions.MFAMethods, pc.MFAMethodsHCL)
 		}
 		if pc.ControlGroupHCL != nil {
 			pc.Permissions.ControlGroup = new(ControlGroup)


### PR DESCRIPTION
Fixing a few small issues I noticed while looking into policy parameter constraints:

 - `nil` was passed to context in tests; replaced it with `context.Background()`
 - `t.Fatal` was being used inside of internal go-routines, which would not fail the test; changed the test to push errors into a channel and check them at the end
 - use `copy` and `append` instead of loops to copy/append slices