### PR TITLE
Fix replication test failure

### DIFF
--- a/ui/tests/acceptance/enterprise-replication-test.js
+++ b/ui/tests/acceptance/enterprise-replication-test.js
@@ -367,9 +367,9 @@ module('Acceptance | Enterprise | replication', function (hooks) {
     await click('[data-test-demote-replication] [data-test-replication-action-trigger]');
 
     // enter confirmation text
-    await fillIn('[data-test-confirmation-modal-input="demote"]', 'Performance');
+    await fillIn('[data-test-confirmation-modal-input="Demote to secondary?"]', 'Performance');
     // Click confirm button
-    await click('[data-test-confirm-button="demote"]');
+    await click('[data-test-confirm-button="Demote to secondary?"]');
 
     await click('[data-test-replication-link="details"]');
 

--- a/ui/tests/acceptance/enterprise-replication-test.js
+++ b/ui/tests/acceptance/enterprise-replication-test.js
@@ -21,7 +21,7 @@ const disableReplication = async (type, assert) => {
     await click('[data-test-disable-replication] button');
 
     const typeDisplay = type === 'dr' ? 'Disaster Recovery' : 'Performance';
-    await fillIn('[data-test-confirmation-modal-input="disable"]', typeDisplay);
+    await fillIn('[data-test-confirmation-modal-input="Disable Replication?"]', typeDisplay);
     await click('[data-test-confirm-button]');
     await settled(); // eslint-disable-line
 


### PR DESCRIPTION
Small failure that was caused by a dynamic selector change on a glimmerization of a component. See PR [here](https://github.com/hashicorp/vault/pull/16032).

Good reminder that it's best to run enterprise test locally on PRs that might in any way touch an enterprise area of the application. I'll try to do a better job as PR reviewer to ask this of folks.

Note: yep, I ran the enterprise test locally and they all passed with this change.