### PR TITLE
add a note clarifying to leave website event in oss only

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -254,6 +254,8 @@ event "promote-production-packaging" {
   }
 }
 
+# The post-publish-website event should not be merged into the enterprise repo.
+# It is for OSS use only. 
 event "post-publish-website" {
   depends = ["promote-production-packaging"]
   action "post-publish-website" {


### PR DESCRIPTION
Adding a note in `ci.hcl` file to emphasize that the `post-publish-website` event is for OSS use only. It should not be merged into Enterprise repos. 