### PR TITLE
docs/k8s: use pod labels for upgrades

### DIFF
--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -439,7 +439,7 @@ $ kubectl delete pod <name of Vault pod>
 If Vault is deployed using `ha` mode, the standby pods must be upgraded first.
 Vault has K8s service discovery built in (when enabled in the server configuration) and
 will automatically change the labels of the pod with its current leader status. These labels 
-can be used to filter the pods:
+can be used to filter the pods.
 
 For example, filter all pods that are Vault standbys:
 

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -437,11 +437,20 @@ $ kubectl delete pod <name of Vault pod>
 ```
 
 If Vault is deployed using `ha` mode, the standby pods must be upgraded first.
-To identify which pod is currently the active primary, run the following command
-on each Vault pod:
+Vault has K8s service discovery built in (when enabled in the server configuration) and
+will automatically change the labels of the pod with its current leader status. These labels 
+can be used to filter the pods:
+
+For example, filter all pods that are Vault standbys:
 
 ```shell-session
-$ kubectl exec -ti <name of pod> -- vault status | grep "HA Mode"
+$ kubectl get pods -l vault-active=false
+```
+
+Filter the Vault active pod:
+
+```shell-session
+$ kubectl get pods -l vault-active=true
 ```
 
 Next, delete every pod that is not the active primary:


### PR DESCRIPTION
The current upgrade documentation doesn't use the K8s service discovery labels when deployed in HA mode, so adding them here to avoid exec commands.