### PR TITLE
Fetch CRLs from a user defined URL

### DIFF
--- a/builtin/credential/cert/backend.go
+++ b/builtin/credential/cert/backend.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
-
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -98,7 +97,7 @@ func (b *backend) updateCRLs(ctx context.Context, req *logical.Request) error {
 	for name, crl := range b.crls {
 		if crl.CDP != nil && time.Now().After(crl.CDP.ValidUntil) {
 			if err := b.fetchCRL(ctx, req.Storage, name, &crl); err != nil {
-				err = multierror.Append(errs, err)
+				errs = multierror.Append(errs, err)
 			}
 		}
 	}

--- a/builtin/credential/cert/backend.go
+++ b/builtin/credential/cert/backend.go
@@ -3,6 +3,7 @@ package cert
 import (
 	"context"
 	"crypto/x509"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -83,9 +84,9 @@ func (b *backend) fetchCRL(ctx context.Context, storage logical.Storage, name st
 			return err
 		}
 		crl.CDP.ValidUntil = certList.TBSCertList.NextUpdate
-		b.setCRL(ctx, storage, certList, name, crl.CDP)
+		return b.setCRL(ctx, storage, certList, name, crl.CDP)
 	}
-	return nil
+	return fmt.Errorf("unexpected response code %d fetching CRL from %s", response.StatusCode, crl.CDP.Url)
 }
 
 func (b *backend) updateCRLs(ctx context.Context, req *logical.Request) error {

--- a/builtin/credential/cert/backend.go
+++ b/builtin/credential/cert/backend.go
@@ -19,7 +19,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	if err := b.Setup(ctx, conf); err != nil {
 		return nil, err
 	}
-	if err := b.populateCRLs(ctx, conf.StorageView); err != nil {
+	if err := b.populateCRLsWithoutLock(ctx, conf.StorageView); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/builtin/credential/cert/backend.go
+++ b/builtin/credential/cert/backend.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"github.com/hashicorp/go-multierror"
 	"io"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"

--- a/builtin/credential/cert/backend.go
+++ b/builtin/credential/cert/backend.go
@@ -91,6 +91,8 @@ func (b *backend) fetchCRL(ctx context.Context, storage logical.Storage, name st
 }
 
 func (b *backend) updateCRLs(ctx context.Context, req *logical.Request) error {
+	b.crlUpdateMutex.Lock()
+	defer b.crlUpdateMutex.Unlock()
 	var errs *multierror.Error
 	for name, crl := range b.crls {
 		if crl.CDP != nil && time.Now().After(crl.CDP.ValidUntil) {

--- a/builtin/credential/cert/backend.go
+++ b/builtin/credential/cert/backend.go
@@ -19,7 +19,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	if err := b.Setup(ctx, conf); err != nil {
 		return nil, err
 	}
-	if err := b.populateCRLsWithoutLock(ctx, conf.StorageView); err != nil {
+	if err := b.lockThenpopulateCRLs(ctx, conf.StorageView); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/builtin/credential/cert/path_crls.go
+++ b/builtin/credential/cert/path_crls.go
@@ -223,7 +223,7 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 		if crl, ok := b.crls[name]; ok {
 			if crl.CDP != nil {
 				// Force a fetch for validation but also because it may be an updated URL
-				crl.CDP.ValidUntil = time.Now()
+				crl.CDP.ValidUntil = time.Time{}
 			}
 		}
 		// Can't defer, it gets taken as a write lock in fetchCRL

--- a/builtin/credential/cert/path_crls.go
+++ b/builtin/credential/cert/path_crls.go
@@ -32,7 +32,7 @@ May be DER or PEM encoded. Note: the expiration time
 is ignored; if the CRL is no longer valid, delete it
 using the same name as specified here.`,
 			},
-			"cdp": {
+			"url": {
 				Type:        framework.TypeString,
 				Description: `The URL of a CRL distribution point.  Only one of 'crl' or 'cdp' parameters should be specified.`,
 			},
@@ -209,17 +209,17 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 		if err != nil {
 			return nil, err
 		}
-	} else if cdpRaw, ok := d.GetOk("cdp"); ok {
+	} else if cdpRaw, ok := d.GetOk("url"); ok {
 		cdl := cdpRaw.(string)
 		if cdl == "" {
-			return logical.ErrorResponse("empty CDP url"), nil
+			return logical.ErrorResponse("empty CRL url"), nil
 		}
 		_, err := url2.Parse(cdl)
 		if err != nil {
-			return logical.ErrorResponse("invalid CDP url: %v", err), nil
+			return logical.ErrorResponse("invalid CRL url: %v", err), nil
 		}
 	} else {
-		return logical.ErrorResponse("one of 'crl' or 'cdp' must be provided"), nil
+		return logical.ErrorResponse("one of 'crl' or 'url' must be provided"), nil
 	}
 
 	return nil, nil

--- a/builtin/credential/cert/path_crls.go
+++ b/builtin/credential/cert/path_crls.go
@@ -27,14 +27,14 @@ func pathCRLs(b *backend) *framework.Path {
 
 			"crl": {
 				Type: framework.TypeString,
-				Description: `The public certificate that should be trusted.
+				Description: `The public CRL that should be trusted to attest to certificates' validity statuses.
 May be DER or PEM encoded. Note: the expiration time
 is ignored; if the CRL is no longer valid, delete it
 using the same name as specified here.`,
 			},
 			"cdp": {
 				Type:        framework.TypeString,
-				Description: `The URL of a CRL distribution point.  Only one of crl or cdp parameters should be specified.`,
+				Description: `The URL of a CRL distribution point.  Only one of 'crl' or 'cdp' parameters should be specified.`,
 			},
 		},
 
@@ -271,10 +271,11 @@ Manage Certificate Revocation Lists checked during authentication.
 
 const pathCRLsHelpDesc = `
 This endpoint allows you to create, read, update, and delete the Certificate
-Revocation Lists checked during authentication.
+Revocation Lists checked during authentication, and/or CRL Distribution Point 
+URLs.
 
 When any CRLs are in effect, any login will check the trust chains sent by a
-client against the submitted CRLs. Any chain containing a serial number revoked
+client against the submitted or retrieved CRLs. Any chain containing a serial number revoked
 by one or more of the CRLs causes that chain to be marked as invalid for the
 authentication attempt. Conversely, *any* valid chain -- that is, a chain
 in which none of the serials are revoked by any CRL -- allows authentication.

--- a/builtin/credential/cert/path_crls.go
+++ b/builtin/credential/cert/path_crls.go
@@ -232,6 +232,8 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		return logical.ErrorResponse("one of 'crl' or 'cdp' must be provided"), nil
 	}
 
 	return nil, nil

--- a/builtin/credential/cert/path_crls.go
+++ b/builtin/credential/cert/path_crls.go
@@ -49,7 +49,7 @@ using the same name as specified here.`,
 	}
 }
 
-func (b *backend) populateCRLsWithoutLock(ctx context.Context, storage logical.Storage) error {
+func (b *backend) lockThenpopulateCRLs(ctx context.Context, storage logical.Storage) error {
 	b.crlUpdateMutex.Lock()
 	defer b.crlUpdateMutex.Unlock()
 	return b.populateCRLs(ctx, storage)
@@ -139,7 +139,7 @@ func (b *backend) pathCRLDelete(ctx context.Context, req *logical.Request, d *fr
 		return logical.ErrorResponse(`"name" parameter cannot be empty`), nil
 	}
 
-	if err := b.populateCRLsWithoutLock(ctx, req.Storage); err != nil {
+	if err := b.lockThenpopulateCRLs(ctx, req.Storage); err != nil {
 		return nil, err
 	}
 
@@ -170,7 +170,7 @@ func (b *backend) pathCRLRead(ctx context.Context, req *logical.Request, d *fram
 		return logical.ErrorResponse(`"name" parameter must be set`), nil
 	}
 
-	if err := b.populateCRLsWithoutLock(ctx, req.Storage); err != nil {
+	if err := b.lockThenpopulateCRLs(ctx, req.Storage); err != nil {
 		return nil, err
 	}
 

--- a/builtin/credential/cert/path_crls_test.go
+++ b/builtin/credential/cert/path_crls_test.go
@@ -1,0 +1,184 @@
+package cert
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/certutil"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCRLFetch(t *testing.T) {
+	storage := &logical.InmemStorage{}
+
+	lb, err := Factory(context.Background(), &logical.BackendConfig{
+		System: &logical.StaticSystemView{
+			DefaultLeaseTTLVal: 300 * time.Second,
+			MaxLeaseTTLVal:     1800 * time.Second,
+		},
+		StorageView: storage,
+	})
+
+	require.NoError(t, err)
+	b := lb.(*backend)
+	closeChan := make(chan bool)
+	go func() {
+		t := time.NewTicker(50 * time.Millisecond)
+		for {
+			select {
+			case <-t.C:
+				b.PeriodicFunc(context.Background(), &logical.Request{Storage: storage})
+			case <-closeChan:
+				break
+			}
+		}
+	}()
+	defer close(closeChan)
+
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+	connState, err := testConnState("test-fixtures/keys/cert.pem",
+		"test-fixtures/keys/key.pem", "test-fixtures/root/rootcacert.pem")
+	require.NoError(t, err)
+	caPEM, err := ioutil.ReadFile("test-fixtures/root/rootcacert.pem")
+	require.NoError(t, err)
+	caKeyPEM, err := ioutil.ReadFile("test-fixtures/keys/key.pem")
+	require.NoError(t, err)
+	certPEM, err := ioutil.ReadFile("test-fixtures/keys/cert.pem")
+
+	caBundle, err := certutil.ParsePEMBundle(string(caPEM))
+	require.NoError(t, err)
+	bundle, err := certutil.ParsePEMBundle(string(certPEM) + "\n" + string(caKeyPEM))
+	require.NoError(t, err)
+	//  Entry with one cert first
+
+	revocationListTemplate := &x509.RevocationList{
+		RevokedCertificates: []pkix.RevokedCertificate{
+			{
+				SerialNumber:   big.NewInt(1),
+				RevocationTime: time.Now(),
+			},
+		},
+		Number:             big.NewInt(1),
+		ThisUpdate:         time.Now(),
+		NextUpdate:         time.Now().Add(50 * time.Millisecond),
+		SignatureAlgorithm: x509.SHA1WithRSA,
+	}
+
+	crlBytes, err := x509.CreateRevocationList(rand.Reader, revocationListTemplate, caBundle.Certificate, bundle.PrivateKey)
+	require.NoError(t, err)
+
+	var serverURL *url.URL
+	crlServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Host == serverURL.Host {
+			w.Write(crlBytes)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	serverURL, _ = url.Parse(crlServer.URL)
+
+	req := &logical.Request{
+		Connection: &logical.Connection{
+			ConnState: &connState,
+		},
+		Storage: storage,
+		Auth:    &logical.Auth{},
+	}
+
+	fd := &framework.FieldData{
+		Raw: map[string]interface{}{
+			"name":        "test",
+			"certificate": string(caPEM),
+			"policies":    "foo,bar",
+		},
+		Schema: pathCerts(b).Fields,
+	}
+
+	resp, err := b.pathCertWrite(context.Background(), req, fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	empty_login_fd := &framework.FieldData{
+		Raw:    map[string]interface{}{},
+		Schema: pathLogin(b).Fields,
+	}
+	resp, err = b.pathLogin(context.Background(), req, empty_login_fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.IsError() {
+		t.Fatalf("got error: %#v", *resp)
+	}
+
+	// Set a bad CRL
+	fd = &framework.FieldData{
+		Raw: map[string]interface{}{
+			"name": "testcrl",
+			"url":  "http://wrongserver.com",
+		},
+		Schema: pathCRLs(b).Fields,
+	}
+	resp, err = b.pathCRLWrite(context.Background(), req, fd)
+	if err == nil {
+		t.Fatal(err)
+	}
+	if resp.IsError() {
+		t.Fatalf("got error: %#v", *resp)
+	}
+
+	// Set good CRL
+	fd = &framework.FieldData{
+		Raw: map[string]interface{}{
+			"name": "testcrl",
+			"url":  crlServer.URL,
+		},
+		Schema: pathCRLs(b).Fields,
+	}
+	resp, err = b.pathCRLWrite(context.Background(), req, fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.IsError() {
+		t.Fatalf("got error: %#v", *resp)
+	}
+
+	if len(b.crls["testcrl"].Serials) != 1 {
+		t.Fatalf("wrong number of certs in CRL")
+	}
+
+	// Add a cert to the CRL, then wait to see if it gets automatically picked up
+	revocationListTemplate.RevokedCertificates = []pkix.RevokedCertificate{
+		{
+			SerialNumber:   big.NewInt(1),
+			RevocationTime: revocationListTemplate.RevokedCertificates[0].RevocationTime,
+		},
+		{
+			SerialNumber:   big.NewInt(2),
+			RevocationTime: time.Now(),
+		},
+	}
+	revocationListTemplate.ThisUpdate = time.Now()
+	revocationListTemplate.NextUpdate = time.Now().Add(1 * time.Minute)
+	revocationListTemplate.Number = big.NewInt(2)
+
+	crlBytes, err = x509.CreateRevocationList(rand.Reader, revocationListTemplate, caBundle.Certificate, bundle.PrivateKey)
+	require.NoError(t, err)
+	time.Sleep(60 * time.Millisecond)
+	if len(b.crls["testcrl"].Serials) != 2 {
+		t.Fatalf("wrong number of certs in CRL")
+	}
+}

--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -10,11 +10,12 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/policyutil"
 	"github.com/hashicorp/vault/sdk/logical"
-	"strings"
 
 	"github.com/hashicorp/vault/sdk/helper/cidrutil"
 	glob "github.com/ryanuber/go-glob"

--- a/changelog/17136.txt
+++ b/changelog/17136.txt
@@ -1,0 +1,5 @@
+```release-note:improvement
+auth/cert: Operators can now specify a CRL distribution point URL, in which
+case the cert auth engine will fetch and use the CRL from that location
+rather than needing to push CRLs directly to auth/cert.
+```

--- a/website/content/docs/auth/cert.mdx
+++ b/website/content/docs/auth/cert.mdx
@@ -28,10 +28,8 @@ configuration. This is because the certificates are sent through TLS communicati
 Since Vault 0.4, the method supports revocation checking.
 
 An authorized user can submit PEM-formatted CRLs identified by a given name;
-these can be updated or deleted at will. (Note: Vault **does not** fetch CRLs;
-the CRLs themselves and any updates must be pushed into Vault when desired,
-such as via a `cron` job that fetches them from the source and pushes them into
-Vault.)
+these can be updated or deleted at will. They may also set the URL of a
+trusted CRL distribution point, and have Vault fetch the CRL as needed.
 
 When there are CRLs present, at the time of client authentication:
 

--- a/website/content/docs/auth/jwt/oidc-providers/google.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/google.mdx
@@ -51,9 +51,6 @@ the only OAuth scopes that should be granted are:
 ~> This is an **important security step** in order to give the service account the least set of privileges
 that enable the feature.
 
-The Google service account key file obtained from the steps in the guide must be made available on the
-host that Vault is running on.
-
 #### Configuration
 
 - `provider` `(string: <required>)` - Name of the provider. Must be set to "gsuite".


### PR DESCRIPTION
Extends path_crl to accept either a CRL in PEM or DER format _or_ a URL for the CRL Distribution Point.  In the latter case, we periodically fetch that CRL according to it's validity dates.