### PR TITLE
Move the IS Autopilot note from 1.11 upgrade guide

### DIFF
--- a/website/content/docs/upgrading/index.mdx
+++ b/website/content/docs/upgrading/index.mdx
@@ -33,9 +33,7 @@ part of the Integrated Storage Autopilot feature. If your Vault environment is
 configured to use Integrated Storage, consider leveraging this new feature to
 upgrade your Vault environment. 
 
--> **Tutorial:** 
-
-Refer to the [Automate Upgrades with Vault
+-> **Tutorial:** Refer to the [Automate Upgrades with Vault
  Enterprise](https://learn.hashicorp.com/tutorials/vault/raft-upgrade-automation)
  tutorial for more details. 
 

--- a/website/content/docs/upgrading/index.mdx
+++ b/website/content/docs/upgrading/index.mdx
@@ -12,7 +12,7 @@ These are general upgrade instructions for Vault for both non-HA and HA setups.
 _Please ensure that you also read any version-specific upgrade notes which can be
 found in the sidebar._
 
-!> **IMPORTANT NOTE:** Always back up your data before upgrading! Vault does not
+!> **Important Note:** Always back up your data before upgrading! Vault does not
 make backward-compatibility guarantees for its data store. Simply replacing the
 newly-installed Vault binary with the previous version will not cleanly
 downgrade Vault, as upgrades may perform changes to the underlying data
@@ -25,10 +25,16 @@ supported. The upgrade notes for each intervening version must be reviewed. The
 upgrade notes may describe additional steps or configuration to update before,
 during, or after the upgrade.
 
-## Tutorial
+### Integrated Storage Autopilot
 
-Refer to the [Vault Upgrade Standard Procedure](https://learn.hashicorp.com/tutorials/vault/sop-upgrade)
-tutorial to learn how to upgrade Vault Enterprise.
+Vault 1.11 introduced [automated
+upgrades](/docs/concepts/integrated-storage/autopilot#automated-upgrades) as 
+part of the Integrated Storage Autopilot feature. If your Vault environment is
+configured to use Integrated Storage, consider leveraging this new feature. 
+
+-> **Tutorial:** See the [Automate Upgrades with Vault
+ Enterprise](https://learn.hashicorp.com/tutorials/vault/raft-upgrade-automation)
+ tutorial for more details. 
 
 ## Agent
 

--- a/website/content/docs/upgrading/index.mdx
+++ b/website/content/docs/upgrading/index.mdx
@@ -12,7 +12,7 @@ These are general upgrade instructions for Vault for both non-HA and HA setups.
 _Please ensure that you also read any version-specific upgrade notes which can be
 found in the sidebar._
 
-!> **Important Note:** Always back up your data before upgrading! Vault does not
+!> **Important:** Always back up your data before upgrading! Vault does not
 make backward-compatibility guarantees for its data store. Simply replacing the
 newly-installed Vault binary with the previous version will not cleanly
 downgrade Vault, as upgrades may perform changes to the underlying data

--- a/website/content/docs/upgrading/index.mdx
+++ b/website/content/docs/upgrading/index.mdx
@@ -30,7 +30,8 @@ during, or after the upgrade.
 Vault 1.11 introduced [automated
 upgrades](/docs/concepts/integrated-storage/autopilot#automated-upgrades) as 
 part of the Integrated Storage Autopilot feature. If your Vault environment is
-configured to use Integrated Storage, consider leveraging this new feature. 
+configured to use Integrated Storage, consider leveraging this new feature to
+upgrade your Vault environment. 
 
 -> **Tutorial:** See the [Automate Upgrades with Vault
  Enterprise](https://learn.hashicorp.com/tutorials/vault/raft-upgrade-automation)

--- a/website/content/docs/upgrading/index.mdx
+++ b/website/content/docs/upgrading/index.mdx
@@ -33,7 +33,9 @@ part of the Integrated Storage Autopilot feature. If your Vault environment is
 configured to use Integrated Storage, consider leveraging this new feature to
 upgrade your Vault environment. 
 
--> **Tutorial:** See the [Automate Upgrades with Vault
+-> **Tutorial:** 
+
+Refer to the [Automate Upgrades with Vault
  Enterprise](https://learn.hashicorp.com/tutorials/vault/raft-upgrade-automation)
  tutorial for more details. 
 

--- a/website/content/docs/upgrading/upgrade-to-1.11.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.11.x.mdx
@@ -18,13 +18,3 @@ path instead of `/_xpack/security` when managing Elasticsearch. If users are on
 an Elasticsearch version prior to 6, they will need to switch back to the old
 API path by setting the [bool config option](/api-docs/secret/databases/elasticdb#use_old_xpack)
 `use_old_xpack=true`.
-
-## Integrated Storage Autopilot
-
-Vault 1.11 introduced [automated
-upgrades](/docs/concepts/integrated-storage/autopilot#automated-upgrades) as 
-part of the Integrated Storage Autopilot feature. If your Vault environment is
-configured to use Integrated Storage, consider leveraging this new feature. See
-the [Automate Upgrades with Vault
-Enterprise](https://learn.hashicorp.com/tutorials/vault/raft-upgrade-automation)
-tutorial for more details. 


### PR DESCRIPTION
Move the note about Integrated Storage automated upgrade note from the [Vault 1.11 Upgrade guide](https://www.vaultproject.io/docs/upgrading/upgrade-to-1.11.x) to the [top-level](https://www.vaultproject.io/docs/upgrading) (requested by Aarti Iyengar). 

🔍 [Deploy Preview](https://vault-git-docs-edit-upgrade-guide-hashicorp.vercel.app/docs/upgrading)
