### PR TITLE
identity/entity-alias: fix bug where wrong metadata was updated

### DIFF
--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -1223,7 +1223,7 @@ func (i *IdentityStore) CreateOrFetchEntity(ctx context.Context, alias *logical.
 // names match or no metadata is different, -1 is returned.
 func changedAliasIndex(entity *identity.Entity, alias *logical.Alias) int {
 	for i, a := range entity.Aliases {
-		if a.Name == alias.Name && !strutil.EqualStringMaps(a.Metadata, alias.Metadata) {
+		if a.Name == alias.Name && a.MountAccessor == alias.MountAccessor && !strutil.EqualStringMaps(a.Metadata, alias.Metadata) {
 			return i
 		}
 	}

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -805,3 +805,52 @@ func TestIdentityStore_NewEntityCounter(t *testing.T) {
 
 	expectSingleCount(t, sink, "identity.entity.creation")
 }
+
+func TestIdentityStore_UpdateAliasMetadataPerAccessor(t *testing.T) {
+	entity := &identity.Entity{
+		ID:       "testEntityID",
+		Name:     "testEntityName",
+		Policies: []string{"foo", "bar"},
+		Aliases: []*identity.Alias{
+			{
+				ID:            "testAliasID1",
+				CanonicalID:   "testEntityID",
+				MountType:     "testMountType",
+				MountAccessor: "testMountAccessor",
+				Name:          "sameAliasName",
+			},
+			{
+				ID:            "testAliasID2",
+				CanonicalID:   "testEntityID",
+				MountType:     "testMountType",
+				MountAccessor: "testMountAccessor2",
+				Name:          "sameAliasName",
+			},
+		},
+		NamespaceID: namespace.RootNamespaceID,
+	}
+
+	login := &logical.Alias{
+		MountType:     "testMountType",
+		MountAccessor: "testMountAccessor",
+		Name:          "sameAliasName",
+		ID:            "testAliasID",
+		Metadata:      map[string]string{"foo": "bar"},
+	}
+
+	if i := changedAliasIndex(entity, login); i != 0 {
+		t.Fatalf("wrong alias index changed. Expected 0, got %d", i)
+	}
+
+	login2 := &logical.Alias{
+		MountType:     "testMountType",
+		MountAccessor: "testMountAccessor2",
+		Name:          "sameAliasName",
+		ID:            "testAliasID2",
+		Metadata:      map[string]string{"bar": "foo"},
+	}
+
+	if i := changedAliasIndex(entity, login2); i != 1 {
+		t.Fatalf("wrong alias index changed. Expected 1, got %d", i)
+	}
+}


### PR DESCRIPTION
This fixes a bug in the Identity store where metadata can be leaked between aliases using the same name but have different mount accessors. This also can have adverse effects on Vault performance because it's causing unnecessary entity updates.