### PR TITLE
Add ability to request manual rebuild of Delta CRLs

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -128,6 +128,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathSign(&b),
 			pathIssue(&b),
 			pathRotateCRL(&b),
+			pathRotateDeltaCRL(&b),
 			pathRevoke(&b),
 			pathRevokeWithKey(&b),
 			pathTidy(&b),
@@ -438,7 +439,7 @@ func (b *backend) periodicFunc(ctx context.Context, request *logical.Request) er
 		// If a delta CRL was rebuilt above as part of the complete CRL rebuild,
 		// this will be a no-op. However, if we do need to rebuild delta CRLs,
 		// this would cause us to do so.
-		if err := b.crlBuilder.rebuildDeltaCRLsIfForced(sc); err != nil {
+		if err := b.crlBuilder.rebuildDeltaCRLsIfForced(sc, false); err != nil {
 			return err
 		}
 

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -5128,6 +5128,7 @@ func TestBackend_IfModifiedSinceHeaders(t *testing.T) {
 			MaxLeaseTTL:     "60h",
 			// Required to allow the header to be passed through.
 			PassthroughRequestHeaders: []string{"if-modified-since"},
+			AllowedResponseHeaders:    []string{"Last-Modified"},
 		},
 	})
 	require.NoError(t, err)
@@ -5383,7 +5384,7 @@ func TestBackend_IfModifiedSinceHeaders(t *testing.T) {
 			field = "crl"
 		}
 
-		// Ensure that the CA is elided if we give it the pre-update time.
+		// Ensure that the CA is returned if we give it the pre-update time.
 		client.AddHeader("If-Modified-Since", beforeThreeWaySwap.Format(time.RFC1123))
 		resp, err = client.Logical().Read(path)
 		require.NoError(t, err)
@@ -5393,8 +5394,65 @@ func TestBackend_IfModifiedSinceHeaders(t *testing.T) {
 		client.SetHeaders(lastHeaders)
 		lastHeaders = client.Headers()
 
-		// Ensure that the CA is returned correctly if we give it the after time.
+		// Ensure that the CA is elided correctly if we give it the after time.
 		client.AddHeader("If-Modified-Since", afterThreeWaySwap.Format(time.RFC1123))
+		resp, err = client.Logical().Read(path)
+		require.NoError(t, err)
+		require.Nil(t, resp)
+		client.SetHeaders(lastHeaders)
+		lastHeaders = client.Headers()
+	}
+
+	time.Sleep(4 * time.Second)
+
+	beforeDeltaRotation := time.Now().Add(-2 * time.Second)
+
+	// Finally, rebuild the delta CRL and ensure that only that is
+	// invalidated. We first need to enable it though.
+	_, err = client.Logical().Write("pki/config/crl", map[string]interface{}{
+		"auto_rebuild": true,
+		"enable_delta": true,
+	})
+	require.NoError(t, err)
+	resp, err = client.Logical().Read("pki/crl/rotate-delta")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+	require.Equal(t, resp.Data["success"], true)
+
+	afterDeltaRotation := time.Now().Add(2 * time.Second)
+
+	for _, path := range []string{"pki/cert/ca", "pki/cert/crl", "pki/issuer/default/json", "pki/issuer/old-root/json", "pki/issuer/new-root/json", "pki/issuer/old-root/crl", "pki/issuer/new-root/crl"} {
+		t.Logf("path: %v", path)
+
+		for _, when := range []time.Time{beforeDeltaRotation, afterDeltaRotation} {
+			client.AddHeader("If-Modified-Since", when.Format(time.RFC1123))
+			resp, err = client.Logical().Read(path)
+			require.NoError(t, err)
+			require.Nil(t, resp)
+			client.SetHeaders(lastHeaders)
+			lastHeaders = client.Headers()
+		}
+	}
+
+	for _, path := range []string{"pki/cert/delta-crl", "pki/issuer/old-root/crl/delta", "pki/issuer/new-root/crl/delta"} {
+		t.Logf("path: %v", path)
+		field := "certificate"
+		if strings.HasPrefix(path, "pki/issuer") && strings.Contains(path, "/crl") {
+			field = "crl"
+		}
+
+		// Ensure that the CRL is present if we give it the pre-update time.
+		client.AddHeader("If-Modified-Since", beforeDeltaRotation.Format(time.RFC1123))
+		resp, err = client.Logical().Read(path)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, resp.Data)
+		require.NotEmpty(t, resp.Data[field])
+		client.SetHeaders(lastHeaders)
+		lastHeaders = client.Headers()
+
+		client.AddHeader("If-Modified-Since", afterDeltaRotation.Format(time.RFC1123))
 		resp, err = client.Logical().Read(path)
 		require.NoError(t, err)
 		require.Nil(t, resp)

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -320,7 +320,7 @@ func (cb *crlBuilder) clearDeltaWAL(sc *storageContext, walSerials []string) err
 	return nil
 }
 
