### PR TITLE
Plugins: Update running version everywhere running sha256 is set

### DIFF
--- a/builtin/plugin/backend_test.go
+++ b/builtin/plugin/backend_test.go
@@ -126,8 +126,9 @@ func testConfig(t *testing.T, pluginCmd string) (*logical.BackendConfig, func())
 		Logger: logging.NewVaultLogger(log.Debug),
 		System: sys,
 		Config: map[string]string{
-			"plugin_name": "mock-plugin",
-			"plugin_type": "secret",
+			"plugin_name":    "mock-plugin",
+			"plugin_type":    "secret",
+			"plugin_version": "v0.0.0+mock",
 		},
 	}
 

--- a/http/sys_auth_test.go
+++ b/http/sys_auth_test.go
@@ -45,7 +45,7 @@ func TestSysAuth(t *testing.T) {
 				"options":                interface{}(nil),
 				"plugin_version":         "",
 				"running_sha256":         "",
-				"running_plugin_version": "",
+				"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeCredential, "token"),
 			},
 		},
 		"token/": map[string]interface{}{
@@ -63,7 +63,7 @@ func TestSysAuth(t *testing.T) {
 			"options":                interface{}(nil),
 			"plugin_version":         "",
 			"running_sha256":         "",
-			"running_plugin_version": "",
+			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeCredential, "token"),
 		},
 	}
 	testResponseStatus(t, resp, 200)
@@ -145,7 +145,7 @@ func TestSysEnableAuth(t *testing.T) {
 				"options":                interface{}(nil),
 				"plugin_version":         "",
 				"running_sha256":         "",
-				"running_plugin_version": "",
+				"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeCredential, "token"),
 			},
 		},
 		"foo/": map[string]interface{}{
@@ -181,7 +181,7 @@ func TestSysEnableAuth(t *testing.T) {
 			"options":                interface{}(nil),
 			"plugin_version":         "",
 			"running_sha256":         "",
-			"running_plugin_version": "",
+			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeCredential, "token"),
 		},
 	}
 	testResponseStatus(t, resp, 200)
@@ -248,7 +248,7 @@ func TestSysDisableAuth(t *testing.T) {
 				"options":                 interface{}(nil),
 				"plugin_version":          "",
 				"running_sha256":          "",
-				"running_plugin_version":  "",
+				"running_plugin_version":  versions.GetBuiltinVersion(consts.PluginTypeCredential, "token"),
 			},
 		},
 		"token/": map[string]interface{}{
@@ -266,7 +266,7 @@ func TestSysDisableAuth(t *testing.T) {
 			"options":                 interface{}(nil),
 			"plugin_version":          "",
 			"running_sha256":          "",
-			"running_plugin_version":  "",
+			"running_plugin_version":  versions.GetBuiltinVersion(consts.PluginTypeCredential, "token"),
 		},
 	}
 	testResponseStatus(t, resp, 200)
@@ -542,7 +542,7 @@ func TestSysRemountAuth(t *testing.T) {
 				"options":                interface{}(nil),
 				"plugin_version":         "",
 				"running_sha256":         "",
-				"running_plugin_version": "",
+				"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeCredential, "token"),
 			},
 		},
 		"bar/": map[string]interface{}{
@@ -577,7 +577,7 @@ func TestSysRemountAuth(t *testing.T) {
 			"options":                interface{}(nil),
 			"plugin_version":         "",
 			"running_sha256":         "",
-			"running_plugin_version": "",
+			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeCredential, "token"),
 		},
 	}
 	testResponseStatus(t, resp, 200)

--- a/sdk/plugin/grpc_backend_test.go
+++ b/sdk/plugin/grpc_backend_test.go
@@ -157,7 +157,7 @@ func TestGRPCBackendPlugin_Version(t *testing.T) {
 	}
 
 	version := versioner.PluginVersion().Version
-	if version != "mock" {
+	if version != "v0.0.0+mock" {
 		t.Fatalf("Got version %s, expected 'mock'", version)
 	}
 }

