### PR TITLE
Setting upload url explicitly empty

### DIFF
--- a/builtin/credential/github/backend.go
+++ b/builtin/credential/github/backend.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/google/go-github/github"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
@@ -69,7 +70,14 @@ func (b *backend) Client(token string) (*github.Client, error) {
 		tc = oauth2.NewClient(ctx, &tokenSource{Value: token})
 	}
 
-	return github.NewClient(tc), nil
+	client := github.NewClient(tc)
+	emptyUrl, err := url.Parse("")
+	if err != nil {
+		return nil, err
+	}
+	client.UploadURL = emptyUrl
+
+	return client, nil
 }
 
 // tokenSource is an oauth2.TokenSource implementation.


### PR DESCRIPTION
Security recommendation; disabling the upload url which is currently unused and unconfigurable will not impair the functionality of the plugin but limit the odds of introducing a potential vulnerability if a code path ever uses the default url (uploadBaseURL  = "https://uploads.github.com/") by mistake

A helper method github.NewEnterpriseClient() was introduced to let urls be configured during the client's instantiation but using it would be breaking. Vault fallbacks on the default base URL (defaultBaseURL = "https://api.github.com/") if the base_url argument is not provided when configuring the github plugin. 