### PR TITLE
Allow configuring the possible salt lengths for RSA PSS signatures

### DIFF
--- a/builtin/logical/transit/path_sign_verify.go
+++ b/builtin/logical/transit/path_sign_verify.go
@@ -2,8 +2,11 @@ package transit
 
 import (
 	"context"
+	"crypto/rsa"
 	"encoding/base64"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
@@ -133,9 +136,10 @@ Options are 'pss' or 'pkcs1v15'. Defaults to 'pss'`,
 			},
 
 			"salt_length": {
-				Type: framework.TypeInt,
+				Type:    framework.TypeString,
+				Default: "auto",
 				Description: `The salt length used to sign. Currently only applies to the RSA PSS signature scheme.
-Options are everything permitted by crypto/rsa.PSSOptions.SaltLength. Defaults to 0 (crypto/rsa.PSSSaltLengthAuto).`,
+Options are 'auto' (crypto/rsa.PSSSaltLengthAuto), 'hash' (crypto/rsa.PSSSaltLengthEqualsHash), or a number of bytes. Defaults to 'auto'.`,
 			},
 		},
 
@@ -225,9 +229,10 @@ Options are 'pss' or 'pkcs1v15'. Defaults to 'pss'`,
 			},
 
 			"salt_length": {
-				Type: framework.TypeInt,
-				Description: `The salt length used to sign and now verify. Currently only applies to the RSA PSS signature scheme.
-Options are everything permitted by crypto/rsa.PSSOptions.SaltLength. Defaults to 0 (crypto/rsa.PSSSaltLengthAuto).`,
+				Type:    framework.TypeString,
+				Default: "auto",
+				Description: `The salt length used to sign. Currently only applies to the RSA PSS signature scheme.
+Options are 'auto' (crypto/rsa.PSSSaltLengthAuto), 'hash' (crypto/rsa.PSSSaltLengthEqualsHash), or a number of bytes. Defaults to 'auto'.`,
 			},
 		},
 
@@ -237,6 +242,33 @@ Options are everything permitted by crypto/rsa.PSSOptions.SaltLength. Defaults t
 
 		HelpSynopsis:    pathVerifyHelpSyn,
 		HelpDescription: pathVerifyHelpDesc,
+	}
+}
+
+func (b *backend) getSaltLength(d *framework.FieldData) (int, error) {
+	rawSaltLength, ok := d.GetOk("salt_length")
+	// This should only happen when something is wrong with the schema,
+	// so this is a reasonable default.
+	if !ok {
+		return rsa.PSSSaltLengthAuto, nil
+	}
+
+	rawSaltLengthStr := rawSaltLength.(string)
+	lowerSaltLengthStr := strings.ToLower(rawSaltLengthStr)
+	switch lowerSaltLengthStr {
+	case "auto":
+		return rsa.PSSSaltLengthAuto, nil
+	case "hash":
+		return rsa.PSSSaltLengthEqualsHash, nil
+	default:
+		saltLengthInt, err := strconv.Atoi(lowerSaltLengthStr)
+		if err != nil {
+			return rsa.PSSSaltLengthEqualsHash - 1, fmt.Errorf("salt length neither 'auto', 'hash', nor an int: %s", rawSaltLength)
+		}
+		if saltLengthInt < rsa.PSSSaltLengthEqualsHash {
+			return rsa.PSSSaltLengthEqualsHash - 1, fmt.Errorf("salt length is invalid: %d", saltLengthInt)
+		}
+		return saltLengthInt, nil
 	}
 }
 
@@ -264,8 +296,10 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 
 	prehashed := d.Get("prehashed").(bool)
 	sigAlgorithm := d.Get("signature_algorithm").(string)
-	// NOTE: If not explicitly set, the salt length is 0, which coincides with rsa.PSSSaltLengthAuto.
-	saltLength := d.Get("salt_length").(int)
+	saltLength, err := b.getSaltLength(d)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+	}
 
 	// Get the policy
 	p, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{
@@ -489,8 +523,10 @@ func (b *backend) pathVerifyWrite(ctx context.Context, req *logical.Request, d *
 
 	prehashed := d.Get("prehashed").(bool)
 	sigAlgorithm := d.Get("signature_algorithm").(string)
-	// NOTE: If not explicitly set, the salt length is 0, which coincides with rsa.PSSSaltLengthAuto.
-	saltLength := d.Get("salt_length").(int)
+	saltLength, err := b.getSaltLength(d)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+	}
 
 	// Get the policy
 	p, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{

--- a/builtin/logical/transit/path_sign_verify.go
+++ b/builtin/logical/transit/path_sign_verify.go
@@ -139,7 +139,7 @@ Options are 'pss' or 'pkcs1v15'. Defaults to 'pss'`,
 				Type:    framework.TypeString,
 				Default: "auto",
 				Description: `The salt length used to sign. Currently only applies to the RSA PSS signature scheme.
-Options are 'auto' (crypto/rsa.PSSSaltLengthAuto), 'hash' (crypto/rsa.PSSSaltLengthEqualsHash), or a number of bytes. Defaults to 'auto'.`,
+Options are 'auto' (the default used by Golang, causing the salt to be as large as possible when signing), 'hash' (causes the salt length to equal the length of the hash used in the signature), or an integer between the minimum and the maximum permissible salt lengths for the given RSA key size. Defaults to 'auto'.`,
 			},
 		},
 
@@ -232,7 +232,7 @@ Options are 'pss' or 'pkcs1v15'. Defaults to 'pss'`,
 				Type:    framework.TypeString,
 				Default: "auto",
 				Description: `The salt length used to sign. Currently only applies to the RSA PSS signature scheme.
-Options are 'auto' (crypto/rsa.PSSSaltLengthAuto), 'hash' (crypto/rsa.PSSSaltLengthEqualsHash), or a number of bytes. Defaults to 'auto'.`,
+Options are 'auto' (the default used by Golang, causing the salt to be as large as possible when signing), 'hash' (causes the salt length to equal the length of the hash used in the signature), or an integer between the minimum and the maximum permissible salt lengths for the given RSA key size. Defaults to 'auto'.`,
 			},
 		},
 

--- a/builtin/logical/transit/path_sign_verify_test.go
+++ b/builtin/logical/transit/path_sign_verify_test.go
@@ -729,12 +729,8 @@ func testTransit_SignVerify_RSA_PSS(t *testing.T, bits int) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.Data = map[string]interface{}{
-		"input":               "dGhlIHF1aWNrIGJyb3duIGZveA==",
-		"signature_algorithm": "pss",
-	}
 
-	signRequest := func(req *logical.Request, errExpected bool, postpath string) string {
+	signRequest := func(errExpected bool, postpath string) string {
 		t.Helper()
 		req.Path = "sign/foo" + postpath
 		resp, err := b.HandleRequest(context.Background(), req)
@@ -753,6 +749,9 @@ func testTransit_SignVerify_RSA_PSS(t *testing.T, bits int) {
 		if resp.IsError() {
 			t.Fatalf("bad: got error response: %#v", *resp)
 		}
+		// Since we are reusing the same request, let's clear the salt length each time.
+		delete(req.Data, "salt_length")
+
 		value, ok := resp.Data["signature"]
 		if !ok {
 			t.Fatalf("no signature key found in returned data, got resp data %#v", resp.Data)
@@ -760,7 +759,7 @@ func testTransit_SignVerify_RSA_PSS(t *testing.T, bits int) {
 		return value.(string)
 	}
 
-	verifyRequest := func(req *logical.Request, errExpected bool, postpath, sig string) {
+	verifyRequest := func(errExpected bool, postpath, sig string) {
 		t.Helper()
 		req.Path = "verify/foo" + postpath
 		req.Data["signature"] = sig
@@ -789,21 +788,31 @@ func testTransit_SignVerify_RSA_PSS(t *testing.T, bits int) {
 		} else if value.(bool) && errExpected {
 			t.Fatalf("expected error and didn't get one; req was %#v, resp is %#v", *req, *resp)
 		}
+		// Since we are reusing the same request, let's clear the signature each time.
+		delete(req.Data, "signature")
 	}
 
-	signAndVerifyRequest := func(req *logical.Request, hashAlgorithm string, signSaltLength string, signErrExpected bool, verifySaltLength string, verifyErrExpected bool) {
-		t.Log("\t\t", signSaltLength, "/", verifySaltLength)
-		req.Data["hash_algorithm"] = hashAlgorithm
+	newReqData := func(hashAlgorithm string, marshalingName string) map[string]interface{} {
+		return map[string]interface{}{
+			"input":                "dGhlIHF1aWNrIGJyb3duIGZveA==",
+			"signature_algorithm":  "pss",
+			"hash_algorithm":       hashAlgorithm,
+			"marshaling_algorithm": marshalingName,
+		}
+	}
+
+	signAndVerifyRequest := func(hashAlgorithm string, marshalingName string, signSaltLength string, signErrExpected bool, verifySaltLength string, verifyErrExpected bool) {
+		t.Log("\t\t\t", signSaltLength, "/", verifySaltLength)
+		req.Data = newReqData(hashAlgorithm, marshalingName)
 
 		req.Data["salt_length"] = signSaltLength
-		sig := signRequest(req, signErrExpected, "")
+		t.Log("\t\t\t\t", "sign req data:", req.Data)
+		sig := signRequest(signErrExpected, "")
 
 		req.Data["salt_length"] = verifySaltLength
-		verifyRequest(req, verifyErrExpected, "", sig)
+		t.Log("\t\t\t\t", "verify req data:", req.Data)
+		verifyRequest(verifyErrExpected, "", sig)
 	}
-
-	hashAlgorithms := []string{"sha1", "sha2-224", "sha2-256", "sha2-384", "sha2-512", "sha3-224", "sha3-256", "sha3-384", "sha3-512"}
-	t.Log("hashAlgorithms:", hashAlgorithms)
 
 	invalidSaltLengths := []string{"bar", "-2"}
 	t.Log("invalidSaltLengths:", invalidSaltLengths)
@@ -823,79 +832,126 @@ func testTransit_SignVerify_RSA_PSS(t *testing.T, bits int) {
 	validSaltLengths := append(autoSaltLengths, nonAutoSaltLengths...)
 	t.Log("validSaltLengths:", validSaltLengths)
 
-	for _, hashAlgorithm := range hashAlgorithms {
-		t.Log("Hash algorithm:", hashAlgorithm)
-
-		t.Log("\t", "valid", "/", "invalid salt lengths")
+	testCombinatorics := func(hashAlgorithm string, marshalingName string) {
+		t.Log("\t\t", "valid", "/", "invalid salt lengths")
 		for _, validSaltLength := range validSaltLengths {
 			for _, invalidSaltLength := range invalidSaltLengths {
-				signAndVerifyRequest(req, hashAlgorithm, validSaltLength, false, invalidSaltLength, true)
+				signAndVerifyRequest(hashAlgorithm, marshalingName, validSaltLength, false, invalidSaltLength, true)
 			}
 		}
 
-		t.Log("\t", "invalid", "/", "invalid salt lengths")
+		t.Log("\t\t", "invalid", "/", "invalid salt lengths")
 		for _, invalidSaltLength1 := range invalidSaltLengths {
 			for _, invalidSaltLength2 := range invalidSaltLengths {
-				signAndVerifyRequest(req, hashAlgorithm, invalidSaltLength1, true, invalidSaltLength2, true)
+				signAndVerifyRequest(hashAlgorithm, marshalingName, invalidSaltLength1, true, invalidSaltLength2, true)
 			}
 		}
 
-		t.Log("\t", "invalid", "/", "valid salt lengths")
+		t.Log("\t\t", "invalid", "/", "valid salt lengths")
 		for _, invalidSaltLength := range invalidSaltLengths {
 			for _, validSaltLength := range validSaltLengths {
-				signAndVerifyRequest(req, hashAlgorithm, invalidSaltLength, true, validSaltLength, true)
+				signAndVerifyRequest(hashAlgorithm, marshalingName, invalidSaltLength, true, validSaltLength, true)
 			}
 		}
 
-		t.Log("\t", "valid", "/", "valid salt lengths")
+		t.Log("\t\t", "valid", "/", "valid salt lengths")
 		for _, validSaltLength := range validSaltLengths {
-			signAndVerifyRequest(req, hashAlgorithm, validSaltLength, false, validSaltLength, false)
+			signAndVerifyRequest(hashAlgorithm, marshalingName, validSaltLength, false, validSaltLength, false)
 		}
 
-		t.Log("\t", "hash", "/", "hash salt lengths")
+		t.Log("\t\t", "hash", "/", "hash salt lengths")
 		for _, hashSaltLength1 := range hashSaltLengths {
 			for _, hashSaltLength2 := range hashSaltLengths {
 				if hashSaltLength1 != hashSaltLength2 {
-					signAndVerifyRequest(req, hashAlgorithm, hashSaltLength1, false, hashSaltLength2, false)
+					signAndVerifyRequest(hashAlgorithm, marshalingName, hashSaltLength1, false, hashSaltLength2, false)
 				}
 			}
 		}
 
-		t.Log("\t", "hash", "/", "positive salt lengths")
+		t.Log("\t\t", "hash", "/", "positive salt lengths")
 		for _, hashSaltLength := range hashSaltLengths {
 			for _, positiveSaltLength := range positiveSaltLengths {
-				signAndVerifyRequest(req, hashAlgorithm, hashSaltLength, false, positiveSaltLength, true)
+				signAndVerifyRequest(hashAlgorithm, marshalingName, hashSaltLength, false, positiveSaltLength, true)
 			}
 		}
 
-		t.Log("\t", "positive", "/", "hash salt lengths")
+		t.Log("\t\t", "positive", "/", "hash salt lengths")
 		for _, positiveSaltLength := range positiveSaltLengths {
 			for _, hashSaltLength := range hashSaltLengths {
-				signAndVerifyRequest(req, hashAlgorithm, positiveSaltLength, false, hashSaltLength, true)
+				signAndVerifyRequest(hashAlgorithm, marshalingName, positiveSaltLength, false, hashSaltLength, true)
 			}
 		}
 
-		t.Log("\t", "auto", "/", "auto salt lengths")
+		t.Log("\t\t", "auto", "/", "auto salt lengths")
 		for _, autoSaltLength1 := range autoSaltLengths {
 			for _, autoSaltLength2 := range autoSaltLengths {
 				if autoSaltLength1 != autoSaltLength2 {
-					signAndVerifyRequest(req, hashAlgorithm, autoSaltLength1, false, autoSaltLength2, false)
+					signAndVerifyRequest(hashAlgorithm, marshalingName, autoSaltLength1, false, autoSaltLength2, false)
 				}
 			}
 		}
 
-		t.Log("\t", "auto", "/", "non-auto salt lengths")
+		t.Log("\t\t", "auto", "/", "non-auto salt lengths")
 		for _, autoSaltLength := range autoSaltLengths {
 			for _, nonAutoSaltLength := range nonAutoSaltLengths {
-				signAndVerifyRequest(req, hashAlgorithm, autoSaltLength, false, nonAutoSaltLength, true)
+				signAndVerifyRequest(hashAlgorithm, marshalingName, autoSaltLength, false, nonAutoSaltLength, true)
 			}
 		}
 
-		t.Log("\t", "non-auto", "/", "auto salt lengths")
+		t.Log("\t\t", "non-auto", "/", "auto salt lengths")
 		for _, nonAutoSaltLength := range nonAutoSaltLengths {
 			for _, autoSaltLength := range autoSaltLengths {
-				signAndVerifyRequest(req, hashAlgorithm, nonAutoSaltLength, false, autoSaltLength, false)
+				signAndVerifyRequest(hashAlgorithm, marshalingName, nonAutoSaltLength, false, autoSaltLength, false)
 			}
+		}
+	}
+
+	testAutoSignAndVerify := func(hashAlgorithm string, marshalingName string) {
+		t.Log("\t\t", "Make a signature with an implicit, automatic salt length")
+		req.Data = newReqData(hashAlgorithm, marshalingName)
+		t.Log("\t\t\t", "sign req data:", req.Data)
+		sig := signRequest(false, "")
+
+		t.Log("\t\t", "Verify it with an implicit, automatic salt length")
+		t.Log("\t\t\t", "verify req data:", req.Data)
+		verifyRequest(false, "", sig)
+
+		t.Log("\t\t", "Verify it with an explicit, automatic salt length")
+		for _, autoSaltLength := range autoSaltLengths {
+			t.Log("\t\t\t", "auto", "/", autoSaltLength)
+			req.Data["salt_length"] = autoSaltLength
+			t.Log("\t\t\t\t", "verify req data:", req.Data)
+			verifyRequest(false, "", sig)
+		}
+
+		t.Log("\t\t", "Try to verify it with an explicit, incorrect salt length")
+		for _, nonAutoSaltLength := range nonAutoSaltLengths {
+			t.Log("\t\t\t", "auto", "/", nonAutoSaltLength)
+			req.Data["salt_length"] = nonAutoSaltLength
+			t.Log("\t\t\t\t", "verify req data:", req.Data)
+			verifyRequest(true, "", sig)
+		}
+
+		t.Log("\t\t", "Make a signature with an explicit, valid salt length & and verify it with an implicit, automatic salt length")
+		for _, validSaltLength := range validSaltLengths {
+			t.Log("\t\t\t", validSaltLength, "/", "auto")
+
+			req.Data = newReqData(hashAlgorithm, marshalingName)
+			req.Data["salt_length"] = validSaltLength
+			t.Log("\t\t\t", "sign req data:", req.Data)
+			sig := signRequest(false, "")
+
+			t.Log("\t\t\t", "verify req data:", req.Data)
+			verifyRequest(false, "", sig)
+		}
+	}
+
+	for hashAlgorithm := range keysutil.HashTypeMap {
+		t.Log("Hash algorithm:", hashAlgorithm)
+		for marshalingName := range keysutil.MarshalingTypeMap {
+			t.Log("\t", "Marshaling type:", marshalingName)
+			testCombinatorics(hashAlgorithm, marshalingName)
+			testAutoSignAndVerify(hashAlgorithm, marshalingName)
 		}
 	}
 }

--- a/changelog/16549.txt
+++ b/changelog/16549.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/transit: Allow configuring the possible salt lengths for RSA PSS signatures.
+```

