### PR TITLE
Add an "Important Note" regarding EKS CSR approval.

### DIFF
--- a/website/content/docs/platform/k8s/helm/examples/standalone-tls.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/standalone-tls.mdx
@@ -83,6 +83,8 @@ e is 65537 (0x10001)
 
 3. Create the certificate
 
+   ~> **Important Note:** If you are using EKS, certificate signing requirements have changed.  As per the AWS [certificate signing](https://docs.aws.amazon.com/eks/latest/userguide/cert-signing.html) documentation, EKS version `1.22` and later now requires the `signerName` to be `beta.eks.amazonaws.com/app-serving`, otherwise, the CSR will be approved but the certificate will not be issued.
+
    1. Create a file `${TMPDIR}/csr.yaml` with the following contents:
 
       ```bash


### PR DESCRIPTION
I've gotten a few tickets regarding the Standalone TLS Helm Chart example not working for customers running EKS.  This is because in version `1.22` and higher you need to use the `signerName: beta.eks.amazonaws.com/app-serving`.  I put an "Important Note" on this tutorial highlighting this to hopefully help prevent customers getting this issue.

Below is how the note renders on the site.

---

<img width="950" alt="image" src="https://user-images.githubusercontent.com/97125550/180273940-2dc66464-b7f1-42a3-9bda-21f664cb00d3.png">
