### PR TITLE
UI: Use correct endpoint for force revoke prefix

### DIFF
--- a/ui/app/adapters/lease.js
+++ b/ui/app/adapters/lease.js
@@ -9,7 +9,7 @@ export default ApplicationAdapter.extend({
   },
 
   forceRevokePrefix(prefix) {
-    let url = this.buildURL() + '/leases/revoke-prefix/' + encodePath(prefix);
+    let url = this.buildURL() + '/leases/revoke-force/' + encodePath(prefix);
     url = url.replace(/\/$/, '');
     return this.ajax(url, 'PUT');
   },


### PR DESCRIPTION
This PR updates the "force revoke" button in the UI to use the correct endpoint. 
![force-revoke](https://user-images.githubusercontent.com/82459713/187488201-36cdcf2b-0646-4cea-932a-6e3dac1bd555.gif)

Previously, the `force revoke` button in the UI was using the `/leases/revoke-prefix/` endpoint causing failures when revoking a database connection to a database which is no longer running: 
<img width="1386" alt="Force revoke attempt failed due to wrong API call" src="https://user-images.githubusercontent.com/82459713/187487760-48776203-124a-4d2a-a743-6ef05deef360.png">

