### PR TITLE
Break grabLockOrStop into two pieces to facilitate investigating deadlocks

### DIFF
--- a/changelog/17187.txt
+++ b/changelog/17187.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Refactor lock grabbing code to simplify stateLock deadlock investigations
+```

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -686,6 +686,7 @@ func newLockGrabber(lockFunc, unlockFunc func(), stopCh chan struct{}) *lockGrab
 		lockFunc:      lockFunc,
 		unlockFunc:    unlockFunc,
 		parentWaiting: true,
+		stopCh:        stopCh,
 	}
 }
 

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -589,7 +589,9 @@ func (b *SystemBackend) handleStorageRaftSnapshotWrite(force bool) framework.Ope
 			defer cleanup()
 
 			// Grab statelock
-			if stopped := grabLockOrStop(b.Core.stateLock.Lock, b.Core.stateLock.Unlock, b.Core.standbyStopCh.Load().(chan struct{})); stopped {
+			l := newLockGrabber(b.Core.stateLock.Lock, b.Core.stateLock.Unlock, b.Core.standbyStopCh.Load().(chan struct{}))
+			go l.grab()
+			if stopped := l.lockOrStop(); stopped {
 				b.Core.logger.Error("not applying snapshot; shutting down")
 				return
 			}

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -635,7 +635,9 @@ func (c *Core) raftSnapshotRestoreCallback(grabLock bool, sealNode bool) func(co
 
 		if grabLock {
 			// Grab statelock
-			if stopped := grabLockOrStop(c.stateLock.Lock, c.stateLock.Unlock, c.standbyStopCh.Load().(chan struct{})); stopped {
+			l := newLockGrabber(c.stateLock.Lock, c.stateLock.Unlock, c.standbyStopCh.Load().(chan struct{}))
+			go l.grab()
+			if stopped := l.lockOrStop(); stopped {
 				c.logger.Error("did not apply snapshot; vault is shutting down")
 				return errors.New("did not apply snapshot; vault is shutting down")
 			}

--- a/vault/rollback.go
+++ b/vault/rollback.go
@@ -209,7 +209,9 @@ func (m *RollbackManager) attemptRollback(ctx context.Context, fullPath string, 
 		}()
 
 		// Grab the statelock or stop
-		if stopped := grabLockOrStop(m.core.stateLock.RLock, m.core.stateLock.RUnlock, stopCh); stopped {
+		l := newLockGrabber(m.core.stateLock.RLock, m.core.stateLock.RUnlock, stopCh)
+		go l.grab()
+		if stopped := l.lockOrStop(); stopped {
 			// If we stopped due to shutdown, return. Otherwise another thread
 			// is holding the lock for us, continue on.
 			select {


### PR DESCRIPTION
Without this change, the "grab" locking goroutine looks the same regardless of who was calling grabLockOrStop, so there's no way to identify one of the deadlock parties.

Example of the confusion we're trying to eliminate:

```
=== CONT  TestSecret_TokenAccessor/auth
POTENTIAL DEADLOCK:
Previous place where the lock was grabbed
goroutine 8799 lock 0xc000ccd298
../../init.go:230 vault.(*Core).Initialize { c.stateLock.Lock() } <<<<<
../../testing.go:341 vault.TestCoreInitClusterWrapperSetup { result, err := core.Initialize(context.Background(), initParams) }
../../testing.go:2037 vault.(*TestCluster).initCores { bKeys, rKeys, root := TestCoreInitClusterWrapperSetup(t, leader.Core, leader.Handler) }
../../testing.go:1759 vault.NewTestCluster { testCluster.initCores(t, opts, addAuditBackend) }
api_integration_test.go:61 api.testVaultServerCoreConfig { cluster := vault.NewTestCluster(benchhelpers.TBtoT(t), coreConfig, &vault.TestClusterOptions{ }
api_integration_test.go:36 api.testVaultServerUnseal { return testVaultServerCoreConfig(t, &vault.CoreConfig{ }
api_integration_test.go:27 api.testVaultServer { client, _, closer := testVaultServerUnseal(t) }
secret_test.go:1005 api.TestSecret_TokenPolicies.func3 { client, closer := testVaultServer(t) }

Have been trying to lock it again for more than 30s
goroutine 10172 lock 0xc000ccd298
../../ha.go:670 vault.grabLockOrStop.func1 { lockFunc() } <<<<<
```