### PR TITLE
PKI: Add support for signature_bits param to the intermediate/generate api

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2539,7 +2539,7 @@ func TestBackend_ConsulSignLeafWithLegacyRole(t *testing.T) {
 
 	signedCert := parseCert(t, certAsPem)
 	rootCert := parseCert(t, rootCaPem)
-	requireSignedBy(t, signedCert, rootCert.PublicKey)
+	requireSignedBy(t, signedCert, rootCert)
 }
 
 func TestBackend_SignSelfIssued(t *testing.T) {
@@ -4097,7 +4097,7 @@ func runFullCAChainTest(t *testing.T, keyType string) {
 
 	rootCaCert := parseCert(t, rootCert)
 	intermediaryCaCert := parseCert(t, intermediateCert)
-	requireSignedBy(t, intermediaryCaCert, rootCaCert.PublicKey)
+	requireSignedBy(t, intermediaryCaCert, rootCaCert)
 	intermediateCaChain := intermediateSignedData["ca_chain"].([]string)
 
 	require.Equal(t, parseCert(t, intermediateCaChain[0]), intermediaryCaCert, "intermediate signed cert should have been part of ca_chain")
@@ -4191,7 +4191,7 @@ func runFullCAChainTest(t *testing.T, keyType string) {
 	issuedCrt := parseCert(t, issueCrtAsPem)
 
 	// Verify that the certificates are signed by the intermediary CA key...
-	requireSignedBy(t, issuedCrt, intermediaryCaCert.PublicKey)
+	requireSignedBy(t, issuedCrt, intermediaryCaCert)
 
 	// Test that we can request that the root ca certificate not appear in the ca_chain field
 	resp, err = CBWrite(b_ext, s_ext, "issue/example", map[string]interface{}{

--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -3,7 +3,6 @@ package pki
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -87,6 +86,7 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 		req:     req,
 		apiData: data,
 	}
+
 	parsedBundle, warnings, err := generateIntermediateCSR(sc, input, b.Backend.GetRandomReader())
 	if err != nil {
 		switch err.(type) {
@@ -95,10 +95,6 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 		default:
 			return nil, err
 		}
-	}
-
-	if err = parsedBundle.CSR.CheckSignature(); err != nil {
-		return nil, errors.New("failed signature validation for CSR")
 	}
 
 	csrb, err := parsedBundle.ToCSRBundle()

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -80,11 +80,8 @@ workaround in some compatibility scenarios
 with Active Directory Certificate Services.`,
 	}
 
-	// Signature bits isn't respected on intermediate generation, as this
-	// only impacts the CSR's internal signature and doesn't impact the
-	// signed certificate's bits (that's on the /sign-intermediate
-	// endpoints). Remove it from the list of fields to avoid confusion.
-	delete(ret.Fields, "signature_bits")
+	// At this time Go does not support signing CSRs using PSS signatures, see
+	// https://github.com/golang/go/issues/45990
 	delete(ret.Fields, "use_pss")
 
 	return ret

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -3,17 +3,12 @@ package pki
 import (
 	"context"
 	"crypto"
-	"crypto/ecdsa"
-	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha256"
-	"crypto/sha512"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"hash"
 	"io"
 	"strings"
 	"testing"
@@ -52,64 +47,10 @@ func mountPKIEndpoint(t testing.TB, client *api.Client, path string) {
 }
 
 // Signing helpers
-func requireSignedBy(t *testing.T, cert *x509.Certificate, key crypto.PublicKey) {
-	switch typedKey := key.(type) {
-	case *rsa.PublicKey:
-		requireRSASignedBy(t, cert, typedKey)
-	case *ecdsa.PublicKey:
-		requireECDSASignedBy(t, cert, typedKey)
-	case ed25519.PublicKey:
-		requireED25519SignedBy(t, cert, typedKey)
-	default:
-		require.Fail(t, "unknown public key type %#v", key)
+func requireSignedBy(t *testing.T, cert *x509.Certificate, signingCert *x509.Certificate) {
+	if err := cert.CheckSignatureFrom(signingCert); err != nil {
+		t.Fatalf("signature verification failed: %v", err)
 	}
-}
-
-func requireRSASignedBy(t *testing.T, cert *x509.Certificate, key *rsa.PublicKey) {
-	require.Contains(t, []x509.SignatureAlgorithm{x509.SHA256WithRSA, x509.SHA512WithRSA},
-		cert.SignatureAlgorithm, "only sha256 signatures supported")
-
-	var hasher hash.Hash
-	var hashAlgo crypto.Hash
-
-	switch cert.SignatureAlgorithm {
-	case x509.SHA256WithRSA:
-		hasher = sha256.New()
-		hashAlgo = crypto.SHA256
-	case x509.SHA512WithRSA:
-		hasher = sha512.New()
-		hashAlgo = crypto.SHA512
-	}
-
-	hasher.Write(cert.RawTBSCertificate)
-	hashData := hasher.Sum(nil)
-
-	err := rsa.VerifyPKCS1v15(key, hashAlgo, hashData, cert.Signature)
-	require.NoError(t, err, "the certificate was not signed by the expected public rsa key.")
-}
-
-func requireECDSASignedBy(t *testing.T, cert *x509.Certificate, key *ecdsa.PublicKey) {
-	require.Contains(t, []x509.SignatureAlgorithm{x509.ECDSAWithSHA256, x509.ECDSAWithSHA512},
-		cert.SignatureAlgorithm, "only ecdsa signatures supported")
-
-	var hasher hash.Hash
-	switch cert.SignatureAlgorithm {
-	case x509.ECDSAWithSHA256:
-		hasher = sha256.New()
-	case x509.ECDSAWithSHA512:
-		hasher = sha512.New()
-	}
-
-	hasher.Write(cert.RawTBSCertificate)
-	hashData := hasher.Sum(nil)
-
-	verify := ecdsa.VerifyASN1(key, hashData, cert.Signature)
-	require.True(t, verify, "the certificate was not signed by the expected public ecdsa key.")
-}
-
-func requireED25519SignedBy(t *testing.T, cert *x509.Certificate, key ed25519.PublicKey) {
-	require.Equal(t, x509.PureEd25519, cert.SignatureAlgorithm)
-	ed25519.Verify(key, cert.RawTBSCertificate, cert.Signature)
 }
 
 // Certificate helper

--- a/changelog/17388.txt
+++ b/changelog/17388.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Add support to specify signature bits when generating CSRs through intermediate/generate apis
+```

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -789,7 +789,7 @@ func CreateCertificateWithKeyGenerator(data *CreationBundle, randReader io.Reade
 	return createCertificate(data, randReader, keyGenerator)
 }
 
-// Set correct correct RSA sig algo
+// Set correct RSA sig algo
 func certTemplateSetSigAlgo(certTemplate *x509.Certificate, data *CreationBundle) {
 	if data.Params.UsePSS {
 		switch data.Params.SignatureBits {
@@ -809,6 +809,35 @@ func certTemplateSetSigAlgo(certTemplate *x509.Certificate, data *CreationBundle
 		case 512:
 			certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
 		}
+	}
+}
+
+// selectSignatureAlgorithmForRSA returns the proper x509.SignatureAlgorithm based on various properties set in the
+// Creation Bundle parameter. This method will default to a SHA256 signature algorithm if the requested signature
+// bits is not set/unknown.
+func selectSignatureAlgorithmForRSA(data *CreationBundle) x509.SignatureAlgorithm {
+	if data.Params.UsePSS {
+		switch data.Params.SignatureBits {
+		case 256:
+			return x509.SHA256WithRSAPSS
+		case 384:
+			return x509.SHA384WithRSAPSS
+		case 512:
+			return x509.SHA512WithRSAPSS
+		default:
+			return x509.SHA256WithRSAPSS
+		}
+	}
+
+	switch data.Params.SignatureBits {
+	case 256:
+		return x509.SHA256WithRSA
+	case 384:
+		return x509.SHA384WithRSA
+	case 512:
+		return x509.SHA512WithRSA
+	default:
+		return x509.SHA256WithRSA
 	}
 }
 
@@ -878,7 +907,11 @@ func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGen
 
 	var certBytes []byte
 	if data.SigningBundle != nil {
-		switch data.SigningBundle.PrivateKeyType {
+		privateKeyType := data.SigningBundle.PrivateKeyType
+		if privateKeyType == ManagedPrivateKey {
+			privateKeyType = GetPrivateKeyTypeFromSigner(data.SigningBundle.PrivateKey)
+		}
+		switch privateKeyType {
 		case RSAPrivateKey:
 			certTemplateSetSigAlgo(certTemplate, data)
 		case Ed25519PrivateKey:
@@ -1049,9 +1082,10 @@ func createCSR(data *CreationBundle, addBasicConstraints bool, randReader io.Rea
 
 	switch data.Params.KeyType {
 	case "rsa":
-		csrTemplate.SignatureAlgorithm = x509.SHA256WithRSA
+		// use specified RSA algorithm defaulting to the appropriate SHA256 RSA signature type
+		csrTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(data)
 	case "ec":
-		csrTemplate.SignatureAlgorithm = x509.ECDSAWithSHA256
+		csrTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(result.PrivateKey.Public(), data.Params.SignatureBits)
 	case "ed25519":
 		csrTemplate.SignatureAlgorithm = x509.PureEd25519
 	}

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -1101,6 +1101,10 @@ func createCSR(data *CreationBundle, addBasicConstraints bool, randReader io.Rea
 		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to parse created certificate: %v", err)}
 	}
 
+	if err = result.CSR.CheckSignature(); err != nil {
+		return nil, errors.New("failed signature validation for CSR")
+	}
+
 	return result, nil
 }
 

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1764,6 +1764,16 @@ generated depending on the `type` request parameter.
   name, or by identifier) to use for generating this request. Only suitable
   for `type=existing` requests.
 
+- `signature_bits` `(int: 0)` - Specifies the number of bits to use in
+  the signature algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384,
+  and 512 for SHA-2-512. Defaults to 0 to automatically detect based
+  on key length (SHA-2-256 for RSA keys, and matching the curve size
+  for NIST P-Curves).
+
+~> **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
+`signature_bits` value; only RSA issuers will change signature types
+based on this parameter.
+
 - `exclude_cn_from_sans` `(bool: false)` - If true, the given `common_name` will
   not be included in DNS or Email Subject Alternate Names (as appropriate).
   Useful if the CN is not a hostname or email address, but is instead some

--- a/website/content/docs/secrets/pki/considerations.mdx
+++ b/website/content/docs/secrets/pki/considerations.mdx
@@ -591,7 +591,7 @@ Additionally, some implementations allow rsaPSS OID certificates to contain
 restrictions on signature parameters allowed by this certificate, but Go and
 Vault do not support adding such restrictions.
 
-At this time Go lacks support for generating CSRs that are PSS signed. If
+At this time Go lacks support for CSRs with the PSS signature algorithm. If
 using a GCP managed key with a RSA PSS algorithm as a backing CA key,
 attempting to generate a CSR will fail signature verification. In this case
 the CSR will need to be generated outside of Vault and the signed version

--- a/website/content/docs/secrets/pki/considerations.mdx
+++ b/website/content/docs/secrets/pki/considerations.mdx
@@ -591,6 +591,12 @@ Additionally, some implementations allow rsaPSS OID certificates to contain
 restrictions on signature parameters allowed by this certificate, but Go and
 Vault do not support adding such restrictions.
 
+At this time Go lacks support for generating CSRs that are PSS signed. If
+using a GCP managed key with a RSA PSS algorithm as a backing CA key,
+attempting to generate a CSR will fail signature verification. In this case
+the CSR will need to be generated outside of Vault and the signed version
+can be imported into the mount.
+
 ## Issuer Subjects and CRLs
 
 As noted on several [GitHub issues](https://github.com/hashicorp/vault/issues/10176),


### PR DESCRIPTION
 - Mainly to work properly with GCP backed managed keys, we need to issue signatures that would match the GCP key algorithm.
 
 - At this time due to https://github.com/golang/go/issues/45990 we can't issue PSS signed CSRs, as the libraries in Go always request a PKCS1v15.

 - Add an extra check in intermediate/generate that validates the CSR's signature before providing it back to the client in case we generated a bad signature such as if an end-user used a GCP backed managed key with a RSA PSS algorithm.
   - GCP ignores the requested signature type and always signs with the key's algorithm which can lead to a CSR that says it is signed with a PKCS1v15 algorithm but is actually a RSA PSS signature