### PR TITLE
command/debug: fix bug where monitor was not honoring configured duration

### DIFF
--- a/changelog/16834.txt
+++ b/changelog/16834.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-debug: Fix issue when capturing logs for debug duration longer than 2 minutes
+command/debug: fix bug where monitor was not honoring configured duration
 ```

--- a/changelog/16834.txt
+++ b/changelog/16834.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+debug: Fix issue when capturing logs for debug duration longer than 2 minutes
+```


### PR DESCRIPTION
This PR fixes a bug in the log target for vault debug. When defining a debug duration length longer than two minutes, the vault.log file in the debug package would only have the first two minutes of logs emitted during the window, and then have newlines for the remainder of the time frame.