### PR TITLE
Add ability to cancel PKI tidy operations, pause between tidying certs

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -226,12 +226,12 @@ type (
 )
 
 const (
-	tidyStatusInactive tidyStatusState = iota
-	tidyStatusStarted
-	tidyStatusFinished
-	tidyStatusError
-	tidyStatusCancelling
-	tidyStatusCancelled
+	tidyStatusInactive   tidyStatusState = iota
+	tidyStatusStarted                    = iota
+	tidyStatusFinished                   = iota
+	tidyStatusError                      = iota
+	tidyStatusCancelling                 = iota
+	tidyStatusCancelled                  = iota
 )
 
 type tidyStatus struct {
@@ -240,6 +240,7 @@ type tidyStatus struct {
 	tidyCertStore     bool
 	tidyRevokedCerts  bool
 	tidyRevokedAssocs bool
+	pauseDuration     string
 
 	// Status
 	state                   tidyStatusState

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -3877,6 +3877,7 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 			"tidy_cert_store":                       true,
 			"tidy_revoked_certs":                    true,
 			"tidy_revoked_cert_issuer_associations": false,
+			"pause_duration":                        "0s",
 			"state":                                 "Finished",
 			"error":                                 nil,
 			"time_started":                          nil,

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -463,5 +463,17 @@ Defaults to 72 hours.`,
 		Default: int(defaultTidyConfig.SafetyBuffer / time.Second), // TypeDurationSecond currently requires defaults to be int
 	}
 
+	fields["pause_duration"] = &framework.FieldSchema{
+		Type: framework.TypeString,
+		Description: `The amount of time to wait between processing
+certificates. This allows operators to change the execution profile
+of tidy to take consume less resources by slowing down how long it
+takes to run. Note that the entire list of certificates will be
+stored in memory during the entire tidy operation, but resources to
+read/process/update existing entries will be spread out over a
+greater period of time. By default this is zero seconds.`,
+		Default: "0s",
+	}
+
 	return fields
 }

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -696,6 +696,16 @@ The result includes the following fields:
 * 'missing_issuer_cert_count': The number of revoked certificates which were missing a valid issuer reference
 `
 
-const pathConfigAutoTidySyn = ``
+const pathConfigAutoTidySyn = `
+Modifies the current configuration for automatic tidy execution.
+`
 
-const pathConfigAutoTidyDesc = ``
+const pathConfigAutoTidyDesc = `
+This endpoint accepts parameters to a tidy operation (see /tidy) that
+will be used for automatic tidy execution. This takes two extra parameters,
+enabled (to enable or disable auto-tidy) and interval_duration (which
+controls the frequency of auto-tidy execution).
+
+Once enabled, a tidy operation will be kicked off automatically, as if it
+were executed with the posted configuration.
+`

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -324,7 +324,9 @@ func (b *backend) doTidyRevocationStore(ctx context.Context, req *logical.Reques
 
 		// Check for pause duration to reduce resource consumption.
 		if config.PauseDuration > (0 * time.Second) {
+			b.revokeStorageLock.Unlock()
 			time.Sleep(config.PauseDuration)
+			b.revokeStorageLock.Lock()
 		}
 
 		revokedEntry, err := req.Storage.Get(ctx, "revoked/"+serial)

--- a/changelog/16958.txt
+++ b/changelog/16958.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Add ability to cancel tidy operations, control tidy resource usage.
+```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -70,6 +70,7 @@ update your API calls accordingly.
   - [Tidy](#tidy)
   - [Configure Automatic Tidy](#configure-automatic-tidy)
   - [Tidy Status](#tidy-status)
+  - [Cancel Tidy](#cancel-tidy)
 - [Cluster Scalability](#cluster-scalability)
 - [Managed Key](#managed-keys) (Enterprise Only)
 - [Vault CLI with DER/PEM responses](#vault-cli-with-der-pem-responses)
@@ -3197,6 +3198,18 @@ expiration time.
   the time must be after the expiration time of the certificate (according to
   the local clock) plus the duration of `safety_buffer`. Defaults to `72h`.
 
+- `pause_duration` `(string: "0s")` - Specifies the duration to pause
+  between tidying individual certificates. This releases the revocation
+  lock and allows other operations to continue while tidy is running.
+  This allows an operator to control tidy's resource utilization within
+  a timespan: the LIST operation will remain in memory, but the space
+  between reading, parsing, and updates on-disk cert entries will be
+  increased, decreasing resource utilization.
+
+~> Note: Using too long of a `pause_duration` can result in tidy operations
+   not concluding during this lifetime! Using too short of a pause duration
+   (but non-zero) can lead to lock contention. Use [tidy's cancellation](#cancel-tidy)
+   to stop a running operation after the sleep period is over.
 
 #### Sample Payload
 
@@ -3320,6 +3333,46 @@ $ curl \
     "revoked_cert_deleted_count": 0,
     "cert_store_deleted_count": 2,
     "state": "Running",
+    "time_started": "2021-10-20T14:52:13.510161-04:00",
+    "time_finished": null
+  },
+```
+
+### Cancel Tidy
+
+This endpoint allows cancelling a running tidy operation. It takes no
+parameter and cancels the tidy at the next available checkpoint, which
+may process additional certificates between when the operation was
+marked as cancelled and when the operation stopped.
+
+The response to this endpoint is the same as the [status](#tidy-status).
+
+| Method | Path               |
+| :----- | :----------------- |
+| `POST` | `/pki/tidy-cancel` |
+
+#### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    http://127.0.0.1:8200/v1/pki/tidy-cancel
+
+```
+
+#### Sample Response
+
+```json
+  "data": {
+    "safety_buffer": 60,
+    "tidy_cert_store": true,
+    "tidy_revoked_certs": true,
+    "error": null,
+    "message": "Tidying certificate store: checking entry 234 of 488",
+    "revoked_cert_deleted_count": 0,
+    "cert_store_deleted_count": 2,
+    "state": "Cancelling",
     "time_started": "2021-10-20T14:52:13.510161-04:00",
     "time_finished": null
   },


### PR DESCRIPTION
This adds two features to the PKI tidy operation that become useful with auto-tidy:

 1. The ability to cancel running tidy operations, freeing up resources on the cluster.
 2. The ability to pause between processing individual certificates. When handling the revoked certificates, this allows the operation to release the revoked-store lock, allowing new revocations to continue. This can reduce the resource utilization on a cluster during a tidy operation, but needs to be tuned carefully so not to have too much lock contention but also not cause the tidy to take too long.
