### PR TITLE
Fix cherrypick on backport to 1.11.x

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -83,7 +83,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 				"issuer/+/pem",
 				"issuer/+/der",
 				"issuer/+/json",
-				"issuers",
+				"issuers/", // LIST operations append a '/' to the requested path
 			},
 
 			LocalStorage: []string{

--- a/changelog/16830.txt
+++ b/changelog/16830.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: LIST issuers endpoint is now unauthenticated.
+```


### PR DESCRIPTION
LIST operation backport fixes failure to cherrypick.