### PR TITLE
command/server: add dev-tls flag

### DIFF
--- a/changelog/16421.txt
+++ b/changelog/16421.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+command/server: add `-dev-tls` subcommand to create a Vault dev server with generated certificates and private key.
+```

--- a/changelog/16421.txt
+++ b/changelog/16421.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-command/server: add `-dev-tls` subcommand to create a Vault dev server with generated certificates and private key.
+command/server: add `-dev-tls` and `-dev-tls-cert-dir` subcommands to create a Vault dev server with generated certificates and private key.
 ```

--- a/command/server.go
+++ b/command/server.go
@@ -1100,7 +1100,7 @@ func (c *ServerCommand) Run(args []string) int {
 		if c.flagDevTLS {
 			if c.flagDevTLSCertDir != "" {
 				_, err := os.Stat(c.flagDevTLSCertDir)
-				if err != nil && !os.IsNotExist(err) {
+				if err != nil {
 					c.UI.Error(err.Error())
 					return 1
 				}
@@ -1115,9 +1115,23 @@ func (c *ServerCommand) Run(args []string) int {
 			}
 			config, err = server.DevTLSConfig(devStorageType, certDir)
 
-			defer os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultCAFilename))
-			defer os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultCertFilename))
-			defer os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultKeyFilename))
+			defer func() {
+				err := os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultCAFilename))
+				if err != nil {
+					c.UI.Error(err.Error())
+				}
+
+				err = os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultCertFilename))
+				if err != nil {
+					c.UI.Error(err.Error())
+				}
+
+				err = os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultKeyFilename))
+				if err != nil {
+					c.UI.Error(err.Error())
+				}
+			}()
+
 		} else {
 			config, err = server.DevConfig(devStorageType)
 		}

--- a/command/server.go
+++ b/command/server.go
@@ -257,11 +257,9 @@ func (c *ServerCommand) Flags() *FlagSets {
 	})
 
 	f.StringVar(&StringVar{
-		Name:       "dev-tls-cert-dir",
-		Target:     &c.flagDevTLSCertDir,
-		Default:    "",
-		Completion: complete.PredictDirs("*"),
-		Hidden:     true,
+		Name:    "dev-tls-cert-dir",
+		Target:  &c.flagDevTLSCertDir,
+		Default: "",
 	})
 
 	f.StringVar(&StringVar{

--- a/command/server.go
+++ b/command/server.go
@@ -260,6 +260,8 @@ func (c *ServerCommand) Flags() *FlagSets {
 		Name:    "dev-tls-cert-dir",
 		Target:  &c.flagDevTLSCertDir,
 		Default: "",
+		Usage: "Directory where generated TLS files are created if `-dev-tls` is " +
+			"specified. If left unset, files are generated in a temporary directory.",
 	})
 
 	f.StringVar(&StringVar{

--- a/command/server.go
+++ b/command/server.go
@@ -1130,6 +1130,14 @@ func (c *ServerCommand) Run(args []string) int {
 				if err != nil {
 					c.UI.Error(err.Error())
 				}
+
+				// Only delete temp directories we made.
+				if c.flagDevTLSCertDir == "" {
+					err = os.Remove(certDir)
+					if err != nil {
+						c.UI.Error(err.Error())
+					}
+				}
 			}()
 
 		} else {

--- a/command/server.go
+++ b/command/server.go
@@ -1116,17 +1116,17 @@ func (c *ServerCommand) Run(args []string) int {
 			config, err = server.DevTLSConfig(devStorageType, certDir)
 
 			defer func() {
-				err := os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultCAFilename))
+				err := os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultDevCAFilename))
 				if err != nil {
 					c.UI.Error(err.Error())
 				}
 
-				err = os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultCertFilename))
+				err = os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultDevCertFilename))
 				if err != nil {
 					c.UI.Error(err.Error())
 				}
 
