### PR TITLE
Check if plugin version matches running version

### DIFF
--- a/builtin/credential/approle/backend.go
+++ b/builtin/credential/approle/backend.go
@@ -2,6 +2,7 @@ package approle
 
 import (
 	"context"
+	"os"
 	"sync"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -111,8 +112,9 @@ func Backend(conf *logical.BackendConfig) (*backend, error) {
 				pathTidySecretID(b),
 			},
 		),
-		Invalidate:  b.invalidate,
-		BackendType: logical.TypeCredential,
+		Invalidate:     b.invalidate,
+		BackendType:    logical.TypeCredential,
+		RunningVersion: os.Getenv(consts.VaultOverrideVersionEnv),
 	}
 	return b, nil
 }

--- a/builtin/credential/approle/backend.go
+++ b/builtin/credential/approle/backend.go
@@ -2,7 +2,6 @@ package approle
 
 import (
 	"context"
-	"os"
 	"sync"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -18,6 +17,9 @@ const (
 	secretIDAccessorPrefix      = "accessor/"
 	secretIDAccessorLocalPrefix = "accessor_local/"
 )
+
+// ReportedVersion is used to report a specific version to Vault.
+var ReportedVersion = ""
 
 type backend struct {
 	*framework.Backend
@@ -114,7 +116,7 @@ func Backend(conf *logical.BackendConfig) (*backend, error) {
 		),
 		Invalidate:     b.invalidate,
 		BackendType:    logical.TypeCredential,
-		RunningVersion: os.Getenv(consts.VaultOverrideVersionEnv),
+		RunningVersion: ReportedVersion,
 	}
 	return b, nil
 }

--- a/builtin/logical/consul/backend.go
+++ b/builtin/logical/consul/backend.go
@@ -2,8 +2,10 @@ package consul
 
 import (
 	"context"
+	"os"
 
 	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -34,7 +36,8 @@ func Backend() *backend {
 		Secrets: []*framework.Secret{
 			secretToken(&b),
 		},
-		BackendType: logical.TypeLogical,
+		BackendType:    logical.TypeLogical,
+		RunningVersion: os.Getenv(consts.VaultOverrideVersionEnv),
 	}
 
 	return &b

--- a/builtin/logical/consul/backend.go
+++ b/builtin/logical/consul/backend.go
@@ -2,12 +2,13 @@ package consul
 
 import (
 	"context"
-	"os"
 
 	"github.com/hashicorp/vault/sdk/framework"
-	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
 )
+
+// ReportedVersion is used to report a specific version to Vault.
+var ReportedVersion = ""
 
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
 	b := Backend()
@@ -37,7 +38,7 @@ func Backend() *backend {
 			secretToken(&b),
 		},
 		BackendType:    logical.TypeLogical,
-		RunningVersion: os.Getenv(consts.VaultOverrideVersionEnv),
+		RunningVersion: ReportedVersion,
 	}
 
 	return &b

--- a/plugins/database/postgresql/postgresql.go
+++ b/plugins/database/postgresql/postgresql.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/database/helper/connutil"
 	"github.com/hashicorp/vault/sdk/database/helper/dbutil"
