### PR TITLE
VAULT-2012 pass CCC index from auto-auth to api proxy

### DIFF
--- a/changelog/17078.txt
+++ b/changelog/17078.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-agent/consistency: Fix issue where X-Vault-Index header from auto-auth was not being passed to API proxy.
+agent/consistency: Fix issue with client consistency between auto-auth and other requests, ensuring token can be used on a different perf standby.
 ```

--- a/changelog/17078.txt
+++ b/changelog/17078.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent/consistency: Fix issue where X-Vault-Index header from auto-auth was not being passed to API proxy.
+```

--- a/command/agent.go
+++ b/command/agent.go
@@ -1107,7 +1107,7 @@ func (c *AgentCommand) handleMetrics() http.Handler {
 		w.Header().Set("Content-Type", resp.Data[logical.HTTPContentType].(string))
 		switch v := resp.Data[logical.HTTPRawBody].(type) {
 		case string:
-			w.WriteHeader((status))
+			w.WriteHeader(status)
 			w.Write([]byte(v))
 		case []byte:
 			w.WriteHeader(status)

--- a/command/agent.go
+++ b/command/agent.go
@@ -851,10 +851,16 @@ func (c *AgentCommand) Run(args []string) int {
 			Token:                        previousToken,
 		})
 
+		var leaseCacheUpdateIndexFunc func(string)
+		if leaseCache != nil {
+			leaseCacheUpdateIndexFunc = leaseCache.UpdateIndexState
+		}
+
 		ss := sink.NewSinkServer(&sink.SinkServerConfig{
-			Logger:        c.logger.Named("sink.server"),
-			Client:        ahClient,
-			ExitAfterAuth: exitAfterAuth,
+			Logger:                    c.logger.Named("sink.server"),
+			Client:                    ahClient,
+			LeaseCacheUpdateIndexFunc: leaseCacheUpdateIndexFunc,
+			ExitAfterAuth:             exitAfterAuth,
 		})
 
 		ts := template.NewServer(&template.ServerConfig{

--- a/command/agent/auth/auth.go
+++ b/command/agent/auth/auth.go
@@ -241,8 +241,9 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 		// This should only happen if there's no preloaded token (regular auto-auth login)
 		//  or if a preloaded token has expired and is now switching to auto-auth.
 		if secret.Auth == nil {
-			clientToUse = clientToUse.WithResponseCallbacks(api.RecordState(&ah.vaultIndex))
-			secret, err = clientToUse.Logical().WriteWithContext(ctx, path, data)
+			clientWithRecordState := clientToUse.WithResponseCallbacks(api.RecordState(&ah.vaultIndex))
+			// We use this new client for one request only, to prevent races.
+			secret, err = clientWithRecordState.Logical().WriteWithContext(ctx, path, data)
 			// Check errors/sanity
 			if err != nil {
 				ah.logger.Error("error authenticating", "error", err, "backoff", backoff)

--- a/command/agent/cache/api_proxy.go
+++ b/command/agent/cache/api_proxy.go
@@ -135,10 +135,6 @@ func (ap *APIProxy) Send(ctx context.Context, req *SendRequest) (*SendResponse, 
 		return nil, err
 	}
 
-	if resp != nil && fwReq != nil {
-		fmt.Printf("Violet: req headers = %s, resp headers = %s", fwReq.Headers, resp.Header)
-	}
-
 	if newState != "" {
 		ap.UpdateIndexState(newState)
 	}

--- a/command/agent/cache/lease_cache.go
+++ b/command/agent/cache/lease_cache.go
@@ -170,6 +170,11 @@ func (c *LeaseCache) SetPersistentStorage(storageIn *cacheboltdb.BoltStorage) {
 	c.ps = storageIn
 }
 
+// UpdateIndexState updates the vault index state with a newer index
+func (c *LeaseCache) UpdateIndexState(newIndex string) {
+	c.proxier.UpdateIndexState(newIndex)
+}
+
 // checkCacheForRequest checks the cache for a particular request based on its
 // computed ID. It returns a non-nil *SendResponse  if an entry is found.
 func (c *LeaseCache) checkCacheForRequest(id string) (*SendResponse, error) {

--- a/command/agent/cache/proxy.go
+++ b/command/agent/cache/proxy.go
@@ -43,6 +43,7 @@ type CacheMeta struct {
 // these tasks combined together would serve the request received by the agent.
 type Proxier interface {
 	Send(ctx context.Context, req *SendRequest) (*SendResponse, error)
+	UpdateIndexState(string)
 }
 
 // NewSendResponse creates a new SendResponse and takes care of initializing its

--- a/command/agent/cache/testing.go
+++ b/command/agent/cache/testing.go
@@ -28,6 +28,8 @@ func newMockProxier(responses []*SendResponse) *mockProxier {
 	}
 }
 
+func (p *mockProxier) UpdateIndexState(newIndex string) {}
+
 func (p *mockProxier) Send(ctx context.Context, req *SendRequest) (*SendResponse, error) {
 	if p.responseIndex >= len(p.proxiedResponses) {
 		return nil, fmt.Errorf("index out of bounds: responseIndex = %d, responses = %d", p.responseIndex, len(p.proxiedResponses))
@@ -70,6 +72,8 @@ type mockTokenVerifierProxier struct {
 	currentToken string
 }
 
+func (p *mockTokenVerifierProxier) UpdateIndexState(newIndex string) {}
+
 func (p *mockTokenVerifierProxier) Send(ctx context.Context, req *SendRequest) (*SendResponse, error) {
 	p.currentToken = req.Token
 	resp := newTestSendResponse(http.StatusOK,
@@ -86,6 +90,8 @@ type mockDelayProxier struct {
 	cacheableResp bool
 	delay         int
 }
+
+func (p *mockDelayProxier) UpdateIndexState(newIndex string) {}
 
 func (p *mockDelayProxier) Send(ctx context.Context, req *SendRequest) (*SendResponse, error) {
 	if p.delay > 0 {

--- a/command/agent/sink/file/sink_test.go
+++ b/command/agent/sink/file/sink_test.go
@@ -10,10 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault/command/agent/auth"
-
 	hclog "github.com/hashicorp/go-hclog"
 	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/command/agent/auth"
 	"github.com/hashicorp/vault/command/agent/sink"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 )

--- a/command/agent/sink/sink.go
+++ b/command/agent/sink/sink.go
@@ -10,10 +10,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/vault/command/agent/auth"
-
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/command/agent/auth"
 	"github.com/hashicorp/vault/helper/dhutil"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 )


### PR DESCRIPTION
There are still some parts of Agent that don't use this header, such as the LifetimeWatcher. Modifying the code so that index is used (and consistent) throughout every API call in Agent seemed like quite a large task with limited benefit. Still, if we want to go down that path in the future, the approach here should make it easier.