### PR TITLE
CI: Delete duplicate vaulttest docker networks to improve reliability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ jobs:
                 $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
                 | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
                 | sed 1d \
-                | xargs -n 1 docker network remove
+                | xargs -r -n 1 docker network remove
             fi
 
 
@@ -509,7 +509,7 @@ jobs:
                 $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
                 | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
                 | sed 1d \
-                | xargs -n 1 docker network remove
+                | xargs -r -n 1 docker network remove
             fi
 
 
@@ -712,7 +712,7 @@ jobs:
                 $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
                 | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
                 | sed 1d \
-                | xargs -n 1 docker network remove
+                | xargs -r -n 1 docker network remove
             fi
 
 
@@ -1025,7 +1025,7 @@ jobs:
                 $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
                 | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
                 | sed 1d \
-                | xargs -n 1 docker network remove
+                | xargs -r -n 1 docker network remove
             fi
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ jobs:
           export VAULT_LICENSE_CI="$VAULT_LICENSE"
           VAULT_LICENSE=
 
-          # Create a docker network for our testcontainer
+          # Create a docker network for our test container
           if [ $USE_DOCKER == 1 ]; then
             # Despite the fact that we're using a circleci image (thus getting the
             # version they chose for the docker cli) and that we're specifying a
@@ -263,8 +263,8 @@ jobs:
 
 
 
-            # Start a docker testcontainer to run the tests in
-            docker run -d \
+            # Start a docker test container to run the tests in
+            CONTAINER_ID="$(docker run -d \
               -e TEST_DOCKER_NETWORK_ID \
               -e GOPRIVATE \
               -e DOCKER_CERT_PATH \
@@ -273,19 +273,21 @@ jobs:
               -e DOCKER_TLS_VERIFY \
               -e NO_PROXY \
               -e VAULT_TEST_LOG_DIR=/tmp/testlogs \
-              --network vaulttest --name \
-              testcontainer docker.mirror.hashicorp.services/cimg/go:1.18.5 \
-              tail -f /dev/null
+              --network vaulttest \
+              docker.mirror.hashicorp.services/cimg/go:1.18.5 \
+              tail -f /dev/null)"
+            mkdir workspace
+            echo ${CONTAINER_ID} > workspace/container_id
 
             # Run tests
-            test -d /tmp/go-cache && docker cp /tmp/go-cache testcontainer:/tmp/gocache
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
-            docker cp . testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/
-            docker cp $DOCKER_CERT_PATH/ testcontainer:$DOCKER_CERT_PATH
+            test -d /tmp/go-cache && docker cp /tmp/go-cache ${CONTAINER_ID}:/tmp/gocache
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
+            docker cp . ${CONTAINER_ID}:/home/circleci/go/src/github.com/hashicorp/vault/
+            docker cp $DOCKER_CERT_PATH/ ${CONTAINER_ID}:$DOCKER_CERT_PATH
 
             # Copy the downloaded modules inside the container.
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/pkg'
-            docker cp "$(go env GOPATH)/pkg/mod" testcontainer:/home/circleci/go/pkg/mod
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/pkg'
+            docker cp "$(go env GOPATH)/pkg/mod" ${CONTAINER_ID}:/home/circleci/go/pkg/mod
 
             docker exec -w /home/circleci/go/src/github.com/hashicorp/vault/ \
               -e CIRCLECI -e VAULT_CI_GO_TEST_RACE \
@@ -294,7 +296,7 @@ jobs:
               -e GOPROXY="off" \
               -e VAULT_LICENSE_CI \
               -e GOARCH=amd64 \
-              testcontainer \
+              ${CONTAINER_ID} \
                 gotestsum --format=short-verbose \
                   --junitfile test-results/go-test/results.xml \
                   --jsonfile test-results/go-test/results.json \
@@ -323,8 +325,8 @@ jobs:
         no_output_timeout: 60m
     - run:
         command: |
-          docker cp testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/test-results .
-          docker cp testcontainer:/tmp/gocache /tmp/go-cache
+          docker cp $(cat workspace/container_id):/home/circleci/go/src/github.com/hashicorp/vault/test-results .
+          docker cp $(cat workspace/container_id):/tmp/gocache /tmp/go-cache
         name: Copy test results
         when: always
     - store_artifacts:
@@ -482,7 +484,7 @@ jobs:
           export VAULT_LICENSE_CI="$VAULT_LICENSE"
           VAULT_LICENSE=
 
-          # Create a docker network for our testcontainer
+          # Create a docker network for our test container
           if [ $USE_DOCKER == 1 ]; then
             # Despite the fact that we're using a circleci image (thus getting the
             # version they chose for the docker cli) and that we're specifying a
@@ -514,8 +516,8 @@ jobs:
 
 
 
