### PR TITLE
Providing better explanation for allow_store_key flag

### DIFF
--- a/website/content/api-docs/system/managed-keys.mdx
+++ b/website/content/api-docs/system/managed-keys.mdx
@@ -87,8 +87,8 @@ $ curl \
   a key into the configured backend even if a key is present, if set to false those operations are forbidden
   if a key exists.
 
-- `allow_store_key` `(string: "false")` - Controls the ability for Vault to import a key
-  to the configured backend, if "false" those operations will be forbidden.
+- `allow_store_key` `(string: "false")` - Controls the ability for Vault to export a Vault private key
+  to the configured HSM, if "false" those operations will be forbidden.
 
 - `any_mount` `(string: "false")` - Allow usage from any mount point within the namespace if "true". If "false"
   specific mount points will need their `allowed_managed_keys` parameter to be updated with the key name to


### PR DESCRIPTION
The current explanation of the `allow_store_key` flag is bit vague, causing confusion with customers. Adding a better explanation from internal engineering conversation.

Also the update needs to be added to [PKI Secrets Engine with Managed Keys ](https://learn.hashicorp.com/tutorials/vault/managed-key-pki?in=vault/secrets-management#configure-a-managed-key)tutorial

