### PR TITLE
CLI: Tune plugin version for auth/secret mounts

### DIFF
--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -247,7 +247,6 @@ type MountInput struct {
 	SealWrap              bool              `json:"seal_wrap" mapstructure:"seal_wrap"`
 	ExternalEntropyAccess bool              `json:"external_entropy_access" mapstructure:"external_entropy_access"`
 	Options               map[string]string `json:"options"`
-	PluginVersion         string            `json:"plugin_version,omitempty"`
 
 	// Deprecated: Newer server responses should be returning this information in the
 	// Type field (json: "type") instead.
@@ -267,6 +266,7 @@ type MountConfigInput struct {
 	AllowedResponseHeaders    []string          `json:"allowed_response_headers,omitempty" mapstructure:"allowed_response_headers"`
 	TokenType                 string            `json:"token_type,omitempty" mapstructure:"token_type"`
 	AllowedManagedKeys        []string          `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
+	PluginVersion             string            `json:"plugin_version,omitempty"`
 
 	// Deprecated: This field will always be blank for newer server responses.
 	PluginName string `json:"plugin_name,omitempty" mapstructure:"plugin_name"`

--- a/command/auth_enable.go
+++ b/command/auth_enable.go
@@ -201,7 +201,7 @@ func (c *AuthEnableCommand) Flags() *FlagSets {
 	})
 
 	f.StringVar(&StringVar{
-		Name:    "plugin-version",
+		Name:    flagNamePluginVersion,
 		Target:  &c.flagPluginVersion,
 		Default: "",
 		Usage:   "Select the semantic version of the plugin to enable.",
@@ -307,7 +307,7 @@ func (c *AuthEnableCommand) Run(args []string) int {
 			authOpts.Config.TokenType = c.flagTokenType
 		}
 
-		if fl.Name == "plugin-version" {
+		if fl.Name == flagNamePluginVersion {
 			authOpts.Config.PluginVersion = c.flagPluginVersion
 		}
 	})

--- a/command/auth_enable.go
+++ b/command/auth_enable.go
@@ -277,7 +277,6 @@ func (c *AuthEnableCommand) Run(args []string) int {
 		Config: api.AuthConfigInput{
 			DefaultLeaseTTL: c.flagDefaultLeaseTTL.String(),
 			MaxLeaseTTL:     c.flagMaxLeaseTTL.String(),
-			PluginVersion:   c.flagPluginVersion,
 		},
 		Options: c.flagOptions,
 	}
@@ -306,6 +305,10 @@ func (c *AuthEnableCommand) Run(args []string) int {
 
 		if fl.Name == flagNameTokenType {
 			authOpts.Config.TokenType = c.flagTokenType
+		}
+
+		if fl.Name == "plugin-version" {
+			authOpts.Config.PluginVersion = c.flagPluginVersion
 		}
 	})
 

--- a/command/auth_enable.go
+++ b/command/auth_enable.go
@@ -270,7 +270,6 @@ func (c *AuthEnableCommand) Run(args []string) int {
 
 	authOpts := &api.EnableAuthOptions{
 		Type:                  authType,
-		PluginVersion:         c.flagPluginVersion,
 		Description:           c.flagDescription,
 		Local:                 c.flagLocal,
 		SealWrap:              c.flagSealWrap,
@@ -278,6 +277,7 @@ func (c *AuthEnableCommand) Run(args []string) int {
 		Config: api.AuthConfigInput{
 			DefaultLeaseTTL: c.flagDefaultLeaseTTL.String(),
 			MaxLeaseTTL:     c.flagMaxLeaseTTL.String(),
+			PluginVersion:   c.flagPluginVersion,
 		},
 		Options: c.flagOptions,
 	}

--- a/command/auth_tune.go
+++ b/command/auth_tune.go
@@ -31,6 +31,7 @@ type AuthTuneCommand struct {
 	flagOptions                   map[string]string
 	flagTokenType                 string
 	flagVersion                   int
+	flagPluginVersion             string
 }
 
 func (c *AuthTuneCommand) Synopsis() string {
@@ -144,6 +145,14 @@ func (c *AuthTuneCommand) Flags() *FlagSets {
 		Usage:   "Select the version of the auth method to run. Not supported by all auth methods.",
 	})
 
+	f.StringVar(&StringVar{
+		Name:    "plugin-version",
+		Target:  &c.flagPluginVersion,
+		Default: "",
+		Usage: "Select the semantic version of the plugin to run. The new version must be registered in " +
+			"the plugin catalog, and will not start running until the plugin is reloaded.",
+	})
+
 	return set
 }
 
@@ -220,6 +229,10 @@ func (c *AuthTuneCommand) Run(args []string) int {
 
 		if fl.Name == flagNameTokenType {
 			mountConfigInput.TokenType = c.flagTokenType
+		}
+
+		if fl.Name == "plugin-version" {
+			mountConfigInput.PluginVersion = c.flagPluginVersion
 		}
 	})
 

--- a/command/auth_tune.go
+++ b/command/auth_tune.go
@@ -146,7 +146,7 @@ func (c *AuthTuneCommand) Flags() *FlagSets {
 	})
 
 	f.StringVar(&StringVar{
-		Name:    "plugin-version",
+		Name:    flagNamePluginVersion,
 		Target:  &c.flagPluginVersion,
 		Default: "",
 		Usage: "Select the semantic version of the plugin to run. The new version must be registered in " +
@@ -231,7 +231,7 @@ func (c *AuthTuneCommand) Run(args []string) int {
 			mountConfigInput.TokenType = c.flagTokenType
 		}
 
-		if fl.Name == "plugin-version" {
+		if fl.Name == flagNamePluginVersion {
 			mountConfigInput.PluginVersion = c.flagPluginVersion
 		}
 	})

--- a/command/auth_tune_test.go
+++ b/command/auth_tune_test.go
@@ -92,7 +92,7 @@ func TestAuthTuneCommand_Run(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			auths, err := client.Sys().ListMounts()
+			auths, err := client.Sys().ListAuth()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/command/auth_tune_test.go
+++ b/command/auth_tune_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/sdk/helper/consts"
+	"github.com/hashicorp/vault/vault"
 	"github.com/mitchellh/cli"
 )
 
@@ -74,7 +76,10 @@ func TestAuthTuneCommand_Run(t *testing.T) {
 	t.Run("integration", func(t *testing.T) {
 		t.Run("flags_all", func(t *testing.T) {
 			t.Parallel()
-			client, closer := testVaultServer(t)
+			pluginDir, cleanup := vault.MakeTestPluginDir(t)
+			defer cleanup(t)
+
+			client, _, closer := testVaultServerPluginDir(t, pluginDir)
 			defer closer()
 
 			ui, cmd := testAuthTuneCommand(t)
@@ -87,6 +92,21 @@ func TestAuthTuneCommand_Run(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			auths, err := client.Sys().ListMounts()
+			if err != nil {
+				t.Fatal(err)
+			}
+			mountInfo, ok := auths["my-auth/"]
+			if !ok {
+				t.Fatalf("expected mount to exist: %#v", auths)
+			}
+
+			if exp := ""; mountInfo.PluginVersion != exp {
+				t.Errorf("expected %q to be %q", mountInfo.PluginVersion, exp)
+			}
+
+			_, _, version := testPluginCreateAndRegisterVersioned(t, client, pluginDir, "userpass", consts.PluginTypeCredential)
+
 			code := cmd.Run([]string{
 				"-description", "new description",
 				"-default-lease-ttl", "30m",
@@ -97,6 +117,7 @@ func TestAuthTuneCommand_Run(t *testing.T) {
 				"-passthrough-request-headers", "www-authentication",
 				"-allowed-response-headers", "authorization,www-authentication",
 				"-listing-visibility", "unauth",
+				"-plugin-version", version,
 				"my-auth/",
 			})
 			if exp := 0; code != exp {
@@ -109,12 +130,12 @@ func TestAuthTuneCommand_Run(t *testing.T) {
 				t.Errorf("expected %q to contain %q", combined, expected)
 			}
 
-			auths, err := client.Sys().ListAuth()
+			auths, err = client.Sys().ListAuth()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			mountInfo, ok := auths["my-auth/"]
+			mountInfo, ok = auths["my-auth/"]
 			if !ok {
 				t.Fatalf("expected auth to exist")
 			}
@@ -123,6 +144,9 @@ func TestAuthTuneCommand_Run(t *testing.T) {
 			}
 			if exp := "userpass"; mountInfo.Type != exp {
 				t.Errorf("expected %q to be %q", mountInfo.Type, exp)
+			}
+			if exp := version; mountInfo.PluginVersion != exp {
+				t.Errorf("expected %q to be %q", mountInfo.PluginVersion, exp)
 			}
 			if exp := 1800; mountInfo.Config.DefaultLeaseTTL != exp {
 				t.Errorf("expected %d to be %d", mountInfo.Config.DefaultLeaseTTL, exp)

--- a/command/commands.go
+++ b/command/commands.go
@@ -124,6 +124,8 @@ const (
 	flagNameTokenType = "token-type"
 	// flagNameAllowedManagedKeys is the flag name used for auth/secrets enable
 	flagNameAllowedManagedKeys = "allowed-managed-keys"
+	// flagNamePluginVersion selects what version of a plugin should be used.
+	flagNamePluginVersion = "plugin-version"
 )
 
 var (

--- a/command/secrets_enable.go
+++ b/command/secrets_enable.go
@@ -175,7 +175,7 @@ func (c *SecretsEnableCommand) Flags() *FlagSets {
 	})
 
 	f.StringVar(&StringVar{
-		Name:    "plugin-version",
+		Name:    flagNamePluginVersion,
 		Target:  &c.flagPluginVersion,
 		Default: "",
 		Usage:   "Select the semantic version of the plugin to enable.",
@@ -329,7 +329,7 @@ func (c *SecretsEnableCommand) Run(args []string) int {
 			mountInput.Config.AllowedManagedKeys = c.flagAllowedManagedKeys
 		}
 
-		if fl.Name == "plugin-version" {
+		if fl.Name == flagNamePluginVersion {
 			mountInput.Config.PluginVersion = c.flagPluginVersion
 		}
 	})

--- a/command/secrets_enable.go
+++ b/command/secrets_enable.go
@@ -32,6 +32,7 @@ type SecretsEnableCommand struct {
 	flagAllowedResponseHeaders    []string
 	flagForceNoCache              bool
 	flagPluginName                string
+	flagPluginVersion             string
 	flagOptions                   map[string]string
 	flagLocal                     bool
 	flagSealWrap                  bool
@@ -171,6 +172,13 @@ func (c *SecretsEnableCommand) Flags() *FlagSets {
 		Completion: c.PredictVaultPlugins(consts.PluginTypeSecrets, consts.PluginTypeDatabase),
 		Usage: "Name of the secrets engine plugin. This plugin name must already " +
 			"exist in Vault's plugin catalog.",
+	})
+
+	f.StringVar(&StringVar{
+		Name:    "plugin-version",
+		Target:  &c.flagPluginVersion,
+		Default: "",
+		Usage:   "Select the semantic version of the plugin to enable.",
 	})
 
 	f.StringMapVar(&StringMapVar{
@@ -319,6 +327,10 @@ func (c *SecretsEnableCommand) Run(args []string) int {
 
 		if fl.Name == flagNameAllowedManagedKeys {
 			mountInput.Config.AllowedManagedKeys = c.flagAllowedManagedKeys
+		}
+
+		if fl.Name == "plugin-version" {
+			mountInput.Config.PluginVersion = c.flagPluginVersion
 		}
 	})
 

--- a/command/secrets_tune.go
+++ b/command/secrets_tune.go
@@ -148,7 +148,7 @@ func (c *SecretsTuneCommand) Flags() *FlagSets {
 	})
 
 	f.StringVar(&StringVar{
-		Name:    "plugin-version",
+		Name:    flagNamePluginVersion,
 		Target:  &c.flagPluginVersion,
 		Default: "",
 		Usage: "Select the semantic version of the plugin to run. The new version must be registered in " +
@@ -236,7 +236,7 @@ func (c *SecretsTuneCommand) Run(args []string) int {
 			mountConfigInput.AllowedManagedKeys = c.flagAllowedManagedKeys
 		}
 
-		if fl.Name == "plugin-version" {
+		if fl.Name == flagNamePluginVersion {
 			mountConfigInput.PluginVersion = c.flagPluginVersion
 		}
 	})

--- a/command/secrets_tune.go
+++ b/command/secrets_tune.go
@@ -30,6 +30,7 @@ type SecretsTuneCommand struct {
 	flagAllowedResponseHeaders    []string
 	flagOptions                   map[string]string
 	flagVersion                   int
+	flagPluginVersion             string
 	flagAllowedManagedKeys        []string
 }
 
@@ -146,6 +147,14 @@ func (c *SecretsTuneCommand) Flags() *FlagSets {
 			"each time with 1 key.",
 	})
 
+	f.StringVar(&StringVar{
+		Name:    "plugin-version",
+		Target:  &c.flagPluginVersion,
+		Default: "",
+		Usage: "Select the semantic version of the plugin to run. The new version must be registered in " +
+			"the plugin catalog, and will not start running until the plugin is reloaded.",
+	})
+
 	return set
 }
 
@@ -225,6 +234,10 @@ func (c *SecretsTuneCommand) Run(args []string) int {
 
 		if fl.Name == flagNameAllowedManagedKeys {
 			mountConfigInput.AllowedManagedKeys = c.flagAllowedManagedKeys
+		}
+
+		if fl.Name == "plugin-version" {
+			mountConfigInput.PluginVersion = c.flagPluginVersion
 		}
 	})
 

--- a/command/secrets_tune_test.go
+++ b/command/secrets_tune_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/sdk/helper/consts"
+	"github.com/hashicorp/vault/vault"
 	"github.com/mitchellh/cli"
 )
 
@@ -148,7 +150,10 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 	t.Run("integration", func(t *testing.T) {
 		t.Run("flags_all", func(t *testing.T) {
 			t.Parallel()
-			client, closer := testVaultServer(t)
+			pluginDir, cleanup := vault.MakeTestPluginDir(t)
+			defer cleanup(t)
+
+			client, _, closer := testVaultServerPluginDir(t, pluginDir)
 			defer closer()
 
 			ui, cmd := testSecretsTuneCommand(t)
@@ -161,6 +166,21 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			mounts, err := client.Sys().ListMounts()
+			if err != nil {
+				t.Fatal(err)
+			}
+			mountInfo, ok := mounts["mount_tune_integration/"]
+			if !ok {
+				t.Fatalf("expected mount to exist")
+			}
+
+			if exp := ""; mountInfo.PluginVersion != exp {
+				t.Errorf("expected %q to be %q", mountInfo.PluginVersion, exp)
+			}
+
+			_, _, version := testPluginCreateAndRegisterVersioned(t, client, pluginDir, "pki", consts.PluginTypeSecrets)
+
 			code := cmd.Run([]string{
 				"-description", "new description",
 				"-default-lease-ttl", "30m",
@@ -172,6 +192,7 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 				"-allowed-response-headers", "authorization,www-authentication",
 				"-allowed-managed-keys", "key1,key2",
 				"-listing-visibility", "unauth",
+				"-plugin-version", version,
 				"mount_tune_integration/",
 			})
 			if exp := 0; code != exp {
@@ -184,12 +205,12 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 				t.Errorf("expected %q to contain %q", combined, expected)
 			}
 
-			mounts, err := client.Sys().ListMounts()
+			mounts, err = client.Sys().ListMounts()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			mountInfo, ok := mounts["mount_tune_integration/"]
+			mountInfo, ok = mounts["mount_tune_integration/"]
 			if !ok {
 				t.Fatalf("expected mount to exist")
 			}
@@ -198,6 +219,9 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 			}
 			if exp := "pki"; mountInfo.Type != exp {
 				t.Errorf("expected %q to be %q", mountInfo.Type, exp)
+			}
+			if exp := version; mountInfo.PluginVersion != exp {
+				t.Errorf("expected %q to be %q", mountInfo.PluginVersion, exp)
 			}
 			if exp := 1800; mountInfo.Config.DefaultLeaseTTL != exp {
 				t.Errorf("expected %d to be %d", mountInfo.Config.DefaultLeaseTTL, exp)

--- a/vault/external_plugin_test.go
+++ b/vault/external_plugin_test.go
@@ -318,8 +318,10 @@ func TestCore_EnableExternalCredentialPlugin_NoVersionOnRegister(t *testing.T) {
 
 			req := logical.TestRequest(t, logical.UpdateOperation, mountTable(tc.pluginType))
 			req.Data = map[string]interface{}{
-				"type":           pluginName,
-				"plugin_version": "v1.0.0",
+				"type": pluginName,
+				"config": map[string]interface{}{
+					"plugin_version": "v1.0.0",
+				},
 			}
 			resp, _ := c.systemBackend.HandleRequest(namespace.RootContext(nil), req)
 			if resp == nil || !resp.IsError() || !strings.Contains(resp.Error().Error(), ErrPluginNotFound.Error()) {
@@ -379,22 +381,7 @@ func TestExternalPlugin_getBackendTypeVersion(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			c, pluginName, pluginSHA256 := testCoreWithPlugin(t, tc.pluginType, tc.setRunningVersion)
-			d := &framework.FieldData{
-				Raw: map[string]interface{}{
-					"name":    pluginName,
-					"sha256":  pluginSHA256,
-					"version": tc.setRunningVersion,
-					"command": pluginName,
-				},
-				Schema: c.systemBackend.pluginsCatalogCRUDPath().Fields,
-			}
-			resp, err := c.systemBackend.handlePluginCatalogUpdate(context.Background(), nil, d)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if resp.Error() != nil {
-				t.Fatalf("%#v", resp)
-			}
+			registerPlugin(t, c.systemBackend, pluginName, tc.pluginType.String(), tc.setRunningVersion, pluginSHA256)
 
 			shaBytes, _ := hex.DecodeString(pluginSHA256)
 			commandFull := filepath.Join(c.pluginCatalog.directory, pluginName)
@@ -407,6 +394,7 @@ func TestExternalPlugin_getBackendTypeVersion(t *testing.T) {
 			}
 
 			var version logical.PluginVersion
+			var err error
 			if tc.pluginType == consts.PluginTypeDatabase {
 				version, err = c.pluginCatalog.getDatabaseRunningVersion(context.Background(), entry)
 			} else {
@@ -447,7 +435,9 @@ func mountPlugin(t *testing.T, sys *SystemBackend, pluginName string, pluginType
 		"type": pluginName,
 	}
 	if version != "" {
-		req.Data["plugin_version"] = version
+		req.Data["config"] = map[string]interface{}{
+			"plugin_version": version,
+		}
 	}
 	resp, err := sys.HandleRequest(namespace.RootContext(nil), req)
 	if err != nil {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1001,10 +1001,6 @@ func (b *SystemBackend) handleMount(ctx context.Context, req *logical.Request, d
 	sealWrap := data.Get("seal_wrap").(bool)
 	externalEntropyAccess := data.Get("external_entropy_access").(bool)
 	options := data.Get("options").(map[string]string)
-	var version string
-	if pluginVersionRaw, ok := data.GetOk("plugin_version"); ok {
-		version = pluginVersionRaw.(string)
-	}
 
 	var config MountConfig
 	var apiConfig APIMountConfig
@@ -1110,6 +1106,7 @@ func (b *SystemBackend) handleMount(ctx context.Context, req *logical.Request, d
 		}
 	}
 
+	version := apiConfig.PluginVersion
 	switch version {
 	case "":
 		var err error
@@ -2349,10 +2346,6 @@ func (b *SystemBackend) handleEnableAuth(ctx context.Context, req *logical.Reque
 	sealWrap := data.Get("seal_wrap").(bool)
 	externalEntropyAccess := data.Get("external_entropy_access").(bool)
 	options := data.Get("options").(map[string]string)
-	var version string
-	if pluginVersionRaw, ok := data.GetOk("plugin_version"); ok {
-		version = pluginVersionRaw.(string)
-	}
 
 	var config MountConfig
 	var apiConfig APIMountConfig
@@ -2446,6 +2439,7 @@ func (b *SystemBackend) handleEnableAuth(ctx context.Context, req *logical.Reque
 		}
 	}
 
+	version := apiConfig.PluginVersion
 	switch version {
 	case "":
 		var err error

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -368,6 +368,7 @@ type APIMountConfig struct {
 	AllowedResponseHeaders    []string              `json:"allowed_response_headers,omitempty" structs:"allowed_response_headers" mapstructure:"allowed_response_headers"`
 	TokenType                 string                `json:"token_type" structs:"token_type" mapstructure:"token_type"`
 	AllowedManagedKeys        []string              `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
+	PluginVersion             string                `json:"plugin_version,omitempty" mapstructure:"plugin_version"`
 
 	// PluginName is the name of the plugin registered in the catalog.
 	//

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -934,7 +934,7 @@ func (c *PluginCatalog) listInternal(ctx context.Context, pluginType consts.Plug
 				return nil, err
 			}
 		case 2: // Unversioned
-			if storedType, err = consts.ParsePluginType(parts[0]); err != nil {
+			if storedType, err = consts.ParsePluginType(parts[0]); err == nil {
 				normalizedName = parts[1]
 				// Use 0.0.0 to ensure unversioned is sorted as the oldest version.
 				semanticVersion, err = semver.NewVersion("0.0.0")
@@ -942,7 +942,7 @@ func (c *PluginCatalog) listInternal(ctx context.Context, pluginType consts.Plug
 					return nil, err
 				}
 			} else {
-				return nil, fmt.Errorf("unknown plugin type in plugin catalog: %s", plugin)
+				return nil, fmt.Errorf("unknown plugin type in plugin catalog: %s: %w", plugin, err)
 			}
 		case 3: // Versioned, with type
 			if !includeVersioned {

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -963,7 +963,7 @@ func (c *PluginCatalog) listInternal(ctx context.Context, pluginType consts.Plug
 		}
 
 		// Only list user-added plugins if they're of the given type.
-		if storedType != pluginType {
+		if storedType != consts.PluginTypeUnknown && storedType != pluginType {
 			continue
 		}
 		entry, err := c.get(ctx, normalizedName, pluginType, version)


### PR DESCRIPTION
* Adds `-plugin-version` flag to `vault secrets tune` and `vault auth tune` commands
* Also adds `-plugin-version` flag to `vault secrets enable` which slipped unnoticed previously
* The `plugin_register_test.go` tests uncovered a bug in listing plugins. If you register both an auth and secrets "my-plugin"@v1.0.0, listing plugins would previously report two v1.0.0 plugins called "my-plugin" for both auth and secret types, giving 4 plugins instead of the correct 2.

I had to move the `PluginVersion` field from `MountInput` to the embedded `MountInputConfig` in order to support the way the `tune` commands gather their inputs. Normally, those two structs' fields would correspond to fields in `MountEntry` and its embedded `MountConfig` respectively, but I have currently left the `Version` field inside of `MountEntry` instead of moving it across to `MountConfig`. It seems to work fine, but I wonder if I've missed a reason that's a bad idea.