### PR TITLE
Parse query parameters for GET request turned in logical.ListOperation

### DIFF
--- a/http/logical.go
+++ b/http/logical.go
@@ -71,6 +71,7 @@ func buildLogicalRequestNoAuth(perfStandby bool, w http.ResponseWriter, r *http.
 				return nil, nil, http.StatusBadRequest, nil
 			}
 			if list {
+				queryVals.Del("list")
 				op = logical.ListOperation
 				if !strings.HasSuffix(path, "/") {
 					path += "/"
@@ -78,9 +79,7 @@ func buildLogicalRequestNoAuth(perfStandby bool, w http.ResponseWriter, r *http.
 			}
 		}
 
-		if !list {
-			data = parseQuery(queryVals)
-		}
+		data = parseQuery(queryVals)
 
 		switch {
 		case strings.HasPrefix(path, "sys/pprof/"):


### PR DESCRIPTION
This PR allows query parameters to be parsed and provided to backends for GET requests that are turned into `logical.ListOperation`. We started doing this for LIST requests as of https://github.com/hashicorp/vault/pull/16181. This makes the behavior consistent for Vault API requests that end up becoming a `logical.ListOperation`.

Example requests that result in a `logical.ListOperation`:
```sh
# GET request method with list=true query parameter
$ curl -X GET http://127.0.0.1:8200/v1/identity/oidc/provider?list=true&allowed_client_id=abc123

# LIST request method
$ curl -X LIST http://127.0.0.1:8200/v1/identity/oidc/provider?allowed_client_id=abc123
```