### PR TITLE
Renew Lease was not respecting Age Header from Cache

### DIFF
--- a/api/sys_leases.go
+++ b/api/sys_leases.go
@@ -32,14 +32,12 @@ func (c *Sys) RenewWithContext(ctx context.Context, id string, increment int) (*
 	defer resp.Body.Close()
 
 	secret, err := ParseSecret(resp.Body)
-
 	if err != nil {
 		return nil, err
 	}
 
 	if ageHeader := resp.Header.Get("Age"); ageHeader != "" {
 		age, err := strconv.Atoi(ageHeader)
-
 		if err != nil {
 			return nil, err
 		}

--- a/api/sys_leases_test.go
+++ b/api/sys_leases_test.go
@@ -8,6 +8,9 @@ import (
 	"time"
 )
 
+//TestRenewLeaseThroughCache validates that cached lease renew responses
+//that include an "Age" header will correctly adjust the TTL age so that
+//API consumers work with the true TTL and not the original cached TTL.
 func TestRenewLeaseThroughCache(t *testing.T) {
 	age := time.Hour * 10
 	expectedDuration := int(((time.Hour * 24) - age).Seconds())

--- a/api/sys_leases_test.go
+++ b/api/sys_leases_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRenewLeaseThroughCache(t *testing.T) {
+	age := time.Hour * 10
+	expectedDuration := int(((time.Hour * 24) - age).Seconds())
+	mockVaultAgentCache := httptest.NewServer(http.HandlerFunc(agedVaultCacheResponseHandler(time.Hour * 10)))
+	defer mockVaultAgentCache.Close()
+
+	cfg := DefaultConfig()
+	cfg.AgentAddress = mockVaultAgentCache.URL
+
+	client, err := NewClient(cfg)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := client.Sys().Renew("112321-bd6b-818g-edbb-e462338bb0aa", 1)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.LeaseDuration != expectedDuration {
+		t.Fatalf("expected lease duration to be %d seconds not %d  seconds", expectedDuration, resp.LeaseDuration)
+	}
+}
+
+func agedVaultCacheResponseHandler(age time.Duration) func(http.ResponseWriter, *http.Request) {
+	ageStr := fmt.Sprintf("%.0f", (time.Hour * 10).Seconds())
+	return func(w http.ResponseWriter, _ *http.Request) {
+
+		w.Header().Set("Age", ageStr)
+
+		renewResponseTemplate := `{
+			"request_id": "82601a91-cd7a-718f-feca-f573449cc1bb",
+			"lease_id": "112321-bd6b-818g-edbb-e462338bb0aa",
+			"renewable": true,
+			"lease_duration": %.0f,
+			"data": {
+			},
+			"warp_info": null,
+			"warnings": null,
+			"auth": null
+		}`
+
+		renewResponse := fmt.Sprintf(renewResponseTemplate, (time.Hour * 24).Seconds())
+		_, _ = w.Write([]byte(renewResponse))
+	}
+}

--- a/api/sys_leases_test.go
+++ b/api/sys_leases_test.go
@@ -8,9 +8,9 @@ import (
 	"time"
 )
 
-//TestRenewLeaseThroughCache validates that cached lease renew responses
-//that include an "Age" header will correctly adjust the TTL age so that
-//API consumers work with the true TTL and not the original cached TTL.
+// TestRenewLeaseThroughCache validates that cached lease renew responses
+// that include an "Age" header will correctly adjust the TTL age so that
+// API consumers work with the true TTL and not the original cached TTL.
 func TestRenewLeaseThroughCache(t *testing.T) {
 	age := time.Hour * 10
 	expectedDuration := int(((time.Hour * 24) - age).Seconds())
@@ -21,13 +21,11 @@ func TestRenewLeaseThroughCache(t *testing.T) {
 	cfg.AgentAddress = mockVaultAgentCache.URL
 
 	client, err := NewClient(cfg)
-
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	resp, err := client.Sys().Renew("112321-bd6b-818g-edbb-e462338bb0aa", 1)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +38,6 @@ func TestRenewLeaseThroughCache(t *testing.T) {
 func agedVaultCacheResponseHandler(age time.Duration) func(http.ResponseWriter, *http.Request) {
 	ageStr := fmt.Sprintf("%.0f", (time.Hour * 10).Seconds())
 	return func(w http.ResponseWriter, _ *http.Request) {
-
 		w.Header().Set("Age", ageStr)
 
 		renewResponseTemplate := `{

--- a/changelog/16887.txt
+++ b/changelog/16887.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: honor "Age" header when returning renewed secrets.
+```


### PR DESCRIPTION
### What
https://github.com/hashicorp/vault/issues/16439 identified that occasionally the Vault Agent Template server would wake up at the incorrect time to renew leased credentials.


I believe I've identified a potential root cause which is that the Vault API library was not accounting for the `Age` header returned from the cache. Without accounting for cache `Age` template servers will work from the original TTL from the cached renew request instead of the true aged TTL.

### How
This change checks the renew request for an Age header and adjusts the TTL accordingly.

### Why
The Vault Agent Cache inserts an `Age` header based on the time the original response was received from the Vault Server ([source](https://github.com/hashicorp/vault/blob/main/command/agent/cache/lease_cache.go#L205)).

This can be used to calculate an approximation of the "true" remaining TTL. (However, imagine a worst case scenario you have several layer of caches then you could potentially see a large error between the Server TTL and the final cache's TTL. It may be better in the future to rely on a "valid_until" strategy, but that has its own problems and is far outside the scope of this issue.)

LifeTimeWatcher's [`doRenew`](https://github.com/hashicorp/vault/blob/76165052e54f884ed0aa2caa496083dc84ad1c19/api/lifetime_watcher.go#L239-L251) uses [`client.Sys().Renew`](https://github.com/hashicorp/vault/blob/9c6d25ad1627d8309cf58c0128ba33119c3c80d6/api/lifetime_watcher.go#L249) which "encapsulates" the Renew API call. This interface currently drops vital information regarding the `Age` header, but modifying the interface to return an age along with the secret would be a large change requiring effort by downstream library users.

Handling `Age` inside `client.Sys().Renew` enforces the _expected_ behavior without breaking the interface.



fixes: https://github.com/hashicorp/vault/issues/16439