### PR TITLE
Update GCP auth to add support for regional instance groups

### DIFF
--- a/changelog/16435.txt
+++ b/changelog/16435.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/gcp: Add support for regional instance groups
+```

--- a/changelog/16435.txt
+++ b/changelog/16435.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-auth/gcp: Add support for regional instance groups
+auth/gcp: Add support for GCE regional instance groups
 ```

--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-azure v0.11.0
 	github.com/hashicorp/vault-plugin-auth-centrify v0.12.0
 	github.com/hashicorp/vault-plugin-auth-cf v0.12.0
-	github.com/hashicorp/vault-plugin-auth-gcp v0.7.1-0.20220630160554-54acedf4f4f6
+	github.com/hashicorp/vault-plugin-auth-gcp v0.13.2-0.20220722185016-9e4fddb995e5
 	github.com/hashicorp/vault-plugin-auth-jwt v0.7.2-0.20220627215329-c817ca9185c2
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.7.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.13.0
@@ -123,7 +123,7 @@ require (
 	github.com/hashicorp/vault/api v1.7.2
 	github.com/hashicorp/vault/api/auth/approle v0.1.0
 	github.com/hashicorp/vault/api/auth/userpass v0.1.0
-	github.com/hashicorp/vault/sdk v0.5.1
+	github.com/hashicorp/vault/sdk v0.5.3
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/jackc/pgx/v4 v4.15.0
 	github.com/jcmturner/gokrb5/v8 v8.4.2

--- a/go.sum
+++ b/go.sum
@@ -1024,8 +1024,8 @@ github.com/hashicorp/vault-plugin-auth-centrify v0.12.0 h1:d2dDZoUlSBNiw+jfi/2wx
 github.com/hashicorp/vault-plugin-auth-centrify v0.12.0/go.mod h1:3fDbIVdwA/hkOVhwktKHDX5lo4DqIUUVbBdwQNNvxHw=
 github.com/hashicorp/vault-plugin-auth-cf v0.12.0 h1:8X3Zlc6P/ih0MVhrPJ54iwiCyMVIcLwfBVpONuYddks=
 github.com/hashicorp/vault-plugin-auth-cf v0.12.0/go.mod h1:dr0cewrZ0SgpsPFkQ7Vf31J4xg+ylxM3Yv+dk1zWpEQ=
-github.com/hashicorp/vault-plugin-auth-gcp v0.7.1-0.20220630160554-54acedf4f4f6 h1:Z+nJ8c6rDlLAP+6S0U5pE0E8FY8FKrJrx3CsU6GdKNg=
-github.com/hashicorp/vault-plugin-auth-gcp v0.7.1-0.20220630160554-54acedf4f4f6/go.mod h1:4urKIVIzGNC8QKz/Iw1T00hIrHNswp9/5tkAwA8s60o=
+github.com/hashicorp/vault-plugin-auth-gcp v0.13.2-0.20220722185016-9e4fddb995e5 h1:uP0e9k8hIMfbWbeMKp6LxdRasxFBg4hTWaTmxDiwXZc=
+github.com/hashicorp/vault-plugin-auth-gcp v0.13.2-0.20220722185016-9e4fddb995e5/go.mod h1:WNwaZN7NWy14xcy3otm1OXp5blcKgblUfvE16eYeUoQ=
 github.com/hashicorp/vault-plugin-auth-jwt v0.7.2-0.20220627215329-c817ca9185c2 h1:f3kLhtR7PBUqGwlXVdPlixDTtMnnKZOTdWsE1cl2kUw=
 github.com/hashicorp/vault-plugin-auth-jwt v0.7.2-0.20220627215329-c817ca9185c2/go.mod h1:rb34Dyl/7t+ERmpyqqZaeLQUmMCKrbExrw7RxOLc9G8=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.7.0 h1:6iQIiF4usqBwXZmab3rpq/dMIw+np+DFbIBxC3r6Ybw=


### PR DESCRIPTION
Manual test steps documented below for the new feature. A GCE instance group was created in the us-east1 region with 1 running instance for the test. Then the same steps were performed on a us-central1 instance to demonstrate failure.

Setup steps:
```
vault policy write gce-reader gce-reader.hcl
vault kv put secret/gcp-info/key name="secret" value="abc"

vault auth enable gcp

vault write auth/gcp/config \
credentials=@credentials.json

vault write auth/gcp/role/reader \
type="gce" \
policies="gce-reader" \
bound_regions="us-east1" \
bound_instance_groups="my-region-group" \
```

New session steps:
```
vault login \
-method=gcp \
role=reader

vault kv get secret/gcp-info/key
```

Success output:
```
robmonte@my-region-group-pdfb:~$ vault login -method=gcp role=reader
Success! You are now authenticated. The token information displayed below
is already stored in the token helper. You do NOT need to run "vault login"
again. Future Vault requests will automatically use this token.

⋮

robmonte@my-region-group-pdfb:~$ vault kv get secret/gcp-info/key
====== Secret Path ======
secret/data/gcp-info/key
⋮
==== Data ====
Key      Value
---      -----
name     secret
value    abc
```

Failure output:
```
robmonte@instance-1:~$ vault login -method=gcp role=admin
Error authenticating: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/auth/gcp/login
Code: 400. Errors:

* instance not in bound regions ["us-east1"]
```