### PR TITLE
auth/oidc: documents the client_nonce parameter

### DIFF
--- a/website/content/api-docs/auth/jwt.mdx
+++ b/website/content/api-docs/auth/jwt.mdx
@@ -306,6 +306,9 @@ Obtain an authorization URL from Vault to start an OIDC login flow.
   of the form, "https://.../oidc/callback" where the leading portion is dependent on your Vault
   server location, port, and the mount of the JWT plugin. This must be configured with Vault and the
   provider. See [Redirect URIs](/docs/auth/jwt#redirect-uris) for more information.
+- `client_nonce` `(string: <optional>)` - Optional client-provided nonce that
+  must match the `client_nonce` value provided during a subsequent request to the
+  [callback](/api-docs/auth/jwt#oidc-callback) API.
 
 ### Sample Payload
 
@@ -354,6 +357,9 @@ against any bound claims, and if valid a Vault token will be returned.
   be included in the the redirect following successful authentication on the provider.
 - `code` `(string: <required>)` - Provider-generated authorization code that Vault will exchange for
   an ID token.
+- `client_nonce` `(string: <optional>)` - Optional client-provided nonce that must
+  match the `client_nonce` value provided during the prior request to the
+  [auth_url](/api-docs/auth/jwt#oidc-authorization-url-request) API.
 
 ### Sample Request
 


### PR DESCRIPTION
This PR documents the optional `client_nonce` parameter in the OIDC auth method [`auth_url`](https://www.vaultproject.io/api-docs/auth/jwt#oidc-authorization-url-request) and [`callback`](https://www.vaultproject.io/api-docs/auth/jwt#oidc-callback) APIs.

Resolves: https://github.com/hashicorp/vault/issues/14188