### PR TITLE
changelog: Add entry for AD secrets engine bug fix

### DIFF
--- a/changelog/16140.txt
+++ b/changelog/16140.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/ad: set config default length only if password_policy is missing
+```


### PR DESCRIPTION
This PR adds a changelog entry for the fix that's addressed by the plugin version bump in #16140.