--- a/sdk/helper/keysutil/consts.go
+++ b/sdk/helper/keysutil/consts.go
@@ -1,6 +1,7 @@
 package keysutil
 
 import (
+	"crypto"
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
@@ -55,6 +56,18 @@ var (
 		HashTypeSHA3256: sha3.New256,
 		HashTypeSHA3384: sha3.New384,
 		HashTypeSHA3512: sha3.New512,
+	}
+
+	CryptoHashMap = map[HashType]crypto.Hash{
+		HashTypeSHA1:    crypto.SHA1,
+		HashTypeSHA2224: crypto.SHA224,
+		HashTypeSHA2256: crypto.SHA256,
+		HashTypeSHA2384: crypto.SHA384,
+		HashTypeSHA2512: crypto.SHA512,
+		HashTypeSHA3224: crypto.SHA3_224,
+		HashTypeSHA3256: crypto.SHA3_256,
+		HashTypeSHA3384: crypto.SHA3_384,
+		HashTypeSHA3512: crypto.SHA3_512,
 	}
 
 	MarshalingTypeMap = map[string]MarshalingType{

--- a/sdk/helper/keysutil/consts.go
+++ b/sdk/helper/keysutil/consts.go
@@ -32,6 +32,14 @@ const (
 	MarshalingTypeJWS
 )
 
+type SaltLengthType uint32
+
+const (
+	_                                 = iota
+	SaltLengthTypeAuto SaltLengthType = iota
+	SaltLengthTypeHash
+)
+
 var (
 	HashTypeMap = map[string]HashType{
 		"sha1":     HashTypeSHA1,
@@ -60,5 +68,10 @@ var (
 	MarshalingTypeMap = map[string]MarshalingType{
 		"asn1": MarshalingTypeASN1,
 		"jws":  MarshalingTypeJWS,
+	}
+
+	SaltLengthTypeMap = map[string]SaltLengthType{
+		"auto": SaltLengthTypeAuto,
+		"hash": SaltLengthTypeHash,
 	}
 )

--- a/sdk/helper/keysutil/consts.go
+++ b/sdk/helper/keysutil/consts.go
@@ -32,14 +32,6 @@ const (
 	MarshalingTypeJWS
 )
 
-type SaltLengthType uint32
-
-const (
-	_                                 = iota
-	SaltLengthTypeAuto SaltLengthType = iota
-	SaltLengthTypeHash
-)
-
 var (
 	HashTypeMap = map[string]HashType{
 		"sha1":     HashTypeSHA1,
@@ -68,10 +60,5 @@ var (
 	MarshalingTypeMap = map[string]MarshalingType{
 		"asn1": MarshalingTypeASN1,
 		"jws":  MarshalingTypeJWS,
-	}
-
-	SaltLengthTypeMap = map[string]SaltLengthType{
-		"auto": SaltLengthTypeAuto,
-		"hash": SaltLengthTypeHash,
 	}
 )

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -1400,7 +1400,7 @@ func (p *Policy) VerifySignatureWithOptions(context, input []byte, sig string, o
 			return false, errutil.InternalError{Err: fmt.Sprintf("unsupported rsa signature algorithm %s", sigAlgorithm)}
 		}
 
-		return err == nil, err
+		return err == nil, nil
 
 	default:
 		return false, errutil.InternalError{Err: fmt.Sprintf("unsupported key type %v", p.Type)}

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -1400,7 +1400,7 @@ func (p *Policy) VerifySignatureWithOptions(context, input []byte, sig string, o
 			return false, errutil.InternalError{Err: fmt.Sprintf("unsupported rsa signature algorithm %s", sigAlgorithm)}
 		}
 
-		return err == nil, nil
+		return err == nil, err
 
 	default:
 		return false, errutil.InternalError{Err: fmt.Sprintf("unsupported key type %v", p.Type)}

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -1041,6 +1041,20 @@ func (p *Policy) Sign(ver int, context, input []byte, hashAlgorithm HashType, si
 	})
 }
 
+func (p *Policy) minRSAPSSSaltLength() int {
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.19:src/crypto/rsa/pss.go;l=247
+	return rsa.PSSSaltLengthEqualsHash
+}
+
+func (p *Policy) maxRSAPSSSaltLength(priv *rsa.PrivateKey, hash crypto.Hash) int {
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.19:src/crypto/rsa/pss.go;l=288
+	return (priv.N.BitLen()-1+7)/8 - 2 - hash.Size()
+}
+
+func (p *Policy) validRSAPSSSaltLength(priv *rsa.PrivateKey, hash crypto.Hash, saltLength int) bool {
+	return p.minRSAPSSSaltLength() <= saltLength && saltLength <= p.maxRSAPSSSaltLength(priv, hash)
+}
+
 func (p *Policy) SignWithOptions(ver int, context, input []byte, options *SigningOptions) (*SigningResult, error) {
 	if !p.Type.SigningSupported() {
 		return nil, fmt.Errorf("message signing not supported for key type %v", p.Type)
@@ -1160,27 +1174,8 @@ func (p *Policy) SignWithOptions(ver int, context, input []byte, options *Signin
 	case KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096:
 		key := keyParams.RSAKey
 
-		var algo crypto.Hash
-		switch hashAlgorithm {
-		case HashTypeSHA1:
-			algo = crypto.SHA1
-		case HashTypeSHA2224:
-			algo = crypto.SHA224
-		case HashTypeSHA2256:
-			algo = crypto.SHA256
-		case HashTypeSHA2384:
-			algo = crypto.SHA384
-		case HashTypeSHA2512:
-			algo = crypto.SHA512
-		case HashTypeSHA3224:
-			algo = crypto.SHA3_224
-		case HashTypeSHA3256:
-			algo = crypto.SHA3_256
-		case HashTypeSHA3384:
-			algo = crypto.SHA3_384
-		case HashTypeSHA3512:
-			algo = crypto.SHA3_512
-		default:
+		algo, ok := CryptoHashMap[hashAlgorithm]
+		if !ok {
 			return nil, errutil.InternalError{Err: "unsupported hash algorithm"}
 		}
 
@@ -1190,9 +1185,7 @@ func (p *Policy) SignWithOptions(ver int, context, input []byte, options *Signin
 
 		switch sigAlgorithm {
 		case "pss":
-			// At the time of writing, this constant has the lowest sentinel value:
-			// https://cs.opensource.google/go/go/+/refs/tags/go1.19:src/crypto/rsa/pss.go;l=247
-			if saltLength < rsa.PSSSaltLengthEqualsHash {
+			if !p.validRSAPSSSaltLength(key, algo, saltLength) {
 				return nil, errutil.UserError{Err: fmt.Sprintf("requested salt length %d is invalid", saltLength)}
 			}
 			sig, err = rsa.SignPSS(rand.Reader, key, algo, input, &rsa.PSSOptions{SaltLength: saltLength})
@@ -1358,27 +1351,8 @@ func (p *Policy) VerifySignatureWithOptions(context, input []byte, sig string, o
 
 		key := keyEntry.RSAKey
 
-		var algo crypto.Hash
-		switch hashAlgorithm {
-		case HashTypeSHA1:
-			algo = crypto.SHA1
-		case HashTypeSHA2224:
-			algo = crypto.SHA224
-		case HashTypeSHA2256:
-			algo = crypto.SHA256
-		case HashTypeSHA2384:
-			algo = crypto.SHA384
-		case HashTypeSHA2512:
-			algo = crypto.SHA512
-		case HashTypeSHA3224:
-			algo = crypto.SHA3_224
-		case HashTypeSHA3256:
-			algo = crypto.SHA3_256
-		case HashTypeSHA3384:
-			algo = crypto.SHA3_384
-		case HashTypeSHA3512:
-			algo = crypto.SHA3_512
-		default:
+		algo, ok := CryptoHashMap[hashAlgorithm]
+		if !ok {
 			return false, errutil.InternalError{Err: "unsupported hash algorithm"}
 		}
 
@@ -1388,9 +1362,7 @@ func (p *Policy) VerifySignatureWithOptions(context, input []byte, sig string, o
 
 		switch sigAlgorithm {
 		case "pss":
-			// At the time of writing, this constant has the lowest sentinel value:
-			// https://cs.opensource.google/go/go/+/refs/tags/go1.19:src/crypto/rsa/pss.go;l=247
-			if saltLength < rsa.PSSSaltLengthEqualsHash {
+			if !p.validRSAPSSSaltLength(key, algo, saltLength) {
 				return false, errutil.UserError{Err: fmt.Sprintf("requested salt length %d is invalid", saltLength)}
 			}
 			err = rsa.VerifyPSS(&key.PublicKey, algo, input, sigBytes, &rsa.PSSOptions{SaltLength: saltLength})

--- a/sdk/helper/keysutil/policy_test.go
+++ b/sdk/helper/keysutil/policy_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	mathrand "math/rand"
 	"reflect"
 	"strconv"
 	"strings"
@@ -818,6 +819,7 @@ func autoVerify(depth int, t *testing.T, p *Policy, input []byte, sig *SigningRe
 
 func Test_RSA_PSS(t *testing.T) {
 	t.Log("Testing RSA PSS")
+	mathrand.Seed(time.Now().UnixNano())
 
 	var userError errutil.UserError
 	ctx := context.Background()
@@ -893,9 +895,11 @@ func Test_RSA_PSS(t *testing.T) {
 			}
 		}
 
-		// 3. For each valid salt length...
+		// 3. For three possible valid salt lengths...
 		t.Log(tabs[3], "Test all valid salt lengths")
-		for saltLength := minSaltLength; saltLength <= maxSaltLength; saltLength++ {
+		midSaltLength := mathrand.Intn(maxSaltLength-1) + 1 // [1, maxSaltLength)
+		validSaltLengths := []int{minSaltLength, midSaltLength, maxSaltLength}
+		for _, saltLength := range validSaltLengths {
 			t.Log(tabs[4], "Salt length:", saltLength)
 			saltedOptions := saltOptions(unsaltedOptions, saltLength)
 

--- a/sdk/helper/keysutil/policy_test.go
+++ b/sdk/helper/keysutil/policy_test.go
@@ -896,7 +896,7 @@ func Test_RSA_PSS(t *testing.T) {
 		}
 
 		// 3. For three possible valid salt lengths...
-		t.Log(tabs[3], "Test all valid salt lengths")
+		t.Log(tabs[3], "Test three possible valid salt lengths")
 		midSaltLength := mathrand.Intn(maxSaltLength-1) + 1 // [1, maxSaltLength)
 		validSaltLengths := []int{minSaltLength, midSaltLength, maxSaltLength}
 		for _, saltLength := range validSaltLengths {

--- a/sdk/helper/keysutil/policy_test.go
+++ b/sdk/helper/keysutil/policy_test.go
@@ -824,18 +824,100 @@ func Test_RSA_PSS(t *testing.T) {
 	storage := &logical.InmemStorage{}
 	// https://crypto.stackexchange.com/a/1222
 	input := []byte("the ancients say the longer the salt, the more provable the security")
-	marshalingType := MarshalingTypeASN1
 	sigAlgorithm := "pss"
+
+	tabs := make(map[int]string)
+	for i := 1; i <= 6; i++ {
+		tabs[i] = strings.Repeat("\t", i)
+	}
+
+	test_RSA_PSS := func(p *Policy, rsaKey *rsa.PrivateKey, hashType HashType, marshalingType MarshalingType) {
+		unsaltedOptions := SigningOptions{
+			HashAlgorithm: hashType,
+			Marshaling:    marshalingType,
+			SigAlgorithm:  sigAlgorithm,
+		}
+		cryptoHash := CryptoHashMap[hashType]
+		minSaltLength := p.minRSAPSSSaltLength()
+		maxSaltLength := p.maxRSAPSSSaltLength(rsaKey, cryptoHash)
+		hash := cryptoHash.New()
+		hash.Write(input)
+		input = hash.Sum(nil)
+
+		// 1. Make an "automatic" signature with the given key size and hash algorithm,
+		// but an automatically chosen salt length.
+		t.Log(tabs[3], "Make an automatic signature")
+		sig, err := p.Sign(0, nil, input, hashType, sigAlgorithm, marshalingType)
+		if err != nil {
+			t.Fatal(tabs[4], "❌ Failed to automatically sign:", err)
+		}
+
+		// 1.1 Verify this automatic signature using the *inferred* salt length.
+		autoVerify(4, t, p, input, sig, unsaltedOptions)
+
+		// 1.2. Verify this automatic signature using the *correct, given* salt length.
+		manualVerify(4, t, p, input, sig, saltOptions(unsaltedOptions, maxSaltLength))
+
+		// 1.3. Try to verify this automatic signature using *incorrect, given* salt lengths.
+		t.Log(tabs[4], "Test incorrect salt lengths")
+		incorrectSaltLengths := []int{minSaltLength, maxSaltLength - 1}
+		for _, saltLength := range incorrectSaltLengths {
+			t.Log(tabs[5], "Salt length:", saltLength)
+			saltedOptions := saltOptions(unsaltedOptions, saltLength)
+
+			verified, _ := p.VerifySignatureWithOptions(nil, input, sig.Signature, &saltedOptions)
+			if verified {
+				t.Fatal(tabs[6], "❌ Failed to invalidate", verified, "signature using incorrect salt length:", err)
+			}
+		}
+
+		// 2. Rule out boundary, invalid salt lengths.
+		t.Log(tabs[3], "Test invalid salt lengths")
+		invalidSaltLengths := []int{minSaltLength - 1, maxSaltLength + 1}
+		for _, saltLength := range invalidSaltLengths {
+			t.Log(tabs[4], "Salt length:", saltLength)
+			saltedOptions := saltOptions(unsaltedOptions, saltLength)
+
+			// 2.1. Fail to sign.
+			t.Log(tabs[5], "Try to make a manual signature")
+			_, err := p.SignWithOptions(0, nil, input, &saltedOptions)
+			if !errors.As(err, &userError) {
+				t.Fatal(tabs[6], "❌ Failed to reject invalid salt length:", err)
+			}
+
+			// 2.2. Fail to verify.
+			t.Log(tabs[5], "Try to verify an automatic signature using an invalid salt length")
+			_, err = p.VerifySignatureWithOptions(nil, input, sig.Signature, &saltedOptions)
+			if !errors.As(err, &userError) {
+				t.Fatal(tabs[6], "❌ Failed to reject invalid salt length:", err)
+			}
+		}
+
+		// 3. For each valid salt length...
+		t.Log(tabs[3], "Test all valid salt lengths")
+		for saltLength := minSaltLength; saltLength <= maxSaltLength; saltLength++ {
+			t.Log(tabs[4], "Salt length:", saltLength)
+			saltedOptions := saltOptions(unsaltedOptions, saltLength)
+
+			// 3.1. Make a "manual" signature with the given key size, hash algorithm, and salt length.
+			t.Log(tabs[5], "Make a manual signature")
+			sig, err := p.SignWithOptions(0, nil, input, &saltedOptions)
+			if err != nil {
+				t.Fatal(tabs[6], "❌ Failed to manually sign:", err)
+			}
+
+			// 3.2. Verify this manual signature using the *correct, given* salt length.
+			manualVerify(6, t, p, input, sig, saltedOptions)
+
+			// 3.3. Verify this manual signature using the *inferred* salt length.
+			autoVerify(6, t, p, input, sig, unsaltedOptions)
+		}
+	}
 
 	rsaKeyTypes := []KeyType{KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096}
 	testKeys, err := generateTestKeys()
 	if err != nil {
 		t.Fatalf("error generating test keys: %s", err)
-	}
-
-	tabs := make(map[int]string)
-	for i := 1; i <= 5; i++ {
-		tabs[i] = strings.Repeat("\t", i)
 	}
 
 	// 1. For each standard RSA key size 2048, 3072, and 4096...
@@ -845,7 +927,6 @@ func Test_RSA_PSS(t *testing.T) {
 			Name: fmt.Sprint(rsaKeyType), // NOTE: crucial to create a new key per key size
 			Type: rsaKeyType,
 		}
-		minSaltLength := p.minRSAPSSSaltLength()
 
 		rsaKeyBytes := testKeys[rsaKeyType]
 		err := p.Import(ctx, storage, rsaKeyBytes, rand.Reader)
@@ -858,87 +939,14 @@ func Test_RSA_PSS(t *testing.T) {
 		}
 		rsaKey := rsaKeyAny.(*rsa.PrivateKey)
 
-		// 1.1. For each hash algorithm...
+		// 2. For each hash algorithm...
 		for hashAlgorithm, hashType := range HashTypeMap {
 			t.Log(tabs[1], "Hash algorithm:", hashAlgorithm)
-			unsaltedOptions := SigningOptions{
-				HashAlgorithm: hashType,
-				Marshaling:    marshalingType,
-				SigAlgorithm:  sigAlgorithm,
-			}
-			cryptoHash := CryptoHashMap[hashType]
-			maxSaltLength := p.maxRSAPSSSaltLength(rsaKey, cryptoHash)
-			hash := cryptoHash.New()
-			hash.Write(input)
-			input = hash.Sum(nil)
 
-			// 1.1.1. Make an "automatic" signature with the given key size and hash algorithm,
-			// but an automatically chosen salt length.
-			t.Log(tabs[2], "Make an automatic signature")
-			sig, err := p.Sign(0, nil, input, hashType, sigAlgorithm, marshalingType)
-			if err != nil {
-				t.Fatal(tabs[3], "❌ Failed to automatically sign:", err)
-			}
-
-			// 1.1.1.1 Verify this automatic signature using the *inferred* salt length.
-			autoVerify(3, t, p, input, sig, unsaltedOptions)
-
-			// 1.1.1.2. Verify this automatic signature using the *correct, given* salt length.
-			manualVerify(3, t, p, input, sig, saltOptions(unsaltedOptions, maxSaltLength))
-
-			// 1.1.1.3. Try to verify this automatic signature using *incorrect, given* salt lengths.
-			t.Log(tabs[3], "Test incorrect salt lengths")
-			incorrectSaltLengths := []int{minSaltLength, maxSaltLength - 1}
-			for _, saltLength := range incorrectSaltLengths {
-				t.Log(tabs[4], "Salt length:", saltLength)
-				saltedOptions := saltOptions(unsaltedOptions, saltLength)
-
-				verified, _ := p.VerifySignatureWithOptions(nil, input, sig.Signature, &saltedOptions)
-				if verified {
-					t.Fatal(tabs[5], "❌ Failed to invalidate", verified, "signature using incorrect salt length:", err)
-				}
-			}
-
-			// 1.1.2. Rule out boundary, invalid salt lengths.
-			t.Log(tabs[2], "Test invalid salt lengths")
-			invalidSaltLengths := []int{minSaltLength - 1, maxSaltLength + 1}
-			for _, saltLength := range invalidSaltLengths {
-				t.Log(tabs[3], "Salt length:", saltLength)
-				saltedOptions := saltOptions(unsaltedOptions, saltLength)
-
-				// 1.1.2.1. Fail to sign.
-				t.Log(tabs[4], "Try to make a manual signature")
-				_, err := p.SignWithOptions(0, nil, input, &saltedOptions)
-				if !errors.As(err, &userError) {
-					t.Fatal(tabs[5], "❌ Failed to reject invalid salt length:", err)
-				}
-
-				// 1.1.2.2. Fail to verify.
-				t.Log(tabs[4], "Try to verify an automatic signature using an invalid salt length")
-				_, err = p.VerifySignatureWithOptions(nil, input, sig.Signature, &saltedOptions)
-				if !errors.As(err, &userError) {
-					t.Fatal(tabs[5], "❌ Failed to reject invalid salt length:", err)
-				}
-			}
-
-			// 1.1.3. For each valid salt length...
-			t.Log(tabs[2], "Test all valid salt lengths")
-			for saltLength := minSaltLength; saltLength <= maxSaltLength; saltLength++ {
-				t.Log(tabs[3], "Salt length:", saltLength)
-				saltedOptions := saltOptions(unsaltedOptions, saltLength)
-
-				// 1.1.3.1. Make a "manual" signature with the given key size, hash algorithm, and salt length.
-				t.Log(tabs[4], "Make a manual signature")
-				sig, err := p.SignWithOptions(0, nil, input, &saltedOptions)
-				if err != nil {
-					t.Fatal(tabs[5], "❌ Failed to manually sign:", err)
-				}
-
-				// 1.1.3.2. Verify this manual signature using the *correct, given* salt length.
-				manualVerify(5, t, p, input, sig, saltedOptions)
-
-				// 1.1.3.3. Verify this manual signature using the *inferred* salt length.
-				autoVerify(5, t, p, input, sig, unsaltedOptions)
+			// 3. For each marshaling type...
+			for marshalingName, marshalingType := range MarshalingTypeMap {
+				t.Log(tabs[2], "Marshaling type:", marshalingName)
+				test_RSA_PSS(p, rsaKey, hashType, marshalingType)
 			}
 		}
 	}

--- a/sdk/helper/keysutil/policy_test.go
+++ b/sdk/helper/keysutil/policy_test.go
@@ -863,9 +863,9 @@ func Test_RSA_PSS(t *testing.T) {
 				t.Log(tabs[4], "Salt length:", saltLength)
 				saltedOptions := saltOptions(unsaltedOptions, saltLength)
 
-				verified, err := p.VerifySignatureWithOptions(nil, input, sig.Signature, &saltedOptions)
-				if err == nil || verified {
-					t.Fatal(tabs[5], "❌ Failed to verify signature:", err)
+				verified, _ := p.VerifySignatureWithOptions(nil, input, sig.Signature, &saltedOptions)
+				if verified {
+					t.Fatal(tabs[5], "❌ Failed to invalidate", verified, "signature using incorrect salt length:", err)
 				}
 			}
 

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -1157,6 +1157,12 @@ supports signing.
     also change the output encoding to URL-safe Base64 encoding instead of
     standard Base64-encoding.
 
+- `salt_length` `(string: "auto")` – The salt length used to sign. This currently only applies to the RSA PSS signature scheme. Options are:
+
+  - `auto`: The default used by Golang (causing the salt to be as large as possible when signing)
+  - `hash`: Causes the salt length to equal the length of the hash used in the signature
+  - An integer between the minimum and the maximum permissible salt lengths for the given RSA key size.
+
 ### Sample Request
 
 ```shell-session
@@ -1327,6 +1333,12 @@ data.
   - `jws`: The version used by JWS (and thus for JWTs). Selecting this will
     also expect the input encoding to URL-safe Base64 encoding instead of
     standard Base64-encoding.
+
+- `salt_length` `(string: "auto")` – The salt length used to sign. This currently only applies to the RSA PSS signature scheme. Options are:
+
+  - `auto`: The default used by Golang (causing the salt to be as large as possible when signing)
+  - `hash`: Causes the salt length to equal the length of the hash used in the signature
+  - An integer between the minimum and the maximum permissible salt lengths for the given RSA key size.
 
 ### Sample Request
 


### PR DESCRIPTION
The Golang `crypto/rsa` package [allows](https://pkg.go.dev/crypto/rsa#pkg-constants) for using at least two possible [salt lengths](https://crypto.stackexchange.com/questions/1217/rsa-pss-salt-size) (`auto` and `hash` for want better terminology) when creating/verifying RSA PSS signatures. However, these options are currently not exposed via the Vault Transit Secrets Engine. These options would allow for cross-platform signature verification without modifying downstream clients (e.g., the [securesystemslib](https://github.com/secure-systems-lab/securesystemslib/pull/262) package, used by the [python-tuf](https://github.com/theupdateframework/python-tuf) and [python-in-toto](https://github.com/in-toto/in-toto) supply chain security frameworks, which currently assumes a different salt length by default than Vault does).

This fixes issue #7531.