### PR TITLE
Store login MFA secret with tokenhelper

### DIFF
--- a/changelog/17040.txt
+++ b/changelog/17040.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+login: Store token in tokenhelper for interactive login MFA
+```

--- a/command/base.go
+++ b/command/base.go
@@ -274,11 +274,6 @@ func (c *BaseCommand) validateMFA(reqID string, methodInfo MFAMethodInfo) (*api.
 		return secret, err
 	}
 
-	// Don't output anything unless using the "table" format
-	if Format(c.UI) == "table" {
-		c.UI.Info("Success! Data written to: sys/mfa/validate")
-	}
-
 	return secret, nil
 }
 

--- a/command/base.go
+++ b/command/base.go
@@ -222,7 +222,7 @@ func (c *BaseCommand) DefaultWrappingLookupFunc(operation, path string) string {
 // getInteractiveMFAMethodInfo returns MFA method information only if operating
 // in interactive mode and one MFA method is configured.
 func (c *BaseCommand) getInteractiveMFAMethodInfo(secret *api.Secret) *MFAMethodInfo {
-	if secret != nil && secret.Auth != nil && secret.Auth.MFARequirement != nil {
+	if secret == nil || secret.Auth == nil || secret.Auth.MFARequirement == nil {
 		return nil
 	}
 

--- a/command/base.go
+++ b/command/base.go
@@ -219,6 +219,18 @@ func (c *BaseCommand) DefaultWrappingLookupFunc(operation, path string) string {
 	return api.DefaultWrappingLookupFunc(operation, path)
 }
 
+func (c *BaseCommand) getMFAValidationRequired(secret *api.Secret) bool {
+	if secret != nil && secret.Auth != nil && secret.Auth.MFARequirement != nil {
+		if c.flagMFA == nil && len(secret.Auth.MFARequirement.MFAConstraints) == 1 {
+			return true
+		} else if len(secret.Auth.MFARequirement.MFAConstraints) > 1 {
+			return true
+		}
+	}
+
+	return false
+}
+
 // getInteractiveMFAMethodInfo returns MFA method information only if operating
 // in interactive mode and one MFA method is configured.
 func (c *BaseCommand) getInteractiveMFAMethodInfo(secret *api.Secret) *MFAMethodInfo {

--- a/command/base.go
+++ b/command/base.go
@@ -219,6 +219,9 @@ func (c *BaseCommand) DefaultWrappingLookupFunc(operation, path string) string {
 	return api.DefaultWrappingLookupFunc(operation, path)
 }
 
+// getValidationRequired checks to see if the secret exists and has an MFA
+// requirement. If MFA is required and the number of constraints is greater than
+// 1, we can assert that interactive validation is not required.
 func (c *BaseCommand) getMFAValidationRequired(secret *api.Secret) bool {
 	if secret != nil && secret.Auth != nil && secret.Auth.MFARequirement != nil {
 		if c.flagMFA == nil && len(secret.Auth.MFARequirement.MFAConstraints) == 1 {

--- a/command/base.go
+++ b/command/base.go
@@ -284,12 +284,7 @@ func (c *BaseCommand) validateMFA(reqID string, methodInfo MFAMethodInfo) (*api.
 		return nil, err
 	}
 
-	secret, err := client.Sys().MFAValidate(reqID, mfaPayload)
-	if err != nil {
-		return secret, err
-	}
-
-	return secret, nil
+	return client.Sys().MFAValidate(reqID, mfaPayload)
 }
 
 type FlagSetBit uint

--- a/command/login.go
+++ b/command/login.go
@@ -234,7 +234,11 @@ func (c *LoginCommand) Run(args []string) int {
 			// request is validated interactively
 			methodInfo := c.getMFAMethodInfo(secret.Auth.MFARequirement.MFAConstraints)
 			if methodInfo.methodID != "" {
-				return c.validateMFA(secret.Auth.MFARequirement.MFARequestID, methodInfo)
+				secret, err = c.validateMFA(secret.Auth.MFARequirement.MFARequestID, methodInfo)
+				if err != nil {
+					c.UI.Error(err.Error())
+					return 2
+				}
 			}
 		}
 		c.UI.Warn(wrapAtLength("A login request was issued that is subject to "+
@@ -243,7 +247,6 @@ func (c *LoginCommand) Run(args []string) int {
 
 		// We return early to prevent success message from being printed
 		c.checkForAndWarnAboutLoginToken()
-		return OutputSecret(c.UI, secret)
 	}
 
 	// Unset any previous token wrapping functionality. If the original request

--- a/command/login.go
+++ b/command/login.go
@@ -230,19 +230,23 @@ func (c *LoginCommand) Run(args []string) int {
 
 	// If there is only one MFA method configured and c.NonInteractive flag is
 	// unset, the login request is validated interactively.
+	//
 	// interactiveMethodInfo here means that `validateMFA` will complete the MFA
-	// by prompting for a password or directing you to a push notification. In this scenario, no external validation is needed.
+	// by prompting for a password or directing you to a push notification. In
+	// this scenario, no external validation is needed.
 	interactiveMethodInfo := c.getInteractiveMFAMethodInfo(secret)
 	if interactiveMethodInfo != nil {
+		c.UI.Warn("Initiating Iteractive MFA Validation...")
 		secret, err = c.validateMFA(secret.Auth.MFARequirement.MFARequestID, *interactiveMethodInfo)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2
 		}
-	} else {
+	} else if c.getMFAValidationRequired(secret) {
 		c.UI.Warn(wrapAtLength("A login request was issued that is subject to "+
 			"MFA validation. Please make sure to validate the login by sending another "+
 			"request to sys/mfa/validate endpoint.") + "\n")
+		return OutputSecret(c.UI, secret)
 	}
 
 	// Unset any previous token wrapping functionality. If the original request

--- a/command/login.go
+++ b/command/login.go
@@ -228,25 +228,20 @@ func (c *LoginCommand) Run(args []string) int {
 		return 2
 	}
 
-	if secret != nil && secret.Auth != nil && secret.Auth.MFARequirement != nil {
-		if c.isInteractiveEnabled(len(secret.Auth.MFARequirement.MFAConstraints)) {
-			// Currently, if there is only one MFA method configured, the login
-			// request is validated interactively
-			methodInfo := c.getMFAMethodInfo(secret.Auth.MFARequirement.MFAConstraints)
-			if methodInfo.methodID != "" {
-				secret, err = c.validateMFA(secret.Auth.MFARequirement.MFARequestID, methodInfo)
-				if err != nil {
-					c.UI.Error(err.Error())
-					return 2
-				}
-			}
+	// If there is only one MFA method configured and c.NonInteractive flag is
+	// unset, the login request is validated interactively.
+	// interactiveMethodInfo here means that `validateMFA` will complete the MFA
+	// by prompting for a password or directing you to a push notification. In this scenario, no external validation is needed.
+	interactiveMethodInfo := c.getInteractiveMFAMethodInfo(secret)
+	if interactiveMethodInfo != nil {
+		secret, err = c.validateMFA(secret.Auth.MFARequirement.MFARequestID, *interactiveMethodInfo)
+		if err != nil {
+			c.UI.Error(err.Error())
 		}
+	} else {
 		c.UI.Warn(wrapAtLength("A login request was issued that is subject to "+
 			"MFA validation. Please make sure to validate the login by sending another "+
 			"request to sys/mfa/validate endpoint.") + "\n")
-
-		// We return early to prevent success message from being printed
-		c.checkForAndWarnAboutLoginToken()
 	}
 
 	// Unset any previous token wrapping functionality. If the original request

--- a/command/login.go
+++ b/command/login.go
@@ -243,6 +243,9 @@ func (c *LoginCommand) Run(args []string) int {
 			return 2
 		}
 	} else if c.getMFAValidationRequired(secret) {
+		// Warn about existing login token, but return here, since the secret
+		// won't have any token information if further validation is required.
+		c.checkForAndWarnAboutLoginToken()
 		c.UI.Warn(wrapAtLength("A login request was issued that is subject to "+
 			"MFA validation. Please make sure to validate the login by sending another "+
 			"request to sys/mfa/validate endpoint.") + "\n")

--- a/command/login.go
+++ b/command/login.go
@@ -237,6 +237,7 @@ func (c *LoginCommand) Run(args []string) int {
 		secret, err = c.validateMFA(secret.Auth.MFARequirement.MFARequestID, *interactiveMethodInfo)
 		if err != nil {
 			c.UI.Error(err.Error())
+			return 2
 		}
 	} else {
 		c.UI.Warn(wrapAtLength("A login request was issued that is subject to "+

--- a/command/login_test.go
+++ b/command/login_test.go
@@ -10,6 +10,7 @@ import (
 	credToken "github.com/hashicorp/vault/builtin/credential/token"
 	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/command/token"
+	"github.com/hashicorp/vault/helper/testhelpers"
 	"github.com/hashicorp/vault/vault"
 )
 
@@ -425,6 +426,93 @@ func TestLoginCommand_Run(t *testing.T) {
 		output := ui.OutputWriter.String() + ui.ErrorWriter.String()
 		if !strings.Contains(output, expected) {
 			t.Errorf("expected %q to contain %q", output, expected)
+		}
+	})
+
+	t.Run("login_mfa_single_phase", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServer(t)
+		defer closer()
+
+		ui, cmd := testLoginCommand(t)
+
+		userclient, entityID, methodID := testhelpers.SetupLoginMFATOTP(t, client)
+		cmd.client = userclient
+
+		enginePath := testhelpers.RegisterEntityInTOTPEngine(t, client, entityID, methodID)
+		totpCode := testhelpers.GetTOTPCodeFromEngine(t, client, enginePath)
+
+		// login command bails early for test clients, so we have to explicitly set this
+		cmd.client.SetMFACreds([]string{methodID + ":" + totpCode})
+		code := cmd.Run([]string{
+			"-method", "userpass",
+			"username=testuser1",
+			"password=testpassword",
+		})
+		if exp := 0; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		tokenHelper, err := cmd.TokenHelper()
+		if err != nil {
+			t.Fatal(err)
+		}
+		storedToken, err := tokenHelper.Get()
+		if err != nil {
+			t.Fatal(err)
+		}
+		output = ui.OutputWriter.String() + ui.ErrorWriter.String()
+		t.Logf("\n%+v", output)
+		if !strings.Contains(output, storedToken) {
+			t.Fatalf("expected stored token: %q, got: %q", storedToken, output)
+		}
+	})
+
+	t.Run("login_mfa_two_phase", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServer(t)
+		defer closer()
+
+		ui, cmd := testLoginCommand(t)
+
+		userclient, entityID, methodID := testhelpers.SetupLoginMFATOTP(t, client)
+		cmd.client = userclient
+
+		_ = testhelpers.RegisterEntityInTOTPEngine(t, client, entityID, methodID)
+		// totpCode := testhelpers.GetTOTPCodeFromEngine(t, client, enginePath)
+
+		// login command bails early for test clients, so we have to explicitly set this
+		cmd.client.SetMFACreds([]string{})
+
+		// testhelpers.SetupLoginMFATOTP(t, client)
+		code := cmd.Run([]string{
+			"-method", "userpass",
+			"username=testuser1",
+			"password=testpassword",
+		})
+		if exp := 0; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := methodID
+		output = ui.OutputWriter.String() + ui.ErrorWriter.String()
+		t.Logf("\n%+v", output)
+		if !strings.Contains(output, expected) {
+			t.Fatalf("expected stored token: %q, got: %q", expected, output)
+		}
+
+		tokenHelper, err := cmd.TokenHelper()
+		if err != nil {
+			t.Fatal(err)
+		}
+		storedToken, err := tokenHelper.Get()
+		if storedToken != "" {
+			t.Fatal("expected empty stored token")
+		}
+		if err != nil {
+			t.Fatal(err)
 		}
 	})
 

--- a/command/login_test.go
+++ b/command/login_test.go
@@ -481,12 +481,10 @@ func TestLoginCommand_Run(t *testing.T) {
 		cmd.client = userclient
 
 		_ = testhelpers.RegisterEntityInTOTPEngine(t, client, entityID, methodID)
-		// totpCode := testhelpers.GetTOTPCodeFromEngine(t, client, enginePath)
 
-		// login command bails early for test clients, so we have to explicitly set this
+		// clear the MFA creds just to be sure
 		cmd.client.SetMFACreds([]string{})
 
-		// testhelpers.SetupLoginMFATOTP(t, client)
 		code := cmd.Run([]string{
 			"-method", "userpass",
 			"username=testuser1",

--- a/command/write.go
+++ b/command/write.go
@@ -159,7 +159,10 @@ func (c *WriteCommand) Run(args []string) int {
 			// request is validated interactively
 			methodInfo := c.getMFAMethodInfo(secret.Auth.MFARequirement.MFAConstraints)
 			if methodInfo.methodID != "" {
-				return c.validateMFA(secret.Auth.MFARequirement.MFARequestID, methodInfo)
+				secret, err = c.validateMFA(secret.Auth.MFARequirement.MFARequestID, methodInfo)
+				if err != nil {
+					c.UI.Error(err.Error())
+				}
 			}
 		}
 		c.UI.Warn(wrapAtLength("A login request was issued that is subject to "+

--- a/command/write.go
+++ b/command/write.go
@@ -153,18 +153,15 @@ func (c *WriteCommand) Run(args []string) int {
 		return 0
 	}
 
-	if secret != nil && secret.Auth != nil && secret.Auth.MFARequirement != nil {
-		if c.isInteractiveEnabled(len(secret.Auth.MFARequirement.MFAConstraints)) {
-			// Currently, if there is only one MFA method configured, the login
-			// request is validated interactively
-			methodInfo := c.getMFAMethodInfo(secret.Auth.MFARequirement.MFAConstraints)
-			if methodInfo.methodID != "" {
-				secret, err = c.validateMFA(secret.Auth.MFARequirement.MFARequestID, methodInfo)
-				if err != nil {
-					c.UI.Error(err.Error())
-				}
-			}
+	// Currently, if there is only one MFA method configured, the login
+	// request is validated interactively
+	methodInfo := c.getInteractiveMFAMethodInfo(secret)
+	if methodInfo != nil {
+		secret, err = c.validateMFA(secret.Auth.MFARequirement.MFARequestID, *methodInfo)
+		if err != nil {
+			c.UI.Error(err.Error())
 		}
+	} else {
 		c.UI.Warn(wrapAtLength("A login request was issued that is subject to "+
 			"MFA validation. Please make sure to validate the login by sending another "+
 			"request to sys/mfa/validate endpoint.") + "\n")

--- a/command/write.go
+++ b/command/write.go
@@ -162,7 +162,7 @@ func (c *WriteCommand) Run(args []string) int {
 			c.UI.Error(err.Error())
 			return 2
 		}
-	} else {
+	} else if c.getMFAValidationRequired(secret) {
 		c.UI.Warn(wrapAtLength("A login request was issued that is subject to "+
 			"MFA validation. Please make sure to validate the login by sending another "+
 			"request to sys/mfa/validate endpoint.") + "\n")

--- a/command/write.go
+++ b/command/write.go
@@ -160,6 +160,7 @@ func (c *WriteCommand) Run(args []string) int {
 		secret, err = c.validateMFA(secret.Auth.MFARequirement.MFARequestID, *methodInfo)
 		if err != nil {
 			c.UI.Error(err.Error())
+			return 2
 		}
 	} else {
 		c.UI.Warn(wrapAtLength("A login request was issued that is subject to "+

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -818,14 +818,7 @@ func CreateEntityAndAlias(t testing.T, client *api.Client, mountAccessor, entity
 	return userClient, entityID, aliasID
 }
 
-func SetupAudit(t testing.T, client *api.Client) {
-	t.Helper()
-	// Enable the audit backend
-	if err := client.Sys().EnableAuditWithOptions("noop", &api.EnableAuditOptions{Type: "noop"}); err != nil {
-		t.Fatal(err)
-	}
-}
-
+// SetupTOTPMount enables the totp secrets engine by mounting it.
 func SetupTOTPMount(t testing.T, client *api.Client) {
 	t.Helper()
 	// Mount the TOTP backend
@@ -837,6 +830,7 @@ func SetupTOTPMount(t testing.T, client *api.Client) {
 	}
 }
 
+// SetupTOTPMethod configures the TOTP secrets engine with a provided config map.
 func SetupTOTPMethod(t testing.T, client *api.Client, config map[string]interface{}) string {
 	t.Helper()
 
@@ -854,6 +848,8 @@ func SetupTOTPMethod(t testing.T, client *api.Client, config map[string]interfac
 	return methodID
 }
 
+// SetupMFALoginEnforcement configures a single enforcement method with name
+// "randomName" using the provided config map.
 func SetupMFALoginEnforcement(t testing.T, client *api.Client, config map[string]interface{}) {
 	_, err := client.Logical().WriteWithContext(context.Background(), "identity/mfa/login-enforcement/randomName", config)
 	if err != nil {
@@ -861,6 +857,7 @@ func SetupMFALoginEnforcement(t testing.T, client *api.Client, config map[string
 	}
 }
 
+// SetupUserpassMountAccessor sets up userpass auth and returns its mount accessor.
 func SetupUserpassMountAccessor(t testing.T, client *api.Client) string {
 	t.Helper()
 	var mountAccessor string
@@ -885,6 +882,8 @@ func SetupUserpassMountAccessor(t testing.T, client *api.Client) string {
 	return mountAccessor
 }
 
+// RegisterEntityInTOTPEngine registers an entity with a methodID and returns
+// the generated name.
 func RegisterEntityInTOTPEngine(t testing.T, client *api.Client, entityID, methodID string) string {
 	t.Helper()
 	totpGenName := fmt.Sprintf("%s-%s", entityID, methodID)
@@ -917,6 +916,7 @@ func RegisterEntityInTOTPEngine(t testing.T, client *api.Client, entityID, metho
 	return totpGenName
 }
 
+// GetTOTPCodeFromEngine requests a TOTP code from the specified enginePath.
 func GetTOTPCodeFromEngine(t testing.T, client *api.Client, enginePath string) string {
 	t.Helper()
 	totpPath := fmt.Sprintf("totp/code/%s", enginePath)
@@ -930,6 +930,8 @@ func GetTOTPCodeFromEngine(t testing.T, client *api.Client, enginePath string) s
 	return secret.Data["code"].(string)
 }
 
+// SetupLoginMFATOTP setups up a TOTP MFA using some basic configuration and
+// returns all relevant information to the client.
 func SetupLoginMFATOTP(t testing.T, client *api.Client) (*api.Client, string, string) {
 	t.Helper()
 	// Mount the totp secrets engine
@@ -944,7 +946,7 @@ func SetupLoginMFATOTP(t testing.T, client *api.Client) (*api.Client, string, st
 	// Configure a default TOTP method
 	totpConfig := map[string]interface{}{
 		"issuer":                  "yCorp",
-		"period":                  30,
+		"period":                  5,
 		"algorithm":               "SHA256",
 		"digits":                  6,
 		"skew":                    0,

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -851,8 +851,8 @@ func SetupTOTPMethod(t testing.T, client *api.Client, config map[string]interfac
 	return methodID
 }
 
-// SetupMFALoginEnforcement configures a single enforcement method with name
-// "randomName" using the provided config map.
+// SetupMFALoginEnforcement configures a single enforcement method using the
+// provided config map. "name" field is required in the config map.
 func SetupMFALoginEnforcement(t testing.T, client *api.Client, config map[string]interface{}) {
 	t.Helper()
 	enfName, ok := config["name"]

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -780,6 +780,8 @@ func RetryUntil(t testing.T, timeout time.Duration, f func() error) {
 	t.Fatalf("did not complete before deadline, err: %v", err)
 }
 
+// CreateEntityAndAlias clones an existing client and creates an entity/alias.
+// It returns the cloned client, entityID, and aliasID.
 func CreateEntityAndAlias(t testing.T, client *api.Client, mountAccessor, entityName, aliasName string) (*api.Client, string, string) {
 	t.Helper()
 	userClient, err := client.Clone()
@@ -851,6 +853,7 @@ func SetupTOTPMethod(t testing.T, client *api.Client, config map[string]interfac
 // SetupMFALoginEnforcement configures a single enforcement method with name
 // "randomName" using the provided config map.
 func SetupMFALoginEnforcement(t testing.T, client *api.Client, config map[string]interface{}) {
+	t.Helper()
 	_, err := client.Logical().WriteWithContext(context.Background(), "identity/mfa/login-enforcement/randomName", config)
 	if err != nil {
 		t.Fatalf("failed to configure MFAEnforcementConfig: %v", err)

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -820,7 +820,8 @@ func CreateEntityAndAlias(t testing.T, client *api.Client, mountAccessor, entity
 	return userClient, entityID, aliasID
 }
 
-// SetupTOTPMount enables the totp secrets engine by mounting it.
+// SetupTOTPMount enables the totp secrets engine by mounting it. This requires
+// that the test cluster has a totp backend available.
 func SetupTOTPMount(t testing.T, client *api.Client) {
 	t.Helper()
 	// Mount the TOTP backend
@@ -860,7 +861,9 @@ func SetupMFALoginEnforcement(t testing.T, client *api.Client, config map[string
 	}
 }
 
-// SetupUserpassMountAccessor sets up userpass auth and returns its mount accessor.
+// SetupUserpassMountAccessor sets up userpass auth and returns its mount
+// accessor. This requires that the test cluster has a "userpass" auth method
+// available.
 func SetupUserpassMountAccessor(t testing.T, client *api.Client) string {
 	t.Helper()
 	var mountAccessor string

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -855,7 +855,11 @@ func SetupTOTPMethod(t testing.T, client *api.Client, config map[string]interfac
 // "randomName" using the provided config map.
 func SetupMFALoginEnforcement(t testing.T, client *api.Client, config map[string]interface{}) {
 	t.Helper()
-	_, err := client.Logical().WriteWithContext(context.Background(), "identity/mfa/login-enforcement/randomName", config)
+	enfName, ok := config["name"]
+	if !ok {
+		t.Fatalf("couldn't find name in login-enforcement config")
+	}
+	_, err := client.Logical().WriteWithContext(context.Background(), fmt.Sprintf("identity/mfa/login-enforcement/%s", enfName), config)
 	if err != nil {
 		t.Fatalf("failed to configure MFAEnforcementConfig: %v", err)
 	}

--- a/vault/external_tests/identity/aliases_test.go
+++ b/vault/external_tests/identity/aliases_test.go
@@ -12,6 +12,7 @@ import (
 	auth "github.com/hashicorp/vault/api/auth/userpass"
 	"github.com/hashicorp/vault/builtin/credential/github"
 	"github.com/hashicorp/vault/builtin/credential/userpass"
+	"github.com/hashicorp/vault/helper/testhelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
@@ -301,7 +302,7 @@ func TestIdentityStore_MergeEntities_FailsDueToClash(t *testing.T) {
 		t.Fatal("did not find userpass accessor")
 	}
 
-	_, entityIdBob, aliasIdBob := createEntityAndAlias(client, mountAccessor, "bob-smith", "bob", t)
+	_, entityIdBob, aliasIdBob := testhelpers.CreateEntityAndAlias(t, client, mountAccessor, "bob-smith", "bob")
 
 	// Create userpass login for alice
 	_, err = client.Logical().Write("auth/userpass/users/alice", map[string]interface{}{
@@ -311,7 +312,7 @@ func TestIdentityStore_MergeEntities_FailsDueToClash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, entityIdAlice, aliasIdAlice := createEntityAndAlias(client, mountAccessor, "alice-smith", "alice", t)
+	_, entityIdAlice, aliasIdAlice := testhelpers.CreateEntityAndAlias(t, client, mountAccessor, "alice-smith", "alice")
 
 	// Perform entity merge
 	mergeResp, err := client.Logical().Write("identity/entity/merge", map[string]interface{}{
@@ -404,9 +405,9 @@ func TestIdentityStore_MergeEntities_FailsDueToClashInFromEntities(t *testing.T)
 		t.Fatal("did not find github accessor")
 	}
 
-	_, entityIdBob, _ := createEntityAndAlias(client, mountAccessor, "bob-smith", "bob", t)
-	_, entityIdAlice, _ := createEntityAndAlias(client, mountAccessorGitHub, "alice-smith", "alice", t)
-	_, entityIdClara, _ := createEntityAndAlias(client, mountAccessorGitHub, "clara-smith", "clara", t)
+	_, entityIdBob, _ := testhelpers.CreateEntityAndAlias(t, client, mountAccessor, "bob-smith", "bob")
+	_, entityIdAlice, _ := testhelpers.CreateEntityAndAlias(t, client, mountAccessorGitHub, "alice-smith", "alice")
+	_, entityIdClara, _ := testhelpers.CreateEntityAndAlias(t, client, mountAccessorGitHub, "clara-smith", "clara")
 
 	// Perform entity merge
 	mergeResp, err := client.Logical().Write("identity/entity/merge", map[string]interface{}{
@@ -491,7 +492,7 @@ func TestIdentityStore_MergeEntities_FailsDueToDoubleClash(t *testing.T) {
 		t.Fatal("did not find github accessor")
 	}
 
-	_, entityIdBob, aliasIdBob := createEntityAndAlias(client, mountAccessor, "bob-smith", "bob", t)
+	_, entityIdBob, aliasIdBob := testhelpers.CreateEntityAndAlias(t, client, mountAccessor, "bob-smith", "bob")
 
 	aliasResp, err := client.Logical().Write("identity/entity-alias", map[string]interface{}{
 		"name":           "bob-github",
@@ -515,8 +516,8 @@ func TestIdentityStore_MergeEntities_FailsDueToDoubleClash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, entityIdAlice, aliasIdAlice := createEntityAndAlias(client, mountAccessor, "alice-smith", "alice", t)
-	_, entityIdClara, aliasIdClara := createEntityAndAlias(client, mountAccessorGitHub, "clara-smith", "clara", t)
+	_, entityIdAlice, aliasIdAlice := testhelpers.CreateEntityAndAlias(t, client, mountAccessor, "alice-smith", "alice")
+	_, entityIdClara, aliasIdClara := testhelpers.CreateEntityAndAlias(t, client, mountAccessorGitHub, "clara-smith", "clara")
 
 	// Perform entity merge
 	mergeResp, err := client.Logical().Write("identity/entity/merge", map[string]interface{}{
@@ -602,7 +603,7 @@ func TestIdentityStore_MergeEntities_FailsDueToClashInFromEntities_CheckRawReque
 		t.Fatal("did not find userpass accessor")
 	}
 
-	_, entityIdBob, _ := createEntityAndAlias(client, mountAccessor, "bob-smith", "bob", t)
+	_, entityIdBob, _ := testhelpers.CreateEntityAndAlias(t, client, mountAccessor, "bob-smith", "bob")
 
 	// Create userpass login for alice
 	_, err = client.Logical().Write("auth/userpass/users/alice", map[string]interface{}{
@@ -612,7 +613,7 @@ func TestIdentityStore_MergeEntities_FailsDueToClashInFromEntities_CheckRawReque
 		t.Fatal(err)
 	}
 
-	_, entityIdAlice, _ := createEntityAndAlias(client, mountAccessor, "alice-smith", "alice", t)
+	_, entityIdAlice, _ := testhelpers.CreateEntityAndAlias(t, client, mountAccessor, "alice-smith", "alice")
 
 	// Perform entity merge as a Raw Request so we can investigate the response body
 	req := client.NewRequest("POST", "/v1/identity/entity/merge")
@@ -772,7 +773,7 @@ func TestIdentityStore_MergeEntities_SameMountAccessor_ThenUseAlias(t *testing.T
 		t.Fatal("did not find userpass accessor")
 	}
 
-	_, entityIdBob, aliasIdBob := createEntityAndAlias(client, mountAccessor, "bob-smith", "bob", t)
+	_, entityIdBob, aliasIdBob := testhelpers.CreateEntityAndAlias(t, client, mountAccessor, "bob-smith", "bob")
 
 	// Create userpass login for alice
 	_, err = client.Logical().Write("auth/userpass/users/alice", map[string]interface{}{
@@ -788,7 +789,7 @@ func TestIdentityStore_MergeEntities_SameMountAccessor_ThenUseAlias(t *testing.T
 		t.Fatal(err)
 	}
 
-	_, entityIdAlice, _ := createEntityAndAlias(client, mountAccessor, "alice-smith", "alice", t)
+	_, entityIdAlice, _ := testhelpers.CreateEntityAndAlias(t, client, mountAccessor, "alice-smith", "alice")
 
 	// Try and login with alias 2 (alice) pre-merge
 	userpassAuth, err := auth.NewUserpassAuth("alice", &auth.Password{FromString: "testpassword"})
@@ -909,7 +910,7 @@ func TestIdentityStore_MergeEntities_FailsDueToMultipleClashMergesAttempted(t *t
 		t.Fatal("did not find github accessor")
 	}
 
-	_, entityIdBob, _ := createEntityAndAlias(client, mountAccessor, "bob-smith", "bob", t)
+	_, entityIdBob, _ := testhelpers.CreateEntityAndAlias(t, client, mountAccessor, "bob-smith", "bob")
 	aliasResp, err := client.Logical().Write("identity/entity-alias", map[string]interface{}{
 		"name":           "bob-github",
 		"canonical_id":   entityIdBob,
@@ -932,8 +933,8 @@ func TestIdentityStore_MergeEntities_FailsDueToMultipleClashMergesAttempted(t *t
 		t.Fatal(err)
 	}
 
-	_, entityIdAlice, aliasIdAlice := createEntityAndAlias(client, mountAccessor, "alice-smith", "alice", t)
-	_, entityIdClara, aliasIdClara := createEntityAndAlias(client, mountAccessorGitHub, "clara-smith", "alice", t)
+	_, entityIdAlice, aliasIdAlice := testhelpers.CreateEntityAndAlias(t, client, mountAccessor, "alice-smith", "alice")
+	_, entityIdClara, aliasIdClara := testhelpers.CreateEntityAndAlias(t, client, mountAccessorGitHub, "clara-smith", "alice")
 
 	// Perform entity merge
 	mergeResp, err := client.Logical().Write("identity/entity/merge", map[string]interface{}{

--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -180,7 +180,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 	time.Sleep(5 * time.Second)
 	totpPasscode1 = testhelpers.GetTOTPCodeFromEngine(t, client, enginePath1)
 
-	secret, err = client.Logical().WriteWithContext(context.Background(), "sys/mfa/validate", map[string]interface{}{
+	secret, err = userClient1.Logical().WriteWithContext(context.Background(), "sys/mfa/validate", map[string]interface{}{
 		"mfa_request_id": secret.Auth.MFARequirement.MFARequestID,
 		"mfa_payload": map[string][]string{
 			methodID: {totpPasscode1},

--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -113,7 +113,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 	testhelpers.SetupMFALoginEnforcement(t, client, enforcementConfig)
 
 	// MFA single-phase login
-	totpPasscode1 := testhelpers.GetTOTPCodeFromEngine(t, userClient1, enginePath1)
+	totpPasscode1 := testhelpers.GetTOTPCodeFromEngine(t, client, enginePath1)
 
 	userClient1.AddHeader("X-Vault-MFA", fmt.Sprintf("%s:%s", methodID, totpPasscode1))
 	secret, err := userClient1.Logical().WriteWithContext(context.Background(), "auth/userpass/login/testuser1", map[string]interface{}{

--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -88,7 +88,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 
 	totpConfig := map[string]interface{}{
 		"issuer":                  "yCorp",
-		"period":                  5,
+		"period":                  10,
 		"algorithm":               "SHA512",
 		"digits":                  6,
 		"skew":                    0,
@@ -177,7 +177,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 
 	// validation
 	// waiting for 5 seconds so that a fresh code could be generated
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 	totpPasscode1 = testhelpers.GetTOTPCodeFromEngine(t, client, enginePath1)
 
 	secret, err = userClient1.Logical().WriteWithContext(context.Background(), "sys/mfa/validate", map[string]interface{}{
@@ -263,7 +263,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 	doTwoPhaseLogin(t, userClient2, enginePath2, methodID, "testuser2")
 
 	// let's see if user1 is able to login after 5 seconds
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 	doTwoPhaseLogin(t, userClient1, enginePath1, methodID, "testuser1")
 
 	// Destroy the secret so that the token can self generate

--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -88,8 +88,8 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 
 	totpConfig := map[string]interface{}{
 		"issuer":                  "yCorp",
-		"period":                  30,
-		"algorithm":               "SHA1",
+		"period":                  5,
+		"algorithm":               "SHA512",
 		"digits":                  6,
 		"skew":                    0,
 		"key_size":                20,
@@ -177,7 +177,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 
 	// validation
 	// waiting for 5 seconds so that a fresh code could be generated
-	time.Sleep(30 * time.Second)
+	time.Sleep(5 * time.Second)
 	totpPasscode2 := testhelpers.GetTOTPCodeFromEngine(t, client, enginePath1)
 
 	secret, err = userClient1.Logical().WriteWithContext(context.Background(), "sys/mfa/validate", map[string]interface{}{
@@ -263,7 +263,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 	doTwoPhaseLogin(t, userClient2, enginePath2, methodID, "testuser2")
 
 	// let's see if user1 is able to login after 5 seconds
-	time.Sleep(30 * time.Second)
+	time.Sleep(5 * time.Second)
 	// getting a fresh totp passcode for the validation step
 	doTwoPhaseLogin(t, userClient1, enginePath1, methodID, "testuser1")
 

--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	upAuth "github.com/hashicorp/vault/api/auth/userpass"
+	"github.com/hashicorp/vault/helper/testhelpers"
 
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/audit"
@@ -18,70 +19,9 @@ import (
 	"github.com/hashicorp/vault/vault"
 )
 
-func createEntityAndAlias(client *api.Client, mountAccessor, entityName, aliasName string, t *testing.T) (*api.Client, string, string) {
-	_, err := client.Logical().WriteWithContext(context.Background(), fmt.Sprintf("auth/userpass/users/%s", aliasName), map[string]interface{}{
-		"password": "testpassword",
-	})
-	if err != nil {
-		t.Fatalf("failed to configure userpass backend: %v", err)
-	}
-
-	userClient, err := client.Clone()
-	if err != nil {
-		t.Fatalf("failed to clone the client:%v", err)
-	}
-	userClient.SetToken(client.Token())
-
-	resp, err := client.Logical().WriteWithContext(context.Background(), "identity/entity", map[string]interface{}{
-		"name": entityName,
-	})
-	if err != nil {
-		t.Fatalf("failed to create an entity:%v", err)
-	}
-	entityID := resp.Data["id"].(string)
-
-	aliasResp, err := client.Logical().WriteWithContext(context.Background(), "identity/entity-alias", map[string]interface{}{
-		"name":           aliasName,
-		"canonical_id":   entityID,
-		"mount_accessor": mountAccessor,
-	})
-	if err != nil {
-		t.Fatalf("failed to create an entity alias:%v", err)
-	}
-
-	aliasID := aliasResp.Data["id"].(string)
-	if aliasID == "" {
-		t.Fatal("Alias ID not present in response")
-	}
-	return userClient, entityID, aliasID
-}
-
-func registerEntityInTOTPEngine(client *api.Client, entityID, methodID string, t *testing.T) string {
-	totpGenName := fmt.Sprintf("%s-%s", entityID, methodID)
-	secret, err := client.Logical().WriteWithContext(context.Background(), fmt.Sprintf("identity/mfa/method/totp/admin-generate"), map[string]interface{}{
-		"entity_id": entityID,
-		"method_id": methodID,
-	})
-	if err != nil {
-		t.Fatalf("failed to generate a TOTP secret on an entity: %v", err)
-	}
-	totpURL := secret.Data["url"].(string)
-
-	_, err = client.Logical().WriteWithContext(context.Background(), fmt.Sprintf("totp/keys/%s", totpGenName), map[string]interface{}{
-		"url": totpURL,
-	})
-	if err != nil {
-		t.Fatalf("failed to register a TOTP URL: %v", err)
-	}
-	return totpGenName
-}
-
-func doTwoPhaseLogin(client *api.Client, totpCodePath, methodID, username string, t *testing.T) {
-	totpResp, err := client.Logical().ReadWithContext(context.Background(), totpCodePath)
-	if err != nil {
-		t.Fatalf("failed to create totp passcode: %v", err)
-	}
-	totpPasscode := totpResp.Data["code"].(string)
+func doTwoPhaseLogin(t *testing.T, client *api.Client, totpCodePath, methodID, username string) {
+	t.Helper()
+	totpPasscode := testhelpers.GetTOTPCodeFromEngine(t, client, totpCodePath)
 
 	upMethod, err := upAuth.NewUserpassAuth(username, &upAuth.Password{FromString: "testpassword"})
 
@@ -134,92 +74,36 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 
 	client := cluster.Cores[0].Client
 
-	// Enable the audit backend
-	err := client.Sys().EnableAuditWithOptions("noop", &api.EnableAuditOptions{Type: "noop"})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Mount the TOTP backend
-	mountInfo := &api.MountInput{
-		Type: "totp",
-	}
-	err = client.Sys().Mount("totp", mountInfo)
-	if err != nil {
-		t.Fatalf("failed to mount totp backend: %v", err)
-	}
-
-	// Enable Userpass authentication
-	err = client.Sys().EnableAuthWithOptions("userpass", &api.EnableAuthOptions{
-		Type: "userpass",
-	})
-	if err != nil {
-		t.Fatalf("failed to enable userpass auth: %v", err)
-	}
-
-	auths, err := client.Sys().ListAuthWithContext(context.Background())
-	if err != nil {
-		t.Fatalf("bb")
-	}
-	var mountAccessor string
-	if auths != nil && auths["userpass/"] != nil {
-		mountAccessor = auths["userpass/"].Accessor
-	}
+	testhelpers.SetupAudit(t, client)
+	testhelpers.SetupTOTPMount(t, client)
+	mountAccessor := testhelpers.SetupUserpassMountAccessor(t, client)
 
 	// Creating two users in the userpass auth mount
-	userClient1, entityID1, _ := createEntityAndAlias(client, mountAccessor, "entity1", "testuser1", t)
-	userClient2, entityID2, _ := createEntityAndAlias(client, mountAccessor, "entity2", "testuser2", t)
+	userClient1, entityID1, _ := testhelpers.CreateEntityAndAlias(t, client, mountAccessor, "entity1", "testuser1")
+	userClient2, entityID2, _ := testhelpers.CreateEntityAndAlias(t, client, mountAccessor, "entity2", "testuser2")
 
-	// configure TOTP secret engine
-	var methodID string
-	// login MFA
-	{
-		// create a config
-		resp1, err := client.Logical().Write("identity/mfa/method/totp", map[string]interface{}{
-			"issuer":                  "yCorp",
-			"period":                  5,
-			"algorithm":               "SHA1",
-			"digits":                  6,
-			"skew":                    1,
-			"key_size":                10,
-			"qr_size":                 100,
-			"max_validation_attempts": 3,
-		})
-
-		if err != nil || (resp1 == nil) {
-			t.Fatalf("bad: resp: %#v\n err: %v", resp1, err)
-		}
-
-		methodID = resp1.Data["method_id"].(string)
-		if methodID == "" {
-			t.Fatalf("method ID is empty")
-		}
-
-		// creating MFAEnforcementConfig
-		_, err = client.Logical().WriteWithContext(context.Background(), "identity/mfa/login-enforcement/randomName", map[string]interface{}{
-			"auth_method_types": []string{"userpass"},
-			"name":              "randomName",
-			"mfa_method_ids":    []string{methodID},
-		})
-		if err != nil {
-			t.Fatalf("failed to configure MFAEnforcementConfig: %v", err)
-		}
+	totpConfig := map[string]interface{}{
+		"issuer":                  "yCorp",
+		"period":                  30,
+		"algorithm":               "SHA1",
+		"digits":                  6,
+		"skew":                    0,
+		"key_size":                20,
+		"qr_size":                 200,
+		"max_validation_attempts": 5,
 	}
+
+	methodID := testhelpers.SetupTOTPSecretsEngine(t, client, totpConfig)
 
 	// registering EntityIDs in the TOTP secret Engine for MethodID
-	totpEngineConfigName1 := registerEntityInTOTPEngine(client, entityID1, methodID, t)
-	totpEngineConfigName2 := registerEntityInTOTPEngine(client, entityID2, methodID, t)
+	enginePath1 := testhelpers.RegisterEntityInTOTPEngine(t, client, entityID1, methodID)
+	enginePath2 := testhelpers.RegisterEntityInTOTPEngine(t, client, entityID2, methodID)
 
 	// MFA single-phase login
-	totpCodePath1 := fmt.Sprintf("totp/code/%s", totpEngineConfigName1)
-	secret, err := client.Logical().ReadWithContext(context.Background(), totpCodePath1)
-	if err != nil {
-		t.Fatalf("failed to create totp passcode: %v", err)
-	}
-	totpPasscode1 := secret.Data["code"].(string)
+	totpPasscode1 := testhelpers.GetTOTPCodeFromEngine(t, client, enginePath1)
 
 	userClient1.AddHeader("X-Vault-MFA", fmt.Sprintf("%s:%s", methodID, totpPasscode1))
-	secret, err = userClient1.Logical().WriteWithContext(context.Background(), "auth/userpass/login/testuser1", map[string]interface{}{
+	secret, err := userClient1.Logical().WriteWithContext(context.Background(), "auth/userpass/login/testuser1", map[string]interface{}{
 		"password": "testpassword",
 	})
 	if err != nil {
@@ -280,18 +164,13 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 
 	// validation
 	// waiting for 5 seconds so that a fresh code could be generated
-	time.Sleep(5 * time.Second)
-	// getting a fresh totp passcode for the validation step
-	totpResp, err := client.Logical().ReadWithContext(context.Background(), totpCodePath1)
-	if err != nil {
-		t.Fatalf("failed to create totp passcode: %v", err)
-	}
-	totpPasscode1 = totpResp.Data["code"].(string)
+	time.Sleep(30 * time.Second)
+	totpPasscode2 := testhelpers.GetTOTPCodeFromEngine(t, client, enginePath1)
 
 	secret, err = userClient1.Logical().WriteWithContext(context.Background(), "sys/mfa/validate", map[string]interface{}{
 		"mfa_request_id": secret.Auth.MFARequirement.MFARequestID,
 		"mfa_payload": map[string][]string{
-			methodID: {totpPasscode1},
+			methodID: {totpPasscode2},
 		},
 	})
 	if err != nil {
@@ -350,7 +229,9 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 	}
 
 	var maxErr error
-	for i := 0; i < 4; i++ {
+	maxAttempts := 6
+	i := 0
+	for i = 0; i < maxAttempts; i++ {
 		_, maxErr = userClient1.Logical().WriteWithContext(context.Background(), "sys/mfa/validate", map[string]interface{}{
 			"mfa_request_id": secret.Auth.MFARequirement.MFARequestID,
 			"mfa_payload": map[string][]string{
@@ -361,18 +242,17 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 			t.Fatalf("MFA succeeded with an invalid passcode")
 		}
 	}
-	if !strings.Contains(maxErr.Error(), "maximum TOTP validation attempts 4 exceeded the allowed attempts 3") {
-		t.Fatalf("unexpected error message when exceeding max failed validation attempts")
+	if !strings.Contains(maxErr.Error(), "maximum TOTP validation attempts") {
+		t.Fatalf("unexpected error message when exceeding max failed validation attempts: %s", maxErr.Error())
 	}
 
 	// let's make sure the configID is not blocked for other users
-	totpCodePath2 := fmt.Sprintf("totp/code/%s", totpEngineConfigName2)
-	doTwoPhaseLogin(userClient2, totpCodePath2, methodID, "testuser2", t)
+	doTwoPhaseLogin(t, userClient2, enginePath2, methodID, "testuser2")
 
 	// let's see if user1 is able to login after 5 seconds
-	time.Sleep(5 * time.Second)
+	time.Sleep(30 * time.Second)
 	// getting a fresh totp passcode for the validation step
-	doTwoPhaseLogin(userClient1, totpCodePath1, methodID, "testuser1", t)
+	doTwoPhaseLogin(t, userClient1, enginePath1, methodID, "testuser1")
 
 	// Destroy the secret so that the token can self generate
 	_, err = client.Logical().WriteWithContext(context.Background(), fmt.Sprintf("identity/mfa/method/totp/admin-destroy"), map[string]interface{}{

--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -88,7 +88,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 
 	totpConfig := map[string]interface{}{
 		"issuer":                  "yCorp",
-		"period":                  5,
+		"period":                  10,
 		"algorithm":               "SHA512",
 		"digits":                  6,
 		"skew":                    0,
@@ -178,9 +178,9 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 	// validation
 	// waiting for 5 seconds so that a fresh code could be generated
 	time.Sleep(5 * time.Second)
-	totpPasscode1 = testhelpers.GetTOTPCodeFromEngine(t, userClient1, enginePath1)
+	totpPasscode1 = testhelpers.GetTOTPCodeFromEngine(t, client, enginePath1)
 
-	secret, err = userClient1.Logical().WriteWithContext(context.Background(), "sys/mfa/validate", map[string]interface{}{
+	secret, err = client.Logical().WriteWithContext(context.Background(), "sys/mfa/validate", map[string]interface{}{
 		"mfa_request_id": secret.Auth.MFARequirement.MFARequestID,
 		"mfa_payload": map[string][]string{
 			methodID: {totpPasscode1},
@@ -264,7 +264,6 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 
 	// let's see if user1 is able to login after 5 seconds
 	time.Sleep(5 * time.Second)
-	// getting a fresh totp passcode for the validation step
 	doTwoPhaseLogin(t, userClient1, enginePath1, methodID, "testuser1")
 
 	// Destroy the secret so that the token can self generate

--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -93,11 +93,20 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 		"max_validation_attempts": 5,
 	}
 
-	methodID := testhelpers.SetupTOTPSecretsEngine(t, client, totpConfig)
+	methodID := testhelpers.SetupTOTPMethod(t, client, totpConfig)
 
 	// registering EntityIDs in the TOTP secret Engine for MethodID
 	enginePath1 := testhelpers.RegisterEntityInTOTPEngine(t, client, entityID1, methodID)
 	enginePath2 := testhelpers.RegisterEntityInTOTPEngine(t, client, entityID2, methodID)
+
+	// Configure a default login enforcement
+	enforcementConfig := map[string]interface{}{
+		"auth_method_types": []string{"userpass"},
+		"name":              "randomName",
+		"mfa_method_ids":    []string{methodID},
+	}
+
+	testhelpers.SetupMFALoginEnforcement(t, client, enforcementConfig)
 
 	// MFA single-phase login
 	totpPasscode1 := testhelpers.GetTOTPCodeFromEngine(t, client, enginePath1)

--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -113,7 +113,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 	testhelpers.SetupMFALoginEnforcement(t, client, enforcementConfig)
 
 	// MFA single-phase login
-	totpPasscode1 := testhelpers.GetTOTPCodeFromEngine(t, client, enginePath1)
+	totpPasscode1 := testhelpers.GetTOTPCodeFromEngine(t, userClient1, enginePath1)
 
 	userClient1.AddHeader("X-Vault-MFA", fmt.Sprintf("%s:%s", methodID, totpPasscode1))
 	secret, err := userClient1.Logical().WriteWithContext(context.Background(), "auth/userpass/login/testuser1", map[string]interface{}{
@@ -178,7 +178,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 	// validation
 	// waiting for 5 seconds so that a fresh code could be generated
 	time.Sleep(5 * time.Second)
-	totpPasscode1 = testhelpers.GetTOTPCodeFromEngine(t, client, enginePath1)
+	totpPasscode1 = testhelpers.GetTOTPCodeFromEngine(t, userClient1, enginePath1)
 
 	secret, err = userClient1.Logical().WriteWithContext(context.Background(), "sys/mfa/validate", map[string]interface{}{
 		"mfa_request_id": secret.Auth.MFARequirement.MFARequestID,

--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -74,7 +74,11 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 
 	client := cluster.Cores[0].Client
 
-	testhelpers.SetupAudit(t, client)
+	// Enable the audit backend
+	if err := client.Sys().EnableAuditWithOptions("noop", &api.EnableAuditOptions{Type: "noop"}); err != nil {
+		t.Fatal(err)
+	}
+
 	testhelpers.SetupTOTPMount(t, client)
 	mountAccessor := testhelpers.SetupUserpassMountAccessor(t, client)
 

--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -88,7 +88,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 
 	totpConfig := map[string]interface{}{
 		"issuer":                  "yCorp",
-		"period":                  10,
+		"period":                  5,
 		"algorithm":               "SHA512",
 		"digits":                  6,
 		"skew":                    0,

--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -178,12 +178,12 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 	// validation
 	// waiting for 5 seconds so that a fresh code could be generated
 	time.Sleep(5 * time.Second)
-	totpPasscode2 := testhelpers.GetTOTPCodeFromEngine(t, client, enginePath1)
+	totpPasscode1 = testhelpers.GetTOTPCodeFromEngine(t, client, enginePath1)
 
 	secret, err = userClient1.Logical().WriteWithContext(context.Background(), "sys/mfa/validate", map[string]interface{}{
 		"mfa_request_id": secret.Auth.MFARequirement.MFARequestID,
 		"mfa_payload": map[string][]string{
-			methodID: {totpPasscode2},
+			methodID: {totpPasscode1},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
This PR updates the `login` path to store a token when using single-phase MFA validation. Still need to do some testing to see if this breaks any of the pre-existing functionality (particularly two-phase MFA).

Fixes: #16928