### PR TITLE
VAULT-8630 Fix goroutine leak from RLQ initialize

### DIFF
--- a/changelog/17281.txt
+++ b/changelog/17281.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/quotas: Fix goroutine leak caused by the seal process not fully cleaning up Rate Limit Quotas.
+```

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -764,10 +764,12 @@ func (m *Manager) resetCache() error {
 		if err != nil {
 			return err
 		}
-		rlq := quota.(*RateLimitQuota)
-		err = rlq.store.Close(context.Background())
-		if err != nil {
-			return err
+		if quota != nil {
+			rlq := quota.(*RateLimitQuota)
+			err = rlq.store.Close(context.Background())
+			if err != nil {
+				return err
+			}
 		}
 	}
 	db, err := memdb.NewMemDB(dbSchema())

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -358,6 +358,11 @@ func (m *Manager) QuotaNames(qType Type) ([]string, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
+	return m.quotaNamesLocked(qType)
+}
+
+// quotaNamesLocked returns the names of all the quota rules for a given type, and must be called with the lock
+func (m *Manager) quotaNamesLocked(qType Type) ([]string, error) {
 	txn := m.db.Txn(false)
 	iter, err := txn.Get(qType.String(), indexID)
 	if err != nil {
@@ -393,6 +398,11 @@ func (m *Manager) QuotaByName(qType string, name string) (Quota, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
+	return m.quotaByNameLocked(qType, name)
+}
+
+// quotaByNameLocked queries for a quota rule in the db for a given quota name, and must be called with the lock
+func (m *Manager) quotaByNameLocked(qType string, name string) (Quota, error) {
 	txn := m.db.Txn(false)
 
 	quotaRaw, err := txn.First(qType, indexName, name)
@@ -745,6 +755,21 @@ func (m *Manager) Reset() error {
 
 // Must be called with the lock held
 func (m *Manager) resetCache() error {
+	names, err := m.quotaNamesLocked(TypeRateLimit)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		quota, err := m.quotaByNameLocked(TypeRateLimit.String(), name)
+		if err != nil {
+			return err
+		}
+		rlq := quota.(*RateLimitQuota)
+		err = rlq.store.Close(context.Background())
+		if err != nil {
+			return err
+		}
+	}
 	db, err := memdb.NewMemDB(dbSchema())
 	if err != nil {
 		return err


### PR DESCRIPTION
We current have a goroutine leak since as part of creating RLQs, we create a goroutine as part of `memorystore.New` - however, as part of `Reset`, we don’t actually call `Close` on it. As a result, upon seal/unseal, a lot of these goroutines get stranded.

This could cause an issue with a combination of high leadership changes and high quotas.

I tested this manually and this definitely fixes things. Adding a non-manual test doesn't seem particularly easy/possible due to our existing leaks.