-	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/dbtxn"
 	"github.com/hashicorp/vault/sdk/helper/template"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -50,6 +48,9 @@ var (
 	// singleQuotedPhrases finds substrings like 'hello'
 	// and pulls them out with the quotes included.
 	singleQuotedPhrases = regexp.MustCompile(`('.*?')`)
+
+	// ReportedVersion is used to report a specific version to Vault.
+	ReportedVersion = ""
 )
 
 func New() (interface{}, error) {
@@ -474,7 +475,7 @@ func (p *PostgreSQL) secretValues() map[string]string {
 }
 
 func (p *PostgreSQL) PluginVersion() logical.PluginVersion {
-	return logical.PluginVersion{Version: os.Getenv(consts.VaultOverrideVersionEnv)}
+	return logical.PluginVersion{Version: ReportedVersion}
 }
 
 // containsMultilineStatement is a best effort to determine whether

--- a/plugins/database/postgresql/postgresql.go
+++ b/plugins/database/postgresql/postgresql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
@@ -12,8 +13,10 @@ import (
 	"github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/database/helper/connutil"
 	"github.com/hashicorp/vault/sdk/database/helper/dbutil"
+	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/dbtxn"
 	"github.com/hashicorp/vault/sdk/helper/template"
+	"github.com/hashicorp/vault/sdk/logical"
 	_ "github.com/jackc/pgx/v4/stdlib"
 )
 
@@ -32,7 +35,8 @@ ALTER ROLE "{{username}}" WITH PASSWORD '{{password}}';
 )
 
 var (
-	_ dbplugin.Database = &PostgreSQL{}
+	_ dbplugin.Database       = (*PostgreSQL)(nil)
+	_ logical.PluginVersioner = (*PostgreSQL)(nil)
 
 	// postgresEndStatement is basically the word "END" but
 	// surrounded by a word boundary to differentiate it from
@@ -467,6 +471,10 @@ func (p *PostgreSQL) secretValues() map[string]string {
 	return map[string]string{
 		p.Password: "[password]",
 	}
+}
+
+func (p *PostgreSQL) PluginVersion() logical.PluginVersion {
+	return logical.PluginVersion{Version: os.Getenv(consts.VaultOverrideVersionEnv)}
 }
 
 // containsMultilineStatement is a best effort to determine whether

--- a/sdk/database/dbplugin/v5/grpc_server.go
+++ b/sdk/database/dbplugin/v5/grpc_server.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/hashicorp/vault/sdk/database/dbplugin/v5/proto"
+	"github.com/hashicorp/vault/sdk/helper/base62"
 	"github.com/hashicorp/vault/sdk/helper/pluginutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"google.golang.org/grpc/codes"
@@ -43,11 +44,14 @@ func (g *gRPCServer) getOrCreateDatabase(ctx context.Context) (Database, error) 
 	if err != nil {
 		return nil, err
 	}
-
 	if db, ok := g.instances[id]; ok {
 		return db, nil
 	}
+	return g.createDatabase(id)
+}
 
