### PR TITLE
Cleanup changes around issuer revocation

### DIFF
--- a/builtin/logical/pki/chain_test.go
+++ b/builtin/logical/pki/chain_test.go
@@ -535,7 +535,7 @@ func (c CBIssueLeaf) RevokeLeaf(t testing.TB, b *backend, s logical.Storage, kno
 		t.Fatalf("failed to revoke issued certificate (%v) under role %v / issuer %v: expected response parameter revocation_time was missing from response:\n%v", api_serial, c.Role, c.Issuer, resp.Data)
 	}
 
-	if !hasCRL && isDefault {
+	if !hasCRL {
 		// Nothing further we can test here. We could re-enable CRL building
 		// and check that it works, but that seems like a stretch. Other
 		// issuers might be functionally the same as this issuer (and thus
@@ -614,7 +614,7 @@ func (c CBIssueLeaf) RevokeLeaf(t testing.TB, b *backend, s logical.Storage, kno
 			}
 		}
 
-		t.Fatalf("expected to find certificate with serial [%v] on issuer %v's CRL but was missing: %v revoked certs\n\nCRL:\n[%v]\n\nLeaf:\n[%v]\n\nIssuer:\n[%v]\n", api_serial, c.Issuer, len(crl.TBSCertList.RevokedCertificates), raw_crl, raw_cert, raw_issuer)
+		t.Fatalf("expected to find certificate with serial [%v] on issuer %v's CRL but was missing: %v revoked certs\n\nCRL:\n[%v]\n\nLeaf:\n[%v]\n\nIssuer (hasCRL: %v):\n[%v]\n", api_serial, c.Issuer, len(crl.TBSCertList.RevokedCertificates), raw_crl, raw_cert, hasCRL, raw_issuer)
 	}
 }
 

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -694,8 +694,14 @@ func TestIssuerRevocation(t *testing.T) {
 	_, err = CBRead(b, s, "crl/rotate")
 	require.NoError(t, err)
 
+	// Ensure the old cert isn't on its own CRL.
+	crl := getParsedCrlFromBackend(t, b, s, "issuer/root2/crl/der")
+	if requireSerialNumberInCRL(nil, crl.TBSCertList, revokedRootSerial) {
+		t.Fatalf("the serial number %v should not be on its own CRL as self-CRL appearance should not occur", revokedRootSerial)
+	}
+
 	// Ensure the old cert isn't on the one's CRL.
-	crl := getParsedCrlFromBackend(t, b, s, "issuer/root/crl/der")
+	crl = getParsedCrlFromBackend(t, b, s, "issuer/root/crl/der")
 	if requireSerialNumberInCRL(nil, crl.TBSCertList, revokedRootSerial) {
 		t.Fatalf("the serial number %v should not be on %v's CRL as they're separate roots", revokedRootSerial, oldRootSerial)
 	}

--- a/changelog/16874.txt
+++ b/changelog/16874.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Improve stability of association of revoked cert with its parent issuer; when an issuer loses crl-signing usage, do not place certs on default issuer's CRL.
+```


### PR DESCRIPTION
This makes four incremental improvements to revocation (around issuers and otherwise):

 1. Fixes the nits from the earlier auto-merged PR (sorry @kitography!) and updates the tests according to @stevendpclark's internal suggestions.
 2. Now that #16762 is merged and #16871 is opened, makes CRL building skip the step of doing cert association. This means we can exit fast if CRL building is disabled altogether.
 3. Fix a bug identified during an internal demo call, wherein a root appeared on its own CRL, and intermediates appearing multiple times (oops). This is because of @kitography's last-minute-but-good suggestion of writing out a fat revInfo entry for serials we see in storage, and my forgetting to filter them out when building the CRL. D'oh.
 4. The **most complex** change: actually addressing stability of revInfo<->issuer association, via delaying the crlSigning usage check. This means any issuer in the representative set can safely be assigned and stability is ensured, and has a side effect noted that they no longer appear on the default issuer's CRL when all issuers lack crlSigning usage.

IMO, existing tests should cover most of this behavior, but let me know if you want me to add explicit tests for certain things.

I think only the latter deserves a changelog entry (given 2 can mostly be covered by the tidy update's changelog) but let me know.