### PR TITLE
secrets/gcp: updates plugin to v0.12.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -108,7 +108,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-ad v0.12.0
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.11.1
 	github.com/hashicorp/vault-plugin-secrets-azure v0.12.0
-	github.com/hashicorp/vault-plugin-secrets-gcp v0.12.0
+	github.com/hashicorp/vault-plugin-secrets-gcp v0.12.1
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.11.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.11.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -988,8 +988,8 @@ github.com/hashicorp/vault-plugin-secrets-alicloud v0.11.1 h1:vuenbRDeUV6Ghn4yFX
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.11.1/go.mod h1:F4KWrlCQZbhP2dFXCkRvbHX2J6CTydlaY0cH+OrLHCE=
 github.com/hashicorp/vault-plugin-secrets-azure v0.12.0 h1:B2rLk3JxIXSRhZb47DLHSxQfX3yVWDFE6dGGzT6QXaA=
 github.com/hashicorp/vault-plugin-secrets-azure v0.12.0/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.12.0 h1:CvkXkxrCSk5gGlDeCfQfrbGBrO2kQFDzVKawIHNMciY=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.12.0/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.12.1 h1:qeI9ZNdTHjnFUB5DLLwR8sWdhACpPl8A75Mph7auN/o=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.12.1/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.11.0 h1:6MUiyfP5tKicVaYgu7Xi/LpCZh3QR8sjOlhpPKk5DzY=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.11.0/go.mod h1:6DPwGu8oGR1sZRpjwkcAnrQZWQuAJ/Ph+rQHfUo1Yf4=
 github.com/hashicorp/vault-plugin-secrets-kv v0.11.0 h1:xSvgh7ObLo3MhVzmGhOxiWND++cTP/QM2LxTmpYim/Q=


### PR DESCRIPTION
This PR updates vault-plugin-secrets-gcp to [v0.12.1](https://github.com/hashicorp/vault-plugin-secrets-gcp/releases/tag/v0.12.1) to bring in a bug fix from https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/144.

Steps:
```
go get -d github.com/hashicorp/vault-plugin-secrets-gcp@v0.12.1
go mod tidy
```