### PR TITLE
[CI-only] Use pattern matching for release_branches

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -10,10 +10,7 @@ project "vault" {
     repository = "vault"
     release_branches = [
       "main",
-      "release/1.8.x",
-      "release/1.9.x",
-      "release/1.10.x",
-      "release/1.11.x",
+      "release/**",
     ]
   }
 }


### PR DESCRIPTION
### Description
Pattern matching was [recently added](https://github.com/hashicorp/crt-orchestrator/pull/51) so that teams no longer have to explicitly list every branch that should trigger the CRT pipeline. This simplifies release preparation- anytime a new release branch is created, it will produce releasable artifacts and exercise the full pipeline.

### Testing & Reproduction steps
This has been tested in multiple projects since being rolled out. There are no vault-specific tests that need to be done.

### Links
PR where this functionality was added: https://github.com/hashicorp/crt-orchestrator/pull/51

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [X] not a security concern