### PR TITLE
Add next-step warning on import without AIA URLs

### DIFF
--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -280,6 +280,13 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 		}
 	}
 
+	// Also while we're here, we should let the user know the next steps.
+	// In particular, if there's no default AIA URLs configuration, we should
+	// tell the user that's probably next.
+	if entries, err := getURLs(ctx, req.Storage); err == nil && len(entries.IssuingCertificates) == 0 && len(entries.CRLDistributionPoints) == 0 && len(entries.OCSPServers) == 0 {
+		response.AddWarning("This mount hasn't configured any authority access information fields; this may make it harder for systems to find missing certificates in the chain or to validate revocation status of certificates. Consider updating /config/urls with this information.")
+	}
+
 	return response, nil
 }
 

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -184,7 +184,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 	if len(parsedBundle.Certificate.OCSPServer) == 0 && len(parsedBundle.Certificate.IssuingCertificateURL) == 0 && len(parsedBundle.Certificate.CRLDistributionPoints) == 0 {
 		// If the operator hasn't configured any of the URLs prior to
 		// generating this issuer, we should add a warning to the response,
-		// informing them they might want to do so and re-generate the issuer.
+		// informing them they might want to do so prior to issuing leaves.
 		resp.AddWarning("This mount hasn't configured any authority access information fields; this may make it harder for systems to find missing certificates in the chain or to validate revocation status of certificates. Consider updating /config/urls with this information.")
 	}
 


### PR DESCRIPTION
This tells the user that the next step should be to configure AIA URLs
on this newly imported issuer/mount point. Ideally this should occur
before any leaves are issued such that they have the correct
information.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`