### PR TITLE
ldap: use canonicalized (lowercase) username when username_as_alias set

### DIFF
--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -196,7 +196,7 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username stri
 	policies = strutil.RemoveDuplicates(policies, true)
 
 	if usernameAsAlias {
-		return username, policies, ldapResponse, allGroups, nil
+		return canonicalUsername, policies, ldapResponse, allGroups, nil
 	}
 
 	entityAliasAttribute, err := ldapClient.GetUserAliasAttributeValue(cfg.ConfigEntry, c, username)

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -642,6 +642,18 @@ func TestBackend_basic_authbind_userfilter(t *testing.T) {
 			testAccStepLoginNoAttachedPolicies(t, "hermes conrad", "hermes"),
 		},
 	})
+
+	// Ensure the same entity is used regardless of case when username_as_alias has been set
+	cfg.UsernameAsAlias = true
+	entity_id = ""
+	logicaltest.Test(t, logicaltest.TestCase{
+		CredentialBackend: b,
+		Steps: []logicaltest.TestStep{
+			testAccStepConfigUrl(t, cfg),
+			testAccStepLoginReturnsSameEntity(t, "hermes conrad", "hermes", &entity_id),
+			testAccStepLoginReturnsSameEntity(t, "Hermes conraD", "hermes", &entity_id),
+		},
+	})
 }
 
 func TestBackend_basic_authbind_metadata_name(t *testing.T) {

--- a/changelog/17146.txt
+++ b/changelog/17146.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ldap: ensure usernames are normalized to lowercase when username_as_alias is set
+```


### PR DESCRIPTION
The previous behavior was slightly erroneous -- the username is [conditionally lowercased](https://github.com/hashicorp/vault/blob/v1.11.3/builtin/credential/ldap/backend.go#L159-L163), but that updated username was not being returned when username_as_alias was set.

Fixes: #16719