### PR TITLE
PKI Issuer List view

### DIFF
--- a/ui/app/adapters/pki/pki-issuer-engine.js
+++ b/ui/app/adapters/pki/pki-issuer-engine.js
@@ -23,7 +23,6 @@ export default class PkiIssuerEngineAdapter extends ApplicationAdapter {
   async query(store, type, query) {
     const { backend, id } = query;
     let response = await this.ajax(this.urlForQuery(backend, id), 'GET', this.optionsForQuery(id));
-    console.log(response, 'response in query');
     return response;
   }
 }

--- a/ui/app/adapters/pki/pki-issuer-engine.js
+++ b/ui/app/adapters/pki/pki-issuer-engine.js
@@ -1,0 +1,29 @@
+import ApplicationAdapter from '../application';
+import { encodePath } from 'vault/utils/path-encoding-helpers';
+
+export default class PkiIssuerEngineAdapter extends ApplicationAdapter {
+  namespace = 'v1';
+
+  optionsForQuery(id) {
+    let data = {};
+    if (!id) {
+      data['list'] = true;
+    }
+    return { data };
+  }
+
+  urlForQuery(backend, id) {
+    let url = `${this.buildURL()}/${encodePath(backend)}/issuers`;
+    if (id) {
+      url = url + '/' + encodePath(id);
+    }
+    return url;
+  }
+
+  async query(store, type, query) {
+    const { backend, id } = query;
+    let response = await this.ajax(this.urlForQuery(backend, id), 'GET', this.optionsForQuery(id));
+    console.log(response, 'response in query');
+    return response;
+  }
+}

--- a/ui/app/models/pki/pki-issuer-engine.js
+++ b/ui/app/models/pki/pki-issuer-engine.js
@@ -21,12 +21,12 @@ export default class PkiIssuersEngineModel extends Model {
   })
   name;
 
-  // get useOpenAPI() {
-  //   return true;
-  // }
-  // getHelpUrl(backend) {
-  //   return `/v1/${backend}/issuers/example?help=1`;
-  // }
+  get useOpenAPI() {
+    return true;
+  }
+  getHelpUrl(backend) {
+    return `/v1/${backend}/issuer/example?help=1`;
+  }
 
   @attr('boolean') isDefault;
   @attr('string') issuerName;

--- a/ui/app/models/pki/pki-issuer-engine.js
+++ b/ui/app/models/pki/pki-issuer-engine.js
@@ -1,0 +1,49 @@
+import Model, { attr } from '@ember-data/model';
+// import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
+import { withModelValidations } from 'vault/decorators/model-validations';
+
+const validations = {
+  name: [
+    { type: 'presence', message: 'Name is required.' },
+    {
+      type: 'containsWhiteSpace',
+      message: 'Name cannot contain whitespace.',
+    },
+  ],
+};
+
+@withModelValidations(validations)
+export default class PkiIssuersEngineModel extends Model {
+  @attr('string', { readOnly: true }) backend;
+  @attr('string', {
+    label: 'Issuer name',
+    fieldValue: 'id',
+  })
+  name;
+
+  // get useOpenAPI() {
+  //   return true;
+  // }
+  // getHelpUrl(backend) {
+  //   return `/v1/${backend}/issuers/example?help=1`;
+  // }
+
+  @attr('object') keyInfo;
+
+  // Form Fields not hidden in toggle options
+  // _attributeMeta = null;
+  // get formFields() {
+  //   if (!this._attributeMeta) {
+  //     this._attributeMeta = expandAttributeMeta(this, [
+  //       'name',
+  //       'leafNotAfterBehavior',
+  //       'usage',
+  //       'manualChain',
+  //       'issuingCertifications',
+  //       'crlDistributionPoints',
+  //       'ocspServers',
+  //     ]);
+  //   }
+  //   return this._attributeMeta;
+  // }
+}

