### PR TITLE
Migrate existing PKI mounts that only contains a key

### DIFF
--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -951,6 +951,12 @@ func (sc *storageContext) writeCaBundle(caBundle *certutil.CertBundle, issuerNam
 		return nil, nil, err
 	}
 
+	// We may have existing mounts that only contained a key with no certificate yet as a signed CSR
+	// was never setup within the mount.
+	if caBundle.Certificate == "" {
+		return &issuerEntry{}, myKey, nil
+	}
+
 	myIssuer, _, err := sc.importIssuer(caBundle.Certificate, issuerName)
 	if err != nil {
 		return nil, nil, err

--- a/changelog/16813.txt
+++ b/changelog/16813.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Fix migration to properly handle mounts that contain only keys, no certificates
+```


### PR DESCRIPTION
- We missed testing a use-case of the migration that someone has a PKI
  mount point that generated a CSR but never called set-signed back on
  that mount point so it only contains a key.

Fixes reported issue #16810 