### PR TITLE
fix(docs): typos

### DIFF
--- a/website/content/docs/concepts/client-count/faq.mdx
+++ b/website/content/docs/concepts/client-count/faq.mdx
@@ -172,11 +172,11 @@ In Vault 1.9, the client count dashboard provides two separate tabs: the **Curre
 
 ### Q: What does the usage metrics look like for Vault 1.10?
 
-In Vault 1.10, the client count dashboard is broken down into tabs, similar to Vault 1.19- the current month and the monthly history. On top of the namespace attribution provided in Vault 1.9 (see [What does the usage metrics UI look like for Vault 1.9?](#q-what-does-the-usage-metrics-ui-look-like-for-vault-1-9) for further information), the UI also contains attribution of clients per auth mount.
+In Vault 1.10, the client count dashboard is broken down into tabs, similar to Vault 1.9- the current month and the monthly history. On top of the namespace attribution provided in Vault 1.9 (see [What does the usage metrics UI look like for Vault 1.9?](#q-what-does-the-usage-metrics-ui-look-like-for-vault-1-9) for further information), the UI also contains attribution of clients per auth mount.
 
 ![Vault Client Count](/img/vault-usage-metrics-1-10.png)
 
-The Vault 1.10 UI does not include montly attribution of clients, although the API for Vault 1.10 supports the same.
+The Vault 1.10 UI does not include monthly attribution of clients, although the API for Vault 1.10 supports the same.
 
 ### Q: What does the usage metrics UI look like for Vault 1.11?
 


### PR DESCRIPTION
# Description

(Reported by @buenospot)

This fixes two typos on https://www.vaultproject.io/docs/concepts/client-count/faq#q-what-does-the-usage-metrics-look-like-for-vault-1-10

```diff
- Vault 1.19
+ Vault 1.9

- montly
+ monthly
```