-            # Start a docker testcontainer to run the tests in
-            docker run -d \
+            # Start a docker test container to run the tests in
+            CONTAINER_ID="$(docker run -d \
               -e TEST_DOCKER_NETWORK_ID \
               -e GOPRIVATE \
               -e DOCKER_CERT_PATH \
@@ -524,19 +526,21 @@ jobs:
               -e DOCKER_TLS_VERIFY \
               -e NO_PROXY \
               -e VAULT_TEST_LOG_DIR=/tmp/testlogs \
-              --network vaulttest --name \
-              testcontainer docker.mirror.hashicorp.services/cimg/go:1.18.5 \
-              tail -f /dev/null
+              --network vaulttest \
+              docker.mirror.hashicorp.services/cimg/go:1.18.5 \
+              tail -f /dev/null)"
+            mkdir workspace
+            echo ${CONTAINER_ID} > workspace/container_id
 
             # Run tests
-            test -d /tmp/go-cache && docker cp /tmp/go-cache testcontainer:/tmp/gocache
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
-            docker cp . testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/
-            docker cp $DOCKER_CERT_PATH/ testcontainer:$DOCKER_CERT_PATH
+            test -d /tmp/go-cache && docker cp /tmp/go-cache ${CONTAINER_ID}:/tmp/gocache
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
+            docker cp . ${CONTAINER_ID}:/home/circleci/go/src/github.com/hashicorp/vault/
+            docker cp $DOCKER_CERT_PATH/ ${CONTAINER_ID}:$DOCKER_CERT_PATH
 
             # Copy the downloaded modules inside the container.
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/pkg'
-            docker cp "$(go env GOPATH)/pkg/mod" testcontainer:/home/circleci/go/pkg/mod
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/pkg'
+            docker cp "$(go env GOPATH)/pkg/mod" ${CONTAINER_ID}:/home/circleci/go/pkg/mod
 
             docker exec -w /home/circleci/go/src/github.com/hashicorp/vault/ \
               -e CIRCLECI -e VAULT_CI_GO_TEST_RACE \
@@ -545,7 +549,7 @@ jobs:
               -e GOPROXY="off" \
               -e VAULT_LICENSE_CI \
               -e GOARCH=amd64 \
-              testcontainer \
+              ${CONTAINER_ID} \
                 gotestsum --format=short-verbose \
                   --junitfile test-results/go-test/results.xml \
                   --jsonfile test-results/go-test/results.json \
@@ -685,7 +689,7 @@ jobs:
           export VAULT_LICENSE_CI="$VAULT_LICENSE"
           VAULT_LICENSE=
 
-          # Create a docker network for our testcontainer
+          # Create a docker network for our test container
           if [ $USE_DOCKER == 1 ]; then
             # Despite the fact that we're using a circleci image (thus getting the
             # version they chose for the docker cli) and that we're specifying a
@@ -717,8 +721,8 @@ jobs:
 
 
 
-            # Start a docker testcontainer to run the tests in
-            docker run -d \
+            # Start a docker test container to run the tests in
+            CONTAINER_ID="$(docker run -d \
               -e TEST_DOCKER_NETWORK_ID \
               -e GOPRIVATE \
               -e DOCKER_CERT_PATH \
@@ -727,19 +731,21 @@ jobs:
               -e DOCKER_TLS_VERIFY \
               -e NO_PROXY \
               -e VAULT_TEST_LOG_DIR=/tmp/testlogs \
-              --network vaulttest --name \
-              testcontainer docker.mirror.hashicorp.services/cimg/go:1.18.5 \
-              tail -f /dev/null
+              --network vaulttest \
+              docker.mirror.hashicorp.services/cimg/go:1.18.5 \
+              tail -f /dev/null)"
+            mkdir workspace
+            echo ${CONTAINER_ID} > workspace/container_id
 
             # Run tests
-            test -d /tmp/go-cache && docker cp /tmp/go-cache testcontainer:/tmp/gocache
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
-            docker cp . testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/
-            docker cp $DOCKER_CERT_PATH/ testcontainer:$DOCKER_CERT_PATH
+            test -d /tmp/go-cache && docker cp /tmp/go-cache ${CONTAINER_ID}:/tmp/gocache
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
+            docker cp . ${CONTAINER_ID}:/home/circleci/go/src/github.com/hashicorp/vault/
+            docker cp $DOCKER_CERT_PATH/ ${CONTAINER_ID}:$DOCKER_CERT_PATH
 
             # Copy the downloaded modules inside the container.
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/pkg'
-            docker cp "$(go env GOPATH)/pkg/mod" testcontainer:/home/circleci/go/pkg/mod
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/pkg'
+            docker cp "$(go env GOPATH)/pkg/mod" ${CONTAINER_ID}:/home/circleci/go/pkg/mod
 
             docker exec -w /home/circleci/go/src/github.com/hashicorp/vault/ \
               -e CIRCLECI -e VAULT_CI_GO_TEST_RACE \
