### PR TITLE
identity/oidc: fixes validation of the request and request_uri parameters

### DIFF
--- a/changelog/16600.txt
+++ b/changelog/16600.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity/oidc: Fixes validation of the `request` and `request_uri` parameters.
+```

--- a/ui/app/controllers/vault/cluster/oidc-provider.js
+++ b/ui/app/controllers/vault/cluster/oidc-provider.js
@@ -13,6 +13,8 @@ export default class VaultClusterOidcProviderController extends Controller {
     'max_age',
     'code_challenge',
     'code_challenge_method',
+    'request',
+    'request_uri',
   ];
   scope = null;
   response_type = null;
@@ -25,4 +27,6 @@ export default class VaultClusterOidcProviderController extends Controller {
   max_age = null;
   code_challenge = null;
   code_challenge_method = null;
+  request = null;
+  request_uri = null;
 }

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -154,6 +154,7 @@ type providerDiscovery struct {
 	AuthorizationEndpoint string   `json:"authorization_endpoint"`
 	TokenEndpoint         string   `json:"token_endpoint"`
 	UserinfoEndpoint      string   `json:"userinfo_endpoint"`
+	RequestParameter      bool     `json:"request_parameter_supported"`
 	RequestURIParameter   bool     `json:"request_uri_parameter_supported"`
 	IDTokenAlgs           []string `json:"id_token_signing_alg_values_supported"`
 	ResponseTypes         []string `json:"response_types_supported"`
@@ -1474,6 +1475,7 @@ func (i *IdentityStore) pathOIDCProviderDiscovery(ctx context.Context, req *logi
 		UserinfoEndpoint:      p.effectiveIssuer + "/userinfo",
 		IDTokenAlgs:           supportedAlgs,
 		Scopes:                scopes,
+		RequestParameter:      false,
 		RequestURIParameter:   false,
 		ResponseTypes:         []string{"code"},
 		Subjects:              []string{"public"},

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -3615,6 +3615,7 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		UserinfoEndpoint:      basePath + "/userinfo",
 		GrantTypes:            []string{"authorization_code"},
 		AuthMethods:           []string{"none", "client_secret_basic"},
+		RequestParameter:      false,
 		RequestURIParameter:   false,
 	}
 	discoveryResp := &providerDiscovery{}
@@ -3669,6 +3670,7 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		UserinfoEndpoint:      basePath + "/userinfo",
 		GrantTypes:            []string{"authorization_code"},
 		AuthMethods:           []string{"none", "client_secret_basic"},
+		RequestParameter:      false,
 		RequestURIParameter:   false,
 	}
 	discoveryResp = &providerDiscovery{}

--- a/website/content/api-docs/secret/identity/oidc-provider.mdx
+++ b/website/content/api-docs/secret/identity/oidc-provider.mdx
@@ -577,6 +577,7 @@ $ curl \
   "authorization_endpoint": "http://127.0.0.1:8200/ui/vault/identity/oidc/provider/test-provider/authorize",
   "token_endpoint": "http://127.0.0.1:8200/v1/identity/oidc/provider/test-provider/token",
   "userinfo_endpoint": "http://127.0.0.1:8200/v1/identity/oidc/provider/test-provider/userinfo",
+  "request_parameter_supported": false,
   "request_uri_parameter_supported": false,
   "id_token_signing_alg_values_supported": [
     "RS256",

--- a/website/content/docs/secrets/identity/oidc-provider.mdx
+++ b/website/content/docs/secrets/identity/oidc-provider.mdx
@@ -100,6 +100,7 @@ Any Vault auth method may be used within the OIDC flow. For simplicity, enable t
      "authorization_endpoint": "http://127.0.0.1:8200/ui/vault/identity/oidc/provider/default/authorize",
      "token_endpoint": "http://127.0.0.1:8200/v1/identity/oidc/provider/default/token",
      "userinfo_endpoint": "http://127.0.0.1:8200/v1/identity/oidc/provider/default/userinfo",
+     "request_parameter_supported": false,
      "request_uri_parameter_supported": false,
      "id_token_signing_alg_values_supported": [
        "RS256",


### PR DESCRIPTION
This PR fixes required validation already present in [identity_store_oidc_provider.go#L1684-L1693](https://github.com/hashicorp/vault/blob/main/vault/identity_store_oidc_provider.go#L1684-L1693) which wasn't being passed to the server by UI code. It also adds the `request_parameter_supported` field to the OIDC discovery document per [6.1. Passing a Request Object by Value](https://openid.net/specs/openid-connect-core-1_0.html#RequestObject).