### PR TITLE
Updated Nomad Secret Engine docs with proper terminology

### DIFF
--- a/website/content/api-docs/secret/nomad.mdx
+++ b/website/content/api-docs/secret/nomad.mdx
@@ -1,19 +1,19 @@
 ---
 layout: api
-page_title: Nomad Secret Backend - HTTP API
-description: This is the API documentation for the Vault Nomad secret backend.
+page_title: Nomad Secrets Engine- HTTP API
+description: This is the API documentation for the Vault Nomad secrets engine.
 ---
 
-# Nomad Secret Backend HTTP API
+# Nomad Secrets Engine (API)
 
 @include 'x509-sha1-deprecation.mdx'
 
-This is the API documentation for the Vault Nomad secret backend. For general
-information about the usage and operation of the Nomad backend, please see the
-[Vault Nomad backend documentation](/docs/secrets/nomad).
+This is the API documentation for the Vault Nomad secrets engine. For general
+information about the usage and operation of the Nomad secrets engine, please see the
+[Vault Nomad secrets engine documentation](/docs/secrets/nomad).
 
-This documentation assumes the Nomad backend is mounted at the `/nomad` path
-in Vault. Since it is possible to mount secret backends at any location, please
+This documentation assumes the Nomad secrets engine is mounted at the `/nomad` path
+in Vault. Since it is possible to mount secrets engines at any location, please
 update your API calls accordingly.
 
 ## Configure Access
@@ -249,7 +249,7 @@ $ curl \
 
 ## List Roles
 
-This endpoint lists all existing roles in the backend.
+This endpoint lists all existing roles in the secrets engine.
 
 | Method | Path                    |
 | :----- | :---------------------- |

--- a/website/content/docs/secrets/nomad.mdx
+++ b/website/content/docs/secrets/nomad.mdx
@@ -1,28 +1,27 @@
 ---
 layout: docs
-page_title: Nomad Secret Backend
-description: The Nomad secret backend for Vault generates tokens for Nomad dynamically.
+page_title: Nomad Secrets Engine
+description: The Nomad secrets engine for Vault generates tokens for Nomad dynamically.
 ---
 
-# Nomad Secret Backend
+# Nomad Secrets Engine
 
 @include 'x509-sha1-deprecation.mdx'
 
 Name: `Nomad`
 
 Nomad is a simple, flexible scheduler and workload orchestrator. The Nomad
-secret backend for Vault generates [Nomad](https://www.nomadproject.io)
+secrets secrets engine for Vault generates [Nomad](https://www.nomadproject.io)
 ACL tokens dynamically based on pre-existing Nomad ACL policies.
 
-This page will show a quick start for this backend. For detailed documentation
-on every path, use `vault path-help` after mounting the backend.
+This page will show a quick start for this secrets engine. For detailed documentation
+on every path, use `vault path-help` after mounting the secrets engine.
 
 ~> **Version information** ACLs are only available on Nomad 0.7.0 and above.
 
 ## Quick Start
 
-The first step to using the vault backend is to mount it.
-Unlike the `generic` backend, the `nomad` backend is not mounted by default.
+The first step to using the Vault secrets engine is to enable it.
 
 ```shell-session
 $ vault secrets enable nomad
@@ -81,7 +80,7 @@ $ vault write nomad/role/monitoring policies=readonly
 Success! Data written to: nomad/role/monitoring
 ```
 
-The backend expects either a single or a comma separated list of policy names.
+The secrets engine expects either a single or a comma separated list of policy names.
 
 To generate a new Nomad ACL token, we simply read from that role:
 
@@ -120,6 +119,6 @@ step-by-step tutorial.
 
 ## API
 
-The Nomad secret backend has a full HTTP API. Please see the
-[Nomad secret backend API](/api-docs/secret/nomad) for more
+The Nomad secrets engine has a full HTTP API. Please see the
+[Nomad Secrets Engine API](/api-docs/secret/nomad) for more
 details.


### PR DESCRIPTION
This PR accomplishes what [PR 8983](https://github.com/hashicorp/vault/pull/8938) meant to do. 

Since PR 8983 was opened back in 2020, it's troublesome to merge the PR.  We'll fix the terminology with this PR and close PR 8983.