### PR TITLE
Finish refactor to remove global crlLifetime

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -193,7 +193,6 @@ type backend struct {
 
 	backendUUID       string
 	storage           logical.Storage
-	crlLifetime       time.Duration
 	revokeStorageLock sync.RWMutex
 	tidyCASGuard      *uint32
 

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -842,6 +842,18 @@ func TestAutoRebuild(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Regression test: ensure we respond with the default values for CRL
+	// config when we haven't set any values yet.
+	resp, err := client.Logical().Read("pki/config/crl")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+	require.Equal(t, resp.Data["expiry"], defaultCrlConfig.Expiry)
+	require.Equal(t, resp.Data["disable"], defaultCrlConfig.Disable)
+	require.Equal(t, resp.Data["ocsp_disable"], defaultCrlConfig.OcspDisable)
+	require.Equal(t, resp.Data["auto_rebuild"], defaultCrlConfig.AutoRebuild)
+	require.Equal(t, resp.Data["auto_rebuild_grace_period"], defaultCrlConfig.AutoRebuildGracePeriod)
+
 	// Safety guard: we play with rebuild timing below. We don't expect
 	// this entire test to take longer than 80s.
 	_, err = client.Logical().Write("pki/config/crl", map[string]interface{}{
@@ -850,7 +862,7 @@ func TestAutoRebuild(t *testing.T) {
 	require.NoError(t, err)
 
 	// Issue a cert and revoke it. It should appear on the CRL right away.
-	resp, err := client.Logical().Write("pki/issue/local-testing", map[string]interface{}{
+	resp, err = client.Logical().Write("pki/issue/local-testing", map[string]interface{}{
 		"common_name": "example.com",
 	})
 	require.NoError(t, err)

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -1087,7 +1087,7 @@ func (sc *storageContext) getRevocationConfig() (*crlConfig, error) {
 
 	var result crlConfig
 	if entry == nil {
-		result.Expiry = sc.Backend.crlLifetime.String()
+		result = defaultCrlConfig
 		return &result, nil
 	}
 


### PR DESCRIPTION
Previously we used the global backend-set `crlLifetime` as a default
value. However, this was refactored into a new `defaultCrlConfig` instead,
which we should reply with when the CRL configuration has not been set
yet. In particular, the 72h default expiry (and new 12h auto-rebuild
grace period) was added and made explicit.

[This fixes the broken UI test](https://app.circleci.com/pipelines/github/hashicorp/vault/40020/workflows/bc2c9cf8-2353-4acb-a4fd-92c4967b6049/jobs/499177).

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

