### PR TITLE
Update validate.mdx

### DIFF
--- a/website/content/api-docs/system/mfa/validate.mdx
+++ b/website/content/api-docs/system/mfa/validate.mdx
@@ -39,7 +39,6 @@ string slices. In cases where an MFA method is configured not to use passcodes, 
 
 ```shell-session
 $ curl \
-    --header "X-Vault-Token: ..." \
     --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/mfa/validate


### PR DESCRIPTION
Removed reference of ``` --header "X-Vault-Token: ..." \``` in Sample request. X-Vault-Token is not required for this endpoint.