### PR TITLE
Adds ldap secrets to plugin registry and updates to v0.9.0

### DIFF
--- a/changelog/17152.txt
+++ b/changelog/17152.txt
@@ -1,0 +1,4 @@
+```release-note:feature
+**LDAP Secrets Engine**: Adds the `ldap` secrets engine with service account check-out 
+functionality for all supported schemas.
+```

--- a/command/secrets_enable_test.go
+++ b/command/secrets_enable_test.go
@@ -12,9 +12,10 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-// logicalBackendAdjustmentFactor is set to 1 for the database backend
-// which is a plugin but not found in go.mod files
-var logicalBackendAdjustmentFactor = 1
+// logicalBackendAdjustmentFactor is set to plus 1 for the database backend
+// which is a plugin but not found in go.mod files, and minus 1 for the ldap
+// and openldap secret backends which have the same underlying plugin.
+var logicalBackendAdjustmentFactor = 1 - 1
 
 func testSecretsEnableCommand(tb testing.TB) (*cli.MockUi, *SecretsEnableCommand) {
 	tb.Helper()

--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.1
 	github.com/hashicorp/vault-plugin-secrets-kv v0.12.1
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0
-	github.com/hashicorp/vault-plugin-secrets-openldap v0.8.0
+	github.com/hashicorp/vault-plugin-secrets-openldap v0.9.0
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.5.0
 	github.com/hashicorp/vault-testing-stepwise v0.1.2
 	github.com/hashicorp/vault/api v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -1146,8 +1146,8 @@ github.com/hashicorp/vault-plugin-secrets-kv v0.12.1 h1:Nef6kmnCQQRRdYzA52diUnx4
 github.com/hashicorp/vault-plugin-secrets-kv v0.12.1/go.mod h1:9V2Ecim3m/qw+YAQelUeFADqZ1GVo8xwoLqfKsqh9pI=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0 h1:EDyX/utLxEKGETeGAyWe4QNoKwIfCw6VpEzKLb8zudc=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0/go.mod h1:PLx2vxXukfsKsDRo/PlG4fxmJ1d+H2h82wT3vf4buuI=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.8.0 h1:WJk5wRg861RlTd8xN6To/sRw3SnEUzqXpWml98GPZks=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.8.0/go.mod h1:XC7R76jZiuD50ENel+I1/Poz5phaEQg9d6Dko8DF3Ts=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.9.0 h1:/6FQzNB4zjep7O14pkVOapwRJvnQ4gINGAc1Ss1IYg8=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.9.0/go.mod h1:o7mF9tWgDkAD5OvvXWM3bOCqN+n/cCpaMm1CrEUZkHc=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.5.0 h1:NbQW1Z2+oIn8v4jjqLBbxDas0Uw0bzV74da4BQsdRow=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.5.0/go.mod h1:GzYAJYytgbNNyT3S7rspz1cLE53E1oajFbEtaDUlVGU=
 github.com/hashicorp/vault-testing-stepwise v0.1.1/go.mod h1:3vUYn6D0ZadvstNO3YQQlIcp7u1a19MdoOC0NQ0yaOE=

--- a/helper/builtinplugins/registry.go
+++ b/helper/builtinplugins/registry.go
@@ -22,7 +22,7 @@ import (
 	logicalKube "github.com/hashicorp/vault-plugin-secrets-kubernetes"
 	logicalKv "github.com/hashicorp/vault-plugin-secrets-kv"
 	logicalMongoAtlas "github.com/hashicorp/vault-plugin-secrets-mongodbatlas"
-	logicalOpenLDAP "github.com/hashicorp/vault-plugin-secrets-openldap"
+	logicalLDAP "github.com/hashicorp/vault-plugin-secrets-openldap"
 	logicalTerraform "github.com/hashicorp/vault-plugin-secrets-terraform"
 	credAppId "github.com/hashicorp/vault/builtin/credential/app-id"
 	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
@@ -162,7 +162,8 @@ func newRegistry() *registry {
 				DeprecationStatus: consts.PendingRemoval,
 			},
 			"nomad":    {Factory: logicalNomad.Factory},
-			"openldap": {Factory: logicalOpenLDAP.Factory},
+			"openldap": {Factory: logicalLDAP.Factory},
+			"ldap":     {Factory: logicalLDAP.Factory},
 			"pki":      {Factory: logicalPki.Factory},
 			"postgresql": {
 				Factory:           logicalPostgres.Factory,

--- a/helper/builtinplugins/registry_test.go
+++ b/helper/builtinplugins/registry_test.go
@@ -91,7 +91,7 @@ func Test_RegistryKeyCounts(t *testing.T) {
 		{
 			name:       "number of secrets plugins",
 			pluginType: consts.PluginTypeSecrets,
-			want:       23,
+			want:       24,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR updates vault-plugin-secrets-openldap to [v0.9.0](https://github.com/hashicorp/vault-plugin-secrets-openldap/releases/tag/v0.9.0).

Additionally, this adds the "ldap" secrets engine to the plugin registry. Eventually, the ability to enable/disable the "ad" and "openldap" secrets engines will be deprecated in favor of the unified "ldap" secrets engine.

Steps:
```
go get github.com/hashicorp/vault-plugin-secrets-openldap@v0.9.0
go mod tidy
```