### PR TITLE
Backport of UI: Fix KV engine deleting latest version instead of specified version depending on policy into release/1.10.x

### DIFF
--- a/changelog/17124.txt
+++ b/changelog/17124.txt
@@ -1,0 +1,2 @@
+```release-note:bug
+ui: Fix kv deleting the latest version when not allowed to soft delete (and delete a specific version of a secret)

--- a/ui/app/templates/components/secret-delete-menu.hbs
+++ b/ui/app/templates/components/secret-delete-menu.hbs
@@ -57,12 +57,21 @@
                 @radioId="delete-version"
               />
               <div class="helper-text">
-                <label for="delete-version" data-test-type-select="delete-version"><strong>Delete this version</strong></label>
-                <p>
-                  This deletes Version
-                  {{@modelForData.version}}
-                  of the secret. It can be un-deleted later.
-                </p>
+                {{#if this.canSoftDeleteSecretData}}
+                  <label for="delete-version" data-test-type-select="delete-version"><strong>Delete this version</strong></label>
+                  <p>
+                    This deletes Version
+                    {{@modelForData.version}}
+                    of the secret. It can be un-deleted later.
+                  </p>
+                {{else}}
+                  <label for="delete-version" data-test-type-select="delete-version"><strong>Delete latest version</strong></label>
+                  <p>
+                    Your policy does not allow deleting a specific version of this secret. This will delete the
+                    <strong>latest version</strong>
+                    of this secret. It can be un-deleted later.
+                  </p>
+                {{/if}}
               </div>
             </div>
           {{/if}}


### PR DESCRIPTION
Backport for #17124 