### PR TITLE
Update the enos provider source in build_local

### DIFF
--- a/enos/modules/build_local/main.tf
+++ b/enos/modules/build_local/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     enos = {
-      source = "hashicorp.com/qti/enos"
+      source = "app.terraform.io/hashicorp-qti/enos"
     }
   }
 }

--- a/enos/modules/build_local/main.tf
+++ b/enos/modules/build_local/main.tf
@@ -1,11 +1,3 @@
-terraform {
-  required_providers {
-    enos = {
-      source = "app.terraform.io/hashicorp-qti/enos"
-    }
-  }
-}
-
 variable "bundle_path" {
   type    = string
   default = "/tmp/vault.zip"


### PR DESCRIPTION
 - When running enos scenario validate <test> the following error comes up.
 
```
❯ enos scenario validate managed_keys
Scenario: managed_keys [arch:arm64 backend:raft builder:local distro:ubuntu edition:ent seal:awskms]
  Generate: ✅
 Init: ❌

Error: Invalid provider registry host

The host "hashicorp.com" given in in provider source address "hashicorp.com/qti/enos" does not offer a Terraform provider registry.
```