### PR TITLE
Pin MongoDB test container images pre-v6

### DIFF
--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -708,7 +708,7 @@ func TestBackend_StaticRole_Rotations_PostgreSQL(t *testing.T) {
 }
 
 func TestBackend_StaticRole_Rotations_MongoDB(t *testing.T) {
-	cleanup, connURL := mongodb.PrepareTestContainerWithDatabase(t, "latest", "vaulttestdb")
+	cleanup, connURL := mongodb.PrepareTestContainerWithDatabase(t, "5.0.10", "vaulttestdb")
 	defer cleanup()
 
 	uc := userCreator(func(t *testing.T, username, password string) {

--- a/builtin/logical/mongodb/backend_test.go
+++ b/builtin/logical/mongodb/backend_test.go
@@ -57,7 +57,7 @@ func TestBackend_basic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cleanup, connURI := mongodb.PrepareTestContainer(t, "latest")
+	cleanup, connURI := mongodb.PrepareTestContainer(t, "5.0.10")
 	defer cleanup()
 	connData := map[string]interface{}{
 		"uri": connURI,
@@ -81,7 +81,7 @@ func TestBackend_roleCrud(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cleanup, connURI := mongodb.PrepareTestContainer(t, "latest")
+	cleanup, connURI := mongodb.PrepareTestContainer(t, "5.0.10")
 	defer cleanup()
 	connData := map[string]interface{}{
 		"uri": connURI,
@@ -107,7 +107,7 @@ func TestBackend_leaseWriteRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cleanup, connURI := mongodb.PrepareTestContainer(t, "latest")
+	cleanup, connURI := mongodb.PrepareTestContainer(t, "5.0.10")
 	defer cleanup()
 	connData := map[string]interface{}{
 		"uri": connURI,

--- a/plugins/database/mongodb/mongodb_test.go
+++ b/plugins/database/mongodb/mongodb_test.go
@@ -27,7 +27,7 @@ import (
 const mongoAdminRole = `{ "db": "admin", "roles": [ { "role": "readWrite" } ] }`
 
 func TestMongoDB_Initialize(t *testing.T) {
-	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
+	cleanup, connURL := mongodb.PrepareTestContainer(t, "5.0.10")
 	defer cleanup()
 
 	db := new()
@@ -120,7 +120,7 @@ func TestNewUser_usernameTemplate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
+			cleanup, connURL := mongodb.PrepareTestContainer(t, "5.0.10")
 			defer cleanup()
 
 			db := new()
@@ -146,7 +146,7 @@ func TestNewUser_usernameTemplate(t *testing.T) {
 }
 
 func TestMongoDB_CreateUser(t *testing.T) {
-	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
+	cleanup, connURL := mongodb.PrepareTestContainer(t, "5.0.10")
 	defer cleanup()
 
 	db := new()
@@ -178,7 +178,7 @@ func TestMongoDB_CreateUser(t *testing.T) {
 }
 
 func TestMongoDB_CreateUser_writeConcern(t *testing.T) {
-	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
+	cleanup, connURL := mongodb.PrepareTestContainer(t, "5.0.10")
 	defer cleanup()
 
 	initReq := dbplugin.InitializeRequest{
@@ -212,7 +212,7 @@ func TestMongoDB_CreateUser_writeConcern(t *testing.T) {
 }
 
 func TestMongoDB_DeleteUser(t *testing.T) {
-	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
+	cleanup, connURL := mongodb.PrepareTestContainer(t, "5.0.10")
 	defer cleanup()
 
 	db := new()
@@ -252,7 +252,7 @@ func TestMongoDB_DeleteUser(t *testing.T) {
 }
 
 func TestMongoDB_UpdateUser_Password(t *testing.T) {
-	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
+	cleanup, connURL := mongodb.PrepareTestContainer(t, "5.0.10")
 	defer cleanup()
 
 	// The docker test method PrepareTestContainer defaults to a database "test"


### PR DESCRIPTION
v6 was released in the last 24h, and our tests fail to connect to the db when v6 is used.
Using v6 needs investigating, but for now I'm pinning to the last known good version.

Failure messages look like:

```
Failed
=== RUN   TestBackend_basic
    mongodbhelper.go:68: could not start docker mongo: no reachable servers
--- FAIL: TestBackend_basic (323.90s)
```

See [here](https://app.circleci.com/pipelines/github/hashicorp/vault/40223/workflows/53234c55-8579-4725-a7ee-f120b47916b1/jobs/500984) for an example failing job.