### PR TITLE
Set address test fix

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -494,6 +494,7 @@ func (c *Config) ParseAddress(address string) (*url.URL, error) {
 		return nil, err
 	}
 
+	previousAddress := c.Address
 	c.Address = address
 
 	if strings.HasPrefix(address, "unix://") {
@@ -516,7 +517,7 @@ func (c *Config) ParseAddress(address string) (*url.URL, error) {
 		} else {
 			return nil, fmt.Errorf("attempting to specify unix:// address with non-transport transport")
 		}
-	} else if strings.HasPrefix(c.Address, "unix://") {
+	} else if strings.HasPrefix(previousAddress, "unix://") {
 		// When the address being set does not begin with unix:// but the previous
 		// address in the Config did, change the transport's DialContext back to
 		// use the default configuration that cleanhttp uses.

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -101,6 +101,7 @@ func TestClientSetAddress(t *testing.T) {
 		t.Fatalf("bad: expected: '172.168.2.1:8300' actual: %q", client.addr.Host)
 	}
 	// Test switching to Unix Socket address from TCP address
+	client.config.HttpClient.Transport.(*http.Transport).DialContext = nil
 	if err := client.SetAddress("unix:///var/run/vault.sock"); err != nil {
 		t.Fatal(err)
 	}
@@ -117,6 +118,7 @@ func TestClientSetAddress(t *testing.T) {
 		t.Fatal("bad: expected DialContext to not be nil")
 	}
 	// Test switching to TCP address from Unix Socket address
+	client.config.HttpClient.Transport.(*http.Transport).DialContext = nil
 	if err := client.SetAddress("http://172.168.2.1:8300"); err != nil {
 		t.Fatal(err)
 	}
@@ -125,6 +127,9 @@ func TestClientSetAddress(t *testing.T) {
 	}
 	if client.addr.Scheme != "http" {
 		t.Fatalf("bad: expected: 'http' actual: %q", client.addr.Scheme)
+	}
+	if client.config.HttpClient.Transport.(*http.Transport).DialContext == nil {
+		t.Fatal("bad: expected DialContext to not be nil")
 	}
 }
 


### PR DESCRIPTION
ParseAddress method was not checking the prefix of the previous address correctly. Also hardened the test.