### PR TITLE
fix namespace patch not found error message

### DIFF
--- a/command/namespace_patch.go
+++ b/command/namespace_patch.go
@@ -124,7 +124,7 @@ func (c *NamespacePatchCommand) Run(args []string) int {
 	}
 
 	if secret == nil || secret.Data == nil {
-		c.UI.Error(fmt.Sprintf("No namespace found: %s", err))
+		c.UI.Error("Namespace not found")
 		return 2
 	}
 

--- a/command/namespace_patch.go
+++ b/command/namespace_patch.go
@@ -3,11 +3,12 @@ package command
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
-	"github.com/posener/complete"
-
+	"github.com/hashicorp/vault/api"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
 )
 
 var (
@@ -119,12 +120,12 @@ func (c *NamespacePatchCommand) Run(args []string) int {
 
 	secret, err := client.Logical().JSONMergePatch(context.Background(), "sys/namespaces/"+namespacePath, data)
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error patching namespace: %s", err))
-		return 2
-	}
+		if re, ok := err.(*api.ResponseError); ok && re.StatusCode == http.StatusNotFound {
+			c.UI.Error("Namespace not found")
+			return 2
+		}
 
-	if secret == nil || secret.Data == nil {
-		c.UI.Error("Namespace not found")
+		c.UI.Error(fmt.Sprintf("Error patching namespace: %s", err))
 		return 2
 	}
 


### PR DESCRIPTION
Namespace not found for `namespace patch` command is now based on 404 response. Fix not found error from `No namespace found: %!s(<nil>)` (erroneously included err var before 404 logic was introduced) to `Namespace not found`