### PR TITLE
VAULT-7698 Fix ignored parameter warnings for endpoint arbitrary data options

### DIFF
--- a/changelog/16794.txt
+++ b/changelog/16794.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fixed erroneous warnings of unrecognized parameters when unwrapping data.
+```

--- a/http/sys_wrapping_test.go
+++ b/http/sys_wrapping_test.go
@@ -146,6 +146,9 @@ func TestHTTP_Wrapping(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if secret.Warnings != nil {
+		t.Fatalf("Warnings found: %v", secret.Warnings)
+	}
 	if secret == nil || secret.Data == nil {
 		t.Fatal("secret or secret data is nil")
 	}
@@ -222,6 +225,9 @@ func TestHTTP_Wrapping(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if secret.Warnings != nil {
+		t.Fatalf("Warnings found: %v", secret.Warnings)
+	}
 	ret4 := secret
 	// Should be expired and fail
 	_, err = client.Logical().Unwrap(wrapInfo.Token)
@@ -286,9 +292,15 @@ func TestHTTP_Wrapping(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if secret.Warnings != nil {
+		t.Fatalf("Warnings found: %v", secret.Warnings)
+	}
 	secret, err = client.Logical().Unwrap(secret.WrapInfo.Token)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if secret.Warnings != nil {
+		t.Fatalf("Warnings found: %v", secret.Warnings)
 	}
 	if !reflect.DeepEqual(data, secret.Data) {
 		t.Fatalf("custom wrap did not match expected: %#v", secret.Data)
@@ -319,6 +331,9 @@ func TestHTTP_Wrapping(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if secret.Warnings != nil {
+		t.Fatalf("Warnings found: %v", secret.Warnings)
 	}
 
 	// Check for correct Creation path after rewrap

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -221,7 +221,7 @@ func (b *Backend) HandleRequest(ctx context.Context, req *logical.Request) (*log
 	var ignored []string
 	for k, v := range req.Data {
 		raw[k] = v
-		if path.Fields[k] == nil {
+		if !path.TakesArbitraryInput && path.Fields[k] == nil {
 			ignored = append(ignored, k)
 		}
 	}

--- a/sdk/framework/path.go
+++ b/sdk/framework/path.go
@@ -116,6 +116,12 @@ type Path struct {
 	// DisplayAttrs provides hints for UI and documentation generators. They
 	// will be included in OpenAPI output if set.
 	DisplayAttrs *DisplayAttributes
+
+	// TakesArbitraryInput is used for endpoints that take arbitrary input, instead
+	// of or as well as their Fields. This is taken into account when printing
+	// warnings about ignored fields. If this is set, we will not warn when data is
+	// provided that is not part of the Fields declaration.
+	TakesArbitraryInput bool
 }
 
 // OperationHandler defines and describes a specific operation handler.

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -1795,6 +1795,8 @@ func (b *SystemBackend) wrappingPaths() []*framework.Path {
 
 			HelpSynopsis:    strings.TrimSpace(sysHelp["wrap"][0]),
 			HelpDescription: strings.TrimSpace(sysHelp["wrap"][1]),
+
+			TakesArbitraryInput: true,
 		},
 
 		{


### PR DESCRIPTION
The changes made to `TestHTTP_Wrapping` made the test fail before my fix, and this fixes the issue.

The output of an unwrap no longer contains a warning:
```
vault write -force sys/wrapping/unwrap
Key    Value
---    -----
foo    bar
```

I could not find any other endpoint that would be appropriate to add `TakesArbitraryInput: true` to, but it made sense to me to add the new option to the framework instead of simply making an exception for this particular endpoint, which felt messy. It seems likely we'll have need for this boolean in the future.
