### PR TITLE
Plugins: Allow explicitly specifying the builtin version of a plugin

### DIFF
--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/helper/versions"
+	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -152,14 +154,23 @@ func TestCore_BuiltinRegistry(t *testing.T) {
 	}
 	c, _, _ := TestCoreUnsealedWithConfig(t, conf)
 
-	me := &MountEntry{
-		Table: credentialTableType,
-		Path:  "approle/",
-		Type:  "approle",
-	}
-	err := c.enableCredential(namespace.RootContext(nil), me)
-	if err != nil {
-		t.Fatalf("err: %v", err)
+	for _, me := range []*MountEntry{
+		{
+			Table: credentialTableType,
+			Path:  "approle/",
+			Type:  "approle",
+		},
+		{
+			Table:   credentialTableType,
+			Path:    "approle2/",
+			Type:    "approle",
+			Version: versions.GetBuiltinVersion(consts.PluginTypeCredential, "approle"),
+		},
+	} {
+		err := c.enableCredential(namespace.RootContext(nil), me)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
 	}
 }
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -629,6 +629,13 @@ func getVersion(d *framework.FieldData) (string, error) {
 			return "", fmt.Errorf("version %q is not a valid semantic version: %w", version, err)
 		}
 
+		metadataIdentifiers := strings.Split(semanticVersion.Metadata(), ".")
+		for _, identifier := range metadataIdentifiers {
+			if identifier == "builtin" {
+				return "", fmt.Errorf("version %q is not allowed because 'builtin' is a reserved metadata identifier", version)
+			}
+		}
+
 		// Canonicalize the version string.
 		// Add the 'v' back in, since semantic version strips it out, and we want to be consistent with internal plugins.
 		version = "v" + semanticVersion.String()

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -3129,6 +3129,29 @@ func TestSystemBackend_PluginCatalog_CRUD(t *testing.T) {
 	}
 }
 
+func TestSystemBackend_PluginCatalog_CannotRegisterBuiltinPlugins(t *testing.T) {
+	c, b, _ := testCoreSystemBackend(t)
+	// Bootstrap the pluginCatalog
+	sym, err := filepath.EvalSymlinks(os.TempDir())
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	c.pluginCatalog.directory = sym
+
+	// Set a plugin
+	req := logical.TestRequest(t, logical.UpdateOperation, "plugins/catalog/database/test-plugin")
+	req.Data["sha256"] = hex.EncodeToString([]byte{'1'})
+	req.Data["command"] = "foo"
+	req.Data["version"] = "v1.2.3+special.builtin"
+	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.Contains(resp.Error().Error(), "reserved metadata") {
+		t.Fatalf("err: %v", resp.Error())
+	}
+}
+
 func TestSystemBackend_ToolsHash(t *testing.T) {
 	b := testSystemBackend(t)
 	req := logical.TestRequest(t, logical.UpdateOperation, "tools/hash")

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -735,7 +735,8 @@ func (c *PluginCatalog) get(ctx context.Context, name string, pluginType consts.
 		}
 	}
 
-	if version == "" {
+	builtinVersion := versions.GetBuiltinVersion(pluginType, name)
+	if version == "" || version == builtinVersion {
 		// Look for builtin plugins
 		if factory, ok := c.builtinRegistry.Get(name, pluginType); ok {
 			return &pluginutil.PluginRunner{
@@ -743,7 +744,7 @@ func (c *PluginCatalog) get(ctx context.Context, name string, pluginType consts.
 				Type:           pluginType,
 				Builtin:        true,
 				BuiltinFactory: factory,
-				Version:        versions.GetBuiltinVersion(pluginType, name),
+				Version:        builtinVersion,
 			}, nil
 		}
 	}


### PR DESCRIPTION
For example, if you have registered a versioned kubernetes auth plugin, omitting the version when mounting kubernetes auth will always select the versioned plugin, but you can specify the builtin version instead like so:

```bash
vault auth enable -plugin-version="v0.14.0+builtin" kubernetes
```

Also disallows registering any plugins with a `builtin` identifier in the metadata. I referenced [here](https://semver.org/#spec-item-10) for the format and terminology of the tag metadata.