### PR TITLE
Add maximums on how much data we will read for OCSP requests

### DIFF
--- a/builtin/logical/pki/ocsp.go
+++ b/builtin/logical/pki/ocsp.go
@@ -27,7 +27,7 @@ import (
 const (
 	ocspReqParam            = "req"
 	ocspResponseContentType = "application/ocsp-response"
-	maximumRequestSize      = 87 * 5 // A normal simple request is 87 bytes, so give us some buffer
+	maximumRequestSize      = 2048 // A normal simple request is 87 bytes, so give us some buffer
 )
 
 type ocspRespInfo struct {


### PR DESCRIPTION
Limit the maximum number of bytes we will consume from the post body, the get request I believe is already a bit too late, but checks added to be consistent. 

Not really sure if this is deserving of a test beyond what we already have.