### PR TITLE
Add upnattribute config option to LDAP

### DIFF
--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -1223,6 +1223,7 @@ func TestLdapAuthBackend_ConfigUpgrade(t *testing.T) {
 			GroupAttr:                cfg.GroupAttr,
 			BindDN:                   cfg.BindDN,
 			BindPassword:             cfg.BindPassword,
+			UPNAttribute:             defParams.UPNAttribute,
 			GroupFilter:              defParams.GroupFilter,
 			DenyNullBind:             defParams.DenyNullBind,
 			TLSMinVersion:            defParams.TLSMinVersion,

--- a/changelog/16713.txt
+++ b/changelog/16713.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+sdk/helper/ldaputil: Add configuration option for UPN attribute
+```

--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -206,7 +206,7 @@ func (c *Client) RenderUserSearchFilter(cfg *ConfigEntry, username string) (stri
 		ldap.EscapeFilter(username),
 	}
 	if cfg.UPNDomain != "" {
-		context.UserAttr = "userPrincipalName"
+		context.UserAttr = cfg.UPNAttribute
 		context.Username = fmt.Sprintf("%s@%s", EscapeLDAPValue(username), cfg.UPNDomain)
 	}
 
@@ -270,7 +270,7 @@ func (c *Client) GetUserDN(cfg *ConfigEntry, conn Connection, bindDN, username s
 	userDN := ""
 	if cfg.UPNDomain != "" {
 		// Find the distinguished name for the user if userPrincipalName used for login
-		filter := fmt.Sprintf("(userPrincipalName=%s@%s)", EscapeLDAPValue(username), cfg.UPNDomain)
+		filter := fmt.Sprintf("(%s=%s@%s)", cfg.UPNAttribute, EscapeLDAPValue(username), cfg.UPNDomain)
 		if c.Logger.IsDebug() {
 			c.Logger.Debug("searching upn", "userdn", cfg.UserDN, "filter", filter)
 		}

--- a/sdk/helper/ldaputil/config.go
+++ b/sdk/helper/ldaputil/config.go
@@ -112,6 +112,16 @@ Default: ({{.UserAttr}}={{.Username}})`,
 			},
 		},
 
+		"upnattribute": {
+			Type:        framework.TypeString,
+			Description: "Sets the name of the UPN attribute (default: userPrincipalName)",
+			Default:     "userPrincipalName",
+			DisplayAttrs: &framework.DisplayAttributes{
+				Name:  "User Principal (UPN) Domain Attribute",
+				Value: "userPrincipalName",
+			},
+		},
+
 		"username_as_alias": {
 			Type:        framework.TypeBool,
 			Default:     false,
@@ -302,6 +312,10 @@ func NewConfigEntry(existing *ConfigEntry, d *framework.FieldData) (*ConfigEntry
 		cfg.UPNDomain = d.Get("upndomain").(string)
 	}
 
+	if _, ok := d.Raw["upnattribute"]; ok || !hadExisting {
+		cfg.UPNAttribute = d.Get("upnattribute").(string)
+	}
+
 	if _, ok := d.Raw["certificate"]; ok || !hadExisting {
 		certificate := d.Get("certificate").(string)
 		if certificate != "" {
@@ -403,6 +417,7 @@ type ConfigEntry struct {
 	GroupFilter              string `json:"groupfilter"`
 	GroupAttr                string `json:"groupattr"`
 	UPNDomain                string `json:"upndomain"`
+	UPNAttribute             string `json:"upnattribute"`
 	UsernameAsAlias          bool   `json:"username_as_alias"`
 	UserFilter               string `json:"userfilter"`
 	UserAttr                 string `json:"userattr"`
@@ -443,6 +458,7 @@ func (c *ConfigEntry) PasswordlessMap() map[string]interface{} {
 		"groupattr":              c.GroupAttr,
 		"userfilter":             c.UserFilter,
 		"upndomain":              c.UPNDomain,
+		"upnattribute":           c.UPNAttribute,
 		"userattr":               c.UserAttr,
 		"certificate":            c.Certificate,
 		"insecure_tls":           c.InsecureTLS,

--- a/sdk/helper/ldaputil/config_test.go
+++ b/sdk/helper/ldaputil/config_test.go
@@ -151,6 +151,7 @@ var jsonConfigDefault = []byte(`
   "groupfilter": "(|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}}))",
   "groupattr": "cn",
   "upndomain": "",
+  "upnattribute": "userPrincipalName",
   "userattr": "cn",
   "userfilter": "({{.UserAttr}}={{.Username}})",
   "certificate": "",

--- a/website/content/docs/auth/ldap.mdx
+++ b/website/content/docs/auth/ldap.mdx
@@ -133,9 +133,10 @@ There are two alternate methods of resolving the user object used to authenticat
 
 @include 'ldap-auth-userfilter-warning.mdx'
 
-#### Binding - User Principal Name (AD)
+#### Binding - User Principal Name
 
 - `upndomain` (string, optional) - userPrincipalDomain used to construct the UPN string for the authenticating user. The constructed UPN will appear as `[username]@UPNDomain`. Example: `example.com`, which will cause vault to bind as `username@example.com`.
+- `upnattribute` (string, optional) - attribute to check the UPN against. The default is `userPrincipalName`.
 
 ### Group Membership Resolution
 


### PR DESCRIPTION
This PR closes #16712.

Based on that issue, while the LDAP backend supports looking up the UPN, it assumes that the attribute the UPN is stored in is called userPrincipalName - however, that is only guaranteed to be the case if the LDAP happens to be Microsoft Active Directory. Given that LDAP schemas are not that well standardized across vendors, I believe this should be configurable, just like e.g. groupattr. This PR does just that, it adds a new config option `upnattribute` and defaults it to the old value.