### PR TITLE
auth/token: Fix ignored parameter warnings for valid parameters on token create

### DIFF
--- a/changelog/16938.txt
+++ b/changelog/16938.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/token: Fix ignored parameter warnings for valid parameters on token create
+```

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -157,6 +157,70 @@ func (ts *TokenStore) paths() []*framework.Path {
 		{
 			Pattern: "create-orphan$",
 
+			Fields: map[string]*framework.FieldSchema{
+				"role_name": {
+					Type:        framework.TypeString,
+					Description: "Name of the role",
+				},
+				"display_name": {
+					Type:        framework.TypeString,
+					Description: "Name to associate with this token",
+				},
+				"explicit_max_ttl": {
+					Type:        framework.TypeString,
+					Description: "Explicit Max TTL of this token",
+				},
+				"entity_alias": {
+					Type:        framework.TypeString,
+					Description: "Name of the entity alias to associate with this token",
+				},
+				"num_uses": {
+					Type:        framework.TypeInt,
+					Description: "Max number of uses for this token",
+				},
+				"period": {
+					Type:        framework.TypeString,
+					Description: "Renew period",
+				},
+				"renewable": {
+					Type:        framework.TypeBool,
+					Description: "Allow token to be renewed past its initial TTL up to system/mount maximum TTL",
+				},
+				"ttl": {
+					Type:        framework.TypeString,
+					Description: "Time to live for this token",
+				},
+				"type": {
+					Type:        framework.TypeString,
+					Description: "Token type",
+				},
+				"no_default_policy": {
+					Type:        framework.TypeBool,
+					Description: "Do not include default policy for this token",
+				},
+				"id": {
+					Type:        framework.TypeString,
+					Description: "Value for the token",
+				},
+				"metadata": {
+					Type:        framework.TypeMap,
+					Description: "Arbitrary key=value metadata to associate with the token",
+				},
+				"no_parent": {
+					Type:        framework.TypeBool,
+					Description: "Create the token with no parent",
+				},
+				"policies": {
+					Type:        framework.TypeStringSlice,
+					Description: "List of policies for the token",
+				},
+				"format": {
+					Type:        framework.TypeString,
+					Query:       true,
+					Description: "Return json formatted output",
+				},
+			},
+
 			Callbacks: map[logical.Operation]framework.OperationFunc{
 				logical.UpdateOperation: ts.handleCreateOrphan,
 			},
@@ -173,6 +237,63 @@ func (ts *TokenStore) paths() []*framework.Path {
 					Type:        framework.TypeString,
 					Description: "Name of the role",
 				},
+				"display_name": {
+					Type:        framework.TypeString,
+					Description: "Name to associate with this token",
+				},
+				"explicit_max_ttl": {
+					Type:        framework.TypeString,
+					Description: "Explicit Max TTL of this token",
+				},
+				"entity_alias": {
+					Type:        framework.TypeString,
+					Description: "Name of the entity alias to associate with this token",
+				},
+				"num_uses": {
+					Type:        framework.TypeInt,
+					Description: "Max number of uses for this token",
+				},
+				"period": {
+					Type:        framework.TypeString,
+					Description: "Renew period",
+				},
+				"renewable": {
+					Type:        framework.TypeBool,
+					Description: "Allow token to be renewed past its initial TTL up to system/mount maximum TTL",
+				},
+				"ttl": {
+					Type:        framework.TypeString,
+					Description: "Time to live for this token",
+				},
+				"type": {
+					Type:        framework.TypeString,
+					Description: "Token type",
+				},
+				"no_default_policy": {
+					Type:        framework.TypeBool,
+					Description: "Do not include default policy for this token",
+				},
+				"id": {
+					Type:        framework.TypeString,
+					Description: "Value for the token",
+				},
+				"metadata": {
+					Type:        framework.TypeMap,
+					Description: "Arbitrary key=value metadata to associate with the token",
+				},
+				"no_parent": {
+					Type:        framework.TypeBool,
+					Description: "Create the token with no parent",
+				},
+				"policies": {
+					Type:        framework.TypeStringSlice,
+					Description: "List of policies for the token",
+				},
+				"format": {
+					Type:        framework.TypeString,
+					Query:       true,
+					Description: "Return json formatted output",
+				},
 			},
 
 			Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -185,6 +306,66 @@ func (ts *TokenStore) paths() []*framework.Path {
 
 		{
 			Pattern: "create$",
+
+			Fields: map[string]*framework.FieldSchema{
+				"display_name": {
+					Type:        framework.TypeString,
+					Description: "Name to associate with this token",
+				},
+				"explicit_max_ttl": {
+					Type:        framework.TypeString,
+					Description: "Explicit Max TTL of this token",
+				},
+				"entity_alias": {
+					Type:        framework.TypeString,
+					Description: "Name of the entity alias to associate with this token",
+				},
+				"num_uses": {
+					Type:        framework.TypeInt,
+					Description: "Max number of uses for this token",
+				},
+				"period": {
+					Type:        framework.TypeString,
+					Description: "Renew period",
+				},
+				"renewable": {
+					Type:        framework.TypeBool,
+					Description: "Allow token to be renewed past its initial TTL up to system/mount maximum TTL",
+				},
+				"ttl": {
+					Type:        framework.TypeString,
+					Description: "Time to live for this token",
+				},
+				"type": {
+					Type:        framework.TypeString,
+					Description: "Token type",
+				},
+				"no_default_policy": {
+					Type:        framework.TypeBool,
+					Description: "Do not include default policy for this token",
+				},
+				"id": {
+					Type:        framework.TypeString,
+					Description: "Value for the token",
+				},
+				"metadata": {
+					Type:        framework.TypeMap,
+					Description: "Arbitrary key=value metadata to associate with the token",
+				},
+				"no_parent": {
+					Type:        framework.TypeBool,
+					Description: "Create the token with no parent",
+				},
+				"policies": {
+					Type:        framework.TypeStringSlice,
+					Description: "List of policies for the token",
+				},
+				"format": {
+					Type:        framework.TypeString,
+					Query:       true,
+					Description: "Return json formatted output",
+				},
+			},
 
 			Callbacks: map[logical.Operation]framework.OperationFunc{
 				logical.UpdateOperation: ts.handleCreate,


### PR DESCRIPTION
This PR fixes a bug where a user would receive a warning that the endpoint ignored unrecognized parameters, when those parameters are in fact recognized and expected when calling `vault token create` in the CLI or the equivalent API call:

```
❯ ./vault token create -explicit-max-ttl="10m" -policy="default"
WARNING! The following warnings were returned from Vault:

  * TTL of "768h" exceeded the effective max_ttl of "10m"; TTL value is capped
  accordingly

  * Endpoint ignored these unrecognized parameters: [display_name entity_alias
  explicit_max_ttl num_uses period policies renewable ttl type]
```