### PR TITLE
identity/oidc: adds client_secret_post token endpoint authentication method

### DIFF
--- a/changelog/16598.txt
+++ b/changelog/16598.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+identity/oidc: Adds the `client_secret_post` token endpoint authentication method.
+```

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -434,6 +434,22 @@ func TestOIDC_Path_OIDC_Token(t *testing.T) {
 			},
 		},
 		{
+			name: "valid token request with client_secret_post client authentication method",
+			args: args{
+				clientReq:     testClientReq(s),
+				providerReq:   testProviderReq(s, clientID),
+				assignmentReq: testAssignmentReq(s, entityID, groupID),
+				authorizeReq:  testAuthorizeReq(s, clientID),
+				tokenReq: func() *logical.Request {
+					req := testTokenReq(s, "", clientID, clientSecret)
+					req.Headers = nil
+					req.Data["client_id"] = clientID
+					req.Data["client_secret"] = clientSecret
+					return req
+				}(),
+			},
+		},
+		{
 			name: "valid token request",
 			args: args{
 				clientReq:     testClientReq(s),

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -3630,7 +3630,7 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		TokenEndpoint:         basePath + "/token",
 		UserinfoEndpoint:      basePath + "/userinfo",
 		GrantTypes:            []string{"authorization_code"},
-		AuthMethods:           []string{"none", "client_secret_basic"},
+		AuthMethods:           []string{"none", "client_secret_basic", "client_secret_post"},
 		RequestURIParameter:   false,
 	}
 	discoveryResp := &providerDiscovery{}
@@ -3684,7 +3684,7 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		TokenEndpoint:         basePath + "/token",
 		UserinfoEndpoint:      basePath + "/userinfo",
 		GrantTypes:            []string{"authorization_code"},
-		AuthMethods:           []string{"none", "client_secret_basic"},
+		AuthMethods:           []string{"none", "client_secret_basic", "client_secret_post"},
 		RequestURIParameter:   false,
 	}
 	discoveryResp = &providerDiscovery{}

--- a/website/content/api-docs/secret/identity/oidc-provider.mdx
+++ b/website/content/api-docs/secret/identity/oidc-provider.mdx
@@ -288,7 +288,7 @@ This endpoint creates or updates a client.
   - `confidential`
     - Capable of maintaining the confidentiality of its credentials
     - Has a client secret
-    - Uses the `client_secret_basic` [client authentication method](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication)
+    - Uses the `client_secret_basic` or `client_secret_post` [client authentication method](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication)
     - May use Proof Key for Code Exchange ([PKCE](https://datatracker.ietf.org/doc/html/rfc7636))
       for the authorization code flow
   - `public`
@@ -601,6 +601,7 @@ $ curl \
   ],
   "token_endpoint_auth_methods_supported": [
     "client_secret_basic",
+    "client_secret_post",
     "none"
   ]}
 ```
@@ -736,9 +737,13 @@ for an OIDC provider.
   authorization request was sent. This must match the `redirect_uri` used when the
   original authorization code was generated.
 
-- `client_id` `(string: <required>)` - The ID of the requesting client. This parameter
-  is only required for `public` clients which do not have a client secret. `confidential`
-  clients should not use this parameter.
+- `client_id` `(string: <optional>)` - The ID of the requesting client. This parameter
+  is required for `public` clients which do not have a client secret or `confidential`
+  clients using the `client_secret_post` client authentication method.
+
+- `client_secret` `(string: <optional>)` - The secret of the requesting client. This
+  parameter is required for `confidential` clients using the `client_secret_post` client
+  authentication method.
 
 - `code_verifier` `(string: <optional>)` - The code verifier associated with the given
   `code`. Required for authorization codes that were granted using [PKCE](https://datatracker.ietf.org/doc/html/rfc7636).
@@ -746,9 +751,10 @@ for an OIDC provider.
 
 ### Headers
 
-- `Authorization: Basic` `(string: <required>)` - An HTTP Basic authentication scheme header
+- `Authorization: Basic` `(string: <optional>)` - An HTTP Basic authentication scheme header
   including the `client_id` and `client_secret` as described in the [client_secret_basic](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication)
-  authentication method. This header is only required for `confidential` clients.
+  authentication method. This header is only required for `confidential` clients using
+  the `client_secret_basic` client authentication method.
 
 ### Sample Request
 

--- a/website/content/docs/concepts/oidc-provider.mdx
+++ b/website/content/docs/concepts/oidc-provider.mdx
@@ -138,7 +138,7 @@ Confidential clients may use Proof Key for Code Exchange ([PKCE](https://datatra
 during the authorization code flow.
 
 Confidential clients must authenticate to the token endpoint using the
-`client_secret_basic` [client authentication method](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication).
+`client_secret_basic` or `client_secret_post` [client authentication method](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication).
 
 ##### Public
 

--- a/website/content/docs/secrets/identity/oidc-provider.mdx
+++ b/website/content/docs/secrets/identity/oidc-provider.mdx
@@ -124,7 +124,8 @@ Any Vault auth method may be used within the OIDC flow. For simplicity, enable t
      ],
      "token_endpoint_auth_methods_supported": [
        "none",
-       "client_secret_basic"
+       "client_secret_basic",
+       "client_secret_post"
      ]
    }
    ```


### PR DESCRIPTION
This PR adds the `client_secret_post` token authentication method per [9. Client Authentication
](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication)