### PR TITLE
PKI: Fix managed key signatures when using specified signature_bits

### DIFF
--- a/changelog/17328.txt
+++ b/changelog/17328.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Do not ignore provided signature bits value when signing intermediate and leaf certificates with a managed key
+```

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -1127,7 +1127,12 @@ func signCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertBun
 		certTemplate.NotBefore = time.Now().Add(-1 * data.Params.NotBeforeDuration)
 	}
 
-	switch data.SigningBundle.PrivateKeyType {
+	privateKeyType := data.SigningBundle.PrivateKeyType
+	if privateKeyType == ManagedPrivateKey {
+		privateKeyType = GetPrivateKeyTypeFromSigner(data.SigningBundle.PrivateKey)
+	}
+
+	switch privateKeyType {
 	case RSAPrivateKey:
 		certTemplateSetSigAlgo(certTemplate, data)
 	case ECPrivateKey:

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -148,16 +148,16 @@ type KeyBundle struct {
 }
 
 func GetPrivateKeyTypeFromSigner(signer crypto.Signer) PrivateKeyType {
-	switch signer.(type) {
-	case *rsa.PrivateKey:
+	// We look at the public key types to work-around limitations/typing of managed keys.
+	switch signer.Public().(type) {
+	case *rsa.PublicKey:
 		return RSAPrivateKey
-	case *ecdsa.PrivateKey:
+	case *ecdsa.PublicKey:
 		return ECPrivateKey
-	case ed25519.PrivateKey:
+	case ed25519.PublicKey:
 		return Ed25519PrivateKey
-	default:
-		return UnknownPrivateKey
 	}
+	return UnknownPrivateKey
 }
 
 // ToPEMBundle converts a string-based certificate bundle


### PR DESCRIPTION
 - When calling sign-intermediate and other apis with signature_bits value overridden with a backing managed key we did not use that value as tests for the private key type were not working.
 - This was exposed with GCP managed key testing as we started failing with a backing PSS SHA512 RSA key


```
vault write  -format=json pki/root/sign-intermediate signature_bits=512 csr=@pki_intermediate.csr use_pss=true \
     format=pem_bundle ttl="43800h" \
     | jq -r '.data.certificate' > intermediate.cert.pem

Error writing data to pki/root/sign-intermediate: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/pki/root/sign-intermediate
Code: 500. Errors:

* 1 error occurred:
	* error signing cert: unable to create certificate: rpc error: code = InvalidArgument desc = The digest SHA256 is not valid for CryptoKeys with algorithm RSA_SIGN_PSS_4096_SHA512.
``` 