### PR TITLE
Add AWS secrets engine policy templating support

### DIFF
--- a/builtin/logical/aws/path_user_test.go
+++ b/builtin/logical/aws/path_user_test.go
@@ -1,0 +1,144 @@
+package aws
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+type mockSTSClient struct {
+	stsiface.STSAPI
+
+	AssumeRoleInput  *sts.AssumeRoleInput
+	AssumeRoleOutput *sts.AssumeRoleOutput
+	AssumeRoleError  error
+}
+
+func (m *mockSTSClient) AssumeRole(input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
+	m.AssumeRoleInput = input
+	if m.AssumeRoleError != nil {
+		return nil, m.AssumeRoleError
+	}
+
+	return m.AssumeRoleOutput, nil
+}
+
+func (m *mockSTSClient) AssumeRoleWithContext(ctx aws.Context, input *sts.AssumeRoleInput, opts ...request.Option) (*sts.AssumeRoleOutput, error) {
+	m.AssumeRoleInput = input
+	if m.AssumeRoleError != nil {
+		return nil, m.AssumeRoleError
+	}
+
+	return m.AssumeRoleOutput, nil
+}
+
+func TestBackend_PathCredsRead(t *testing.T) {
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+	config.System = &logical.StaticSystemView{
+		EntityVal: &logical.Entity{
+			ID:   "test-id",
+			Name: "test",
+			Aliases: []*logical.Alias{
+				{
+					MountAccessor: "auth_jwt_1234",
+					Metadata: map[string]string{
+						"group": "dev",
+					},
+				},
+			},
+		},
+	}
+
+	b := Backend(config)
+	if err := b.Setup(context.Background(), config); err != nil {
+		t.Fatal(err)
+	}
+
+	b.stsClient = &mockSTSClient{
+		AssumeRoleOutput: &sts.AssumeRoleOutput{
+			AssumedRoleUser: &sts.AssumedRoleUser{
+				Arn: aws.String("arn:aws:iam::123456789012:role/test"),
+			},
+			Credentials: &sts.Credentials{
+				Expiration:      aws.Time(time.Now()),
+				AccessKeyId:     aws.String("123456"),
+				SecretAccessKey: aws.String("123456"),
+				SessionToken:    aws.String("123456"),
+			},
+		},
+	}
+
+	roleData := map[string]interface{}{
+		"role_arns":                         []string{"arn:aws:iam::123456789012:role/test"},
+		"credential_type":                   assumedRoleCred,
+		"enable_policy_document_templating": true,
+		"policy_document": `
+{
+	"Version": "2012-10-07",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": "ec2:Describe*",
+			"Resource": "*",
+            "Condition": {
+				"StringEquals": {
+					"ec2:ResourceTag/Entity": "{{identity.entity.name}}",
+					"ec2:ResourceTag/Group": "{{identity.entity.aliases.auth_jwt_1234.metadata.group}}"
+				}
+            }
+		}
+	]
+}`,
+		"default_sts_ttl": 3600,
+		"max_sts_ttl":     3600,
+	}
+
+	updateRoleResp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "roles/test",
+		Storage:   config.StorageView,
+		Data:      roleData,
+	})
+	if err != nil || (updateRoleResp != nil && updateRoleResp.IsError()) {
+		t.Fatalf("bad: role creation failed. updateRoleResp:%#v\nerr:%v", updateRoleResp, err)
+	}
+
+	readResp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "creds/test",
+		Storage:   config.StorageView,
+		EntityID:  "test-id",
+	})
+	if err != nil || (readResp != nil && readResp.IsError()) {
+		t.Fatalf("bad: reading creds failed. readResp:%#v\n err:%v", readResp, err)
+	}
+
+	expectedPolicy, err := compactJSON(`{
+		"Version": "2012-10-07",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Action": "ec2:Describe*",
+				"Resource": "*",
+				"Condition": {
+					"StringEquals": {
+						"ec2:ResourceTag/Entity": "test",
+						"ec2:ResourceTag/Group": "dev"
+					}
+				}
+			}
+		]
+	}`)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedPolicy, *b.stsClient.(*mockSTSClient).AssumeRoleInput.Policy)
+}

