### PR TITLE
Add ocsp_expiry configuration field to PKI crl config

### DIFF
--- a/builtin/logical/pki/ocsp.go
+++ b/builtin/logical/pki/ocsp.go
@@ -129,7 +129,7 @@ func (b *backend) ocspHandler(ctx context.Context, request *logical.Request, dat
 			// Since we were not able to find a matching issuer for the incoming request
 			// generate an Unknown OCSP response. This might turn into an Unauthorized if
 			// we find out that we don't have a default issuer or it's missing the proper Usage flags
-			return generateUnknownResponse(sc, ocspReq), nil
+			return generateUnknownResponse(cfg, sc, ocspReq), nil
 		}
 		if errors.Is(err, ErrMissingOcspUsage) {
 			// If we did find a matching issuer but aren't allowed to sign, the spec says
@@ -141,7 +141,7 @@ func (b *backend) ocspHandler(ctx context.Context, request *logical.Request, dat
 		return logAndReturnInternalError(b, err), nil
 	}
 
-	byteResp, err := genResponse(caBundle, ocspStatus, ocspReq.HashAlgorithm)
+	byteResp, err := genResponse(cfg, caBundle, ocspStatus, ocspReq.HashAlgorithm)
 	if err != nil {
 		return logAndReturnInternalError(b, err), nil
 	}
@@ -155,7 +155,7 @@ func (b *backend) ocspHandler(ctx context.Context, request *logical.Request, dat
 	}, nil
 }
 
