### PR TITLE
Docs: PostgreSQL Docs added DB name note for connection_url. 

### DIFF
--- a/website/content/docs/secrets/databases/postgresql.mdx
+++ b/website/content/docs/secrets/databases/postgresql.mdx
@@ -46,7 +46,7 @@ options, including SSL options, can be found in the [pgx][pgxlib] and
     $ vault write database/config/my-postgresql-database \
         plugin_name="postgresql-database-plugin" \
         allowed_roles="my-role" \
-        connection_url="postgresql://{{username}}:{{password}}@localhost:5432/" \
+        connection_url="postgresql://{{username}}:{{password}}@localhost:5432/database-name" \
         username="vaultuser" \
         password="vaultpass"
     ```


### PR DESCRIPTION
Relates to #12458 and website section: [vaultproject.io/docs/secrets/databases/postgresql](https://www.vaultproject.io/docs/secrets/databases/postgresql#setup)