-				err = os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultKeyFilename))
+				err = os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultDevKeyFilename))
 				if err != nil {
 					c.UI.Error(err.Error())
 				}

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -168,15 +168,15 @@ func DevTLSConfig(storageType string) (*Config, string, error) {
 		return nil, "", err
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s/vault-ca.pem", dir), []byte(ca.PEM), 0o644); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/vault-ca.pem", dir), []byte(ca.PEM), 0o444); err != nil {
 		return nil, "", err
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s/vault-cert.pem", dir), []byte(cert), 0o644); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/vault-cert.pem", dir), []byte(cert), 0o400); err != nil {
 		return nil, "", err
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s/vault-key.pem", dir), []byte(key), 0o644); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/vault-key.pem", dir), []byte(key), 0o400); err != nil {
 		return nil, "", err
 	}
 

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -214,7 +214,6 @@ ui = true
 }
 
 func CleanupTLS(dir string) {
-
 }
 
 // Storage is the underlying storage configuration for the server.

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	VaultCAFilename   = "vault-ca.pem"
-	VaultCertFilename = "vault-cert.pem"
-	VaultKeyFilename  = "vault-key.pem"
+	VaultDevCAFilename   = "vault-ca.pem"
+	VaultDevCertFilename = "vault-cert.pem"
+	VaultDevKeyFilename  = "vault-key.pem"
 )
 
 var entConfigValidate = func(_ *Config, _ string) []configutil.ConfigError {
@@ -169,15 +169,15 @@ func DevTLSConfig(storageType, certDir string) (*Config, error) {
 		return nil, err
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, VaultCAFilename), []byte(ca.PEM), 0o444); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, VaultDevCAFilename), []byte(ca.PEM), 0o444); err != nil {
 		return nil, err
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, VaultCertFilename), []byte(cert), 0o400); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, VaultDevCertFilename), []byte(cert), 0o400); err != nil {
 		return nil, err
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, VaultKeyFilename), []byte(key), 0o400); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, VaultDevKeyFilename), []byte(key), 0o400); err != nil {
 		return nil, err
 	}
 

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -213,9 +213,6 @@ ui = true
 	return parsed, nil
 }
 
-func CleanupTLS(dir string) {
-}
-
 // Storage is the underlying storage configuration for the server.
 type Storage struct {
 	Type              string

--- a/command/server/tls_util.go
+++ b/command/server/tls_util.go
@@ -1,0 +1,167 @@
+package server
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"strings"
+	"time"
+)
+
+type CaCert struct {
+	PEM      string
+	Template *x509.Certificate
+	Signer   crypto.Signer
+}
+
+// GenerateCert creates a new leaf cert from provided CA template and signer
+func GenerateCert(caCertTemplate *x509.Certificate, caSigner crypto.Signer) (string, string, error) {
+	// Create the private key
+	signer, keyPEM, err := privateKey()
+	if err != nil {
+		return "", "", err
+	}
+
+	// The serial number for the cert
+	sn, err := serialNumber()
+	if err != nil {
+		return "", "", err
+	}
+
+	// Create the leaf cert
+	template := x509.Certificate{
+		SerialNumber:          sn,
+		Subject:               pkix.Name{CommonName: "Vault server"},
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		NotBefore:             time.Now().Add(-1 * time.Minute),
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	bs, err := x509.CreateCertificate(
+		rand.Reader, &template, caCertTemplate, signer.Public(), caSigner)
+	if err != nil {
+		return "", "", err
+	}
+	var buf bytes.Buffer
+	err = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: bs})
+	if err != nil {
+		return "", "", err
+	}
+
+	return buf.String(), keyPEM, nil
+}
+
+// GenerateCA generates a new self-signed CA cert and returns a
+// CaCert struct containing the PEM encoded cert,
+// X509 Certificate Template, and crypto.Signer
+func GenerateCA() (*CaCert, error) {
+	// Create the private key we'll use for this CA cert.
+	signer, _, err := privateKey()
+	if err != nil {
+		return nil, err
+	}
+
+	// The serial number for the cert
+	sn, err := serialNumber()
+	if err != nil {
+		return nil, err
+	}
+
+	signerKeyId, err := keyId(signer.Public())
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the CA cert
+	template := x509.Certificate{
+		SerialNumber:          sn,
+		Subject:               pkix.Name{CommonName: "Vault CA"},
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:                  true,
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		NotBefore:             time.Now().Add(-1 * time.Minute),
+		AuthorityKeyId:        signerKeyId,
+		SubjectKeyId:          signerKeyId,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	bs, err := x509.CreateCertificate(
+		rand.Reader, &template, &template, signer.Public(), signer)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	err = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: bs})
+	if err != nil {
+		return nil, err
+	}
+	return &CaCert{
+		PEM:      buf.String(),
+		Template: &template,
+		Signer:   signer,
+	}, nil
+}
+
+// privateKey returns a new ECDSA-based private key. Both a crypto.Signer
+// and the key in PEM format are returned.
+func privateKey() (crypto.Signer, string, error) {
+	pk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, "", err
+	}
+
+	bs, err := x509.MarshalECPrivateKey(pk)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var buf bytes.Buffer
+	err = pem.Encode(&buf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: bs})
+	if err != nil {
+		return nil, "", err
+	}
+
+	return pk, buf.String(), nil
+}
+
+// serialNumber generates a new random serial number.
+func serialNumber() (*big.Int, error) {
+	return rand.Int(rand.Reader, (&big.Int{}).Exp(big.NewInt(2), big.NewInt(159), nil))
+}
+
+// keyId returns a x509 KeyId from the given signing key. The key must be
+// an *ecdsa.PublicKey currently, but may support more types in the future.
+func keyId(raw interface{}) ([]byte, error) {
+	switch raw.(type) {
+	case *ecdsa.PublicKey:
+	default:
+		return nil, fmt.Errorf("invalid key type: %T", raw)
+	}
+
+	// This is not standard; RFC allows any unique identifier as long as they
+	// match in subject/authority chains but suggests specific hashing of DER
+	// bytes of public key including DER tags.
+	bs, err := x509.MarshalPKIXPublicKey(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	// String formatted
+	kID := sha256.Sum256(bs)
+	return []byte(strings.Replace(fmt.Sprintf("% x", kID), " ", ":", -1)), nil
+}

--- a/website/content/docs/commands/server.mdx
+++ b/website/content/docs/commands/server.mdx
@@ -70,6 +70,8 @@ flags](/docs/commands) included on all commands.
   in-memory and starts unsealed with a generated TLS CA, certificate and key. 
   As the name implies, do not run "dev" mode in production.
 