--- a/changelog/16580.txt
+++ b/changelog/16580.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+secrets/aws: Add AWS secrets engine policy templating support
+```

--- a/ui/app/models/role-aws.js
+++ b/ui/app/models/role-aws.js
@@ -60,12 +60,16 @@ export default Model.extend({
       'A policy is an object in AWS that, when associated with an identity or resource, defines their permissions.',
     // Cannot have a default_value on policy_document because in some cases AWS expects this value to be empty.
   }),
+  enablePolicyDocumentTemplating: attr('boolean', {
+    defaultValue: false,
+    helpText: 'Enable templating of the policy document with Identity metadata.',
+  }),
   fields: computed('credentialType', function () {
     const credentialType = this.credentialType;
     const keysForType = {
-      iam_user: ['name', 'credentialType', 'policyArns', 'policyDocument'],
-      assumed_role: ['name', 'credentialType', 'roleArns', 'policyDocument'],
-      federation_token: ['name', 'credentialType', 'policyDocument'],
+      iam_user: ['name', 'credentialType', 'policyArns', 'policyDocument', 'enablePolicyDocumentTemplating'],
+      assumed_role: ['name', 'credentialType', 'roleArns', 'policyDocument', 'enablePolicyDocumentTemplating'],
+      federation_token: ['name', 'credentialType', 'policyDocument', 'enablePolicyDocumentTemplating'],
       session_token: [],
     };
 

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -31,7 +31,7 @@ files, or IAM/ECS instances.
 
 - Static credentials provided to the API as a payload
 
-- [Plugin workload identity federation](/vault/docs/secrets/aws#plugin-workload-identity-federation-wif) 
+- [Plugin workload identity federation](/vault/docs/secrets/aws#plugin-workload-identity-federation-wif)
   credentials
 
 - Credentials in the `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, and `AWS_REGION`
@@ -60,15 +60,15 @@ valid AWS credentials with proper permissions.
 - `secret_key` `(string: "")` – Specifies the AWS secret access key. Must be provided with
   `access_key`.
 
-- `role_arn` `(string: "")` – <EnterpriseAlert product="vault" inline /> Role ARN to assume 
+- `role_arn` `(string: "")` – <EnterpriseAlert product="vault" inline /> Role ARN to assume
   for plugin workload identity federation. Required with `identity_token_audience`.
 
