### PR TITLE
Fix naming of permitted_dns_domains in webui

### DIFF
--- a/changelog/16739.txt
+++ b/changelog/16739.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix naming of permitted_dns_domains form parameter on CA creation (root generation and sign intermediate).
+```

--- a/ui/app/models/pki-ca-certificate-sign.js
+++ b/ui/app/models/pki-ca-certificate-sign.js
@@ -14,7 +14,7 @@ export default Certificate.extend({
   maxPathLength: attr('number', {
     defaultValue: -1,
   }),
-  permittedDnsNames: attr('string', {
+  permittedDnsDomains: attr('string', {
     label: 'Permitted DNS domains',
   }),
   ou: attr({
@@ -51,7 +51,7 @@ export default Certificate.extend({
           'ttl',
           'excludeCnFromSans',
           'maxPathLength',
-          'permittedDnsNames',
+          'permittedDnsDomains',
           'ou',
           'organization',
           'otherSans',

--- a/ui/app/models/pki-ca-certificate.js
+++ b/ui/app/models/pki-ca-certificate.js
@@ -63,7 +63,7 @@ export default Certificate.extend({
     label: 'PEM bundle',
     editType: 'file',
   }),
-  permittedDnsNames: attr('string', {
+  permittedDnsDomains: attr('string', {
     label: 'Permitted DNS domains',
   }),
   privateKeyFormat: attr('string', {
@@ -117,7 +117,7 @@ export default Certificate.extend({
             'keyType',
             'keyBits',
             'maxPathLength',
-            'permittedDnsNames',
+            'permittedDnsDomains',
             'excludeCnFromSans',
             'ou',
             'organization',


### PR DESCRIPTION
PKI has consistently used `permitted_dns_domains` since it was originally
[introduced as a parameter](https://github.com/hashicorp/vault/commit/e6b43f7278d2c7e710b727b2e903c2fef1458d46). However, it appears the Web UI was updated to
[add this field (n.b.: prior to the move to OSS)](https://github.com/hashicorp/vault/blob/2c2f0d853f0342509037b4573c28d9be409db2fb//ui/app/models/pki-ca-certificate.js#L58), but used an incorrect internal identifier
(`permittedDnsNames` rather than `permittedDnsDomains`).

This triggers a warning from the backend about an unknown parameter, and
the domain restriction isn't added:

> ```
> Endpoint ignored these unrecognized parameters: [permitted_dns_names]
> ```

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

I think with the changes to the UI files, this'll apply cleanly on 1.11, but not sure the backport to 1.10.x will work. :-) I'll let you do that @hellobontempo if that's desired.


Before:

![image](https://user-images.githubusercontent.com/914030/184925185-f4ff80f7-c5a1-4480-8be5-3d5eb858f18f.png)

![image](https://user-images.githubusercontent.com/914030/184925342-4282ea7f-92e0-4fd8-8d34-1e2b77e1660e.png)

![image](https://user-images.githubusercontent.com/914030/184925389-bbca7378-4c7b-4238-b0ba-32e2a6607970.png)


After:

![image](https://user-images.githubusercontent.com/914030/184925530-e6c5a5d7-540f-45d6-b243-6b50b9037096.png)

![image](https://user-images.githubusercontent.com/914030/184925659-4a646d92-9cb6-444d-a29a-fdaaffbee47d.png)

![image](https://user-images.githubusercontent.com/914030/184925703-0a02a757-4a6d-4480-b2ee-3fcaea113171.png)
