### PR TITLE
UI: Remove trailing comma from scopes, provider details page

### DIFF
--- a/ui/app/templates/components/alphabet-edit.hbs
+++ b/ui/app/templates/components/alphabet-edit.hbs
@@ -116,7 +116,6 @@
           @value={{get this.model attr.name}}
           @type={{attr.type}}
           @isLink={{eq attr.name "transformations"}}
-          @viewAll="transformations"
         />
       {{else}}
         <InfoTableRow

--- a/ui/app/templates/components/transform-role-edit.hbs
+++ b/ui/app/templates/components/transform-role-edit.hbs
@@ -99,7 +99,6 @@
           @value={{get this.model attr.name}}
           @type={{attr.type}}
           @isLink={{eq attr.name "transformations"}}
-          @viewAll="transformations"
         />
       {{else}}
         <InfoTableRow

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -14,7 +14,6 @@
         @queryParam="role"
         @modelType="transform/role"
         @wildcardLabel={{attr.options.wildcardLabel}}
-        @viewAll="roles"
         @backend={{this.model.backend}}
       />
     {{else}}

--- a/ui/app/templates/vault/cluster/access/oidc/assignments/assignment/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/assignments/assignment/details.hbs
@@ -61,25 +61,23 @@
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   <InfoTableRow @label="Name" @value={{@model.name}} />
   <InfoTableRow
+    @label="Entities"
     @type="array"
     @value={{@model.entityIds}}
     @model={{@model}}
     @isLink={{true}}
-    @label="Entities"
     @modelType="oidc/assignment"
-    @viewAll="entities."
     @itemRoute={{(array "vault.cluster.access.identity.show" "entities" "details")}}
     @alwaysRender={{true}}
     @toggleViewAll={{true}}
   />
   <InfoTableRow
+    @label="Groups"
     @type="array"
     @value={{@model.groupIds}}
     @model={{@model}}
     @isLink={{true}}
-    @label="Groups"
     @modelType="oidc/assignment"
-    @viewAll="groups."
     @itemRoute={{(array "vault.cluster.access.identity.show" "groups" "details")}}
     @alwaysRender={{true}}
     @doNotTruncate={{true}}

--- a/ui/app/templates/vault/cluster/access/oidc/providers/provider/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/provider/details.hbs
@@ -34,16 +34,15 @@
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   <InfoTableRow @label="Name" @value={{this.model.name}} @alwaysRender={{true}} />
   <InfoTableRow @label="Issuer URL" @value={{this.model.issuer}} @addCopyButton={{true}} @alwaysRender={{true}} />
