### PR TITLE
Revert "fixing a bug for cli when namespace is in both arg and path"

### DIFF
--- a/changelog/12911.txt
+++ b/changelog/12911.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-cli: fixes CLI requests when namespace is both provided as argument and part of the path
-```

--- a/command/kv_helpers.go
+++ b/command/kv_helpers.go
@@ -139,8 +139,8 @@ func addPrefixToKVPath(p, mountPath, apiPrefix string) string {
 		if len(partialMountPath) <= 1 || partialMountPath[1] == "" {
 			break
 		}
-		mountPath = strings.TrimSuffix(partialMountPath[1], "/")
-		tp = strings.TrimPrefix(tp, mountPath)
+		mountPath = partialMountPath[1]
+		tp = strings.TrimPrefix(p, mountPath)
 	}
 
 	return path.Join(mountPath, apiPrefix, tp)


### PR DESCRIPTION
Reverts hashicorp/vault#12911