### PR TITLE
identity/oidc: change the state parameter to optional

### DIFF
--- a/changelog/16599.txt
+++ b/changelog/16599.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity/oidc: Change the `state` parameter of the Authorization Endpoint to optional.
+```

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -448,7 +448,6 @@ func oidcProviderPaths(i *IdentityStore) []*framework.Path {
 				"state": {
 					Type:        framework.TypeString,
 					Description: "The value used to maintain state between the authentication request and client.",
-					Required:    true,
 				},
 				"nonce": {
 					Type:        framework.TypeString,
@@ -1609,11 +1608,7 @@ func (i *IdentityStore) keyIDsReferencedByTargetClientIDs(ctx context.Context, s
 }
 
 func (i *IdentityStore) pathOIDCAuthorize(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	// Validate the state
 	state := d.Get("state").(string)
-	if state == "" {
-		return authResponse("", "", ErrAuthInvalidRequest, "state parameter is required")
-	}
 
 	// Get the namespace
 	ns, err := namespace.FromContext(ctx)

--- a/website/content/api-docs/secret/identity/oidc-provider.mdx
+++ b/website/content/api-docs/secret/identity/oidc-provider.mdx
@@ -672,7 +672,7 @@ to be used for the [Authorization Code Flow](https://openid.net/specs/openid-con
 
 - `redirect_uri` `(string: <required>)` - The redirection URI to which the response will be sent.
 
-- `state` `(string: <required>)` - A value used to maintain state between the authentication request and client.
+- `state` `(string: <optional>)` - A value used to maintain state between the authentication request and client.
 
 - `nonce` `(string: <optional>)` - A value that is returned in the ID token nonce claim. It is used to mitigate replay attacks, so we *strongly encourage* providing this optional parameter.
 

--- a/website/content/docs/concepts/oidc-provider.mdx
+++ b/website/content/docs/concepts/oidc-provider.mdx
@@ -199,7 +199,7 @@ Each provider offers an unauthenticated endpoint that provides the public portio
 
 ### Authorization Endpoint
 
-Each provider offers an authenticated [authorization endpoint](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint). The authorization endpoint for each provider is added to Vault's [default policy](/docs/concepts/policies#default-policy) using the `identity/oidc/provider/+/authorize` path. The endpoint incorporates all required [authentication request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) parameters as input. Additionally, the `state` parameter is required.
+Each provider offers an authenticated [authorization endpoint](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint). The authorization endpoint for each provider is added to Vault's [default policy](/docs/concepts/policies#default-policy) using the `identity/oidc/provider/+/authorize` path. The endpoint incorporates all required [authentication request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) parameters as input.
 
 The endpoint [validates](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequestValidation) client requests and ensures that all required parameters are present and valid. The `redirect_uri` of the request is validated against the client's `redirect_uris`. The requesting Vault entity will be validated against the client's `assignments`. An appropriate [error code](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) is returned for invalid requests.
 


### PR DESCRIPTION
This PR makes the `state` parameter optional per [3.1.2.1. Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).

Fixes: https://github.com/hashicorp/vault/issues/14194