### PR TITLE
recreate client for 'cert' auto_auth on file change

### DIFF
--- a/command/agent/auth/cert/file_watcher.go
+++ b/command/agent/auth/cert/file_watcher.go
@@ -1,0 +1,299 @@
+package cert
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/hashicorp/go-hclog"
+)
+
+const timeoutDuration = 200 * time.Millisecond
+
+type Watcher interface {
+	Start(ctx context.Context)
+	Stop() error
+	Add(filename string) error
+	Remove(filename string)
+	Replace(oldFile, newFile string) error
+	EventsCh() chan *FileWatcherEvent
+}
+
+type fileWatcher struct {
+	watcher          *fsnotify.Watcher
+	configFiles      map[string]*watchedFile
+	configFilesLock  sync.RWMutex
+	logger           hclog.Logger
+	reconcileTimeout time.Duration
+	cancel           context.CancelFunc
+	done             chan interface{}
+	stopOnce         sync.Once
+
+	//eventsCh Channel where an event will be emitted when a file change is detected
+	// a call to Start is needed before any event is emitted
+	// after a Call to Stop succeed, the channel will be closed
+	eventsCh chan *FileWatcherEvent
+}
+
+type watchedFile struct {
+	modTime time.Time
+}
+
+type FileWatcherEvent struct {
+	Filenames []string
+}
+
+//NewFileWatcher create a file watcher that will watch all the files/folders from configFiles
+// if success a fileWatcher will be returned and a nil error
+// otherwise an error and a nil fileWatcher are returned
+func NewFileWatcher(configFiles []string, logger hclog.Logger) (Watcher, error) {
+	ws, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	w := &fileWatcher{
+		watcher:          ws,
+		logger:           logger.Named("file-watcher"),
+		configFiles:      make(map[string]*watchedFile),
+		eventsCh:         make(chan *FileWatcherEvent),
+		reconcileTimeout: timeoutDuration,
+		done:             make(chan interface{}),
+	}
+	for _, f := range configFiles {
+		err = w.Add(f)
+		if err != nil {
+			return nil, fmt.Errorf("error adding file %q: %w", f, err)
+		}
+	}
+
+	return w, nil
+}
+
+// Start start a file watcher, with a copy of the passed context.
+// calling Start multiple times is a noop
+func (w *fileWatcher) Start(ctx context.Context) {
+	if w.cancel == nil {
+		cancelCtx, cancel := context.WithCancel(ctx)
+		w.cancel = cancel
+		go w.watch(cancelCtx)
+	}
+}
+
+// Stop the file watcher
+// calling Stop multiple times is a noop, Stop must be called after a Start
+func (w *fileWatcher) Stop() error {
+	var err error
+	w.stopOnce.Do(func() {
+		w.cancel()
+		<-w.done
+		err = w.watcher.Close()
+	})
+	return err
+}
+
+// Add a file to the file watcher
+// Add will lock the file watcher during the add
+func (w *fileWatcher) Add(filename string) error {
+	filename = filepath.Clean(filename)
+	w.logger.Trace("adding file", "file", filename)
+	if err := w.watcher.Add(filename); err != nil {
+		return err
+	}
+	modTime, err := w.getFileModifiedTime(filename)
+	if err != nil {
+		return err
+	}
+	w.addFile(filename, modTime)
+	return nil
+}
+
+// Remove a file from the file watcher
+// Remove will lock the file watcher during the remove
+func (w *fileWatcher) Remove(filename string) {
+	w.removeFile(filename)
+}
+
+// Replace a file in the file watcher
+// Replace will lock the file watcher during the replace
+func (w *fileWatcher) Replace(oldFile, newFile string) error {
+	if oldFile == newFile {
+		return nil
+	}
+	newFile = filepath.Clean(newFile)
+	w.logger.Trace("adding file", "file", newFile)
+	if err := w.watcher.Add(newFile); err != nil {
+		return err
+	}
+	modTime, err := w.getFileModifiedTime(newFile)
+	if err != nil {
+		return err
+	}
+	w.replaceFile(oldFile, newFile, modTime)
+	return nil
+}
+
+func (w *fileWatcher) replaceFile(oldFile, newFile string, modTime time.Time) {
+	w.configFilesLock.Lock()
+	defer w.configFilesLock.Unlock()
+	delete(w.configFiles, oldFile)
+	w.configFiles[newFile] = &watchedFile{modTime: modTime}
+}
+
+func (w *fileWatcher) addFile(filename string, modTime time.Time) {
+	w.configFilesLock.Lock()
+	defer w.configFilesLock.Unlock()
+	w.configFiles[filename] = &watchedFile{modTime: modTime}
+}
+
+func (w *fileWatcher) removeFile(filename string) {
+	w.configFilesLock.Lock()
+	defer w.configFilesLock.Unlock()
+	delete(w.configFiles, filename)
+}
+
+func (w *fileWatcher) EventsCh() chan *FileWatcherEvent {
+	return w.eventsCh
+}
+
+func (w *fileWatcher) watch(ctx context.Context) {
+	ticker := time.NewTicker(w.reconcileTimeout)
+	defer ticker.Stop()
+	defer close(w.done)
+	defer close(w.eventsCh)
+
+	for {
+		select {
+		case event, ok := <-w.watcher.Events:
+			if !ok {
+				w.logger.Error("watcher event channel is closed")
+				return
+			}
+			w.logger.Trace("received watcher event", "event", event)
+			if err := w.handleEvent(ctx, event); err != nil {
+				w.logger.Error("error handling watcher event", "error", err, "event", event)
+			}
+		case _, ok := <-w.watcher.Errors:
+			if !ok {
+				w.logger.Error("watcher error channel is closed")
+				return
+			}
+		case <-ticker.C:
+			w.reconcile(ctx)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (w *fileWatcher) handleEvent(ctx context.Context, event fsnotify.Event) error {
+	w.logger.Trace("event received ", "filename", event.Name, "OP", event.Op)
+	// we only want Create and Remove events to avoid triggering a reload on file modification
+	if !isCreateEvent(event) && !isRemoveEvent(event) && !isWriteEvent(event) && !isRenameEvent(event) {
+		return nil
+	}
+	filename := filepath.Clean(event.Name)
+	configFile, basename, ok := w.isWatched(filename)
+	if !ok {
+		return fmt.Errorf("file %s is not watched", event.Name)
+	}
+
+	// we only want to update mod time and re-add if the event is on the watched file itself
+	if filename == basename {
+		if isRemoveEvent(event) {
+			// If the file was removed, try to reconcile and see if anything changed.
+			w.logger.Trace("attempt a reconcile ", "filename", event.Name, "OP", event.Op)
+			configFile.modTime = time.Time{}
+			w.reconcile(ctx)
+		}
+	}
+	if isCreateEvent(event) || isWriteEvent(event) || isRenameEvent(event) {
+		w.logger.Trace("call the handler", "filename", event.Name, "OP", event.Op)
+		select {
+		case w.eventsCh <- &FileWatcherEvent{Filenames: []string{filename}}:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+	}
+	return nil
+}
+
+func (w *fileWatcher) isWatched(filename string) (*watchedFile, string, bool) {
+	path := filename
+	w.configFilesLock.RLock()
+	configFile, ok := w.configFiles[path]
+	w.configFilesLock.RUnlock()
+	if ok {
+		return configFile, path, true
+	}
+
+	stat, err := os.Lstat(filename)
+
+	// if the error is a not exist still try to find if the event for a configured file
+	if os.IsNotExist(err) || (!stat.IsDir() && stat.Mode()&os.ModeSymlink == 0) {
+		w.logger.Trace("not a dir and not a symlink to a dir")
+		// try to see if the watched path is the parent dir
+		newPath := filepath.Dir(path)
+		w.logger.Trace("get dir", "dir", newPath)
+		w.configFilesLock.RLock()
+		configFile, ok = w.configFiles[newPath]
+		w.configFilesLock.RUnlock()
+	}
+	return configFile, path, ok
+}
+
+func (w *fileWatcher) reconcile(ctx context.Context) {
+	w.configFilesLock.Lock()
+	defer w.configFilesLock.Unlock()
+	for filename, configFile := range w.configFiles {
+		newModTime, err := w.getFileModifiedTime(filename)
+		if err != nil {
+			w.logger.Error("failed to get file modTime", "file", filename, "err", err)
+			continue
+		}
+
+		err = w.watcher.Add(filename)
+		if err != nil {
+			w.logger.Error("failed to add file to watcher", "file", filename, "err", err)
+			continue
+		}
+		if !configFile.modTime.Equal(newModTime) {
+			w.logger.Trace("call the handler", "filename", filename, "old modTime", configFile.modTime, "new modTime", newModTime)
+			configFile.modTime = newModTime
+			select {
+			case w.eventsCh <- &FileWatcherEvent{Filenames: []string{filename}}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+func isCreateEvent(event fsnotify.Event) bool {
+	return event.Op&fsnotify.Create == fsnotify.Create
+}
+
+func isRemoveEvent(event fsnotify.Event) bool {
+	return event.Op&fsnotify.Remove == fsnotify.Remove
+}
+
+func isWriteEvent(event fsnotify.Event) bool {
+	return event.Op&fsnotify.Write == fsnotify.Write
+}
+
+func isRenameEvent(event fsnotify.Event) bool {
+	return event.Op&fsnotify.Rename == fsnotify.Rename
+}
+
+func (w *fileWatcher) getFileModifiedTime(filename string) (time.Time, error) {
+	fileInfo, err := os.Stat(filename)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return fileInfo.ModTime(), err
+}

--- a/command/agent/auth/cert/file_watcher_test.go
+++ b/command/agent/auth/cert/file_watcher_test.go
@@ -1,0 +1,415 @@
+package cert
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+const defaultTimeout = 500 * time.Millisecond
+
+func TestNewWatcher(t *testing.T) {
+	w, err := NewFileWatcher([]string{}, hclog.New(&hclog.LoggerOptions{}))
+	require.NoError(t, err)
+	require.NotNil(t, w)
+}
+
+func TestWatcherRenameEvent(t *testing.T) {
+
+	fileTmp := createTempConfigFile(t, "temp_config3")
+	filepaths := []string{createTempConfigFile(t, "temp_config1"), createTempConfigFile(t, "temp_config2")}
+	wi, err := NewFileWatcher(filepaths, hclog.New(&hclog.LoggerOptions{}))
+	w := wi.(*fileWatcher)
+
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+
+	require.NoError(t, err)
+	err = os.Rename(fileTmp, filepaths[0])
+	time.Sleep(w.reconcileTimeout + 50*time.Millisecond)
+	require.NoError(t, err)
+	require.NoError(t, assertEvent(filepaths[0], w.eventsCh, defaultTimeout))
+	// make sure we consume all events
+	_ = assertEvent(filepaths[0], w.eventsCh, defaultTimeout)
+}
+
+func TestWatcherAddRemove(t *testing.T) {
+	var filepaths []string
+	wi, err := NewFileWatcher(filepaths, hclog.New(&hclog.LoggerOptions{}))
+	w := wi.(*fileWatcher)
+	require.NoError(t, err)
+	file1 := createTempConfigFile(t, "temp_config1")
+	err = w.Add(file1)
+	require.NoError(t, err)
+	file2 := createTempConfigFile(t, "temp_config2")
+	err = w.Add(file2)
+	require.NoError(t, err)
+	w.Remove(file2)
+	_, ok := w.configFiles[file1]
+	require.True(t, ok)
+	_, ok = w.configFiles[file2]
+	require.False(t, ok)
+
+}
+
+func TestWatcherReplace(t *testing.T) {
+	var filepaths []string
+	wi, err := NewFileWatcher(filepaths, hclog.New(&hclog.LoggerOptions{}))
+	w := wi.(*fileWatcher)
+	require.NoError(t, err)
+	file1 := createTempConfigFile(t, "temp_config1")
+	err = w.Add(file1)
+	require.NoError(t, err)
+	file2 := createTempConfigFile(t, "temp_config2")
+	err = w.Replace(file1, file2)
+	require.NoError(t, err)
+	_, ok := w.configFiles[file1]
+	require.False(t, ok)
+	_, ok = w.configFiles[file2]
+	require.True(t, ok)
+}
+
+func TestWatcherAddWhileRunning(t *testing.T) {
+	var filepaths []string
+	wi, err := NewFileWatcher(filepaths, hclog.New(&hclog.LoggerOptions{}))
+	w := wi.(*fileWatcher)
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+	file1 := createTempConfigFile(t, "temp_config1")
+	err = w.Add(file1)
+	require.NoError(t, err)
+	file2 := createTempConfigFile(t, "temp_config2")
+	err = w.Add(file2)
+	require.NoError(t, err)
+	w.Remove(file2)
+	require.Len(t, w.configFiles, 1)
+	_, ok := w.configFiles[file1]
+	require.True(t, ok)
+	_, ok = w.configFiles[file2]
+	require.False(t, ok)
+}
+
+func TestWatcherRemoveNotFound(t *testing.T) {
+	var filepaths []string
+	w, err := NewFileWatcher(filepaths, hclog.New(&hclog.LoggerOptions{}))
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+
+	file := createTempConfigFile(t, "temp_config2")
+	w.Remove(file)
+}
+
+func TestWatcherAddNotExist(t *testing.T) {
+
+	file := testutil.TempFile(t, "temp_config")
+	filename := file.Name() + randomStr(16)
+	w, err := NewFileWatcher([]string{filename}, hclog.New(&hclog.LoggerOptions{}))
+	require.Error(t, err, "no such file or directory")
+	require.Nil(t, w)
+}
+
+func TestEventWatcherWrite(t *testing.T) {
+
+	file := testutil.TempFile(t, "temp_config")
+	_, err := file.WriteString("test config")
+	require.NoError(t, err)
+	err = file.Sync()
+	require.NoError(t, err)
+	w, err := NewFileWatcher([]string{file.Name()}, hclog.New(&hclog.LoggerOptions{}))
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+
+	_, err = file.WriteString("test config 2")
+	require.NoError(t, err)
+	err = file.Sync()
+	require.NoError(t, err)
+	require.NoError(t, assertEvent(file.Name(), w.EventsCh(), defaultTimeout))
+}
+
+func TestEventWatcherRead(t *testing.T) {
+
+	filepath := createTempConfigFile(t, "temp_config1")
+	w, err := NewFileWatcher([]string{filepath}, hclog.New(&hclog.LoggerOptions{}))
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+
+	_, err = os.ReadFile(filepath)
+	require.NoError(t, err)
+	require.Error(t, assertEvent(filepath, w.EventsCh(), defaultTimeout), "timedout waiting for event")
+}
+
+func TestEventWatcherChmod(t *testing.T) {
+	file := testutil.TempFile(t, "temp_config")
+	defer func() {
+		err := file.Close()
+		require.NoError(t, err)
+	}()
+	_, err := file.WriteString("test config")
+	require.NoError(t, err)
+	err = file.Sync()
+	require.NoError(t, err)
+
+	w, err := NewFileWatcher([]string{file.Name()}, hclog.New(&hclog.LoggerOptions{}))
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+
+	err = file.Chmod(0777)
+	require.NoError(t, err)
+	require.Error(t, assertEvent(file.Name(), w.EventsCh(), defaultTimeout), "timedout waiting for event")
+}
+
+func TestEventWatcherRemoveCreate(t *testing.T) {
+
+	filepath := createTempConfigFile(t, "temp_config1")
+	w, err := NewFileWatcher([]string{filepath}, hclog.New(&hclog.LoggerOptions{}))
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+
+	require.NoError(t, err)
+	err = os.Remove(filepath)
+	require.NoError(t, err)
+	recreated, err := os.Create(filepath)
+	require.NoError(t, err)
+	_, err = recreated.WriteString("config 2")
+	require.NoError(t, err)
+	err = recreated.Sync()
+	require.NoError(t, err)
+	// this an event coming from the reconcile loop
+	require.NoError(t, assertEvent(filepath, w.EventsCh(), defaultTimeout))
+}
+
+func TestEventWatcherMove(t *testing.T) {
+
+	filepath := createTempConfigFile(t, "temp_config1")
+
+	w, err := NewFileWatcher([]string{filepath}, hclog.New(&hclog.LoggerOptions{}))
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+
+	for i := 0; i < 10; i++ {
+		filepath2 := createTempConfigFile(t, "temp_config2")
+		err = os.Rename(filepath2, filepath)
+		time.Sleep(timeoutDuration + 50*time.Millisecond)
+		require.NoError(t, err)
+		require.NoError(t, assertEvent(filepath, w.EventsCh(), defaultTimeout))
+	}
+}
+
+func TestEventReconcileMove(t *testing.T) {
+	filepath := createTempConfigFile(t, "temp_config1")
+	filepath2 := createTempConfigFile(t, "temp_config2")
+	err := os.Chtimes(filepath, time.Now(), time.Now().Add(-1*time.Second))
+	require.NoError(t, err)
+	wi, err := NewFileWatcher([]string{filepath}, hclog.New(&hclog.LoggerOptions{}))
+	w := wi.(*fileWatcher)
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+
+	// remove the file from the internal watcher to only trigger the reconcile
+	err = w.watcher.Remove(filepath)
+	require.NoError(t, err)
+
+	err = os.Rename(filepath2, filepath)
+	time.Sleep(timeoutDuration + 50*time.Millisecond)
+	require.NoError(t, err)
+	require.NoError(t, assertEvent(filepath, w.EventsCh(), 2000*time.Millisecond))
+}
+
+func TestEventWatcherDirCreateRemove(t *testing.T) {
+	filepath := testutil.TempDir(t, "temp_config1")
+	w, err := NewFileWatcher([]string{filepath}, hclog.New(&hclog.LoggerOptions{}))
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+	for i := 0; i < 1; i++ {
+		name := filepath + "/" + randomStr(20)
+		file, err := os.Create(name)
+		require.NoError(t, err)
+		err = file.Close()
+		require.NoError(t, err)
+		require.NoError(t, assertEvent(filepath, w.EventsCh(), defaultTimeout))
+
+		err = os.Remove(name)
+		require.NoError(t, err)
+		require.NoError(t, assertEvent(filepath, w.EventsCh(), defaultTimeout))
+	}
+}
+
+func TestEventWatcherDirMove(t *testing.T) {
+	filepath := testutil.TempDir(t, "temp_config1")
+
+	name := filepath + "/" + randomStr(20)
+	file, err := os.Create(name)
+	require.NoError(t, err)
+	err = file.Close()
+	require.NoError(t, err)
+	w, err := NewFileWatcher([]string{filepath}, hclog.New(&hclog.LoggerOptions{}))
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+
+	for i := 0; i < 100; i++ {
+		filepathTmp := createTempConfigFile(t, "temp_config2")
+		err = os.Rename(filepathTmp, name)
+		require.NoError(t, err)
+		require.NoError(t, assertEvent(filepath, w.EventsCh(), defaultTimeout))
+	}
+}
+
+func TestEventWatcherDirMoveTrim(t *testing.T) {
+	filepath := testutil.TempDir(t, "temp_config1")
+
+	name := filepath + "/" + randomStr(20)
+	file, err := os.Create(name)
+	require.NoError(t, err)
+	err = file.Close()
+	require.NoError(t, err)
+	w, err := NewFileWatcher([]string{filepath + "/"}, hclog.New(&hclog.LoggerOptions{}))
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+
+	for i := 0; i < 100; i++ {
+		filepathTmp := createTempConfigFile(t, "temp_config2")
+		err = os.Rename(filepathTmp, name)
+		require.NoError(t, err)
+		require.NoError(t, assertEvent(filepath, w.EventsCh(), defaultTimeout))
+	}
+}
+
+// Consul do not support configuration in sub-directories
+func TestEventWatcherSubDirMove(t *testing.T) {
+	filepath := testutil.TempDir(t, "temp_config1")
+	err := os.Mkdir(filepath+"/temp", 0777)
+	require.NoError(t, err)
+	name := filepath + "/temp/" + randomStr(20)
+	file, err := os.Create(name)
+	require.NoError(t, err)
+	err = file.Close()
+	require.NoError(t, err)
+	w, err := NewFileWatcher([]string{filepath}, hclog.New(&hclog.LoggerOptions{}))
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+
+	for i := 0; i < 2; i++ {
+		filepathTmp := createTempConfigFile(t, "temp_config2")
+		err = os.Rename(filepathTmp, name)
+		require.NoError(t, err)
+		require.Error(t, assertEvent(filepath, w.EventsCh(), defaultTimeout), "timedout waiting for event")
+	}
+}
+
+func TestEventWatcherDirRead(t *testing.T) {
+	filepath := testutil.TempDir(t, "temp_config1")
+
+	name := filepath + "/" + randomStr(20)
+	file, err := os.Create(name)
+	require.NoError(t, err)
+	err = file.Close()
+	require.NoError(t, err)
+	w, err := NewFileWatcher([]string{filepath}, hclog.New(&hclog.LoggerOptions{}))
+	require.NoError(t, err)
+	w.Start(context.Background())
+	t.Cleanup(func() {
+		_ = w.Stop()
+	})
+
+	_, err = os.ReadFile(name)
+	require.NoError(t, err)
+	require.Error(t, assertEvent(filepath, w.EventsCh(), defaultTimeout), "timedout waiting for event")
+}
+
+func TestEventWatcherMoveSoftLink(t *testing.T) {
+
+	filepath := createTempConfigFile(t, "temp_config1")
+	tempDir := testutil.TempDir(t, "temp_dir")
+	name := tempDir + "/" + randomStr(20)
+	err := os.Symlink(filepath, name)
+	require.NoError(t, err)
+
+	w, err := NewFileWatcher([]string{name}, hclog.New(&hclog.LoggerOptions{}))
+	require.NoError(t, err)
+	require.NotNil(t, w)
+
+}
+
+func assertEvent(name string, watcherCh chan *FileWatcherEvent, timeout time.Duration) error {
+	select {
+	case ev := <-watcherCh:
+		if ev.Filenames[0] != name && !strings.Contains(ev.Filenames[0], name) {
+			return fmt.Errorf("filename do not match %s %s", ev.Filenames[0], name)
+		}
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("timedout waiting for event")
+	}
+}
+
+func createTempConfigFile(t *testing.T, filename string) string {
+	file := testutil.TempFile(t, filename)
+
+	_, err1 := file.WriteString("test config")
+	err2 := file.Close()
+
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+
+	return file.Name()
+}
+
+func randomStr(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyz" +
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	var seededRand *rand.Rand = rand.New(
+		rand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}

--- a/command/agent/auth/cert/ratelimited_file_watcher.go
+++ b/command/agent/auth/cert/ratelimited_file_watcher.go
@@ -1,0 +1,90 @@
+package cert
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+type rateLimitedFileWatcher struct {
+	watcher          Watcher
+	eventCh          chan *FileWatcherEvent
+	coalesceInterval time.Duration
+}
+
+func (r *rateLimitedFileWatcher) Start(ctx context.Context) {
+	r.watcher.Start(ctx)
+	r.coalesceTimer(ctx, r.watcher.EventsCh(), r.coalesceInterval)
+}
+
+func (r rateLimitedFileWatcher) Stop() error {
+	return r.watcher.Stop()
+}
+
+func (r rateLimitedFileWatcher) Add(filename string) error {
+	return r.watcher.Add(filename)
+}
+
+func (r rateLimitedFileWatcher) Remove(filename string) {
+	r.watcher.Remove(filename)
+}
+
+func (r rateLimitedFileWatcher) Replace(oldFile, newFile string) error {
+	return r.watcher.Replace(oldFile, newFile)
+}
+
+func (r rateLimitedFileWatcher) EventsCh() chan *FileWatcherEvent {
+	return r.eventCh
+}
+
+func NewRateLimitedFileWatcher(configFiles []string, logger hclog.Logger, coalesceInterval time.Duration) (Watcher, error) {
+
+	watcher, err := NewFileWatcher(configFiles, logger)
+	if err != nil {
+		return nil, err
+	}
+	return &rateLimitedFileWatcher{
+		watcher:          watcher,
+		coalesceInterval: coalesceInterval,
+		eventCh:          make(chan *FileWatcherEvent),
+	}, nil
+}
+
+func (r rateLimitedFileWatcher) coalesceTimer(ctx context.Context, inputCh chan *FileWatcherEvent, coalesceDuration time.Duration) {
+	var (
+		coalesceTimer     *time.Timer
+		sendCh            = make(chan struct{})
+		fileWatcherEvents []string
+	)
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-inputCh:
+				if !ok {
+					if len(fileWatcherEvents) > 0 {
+						r.eventCh <- &FileWatcherEvent{Filenames: fileWatcherEvents}
+					}
+					close(r.eventCh)
+					return
+				}
+				fileWatcherEvents = append(fileWatcherEvents, event.Filenames...)
+				if coalesceTimer == nil {
+					coalesceTimer = time.AfterFunc(coalesceDuration, func() {
+						// This runs in another goroutine so we can't just do the send
+						// directly here as access to fileWatcherEvents is racy. Instead,
+						// signal the main loop above.
+						sendCh <- struct{}{}
+					})
+				}
+			case <-sendCh:
+				coalesceTimer = nil
+				r.eventCh <- &FileWatcherEvent{Filenames: fileWatcherEvents}
+				fileWatcherEvents = make([]string, 0)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}

--- a/command/agent/auth/cert/ratelimited_file_watcher_test.go
+++ b/command/agent/auth/cert/ratelimited_file_watcher_test.go
@@ -1,4 +1,4 @@
-package creds
+package cert
 
 import (
 	"context"

--- a/command/agent/auth/cert/ratelimited_file_watcher_test.go
+++ b/command/agent/auth/cert/ratelimited_file_watcher_test.go
@@ -1,0 +1,91 @@
+package creds
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRateLimitedWatcher(t *testing.T) {
+	w, err := NewRateLimitedFileWatcher([]string{}, hclog.New(&hclog.LoggerOptions{}), 1*time.Nanosecond)
+	require.NoError(t, err)
+	require.NotNil(t, w)
+}
+
+func TestRateLimitedWatcherRenameEvent(t *testing.T) {
+
+	fileTmp := createTempConfigFile(t, "temp_config3")
+	filepaths := []string{createTempConfigFile(t, "temp_config1"), createTempConfigFile(t, "temp_config2")}
+	w, err := NewRateLimitedFileWatcher(filepaths, hclog.New(&hclog.LoggerOptions{}), 1*time.Nanosecond)
+
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+
+	require.NoError(t, err)
+	err = os.Rename(fileTmp, filepaths[0])
+	time.Sleep(timeoutDuration + 50*time.Millisecond)
+	require.NoError(t, err)
+	require.NoError(t, assertEvent(filepaths[0], w.EventsCh(), defaultTimeout))
+	// make sure we consume all events
+	_ = assertEvent(filepaths[0], w.EventsCh(), defaultTimeout)
+}
+
+func TestRateLimitedWatcherAddNotExist(t *testing.T) {
+
+	file := testutil.TempFile(t, "temp_config")
+	filename := file.Name() + randomStr(16)
+	w, err := NewRateLimitedFileWatcher([]string{filename}, hclog.New(&hclog.LoggerOptions{}), 1*time.Nanosecond)
+	require.Error(t, err, "no such file or directory")
+	require.Nil(t, w)
+}
+
+func TestEventRateLimitedWatcherWrite(t *testing.T) {
+
+	file := testutil.TempFile(t, "temp_config")
+	_, err := file.WriteString("test config")
+	require.NoError(t, err)
+	err = file.Sync()
+	require.NoError(t, err)
+	w, err := NewRateLimitedFileWatcher([]string{file.Name()}, hclog.New(&hclog.LoggerOptions{}), 1*time.Nanosecond)
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+
+	_, err = file.WriteString("test config 2")
+	require.NoError(t, err)
+	err = file.Sync()
+	require.NoError(t, err)
+	require.NoError(t, assertEvent(file.Name(), w.EventsCh(), defaultTimeout))
+}
+
+func TestEventRateLimitedWatcherMove(t *testing.T) {
+
+	filepath := createTempConfigFile(t, "temp_config1")
+
+	w, err := NewRateLimitedFileWatcher([]string{filepath}, hclog.New(&hclog.LoggerOptions{}), 1*time.Second)
+	require.NoError(t, err)
+	w.Start(context.Background())
+	defer func() {
+		_ = w.Stop()
+	}()
+
+	for i := 0; i < 10; i++ {
+		filepath2 := createTempConfigFile(t, "temp_config2")
+		err = os.Rename(filepath2, filepath)
+		time.Sleep(timeoutDuration + 50*time.Millisecond)
+		require.NoError(t, err)
+	}
+	require.NoError(t, assertEvent(filepath, w.EventsCh(), defaultTimeout))
+	require.Error(t, assertEvent(filepath, w.EventsCh(), defaultTimeout), "expected timeout error")
+}


### PR DESCRIPTION
proof of concept for solving https://github.com/hashicorp/vault/issues/8216 piggy backing off of the work of:
+ https://github.com/hashicorp/consul/pull/12490
+ https://github.com/hashicorp/consul/pull/12329
+ https://github.com/hashicorp/consul/pull/12301

Instead of working on a SIGHUP based system, the cert AutoAuthMethod sets up a goroutine which watches the `CertFile` and `CertKey` for changes and invalidates the vault client if they change.

The current implementation has a weird quirk where the user must specify the `config` key like

```hcl
vault {
  address     = "https://vault.service.consul:8200"
  ca_cert     = "ca.pem"
  client_cert = "cert.pem"
  client_key  = "key.pem"
}

auto_auth {
  method "cert" {
    config = {
      ca_cert     = "ca.pem"
      client_cert = "cert.pem"
      client_key  = "key.pem"
    }
  }
}
```

since the only Config passed to the `NewCertAuthMethod` function must be explicit so the FileWatcher can be setup.

 It currently doesnt have:
- [ ] validation that both files are changed. This is mitigated by the 'coalesceInterval', but there is in theory a race condition here
- [ ] validation that when the files change, they result in a valid certificate. This will result in an upstream error so i think this is fine
- [ ] documentation changes since this is just a proof of concept

and I can also remove the added dependency to `github.com/hashicorp/consul/sdk/testutil`

I am happy to add/change any and all of these, but wanted to start the conversation to see if this is the approach that the vault maintainers want to take.