### PR TITLE
Add remove_roots_from_chain to sign and issue pki apis

### DIFF
--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -141,6 +141,13 @@ be larger than the role max TTL.`,
 The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ`,
 	}
 
+	fields["remove_roots_from_chain"] = &framework.FieldSchema{
+		Type:    framework.TypeBool,
+		Default: false,
+		Description: `Whether or not to remove self-signed CA certificates in the output
+of the ca_chain field.`,
+	}
+
 	fields = addIssuerRefField(fields)
 
 	return fields

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -438,8 +438,9 @@ func newCaChainOutput(parsedBundle *certutil.ParsedCertBundle, data *framework.F
 		var myChain []*certutil.CertBlock
 		for _, certBlock := range parsedBundle.CAChain {
 			cert := certBlock.Certificate
+
 			if (len(cert.AuthorityKeyId) > 0 && !bytes.Equal(cert.AuthorityKeyId, cert.SubjectKeyId)) ||
-				(len(cert.AuthorityKeyId) == 0 && !bytes.Equal(cert.RawIssuer, cert.RawSubject)) {
+				(len(cert.AuthorityKeyId) == 0 && (!bytes.Equal(cert.RawIssuer, cert.RawSubject) || cert.CheckSignatureFrom(cert) != nil)) {
 				// We aren't self-signed so add it to the list.
 				myChain = append(myChain, certBlock)
 			}

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -1,9 +1,11 @@
 package pki
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"strings"
 	"time"
@@ -333,6 +335,8 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 		return nil, fmt.Errorf("error converting raw cert bundle to cert bundle: %w", err)
 	}
 
+	caChainGen := newCaChainOutput(parsedBundle, data)
+
 	respData := map[string]interface{}{
 		"expiration":    int64(parsedBundle.Certificate.NotAfter.Unix()),
 		"serial_number": cb.SerialNumber,
@@ -342,8 +346,8 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 	case "pem":
 		respData["issuing_ca"] = signingCB.Certificate
 		respData["certificate"] = cb.Certificate
-		if cb.CAChain != nil && len(cb.CAChain) > 0 {
-			respData["ca_chain"] = cb.CAChain
+		if caChainGen.containsChain() {
+			respData["ca_chain"] = caChainGen.pemEncodedChain()
 		}
 		if !useCSR {
 			respData["private_key"] = cb.PrivateKey
@@ -353,8 +357,8 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 	case "pem_bundle":
 		respData["issuing_ca"] = signingCB.Certificate
 		respData["certificate"] = cb.ToPEMBundle()
-		if cb.CAChain != nil && len(cb.CAChain) > 0 {
-			respData["ca_chain"] = cb.CAChain
+		if caChainGen.containsChain() {
+			respData["ca_chain"] = caChainGen.pemEncodedChain()
 		}
 		if !useCSR {
 			respData["private_key"] = cb.PrivateKey
@@ -365,12 +369,8 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 		respData["certificate"] = base64.StdEncoding.EncodeToString(parsedBundle.CertificateBytes)
 		respData["issuing_ca"] = base64.StdEncoding.EncodeToString(signingBundle.CertificateBytes)
 
-		var caChain []string
-		for _, caCert := range parsedBundle.CAChain {
-			caChain = append(caChain, base64.StdEncoding.EncodeToString(caCert.Bytes))
-		}
-		if caChain != nil && len(caChain) > 0 {
-			respData["ca_chain"] = caChain
+		if caChainGen.containsChain() {
+			respData["ca_chain"] = caChainGen.derEncodedChain()
 		}
 
 		if !useCSR {
@@ -427,6 +427,49 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 	}
 
 	return resp, nil
+}
+
+type caChainOutput struct {
+	chain []*certutil.CertBlock
+}
+
+func newCaChainOutput(parsedBundle *certutil.ParsedCertBundle, data *framework.FieldData) caChainOutput {
+	if filterCaChain := data.Get("remove_roots_from_chain").(bool); filterCaChain {
+		var myChain []*certutil.CertBlock
+		for _, certBlock := range parsedBundle.CAChain {
+			cert := certBlock.Certificate
+			if (len(cert.AuthorityKeyId) > 0 && !bytes.Equal(cert.AuthorityKeyId, cert.SubjectKeyId)) ||
+				(len(cert.AuthorityKeyId) == 0 && !bytes.Equal(cert.RawIssuer, cert.RawSubject)) {
+				// We aren't self-signed so add it to the list.
+				myChain = append(myChain, certBlock)
+			}
+		}
+		return caChainOutput{chain: myChain}
+	}
+
+	return caChainOutput{chain: parsedBundle.CAChain}
+}
+
+func (cac *caChainOutput) containsChain() bool {
+	return len(cac.chain) > 0
+}
+
+func (cac *caChainOutput) pemEncodedChain() []string {
+	var chain []string
+	for _, cert := range cac.chain {
+		block := pem.Block{Type: "CERTIFICATE", Bytes: cert.Bytes}
+		certificate := strings.TrimSpace(string(pem.EncodeToMemory(&block)))
+		chain = append(chain, certificate)
+	}
+	return chain
+}
+
+func (cac *caChainOutput) derEncodedChain() []string {
+	var derCaChain []string
+	for _, caCert := range cac.chain {
+		derCaChain = append(derCaChain, base64.StdEncoding.EncodeToString(caCert.Bytes))
+	}
+	return derCaChain
 }
 
 const pathIssueHelpSyn = `

--- a/changelog/16935.txt
+++ b/changelog/16935.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Add a new flag to issue/sign APIs which can filter out root CAs from the returned ca_chain field
+```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -401,6 +401,10 @@ It is suggested to limit access to the path-overridden sign endpoint (on
   `YYYY-MM-ddTHH:MM:SSZ`. Supports the Y10K end date for IEEE 802.1AR-2018
   standard devices, `9999-12-31T23:59:59Z`.
 
+- `remove_roots_from_chain` `(bool: false)` - If true, the returned `ca_chain`
+  field will not include any self-signed CA certificates. Useful if end-users
+  already have the root CA in their trust store.
+
 #### Sample Payload
 
 ```json
@@ -781,6 +785,10 @@ have access.**
 - `use_pss` `(bool: false)` - Specifies whether or not to use PSS signatures
   over PKCS#1v1.5 signatures when a RSA-type issuer is used. Ignored for
   ECDSA/Ed25519 issuers.
+
+- `remove_roots_from_chain` `(bool: false)` - If true, the returned `ca_chain`
+  field will not include any self-signed CA certificates. Useful if end-users
+  already have the root CA in their trust store.
 
 #### Sample Payload
 


### PR DESCRIPTION
This adds a new flag to allow end-users to control if we return the self-signed/root CA certificates within the ca_chain field on issue and sign api calls. This was done to resolve concerns brought up by @maxb within issue #16057. The default behavior for the flag does preserve the behavior returning the root CA within the ca_chain field. The new flag is available on the following apis.
 
- `issue/<role>`
- `issuer/<issuer ref>/issue/<role>`
- `sign/<role>`
- `issuer/<issuer_ref>/sign/<role>`
- `sign-verbatim`

Note that the change mentioned within #16057 only affected mounts that had been initialized with the `root/generate/internal` api. Had an intermediary mount had an `intermediate/set-signed` call with the root CA within the PEM bundle, it would have contained the root CA certificate within ca_chain field (tested on 1.9.8 and 1.10.5). We should have made it clearer in the original changelog that we were making the behavior consistent no matter how the mount was populated.