### PR TITLE
Env Flag Filtering

### DIFF
--- a/changelog/16683.txt
+++ b/changelog/16683.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-cli: CLI commands will not print a warning if environmental flags are passed after positional arguments.
-```

--- a/changelog/16683.txt
+++ b/changelog/16683.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: CLI commands will not print a warning if environmental flags are passed after positional arguments.
+```

--- a/command/base.go
+++ b/command/base.go
@@ -589,7 +589,7 @@ func (f *FlagSets) Parse(args []string) error {
 	err := f.mainSet.Parse(args)
 
 	warnings := generateFlagWarnings(f.Args())
-	if warnings != "" && Format(f.ui) != "json" {
+	if warnings != "" && Format(f.ui) == "table" {
 		f.ui.Warn(warnings)
 	}
 

--- a/command/base.go
+++ b/command/base.go
@@ -589,7 +589,7 @@ func (f *FlagSets) Parse(args []string) error {
 	err := f.mainSet.Parse(args)
 
 	warnings := generateFlagWarnings(f.Args())
-	if warnings != "" {
+	if warnings != "" && Format(f.ui) != "json" {
 		f.ui.Warn(warnings)
 	}
 

--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -300,14 +300,14 @@ func generateFlagWarnings(args []string) string {
 			continue
 		}
 
-		isEnvFlag := false
+		isGlobalFlag := false
 		trimmedArg, _, _ := strings.Cut(strings.TrimLeft(arg, "-"), "=")
 		for _, flag := range envFlags {
 			if trimmedArg == flag {
-				isEnvFlag = true
+				isGlobalFlag = true
 			}
 		}
-		if isEnvFlag {
+		if isGlobalFlag {
 			continue
 		}
 

--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -302,7 +302,7 @@ func generateFlagWarnings(args []string) string {
 
 		isGlobalFlag := false
 		trimmedArg, _, _ := strings.Cut(strings.TrimLeft(arg, "-"), "=")
-		for _, flag := range envFlags {
+		for _, flag := range globalFlags {
 			if trimmedArg == flag {
 				isGlobalFlag = true
 			}

--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -296,13 +296,26 @@ func parseFlagFile(raw string) (string, error) {
 func generateFlagWarnings(args []string) string {
 	var trailingFlags []string
 	for _, arg := range args {
-		if strings.HasPrefix(arg, "-") {
-			trailingFlags = append(trailingFlags, arg)
+		if !strings.HasPrefix(arg, "-") {
+			continue
 		}
+
+		isEnvFlag := false
+		trimmedArg, _, _ := strings.Cut(strings.TrimLeft(arg, "-"), "=")
+		for _, flag := range envFlags {
+			if trimmedArg == flag {
+				isEnvFlag = true
+			}
+		}
+		if isEnvFlag {
+			continue
+		}
+
+		trailingFlags = append(trailingFlags, arg)
 	}
 
 	if len(trailingFlags) > 0 {
-		return fmt.Sprintf("Flags must be provided before positional arguments. "+
+		return fmt.Sprintf("Command flags must be provided before positional arguments. "+
 			"The following arguments will not be parsed as flags: [%s]", strings.Join(trailingFlags, ","))
 	} else {
 		return ""

--- a/command/base_helpers_test.go
+++ b/command/base_helpers_test.go
@@ -243,20 +243,24 @@ func TestArgWarnings(t *testing.T) {
 			"-a",
 		},
 		{
-			[]string{envFlagDetailed},
+			[]string{globalFlagDetailed},
 			"",
 		},
 		{
-			[]string{"-" + envFlagOutputCurlString + "=true"},
+			[]string{"-" + globalFlagOutputCurlString + "=true"},
 			"",
 		},
 		{
-			[]string{"-x" + envFlagDetailed},
-			"-x" + envFlagDetailed,
+			[]string{"--" + globalFlagFormat + "=false"},
+			"",
 		},
 		{
-			[]string{"--x=" + envFlagDetailed},
-			"--x=" + envFlagDetailed,
+			[]string{"-x" + globalFlagDetailed},
+			"-x" + globalFlagDetailed,
+		},
+		{
+			[]string{"--x=" + globalFlagDetailed},
+			"--x=" + globalFlagDetailed,
 		},
 	}
 

--- a/command/base_helpers_test.go
+++ b/command/base_helpers_test.go
@@ -242,6 +242,22 @@ func TestArgWarnings(t *testing.T) {
 			[]string{"-a", "b"},
 			"-a",
 		},
+		{
+			[]string{envFlagDetailed},
+			"",
+		},
+		{
+			[]string{"-" + envFlagOutputCurlString + "=true"},
+			"",
+		},
+		{
+			[]string{"-x" + envFlagDetailed},
+			"-x" + envFlagDetailed,
+		},
+		{
+			[]string{"--x=" + envFlagDetailed},
+			"--x=" + envFlagDetailed,
+		},
 	}
 
 	for _, tc := range cases {

--- a/command/main.go
+++ b/command/main.go
@@ -25,14 +25,14 @@ type VaultUI struct {
 }
 
 const (
-	envFlagOutputCurlString = "output-curl-string"
-	envFlagOutputPolicy     = "output-policy"
-	envFlagFormat           = "format"
-	envFlagDetailed         = "detailed"
+	globalFlagOutputCurlString = "output-curl-string"
+	globalFlagOutputPolicy     = "output-policy"
+	globalFlagFormat           = "format"
+	globalFlagDetailed         = "detailed"
 )
 
 var envFlags = []string{
-	envFlagOutputCurlString, envFlagOutputPolicy, envFlagFormat, envFlagDetailed,
+	globalFlagOutputCurlString, globalFlagOutputPolicy, globalFlagFormat, globalFlagDetailed,
 }
 
 // setupEnv parses args and may replace them and sets some env vars to known
@@ -58,28 +58,28 @@ func setupEnv(args []string) (retArgs []string, format string, detailed bool, ou
 			break
 		}
 
-		if isEnvFlag(arg, envFlagOutputCurlString) {
+		if isEnvFlag(arg, globalFlagOutputCurlString) {
 			outputCurlString = true
 			continue
 		}
 
-		if isEnvFlag(arg, envFlagOutputPolicy) {
+		if isEnvFlag(arg, globalFlagOutputPolicy) {
 			outputPolicy = true
 			continue
 		}
 
 		// Parse a given flag here, which overrides the env var
-		if isEnvFlagWithValue(arg, envFlagFormat) {
+		if isEnvFlagWithValue(arg, globalFlagFormat) {
 			format = getEnvFlagValue(arg)
 		}
 		// For backwards compat, it could be specified without an equal sign
-		if isEnvFlag(arg, envFlagFormat) {
+		if isEnvFlag(arg, globalFlagFormat) {
 			nextArgFormat = true
 		}
 
 		// Parse a given flag here, which overrides the env var
-		if isEnvFlagWithValue(arg, envFlagDetailed) {
-			detailed, err = strconv.ParseBool(getEnvFlagValue(envFlagDetailed))
+		if isEnvFlagWithValue(arg, globalFlagDetailed) {
+			detailed, err = strconv.ParseBool(getEnvFlagValue(globalFlagDetailed))
 			if err != nil {
 				detailed = false
 			}
@@ -87,7 +87,7 @@ func setupEnv(args []string) (retArgs []string, format string, detailed bool, ou
 		}
 		// For backwards compat, it could be specified without an equal sign to enable
 		// detailed output.
-		if isEnvFlag(arg, envFlagDetailed) {
+		if isEnvFlag(arg, globalFlagDetailed) {
 			detailed = true
 			haveDetailed = true
 		}

--- a/command/main.go
+++ b/command/main.go
@@ -24,6 +24,17 @@ type VaultUI struct {
 	detailed bool
 }
 
+const (
+	envFlagOutputCurlString = "output-curl-string"
+	envFlagOutputPolicy     = "output-policy"
+	envFlagFormat           = "format"
+	envFlagDetailed         = "detailed"
+)
+
+var envFlags = []string{
+	envFlagOutputCurlString, envFlagOutputPolicy, envFlagFormat, envFlagDetailed,
+}
+
 // setupEnv parses args and may replace them and sets some env vars to known
 // values based on format options
 func setupEnv(args []string) (retArgs []string, format string, detailed bool, outputCurlString bool, outputPolicy bool) {
@@ -47,38 +58,28 @@ func setupEnv(args []string) (retArgs []string, format string, detailed bool, ou
 			break
 		}
 
-		if arg == "-output-curl-string" || arg == "--output-curl-string" {
+		if isEnvFlag(arg, envFlagOutputCurlString) {
 			outputCurlString = true
 			continue
 		}
 
-		if arg == "-output-policy" || arg == "--output-policy" {
+		if isEnvFlag(arg, envFlagOutputPolicy) {
 			outputPolicy = true
 			continue
 		}
 
 		// Parse a given flag here, which overrides the env var
-		if strings.HasPrefix(arg, "--format=") {
-			format = strings.TrimPrefix(arg, "--format=")
-		}
-		if strings.HasPrefix(arg, "-format=") {
-			format = strings.TrimPrefix(arg, "-format=")
+		if isEnvFlagWithValue(arg, envFlagFormat) {
+			format = getEnvFlagValue(arg)
 		}
 		// For backwards compat, it could be specified without an equal sign
-		if arg == "-format" || arg == "--format" {
+		if isEnvFlag(arg, envFlagFormat) {
 			nextArgFormat = true
 		}
 
 		// Parse a given flag here, which overrides the env var
-		if strings.HasPrefix(arg, "--detailed=") {
-			detailed, err = strconv.ParseBool(strings.TrimPrefix(arg, "--detailed="))
-			if err != nil {
-				detailed = false
-			}
-			haveDetailed = true
-		}
-		if strings.HasPrefix(arg, "-detailed=") {
-			detailed, err = strconv.ParseBool(strings.TrimPrefix(arg, "-detailed="))
+		if isEnvFlagWithValue(arg, envFlagDetailed) {
+			detailed, err = strconv.ParseBool(getEnvFlagValue(envFlagDetailed))
 			if err != nil {
 				detailed = false
 			}
@@ -86,7 +87,7 @@ func setupEnv(args []string) (retArgs []string, format string, detailed bool, ou
 		}
 		// For backwards compat, it could be specified without an equal sign to enable
 		// detailed output.
-		if arg == "-detailed" || arg == "--detailed" {
+		if isEnvFlag(arg, envFlagDetailed) {
 			detailed = true
 			haveDetailed = true
 		}
@@ -113,6 +114,20 @@ func setupEnv(args []string) (retArgs []string, format string, detailed bool, ou
 	}
 
 	return args, format, detailed, outputCurlString, outputPolicy
+}
+
+func isEnvFlag(arg string, flag string) bool {
+	return arg == "-"+flag || arg == "--"+flag
+}
+
+func isEnvFlagWithValue(arg string, flag string) bool {
+	return strings.HasPrefix(arg, "--"+flag+"=") || strings.HasPrefix(arg, "-"+flag+"=")
+}
+
+func getEnvFlagValue(arg string) string {
+	_, value, _ := strings.Cut(arg, "=")
+
+	return value
 }
 
 type RunOptions struct {

--- a/command/main.go
+++ b/command/main.go
@@ -58,28 +58,28 @@ func setupEnv(args []string) (retArgs []string, format string, detailed bool, ou
 			break
 		}
 
-		if isEnvFlag(arg, globalFlagOutputCurlString) {
+		if isGlobalFlag(arg, globalFlagOutputCurlString) {
 			outputCurlString = true
 			continue
 		}
 
-		if isEnvFlag(arg, globalFlagOutputPolicy) {
+		if isGlobalFlag(arg, globalFlagOutputPolicy) {
 			outputPolicy = true
 			continue
 		}
 
 		// Parse a given flag here, which overrides the env var
-		if isEnvFlagWithValue(arg, globalFlagFormat) {
-			format = getEnvFlagValue(arg)
+		if isGlobalFlagWithValue(arg, globalFlagFormat) {
+			format = getGlobalFlagValue(arg)
 		}
 		// For backwards compat, it could be specified without an equal sign
-		if isEnvFlag(arg, globalFlagFormat) {
+		if isGlobalFlag(arg, globalFlagFormat) {
 			nextArgFormat = true
 		}
 
 		// Parse a given flag here, which overrides the env var
-		if isEnvFlagWithValue(arg, globalFlagDetailed) {
-			detailed, err = strconv.ParseBool(getEnvFlagValue(globalFlagDetailed))
+		if isGlobalFlagWithValue(arg, globalFlagDetailed) {
+			detailed, err = strconv.ParseBool(getGlobalFlagValue(globalFlagDetailed))
 			if err != nil {
 				detailed = false
 			}
@@ -87,7 +87,7 @@ func setupEnv(args []string) (retArgs []string, format string, detailed bool, ou
 		}
 		// For backwards compat, it could be specified without an equal sign to enable
 		// detailed output.
-		if isEnvFlag(arg, globalFlagDetailed) {
+		if isGlobalFlag(arg, globalFlagDetailed) {
 			detailed = true
 			haveDetailed = true
 		}
@@ -116,11 +116,11 @@ func setupEnv(args []string) (retArgs []string, format string, detailed bool, ou
 	return args, format, detailed, outputCurlString, outputPolicy
 }
 
-func isEnvFlag(arg string, flag string) bool {
+func isGlobalFlag(arg string, flag string) bool {
 	return arg == "-"+flag || arg == "--"+flag
 }
 
-func isEnvFlagWithValue(arg string, flag string) bool {
+func isGlobalFlagWithValue(arg string, flag string) bool {
 	return strings.HasPrefix(arg, "--"+flag+"=") || strings.HasPrefix(arg, "-"+flag+"=")
 }
 


### PR DESCRIPTION
### Summary
+ added filtering for env flags when generating command parsing warnings
- removed some duplication and created constants so new flags are properly handled automatically if added to the defined collection

### Problem
Env flags passed at the end of a command generates undesired warnings, e.g.:
```
vault read sys/auth/approle/tune -format=json
Flags must be provided before positional arguments. The following arguments will not be parsed as flags: [-format=json]
(...)
```

### Context
Some flags are not tied to a command but to the general execution environment and are valid when passed at the very end. For example: `format=json`. Warnings introduced during [this pull request](https://github.com/hashicorp/vault/pull/16441) could create false positives when environment flags are used appropriately as it treated any trailing flags as a potential user mistake.

With this fix env flags are acceptable both as flags `options` and `args`
`vault <command> [options] [path] [args]`

### Example
```
$ vault read sys/auth/approle/tune --format=json
{
  "request_id": "33cafd05-197f-3fcb-53ba-bc1bf3689f23",
  "lease_id": "",
  "lease_duration": 0,
  "renewable": false,
  "data": {
    "default_lease_ttl": 2764800,
    "description": "",
    "force_no_cache": false,
    "max_lease_ttl": 2764800,
    "token_type": "default-service"
  },
  "warnings": [
    "Endpoint ignored these unrecognized parameters: [--format]"
  ]
}

$ vault read --format=json sys/auth/approle/tune
{
  "request_id": "2386f2f2-8c5c-915b-ffe3-7df7941cc088",
  "lease_id": "",
  "lease_duration": 0,
  "renewable": false,
  "data": {
    "default_lease_ttl": 2764800,
    "description": "",
    "force_no_cache": false,
    "max_lease_ttl": 2764800,
    "token_type": "default-service"
  },
  "warnings": null
}
```

