### PR TITLE
auth/kerberos: add config to include ldap groups in group alias

### DIFF
--- a/changelog/16890.txt
+++ b/changelog/16890.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/kerberos: add `add_group_aliases` config to include LDAP groups in Vault group aliases
+```

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-cf v0.12.0
 	github.com/hashicorp/vault-plugin-auth-gcp v0.13.2-0.20220722185016-9e4fddb995e5
 	github.com/hashicorp/vault-plugin-auth-jwt v0.13.2-0.20220728183411-0edf6ecc0b37
-	github.com/hashicorp/vault-plugin-auth-kerberos v0.7.2
+	github.com/hashicorp/vault-plugin-auth-kerberos v0.7.3
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.13.0
 	github.com/hashicorp/vault-plugin-auth-oci v0.11.0
 	github.com/hashicorp/vault-plugin-database-couchbase v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1015,8 +1015,8 @@ github.com/hashicorp/vault-plugin-auth-gcp v0.13.2-0.20220722185016-9e4fddb995e5
 github.com/hashicorp/vault-plugin-auth-gcp v0.13.2-0.20220722185016-9e4fddb995e5/go.mod h1:WNwaZN7NWy14xcy3otm1OXp5blcKgblUfvE16eYeUoQ=
 github.com/hashicorp/vault-plugin-auth-jwt v0.13.2-0.20220728183411-0edf6ecc0b37 h1:gmJ49AHEJcrWNyo3GioyHvZVJCxSnKnTbLdm81A7XIU=
 github.com/hashicorp/vault-plugin-auth-jwt v0.13.2-0.20220728183411-0edf6ecc0b37/go.mod h1:oWM7Naj8lo4J9vJ23S0kpNW9pmeiHRiG/9ghLlPu6N0=
-github.com/hashicorp/vault-plugin-auth-kerberos v0.7.2 h1:rtQ4aSr3vtAaQ8Al4p4ftZXgl47o+XyEbAR+mQNYaMs=
-github.com/hashicorp/vault-plugin-auth-kerberos v0.7.2/go.mod h1:eqjae8tMBpAWgJNk1NjV/vtJYXQRZnYudUkBFowz3bY=
+github.com/hashicorp/vault-plugin-auth-kerberos v0.7.3 h1:QumrPHn5n9iTaZScZwplqdnXoeMOrb3GJcwMweTmR3o=
+github.com/hashicorp/vault-plugin-auth-kerberos v0.7.3/go.mod h1:eqjae8tMBpAWgJNk1NjV/vtJYXQRZnYudUkBFowz3bY=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.13.0 h1:pONFgWz9hbcS1wFxPtQJYj9Mt/nzPVX1kw1DGv+92Ww=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.13.0/go.mod h1:/hQF30guXWLcIUiTYsXoQ0dUTHspo0q30nLBr1RE+Lw=
 github.com/hashicorp/vault-plugin-auth-oci v0.11.0 h1:DrdccnGU8O28I1MIs21zmbYM2Nta7RLOAzozvDSX9h0=
@@ -1794,8 +1794,6 @@ golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
-golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8 h1:GIAS/yBem/gq2MUqgNIzUHW7cJMmx3TGZOrnyYaNQ6c=
 golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/website/content/api-docs/auth/kerberos.mdx
+++ b/website/content/api-docs/auth/kerberos.mdx
@@ -39,6 +39,8 @@ for verifying inbound SPNEGO tokens.
   principal name when parsing the keytab file. For example when this is set to true,
   if a keytab has the service principal name `foo/localhost@example.com`, Vault
   will strip the service principal name to just be `foo@example.com`. 
+- `add_group_aliases` - When set to true, Vault will add any LDAP groups found for 
+  the user as group aliases.
 
 ### Sample Request
 
@@ -54,9 +56,10 @@ $ curl \
 
 ```json
 {
+  "add_group_aliases": false,
   "keytab": "BQIAAAA6AAEACk1BVFJJWC5MQU4ACXZhdWx0X3N2YwAAAAFdzZSjAgAXABDwhEyRR9nRqkpP8KTn2A83AAAAAg==",
   "remove_instance_name": false,
-  "service_account": "vault_svc",
+  "service_account": "vault_svc"
 }
 ```
 
@@ -85,6 +88,7 @@ $ curl \
   "warnings": null,
   "wrap_info": null,
   "data": {
+    "add_group_aliases": false,
     "remove_instance_name": false,
     "service_account": "vault_svc"
   },


### PR DESCRIPTION
Updates Vault to include new kerberos auth config `add_group_aliases`, which includes LDAP groups in the group aliases for the login: https://github.com/hashicorp/vault-plugin-auth-kerberos/pull/73.