### PR TITLE
PKI: Do not load revoked certificates if CRL has been disabled

### DIFF
--- a/changelog/17385.txt
+++ b/changelog/17385.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Do not read revoked certificates from backend when CRL is disabled
+```


### PR DESCRIPTION
 - Restore the prior behavior of not reading in all revoked certificates if the CRL has been disabled as there might be performance issues if a customer had or is still revoking a lot of certificates.

This is pulling up the missing piece from https://github.com/hashicorp/vault/pull/17384 for main and 1.12. 