### PR TITLE
Add BYOC-based revocation to PKI secrets engine

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1908,7 +1908,7 @@ func TestBackend_PathFetchValidRaw(t *testing.T) {
 
 	issueCrtAsPem := resp.Data["certificate"].(string)
 	issuedCrt := parseCert(t, issueCrtAsPem)
-	expectedSerial := certutil.GetHexFormatted(issuedCrt.SerialNumber.Bytes(), ":")
+	expectedSerial := serialFromCert(issuedCrt)
 	expectedCert := []byte(issueCrtAsPem)
 
 	// get der cert

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/hashicorp/vault/sdk/helper/consts"
 
-	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -151,7 +150,7 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 		}
 
 		colonSerial := strings.ReplaceAll(strings.ToLower(serial), "-", ":")
-		if colonSerial == certutil.GetHexFormatted(parsedBundle.Certificate.SerialNumber.Bytes(), ":") {
+		if colonSerial == serialFromCert(parsedBundle.Certificate) {
 			return logical.ErrorResponse(fmt.Sprintf("adding issuer (id: %v) to its own CRL is not allowed", issuer)), nil
 		}
 	}

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -71,6 +71,11 @@ func (b *backend) pathRevokeWriteHandleCertificate(ctx context.Context, req *log
 	// write out to disk, and an error if one occurred.
 	//
 	// First start by parsing the certificate.
+	if len(certPem) < 75 {
+		// See note in pathImportIssuers about this check.
+		return "", nil, errutil.UserError{Err: "provided certificate data was too short; perhaps a path was passed to the API rather than the contents of a PEM file"}
+	}
+
 	pemBlock, _ := pem.Decode([]byte(certPem))
 	if pemBlock == nil {
 		return "", nil, errutil.UserError{Err: "certificate contains no PEM data"}

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -69,7 +69,14 @@ func (b *backend) pathRevokeWriteHandleCertificate(ctx context.Context, req *log
 	//
 	// We return the parsed serial number, an optionally-nil byte array to
 	// write out to disk, and an error if one occurred.
-	//
+	if b.useLegacyBundleCaStorage() {
+		// We require listing all issuers from the 1.11 method. If we're
+		// still using the legacy CA bundle but with the newer certificate
+		// attribute, we err and require the operator to upgrade and migrate
+		// prior to servicing new requests.
+		return "", nil, errutil.UserError{Err: "unable to process BYOC revocation until CA issuer migration has completed"}
+	}
+
 	// First start by parsing the certificate.
 	if len(certPem) < 75 {
 		// See note in pathImportIssuers about this check.

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -669,7 +669,7 @@ func (sc *storageContext) importIssuer(certValue string, issuerName string) (*is
 		return nil, false, fmt.Errorf("bad issuer: potentially multiple PEM blobs in one certificate storage entry:\n%v", result.Certificate)
 	}
 
-	result.SerialNumber = strings.TrimSpace(certutil.GetHexFormatted(issuerCert.SerialNumber.Bytes(), ":"))
+	result.SerialNumber = serialFromCert(issuerCert)
 
 	// Before we return below, we need to iterate over _all_ keys and see if
 	// one of them a public key matching this certificate, and if so, update our

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -2,6 +2,7 @@ package pki
 
 import (
 	"crypto"
+	"crypto/x509"
 	"fmt"
 	"regexp"
 	"strings"
@@ -24,6 +25,10 @@ var (
 	errIssuerNameInUse = errutil.UserError{Err: "issuer name already in use"}
 	errKeyNameInUse    = errutil.UserError{Err: "key name already in use"}
 )
+
+func serialFromCert(cert *x509.Certificate) string {
+	return strings.TrimSpace(certutil.GetHexFormatted(cert.SerialNumber.Bytes(), ":"))
+}
 
 func normalizeSerial(serial string) string {
 	return strings.ReplaceAll(strings.ToLower(serial), ":", "-")

--- a/changelog/16564.txt
+++ b/changelog/16564.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Allow revocation of certificates with explicitly provided certificate (bring your own certificate / BYOC).
+```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -834,8 +834,15 @@ successful revocation will rotate the CRL.
 
 #### Parameters
 
-- `serial_number` `(string: <required>)` - Specifies the serial number of the
+~> Note: either `serial_number` or `certificate` (but not both) must be
+   specified on requests to this endpoint.
+
+- `serial_number` `(string: <optional>)` - Specifies the serial number of the
   certificate to revoke, in hyphen-separated or colon-separated hexadecimal.
+
+- `certificate` `(string: <optional>)` - Specifies the certificate to revoke,
+  in PEM format. This certificate must have been signed by one of the issuers
+  in this mount in order to be accepted for revocation.
 
 #### Sample Payload
 


### PR DESCRIPTION
This PR adds support for post-hoc revocation of certificates either signed externally (prior to Vault owning the CA) or of certificates issued from a `no_store=true` role. This allows all certificates to be revoked, regardless of origin. 

This is done by specifying the `certificate` parameter (taking a PEM-encoded certificate) on the `/revoke` API endpoint, instead of the `serial_number` argument. Vault verifies this against the mount's issuers and adds it to the local storage before also revoking it.

Currently there is no way to import active certificates for storage without revoking them as well.

---

- [x] Needs magical length check.
- [x] Tests for BYOC revocation
- [x] Change log entry