### PR TITLE
HCP Link Status

### DIFF
--- a/changelog/16959.txt
+++ b/changelog/16959.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ui: adds HCP link status banner
+```

--- a/ui/app/components/link-status.js
+++ b/ui/app/components/link-status.js
@@ -1,0 +1,44 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+/**
+ * @module LinkStatus
+ * LinkStatus components are used to indicate link status to the hashicorp cloud platform
+ *
+ * @example
+ * ```js
+ * <LinkStatus />
+ * ```
+ */
+
+export default class LinkStatus extends Component {
+  @service store;
+  @service version;
+
+  @tracked status;
+
+  constructor() {
+    super(...arguments);
+    // enterprise only feature at this time but will expand to OSS in future release
+    if (this.version.isEnterprise) {
+      this.fetchStatus();
+    }
+  }
+
+  async fetchStatus() {
+    try {
+      const { hcp_link_status } = await this.store.adapterFor('cluster').sealStatus();
+      // there are plans to handle connection failure states -- only alert if connected until further states are returned
+      if (hcp_link_status === 'connected') {
+        this.status = hcp_link_status;
+      }
+    } catch (error) {
+      this.status = null;
+    }
+  }
+
+  get bannerClass() {
+    return this.status === 'connected' ? 'connected' : 'warning';
+  }
+}

--- a/ui/app/components/link-status.js
+++ b/ui/app/components/link-status.js
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 
 /**
  * @module LinkStatus
@@ -8,37 +7,23 @@ import { tracked } from '@glimmer/tracking';
  *
  * @example
  * ```js
