### PR TITLE
Mount paths case-sensitivity

### DIFF
--- a/website/content/docs/commands/secrets/enable.mdx
+++ b/website/content/docs/commands/secrets/enable.mdx
@@ -90,6 +90,10 @@ flags](/docs/commands) included on all commands.
 - `-path` `(string: "")` Place where the secrets engine will be accessible. This
   must be unique cross all secrets engines. This defaults to the "type" of the
   secrets engine.
+  
+  !> **Case-sensitive:** The path you enable secrets engines is case-sensitive. For
+  example, the KV secrets engine enabled at `kv/` and `KV/` are treated as two
+  distinct instances of KV secrets engine.
 
 - `-passthrough-request-headers` `(string: "")` - request header values that will
   be sent to the secrets engine. Note that multiple keys may be

--- a/website/content/docs/commands/secrets/enable.mdx
+++ b/website/content/docs/commands/secrets/enable.mdx
@@ -91,7 +91,7 @@ flags](/docs/commands) included on all commands.
   must be unique cross all secrets engines. This defaults to the "type" of the
   secrets engine.
   
-  !> **Case-sensitive:** The path you enable secrets engines is case-sensitive. For
+  !> **Case-sensitive:** The path where you enable secrets engines is case-sensitive. For
   example, the KV secrets engine enabled at `kv/` and `KV/` are treated as two
   distinct instances of KV secrets engine.
 

--- a/website/content/docs/secrets/index.mdx
+++ b/website/content/docs/secrets/index.mdx
@@ -43,7 +43,7 @@ API.
 
 - [Move](/docs/commands/secrets/move) - This moves the path for an existing
   secrets engine. This process revokes all secrets, since secret leases are tied
-  to the path they were created at. The configuration data stored for the engine
+  to the path where they were created. The configuration data stored for the engine
   persists through the move.
 
 - [Tune](/docs/commands/secrets/tune) - This tunes global configuration for

--- a/website/content/docs/secrets/index.mdx
+++ b/website/content/docs/secrets/index.mdx
@@ -28,7 +28,7 @@ Most secrets engines can be enabled, disabled, tuned, and moved via the CLI or
 API. 
 
 - [Enable](/docs/commands/secrets/enable) - This enables a secrets engine at
-  a given path. With few exceptions, secrets engines can be enabled at multiple
+  a given path. With a few exceptions, secrets engines can be enabled at multiple
   paths. Each secrets engine is isolated to its path. By default, they are
   enabled at their "type" (e.g. "aws" enables at `aws/`).
 

--- a/website/content/docs/secrets/index.mdx
+++ b/website/content/docs/secrets/index.mdx
@@ -16,34 +16,38 @@ Redis/Memcached. Other secrets engines connect to other services and generate
 dynamic credentials on demand. Other secrets engines provide encryption as a
 service, totp generation, certificates, and much more.
 
-Secrets engines are enabled at a "path" in Vault. When a request comes to Vault,
-the router automatically routes anything with the route prefix to the secrets
-engine. In this way, each secrets engine defines its own paths and properties.
-To the user, secrets engines behave similar to a virtual filesystem, supporting
-operations like read, write, and delete.
+Secrets engines are enabled at a **path** in Vault. When a request comes to
+Vault, the router automatically routes anything with the route prefix to the
+secrets engine. In this way, each secrets engine defines its own paths and
+properties. To the user, secrets engines behave similar to a virtual filesystem,
+supporting operations like read, write, and delete.
 
 ## Secrets Engines Lifecycle
 
 Most secrets engines can be enabled, disabled, tuned, and moved via the CLI or
-API. Previous versions of Vault called these "mounts", but that term was
-overloaded.
+API. 
 
-- **Enable** - This enables a secrets engine at a given path. With few
-  exceptions, secrets engines can be enabled at multiple paths. Each secrets
-  engine is isolated to its path. By default, they are enabled at their "type"
-  (e.g. "aws" enables at "aws/").
+- [Enable](/docs/commands/secrets/enable) - This enables a secrets engine at
+  a given path. With few exceptions, secrets engines can be enabled at multiple
+  paths. Each secrets engine is isolated to its path. By default, they are
+  enabled at their "type" (e.g. "aws" enables at `aws/`).
 
-- **Disable** - This disables an existing secrets engine. When a secrets engine
-  is disabled, all of its secrets are revoked (if they support it), and all of
-  the data stored for that engine in the physical storage layer is deleted.
+  !> **Case-sensitive:** The path you enable secrets engines is case-sensitive. For
+  example, the KV secrets engine enabled at `kv/` and `KV/` are treated as two
+  distinct instances of KV secrets engine.
 
-- **Move** - This moves the path for an existing secrets engine. This process
-  revokes all secrets, since secret leases are tied to the path they were
-  created at. The configuration data stored for the engine persists through the
-  move.
+- [Disable](/docs/commands/secrets/disable) - This disables an existing
+  secrets engine. When a secrets engine is disabled, all of its secrets are
+  revoked (if they support it), and all of the data stored for that engine in
+  the physical storage layer is deleted.
 
-- **Tune** - This tunes global configuration for the secrets engine such as the
-  TTLs.
+- [Move](/docs/commands/secrets/move) - This moves the path for an existing
+  secrets engine. This process revokes all secrets, since secret leases are tied
+  to the path they were created at. The configuration data stored for the engine
+  persists through the move.
+
+- [Tune](/docs/commands/secrets/tune) - This tunes global configuration for
+  the secrets engine such as the TTLs.
 
 Once a secrets engine is enabled, you can interact with it directly at its path
 according to its own API. Use `vault path-help` to determine the paths it

--- a/website/content/docs/secrets/index.mdx
+++ b/website/content/docs/secrets/index.mdx
@@ -38,7 +38,7 @@ API.
 
 - [Disable](/docs/commands/secrets/disable) - This disables an existing
   secrets engine. When a secrets engine is disabled, all of its secrets are
-  revoked (if they support it), and all of the data stored for that engine in
+  revoked (if they support it), and all the data stored for that engine in
   the physical storage layer is deleted.
 
 - [Move](/docs/commands/secrets/move) - This moves the path for an existing

--- a/website/content/docs/secrets/index.mdx
+++ b/website/content/docs/secrets/index.mdx
@@ -32,7 +32,7 @@ API.
   paths. Each secrets engine is isolated to its path. By default, they are
   enabled at their "type" (e.g. "aws" enables at `aws/`).
 
-  !> **Case-sensitive:** The path you enable secrets engines is case-sensitive. For
+  !> **Case-sensitive:** The path where you enable secrets engines is case-sensitive. For
   example, the KV secrets engine enabled at `kv/` and `KV/` are treated as two
   distinct instances of KV secrets engine.
 


### PR DESCRIPTION
🔍 [Deploy Preview - Secrets Engine](https://vault-git-docs-secrets-mount-paths-hashicorp.vercel.app/docs/secrets)
🔍 [Deploy Preview - secrets enable command](https://vault-git-docs-secrets-mount-paths-hashicorp.vercel.app/docs/commands/secrets/enable#path)

This PR fixes what [PR 9199](https://github.com/hashicorp/vault/pull/9199) intended to fix. 

- Adds a callout note to say that mount path is case-sensitive
- Add hyperlinks to respective command docs 

![image](https://user-images.githubusercontent.com/7660718/184934318-627ac4cc-70bb-4d20-859d-33641faa35d4.png)
