### PR TITLE
Update Vault Azure Secrets docs for permanent deletion feature

### DIFF
--- a/changelog/17045.txt
+++ b/changelog/17045.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-secrets/azure: Add documentation around permanently deleting Azure objects created by Vault.
+secrets/azure: Adds option to permanently delete AzureAD objects created by Vault.
 ```

--- a/changelog/17045.txt
+++ b/changelog/17045.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/azure: Add documentation around permanently deleting Azure objects created by Vault.
+```

--- a/website/content/api-docs/secret/azure.mdx
+++ b/website/content/api-docs/secret/azure.mdx
@@ -241,6 +241,8 @@ information about roles.
   Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine default TTL time.
 - `max_ttl` (`string: ""`) – Specifies the maximum TTL for service principals generated using this role. Accepts time
   suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine max TTL time.
+- `permanently_delete` (`bool: false`) - Specifies whether to permanently delete Applications and Service Principals that are dynamically
+  created by Vault. If `application_object_id` is present, `permanently_delete` must be `false`.
 
 ### Sample Payload
 

--- a/website/content/docs/secrets/azure.mdx
+++ b/website/content/docs/secrets/azure.mdx
@@ -183,6 +183,25 @@ $ cat az_groups.json
 ]
 ```
 
+### Permanently Delete Azure Objects
+If dynamic service principals are used, the option to permanently delete the applications and service principals created by Vault may be configured on the Vault role.
+When this option is enabled and a lease is expired or revoked, the application and service principal associated with the lease will be [permanently deleted](https://docs.microsoft.com/en-us/graph/api/directory-deleteditems-delete) from the Azure Active Directory.
+As a result, these objects will not count toward the [quota](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#active-directory-limits) of total resources in an Azure tenant. When this option is not enabled
+and a lease is expired or revoked, the application and service principal associated with the lease will be deleted, but not permanently. These objects will be available to restore for 30 days from deletion. 
+
+Example of role configuration:
+
+```shell-session
+$ vault write azure/roles/my-role permanently_delete=true ttl=1h azure_roles=-<<EOF
+    [
+        {
+            "role_name": "Contributor",
+            "scope":  "/subscriptions/<uuid>/resourceGroups/Website"
+        }
+    ]
+EOF
+```
+
 ## Authentication
 
 The Azure secrets backend must have sufficient permissions to read Azure role information and manage


### PR DESCRIPTION
Corresponds to https://github.com/hashicorp/vault-plugin-secrets-azure/pull/104

That PR allows for permanent deletion of AzureAD apps and service principals that are created by the secrets engine. Traditionally, the Vault secrets engine does not permanently delete the service principals/apps from AzureAD when leases expire. Instead, the objects are placed in a "recycle bin," and they count toward the [limit of AzureAD objects in a tenant](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#active-directory-limits) (that limit ranges from 50k to 500k objects). So after 50k-500k leases, Vault hits the limit of objects in an Azure AD and causes all create operations on the tenant to fail.