@@ -748,7 +754,7 @@ jobs:
               -e GOPROXY="off" \
               -e VAULT_LICENSE_CI \
               -e GOARCH=amd64 \
-              testcontainer \
+              ${CONTAINER_ID} \
                 gotestsum --format=short-verbose \
                   --junitfile test-results/go-test/results.xml \
                   --jsonfile test-results/go-test/results.json \
@@ -998,7 +1004,7 @@ jobs:
           export VAULT_LICENSE_CI="$VAULT_LICENSE"
           VAULT_LICENSE=
 
-          # Create a docker network for our testcontainer
+          # Create a docker network for our test container
           if [ $USE_DOCKER == 1 ]; then
             # Despite the fact that we're using a circleci image (thus getting the
             # version they chose for the docker cli) and that we're specifying a
@@ -1030,8 +1036,8 @@ jobs:
 
 
 
-            # Start a docker testcontainer to run the tests in
-            docker run -d \
+            # Start a docker test container to run the tests in
+            CONTAINER_ID="$(docker run -d \
               -e TEST_DOCKER_NETWORK_ID \
               -e GOPRIVATE \
               -e DOCKER_CERT_PATH \
@@ -1040,19 +1046,21 @@ jobs:
               -e DOCKER_TLS_VERIFY \
               -e NO_PROXY \
               -e VAULT_TEST_LOG_DIR=/tmp/testlogs \
-              --network vaulttest --name \
-              testcontainer docker.mirror.hashicorp.services/cimg/go:1.18.5 \
-              tail -f /dev/null
+              --network vaulttest \
+              docker.mirror.hashicorp.services/cimg/go:1.18.5 \
+              tail -f /dev/null)"
+            mkdir workspace
+            echo ${CONTAINER_ID} > workspace/container_id
 
             # Run tests
-            test -d /tmp/go-cache && docker cp /tmp/go-cache testcontainer:/tmp/gocache
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
-            docker cp . testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/
-            docker cp $DOCKER_CERT_PATH/ testcontainer:$DOCKER_CERT_PATH
+            test -d /tmp/go-cache && docker cp /tmp/go-cache ${CONTAINER_ID}:/tmp/gocache
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
+            docker cp . ${CONTAINER_ID}:/home/circleci/go/src/github.com/hashicorp/vault/
+            docker cp $DOCKER_CERT_PATH/ ${CONTAINER_ID}:$DOCKER_CERT_PATH
 
             # Copy the downloaded modules inside the container.
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/pkg'
-            docker cp "$(go env GOPATH)/pkg/mod" testcontainer:/home/circleci/go/pkg/mod
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/pkg'
+            docker cp "$(go env GOPATH)/pkg/mod" ${CONTAINER_ID}:/home/circleci/go/pkg/mod
 
             docker exec -w /home/circleci/go/src/github.com/hashicorp/vault/ \
               -e CIRCLECI -e VAULT_CI_GO_TEST_RACE \
@@ -1061,7 +1069,7 @@ jobs:
               -e GOPROXY="off" \
               -e VAULT_LICENSE_CI \
               -e GOARCH=amd64 \
-              testcontainer \
+              ${CONTAINER_ID} \
                 gotestsum --format=short-verbose \
                   --junitfile test-results/go-test/results.xml \
                   --jsonfile test-results/go-test/results.json \
@@ -1090,8 +1098,8 @@ jobs:
         no_output_timeout: 60m
     - run:
         command: |
-          docker cp testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/test-results .
-          docker cp testcontainer:/tmp/gocache /tmp/go-cache
+          docker cp $(cat workspace/container_id):/home/circleci/go/src/github.com/hashicorp/vault/test-results .
+          docker cp $(cat workspace/container_id):/tmp/gocache /tmp/go-cache
         name: Copy test results
         when: always
     - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,9 +240,10 @@ jobs:
             # reasons unclear.
             export DOCKER_API_VERSION=1.39
 
-            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter='name=vaulttest')
+            TEST_DOCKER_NETWORK_NAME="${CIRCLE_WORKFLOW_JOB_ID}-${CIRCLE_NODE_INDEX}"
+            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter="name=${TEST_DOCKER_NETWORK_NAME}")
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
-              TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
+              TEST_DOCKER_NETWORK_ID=$(docker network create "${TEST_DOCKER_NETWORK_NAME}")
 
               # Multiple concurrent calls to 'docker network create' can succeed and cause "ambiguous network" errors from docker,
               # because multiple networks of the same name exist. By design: https://github.com/moby/moby/issues/20648#issuecomment-188215208.
@@ -493,9 +494,10 @@ jobs:
             # reasons unclear.
             export DOCKER_API_VERSION=1.39
 
