### PR TITLE
UI: Pass param so infotooltip conditionally renders

### DIFF
--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -95,6 +95,7 @@
         @fallbackComponent="string-list"
         @passObject={{true}}
         @objectKeys={{array "clientId"}}
+        @renderInfoTooltip={{true}}
       />
     {{/if}}
   </div>

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -32,7 +32,7 @@ import { isWildcardString } from 'vault/helpers/is-wildcard-string';
  * @param {string} [wildcardLabel] - when you want the searchSelect component to return a count on the model for options returned when using a wildcard you must provide a label of the count e.g. role.  Should be singular.
  * @param {string} [placeholder] - text you wish to replace the default "search" with
  * @param {boolean} [displayInherit] - if you need the search select component to display inherit instead of box.
- * @param {boolean} [renderInfoTooltip] - if you want search select to render a tooltip beside a selected item if no corresponding model was returned from .query
+ * @param {boolean} [renderInfoTooltip=false] - if you want search select to render a tooltip beside a selected item if no corresponding model was returned from .query
  *
  * @param {Array} options - *Advanced usage* - `options` can be passed directly from the outside to the
  * power-select component. If doing this, `models` should not also be passed as that will overwrite the

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -32,6 +32,7 @@ import { isWildcardString } from 'vault/helpers/is-wildcard-string';
  * @param {string} [wildcardLabel] - when you want the searchSelect component to return a count on the model for options returned when using a wildcard you must provide a label of the count e.g. role.  Should be singular.
  * @param {string} [placeholder] - text you wish to replace the default "search" with
  * @param {boolean} [displayInherit] - if you need the search select component to display inherit instead of box.
+ * @param {boolean} [renderInfoTooltip] - if you want search select to render a tooltip beside a selected item if no corresponding model was returned from .query
  *
  * @param {Array} options - *Advanced usage* - `options` can be passed directly from the outside to the
  * power-select component. If doing this, `models` should not also be passed as that will overwrite the
@@ -90,7 +91,8 @@ export default Component.extend({
       let matchingOption = options.findBy(this.idKey, option);
       // an undefined matchingOption means a selectedOption, on edit, didn't match a model returned from the query
       // this means it is a wildcard string or no longer exists
-      let addTooltip = matchingOption || isWildcardString([option]) ? false : true; // add tooltip to let user know the selection can be discarded
+      // permissions shouldn't inhibit viewing a record here, because the fallback component would render instead of search-select
+      let addTooltip = matchingOption || isWildcardString([option]) ? false : true; // add tooltip to let user know the selection may not exist
       options.removeObject(matchingOption);
       return {
         id: option,

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -72,11 +72,11 @@
           </div>
         {{/if}}
         <div class="control">
-          {{#if selected.addTooltip}}
+          {{#if (and selected.addTooltip @renderInfoTooltip)}}
             <InfoTooltip>
-              The item with this
+              The item associated with this
               {{to-label this.idKey}}
-              no longer exists.
+              may no longer exist.
             </InfoTooltip>
           {{/if}}
           <button

--- a/ui/tests/integration/components/search-select-test.js
+++ b/ui/tests/integration/components/search-select-test.js
@@ -608,6 +608,7 @@ module('Integration | Component | search select', function (hooks) {
         @onChange={{this.onChange}}
         @objectKeys={{this.objectKeys}}
         @inputValue={{this.inputValue}}
+        @renderInfoTooltip={{true}}
       />
       `);
 
@@ -640,6 +641,7 @@ module('Integration | Component | search select', function (hooks) {
         @objectKeys={{this.objectKeys}}
         @inputValue={{this.inputValue}}
         @passObject={{true}}
+        @renderInfoTooltip={{true}}
       />
     `);
 
@@ -669,6 +671,7 @@ module('Integration | Component | search select', function (hooks) {
         @onChange={{this.onChange}}
         @inputValue={{this.inputValue}}
         @passObject={{true}}
+        @renderInfoTooltip={{true}}
       />
     `);
 
@@ -698,6 +701,7 @@ module('Integration | Component | search select', function (hooks) {
         @onChange={{this.onChange}}
         @inputValue={{this.inputValue}}
         @passObject={{false}}
+        @renderInfoTooltip={{true}}
       />
     `);
     assert.equal(component.selectedOptions.length, 3, 'there are three selected options');
@@ -710,6 +714,33 @@ module('Integration | Component | search select', function (hooks) {
     assert
       .dom('[data-test-selected-option="1"] [data-test-component="info-tooltip"]')
       .exists('renders info tooltip for model not returned from query');
+    assert
+      .dom('[data-test-selected-option="2"] [data-test-component="info-tooltip"]')
+      .doesNotExist('does not render info tooltip for wildcard option');
+  });
+
+  test('it does not render an info tooltip beside selection if does not match a record returned from query and not passed @renderInfoTooltip', async function (assert) {
+    const models = ['some/model'];
+    const spy = sinon.spy();
+    const inputValue = ['model-a-id', 'non-existent-model', 'wildcard*'];
+    this.set('models', models);
+    this.set('onChange', spy);
+    this.set('inputValue', inputValue);
+    await render(hbs`
+      <SearchSelect
+        @label="foo"
+        @models={{this.models}}
+        @onChange={{this.onChange}}
+        @inputValue={{this.inputValue}}
+        @passObject={{false}}
+      />
+    `);
+    assert
+      .dom('[data-test-selected-option="0"] [data-test-component="info-tooltip"]')
+      .doesNotExist('does not render info tooltip for model that exists');
+    assert
+      .dom('[data-test-selected-option="1"] [data-test-component="info-tooltip"]')
+      .doesNotExist('does not render info tooltip for model not returned from query');
     assert
       .dom('[data-test-selected-option="2"] [data-test-component="info-tooltip"]')
       .doesNotExist('does not render info tooltip for wildcard option');


### PR DESCRIPTION
This functionality was originally added so that a user would be able to clean up an OIDC provider, and remove any allowed app's that may have been deleted. As you can see from the screenshot, only the `client_id` renders, and not the rest of the model information when a client has been deleted.

Search select is used widely so decided to add a param so that the tooltip _only_  renders if we expect it to (as we do in the `provider-form`). This component will be fully refactored in 1.13, so the intent here is a quick fix to avoid wide-reaching consequences where we may not anticipate them. 
<img width="1140" alt="Screen Shot 2022-09-22 at 2 16 25 PM" src="https://user-images.githubusercontent.com/68122737/191852506-d90bfeea-0714-498d-8947-43b43d3a7ede.png">
