### PR TITLE
Docs: SSH CA Config & Comments. Resolves: #7529

### DIFF
--- a/changelog/16826.txt
+++ b/changelog/16826.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-website/docs: SSH CA Certificate notes clarifying how to preserve comment attributes in keys.
-```

--- a/changelog/16826.txt
+++ b/changelog/16826.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+website/docs: SSH CA Certificate notes clarifying how to preserve comment attributes in keys.
+```

--- a/website/content/docs/secrets/ssh/signed-ssh-certificates.mdx
+++ b/website/content/docs/secrets/ssh/signed-ssh-certificates.mdx
@@ -508,8 +508,7 @@ curl -X POST -H "X-Vault-Token: ..." -d @payload.json http://127.0.0.1:8200/v1/h
 ```
 
 ~> **IMPORTANT:** Do NOT add a private key password since Vault can't decrypt it.
-Destroy the keypair and `payload.json` from your hosts immediately after they have  
-been confirmed as successfully uploaded.
+Destroy the keypair and `payload.json` from your hosts immediately after they have been confirmed as successfully uploaded.
 
 ### Known Issues
 - On SELinux-enforcing systems, you may need to adjust related types so that the

--- a/website/content/docs/secrets/ssh/signed-ssh-certificates.mdx
+++ b/website/content/docs/secrets/ssh/signed-ssh-certificates.mdx
@@ -466,6 +466,51 @@ forwarding. See [no prompt after login](#no-prompt-after-login) for examples.
 }
 ```
 
+### Key Comments
+There are additional steps needed to preserve [comment attributes](https://docs.oasis-open.org/kmip/kmip-spec/v2.1/cs01/kmip-spec-v2.1-cs01.html#_Toc32239331)
+in keys which ought to be considered if they are required. Private and public 
+key may have comments applied to them and for example where `ssh-keygen` is used 
+with its `-C` parameter - similar to:
+
+```shell-session
+ssh-keygen -C "...Comments" -N "" -t rsa -b 4096 -f host-ca
+```
+
+Adapted key values containing comments must be provided with the key related 
+parameters as per the Vault CLI and API steps demonstrated below. 
+
+```shell-extension
+# Using CLI:
+vault secrets enable -path=hosts-ca ssh
+KEY_PRI=$(cat ~/.ssh/id_rsa | tr '\n' '*' | sed 's/\*/\\n/g')
+KEY_PUB=$(cat ~/.ssh/id_rsa.pub | tr '\n' '*' | sed 's/\*/\\n/g')
+# Create / Update keypair in Vault
+vault write ssh-client-signer/config/ca \
+  generate_signing_key=false \
+  private_key="${KEY_PRI}" \
+  public_key="${KEY_PUB}"
+```
+
+```shell-extension
+# Using API:
+curl -X POST -H "X-Vault-Token: ..." -d '{"type":"ssh"}' http://127.0.0.1:8200/v1/sys/mounts/hosts-ca
+KEY_PRI=$(cat ~/.ssh/id_rsa | tr '\n' '*' | sed 's/\*/\\n/g')
+KEY_PUB=$(cat ~/.ssh/id_rsa.pub | tr '\n' '*' | sed 's/\*/\\n/g')
+tee payload.json <<EOF
+{
+  "generate_signing_key" : false,
+  "private_key"          : "${KEY_PRI}",
+  "public_key"           : "${KEY_PUB}"
+}
+EOF
+# Create / Update keypair in Vault
+curl -X POST -H "X-Vault-Token: ..." -d @payload.json http://127.0.0.1:8200/v1/hosts-ca/config/ca
+```
+
+~> **IMPORTANT:** Do NOT add a private key password since Vault can't decrypt it.
+Destroy the keypair and `payload.json` from your hosts immediately after they have  
+been confirmed as successfully uploaded.
+
 ### Known Issues
 - On SELinux-enforcing systems, you may need to adjust related types so that the
   SSH daemon is able to read it. For example, adjust the signed host certificate

--- a/website/content/docs/secrets/ssh/signed-ssh-certificates.mdx
+++ b/website/content/docs/secrets/ssh/signed-ssh-certificates.mdx
@@ -467,7 +467,7 @@ forwarding. See [no prompt after login](#no-prompt-after-login) for examples.
 ```
 
 ### Key Comments
-There are additional steps needed to preserve [comment attributes](https://docs.oasis-open.org/kmip/kmip-spec/v2.1/cs01/kmip-spec-v2.1-cs01.html#_Toc32239331)
+There are additional steps needed to preserve [comment attributes](https://www.rfc-editor.org/rfc/rfc4716#section-3.3.2)
 in keys which ought to be considered if they are required. Private and public 
 key may have comments applied to them and for example where `ssh-keygen` is used 
 with its `-C` parameter - similar to:
@@ -482,8 +482,8 @@ parameters as per the Vault CLI and API steps demonstrated below.
 ```shell-extension
 # Using CLI:
 vault secrets enable -path=hosts-ca ssh
-KEY_PRI=$(cat ~/.ssh/id_rsa | tr '\n' '*' | sed 's/\*/\\n/g')
-KEY_PUB=$(cat ~/.ssh/id_rsa.pub | tr '\n' '*' | sed 's/\*/\\n/g')
+KEY_PRI=$(cat ~/.ssh/id_rsa | sed -z 's/\n/\\n/g')
+KEY_PUB=$(cat ~/.ssh/id_rsa.pub | sed -z 's/\n/\\n/g')
 # Create / Update keypair in Vault
 vault write ssh-client-signer/config/ca \
   generate_signing_key=false \
@@ -494,8 +494,8 @@ vault write ssh-client-signer/config/ca \
 ```shell-extension
 # Using API:
 curl -X POST -H "X-Vault-Token: ..." -d '{"type":"ssh"}' http://127.0.0.1:8200/v1/sys/mounts/hosts-ca
-KEY_PRI=$(cat ~/.ssh/id_rsa | tr '\n' '*' | sed 's/\*/\\n/g')
-KEY_PUB=$(cat ~/.ssh/id_rsa.pub | tr '\n' '*' | sed 's/\*/\\n/g')
+KEY_PRI=$(cat ~/.ssh/id_rsa | sed -z 's/\n/\\n/g')
+KEY_PUB=$(cat ~/.ssh/id_rsa.pub | sed -z 's/\n/\\n/g')
 tee payload.json <<EOF
 {
   "generate_signing_key" : false,


### PR DESCRIPTION
Relates to website section: [vaultproject.io/docs/secrets/ssh/signed-ssh-certificates](https://www.vaultproject.io/docs/secrets/ssh/signed-ssh-certificates) & Issue request #7529 - which still seems relevant and the clarity note would still be welcome.

Original request was asking for API addition - however given the nature of the request and explanations required it's been detailed instead in the bottom of the page near the Troubleshoot and Known issues area.

<img width="1179" alt="Screenshot 2022-08-23 at 01 38 38" src="https://user-images.githubusercontent.com/974854/186038630-c745fa37-91f6-481c-b186-d1c9d7db8fcf.png">

