### PR TITLE
Add missing flag to wrapKey command in key wrapping guide

### DIFF
--- a/website/content/docs/secrets/transit/key-wrapping-guide.mdx
+++ b/website/content/docs/secrets/transit/key-wrapping-guide.mdx
@@ -145,13 +145,14 @@ The next step is wrapping the target key using the wrapping key. If the
 ID of the target key is `1` and the wrapping key is `2`, the command looks like this:
 
 ```shell-session
-$ wrapKey -k 1 -w 2 -t 3 -m 7 -out ciphertext.key
+$ wrapKey -noheader -k 1 -w 2 -t 3 -m 7 -out ciphertext.key
 ```
 
 The `-m 7` flag specifies the mechanism to use for the key wrapping. For AWS CloudHSM,
 7 corresponds to the PKCS11 mechanism `CKM_AES_RSA_KEY_WRAP` ([see the AWS documentation for details](https://docs.aws.amazon.com/cloudhsm/latest/userguide/key_mgmt_util-wrapKey.html)).
 The `-t 3` flag specifies `SHA256` as the hash function. The result is written to a
-file called `ciphertext.key`.
+file called `ciphertext.key`. The `noheader` flag ensures that the ciphertext does
+not include an AWS-specific header.
 
 The output from this is a binary file, which needs to be base64-encoded when it
 is provided to Vault.


### PR DESCRIPTION
This adds the `noheader` flag to the `wrapKey` command. This flag is required for the output to be decrypted successfully by Vault