### PR TITLE
Validate parameters for vault operator init  

### DIFF
--- a/changelog/16379.txt
+++ b/changelog/16379.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Validate input parameters for vault operator init command  
+```

--- a/command/operator_init.go
+++ b/command/operator_init.go
@@ -237,7 +237,7 @@ func (c *OperatorInitCommand) Run(args []string) int {
 		return 2
 	}
 
-	// check if this is auto-unseal
+	// Set defaults based on use of auto unseal seal
 	sealInfo, err := client.Sys().SealStatus()
 	if err != nil {
 		c.UI.Error(err.Error())

--- a/command/operator_init.go
+++ b/command/operator_init.go
@@ -39,11 +39,6 @@ type OperatorInitCommand struct {
 	flagConsulService string
 }
 
-const (
-	defKeyShares    = 5
-	defKeyThreshold = 3
-)
-
 func (c *OperatorInitCommand) Synopsis() string {
 	return "Initializes a server"
 }
@@ -103,7 +98,6 @@ func (c *OperatorInitCommand) Flags() *FlagSets {
 		Name:       "key-shares",
 		Aliases:    []string{"n"},
 		Target:     &c.flagKeyShares,
-		Default:    defKeyShares,
 		Completion: complete.PredictAnything,
 		Usage: "Number of key shares to split the generated root key into. " +
 			"This is the number of \"unseal keys\" to generate.",
@@ -113,7 +107,6 @@ func (c *OperatorInitCommand) Flags() *FlagSets {
 		Name:       "key-threshold",
 		Aliases:    []string{"t"},
 		Target:     &c.flagKeyThreshold,
-		Default:    defKeyThreshold,
 		Completion: complete.PredictAnything,
 		Usage: "Number of key shares required to reconstruct the root key. " +
 			"This must be less than or equal to -key-shares.",
@@ -182,7 +175,6 @@ func (c *OperatorInitCommand) Flags() *FlagSets {
 	f.IntVar(&IntVar{
 		Name:       "recovery-shares",
 		Target:     &c.flagRecoveryShares,
-		Default:    5,
 		Completion: complete.PredictAnything,
 		Usage: "Number of key shares to split the recovery key into. " +
 			"This is only used in auto-unseal mode.",
@@ -191,7 +183,6 @@ func (c *OperatorInitCommand) Flags() *FlagSets {
 	f.IntVar(&IntVar{
 		Name:       "recovery-threshold",
 		Target:     &c.flagRecoveryThreshold,
-		Default:    3,
 		Completion: complete.PredictAnything,
 		Usage: "Number of key shares required to reconstruct the recovery key. " +
 			"This is only used in Auto Unseal mode.",
@@ -469,14 +460,6 @@ func (c *OperatorInitCommand) init(client *api.Client, req *api.InitRequest) int
 				"Please securely distribute the key shares printed above.",
 			req.RecoveryShares,
 			req.RecoveryThreshold)))
-	}
-
-	if len(resp.RecoveryKeys) > 0 && (req.SecretShares != defKeyShares || req.SecretThreshold != defKeyThreshold) {
-		c.UI.Output("")
-		c.UI.Warn(wrapAtLength(
-			"WARNING! -key-shares and -key-threshold is ignored when " +
-				"Auto Unseal is used. Use -recovery-shares and -recovery-threshold instead.",
-		))
 	}
 
 	return 0

--- a/command/operator_init_test.go
+++ b/command/operator_init_test.go
@@ -355,7 +355,7 @@ func TestOperatorInitCommand_Run(t *testing.T) {
 			t.Errorf("expected %d to be %d", code, exp)
 		}
 
-		expected := "Error initializing: "
+		expected := "Error making API request"
 		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
 		if !strings.Contains(combined, expected) {
 			t.Errorf("expected %q to contain %q", combined, expected)

--- a/http/sys_init.go
+++ b/http/sys_init.go
@@ -51,9 +51,6 @@ func handleSysInitPut(core *vault.Core, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Set Default values for shares and threshold if absent
-	req = setDefaultIfAbsent(req)
-
 	// Initialize
 	barrierConfig := &vault.SealConfig{
 		SecretShares:    req.SecretShares,
@@ -146,22 +143,6 @@ const (
 	defRecoveryThreshold = 3
 )
 
-// Set default values for shares and threshold if absent in init request
-func setDefaultIfAbsent(req InitRequest) InitRequest {
-	if req.SecretShares == 0 {
-		req.SecretShares = defKeyShares
-	}
-	if req.SecretThreshold == 0 {
-		req.SecretThreshold = defKeyThreshold
-	}
-	if req.RecoveryShares == 0 {
-		req.RecoveryShares = defRecoveryShares
-	}
-	if req.RecoveryThreshold == 0 {
-		req.RecoveryThreshold = defRecoveryThreshold
-	}
-	return req
-}
 
 // Validates if the right parameters are used based on AutoUnseal
 func validateInitParameters(core *vault.Core, req InitRequest) error {

--- a/http/sys_init.go
+++ b/http/sys_init.go
@@ -144,37 +144,31 @@ func validateInitParameters(core *vault.Core, req InitRequest) error {
 
 	if req.SecretShares != 0 {
 		barrierFlags = append(barrierFlags, "secret_shares")
-
 	}
 	if req.SecretThreshold != 0 {
 		barrierFlags = append(barrierFlags, "secret_threshold")
-
 	}
-	if len(req.PGPKeys) !=0{
+	if len(req.PGPKeys) != 0 {
 		barrierFlags = append(barrierFlags, "pgp_keys")
-
 	}
 	if req.RecoveryShares != 0 {
 		recoveryFlags = append(recoveryFlags, "recovery_shares")
-
 	}
 	if req.RecoveryThreshold != 0 {
 		recoveryFlags = append(recoveryFlags, "recovery_threshold")
-
 	}
-	if len(req.RecoveryPGPKeys) !=0{
+	if len(req.RecoveryPGPKeys) != 0 {
 		recoveryFlags = append(recoveryFlags, "recovery_pgp_keys")
-
 	}
 
 	switch core.SealAccess().RecoveryKeySupported() {
 	case true:
-		if len(barrierFlags)>0{
-			return fmt.Errorf("parameters %s not applicable to seal type %s", strings.Join(barrierFlags,","), core.SealAccess().BarrierType())
+		if len(barrierFlags) > 0 {
+			return fmt.Errorf("parameters %s not applicable to seal type %s", strings.Join(barrierFlags, ","), core.SealAccess().BarrierType())
 		}
 	default:
-		if len(recoveryFlags)>0 {
-			return fmt.Errorf("parameters %s not applicable to seal type %s", strings.Join(recoveryFlags,","), core.SealAccess().BarrierType())
+		if len(recoveryFlags) > 0 {
+			return fmt.Errorf("parameters %s not applicable to seal type %s", strings.Join(recoveryFlags, ","), core.SealAccess().BarrierType())
 		}
 
 	}

--- a/http/sys_init.go
+++ b/http/sys_init.go
@@ -136,14 +136,6 @@ type InitStatusResponse struct {
 	Initialized bool `json:"initialized"`
 }
 
-const (
-	defKeyShares         = 5
-	defKeyThreshold      = 3
-	defRecoveryShares    = 5
-	defRecoveryThreshold = 3
-)
-
-
 // Validates if the right parameters are used based on AutoUnseal
 func validateInitParameters(core *vault.Core, req InitRequest) error {
 	var recoveryFlagsPresent bool

--- a/http/sys_init.go
+++ b/http/sys_init.go
@@ -45,7 +45,7 @@ func handleSysInitPut(core *vault.Core, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Validate the request parameters
+	// Validate init request parameters
 	if err := validateInitParameters(core, req); err != nil {
 		respondError(w, http.StatusBadRequest, err)
 		return

--- a/http/sys_init_test.go
+++ b/http/sys_init_test.go
@@ -138,7 +138,7 @@ func TestSysInit_Put_ValidateParams(t *testing.T) {
 	testResponseStatus(t, resp, http.StatusBadRequest)
 	body := map[string][]string{}
 	testResponseBody(t, resp, &body)
-	if body["errors"][0] != "parameters specific to auto unseal seals present" {
+	if body["errors"][0] != "parameters recovery_shares,recovery_threshold not applicable to seal type shamir" {
 		t.Fatal(body)
 	}
 }

--- a/http/sys_init_test.go
+++ b/http/sys_init_test.go
@@ -123,3 +123,45 @@ func TestSysInit_put(t *testing.T) {
 		t.Fatal("should not be sealed")
 	}
 }
+
+// func TestSysInit_put_autounseal(t *testing.T) {
+// 	core := vault.TestCore(t)
+// 	testSeal := seal.NewTestSeal(nil)
+// 	ln, addr := TestServer(t, core)
+// 	defer ln.Close()
+
+// 	autoSeal := vault.NewAutoSeal(testSeal)
+// 	autoSeal.SetCore(core)
+
+// 	resp := testHttpPut(t, "", addr+"/v1/sys/init", map[string]interface{}{
+// 		"recovery_shares":    5,
+// 		"recovery_threshold": 3,
+// 	})
+
+// 	var actual map[string]interface{}
+// 	testResponseStatus(t, resp, 200)
+// 	testResponseBody(t, resp, &actual)
+// 	keysRaw, ok := actual["keys"]
+// 	if !ok {
+// 		t.Fatalf("no keys: %#v", actual)
+// 	}
+
+// 	if _, ok := actual["root_token"]; !ok {
+// 		t.Fatal("no root token")
+// 	}
+
+// 	for _, key := range keysRaw.([]interface{}) {
+// 		keySlice, err := hex.DecodeString(key.(string))
+// 		if err != nil {
+// 			t.Fatalf("bad: %s", err)
+// 		}
+
+// 		if _, err := core.Unseal(keySlice); err != nil {
+// 			t.Fatalf("bad: %s", err)
+// 		}
+// 	}
+
+// 	if core.Sealed() {
+// 		t.Fatal("should not be sealed")
+// 	}
+// }

--- a/http/sys_init_test.go
+++ b/http/sys_init_test.go
@@ -4,9 +4,15 @@ import (
 	"encoding/hex"
 	"net/http"
 	"reflect"
+	"strconv"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/builtin/logical/transit"
+	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
+	"github.com/hashicorp/vault/vault/seal"
 )
 
 func TestSysInit_get(t *testing.T) {
@@ -139,6 +145,47 @@ func TestSysInit_Put_ValidateParams(t *testing.T) {
 	body := map[string][]string{}
 	testResponseBody(t, resp, &body)
 	if body["errors"][0] != "parameters recovery_shares,recovery_threshold not applicable to seal type shamir" {
+		t.Fatal(body)
+	}
+}
+
+func TestSysInit_Put_ValidateParams_AutoUnseal(t *testing.T) {
+	testSeal := seal.NewTestSeal(nil)
+	autoSeal := vault.NewAutoSeal(testSeal)
+	autoSeal.SetType("transit")
+
+	// Create the transit server.
+	conf := &vault.CoreConfig{
+		LogicalBackends: map[string]logical.Factory{
+			"transit": transit.Factory,
+		},
+		Seal: autoSeal,
+	}
+	opts := &vault.TestClusterOptions{
+		NumCores:    1,
+		HandlerFunc: Handler,
+		Logger:      logging.NewVaultLogger(hclog.Trace).Named(t.Name()).Named("transit-seal" + strconv.Itoa(0)),
+	}
+	cluster := vault.NewTestCluster(t, conf, opts)
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	cores := cluster.Cores
+	core := cores[0].Core
+
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+
+	resp := testHttpPut(t, "", addr+"/v1/sys/init", map[string]interface{}{
+		"secret_shares":      5,
+		"secret_threshold":   3,
+		"recovery_shares":    5,
+		"recovery_threshold": 3,
+	})
+	testResponseStatus(t, resp, http.StatusBadRequest)
+	body := map[string][]string{}
+	testResponseBody(t, resp, &body)
+	if body["errors"][0] != "parameters secret_shares,secret_threshold not applicable to seal type transit" {
 		t.Fatal(body)
 	}
 }

--- a/http/sys_init_test.go
+++ b/http/sys_init_test.go
@@ -124,44 +124,21 @@ func TestSysInit_put(t *testing.T) {
 	}
 }
 
-// func TestSysInit_put_autounseal(t *testing.T) {
-// 	core := vault.TestCore(t)
-// 	testSeal := seal.NewTestSeal(nil)
-// 	ln, addr := TestServer(t, core)
-// 	defer ln.Close()
+func TestSysInit_Put_ValidateParams(t *testing.T) {
+	core := vault.TestCore(t)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
 
-// 	autoSeal := vault.NewAutoSeal(testSeal)
-// 	autoSeal.SetCore(core)
-
-// 	resp := testHttpPut(t, "", addr+"/v1/sys/init", map[string]interface{}{
-// 		"recovery_shares":    5,
-// 		"recovery_threshold": 3,
-// 	})
-
-// 	var actual map[string]interface{}
-// 	testResponseStatus(t, resp, 200)
-// 	testResponseBody(t, resp, &actual)
-// 	keysRaw, ok := actual["keys"]
-// 	if !ok {
-// 		t.Fatalf("no keys: %#v", actual)
-// 	}
-
-// 	if _, ok := actual["root_token"]; !ok {
-// 		t.Fatal("no root token")
-// 	}
-
-// 	for _, key := range keysRaw.([]interface{}) {
-// 		keySlice, err := hex.DecodeString(key.(string))
-// 		if err != nil {
-// 			t.Fatalf("bad: %s", err)
-// 		}
-
-// 		if _, err := core.Unseal(keySlice); err != nil {
-// 			t.Fatalf("bad: %s", err)
-// 		}
-// 	}
-
-// 	if core.Sealed() {
-// 		t.Fatal("should not be sealed")
-// 	}
-// }
+	resp := testHttpPut(t, "", addr+"/v1/sys/init", map[string]interface{}{
+		"secret_shares":      5,
+		"secret_threshold":   3,
+		"recovery_shares":    5,
+		"recovery_threshold": 3,
+	})
+	testResponseStatus(t, resp, http.StatusBadRequest)
+	body := map[string][]string{}
+	testResponseBody(t, resp, &body)
+	if body["errors"][0] != "parameters specific to auto unseal seals present" {
+		t.Fatal(body)
+	}
+}


### PR DESCRIPTION
https://hashicorp.atlassian.net/browse/VAULT-951

The "vault operator" command should not operate if there are unused command-line flags, for example:
vault operator init --recovery-threshold=1 --recovery-shares=1
should return an error because auto unseal is not being used (the correct flags are -key-shares and -key threshold.)
