### PR TITLE
Fix Link: OIDC Provider Config - Okta

### DIFF
--- a/website/content/docs/auth/jwt/oidc-providers/index.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/index.mdx
@@ -22,5 +22,5 @@ and additions may be submitted via the [Vault Github repository](https://github.
 - [Google](/docs/auth/jwt/oidc-providers/google)
 - [Keycloak](/docs/auth/jwt/oidc-providers/keycloak)
 - [Kubernetes](/docs/auth/jwt/oidc-providers/kubernetes)
-- [Okta](/docs/auth/jwt/oidc-providers/kubernetes)
+- [Okta](/docs/auth/jwt/oidc-providers/okta)
 - [SecureAuth](/docs/auth/jwt/oidc-providers/secureauth)


### PR DESCRIPTION
Okta was pointing at /docs/auth/jwt/oidc-providers/kubernetes.  Updated to point at /docs/auth/jwt/oidc-providers/okta