### PR TITLE
secrets/db: update documentation on password policies

### DIFF
--- a/website/content/docs/secrets/databases/index.mdx
+++ b/website/content/docs/secrets/databases/index.mdx
@@ -168,15 +168,12 @@ plugins for the credential types they support and usage examples.
 ## Password Generation
 
 Passwords are generated via [Password Policies](/docs/concepts/password-policies).
-Databases can optionally set a password policy for use across all roles for that database.
-In other words, each time you call `vault write database/config/my-database` you can specify
-a password policy for all roles using `my-database`. Each database has a default password
-policy defined as: 20 characters with at least 1 uppercase character, at least 1 lowercase
-character, at least 1 number, and at least 1 dash character.
-
-You cannot specify a password policy on a specific role as the purpose of password policies is
-to adhere to password requirements of systems (such as a database), not making passwords
-for specific users.
+Databases can optionally set a password policy for use across all roles or at the
+individual role level for that database. For example, each time you call
+`vault write database/config/my-database` you can specify a password policy for all
+roles using `my-database`. Each database has a default password policy defined as:
+20 characters with at least 1 uppercase character, at least 1 lowercase character,
+at least 1 number, and at least 1 dash character.
 
 The default password generation can be represented as the following password policy:
 


### PR DESCRIPTION
This PR removes a statement that's no longer true from the password policy section of the database secrets engine documentation. Password policies can be set at the [role level](https://www.vaultproject.io/api-docs/secret/databases#password_policy-1) since Vault 1.11.