### PR TITLE
VAULT-6818 Docs for entity merge functionality

### DIFF
--- a/website/content/api-docs/secret/identity/entity.mdx
+++ b/website/content/api-docs/secret/identity/entity.mdx
@@ -396,6 +396,9 @@ $ curl \
 ## Merge Entities
 
 This endpoint merges many entities into one entity. Additionally, all groups associated with `from_entity_ids` are merged with those of `to_entity_id`.
+Note that if these entities contain aliases sharing the same mount accessor, the merge will fail unless `conflicting_alias_ids_to_keep` is present, and
+entities must be merged one at a time. This is because each entity can only have one alias with each mount accessor - for more
+information, see the [identity concepts page](/docs/concepts/identity).
 
 | Method | Path                     |
 | :----- | :----------------------- |
@@ -403,7 +406,7 @@ This endpoint merges many entities into one entity. Additionally, all groups ass
 
 ### Parameters
 
-- `from_entity_ids` `(array: <required>)` - Entity IDs which needs to get
+- `from_entity_ids` `(list of strings: <required>)` - Entity IDs which need to get
   merged.
 
 - `to_entity_id` `(string: <required>)` - Entity ID into which all the other
@@ -414,6 +417,11 @@ This endpoint merges many entities into one entity. Additionally, all groups ass
   that are merged from and in entity into which all others are getting merged,
   secrets in the destination will be unaltered. If not set, this API will throw
   an error containing all the conflicts.
+
+- `conflicting_alias_ids_to_keep` `(list of strings: [])` - A list of entity
+  aliases to keep in the case where the to-Entity and from-Entity have aliases
+  with the same mount accessor. Note that merges requiring this parameter must
+  have only one from-Entity.
 
 ### Sample Payload
 

--- a/website/content/api-docs/secret/identity/entity.mdx
+++ b/website/content/api-docs/secret/identity/entity.mdx
@@ -420,8 +420,9 @@ information, see the [identity concepts page](/docs/concepts/identity).
 
 - `conflicting_alias_ids_to_keep` `(list of strings: [])` - A list of entity
   aliases to keep in the case where the to-Entity and from-Entity have aliases
-  with the same mount accessor. Note that merges requiring this parameter must
-  have only one from-Entity.
+  with the same mount accessor. In the case where alias share mount accessors,
+  the alias ID given in this list will be kept or merged, and the other alias will be deleted.
+  Note that merges requiring this parameter must have only one from-Entity.
 
 ### Sample Payload
 


### PR DESCRIPTION
Sister PR to https://github.com/hashicorp/vault/pull/16539 - context about this particular change can be found there.

In short, just documentation about the new behaviour for entity merging in the case of alias clash.