### PR TITLE
ignore leading slash in kv get command

### DIFF
--- a/changelog/16443.txt
+++ b/changelog/16443.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/kv: Fix `kv get` issue preventing the ability to read a secret when providing a leading slash
+```

--- a/command/kv_get.go
+++ b/command/kv_get.go
@@ -116,16 +116,16 @@ func (c *KVGetCommand) Run(args []string) int {
 	mountFlagSyntax := (c.flagMount != "")
 
 	var (
-		mountPath   string
-		partialPath string
-		v2          bool
+		mountPath string
+		v2        bool
 	)
+
+	// Ignore leading slash
+	partialPath := strings.TrimPrefix(args[0], "/")
 
 	// Parse the paths and grab the KV version
 	if mountFlagSyntax {
 		// In this case, this arg is the secret path (e.g. "foo").
-		partialPath = args[0]
-
 		mountPath = sanitizePath(c.flagMount)
 		_, v2, err = isKVv2(mountPath, client)
 		if err != nil {
@@ -135,8 +135,6 @@ func (c *KVGetCommand) Run(args []string) int {
 	} else {
 		// In this case, this arg is a path-like combination of mountPath/secretPath.
 		// (e.g. "secret/foo")
-		partialPath = args[0]
-
 		mountPath, v2, err = isKVv2(partialPath, client)
 		if err != nil {
 			c.UI.Error(err.Error())

--- a/command/kv_test.go
+++ b/command/kv_test.go
@@ -459,6 +459,12 @@ func TestKVGetCommand(t *testing.T) {
 			0,
 		},
 		{
+			"v2_mount_flag_syntax_leading_slash",
+			[]string{"-mount", "kv", "/read/foo"},
+			append(baseV2ExpectedFields, "foo"),
+			0,
+		},
+		{
 			"v2_not_found",
 			[]string{"kv/nope/not/once/never"},
 			[]string{"No value found at kv/data/nope/not/once/never"},
@@ -467,6 +473,12 @@ func TestKVGetCommand(t *testing.T) {
 		{
 			"v2_read",
 			[]string{"kv/read/foo"},
+			append(baseV2ExpectedFields, "foo"),
+			0,
+		},
+		{
+			"v2_read_leading_slash",
+			[]string{"/kv/read/foo"},
 			append(baseV2ExpectedFields, "foo"),
 			0,
 		},


### PR DESCRIPTION
Handling of leading slashes was not consistent in the `vault kv get` command. This can be fixed by simply ignoring the leading slash of the requested path. The following will all successfully fetch a secret at path `secret/foo`:

```
vault kv get /secret/foo

vault kv get secret/foo

vault kv get -mount=secret /foo

vault kv get -mount=secret foo
```

Fixes https://github.com/hashicorp/vault/issues/16238