### PR TITLE
Update Userpass API Docs 

### DIFF
--- a/website/content/api-docs/auth/userpass.mdx
+++ b/website/content/api-docs/auth/userpass.mdx
@@ -37,8 +37,8 @@ Create a new user or update an existing user. This path honors the distinction b
 ```json
 {
   "password": "superSecretPassword",
-  "policies": "admin,default",
-  "bound_cidrs": ["127.0.0.1/32", "128.252.0.0/16"]
+  "token_policies": ["admin", "default"],
+  "token_bound_cidrs": ["127.0.0.1/32", "128.252.0.0/16"]
 }
 ```
 
@@ -72,16 +72,30 @@ $ curl \
 
 ```json
 {
-  "request_id": "812229d7-a82e-0b20-c35b-81ce8c1b9fa6",
+  "request_id": "0ad1be52-9398-4b3c-f58b-98e427406471",
   "lease_id": "",
-  "lease_duration": 0,
   "renewable": false,
+  "lease_duration": 0,
   "data": {
-    "max_ttl": 0,
-    "policies": ["default", "dev"],
-    "ttl": 0
+    "token_bound_cidrs": [
+      "127.0.0.1",
+      "128.252.0.0/16"
+    ],
+    "token_explicit_max_ttl": 0,
+    "token_max_ttl": 0,
+    "token_no_default_policy": false,
+    "token_num_uses": 0,
+    "token_period": 0,
+    "token_policies": [
+      "admin",
+      "default"
+    ],
+    "token_ttl": 0,
+    "token_type": "default"
   },
-  "warnings": null
+  "wrap_info": null,
+  "warnings": null,
+  "auth": null
 }
 ```
 
@@ -148,13 +162,15 @@ Update policies for an existing user.
 ### Parameters
 
 - `username` `(string: <required>)` – The username for the user.
-- `policies` `(string: "")` – Comma-separated list of policies. If set to empty
+- `token_policies` `(array: [] or comma-delimited string: "")` - List of
+  policies to encode onto generated tokens. Depending on the auth method, this
+  list may be supplemented by user/group/other values.
 
 ### Sample Payload
 
 ```json
 {
-  "policies": ["policy1", "policy2"]
+  "token_policies": ["policy1", "policy2"]
 }
 ```
 
@@ -229,20 +245,36 @@ $ curl \
 
 ```json
 {
+  "request_id": "ae1882ba-f60a-7629-ce1a-6618c482de3e",
   "lease_id": "",
   "renewable": false,
   "lease_duration": 0,
   "data": null,
+  "wrap_info": null,
   "warnings": null,
   "auth": {
-    "client_token": "64d2a8f2-2a2f-5688-102b-e6088b76e344",
-    "accessor": "18bb8f89-826a-56ee-c65b-1736dc5ea27d",
-    "policies": ["default"],
+    "client_token": "hvs.CAESIJyeFmhLYRWVXPJStT3fDP1ZdFkon_otuk1sJUpkfk_WGh4KHGh2cy5xdW9XVHBnVUwwbzB1ZEhzZkpkRmVoU08",
+    "accessor": "iP2Lw1JXpjlALbgJSeIx51n7",
+    "policies": [
+      "default",
+      "policy1",
+      "policy2"
+    ],
+    "token_policies": [
+      "default",
+      "policy1",
+      "policy2"
+    ],
     "metadata": {
       "username": "mitchellh"
     },
-    "lease_duration": 7200,
-    "renewable": true
+    "lease_duration": 2764800,
+    "renewable": true,
+    "entity_id": "0660dce5-4f2c-926a-8b15-158901557d9d",
+    "token_type": "service",
+    "orphan": true,
+    "mfa_requirement": null,
+    "num_uses": 0
   }
 }
 ```


### PR DESCRIPTION
While using the Userpass docs recently, I noticed that there were inconsistencies in the names of parameters.  Upon further research, I found that the docs were using a mixture of up-to-date and deprecated parameter names which I found confusing.

I went through and updated the Userpass API docs to no longer use deprecated parameter names.  Additionally, I updated the output examples to be accurate for latest version of Vault.  This generally made the docs more cohesive and less contradictory in my opinion.

Note that you can see which parameters are deprecated with the help of the `path-help` command.  I'll include an example below:

```
$ vault path-help auth/userpass/users/mitchellh

Request:        users/mitchellh
Matching Route: ^users/(?P<username>\w(([\w-.]+)?\w)?)$

Manage users allowed to authenticate.

## PARAMETERS

    bound_cidrs (slice)

        (DEPRECATED) Use "token_bound_cidrs" instead. If this and "token_bound_cidrs" are both specified, only "token_bound_cidrs" will be used.

    max_ttl (duration (sec))

        (DEPRECATED) Use "token_max_ttl" instead. If this and "token_max_ttl" are both specified, only "token_max_ttl" will be used.

    password (string)

        Password for this user.

    policies (slice)

        (DEPRECATED) Use "token_policies" instead. If this and "token_policies" are both specified, only "token_policies" will be used.

    token_bound_cidrs (slice)

        Comma separated string or JSON list of CIDR blocks. If set, specifies the blocks of IP addresses which are allowed to use the generated token.

    token_explicit_max_ttl (duration (sec))

        If set, tokens created via this role
        carry an explicit maximum TTL. During renewal,
        the current maximum TTL values of the role
        and the mount are not checked for changes,
        and any updates to these values will have
        no effect on the token being renewed.

    token_max_ttl (duration (sec))

        The maximum lifetime of the generated token

    token_no_default_policy (bool)

        If true, the 'default' policy will not automatically be added to generated tokens

    token_num_uses (int)

        The maximum number of times a token may be used, a value of zero means unlimited

    token_period (duration (sec))

        If set, tokens created via this role
        will have no max lifetime; instead, their
        renewal period will be fixed to this value.
        This takes an integer number of seconds,
        or a string duration (e.g. "24h").

    token_policies (slice)

        Comma-separated list of policies

    token_ttl (duration (sec))

        The initial ttl of the token to generate

    token_type (string)

        The type of token to generate, service or batch

    ttl (duration (sec))

        (DEPRECATED) Use "token_ttl" instead. If this and "token_ttl" are both specified, only "token_ttl" will be used.

    username (string)

        Username for this user.

## DESCRIPTION

This endpoint allows you to create, read, update, and delete users
that are allowed to authenticate.

Deleting a user will not revoke auth for prior authenticated users
with that name. To do this, do a revoke on "login/<username>" for
the username you want revoked. If you don't need to revoke login immediately,
then the next renew will cause the lease to expire.

```