### PR TITLE
semgrep: Enforce no loop vars in goroutines

### DIFF
--- a/tools/semgrep/ci/loopclosure.yml
+++ b/tools/semgrep/ci/loopclosure.yml
@@ -1,0 +1,28 @@
+rules:
+  - id: loopclosure
+    patterns:
+      - pattern-inside: |
+          for $A, $B := range $C {
+            ...
+          }
+      - pattern-inside: |
+          go func() {
+            ...
+          }()
+      - pattern-not-inside: |
+          go func(..., $B, ...) {
+            ...
+          }(..., $B, ...)
+      - pattern-not-inside: |
+          go func() {
+            ...
+            for ... {
+              ...
+            }
+            ...
+          }()
+      - pattern: $B
+    message: Loop variable $B used inside goroutine
+    languages:
+      - go
+    severity: WARNING


### PR DESCRIPTION
`go tool vet -loopclosure` does not find all instances of loop closure captures. Add a check to catch loop vars in goroutines. This is taken from the Nomad project's semgrep rules: https://github.com/hashicorp/nomad/blob/d83ae577f3073e226e9740019eefc3c08ece161f/.semgrep/loopclosure.yml