### PR TITLE
secrets/gcp: updates plugin to v0.13.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-ad v0.13.1
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.12.0
 	github.com/hashicorp/vault-plugin-secrets-azure v0.13.0
-	github.com/hashicorp/vault-plugin-secrets-gcp v0.13.0
+	github.com/hashicorp/vault-plugin-secrets-gcp v0.13.1
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.12.0
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.1
 	github.com/hashicorp/vault-plugin-secrets-kv v0.12.1

--- a/go.sum
+++ b/go.sum
@@ -1002,8 +1002,8 @@ github.com/hashicorp/vault-plugin-secrets-alicloud v0.12.0 h1:4Ke3dtM7ARa9ga2jI2
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.12.0/go.mod h1:F4KWrlCQZbhP2dFXCkRvbHX2J6CTydlaY0cH+OrLHCE=
 github.com/hashicorp/vault-plugin-secrets-azure v0.13.0 h1:35JsvhKhvuATkP6vVQisA4prHd2gjzX4AT0CPvPXJ7I=
 github.com/hashicorp/vault-plugin-secrets-azure v0.13.0/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.13.0 h1:GDh70QU8yG/ObIRfKjhxfMQbj+qJF1iNkzcrJ6v5byw=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.13.0/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.13.1 h1:6aUi1Y9jGBoWm58wsJnq8xerxAsxXjdeFsgUle1eIqw=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.13.1/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.12.0 h1:MXqB1waq3L18eUhTZ7ng14MbjOiAlwANgZCVUwoLBXo=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.12.0/go.mod h1:6DPwGu8oGR1sZRpjwkcAnrQZWQuAJ/Ph+rQHfUo1Yf4=
 github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.1 h1:KiYpZpQv7X7Tm9wHUvboC2CyquwmjMhrPU2DvTcPC8o=


### PR DESCRIPTION
This PR updates vault-plugin-secrets-gcp to [v0.13.1](https://github.com/hashicorp/vault-plugin-secrets-gcp/releases/tag/v0.13.1) to bring in a bug fix from https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/144.

Steps:
```
go get -d github.com/hashicorp/vault-plugin-secrets-gcp@v0.13.1
go mod tidy
```