### PR TITLE
Description

### DIFF
--- a/website/content/docs/enterprise/license/autoloading.mdx
+++ b/website/content/docs/enterprise/license/autoloading.mdx
@@ -29,5 +29,4 @@ are discrepancies.
 
 If autoloading is used, any existing stored license will be ignored. The presence
 of a stored license in conjunction with an autoloaded license will also result in
-logged warnings. Once a migration to autoloading is completed, it is recommended to use
-the [DELETE API](/api-docs/system/license#delete-license) to remove the stored license.
+logged warnings, which may require a service restart to clear.


### PR DESCRIPTION
The "DELETE API" links to a nonexistent subsection of the /sys/license/status page from 1.11.x onwards. Not sure if the suggestion to restart the service should remain in this edit - I found a restart of all Vault servers cleared this message where other attempts failed - happy to remove it if preferred, though.