### PR TITLE
Fix the referenced learn link

### DIFF
--- a/website/content/docs/platform/k8s/index.mdx
+++ b/website/content/docs/platform/k8s/index.mdx
@@ -46,16 +46,16 @@ There are several ways to try Vault with Kubernetes in different environments.
 
 ### Guides
 
-- [Vault Installation to Minikube via Helm](https://learn.hashicorp.com/tutorials/vault/kubernetes-minikube-consul?in=vault/kubernetes) covers installing Vault locally using Minikube and the official Helm chart.
+- [Vault Installation to Minikube via Helm with Integrated Storage](https://learn.hashicorp.com/tutorials/vault/kubernetes-minikube-raft) covers installing Vault locally using Minikube and the official Helm chart.
 
-- [Vault Installation to Red Hat OpenShift via Helm](https://learn.hashicorp.com/tutorials/vault/kubernetes-openshift?in=vault/kubernetes) covers installing Vault using Helm on Red Hat's OpenShift platform.
+- [Vault Installation to Red Hat OpenShift via Helm](https://learn.hashicorp.com/tutorials/vault/kubernetes-openshift) covers installing Vault using Helm on Red Hat's OpenShift platform.
 
-- [Integrate a Kubernetes Cluster with an External Vault](https://learn.hashicorp.com/tutorials/vault/kubernetes-external-vault?in=vault/kubernetes) provides an example of making Vault accessible via a Kubernetes service and endpoint.
+- [Integrate a Kubernetes Cluster with an External Vault](https://learn.hashicorp.com/tutorials/vault/kubernetes-external-vault) provides an example of making Vault accessible via a Kubernetes service and endpoint.
 
-- [Vault on Kubernetes Deployment Guide](https://learn.hashicorp.com/tutorials/vault/kubernetes-raft-deployment-guide?in=vault/kubernetes) covers the steps required to install and configure a single HashiCorp Vault cluster as defined in the [Vault on Kubernetes Reference Architecture](https://learn.hashicorp.com/tutorials/vault/kubernetes-reference-architecture?in=vault/kubernetes).
+- [Vault on Kubernetes Deployment Guide](https://learn.hashicorp.com/tutorials/vault/kubernetes-raft-deployment-guide) covers the steps required to install and configure a single HashiCorp Vault cluster as defined in the [Vault on Kubernetes Reference Architecture](https://learn.hashicorp.com/tutorials/vault/kubernetes-reference-architecture).
 
 ### Documentation
 
-- [Vault on Kubernetes Reference Architecture](https://learn.hashicorp.com/tutorials/vault/kubernetes-reference-architecture?in=vault/kubernetes) provides recommended practices for running Vault on Kubernetes in production.
+- [Vault on Kubernetes Reference Architecture](https://learn.hashicorp.com/tutorials/vault/kubernetes-reference-architecture) provides recommended practices for running Vault on Kubernetes in production.
 
-- [Vault on Kubernetes Security Considerations](https://learn.hashicorp.com/tutorials/vault/kubernetes-security-concerns?in=vault/kubernetes) provides recommendations specific to securely running Vault in a production Kubernetes environment.
+- [Vault on Kubernetes Security Considerations](https://learn.hashicorp.com/tutorials/vault/kubernetes-security-concerns) provides recommendations specific to securely running Vault in a production Kubernetes environment.


### PR DESCRIPTION
🧵 [Slack chat](https://hashicorp.slack.com/archives/CQS78SFQD/p1660642943470079)

🔍 [Deploy Preview](https://vault-git-docs-fix-k8s-raft-hashicorp.vercel.app/docs/platform/k8s#guides)

It was reported that the doc points to the wrong tutorial. 

This PR:
- Points to the correct tutorial link 
- Removed the collection path in the tutorial URL (`?in=vault/kubernetes`) to avoid potential complication post migrating to DevDot