### PR TITLE
Fixing flaky "oidc auth method" tests

### DIFF
--- a/ui/tests/acceptance/oidc-auth-method-test.js
+++ b/ui/tests/acceptance/oidc-auth-method-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { click, visit, fillIn } from '@ember/test-helpers';
+import { click, fillIn, find, waitUntil } from '@ember/test-helpers';
+import authPage from 'vault/tests/pages/auth';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { fakeWindow, buildMessage } from '../helpers/oidc-window-stub';
 import sinon from 'sinon';
@@ -25,20 +26,20 @@ module('Acceptance | oidc auth method', function (hooks) {
     this.openStub.restore();
   });
 
-  const login = async (select) => {
-    await visit('/vault/auth');
-    // select from dropdown or click auth path tab
-    if (select) {
-      await fillIn('[data-test-select="auth-method"]', 'oidc');
-    } else {
-      await click('[data-test-auth-method-link="oidc"]');
-    }
-    later(() => {
-      window.postMessage(buildMessage().data, window.origin);
-      cancelTimers();
-    }, 50);
-    await click('[data-test-auth-submit]');
-  };
+  // const login = async (select) => {
+  //   authPage.logout();
+  //   // select from dropdown or click auth path tab
+  //   if (select) {
+  //     await fillIn('[data-test-select="auth-method"]', 'oidc');
+  //   } else {
+  //     await click('[data-test-auth-method-link="oidc"]');
+  //   }
+  //   later(() => {
+  //     window.postMessage(buildMessage().data, window.origin);
+  //     cancelTimers();
+  //   }, 50);
+  //   await click('[data-test-auth-submit]');
+  // };
 
   test('it should login with oidc when selected from auth methods dropdown', async function (assert) {
     assert.expect(1);
@@ -47,8 +48,16 @@ module('Acceptance | oidc auth method', function (hooks) {
       assert.ok(true, 'request made to auth/token/lookup-self after oidc callback');
       req.passthrough();
     });
-
-    await login(true);
+    // make sure you're logged out before trying to login.
+    authPage.logout();
+    // select from dropdown or click auth path tab
+    await waitUntil(() => find('[data-test-select="auth-method"]'));
+    await fillIn('[data-test-select="auth-method"]', 'oidc');
+    later(() => {
+      window.postMessage(buildMessage().data, window.origin);
+      cancelTimers();
+    }, 50);
+    await click('[data-test-auth-submit]');
   });
 
   test('it should login with oidc from listed auth mount tab', async function (assert) {
@@ -74,12 +83,30 @@ module('Acceptance | oidc auth method', function (hooks) {
       assert.ok(true, 'request made to auth/token/lookup-self after oidc callback');
       req.passthrough();
     });
-    await login();
+
+    authPage.logout();
+    // select from dropdown or click auth path tab
+    await waitUntil(() => find('[data-test-auth-method-link="oidc"]'));
+    await click('[data-test-auth-method-link="oidc"]');
+    later(() => {
+      window.postMessage(buildMessage().data, window.origin);
+      cancelTimers();
+    }, 50);
+    await click('[data-test-auth-submit]');
   });
 
   // coverage for bug where token was selected as auth method for oidc and jwt
   test('it should populate oidc auth method on logout', async function (assert) {
-    await login(true);
+    // make sure you're logged out before trying to login.
+    authPage.logout();
+    // select from dropdown or click auth path tab
+    await waitUntil(() => find('[data-test-select="auth-method"]'));
+    await fillIn('[data-test-select="auth-method"]', 'oidc');
+    later(() => {
+      window.postMessage(buildMessage().data, window.origin);
+      cancelTimers();
+    }, 50);
+    await click('[data-test-auth-submit]');
     await click('.nav-user-button button');
     await click('#logout');
     assert

--- a/ui/tests/acceptance/oidc-auth-method-test.js
+++ b/ui/tests/acceptance/oidc-auth-method-test.js
@@ -22,24 +22,10 @@ module('Acceptance | oidc auth method', function (hooks) {
     // ensure clean state
     localStorage.removeItem('selectedAuth');
   });
+
   hooks.afterEach(function () {
     this.openStub.restore();
   });
-
-  // const login = async (select) => {
-  //   authPage.logout();
-  //   // select from dropdown or click auth path tab
-  //   if (select) {
-  //     await fillIn('[data-test-select="auth-method"]', 'oidc');
-  //   } else {
-  //     await click('[data-test-auth-method-link="oidc"]');
-  //   }
-  //   later(() => {
-  //     window.postMessage(buildMessage().data, window.origin);
-  //     cancelTimers();
-  //   }, 50);
-  //   await click('[data-test-auth-submit]');
-  // };
 
   test('it should login with oidc when selected from auth methods dropdown', async function (assert) {
     assert.expect(1);

--- a/ui/tests/acceptance/oidc-auth-method-test.js
+++ b/ui/tests/acceptance/oidc-auth-method-test.js
@@ -34,7 +34,6 @@ module('Acceptance | oidc auth method', function (hooks) {
       assert.ok(true, 'request made to auth/token/lookup-self after oidc callback');
       req.passthrough();
     });
-    // make sure you're logged out before trying to login.
     authPage.logout();
     // select from dropdown or click auth path tab
     await waitUntil(() => find('[data-test-select="auth-method"]'));
@@ -83,7 +82,6 @@ module('Acceptance | oidc auth method', function (hooks) {
 
   // coverage for bug where token was selected as auth method for oidc and jwt
   test('it should populate oidc auth method on logout', async function (assert) {
-    // make sure you're logged out before trying to login.
     authPage.logout();
     // select from dropdown or click auth path tab
     await waitUntil(() => find('[data-test-select="auth-method"]'));


### PR DESCRIPTION
It appears to be an issue with having the login async function outside of the tests. I tried adding the `waitUntil` inside the login function, but that wasn't enough. I had to remove the function entirely and add the chunks to the individual tests and add the waitUntils.

To reproduce the earlier failure, just run this test suite more than once. I have tested with this fix and it longer fails after running several times in a row 🎉.
