### PR TITLE
cli/api: Update plugin listing to always include version info in the response

### DIFF
--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -32,7 +32,7 @@ type ListPluginsResponse struct {
 }
 
 type PluginDetails struct {
-	Type              string `json:"string"`
+	Type              string `json:"type"`
 	Name              string `json:"name"`
 	Version           string `json:"version,omitempty"`
 	Builtin           bool   `json:"builtin"`
@@ -50,25 +50,7 @@ func (c *Sys) ListPluginsWithContext(ctx context.Context, i *ListPluginsInput) (
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	path := ""
-	method := ""
-	if i.Type == consts.PluginTypeUnknown {
-		path = "/v1/sys/plugins/catalog"
-		method = http.MethodGet
-	} else {
-		path = fmt.Sprintf("/v1/sys/plugins/catalog/%s", i.Type)
-		method = "LIST"
-	}
-
-	req := c.c.NewRequest(method, path)
-	if method == "LIST" {
-		// Set this for broader compatibility, but we use LIST above to be able
-		// to handle the wrapping lookup function
-		req.Method = http.MethodGet
-		req.Params.Set("list", "true")
-	}
-
-	resp, err := c.c.rawRequestWithContext(ctx, req)
+	resp, err := c.c.rawRequestWithContext(ctx, c.c.NewRequest(http.MethodGet, "/v1/sys/plugins/catalog"))
 	if err != nil && resp == nil {
 		return nil, err
 	}
@@ -76,27 +58,6 @@ func (c *Sys) ListPluginsWithContext(ctx context.Context, i *ListPluginsInput) (
 		return nil, nil
 	}
 	defer resp.Body.Close()
-
-	// We received an Unsupported Operation response from Vault, indicating
-	// Vault of an older version that doesn't support the GET method yet;
-	// switch it to a LIST.
-	if resp.StatusCode == 405 {
-		req.Params.Set("list", "true")
-		resp, err := c.c.rawRequestWithContext(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
-		var result struct {
-			Data struct {
-				Keys []string `json:"keys"`
-			} `json:"data"`
-		}
-		if err := resp.DecodeJSON(&result); err != nil {
-			return nil, err
-		}
-		return &ListPluginsResponse{Names: result.Data.Keys}, nil
-	}
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
@@ -108,9 +69,9 @@ func (c *Sys) ListPluginsWithContext(ctx context.Context, i *ListPluginsInput) (
 
 	result := &ListPluginsResponse{
 		PluginsByType: make(map[consts.PluginType][]string),
-		Details:       []PluginDetails{},
 	}
-	if i.Type == consts.PluginTypeUnknown {
+	switch i.Type {
+	case consts.PluginTypeUnknown:
 		for _, pluginType := range consts.PluginTypes {
 			pluginsRaw, ok := secret.Data[pluginType.String()]
 			if !ok {
@@ -132,17 +93,35 @@ func (c *Sys) ListPluginsWithContext(ctx context.Context, i *ListPluginsInput) (
 			}
 			result.PluginsByType[pluginType] = plugins
 		}
-	} else {
+	default:
+		pluginsRaw, ok := secret.Data[i.Type.String()]
+		if !ok {
+			return nil, fmt.Errorf("no %s entry in returned data", i.Type.String())
+		}
+
 		var respKeys []string
-		if err := mapstructure.Decode(secret.Data["keys"], &respKeys); err != nil {
+		if err := mapstructure.Decode(pluginsRaw, &respKeys); err != nil {
 			return nil, err
 		}
 		result.PluginsByType[i.Type] = respKeys
 	}
 
 	if detailed, ok := secret.Data["detailed"]; ok {
-		if err := mapstructure.Decode(detailed, &result.Details); err != nil {
+		var details []PluginDetails
+		if err := mapstructure.Decode(detailed, &details); err != nil {
 			return nil, err
+		}
+
+		switch i.Type {
+		case consts.PluginTypeUnknown:
+			result.Details = details
+		default:
+			// Filter for just the queried type.
+			for _, entry := range details {
+				if entry.Type == i.Type.String() {
+					result.Details = append(result.Details, entry)
+				}
+			}
 		}
 	}
 

--- a/changelog/17347.txt
+++ b/changelog/17347.txt
@@ -1,0 +1,6 @@
+```release-note:change
+api: Exclusively use `GET /sys/plugins/catalog` endpoint for listing plugins, and add `details` field to typed list response.
+```
+```release-note:improvement
+cli: `vault plugin list` now has a `details` field in JSON format, and version and type information in table format.
+```

--- a/changelog/17347.txt
+++ b/changelog/17347.txt
@@ -1,5 +1,5 @@
 ```release-note:change
-api: Exclusively use `GET /sys/plugins/catalog` endpoint for listing plugins, and add `details` field to typed list response.
+api: Exclusively use `GET /sys/plugins/catalog` endpoint for listing plugins, and add `details` field to list responses.
 ```
 ```release-note:improvement
 cli: `vault plugin list` now has a `details` field in JSON format, and version and type information in table format.

--- a/command/plugin_list_test.go
+++ b/command/plugin_list_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -36,7 +37,7 @@ func TestPluginListCommand_Run(t *testing.T) {
 		{
 			"lists",
 			nil,
-			"Plugins",
+			"Name\\s+Type\\s+Version",
 			0,
 		},
 	}
@@ -62,7 +63,8 @@ func TestPluginListCommand_Run(t *testing.T) {
 				}
 
 				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
-				if !strings.Contains(combined, tc.out) {
+				matcher := regexp.MustCompile(tc.out)
+				if !matcher.MatchString(combined) {
 					t.Errorf("expected %q to contain %q", combined, tc.out)
 				}
 			})

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -426,7 +426,7 @@ func (b *SystemBackend) handlePluginCatalogUntypedList(ctx context.Context, _ *l
 		}
 
 		// Sort for consistent ordering
-		sortVersionedPlugins(versionedPlugins)
+		sortVersionedPlugins(versioned)
 
 		versionedPlugins = append(versionedPlugins, versioned...)
 	}

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -5086,7 +5086,7 @@ func TestSortVersionedPlugins(t *testing.T) {
 		// Include differing versions twice so we can test out equality too.
 		"differing types, names and versions": append(differingTypes,
 			append(differingNames,
-				append(differingVersions, differingVersions...)...)...),
+				append(differingVersions, differingTypes...)...)...),
 		"mix of unversioned, versioned, and builtin": versionedUnversionedAndBuiltin,
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -5086,7 +5086,7 @@ func TestSortVersionedPlugins(t *testing.T) {
 		// Include differing versions twice so we can test out equality too.
 		"differing types, names and versions": append(differingTypes,
 			append(differingNames,
-				append(differingVersions, differingTypes...)...)...),
+				append(differingVersions, differingVersions...)...)...),
 		"mix of unversioned, versioned, and builtin": versionedUnversionedAndBuiltin,
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/website/content/docs/commands/plugin/list.mdx
+++ b/website/content/docs/commands/plugin/list.mdx
@@ -21,16 +21,15 @@ List all available plugins in the catalog.
 
 ```shell-session
 $ vault plugin list
-
-Plugins
--------
-my-custom-plugin
+Name                                 Type        Version
+----                                 ----        -------
+alicloud                             auth        v0.13.0+builtin
 # ...
 
 $ vault plugin list database
-Plugins
--------
-cassandra-database-plugin
+Name                                 Version
+----                                 -------
+cassandra-database-plugin            v1.13.0+builtin.vault
 # ...
 ```
 
@@ -44,6 +43,7 @@ alicloud                         auth        v0.12.0+builtin                    
 app-id                           auth        v1.12.0+builtin.vault                            pending removal
 # ...
 ```
+
 ## Usage
 
 The following flags are available in addition to the [standard set of


### PR DESCRIPTION
I found an issue where `vault plugin list -detailed auth` returned an empty response. There was also a small bug in the `api` package's JSON tags that stopped `type` getting populated in details.

```shell-session
$ vault plugin list -detailed auth
Name    Type    Version    Deprecation Status
----    ----    -------    ------------------
```

api: Updated the typed call to always use the untyped API so that it can always include the extra details like version etc.
cli: Added `detailed` key to JSON output, and type/version to non-detailed output because a plugin name on its own is not enough to specify a plugin, so it's not very informative to just list the names.

New output:

```shell-session
$ vault plugin list secret
Name             Version
----             -------
kv               v0.13.0+builtin
mongodb          v1.13.0+builtin.vault
...

$ vault plugin list -detailed auth
Name          Type    Version                  Deprecation Status
----          ----    -------                  ------------------
alicloud      auth    v0.13.0+builtin          supported
app-id        auth    v1.13.0+builtin.vault    pending removal
...

$ vault plugin list
Name                                 Type        Version
----                                 ----        -------
alicloud                             auth        v0.13.0+builtin
app-id                               auth        v1.13.0+builtin.vault
...

$ vault plugin list -format=json
{
  "auth": [
    "alicloud",
    ...
  ],
  "database": [
    "cassandra-database-plugin",
    "couchbase-database-plugin",
    ...
  ],
  "details": [
    {
      "type": "auth",
      "name": "alicloud",
      "version": "v0.13.0+builtin",
      "builtin": true,
      "deprecation_status": "supported"
    },
    ...

$ vault plugin list -format=json auth
{
  "auth": [
    "alicloud",
    ...
  ],
  "details": [
    {
      "type": "auth",
      "name": "alicloud",
      "version": "v0.13.0+builtin",
      "builtin": true,
      "deprecation_status": "supported"
    },
    ...
```