### PR TITLE
Mention allowed_users and allowed_domains are comma separated lists

### DIFF
--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -136,11 +136,11 @@ This endpoint creates or updates a named role.
 
 - `allowed_users` `(string: "")` – If this option is not specified, or if it is
   `*`, the client can request a credential for any valid user at the remote
-  host, including the admin user. If only certain usernames are to be allowed,
-  then this list enforces it. If this field is set, then credentials can only
-  be created for `default_user` and usernames present in this list. Setting
-  this option will enable all the users with access this role to fetch
-  credentials for all other usernames in this list.
+  host, including the admin user. To only allow an explicit list of users, set
+  this parameter using a comma-separated username list to enforce it. When this
+  parameter is set, the credentials are created only for `default_user` and
+  usernames listed. Setting this option will enable all the users with access
+  this role to fetch credentials for all other usernames in this list.
   When `allowed_users_template` is set to `true`, this field can contain an identity
   template with any prefix or suffix, like `ssh-{{identity.entity.id}}-user`.
   Use with caution. N.B.: if the type is `ca`, an empty list does not allow any user;
@@ -149,10 +149,10 @@ This endpoint creates or updates a named role.
 - `allowed_users_template` `(bool: false)` - If set, `allowed_users` can be specified
   using identity template policies. Non-templated users are also permitted.
 
-- `allowed_domains` `(string: "")` – The list of domains for which a client can
-  request a host certificate. If this option is explicitly set to `"*"`, then
-  credentials can be created for any domain. See also `allow_bare_domains` and
-  `allow_subdomains`.
+- `allowed_domains` `(string: "")` – A comma-separated list of domains for which 
+  a client can request a host certificate. If this option is explicitly set to
+  `"*"`, then credentials can be created for any domain. See also
+  `allow_bare_domains` and `allow_subdomains`.
 
 - `allowed_domains_template` `(bool: false)` - If set, `allowed_domains` can be
   specified using identity template policies. Non-templated domains are also


### PR DESCRIPTION
This PR attempts to accomplish what [PR 10012](https://github.com/hashicorp/vault/pull/10012) intended.

In addition, I rephrased the sentence to read better. 

🔍 [Deploy preview](https://vault-git-docs-update-ssh-secrets-hashicorp.vercel.app/api-docs/secret/ssh#allowed_users)

