### PR TITLE
Enable periodic, automatic rebuilding of CRLs

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -395,6 +395,11 @@ func (b *backend) periodicFunc(ctx context.Context, request *logical.Request) er
 		return err
 	}
 
+	// Check if we're set to auto rebuild and a CRL is set to expire.
+	if err := b.crlBuilder.checkForAutoRebuild(sc); err != nil {
+		return err
+	}
+
 	// Then attempt to rebuild the CRLs if required.
 	if err := b.crlBuilder.rebuildIfForced(ctx, b, request); err != nil {
 		return err

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -8,8 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	atomic2 "go.uber.org/atomic"
-
 	"github.com/hashicorp/vault/sdk/helper/consts"
 
 	"github.com/armon/go-metrics"
@@ -176,7 +174,6 @@ func Backend(conf *logical.BackendConfig) *backend {
 		PeriodicFunc:   b.periodicFunc,
 	}
 
-	b.crlLifetime = time.Hour * 72
 	b.tidyCASGuard = new(uint32)
 	b.tidyStatus = &tidyStatus{state: tidyStatusInactive}
 	b.storage = conf.StorageView
@@ -184,8 +181,8 @@ func Backend(conf *logical.BackendConfig) *backend {
 
 	b.pkiStorageVersion.Store(0)
 
-	b.crlBuilder = &crlBuilder{}
-	b.isOcspDisabled = atomic2.NewBool(false)
+	b.crlBuilder = newCRLBuilder()
+
 	return &b
 }
 
@@ -206,9 +203,6 @@ type backend struct {
 
 	// Write lock around issuers and keys.
 	issuersLock sync.RWMutex
-
-	// Optimization to not read the CRL config on every OCSP request.
-	isOcspDisabled *atomic2.Bool
 }
 
 type (
@@ -305,8 +299,10 @@ func (b *backend) metricsWrap(callType string, roleMode int, ofunc roleOperation
 
 // initialize is used to perform a possible PKI storage migration if needed
 func (b *backend) initialize(ctx context.Context, _ *logical.InitializationRequest) error {
-	// load ocsp enabled status
-	setOcspStatus(b, ctx)
+	sc := b.makeStorageContext(ctx, b.storage)
+	if err := b.crlBuilder.reloadConfigIfRequired(sc); err != nil {
+		return err
+	}
 
 	// Grab the lock prior to the updating of the storage lock preventing us flipping
 	// the storage flag midway through the request stream of other requests.
@@ -331,14 +327,6 @@ func (b *backend) initialize(ctx context.Context, _ *logical.InitializationReque
 	b.updatePkiStorageVersion(ctx, false)
 
 	return nil
-}
-
-func setOcspStatus(b *backend, ctx context.Context) {
-	sc := b.makeStorageContext(ctx, b.storage)
-	config, err := sc.getRevocationConfig()
-	if config != nil && err == nil {
-		b.isOcspDisabled.Store(config.OcspDisable)
-	}
 }
 
 func (b *backend) useLegacyBundleCaStorage() bool {
@@ -396,10 +384,22 @@ func (b *backend) invalidate(ctx context.Context, key string) {
 		}
 	case key == "config/crl":
 		// We may need to reload our OCSP status flag
-		setOcspStatus(b, ctx)
+		b.crlBuilder.markConfigDirty()
 	}
 }
 
 func (b *backend) periodicFunc(ctx context.Context, request *logical.Request) error {
-	return b.crlBuilder.rebuildIfForced(ctx, b, request)
+	// First attempt to reload the CRL configuration.
+	sc := b.makeStorageContext(ctx, request.Storage)
+	if err := b.crlBuilder.reloadConfigIfRequired(sc); err != nil {
+		return err
+	}
+
+	// Then attempt to rebuild the CRLs if required.
+	if err := b.crlBuilder.rebuildIfForced(ctx, b, request); err != nil {
+		return err
+	}
+
+	// All good!
+	return nil
 }

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -13,6 +13,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	atomic2 "go.uber.org/atomic"
+
 	"github.com/hashicorp/vault/sdk/helper/consts"
 
 	"github.com/hashicorp/vault/sdk/helper/errutil"
@@ -33,15 +35,76 @@ type revocationInfo struct {
 // without the actual API calls. During the storage invalidation process, we do not have the required state
 // to actually rebuild the CRLs, so we need to schedule it in a deferred fashion. This allows either
 // read or write calls to perform the operation if required, or have the flag reset upon a write operation
+//
+// The CRL builder also tracks the revocation configuration.
 type crlBuilder struct {
 	m            sync.Mutex
 	forceRebuild uint32
+
+	c      sync.RWMutex
+	dirty  *atomic2.Bool
+	config crlConfig
 }
 
 const (
 	_ignoreForceFlag  = true
 	_enforceForceFlag = false
 )
+
+func newCRLBuilder() *crlBuilder {
+	return &crlBuilder{
+		dirty:  atomic2.NewBool(true),
+		config: defaultCrlConfig,
+	}
+}
+
+func (cb *crlBuilder) markConfigDirty() {
+	cb.dirty.Store(true)
+}
+
+func (cb *crlBuilder) reloadConfigIfRequired(sc *storageContext) error {
+	if cb.dirty.Load() {
+		// Acquire a write lock.
+		cb.c.Lock()
+		defer cb.c.Unlock()
+
+		config, err := sc.getRevocationConfig()
+		if err != nil {
+			return err
+		}
+
+		// Set the default config if none was returned to us.
+		if config != nil {
+			cb.config = *config
+		} else {
+			cb.config = defaultCrlConfig
+		}
+
+		// Updated the config; unset dirty.
+		cb.dirty.Store(false)
+	}
+
+	return nil
+}
+
+func (cb *crlBuilder) GetConfig() *crlConfig {
+	// Config may mutate immediately after accessing!
+	cb.c.RLock()
+	defer cb.c.RUnlock()
+
+	configCopy := cb.config
+	return &configCopy
+}
+
+func (cb *crlBuilder) GetConfigWithUpdate(sc *storageContext) (*crlConfig, error) {
+	// Config may mutate immediately after accessing, but will be freshly
+	// fetched if necessary.
+	if err := cb.reloadConfigIfRequired(sc); err != nil {
+		return nil, err
+	}
+
+	return cb.GetConfig(), nil
+}
 
 // rebuildIfForced is to be called by readers or periodic functions that might need to trigger
 // a refresh of the CRL before the read occurs.
@@ -238,10 +301,9 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 	// Fetch the config and see if we need to rebuild the CRL. If we have
 	// auto building enabled, we will wait for the next rebuild period to
 	// actually rebuild it.
-	sc := b.makeStorageContext(ctx, req.Storage)
-	config, err := sc.getRevocationConfig()
+	config, err := b.crlBuilder.GetConfigWithUpdate(sc)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error building CRL: while updating config: %v", err)
 	}
 
 	if !config.AutoRebuild {
@@ -298,6 +360,13 @@ func buildCRLs(ctx context.Context, b *backend, req *logical.Request, forceNew b
 	var issuers []issuerID
 	var wasLegacy bool
 	sc := b.makeStorageContext(ctx, req.Storage)
+
+	// First, fetch an updated copy of the CRL config. We'll pass this into
+	// buildCRL.
+	globalCRLConfig, err := b.crlBuilder.GetConfigWithUpdate(sc)
+	if err != nil {
+		return fmt.Errorf("error building CRL: while updating config: %v", err)
+	}
 
 	if !b.useLegacyBundleCaStorage() {
 		issuers, err = sc.listIssuers()
@@ -427,7 +496,7 @@ func buildCRLs(ctx context.Context, b *backend, req *logical.Request, forceNew b
 			crlConfig.CRLNumberMap[crlIdentifier] += 1
 
 			// Lastly, build the CRL.
-			if err := buildCRL(sc, forceNew, representative, revokedCerts, crlIdentifier, crlNumber); err != nil {
+			if err := buildCRL(sc, globalCRLConfig, forceNew, representative, revokedCerts, crlIdentifier, crlNumber); err != nil {
 				return fmt.Errorf("error building CRLs: unable to build CRL for issuer (%v): %v", representative, err)
 			}
 		}
@@ -583,21 +652,12 @@ func getRevokedCertEntries(ctx context.Context, req *logical.Request, issuerIDCe
 
 // Builds a CRL by going through the list of revoked certificates and building
 // a new CRL with the stored revocation times and serial numbers.
-func buildCRL(sc *storageContext, forceNew bool, thisIssuerId issuerID, revoked []pkix.RevokedCertificate, identifier crlID, crlNumber int64) error {
-	crlInfo, err := sc.getRevocationConfig()
-	if err != nil {
-		return errutil.InternalError{Err: fmt.Sprintf("error fetching CRL config information: %s", err)}
-	}
-
-	crlLifetime := sc.Backend.crlLifetime
+func buildCRL(sc *storageContext, crlInfo *crlConfig, forceNew bool, thisIssuerId issuerID, revoked []pkix.RevokedCertificate, identifier crlID, crlNumber int64) error {
 	var revokedCerts []pkix.RevokedCertificate
 
-	if crlInfo.Expiry != "" {
-		crlDur, err := time.ParseDuration(crlInfo.Expiry)
-		if err != nil {
-			return errutil.InternalError{Err: fmt.Sprintf("error parsing CRL duration of %s", crlInfo.Expiry)}
-		}
-		crlLifetime = crlDur
+	crlLifetime, err := time.ParseDuration(crlInfo.Expiry)
+	if err != nil {
+		return errutil.InternalError{Err: fmt.Sprintf("error parsing CRL duration of %s", crlInfo.Expiry)}
 	}
 
 	if crlInfo.Disable {

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -87,7 +87,7 @@ func (cb *crlBuilder) reloadConfigIfRequired(sc *storageContext) error {
 	return nil
 }
 
-func (cb *crlBuilder) GetConfig() *crlConfig {
+func (cb *crlBuilder) getConfig() *crlConfig {
 	// Config may mutate immediately after accessing!
 	cb.c.RLock()
 	defer cb.c.RUnlock()
@@ -96,14 +96,74 @@ func (cb *crlBuilder) GetConfig() *crlConfig {
 	return &configCopy
 }
 
-func (cb *crlBuilder) GetConfigWithUpdate(sc *storageContext) (*crlConfig, error) {
+func (cb *crlBuilder) getConfigWithUpdate(sc *storageContext) (*crlConfig, error) {
 	// Config may mutate immediately after accessing, but will be freshly
 	// fetched if necessary.
 	if err := cb.reloadConfigIfRequired(sc); err != nil {
 		return nil, err
 	}
 
-	return cb.GetConfig(), nil
+	return cb.getConfig(), nil
+}
+
+func (cb *crlBuilder) checkForAutoRebuild(sc *storageContext) error {
+	cfg := cb.getConfig()
+	if cfg.Disable || !cfg.AutoRebuild || atomic.LoadUint32(&cb.forceRebuild) == 1 {
+		// Not enabled, not on auto-rebuilder, or we're already scheduled to
+		// rebuild so there's no point to interrogate CRL values...
+		return nil
+	}
+
+	// Auto-Rebuild is enabled. We need to check each issuer's CRL and see
+	// if its about to expire. If it is, we've gotta rebuild it (and well,
+	// every other CRL since we don't have a fine-toothed rebuilder).
+	//
+	// We store a list of all (unique) CRLs in the cluster-local CRL
+	// configuration along with their expiration dates.
+    crlConfig, err := sc.getLocalCRLConfig()
+    if err != nil {
+        return fmt.Errorf("error checking for auto-rebuild status: unable to fetch cluster-local CRL configuration: %v", err)
+    }
+
+	// If there's no config, assume we've gotta rebuild it to get this
+	// information.
+	if crlConfig == nil {
+		atomic.CompareAndSwapUint32(&cb.forceRebuild, 0, 1)
+		return nil
+	}
+
+	// If the map is empty, assume we need to upgrade and schedule a
+	// rebuild.
+	if len(crlConfig.CRLExpirationMap) == 0 {
+		atomic.CompareAndSwapUint32(&cb.forceRebuild, 0, 1)
+		return nil
+	}
+
+	// Otherwise, check CRL's expirations and see if its zero or within
+	// the grace period and act accordingly.
+	now := time.Now()
+
+	period, err := time.ParseDuration(cfg.AutoRebuildGracePeriod)
+	if err != nil {
+		// This may occur if the duration is empty; in that case
+		// assume the default. The default should be valid and shouldn't
+		// error.
+		defaultPeriod, defaultErr := time.ParseDuration(defaultCrlConfig.AutoRebuildGracePeriod)
+		if defaultErr != nil {
+			return fmt.Errorf("error checking for auto-rebuild status: unable to parse duration from both config's grace period (%v) and default grace period (%v):\n- config: %v\n- default: %v\n", cfg.AutoRebuildGracePeriod, defaultCrlConfig.AutoRebuildGracePeriod, err, defaultErr)
+		}
+
+		period = defaultPeriod
+	}
+
+	for _, value := range crlConfig.CRLExpirationMap {
+		if value.IsZero() || now.After(value.Add(-1 * period)) {
+			atomic.CompareAndSwapUint32(&cb.forceRebuild, 0, 1)
+			return nil
+		}
+	}
+
+	return nil
 }
 
 // rebuildIfForced is to be called by readers or periodic functions that might need to trigger
@@ -301,7 +361,7 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 	// Fetch the config and see if we need to rebuild the CRL. If we have
 	// auto building enabled, we will wait for the next rebuild period to
 	// actually rebuild it.
-	config, err := b.crlBuilder.GetConfigWithUpdate(sc)
+	config, err := b.crlBuilder.getConfigWithUpdate(sc)
 	if err != nil {
 		return nil, fmt.Errorf("error building CRL: while updating config: %v", err)
 	}
@@ -363,7 +423,7 @@ func buildCRLs(ctx context.Context, b *backend, req *logical.Request, forceNew b
 
 	// First, fetch an updated copy of the CRL config. We'll pass this into
 	// buildCRL.
-	globalCRLConfig, err := b.crlBuilder.GetConfigWithUpdate(sc)
+	globalCRLConfig, err := b.crlBuilder.getConfigWithUpdate(sc)
 	if err != nil {
 		return fmt.Errorf("error building CRL: while updating config: %v", err)
 	}
@@ -496,9 +556,12 @@ func buildCRLs(ctx context.Context, b *backend, req *logical.Request, forceNew b
 			crlConfig.CRLNumberMap[crlIdentifier] += 1
 
 			// Lastly, build the CRL.
-			if err := buildCRL(sc, globalCRLConfig, forceNew, representative, revokedCerts, crlIdentifier, crlNumber); err != nil {
+			nextUpdate, err := buildCRL(sc, globalCRLConfig, forceNew, representative, revokedCerts, crlIdentifier, crlNumber)
+			if err != nil {
 				return fmt.Errorf("error building CRLs: unable to build CRL for issuer (%v): %v", representative, err)
 			}
+
+			crlConfig.CRLExpirationMap[crlIdentifier] = *nextUpdate
 		}
 	}
 
@@ -652,17 +715,19 @@ func getRevokedCertEntries(ctx context.Context, req *logical.Request, issuerIDCe
 
 // Builds a CRL by going through the list of revoked certificates and building
 // a new CRL with the stored revocation times and serial numbers.
-func buildCRL(sc *storageContext, crlInfo *crlConfig, forceNew bool, thisIssuerId issuerID, revoked []pkix.RevokedCertificate, identifier crlID, crlNumber int64) error {
+func buildCRL(sc *storageContext, crlInfo *crlConfig, forceNew bool, thisIssuerId issuerID, revoked []pkix.RevokedCertificate, identifier crlID, crlNumber int64) (*time.Time, error) {
 	var revokedCerts []pkix.RevokedCertificate
 
 	crlLifetime, err := time.ParseDuration(crlInfo.Expiry)
 	if err != nil {
-		return errutil.InternalError{Err: fmt.Sprintf("error parsing CRL duration of %s", crlInfo.Expiry)}
+		return nil, errutil.InternalError{Err: fmt.Sprintf("error parsing CRL duration of %s", crlInfo.Expiry)}
 	}
 
 	if crlInfo.Disable {
 		if !forceNew {
-			return nil
+			// In the event of a disabled CRL, we'll have the next time set
+			// to the zero time as a sentinel in case we get re-enabled.
+			return &time.Time{}, nil
 		}
 
 		// NOTE: in this case, the passed argument (revoked) is not added
@@ -681,23 +746,26 @@ WRITE:
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:
-			return errutil.UserError{Err: fmt.Sprintf("could not fetch the CA certificate: %s", caErr)}
+			return nil, errutil.UserError{Err: fmt.Sprintf("could not fetch the CA certificate: %s", caErr)}
 		default:
-			return errutil.InternalError{Err: fmt.Sprintf("error fetching CA certificate: %s", caErr)}
+			return nil, errutil.InternalError{Err: fmt.Sprintf("error fetching CA certificate: %s", caErr)}
 		}
 	}
+
+	now := time.Now()
+	nextUpdate := now.Add(crlLifetime)
 
 	revocationListTemplate := &x509.RevocationList{
 		RevokedCertificates: revokedCerts,
 		Number:              big.NewInt(crlNumber),
-		ThisUpdate:          time.Now(),
-		NextUpdate:          time.Now().Add(crlLifetime),
+		ThisUpdate:          now,
+		NextUpdate:          nextUpdate,
 		SignatureAlgorithm:  signingBundle.RevocationSigAlg,
 	}
 
 	crlBytes, err := x509.CreateRevocationList(rand.Reader, revocationListTemplate, signingBundle.Certificate, signingBundle.PrivateKey)
 	if err != nil {
-		return errutil.InternalError{Err: fmt.Sprintf("error creating new CRL: %s", err)}
+		return nil, errutil.InternalError{Err: fmt.Sprintf("error creating new CRL: %s", err)}
 	}
 
 	writePath := "crls/" + identifier.String()
@@ -712,8 +780,8 @@ WRITE:
 		Value: crlBytes,
 	})
 	if err != nil {
-		return errutil.InternalError{Err: fmt.Sprintf("error storing CRL: %s", err)}
+		return nil, errutil.InternalError{Err: fmt.Sprintf("error storing CRL: %s", err)}
 	}
 
-	return nil
+	return &nextUpdate, nil
 }

--- a/builtin/logical/pki/ocsp.go
+++ b/builtin/logical/pki/ocsp.go
@@ -96,7 +96,7 @@ func buildPathOcspPost(b *backend) *framework.Path {
 }
 
 func (b *backend) ocspHandler(ctx context.Context, request *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	if b.crlBuilder.GetConfig().OcspDisable {
+	if b.crlBuilder.getConfig().OcspDisable {
 		return OcspUnauthorizedResponse, nil
 	}
 

--- a/builtin/logical/pki/ocsp.go
+++ b/builtin/logical/pki/ocsp.go
@@ -96,7 +96,7 @@ func buildPathOcspPost(b *backend) *framework.Path {
 }
 
 func (b *backend) ocspHandler(ctx context.Context, request *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	if b.isOcspDisabled.Load() {
+	if b.crlBuilder.GetConfig().OcspDisable {
 		return OcspUnauthorizedResponse, nil
 	}
 

--- a/builtin/logical/pki/path_config_crl.go
+++ b/builtin/logical/pki/path_config_crl.go
@@ -16,7 +16,7 @@ type crlConfig struct {
 	Disable     bool   `json:"disable"`
 	OcspDisable bool   `json:"ocsp_disable"`
 	AutoRebuild bool `json:"auto_rebuild"`
-	AutoRebuildGracePeriod time.Duration `json:"auto_rebuild_grace_period"`
+	AutoRebuildGracePeriod string `json:"auto_rebuild_grace_period"`
 }
 
 func pathConfigCRL(b *backend) *framework.Path {
@@ -39,7 +39,7 @@ valid; defaults to 72 hours`,
 			},
 			"auto_rebuild": {
 				Type: framework.TypeBool,
-				Description: `If set to true, enables automatic rebuilding of the CRL`
+				Description: `If set to true, enables automatic rebuilding of the CRL`,
 			},
 			"auto_rebuild_grace_period": {
 				Type: framework.TypeDurationSecond,
@@ -148,7 +148,7 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 		gracePeriod, _ := time.ParseDuration(config.AutoRebuildGracePeriod)
 
 		if gracePeriod >= expiry {
-			return logical.ErrorResponse(fmt.Sprintf("CRL auto-rebuilding grace period (%v) must be strictly shorter than CRL expiry (%v) value when auto-rebuilding of CRLs is enabled", config.AutoRebuildGracePeriod, config.Expiry))
+			return logical.ErrorResponse(fmt.Sprintf("CRL auto-rebuilding grace period (%v) must be strictly shorter than CRL expiry (%v) value when auto-rebuilding of CRLs is enabled", config.AutoRebuildGracePeriod, config.Expiry)), nil
 		}
 	}
 

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -232,7 +232,7 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 					sc := b.makeStorageContext(ctx, req.Storage)
 					config, err := sc.getRevocationConfig()
 					if err != nil {
-						return nil, err
+						return err
 					}
 
 					if !config.AutoRebuild {

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -225,8 +225,20 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 				}
 
 				if rebuildCRL {
-					if err := b.crlBuilder.rebuild(ctx, b, req, false); err != nil {
-						return err
+					// Expired certificates isn't generally an important
+					// reason to trigger a CRL rebuild for. Check if
+					// automatic CRL rebuilds have been enabled and defer
+					// the rebuild if so.
+					sc := b.makeStorageContext(ctx, req.Storage)
+					config, err := sc.getRevocationConfig()
+					if err != nil {
+						return nil, err
+					}
+
+					if !config.AutoRebuild {
+						if err := b.crlBuilder.rebuild(ctx, b, req, false); err != nil {
+							return err
+						}
 					}
 				}
 			}

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
@@ -155,8 +156,9 @@ type issuerEntry struct {
 }
 
 type localCRLConfigEntry struct {
-	IssuerIDCRLMap map[issuerID]crlID `json:"issuer_id_crl_map"`
-	CRLNumberMap   map[crlID]int64    `json:"crl_number_map"`
+	IssuerIDCRLMap   map[issuerID]crlID  `json:"issuer_id_crl_map"`
+	CRLNumberMap     map[crlID]int64     `json:"crl_number_map"`
+	CRLExpirationMap map[crlID]time.Time `json:"crl_expiration_map"`
 }
 
 type keyConfigEntry struct {
@@ -783,6 +785,10 @@ func (sc *storageContext) getLocalCRLConfig() (*localCRLConfigEntry, error) {
 
 	if len(mapping.CRLNumberMap) == 0 {
 		mapping.CRLNumberMap = make(map[crlID]int64)
+	}
+
+	if len(mapping.CRLExpirationMap) == 0 {
+		mapping.CRLExpirationMap = make(map[crlID]time.Time)
 	}
 
 	return mapping, nil


### PR DESCRIPTION
This enables automatic, periodic rebuilding of CRLs. When periodic rebuilding of CRLs is enabled, we'll decline to rebuild the CRL on every revocation and instead wait until the next update (or some precipitating event -- revocation of an issuer, manual rebuild, &c). This ensures that there's not a lot of load on the CRL building nodes (also allowing "batch" revocations as a side effect) between expected CRL updates. This also fixes a long-standing bug, wherein the CRL would expire but if an operator does not issue a new revocation (or does not manually trigger a rebuild), we'd let the CRL lapse.

---

- [ ] Rebase on #16723 
- [ ] Tests
- [ ] Docs
- [ ] Changelog entry
