### PR TITLE
Ignore EC PARAMETER blocks during issuer import

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -4893,6 +4893,35 @@ func TestSealWrappedStorageConfigured(t *testing.T) {
 	require.Contains(t, wrappedEntries, "config/key/", "key prefix with trailing / missing from seal wrap.")
 }
 
+func TestBackend_ConfigCA_WithECParams(t *testing.T) {
+	t.Parallel()
+	b, s := createBackendWithStorage(t)
+
+	// Generated key with OpenSSL:
+	// $ openssl ecparam -out p256.key -name prime256v1 -genkey
+	//
+	// Regression test for https://github.com/hashicorp/vault/issues/16667
+	resp, err := CBWrite(b, s, "config/ca", map[string]interface{}{
+		"pem_bundle": `
+-----BEGIN EC PARAMETERS-----
+BggqhkjOPQMBBw==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEINzXthCZdhyV7+wIEBl/ty+ctNsUS99ykTeax6EbYZtvoAoGCCqGSM49
+AwEHoUQDQgAE57NX8bR/nDoW8yRgLswoXBQcjHrdyfuHS0gPwki6BNnfunUzryVb
+8f22/JWj6fsEF6AOADZlrswKIbR2Es9e/w==
+-----END EC PRIVATE KEY-----
+		`,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp, "expected ca info")
+	importedKeys := resp.Data["imported_keys"].([]string)
+	importedIssuers := resp.Data["imported_issuers"].([]string)
+
+	require.Equal(t, len(importedKeys), 1)
+	require.Equal(t, len(importedIssuers), 0)
+}
+
 var (
 	initTest  sync.Once
 	rsaCAKey  string

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -192,6 +192,12 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 			issuers = append(issuers, pemBlockString)
 		case "CRL", "X509 CRL":
 			// Ignore any CRL entries.
+		case "EC PARAMS", "EC PARAMETERS":
+			// Ignore any EC parameter entries. This is an optional block
+			// that some implementations send, to ensure some semblance of
+			// compatibility with weird curves. Go doesn't support custom
+			// curves and 99% of software doesn't either, so discard them
+			// without parsing them.
 		default:
 			// Otherwise, treat them as keys.
 			keys = append(keys, pemBlockString)

--- a/changelog/16721.txt
+++ b/changelog/16721.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Ignore EC PARAMETER PEM blocks during issuer import (/config/ca, /issuers/import/*, and /intermediate/set-signed)
+```


### PR DESCRIPTION
While older versions of Vault supported sending this, we broke such
support in 1.11. Ignore them from the manage issuers endpoint (which is
aliased to the old `/config/ca` path) -- but keep erring in the import
keys paths. The latter is a new endpoint not aliased to anything and
only expects a single PEM block.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

Resolves: #16667