### PR TITLE
enos: don't fail fast in enos integration matrix

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -17,6 +17,7 @@ jobs:
   enos:
     name: Integration
     strategy:
+      fail-fast: false # don't fail as that can skip required cleanup steps for jobs
       matrix:
         # Run four scenarios to get a maximal distribution of variants in as
         # few jobs as possible.


### PR DESCRIPTION
Disable the fail-fast feature for the matrix strategy. This prevents a
single failure to cascade to all jobs in the matrix. This prevents cases
where other jobs fail before they're able to clean up resources.

Signed-off-by: Ryan Cragun <me@ryan.ec>