### PR TITLE
Inject Store Service When Accessed Implicitly

### DIFF
--- a/ui/app/adapters/generated-item-list.js
+++ b/ui/app/adapters/generated-item-list.js
@@ -1,11 +1,14 @@
 import { assign } from '@ember/polyfills';
 import ApplicationAdapter from './application';
 import { task } from 'ember-concurrency';
+import { inject as service } from '@ember/service';
 
 export default ApplicationAdapter.extend({
+  store: service(),
   namespace: 'v1',
   urlForItem() {},
   dynamicApiPath: '',
+
   getDynamicApiPath: task(function* (id) {
     // TODO: remove yield at some point.
     let result = yield this.store.peekRecord('auth-method', id);

--- a/ui/app/adapters/keymgmt/key.js
+++ b/ui/app/adapters/keymgmt/key.js
@@ -1,6 +1,7 @@
 import ApplicationAdapter from '../application';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 import ControlGroupError from '../../lib/control-group-error';
+import { inject as service } from '@ember/service';
 
 function pickKeys(obj, picklist) {
   const data = {};
@@ -11,7 +12,9 @@ function pickKeys(obj, picklist) {
   });
   return data;
 }
+
 export default class KeymgmtKeyAdapter extends ApplicationAdapter {
+  @service store;
   namespace = 'v1';
 
   pathForType() {

--- a/ui/app/adapters/secret-v2-version.js
+++ b/ui/app/adapters/secret-v2-version.js
@@ -1,12 +1,16 @@
 /* eslint-disable */
 import AdapterError from '@ember-data/adapter/error';
+
 import { isEmpty } from '@ember/utils';
 import { get } from '@ember/object';
 import ApplicationAdapter from './application';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
+import { inject as service } from '@ember/service';
 
 export default ApplicationAdapter.extend({
+  store: service(),
   namespace: 'v1',
+
   _url(backend, id, infix = 'data') {
     let url = `${this.buildURL()}/${encodePath(backend)}/${infix}/`;
     if (!isEmpty(id)) {

--- a/ui/app/components/transform-role-edit.js
+++ b/ui/app/components/transform-role-edit.js
@@ -1,6 +1,8 @@
 import TransformBase, { addToList, removeFromList } from './transform-edit-base';
+import { inject as service } from '@ember/service';
 
 export default TransformBase.extend({
+  store: service(),
   initialTransformations: null,
 
   init() {

--- a/ui/app/components/transformation-edit.js
+++ b/ui/app/components/transformation-edit.js
@@ -1,6 +1,8 @@
 import TransformBase, { addToList, removeFromList } from './transform-edit-base';
+import { inject as service } from '@ember/service';
 
 export default TransformBase.extend({
+  store: service(),
   initialRoles: null,
 
   init() {

--- a/ui/app/controllers/vault/cluster/access/mfa/methods/create.js
+++ b/ui/app/controllers/vault/cluster/access/mfa/methods/create.js
@@ -6,6 +6,7 @@ import { capitalize } from '@ember/string';
 import { task } from 'ember-concurrency';
 
 export default class MfaMethodCreateController extends Controller {
+  @service store;
   @service flashMessages;
   @service router;
 

--- a/ui/app/controllers/vault/cluster/access/oidc/keys/key/details.js
+++ b/ui/app/controllers/vault/cluster/access/oidc/keys/key/details.js
@@ -5,6 +5,7 @@ import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 
 export default class OidcKeyDetailsController extends Controller {
+  @service store;
   @service router;
   @service flashMessages;
 

--- a/ui/app/models/keymgmt/provider.js
+++ b/ui/app/models/keymgmt/provider.js
@@ -3,13 +3,16 @@ import { tracked } from '@glimmer/tracking';
 import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 import { withModelValidations } from 'vault/decorators/model-validations';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
+import { inject as service } from '@ember/service';
 
 const CRED_PROPS = {
   azurekeyvault: ['client_id', 'client_secret', 'tenant_id'],
   awskms: ['access_key', 'secret_key', 'session_token', 'endpoint'],
   gcpckms: ['service_account_file'],
 };
+
 const OPTIONAL_CRED_PROPS = ['session_token', 'endpoint'];
+
 // since we have dynamic credential attributes based on provider we need a dynamic presence validator
 // add validators for all cred props and return true for value if not associated with selected provider
 const credValidators = Object.keys(CRED_PROPS).reduce((obj, providerKey) => {
@@ -27,13 +30,16 @@ const credValidators = Object.keys(CRED_PROPS).reduce((obj, providerKey) => {
   });
   return obj;
 }, {});
+
 const validations = {
   name: [{ type: 'presence', message: 'Provider name is required' }],
   keyCollection: [{ type: 'presence', message: 'Key Vault instance name' }],
   ...credValidators,
 };
+
 @withModelValidations(validations)
 export default class KeymgmtProviderModel extends Model {
+  @service store;
   @attr('string') backend;
   @attr('string', {
     label: 'Provider name',

--- a/ui/app/models/mfa-login-enforcement.js
+++ b/ui/app/models/mfa-login-enforcement.js
@@ -4,6 +4,7 @@ import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import { methods } from 'vault/helpers/mountable-auth-methods';
 import { withModelValidations } from 'vault/decorators/model-validations';
 import { isPresent } from '@ember/utils';
+import { inject as service } from '@ember/service';
 
 const validations = {
   name: [{ type: 'presence', message: 'Name is required' }],
@@ -26,8 +27,10 @@ const validations = {
     },
   ],
 };
+
 @withModelValidations(validations)
 export default class MfaLoginEnforcementModel extends Model {
+  @service store;
   @attr('string') name;
   @hasMany('mfa-method') mfa_methods;
   @attr('string') namespace_id;

--- a/ui/app/routes/vault.js
+++ b/ui/app/routes/vault.js
@@ -7,10 +7,13 @@ import Ember from 'ember';
 const SPLASH_DELAY = Ember.testing ? 0 : 300;
 
 export default Route.extend({
+  store: service(),
   version: service(),
+
   beforeModel() {
     return this.version.fetchVersion();
   },
+
   model() {
     // hardcode single cluster
     const fixture = {

--- a/ui/app/routes/vault/cluster/access/identity/aliases/show.js
+++ b/ui/app/routes/vault/cluster/access/identity/aliases/show.js
@@ -3,8 +3,11 @@ import { hash } from 'rsvp';
 import { set } from '@ember/object';
 import Route from '@ember/routing/route';
 import { TABS } from 'vault/helpers/tabs-for-identity-show';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  store: service(),
+
   model(params) {
     let { section } = params;
     let itemType = this.modelFor('vault.cluster.access.identity') + '-alias';

--- a/ui/app/routes/vault/cluster/access/identity/show.js
+++ b/ui/app/routes/vault/cluster/access/identity/show.js
@@ -4,8 +4,11 @@ import { hash } from 'rsvp';
 import { set } from '@ember/object';
 import Route from '@ember/routing/route';
 import { TABS } from 'vault/helpers/tabs-for-identity-show';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  store: service(),
+
   model(params) {
     let { section } = params;
     let itemType = this.modelFor('vault.cluster.access.identity');

--- a/ui/app/routes/vault/cluster/access/leases/list.js
+++ b/ui/app/routes/vault/cluster/access/leases/list.js
@@ -1,8 +1,11 @@
 import { set } from '@ember/object';
 import { hash } from 'rsvp';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  store: service(),
+
   queryParams: {
     page: {
       refreshModel: true,

--- a/ui/app/routes/vault/cluster/access/method.js
+++ b/ui/app/routes/vault/cluster/access/method.js
@@ -4,7 +4,9 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  store: service(),
   pathHelp: service('path-help'),
+
   model(params) {
     const { path } = params;
     return this.store.findAll('auth-method').then((modelArray) => {

--- a/ui/app/routes/vault/cluster/access/method/item/show.js
+++ b/ui/app/routes/vault/cluster/access/method/item/show.js
@@ -3,7 +3,9 @@ import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default Route.extend({
+  store: service(),
   pathHelp: service('path-help'),
+
   model(params) {
     const id = params.item_id;
     const { item_type: itemType } = this.paramsFor('vault.cluster.access.method.item');

--- a/ui/app/routes/vault/cluster/access/methods.js
+++ b/ui/app/routes/vault/cluster/access/methods.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  store: service(),
+
   queryParams: {
     page: {
       refreshModel: true,

--- a/ui/app/routes/vault/cluster/access/mfa/enforcements/index.js
+++ b/ui/app/routes/vault/cluster/access/mfa/enforcements/index.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class MfaEnforcementsRoute extends Route {
+  @service store;
+
   model() {
     return this.store.query('mfa-login-enforcement', {}).catch((err) => {
       if (err.httpStatus === 404) {

--- a/ui/app/routes/vault/cluster/access/mfa/index.js
+++ b/ui/app/routes/vault/cluster/access/mfa/index.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class MfaConfigureRoute extends Route {
+  @service store;
+
   beforeModel() {
     return this.store
       .query('mfa-method', {})

--- a/ui/app/routes/vault/cluster/access/mfa/methods/index.js
+++ b/ui/app/routes/vault/cluster/access/mfa/methods/index.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class MfaMethodsRoute extends Route {
+  @service store;
   @service router;
 
   model() {

--- a/ui/app/routes/vault/cluster/access/mfa/methods/method.js
+++ b/ui/app/routes/vault/cluster/access/mfa/methods/method.js
@@ -1,6 +1,10 @@
 import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
+import { inject as service } from '@ember/service';
+
 export default class MfaMethodRoute extends Route {
+  @service store;
+
   model({ id }) {
     return hash({
       method: this.store.findRecord('mfa-method', id).then((data) => data),

--- a/ui/app/routes/vault/cluster/access/oidc/assignments/assignment.js
+++ b/ui/app/routes/vault/cluster/access/oidc/assignments/assignment.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcAssignmentRoute extends Route {
+  @service store;
+
   model({ name }) {
     return this.store.findRecord('oidc/assignment', name);
   }

--- a/ui/app/routes/vault/cluster/access/oidc/assignments/create.js
+++ b/ui/app/routes/vault/cluster/access/oidc/assignments/create.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcAssignmentsCreateRoute extends Route {
+  @service store;
+
   model() {
     return this.store.createRecord('oidc/assignment');
   }

--- a/ui/app/routes/vault/cluster/access/oidc/assignments/index.js
+++ b/ui/app/routes/vault/cluster/access/oidc/assignments/index.js
@@ -1,6 +1,8 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcAssignmentsRoute extends Route {
+  @service store;
   model() {
     return this.store.query('oidc/assignment', {}).catch((err) => {
       if (err.httpStatus === 404) {

--- a/ui/app/routes/vault/cluster/access/oidc/clients/client.js
+++ b/ui/app/routes/vault/cluster/access/oidc/clients/client.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcClientRoute extends Route {
+  @service store;
+
   model({ name }) {
     return this.store.findRecord('oidc/client', name);
   }

--- a/ui/app/routes/vault/cluster/access/oidc/clients/client/providers.js
+++ b/ui/app/routes/vault/cluster/access/oidc/clients/client/providers.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcClientProvidersRoute extends Route {
+  @service store;
+
   model() {
     const model = this.modelFor('vault.cluster.access.oidc.clients.client');
     return this.store

--- a/ui/app/routes/vault/cluster/access/oidc/clients/create.js
+++ b/ui/app/routes/vault/cluster/access/oidc/clients/create.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcClientsCreateRoute extends Route {
+  @service store;
+
   model() {
     return this.store.createRecord('oidc/client');
   }

--- a/ui/app/routes/vault/cluster/access/oidc/clients/index.js
+++ b/ui/app/routes/vault/cluster/access/oidc/clients/index.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 export default class OidcClientsRoute extends Route {
+  @service store;
   @service router;
 
   model() {

--- a/ui/app/routes/vault/cluster/access/oidc/index.js
+++ b/ui/app/routes/vault/cluster/access/oidc/index.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class OidcConfigureRoute extends Route {
+  @service store;
   @service router;
 
   beforeModel() {

--- a/ui/app/routes/vault/cluster/access/oidc/keys/create.js
+++ b/ui/app/routes/vault/cluster/access/oidc/keys/create.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcKeysCreateRoute extends Route {
+  @service store;
+
   model() {
     return this.store.createRecord('oidc/key');
   }

--- a/ui/app/routes/vault/cluster/access/oidc/keys/index.js
+++ b/ui/app/routes/vault/cluster/access/oidc/keys/index.js
@@ -1,5 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
 export default class OidcKeysRoute extends Route {
+  @service store;
+
   model() {
     return this.store.query('oidc/key', {}).catch((err) => {
       if (err.httpStatus === 404) {

--- a/ui/app/routes/vault/cluster/access/oidc/keys/key.js
+++ b/ui/app/routes/vault/cluster/access/oidc/keys/key.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcKeyRoute extends Route {
+  @service store;
+
   model({ name }) {
     return this.store.findRecord('oidc/key', name);
   }

--- a/ui/app/routes/vault/cluster/access/oidc/keys/key/clients.js
+++ b/ui/app/routes/vault/cluster/access/oidc/keys/key/clients.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcKeyClientsRoute extends Route {
+  @service store;
+
   async model() {
     const { allowedClientIds } = this.modelFor('vault.cluster.access.oidc.keys.key');
     return await this.store.query('oidc/client', { paramKey: 'client_id', filterFor: allowedClientIds });

--- a/ui/app/routes/vault/cluster/access/oidc/providers/create.js
+++ b/ui/app/routes/vault/cluster/access/oidc/providers/create.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcProvidersCreateRoute extends Route {
+  @service store;
+
   model() {
     return this.store.createRecord('oidc/provider');
   }

--- a/ui/app/routes/vault/cluster/access/oidc/providers/index.js
+++ b/ui/app/routes/vault/cluster/access/oidc/providers/index.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcProvidersRoute extends Route {
+  @service store;
+
   model() {
     return this.store.query('oidc/provider', {}).catch((err) => {
       if (err.httpStatus === 404) {

--- a/ui/app/routes/vault/cluster/access/oidc/providers/provider.js
+++ b/ui/app/routes/vault/cluster/access/oidc/providers/provider.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcProviderRoute extends Route {
+  @service store;
+
   model({ name }) {
     return this.store.findRecord('oidc/provider', name);
   }

--- a/ui/app/routes/vault/cluster/access/oidc/providers/provider/clients.js
+++ b/ui/app/routes/vault/cluster/access/oidc/providers/provider/clients.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcProviderClientsRoute extends Route {
+  @service store;
+
   async model() {
     const { allowedClientIds } = this.modelFor('vault.cluster.access.oidc.providers.provider');
     return await this.store.query('oidc/client', { paramKey: 'client_id', filterFor: allowedClientIds });

--- a/ui/app/routes/vault/cluster/access/oidc/scopes/create.js
+++ b/ui/app/routes/vault/cluster/access/oidc/scopes/create.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcScopesCreateRoute extends Route {
+  @service store;
+
   model() {
     return this.store.createRecord('oidc/scope');
   }

--- a/ui/app/routes/vault/cluster/access/oidc/scopes/index.js
+++ b/ui/app/routes/vault/cluster/access/oidc/scopes/index.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcScopesRoute extends Route {
+  @service store;
+
   model() {
     return this.store.query('oidc/scope', {}).catch((err) => {
       if (err.httpStatus === 404) {

--- a/ui/app/routes/vault/cluster/access/oidc/scopes/scope.js
+++ b/ui/app/routes/vault/cluster/access/oidc/scopes/scope.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OidcScopeRoute extends Route {
+  @service store;
+
   model({ name }) {
     return this.store.findRecord('oidc/scope', name);
   }

--- a/ui/app/routes/vault/cluster/clients.js
+++ b/ui/app/routes/vault/cluster/clients.js
@@ -2,9 +2,11 @@ import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 import { action } from '@ember/object';
 import getStorage from 'vault/lib/token-storage';
-
+import { inject as service } from '@ember/service';
 const INPUTTED_START_DATE = 'vault:ui-inputted-start-date';
+
 export default class ClientsRoute extends Route {
+  @service store;
   async getVersionHistory() {
     try {
       let arrayOfModels = [];

--- a/ui/app/routes/vault/cluster/clients/config.js
+++ b/ui/app/routes/vault/cluster/clients/config.js
@@ -1,5 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
 export default class ConfigRoute extends Route {
+  @service store;
+
   model() {
     return this.store.queryRecord('clients/config', {});
   }

--- a/ui/app/routes/vault/cluster/clients/current.js
+++ b/ui/app/routes/vault/cluster/clients/current.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
+import { inject as service } from '@ember/service';
 
 export default class CurrentRoute extends Route {
+  @service store;
+
   async model() {
     let parentModel = this.modelFor('vault.cluster.clients');
 

--- a/ui/app/routes/vault/cluster/clients/edit.js
+++ b/ui/app/routes/vault/cluster/clients/edit.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  store: service(),
+
   model() {
     return this.store.queryRecord('clients/config', {});
   },

--- a/ui/app/routes/vault/cluster/clients/history.js
+++ b/ui/app/routes/vault/cluster/clients/history.js
@@ -3,9 +3,12 @@ import { isSameMonth } from 'date-fns';
 import RSVP from 'rsvp';
 import getStorage from 'vault/lib/token-storage';
 import { parseRFC3339 } from 'core/utils/date-formatters';
-
+import { inject as service } from '@ember/service';
 const INPUTTED_START_DATE = 'vault:ui-inputted-start-date';
+
 export default class HistoryRoute extends Route {
+  @service store;
+
   async getActivity(start_time) {
     if (isSameMonth(new Date(start_time), new Date())) {
       // triggers empty state to manually enter date if license begins in current month

--- a/ui/app/routes/vault/cluster/secrets/backend.js
+++ b/ui/app/routes/vault/cluster/secrets/backend.js
@@ -1,9 +1,11 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 export default Route.extend({
+  store: service(),
   flashMessages: service(),
   secretMountPath: service(),
   oldModel: null,
+
   model(params) {
     let { backend } = params;
     this.secretMountPath.update(backend);

--- a/ui/app/routes/vault/cluster/secrets/backend/create-root.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/create-root.js
@@ -28,6 +28,7 @@ const transformModel = (queryParams) => {
 };
 
 export default EditBase.extend({
+  store: service(),
   wizard: service(),
 
   createModel(transition) {

--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -8,10 +8,13 @@ import { normalizePath } from 'vault/utils/path-encoding-helpers';
 const SUPPORTED_BACKENDS = supportedSecretBackends();
 
 export default Route.extend({
+  store: service(),
   templateName: 'vault/cluster/secrets/backend/list',
   pathHelp: service('path-help'),
+
   // By default assume user doesn't have permissions
   noMetadataPermissions: true,
+
   queryParams: {
     page: {
       refreshModel: true,

--- a/ui/app/routes/vault/cluster/secrets/backend/overview.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/overview.js
@@ -1,12 +1,16 @@
 import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  store: service(),
   type: '',
+
   enginePathParam() {
     let { backend } = this.paramsFor('vault.cluster.secrets.backend');
     return backend;
   },
+
   async fetchConnection(queryOptions) {
     try {
       return await this.store.query('database/connection', queryOptions);
@@ -14,6 +18,7 @@ export default Route.extend({
       return e.httpStatus;
     }
   },
+
   async fetchAllRoles(queryOptions) {
     try {
       return await this.store.query('database/role', queryOptions);
@@ -21,20 +26,25 @@ export default Route.extend({
       return e.httpStatus;
     }
   },
+
   pathQuery(backend, endpoint) {
     return {
       id: `${backend}/${endpoint}/`,
     };
   },
+
   async fetchCapabilitiesRole(queryOptions) {
     return this.store.queryRecord('capabilities', this.pathQuery(queryOptions.backend, 'roles'));
   },
+
   async fetchCapabilitiesStaticRole(queryOptions) {
     return this.store.queryRecord('capabilities', this.pathQuery(queryOptions.backend, 'static-roles'));
   },
+
   async fetchCapabilitiesConnection(queryOptions) {
     return this.store.queryRecord('capabilities', this.pathQuery(queryOptions.backend, 'config'));
   },
+
   model() {
     let backend = this.enginePathParam();
     let queryOptions = { backend, id: '' };
@@ -57,6 +67,7 @@ export default Route.extend({
       icon: 'database',
     });
   },
+
   setupController(controller, model) {
     this._super(...arguments);
     let showEmptyState = model.connections === 404 && model.roles === 404;

--- a/ui/app/routes/vault/cluster/secrets/backends.js
+++ b/ui/app/routes/vault/cluster/secrets/backends.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  store: service(),
+
   model() {
     return this.store.query('secret-engine', {});
   },

--- a/ui/app/routes/vault/cluster/settings/auth/configure.js
+++ b/ui/app/routes/vault/cluster/settings/auth/configure.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  store: service(),
+
   model() {
     const { method } = this.paramsFor(this.routeName);
     return this.store.findAll('auth-method').then(() => {

--- a/ui/app/routes/vault/cluster/settings/configure-secret-backend.js
+++ b/ui/app/routes/vault/cluster/settings/configure-secret-backend.js
@@ -1,10 +1,12 @@
 import AdapterError from '@ember-data/adapter/error';
 import { set } from '@ember/object';
 import Route from '@ember/routing/route';
-
+import { inject as service } from '@ember/service';
 const CONFIGURABLE_BACKEND_TYPES = ['aws', 'ssh', 'pki'];
 
 export default Route.extend({
+  store: service(),
+
   model() {
     const { backend } = this.paramsFor(this.routeName);
     return this.store.query('secret-engine', { path: backend }).then((modelList) => {

--- a/ui/app/routes/vault/cluster/settings/configure-secret-backend/section.js
+++ b/ui/app/routes/vault/cluster/settings/configure-secret-backend/section.js
@@ -1,12 +1,16 @@
 import AdapterError from '@ember-data/adapter/error';
 import { set } from '@ember/object';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 // ARG TODO glimmerize
 const SECTIONS_FOR_TYPE = {
   pki: ['cert', 'urls', 'crl', 'tidy'],
 };
+
 export default Route.extend({
+  store: service(),
+
   fetchModel() {
     const { section_name: sectionName } = this.paramsFor(this.routeName);
     const backendModel = this.modelFor('vault.cluster.settings.configure-secret-backend');

--- a/ui/app/routes/vault/cluster/settings/seal.js
+++ b/ui/app/routes/vault/cluster/settings/seal.js
@@ -1,7 +1,10 @@
 import { hash } from 'rsvp';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  store: service(),
+
   model() {
     return hash({
       cluster: this.modelFor('vault.cluster'),

--- a/ui/scripts/codemods/inject-store-service.js
+++ b/ui/scripts/codemods/inject-store-service.js
@@ -1,0 +1,112 @@
+// jscodeshift can take a parser, like "babel", "babylon", "flow", "ts", or "tsx"
+// Read more: https://github.com/facebook/jscodeshift#parser
+// export const parser = 'babylon';
+
+export default function transformer({ source }, api) {
+  const j = api.jscodeshift;
+  const filterForStore = (path) => {
+    return j(path.value).find(j.MemberExpression, {
+      object: {
+        type: 'ThisExpression',
+      },
+      property: {
+        name: 'store',
+      },
+    }).length;
+  };
+  let didInjectStore = false;
+
+  // find class bodies and filter down to ones that access this.store
+  const classesAccessingStore = j(source).find(j.ClassBody).filter(filterForStore);
+
+  if (classesAccessingStore.length) {
+    // filter down to class bodies where service is not injected
+    const missingService = classesAccessingStore.filter((path) => {
+      return !j(path.value)
+        .find(j.ClassProperty, {
+          key: {
+            name: 'store',
+          },
+        })
+        .filter((path) => {
+          // ensure store property belongs to service decorator
+          return path.value.decorators.find((path) => path.expression.name === 'service');
+        }).length;
+    });
+
+    if (missingService.length) {
+      // inject store service
+      const storeService = j.classProperty(j.identifier('@service store'), null);
+      // adding a decorator this way will force store down to a new line and then add a new line
+      // leaving in just in case it's needed
+      // storeService.decorators = [j.decorator(j.identifier('service'))];
+
+      source = missingService
+        .forEach((path) => {
+          path.value.body.unshift(storeService);
+        })
+        .toSource();
+
+      didInjectStore = true;
+    }
+  }
+
+  // find object expressions and filter down to ones that access this.store (Ember classic)
+  const objectsAccessingStore = j(source).find(j.ObjectExpression).filter(filterForStore);
+
+  if (objectsAccessingStore.length) {
+    // filter down to objects where service is not injected
+    const missingService = objectsAccessingStore.filter((path) => {
+      return !j(path.value).find(j.ObjectProperty, {
+        key: {
+          name: 'store',
+        },
+        value: {
+          callee: {
+            name: 'service',
+          },
+        },
+      }).length;
+    });
+
+    if (missingService.length) {
+      // inject store service
+      const storeService = j.objectProperty(
+        j.identifier('store'),
+        j.callExpression(j.identifier('service'), [])
+      );
+
+      source = missingService
+        .forEach((path) => {
+          path.value.properties.unshift(storeService);
+        })
+        .toSource();
+
+      didInjectStore = true;
+    }
+  }
+
+  // if store was injected here check if inject has been imported
+  if (didInjectStore) {
+    const needsImport = !j(source).find(j.ImportSpecifier, {
+      imported: {
+        name: 'inject',
+      },
+    }).length;
+
+    if (needsImport) {
+      const injectionImport = j.importDeclaration(
+        [j.importSpecifier(j.identifier('inject'), j.identifier('service'))],
+        j.literal('@ember/service')
+      );
+
+      const imports = j(source).find(j.ImportDeclaration);
+      source = imports
+        .at(imports.length - 1)
+        .insertAfter(injectionImport)
+        .toSource({ reuseWhitespace: false });
+    }
+  }
+
+  return source;
+}

--- a/ui/scripts/codemods/inject-store-service.js
+++ b/ui/scripts/codemods/inject-store-service.js
@@ -1,6 +1,11 @@
-// jscodeshift can take a parser, like "babel", "babylon", "flow", "ts", or "tsx"
-// Read more: https://github.com/facebook/jscodeshift#parser
-// export const parser = 'babylon';
+import babylonParser from './jscodeshift-babylon-parser';
+
+// use babylon parser with decorators-legacy plugin
+export const parser = babylonParser;
+
+// example usage
+// npx jscodeshift -t ./scripts/codemods/inject-store-service.js ./app/**/*.js
+// pass -d for dry run (no files transformed)
 
 export default function transformer({ source }, api) {
   const j = api.jscodeshift;

--- a/ui/scripts/codemods/jscodeshift-babylon-parser.js
+++ b/ui/scripts/codemods/jscodeshift-babylon-parser.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/* eslint-env node */
+
+// Read more: https://github.com/facebook/jscodeshift#parser
+
+const babylon = require('@babel/parser');
+
+const parserConfig = {
+  sourceType: 'module',
+  allowImportExportEverywhere: true,
+  allowReturnOutsideFunction: true,
+  startLine: 1,
+  tokens: true,
+  plugins: [
+    ['flow', { all: true }],
+    'flowComments',
+    'jsx',
+    'asyncGenerators',
+    'bigInt',
+    'classProperties',
+    'classPrivateProperties',
+    'classPrivateMethods',
+    'decorators-legacy', // allows decorator to come before export statement
+    'doExpressions',
+    'dynamicImport',
+    'exportDefaultFrom',
+    'exportNamespaceFrom',
+    'functionBind',
+    'functionSent',
+    'importMeta',
+    'logicalAssignment',
+    'nullishCoalescingOperator',
+    'numericSeparator',
+    'objectRestSpread',
+    'optionalCatchBinding',
+    'optionalChaining',
+    ['pipelineOperator', { proposal: 'minimal' }],
+    'throwExpressions',
+  ],
+};
+
+export default {
+  parse: function (source) {
+    return babylon.parse(source, parserConfig);
+  },
+};


### PR DESCRIPTION
This work is part of the Ember 4.4 upgrade to address the [implicit service injection deprecation](https://github.com/emberjs/rfcs/blob/master/text/0680-implicit-injection-deprecation.md), specifically the store service which is no longer injected through an initializer by Ember Data.

I came up with a codemod to identify where `this.store` is accessed and optionally inject the store service and import `inject`. It also handles the classic Ember extend style as well as native classes. After running across all js files, 53 were modified and I'm no longer seeing the missing service injection error in the console when loading the app.