### PR TITLE
UI/vault 7312/fix vault enterprise error for okta number challenge

### DIFF
--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -317,6 +317,10 @@ export default Component.extend(DEFAULTS, {
       // add nonce field for okta backend
       if (backend.id == 'okta') {
         data.nonce = crypto.randomUUID();
+        // add a default path of okta if it doesn't exist to be used for Okta Number Challenge
+        if (!data.path) {
+          data.path = 'okta';
+        }
       }
       return this.authenticate.unlinked().perform(backend.type, data);
     },

--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -315,7 +315,7 @@ export default Component.extend(DEFAULTS, {
         data.path = this.customPath || backend.id;
       }
       // add nonce field for okta backend
-      if (backend.id == 'okta') {
+      if (backend.type === 'okta') {
         data.nonce = crypto.randomUUID();
         // add a default path of okta if it doesn't exist to be used for Okta Number Challenge
         if (!data.path) {

--- a/ui/app/services/auth.js
+++ b/ui/app/services/auth.js
@@ -443,9 +443,8 @@ export default Service.extend({
   }),
 
   getOktaNumberChallengeAnswer(nonce, mount) {
-    let namespace = this.namespaceService.path;
     const url = `/v1/auth/${mount}/verify/${nonce}`;
-    return this.ajax(url, 'GET', { namespace }).then(
+    return this.ajax(url, 'GET', {}).then(
       (resp) => {
         return resp.data.correct_answer;
       },

--- a/ui/app/services/auth.js
+++ b/ui/app/services/auth.js
@@ -443,7 +443,7 @@ export default Service.extend({
   }),
 
   getOktaNumberChallengeAnswer(nonce, mount) {
-    let namespace = 'undefined';
+    let namespace = this.namespaceService.path;
     const url = `/v1/auth/${mount}/verify/${nonce}`;
     return this.ajax(url, 'GET', { namespace }).then(
       (resp) => {

--- a/ui/app/templates/vault/cluster/auth.hbs
+++ b/ui/app/templates/vault/cluster/auth.hbs
@@ -109,7 +109,7 @@
         @onSuccess={{action "onMfaSuccess"}}
         @onError={{fn (mut this.mfaErrors)}}
       />
-    {{else if (eq this.authMethod "okta/")}}
+    {{else}}
       <AuthForm
         @wrappedToken={{this.wrappedToken}}
         @cluster={{this.model}}
@@ -121,15 +121,6 @@
         @waitingForOktaNumberChallenge={{this.waitingForOktaNumberChallenge}}
         @setCancellingAuth={{fn (mut this.cancelAuth)}}
         @cancelAuthForOktaNumberChallenge={{this.cancelAuth}}
-      />
-    {{else}}
-      <AuthForm
-        @wrappedToken={{this.wrappedToken}}
-        @cluster={{this.model}}
-        @namespace={{this.namespaceQueryParam}}
-        @redirectTo={{this.redirectTo}}
-        @selectedAuth={{this.authMethod}}
-        @onSuccess={{action "onAuthResponse"}}
       />
     {{/if}}
   </Page.content>


### PR DESCRIPTION
Fixed 403 error on Vault Enterprise, fixed issue where namespace is undefined and bug where when Okta selected in 'Other' tab, it doesn't work. 

Changed the `auth.hbs` to not check if the `authMethod` is Okta because I noticed that if the user logs out from originally signing in with a token and we switch to the okta tab, the authMethod value isn't `okta/`