### PR TITLE
Docs: API: Remove unnecessary parameter from example

### DIFF
--- a/website/content/api-docs/secret/identity/tokens.mdx
+++ b/website/content/api-docs/secret/identity/tokens.mdx
@@ -365,7 +365,6 @@ Use this endpoint to generate a signed ID (OIDC) token.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request GET \
-    --data @payload.json \
     http://127.0.0.1:8200/v1/identity/oidc/token/role-001
 ```
 


### PR DESCRIPTION
Remove the need for a payload.json from identity/oidc/token/:name example curl command as payload is not required.

- This PR supersedes #12346