### PR TITLE
secrets/auth: fix bug with aliased backends

### DIFF
--- a/changelog/16673.txt
+++ b/changelog/16673.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-plugin/secrets/auth: Fix a bug with aliased backends
+plugin/secrets/auth: Fix a bug with aliased backends such as aws-ec2 or generic
 ```

--- a/changelog/16673.txt
+++ b/changelog/16673.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/secrets/auth: Fix a bug with aliased backends
+```

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -911,12 +911,12 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *MountEntry, sysV
 
 	f, ok := c.credentialBackends[t]
 	if !ok {
-		plug, err := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential)
+		plug, err := c.pluginCatalog.Get(ctx, t, consts.PluginTypeCredential)
 		if err != nil {
 			return nil, err
 		}
 		if plug == nil {
-			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, entry.Type)
+			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, t)
 		}
 
 		f = plugin.Factory

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1419,12 +1419,12 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 
 	f, ok := c.logicalBackends[t]
 	if !ok {
-		plug, err := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeSecrets)
+		plug, err := c.pluginCatalog.Get(ctx, t, consts.PluginTypeSecrets)
 		if err != nil {
 			return nil, err
 		}
 		if plug == nil {
-			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, entry.Type)
+			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, t)
 		}
 
 		f = plugin.Factory

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -2167,6 +2167,7 @@ func NewMockBuiltinRegistry() *mockBuiltinRegistry {
 			"mysql-database-plugin":      consts.PluginTypeDatabase,
 			"postgresql-database-plugin": consts.PluginTypeDatabase,
 			"approle":                    consts.PluginTypeCredential,
+			"aws":                        consts.PluginTypeCredential,
 		},
 	}
 }
@@ -2187,6 +2188,15 @@ func (m *mockBuiltinRegistry) Get(name string, pluginType consts.PluginType) (fu
 
 	if name == "approle" {
 		return toFunc(approle.Factory), true
+	}
+
+	if name == "aws" {
+		return toFunc(func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
+			b := new(framework.Backend)
+			b.Setup(ctx, config)
+			b.BackendType = logical.TypeCredential
+			return b, nil
+		}), true
 	}
 
 	if name == "postgresql-database-plugin" {


### PR DESCRIPTION
Ensure we use the alias mappings for secrets engines and auth methods if they exist. This will prevent vault from reporting the plugin does not exist in the catalog.

These alias mappings are evaluated JIT before instantiating the backend as a less invasive solution to support legacy backend types.