### PR TITLE
Update docs for new test/sign params for managed key api and GCP parameters

### DIFF
--- a/website/content/api-docs/system/managed-keys.mdx
+++ b/website/content/api-docs/system/managed-keys.mdx
@@ -150,7 +150,7 @@ $ curl \
   `"true"`). This key is mainly to work around a limitation within AWS's CloudHSM v5
   pkcs11 implementation.
 
-- `max_parallel` `(int: 1)` - The number of concurrent requests that may be in 
+- `max_parallel` `(int: 1)` - The number of concurrent requests that may be in
   flight to the HSM at any given time.
 
 #### AWS KMS Parameters
@@ -217,6 +217,7 @@ $ curl \
 - `key_type` `(string: <required>)`: The type of key to use. At this time only supported value is `RSA`.
 
 #### GCP Cloud KMS Parameters
+- `type` `(string: "gcpckms")` - To select an GCP Cloud KMS backend, the type parameter must be set to `gcpckms`.
 
 - `credentials` `(string: <required>)`: The path of the credential file to use for authenticating to GCP.
 This can also be provided in the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
@@ -296,8 +297,7 @@ $ curl \
 ## Test Sign with a managed key
 
 This endpoint allows an operator to validate that a managed key configuration works
-by signing and verifying some randomly generated data. No values can be provided to sign,
-nor are signed or verified data returned to the caller. If the call returns a successful HTTP
+by signing and verifying some randomly generated data. If the call returns a successful HTTP
 status code, the configuration can be considered valid.
 
 ~> **Note**: if key generation is allowed and no existing key can be found, this call will generate the key
@@ -309,7 +309,21 @@ status code, the configuration can be considered valid.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options are `pkcs11`, `awskms`, `azurekeyvault`, or `gcpckms`.
+
+- `use_pss` `(bool: false)` - Use RSA PSS signatures within the signing/verification api calls.
+
+- `hash_algorithm` `(string: sha2-256)` - Use the following hashing algorithm within the signing/verification api calls.
+  The supported values are
+   - sha1
+   - sha2-224
+   - sha2-256
+   - sha2-384
+   - sha2-512
+   - sha3-224
+   - sha3-256
+   - sha3-384
+   - sha3-512
 
 ### Sample Request
 

--- a/website/content/api-docs/system/managed-keys.mdx
+++ b/website/content/api-docs/system/managed-keys.mdx
@@ -238,7 +238,6 @@ with the `GOOGLE_REGION` environment variable.
 values for signature algorithms are:
   - `EC_SIGN_P256_SHA256`
   - `EC_SIGN_P384_SHA384`
-  - `EC_SIGN_P256_SHA256`
   - `RSA_SIGN_PSS_2048_SHA256`
   - `RSA_SIGN_PSS_3072_SHA256`
   - `RSA_SIGN_PSS_4096_SHA256`

--- a/website/content/api-docs/system/managed-keys.mdx
+++ b/website/content/api-docs/system/managed-keys.mdx
@@ -220,22 +220,23 @@ $ curl \
 - `type` `(string: "gcpckms")` - To select an GCP Cloud KMS backend, the type parameter must be set to `gcpckms`.
 
 - `credentials` `(string: <required>)`: The path of the credential file to use for authenticating to GCP.
-This can also be provided in the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+  This can also be provided in the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
 
 - `crypto_key` `(string: <required>)`: The name of the GCP Cloud KMS key. If there is no existing key
-and `allow_generate_key` is `true`, Vault will generate a key with this name.
+  and `allow_generate_key` is `true`, Vault will generate a key with this name.
 
 - `crypto_key_version` `(string: "1")`: The version of the key to use.
 
-- `key_ring` `(string: <required>)`: The name of the key ring in GCP Cloud KMS.
+- `key_ring` `(string: <required>)`: The name of the key ring in GCP Cloud KMS. This needs to be created
+  prior to key creation.
 
 - `project` `(string: <required>)`: The ID of the GCP project.
 
 - `region` `(string: <required>)`: The region where the key ring was created. This can also be provided
-with the `GOOGLE_REGION` environment variable.
+  with the `GOOGLE_REGION` environment variable.
 
 - `algorithm` `(string: <required>)`: The signature algorithm to be used with the key. Supported
-values for signature algorithms are:
+  values for signature algorithms are:
   - `EC_SIGN_P256_SHA256`
   - `EC_SIGN_P384_SHA384`
   - `RSA_SIGN_PSS_2048_SHA256`

--- a/website/content/api-docs/system/managed-keys.mdx
+++ b/website/content/api-docs/system/managed-keys.mdx
@@ -220,7 +220,7 @@ $ curl \
 - `type` `(string: "gcpckms")` - To select an GCP Cloud KMS backend, the type parameter must be set to `gcpckms`.
 
 - `credentials` `(string: <required>)`: The path of the credential file to use for authenticating to GCP.
-  This can also be provided in the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+  This can also be provided in the `GOOGLE_CREDENTIALS` or `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
 
 - `crypto_key` `(string: <required>)`: The name of the GCP Cloud KMS key. If there is no existing key
   and `allow_generate_key` is `true`, Vault will generate a key with this name.
@@ -230,7 +230,8 @@ $ curl \
 - `key_ring` `(string: <required>)`: The name of the key ring in GCP Cloud KMS. This needs to be created
   prior to key creation.
 
-- `project` `(string: <required>)`: The ID of the GCP project.
+- `project` `(string: <required>)`: The ID of the GCP project. This can also be provided with
+  the `GOOGLE_PROJECT` environment variable.
 
 - `region` `(string: <required>)`: The region where the key ring was created. This can also be provided
   with the `GOOGLE_REGION` environment variable.


### PR DESCRIPTION
 - The existing test/sign managed key api now has two new api params allowing an operator to specify to use RSA PSS signatures (use_pss) and to specify the hashing algorithm to use (hash_algorithm)

This brings back the documentation update within the corresponding enterprise PR.