### PR TITLE
Update PKI documentation to clear up PKCS8 marshalling behavior

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -272,10 +272,14 @@ It is suggested to limit access to the path-overridden issue endpoint (on
   private key and certificate, concatenated; if the issuing CA is not a
   Vault-derived self-signed root, this will be included as well.
 
-- `private_key_format` `(string: "der")` - Specifies the format for marshaling the
-  private key. Defaults to `der` which will return either base64-encoded DER or
-  PEM-encoded DER, depending on the value of `format`. The other option is
-  `pkcs8` which will return the key marshalled as PEM-encoded PKCS8.
+- `private_key_format` `(string: "der")` - Specifies the format for marshaling
+  the private key within the private_key response field. Defaults to `der` which will
+  return either base64-encoded DER or PEM-encoded DER, depending on the value of
+  `format`. The other option is `pkcs8` which will return the key marshalled as
+  PEM-encoded PKCS8.
+
+~> **Note** that this does not apply to the private key within the certificate
+  field if `format=pem_bundle` parameter is specified.
 
 - `exclude_cn_from_sans` `(bool: false)` - If true, the given `common_name` will
   not be included in DNS or Email Subject Alternate Names (as appropriate).
@@ -1530,10 +1534,14 @@ use the values set via `config/urls`.
   exported) and certificate, concatenated; if the issuing CA is not a
   Vault-derived self-signed root, this will be included as well.
 
-- `private_key_format` `(string: "der")` - Specifies the format for marshaling the
-  private key. Defaults to `der` which will return either base64-encoded DER or
-  PEM-encoded DER, depending on the value of `format`. The other option is
-  `pkcs8` which will return the key marshalled as PEM-encoded PKCS8.
+- `private_key_format` `(string: "der")` - Specifies the format for marshaling
+  the private key within the private_key response field. Defaults to `der` which will
+  return either base64-encoded DER or PEM-encoded DER, depending on the value of
+  `format`. The other option is `pkcs8` which will return the key marshalled as
+  PEM-encoded PKCS8.
+
+~> **Note** that this does not apply to the private key within the certificate
+  field if `format=pem_bundle` parameter is specified.
 
 - `key_type` `(string: "rsa")` - Specifies the desired key type; must be `rsa`, `ed25519`
   or `ec`.
@@ -1723,10 +1731,14 @@ generated depending on the `type` request parameter.
   base64 encoded. If `pem_bundle`, the `csr` field will contain the private key
   (if exported) and CSR, concatenated.
 
-- `private_key_format` `(string: "der")` - Specifies the format for marshaling the
-  private key. Defaults to `der` which will return either base64-encoded DER or
-  PEM-encoded DER, depending on the value of `format`. The other option is
-  `pkcs8` which will return the key marshalled as PEM-encoded PKCS8.
+- `private_key_format` `(string: "der")` - Specifies the format for marshaling
+  the private key within the private_key response field. Defaults to `der` which will
+  return either base64-encoded DER or PEM-encoded DER, depending on the value of
+  `format`. The other option is `pkcs8` which will return the key marshalled as
+  PEM-encoded PKCS8.
+
+~> **Note** that this does not apply to the private key within the certificate
+  field if `format=pem_bundle` parameter is specified.
 
 - `key_type` `(string: "rsa")` - Specifies the desired key type; must be `rsa`, `ed25519`
   or `ec`. Not suitable for `type=existing` requests.


### PR DESCRIPTION
 - Update the documentation in regards to the private_key_format argument only controls the behavior of the private_key response field and does not modify the encoding of the private key within the pem_bundle.