### PR TITLE
update semgrep to 0.106.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -744,7 +744,7 @@ jobs:
     steps:
     - run:
         command: |
-          apk add --no-cache python3 py3-pip make
+          apk add --no-cache python3 python3-dev py3-pip make gcc g++
           python3 -m pip install --user semgrep==0.106.0
           export PATH="$HOME/.local/bin:$PATH"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -745,7 +745,7 @@ jobs:
     - run:
         command: |
           apk add --no-cache python3 py3-pip make
-          python3 -m pip install --user semgrep==0.97.0
+          python3 -m pip install --user semgrep==0.106.0
           export PATH="$HOME/.local/bin:$PATH"
 
           echo "$ semgrep --version"

--- a/.circleci/config/commands/setup-semgrep.yml
+++ b/.circleci/config/commands/setup-semgrep.yml
@@ -6,7 +6,7 @@ steps:
       working_directory: ~/
       name: Setup Semgrep
       command: |
-        apk add --no-cache python3 py3-pip make
+        apk add --no-cache python3 python3-dev py3-pip make gcc g++
         python3 -m pip install --user semgrep==0.106.0
         export PATH="$HOME/.local/bin:$PATH"
 

--- a/.circleci/config/commands/setup-semgrep.yml
+++ b/.circleci/config/commands/setup-semgrep.yml
@@ -7,7 +7,7 @@ steps:
       name: Setup Semgrep
       command: |
         apk add --no-cache python3 py3-pip make
-        python3 -m pip install --user semgrep==0.97.0
+        python3 -m pip install --user semgrep==0.106.0
         export PATH="$HOME/.local/bin:$PATH"
 
         echo "$ semgrep --version"


### PR DESCRIPTION
Update to the latest version of [semgrep](https://semgrep.dev/) 0.106.0. 

New dependencies (ujson) are being pulled that now require the environment to have gcc/g++ and python3-dev. Part of me wonders if we should instead switch this to using the upstream docker image: https://hub.docker.com/r/returntocorp/semgrep