### PR TITLE
Include jwt_claim expiration error message

### DIFF
--- a/website/content/docs/auth/gcp.mdx
+++ b/website/content/docs/auth/gcp.mdx
@@ -310,6 +310,8 @@ be specified as a [NumericDate](https://tools.ietf.org/html/rfc7519#section-2) v
 (seconds from Epoch). This value must be before the max JWT expiration allowed for a
 role. This defaults to 15 minutes and cannot be more than 1 hour.
 
+If a user generates a token that expires after 15 minutes, and the gcp role has `max_jwt_exp` set to the default, Vault will return the following error: `Expiration date must be set to no more that 15 mins in JWT_CLAIM, otherwise the login request returns error "role requires that service account JWTs expire within 900 seconds`. In this case, the user must create a new signed JWT with a shorter expiration, or set `max_jwt_exp` to a higher value in the gcp role.
+
 One you have all this information, the JWT token can be signed using curl and
 [oauth2l](https://github.com/google/oauth2l):
 


### PR DESCRIPTION
This replicates [PR 11513](https://github.com/hashicorp/vault/pull/11513) which was opened in May, 2021.  Since the originator hasn't signed the CLA, we cannot merge the PR. 

This PR attempts to implement the suggested updates. 

🔍 [Deploy Preview](https://vault-git-docs-gcp-auth-jwt-hashicorp.vercel.app/docs/auth/gcp#service-account-credentials-api)
