### PR TITLE
Core: CLI imporvement VAULT_ADDR Warning message

### DIFF
--- a/changelog/17008.txt
+++ b/changelog/17008.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/cli: Warning related to VAULT_ADDR & -address not set with CLI requests.
+```

--- a/command/base.go
+++ b/command/base.go
@@ -333,9 +333,8 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 				addrStringVar.Default = c.flagAddress
 			} else {
 				addrStringVar.Default = "https://127.0.0.1:8200"
-				// if no VAULT_ADDR or -address provided then give warning.
 				if os.Getenv("VAULT_ADDR") == "" {
-					c.UI.Warn("WARNING: neither VAULT_ADDR nor the -address parameter is set. Defaulting to loopback address (https://127.0.0.1:8200).")
+					c.UI.Warn(wrapAtLength(fmt.Sprintf("WARNING! VAULT_ADDR and -address unset. Defaulting to %s.", addrStringVar.Default)))
 				}
 			}
 			f.StringVar(addrStringVar)

--- a/command/base.go
+++ b/command/base.go
@@ -333,6 +333,10 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 				addrStringVar.Default = c.flagAddress
 			} else {
 				addrStringVar.Default = "https://127.0.0.1:8200"
+				// if no VAULT_ADDR or -address provided then give warning.
+				if os.Getenv("VAULT_ADDR") == "" {
+					c.UI.Warn("WARNING: neither VAULT_ADDR nor the -address parameter is set. Defaulting to loopback address (https://127.0.0.1:8200).")
+				}
 			}
 			f.StringVar(addrStringVar)
 


### PR DESCRIPTION
When `VAULT_ADDR` or `-address` is not set provide warning messages as below. Resolves #9684.

```shell
./vault status
  # WARNING: neither VAULT_ADDR nor the -address parameter is set. Defaulting to loopback address (https://127.0.0.1:8200).
  # Error checking seal status: Get "https://127.0.0.1:8200/v1/sys/seal-status": dial tcp 127.0.0.1:8200: connect: connection refused
```