-            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter='name=vaulttest')
+            TEST_DOCKER_NETWORK_NAME="${CIRCLE_WORKFLOW_JOB_ID}-${CIRCLE_NODE_INDEX}"
+            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter="name=${TEST_DOCKER_NETWORK_NAME}")
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
-              TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
+              TEST_DOCKER_NETWORK_ID=$(docker network create "${TEST_DOCKER_NETWORK_NAME}")
 
               # Multiple concurrent calls to 'docker network create' can succeed and cause "ambiguous network" errors from docker,
               # because multiple networks of the same name exist. By design: https://github.com/moby/moby/issues/20648#issuecomment-188215208.
@@ -698,9 +700,10 @@ jobs:
             # reasons unclear.
             export DOCKER_API_VERSION=1.39
 
-            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter='name=vaulttest')
+            TEST_DOCKER_NETWORK_NAME="${CIRCLE_WORKFLOW_JOB_ID}-${CIRCLE_NODE_INDEX}"
+            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter="name=${TEST_DOCKER_NETWORK_NAME}")
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
-              TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
+              TEST_DOCKER_NETWORK_ID=$(docker network create "${TEST_DOCKER_NETWORK_NAME}")
 
               # Multiple concurrent calls to 'docker network create' can succeed and cause "ambiguous network" errors from docker,
               # because multiple networks of the same name exist. By design: https://github.com/moby/moby/issues/20648#issuecomment-188215208.
@@ -1013,9 +1016,10 @@ jobs:
             # reasons unclear.
             export DOCKER_API_VERSION=1.39
 
-            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter='name=vaulttest')
+            TEST_DOCKER_NETWORK_NAME="${CIRCLE_WORKFLOW_JOB_ID}-${CIRCLE_NODE_INDEX}"
+            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter="name=${TEST_DOCKER_NETWORK_NAME}")
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
-              TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
+              TEST_DOCKER_NETWORK_ID=$(docker network create "${TEST_DOCKER_NETWORK_NAME}")
 
               # Multiple concurrent calls to 'docker network create' can succeed and cause "ambiguous network" errors from docker,
               # because multiple networks of the same name exist. By design: https://github.com/moby/moby/issues/20648#issuecomment-188215208.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs:
               # Algorithm based on another comment in that issue: https://github.com/moby/moby/issues/20648#issuecomment-883082789.
               # jq does a consistent sort to ensure any concurrent deletes agree on the correct network to delete.
               # Sorts by:
-              #   1. Number of containers attached in descending order (hopefully only ever one network gets attached to at most)
+              #   1. Number of containers attached in descending order (should only be possible for one network to be > 0)
               #   2. Then by ascending creation time
               # We then discard the first network and delete the rest.
               docker network inspect \
@@ -502,7 +502,7 @@ jobs:
               # Algorithm based on another comment in that issue: https://github.com/moby/moby/issues/20648#issuecomment-883082789.
               # jq does a consistent sort to ensure any concurrent deletes agree on the correct network to delete.
               # Sorts by:
-              #   1. Number of containers attached in descending order (hopefully only ever one network gets attached to at most)
+              #   1. Number of containers attached in descending order (should only be possible for one network to be > 0)
               #   2. Then by ascending creation time
               # We then discard the first network and delete the rest.
               docker network inspect \
@@ -705,7 +705,7 @@ jobs:
               # Algorithm based on another comment in that issue: https://github.com/moby/moby/issues/20648#issuecomment-883082789.
               # jq does a consistent sort to ensure any concurrent deletes agree on the correct network to delete.
               # Sorts by:
-              #   1. Number of containers attached in descending order (hopefully only ever one network gets attached to at most)
+              #   1. Number of containers attached in descending order (should only be possible for one network to be > 0)
               #   2. Then by ascending creation time
               # We then discard the first network and delete the rest.
               docker network inspect \
@@ -1018,7 +1018,7 @@ jobs:
               # Algorithm based on another comment in that issue: https://github.com/moby/moby/issues/20648#issuecomment-883082789.
               # jq does a consistent sort to ensure any concurrent deletes agree on the correct network to delete.
               # Sorts by:
-              #   1. Number of containers attached in descending order (hopefully only ever one network gets attached to at most)
+              #   1. Number of containers attached in descending order (should only be possible for one network to be > 0)
               #   2. Then by ascending creation time
               # We then discard the first network and delete the rest.
               docker network inspect \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,9 +240,25 @@ jobs:
             # reasons unclear.
             export DOCKER_API_VERSION=1.39
 
-            export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
+            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter='name=vaulttest')
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
               TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
