### PR TITLE
identity/oidc: adds detailed listing capability for clients and providers

### DIFF
--- a/changelog/16567.txt
+++ b/changelog/16567.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+identity/oidc: Adds support for detailed listing of clients and providers.
+```

--- a/website/content/api-docs/secret/identity/oidc-provider.mdx
+++ b/website/content/api-docs/secret/identity/oidc-provider.mdx
@@ -89,8 +89,6 @@ This endpoint returns a list of all OIDC providers.
 - `allowed_client_id` `(string: <optional>)` – Filters the list of OIDC providers to those
   that allow the given client ID in their set of [allowed_client_ids](/api-docs/secret/identity/oidc-provider#allowed_client_ids).
 
-- `detailed` `(bool: <optional>)` – Returns additional provider fields in the list response if true.
-
 ### Sample Request
 
 ```shell-session
@@ -105,10 +103,19 @@ $ curl \
 ```json
 {
   "data": {
-      "keys":[
-         "test-provider"
-      ]
-   }
+    "key_info": {
+      "default": {
+        "allowed_client_ids": [
+          "*"
+        ],
+        "issuer": "http://127.0.0.1:8200/v1/identity/oidc/provider/default",
+        "scopes_supported": []
+      }
+    },
+    "keys": [
+      "default"
+    ]
+  }
 }
 ```
 
@@ -363,10 +370,6 @@ This endpoint returns a list of all configured clients.
 | :----- | :------------------------------ |
 | `LIST` | `/identity/oidc/client`         |
 
-### Query Parameters
-
-- `detailed` `(bool: <optional>)` – Returns additional client fields in the list response if true.
-
 ### Sample Request
 
 ```shell-session
@@ -381,10 +384,25 @@ $ curl \
 ```json
 {
   "data": {
-      "keys":[
-         "test-client"
-      ]
-   }
+    "key_info": {
+      "my-app": {
+        "access_token_ttl": 86400,
+        "assignments": [
+          "allow_all"
+        ],
+        "client_id": "wGr981oYLJbcr4zrUriYxjxSc80JL7HW",
+        "client_type": "confidential",
+        "id_token_ttl": 86400,
+        "key": "default",
+        "redirect_uris": [
+          "http://localhost:5555/callback"
+        ]
+      }
+    },
+    "keys": [
+      "my-app"
+    ]
+  }
 }
 ```
 

--- a/website/content/api-docs/secret/identity/oidc-provider.mdx
+++ b/website/content/api-docs/secret/identity/oidc-provider.mdx
@@ -89,6 +89,8 @@ This endpoint returns a list of all OIDC providers.
 - `allowed_client_id` `(string: <optional>)` – Filters the list of OIDC providers to those
   that allow the given client ID in their set of [allowed_client_ids](/api-docs/secret/identity/oidc-provider#allowed_client_ids).
 
+- `detailed` `(bool: <optional>)` – Returns additional provider fields in the list response if true.
+
 ### Sample Request
 
 ```shell-session
@@ -359,7 +361,11 @@ This endpoint returns a list of all configured clients.
 
 | Method | Path                            |
 | :----- | :------------------------------ |
-| `LIST` | `/identity/oidc/client`           |
+| `LIST` | `/identity/oidc/client`         |
+
+### Query Parameters
+
+- `detailed` `(bool: <optional>)` – Returns additional client fields in the list response if true.
 
 ### Sample Request
 


### PR DESCRIPTION
This PR adds detailed listing capability for OIDC clients and providers by introducing the `detailed` query parameter. The motivation for this is to improve the user experience in the Vault UI.

Example of detailed client list:
```sh
$ vault list -detailed identity/oidc/client

Keys      access_token_ttl    assignments    client_id                           client_type     id_token_ttl    key        redirect_uris
----      ----------------    -----------    ---------                           -----------     ------------    ---        -------------
my-app    24h                 [allow_all]    wGr981oYLJbcr4zrUriYxjxSc80JL7HW    confidential    24h             default    [http://localhost:5555/callback]

```

Example of detailed provider list:
```sh
$ vault list -detailed identity/oidc/provider

Keys       allowed_client_ids    issuer                                                     scopes_supported
----       ------------------    ------                                                     ----------------
default    [*]                   http://127.0.0.1:8200/v1/identity/oidc/provider/default    []
```