### PR TITLE
VAULT-6433: Add namespace path to MFA read/list endpoints

### DIFF
--- a/changelog/16911.txt
+++ b/changelog/16911.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api/mfa: Add namespace path to the MFA read/list endpoint
+```

--- a/vault/external_tests/mfa/login_mfa_test.go
+++ b/vault/external_tests/mfa/login_mfa_test.go
@@ -138,6 +138,14 @@ func TestLoginMFA_Method_CRUD(t *testing.T) {
 				t.Fatal("expected response id to match existing method id but it didn't")
 			}
 
+			if resp.Data["namespace_id"] != "root" {
+				t.Fatalf("namespace id was not root, it was %s", resp.Data["namespace_id"])
+			}
+
+			if resp.Data["namespace_path"] != "" {
+				t.Fatalf("namespace path was not empty, it was %s", resp.Data["namespace_path"])
+			}
+
 			// listing should show it
 			resp, err = client.Logical().List(myPath)
 			if err != nil {

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -1362,11 +1362,10 @@ func (b *LoginMFABackend) mfaLoginEnforcementConfigToMap(eConfig *mfa.MFAEnforce
 	resp := make(map[string]interface{})
 	resp["name"] = eConfig.Name
 	ns, err := b.namespacer.NamespaceByID(context.Background(), eConfig.NamespaceID)
-	if ns != nil && err == nil {
-		resp["namespace_path"] = ns.Path
-	} else {
+	if ns == nil || err != nil {
 		return nil, err
 	}
+	resp["namespace_path"] = ns.Path
 	resp["namespace_id"] = eConfig.NamespaceID
 	resp["mfa_method_ids"] = append([]string{}, eConfig.MFAMethodIDs...)
 	resp["auth_method_accessors"] = append([]string{}, eConfig.AuthMethodAccessors...)
@@ -1424,11 +1423,10 @@ func (b *MFABackend) mfaConfigToMap(mConfig *mfa.Config) (map[string]interface{}
 	respData["name"] = mConfig.Name
 	respData["namespace_id"] = mConfig.NamespaceID
 	ns, err := b.namespacer.NamespaceByID(context.Background(), mConfig.NamespaceID)
-	if ns != nil && err == nil {
-		respData["namespace_path"] = ns.Path
-	} else {
+	if ns == nil || err != nil {
 		return nil, err
 	}
+	respData["namespace_path"] = ns.Path
 
 	return respData, nil
 }

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -1361,6 +1361,10 @@ func (b *LoginMFABackend) mfaLoginEnforcementConfigByNameAndNamespace(name, name
 func (b *LoginMFABackend) mfaLoginEnforcementConfigToMap(eConfig *mfa.MFAEnforcementConfig) (map[string]interface{}, error) {
 	resp := make(map[string]interface{})
 	resp["name"] = eConfig.Name
+	ns, err := b.namespacer.NamespaceByID(context.Background(), eConfig.NamespaceID)
+	if ns != nil && err == nil {
+		resp["namespace_path"] = ns.Path
+	}
 	resp["namespace_id"] = eConfig.NamespaceID
 	resp["mfa_method_ids"] = append([]string{}, eConfig.MFAMethodIDs...)
 	resp["auth_method_accessors"] = append([]string{}, eConfig.AuthMethodAccessors...)
@@ -1417,6 +1421,10 @@ func (b *MFABackend) mfaConfigToMap(mConfig *mfa.Config) (map[string]interface{}
 	respData["id"] = mConfig.ID
 	respData["name"] = mConfig.Name
 	respData["namespace_id"] = mConfig.NamespaceID
+	ns, err := b.namespacer.NamespaceByID(context.Background(), mConfig.NamespaceID)
+	if ns != nil && err == nil {
+		respData["namespace_path"] = ns.Path
+	}
 
 	return respData, nil
 }

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -1364,6 +1364,8 @@ func (b *LoginMFABackend) mfaLoginEnforcementConfigToMap(eConfig *mfa.MFAEnforce
 	ns, err := b.namespacer.NamespaceByID(context.Background(), eConfig.NamespaceID)
 	if ns != nil && err == nil {
 		resp["namespace_path"] = ns.Path
+	} else {
+		return nil, err
 	}
 	resp["namespace_id"] = eConfig.NamespaceID
 	resp["mfa_method_ids"] = append([]string{}, eConfig.MFAMethodIDs...)
@@ -1424,6 +1426,8 @@ func (b *MFABackend) mfaConfigToMap(mConfig *mfa.Config) (map[string]interface{}
 	ns, err := b.namespacer.NamespaceByID(context.Background(), mConfig.NamespaceID)
 	if ns != nil && err == nil {
 		respData["namespace_path"] = ns.Path
+	} else {
+		return nil, err
 	}
 
 	return respData, nil


### PR DESCRIPTION
namespace_path is now returned:
```
violet@violet-TX54KFJWXM vault % curl \
     --header "X-Vault-Token: hvs.INkinqiHlLMccLwuOsTB9WTI" \
     --header "X-Vault-Namespace: abc" \
    --request GET \
    'http://127.0.0.1:8200/v1/identity/mfa/method?list=true'
{"request_id":"dac656b6-b86b-9e51-bf47-c78d07acc370","lease_id":"","renewable":false,"lease_duration":0,"data":{"key_info":{"25241e4f-6146-c1fb-9cdd-761e56599e73":{"base_url":"okta.com","id":"25241e4f-6146-c1fb-9cdd-761e56599e73","mount_accessor":"","name":"","namespace_id":"cBQTS","namespace_path":"abc/","org_name":"dev-08217481","type":"okta","username_format":"{{identity.entity.aliases.auth_userpass_3aae7eb0.name}}.hynes+second@hashicorp.com"}},"keys":["25241e4f-6146-c1fb-9cdd-761e56599e73"]},"wrap_info":null,"warnings":null,"auth":null}
violet@violet-TX54KFJWXM vault % vault write -field method_id -namespace=abc identity/mfa/method/okta2 org_name="dev-08217481" api_token="00bQm3U15RXP2Q1tfzBdrndK2aiTjjHqxXkR7cGaqA" base_url="okta.com" username_format="{{identity.entity.aliases.auth_userpass_3aae7eb0.name}}.hynes+second@hashicorp.com" primary_email=true
```

```
violet@violet-TX54KFJWXM vault % vault read -namespace=abc identity/mfa/method/25241e4f-6146-c1fb-9cdd-761e56599e73
Key                Value
---                -----
base_url           okta.com
id                 25241e4f-6146-c1fb-9cdd-761e56599e73
mount_accessor     n/a
name               n/a
namespace_id       cBQTS
namespace_path     abc/
org_name           dev-08217481
type               okta
username_format    {{identity.entity.aliases.auth_userpass_3aae7eb0.name}}.hynes+second@hashicorp.com
```