### PR TITLE
Docs: Add log level environment variable for Vault Lambda Extension

### DIFF
--- a/website/content/docs/platform/aws/lambda-extension.mdx
+++ b/website/content/docs/platform/aws/lambda-extension.mdx
@@ -201,7 +201,8 @@ initialization timeout imposed by the Extensions API when writing files to disk.
 | `VAULT_NAMESPACE`             | The namespace to use for pre-configured secrets. Ignored by proxy server                                                                                                        | No       | `education`         |
 | `VAULT_DEFAULT_CACHE_TTL`     | The time to live configuration (aka, TTL) of the cache used by proxy server. Must have a unit and be parsable as a time.Duration. Required for caching to be enabled.           | No       | `15m`               |
 | `VAULT_DEFAULT_CACHE_ENABLED` | Enable caching for all requests, without needing to set the X-Vault-Cache-Control header for each request. Must be set to a boolean value.                                      | No       | `true`              |
-| `VAULT_ASSUMED_ROLE_ARN`      | Valid ARN of an IAM role that can be assumed by the execution role assigned to your Lambda function. | No | `arn:aws:iam::123456789012:role/xaccounts3access`
+| `VAULT_ASSUMED_ROLE_ARN`      | Valid ARN of an IAM role that can be assumed by the execution role assigned to your Lambda function.                                                                            | No       | `arn:aws:iam::123456789012:role/xaccounts3access`
+| `VAULT_LOG_LEVEL`             | Log verbosity level, one of TRACE, DEBUG, INFO, WARN, ERROR, OFF. Defaults to INFO.                                                                                             | No       | `DEBUG`
 
 ### AWS STS client configuration
 


### PR DESCRIPTION
Adds missing `VAULT_LOG_LEVEL` as a configuration option to the docs for Vault Lambda Extension.