### PR TITLE
Plugins: Fix file permissions check to always use the correct path

### DIFF
--- a/changelog/17340.txt
+++ b/changelog/17340.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugins: Corrected the path to check permissions on when the registered plugin name does not match the plugin binary's filename.
+```

--- a/vault/external_plugin_test.go
+++ b/vault/external_plugin_test.go
@@ -555,8 +555,11 @@ func TestExternalPlugin_CheckFilePermissions(t *testing.T) {
 				"version": tc.pluginVersion,
 			}
 			resp, err := c.systemBackend.HandleRequest(namespace.RootContext(nil), req)
-			if err != nil || resp.Error() != nil {
-				t.Fatalf("resp: %s, err: %s", resp.Error(), err)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.Error() != nil {
+				t.Fatal(resp.Error())
 			}
 
 			// Now attempt to mount the plugin, which should trigger checking the permissions again.
@@ -570,8 +573,11 @@ func TestExternalPlugin_CheckFilePermissions(t *testing.T) {
 				}
 			}
 			resp, err = c.systemBackend.HandleRequest(namespace.RootContext(nil), req)
-			if err != nil || resp.Error() != nil {
-				t.Fatalf("resp: %s, err: %s", resp.Error(), err)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.Error() != nil {
+				t.Fatal(resp.Error())
 			}
 		})
 	}
@@ -586,8 +592,11 @@ func registerPlugin(t *testing.T, sys *SystemBackend, pluginName, pluginType, ve
 		"version": version,
 	}
 	resp, err := sys.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || resp.Error() != nil {
-		t.Fatalf("resp: %s, err: %s", resp.Error(), err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error() != nil {
+		t.Fatal(resp.Error())
 	}
 }
 
@@ -603,8 +612,11 @@ func mountPlugin(t *testing.T, sys *SystemBackend, pluginName string, pluginType
 		}
 	}
 	resp, err := sys.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || resp.Error() != nil {
-		t.Fatalf("resp: %s, err: %s", resp.Error(), err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error() != nil {
+		t.Fatal(resp.Error())
 	}
 }
 

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -110,7 +110,12 @@ func wrapFactoryCheckPerms(core *Core, f logical.Factory) logical.Factory {
 			return nil, fmt.Errorf("failed to find %s in plugin catalog", pluginDescription)
 		}
 
-		if err := core.CheckPluginPerms(path.Base(plugin.Command)); err != nil {
+		command, err := filepath.Rel(core.pluginCatalog.directory, plugin.Command)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute plugin command: %w", err)
+		}
+
+		if err := core.CheckPluginPerms(command); err != nil {
 			return nil, err
 		}
 		return f(ctx, conf)


### PR DESCRIPTION
Previously, there was a bug where the wrong path would be checked during the mount operation because we just pulled the plugin name from the config (but not during registration, because it correctly used the `command` input at that point). The plugin name often matches the binary name, but not necessarily, and it will match the name less often once people start using versioned plugins if they want two versions of the same plugin to co-exist in the plugin directory.

I've committed the test first, so hopefully that should show an error which gets fixed by the second commit once the CI finishes.