### PR TITLE
command/audit: improve audit enable type missing error message

### DIFF
--- a/changelog/16409.txt
+++ b/changelog/16409.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+command/audit: Improve missing type error message
+```

--- a/command/audit_enable.go
+++ b/command/audit_enable.go
@@ -110,7 +110,7 @@ func (c *AuditEnableCommand) Run(args []string) int {
 
 	args = f.Args()
 	if len(args) < 1 {
-		c.UI.Error("Missing TYPE!")
+		c.UI.Error("Error enabling audit device: audit type missing. Valid types include 'file', 'socket' and 'syslog'.")
 		return 1
 	}
 

--- a/command/audit_enable_test.go
+++ b/command/audit_enable_test.go
@@ -32,7 +32,7 @@ func TestAuditEnableCommand_Run(t *testing.T) {
 		{
 			"empty",
 			nil,
-			"Missing TYPE!",
+			"Error enabling audit device: audit type missing. Valid types include 'file', 'socket' and 'syslog'.",
 			1,
 		},
 		{


### PR DESCRIPTION
Just a small improvement to the returned error message if you don't include the audit device type:

```bash
[~] vault audit enable
Missing TYPE!
```

The new error message looks like this:

```
[~] vault audit enable
Error enabling audit device: audit type missing. Valid types include 'file', 'socket' and 'syslog'.
```