### PR TITLE
Write explicit -help output to stdout

### DIFF
--- a/changelog/17308.txt
+++ b/changelog/17308.txt
@@ -1,0 +1,3 @@
+```release-note:improvement:
+cli: User-requested -help text now appears on stdout for paging rather than stderr
+```

--- a/command/main.go
+++ b/command/main.go
@@ -228,7 +228,8 @@ func RunCustom(args []string, runOpts *RunOptions) int {
 		HelpFunc: groupedHelpFunc(
 			cli.BasicHelpFunc("vault"),
 		),
-		HelpWriter:                 runOpts.Stderr,
+		HelpWriter:                 runOpts.Stdout,
+		ErrorWriter:                runOpts.Stderr,
 		HiddenCommands:             hiddenCommands,
 		Autocomplete:               true,
 		AutocompleteNoDefaultFlags: true,


### PR DESCRIPTION
Per the consensus of most programs, and mirroring the GNU Coding Standards for CLI design, when users request `-help` explicitly via the CLI, this should be written to `stdout` to allow paging of output. `stderr` is (implicitly) fine when an invalid usage triggers the help text however.

In our case, `mitchellh/cli` helpfully adds a `HelpWriter` that we previously set to `stderr` explicitly. This writer is only called to print user-requested help text; it is not called on error cases (e.g., bad usage triggering additional help text to the user).

Thus it should safely be settable to `stdout`, enabling pagers without additional redirects and without affecting any user scripts relying on stdout not containing help text when bad usage occurs (or similarly, that stderr contains help when bad usage occurs).

See also: https://www.gnu.org/prep/standards/html_node/_002d_002dhelp.html
Resolves: #17004

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`