### PR TITLE
Clean up behavior of If-Modified-Since header

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -5143,10 +5143,10 @@ func TestBackend_IfModifiedSinceHeaders(t *testing.T) {
 	// last headers, otherwise the headers added after the last set operation
 	// leak into this copy... Yuck!
 	lastHeaders := client.Headers()
-	for _, path := range []string{"pki/cert/ca", "pki/cert/crl", "pki/issuer/default/json", "pki/issuer/old-root/json", "pki/issuer/old-root/crl"} {
+	for _, path := range []string{"pki/cert/ca", "pki/cert/crl", "pki/issuer/default/json", "pki/issuer/old-root/json", "pki/issuer/old-root/crl", "pki/cert/delta-crl", "pki/issuer/old-root/crl/delta"} {
 		t.Logf("path: %v", path)
 		field := "certificate"
-		if strings.HasPrefix(path, "pki/issuer") && strings.HasSuffix(path, "/crl") {
+		if strings.HasPrefix(path, "pki/issuer") && strings.Contains(path, "/crl") {
 			field = "crl"
 		}
 
@@ -5198,10 +5198,10 @@ func TestBackend_IfModifiedSinceHeaders(t *testing.T) {
 	afterNewCAGeneration := time.Now().Add(2 * time.Second)
 
 	// New root isn't the default, so it has fewer paths.
-	for _, path := range []string{"pki/issuer/new-root/json", "pki/issuer/new-root/crl"} {
+	for _, path := range []string{"pki/issuer/new-root/json", "pki/issuer/new-root/crl", "pki/issuer/new-root/crl/delta"} {
 		t.Logf("path: %v", path)
 		field := "certificate"
-		if strings.HasPrefix(path, "pki/issuer") && strings.HasSuffix(path, "/crl") {
+		if strings.HasPrefix(path, "pki/issuer") && strings.Contains(path, "/crl") {
 			field = "crl"
 		}
 
@@ -5244,10 +5244,10 @@ func TestBackend_IfModifiedSinceHeaders(t *testing.T) {
 	require.NoError(t, err)
 
 	// Reading both with the last modified date should return new values.
-	for _, path := range []string{"pki/cert/ca", "pki/cert/crl", "pki/issuer/default/json", "pki/issuer/old-root/json", "pki/issuer/new-root/json", "pki/issuer/old-root/crl", "pki/issuer/new-root/crl"} {
+	for _, path := range []string{"pki/cert/ca", "pki/cert/crl", "pki/issuer/default/json", "pki/issuer/old-root/json", "pki/issuer/new-root/json", "pki/issuer/old-root/crl", "pki/issuer/new-root/crl", "pki/cert/delta-crl", "pki/issuer/old-root/crl/delta", "pki/issuer/new-root/crl/delta"} {
 		t.Logf("path: %v", path)
 		field := "certificate"
-		if strings.HasPrefix(path, "pki/issuer") && strings.HasSuffix(path, "/crl") {
+		if strings.HasPrefix(path, "pki/issuer") && strings.Contains(path, "/crl") {
 			field = "crl"
 		}
 
@@ -5279,7 +5279,7 @@ func TestBackend_IfModifiedSinceHeaders(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// The above tests should say everything is cached.
-	for _, path := range []string{"pki/cert/ca", "pki/cert/crl", "pki/issuer/default/json", "pki/issuer/old-root/json", "pki/issuer/new-root/json", "pki/issuer/old-root/crl", "pki/issuer/new-root/crl"} {
+	for _, path := range []string{"pki/cert/ca", "pki/cert/crl", "pki/issuer/default/json", "pki/issuer/old-root/json", "pki/issuer/new-root/json", "pki/issuer/old-root/crl", "pki/issuer/new-root/crl", "pki/cert/delta-crl", "pki/issuer/old-root/crl/delta", "pki/issuer/new-root/crl/delta"} {
 		t.Logf("path: %v", path)
 
 		// Ensure that the CA is returned correctly if we give it the new time.
@@ -5311,10 +5311,10 @@ func TestBackend_IfModifiedSinceHeaders(t *testing.T) {
 	}
 
 	// CRL should be invalidated
-	for _, path := range []string{"pki/cert/crl", "pki/issuer/old-root/crl", "pki/issuer/new-root/crl"} {
+	for _, path := range []string{"pki/cert/crl", "pki/issuer/old-root/crl", "pki/issuer/new-root/crl", "pki/cert/delta-crl", "pki/issuer/old-root/crl/delta", "pki/issuer/new-root/crl/delta"} {
 		t.Logf("path: %v", path)
 		field := "certificate"
-		if strings.HasPrefix(path, "pki/issuer") && strings.HasSuffix(path, "/crl") {
+		if strings.HasPrefix(path, "pki/issuer") && strings.Contains(path, "/crl") {
 			field = "crl"
 		}
 
@@ -5330,7 +5330,7 @@ func TestBackend_IfModifiedSinceHeaders(t *testing.T) {
 
 	// If we send some time in the future, everything should be cached again!
 	futureTime := time.Now().Add(30 * time.Second)
-	for _, path := range []string{"pki/cert/ca", "pki/cert/crl", "pki/issuer/default/json", "pki/issuer/old-root/json", "pki/issuer/new-root/json", "pki/issuer/old-root/crl", "pki/issuer/new-root/crl"} {
+	for _, path := range []string{"pki/cert/ca", "pki/cert/crl", "pki/issuer/default/json", "pki/issuer/old-root/json", "pki/issuer/new-root/json", "pki/issuer/old-root/crl", "pki/issuer/new-root/crl", "pki/cert/delta-crl", "pki/issuer/old-root/crl/delta", "pki/issuer/new-root/crl/delta"} {
 		t.Logf("path: %v", path)
 
 		// Ensure that the CA is returned correctly if we give it the new time.
@@ -5361,10 +5361,10 @@ func TestBackend_IfModifiedSinceHeaders(t *testing.T) {
 
 	afterThreeWaySwap := time.Now().Add(2 * time.Second)
 
-	for _, path := range []string{"pki/cert/ca", "pki/cert/crl", "pki/issuer/default/json", "pki/issuer/old-root/json", "pki/issuer/new-root/json", "pki/issuer/old-root/crl", "pki/issuer/new-root/crl"} {
+	for _, path := range []string{"pki/cert/ca", "pki/cert/crl", "pki/issuer/default/json", "pki/issuer/old-root/json", "pki/issuer/new-root/json", "pki/issuer/old-root/crl", "pki/issuer/new-root/crl", "pki/cert/delta-crl", "pki/issuer/old-root/crl/delta", "pki/issuer/new-root/crl/delta"} {
 		t.Logf("path: %v", path)
 		field := "certificate"
-		if strings.HasPrefix(path, "pki/issuer") && strings.HasSuffix(path, "/crl") {
+		if strings.HasPrefix(path, "pki/issuer") && strings.Contains(path, "/crl") {
 			field = "crl"
 		}
 

--- a/builtin/logical/pki/config_util.go
+++ b/builtin/logical/pki/config_util.go
@@ -91,6 +91,7 @@ func (sc *storageContext) updateDefaultIssuerId(id issuerID) error {
 		}
 
 		cfg.LastModified = now
+		cfg.DeltaLastModified = now
 		err = sc.setLocalCRLConfig(cfg)
 		if err != nil {
 			return fmt.Errorf("unable to update local CRL config's modification time: error persisting local CRL config: %v", err)

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -229,6 +229,7 @@ func (cb *crlBuilder) flushCRLBuildTimeInvalidation(sc *storageContext) error {
 		}
 
 		cfg.LastModified = time.Now().UTC()
+		cfg.DeltaLastModified = time.Now().UTC()
 		err = sc.setLocalCRLConfig(cfg)
 		if err != nil {
 			cb.invalidate.Store(true)
@@ -931,7 +932,11 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 			}
 
 			// Update `LastModified`
-			crlConfig.LastModified = time.Now().UTC()
+			if isDelta {
+				crlConfig.DeltaLastModified = time.Now().UTC()
+			} else {
+				crlConfig.LastModified = time.Now().UTC()
+			}
 
 			// Lastly, build the CRL.
 			nextUpdate, err := buildCRL(sc, globalCRLConfig, forceNew, representative, revokedCerts, crlIdentifier, crlNumber, isDelta, lastCompleteNumber)

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -347,6 +347,9 @@ func (b *backend) pathUpdateIssuer(ctx context.Context, req *logical.Request, da
 		oldName = issuer.Name
 		issuer.Name = newName
 		issuer.LastModified = time.Now().UTC()
+		// See note in updateDefaultIssuerId about why this is necessary.
+		b.crlBuilder.invalidateCRLBuildTime()
+		b.crlBuilder.flushCRLBuildTimeInvalidation(sc)
 		modified = true
 	}
 
@@ -534,6 +537,9 @@ func (b *backend) pathPatchIssuer(ctx context.Context, req *logical.Request, dat
 			oldName = issuer.Name
 			issuer.Name = newName
 			issuer.LastModified = time.Now().UTC()
+			// See note in updateDefaultIssuerId about why this is necessary.
+			b.crlBuilder.invalidateCRLBuildTime()
+			b.crlBuilder.flushCRLBuildTimeInvalidation(sc)
 			modified = true
 		}
 	}

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -755,7 +755,7 @@ func (b *backend) pathGetRawIssuer(ctx context.Context, req *logical.Request, da
 	var certificate []byte
 
 	response := &logical.Response{}
-	ret, err := sendNotModifiedResponseIfNecessary(&IfModifiedSinceHelper{req: req, issuerRef: ref}, sc, response)
+	ret, err := sendNotModifiedResponseIfNecessary(&IfModifiedSinceHelper{req: req, reqType: ifModifiedCA, issuerRef: ref}, sc, response)
 	if err != nil {
 		return nil, err
 	}
@@ -937,7 +937,11 @@ func (b *backend) pathGetIssuerCRL(ctx context.Context, req *logical.Request, da
 
 	sc := b.makeStorageContext(ctx, req.Storage)
 	response := &logical.Response{}
-	ret, err := sendNotModifiedResponseIfNecessary(&IfModifiedSinceHelper{req: req}, sc, response)
+	var crlType ifModifiedReqType = ifModifiedCRL
+	if strings.Contains(req.Path, "delta") {
+		crlType = ifModifiedDeltaCRL
+	}
+	ret, err := sendNotModifiedResponseIfNecessary(&IfModifiedSinceHelper{req: req, reqType: crlType}, sc, response)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -35,9 +35,6 @@ const (
 	maxRolesToFindOnIssuerChange = 10
 
 	latestIssuerVersion = 1
-
-	headerIfModifiedSince = "If-Modified-Since"
-	headerLastModified    = "Last-Modified"
 )
 
 type keyID string
@@ -170,6 +167,7 @@ type localCRLConfigEntry struct {
 	LastCompleteNumberMap map[crlID]int64     `json:"last_complete_number_map"`
 	CRLExpirationMap      map[crlID]time.Time `json:"crl_expiration_map"`
 	LastModified          time.Time           `json:"last_modified"`
+	DeltaLastModified     time.Time           `json:"delta_last_modified"`
 }
 
 type keyConfigEntry struct {


### PR DESCRIPTION
This adds two behavior fixes to the If-Modified-Since header:

 1. Ensure that issuer renames correctly invalidate the config. A three-way swap of issuer names is equivalent to the default changing.
 2. Add correct handling behavior for the delta CRL.

2 needs some follow-up testing in a second PR; we want to introduce a `crl/rotate-delta` URL that rotates _just_ the delta CRL, which we can use for further testing of the Delta CRL IMS behavior. Right now we just test to ensure it has semantics equivalent to the main CRL...

No new changelog or docs entries are necessary since this isn't yet shipped in a release. 

---

cc @Gabrielopesantos -- in case you're interested in what the follow-up looks like :-)