### PR TITLE
UI: Checks if records exists before creating record when URL contains :name

### DIFF
--- a/ui/app/adapters/named-path.js
+++ b/ui/app/adapters/named-path.js
@@ -3,7 +3,7 @@
  * save requests are made to the same endpoint and the resource is either created if not found or updated
  * */
 import ApplicationAdapter from './application';
-
+import { assert } from '@ember/debug';
 export default class NamedPathAdapter extends ApplicationAdapter {
   namespace = 'v1';
   saveMethod = 'POST'; // override when extending if PUT is used rather than POST
@@ -21,9 +21,9 @@ export default class NamedPathAdapter extends ApplicationAdapter {
     let [store, { modelName }, snapshot] = arguments;
     let name = snapshot.attr('name');
     // throw error if user attempts to create a record with same name, otherwise POST request silently overrides (updates) the existing model
-    if (store.hasRecordForId(modelName, name))
+    if (store.hasRecordForId(modelName, name)) {
       throw new Error(`A record already exists with the name: ${name}`);
-    else {
+    } else {
       return this._saveRecord(...arguments);
     }
   }
@@ -54,6 +54,7 @@ export default class NamedPathAdapter extends ApplicationAdapter {
     const response = await this.ajax(url, 'GET', { data: { list: true } });
 
     // filter LIST response only if key_info exists and query includes both 'paramKey' & 'filterFor'
+    if (filterFor) assert('filterFor must be an array', Array.isArray(filterFor));
     if (response.data.key_info && filterFor && paramKey && !filterFor.includes('*')) {
       const data = this.filterListResponse(paramKey, filterFor, response.data.key_info);
       return { ...response, data };

--- a/ui/app/adapters/named-path.js
+++ b/ui/app/adapters/named-path.js
@@ -15,14 +15,24 @@ export default class NamedPathAdapter extends ApplicationAdapter {
       data,
     }).then(() => data);
   }
+
   // create does not return response similar to PUT request
   createRecord() {
-    return this._saveRecord(...arguments);
+    let [store, { modelName }, snapshot] = arguments;
+    let name = snapshot.attr('name');
+    // throw error if user attempts to create a record with same name, otherwise POST request silently overrides (updates) the existing model
+    if (store.hasRecordForId(modelName, name))
+      throw new Error(`A record already exists with the name: ${name}`);
+    else {
+      return this._saveRecord(...arguments);
+    }
   }
+
   // update uses same endpoint and method as create
   updateRecord() {
     return this._saveRecord(...arguments);
   }
+
   // if backend does not return name in response Ember Data will throw an error for pushing a record with no id
   // use the id (name) supplied to findRecord to set property on response data
   findRecord(store, type, name) {
@@ -33,6 +43,7 @@ export default class NamedPathAdapter extends ApplicationAdapter {
       return resp;
     });
   }
+
   // GET request with list=true as query param
   async query(store, type, query) {
     const url = this.urlForQuery(query, type.modelName);

--- a/ui/app/components/oidc/assignment-form.js
+++ b/ui/app/components/oidc/assignment-form.js
@@ -26,6 +26,7 @@ export default class OidcAssignmentFormComponent extends Component {
   @service store;
   @service flashMessages;
   @tracked modelValidations;
+  @tracked errorBanner;
 
   @task
   *save(event) {
@@ -43,7 +44,7 @@ export default class OidcAssignmentFormComponent extends Component {
       }
     } catch (error) {
       const message = error.errors ? error.errors.join('. ') : error.message;
-      this.flashMessages.danger(message);
+      this.errorBanner = message;
     }
   }
 

--- a/ui/app/components/oidc/assignment-form.js
+++ b/ui/app/components/oidc/assignment-form.js
@@ -35,7 +35,7 @@ export default class OidcAssignmentFormComponent extends Component {
     try {
       const { isValid, state, invalidFormMessage } = this.args.model.validate();
       this.modelValidations = isValid ? null : state;
-      this.invalidFormMessage = invalidFormMessage;
+      this.invalidFormAlert = invalidFormMessage;
       if (isValid) {
         const { isNew, name } = this.args.model;
         yield this.args.model.save();

--- a/ui/app/components/oidc/assignment-form.js
+++ b/ui/app/components/oidc/assignment-form.js
@@ -27,13 +27,15 @@ export default class OidcAssignmentFormComponent extends Component {
   @service flashMessages;
   @tracked modelValidations;
   @tracked errorBanner;
+  @tracked invalidFormMessage;
 
   @task
   *save(event) {
     event.preventDefault();
     try {
-      const { isValid, state } = this.args.model.validate();
+      const { isValid, state, invalidFormMessage } = this.args.model.validate();
       this.modelValidations = isValid ? null : state;
+      this.invalidFormMessage = invalidFormMessage;
       if (isValid) {
         const { isNew, name } = this.args.model;
         yield this.args.model.save();

--- a/ui/app/components/oidc/assignment-form.js
+++ b/ui/app/components/oidc/assignment-form.js
@@ -27,15 +27,13 @@ export default class OidcAssignmentFormComponent extends Component {
   @service flashMessages;
   @tracked modelValidations;
   @tracked errorBanner;
-  @tracked invalidFormMessage;
 
   @task
   *save(event) {
     event.preventDefault();
     try {
-      const { isValid, state, invalidFormMessage } = this.args.model.validate();
+      const { isValid, state } = this.args.model.validate();
       this.modelValidations = isValid ? null : state;
-      this.invalidFormAlert = invalidFormMessage;
       if (isValid) {
         const { isNew, name } = this.args.model;
         yield this.args.model.save();

--- a/ui/app/components/oidc/client-form.js
+++ b/ui/app/components/oidc/client-form.js
@@ -21,12 +21,22 @@ import { task } from 'ember-concurrency';
 export default class OidcClientForm extends Component {
   @service store;
   @service flashMessages;
-  @tracked errorBanner;
   @tracked modelValidations;
+  @tracked errorBanner;
+  @tracked invalidFormMessage;
   @tracked radioCardGroupValue =
     !this.args.model.assignments || this.args.model.assignments.includes('allow_all')
       ? 'allow_all'
       : 'limited';
+
+  get modelAssignments() {
+    const { assignments } = this.args.model;
+    if (assignments.includes('allow_all') && assignments.length === 1) {
+      return [];
+    } else {
+      return assignments;
+    }
+  }
 
   @action
   handleAssignmentSelection(selection) {
@@ -41,20 +51,20 @@ export default class OidcClientForm extends Component {
     }
   }
 
-  get modelAssignments() {
-    const { assignments } = this.args.model;
-    if (assignments.includes('allow_all') && assignments.length === 1) {
-      return [];
-    } else {
-      return assignments;
-    }
+  @action
+  cancel() {
+    const method = this.args.model.isNew ? 'unloadRecord' : 'rollbackAttributes';
+    this.args.model[method]();
+    this.args.onCancel();
   }
+
   @task
   *save(event) {
     event.preventDefault();
     try {
-      const { isValid, state } = this.args.model.validate();
+      const { isValid, state, invalidFormMessage } = this.args.model.validate();
       this.modelValidations = isValid ? null : state;
+      this.invalidFormMessage = invalidFormMessage;
       if (isValid) {
         if (this.radioCardGroupValue === 'allow_all') {
           // the backend permits 'allow_all' AND other assignments, though 'allow_all' will take precedence
@@ -76,12 +86,5 @@ export default class OidcClientForm extends Component {
       const message = error.errors ? error.errors.join('. ') : error.message;
       this.errorBanner = message;
     }
-  }
-
-  @action
-  cancel() {
-    const method = this.args.model.isNew ? 'unloadRecord' : 'rollbackAttributes';
-    this.args.model[method]();
-    this.args.onCancel();
   }
 }

--- a/ui/app/components/oidc/client-form.js
+++ b/ui/app/components/oidc/client-form.js
@@ -21,7 +21,7 @@ import { task } from 'ember-concurrency';
 export default class OidcClientForm extends Component {
   @service store;
   @service flashMessages;
-
+  @tracked errorBanner;
   @tracked modelValidations;
   @tracked radioCardGroupValue =
     !this.args.model.assignments || this.args.model.assignments.includes('allow_all')
@@ -74,7 +74,7 @@ export default class OidcClientForm extends Component {
       }
     } catch (error) {
       const message = error.errors ? error.errors.join('. ') : error.message;
-      this.flashMessages.danger(message);
+      this.errorBanner = message;
     }
   }
 

--- a/ui/app/components/oidc/client-form.js
+++ b/ui/app/components/oidc/client-form.js
@@ -84,9 +84,8 @@ export default class OidcClientForm extends Component {
       }
     } catch (error) {
       const message = error.errors ? error.errors.join('. ') : error.message;
-      console.log(error.errors);
       this.errorBanner = message;
-      this.invalidFormAlert = 'There was a problem submitting';
+      this.invalidFormAlert = 'There was an error submitting this form.';
     }
   }
 }

--- a/ui/app/components/oidc/client-form.js
+++ b/ui/app/components/oidc/client-form.js
@@ -23,7 +23,7 @@ export default class OidcClientForm extends Component {
   @service flashMessages;
   @tracked modelValidations;
   @tracked errorBanner;
-  @tracked invalidFormMessage;
+  @tracked invalidFormAlert;
   @tracked radioCardGroupValue =
     !this.args.model.assignments || this.args.model.assignments.includes('allow_all')
       ? 'allow_all'
@@ -64,7 +64,7 @@ export default class OidcClientForm extends Component {
     try {
       const { isValid, state, invalidFormMessage } = this.args.model.validate();
       this.modelValidations = isValid ? null : state;
-      this.invalidFormMessage = invalidFormMessage;
+      this.invalidFormAlert = invalidFormMessage;
       if (isValid) {
         if (this.radioCardGroupValue === 'allow_all') {
           // the backend permits 'allow_all' AND other assignments, though 'allow_all' will take precedence
@@ -84,7 +84,9 @@ export default class OidcClientForm extends Component {
       }
     } catch (error) {
       const message = error.errors ? error.errors.join('. ') : error.message;
+      console.log(error.errors);
       this.errorBanner = message;
+      this.invalidFormAlert = 'There was a problem submitting';
     }
   }
 }

--- a/ui/app/components/oidc/key-form.js
+++ b/ui/app/components/oidc/key-form.js
@@ -57,7 +57,7 @@ export default class OidcKeyForm extends Component {
     try {
       const { isValid, state, invalidFormMessage } = this.args.model.validate();
       this.modelValidations = isValid ? null : state;
-      this.invalidFormMessage = invalidFormMessage;
+      this.invalidFormAlert = invalidFormMessage;
       if (isValid) {
         const { isNew, name } = this.args.model;
         if (this.radioCardGroupValue === 'allow_all') {

--- a/ui/app/components/oidc/key-form.js
+++ b/ui/app/components/oidc/key-form.js
@@ -23,6 +23,7 @@ export default class OidcKeyForm extends Component {
   @service store;
   @service flashMessages;
   @tracked errorBanner;
+  @tracked invalidFormMessage;
   @tracked modelValidations;
   @tracked radioCardGroupValue =
     // If "*" is provided, all clients are allowed: https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#parameters
@@ -54,8 +55,9 @@ export default class OidcKeyForm extends Component {
   *save(event) {
     event.preventDefault();
     try {
-      const { isValid, state } = this.args.model.validate();
+      const { isValid, state, invalidFormMessage } = this.args.model.validate();
       this.modelValidations = isValid ? null : state;
+      this.invalidFormMessage = invalidFormMessage;
       if (isValid) {
         const { isNew, name } = this.args.model;
         if (this.radioCardGroupValue === 'allow_all') {

--- a/ui/app/components/oidc/key-form.js
+++ b/ui/app/components/oidc/key-form.js
@@ -23,7 +23,7 @@ export default class OidcKeyForm extends Component {
   @service store;
   @service flashMessages;
   @tracked errorBanner;
-  @tracked invalidFormMessage;
+  @tracked invalidFormAlert;
   @tracked modelValidations;
   @tracked radioCardGroupValue =
     // If "*" is provided, all clients are allowed: https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#parameters
@@ -78,6 +78,7 @@ export default class OidcKeyForm extends Component {
     } catch (error) {
       const message = error.errors ? error.errors.join('. ') : error.message;
       this.errorBanner = message;
+      this.invalidFormAlert = 'There was an error submitting this form.';
     }
   }
 }

--- a/ui/app/components/oidc/key-form.js
+++ b/ui/app/components/oidc/key-form.js
@@ -22,7 +22,7 @@ import { task } from 'ember-concurrency';
 export default class OidcKeyForm extends Component {
   @service store;
   @service flashMessages;
-
+  @tracked errorBanner;
   @tracked modelValidations;
   @tracked radioCardGroupValue =
     // If "*" is provided, all clients are allowed: https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#parameters
@@ -75,7 +75,7 @@ export default class OidcKeyForm extends Component {
       }
     } catch (error) {
       const message = error.errors ? error.errors.join('. ') : error.message;
-      this.flashMessages.danger(message);
+      this.errorBanner = message;
     }
   }
 }

--- a/ui/app/components/oidc/provider-form.js
+++ b/ui/app/components/oidc/provider-form.js
@@ -63,7 +63,7 @@ export default class OidcProviderForm extends Component {
     try {
       const { isValid, state, invalidFormMessage } = this.args.model.validate();
       this.modelValidations = isValid ? null : state;
-      this.invalidFormMessage = invalidFormMessage;
+      this.invalidFormAlert = invalidFormMessage;
       if (isValid) {
         const { isNew, name } = this.args.model;
         if (this.radioCardGroupValue === 'allow_all') {

--- a/ui/app/components/oidc/provider-form.js
+++ b/ui/app/components/oidc/provider-form.js
@@ -23,7 +23,7 @@ import parseURL from 'core/utils/parse-url';
 export default class OidcProviderForm extends Component {
   @service store;
   @service flashMessages;
-
+  @tracked errorBanner;
   @tracked modelValidations;
   @tracked radioCardGroupValue =
     // If "*" is provided, all clients are allowed: https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#parameters
@@ -77,7 +77,7 @@ export default class OidcProviderForm extends Component {
       }
     } catch (error) {
       const message = error.errors ? error.errors.join('. ') : error.message;
-      this.flashMessages.danger(message);
+      this.errorBanner = message;
     }
   }
 }

--- a/ui/app/components/oidc/provider-form.js
+++ b/ui/app/components/oidc/provider-form.js
@@ -4,7 +4,6 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import parseURL from 'core/utils/parse-url';
-
 /**
  * @module OidcProviderForm
  * OidcProviderForm components are used to create and update OIDC providers
@@ -23,8 +22,9 @@ import parseURL from 'core/utils/parse-url';
 export default class OidcProviderForm extends Component {
   @service store;
   @service flashMessages;
-  @tracked errorBanner;
   @tracked modelValidations;
+  @tracked errorBanner;
+  @tracked invalidFormMessage;
   @tracked radioCardGroupValue =
     // If "*" is provided, all clients are allowed: https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#parameters
     !this.args.model.allowedClientIds || this.args.model.allowedClientIds.includes('*')
@@ -61,8 +61,9 @@ export default class OidcProviderForm extends Component {
   *save(event) {
     event.preventDefault();
     try {
-      const { isValid, state } = this.args.model.validate();
+      const { isValid, state, invalidFormMessage } = this.args.model.validate();
       this.modelValidations = isValid ? null : state;
+      this.invalidFormMessage = invalidFormMessage;
       if (isValid) {
         const { isNew, name } = this.args.model;
         if (this.radioCardGroupValue === 'allow_all') {

--- a/ui/app/components/oidc/provider-form.js
+++ b/ui/app/components/oidc/provider-form.js
@@ -24,7 +24,7 @@ export default class OidcProviderForm extends Component {
   @service flashMessages;
   @tracked modelValidations;
   @tracked errorBanner;
-  @tracked invalidFormMessage;
+  @tracked invalidFormAlert;
   @tracked radioCardGroupValue =
     // If "*" is provided, all clients are allowed: https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#parameters
     !this.args.model.allowedClientIds || this.args.model.allowedClientIds.includes('*')
@@ -79,6 +79,7 @@ export default class OidcProviderForm extends Component {
     } catch (error) {
       const message = error.errors ? error.errors.join('. ') : error.message;
       this.errorBanner = message;
+      this.invalidFormAlert = 'There was an error submitting this form.';
     }
   }
 }

--- a/ui/app/components/oidc/scope-form.js
+++ b/ui/app/components/oidc/scope-form.js
@@ -22,6 +22,7 @@ import { inject as service } from '@ember/service';
 export default class OidcScopeFormComponent extends Component {
   @service flashMessages;
   @tracked errorBanner;
+  @tracked invalidFormMessage;
   @tracked modelValidations;
   // formatting here is purposeful so that whitespace renders correctly in JsonEditor
   exampleTemplate = `{
@@ -37,8 +38,9 @@ export default class OidcScopeFormComponent extends Component {
   *save(event) {
     event.preventDefault();
     try {
-      const { isValid, state } = this.args.model.validate();
+      const { isValid, state, invalidFormMessage } = this.args.model.validate();
       this.modelValidations = isValid ? null : state;
+      this.invalidFormMessage = invalidFormMessage;
       if (isValid) {
         const { isNew, name } = this.args.model;
         yield this.args.model.save();

--- a/ui/app/components/oidc/scope-form.js
+++ b/ui/app/components/oidc/scope-form.js
@@ -40,7 +40,7 @@ export default class OidcScopeFormComponent extends Component {
     try {
       const { isValid, state, invalidFormMessage } = this.args.model.validate();
       this.modelValidations = isValid ? null : state;
-      this.invalidFormMessage = invalidFormMessage;
+      this.invalidFormAlert = invalidFormMessage;
       if (isValid) {
         const { isNew, name } = this.args.model;
         yield this.args.model.save();

--- a/ui/app/components/oidc/scope-form.js
+++ b/ui/app/components/oidc/scope-form.js
@@ -22,7 +22,7 @@ import { inject as service } from '@ember/service';
 export default class OidcScopeFormComponent extends Component {
   @service flashMessages;
   @tracked errorBanner;
-  @tracked invalidFormMessage;
+  @tracked invalidFormAlert;
   @tracked modelValidations;
   // formatting here is purposeful so that whitespace renders correctly in JsonEditor
   exampleTemplate = `{
@@ -50,6 +50,7 @@ export default class OidcScopeFormComponent extends Component {
     } catch (error) {
       const message = error.errors ? error.errors.join('. ') : error.message;
       this.errorBanner = message;
+      this.invalidFormAlert = 'There was an error submitting this form.';
     }
   }
   @action

--- a/ui/app/components/oidc/scope-form.js
+++ b/ui/app/components/oidc/scope-form.js
@@ -21,7 +21,7 @@ import { inject as service } from '@ember/service';
 
 export default class OidcScopeFormComponent extends Component {
   @service flashMessages;
-
+  @tracked errorBanner;
   @tracked modelValidations;
   // formatting here is purposeful so that whitespace renders correctly in JsonEditor
   exampleTemplate = `{
@@ -47,7 +47,7 @@ export default class OidcScopeFormComponent extends Component {
       }
     } catch (error) {
       const message = error.errors ? error.errors.join('. ') : error.message;
-      this.flashMessages.danger(message);
+      this.errorBanner = message;
     }
   }
   @action

--- a/ui/app/models/oidc/client.js
+++ b/ui/app/models/oidc/client.js
@@ -12,6 +12,7 @@ const validations = {
       message: 'Name cannot contain whitespace.',
     },
   ],
+  key: [{ type: 'presence', message: 'Key is required.' }],
 };
 
 @withModelValidations(validations)

--- a/ui/app/styles/core/forms.scss
+++ b/ui/app/styles/core/forms.scss
@@ -331,6 +331,11 @@ select.has-error-border {
   border: 1px solid $red-500;
 }
 
+.dropdown-has-error-border > div.ember-basic-dropdown-trigger {
+  border: 1px solid $red-500;
+}
+
+
 .autocomplete-input {
   background: $white !important;
   border: 1px solid $grey-light;

--- a/ui/app/templates/components/oidc/assignment-form.hbs
+++ b/ui/app/templates/components/oidc/assignment-form.hbs
@@ -91,5 +91,10 @@
     >
       Cancel
     </button>
+    {{#if this.invalidFormMessage}}
+      <div class="control">
+        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormMessage}} @mimicRefresh={{true}} />
+      </div>
+    {{/if}}
   </div>
 </form>

--- a/ui/app/templates/components/oidc/assignment-form.hbs
+++ b/ui/app/templates/components/oidc/assignment-form.hbs
@@ -71,9 +71,6 @@
     />
   </div>
   <div class="has-top-padding-s">
-    {{#if this.modelValidations.targets.errors}}
-      <AlertInline @type="danger" @message={{join ", " this.modelValidations.targets.errors}} class="has-top-margin-m" />
-    {{/if}}
     <button
       type="submit"
       class="button is-primary {{if this.save.isRunning 'is-loading'}}"
@@ -91,10 +88,8 @@
     >
       Cancel
     </button>
-    {{#if this.invalidFormAlert}}
-      <div class="control">
-        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
-      </div>
+    {{#if this.modelValidations.targets.errors}}
+      <AlertInline @type="danger" @message={{join ", " this.modelValidations.targets.errors}} @paddingTop={{true}} />
     {{/if}}
   </div>
 </form>

--- a/ui/app/templates/components/oidc/assignment-form.hbs
+++ b/ui/app/templates/components/oidc/assignment-form.hbs
@@ -91,9 +91,9 @@
     >
       Cancel
     </button>
-    {{#if this.invalidFormMessage}}
+    {{#if this.invalidFormAlert}}
       <div class="control">
-        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormMessage}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
       </div>
     {{/if}}
   </div>

--- a/ui/app/templates/components/oidc/assignment-form.hbs
+++ b/ui/app/templates/components/oidc/assignment-form.hbs
@@ -29,6 +29,7 @@
 {{/unless}}
 <form {{on "submit" (perform this.save)}}>
   <div class="box is-sideless is-fullwidth is-marginless">
+    <MessageError @errorMessage={{this.errorBanner}} class="has-top-margin-s" />
     <FormFieldLabel for="name" @label="Name" />
     <input
       autocomplete="off"

--- a/ui/app/templates/components/oidc/client-form.hbs
+++ b/ui/app/templates/components/oidc/client-form.hbs
@@ -90,5 +90,10 @@
         Cancel
       </button>
     </div>
+    {{#if this.invalidFormMessage}}
+      <div class="control">
+        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormMessage}} @mimicRefresh={{true}} />
+      </div>
+    {{/if}}
   </div>
 </form>

--- a/ui/app/templates/components/oidc/client-form.hbs
+++ b/ui/app/templates/components/oidc/client-form.hbs
@@ -90,9 +90,9 @@
         Cancel
       </button>
     </div>
-    {{#if this.invalidFormMessage}}
+    {{#if this.invalidFormAlert}}
       <div class="control">
-        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormMessage}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
       </div>
     {{/if}}
   </div>

--- a/ui/app/templates/components/oidc/client-form.hbs
+++ b/ui/app/templates/components/oidc/client-form.hbs
@@ -26,7 +26,7 @@
 </PageHeader>
 <form {{on "submit" (perform this.save)}}>
   <div class="box is-sideless is-fullwidth is-bottomless">
-    <MessageError @errorMessage={{this.error}} class="has-top-margin-s" />
+    <MessageError @errorMessage={{this.errorBanner}} class="has-top-margin-s" />
     {{#each @model.formFields as |attr|}}
       <FormField @attr={{attr}} @model={{@model}} @modelValidations={{this.modelValidations}} />
     {{/each}}

--- a/ui/app/templates/components/oidc/key-form.hbs
+++ b/ui/app/templates/components/oidc/key-form.hbs
@@ -87,9 +87,9 @@
         Cancel
       </button>
     </div>
-    {{#if this.invalidFormMessage}}
+    {{#if this.invalidFormAlert}}
       <div class="control">
-        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormMessage}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
       </div>
     {{/if}}
   </div>

--- a/ui/app/templates/components/oidc/key-form.hbs
+++ b/ui/app/templates/components/oidc/key-form.hbs
@@ -87,5 +87,10 @@
         Cancel
       </button>
     </div>
+    {{#if this.invalidFormMessage}}
+      <div class="control">
+        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormMessage}} @mimicRefresh={{true}} />
+      </div>
+    {{/if}}
   </div>
 </form>

--- a/ui/app/templates/components/oidc/key-form.hbs
+++ b/ui/app/templates/components/oidc/key-form.hbs
@@ -27,7 +27,7 @@
 
 <form {{on "submit" (perform this.save)}}>
   <div class="box is-sideless is-fullwidth is-bottomless">
-    <MessageError @errorMessage={{this.error}} class="has-top-margin-s" />
+    <MessageError @errorMessage={{this.errorBanner}} class="has-top-margin-s" />
     {{#each @model.formFields as |attr|}}
       <FormField @attr={{attr}} @model={{@model}} @modelValidations={{this.modelValidations}} />
     {{/each}}

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -27,7 +27,7 @@
 
 <form {{on "submit" (perform this.save)}}>
   <div class="box is-sideless is-fullwidth is-bottomless">
-    <MessageError @errorMessage={{this.error}} class="has-top-margin-s" />
+    <MessageError @errorMessage={{this.errorBanner}} class="has-top-margin-s" />
     {{! name field }}
     <FormField
       data-test-field={{true}}

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -118,9 +118,9 @@
         Cancel
       </button>
     </div>
-    {{#if this.invalidFormMessage}}
+    {{#if this.invalidFormAlert}}
       <div class="control">
-        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormMessage}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
       </div>
     {{/if}}
   </div>

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -118,5 +118,10 @@
         Cancel
       </button>
     </div>
+    {{#if this.invalidFormMessage}}
+      <div class="control">
+        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormMessage}} @mimicRefresh={{true}} />
+      </div>
+    {{/if}}
   </div>
 </form>

--- a/ui/app/templates/components/oidc/scope-form.hbs
+++ b/ui/app/templates/components/oidc/scope-form.hbs
@@ -31,6 +31,7 @@
     <p class="has-bottom-margin-l">
       Providers may reference a set of scopes to make specific identity information available as claims
     </p>
+    <MessageError @errorMessage={{this.errorBanner}} class="has-top-margin-s" />
     {{#each @model.formFields as |field|}}
       <FormField @attr={{field}} @model={{@model}} @modelValidations={{this.modelValidations}} />
     {{/each}}

--- a/ui/app/templates/components/oidc/scope-form.hbs
+++ b/ui/app/templates/components/oidc/scope-form.hbs
@@ -66,6 +66,11 @@
       Cancel
     </button>
   </div>
+  {{#if this.invalidFormMessage}}
+    <div class="control">
+      <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormMessage}} @mimicRefresh={{true}} />
+    </div>
+  {{/if}}
 </form>
 
 <Modal

--- a/ui/app/templates/components/oidc/scope-form.hbs
+++ b/ui/app/templates/components/oidc/scope-form.hbs
@@ -66,9 +66,9 @@
       Cancel
     </button>
   </div>
-  {{#if this.invalidFormMessage}}
+  {{#if this.invalidFormAlert}}
     <div class="control">
-      <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormMessage}} @mimicRefresh={{true}} />
+      <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
     </div>
   {{/if}}
 </form>

--- a/ui/lib/core/addon/components/alert-inline.hbs
+++ b/ui/lib/core/addon/components/alert-inline.hbs
@@ -1,5 +1,5 @@
 <div
-  {{did-update this.refresh @message}}
+  {{did-update this.refresh this.displayMessage}}
   class={{concat "message-inline" this.paddingTop this.isMarginless this.sizeSmall}}
   data-test-inline-alert
   ...attributes
@@ -12,7 +12,7 @@
       {{#if (has-block)}}
         {{yield}}
       {{else}}
-        {{@message}}
+        {{this.displayMessage}}
       {{/if}}
     </p>
   {{/if}}

--- a/ui/lib/core/addon/components/alert-inline.hbs
+++ b/ui/lib/core/addon/components/alert-inline.hbs
@@ -1,5 +1,5 @@
 <div
-  {{did-update this.refresh this.displayMessage}}
+  {{did-update this.refresh @message}}
   class={{concat "message-inline" this.paddingTop this.isMarginless this.sizeSmall}}
   data-test-inline-alert
   ...attributes
@@ -12,7 +12,7 @@
       {{#if (has-block)}}
         {{yield}}
       {{else}}
-        {{this.displayMessage}}
+        {{@message}}
       {{/if}}
     </p>
   {{/if}}

--- a/ui/lib/core/addon/components/alert-inline.js
+++ b/ui/lib/core/addon/components/alert-inline.js
@@ -19,7 +19,6 @@ import { messageTypes } from 'core/helpers/message-types';
  * @param {boolean} [isMarginless=false] - Whether or not to remove margin bottom below component.
  * @param {boolean} [sizeSmall=false] - Whether or not to display a small font with padding below of alert message.
  * @param {boolean} [mimicRefresh=false] - If true will display a loading icon when attributes change (e.g. when a form submits and the alert message changes).
- * @param {number} [formErrorCount=null] - Number of errors (i.e. error.errors.length) to display an inline alert (typically be the submit button).
  */
 
 export default class AlertInlineComponent extends Component {
@@ -50,18 +49,6 @@ export default class AlertInlineComponent extends Component {
 
   get alertType() {
     return messageTypes([this.args.type]);
-  }
-
-  get displayMessage() {
-    const { formErrorCount, message } = this.args;
-    return formErrorCount ? this.generateErrorCountMessage(formErrorCount) : message;
-  }
-
-  generateErrorCountMessage(errorCount) {
-    if (errorCount < 1) return null;
-    // returns count specific message: 'There is an error/are N errors with this form.'
-    let isPlural = errorCount > 1 ? `are ${errorCount} errors` : false;
-    return `There ${isPlural ? isPlural : 'is an error'} with this form.`;
   }
 
   @action

--- a/ui/lib/core/addon/components/alert-inline.js
+++ b/ui/lib/core/addon/components/alert-inline.js
@@ -13,12 +13,13 @@ import { messageTypes } from 'core/helpers/message-types';
  * <AlertInline @type="danger" @message="{{model.keyId}} is not a valid lease ID"/>
  * ```
  *
- * @param type=null{String} - The alert type passed to the message-types helper.
- * @param [message=null]{String} - The message to display within the alert.
- * @param [paddingTop=false]{Boolean} - Whether or not to add padding above component.
- * @param [isMarginless=false]{Boolean} - Whether or not to remove margin bottom below component.
- * @param [sizeSmall=false]{Boolean} - Whether or not to display a small font with padding below of alert message.
- * @param [mimicRefresh=false]{Boolean} - If true will display a loading icon when attributes change (e.g. when a form submits and the alert message changes).
+ * @param {string} type=null - The alert type passed to the message-types helper.
+ * @param {string} [message=null] - The message to display within the alert.
+ * @param {boolean} [paddingTop=false] - Whether or not to add padding above component.
+ * @param {boolean} [isMarginless=false] - Whether or not to remove margin bottom below component.
+ * @param {boolean} [sizeSmall=false] - Whether or not to display a small font with padding below of alert message.
+ * @param {boolean} [mimicRefresh=false] - If true will display a loading icon when attributes change (e.g. when a form submits and the alert message changes).
+ * @param {number} [formErrorCount=null] - Number of errors (i.e. error.errors.length) to display an inline alert (typically be the submit button).
  */
 
 export default class AlertInlineComponent extends Component {
@@ -49,6 +50,18 @@ export default class AlertInlineComponent extends Component {
 
   get alertType() {
     return messageTypes([this.args.type]);
+  }
+
+  get displayMessage() {
+    const { formErrorCount, message } = this.args;
+    return formErrorCount ? this.generateErrorCountMessage(formErrorCount) : message;
+  }
+
+  generateErrorCountMessage(errorCount) {
+    if (errorCount < 1) return null;
+    // returns count specific message: 'There is an error/are N errors with this form.'
+    let isPlural = errorCount > 1 ? `are ${errorCount} errors` : false;
+    return `There ${isPlural ? isPlural : 'is an error'} with this form.`;
   }
 
   @action

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -93,8 +93,12 @@
         @backend={{@model.backend}}
         @disallowNewItems={{@attr.options.onlyAllowExisting}}
         @labelClass={{@labelClass}}
+        class={{if this.validationError "dropdown-has-error-border"}}
       />
     </div>
+    {{#if this.validationError}}
+      <AlertInline @type="danger" @message={{this.validationError}} @paddingTop={{true}} />
+    {{/if}}
   {{else if (eq @attr.options.editType "mountAccessor")}}
     <MountAccessorSelect
       @name={{@attr.name}}

--- a/ui/tests/acceptance/oidc-config/clients-test.js
+++ b/ui/tests/acceptance/oidc-config/clients-test.js
@@ -4,13 +4,14 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import ENV from 'vault/config/environment';
 import authPage from 'vault/tests/pages/auth';
-import { OIDC_BASE_URL, SELECTORS } from 'vault/tests/helpers/oidc-config';
 import logout from 'vault/tests/pages/logout';
 import { create } from 'ember-cli-page-object';
 import { clickTrigger } from 'ember-power-select/test-support/helpers';
 import ss from 'vault/tests/pages/components/search-select';
 import fm from 'vault/tests/pages/components/flash-message';
 import {
+  OIDC_BASE_URL,
+  SELECTORS,
   clearRecord,
   overrideCapabilities,
   overrideMirageResponse,

--- a/ui/tests/helpers/oidc-config.js
+++ b/ui/tests/helpers/oidc-config.js
@@ -8,6 +8,7 @@ export const SELECTORS = {
   oidcRouteTabs: '[data-test-oidc-tabs]',
   oidcLandingImg: '[data-test-oidc-img]',
   confirmDeleteButton: '[data-test-confirm-button="true"]',
+  inlineAlert: '[data-test-inline-alert]',
   // client route
   clientSaveButton: '[data-test-oidc-client-save]',
   clientCancelButton: '[data-test-oidc-client-cancel]',

--- a/ui/tests/integration/components/oidc/key-form-test.js
+++ b/ui/tests/integration/components/oidc/key-form-test.js
@@ -4,7 +4,13 @@ import { render, fillIn, click, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import ENV from 'vault/config/environment';
-import { overrideMirageResponse, CLIENT_LIST_RESPONSE } from 'vault/tests/helpers/oidc-config';
+import {
+  OIDC_BASE_URL,
+  CLIENT_LIST_RESPONSE,
+  SELECTORS,
+  overrideMirageResponse,
+  overrideCapabilities,
+} from 'vault/tests/helpers/oidc-config';
 
 module('Integration | Component | oidc/key-form', function (hooks) {
   setupRenderingTest(hooks);
@@ -45,15 +51,14 @@ module('Integration | Component | oidc/key-form', function (hooks) {
     assert.equal(findAll('[data-test-field]').length, 4, 'renders all input fields');
 
     // check validation errors
+    await fillIn('[data-test-input="name"]', ' ');
     await click('[data-test-oidc-key-save]');
+
+    let validationErrors = findAll(SELECTORS.inlineAlert);
     assert
-      .dom('[data-test-inline-error-message]')
-      .hasText('Name is required.', 'Validation message is shown for name');
-    await fillIn('[data-test-input="name"]', 'test space');
-    await click('[data-test-oidc-key-save]');
-    assert
-      .dom('[data-test-inline-error-message]')
-      .hasText('Name cannot contain whitespace.', 'Validation message is shown whitespace');
+      .dom(validationErrors[0])
+      .hasText('Name is required. Name cannot contain whitespace.', 'Validation messages are shown for name');
+    assert.dom(validationErrors[1]).hasText('There are 2 errors with this form.', 'Renders form error count');
 
     await click('label[for=limited]');
     assert
@@ -158,5 +163,24 @@ module('Integration | Component | oidc/key-form', function (hooks) {
     assert
       .dom('[data-test-component="search-select"]#allowedClientIds [data-test-component="string-list"]')
       .exists('Radio toggle shows assignments string-list input');
+  });
+
+  test('it should render error alerts when API returns an error', async function (assert) {
+    assert.expect(2);
+    this.model = this.store.createRecord('oidc/key');
+    this.server.post('/sys/capabilities-self', () => overrideCapabilities(OIDC_BASE_URL + '/keys'));
+    await render(hbs`
+      <Oidc::KeyForm
+        @model={{this.model}}
+        @onCancel={{this.onCancel}}
+        @onSave={{this.onSave}}
+      />
+    `);
+    await fillIn('[data-test-input="name"]', 'some-app');
+    await click('[data-test-oidc-key-save]');
+    assert
+      .dom(SELECTORS.inlineAlert)
+      .hasText('There was an error submitting this form.', 'form error alert renders ');
+    assert.dom('[data-test-alert-banner="alert"]').exists('alert banner renders');
   });
 });

--- a/ui/tests/unit/adapters/oidc/test-helper.js
+++ b/ui/tests/unit/adapters/oidc/test-helper.js
@@ -70,7 +70,7 @@ export default (test) => {
       },
     };
 
-    this.server.get(`/identity/${this.modelName}`, (schema, req) => {
+    this.server.get(`/identity/${this.modelName}`, () => {
       if (keyInfoModels.some((model) => this.modelName.includes(model))) {
         return { data: { keys, key_info } };
       } else {


### PR DESCRIPTION
### Checks if a model already exists before sending a `POST` request to `identity/oidc/<model>/:name`

<img width="1106" alt="Screen Shot 2022-08-22 at 3 01 32 PM" src="https://user-images.githubusercontent.com/68122737/186026419-0fc32807-b373-4856-be6b-884014c5e79d.png">

### Also adds an inline alert if there's a form error:
<img width="276" alt="Screen Shot 2022-08-23 at 5 15 59 PM" src="https://user-images.githubusercontent.com/68122737/186287767-4602695b-10fc-4e34-bac2-31f92ee2ba0c.png">


### adds styling for search-select validation errors: 

<img width="1033" alt="Screen Shot 2022-08-23 at 11 10 48 AM" src="https://user-images.githubusercontent.com/68122737/186287703-ac24d9fe-f2c4-47af-9343-41ab58624212.png">

