### PR TITLE
auth/oidc: update docs for google workspace config

### DIFF
--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"

--- a/website/content/docs/auth/jwt/oidc-providers/google.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/google.mdx
@@ -51,9 +51,6 @@ the only OAuth scopes that should be granted are:
 ~> This is an **important security step** in order to give the service account the least set of privileges
 that enable the feature.
 
-The Google service account key file obtained from the steps in the guide must be made available on the
-host that Vault is running on.
-
 #### Configuration
 
 - `provider` `(string: <required>)` - Name of the provider. Must be set to "gsuite".


### PR DESCRIPTION
This PR removes a statement that is no longer true from the OIDC auth docs for Google workspace. You can now provide the contents of the service account JSON file directly via the API.

Additionally, this runs `make fmt` to fix the format check.