### PR TITLE
Bug Fix for Kymgmt keyType on default

### DIFF
--- a/changelog/17407.txt
+++ b/changelog/17407.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui/keymgmt: Sets the defaultValue for type when creating a key.
+```

--- a/ui/app/models/keymgmt/key.js
+++ b/ui/app/models/keymgmt/key.js
@@ -24,6 +24,7 @@ export default class KeymgmtKeyModel extends Model {
   @attr('string', {
     subText: 'The type of cryptographic key that will be created.',
     possibleValues: KEY_TYPES,
+    defaultValue: 'rsa-2048',
   })
   type;
 

--- a/ui/tests/integration/components/keymgmt/key-edit-test.js
+++ b/ui/tests/integration/components/keymgmt/key-edit-test.js
@@ -75,4 +75,14 @@ module('Integration | Component | keymgmt/key-edit', function (hooks) {
     assert.dom('[data-test-tab="Details"]').doesNotExist('Details tab does not exist');
     assert.dom('[data-test-tab="Versions"]').doesNotExist('Versions tab does not exist');
   });
+
+  test('it defaults to keyType rsa-2048', async function (assert) {
+    // Catches bug: https://hashicorp.atlassian.net/browse/VAULT-8517
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    this.model = store.createRecord('keymgmt/key');
+    this.set('mode', 'create');
+    await render(hbs`<Keymgmt::KeyEdit @model={{model}} @mode={{mode}} /><div id="modal-wormhole" />`);
+    assert.dom('[data-test-input="type"]').hasValue('rsa-2048', 'Has type rsa-2048 by default');
+  });
 });

--- a/ui/tests/integration/components/keymgmt/key-edit-test.js
+++ b/ui/tests/integration/components/keymgmt/key-edit-test.js
@@ -77,7 +77,6 @@ module('Integration | Component | keymgmt/key-edit', function (hooks) {
   });
 
   test('it defaults to keyType rsa-2048', async function (assert) {
-    // Catches bug: https://hashicorp.atlassian.net/browse/VAULT-8517
     assert.expect(1);
     const store = this.owner.lookup('service:store');
     this.model = store.createRecord('keymgmt/key');


### PR DESCRIPTION
Fixes a bug where the first possibleValue was being populated in the dropdown Key Type but because no change event was triggered on init the `defaultValue` of `rsa-2048` was being sent, not the value shown. Setting the `defaultValue` to match the [API](https://www.vaultproject.io/api-docs/secret/key-management#create-key) fixes this. 

_Note: `defaultValue` is a attr on the ember data model. So though our form-field.hbs component does not set the defaultValue if one is specified, the model automatically adds it because it's an ember attribute._

Ran enterprise test locally and all are passing.