### PR TITLE
Update Go version changelog checker to indicate underscore is required

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -39,11 +39,11 @@ jobs:
 
           if [ -z "$changelog_files" ]; then
             echo "Not found."
-            echo "looking for changelog file matching changelog/go-ver-*.txt"
+            echo "looking for changelog file matching changelog/_go-ver-*.txt"
             # If we do not find a file matching the PR # in changelog/, we fail the check
             # unless we did a Go toolchain version update, in which case we check the
             # alternative name.
-            toolchain_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/${{ github.event.pull_request.base.ref }}")" -- 'changelog/go-ver-*.txt')
+            toolchain_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/${{ github.event.pull_request.base.ref }}")" -- 'changelog/_go-ver-*.txt')
             if [ -z "$toolchain_files" ]; then
               echo "Not found."
               echo ""
@@ -82,8 +82,8 @@ jobs:
             exit 1
           elif grep -q '^core: Bump Go version' "$changelog_files"; then
             echo "Don't use PR numbered changelog entries for Go version bumps!"
-            echo "Please use the format changelog/go-ver-<VAULT_VERSION_WITHOUT_DOTS>.txt instead."
-            echo "Example: go-ver-1110.txt for Vault 1.11.0"
+            echo "Please use the format changelog/_go-ver-<VAULT_VERSION_WITHOUT_DOTS>.txt instead."
+            echo "Example: _go-ver-1110.txt for Vault 1.11.0"
             exit 1
           else
             echo "Found changelog entry in PR!"


### PR DESCRIPTION
 - Bringing back @mladlow's work that was done in ENT to OSS updating our filename checks for Go version bumps in the changelog checker