- * <LinkStatus />
+ * <LinkStatus @status={{this.currentCluser.cluster.hcpLinkStatus}} />
  * ```
+ *
+ * @param {string} status - cluster.hcpLinkStatus value from currentCluster service
  */
 
 export default class LinkStatus extends Component {
   @service store;
   @service version;
 
-  @tracked status;
-
-  constructor() {
-    super(...arguments);
+  get showBanner() {
     // enterprise only feature at this time but will expand to OSS in future release
-    if (this.version.isEnterprise) {
-      this.fetchStatus();
-    }
-  }
-
-  async fetchStatus() {
-    try {
-      const { hcp_link_status } = await this.store.adapterFor('cluster').sealStatus();
-      // there are plans to handle connection failure states -- only alert if connected until further states are returned
-      if (hcp_link_status === 'connected') {
-        this.status = hcp_link_status;
-      }
-    } catch (error) {
-      this.status = null;
-    }
+    // there are plans to handle connection failure states -- only alert if connected until further states are returned
+    return this.version.isEnterprise && this.args.status === 'connected';
   }
 
   get bannerClass() {
-    return this.status === 'connected' ? 'connected' : 'warning';
+    return this.args.status === 'connected' ? 'connected' : 'warning';
   }
 }

--- a/ui/app/components/nav-header.js
+++ b/ui/app/components/nav-header.js
@@ -4,6 +4,7 @@ import { computed } from '@ember/object';
 
 export default Component.extend({
   router: service(),
+  currentCluster: service(),
   'data-test-navheader': true,
   attributeBindings: ['data-test-navheader'],
   classNameBindings: 'consoleFullscreen:panel-fullscreen',

--- a/ui/app/models/cluster.js
+++ b/ui/app/models/cluster.js
@@ -43,6 +43,7 @@ export default Model.extend({
   sealProgress: alias('leaderNode.progress'),
   sealType: alias('leaderNode.type'),
   storageType: alias('leaderNode.storageType'),
+  hcpLinkStatus: alias('leaderNode.hcpLinkStatus'),
   hasProgress: gte('sealProgress', 1),
   usingRaft: equal('storageType', 'raft'),
 

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -24,6 +24,7 @@ export default Model.extend({
   version: attr('string'),
   type: attr('string'),
   storageType: attr('string'),
+  hcpLinkStatus: attr('string'),
 
   //https://www.vaultproject.io/docs/http/sys-leader.html
   haEnabled: attr('boolean'),

--- a/ui/app/styles/core/navbar.scss
+++ b/ui/app/styles/core/navbar.scss
@@ -1,13 +1,45 @@
 .navbar {
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  @include from($mobile) {
+    display: block;
+  }
+}
+
+.navbar-status {
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: $size-7;
+  font-weight: $font-weight-semibold;
+
+  &.connected {
+    background-color: $ui-gray-800;
+    color: #c2c5cb;
+
+    a {
+      color: #c2c5cb;
+    }
+  }
+  &.warning {
+    background-color: #fcf6ea;
+    color: #975b06;
+
+    a {
+      color: #975b06;
+    }
+  }
+}
+
+.navbar-actions {
   background-color: $black;
   display: flex;
   height: $header-height;
   justify-content: flex-start;
-  left: 0;
   padding: $spacing-xs $spacing-s $spacing-xs 0;
-  position: fixed;
-  right: 0;
-  top: 0;
 }
 
 .navbar-brand {

--- a/ui/app/templates/components/link-status.hbs
+++ b/ui/app/templates/components/link-status.hbs
@@ -1,16 +1,16 @@
-{{#if this.status}}
+{{#if this.showBanner}}
   <div class="navbar-status {{this.bannerClass}}">
     <Icon @name="info" />
     <p data-test-link-status>
-      {{#if (eq this.status "connected")}}
+      {{#if (eq @status "connected")}}
         This self-managed Vault is linked to the
         <a href="https://portal.cloud.hashicorp.com/sign-in" target="_blank" rel="noopener noreferrer">
           HashiCorp Cloud Platform.
         </a>
-      {{else if (eq this.status "401")}}
+      {{else if (eq @status "401")}}
         {{! roughing in 401 and 500 connection statuses -- update strings once they are exposed by the API }}
         Vault can’t connect to HashiCorp Cloud Portal. Check your config file to ensure that credentials are correct.
-      {{else if (eq this.status "500")}}
+      {{else if (eq @status "500")}}
         Vault’s connection to HashiCorp Cloud Portal is down. Check
         <a href="https://status.hashicorp.com" target="_blank" rel="noopener noreferrer">
           the status page

--- a/ui/app/templates/components/link-status.hbs
+++ b/ui/app/templates/components/link-status.hbs
@@ -5,7 +5,7 @@
       {{#if (eq this.status "connected")}}
         This self-managed Vault is linked to the
         <a href="https://portal.cloud.hashicorp.com/sign-in" target="_blank" rel="noopener noreferrer">
-          HashiCorp Cloud Platform
+          HashiCorp Cloud Platform.
         </a>
       {{else if (eq this.status "401")}}
         {{! roughing in 401 and 500 connection statuses -- update strings once they are exposed by the API }}

--- a/ui/app/templates/components/link-status.hbs
+++ b/ui/app/templates/components/link-status.hbs
@@ -1,0 +1,22 @@
+{{#if this.status}}
+  <div class="navbar-status {{this.bannerClass}}">
+    <Icon @name="info" />
+    <p data-test-link-status>
+      {{#if (eq this.status "connected")}}
+        This self-managed Vault is linked to the
+        <a href="https://portal.cloud.hashicorp.com/sign-in" target="_blank" rel="noopener noreferrer">
+          HashiCorp Cloud Platform
+        </a>
+      {{else if (eq this.status "401")}}
+        {{! roughing in 401 and 500 connection statuses -- update strings once they are exposed by the API }}
+        Vault can’t connect to HashiCorp Cloud Portal. Check your config file to ensure that credentials are correct.
+      {{else if (eq this.status "500")}}
+        Vault’s connection to HashiCorp Cloud Portal is down. Check
+        <a href="https://status.hashicorp.com" target="_blank" rel="noopener noreferrer">
+          the status page
+        </a>
+        for details.
+      {{/if}}
+    </p>
+  </div>
+{{/if}}

--- a/ui/app/templates/components/nav-header.hbs
+++ b/ui/app/templates/components/nav-header.hbs
@@ -1,38 +1,42 @@
 <nav class="navbar">
-  <div class="navbar-brand" data-test-navheader-home>
-    {{yield (hash home=(component "nav-header/home"))}}
-  </div>
+  <LinkStatus />
 
-  {{#unless this.navDrawerOpen}}
-    <button type="button" class="navbar-drawer-toggle is-hidden-tablet" {{action "toggleNavDrawer"}}>
-      <Icon @name="more-vertical" />
-      Menu
-    </button>
-  {{/unless}}
-
-  {{#unless this.hideLinks}}
-    <div class="navbar-drawer{{if this.navDrawerOpen ' is-active'}}">
-      <div class="navbar-drawer-scroll">
-        <div data-test-navheader-main>
-          {{yield (hash main=(component "nav-header/main") closeDrawer=(action "toggleNavDrawer" false))}}
-        </div>
-        <div class="navbar-end" data-test-navheader-items>
-          {{yield (hash items=(component "nav-header/items") closeDrawer=(action "toggleNavDrawer" false))}}
-        </div>
-      </div>
-
-      {{#if this.navDrawerOpen}}
-        <button class="navbar-drawer-toggle is-hidden-tablet" type="button" {{action "toggleNavDrawer" false}}>
-          <Icon @name="x" />
-        </button>
-      {{/if}}
+  <div class="navbar-actions">
+    <div class="navbar-brand" data-test-navheader-home>
+      {{yield (hash home=(component "nav-header/home"))}}
     </div>
-  {{/unless}}
 
-  <div
-    class="navbar-drawer-overlay{{if this.navDrawerOpen ' is-active'}}"
-    role="button"
-    onclick={{action "toggleNavDrawer" (not this.navDrawerOpen)}}
-  ></div>
+    {{#unless this.navDrawerOpen}}
+      <button type="button" class="navbar-drawer-toggle is-hidden-tablet" {{action "toggleNavDrawer"}}>
+        <Icon @name="more-vertical" />
+        Menu
+      </button>
+    {{/unless}}
+
+    {{#unless this.hideLinks}}
+      <div class="navbar-drawer{{if this.navDrawerOpen ' is-active'}}">
+        <div class="navbar-drawer-scroll">
+          <div data-test-navheader-main>
+            {{yield (hash main=(component "nav-header/main") closeDrawer=(action "toggleNavDrawer" false))}}
+          </div>
+          <div class="navbar-end" data-test-navheader-items>
+            {{yield (hash items=(component "nav-header/items") closeDrawer=(action "toggleNavDrawer" false))}}
+          </div>
+        </div>
+
+        {{#if this.navDrawerOpen}}
+          <button class="navbar-drawer-toggle is-hidden-tablet" type="button" {{action "toggleNavDrawer" false}}>
+            <Icon @name="x" />
+          </button>
+        {{/if}}
+      </div>
+    {{/unless}}
+
+    <div
+      class="navbar-drawer-overlay{{if this.navDrawerOpen ' is-active'}}"
+      role="button"
+      onclick={{action "toggleNavDrawer" (not this.navDrawerOpen)}}
+    ></div>
+  </div>
 </nav>
 <Console::UiPanel @isFullscreen={{this.consoleFullscreen}} />

--- a/ui/app/templates/components/nav-header.hbs
+++ b/ui/app/templates/components/nav-header.hbs
@@ -1,5 +1,5 @@
 <nav class="navbar">
-  <LinkStatus />
+  <LinkStatus @status={{this.currentCluster.cluster.hcpLinkStatus}} />
 
   <div class="navbar-actions">
     <div class="navbar-brand" data-test-navheader-home>

--- a/ui/mirage/handlers/hcp-link.js
+++ b/ui/mirage/handlers/hcp-link.js
@@ -1,0 +1,21 @@
+export default function (server) {
+  const handleResponse = (req, props) => {
+    const xhr = req.passthrough();
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState === 4 && xhr.status < 300) {
+        // XMLHttpRequest response prop only has a getter -- redefine as writable and set value
+        Object.defineProperty(xhr, 'response', {
+          writable: true,
+          value: JSON.stringify({
+            ...JSON.parse(xhr.responseText),
+            ...props,
+          }),
+        });
+      }
+    };
+  };
+
+  server.get('sys/seal-status', (schema, req) => handleResponse(req, { hcp_link_status: 'connected' }));
+  // enterprise only feature initially
+  server.get('sys/health', (schema, req) => handleResponse(req, { version: '1.12.0-dev1+ent' }));
+}

--- a/ui/mirage/handlers/hcp-link.js
+++ b/ui/mirage/handlers/hcp-link.js
@@ -15,7 +15,12 @@ export default function (server) {
     };
   };
 
-  server.get('sys/seal-status', (schema, req) => handleResponse(req, { hcp_link_status: 'connected' }));
+  server.get('sys/seal-status', (schema, req) => {
+    // randomly return one of the various states to test polling
+    // 401 and 500 are stubs -- update with actual API values once determined
+    const hcp_link_status = ['connected', 'disconnected', '401', '500'][Math.floor(Math.random() * 2)];
+    return handleResponse(req, { hcp_link_status });
+  });
   // enterprise only feature initially
   server.get('sys/health', (schema, req) => handleResponse(req, { version: '1.12.0-dev1+ent' }));
 }

--- a/ui/mirage/handlers/index.js
+++ b/ui/mirage/handlers/index.js
@@ -7,5 +7,6 @@ import clients from './clients';
 import db from './db';
 import kms from './kms';
 import mfaConfig from './mfa-config';
+import hcpLink from './hcp-link';
 
-export { base, activity, mfaLogin, mfaConfig, clients, db, kms };
+export { base, activity, mfaLogin, mfaConfig, clients, db, kms, hcpLink };

--- a/ui/tests/integration/components/link-status-test.js
+++ b/ui/tests/integration/components/link-status-test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Integration | Component | link-status', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  // this can be removed once feature is released for OSS
+  hooks.beforeEach(function () {
+    this.owner.lookup('service:version').set('isEnterprise', true);
+  });
+
+  test('it does not render disconnected status', async function (assert) {
+    this.server.get('sys/seal-status', () => ({ hcp_link_status: 'disconnected' }));
+
+    await render(hbs`<LinkStatus />`);
+
+    assert.dom('.navbar-status').doesNotExist('Banner is hidden for disconnected state');
+  });
+
+  test('it renders connected status', async function (assert) {
+    this.server.get('sys/seal-status', () => ({ hcp_link_status: 'connected' }));
+
+    await render(hbs`<LinkStatus />`);
+
+    assert.dom('.navbar-status').hasClass('connected', 'Correct class renders for connected state');
+    assert
+      .dom('[data-test-link-status]')
+      .hasText(
+        'This self-managed Vault is linked to the HashiCorp Cloud Platform',
+        'Copy renders for connected state'
+      );
+    assert
+      .dom('[data-test-link-status] a')
+      .hasAttribute('href', 'https://portal.cloud.hashicorp.com/sign-in', 'HCP sign in link renders');
+  });
+});

--- a/ui/tests/integration/components/link-status-test.js
+++ b/ui/tests/integration/components/link-status-test.js
@@ -14,23 +14,19 @@ module('Integration | Component | link-status', function (hooks) {
   });
 
   test('it does not render disconnected status', async function (assert) {
-    this.server.get('sys/seal-status', () => ({ hcp_link_status: 'disconnected' }));
-
-    await render(hbs`<LinkStatus />`);
+    await render(hbs`<LinkStatus @status="disconnected" />`);
 
     assert.dom('.navbar-status').doesNotExist('Banner is hidden for disconnected state');
   });
 
   test('it renders connected status', async function (assert) {
-    this.server.get('sys/seal-status', () => ({ hcp_link_status: 'connected' }));
-
-    await render(hbs`<LinkStatus />`);
+    await render(hbs`<LinkStatus @status="connected" />`);
 
     assert.dom('.navbar-status').hasClass('connected', 'Correct class renders for connected state');
     assert
       .dom('[data-test-link-status]')
       .hasText(
-        'This self-managed Vault is linked to the HashiCorp Cloud Platform',
+        'This self-managed Vault is linked to the HashiCorp Cloud Platform.',
         'Copy renders for connected state'
       );
     assert


### PR DESCRIPTION
This PR adds a new component to the nav bar to display the HCP link status. At this time, given the data returned from the API, only the connected state will trigger the banner to display (enterprise only). The warning states have been roughed in and a subsequent PR will be opened once the API is updated.

![image](https://user-images.githubusercontent.com/24611656/187741205-f98523ab-47ac-4671-8849-6939334c47c2.png)
