### PR TITLE
Replace query-params helper with hash

### DIFF
--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -63,7 +63,7 @@
             @secret=""
             @mode="create"
             @type="add"
-            @queryParams={{query-params initialKey=@model.name itemType="role"}}
+            @queryParams={{hash initialKey=@model.name itemType="role"}}
             data-test-secret-create={{true}}
           >
             Add role

--- a/ui/app/templates/components/database-role-edit.hbs
+++ b/ui/app/templates/components/database-role-edit.hbs
@@ -51,7 +51,7 @@
           @secret={{concat "role/" @model.id}}
           @mode="edit"
           @replace={{true}}
-          @queryParams={{query-params itemType="role"}}
+          @queryParams={{hash itemType="role"}}
           data-test-edit-link={{true}}
         >
           Edit role

--- a/ui/app/templates/components/keymgmt/key-edit.hbs
+++ b/ui/app/templates/components/keymgmt/key-edit.hbs
@@ -102,7 +102,7 @@
             @secret={{@model.id}}
             @mode="edit"
             @replace={{true}}
-            @queryParams={{query-params itemType="key"}}
+            @queryParams={{hash itemType="key"}}
             @data-test-edit-link={{true}}
           >
             Edit key

--- a/ui/app/templates/components/keymgmt/provider-edit.hbs
+++ b/ui/app/templates/components/keymgmt/provider-edit.hbs
@@ -83,7 +83,7 @@
               @secret={{@model.id}}
               @mode="edit"
               @replace={{true}}
-              @queryParams={{query-params itemType="provider"}}
+              @queryParams={{hash itemType="provider"}}
               disabled={{(not @model.canEdit)}}
             >
               Update credentials
@@ -182,7 +182,7 @@
               @title="No keys for this provider"
               @message="Keys for this provider will be listed here. Add a key to get started."
             >
-              <SecretLink @mode="create" @secret="" @queryParams={{query-params itemType="key"}} class="link">
+              <SecretLink @mode="create" @secret="" @queryParams={{hash itemType="key"}} class="link">
                 Create key
               </SecretLink>
             </EmptyState>

--- a/ui/app/templates/components/pki/role-pki-edit.hbs
+++ b/ui/app/templates/components/pki/role-pki-edit.hbs
@@ -35,7 +35,7 @@
         <ToolbarSecretLink
           @secret={{this.model.id}}
           @mode="credentials"
-          @queryParams={{query-params action="issue"}}
+          @queryParams={{hash action="issue"}}
           data-test-credentials-link={{true}}
         >
           Generate Certificate
@@ -45,7 +45,7 @@
         <ToolbarSecretLink
           @secret={{this.model.id}}
           @mode="credentials"
-          @queryParams={{query-params action="sign"}}
+          @queryParams={{hash action="sign"}}
           data-test-sign-link={{true}}
         >
           Sign Certificate

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -248,12 +248,7 @@
           </button>
         </div>
         <div class="control">
-          <SecretLink
-            @mode="show"
-            @secret={{@model.id}}
-            @queryParams={{query-params version=@modelForData.version}}
-            class="button"
-          >
+          <SecretLink @mode="show" @secret={{@model.id}} @queryParams={{hash version=@modelForData.version}} class="button">
             Cancel
           </SecretLink>
         </div>

