### PR TITLE
core: Parse VAULT_ALLOW_PENDING_REMOVAL_MOUNTS as bool

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1272,7 +1272,7 @@ func (c *ServerCommand) Run(args []string) int {
 		vault.PendingRemovalMountsAllowed, err = strconv.ParseBool(allowPendingRemoval)
 		if err != nil {
 			c.UI.Warn(wrapAtLength("WARNING! failed to parse " +
-				"VAULT_ENABLE_PENDING_REMOVAL_MOUNTS env var: " +
+				consts.VaultAllowPendingRemovalMountsEnv + " env var: " +
 				"defaulting to false."))
 		}
 	}

--- a/command/server.go
+++ b/command/server.go
@@ -40,6 +40,7 @@ import (
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/internalshared/configutil"
 	"github.com/hashicorp/vault/internalshared/listenerutil"
+	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/helper/strutil"
@@ -1263,6 +1264,16 @@ func (c *ServerCommand) Run(args []string) int {
 			c.UI.Warn(wrapAtLength("WARNING! failed to parse " +
 				"VAULT_DISABLE_SERVER_SIDE_CONSISTENT_TOKENS env var: " +
 				"setting to default value false"))
+		}
+	}
+
+	if allowPendingRemoval := os.Getenv(consts.VaultAllowPendingRemovalMountsEnv); allowPendingRemoval != "" {
+		var err error
+		vault.PendingRemovalMountsAllowed, err = strconv.ParseBool(allowPendingRemoval)
+		if err != nil {
+			c.UI.Warn(wrapAtLength("WARNING! failed to parse " +
+				"VAULT_ENABLE_PENDING_REMOVAL_MOUNTS env var: " +
+				"defaulting to false."))
 		}
 	}
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -104,6 +104,8 @@ var (
 	// mountAliases maps old backend names to new backend names, allowing us
 	// to move/rename backends but maintain backwards compatibility
 	mountAliases = map[string]string{"generic": "kv"}
+
+	PendingRemovalMountsAllowed = false
 )
 
 func (c *Core) generateMountAccessor(entryType string) (string, error) {
@@ -960,7 +962,7 @@ func (c *Core) handleDeprecatedMountEntry(ctx context.Context, entry *MountEntry
 
 		case consts.PendingRemoval:
 			dl.Error(errDeprecatedMount.Error())
-			if allow := os.Getenv(consts.VaultAllowPendingRemovalMountsEnv); allow == "" {
+			if !PendingRemovalMountsAllowed {
 				return nil, fmt.Errorf("could not mount %q: %w", t, errDeprecatedMount)
 			}
 			resp.AddWarning(errDeprecatedMount.Error())

--- a/website/content/docs/commands/server.mdx
+++ b/website/content/docs/commands/server.mdx
@@ -60,7 +60,7 @@ flags](/docs/commands) included on all commands.
   are "standard" and "json". This can also be specified via the
   VAULT_LOG_FORMAT environment variable.
 
-- `VAULT_ALLOW_PENDING_REMOVAL_MOUNTS` `(string: "")` - (environment variable)
+- `VAULT_ALLOW_PENDING_REMOVAL_MOUNTS` `(bool: false)` - (environment variable)
 Allow Vault to be started with builtin engines which have the `Pending Removal`
 deprecation state. This is a temporary stopgap in place in order to perform an
 upgrade and disable these engines. Once these engines are marked `Removed` (in


### PR DESCRIPTION
Previously the environment variable used to allow deprecated ("Pending Removal") builtins to be mounted was processed using string validation (set v. unset). It was confusing for users who might set `VAULT_ALLOW_PENDING_REMOVAL_MOUNTS=false`, which would behave exactly like `VAULT_ALLOW_PENDING_REMOVAL_MOUNTS=true`. Change this logic to instead be processed as a boolean in accordance with the principle of least surprise.