+
+              # Multiple concurrent calls to 'docker network create' can succeed and cause "ambiguous network" errors from docker,
+              # because multiple networks of the same name exist. By design: https://github.com/moby/moby/issues/20648#issuecomment-188215208.
+              # So we need to clean up any possible duplicate networks straight after creating.
+              #
+              # Algorithm based on another comment in that issue: https://github.com/moby/moby/issues/20648#issuecomment-883082789.
+              # jq does a consistent sort to ensure any concurrent deletes agree on the correct network to delete.
+              # Sorts by:
+              #   1. Number of containers attached in descending order (hopefully only ever one network gets attached to at most)
+              #   2. Then by ascending creation time
+              # We then discard the first network and delete the rest.
+              docker network inspect \
+                $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
+                | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
+                | sed 1d \
+                | xargs -n 1 docker network remove
             fi
 
 
@@ -475,9 +491,25 @@ jobs:
             # reasons unclear.
             export DOCKER_API_VERSION=1.39
 
-            export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
+            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter='name=vaulttest')
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
               TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
+
+              # Multiple concurrent calls to 'docker network create' can succeed and cause "ambiguous network" errors from docker,
+              # because multiple networks of the same name exist. By design: https://github.com/moby/moby/issues/20648#issuecomment-188215208.
+              # So we need to clean up any possible duplicate networks straight after creating.
+              #
+              # Algorithm based on another comment in that issue: https://github.com/moby/moby/issues/20648#issuecomment-883082789.
+              # jq does a consistent sort to ensure any concurrent deletes agree on the correct network to delete.
+              # Sorts by:
+              #   1. Number of containers attached in descending order (hopefully only ever one network gets attached to at most)
+              #   2. Then by ascending creation time
+              # We then discard the first network and delete the rest.
+              docker network inspect \
+                $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
+                | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
+                | sed 1d \
+                | xargs -n 1 docker network remove
             fi
 
 
@@ -662,9 +694,25 @@ jobs:
             # reasons unclear.
             export DOCKER_API_VERSION=1.39
 
-            export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
+            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter='name=vaulttest')
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
               TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
+
+              # Multiple concurrent calls to 'docker network create' can succeed and cause "ambiguous network" errors from docker,
+              # because multiple networks of the same name exist. By design: https://github.com/moby/moby/issues/20648#issuecomment-188215208.
+              # So we need to clean up any possible duplicate networks straight after creating.
+              #
+              # Algorithm based on another comment in that issue: https://github.com/moby/moby/issues/20648#issuecomment-883082789.
+              # jq does a consistent sort to ensure any concurrent deletes agree on the correct network to delete.
+              # Sorts by:
+              #   1. Number of containers attached in descending order (hopefully only ever one network gets attached to at most)
+              #   2. Then by ascending creation time
+              # We then discard the first network and delete the rest.
+              docker network inspect \
+                $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
+                | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
+                | sed 1d \
+                | xargs -n 1 docker network remove
             fi
 
 
@@ -959,9 +1007,25 @@ jobs:
             # reasons unclear.
             export DOCKER_API_VERSION=1.39
 
-            export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
+            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter='name=vaulttest')
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
               TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
+
+              # Multiple concurrent calls to 'docker network create' can succeed and cause "ambiguous network" errors from docker,
+              # because multiple networks of the same name exist. By design: https://github.com/moby/moby/issues/20648#issuecomment-188215208.
+              # So we need to clean up any possible duplicate networks straight after creating.
+              #
+              # Algorithm based on another comment in that issue: https://github.com/moby/moby/issues/20648#issuecomment-883082789.
+              # jq does a consistent sort to ensure any concurrent deletes agree on the correct network to delete.
+              # Sorts by:
+              #   1. Number of containers attached in descending order (hopefully only ever one network gets attached to at most)
+              #   2. Then by ascending creation time
+              # We then discard the first network and delete the rest.
+              docker network inspect \
+                $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
+                | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
+                | sed 1d \
+                | xargs -n 1 docker network remove
             fi
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,22 +244,6 @@ jobs:
             export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter="name=${TEST_DOCKER_NETWORK_NAME}")
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
               TEST_DOCKER_NETWORK_ID=$(docker network create "${TEST_DOCKER_NETWORK_NAME}")
-
-              # Multiple concurrent calls to 'docker network create' can succeed and cause "ambiguous network" errors from docker,
-              # because multiple networks of the same name exist. By design: https://github.com/moby/moby/issues/20648#issuecomment-188215208.
-              # So we need to clean up any possible duplicate networks straight after creating.
-              #
-              # Algorithm based on another comment in that issue: https://github.com/moby/moby/issues/20648#issuecomment-883082789.
-              # jq does a consistent sort to ensure any concurrent deletes agree on the correct network to delete.
-              # Sorts by:
-              #   1. Number of containers attached in descending order (should only be possible for one network to be > 0)
-              #   2. Then by ascending creation time
-              # We then discard the first network and delete the rest.
-              docker network inspect \
-                $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
-                | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
-                | sed 1d \
-                | xargs -r -n 1 docker network remove
             fi
 
 
@@ -274,7 +258,7 @@ jobs:
               -e DOCKER_TLS_VERIFY \
               -e NO_PROXY \
               -e VAULT_TEST_LOG_DIR=/tmp/testlogs \
