### PR TITLE
UI/remove has many relationship

### DIFF
--- a/ui/app/components/oidc/assignment-form.js
+++ b/ui/app/components/oidc/assignment-form.js
@@ -3,7 +3,6 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
-import handleHasManySelection from 'core/utils/search-select-has-many';
 
 /**
  * @module Oidc::AssignmentForm
@@ -26,55 +25,7 @@ import handleHasManySelection from 'core/utils/search-select-has-many';
 export default class OidcAssignmentFormComponent extends Component {
   @service store;
   @service flashMessages;
-
-  targetTypes = [
-    { label: 'Entity', type: 'identity/entity', key: 'entity_ids' },
-    { label: 'Group', type: 'identity/group', key: 'groups_ids' },
-  ];
-
   @tracked modelValidations;
-  @tracked targets = [];
-
-  constructor() {
-    super(...arguments);
-    // aggregate different target array properties on model into flat list
-    this.flattenTargets();
-    // eagerly fetch identity groups and entities for use as search select options
-    this.resetTargetState();
-  }
-  // ARG TODO these functions are similar to the one used in MFA. Making a ticket to turn into a util/helper.
-  async flattenTargets() {
-    if (!this.args.model) {
-      return;
-    }
-    for (let { label, key } of this.targetTypes) {
-      const targetArray = await this.args.model[key];
-      if (typeof targetArray !== 'object') {
-        return;
-      }
-      const targets = targetArray.map((value) => ({ label, key, value }));
-      this.targets.addObjects(targets);
-    }
-  }
-  async resetTargetState() {
-    this.selectedTargetValue = null;
-    const options = this.searchSelectOptions || {};
-    if (!this.searchSelectOptions) {
-      const types = ['identity/group', 'identity/entity'];
-      for (const type of types) {
-        try {
-          options[type] = (await this.store.query(type, {})).toArray();
-        } catch (error) {
-          options[type] = [];
-        }
-      }
-      this.searchSelectOptions = options;
-    }
-  }
-
-  get selectedTarget() {
-    return this.targetTypes.findBy('type', this.selectedTargetType);
-  }
 
   @task
   *save(event) {
@@ -101,27 +52,17 @@ export default class OidcAssignmentFormComponent extends Component {
   }
 
   @action
-  handleOperation(e) {
-    const value = e.target.value;
-    this.args.model.name = value;
+  handleOperation({ target }) {
+    this.args.model.name = target.value;
   }
 
   @action
-  async onEntitiesSelect(selectedIds) {
-    const entityIds = await this.args.model.entity_ids;
-    handleHasManySelection(selectedIds, entityIds, this.store, 'identity/entity');
+  onEntitiesSelect(selectedIds) {
+    this.args.model.entityIds = selectedIds;
   }
 
   @action
-  async onGroupsSelect(selectedIds) {
-    const groupIds = await this.args.model.group_ids;
-    handleHasManySelection(selectedIds, groupIds, this.store, 'identity/group');
-  }
-
-  @action
-  removeTarget(target) {
-    this.targets.removeObject(target);
-    // remove target from appropriate model property
-    this.args.model[target.key].removeObject(target.value);
+  onGroupsSelect(selectedIds) {
+    this.args.model.groupIds = selectedIds;
   }
 }

--- a/ui/app/models/oidc/assignment.js
+++ b/ui/app/models/oidc/assignment.js
@@ -1,4 +1,4 @@
-import Model, { attr, hasMany } from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 import ArrayProxy from '@ember/array/proxy';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
@@ -8,11 +8,10 @@ import { isPresent } from '@ember/utils';
 const validations = {
   name: [
     { type: 'presence', message: 'Name is required.' },
-    // ARG TODO add in after Claire pushes her branch
-    // {
-    //   type: 'containsWhiteSpace',
-    //   message: 'Name cannot contain whitespace.',
-    // },
+    {
+      type: 'containsWhiteSpace',
+      message: 'Name cannot contain whitespace.',
+    },
   ],
   targets: [
     {
@@ -29,17 +28,8 @@ const validations = {
 @withModelValidations(validations)
 export default class OidcAssignmentModel extends Model {
   @attr('string') name;
-  @hasMany('identity/entity') entity_ids;
-  @hasMany('identity/group') group_ids;
-
-  @lazyCapabilities(apiPath`identity/oidc/assignment/${'name'}`, 'name') assignmentPath;
-  @lazyCapabilities(apiPath`identity/oidc/assignment`) assignmentsPath;
-
-  get targets() {
-    return ArrayProxy.extend(PromiseProxyMixin).create({
-      promise: this.prepareTargets(),
-    });
-  }
+  @attr('identity/entity') entity_ids;
+  @attr('identity/group') group_ids;
 
   async prepareTargets() {
     const targets = [];
@@ -56,6 +46,16 @@ export default class OidcAssignmentModel extends Model {
 
     return targets;
   }
+
+  get targets() {
+    return ArrayProxy.extend(PromiseProxyMixin).create({
+      promise: this.prepareTargets(),
+    });
+  }
+
+  // CAPABILITIES
+  @lazyCapabilities(apiPath`identity/oidc/assignment/${'name'}`, 'name') assignmentPath;
+  @lazyCapabilities(apiPath`identity/oidc/assignment`) assignmentsPath;
 
   get canCreate() {
     return this.assignmentPath.get('canCreate');

--- a/ui/app/models/oidc/client.js
+++ b/ui/app/models/oidc/client.js
@@ -4,11 +4,7 @@ import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 import fieldToAttrs from '../../utils/field-to-attrs';
 
 export default class OidcClientModel extends Model {
-  @attr('string', {
-    label: 'Application name',
-  })
-  name;
-
+  @attr('string', { label: 'Application name' }) name;
   @attr('string', {
     label: 'Type',
     subText: 'Specify whether the application type is confidential or public. The public type must use PKCE.',
@@ -27,12 +23,17 @@ export default class OidcClientModel extends Model {
 
   // >> MORE OPTIONS TOGGLE <<
 
-  // might be a good candidate for using @belongsTo relationship?
   @attr('string', {
     label: 'Signing key',
     subText: 'Add a key to sign and verify the JSON web tokens (JWT). This cannot be edited later.',
     editType: 'searchSelect',
-    fallbackComponent: 'string-list',
+    editDisabled: true,
+    disallowNewItems: true,
+    defaultValue() {
+      return ['default'];
+    },
+    fallbackComponent: 'input-search',
+    selectLimit: 1,
     models: ['oidc/key'],
   })
   key;
@@ -41,6 +42,7 @@ export default class OidcClientModel extends Model {
     label: 'Access Token TTL',
     editType: 'ttl',
     helperTextDisabled: 'Vault will use the default lease duration',
+    setDefault: false,
   })
   accessTokenTtl;
 
@@ -48,35 +50,22 @@ export default class OidcClientModel extends Model {
     label: 'ID Token TTL',
     editType: 'ttl',
     helperTextDisabled: 'Vault will use the default lease duration',
+    setDefault: false,
   })
   idTokenTtl;
 
   // >> END MORE OPTIONS TOGGLE <<
 
-  // form has a radio option to allow_all (default), or limit access to selected 'assignment'
-  // if limited, expose search-select to select or create new and add via modal
-  @attr('array', {
-    label: 'Assign access',
-    editType: 'searchSelect',
-  })
-  assignments; // might be a good candidate for @hasMany relationship instead of @attr
+  @attr('array', { label: 'Assign access' }) assignments; // no editType because does not use form-field component
+  @attr('string', { label: 'Client ID' }) clientId;
+  @attr('string') clientSecret;
 
-  @attr('string', {
-    label: 'Client ID',
-  })
-  clientId;
+  // TODO API WIP - attr TBD, current PR proposes the following:
+  // $ curl -H "X-Vault-Token: ..." -X LIST http://127.0.0.1:8200/v1/identity/oidc/provider?allowed_client_id="<client_id>"
+  // add to model on route? or query from tab in UI?
+  @attr('string', { label: 'Providers' }) providers;
 
-  @attr('string', {
-    label: 'Client Secret',
-  })
-  clientSecret;
-
-  // API WIP - param TBD
-  @attr('string', {
-    label: 'Providers',
-  })
-  provider_ds; // might be a good candidate for @hasMany relationship instead of @attr
-
+  // CAPABILITIES //
   @lazyCapabilities(apiPath`identity/oidc/client/${'name'}`, 'name') clientPath;
   @lazyCapabilities(apiPath`identity/oidc/client`) clientsPath;
   get canCreate() {

--- a/ui/app/models/oidc/key.js
+++ b/ui/app/models/oidc/key.js
@@ -10,11 +10,7 @@ export default class OidcKeyModel extends Model {
   })
   algorithm;
 
-  @attr({
-    editType: 'ttl',
-    helperTextDisabled: 'Vault will use the default lease duration',
-  })
-  rotationPeriod;
+  @attr({ editType: 'ttl', helperTextDisabled: 'Vault will use the default lease duration' }) rotationPeriod;
 
   @attr({
     label: 'Verification TTL',
@@ -24,11 +20,7 @@ export default class OidcKeyModel extends Model {
   })
   verificationTtl;
 
-  @attr('array', {
-    label: 'Allowed applications',
-    editType: 'stringArray',
-  })
-  allowedClientIds;
+  @attr('array', { label: 'Allowed applications' }) allowedClientIds; // no editType because does not use form-field component
 
   @lazyCapabilities(apiPath`identity/oidc/key/${'name'}`, 'name') keyPath;
   @lazyCapabilities(apiPath`identity/oidc/key`) keysPath;

--- a/ui/app/models/oidc/provider.js
+++ b/ui/app/models/oidc/provider.js
@@ -1,25 +1,11 @@
-import Model, { attr, hasMany } from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 
 export default class OidcProviderModel extends Model {
-  @hasMany('oidc/scope') scopes_supported;
   @attr('string') name;
-  @attr('string', {
-    label: 'Issuer URL',
-  })
-  issuer;
-
-  @attr('array', {
-    editType: 'searchSelect',
-  })
-  scopesSupported; // potential candidate for @hasMany relationship
-
-  // form has a radio option to allow_all, or limit access to selected 'application'
-  // if limited, expose assignment dropdown and add via search-select
-  @attr('array', {
-    editType: 'searchSelect',
-  })
-  allowedClientIds; // potential candidate for @hasMany relationship
+  @attr('string', { label: 'Issuer UR' }) issuer;
+  @attr('array', { label: 'Supported scopes', editType: 'searchSelect' }) scopesSupported;
+  @attr('array', { label: 'Allowed applications' }) allowedClientIds; // no editType because does not use form-field component
 
   @lazyCapabilities(apiPath`identity/oidc/provider/${'name'}`, 'name') providerPath;
   @lazyCapabilities(apiPath`identity/oidc/provider`) providersPath;

--- a/ui/app/templates/components/oidc/assignment-form.hbs
+++ b/ui/app/templates/components/oidc/assignment-form.hbs
@@ -42,33 +42,29 @@
         <AlertInline @type="danger" @message={{join ", " this.modelValidations.name.errors}} />
       {{/if}}
       {{#if (or @model.canListEntities @model.canListGroups)}}
-        {{#if @model.entity_ids.isFulfilled}}
-          <SearchSelect
-            @id="entities"
-            @label="Entities"
-            @labelClass="is-label"
-            @placeholder="Search"
-            @models={{array "identity/entity"}}
-            @inputValue={{map-by "id" @model.entity_ids}}
-            @shouldRenderName={{true}}
-            @onChange={{this.onEntitiesSelect}}
-            @disallowNewItems={{true}}
-            data-test-search-select="entities"
-          />
-        {{/if}}
-        {{#if @model.group_ids.isFulfilled}}
-          <SearchSelect
-            @id="groups"
-            @label="Groups"
-            @labelClass="is-label"
-            @placeholder="Search"
-            @models={{array "identity/group"}}
-            @inputValue={{map-by "id" @model.group_ids}}
-            @shouldRenderName={{true}}
-            @onChange={{this.onGroupsSelect}}
-            @disallowNewItems={{true}}
-          />
-        {{/if}}
+        <SearchSelect
+          @id="entities"
+          @label="Entities"
+          @labelClass="is-label"
+          @placeholder="Search"
+          @models={{array "identity/entity"}}
+          @inputValue={{map-by "id" @model.entityIds}}
+          @shouldRenderName={{true}}
+          @onChange={{this.onEntitiesSelect}}
+          @disallowNewItems={{true}}
+          data-test-search-select="entities"
+        />
+        <SearchSelect
+          @id="groups"
+          @label="Groups"
+          @labelClass="is-label"
+          @placeholder="Search"
+          @models={{array "identity/group"}}
+          @inputValue={{map-by "id" @model.groupIds}}
+          @shouldRenderName={{true}}
+          @onChange={{this.onGroupsSelect}}
+          @disallowNewItems={{true}}
+        />
       {{else}}
         <EmptyState
           @title="Permissions error"

--- a/ui/app/templates/components/oidc/assignment-form.hbs
+++ b/ui/app/templates/components/oidc/assignment-form.hbs
@@ -48,7 +48,7 @@
           @labelClass="is-label"
           @placeholder="Search"
           @models={{array "identity/entity"}}
-          @inputValue={{map-by "id" @model.entityIds}}
+          @inputValue={{@model.entityIds}}
           @shouldRenderName={{true}}
           @onChange={{this.onEntitiesSelect}}
           @disallowNewItems={{true}}
@@ -60,10 +60,11 @@
           @labelClass="is-label"
           @placeholder="Search"
           @models={{array "identity/group"}}
-          @inputValue={{map-by "id" @model.groupIds}}
+          @inputValue={{@model.groupIds}}
           @shouldRenderName={{true}}
           @onChange={{this.onGroupsSelect}}
           @disallowNewItems={{true}}
+          data-test-search-select="groups"
         />
       {{else}}
         <EmptyState

--- a/ui/tests/integration/components/oidc/assignment-form-test.js
+++ b/ui/tests/integration/components/oidc/assignment-form-test.js
@@ -60,11 +60,13 @@ module('Integration | Component | oidc/assignment-form', function (hooks) {
   });
 
   test('it should populate fields with model data on edit view and update an assignment', async function (assert) {
-    assert.expect(5);
+    assert.expect(6);
 
     this.store.pushPayload('oidc/assignment', {
       modelName: 'oidc/assignment',
       name: 'test',
+      entity_ids: ['1234-12345'],
+      group_ids: ['abcdef-123'],
     });
     this.model = this.store.peekRecord('oidc/assignment', 'test');
     // override capability getters
@@ -72,8 +74,6 @@ module('Integration | Component | oidc/assignment-form', function (hooks) {
       canListGroups: { value: true },
       canListEntities: { value: true },
     });
-    const [group] = (await this.store.query('identity/group', {})).toArray();
-    this.model.group_ids.addObject(group);
     await render(hbs`
       <Oidc::AssignmentForm
         @model={{this.model}}
@@ -86,10 +86,12 @@ module('Integration | Component | oidc/assignment-form', function (hooks) {
     assert.dom('[data-test-oidc-assignment-save]').hasText('Update', 'Save button has correct label');
     assert.dom('[data-test-input="name"]').isDisabled('Name input is disabled when editing');
     assert.dom('[data-test-input="name"]').hasValue('test', 'Name input is populated with model value');
-    assert.dom('[data-test-smaller-id="true"]').hasText('abcdef-123', 'group id renders in selected option');
-
-    await click('[data-test-component="search-select"] .ember-basic-dropdown-trigger');
-    await click('.ember-power-select-option');
+    assert
+      .dom('[data-test-search-select="entities"] [data-test-smaller-id="true"]')
+      .hasText('1234-12345', 'entity id renders in selected option');
+    assert
+      .dom('[data-test-search-select="groups"] [data-test-smaller-id="true"]')
+      .hasText('abcdef-123', 'group id renders in selected option');
   });
 
   test('it should not show an error message if permissions shows at least entities or groups', async function (assert) {


### PR DESCRIPTION
After team discussion, we decided that leveraging Ember relationships for models created unnecessary complication when permissions are involved. 

For example, if a user has read capabilities for a `Group` model they should be able to read all the params for that record: 
```
// sample response for a Group record
data: {
 name: "Some-group",
 users: ["user-1", "user-2"],
}
```
If `Group` has a `hasMany` relationship with the `User` model then Ember data intercepts and makes that attribute a `PromiseArray`, rather than an array of strings. We hoped this would simplify things by leveraging Ember to make requests under the hood. The problem is if a user doesn't have `LIST` or `READ` capabilities for `User`, then the request fails and that attribute will not be available on the `Group` record - which is unintuitive as they _do_ have permissions to view a `Group` record.

While there are workarounds, it does't feel worth it to further complicate permissions - which are already a complex aspect of the Vault UI.