-- `identity_token_audience` `(string: "")` - <EnterpriseAlert product="vault" inline /> The 
-  audience claim value for plugin identity tokens. Must match an allowed audience configured 
+- `identity_token_audience` `(string: "")` - <EnterpriseAlert product="vault" inline /> The
+  audience claim value for plugin identity tokens. Must match an allowed audience configured
   for the target [IAM OIDC identity provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html#manage-oidc-provider-console).
   Mutually exclusive with `access_key`.
 
-- `identity_token_ttl` `(string/int: 3600)` - <EnterpriseAlert product="vault" inline /> The 
+- `identity_token_ttl` `(string/int: 3600)` - <EnterpriseAlert product="vault" inline /> The
   TTL of generated tokens. Defaults to 1 hour. Uses [duration format strings](/vault/docs/concepts/duration-format).
 
 - `region` `(string: <optional>)` – Specifies the AWS region. If not set it
@@ -293,6 +293,10 @@ updated with the new attributes.
   user has. With `assumed_role` and `federation_token`, the policy document will
   act as a filter on what the credentials can do, similar to `policy_arns`. With
   `session_token`, this field is disallowed.
+
+ - `enable_policy_document_templating` `(string)` - Enable templating of the
+  policy document with Identity metadata. With `session_token`, this field
+  is disallowed.
 
 - `iam_groups` `(list: [])` - A list of IAM group names. IAM users generated
   against this vault role will be added to these IAM Groups. For a credential

--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -86,7 +86,7 @@ management tool.
     In some cases, you cannot set sensitive IAM security credentials in your
     Vault configuration. For example, your organization may require that all
     security credentials are short-lived or explicitly tied to a machine identity.
-    
+
     To provide IAM security credentials to Vault, we recommend using Vault
     [plugin workload identity federation](#plugin-workload-identity-federation-wif)
     (WIF).
@@ -163,6 +163,45 @@ management tool.
     }
     EOF
     ```
+
+    Finally, the `policy_document` argument supports the same
+    [identity templating](https://developer.hashicorp.com/vault/docs/concepts/policies#templated-policies)
+    as for Vault policies. This enables advanced use cases such as restricting resources
+    based on claims provided via JWT authentication. For example with Gitlab:
+
+    ```text
+    $ vault write aws/roles/my-other-role \
+        policy_arns=arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess,arn:aws:iam::aws:policy/IAMReadOnlyAccess \
+        iam_groups=group1,group2 \
+        credential_type=iam_user \
+        enable_policy_document_templating=true \
+        policy_document=-<<EOF
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "ec2:*",
+          "Resource": "*",
+          "Condition": {
+            "StringEquals": {"aws:ResourceTag/GitlabProject": "{{identity.entity.aliases.auth_jwt_123456ab.metadata.gitlab_project}}"}
+          }
+        }
+      ]
+    }
+    EOF
+    ```
+
+    Note: You can list the authentication methods aliases with the `vault auth list` command:
+
+    ```text
+    $ vault auth list
+    Path      Type     Accessor               Description
+    ----      ----     --------               -----------
+    jwt/      jwt      auth_jwt_123456ab      n/a
+    ```
+
+    This policy will restrict access to only the resources with the tag `GitlabProject` matching the metadata value.
 
     For more information on IAM policies, please see the
     [AWS IAM policy documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/PoliciesOverview.html).
@@ -306,8 +345,8 @@ them).
 <EnterpriseAlert product="vault" />
 
 The AWS secrets engine supports the Plugin WIF workflow, and has a source of identity called
-a plugin identity token. The plugin identity token is a JWT that is internally signed by Vault's 
-[plugin identity token issuer](/vault/api-docs/secret/identity/tokens#read-plugin-workload-identity-issuer-s-openid-configuration). 
+a plugin identity token. The plugin identity token is a JWT that is internally signed by Vault's
+[plugin identity token issuer](/vault/api-docs/secret/identity/tokens#read-plugin-workload-identity-issuer-s-openid-configuration).
 
 If there is a trust relationship configured between Vault and AWS through
 [Web Identity Federation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html),
@@ -321,15 +360,15 @@ credentials.
 To configure the secrets engine to use plugin WIF:
 
 1. Ensure that Vault [openid-configuration](/vault/api-docs/secret/identity/tokens#read-plugin-identity-token-issuer-s-openid-configuration)
-   and [public JWKS](/vault/api-docs/secret/identity/tokens#read-plugin-identity-token-issuer-s-public-jwks) 
+   and [public JWKS](/vault/api-docs/secret/identity/tokens#read-plugin-identity-token-issuer-s-public-jwks)
    APIs are network-reachable by AWS. We recommend using an API proxy or gateway
-   if you need to limit Vault API exposure.  
+   if you need to limit Vault API exposure.
 
 1. Create an
    [IAM OIDC identity provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html)
    in AWS.
    1. The provider URL **must** point at your [Vault plugin identity token issuer](/vault/api-docs/secret/identity/tokens#read-plugin-workload-identity-issuer-s-openid-configuration) with the
-   `/.well-known/openid-configuration` suffix removed. For example: 
+   `/.well-known/openid-configuration` suffix removed. For example:
    `https://host:port/v1/identity/oidc/plugins`.
    1. The audience should uniquely identify the recipient of the plugin identity
    token. In AWS, the recipient is the identity provider. We recommend using
@@ -348,11 +387,11 @@ $ vault write aws/config/root \
     role_arn="arn:aws:iam::123456789123:role/example-web-identity-role"
 ```
 
-Your secrets engine can now use plugin WIF for its configuration credentials. 
-By default, WIF [credentials](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html) 
+Your secrets engine can now use plugin WIF for its configuration credentials.
+By default, WIF [credentials](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html)
 have a time-to-live of 1 hour and automatically refresh when they expire.
 
-Please see the [API documentation](/vault/api-docs/secret/aws#configure-root-credentials) 
+Please see the [API documentation](/vault/api-docs/secret/aws#configure-root-credentials)
 for more details on the fields associated with plugin WIF.
 
 ## STS credentials


### PR DESCRIPTION
This change brings the possibility for users to configure
templating of policies based on claims issued from auth
sources.

This enables many use-cases like scoping CI/CD permissions
based on Gitlab or Github JWT claims.

See #9934

Signed-off-by: Adrien Fillon <adrien.fillon@manomano.com>