### PR TITLE
docs: Update agent autoauth sinks examples

### DIFF
--- a/website/content/docs/agent/autoauth/index.mdx
+++ b/website/content/docs/agent/autoauth/index.mdx
@@ -209,8 +209,8 @@ the two formats.
 The HCL format may define any number of sink objects with an optional wrapping
 `sinks {...}` object.
 
-~> Note: The [corresponding JSON format](#sinks-json-format) _must_ specify a `"sinks"
-: [...]` array to encapsulate all `sink` JSON objects.
+~> Note: The [corresponding JSON format](#sinks-json-format) _must_ specify a
+`"sinks" : [...]` array to encapsulate all `sink` JSON objects.
 
 ```hcl
 // Other Vault Agent configuration blocks
@@ -275,8 +275,8 @@ auto_auth {
 
 #### Sinks (JSON format)
 
-The following format illustrates the need for a `sinks: [...]` array wrapping
-any number of `sink` objects.
+The following JSON configuration illustrates the need for a `sinks: [...]` array
+wrapping any number of `sink` objects.
 
 ```json
 {
@@ -298,10 +298,11 @@ any number of `sink` objects.
 
           config = {
             path = "/tmp/file-foo"
+          }
         }
       }
-    }
-  ]
+    ]
+  }
 }
 ```
 
@@ -328,6 +329,7 @@ array:
 
           config = {
             path = "/tmp/file-foo"
+          }
         }
       },
       {
@@ -339,7 +341,7 @@ array:
           }
         }
       }
-    }
-  ]
+    ]
+  }
 }
 ```

--- a/website/content/docs/agent/autoauth/index.mdx
+++ b/website/content/docs/agent/autoauth/index.mdx
@@ -200,7 +200,14 @@ These configuration values are common to all Sinks:
 
 ### Auto Auth Examples
 
-#### Single sink (HCL)
+Auto-Auth configuration objects take two separate forms when specified in `HCL`
+and `JSON`. The following examples are meant to clarify the differences between
+the two formats.
+
+#### HCL sinks
+
+The HCL format may define any number of sink objects with an optional wrapping
+`sinks {...}` object.
 
 ```hcl
 // Other Vault Agent configuration blocks
@@ -228,9 +235,8 @@ auto_auth {
 }
 ```
 
-In HCL, it is also viable to specify a single sink without a wrapping `sinks {...}` object.
-
-**Note:** The [corresponding JSON form](#single-sink-json) _must_ specify the equivalent `"sinks" : [...]` array.
+The following valid HCL omits the wrapping `sinks` object while specifying
+multiple sinks.
 
 ```hcl
 // Other Vault Agent configuration blocks
@@ -253,10 +259,24 @@ auto_auth {
       path = "/tmp/file-foo"
     }
   }
+
+  sink {
+    type = "file"
+
+    config = {
+      path = "/tmp/file-bar"
+    }
+  }
 }
 ```
 
-#### Single sink (JSON)
+~> The [corresponding JSON format](#json-sinks) _must_ specify a `"sinks" :
+[...]` array to encapsulate all `sink` JSON objects.
+
+#### JSON sinks
+
+The following format illustrates the need for a `sinks: [...]` array wrapping
+any number of `sink` objects.
 
 ```json
 {
@@ -285,79 +305,8 @@ auto_auth {
 }
 ```
 
-#### Multiple sinks (HCL)
-
-```hcl
-// Other Vault Agent configuration blocks
-// ...
-
-auto_auth {
-  method {
-    type = "approle"
-
-    config = {
-      role_id_file_path = "/etc/vault/roleid"
-      secret_id_file_path = "/etc/vault/secretid"
-    }
-  }
-
-  sinks {
-    sink {
-      type = "file"
-
-      config = {
-        path = "/tmp/file-foo"
-      }
-    }
-    
-    sink {
-      type = "file"
-
-      config = {
-        path = "/tmp/file-bar"
-      }
-    }
-  }
-}
-```
-
-In HCL, it is also viable to specify a single sink without a wrapping `sinks {...}`.
-
-**Note:** The [corresponding JSON form](#multiple-sinks-json) _must_ specify the equivalent `"sinks" : [...]`.
-
-```hcl
-// Other Vault Agent configuration blocks
-// ...
-
-auto_auth {
-  method {
-    type = "approle"
-
-    config = {
-      role_id_file_path = "/etc/vault/roleid"
-      secret_id_file_path = "/etc/vault/secretid"
-    }
-  }
-
-  sink {
-    type = "file"
-
-    config = {
-      path = "/tmp/file-foo"
-    }
-  }
-  
-  sink {
-    type = "file"
-
-    config = {
-      path = "/tmp/file-bar"
-    }
-  }
-}
-```
-
-#### Multiple sinks (JSON)
+Multiple sinks are defined by appending more `sink` objects within the `sinks`
+array:
 
 ```json
 {
@@ -387,6 +336,7 @@ auto_auth {
 
           config = {
             path = "/tmp/file-bar"
+          }
         }
       }
     }

