### PR TITLE
db/elasticsearch: update plugin to v0.11.1

### DIFF
--- a/changelog/16526.txt
+++ b/changelog/16526.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+database/elasticsearch: Fixes a bug in boolean parsing for initialize
+```

--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.13.0
 	github.com/hashicorp/vault-plugin-auth-oci v0.11.0
 	github.com/hashicorp/vault-plugin-database-couchbase v0.7.0
-	github.com/hashicorp/vault-plugin-database-elasticsearch v0.11.0
+	github.com/hashicorp/vault-plugin-database-elasticsearch v0.11.1
 	github.com/hashicorp/vault-plugin-database-mongodbatlas v0.7.0
 	github.com/hashicorp/vault-plugin-database-snowflake v0.5.1
 	github.com/hashicorp/vault-plugin-mock v0.16.1

--- a/go.sum
+++ b/go.sum
@@ -988,8 +988,8 @@ github.com/hashicorp/vault-plugin-auth-oci v0.11.0 h1:DrdccnGU8O28I1MIs21zmbYM2N
 github.com/hashicorp/vault-plugin-auth-oci v0.11.0/go.mod h1:Cn5cjR279Y+snw8LTaiLTko3KGrbigRbsQPOd2D5xDw=
 github.com/hashicorp/vault-plugin-database-couchbase v0.7.0 h1:p//NCrYPF7AlCFtwKsO6dT7RvINSq3/x1VN19nfPlK4=
 github.com/hashicorp/vault-plugin-database-couchbase v0.7.0/go.mod h1:Xw7uSxLWTzyWRHZhOBoc51cBC2nmNc7ekPgaaKK7UWI=
-github.com/hashicorp/vault-plugin-database-elasticsearch v0.11.0 h1:3L3/KB7323cBkTzGDrRwVMcGtDMhU5VTWw9bYcVorEU=
-github.com/hashicorp/vault-plugin-database-elasticsearch v0.11.0/go.mod h1:OMEQaNXsITksICGgkWW2y9/Nekv/cPKdqGOcMW5uUdI=
+github.com/hashicorp/vault-plugin-database-elasticsearch v0.11.1 h1:XU2b1wrvHNeQafypbJ0Xs6Zec0kN5VzMZ0AJzWXlI+4=
+github.com/hashicorp/vault-plugin-database-elasticsearch v0.11.1/go.mod h1:OMEQaNXsITksICGgkWW2y9/Nekv/cPKdqGOcMW5uUdI=
 github.com/hashicorp/vault-plugin-database-mongodbatlas v0.7.0 h1:TAyYn8/rWn+OeeiYAqlACV4q7A5YYDv3vVqucHTJgxE=
 github.com/hashicorp/vault-plugin-database-mongodbatlas v0.7.0/go.mod h1:e3HTaMD+aRWHBVctX/M39OaARQA8ux9TvdWDU0dJaoc=
 github.com/hashicorp/vault-plugin-database-snowflake v0.5.1 h1:/arASm4g8nyZrL2DxDSWhhQ7RjTrveXHURL3dRIfHM0=


### PR DESCRIPTION
This PR updates vault-plugin-database-elasticsearch to [v0.11.1](https://github.com/hashicorp/vault-plugin-database-elasticsearch/releases/tag/v0.11.1) to bring in a bug fix from https://github.com/hashicorp/vault-plugin-database-elasticsearch/pull/38


Steps:

```
go get -d github.com/hashicorp/vault-plugin-database-elasticsearch@v0.11.1
go mod tidy
```