### PR TITLE
Don't race for CRL rebuilding capability check

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -193,7 +193,12 @@ func Backend(conf *logical.BackendConfig) *backend {
 
 	b.pkiStorageVersion.Store(0)
 
-	b.crlBuilder = newCRLBuilder()
+	// b isn't yet initialized with SystemView state; calling b.System() will
+	// result in a nil pointer dereference. Instead query BackendConfig's
+	// copy of SystemView instead.
+	cannotRebuildCRLs := conf.System.ReplicationState().HasState(consts.ReplicationPerformanceStandby) ||
+		conf.System.ReplicationState().HasState(consts.ReplicationDRSecondary)
+	b.crlBuilder = newCRLBuilder(!cannotRebuildCRLs)
 
 	// Delay the first tidy until after we've started up.
 	b.lastTidy = time.Now()

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -195,7 +195,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 
 	// b isn't yet initialized with SystemView state; calling b.System() will
 	// result in a nil pointer dereference. Instead query BackendConfig's
-	// copy of SystemView instead.
+	// copy of SystemView.
 	cannotRebuildCRLs := conf.System.ReplicationState().HasState(consts.ReplicationPerformanceStandby) ||
 		conf.System.ReplicationState().HasState(consts.ReplicationDRSecondary)
 	b.crlBuilder = newCRLBuilder(!cannotRebuildCRLs)

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -388,7 +388,7 @@ func TestCrlRebuilder(t *testing.T) {
 	require.NoError(t, err)
 
 	req := &logical.Request{Storage: s}
-	cb := newCRLBuilder()
+	cb := newCRLBuilder(true /* can rebuild and write CRLs */)
 
 	// Force an initial build
 	err = cb.rebuild(ctx, b, req, true)


### PR DESCRIPTION
Core has recently seen some data races during `SystemView`/replication updates between them and the PKI subsystem. This is because this `SystemView` access occurs outside of a request (during invalidation handling) and thus the proper lock isn't held.

Because replication status cannot change within the lifetime of a plugin (and instead, if a node switches replication status, the entire plugin instance will be torn down and recreated), it is safe to cache this once, at plugin startup, and use it throughout its lifetime.

Thus, we replace this `SystemView` access with a stored boolean variable computed ahead of time.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`