### PR TITLE
Load existing CRLs on startup and after invalidate

### DIFF
--- a/builtin/credential/cert/backend.go
+++ b/builtin/credential/cert/backend.go
@@ -14,6 +14,9 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	if err := b.Setup(ctx, conf); err != nil {
 		return nil, err
 	}
+	if err := b.populateCRLs(ctx, conf.StorageView); err != nil {
+		return nil, err
+	}
 	return b, nil
 }
 

--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -82,6 +82,12 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, data *fra
 		return nil, err
 	}
 
+	if b.crls == nil {
+		if err := b.populateCRLs(ctx, req.Storage); err != nil {
+			return nil, err
+		}
+	}
+
 	var matched *ParsedCert
 	if verifyResp, resp, err := b.verifyCredentials(ctx, req, data); err != nil {
 		return nil, err

--- a/changelog/17138.txt
+++ b/changelog/17138.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/cert: Vault does not initially load the CRLs in cert auth unless the read/write CRL endpoint is hit.
+```


### PR DESCRIPTION
Currently Vault doesn't do this, so CRLs aren't in force until the CRL read or write endpoint is hit.