### PR TITLE
api: use response from redirected request

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -1521,6 +1521,8 @@ func (c *Client) httpRequestWithContext(ctx context.Context, r *Request) (*Respo
 		if err != nil {
 			return result, fmt.Errorf("redirect failed: %s", err)
 		}
+
+		result = &Response{Response: resp}
 	}
 
 	if err := result.Error(); err != nil {


### PR DESCRIPTION
Fixes func introduced in e7c238c, used by the raft snapshot and restore methods, allowing these operations to work when ran against stand-by nodes.

Fixes #15258.