### PR TITLE
identity/oidc: minor fixes to the API documentation

### DIFF
--- a/website/content/api-docs/secret/identity/oidc-provider.mdx
+++ b/website/content/api-docs/secret/identity/oidc-provider.mdx
@@ -283,8 +283,9 @@ This endpoint creates or updates a client.
   [allow_all](/docs/concepts/oidc-provider#assignments) assignment.
 
 - `client_type` `(string: "confidential")` – The [client type](https://datatracker.ietf.org/doc/html/rfc6749#section-2.1)
-  based on its ability to maintain confidentiality of credentials. The following list details
-  the differences between confidential and public clients in Vault:
+  based on its ability to maintain confidentiality of credentials. This cannot be modified
+  after creation. The following list details the differences between confidential and public
+  clients in Vault:
   - `confidential`
     - Capable of maintaining the confidentiality of its credentials
     - Has a client secret
@@ -447,8 +448,8 @@ This endpoint creates or updates an assignment.
 
 ```json
 {
-   "group_ids":["my-group"],
-   "entity_ids":["my-entity"]
+   "group_ids":["262ca5b9-7b69-0a84-446a-303dc7d778af"],
+   "entity_ids":["b6094ac6-baf4-6520-b05a-2bd9f07c66da"]
 }
 ```
 
@@ -488,10 +489,10 @@ $ curl \
 {
   "data":{
       "entity_ids":[
-         "my-entity"
+         "b6094ac6-baf4-6520-b05a-2bd9f07c66da"
       ],
       "group_ids":[
-         "my-group"
+         "262ca5b9-7b69-0a84-446a-303dc7d778af"
       ]
    }
 }


### PR DESCRIPTION
This PR makes minor fixes the OIDC provider API documentation including:
- Stating that the `client_type` cannot be modified after creation
- Using UUIDs in the examples for creating and reading an assignment