### PR TITLE
move custom metadata validation logic to its own package

### DIFF
--- a/sdk/helper/custommetadata/custom_metadata.go
+++ b/sdk/helper/custommetadata/custom_metadata.go
@@ -7,8 +7,12 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 )
 
+// CustomMetadata should be arbitrary user-provided key-value pairs meant to
+// provide supplemental information about a resource.
 type CustomMetadata map[string]string
 
+// The following constants are used by Validate and are meant to be imposed
+// broadly for consistency.
 const (
 	maxKeys               = 64
 	maxKeyLength          = 128
@@ -16,6 +20,14 @@ const (
 	validationErrorPrefix = "custom_metadata validation failed"
 )
 
+// Validate will perform input validation for custom metadata. If the key count
+// exceeds maxKeys, the validation will be short-circuited to prevent
+// unnecessary (and potentially costly) validation to be run. If the key count
+// falls at or below maxKeys, multiple checks will be made per key and value.
+// These checks include:
+//   - 0 < length of key <= maxKeyLength
+//   - 0 < length of value <= maxValueLength
+//   - keys and values cannot include unprintable characters
 func Validate(cm CustomMetadata) error {
 	var errs *multierror.Error
 

--- a/sdk/helper/custommetadata/custom_metadata.go
+++ b/sdk/helper/custommetadata/custom_metadata.go
@@ -1,0 +1,66 @@
+package custommetadata
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-secure-stdlib/strutil"
+)
+
+type CustomMetadata map[string]string
+
+const (
+	maxKeys               = 64
+	maxKeyLength          = 128
+	maxValueLength        = 512
+	validationErrorPrefix = "custom_metadata validation failed"
+)
+
+func Validate(cm CustomMetadata) error {
+	var errs *multierror.Error
+
+	if keyCount := len(cm); keyCount > maxKeys {
+		errs = multierror.Append(errs, fmt.Errorf("%s: payload must contain at most %d keys, provided %d",
+			validationErrorPrefix,
+			maxKeys,
+			keyCount))
+
+		return errs.ErrorOrNil()
+	}
+
+	// Perform validation on each key and value and return ALL errors
+	for key, value := range cm {
+		if keyLen := len(key); 0 == keyLen || keyLen > maxKeyLength {
+			errs = multierror.Append(errs, fmt.Errorf("%s: length of key %q is %d but must be 0 < len(key) <= %d",
+				validationErrorPrefix,
+				key,
+				keyLen,
+				maxKeyLength))
+		}
+
+		if valueLen := len(value); 0 == valueLen || valueLen > maxValueLength {
+			errs = multierror.Append(errs, fmt.Errorf("%s: length of value for key %q is %d but must be 0 < len(value) <= %d",
+				validationErrorPrefix,
+				key,
+				valueLen,
+				maxValueLength))
+		}
+
+		if !strutil.Printable(key) {
+			// Include unquoted format (%s) to also include the string without the unprintable
+			//  characters visible to allow for easier debug and key identification
+			errs = multierror.Append(errs, fmt.Errorf("%s: key %q (%s) contains unprintable characters",
+				validationErrorPrefix,
+				key,
+				key))
+		}
+
+		if !strutil.Printable(value) {
+			errs = multierror.Append(errs, fmt.Errorf("%s: value for key %q contains unprintable characters",
+				validationErrorPrefix,
+				key))
+		}
+	}
+
+	return errs.ErrorOrNil()
+}

--- a/sdk/helper/custommetadata/custom_metadata_test.go
+++ b/sdk/helper/custommetadata/custom_metadata_test.go
@@ -1,0 +1,85 @@
+package custommetadata
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      CustomMetadata
+		shouldPass bool
+	}{
+		{
+			"valid",
+			CustomMetadata{
+				"foo": "abc",
+				"bar": "def",
+				"baz": "ghi",
+			},
+			true,
+		},
+		{
+			"too_many_keys",
+			func() CustomMetadata {
+				cm := make(CustomMetadata)
+
+				for i := 0; i < maxKeyLength+1; i++ {
+					s := strconv.Itoa(i)
+					cm[s] = s
+				}
+
+				return cm
+			}(),
+			false,
+		},
+		{
+			"key_too_long",
+			CustomMetadata{
+				strings.Repeat("a", maxKeyLength+1): "abc",
+			},
+			false,
+		},
+		{
+			"value_too_long",
+			CustomMetadata{
+				"foo": strings.Repeat("a", maxValueLength+1),
+			},
+			false,
+		},
+		{
+			"unprintable_key",
+			CustomMetadata{
+				"unprint\u200bable": "abc",
+			},
+			false,
+		},
+		{
+			"unprintable_value",
+			CustomMetadata{
+				"foo": "unprint\u200bable",
+			},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := Validate(tc.input)
+
+			if tc.shouldPass && err != nil {
+				t.Fatalf("expected validation to pass, input: %#v, err: %v", tc.input, err)
+			}
+
+			if !tc.shouldPass && err == nil {
+				t.Fatalf("expected validation to fail, input: %#v, err: %v", tc.input, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Custom metadata is a concept that has been included in multiple features including KVv2 metadata and identity aliases. Issue #16217 outlines an enhancement request to include it for namespace entries. Including it within storage entries is generally straightforward and it likely makes sense to impose the same limits across all of Vault to ensure a consistent UX. This PR moves the constants and validation logic from the identity alias logic (which was initially lifted from KVv2 metadata) into its own package so that it can be used in a consistent way across Vault.