### PR TITLE
Enos: Add missing tags and use az_finder for AZs to Autopilot scenario

### DIFF
--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -59,7 +59,8 @@ scenario "autopilot" {
   }
 
   step "create_vpc" {
-    module = module.create_vpc
+    module     = module.create_vpc
+    depends_on = [step.find_azs]
 
     variables {
       ami_architectures  = [matrix.arch]

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -63,6 +63,8 @@ scenario "autopilot" {
 
     variables {
       ami_architectures = [matrix.arch]
+      availability_zones = step.find_azs.availability_zones
+      common_tags        = local.tags
     }
   }
 

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -62,7 +62,7 @@ scenario "autopilot" {
     module = module.create_vpc
 
     variables {
-      ami_architectures = [matrix.arch]
+      ami_architectures  = [matrix.arch]
       availability_zones = step.find_azs.availability_zones
       common_tags        = local.tags
     }


### PR DESCRIPTION
This scenario was getting occasional errors from AWS complaining that `t3a.small` instances weren't available in all AZs within the region. The `az_finder` module limits the VPC to only the AZs that have the requested instance type. Also, forgot some tags! 