### PR TITLE
Fix comment of default value of tidy interval

### DIFF
--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -1,6 +1,10 @@
 package pki
 
-import "github.com/hashicorp/vault/sdk/framework"
+import (
+	"time"
+
+	"github.com/hashicorp/vault/sdk/framework"
+)
 
 const (
 	issuerRefParam = "issuer_ref"
@@ -449,7 +453,7 @@ and OCSP responses.`,
 beyond certificate expiration before it is removed
 from the backend storage and/or revocation list.
 Defaults to 72 hours.`,
-		Default: 259200, // 72h, but TypeDurationSecond currently requires defaults to be int
+		Default: int(defaultTidyConfig.SafetyBuffer / time.Second), // TypeDurationSecond currently requires defaults to be int
 	}
 
 	return fields

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -31,7 +31,7 @@ var defaultTidyConfig = tidyConfig{
 	CertStore:    false,
 	RevokedCerts: false,
 	IssuerAssocs: false,
-	SafetyBuffer: 259200 * time.Second,
+	SafetyBuffer: 72 * time.Hour,
 }
 
 func pathTidy(b *backend) *framework.Path {
@@ -74,7 +74,7 @@ func pathConfigAutoTidy(b *backend) *framework.Path {
 			"interval_duration": {
 				Type:        framework.TypeDurationSecond,
 				Description: `Interval at which to run an auto-tidy operation. This is the time between tidy invocations (after one finishes to the start of the next). Running a manual tidy will reset this duration.`,
-				Default:     43200, // 32h, but TypeDurationSecond currently requires the default to be an int.
+				Default:     int(defaultTidyConfig.Interval / time.Second), // TypeDurationSecond currently requires the default to be an int.
 			},
 		}),
 		Operations: map[logical.Operation]framework.OperationHandler{


### PR DESCRIPTION
We switch these fields to use the explicit default value (computing the
time in seconds appropriately).

As reported by @beornf, thanks!

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`