--- a/ui/app/models/pki/pki-issuer-engine.js
+++ b/ui/app/models/pki/pki-issuer-engine.js
@@ -42,6 +42,7 @@ export default class PkiIssuersEngineModel extends Model {
   //       'issuingCertifications',
   //       'crlDistributionPoints',
   //       'ocspServers',
+  //       'deltaCrlUrls', // new endpoint, mentioned in RFC, but need to confirm it's there.
   //     ]);
   //   }
   //   return this._attributeMeta;

--- a/ui/app/models/pki/pki-issuer-engine.js
+++ b/ui/app/models/pki/pki-issuer-engine.js
@@ -1,5 +1,5 @@
 import Model, { attr } from '@ember-data/model';
-// import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
+import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 import { withModelValidations } from 'vault/decorators/model-validations';
 
 const validations = {
@@ -32,20 +32,20 @@ export default class PkiIssuersEngineModel extends Model {
   @attr('string') issuerName;
 
   // Form Fields not hidden in toggle options
-  // _attributeMeta = null;
-  // get formFields() {
-  //   if (!this._attributeMeta) {
-  //     this._attributeMeta = expandAttributeMeta(this, [
-  //       'name',
-  //       'leafNotAfterBehavior',
-  //       'usage',
-  //       'manualChain',
-  //       'issuingCertifications',
-  //       'crlDistributionPoints',
-  //       'ocspServers',
-  //       'deltaCrlUrls', // new endpoint, mentioned in RFC, but need to confirm it's there.
-  //     ]);
-  //   }
-  //   return this._attributeMeta;
-  // }
+  _attributeMeta = null;
+  get formFields() {
+    if (!this._attributeMeta) {
+      this._attributeMeta = expandAttributeMeta(this, [
+        'name',
+        'leafNotAfterBehavior',
+        'usage',
+        'manualChain',
+        'issuingCertifications',
+        'crlDistributionPoints',
+        'ocspServers',
+        'deltaCrlUrls', // new endpoint, mentioned in RFC, but need to confirm it's there.
+      ]);
+    }
+    return this._attributeMeta;
+  }
 }

--- a/ui/app/models/pki/pki-issuer-engine.js
+++ b/ui/app/models/pki/pki-issuer-engine.js
@@ -28,7 +28,8 @@ export default class PkiIssuersEngineModel extends Model {
   //   return `/v1/${backend}/issuers/example?help=1`;
   // }
 
-  @attr('object') keyInfo;
+  @attr('boolean') isDefault;
+  @attr('string') issuerName;
 
   // Form Fields not hidden in toggle options
   // _attributeMeta = null;

--- a/ui/app/models/pki/pki-role-engine.js
+++ b/ui/app/models/pki/pki-role-engine.js
@@ -97,19 +97,16 @@ export default class PkiRolesEngineModel extends Model {
             'extKeyUsage', // ARG TODO: takes a list, but we have these as checkboxes from the options on the golang site: https://pkg.go.dev/crypto/x509#ExtKeyUsage
           ],
         },
-        { 'Policy identifiers': ['policy_identifiers'] },
+        { 'Policy identifiers': ['policyIdentifiers'] },
         {
-          'Subject Alternative Name (SAN) Options': [
-            'allow_ip_sans',
-            'allowed_uri_sans',
-            'allowed_other_sans',
-          ],
+          'Subject Alternative Name (SAN) Options': ['allowIpSans', 'allowedUriSans', 'allowedOtherSans'],
         },
         {
           'Additional subject fields': [
             'allowed_serial_numbers',
-            'require_cn',
-            'use_csr_common_name',
+            'requireCn',
+            'useCsrCommonName',
+            'useCsrSans',
             'ou',
             'organization',
             'country',

--- a/ui/app/models/pki/pki-role-engine.js
+++ b/ui/app/models/pki/pki-role-engine.js
@@ -75,6 +75,7 @@ export default class PkiRolesEngineModel extends Model {
         { default: ['name'] },
         {
           'Domain handling': [
+            'allowedDomains',
             'allowedDomainTemplate',
             'allowBareDomains',
             'allowSubdomains',
@@ -93,6 +94,7 @@ export default class PkiRolesEngineModel extends Model {
             'DigitalSignature', // ARG TODO: capitalized in the docs, but should confirm
             'KeyAgreement',
             'KeyEncipherment',
+            'extKeyUsage', // ARG TODO: takes a list, but we have these as checkboxes from the options on the golang site: https://pkg.go.dev/crypto/x509#ExtKeyUsage
           ],
         },
         { 'Policy identifiers': ['policy_identifiers'] },

--- a/ui/app/serializers/pki/pki-issuer-engine.js
+++ b/ui/app/serializers/pki/pki-issuer-engine.js
@@ -4,17 +4,15 @@ export default class PkiIssuerEngineSerializer extends ApplicationSerializer {
   primaryKey = 'id';
 
   // rehydrate each issuer model so all model attributes are accessible from the LIST response
-  // normalizeItems(payload) {
-  //   payload.data.backend = 'blah';
-  //   Object.assign(payload, payload.data);
-  //   delete payload.data;
-  //   // if (payload.data) {
-  //   //   if (payload.data?.key_info) {
-  //   //     // return payload.data.keys.map((key) => ({ id: key, ...payload.data.key_info[key] }));
-  //   //   }
-  //   //   Object.assign(payload, payload.data);
-  //   //   delete payload.data;
-  //   // }
-  //   return payload;
-  // }
+  normalizeItems(payload) {
+    // debugger;
+    if (payload.data) {
+      if (payload.data?.keys && Array.isArray(payload.data.keys)) {
+        return payload.data.keys.map((key) => ({ name: key, ...payload.data.key_info[key] }));
+      }
+      Object.assign(payload, payload.data);
+      delete payload.data;
+    }
+    return payload;
+  }
 }

--- a/ui/app/serializers/pki/pki-issuer-engine.js
+++ b/ui/app/serializers/pki/pki-issuer-engine.js
@@ -1,8 +1,6 @@
 import ApplicationSerializer from '../application';
 
 export default class PkiIssuerEngineSerializer extends ApplicationSerializer {
-  primaryKey = 'id';
-
   // rehydrate each issuer model so all model attributes are accessible from the LIST response
   normalizeItems(payload) {
     if (payload.data) {

--- a/ui/app/serializers/pki/pki-issuer-engine.js
+++ b/ui/app/serializers/pki/pki-issuer-engine.js
@@ -1,0 +1,20 @@
+import ApplicationSerializer from '../application';
+
+export default class PkiIssuerEngineSerializer extends ApplicationSerializer {
+  primaryKey = 'id';
+
+  // rehydrate each issuer model so all model attributes are accessible from the LIST response
+  // normalizeItems(payload) {
+  //   payload.data.backend = 'blah';
+  //   Object.assign(payload, payload.data);
+  //   delete payload.data;
+  //   // if (payload.data) {
+  //   //   if (payload.data?.key_info) {
+  //   //     // return payload.data.keys.map((key) => ({ id: key, ...payload.data.key_info[key] }));
+  //   //   }
+  //   //   Object.assign(payload, payload.data);
+  //   //   delete payload.data;
+  //   // }
+  //   return payload;
+  // }
+}

--- a/ui/app/serializers/pki/pki-issuer-engine.js
+++ b/ui/app/serializers/pki/pki-issuer-engine.js
@@ -5,10 +5,9 @@ export default class PkiIssuerEngineSerializer extends ApplicationSerializer {
 
   // rehydrate each issuer model so all model attributes are accessible from the LIST response
   normalizeItems(payload) {
-    // debugger;
     if (payload.data) {
       if (payload.data?.keys && Array.isArray(payload.data.keys)) {
-        return payload.data.keys.map((key) => ({ name: key, ...payload.data.key_info[key] }));
+        return payload.data.keys.map((key) => ({ id: key, ...payload.data.key_info[key] }));
       }
       Object.assign(payload, payload.data);
       delete payload.data;

--- a/ui/lib/pki/addon/controllers/issuers/index.js
+++ b/ui/lib/pki/addon/controllers/issuers/index.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+
+export default class PkiRolesIssuerController extends Controller {
+  // To prevent production build bug of passing D.actions to on "click": https://github.com/hashicorp/vault/pull/16983
+  @action onLinkClick(D) {
+    D.actions.close();
+  }
+}

--- a/ui/lib/pki/addon/controllers/issuers/index.js
+++ b/ui/lib/pki/addon/controllers/issuers/index.js
@@ -1,9 +1,10 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { next } from '@ember/runloop';
 
 export default class PkiRolesIssuerController extends Controller {
   // To prevent production build bug of passing D.actions to on "click": https://github.com/hashicorp/vault/pull/16983
   @action onLinkClick(D) {
-    D.actions.close();
+    next(() => D.actions.close());
   }
 }

--- a/ui/lib/pki/addon/controllers/roles/index.js
+++ b/ui/lib/pki/addon/controllers/roles/index.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { getOwner } from '@ember/application';
 
-export default class BlogPostController extends Controller {
+export default class PkiRolesIndexController extends Controller {
   get mountPoint() {
     return getOwner(this).mountPoint;
   }

--- a/ui/lib/pki/addon/routes.js
+++ b/ui/lib/pki/addon/routes.js
@@ -15,7 +15,7 @@ export default buildRoutes(function () {
     this.route('details');
   });
   this.route('roles', function () {
-    this.route('index', { path: '/' }); // ARG TODO remove
+    this.route('index', { path: '/' });
     this.route('create');
     this.route('role', { path: '/:id' }, function () {
       this.route('details');
@@ -23,6 +23,7 @@ export default buildRoutes(function () {
     });
   });
   this.route('issuers', function () {
+    this.route('index', { path: '/' });
     this.route('create');
     this.route('issuer', { path: '/:id' }, function () {
       this.route('details');

--- a/ui/lib/pki/addon/routes.js
+++ b/ui/lib/pki/addon/routes.js
@@ -24,7 +24,6 @@ export default buildRoutes(function () {
   });
   this.route('issuers', function () {
     this.route('index', { path: '/' });
-    this.route('create');
     this.route('issuer', { path: '/:id' }, function () {
       this.route('details');
       this.route('edit');

--- a/ui/lib/pki/addon/routes/configuration/create/generate-csr.js
+++ b/ui/lib/pki/addon/routes/configuration/create/generate-csr.js
@@ -1,3 +1,3 @@
 import Route from '@ember/routing/route';
 
-export default class ConfigurationCreateGenerateCsrRoute extends Route {}
+export default class PkiConfigurationCreateGenerateCsrRoute extends Route {}

--- a/ui/lib/pki/addon/routes/configuration/create/generate-csr.js
+++ b/ui/lib/pki/addon/routes/configuration/create/generate-csr.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class ConfigurationCreateGenerateCsrRoute extends Route {}

--- a/ui/lib/pki/addon/routes/configuration/create/generate-root.js
+++ b/ui/lib/pki/addon/routes/configuration/create/generate-root.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class ConfigurationCreateGenerateRootRoute extends Route {}

--- a/ui/lib/pki/addon/routes/configuration/create/generate-root.js
+++ b/ui/lib/pki/addon/routes/configuration/create/generate-root.js
@@ -1,3 +1,3 @@
 import Route from '@ember/routing/route';
 
-export default class ConfigurationCreateGenerateRootRoute extends Route {}
+export default class PkiConfigurationCreateGenerateRootRoute extends Route {}

--- a/ui/lib/pki/addon/routes/configuration/create/import-ca.js
+++ b/ui/lib/pki/addon/routes/configuration/create/import-ca.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class ConfigurationCreateImportCaRoute extends Route {}

--- a/ui/lib/pki/addon/routes/configuration/create/import-ca.js
+++ b/ui/lib/pki/addon/routes/configuration/create/import-ca.js
@@ -1,3 +1,3 @@
 import Route from '@ember/routing/route';
 
-export default class ConfigurationCreateImportCaRoute extends Route {}
+export default class PkiConfigurationCreateImportCaRoute extends Route {}

--- a/ui/lib/pki/addon/routes/issuers/index.js
+++ b/ui/lib/pki/addon/routes/issuers/index.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class PkiIssuersIndexRoute extends Route {}

--- a/ui/lib/pki/addon/routes/issuers/index.js
+++ b/ui/lib/pki/addon/routes/issuers/index.js
@@ -1,3 +1,25 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
-export default class PkiIssuersIndexRoute extends Route {}
+export default class PkiIssuersIndexRoute extends Route {
+  @service store;
+  @service secretMountPath;
+  @service pathHelp;
+
+  async model() {
+    // the pathHelp service is needed for adding openAPI to the model
+    await this.pathHelp.getNewModel('pki/pki-issuer-engine', 'pki');
+
+    let response = await this.store
+      .query('pki/pki-issuer-engine', { backend: this.secretMountPath.currentPath })
+      .catch((err) => {
+        if (err.httpStatus === 404) {
+          return [];
+        } else {
+          throw err;
+        }
+      });
+    console.log(response, 'response in index');
+    return response;
+  }
+}

--- a/ui/lib/pki/addon/routes/issuers/index.js
+++ b/ui/lib/pki/addon/routes/issuers/index.js
@@ -19,7 +19,6 @@ export default class PkiIssuersIndexRoute extends Route {
           throw err;
         }
       });
-    console.log(response, 'response in index');
     return response;
   }
 }

--- a/ui/lib/pki/addon/routes/issuers/index.js
+++ b/ui/lib/pki/addon/routes/issuers/index.js
@@ -6,11 +6,11 @@ export default class PkiIssuersIndexRoute extends Route {
   @service secretMountPath;
   @service pathHelp;
 
-  async model() {
+  model() {
     // the pathHelp service is needed for adding openAPI to the model
-    await this.pathHelp.getNewModel('pki/pki-issuer-engine', 'pki');
+    this.pathHelp.getNewModel('pki/pki-issuer-engine', 'pki');
 
-    return await this.store
+    return this.store
       .query('pki/pki-issuer-engine', { backend: this.secretMountPath.currentPath })
       .catch((err) => {
         if (err.httpStatus === 404) {

--- a/ui/lib/pki/addon/routes/issuers/index.js
+++ b/ui/lib/pki/addon/routes/issuers/index.js
@@ -10,7 +10,7 @@ export default class PkiIssuersIndexRoute extends Route {
     // the pathHelp service is needed for adding openAPI to the model
     await this.pathHelp.getNewModel('pki/pki-issuer-engine', 'pki');
 
-    let response = await this.store
+    return await this.store
       .query('pki/pki-issuer-engine', { backend: this.secretMountPath.currentPath })
       .catch((err) => {
         if (err.httpStatus === 404) {
@@ -19,6 +19,5 @@ export default class PkiIssuersIndexRoute extends Route {
           throw err;
         }
       });
-    return response;
   }
 }

--- a/ui/lib/pki/addon/templates/configuration/create/generate-csr.hbs
+++ b/ui/lib/pki/addon/templates/configuration/create/generate-csr.hbs
@@ -1,2 +1,1 @@
-{{page-title "GenerateCsr"}}
-{{outlet}}
+configuration.create.generate-csr

--- a/ui/lib/pki/addon/templates/configuration/create/generate-csr.hbs
+++ b/ui/lib/pki/addon/templates/configuration/create/generate-csr.hbs
@@ -1,0 +1,2 @@
+{{page-title "GenerateCsr"}}
+{{outlet}}

--- a/ui/lib/pki/addon/templates/configuration/create/generate-root.hbs
+++ b/ui/lib/pki/addon/templates/configuration/create/generate-root.hbs
@@ -1,0 +1,2 @@
+{{page-title "GenerateRoot"}}
+{{outlet}}

--- a/ui/lib/pki/addon/templates/configuration/create/generate-root.hbs
+++ b/ui/lib/pki/addon/templates/configuration/create/generate-root.hbs
@@ -1,2 +1,1 @@
-{{page-title "GenerateRoot"}}
-{{outlet}}
+configuration.create.generate-root

--- a/ui/lib/pki/addon/templates/configuration/create/import-ca.hbs
+++ b/ui/lib/pki/addon/templates/configuration/create/import-ca.hbs
@@ -1,0 +1,1 @@
+configuration.create.import-ca

--- a/ui/lib/pki/addon/templates/issuers.hbs
+++ b/ui/lib/pki/addon/templates/issuers.hbs
@@ -8,3 +8,4 @@
   }}
   @isEngine={{true}}
 />
+{{outlet}}

--- a/ui/lib/pki/addon/templates/issuers/index.hbs
+++ b/ui/lib/pki/addon/templates/issuers/index.hbs
@@ -1,0 +1,29 @@
+<Toolbar>
+  <ToolbarActions>
+    <ToolbarLink @params={{array "configuration.create.import-ca"}}>
+      Import
+    </ToolbarLink>
+    <BasicDropdown @class="popup-menu" @horizontalPosition="auto-right" @verticalPosition="below" as |D|>
+      <D.Trigger class={{concat "toolbar-link" (if D.isOpen " is-active")}} @htmlTag="button">
+        Generate
+        <Chevron @direction="down" @isButton={{true}} />
+      </D.Trigger>
+      <D.Content @defaultClass="popup-menu-content">
+        <nav class="box menu">
+          <ul class="menu-list">
+            <li class="action">
+              <LinkTo @route="configuration.create.generate-root" {{on "click" D.actions.close}}>
+                Root
+              </LinkTo>
+            </li>
+            <li class="action">
+              <LinkTo @route="configuration.create.generate-csr" {{on "click" D.actions.close}}>
+                Intermediate CSR
+              </LinkTo>
+            </li>
+          </ul>
+        </nav>
+      </D.Content>
+    </BasicDropdown>
+  </ToolbarActions>
+</Toolbar>

--- a/ui/lib/pki/addon/templates/issuers/index.hbs
+++ b/ui/lib/pki/addon/templates/issuers/index.hbs
@@ -27,3 +27,64 @@
     </BasicDropdown>
   </ToolbarActions>
 </Toolbar>
+{{#if (gt this.model.length 0)}}
+  {{#each this.model as |model|}}
+    <LinkedBlock class="list-item-row" @params={{array "roles.role.details" model.id}} @linkPrefix={{this.mountPoint}}>
+      <div class="level is-mobile">
+        <div class="level-left">
+          <div>
+            <Icon @name="certificate" class="has-text-grey-light" />
+            <span class="has-text-weight-semibold is-underline">
+              {{model.id}}
+            </span>
+            <div class="is-flex-row has-left-margin-l has-top-margin-xs">
+              {{! if default_issuer is true (there can only be one) }}
+              <span class="tag has-text-grey-dark">default issuer</span>
+            </div>
+          </div>
+        </div>
+        <div class="level-right is-flex is-paddingless is-marginless">
+          <div class="level-item">
+            <PopupMenu>
+              <nav class="menu">
+                <ul class="menu-list">
+                  <li>
+                    <LinkTo
+                      @route="roles.role.details"
+                      @model={{model.id}}
+                      {{! ARG TODO return with permissions }}
+                      {{!-- @disabled={{eq model.canRead false}} --}}
+                    >
+                      Details
+                    </LinkTo>
+                  </li>
+                  <li>
+                    <LinkTo
+                      @route="roles.role.edit"
+                      @model={{model.id}}
+                      {{! ARG TODO return with permissions }}
+                      {{!-- @disabled={{eq model.canEdit false}} --}}
+                    >
+                      Edit
+                    </LinkTo>
+                  </li>
+                </ul>
+              </nav>
+            </PopupMenu>
+          </div>
+        </div>
+      </div>
+    </LinkedBlock>
+  {{/each}}
+{{else}}
+  <EmptyState @title="No roles yet">
+    <div>
+      <p>When created, roles will be listed here. Create a role to start generating certificates.</p>
+      <div class="has-top-margin-m">
+        <LinkTo @route="roles.create">
+          Create role
+        </LinkTo>
+      </div>
+    </div>
+  </EmptyState>
+{{/if}}

--- a/ui/lib/pki/addon/templates/issuers/index.hbs
+++ b/ui/lib/pki/addon/templates/issuers/index.hbs
@@ -77,14 +77,9 @@
     </LinkedBlock>
   {{/each}}
 {{else}}
-  <EmptyState @title="No roles yet">
-    <div>
-      <p>When created, roles will be listed here. Create a role to start generating certificates.</p>
-      <div class="has-top-margin-m">
-        <LinkTo @route="roles.create">
-          Create role
-        </LinkTo>
-      </div>
-    </div>
+  <EmptyState @title="PKI not configured" @message="This PKI mount hasn’t yet been configured with a certificate issuer.">
+    <LinkTo @route="configuration.create.index" @model={{this.model}}>
+      Configure PKI
+    </LinkTo>
   </EmptyState>
 {{/if}}

--- a/ui/lib/pki/addon/templates/issuers/index.hbs
+++ b/ui/lib/pki/addon/templates/issuers/index.hbs
@@ -12,12 +12,12 @@
         <nav class="box menu">
           <ul class="menu-list">
             <li class="action">
-              <LinkTo @route="configuration.create.generate-root" {{on "click" D.actions.close}}>
+              <LinkTo @route="configuration.create.generate-root" {{on "click" (fn this.onLinkClick D)}}>
                 Root
               </LinkTo>
             </li>
             <li class="action">
-              <LinkTo @route="configuration.create.generate-csr" {{on "click" D.actions.close}}>
+              <LinkTo @route="configuration.create.generate-csr" {{on "click" (fn this.onLinkClick D)}}>
                 Intermediate CSR
               </LinkTo>
             </li>

--- a/ui/lib/pki/addon/templates/issuers/index.hbs
+++ b/ui/lib/pki/addon/templates/issuers/index.hbs
@@ -41,6 +41,9 @@
               {{#if model.isDefault}}
                 <span class="tag has-text-grey-dark">default issuer</span>
               {{/if}}
+              {{#if model.issuerName}}
+                <span class="tag has-text-grey-dark">{{model.id}}</span>
+              {{/if}}
             </div>
           </div>
         </div>

--- a/ui/lib/pki/addon/templates/issuers/index.hbs
+++ b/ui/lib/pki/addon/templates/issuers/index.hbs
@@ -35,11 +35,13 @@
           <div>
             <Icon @name="certificate" class="has-text-grey-light" />
             <span class="has-text-weight-semibold is-underline">
-              {{model.id}}
+              {{or model.issuerName model.id}}
             </span>
             <div class="is-flex-row has-left-margin-l has-top-margin-xs">
               {{! if default_issuer is true (there can only be one) }}
-              <span class="tag has-text-grey-dark">default issuer</span>
+              {{#if model.isDefault}}
+                <span class="tag has-text-grey-dark">default issuer</span>
+              {{/if}}
             </div>
           </div>
         </div>
@@ -49,22 +51,12 @@
               <nav class="menu">
                 <ul class="menu-list">
                   <li>
-                    <LinkTo
-                      @route="roles.role.details"
-                      @model={{model.id}}
-                      {{! ARG TODO return with permissions }}
-                      {{!-- @disabled={{eq model.canRead false}} --}}
-                    >
+                    <LinkTo @route="roles.role.details" @model={{model.id}}>
                       Details
                     </LinkTo>
                   </li>
                   <li>
-                    <LinkTo
-                      @route="roles.role.edit"
-                      @model={{model.id}}
-                      {{! ARG TODO return with permissions }}
-                      {{!-- @disabled={{eq model.canEdit false}} --}}
-                    >
+                    <LinkTo @route="roles.role.edit" @model={{model.id}}>
                       Edit
                     </LinkTo>
                   </li>

--- a/ui/lib/pki/addon/templates/issuers/index.hbs
+++ b/ui/lib/pki/addon/templates/issuers/index.hbs
@@ -38,7 +38,6 @@
               {{or model.issuerName model.id}}
             </span>
             <div class="is-flex-row has-left-margin-l has-top-margin-xs">
-              {{! if default_issuer is true (there can only be one) }}
               {{#if model.isDefault}}
                 <span class="tag has-text-grey-dark">default issuer</span>
               {{/if}}

--- a/ui/lib/pki/addon/templates/roles/index.hbs
+++ b/ui/lib/pki/addon/templates/roles/index.hbs
@@ -42,12 +42,12 @@
     </LinkedBlock>
   {{/each}}
 {{else}}
-  <EmptyState @title="No issuers yet">
+  <EmptyState @title="No roles yet">
     <div>
-      <p>When created, issuers will be listed here. ARG TODO Language coming from design?</p>
+      <p>When created, roles will be listed here. Create a role to start generating certificates.</p>
       <div class="has-top-margin-m">
         <LinkTo @route="roles.create">
-          ARG TODO will change
+          Create role
         </LinkTo>
       </div>
     </div>

--- a/ui/lib/pki/addon/templates/roles/index.hbs
+++ b/ui/lib/pki/addon/templates/roles/index.hbs
@@ -12,7 +12,7 @@
       <div class="level is-mobile">
         <div class="level-left">
           <div>
-            <Icon @name="file" class="has-text-grey-light" />
+            <Icon @name="user" class="has-text-grey-light" />
             <span class="has-text-weight-semibold is-underline">
               {{model.id}}
             </span>

--- a/ui/lib/pki/addon/templates/roles/index.hbs
+++ b/ui/lib/pki/addon/templates/roles/index.hbs
@@ -24,22 +24,12 @@
               <nav class="menu">
                 <ul class="menu-list">
                   <li>
-                    <LinkTo
-                      @route="roles.role.details"
-                      @model={{model.id}}
-                      {{! ARG TODO return with permissions }}
-                      {{!-- @disabled={{eq model.canRead false}} --}}
-                    >
+                    <LinkTo @route="roles.role.details" @model={{model.id}}>
                       Details
                     </LinkTo>
                   </li>
                   <li>
-                    <LinkTo
-                      @route="roles.role.edit"
-                      @model={{model.id}}
-                      {{! ARG TODO return with permissions }}
-                      {{!-- @disabled={{eq model.canEdit false}} --}}
-                    >
+                    <LinkTo @route="roles.role.edit" @model={{model.id}}>
                       Edit
                     </LinkTo>
                   </li>
@@ -52,12 +42,12 @@
     </LinkedBlock>
   {{/each}}
 {{else}}
-  <EmptyState @title="No roles yet">
+  <EmptyState @title="No issuers yet">
     <div>
-      <p>When created, roles will be listed here. Create a role to start generating certificates.</p>
+      <p>When created, issuers will be listed here. ARG TODO Language coming from design?</p>
       <div class="has-top-margin-m">
         <LinkTo @route="roles.create">
-          Create role
+          ARG TODO will change
         </LinkTo>
       </div>
     </div>


### PR DESCRIPTION
This PR adds the list view for the default issuer. Confirmed with Backend and Design that at this point we cannot get all the information Design originally wanted on this list view without iterating over each issuer and making additional network request. We put this as a nice-to-have ticket in the future as it's outside the scope of this ticket (design originally thought this data was available on the LIST endpoint).

**Here are the designs:**
![image](https://user-images.githubusercontent.com/6618863/191093854-ced1790f-b33a-4a31-b680-b6efca81a4a4.png)

**Here is the outcome:** 
* Not every issuer will have a issuer_name so in those cases we use the id.
* Flight icons won't let us go smaller than what we are currently using and thus they don't fit the designs. Design gave okay to not use the info icons as they did not look great with the current sizing available to us.
* We can't know if it's an intermediate or not without another API request. This will happen in the nice-to-have ticket.
![image](https://user-images.githubusercontent.com/6618863/191108973-b4df19b6-0bb7-4928-a8fd-ee1c06979c6f.png)

