### PR TITLE
Make lifetime_watcher Cache-Control Age header aware.

### DIFF
--- a/api/lifetime_watcher.go
+++ b/api/lifetime_watcher.go
@@ -251,7 +251,8 @@ func (r *LifetimeWatcher) doRenew() error {
 }
 
 func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, initLeaseDuration int, credString string,
-	renew renewFunc, initialRetryInterval time.Duration) error {
+	renew renewFunc, initialRetryInterval time.Duration,
+) error {
 	if credString == "" ||
 		(nonRenewable && r.renewBehavior == RenewBehaviorErrorOnErrors) {
 		return r.errLifetimeWatcherNotRenewable

--- a/api/lifetime_watcher.go
+++ b/api/lifetime_watcher.go
@@ -383,7 +383,12 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 
 			// The sleep duration is set to 2/3 of the current lease duration plus
 			// 1/3 of the current grace period, which adds jitter.
-			sleepDuration = time.Duration(float64(remainingLeaseDuration.Nanoseconds())*2/3 + float64(r.grace.Nanoseconds())/3 - float64(age.Nanoseconds()))
+			sleepDuration = time.Duration(float64(remainingLeaseDuration.Nanoseconds())*2/3 + float64(r.grace.Nanoseconds())/3)
+
+			//sleepDuration can't be negative.
+			if sleepDuration >= age {
+				sleepDuration = sleepDuration - age
+			}
 		}
 
 		// If we are within grace, return now; or, if the amount of time we

--- a/api/lifetime_watcher.go
+++ b/api/lifetime_watcher.go
@@ -294,18 +294,23 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 				defer renewal.Body.Close()
 				renewalSecret, err = ParseSecret(renewal.Body)
 
+				if err != nil {
+					return err
+				}
+
 				if ageHeader := renewal.Header.Get("Age"); err == nil && ageHeader != "" {
 					// Age header is a string that represents the number of seconds
 					// since entering the cache.
 					// https://www.rfc-editor.org/rfc/rfc7234#section-5.1
 					age, err = time.ParseDuration(ageHeader + "s")
 
-					if err == nil {
-						//  initialTime is when the lifetime_watcher begins.
-						//  if a response includes an Age header the initial time
-						//  is _before_ when the lifetime_watcher started.
-						initialTime = initialTime.Add(-age)
+					if err != nil {
+						return err
 					}
+					//  initialTime is when the lifetime_watcher begins.
+					//  if a response includes an Age header the initial time
+					//  is _before_ when the lifetime_watcher started.
+					initialTime = initialTime.Add(-age)
 				}
 			}
 

--- a/api/lifetime_watcher.go
+++ b/api/lifetime_watcher.go
@@ -272,7 +272,7 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 		}
 
 		var remainingLeaseDuration time.Duration
-		fallbackLeaseDuration := initialTime.Add(priorDuration).Sub(time.Now())
+		fallbackLeaseDuration := time.Until(initialTime.Add(priorDuration))
 		var renewal *Response
 		var renewalSecret *Secret
 		var age time.Duration
@@ -325,7 +325,7 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 				}
 
 				// Calculate remaining duration until initial token lease expires
