### PR TITLE
HCP Link Copy Fix

### DIFF
--- a/ui/app/templates/components/link-status.hbs
+++ b/ui/app/templates/components/link-status.hbs
@@ -3,9 +3,9 @@
     <Icon @name="info" />
     <p data-test-link-status>
       {{#if (eq this.state "connected")}}
-        This self-managed Vault is linked to the
+        This self-managed Vault is linked to
         <a href="https://portal.cloud.hashicorp.com/sign-in" target="_blank" rel="noopener noreferrer">
-          HashiCorp Cloud Platform.
+          HCP.
         </a>
       {{else}}
         There was an error connecting to HCP. Click


### PR DESCRIPTION
This PR resolves a merge conflict from #17302 where the wrong commit was selected reverting the template copy change from HCP to Hashicorp Cloud Platform.