### PR TITLE
Vault 7338/fix retry join

### DIFF
--- a/changelog/16550.txt
+++ b/changelog/16550.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+storage/raft: Fix retry_join initialization failure
+```

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -657,6 +657,8 @@ func VerifyRaftPeers(t testing.T, client *api.Client, expected map[string]bool) 
 	if len(expected) != 0 {
 		return fmt.Errorf("failed to read configuration successfully, expected peers not found in configuration list: %v", expected)
 	}
+
+	return nil
 }
 
 func TestMetricSinkProvider(gaugeInterval time.Duration) func(string) (*metricsutil.ClusterMetricSink, *metricsutil.MetricsHelper) {

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -623,6 +623,10 @@ func GenerateDebugLogs(t testing.T, client *api.Client) chan struct{} {
 	return stopCh
 }
 
+// VerifyRaftPeers verifies that the raft configuration contains a given set of peers.
+// The `expected` argument is a map consisting of the nodeId string (key) and a
+// boolean representing peer existence (value).
+// For example: { "core-0": true, "core-1": false, "core-2": true }
 func VerifyRaftPeers(t testing.T, client *api.Client, expected map[string]bool) error {
 	t.Helper()
 

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -624,9 +624,10 @@ func GenerateDebugLogs(t testing.T, client *api.Client) chan struct{} {
 }
 
 // VerifyRaftPeers verifies that the raft configuration contains a given set of peers.
-// The `expected` argument is a map consisting of the nodeId string (key) and a
-// boolean representing peer existence (value).
-// For example: { "core-0": true, "core-1": false, "core-2": true }
+// The `expected` contains a map of expected peers. Existing entries are deleted
+// from the map by removing entries whose keys are in the raft configuration.
+// Remaining entries result in an error return so that the caller can poll for
+// an expected configuration.
 func VerifyRaftPeers(t testing.T, client *api.Client, expected map[string]bool) error {
 	t.Helper()
 

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -623,7 +623,7 @@ func GenerateDebugLogs(t testing.T, client *api.Client) chan struct{} {
 	return stopCh
 }
 
-func VerifyRaftPeers(t testing.T, client *api.Client, expected map[string]bool) {
+func VerifyRaftPeers(t testing.T, client *api.Client, expected map[string]bool) error {
 	t.Helper()
 
 	resp, err := client.Logical().Read("sys/storage/raft/configuration")
@@ -655,7 +655,7 @@ func VerifyRaftPeers(t testing.T, client *api.Client, expected map[string]bool) 
 	// If the collection is non-empty, it means that the peer was not found in
 	// the response.
 	if len(expected) != 0 {
-		t.Fatalf("failed to read configuration successfully, expected peers not found in configuration list: %v", expected)
+		return fmt.Errorf("failed to read configuration successfully, expected peers not found in configuration list: %v", expected)
 	}
 }
 

--- a/vault/external_tests/raftha/raft_ha_test.go
+++ b/vault/external_tests/raftha/raft_ha_test.go
@@ -100,14 +100,17 @@ func testRaftHANewCluster(t *testing.T, bundler teststorage.PhysicalBackendBundl
 
 	// Ensure peers are added
 	leaderClient := cluster.Cores[0].Client
-	testhelpers.VerifyRaftPeers(t, leaderClient, map[string]bool{
+	err := testhelpers.VerifyRaftPeers(t, leaderClient, map[string]bool{
 		"core-0": true,
 		"core-1": true,
 		"core-2": true,
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Test remove peers
-	_, err := leaderClient.Logical().Write("sys/storage/raft/remove-peer", map[string]interface{}{
+	_, err = leaderClient.Logical().Write("sys/storage/raft/remove-peer", map[string]interface{}{
 		"server_id": "core-1",
 	})
 	if err != nil {
@@ -122,9 +125,12 @@ func testRaftHANewCluster(t *testing.T, bundler teststorage.PhysicalBackendBundl
 	}
 
 	// Ensure peers are removed
-	testhelpers.VerifyRaftPeers(t, leaderClient, map[string]bool{
+	err = testhelpers.VerifyRaftPeers(t, leaderClient, map[string]bool{
 		"core-0": true,
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestRaft_HA_ExistingCluster(t *testing.T) {
@@ -233,11 +239,14 @@ func TestRaft_HA_ExistingCluster(t *testing.T) {
 		joinFunc(cluster.Cores[2].Client)
 
 		// Ensure peers are added
-		testhelpers.VerifyRaftPeers(t, leaderClient, map[string]bool{
+		err := testhelpers.VerifyRaftPeers(t, leaderClient, map[string]bool{
 			"core-0": true,
 			"core-1": true,
 			"core-2": true,
 		})
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	updateCluster(t)

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -1014,6 +1014,9 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 				if err == nil {
 					return nil
 				}
+			} else {
+				// Return an error so we can retry_join
+				err = fmt.Errorf("failed to get raft challenge")
 			}
 		}
 		return err


### PR DESCRIPTION
This PR addresses a bug found in https://github.com/hashicorp/vault/issues/16486

The `retry_join` loop in `JoinRaftCluster` continues to execute if a call to `join()` returns with an error.

Commit introduced a change which removes an erroneous error wrapper, but did not
handle the case where a join was in progress and err == nil. This ends the
`retry_join` loop and prevents a node from waiting to join.

Fix this by handling the `nil` channel response and returning an
error, allowing the `retry_join` to continue.