-func generateUnknownResponse(sc *storageContext, ocspReq *ocsp.Request) *logical.Response {
+func generateUnknownResponse(cfg *crlConfig, sc *storageContext, ocspReq *ocsp.Request) *logical.Response {
 	// Generate an Unknown OCSP response, signing with the default issuer from the mount as we did
 	// not match the request's issuer. If no default issuer can be used, return with Unauthorized as there
 	// isn't much else we can do at this point.
@@ -189,7 +189,7 @@ func generateUnknownResponse(sc *storageContext, ocspReq *ocsp.Request) *logical
 		ocspStatus:   ocsp.Unknown,
 	}
 
-	byteResp, err := genResponse(caBundle, info, ocspReq.HashAlgorithm)
+	byteResp, err := genResponse(cfg, caBundle, info, ocspReq.HashAlgorithm)
 	if err != nil {
 		return logAndReturnInternalError(sc.Backend, err)
 	}
@@ -384,14 +384,18 @@ func doesRequestMatchIssuer(parsedBundle *certutil.ParsedCertBundle, req *ocsp.R
 	return bytes.Equal(req.IssuerKeyHash, issuerKeyHash) && bytes.Equal(req.IssuerNameHash, issuerNameHash), nil
 }
 
-func genResponse(caBundle *certutil.ParsedCertBundle, info *ocspRespInfo, reqHash crypto.Hash) ([]byte, error) {
+func genResponse(cfg *crlConfig, caBundle *certutil.ParsedCertBundle, info *ocspRespInfo, reqHash crypto.Hash) ([]byte, error) {
 	curTime := time.Now()
+	duration, err := time.ParseDuration(cfg.OcspExpiry)
+	if err != nil {
+		return nil, err
+	}
 	template := ocsp.Response{
 		IssuerHash:      reqHash,
 		Status:          info.ocspStatus,
 		SerialNumber:    info.serialNumber,
 		ThisUpdate:      curTime,
-		NextUpdate:      curTime,
+		NextUpdate:      curTime.Add(duration),
 		Certificate:     caBundle.Certificate,
 		ExtraExtensions: []pkix.Extension{},
 	}

--- a/builtin/logical/pki/ocsp_test.go
+++ b/builtin/logical/pki/ocsp_test.go
@@ -457,7 +457,6 @@ func runOcspRequestTest(t *testing.T, requestType string, caKeyType string, requ
 	require.Equal(t, testEnv.issuer2, ocspResp.Certificate)
 	require.Equal(t, 0, ocspResp.RevocationReason)
 	require.Equal(t, testEnv.leafCertIssuer2.SerialNumber, ocspResp.SerialNumber)
-	require.Equal(t, testEnv.leafCertIssuer2.SerialNumber, ocspResp.SerialNumber)
 
 	// Verify that our thisUpdate and nextUpdate fields are updated as expected
 	thisUpdate := ocspResp.ThisUpdate

--- a/builtin/logical/pki/path_config_crl.go
+++ b/builtin/logical/pki/path_config_crl.go
@@ -10,8 +10,11 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+const latestCrlConfigVersion = 1
+
 // CRLConfig holds basic CRL configuration information
 type crlConfig struct {
+	Version                int    `json:"version"`
 	Expiry                 string `json:"expiry"`
 	Disable                bool   `json:"disable"`
 	OcspDisable            bool   `json:"ocsp_disable"`
@@ -22,6 +25,7 @@ type crlConfig struct {
 
 // Implicit default values for the config if it does not exist.
 var defaultCrlConfig = crlConfig{
+	Version:                latestCrlConfigVersion,
 	Expiry:                 "72h",
 	Disable:                false,
 	OcspDisable:            false,

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -1120,5 +1120,14 @@ func (sc *storageContext) getRevocationConfig() (*crlConfig, error) {
 		return nil, err
 	}
 
+	// Automatically update existing configurations.
+	if result.AutoRebuildGracePeriod == "" {
+		result.AutoRebuildGracePeriod = defaultCrlConfig.AutoRebuildGracePeriod
+	}
+
+	if result.OcspExpiry == "" {
+		result.OcspExpiry = defaultCrlConfig.OcspExpiry
+	}
+
 	return &result, nil
 }

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -1120,13 +1120,13 @@ func (sc *storageContext) getRevocationConfig() (*crlConfig, error) {
 		return nil, err
 	}
 
-	// Automatically update existing configurations.
-	if result.AutoRebuildGracePeriod == "" {
-		result.AutoRebuildGracePeriod = defaultCrlConfig.AutoRebuildGracePeriod
-	}
-
-	if result.OcspExpiry == "" {
+	if result.Version == 0 {
+		// Automatically update existing configurations.
+		result.OcspDisable = defaultCrlConfig.OcspDisable
 		result.OcspExpiry = defaultCrlConfig.OcspExpiry
+		result.AutoRebuild = defaultCrlConfig.AutoRebuild
+		result.AutoRebuildGracePeriod = defaultCrlConfig.AutoRebuildGracePeriod
+		result.Version = 1
 	}
 
 	return &result, nil

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -2989,7 +2989,10 @@ $ curl \
   "data": {
     "disable": false,
     "expiry": "72h",
-    "ocsp_disable": false
+    "ocsp_disable": false,
+    "ocsp_expiry": "12h",
+    "auto_rebuild": false,
+    "auto_rebuild_grace_period": "12h"
   },
   "auth": null
 }
@@ -3031,6 +3034,9 @@ the CRL.
 - `expiry` `(string: "72h")` - The amount of time the generated CRL should be valid.
 - `disable` `(bool: false)` - Disables or enables CRL building.
 - `ocsp_disable` `(bool: false)` - Disables or enables the OCSP responder in Vault.
+- `ocsp_expiry` `(string: "12h")` - The amount of time an OCSP response can be cached for,
+  (controls the NextUpdate field), useful for OCSP stapling refresh durations. Setting to 0
+  should effectively disable caching in third party systems.
 - `auto_rebuild` `(bool: false)` - Enables or disables periodic rebuilding of
   the CRL upon expiry.
 - `auto_rebuild_grace_period` `(string: "12h")` - Grace period before CRL expiry
@@ -3043,6 +3049,7 @@ the CRL.
   "expiry": "48h",
   "disable": "false",
   "ocsp_disable": "false",
+  "ocsp_expiry": "12h",
   "auto_rebuild": "true",
   "auto_rebuild_grace_period": "8h"
 }


### PR DESCRIPTION
 - Add a new configurable duration field to the crl configuration to allow operator control of how long an OCSP response can be cached for. A value of 0 means no one should cache the response.
 - This is useful for how long a server like NGINX/Apache is allowed to cache the response for OCSP stapling.
 - Address an issue discovered that we did not upgrade existing crl configurations properly