### PR TITLE
Fix LinkTo @query param on KMSE

### DIFF
--- a/ui/app/templates/components/keymgmt/key-edit.hbs
+++ b/ui/app/templates/components/keymgmt/key-edit.hbs
@@ -134,7 +134,7 @@
               <LinkTo
                 @route={{if this.isCreating @root.path "vault.cluster.secrets.backend.show"}}
                 @model={{if this.isCreating @root.model @model.id}}
-                @query={{unless this.isCreating (hash itemType="key")}}
+                @query={{unless this.isCreating (hash itemType="key") (hash itemType="")}}
                 @disabled={{this.savekey.isRunning}}
                 class="button"
                 data-test-keymgmt-key-cancel


### PR DESCRIPTION
[The following test](https://app.circleci.com/pipelines/github/hashicorp/vault-enterprise/16638/workflows/56da18b4-1798-4945-9738-b3b9a837ad7f/jobs/406447) was failing on enterprise because the unless was passing an empty object to the `LinkTo @query` param. 

Acceptance | Enterprise | keymgmt: it should add new key and distribute to provider.

![image](https://user-images.githubusercontent.com/6618863/188758654-8bf7afea-c88a-489e-83bf-c14d2b039d99.png)

I did a search for similar situations on query but we have a LOT of LinkTos, so it was tough to look through them all. If anyone has any thoughts of why suddenly this would fail, I'm all ears. I've been running enterprise locally for PKI work and haven't seen the failure, but I'm seeing it now on main. There doesn't appear to be any PRs that touched this code recently either.

Notes: I ran test locally, they failed on this test before the fix and don't fail after the fix.