### PR TITLE
Clarify keytab gen process

### DIFF
--- a/website/content/docs/auth/kerberos.mdx
+++ b/website/content/docs/auth/kerberos.mdx
@@ -61,7 +61,7 @@ $ vault auth enable \
     kerberos
 ```
 
-- Create a `keytab` for the Kerberos plugin:
+- Create a `keytab` for the Kerberos plugin (this keytab is used by the Vault server itself, another keytab should be generated for login purposes):
 
 ```shell-session
 $ ktutil


### PR DESCRIPTION
For some reason, the original [PR 12880](https://github.com/hashicorp/vault/pull/12880) seems to hang. 

This PR attempts to try making the same edit. 

🔍 [Deploy preview](https://vault-git-docs-clarify-keytab-hashicorp.vercel.app/docs/auth/kerberos)
