### PR TITLE
Remove LinkTo positional params

### DIFF
--- a/ui/app/templates/components/generated-item-list.hbs
+++ b/ui/app/templates/components/generated-item-list.hbs
@@ -37,9 +37,10 @@
 <Toolbar>
   <ToolbarActions>
     <ToolbarLink
-      data-test-entity-create-link={{this.itemType}}
+      @route="vault.cluster.access.method.item.create"
+      @model={{this.itemType}}
       @type="add"
-      @params={{array "vault.cluster.access.method.item.create" this.itemType}}
+      data-test-entity-create-link={{this.itemType}}
     >
       Create
       {{singularize this.itemType}}

--- a/ui/app/templates/components/generated-item.hbs
+++ b/ui/app/templates/components/generated-item.hbs
@@ -44,7 +44,8 @@
       </ConfirmAction>
       <div class="toolbar-separator"></div>
       <ToolbarLink
-        @params={{array "vault.cluster.access.method.item.edit" this.itemType this.model.id}}
+        @route="vault.cluster.access.method.item.edit"
+        @models={{array this.itemType this.model.id}}
         data-test-configure-link="true"
       >
         Edit

--- a/ui/app/templates/components/identity/entity-nav.hbs
+++ b/ui/app/templates/components/identity/entity-nav.hbs
@@ -26,7 +26,8 @@
   <ToolbarActions>
     {{#if (eq this.identityType "entity")}}
       <ToolbarLink
-        @params={{array "vault.cluster.access.identity.merge" (pluralize this.identityType)}}
+        @route={{"vault.cluster.access.identity.merge"}}
+        @model={{pluralize this.identityType}}
         data-test-entity-merge-link={{true}}
       >
         Merge
@@ -34,8 +35,9 @@
       </ToolbarLink>
     {{/if}}
     <ToolbarLink
+      @route="vault.cluster.access.identity.create"
+      @model={{pluralize this.identityType}}
       @type="add"
-      @params={{array "vault.cluster.access.identity.create" (pluralize this.identityType)}}
       data-test-entity-create-link={{true}}
     >
       Create

--- a/ui/app/templates/components/secret-edit-toolbar.hbs
+++ b/ui/app/templates/components/secret-edit-toolbar.hbs
@@ -92,15 +92,17 @@
         {{#if @isV2}}
           <ToolbarLink
             {{! Always create new version from latest if no metadata read access }}
-            @params={{array targetRoute @model.id (hash version=(if @model.canReadMetadata @modelForData.version ""))}}
-            data-test-secret-edit="true"
+            @route={{targetRoute}}
+            @model={{@model.id}}
+            @query={{hash version=(if @model.canReadMetadata @modelForData.version "")}}
             @replace={{true}}
             @type="add"
+            data-test-secret-edit="true"
           >
             Create new version
           </ToolbarLink>
         {{else}}
-          <ToolbarLink @params={{array targetRoute @model.id}} data-test-secret-edit="true" @replace={{true}}>
+          <ToolbarLink @route={{targetRoute}} @model={{@model.id}} @replace={{true}} data-test-secret-edit="true">
             Edit secret
           </ToolbarLink>
         {{/if}}

--- a/ui/app/templates/vault/cluster/access/control-group-accessor.hbs
+++ b/ui/app/templates/vault/cluster/access/control-group-accessor.hbs
@@ -9,7 +9,7 @@
   {{#if this.model.canConfigure}}
     <Toolbar>
       <ToolbarActions>
-        <ToolbarLink @params={{array "vault.cluster.access.control-groups-configure"}}>
+        <ToolbarLink @route="vault.cluster.access.control-groups-configure">
           Configure
         </ToolbarLink>
       </ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/control-groups.hbs
+++ b/ui/app/templates/vault/cluster/access/control-groups.hbs
@@ -9,7 +9,7 @@
   {{#if this.model.canConfigure}}
     <Toolbar>
       <ToolbarActions>
-        <ToolbarLink @params={{array "vault.cluster.access.control-groups-configure"}}>
+        <ToolbarLink @route="vault.cluster.access.control-groups-configure">
           Configure
         </ToolbarLink>
       </ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/identity/aliases/show.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/show.hbs
@@ -30,10 +30,7 @@
 </div>
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink
-      @params={{array "vault.cluster.access.identity.aliases.edit" this.model.id}}
-      data-test-alias-edit-link={{true}}
-    >
+    <ToolbarLink @route="vault.cluster.access.identity.aliases.edit" @model={{this.model.id}} data-test-alias-edit-link>
       Edit
       {{lowercase (humanize this.model.identityType)}}
     </ToolbarLink>

--- a/ui/app/templates/vault/cluster/access/identity/show.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/show.hbs
@@ -37,15 +37,17 @@
     {{! template-lint-configure simple-unless "warn" }}
     {{#unless (or (and (eq this.model.identityType "group") (eq this.model.type "internal")) this.model.alias)}}
       <ToolbarLink
+        @route="vault.cluster.access.identity.aliases.add"
+        @models={{array (pluralize this.model.identityType) this.model.id}}
         @type="add"
-        @params={{array "vault.cluster.access.identity.aliases.add" (pluralize this.model.identityType) this.model.id}}
         data-test-entity-create-link={{true}}
       >
         Add alias
       </ToolbarLink>
     {{/unless}}
     <ToolbarLink
-      @params={{array "vault.cluster.access.identity.edit" (pluralize this.model.identityType) this.model.id}}
+      @route="vault.cluster.access.identity.edit"
+      @models={{array (pluralize this.model.identityType) this.model.id}}
       data-test-entity-edit-link={{true}}
     >
       Edit

--- a/ui/app/templates/vault/cluster/access/method/section.hbs
+++ b/ui/app/templates/vault/cluster/access/method/section.hbs
@@ -31,7 +31,7 @@
 {{#if (eq this.section "configuration")}}
   <Toolbar>
     <ToolbarActions>
-      <ToolbarLink @params={{array "vault.cluster.settings.auth.configure" this.model.id}} data-test-configure-link="true">
+      <ToolbarLink @route="vault.cluster.settings.auth.configure" @model={{this.model.id}} data-test-configure-link="true">
         Configure
       </ToolbarLink>
     </ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/methods.hbs
+++ b/ui/app/templates/vault/cluster/access/methods.hbs
@@ -8,7 +8,7 @@
 
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink @type="add" @params={{array "vault.cluster.settings.auth.enable"}} data-test-auth-enable>
+    <ToolbarLink @route="vault.cluster.settings.auth.enable" @type="add" data-test-auth-enable>
       Enable new method
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/mfa/enforcements/enforcement/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/enforcements/enforcement/index.hbs
@@ -50,8 +50,9 @@
     </button>
     <div class="toolbar-separator"></div>
     <ToolbarLink
-      @params={{array "vault.cluster.access.mfa.enforcements.enforcement.edit" this.model.id}}
-      data-test-enforcement-edit={{true}}
+      @route="vault.cluster.access.mfa.enforcements.enforcement.edit"
+      @model={{this.model.id}}
+      data-test-enforcement-edit
     >
       Edit enforcement
     </ToolbarLink>

--- a/ui/app/templates/vault/cluster/access/mfa/enforcements/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/enforcements/index.hbs
@@ -10,11 +10,7 @@
 
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink
-      @type="add"
-      @params={{array "vault.cluster.access.mfa.enforcements.create"}}
-      data-test-enforcement-create={{true}}
-    >
+    <ToolbarLink @route="vault.cluster.access.mfa.enforcements.create" @type="add" data-test-enforcement-create>
       New enforcement
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/mfa/methods/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/index.hbs
@@ -10,7 +10,7 @@
 
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink @type="add" @params={{array "vault.cluster.access.mfa.methods.create"}} data-test-mfa-method-create>
+    <ToolbarLink @route="vault.cluster.access.mfa.methods.create" @type="add" data-test-mfa-method-create>
       New MFA method
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/mfa/methods/method/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/method/index.hbs
@@ -50,7 +50,8 @@
         Delete
       </ConfirmAction>
       <ToolbarLink
-        @params={{array "vault.cluster.access.mfa.methods.method.edit" this.model.method.id}}
+        @route="vault.cluster.access.mfa.methods.method.edit"
+        @model={{this.model.method.id}}
         data-test-mfa-method-edit
       >
         Edit

--- a/ui/app/templates/vault/cluster/access/namespaces/index.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/index.hbs
@@ -9,7 +9,7 @@
 
   <Toolbar>
     <ToolbarActions>
-      <ToolbarLink @type="add" @params={{array "vault.cluster.access.namespaces.create"}}>
+      <ToolbarLink @route="vault.cluster.access.namespaces.create" @type="add">
         Create namespace
       </ToolbarLink>
     </ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/assignments/assignment/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/assignments/assignment/details.hbs
@@ -49,7 +49,8 @@
     {{/if}}
     {{#if @model.canEdit}}
       <ToolbarLink
-        @params={{array "vault.cluster.access.oidc.assignments.assignment.edit" @model.name}}
+        @route="vault.cluster.access.oidc.assignments.assignment.edit"
+        @model={{@model.name}}
         data-test-oidc-assignment-edit
       >
         Edit assignment

--- a/ui/app/templates/vault/cluster/access/oidc/assignments/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/assignments/index.hbs
@@ -1,10 +1,6 @@
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink
-      @type="add"
-      @params={{array "vault.cluster.access.oidc.assignments.create"}}
-      data-test-oidc-assignment-create
-    >
+    <ToolbarLink @route="vault.cluster.access.oidc.assignments.create" @type="add" data-test-oidc-assignment-create>
       Create assignment
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/clients/client/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/clients/client/details.hbs
@@ -15,8 +15,9 @@
     {{/if}}
     {{#if this.model.canEdit}}
       <ToolbarLink
+        @route="vault.cluster.access.oidc.clients.client.edit"
+        @model={{this.model.name}}
         data-test-oidc-client-edit
-        @params={{array "vault.cluster.access.oidc.clients.client.edit" this.model.name}}
       >
         Edit application
       </ToolbarLink>

--- a/ui/app/templates/vault/cluster/access/oidc/clients/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/clients/index.hbs
@@ -1,6 +1,6 @@
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink data-test-oidc-client-create @type="add" @params={{array "vault.cluster.access.oidc.clients.create"}}>
+    <ToolbarLink @route="vault.cluster.access.oidc.clients.create" @type="add" data-test-oidc-client-create>
       Create application
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/keys/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/index.hbs
@@ -1,6 +1,6 @@
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink data-test-oidc-key-create @type="add" @params={{array "vault.cluster.access.oidc.keys.create"}}>
+    <ToolbarLink @route="vault.cluster.access.oidc.keys.create" @type="add" data-test-oidc-key-create>
       Create key
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/keys/key/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/key/details.hbs
@@ -39,7 +39,7 @@
       </ConfirmAction>
     {{/if}}
     {{#if this.model.canEdit}}
-      <ToolbarLink data-test-oidc-key-edit @params={{array "vault.cluster.access.oidc.keys.key.edit" this.model.name}}>
+      <ToolbarLink @route="vault.cluster.access.oidc.keys.key.edit" @model={{this.model.name}} data-test-oidc-key-edit>
         Edit key
       </ToolbarLink>
     {{/if}}

--- a/ui/app/templates/vault/cluster/access/oidc/providers/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/index.hbs
@@ -1,6 +1,6 @@
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink data-test-oidc-provider-create @type="add" @params={{array "vault.cluster.access.oidc.providers.create"}}>
+    <ToolbarLink @route="vault.cluster.access.oidc.providers.create" @type="add" data-test-oidc-provider-create>
       Create provider
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/providers/provider/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/provider/details.hbs
@@ -27,8 +27,9 @@
     {{/if}}
     {{#if this.model.canEdit}}
       <ToolbarLink
+        @route="vault.cluster.access.oidc.providers.provider.edit"
+        @model={{this.model.name}}
         data-test-oidc-provider-edit
-        @params={{array "vault.cluster.access.oidc.providers.provider.edit" this.model.name}}
       >
         Edit provider
       </ToolbarLink>

--- a/ui/app/templates/vault/cluster/access/oidc/scopes/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/scopes/index.hbs
@@ -1,6 +1,6 @@
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink @type="add" @params={{array "vault.cluster.access.oidc.scopes.create"}} data-test-oidc-scope-create>
+    <ToolbarLink @route="vault.cluster.access.oidc.scopes.create" @type="add" data-test-oidc-scope-create>
       Create scope
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/scopes/scope/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/scopes/scope/details.hbs
@@ -44,7 +44,7 @@
       <div class="toolbar-separator"></div>
     {{/if}}
     {{#if this.model.canEdit}}
-      <ToolbarLink data-test-oidc-scope-edit @params={{array "vault.cluster.access.oidc.scopes.scope.edit" this.model.name}}>
+      <ToolbarLink @route="vault.cluster.access.oidc.scopes.scope.edit" @model={{this.model.name}} data-test-oidc-scope-edit>
         Edit scope
       </ToolbarLink>
     {{/if}}

--- a/ui/app/templates/vault/cluster/policies/index.hbs
+++ b/ui/app/templates/vault/cluster/policies/index.hbs
@@ -44,7 +44,7 @@
       </ToolbarFilters>
     {{/if}}
     <ToolbarActions>
-      <ToolbarLink @type="add" @params={{array "vault.cluster.policies.create"}} data-test-policy-create-link={{true}}>
+      <ToolbarLink @route="vault.cluster.policies.create" @type="add" data-test-policy-create-link>
         Create
         {{uppercase this.policyType}}
         policy

--- a/ui/app/templates/vault/cluster/policy/edit.hbs
+++ b/ui/app/templates/vault/cluster/policy/edit.hbs
@@ -35,7 +35,7 @@
         </ConfirmAction>
         <div class="toolbar-separator"></div>
       {{/if}}
-      <ToolbarLink @params={{array "vault.cluster.policy.show" this.model.id}} data-test-policy-edit-toggle={{true}}>
+      <ToolbarLink @route="vault.cluster.policy.show" @model={{this.model.id}} data-test-policy-edit-toggle>
         Back to policy
       </ToolbarLink>
     </ToolbarActions>

--- a/ui/app/templates/vault/cluster/policy/show.hbs
+++ b/ui/app/templates/vault/cluster/policy/show.hbs
@@ -30,7 +30,7 @@
       @data={{this.model.policy}}
     />
     {{#if (and (not-eq this.model.id "root") (or this.capabilities.canUpdate this.capabilities.canDelete))}}
-      <ToolbarLink @params={{array "vault.cluster.policy.edit" this.model.id}} data-test-policy-edit-toggle={{true}}>
+      <ToolbarLink @route="vault.cluster.policy.edit" @model={{this.model.id}} data-test-policy-edit-toggle>
         Edit policy
       </ToolbarLink>
     {{/if}}

--- a/ui/app/templates/vault/cluster/secrets/backend/configuration.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/configuration.hbs
@@ -13,8 +13,9 @@
   <Toolbar>
     <ToolbarActions>
       <ToolbarLink
-        @params={{array "vault.cluster.settings.configure-secret-backend" this.model.id}}
-        data-test-secret-backend-configure={{true}}
+        @route="vault.cluster.settings.configure-secret-backend"
+        @model={{this.model.id}}
+        data-test-secret-backend-configure
       >
         Configure
       </ToolbarLink>

--- a/ui/app/templates/vault/cluster/secrets/backend/metadata.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/metadata.hbs
@@ -32,7 +32,7 @@
   {{! You must have update on metadata, create is not enough. }}
   {{#if this.model.canUpdateMetadata}}
     <ToolbarActions>
-      <ToolbarLink @params={{array "vault.cluster.secrets.backend.edit-metadata" this.id}}>
+      <ToolbarLink @route="vault.cluster.secrets.backend.edit-metadata" @model={{this.id}}>
         Edit metadata
       </ToolbarLink>
     </ToolbarActions>

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -8,11 +8,7 @@
 
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink
-      @type="add"
-      @params={{array "vault.cluster.settings.mount-secret-backend"}}
-      data-test-enable-engine={{true}}
-    >
+    <ToolbarLink @route="vault.cluster.settings.mount-secret-backend" @type="add" data-test-enable-engine>
       Enable new engine
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/app/templates/vault/cluster/settings/auth/configure.hbs
+++ b/ui/app/templates/vault/cluster/settings/auth/configure.hbs
@@ -14,7 +14,7 @@
 
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink @params={{array "vault.cluster.access.method" this.model.id}} data-test-backend-view-link={{true}}>
+    <ToolbarLink @route="vault.cluster.access.method" @model={{this.model.id}} data-test-backend-view-link>
       View method
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/app/templates/vault/cluster/settings/configure-secret-backend.hbs
+++ b/ui/app/templates/vault/cluster/settings/configure-secret-backend.hbs
@@ -17,7 +17,7 @@
 
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink @params={{array "vault.cluster.secrets.backend" this.model.id}} data-test-backend-view-link={{true}}>
+    <ToolbarLink @route="vault.cluster.secrets.backend" @model={{this.model.id}} data-test-backend-view-link>
       View backend
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/lib/core/addon/components/toolbar-actions.js
+++ b/ui/lib/core/addon/components/toolbar-actions.js
@@ -7,7 +7,7 @@
  * ```js
  * <Toolbar>
  *   <ToolbarActions>
- *     <ToolbarLink @params={{array 'vault.cluster.policy.edit'}}>
+ *     <ToolbarLink @route="vault.cluster.policy.edit">
  *       Edit policy
  *     </ToolbarLink>
  *   </ToolbarActions>

--- a/ui/lib/core/addon/components/toolbar-link.hbs
+++ b/ui/lib/core/addon/components/toolbar-link.hbs
@@ -7,6 +7,7 @@
         @route={{@route}}
         @models={{this.models}}
         @query={{this.query}}
+        @replace={{@replace}}
         @disabled={{@disabled}}
       >
         {{yield}}
@@ -26,6 +27,7 @@
     @route={{@route}}
     @models={{this.models}}
     @query={{this.query}}
+    @replace={{@replace}}
     @disabled={{@disabled}}
   >
     {{yield}}

--- a/ui/lib/core/addon/components/toolbar-link.hbs
+++ b/ui/lib/core/addon/components/toolbar-link.hbs
@@ -1,25 +1,34 @@
-{{#let
-  (component "link-to" class="toolbar-link" disabled=@disabled route=this.route models=this.models)
-  as |LinkToComponent|
-}}
-  {{#if (and @disabled @disabledTooltip)}}
-    <ToolTip @verticalPosition="above" as |T|>
-      <T.Trigger tabindex="-1">
-        <LinkToComponent ...attributes>
-          {{yield}}
-          <Icon @name={{this.glyph}} data-test-icon={{this.glyph}} />
-        </LinkToComponent>
-      </T.Trigger>
-      <T.Content @defaultClass="tool-tip smaller-font">
-        <div class="box" data-test-disabled-tooltip>
-          {{@disabledTooltip}}
-        </div>
-      </T.Content>
-    </ToolTip>
-  {{else}}
-    <LinkToComponent ...attributes>
-      {{yield}}
-      <Icon @name={{this.glyph}} data-test-icon={{this.glyph}} />
-    </LinkToComponent>
-  {{/if}}
-{{/let}}
+{{#if (and @disabled @disabledTooltip)}}
+  <ToolTip @verticalPosition="above" as |T|>
+    <T.Trigger tabindex="-1">
+      <LinkTo
+        class="toolbar-link"
+        ...attributes
+        @route={{@route}}
+        @models={{this.models}}
+        @query={{this.query}}
+        @disabled={{@disabled}}
+      >
+        {{yield}}
+        <Icon @name={{this.glyph}} data-test-icon={{this.glyph}} />
+      </LinkTo>
+    </T.Trigger>
+    <T.Content @defaultClass="tool-tip smaller-font">
+      <div class="box" data-test-disabled-tooltip>
+        {{@disabledTooltip}}
+      </div>
+    </T.Content>
+  </ToolTip>
+{{else}}
+  <LinkTo
+    class="toolbar-link"
+    ...attributes
+    @route={{@route}}
+    @models={{this.models}}
+    @query={{this.query}}
+    @disabled={{@disabled}}
+  >
+    {{yield}}
+    <Icon @name={{this.glyph}} data-test-icon={{this.glyph}} />
+  </LinkTo>
+{{/if}}

--- a/ui/lib/core/addon/components/toolbar-link.js
+++ b/ui/lib/core/addon/components/toolbar-link.js
@@ -8,14 +8,18 @@ import Component from '@glimmer/component';
  * ```js
  * <Toolbar>
  *   <ToolbarActions>
- *     <ToolbarLink @params={{array 'vault.cluster.policies.create'}} @type="add" @disabled={{true}} @disabledTooltip="This link is disabled">
+ *     <ToolbarLink @route="vault.cluster.policies.create" @type="add" @disabled={{true}} @disabledTooltip="This link is disabled">
  *       Create policy
  *     </ToolbarLink>
  *   </ToolbarActions>
  * </Toolbar>
  * ```
  *
- * @param {array} params - Array to pass to LinkTo
+ * @param {string} route - route to pass to LinkTo
+ * @param {Model} model - model to pass to LinkTo
+ * @param {Array} models - array of models to pass to LinkTo
+ * @param {Object} query - query params to pass to LinkTo
+ * @param {boolean} replace - replace arg to pass to LinkTo
  * @param {string} type - Use "add" to change icon
  * @param {boolean} disabled - pass true to disable link
  * @param {string} disabledTooltip - tooltip to display on hover when disabled
@@ -25,13 +29,14 @@ export default class ToolbarLinkComponent extends Component {
   get glyph() {
     return this.args.type == 'add' ? 'plus' : 'chevron-right';
   }
-  // TODO JR: temporary workaround for params no longer supported on LinkTo
-  // args should be added for individual LinkTo args
-  get route() {
-    return this.args.params[0];
-  }
   get models() {
-    const [route, ...models] = this.args.params; // eslint-disable-line
-    return models;
+    const { model, models } = this.args;
+    if (model) {
+      return [model];
+    }
+    return models || [];
+  }
+  get query() {
+    return this.args.query || {};
   }
 }

--- a/ui/lib/core/addon/templates/components/replication-summary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-summary-card.hbs
@@ -6,7 +6,7 @@
   {{#if (eq this.title "Disaster Recovery")}}
     <h3 class="title is-5 grid-item-top-left card-title">{{this.title}}</h3>
     <div class="grid-item-top-right">
-      <ToolbarLink @params={{array "mode.index" "dr"}} data-test-manage-link={{this.title}}>
+      <ToolbarLink @route="mode.index" @model="dr" data-test-manage-link={{this.title}}>
         Details
       </ToolbarLink>
     </div>
@@ -30,7 +30,7 @@
   {{else}}
     <h3 class="title is-5 grid-item-top-left card-title">{{this.title}}</h3>
     <div class="grid-item-top-right">
-      <ToolbarLink @params={{array "mode.index" "performance"}} data-test-manage-link={{this.title}}>
+      <ToolbarLink @route="mode.index" @model="performance" data-test-manage-link={{this.title}}>
         Details
       </ToolbarLink>
     </div>

--- a/ui/lib/kmip/addon/templates/configuration.hbs
+++ b/ui/lib/kmip/addon/templates/configuration.hbs
@@ -9,7 +9,7 @@
         @data={{this.model.ca.caPem}}
       />
     {{/if}}
-    <ToolbarLink @params={{array "configure"}} data-test-kmip-link-configure>
+    <ToolbarLink @route="configure" data-test-kmip-link-configure>
       Configure
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/lib/kmip/addon/templates/credentials/index.hbs
+++ b/ui/lib/kmip/addon/templates/credentials/index.hbs
@@ -35,7 +35,7 @@
     </ToolbarFilters>
   {{/if}}
   <ToolbarActions>
-    <ToolbarLink @type="add" @params={{array "credentials.generate"}} data-test-kmip-link-generate-credentials>
+    <ToolbarLink @route={{"credentials.generate"}} @type="add" data-test-kmip-link-generate-credentials>
       Generate credentials
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/lib/kmip/addon/templates/credentials/show.hbs
+++ b/ui/lib/kmip/addon/templates/credentials/show.hbs
@@ -23,7 +23,7 @@
       </ConfirmAction>
       <div class="toolbar-separator"></div>
     {{/if}}
-    <ToolbarLink @params={{array "credentials.index" this.scope this.role}} data-test-kmip-link-back-to-role>
+    <ToolbarLink @route="credentials.index" @models={{array this.scope this.role}} data-test-kmip-link-back-to-role>
       Back to role
     </ToolbarLink>
     <CopyButton

--- a/ui/lib/kmip/addon/templates/role.hbs
+++ b/ui/lib/kmip/addon/templates/role.hbs
@@ -13,7 +13,7 @@
       <div class="toolbar-separator"></div>
     {{/if}}
     {{#if this.model.updatePath.canUpdate}}
-      <ToolbarLink @params={{array "role.edit" this.scope this.role}} data-test-kmip-link-edit-role>
+      <ToolbarLink @route="role.edit" @models={{array this.scope this.role}} data-test-kmip-link-edit-role>
         Edit role
       </ToolbarLink>
     {{/if}}

--- a/ui/lib/kmip/addon/templates/scope/roles.hbs
+++ b/ui/lib/kmip/addon/templates/scope/roles.hbs
@@ -45,7 +45,7 @@
     </ToolbarFilters>
   {{/if}}
   <ToolbarActions>
-    <ToolbarLink @type="add" @params={{array "scope.roles.create"}} data-test-role-create>
+    <ToolbarLink @route="scope.roles.create" @type="add" data-test-role-create>
       Create role
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/lib/kmip/addon/templates/scopes/index.hbs
+++ b/ui/lib/kmip/addon/templates/scopes/index.hbs
@@ -34,7 +34,7 @@
     </ToolbarFilters>
   {{/if}}
   <ToolbarActions>
-    <ToolbarLink @type="add" @params={{array "scopes.create"}} data-test-scope-create>
+    <ToolbarLink @route="scopes.create" @type="add" data-test-scope-create>
       Create scope
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
+++ b/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
@@ -1,7 +1,7 @@
 <div class="selectable-card is-rounded secondaries">
   <div class="level">
     <h3 class="card-title title is-5">{{this.replicationAttrs.secondaries.length}} Known Secondaries</h3>
-    <ToolbarLink @params={{array "mode.secondaries" this.cluster.replicationMode}} data-test-manage-link={{true}}>
+    <ToolbarLink @route="mode.secondaries" @model={{this.cluster.replicationMode}} data-test-manage-link>
       View all
     </ToolbarLink>
   </div>

--- a/ui/lib/replication/addon/templates/mode/secondaries/config-show.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/config-show.hbs
@@ -2,14 +2,16 @@
   <ToolbarActions>
     {{#if this.model.config.mode}}
       <ToolbarLink
-        @params={{array "mode.secondaries.config-edit" this.model.config.id}}
+        @route="mode.secondaries.config-edit"
+        @model={{this.model.config.id}}
         data-test-replication-link="edit-mount-config"
       >
         Edit config
       </ToolbarLink>
     {{else}}
       <ToolbarLink
-        @params={{array "mode.secondaries.config-create" this.model.config.id}}
+        @route="mode.secondaries.config-create"
+        @params={{this.model.config.id}}
         data-test-replication-link="create-mount-config"
       >
         Create config

--- a/ui/lib/replication/addon/templates/mode/secondaries/index.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/index.hbs
@@ -3,17 +3,13 @@
     <ToolbarActions>
       {{#if this.model.replicationAttrs.knownSecondaries.length}}
         {{#if this.model.canRevokeSecondary}}
-          <ToolbarLink @params={{array "mode.secondaries.revoke" this.replicationMode}}>
+          <ToolbarLink @route="mode.secondaries.revoke" @model={{this.replicationMode}}>
             Revoke secondary
           </ToolbarLink>
         {{/if}}
       {{/if}}
       {{#if this.model.canAddSecondary}}
-        <ToolbarLink
-          @type="add"
-          @params={{array "mode.secondaries.add" this.replicationMode}}
-          data-test-secondary-add={{true}}
-        >
+        <ToolbarLink @route="mode.secondaries.add" @model={{this.replicationMode}} @type="add" data-test-secondary-add>
           Add secondary
         </ToolbarLink>
       {{/if}}

--- a/ui/package.json
+++ b/ui/package.json
@@ -98,7 +98,7 @@
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-mirage": "2.4.0",
-    "ember-cli-page-object": "1.17.9",
+    "ember-cli-page-object": "1.17.10",
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "meirish/ember-cli-sri#rooturl",
     "ember-cli-string-helpers": "6.1.0",

--- a/ui/tests/integration/components/toolbar-link-test.js
+++ b/ui/tests/integration/components/toolbar-link-test.js
@@ -8,7 +8,7 @@ module('Integration | Component | toolbar-link', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
-    await render(hbs`<ToolbarLink @params={{array '/secrets'}}>Link</ToolbarLink>`);
+    await render(hbs`<ToolbarLink @route="/secrets">Link</ToolbarLink>`);
 
     assert.dom(this.element).hasText('Link');
     assert.ok(isPresent('.toolbar-link'));
@@ -20,7 +20,7 @@ module('Integration | Component | toolbar-link', function (hooks) {
 
     await render(hbs`
       <ToolbarLink
-        @params={{array '/secrets'}}
+        @route="/secrets"
         @type={{this.type}}
       >
         Test Link
@@ -37,7 +37,7 @@ module('Integration | Component | toolbar-link', function (hooks) {
 
     await render(hbs`
       <ToolbarLink
-        @params={{array '/secrets'}}
+        @route="/secrets"
         @disabled={{true}}
         @disabledTooltip={{this.tooltip}}
       >

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -8663,7 +8663,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, em
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0:
+ember-cli-babel@^6.6.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -8682,7 +8682,7 @@ ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.20.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.0, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.26.8, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.20.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.0, ember-cli-babel@^7.26.1, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.26.8, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.3:
   version "7.26.11"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz#50da0fe4dcd99aada499843940fec75076249a9f"
   integrity sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==
@@ -8914,15 +8914,15 @@ ember-cli-normalize-entity-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-page-object@1.17.9:
-  version "1.17.9"
-  resolved "https://registry.yarnpkg.com/ember-cli-page-object/-/ember-cli-page-object-1.17.9.tgz#d5d730661755083987db599732d24145b9f25521"
-  integrity sha512-c2pMCuPRM0x/eO8Ot3NDesebdJGlNPwwOWAtXsXH339j/TDeh2DIz2sGJNnmZkFqEsdTqgVq2rkmGzmd7i1xeg==
+ember-cli-page-object@1.17.10:
+  version "1.17.10"
+  resolved "https://registry.yarnpkg.com/ember-cli-page-object/-/ember-cli-page-object-1.17.10.tgz#a3145c7b0341e6180dab28e10c858f8b6535e66a"
+  integrity sha512-J7OQZ4IWftHLunsCicFbaVb/GrI+/DMWMPO5EAca9+0x9K+rxml351Tl1Z/Fpr8UmHg1q/KGwqGx9xGodrRxbg==
   dependencies:
     broccoli-file-creator "^2.1.1"
     broccoli-merge-trees "^2.0.0"
     ceibo "~2.0.0"
-    ember-cli-babel "^6.16.0"
+    ember-cli-babel "^7.26.1"
     ember-cli-node-assets "^0.2.2"
     ember-native-dom-helpers "^0.7.0"
     jquery "^3.4.1"


### PR DESCRIPTION
In Ember 4.0 [positional parameters were removed](https://deprecations.emberjs.com/v3.x#toc_ember-glimmer-link-to-positional-arguments) from the LinkTo component. In #17396 I implemented a temporary workaround for the `ToolbarLink` component to take the array from the `params` arg and split it up into respective values. This PR updates the component to accept the same args as `LinkTo` to make it apparent that positional parameters are no longer supported. 