### PR TITLE
Remove HCP Link UI Changelog Entry

### DIFF
--- a/changelog/16959.txt
+++ b/changelog/16959.txt
@@ -1,3 +1,0 @@
-```release-note:feature
-ui: adds HCP link status banner
-```


### PR DESCRIPTION
A changelog entry for the HCP link UI banner was added by mistake and this PR is to remove it.  