### PR TITLE
Replication Test Fix

### DIFF
--- a/ui/lib/core/addon/components/modal.hbs
+++ b/ui/lib/core/addon/components/modal.hbs
@@ -1,6 +1,6 @@
 <EmberWormhole @to="modal-wormhole">
   <div class="{{this.modalClass}} {{if this.isActive 'is-active'}}" aria-modal="true" data-test-modal-div>
-    <div class="modal-background" role="button" {{on "click" @onClose}} data-test-modal-background></div>
+    <div class="modal-background" role="button" {{on "click" @onClose}} data-test-modal-background={{@title}}></div>
     <div class="modal-card">
       <header class="modal-card-head">
         <h2 class="modal-card-title title is-5" data-test-modal-title>

--- a/ui/tests/acceptance/enterprise-replication-test.js
+++ b/ui/tests/acceptance/enterprise-replication-test.js
@@ -277,7 +277,7 @@ module('Acceptance | Enterprise | replication', function (hooks) {
     assert.dom('#modal-wormhole').exists();
     assert.equal(modalDefaultTtl, '1800s', 'shows the correct TTL of 1800s');
     // click off the modal to make sure you don't just have to click on the copy-close button to copy the token
-    await click('[data-test-modal-background]');
+    await click('[data-test-modal-background="Copy your token"]');
 
     // add another secondary not using the default ttl
     await click('[data-test-secondary-add]');
@@ -292,7 +292,7 @@ module('Acceptance | Enterprise | replication', function (hooks) {
     await settled();
     let modalTtl = document.querySelector('[data-test-row-value="TTL"]').innerText;
     assert.equal(modalTtl, '180s', 'shows the correct TTL of 180s');
-    await click('[data-test-modal-background]');
+    await click('[data-test-modal-background="Copy your token"]');
 
     // confirm you were redirected to the secondaries page
     assert.equal(


### PR DESCRIPTION
After adding a modal to the `LinkStatus` component it's possible that tests previously expecting only 1 modal to be rendered would be selecting the incorrect modal. This was the case with an enterprise replication test. I added `@title` as the value for the `data-test-modal-background` attribute so that it can be individually targeted.  