### PR TITLE
UI: Add 'disable' to CRL config

### DIFF
--- a/changelog/17153.txt
+++ b/changelog/17153.txt
@@ -1,2 +1,2 @@
 ```release-note:improvement
-ui: add 'disable' param to pki crl configuration, update default lease duration when expiry is toggled off
+ui: add 'disable' param to pki crl configuration

--- a/changelog/17153.txt
+++ b/changelog/17153.txt
@@ -1,0 +1,2 @@
+```release-note:improvement
+ui: add 'disable' param to pki crl configuration, update default lease duration when expiry is toggled off

--- a/ui/app/components/pki/config-pki.js
+++ b/ui/app/components/pki/config-pki.js
@@ -39,6 +39,8 @@ export default Component.extend({
   actions: {
     save(section) {
       this.set('loading', true);
+      // if 0 returned from TTL component, reset expiry to default lease duration
+      if (Number(this.config.expiry) === 0) this.config.expiry = '72h';
       const config = this.config;
       config
         .save({

--- a/ui/app/components/pki/config-pki.js
+++ b/ui/app/components/pki/config-pki.js
@@ -6,6 +6,7 @@ export default Component.extend({
   classNames: 'config-pki',
   flashMessages: service(),
   errors: null,
+  buildCrl: true,
   /*
    *
    * @param String
@@ -39,8 +40,8 @@ export default Component.extend({
   actions: {
     save(section) {
       this.set('loading', true);
-      // if 0 returned from TTL component, reset expiry to default lease duration
-      if (Number(this.config.expiry) === 0) this.config.expiry = '72h';
+      // set 'disable' here from buildCrl toggle state
+      this.config.set('disable', !this.buildCrl);
       const config = this.config;
       config
         .save({

--- a/ui/app/components/pki/config-pki.js
+++ b/ui/app/components/pki/config-pki.js
@@ -1,12 +1,12 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import { get } from '@ember/object';
+import { get, computed } from '@ember/object';
 
 export default Component.extend({
   classNames: 'config-pki',
   flashMessages: service(),
   errors: null,
-  buildCrl: true,
+  buildCrl: computed.not('config.disable'),
   /*
    *
    * @param String
@@ -40,8 +40,10 @@ export default Component.extend({
   actions: {
     save(section) {
       this.set('loading', true);
-      // set 'disable' here from buildCrl toggle state
-      this.config.set('disable', !this.buildCrl);
+      if (section === 'crl') {
+        // set 'disable' here from buildCrl toggle state
+        this.config.set('disable', !this.buildCrl);
+      }
       const config = this.config;
       config
         .save({

--- a/ui/app/components/pki/config-pki.js
+++ b/ui/app/components/pki/config-pki.js
@@ -1,12 +1,11 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import { get, computed } from '@ember/object';
+import { get } from '@ember/object';
 
 export default Component.extend({
   classNames: 'config-pki',
   flashMessages: service(),
   errors: null,
-  buildCrl: computed.not('config.disable'),
   /*
    *
    * @param String
@@ -38,12 +37,12 @@ export default Component.extend({
   loading: false,
 
   actions: {
+    handleCrlTtl({ enabled, goSafeTimeString }) {
+      this.config.disable = !enabled; // when TTL enabled, config disable=false
+      this.config.expiry = goSafeTimeString;
+    },
     save(section) {
       this.set('loading', true);
-      if (section === 'crl') {
-        // set 'disable' here from buildCrl toggle state
-        this.config.set('disable', !this.buildCrl);
-      }
       const config = this.config;
       config
         .save({

--- a/ui/app/models/pki/pki-config.js
+++ b/ui/app/models/pki/pki-config.js
@@ -51,12 +51,6 @@ export default Model.extend({
     return this.attrList(keys);
   }),
   //crl
-  expiry: attr({
-    label: 'CRL building enabled',
-    helperTextEnabled: 'The CRL will expire after',
-    defaultValue: '72h',
-    editType: 'ttl',
-    hideToggle: true, // this form field is wrapped by a toggle that sets the 'disable' attr
-  }),
+  expiry: attr('string', { defaultValue: '72h' }),
   disable: attr('boolean', { defaultValue: false }),
 });

--- a/ui/app/models/pki/pki-config.js
+++ b/ui/app/models/pki/pki-config.js
@@ -51,12 +51,12 @@ export default Model.extend({
     return this.attrList(keys);
   }),
   //crl
-  disable: attr('boolean', { defaultValue: false }),
   expiry: attr({
     label: 'CRL building enabled',
     helperTextEnabled: 'The CRL will expire after',
     defaultValue: '72h',
     editType: 'ttl',
-    hideToggle: true,
+    hideToggle: true, // this form field is wrapped by a toggle that sets the 'disable' attr
   }),
+  disable: attr('boolean', { defaultValue: false }),
 });

--- a/ui/app/models/pki/pki-config.js
+++ b/ui/app/models/pki/pki-config.js
@@ -51,13 +51,12 @@ export default Model.extend({
     return this.attrList(keys);
   }),
   //crl
+  disable: attr('boolean', { defaultValue: false }),
   expiry: attr({
+    label: 'CRL building enabled',
+    helperTextEnabled: 'The CRL will expire after',
     defaultValue: '72h',
     editType: 'ttl',
-    helperTextEnabled: 'The CRL will expire after',
-  }),
-  disable: attr('boolean', {
-    defaultValue: false,
-    subText: 'If disabled the CRL will not be built.',
+    hideToggle: true,
   }),
 });

--- a/ui/app/models/pki/pki-config.js
+++ b/ui/app/models/pki/pki-config.js
@@ -47,12 +47,17 @@ export default Model.extend({
   }),
 
   crlAttrs: computed(function () {
-    let keys = ['expiry'];
+    let keys = ['expiry', 'disable'];
     return this.attrList(keys);
   }),
   //crl
   expiry: attr({
     defaultValue: '72h',
     editType: 'ttl',
+    helperTextEnabled: 'The CRL will expire after',
+  }),
+  disable: attr('boolean', {
+    defaultValue: false,
+    subText: 'If disabled the CRL will not be built.',
   }),
 });

--- a/ui/app/templates/components/pki/config-pki.hbs
+++ b/ui/app/templates/components/pki/config-pki.hbs
@@ -16,28 +16,21 @@
 
 <MessageError @model={{this.config}} @errors={{this.errors}} />
 <form {{action "save" this.section on="submit"}} class="box is-shadowless is-marginless is-fullwidth has-slim-padding">
-  {{#let (get this.config (concat this.section "Attrs")) as |sectionAttrs|}}
-    {{#if (eq this.section "crl")}}
-      <Toggle
-        @name="show-build-crl"
-        @status="success"
-        @size="small"
-        @onChange={{action (mut this.buildCrl)}}
-        @checked={{this.buildCrl}}
-      >
-        {{#if this.buildCrl}}
-          <FormField @attr={{get sectionAttrs "0"}} @model={{this.config}} @data-test-field="expiry" />
-        {{else}}
-          <span class="field ttl-picker-label">CRL building disabled</span><br />
-          <div class="description has-text-grey">The CRL will not be built.</div>
-        {{/if}}
-      </Toggle>
-    {{else}}
-      {{#each sectionAttrs as |attr|}}
-        <FormField @attr={{attr}} @model={{this.config}} @data-test-field={{attr.name}} />
-      {{/each}}
-    {{/if}}
-  {{/let}}
+  {{#if (eq this.section "crl")}}
+    <TtlPicker2
+      data-test-input="expiry"
+      @onChange={{action "handleCrlTtl"}}
+      @label={{if (get this.config "disable") "CRL building disabled" "CRL building enabled"}}
+      @helperTextDisabled="The CRL will not be built."
+      @helperTextEnabled="The CRL will expire after"
+      @initialValue={{get this.config "expiry"}}
+      @initialEnabled={{not (get this.config "disable")}}
+    />
+  {{else}}
+    {{#each (get this.config (concat this.section "Attrs")) as |attr|}}
+      <FormField @attr={{attr}} @model={{this.config}} @data-test-field={{attr.name}} />
+    {{/each}}
+  {{/if}}
   <div class="field has-top-margin-m is-grouped box is-fullwidth is-bottomless">
     <div class="control">
       <button

--- a/ui/app/templates/components/pki/config-pki.hbs
+++ b/ui/app/templates/components/pki/config-pki.hbs
@@ -16,10 +16,23 @@
 
 <MessageError @model={{this.config}} @errors={{this.errors}} />
 <form {{action "save" this.section on="submit"}} class="box is-shadowless is-marginless is-fullwidth has-slim-padding">
-  {{#each (get this.config (concat this.section "Attrs")) as |attr|}}
-    <FormField @attr={{attr}} @model={{this.config}} @data-test-field={{attr.name}} />
-  {{/each}}
-  <div class="field is-grouped box is-fullwidth is-bottomless">
+  <Toggle
+    @name="show-build-crl"
+    @status="success"
+    @size="small"
+    @onChange={{action (mut this.buildCrl)}}
+    @checked={{this.buildCrl}}
+  >
+    {{#if this.buildCrl}}
+      {{#let (get this.config (concat this.section "Attrs")) as |crlAttrs|}}
+        <FormField @attr={{get crlAttrs "0"}} @model={{this.config}} @data-test-field="expiry" />
+      {{/let}}
+    {{else}}
+      <span class="field ttl-picker-label">CRL building disabled</span><br />
+      <div class="description has-text-grey">The CRL will not be built.</div>
+    {{/if}}
+  </Toggle>
+  <div class="field has-top-margin-m is-grouped box is-fullwidth is-bottomless">
     <div class="control">
       <button
         data-test-submit

--- a/ui/app/templates/components/pki/config-pki.hbs
+++ b/ui/app/templates/components/pki/config-pki.hbs
@@ -16,22 +16,28 @@
 
 <MessageError @model={{this.config}} @errors={{this.errors}} />
 <form {{action "save" this.section on="submit"}} class="box is-shadowless is-marginless is-fullwidth has-slim-padding">
-  <Toggle
-    @name="show-build-crl"
-    @status="success"
-    @size="small"
-    @onChange={{action (mut this.buildCrl)}}
-    @checked={{this.buildCrl}}
-  >
-    {{#if this.buildCrl}}
-      {{#let (get this.config (concat this.section "Attrs")) as |crlAttrs|}}
-        <FormField @attr={{get crlAttrs "0"}} @model={{this.config}} @data-test-field="expiry" />
-      {{/let}}
+  {{#let (get this.config (concat this.section "Attrs")) as |sectionAttrs|}}
+    {{#if (eq this.section "crl")}}
+      <Toggle
+        @name="show-build-crl"
+        @status="success"
+        @size="small"
+        @onChange={{action (mut this.buildCrl)}}
+        @checked={{this.buildCrl}}
+      >
+        {{#if this.buildCrl}}
+          <FormField @attr={{get sectionAttrs "0"}} @model={{this.config}} @data-test-field="expiry" />
+        {{else}}
+          <span class="field ttl-picker-label">CRL building disabled</span><br />
+          <div class="description has-text-grey">The CRL will not be built.</div>
+        {{/if}}
+      </Toggle>
     {{else}}
-      <span class="field ttl-picker-label">CRL building disabled</span><br />
-      <div class="description has-text-grey">The CRL will not be built.</div>
+      {{#each sectionAttrs as |attr|}}
+        <FormField @attr={{attr}} @model={{this.config}} @data-test-field={{attr.name}} />
+      {{/each}}
     {{/if}}
-  </Toggle>
+  {{/let}}
   <div class="field has-top-margin-m is-grouped box is-fullwidth is-bottomless">
     <div class="control">
       <button

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -114,7 +114,7 @@ export default class FormFieldComponent extends Component {
   }
   @action
   setAndBroadcastTtl(value) {
-    const alwaysSendValue = this.valuePath === 'expiry' || this.valuePath === 'safetyBuffer';
+    const alwaysSendValue = this.valuePath === 'safetyBuffer';
     let valueToSet = value.enabled === true || alwaysSendValue ? `${value.seconds}s` : 0;
     this.setAndBroadcast(`${valueToSet}`);
   }

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -114,7 +114,7 @@ export default class FormFieldComponent extends Component {
   }
   @action
   setAndBroadcastTtl(value) {
-    const alwaysSendValue = this.valuePath === 'safetyBuffer';
+    const alwaysSendValue = this.valuePath === 'expiry' || this.valuePath === 'safetyBuffer';
     let valueToSet = value.enabled === true || alwaysSendValue ? `${value.seconds}s` : 0;
     this.setAndBroadcast(`${valueToSet}`);
   }

--- a/ui/tests/integration/components/pki/config-pki-test.js
+++ b/ui/tests/integration/components/pki/config-pki-test.js
@@ -1,7 +1,7 @@
 import { resolve } from 'rsvp';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { create } from 'ember-cli-page-object';
 import configPki from 'vault/tests/pages/components/pki/config-pki';
@@ -11,71 +11,72 @@ const component = create(configPki);
 module('Integration | Component | config pki', function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
+  hooks.beforeEach(async function () {
     this.owner.lookup('service:flash-messages').registerTypes(['success']);
+    this.store = this.owner.lookup('service:store');
+    this.config = this.store.createRecord('pki/pki-config');
+    this.mockConfigSave = function (saveFn) {
+      const { tidyAttrs, crlAttrs, urlsAttrs } = this.config;
+      return {
+        save: saveFn,
+        rollbackAttributes: () => {},
+        tidyAttrs,
+        crlAttrs,
+        urlsAttrs,
+        disable: false,
+        set: () => {},
+      };
+    };
   });
 
-  const config = function (saveFn) {
-    return {
-      save: saveFn,
-      rollbackAttributes: () => {},
-      tidyAttrs: [
-        {
-          type: 'boolean',
-          name: 'tidyCertStore',
-        },
-        {
-          type: 'string',
-          name: 'anotherAttr',
-        },
-      ],
-      crlAttrs: [
-        {
-          type: 'string',
-          name: 'crl',
-        },
-      ],
-      urlsAttrs: [
-        {
-          type: 'string',
-          name: 'urls',
-        },
-      ],
-    };
-  };
-
-  const setupAndRender = async function (context, section = 'tidy') {
-    context.set('config', config());
+  const setupAndRender = async function (context, config, section = 'tidy') {
+    context.set('config', config);
     context.set('section', section);
     await context.render(hbs`<Pki::ConfigPki @section={{section}} @config={{config}} />`);
   };
 
   test('it renders tidy section', async function (assert) {
-    await setupAndRender(this);
+    await setupAndRender(this, this.config);
     assert.ok(component.text.startsWith('You can tidy up the backend'));
     assert.notOk(component.hasTitle, 'No title for tidy section');
-    assert.equal(component.fields.length, 2);
-    assert.ok(component.fields.objectAt(0).labelText, 'Tidy cert store');
-    assert.ok(component.fields.objectAt(1).labelText, 'Another attr');
+    assert.equal(component.fields.length, 3, 'renders all three tidy fields');
+    assert.ok(component.fields.objectAt(0).labelText, 'Tidy the Certificate Store');
+    assert.ok(component.fields.objectAt(1).labelText, 'Tidy the Revocation List (CRL)');
+    assert.ok(component.fields.objectAt(1).labelText, 'Safety buffer');
   });
 
   test('it renders crl section', async function (assert) {
-    await setupAndRender(this, 'crl');
+    await setupAndRender(this, this.config, 'crl');
     assert.ok(component.hasTitle, 'renders the title');
     assert.equal(component.title, 'Certificate Revocation List (CRL) config');
     assert.ok(component.text.startsWith('Set the duration for which the generated CRL'));
     assert.equal(component.fields.length, 1);
     assert.ok(component.fields.objectAt(0).labelText, 'Crl');
+    assert
+      .dom('[data-test-input="expiry"]')
+      .hasText(
+        'CRL building enabled The CRL will expire after seconds minutes hours days',
+        'renders enabled field title and subtext'
+      );
+    assert.dom('[data-test-toggle-input="show-build-crl"]').isChecked('defaults to enabling CRL build');
+    assert.dom('[data-test-ttl-value="CRL building enabled"]').hasValue('3', 'default value is 3 (72h)');
+    assert.dom('[data-test-select="ttl-unit"]').hasValue('d', 'default unit value is days');
+    await click('[data-test-toggle-input="show-build-crl"]');
+    assert
+      .dom('[data-test-toggle-label]')
+      .hasText('CRL building disabled The CRL will not be built.', 'renders disabled text when toggled off');
   });
 
   test('it renders urls section', async function (assert) {
-    await setupAndRender(this, 'urls');
+    await setupAndRender(this, this.config, 'urls');
     assert.notOk(component.hasTitle, 'No title for urls section');
-    assert.equal(component.fields.length, 1);
-    assert.ok(component.fields.objectAt(0).labelText, 'urls');
+    assert.equal(component.fields.length, 3);
+    assert.ok(component.fields.objectAt(0).labelText, 'Issuing certificates');
+    assert.ok(component.fields.objectAt(1).labelText, 'CRL Distribution Points');
+    assert.ok(component.fields.objectAt(2).labelText, 'OCSP Servers');
   });
 
-  test('it calls save with the correct arguments', async function (assert) {
+  test('it calls save with the correct arguments for tidy', async function (assert) {
     assert.expect(3);
     const section = 'tidy';
     this.set('onRefresh', () => {
@@ -83,12 +84,12 @@ module('Integration | Component | config pki', function (hooks) {
     });
     this.set(
       'config',
-      config((options) => {
+      this.mockConfigSave((options) => {
         assert.equal(options.adapterOptions.method, section, 'method passed to save');
         assert.deepEqual(
           options.adapterOptions.fields,
-          ['tidyCertStore', 'anotherAttr'],
-          'fields passed to save'
+          ['tidyCertStore', 'tidyRevocationList', 'safetyBuffer'],
+          'tidy fields passed to save'
         );
         return resolve();
       })
@@ -97,5 +98,39 @@ module('Integration | Component | config pki', function (hooks) {
     await render(hbs`<Pki::ConfigPki @section={{section}} @config={{config}} @onRefresh={{onRefresh}} />`);
 
     component.submit();
+  });
+
+  test('it calls save with the correct arguments for crl', async function (assert) {
+    assert.expect(3);
+    const section = 'crl';
+    this.set('onRefresh', () => {
+      assert.ok(true, 'refresh called');
+    });
+    this.set(
+      'config',
+      this.mockConfigSave((options) => {
+        assert.equal(options.adapterOptions.method, section, 'method passed to save');
+        assert.deepEqual(options.adapterOptions.fields, ['expiry', 'disable'], 'crl fields passed to save');
+        return resolve();
+      })
+    );
+    this.set('section', section);
+    await render(hbs`<Pki::ConfigPki @section={{section}} @config={{config}} @onRefresh={{onRefresh}} />`);
+    component.submit();
+  });
+
+  test('it initially sets toggle based on the config value', async function (assert) {
+    assert.expect(3);
+    const { crlAttrs } = this.config;
+    this.set('config', { crlAttrs, expiry: '1m', disable: true });
+    await render(hbs`<Pki::ConfigPki @section="crl" @config={{config}} />`);
+    assert
+      .dom('[data-test-toggle-input="show-build-crl"]')
+      .isNotChecked('when crl config disable=true, toggle is off');
+    await click('[data-test-toggle-input="show-build-crl"]');
+    assert
+      .dom('[data-test-ttl-value="CRL building enabled"]')
+      .hasValue('1', 'when toggled on shows last set expired value');
+    assert.dom('[data-test-select="ttl-unit"]').hasValue('m', 'when toggled back on shows last set unit');
   });
 });


### PR DESCRIPTION
Adds the `disable` param to CRL config while saving whatever the last `expiry` value was, so when re-enabling the last set TTL duration is there.

![crl](https://user-images.githubusercontent.com/68122737/190724402-609f8c34-ee4a-43b3-8506-75b3ad921b65.gif)
