### PR TITLE
Make PKI tests run in parallel

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -101,6 +101,7 @@ OzQeADTSCn5VidOfjDkIst9UXjMlrFfV9/oJEw5Eiqa6lkNPCGDhfA8=
 )
 
 func TestPKI_RequireCN(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
@@ -176,6 +177,7 @@ func TestPKI_RequireCN(t *testing.T) {
 }
 
 func TestPKI_DeviceCert(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
@@ -244,6 +246,7 @@ func TestPKI_DeviceCert(t *testing.T) {
 }
 
 func TestBackend_InvalidParameter(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	_, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
@@ -265,6 +268,7 @@ func TestBackend_InvalidParameter(t *testing.T) {
 }
 
 func TestBackend_CSRValues(t *testing.T) {
+	t.Parallel()
 	initTest.Do(setCerts)
 	b, _ := createBackendWithStorage(t)
 
@@ -281,6 +285,7 @@ func TestBackend_CSRValues(t *testing.T) {
 }
 
 func TestBackend_URLsCRUD(t *testing.T) {
+	t.Parallel()
 	initTest.Do(setCerts)
 	b, _ := createBackendWithStorage(t)
 
@@ -299,6 +304,7 @@ func TestBackend_URLsCRUD(t *testing.T) {
 // Generates and tests steps that walk through the various possibilities
 // of role flags to ensure that they are properly restricted
 func TestBackend_Roles(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name      string
 		key, cert *string
@@ -1715,6 +1721,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 }
 
 func TestRolesAltIssuer(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	// Create two issuers.
@@ -1812,6 +1819,7 @@ func TestRolesAltIssuer(t *testing.T) {
 }
 
 func TestBackend_PathFetchValidRaw(t *testing.T) {
+	t.Parallel()
 	b, storage := createBackendWithStorage(t)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
@@ -1942,6 +1950,7 @@ func TestBackend_PathFetchValidRaw(t *testing.T) {
 }
 
 func TestBackend_PathFetchCertList(t *testing.T) {
+	t.Parallel()
 	// create the backend
 	b, storage := createBackendWithStorage(t)
 
@@ -2067,6 +2076,7 @@ func TestBackend_PathFetchCertList(t *testing.T) {
 }
 
 func TestBackend_SignVerbatim(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		testName string
 		keyType  string
@@ -2077,6 +2087,7 @@ func TestBackend_SignVerbatim(t *testing.T) {
 		{testName: "Any", keyType: "any"},
 	}
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			runTestSignVerbatim(t, tc.keyType)
 		})
@@ -2316,6 +2327,7 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 }
 
 func TestBackend_Root_Idempotency(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	// This is a change within 1.11, we are no longer idempotent across generate/internal calls.
@@ -2420,6 +2432,7 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 }
 
 func TestBackend_SignIntermediate_AllowedPastCA(t *testing.T) {
+	t.Parallel()
 	b_root, s_root := createBackendWithStorage(t)
 	b_int, s_int := createBackendWithStorage(t)
 	var err error
@@ -2487,6 +2500,7 @@ func TestBackend_SignIntermediate_AllowedPastCA(t *testing.T) {
 }
 
 func TestBackend_ConsulSignLeafWithLegacyRole(t *testing.T) {
+	t.Parallel()
 	// create the backend
 	b, s := createBackendWithStorage(t)
 
@@ -2521,6 +2535,7 @@ func TestBackend_ConsulSignLeafWithLegacyRole(t *testing.T) {
 }
 
 func TestBackend_SignSelfIssued(t *testing.T) {
+	t.Parallel()
 	// create the backend
 	b, storage := createBackendWithStorage(t)
 
@@ -2661,6 +2676,7 @@ func TestBackend_SignSelfIssued(t *testing.T) {
 // TestBackend_SignSelfIssued_DifferentTypes tests the functionality of the
 // require_matching_certificate_algorithms flag.
 func TestBackend_SignSelfIssued_DifferentTypes(t *testing.T) {
+	t.Parallel()
 	// create the backend
 	b, storage := createBackendWithStorage(t)
 
@@ -2786,6 +2802,7 @@ func TestBackend_SignSelfIssued_DifferentTypes(t *testing.T) {
 // here into the form at that site as it will do the right thing so it's pretty
 // easy to validate.
 func TestBackend_OID_SANs(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	var err error
@@ -3008,6 +3025,7 @@ func TestBackend_OID_SANs(t *testing.T) {
 }
 
 func TestBackend_AllowedSerialNumbers(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	var err error
@@ -3114,6 +3132,7 @@ func TestBackend_AllowedSerialNumbers(t *testing.T) {
 }
 
 func TestBackend_URI_SANs(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	var err error
@@ -3207,6 +3226,7 @@ func TestBackend_URI_SANs(t *testing.T) {
 }
 
 func TestBackend_AllowedURISANsTemplate(t *testing.T) {
+	t.Parallel()
 	coreConfig := &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
 			"userpass": userpass.Factory,
@@ -3331,6 +3351,7 @@ func TestBackend_AllowedURISANsTemplate(t *testing.T) {
 }
 
 func TestBackend_AllowedDomainsTemplate(t *testing.T) {
+	t.Parallel()
 	coreConfig := &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
 			"userpass": userpass.Factory,
@@ -3462,6 +3483,7 @@ func TestBackend_AllowedDomainsTemplate(t *testing.T) {
 }
 
 func TestReadWriteDeleteRoles(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	coreConfig := &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
@@ -3689,6 +3711,8 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 	// that we have to deal with more than one interval.
 	// InMemSink rounds down to an interval boundary rather than
 	// starting one at the time of initialization.
+	//
+	// This test is not parallelizable.
 	inmemSink := metrics.NewInmemSink(
 		1000000*time.Hour,
 		2000000*time.Hour)
@@ -3928,6 +3952,7 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 }
 
 func TestBackend_Root_FullCAChain(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		testName string
 		keyType  string
@@ -3937,6 +3962,7 @@ func TestBackend_Root_FullCAChain(t *testing.T) {
 		{testName: "EC", keyType: "ec"},
 	}
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			runFullCAChainTest(t, tc.keyType)
 		})
@@ -4223,6 +4249,7 @@ func RoleIssuanceRegressionHelper(t *testing.T, b *backend, s logical.Storage, i
 }
 
 func TestBackend_Roles_IssuanceRegression(t *testing.T) {
+	t.Parallel()
 	// Regression testing of role's issuance policy.
 	testCases := []IssuanceRegression{
 		// allowed, bare, glob, subdomains, localhost, wildcards, cn, issued
@@ -4509,6 +4536,7 @@ func RoleKeySizeRegressionHelper(t *testing.T, b *backend, s logical.Storage, in
 }
 
 func TestBackend_Roles_KeySizeRegression(t *testing.T) {
+	t.Parallel()
 	// Regression testing of role's issuance policy.
 	testCases := []KeySizeRegression{
 		// RSA with default parameters should fail to issue smaller RSA keys
@@ -4557,6 +4585,7 @@ func TestBackend_Roles_KeySizeRegression(t *testing.T) {
 }
 
 func TestRootWithExistingKey(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 	var err error
 
@@ -4689,6 +4718,7 @@ func TestRootWithExistingKey(t *testing.T) {
 }
 
 func TestIntermediateWithExistingKey(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	var err error
@@ -4753,6 +4783,7 @@ func TestIntermediateWithExistingKey(t *testing.T) {
 }
 
 func TestIssuanceTTLs(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
@@ -4827,6 +4858,7 @@ func TestIssuanceTTLs(t *testing.T) {
 }
 
 func TestSealWrappedStorageConfigured(t *testing.T) {
+	t.Parallel()
 	b, _ := createBackendWithStorage(t)
 	wrappedEntries := b.Backend.PathsSpecial.SealWrapStorage
 

--- a/builtin/logical/pki/ca_test.go
+++ b/builtin/logical/pki/ca_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestBackend_CA_Steps(t *testing.T) {
+	t.Parallel()
 	var b *backend
 
 	factory := func(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {

--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestPki_FetchCertBySerial(t *testing.T) {
+	t.Parallel()
 	b, storage := createBackendWithStorage(t)
 
 	cases := map[string]struct {
@@ -91,6 +92,7 @@ func TestPki_FetchCertBySerial(t *testing.T) {
 // Demonstrate that multiple OUs in the name are handled in an
 // order-preserving way.
 func TestPki_MultipleOUs(t *testing.T) {
+	t.Parallel()
 	var b backend
 	fields := addCACommonFields(map[string]*framework.FieldSchema{})
 
@@ -122,6 +124,7 @@ func TestPki_MultipleOUs(t *testing.T) {
 }
 
 func TestPki_PermitFQDNs(t *testing.T) {
+	t.Parallel()
 	var b backend
 	fields := addCACommonFields(map[string]*framework.FieldSchema{})
 
@@ -206,6 +209,8 @@ func TestPki_PermitFQDNs(t *testing.T) {
 	}
 
 	for name, testCase := range cases {
+		name := name
+		testCase := testCase
 		t.Run(name, func(t *testing.T) {
 			cb, err := generateCreationBundle(&b, testCase.input, nil, nil)
 			if err != nil {

--- a/builtin/logical/pki/chain_test.go
+++ b/builtin/logical/pki/chain_test.go
@@ -1572,6 +1572,7 @@ var chainBuildingTestCases = []CBTestScenario{
 }
 
 func Test_CAChainBuilding(t *testing.T) {
+	t.Parallel()
 	for testIndex, testCase := range chainBuildingTestCases {
 		b, s := createBackendWithStorage(t)
 

--- a/builtin/logical/pki/integation_test.go
+++ b/builtin/logical/pki/integation_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestIntegration_RotateRootUsesNext(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -75,6 +76,7 @@ func TestIntegration_RotateRootUsesNext(t *testing.T) {
 }
 
 func TestIntegration_ReplaceRootNormal(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	// generate roots
@@ -112,6 +114,7 @@ func TestIntegration_ReplaceRootNormal(t *testing.T) {
 }
 
 func TestIntegration_ReplaceRootDefaultsToNext(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	// generate roots
@@ -148,6 +151,7 @@ func TestIntegration_ReplaceRootDefaultsToNext(t *testing.T) {
 }
 
 func TestIntegration_ReplaceRootBadIssuer(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	// generate roots
@@ -197,6 +201,7 @@ func TestIntegration_ReplaceRootBadIssuer(t *testing.T) {
 }
 
 func TestIntegration_SetSignedWithBackwardsPemBundles(t *testing.T) {
+	t.Parallel()
 	rootBackend, rootStorage := createBackendWithStorage(t)
 	intBackend, intStorage := createBackendWithStorage(t)
 

--- a/builtin/logical/pki/path_manage_keys_test.go
+++ b/builtin/logical/pki/path_manage_keys_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestPKI_PathManageKeys_GenerateInternalKeys(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	tests := []struct {
@@ -33,6 +34,7 @@ func TestPKI_PathManageKeys_GenerateInternalKeys(t *testing.T) {
 		{"error-bad-type", "dskjfkdsfjdkf", []int{0}, true},
 	}
 	for _, tt := range tests {
+		tt := tt
 		for _, keyBitParam := range tt.keyBits {
 			keyName := fmt.Sprintf("%s-%d", tt.name, keyBitParam)
 			t.Run(keyName, func(t *testing.T) {
@@ -79,6 +81,7 @@ func TestPKI_PathManageKeys_GenerateInternalKeys(t *testing.T) {
 }
 
 func TestPKI_PathManageKeys_GenerateExportedKeys(t *testing.T) {
+	t.Parallel()
 	// We tested a lot of the logic above within the internal test, so just make sure we honor the exported contract
 	b, s := createBackendWithStorage(t)
 
@@ -111,6 +114,7 @@ func TestPKI_PathManageKeys_GenerateExportedKeys(t *testing.T) {
 }
 
 func TestPKI_PathManageKeys_ImportKeyBundle(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	bundle1, err := certutil.CreateKeyBundle("ec", 224, rand.Reader)
@@ -243,6 +247,7 @@ func TestPKI_PathManageKeys_ImportKeyBundle(t *testing.T) {
 }
 
 func TestPKI_PathManageKeys_DeleteDefaultKeyWarns(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
@@ -270,6 +275,7 @@ func TestPKI_PathManageKeys_DeleteDefaultKeyWarns(t *testing.T) {
 }
 
 func TestPKI_PathManageKeys_DeleteUsedKeyFails(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
@@ -296,6 +302,7 @@ func TestPKI_PathManageKeys_DeleteUsedKeyFails(t *testing.T) {
 }
 
 func TestPKI_PathManageKeys_UpdateKeyDetails(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
@@ -348,6 +355,7 @@ func TestPKI_PathManageKeys_UpdateKeyDetails(t *testing.T) {
 }
 
 func TestPKI_PathManageKeys_ImportKeyBundleBadData(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
@@ -381,6 +389,7 @@ func TestPKI_PathManageKeys_ImportKeyBundleBadData(t *testing.T) {
 }
 
 func TestPKI_PathManageKeys_ImportKeyRejectsMultipleKeys(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 
 	bundle1, err := certutil.CreateKeyBundle("ec", 224, rand.Reader)

--- a/builtin/logical/pki/path_roles_test.go
+++ b/builtin/logical/pki/path_roles_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestPki_RoleGenerateLease(t *testing.T) {
+	t.Parallel()
 	var resp *logical.Response
 	var err error
 	b, storage := createBackendWithStorage(t)
@@ -121,6 +122,7 @@ func TestPki_RoleGenerateLease(t *testing.T) {
 }
 
 func TestPki_RoleKeyUsage(t *testing.T) {
+	t.Parallel()
 	var resp *logical.Response
 	var err error
 	b, storage := createBackendWithStorage(t)
@@ -211,6 +213,7 @@ func TestPki_RoleKeyUsage(t *testing.T) {
 }
 
 func TestPki_RoleOUOrganizationUpgrade(t *testing.T) {
+	t.Parallel()
 	var resp *logical.Response
 	var err error
 	b, storage := createBackendWithStorage(t)
@@ -316,6 +319,7 @@ func TestPki_RoleOUOrganizationUpgrade(t *testing.T) {
 }
 
 func TestPki_RoleAllowedDomains(t *testing.T) {
+	t.Parallel()
 	var resp *logical.Response
 	var err error
 	b, storage := createBackendWithStorage(t)
@@ -403,6 +407,7 @@ func TestPki_RoleAllowedDomains(t *testing.T) {
 }
 
 func TestPki_RoleAllowedURISANs(t *testing.T) {
+	t.Parallel()
 	var resp *logical.Response
 	var err error
 	b, storage := createBackendWithStorage(t)
@@ -437,6 +442,7 @@ func TestPki_RoleAllowedURISANs(t *testing.T) {
 }
 
 func TestPki_RolePkixFields(t *testing.T) {
+	t.Parallel()
 	var resp *logical.Response
 	var err error
 	b, storage := createBackendWithStorage(t)
@@ -528,6 +534,7 @@ func TestPki_RolePkixFields(t *testing.T) {
 }
 
 func TestPki_RoleNoStore(t *testing.T) {
+	t.Parallel()
 	var resp *logical.Response
 	var err error
 	b, storage := createBackendWithStorage(t)
@@ -648,6 +655,7 @@ func TestPki_RoleNoStore(t *testing.T) {
 }
 
 func TestPki_CertsLease(t *testing.T) {
+	t.Parallel()
 	var resp *logical.Response
 	var err error
 	b, storage := createBackendWithStorage(t)
@@ -729,6 +737,7 @@ func TestPki_CertsLease(t *testing.T) {
 }
 
 func TestPki_RolePatch(t *testing.T) {
+	t.Parallel()
 	type TestCase struct {
 		Field   string
 		Before  interface{}
@@ -1008,6 +1017,7 @@ func TestPki_RolePatch(t *testing.T) {
 }
 
 func TestPKI_RolePolicyInformation_Flat(t *testing.T) {
+	t.Parallel()
 	type TestCase struct {
 		Input   interface{}
 		ASN     interface{}

--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func Test_migrateStorageEmptyStorage(t *testing.T) {
+	t.Parallel()
 	startTime := time.Now()
 	ctx := context.Background()
 	b, s := createBackendWithStorage(t)
@@ -60,6 +61,7 @@ func Test_migrateStorageEmptyStorage(t *testing.T) {
 }
 
 func Test_migrateStorageSimpleBundle(t *testing.T) {
+	t.Parallel()
 	startTime := time.Now()
 	ctx := context.Background()
 	b, s := createBackendWithStorage(t)
@@ -167,6 +169,7 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 }
 
 func TestExpectedOpsWork_PreMigration(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	b, s := createBackendWithStorage(t)
 	// Reset the version the helper above set to 1.

--- a/builtin/logical/pki/storage_test.go
+++ b/builtin/logical/pki/storage_test.go
@@ -14,6 +14,7 @@ import (
 var ctx = context.Background()
 
 func Test_ConfigsRoundTrip(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 	sc := b.makeStorageContext(ctx, s)
 
@@ -49,6 +50,7 @@ func Test_ConfigsRoundTrip(t *testing.T) {
 }
 
 func Test_IssuerRoundTrip(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 	sc := b.makeStorageContext(ctx, s)
 	issuer1, key1 := genIssuerAndKey(t, b, s)
@@ -94,6 +96,7 @@ func Test_IssuerRoundTrip(t *testing.T) {
 }
 
 func Test_KeysIssuerImport(t *testing.T) {
+	t.Parallel()
 	b, s := createBackendWithStorage(t)
 	sc := b.makeStorageContext(ctx, s)
 


### PR DESCRIPTION
This decreases the total time to run the test suite significantly. From
[the last PR](#15999), we were at 151s:

> [cipherboy@xps15 pki]$ go test -count=1 github.com/hashicorp/vault/builtin/logical/pki
> ok    github.com/hashicorp/vault/builtin/logical/pki  151.182s

Now we're around 60s:

> [cipherboy@xps15 pki]$ go test -count=1 github.com/hashicorp/vault/builtin/logical/pki
> ok    github.com/hashicorp/vault/builtin/logical/pki  61.838s

Notably, Go will [correctly handle parallelizing tests](https://engineering.mercari.com/en/blog/entry/20220408-how_to_use_t_parallel/) across both
packages and within a package, so this shouldn't really impact test
runners (if they're already saturated).

The [only gotcha in this approach](https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721) is that the call to `t.Run(...)` becomes
effectively async; this means we either need to not mark the test as
parallel or shadow any loop variables inside the scope of the loop to
allow the `t.Run(...)` call to have the correct copy.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

@stevendpclark -- if you don't mind, could you run Goland's coverage before and after this change so we know we really are still exercising everything? Thank you!
