### PR TITLE
Add PSS support to PKI Secrets Engine

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -3552,6 +3552,7 @@ func TestReadWriteDeleteRoles(t *testing.T) {
 		"allowed_serial_numbers":             []interface{}{},
 		"generate_lease":                     false,
 		"signature_bits":                     json.Number("256"),
+		"use_pss":                            false,
 		"allowed_domains":                    []interface{}{},
 		"allowed_uri_sans_template":          false,
 		"enforce_hostnames":                  true,

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -4460,6 +4460,7 @@ type KeySizeRegression struct {
 
 	// Signature Bits presently is only specified on the role.
 	RoleSignatureBits []int
+	RoleUsePSS        bool
 
 	// These are tuples; must be of the same length.
 	TestKeyTypes []string
@@ -4503,6 +4504,7 @@ func RoleKeySizeRegressionHelper(t *testing.T, b *backend, s logical.Storage, in
 						"key_type":       test.RoleKeyType,
 						"key_bits":       roleKeyBits,
 						"signature_bits": roleSignatureBits,
+						"use_pss":        test.RoleUsePSS,
 					})
 					if err != nil {
 						t.Fatal(err)
@@ -4528,6 +4530,15 @@ func RoleKeySizeRegressionHelper(t *testing.T, b *backend, s logical.Storage, in
 							t.Fatalf("key size regression test [%d] failed: haveErr: %v, expectErr: %v, err: %v, resp: %v, test case: %v, caKeyType: %v, caKeyBits: %v, role: %v, keyType: %v, keyBits: %v", index, haveErr, test.ExpectError, err, resp, test, caKeyType, caKeyBits, role, keyType, keyBits)
 						}
 
+						if resp != nil && test.RoleUsePSS && caKeyType == "rsa" {
+							leafCert := parseCert(t, resp.Data["certificate"].(string))
+							switch leafCert.SignatureAlgorithm {
+							case x509.SHA256WithRSAPSS, x509.SHA384WithRSAPSS, x509.SHA512WithRSAPSS:
+							default:
+								t.Fatalf("key size regression test [%d] failed on role %v: unexpected signature algorithm; expected RSA-type CA to sign a leaf cert with PSS algorithm; got %v", index, role, leafCert.SignatureAlgorithm.String())
+							}
+						}
+
 						tested += 1
 					}
 				}
