### PR TITLE
Fix a typo -> 'authorised' should be 'authorized'

### DIFF
--- a/website/content/docs/auth/cert.mdx
+++ b/website/content/docs/auth/cert.mdx
@@ -27,7 +27,7 @@ configuration. This is because the certificates are sent through TLS communicati
 
 Since Vault 0.4, the method supports revocation checking.
 
-An authorised user can submit PEM-formatted CRLs identified by a given name;
+An authorized user can submit PEM-formatted CRLs identified by a given name;
 these can be updated or deleted at will. (Note: Vault **does not** fetch CRLs;
 the CRLs themselves and any updates must be pushed into Vault when desired,
 such as via a `cron` job that fetches them from the source and pushes them into


### PR DESCRIPTION
[Old PR](https://github.com/hashicorp/vault/pull/10389) created in 2020 fixes this typo in a different directory structure. 

The typo still exists, so this PR fixes that. 

🔍 [Deploy Preview](https://vault-git-docs-fix-auth-cert-typo-hashicorp.vercel.app/docs/auth/cert#revocation-checking)