### PR TITLE
Add warning when generate_lease=true on PKI roles

### DIFF
--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -735,6 +735,9 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		}
 	} else {
 		*entry.GenerateLease = data.Get("generate_lease").(bool)
+		if *entry.GenerateLease {
+			warning = "it is encouraged to disable generate_lease and rely on PKI's native capabilities when possible; this option can cause Vault-wide issues with large numbers of issued certificates"
+		}
 	}
 
 	resp, err := validateRole(b, entry, ctx, req.Storage)
@@ -938,6 +941,10 @@ func (b *backend) pathRolePatch(ctx context.Context, req *logical.Request, data 
 			*entry.GenerateLease = data.Get("generate_lease").(bool)
 		} else {
 			entry.GenerateLease = oldEntry.GenerateLease
+		}
+
+		if *entry.GenerateLease {
+			warning = "it is encouraged to disable generate_lease and rely on PKI's native capabilities when possible; this option can cause Vault-wide issues with large numbers of issued certificates"
 		}
 	}
 


### PR DESCRIPTION
This option is known to cause problems with large numbers of issued
certificates. Ensure admins are warned about the impact of this field
and encourage them to disable it.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`