### PR TITLE
Fixes concurrent map writes in GRPC plugin server setup

### DIFF
--- a/sdk/plugin/grpc_backend_server.go
+++ b/sdk/plugin/grpc_backend_server.go
@@ -77,6 +77,9 @@ func (b *backendGRPCPluginServer) Setup(ctx context.Context, args *pb.SetupArgs)
 	var err error
 	id := singleImplementationID
 
+	b.instancesLock.Lock()
+	defer b.instancesLock.Unlock()
+
 	if b.multiplexingSupport {
 		id, err = pluginutil.GetMultiplexIDFromContext(ctx)
 		if err != nil {

--- a/sdk/plugin/grpc_backend_server.go
+++ b/sdk/plugin/grpc_backend_server.go
@@ -77,9 +77,6 @@ func (b *backendGRPCPluginServer) Setup(ctx context.Context, args *pb.SetupArgs)
 	var err error
 	id := singleImplementationID
 
-	b.instancesLock.Lock()
-	defer b.instancesLock.Unlock()
-
 	if b.multiplexingSupport {
 		id, err = pluginutil.GetMultiplexIDFromContext(ctx)
 		if err != nil {
@@ -112,6 +109,9 @@ func (b *backendGRPCPluginServer) Setup(ctx context.Context, args *pb.SetupArgs)
 			Err: pb.ErrToString(err),
 		}, nil
 	}
+
+	b.instancesLock.Lock()
+	defer b.instancesLock.Unlock()
 	b.instances[id] = backendInstance{
 		brokeredClient: brokeredClient,
 		backend:        backend,


### PR DESCRIPTION
This PR fixes a concurrent map write panic seen in testing multiplexed secrets/auth external plugins. See error below for top of goroutine stack where this occurred.

```
2022-09-20T22:00:19.435-0700 [DEBUG] auth.vault-plugin-auth-userpass-mux-ext.auth_vault-plugin-auth-userpass-mux-ext_a4786ce6.vault-plugin-auth-userpass-mux-ext.vault-plugin-auth-userpass-mux-ext: fatal error: concurrent map writes
2022-09-20T22:00:19.443-0700 [DEBUG] auth.vault-plugin-auth-userpass-mux-ext.auth_vault-plugin-auth-userpass-mux-ext_a4786ce6.vault-plugin-auth-userpass-mux-ext.vault-plugin-auth-userpass-mux-ext
2022-09-20T22:00:19.443-0700 [DEBUG] auth.vault-plugin-auth-userpass-mux-ext.auth_vault-plugin-auth-userpass-mux-ext_a4786ce6.vault-plugin-auth-userpass-mux-ext.vault-plugin-auth-userpass-mux-ext: goroutine 28 [running]:
2022-09-20T22:00:19.443-0700 [DEBUG] auth.vault-plugin-auth-userpass-mux-ext.auth_vault-plugin-auth-userpass-mux-ext_a4786ce6.vault-plugin-auth-userpass-mux-ext.vault-plugin-auth-userpass-mux-ext: github.com/hashicorp/vault/sdk/plugin.(*backendGRPCPluginServer).Setup(0xc00013bb30, {0x17ab620, 0xc000416720}, 0xc00043c230)
2022-09-20T22:00:19.443-0700 [DEBUG] auth.vault-plugin-auth-userpass-mux-ext.auth_vault-plugin-auth-userpass-mux-ext_a4786ce6.vault-plugin-auth-userpass-mux-ext.vault-plugin-auth-userpass-mux-ext:         /Users/austingebauer/Workspace/hashicorp/vault/sdk/plugin/grpc_backend_server.go:111 +0x33d
```