### PR TITLE
UI/Add client ids to search select

### DIFF
--- a/ui/app/adapters/named-path.js
+++ b/ui/app/adapters/named-path.js
@@ -38,11 +38,11 @@ export default class NamedPathAdapter extends ApplicationAdapter {
     const url = this.urlForQuery(query, type.modelName);
     const { paramKey, filterFor } = query;
     // * 'paramKey' is a string of the param name (model attr) we're filtering for, e.g. 'client_id'
-    // * 'filterFor' is an array of values to filter for (value type must match the attr type), e.g. list of ID strings
+    // * 'filterFor' is an array of values to filter for (value type must match the attr type), e.g. array of ID strings
     // example: the OidcProviderClientsRoute where we only want to list clients that are permitted to use the currently viewed provider
     const response = await this.ajax(url, 'GET', { data: { list: true } });
 
-    // filter LIST response only if key_info exists and passed both 'paramKey' & 'filterFor'
+    // filter LIST response only if key_info exists and query includes both 'paramKey' & 'filterFor'
     if (response.data.key_info && filterFor && paramKey && !filterFor.includes('*')) {
       const data = this.filterListResponse(paramKey, filterFor, response.data.key_info);
       return { ...response, data };

--- a/ui/app/adapters/named-path.js
+++ b/ui/app/adapters/named-path.js
@@ -48,8 +48,8 @@ export default class NamedPathAdapter extends ApplicationAdapter {
 
   filterListResponse(filterKey, matchValues, key_info) {
     const keyInfoAsArray = Object.entries(key_info);
-    const filtered = keyInfoAsArray.filter(([key, value]) => {
-      // value is the object of model attributes
+    const filtered = keyInfoAsArray.filter((key) => {
+      const value = key[1]; // value is the object of model attributes
       return matchValues.includes(value[filterKey]);
     });
     const filteredKeyInfo = Object.fromEntries(filtered);

--- a/ui/app/adapters/named-path.js
+++ b/ui/app/adapters/named-path.js
@@ -36,20 +36,24 @@ export default class NamedPathAdapter extends ApplicationAdapter {
   // GET request with list=true as query param
   async query(store, type, query) {
     const url = this.urlForQuery(query, type.modelName);
-    const { filterIds } = query;
+    const { key, filterFor } = query;
     const response = await this.ajax(url, 'GET', { data: { list: true } });
-
-    // filter LIST response when key_info and filterIds exist
-    if (response.data.key_info && filterIds && !filterIds.includes('*')) {
-      const data = this.filterListResponse(filterIds, response.data.keys, response.data.key_info);
+    // filter LIST response when key_info and filterFor exist
+    if (response.data.key_info && filterFor && !filterFor.includes('*')) {
+      const data = this.filterListResponse(key, filterFor, response.data.key_info);
       return { ...response, data };
     }
     return response;
   }
 
-  filterListResponse(matchKeys, keys, key_info) {
-    let filteredKeys = keys.filter((k) => matchKeys.includes(k));
-    let filteredKeyInfo = { key_info: Object.fromEntries(filteredKeys.map((key) => [key, key_info[key]])) };
+  filterListResponse(filterKey, matchValues, key_info) {
+    const keyInfoAsArray = Object.entries(key_info);
+    const filtered = keyInfoAsArray.filter(([key, value]) => {
+      // value is the object of model attributes
+      return matchValues.includes(value[filterKey]);
+    });
+    const filteredKeyInfo = Object.fromEntries(filtered);
+    const filteredKeys = Object.keys(filteredKeyInfo);
     return { keys: filteredKeys, key_info: filteredKeyInfo };
   }
 }

--- a/ui/app/adapters/named-path.js
+++ b/ui/app/adapters/named-path.js
@@ -38,6 +38,7 @@ export default class NamedPathAdapter extends ApplicationAdapter {
     const url = this.urlForQuery(query, type.modelName);
     const { key, filterFor } = query;
     const response = await this.ajax(url, 'GET', { data: { list: true } });
+
     // filter LIST response when key_info and filterFor exist
     if (response.data.key_info && filterFor && !filterFor.includes('*')) {
       const data = this.filterListResponse(key, filterFor, response.data.key_info);

--- a/ui/app/adapters/named-path.js
+++ b/ui/app/adapters/named-path.js
@@ -36,22 +36,25 @@ export default class NamedPathAdapter extends ApplicationAdapter {
   // GET request with list=true as query param
   async query(store, type, query) {
     const url = this.urlForQuery(query, type.modelName);
-    const { key, filterFor } = query;
+    const { paramKey, filterFor } = query;
+    // * 'paramKey' is a string of the param name (model attr) we're filtering for, e.g. 'client_id'
+    // * 'filterFor' is an array of values to filter for (value type must match the attr type), e.g. list of ID strings
+    // example: the OidcProviderClientsRoute where we only want to list clients that are permitted to use the currently viewed provider
     const response = await this.ajax(url, 'GET', { data: { list: true } });
 
-    // filter LIST response when key_info and filterFor exist
-    if (response.data.key_info && filterFor && !filterFor.includes('*')) {
-      const data = this.filterListResponse(key, filterFor, response.data.key_info);
+    // filter LIST response only if key_info exists and passed both 'paramKey' & 'filterFor'
+    if (response.data.key_info && filterFor && paramKey && !filterFor.includes('*')) {
+      const data = this.filterListResponse(paramKey, filterFor, response.data.key_info);
       return { ...response, data };
     }
     return response;
   }
 
-  filterListResponse(filterKey, matchValues, key_info) {
+  filterListResponse(paramKey, matchValues, key_info) {
     const keyInfoAsArray = Object.entries(key_info);
     const filtered = keyInfoAsArray.filter((key) => {
-      const value = key[1]; // value is the object of model attributes
-      return matchValues.includes(value[filterKey]);
+      const value = key[1]; // value is an object of model attributes
+      return matchValues.includes(value[paramKey]);
     });
     const filteredKeyInfo = Object.fromEntries(filtered);
     const filteredKeys = Object.keys(filteredKeyInfo);

--- a/ui/app/components/oidc/provider-form.js
+++ b/ui/app/components/oidc/provider-form.js
@@ -36,11 +36,6 @@ export default class OidcProviderForm extends Component {
     super(...arguments);
     const { model } = this.args;
     model.issuer = model.isNew ? '' : parseURL(model.issuer).origin;
-    this.store
-      .query('oidc/client', {
-        filterIds: this.args.model.allowedClientIds,
-      })
-      .then((resp) => (this.modelClientIds = resp));
   }
 
   @action

--- a/ui/app/components/oidc/provider-form.js
+++ b/ui/app/components/oidc/provider-form.js
@@ -24,6 +24,7 @@ export default class OidcProviderForm extends Component {
   @service store;
   @service flashMessages;
 
+  @tracked modelClientIds;
   @tracked modelValidations;
   @tracked radioCardGroupValue =
     // If "*" is provided, all clients are allowed: https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#parameters
@@ -35,13 +36,18 @@ export default class OidcProviderForm extends Component {
     super(...arguments);
     const { model } = this.args;
     model.issuer = model.isNew ? '' : parseURL(model.issuer).origin;
+    this.store
+      .query('oidc/client', {
+        filterIds: this.args.model.allowedClientIds,
+      })
+      .then((resp) => (this.modelClientIds = resp));
   }
 
   @action
   handleClientSelection(selection) {
     // if array then coming from search-select component, set selection as model clients
     if (Array.isArray(selection)) {
-      this.args.model.allowedClientIds = selection;
+      this.args.model.allowedClientIds = selection.map((client) => client.clientId);
     } else {
       // otherwise update radio button value and reset clients so
       // UI always reflects a user's selection (including when no clients are selected)

--- a/ui/app/components/oidc/provider-form.js
+++ b/ui/app/components/oidc/provider-form.js
@@ -24,7 +24,6 @@ export default class OidcProviderForm extends Component {
   @service store;
   @service flashMessages;
 
-  @tracked modelClientIds;
   @tracked modelValidations;
   @tracked radioCardGroupValue =
     // If "*" is provided, all clients are allowed: https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#parameters

--- a/ui/app/routes/vault/cluster/access/oidc/clients/client/providers.js
+++ b/ui/app/routes/vault/cluster/access/oidc/clients/client/providers.js
@@ -3,6 +3,7 @@ import Route from '@ember/routing/route';
 export default class OidcClientProvidersRoute extends Route {
   model() {
     const model = this.modelFor('vault.cluster.access.oidc.clients.client');
+    // TODO CMB: broken - waiting for backend to accept GET + ?list=true
     return this.store.query('oidc/provider', {
       allowed_client_id: model.clientId,
     });

--- a/ui/app/routes/vault/cluster/access/oidc/clients/client/providers.js
+++ b/ui/app/routes/vault/cluster/access/oidc/clients/client/providers.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 export default class OidcClientProvidersRoute extends Route {
   model() {
     const model = this.modelFor('vault.cluster.access.oidc.clients.client');
-    // TODO CMB: broken - waiting for backend to accept GET + ?list=true
+    // TODO CMB: not filtering correctly - waiting for backend to accept GET + ?list=true
     return this.store.query('oidc/provider', {
       allowed_client_id: model.clientId,
     });

--- a/ui/app/routes/vault/cluster/access/oidc/providers/provider/clients.js
+++ b/ui/app/routes/vault/cluster/access/oidc/providers/provider/clients.js
@@ -3,6 +3,6 @@ import Route from '@ember/routing/route';
 export default class OidcProviderClientsRoute extends Route {
   async model() {
     const { allowedClientIds } = this.modelFor('vault.cluster.access.oidc.providers.provider');
-    return await this.store.query('oidc/client', { filterIds: allowedClientIds });
+    return await this.store.query('oidc/client', { key: 'client_id', filterFor: allowedClientIds });
   }
 }

--- a/ui/app/routes/vault/cluster/access/oidc/providers/provider/clients.js
+++ b/ui/app/routes/vault/cluster/access/oidc/providers/provider/clients.js
@@ -3,6 +3,6 @@ import Route from '@ember/routing/route';
 export default class OidcProviderClientsRoute extends Route {
   async model() {
     const { allowedClientIds } = this.modelFor('vault.cluster.access.oidc.providers.provider');
-    return await this.store.query('oidc/client', { key: 'client_id', filterFor: allowedClientIds });
+    return await this.store.query('oidc/client', { paramKey: 'client_id', filterFor: allowedClientIds });
   }
 }

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -89,10 +89,13 @@
         @id="allowedClientIds"
         @subLabel="Application name"
         @models={{array "oidc/client"}}
-        @inputValue={{@model.allowedClientIds}}
+        @inputValue={{this.modelClientIds}}
+        {{!-- @inputValue={{@model.allowedClientIds}} --}}
         @onChange={{this.handleClientSelection}}
         @disallowNewItems={{true}}
         @fallbackComponent="string-list"
+        @passObject={{true}}
+        @objectKeys={{array "clientId"}}
       />
     {{/if}}
   </div>

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -89,8 +89,7 @@
         @id="allowedClientIds"
         @subLabel="Application name"
         @models={{array "oidc/client"}}
-        @inputValue={{this.modelClientIds}}
-        {{!-- @inputValue={{@model.allowedClientIds}} --}}
+        @inputValue={{@model.allowedClientIds}}
         @onChange={{this.handleClientSelection}}
         @disallowNewItems={{true}}
         @fallbackComponent="string-list"

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -55,10 +55,14 @@ export default Component.extend({
   options: null, // all possible options
   shouldUseFallback: false,
   shouldRenderName: false,
-  objectKeys: null,
   disallowNewItems: false,
   passObject: false,
-
+  objectKeys: null,
+  idKey: computed('objectKeys', function () {
+    // if objectKeys exists, then use the first element of the array as the identifier
+    // e.g. 'clientId' otherwise use 'id'
+    return this.objectKeys ? this.objectKeys[0] : 'id';
+  }),
   init() {
     this._super(...arguments);
     this.set('selectedOptions', this.inputValue || []);
@@ -75,7 +79,7 @@ export default Component.extend({
   },
   formatOptions: function (options) {
     options = options.toArray().map((option) => {
-      option.searchText = `${option.name} ${option.id}`;
+      option.searchText = `${option.name} ${option[this.idKey]}`;
       return option;
     });
     let allOptions = options.toArray().map((option) => {
@@ -83,7 +87,7 @@ export default Component.extend({
     });
     this.set('allOptions', allOptions); // used by filter-wildcard helper
     let formattedOptions = this.selectedOptions.map((option) => {
-      let matchingOption = options.findBy('id', option);
+      let matchingOption = options.findBy(this.idKey, option);
       options.removeObject(matchingOption);
       return {
         id: option,
@@ -91,7 +95,7 @@ export default Component.extend({
         searchText: matchingOption ? matchingOption.searchText : option,
       };
     });
-
+    console.log(formattedOptions);
     this.set('selectedOptions', formattedOptions);
     if (this.options) {
       options = this.options.concat(options).uniq();
@@ -106,7 +110,7 @@ export default Component.extend({
       return;
     }
     for (let modelType of this.models) {
-      if (modelType.includes('identity')) {
+      if (modelType.includes('identity') || modelType.includes('oidc/client')) {
         this.set('shouldRenderName', true);
       }
       try {

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -21,8 +21,8 @@ import layout from '../templates/components/search-select';
  * @param {string} fallbackComponent - name of component to be rendered if the API call 403s
  * @param {string} [backend] - name of the backend if the query for options needs additional information (eg. secret backend)
  * @param {boolean} [disallowNewItems=false] - Controls whether or not the user can add a new item if none found
- * @param {boolean} [passObject=false] - When true, the onChange callback returns an array of objects with id (string) and isNew (boolean)
- * @param {array} [objectKeys=null] - Array of strings that correlate to model attrs. When passObject=true and you want to customize the object rendered and returned by search-select, passed in objectKeys will be added to the option object. NOTE: the first string in the array sets the dynamic idKey
+ * @param {boolean} [passObject=false] - When true, the onChange callback returns an array of objects with id (string) and isNew (boolean) (instead of an array of id strings)
+ * @param {array} [objectKeys=null] - Array of strings that correlate to model attrs. When passObject=true, objectKeys are added to the passed object. NOTE: make 'id' as the first element in objectKeys if you do not want to override the default of 'id'
  * @param {number} [selectLimit] - A number that sets the limit to how many select options they can choose
  * @param {string} [subText] - Text to be displayed below the label
  * @param {string} [subLabel] - a smaller label below the main Label
@@ -59,7 +59,6 @@ export default Component.extend({
   objectKeys: null,
   idKey: computed('objectKeys', function () {
     // if objectKeys exists, then use the first element of the array as the identifier
-    // pass 'id' as the first element in objectKeys if you do not want to override the default of 'id'
     return this.objectKeys ? this.objectKeys[0] : 'id';
   }),
   init() {

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -183,7 +183,7 @@ export default Component.extend({
       let additionalKeys;
       if (this.objectKeys) {
         // if the LIST endpoint has key_info and the model has been hydrated in serializer (ex: serializer/oidc/clients)
-        // 'option' is a model record, so pull any attrs we want sent to the parent by adding them to the selected option (object)
+        // 'option' is a model record, so pull any attrs, add to the selected option (object) and send to the parent
         additionalKeys = Object.fromEntries(this.objectKeys.map((key) => [key, option[key]]));
         if (Object.values(additionalKeys).includes(undefined)) additionalKeys = false;
       }

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -23,6 +23,7 @@ import layout from '../templates/components/search-select';
  * @param {boolean} [disallowNewItems=false] - Controls whether or not the user can add a new item if none found
  * @param {boolean} [passObject=false] - When true, the onChange callback returns an array of objects with id (string) and isNew (boolean) (instead of an array of id strings)
  * @param {array} [objectKeys=null] - Array of strings that correlate to model attrs. When passObject=true, objectKeys are added to the passed object. NOTE: make 'id' as the first element in objectKeys if you do not want to override the default of 'id'
+ * @param {string} [helpText] - Text to be displayed in the info tooltip for this form field
  * @param {number} [selectLimit] - A number that sets the limit to how many select options they can choose
  * @param {string} [subText] - Text to be displayed below the label
  * @param {string} [subLabel] - a smaller label below the main Label

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -93,9 +93,10 @@ export default Component.extend({
         id: option,
         name: matchingOption ? matchingOption.name : option,
         searchText: matchingOption ? matchingOption.searchText : option,
+        // conditionally spread configured object if we've passed in a dynamic param
+        ...(this.idKey !== 'id' && this.configureObject(matchingOption)),
       };
     });
-    console.log(formattedOptions);
     this.set('selectedOptions', formattedOptions);
     if (this.options) {
       options = this.options.concat(options).uniq();

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -109,8 +109,11 @@ export default Component.extend({
       }
       return;
     }
+    if (this.idKey !== 'id' && this.models.length === 1) {
+      this.set('shouldRenderName', true);
+    }
     for (let modelType of this.models) {
-      if (modelType.includes('identity') || this.idKey !== 'id') {
+      if (modelType.includes('identity')) {
         this.set('shouldRenderName', true);
       }
       try {

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -110,7 +110,7 @@ export default Component.extend({
       return;
     }
     for (let modelType of this.models) {
-      if (modelType.includes('identity') || modelType.includes('oidc/client')) {
+      if (modelType.includes('identity') || this.idKey !== 'id') {
         this.set('shouldRenderName', true);
       }
       try {

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -40,7 +40,7 @@
       {{#if this.shouldRenderName}}
         {{option.name}}
         <small class="search-select-list-key" data-test-smaller-id="true">
-          {{option.id}}
+          {{get option this.idKey}}
         </small>
       {{else}}
         {{option.id}}
@@ -53,7 +53,7 @@
         {{#if this.shouldRenderName}}
           {{selected.name}}
           <small class="search-select-list-key" data-test-smaller-id="true">
-            {{selected.id}}
+            {{get selected this.idKey}}
           </small>
         {{else}}
           <div>

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -52,6 +52,7 @@
       <li class="search-select-list-item" data-test-selected-option="true">
         {{#if this.shouldRenderName}}
           {{selected.name}}
+          {{log "SELECTED" selected}}
           <small class="search-select-list-key" data-test-smaller-id="true">
             {{get selected this.idKey}}
           </small>

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -52,7 +52,6 @@
       <li class="search-select-list-item" data-test-selected-option="true">
         {{#if this.shouldRenderName}}
           {{selected.name}}
-          {{log "SELECTED" selected}}
           <small class="search-select-list-key" data-test-smaller-id="true">
             {{get selected this.idKey}}
           </small>

--- a/ui/tests/integration/components/oidc/provider-form-test.js
+++ b/ui/tests/integration/components/oidc/provider-form-test.js
@@ -42,7 +42,7 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
   });
 
   test('it should save new provider', async function (assert) {
-    assert.expect(12);
+    assert.expect(13);
     this.server.post('/identity/oidc/provider/test-provider', (schema, req) => {
       assert.ok(true, 'Request made to save provider');
       return JSON.parse(req.requestBody);
@@ -85,6 +85,7 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
       .exists('Limited radio button shows clients search select');
     await click('[data-test-component="search-select"]#allowedClientIds .ember-basic-dropdown-trigger');
     assert.dom('li.ember-power-select-option').hasTextContaining('some-app', 'dropdown renders client name');
+    assert.dom('[data-test-smaller-id]').exists('renders smaller client id in dropdown');
 
     await click('label[for=allow-all]');
     assert

--- a/ui/tests/integration/components/oidc/provider-form-test.js
+++ b/ui/tests/integration/components/oidc/provider-form-test.js
@@ -84,7 +84,7 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
       .dom('[data-test-component="search-select"]#allowedClientIds')
       .exists('Limited radio button shows clients search select');
     await click('[data-test-component="search-select"]#allowedClientIds .ember-basic-dropdown-trigger');
-    assert.dom('li.ember-power-select-option').hasText('some-app', 'dropdown renders clients');
+    assert.dom('li.ember-power-select-option').hasTextContaining('some-app', 'dropdown renders client name');
 
     await click('label[for=allow-all]');
     assert

--- a/ui/tests/integration/components/search-select-test.js
+++ b/ui/tests/integration/components/search-select-test.js
@@ -397,7 +397,7 @@ module('Integration | Component | search select', function (hooks) {
     );
   });
 
-  test('it lists option name and passed objectKey in dropdown for oidc/client models', async function (assert) {
+  test('it correctly renders when passed objectKeys', async function (assert) {
     const models = ['oidc/client'];
     const spy = sinon.spy();
     this.set('models', models);
@@ -423,15 +423,9 @@ module('Integration | Component | search select', function (hooks) {
     assert.equal(component.selectedOptions.length, 1, 'there is 1 selected option');
     assert
       .dom('[data-test-selected-option]')
-      .hasText('client-a asecret123', 'oidc/client models renders both name and dynamic id');
+      .hasText('client-a asecret123', 'renders both name and dynamic id in dropdown');
     assert
       .dom('[data-test-smaller-id]')
       .hasText('asecret123', 'renders passed in objectKey as the smaller id');
-
-    assert.propEqual(
-      spy.args[0][0],
-      [{ id: 'client-a', isNew: false, client_secret: 'asecret123' }],
-      'onClick is called with array of objects with isNew true on new item'
-    );
   });
 });

--- a/ui/tests/integration/components/search-select-test.js
+++ b/ui/tests/integration/components/search-select-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { create } from 'ember-cli-page-object';
 import { typeInSearch, clickTrigger } from 'ember-power-select/test-support/helpers';
 import Service from '@ember/service';
-import { render, settled } from '@ember/test-helpers';
+import { click, render, settled } from '@ember/test-helpers';
 import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
@@ -48,9 +48,9 @@ const storeService = Service.extend({
           break;
         case 'some/model':
           resolve([
-            { id: 'client-a-id', name: 'client-a', uuid: 'a123' },
-            { id: 'client-b-id', name: 'client-b', uuid: 'b456' },
-            { id: 'client-c-id', name: 'client-c', uuid: 'c789' },
+            { id: 'model-a-id', name: 'model-a', uuid: 'a123', type: 'a' },
+            { id: 'model-b-id', name: 'model-b', uuid: 'b456', type: 'b' },
+            { id: 'model-c-id', name: 'model-c', uuid: 'c789', type: 'c' },
           ]);
           break;
         default:
@@ -338,7 +338,7 @@ module('Integration | Component | search select', function (hooks) {
     );
   });
 
-  test('it returns custom object if passObject=true and multiple objectKeys', async function (assert) {
+  test(`it returns custom object if passObject=true and multiple objectKeys with objectKeys[0]='id'`, async function (assert) {
     const models = ['some/model'];
     const spy = sinon.spy();
     this.set('models', models);
@@ -364,11 +364,11 @@ module('Integration | Component | search select', function (hooks) {
     assert.equal(component.selectedOptions.length, 1, 'there is 1 selected option');
     assert
       .dom('[data-test-selected-option]')
-      .hasText('client-a-id', 'does not render name if first objectKey is id');
+      .hasText('model-a-id', 'does not render name if first objectKey is id');
     assert.ok(this.onChange.calledOnce);
     assert.ok(
-      this.onChange.calledWith([{ id: 'client-a-id', isNew: false, uuid: 'a123' }]),
-      'onClick is called with array of single object with two keys: id, uuid'
+      this.onChange.calledWith([{ id: 'model-a-id', isNew: false, uuid: 'a123' }]),
+      'onClick is called with array of single object with keys: id, uuid'
     );
     // Then create a new item and select it
     await clickTrigger();
@@ -380,7 +380,7 @@ module('Integration | Component | search select', function (hooks) {
       spy.args[1][0],
       [
         {
-          id: 'client-a-id',
+          id: 'model-a-id',
           isNew: false,
           uuid: 'a123',
         },
@@ -389,11 +389,11 @@ module('Integration | Component | search select', function (hooks) {
           isNew: true,
         },
       ],
-      'onClick is called with array of objects with isNew true on new item'
+      'onClick is called with array of objects with isNew=true (and no additional keys) on new item'
     );
   });
 
-  test('it returns custom object if passObject=true and renders name', async function (assert) {
+  test('it returns custom object and renders name if passObject=true and multiple objectKeys', async function (assert) {
     const models = ['some/model'];
     const spy = sinon.spy();
     const objectKeys = ['uuid', 'name'];
@@ -418,19 +418,177 @@ module('Integration | Component | search select', function (hooks) {
     // First select existing option
     await component.selectOption();
     assert.equal(component.selectedOptions.length, 1, 'there is 1 selected option');
-    assert.dom('[data-test-selected-option]').hasText('client-a a123', 'renders both name and uuid');
-    assert.dom('[data-test-smaller-id]').hasText('a123', 'renders passed in objectKey as the smaller id');
+    assert
+      .dom('[data-test-selected-option]')
+      .hasText('model-a a123', `renders name and ${objectKeys[0]} if first objectKey is not id`);
+    assert.dom('[data-test-smaller-id]').exists();
     assert.propEqual(
       spy.args[0][0],
       [
         {
-          id: 'client-a-id',
+          id: 'model-a-id',
           isNew: false,
-          name: 'client-a',
+          name: 'model-a',
           uuid: 'a123',
         },
       ],
       `onClick is called with array of single object: isNew=false, and has keys: ${objectKeys.join(', ')}`
     );
+  });
+
+  test('it renders ids if model does not have the passed objectKeys as an attribute', async function (assert) {
+    const models = ['policy/acl'];
+    const spy = sinon.spy();
+    const objectKeys = ['uuid'];
+    this.set('models', models);
+    this.set('onChange', spy);
+    this.set('objectKeys', objectKeys);
+    await render(hbs`
+    <div class="box">
+      <SearchSelect
+        @label="foo"
+        @models={{this.models}}
+        @onChange={{this.onChange}}
+        @objectKeys={{this.objectKeys}}
+      />
+    </div>
+    `);
+
+    await clickTrigger();
+    await settled();
+
+    // First select existing option
+    await component.selectOption();
+    assert.equal(component.selectedOptions.length, 1, 'there is 1 selected option');
+    assert
+      .dom('[data-test-selected-option]')
+      .hasText('1', 'renders model id if does not have objectKey as an attribute');
+    assert.propEqual(spy.args[0][0], ['1'], 'onClick is called with array of single id string');
+  });
+
+  test('it renders when passObject=true and model does not have the passed objectKeys as an attr', async function (assert) {
+    const models = ['policy/acl'];
+    const spy = sinon.spy();
+    const objectKeys = ['uuid'];
+    this.set('models', models);
+    this.set('onChange', spy);
+    this.set('objectKeys', objectKeys);
+    await render(hbs`
+    <div class="box">
+      <SearchSelect
+        @label="foo"
+        @models={{this.models}}
+        @onChange={{this.onChange}}
+        @passObject={{true}}
+        @objectKeys={{this.objectKeys}}
+      />
+    </div>
+    `);
+
+    await clickTrigger();
+    await settled();
+
+    // First select existing option
+    await component.selectOption();
+    assert.equal(component.selectedOptions.length, 1, 'there is 1 selected option');
+    assert.dom('[data-test-selected-option]').hasText('1', 'renders model id if does not have objectKey');
+    assert.propEqual(
+      spy.args[0][0],
+      [
+        {
+          id: '1',
+          isNew: false,
+        },
+      ],
+      'onClick is called with array of single object with correct keys'
+    );
+  });
+
+  test('it renders when passed multiple models, passObject=true and one model does not have the attr in objectKeys', async function (assert) {
+    const models = ['policy/acl', 'some/model'];
+    const spy = sinon.spy();
+    const objectKeys = ['uuid'];
+    this.set('models', models);
+    this.set('onChange', spy);
+    this.set('objectKeys', objectKeys);
+    await render(hbs`
+    <div class="box">
+      <SearchSelect
+        @label="foo"
+        @models={{this.models}}
+        @onChange={{this.onChange}}
+        @passObject={{true}}
+        @objectKeys={{this.objectKeys}}
+      />
+    </div>
+    `);
+
+    await clickTrigger();
+    await settled();
+    assert.equal(component.options.objectAt(0).text, '1', 'first option renders just id as name');
+    assert.equal(
+      component.options.objectAt(3).text,
+      'model-a a123',
+      `4 option renders both name and ${objectKeys[0]}`
+    );
+
+    // First select options with and without id
+    await component.selectOption();
+    await clickTrigger();
+    await settled();
+    await click('[data-option-index="2"]');
+    const expectedArray = [
+      {
+        id: '1',
+        isNew: false,
+      },
+      {
+        id: 'model-a-id',
+        isNew: false,
+        uuid: 'a123',
+      },
+    ];
+    assert.propEqual(
+      spy.args[1][0],
+      expectedArray,
+      `onClick is called with array of objects and correct keys.
+      first object: ${Object.keys(expectedArray[0]).join(', ')}, 
+      second object: ${Object.keys(expectedArray[1]).join(', ')}`
+    );
+  });
+
+  test('it renders when passed multiple models, passedObject=false and one model does not have the attr in objectKeys', async function (assert) {
+    const models = ['policy/acl', 'some/model'];
+    const spy = sinon.spy();
+    const objectKeys = ['uuid'];
+    this.set('models', models);
+    this.set('onChange', spy);
+    this.set('objectKeys', objectKeys);
+    await render(hbs`
+    <div class="box">
+      <SearchSelect
+        @label="foo"
+        @models={{this.models}}
+        @onChange={{this.onChange}}
+        @objectKeys={{this.objectKeys}}
+      />
+    </div>
+    `);
+
+    await clickTrigger();
+    await settled();
+    assert.equal(component.options.objectAt(0).text, '1', 'first option is just id as name');
+    assert.equal(
+      component.options.objectAt(3).text,
+      'model-a a123',
+      `4th option has both name and ${objectKeys[0]}`
+    );
+
+    // First select options with and without id
+    await component.selectOption();
+    await clickTrigger();
+    await settled();
+    await click('[data-option-index="2"]');
+    assert.propEqual(spy.args[1][0], ['1', 'model-a-id'], 'onClick is called with array of id strings');
   });
 });

--- a/ui/tests/unit/adapters/oidc/test-helper.js
+++ b/ui/tests/unit/adapters/oidc/test-helper.js
@@ -27,56 +27,59 @@ export default (test) => {
     const keyInfoModels = ['client', 'provider'];
     if (keyInfoModels.some((model) => this.modelName.includes(model))) {
       const keys = ['model-1', 'model-2', 'model-3'];
-      const key_info = [
-        {
-          'model-1': {
-            key: 'test-key',
-            access_token_ttl: '30m',
-            id_token_ttl: '1h',
-          },
+      const key_info = {
+        'model-1': {
+          model_id: 'a123',
+          key: 'test-key',
+          access_token_ttl: '30m',
+          id_token_ttl: '1h',
         },
-        {
-          'model-2': {
-            key: 'test-key',
-            access_token_ttl: '30m',
-            id_token_ttl: '1h',
-          },
+        'model-2': {
+          model_id: 'b123',
+          key: 'test-key',
+          access_token_ttl: '30m',
+          id_token_ttl: '1h',
         },
-        {
-          'model-3': {
-            key: 'test-key',
-            access_token_ttl: '30m',
-            id_token_ttl: '1h',
-          },
+        'model-3': {
+          model_id: 'c123',
+          key: 'test-key',
+          access_token_ttl: '30m',
+          id_token_ttl: '1h',
         },
-      ];
+      };
 
       this.server.get(`/identity/${this.modelName}`, (schema, req) => {
         assert.equal(req.queryParams.list, 'true', 'request is made to correct endpoint on query');
         return { data: { keys, key_info } };
       });
 
-      let testQuery = ['*', 'model-1'];
+      // test passing 'key' and 'filterFor' to query and filterListResponse in adapters/named-path.js works as expected
+      let testQuery = ['*', 'a123'];
       await this.store
-        .query(this.modelName, { filterIds: testQuery })
+        .query(this.modelName, { key: 'model_id', filterFor: testQuery })
         .then((resp) =>
           assert.equal(resp.content.length, 3, 'returns all clients when ids include glob (*)')
         );
 
       testQuery = ['*'];
       await this.store
-        .query(this.modelName, { filterIds: testQuery })
+        .query(this.modelName, { key: 'model_id', filterFor: testQuery })
         .then((resp) => assert.equal(resp.content.length, 3, 'returns all clients when glob (*) is only id'));
 
-      testQuery = ['model-2'];
-      await this.store.query(this.modelName, { filterIds: testQuery }).then((resp) => {
+      testQuery = ['b123'];
+      await this.store.query(this.modelName, { key: 'model_id', filterFor: testQuery }).then((resp) => {
+        console.log(resp);
         assert.equal(resp.content.length, 1, 'filters response and returns only matching id');
+        console.log(resp.firstObject, 'FIRST OBJECT');
         assert.equal(resp.firstObject.name, 'model-2', 'response contains correct model');
       });
 
-      testQuery = ['model-2', 'model-3'];
-      await this.store.query(this.modelName, { filterIds: testQuery }).then((resp) => {
+      testQuery = ['b123', 'c123'];
+      await this.store.query(this.modelName, { key: 'model_id', filterFor: testQuery }).then((resp) => {
         assert.equal(resp.content.length, 2, 'filters response when passed multiple ids');
+        resp.content.forEach((m) =>
+          assert.ok(['model-2', 'model-3'].includes(m.id), `it filters correctly and included: ${m.id}`)
+        );
       });
     } else {
       this.server.get(`/identity/${this.modelName}`, (schema, req) => {
@@ -87,7 +90,7 @@ export default (test) => {
       this.store.query(this.modelName, {});
 
       this.store
-        .query(this.modelName, { filterIds: this.data.name })
+        .query(this.modelName, { key: 'model_id', filterFor: this.data.name })
         .then((resp) => assert.ok(resp.isLoaded, 'does not attempt to filter when no key_info'));
     }
   });

--- a/ui/tests/unit/adapters/oidc/test-helper.js
+++ b/ui/tests/unit/adapters/oidc/test-helper.js
@@ -53,21 +53,21 @@ export default (test) => {
         return { data: { keys, key_info } };
       });
 
-      // test passing 'key' and 'filterFor' to query and filterListResponse in adapters/named-path.js works as expected
+      // test passing 'paramKey' and 'filterFor' to query and filterListResponse in adapters/named-path.js works as expected
       let testQuery = ['*', 'a123'];
       await this.store
-        .query(this.modelName, { key: 'model_id', filterFor: testQuery })
+        .query(this.modelName, { paramKey: 'model_id', filterFor: testQuery })
         .then((resp) =>
           assert.equal(resp.content.length, 3, 'returns all clients when ids include glob (*)')
         );
 
       testQuery = ['*'];
       await this.store
-        .query(this.modelName, { key: 'model_id', filterFor: testQuery })
+        .query(this.modelName, { paramKey: 'model_id', filterFor: testQuery })
         .then((resp) => assert.equal(resp.content.length, 3, 'returns all clients when glob (*) is only id'));
 
       testQuery = ['b123'];
-      await this.store.query(this.modelName, { key: 'model_id', filterFor: testQuery }).then((resp) => {
+      await this.store.query(this.modelName, { paramKey: 'model_id', filterFor: testQuery }).then((resp) => {
         console.log(resp);
         assert.equal(resp.content.length, 1, 'filters response and returns only matching id');
         console.log(resp.firstObject, 'FIRST OBJECT');
@@ -75,7 +75,7 @@ export default (test) => {
       });
 
       testQuery = ['b123', 'c123'];
-      await this.store.query(this.modelName, { key: 'model_id', filterFor: testQuery }).then((resp) => {
+      await this.store.query(this.modelName, { paramKey: 'model_id', filterFor: testQuery }).then((resp) => {
         assert.equal(resp.content.length, 2, 'filters response when passed multiple ids');
         resp.content.forEach((m) =>
           assert.ok(['model-2', 'model-3'].includes(m.id), `it filters correctly and included: ${m.id}`)
@@ -90,7 +90,7 @@ export default (test) => {
       this.store.query(this.modelName, {});
 
       this.store
-        .query(this.modelName, { key: 'model_id', filterFor: this.data.name })
+        .query(this.modelName, { paramKey: 'model_id', filterFor: this.data.name })
         .then((resp) => assert.ok(resp.isLoaded, 'does not attempt to filter when no key_info'));
     }
   });


### PR DESCRIPTION
Fixes form so the client's param of `client_id` is added to a provider's `allowed_client_ids=[]` instead of the client's `name` (which in ember _is_  is the `id` assigned when the record is created) [Vault docs](https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#parameters)
<hr>

![ss](https://user-images.githubusercontent.com/68122737/184977057-2b3e50bd-6563-4413-8c29-45e8b3a082e1.gif)