--- a/ui/app/templates/components/secret-edit-toolbar.hbs
+++ b/ui/app/templates/components/secret-edit-toolbar.hbs
@@ -92,11 +92,7 @@
         {{#if @isV2}}
           <ToolbarLink
             {{! Always create new version from latest if no metadata read access }}
-            @params={{array
-              targetRoute
-              @model.id
-              (query-params version=(if @model.canReadMetadata @modelForData.version ""))
-            }}
+            @params={{array targetRoute @model.id (hash version=(if @model.canReadMetadata @modelForData.version ""))}}
             data-test-secret-edit="true"
             @replace={{true}}
             @type="add"

--- a/ui/app/templates/components/secret-list/transform-list-item.hbs
+++ b/ui/app/templates/components/secret-list/transform-list-item.hbs
@@ -11,7 +11,7 @@
         <SecretLink
           @mode="show"
           @secret={{@itemPath}}
-          @queryParams={{query-params type=@modelType}}
+          @queryParams={{hash type=@modelType}}
           class="has-text-black has-text-weight-semibold"
         >
           <Icon @name="file" class="has-text-grey-light" />

--- a/ui/app/templates/components/secret-list/transform-transformation-item.hbs
+++ b/ui/app/templates/components/secret-list/transform-transformation-item.hbs
@@ -12,7 +12,7 @@
         <SecretLink
           @mode="show"
           @secret={{@item.id}}
-          @queryParams={{if (eq @backendModel.type "transform") (query-params tab="actions") ""}}
+          @queryParams={{if (eq @backendModel.type "transform") (hash tab="actions") ""}}
           class="has-text-black has-text-weight-semibold"
         >
           <Icon @name="file" class="has-text-grey-light" />

--- a/ui/app/templates/components/transit-form-show.hbs
+++ b/ui/app/templates/components/transit-form-show.hbs
@@ -6,7 +6,7 @@
           @secret={{@key.id}}
           @mode="show"
           @replace={{true}}
-          @queryParams={{query-params tab="actions"}}
+          @queryParams={{hash tab="actions"}}
           data-test-transit-key-actions-link={{true}}
         >
           Key Actions
@@ -18,7 +18,7 @@
           @secret={{@key.id}}
           @mode="show"
           @replace={{true}}
-          @queryParams={{query-params tab="details"}}
+          @queryParams={{hash tab="details"}}
           data-test-transit-link="details"
         >
           Details
@@ -30,7 +30,7 @@
           @secret={{@key.id}}
           @mode="show"
           @replace={{true}}
-          @queryParams={{query-params tab="versions"}}
+          @queryParams={{hash tab="versions"}}
           data-test-transit-link="versions"
         >
           Versions

--- a/ui/app/templates/vault/cluster/secrets/backend/list.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/list.hbs
@@ -13,7 +13,7 @@
         @secret=""
         @mode="create"
         @type="add"
-        @queryParams={{query-params initialKey=(or this.filter this.baseKey.id) itemType=this.tab}}
+        @queryParams={{hash initialKey=(or this.filter this.baseKey.id) itemType=this.tab}}
         data-test-secret-create={{true}}
       >
         Create Secret
@@ -76,7 +76,7 @@
             @secret=""
             @mode="create"
             @type="add"
-            @queryParams={{query-params initialKey=(or this.filter this.baseKey.id) itemType=this.tab}}
+            @queryParams={{hash initialKey=(or this.filter this.baseKey.id) itemType=this.tab}}
             data-test-secret-create={{true}}
           >
             {{options.create}}
@@ -136,7 +136,7 @@
             <SecretLink
               @mode="create"
               @secret=""
-              @queryParams={{query-params initialKey=(or this.filter this.baseKey.id) itemType=this.tab}}
+              @queryParams={{hash initialKey=(or this.filter this.baseKey.id) itemType=this.tab}}
               class="link"
             >
               {{options.create}}
@@ -150,7 +150,7 @@
             <SecretLink
               @mode="create"
               @secret=""
-              @queryParams={{query-params initialKey=(or this.filter this.baseKey.id) itemType=this.tab}}
+              @queryParams={{hash initialKey=(or this.filter this.baseKey.id) itemType=this.tab}}
               class="link"
             >
               {{options.create}}

--- a/ui/app/templates/vault/cluster/secrets/backend/overview.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/overview.hbs
@@ -14,7 +14,7 @@
         <SecretLink
           @mode="create"
           @secret=""
-          @queryParams={{query-params initialKey=(or this.filter this.baseKey.id) itemType=this.tab}}
+          @queryParams={{hash initialKey=(or this.filter this.baseKey.id) itemType=this.tab}}
           class="link"
           data-test-secret-create="connections"
         >

--- a/ui/app/templates/vault/cluster/secrets/backend/transit-actions-layout.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/transit-actions-layout.hbs
@@ -17,7 +17,7 @@
             @secret={{this.model.id}}
             @mode="show"
             @replace={{true}}
-            @queryParams={{query-params tab="actions"}}
+            @queryParams={{hash tab="actions"}}
             data-test-transit-link="actions"
           >
             <Icon @name="arrow-left" />
@@ -35,7 +35,7 @@
               <SecretLink
                 @mode="actions"
                 @secret={{this.model.id}}
-                @queryParams={{query-params action=supportedAction.name}}
+                @queryParams={{hash action=supportedAction.name}}
                 data-test-transit-action-link={{supportedAction.name}}
               >
                 {{#if (eq supportedAction.name "export")}}

--- a/ui/app/templates/vault/cluster/secrets/backend/versions.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/versions.hbs
@@ -87,7 +87,7 @@
                   @mode="show"
                   @secret={{this.model.id}}
                   class="has-text-black has-text-weight-semibold"
-                  @queryParams={{query-params version=list.item.version}}
+                  @queryParams={{hash version=list.item.version}}
                 >
                   View version
                   {{list.item.version}}
@@ -98,7 +98,7 @@
                   @mode="edit"
                   @secret={{this.model.id}}
                   class="has-text-black has-text-weight-semibold"
-                  @queryParams={{query-params version=list.item.version}}
+                  @queryParams={{hash version=list.item.version}}
                 >
                   Create new version from
                   {{list.item.version}}


### PR DESCRIPTION
As of Ember version 4.0 [the query-params helper was removed](https://deprecations.emberjs.com/v3.x#toc_ember-glimmer-link-to-positional-arguments) and the `query` arg on `LinkTo` can be passed a simple object. This PR replaces the `query-params` helper with `hash`. 