-              --network vaulttest \
+              --network ${TEST_DOCKER_NETWORK_NAME} \
               docker.mirror.hashicorp.services/cimg/go:1.18.5 \
               tail -f /dev/null)"
             mkdir workspace
@@ -498,22 +482,6 @@ jobs:
             export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter="name=${TEST_DOCKER_NETWORK_NAME}")
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
               TEST_DOCKER_NETWORK_ID=$(docker network create "${TEST_DOCKER_NETWORK_NAME}")
-
-              # Multiple concurrent calls to 'docker network create' can succeed and cause "ambiguous network" errors from docker,
-              # because multiple networks of the same name exist. By design: https://github.com/moby/moby/issues/20648#issuecomment-188215208.
-              # So we need to clean up any possible duplicate networks straight after creating.
-              #
-              # Algorithm based on another comment in that issue: https://github.com/moby/moby/issues/20648#issuecomment-883082789.
-              # jq does a consistent sort to ensure any concurrent deletes agree on the correct network to delete.
-              # Sorts by:
-              #   1. Number of containers attached in descending order (should only be possible for one network to be > 0)
-              #   2. Then by ascending creation time
-              # We then discard the first network and delete the rest.
-              docker network inspect \
-                $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
-                | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
-                | sed 1d \
-                | xargs -r -n 1 docker network remove
             fi
 
 
@@ -528,7 +496,7 @@ jobs:
               -e DOCKER_TLS_VERIFY \
               -e NO_PROXY \
               -e VAULT_TEST_LOG_DIR=/tmp/testlogs \
-              --network vaulttest \
+              --network ${TEST_DOCKER_NETWORK_NAME} \
               docker.mirror.hashicorp.services/cimg/go:1.18.5 \
               tail -f /dev/null)"
             mkdir workspace
@@ -704,22 +672,6 @@ jobs:
             export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter="name=${TEST_DOCKER_NETWORK_NAME}")
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
               TEST_DOCKER_NETWORK_ID=$(docker network create "${TEST_DOCKER_NETWORK_NAME}")
-
-              # Multiple concurrent calls to 'docker network create' can succeed and cause "ambiguous network" errors from docker,
-              # because multiple networks of the same name exist. By design: https://github.com/moby/moby/issues/20648#issuecomment-188215208.
-              # So we need to clean up any possible duplicate networks straight after creating.
-              #
-              # Algorithm based on another comment in that issue: https://github.com/moby/moby/issues/20648#issuecomment-883082789.
-              # jq does a consistent sort to ensure any concurrent deletes agree on the correct network to delete.
-              # Sorts by:
-              #   1. Number of containers attached in descending order (should only be possible for one network to be > 0)
-              #   2. Then by ascending creation time
-              # We then discard the first network and delete the rest.
-              docker network inspect \
-                $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
-                | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
-                | sed 1d \
-                | xargs -r -n 1 docker network remove
             fi
 
 
@@ -734,7 +686,7 @@ jobs:
               -e DOCKER_TLS_VERIFY \
               -e NO_PROXY \
               -e VAULT_TEST_LOG_DIR=/tmp/testlogs \
-              --network vaulttest \
+              --network ${TEST_DOCKER_NETWORK_NAME} \
               docker.mirror.hashicorp.services/cimg/go:1.18.5 \
               tail -f /dev/null)"
             mkdir workspace
@@ -1020,22 +972,6 @@ jobs:
             export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter="name=${TEST_DOCKER_NETWORK_NAME}")
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
               TEST_DOCKER_NETWORK_ID=$(docker network create "${TEST_DOCKER_NETWORK_NAME}")
-
-              # Multiple concurrent calls to 'docker network create' can succeed and cause "ambiguous network" errors from docker,
-              # because multiple networks of the same name exist. By design: https://github.com/moby/moby/issues/20648#issuecomment-188215208.
-              # So we need to clean up any possible duplicate networks straight after creating.
-              #
-              # Algorithm based on another comment in that issue: https://github.com/moby/moby/issues/20648#issuecomment-883082789.
-              # jq does a consistent sort to ensure any concurrent deletes agree on the correct network to delete.
-              # Sorts by:
-              #   1. Number of containers attached in descending order (should only be possible for one network to be > 0)
-              #   2. Then by ascending creation time
-              # We then discard the first network and delete the rest.
-              docker network inspect \
-                $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
-                | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
-                | sed 1d \
-                | xargs -r -n 1 docker network remove
             fi
 
 
@@ -1050,7 +986,7 @@ jobs:
               -e DOCKER_TLS_VERIFY \
               -e NO_PROXY \
               -e VAULT_TEST_LOG_DIR=/tmp/testlogs \