-				remainingLeaseDuration = initialTime.Add(time.Duration(initLeaseDuration) * time.Second).Sub(time.Now())
+				remainingLeaseDuration = time.Until(initialTime.Add(time.Duration(initLeaseDuration) * time.Second))
 				if errorBackoff == nil {
 					errorBackoff = &backoff.ExponentialBackOff{
 						MaxElapsedTime:      remainingLeaseDuration,

--- a/api/renewer_test.go
+++ b/api/renewer_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -79,10 +81,17 @@ func TestRenewer_NewRenewer(t *testing.T) {
 
 // renewedResponse returns an empty http.Response
 // for testing TestLifetimeWatcher
-func renewedResponse() *Response {
+func renewedResponse(age string) *Response {
+	headers := http.Header{}
+
+	if age != "" {
+		headers.Set("Age", age)
+	}
+
 	return &Response{
 		Response: &http.Response{
-			Body: io.NopCloser(strings.NewReader("{}")),
+			Header: headers,
+			Body:   io.NopCloser(strings.NewReader("{}")),
 		},
 	}
 }
@@ -116,7 +125,7 @@ func TestLifetimeWatcher(t *testing.T) {
 			leaseDurationSeconds: 60,
 			incrementSeconds:     60,
 			renew: func(_ string, _ int) (*Response, error) {
-				return renewedResponse(), nil
+				return renewedResponse(""), nil
 			},
 			expectError:   nil,
 			expectRenewal: true,
@@ -127,7 +136,7 @@ func TestLifetimeWatcher(t *testing.T) {
 			leaseDurationSeconds: 60,
 			incrementSeconds:     10,
 			renew: func(_ string, _ int) (*Response, error) {
-				return renewedResponse(), nil
+				return renewedResponse(""), nil
 			},
 			expectError:   nil,
 			expectRenewal: true,
@@ -142,7 +151,7 @@ func TestLifetimeWatcher(t *testing.T) {
 					caseOneErrorCount++
 					return nil, fmt.Errorf("renew failure")
 				}
-				return renewedResponse(), nil
+				return renewedResponse(""), nil
 			},
 			expectError:   nil,
 			expectRenewal: true,
@@ -154,7 +163,7 @@ func TestLifetimeWatcher(t *testing.T) {
 			incrementSeconds:     15,
 			renew: func(_ string, _ int) (*Response, error) {
 				if caseManyErrorsCount == 3 {
-					return renewedResponse(), nil
+					return renewedResponse(""), nil
 				}
 				caseManyErrorsCount++
 				return nil, fmt.Errorf("renew failure")
@@ -179,7 +188,7 @@ func TestLifetimeWatcher(t *testing.T) {
 			leaseDurationSeconds: -15,
 			incrementSeconds:     15,
 			renew: func(_ string, _ int) (*Response, error) {
-				return renewedResponse(), nil
+				return renewedResponse(""), nil
 			},
 			expectError:   nil,
 			expectRenewal: true,
@@ -216,7 +225,7 @@ func TestLifetimeWatcher(t *testing.T) {
 					if !tc.expectRenewal {
 						t.Fatal("expected no renewals")
 					}
-					if r.Secret != renewedSecret {
+					if !reflect.DeepEqual(r.Secret, renewedSecret) {
 						t.Fatalf("expected secret %v, got %v", renewedSecret, r.Secret)
 					}
 					receivedRenewal = true
@@ -243,6 +252,107 @@ func TestLifetimeWatcher(t *testing.T) {
 			if tc.expectRenewal && !receivedRenewal {
 				t.Fatalf("expected at least one renewal, got none.")
 			}
+		})
+	}
+}
+
+func agingRenew() func(string, int) (*Response, error) {
+	origin := time.Now()
+	headers := http.Header{}
+
+	return func(leaseID string, increment int) (*Response, error) {
+		headers.Set("Age", strconv.Itoa(int(time.Since(origin))))
+		return &Response{
+			Response: &http.Response{
+				Header: headers,
+				Body:   io.NopCloser(strings.NewReader(fmt.Sprintf(`{"lease_id": "%s", "increment": %d}`, leaseID, increment))),
+			},
+		}, nil
+	}
+}
+
+// TestLifeTimeWatcherCached specifically tests how LifeTimeWatchers react to
+// cached renew responses.
+func TestLifeTimeWatcherCached(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		// the full duration a test should run for
+		// the maxTestTime should relate to the number
+		// of renewals expected.
+		maxTestTime time.Duration
+		// corresponds to the lease duration of a secret
+		// the lease duration should indicate how many
+		// "maximum" renewals we should expect during a maxTestTime.
+		leaseDurationSeconds time.Duration
+		// indicates how long renewals should request
+		// also determines how many renewals we should expect during the maxTestTime.
+		incrementSeconds time.Duration
+		// the initial age in seconds for a renewal response.
+		age         int
+		expectError error
+	}{
+		{
+			name:                 "origin",
+			maxTestTime:          20 * time.Second,
+			leaseDurationSeconds: 2 * time.Second,
+			incrementSeconds:     1 * time.Second,
+			age:                  0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// from the initial lease how many renewals will we execute
+			// +1 is because the renewal loop always runs the first time a lifetimewatcher starts
+			expectedRenewals := int(((tc.maxTestTime - tc.leaseDurationSeconds) / tc.incrementSeconds) + 1)
+
+			lw, err := client.NewLifetimeWatcher(&LifetimeWatcherInput{
+				Secret: &Secret{
+					LeaseDuration: int(tc.leaseDurationSeconds.Seconds()),
+				},
+				Increment: int(tc.incrementSeconds.Seconds()),
+			})
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			doneCh := make(chan error, 1)
+
+			go func() {
+				doneCh <- lw.doRenewWithOptions(false, false, int(tc.leaseDurationSeconds.Seconds()), tc.name, agingRenew(), tc.incrementSeconds)
+			}()
+			defer lw.Stop()
+
+			//count the renewals that occur during a test.
+			actualRenewals := 0
+		ChannelLoop:
+			for {
+				select {
+				case <-time.After(tc.maxTestTime):
+					break ChannelLoop
+				case <-lw.RenewCh():
+					actualRenewals += 1
+					continue ChannelLoop
+				case loopErr := <-doneCh:
+					if loopErr != nil {
+						t.Fatal(loopErr)
+						return
+					}
+				}
+			}
+
+			if expectedRenewals != actualRenewals {
+				t.Fatalf("expected %d renewals, %d occurred", expectedRenewals, actualRenewals)
+			}
+
 		})
 	}
 }

--- a/changelog/16924.txt
+++ b/changelog/16924.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api/lifetime_watcher: utilize Age header when calculating sleep duration.
+```

--- a/command/agent/cache/lease_cache.go
+++ b/command/agent/cache/lease_cache.go
@@ -198,8 +198,6 @@ func (c *LeaseCache) checkCacheForRequest(id string) (*SendResponse, error) {
 	}
 	sendResp.CacheMeta.Hit = true
 
-	//this is the time the response was received, but what if the response
-	//had an age on it as well?
 	respTime, err := http.ParseTime(resp.Header.Get("Date"))
 	if err != nil {
 		c.logger.Error("failed to parse cached response date", "error", err)
@@ -207,11 +205,10 @@ func (c *LeaseCache) checkCacheForRequest(id string) (*SendResponse, error) {
 	}
 	sendResp.CacheMeta.Age = time.Now().Sub(respTime)
 
-	//if the cached response had an age header attached to it
-	//we need to propagate that age.
+	//  if the cached response had an age header attached to it
+	//  we need to propagate that age.
 	if respAgeTxt := resp.Header.Get("Age"); respAgeTxt != "" {
 		respAge, err := strconv.Atoi(respAgeTxt)
-
 		if err != nil {
 			c.logger.Error("failed to parse ")
 			return nil, err
@@ -320,14 +317,13 @@ func (c *LeaseCache) Send(ctx context.Context, req *SendRequest) (*SendResponse,
 	// The "Age" header is an HTTP Cache-Control header.
 	if ageHeader := resp.Response.Header.Get("Age"); ageHeader != "" {
 		age, err := strconv.Atoi(ageHeader)
-
 		if err != nil {
 			return resp, err
 		}
 
 		// this is a negative add because the Age indicates how many
 		// seconds before now the response was originally created.
-		//lastRenewed(now) ----------> trueLastRenewed(now - age)
+		// lastRenewed(now) ----------> trueLastRenewed(now - age)
 		lastRenewed = lastRenewed.Add(time.Duration(age) * -time.Second)
 	}
 


### PR DESCRIPTION
### What
https://github.com/hashicorp/vault/issues/16439 identified that occasionally the Vault Agent Template server would wake up at the incorrect time to renew leased credentials.


I believe I've identified a potential root cause which is that the Vault API library was not accounting for the `Age` header returned from the cache. Without accounting for cache `Age` template servers will work from the original TTL from the cached renew request instead of the true aged TTL.

The design and reasoning for this current approach is explained in more detail here https://github.com/hashicorp/vault/issues/16439#issuecomment-1230233485

### How
1. API library for Sys.Renew() and Auth().Token().RenewTokenAsSelf have methods that return the full response including the header.  22cc6feba9a12844ca5d182dd6d5c9913abd704d
2. The Vault Agent now updates the `Age` when forwarding cached responses be0b314f81876969ce01bf86f2a71a64ec280f14 
3. lifetime_watcher becomes Age aware cb0b92c9d7b6767d920ecb194789d0a1d0f761a3

We need to write tests and run tests.


### Why
The Vault Agent Cache inserts an `Age` header based on the time the original response was received from the Vault Server ([source](https://github.com/hashicorp/vault/blob/main/command/agent/cache/lease_cache.go#L205)).

The lifetime_watcher needs access to the Age header, as opposed to modifying the TTL, because the TTL has a very strong affect on the sleep duration. This is because the TTL is used in multiple terms of the sleep duration.

To achieve the correct sleepDuration the Age must be subtracted from the sleepDuration after all other calculations.



fixes: https://github.com/hashicorp/vault/issues/16439