### PR TITLE
UI/OIDC auth bug for hcp namespace flag

### DIFF
--- a/changelog/16886.txt
+++ b/changelog/16886.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix OIDC callback to accept namespace flag in different formats
+```

--- a/ui/app/routes/vault/cluster/oidc-callback.js
+++ b/ui/app/routes/vault/cluster/oidc-callback.js
@@ -10,9 +10,7 @@ export default Route.extend({
     let { namespaceQueryParam: namespace } = this.paramsFor('vault.cluster');
     // only replace namespace param from cluster if state has a namespace
     if (state?.includes(',ns=')) {
-      let arrayParams = state.split(',ns=');
-      state = arrayParams[0];
-      namespace = arrayParams[1];
+      [state, namespace] = state.split(',ns=');
     }
     path = window.decodeURIComponent(path);
     const source = 'oidc-callback'; // required by event listener in auth-jwt component

--- a/ui/app/routes/vault/cluster/oidc-callback.js
+++ b/ui/app/routes/vault/cluster/oidc-callback.js
@@ -5,29 +5,21 @@ export default Route.extend({
   model() {
     // left blank so we render the template immediately
   },
+  // const queryString = decodeURIComponent(window.location.search);
+  // Since state param can also contain namespace, fetch the values using native url api.
+  // For instance, state params value can be state=st_123456,ns=d4fq
   afterModel() {
-    const queryString = decodeURIComponent(window.location.search);
-    // Since state param can also contain namespace, fetch the values using native url api.
-    // For instance, state params value can be state=st_123456,ns=d4fq
-    // Ember paramsFor used to strip out the value after the "=" sign. In short ns value was not being passed along.
-    let urlParams = new URLSearchParams(queryString);
-    let state = urlParams.get('state'),
-      code = urlParams.get('code'),
-      ns;
-    if (state.includes(',ns=')) {
+    let { auth_path: path, code, state } = this.paramsFor(this.routeName);
+    let { namespaceQueryParam: namespace } = this.paramsFor('vault.cluster');
+    console.log(namespace, 'ANAMESPCE');
+    if (namespace === '' && state?.includes(',ns=')) {
       let arrayParams = state.split(',ns=');
       state = arrayParams[0];
-      ns = arrayParams[1];
+      namespace = arrayParams[1];
     }
-    let { auth_path: path } = this.paramsFor(this.routeName);
-    let { namespaceQueryParam: namespace } = this.paramsFor('vault.cluster');
     path = window.decodeURIComponent(path);
     const source = 'oidc-callback'; // required by event listener in auth-jwt component
     let queryParams = { source, namespace, path, code, state };
-    // If state had ns value, send it as part of namespace param
-    if (ns) {
-      queryParams.namespace = ns;
-    }
     window.opener.postMessage(queryParams, window.origin);
   },
   setupController(controller) {

--- a/ui/app/routes/vault/cluster/oidc-callback.js
+++ b/ui/app/routes/vault/cluster/oidc-callback.js
@@ -11,7 +11,6 @@ export default Route.extend({
   afterModel() {
     let { auth_path: path, code, state } = this.paramsFor(this.routeName);
     let { namespaceQueryParam: namespace } = this.paramsFor('vault.cluster');
-    console.log(namespace, 'ANAMESPCE');
     if (namespace === '' && state?.includes(',ns=')) {
       let arrayParams = state.split(',ns=');
       state = arrayParams[0];

--- a/ui/app/routes/vault/cluster/oidc-callback.js
+++ b/ui/app/routes/vault/cluster/oidc-callback.js
@@ -5,13 +5,11 @@ export default Route.extend({
   model() {
     // left blank so we render the template immediately
   },
-  // const queryString = decodeURIComponent(window.location.search);
-  // Since state param can also contain namespace, fetch the values using native url api.
-  // For instance, state params value can be state=st_123456,ns=d4fq
   afterModel() {
     let { auth_path: path, code, state } = this.paramsFor(this.routeName);
     let { namespaceQueryParam: namespace } = this.paramsFor('vault.cluster');
-    if (namespace === '' && state?.includes(',ns=')) {
+    // only replace namespace param from cluster if state has a namespace
+    if (state?.includes(',ns=')) {
       let arrayParams = state.split(',ns=');
       state = arrayParams[0];
       namespace = arrayParams[1];

--- a/ui/tests/unit/routes/vault/cluster/oidc-callback-test.js
+++ b/ui/tests/unit/routes/vault/cluster/oidc-callback-test.js
@@ -118,7 +118,7 @@ module('Unit | Route | vault/cluster/oidc-callback', function (hooks) {
     );
   });
 
-  test('the afterModel hook returns when both cluster and route params are empty', function (assert) {
+  test('the afterModel hook returns when both cluster and route params are empty strings', function (assert) {
     this.routeName = 'vault.cluster.oidc-callback';
     this.route.paramsFor = (path) => {
       if (path === 'vault.cluster') return { namespaceQueryParam: '' };
@@ -140,7 +140,27 @@ module('Unit | Route | vault/cluster/oidc-callback', function (hooks) {
     );
   });
 
-  test('the afterModel hook returns when cluster namespaceQueryParam exists and all route params are empty', function (assert) {
+  test('the afterModel hook returns when state param does not exist', function (assert) {
+    this.routeName = 'vault.cluster.oidc-callback';
+    this.route.paramsFor = (path) => {
+      if (path === 'vault.cluster') return { namespaceQueryParam: '' };
+      return {
+        auth_path: this.path,
+      };
+    };
+    this.route.afterModel();
+    assert.propContains(
+      this.windowStub.lastCall.args[0],
+      {
+        code: undefined,
+        path: 'oidc',
+        state: undefined,
+      },
+      'model hook returns non-existent state param'
+    );
+  });
+
+  test('the afterModel hook returns when cluster namespaceQueryParam exists and all route params are empty strings', function (assert) {
     this.routeName = 'vault.cluster.oidc-callback';
     this.route.paramsFor = (path) => {
       if (path === 'vault.cluster') return { namespaceQueryParam: 'ns1' };

--- a/ui/tests/unit/routes/vault/cluster/oidc-callback-test.js
+++ b/ui/tests/unit/routes/vault/cluster/oidc-callback-test.js
@@ -1,0 +1,111 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | vault/cluster/oidc-callback', function (hooks) {
+  setupTest(hooks);
+  const parentNs = 'admin';
+  const childNs = 'admin/child-ns';
+  const path = 'oidc';
+  const customPath = 'oidc-dev';
+  const code = 'lTazRXEwKfyGKBUCo5TyLJzdIt39YniBJOXPABiRMkL0T';
+  const state = (ns) => {
+    ns ? 'st_91ji6vR2sQ2zBiZSQkqJ' + `,ns=${ns}` : 'st_91ji6vR2sQ2zBiZSQkqJ';
+  };
+
+  hooks.beforeEach(function () {
+    this.router = this.owner.lookup('service:router');
+    this.route = this.owner.lookup('route:vault/cluster/oidc-callback');
+    this.windowStub = sinon.stub(window.opener, 'postMessage');
+  });
+
+  test('it calls route', function (assert) {
+    assert.ok(this.route);
+  });
+
+  test('it uses namespace param from state not namespaceQueryParam from cluster with default path', function (assert) {
+    this.routeName = 'vault.cluster.oidc-callback';
+
+    this.route.paramsFor = (path) => {
+      if (path === 'vault.cluster') return { namespaceQueryParam: parentNs };
+      return {
+        auth_path: path,
+        state: state(childNs),
+        code,
+      };
+    };
+    assert.ok(this.windowStub.calledWith, 'test');
+    assert.propContains(
+      this.route.afterModel(),
+      {
+        path,
+        namespace: childNs,
+        state: state(),
+      },
+      'state and namespace queryParams are correct'
+    );
+  });
+
+  test('it uses namespace param from state not namespaceQueryParam from cluster with custom path', function (assert) {
+    this.routeName = 'vault.cluster.oidc-callback';
+    this.route.paramsFor = (path) => {
+      if (path === 'vault.cluster') return { namespaceQueryParam: parentNs };
+      return {
+        auth_path: customPath,
+        state: state(childNs),
+        code,
+      };
+    };
+    assert.propContains(
+      this.route.afterModel(),
+      {
+        path: customPath,
+        namespace: childNs,
+        state: state(),
+      },
+      'state ns takes precedence, state no longer has ns query'
+    );
+  });
+
+  test('it uses namespace from namespaceQueryParam when no ns param from state', function (assert) {
+    this.routeName = 'vault.cluster.oidc-callback';
+    this.route.paramsFor = (path) => {
+      if (path === 'vault.cluster') return { namespaceQueryParam: parentNs };
+      return {
+        auth_path: path,
+        state: state(),
+        code,
+      };
+    };
+    assert.propContains(
+      this.route.afterModel(),
+      {
+        path,
+        namespace: parentNs,
+        state: state(),
+      },
+      'namespace is from cluster namespaceQueryParam'
+    );
+  });
+
+  test('it uses ns param from state when no namespaceQueryParam from cluster', function (assert) {
+    this.routeName = 'vault.cluster.oidc-callback';
+    this.route.paramsFor = (path) => {
+      if (path === 'vault.cluster') return { namespaceQueryParam: '' };
+      return {
+        auth_path: path,
+        state: state('ns1'),
+        code,
+      };
+    };
+    assert.propContains(
+      this.route.afterModel(),
+      {
+        path,
+        namespace: 'ns1',
+        state: state(),
+      },
+      'it strips ns from state and uses as namespace param'
+    );
+  });
+});

--- a/ui/tests/unit/routes/vault/cluster/oidc-callback-test.js
+++ b/ui/tests/unit/routes/vault/cluster/oidc-callback-test.js
@@ -2,21 +2,37 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
+// window.opener = {
+//   postMessage: () => {},
+//   origin: 'http://localhost:4200',
+// };
+const origin = 'http://localhost:4200';
+
 module('Unit | Route | vault/cluster/oidc-callback', function (hooks) {
   setupTest(hooks);
-  const parentNs = 'admin';
-  const childNs = 'admin/child-ns';
-  const path = 'oidc';
-  const customPath = 'oidc-dev';
-  const code = 'lTazRXEwKfyGKBUCo5TyLJzdIt39YniBJOXPABiRMkL0T';
-  const state = (ns) => {
-    ns ? 'st_91ji6vR2sQ2zBiZSQkqJ' + `,ns=${ns}` : 'st_91ji6vR2sQ2zBiZSQkqJ';
-  };
 
   hooks.beforeEach(function () {
+    this.originalOpener = window.opener;
+    window.opener = {
+      postMessage: () => {},
+      origin, // todo need?
+    };
     this.router = this.owner.lookup('service:router');
     this.route = this.owner.lookup('route:vault/cluster/oidc-callback');
     this.windowStub = sinon.stub(window.opener, 'postMessage');
+    this.parentNs = 'admin';
+    this.childNs = 'admin/child-ns';
+    this.path = 'oidc';
+    this.customPath = 'oidc-dev';
+    this.code = 'lTazRXEwKfyGKBUCo5TyLJzdIt39YniBJOXPABiRMkL0T';
+    this.state = (ns) => {
+      ns ? 'st_91ji6vR2sQ2zBiZSQkqJ' + `,ns=${ns}` : 'st_91ji6vR2sQ2zBiZSQkqJ';
+    };
+  });
+
+  hooks.afterEach(function () {
+    this.windowStub.restore();
+    window.opener = this.originalOpener;
   });
 
   test('it calls route', function (assert) {
@@ -25,24 +41,27 @@ module('Unit | Route | vault/cluster/oidc-callback', function (hooks) {
 
   test('it uses namespace param from state not namespaceQueryParam from cluster with default path', function (assert) {
     this.routeName = 'vault.cluster.oidc-callback';
-
     this.route.paramsFor = (path) => {
-      if (path === 'vault.cluster') return { namespaceQueryParam: parentNs };
+      if (path === 'vault.cluster') return { namespaceQueryParam: this.parentNs };
       return {
-        auth_path: path,
-        state: state(childNs),
-        code,
+        auth_path: this.path,
+        state: this.state(this.childNs),
+        code: this.code,
       };
     };
-    assert.ok(this.windowStub.calledWith, 'test');
+    this.route.afterModel();
+
+    assert.ok(this.windowStub.calledOnce, 'it is called');
     assert.propContains(
-      this.route.afterModel(),
+      this.windowStub.getCall(0).args[0],
       {
-        path,
-        namespace: childNs,
-        state: state(),
+        code: 'lTazRXEwKfyGKBUCo5TyLJzdIt39YniBJOXPABiRMkL0T',
+        namespace: 'admin',
+        path: 'oidc',
+        source: 'oidc-callback',
       },
-      'state and namespace queryParams are correct'
+
+      'calls correct'
     );
   });
 
@@ -51,17 +70,17 @@ module('Unit | Route | vault/cluster/oidc-callback', function (hooks) {
     this.route.paramsFor = (path) => {
       if (path === 'vault.cluster') return { namespaceQueryParam: parentNs };
       return {
-        auth_path: customPath,
-        state: state(childNs),
-        code,
+        auth_path: this.customPath,
+        state: this.state(this.childNs),
+        code: this.code,
       };
     };
     assert.propContains(
       this.route.afterModel(),
       {
-        path: customPath,
-        namespace: childNs,
-        state: state(),
+        path: this.customPath,
+        namespace: this.childNs,
+        state: this.state(),
       },
       'state ns takes precedence, state no longer has ns query'
     );


### PR DESCRIPTION
Fixes the `afterModel()` hook so that it can handle both when a namespace comes in as a param from the cluster: `namespaceQueryParam = 'admin'` and when it's attached to the state from the route params: `state="st_z6y8L12PndJ33FmW1Ls2,ns=admin"`

The namespace passed via state will take precedence
