### PR TITLE
auth/oidc: fix changelog entry for SecureAuth groups parsing

### DIFF
--- a/changelog/16274.txt
+++ b/changelog/16274.txt
@@ -1,3 +1,3 @@
-```release-note:feature
+```release-note:improvement
 auth/oidc: Adds support for group membership parsing when using SecureAuth as an OIDC provider.
 ```


### PR DESCRIPTION
This PR fixes a changelog entry for SecureAuth groups parsing. It's not really a feature and wasn't in the specific feature format.

Prompted by https://github.com/hashicorp/vault/pull/16274#discussion_r926028248.