### PR TITLE
Remove delta indicator on main CRL

### DIFF
--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -294,12 +294,20 @@ func crlEnableDisableTestForBackend(t *testing.T, b *backend, s logical.Storage,
 			requireSerialNumberInCRL(t, certList, serialNum)
 		}
 
+		if len(certList.Extensions) > 2 {
+			t.Fatalf("expected up to 2 extensions on main CRL but got %v", len(certList.Extensions))
+		}
+
 		// Since this test assumes a complete CRL was rebuilt, we can grab
 		// the delta CRL and ensure it is empty.
 		deltaList := getParsedCrlFromBackend(t, b, s, "crl/delta").TBSCertList
 		lenDeltaList := len(deltaList.RevokedCertificates)
 		if lenDeltaList != 0 {
 			t.Fatalf("expected zero revoked certificates on the delta CRL due to complete CRL rebuild, found %d", lenDeltaList)
+		}
+
+		if len(deltaList.Extensions) != len(certList.Extensions)+1 {
+			t.Fatalf("expected one more extensions on delta CRL than main but got %v on main vs %v on delta", len(certList.Extensions), len(deltaList.Extensions))
 		}
 	}
 

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -1269,9 +1269,13 @@ WRITE:
 	now := time.Now()
 	nextUpdate := now.Add(crlLifetime)
 
-	ext, err := certutil.CreateDeltaCRLIndicatorExt(lastCompleteNumber)
-	if err != nil {
-		return nil, fmt.Errorf("could not create crl delta indicator extension: %v", err)
+	var extensions []pkix.Extension
+	if isDelta {
+		ext, err := certutil.CreateDeltaCRLIndicatorExt(lastCompleteNumber)
+		if err != nil {
+			return nil, fmt.Errorf("could not create crl delta indicator extension: %v", err)
+		}
+		extensions = []pkix.Extension{ext}
 	}
 
 	revocationListTemplate := &x509.RevocationList{
@@ -1280,7 +1284,7 @@ WRITE:
 		ThisUpdate:          now,
 		NextUpdate:          nextUpdate,
 		SignatureAlgorithm:  signingBundle.RevocationSigAlg,
-		ExtraExtensions:     []pkix.Extension{ext},
+		ExtraExtensions:     extensions,
 	}
 
 	crlBytes, err := x509.CreateRevocationList(rand.Reader, revocationListTemplate, signingBundle.Certificate, signingBundle.PrivateKey)


### PR DESCRIPTION
When adding delta CRL support, we unconditionally added the delta indicator extension to the main CRL. We shouldn't have done this, and instead only added it conditionally when we were building delta CRLs.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`