+// must hold the g.Lock() to call this function
+func (g *gRPCServer) createDatabase(id string) (Database, error) {
 	db, err := g.factoryFunc()
 	if err != nil {
 		return nil, err
@@ -306,10 +310,22 @@ func (g *gRPCServer) Close(ctx context.Context, _ *proto.Empty) (*proto.Empty, e
 
 // Version forwards the version request to the underlying Database implementation.
 func (g *gRPCServer) Version(ctx context.Context, _ *logical.Empty) (*logical.VersionReply, error) {
-	impl, err := g.getDatabaseInternal(ctx)
+	impl, err := g.getOrCreateDatabase(ctx)
 	if err != nil {
-		return nil, err
+		// if this is called without a multiplexing context, like from the plugin catalog directly,
+		// then we won't have a database ID, so let's generate a new database instance
+		g.Lock()
+		defer g.Unlock()
+		id, err := base62.Random(10)
+		if err != nil {
+			return nil, err
+		}
+		impl, err = g.createDatabase(id)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	if versioner, ok := impl.(logical.PluginVersioner); ok {
 		return &logical.VersionReply{PluginVersion: versioner.PluginVersion().Version}, nil
 	}

--- a/sdk/database/dbplugin/v5/middleware.go
+++ b/sdk/database/dbplugin/v5/middleware.go
@@ -233,7 +233,10 @@ func (mw databaseMetricsMiddleware) Close() (err error) {
 // Error Sanitizer Middleware Domain
 // ///////////////////////////////////////////////////
 
-var _ Database = DatabaseErrorSanitizerMiddleware{}
+var (
+	_ Database                = (*DatabaseErrorSanitizerMiddleware)(nil)
+	_ logical.PluginVersioner = (*DatabaseErrorSanitizerMiddleware)(nil)
+)
 
 // DatabaseErrorSanitizerMiddleware wraps an implementation of Databases and
 // sanitizes returned error messages
@@ -278,6 +281,13 @@ func (mw DatabaseErrorSanitizerMiddleware) Type() (string, error) {
 
 func (mw DatabaseErrorSanitizerMiddleware) Close() (err error) {
 	return mw.sanitize(mw.next.Close())
+}
+
+func (mw DatabaseErrorSanitizerMiddleware) PluginVersion() logical.PluginVersion {
+	if versioner, ok := mw.next.(logical.PluginVersioner); ok {
+		return versioner.PluginVersion()
+	}
+	return logical.EmptyPluginVersion
 }
 
 // sanitize errors by removing any sensitive strings within their messages. This uses

--- a/sdk/helper/consts/consts.go
+++ b/sdk/helper/consts/consts.go
@@ -34,4 +34,7 @@ const (
 	ReplicationResolverALPN = "replication_resolver_v1"
 
 	VaultEnableFilePermissionsCheckEnv = "VAULT_ENABLE_FILE_PERMISSIONS_CHECK"
+
+	// VaultOverrideVersionEnv used in testing to override the reported running version
+	VaultOverrideVersionEnv = "VAULT_TESTING_OVERRIDE_VERSION"
 )

--- a/sdk/helper/consts/consts.go
+++ b/sdk/helper/consts/consts.go
@@ -34,7 +34,4 @@ const (
 	ReplicationResolverALPN = "replication_resolver_v1"
 
 	VaultEnableFilePermissionsCheckEnv = "VAULT_ENABLE_FILE_PERMISSIONS_CHECK"
-
-	// VaultOverrideVersionEnv used in testing to override the reported running version
-	VaultOverrideVersionEnv = "VAULT_TESTING_OVERRIDE_VERSION"
 )

--- a/sdk/helper/pluginutil/multiplexing.go
+++ b/sdk/helper/pluginutil/multiplexing.go
@@ -2,6 +2,7 @@ package pluginutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -12,6 +13,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
+
+var ErrNoMultiplexingIDFound = errors.New("no multiplexing ID found")
 
 type PluginMultiplexingServerImpl struct {
 	UnimplementedPluginMultiplexingServer
@@ -62,7 +65,9 @@ func GetMultiplexIDFromContext(ctx context.Context) (string, error) {
 	}
 
 	multiplexIDs := md[MultiplexingCtxKey]
-	if len(multiplexIDs) != 1 {
+	if len(multiplexIDs) == 0 {
+		return "", ErrNoMultiplexingIDFound
+	} else if len(multiplexIDs) != 1 {
 		return "", fmt.Errorf("unexpected number of IDs in metadata: (%d)", len(multiplexIDs))
 	}
 

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -170,7 +171,7 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 	var backend logical.Backend
 	// Create the new backend
 	sysView := c.mountEntrySysView(entry)
-	backend, err = c.newCredentialBackend(ctx, entry, sysView, view)
+	backend, entry.RunningSha, err = c.newCredentialBackend(ctx, entry, sysView, view)
 	if err != nil {
 		return err
 	}
@@ -794,7 +795,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 		// Initialize the backend
 		sysView := c.mountEntrySysView(entry)
 
-		backend, err = c.newCredentialBackend(ctx, entry, sysView, view)
+		backend, entry.RunningSha, err = c.newCredentialBackend(ctx, entry, sysView, view)
 		if err != nil {
 			c.logger.Error("failed to create credential entry", "path", entry.Path, "error", err)
 			if plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential, ""); plugerr == nil && !plug.Builtin {
@@ -912,25 +913,30 @@ func (c *Core) teardownCredentials(ctx context.Context) error {
 	return nil
 }
 
-// newCredentialBackend is used to create and configure a new credential backend by name
-func (c *Core) newCredentialBackend(ctx context.Context, entry *MountEntry, sysView logical.SystemView, view logical.Storage) (logical.Backend, error) {
+// newCredentialBackend is used to create and configure a new credential backend by name.
+// It also returns the SHA256 of the plugin, if available.
+func (c *Core) newCredentialBackend(ctx context.Context, entry *MountEntry, sysView logical.SystemView, view logical.Storage) (logical.Backend, string, error) {
 	t := entry.Type
 	if alias, ok := credentialAliases[t]; ok {
 		t = alias
 	}
 
+	var runningSha string
 	f, ok := c.credentialBackends[t]
 	if !ok {
 		plug, err := c.pluginCatalog.Get(ctx, t, consts.PluginTypeCredential, entry.Version)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		if plug == nil {
 			errContext := t
 			if entry.Version != "" {
 				errContext += fmt.Sprintf(", version=%s", entry.Version)
 			}
-			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, errContext)
+			return nil, "", fmt.Errorf("%w: %s", ErrPluginNotFound, errContext)
+		}
+		if len(plug.Sha256) > 0 {
+			runningSha = hex.EncodeToString(plug.Sha256)
 		}
 
 		f = plugin.Factory
@@ -966,10 +972,10 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *MountEntry, sysV
 
 	b, err := f(ctx, config)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
-	return b, nil
+	return b, runningSha, nil
 }
 
 // defaultAuthTable creates a default auth table

--- a/vault/external_plugin_test.go
+++ b/vault/external_plugin_test.go
@@ -276,6 +276,10 @@ func TestCore_EnableExternalPlugin_MultipleVersions(t *testing.T) {
 			if raw.(*routeEntry).mountEntry.RunningVersion != "" {
 				t.Errorf("Expected mount to have no running version but got %s", raw.(*routeEntry).mountEntry.RunningVersion)
 			}
+
+			if raw.(*routeEntry).mountEntry.RunningSha == "" {
+				t.Errorf("Expected RunningSha to be present: %+v", raw.(*routeEntry).mountEntry.RunningSha)
+			}
 		})
 	}
 }

--- a/vault/external_plugin_test.go
+++ b/vault/external_plugin_test.go
@@ -458,9 +458,9 @@ func TestExternalPlugin_getBackendTypeVersion(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			//if version.Version != tc.setRunningVersion {
-			t.Errorf("Expected to get version %v but got %v", tc.setRunningVersion, version.Version)
-			//}
+			if version.Version != tc.setRunningVersion {
+				t.Errorf("Expected to get version %v but got %v", tc.setRunningVersion, version.Version)
+			}
 		})
 	}
 }

--- a/vault/identity_store_entities_test.go
+++ b/vault/identity_store_entities_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-uuid"
 	credGithub "github.com/hashicorp/vault/builtin/credential/github"
 	"github.com/hashicorp/vault/helper/identity"
 	"github.com/hashicorp/vault/helper/namespace"
@@ -688,7 +688,7 @@ func TestIdentityStore_LoadingEntities(t *testing.T) {
 	ghSysview := c.mountEntrySysView(meGH)
 
 	// Create new github auth credential backend
-	ghAuth, err := c.newCredentialBackend(context.Background(), meGH, ghSysview, ghView)
+	ghAuth, _, err := c.newCredentialBackend(context.Background(), meGH, ghSysview, ghView)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -517,6 +517,9 @@ func (b *SystemBackend) handlePluginCatalogUpdate(ctx context.Context, _ *logica
 
 	err = b.Core.pluginCatalog.Set(ctx, pluginName, pluginType, pluginVersion, parts[0], args, env, sha256Bytes)
 	if err != nil {
+		if errors.Is(err, ErrPluginNotFound) || strings.HasPrefix(err.Error(), "plugin version mismatch") {
+			return logical.ErrorResponse(err.Error()), nil
+		}
 		return nil, err
 	}
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -609,7 +610,7 @@ func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStora
 	var backend logical.Backend
 	sysView := c.mountEntrySysView(entry)
 
-	backend, err = c.newLogicalBackend(ctx, entry, sysView, view)
+	backend, entry.RunningSha, err = c.newLogicalBackend(ctx, entry, sysView, view)
 	if err != nil {
 		return err
 	}
@@ -1420,7 +1421,7 @@ func (c *Core) setupMounts(ctx context.Context) error {
 		var backend logical.Backend
 		// Create the new backend
 		sysView := c.mountEntrySysView(entry)
-		backend, err = c.newLogicalBackend(ctx, entry, sysView, view)
+		backend, entry.RunningSha, err = c.newLogicalBackend(ctx, entry, sysView, view)
 		if err != nil {
 			c.logger.Error("failed to create mount entry", "path", entry.Path, "error", err)
 			if !c.builtinRegistry.Contains(entry.Type, consts.PluginTypeSecrets) {
@@ -1524,25 +1525,30 @@ func (c *Core) unloadMounts(ctx context.Context) error {
 	return nil
 }
 
-// newLogicalBackend is used to create and configure a new logical backend by name
-func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView logical.SystemView, view logical.Storage) (logical.Backend, error) {
+// newLogicalBackend is used to create and configure a new logical backend by name.
+// It also returns the SHA256 of the plugin, if available.
+func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView logical.SystemView, view logical.Storage) (logical.Backend, string, error) {
 	t := entry.Type
 	if alias, ok := mountAliases[t]; ok {
 		t = alias
 	}
 
+	var runningSha string
 	f, ok := c.logicalBackends[t]
 	if !ok {
 		plug, err := c.pluginCatalog.Get(ctx, t, consts.PluginTypeSecrets, entry.Version)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		if plug == nil {
 			errContext := t
 			if entry.Version != "" {
 				errContext += fmt.Sprintf(", version=%s", entry.Version)
 			}
-			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, errContext)
+			return nil, "", fmt.Errorf("%w: %s", ErrPluginNotFound, errContext)
+		}
+		if len(plug.Sha256) > 0 {
+			runningSha = hex.EncodeToString(plug.Sha256)
 		}
 
 		f = plugin.Factory
@@ -1579,14 +1585,14 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 	ctx = context.WithValue(ctx, "core_number", c.coreNumber)
 	b, err := f(ctx, config)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if b == nil {
-		return nil, fmt.Errorf("nil backend of type %q returned from factory", t)
+		return nil, "", fmt.Errorf("nil backend of type %q returned from factory", t)
 	}
 	addLicenseCallback(c, b)
 
-	return b, nil
+	return b, runningSha, nil
 }
 
 // defaultMountTable creates a default mount table

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -365,7 +365,7 @@ func (c *PluginCatalog) newPluginClient(ctx context.Context, pluginRunner *plugi
 // getPluginTypeFromUnknown will attempt to run the plugin to determine the
 // type. It will first attempt to run as a database plugin then a backend
 // plugin.
-func (c *PluginCatalog) getPluginTypeFromUnknown(ctx context.Context, logger log.Logger, plugin *pluginutil.PluginRunner) (consts.PluginType, error) {
+func (c *PluginCatalog) getPluginTypeFromUnknown(ctx context.Context, plugin *pluginutil.PluginRunner) (consts.PluginType, error) {
 	merr := &multierror.Error{}
 	err := c.isDatabasePlugin(ctx, plugin)
 	if err == nil {
@@ -459,6 +459,124 @@ func (c *PluginCatalog) getBackendPluginType(ctx context.Context, pluginRunner *
 	merr = multierror.Append(merr, fmt.Errorf("failed to load plugin as backend plugin: %w", err))
 
 	return consts.PluginTypeUnknown, merr.ErrorOrNil()
+}
+
+// getBackendRunningVersion attempts to get the plugin version
+func (c *PluginCatalog) getBackendRunningVersion(ctx context.Context, pluginRunner *pluginutil.PluginRunner) (logical.PluginVersion, error) {
+	merr := &multierror.Error{}
+	// Attempt to run as backend plugin
+	config := pluginutil.PluginClientConfig{
+		Name:            pluginRunner.Name,
+		PluginSets:      backendplugin.PluginSet,
+		HandshakeConfig: backendplugin.HandshakeConfig,
+		Logger:          log.NewNullLogger(),
+		IsMetadataMode:  false,
+		AutoMTLS:        true,
+	}
+
+	var client logical.Backend
+	// First, attempt to run as backend V5 plugin
+	c.logger.Debug("attempting to load backend plugin", "name", pluginRunner.Name)
+	pc, err := c.newPluginClient(ctx, pluginRunner, config)
+	if err == nil {
+		// we spawned a subprocess, so make sure to clean it up
+		defer c.cleanupExternalPlugin(pluginRunner.Name, pc.id)
+
+		// dispense the plugin so we can get its version
+		client, err = backendplugin.Dispense(pc.ClientProtocol, pc)
+		if err == nil {
+			c.logger.Debug("successfully dispensed v5 backend plugin", "name", pluginRunner.Name)
+
+			err = client.Setup(ctx, &logical.BackendConfig{})
+			if err != nil {
+				return logical.EmptyPluginVersion, nil
+			}
+			if versioner, ok := client.(logical.PluginVersioner); ok {
+				return versioner.PluginVersion(), nil
+			}
+			return logical.EmptyPluginVersion, nil
+		}
+		merr = multierror.Append(merr, fmt.Errorf("failed to dispense plugin as backend v5: %w", err))
+	}
+	c.logger.Debug("failed to dispense v5 backend plugin", "name", pluginRunner.Name, "error", err)
+	config.AutoMTLS = false
+	config.IsMetadataMode = true
+	// attempt to run as a v4 backend plugin
+	client, err = backendplugin.NewPluginClient(ctx, nil, pluginRunner, log.NewNullLogger(), true)
+	if err != nil {
+		merr = multierror.Append(merr, fmt.Errorf("failed to dispense v4 backend plugin: %w", err))
+		c.logger.Debug("failed to dispense v4 backend plugin", "name", pluginRunner.Name, "error", merr)
+		return logical.EmptyPluginVersion, merr.ErrorOrNil()
+	}
+	c.logger.Debug("successfully dispensed v4 backend plugin", "name", pluginRunner.Name)
+	defer client.Cleanup(ctx)
+
+	err = client.Setup(ctx, &logical.BackendConfig{})
+	if err != nil {
+		return logical.EmptyPluginVersion, err
+	}
+	if versioner, ok := client.(logical.PluginVersioner); ok {
+		return versioner.PluginVersion(), nil
+	}
+	return logical.EmptyPluginVersion, nil
+}
+
+// getDatabaseRunningVersion returns the version reported by a database plugin
+func (c *PluginCatalog) getDatabaseRunningVersion(ctx context.Context, pluginRunner *pluginutil.PluginRunner) (logical.PluginVersion, error) {
+	merr := &multierror.Error{}
+	config := pluginutil.PluginClientConfig{
+		Name:            pluginRunner.Name,
+		PluginSets:      v5.PluginSets,
+		PluginType:      consts.PluginTypeDatabase,
+		Version:         pluginRunner.Version,
+		HandshakeConfig: v5.HandshakeConfig,
+		Logger:          log.Default(),
+		IsMetadataMode:  true,
+		AutoMTLS:        true,
+	}
+
+	// Attempt to run as database V5 or V6 multiplexed plugin
+	c.logger.Debug("attempting to load database plugin as v5", "name", pluginRunner.Name)
+	v5Client, err := c.newPluginClient(ctx, pluginRunner, config)
+	if err == nil {
+		defer func() {
+			// Close the client and cleanup the plugin process
+			err = c.cleanupExternalPlugin(pluginRunner.Name, v5Client.id)
+			if err != nil {
+				c.logger.Error("error closing plugin client", "error", err)
+			}
+		}()
+
+		raw, err := v5Client.Dispense("database")
+		if err != nil {
+			return logical.EmptyPluginVersion, err
+		}
+		if versioner, ok := raw.(logical.PluginVersioner); ok {
+			return versioner.PluginVersion(), nil
+		}
+		return logical.EmptyPluginVersion, nil
+	}
+	merr = multierror.Append(merr, fmt.Errorf("failed to load plugin as database v5: %w", err))
+
+	c.logger.Debug("attempting to load database plugin as v4", "name", pluginRunner.Name)
+	v4Client, err := v4.NewPluginClient(ctx, nil, pluginRunner, log.NewNullLogger(), true)
+	if err == nil {
+		// Close the client and cleanup the plugin process
+		defer func() {
+			err = v4Client.Close()
+			if err != nil {
+				c.logger.Error("error closing plugin client", "error", err)
+			}
+		}()
+
+		if versioner, ok := v4Client.(logical.PluginVersioner); ok {
+			return versioner.PluginVersion(), nil
+		}
+
+		return logical.EmptyPluginVersion, nil
+	}
+	merr = multierror.Append(merr, fmt.Errorf("failed to load plugin as database v4: %w", err))
+	return logical.EmptyPluginVersion, merr
 }
 
 // isDatabasePlugin returns an error if the plugin is not a database plugin.
@@ -671,26 +789,45 @@ func (c *PluginCatalog) setInternal(ctx context.Context, name string, pluginType
 		return nil, errors.New("cannot execute files outside of configured plugin directory")
 	}
 
+	// entryTmp should only be used for the below type and version checks, it uses the
+	// full command instead of the relative command.
+	entryTmp := &pluginutil.PluginRunner{
+		Name:    name,
+		Command: commandFull,
+		Args:    args,
+		Env:     env,
+		Sha256:  sha256,
+		Builtin: false,
+	}
 	// If the plugin type is unknown, we want to attempt to determine the type
 	if pluginType == consts.PluginTypeUnknown {
-		// entryTmp should only be used for the below type check, it uses the
-		// full command instead of the relative command.
-		entryTmp := &pluginutil.PluginRunner{
-			Name:    name,
-			Command: commandFull,
-			Args:    args,
-			Env:     env,
-			Sha256:  sha256,
-			Builtin: false,
-		}
-
-		pluginType, err = c.getPluginTypeFromUnknown(ctx, log.Default(), entryTmp)
+		pluginType, err = c.getPluginTypeFromUnknown(ctx, entryTmp)
 		if err != nil {
 			return nil, err
 		}
 		if pluginType == consts.PluginTypeUnknown {
 			return nil, ErrPluginBadType
 		}
+	}
+
+	runningVersion := logical.EmptyPluginVersion
+	switch pluginType {
+	case consts.PluginTypeSecrets, consts.PluginTypeCredential:
+		runningVersion, err = c.getBackendRunningVersion(ctx, entryTmp)
+		if err != nil {
+			return nil, err
+		}
+	case consts.PluginTypeDatabase:
+		runningVersion, err = c.getDatabaseRunningVersion(ctx, entryTmp)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unknown plugin type: %v", pluginType)
+	}
+
+	if version != "" && runningVersion.Version != "" && version != runningVersion.Version {
+		c.logger.Warn("Plugin self-reported version did not match requested version", "plugin", name, "requestedVersion", version, "reportedVersion", runningVersion.Version)
 	}
 
 	entry := &pluginutil.PluginRunner{

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -535,7 +535,7 @@ func (c *PluginCatalog) getDatabaseRunningVersion(ctx context.Context, pluginRun
 		AutoMTLS:        true,
 	}
 
-	// Attempt to run as database V5 or V6 multiplexed plugin
+	// Attempt to run as database V5+ multiplexed plugin
 	c.logger.Debug("attempting to load database plugin as v5", "name", pluginRunner.Name)
 	v5Client, err := c.newPluginClient(ctx, pluginRunner, config)
 	if err == nil {
@@ -593,7 +593,7 @@ func (c *PluginCatalog) isDatabasePlugin(ctx context.Context, pluginRunner *plug
 		AutoMTLS:        true,
 	}
 
-	// Attempt to run as database V5 or V6 multiplexed plugin
+	// Attempt to run as database V5+ multiplexed plugin
 	c.logger.Debug("attempting to load database plugin as v5", "name", pluginRunner.Name)
 	v5Client, err := c.newPluginClient(ctx, pluginRunner, config)
 	if err == nil {
@@ -825,6 +825,7 @@ func (c *PluginCatalog) setInternal(ctx context.Context, name string, pluginType
 		c.logger.Warn("Error determining plugin version", "error", versionErr)
 	} else if version != "" && runningVersion.Version != "" && version != runningVersion.Version {
 		c.logger.Warn("Plugin self-reported version did not match requested version", "plugin", name, "requestedVersion", version, "reportedVersion", runningVersion.Version)
+		return nil, ErrPluginNotFound
 	}
 
 	entry := &pluginutil.PluginRunner{

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -32,6 +32,7 @@ var (
 	pluginCatalogPath           = "core/plugin-catalog/"
 	ErrDirectoryNotConfigured   = errors.New("could not set plugin, plugin directory is not configured")
 	ErrPluginNotFound           = errors.New("plugin not found in the catalog")
+	ErrPluginMismatchedVersion  = errors.New("plugin reported version did not match requested version")
 	ErrPluginConnectionNotFound = errors.New("plugin connection not found for client")
 	ErrPluginBadType            = errors.New("unable to determine plugin type")
 )
@@ -825,7 +826,7 @@ func (c *PluginCatalog) setInternal(ctx context.Context, name string, pluginType
 		c.logger.Warn("Error determining plugin version", "error", versionErr)
 	} else if version != "" && runningVersion.Version != "" && version != runningVersion.Version {
 		c.logger.Warn("Plugin self-reported version did not match requested version", "plugin", name, "requestedVersion", version, "reportedVersion", runningVersion.Version)
-		return nil, ErrPluginNotFound
+		return nil, ErrPluginMismatchedVersion
 	}
 
 	entry := &pluginutil.PluginRunner{

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -32,7 +32,6 @@ var (
 	pluginCatalogPath           = "core/plugin-catalog/"
 	ErrDirectoryNotConfigured   = errors.New("could not set plugin, plugin directory is not configured")
 	ErrPluginNotFound           = errors.New("plugin not found in the catalog")
-	ErrPluginMismatchedVersion  = errors.New("plugin reported version did not match requested version")
 	ErrPluginConnectionNotFound = errors.New("plugin connection not found for client")
 	ErrPluginBadType            = errors.New("unable to determine plugin type")
 )
@@ -826,7 +825,7 @@ func (c *PluginCatalog) setInternal(ctx context.Context, name string, pluginType
 		c.logger.Warn("Error determining plugin version", "error", versionErr)
 	} else if version != "" && runningVersion.Version != "" && version != runningVersion.Version {
 		c.logger.Warn("Plugin self-reported version did not match requested version", "plugin", name, "requestedVersion", version, "reportedVersion", runningVersion.Version)
-		return nil, ErrPluginMismatchedVersion
+		return nil, fmt.Errorf("plugin version mismatch: %s reported version (%s) did not match requested version (%s)", name, runningVersion.Version, version)
 	}
 
 	entry := &pluginutil.PluginRunner{

--- a/vault/plugin_reload.go
+++ b/vault/plugin_reload.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/vault/helper/namespace"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/plugin"
@@ -174,11 +174,12 @@ func (c *Core) reloadBackendCommon(ctx context.Context, entry *MountEntry, isAut
 	}
 
 	var backend logical.Backend
+	oldSha := entry.RunningSha
 	if !isAuth {
 		// Dispense a new backend
-		backend, err = c.newLogicalBackend(ctx, entry, sysView, view)
+		backend, entry.RunningSha, err = c.newLogicalBackend(ctx, entry, sysView, view)
 	} else {
-		backend, err = c.newCredentialBackend(ctx, entry, sysView, view)
+		backend, entry.RunningSha, err = c.newCredentialBackend(ctx, entry, sysView, view)
 	}
 	if err != nil {
 		return err
@@ -187,6 +188,20 @@ func (c *Core) reloadBackendCommon(ctx context.Context, entry *MountEntry, isAut
 		return fmt.Errorf("nil backend of type %q returned from creation function", entry.Type)
 	}
 
+	// update the mount table since we changed the runningSha
+	if oldSha != entry.RunningSha && MountTableUpdateStorage {
+		if isAuth {
+			err = c.persistAuth(ctx, c.auth, &entry.Local)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = c.persistMounts(ctx, c.mounts, &entry.Local)
+			if err != nil {
+				return err
+			}
+		}
+	}
 	addPathCheckers(c, entry, backend, viewPath)
 
 	if nilMount {


### PR DESCRIPTION
When registering a plugin, we check if the request version matches the self-reported version from the plugin. If these do not match, we log a warning.

This uncovered a few missing pieces for getting the database version code fully working.

We added an environment variable that helps us unit test the running version behavior as well, but only for approle, postgresql, and consul plugins.