### PR TITLE
plugin sdk: check for tlsprovider for versions that require it

### DIFF
--- a/sdk/plugin/serve.go
+++ b/sdk/plugin/serve.go
@@ -45,14 +45,16 @@ func Serve(opts *ServeOpts) error {
 		// and version 4.
 		3: {
 			"backend": &GRPCBackendPlugin{
-				Factory: opts.BackendFactoryFunc,
-				Logger:  logger,
+				Factory:        opts.BackendFactoryFunc,
+				Logger:         logger,
+				TLSProviderSet: opts.TLSProviderFunc != nil,
 			},
 		},
 		4: {
 			"backend": &GRPCBackendPlugin{
-				Factory: opts.BackendFactoryFunc,
-				Logger:  logger,
+				Factory:        opts.BackendFactoryFunc,
+				Logger:         logger,
+				TLSProviderSet: opts.TLSProviderFunc != nil,
 			},
 		},
 		5: {
@@ -108,14 +110,16 @@ func ServeMultiplex(opts *ServeOpts) error {
 		// and version 4.
 		3: {
 			"backend": &GRPCBackendPlugin{
-				Factory: opts.BackendFactoryFunc,
-				Logger:  logger,
+				Factory:        opts.BackendFactoryFunc,
+				Logger:         logger,
+				TLSProviderSet: opts.TLSProviderFunc != nil,
 			},
 		},
 		4: {
 			"backend": &GRPCBackendPlugin{
-				Factory: opts.BackendFactoryFunc,
-				Logger:  logger,
+				Factory:        opts.BackendFactoryFunc,
+				Logger:         logger,
+				TLSProviderSet: opts.TLSProviderFunc != nil,
 			},
 		},
 		5: {


### PR DESCRIPTION
Ensure that plugins set a TLSProvider when vault does not support AutoMTLS for that plugin version. This is so that we can fail fast and give a better UX. Otherwise the vault client will hang and timeout.

This should be backported n-2.