--- a/website/content/docs/agent/autoauth/index.mdx
+++ b/website/content/docs/agent/autoauth/index.mdx
@@ -204,7 +204,7 @@ Auto-Auth configuration objects take two separate forms when specified in `HCL`
 and `JSON`. The following examples are meant to clarify the differences between
 the two formats.
 
-#### HCL sinks
+#### Sinks (HCL Format)
 
 The HCL format may define any number of sink objects with an optional wrapping
 `sinks {...}` object.
@@ -236,7 +236,7 @@ auto_auth {
 ```
 
 The following valid HCL omits the wrapping `sinks` object while specifying
-multiple sinks.
+multiple sinks. This is valid in the HCL format, but not in JSON format.
 
 ```hcl
 // Other Vault Agent configuration blocks
@@ -270,10 +270,10 @@ auto_auth {
 }
 ```
 
-~> The [corresponding JSON format](#json-sinks) _must_ specify a `"sinks" :
-[...]` array to encapsulate all `sink` JSON objects.
+#### Sinks (JSON format)
 
-#### JSON sinks
+~> The [corresponding JSON format](#sinks-json-format) _must_ specify a `"sinks" :
+[...]` array to encapsulate all `sink` JSON objects.
 
 The following format illustrates the need for a `sinks: [...]` array wrapping
 any number of `sink` objects.

--- a/website/content/docs/agent/autoauth/index.mdx
+++ b/website/content/docs/agent/autoauth/index.mdx
@@ -200,14 +200,17 @@ These configuration values are common to all Sinks:
 
 ### Auto Auth Examples
 
-Auto-Auth configuration objects take two separate forms when specified in `HCL`
-and `JSON`. The following examples are meant to clarify the differences between
+Auto-Auth configuration objects take two separate forms when specified in HCL
+and JSON. The following examples are meant to clarify the differences between
 the two formats.
 
 #### Sinks (HCL Format)
 
 The HCL format may define any number of sink objects with an optional wrapping
 `sinks {...}` object.
+
+~> Note: The [corresponding JSON format](#sinks-json-format) _must_ specify a `"sinks"
+: [...]` array to encapsulate all `sink` JSON objects.
 
 ```hcl
 // Other Vault Agent configuration blocks
@@ -236,7 +239,7 @@ auto_auth {
 ```
 
 The following valid HCL omits the wrapping `sinks` object while specifying
-multiple sinks. This is valid in the HCL format, but not in JSON format.
+multiple sinks.
 
 ```hcl
 // Other Vault Agent configuration blocks
@@ -271,9 +274,6 @@ auto_auth {
 ```
 
 #### Sinks (JSON format)
-
-~> The [corresponding JSON format](#sinks-json-format) _must_ specify a `"sinks" :
-[...]` array to encapsulate all `sink` JSON objects.
 
 The following format illustrates the need for a `sinks: [...]` array wrapping
 any number of `sink` objects.

--- a/website/content/docs/agent/autoauth/index.mdx
+++ b/website/content/docs/agent/autoauth/index.mdx
@@ -198,11 +198,43 @@ These configuration values are common to all Sinks:
 - `config` `(object: required)` - Configuration of the sink itself. See the
   sidebar for information about each sink.
 
-### Auto Auth Example
+### Auto Auth Examples
+
+#### Single sink (HCL)
 
 ```hcl
-# Other Vault Agent configuration blocks
-# ...
+// Other Vault Agent configuration blocks
+// ...
+
+auto_auth {
+  method {
+    type = "approle"
+
+    config = {
+      role_id_file_path = "/etc/vault/roleid"
+      secret_id_file_path = "/etc/vault/secretid"
+    }
+  }
+
+  sinks {
+    sink {
+      type = "file"
+
+      config = {
+        path = "/tmp/file-foo"
+      }
+    }
+  }
+}
+```
+
+In HCL, it is also viable to specify a single sink without a wrapping `sinks {...}` object.
+
+**Note:** The [corresponding JSON form](#single-sink-json) _must_ specify the equivalent `"sinks" : [...]` array.
+
+```hcl
+// Other Vault Agent configuration blocks
+// ...
 
 auto_auth {
   method {
@@ -221,5 +253,143 @@ auto_auth {
       path = "/tmp/file-foo"
     }
   }
+}
+```
+
+#### Single sink (JSON)
+
+```json
+{
+  "auto_auth" : {
+    "method" : [
+      {
+        type = "approle"
+
+        config = {
+          role_id_file_path = "/etc/vault/roleid"
+          secret_id_file_path = "/etc/vault/secretid"
+        }
+      }
+    ],
+    "sinks" : [
+      {
+        "sink" : {
+          type = "file"
+
+          config = {
+            path = "/tmp/file-foo"
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Multiple sinks (HCL)
+
+```hcl
+// Other Vault Agent configuration blocks
+// ...
+
+auto_auth {
+  method {
+    type = "approle"
+
+    config = {
+      role_id_file_path = "/etc/vault/roleid"
+      secret_id_file_path = "/etc/vault/secretid"
+    }
+  }
+
+  sinks {
+    sink {
+      type = "file"
+
+      config = {
+        path = "/tmp/file-foo"
+      }
+    }
+    
+    sink {
+      type = "file"
+
+      config = {
+        path = "/tmp/file-bar"
+      }
+    }
+  }
+}
+```
+
+In HCL, it is also viable to specify a single sink without a wrapping `sinks {...}`.
+
+**Note:** The [corresponding JSON form](#multiple-sinks-json) _must_ specify the equivalent `"sinks" : [...]`.
+
+```hcl
+// Other Vault Agent configuration blocks
+// ...
+
+auto_auth {
+  method {
+    type = "approle"
+
+    config = {
+      role_id_file_path = "/etc/vault/roleid"
+      secret_id_file_path = "/etc/vault/secretid"
+    }
+  }
+
+  sink {
+    type = "file"
+
+    config = {
+      path = "/tmp/file-foo"
+    }
+  }
+  
+  sink {
+    type = "file"
+
+    config = {
+      path = "/tmp/file-bar"
+    }
+  }
+}
+```
+
+#### Multiple sinks (JSON)
+
+```json
+{
+  "auto_auth" : {
+    "method" : [
+      {
+        type = "approle"
+
+        config = {
+          role_id_file_path = "/etc/vault/roleid"
+          secret_id_file_path = "/etc/vault/secretid"
+        }
+      }
+    ],
+    "sinks" : [
+      {
+        "sink" : {
+          type = "file"
+
+          config = {
+            path = "/tmp/file-foo"
+        }
+      },
+      {
+        "sink" : {
+          type = "file"
+
+          config = {
+            path = "/tmp/file-bar"
+        }
+      }
+    }
+  ]
 }
 ```


### PR DESCRIPTION
This PR aims to clarify some confusion around the differing `sinks` specifications in the auto-auth config. Relevant discussion in #7380.