### PR TITLE
UI/fix client form edit

### DIFF
--- a/ui/app/templates/components/oidc/client-form.hbs
+++ b/ui/app/templates/components/oidc/client-form.hbs
@@ -44,7 +44,7 @@
         @icon="org"
         @value="allow_all"
         @groupValue={{this.radioCardGroupValue}}
-        @onChange={{fn (mut this.radioCardGroupValue)}}
+        @onChange={{this.handleAssignmentSelection}}
       />
       <RadioCard
         @title="Limit access to selected users"
@@ -52,7 +52,7 @@
         @icon="users"
         @value="limited"
         @groupValue={{this.radioCardGroupValue}}
-        @onChange={{fn (mut this.radioCardGroupValue)}}
+        @onChange={{this.handleAssignmentSelection}}
       />
     </div>
     {{#if (eq this.radioCardGroupValue "limited")}}
@@ -61,7 +61,7 @@
         @label="Assignment name"
         @subText="Search for an existing assignment, or type a new name to create it."
         @model="oidc/assignment"
-        @inputValue={{@model.assignments}}
+        @inputValue={{this.modelAssignments}}
         @onChange={{this.handleAssignmentSelection}}
         @excludeOptions={{array "allow_all"}}
         @fallbackComponent="string-list"


### PR DESCRIPTION
When updating an application from allowing all assignments, to allowing _no_ assignments, the edit form would show `allow_all` in the search-select dropdown menu. This fixes the bug, and effectively clears out any selection so that the UI accurately depicts the model's assignments. This way a user can select the "limited" radio button and, without choosing anything from the dropdown, it will clear allowed assignments complete and make it an empty array.