### PR TITLE
UI/OIDC providers create/edit route

### DIFF
--- a/ui/app/components/oidc/provider-form.js
+++ b/ui/app/components/oidc/provider-form.js
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
+
 /**
  * @module OidcProviderForm
  * OidcProviderForm components are used to create and update OIDC providers
@@ -51,9 +52,11 @@ export default class OidcProviderForm extends Component {
         if (this.radioCardGroupValue === 'allow_all') {
           this.args.model.allowedClientIds = ['*'];
         }
+        const { isNew, name } = this.args.model;
         yield this.args.model.save();
         this.flashMessages.success(
-          `Successfully ${this.args.model.isNew ? 'created an' : 'updated'} application`
+          `Successfully ${isNew ? 'created' : 'updated'} the OIDC provider 
+          ${name}.`
         );
         this.args.onSave();
       }

--- a/ui/app/components/oidc/provider-form.js
+++ b/ui/app/components/oidc/provider-form.js
@@ -26,6 +26,7 @@ export default class OidcProviderForm extends Component {
 
   @tracked modelValidations;
   @tracked radioCardGroupValue =
+    // If "*" is provided, all clients are allowed: https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#parameters
     !this.args.model.allowedClientIds || this.args.model.allowedClientIds.includes('*')
       ? 'allow_all'
       : 'limited';
@@ -49,6 +50,13 @@ export default class OidcProviderForm extends Component {
     }
   }
 
+  @action
+  cancel() {
+    const method = this.args.model.isNew ? 'unloadRecord' : 'rollbackAttributes';
+    this.args.model[method]();
+    this.args.onCancel();
+  }
+
   @task
   *save(event) {
     event.preventDefault();
@@ -56,10 +64,10 @@ export default class OidcProviderForm extends Component {
       const { isValid, state } = this.args.model.validate();
       this.modelValidations = isValid ? null : state;
       if (isValid) {
+        const { isNew, name } = this.args.model;
         if (this.radioCardGroupValue === 'allow_all') {
           this.args.model.allowedClientIds = ['*'];
         }
-        const { isNew, name } = this.args.model;
         yield this.args.model.save();
         this.flashMessages.success(
           `Successfully ${isNew ? 'created' : 'updated'} the OIDC provider 
@@ -71,12 +79,5 @@ export default class OidcProviderForm extends Component {
       const message = error.errors ? error.errors.join('. ') : error.message;
       this.flashMessages.danger(message);
     }
-  }
-
-  @action
-  cancel() {
-    const method = this.args.model.isNew ? 'unloadRecord' : 'rollbackAttributes';
-    this.args.model[method]();
-    this.args.onCancel();
   }
 }

--- a/ui/app/components/oidc/provider-form.js
+++ b/ui/app/components/oidc/provider-form.js
@@ -1,0 +1,72 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+/**
+ * @module OidcProviderForm
+ * OidcProviderForm components are used to create and update OIDC providers
+ *
+ * @example
+ * ```js
+ * <OidcProviderForm @model={{this.model}} />
+ * ```
+ * @callback onCancel
+ * @callback onSave
+ * @param {Object} model - oidc client model
+ * @param {onCancel} onCancel - callback triggered when cancel button is clicked
+ * @param {onSave} onSave - callback triggered on save success
+ */
+
+export default class OidcProviderForm extends Component {
+  @service store;
+  @service flashMessages;
+
+  @tracked modelValidations;
+  @tracked radioCardGroupValue =
+    !this.args.model.allowedClientIds || this.args.model.allowedClientIds.includes('*')
+      ? 'allow_all'
+      : 'limited';
+
+  @action
+  handleClientSelection(selection) {
+    // if array then coming from search-select component, set selection as model clients
+    if (Array.isArray(selection)) {
+      this.args.model.allowedClientIds = selection;
+    } else {
+      // otherwise update radio button value and reset clients so
+      // UI always reflects a user's selection (including when no clients are selected)
+      this.radioCardGroupValue = selection;
+      this.args.model.allowedClientIds = [];
+    }
+  }
+
+  @task
+  *save(event) {
+    event.preventDefault();
+    try {
+      const { isValid, state } = this.args.model.validate();
+      this.modelValidations = isValid ? null : state;
+      if (isValid) {
+        if (this.radioCardGroupValue === 'allow_all') {
+          this.args.model.allowedClientIds = ['*'];
+        }
+        yield this.args.model.save();
+        this.flashMessages.success(
+          `Successfully ${this.args.model.isNew ? 'created an' : 'updated'} application`
+        );
+        this.args.onSave();
+      }
+    } catch (error) {
+      const message = error.errors ? error.errors.join('. ') : error.message;
+      this.flashMessages.danger(message);
+    }
+  }
+
+  @action
+  cancel() {
+    const method = this.args.model.isNew ? 'unloadRecord' : 'rollbackAttributes';
+    this.args.model[method]();
+    this.args.onCancel();
+  }
+}

