### PR TITLE
Handle when pluginCatalog.Get returns (nil,nil) during cred backend creation

### DIFF
--- a/changelog/17204.txt
+++ b/changelog/17204.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix panic when the plugin catalog returns neither a plugin nor an error.
+```

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -797,7 +797,8 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 		backend, err = c.newCredentialBackend(ctx, entry, sysView, view)
 		if err != nil {
 			c.logger.Error("failed to create credential entry", "path", entry.Path, "error", err)
-			if plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential, ""); plugerr == nil && !plug.Builtin {
+			plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential, "")
+			if plugerr == nil && plug != nil && !plug.Builtin {
 				// If we encounter an error instantiating the backend due to an error,
 				// skip backend initialization but register the entry to the mount table
 				// to preserve storage and path.


### PR DESCRIPTION
Example panic this should avert: https://app.circleci.com/pipelines/github/hashicorp/vault-enterprise/16970/workflows/b790bc33-bd1f-485b-9025-e4e4b5dd023b/jobs/409253