### PR TITLE
Lookup, wrap, rewrap and unwrap token rename with description

### DIFF
--- a/changelog/16489.txt
+++ b/changelog/16489.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+ui: Renamed labels under Tools for wrap, lookup, rewrap and unwrap with description.
+```

--- a/changelog/16489.txt
+++ b/changelog/16489.txt
@@ -1,3 +1,3 @@
-```release-note:enhancement
+```release-note:improvement
 ui: Renamed labels under Tools for wrap, lookup, rewrap and unwrap with description.
 ```

--- a/ui/app/templates/components/tool-lookup.hbs
+++ b/ui/app/templates/components/tool-lookup.hbs
@@ -28,7 +28,10 @@
     <NamespaceReminder @mode="perform" @noun={{@selectedAction}} />
     <MessageError @errors={{@errors}} />
     <div class="field">
-      <label for="token" class="is-label">Wrapping token</label>
+      <label for="token" class="is-label">Wrapped token</label>
+      <div class="has-text-grey is-size-8">
+        Enter your wrapped token here to display its information.
+      </div>
       <div class="control">
         <Input @value={{@token}} class="input" id="token" name="token" data-test-tools-input="wrapping-token" />
       </div>

--- a/ui/app/templates/components/tool-lookup.hbs
+++ b/ui/app/templates/components/tool-lookup.hbs
@@ -29,7 +29,7 @@
     <MessageError @errors={{@errors}} />
     <div class="field">
       <label for="token" class="is-label">Wrapped token</label>
-      <div class="has-text-grey is-size-8">
+      <div class="has-text-grey is-size-8 has-bottom-margin-xs">
         Enter your wrapped token here to display its information.
       </div>
       <div class="control">

--- a/ui/app/templates/components/tool-rewrap.hbs
+++ b/ui/app/templates/components/tool-rewrap.hbs
@@ -44,7 +44,10 @@
     <NamespaceReminder @mode="perform" @noun={{@selectedAction}} />
     <MessageError @errors={{@errors}} />
     <div class="field">
-      <label for="token" class="is-label">Wrapping token</label>
+      <label for="token" class="is-label">Wrapped token</label>
+      <div class="has-text-grey is-size-8 has-bottom-margin-xs">
+        Enter your wrapped token here to rewrap it and refresh its TTL.
+      </div>
       <div class="control">
         <Input @value={{@token}} class="input" id="token" name="token" data-test-tools-input="wrapping-token" />
       </div>

--- a/ui/app/templates/components/tool-unwrap.hbs
+++ b/ui/app/templates/components/tool-unwrap.hbs
@@ -86,7 +86,10 @@
     <NamespaceReminder @mode="perform" @noun={{@selectedAction}} />
     <MessageError @errors={{@errors}} />
     <div class="field">
-      <label for="token" class="is-label">Wrapping token</label>
+      <label for="token" class="is-label">Wrapped token</label>
+      <div class="has-text-grey is-size-8 has-bottom-margin-xs">
+        Enter your wrapped token here to unwrap it and return its original value.
+      </div>
       <div class="control">
         <Input
           @value={{@token}}

--- a/ui/app/templates/components/tool-wrap.hbs
+++ b/ui/app/templates/components/tool-wrap.hbs
@@ -9,7 +9,7 @@
 {{#if @token}}
   <div class="box is-sideless is-fullwidth is-marginless">
     <div class="field">
-      <label for="wrap-info" class="is-label">Wrapping token</label>
+      <label for="wrap-info" class="is-label">Wrapped token</label>
       <div class="control">
         <Textarea
           @value={{@token}}

--- a/ui/app/templates/components/wizard/tools-unwrapped.hbs
+++ b/ui/app/templates/components/wizard/tools-unwrapped.hbs
@@ -2,7 +2,7 @@
   <WizardSection @headerText="Your unwrapped data" @docText="API: Unwrap Data" @docPath="/api/system/wrapping-unwrap.html">
     <p>
       Here you can see that your data survived intact. These tools are mostly handy for applications to use, but if you ever
-      do need to wrap data or handle the wrapping token, now you know how.
+      do need to wrap data or handle the wrapped token, now you know how.
     </p>
   </WizardSection>
   <button type="button" class="button next-feature-step" {{action @onAdvance}}>


### PR DESCRIPTION
Renamed label of `wrapping token` to `wrapped token` under Tools for Lookup, Unwrap and Rewrap. Added descriptions for them as well. Changed label under Wrap as well. Note that if an error is thrown, it still says `wrapping token` since that error message comes from the backend
<img width="1053" alt="Screen Shot 2022-07-28 at 12 46 10 PM" src="https://user-images.githubusercontent.com/57650314/181593133-f2e300ae-eb29-4cea-a675-1abeb330d4c4.png">
<img width="1041" alt="Screen Shot 2022-07-28 at 12 46 23 PM" src="https://user-images.githubusercontent.com/57650314/181593168-278b9639-edf5-4b07-bb50-95489fabf22d.png">
<img width="1048" alt="Screen Shot 2022-07-28 at 12 46 32 PM" src="https://user-images.githubusercontent.com/57650314/181593198-20af8cb7-7c9b-4a73-9b4c-a41fa9b5db82.png">
<img width="1035" alt="Screen Shot 2022-07-28 at 12 47 29 PM" src="https://user-images.githubusercontent.com/57650314/181593355-199546fb-b40a-4707-be64-1128098cf0e7.png">

