### PR TITLE
Fix incorrect MaxNsIdLength

### DIFF
--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -71,8 +71,8 @@ const (
 	// any namespace information
 	TokenLength = 24
 
-	// MaxNsIdLength is the maximum namespace ID length (4 characters prepended by a ".")
-	MaxNsIdLength = 5
+	// MaxNsIdLength is the maximum namespace ID length (5 characters prepended by a ".")
+	MaxNsIdLength = 6
 
 	// TokenPrefixLength is the length of the new token prefixes ("hvs.", "hvb.",
 	// and "hvr.")


### PR DESCRIPTION
Namespace IDs are 5 characters, not 4.

The practical implication of this is that the IsSSCToken heuristic comes
up with the wrong answer when presented with a child namespace non-SSC
token, leading to Vault attempting to base64 decode it, leading to noise
in the logs:

```
[WARN]  core: cannot decode token: error="illegal base64 data at input byte 24"
```