### PR TITLE
VAULT-6433 do not return nil resp if ns is nil

### DIFF
--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -1366,7 +1366,7 @@ func (b *LoginMFABackend) mfaLoginEnforcementConfigToMap(eConfig *mfa.MFAEnforce
 		return nil, err
 	}
 	if ns != nil {
-		respData["namespace_path"] = ns.Path
+		resp["namespace_path"] = ns.Path
 	}
 	resp["namespace_id"] = eConfig.NamespaceID
 	resp["mfa_method_ids"] = append([]string{}, eConfig.MFAMethodIDs...)

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -1362,10 +1362,12 @@ func (b *LoginMFABackend) mfaLoginEnforcementConfigToMap(eConfig *mfa.MFAEnforce
 	resp := make(map[string]interface{})
 	resp["name"] = eConfig.Name
 	ns, err := b.namespacer.NamespaceByID(context.Background(), eConfig.NamespaceID)
-	if ns == nil || err != nil {
+	if err != nil {
 		return nil, err
 	}
-	resp["namespace_path"] = ns.Path
+	if ns != nil {
+		respData["namespace_path"] = ns.Path
+	}
 	resp["namespace_id"] = eConfig.NamespaceID
 	resp["mfa_method_ids"] = append([]string{}, eConfig.MFAMethodIDs...)
 	resp["auth_method_accessors"] = append([]string{}, eConfig.AuthMethodAccessors...)
@@ -1423,10 +1425,12 @@ func (b *MFABackend) mfaConfigToMap(mConfig *mfa.Config) (map[string]interface{}
 	respData["name"] = mConfig.Name
 	respData["namespace_id"] = mConfig.NamespaceID
 	ns, err := b.namespacer.NamespaceByID(context.Background(), mConfig.NamespaceID)
-	if ns == nil || err != nil {
+	if err != nil {
 		return nil, err
 	}
-	respData["namespace_path"] = ns.Path
+	if ns != nil {
+		respData["namespace_path"] = ns.Path
+	}
 
 	return respData, nil
 }


### PR DESCRIPTION
Small bug that was breaking `TestIdentityMFA_TypeImmutability` in ent. I did run the tests in ent that I found before merging, but missed this one as it was in the `vault` package.