### PR TITLE
auth/gcp: updates plugin to v0.12.2

### DIFF
--- a/changelog/16524.txt
+++ b/changelog/16524.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/gcp: Fixes the ability to reset the configuration's credentials to use application default credentials.
+```

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-azure v0.10.0
 	github.com/hashicorp/vault-plugin-auth-centrify v0.11.0
 	github.com/hashicorp/vault-plugin-auth-cf v0.11.0
-	github.com/hashicorp/vault-plugin-auth-gcp v0.12.1
+	github.com/hashicorp/vault-plugin-auth-gcp v0.12.2
 	github.com/hashicorp/vault-plugin-auth-jwt v0.12.1
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.6.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.12.1

--- a/go.sum
+++ b/go.sum
@@ -962,8 +962,8 @@ github.com/hashicorp/vault-plugin-auth-centrify v0.11.0 h1:W1Al8Kw4VvXm/mtDdzgBa
 github.com/hashicorp/vault-plugin-auth-centrify v0.11.0/go.mod h1:3fDbIVdwA/hkOVhwktKHDX5lo4DqIUUVbBdwQNNvxHw=
 github.com/hashicorp/vault-plugin-auth-cf v0.11.0 h1:W8KkpZv8AHM9eMYrTgCmc9aKac/KORzby7Go0I0MpQ8=
 github.com/hashicorp/vault-plugin-auth-cf v0.11.0/go.mod h1:4HM4amMEcCyoLZNNjyz5AYILIlhMLTErxrinM3Vopy4=
-github.com/hashicorp/vault-plugin-auth-gcp v0.12.1 h1:LOxL1IedHBEkgziRelh3yv8gIKognoyRDqTuhJFZsr4=
-github.com/hashicorp/vault-plugin-auth-gcp v0.12.1/go.mod h1:mNOajlE7KlNecnCqO1we+PG0/EIHgHMTuVhk/H2W+Tw=
+github.com/hashicorp/vault-plugin-auth-gcp v0.12.2 h1:P84dkVKna7snHSYnH8iBt6cbuTMuyYrvyV6Xpw2TDYU=
+github.com/hashicorp/vault-plugin-auth-gcp v0.12.2/go.mod h1:mNOajlE7KlNecnCqO1we+PG0/EIHgHMTuVhk/H2W+Tw=
 github.com/hashicorp/vault-plugin-auth-jwt v0.12.1 h1:F8aNPecN7Bihyndku9g1XrGOy4ioQM8JE+Uhg/e8nFY=
 github.com/hashicorp/vault-plugin-auth-jwt v0.12.1/go.mod h1:+WL5kaq/0L5OROsA31X15U8yTIX4GTEv1rTLA9d15eo=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.6.0 h1:5GiKYqA8NTW9QPA1gahok2CVTKwa50lccB30i3GLffk=


### PR DESCRIPTION
This PR updates vault-plugin-auth-gcp to [v0.12.2](https://github.com/hashicorp/vault-plugin-auth-gcp/releases/tag/v0.12.2) to bring in a bug fix from https://github.com/hashicorp/vault-plugin-auth-gcp/pull/132.

Steps:
```
go get -d github.com/hashicorp/vault-plugin-auth-gcp@v0.12.2
go mod tidy
```