### PR TITLE
Remove Ecosystem as a code owner of Vault Agent

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,7 +22,6 @@
 /builtin/logical/postgresql/  @hashicorp/vault-ecosystem
 /builtin/logical/rabbitmq/    @hashicorp/vault-ecosystem
 
-/command/agent/               @hashicorp/vault-ecosystem
 /plugins/                     @hashicorp/vault-ecosystem
 /vault/plugin_catalog.go      @hashicorp/vault-ecosystem
 


### PR DESCRIPTION
Hi gang. With Core taking over Agent, it makes sense to me to remove ecosystem as the owner of Agent, so we don't spam you with pull requests :)