### PR TITLE
Add links for service registration provides

### DIFF
--- a/website/content/docs/configuration/service-registration/index.mdx
+++ b/website/content/docs/configuration/service-registration/index.mdx
@@ -32,8 +32,8 @@ storage "raft" {
 }
 ```
 
-For information about a specific service registration provider, choose one from
-the navigation on the left.
+For information about a specific service registration provider, visit the [Consul Service Registration][consul-service-registration] or [Kubernetes Service Registration
+][kubernetes-service-registration] pages.
 
 ## Configuration
 
@@ -63,3 +63,5 @@ file.
 [storage-backend]: /docs/configuration/storage
 [consul-backend]: /docs/configuration/storage/consul
 [raft-backend]: /docs/configuration/storage/raft
+[consul-service-registration]: /docs/configuration/service-registration/consul
+[kubernetes-service-registration]: /docs/configuration/service-registration/kubernetes


### PR DESCRIPTION
Adds links to service registration providers to the overview page for service registration: https://developer.hashicorp.com/vault/docs/configuration/service-registration .

https://hashicorp.atlassian.net/browse/VAULT-8455