### PR TITLE
Update issuer usage with ocsp-signing by default

### DIFF
--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -103,10 +103,10 @@ intermediate CAs and "permit" only for root CAs.`,
 	fields["usage"] = &framework.FieldSchema{
 		Type: framework.TypeCommaStringSlice,
 		Description: `Comma-separated list (or string slice) of usages for
-this issuer; valid values are "read-only", "issuing-certificates", and
-"crl-signing". Multiple values may be specified. Read-only is implicit
-and always set.`,
-		Default: []string{"read-only", "issuing-certificates", "crl-signing"},
+this issuer; valid values are "read-only", "issuing-certificates",
+"crl-signing", and "ocsp-signing". Multiple values may be specified. Read-only
+is implicit and always set.`,
+		Default: []string{"read-only", "issuing-certificates", "crl-signing", "ocsp-signing"},
 	}
 	fields["revocation_signature_algorithm"] = &framework.FieldSchema{
 		Type: framework.TypeString,


### PR DESCRIPTION
This option was elided from the default value for the usage field. This results in issuers "losing" `ocsp-signing` when they're `POST` updated. Most issuers will want OCSP signing by default, so it makes sense to add this as the default.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`