### PR TITLE
Fix UI Enterprise test failures on 1.9 specifically

### DIFF
--- a/ui/tests/acceptance/enterprise-control-groups-test.js
+++ b/ui/tests/acceptance/enterprise-control-groups-test.js
@@ -1,4 +1,4 @@
-import { settled, currentURL, currentRouteName, visit } from '@ember/test-helpers';
+import { settled, currentURL, currentRouteName, visit, waitUntil } from '@ember/test-helpers';
 import { module, test, skip } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { create } from 'ember-cli-page-object';
@@ -130,9 +130,8 @@ module('Acceptance | Enterprise | control groups', function(hooks) {
     await settled();
     await visit('/vault/secrets/kv-v2-mount/show/foo');
     await settled();
-    assert.equal(
-      currentRouteName(),
-      'vault.cluster.access.control-group-accessor',
+    assert.ok(
+      await waitUntil(() => currentRouteName() === 'vault.cluster.access.control-group-accessor'),
       'redirects to access control group route'
     );
   });

--- a/ui/tests/acceptance/enterprise-kmip-test.js
+++ b/ui/tests/acceptance/enterprise-kmip-test.js
@@ -1,4 +1,4 @@
-import { currentURL, currentRouteName, settled, fillIn } from '@ember/test-helpers';
+import { currentURL, currentRouteName, settled, fillIn, waitUntil, find } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { create } from 'ember-cli-page-object';
@@ -132,6 +132,7 @@ module('Acceptance | Enterprise | KMIP secrets', function(hooks) {
     await settled();
     await credentialsPage.visitDetail({ backend: path, scope, role, serial });
     await settled();
+    await waitUntil(() => find('[data-test-confirm-action-trigger]'));
     assert.dom('[data-test-confirm-action-trigger]').exists('delete button exists');
     await credentialsPage.delete().confirmDelete();
     await settled();
@@ -241,6 +242,7 @@ module('Acceptance | Enterprise | KMIP secrets', function(hooks) {
     await settled();
     await rolesPage.visitDetail({ backend: path, scope, role });
     await settled();
+    await waitUntil(() => find('[data-test-kmip-link-edit-role]'));
     await rolesPage.detailEditLink();
     await settled();
     assert.equal(


### PR DESCRIPTION
Instead of backporting because some of the fixes already exist already on main, I'm targeting the individual release branches, and making fixes here. There will be two other PRs: one for 1.10 and one for 1.11.

This PR address these failures. 
![image](https://user-images.githubusercontent.com/6618863/184251825-b112e2bc-9354-40aa-bd91-6ed4aceab4cf.png)
