### PR TITLE
Adds vault-plugin-database-cloudsql plugin to docs

### DIFF
--- a/changelog/_17051.txt
+++ b/changelog/_17051.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+website/docs: adds a link to the vault-plugin-database-cloudsql plugin.
+```

--- a/website/content/docs/plugins/plugin-portal.mdx
+++ b/website/content/docs/plugins/plugin-portal.mdx
@@ -126,6 +126,9 @@ Plugin authors who wish to have their plugins listed may file a submission via a
 [GitHub issue][github-issue] or directly open a pull request with changes to
 [this page][plugin-portal-mdx].
 
+### Database
+- [GCP CloudSQL](https://github.com/expel-io/vault-plugin-database-cloudsql)
+
 ### Auth
 
 - [Jenkins](https://plugins.jenkins.io/hashicorp-vault-plugin)


### PR DESCRIPTION
## What
- adds [GCP CloudSQL](https://github.com/expel-io/vault-plugin-database-cloudsql) plugin to the docs
- this plugin supports connecting to GCP CloudSQL instances using the [cloud-sql-go-connector](https://github.com/GoogleCloudPlatform/cloud-sql-go-connector) allowing Vault to authenticate to CloudSQL instances using IAM authentication. 
