### PR TITLE
CLI: Fix erroneous warning when reading from stdin

### DIFF
--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -296,7 +296,8 @@ func parseFlagFile(raw string) (string, error) {
 func generateFlagWarnings(args []string) string {
 	var trailingFlags []string
 	for _, arg := range args {
-		if !strings.HasPrefix(arg, "-") {
+		// "-" can be used where a file is expected to denote stdin.
+		if !strings.HasPrefix(arg, "-") || arg == "-" {
 			continue
 		}
 

--- a/command/base_helpers_test.go
+++ b/command/base_helpers_test.go
@@ -262,6 +262,10 @@ func TestArgWarnings(t *testing.T) {
 			[]string{"--x=" + globalFlagDetailed},
 			"--x=" + globalFlagDetailed,
 		},
+		{
+			[]string{"policy", "write", "my-policy", "-"},
+			"",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Previously we got an error when using stdin as the path argument in a command:

```shell-session
$ vault policy write myapp-kv-ro - <<EOF
path "secret/data/myapp/*" {
    capabilities = ["read", "list"]
}
EOF
Command flags must be provided before positional arguments. The following arguments will not be parsed as flags: [-]
Success! Uploaded policy: myapp-kv-ro
```

Now:

```shell-session
$ vault policy write myapp-kv-ro - <<EOF
path "secret/data/myapp/*" {
    capabilities = ["read", "list"]
}
EOF
Success! Uploaded policy: myapp-kv-ro
```

I've skipped adding a changelog because I don't believe the original code has been released yet.