### PR TITLE
re-add namespace attribution to current month

### DIFF
--- a/changelog/16447.txt
+++ b/changelog/16447.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-activity: Add timestamp to current month calculation and remove deduplication for current month
-```

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1576,11 +1576,13 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 		// the namespaces from it.
 		currentMonthNamespaceAttribution := a.transformMonthBreakdowns(partialByMonth)
 		// Ensure that there is only one element in this list -- if not, warn.
-		if len(currentMonthNamespaceAttribution) != 1 {
+		if len(currentMonthNamespaceAttribution) > 1 {
 			a.logger.Warn("more than one month worth of namespace and mount attribution calculated for "+
 				"current month values", "number of months", len(currentMonthNamespaceAttribution))
 		}
-		if len(currentMonthNamespaceAttribution) > 0 {
+		if len(currentMonthNamespaceAttribution) == 0 {
+			a.logger.Warn("no month data found, returning query with no namespace attribution for current month")
+		} else {
 			currentMonth.Namespaces = currentMonthNamespaceAttribution[0].Namespaces
 		}
 		pq.Months = append(pq.Months, currentMonth)

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1570,6 +1570,19 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 		if err != nil {
 			return nil, err
 		}
+		// Add the namespace attribution for the current month to the newly computed current month value. Note
+		// that transformMonthBreakdowns calculates a superstruct of the required namespace struct due to its
+		// primary use-case being for precomputedQueryWorker, but we will reuse this code for brevity and extract
+		// the namespaces from it.
+		currentMonthNamespaceAttribution := a.transformMonthBreakdowns(partialByMonth)
+		// Ensure that there is only one element in this list -- if not, warn.
+		if len(currentMonthNamespaceAttribution) != 1 {
+			a.logger.Warn("more than one month worth of namespace and mount attribution calculated for "+
+				"current month values", "number of months", len(currentMonthNamespaceAttribution))
+		}
+		if len(currentMonthNamespaceAttribution) > 0 {
+			currentMonth.Namespaces = currentMonthNamespaceAttribution[0].Namespaces
+		}
 		pq.Months = append(pq.Months, currentMonth)
 		distinctEntitiesResponse += pq.Months[len(pq.Months)-1].NewClients.Counts.EntityClients
 	}


### PR DESCRIPTION
Deleted changelog for https://github.com/hashicorp/vault/pull/16447/files as it's a bug fix before feature release. 

Tests for HandleQuery must be in Ent: https://github.com/hashicorp/vault-enterprise/pull/3081/files