### PR TITLE
Do not mask RSA verification misuse errors as verification failures

### DIFF
--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -1355,7 +1355,14 @@ func (p *Policy) VerifySignature(context, input []byte, hashAlgorithm HashType, 
 			return false, errutil.InternalError{Err: fmt.Sprintf("unsupported rsa signature algorithm %s", sigAlgorithm)}
 		}
 
-		return err == nil, nil
+		if err != nil {
+			// Don't send back verification errors to caller, only misuse errors.
+			if errors.Is(err, rsa.ErrVerification) {
+				return false, nil
+			}
+			return false, errutil.InternalError{Err: err.Error()}
+		}
+		return true, nil
 
 	default:
 		return false, errutil.InternalError{Err: fmt.Sprintf("unsupported key type %v", p.Type)}


### PR DESCRIPTION
Found by @trishankatdatadog in [PR#16549](https://github.com/hashicorp/vault/pull/16549#discussion_r943618434). We are masking errors coming out of the RSA verification call, as verification errors instead of returning them as usage errors.