### PR TITLE
Fix a broken URL in Transit API doc

### DIFF
--- a/website/content/docs/secrets/transit/index.mdx
+++ b/website/content/docs/secrets/transit/index.mdx
@@ -306,5 +306,5 @@ tutorial to learn how to use the transit secrets engine to handle cryptographic 
 ## API
 
 The Transit secrets engine has a full HTTP API. Please see the
-[Transit secrets engine API](/api-docs/secrets/transit) for more
+[Transit secrets engine API](/api-docs/secret/transit) for more
 details.


### PR DESCRIPTION
🧵 [Slack](https://hashicorp.slack.com/archives/C012RTGJR1V/p1663398926721949)


It was reported that the links to Transit secrets engine API doc is broken.  This PR is to fix the URL:  `/secrets/` --> `/secret/`