### PR TITLE
MFA: TOTP: Add a non-administrative destory call, use non-administrative calls in the UI

### DIFF
--- a/changelog/16504.txt
+++ b/changelog/16504.txt
@@ -1,0 +1,4 @@
+```release-note:improvment
+mfa/totp: Add non-administrative destory endpoint
+ui: Use non-administratives endpoints for MFA setup
+```

--- a/ui/app/adapters/mfa-setup.js
+++ b/ui/app/adapters/mfa-setup.js
@@ -1,13 +1,13 @@
 import ApplicationAdapter from './application';
 
 export default class MfaSetupAdapter extends ApplicationAdapter {
-  adminGenerate(data) {
-    let url = `/v1/identity/mfa/method/totp/admin-generate`;
+  generate(data) {
+    let url = `/v1/identity/mfa/method/totp/generate`;
     return this.ajax(url, 'POST', { data });
   }
 
-  adminDestroy(data) {
-    let url = `/v1/identity/mfa/method/totp/admin-destroy`;
+  destroy(data) {
+    let url = `/v1/identity/mfa/method/totp/destroy`;
     return this.ajax(url, 'POST', { data });
   }
 }

--- a/ui/app/components/mfa/mfa-setup-step-one.js
+++ b/ui/app/components/mfa/mfa-setup-step-one.js
@@ -5,13 +5,13 @@ import { tracked } from '@glimmer/tracking';
 
 /**
  * @module MfaSetupStepOne
- * MfaSetupStepOne component is a child component used in the end user setup for MFA. It records the UUID (aka method_id) and sends a admin-generate request.
+ * MfaSetupStepOne component is a child component used in the end user setup for MFA. It records the UUID (aka method_id) and sends a generate request.
  *
  * @param {string} entityId - the entityId of the user. This comes from the auth service which records it on loading of the cluster. A root user does not have an entityId.
- * @param {function} isUUIDVerified - a function that consumes a boolean. Is true if the admin-generate is successful and false if it throws a warning or error.
+ * @param {function} isUUIDVerified - a function that consumes a boolean. Is true if the generate is successful and false if it throws a warning or error.
  * @param {boolean} restartFlow - a boolean that is true that is true if the user should proceed to step two or false if they should stay on step one.
  * @param {function} saveUUIDandQrCode - A function that sends the inputted UUID and return qrCode from step one to the parent.
- * @param {boolean} showWarning - whether a warning is returned from the admin-generate query. Needs to be passed to step two.
+ * @param {boolean} showWarning - whether a warning is returned from the generate query. Needs to be passed to step two.
  */
 
 export default class MfaSetupStepOne extends Component {
@@ -29,7 +29,7 @@ export default class MfaSetupStepOne extends Component {
   @action
   async verifyUUID(evt) {
     evt.preventDefault();
-    let response = await this.postAdminGenerate();
+    let response = await this.postGenerate();
 
     if (response === 'stop_progress') {
       this.args.isUUIDVerified(false);
@@ -40,15 +40,14 @@ export default class MfaSetupStepOne extends Component {
     }
   }
 
-  async postAdminGenerate() {
+  async postGenerate() {
     this.error = '';
     this.warning = '';
     let adapter = this.store.adapterFor('mfa-setup');
     let response;
 
     try {
-      response = await adapter.adminGenerate({
-        entity_id: this.args.entityId,
+      response = await adapter.generate({
         method_id: this.UUID, // comes from value on the input
       });
       this.args.saveUUIDandQrCode(this.UUID, response.data?.url);

--- a/ui/app/components/mfa/mfa-setup-step-two.js
+++ b/ui/app/components/mfa/mfa-setup-step-two.js
@@ -8,9 +8,9 @@ import { action } from '@ember/object';
  *
  * @param {string} entityId - the entityId of the user. This comes from the auth service which records it on loading of the cluster. A root user does not have an entityId.
  * @param {string} uuid - the UUID that is entered in the input on step one.
- * @param {string} qrCode - the returned url from the admin-generate post. Used to create the qrCode.
+ * @param {string} qrCode - the returned url from the generate post. Used to create the qrCode.
  * @param {boolean} restartFlow - a boolean that is true that is true if the user should proceed to step two or false if they should stay on step one.
- * @param {string} warning - if there is a warning returned from the admin-generate post then it's sent to the step two component in this param.
+ * @param {string} warning - if there is a warning returned from the generate post then it's sent to the step two component in this param.
  */
 
 export default class MfaSetupStepTwo extends Component {
@@ -27,8 +27,7 @@ export default class MfaSetupStepTwo extends Component {
     this.error = null;
     let adapter = this.store.adapterFor('mfa-setup');
     try {
-      await adapter.adminDestroy({
-        entity_id: this.args.entityId,
+      await adapter.destroy({
         method_id: this.args.uuid,
       });
     } catch (error) {

--- a/ui/app/controllers/vault/cluster/mfa-setup.js
+++ b/ui/app/controllers/vault/cluster/mfa-setup.js
@@ -30,7 +30,7 @@ export default class VaultClusterMfaSetupController extends Controller {
 
   @action
   saveUUIDandQrCode(uuid, qrCode) {
-    // qrCode could be an empty string if the admin-generate was not successful
+    // qrCode could be an empty string if the generate was not successful
     this.uuid = uuid;
     this.qrCode = qrCode;
   }

--- a/ui/tests/acceptance/mfa-setup-test.js
+++ b/ui/tests/acceptance/mfa-setup-test.js
@@ -50,10 +50,10 @@ module('Acceptance | mfa-setup', function (hooks) {
     await click('[data-test-status-link="mfa"]');
   });
 
-  test('it should login through MFA and post to admin-generate and be able to restart the setup', async function (assert) {
+  test('it should login through MFA and post to generate and be able to restart the setup', async function (assert) {
     assert.expect(5);
     // the network requests required in this test
-    this.server.post('/identity/mfa/method/totp/admin-generate', (scheme, req) => {
+    this.server.post('/identity/mfa/method/totp/generate', (scheme, req) => {
       const json = JSON.parse(req.requestBody);
       assert.equal(json.method_id, '123', 'sends the UUID value');
       return {
@@ -65,7 +65,7 @@ module('Acceptance | mfa-setup', function (hooks) {
         },
       };
     });
-    this.server.post('/identity/mfa/method/totp/admin-destroy', (scheme, req) => {
+    this.server.post('/identity/mfa/method/totp/destroy', (scheme, req) => {
       const json = JSON.parse(req.requestBody);
       assert.equal(json.method_id, '123', 'sends the UUID value');
       // returns nothing
@@ -82,7 +82,7 @@ module('Acceptance | mfa-setup', function (hooks) {
   test('it should show a warning if you enter in the same UUID without restarting the setup', async function (assert) {
     assert.expect(2);
     // the network requests required in this test
-    this.server.post('/identity/mfa/method/totp/admin-generate', () => {
+    this.server.post('/identity/mfa/method/totp/generate', () => {
       return {
         data: null,
         warnings: ['Entity already has a secret for MFA method “”'],

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -252,6 +252,22 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 			},
 		},
 		{
+			Pattern: "mfa/method/totp/destroy$",
+			Fields: map[string]*framework.FieldSchema{
+				"method_id": {
+					Type:        framework.TypeString,
+					Description: "The unique identifier for this MFA method.",
+					Required:    true,
+				},
+			},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback: i.handleLoginMFADestroyUpdate,
+					Summary:  "Destroys a TOTP secret for the given MFA method ID on the given entity",
+				},
+			},
+		},
+		{
 			Pattern: "mfa/method/totp/admin-generate$",
 			Fields: map[string]*framework.FieldSchema{
 				"method_id": {

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -475,16 +475,22 @@ func (i *IdentityStore) handleLoginMFAGenerateCommon(ctx context.Context, req *l
 	}
 }
 
+func (i *IdentityStore) handleLoginMFADestroyUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	return i.handleLoginMFADestroyCommon(ctx, req, d.Get("method_id").(string), req.EntityID)
+}
+
 func (i *IdentityStore) handleLoginMFAAdminDestroyUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	return i.handleLoginMFADestroyCommon(ctx, req, d.Get("method_id").(string), d.Get("entity_id").(string))
+}
+
+func (i *IdentityStore) handleLoginMFADestroyCommon(ctx context.Context, req *logical.Request, methodID, entityID string) (*logical.Response, error) {
 	var entity *identity.Entity
 	var err error
 
-	methodID := d.Get("method_id").(string)
 	if methodID == "" {
 		return logical.ErrorResponse("missing method ID"), nil
 	}
 
-	entityID := d.Get("entity_id").(string)
 	if entityID == "" {
 		return logical.ErrorResponse("missing entity ID"), nil
 	}
@@ -2789,6 +2795,12 @@ var mfaHelp = map[string][2]string{
 		`This endpoint generates an MFA secret based on the
 		configuration tied to the method name and stores it in the entity of
 		the token making this request.`,
+	},
+	"totp-destroy": {
+		`Deletes the TOTP secret for the given method name on the entity of the
+		calling token.`,
+		`This endpoint removes the secret belonging to method name from the
+		entity regardless of the secret type.`,
 	},
 	"totp-admin-generate": {
 		`Generates a TOTP secret for the given method name on the given entity.`,

--- a/website/content/api-docs/system/mfa/totp.mdx
+++ b/website/content/api-docs/system/mfa/totp.mdx
@@ -151,6 +151,33 @@ $ curl \
 }
 ```
 
+
+### Destroy TOTP MFA Secret
+
+This endpoint deletes a TOTP MFA secret in the entity of the calling token.
+
+Note that in order to overwrite a secret on the entity, it is required to
+explicitly delete the secret first. This API can be used to delete the secret
+and the `generate` or `admin-generate` APIs should be used to regenerate a new
+secret.
+
+| Method | Path                                  |
+| :----- | :------------------------------------ |
+| `POST` | `/sys/mfa/method/:name/destroy` |
+
+### Parameters
+
+- `name` `(string: <required>)` – Name of the MFA method.
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    http://127.0.0.1:8200/v1/sys/mfa/method/totp/my_totp/destroy
+```
+
 ## Administratively Generate a TOTP MFA Secret
 
 This endpoint can be used to generate a TOTP MFA secret. Unlike the `generate`


### PR DESCRIPTION
Hello,

The UI to setup MFA with TOTP is using administrative calls, which can be can issue since entities with restricted rights must have permission to call those endpoints, allowing then to add or remove TOTP to any entity.

This PR change the UI to use the non-administrative endpoints who can be granted to anyone since they does not pose a security risk.

Since the 'destroy' endpoint exists only in a administrative version, this PR also add a new non-administrative endpoint, like the 'generate' endpoint.