-              --network vaulttest \
+              --network ${TEST_DOCKER_NETWORK_NAME} \
               docker.mirror.hashicorp.services/cimg/go:1.18.5 \
               tail -f /dev/null)"
             mkdir workspace

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -116,9 +116,10 @@ steps:
           # reasons unclear.
           export DOCKER_API_VERSION=1.39
 
-          export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter='name=vaulttest')
+          TEST_DOCKER_NETWORK_NAME="${CIRCLE_WORKFLOW_JOB_ID}-${CIRCLE_NODE_INDEX}"
+          export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter="name=${TEST_DOCKER_NETWORK_NAME}")
           if [ -z $TEST_DOCKER_NETWORK_ID ]; then
-            TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
+            TEST_DOCKER_NETWORK_ID=$(docker network create "${TEST_DOCKER_NETWORK_NAME}")
 
             # Multiple concurrent calls to 'docker network create' can succeed and cause "ambiguous network" errors from docker,
             # because multiple networks of the same name exist. By design: https://github.com/moby/moby/issues/20648#issuecomment-188215208.

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -107,7 +107,7 @@ steps:
         export VAULT_LICENSE_CI="$VAULT_LICENSE"
         VAULT_LICENSE=
 
-        # Create a docker network for our testcontainer
+        # Create a docker network for our test container
         if [ $USE_DOCKER == 1 ]; then
           # Despite the fact that we're using a circleci image (thus getting the
           # version they chose for the docker cli) and that we're specifying a
@@ -139,8 +139,8 @@ steps:
 
 
 
-          # Start a docker testcontainer to run the tests in
-          docker run -d \
+          # Start a docker test container to run the tests in
+          CONTAINER_ID="$(docker run -d \
             -e TEST_DOCKER_NETWORK_ID \
             -e GOPRIVATE \
             -e DOCKER_CERT_PATH \
@@ -149,19 +149,21 @@ steps:
             -e DOCKER_TLS_VERIFY \
             -e NO_PROXY \
             -e VAULT_TEST_LOG_DIR=<< parameters.log_dir >> \
-            --network vaulttest --name \
-            testcontainer << parameters.go_image >> \
-            tail -f /dev/null
+            --network vaulttest \
+            << parameters.go_image >> \
+            tail -f /dev/null)"
+          mkdir workspace
+          echo ${CONTAINER_ID} > workspace/container_id
 
           # Run tests
-          test -d << parameters.cache_dir >> && docker cp << parameters.cache_dir >> testcontainer:/tmp/gocache
-          docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
-          docker cp . testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/
-          docker cp $DOCKER_CERT_PATH/ testcontainer:$DOCKER_CERT_PATH
+          test -d << parameters.cache_dir >> && docker cp << parameters.cache_dir >> ${CONTAINER_ID}:/tmp/gocache
+          docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
+          docker cp . ${CONTAINER_ID}:/home/circleci/go/src/github.com/hashicorp/vault/
+          docker cp $DOCKER_CERT_PATH/ ${CONTAINER_ID}:$DOCKER_CERT_PATH
 
           # Copy the downloaded modules inside the container.
-          docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/pkg'
-          docker cp "$(go env GOPATH)/pkg/mod" testcontainer:/home/circleci/go/pkg/mod
+          docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/pkg'
+          docker cp "$(go env GOPATH)/pkg/mod" ${CONTAINER_ID}:/home/circleci/go/pkg/mod
 
           docker exec -w /home/circleci/go/src/github.com/hashicorp/vault/ \
             -e CIRCLECI -e VAULT_CI_GO_TEST_RACE \
@@ -170,7 +172,7 @@ steps:
             -e GOPROXY="off" \
             -e VAULT_LICENSE_CI \
             -e GOARCH=<< parameters.arch >> \
-            testcontainer \
+            ${CONTAINER_ID} \
               gotestsum --format=short-verbose \
                 --junitfile test-results/go-test/results.xml \
                 --jsonfile test-results/go-test/results.json \
@@ -201,8 +203,8 @@ steps:
             name: Copy test results
             when: always
             command: |
-              docker cp testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/test-results .
-              docker cp testcontainer:/tmp/gocache << parameters.cache_dir >>
+              docker cp $(cat workspace/container_id):/home/circleci/go/src/github.com/hashicorp/vault/test-results .
+              docker cp $(cat workspace/container_id):/tmp/gocache << parameters.cache_dir >>
   - when:
       condition: << parameters.save_cache >>
       steps:

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -120,22 +120,6 @@ steps:
           export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter="name=${TEST_DOCKER_NETWORK_NAME}")
           if [ -z $TEST_DOCKER_NETWORK_ID ]; then
             TEST_DOCKER_NETWORK_ID=$(docker network create "${TEST_DOCKER_NETWORK_NAME}")
