### PR TITLE
auth/oidc: fix documentation link anchors for Google Workspace integration

### DIFF
--- a/website/content/docs/auth/jwt/oidc-providers/google.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/google.mdx
@@ -13,7 +13,7 @@ Main reference: [Using OAuth 2.0 to Access Google APIs](https://developers.googl
 1. Create a new credential via Credentials > Create Credentials > OAuth Client ID.
 1. Configure the OAuth Consent Screen. Application Name is required. Save.
 1. Select application type: "Web Application".
-1. Configure Authorized Redirect URIs.
+1. Configure Authorized [Redirect URIs](/docs/auth/jwt#redirect-uris).
 1. Save client ID and secret.
 
 ### Optional Google-specific Configuration
@@ -35,14 +35,14 @@ To set up the Google-specific handling, you'll need:
 - An OAuth 2.0 application with an [external user type](https://support.google.com/cloud/answer/10311615#user-type).
 
 The Google-specific handling that's used to fetch Google Workspace groups and user information in Vault uses
-[Google Workspace Domain-Wide Delegation of Authority](https://developers.google.com/admin-sdk/directory/v1/guides/delegation)
-for authentication and authorization. You need to follow **all steps** in the [guide](https://developers.google.com/admin-sdk/directory/v1/guides/delegation)
+Google Workspace Domain-Wide Delegation of Authority for authentication and authorization. You need to follow
+**all steps** in the [guide](https://developers.google.com/workspace/guides/create-credentials#service-account)
 to obtain the key file for a Google service account capable of making requests to the Google Workspace
 [User Accounts](https://developers.google.com/admin-sdk/directory/v1/guides/manage-users) and
 [Groups](https://developers.google.com/admin-sdk/directory/v1/guides/manage-groups) APIs.
 
-In **step 5** within the section titled
-[Delegate domain-wide authority to your service account](https://developers.google.com/admin-sdk/directory/v1/guides/delegation#delegate_domain-wide_authority_to_your_service_account),
+In **step 11** within the section titled
+[Optional: Set up domain-wide delegation for a service account](https://developers.google.com/workspace/guides/create-credentials#optional_set_up_domain-wide_delegation_for_a_service_account),
 the only OAuth scopes that should be granted are:
 
 - `https://www.googleapis.com/auth/admin.directory.group.readonly`


### PR DESCRIPTION
This PR fixes broken links to documentation for setting up domain-wide delegation of authority for the Google Workspace OIDC auth integration.