### PR TITLE
Load SSCT Generation Counter Upon DR Promotion [OSS]

### DIFF
--- a/changelog/16956.txt
+++ b/changelog/16956.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-core: Load SSCT Token Generation counter from storage when upgrading a DR to a primary
+core: Prevent 2 or more DR failovers from invalidating SSCT tokens generated on the previous primaries.
 ```

--- a/changelog/16956.txt
+++ b/changelog/16956.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-core: Prevent 2 or more DR failovers from invalidating SSCT tokens generated on the previous primaries.
+core: Prevent two or more DR failovers from invalidating SSCT tokens generated on the previous primaries.
 ```

--- a/changelog/16956.txt
+++ b/changelog/16956.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Load SSCT Token Generation counter from storage when upgrading a DR to a primary
+```

--- a/vault/token_store_util_common.go
+++ b/vault/token_store_util_common.go
@@ -38,6 +38,9 @@ func (ts *TokenStore) loadSSCTokensGenerationCounter(ctx context.Context) error 
 }
 
 func (ts *TokenStore) UpdateSSCTokensGenerationCounter(ctx context.Context) error {
+	if err := ts.loadSSCTokensGenerationCounter(ctx); err != nil {
+		return err
+	}
 	ts.sscTokensGenerationCounter.Counter += 1
 	if ts.sscTokensGenerationCounter.Counter <= 0 {
 		// Don't store the 0 value


### PR DESCRIPTION
This PR is a port of https://github.com/hashicorp/vault-enterprise/pull/3170/files.

Description (from ent PR): 
This PR fixes the regression with SSCT. 

The issue is that the SSCT Generation counter was not being loaded from storage, so when it was written to storage during DR promotion it would always be 1. The fix is to load the value from storage during DR promotion. DRs never use the generation counter, but on DR clusters the value in memory will always be 1 less than the value in storage. However, the moment the DR gets updated to a primary, the value from storage will be incremented and written back.

Will open the OSS port after this PR is approved, with a changelog in OSS.

The PR will need to be backported to 1.10.