### PR TITLE
Mark database-specific secrets engines Pending Removal

### DIFF
--- a/changelog/17038.txt
+++ b/changelog/17038.txt
@@ -1,0 +1,3 @@
+```release-note:change
+secrets: All database-specific (standalone DB) secrets engines are now marked `Pending Removal`.
+```

--- a/command/secrets_enable_test.go
+++ b/command/secrets_enable_test.go
@@ -243,7 +243,7 @@ func TestSecretsEnableCommand_Run(t *testing.T) {
 		}
 
 		for _, b := range backends {
-			var expectedResult int = 0
+			expectedResult := 0
 			status, _ := builtinplugins.Registry.DeprecationStatus(b, consts.PluginTypeSecrets)
 			allowDeprecated := os.Getenv(consts.VaultAllowPendingRemovalMountsEnv)
 

--- a/command/secrets_enable_test.go
+++ b/command/secrets_enable_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -242,14 +243,23 @@ func TestSecretsEnableCommand_Run(t *testing.T) {
 		}
 
 		for _, b := range backends {
+			var expectedResult int = 0
+			status, _ := builtinplugins.Registry.DeprecationStatus(b, consts.PluginTypeSecrets)
+			allowDeprecated := os.Getenv(consts.VaultAllowPendingRemovalMountsEnv)
+
+			// Need to handle deprecated builtins specially
+			if (status == consts.PendingRemoval && allowDeprecated == "") || status == consts.Removed {
+				expectedResult = 2
+			}
+
 			ui, cmd := testSecretsEnableCommand(t)
 			cmd.client = client
 
-			code := cmd.Run([]string{
+			actualResult := cmd.Run([]string{
 				b,
 			})
-			if exp := 0; code != exp {
-				t.Errorf("type %s, expected %d to be %d - %s", b, code, exp, ui.OutputWriter.String()+ui.ErrorWriter.String())
+			if actualResult != expectedResult {
+				t.Errorf("type: %s - got: %d, expected: %d - %s", b, actualResult, expectedResult, ui.OutputWriter.String()+ui.ErrorWriter.String())
 			}
 		}
 	})

--- a/helper/builtinplugins/registry.go
+++ b/helper/builtinplugins/registry.go
@@ -141,7 +141,7 @@ func newRegistry() *registry {
 			"azure":    {Factory: logicalAzure.Factory},
 			"cassandra": {
 				Factory:           logicalCass.Factory,
-				DeprecationStatus: consts.Deprecated,
+				DeprecationStatus: consts.PendingRemoval,
 			},
 			"consul":     {Factory: logicalConsul.Factory},
 			"gcp":        {Factory: logicalGcp.Factory},
@@ -150,23 +150,23 @@ func newRegistry() *registry {
 			"kv":         {Factory: logicalKv.Factory},
 			"mongodb": {
 				Factory:           logicalMongo.Factory,
-				DeprecationStatus: consts.Deprecated,
+				DeprecationStatus: consts.PendingRemoval,
 			},
 			"mongodbatlas": {Factory: logicalMongoAtlas.Factory},
 			"mssql": {
 				Factory:           logicalMssql.Factory,
-				DeprecationStatus: consts.Deprecated,
+				DeprecationStatus: consts.PendingRemoval,
 			},
 			"mysql": {
 				Factory:           logicalMysql.Factory,
-				DeprecationStatus: consts.Deprecated,
+				DeprecationStatus: consts.PendingRemoval,
 			},
 			"nomad":    {Factory: logicalNomad.Factory},
 			"openldap": {Factory: logicalOpenLDAP.Factory},
 			"pki":      {Factory: logicalPki.Factory},
 			"postgresql": {
 				Factory:           logicalPostgres.Factory,
-				DeprecationStatus: consts.Deprecated,
+				DeprecationStatus: consts.PendingRemoval,
 			},
 			"rabbitmq":  {Factory: logicalRabbit.Factory},
 			"ssh":       {Factory: logicalSsh.Factory},

--- a/helper/builtinplugins/registry_test.go
+++ b/helper/builtinplugins/registry_test.go
@@ -180,8 +180,8 @@ func Test_RegistryStatus(t *testing.T) {
 		},
 		{
 			name:       "deprecated builtin lookup",
-			builtin:    "mongodb",
-			pluginType: consts.PluginTypeSecrets,
+			builtin:    "pcf",
+			pluginType: consts.PluginTypeCredential,
 			want:       consts.Deprecated,
 			wantOk:     true,
 		},


### PR DESCRIPTION
This PR marks the database-specific secrets engines (standalone DB) as `Pending Removal` and updates associated tests so they pass. These database engines will now be subject to the deprecation handling introduced in https://github.com/hashicorp/vault/pull/17005