### PR TITLE
Stop sending CORS when Vault is manually sealed

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1939,6 +1939,29 @@ func (c *Core) sealInitCommon(ctx context.Context, req *logical.Request) (retErr
 		}
 	}
 
+	// Finally, we should stop sending CORS headers. When Vault is initially
+	// started prior to unsealing, CORS configuration is stored within
+	// barrier protected storage and isn't present on initial requests prior
+	// to unsealing.
+	//
+	// By disabling CORS while Vault is sealed, we potentially prohibit access
+	// to sealed Vault from CORS clients and behave like a freshly-started
+	// Vault. Since requests to unseal are not authenticated (because the auth
+	// system is likewise barrier protected), a malicious CORS-executed script
+	// could spam unseal requests, prohibiting operators from themselves
+	// unsealing.
+	//
+	// This is all within relatively-safe windows though: clients are allowed
+	// to cache Vault CORS responses for a period of 300 seconds (see the
+	// value of Access-Control-Max-Age in vault/cors.go). So immediately after
+	// Vault is sealed, CORS scripts could still abuse access to unsealing,
+	// but after their client invalidates this cache, they'll be prohibited
+	// until Vault is unsealed by an operator.
+	//
+	// We explicitly do not call c.CORSConfig().Disable() as we do not wish
+	// for this to be persisted.
+	atomic.StoreUint32(c.CORSConfig().Enabled, 1)
+
 	// Unlock; sealing will grab the lock when needed
 	unlocked = true
 	c.stateLock.RUnlock()


### PR DESCRIPTION
When Vault has CORS configuration set, it serves all relevant handlers with CORS request data. This configuration is stored within barrier protected storage, so when Vault starts up with a manual seal method, no CORS headers are initially served. However, once unsealed, Vault will start servicing requests with CORS headers.

When Vault is subsequently manually sealed, CORS headers were previously still sent on outbound requests.

This meant any misbehaving CORS script could request Vault be unsealed and provide bogus Shamir shares, because the browser's CORS validation would permit access Vault, as Vault is still serving valid CORS headers.

By disabling CORS, we fall back to Vault's default logic of servicing the request directly--but note that conforming browsers will still deny the request because Vault does not respond to CORS validation requests successfully after their expiry. This is more secure: most browsers are well-behaved and thus will not institute CORS requests after the initial `Access-Control-Max-Age` (300 seconds) expires.

Resolves: #12569

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

What threw me for a loop was the start of `wrapCORSHandler`:

```go
func wrapCORSHandler(h http.Handler, core *vault.Core) http.Handler {
    return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
        corsConf := core.CORSConfig()

        // If CORS is not enabled or if no Origin header is present (i.e. the request
        // is from the Vault CLI. A browser will always send an Origin header), then
        // just return a 204.
        if !corsConf.IsEnabled() {
            h.ServeHTTP(w, req)
            return
        }

        origin := req.Header.Get("Origin")
        requestMethod := req.Header.Get("Access-Control-Request-Method")

        if origin == "" {
            h.ServeHTTP(w, req)
            return
        }

        // Return a 403 if the origin is not allowed to make cross-origin requests.
        if !corsConf.IsValidOrigin(origin) {
            respondError(w, http.StatusForbidden, fmt.Errorf("origin not allowed"))
            return
        }
```

I'd _expect_ Vault to check, if CORS is disabled, that if `Origin`+`Access-Control-Request-Method` client request headers are provided, we'd deny the request.  However, since plugins can't really do METHOD-typed requests, we should still err out from the call (maybe not with `http.StatusForbidden` but a 404 should behave the same in the end on conforming Browsers).

Non-conforming browsers which don't send these requests don't really matter, as they'd not set Origin on CORS requests either way, so Vault would have nothing to validate.