### PR TITLE
Fix changelog type for registry deprecation status

### DIFF
--- a/changelog/16846.txt
+++ b/changelog/16846.txt
@@ -1,3 +1,3 @@
-```release-note:enhancement
+```release-note:improvement
 plugins: Add Deprecation Status method to builtinregistry.
 ```


### PR DESCRIPTION
The previous changelog specified a type of `enhancement`, which is
invalid. It should be `improvement`.