### PR TITLE
UI: Fix KV engine deleting latest version instead of specified version depending on policy

### DIFF
--- a/changelog/17124.txt
+++ b/changelog/17124.txt
@@ -1,0 +1,2 @@
+```release-note:bug
+ui: Fix kv deleting the latest version when not allowed to soft delete (and delete a specific version of a secret)

--- a/ui/app/components/secret-delete-menu.js
+++ b/ui/app/components/secret-delete-menu.js
@@ -129,7 +129,7 @@ export default class SecretDeleteMenu extends Component {
       });
     } else {
       // if they do not have read access on the metadata endpoint we need to pull the version from modelForData so they can perform delete and undelete operations
-      // only perform if no access to metatdata otherwise it will only delete latest version for any deleteType === delete
+      // only perform if no access to metadata otherwise it will only delete latest version for any deleteType === delete
       let currentVersionForNoReadMetadata;
       if (!this.args.canReadSecretMetadata) {
         currentVersionForNoReadMetadata = this.args.modelForData?.version;

--- a/ui/app/templates/components/secret-delete-menu.hbs
+++ b/ui/app/templates/components/secret-delete-menu.hbs
@@ -48,41 +48,31 @@
         {{#unless @modelForData.deleted}}
           {{#if (or this.canSoftDeleteSecretData this.canDeleteSecretData)}}
             <div class="modal-radio-button" data-test-delete-modal="delete-version">
-              {{#if this.canSoftDeleteSecretData}}
-                <RadioButton
-                  id="delete-version"
-                  name="setup-deleteType"
-                  class="radio"
-                  @value="soft-delete"
-                  @groupValue={{this.deleteType}}
-                  @onChange={{fn (mut this.deleteType)}}
-                />
-                <div class="helper-text">
+              <RadioButton
+                id="delete-version"
+                name="setup-deleteType"
+                class="radio"
+                @value={{if this.canSoftDeleteSecretData "soft-delete" "delete-latest-version"}}
+                @groupValue={{this.deleteType}}
+                @onChange={{fn (mut this.deleteType)}}
+              />
+              <div class="helper-text">
+                {{#if this.canSoftDeleteSecretData}}
                   <label for="delete-version" data-test-type-select="delete-version"><strong>Delete this version</strong></label>
                   <p>
                     This deletes Version
                     {{@modelForData.version}}
                     of the secret. It can be un-deleted later.
                   </p>
-                </div>
-              {{else}}
-                <RadioButton
-                  id="delete-version"
-                  name="setup-deleteType"
-                  class="radio"
-                  @value="delete-latest-version"
-                  @groupValue={{this.deleteType}}
-                  @onChange={{fn (mut this.deleteType)}}
-                />
-                <div class="helper-text">
+                {{else}}
                   <label for="delete-version" data-test-type-select="delete-version"><strong>Delete latest version</strong></label>
                   <p>
                     Your policy does not allow deleting a specific version of this secret. This will delete the
                     <strong>latest version</strong>
                     of this secret. It can be un-deleted later.
                   </p>
-                </div>
-              {{/if}}
+                {{/if}}
+              </div>
             </div>
           {{/if}}
         {{/unless}}

--- a/ui/app/templates/components/secret-delete-menu.hbs
+++ b/ui/app/templates/components/secret-delete-menu.hbs
@@ -48,22 +48,41 @@
         {{#unless @modelForData.deleted}}
           {{#if (or this.canSoftDeleteSecretData this.canDeleteSecretData)}}
             <div class="modal-radio-button" data-test-delete-modal="delete-version">
-              <RadioButton
-                id="delete-version"
-                name="setup-deleteType"
-                class="radio"
-                @value={{if this.canSoftDeleteSecretData "soft-delete" "delete-latest-version"}}
-                @groupValue={{this.deleteType}}
-                @onChange={{fn (mut this.deleteType)}}
-              />
-              <div class="helper-text">
-                <label for="delete-version" data-test-type-select="delete-version"><strong>Delete this version</strong></label>
-                <p>
-                  This deletes Version
-                  {{@modelForData.version}}
-                  of the secret. It can be un-deleted later.
-                </p>
-              </div>
+              {{#if this.canSoftDeleteSecretData}}
+                <RadioButton
+                  id="delete-version"
+                  name="setup-deleteType"
+                  class="radio"
+                  @value="soft-delete"
+                  @groupValue={{this.deleteType}}
+                  @onChange={{fn (mut this.deleteType)}}
+                />
+                <div class="helper-text">
+                  <label for="delete-version" data-test-type-select="delete-version"><strong>Delete this version</strong></label>
+                  <p>
+                    This deletes Version
+                    {{@modelForData.version}}
+                    of the secret. It can be un-deleted later.
+                  </p>
+                </div>
+              {{else}}
+                <RadioButton
+                  id="delete-version"
+                  name="setup-deleteType"
+                  class="radio"
+                  @value="delete-latest-version"
+                  @groupValue={{this.deleteType}}
+                  @onChange={{fn (mut this.deleteType)}}
+                />
+                <div class="helper-text">
+                  <label for="delete-version" data-test-type-select="delete-version"><strong>Delete latest version</strong></label>
+                  <p>
+                    Your policy does not allow deleting a specific version of this secret. This will delete the
+                    <strong>latest version</strong>
+                    of this secret. It can be un-deleted later.
+                  </p>
+                </div>
+              {{/if}}
             </div>
           {{/if}}
         {{/unless}}

--- a/ui/app/templates/components/secret-version-menu.hbs
+++ b/ui/app/templates/components/secret-version-menu.hbs
@@ -16,7 +16,12 @@
         {{/if}}
         {{#each (reverse @model.versions) as |secretVersion|}}
           <li class="action">
-            <LinkTo class="link" @query={{hash version=secretVersion.version}} {{on "click" (fn this.closeDropdown D)}}>
+            <LinkTo
+              class="link"
+              @query={{hash version=secretVersion.version}}
+              {{on "click" (fn this.closeDropdown D)}}
+              data-test-version-dropdown-link={{secretVersion.version}}
+            >
               Version
               {{secretVersion.version}}
               {{#if


### PR DESCRIPTION
The following policy grants `delete` capabilities to `some-secret` and allows [deletion of the latest version ](https://www.vaultproject.io/api-docs/secret/kv/kv-v2#delete-latest-version-of-secret) of a secret, but **does not allow** deleting a specific the version of the secret.

```
    path "kv-engine-path/data/some-secret" { capabilities = ["create","read","update","delete","list"] }
    path "kv-engine-path/metadata/*" { capabilities = ["create","update","delete","list","read"] }
    path "kv-engine-path/undelete/*" { capabilities = ["update"] }
```

This was unclear in the UI because the delete modal appeared to offer "Delete this version" as an option. When a user selected that option, they would find that the latest version had been deleted, not an older version as expected (Version 1 in this example).
![image](https://user-images.githubusercontent.com/68122737/190013434-84066c77-ec95-4c94-ad46-dd7a29fa7d41.png)
<hr>


### with fix: 
Now, with the above policy, the modal accurately explains what is happening: 
![image](https://user-images.githubusercontent.com/68122737/190013621-4d732856-7706-4067-a9a0-9409b2439139.png)

And when a policy _includes_ access to the `/delete` endpoint:  `kv-engine-path/delete/*" { capabilities = ["update"] }` 
The modal provides "Delete this version" as an option, allowing the user to delete the selected version