--- a/ui/app/components/oidc/provider-form.js
+++ b/ui/app/components/oidc/provider-form.js
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
+import parseURL from 'core/utils/parse-url';
 
 /**
  * @module OidcProviderForm
@@ -28,6 +29,10 @@ export default class OidcProviderForm extends Component {
     !this.args.model.allowedClientIds || this.args.model.allowedClientIds.includes('*')
       ? 'allow_all'
       : 'limited';
+
+  get parseUrlOrigin() {
+    return this.args.model.isNew ? '' : parseURL(this.args.model.issuer).origin;
+  }
 
   @action
   handleClientSelection(selection) {

--- a/ui/app/components/oidc/provider-form.js
+++ b/ui/app/components/oidc/provider-form.js
@@ -30,8 +30,10 @@ export default class OidcProviderForm extends Component {
       ? 'allow_all'
       : 'limited';
 
-  get parseUrlOrigin() {
-    return this.args.model.isNew ? '' : parseURL(this.args.model.issuer).origin;
+  constructor() {
+    super(...arguments);
+    const { model } = this.args;
+    model.issuer = model.isNew ? '' : parseURL(model.issuer).origin;
   }
 
   @action

--- a/ui/app/components/regex-validator.hbs
+++ b/ui/app/components/regex-validator.hbs
@@ -16,9 +16,9 @@
           <p class="sub-text">
             {{@attr.options.subText}}
             {{#if @attr.options.docLink}}
-              <a href={{@attr.options.docLink}} target="_blank" rel="noopener noreferrer">
+              <DocLink @path={{@attr.options.docLink}}>
                 See our documentation
-              </a>
+              </DocLink>
               for help.
             {{/if}}
           </p>

--- a/ui/app/controllers/vault/cluster/access/oidc/providers/provider.js
+++ b/ui/app/controllers/vault/cluster/access/oidc/providers/provider.js
@@ -1,0 +1,20 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class OidcProviderController extends Controller {
+  @service router;
+  @tracked isEditRoute;
+
+  constructor() {
+    super(...arguments);
+    this.router.on('routeDidChange', ({ targetName }) => {
+      return (this.isEditRoute = targetName.includes('edit') ? true : false);
+    });
+  }
+
+  get showHeader() {
+    // hide header when rendering the edit form
+    return !this.isEditRoute;
+  }
+}

--- a/ui/app/models/database/connection.js
+++ b/ui/app/models/database/connection.js
@@ -54,7 +54,7 @@ export default Model.extend({
     defaultSubText:
       'Unless a custom policy is specified, Vault will use a default: 20 characters with at least 1 uppercase, 1 lowercase, 1 number, and 1 dash character.',
     defaultShown: 'Default',
-    docLink: 'https://www.vaultproject.io/docs/concepts/password-policies',
+    docLink: '/docs/concepts/password-policies',
   }),
 
   // common fields
@@ -106,7 +106,7 @@ export default Model.extend({
     subText: 'Enter the custom username template to use.',
     defaultSubText:
       'Template describing how dynamic usernames are generated. Vault will use the default for this plugin.',
-    docLink: 'https://www.vaultproject.io/docs/concepts/username-templating',
+    docLink: '/docs/concepts/username-templating',
     defaultShown: 'Default',
   }),
   max_open_connections: attr('number', {

--- a/ui/app/models/oidc/provider.js
+++ b/ui/app/models/oidc/provider.js
@@ -17,9 +17,11 @@ const validations = {
 export default class OidcProviderModel extends Model {
   @attr('string', { editDisabled: true }) name;
   @attr('string', {
-    label: 'Issuer URL',
-    subText: 'The issuer URL parameter is necessary for the validation of ID tokens by applications.',
+    subText:
+      'The scheme, host, and optional port for your issuer. This will be used to build the URL that validates ID tokens.',
+    placeholderText: 'e.g. https://example.com:8200',
     docLink: '/api-docs/secret/identity/oidc-provider#create-or-update-a-provider',
+    helpText: `Optional. This defaults to a URL with Vault's api_addr`,
   })
   issuer;
 

--- a/ui/app/models/oidc/provider.js
+++ b/ui/app/models/oidc/provider.js
@@ -29,6 +29,7 @@ export default class OidcProviderModel extends Model {
     editType: 'searchSelect',
     models: ['oidc/scope'],
     fallbackComponent: 'string-list',
+    onlyAllowExisting: true,
   })
   scopesSupported;
 

--- a/ui/app/models/oidc/provider.js
+++ b/ui/app/models/oidc/provider.js
@@ -1,12 +1,38 @@
 import Model, { attr } from '@ember-data/model';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
+import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
+import { withModelValidations } from 'vault/decorators/model-validations';
 
+const validations = {
+  name: [{ type: 'presence', message: 'Name is required.' }],
+};
+
+@withModelValidations(validations)
 export default class OidcProviderModel extends Model {
-  @attr('string') name;
-  @attr('string', { label: 'Issuer UR' }) issuer;
-  @attr('array', { label: 'Supported scopes', editType: 'searchSelect' }) scopesSupported;
+  @attr('string', { editDisabled: true }) name;
+  @attr('string', {
+    label: 'Issuer URL',
+    subText: 'The issuer URL parameter is necessary for the validation of ID tokens by applications.',
+    docLink: '/api-docs/secret/identity/oidc-provider#create-or-update-a-provider',
+  })
+  issuer;
+  @attr('array', {
+    label: 'Supported scopes',
+    subText: 'Scopes define information about a user and the OIDC service. Optional.',
+    editType: 'searchSelect',
+    models: ['oidc/scope'],
+  })
+  scopesSupported;
   @attr('array', { label: 'Allowed applications' }) allowedClientIds; // no editType because does not use form-field component
 
+  // TODO refactor when field-to-attrs is refactored as decorator
+  _attributeMeta = null; // cache initial result of expandAttributeMeta in getter and return
+  get formFields() {
+    if (!this._attributeMeta) {
+      this._attributeMeta = expandAttributeMeta(this, ['name', 'issuer', 'scopesSupported']);
+    }
+    return this._attributeMeta;
+  }
   @lazyCapabilities(apiPath`identity/oidc/provider/${'name'}`, 'name') providerPath;
   @lazyCapabilities(apiPath`identity/oidc/provider`) providersPath;
   get canCreate() {

--- a/ui/app/models/oidc/provider.js
+++ b/ui/app/models/oidc/provider.js
@@ -4,7 +4,13 @@ import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 import { withModelValidations } from 'vault/decorators/model-validations';
 
 const validations = {
-  name: [{ type: 'presence', message: 'Name is required.' }],
+  name: [
+    { type: 'presence', message: 'Name is required.' },
+    {
+      type: 'containsWhiteSpace',
+      message: 'Name cannot contain whitespace.',
+    },
+  ],
 };
 
 @withModelValidations(validations)
@@ -16,13 +22,16 @@ export default class OidcProviderModel extends Model {
     docLink: '/api-docs/secret/identity/oidc-provider#create-or-update-a-provider',
   })
   issuer;
+
   @attr('array', {
     label: 'Supported scopes',
     subText: 'Scopes define information about a user and the OIDC service. Optional.',
     editType: 'searchSelect',
     models: ['oidc/scope'],
+    fallbackComponent: 'string-list',
   })
   scopesSupported;
+
   @attr('array', { label: 'Allowed applications' }) allowedClientIds; // no editType because does not use form-field component
 
   // TODO refactor when field-to-attrs is refactored as decorator

--- a/ui/app/routes/vault/cluster/access/oidc/providers/create.js
+++ b/ui/app/routes/vault/cluster/access/oidc/providers/create.js
@@ -1,3 +1,7 @@
 import Route from '@ember/routing/route';
 
-export default class OidcProvidersCreateRoute extends Route {}
+export default class OidcProvidersCreateRoute extends Route {
+  model() {
+    return this.store.createRecord('oidc/provider');
+  }
+}

--- a/ui/app/routes/vault/cluster/access/oidc/providers/provider.js
+++ b/ui/app/routes/vault/cluster/access/oidc/providers/provider.js
@@ -1,3 +1,7 @@
 import Route from '@ember/routing/route';
 
-export default class OidcProviderRoute extends Route {}
+export default class OidcProviderRoute extends Route {
+  model({ name }) {
+    return this.store.findRecord('oidc/provider', name);
+  }
+}

--- a/ui/app/templates/components/clients/config.hbs
+++ b/ui/app/templates/components/clients/config.hbs
@@ -9,9 +9,9 @@
             <p class="sub-text">
               {{attr.options.helpText}}
               {{#if attr.options.docLink}}
-                <a href={{attr.options.docLink}} target="_blank" rel="noopener noreferrer">
+                <DocLink @path={{attr.options.docLink}}>
                   See our documentation
-                </a>
+                </DocLink>
                 for help.
               {{/if}}
             </p>
@@ -43,9 +43,9 @@
               <p class="sub-text">
                 {{attr.options.subText}}
                 {{#if attr.options.docLink}}
-                  <a href={{attr.options.docLink}} target="_blank" rel="noopener noreferrer">
+                  <DocLink @path={{attr.options.docLink}}>
                     See our documentation
-                  </a>
+                  </DocLink>
                   for help.
                 {{/if}}
               </p>

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -6,7 +6,7 @@
           <span class="sep">&#x0002f;</span>
           {{#if @model.isNew}}
             <LinkTo @route="vault.cluster.access.oidc.providers">
-              Applications
+              Providers
             </LinkTo>
           {{else}}
             <LinkTo @route="vault.cluster.access.oidc.providers.provider.details" @model={{@model.name}}>
@@ -24,6 +24,7 @@
     </h1>
   </p.levelLeft>
 </PageHeader>
+
 <form {{on "submit" (perform this.save)}}>
   <div class="box is-sideless is-fullwidth is-bottomless">
     <MessageError @errorMessage={{this.error}} class="has-top-margin-s" />

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -29,7 +29,13 @@
   <div class="box is-sideless is-fullwidth is-bottomless">
     <MessageError @errorMessage={{this.error}} class="has-top-margin-s" />
     {{#each @model.formFields as |attr|}}
-      <FormField data-test-field={{true}} @attr={{attr}} @model={{@model}} @modelValidations={{this.modelValidations}} />
+      <FormField
+        data-test-field={{true}}
+        @attr={{attr}}
+        @model={{@model}}
+        @modelValidations={{this.modelValidations}}
+        @overrideEditValue={{if (eq attr.name "issuer") this.parseUrlOrigin}}
+      />
     {{/each}}
   </div>
   {{! RADIO CARD + SEARCH SELECT }}

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -44,6 +44,7 @@
         @docLink={{attr.options.docLink}}
       />
       <Input
+        data-test-field={{true}}
         data-test-input={{attr.name}}
         id={{attr.name}}
         autocomplete="off"

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -28,15 +28,39 @@
 <form {{on "submit" (perform this.save)}}>
   <div class="box is-sideless is-fullwidth is-bottomless">
     <MessageError @errorMessage={{this.error}} class="has-top-margin-s" />
-    {{#each @model.formFields as |attr|}}
-      <FormField
-        data-test-field={{true}}
-        @attr={{attr}}
-        @model={{@model}}
-        @modelValidations={{this.modelValidations}}
-        @overrideEditValue={{if (eq attr.name "issuer") this.parseUrlOrigin}}
+    {{! name field }}
+    <FormField
+      data-test-field={{true}}
+      @attr={{get @model.formFields "0"}}
+      @model={{@model}}
+      @modelValidations={{this.modelValidations}}
+    />
+    {{#let (get @model.formFields "1") as |attr|}}
+      <FormFieldLabel
+        for={{attr.name}}
+        @label="Issuer"
+        @helpText={{attr.options.helpText}}
+        @subText={{attr.options.subText}}
+        @docLink={{attr.options.docLink}}
       />
-    {{/each}}
+      <Input
+        data-test-input={{attr.name}}
+        id={{attr.name}}
+        autocomplete="off"
+        spellcheck="false"
+        @value={{@model.issuer}}
+        class="input {{if this.validationError 'has-error-border'}}"
+        placeholder={{attr.options.placeholderText}}
+      />
+    {{/let}}
+    {{! scopesSupported field }}
+    <FormField
+      data-test-field={{true}}
+      @attr={{get @model.formFields "2"}}
+      @model={{@model}}
+      @modelValidations={{this.modelValidations}}
+      @labelClass="is-label"
+    />
   </div>
   {{! RADIO CARD + SEARCH SELECT }}
   <div class="box is-sideless is-fullwidth is-marginless has-top-padding-xxl">

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -55,7 +55,7 @@
     </div>
     {{#if (eq this.radioCardGroupValue "limited")}}
       <SearchSelect
-        @id="clients"
+        @id="allowedClientIds"
         @subLabel="Application name"
         @models={{array "oidc/client"}}
         @inputValue={{@model.allowedClientIds}}

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -1,0 +1,88 @@
+<PageHeader as |p|>
+  <p.top>
+    <nav class="breadcrumb">
+      <ul>
+        <li>
+          <span class="sep">&#x0002f;</span>
+          {{#if @model.isNew}}
+            <LinkTo @route="vault.cluster.access.oidc.providers">
+              Applications
+            </LinkTo>
+          {{else}}
+            <LinkTo @route="vault.cluster.access.oidc.providers.provider.details" @model={{@model.name}}>
+              Details
+            </LinkTo>
+          {{/if}}
+        </li>
+      </ul>
+    </nav>
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3" data-test-oidc-provider-title>
+      {{if @model.isNew "Create" "Edit"}}
+      provider
+    </h1>
+  </p.levelLeft>
+</PageHeader>
+<form {{on "submit" (perform this.save)}}>
+  <div class="box is-sideless is-fullwidth is-bottomless">
+    <MessageError @errorMessage={{this.error}} class="has-top-margin-s" />
+    {{#each @model.formFields as |attr|}}
+      <FormField data-test-field={{true}} @attr={{attr}} @model={{@model}} @modelValidations={{this.modelValidations}} />
+    {{/each}}
+  </div>
+  {{! RADIO CARD + SEARCH SELECT }}
+  <div class="box is-sideless is-fullwidth is-marginless has-top-padding-xxl">
+    <h4 class="title is-4">Allowed applications</h4>
+    <div class="is-flex-row">
+      <RadioCard
+        @title="Allow every application to use"
+        @description="All applications can use this provider for authentication requests."
+        @icon="globe"
+        @value="allow_all"
+        @groupValue={{this.radioCardGroupValue}}
+        @onChange={{this.handleClientSelection}}
+      />
+      <RadioCard
+        @title="Limit access to selected application"
+        @description="Only selected applications can use this provider for authentication requests."
+        @icon="globe-private"
+        @value="limited"
+        @groupValue={{this.radioCardGroupValue}}
+        @onChange={{this.handleClientSelection}}
+      />
+    </div>
+    {{#if (eq this.radioCardGroupValue "limited")}}
+      <SearchSelect
+        @id="clients"
+        @subLabel="Application name"
+        @models={{array "oidc/client"}}
+        @inputValue={{@model.allowedClientIds}}
+        @onChange={{this.handleClientSelection}}
+        @disallowNewItems={{true}}
+        @fallbackComponent="string-list"
+      />
+    {{/if}}
+  </div>
+  <div class="field box is-fullwidth is-bottomless">
+    <div class="control">
+      <button
+        type="submit"
+        class="button is-primary {{if this.save.isRunning 'is-loading'}}"
+        disabled={{this.save.isRunning}}
+        data-test-oidc-provider-save
+      >
+        {{if @model.isNew "Create" "Update"}}
+      </button>
+      <button
+        type="button"
+        class="button has-left-margin-s"
+        disabled={{this.save.isRunning}}
+        {{on "click" this.cancel}}
+        data-test-oidc-provider-cancel
+      >
+        Cancel
+      </button>
+    </div>
+  </div>
+</form>

--- a/ui/app/templates/vault/cluster/access/oidc/providers/create.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/create.hbs
@@ -1,0 +1,5 @@
+<Oidc::ProviderForm
+  @model={{this.model}}
+  @onCancel={{transition-to "vault.cluster.access.oidc.providers"}}
+  @onSave={{transition-to "vault.cluster.access.oidc.providers.provider.details" this.model.name}}
+/>

--- a/ui/app/templates/vault/cluster/access/oidc/providers/provider.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/provider.hbs
@@ -1,0 +1,36 @@
+{{#if this.showHeader}}
+  <PageHeader as |p|>
+    <p.top>
+      <nav class="breadcrumb" aria-label="breadcrumbs">
+        <ul>
+          <li>
+            <span class="sep">&#x0002f;</span>
+            <LinkTo @route="vault.cluster.access.oidc.providers">
+              Providers
+            </LinkTo>
+          </li>
+        </ul>
+      </nav>
+    </p.top>
+    <p.levelLeft>
+      <h1 class="title is-3">
+        {{this.model.name}}
+      </h1>
+    </p.levelLeft>
+  </PageHeader>
+
+  <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
+    <nav class="tabs" aria-label="tabs">
+      <ul>
+        <LinkTo @route="vault.cluster.access.oidc.providers.provider.details" @model={{this.model}}>
+          Details
+        </LinkTo>
+        <LinkTo @route="vault.cluster.access.oidc.providers.provider.clients" @model={{this.model}}>
+          Applications
+        </LinkTo>
+      </ul>
+    </nav>
+  </div>
+{{/if}}
+
+{{outlet}}

--- a/ui/app/templates/vault/cluster/access/oidc/providers/provider.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/provider.hbs
@@ -25,9 +25,6 @@
         <LinkTo @route="vault.cluster.access.oidc.providers.provider.details" @model={{this.model}}>
           Details
         </LinkTo>
-        <LinkTo @route="vault.cluster.access.oidc.providers.provider.clients" @model={{this.model}}>
-          Applications
-        </LinkTo>
       </ul>
     </nav>
   </div>

--- a/ui/app/templates/vault/cluster/access/oidc/providers/provider/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/provider/edit.hbs
@@ -1,0 +1,5 @@
+<Oidc::ProviderForm
+  @model={{this.model}}
+  @onCancel={{transition-to "vault.cluster.access.oidc.providers.provider.details" this.model.name}}
+  @onSave={{transition-to "vault.cluster.access.oidc.providers.provider.details" this.model.name}}
+/>

--- a/ui/lib/core/addon/components/form-field-label.hbs
+++ b/ui/lib/core/addon/components/form-field-label.hbs
@@ -12,10 +12,9 @@
   <p class="sub-text" data-test-label-subtext>
     {{@subText}}
     {{#if @docLink}}
-      <a href={{@docLink}} target="_blank" rel="noopener noreferrer">
-        See our documentation
-      </a>
-      for help.
+      <DocLink @path={{@docLink}}>
+        Learn more
+      </DocLink>
     {{/if}}
   </p>
 {{/if}}

--- a/ui/lib/core/addon/components/form-field-label.hbs
+++ b/ui/lib/core/addon/components/form-field-label.hbs
@@ -13,8 +13,9 @@
     {{@subText}}
     {{#if @docLink}}
       <DocLink @path={{@docLink}}>
-        Learn more
+        See our documentation
       </DocLink>
+      for help
     {{/if}}
   </p>
 {{/if}}

--- a/ui/lib/core/addon/components/form-field-label.hbs
+++ b/ui/lib/core/addon/components/form-field-label.hbs
@@ -15,7 +15,7 @@
       <DocLink @path={{@docLink}}>
         See our documentation
       </DocLink>
-      for help
+      for help.
     {{/if}}
   </p>
 {{/if}}

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -91,6 +91,7 @@
         @selectLimit={{@attr.options.selectLimit}}
         @backend={{@model.backend}}
         @disallowNewItems={{@attr.options.onlyAllowExisting}}
+        @labelClass={{@labelClass}}
       />
     </div>
   {{else if (eq @attr.options.editType "mountAccessor")}}
@@ -288,12 +289,11 @@
           disabled={{and @attr.options.editDisabled (not @model.isNew)}}
           autocomplete="off"
           spellcheck="false"
-          value={{or @overrideEditValue (or (get @model this.valuePath) @attr.options.defaultValue)}}
+          value={{or (get @model this.valuePath) @attr.options.defaultValue}}
           onchange={{this.onChangeWithEvent}}
           onkeyup={{this.handleKeyUp}}
           class="input {{if this.validationError 'has-error-border'}}"
           maxLength={{@attr.options.characterLimit}}
-          placeholder={{@attr.options.placeholderText}}
         />
         {{#if @attr.options.validationAttr}}
           {{#if (and (get @model this.valuePath) (not (get @model @attr.options.validationAttr)))}}

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -163,9 +163,9 @@
           <span>
             {{@attr.options.subText}}
             {{#if @attr.options.docLink}}
-              <a href={{@attr.options.docLink}} target="_blank" rel="noopener noreferrer">
+              <DocLink @path={{@attr.options.docLink}}>
                 See our documentation
-              </a>
+              </DocLink>
               for help.
             {{/if}}
           </span>
@@ -173,9 +173,9 @@
           <span>
             {{or @attr.options.defaultSubText "Vault will use the engine default."}}
             {{#if @attr.options.docLink}}
-              <a href={{@attr.options.docLink}} target="_blank" rel="noopener noreferrer">
+              <DocLink @path={{@attr.options.docLink}}>
                 See our documentation
-              </a>
+              </DocLink>
               for help.
             {{/if}}
           </span>
@@ -272,9 +272,9 @@
           <p class="sub-text">
             {{@attr.options.subText}}
             {{#if @attr.options.docLink}}
-              <a href={{@attr.options.docLink}} target="_blank" rel="noopener noreferrer">
+              <DocLink @path={{@attr.options.docLink}}>
                 See our documentation
-              </a>
+              </DocLink>
               for help.
             {{/if}}
           </p>

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -288,11 +288,12 @@
           disabled={{and @attr.options.editDisabled (not @model.isNew)}}
           autocomplete="off"
           spellcheck="false"
-          value={{or (get @model this.valuePath) @attr.options.defaultValue}}
+          value={{or @overrideEditValue (or (get @model this.valuePath) @attr.options.defaultValue)}}
           onchange={{this.onChangeWithEvent}}
           onkeyup={{this.handleKeyUp}}
           class="input {{if this.validationError 'has-error-border'}}"
           maxLength={{@attr.options.characterLimit}}
+          placeholder={{@attr.options.placeholderText}}
         />
         {{#if @attr.options.validationAttr}}
           {{#if (and (get @model this.valuePath) (not (get @model @attr.options.validationAttr)))}}

--- a/ui/mirage/handlers/oidc-config.js
+++ b/ui/mirage/handlers/oidc-config.js
@@ -44,6 +44,37 @@ export default function (server) {
     };
   });
 
+  // LIST ENDPOINTS
+  server.get('/identity/oidc/client', () => {
+    return {
+      request_id: 'client-list-id',
+      lease_id: '',
+      renewable: false,
+      lease_duration: 0,
+      data: {
+        keys: ['some-app'],
+      },
+      wrap_info: null,
+      warnings: null,
+      auth: null,
+    };
+  });
+
+  server.get('/identity/oidc/scope', () => {
+    return {
+      request_id: 'scope-list-id',
+      lease_id: '',
+      renewable: false,
+      lease_duration: 0,
+      data: {
+        keys: ['test-scope'],
+      },
+      wrap_info: null,
+      warnings: null,
+      auth: null,
+    };
+  });
+
   server.get('/identity/oidc/assignment', () => {
     return {
       request_id: 'assignment-list-id',
@@ -68,6 +99,7 @@ export default function (server) {
       keys: ['1234-12345'],
     },
   }));
+
   server.get('/identity/group/id', () => ({
     data: {
       key_info: { 'abcdef-123': { name: 'test-group' } },

--- a/ui/tests/integration/components/form-field-label-test.js
+++ b/ui/tests/integration/components/form-field-label-test.js
@@ -37,8 +37,8 @@ module('Integration | Component | form-field-label', function (hooks) {
     assert.dom('[data-test-help-text]').hasText(this.helpText, 'Help text renders in tooltip');
     assert.dom('.sub-text').hasText(this.subText, 'Sub text renders');
     assert.dom('a').doesNotExist('docLink hidden when not provided');
-    this.set('docLink', 'foo.com/bar');
+    this.set('docLink', '/doc/path');
     assert.dom('.sub-text').includesText('See our documentation for help', 'Doc link text renders');
-    assert.dom('a').hasAttribute('href', this.docLink, 'Doc link renders');
+    assert.dom('a').hasAttribute('href', 'https://www.vaultproject.io' + this.docLink, 'Doc link renders');
   });
 });

--- a/ui/tests/integration/components/oidc/provider-form-test.js
+++ b/ui/tests/integration/components/oidc/provider-form-test.js
@@ -5,6 +5,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import ENV from 'vault/config/environment';
 import { overrideMirageResponse } from 'vault/tests/helpers/oidc-config';
+import parseURL from 'core/utils/parse-url';
 
 const ISSUER_URL = 'http://127.0.0.1:8200/v1/identity/oidc/provider/test-provider';
 
@@ -25,7 +26,7 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
   });
 
   test('it should save new provider', async function (assert) {
-    assert.expect(11);
+    assert.expect(12);
     this.server.post('/identity/oidc/provider/test-provider', (schema, req) => {
       assert.ok(true, 'Request made to save provider');
       return JSON.parse(req.requestBody);
@@ -44,6 +45,9 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
       .dom('[data-test-oidc-provider-title]')
       .hasText('Create provider', 'Form title renders correct text');
     assert.dom('[data-test-oidc-provider-save]').hasText('Create', 'Save button has correct text');
+    assert
+      .dom('[data-test-input="issuer"]')
+      .hasAttribute('placeholder', 'e.g. https://example.com:8200', 'issuer placeholder text is correct');
     assert.equal(findAll('[data-test-field]').length, 3, 'renders all input fields');
     await click('[data-test-component="search-select"]#scopesSupported .ember-basic-dropdown-trigger');
     assert.dom('li.ember-power-select-option').hasText('test-scope', 'dropdown renders scopes');
@@ -110,7 +114,8 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
       .hasValue('test-provider', 'Name input is populated with model value');
     assert
       .dom('[data-test-input="issuer"]')
-      .hasValue(ISSUER_URL, 'issuer url input is populated with model value');
+      .hasValue(parseURL(ISSUER_URL).origin, 'issuer value is just scheme://host:port portion of full URL');
+
     assert.dom('[data-test-selected-option="true"]').hasText('test-scope', 'model scope is selected');
     assert.dom('input#allow-all').isChecked('Allow all radio button is selected');
     await click('[data-test-oidc-provider-save]');

--- a/ui/tests/integration/components/oidc/provider-form-test.js
+++ b/ui/tests/integration/components/oidc/provider-form-test.js
@@ -1,0 +1,179 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, fillIn, click, findAll } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import ENV from 'vault/config/environment';
+import { overrideMirageResponse } from 'vault/tests/helpers/oidc-config';
+
+const ISSUER_URL = 'http://127.0.0.1:8200/v1/identity/oidc/provider/test-provider';
+
+module('Integration | Component | oidc/provider-form', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.before(function () {
+    ENV['ember-cli-mirage'].handler = 'oidcConfig';
+  });
+  ``;
+  hooks.after(function () {
+    ENV['ember-cli-mirage'].handler = null;
+  });
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+  });
+
+  test('it should save new provider', async function (assert) {
+    assert.expect(11);
+    this.server.post('/identity/oidc/provider/test-provider', (schema, req) => {
+      assert.ok(true, 'Request made to save provider');
+      return JSON.parse(req.requestBody);
+    });
+    this.model = this.store.createRecord('oidc/provider');
+    this.onSave = () => assert.ok(true, 'onSave callback fires on save success');
+    await render(hbs`
+    <Oidc::ProviderForm
+    @model={{this.model}}
+    @onCancel={{this.onCancel}}
+    @onSave={{this.onSave}}
+    />
+    `);
+
+    assert
+      .dom('[data-test-oidc-provider-title]')
+      .hasText('Create provider', 'Form title renders correct text');
+    assert.dom('[data-test-oidc-provider-save]').hasText('Create', 'Save button has correct text');
+    assert.equal(findAll('[data-test-field]').length, 3, 'renders all input fields');
+    await click('[data-test-component="search-select"]#scopesSupported .ember-basic-dropdown-trigger');
+    assert.dom('li.ember-power-select-option').hasText('test-scope', 'dropdown renders scopes');
+
+    // check validation errors
+    await click('[data-test-oidc-provider-save]');
+    assert
+      .dom('[data-test-inline-error-message]')
+      .hasText('Name is required.', 'Validation message is shown for name');
+    await fillIn('[data-test-input="name"]', 'test space');
+    await click('[data-test-oidc-provider-save]');
+    assert
+      .dom('[data-test-inline-error-message]')
+      .hasText('Name cannot contain whitespace.', 'Validation message is shown whitespace');
+
+    await click('label[for=limited]');
+    assert
+      .dom('[data-test-component="search-select"]#allowedClientIds')
+      .exists('Limited radio button shows clients search select');
+    await click('[data-test-component="search-select"]#allowedClientIds .ember-basic-dropdown-trigger');
+    assert.dom('li.ember-power-select-option').hasText('some-app', 'dropdown renders clients');
+
+    await click('label[for=allow-all]');
+    assert
+      .dom('[data-test-component="search-select"]#allowedClientIds')
+      .doesNotExist('Allow all radio button hides search select');
+
+    await fillIn('[data-test-input="name"]', 'test-provider');
+    await click('[data-test-oidc-provider-save]');
+  });
+
+  test('it should update provider', async function (assert) {
+    assert.expect(9);
+
+    this.server.post('/identity/oidc/provider/test-provider', (schema, req) => {
+      assert.ok(true, 'Request made to save provider');
+      return JSON.parse(req.requestBody);
+    });
+
+    this.store.pushPayload('oidc/provider', {
+      modelName: 'oidc/provider',
+      name: 'test-provider',
+      allowed_client_ids: ['*'],
+      issuer: ISSUER_URL,
+      scopes_supported: ['test-scope'],
+    });
+
+    this.model = this.store.peekRecord('oidc/provider', 'test-provider');
+    this.onSave = () => assert.ok(true, 'onSave callback fires on save success');
+
+    await render(hbs`
+      <Oidc::ProviderForm
+        @model={{this.model}}
+        @onCancel={{this.onCancel}}
+        @onSave={{this.onSave}}
+      />
+    `);
+
+    assert.dom('[data-test-oidc-provider-title]').hasText('Edit provider', 'Title renders correct text');
+    assert.dom('[data-test-oidc-provider-save]').hasText('Update', 'Save button has correct text');
+    assert.dom('[data-test-input="name"]').isDisabled('Name input is disabled when editing');
+    assert
+      .dom('[data-test-input="name"]')
+      .hasValue('test-provider', 'Name input is populated with model value');
+    assert
+      .dom('[data-test-input="issuer"]')
+      .hasValue(ISSUER_URL, 'issuer url input is populated with model value');
+    assert.dom('[data-test-selected-option="true"]').hasText('test-scope', 'model scope is selected');
+    assert.dom('input#allow-all').isChecked('Allow all radio button is selected');
+    await click('[data-test-oidc-provider-save]');
+  });
+
+  test('it should rollback attributes or unload record on cancel', async function (assert) {
+    assert.expect(4);
+    this.model = this.store.createRecord('oidc/provider');
+    this.onCancel = () => assert.ok(true, 'onCancel callback fires');
+
+    await render(hbs`
+      <Oidc::ProviderForm
+        @model={{this.model}}
+        @onCancel={{this.onCancel}}
+        @onSave={{this.onSave}}
+      />
+    `);
+
+    await click('[data-test-oidc-provider-cancel]');
+    assert.true(this.model.isDestroyed, 'New model is unloaded on cancel');
+
+    this.store.pushPayload('oidc/provider', {
+      modelName: 'oidc/provider',
+      name: 'test-provider',
+      allowed_client_ids: ['*'],
+      issuer: ISSUER_URL,
+      scopes_supported: ['test-scope'],
+    });
+
+    this.model = this.store.peekRecord('oidc/provider', 'test-provider');
+
+    await render(hbs`
+      <Oidc::ProviderForm
+        @model={{this.model}}
+        @onCancel={{this.onCancel}}
+        @onSave={{this.onSave}}
+      />
+    `);
+
+    await click('label[for=limited]');
+    await click('[data-test-oidc-provider-cancel]');
+    assert.equal(this.model.allowed_client_ids, undefined, 'Model attributes rolled back on cancel');
+  });
+
+  test('it should render fallback for search select', async function (assert) {
+    assert.expect(2);
+    this.model = this.store.createRecord('oidc/provider');
+    this.server.get('/identity/oidc/scope', () => overrideMirageResponse(403));
+    this.server.get('/identity/oidc/client', () => overrideMirageResponse(403));
+    await render(hbs`
+      <Oidc::ProviderForm
+        @model={{this.model}}
+        @onCancel={{this.onCancel}}
+        @onSave={{this.onSave}}
+      />
+    `);
+
+    assert
+      .dom('[data-test-component="search-select"]#scopesSupported [data-test-component="string-list"]')
+      .exists('renders fall back for scopes search select');
+    await click('label[for=limited]');
+    assert
+      .dom('[data-test-component="search-select"]#allowedClientIds [data-test-component="string-list"]')
+      .exists('Radio toggle shows assignments string-list input');
+  });
+});

--- a/ui/tests/integration/components/oidc/provider-form-test.js
+++ b/ui/tests/integration/components/oidc/provider-form-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
   hooks.before(function () {
     ENV['ember-cli-mirage'].handler = 'oidcConfig';
   });
-  ``;
+
   hooks.after(function () {
     ENV['ember-cli-mirage'].handler = null;
   });


### PR DESCRIPTION
Updated PR to reflect latest designs. Notice that the `Issuer` has a placeholder on create, and then on edit the URL path is trimmed to just the `scheme://host:port` portion. The issuer param's _output_ is different than the _input_. The full URL is the output of a provider's attribute, but only the origin piece is valid input. [See docs](https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#parameters)

<hr>

### form 
![provider-form](https://user-images.githubusercontent.com/68122737/183783885-6ecb2e72-ca71-42d2-8cd6-b218e707bcae.gif)

### validations 
![provider-validations](https://user-images.githubusercontent.com/68122737/183475085-e4ee1ac9-8c9f-41b5-af5e-8bff57a083c8.gif)

### success flash messages
_**create**_
<img width="300" alt="Screen Shot 2022-08-09 at 11 26 25 AM" src="https://user-images.githubusercontent.com/68122737/183733868-cbcb779a-e2fc-4725-a09f-642551813b93.png">

_**edit**_
<img width="300" alt="Screen Shot 2022-08-09 at 11 27 03 AM" src="https://user-images.githubusercontent.com/68122737/183733986-e8115c89-3af2-4af8-9b8f-853dc5fa5ad9.png">