@@ -4549,36 +4560,41 @@ func TestBackend_Roles_KeySizeRegression(t *testing.T) {
 	testCases := []KeySizeRegression{
 		// RSA with default parameters should fail to issue smaller RSA keys
 		// and any size ECDSA/Ed25519 keys.
-		/*  0 */ {"rsa", []int{0, 2048}, []int{0, 256, 384, 512}, []string{"rsa", "ec", "ec", "ec", "ec", "ed25519"}, []int{1024, 224, 256, 384, 521, 0}, true},
+		/*  0 */ {"rsa", []int{0, 2048}, []int{0, 256, 384, 512}, false, []string{"rsa", "ec", "ec", "ec", "ec", "ed25519"}, []int{1024, 224, 256, 384, 521, 0}, true},
 		// But it should work to issue larger RSA keys.
-		/*  1 */ {"rsa", []int{0, 2048}, []int{0, 256, 384, 512}, []string{"rsa", "rsa"}, []int{2048, 3072}, false},
+		/*  1 */ {"rsa", []int{0, 2048}, []int{0, 256, 384, 512}, false, []string{"rsa", "rsa"}, []int{2048, 3072}, false},
 
 		// EC with default parameters should fail to issue smaller EC keys
 		// and any size RSA/Ed25519 keys.
-		/*  2 */ {"ec", []int{0}, []int{0}, []string{"rsa", "ec", "ed25519"}, []int{2048, 224, 0}, true},
+		/*  2 */ {"ec", []int{0}, []int{0}, false, []string{"rsa", "ec", "ed25519"}, []int{2048, 224, 0}, true},
 		// But it should work to issue larger EC keys. Note that we should be
 		// independent of signature bits as that's computed from the issuer
 		// type (for EC based issuers).
-		/*  3 */ {"ec", []int{224}, []int{0, 256, 384, 521}, []string{"ec", "ec", "ec", "ec"}, []int{224, 256, 384, 521}, false},
-		/*  4 */ {"ec", []int{0, 256}, []int{0, 256, 384, 521}, []string{"ec", "ec", "ec"}, []int{256, 384, 521}, false},
-		/*  5 */ {"ec", []int{384}, []int{0, 256, 384, 521}, []string{"ec", "ec"}, []int{384, 521}, false},
-		/*  6 */ {"ec", []int{521}, []int{0, 256, 384, 512}, []string{"ec"}, []int{521}, false},
+		/*  3 */ {"ec", []int{224}, []int{0, 256, 384, 521}, false, []string{"ec", "ec", "ec", "ec"}, []int{224, 256, 384, 521}, false},
+		/*  4 */ {"ec", []int{0, 256}, []int{0, 256, 384, 521}, false, []string{"ec", "ec", "ec"}, []int{256, 384, 521}, false},
+		/*  5 */ {"ec", []int{384}, []int{0, 256, 384, 521}, false, []string{"ec", "ec"}, []int{384, 521}, false},
+		/*  6 */ {"ec", []int{521}, []int{0, 256, 384, 512}, false, []string{"ec"}, []int{521}, false},
 
 		// Ed25519 should reject RSA and EC keys.
-		/*  7 */ {"ed25519", []int{0}, []int{0}, []string{"rsa", "ec", "ec"}, []int{2048, 256, 521}, true},
+		/*  7 */ {"ed25519", []int{0}, []int{0}, false, []string{"rsa", "ec", "ec"}, []int{2048, 256, 521}, true},
 		// But it should work to issue Ed25519 keys.
-		/*  8 */ {"ed25519", []int{0}, []int{0}, []string{"ed25519"}, []int{0}, false},
+		/*  8 */ {"ed25519", []int{0}, []int{0}, false, []string{"ed25519"}, []int{0}, false},
 
 		// Any key type should reject insecure RSA key sizes.
-		/*  9 */ {"any", []int{0}, []int{0, 256, 384, 512}, []string{"rsa", "rsa"}, []int{512, 1024}, true},
+		/*  9 */ {"any", []int{0}, []int{0, 256, 384, 512}, false, []string{"rsa", "rsa"}, []int{512, 1024}, true},
 		// But work for everything else.
-		/* 10 */ {"any", []int{0}, []int{0, 256, 384, 512}, []string{"rsa", "rsa", "ec", "ec", "ec", "ec", "ed25519"}, []int{2048, 3072, 224, 256, 384, 521, 0}, false},
+		/* 10 */ {"any", []int{0}, []int{0, 256, 384, 512}, false, []string{"rsa", "rsa", "ec", "ec", "ec", "ec", "ed25519"}, []int{2048, 3072, 224, 256, 384, 521, 0}, false},
 
 		// RSA with larger than default key size should reject smaller ones.
-		/* 11 */ {"rsa", []int{3072}, []int{0, 256, 384, 512}, []string{"rsa"}, []int{2048}, true},
+		/* 11 */ {"rsa", []int{3072}, []int{0, 256, 384, 512}, false, []string{"rsa"}, []int{2048}, true},
+
+		// We should be able to sign with PSS with any CA key type.
+		/* 12 */ {"rsa", []int{0}, []int{0, 256, 384, 512}, true, []string{"rsa"}, []int{2048}, false},
+		/* 13 */ {"ec", []int{0}, []int{0}, true, []string{"ec"}, []int{256}, false},
+		/* 14 */ {"ed25519", []int{0}, []int{0}, true, []string{"ed25519"}, []int{0}, false},
 	}
 
-	if len(testCases) != 12 {
+	if len(testCases) != 15 {
 		t.Fatalf("misnumbered test case entries will make it hard to find bugs: %v", len(testCases))
 	}
 

--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -49,6 +49,7 @@ func getGenerationParams(sc *storageContext, data *framework.FieldData) (exporte
 		KeyType:                   keyType,
 		KeyBits:                   keyBits,
 		SignatureBits:             data.Get("signature_bits").(int),
+		UsePSS:                    new(bool),
 		AllowLocalhost:            true,
 		AllowAnyName:              true,
 		AllowIPSANs:               true,
@@ -68,6 +69,12 @@ func getGenerationParams(sc *storageContext, data *framework.FieldData) (exporte
 		CNValidations:             []string{"disabled"},
 	}
 	*role.AllowWildcardCertificates = true
+
+	usePSS, present := data.GetOk("use_pss")
+	if !present {
+		usePSS = false
+	}
+	*role.UsePSS = usePSS.(bool)
 
 	if role.KeyBits, role.SignatureBits, err = certutil.ValidateDefaultOrValueKeyTypeSignatureLength(role.KeyType, role.KeyBits, role.SignatureBits); err != nil {
 		errorResp = logical.ErrorResponse(err.Error())

--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -49,7 +49,7 @@ func getGenerationParams(sc *storageContext, data *framework.FieldData) (exporte
 		KeyType:                   keyType,
 		KeyBits:                   keyBits,
 		SignatureBits:             data.Get("signature_bits").(int),
-		UsePSS:                    new(bool),
+		UsePSS:                    data.Get("use_pss").(bool),
 		AllowLocalhost:            true,
 		AllowAnyName:              true,
 		AllowIPSANs:               true,
@@ -69,12 +69,6 @@ func getGenerationParams(sc *storageContext, data *framework.FieldData) (exporte
 		CNValidations:             []string{"disabled"},
 	}
 	*role.AllowWildcardCertificates = true
-
-	usePSS, present := data.GetOk("use_pss")
-	if !present {
-		usePSS = false
-	}
-	*role.UsePSS = usePSS.(bool)
 
 	if role.KeyBits, role.SignatureBits, err = certutil.ValidateDefaultOrValueKeyTypeSignatureLength(role.KeyType, role.KeyBits, role.SignatureBits); err != nil {
 		errorResp = logical.ErrorResponse(err.Error())

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -1374,7 +1374,7 @@ func generateCreationBundle(b *backend, data *inputBundle, caSign *certutil.CAIn
 			KeyType:                       data.role.KeyType,
 			KeyBits:                       data.role.KeyBits,
 			SignatureBits:                 data.role.SignatureBits,
-			UsePSS:                        false,
+			UsePSS:                        data.role.UsePSS,
 			NotAfter:                      notAfter,
 			KeyUsage:                      x509.KeyUsage(parseKeyUsages(data.role.KeyUsage)),
 			ExtKeyUsage:                   parseExtKeyUsages(data.role),
@@ -1387,9 +1387,6 @@ func generateCreationBundle(b *backend, data *inputBundle, caSign *certutil.CAIn
 		},
 		SigningBundle: caSign,
 		CSR:           csr,
-	}
-	if data.role.UsePSS != nil {
-		creation.Params.UsePSS = *data.role.UsePSS
 	}
 
 	// Don't deal with URLs or max path length if it's self-signed, as these

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -1373,6 +1373,7 @@ func generateCreationBundle(b *backend, data *inputBundle, caSign *certutil.CAIn
 			KeyType:                       data.role.KeyType,
 			KeyBits:                       data.role.KeyBits,
 			SignatureBits:                 data.role.SignatureBits,
+			UsePSS:                        false,
 			NotAfter:                      notAfter,
 			KeyUsage:                      x509.KeyUsage(parseKeyUsages(data.role.KeyUsage)),
 			ExtKeyUsage:                   parseExtKeyUsages(data.role),
@@ -1385,6 +1386,9 @@ func generateCreationBundle(b *backend, data *inputBundle, caSign *certutil.CAIn
 		},
 		SigningBundle: caSign,
 		CSR:           csr,
+	}
+	if data.role.UsePSS != nil {
+		creation.Params.UsePSS = *data.role.UsePSS
 	}
 
 	// Don't deal with URLs or max path length if it's self-signed, as these

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -138,6 +138,7 @@ func (sc *storageContext) fetchCAInfoByIssuerId(issuerId issuerID, usage issuerU
 		ParsedCertBundle:     *parsedBundle,
 		URLs:                 nil,
 		LeafNotAfterBehavior: entry.LeafNotAfterBehavior,
+		RevocationSigAlg:     entry.RevocationSigAlg,
 	}
 
 	entries, err := getURLs(sc.Context, sc.Storage)

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -622,6 +622,7 @@ WRITE:
 		Number:              big.NewInt(crlNumber),
 		ThisUpdate:          time.Now(),
 		NextUpdate:          time.Now().Add(crlLifetime),
+		SignatureAlgorithm:  signingBundle.RevocationSigAlg,
 	}
 
 	crlBytes, err := x509.CreateRevocationList(rand.Reader, revocationListTemplate, signingBundle.Certificate, signingBundle.PrivateKey)

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -319,6 +319,13 @@ SHA-2-512. Defaults to 0 to automatically detect based on key length
 		},
 	}
 
+	fields["use_pss"] = &framework.FieldSchema{
+		Type:    framework.TypeBool,
+		Default: false,
+		Description: `Whether or not to use PSS signatures when using a
+RSA key-type issuer. Defaults to false.`,
+	}
+
 	fields["key_type"] = &framework.FieldSchema{
 		Type:    framework.TypeString,
 		Default: "rsa",

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -273,7 +273,7 @@ func (b *backend) pathUpdateIssuer(ctx context.Context, req *logical.Request, da
 
 	// Revocation signature algorithm changes
 	revSigAlgStr := data.Get("revocation_signature_algorithm").(string)
-	revSigAlg, present := certutil.SignatureAlgorithmNames[revSigAlgStr]
+	revSigAlg, present := certutil.SignatureAlgorithmNames[strings.ToLower(revSigAlgStr)]
 	if !present && revSigAlgStr != "" {
 		var knownAlgos []string
 		for algoName := range certutil.SignatureAlgorithmNames {
@@ -465,7 +465,7 @@ func (b *backend) pathPatchIssuer(ctx context.Context, req *logical.Request, dat
 	rawRevSigAlg, ok := data.GetOk("revocation_signature_algorithm")
 	if ok {
 		revSigAlgStr := rawRevSigAlg.(string)
-		revSigAlg, present := certutil.SignatureAlgorithmNames[revSigAlgStr]
+		revSigAlg, present := certutil.SignatureAlgorithmNames[strings.ToLower(revSigAlgStr)]
 		if !present && revSigAlgStr != "" {
 			var knownAlgos []string
 			for algoName := range certutil.SignatureAlgorithmNames {

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -191,6 +191,11 @@ func respondReadIssuer(issuer *issuerEntry) (*logical.Response, error) {
 		respManualChain = append(respManualChain, string(entity))
 	}
 
+	revSigAlgStr := issuer.RevocationSigAlg.String()
+	if issuer.RevocationSigAlg == x509.UnknownSignatureAlgorithm {
+		revSigAlgStr = ""
+	}
+
 	return &logical.Response{
 		Data: map[string]interface{}{
 			"issuer_id":                      issuer.ID,
@@ -201,7 +206,7 @@ func respondReadIssuer(issuer *issuerEntry) (*logical.Response, error) {
 			"ca_chain":                       issuer.CAChain,
 			"leaf_not_after_behavior":        issuer.LeafNotAfterBehavior.String(),
 			"usage":                          issuer.Usage.Names(),
-			"revocation_signature_algorithm": issuer.RevocationSigAlg,
+			"revocation_signature_algorithm": revSigAlgStr,
 		},
 	}, nil
 }

--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -66,13 +66,18 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 	// Nasty hack part two. :-) For generation of CSRs, certutil presently doesn't
 	// support configuration of this. However, because we need generation parameters,
 	// which create a role and attempt to read this parameter, we need to provide
-	// a value (which will be ignored). Hence, we stub in the missing parameter here,
+	// a value (which will be ignored). Hence, we stub in the missing parameters here,
 	// including its schema, just enough for it to work..
 	data.Schema["signature_bits"] = &framework.FieldSchema{
 		Type:    framework.TypeInt,
 		Default: 0,
 	}
 	data.Raw["signature_bits"] = 0
+	data.Schema["use_pss"] = &framework.FieldSchema{
+		Type:    framework.TypeBool,
+		Default: false,
+	}
+	data.Raw["use_pss"] = false
 
 	sc := b.makeStorageContext(ctx, req.Storage)
 	exported, format, role, errorResp := getGenerationParams(sc, data)

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -151,6 +151,13 @@ SHA-2-512. Defaults to 0 to automatically detect based on key length
 		},
 	}
 
+	ret.Fields["use_pss"] = &framework.FieldSchema{
+		Type:    framework.TypeBool,
+		Default: false,
+		Description: `Whether or not to use PSS signatures when using a
+RSA key-type issuer. Defaults to false.`,
+	}
+
 	return ret
 }
 
@@ -211,10 +218,17 @@ func (b *backend) pathSignVerbatim(ctx context.Context, req *logical.Request, da
 		ExtKeyUsage:               data.Get("ext_key_usage").([]string),
 		ExtKeyUsageOIDs:           data.Get("ext_key_usage_oids").([]string),
 		SignatureBits:             data.Get("signature_bits").(int),
+		UsePSS:                    new(bool),
 	}
 	*entry.AllowWildcardCertificates = true
 
 	*entry.GenerateLease = false
+
+	usePSS, present := data.GetOk("use_pss")
+	if !present {
+		usePSS = false
+	}
+	*entry.UsePSS = usePSS.(bool)
 
 	if role != nil {
 		if role.TTL > 0 {

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -218,17 +218,11 @@ func (b *backend) pathSignVerbatim(ctx context.Context, req *logical.Request, da
 		ExtKeyUsage:               data.Get("ext_key_usage").([]string),
 		ExtKeyUsageOIDs:           data.Get("ext_key_usage_oids").([]string),
 		SignatureBits:             data.Get("signature_bits").(int),
-		UsePSS:                    new(bool),
+		UsePSS:                    data.Get("use_pss").(bool),
 	}
 	*entry.AllowWildcardCertificates = true
 
 	*entry.GenerateLease = false
-
-	usePSS, present := data.GetOk("use_pss")
-	if !present {
-		usePSS = false
-	}
-	*entry.UsePSS = usePSS.(bool)
 
 	if role != nil {
 		if role.TTL > 0 {

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -82,6 +82,7 @@ with Active Directory Certificate Services.`,
 	// signed certificate's bits (that's on the /sign-intermediate
 	// endpoints). Remove it from the list of fields to avoid confusion.
 	delete(ret.Fields, "signature_bits")
+	delete(ret.Fields, "use_pss")
 
 	return ret
 }

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -239,6 +239,13 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 	if len(createdIssuers) > 0 {
 		err := b.crlBuilder.rebuild(ctx, b, req, true)
 		if err != nil {
+			// Before returning, check if the error message includes the
+			// string "PSS". If so, it indicates we might've wanted to modify
+			// this issuer, so convert the error to a warning.
+			if strings.Contains(err.Error(), "PSS") || strings.Contains(err.Error(), "pss") {
+				err = fmt.Errorf("Rebuilding the CRL failed with a message relating to the PSS signature algorithm. This likely means the revocation_signature_algorithm needs to be set on the newly imported issuer(s) because a managed key supports only the PSS algorithm; by default PKCS#1v1.5 was used to build the CRLs. CRLs will not be generated until this has been addressed, however the import was successful. The original error is reproduced below:\n\n\t%v", err)
+			}
+
 			return nil, err
 		}
 	}

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -594,13 +594,6 @@ func (b *backend) getRole(ctx context.Context, s logical.Storage, n string) (*ro
 		modified = true
 	}
 
-	// Update PSS usage to be the present default; false.
-	if result.UsePSS == nil {
-		result.UsePSS = new(bool)
-		*result.UsePSS = false
-		modified = true
-	}
-
 	// Ensure the role is valid after updating.
 	_, err = validateRole(b, &result, ctx, s)
 	if err != nil {
@@ -687,7 +680,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		KeyType:                       data.Get("key_type").(string),
 		KeyBits:                       data.Get("key_bits").(int),
 		SignatureBits:                 data.Get("signature_bits").(int),
-		UsePSS:                        new(bool),
+		UsePSS:                        data.Get("use_pss").(bool),
 		UseCSRCommonName:              data.Get("use_csr_common_name").(bool),
 		UseCSRSANs:                    data.Get("use_csr_sans").(bool),
 		KeyUsage:                      data.Get("key_usage").([]string),
@@ -732,12 +725,6 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		allowWildcardCertificates = true
 	}
 	*entry.AllowWildcardCertificates = allowWildcardCertificates.(bool)
-
-	usePSS, present := data.GetOk("use_pss")
-	if !present {
-		usePSS = false
-	}
-	*entry.UsePSS = usePSS.(bool)
 
 	warning := ""
 	// no_store implies generate_lease := false
@@ -890,7 +877,7 @@ func (b *backend) pathRolePatch(ctx context.Context, req *logical.Request, data 
 		KeyType:                       getWithExplicitDefault(data, "key_type", oldEntry.KeyType).(string),
 		KeyBits:                       getWithExplicitDefault(data, "key_bits", oldEntry.KeyBits).(int),
 		SignatureBits:                 getWithExplicitDefault(data, "signature_bits", oldEntry.SignatureBits).(int),
-		UsePSS:                        new(bool),
+		UsePSS:                        getWithExplicitDefault(data, "use_pss", oldEntry.UsePSS).(bool),
 		UseCSRCommonName:              getWithExplicitDefault(data, "use_csr_common_name", oldEntry.UseCSRCommonName).(bool),
 		UseCSRSANs:                    getWithExplicitDefault(data, "use_csr_sans", oldEntry.UseCSRSANs).(bool),
 		KeyUsage:                      getWithExplicitDefault(data, "key_usage", oldEntry.KeyUsage).([]string),
@@ -937,12 +924,6 @@ func (b *backend) pathRolePatch(ctx context.Context, req *logical.Request, data 
 		allowWildcardCertificates = *oldEntry.AllowWildcardCertificates
 	}
 	*entry.AllowWildcardCertificates = allowWildcardCertificates.(bool)
-
-	usePSS, present := data.GetOk("use_pss")
-	if !present {
-		usePSS = *oldEntry.UsePSS
-	}
-	*entry.UsePSS = usePSS.(bool)
 
 	warning := ""
 	generateLease, ok := data.GetOk("generate_lease")
@@ -1091,7 +1072,7 @@ type roleEntry struct {
 	UseCSRSANs                    bool          `json:"use_csr_sans"`
 	KeyType                       string        `json:"key_type"`
 	KeyBits                       int           `json:"key_bits"`
-	UsePSS                        *bool         `json:"use_pss"`
+	UsePSS                        bool          `json:"use_pss"`
 	SignatureBits                 int           `json:"signature_bits"`
 	MaxPathLength                 *int          `json:",omitempty"`
 	KeyUsageOld                   string        `json:"key_usage,omitempty"`

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -290,6 +290,7 @@ func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.R
 		EnforceHostnames:          false,
 		KeyType:                   "any",
 		SignatureBits:             data.Get("signature_bits").(int),
+		UsePSS:                    new(bool),
 		AllowedOtherSANs:          []string{"*"},
 		AllowedSerialNumbers:      []string{"*"},
 		AllowedURISANs:            []string{"*"},
@@ -298,6 +299,12 @@ func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.R
 		CNValidations:             []string{"disabled"},
 	}
 	*role.AllowWildcardCertificates = true
+
+	usePSS, present := data.GetOk("use_pss")
+	if !present {
+		usePSS = false
+	}
+	*role.UsePSS = usePSS.(bool)
 
 	if cn := data.Get("common_name").(string); len(cn) == 0 {
 		role.UseCSRCommonName = true

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -239,7 +239,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 	// Update the issuer to reflect the PSS status here for revocation; this
 	// allows CRL building to succeed if the root is using a managed key with
 	// only PSS support.
-	if input.role.KeyType == "rsa" && *input.role.UsePSS {
+	if input.role.KeyType == "rsa" && input.role.UsePSS {
 		myIssuer.RevocationSigAlg = x509.SHA256WithRSAPSS
 		switch input.role.SignatureBits {
 		case 384:
@@ -307,7 +307,7 @@ func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.R
 		EnforceHostnames:          false,
 		KeyType:                   "any",
 		SignatureBits:             data.Get("signature_bits").(int),
-		UsePSS:                    new(bool),
+		UsePSS:                    data.Get("use_pss").(bool),
 		AllowedOtherSANs:          []string{"*"},
 		AllowedSerialNumbers:      []string{"*"},
 		AllowedURISANs:            []string{"*"},
@@ -316,12 +316,6 @@ func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.R
 		CNValidations:             []string{"disabled"},
 	}
 	*role.AllowWildcardCertificates = true
-
-	usePSS, present := data.GetOk("use_pss")
-	if !present {
-		usePSS = false
-	}
-	*role.UsePSS = usePSS.(bool)
 
 	if cn := data.Get("common_name").(string); len(cn) == 0 {
 		role.UseCSRCommonName = true

--- a/builtin/logical/pki/path_sign_issuers.go
+++ b/builtin/logical/pki/path_sign_issuers.go
@@ -85,6 +85,13 @@ in the above RFC section.`,
 		},
 	}
 
+	fields["use_pss"] = &framework.FieldSchema{
+		Type:    framework.TypeBool,
+		Default: false,
+		Description: `Whether or not to use PSS signatures when using a
+RSA key-type issuer. Defaults to false.`,
+	}
+
 	return path
 }
 

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -284,6 +284,10 @@ func CBWrite(b *backend, s logical.Storage, path string, data map[string]interfa
 	return CBReq(b, s, logical.UpdateOperation, path, data)
 }
 
+func CBPatch(b *backend, s logical.Storage, path string, data map[string]interface{}) (*logical.Response, error) {
+	return CBReq(b, s, logical.PatchOperation, path, data)
+}
+
 func CBList(b *backend, s logical.Storage, path string) (*logical.Response, error) {
 	return CBReq(b, s, logical.ListOperation, path, make(map[string]interface{}))
 }

--- a/changelog/16519.txt
+++ b/changelog/16519.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secret/pki: Add RSA PSS signature support for issuing certificates, signing CRLs
+```

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -51,17 +51,17 @@ var expectedNISTPCurveHashBits = map[int]int{
 
 // Mapping of constant names<->constant values for SignatureAlgorithm
 var SignatureAlgorithmNames = map[string]x509.SignatureAlgorithm{
-	"SHA256WithRSA":    x509.SHA256WithRSA,
-	"SHA384WithRSA":    x509.SHA384WithRSA,
-	"SHA512WithRSA":    x509.SHA512WithRSA,
-	"ECDSAWithSHA256":  x509.ECDSAWithSHA256,
-	"ECDSAWithSHA384":  x509.ECDSAWithSHA384,
-	"ECDSAWithSHA512":  x509.ECDSAWithSHA512,
-	"SHA256WithRSAPSS": x509.SHA256WithRSAPSS,
-	"SHA384WithRSAPSS": x509.SHA384WithRSAPSS,
-	"SHA512WithRSAPSS": x509.SHA512WithRSAPSS,
-	"PureEd25519":      x509.PureEd25519,
-	"Ed25519":          x509.PureEd25519, // Duplicated for clarity; most won't expect the "Pure" prefix.
+	"sha256withrsa":    x509.SHA256WithRSA,
+	"sha384withrsa":    x509.SHA384WithRSA,
+	"sha512withrsa":    x509.SHA512WithRSA,
+	"ecdsawithsha256":  x509.ECDSAWithSHA256,
+	"ecdsawithsha384":  x509.ECDSAWithSHA384,
+	"ecdsawithsha512":  x509.ECDSAWithSHA512,
+	"sha256withrsapss": x509.SHA256WithRSAPSS,
+	"sha384withrsapss": x509.SHA384WithRSAPSS,
+	"sha512withrsapss": x509.SHA512WithRSAPSS,
+	"pureed25519":      x509.PureEd25519,
+	"ed25519":          x509.PureEd25519, // Duplicated for clarity; most won't expect the "Pure" prefix.
 }
 
 // GetHexFormatted returns the byte buffer formatted in hex with

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -49,6 +49,21 @@ var expectedNISTPCurveHashBits = map[int]int{
 	521: 512,
 }
 
+// Mapping of constant names<->constant values for SignatureAlgorithm
+var SignatureAlgorithmNames = map[string]x509.SignatureAlgorithm{
+	"SHA256WithRSA":    x509.SHA256WithRSA,
+	"SHA384WithRSA":    x509.SHA384WithRSA,
+	"SHA512WithRSA":    x509.SHA512WithRSA,
+	"ECDSAWithSHA256":  x509.ECDSAWithSHA256,
+	"ECDSAWithSHA384":  x509.ECDSAWithSHA384,
+	"ECDSAWithSHA512":  x509.ECDSAWithSHA512,
+	"SHA256WithRSAPSS": x509.SHA256WithRSAPSS,
+	"SHA384WithRSAPSS": x509.SHA384WithRSAPSS,
+	"SHA512WithRSAPSS": x509.SHA512WithRSAPSS,
+	"PureEd25519":      x509.PureEd25519,
+	"Ed25519":          x509.PureEd25519, // Duplicated for clarity; most won't expect the "Pure" prefix.
+}
+
 // GetHexFormatted returns the byte buffer formatted in hex with
 // the specified separator between bytes.
 func GetHexFormatted(buf []byte, sep string) string {

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -781,6 +781,29 @@ func CreateCertificateWithKeyGenerator(data *CreationBundle, randReader io.Reade
 	return createCertificate(data, randReader, keyGenerator)
 }
 
+// Set correct correct RSA sig algo
+func certTemplateSetSigAlgo(certTemplate *x509.Certificate, data *CreationBundle) {
+	if data.Params.UsePSS {
+		switch data.Params.SignatureBits {
+		case 256:
+			certTemplate.SignatureAlgorithm = x509.SHA256WithRSAPSS
+		case 384:
+			certTemplate.SignatureAlgorithm = x509.SHA384WithRSAPSS
+		case 512:
+			certTemplate.SignatureAlgorithm = x509.SHA512WithRSAPSS
+		}
+	} else {
+		switch data.Params.SignatureBits {
+		case 256:
+			certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
+		case 384:
+			certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
+		case 512:
+			certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
+		}
+	}
+}
+
 func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGenerator KeyGenerator) (*ParsedCertBundle, error) {
 	var err error
 	result := &ParsedCertBundle{}
@@ -849,25 +872,7 @@ func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGen
 	if data.SigningBundle != nil {
 		switch data.SigningBundle.PrivateKeyType {
 		case RSAPrivateKey:
-			if data.Params.UsePSS {
-				switch data.Params.SignatureBits {
-				case 256:
-					certTemplate.SignatureAlgorithm = x509.SHA256WithRSAPSS
-				case 384:
-					certTemplate.SignatureAlgorithm = x509.SHA384WithRSAPSS
-				case 512:
-					certTemplate.SignatureAlgorithm = x509.SHA512WithRSAPSS
-				}
-			} else {
-				switch data.Params.SignatureBits {
-				case 256:
-					certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
-				case 384:
-					certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
-				case 512:
-					certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
-				}
-			}
+			certTemplateSetSigAlgo(certTemplate, data)
 		case Ed25519PrivateKey:
 			certTemplate.SignatureAlgorithm = x509.PureEd25519
 		case ECPrivateKey:
@@ -889,25 +894,7 @@ func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGen
 
 		switch data.Params.KeyType {
 		case "rsa":
-			if data.Params.UsePSS {
-				switch data.Params.SignatureBits {
-				case 256:
-					certTemplate.SignatureAlgorithm = x509.SHA256WithRSAPSS
-				case 384:
-					certTemplate.SignatureAlgorithm = x509.SHA384WithRSAPSS
-				case 512:
-					certTemplate.SignatureAlgorithm = x509.SHA512WithRSAPSS
-				}
-			} else {
-				switch data.Params.SignatureBits {
-				case 256:
-					certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
-				case 384:
-					certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
-				case 512:
-					certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
-				}
-			}
+			certTemplateSetSigAlgo(certTemplate, data)
 		case "ed25519":
 			certTemplate.SignatureAlgorithm = x509.PureEd25519
 		case "ec":
@@ -1134,25 +1121,7 @@ func signCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertBun
 
 	switch data.SigningBundle.PrivateKeyType {
 	case RSAPrivateKey:
-		if data.Params.UsePSS {
-			switch data.Params.SignatureBits {
-			case 256:
-				certTemplate.SignatureAlgorithm = x509.SHA256WithRSAPSS
-			case 384:
-				certTemplate.SignatureAlgorithm = x509.SHA384WithRSAPSS
-			case 512:
-				certTemplate.SignatureAlgorithm = x509.SHA512WithRSAPSS
-			}
-		} else {
-			switch data.Params.SignatureBits {
-			case 256:
-				certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
-			case 384:
-				certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
-			case 512:
-				certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
-			}
-		}
+		certTemplateSetSigAlgo(certTemplate, data)
 	case ECPrivateKey:
 		switch data.Params.SignatureBits {
 		case 256:

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -834,13 +834,24 @@ func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGen
 	if data.SigningBundle != nil {
 		switch data.SigningBundle.PrivateKeyType {
 		case RSAPrivateKey:
-			switch data.Params.SignatureBits {
-			case 256:
-				certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
-			case 384:
-				certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
-			case 512:
-				certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
+			if data.Params.UsePSS {
+				switch data.Params.SignatureBits {
+				case 256:
+					certTemplate.SignatureAlgorithm = x509.SHA256WithRSAPSS
+				case 384:
+					certTemplate.SignatureAlgorithm = x509.SHA384WithRSAPSS
+				case 512:
+					certTemplate.SignatureAlgorithm = x509.SHA512WithRSAPSS
+				}
+			} else {
+				switch data.Params.SignatureBits {
+				case 256:
+					certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
+				case 384:
+					certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
+				case 512:
+					certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
+				}
 			}
 		case Ed25519PrivateKey:
 			certTemplate.SignatureAlgorithm = x509.PureEd25519
@@ -863,13 +874,24 @@ func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGen
 
 		switch data.Params.KeyType {
 		case "rsa":
-			switch data.Params.SignatureBits {
-			case 256:
-				certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
-			case 384:
-				certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
-			case 512:
-				certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
+			if data.Params.UsePSS {
+				switch data.Params.SignatureBits {
+				case 256:
+					certTemplate.SignatureAlgorithm = x509.SHA256WithRSAPSS
+				case 384:
+					certTemplate.SignatureAlgorithm = x509.SHA384WithRSAPSS
+				case 512:
+					certTemplate.SignatureAlgorithm = x509.SHA512WithRSAPSS
+				}
+			} else {
+				switch data.Params.SignatureBits {
+				case 256:
+					certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
+				case 384:
+					certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
+				case 512:
+					certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
+				}
 			}
 		case "ed25519":
 			certTemplate.SignatureAlgorithm = x509.PureEd25519
@@ -1097,13 +1119,24 @@ func signCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertBun
 
 	switch data.SigningBundle.PrivateKeyType {
 	case RSAPrivateKey:
-		switch data.Params.SignatureBits {
-		case 256:
-			certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
-		case 384:
-			certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
-		case 512:
-			certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
+		if data.Params.UsePSS {
+			switch data.Params.SignatureBits {
+			case 256:
+				certTemplate.SignatureAlgorithm = x509.SHA256WithRSAPSS
+			case 384:
+				certTemplate.SignatureAlgorithm = x509.SHA384WithRSAPSS
+			case 512:
+				certTemplate.SignatureAlgorithm = x509.SHA512WithRSAPSS
+			}
+		} else {
+			switch data.Params.SignatureBits {
+			case 256:
+				certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
+			case 384:
+				certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
+			case 512:
+				certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
+			}
 		}
 	case ECPrivateKey:
 		switch data.Params.SignatureBits {

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -782,6 +782,7 @@ type CreationParameters struct {
 	PolicyIdentifiers             []string
 	BasicConstraintsValidForNonCA bool
 	SignatureBits                 int
+	UsePSS                        bool
 	ForceAppendCaChain            bool
 
 	// Only used when signing a CA cert

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -710,6 +710,7 @@ type CAInfoBundle struct {
 	ParsedCertBundle
 	URLs                 *URLEntries
 	LeafNotAfterBehavior NotAfterBehavior
+	RevocationSigAlg     x509.SignatureAlgorithm
 }
 
 func (b *CAInfoBundle) GetCAChain() []*CertBlock {

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -581,6 +581,10 @@ when signing an externally-owned intermediate.
    certain TLS implementations (such as OpenSSL) which use SKID/AKID
    matches in chain building to restrict possible valid chains.
 
+- `use_pss` `(bool: false)` - Specifies whether or not to use PSS signatures
+  over PKCS#1v1.5 signatures when a RSA-type issuer is used. Ignored for
+  ECDSA/Ed25519 issuers.
+
 #### Sample Payload
 
 ```json
@@ -770,6 +774,10 @@ have access.**
 ~> **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
    `signature_bits` value; only RSA issuers will change signature types
    based on this parameter.
+
+- `use_pss` `(bool: false)` - Specifies whether or not to use PSS signatures
+  over PKCS#1v1.5 signatures when a RSA-type issuer is used. Ignored for
+  ECDSA/Ed25519 issuers.
 
 #### Sample Payload
 
@@ -1898,6 +1906,18 @@ do so, import a new issuer and a new `issuer_id` will be assigned.
    could be marked `usage=read-only`, freezing the CRL. Finally, after a grace
    period, the issuer could be deleted.
 
+- `revocation_signature_algorithm` `(string: "")` - Which signature algorithm
+  to use when building CRLs. See Go's [`x509.SignatureAlgorithm`](https://pkg.go.dev/crypto/x509#SignatureAlgorithm)
+  constant for possible values. This flag allows control over hash function
+  and signature scheme (PKCS#1v1.5 vs PSS). The default (empty string) value
+  is for Go to select the signature algorithm automatically, which may not
+  always work.
+
+~> Note: This can fail if the underlying key does not support the requested
+   signature algorithm; this may not always be known at modification time.
+   This most commonly needs to be modified when using PKCS#11 managed keys
+   with the `CKM_RSA_PKCS_PSS` mechanism type.
+
 #### Sample Payload
 
 ```json
@@ -2369,6 +2389,10 @@ request is denied.
 ~> **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
    `signature_bits` value; only RSA issuers will change signature types
    based on this parameter.
+
+- `use_pss` `(bool: false)` - Specifies whether or not to use PSS signatures
+  over PKCS#1v1.5 signatures when a RSA-type issuer is used. Ignored for
+  ECDSA/Ed25519 issuers.
 
 - `key_usage` `(list: ["DigitalSignature", "KeyAgreement", "KeyEncipherment"])` -
   Specifies the allowed key usage constraint on issued certificates. Valid


### PR DESCRIPTION
Noting that NIST is deprecating PKCS#1v1.5 signatures here at the end of December 2023, we've gone ahead and added PSS support for RSA-typed issuers in the PKI Secrets Mount. 

This introduces two changes:

 - `use_pss` on roles and signing endpoints (such as `/sign-verbatim` &c) -- this allows us to create self-signed roots & intermediates using the PSS algorithm.
 - Setting a `revocation_signature_algorithm` on the Issuer, allowing us to choose override the default signature on CRLs &c.

This should let us work with PSS-only keys in the future (from say, a HSM) in Vault Enterprise within the PKI mount.