### PR TITLE
Update changelog for OCSP feature

### DIFF
--- a/changelog/16723.txt
+++ b/changelog/16723.txt
@@ -1,4 +1,4 @@
 ```release-note:feature
-secrets/pki: Add an OCSP responder that implements a subset of RFC6960, answering single serial number OCSP requests for
+**OCSP Responder**: PKI mounts now have an OCSP responder that implements a subset of RFC6960, answering single serial number OCSP requests for
 a specific cluster's revoked certificates in a mount.
 ```


### PR DESCRIPTION
Update the OCSP feature changelog entry to use the proper formatting as pointed out by @mladlow in https://github.com/hashicorp/vault/pull/16723#discussion_r959973127

One question is do I need to update the changelog.md file as part of this or will the existing reference be updated when this gets merged?