### PR TITLE
Update terraform secrets version to v.0.6.0

### DIFF
--- a/changelog/17172.txt
+++ b/changelog/17172.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/terraform: upgrade to v0.6.0
+```

--- a/changelog/17172.txt
+++ b/changelog/17172.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-secrets/terraform: upgrade to v0.6.0
-```

--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-kv v0.12.1
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.9.0
-	github.com/hashicorp/vault-plugin-secrets-terraform v0.5.0
+	github.com/hashicorp/vault-plugin-secrets-terraform v0.6.0
 	github.com/hashicorp/vault-testing-stepwise v0.1.2
 	github.com/hashicorp/vault/api v1.7.2
 	github.com/hashicorp/vault/api/auth/approle v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1155,8 +1155,8 @@ github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0 h1:EDyX/utLxEKGETe
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.7.0/go.mod h1:PLx2vxXukfsKsDRo/PlG4fxmJ1d+H2h82wT3vf4buuI=
 github.com/hashicorp/vault-plugin-secrets-openldap v0.9.0 h1:/6FQzNB4zjep7O14pkVOapwRJvnQ4gINGAc1Ss1IYg8=
 github.com/hashicorp/vault-plugin-secrets-openldap v0.9.0/go.mod h1:o7mF9tWgDkAD5OvvXWM3bOCqN+n/cCpaMm1CrEUZkHc=
-github.com/hashicorp/vault-plugin-secrets-terraform v0.5.0 h1:NbQW1Z2+oIn8v4jjqLBbxDas0Uw0bzV74da4BQsdRow=
-github.com/hashicorp/vault-plugin-secrets-terraform v0.5.0/go.mod h1:GzYAJYytgbNNyT3S7rspz1cLE53E1oajFbEtaDUlVGU=
+github.com/hashicorp/vault-plugin-secrets-terraform v0.6.0 h1:N5s1ojXyG8gBZlx6BdqE04LviR0rw4vX1dDDMdnEzX8=
+github.com/hashicorp/vault-plugin-secrets-terraform v0.6.0/go.mod h1:GzYAJYytgbNNyT3S7rspz1cLE53E1oajFbEtaDUlVGU=
 github.com/hashicorp/vault-testing-stepwise v0.1.1/go.mod h1:3vUYn6D0ZadvstNO3YQQlIcp7u1a19MdoOC0NQ0yaOE=
 github.com/hashicorp/vault-testing-stepwise v0.1.2 h1:3obC/ziAPGnsz2IQxr5e4Ayb7tu7WL6pm6mmZ5gwhhs=
 github.com/hashicorp/vault-testing-stepwise v0.1.2/go.mod h1:TeU6B+5NqxUjto+Zey+QQEH1iywuHn0ciHZNYh4q3uI=


### PR DESCRIPTION
Update terraform secrets plugin to v0.6.0.

```
go get github.com/hashicorp/vault-plugin-secrets-terraform/@v0.6.0
go mod tidy
```