+- `-dev-tls-cert-dir` `(string: "")` - Directory where generated TLS files are created if `-dev-tls` is specified. If left unset, files are generated in a temporary directory.
+
 - `-dev-listen-address` `(string: "127.0.0.1:8200")` - Address to bind to in
   "dev" mode. This can also be specified via the `VAULT_DEV_LISTEN_ADDRESS`
   environment variable.

--- a/website/content/docs/commands/server.mdx
+++ b/website/content/docs/commands/server.mdx
@@ -66,6 +66,10 @@ flags](/docs/commands) included on all commands.
   in-memory and starts unsealed. As the name implies, do not run "dev" mode in
   production.
 
+- `-dev-tls` `(bool: false)` - Enable TLS development mode. In this mode, Vault runs
+  in-memory and starts unsealed with a generated TLS CA, certificate and key. 
+  As the name implies, do not run "dev" mode in production.
+
 - `-dev-listen-address` `(string: "127.0.0.1:8200")` - Address to bind to in
   "dev" mode. This can also be specified via the `VAULT_DEV_LISTEN_ADDRESS`
   environment variable.


### PR DESCRIPTION
This adds new server subcommands, `-dev-tls` and `-dev-tls-cert-dir`, which will generate self-signed CA, server certificate, private key and will configure Vault to use them for TLS. This is helpful if you want to do dev work against a TLS enabled server. The generated certs are valid for 1 year.

During startup, the server will output the location of the CA so you can easily set the `VAULT_CACERT` environment variable:

```bash
[~/vault] vault server -dev-tls
==> Vault server configuration:
...
WARNING! dev mode is enabled! In this mode, Vault runs entirely in-memory
and starts unsealed with a single unseal key. The root token is already
authenticated to the CLI, so you can immediately begin using Vault.

You may need to set the following environment variable:

    $ export VAULT_ADDR='https://127.0.0.1:8200'
    $ export VAULT_CACERT='/var/folders/xh/8_phfcd132gfsx4gwbfcnwkm0000gq/T/vault-tls2597705420/vault-ca.pem'
...
```

Additionally you can specify `-dev-tls-cert-dir` to configure the directory where the TLS files are created. This will be helpful for guides and automated environments.