### PR TITLE
Prevent Requests to resultant-acl Endpoint When Unauthenticated

### DIFF
--- a/changelog/17139.txt
+++ b/changelog/17139.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+ui: Prevents requests to /sys/internal/ui/resultant-acl endpoint when unauthenticated
+```
+```release-note:improvement
+website/docs: Removes mentions of unauthenticated from internal ui resultant-acl doc
+```

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -72,7 +72,9 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
     const id = this.getClusterId(params);
     if (id) {
       this.auth.setCluster(id);
-      await this.permissions.getPaths.perform();
+      if (this.auth.currentToken) {
+        await this.permissions.getPaths.perform();
+      }
       return this.version.fetchFeatures();
     } else {
       return reject({ httpStatus: 404, message: 'not found', path: params.cluster_name });

--- a/website/content/api-docs/system/internal-ui-resultant-acl.mdx
+++ b/website/content/api-docs/system/internal-ui-resultant-acl.mdx
@@ -8,11 +8,10 @@ description: >-
 # `/sys/internal/ui/resultant-acl`
 
 The `/sys/internal/ui/resultant-acl` endpoint is used to expose resultant-acl
-to the UI so that it can change its behavior in response, even before a user logs in.
+to the UI so that it can change its behavior in response.
 
-This is currently only being used internally for the UI and is
-an unauthenticated endpoint. Due to the nature of its intended usage, there is no
-guarantee on backwards compatibility for this endpoint.
+This is currently only being used internally for the UI. Due to the nature of its
+intended usage, there is no guarantee on backwards compatibility for this endpoint.
 
 ## Get Resultant-acl
 


### PR DESCRIPTION
In PR #12713 the `/sys/internal/ui/resultant-acl` endpoint was made to be authenticated. As mentioned in issue #14097 the UI was continuing to make requests to this endpoint when unauthenticated so that has been updated as well as an update to the api doc. 