### PR TITLE
fix scopes and clients tests

### DIFF
--- a/ui/tests/acceptance/oidc-config/clients-test.js
+++ b/ui/tests/acceptance/oidc-config/clients-test.js
@@ -47,9 +47,7 @@ module('Acceptance | oidc-config/clients', function (hooks) {
 
   test('it renders empty state when no clients are configured', async function (assert) {
     assert.expect(5);
-
-    //* clear out test state
-    await clearRecord(this.store, 'oidc/client', 'some-app');
+    this.server.get('/identity/oidc/client', () => overrideMirageResponse(404));
 
     await visit(OIDC_BASE_URL);
     assert.equal(currentURL(), '/vault/access/oidc');
@@ -71,9 +69,8 @@ module('Acceptance | oidc-config/clients', function (hooks) {
     //* clear out test state
     await clearRecord(this.store, 'oidc/client', 'some-app');
 
-    await visit(OIDC_BASE_URL);
+    await visit(OIDC_BASE_URL+'/clients/create');
     // create a new application
-    await click(SELECTORS.oidcClientCreateButton);
     assert.equal(currentRouteName(), 'vault.cluster.access.oidc.clients.create', 'navigates to create form');
     await fillIn('[data-test-input="name"]', 'some-app');
     await click('[data-test-toggle-group="More options"]');

--- a/ui/tests/acceptance/oidc-config/scopes-test.js
+++ b/ui/tests/acceptance/oidc-config/scopes-test.js
@@ -9,6 +9,9 @@ import logout from 'vault/tests/pages/logout';
 import { create } from 'ember-cli-page-object';
 import fm from 'vault/tests/pages/components/flash-message';
 const flashMessage = create(fm);
+import {
+  clearRecord,
+} from '../../helpers/oidc-config';
 const SCOPES_URL = OIDC_BASE_URL.concat('/scopes');
 
 module('Acceptance | oidc-config/scopes', function (hooks) {
@@ -34,6 +37,9 @@ module('Acceptance | oidc-config/scopes', function (hooks) {
 
   test('it renders empty state when no scopes are configured', async function (assert) {
     assert.expect(2);
+    //* clear out test state
+    await clearRecord(this.store, 'oidc/scope', 'test-scope');
+
     await visit(SCOPES_URL);
     assert.equal(currentURL(), '/vault/access/oidc/scopes');
 
@@ -48,6 +54,10 @@ module('Acceptance | oidc-config/scopes', function (hooks) {
 
   test('it creates a scope from empty state create scope button', async function (assert) {
     assert.expect(3);
+
+    //* clear out test state
+    await clearRecord(this.store, 'oidc/scope', 'test-scope');
+    
     await visit(SCOPES_URL);
     // create a new scope
     await click(SELECTORS.scopeCreateButtonEmptyState);
@@ -72,6 +82,10 @@ module('Acceptance | oidc-config/scopes', function (hooks) {
 
   test('it creates, updates and deletes a scope', async function (assert) {
     assert.expect(11);
+
+    //* clear out test state
+    await clearRecord(this.store, 'oidc/scope', 'test-scope');
+
     await visit(SCOPES_URL);
     // create a new scope
     await click(SELECTORS.scopeCreateButton);
@@ -133,6 +147,9 @@ module('Acceptance | oidc-config/scopes', function (hooks) {
       'vault.cluster.access.oidc.scopes.index',
       'navigates back to list view after delete'
     );
+
+    //* clear out test state
+    await clearRecord(this.store, 'oidc/scope', 'test-scope');
   });
 
   test('it renders scope list when scopes exist', async function (assert) {

--- a/ui/tests/helpers/oidc-config.js
+++ b/ui/tests/helpers/oidc-config.js
@@ -38,8 +38,8 @@ export function overrideMirageResponse(httpStatus, data) {
       JSON.stringify({ errors: ['permission denied'] })
     );
   }
-  if (httpStatus === 204) {
-    return new Response(204, { 'Content-Type': 'application/json' });
+  if (httpStatus === 404) {
+    return new Response(404, { 'Content-Type': 'application/json' });
   }
   if (httpStatus === 200) {
     return new Response(200, { 'Content-Type': 'application/json' }, JSON.stringify(data));
@@ -114,4 +114,23 @@ export const CLIENT_DATA_RESPONSE = {
   id_token_ttl: 0,
   key: 'default',
   redirect_uris: [],
+};
+
+export const SCOPE_LIST_RESPONSE = {
+  keys: ['test-scope'],
+};
+
+export const SCOPE_DATA_RESPONSE = {
+  description: 'this is a test',
+  template: '{ test }',
+};
+
+export const PROVIDER_LIST_RESPONSE = {
+  keys: ['test-provider'],
+};
+
+export const PROVIDER_DATA_RESPONSE = {
+  allowed_client_ids: ['*'],
+  issuer: '',
+  scopes_supported: ['test-scope'],
 };


### PR DESCRIPTION
Fixed the scopes and clients acceptance tests that failed when rerunning them. This is because the failing tests required an empty state but there was data left from previous test in the file `ui/tests/acceptance/oidc-provider-test.js` that were populating the LIST views and they were not being deleted. This PR did not delete the data created from the `oidc-provider-test.js` tests as it only overwrote the LIST API call to return an empty state but in the future could look into deleting the data created from that test. 