--- a/sdk/plugin/mock/backend.go
+++ b/sdk/plugin/mock/backend.go
@@ -59,7 +59,7 @@ func Backend() *backend {
 		BackendType: logical.TypeLogical,
 	}
 	b.internal = "bar"
-	b.RunningVersion = "mock"
+	b.RunningVersion = "v0.0.0+mock"
 	return &b
 }
 

--- a/vault/external_plugin_test.go
+++ b/vault/external_plugin_test.go
@@ -242,9 +242,8 @@ func TestCore_EnableExternalPlugin_MultipleVersions(t *testing.T) {
 				t.Errorf("Expected mount to be version %s but got %s", tc.expectedVersion, raw.(*routeEntry).mountEntry.Version)
 			}
 
-			// we don't override the running version of non-builtins, and they don't have the version set explicitly (yet)
-			if raw.(*routeEntry).mountEntry.RunningVersion != "" {
-				t.Errorf("Expected mount to have no running version but got %s", raw.(*routeEntry).mountEntry.RunningVersion)
+			if raw.(*routeEntry).mountEntry.RunningVersion != tc.expectedVersion {
+				t.Errorf("Expected mount running version to be %s but got %s", tc.expectedVersion, raw.(*routeEntry).mountEntry.RunningVersion)
 			}
 
 			if raw.(*routeEntry).mountEntry.RunningSha256 == "" {

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -1850,7 +1850,7 @@ func TestSystemBackend_authTable(t *testing.T) {
 			"seal_wrap":              false,
 			"options":                map[string]string(nil),
 			"plugin_version":         "",
-			"running_plugin_version": "",
+			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeCredential, "token"),
 			"running_sha256":         "",
 		},
 	}
@@ -1936,7 +1936,7 @@ func TestSystemBackend_enableAuth(t *testing.T) {
 			"seal_wrap":              false,
 			"options":                map[string]string(nil),
 			"plugin_version":         "",
-			"running_plugin_version": "",
+			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeCredential, "token"),
 			"running_sha256":         "",
 		},
 	}
@@ -3445,7 +3445,7 @@ func TestSystemBackend_InternalUIMounts(t *testing.T) {
 				"local":                   false,
 				"seal_wrap":               false,
 				"plugin_version":          "",
-				"running_plugin_version":  "",
+				"running_plugin_version":  versions.GetBuiltinVersion(consts.PluginTypeCredential, "token"),
 				"running_sha256":          "",
 			},
 		},

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -827,6 +827,8 @@ func (c *PluginCatalog) setInternal(ctx context.Context, name string, pluginType
 	} else if version != "" && runningVersion.Version != "" && version != runningVersion.Version {
 		c.logger.Warn("Plugin self-reported version did not match requested version", "plugin", name, "requestedVersion", version, "reportedVersion", runningVersion.Version)
 		return nil, fmt.Errorf("plugin version mismatch: %s reported version (%s) did not match requested version (%s)", name, runningVersion.Version, version)
+	} else if version == "" && runningVersion.Version != "" {
+		version = runningVersion.Version
 	}
 
 	entry := &pluginutil.PluginRunner{

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -829,6 +829,11 @@ func (c *PluginCatalog) setInternal(ctx context.Context, name string, pluginType
 		return nil, fmt.Errorf("plugin version mismatch: %s reported version (%s) did not match requested version (%s)", name, runningVersion.Version, version)
 	} else if version == "" && runningVersion.Version != "" {
 		version = runningVersion.Version
+		_, err := semver.NewVersion(version)
+		if err != nil {
+			return nil, fmt.Errorf("plugin self-reported version %q is not a valid semantic version: %w", version, err)
+		}
+
 	}
 
 	entry := &pluginutil.PluginRunner{


### PR DESCRIPTION
There were a few cases where `running_plugin_version` wasn't getting populated, but it should always be up to date and in sync with the `running_sha256` field now.

I also added a small tweak to plugin catalog registration to ensure we always capture output of the `Versioner` interface on registration, so we should be able to just use the mount entry's configured version immediately after starting a new backend, as that will be the version it used to query the catalog. ~I'll try to write an additional test for that, but wanted to get some feedback while that's in progress.~ Turns out the existing tests exercise that functionality quite nicely.