### PR TITLE
Vault documentation: release notes for 1.12

### DIFF
--- a/website/content/docs/release-notes/1.12.0.mdx
+++ b/website/content/docs/release-notes/1.12.0.mdx
@@ -11,7 +11,7 @@ description: |-
 
 **Summary:** Vault Release 1.12.0 offers features and enhancements that improve the user experience while solving critical  issues previously encountered by our customers. We are providing an overview  of improvements in this set of  release notes.
 
-We encourage you to upgrade to the latest release of Vault to take advantage of the new benefits provided. With this latest release, we offer solutions to critical feature gaps that were identified previously. Please refer to the Changelog within the Vault release for further information on product improvements, including a comprehensive list of bug fixes.
+We encourage you to upgrade to the latest release of Vault to take advantage of the new benefits provided. With this latest release, we offer solutions to critical feature gaps that were identified previously. Please refer to the [Changelog](https://github.com/hashicorp/vault/blob/main/CHANGELOG.md) within the Vault release for further information on product improvements, including a comprehensive list of bug fixes.
 
 Some of these enhancements and changes in this release include the following:
 

--- a/website/content/docs/release-notes/1.12.0.mdx
+++ b/website/content/docs/release-notes/1.12.0.mdx
@@ -92,7 +92,7 @@ The billing period for client counting API can now be specified with the [curren
 
 ### Redis Database Secrets Engine
 
-With the support of the Redis secrets engine, users can use Vault to manage static role or dynamic credentials for Redis OSS. The engine  works similarly to other database secrets engines. Refer to the [Redis](/docs/secrets/redis) documentation for more information. Huge thanks to [Francis Hitchens](https://github.com/fhitchen), who contributed their repository to HashiCorp
+With the support of the Redis database secrets engine, users can use Vault to manage static and dynamic credentials for Redis OSS. The engine  works similarly to other database secrets engines. Refer to the [Redis](/docs/secrets/redis) documentation for more information. Huge thanks to [Francis Hitchens](https://github.com/fhitchen), who contributed their repository to HashiCorp
 
 ### AWS Elasticache Database Secrets Engine
 With the support of the AWS ElastiCache secrets engine, users may use Vault to manage static  for AWS Elasticache instances that use Redis as their backend. The engine will work similarly to other database secrets engines. Refer to the [elasticache](/docs/secrets/databases/rediselasticache) documentation for more information.

--- a/website/content/docs/release-notes/1.12.0.mdx
+++ b/website/content/docs/release-notes/1.12.0.mdx
@@ -34,7 +34,7 @@ This section describes the new features introduced in Vault 1.12.0.
 
 These features need the Vault Enterprise ADP License.
 
-### Bring Your Own Key(BYOK) for Transform
+### Bring Your Own Key (BYOK) for Transform
 
 In release 1.11, we introduced BYOK support to Vault, enabling  customers to import existing keys into the Vault Transit Secrets Engine and  enabling secure and flexible Vault deployments.
 We  are extending that support to the Vault Transform Secrets Engine in this release.
@@ -46,17 +46,7 @@ An MSSQL store is now available to be used as an external storage engine with to
 ### Key Auto Rotation
 
 Periodic rotation of encryption keys is a recommended key management practice for a good security posture. In Vault release 1.10, we added support for Auto key rotation for Transit Secrets Engine. In Vault 1.12, the Transform secrets engine is now  enhanced, allowing users to set the rotation policy during key creation in a time interval, which will cause Vault to rotate the Transform keys when the time interval elapses automatically.
-Refer to the following documents, [Transit Secrets Engine](/docs/secrets/transit) and [Transit Secrets Engine(API)](/api-docs/secret/transit#rotate-key) for more information.
-
-## PKI Engine Improvements
-
-### PKI Engine Revocation Enhancements
-
-We are improving Vault PKI Engine’s revocation capabilities by adding support for the Online Certificate Status Protocol (OCSP) and a delta Certificate Revocation List (CRL) to track changes to the main CRL. These enhancements significantly streamline customer experience with the PKI engine making the certification revocation semantics easier to understand and manage.
-
-### PKI Telemetry Improvements
-
-In this release, we are adding additional telemetry to Vault’s PKI Secrets Engine, enabling customers to gather better  insights into  certificate usage via the count of stored and revoked certificates. Additionally, the Vault `tidy` function is enhanced with additional metrics that reflect the remaining stored and revoked certificates.
+Refer to the following documentation [Tokenization Transform](/docs/secrets/transform/tokenization) and [Transform Secrets Engine(API)](/api-docs/secret/transform#rotate-tokenization-key) for more information.
 
 ### Auto-fetch CRL in the Certificate Auth Method
 
@@ -117,6 +107,16 @@ In Vault 1.11, we added support for Okta’s Number Challenge feature in the CLI
 
 ### OIDC Provider support in the UI
 Vault can now act as an OIDC provider for applications that wish to delegate authentication to Vault and leverage its identity system. As an OIDC provider, Vault supports PKCE for authorization code flow, preventing attacks such as SSRF. After OIDC provider functionality went GA, our design and user research team gathered feedback from community members, and we simplified the setup experience. With a few CLI commands or UI clicks, users can now have a default OIDC provider with its defaults configured and ready to go for applications to utilize the functionality.
+
+## PKI Engine Improvements
+
+### PKI Engine Revocation Enhancements
+
+We are improving Vault PKI Engine’s revocation capabilities by adding support for the Online Certificate Status Protocol (OCSP) and a delta Certificate Revocation List (CRL) to track changes to the main CRL. These enhancements significantly streamline customer experience with the PKI engine making the certification revocation semantics easier to understand and manage. Additionally, support for automatic CRL rotation and periodic tidy operations help reduce operator burden, alleviate the demand on cluster resources during periods of high revocation, and ensure clients are always served valid CRLs.
+
+### PKI Telemetry Improvements
+
+In this release, we are adding additional telemetry to Vault’s PKI Secrets Engine, enabling customers to gather better  insights into  certificate usage via the count of stored and revoked certificates. Additionally, the Vault `tidy` function is enhanced with additional metrics that reflect the remaining stored and revoked certificates.
 
 ## Other Features and Enhancements
 

--- a/website/content/docs/release-notes/1.12.0.mdx
+++ b/website/content/docs/release-notes/1.12.0.mdx
@@ -1,0 +1,136 @@
+---
+layout: docs
+page_title: 1.12.0
+description: |-
+  This page contains release notes for Vault 1.12.0
+---
+
+# Vault 1.12.0 Release Notes
+
+**Software Release date:** Oct. 12, 2022
+
+**Summary:** Vault Release 1.12.0 offers features and enhancements that improve the user experience while solving critical  issues previously encountered by our customers. We are providing an overview  of improvements in this set of  release notes.
+
+We encourage you to upgrade to the latest release of Vault to take advantage of the new benefits provided. With this latest release, we offer solutions to critical feature gaps that were identified previously. Please refer to the Changelog within the Vault release for further information on product improvements, including a comprehensive list of bug fixes.
+
+Some of these enhancements and changes in this release include the following:
+
+
+- Vault Enterprise now supports PKCS#11 provider plugin (client library) functionality.
+- Vault Enterprise can now manage keys for Oracle TDE. This requires the Advanced Data Protection license.
+- PKI Key revocation improvements are made to Vault’s PKI engine, introducing a new OCSP responder and automatic CRL rebuilding (with up-to-date Delta CRL), that offers significant performance and data transfer improvements to revocation workflows.
+- BYOK in Transform engines now allow users to import their keys generated elsewhere.
+- KMIP Server Profile adds support for additional operations, allowing  Vault to claim support for the baseline server profile.
+- Transform secrets engine supports time-based auto-key rotation for tokenization.
+- Path and Role-based Quotas extend the existing Vault Quota support by allowing quotas to be extended to the API path suffixes and auth mount roles.
+- Licensing termination behavior has changed where non-evaluation licenses (production licenses) will no longer have a termination date.
+- TFVP includes improvements made to the Vault Version Detection and Auth engine.
+
+## New Features
+
+This section describes the new features introduced in Vault 1.12.0.
+
+##3 Transform Secrets Engine Enhancements
+
+These features need the Vault Enterprise ADP License.
+
+### Bring Your Own Key(BYOK) for Transform
+
+In release 1.11, we introduced BYOK support to Vault, enabling  customers to import existing keys into the Vault Transit Secrets Engine and  enabling secure and flexible Vault deployments.
+We  are extending that support to the Vault Transform Secrets Engine in this release.
+
+### MSSQL Support
+
+An MSSQL store is now available to be used as an external storage engine with tokenization Transform Secrets Engine. Refer to the following documents, [Transform Secrets Engine(API)](/api-docs/secret/transform), [Transform Secrets Engine](/docs/secrets/transform/index), and [Tokenization Transform](/docs/secrets/transform/tokenization) for more information.
+
+### Key Auto Rotation
+
+Periodic rotation of encryption keys is a recommended key management practice for a good security posture. In Vault release 1.10, we added support for Auto key rotation for Transit Secrets Engine. In Vault 1.12, the Transform secrets engine is now  enhanced, allowing users to set the rotation policy during key creation in a time interval, which will cause Vault to rotate the Transform keys when the time interval elapses automatically.
+Refer to the following documents, [Transit Secrets Engine](/docs/secrets/transit) and [Transit Secrets Engine(API)](/api-docs/secret/transit#rotate-key) for more information.
+
+## PKI Engine Improvements
+
+### PKI Engine Revocation Enhancements
+
+We are improving Vault PKI Engine’s revocation capabilities by adding support for the Online Certificate Status Protocol (OCSP) and a delta Certificate Revocation List (CRL) to track changes to the main CRL. These enhancements significantly streamline customer experience with the PKI engine making the certification revocation semantics easier to understand and manage.
+
+### PKI Telemetry Improvements
+
+In this release, we are adding additional telemetry to Vault’s PKI Secrets Engine, enabling customers to gather better  insights into  certificate usage via the count of stored and revoked certificates. Additionally, the Vault `tidy` function is enhanced with additional metrics that reflect the remaining stored and revoked certificates.
+
+### Auto-fetch CRL in the Certificate Auth Method
+
+Operators will now be able to specify one or more CRL URLs that Vault will automatically fetch and keep up-to-date, rather than having to push the CRLs to the cert auth method. This should make certificate management easier for those users that have large cert auth deployments.
+
+### KMIP Server Profile
+
+The [Baseline Server Profile](https://docs.oasis-open.org/kmip/kmip-profiles/v2.1/os/kmip-profiles-v2.1-os.html) specifies the basic functionality expected of a KMIP server.  In Vault 1.12, we offer support for the operations and attributes in the Baseline server profile. With this release, Vault Enterprise now supports the Symmetric Key lifecycle server profile, Baseline server profile, and the Basic Cryptographic server profile (as of Release 1.11), enabling the  support of KMIP integrations with various clients more effectively. This requires the Enterprise ADP license.
+
+### GCP Cloud Key Manager Support
+
+Managed Keys let Vault secrets engines (currently PKI) use keys stored in Cloud KMS systems for cryptographic operations like certificate signing.  Vault 1.12 adds support for GCP Cloud KMS to the Managed Key system, where previously AWS, Azure, and PKCS#11 Hardware Security Modules were supported.
+
+### Path and Role-Based Resource Quotas
+
+In this release, the existing resource quota functionality has been enhanced. In addition to applying the API rate limiting and lease quotas at the namespace or mount level, you can now use  the quotas to the [API path suffixes and auth mount roles](/docs/enterprise/lease-count-quotas). This enhancement provides users with more control over issued certificates.
+
+### Client Count Improvements
+
+The billing period for client counting API can now be specified with the [current month](/docs/concepts/client-count) for the end date parameter. When this is done the "new_clients" field will have an hyperlog approximate value indicating the number of new clients that came in the current month. Note that for the previous months, the number will be an exact value.
+
+### Redis Secrets Engine
+
+With the support of the Redis Secrets Engine, users can use Vault to manage static or dynamic credentials for Redis OSS. The engine  works similarly to other database secrets engines. Refer to the [Redis](/docs/secrets/redis) documentation for more information. Huge thanks to [Francis Hitchens](https://github.com/fhitchen), who contributed their repository to HashiCorp
+
+### AWS Elasticache Secrets Engine
+With the support of the AWS ElastiCache Secrets Engine, users may use Vault to manage static  for AWS Elasticache instances that use Redis as their backend. The engine will work similarly to other database secrets engines. Refer to the [elasticache](/docs/secrets/databases/rediselasticache) documentation for more information.
+
+### LDAP Secrets Engine
+
+Vault 1.12 introduces a new LDAP secrets engine that unifies the user experience between the Active Directory (AD) secrets engine and OpenLDAP secrets engine. This new engine simplifies the user experience when Vault is used to manage credentials for directory services. This new engine supports all modes from both of the engines mentioned above (AD, LDAP and RACF modes) and brings dynamic credential capabilities for users relying on Active Directory.
+
+~> **Note:** This engine does _not_ replace the current Active Directory Secrets Engine. We will continue to maintain the engine and provide bug fixes, but encourage all new users to use the unified LDAP engine. We will communicate the schedule to deprecate the Active Directory secrets engine well in advance, providing time for users to migrate over.
+
+### Terraform Vault Provider: Vault Version Detection
+
+Vault Terraform provider v3.9.0 can now query Vault to detect the server’s version of the server and then perform a semantic version comparison against a provided minimum threshold version to determine whether a selected feature is available for use. This allows for the Vault provider to deterministically anticipate Vault’s behavior.
+
+### Plugin Versioning
+
+In prior versions of Vault, plugins were not “version-aware,”  creating a suboptimal user experience during plugin installation and upgrades. In Vault 1.12, we are introducing the concept of versions to plugins, making plugins “version-aware” and allowing standardization of the release processes and offering a better user experience when installing and upgrading plugins.
+
+### PKCS#11 Client support
+​​
+Software solutions often require cryptographic objects-like keys, X.509 certificates, or perform operations like a certificate or key generation, hashing, encryption, decryption, and signing. Hardware Security Modules (HSM) are traditionally used as a secure option, but are expensive and challenging to operationalize.
+
+Vault Enterprise 1.12 is a PKCS#11 2.40 compliant provider, extended profile. PKCS#11 is the standard protocol supported for integrating with HSMs. Support for this protocol is the first step to enabling customers to consolidate HSMs. It also has the operational flexibility and advantages of software for key generation, encryption, and object storage operations. The PKCS#11 support in Vault 1.12 supports a subset of key generation, encryption, decryption and key storage operations. This requires the Enterprise ADP-KM license.
+
+~> **Note:** With this feature, Vault does not become an HSM. HSMs are needed where customer use cases need FIPS 140-2 L2+ compliance support.
+
+### Oracle TDE
+
+With Vault 1.12, Vault Enterprise (ADP-KM) can now act as an external key manager for Oracle instances when Transparent Data Encryption is enabled. TDE allows users to conjure and use Vault to protect their Data Encryption Keys by using Vault to protect them using a Key Encryption Key. Reading and writing of data securely are handled transparently by Oracle database instances without needing user intervention. This will need the Enterprise ADP license.
+
+### UI Support for Okta Number Challenge
+
+In Vault 1.11, we added support for Okta’s Number Challenge feature in the CLI and API. In Vault 1.12, we’ve extended this support to the Vault UI, allowing users to complete the Okta Number Challenge from a web browser, the command line, and the HTTP API.
+
+### OIDC Provider support in the UI
+Vault can now act as an OIDC provider for applications that wish to delegate authentication to Vault and leverage its identity system. As an OIDC provider, Vault supports PKCE for authorization code flow, preventing attacks such as SSRF. After OIDC provider functionality went GA, our design and user research team gathered feedback from community members, and we simplified the setup experience. With a few CLI commands or UI clicks, users can now have a default OIDC provider with its defaults configured and ready to go for applications to utilize the functionality.
+
+## Other Features and Enhancements
+
+### License Termination Behavior
+
+The Licensing termination behavior has changed where non-evaluation licenses (production licenses) no longer have a termination date, making Vault more robust for Vault Enterprise customers. Also refer to the updated [licensing FAQ](/docs/enterprise/license/faq) for more information.
+
+### Namespace Custom Metadata
+Customers can now specify [custom metadata](/api-docs/system/namespaces) on the namespaces. The new `vault namespace patch` [command](/docs/commands/namespace) can be used to update existing namespaces with custom metadata as well. This will make it possible to tag namespaces with additional fields (For example: owner, region department) describing it.
+
+## Known issues
+
+There are no known issues documented for this release.
+
+## Feature Deprecations and EOL
+
+Please refer to the [Deprecation Plans and Notice](/docs/deprecation) page for up-to-date information on feature deprecations and plans. A [Feature Deprecation FAQ](/docs/deprecation/faq) page addresses questions about  decisions made about Vault feature deprecations.

--- a/website/content/docs/release-notes/1.12.0.mdx
+++ b/website/content/docs/release-notes/1.12.0.mdx
@@ -30,7 +30,7 @@ Some of these enhancements and changes in this release include the following:
 
 This section describes the new features introduced in Vault 1.12.0.
 
-##3 Transform Secrets Engine Enhancements
+### Transform Secrets Engine Enhancements
 
 These features need the Vault Enterprise ADP License.
 

--- a/website/content/docs/release-notes/1.12.0.mdx
+++ b/website/content/docs/release-notes/1.12.0.mdx
@@ -17,14 +17,15 @@ Some of these enhancements and changes in this release include the following:
 
 
 - Vault Enterprise now supports **PKCS#11** provider plugin (client library) functionality.
-- Vault Enterprise can now manage keys for **Oracle TDE**. This requires the Advanced Data Protection license.
+- Vault Enterprise can manage keys for **Oracle TDE**. This requires the Advanced Data Protection license.
 - **PKI Key revocation** improvements are made to Vault’s PKI engine, introducing a new OCSP responder and automatic CRL rebuilding (with up-to-date Delta CRL), that offers significant performance and data transfer improvements to revocation workflows.
 - **BYOK in Transform engines** now allow users to import their keys generated elsewhere.
 - **KMIP Server Profile** adds support for additional operations, allowing  Vault to claim support for the baseline server profile.
 - **Transform secrets engine** supports time-based auto-key rotation for tokenization.
 - **Path and Role-based Quotas** extend the existing Vault Quota support by allowing quotas to be extended to the API path suffixes and auth mount roles.
 - **Licensing** termination behavior has changed where non-evaluation licenses (production licenses) will no longer have a termination date.
-- **Terraform Vault Provider** improvements include Version Detection. It allows Terraform Vault Provider to detect the target Vault version to determine if the selected Vault feature is available.
+- **Redis Database Secrets Engine** is now available to manage static roles or generation of dynamic credentials, as well as root credential rotation on a stand-alone Redis server.
+- **AWS Elasticache Database Secrets Engine** is introduced to manage static credentials for AWS Elasticache instances. 
 
 ## New Features
 

--- a/website/content/docs/release-notes/1.12.0.mdx
+++ b/website/content/docs/release-notes/1.12.0.mdx
@@ -95,7 +95,7 @@ The billing period for client counting API can now be specified with the [curren
 With the support of the Redis database secrets engine, users can use Vault to manage static and dynamic credentials for Redis OSS. The engine  works similarly to other database secrets engines. Refer to the [Redis](/docs/secrets/redis) documentation for more information. Huge thanks to [Francis Hitchens](https://github.com/fhitchen), who contributed their repository to HashiCorp
 
 ### AWS Elasticache Database Secrets Engine
-With the support of the AWS ElastiCache secrets engine, users may use Vault to manage static  for AWS Elasticache instances that use Redis as their backend. The engine will work similarly to other database secrets engines. Refer to the [elasticache](/docs/secrets/databases/rediselasticache) documentation for more information.
+With the support of the AWS ElastiCache database secrets engine, users may use Vault to manage static credentials for AWS Elasticache instances. The engine will work similarly to other database secrets engines. Refer to the [elasticache](/docs/secrets/databases/rediselasticache) documentation for more information.
 
 ### LDAP Secrets Engine
 

--- a/website/content/docs/release-notes/1.12.0.mdx
+++ b/website/content/docs/release-notes/1.12.0.mdx
@@ -89,7 +89,7 @@ In this release, the existing resource quota functionality has been enhanced. In
 
 The billing period for client counting API can now be specified with the [current month](/docs/concepts/client-count) for the end date parameter. When this is done the "new_clients" field will have an hyperlog approximate value indicating the number of new clients that came in the current month. Note that for the previous months, the number will be an exact value.
 
-### Redis Secrets Engine
+### Redis Database Secrets Engine
 
 With the support of the Redis secrets engine, users can use Vault to manage static role or dynamic credentials for Redis OSS. The engine  works similarly to other database secrets engines. Refer to the [Redis](/docs/secrets/redis) documentation for more information. Huge thanks to [Francis Hitchens](https://github.com/fhitchen), who contributed their repository to HashiCorp
 

--- a/website/content/docs/release-notes/1.12.0.mdx
+++ b/website/content/docs/release-notes/1.12.0.mdx
@@ -93,7 +93,7 @@ The billing period for client counting API can now be specified with the [curren
 
 With the support of the Redis secrets engine, users can use Vault to manage static role or dynamic credentials for Redis OSS. The engine  works similarly to other database secrets engines. Refer to the [Redis](/docs/secrets/redis) documentation for more information. Huge thanks to [Francis Hitchens](https://github.com/fhitchen), who contributed their repository to HashiCorp
 
-### AWS Elasticache Secrets Engine
+### AWS Elasticache Database Secrets Engine
 With the support of the AWS ElastiCache secrets engine, users may use Vault to manage static  for AWS Elasticache instances that use Redis as their backend. The engine will work similarly to other database secrets engines. Refer to the [elasticache](/docs/secrets/databases/rediselasticache) documentation for more information.
 
 ### LDAP Secrets Engine

--- a/website/content/docs/release-notes/1.12.0.mdx
+++ b/website/content/docs/release-notes/1.12.0.mdx
@@ -99,7 +99,7 @@ With the support of the AWS ElastiCache database secrets engine, users may use V
 
 ### LDAP Secrets Engine
 
-Vault 1.12 introduces a new LDAP secrets engine that unifies the user experience between the Active Directory (AD) secrets engine and OpenLDAP secrets engine. This new engine simplifies the user experience when Vault is used to manage credentials for directory services. This new engine supports all modes from both of the engines mentioned above (AD, LDAP and RACF modes) and brings dynamic credential capabilities for users relying on Active Directory.
+Vault 1.12 introduces a new LDAP secrets engine that unifies the user experience between the Active Directory (AD) secrets engine and OpenLDAP secrets engine. This new engine simplifies the user experience when Vault is used to manage credentials for directory services. This new engine supports all implementations from both of the engines mentioned above (AD, LDAP and RACF) and brings dynamic credential capabilities for users relying on Active Directory.
 
 ~> **Note:** This engine does _not_ replace the current Active Directory secrets engine. We will continue to maintain the engine and provide bug fixes, but encourage all new users to use the unified LDAP engine. We will communicate the schedule to deprecate the Active Directory secrets engine well in advance, providing time for users to migrate over.
 

--- a/website/content/docs/release-notes/1.12.0.mdx
+++ b/website/content/docs/release-notes/1.12.0.mdx
@@ -16,15 +16,15 @@ We encourage you to upgrade to the latest release of Vault to take advantage of 
 Some of these enhancements and changes in this release include the following:
 
 
-- Vault Enterprise now supports PKCS#11 provider plugin (client library) functionality.
-- Vault Enterprise can now manage keys for Oracle TDE. This requires the Advanced Data Protection license.
-- PKI Key revocation improvements are made to Vault’s PKI engine, introducing a new OCSP responder and automatic CRL rebuilding (with up-to-date Delta CRL), that offers significant performance and data transfer improvements to revocation workflows.
-- BYOK in Transform engines now allow users to import their keys generated elsewhere.
-- KMIP Server Profile adds support for additional operations, allowing  Vault to claim support for the baseline server profile.
-- Transform secrets engine supports time-based auto-key rotation for tokenization.
-- Path and Role-based Quotas extend the existing Vault Quota support by allowing quotas to be extended to the API path suffixes and auth mount roles.
-- Licensing termination behavior has changed where non-evaluation licenses (production licenses) will no longer have a termination date.
-- TFVP includes improvements made to the Vault Version Detection and Auth engine.
+- Vault Enterprise now supports **PKCS#11** provider plugin (client library) functionality.
+- Vault Enterprise can now manage keys for **Oracle TDE**. This requires the Advanced Data Protection license.
+- **PKI Key revocation** improvements are made to Vault’s PKI engine, introducing a new OCSP responder and automatic CRL rebuilding (with up-to-date Delta CRL), that offers significant performance and data transfer improvements to revocation workflows.
+- **BYOK in Transform engines** now allow users to import their keys generated elsewhere.
+- **KMIP Server Profile** adds support for additional operations, allowing  Vault to claim support for the baseline server profile.
+- **Transform secrets engine** supports time-based auto-key rotation for tokenization.
+- **Path and Role-based Quotas** extend the existing Vault Quota support by allowing quotas to be extended to the API path suffixes and auth mount roles.
+- **Licensing** termination behavior has changed where non-evaluation licenses (production licenses) will no longer have a termination date.
+- **Terraform Vault Provider** improvements include Version Detection. It allows Terraform Vault Provider to detect the target Vault version to determine if the selected Vault feature is available.
 
 ## New Features
 
@@ -32,33 +32,54 @@ This section describes the new features introduced in Vault 1.12.0.
 
 ### Transform Secrets Engine Enhancements
 
-These features need the Vault Enterprise ADP License.
+-> **NOTE:** These features need the Vault Enterprise ADP License.
 
-### Bring Your Own Key (BYOK) for Transform
+#### Bring Your Own Key (BYOK) for Transform
 
 In release 1.11, we introduced BYOK support to Vault, enabling  customers to import existing keys into the Vault Transit Secrets Engine and  enabling secure and flexible Vault deployments.
 We  are extending that support to the Vault Transform Secrets Engine in this release.
 
-### MSSQL Support
+#### MSSQL Support
 
 An MSSQL store is now available to be used as an external storage engine with tokenization Transform Secrets Engine. Refer to the following documents, [Transform Secrets Engine(API)](/api-docs/secret/transform), [Transform Secrets Engine](/docs/secrets/transform/index), and [Tokenization Transform](/docs/secrets/transform/tokenization) for more information.
 
-### Key Auto Rotation
+#### Key Auto Rotation
 
 Periodic rotation of encryption keys is a recommended key management practice for a good security posture. In Vault release 1.10, we added support for Auto key rotation for Transit Secrets Engine. In Vault 1.12, the Transform secrets engine is now  enhanced, allowing users to set the rotation policy during key creation in a time interval, which will cause Vault to rotate the Transform keys when the time interval elapses automatically.
+
 Refer to the following documentation [Tokenization Transform](/docs/secrets/transform/tokenization) and [Transform Secrets Engine(API)](/api-docs/secret/transform#rotate-tokenization-key) for more information.
 
-### Auto-fetch CRL in the Certificate Auth Method
+### PKI Secrets Engine Improvements
+
+#### PKI Secrets Engine Revocation enhancements
+
+We are improving Vault PKI Engine’s revocation capabilities by adding support for the Online Certificate Status Protocol (OCSP) and a delta Certificate Revocation List (CRL) to track changes to the main CRL. These enhancements significantly streamline customer experience with the PKI engine making the certification revocation semantics easier to understand and manage. Additionally, support for automatic CRL rotation and periodic tidy operations help reduce operator burden, alleviate the demand on cluster resources during periods of high revocation, and ensure clients are always served valid CRLs. Finally, support for Bring-Your-Own-Cert (BYOC) allows revocation of `no_store=true` certificates and for Proof-of-Possession (PoP) allows end-users to safely revoke their own certificates (with corresponding private key) without operator intervention. 
+
+#### PKI and Managed Key support for RSA-PSS Signatures
+
+Since its initial release, Vault's PKI secrets engine only supported RSA-PKCS#1v1.5 (Public Key Cryptographic Standards) signatures for issuers and leaves. To conform with NIST's guidance around key transport and for compatibility with newer HSM Firmware, we have included support for RSA-PSS signatures (Probabilistic Signature Scheme). See the section on [PSS Support in the PKI documentation](https://www.vaultproject.io/docs/secrets/pki/considerations#pss-support) for limitations of this feature.
+
+#### PKI Telemetry Improvements
+
+In this release, we are adding additional telemetry to Vault’s PKI secrets engine, enabling customers to gather better  insights into  certificate usage via the count of stored and revoked certificates. Additionally, the Vault `tidy` function is enhanced with additional metrics that reflect the remaining stored and revoked certificates.
+
+#### Auto-fetch CRL in the Certificate Auth Method
 
 Operators will now be able to specify one or more CRL URLs that Vault will automatically fetch and keep up-to-date, rather than having to push the CRLs to the cert auth method. This should make certificate management easier for those users that have large cert auth deployments.
 
-### KMIP Server Profile
-
-The [Baseline Server Profile](https://docs.oasis-open.org/kmip/kmip-profiles/v2.1/os/kmip-profiles-v2.1-os.html) specifies the basic functionality expected of a KMIP server.  In Vault 1.12, we offer support for the operations and attributes in the Baseline server profile. With this release, Vault Enterprise now supports the Symmetric Key lifecycle server profile, Baseline server profile, and the Basic Cryptographic server profile (as of Release 1.11), enabling the  support of KMIP integrations with various clients more effectively. This requires the Enterprise ADP license.
-
-### GCP Cloud Key Manager Support
+#### GCP Cloud Key Manager Support
 
 Managed Keys let Vault secrets engines (currently PKI) use keys stored in Cloud KMS systems for cryptographic operations like certificate signing.  Vault 1.12 adds support for GCP Cloud KMS to the Managed Key system, where previously AWS, Azure, and PKCS#11 Hardware Security Modules were supported.
+
+### KMIP Server Profile
+
+The [Baseline Server Profile](https://docs.oasis-open.org/kmip/kmip-profiles/v2.1/os/kmip-profiles-v2.1-os.html) specifies the basic functionality expected of a KMIP server.  In Vault 1.12, we offer support for the operations and attributes in the Baseline server profile. With this release, Vault Enterprise now supports the Symmetric Key lifecycle server profile, Baseline server profile, and the Basic Cryptographic server profile (as of Release 1.11), enabling the  support of KMIP integrations with various clients more effectively. This requires the Vault Enterprise ADP license.
+
+### SSH Secrets Engine Support for Generating Keys
+
+Previously, Vault's SSH Secrets Engine when used as an SSH CA required requesters to provide their own public key for signing. In Vault 1.12, Vault can now generate credential key pairs dynamically, returning them to the requester.
+
+This was a community contributed enhancement.
 
 ### Path and Role-Based Resource Quotas
 
@@ -70,16 +91,16 @@ The billing period for client counting API can now be specified with the [curren
 
 ### Redis Secrets Engine
 
-With the support of the Redis Secrets Engine, users can use Vault to manage static or dynamic credentials for Redis OSS. The engine  works similarly to other database secrets engines. Refer to the [Redis](/docs/secrets/redis) documentation for more information. Huge thanks to [Francis Hitchens](https://github.com/fhitchen), who contributed their repository to HashiCorp
+With the support of the Redis secrets engine, users can use Vault to manage static role or dynamic credentials for Redis OSS. The engine  works similarly to other database secrets engines. Refer to the [Redis](/docs/secrets/redis) documentation for more information. Huge thanks to [Francis Hitchens](https://github.com/fhitchen), who contributed their repository to HashiCorp
 
 ### AWS Elasticache Secrets Engine
-With the support of the AWS ElastiCache Secrets Engine, users may use Vault to manage static  for AWS Elasticache instances that use Redis as their backend. The engine will work similarly to other database secrets engines. Refer to the [elasticache](/docs/secrets/databases/rediselasticache) documentation for more information.
+With the support of the AWS ElastiCache secrets engine, users may use Vault to manage static  for AWS Elasticache instances that use Redis as their backend. The engine will work similarly to other database secrets engines. Refer to the [elasticache](/docs/secrets/databases/rediselasticache) documentation for more information.
 
 ### LDAP Secrets Engine
 
 Vault 1.12 introduces a new LDAP secrets engine that unifies the user experience between the Active Directory (AD) secrets engine and OpenLDAP secrets engine. This new engine simplifies the user experience when Vault is used to manage credentials for directory services. This new engine supports all modes from both of the engines mentioned above (AD, LDAP and RACF modes) and brings dynamic credential capabilities for users relying on Active Directory.
 
-~> **Note:** This engine does _not_ replace the current Active Directory Secrets Engine. We will continue to maintain the engine and provide bug fixes, but encourage all new users to use the unified LDAP engine. We will communicate the schedule to deprecate the Active Directory secrets engine well in advance, providing time for users to migrate over.
+~> **Note:** This engine does _not_ replace the current Active Directory secrets engine. We will continue to maintain the engine and provide bug fixes, but encourage all new users to use the unified LDAP engine. We will communicate the schedule to deprecate the Active Directory secrets engine well in advance, providing time for users to migrate over.
 
 ### Terraform Vault Provider: Vault Version Detection
 
@@ -105,18 +126,9 @@ With Vault 1.12, Vault Enterprise (ADP-KM) can now act as an external key manage
 
 In Vault 1.11, we added support for Okta’s Number Challenge feature in the CLI and API. In Vault 1.12, we’ve extended this support to the Vault UI, allowing users to complete the Okta Number Challenge from a web browser, the command line, and the HTTP API.
 
-### OIDC Provider support in the UI
+### OIDC Provider Support in the UI
 Vault can now act as an OIDC provider for applications that wish to delegate authentication to Vault and leverage its identity system. As an OIDC provider, Vault supports PKCE for authorization code flow, preventing attacks such as SSRF. After OIDC provider functionality went GA, our design and user research team gathered feedback from community members, and we simplified the setup experience. With a few CLI commands or UI clicks, users can now have a default OIDC provider with its defaults configured and ready to go for applications to utilize the functionality.
 
-## PKI Engine Improvements
-
-### PKI Engine Revocation Enhancements
-
-We are improving Vault PKI Engine’s revocation capabilities by adding support for the Online Certificate Status Protocol (OCSP) and a delta Certificate Revocation List (CRL) to track changes to the main CRL. These enhancements significantly streamline customer experience with the PKI engine making the certification revocation semantics easier to understand and manage. Additionally, support for automatic CRL rotation and periodic tidy operations help reduce operator burden, alleviate the demand on cluster resources during periods of high revocation, and ensure clients are always served valid CRLs.
-
-### PKI Telemetry Improvements
-
-In this release, we are adding additional telemetry to Vault’s PKI Secrets Engine, enabling customers to gather better  insights into  certificate usage via the count of stored and revoked certificates. Additionally, the Vault `tidy` function is enhanced with additional metrics that reflect the remaining stored and revoked certificates.
 
 ## Other Features and Enhancements
 
@@ -126,6 +138,16 @@ The Licensing termination behavior has changed where non-evaluation licenses (pr
 
 ### Namespace Custom Metadata
 Customers can now specify [custom metadata](/api-docs/system/namespaces) on the namespaces. The new `vault namespace patch` [command](/docs/commands/namespace) can be used to update existing namespaces with custom metadata as well. This will make it possible to tag namespaces with additional fields (For example: owner, region department) describing it.
+
+### Vault Agent Improvements
+
+Vault Agent introduced new configuration parameters that will significantly improve the use of Vault Agent. These includes:
+
+- Added `disable_idle_connections` configuration to disable leaving idle connections open in auto-auth, caching and templating.
+- Added `disable_keep_alives` configuration to disable keep alives in auto-auth, caching and templating.
+- JWT auto-auth now supports a `remove_jwt_after_reading` configuration option which defaults to true.
+
+
 
 ## Known issues
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1881,6 +1881,10 @@
         "path": "release-notes"
       },
       {
+        "title": "1.12.0",
+        "path": "release-notes/1.12.0"
+      },
+      {
         "title": "1.11.0",
         "path": "release-notes/1.11.0"
       },


### PR DESCRIPTION
Release notes for Vault 1.12 release based on the [google doc](https://docs.google.com/document/d/15RyS_UzERLuj1_71_kgb5k5cUMtrzOtD62TqCD4TNVU/edit#heading=h.n7xfh4gvdmb)

**Outstanding items that still need to be addressed include the following:**
- PKI Telemetry Improvements section still needs two documentation links
- Redis Secrets engine section calls out an individual by name. The decision to include the person's name in the release notes has not been finalized it.

:mag: [Deploy Preview](https://vault-git-docs-release-notes-1-12-hashicorp.vercel.app/docs/release-notes/1.12.0)

