### PR TITLE
VAULT-7256: Add custom_metadata to namespaces

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -347,6 +347,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"namespace patch": func() (cli.Command, error) {
+			return &NamespacePatchCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"namespace delete": func() (cli.Command, error) {
 			return &NamespaceDeleteCommand{
 				BaseCommand: getBaseCommand(),

--- a/command/namespace.go
+++ b/command/namespace.go
@@ -36,6 +36,10 @@ Usage: vault namespace <subcommand> [options] [args]
 
       $ vault namespace create
 
+  Patch an existing namespace:
+
+      $ vault namespace patch
+
   Delete an existing namespace:
 
       $ vault namespace delete

--- a/command/namespace_patch.go
+++ b/command/namespace_patch.go
@@ -1,0 +1,137 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/posener/complete"
+
+	"github.com/mitchellh/cli"
+)
+
+var (
+	_ cli.Command             = (*NamespacePatchCommand)(nil)
+	_ cli.CommandAutocomplete = (*NamespacePatchCommand)(nil)
+)
+
+type NamespacePatchCommand struct {
+	*BaseCommand
+
+	flagCustomMetadata       map[string]string
+	flagRemoveCustomMetadata []string
+}
+
+func (c *NamespacePatchCommand) Synopsis() string {
+	return "Patch an existing namespace"
+}
+
+func (c *NamespacePatchCommand) Help() string {
+	helpText := `
+Usage: vault namespace patch [options] PATH
+
+  Patch an existing namespace. The namespace patched will be relative to the
+  namespace provided in either the VAULT_NAMESPACE environment variable or
+  -namespace CLI flag.
+
+  Patch an existing child namespace by adding and removing custom-metadata (e.g. ns1/):
+
+      $ vault namespace patch ns1 -custom-metadata=foo=abc -remove-custom-metadata=bar
+
+  Patch an existing child namespace from a parent namespace (e.g. ns1/ns2/):
+
+      $ vault namespace patch -namespace=ns1 ns2 -custom-metadata=foo=abc
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *NamespacePatchCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat)
+
+	f := set.NewFlagSet("Command Options")
+	f.StringMapVar(&StringMapVar{
+		Name:    "custom-metadata",
+		Target:  &c.flagCustomMetadata,
+		Default: map[string]string{},
+		Usage: "Specifies arbitrary key=value metadata meant to describe a namespace." +
+			"This can be specified multiple times to add multiple pieces of metadata.",
+	})
+
+	f.StringSliceVar(&StringSliceVar{
+		Name:    "remove-custom-metadata",
+		Target:  &c.flagRemoveCustomMetadata,
+		Default: []string{},
+		Usage:   "Key to remove from custom metadata. To specify multiple values, specify this flag multiple times.",
+	})
+
+	return set
+}
+
+func (c *NamespacePatchCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *NamespacePatchCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *NamespacePatchCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	switch {
+	case len(args) < 1:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 1, got %d)", len(args)))
+		return 1
+	case len(args) > 1:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	namespacePath := strings.TrimSpace(args[0])
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	data := make(map[string]interface{})
+	customMetadata := make(map[string]interface{})
+
+	for key, value := range c.flagCustomMetadata {
+		customMetadata[key] = value
+	}
+
+	for _, key := range c.flagRemoveCustomMetadata {
+		// A null in a JSON merge patch payload will remove the associated key
+		customMetadata[key] = nil
+	}
+
+	data["custom_metadata"] = customMetadata
+
+	secret, err := client.Logical().JSONMergePatch(context.Background(), "sys/namespaces/"+namespacePath, data)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error patching namespace: %s", err))
+		return 2
+	}
+
+	if secret == nil || secret.Data == nil {
+		c.UI.Error(fmt.Sprintf("No namespace found: %s", err))
+		return 2
+	}
+
+	// Handle single field output
+	if c.flagField != "" {
+		return PrintRawField(c.UI, secret, c.flagField)
+	}
+
+	return OutputSecret(c.UI, secret)
+}

--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -12,9 +12,9 @@ import (
 type contextValues struct{}
 
 type Namespace struct {
-	ID             string            `json:"id"`
-	Path           string            `json:"path"`
-	CustomMetadata map[string]string `json:"custom_metadata"`
+	ID             string            `json:"id" mapstructure:"id"`
+	Path           string            `json:"path" mapstructure:"path"`
+	CustomMetadata map[string]string `json:"custom_metadata" mapstructure:"custom_metadata"`
 }
 
 func (n *Namespace) String() string {

--- a/sdk/helper/custommetadata/custom_metadata.go
+++ b/sdk/helper/custommetadata/custom_metadata.go
@@ -3,6 +3,8 @@ package custommetadata
 import (
 	"fmt"
 
+	"github.com/mitchellh/mapstructure"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 )
@@ -15,6 +17,31 @@ const (
 	maxValueLength        = 512
 	validationErrorPrefix = "custom_metadata validation failed"
 )
+
+// Parse is used to effectively convert the TypeMap
+// (map[string]interface{}) into a TypeKVPairs (map[string]string)
+// which is how custom_metadata is stored. Defining custom_metadata
+// as a TypeKVPairs will convert nulls into empty strings. A null,
+// however, is essential for a PATCH operation in that it signals
+// the handler to remove the field. The filterNils flag should
+// only be used during a patch operation.
+func Parse(raw map[string]interface{}, filterNils bool) (map[string]string, error) {
+	customMetadata := map[string]string{}
+	for k, v := range raw {
+		if filterNils && v == nil {
+			continue
+		}
+
+		var s string
+		if err := mapstructure.WeakDecode(v, &s); err != nil {
+			return nil, err
+		}
+
+		customMetadata[k] = s
+	}
+
+	return customMetadata, nil
+}
 
 // Validate will perform input validation for custom metadata.
 // CustomMetadata should be arbitrary user-provided key-value pairs meant to


### PR DESCRIPTION
Issue https://github.com/hashicorp/vault/issues/16217 describes the request to enhance namespaces with the addition of `custom_metadata`. This PR introduces the necessary changes to both the API and CLI to allow for both writing and reading custom metadata.

This PR includes the following changes:

- Add `mapstructure` tags to `Namespace` for struct->map decoding
- Add a `Parse` function to custom metadata helper which is largely taken from [parseCustomMetadata](https://github.com/hashicorp/vault-plugin-secrets-kv/blob/main/path_metadata.go#L227) in KVv2.
- Add `-custom-metadata` flag to the `vault namespace create` command
- Add a `vault namespace patch command` which allows users to patch an existing namespace's custom metadata

The changelog entry has been provided in a separate ENT PR. Doc updates can be found in https://github.com/hashicorp/vault/pull/16633.
