### PR TITLE
Fixes multiplexed plugin initialization after manual plugin reload

### DIFF
--- a/builtin/plugin/backend.go
+++ b/builtin/plugin/backend.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	log "github.com/hashicorp/go-hclog"
-
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	v5 "github.com/hashicorp/vault/builtin/plugin/v5"

--- a/vault/plugin_reload.go
+++ b/vault/plugin_reload.go
@@ -202,7 +202,7 @@ func (c *Core) reloadBackendCommon(ctx context.Context, entry *MountEntry, isAut
 		// rely on lazy loading for initialization. v5 backends do not rely on lazy loading
 		// for initialization unless the plugin process is killed. Reload of a v5 backend
 		// results in a new plugin process, so we must initialize the backend here.
-		err := backend.Initialize(c.activeContext, &logical.InitializationRequest{Storage: view})
+		err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})
 		if err != nil {
 			return err
 		}

--- a/vault/plugin_reload.go
+++ b/vault/plugin_reload.go
@@ -198,6 +198,15 @@ func (c *Core) reloadBackendCommon(ctx context.Context, entry *MountEntry, isAut
 	re.backend = backend
 
 	if backend != nil {
+		// Initialize the backend after reload. This is a no-op for backends < v5 which
+		// rely on lazy loading for initialization. v5 backends do not rely on lazy loading
+		// for initialization unless the plugin process is killed. Reload of a v5 backend
+		// results in a new plugin process, so we must initialize the backend here.
+		err := backend.Initialize(c.activeContext, &logical.InitializationRequest{Storage: view})
+		if err != nil {
+			return err
+		}
+
 		// Set paths as well
 		paths := backend.SpecialPaths()
 		if paths != nil {


### PR DESCRIPTION
This PR fixes an issue where multiplexed v5 plugin backends aren't initialized after a manual [plugin reload](https://www.vaultproject.io/docs/commands/plugin/reload). This call to `Initialize()` is a no-op for backends < v5 which rely on lazy loading for initialization (see [backend.go#L265-L269](https://github.com/hashicorp/vault/blob/main/builtin/plugin/backend.go#L265-L269)). v5 backends do not rely on lazy loading for initialization (unless the plugin process is killed, which was recently fixed in https://github.com/hashicorp/vault/pull/17140). Reload of a v5 backend results in a new plugin process, so we must initialize the backend at this location. Otherwise, the plugin will not be initialized via [request handling logic](https://github.com/hashicorp/vault/blob/main/builtin/plugin/v5/backend.go#L96-L118) (again, _unless_ its process is killed).

I tested that this results in the multiplexed plugin `Initialize()` being called once upon reload. I also tested that reload still works as expected (via lazy loading) for plugin backend < v5 and builtin plugins.