### PR TITLE
Fix unsafe access to perf standby status from systemview

### DIFF
--- a/changelog/17186.txt
+++ b/changelog/17186.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: fix race when using SystemView.ReplicationState outside of a request context
+```

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -23,8 +23,9 @@ func (c ctxKeyForwardedRequestMountAccessor) String() string {
 }
 
 type dynamicSystemView struct {
-	core       *Core
-	mountEntry *MountEntry
+	core        *Core
+	mountEntry  *MountEntry
+	perfStandby bool
 }
 
 type extendedSystemView interface {
@@ -178,7 +179,7 @@ func (d dynamicSystemView) LocalMount() bool {
 // in read mode.
 func (d dynamicSystemView) ReplicationState() consts.ReplicationState {
 	state := d.core.ReplicationState()
-	if d.core.perfStandby {
+	if d.perfStandby {
 		state |= consts.ReplicationPerformanceStandby
 	}
 	return state

--- a/vault/mount_util.go
+++ b/vault/mount_util.go
@@ -49,8 +49,9 @@ func verifyNamespace(*Core, *namespace.Namespace, *MountEntry) error { return ni
 func (c *Core) mountEntrySysView(entry *MountEntry) extendedSystemView {
 	return extendedSystemViewImpl{
 		dynamicSystemView{
-			core:       c,
-			mountEntry: entry,
+			core:        c,
+			mountEntry:  entry,
+			perfStandby: c.perfStandby,
 		},
 	}
 }

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -251,7 +251,7 @@ func NewPolicyStore(ctx context.Context, core *Core, baseView *BarrierView, syst
 func (c *Core) setupPolicyStore(ctx context.Context) error {
 	// Create the policy store
 	var err error
-	sysView := &dynamicSystemView{core: c}
+	sysView := &dynamicSystemView{core: c, perfStandby: c.perfStandby}
 	psLogger := c.baseLogger.Named("policy")
 	c.AddLogger(psLogger)
 	c.policyStore, err = NewPolicyStore(ctx, c, c.systemBarrierView, sysView, psLogger)

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -508,7 +508,7 @@ func TestDynamicSystemView(c *Core, ns *namespace.Namespace) *dynamicSystemView 
 		me.namespace = ns
 	}
 
-	return &dynamicSystemView{c, me}
+	return &dynamicSystemView{c, me, true}
 }
 
 // TestAddTestPlugin registers the testFunc as part of the plugin command to the

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -508,7 +508,7 @@ func TestDynamicSystemView(c *Core, ns *namespace.Namespace) *dynamicSystemView 
 		me.namespace = ns
 	}
 
-	return &dynamicSystemView{c, me, true}
+	return &dynamicSystemView{c, me, c.perfStandby}
 }
 
 // TestAddTestPlugin registers the testFunc as part of the plugin command to the


### PR DESCRIPTION
Ensure that we don't try to access Core.perfStandby or Core.PerfStandby() from dynamicSystemView, which might be accessed with or without stateLock held.