### PR TITLE
secret/database: fix bug where too many wal deletes are deferred

### DIFF
--- a/builtin/logical/database/rotation.go
+++ b/builtin/logical/database/rotation.go
@@ -537,7 +537,7 @@ func (b *databaseBackend) initQueue(ctx context.Context, conf *logical.BackendCo
 			}
 
 			walID, err := framework.PutWAL(ctx, conf.StorageView, staticWALKey, &setCredentialsWAL{RoleName: "vault-readonlytest"})
-			if walID != "" {
+			if walID != "" && err == nil {
 				defer framework.DeleteWAL(ctx, conf.StorageView, walID)
 			}
 			switch {

--- a/changelog/16686.txt
+++ b/changelog/16686.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/secrets/database: Fix a bug where the secret engine would queue up a lot of WAL deletes during startup.
+```

--- a/changelog/16686.txt
+++ b/changelog/16686.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-plugin/secrets/database: Fix a bug where the secret engine would queue up a lot of WAL deletes during startup.
+secrets/database: Fix a bug where the secret engine would queue up a lot of WAL deletes during startup.
 ```


### PR DESCRIPTION
This fixes a small bug in the `initQueue` function where a WAL write test is performed prior to starting the database secret engine caused a lot of delete wal calls to be queued. 

When Vault is starting up, it's storage is in read only, so writes will produce an error. The current code checks if a WAL ID is returned after calling `PutWal`, but this function always returns a WAL ID so it defers a delete call. Since an error is also returned, it then loops and tries again. If start up is taking an excessive amount of time, this bug will queue up a delete wal every 10ms until Vault's storage accepts writes. This is amplified if you have many database secret engines.