### PR TITLE
Remove extra empty lines from vault.log - Debug command 

### DIFF
--- a/changelog/16714.txt
+++ b/changelog/16714.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+debug: Remove extra empty lines from vault.log when debug command is run
+```

--- a/command/debug.go
+++ b/command/debug.go
@@ -1080,7 +1080,7 @@ func (c *DebugCommand) writeLogs(ctx context.Context) {
 	for {
 		select {
 		case log := <-logCh:
-			if len(log) >0 {
+			if len(log) > 0 {
 				if !strings.HasSuffix(log, "\n") {
 					log += "\n"
 				}

--- a/command/debug.go
+++ b/command/debug.go
@@ -1080,13 +1080,15 @@ func (c *DebugCommand) writeLogs(ctx context.Context) {
 	for {
 		select {
 		case log := <-logCh:
-			if !strings.HasSuffix(log, "\n") {
-				log += "\n"
-			}
-			_, err = out.WriteString(log)
-			if err != nil {
-				c.captureError("log", err)
-				return
+			if len(log) >0 {
+				if !strings.HasSuffix(log, "\n") {
+					log += "\n"
+				}
+				_, err = out.WriteString(log)
+				if err != nil {
+					c.captureError("log", err)
+					return
+				}
 			}
 		case <-ctx.Done():
 			return

--- a/website/content/api-docs/system/monitor.mdx
+++ b/website/content/api-docs/system/monitor.mdx
@@ -26,7 +26,7 @@ default, this is text.
 - `log_level` `(string: "info")` – Specifies the log level to use when streaming logs. This defaults to `info`
   if not specified.
 
-- `log_format` `(string: "standard")` – Specifies the log format to emit when streaming logs. Supported values are "standard" and "json". The default is `standard`.
+- `log_format` `(string: "standard")` – Specifies the log format to emit when streaming logs. Supported values are "standard" and "json". The default is `standard`,
 if not specified.
 
 ### Sample Request


### PR DESCRIPTION
https://github.com/hashicorp/vault/issues/16228

When running vault debug command, then either observe the vault.log while the command is running or examine the vault.log in the archive, there are several empty lines added. 