### PR TITLE
Docs: GCP SA clarity. Resolved merge conflict. Closes: #12231.

### DIFF
--- a/website/content/docs/auth/gcp.mdx
+++ b/website/content/docs/auth/gcp.mdx
@@ -207,7 +207,7 @@ If you are using Group Aliases as described below, you will also need to add the
 #### Permissions For Authenticating Against Vault
 
 If you are authenticating to Vault from Google Cloud, you can skip the following step as
-Vault will use generate and present the identity token of the service account configured
+Vault will generate and present the identity token of the service account configured
 on the instance or the pod.
 
 Note that the previously mentioned permissions are given to the _Vault servers_.

--- a/website/content/docs/auth/gcp.mdx
+++ b/website/content/docs/auth/gcp.mdx
@@ -31,9 +31,10 @@ repository.
 ### Via the CLI Helper
 
 Vault includes a CLI helper that obtains a signed JWT locally and sends the
-request to Vault. This helper is only available for IAM-type roles.
+request to Vault.
 
 ```shell-session
+# Authentication to vault outside of Google Cloud
 $ vault login -method=gcp \
     role="my-role" \
     service_account="authenticating-account@my-project.iam.gserviceaccount.com" \
@@ -41,7 +42,15 @@ $ vault login -method=gcp \
     credentials=@path/to/signer/credentials.json
 ```
 
+```shell-session
+# Authentication to vault inside of Google Cloud
+$ vault login -method=gcp role="my-role"
+```
+
 For more usage information, run `vault auth help gcp`.
+
+-> **Note:** The `project` parameter has been removed in Vault 1.5.9+, 1.6.5+, and 1.7.2+.
+It is no longer needed for configuration and will be ignored if provided.
 
 ### Via the CLI
 
@@ -76,7 +85,7 @@ management tool.
    $ vault auth enable gcp
    ```
 
-1. Configure the auth method credentials:
+1. Configure the auth method credentials if Vault is not running on Google Cloud:
 
    ```text
    $ vault write auth/gcp/config \
@@ -197,6 +206,10 @@ If you are using Group Aliases as described below, you will also need to add the
 
 #### Permissions For Authenticating Against Vault
 
+If you are authenticating to Vault from Google Cloud, you can skip the following step as
+Vault will use generate and present the identity token of the service account configured
+on the instance or the pod.
+
 Note that the previously mentioned permissions are given to the _Vault servers_.
 The IAM service account or GCE instance that is **authenticating against Vault**
 must have the following role:
@@ -262,8 +275,8 @@ for IAM service accounts looks like this:
 ### GCE Login
 
 GCE login only applies to roles of type `gce` and **must be completed on an
-instance running in GCE**. These steps will not work from your local laptop or
-another cloud provider.
+infrastructure running on Google Cloud**. These steps will not work from your 
+local laptop or another cloud provider.
 
 [![Vault Google Cloud GCE Login Workflow](/img/vault-gcp-gce-auth-workflow.svg)](/img/vault-gcp-gce-auth-workflow.svg)
 
@@ -346,6 +359,8 @@ Read more on the
 [Google Open Source blog](https://opensource.googleblog.com/2017/08/hashicorp-vault-and-google-cloud-iam.html).
 
 ### GCE
+
+You can autogenerate this token in Vault versions 1.8.2 or higher.
 
 GCE tokens **can only be generated from a GCE instance**.
 


### PR DESCRIPTION
Missed merger (from: #12231) with good clarity notes that still relevant to: [vaultproject.io/docs/auth/gcp](https://www.vaultproject.io/docs/auth/gcp#permissions-for-authenticating-against-vault) - please merge.

<img width="1248" alt="Screenshot 2022-08-19 at 00 49 34" src="https://user-images.githubusercontent.com/974854/185508717-879db998-890e-45ad-b6f5-6c467c45c6ad.png">

