### PR TITLE
Fix TtlPicker2 when no defaultValue in model sends 30 instead of "30s"

### DIFF
--- a/ui/app/utils/openapi-to-attrs.js
+++ b/ui/app/utils/openapi-to-attrs.js
@@ -51,6 +51,12 @@ export const expandOpenApiProps = function (props) {
       attrDefn.label = name;
     }
 
+    // if the defaultValue is 30 for ttl it needs to have a unit
+    // otherwise untouched it will send 30 to the backend and not define a unit (e.g. "30s")
+    if (editType === 'ttl' && attrDefn.defaultValue === 30) {
+      attrDefn.defaultValue = '30s';
+    }
+
     // ttls write as a string and read as a number
     // so setting type on them runs the wrong transform
     if (editType !== 'ttl' && type !== 'array') {


### PR DESCRIPTION
Claire noticed this while reviewing my PKI role create view. Learned there wasn't anything wrong with my code, but that the value that was assigned by OpenAPI when using editType: 'ttl' set the defaultValue (if there was none defined in the model) as 30, instead of "30s"

Notes:
* I drilled down as deep as I could go, but I couldn't actually find where the original 30 was being set. I only found a way to change/interrupt it in the `openapi-to-attrs.js` file. If anyone can find that original 30, that's probably the better place to set it unless it effects CLI, etc (which, I suspect it does).

To Test:
- This was also an issue on the MFA work. Without my fix ...