### PR TITLE
Add note about issuer naming and CRLs

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1889,6 +1889,10 @@ imported entries present in the same bundle).
    issues; this may impact long-term use of these issuers, but some issuers or
    keys may still be imported as a result of this process.
 
+~> Warning: See the [note](/docs/secrets/pki/considerations#issuer-subjects-and-crls)
+   regarding Subject naming on externally created CA certificates and
+   shortcomings with CRL building.
+
 #### Parameters
 
 - `pem_bundle` `(string: <required>)` - Specifies the unencrypted private key

--- a/website/content/docs/secrets/pki/considerations.mdx
+++ b/website/content/docs/secrets/pki/considerations.mdx
@@ -36,6 +36,7 @@ generating the CA to use with this secrets engine.
  - [Replicated DataSets](#replicated-datasets)
  - [Cluster Scalability](#cluster-scalability)
  - [PSS Support](#pss-support)
+ - [Issuer Subjects and CRLs](#issuer-subjects-and-crls)
 
 ## Be Careful with Root CAs
 
@@ -589,6 +590,17 @@ of certificates if they do not support `rsa_pss_rsae_*` signature schemes.
 Additionally, some implementations allow rsaPSS OID certificates to contain
 restrictions on signature parameters allowed by this certificate, but Go and
 Vault do not support adding such restrictions.
+
+## Issuer Subjects and CRLs
+
+As noted on several [GitHub issues](https://github.com/hashicorp/vault/issues/10176),
+Go's x509 library has an opinionated parsing and structuring mechanism for
+certificate's Subjects. Issuers created within Vault are fine, but when using
+externally created CA certificates, note that these may not be parsed
+correctly throughout all parts of the PKI. In particular, CRLs embed a
+(modified) copy of the issuer name. This can be avoided by using OCSP to
+track revocation, but note that performance characteristics are different
+between OCSP and CRLs.
 
 ## Tutorial
 


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

Seeing as https://github.com/golang/go/issues/53754 has not received any attention upstream, it is best we add this shortcoming of Go's CRL generation to the documentation.