### PR TITLE
UI: Forward to `redirect_to` param to when auth'd

### DIFF
--- a/changelog/16821.txt
+++ b/changelog/16821.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: redirect_to param forwards from auth route when authenticated
+```

--- a/ui/app/lib/route-paths.js
+++ b/ui/app/lib/route-paths.js
@@ -1,0 +1,11 @@
+export const INIT = 'vault.cluster.init';
+export const UNSEAL = 'vault.cluster.unseal';
+export const AUTH = 'vault.cluster.auth';
+export const CLUSTER = 'vault.cluster';
+export const CLUSTER_INDEX = 'vault.cluster.index';
+export const OIDC_CALLBACK = 'vault.cluster.oidc-callback';
+export const OIDC_PROVIDER = 'vault.cluster.oidc-provider';
+export const NS_OIDC_PROVIDER = 'vault.cluster.oidc-provider-ns';
+export const DR_REPLICATION_SECONDARY = 'vault.cluster.replication-dr-promote';
+export const DR_REPLICATION_SECONDARY_DETAILS = 'vault.cluster.replication-dr-promote.details';
+export const EXCLUDED_REDIRECT_URLS = ['/vault/logout'];

--- a/ui/app/lib/route-paths.js
+++ b/ui/app/lib/route-paths.js
@@ -1,6 +1,7 @@
 export const INIT = 'vault.cluster.init';
 export const UNSEAL = 'vault.cluster.unseal';
 export const AUTH = 'vault.cluster.auth';
+export const REDIRECT = 'vault.cluster.redirect';
 export const CLUSTER = 'vault.cluster';
 export const CLUSTER_INDEX = 'vault.cluster.index';
 export const OIDC_CALLBACK = 'vault.cluster.oidc-callback';

--- a/ui/app/mixins/cluster-route.js
+++ b/ui/app/mixins/cluster-route.js
@@ -1,19 +1,19 @@
 import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
 import RSVP from 'rsvp';
-const INIT = 'vault.cluster.init';
-const UNSEAL = 'vault.cluster.unseal';
-const AUTH = 'vault.cluster.auth';
-const CLUSTER = 'vault.cluster';
-const CLUSTER_INDEX = 'vault.cluster.index';
-const OIDC_CALLBACK = 'vault.cluster.oidc-callback';
-const OIDC_PROVIDER = 'vault.cluster.oidc-provider';
-const NS_OIDC_PROVIDER = 'vault.cluster.oidc-provider-ns';
-const DR_REPLICATION_SECONDARY = 'vault.cluster.replication-dr-promote';
-const DR_REPLICATION_SECONDARY_DETAILS = 'vault.cluster.replication-dr-promote.details';
-const EXCLUDED_REDIRECT_URLS = ['/vault/logout'];
-
-export { INIT, UNSEAL, AUTH, CLUSTER, CLUSTER_INDEX, DR_REPLICATION_SECONDARY };
+import {
+  INIT,
+  UNSEAL,
+  AUTH,
+  CLUSTER,
+  CLUSTER_INDEX,
+  OIDC_CALLBACK,
+  OIDC_PROVIDER,
+  NS_OIDC_PROVIDER,
+  DR_REPLICATION_SECONDARY,
+  DR_REPLICATION_SECONDARY_DETAILS,
+  EXCLUDED_REDIRECT_URLS,
+} from '../lib/route-paths';
 
 export default Mixin.create({
   auth: service(),

--- a/ui/app/mixins/cluster-route.js
+++ b/ui/app/mixins/cluster-route.js
@@ -13,7 +13,8 @@ import {
   DR_REPLICATION_SECONDARY,
   DR_REPLICATION_SECONDARY_DETAILS,
   EXCLUDED_REDIRECT_URLS,
-} from '../lib/route-paths';
+  REDIRECT,
+} from 'vault/lib/route-paths';
 
 export default Mixin.create({
   auth: service(),
@@ -96,10 +97,13 @@ export default Mixin.create({
     if (
       (!cluster.needsInit && this.routeName === INIT) ||
       (!cluster.sealed && this.routeName === UNSEAL) ||
-      (!cluster?.dr?.isSecondary && this.routeName === DR_REPLICATION_SECONDARY) ||
-      (isAuthed && this.routeName === AUTH)
+      (!cluster?.dr?.isSecondary && this.routeName === DR_REPLICATION_SECONDARY)
     ) {
       return CLUSTER;
+    }
+    if (isAuthed && this.routeName === AUTH) {
+      // if you're already authed and you wanna go to auth, you probably want to redirect
+      return REDIRECT;
     }
     return null;
   },

--- a/ui/app/router.js
+++ b/ui/app/router.js
@@ -13,6 +13,7 @@ Router.map(function () {
       this.route('oidc-provider', { path: '/identity/oidc/provider/:provider_name/authorize' });
       this.route('oidc-callback', { path: '/auth/*auth_path/oidc/callback' });
       this.route('auth');
+      this.route('redirect');
       this.route('init');
       this.route('logout');
       this.mount('open-api-explorer', { path: '/api-explorer' });

--- a/ui/app/routes/vault/cluster/redirect.js
+++ b/ui/app/routes/vault/cluster/redirect.js
@@ -11,16 +11,17 @@ export default class VaultClusterRedirectRoute extends Route {
     const isAuthed = this.auth.currentToken;
     // eslint-disable-next-line ember/no-controller-access-in-routes
     const controller = this.controllerFor('vault.cluster.auth');
+    const { redirect_to, ...otherParams } = queryParams;
 
-    if (isAuthed && queryParams.redirect_to) {
-      // if authenticated and redirect exists, redirect to that place
-      transition = this.router.replaceWith(queryParams.redirect_to);
+    if (isAuthed && redirect_to) {
+      // if authenticated and redirect exists, redirect to that place and strip other params
+      transition = this.router.replaceWith(redirect_to);
     } else if (isAuthed) {
       // if authed no redirect, go to cluster
-      transition = this.router.replaceWith(CLUSTER);
+      transition = this.router.replaceWith(CLUSTER, { queryParams: otherParams });
     } else {
       // default go to Auth
-      transition = this.router.replaceWith(AUTH);
+      transition = this.router.replaceWith(AUTH, { queryParams: otherParams });
     }
     transition.followRedirects().then(() => {
       controller.set('redirectTo', '');

--- a/ui/app/routes/vault/cluster/redirect.js
+++ b/ui/app/routes/vault/cluster/redirect.js
@@ -10,7 +10,7 @@ export default class VaultClusterRedirectRoute extends Route {
     let transition;
     const isAuthed = this.auth.currentToken;
     // eslint-disable-next-line ember/no-controller-access-in-routes
-    const controller = this.controllerFor('vault.cluster.auth');
+    const controller = this.controllerFor('vault');
     const { redirect_to, ...otherParams } = queryParams;
 
     if (isAuthed && redirect_to) {

--- a/ui/app/routes/vault/cluster/redirect.js
+++ b/ui/app/routes/vault/cluster/redirect.js
@@ -1,0 +1,29 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { AUTH, CLUSTER } from 'vault/lib/route-paths';
+
+export default class VaultClusterRedirectRoute extends Route {
+  @service auth;
+  @service router;
+
+  beforeModel({ to: { queryParams } }) {
+    let transition;
+    const isAuthed = this.auth.currentToken;
+    // eslint-disable-next-line ember/no-controller-access-in-routes
+    const controller = this.controllerFor('vault.cluster.auth');
+
+    if (isAuthed && queryParams.redirect_to) {
+      // if authenticated and redirect exists, redirect to that place
+      transition = this.router.transitionTo(queryParams.redirect_to);
+    } else if (isAuthed) {
+      // if authed no redirect, go to cluster
+      transition = this.router.transitionTo(CLUSTER);
+    } else {
+      // default go to Auth
+      transition = this.router.transitionTo(AUTH);
+    }
+    transition.followRedirects().then(() => {
+      controller.set('redirectTo', '');
+    });
+  }
+}

--- a/ui/app/routes/vault/cluster/redirect.js
+++ b/ui/app/routes/vault/cluster/redirect.js
@@ -14,13 +14,13 @@ export default class VaultClusterRedirectRoute extends Route {
 
     if (isAuthed && queryParams.redirect_to) {
       // if authenticated and redirect exists, redirect to that place
-      transition = this.router.transitionTo(queryParams.redirect_to);
+      transition = this.router.replaceWith(queryParams.redirect_to);
     } else if (isAuthed) {
       // if authed no redirect, go to cluster
-      transition = this.router.transitionTo(CLUSTER);
+      transition = this.router.replaceWith(CLUSTER);
     } else {
       // default go to Auth
-      transition = this.router.transitionTo(AUTH);
+      transition = this.router.replaceWith(AUTH);
     }
     transition.followRedirects().then(() => {
       controller.set('redirectTo', '');

--- a/ui/app/templates/vault/cluster/redirect.hbs
+++ b/ui/app/templates/vault/cluster/redirect.hbs
@@ -1,0 +1,1 @@
+<LogoSplash />

--- a/ui/tests/unit/mixins/cluster-route-test.js
+++ b/ui/tests/unit/mixins/cluster-route-test.js
@@ -1,14 +1,7 @@
 import { assign } from '@ember/polyfills';
 import EmberObject from '@ember/object';
 import ClusterRouteMixin from 'vault/mixins/cluster-route';
-import {
-  INIT,
-  UNSEAL,
-  AUTH,
-  CLUSTER,
-  CLUSTER_INDEX,
-  DR_REPLICATION_SECONDARY,
-} from 'vault/mixins/cluster-route';
+import { INIT, UNSEAL, AUTH, CLUSTER, CLUSTER_INDEX, DR_REPLICATION_SECONDARY } from 'vault/lib/route-paths';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 

--- a/ui/tests/unit/mixins/cluster-route-test.js
+++ b/ui/tests/unit/mixins/cluster-route-test.js
@@ -1,7 +1,15 @@
 import { assign } from '@ember/polyfills';
 import EmberObject from '@ember/object';
 import ClusterRouteMixin from 'vault/mixins/cluster-route';
-import { INIT, UNSEAL, AUTH, CLUSTER, CLUSTER_INDEX, DR_REPLICATION_SECONDARY } from 'vault/lib/route-paths';
+import {
+  INIT,
+  UNSEAL,
+  AUTH,
+  CLUSTER,
+  CLUSTER_INDEX,
+  DR_REPLICATION_SECONDARY,
+  REDIRECT,
+} from 'vault/lib/route-paths';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -72,12 +80,34 @@ module('Unit | Mixin | cluster route', function () {
     assert.equal(subject.targetRouteName(), CLUSTER, 'forwards when unsealed and navigating to UNSEAL');
 
     subject.routeName = AUTH;
-    assert.equal(subject.targetRouteName(), CLUSTER, 'forwards when authenticated and navigating to AUTH');
+    assert.equal(subject.targetRouteName(), REDIRECT, 'forwards when authenticated and navigating to AUTH');
 
     subject.routeName = DR_REPLICATION_SECONDARY;
     assert.equal(
       subject.targetRouteName(),
       CLUSTER,
+      'forwards when not a DR secondary and navigating to DR_REPLICATION_SECONDARY'
+    );
+  });
+
+  test('#targetRouteName happy path when not authed forwards to AUTH', function (assert) {
+    let subject = createClusterRoute(
+      { needsInit: false, sealed: false, dr: { isSecondary: false } },
+      { authToken: () => null }
+    );
+    subject.routeName = INIT;
+    assert.equal(subject.targetRouteName(), AUTH, 'forwards when inited and navigating to INIT');
+
+    subject.routeName = UNSEAL;
+    assert.equal(subject.targetRouteName(), AUTH, 'forwards when unsealed and navigating to UNSEAL');
+
+    subject.routeName = AUTH;
+    assert.equal(subject.targetRouteName(), AUTH, 'forwards when non-authenticated and navigating to AUTH');
+
+    subject.routeName = DR_REPLICATION_SECONDARY;
+    assert.equal(
+      subject.targetRouteName(),
+      AUTH,
       'forwards when not a DR secondary and navigating to DR_REPLICATION_SECONDARY'
     );
   });
@@ -90,6 +120,20 @@ module('Unit | Mixin | cluster route', function () {
     subject.transitionToTargetRoute();
     assert.ok(
       spy.calledWithExactly(AUTH, { queryParams: { redirect_to: redirectRouteURL } }),
+      'calls transitionTo with the expected args'
+    );
+
+    spy.restore();
+  });
+
+  test('#transitionToTargetRoute to AUTH when authd', function (assert) {
+    let redirectRouteURL = '/vault/secrets/secret/create';
+    let subject = createClusterRoute({ needsInit: false, sealed: false }, { authToken: () => 'has-token' });
+    subject.router.queryParams.redirect_to = redirectRouteURL;
+    let spy = sinon.spy(subject, 'transitionTo');
+    subject.transitionToTargetRoute();
+    assert.ok(
+      spy.calledWithExactly(REDIRECT, { queryParams: { redirect_to: redirectRouteURL } }),
       'calls transitionTo with the expected args'
     );
 

--- a/ui/tests/unit/mixins/cluster-route-test.js
+++ b/ui/tests/unit/mixins/cluster-route-test.js
@@ -93,7 +93,7 @@ module('Unit | Mixin | cluster route', function () {
   test('#targetRouteName happy path when not authed forwards to AUTH', function (assert) {
     let subject = createClusterRoute(
       { needsInit: false, sealed: false, dr: { isSecondary: false } },
-      { authToken: () => null }
+      { hasKeyData: () => false, authToken: () => null }
     );
     subject.routeName = INIT;
     assert.equal(subject.targetRouteName(), AUTH, 'forwards when inited and navigating to INIT');
@@ -120,20 +120,6 @@ module('Unit | Mixin | cluster route', function () {
     subject.transitionToTargetRoute();
     assert.ok(
       spy.calledWithExactly(AUTH, { queryParams: { redirect_to: redirectRouteURL } }),
-      'calls transitionTo with the expected args'
-    );
-
-    spy.restore();
-  });
-
-  test('#transitionToTargetRoute to AUTH when authd', function (assert) {
-    let redirectRouteURL = '/vault/secrets/secret/create';
-    let subject = createClusterRoute({ needsInit: false, sealed: false }, { authToken: () => 'has-token' });
-    subject.router.queryParams.redirect_to = redirectRouteURL;
-    let spy = sinon.spy(subject, 'transitionTo');
-    subject.transitionToTargetRoute();
-    assert.ok(
-      spy.calledWithExactly(REDIRECT, { queryParams: { redirect_to: redirectRouteURL } }),
       'calls transitionTo with the expected args'
     );
 

--- a/ui/tests/unit/routes/vault/cluster/redirect-test.js
+++ b/ui/tests/unit/routes/vault/cluster/redirect-test.js
@@ -8,7 +8,7 @@ module('Unit | Route | vault/cluster/redirect', function (hooks) {
   hooks.beforeEach(function () {
     this.router = this.owner.lookup('service:router');
     this.originalTransition = this.router.transitionTo;
-    this.router.transitionTo = sinon.stub().returns({
+    this.router.replaceWith = sinon.stub().returns({
       followRedirects: function () {
         return {
           then: function (callback) {

--- a/ui/tests/unit/routes/vault/cluster/redirect-test.js
+++ b/ui/tests/unit/routes/vault/cluster/redirect-test.js
@@ -6,28 +6,24 @@ module('Unit | Route | vault/cluster/redirect', function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    // this.owner.register('service:router', routerService);
     this.router = this.owner.lookup('service:router');
-    this.router.reopen({
-      transitionTo: sinon.stub().returns({
-        followRedirects: function () {
-          return {
-            then: function (callback) {
-              callback();
-            },
-          };
-        },
-      }),
-      urlFor: sinon.stub().returns('/ui/vault/foo'),
+    this.originalTransition = this.router.transitionTo;
+    this.router.transitionTo = sinon.stub().returns({
+      followRedirects: function () {
+        return {
+          then: function (callback) {
+            callback();
+          },
+        };
+      },
     });
-    // this.routerStub = this.owner.lookup('service:router');
   });
 
   hooks.afterEach(function () {
-    // this.owner.unregister('service:router');
+    this.router.transitionTo = this.originalTransition;
   });
 
-  test('it calls ', function (assert) {
+  test('it calls route', function (assert) {
     let route = this.owner.lookup('route:vault/cluster/redirect');
     assert.ok(route);
   });

--- a/ui/tests/unit/routes/vault/cluster/redirect-test.js
+++ b/ui/tests/unit/routes/vault/cluster/redirect-test.js
@@ -1,0 +1,82 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | vault/cluster/redirect', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    // this.owner.register('service:router', routerService);
+    this.router = this.owner.lookup('service:router');
+    this.router.reopen({
+      transitionTo: sinon.stub().returns({
+        followRedirects: function () {
+          return {
+            then: function (callback) {
+              callback();
+            },
+          };
+        },
+      }),
+      urlFor: sinon.stub().returns('/ui/vault/foo'),
+    });
+    // this.routerStub = this.owner.lookup('service:router');
+  });
+
+  hooks.afterEach(function () {
+    // this.owner.unregister('service:router');
+  });
+
+  test('it calls ', function (assert) {
+    let route = this.owner.lookup('route:vault/cluster/redirect');
+    assert.ok(route);
+  });
+
+  test('it redirects to auth when unauthenticated', function (assert) {
+    let route = this.owner.lookup('route:vault/cluster/redirect');
+    const auth = this.owner.lookup('service:auth');
+    const originalToken = auth.currentToken;
+
+    auth.currentToken = null;
+
+    route.beforeModel({ to: { queryParams: { redirect_to: 'vault/cluster/tools' } } });
+
+    assert.true(
+      this.router.transitionTo.calledWith('vault.cluster.auth'),
+      'transitions to auth when not authenticated'
+    );
+    auth.currentToken = originalToken;
+  });
+
+  test('it redirects to cluster when authenticated without redirect param', function (assert) {
+    let route = this.owner.lookup('route:vault/cluster/redirect');
+    const auth = this.owner.lookup('service:auth');
+    const originalToken = auth.currentToken;
+
+    auth.currentToken = 's.xxxxxxxxx';
+
+    route.beforeModel({ to: { queryParams: { foo: 'bar' } } });
+
+    assert.true(
+      this.router.transitionTo.calledWith('vault.cluster'),
+      'transitions to cluster when not authenticated'
+    );
+    auth.currentToken = originalToken;
+  });
+
+  test('it redirects to desired path when authenticated with redirect param', function (assert) {
+    let route = this.owner.lookup('route:vault/cluster/redirect');
+    const auth = this.owner.lookup('service:auth');
+    const originalToken = auth.currentToken;
+
+    auth.currentToken = 's.xxxxxxxxx';
+
+    route.beforeModel({ to: { queryParams: { redirect_to: 'vault/cluster/tools' } } });
+
+    assert.true(
+      this.router.transitionTo.calledWith('vault/cluster/tools'),
+      'transitions to redirect_to path when authenticated'
+    );
+    auth.currentToken = originalToken;
+  });
+});


### PR DESCRIPTION
This adds behavior to the auth route where, if the user is already logged in and they attempt to go to the auth url with the `redirect_to` param present, they will get redirected to the `redirect_to` route:
![redirect-after](https://user-images.githubusercontent.com/82459713/186006159-bbb2eba9-e4ea-4d7b-a7a5-bba52e29513d.gif)


Previously, attempting to go to the auth route when already logged in will always route you to the main secrets list:
![redirect-before](https://user-images.githubusercontent.com/82459713/186006115-15784aa2-32c1-4ac7-b0de-a8c1cd20d835.gif)
 