-func (cb *crlBuilder) rebuildDeltaCRLsIfForced(sc *storageContext) error {
+func (cb *crlBuilder) rebuildDeltaCRLsIfForced(sc *storageContext, override bool) error {
 	// Delta CRLs use the same expiry duration as the complete CRL. Because
 	// we always rebuild the complete CRL and then the delta CRL, we can
 	// be assured that the delta CRL always expires after a complete CRL,
@@ -355,7 +355,7 @@ func (cb *crlBuilder) rebuildDeltaCRLsIfForced(sc *storageContext) error {
 	now := time.Now()
 	last := cb.lastDeltaRebuildCheck
 	nextRebuildCheck := last.Add(deltaRebuildDuration)
-	if now.Before(nextRebuildCheck) {
+	if !override && now.Before(nextRebuildCheck) {
 		// If we're still before the time of our next rebuild check, we can
 		// safely return here even if we have certs. We'll wait for a bit,
 		// retrigger this check, and then do the rebuild.
@@ -371,7 +371,7 @@ func (cb *crlBuilder) rebuildDeltaCRLsIfForced(sc *storageContext) error {
 	// Fetch two storage entries to see if we actually need to do this
 	// rebuild, given we're within the window.
 	lastWALEntry, err := sc.Storage.Get(sc.Context, deltaWALLastRevokedSerial)
-	if err != nil || lastWALEntry == nil || lastWALEntry.Value == nil {
+	if err != nil || !override && (lastWALEntry == nil || lastWALEntry.Value == nil) {
 		// If this entry does not exist, we don't need to rebuild the
 		// delta WAL due to the expiration assumption above. There must
 		// not have been any new revocations. Since err should be nil
@@ -384,7 +384,7 @@ func (cb *crlBuilder) rebuildDeltaCRLsIfForced(sc *storageContext) error {
 		return err
 	}
 
-	if lastBuildEntry != nil && lastBuildEntry.Value != nil {
+	if !override && lastBuildEntry != nil && lastBuildEntry.Value != nil {
 		// If the last build entry doesn't exist, we still want to build a
 		// new delta WAL, since this could be our very first time doing so.
 		//

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -67,6 +67,7 @@ update your API calls accordingly.
   - [Read CRL Configuration](#read-crl-configuration)
   - [Set CRL Configuration](#set-crl-configuration)
   - [Rotate CRLs](#rotate-crls)
+  - [Rotate Delta CRLs](#rotate-delta-crls)
   - [Tidy](#tidy)
   - [Configure Automatic Tidy](#configure-automatic-tidy)
   - [Tidy Status](#tidy-status)
@@ -1030,7 +1031,9 @@ These are unauthenticated endpoints.
 ~> Note: this endpoint accepts the `If-Modified-Since` header, to respond with
    304 Not Modified when the requested resource has not changed. This header
    needs to be allowed on the PKI mount by tuning the `passthrough_request_headers`
-   option.
+   option. In order for clients to know the last modified time, the response
+   header `Last-Modified` needs to be added to the mount tunable
+   `allowed_response_headers`.
 
 | Method | Path                           | Issuer    | Format                                                                            |
 | :----- | :----------------------------- | :-------- |:----------------------------------------------------------------------------------|
@@ -1136,7 +1139,9 @@ These are unauthenticated endpoints.
 ~> Note: this endpoint accepts the `If-Modified-Since` header, to respond with
    304 Not Modified when the requested resource has not changed. This header
    needs to be allowed on the PKI mount by tuning the `passthrough_request_headers`
-   option.
+   option. In order for clients to know the last modified time, the response
+   header `Last-Modified` needs to be added to the mount tunable
+   `allowed_response_headers`.
 
 | Method | Path                                    | Issuer    | Format                                                                            | Type     |
 | :----- | :-------------------------------------- | :-------- | :-------------------------------------------------------------------------------- | :------- |
@@ -3160,6 +3165,39 @@ $ curl \
   }
 }
 ```
+
+### Rotate Delta CRLs
+
+This endpoint forces a rotation of all issuers' delta CRLs, when enabled.
+This can be used by administrators to force a rebuild of a delta CRL if
+high-profile revocations have occurred and there's a long high interval
+between delta rebuilds (`delta_rebuild_interval`).
+
+See notes about rotating regular CRLs above as they apply here as well.
+
+| Method | Path                    |
+| :----- | :---------------------- |
+| `GET`  | `/pki/crl/rotate-delta` |
+
+#### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/pki/crl/rotate
+```
+
+#### Sample Response
+
+```json
+{
+  "data": {
+    "success": true
+  }
+}
+```
+
+
 
 ### Tidy
 


### PR DESCRIPTION
Since Delta CRL functionality has its own changelog entry, I'm inclined not to bother with a changelog for this.

---

We add a new read endpoint, `crl/rotate-delta` to force a manual rebuild of the Delta CRLs on this local cluster. This mirrors the behavior of the existing `crl/rotate` endpoint, just for delta CRLs instead of full CRLs. We add a warning that this is a no-op when delta CRLs are not enabled.

This also adds a missing doc (as pointed out by @Gabrielopesantos in a ticket) about the response header. As far as I can tell, there's no real way to validate this header with `client.Logical()`; we'd probably have to resort to `client.RawRequest(...)` to validate it if we wanted to.