### PR TITLE
Add an empty State Message to the DB secret engine when the UI does not support the connection type

### DIFF
--- a/changelog/16758.txt
+++ b/changelog/16758.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Add empty state to Database secret engine when DB type is not supported.
+```

--- a/ui/app/models/database/connection.js
+++ b/ui/app/models/database/connection.js
@@ -238,6 +238,10 @@ export default Model.extend({
     defaultShown: 'Default',
   }),
 
+  isAvailablePlugin: computed('plugin_name', function() {
+    return !!AVAILABLE_PLUGIN_TYPES.find(a => a.value === this.plugin_name);
+  }),
+
   showAttrs: computed('plugin_name', function() {
     const fields = AVAILABLE_PLUGIN_TYPES.find(a => a.value === this.plugin_name)
       .fields.filter(f => f.show !== false)

--- a/ui/app/styles/components/empty-state.scss
+++ b/ui/app/styles/components/empty-state.scss
@@ -42,6 +42,8 @@
 
 .empty-state-actions {
   margin-top: $spacing-xs;
+  display: flex;
+  justify-content: space-between;
 
   a,
   .link,
@@ -54,6 +56,7 @@
 
   > * + * {
     margin-left: $spacing-s;
+    margin-right: $spacing-s;
   }
 }
 

--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -1,12 +1,17 @@
 <PageHeader as |p|>
   <p.top>
-    <KeyValueHeader @path="vault.cluster.secrets.backend.show" @mode={{mode}} @root={{@root}} @showCurrent={{true}}  />
+    <KeyValueHeader
+      @path='vault.cluster.secrets.backend.show'
+      @mode={{mode}}
+      @root={{@root}}
+      @showCurrent={{true}}
+    />
   </p.top>
   <p.levelLeft>
-    <h1 class="title is-3" data-test-secret-header="true">
-      {{#if (eq @mode "create") }}
+    <h1 class='title is-3' data-test-secret-header='true'>
+      {{#if (eq @mode 'create')}}
         Create Connection
-      {{else if (eq @mode "edit")}}
+      {{else if (eq @mode 'edit')}}
         Edit Connection
       {{else}}
         {{@model.id}}
@@ -14,70 +19,66 @@
     </h1>
   </p.levelLeft>
 </PageHeader>
-
-{{#if (eq @mode "show")}}
-  <Toolbar>
-    <ToolbarActions>
-      {{#if @model.canDelete}}
-      <button
-        type="button"
-        class="toolbar-link"
-        {{on 'click' this.delete}}
-        data-test-database-connection-delete
-      >
-        Delete connection
-      </button>
-      {{/if}}
-      {{#if @model.canReset}}
-      <ConfirmAction
-        @buttonClasses="toolbar-link"
-        @onConfirmAction={{action 'reset'}}
-        @confirmTitle="Reset connection?"
-        @confirmMessage="This will close the connection and its underlying plugin and restart it with the configuration stored in the barrier."
-        @confirmButtonText="Reset"
-        data-test-database-connection-reset
-      >
-        Reset connection
-      </ConfirmAction>
-      {{/if}}
-      {{#if (or @model.canReset @model.canDelete)}}
-      <div class="toolbar-separator" />
-      {{/if}}
-      {{#if @model.canRotateRoot }}
-        <ConfirmAction
-          @buttonClasses="toolbar-link"
-          @onConfirmAction={{this.rotate}}
-          @confirmTitle="Rotate credentials?"
-          @confirmMessage={{'This will rotate the "root" user credentials stored for the database connection. The password will not be accessible once rotated.'}}
-          @confirmButtonText="Rotate"
-          data-test-database-connection-rotate
-        >
-          Rotate root credentials
-        </ConfirmAction>
-      {{/if}}
-      {{#if @model.canAddRole}}
-      <ToolbarSecretLink
-        @secret=''
-        @mode="create"
-        @type="add"
-        @queryParams={{query-params initialKey=@model.name itemType="role"}}
-        @data-test-secret-create=true
-      >
-        Add role
-      </ToolbarSecretLink>
-      {{/if}}
-      {{#if @model.canEdit}}
-      <ToolbarSecretLink
-        @secret={{@model.id}}
-        @mode="edit"
-        @data-test-edit-link=true
-        @replace=true
-      >
-        Edit configuration
-      </ToolbarSecretLink>
-      {{/if}}
-    </ToolbarActions>
-  </Toolbar>
+{{#if @model.isAvailablePlugin}}
+  {{#if (eq @mode 'show')}}
+    <Toolbar>
+      <ToolbarActions>
+        {{#if @model.canDelete}}
+          <button
+            type='button'
+            class='toolbar-link'
+            {{on 'click' this.delete}}
+            data-test-database-connection-delete
+          >
+            Delete connection
+          </button>
+        {{/if}}
+        {{#if @model.canReset}}
+          <ConfirmAction
+            @buttonClasses='toolbar-link'
+            @onConfirmAction={{action 'reset'}}
+            @confirmTitle='Reset connection?'
+            @confirmMessage='This will close the connection and its underlying plugin and restart it with the configuration stored in the barrier.'
+            @confirmButtonText='Reset'
+            data-test-database-connection-reset
+          >
+            Reset connection
+          </ConfirmAction>
+        {{/if}}
+        {{#if (or @model.canReset @model.canDelete)}}
+          <div class='toolbar-separator'></div>
+        {{/if}}
+        {{#if @model.canRotateRoot}}
+          <ConfirmAction
+            @buttonClasses='toolbar-link'
+            @onConfirmAction={{this.rotate}}
+            @confirmTitle='Rotate credentials?'
+            @confirmMessage={{'This will rotate the "root" user credentials stored for the database connection. The password will not be accessible once rotated.'}}
+            @confirmButtonText='Rotate'
+            data-test-database-connection-rotate
+          >
+            Rotate root credentials
+          </ConfirmAction>
+        {{/if}}
+        {{#if @model.canAddRole}}
+          <ToolbarSecretLink
+            @secret=''
+            @mode='create'
+            @type='add'
+            @queryParams={{query-params initialKey=@model.name itemType='role'}}
+            @data-test-secret-create='true'
+          >
+            Add role
+          </ToolbarSecretLink>
+        {{/if}}
+        {{#if @model.canEdit}}
+          <ToolbarSecretLink @secret={{@model.id}} @mode='edit' @data-test-edit-link='true' @replace='true'>
+            Edit configuration
+          </ToolbarSecretLink>
+        {{/if}}
+      </ToolbarActions>
+    </Toolbar>
+  {{/if}}
 {{/if}}
 
 {{#if (eq @mode 'create')}}
@@ -88,43 +89,48 @@
       {{/if}}
     {{/each}}
 
-    {{!-- Plugin Config Section --}}
-    <div class="form-section box is-shadowless is-fullwidth">
-      <fieldset class="form-fieldset">
-        <legend class="title is-5">Plugin config</legend>
+    {{! Plugin Config Section }}
+    <div class='form-section box is-shadowless is-fullwidth'>
+      <fieldset class='form-fieldset'>
+        <legend class='title is-5'>Plugin config</legend>
         {{#unless @model.pluginFieldGroups}}
           <EmptyState
-            @title="No plugin selected"
-            @message="Select a plugin type to be able to configure it."
+            @title='No plugin selected'
+            @message='Select a plugin type to be able to configure it.'
           />
         {{else}}
           {{#each @model.pluginFieldGroups as |fieldGroup|}}
             {{#each-in fieldGroup as |group fields|}}
-              {{#if (eq group "default")}}
-                <div class="columns is-desktop is-multiline">
-                {{#each fields as |attr|}}
-                  {{#if (contains
-                    attr.name
-                    (array
-                      "max_open_connections"
-                      "max_idle_connections"
-                      "max_connection_lifetime"
-                    )
-                  )}}
-                    <div class="column is-one-third">
-                      {{form-field data-test-field attr=attr model=@model}}
-                    </div>
-                  {{else}}
-                    <div class="column is-full">
-                      {{form-field data-test-field attr=attr model=@model}}
-                    </div>
-                  {{/if}}
-                {{/each}}
+              {{#if (eq group 'default')}}
+                <div class='columns is-desktop is-multiline'>
+                  {{#each fields as |attr|}}
+                    {{#if
+                      (contains
+                        attr.name
+                        (array 'max_open_connections' 'max_idle_connections' 'max_connection_lifetime')
+                      )
+                    }}
+                      <div class='column is-one-third'>
+                        {{form-field data-test-field attr=attr model=@model}}
+                      </div>
+                    {{else}}
+                      <div class='column is-full'>
+                        {{form-field data-test-field attr=attr model=@model}}
+                      </div>
+                    {{/if}}
+                  {{/each}}
                 </div>
               {{else}}
-                <ToggleButton @class="is-block" @toggleAttr={{concat "show" (camelize group)}} @toggleTarget={{this}} @openLabel={{concat "Hide " group}} @closedLabel={{group}} @data-test-toggle-group={{group}} />
-                {{#if (get this (concat "show" (camelize group)))}}
-                  <div class="box is-marginless">
+                <ToggleButton
+                  @class='is-block'
+                  @toggleAttr={{concat 'show' (camelize group)}}
+                  @toggleTarget={{this}}
+                  @openLabel={{concat 'Hide ' group}}
+                  @closedLabel={{group}}
+                  @data-test-toggle-group={{group}}
+                />
+                {{#if (get this (concat 'show' (camelize group)))}}
+                  <div class='box is-marginless'>
                     {{#each fields as |attr|}}
                       {{form-field data-test-field attr=attr model=@model}}
                     {{/each}}
@@ -137,14 +143,14 @@
       </fieldset>
     </div>
 
-    {{!-- Statements Section --}}
+    {{! Statements Section }}
     {{#unless (and @model.plugin_name (not @model.statementFields))}}
-      <div class="form-section box is-shadowless is-fullwidth">
-        <h3 class="title is-5">Statements</h3>
+      <div class='form-section box is-shadowless is-fullwidth'>
+        <h3 class='title is-5'>Statements</h3>
         {{#if (eq @model.statementFields null)}}
           <EmptyState
-            @title="No plugin selected"
-            @message="Select a plugin type to be able to configure it."
+            @title='No plugin selected'
+            @message='Select a plugin type to be able to configure it.'
           />
         {{else}}
           {{#each @model.statementFields as |attr|}}
@@ -154,27 +160,22 @@
       </div>
     {{/unless}}
 
-    <div class="field is-grouped is-grouped-split is-fullwidth box is-bottomless">
-      <div class="field is-grouped">
-        <div class="control">
-          <button
-            data-test-secret-save
-            type="submit"
-            disabled={{buttonDisabled}}
-            class="button is-primary"
-          >
+    <div class='field is-grouped is-grouped-split is-fullwidth box is-bottomless'>
+      <div class='field is-grouped'>
+        <div class='control'>
+          <button data-test-secret-save type='submit' disabled={{buttonDisabled}} class='button is-primary'>
             Create database
           </button>
         </div>
-        <div class="control">
-          <SecretLink @mode="list" @class="button">
+        <div class='control'>
+          <SecretLink @mode='list' @class='button'>
             Cancel
           </SecretLink>
         </div>
       </div>
     </div>
   </form>
-{{else if (eq @mode 'edit')}}
+{{else if (and (eq @mode 'edit') @model.isAvailablePlugin)}}
   <form {{on 'submit' this.handleUpdateConnection}}>
     {{#each @model.fieldAttrs as |attr|}}
       {{#if (or (eq attr.name 'name') (eq attr.name 'plugin_name'))}}
@@ -184,69 +185,79 @@
       {{/if}}
     {{/each}}
 
-    {{!-- Plugin Config Edit --}}
-    <div class="form-section box is-shadowless is-fullwidth">
-      <fieldset class="form-fieldset">
-        <legend class="title is-5">Plugin config</legend>
+    {{! Plugin Config Edit }}
+    <div class='form-section box is-shadowless is-fullwidth'>
+      <fieldset class='form-fieldset'>
+        <legend class='title is-5'>Plugin config</legend>
         {{#each @model.pluginFieldGroups as |fieldGroup|}}
           {{#each-in fieldGroup as |group fields|}}
-            {{#if (eq group "default")}}
-              <div class="columns is-desktop is-multiline">
+            {{#if (eq group 'default')}}
+              <div class='columns is-desktop is-multiline'>
                 {{#each fields as |attr|}}
-                  {{#if (contains
-                    attr.name
-                    (array
-                      "max_open_connections"
-                      "max_idle_connections"
-                      "max_connection_lifetime"
+                  {{#if
+                    (contains
+                      attr.name
+                      (array 'max_open_connections' 'max_idle_connections' 'max_connection_lifetime')
                     )
-                  )}}
-                    <div class="column is-one-third">
+                  }}
+                    <div class='column is-one-third'>
                       {{form-field data-test-field attr=attr model=@model}}
                     </div>
-                  {{else if (eq attr.name "password")}}
-                    <div class="column is-full">
-                      <label for="{{attr.name}}" class="is-label">
+                  {{else if (eq attr.name 'password')}}
+                    <div class='column is-full'>
+                      <label for='{{attr.name}}' class='is-label'>
                         {{capitalize (or attr.options.label attr.name)}}
                       </label>
-                      <div class="field">
+                      <div class='field'>
                         <Toggle
-                          @name="show-{{attr.name}}"
-                          @status="success"
-                          @size="small"
+                          @name='show-{{attr.name}}'
+                          @status='success'
+                          @size='small'
                           @onChange={{fn this.updateShowPassword (not this.showPasswordField)}}
                           @checked={{this.showPasswordField}}
                           data-test-toggle={{attr.name}}
                         >
-                          <span class="ttl-picker-label has-text-grey">Update password</span><br/>
-                          <div class="description has-text-grey">
-                            <span>{{if this.showPasswordField 'The new password that will be used when connecting to the database' 'Vault will use the existing password'}}</span>
+                          <span class='ttl-picker-label has-text-grey'>Update password</span><br />
+                          <div class='description has-text-grey'>
+                            <span>{{if
+                                this.showPasswordField
+                                'The new password that will be used when connecting to the database'
+                                'Vault will use the existing password'
+                              }}</span>
                           </div>
                           {{#if this.showPasswordField}}
                             <Input
-                              {{on "change" (fn this.updatePassword attr.name)}}
-                              @type="password"
+                              {{on 'change' (fn this.updatePassword attr.name)}}
+                              @type='password'
                               @value={{get @model attr.name}}
                               @name={{attr.name}}
-                              class="input"
-                              {{!-- Prevents browsers from auto-filling --}}
-                              @autocomplete="new-password"
-                              @spellcheck="false" />
+                              class='input'
+                              {{! Prevents browsers from auto-filling }}
+                              @autocomplete='new-password'
+                              @spellcheck='false'
+                            />
                           {{/if}}
                         </Toggle>
                       </div>
                     </div>
                   {{else}}
-                    <div class="column is-full">
+                    <div class='column is-full'>
                       {{form-field data-test-field attr=attr model=@model}}
                     </div>
                   {{/if}}
                 {{/each}}
               </div>
             {{else}}
-              <ToggleButton @class="is-block" @toggleAttr={{concat "show" (camelize group)}} @toggleTarget={{this}} @openLabel={{concat "Hide " group}} @closedLabel={{group}} @data-test-toggle-group={{group}} />
-              {{#if (get this (concat "show" (camelize group)))}}
-                <div class="box is-marginless">
+              <ToggleButton
+                @class='is-block'
+                @toggleAttr={{concat 'show' (camelize group)}}
+                @toggleTarget={{this}}
+                @openLabel={{concat 'Hide ' group}}
+                @closedLabel={{group}}
+                @data-test-toggle-group={{group}}
+              />
+              {{#if (get this (concat 'show' (camelize group)))}}
+                <div class='box is-marginless'>
                   {{#each fields as |attr|}}
                     {{form-field data-test-field attr=attr model=@model}}
                   {{/each}}
@@ -258,11 +269,11 @@
       </fieldset>
     </div>
 
-    {{!-- Statements Edit Section --}}
+    {{! Statements Edit Section }}
     {{#unless (and @model.plugin_name (not @model.statementFields))}}
-      <div class="form-section box is-shadowless is-fullwidth">
-        <fieldset class="form-fieldset">
-          <legend class="title is-5">Statements</legend>
+      <div class='form-section box is-shadowless is-fullwidth'>
+        <fieldset class='form-fieldset'>
+          <legend class='title is-5'>Statements</legend>
           {{#each @model.statementFields as |attr|}}
             {{form-field data-test-field attr=attr model=@model}}
           {{/each}}
@@ -270,44 +281,57 @@
       </div>
     {{/unless}}
 
-    <div class="field is-grouped is-grouped-split is-fullwidth box is-bottomless">
-      <div class="field is-grouped">
-        <div class="control">
-          <button
-            data-test-secret-save
-            type="submit"
-            disabled={{buttonDisabled}}
-            class="button is-primary"
-          >
+    <div class='field is-grouped is-grouped-split is-fullwidth box is-bottomless'>
+      <div class='field is-grouped'>
+        <div class='control'>
+          <button data-test-secret-save type='submit' disabled={{buttonDisabled}} class='button is-primary'>
             Save
           </button>
         </div>
-        <div class="control">
-          <SecretLink @mode="list" @class="button">
+        <div class='control'>
+          <SecretLink @mode='list' @class='button'>
             Cancel
           </SecretLink>
         </div>
       </div>
     </div>
   </form>
+{{else if (eq @model.isAvailablePlugin false)}}
+  <EmptyState
+    @title='Database type unavailable'
+    @subTitle='Not supported in the UI'
+    @icon='disabled'
+    @message='This database type cannot be viewed in the UI. You will have to use the API or CLI to perform actions here.'
+    @bottomBorder={{true}}
+  >
+    <LinkTo @route='vault.cluster.secrets.backend.list-root' class='link'>
+      <Chevron @direction='left' />
+      Go back
+    </LinkTo>
+    <a
+      href='https://www.vaultproject.io/api/secret/databases'
+      target='_blank'
+      rel='noreferrer noopener'
+    >Documentation</a>
+  </EmptyState>
 {{else}}
   {{#each @model.showAttrs as |attr|}}
     {{#let attr.options.defaultDisplay as |defaultDisplay|}}
-      {{#if (eq attr.type "object")}}
+      {{#if (eq attr.type 'object')}}
         <InfoTableRow
           @alwaysRender={{true}}
           @defaultShown={{attr.options.defaultShown}}
           @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}}
           @value={{stringify (get @model attr.name)}}
         />
-      {{else if (eq attr.type "array")}}
+      {{else if (eq attr.type 'array')}}
         <InfoTableRow
           @alwaysRender={{true}}
           @defaultShown={{attr.options.defaultShown}}
           @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}}
           @value={{or (get @model attr.name) defaultDisplay}}
           @isLink={{true}}
-          @queryParam="role"
+          @queryParam='role'
           @type={{attr.type}}
         />
       {{else}}
@@ -323,28 +347,30 @@
 {{/if}}
 
 <Modal
-  @title="Rotate your root credentials?"
+  @title='Rotate your root credentials?'
   @onClose={{action 'continueWithoutRotate'}}
   @isActive={{this.showSaveModal}}
-  @type="info"
+  @type='info'
   @showCloseButton={{false}}
 >
-  <section class="modal-card-body">
-    <p class="has-bottom-margin-s">It’s best practice to rotate the root credential immediately after the initial configuration of each database. Once rotated, <strong>only Vault knows the new root password</strong>.</p>
+  <section class='modal-card-body'>
+    <p class='has-bottom-margin-s'>It’s best practice to rotate the root credential immediately after the
+      initial configuration of each database. Once rotated,
+      <strong>only Vault knows the new root password</strong>.</p>
     <p>Would you like to rotate your new credentials? You can also do this later.</p>
   </section>
-  <footer class="modal-card-foot modal-card-foot-outlined">
+  <footer class='modal-card-foot modal-card-foot-outlined'>
     <button
-      type="button"
-      class="button is-primary"
+      type='button'
+      class='button is-primary'
       {{on 'click' this.continueWithRotate}}
       data-test-enable-rotate-connection
     >
       Rotate and enable
     </button>
     <button
-      type="button"
-      class="button is-secondary"
+      type='button'
+      class='button is-secondary'
       {{on 'click' this.continueWithoutRotate}}
       data-test-enable-connection
     >


### PR DESCRIPTION
We had added this to 1.9 + but because folks are using databases like Postgres via the CLI/API in 1.8, and hitting the blank page error in the UI, I have taken this chunk of code from [this PR](https://github.com/hashicorp/vault/pull/12672/files) and I am adding the empty state to the 1.8 release. 

Note: We have decided not to support Postgres in 1.8 because of the significant changes made the DB engine during that time. Backporting that specific support would be a bit of a mess.

**With Fix:**
![image](https://user-images.githubusercontent.com/6618863/184988888-341935d9-7ea7-49a4-93b5-4b0a0861a939.png)

**Before:**
![image](https://user-images.githubusercontent.com/6618863/184988981-5455ca4e-4be4-4671-b562-d3cbbd32b60d.png)
