### PR TITLE
docs: update token type for auth enable CLI command

### DIFF
--- a/website/content/docs/commands/auth/enable.mdx
+++ b/website/content/docs/commands/auth/enable.mdx
@@ -87,5 +87,4 @@ flags](/docs/commands) included on all commands.
   values stored by the mount to be wrapped by the seal's encryption capability.
 
 - `-token-type` `(string: "")` - Specifies the type of tokens that should be
-  returned by the auth method. Note that multiple keys may be
-  specified by providing this option multiple times, each time with 1 key.
+  returned by the auth method.

--- a/website/content/docs/commands/auth/enable.mdx
+++ b/website/content/docs/commands/auth/enable.mdx
@@ -85,3 +85,7 @@ flags](/docs/commands) included on all commands.
 
 - `-seal-wrap` `(bool: false)` - Enable seal wrapping for the mount, causing
   values stored by the mount to be wrapped by the seal's encryption capability.
+
+- `-token-type` `(string: "")` - Specifies the type of tokens that should be
+  returned by the auth method. Note that multiple keys may be
+  specified by providing this option multiple times, each time with 1 key.

--- a/website/content/docs/commands/auth/tune.mdx
+++ b/website/content/docs/commands/auth/tune.mdx
@@ -82,5 +82,4 @@ flags](/docs/commands) included on all commands.
   specified by providing this option multiple times, each time with 1 key.
 
 - `-token-type` `(string: "")` - Specifies the type of tokens that should be
-  returned by the auth method. Note that multiple keys may be
-  specified by providing this option multiple times, each time with 1 key.
+  returned by the auth method.


### PR DESCRIPTION
Token type is a valid option for the `auth enable` command.  This adds that to the documentation.