### PR TITLE
UI: Disable limiting clients when creating key, filter clients when editing

### DIFF
--- a/ui/app/components/oidc/client-form.js
+++ b/ui/app/components/oidc/client-form.js
@@ -28,6 +28,15 @@ export default class OidcClientForm extends Component {
       ? 'allow_all'
       : 'limited';
 
+  get modelAssignments() {
+    const { assignments } = this.args.model;
+    if (assignments.includes('allow_all') && assignments.length === 1) {
+      return [];
+    } else {
+      return assignments;
+    }
+  }
+
   @action
   handleAssignmentSelection(selection) {
     // if array then coming from search-select component, set selection as model assignments
@@ -41,14 +50,6 @@ export default class OidcClientForm extends Component {
     }
   }
 
-  get modelAssignments() {
-    const { assignments } = this.args.model;
-    if (assignments.includes('allow_all') && assignments.length === 1) {
-      return [];
-    } else {
-      return assignments;
-    }
-  }
   @task
   *save(event) {
     event.preventDefault();

--- a/ui/app/components/oidc/client-form.js
+++ b/ui/app/components/oidc/client-form.js
@@ -49,7 +49,6 @@ export default class OidcClientForm extends Component {
       return assignments;
     }
   }
-
   @task
   *save(event) {
     event.preventDefault();

--- a/ui/app/components/oidc/client-form.js
+++ b/ui/app/components/oidc/client-form.js
@@ -28,15 +28,6 @@ export default class OidcClientForm extends Component {
       ? 'allow_all'
       : 'limited';
 
-  get modelAssignments() {
-    const { assignments } = this.args.model;
-    if (assignments.includes('allow_all') && assignments.length === 1) {
-      return [];
-    } else {
-      return assignments;
-    }
-  }
-
   @action
   handleAssignmentSelection(selection) {
     // if array then coming from search-select component, set selection as model assignments
@@ -47,6 +38,15 @@ export default class OidcClientForm extends Component {
       // UI always reflects a user's selection (including when no assignments are selected)
       this.radioCardGroupValue = selection;
       this.args.model.assignments = [];
+    }
+  }
+
+  get modelAssignments() {
+    const { assignments } = this.args.model;
+    if (assignments.includes('allow_all') && assignments.length === 1) {
+      return [];
+    } else {
+      return assignments;
     }
   }
 

--- a/ui/app/components/oidc/key-form.js
+++ b/ui/app/components/oidc/key-form.js
@@ -30,6 +30,10 @@ export default class OidcKeyForm extends Component {
       ? 'allow_all'
       : 'limited';
 
+  get filterSearchSelect() {
+    return { paramKey: 'key', filterFor: [this.args.model.name] };
+  }
+
   @action
   handleClientSelection(selection) {
     // if array then coming from search-select component, set selection as model clients

--- a/ui/app/components/oidc/key-form.js
+++ b/ui/app/components/oidc/key-form.js
@@ -30,7 +30,8 @@ export default class OidcKeyForm extends Component {
       ? 'allow_all'
       : 'limited';
 
-  get filterSearchSelect() {
+  get filterDropdownOptions() {
+    // query object sent to search-select so only clients that reference this key appear in dropdown
     return { paramKey: 'key', filterFor: [this.args.model.name] };
   }
 

--- a/ui/app/templates/components/oidc/key-form.hbs
+++ b/ui/app/templates/components/oidc/key-form.hbs
@@ -52,14 +52,14 @@
         @groupValue={{this.radioCardGroupValue}}
         @onChange={{this.handleClientSelection}}
         @disabled={{@model.isNew}}
-        @disabledTooltipMessage="This option has been disabled for now. To limit access, you must first create an application that uses this key."
+        @disabledTooltipMessage="This option has been disabled for now. To limit access, you must first create an application that references this key."
       />
     </div>
     {{#if (eq this.radioCardGroupValue "limited")}}
       <SearchSelect
         @id="allowedClientIds"
         @subLabel="Application name"
-        @subText="Select which applications are allowed to use this key. Only applications that that currently reference this key will appear in dropdown."
+        @subText="Select which applications are allowed to use this key. Only applications that currently reference this key will appear in the dropdown."
         @models={{array "oidc/client"}}
         @inputValue={{@model.allowedClientIds}}
         @onChange={{this.handleClientSelection}}

--- a/ui/app/templates/components/oidc/key-form.hbs
+++ b/ui/app/templates/components/oidc/key-form.hbs
@@ -67,7 +67,7 @@
         @fallbackComponent="string-list"
         @passObject={{true}}
         @objectKeys={{array "clientId"}}
-        @queryObject={{this.filterSearchSelect}}
+        @queryObject={{this.filterDropdownOptions}}
       />
     {{/if}}
   </div>

--- a/ui/app/templates/components/oidc/key-form.hbs
+++ b/ui/app/templates/components/oidc/key-form.hbs
@@ -51,6 +51,8 @@
         @value="limited"
         @groupValue={{this.radioCardGroupValue}}
         @onChange={{this.handleClientSelection}}
+        @disabled={{@model.isNew}}
+        @disabledTooltipMessage="This option has been disabled for now. To limit access, you must first create an application that uses this key."
       />
     </div>
     {{#if (eq this.radioCardGroupValue "limited")}}

--- a/ui/app/templates/components/oidc/key-form.hbs
+++ b/ui/app/templates/components/oidc/key-form.hbs
@@ -59,6 +59,7 @@
       <SearchSelect
         @id="allowedClientIds"
         @subLabel="Application name"
+        @subText="Select which applications are allowed to use this key. Only applications that that currently reference this key will appear in dropdown."
         @models={{array "oidc/client"}}
         @inputValue={{@model.allowedClientIds}}
         @onChange={{this.handleClientSelection}}
@@ -66,6 +67,7 @@
         @fallbackComponent="string-list"
         @passObject={{true}}
         @objectKeys={{array "clientId"}}
+        @queryObject={{this.filterSearchSelect}}
       />
     {{/if}}
   </div>

--- a/ui/app/templates/components/radio-card.hbs
+++ b/ui/app/templates/components/radio-card.hbs
@@ -3,33 +3,44 @@
   class="radio-card {{if (eq @value @groupValue) 'is-selected'}} {{if @disabled 'is-disabled'}}"
   ...attributes
 >
-  {{#if (has-block)}}
-    {{yield}}
-  {{else}}
-    <div class="radio-card-row">
-      <div>
-        <Icon @name={{@icon}} @size="24" class="has-text-grey-light" />
+  <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
+    <T.Trigger tabindex="-1">
+      {{#if (has-block)}}
+        {{yield}}
+      {{else}}
+        <div class="radio-card-row">
+          <div>
+            <Icon @name={{@icon}} @size="24" class="has-text-grey-light" />
+          </div>
+          <div class="has-left-margin-s">
+            <h5 class="radio-card-message-title">
+              {{@title}}
+            </h5>
+            <p class="radio-card-message-body">
+              {{@description}}
+            </p>
+          </div>
+        </div>
+      {{/if}}
+      <div class="radio-card-radio-row">
+        <RadioButton
+          id={{dasherize @value}}
+          name="config-mode"
+          class="radio"
+          @disabled={{@disabled}}
+          @value={{@value}}
+          @groupValue={{@groupValue}}
+          @onChange={{@onChange}}
+        />
+        <span class="dot"></span>
       </div>
-      <div class="has-left-margin-s">
-        <h5 class="radio-card-message-title">
-          {{@title}}
-        </h5>
-        <p class="radio-card-message-body">
-          {{@description}}
-        </p>
-      </div>
-    </div>
-  {{/if}}
-  <div class="radio-card-radio-row">
-    <RadioButton
-      id={{dasherize @value}}
-      name="config-mode"
-      class="radio"
-      @disabled={{@disabled}}
-      @value={{@value}}
-      @groupValue={{@groupValue}}
-      @onChange={{@onChange}}
-    />
-    <span class="dot"></span>
-  </div>
+    </T.Trigger>
+    {{#if (and @disabled @disabledTooltipMessage)}}
+      <T.Content @defaultClass="tool-tip smaller-font">
+        <div class="box">
+          {{@disabledTooltipMessage}}
+        </div>
+      </T.Content>
+    {{/if}}
+  </ToolTip>
 </label>

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -15,7 +15,7 @@ import layout from '../templates/components/search-select';
  *
  * @param {string} id - The name of the form field
  * @param {Array} models - An array of model types to fetch from the API.
- * @param {object} queryObject - query object to pass as query options to as second argument to this.store.query(modelType, {})
+ * @param {object} [queryObject] - object passed as query options to this.store.query(). NOTE: will override this.backend
  * @param {function} onChange - The onchange action for this form field. ** SEE UTIL ** search-select-has-many.js if selecting models from a hasMany relationship
  * @param {string | Array} inputValue -  A comma-separated string or an array of strings -- array of ids for models.
  * @param {string} label - Label for this form field
@@ -53,7 +53,6 @@ export default Component.extend({
   allOptions: null, // list of options including matched
   selectedOptions: null, // list of selected options
   options: null, // all possible options
-  queryObject: null,
   shouldUseFallback: false,
   shouldRenderName: false,
   disallowNewItems: false,
@@ -127,7 +126,6 @@ export default Component.extend({
           queryOptions = this.queryObject;
         }
         let options = yield this.store.query(modelType, queryOptions);
-        console.log(options, 'OPTIIONS');
         this.formatOptions(options);
       } catch (err) {
         if (err.httpStatus === 404) {

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -15,6 +15,7 @@ import layout from '../templates/components/search-select';
  *
  * @param {string} id - The name of the form field
  * @param {Array} models - An array of model types to fetch from the API.
+ * @param {object} queryObject - query object to pass as query options to as second argument to this.store.query(modelType, {})
  * @param {function} onChange - The onchange action for this form field. ** SEE UTIL ** search-select-has-many.js if selecting models from a hasMany relationship
  * @param {string | Array} inputValue -  A comma-separated string or an array of strings -- array of ids for models.
  * @param {string} label - Label for this form field
@@ -45,7 +46,6 @@ export default Component.extend({
   classNameBindings: ['displayInherit:display-inherit'],
   classNames: ['field', 'search-select'],
   store: service(),
-
   onChange: () => {},
   inputValue: computed(function () {
     return [];
@@ -53,6 +53,7 @@ export default Component.extend({
   allOptions: null, // list of options including matched
   selectedOptions: null, // list of selected options
   options: null, // all possible options
+  queryObject: null,
   shouldUseFallback: false,
   shouldRenderName: false,
   disallowNewItems: false,
@@ -122,7 +123,11 @@ export default Component.extend({
         if (this.backend) {
           queryOptions = { backend: this.backend };
         }
+        if (this.queryObject) {
+          queryOptions = this.queryObject;
+        }
         let options = yield this.store.query(modelType, queryOptions);
+        console.log(options, 'OPTIIONS');
         this.formatOptions(options);
       } catch (err) {
         if (err.httpStatus === 404) {

--- a/ui/lib/core/addon/components/tool-tip.js
+++ b/ui/lib/core/addon/components/tool-tip.js
@@ -7,7 +7,7 @@ export default class ToolTipComponent extends Component {
     return this.args.delay || 200;
   }
   get horizontalPosition() {
-    return this.args.delay || 'auto-right';
+    return this.args.horizontalPosition || 'auto-right';
   }
 
   toggleState({ dropdown, action }) {

--- a/ui/tests/helpers/oidc-config.js
+++ b/ui/tests/helpers/oidc-config.js
@@ -96,7 +96,7 @@ const deleteModelRecord = async (model) => {
 // MOCK RESPONSES:
 
 export const CLIENT_LIST_RESPONSE = {
-  keys: ['some-app'],
+  keys: ['some-app', 'app-1'],
   key_info: {
     'some-app': {
       assignments: ['allow_all'],
@@ -105,6 +105,15 @@ export const CLIENT_LIST_RESPONSE = {
       client_type: 'confidential',
       id_token_ttl: 0,
       key: 'default',
+      redirect_uris: [],
+    },
+    'app-1': {
+      assignments: ['allow_all'],
+      client_id: 'HkmsTA4GG17j0Djy4EUAB2VAyzuLVewg',
+      client_secret: 'hvo_secret_g3f30MxAJWLXhhrCejbG4zY3O4LEHhEIO24aMy181AYKnfQtWTVV924ZmnlpUFUw',
+      client_type: 'confidential',
+      id_token_ttl: 0,
+      key: 'test-key',
       redirect_uris: [],
     },
   },

--- a/ui/tests/integration/components/mfa-login-enforcement-header-test.js
+++ b/ui/tests/integration/components/mfa-login-enforcement-header-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { clickTrigger } from 'ember-power-select/test-support/helpers';
 
 module('Integration | Component | mfa-login-enforcement-header', function (hooks) {
   setupRenderingTest(hooks);
@@ -50,12 +51,11 @@ module('Integration | Component | mfa-login-enforcement-header', function (hooks
     assert
       .dom('[data-test-mleh-description]')
       .includesText('An enforcement includes the authentication types', 'Description renders');
-
     for (const option of ['new', 'existing', 'skip']) {
       await click(`[data-test-mleh-radio="${option}"] input`);
       assert.equal(this.value, option, 'Value is updated on radio select');
       if (option === 'existing') {
-        await click('.ember-basic-dropdown-trigger');
+        await clickTrigger();
         await click('.ember-power-select-option');
       }
     }

--- a/ui/tests/integration/components/oidc/key-form-test.js
+++ b/ui/tests/integration/components/oidc/key-form-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | oidc/key-form', function (hooks) {
   });
 
   test('it should save new key', async function (assert) {
-    assert.expect(12);
+    assert.expect(9);
     this.server.post('/identity/oidc/key/test-key', (schema, req) => {
       assert.ok(true, 'Request made to save key');
       return JSON.parse(req.requestBody);
@@ -55,28 +55,16 @@ module('Integration | Component | oidc/key-form', function (hooks) {
       .dom('[data-test-inline-error-message]')
       .hasText('Name cannot contain whitespace.', 'Validation message is shown whitespace');
 
-    await click('label[for=limited]');
-    assert
-      .dom('[data-test-component="search-select"]#allowedClientIds')
-      .exists('Limited radio button shows clients search select');
-    await click('[data-test-component="search-select"]#allowedClientIds .ember-basic-dropdown-trigger');
-    assert.dom('li.ember-power-select-option').hasTextContaining('some-app', 'dropdown renders clients');
-    assert.dom('[data-test-smaller-id]').exists('renders smaller client id in dropdown');
-
-    await click('label[for=allow-all]');
-    assert
-      .dom('[data-test-component="search-select"]#allowedClientIds')
-      .doesNotExist('Allow all radio button hides search select');
-
+    assert.dom('label[for=limited] input').isDisabled('limit radio button disabled on create');
     await fillIn('[data-test-input="name"]', 'test-key');
     await click('[data-test-oidc-key-save]');
   });
 
-  test('it should update key', async function (assert) {
-    assert.expect(7);
+  test('it should update key and limit access to selected applications', async function (assert) {
+    assert.expect(12);
 
     this.server.post('/identity/oidc/key/test-key', (schema, req) => {
-      assert.ok(true, 'Request made to save key');
+      assert.ok(true, 'Request made to update key');
       return JSON.parse(req.requestBody);
     });
 
@@ -87,7 +75,7 @@ module('Integration | Component | oidc/key-form', function (hooks) {
     });
 
     this.model = this.store.peekRecord('oidc/key', 'test-key');
-    this.onSave = () => assert.ok(true, 'onSave callback fires on save success');
+    this.onSave = () => assert.ok(true, 'onSave callback fires on update success');
 
     await render(hbs`
       <Oidc::KeyForm
@@ -102,6 +90,23 @@ module('Integration | Component | oidc/key-form', function (hooks) {
     assert.dom('[data-test-input="name"]').isDisabled('Name input is disabled when editing');
     assert.dom('[data-test-input="name"]').hasValue('test-key', 'Name input is populated with model value');
     assert.dom('input#allow-all').isChecked('Allow all radio button is selected');
+
+    await click('label[for=limited]');
+    assert
+      .dom('[data-test-component="search-select"]#allowedClientIds')
+      .exists('Limited radio button shows clients search select');
+    await click('[data-test-component="search-select"]#allowedClientIds .ember-basic-dropdown-trigger');
+    assert.equal(findAll('li.ember-power-select-option').length, 1, 'dropdown only renders one option');
+    assert
+      .dom('li.ember-power-select-option')
+      .hasTextContaining('app-1', 'dropdown contains client that references key');
+    assert.dom('[data-test-smaller-id]').exists('renders smaller client id in dropdown');
+
+    await click('label[for=allow-all]');
+    assert
+      .dom('[data-test-component="search-select"]#allowedClientIds')
+      .doesNotExist('Allow all radio button hides search select');
+
     await click('[data-test-oidc-key-save]');
   });
 
@@ -144,7 +149,20 @@ module('Integration | Component | oidc/key-form', function (hooks) {
 
   test('it should render fallback for search select', async function (assert) {
     assert.expect(1);
-    this.model = this.store.createRecord('oidc/key');
+
+    this.server.post('/identity/oidc/key/test-key', (schema, req) => {
+      assert.ok(true, 'Request made to update key');
+      return JSON.parse(req.requestBody);
+    });
+
+    this.store.pushPayload('oidc/key', {
+      modelName: 'oidc/key',
+      name: 'test-key',
+      allowed_client_ids: ['*'],
+    });
+
+    this.model = this.store.peekRecord('oidc/key', 'test-key');
+
     this.server.get('/identity/oidc/client', () => overrideMirageResponse(403));
     await render(hbs`
       <Oidc::KeyForm
@@ -157,6 +175,6 @@ module('Integration | Component | oidc/key-form', function (hooks) {
     await click('label[for=limited]');
     assert
       .dom('[data-test-component="search-select"]#allowedClientIds [data-test-component="string-list"]')
-      .exists('Radio toggle shows assignments string-list input');
+      .exists('Radio toggle shows client string-list input');
   });
 });


### PR DESCRIPTION
This PR disables limiting applications when initially creating a key to prevent a user from limiting access to an application that references a different key. An application's key **cannot be edited** so the key must first exist and assigned to an application before a key's access can be limited. 
> _Application form dropdown for selecting a `key`_

 <img width="500" alt="Screen Shot 2022-08-29 at 11 30 06 AM" src="https://user-images.githubusercontent.com/68122737/187272634-ee224c95-bab9-46e7-adea-6282f0de453e.png">

Once the key is referenced by an application, then we can go back and **edit** the key and limit access so only selected applications can use it for authentication requests. The search select dropdown only shows applications that reference the current key. Notice that `test-key` only has `app-1` and `app-2` in the dropdown because they are the only two apps that use it. 
<hr> 

### Gif demo: 
![key-limit](https://user-images.githubusercontent.com/68122737/187274909-e6ad1fd1-ff0a-4820-8c65-d1e9e95845b4.gif)


### Tooltip text:

<img width="400" alt="Screen Shot 2022-08-29 at 11 28 31 AM" src="https://user-images.githubusercontent.com/68122737/187272331-9411083d-6f84-46db-9533-d3d4169c9e36.png">
