### PR TITLE
secrets/gcp: adds changelog entry for bug fixes in release branches

### DIFF
--- a/changelog/16534.txt
+++ b/changelog/16534.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/gcp: Fixes duplicate static account key creation from performance secondary clusters. 
+```


### PR DESCRIPTION
This PR adds a changelog entry for the GCP secrets bug fixes in:
- https://github.com/hashicorp/vault/pull/16532
- https://github.com/hashicorp/vault/pull/16533