### PR TITLE
Update apiVersion of the ClusterRoleBinding example

### DIFF
--- a/website/content/docs/auth/kubernetes.mdx
+++ b/website/content/docs/auth/kubernetes.mdx
@@ -300,7 +300,7 @@ Account should be granted permissions to access this API. The following
 example ClusterRoleBinding could be used to grant these permissions:
 
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: role-tokenreview-binding


### PR DESCRIPTION
Update the `apiVersion` of the `ClusterRoleBinding` example in the [Configuring Kubernetes](https://www.vaultproject.io/docs/auth/kubernetes#configuring-kubernetes) section of the Kubernetes Auth method documentation.  This is necessary as the `v1beta1` version has been deprecated and removed.

> [Warning: rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+](https://stackoverflow.com/q/65068168/6466149)

Without this, we get the following error:

```sh
$ k apply --filename cluster-role-binding.yaml

error: unable to recognize "cluster-role-binding.yaml": no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"
```

Before and after shots attached.

---

# BEFORE
<img width="983" alt="image" src="https://user-images.githubusercontent.com/97125550/185936746-679112a0-d5f5-475b-a84b-0fa8a06104fe.png">

# AFTER
<img width="944" alt="image" src="https://user-images.githubusercontent.com/97125550/185936824-35bee876-d3c9-440c-b4f1-57d6d1d8ca4c.png">
