### PR TITLE
Allow marking issuers as revoked

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -141,6 +141,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathCrossSignIntermediate(&b),
 			pathConfigIssuers(&b),
 			pathReplaceRoot(&b),
+			pathRevokeIssuer(&b),
 
 			// Key APIs
 			pathListKeys(&b),

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -578,6 +578,141 @@ func TestPoP(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestIssuerRevocation(t *testing.T) {
+	b, s := createBackendWithStorage(t)
+
+	// Create a root CA.
+	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
+		"common_name": "root example.com",
+		"issuer_name": "root",
+		"key_type":    "ec",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.Data["certificate"])
+	require.NotEmpty(t, resp.Data["serial_number"])
+	// oldRoot := resp.Data["certificate"].(string)
+	oldRootSerial := resp.Data["serial_number"].(string)
+
+	// Create a second root CA. We'll revoke this one and ensure it
+	// doesn't appear on the former's CRL.
+	resp, err = CBWrite(b, s, "root/generate/internal", map[string]interface{}{
+		"common_name": "root2 example.com",
+		"issuer_name": "root2",
+		"key_type":    "ec",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.Data["certificate"])
+	require.NotEmpty(t, resp.Data["serial_number"])
+	// revokedRoot := resp.Data["certificate"].(string)
+	revokedRootSerial := resp.Data["serial_number"].(string)
+
+	// Shouldn't be able to revoke it by serial number.
+	_, err = CBWrite(b, s, "revoke", map[string]interface{}{
+		"serial_number": revokedRootSerial,
+	})
+	require.Error(t, err)
+
+	// Revoke it.
+	resp, err = CBWrite(b, s, "issuer/root2/revoke", map[string]interface{}{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotZero(t, resp.Data["revocation_time"])
+
+	// Regenerate the CRLs
+	_, err = CBRead(b, s, "crl/rotate")
+	require.NoError(t, err)
+
+	// Ensure the old cert isn't on the one's CRL.
+	crl := getParsedCrlFromBackend(t, b, s, "issuer/root/crl/der")
+	if requireSerialNumberInCRL(nil, crl.TBSCertList, revokedRootSerial) {
+		t.Fatalf("the serial number %v should not be on %v's CRL as they're separate roots", revokedRootSerial, oldRootSerial)
+	}
+
+	// Create a role and ensure we can't use the revoked root.
+	_, err = CBWrite(b, s, "roles/local-testing", map[string]interface{}{
+		"allow_any_name":    true,
+		"enforce_hostnames": false,
+		"key_type":          "ec",
+		"ttl":               "75s",
+	})
+	require.NoError(t, err)
+
+	// Issue a leaf cert and ensure it fails (because the issuer is revoked).
+	_, err = CBWrite(b, s, "issuer/root2/issue/local-testing", map[string]interface{}{
+		"common_name": "testing",
+	})
+	require.Error(t, err)
+
+	// Issue an intermediate and ensure we can revoke it.
+	resp, err = CBWrite(b, s, "intermediate/generate/internal", map[string]interface{}{
+		"common_name": "intermediate example.com",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.Data["csr"])
+	intCsr := resp.Data["csr"].(string)
+	resp, err = CBWrite(b, s, "root/sign-intermediate", map[string]interface{}{
+		"ttl": "30h",
+		"csr": intCsr,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.Data["certificate"])
+	require.NotEmpty(t, resp.Data["serial_number"])
+	intCert := resp.Data["certificate"].(string)
+	intCertSerial := resp.Data["serial_number"].(string)
+	resp, err = CBWrite(b, s, "intermediate/set-signed", map[string]interface{}{
+		"certificate": intCert,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.Data["imported_issuers"])
+	importedIssuers := resp.Data["imported_issuers"].([]string)
+	require.Equal(t, len(importedIssuers), 1)
+	intId := importedIssuers[0]
+	_, err = CBPatch(b, s, "issuer/"+intId, map[string]interface{}{
+		"issuer_name": "int1",
+	})
+	require.NoError(t, err)
+
+	// Now issue a leaf with the intermediate.
+	resp, err = CBWrite(b, s, "issuer/int1/issue/local-testing", map[string]interface{}{
+		"common_name": "testing",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.Data["certificate"])
+	require.NotEmpty(t, resp.Data["serial_number"])
+	issuedSerial := resp.Data["serial_number"].(string)
+
+	// Now revoke the intermediate.
+	resp, err = CBWrite(b, s, "issuer/int1/revoke", map[string]interface{}{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotZero(t, resp.Data["revocation_time"])
+
+	// Update the CRLs and ensure it appears.
+	_, err = CBRead(b, s, "crl/rotate")
+	require.NoError(t, err)
+	crl = getParsedCrlFromBackend(t, b, s, "issuer/root/crl/der")
+	requireSerialNumberInCRL(t, crl.TBSCertList, intCertSerial)
+
+	// Ensure we can still revoke the issued leaf.
+	resp, err = CBWrite(b, s, "revoke", map[string]interface{}{
+		"serial_number": issuedSerial,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Ensure it appears on the intermediate's CRL.
+	_, err = CBRead(b, s, "crl/rotate")
+	require.NoError(t, err)
+	crl = getParsedCrlFromBackend(t, b, s, "issuer/int1/crl/der")
+	requireSerialNumberInCRL(t, crl.TBSCertList, issuedSerial)
+}
+
 func requestCrlFromBackend(t *testing.T, s logical.Storage, b *backend) *logical.Response {
 	crlReq := &logical.Request{
 		Operation: logical.ReadOperation,

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -711,6 +711,12 @@ func TestIssuerRevocation(t *testing.T) {
 	require.NoError(t, err)
 	crl = getParsedCrlFromBackend(t, b, s, "issuer/int1/crl/der")
 	requireSerialNumberInCRL(t, crl.TBSCertList, issuedSerial)
+
+	// Ensure we can't fetch the intermediate's cert by serial any more.
+	resp, err = CBRead(b, s, "cert/"+intCertSerial)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.Data["revocation_time"])
 }
 
 func requestCrlFromBackend(t *testing.T, s logical.Storage, b *backend) *logical.Response {

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -364,6 +364,10 @@ func buildCRLs(ctx context.Context, b *backend, req *logical.Request, forceNew b
 		return fmt.Errorf("error building CRLs: unable to get revoked certificate entries: %v", err)
 	}
 
+	if err := augmentWithRevokedIssuers(issuerIDEntryMap, issuerIDCertMap, revokedCertsMap); err != nil {
+		return fmt.Errorf("error building CRLs: unable to parse revoked issuers: %v", err)
+	}
+
 	// Now we can call buildCRL once, on an arbitrary/representative issuer
 	// from each of these (keyID, subject) sets.
 	for _, subjectIssuersMap := range keySubjectIssuersMap {
@@ -568,6 +572,40 @@ func getRevokedCertEntries(ctx context.Context, req *logical.Request, issuerIDCe
 	}
 
 	return unassignedCerts, revokedCertsMap, nil
+}
+
+func augmentWithRevokedIssuers(issuerIDEntryMap map[issuerID]*issuerEntry, issuerIDCertMap map[issuerID]*x509.Certificate, revokedCertsMap map[issuerID][]pkix.RevokedCertificate) error {
+	// When setup our maps with the legacy CA bundle, we only have a
+	// single entry here. This entry is never revoked, so the outer loop
+	// will exit quickly.
+	for ourIssuerID, ourIssuer := range issuerIDEntryMap {
+		if !ourIssuer.Revoked {
+			continue
+		}
+
+		ourCert := issuerIDCertMap[ourIssuerID]
+		ourRevCert := pkix.RevokedCertificate{
+			SerialNumber:   ourCert.SerialNumber,
+			RevocationTime: ourIssuer.RevocationTimeUTC,
+		}
+
+		for otherIssuerID := range issuerIDEntryMap {
+			if otherIssuerID == ourIssuerID {
+				continue
+			}
+
+			// Find all _other_ certificates which verify this issuer,
+			// allowing us to add this revoked issuer to this issuer's
+			// CRL.
+			otherCert := issuerIDCertMap[otherIssuerID]
+			if err := ourCert.CheckSignatureFrom(otherCert); err == nil {
+				// Valid signature; add our result.
+				revokedCertsMap[otherIssuerID] = append(revokedCertsMap[otherIssuerID], ourRevCert)
+			}
+		}
+	}
+
+	return nil
 }
 
 // Builds a CRL by going through the list of revoked certificates and building

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
@@ -211,7 +212,7 @@ func respondReadIssuer(issuer *issuerEntry) (*logical.Response, error) {
 
 	if issuer.Revoked {
 		data["revocation_time"] = issuer.RevocationTime
-		data["revocation_time_utc"] = issuer.RevocationTimeUTC
+		data["revocation_time_rfc3339"] = issuer.RevocationTimeUTC.Format(time.RFC3339Nano)
 	}
 
 	return &logical.Response{

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -524,6 +524,11 @@ func (b *backend) pathRevokeIssuer(ctx context.Context, req *logical.Request, da
 		response.AddWarning("This issuer lacks another parent issuer within the mount. This means it will not appear on any other CRLs and may not be considered revoked by clients. Consider adding this issuer to its issuer's CRL as well if it is not self-signed.")
 	}
 
+	config, err := sc.getIssuersConfig()
+	if err == nil && config != nil && config.DefaultIssuerId == issuer.ID {
+		response.AddWarning("This issuer is currently configured as the default issuer for this mount; operations such as certificate issuance may not work until a new default issuer is selected.")
+	}
+
 	return response, nil
 }
 

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
@@ -146,6 +147,9 @@ type issuerEntry struct {
 	LeafNotAfterBehavior certutil.NotAfterBehavior `json:"not_after_behavior"`
 	Usage                issuerUsage               `json:"usage"`
 	RevocationSigAlg     x509.SignatureAlgorithm   `json:"revocation_signature_algorithm"`
+	Revoked              bool                      `json:"revoked"`
+	RevocationTime       int64                     `json:"revocation_time"`
+	RevocationTimeUTC    time.Time                 `json:"revocation_time_utc"`
 }
 
 type localCRLConfigEntry struct {

--- a/changelog/16621.txt
+++ b/changelog/16621.txt
@@ -1,0 +1,2 @@
+```release-note:improvement
+secrets/pki: Allow revocation of issuers within the same mount.

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -45,6 +45,7 @@ update your API calls accordingly.
   - [Import CA Certificates and Keys](#import-ca-certificates-and-keys)
   - [Read Issuer](#read-issuer)
   - [Update Issuer](#update-issuer)
+  - [Revoke Issuer](#revoke-issuer)
   - [Delete Issuer](#delete-issuer)
   - [Import Key](#import-key)
   - [Read Key](#read-key)
@@ -2028,6 +2029,52 @@ $ curl \
     "leaf_not_after_behavior": "truncate",
     "manual_chain": null,
     "usage": "read-only,issuing-certificates,crl-signing"
+  }
+}
+```
+
+### Revoke Issuer
+
+This endpoint allows an operator to revoke an issuer certificate, marking it
+unable to issue new certificates and adding it to other issuers' CRLs, if they
+have signed this issuer's certificate.
+
+~> **Warning**: This operation cannot be undone!
+
+| Method  | Path                             |
+| :------ | :------------------------------- |
+| `POST`  | `/pki/issuer/:issuer_ref/revoke` |
+
+#### Parameters
+
+No parameters.
+
+#### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    http://127.0.0.1:8200/v1/pki/issuer/old-intermediate/revoke
+```
+
+#### Sample Response
+
+```text
+{
+  "data": {
+    "ca_chain": [
+      "-----BEGIN CERTIFICATE-----\nMIIDFDCCAfygAwIBAgIUXgxy54mKooz5soqQoRINazH/3pQwDQYJKoZIhvcNAQEL\n...",
+      "-----BEGIN CERTIFICATE-----\nMIIDFTCCAf2gAwIBAgIUUo/qwLm5AyqUWqFHw1MlgwUtS/kwDQYJKoZIhvcNAQEL\n..."
+    ],
+    "certificate": "-----BEGIN CERTIFICATE-----\nMIIDFDCCAfygAwIBAgIUXgxy54mKooz5soqQoRINazH/3pQwDQYJKoZIhvcNAQEL\n...",
+    "issuer_id": "7545992c-1910-0898-9e64-d575549fbe9c",
+    "issuer_name": "old-intermediate",
+    "key_id": "baadd98d-ec5a-66ac-06b7-dfc91c02c9cf",
+    "leaf_not_after_behavior": "truncate",
+    "manual_chain": null,
+    "usage": "read-only,issuing-certificates,crl-signing"
+    "revocation_time": 1433269787,
   }
 }
 ```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -2037,7 +2037,7 @@ $ curl \
 
 This endpoint allows an operator to revoke an issuer certificate, marking it
 unable to issue new certificates and adding it to other issuers' CRLs, if they
-have signed this issuer's certificate.
+have signed this issuer's certificate. This will cause all CRLs to be rebuilt.
 
 ~> **Warning**: This operation cannot be undone!
 

--- a/website/content/docs/secrets/pki/considerations.mdx
+++ b/website/content/docs/secrets/pki/considerations.mdx
@@ -445,6 +445,7 @@ For these personas, we suggest the following ACLs, in condensed, tabular form:
 | `/config/keys` | Read, Write | Yes | |  |  |  |
 | `/config/urls` | Read, Write | Yes | |  |  |  |
 | `/issuer/:issuer_ref` | Write | Yes | | | | |
+| `/issuer/:issuer_ref/revoke` | Write | Yes | | | | |
 | `/issuer/:issuer_ref/sign-intermediate` | Write | Yes | | | | |
 | `/issuer/issuer_ref/sign-self-issued` | Write | Yes | | | | |
 | `/issuers/generate/+/+` | Write | Yes | | | | |


### PR DESCRIPTION
This allows PKI's issuers to be considered revoked and appear on each
others' CRLs. We disable issuance (via removing the usage) and prohibit
modifying the usage via the regular issuer management interface.

A separate endpoint is necessary because issuers (especially if signed
by a third-party CA using incremental serial numbers) might share a
serial number (e.g., an intermediate under cross-signing might share the
same number as an external root or an unrelated intermediate).

When the next CRL rebuild happens, this issuer will then appear on
others issuers CRLs, if they validate this issuer's certificate.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

 - [x] Docs
 - [x] Tests
 - [x] Changelog entry