### PR TITLE
Docs: API secret/ssh clarity on Create & Update

### DIFF
--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -823,7 +823,7 @@ supports `create` and `update` policy capabilities as follows: if the user has
 `create` capability for this endpoint, and the key does not exist, it will be 
 created with the default parameters already configured. If the user only has 
 `update` capability and the SSH key does not exist, an error will be returned. 
-To fully manage the signing of SSH keys using a single role both `create` and 
+To fully manage the signing of SSH keys using a single role, both `create` and 
 `update` capabilities will be required.
 
 | Method | Path              |

--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -817,8 +817,14 @@ $ curl \
 
 ## Sign SSH Key
 
-This endpoint signs an SSH public key based on the supplied parameters, subject
-to the restrictions contained in the role named in the endpoint.
+This endpoint signs an SSH public key based on the supplied parameters, subject 
+to the restrictions contained in the role named in the endpoint. This path 
+supports `create` and `update` policy capabilities as follows: if the user has 
+`create` capability for this endpoint, and the key does not exist, it will be 
+created with the default parameters already configured. If the user only has 
+`update` capability and the SSH key does not exist, an error will be returned. 
+To fully manage the signing of SSH keys using a single role both `create` and 
+`update` capabilities will be required.
 
 | Method | Path              |
 | :----- | :---------------- |

--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -817,14 +817,13 @@ $ curl \
 
 ## Sign SSH Key
 
-This endpoint signs an SSH public key based on the supplied parameters, subject 
-to the restrictions contained in the role named of the endpoint. This path 
-supports `create` and `update` policy capabilities as follows: if the user has 
-`create` capability for this endpoint, and the key does not exist, it will be 
-created with the default parameters already configured. If the user only has 
-`update` capability and the SSH key does not exist, an error will be returned. 
-To fully manage the signing of SSH keys using a single role, both `create` and 
-`update` capabilities will be required.
+This endpoint signs an SSH public key based on the supplied parameters and 
+subject to the restrictions of the role named in the path. Both `create` and 
+`update` policy capabilities are needed to sign and update SSH keys. If only 
+`create` capability is granted, and a SSH key does not exist, it will be created 
+using the default parameters already configured. If only `update` capability is 
+available and a SSH key does not exist, an error will be returned and SSH keys 
+must exist already before may be updated.
 
 | Method | Path              |
 | :----- | :---------------- |

--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -818,7 +818,7 @@ $ curl \
 ## Sign SSH Key
 
 This endpoint signs an SSH public key based on the supplied parameters, subject 
-to the restrictions contained in the role named in the endpoint. This path 
+to the restrictions contained in the role named of the endpoint. This path 
 supports `create` and `update` policy capabilities as follows: if the user has 
 `create` capability for this endpoint, and the key does not exist, it will be 
 created with the default parameters already configured. If the user only has 


### PR DESCRIPTION
Added clarity notes on required permissions (`update` & `create`) that's otherwise not obvious without experience of other mounts that have requirements for similar ACL to manage. Resolves #9888.