### PR TITLE
Fix AKID/SKID equality checks according to RFC 5280

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2669,10 +2669,10 @@ func TestBackend_SignSelfIssued(t *testing.T) {
 	if !reflect.DeepEqual(newCert.Issuer, signingBundle.Certificate.Subject) {
 		t.Fatalf("expected matching issuer/CA subject\n\nIssuer:\n%#v\nSubject:\n%#v\n", newCert.Issuer, signingBundle.Certificate.Subject)
 	}
-	if bytes.Equal(newCert.AuthorityKeyId, newCert.SubjectKeyId) {
+	if certutil.AreKeyIdentifiersEqual(newCert.AuthorityKeyId, newCert.SubjectKeyId) {
 		t.Fatal("expected different authority/subject")
 	}
-	if !bytes.Equal(newCert.AuthorityKeyId, signingBundle.Certificate.SubjectKeyId) {
+	if !certutil.AreKeyIdentifiersEqual(newCert.AuthorityKeyId, signingBundle.Certificate.SubjectKeyId) {
 		t.Fatal("expected authority on new cert to be same as signing subject")
 	}
 	if newCert.Subject.CommonName != "foo.bar.com" {

--- a/changelog/16952.txt
+++ b/changelog/16952.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Fix verification failure with RFC-correct AKID encodings on imported intermediates (e.g., from Microsoft ADCA).
+```


### PR DESCRIPTION
Notably, AKID/SKID are encoded differently according to RFC 5280. While Go doesn't parse the inner `SEQUENCE` of the AKID, and many implementations place the encoded SKID in the AKID field (eliding the `SEQUENCE` and instead keeping it as an `OCTET STRING`), Microsoft ADCA appears to have chosen to correctly encode the AKID.

This means that any intermediate issued from an ADCA (and then imported into Vault) _may_ have the incorrect AKID/SKID comparison, causing us to bail out on calls to `Verify(...)`. I've gone ahead and applied the same logic consistently to the other places AKID/SKID are compared, including the signature check in the case of AKID/SKID missing.