-
-            # Multiple concurrent calls to 'docker network create' can succeed and cause "ambiguous network" errors from docker,
-            # because multiple networks of the same name exist. By design: https://github.com/moby/moby/issues/20648#issuecomment-188215208.
-            # So we need to clean up any possible duplicate networks straight after creating.
-            #
-            # Algorithm based on another comment in that issue: https://github.com/moby/moby/issues/20648#issuecomment-883082789.
-            # jq does a consistent sort to ensure any concurrent deletes agree on the correct network to delete.
-            # Sorts by:
-            #   1. Number of containers attached in descending order (should only be possible for one network to be > 0)
-            #   2. Then by ascending creation time
-            # We then discard the first network and delete the rest.
-            docker network inspect \
-              $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
-              | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
-              | sed 1d \
-              | xargs -r -n 1 docker network remove
           fi
 
 
@@ -150,7 +134,7 @@ steps:
             -e DOCKER_TLS_VERIFY \
             -e NO_PROXY \
             -e VAULT_TEST_LOG_DIR=<< parameters.log_dir >> \
-            --network vaulttest \
+            --network ${TEST_DOCKER_NETWORK_NAME} \
             << parameters.go_image >> \
             tail -f /dev/null)"
           mkdir workspace

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -127,7 +127,7 @@ steps:
             # Algorithm based on another comment in that issue: https://github.com/moby/moby/issues/20648#issuecomment-883082789.
             # jq does a consistent sort to ensure any concurrent deletes agree on the correct network to delete.
             # Sorts by:
-            #   1. Number of containers attached in descending order (hopefully only ever one network gets attached to at most)
+            #   1. Number of containers attached in descending order (should only be possible for one network to be > 0)
             #   2. Then by ascending creation time
             # We then discard the first network and delete the rest.
             docker network inspect \

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -134,7 +134,7 @@ steps:
               $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
               | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
               | sed 1d \
-              | xargs -n 1 docker network remove
+              | xargs -r -n 1 docker network remove
           fi
 
 

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -116,9 +116,25 @@ steps:
           # reasons unclear.
           export DOCKER_API_VERSION=1.39
 
-          export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
+          export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter='name=vaulttest')
           if [ -z $TEST_DOCKER_NETWORK_ID ]; then
             TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
+
+            # Multiple concurrent calls to 'docker network create' can succeed and cause "ambiguous network" errors from docker,
+            # because multiple networks of the same name exist. By design: https://github.com/moby/moby/issues/20648#issuecomment-188215208.
+            # So we need to clean up any possible duplicate networks straight after creating.
+            #
+            # Algorithm based on another comment in that issue: https://github.com/moby/moby/issues/20648#issuecomment-883082789.
+            # jq does a consistent sort to ensure any concurrent deletes agree on the correct network to delete.
+            # Sorts by:
+            #   1. Number of containers attached in descending order (hopefully only ever one network gets attached to at most)
+            #   2. Then by ascending creation time
+            # We then discard the first network and delete the rest.
+            docker network inspect \
+              $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
+              | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
+              | sed 1d \
+              | xargs -n 1 docker network remove
           fi
 
 


### PR DESCRIPTION
`test-go-remote-docker` and `test-go-race-remote-docker` seem to have been a little flaky lately, with [errors](https://app.circleci.com/pipelines/github/hashicorp/vault/40740/workflows/6b6a714b-9da3-4edf-9f5c-db9101e27037/jobs/505610) [like so](https://app.circleci.com/pipelines/github/hashicorp/vault/40762/workflows/95737136-c6b7-422f-b40e-955964a77e7d/jobs/505821):

```
Failed
=== RUN   TestBackend_basic
    mongodbhelper.go:68: could not start docker mongo: container start failed: Error response from daemon: network 953d93bc05fe is ambiguous (4 matches found on name)
--- FAIL: TestBackend_basic (1.05s)
```

_EDIT: Also some new follow-up errors in the comment down below._

It seems that multiple concurrent calls to `docker network create vaulttest` can all succeed. On using the network, the error occurs even if you refer to the network by its non-ambiguous ID hash (as we already do). So this attempts to clean up duplicates before proceeding. I am not 100% familiar with the execution environment for our CircleCI tests, so it may be that we can simplify this solution by moving network creation to another location where we can ensure it never occurs in parallel instead.

To test the bash out locally, you can run:

```bash
# Create multiple networks with the same name
docker network create vaulttest & docker network create vaulttest & docker network create vaulttest

# Observe 3 networks created with the same name
docker network ls

# Clean up
# Should be idempotent, and work as long as there is >= 1 vaulttest network,
# so should be able to run this command multiple times
docker network inspect \
    $(docker network list --no-trunc --filter='name=vaulttest' --quiet) \
    | jq -r 'map({"attached": .Containers | keys | length, "created": .Created, "id": .Id}) | sort_by(-.attached, .created)[] | .id' \
    | sed 1d \
    | xargs -n 1 docker network remove

# Should only be one network now
docker network ls
```