### PR TITLE
Add a sentinel error for missing KV secrets

### DIFF
--- a/api/kv.go
+++ b/api/kv.go
@@ -1,5 +1,11 @@
 package api
 
+import "errors"
+
+// ErrSecretNotFound is returned by KVv1 and KVv2 wrappers to indicate that the
+// secret is missing at the given location.
+var ErrSecretNotFound = errors.New("secret not found")
+
 // A KVSecret is a key-value secret returned by Vault's KV secrets engine,
 // and is the most basic type of secret stored in Vault.
 //

--- a/api/kv_v1.go
+++ b/api/kv_v1.go
@@ -19,7 +19,7 @@ func (kv *KVv1) Get(ctx context.Context, secretPath string) (*KVSecret, error) {
 		return nil, fmt.Errorf("error encountered while reading secret at %s: %w", pathToRead, err)
 	}
 	if secret == nil {
-		return nil, fmt.Errorf("no secret found at %s", pathToRead)
+		return nil, fmt.Errorf("%w: at %s", ErrSecretNotFound, pathToRead)
 	}
 
 	return &KVSecret{
@@ -36,9 +36,12 @@ func (kv *KVv1) Get(ctx context.Context, secretPath string) (*KVSecret, error) {
 func (kv *KVv1) Put(ctx context.Context, secretPath string, data map[string]interface{}) error {
 	pathToWriteTo := fmt.Sprintf("%s/%s", kv.mountPath, secretPath)
 
-	_, err := kv.c.Logical().WriteWithContext(ctx, pathToWriteTo, data)
+	secret, err := kv.c.Logical().WriteWithContext(ctx, pathToWriteTo, data)
 	if err != nil {
 		return fmt.Errorf("error writing secret to %s: %w", pathToWriteTo, err)
+	}
+	if secret == nil {
+		return fmt.Errorf("%w: after writing to %s", ErrSecretNotFound, pathToWriteTo)
 	}
 
 	return nil

--- a/api/kv_v1.go
+++ b/api/kv_v1.go
@@ -36,12 +36,9 @@ func (kv *KVv1) Get(ctx context.Context, secretPath string) (*KVSecret, error) {
 func (kv *KVv1) Put(ctx context.Context, secretPath string, data map[string]interface{}) error {
 	pathToWriteTo := fmt.Sprintf("%s/%s", kv.mountPath, secretPath)
 
-	secret, err := kv.c.Logical().WriteWithContext(ctx, pathToWriteTo, data)
+	_, err := kv.c.Logical().WriteWithContext(ctx, pathToWriteTo, data)
 	if err != nil {
 		return fmt.Errorf("error writing secret to %s: %w", pathToWriteTo, err)
-	}
-	if secret == nil {
-		return fmt.Errorf("%w: after writing to %s", ErrSecretNotFound, pathToWriteTo)
 	}
 
 	return nil

--- a/api/kv_v2.go
+++ b/api/kv_v2.go
@@ -690,6 +690,7 @@ func mergePatch(ctx context.Context, client *Client, mountPath string, secretPat
 	secret, err := client.Logical().JSONMergePatch(ctx, pathToMergePatch, wrappedData)
 	if err != nil {
 		var re *ResponseError
+
 		if errors.As(err, &re) {
 			switch re.StatusCode {
 			// 403
@@ -710,9 +711,6 @@ func mergePatch(ctx context.Context, client *Client, mountPath string, secretPat
 		}
 
 		return nil, fmt.Errorf("error performing merge patch to %s: %w", pathToMergePatch, err)
-	}
-	if secret == nil {
-		return nil, fmt.Errorf("%w: performing merge patch to %s", ErrSecretNotFound, pathToMergePatch)
 	}
 
 	metadata, err := extractVersionMetadata(secret)

--- a/api/kv_v2.go
+++ b/api/kv_v2.go
@@ -149,7 +149,7 @@ func (kv *KVv2) GetVersion(ctx context.Context, secretPath string, version int) 
 		return nil, err
 	}
 	if secret == nil {
-		return nil, fmt.Errorf("%w: for version %d at %s", err, version, pathToRead)
+		return nil, fmt.Errorf("%w: for version %d at %s", ErrSecretNotFound, version, pathToRead)
 	}
 
 	kvSecret, err := extractDataAndVersionMetadata(secret)

--- a/changelog/16699.txt
+++ b/changelog/16699.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Add a sentinel error for missing KV secrets
+```

--- a/changelog/16699.txt
+++ b/changelog/16699.txt
@@ -1,3 +1,3 @@
-```release-note:bug
+```release-note:improvement
 api: Add a sentinel error for missing KV secrets
 ```

--- a/vault/external_tests/api/kv_helpers_test.go
+++ b/vault/external_tests/api/kv_helpers_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -80,7 +81,7 @@ func TestKVHelpers(t *testing.T) {
 	}
 
 	//// v1 ////
-	t.Run("kv v1 helpers", func(t *testing.T) {
+	t.Run("kv v1: put, get, and delete data", func(t *testing.T) {
 		if err := client.KVv1(v1MountPath).Put(context.Background(), secretPath, secretData); err != nil {
 			t.Fatal(err)
 		}
@@ -97,10 +98,25 @@ func TestKVHelpers(t *testing.T) {
 		if err := client.KVv1(v1MountPath).Delete(context.Background(), secretPath); err != nil {
 			t.Fatal(err)
 		}
+
+		_, err = client.KVv1(v1MountPath).Get(context.Background(), secretPath)
+		if !errors.Is(err, api.ErrSecretNotFound) {
+			t.Fatalf("KVv1.Get is expected to return an api.ErrSecretNotFound wrapped error after secret had been deleted; got %v", err)
+		}
+	})
+
+	t.Run("kv v1: get secret that does not exist", func(t *testing.T) {
+		_, err = client.KVv1(v1MountPath).Get(context.Background(), "does/not/exist")
+		if err == nil {
+			t.Fatalf("KVv1.Get is expected to return an error for a missing secret")
+		}
+		if !errors.Is(err, api.ErrSecretNotFound) {
+			t.Fatalf("KVv1.Get is expected to return an api.ErrSecretNotFound wrapped error for a missing secret; got %v", err)
+		}
 	})
 
 	//// v2 ////
-	t.Run("get data and full metadata", func(t *testing.T) {
+	t.Run("kv v2: get data and full metadata", func(t *testing.T) {
 		teardownTest, originalSecret := setupKVv2Test(t)
 		defer teardownTest(t)
 
@@ -125,7 +141,17 @@ func TestKVHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("multiple versions", func(t *testing.T) {
+	t.Run("kv v2: get secret that does not exist", func(t *testing.T) {
+		_, err = client.KVv2(v1MountPath).Get(context.Background(), "does/not/exist")
+		if err == nil {
+			t.Fatalf("KVv2.Get is expected to return an error for a missing secret")
+		}
+		if !errors.Is(err, api.ErrSecretNotFound) {
+			t.Fatalf("KVv2.Get is expected to return an api.ErrSecretNotFound wrapped error for a missing secret; got %v", err)
+		}
+	})
+
+	t.Run("kv v2: multiple versions", func(t *testing.T) {
 		teardownTest, _ := setupKVv2Test(t)
 		defer teardownTest(t)
 
@@ -149,7 +175,7 @@ func TestKVHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("delete and undelete", func(t *testing.T) {
+	t.Run("kv v2: delete and undelete", func(t *testing.T) {
 		teardownTest, _ := setupKVv2Test(t)
 		defer teardownTest(t)
 
@@ -193,9 +219,18 @@ func TestKVHelpers(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		s1AfterUndelete, err := client.KVv2(v2MountPath).GetVersion(context.Background(), secretPath, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if s1AfterUndelete.Data == nil {
+			t.Fatalf("data is empty for the first version of the secret despite this version being undeleted")
+		}
 	})
 
-	t.Run("destroy", func(t *testing.T) {
+	t.Run("kv v2: destroy", func(t *testing.T) {
 		teardownTest, _ := setupKVv2Test(t)
 		defer teardownTest(t)
 
@@ -214,7 +249,7 @@ func TestKVHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("use named functional options and generic WithOption", func(t *testing.T) {
+	t.Run("kv v2: use named functional options and generic WithOption", func(t *testing.T) {
 		teardownTest, _ := setupKVv2Test(t)
 		defer teardownTest(t)
 
@@ -238,7 +273,7 @@ func TestKVHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("patch", func(t *testing.T) {
+	t.Run("kv v2: patch", func(t *testing.T) {
 		teardownTest, _ := setupKVv2Test(t)
 		defer teardownTest(t)
 
@@ -273,14 +308,6 @@ func TestKVHelpers(t *testing.T) {
 		}
 		if patchRW.VersionMetadata.Version != 4 {
 			t.Fatalf("incorrect version %d, expected 4", patchRW.VersionMetadata.Version)
-		}
-
-		// patch something that doesn't exist
-		_, err = client.KVv2(v2MountPath).Patch(context.Background(), "nonexistent-secret", map[string]interface{}{
-			"no": "nope",
-		})
-		if err == nil {
-			t.Fatal("expected error from trying to patch something that doesn't exist")
 		}
 
 		secretAfterPatches, err := client.KVv2(v2MountPath).Get(context.Background(), secretPath)
@@ -353,7 +380,25 @@ func TestKVHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("roll back to an old version", func(t *testing.T) {
+	t.Run("kv v2: patch a secret that does not exist", func(t *testing.T) {
+		for _, method := range [][]api.KVOption{
+			{},
+			{api.WithMergeMethod(api.KVMergeMethodPatch)},
+			{api.WithMergeMethod(api.KVMergeMethodReadWrite)},
+		} {
+			_, err = client.KVv2(v2MountPath).Patch(
+				context.Background(),
+				"does/not/exist",
+				map[string]interface{}{"no": "nope"},
+				method...,
+			)
+			if !errors.Is(err, api.ErrSecretNotFound) {
+				t.Fatalf("expected an api.ErrSecretNotFound wrapped error from trying to patch something that doesn't exist for %v method; got: %v", method, err)
+			}
+		}
+	})
+
+	t.Run("kv v2: roll back to an old version", func(t *testing.T) {
 		teardownTest, _ := setupKVv2Test(t)
 		defer teardownTest(t)
 
@@ -402,7 +447,7 @@ func TestKVHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("delete all versions of a secret", func(t *testing.T) {
+	t.Run("kv v2: delete all versions of a secret", func(t *testing.T) {
 		teardownTest, _ := setupKVv2Test(t)
 		defer teardownTest(t)
 
@@ -429,7 +474,7 @@ func TestKVHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("create a secret with metadata but no data", func(t *testing.T) {
+	t.Run("kv v2: create a secret with metadata but no data", func(t *testing.T) {
 		// put and patch metadata
 		////
 		noDataSecretPath := "empty"
@@ -457,7 +502,7 @@ func TestKVHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("put and patch metadata", func(t *testing.T) {
+	t.Run("kv v2: put and patch metadata", func(t *testing.T) {
 		teardownTest, _ := setupKVv2Test(t)
 		defer teardownTest(t)
 
@@ -529,7 +574,7 @@ func TestKVHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("patch with explicit zero values", func(t *testing.T) {
+	t.Run("kv v2: patch with explicit zero values", func(t *testing.T) {
 		teardownTest, _ := setupKVv2Test(t)
 		defer teardownTest(t)
 

--- a/vault/external_tests/api/kv_helpers_test.go
+++ b/vault/external_tests/api/kv_helpers_test.go
@@ -142,12 +142,22 @@ func TestKVHelpers(t *testing.T) {
 	})
 
 	t.Run("kv v2: get secret that does not exist", func(t *testing.T) {
+		teardownTest, _ := setupKVv2Test(t)
+		defer teardownTest(t)
+
 		_, err = client.KVv2(v1MountPath).Get(context.Background(), "does/not/exist")
-		if err == nil {
-			t.Fatalf("KVv2.Get is expected to return an error for a missing secret")
-		}
 		if !errors.Is(err, api.ErrSecretNotFound) {
 			t.Fatalf("KVv2.Get is expected to return an api.ErrSecretNotFound wrapped error for a missing secret; got %v", err)
+		}
+
+		_, err = client.KVv2(v1MountPath).GetMetadata(context.Background(), "does/not/exist")
+		if !errors.Is(err, api.ErrSecretNotFound) {
+			t.Fatalf("KVv2.GetMetadata is expected to return an api.ErrSecretNotFound wrapped error for a missing secret; got %v", err)
+		}
+
+		_, err = client.KVv2(v1MountPath).GetVersion(context.Background(), secretPath, 99)
+		if !errors.Is(err, api.ErrSecretNotFound) {
+			t.Fatalf("KVv2.GetVersion is expected to return an api.ErrSecretNotFound wrapped error for a missing secret version; got %v", err)
 		}
 	})
 


### PR DESCRIPTION
Adding a sentinel error value `ErrSecretNotFound`. With this change, callers can check specifically for non-existing secrets:

```go
secret, err := client.KvV2("secret").Get("foo")

if errors.Is(err, vault.ErrSecretNotFound) {
    // handle missing secret
}
if err != nil {
    // handle other errors
}
```

An example where this would be useful is when implementing an "upsert" behavior, as suggested in #16483. The caller can check the error returned from `KVv2.Patch` for `errors.Is(err, vault.ErrSecretNotFound)` and call `KvV2.Put` accordingly.