### PR TITLE
Add 'internal/ui/resultant-acl' so it can be accessed unauthenticated

### DIFF
--- a/changelog/17137.txt
+++ b/changelog/17137.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Allow internal/ui/resultant-acl API endpoint to be accessible without a token (while unauthenticated)
+```

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -122,6 +122,7 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 				"internal/ui/mounts",
 				"internal/ui/mounts/*",
 				"internal/ui/namespaces",
+				"internal/ui/resultant-acl",
 				"replication/performance/status",
 				"replication/dr/status",
 				"replication/dr/secondary/promote",


### PR DESCRIPTION
Fixes issue https://github.com/hashicorp/vault/issues/14097
