### PR TITLE
VAULT-7256 - Add CustomMetadata to Namespace type

### DIFF
--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -12,8 +12,9 @@ import (
 type contextValues struct{}
 
 type Namespace struct {
-	ID   string `json:"id"`
-	Path string `json:"path"`
+	ID             string            `json:"id"`
+	Path           string            `json:"path"`
+	CustomMetadata map[string]string `json:"custom_metadata"`
 }
 
 func (n *Namespace) String() string {
@@ -28,8 +29,9 @@ var (
 	contextNamespace contextValues = struct{}{}
 	ErrNoNamespace   error         = errors.New("no namespace")
 	RootNamespace    *Namespace    = &Namespace{
-		ID:   RootNamespaceID,
-		Path: "",
+		ID:             RootNamespaceID,
+		Path:           "",
+		CustomMetadata: make(map[string]string),
 	}
 )
 

--- a/sdk/helper/custommetadata/custom_metadata.go
+++ b/sdk/helper/custommetadata/custom_metadata.go
@@ -7,10 +7,6 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 )
 
-// CustomMetadata should be arbitrary user-provided key-value pairs meant to
-// provide supplemental information about a resource.
-type CustomMetadata map[string]string
-
 // The following constants are used by Validate and are meant to be imposed
 // broadly for consistency.
 const (
@@ -20,7 +16,9 @@ const (
 	validationErrorPrefix = "custom_metadata validation failed"
 )
 
-// Validate will perform input validation for custom metadata. If the key count
+// Validate will perform input validation for custom metadata.
+// CustomMetadata should be arbitrary user-provided key-value pairs meant to
+// provide supplemental information about a resource. If the key count
 // exceeds maxKeys, the validation will be short-circuited to prevent
 // unnecessary (and potentially costly) validation to be run. If the key count
 // falls at or below maxKeys, multiple checks will be made per key and value.
@@ -28,7 +26,7 @@ const (
 //   - 0 < length of key <= maxKeyLength
 //   - 0 < length of value <= maxValueLength
 //   - keys and values cannot include unprintable characters
-func Validate(cm CustomMetadata) error {
+func Validate(cm map[string]string) error {
 	var errs *multierror.Error
 
 	if keyCount := len(cm); keyCount > maxKeys {

--- a/sdk/helper/custommetadata/custom_metadata_test.go
+++ b/sdk/helper/custommetadata/custom_metadata_test.go
@@ -9,12 +9,12 @@ import (
 func TestValidate(t *testing.T) {
 	cases := []struct {
 		name       string
-		input      CustomMetadata
+		input      map[string]string
 		shouldPass bool
 	}{
 		{
 			"valid",
-			CustomMetadata{
+			map[string]string{
 				"foo": "abc",
 				"bar": "def",
 				"baz": "ghi",
@@ -23,8 +23,8 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			"too_many_keys",
-			func() CustomMetadata {
-				cm := make(CustomMetadata)
+			func() map[string]string {
+				cm := make(map[string]string)
 
 				for i := 0; i < maxKeyLength+1; i++ {
 					s := strconv.Itoa(i)
@@ -37,28 +37,28 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			"key_too_long",
-			CustomMetadata{
+			map[string]string{
 				strings.Repeat("a", maxKeyLength+1): "abc",
 			},
 			false,
 		},
 		{
 			"value_too_long",
-			CustomMetadata{
+			map[string]string{
 				"foo": strings.Repeat("a", maxValueLength+1),
 			},
 			false,
 		},
 		{
 			"unprintable_key",
-			CustomMetadata{
+			map[string]string{
 				"unprint\u200bable": "abc",
 			},
 			false,
 		},
 		{
 			"unprintable_value",
-			CustomMetadata{
+			map[string]string{
 				"foo": "unprint\u200bable",
 			},
 			false,


### PR DESCRIPTION
A [prior PR](https://github.com/hashicorp/vault/pull/16464) abstracted the concept of custom metadata into its own helper package. That initial abstraction included a type which ultimately does not play nicely with the `framework.FieldData` logic. We could use a type alias instead of a strict type but that seems to just add cognitive overhead with not much gain. With that said, this PR removes the `CustomMetadata` type in favor of using `map[string]string` which the `Validate` function uses. The type also did not provide much gain in terms of consistency because API paths would need to be defined to use `framework.TypeKVPairs` which maps to a `map[string]string`.

Along with that, this PR prepares for the addition of custom metadata to namespaces by adding the associated field to the `Namespace` struct type.

A changelog will be added to the enterprise PR that provides the actual namespace handling.