### PR TITLE
Add Multi-Host Connection String info to Postgres secrets API docs

### DIFF
--- a/website/content/api-docs/secret/databases/postgresql.mdx
+++ b/website/content/api-docs/secret/databases/postgresql.mdx
@@ -120,10 +120,11 @@ $ curl \
 
 ### Connection Strings with Multiple Hosts
 
-Postgres supports multiple hosts in the connection string, however there are some formatting rules
-attached when using this feature. Please refer to the ["Specifying Multiple Hosts" section of the
+Postgres supports multiple hosts in the connection string. An example use-case for this might be having
+Postgres set up with Replication Manager. However, there are some formatting rules to consider when using
+this feature. Please refer to the ["Specifying Multiple Hosts" section of the
 official Postgres documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
-for more information. 
+for more information. Below are two small examples.
 
 #### URI-format Multi-Host String:
 

--- a/website/content/api-docs/secret/databases/postgresql.mdx
+++ b/website/content/api-docs/secret/databases/postgresql.mdx
@@ -29,7 +29,9 @@ has a number of parameters to further configure a connection.
   parameters in the following format `{{field_name}}`. Certificate authentication
   can be used by setting `?sslinline=true` and giving the SSL credentials in the
   `sslrootcert`, `sslcert` and `sslkey` credentials. A templated connection URL
-  is required when using root credential rotation.
+  is required when using root credential rotation. This field supports both format
+  string types, URI and keyword/value. Both formats support multiple host connection
+  strings.
 
 - `max_open_connections` `(int: 4)` - Specifies the maximum number of open
   connections to the database.
@@ -78,13 +80,27 @@ has a number of parameters to further configure a connection.
 </details>
 </details>
 
-### Sample Payload
+### Sample Payload with URI-format Connection String
 
 ```json
 {
   "plugin_name": "postgresql-database-plugin",
   "allowed_roles": "readonly",
   "connection_url": "postgresql://{{username}}:{{password}}@localhost:5432/postgres",
+  "max_open_connections": 5,
+  "max_connection_lifetime": "5s",
+  "username": "username",
+  "password": "password"
+}
+```
+
+### Sample Payload with Keyword/Value-format Connection String
+
+```json
+{
+  "plugin_name": "postgresql-database-plugin",
+  "allowed_roles": "readonly",
+  "connection_url": "host=localhost port=5432 user={{username}} password={{password}}",
   "max_open_connections": 5,
   "max_connection_lifetime": "5s",
   "username": "username",
@@ -100,6 +116,29 @@ $ curl \
     --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/database/config/postgresql
+```
+
+### Multiple Hosts Connection Strings
+
+Postgres supports multiple hosts in the connection string, however there are some formatting rules
+attached when using this feature. Please refer to the ["Specifying Multiple Hosts" section of the
+official Postgres documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
+for more information. 
+
+### Multiple Hosts URI-format Connection String
+
+```json
+{
+  "connection_url": "postgresql://{{username}}:{{password}}@hostone:5432,hosttwo:5432,hostthree:9999/postgres"
+}
+```
+
+### Multiple Hosts Keyword/Value-format Connection String
+
+```json
+{
+  "connection_url": "host=hostone,hosttwo,hostthree port=5432,5432,9999 user={{username}} password={{password}} dbname=postgres"
+}
 ```
 
 ## Statements

--- a/website/content/api-docs/secret/databases/postgresql.mdx
+++ b/website/content/api-docs/secret/databases/postgresql.mdx
@@ -118,14 +118,14 @@ $ curl \
     http://127.0.0.1:8200/v1/database/config/postgresql
 ```
 
-### Multiple Hosts Connection Strings
+### Connection Strings with Multiple Hosts
 
 Postgres supports multiple hosts in the connection string, however there are some formatting rules
 attached when using this feature. Please refer to the ["Specifying Multiple Hosts" section of the
 official Postgres documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
 for more information. 
 
-### Multiple Hosts URI-format Connection String
+#### URI-format Multi-Host String:
 
 ```json
 {
@@ -133,7 +133,7 @@ for more information.
 }
 ```
 
-### Multiple Hosts Keyword/Value-format Connection String
+#### Keyword/Value-format Multi-Host String:
 
 ```json
 {

--- a/website/content/docs/secrets/databases/postgresql.mdx
+++ b/website/content/docs/secrets/databases/postgresql.mdx
@@ -32,7 +32,7 @@ options, including SSL options, can be found in the [pgx][pgxlib] and
 
 1.  Enable the database secrets engine if it is not already enabled:
 
-    ```text
+    ```shell-session
     $ vault secrets enable database
     Success! Enabled the database secrets engine at: database/
     ```
@@ -42,9 +42,9 @@ options, including SSL options, can be found in the [pgx][pgxlib] and
 
 1.  Configure Vault with the proper plugin and connection information:
 
-    ```text
+    ```shell-session
     $ vault write database/config/my-postgresql-database \
-        plugin_name=postgresql-database-plugin \
+        plugin_name="postgresql-database-plugin" \
         allowed_roles="my-role" \
         connection_url="postgresql://{{username}}:{{password}}@localhost:5432/" \
         username="vaultuser" \
@@ -54,9 +54,9 @@ options, including SSL options, can be found in the [pgx][pgxlib] and
 1.  Configure a role that maps a name in Vault to an SQL statement to execute to
     create the database credential:
 
-    ```text
+    ```shell-session
     $ vault write database/roles/my-role \
-        db_name=my-postgresql-database \
+        db_name="my-postgresql-database" \
         creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; \
             GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\";" \
         default_ttl="1h" \
@@ -72,7 +72,7 @@ the proper permission, it can generate credentials.
 1.  Generate a new credential by reading from the `/creds` endpoint with the name
     of the role:
 
-    ```text
+    ```shell-session
     $ vault read database/creds/my-role
     Key                Value
     ---                -----


### PR DESCRIPTION
With the switch to `pgx` for the database driver, multi-host connection strings are now supported by the postgresql database plugin. This adds a small bit of documentation outlining how you might use it and refers to the official Postgres docs for more info on string formatting.

Also added examples for the keyword/value style connection.

e.g.
`"postgresql://{{username}}:{{password}}@host1:5432,host2:5432/database"`
`"host=host1,host2 port=5432 user={{username}} password={{password}} dbname=database"`