### PR TITLE
Added list view for keys

### DIFF
--- a/ui/app/routes/vault/cluster/access/oidc/keys/index.js
+++ b/ui/app/routes/vault/cluster/access/oidc/keys/index.js
@@ -1,3 +1,12 @@
 import Route from '@ember/routing/route';
-
-export default class OidcKeysRoute extends Route {}
+export default class OidcKeysRoute extends Route {
+  model() {
+    return this.store.query('oidc/key', {}).catch((err) => {
+      if (err.httpStatus === 404) {
+        return [];
+      } else {
+        throw err;
+      }
+    });
+  }
+}

--- a/ui/app/templates/vault/cluster/access/oidc/keys/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/index.hbs
@@ -1,0 +1,49 @@
+<Toolbar>
+  <ToolbarActions>
+    <ToolbarLink @type="add" @params={{array "vault.cluster.access.oidc.keys.create"}}>
+      Create key
+    </ToolbarLink>
+  </ToolbarActions>
+</Toolbar>
+{{#each this.model as |model|}}
+  <LinkedBlock class="list-item-row" @params={{array "vault.cluster.access.oidc.keys.key.details" model.name}}>
+    <div class="level is-mobile">
+      <div class="level-left">
+        <div>
+          <Icon @name="key" class="has-text-grey-light" />
+          <span class="has-text-weight-semibold is-underline">
+            {{model.name}}
+          </span>
+        </div>
+      </div>
+      <div class="level-right is-flex is-paddingless is-marginless">
+        <div class="level-item">
+          <PopupMenu>
+            <nav class="menu">
+              <ul class="menu-list">
+                <li>
+                  <LinkTo
+                    @route="vault.cluster.access.oidc.keys.key.details"
+                    @model={{model.name}}
+                    @disabled={{not model.canRead}}
+                  >
+                    Details
+                  </LinkTo>
+                </li>
+                <li>
+                  <LinkTo
+                    @route="vault.cluster.access.oidc.keys.key.edit"
+                    @model={{model.name}}
+                    @disabled={{not model.canEdit}}
+                  >
+                    Edit
+                  </LinkTo>
+                </li>
+              </ul>
+            </nav>
+          </PopupMenu>
+        </div>
+      </div>
+    </div>
+  </LinkedBlock>
+{{/each}}


### PR DESCRIPTION
Added list view for keys. There is always a default key which cannot be deleted but can be edited so there is no empty state for the list view. Since this default key cannot be deleted but only edited, the deleted button will be greyed out in the details view with a tooltip note instead.
<img width="1040" alt="Screen Shot 2022-07-26 at 2 24 38 PM" src="https://user-images.githubusercontent.com/57650314/181083074-06a2bfa7-9290-48ec-aebf-28ef221eeaff.png">

