### PR TITLE
Updating the release slack channel

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -3,7 +3,7 @@ schema = "1"
 project "vault" {
   team = "vault"
   slack {
-    notification_channel = "CRF6FFKEW" // #vault-releases
+    notification_channel = "C03RXFX5M4L" // #vault-releases
   }
   github {
     organization = "hashicorp"

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -3,7 +3,7 @@ schema = "1"
 project "vault" {
   team = "vault"
   slack {
-    notification_channel = "C03RXFX5M4L" // #vault-releases
+    notification_channel = "C03RXFX5M4L" // #feed-vault-releases
   }
   github {
     organization = "hashicorp"


### PR DESCRIPTION
We've discussed moving the CRT notifications to a different slack channel so we can still have release-related discussions in the releases channel. I'd like to get an approval ask an ack from @ldilalla-HC @anwittin @calvn please, as this will change where we need to look to approve jobs.

@samsalisbury / @alvin-huang - I think this is the only place I need to change?