-  <InfoTableRow @label="Scopes">
-    {{#if (gt @model.scopesSupported.length 0)}}
-      {{#each @model.scopesSupported as |scope|}}
-        <LinkTo @route="vault.cluster.access.oidc.scopes.scope.details" @model={{scope}}>
-          {{scope}}
-        </LinkTo>
-        ,
-      {{/each}}
-    {{else}}
-      -
-    {{/if}}
-  </InfoTableRow>
+  <InfoTableRow
+    @label="Scopes"
+    @type="array"
+    @value={{@model.scopesSupported}}
+    @model={{@model}}
+    @isLink={{true}}
+    @modelType="oidc/scope"
+    @itemRoute={{"vault.cluster.access.oidc.scopes.scope.details"}}
+    @alwaysRender={{true}}
+    @doNotTruncate={{true}}
+  />
 </div>

--- a/ui/lib/core/addon/components/info-table-item-array.hbs
+++ b/ui/lib/core/addon/components/info-table-item-array.hbs
@@ -45,15 +45,15 @@
             ,&nbsp;
           {{/if}}
           {{#unless this.doNotTruncate}}
-            {{#if (and (eq name this.displayArrayTruncated.lastObject) (gte this.displayArray.length 10))}}
+            {{#if (and (eq name this.displayArrayTruncated.lastObject) (gte @displayArray.length 10))}}
               {{! dec is a math helper that decrements by 5 the length of the array ex: 11-5 = "and 6 others."}}
-              <span data-test-and={{dec 5 this.displayArray.length}}>
+              <span data-test-and={{dec 5 @displayArray.length}}>
                 &nbsp;and
-                {{dec 5 this.displayArray.length}}
+                {{dec 5 @displayArray.length}}
                 others.&nbsp;
               </span>
             {{/if}}
-            {{#if (and (eq name this.displayArrayTruncated.lastObject) (gte this.displayArray.length 10))}}
+            {{#if (and (eq name this.displayArrayTruncated.lastObject) (gte @displayArray.length 10))}}
               {{#if (is-array @rootRoute)}}
                 <LinkTo @route={{(get @rootRoute "0")}} @model={{(get @rootRoute "1")}}>
                   <span data-test-view-all={{lowercase @label}}>View all {{lowercase @label}}.</span>

--- a/ui/lib/core/addon/components/info-table-item-array.hbs
+++ b/ui/lib/core/addon/components/info-table-item-array.hbs
@@ -3,7 +3,7 @@
   {{#if @isLink}}
     <div data-test-row-value={{@label}}>
       <ReadMore>
-        {{#each this.displayArrayAmended as |name|}}
+        {{#each this.displayArrayTruncated as |name|}}
           {{#if (is-wildcard-string name)}}
             {{#let (filter-wildcard name this.allOptions) as |wildcardCount|}}
               <span>{{name}}</span>
@@ -12,9 +12,9 @@
                 {{if wildcardCount wildcardCount 0}}
                 {{if (eq wildcardCount 1) @wildcardLabel (pluralize @wildcardLabel)}}
               </span>
-              {{#if (eq this.displayArrayAmended.lastObject name)}}
+              {{#if (eq this.displayArrayTruncated.lastObject name)}}
                 <LinkTo @route={{this.rootRoute}} @query={{hash tab=@queryParam}}>
-                  <span data-test-view-all={{@viewAll}}>View all {{@viewAll}}</span>
+                  <span data-test-view-all={{lowercase @label}}>View all {{lowercase @label}}.</span>
                 </LinkTo>
               {{/if}}
             {{/let}}
@@ -38,14 +38,14 @@
           {{/if}}
           {{#if
             (or
-              (and (not-eq name this.displayArrayAmended.lastObject) this.wildcardInDisplayArray)
-              (not-eq name this.displayArrayAmended.lastObject)
+              (and (not-eq name this.displayArrayTruncated.lastObject) this.wildcardInDisplayArray)
+              (not-eq name this.displayArrayTruncated.lastObject)
             )
           }}
             ,&nbsp;
           {{/if}}
           {{#unless this.doNotTruncate}}
-            {{#if (and (eq name this.displayArrayAmended.lastObject) (gte this.displayArray.length 10))}}
+            {{#if (and (eq name this.displayArrayTruncated.lastObject) (gte this.displayArray.length 10))}}
               {{! dec is a math helper that decrements by 5 the length of the array ex: 11-5 = "and 6 others."}}
               <span data-test-and={{dec 5 this.displayArray.length}}>
                 &nbsp;and
@@ -53,14 +53,14 @@
                 others.&nbsp;
               </span>
             {{/if}}
-            {{#if (and (eq name this.displayArrayAmended.lastObject) (gte this.displayArray.length 10))}}
+            {{#if (and (eq name this.displayArrayTruncated.lastObject) (gte this.displayArray.length 10))}}
               {{#if (is-array @rootRoute)}}
                 <LinkTo @route={{(get @rootRoute "0")}} @model={{(get @rootRoute "1")}}>
-                  <span data-test-view-all={{@viewAll}}>View all {{@viewAll}} </span>
+                  <span data-test-view-all={{lowercase @label}}>View all {{lowercase @label}}.</span>
                 </LinkTo>
               {{else}}
                 <LinkTo @route={{this.rootRoute}} @query={{hash tab=@queryParam}}>
-                  <span data-test-view-all={{@viewAll}}>View all {{@viewAll}} </span>
+                  <span data-test-view-all={{lowercase @label}}>View all {{lowercase @label}}.</span>
                 </LinkTo>
               {{/if}}
             {{/if}}
@@ -71,9 +71,9 @@
   {{else}}
     <code class="is-word-break has-text-black" data-test-row-value={{@label}}>
       {{if
-        (gte this.displayArray.length 10)
-        (concat this.displayArray ", and " (dec 5 this.displayArray.length) " more.")
-        this.displayArray
+        (gte @displayArray.length 10)
+        (concat @displayArray ", and " (dec 5 @displayArray.length) " more.")
+        @displayArray
       }}
     </code>
   {{/if}}

--- a/ui/lib/core/addon/components/info-table-item-array.js
+++ b/ui/lib/core/addon/components/info-table-item-array.js
@@ -48,20 +48,16 @@ export default class InfoTableItemArray extends Component {
     return this.args.itemRoute || 'vault.cluster.secrets.backend.show';
   }
 
-  get displayArray() {
-    return this.args.displayArray || null;
-  }
-
   get doNotTruncate() {
     return this.args.doNotTruncate || false;
   }
 
   get displayArrayTruncated() {
-    let { displayArray } = this;
+    let { displayArray } = this.args;
     if (!displayArray) return null;
     if ((displayArray.length >= 10) & !this.args.doNotTruncate) {
       // if array greater than 10 in length only display the first 5
-      displayArray = displayArray.slice(0, 5);
+      return displayArray.slice(0, 5);
     }
     return displayArray;
   }

--- a/ui/lib/core/addon/components/info-table-item-array.js
+++ b/ui/lib/core/addon/components/info-table-item-array.js
@@ -15,6 +15,7 @@ import { isWildcardString } from 'vault/helpers/is-wildcard-string';
  * @example
  * ```js
  * <InfoTableItemArray
+ * @label="Roles"
  * @displayArray={{['test-1','test-2','test-3']}}
  * @isLink={{true}}
  * @rootRoute="vault.cluster.secrets.backend.list-root"
@@ -22,18 +23,17 @@ import { isWildcardString } from 'vault/helpers/is-wildcard-string';
  * @modelType="transform/role"
  * @queryParam="role"
  * @backend="transform"
- * viewAll="roles"/>
  * ```
  *
- * @param displayArray=null {array} - The array of data to be displayed.  If there are more than 10 items in the array only five will show and a count of the other number in the array will show.
- * @param [isLink] {Boolean} - Indicates if the item should contain a link-to component.  Only setup for arrays, but this could be changed if needed.
- * @param [rootRoute="vault.cluster.secrets.backend.list-root"] - {string || array} - Tells what route the link should go to when selecting "view all". If the route requires more than one dynamic param, insert an array.
- * @param [itemRoute=vault.cluster.secrets.backend.show] - {string || array} - Tells what route the link should go to when selecting the individual item. If the route requires more than one dynamic param, insert an array.
- * @param [modelType] {string} - Tells which model you want data for the allOptions to be returned from.  Used in conjunction with the the isLink.
- * @param [wildcardLabel] {String} - when you want the component to return a count on the model for options returned when using a wildcard you must provide a label of the count e.g. role.  Should be singular.
- * @param [backend] {String} - To specify which backend to point the link to.
- * @param [viewAll] {String} - Specify the word at the end of the link View all "roles".
- * @param [doNotTruncate=false] {Boolean} - Determines whether to show the View all "roles" link.
+ * @param {string} label - used to render lowercased display text for "View all <label>."
+ * @param {array} displayArray - The array of data to be displayed. (In InfoTableRow this comes from the @value arg.) If the array length > 10, and @doNotTruncate is false only 5 will show with a count of the number hidden.
+ * @param {boolean} [isLink]  - Indicates if the item should contain a link-to component.  Only setup for arrays, but this could be changed if needed.
+ * @param {string || array} [rootRoute="vault.cluster.secrets.backend.list-root"] -  Tells what route the link should go to when selecting "view all". If the route requires more than one dynamic param, insert an array.
+ * @param {string || array} [itemRoute=vault.cluster.secrets.backend.show] - Tells what route the link should go to when selecting the individual item. If the route requires more than one dynamic param, insert an array.
+ * @param {string} [modelType]  - Tells which model you want data for the allOptions to be returned from.  Used in conjunction with the the isLink.
+ * @param {string} [wildcardLabel]  - when you want the component to return a count on the model for options returned when using a wildcard you must provide a label of the count e.g. role.  Should be singular.
+ * @param {string} [backend] - To specify which backend to point the link to.
+ * @param {boolean} [doNotTruncate=false] - Determines whether to show the View all "roles" link.
  */
 export default class InfoTableItemArray extends Component {
   @tracked allOptions = null;
@@ -56,7 +56,7 @@ export default class InfoTableItemArray extends Component {
     return this.args.doNotTruncate || false;
   }
 
-  get displayArrayAmended() {
+  get displayArrayTruncated() {
     let { displayArray } = this;
     if (!displayArray) return null;
     if ((displayArray.length >= 10) & !this.args.doNotTruncate) {

--- a/ui/lib/core/addon/components/info-table-row.hbs
+++ b/ui/lib/core/addon/components/info-table-row.hbs
@@ -64,13 +64,12 @@
       {{else}}
         {{#if (eq @type "array")}}
           <InfoTableItemArray
+            @label={{@label}}
             @backend={{@backend}}
             @displayArray={{@value}}
             @isLink={{@isLink}}
-            @label={{@label}}
             @modelType={{@modelType}}
             @queryParam={{@queryParam}}
-            @viewAll={{@viewAll}}
             @wildcardLabel={{@wildcardLabel}}
             @rootRoute={{@rootRoute}}
             @itemRoute={{@itemRoute}}

--- a/ui/tests/integration/components/info-table-item-array-test.js
+++ b/ui/tests/integration/components/info-table-item-array-test.js
@@ -32,7 +32,7 @@ module('Integration | Component | InfoTableItemArray', function (hooks) {
     this.set('queryParam', 'role');
     this.set('backend', 'transform');
     this.set('wildcardLabel', 'role');
-    this.set('viewAll', 'roles');
+    this.set('label', 'Roles');
     run(() => {
       this.owner.unregister('service:store');
       this.owner.register('service:store', storeService);
@@ -58,13 +58,15 @@ module('Integration | Component | InfoTableItemArray', function (hooks) {
   });
 
   test('it renders links if isLink is true', async function (assert) {
-    await render(hbs`<InfoTableItemArray
-      @displayArray={{this.displayArray}}
-      @isLink={{this.isLink}}
-      @modelType={{this.modelType}}
-      @queryParam={{this.queryParam}}
-      @backend={{this.backend}}
-    />`);
+    await render(hbs`
+      <InfoTableItemArray
+        @displayArray={{this.displayArray}}
+        @isLink={{this.isLink}}
+        @modelType={{this.modelType}}
+        @queryParam={{this.queryParam}}
+        @backend={{this.backend}}
+      />
+    `);
     assert.equal(
       document.querySelectorAll('a > span').length,
       DISPLAY_ARRAY.length,
@@ -75,15 +77,15 @@ module('Integration | Component | InfoTableItemArray', function (hooks) {
   test('it renders a badge and view all if wildcard in display array && < 10', async function (assert) {
     const displayArrayWithWildcard = ['role-1', 'role-2', 'role-3', 'r*'];
     this.set('displayArrayWithWildcard', displayArrayWithWildcard);
-    await render(hbs`<InfoTableItemArray
+    await render(hbs`
+    <InfoTableItemArray
+      @label={{this.label}}
       @displayArray={{this.displayArrayWithWildcard}}
       @isLink={{this.isLink}}
       @modelType={{this.modelType}}
       @queryParam={{this.queryParam}}
       @backend={{this.backend}}
-      @viewAll={{this.viewAll}}
     />`);
-
     assert.equal(
       document.querySelectorAll('a > span').length,
       DISPLAY_ARRAY.length - 1,
@@ -92,6 +94,7 @@ module('Integration | Component | InfoTableItemArray', function (hooks) {
     // 6 here comes from the six roles setup in the store service.
     assert.dom('[data-test-count="6"]').exists('correctly counts with wildcard filter and shows the count');
     assert.dom('[data-test-view-all="roles"]').exists({ count: 1 }, 'renders 1 view all roles');
+    assert.dom('[data-test-view-all="roles"]').hasText('View all roles.', 'renders correct view all text');
   });
 
   test('it renders a badge and view all if wildcard in display array && >= 10', async function (assert) {
@@ -109,18 +112,20 @@ module('Integration | Component | InfoTableItemArray', function (hooks) {
       'role-10',
     ];
     this.set('displayArrayWithWildcard', displayArrayWithWildcard);
-    await render(hbs`<InfoTableItemArray
+    await render(hbs`
+    <InfoTableItemArray
+      @label={{this.label}}
       @displayArray={{this.displayArrayWithWildcard}}
       @isLink={{this.isLink}}
       @modelType={{this.modelType}}
       @queryParam={{this.queryParam}}
       @backend={{this.backend}}
-      @viewAll={{this.viewAll}}
     />`);
     const numberCutOffTruncatedArray = displayArrayWithWildcard.length - 5;
     assert.equal(document.querySelectorAll('a > span').length, 5, 'renders truncated array of five');
     assert
       .dom(`[data-test-and="${numberCutOffTruncatedArray}"]`)
       .exists('correctly counts with wildcard filter and shows the count');
+    assert.dom('[data-test-view-all="roles"]').hasText('View all roles.', 'renders correct view all text');
   });
 });


### PR DESCRIPTION
In addition to cleaning up the provider details, this includes some small cleanup for the `InfoTableArray` component

one scope:


<img width="500" alt="Screen Shot 2022-09-08 at 1 07 46 PM" src="https://user-images.githubusercontent.com/68122737/189215904-42f51c13-3d54-4e36-8780-f86e165d86ad.png">

multiple:


<img width="500" alt="Screen Shot 2022-09-08 at 1 07 55 PM" src="https://user-images.githubusercontent.com/68122737/189215926-5992db30-2973-41bb-84e6-70e4aa25a834.png">
