### PR TITLE
Clean up js lint errors

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
     browser: true,
   },
   rules: {
-    'no-console': 'warn',
+    'no-console': 'error',
     'ember/no-mixins': 'warn',
     'ember/no-new-mixins': 'off', // should be warn but then every line of the mixin is green
     // need to be fully glimmerized before these rules can be turned on

--- a/ui/.template-lintrc.js
+++ b/ui/.template-lintrc.js
@@ -29,7 +29,7 @@ try {
     prettier: false,
   };
 } catch (error) {
-  console.log(error);
+  console.log(error); // eslint-disable-line
 }
 
 module.exports = {

--- a/ui/app/components/calendar-widget.js
+++ b/ui/app/components/calendar-widget.js
@@ -88,7 +88,7 @@ class CalendarWidget extends Component {
         const year = this.args.endTimeDisplay.split(' ')[1];
         setYear = parseInt(year);
       } catch (e) {
-        console.debug('Error resetting display year', e);
+        console.debug('Error resetting display year', e); // eslint-disable-line
       }
     }
     this.displayYear = setYear;

--- a/ui/app/components/clients/line-chart.js
+++ b/ui/app/components/clients/line-chart.js
@@ -49,9 +49,10 @@ export default class LineChart extends Component {
     const upgradeData = this.args.upgradeData;
     if (!upgradeData) return null;
     if (!Array.isArray(upgradeData)) {
-      console.debug('upgradeData must be an array of objects containing upgrade history');
+      console.debug('upgradeData must be an array of objects containing upgrade history'); // eslint-disable-line
       return null;
     } else if (!Object.keys(upgradeData[0]).includes('timestampInstalled')) {
+      // eslint-disable-next-line
       console.debug(
         `upgrade must be an object with the following key names: ['id', 'previousVersion', 'timestampInstalled']`
       );

--- a/ui/app/components/database-role-edit.js
+++ b/ui/app/components/database-role-edit.js
@@ -70,7 +70,7 @@ export default class DatabaseRoleEdit extends Component {
         try {
           this.router.transitionTo(LIST_ROOT_ROUTE, backend, { queryParams: { tab: 'role' } });
         } catch (e) {
-          console.debug(e);
+          console.debug(e); // eslint-disable-line
         }
       })
       .catch((e) => {
@@ -97,7 +97,7 @@ export default class DatabaseRoleEdit extends Component {
         try {
           this.router.transitionTo(SHOW_ROUTE, `role/${secretId}`);
         } catch (e) {
-          console.debug(e);
+          console.debug(e); // eslint-disable-line
         }
       })
       .catch((e) => {

--- a/ui/app/components/oidc-consent-block.js
+++ b/ui/app/components/oidc-consent-block.js
@@ -34,7 +34,7 @@ export default class OidcConsentBlockComponent extends Component {
       });
       return url;
     } catch (e) {
-      console.debug('DEBUG: parsing url failed for', urlString);
+      console.debug('DEBUG: parsing url failed for', urlString); // eslint-disable-line
       throw new Error('Invalid URL');
     }
   }

--- a/ui/app/helpers/parse-pki-cert.js
+++ b/ui/app/helpers/parse-pki-cert.js
@@ -16,7 +16,7 @@ export function parsePkiCert([model]) {
     let cert_asn1 = asn1js.fromBER(stringToArrayBuffer(cert_der));
     cert = new Certificate({ schema: cert_asn1.result });
   } catch (error) {
-    console.debug('DEBUG: Parsing Certificate', error);
+    console.debug('DEBUG: Parsing Certificate', error); // eslint-disable-line
     return {
       can_parse: false,
     };

--- a/ui/app/routes/vault/cluster/clients.js
+++ b/ui/app/routes/vault/cluster/clients.js
@@ -20,14 +20,14 @@ export default class ClientsRoute extends Route {
       });
       return arrayOfModels;
     } catch (e) {
-      console.debug(e);
+      console.debug(e); // eslint-disable-line
       return [];
     }
   }
 
   async model() {
     let config = await this.store.queryRecord('clients/config', {}).catch((e) => {
-      console.debug(e);
+      console.debug(e); // eslint-disable-line
       // swallowing error so activity can show if no config permissions
       return {};
     });

--- a/ui/app/routes/vault/cluster/oidc-provider.js
+++ b/ui/app/routes/vault/cluster/oidc-provider.js
@@ -81,7 +81,7 @@ export default class VaultClusterOidcProviderRoute extends Route {
       });
       return url;
     } catch (e) {
-      console.debug('DEBUG: parsing url failed for', urlString);
+      console.debug('DEBUG: parsing url failed for', urlString); // eslint-disable-line
       throw new Error('Invalid URL');
     }
   }

--- a/ui/app/services/path-help.js
+++ b/ui/app/services/path-help.js
@@ -93,7 +93,7 @@ export default Service.extend({
       })
       .catch((err) => {
         // TODO: we should handle the error better here
-        console.error(err);
+        console.error(err); // eslint-disable-line
       });
   },
 

--- a/ui/lib/core/addon/components/replication-dashboard.js
+++ b/ui/lib/core/addon/components/replication-dashboard.js
@@ -82,7 +82,7 @@ export default Component.extend({
       // when DR and Performance is enabled on the same cluster,
       // the states should always be the same
       // we are leaving this console log statement to be sure
-      console.log('DR State: ', drState, 'Performance State: ', performanceState);
+      console.log('DR State: ', drState, 'Performance State: ', performanceState); // eslint-disable-line
     }
 
     return drState;

--- a/ui/lib/core/addon/helpers/changelog-url-for.js
+++ b/ui/lib/core/addon/helpers/changelog-url-for.js
@@ -25,8 +25,8 @@ export function changelogUrlFor([version]) {
       return url.concat(versionNumber);
     }
   } catch (e) {
-    console.log(e);
-    console.log('Cannot generate URL for version: ', version);
+    console.log(e); // eslint-disable-line
+    console.log('Cannot generate URL for version: ', version); // eslint-disable-line
   }
   return url;
 }

--- a/ui/lib/service-worker-authenticated-download/service-worker-registration/index.js
+++ b/ui/lib/service-worker-authenticated-download/service-worker-registration/index.js
@@ -16,11 +16,11 @@ addSuccessHandler(function (registration) {
     if (action === 'getToken') {
       let token = getToken();
       if (!token) {
-        console.error('Unable to retrieve Vault tokent');
+        console.error('Unable to retrieve Vault tokent'); // eslint-disable-line
       }
       port.postMessage({ token: token });
     } else {
-      console.error('Unknown event', event);
+      console.error('Unknown event', event); // eslint-disable-line
       port.postMessage({
         error: 'Unknown request',
       });

--- a/ui/mirage/handlers/mfa-login.js
+++ b/ui/mirage/handlers/mfa-login.js
@@ -38,7 +38,7 @@ export const validationHandler = (schema, req) => {
               limit:
                 'maximum TOTP validation attempts 4 exceeded the allowed attempts 3. Please try again in 15 seconds',
             }[passcode] || 'failed to validate';
-          console.log(error);
+          console.log(error); // eslint-disable-line
           return new Response(403, {}, { errors: [error] });
         }
       } else if (passcode) {
@@ -48,7 +48,7 @@ export const validationHandler = (schema, req) => {
     }
     return authResponses[mfa_request_id];
   } catch (error) {
-    console.log(error);
+    console.log(error); // eslint-disable-line
     return new Response(500, {}, { errors: ['Mirage Handler Error: /sys/mfa/validate'] });
   }
 };

--- a/ui/testem.enos.js
+++ b/ui/testem.enos.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const vault_addr = process.env.VAULT_ADDR;
-console.log('VAULT_ADDR=' + vault_addr);
+console.log('VAULT_ADDR=' + vault_addr); // eslint-disable-line
 
 module.exports = {
   test_page: 'tests/index.html?hidepassed',

--- a/ui/tests/acceptance/access/identity/_shared-alias-tests.js
+++ b/ui/tests/acceptance/access/identity/_shared-alias-tests.js
@@ -29,7 +29,7 @@ export const testAliasCRUD = async function (name, itemType, assert) {
 
   idRow = aliasShowPage.rows.filterBy('hasLabel').filterBy('rowLabel', 'ID')[0];
   aliasID = idRow.rowValue;
-  assert.equal(
+  assert.strictEqual(
     currentRouteName(),
     'vault.cluster.access.identity.aliases.show',
     'navigates to the correct route'
@@ -38,7 +38,7 @@ export const testAliasCRUD = async function (name, itemType, assert) {
 
   await aliasIndexPage.visit({ item_type: itemType });
   await settled();
-  assert.equal(
+  assert.strictEqual(
     aliasIndexPage.items.filterBy('name', name).length,
     1,
     `${itemType}: lists the entity in the entity list`
@@ -56,7 +56,11 @@ export const testAliasCRUD = async function (name, itemType, assert) {
     `${itemType}: shows flash message`
   );
 
-  assert.equal(aliasIndexPage.items.filterBy('id', aliasID).length, 0, `${itemType}: the row is deleted`);
+  assert.strictEqual(
+    aliasIndexPage.items.filterBy('id', aliasID).length,
+    0,
+    `${itemType}: the row is deleted`
+  );
 };
 
 export const testAliasDeleteFromForm = async function (name, itemType, assert) {
@@ -80,7 +84,7 @@ export const testAliasDeleteFromForm = async function (name, itemType, assert) {
   aliasID = idRow.rowValue;
   await aliasShowPage.edit();
   await settled();
-  assert.equal(
+  assert.strictEqual(
     currentRouteName(),
     'vault.cluster.access.identity.aliases.edit',
     `${itemType}: navigates to edit on create`
@@ -93,12 +97,12 @@ export const testAliasDeleteFromForm = async function (name, itemType, assert) {
     aliasIndexPage.flashMessage.latestMessage.startsWith('Successfully deleted'),
     `${itemType}: shows flash message`
   );
-  assert.equal(
+  assert.strictEqual(
     currentRouteName(),
     'vault.cluster.access.identity.aliases.index',
     `${itemType}: navigates to list page on delete`
   );
-  assert.equal(
+  assert.strictEqual(
     aliasIndexPage.items.filterBy('id', aliasID).length,
     0,
     `${itemType}: the row does not show in the list`

--- a/ui/tests/acceptance/access/identity/_shared-tests.js
+++ b/ui/tests/acceptance/access/identity/_shared-tests.js
@@ -13,7 +13,7 @@ export const testCRUD = async (name, itemType, assert) => {
     showPage.flashMessage.latestMessage.startsWith('Successfully saved'),
     `${itemType}: shows a flash message`
   );
-  assert.equal(
+  assert.strictEqual(
     currentRouteName(),
     'vault.cluster.access.identity.show',
     `${itemType}: navigates to show on create`
@@ -22,7 +22,7 @@ export const testCRUD = async (name, itemType, assert) => {
 
   await indexPage.visit({ item_type: itemType });
   await settled();
-  assert.equal(
+  assert.strictEqual(
     indexPage.items.filterBy('name', name).length,
     1,
     `${itemType}: lists the entity in the entity list`
@@ -37,7 +37,7 @@ export const testCRUD = async (name, itemType, assert) => {
     indexPage.flashMessage.latestMessage.startsWith('Successfully deleted'),
     `${itemType}: shows flash message`
   );
-  assert.equal(indexPage.items.filterBy('name', name).length, 0, `${itemType}: the row is deleted`);
+  assert.strictEqual(indexPage.items.filterBy('name', name).length, 0, `${itemType}: the row is deleted`);
 };
 
 export const testDeleteFromForm = async (name, itemType, assert) => {
@@ -55,7 +55,7 @@ export const testDeleteFromForm = async (name, itemType, assert) => {
   await click('[data-test-tab-subnav="metadata"]');
   assert.dom('.info-table-row').hasText('hello goodbye', 'Metadata shows on tab');
   await showPage.edit();
-  assert.equal(
+  assert.strictEqual(
     currentRouteName(),
     'vault.cluster.access.identity.edit',
     `${itemType}: navigates to edit on create`
@@ -69,12 +69,12 @@ export const testDeleteFromForm = async (name, itemType, assert) => {
     indexPage.flashMessage.latestMessage.startsWith('Successfully deleted'),
     `${itemType}: shows flash message`
   );
-  assert.equal(
+  assert.strictEqual(
     currentRouteName(),
     'vault.cluster.access.identity.index',
     `${itemType}: navigates to list page on delete`
   );
-  assert.equal(
+  assert.strictEqual(
     indexPage.items.filterBy('name', name).length,
     0,
     `${itemType}: the row does not show in the list`

--- a/ui/tests/acceptance/access/identity/entities/create-test.js
+++ b/ui/tests/acceptance/access/identity/entities/create-test.js
@@ -14,7 +14,7 @@ module('Acceptance | /access/identity/entities/create', function (hooks) {
 
   test('it visits the correct page', async function (assert) {
     await page.visit({ item_type: 'entities' });
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.identity.create',
       'navigates to the correct route'

--- a/ui/tests/acceptance/access/identity/entities/index-test.js
+++ b/ui/tests/acceptance/access/identity/entities/index-test.js
@@ -13,11 +13,19 @@ module('Acceptance | /access/identity/entities', function (hooks) {
 
   test('it renders the entities page', async function (assert) {
     await page.visit({ item_type: 'entities' });
-    assert.equal(currentRouteName(), 'vault.cluster.access.identity.index', 'navigates to the correct route');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.access.identity.index',
+      'navigates to the correct route'
+    );
   });
 
   test('it renders the groups page', async function (assert) {
     await page.visit({ item_type: 'groups' });
-    assert.equal(currentRouteName(), 'vault.cluster.access.identity.index', 'navigates to the correct route');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.access.identity.index',
+      'navigates to the correct route'
+    );
   });
 });

--- a/ui/tests/acceptance/access/identity/groups/create-test.js
+++ b/ui/tests/acceptance/access/identity/groups/create-test.js
@@ -14,7 +14,7 @@ module('Acceptance | /access/identity/groups/create', function (hooks) {
 
   test('it visits the correct page', async function (assert) {
     await page.visit({ item_type: 'groups' });
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.identity.create',
       'navigates to the correct route'

--- a/ui/tests/acceptance/access/methods-test.js
+++ b/ui/tests/acceptance/access/methods-test.js
@@ -13,8 +13,8 @@ module('Acceptance | /access/', function (hooks) {
 
   test('it navigates', async function (assert) {
     await page.visit();
-    assert.equal(currentRouteName(), 'vault.cluster.access.methods', 'navigates to the correct route');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.access.methods', 'navigates to the correct route');
     assert.ok(page.navLinks.objectAt(0).isActive, 'the first link is active');
-    assert.equal(page.navLinks.objectAt(0).text, 'Auth Methods');
+    assert.strictEqual(page.navLinks.objectAt(0).text, 'Auth Methods');
   });
 });

--- a/ui/tests/acceptance/access/namespaces/index-test.js
+++ b/ui/tests/acceptance/access/namespaces/index-test.js
@@ -21,7 +21,7 @@ module('Acceptance | Enterprise | /access/namespaces', function (hooks) {
   test('it navigates to namespaces page', async function (assert) {
     assert.expect(1);
     await page.visit();
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.namespaces.index',
       'navigates to the correct route'
@@ -33,7 +33,7 @@ module('Acceptance | Enterprise | /access/namespaces', function (hooks) {
     await page.visit();
     const store = this.owner.lookup('service:store');
     // Default page size is 15
-    assert.equal(store.peekAll('namespace').length, 15, 'Store has 15 namespaces records');
+    assert.strictEqual(store.peekAll('namespace').length, 15, 'Store has 15 namespaces records');
     assert.dom('.list-item-row').exists({ count: 15 });
     assert.dom('[data-test-list-view-pagination]').exists();
   });

--- a/ui/tests/acceptance/auth-test.js
+++ b/ui/tests/acceptance/auth-test.js
@@ -38,10 +38,10 @@ module('Acceptance | auth', function (hooks) {
     let backends = supportedAuthBackends();
     assert.expect(backends.length + 1);
     await visit('/vault/auth');
-    assert.equal(currentURL(), '/vault/auth?with=token');
+    assert.strictEqual(currentURL(), '/vault/auth?with=token');
     for (let backend of backends.reverse()) {
       await component.selectMethod(backend.type);
-      assert.equal(
+      assert.strictEqual(
         currentURL(),
         `/vault/auth?with=${backend.type}`,
         `has the correct URL for ${backend.type}`
@@ -51,10 +51,10 @@ module('Acceptance | auth', function (hooks) {
 
   test('it clears token when changing selected auth method', async function (assert) {
     await visit('/vault/auth');
-    assert.equal(currentURL(), '/vault/auth?with=token');
+    assert.strictEqual(currentURL(), '/vault/auth?with=token');
     await component.token('token').selectMethod('github');
     await component.selectMethod('token');
-    assert.equal(component.tokenValue, '', 'it clears the token value when toggling methods');
+    assert.strictEqual(component.tokenValue, '', 'it clears the token value when toggling methods');
   });
 
   test('it sends the right attributes when authenticating', async function (assert) {

--- a/ui/tests/acceptance/aws-test.js
+++ b/ui/tests/acceptance/aws-test.js
@@ -37,7 +37,7 @@ module('Acceptance | aws secret backend', function (hooks) {
 
     await click('[data-test-secret-backend-configure]');
 
-    assert.equal(currentURL(), `/vault/settings/secrets/configure/${path}`);
+    assert.strictEqual(currentURL(), `/vault/settings/secrets/configure/${path}`);
     assert.ok(findAll('[data-test-aws-root-creds-form]').length, 'renders the empty root creds form');
     assert.ok(findAll('[data-test-aws-link="root-creds"]').length, 'renders the root creds link');
     assert.ok(findAll('[data-test-aws-link="leases"]').length, 'renders the leases config link');
@@ -63,7 +63,7 @@ module('Acceptance | aws secret backend', function (hooks) {
 
     await click('[data-test-backend-view-link]');
 
-    assert.equal(currentURL(), `/vault/secrets/${path}/list`, `navigates to the roles list`);
+    assert.strictEqual(currentURL(), `/vault/secrets/${path}/list`, `navigates to the roles list`);
 
     await click('[data-test-secret-create]');
 
@@ -79,7 +79,7 @@ module('Acceptance | aws secret backend', function (hooks) {
     // save the role
     await click('[data-test-role-aws-create]');
     await waitUntil(() => currentURL() === `/vault/secrets/${path}/show/${roleName}`); // flaky without this
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${path}/show/${roleName}`,
       `$aws: navigates to the show page on creation`
@@ -87,7 +87,7 @@ module('Acceptance | aws secret backend', function (hooks) {
 
     await click('[data-test-secret-root-link]');
 
-    assert.equal(currentURL(), `/vault/secrets/${path}/list`);
+    assert.strictEqual(currentURL(), `/vault/secrets/${path}/list`);
     assert.ok(findAll(`[data-test-secret-link="${roleName}"]`).length, `aws: role shows in the list`);
 
     //and delete

--- a/ui/tests/acceptance/client-current-test.js
+++ b/ui/tests/acceptance/client-current-test.js
@@ -41,7 +41,7 @@ module('Acceptance | clients current tab', function (hooks) {
     });
     this.server.get('sys/internal/counters/activity/monthly', () => overrideResponse(204));
     await visit('/vault/clients/current');
-    assert.equal(currentURL(), '/vault/clients/current');
+    assert.strictEqual(currentURL(), '/vault/clients/current');
     assert.dom(SELECTORS.currentMonthActiveTab).hasText('Current month', 'current month tab is active');
     assert.dom(SELECTORS.emptyStateTitle).hasText('Tracking is disabled');
   });
@@ -63,7 +63,7 @@ module('Acceptance | clients current tab', function (hooks) {
       };
     });
     await visit('/vault/clients/current');
-    assert.equal(currentURL(), '/vault/clients/current');
+    assert.strictEqual(currentURL(), '/vault/clients/current');
     assert.dom(SELECTORS.currentMonthActiveTab).hasText('Current month', 'current month tab is active');
     assert.dom(SELECTORS.emptyStateTitle).hasText('No data received');
   });
@@ -71,7 +71,7 @@ module('Acceptance | clients current tab', function (hooks) {
   test('filters correctly on current with full data', async function (assert) {
     assert.expect(27);
     await visit('/vault/clients/current');
-    assert.equal(currentURL(), '/vault/clients/current');
+    assert.strictEqual(currentURL(), '/vault/clients/current');
     assert.dom(SELECTORS.currentMonthActiveTab).hasText('Current month', 'current month tab is active');
     assert.dom(SELECTORS.usageStats).exists('usage stats block exists');
     assert.dom('[data-test-stat-text-container]').exists({ count: 3 }, '3 stat texts exist');
@@ -130,7 +130,7 @@ module('Acceptance | clients current tab', function (hooks) {
   test('filters correctly on current with no auth mounts', async function (assert) {
     assert.expect(16);
     await visit('/vault/clients/current');
-    assert.equal(currentURL(), '/vault/clients/current');
+    assert.strictEqual(currentURL(), '/vault/clients/current');
     assert.dom(SELECTORS.currentMonthActiveTab).hasText('Current month', 'current month tab is active');
     assert.dom(SELECTORS.usageStats).exists('usage stats block exists');
     assert.dom('[data-test-stat-text-container]').exists({ count: 3 }, '3 stat texts exist');

--- a/ui/tests/acceptance/client-history-test.js
+++ b/ui/tests/acceptance/client-history-test.js
@@ -54,7 +54,7 @@ module('Acceptance | clients history tab', function (hooks) {
       };
     });
     await visit('/vault/clients/history');
-    assert.equal(currentURL(), '/vault/clients/history');
+    assert.strictEqual(currentURL(), '/vault/clients/history');
     assert.dom(SELECTORS.historyActiveTab).hasText('History', 'history tab is active');
     assert.dom('[data-test-tracking-disabled] .message-title').hasText('Tracking is disabled');
     assert.dom(SELECTORS.emptyStateTitle).hasText('No data received');
@@ -77,7 +77,7 @@ module('Acceptance | clients history tab', function (hooks) {
       };
     });
     await visit('/vault/clients/history');
-    assert.equal(currentURL(), '/vault/clients/history');
+    assert.strictEqual(currentURL(), '/vault/clients/history');
     assert.dom(SELECTORS.historyActiveTab).hasText('History', 'history tab is active');
     assert.dom(SELECTORS.emptyStateTitle).hasText('Data tracking is disabled');
     assert.dom(SELECTORS.filterBar).doesNotExist('Filter bar is hidden when no data available');
@@ -98,7 +98,7 @@ module('Acceptance | clients history tab', function (hooks) {
       };
     });
     await visit('/vault/clients/history');
-    assert.equal(currentURL(), '/vault/clients/history');
+    assert.strictEqual(currentURL(), '/vault/clients/history');
     assert.dom(SELECTORS.historyActiveTab).hasText('History', 'history tab is active');
 
     assert.dom(SELECTORS.emptyStateTitle).hasText('No monthly history');
@@ -108,7 +108,7 @@ module('Acceptance | clients history tab', function (hooks) {
   test('visiting history tab config on and data with mounts', async function (assert) {
     assert.expect(8);
     await visit('/vault/clients/history');
-    assert.equal(currentURL(), '/vault/clients/history');
+    assert.strictEqual(currentURL(), '/vault/clients/history');
 
     assert
       .dom(SELECTORS.dateDisplay)
@@ -127,7 +127,7 @@ module('Acceptance | clients history tab', function (hooks) {
     assert
       .dom(find('[data-test-line-chart="x-axis-labels"] g.tick text'))
       .hasText(`${format(LICENSE_START, 'M/yy')}`, 'x-axis labels start with billing start date');
-    assert.equal(
+    assert.strictEqual(
       findAll('[data-test-line-chart="plot-point"]').length,
       5,
       `line chart plots 5 points to match query`
@@ -139,7 +139,7 @@ module('Acceptance | clients history tab', function (hooks) {
     // TODO CMB: wire up dynamically generated activity to mirage clients handler
     // const activity = generateActivityResponse(5, LICENSE_START, LAST_MONTH);
     await visit('/vault/clients/history');
-    assert.equal(currentURL(), '/vault/clients/history');
+    assert.strictEqual(currentURL(), '/vault/clients/history');
 
     // query for single, historical month with no new counts
     await click(SELECTORS.rangeDropdown);
@@ -186,7 +186,7 @@ module('Acceptance | clients history tab', function (hooks) {
     assert
       .dom(find('[data-test-line-chart="x-axis-labels"] g.tick text'))
       .hasText(`${format(UPGRADE_DATE, 'M/yy')}`, 'x-axis labels start with updated billing start month');
-    assert.equal(
+    assert.strictEqual(
       findAll('[data-test-line-chart="plot-point"]').length,
       5,
       `line chart plots 5 points to match query`
@@ -205,7 +205,7 @@ module('Acceptance | clients history tab', function (hooks) {
     assert
       .dom(SELECTORS.runningTotalMonthlyCharts)
       .exists('Shows running totals with monthly breakdown charts');
-    assert.equal(
+    assert.strictEqual(
       findAll('[data-test-line-chart="plot-point"]').length,
       3,
       `line chart plots 3 points to match query`
@@ -253,7 +253,7 @@ module('Acceptance | clients history tab', function (hooks) {
   test('filters correctly on history with full data', async function (assert) {
     assert.expect(19);
     await visit('/vault/clients/history');
-    assert.equal(currentURL(), '/vault/clients/history', 'clients/history URL is correct');
+    assert.strictEqual(currentURL(), '/vault/clients/history', 'clients/history URL is correct');
     assert.dom(SELECTORS.historyActiveTab).hasText('History', 'history tab is active');
     assert
       .dom(SELECTORS.runningTotalMonthlyCharts)
@@ -327,7 +327,7 @@ module('Acceptance | clients history tab', function (hooks) {
       };
     });
     await visit('/vault/clients/history');
-    assert.equal(currentURL(), '/vault/clients/history', 'clients/history URL is correct');
+    assert.strictEqual(currentURL(), '/vault/clients/history', 'clients/history URL is correct');
     assert.dom(SELECTORS.historyActiveTab).hasText('History', 'history tab is active');
     assert
       .dom('[data-test-alert-banner="alert"]')
@@ -355,7 +355,7 @@ module('Acceptance | clients history tab', function (hooks) {
       };
     });
     await visit('/vault/clients/history');
-    assert.equal(currentURL(), '/vault/clients/history', 'clients/history URL is correct');
+    assert.strictEqual(currentURL(), '/vault/clients/history', 'clients/history URL is correct');
     assert.dom(SELECTORS.emptyStateTitle).hasText('No data for this billing period');
     assert
       .dom(SELECTORS.dateDisplay)
@@ -367,7 +367,7 @@ module('Acceptance | clients history tab', function (hooks) {
   test('shows correct interface if no permissions on license', async function (assert) {
     this.server.get('/sys/license/status', () => overrideResponse(403));
     await visit('/vault/clients/history');
-    assert.equal(currentURL(), '/vault/clients/history', 'clients/history URL is correct');
+    assert.strictEqual(currentURL(), '/vault/clients/history', 'clients/history URL is correct');
     assert.dom(SELECTORS.historyActiveTab).hasText('History', 'history tab is active');
     // Message changes depending on ent or OSS
     assert.dom(SELECTORS.emptyStateTitle).exists('Empty state exists');
@@ -382,7 +382,7 @@ module('Acceptance | clients history tab', function (hooks) {
     this.server.get('sys/internal/counters/activity', () => overrideResponse(403));
 
     await visit('/vault/clients/history');
-    assert.equal(currentURL(), '/vault/clients/history', 'clients/history URL is correct');
+    assert.strictEqual(currentURL(), '/vault/clients/history', 'clients/history URL is correct');
     assert
       .dom(SELECTORS.emptyStateTitle)
       .includesText('start date found', 'Empty state shows no billing start date');

--- a/ui/tests/acceptance/console-test.js
+++ b/ui/tests/acceptance/console-test.js
@@ -29,7 +29,7 @@ module('Acceptance | console', function (hooks) {
     }
     await consoleComponent.runCommands('refresh');
     await settled();
-    assert.equal(enginesPage.rows.length, numEngines + 3, 'new engines were added to the page');
+    assert.strictEqual(enginesPage.rows.length, numEngines + 3, 'new engines were added to the page');
   });
 
   test('fullscreen command expands the cli panel', async function (assert) {
@@ -40,8 +40,12 @@ module('Acceptance | console', function (hooks) {
     const consoleEle = document.querySelector('[data-test-component="console/ui-panel"]');
     // wait for the CSS transition to finish
     await waitUntil(() => consoleEle.offsetHeight === window.innerHeight);
-    assert.equal(consoleEle.offsetHeight, window.innerHeight, 'fullscreen is the same height as the window');
-    assert.equal(consoleEle.offsetTop, 0, 'fullscreen is aligned to the top of window');
+    assert.strictEqual(
+      consoleEle.offsetHeight,
+      window.innerHeight,
+      'fullscreen is the same height as the window'
+    );
+    assert.strictEqual(consoleEle.offsetTop, 0, 'fullscreen is aligned to the top of window');
   });
 
   test('array output is correctly formatted', async function (assert) {
@@ -53,7 +57,7 @@ module('Acceptance | console', function (hooks) {
     // wait for the CSS transition to finish
     await waitUntil(() => consoleOut.innerText);
     assert.notOk(consoleOut.innerText.includes('function(){'));
-    assert.equal(consoleOut.innerText, '["root"]');
+    assert.strictEqual(consoleOut.innerText, '["root"]');
   });
 
   test('number output is correctly formatted', async function (assert) {
@@ -64,7 +68,7 @@ module('Acceptance | console', function (hooks) {
     const consoleOut = document.querySelector('.console-ui-output>pre');
     // wait for the CSS transition to finish
     await waitUntil(() => consoleOut.innerText);
-    assert.equal(consoleOut.innerText.match(/^\d+$/).length, 1);
+    assert.strictEqual(consoleOut.innerText.match(/^\d+$/).length, 1);
   });
 
   test('boolean output is correctly formatted', async function (assert) {
@@ -75,6 +79,6 @@ module('Acceptance | console', function (hooks) {
     let consoleOut = document.querySelector('.console-ui-output>pre');
     // have to wrap in a later so that we can wait for the CSS transition to finish
     await waitUntil(() => consoleOut.innerText);
-    assert.equal(consoleOut.innerText.match(/^(true|false)$/g).length, 1);
+    assert.strictEqual(consoleOut.innerText.match(/^(true|false)$/g).length, 1);
   });
 });

--- a/ui/tests/acceptance/enterprise-control-groups-test.js
+++ b/ui/tests/acceptance/enterprise-control-groups-test.js
@@ -166,7 +166,7 @@ module('Acceptance | Enterprise | control groups', function (hooks) {
     assert.dom('[data-test-authorize-button]').exists();
     await controlGroupComponent.authorize();
     await settled();
-    assert.equal(controlGroupComponent.bannerPrefix, 'Thanks!', 'text display changes');
+    assert.strictEqual(controlGroupComponent.bannerPrefix, 'Thanks!', 'text display changes');
     await settled();
     await authPage.logout();
     await settled();
@@ -189,7 +189,7 @@ module('Acceptance | Enterprise | control groups', function (hooks) {
       assert.ok(controlGroupSuccessComponent.showsNavigateMessage, 'shows user the navigate message');
       await controlGroupSuccessComponent.navigate();
       await settled();
-      assert.equal(currentURL(), url, 'successfully loads the target url');
+      assert.strictEqual(currentURL(), url, 'successfully loads the target url');
     } else {
       await visit(`/vault/access/control-groups/${accessor}`);
 

--- a/ui/tests/acceptance/enterprise-kmip-test.js
+++ b/ui/tests/acceptance/enterprise-kmip-test.js
@@ -86,7 +86,7 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
     let path = `kmip-${Date.now()}`;
     await mountSecrets.enable('kmip', path);
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${path}/kmip/scopes`,
       'mounts and redirects to the kmip scopes page'
@@ -100,7 +100,7 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
     await settled();
     await scopesPage.configurationLink();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${path}/kmip/configuration`,
       'configuration navigates to the config page'
@@ -109,7 +109,7 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
 
     await scopesPage.configureLink();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${path}/kmip/configure`,
       'configuration navigates to the configure page'
@@ -119,7 +119,7 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
 
     await scopesPage.submit();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${path}/kmip/configuration`,
       'redirects to configuration page after saving config'
@@ -137,7 +137,7 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
     await credentialsPage.delete().confirmDelete();
     await settled();
 
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${path}/kmip/scopes/${scope}/roles/${role}/credentials`,
       'redirects to the credentials list'
@@ -151,7 +151,7 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
     await settled();
     await scopesPage.createLink();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${path}/kmip/scopes/create`,
       'navigates to the kmip scope create page'
@@ -162,12 +162,12 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
     await settled();
     await scopesPage.submit();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${path}/kmip/scopes`,
       'navigates to the kmip scopes page after create'
     );
-    assert.equal(scopesPage.listItemLinks.length, 1, 'renders a single scope');
+    assert.strictEqual(scopesPage.listItemLinks.length, 1, 'renders a single scope');
   });
 
   test('it can delete a scope from the list', async function (assert) {
@@ -181,7 +181,7 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
     await settled();
     await scopesPage.confirmDelete();
     await settled();
-    assert.equal(scopesPage.listItemLinks.length, 0, 'no scopes');
+    assert.strictEqual(scopesPage.listItemLinks.length, 0, 'no scopes');
     assert.ok(scopesPage.isEmpty, 'renders the empty state');
   });
 
@@ -203,7 +203,7 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
     assert.ok(rolesPage.isEmpty, 'renders the empty role page');
     await rolesPage.create();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${path}/kmip/scopes/${scope}/roles/create`,
       'links to the role create form'
@@ -213,13 +213,13 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
     await settled();
     await rolesPage.submit();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${path}/kmip/scopes/${scope}/roles`,
       'redirects to roles list'
     );
 
-    assert.equal(rolesPage.listItemLinks.length, 1, 'renders a single role');
+    assert.strictEqual(rolesPage.listItemLinks.length, 1, 'renders a single role');
   });
 
   test('it can delete a role from the list', async function (assert) {
@@ -233,7 +233,7 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
     await settled();
     await rolesPage.confirmDelete();
     await settled();
-    assert.equal(rolesPage.listItemLinks.length, 0, 'renders no roles');
+    assert.strictEqual(rolesPage.listItemLinks.length, 0, 'renders no roles');
     assert.ok(rolesPage.isEmpty, 'renders empty');
   });
 
@@ -245,21 +245,21 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
     await waitUntil(() => find('[data-test-kmip-link-edit-role]'));
     await rolesPage.detailEditLink();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${path}/kmip/scopes/${scope}/roles/${role}/edit`,
       'navigates to role edit'
     );
     await rolesPage.cancelLink();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${path}/kmip/scopes/${scope}/roles/${role}`,
       'cancel navigates to role show'
     );
     await rolesPage.delete().confirmDelete();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${path}/kmip/scopes/${scope}/roles`,
       'redirects to the roles list'
@@ -275,21 +275,21 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
     assert.ok(credentialsPage.isEmpty, 'renders empty creds page');
     await credentialsPage.generateCredentialsLink();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${path}/kmip/scopes/${scope}/roles/${role}/credentials/generate`,
       'navigates to generate credentials'
     );
     await credentialsPage.submit();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.secrets.backend.kmip.credentials.show',
       'generate redirects to the show page'
     );
     await credentialsPage.backToRoleLink();
     await settled();
-    assert.equal(credentialsPage.listItemLinks.length, 1, 'renders a single credential');
+    assert.strictEqual(credentialsPage.listItemLinks.length, 1, 'renders a single credential');
   });
 
   test('it can revoke a credential from the list', async function (assert) {
@@ -301,7 +301,7 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
     await settled();
     await credentialsPage.delete().confirmDelete();
     await settled();
-    assert.equal(credentialsPage.listItemLinks.length, 0, 'renders no credentials');
+    assert.strictEqual(credentialsPage.listItemLinks.length, 0, 'renders no credentials');
     assert.ok(credentialsPage.isEmpty, 'renders empty');
   });
 });

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -74,7 +74,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
   test('it shows the regular namespace toolbar when not managed', async function (assert) {
     // This test is the opposite of the test in managed-namespace-test
     await logout.visit();
-    assert.equal(currentURL(), '/vault/auth?with=token', 'Does not redirect');
+    assert.strictEqual(currentURL(), '/vault/auth?with=token', 'Does not redirect');
     assert.dom('[data-test-namespace-toolbar]').exists('Normal namespace toolbar exists');
     assert
       .dom('[data-test-managed-namespace-toolbar]')
@@ -82,7 +82,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
     assert.dom('input#namespace').hasAttribute('placeholder', '/ (Root)');
     await fillIn('input#namespace', '/foo');
     let encodedNamespace = encodeURIComponent('/foo');
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/auth?namespace=${encodedNamespace}&with=token`,
       'Does not prepend root to namespace'

--- a/ui/tests/acceptance/enterprise-replication-test.js
+++ b/ui/tests/acceptance/enterprise-replication-test.js
@@ -27,7 +27,7 @@ const disableReplication = async (type, assert) => {
 
     if (assert) {
       // bypassing for now -- remove if tests pass reliably
-      // assert.equal(
+      // assert.strictEqual(
       //   flash.latestMessage,
       //   'This cluster is having replication disabled. Vault will be unavailable for a brief period and will resume service shortly.',
       //   'renders info flash when disabled'
@@ -83,7 +83,7 @@ module('Acceptance | Enterprise | replication', function (hooks) {
 
     await visit('/vault/replication');
 
-    assert.equal(currentURL(), '/vault/replication');
+    assert.strictEqual(currentURL(), '/vault/replication');
 
     // enable perf replication
     await click('[data-test-replication-type-select="performance"]');
@@ -118,7 +118,10 @@ module('Acceptance | Enterprise | replication', function (hooks) {
 
     await click('[data-test-replication-path-filter-link]');
 
-    assert.equal(currentURL(), `/vault/replication/performance/secondaries/config/show/${secondaryName}`);
+    assert.strictEqual(
+      currentURL(),
+      `/vault/replication/performance/secondaries/config/show/${secondaryName}`
+    );
     assert.dom('[data-test-mount-config-mode]').includesText(mode, 'show page renders the correct mode');
     assert
       .dom('[data-test-mount-config-paths]')
@@ -132,12 +135,12 @@ module('Acceptance | Enterprise | replication', function (hooks) {
     await click('[data-test-config-save]');
     await settled(); // eslint-disable-line
 
-    assert.equal(
+    assert.strictEqual(
       flash.latestMessage,
       `The performance mount filter config for the secondary ${secondaryName} was successfully deleted.`,
       'renders success flash upon deletion'
     );
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/replication/performance/secondaries`,
       'redirects to the secondaries page'
@@ -275,7 +278,7 @@ module('Acceptance | Enterprise | replication', function (hooks) {
     let modalDefaultTtl = document.querySelector('[data-test-row-value="TTL"]').innerText;
     // checks on secondary token modal
     assert.dom('#modal-wormhole').exists();
-    assert.equal(modalDefaultTtl, '1800s', 'shows the correct TTL of 1800s');
+    assert.strictEqual(modalDefaultTtl, '1800s', 'shows the correct TTL of 1800s');
     // click off the modal to make sure you don't just have to click on the copy-close button to copy the token
     await click('[data-test-modal-background]');
 
@@ -291,11 +294,11 @@ module('Acceptance | Enterprise | replication', function (hooks) {
     await pollCluster(this.owner);
     await settled();
     let modalTtl = document.querySelector('[data-test-row-value="TTL"]').innerText;
-    assert.equal(modalTtl, '180s', 'shows the correct TTL of 180s');
+    assert.strictEqual(modalTtl, '180s', 'shows the correct TTL of 180s');
     await click('[data-test-modal-background]');
 
     // confirm you were redirected to the secondaries page
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/replication/performance/secondaries`,
       'redirects to the secondaries page'
@@ -345,7 +348,7 @@ module('Acceptance | Enterprise | replication', function (hooks) {
     assert
       .dom('[data-test-selectable-card-container="primary"]')
       .exists('shows the correct card on the details dashboard');
-    assert.equal(currentURL(), '/vault/replication/dr');
+    assert.strictEqual(currentURL(), '/vault/replication/dr');
   });
 
   test('render performance secondary and navigate to the details page', async function (assert) {

--- a/ui/tests/acceptance/enterprise-transform-test.js
+++ b/ui/tests/acceptance/enterprise-transform-test.js
@@ -64,7 +64,7 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     let backend = `transform-${Date.now()}`;
     await mountSecrets.enable('transform', backend);
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/list`,
       'mounts and redirects to the transformations list page'
@@ -85,7 +85,11 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     await settled();
     await transformationsPage.createLink({ backend });
     await settled();
-    assert.equal(currentURL(), `/vault/secrets/${backend}/create`, 'redirects to create transformation page');
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets/${backend}/create`,
+      'redirects to create transformation page'
+    );
     await transformationsPage.name(transformationName);
     await settled();
     assert.dom('[data-test-input="type"]').hasValue('fpe', 'Has type FPE by default');
@@ -98,7 +102,7 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     assert.dom('[data-test-input="tweak_source"]').doesNotExist('Does not show tweak source when masking');
     await clickTrigger('#template');
     await settled();
-    assert.equal(searchSelectComponent.options.length, 2, 'list shows two builtin options by default');
+    assert.strictEqual(searchSelectComponent.options.length, 2, 'list shows two builtin options by default');
     await selectChoose('#template', '.ember-power-select-option', 0);
     await settled();
 
@@ -110,13 +114,17 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     await settled();
     await transformationsPage.submit();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/show/${transformationName}`,
       'redirects to show transformation page after submit'
     );
     await click(`[data-test-secret-breadcrumb="${backend}"]`);
-    assert.equal(currentURL(), `/vault/secrets/${backend}/list`, 'Links back to list view from breadcrumb');
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets/${backend}/list`,
+      'Links back to list view from breadcrumb'
+    );
   });
 
   test('it can create a role and add itself to the transformation attached', async function (assert) {
@@ -125,29 +133,33 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     // create transformation without role
     await newTransformation(backend, 'a-transformation', true);
     await click(`[data-test-secret-breadcrumb="${backend}"]`);
-    assert.equal(currentURL(), `/vault/secrets/${backend}/list`, 'Links back to list view from breadcrumb');
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets/${backend}/list`,
+      'Links back to list view from breadcrumb'
+    );
     await click('[data-test-secret-list-tab="Roles"]');
-    assert.equal(currentURL(), `/vault/secrets/${backend}/list?tab=role`, 'links to role list page');
+    assert.strictEqual(currentURL(), `/vault/secrets/${backend}/list?tab=role`, 'links to role list page');
     // create role with transformation attached
     await rolesPage.createLink();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/create?itemType=role`,
       'redirects to create role page'
     );
     await rolesPage.name(roleName);
     await clickTrigger('#transformations');
-    assert.equal(searchSelectComponent.options.length, 1, 'lists the transformation');
+    assert.strictEqual(searchSelectComponent.options.length, 1, 'lists the transformation');
     await selectChoose('#transformations', '.ember-power-select-option', 0);
     await rolesPage.submit();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/show/role/${roleName}`,
       'redirects to show role page after submit'
     );
     await click(`[data-test-secret-breadcrumb="${backend}"]`);
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/list?tab=role`,
       'Links back to role list view from breadcrumb'
@@ -177,7 +189,7 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     assert.dom('.modal.is-active').exists('Confirmation modal appears');
     await rolesPage.modalConfirm();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/edit/${transformation}`,
       'Correctly links to edit page for secret'
@@ -189,7 +201,7 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     await transformationsPage.save();
     await settled();
     assert.dom('.flash-message.is-info').exists('Shows info message since role could not be updated');
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/show/${transformation}`,
       'Correctly links to show page for secret'
@@ -204,10 +216,14 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     let backend = await mount();
     await click('[data-test-secret-list-tab="Templates"]');
 
-    assert.equal(currentURL(), `/vault/secrets/${backend}/list?tab=template`, 'links to template list page');
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets/${backend}/list?tab=template`,
+      'links to template list page'
+    );
     await settled();
     await templatesPage.createLink();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/create?itemType=template`,
       'redirects to create template page'
@@ -221,14 +237,14 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     assert.dom('#alphabet .ember-power-select-trigger').doesNotExist('Alphabet input no longer searchable');
     await templatesPage.submit();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/show/template/${templateName}`,
       'redirects to show template page after submit'
     );
     await templatesPage.editLink();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/edit/template/${templateName}`,
       'Links to template edit page'
@@ -242,10 +258,14 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     let backend = await mount();
     await click('[data-test-secret-list-tab="Alphabets"]');
 
-    assert.equal(currentURL(), `/vault/secrets/${backend}/list?tab=alphabet`, 'links to alphabet list page');
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets/${backend}/list?tab=alphabet`,
+      'links to alphabet list page'
+    );
     await alphabetsPage.createLink();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/create?itemType=alphabet`,
       'redirects to create alphabet page'
@@ -254,7 +274,7 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     await alphabetsPage.alphabet('aeiou');
     await alphabetsPage.submit();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/show/alphabet/${alphabetName}`,
       'redirects to show alphabet page after submit'
@@ -263,7 +283,7 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     assert.dom('[data-test-row-value="Alphabet"]').hasText('aeiou');
     await alphabetsPage.editLink();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/edit/alphabet/${alphabetName}`,
       'Links to alphabet edit page'

--- a/ui/tests/acceptance/init-test.js
+++ b/ui/tests/acceptance/init-test.js
@@ -89,12 +89,12 @@ module('Acceptance | init', function (hooks) {
     setInitResponse(this.server, CLOUD_SEAL_RESPONSE);
     setStatusResponse(this.server, CLOUD_SEAL_STATUS_RESPONSE);
     await initPage.init(5, 3);
-    assert.equal(
+    assert.strictEqual(
       initPage.keys.length,
       CLOUD_SEAL_RESPONSE.recovery_keys.length,
       'shows all of the recovery keys'
     );
-    assert.equal(initPage.buttonText, 'Continue to Authenticate', 'links to authenticate');
+    assert.strictEqual(initPage.buttonText, 'Continue to Authenticate', 'links to authenticate');
     let { requestBody } = this.server.handledRequests.findBy('url', '/v1/sys/init');
     requestBody = JSON.parse(requestBody);
     for (let attr of ['recovery_shares', 'recovery_threshold']) {
@@ -108,8 +108,8 @@ module('Acceptance | init', function (hooks) {
     setStatusResponse(this.server, SEAL_STATUS_RESPONSE);
 
     await initPage.init(3, 2);
-    assert.equal(initPage.keys.length, SEAL_RESPONSE.keys.length, 'shows all of the recovery keys');
-    assert.equal(initPage.buttonText, 'Continue to Unseal', 'links to unseal');
+    assert.strictEqual(initPage.keys.length, SEAL_RESPONSE.keys.length, 'shows all of the recovery keys');
+    assert.strictEqual(initPage.buttonText, 'Continue to Unseal', 'links to unseal');
 
     let { requestBody } = this.server.handledRequests.findBy('url', '/v1/sys/init');
     requestBody = JSON.parse(requestBody);

--- a/ui/tests/acceptance/jwt-auth-method-test.js
+++ b/ui/tests/acceptance/jwt-auth-method-test.js
@@ -31,8 +31,8 @@ module('Acceptance | jwt auth method', function (hooks) {
     this.server.post('/auth/jwt/login', (schema, req) => {
       const { jwt, role } = JSON.parse(req.requestBody);
       assert.ok(true, 'request made to auth/jwt/login after submit');
-      assert.equal(jwt, 'my-test-jwt-token', 'JWT token is sent in body');
-      assert.equal(role, undefined, 'role is not sent in body when not filled in');
+      assert.strictEqual(jwt, 'my-test-jwt-token', 'JWT token is sent in body');
+      assert.strictEqual(role, undefined, 'role is not sent in body when not filled in');
       req.passthrough();
     });
     await visit('/vault/auth');
@@ -49,8 +49,8 @@ module('Acceptance | jwt auth method', function (hooks) {
     this.server.post('/auth/jwt/login', (schema, req) => {
       const { jwt, role } = JSON.parse(req.requestBody);
       assert.ok(true, 'request made to auth/jwt/login after login');
-      assert.equal(jwt, 'my-test-jwt-token', 'JWT token is sent in body');
-      assert.equal(role, 'some-role', 'role is sent in the body when filled in');
+      assert.strictEqual(jwt, 'my-test-jwt-token', 'JWT token is sent in body');
+      assert.strictEqual(role, 'some-role', 'role is sent in the body when filled in');
       req.passthrough();
     });
     await visit('/vault/auth');
@@ -76,8 +76,8 @@ module('Acceptance | jwt auth method', function (hooks) {
     this.server.post('/auth/test-jwt/login', (schema, req) => {
       const { jwt, role } = JSON.parse(req.requestBody);
       assert.ok(true, 'request made to auth/custom-jwt-login after login');
-      assert.equal(jwt, 'my-test-jwt-token', 'JWT token is sent in body');
-      assert.equal(role, 'some-role', 'role is sent in body when filled in');
+      assert.strictEqual(jwt, 'my-test-jwt-token', 'JWT token is sent in body');
+      assert.strictEqual(role, 'some-role', 'role is sent in body when filled in');
       req.passthrough();
     });
     await visit('/vault/auth');

--- a/ui/tests/acceptance/leases-test.js
+++ b/ui/tests/acceptance/leases-test.js
@@ -48,7 +48,7 @@ module('Acceptance | leases', function (hooks) {
   skip('it renders the show page', function (assert) {
     createSecret(this);
     navToDetail(this);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.leases.show',
       'a lease for the secret is in the list'
@@ -62,7 +62,7 @@ module('Acceptance | leases', function (hooks) {
   skip('it renders the show page with a picker', function (assert) {
     createSecret(this, true);
     navToDetail(this);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.leases.show',
       'a lease for the secret is in the list'
@@ -77,7 +77,7 @@ module('Acceptance | leases', function (hooks) {
     navToDetail(this);
     await click('[data-test-lease-revoke] button');
     await click('[data-test-confirm-button]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.leases.list-root',
       'it navigates back to the leases root on revocation'
@@ -94,7 +94,7 @@ module('Acceptance | leases', function (hooks) {
     await visit(`/vault/access/leases/list/${this.enginePath}`);
     await click('[data-test-lease-revoke-prefix] button');
     await click('[data-test-confirm-button]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.leases.list-root',
       'it navigates back to the leases root on revocation'

--- a/ui/tests/acceptance/managed-namespace-test.js
+++ b/ui/tests/acceptance/managed-namespace-test.js
@@ -44,7 +44,7 @@ module('Acceptance | Enterprise | Managed namespace root', function (hooks) {
     assert.dom('input#namespace').hasAttribute('placeholder', '/ (Default)');
     await fillIn('input#namespace', '/foo');
     let encodedNamespace = encodeURIComponent('admin/foo');
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/auth?namespace=${encodedNamespace}&with=token`,
       'Correctly prepends root to namespace'
@@ -53,17 +53,17 @@ module('Acceptance | Enterprise | Managed namespace root', function (hooks) {
 
   test('getManagedNamespace helper works as expected', function (assert) {
     let managedNs = getManagedNamespace(null, 'admin');
-    assert.equal(managedNs, 'admin', 'returns root ns when no namespace present');
+    assert.strictEqual(managedNs, 'admin', 'returns root ns when no namespace present');
     managedNs = getManagedNamespace('admin/', 'admin');
-    assert.equal(managedNs, 'admin', 'returns root ns when matches passed ns');
+    assert.strictEqual(managedNs, 'admin', 'returns root ns when matches passed ns');
     managedNs = getManagedNamespace('adminfoo/', 'admin');
-    assert.equal(
+    assert.strictEqual(
       managedNs,
       'admin/adminfoo/',
       'appends passed namespace to root even if it matches without slashes'
     );
     managedNs = getManagedNamespace('admin/foo/', 'admin');
-    assert.equal(managedNs, 'admin/foo/', 'returns passed namespace if it starts with root and /');
+    assert.strictEqual(managedNs, 'admin/foo/', 'returns passed namespace if it starts with root and /');
   });
 
   test('it redirects to root prefixed ns when non-root passed', async function (assert) {

--- a/ui/tests/acceptance/mfa-login-enforcement-test.js
+++ b/ui/tests/acceptance/mfa-login-enforcement-test.js
@@ -32,14 +32,14 @@ module('Acceptance | mfa-login-enforcement', function (hooks) {
       .exists({ count: 3 }, 'Validation error messages are displayed');
 
     await click('[data-test-mlef-cancel]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.enforcements.index',
       'Cancel transitions to enforcements list'
     );
     await click('[data-test-enforcement-create]');
     await click('.breadcrumb a');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.enforcements.index',
       'Breadcrumb transitions to enforcements list'
@@ -52,7 +52,7 @@ module('Acceptance | mfa-login-enforcement', function (hooks) {
     await fillIn('[data-test-mount-accessor-select]', 'auth_userpass_bb95c2b1');
     await click('[data-test-mlef-add-target]');
     await click('[data-test-mlef-save]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.enforcements.enforcement.index',
       'Route transitions to enforcement on save success'
@@ -68,7 +68,7 @@ module('Acceptance | mfa-login-enforcement', function (hooks) {
       .includesText('New enforcement', 'New enforcement link renders');
 
     await click('[data-test-enforcement-create]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.enforcements.create',
       'New enforcement link transitions to create route'
@@ -85,7 +85,7 @@ module('Acceptance | mfa-login-enforcement', function (hooks) {
 
     await click('[data-test-popup-menu-trigger]');
     await click('[data-test-list-item-link="details"]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.enforcements.enforcement.index',
       'Details more menu action transitions to enforcement route'
@@ -93,7 +93,7 @@ module('Acceptance | mfa-login-enforcement', function (hooks) {
     await click('.breadcrumb a');
     await click('[data-test-popup-menu-trigger]');
     await click('[data-test-list-item-link="edit"]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.enforcements.enforcement.edit',
       'Edit more menu action transitions to enforcement edit route'
@@ -166,7 +166,7 @@ module('Acceptance | mfa-login-enforcement', function (hooks) {
     assert.dom('[data-test-confirm-button]').isDisabled('Delete button disabled with no confirmation');
     await fillIn('[data-test-confirmation-modal-input]', enforcement.name);
     await click('[data-test-confirm-button]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.enforcements.index',
       'Route transitions to enforcements list on delete success'
@@ -205,7 +205,7 @@ module('Acceptance | mfa-login-enforcement', function (hooks) {
     await click('[data-test-mlef-remove-target="Authentication method"]');
     await click('[data-test-mlef-save]');
 
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.enforcements.enforcement.index',
       'Route transitions to enforcement on save success'

--- a/ui/tests/acceptance/mfa-login-test.js
+++ b/ui/tests/acceptance/mfa-login-test.js
@@ -31,7 +31,7 @@ module('Acceptance | mfa-login', function (hooks) {
     await click('[data-test-auth-submit]');
   };
   const didLogin = (assert) => {
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backends', 'Route transitions after login');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backends', 'Route transitions after login');
   };
   const validate = async (multi) => {
     await fillIn('[data-test-mfa-passcode="0"]', 'test');

--- a/ui/tests/acceptance/mfa-method-test.js
+++ b/ui/tests/acceptance/mfa-method-test.js
@@ -32,18 +32,18 @@ module('Acceptance | mfa-method', function (hooks) {
   test('it should display landing page when no methods exist', async function (assert) {
     this.server.get('/identity/mfa/method/', () => new Response(404, {}, { errors: [] }));
     await visit('/vault/access/mfa/methods');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.index',
       'Route redirects to mfa index when no methods exist'
     );
     await click('[data-test-mfa-configure]');
-    assert.equal(currentRouteName(), 'vault.cluster.access.mfa.methods.create');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.access.mfa.methods.create');
   });
 
   test('it should list methods', async function (assert) {
     await visit('/vault/access/mfa');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.methods.index',
       'Parent route redirects to methods when some exist'
@@ -53,7 +53,7 @@ module('Acceptance | mfa-method', function (hooks) {
     assert.dom('[data-test-mfa-method-create]').includesText('New MFA method', 'New mfa link renders');
 
     await click('[data-test-mfa-method-create]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.methods.create',
       'New method link transitions to create route'
@@ -73,7 +73,7 @@ module('Acceptance | mfa-method', function (hooks) {
 
     await click('[data-test-popup-menu-trigger]');
     await click('[data-test-mfa-method-menu-link="details"]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.methods.method.index',
       'Details more menu action transitions to method route'
@@ -81,7 +81,7 @@ module('Acceptance | mfa-method', function (hooks) {
     await click('.breadcrumb a');
     await click('[data-test-popup-menu-trigger]');
     await click('[data-test-mfa-method-menu-link="edit"]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.methods.method.edit',
       'Edit more menu action transitions to method edit route'
@@ -138,7 +138,7 @@ module('Acceptance | mfa-method', function (hooks) {
 
     await click('[data-test-mfa-method-list-item]');
     await click('[data-test-mfa-method-edit]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.methods.method.edit',
       'Toolbar action transitions to edit route'
@@ -191,7 +191,7 @@ module('Acceptance | mfa-method', function (hooks) {
         await fillIn(`[data-test-${inputType}="${field}"]`, 'foo');
       }
       await click('[data-test-mfa-create-save]');
-      assert.equal(
+      assert.strictEqual(
         currentRouteName(),
         'vault.cluster.access.mfa.methods.method.index',
         `${type} method is displayed on save`
@@ -212,7 +212,7 @@ module('Acceptance | mfa-method', function (hooks) {
     await fillIn('[data-test-mount-accessor-select]', 'auth_userpass_bb95c2b1');
     await click('[data-test-mlef-add-target]');
     await click('[data-test-mfa-create-save]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.methods.method.index',
       'Route transitions to method on save'
@@ -240,7 +240,7 @@ module('Acceptance | mfa-method', function (hooks) {
     const name = enforcement.children[0].textContent.trim();
     await click(enforcement);
     await click('[data-test-mfa-create-save]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.mfa.methods.method.index',
       'Route transitions to method on save'

--- a/ui/tests/acceptance/mfa-setup-test.js
+++ b/ui/tests/acceptance/mfa-setup-test.js
@@ -55,7 +55,7 @@ module('Acceptance | mfa-setup', function (hooks) {
     // the network requests required in this test
     this.server.post('/identity/mfa/method/totp/admin-generate', (scheme, req) => {
       const json = JSON.parse(req.requestBody);
-      assert.equal(json.method_id, '123', 'sends the UUID value');
+      assert.strictEqual(json.method_id, '123', 'sends the UUID value');
       return {
         data: {
           barcode:
@@ -67,7 +67,7 @@ module('Acceptance | mfa-setup', function (hooks) {
     });
     this.server.post('/identity/mfa/method/totp/admin-destroy', (scheme, req) => {
       const json = JSON.parse(req.requestBody);
-      assert.equal(json.method_id, '123', 'sends the UUID value');
+      assert.strictEqual(json.method_id, '123', 'sends the UUID value');
       // returns nothing
       return {};
     });

--- a/ui/tests/acceptance/oidc-config/clients-assignments-test.js
+++ b/ui/tests/acceptance/oidc-config/clients-assignments-test.js
@@ -49,7 +49,7 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
     await clearRecord(this.store, 'oidc/assignment', 'test-assignment');
 
     await visit(OIDC_BASE_URL + '/assignments');
-    assert.equal(currentURL(), '/vault/access/oidc/assignments');
+    assert.strictEqual(currentURL(), '/vault/access/oidc/assignments');
     assert.dom('[data-test-tab="assignments"]').hasClass('active', 'assignments tab is active');
     assert
       .dom('[data-test-oidc-assignment-linked-block="allow_all"]')
@@ -61,7 +61,7 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
     this.server.get('/identity/oidc/client', () => overrideMirageResponse(404));
 
     await visit(OIDC_BASE_URL);
-    assert.equal(currentURL(), '/vault/access/oidc');
+    assert.strictEqual(currentURL(), '/vault/access/oidc');
     assert.dom('h1.title.is-3').hasText('OIDC Provider');
     assert.dom(SELECTORS.oidcHeader).hasText(
       `Configure Vault to act as an OIDC identity provider, and offer Vault’s various authentication
@@ -84,19 +84,23 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
 
     // create a client with allow all access
     await visit(OIDC_BASE_URL + '/clients/create');
-    assert.equal(currentRouteName(), 'vault.cluster.access.oidc.clients.create', 'navigates to create form');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.access.oidc.clients.create',
+      'navigates to create form'
+    );
     await fillIn('[data-test-input="name"]', 'test-app');
     await click('[data-test-toggle-group="More options"]');
     // toggle ttls to false, testing it sets correct default duration
     await click('[data-test-input="idTokenTtl"]');
     await click('[data-test-input="accessTokenTtl"]');
     await click(SELECTORS.clientSaveButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Successfully created the application test-app.',
       'renders success flash upon client creation'
     );
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.clients.client.details',
       'navigates to client details view after save'
@@ -123,7 +127,7 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
     // edit client
     await click(SELECTORS.clientDetailsTab);
     await click(SELECTORS.clientEditButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.clients.client.edit',
       'navigates to edit page from details'
@@ -140,18 +144,18 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
     await click('[data-test-search-select="groups"] .ember-basic-dropdown-trigger');
     await searchSelect.options.objectAt(0).click();
     await click(SELECTORS.assignmentSaveButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Successfully created the assignment assignment-inline.',
       'renders success flash upon assignment creating'
     );
     await click(SELECTORS.clientSaveButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Successfully updated the application test-app.',
       'renders success flash upon client updating'
     );
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.clients.client.details',
       'navigates back to details on update'
@@ -178,22 +182,22 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
     // immediately delete client, test transition
     await click(SELECTORS.clientDeleteButton);
     await click(SELECTORS.confirmActionButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Application deleted successfully',
       'renders success flash upon deleting client'
     );
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.clients.index',
       'navigates back to list view after delete'
     );
     // delete last client
     await click('[data-test-oidc-client-linked-block]');
-    assert.equal(currentRouteName(), 'vault.cluster.access.oidc.clients.client.details');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.access.oidc.clients.client.details');
     await click(SELECTORS.clientDeleteButton);
     await click(SELECTORS.confirmActionButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.index',
       'redirects to call to action if only existing client is deleted'
@@ -211,7 +215,7 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
 
     // create a new assignment
     await click(SELECTORS.assignmentCreateButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.assignments.create',
       'navigates to create form'
@@ -220,12 +224,12 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
     await click('[data-test-component="search-select"]#entities .ember-basic-dropdown-trigger');
     await click('.ember-power-select-option');
     await click(SELECTORS.assignmentSaveButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Successfully created the assignment test-assignment.',
       'renders success flash upon creating the assignment'
     );
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.assignments.assignment.details',
       'navigates to the assignments detail view after save'
@@ -237,7 +241,7 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
 
     // edit assignment
     await click(SELECTORS.assignmentEditButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.assignments.assignment.edit',
       'navigates to the assignment edit page from details'
@@ -246,7 +250,7 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
     await click('.ember-power-select-option');
     assert.dom('[data-test-oidc-assignment-save]').hasText('Update');
     await click(SELECTORS.assignmentSaveButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Successfully updated the assignment test-assignment.',
       'renders success flash upon updating the assignment'
@@ -258,12 +262,12 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
     // delete the assignment
     await click(SELECTORS.assignmentDeleteButton);
     await click(SELECTORS.confirmActionButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Assignment deleted successfully',
       'renders success flash upon deleting assignment'
     );
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.assignments.index',
       'navigates back to assignment list view after delete'
@@ -284,13 +288,13 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
       .exists('displays linked block for test-assignment');
 
     await click(SELECTORS.assignmentCreateButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.assignments.create',
       'assignments index toolbar navigates to create form'
     );
     await click(SELECTORS.assignmentCancelButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.assignments.index',
       'create form navigates back to assignment index on cancel'
@@ -298,13 +302,13 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
 
     await click('[data-test-popup-menu-trigger]');
     await click('[data-test-oidc-assignment-menu-link="edit"]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.assignments.assignment.edit',
       'linked block popup menu navigates to edit'
     );
     await click(SELECTORS.assignmentCancelButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.assignments.assignment.details',
       'edit form navigates back to assignment details on cancel'
@@ -313,7 +317,7 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
     await visit('/vault/access/oidc/assignments');
     await click('[data-test-popup-menu-trigger]');
     await click('[data-test-oidc-assignment-menu-link="details"]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.assignments.assignment.details',
       'popup menu navigates to assignment details'
@@ -340,7 +344,7 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
     assert.dom(SELECTORS.assignmentDetailsTab).hasClass('active', 'details tab is active');
     assert.dom(SELECTORS.assignmentDeleteButton).doesNotExist('delete option is hidden');
     assert.dom(SELECTORS.assignmentEditButton).doesNotExist('edit button is hidden');
-    assert.equal(
+    assert.strictEqual(
       findAll('[data-test-component="info-table-row"]').length,
       3,
       'renders all assignment info rows'

--- a/ui/tests/acceptance/oidc-config/clients-keys-test.js
+++ b/ui/tests/acceptance/oidc-config/clients-keys-test.js
@@ -60,7 +60,7 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
 
     // check reroutes from oidc index to clients index when client exists
     await visit(OIDC_BASE_URL);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.clients.index',
       'redirects to clients index route when clients exist'
@@ -73,7 +73,7 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
     // navigate to keys
     await click('[data-test-tab="keys"]');
     assert.dom('[data-test-tab="keys"]').hasClass('active', 'keys tab is active');
-    assert.equal(currentRouteName(), 'vault.cluster.access.oidc.keys.index');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.access.oidc.keys.index');
     assert
       .dom('[data-test-oidc-key-linked-block="default"]')
       .hasText('default', 'index page lists default key');
@@ -83,13 +83,13 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
     await click('[data-test-oidc-key-menu-link="details"]');
     assert.dom(SELECTORS.keyDeleteButton).isDisabled('delete button is disabled for default key');
     await click(SELECTORS.keyEditButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.keys.key.edit',
       'navigates to edit from key details'
     );
     await click(SELECTORS.keyCancelButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.keys.key.details',
       'key edit form navigates back to details on cancel'
@@ -101,16 +101,20 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
 
     // create a new key
     await click('[data-test-breadcrumb-link="oidc-keys"]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.keys.index',
       'keys breadcrumb navigates back to list view'
     );
     await click('[data-test-oidc-key-create]');
-    assert.equal(currentRouteName(), 'vault.cluster.access.oidc.keys.create', 'navigates to key create form');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.access.oidc.keys.create',
+      'navigates to key create form'
+    );
     await fillIn('[data-test-input="name"]', 'test-key');
     await click(SELECTORS.keySaveButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.keys.key.details',
       'navigates to key details after save'
@@ -130,25 +134,25 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
     await visit(OIDC_BASE_URL + '/keys');
     await click('[data-test-oidc-key-linked-block="test-key"] [data-test-popup-menu-trigger]');
     await click('[data-test-oidc-key-menu-link="edit"]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.keys.key.edit',
       'key linked block popup menu navigates to edit'
     );
     await click('label[for=limited]');
     await clickTrigger();
-    assert.equal(searchSelect.options.length, 1, 'dropdown has only application that uses this key');
+    assert.strictEqual(searchSelect.options.length, 1, 'dropdown has only application that uses this key');
     assert
       .dom('.ember-power-select-option')
       .hasTextContaining('client-with-test-key', 'dropdown renders correct application');
     await searchSelect.options.objectAt(0).click();
     await click(SELECTORS.keySaveButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Successfully updated the key test-key.',
       'renders success flash upon key updating'
     );
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.keys.key.details',
       'navigates back to details on update'
@@ -157,7 +161,7 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
     assert
       .dom('[data-test-oidc-client-linked-block="client-with-test-key"]')
       .exists('lists client-with-test-key');
-    assert.equal(findAll('[data-test-oidc-client-linked-block]').length, 1, 'it lists only one client');
+    assert.strictEqual(findAll('[data-test-oidc-client-linked-block]').length, 1, 'it lists only one client');
 
     // edit back to allow all
     await click(SELECTORS.keyDetailsTab);
@@ -183,7 +187,7 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
     this.server.get('/identity/oidc/client', () => overrideMirageResponse(null, CLIENT_LIST_RESPONSE));
     this.server.post('/identity/oidc/key/test-key/rotate', (schema, req) => {
       const json = JSON.parse(req.requestBody);
-      assert.equal(json.verification_ttl, 86400, 'request made with correct args to accurate endpoint');
+      assert.strictEqual(json.verification_ttl, 86400, 'request made with correct args to accurate endpoint');
     });
 
     //* clear out test state
@@ -198,7 +202,7 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
     assert.dom('input#limited').isDisabled('limiting access radio button is disabled on create');
     assert.dom('label[for=limited]').hasClass('is-disabled', 'limited radio button label has disabled class');
     await click(SELECTORS.keySaveButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Successfully created the key test-key.',
       'renders success flash upon key creation'
@@ -217,7 +221,7 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
     await click(SELECTORS.keyDetailsTab);
     await click(SELECTORS.keyRotateButton);
     await click(SELECTORS.confirmActionButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Success: test-key connection was rotated.',
       'renders success flash upon key rotation'
@@ -225,12 +229,12 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
     // delete
     await click(SELECTORS.keyDeleteButton);
     await click(SELECTORS.confirmActionButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Key deleted successfully',
       'success flash message renders after deleting key'
     );
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.keys.index',
       'navigates back to list view after delete'
@@ -249,10 +253,10 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
     assert.dom(SELECTORS.clientDetailsTab).hasClass('active', 'details tab is active');
     assert.dom(SELECTORS.clientDeleteButton).exists('toolbar renders delete option');
     assert.dom(SELECTORS.clientEditButton).exists('toolbar renders edit button');
-    assert.equal(findAll('[data-test-component="info-table-row"]').length, 9, 'renders all info rows');
+    assert.strictEqual(findAll('[data-test-component="info-table-row"]').length, 9, 'renders all info rows');
 
     await click(SELECTORS.clientProvidersTab);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.clients.client.providers',
       'navigates to client providers route'
@@ -277,7 +281,7 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
     assert.dom(SELECTORS.clientDetailsTab).hasClass('active', 'details tab is active');
     assert.dom(SELECTORS.clientDeleteButton).doesNotExist('delete option is hidden');
     assert.dom(SELECTORS.clientEditButton).doesNotExist('edit button is hidden');
-    assert.equal(findAll('[data-test-component="info-table-row"]').length, 9, 'renders all info rows');
+    assert.strictEqual(findAll('[data-test-component="info-table-row"]').length, 9, 'renders all info rows');
   });
 
   test('it hides delete and edit key when no permission', async function (assert) {
@@ -300,6 +304,6 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
     assert.dom(SELECTORS.keyDetailsTab).hasClass('active', 'details tab is active');
     assert.dom(SELECTORS.keyDeleteButton).doesNotExist('delete option is hidden');
     assert.dom(SELECTORS.keyEditButton).doesNotExist('edit button is hidden');
-    assert.equal(findAll('[data-test-component="info-table-row"]').length, 4, 'renders all info rows');
+    assert.strictEqual(findAll('[data-test-component="info-table-row"]').length, 4, 'renders all info rows');
   });
 });

--- a/ui/tests/acceptance/oidc-config/providers-scopes-test.js
+++ b/ui/tests/acceptance/oidc-config/providers-scopes-test.js
@@ -55,7 +55,7 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
     this.server.get('/identity/oidc/scope', () => overrideMirageResponse(404));
     await visit(OIDC_BASE_URL);
     await click('[data-test-tab="scopes"]');
-    assert.equal(currentURL(), '/vault/access/oidc/scopes');
+    assert.strictEqual(currentURL(), '/vault/access/oidc/scopes');
     assert.dom('[data-test-tab="scopes"]').hasClass('active', 'scopes tab is active');
     assert
       .dom(SELECTORS.scopeEmptyState)
@@ -76,7 +76,7 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
       overrideMirageResponse(null, SCOPE_DATA_RESPONSE)
     );
     await visit(OIDC_BASE_URL + '/scopes');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.scopes.index',
       'redirects to scopes index route when scopes exist'
@@ -87,13 +87,13 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
 
     // navigates to/from create, edit, detail views from list view
     await click(SELECTORS.scopeCreateButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.scopes.create',
       'scope index toolbar navigates to create form'
     );
     await click(SELECTORS.scopeCancelButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.scopes.index',
       'create form navigates back to index on cancel'
@@ -101,13 +101,13 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
 
     await click('[data-test-popup-menu-trigger]');
     await click('[data-test-oidc-scope-menu-link="edit"]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.scopes.scope.edit',
       'linked block popup menu navigates to edit'
     );
     await click(SELECTORS.scopeCancelButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.scopes.scope.details',
       'scope edit form navigates back to details on cancel'
@@ -117,7 +117,7 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
     await click('[data-test-breadcrumb-link="oidc-scopes"]');
     await click('[data-test-popup-menu-trigger]');
     await click('[data-test-oidc-scope-menu-link="details"]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.scopes.scope.details',
       'popup menu navigates to details'
@@ -126,7 +126,7 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
     assert.dom(SELECTORS.scopeDetailsTab).hasClass('active', 'details tab is active');
     assert.dom(SELECTORS.scopeDeleteButton).exists('toolbar renders delete option');
     assert.dom(SELECTORS.scopeEditButton).exists('toolbar renders edit button');
-    assert.equal(findAll('[data-test-component="info-table-row"]').length, 2, 'renders all info rows');
+    assert.strictEqual(findAll('[data-test-component="info-table-row"]').length, 2, 'renders all info rows');
   });
 
   // ERROR DELETING SCOPE
@@ -158,7 +158,7 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
     // try to delete scope
     await click(SELECTORS.scopeDeleteButton);
     await click(SELECTORS.confirmActionButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'unable to delete scope "test-scope" because it is currently referenced by these providers: test-provider',
       'renders error flash upon scope deletion'
@@ -175,17 +175,21 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
 
     // create a new scope
     await visit(OIDC_BASE_URL + '/scopes/create');
-    assert.equal(currentRouteName(), 'vault.cluster.access.oidc.scopes.create', 'navigates to create form');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.access.oidc.scopes.create',
+      'navigates to create form'
+    );
     await fillIn('[data-test-input="name"]', 'test-scope');
     await fillIn('[data-test-input="description"]', 'this is a test');
     await fillIn('[data-test-component="code-mirror-modifier"] textarea', SCOPE_DATA_RESPONSE.template);
     await click(SELECTORS.scopeSaveButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Successfully created the scope test-scope.',
       'renders success flash upon scope creation'
     );
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.scopes.scope.details',
       'navigates to scope detail view after save'
@@ -198,19 +202,19 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
 
     // edit scope
     await click(SELECTORS.scopeEditButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.scopes.scope.edit',
       'navigates to edit page from details'
     );
     await fillIn('[data-test-input="description"]', 'this is an edit test');
     await click(SELECTORS.scopeSaveButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Successfully updated the scope test-scope.',
       'renders success flash upon scope updating'
     );
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.scopes.scope.details',
       'navigates back to scope details on update'
@@ -224,7 +228,7 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
     await click('[data-test-tab="providers"]');
     assert.dom('[data-test-tab="providers"]').hasClass('active', 'providers tab is active');
     await click('[data-test-oidc-provider-create]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.providers.create',
       'navigates to provider create form'
@@ -233,12 +237,12 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
     await clickTrigger('#scopesSupported');
     await selectChoose('#scopesSupported', 'test-scope');
     await click(SELECTORS.providerSaveButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Successfully created the OIDC provider test-provider.',
       'renders success flash upon provider creation'
     );
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.providers.provider.details',
       'navigates to provider detail view after save'
@@ -255,7 +259,7 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
 
     // check provider's application list view
     await click(SELECTORS.providerClientsTab);
-    assert.equal(
+    assert.strictEqual(
       findAll('[data-test-oidc-client-linked-block]').length,
       2,
       'all applications appear in provider applications tab'
@@ -264,7 +268,7 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
     // edit and limit applications
     await click(SELECTORS.providerDetailsTab);
     await click(SELECTORS.providerEditButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.providers.provider.edit',
       'navigates to provider edit page from details'
@@ -274,12 +278,12 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
     await fillIn('.ember-power-select-search input', 'test-app');
     await searchSelect.options.objectAt(0).click();
     await click(SELECTORS.providerSaveButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Successfully updated the OIDC provider test-provider.',
       'renders success flash upon provider updating'
     );
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.providers.provider.details',
       'navigates back to provider details after updating'
@@ -295,7 +299,7 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
     await click('label[for=allow-all]');
     await click(SELECTORS.providerSaveButton);
     await click(SELECTORS.providerClientsTab);
-    assert.equal(
+    assert.strictEqual(
       findAll('[data-test-oidc-client-linked-block]').length,
       2,
       'all applications appear in provider applications tab'
@@ -305,12 +309,12 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
     await click(SELECTORS.providerDetailsTab);
     await click(SELECTORS.providerDeleteButton);
     await click(SELECTORS.confirmActionButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Provider deleted successfully',
       'success flash message renders after deleting provider'
     );
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.providers.index',
       'navigates back to list view after delete'
@@ -320,12 +324,12 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
     await visit(OIDC_BASE_URL + '/scopes/test-scope/details');
     await click(SELECTORS.scopeDeleteButton);
     await click(SELECTORS.confirmActionButton);
-    assert.equal(
+    assert.strictEqual(
       flashMessage.latestMessage,
       'Scope deleted successfully',
       'renders success flash upon deleting scope'
     );
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.scopes.index',
       'navigates back to list view after delete'
@@ -338,20 +342,20 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
     await visit(OIDC_BASE_URL);
     await click('[data-test-tab="providers"]');
     assert.dom('[data-test-tab="providers"]').hasClass('active', 'providers tab is active');
-    assert.equal(currentURL(), '/vault/access/oidc/providers');
+    assert.strictEqual(currentURL(), '/vault/access/oidc/providers');
     assert
       .dom('[data-test-oidc-provider-linked-block="default"]')
       .exists('index page lists default provider');
     await click('[data-test-popup-menu-trigger]');
 
     await click('[data-test-oidc-provider-menu-link="edit"]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.providers.provider.edit',
       'provider linked block popup menu navigates to edit'
     );
     await click(SELECTORS.providerCancelButton);
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.providers.provider.details',
       'provider edit form navigates back to details on cancel'
@@ -359,7 +363,7 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
 
     // navigate to details from index page
     await click('[data-test-breadcrumb-link="oidc-providers"]');
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.access.oidc.providers.index',
       'providers breadcrumb navigates back to list view'

--- a/ui/tests/acceptance/oidc-provider-test.js
+++ b/ui/tests/acceptance/oidc-provider-test.js
@@ -155,7 +155,7 @@ module('Acceptance | oidc provider', function (hooks) {
     await authFormComponent.password(USER_PASSWORD);
     await authFormComponent.login();
     await settled();
-    assert.equal(currentURL(), url, 'URL is as expected after login');
+    assert.strictEqual(currentURL(), url, 'URL is as expected after login');
     assert.dom('[data-test-oidc-redirect]').exists('redirect text exists');
     assert
       .dom('[data-test-oidc-redirect]')

--- a/ui/tests/acceptance/policies-acl-old-test.js
+++ b/ui/tests/acceptance/policies-acl-old-test.js
@@ -24,12 +24,12 @@ module('Acceptance | policies (old)', function (hooks) {
     await fillIn('[data-test-policy-input="name"]', policyName);
     await click('[data-test-policy-save]');
     const errors = await waitUntil(() => findAll('[data-test-error]'));
-    assert.equal(errors.length, 1, 'renders error messages on save');
+    assert.strictEqual(errors.length, 1, 'renders error messages on save');
     find('.CodeMirror').CodeMirror.setValue(policyString);
     await click('[data-test-policy-save]');
 
     await waitUntil(() => currentURL() === `/vault/policy/acl/${encodeURIComponent(policyLower)}`);
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/policy/acl/${encodeURIComponent(policyLower)}`,
       'navigates to policy show on successful save'
@@ -51,7 +51,11 @@ module('Acceptance | policies (old)', function (hooks) {
 
     await click('[data-test-confirm-button]');
     await waitUntil(() => currentURL() === `/vault/policies/acl`);
-    assert.equal(currentURL(), `/vault/policies/acl`, 'navigates to policy list on successful deletion');
+    assert.strictEqual(
+      currentURL(),
+      `/vault/policies/acl`,
+      'navigates to policy list on successful deletion'
+    );
     assert
       .dom(`[data-test-policy-item="${policyLower}"]`)
       .doesNotExist('deleted policy is not shown in the list');

--- a/ui/tests/acceptance/policies-test.js
+++ b/ui/tests/acceptance/policies-test.js
@@ -12,17 +12,17 @@ module('Acceptance | policies', function (hooks) {
 
   test('it redirects to acls on unknown policy type', async function (assert) {
     await visit('/vault/policy/foo/default');
-    assert.equal(currentRouteName(), 'vault.cluster.policies.index');
-    assert.equal(currentURL(), '/vault/policies/acl');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.policies.index');
+    assert.strictEqual(currentURL(), '/vault/policies/acl');
 
     await visit('/vault/policy/foo/default/edit');
-    assert.equal(currentRouteName(), 'vault.cluster.policies.index');
-    assert.equal(currentURL(), '/vault/policies/acl');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.policies.index');
+    assert.strictEqual(currentURL(), '/vault/policies/acl');
   });
 
   test('it redirects to acls on index navigation', async function (assert) {
     await visit('/vault/policy/acl');
-    assert.equal(currentRouteName(), 'vault.cluster.policies.index');
-    assert.equal(currentURL(), '/vault/policies/acl');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.policies.index');
+    assert.strictEqual(currentURL(), '/vault/policies/acl');
   });
 });

--- a/ui/tests/acceptance/policies/index-test.js
+++ b/ui/tests/acceptance/policies/index-test.js
@@ -19,7 +19,7 @@ module('Acceptance | policies/acl', function (hooks) {
   test('it lists default and root acls', async function (assert) {
     await page.visit({ type: 'acl' });
     await settled();
-    assert.equal(currentURL(), '/vault/policies/acl');
+    assert.strictEqual(currentURL(), '/vault/policies/acl');
     assert.ok(page.findPolicyByName('root'), 'root policy shown in the list');
     assert.ok(page.findPolicyByName('default'), 'default policy shown in the list');
   });
@@ -29,8 +29,8 @@ module('Acceptance | policies/acl', function (hooks) {
     await settled();
     await page.findPolicyByName('default').click();
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.policy.show');
-    assert.equal(currentURL(), '/vault/policy/acl/default');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.policy.show');
+    assert.strictEqual(currentURL(), '/vault/policy/acl/default');
   });
 
   test('it allows deletion of policies with dots in names', async function (assert) {

--- a/ui/tests/acceptance/policy-test.js
+++ b/ui/tests/acceptance/policy-test.js
@@ -17,7 +17,7 @@ module('Acceptance | policies', function (hooks) {
 
   test('it redirects to acls with unknown policy type', async function (assert) {
     await visit('/vault/policies/foo');
-    assert.equal(currentRouteName(), 'vault.cluster.policies.index');
-    assert.equal(currentURL(), '/vault/policies/acl');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.policies.index');
+    assert.strictEqual(currentURL(), '/vault/policies/acl');
   });
 });

--- a/ui/tests/acceptance/policy/edit-test.js
+++ b/ui/tests/acceptance/policy/edit-test.js
@@ -13,7 +13,11 @@ module('Acceptance | policy/acl/:name/edit', function (hooks) {
 
   test('it redirects to list if navigating to root', async function (assert) {
     await page.visit({ type: 'acl', name: 'root' });
-    assert.equal(currentURL(), '/vault/policies/acl', 'navigation to root show redirects you to policy list');
+    assert.strictEqual(
+      currentURL(),
+      '/vault/policies/acl',
+      'navigation to root show redirects you to policy list'
+    );
   });
 
   test('it does not show delete for default policy', async function (assert) {
@@ -23,6 +27,6 @@ module('Acceptance | policy/acl/:name/edit', function (hooks) {
 
   test('it navigates to show when the toggle is clicked', async function (assert) {
     await page.visit({ type: 'acl', name: 'default' }).toggleEdit();
-    assert.equal(currentURL(), '/vault/policy/acl/default', 'toggle navigates from edit to show');
+    assert.strictEqual(currentURL(), '/vault/policy/acl/default', 'toggle navigates from edit to show');
   });
 });

--- a/ui/tests/acceptance/policy/show-test.js
+++ b/ui/tests/acceptance/policy/show-test.js
@@ -13,11 +13,15 @@ module('Acceptance | policy/acl/:name', function (hooks) {
 
   test('it redirects to list if navigating to root', async function (assert) {
     await page.visit({ type: 'acl', name: 'root' });
-    assert.equal(currentURL(), '/vault/policies/acl', 'navigation to root show redirects you to policy list');
+    assert.strictEqual(
+      currentURL(),
+      '/vault/policies/acl',
+      'navigation to root show redirects you to policy list'
+    );
   });
 
   test('it navigates to edit when the toggle is clicked', async function (assert) {
     await page.visit({ type: 'acl', name: 'default' }).toggleEdit();
-    assert.equal(currentURL(), '/vault/policy/acl/default/edit', 'toggle navigates to edit page');
+    assert.strictEqual(currentURL(), '/vault/policy/acl/default/edit', 'toggle navigates to edit page');
   });
 });

--- a/ui/tests/acceptance/raft-storage-test.js
+++ b/ui/tests/acceptance/raft-storage-test.js
@@ -41,7 +41,7 @@ module('Acceptance | raft storage', function (hooks) {
     await visit('/vault/secrets');
     await visit('/vault/storage/raft');
     const store = this.owner.lookup('service:store');
-    assert.equal(
+    assert.strictEqual(
       store.peekAll('server').length,
       2,
       'Store contains 2 server records since remove peer was triggered externally'
@@ -55,7 +55,7 @@ module('Acceptance | raft storage', function (hooks) {
     this.server.get('/sys/storage/raft/configuration', () => this.config);
     this.server.post('/sys/storage/raft/remove-peer', (schema, req) => {
       const body = JSON.parse(req.requestBody);
-      assert.equal(
+      assert.strictEqual(
         body.server_id,
         this.config.data.config.servers[1].node_id,
         'Remove peer request made with node id'

--- a/ui/tests/acceptance/redirect-to-test.js
+++ b/ui/tests/acceptance/redirect-to-test.js
@@ -59,7 +59,7 @@ module('Acceptance | redirect_to query param functionality', function (hooks) {
     // the login method on this page does another visit call that we don't want here
     await auth.tokenInput('root').submit();
     await settled();
-    assert.equal(currentURL(), url, 'navigates to the redirect_to url after auth');
+    assert.strictEqual(currentURL(), url, 'navigates to the redirect_to url after auth');
   });
 
   test('redirect from root does not include redirect_to', async function (assert) {
@@ -77,7 +77,7 @@ module('Acceptance | redirect_to query param functionality', function (hooks) {
     );
     await auth.tokenInput('root').submit();
     await settled();
-    assert.equal(currentURL(), url, 'navigates to the redirect_to with the query param after auth');
+    assert.strictEqual(currentURL(), url, 'navigates to the redirect_to with the query param after auth');
   });
 
   test('redirect to logout with wrapped token authenticates you', async function (assert) {
@@ -90,6 +90,6 @@ module('Acceptance | redirect_to query param functionality', function (hooks) {
     });
     await settled();
 
-    assert.equal(currentURL(), url, 'authenticates then navigates to the redirect_to url after auth');
+    assert.strictEqual(currentURL(), url, 'authenticates then navigates to the redirect_to url after auth');
   });
 });

--- a/ui/tests/acceptance/secrets/backend/alicloud/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/alicloud/secret-test.js
@@ -21,7 +21,11 @@ module('Acceptance | alicloud/enable', function (hooks) {
     await mountSecrets.next().path(enginePath).submit();
     await settled();
 
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backends', 'redirects to the backends page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backends',
+      'redirects to the backends page'
+    );
     await settled();
     assert.ok(backendsPage.rows.filterBy('path', `${enginePath}/`)[0], 'shows the alicloud engine');
   });

--- a/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
@@ -23,13 +23,21 @@ module('Acceptance | secrets/cubbyhole/create', function (hooks) {
     const kvPath = `cubbyhole-kv-${new Date().getTime()}`;
     await listPage.visitRoot({ backend: 'cubbyhole' });
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.list-root', 'navigates to the list page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.list-root',
+      'navigates to the list page'
+    );
 
     await listPage.create();
     await settled();
     await editPage.createSecret(kvPath, 'foo', 'bar');
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.show',
+      'redirects to the show page'
+    );
     assert.ok(showPage.editIsPresent, 'shows the edit button');
   });
 });

--- a/ui/tests/acceptance/secrets/backend/database/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/database/secret-test.js
@@ -248,7 +248,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
     let backend = `database-${Date.now()}`;
     await mountSecrets.enable('database', backend);
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/list`,
       'Mounts and redirects to connection list page'
@@ -258,7 +258,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
       .dom('.active[data-test-secret-list-tab="Connections"]')
       .exists('Has Connections tab which is active');
     await click('[data-test-tab="overview"]');
-    assert.equal(currentURL(), `/vault/secrets/${backend}/overview`, 'Tab links to overview page');
+    assert.strictEqual(currentURL(), `/vault/secrets/${backend}/overview`, 'Tab links to overview page');
     assert.dom('[data-test-component="empty-state"]').exists('Empty state also exists on overview page');
     assert.dom('[data-test-secret-list-tab="Roles"]').exists('Has Roles tab');
   });
@@ -268,7 +268,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
     const backend = await mount();
     for (let testCase of connectionTests) {
       await connectionPage.visitCreate({ backend });
-      assert.equal(currentURL(), `/vault/secrets/${backend}/create`, 'Correct creation URL');
+      assert.strictEqual(currentURL(), `/vault/secrets/${backend}/create`, 'Correct creation URL');
       assert
         .dom('[data-test-empty-state-title]')
         .hasText('No plugin selected', 'No plugin is selected by default and empty state shows');
@@ -316,7 +316,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
       // click "Add Role"
       await connectionPage.addRole();
       await settled();
-      assert.equal(
+      assert.strictEqual(
         searchSelectComponent.selectedOptions[0].text,
         testCase.name,
         'Database connection is pre-selected on the form'
@@ -338,13 +338,13 @@ module('Acceptance | secrets/database/*', function (hooks) {
         { label: 'Write concern', name: 'write_concern' },
       ],
     };
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/list`,
       'Mounts and redirects to connection list page'
     );
     await connectionPage.createLink();
-    assert.equal(currentURL(), `/vault/secrets/${backend}/create`, 'Create link goes to create page');
+    assert.strictEqual(currentURL(), `/vault/secrets/${backend}/create`, 'Create link goes to create page');
     assert
       .dom('[data-test-empty-state-title]')
       .hasText('No plugin selected', 'No plugin is selected by default and empty state shows');
@@ -366,7 +366,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
       .dom('.modal.is-active .title')
       .hasText('Rotate your root credentials?', 'Modal appears asking to ');
     await connectionPage.enable();
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/show/${connectionDetails.id}`,
       'Saves connection and takes you to show page'
@@ -389,7 +389,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
     await fillIn('[data-test-confirmation-modal-input="Delete connection?"]', connectionDetails.id);
     await click('[data-test-confirm-button]');
 
-    assert.equal(currentURL(), `/vault/secrets/${backend}/list`, 'Redirects to connection list page');
+    assert.strictEqual(currentURL(), `/vault/secrets/${backend}/list`, 'Redirects to connection list page');
     assert
       .dom('[data-test-empty-state-title]')
       .hasText('No connections in this backend', 'No connections listed because it was deleted');
@@ -427,7 +427,11 @@ module('Acceptance | secrets/database/*', function (hooks) {
     await logout.visit();
     await authPage.login(token);
     await connectionPage.visitShow({ backend, id: connection });
-    assert.equal(currentURL(), `/vault/secrets/${backend}/show/${connection}`, 'Allows reading connection');
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets/${backend}/show/${connection}`,
+      'Allows reading connection'
+    );
     assert
       .dom('[data-test-database-connection-delete]')
       .doesNotExist('Delete button does not show due to permissions');
@@ -457,7 +461,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
       .dom('[data-test-component="empty-state"]')
       .exists({ count: 2 }, 'Two empty states exist before selections made');
     await clickTrigger('#database');
-    assert.equal(searchSelectComponent.options.length, 1, 'list shows existing connections so far');
+    assert.strictEqual(searchSelectComponent.options.length, 1, 'list shows existing connections so far');
     await selectChoose('#database', '.ember-power-select-option', 0);
     assert
       .dom('[data-test-component="empty-state"]')
@@ -514,7 +518,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
     assert.dom('[data-test-secret-list-tab="Roles"]').exists('renders connections tab');
 
     await click('[data-test-secret-create="connections"]');
-    assert.equal(currentURL(), '/vault/secrets/database/create');
+    assert.strictEqual(currentURL(), '/vault/secrets/database/create');
 
     // Login with restricted policy
     await logout.visit();
@@ -532,6 +536,6 @@ module('Acceptance | secrets/database/*', function (hooks) {
       .exists({ count: 1 }, 'renders only the connection card');
 
     await click('[data-test-action-text="Configure new"]');
-    assert.equal(currentURL(), '/vault/secrets/database/create?itemType=connection');
+    assert.strictEqual(currentURL(), '/vault/secrets/database/create?itemType=connection');
   });
 });

--- a/ui/tests/acceptance/secrets/backend/engines-test.js
+++ b/ui/tests/acceptance/secrets/backend/engines-test.js
@@ -28,9 +28,13 @@ module('Acceptance | engine/disable', function (hooks) {
     await settled();
     await backendsPage.confirmDisable();
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backends', 'redirects to the backends page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backends',
+      'redirects to the backends page'
+    );
 
-    assert.equal(
+    assert.strictEqual(
       backendsPage.rows.filterBy('path', `${enginePath}/`).length,
       0,
       'does not show the disabled engine'

--- a/ui/tests/acceptance/secrets/backend/gcpkms/secrets-test.js
+++ b/ui/tests/acceptance/secrets/backend/gcpkms/secrets-test.js
@@ -20,7 +20,11 @@ module('Acceptance | gcpkms/enable', function (hooks) {
     await mountSecrets.selectType('gcpkms');
     await mountSecrets.next().path(enginePath).submit();
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backends', 'redirects to the backends page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backends',
+      'redirects to the backends page'
+    );
     assert.ok(backendsPage.rows.filterBy('path', `${enginePath}/`)[0], 'shows the gcpkms engine');
   });
 });

--- a/ui/tests/acceptance/secrets/backend/generic/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/generic/secret-test.js
@@ -30,12 +30,20 @@ module('Acceptance | secrets/generic/create', function (hooks) {
     const kvPath = `generic-kv-${new Date().getTime()}`;
     await cli.runCommands([`write sys/mounts/${path} type=generic`, `write ${path}/foo bar=baz`]);
     await listPage.visitRoot({ backend: path });
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.list-root', 'navigates to the list page');
-    assert.equal(listPage.secrets.length, 1, 'lists one secret in the backend');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.list-root',
+      'navigates to the list page'
+    );
+    assert.strictEqual(listPage.secrets.length, 1, 'lists one secret in the backend');
 
     await listPage.create();
     await editPage.createSecret(kvPath, 'foo', 'bar');
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.show',
+      'redirects to the show page'
+    );
     assert.ok(showPage.editIsPresent, 'shows the edit button');
   });
 
@@ -49,12 +57,16 @@ module('Acceptance | secrets/generic/create', function (hooks) {
       `write sys/mounts/${path}/tune options=version=2`,
     ]);
     await listPage.visitRoot({ backend: path });
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.list-root', 'navigates to the list page');
-    assert.equal(listPage.secrets.length, 1, 'lists the old secret in the backend');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.list-root',
+      'navigates to the list page'
+    );
+    assert.strictEqual(listPage.secrets.length, 1, 'lists the old secret in the backend');
 
     await listPage.create();
     await editPage.createSecret(kvPath, 'foo', 'bar');
     await listPage.visitRoot({ backend: path });
-    assert.equal(listPage.secrets.length, 2, 'lists two secrets in the backend');
+    assert.strictEqual(listPage.secrets.length, 2, 'lists two secrets in the backend');
   });
 });

--- a/ui/tests/acceptance/secrets/backend/kv/diff-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/diff-test.js
@@ -57,7 +57,7 @@ module('Acceptance | kv2 diff view', function (hooks) {
     await click('[data-test-view-diff]');
 
     let diffBetweenVersion2and1 = document.querySelector('.jsondiffpatch-added').innerText;
-    assert.equal(diffBetweenVersion2and1, 'version2"world!"', 'shows the correct added part');
+    assert.strictEqual(diffBetweenVersion2and1, 'version2"world!"', 'shows the correct added part');
 
     await click('[data-test-popup-menu-trigger="right-version"]');
 

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -34,7 +34,7 @@ let deleteEngine = async function (enginePath, assert) {
   await authPage.login();
   await consoleComponent.runCommands([`delete sys/mounts/${enginePath}`]);
   const response = consoleComponent.lastLogOutput;
-  assert.equal(
+  assert.strictEqual(
     response,
     `Success! Data deleted (if it existed) at: sys/mounts/${enginePath}`,
     'Engine successfully deleted'
@@ -57,7 +57,11 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     const secretPath = `kv-path-${new Date().getTime()}`;
     await listPage.visitRoot({ backend: 'secret' });
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.list-root', 'navigates to the list page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.list-root',
+      'navigates to the list page'
+    );
 
     await listPage.create();
     await settled();
@@ -67,7 +71,11 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await editPage.createSecret(secretPath, 'foo', 'bar');
     await settled();
 
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.show',
+      'redirects to the show page'
+    );
     assert.ok(showPage.editIsPresent, 'shows the edit button');
   });
 
@@ -78,7 +86,11 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await mountSecrets.enable('kv', enginePath);
     await consoleComponent.runCommands(`write ${enginePath}/config cas_required=true`);
     await writeSecret(enginePath, secretPath, 'foo', 'bar');
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.show',
+      'redirects to the show page'
+    );
     assert.ok(showPage.editIsPresent, 'shows the edit button');
   });
 
@@ -102,7 +114,7 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     let savedMaxVersions = Number(
       document.querySelector('[data-test-value-div="Maximum versions"]').innerText
     );
-    assert.equal(
+    assert.strictEqual(
       maxVersions,
       savedMaxVersions,
       'max_version displays the saved number set when creating the secret'
@@ -114,8 +126,8 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await click('[data-test-save-metadata]');
     let key = document.querySelector('[data-test-row-label="key"]').innerText;
     let value = document.querySelector('[data-test-row-value="key"]').innerText;
-    assert.equal(key, 'key', 'metadata key displays after adding it.');
-    assert.equal(value, 'value', 'metadata value displays after adding it.');
+    assert.strictEqual(key, 'key', 'metadata key displays after adding it.');
+    assert.strictEqual(value, 'value', 'metadata value displays after adding it.');
   });
 
   test('it can handle validation on custom metadata', async function (assert) {
@@ -170,13 +182,13 @@ module('Acceptance | secrets/secret/create', function (hooks) {
       '[data-test-value-div="Maximum number of versions"]'
     ).innerText;
 
-    assert.equal(
+    assert.strictEqual(
       maxVersion,
       savedMaxVersion,
       'displays the max version set when configuring the secret-engine'
     );
-    assert.equal(cas.trim(), 'Yes', 'displays the cas set when configuring the secret-engine');
-    assert.equal(
+    assert.strictEqual(cas.trim(), 'Yes', 'displays the cas set when configuring the secret-engine');
+    assert.strictEqual(
       deleteVersionAfter.trim(),
       '1s',
       'displays the delete version after set when configuring the secret-engine'
@@ -201,7 +213,7 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await editPage.metadataTab();
     await settled();
     let savedMaxVersions = Number(document.querySelectorAll('[data-test-value-div]')[0].innerText);
-    assert.equal(
+    assert.strictEqual(
       maxVersions,
       savedMaxVersions,
       'max_version displays the saved number set when creating the secret'
@@ -235,7 +247,11 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await editPage.path(secretPath);
     await triggerKeyEvent('[data-test-secret-path="true"]', 'keyup', 65);
     await click('[data-test-secret-save]');
-    assert.equal(currentURL(), `/vault/secrets/${enginePath}/show/${secretPath}`, 'navigates to show secret');
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets/${enginePath}/show/${secretPath}`,
+      'navigates to show secret'
+    );
   });
 
   test('it navigates to version history and to a specific version', async function (assert) {
@@ -265,7 +281,7 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await click('.linked-block');
     await click('button.button.masked-input-toggle');
     assert.dom('[data-test-masked-input]').hasText('bar', 'renders secret on the secret version show page');
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${enginePath}/show/${secretPath}?version=1`,
       'redirects to the show page with queryParam version=1'
@@ -281,7 +297,11 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await mountSecrets.next().path(enginePath).toggleOptions().version(1).submit();
     await listPage.create();
     await editPage.createSecret(secretPath, 'foo', 'bar');
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.show',
+      'redirects to the show page'
+    );
     assert.ok(showPage.editIsPresent, 'shows the edit button');
     // check for metadata tab should not exist on KV version 1
     assert.dom('[data-test-secret-metadata-tab]').doesNotExist('does not show metadata tab');
@@ -324,15 +344,15 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await listPage.delete();
     await listPage.confirmDelete();
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.list');
-    assert.equal(currentURL(), `/vault/secrets/${enginePath}/list/1/2/3/`, 'remains on the page');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.list');
+    assert.strictEqual(currentURL(), `/vault/secrets/${enginePath}/list/1/2/3/`, 'remains on the page');
 
     await listPage.secrets.objectAt(0).menuToggle();
     await listPage.delete();
     await listPage.confirmDelete();
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.list');
-    assert.equal(
+    assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.list');
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${enginePath}/list/1/`,
       'navigates to the ancestor created earlier'
@@ -349,7 +369,7 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await listPage.create();
     await editPage.createSecret(secretPath, 'foo', 'bar');
     await showPage.deleteSecretV1();
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.secrets.backend.list-root',
       'redirected to the list page on delete'
@@ -375,7 +395,7 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await settled();
     // use visit helper here because ids with / in them get encoded
     await visit('/vault/secrets/secret/list/foo/bar');
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.list');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.list');
     assert.ok(currentURL().endsWith('/'), 'redirects to the path ending in a slash');
   });
 
@@ -389,10 +409,14 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     instance.setValue(content);
     await editPage.save();
 
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.show',
+      'redirects to the show page'
+    );
     assert.ok(showPage.editIsPresent, 'shows the edit button');
     let savedInstance = document.querySelector('.CodeMirror').CodeMirror;
-    assert.equal(
+    assert.strictEqual(
       savedInstance.options.value,
       JSON.stringify({ bar: 'boo', foo: 'fa' }, null, 2),
       'saves the content'
@@ -431,7 +455,7 @@ module('Acceptance | secrets/secret/create', function (hooks) {
       await listPage.visit({ backend, id: path });
       assert.ok(listPage.secrets.filterBy('text', '2')[0], `${path}: secret is displayed properly`);
       await listPage.secrets.filterBy('text', '2')[0].click();
-      assert.equal(
+      assert.strictEqual(
         currentRouteName(),
         'vault.cluster.secrets.backend.show',
         `${path}: show page renders correctly`
@@ -467,7 +491,7 @@ module('Acceptance | secrets/secret/create', function (hooks) {
 
     // perform encode function that should be done by the encodePath
     let encodedSecretPath = secretPath.replace(/ /g, '%20');
-    assert.equal(currentURL(), `/vault/secrets/${enginePath}/show/${encodedSecretPath}?version=1`);
+    assert.strictEqual(currentURL(), `/vault/secrets/${enginePath}/show/${encodedSecretPath}?version=1`);
   });
 
   // the web cli does not handle a quote as part of a path, so we test it here via the UI
@@ -482,7 +506,7 @@ module('Acceptance | secrets/secret/create', function (hooks) {
       await listPage.visit({ backend: 'kv', id: path });
       assert.ok(listPage.secrets.filterBy('text', '2')[0], `${path}: secret is displayed properly`);
       await listPage.secrets.filterBy('text', '2')[0].click();
-      assert.equal(
+      assert.strictEqual(
         currentRouteName(),
         'vault.cluster.secrets.backend.show',
         `${path}: show page renders correctly`
@@ -499,13 +523,13 @@ module('Acceptance | secrets/secret/create', function (hooks) {
       'vault write test/filter/foo2 keys=a keys=b',
     ]);
     await listPage.visit({ backend: 'test', id: 'filter' });
-    assert.equal(listPage.secrets.length, 3, 'renders three secrets');
+    assert.strictEqual(listPage.secrets.length, 3, 'renders three secrets');
     await listPage.filterInput('filter/foo1');
-    assert.equal(listPage.secrets.length, 1, 'renders only one secret');
+    assert.strictEqual(listPage.secrets.length, 1, 'renders only one secret');
     await listPage.secrets.objectAt(0).click();
     await showPage.breadcrumbs.filterBy('text', 'filter')[0].click();
-    assert.equal(listPage.secrets.length, 3, 'renders three secrets');
-    assert.equal(listPage.filterInputValue, 'filter/', 'pageFilter has been reset');
+    assert.strictEqual(listPage.secrets.length, 3, 'renders three secrets');
+    assert.strictEqual(listPage.filterInputValue, 'filter/', 'pageFilter has been reset');
   });
 
   // All policy tests below this line
@@ -533,7 +557,11 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await authPage.login(userToken);
 
     await writeSecret(enginePath, secretPath, 'foo', 'bar');
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.show',
+      'redirects to the show page'
+    );
     assert.ok(showPage.editIsPresent, 'shows the edit button');
     //check for metadata tab which should not show because you don't have read capabilities
     assert.dom('[data-test-secret-metadata-tab]').doesNotExist('does not show metadata tab');
@@ -625,7 +653,7 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await click('[data-test-secret-edit]');
 
     // create new version should not include version in the URL
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/vault/secrets/${enginePath}/edit/${secretPath}`,
       'edit route does not include version query param'
@@ -656,7 +684,7 @@ module('Acceptance | secrets/secret/create', function (hooks) {
 
     await click('[data-test-modal-delete]');
 
-    assert.equal(currentURL(), `/vault/secrets/${enginePath}/list`, 'brings you back to the list page');
+    assert.strictEqual(currentURL(), `/vault/secrets/${enginePath}/list`, 'brings you back to the list page');
     await visit(`/vault/secrets/${enginePath}/show/${secretPath}`);
 
     assert.dom('[data-test-secret-not-found]').exists('secret no longer found');
@@ -872,7 +900,11 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     assert.notOk(editPage.hasMetadataFields, 'hides the metadata form');
 
     await editPage.editSecret('bar', 'baz');
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.show',
+      'redirects to the show page'
+    );
   });
 
   test('write without read: version 2 with metadata read', async function (assert) {
@@ -892,7 +924,11 @@ module('Acceptance | secrets/secret/create', function (hooks) {
       .exists('shows custom warning instead of default API warning about permissions');
 
     await editPage.editSecret('bar', 'baz');
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.show',
+      'redirects to the show page'
+    );
   });
 
   test('write without read: version 1', async function (assert) {
@@ -908,6 +944,10 @@ module('Acceptance | secrets/secret/create', function (hooks) {
 
     await editPage.visitEdit({ backend, id: 'secret' });
     await editPage.editSecret('bar', 'baz');
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.show',
+      'redirects to the show page'
+    );
   });
 });

--- a/ui/tests/acceptance/secrets/backend/pki/cert-test.js
+++ b/ui/tests/acceptance/secrets/backend/pki/cert-test.js
@@ -57,7 +57,7 @@ elRplAzrMF4=
     await settled();
     await generatePage.issueCert('foo');
     await settled();
-    assert.equal(currentURL(), `/vault/secrets/${mount}/credentials/role?action=issue`);
+    assert.strictEqual(currentURL(), `/vault/secrets/${mount}/credentials/role?action=issue`);
     assert.dom(SELECTORS.certificate).exists('displays masked certificate');
     assert.dom(SELECTORS.commonName).exists('displays common name');
     assert.dom(SELECTORS.issueDate).exists('displays issue date');
@@ -91,11 +91,15 @@ elRplAzrMF4=
     await settled();
     await listPage.visitRoot({ backend: path, tab: 'cert' });
     await settled();
-    assert.equal(currentURL(), `/vault/secrets/${path}/list?tab=cert`);
-    assert.equal(listPage.secrets.length, 2, 'lists certs');
+    assert.strictEqual(currentURL(), `/vault/secrets/${path}/list?tab=cert`);
+    assert.strictEqual(listPage.secrets.length, 2, 'lists certs');
     await listPage.secrets.objectAt(0).click();
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'navigates to the show page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.show',
+      'navigates to the show page'
+    );
     assert.dom(SELECTORS.certificate).exists('displays masked certificate');
     assert.dom(SELECTORS.commonName).exists('displays common name');
     assert.dom(SELECTORS.issueDate).exists('displays issue date');

--- a/ui/tests/acceptance/secrets/backend/pki/list-test.js
+++ b/ui/tests/acceptance/secrets/backend/pki/list-test.js
@@ -21,11 +21,15 @@ module('Acceptance | secrets/pki/list', function (hooks) {
   test('it renders an empty list', async function (assert) {
     assert.expect(5);
     await mountAndNav(assert);
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.list-root', 'redirects from the index');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.list-root',
+      'redirects from the index'
+    );
     assert.ok(page.createIsPresent, 'create button is present');
     await click('[data-test-configuration-tab]');
     assert.ok(page.configureIsPresent, 'configure button is present');
-    assert.equal(page.tabs.length, 2, 'shows 2 tabs');
+    assert.strictEqual(page.tabs.length, 2, 'shows 2 tabs');
     assert.ok(page.backendIsEmpty);
   });
 
@@ -33,7 +37,11 @@ module('Acceptance | secrets/pki/list', function (hooks) {
     assert.expect(1);
     await mountAndNav(assert);
     await page.create();
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.create-root', 'links to the create page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.create-root',
+      'links to the create page'
+    );
   });
 
   test('it navigates to the configure page', async function (assert) {
@@ -42,7 +50,7 @@ module('Acceptance | secrets/pki/list', function (hooks) {
     await click('[data-test-configuration-tab]');
     await page.configure();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.settings.configure-secret-backend.section',
       'links to the configure page'

--- a/ui/tests/acceptance/secrets/backend/pki/role-test.js
+++ b/ui/tests/acceptance/secrets/backend/pki/role-test.js
@@ -22,7 +22,11 @@ module('Acceptance | secrets/pki/create', function (hooks) {
     await settled();
     await editPage.createRole('role', 'example.com');
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.show',
+      'redirects to the show page'
+    );
     assert.dom('[data-test-edit-link="true"]').exists('shows the edit button');
     assert.dom('[data-test-credentials-link="true"]').exists('shows the generate button');
     assert.dom('[data-test-sign-link="true"]').exists('shows the sign button');
@@ -31,7 +35,7 @@ module('Acceptance | secrets/pki/create', function (hooks) {
     await settled();
     await showPage.generateCert();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.secrets.backend.credentials',
       'navs to the credentials page'
@@ -41,7 +45,7 @@ module('Acceptance | secrets/pki/create', function (hooks) {
     await settled();
     await visit(`/vault/secrets/${path}/credentials/role?action=sign`);
 
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.secrets.backend.credentials',
       'navs to the credentials page'
@@ -49,7 +53,7 @@ module('Acceptance | secrets/pki/create', function (hooks) {
 
     await listPage.visitRoot({ backend: path });
     await settled();
-    assert.equal(listPage.secrets.length, 1, 'shows role in the list');
+    assert.strictEqual(listPage.secrets.length, 1, 'shows role in the list');
     let secret = listPage.secrets.objectAt(0);
     await secret.menuToggle();
     await settled();

--- a/ui/tests/acceptance/secrets/backend/ssh/role-test.js
+++ b/ui/tests/acceptance/secrets/backend/ssh/role-test.js
@@ -29,14 +29,18 @@ module('Acceptance | secrets/ssh', function (hooks) {
     const path = await mountAndNav(assert);
     await editPage.createOTPRole('role');
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.show',
+      'redirects to the show page'
+    );
     assert.ok(showPage.generateIsPresent, 'shows the generate button');
 
     await showPage.visit({ backend: path, id: 'role' });
     await settled();
     await showPage.generate();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.secrets.backend.credentials',
       'navs to the credentials page'
@@ -44,7 +48,7 @@ module('Acceptance | secrets/ssh', function (hooks) {
 
     await listPage.visitRoot({ backend: path });
     await settled();
-    assert.equal(listPage.secrets.length, 1, 'shows role in the list');
+    assert.strictEqual(listPage.secrets.length, 1, 'shows role in the list');
     let secret = listPage.secrets.objectAt(0);
     await secret.menuToggle();
     assert.ok(listPage.menuItems.length > 0, 'shows links in the menu');
@@ -59,7 +63,11 @@ module('Acceptance | secrets/ssh', function (hooks) {
     await settled();
     await showPage.deleteRole();
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.list-root', 'redirects to list page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.list-root',
+      'redirects to list page'
+    );
     assert.ok(listPage.backendIsEmpty, 'no roles listed');
   });
 
@@ -68,14 +76,18 @@ module('Acceptance | secrets/ssh', function (hooks) {
     const path = await mountAndNav(assert);
     await editPage.createOTPRole('role');
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.show',
+      'redirects to the show page'
+    );
     assert.ok(showPage.generateIsPresent, 'shows the generate button');
 
     await showPage.visit({ backend: path, id: 'role' });
     await settled();
     await showPage.generate();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.secrets.backend.credentials',
       'navs to the credentials page'

--- a/ui/tests/acceptance/settings-test.js
+++ b/ui/tests/acceptance/settings-test.js
@@ -25,7 +25,7 @@ module('Acceptance | settings', function (hooks) {
     // mount unsupported backend
     await visit('/vault/settings/mount-secret-backend');
 
-    assert.equal(currentURL(), '/vault/settings/mount-secret-backend');
+    assert.strictEqual(currentURL(), '/vault/settings/mount-secret-backend');
 
     await mountSecrets.selectType(type);
     await mountSecrets
@@ -42,10 +42,10 @@ module('Acceptance | settings', function (hooks) {
       `Successfully mounted '${type}' at '${path}'!`
     );
     await settled();
-    assert.equal(currentURL(), `/vault/secrets`, 'redirects to secrets page');
+    assert.strictEqual(currentURL(), `/vault/secrets`, 'redirects to secrets page');
     let row = backendListPage.rows.filterBy('path', path + '/')[0];
     await row.menu();
     await backendListPage.configLink();
-    assert.equal(currentURL(), `/vault/secrets/${path}/configuration`, 'navigates to the config page');
+    assert.strictEqual(currentURL(), `/vault/secrets/${path}/configuration`, 'navigates to the config page');
   });
 });

--- a/ui/tests/acceptance/settings/auth/configure/index-test.js
+++ b/ui/tests/acceptance/settings/auth/configure/index-test.js
@@ -17,8 +17,12 @@ module('Acceptance | settings/auth/configure', function (hooks) {
     const type = 'approle';
     await enablePage.enable(type, path);
     await page.visit({ path });
-    assert.equal(currentRouteName(), 'vault.cluster.settings.auth.configure.section');
-    assert.equal(currentURL(), `/vault/settings/auth/configure/${path}/options`, 'loads the options route');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.settings.auth.configure.section');
+    assert.strictEqual(
+      currentURL(),
+      `/vault/settings/auth/configure/${path}/options`,
+      'loads the options route'
+    );
   });
 
   test('it redirects to the first section', async function (assert) {
@@ -26,8 +30,8 @@ module('Acceptance | settings/auth/configure', function (hooks) {
     const type = 'aws';
     await enablePage.enable(type, path);
     await page.visit({ path });
-    assert.equal(currentRouteName(), 'vault.cluster.settings.auth.configure.section');
-    assert.equal(
+    assert.strictEqual(currentRouteName(), 'vault.cluster.settings.auth.configure.section');
+    assert.strictEqual(
       currentURL(),
       `/vault/settings/auth/configure/${path}/client`,
       'loads the first section for the type of auth method'

--- a/ui/tests/acceptance/settings/auth/configure/section-test.js
+++ b/ui/tests/acceptance/settings/auth/configure/section-test.js
@@ -30,7 +30,7 @@ module('Acceptance | settings/auth/configure/section', function (hooks) {
     await page.visit({ path, section });
     await page.fillInTextarea('description', 'This is AppRole!');
     await page.save();
-    assert.equal(
+    assert.strictEqual(
       page.flash.latestMessage,
       `The configuration was saved successfully.`,
       'success flash shows'
@@ -49,7 +49,7 @@ module('Acceptance | settings/auth/configure/section', function (hooks) {
       await indexPage.visit({ path });
       // aws has 4 tabs, the others will have 'Configuration' and 'Method Options' tabs
       let numTabs = type === 'aws' ? 4 : 2;
-      assert.equal(page.tabs.length, numTabs, 'shows correct number of tabs');
+      assert.strictEqual(page.tabs.length, numTabs, 'shows correct number of tabs');
     });
   }
 });

--- a/ui/tests/acceptance/settings/auth/enable-test.js
+++ b/ui/tests/acceptance/settings/auth/enable-test.js
@@ -17,15 +17,15 @@ module('Acceptance | settings/auth/enable', function (hooks) {
     const path = `approle-${new Date().getTime()}`;
     const type = 'approle';
     await page.visit();
-    assert.equal(currentRouteName(), 'vault.cluster.settings.auth.enable');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.settings.auth.enable');
     await page.enable(type, path);
     await settled();
-    await assert.equal(
+    await assert.strictEqual(
       page.flash.latestMessage,
       `Successfully mounted the ${type} auth method at ${path}.`,
       'success flash shows'
     );
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.settings.auth.configure.section',
       'redirects to the auth config page'

--- a/ui/tests/acceptance/settings/configure-secret-backends/pki/index-test.js
+++ b/ui/tests/acceptance/settings/configure-secret-backends/pki/index-test.js
@@ -18,7 +18,7 @@ module('Acceptance | settings/configure/secrets/pki', function (hooks) {
     await settled();
     await page.visit({ backend: path });
     await settled();
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       'vault.cluster.settings.configure-secret-backend.section',
       'redirects from the index'

--- a/ui/tests/acceptance/settings/configure-secret-backends/pki/section-cert-test.js
+++ b/ui/tests/acceptance/settings/configure-secret-backends/pki/section-cert-test.js
@@ -74,7 +74,7 @@ BXUV2Uwtxf+QCphnlht9muX2fsLIzDJea0JipWj1uf2H8OZsjE8=
     assert.expect(10);
     await mountAndNav(assert);
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.settings.configure-secret-backend.section');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.settings.configure-secret-backend.section');
 
     await page.form.generateCA();
     await settled();
@@ -97,7 +97,7 @@ BXUV2Uwtxf+QCphnlht9muX2fsLIzDJea0JipWj1uf2H8OZsjE8=
     assert.expect(2);
     await mountAndNav(assert);
     await settled();
-    assert.equal(page.form.downloadLinks.length, 0, 'there are no download links');
+    assert.strictEqual(page.form.downloadLinks.length, 0, 'there are no download links');
 
     await page.form.uploadCA(PEM_BUNDLE);
     await settled();

--- a/ui/tests/acceptance/settings/configure-secret-backends/pki/section-crl-test.js
+++ b/ui/tests/acceptance/settings/configure-secret-backends/pki/section-crl-test.js
@@ -18,11 +18,11 @@ module('Acceptance | settings/configure/secrets/pki/crl', function (hooks) {
     await settled();
     await page.visit({ backend: path, section: 'crl' });
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.settings.configure-secret-backend.section');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.settings.configure-secret-backend.section');
     await page.form.fillInUnit('h');
     await page.form.fillInValue(3);
     await page.form.submit();
     await settled();
-    assert.equal(page.lastMessage, 'The crl config for this backend has been updated.');
+    assert.strictEqual(page.lastMessage, 'The crl config for this backend has been updated.');
   });
 });

--- a/ui/tests/acceptance/settings/configure-secret-backends/pki/section-tidy-test.js
+++ b/ui/tests/acceptance/settings/configure-secret-backends/pki/section-tidy-test.js
@@ -18,11 +18,11 @@ module('Acceptance | settings/configure/secrets/pki/tidy', function (hooks) {
     await settled();
     await page.visit({ backend: path, section: 'tidy' });
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.settings.configure-secret-backend.section');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.settings.configure-secret-backend.section');
     await page.form.fields.objectAt(0).clickLabel();
 
     await page.form.submit();
     await settled();
-    assert.equal(page.lastMessage, 'The tidy config for this backend has been updated.');
+    assert.strictEqual(page.lastMessage, 'The tidy config for this backend has been updated.');
   });
 });

--- a/ui/tests/acceptance/settings/configure-secret-backends/pki/section-urls-test.js
+++ b/ui/tests/acceptance/settings/configure-secret-backends/pki/section-urls-test.js
@@ -18,7 +18,7 @@ module('Acceptance | settings/configure/secrets/pki/urls', function (hooks) {
     await settled();
     await page.visit({ backend: path, section: 'urls' });
     await settled();
-    assert.equal(currentRouteName(), 'vault.cluster.settings.configure-secret-backend.section');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.settings.configure-secret-backend.section');
 
     await page.form.fields.objectAt(0).textarea('foo').change();
     await page.form.submit();
@@ -28,6 +28,6 @@ module('Acceptance | settings/configure/secrets/pki/urls', function (hooks) {
     await page.form.fields.objectAt(0).textarea('foo.example.com').change();
     await page.form.submit();
     await settled();
-    assert.equal(page.lastMessage, 'The urls config for this backend has been updated.');
+    assert.strictEqual(page.lastMessage, 'The urls config for this backend has been updated.');
   });
 });

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -28,7 +28,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
 
     await page.visit();
 
-    assert.equal(currentRouteName(), 'vault.cluster.settings.mount-secret-backend');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.settings.mount-secret-backend');
     await page.selectType('kv');
     await page
       .next()
@@ -42,8 +42,8 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
       .maxTTLVal(maxTTLHours)
       .submit();
     await configPage.visit({ backend: path });
-    assert.equal(configPage.defaultTTL, defaultTTLSeconds, 'shows the proper TTL');
-    assert.equal(configPage.maxTTL, maxTTLSeconds, 'shows the proper max TTL');
+    assert.strictEqual(configPage.defaultTTL, defaultTTLSeconds, 'shows the proper TTL');
+    assert.strictEqual(configPage.maxTTL, maxTTLSeconds, 'shows the proper max TTL');
   });
 
   test('it sets the ttl when enabled then disabled', async function (assert) {
@@ -54,7 +54,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
 
     await page.visit();
 
-    assert.equal(currentRouteName(), 'vault.cluster.settings.mount-secret-backend');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.settings.mount-secret-backend');
     await page.selectType('kv');
     await page
       .next()
@@ -67,8 +67,8 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
       .maxTTLVal(maxTTLHours)
       .submit();
     await configPage.visit({ backend: path });
-    assert.equal(configPage.defaultTTL, 0, 'shows the proper TTL');
-    assert.equal(configPage.maxTTL, maxTTLSeconds, 'shows the proper max TTL');
+    assert.strictEqual(configPage.defaultTTL, 0, 'shows the proper TTL');
+    assert.strictEqual(configPage.maxTTL, maxTTLSeconds, 'shows the proper max TTL');
   });
 
   test('it throws error if setting duplicate path name', async function (assert) {
@@ -81,7 +81,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
 
     await page.visit();
 
-    assert.equal(currentRouteName(), 'vault.cluster.settings.mount-secret-backend');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.settings.mount-secret-backend');
     await page.selectType('kv');
     await page.next().path(path).submit();
     await page.secretList();
@@ -90,7 +90,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
     await page.selectType('kv');
     await page.next().path(path).submit();
     assert.dom('[data-test-alert-banner="alert"]').containsText(`path is already in use at ${path}`);
-    assert.equal(currentRouteName(), 'vault.cluster.settings.mount-secret-backend');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.settings.mount-secret-backend');
 
     await page.secretList();
     await settled();

--- a/ui/tests/acceptance/ssh-test.js
+++ b/ui/tests/acceptance/ssh-test.js
@@ -33,10 +33,14 @@ module('Acceptance | ssh secret backend', function (hooks) {
         assert.dom('[data-test-form-field-from-model]').exists('renders the FormFieldFromModel');
         let value = document.querySelector('[data-test-ttl-value="TTL"]').value;
         // confirms that the actions are correctly being passed down to the FormFieldFromModel component
-        assert.equal(value, '30', 'renders action updateTtl');
+        assert.strictEqual(value, '30', 'renders action updateTtl');
       },
       assertAfterGenerate(assert, sshPath) {
-        assert.equal(currentURL(), `/vault/secrets/${sshPath}/sign/${this.name}`, 'ca sign url is correct');
+        assert.strictEqual(
+          currentURL(),
+          `/vault/secrets/${sshPath}/sign/${this.name}`,
+          'ca sign url is correct'
+        );
         assert.dom('[data-test-row-label="Signed key"]').exists({ count: 1 }, 'renders the signed key');
         assert
           .dom('[data-test-row-value="Signed key"]')
@@ -58,7 +62,7 @@ module('Acceptance | ssh secret backend', function (hooks) {
         await fillIn('[data-test-input="ip"]', '1.2.3.4');
       },
       assertAfterGenerate(assert, sshPath) {
-        assert.equal(
+        assert.strictEqual(
           currentURL(),
           `/vault/secrets/${sshPath}/credentials/${this.name}`,
           'otp credential url is correct'
@@ -81,7 +85,7 @@ module('Acceptance | ssh secret backend', function (hooks) {
 
     await click('[data-test-secret-backend-configure]');
 
-    assert.equal(currentURL(), `/vault/settings/secrets/configure/${sshPath}`);
+    assert.strictEqual(currentURL(), `/vault/settings/secrets/configure/${sshPath}`);
     assert.ok(findAll('[data-test-ssh-configure-form]').length, 'renders the empty configuration form');
 
     // default has generate CA checked so we just submit the form
@@ -93,7 +97,7 @@ module('Acceptance | ssh secret backend', function (hooks) {
     );
     await click('[data-test-backend-view-link]');
 
-    assert.equal(currentURL(), `/vault/secrets/${sshPath}/list`, `redirects to ssh index`);
+    assert.strictEqual(currentURL(), `/vault/secrets/${sshPath}/list`, `redirects to ssh index`);
 
     for (let role of ROLES) {
       // create a role
@@ -112,7 +116,7 @@ module('Acceptance | ssh secret backend', function (hooks) {
       // save the role
       await click('[data-test-role-ssh-create]');
       await waitUntil(() => currentURL() === `/vault/secrets/${sshPath}/show/${role.name}`); // flaky without this
-      assert.equal(
+      assert.strictEqual(
         currentURL(),
         `/vault/secrets/${sshPath}/show/${role.name}`,
         `${role.type}: navigates to the show page on creation`
@@ -142,7 +146,7 @@ module('Acceptance | ssh secret backend', function (hooks) {
 
       await click('[data-test-secret-generate-cancel]');
 
-      assert.equal(
+      assert.strictEqual(
         currentURL(),
         `/vault/secrets/${sshPath}/list`,
         `${role.type}: cancel takes you to ssh index`

--- a/ui/tests/acceptance/tools-test.js
+++ b/ui/tests/acceptance/tools-test.js
@@ -42,7 +42,7 @@ module('Acceptance | tools', function (hooks) {
     var tokenStore = createTokenStore();
     await visit('/vault/tools');
 
-    assert.equal(currentURL(), '/vault/tools/wrap', 'forwards to the first action');
+    assert.strictEqual(currentURL(), '/vault/tools/wrap', 'forwards to the first action');
     TOOLS_ACTIONS.forEach((action) => {
       assert.dom(`[data-test-tools-action-link="${action}"]`).exists(`${action} link renders`);
     });

--- a/ui/tests/acceptance/transit-test.js
+++ b/ui/tests/acceptance/transit-test.js
@@ -142,7 +142,7 @@ const testConvergentEncryption = async function (assert, keyName) {
 
       assertAfterDecrypt: (key) => {
         assert.dom('.modal.is-active').exists(`${key}: Modal opens after decrypt`);
-        assert.equal(
+        assert.strictEqual(
           find('[data-test-encrypted-value="plaintext"]').innerText,
           'NaXud2QW7KjyK6Me9ggh+zmnCeBGdG93LQED49PtoOI=',
           `${key}: the ui shows the base64-encoded plaintext`
@@ -170,7 +170,7 @@ const testConvergentEncryption = async function (assert, keyName) {
       },
       assertAfterDecrypt: (key) => {
         assert.dom('.modal.is-active').exists(`${key}: Modal opens after decrypt`);
-        assert.equal(
+        assert.strictEqual(
           find('[data-test-encrypted-value="plaintext"]').innerText,
           'NaXud2QW7KjyK6Me9ggh+zmnCeBGdG93LQED49PtoOI=',
           `${key}: the ui shows the base64-encoded plaintext`
@@ -198,7 +198,7 @@ const testConvergentEncryption = async function (assert, keyName) {
       },
       assertAfterDecrypt: (key) => {
         assert.dom('.modal.is-active').exists(`${key}: Modal opens after decrypt`);
-        assert.equal(
+        assert.strictEqual(
           find('[data-test-encrypted-value="plaintext"]').innerText,
           encodeString('This is the secret'),
           `${key}: the ui decodes plaintext`
@@ -227,7 +227,7 @@ const testConvergentEncryption = async function (assert, keyName) {
       },
       assertAfterDecrypt: (key) => {
         assert.dom('.modal.is-active').exists(`${key}: Modal opens after decrypt`);
-        assert.equal(
+        assert.strictEqual(
           find('[data-test-encrypted-value="plaintext"]').innerText,
           encodeString('There are many secrets 🤐'),
           `${key}: the ui decodes plaintext`
@@ -299,7 +299,7 @@ module('Acceptance | transit', function (hooks) {
     await generateTransitKey(keyTypes[0], now);
     await secretListPage.secrets.objectAt(0).menuToggle();
     await settled();
-    assert.equal(secretListPage.menuItems.length, 2, 'shows 2 items in the menu');
+    assert.strictEqual(secretListPage.menuItems.length, 2, 'shows 2 items in the menu');
   });
   for (let key of keyTypes) {
     test(`transit backend: ${key.type}`, async function (assert) {

--- a/ui/tests/acceptance/unseal-test.js
+++ b/ui/tests/acceptance/unseal-test.js
@@ -22,7 +22,7 @@ module('Acceptance | unseal', function (hooks) {
   test('seal then unseal', async function (assert) {
     await visit('/vault/settings/seal');
 
-    assert.equal(currentURL(), '/vault/settings/seal');
+    assert.strictEqual(currentURL(), '/vault/settings/seal');
 
     // seal
     await click('[data-test-seal] button');
@@ -31,7 +31,7 @@ module('Acceptance | unseal', function (hooks) {
 
     await pollCluster(this.owner);
     await settled();
-    assert.equal(currentURL(), '/vault/unseal', 'vault is on the unseal page');
+    assert.strictEqual(currentURL(), '/vault/unseal', 'vault is on the unseal page');
 
     // unseal
     for (const key of unsealKeys) {
@@ -44,6 +44,6 @@ module('Acceptance | unseal', function (hooks) {
     }
 
     assert.dom('[data-test-cluster-status]').doesNotExist('ui does not show sealed warning');
-    assert.equal(currentRouteName(), 'vault.cluster.auth', 'vault is ready to authenticate');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.auth', 'vault is ready to authenticate');
   });
 });

--- a/ui/tests/acceptance/wrapped-token-test.js
+++ b/ui/tests/acceptance/wrapped-token-test.js
@@ -32,13 +32,13 @@ module('Acceptance | wrapped_token query param functionality', function (hooks) 
     let token = await setupWrapping();
     await auth.visit({ wrapped_token: token });
     await settled();
-    assert.equal(currentURL(), '/vault/secrets', 'authenticates and redirects to home');
+    assert.strictEqual(currentURL(), '/vault/secrets', 'authenticates and redirects to home');
   });
 
   test('it authenticates when used with the with=token query param', async function (assert) {
     let token = await setupWrapping();
     await auth.visit({ wrapped_token: token, with: 'token' });
     await settled();
-    assert.equal(currentURL(), '/vault/secrets', 'authenticates and redirects to home');
+    assert.strictEqual(currentURL(), '/vault/secrets', 'authenticates and redirects to home');
   });
 });

--- a/ui/tests/integration/components/auth-form-test.js
+++ b/ui/tests/integration/components/auth-form-test.js
@@ -68,7 +68,7 @@ module('Integration | Component | auth form', function (hooks) {
     // we have to manually force settling the run queue
     later(() => cancelTimers(), 50);
     return settled().then(() => {
-      assert.equal(component.errorText, CSP_ERR_TEXT);
+      assert.strictEqual(component.errorText, CSP_ERR_TEXT);
     });
   });
 
@@ -90,7 +90,7 @@ module('Integration | Component | auth form', function (hooks) {
     this.set('selectedAuth', 'token');
     await render(hbs`{{auth-form cluster=cluster selectedAuth=selectedAuth}}`);
     return component.login().then(() => {
-      assert.equal(component.errorText, 'Error Authentication failed: Not allowed');
+      assert.strictEqual(component.errorText, 'Error Authentication failed: Not allowed');
       server.shutdown();
     });
   });
@@ -108,7 +108,7 @@ module('Integration | Component | auth form', function (hooks) {
     await render(hbs`{{auth-form cluster=cluster selectedAuth=selectedAuth}}`);
     // ARG TODO research and see if adapter errors changed, but null used to be Bad Request
     return component.login().then(() => {
-      assert.equal(component.errorText, 'Error Authentication failed: null');
+      assert.strictEqual(component.errorText, 'Error Authentication failed: null');
       server.shutdown();
     });
   });
@@ -126,7 +126,7 @@ module('Integration | Component | auth form', function (hooks) {
     });
     await render(hbs`<AuthForm @cluster={{cluster}} />`);
 
-    assert.equal(component.tabs.length, 0, 'renders a tab for every backend');
+    assert.strictEqual(component.tabs.length, 0, 'renders a tab for every backend');
     server.shutdown();
   });
 
@@ -148,9 +148,9 @@ module('Integration | Component | auth form', function (hooks) {
     this.set('cluster', EmberObject.create({}));
     await render(hbs`{{auth-form cluster=cluster }}`);
 
-    assert.equal(component.tabs.length, 2, 'renders a tab for userpass and Other');
-    assert.equal(component.tabs.objectAt(0).name, 'foo', 'uses the path in the label');
-    assert.equal(component.tabs.objectAt(1).name, 'Other', 'second tab is the Other tab');
+    assert.strictEqual(component.tabs.length, 2, 'renders a tab for userpass and Other');
+    assert.strictEqual(component.tabs.objectAt(0).name, 'foo', 'uses the path in the label');
+    assert.strictEqual(component.tabs.objectAt(1).name, 'Other', 'second tab is the Other tab');
     server.shutdown();
   });
 
@@ -169,7 +169,11 @@ module('Integration | Component | auth form', function (hooks) {
     this.set('cluster', EmberObject.create({}));
     await render(hbs`{{auth-form cluster=cluster }}`);
 
-    assert.equal(component.descriptionText, 'app description', 'renders a description for auth methods');
+    assert.strictEqual(
+      component.descriptionText,
+      'app description',
+      'renders a description for auth methods'
+    );
     server.shutdown();
   });
 
@@ -197,7 +201,7 @@ module('Integration | Component | auth form', function (hooks) {
     await settled();
     assert.ok(authSpy.calledOnce, 'a call to authenticate was made');
     let { data } = authSpy.getCall(0).args[0];
-    assert.equal(data.path, 'foo', 'uses the id for the path');
+    assert.strictEqual(data.path, 'foo', 'uses the id for the path');
     authSpy.restore();
     server.shutdown();
   });
@@ -217,7 +221,7 @@ module('Integration | Component | auth form', function (hooks) {
     await render(hbs`<AuthForm @cluster={{cluster}} />`);
 
     server.shutdown();
-    assert.equal(component.tabs.length, 0, 'renders a tab for every backend');
+    assert.strictEqual(component.tabs.length, 0, 'renders a tab for every backend');
   });
 
   test('it makes a request to unwrap if passed a wrappedToken and logs in', async function (assert) {
@@ -244,8 +248,12 @@ module('Integration | Component | auth form', function (hooks) {
     await render(hbs`<AuthForm @cluster={{cluster}} @wrappedToken={{wrappedToken}} />`);
     later(() => cancelTimers(), 50);
     await settled();
-    assert.equal(server.handledRequests[0].url, '/v1/sys/wrapping/unwrap', 'makes call to unwrap the token');
-    assert.equal(
+    assert.strictEqual(
+      server.handledRequests[0].url,
+      '/v1/sys/wrapping/unwrap',
+      'makes call to unwrap the token'
+    );
+    assert.strictEqual(
       server.handledRequests[0].requestHeaders['X-Vault-Token'],
       wrappedToken,
       'uses passed wrapped token for the unwrap'
@@ -273,7 +281,7 @@ module('Integration | Component | auth form', function (hooks) {
     later(() => cancelTimers(), 50);
 
     await settled();
-    assert.equal(
+    assert.strictEqual(
       component.errorText,
       'Error Token unwrap failed: There was an error unwrapping!',
       'shows the error'

--- a/ui/tests/integration/components/auth-jwt-test.js
+++ b/ui/tests/integration/components/auth-jwt-test.js
@@ -108,7 +108,7 @@ module('Integration | Component | auth jwt', function (hooks) {
 
   test('it renders the yield', async function (assert) {
     await render(hbs`<AuthJwt @onSubmit={{action (mut submit)}}>Hello!</AuthJwt>`);
-    assert.equal(component.yieldContent, 'Hello!', 'yields properly');
+    assert.strictEqual(component.yieldContent, 'Hello!', 'yields properly');
   });
 
   test('jwt: it renders and makes auth_url requests', async function (assert) {
@@ -116,12 +116,12 @@ module('Integration | Component | auth jwt', function (hooks) {
     await settled();
     assert.ok(component.jwtPresent, 'renders jwt field');
     assert.ok(component.rolePresent, 'renders jwt field');
-    assert.equal(this.server.handledRequests.length, 1, 'request to the default path is made');
-    assert.equal(this.server.handledRequests[0].url, '/v1/auth/jwt/oidc/auth_url');
+    assert.strictEqual(this.server.handledRequests.length, 1, 'request to the default path is made');
+    assert.strictEqual(this.server.handledRequests[0].url, '/v1/auth/jwt/oidc/auth_url');
     this.set('selectedAuthPath', 'foo');
     await settled();
-    assert.equal(this.server.handledRequests.length, 2, 'a second request was made');
-    assert.equal(
+    assert.strictEqual(this.server.handledRequests.length, 2, 'a second request was made');
+    assert.strictEqual(
       this.server.handledRequests[1].url,
       '/v1/auth/foo/oidc/auth_url',
       'requests when path is set'
@@ -141,12 +141,16 @@ module('Integration | Component | auth jwt', function (hooks) {
     await component.role('test');
     await settled();
     assert.notOk(component.jwtPresent, 'does not show jwt input for OIDC type login');
-    assert.equal(component.loginButtonText, 'Sign in with OIDC Provider');
+    assert.strictEqual(component.loginButtonText, 'Sign in with OIDC Provider');
 
     await component.role('okta');
     // 1 for initial render, 1 for each time role changed = 3
-    assert.equal(this.server.handledRequests.length, 4, 'fetches the auth_url when the path changes');
-    assert.equal(component.loginButtonText, 'Sign in with Okta', 'recognizes auth methods with certain urls');
+    assert.strictEqual(this.server.handledRequests.length, 4, 'fetches the auth_url when the path changes');
+    assert.strictEqual(
+      component.loginButtonText,
+      'Sign in with Okta',
+      'recognizes auth methods with certain urls'
+    );
   });
 
   test('oidc: it calls window.open popup window on login', async function (assert) {
@@ -176,7 +180,7 @@ module('Integration | Component | auth jwt', function (hooks) {
     });
     this.window.close();
     await settled();
-    assert.equal(this.error, ERROR_WINDOW_CLOSED, 'calls onError with error string');
+    assert.strictEqual(this.error, ERROR_WINDOW_CLOSED, 'calls onError with error string');
   });
 
   test('oidc: shows error when message posted with state key, wrong params', async function (assert) {
@@ -192,7 +196,7 @@ module('Integration | Component | auth jwt', function (hooks) {
       buildMessage({ data: { source: 'oidc-callback', state: 'state', foo: 'bar' } })
     );
     cancelTimers();
-    assert.equal(this.error, ERROR_MISSING_PARAMS, 'calls onError with params missing error');
+    assert.strictEqual(this.error, ERROR_MISSING_PARAMS, 'calls onError with params missing error');
   });
 
   test('oidc: storage event fires with state key, correct params', async function (assert) {
@@ -205,7 +209,7 @@ module('Integration | Component | auth jwt', function (hooks) {
     });
     this.window.trigger('message', buildMessage());
     await settled();
-    assert.equal(this.token, 'token', 'calls onToken with token');
+    assert.strictEqual(this.token, 'token', 'calls onToken with token');
     assert.ok(this.handler.calledOnce, 'calls the onSubmit handler');
   });
 

--- a/ui/tests/integration/components/autocomplete-input-test.js
+++ b/ui/tests/integration/components/autocomplete-input-test.js
@@ -29,7 +29,7 @@ module('Integration | Component | autocomplete-input', function (hooks) {
     const changeValue = 'foo bar';
     this.value = 'test';
     this.placeholder = 'text goes here';
-    this.onChange = (value) => assert.equal(value, changeValue, 'Value sent in onChange callback');
+    this.onChange = (value) => assert.strictEqual(value, changeValue, 'Value sent in onChange callback');
 
     await render(
       hbs`
@@ -82,6 +82,6 @@ module('Integration | Component | autocomplete-input', function (hooks) {
     assert
       .dom('input')
       .hasValue('$foo-$bar', 'Value is updated correctly. Trigger character is prepended to option.');
-    assert.equal(this.value, '$foo-$bar', 'Value prop is updated correctly onChange');
+    assert.strictEqual(this.value, '$foo-$bar', 'Value prop is updated correctly onChange');
   });
 });

--- a/ui/tests/integration/components/b64-toggle-test.js
+++ b/ui/tests/integration/components/b64-toggle-test.js
@@ -15,9 +15,9 @@ module('Integration | Component | b64 toggle', function (hooks) {
     this.set('value', 'value');
     await render(hbs`{{b64-toggle value=value}}`);
     await click('button');
-    assert.equal(this.value, btoa('value'), 'encodes to base64');
+    assert.strictEqual(this.value, btoa('value'), 'encodes to base64');
     await click('button');
-    assert.equal(this.value, 'value', 'decodes from base64');
+    assert.strictEqual(this.value, 'value', 'decodes from base64');
   });
 
   test('it toggles encoding starting with base64', async function (assert) {
@@ -25,7 +25,7 @@ module('Integration | Component | b64 toggle', function (hooks) {
     await render(hbs`{{b64-toggle value=value initialEncoding='base64'}}`);
     assert.ok(find('button').textContent.includes('Decode'), 'renders as on when in b64 mode');
     await click('button');
-    assert.equal(this.value, 'value', 'decodes from base64');
+    assert.strictEqual(this.value, 'value', 'decodes from base64');
   });
 
   test('it detects changes to value after encoding', async function (assert) {

--- a/ui/tests/integration/components/clients/config-test.js
+++ b/ui/tests/integration/components/clients/config-test.js
@@ -50,7 +50,7 @@ module('Integration | Component | client count config', function (hooks) {
 
     assert.dom('[data-test-pricing-metrics-config-table]').exists('Pricing metrics config table exists');
     const rows = document.querySelectorAll('.info-table-row');
-    assert.equal(rows.length, 2, 'renders 2 infotable rows');
+    assert.strictEqual(rows.length, 2, 'renders 2 infotable rows');
     assert.ok(
       find('[data-test-row-value="Usage data collection"]').textContent.includes('On'),
       'Enabled value matches model'
@@ -69,7 +69,7 @@ module('Integration | Component | client count config', function (hooks) {
 
     assert.dom('[data-test-pricing-metrics-config-form]').exists('Pricing metrics config form exists');
     const fields = document.querySelectorAll('[data-test-field]');
-    assert.equal(fields.length, 2, 'renders 2 fields');
+    assert.strictEqual(fields.length, 2, 'renders 2 fields');
   });
 
   test('it shows a modal with correct messaging when disabling', async function (assert) {

--- a/ui/tests/integration/components/clients/horizontal-bar-chart-test.js
+++ b/ui/tests/integration/components/clients/horizontal-bar-chart-test.js
@@ -32,8 +32,8 @@ module('Integration | Component | clients/horizontal-bar-chart', function (hooks
     const dataBars = findAll('[data-test-horizontal-bar-chart] rect.data-bar');
     const actionBars = findAll('[data-test-horizontal-bar-chart] rect.action-bar');
 
-    assert.equal(actionBars.length, dataArray.length, 'renders correct number of hover bars');
-    assert.equal(dataBars.length, dataArray.length * 2, 'renders correct number of data bars');
+    assert.strictEqual(actionBars.length, dataArray.length, 'renders correct number of hover bars');
+    assert.strictEqual(dataBars.length, dataArray.length * 2, 'renders correct number of data bars');
 
     const textLabels = this.element.querySelectorAll('[data-test-horizontal-bar-chart] .tick text');
     const textTotals = this.element.querySelectorAll('[data-test-horizontal-bar-chart] text.total-value');
@@ -71,8 +71,8 @@ module('Integration | Component | clients/horizontal-bar-chart', function (hooks
     const dataBars = findAll('[data-test-horizontal-bar-chart] rect.data-bar');
     const actionBars = findAll('[data-test-horizontal-bar-chart] rect.action-bar');
 
-    assert.equal(actionBars.length, dataArray.length, 'renders correct number of hover bars');
-    assert.equal(dataBars.length, dataArray.length * 2, 'renders correct number of data bars');
+    assert.strictEqual(actionBars.length, dataArray.length, 'renders correct number of hover bars');
+    assert.strictEqual(dataBars.length, dataArray.length * 2, 'renders correct number of data bars');
 
     for (let [i, bar] of actionBars.entries()) {
       let percent = Math.round((dataArray[i].clients / totalObject.clients) * 100);

--- a/ui/tests/integration/components/console/log-json-test.js
+++ b/ui/tests/integration/components/console/log-json-test.js
@@ -20,6 +20,6 @@ module('Integration | Component | console/log json', function (hooks) {
 
     await render(hbs`{{console/log-json content=content}}`);
     const instance = find('[data-test-component=code-mirror-modifier]').innerText;
-    assert.equal(instance, expectedText);
+    assert.strictEqual(instance, expectedText);
   });
 });

--- a/ui/tests/integration/components/console/ui-panel-test.js
+++ b/ui/tests/integration/components/console/ui-panel-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | console/ui panel', function (hooks) {
 
     await component.runCommands('list this/thing/here');
     await settled();
-    assert.equal(component.consoleInputValue, '', 'empties input field on enter');
+    assert.strictEqual(component.consoleInputValue, '', 'empties input field on enter');
   });
 
   test('it clears the log when using clear command', async function (assert) {
@@ -35,8 +35,8 @@ module('Integration | Component | console/ui panel', function (hooks) {
     await settled();
     await component.up();
     await settled();
-    assert.equal(component.logOutput, '', 'clears the output log');
-    assert.equal(
+    assert.strictEqual(component.logOutput, '', 'clears the output log');
+    assert.strictEqual(
       component.consoleInputValue,
       'clear',
       'populates console input with previous command on up after enter'
@@ -50,14 +50,14 @@ module('Integration | Component | console/ui panel', function (hooks) {
     await settled();
     await component.up();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       component.consoleInputValue,
       'list this/thing/here',
       'populates console input with previous command on up after enter'
     );
     await component.down();
     await settled();
-    assert.equal(component.consoleInputValue, '', 'populates console input with next command on down');
+    assert.strictEqual(component.consoleInputValue, '', 'populates console input with next command on down');
   });
 
   test('it cycles through history with more than one command', async function (assert) {
@@ -67,35 +67,35 @@ module('Integration | Component | console/ui panel', function (hooks) {
     await settled();
     await component.up();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       component.consoleInputValue,
       'qwerty',
       'populates console input with previous command on up after enter'
     );
     await component.up();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       component.consoleInputValue,
       'read that/thing/there',
       'populates console input with previous command on up'
     );
     await component.up();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       component.consoleInputValue,
       'list this/thing/here',
       'populates console input with previous command on up'
     );
     await component.up();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       component.consoleInputValue,
       'qwerty',
       'populates console input with initial command if cycled through all previous commands'
     );
     await component.down();
     await settled();
-    assert.equal(
+    assert.strictEqual(
       component.consoleInputValue,
       '',
       'clears console input if down pressed after history is on most recent command'

--- a/ui/tests/integration/components/control-group-test.js
+++ b/ui/tests/integration/components/control-group-test.js
@@ -59,9 +59,9 @@ module('Integration | Component | control group', function (hooks) {
     this.set('auth.authData', authData);
     await render(hbs`{{control-group model=model}}`);
     assert.ok(component.showsAccessorCallout, 'shows accessor callout');
-    assert.equal(component.bannerPrefix, 'Locked');
-    assert.equal(component.bannerText, 'The path you requested is locked by a Control Group');
-    assert.equal(component.requestorText, `You are requesting access to ${model.requestPath}`);
+    assert.strictEqual(component.bannerPrefix, 'Locked');
+    assert.strictEqual(component.bannerText, 'The path you requested is locked by a Control Group');
+    assert.strictEqual(component.requestorText, `You are requesting access to ${model.requestPath}`);
     assert.false(component.showsTokenText, 'does not show token message when there is no token');
     assert.ok(component.showsRefresh, 'shows refresh button');
     assert.ok(component.authorizationText, 'Awaiting authorization.');
@@ -74,7 +74,7 @@ module('Integration | Component | control group', function (hooks) {
     this.set('controlGroup.wrapInfo', { token: 'token' });
     await render(hbs`{{control-group model=model}}`);
     assert.true(component.showsTokenText, 'shows token message');
-    assert.equal(component.token, 'token', 'shows token value');
+    assert.strictEqual(component.token, 'token', 'shows token value');
   });
 
   test('requestor rendering: some approvals', async function (assert) {
@@ -91,8 +91,8 @@ module('Integration | Component | control group', function (hooks) {
     this.set('auth.authData', authData);
     await render(hbs`{{control-group model=model}}`);
 
-    assert.equal(component.bannerPrefix, 'Success!');
-    assert.equal(component.bannerText, 'You have been given authorization');
+    assert.strictEqual(component.bannerPrefix, 'Success!');
+    assert.strictEqual(component.bannerText, 'You have been given authorization');
     assert.false(component.showsTokenText, 'does not show token message when there is no token');
     assert.notOk(component.showsRefresh, 'does not shows refresh button');
     assert.ok(component.showsSuccessComponent, 'renders control group success');
@@ -116,9 +116,12 @@ module('Integration | Component | control group', function (hooks) {
     this.set('auth.authData', authData);
     await render(hbs`{{control-group model=model}}`);
 
-    assert.equal(component.bannerPrefix, 'Locked');
-    assert.equal(component.bannerText, 'Someone is requesting access to a path locked by a Control Group');
-    assert.equal(
+    assert.strictEqual(component.bannerPrefix, 'Locked');
+    assert.strictEqual(
+      component.bannerText,
+      'Someone is requesting access to a path locked by a Control Group'
+    );
+    assert.strictEqual(
       component.requestorText,
       `${model.requestEntity.name} is requesting access to ${model.requestPath}`
     );
@@ -137,8 +140,8 @@ module('Integration | Component | control group', function (hooks) {
     this.set('auth.authData', authData);
     await render(hbs`{{control-group model=model}}`);
 
-    assert.equal(component.bannerPrefix, 'Thanks!');
-    assert.equal(component.bannerText, 'You have given authorization');
+    assert.strictEqual(component.bannerPrefix, 'Thanks!');
+    assert.strictEqual(component.bannerText, 'You have given authorization');
     assert.ok(component.showsBackLink, 'back link is visible');
   });
 
@@ -152,10 +155,10 @@ module('Integration | Component | control group', function (hooks) {
     this.set('auth.authData', authData);
     await render(hbs`{{control-group model=model}}`);
 
-    assert.equal(component.bannerPrefix, 'Thanks!');
-    assert.equal(component.bannerText, 'You have given authorization');
+    assert.strictEqual(component.bannerPrefix, 'Thanks!');
+    assert.strictEqual(component.bannerText, 'You have given authorization');
     assert.ok(component.showsBackLink, 'back link is visible');
-    assert.equal(
+    assert.strictEqual(
       component.requestorText,
       `${model.requestEntity.name} is authorized to access ${model.requestPath}`
     );
@@ -171,8 +174,8 @@ module('Integration | Component | control group', function (hooks) {
     this.set('model', model);
     this.set('auth.authData', authData);
     await render(hbs`{{control-group model=model}}`);
-    assert.equal(component.bannerPrefix, 'Success!');
-    assert.equal(component.bannerText, 'This Control Group has been authorized');
+    assert.strictEqual(component.bannerPrefix, 'Success!');
+    assert.strictEqual(component.bannerText, 'This Control Group has been authorized');
     assert.ok(component.showsBackLink, 'back link is visible');
     assert.notOk(component.showsSuccessComponent, 'does not render control group success');
   });

--- a/ui/tests/integration/components/date-dropdown-test.js
+++ b/ui/tests/integration/components/date-dropdown-test.js
@@ -46,8 +46,8 @@ module('Integration | Component | date-dropdown', function (hooks) {
   test('it renders dropdown and selects month and year', async function (assert) {
     assert.expect(27);
     let parentAction = (month, year) => {
-      assert.equal(month, 'January', 'sends correct month to parent callback');
-      assert.equal(year, CURRENT_YEAR, 'sends correct year to parent callback');
+      assert.strictEqual(month, 'January', 'sends correct month to parent callback');
+      assert.strictEqual(year, CURRENT_YEAR, 'sends correct year to parent callback');
     };
     this.set('parentAction', parentAction);
 
@@ -66,7 +66,7 @@ module('Integration | Component | date-dropdown', function (hooks) {
 
     await click(monthDropdown);
     let dropdownListMonths = this.element.querySelectorAll('[data-test-month-list] button');
-    assert.equal(dropdownListMonths.length, 12, 'dropdown has 12 months');
+    assert.strictEqual(dropdownListMonths.length, 12, 'dropdown has 12 months');
     for (let [index, month] of ARRAY_OF_MONTHS.entries()) {
       assert.dom(dropdownListMonths[index]).hasText(`${month}`, `dropdown includes ${month}`);
     }
@@ -77,7 +77,7 @@ module('Integration | Component | date-dropdown', function (hooks) {
 
     await click(yearDropdown);
     let dropdownListYears = this.element.querySelectorAll('[data-test-year-list] button');
-    assert.equal(dropdownListYears.length, 5, 'dropdown has 5 years');
+    assert.strictEqual(dropdownListYears.length, 5, 'dropdown has 5 years');
 
     for (let [index, year] of dropdownListYears.entries()) {
       let comparisonYear = CURRENT_YEAR - index;

--- a/ui/tests/integration/components/diff-version-selector-test.js
+++ b/ui/tests/integration/components/diff-version-selector-test.js
@@ -28,7 +28,7 @@ module('Integration | Component | diff-version-selector', function (hooks) {
     let leftSideVersion = document
       .querySelector('[data-test-popup-menu-trigger="left-version"]')
       .innerText.trim();
-    assert.equal(leftSideVersion, 'Version 2', 'left side toolbar defaults to currentVersion');
+    assert.strictEqual(leftSideVersion, 'Version 2', 'left side toolbar defaults to currentVersion');
 
     await click('[data-test-popup-menu-trigger="left-version"]');
 

--- a/ui/tests/integration/components/edit-form-kmip-role-test.js
+++ b/ui/tests/integration/components/edit-form-kmip-role-test.js
@@ -162,7 +162,11 @@ module('Integration | Component | edit form kmip role', function (hooks) {
         await click(`label[for=${clickTarget}]`);
       }
       for (let beforeStateKey of Object.keys(stateBeforeSave)) {
-        assert.equal(model.get(beforeStateKey), stateBeforeSave[beforeStateKey], `sets ${beforeStateKey}`);
+        assert.strictEqual(
+          model.get(beforeStateKey),
+          stateBeforeSave[beforeStateKey],
+          `sets ${beforeStateKey}`
+        );
       }
 
       click('[data-test-edit-form-submit]');
@@ -170,7 +174,7 @@ module('Integration | Component | edit form kmip role', function (hooks) {
       later(() => cancelTimers(), 50);
       return settled().then(() => {
         for (let afterStateKey of Object.keys(stateAfterSave)) {
-          assert.equal(
+          assert.strictEqual(
             model.get(afterStateKey),
             stateAfterSave[afterStateKey],
             `sets ${afterStateKey} on save`

--- a/ui/tests/integration/components/edit-form-test.js
+++ b/ui/tests/integration/components/edit-form-test.js
@@ -67,10 +67,10 @@ module('Integration | Component | edit form', function (hooks) {
     later(() => cancelTimers(), 50);
     return settled().then(() => {
       assert.ok(saveSpy.calledOnce, 'calls passed onSave');
-      assert.equal(saveSpy.getCall(0).args[0].saveType, 'save');
+      assert.strictEqual(saveSpy.getCall(0).args[0].saveType, 'save');
       assert.deepEqual(saveSpy.getCall(0).args[0].model, model, 'passes model to onSave');
       let flash = this.owner.lookup('service:flash-messages');
-      assert.equal(flash.success.callCount, 1, 'calls flash message success');
+      assert.strictEqual(flash.success.callCount, 1, 'calls flash message success');
     });
   });
 });

--- a/ui/tests/integration/components/features-selection-test.js
+++ b/ui/tests/integration/components/features-selection-test.js
@@ -32,7 +32,7 @@ module('Integration | Component | features-selection', function (hooks) {
     await render(hbs`<Wizard::FeaturesSelection/>`);
 
     component.wizardItems.forEach((i) => {
-      assert.equal(
+      assert.strictEqual(
         i.hasDisabledTooltip,
         !enabled[i.text],
         'shows a tooltip only when the wizard item is not enabled'

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -36,24 +36,24 @@ module('Integration | Component | form field', function (hooks) {
     this.model = model;
     await render(hbs`<FormField @attr={{this.attr}} @model={{this.model}} />`);
 
-    assert.equal(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
+    assert.strictEqual(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
     assert.notOk(component.hasInput, 'renders only the label');
   });
 
   test('it renders: string', async function (assert) {
     let [model, spy] = await setup.call(this, createAttr('foo', 'string', { defaultValue: 'default' }));
-    assert.equal(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
-    assert.equal(component.fields.objectAt(0).inputValue, 'default', 'renders default value');
+    assert.strictEqual(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
+    assert.strictEqual(component.fields.objectAt(0).inputValue, 'default', 'renders default value');
     assert.ok(component.hasInput, 'renders input for string');
     await component.fields.objectAt(0).input('bar').change();
 
-    assert.equal(model.get('foo'), 'bar');
+    assert.strictEqual(model.get('foo'), 'bar');
     assert.ok(spy.calledWith('foo', 'bar'), 'onChange called with correct args');
   });
 
   test('it renders: boolean', async function (assert) {
     let [model, spy] = await setup.call(this, createAttr('foo', 'boolean', { defaultValue: false }));
-    assert.equal(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
+    assert.strictEqual(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
     assert.notOk(component.fields.objectAt(0).inputChecked, 'renders default value');
     assert.ok(component.hasCheckbox, 'renders a checkbox for boolean');
     await component.fields.objectAt(0).clickLabel();
@@ -64,24 +64,24 @@ module('Integration | Component | form field', function (hooks) {
 
   test('it renders: number', async function (assert) {
     let [model, spy] = await setup.call(this, createAttr('foo', 'number', { defaultValue: 5 }));
-    assert.equal(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
-    assert.equal(component.fields.objectAt(0).inputValue, 5, 'renders default value');
+    assert.strictEqual(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
+    assert.strictEqual(component.fields.objectAt(0).inputValue, 5, 'renders default value');
     assert.ok(component.hasInput, 'renders input for number');
     await component.fields.objectAt(0).input(8).change();
 
-    assert.equal(model.get('foo'), 8);
+    assert.strictEqual(model.get('foo'), 8);
     assert.ok(spy.calledWith('foo', '8'), 'onChange called with correct args');
   });
 
   test('it renders: object', async function (assert) {
     await setup.call(this, createAttr('foo', 'object'));
-    assert.equal(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
+    assert.strictEqual(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
     assert.ok(component.hasJSONEditor, 'renders the json editor');
   });
 
   test('it renders: string as json with clear button', async function (assert) {
     await setup.call(this, createAttr('foo', 'string', { editType: 'json', allowReset: true }));
-    assert.equal(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
+    assert.strictEqual(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
     assert.ok(component.hasJSONEditor, 'renders the json editor');
     assert.ok(component.hasJSONClearButton, 'renders button that will clear the JSON value');
   });
@@ -91,12 +91,12 @@ module('Integration | Component | form field', function (hooks) {
       this,
       createAttr('foo', 'string', { defaultValue: 'goodbye', editType: 'textarea' })
     );
-    assert.equal(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
+    assert.strictEqual(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
     assert.ok(component.hasTextarea, 'renders a textarea');
-    assert.equal(component.fields.objectAt(0).textareaValue, 'goodbye', 'renders default value');
+    assert.strictEqual(component.fields.objectAt(0).textareaValue, 'goodbye', 'renders default value');
     await component.fields.objectAt(0).textarea('hello');
 
-    assert.equal(model.get('foo'), 'hello');
+    assert.strictEqual(model.get('foo'), 'hello');
     assert.ok(spy.calledWith('foo', 'hello'), 'onChange called with correct args');
   });
 
@@ -117,7 +117,7 @@ module('Integration | Component | form field', function (hooks) {
     await component.fields.objectAt(0).select('h').change();
     await component.fields.objectAt(0).ttlTime('3');
     const expectedSeconds = `${3 * 3600}s`;
-    assert.equal(model.get('foo'), expectedSeconds);
+    assert.strictEqual(model.get('foo'), expectedSeconds);
     assert.ok(spy.calledWith('foo', expectedSeconds), 'onChange called with correct args');
   });
 
@@ -126,7 +126,7 @@ module('Integration | Component | form field', function (hooks) {
     await component.fields.objectAt(0).select('h').change();
     await component.fields.objectAt(0).ttlTime('3');
     const expectedSeconds = `${3 * 3600}s`;
-    assert.equal(model.get('foo'), expectedSeconds);
+    assert.strictEqual(model.get('foo'), expectedSeconds);
     assert.ok(spy.calledWith('foo', expectedSeconds), 'onChange called with correct args');
   });
 
@@ -138,7 +138,7 @@ module('Integration | Component | form field', function (hooks) {
     assert.ok(component.hasRadio, 'renders radio buttons');
     const selectedValue = 'SHA256';
     await component.selectRadioInput(selectedValue);
-    assert.equal(model.get('foo'), selectedValue);
+    assert.strictEqual(model.get('foo'), selectedValue);
     assert.ok(spy.calledWith('foo', selectedValue), 'onChange called with correct args');
   });
 
@@ -155,13 +155,13 @@ module('Integration | Component | form field', function (hooks) {
     let [model, spy] = await setup.call(this, createAttr('password', 'string', { sensitive: true }));
     assert.ok(component.hasMaskedInput, 'renders the masked-input component');
     await component.fields.objectAt(0).textarea('secret');
-    assert.equal(model.get('password'), 'secret');
+    assert.strictEqual(model.get('password'), 'secret');
     assert.ok(spy.calledWith('password', 'secret'), 'onChange called with correct args');
   });
 
   test('it uses a passed label', async function (assert) {
     await setup.call(this, createAttr('foo', 'string', { label: 'Not Foo' }));
-    assert.equal(component.fields.objectAt(0).labelText, 'Not Foo', 'renders the label from options');
+    assert.strictEqual(component.fields.objectAt(0).labelText, 'Not Foo', 'renders the label from options');
   });
 
   test('it renders a help tooltip', async function (assert) {

--- a/ui/tests/integration/components/get-credentials-card-test.js
+++ b/ui/tests/integration/components/get-credentials-card-test.js
@@ -59,7 +59,7 @@ module('Integration | Component | get-credentials-card', function (hooks) {
     );
     let card = document.querySelector('[data-test-search-roles]').childNodes[1];
     let placeholder = card.querySelector('input').placeholder;
-    assert.equal(placeholder, 'secret/');
+    assert.strictEqual(placeholder, 'secret/');
 
     await typeIn(card.querySelector('input'), 'test');
     assert.dom('[data-test-get-credentials]').isEnabled();

--- a/ui/tests/integration/components/hover-copy-button-test.js
+++ b/ui/tests/integration/components/hover-copy-button-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | hover copy button', function (hooks) {
     assert.ok(component.buttonIsVisible);
     await component.mouseEnter();
     await settled();
-    assert.equal(component.tooltipText, 'Copy', 'shows copy');
+    assert.strictEqual(component.tooltipText, 'Copy', 'shows copy');
   });
 
   test('it has the correct class when alwaysShow is true', async function (assert) {

--- a/ui/tests/integration/components/icon-test.js
+++ b/ui/tests/integration/components/icon-test.js
@@ -27,7 +27,7 @@ module('Integration | Component | icon', function (hooks) {
     let promise = waitForError();
     render(hbs`<Icon @name="vault-logo" @size="12"/>`);
     let err = await promise;
-    assert.equal(
+    assert.strictEqual(
       err.message,
       'Assertion Failed: Icon component size argument must be either "16" or "24"',
       'Error is thrown when supported size is not provided'
@@ -47,7 +47,7 @@ module('Integration | Component | icon', function (hooks) {
     const promise = waitForError();
     render(hbs`<Icon @name="x" @size="12"/>`);
     const err = await promise;
-    assert.equal(
+    assert.strictEqual(
       err.message,
       'Assertion Failed: Icon component size argument must be either "16" or "24"',
       'Error is thrown when supported size is not provided'

--- a/ui/tests/integration/components/info-table-item-array-test.js
+++ b/ui/tests/integration/components/info-table-item-array-test.js
@@ -50,7 +50,7 @@ module('Integration | Component | InfoTableItemArray', function (hooks) {
 
     assert.dom('[data-test-info-table-item-array]').exists();
     let noLinkString = document.querySelector('code').textContent.trim();
-    assert.equal(
+    assert.strictEqual(
       noLinkString.length,
       DISPLAY_ARRAY.toString().length,
       'renders a string of the array if isLink is not provided'
@@ -67,7 +67,7 @@ module('Integration | Component | InfoTableItemArray', function (hooks) {
         @backend={{this.backend}}
       />
     `);
-    assert.equal(
+    assert.strictEqual(
       document.querySelectorAll('a > span').length,
       DISPLAY_ARRAY.length,
       'renders each item in array with link'
@@ -86,7 +86,7 @@ module('Integration | Component | InfoTableItemArray', function (hooks) {
       @queryParam={{this.queryParam}}
       @backend={{this.backend}}
     />`);
-    assert.equal(
+    assert.strictEqual(
       document.querySelectorAll('a > span').length,
       DISPLAY_ARRAY.length - 1,
       'renders each item in array with link'
@@ -122,7 +122,7 @@ module('Integration | Component | InfoTableItemArray', function (hooks) {
       @backend={{this.backend}}
     />`);
     const numberCutOffTruncatedArray = displayArrayWithWildcard.length - 5;
-    assert.equal(document.querySelectorAll('a > span').length, 5, 'renders truncated array of five');
+    assert.strictEqual(document.querySelectorAll('a > span').length, 5, 'renders truncated array of five');
     assert
       .dom(`[data-test-and="${numberCutOffTruncatedArray}"]`)
       .exists('correctly counts with wildcard filter and shows the count');

--- a/ui/tests/integration/components/info-table-row-test.js
+++ b/ui/tests/integration/components/info-table-row-test.js
@@ -67,7 +67,7 @@ module('Integration | Component | InfoTableRow', function (hooks) {
     await triggerEvent('[data-test-value-div="test label"] .ember-basic-dropdown-trigger', 'mouseenter');
 
     let tooltip = document.querySelector('div.box').textContent.trim();
-    assert.equal(tooltip, 'Tooltip text!', 'renders tooltip text');
+    assert.strictEqual(tooltip, 'Tooltip text!', 'renders tooltip text');
   });
 
   test('it should copy tooltip', async function (assert) {
@@ -148,7 +148,11 @@ module('Integration | Component | InfoTableRow', function (hooks) {
     this.set('label', '');
     this.set('default', '');
     let dashCount = document.querySelectorAll('.flight-icon').length;
-    assert.equal(dashCount, 2, 'Renders dash (-) when both label and value do not exist (and no defaults)');
+    assert.strictEqual(
+      dashCount,
+      2,
+      'Renders dash (-) when both label and value do not exist (and no defaults)'
+    );
   });
 
   test('block content overrides any passed in value content', async function (assert) {
@@ -160,7 +164,7 @@ module('Integration | Component | InfoTableRow', function (hooks) {
       </InfoTableRow>`);
 
     let block = document.querySelector('[data-test-value-div]').textContent.trim();
-    assert.equal(block, 'Block content is here', 'renders block passed through');
+    assert.strictEqual(block, 'Block content is here', 'renders block passed through');
   });
 
   test('Row renders when block content even if alwaysRender = false', async function (assert) {

--- a/ui/tests/integration/components/info-table-test.js
+++ b/ui/tests/integration/components/info-table-test.js
@@ -28,10 +28,10 @@ module('Integration | Component | InfoTable', function (hooks) {
     assert.dom('[data-test-info-table] th').includesText(HEADER, `shows the table header`);
 
     const rows = document.querySelectorAll('.info-table-row');
-    assert.equal(rows.length, ITEMS.length, 'renders an InfoTableRow for each item');
+    assert.strictEqual(rows.length, ITEMS.length, 'renders an InfoTableRow for each item');
 
     rows.forEach((row, i) => {
-      assert.equal(row.innerText, ITEMS[i], 'handles strings and numbers as row values');
+      assert.strictEqual(row.innerText, ITEMS[i], 'handles strings and numbers as row values');
     });
   });
 });

--- a/ui/tests/integration/components/json-editor-test.js
+++ b/ui/tests/integration/components/json-editor-test.js
@@ -34,7 +34,7 @@ module('Integration | Component | json-editor', function (hooks) {
         @readOnly={{true}}
       />`);
 
-    assert.equal(component.title, 'Test title', 'renders the provided title');
+    assert.strictEqual(component.title, 'Test title', 'renders the provided title');
     assert.true(component.hasToolbar, 'renders the toolbar');
     assert.true(component.hasJSONEditor, 'renders the code mirror modifier');
     assert.ok(component.canEdit, 'json editor can be edited');

--- a/ui/tests/integration/components/keymgmt/distribute-test.js
+++ b/ui/tests/integration/components/keymgmt/distribute-test.js
@@ -104,7 +104,7 @@ module('Integration | Component | keymgmt/distribute', function (hooks) {
     assert.dom(SELECTORS.operationsSection).hasAttribute('disabled');
     // Select
     await clickTrigger();
-    assert.equal(ssComponent.options.length, 3, 'shows all provider options');
+    assert.strictEqual(ssComponent.options.length, 3, 'shows all provider options');
     await typeInSearch('aws');
     await ssComponent.selectOption();
     await settled();

--- a/ui/tests/integration/components/keymgmt/provider-edit-test.js
+++ b/ui/tests/integration/components/keymgmt/provider-edit-test.js
@@ -65,8 +65,8 @@ module('Integration | Component | keymgmt/provider-edit', function (hooks) {
     });
     this.owner.lookup('service:router').reopen({
       transitionTo(path, model, { queryParams: { tab } }) {
-        assert.equal(path, root.path, 'Root path sent in transitionTo on delete');
-        assert.equal(model, root.model, 'Root model sent in transitionTo on delete');
+        assert.strictEqual(path, root.path, 'Root path sent in transitionTo on delete');
+        assert.strictEqual(model, root.model, 'Root model sent in transitionTo on delete');
         assert.deepEqual(tab, 'provider', 'Correct query params sent in transitionTo on delete');
       },
     });
@@ -130,8 +130,12 @@ module('Integration | Component | keymgmt/provider-edit', function (hooks) {
     });
     this.owner.lookup('service:router').reopen({
       transitionTo(path, model, { queryParams: { itemType } }) {
-        assert.equal(path, 'vault.cluster.secrets.backend.show', 'Show route sent in transitionTo on save');
-        assert.equal(model, 'foo', 'Model id sent in transitionTo on save');
+        assert.strictEqual(
+          path,
+          'vault.cluster.secrets.backend.show',
+          'Show route sent in transitionTo on save'
+        );
+        assert.strictEqual(model, 'foo', 'Model id sent in transitionTo on save');
         assert.deepEqual(itemType, 'provider', 'Correct query params sent in transitionTo on save');
       },
     });
@@ -190,8 +194,12 @@ module('Integration | Component | keymgmt/provider-edit', function (hooks) {
     });
     this.owner.lookup('service:router').reopen({
       transitionTo(path, model, { queryParams: { itemType } }) {
-        assert.equal(path, 'vault.cluster.secrets.backend.show', 'Show route sent in transitionTo on save');
-        assert.equal(model, 'foo', 'Model id sent in transitionTo on save');
+        assert.strictEqual(
+          path,
+          'vault.cluster.secrets.backend.show',
+          'Show route sent in transitionTo on save'
+        );
+        assert.strictEqual(model, 'foo', 'Model id sent in transitionTo on save');
         assert.deepEqual(itemType, 'provider', 'Correct query params sent in transitionTo on save');
       },
     });

--- a/ui/tests/integration/components/known-secondaries-table-test.js
+++ b/ui/tests/integration/components/known-secondaries-table-test.js
@@ -30,7 +30,7 @@ module('Integration | Component | replication known-secondaries-table', function
     await render(hbs`<KnownSecondariesTable @secondaries={{secondaries}} />`);
 
     SECONDARIES.forEach((secondary) => {
-      assert.equal(
+      assert.strictEqual(
         this.element.querySelector(`[data-test-secondaries=row-for-${secondary.node_id}]`).innerHTML.trim(),
         secondary.node_id,
         'shows a table row and ID for each known secondary'
@@ -39,7 +39,7 @@ module('Integration | Component | replication known-secondaries-table', function
       if (secondary.api_address) {
         const expectedUrl = `${secondary.api_address}/ui/`;
 
-        assert.equal(
+        assert.strictEqual(
           this.element.querySelector(`[data-test-secondaries=api-address-for-${secondary.node_id}]`).href,
           expectedUrl,
           'renders a URL to the secondary UI'
@@ -50,7 +50,7 @@ module('Integration | Component | replication known-secondaries-table', function
         );
       }
 
-      assert.equal(
+      assert.strictEqual(
         this.element
           .querySelector(`[data-test-secondaries=connection-status-for-${secondary.node_id}]`)
           .innerHTML.trim(),

--- a/ui/tests/integration/components/kv-object-editor-test.js
+++ b/ui/tests/integration/components/kv-object-editor-test.js
@@ -18,29 +18,29 @@ module('Integration | Component | kv-object-editor', function (hooks) {
 
   test('it renders with no initial value', async function (assert) {
     await render(hbs`{{kv-object-editor onChange=this.spy}}`);
-    assert.equal(component.rows.length, 1, 'renders a single row');
+    assert.strictEqual(component.rows.length, 1, 'renders a single row');
     await component.addRow();
-    assert.equal(component.rows.length, 1, 'will only render row with a blank key');
+    assert.strictEqual(component.rows.length, 1, 'will only render row with a blank key');
   });
 
   test('it calls onChange when the val changes', async function (assert) {
     await render(hbs`{{kv-object-editor onChange=this.spy}}`);
     await component.rows.objectAt(0).kvKey('foo').kvVal('bar');
-    assert.equal(this.spy.callCount, 2, 'calls onChange each time change is triggered');
+    assert.strictEqual(this.spy.callCount, 2, 'calls onChange each time change is triggered');
     assert.deepEqual(
       this.spy.lastCall.args[0],
       { foo: 'bar' },
       'calls onChange with the JSON respresentation of the data'
     );
     await component.addRow();
-    assert.equal(component.rows.length, 2, 'adds a row when there is no blank one');
+    assert.strictEqual(component.rows.length, 2, 'adds a row when there is no blank one');
   });
 
   test('it renders passed data', async function (assert) {
     let metadata = { foo: 'bar', baz: 'bop' };
     this.set('value', metadata);
     await render(hbs`{{kv-object-editor value=value}}`);
-    assert.equal(
+    assert.strictEqual(
       component.rows.length,
       Object.keys(metadata).length + 1,
       'renders both rows of the metadata, plus an empty one'
@@ -51,12 +51,12 @@ module('Integration | Component | kv-object-editor', function (hooks) {
     await render(hbs`{{kv-object-editor onChange=this.spy}}`);
     await component.rows.objectAt(0).kvKey('foo').kvVal('bar');
     await component.addRow();
-    assert.equal(component.rows.length, 2);
-    assert.equal(this.spy.callCount, 2, 'calls onChange for editing');
+    assert.strictEqual(component.rows.length, 2);
+    assert.strictEqual(this.spy.callCount, 2, 'calls onChange for editing');
     await component.rows.objectAt(0).deleteRow();
 
-    assert.equal(component.rows.length, 1, 'only the blank row left');
-    assert.equal(this.spy.callCount, 3, 'calls onChange deleting row');
+    assert.strictEqual(component.rows.length, 1, 'only the blank row left');
+    assert.strictEqual(this.spy.callCount, 3, 'calls onChange deleting row');
     assert.deepEqual(this.spy.lastCall.args[0], {}, 'last call to onChange is an empty object');
   });
 

--- a/ui/tests/integration/components/license-info-test.js
+++ b/ui/tests/integration/components/license-info-test.js
@@ -23,10 +23,14 @@ module('Integration | Component | license info', function (hooks) {
     await render(
       hbs`<LicenseInfo @licenseId={{this.licenseId}} @expirationTime={{this.expirationTime}} @startTime={{this.startTime}} @features={{this.features}}/>`
     );
-    assert.equal(component.detailRows.length, 3, 'Shows License ID, Valid from, and License State rows');
-    assert.equal(component.featureRows.length, FEATURES.length, 'it renders all of the features');
+    assert.strictEqual(
+      component.detailRows.length,
+      3,
+      'Shows License ID, Valid from, and License State rows'
+    );
+    assert.strictEqual(component.featureRows.length, FEATURES.length, 'it renders all of the features');
     let activeFeatures = component.featureRows.filter((f) => f.featureStatus === 'Active');
-    assert.equal(activeFeatures.length, 2, 'Has two features listed as active');
+    assert.strictEqual(activeFeatures.length, 2, 'Has two features listed as active');
   });
 
   test('it renders properly for autoloaded license', async function (assert) {
@@ -46,7 +50,7 @@ module('Integration | Component | license info', function (hooks) {
       />`
     );
     let row = component.detailRows.filterBy('rowName', 'License state')[0];
-    assert.equal(row.rowValue, 'Autoloaded', 'Shows autoloaded status');
+    assert.strictEqual(row.rowValue, 'Autoloaded', 'Shows autoloaded status');
   });
 
   test('it renders Performance Standby as inactive if count is 0', async function (assert) {
@@ -62,7 +66,11 @@ module('Integration | Component | license info', function (hooks) {
     );
 
     let row = component.featureRows.filterBy('featureName', 'Performance Standby')[0];
-    assert.equal(row.featureStatus, 'Not Active', 'renders feature as inactive because when count is 0');
+    assert.strictEqual(
+      row.featureStatus,
+      'Not Active',
+      'renders feature as inactive because when count is 0'
+    );
   });
 
   test('it renders Performance Standby as active and shows count', async function (assert) {
@@ -84,6 +92,10 @@ module('Integration | Component | license info', function (hooks) {
     );
 
     let row = component.featureRows.filterBy('featureName', 'Performance Standby')[0];
-    assert.equal(row.featureStatus, 'Active — 4 standby nodes allotted', 'renders active and displays count');
+    assert.strictEqual(
+      row.featureStatus,
+      'Active — 4 standby nodes allotted',
+      'renders active and displays count'
+    );
   });
 });

--- a/ui/tests/integration/components/masked-input-test.js
+++ b/ui/tests/integration/components/masked-input-test.js
@@ -74,11 +74,11 @@ module('Integration | Component | masked input', function (hooks) {
     this.set('value', '123456789-123456789-123456789');
     await render(hbs`{{masked-input value=value displayOnly=true}}`);
     let maskedValue = document.querySelector('.masked-value').innerText;
-    assert.equal(maskedValue.length, 11);
+    assert.strictEqual(maskedValue.length, 11);
 
     await component.toggleMasked();
     let unMaskedValue = document.querySelector('.masked-value').innerText;
-    assert.equal(unMaskedValue.length, this.value.length);
+    assert.strictEqual(unMaskedValue.length, this.value.length);
   });
 
   test('it does not unmask text on focus', async function (assert) {
@@ -95,6 +95,6 @@ module('Integration | Component | masked input', function (hooks) {
     await triggerKeyEvent('[data-test-textarea]', 'keydown', 9);
     await component.toggleMasked();
     let unMaskedValue = document.querySelector('.masked-value').value;
-    assert.equal(unMaskedValue, this.value);
+    assert.strictEqual(unMaskedValue, this.value);
   });
 });

--- a/ui/tests/integration/components/mfa-form-test.js
+++ b/ui/tests/integration/components/mfa-form-test.js
@@ -116,7 +116,7 @@ module('Integration | Component | mfa-form', function (hooks) {
     });
 
     this.onSuccess = (resp) =>
-      assert.equal(resp, 'test response', 'Response is returned in onSuccess callback');
+      assert.strictEqual(resp, 'test response', 'Response is returned in onSuccess callback');
 
     await render(hbs`
       <Mfa::MfaForm
@@ -157,7 +157,7 @@ module('Integration | Component | mfa-form', function (hooks) {
     });
 
     this.onSuccess = (resp) =>
-      assert.equal(resp, 'test response', 'Response is returned in onSuccess callback');
+      assert.strictEqual(resp, 'test response', 'Response is returned in onSuccess callback');
 
     await render(hbs`
       <Mfa::MfaForm

--- a/ui/tests/integration/components/mfa-login-enforcement-form-test.js
+++ b/ui/tests/integration/components/mfa-login-enforcement-form-test.js
@@ -124,9 +124,9 @@ module('Integration | Component | mfa-login-enforcement-form', function (hooks) 
     await click('[data-test-mlef-add-target]');
     await click('[data-test-mlef-save]');
     assert.true(this.didSave, 'onSave callback triggered');
-    assert.equal(this.model.name, 'bar', 'Name property set on model');
-    assert.equal(this.model.mfa_methods.firstObject.id, '123456', 'Mfa method added to model');
-    assert.equal(
+    assert.strictEqual(this.model.name, 'bar', 'Name property set on model');
+    assert.strictEqual(this.model.mfa_methods.firstObject.id, '123456', 'Mfa method added to model');
+    assert.strictEqual(
       this.model.auth_method_accessors.firstObject,
       'auth_userpass_1234',
       'Target saved to correct model property'

--- a/ui/tests/integration/components/mfa-login-enforcement-header-test.js
+++ b/ui/tests/integration/components/mfa-login-enforcement-header-test.js
@@ -53,13 +53,13 @@ module('Integration | Component | mfa-login-enforcement-header', function (hooks
       .includesText('An enforcement includes the authentication types', 'Description renders');
     for (const option of ['new', 'existing', 'skip']) {
       await click(`[data-test-mleh-radio="${option}"] input`);
-      assert.equal(this.value, option, 'Value is updated on radio select');
+      assert.strictEqual(this.value, option, 'Value is updated on radio select');
       if (option === 'existing') {
         await clickTrigger();
         await click('.ember-power-select-option');
       }
     }
 
-    assert.equal(this.enforcement.name, 'foo', 'Existing enforcement is selected');
+    assert.strictEqual(this.enforcement.name, 'foo', 'Existing enforcement is selected');
   });
 });

--- a/ui/tests/integration/components/mfa/method-form-test.js
+++ b/ui/tests/integration/components/mfa/method-form-test.js
@@ -56,7 +56,7 @@ module('Integration | Component | mfa-method-form', function (hooks) {
     await fillIn('[data-test-confirmation-modal-input="Edit totp configuration?"]', 'totp');
     await click('[data-test-confirm-button="Edit totp configuration?"]');
     assert.true(this.didSave, 'onSave callback triggered');
-    assert.equal(this.model.issuer, 'Vault', 'Issuer property set on model');
+    assert.strictEqual(this.model.issuer, 'Vault', 'Issuer property set on model');
   });
 
   test('it should populate form fields with model data', async function (assert) {

--- a/ui/tests/integration/components/mount-accessor-select-test.js
+++ b/ui/tests/integration/components/mount-accessor-select-test.js
@@ -29,14 +29,14 @@ module('Integration | Component | mount-accessor-select', function (hooks) {
     await render(hbs`<MountAccessorSelect @onChange={{onChange}} @filterToken={{true}}/>`);
     await click('[data-test-mount-accessor-select]');
     let options = document.querySelector('[data-test-mount-accessor-select]').options;
-    assert.equal(options.length, 1, 'only the auth option, no token');
+    assert.strictEqual(options.length, 1, 'only the auth option, no token');
   });
 
   test('it shows token', async function (assert) {
     await render(hbs`<MountAccessorSelect @onChange={{onChange}}/>`);
     await click('[data-test-mount-accessor-select]');
     let options = document.querySelector('[data-test-mount-accessor-select]').options;
-    assert.equal(options.length, 2, 'both auth and token show');
+    assert.strictEqual(options.length, 2, 'both auth and token show');
   });
 
   test('it sends value to parent onChange', async function (assert) {
@@ -52,13 +52,13 @@ module('Integration | Component | mount-accessor-select', function (hooks) {
     await render(hbs`<MountAccessorSelect @onChange={{onChange}} />`);
     let defaultSelection = document.querySelector('[data-test-mount-accessor-select]').options[0].innerHTML;
     // remove all non letters
-    assert.equal(defaultSelection.replace(/\W/g, ''), 'userpassuserpass');
+    assert.strictEqual(defaultSelection.replace(/\W/g, ''), 'userpassuserpass');
   });
 
   test('it shows Select one if yes default', async function (assert) {
     await render(hbs`<MountAccessorSelect @onChange={{onChange}} @noDefault={{true}} />`);
     let defaultSelection = document.querySelector('[data-test-mount-accessor-select]').options[0].innerHTML;
     // remove all non letters
-    assert.equal(defaultSelection.replace(/\W/g, ''), 'Selectone');
+    assert.strictEqual(defaultSelection.replace(/\W/g, ''), 'Selectone');
   });
 });

--- a/ui/tests/integration/components/mount-backend-form-test.js
+++ b/ui/tests/integration/components/mount-backend-form-test.js
@@ -26,7 +26,11 @@ module('Integration | Component | mount backend form', function (hooks) {
 
   test('it renders', async function (assert) {
     await render(hbs`{{mount-backend-form}}`);
-    assert.equal(component.header, 'Enable an Authentication Method', 'renders auth header in default state');
+    assert.strictEqual(
+      component.header,
+      'Enable an Authentication Method',
+      'renders auth header in default state'
+    );
     assert.ok(component.types.length > 0, 'renders type picker');
   });
 
@@ -34,23 +38,23 @@ module('Integration | Component | mount backend form', function (hooks) {
     await render(hbs`{{mount-backend-form}}`);
     await component.selectType('aws');
     await component.next();
-    assert.equal(component.pathValue, 'aws', 'sets the value of the type');
+    assert.strictEqual(component.pathValue, 'aws', 'sets the value of the type');
     await component.back();
     await component.selectType('approle');
     await component.next();
-    assert.equal(component.pathValue, 'approle', 'updates the value of the type');
+    assert.strictEqual(component.pathValue, 'approle', 'updates the value of the type');
   });
 
   test('it keeps path value if the user has changed it', async function (assert) {
     await render(hbs`{{mount-backend-form}}`);
     await component.selectType('approle');
     await component.next();
-    assert.equal(component.pathValue, 'approle', 'defaults to approle (first in the list)');
+    assert.strictEqual(component.pathValue, 'approle', 'defaults to approle (first in the list)');
     await component.path('newpath');
     await component.back();
     await component.selectType('aws');
     await component.next();
-    assert.equal(component.pathValue, 'newpath', 'updates to the value of the type');
+    assert.strictEqual(component.pathValue, 'newpath', 'updates to the value of the type');
   });
 
   test('it calls mount success', async function (assert) {

--- a/ui/tests/integration/components/nav-header-test.js
+++ b/ui/tests/integration/components/nav-header-test.js
@@ -26,8 +26,8 @@ module('Integration | Component | nav header', function (hooks) {
       `);
 
     assert.ok(component.ele, 'renders the outer element');
-    assert.equal(component.homeText.trim(), 'Home!', 'renders home content');
-    assert.equal(component.itemsText.trim(), 'Some Items', 'renders items content');
-    assert.equal(component.mainText.trim(), 'Main stuff here', 'renders items content');
+    assert.strictEqual(component.homeText.trim(), 'Home!', 'renders home content');
+    assert.strictEqual(component.itemsText.trim(), 'Some Items', 'renders items content');
+    assert.strictEqual(component.mainText.trim(), 'Main stuff here', 'renders items content');
   });
 });

--- a/ui/tests/integration/components/oidc/assignment-form-test.js
+++ b/ui/tests/integration/components/oidc/assignment-form-test.js
@@ -46,7 +46,11 @@ module('Integration | Component | oidc/assignment-form', function (hooks) {
     assert
       .dom('[data-test-inline-alert]')
       .hasText('Name is required.', 'Validation message is shown for name');
-    assert.equal(findAll('[data-test-inline-error-message]').length, 2, `there are two validations errors.`);
+    assert.strictEqual(
+      findAll('[data-test-inline-error-message]').length,
+      2,
+      `there are two validations errors.`
+    );
     await fillIn('[data-test-input="name"]', 'test');
     await click('[data-test-component="search-select"]#entities .ember-basic-dropdown-trigger');
     await click('.ember-power-select-option');

--- a/ui/tests/integration/components/oidc/client-form-test.js
+++ b/ui/tests/integration/components/oidc/client-form-test.js
@@ -80,7 +80,7 @@ module('Integration | Component | oidc/client-form', function (hooks) {
       .dom('[data-test-oidc-client-title]')
       .hasText('Create application', 'Form title renders correct text');
     assert.dom(SELECTORS.clientSaveButton).hasText('Create', 'Save button has correct text');
-    assert.equal(findAll('[data-test-field]').length, 6, 'renders all attribute fields');
+    assert.strictEqual(findAll('[data-test-field]').length, 6, 'renders all attribute fields');
     assert.dom('input#allow-all').isChecked('Allow all radio button selected by default');
     assert.dom('[data-test-ttl-value="ID Token TTL"]').hasValue('1', 'ttl defaults to 24h');
     assert.dom('[data-test-ttl-value="Access Token TTL"]').hasValue('1', 'ttl defaults to 24h');
@@ -188,7 +188,7 @@ module('Integration | Component | oidc/client-form', function (hooks) {
     await fillIn('[data-test-input="redirectUris"] [data-test-string-list-input="0"]', 'some-url.com');
     await click('[data-test-string-list-button="add"]');
     await click(SELECTORS.clientCancelButton);
-    assert.equal(this.model.redirectUris, undefined, 'Model attributes rolled back on cancel');
+    assert.strictEqual(this.model.redirectUris, undefined, 'Model attributes rolled back on cancel');
   });
 
   test('it should show create assignment modal', async function (assert) {

--- a/ui/tests/integration/components/oidc/key-form-test.js
+++ b/ui/tests/integration/components/oidc/key-form-test.js
@@ -48,7 +48,7 @@ module('Integration | Component | oidc/key-form', function (hooks) {
     assert.dom('[data-test-oidc-key-title]').hasText('Create key', 'Form title renders correct text');
     assert.dom(SELECTORS.keySaveButton).hasText('Create', 'Save button has correct text');
     assert.dom('[data-test-input="algorithm"]').hasValue('RS256', 'default algorithm is correct');
-    assert.equal(findAll('[data-test-field]').length, 4, 'renders all input fields');
+    assert.strictEqual(findAll('[data-test-field]').length, 4, 'renders all input fields');
 
     // check validation errors
     await fillIn('[data-test-input="name"]', ' ');
@@ -101,7 +101,7 @@ module('Integration | Component | oidc/key-form', function (hooks) {
       .dom('[data-test-component="search-select"]#allowedClientIds')
       .exists('Limited radio button shows clients search select');
     await click('[data-test-component="search-select"]#allowedClientIds .ember-basic-dropdown-trigger');
-    assert.equal(findAll('li.ember-power-select-option').length, 1, 'dropdown only renders one option');
+    assert.strictEqual(findAll('li.ember-power-select-option').length, 1, 'dropdown only renders one option');
     assert
       .dom('li.ember-power-select-option')
       .hasTextContaining('app-1', 'dropdown contains client that references key');
@@ -149,7 +149,7 @@ module('Integration | Component | oidc/key-form', function (hooks) {
 
     await click('label[for=limited]');
     await click(SELECTORS.keyCancelButton);
-    assert.equal(this.model.allowed_client_ids, undefined, 'Model attributes rolled back on cancel');
+    assert.strictEqual(this.model.allowed_client_ids, undefined, 'Model attributes rolled back on cancel');
   });
 
   test('it should render fallback for search select', async function (assert) {

--- a/ui/tests/integration/components/oidc/provider-form-test.js
+++ b/ui/tests/integration/components/oidc/provider-form-test.js
@@ -69,7 +69,7 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
     assert
       .dom('[data-test-input="issuer"]')
       .hasAttribute('placeholder', 'e.g. https://example.com:8200', 'issuer placeholder text is correct');
-    assert.equal(findAll('[data-test-field]').length, 3, 'renders all input fields');
+    assert.strictEqual(findAll('[data-test-field]').length, 3, 'renders all input fields');
     await click('[data-test-component="search-select"]#scopesSupported .ember-basic-dropdown-trigger');
     assert.dom('li.ember-power-select-option').hasText('test-scope', 'dropdown renders scopes');
 
@@ -178,7 +178,7 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
 
     await click('label[for=limited]');
     await click(SELECTORS.providerCancelButton);
-    assert.equal(this.model.allowed_client_ids, undefined, 'Model attributes rolled back on cancel');
+    assert.strictEqual(this.model.allowed_client_ids, undefined, 'Model attributes rolled back on cancel');
   });
 
   test('it should render fallback for search select', async function (assert) {

--- a/ui/tests/integration/components/oidc/scope-form-test.js
+++ b/ui/tests/integration/components/oidc/scope-form-test.js
@@ -141,7 +141,11 @@ module('Integration | Component | oidc/scope-form', function (hooks) {
 
     await fillIn('[data-test-input="description"]', 'changed description attribute');
     await click(SELECTORS.scopeCancelButton);
-    assert.equal(this.model.description, 'this is a test', 'Model attributes are rolled back on cancel');
+    assert.strictEqual(
+      this.model.description,
+      'this is a test',
+      'Model attributes are rolled back on cancel'
+    );
   });
 
   test('it should show example template modal', async function (assert) {

--- a/ui/tests/integration/components/pagination-controls-test.js
+++ b/ui/tests/integration/components/pagination-controls-test.js
@@ -28,7 +28,7 @@ module('Integration | Component | pagination-controls', function (hooks) {
 
     let expectedPage = 2;
     this.onChange = (page) => {
-      assert.equal(page, expectedPage, 'onChange callback is fired with correct page number');
+      assert.strictEqual(page, expectedPage, 'onChange callback is fired with correct page number');
     };
 
     await render(hbs`<PaginationControls @total={{75}} @onChange={{this.onChange}} />`);

--- a/ui/tests/integration/components/path-filter-config-list-test.js
+++ b/ui/tests/integration/components/path-filter-config-list-test.js
@@ -76,21 +76,21 @@ module('Integration | Component | path filter config list', function (hooks) {
     assert.ok(this.config.paths.includes('auth/userpass/'), 'adds to paths');
 
     await clickTrigger();
-    await assert.equal(searchSelect.options.length, 1, 'has one option left');
+    await assert.strictEqual(searchSelect.options.length, 1, 'has one option left');
 
     await searchSelect.deleteButtons.objectAt(0).click();
-    assert.equal(this.config.paths.length, 0, 'removes from paths');
+    assert.strictEqual(this.config.paths.length, 0, 'removes from paths');
     await clickTrigger();
-    await assert.equal(searchSelect.options.length, 2, 'has both options');
+    await assert.strictEqual(searchSelect.options.length, 2, 'has both options');
   });
 
   test('it sets config.mode', async function (assert) {
     this.set('config', { mode: 'allow', paths: [] });
     await render(hbs`<PathFilterConfigList @config={{this.config}} />`);
     await click('#deny');
-    assert.equal(this.config.mode, 'deny');
+    assert.strictEqual(this.config.mode, 'deny');
     await click('#no-filtering');
-    assert.equal(this.config.mode, null);
+    assert.strictEqual(this.config.mode, null);
   });
 
   test('it shows a warning when going from a mode to allow all', async function (assert) {
@@ -106,10 +106,10 @@ module('Integration | Component | path filter config list', function (hooks) {
     await render(hbs`<PathFilterConfigList @config={{config}} @paths={{paths}} />`);
 
     await clickTrigger();
-    assert.equal(searchSelect.options.length, 2, 'shows userpass and namespace as an option');
+    assert.strictEqual(searchSelect.options.length, 2, 'shows userpass and namespace as an option');
     // type the namespace to trigger an ajax request
     await typeInSearch('ns1');
-    assert.equal(searchSelect.options.length, 2, 'has ns and ns mount in the list');
+    assert.strictEqual(searchSelect.options.length, 2, 'has ns and ns mount in the list');
     await searchSelect.options.objectAt(1).click();
     assert.ok(this.config.paths.includes('ns1/namespace-kv/'), 'adds namespace mount to paths');
   });

--- a/ui/tests/integration/components/pgp-file-test.js
+++ b/ui/tests/integration/components/pgp-file-test.js
@@ -60,9 +60,13 @@ module('Integration | Component | pgp file', function (hooks) {
     });
     assert.dom('[data-test-pgp-file-input-label]').hasText(file.name, 'the file input shows the file name');
     assert.notDeepEqual(this.lastOnChangeCall[1].value, key.value, 'onChange was called with the new key');
-    assert.equal(this.lastOnChangeCall[0], 0, 'onChange is called with the index value');
+    assert.strictEqual(this.lastOnChangeCall[0], 0, 'onChange is called with the index value');
     await click('[data-test-pgp-clear]');
-    assert.equal(this.lastOnChangeCall[1].value, key.value, 'the key gets reset when the input is cleared');
+    assert.strictEqual(
+      this.lastOnChangeCall[1].value,
+      key.value,
+      'the key gets reset when the input is cleared'
+    );
   });
 
   test('it allows for text entry', async function (assert) {
@@ -85,7 +89,7 @@ module('Integration | Component | pgp file', function (hooks) {
     await waitUntil(() => {
       return !!this.lastOnChangeCall;
     });
-    assert.equal(this.lastOnChangeCall[1].value, text, 'the key value is passed to onChange');
+    assert.strictEqual(this.lastOnChangeCall[1].value, text, 'the key value is passed to onChange');
   });
 
   test('toggling back and forth', async function (assert) {

--- a/ui/tests/integration/components/pki/config-pki-ca-test.js
+++ b/ui/tests/integration/components/pki/config-pki-ca-test.js
@@ -58,15 +58,15 @@ module('Integration | Component | config pki ca', function (hooks) {
     await setupAndRender(this);
 
     assert.notOk(component.hasTitle, 'no title in the default state');
-    assert.equal(component.replaceCAText, 'Configure CA');
-    assert.equal(component.downloadLinks.length, 0, 'there are no download links');
+    assert.strictEqual(component.replaceCAText, 'Configure CA');
+    assert.strictEqual(component.downloadLinks.length, 0, 'there are no download links');
 
     await component.replaceCA();
-    assert.equal(component.title, 'Configure CA Certificate');
+    assert.strictEqual(component.title, 'Configure CA Certificate');
     await component.back();
 
     await component.setSignedIntermediateBtn();
-    assert.equal(component.title, 'Set signed intermediate');
+    assert.strictEqual(component.title, 'Set signed intermediate');
   });
 
   test('it renders, with pem', async function (assert) {
@@ -74,7 +74,7 @@ module('Integration | Component | config pki ca', function (hooks) {
     this.set('config', c);
     await render(hbs`<Pki::ConfigPkiCa @config={{config}} />`);
     assert.notOk(component.hasTitle, 'no title in the default state');
-    assert.equal(component.replaceCAText, 'Add CA');
-    assert.equal(component.downloadLinks.length, 3, 'shows download links');
+    assert.strictEqual(component.replaceCAText, 'Add CA');
+    assert.strictEqual(component.downloadLinks.length, 3, 'shows download links');
   });
 });

--- a/ui/tests/integration/components/pki/config-pki-test.js
+++ b/ui/tests/integration/components/pki/config-pki-test.js
@@ -54,7 +54,7 @@ module('Integration | Component | config pki', function (hooks) {
     await setupAndRender(this);
     assert.ok(component.text.startsWith('You can tidy up the backend'));
     assert.notOk(component.hasTitle, 'No title for tidy section');
-    assert.equal(component.fields.length, 2);
+    assert.strictEqual(component.fields.length, 2);
     assert.ok(component.fields.objectAt(0).labelText, 'Tidy cert store');
     assert.ok(component.fields.objectAt(1).labelText, 'Another attr');
   });
@@ -62,16 +62,16 @@ module('Integration | Component | config pki', function (hooks) {
   test('it renders crl section', async function (assert) {
     await setupAndRender(this, 'crl');
     assert.ok(component.hasTitle, 'renders the title');
-    assert.equal(component.title, 'Certificate Revocation List (CRL) config');
+    assert.strictEqual(component.title, 'Certificate Revocation List (CRL) config');
     assert.ok(component.text.startsWith('Set the duration for which the generated CRL'));
-    assert.equal(component.fields.length, 1);
+    assert.strictEqual(component.fields.length, 1);
     assert.ok(component.fields.objectAt(0).labelText, 'Crl');
   });
 
   test('it renders urls section', async function (assert) {
     await setupAndRender(this, 'urls');
     assert.notOk(component.hasTitle, 'No title for urls section');
-    assert.equal(component.fields.length, 1);
+    assert.strictEqual(component.fields.length, 1);
     assert.ok(component.fields.objectAt(0).labelText, 'urls');
   });
 
@@ -84,7 +84,7 @@ module('Integration | Component | config pki', function (hooks) {
     this.set(
       'config',
       config((options) => {
-        assert.equal(options.adapterOptions.method, section, 'method passed to save');
+        assert.strictEqual(options.adapterOptions.method, section, 'method passed to save');
         assert.deepEqual(
           options.adapterOptions.fields,
           ['tidyCertStore', 'anotherAttr'],

--- a/ui/tests/integration/components/radial-progress-test.js
+++ b/ui/tests/integration/components/radial-progress-test.js
@@ -16,14 +16,14 @@ module('Integration | Component | radial progress', function (hooks) {
     let circumference = ((19 / 2) * Math.PI * 2).toFixed(2);
     await render(hbs`{{radial-progress progressDecimal=0.5}}`);
 
-    assert.equal(component.viewBox, '0 0 20 20');
-    assert.equal(component.height, '20');
-    assert.equal(component.width, '20');
-    assert.equal(component.strokeWidth, '1');
-    assert.equal(component.r, 19 / 2);
-    assert.equal(component.cx, 10);
-    assert.equal(component.cy, 10);
-    assert.equal(Number(component.strokeDash).toFixed(2), circumference);
-    assert.equal(Number(component.strokeDashOffset).toFixed(3), (circumference * 0.5).toFixed(3));
+    assert.strictEqual(component.viewBox, '0 0 20 20');
+    assert.strictEqual(component.height, '20');
+    assert.strictEqual(component.width, '20');
+    assert.strictEqual(component.strokeWidth, '1');
+    assert.strictEqual(component.r, 19 / 2);
+    assert.strictEqual(component.cx, 10);
+    assert.strictEqual(component.cy, 10);
+    assert.strictEqual(Number(component.strokeDash).toFixed(2), circumference);
+    assert.strictEqual(Number(component.strokeDashOffset).toFixed(3), (circumference * 0.5).toFixed(3));
   });
 });

--- a/ui/tests/integration/components/replication-secondary-card-test.js
+++ b/ui/tests/integration/components/replication-secondary-card-test.js
@@ -46,7 +46,7 @@ module('Integration | Component | replication-secondary-card', function (hooks) 
     const url = this.element.querySelector('[data-test-primary-link]').href;
     const expectedUrl = `${REPLICATION_DETAILS.primaries[0].api_address}/ui/`;
 
-    assert.equal(url, expectedUrl, 'it renders a link to the primary cluster UI');
+    assert.strictEqual(url, expectedUrl, 'it renders a link to the primary cluster UI');
   });
 
   test('it does not render a link to the primary cluster UI when the primary api address or known primaries are unknown', async function (assert) {

--- a/ui/tests/integration/components/search-select-test.js
+++ b/ui/tests/integration/components/search-select-test.js
@@ -79,9 +79,9 @@ module('Integration | Component | search select', function (hooks) {
     await render(hbs`{{search-select label="foo" models=models onChange=onChange}}`);
 
     assert.ok(component.hasLabel, 'it renders the label');
-    assert.equal(component.labelText, 'foo', 'the label text is correct');
+    assert.strictEqual(component.labelText, 'foo', 'the label text is correct');
     assert.ok(component.hasTrigger, 'it renders the power select trigger');
-    assert.equal(component.selectedOptions.length, 0, 'there are no selected options');
+    assert.strictEqual(component.selectedOptions.length, 0, 'there are no selected options');
   });
 
   test('it shows options when trigger is clicked', async function (assert) {
@@ -92,8 +92,8 @@ module('Integration | Component | search select', function (hooks) {
 
     await clickTrigger();
     await settled();
-    assert.equal(component.options.length, 3, 'shows all options');
-    assert.equal(
+    assert.strictEqual(component.options.length, 3, 'shows all options');
+    assert.strictEqual(
       component.options.objectAt(0).text,
       component.selectedOptionText,
       'first object in list is focused'
@@ -108,13 +108,17 @@ module('Integration | Component | search select', function (hooks) {
 
     await clickTrigger();
     await settled();
-    assert.equal(component.options.length, 3, 'shows all options');
+    assert.strictEqual(component.options.length, 3, 'shows all options');
     await typeInSearch('n');
-    assert.equal(component.options.length, 3, 'list still shows three options, including the add option');
+    assert.strictEqual(
+      component.options.length,
+      3,
+      'list still shows three options, including the add option'
+    );
     await typeInSearch('ni');
-    assert.equal(component.options.length, 2, 'list shows two options, including the add option');
+    assert.strictEqual(component.options.length, 2, 'list shows two options, including the add option');
     await typeInSearch('nine');
-    assert.equal(component.options.length, 1, 'list shows one option');
+    assert.strictEqual(component.options.length, 1, 'list shows one option');
   });
 
   test('it counts options when wildcard is used and displays the count', async function (assert) {
@@ -139,10 +143,10 @@ module('Integration | Component | search select', function (hooks) {
     await render(hbs`{{search-select label="foo" models=models onChange=onChange disallowNewItems=true}}`);
 
     await clickTrigger();
-    assert.equal(component.options.length, 3, 'shows all options');
+    assert.strictEqual(component.options.length, 3, 'shows all options');
     await typeInSearch('p');
-    assert.equal(component.options.length, 1, 'list shows one option');
-    assert.equal(component.options[0].text, 'No results found');
+    assert.strictEqual(component.options.length, 1, 'list shows one option');
+    assert.strictEqual(component.options[0].text, 'No results found');
     await clickTrigger();
     assert.ok(this.onChange.notCalled, 'on change not called when empty state clicked');
   });
@@ -155,15 +159,15 @@ module('Integration | Component | search select', function (hooks) {
 
     await clickTrigger();
     await settled();
-    assert.equal(component.options.length, 3, 'shows all options');
+    assert.strictEqual(component.options.length, 3, 'shows all options');
     await component.selectOption();
     await settled();
-    assert.equal(component.selectedOptions.length, 1, 'there is 1 selected option');
+    assert.strictEqual(component.selectedOptions.length, 1, 'there is 1 selected option');
     assert.ok(this.onChange.calledOnce);
     assert.ok(this.onChange.calledWith(['7']));
     await clickTrigger();
     await settled();
-    assert.equal(component.options.length, 2, 'shows two options');
+    assert.strictEqual(component.options.length, 2, 'shows two options');
   });
 
   test('it pre-populates list with passed in selectedOptions', async function (assert) {
@@ -173,10 +177,10 @@ module('Integration | Component | search select', function (hooks) {
     this.set('inputValue', ['8']);
     await render(hbs`{{search-select label="foo" inputValue=inputValue models=models onChange=onChange}}`);
 
-    assert.equal(component.selectedOptions.length, 1, 'there is 1 selected option');
+    assert.strictEqual(component.selectedOptions.length, 1, 'there is 1 selected option');
     await clickTrigger();
     await settled();
-    assert.equal(component.options.length, 2, 'shows two options');
+    assert.strictEqual(component.options.length, 2, 'shows two options');
   });
 
   test('it adds discarded list items back into select', async function (assert) {
@@ -186,15 +190,15 @@ module('Integration | Component | search select', function (hooks) {
     this.set('inputValue', ['8']);
     await render(hbs`{{search-select label="foo" inputValue=inputValue models=models onChange=onChange}}`);
 
-    assert.equal(component.selectedOptions.length, 1, 'there is 1 selected option');
+    assert.strictEqual(component.selectedOptions.length, 1, 'there is 1 selected option');
     await component.deleteButtons.objectAt(0).click();
     await settled();
-    assert.equal(component.selectedOptions.length, 0, 'there are no selected options');
+    assert.strictEqual(component.selectedOptions.length, 0, 'there are no selected options');
     assert.ok(this.onChange.calledOnce);
     assert.ok(this.onChange.calledWith([]));
     await clickTrigger();
     await settled();
-    assert.equal(component.options.length, 3, 'shows all options');
+    assert.strictEqual(component.options.length, 3, 'shows all options');
   });
 
   test('it adds created item to list items on create and removes without adding back to options on delete', async function (assert) {
@@ -205,22 +209,26 @@ module('Integration | Component | search select', function (hooks) {
 
     await clickTrigger();
     await settled();
-    assert.equal(component.options.length, 3, 'shows all options');
+    assert.strictEqual(component.options.length, 3, 'shows all options');
     await typeInSearch('n');
-    assert.equal(component.options.length, 3, 'list still shows three options, including the add option');
+    assert.strictEqual(
+      component.options.length,
+      3,
+      'list still shows three options, including the add option'
+    );
     await typeInSearch('ni');
     await component.selectOption();
     await settled();
-    assert.equal(component.selectedOptions.length, 1, 'there is 1 selected option');
+    assert.strictEqual(component.selectedOptions.length, 1, 'there is 1 selected option');
     assert.ok(this.onChange.calledOnce);
     assert.ok(this.onChange.calledWith(['ni']));
     await component.deleteButtons.objectAt(0).click();
     await settled();
-    assert.equal(component.selectedOptions.length, 0, 'there are no selected options');
+    assert.strictEqual(component.selectedOptions.length, 0, 'there are no selected options');
     assert.ok(this.onChange.calledWith([]));
     await clickTrigger();
     await settled();
-    assert.equal(component.options.length, 3, 'does not add deleted option back to list');
+    assert.strictEqual(component.options.length, 3, 'does not add deleted option back to list');
   });
 
   test('it uses fallback component if endpoint 403s', async function (assert) {
@@ -244,8 +252,12 @@ module('Integration | Component | search select', function (hooks) {
 
     await clickTrigger();
     await settled();
-    assert.equal(component.options.length, 1, 'prompts for search to add new options');
-    assert.equal(component.options.objectAt(0).text, 'Type to search', 'text of option shows Type to search');
+    assert.strictEqual(component.options.length, 1, 'prompts for search to add new options');
+    assert.strictEqual(
+      component.options.objectAt(0).text,
+      'Type to search',
+      'text of option shows Type to search'
+    );
   });
 
   test('it shows add suggestion if there are no options', async function (assert) {
@@ -260,7 +272,11 @@ module('Integration | Component | search select', function (hooks) {
     await settled();
 
     await typeInSearch('new item');
-    assert.equal(component.options.objectAt(0).text, 'Add new foo: new item', 'shows the create suggestion');
+    assert.strictEqual(
+      component.options.objectAt(0).text,
+      'Add new foo: new item',
+      'shows the create suggestion'
+    );
   });
 
   test('it shows items not in the returned response', async function (assert) {
@@ -271,7 +287,7 @@ module('Integration | Component | search select', function (hooks) {
       hbs`{{search-select label="foo" inputValue=inputValue models=models fallbackComponent="string-list" onChange=onChange}}`
     );
 
-    assert.equal(component.selectedOptions.length, 2, 'renders inputOptions as selectedOptions');
+    assert.strictEqual(component.selectedOptions.length, 2, 'renders inputOptions as selectedOptions');
   });
 
   test('it shows both name and smaller id for identity endpoints', async function (assert) {
@@ -281,8 +297,8 @@ module('Integration | Component | search select', function (hooks) {
     await render(hbs`{{search-select label="foo" inputValue=inputValue models=models onChange=onChange}}`);
 
     await clickTrigger();
-    assert.equal(component.options.length, 3, 'shows all options');
-    assert.equal(component.smallOptionIds.length, 3, 'shows the smaller id text and the name');
+    assert.strictEqual(component.options.length, 3, 'shows all options');
+    assert.strictEqual(component.smallOptionIds.length, 3, 'shows the smaller id text and the name');
   });
 
   test('it does not show name and smaller id for non-identity endpoints', async function (assert) {
@@ -292,8 +308,8 @@ module('Integration | Component | search select', function (hooks) {
     await render(hbs`{{search-select label="foo" inputValue=inputValue models=models onChange=onChange}}`);
 
     await clickTrigger();
-    assert.equal(component.options.length, 3, 'shows all options');
-    assert.equal(component.smallOptionIds.length, 0, 'only shows the regular sized id');
+    assert.strictEqual(component.options.length, 3, 'shows all options');
+    assert.strictEqual(component.smallOptionIds.length, 0, 'only shows the regular sized id');
   });
 
   test('it throws an error if endpoint 500s', async function (assert) {
@@ -317,7 +333,7 @@ module('Integration | Component | search select', function (hooks) {
     await settled();
     // First select existing option
     await component.selectOption();
-    assert.equal(component.selectedOptions.length, 1, 'there is 1 selected option');
+    assert.strictEqual(component.selectedOptions.length, 1, 'there is 1 selected option');
     assert.ok(this.onChange.calledOnce);
     assert.ok(
       this.onChange.calledWith([{ id: '7', isNew: false }]),
@@ -361,7 +377,7 @@ module('Integration | Component | search select', function (hooks) {
 
     // First select existing option
     await component.selectOption();
-    assert.equal(component.selectedOptions.length, 1, 'there is 1 selected option');
+    assert.strictEqual(component.selectedOptions.length, 1, 'there is 1 selected option');
     assert
       .dom('[data-test-selected-option]')
       .hasText('model-a-id', 'does not render name if first objectKey is id');
@@ -417,7 +433,7 @@ module('Integration | Component | search select', function (hooks) {
 
     // First select existing option
     await component.selectOption();
-    assert.equal(component.selectedOptions.length, 1, 'there is 1 selected option');
+    assert.strictEqual(component.selectedOptions.length, 1, 'there is 1 selected option');
     assert
       .dom('[data-test-selected-option]')
       .hasText('model-a a123', `renders name and ${objectKeys[0]} if first objectKey is not id`);
@@ -459,7 +475,7 @@ module('Integration | Component | search select', function (hooks) {
 
     // First select existing option
     await component.selectOption();
-    assert.equal(component.selectedOptions.length, 1, 'there is 1 selected option');
+    assert.strictEqual(component.selectedOptions.length, 1, 'there is 1 selected option');
     assert
       .dom('[data-test-selected-option]')
       .hasText('1', 'renders model id if does not have objectKey as an attribute');
@@ -490,7 +506,7 @@ module('Integration | Component | search select', function (hooks) {
 
     // First select existing option
     await component.selectOption();
-    assert.equal(component.selectedOptions.length, 1, 'there is 1 selected option');
+    assert.strictEqual(component.selectedOptions.length, 1, 'there is 1 selected option');
     assert.dom('[data-test-selected-option]').hasText('1', 'renders model id if does not have objectKey');
     assert.propEqual(
       spy.args[0][0],
@@ -525,8 +541,8 @@ module('Integration | Component | search select', function (hooks) {
 
     await clickTrigger();
     await settled();
-    assert.equal(component.options.objectAt(0).text, '1', 'first option renders just id as name');
-    assert.equal(
+    assert.strictEqual(component.options.objectAt(0).text, '1', 'first option renders just id as name');
+    assert.strictEqual(
       component.options.objectAt(3).text,
       'model-a a123',
       `4 option renders both name and ${objectKeys[0]}`
@@ -577,8 +593,8 @@ module('Integration | Component | search select', function (hooks) {
 
     await clickTrigger();
     await settled();
-    assert.equal(component.options.objectAt(0).text, '1', 'first option is just id as name');
-    assert.equal(
+    assert.strictEqual(component.options.objectAt(0).text, '1', 'first option is just id as name');
+    assert.strictEqual(
       component.options.objectAt(3).text,
       'model-a a123',
       `4th option has both name and ${objectKeys[0]}`
@@ -611,7 +627,7 @@ module('Integration | Component | search select', function (hooks) {
       />
       `);
 
-    assert.equal(component.selectedOptions.length, 2, 'there are two selected options');
+    assert.strictEqual(component.selectedOptions.length, 2, 'there are two selected options');
     assert.dom('[data-test-selected-option="0"]').hasText('model-a');
     assert.dom('[data-test-selected-option="1"]').hasText('non-existent-model');
     assert
@@ -643,7 +659,7 @@ module('Integration | Component | search select', function (hooks) {
       />
     `);
 
-    assert.equal(component.selectedOptions.length, 2, 'there are two selected options');
+    assert.strictEqual(component.selectedOptions.length, 2, 'there are two selected options');
     assert.dom('[data-test-selected-option="0"]').hasText('model-a a123');
     assert.dom('[data-test-selected-option="1"]').hasText('non-existent-model');
     assert
@@ -672,7 +688,7 @@ module('Integration | Component | search select', function (hooks) {
       />
     `);
 
-    assert.equal(component.selectedOptions.length, 2, 'there are two selected options');
+    assert.strictEqual(component.selectedOptions.length, 2, 'there are two selected options');
     assert.dom('[data-test-selected-option="0"]').hasText('model-a-id');
     assert.dom('[data-test-selected-option="1"]').hasText('non-existent-model');
     assert
@@ -701,7 +717,7 @@ module('Integration | Component | search select', function (hooks) {
       />
     `);
 
-    assert.equal(component.selectedOptions.length, 2, 'there are two selected options');
+    assert.strictEqual(component.selectedOptions.length, 2, 'there are two selected options');
     assert.dom('[data-test-selected-option="0"]').hasText('model-a-id');
     assert.dom('[data-test-selected-option="1"]').hasText('non-existent-model');
     assert

--- a/ui/tests/integration/components/search-select-with-modal-test.js
+++ b/ui/tests/integration/components/search-select-with-modal-test.js
@@ -86,12 +86,12 @@ module('Integration | Component | search select with modal', function (hooks) {
   `);
 
     assert.dom('[data-test-search-select-with-modal]').exists('the component renders');
-    assert.equal(component.labelText, 'Entity ID', 'label text is correct');
+    assert.strictEqual(component.labelText, 'Entity ID', 'label text is correct');
     assert.ok(component.hasTrigger, 'it renders the power select trigger');
-    assert.equal(component.selectedOptions.length, 0, 'there are no selected options');
+    assert.strictEqual(component.selectedOptions.length, 0, 'there are no selected options');
 
     await clickTrigger();
-    assert.equal(component.options.length, 2, 'dropdown renders passed in models as options');
+    assert.strictEqual(component.options.length, 2, 'dropdown renders passed in models as options');
   });
 
   test('it filters options and adds option to create new item', async function (assert) {
@@ -111,16 +111,16 @@ module('Integration | Component | search select with modal', function (hooks) {
   `);
 
     await clickTrigger();
-    assert.equal(component.options.length, 2, 'dropdown renders all options');
+    assert.strictEqual(component.options.length, 2, 'dropdown renders all options');
 
     await typeInSearch('e');
-    assert.equal(component.options.length, 3, 'dropdown renders all options plus add option');
+    assert.strictEqual(component.options.length, 3, 'dropdown renders all options plus add option');
 
     await typeInSearch('entity-1');
-    assert.equal(component.options[0].text, 'entity-1-id', 'dropdown renders only matching option');
+    assert.strictEqual(component.options[0].text, 'entity-1-id', 'dropdown renders only matching option');
 
     await typeInSearch('entity-1-new');
-    assert.equal(
+    assert.strictEqual(
       component.options[0].text,
       'Create new entity: entity-1-new',
       'dropdown gives option to create new option'

--- a/ui/tests/integration/components/select-test.js
+++ b/ui/tests/integration/components/select-test.js
@@ -26,7 +26,7 @@ module('Integration | Component | Select', function (hooks) {
     await render(hbs`<Select @options={{options}} @label={{label}} @name={{name}}/>`);
 
     assert.dom('[data-test-select="foo"]').hasValue('foo');
-    assert.equal(this.element.querySelector('[data-test-select="foo"]').options.length, 3);
+    assert.strictEqual(this.element.querySelector('[data-test-select="foo"]').options.length, 3);
   });
 
   test('it renders when options is an array of objects', async function (assert) {
@@ -38,7 +38,7 @@ module('Integration | Component | Select', function (hooks) {
     await render(hbs`<Select @options={{options}} @label={{label}} @name={{name}}/>`);
 
     assert.dom('[data-test-select="foo"]').hasValue('berry');
-    assert.equal(this.element.querySelector('[data-test-select="foo"]').options.length, 2);
+    assert.strictEqual(this.element.querySelector('[data-test-select="foo"]').options.length, 2);
   });
 
   test('it renders when options is an array of custom objects', async function (assert) {

--- a/ui/tests/integration/components/selectable-card-test.js
+++ b/ui/tests/integration/components/selectable-card-test.js
@@ -18,12 +18,12 @@ module('Integration | Component selectable-card', function (hooks) {
     await render(hbs`<SelectableCard @total={{total}} @cardTitle={{cardTitle}}/>`);
     let titleNumber = this.element.querySelector('.title-number').innerText;
 
-    assert.equal(titleNumber, 15);
+    assert.strictEqual(titleNumber, 15);
   });
 
   test('it returns card title, ', async function (assert) {
     await render(hbs`<SelectableCard @total={{1}} @cardTitle={{cardTitle}}/>`);
     let titleText = this.element.querySelector('.title').innerText;
-    assert.equal(titleText, 'Connections');
+    assert.strictEqual(titleText, 'Connections');
   });
 });

--- a/ui/tests/integration/components/string-list-test.js
+++ b/ui/tests/integration/components/string-list-test.js
@@ -110,7 +110,7 @@ module('Integration | Component | string list', function (hooks) {
     assert.expect(2);
     this.set('inputValue', 'foo');
     this.set('onChange', function (val) {
-      assert.equal(val, 'foo,bar', 'calls onChange with expected value');
+      assert.strictEqual(val, 'foo,bar', 'calls onChange with expected value');
     });
     await render(hbs`<StringList @inputValue={{inputValue}} @onChange={{onChange}}/>`);
     await fillIn('[data-test-string-list-input="1"]', 'bar');
@@ -121,7 +121,7 @@ module('Integration | Component | string list', function (hooks) {
     assert.expect(4);
     this.set('inputValue', ['foo', 'bar']);
     this.set('onChange', function (val) {
-      assert.equal(val, 'bar', 'calls onChange with expected value');
+      assert.strictEqual(val, 'bar', 'calls onChange with expected value');
     });
     await render(hbs`<StringList @inputValue={{inputValue}} @onChange={{onChange}} />`);
 

--- a/ui/tests/integration/components/transit-key-actions-test.js
+++ b/ui/tests/integration/components/transit-key-actions-test.js
@@ -141,7 +141,7 @@ module('Integration | Component | transit key actions', function (hooks) {
       'passes expected args to the adapter'
     );
 
-    assert.equal(find('[data-test-encrypted-value="ciphertext"]').innerText, 'secret');
+    assert.strictEqual(find('[data-test-encrypted-value="ciphertext"]').innerText, 'secret');
 
     // exit modal
     await click('[data-test-modal-background]');
@@ -221,7 +221,7 @@ module('Integration | Component | transit key actions', function (hooks) {
 
     this.set('storeService.keyActionReturnVal', { plaintext });
     this.set('selectedAction', 'decrypt');
-    assert.equal(
+    assert.strictEqual(
       find('#ciphertext-control .CodeMirror').CodeMirror.getValue(),
       '',
       'does not prefill ciphertext value'
@@ -259,8 +259,12 @@ module('Integration | Component | transit key actions', function (hooks) {
       },
       'passes expected args to the adapter'
     );
-    assert.equal(this.storeService.callArgsOptions.wrapTTL, '30m', 'passes value for wrapTTL');
-    assert.equal(find('[data-test-encrypted-value="export"]').innerText, 'wrapped-token', 'wraps by default');
+    assert.strictEqual(this.storeService.callArgsOptions.wrapTTL, '30m', 'passes value for wrapTTL');
+    assert.strictEqual(
+      find('[data-test-encrypted-value="export"]').innerText,
+      'wrapped-token',
+      'wraps by default'
+    );
   });
 
   test('it can export a key:unwrapped behavior', async function (assert) {

--- a/ui/tests/integration/components/ttl-picker-test.js
+++ b/ui/tests/integration/components/ttl-picker-test.js
@@ -17,7 +17,7 @@ module('Integration | Component | ttl picker', function (hooks) {
 
     let callCount = this.changeSpy.callCount;
     await fillIn('[data-test-ttl-value]', 'foo');
-    assert.equal(this.changeSpy.callCount, callCount, "it didn't call onChange again");
+    assert.strictEqual(this.changeSpy.callCount, callCount, "it didn't call onChange again");
     assert.dom('[data-test-ttl-error]').includesText('Error', 'renders the error box');
     await fillIn('[data-test-ttl-value]', '33');
     assert.dom('[data-test-ttl-error]').doesNotExist('removes the error box');

--- a/ui/tests/integration/components/wrap-ttl-test.js
+++ b/ui/tests/integration/components/wrap-ttl-test.js
@@ -23,22 +23,22 @@ module('Integration | Component | wrap ttl', function (hooks) {
 
   test('it renders', async function (assert) {
     await render(hbs`{{wrap-ttl onChange=(action onChange)}}`);
-    assert.equal(this.lastOnChangeCall, '30m', 'calls onChange with 30m default on first render');
+    assert.strictEqual(this.lastOnChangeCall, '30m', 'calls onChange with 30m default on first render');
     assert.dom('label[for="toggle-Wrapresponse"] .ttl-picker-label').hasText('Wrap response');
   });
 
   test('it nulls out value when you uncheck wrapResponse', async function (assert) {
     await render(hbs`{{wrap-ttl onChange=(action onChange)}}`);
     await click('[data-test-toggle-label="Wrap response"]');
-    assert.equal(this.lastOnChangeCall, null, 'calls onChange with null');
+    assert.strictEqual(this.lastOnChangeCall, null, 'calls onChange with null');
   });
 
   test('it sends value changes to onChange handler', async function (assert) {
     await render(hbs`{{wrap-ttl onChange=(action onChange)}}`);
     // for testing purposes we need to input unit first because it keeps seconds value
     await fillIn('[data-test-select="ttl-unit"]', 'h');
-    assert.equal(this.lastOnChangeCall, '1800s', 'calls onChange correctly on time input');
+    assert.strictEqual(this.lastOnChangeCall, '1800s', 'calls onChange correctly on time input');
     await fillIn('[data-test-ttl-value="Wrap response"]', '20');
-    assert.equal(this.lastOnChangeCall, '72000s', 'calls onChange correctly on unit change');
+    assert.strictEqual(this.lastOnChangeCall, '72000s', 'calls onChange correctly on unit change');
   });
 });

--- a/ui/tests/integration/helpers/add-to-array-test.js
+++ b/ui/tests/integration/helpers/add-to-array-test.js
@@ -19,7 +19,7 @@ module('Integration | Helper | add-to-array', function (hooks) {
     } catch (e) {
       result = e.message;
     }
-    assert.equal(result, 'Assertion Failed: Value provided is not an array');
+    assert.strictEqual(result, 'Assertion Failed: Value provided is not an array');
   });
 
   test('it works with non-string arrays', function (assert) {

--- a/ui/tests/integration/helpers/changelog-url-for-test.js
+++ b/ui/tests/integration/helpers/changelog-url-for-test.js
@@ -9,21 +9,21 @@ module('Integration | Helper | changelog-url-for', function (hooks) {
 
   test('it builds an enterprise URL', function (assert) {
     const result = changelogUrlFor(['1.5.0+prem']);
-    assert.equal(result, CHANGELOG_URL.concat('150'));
+    assert.strictEqual(result, CHANGELOG_URL.concat('150'));
   });
 
   test('it builds an OSS URL', function (assert) {
     const result = changelogUrlFor(['1.4.3']);
-    assert.equal(result, CHANGELOG_URL.concat('143'));
+    assert.strictEqual(result, CHANGELOG_URL.concat('143'));
   });
 
   test('it returns the base changelog URL if the version is less than 1.4.3', function (assert) {
     const result = changelogUrlFor(['1.4.0']);
-    assert.equal(result, CHANGELOG_URL);
+    assert.strictEqual(result, CHANGELOG_URL);
   });
 
   test('it returns the base changelog URL if version cannot be found', function (assert) {
     const result = changelogUrlFor(['']);
-    assert.equal(result, CHANGELOG_URL);
+    assert.strictEqual(result, CHANGELOG_URL);
   });
 });

--- a/ui/tests/integration/helpers/remove-from-array-test.js
+++ b/ui/tests/integration/helpers/remove-from-array-test.js
@@ -25,7 +25,7 @@ module('Integration | Helper | remove-from-array', function (hooks) {
     } catch (e) {
       result = e.message;
     }
-    assert.equal(result, 'Assertion Failed: Value provided is not an array');
+    assert.strictEqual(result, 'Assertion Failed: Value provided is not an array');
   });
 
   test('it works with non-string arrays', function (assert) {

--- a/ui/tests/integration/services/auth-test.js
+++ b/ui/tests/integration/services/auth-test.js
@@ -184,14 +184,14 @@ module('Integration | Service | auth', function (hooks) {
         const authData = service.get('authData');
 
         const expectedTokenName = `${TOKEN_PREFIX}${ROOT_PREFIX}${TOKEN_SEPARATOR}1`;
-        assert.equal(clusterToken, 'test', 'token is saved properly');
-        assert.equal(
+        assert.strictEqual(clusterToken, 'test', 'token is saved properly');
+        assert.strictEqual(
           `${TOKEN_PREFIX}${ROOT_PREFIX}${TOKEN_SEPARATOR}1`,
           clusterTokenName,
           'token name is saved properly'
         );
-        assert.equal(authData.backend.type, 'token', 'backend is saved properly');
-        assert.equal(
+        assert.strictEqual(authData.backend.type, 'token', 'backend is saved properly');
+        assert.strictEqual(
           ROOT_TOKEN_RESPONSE.data.display_name,
           authData.displayName,
           'displayName is saved properly'
@@ -200,7 +200,7 @@ module('Integration | Service | auth', function (hooks) {
           this.memStore.keys().includes(expectedTokenName),
           'root token is stored in the memory store'
         );
-        assert.equal(this.store.keys().length, 0, 'normal storage is empty');
+        assert.strictEqual(this.store.keys().length, 0, 'normal storage is empty');
         done();
       });
     });
@@ -228,20 +228,20 @@ module('Integration | Service | auth', function (hooks) {
     const authData = service.get('authData');
 
     const expectedTokenName = `${TOKEN_PREFIX}${ROOT_PREFIX}${TOKEN_SEPARATOR}1`;
-    assert.equal(clusterToken, 'test', 'token is saved properly');
-    assert.equal(
+    assert.strictEqual(clusterToken, 'test', 'token is saved properly');
+    assert.strictEqual(
       `${TOKEN_PREFIX}${ROOT_PREFIX}${TOKEN_SEPARATOR}1`,
       clusterTokenName,
       'token name is saved properly'
     );
-    assert.equal(authData.backend.type, 'token', 'backend is saved properly');
-    assert.equal(
+    assert.strictEqual(authData.backend.type, 'token', 'backend is saved properly');
+    assert.strictEqual(
       ROOT_TOKEN_RESPONSE.data.display_name,
       authData.displayName,
       'displayName is saved properly'
     );
     assert.ok(this.store.keys().includes(expectedTokenName), 'root token is stored in the store');
-    assert.equal(this.memStore.keys().length, 0, 'mem storage is empty');
+    assert.strictEqual(this.memStore.keys().length, 0, 'mem storage is empty');
   });
 
   test('github authentication', function (assert) {
@@ -258,15 +258,15 @@ module('Integration | Service | auth', function (hooks) {
         const authData = service.get('authData');
         const expectedTokenName = `${TOKEN_PREFIX}github${TOKEN_SEPARATOR}1`;
 
-        assert.equal(GITHUB_RESPONSE.auth.client_token, clusterToken, 'token is saved properly');
-        assert.equal(expectedTokenName, clusterTokenName, 'token name is saved properly');
-        assert.equal(authData.backend.type, 'github', 'backend is saved properly');
-        assert.equal(
+        assert.strictEqual(GITHUB_RESPONSE.auth.client_token, clusterToken, 'token is saved properly');
+        assert.strictEqual(expectedTokenName, clusterTokenName, 'token name is saved properly');
+        assert.strictEqual(authData.backend.type, 'github', 'backend is saved properly');
+        assert.strictEqual(
           GITHUB_RESPONSE.auth.metadata.org + '/' + GITHUB_RESPONSE.auth.metadata.username,
           authData.displayName,
           'displayName is saved properly'
         );
-        assert.equal(this.memStore.keys().length, 0, 'mem storage is empty');
+        assert.strictEqual(this.memStore.keys().length, 0, 'mem storage is empty');
         assert.ok(this.store.keys().includes(expectedTokenName), 'normal storage contains the token');
         done();
       });
@@ -289,14 +289,14 @@ module('Integration | Service | auth', function (hooks) {
           const clusterToken = service.get('currentToken');
           const authData = service.get('authData');
 
-          assert.equal(USERPASS_RESPONSE.auth.client_token, clusterToken, 'token is saved properly');
-          assert.equal(
+          assert.strictEqual(USERPASS_RESPONSE.auth.client_token, clusterToken, 'token is saved properly');
+          assert.strictEqual(
             `${TOKEN_PREFIX}userpass${TOKEN_SEPARATOR}1`,
             clusterTokenName,
             'token name is saved properly'
           );
-          assert.equal(authData.backend.type, 'userpass', 'backend is saved properly');
-          assert.equal(
+          assert.strictEqual(authData.backend.type, 'userpass', 'backend is saved properly');
+          assert.strictEqual(
             USERPASS_RESPONSE.auth.metadata.username,
             authData.displayName,
             'displayName is saved properly'
@@ -326,14 +326,18 @@ module('Integration | Service | auth', function (hooks) {
         const clusterToken = service.get('currentToken');
         const authData = service.get('authData');
 
-        assert.equal(clusterToken, 'test', 'token is saved properly');
-        assert.equal(
+        assert.strictEqual(clusterToken, 'test', 'token is saved properly');
+        assert.strictEqual(
           `${TOKEN_PREFIX}token${TOKEN_SEPARATOR}1`,
           clusterTokenName,
           'token name is saved properly'
         );
-        assert.equal(authData.backend.type, 'token', 'backend is saved properly');
-        assert.equal(authData.displayName, tokenResp.data.display_name, 'displayName is saved properly');
+        assert.strictEqual(authData.backend.type, 'token', 'backend is saved properly');
+        assert.strictEqual(
+          authData.displayName,
+          tokenResp.data.display_name,
+          'displayName is saved properly'
+        );
         assert.false(service.get('tokenExpired'), 'token is not expired');
         done();
       });

--- a/ui/tests/integration/utils/client-count-utils-test.js
+++ b/ui/tests/integration/utils/client-count-utils-test.js
@@ -623,7 +623,7 @@ module('Integration | Util | client count utils', function (hooks) {
         : ['clients', 'distinct_entities', 'non_entity_tokens'];
 
       newObjectKeys.forEach((key, i) => {
-        assert.equal(
+        assert.strictEqual(
           object[key],
           originalObject.counts[originalKeys[i]],
           `${object.month} ${key} equal original counts`
@@ -678,7 +678,7 @@ module('Integration | Util | client count utils', function (hooks) {
         timestamp: '2021-07-01T00:00:00Z',
       },
     ];
-    assert.equal(formatByMonths(SOME_OBJECT), SOME_OBJECT, 'it returns if arg is not an array');
+    assert.strictEqual(formatByMonths(SOME_OBJECT), SOME_OBJECT, 'it returns if arg is not an array');
     assert.propEqual(expected, formatByMonths(EMPTY_MONTHS), 'it does not error with null months');
     assert.ok(formatByMonths([...EMPTY_MONTHS, ...MONTHS]), 'it does not error with combined data');
   });
@@ -698,10 +698,10 @@ module('Integration | Util | client count utils', function (hooks) {
     };
     const keyValueAssertions = (object, pathName, originalObject) => {
       const keysToAssert = ['clients', 'entity_clients', 'non_entity_clients'];
-      assert.equal(object.label, originalObject[pathName], `${pathName} matches label`);
+      assert.strictEqual(object.label, originalObject[pathName], `${pathName} matches label`);
 
       keysToAssert.forEach((key) => {
-        assert.equal(object[key], originalObject.counts[key], `number of ${key} equal original`);
+        assert.strictEqual(object[key], originalObject.counts[key], `number of ${key} equal original`);
       });
     };
 
@@ -736,9 +736,9 @@ module('Integration | Util | client count utils', function (hooks) {
     let formattedNsWithoutMounts = formatByNamespace([nsWithoutMounts])[0];
     keyNameAssertions(formattedNsWithoutMounts, 'namespace without mounts');
     keyValueAssertions(formattedNsWithoutMounts, 'namespace_path', nsWithoutMounts);
-    assert.equal(formattedNsWithoutMounts.mounts.length, 0, 'formatted namespace has no mounts');
+    assert.strictEqual(formattedNsWithoutMounts.mounts.length, 0, 'formatted namespace has no mounts');
 
-    assert.equal(formatByNamespace(SOME_OBJECT), SOME_OBJECT, 'it returns if arg is not an array');
+    assert.strictEqual(formatByNamespace(SOME_OBJECT), SOME_OBJECT, 'it returns if arg is not an array');
   });
 
   test('homogenizeClientNaming: homogenizes key names when both old and new keys exist, or just old key names', async function (assert) {
@@ -814,13 +814,13 @@ module('Integration | Util | client count utils', function (hooks) {
     keyNameAssertions(flattenedMonth, 'month object');
     keyNameAssertions(flattenedNewMonthClients, 'month new_clients object');
 
-    assert.equal(
+    assert.strictEqual(
       flattenDataset(SOME_OBJECT),
       SOME_OBJECT,
       "it returns original object if counts key doesn't exist"
     );
 
-    assert.equal(
+    assert.strictEqual(
       flattenDataset(objectNullCounts),
       objectNullCounts,
       'it returns original object if counts are null'
@@ -831,8 +831,8 @@ module('Integration | Util | client count utils', function (hooks) {
       flattenDataset(['some array']),
       'it fails gracefully if an array is passed in'
     );
-    assert.equal(flattenDataset(null), null, 'it fails gracefully if null is passed in');
-    assert.equal(
+    assert.strictEqual(flattenDataset(null), null, 'it fails gracefully if null is passed in');
+    assert.strictEqual(
       flattenDataset('some string'),
       'some string',
       'it fails gracefully if a string is passed in'
@@ -856,7 +856,7 @@ module('Integration | Util | client count utils', function (hooks) {
       'third timestamp date is later second'
     );
     assert.notEqual(sortedMonths[1], MONTHS[1], 'it does not modify original array');
-    assert.equal(sortedMonths[0], MONTHS[0], 'it does not modify original array');
+    assert.strictEqual(sortedMonths[0], MONTHS[0], 'it does not modify original array');
   });
 
   test('namespaceArrayToObject: transforms data without modifying original', async function (assert) {
@@ -866,7 +866,7 @@ module('Integration | Util | client count utils', function (hooks) {
       let valuesToCheck = ['clients', 'entity_clients', 'non_entity_clients'];
 
       valuesToCheck.forEach((key) => {
-        assert.equal(object[key], originalObject[key], `${key} equal original counts`);
+        assert.strictEqual(object[key], originalObject[key], `${key} equal original counts`);
       });
     };
     const totalClientsByNamespace = formatByNamespace(MONTHS[1].namespaces);

--- a/ui/tests/integration/utils/date-formatters-test.js
+++ b/ui/tests/integration/utils/date-formatters-test.js
@@ -17,7 +17,7 @@ module('Integration | Util | date formatters utils', function (hooks) {
 
   test('parseAPITimestamp: parses API timestamp string irrespective of timezone', async function (assert) {
     assert.expect(6);
-    assert.equal(parseAPITimestamp(UNIX_TIME), undefined, 'it returns if timestamp is not a string');
+    assert.strictEqual(parseAPITimestamp(UNIX_TIME), undefined, 'it returns if timestamp is not a string');
 
     let parsedTimestamp = parseAPITimestamp(API_TIMESTAMP);
 
@@ -27,18 +27,22 @@ module('Integration | Util | date formatters utils', function (hooks) {
     assert.true(isSameDay(parsedTimestamp, DATE), 'parsed timestamp is correct day');
 
     let formattedTimestamp = parseAPITimestamp(API_TIMESTAMP, 'MM yyyy');
-    assert.equal(formattedTimestamp, format(DATE, 'MM yyyy'), 'it formats the date');
+    assert.strictEqual(formattedTimestamp, format(DATE, 'MM yyyy'), 'it formats the date');
   });
 
   test('parseRFC3339: convert timestamp to array for widget', async function (assert) {
     assert.expect(4);
     let arrayArg = ['2021', 2];
-    assert.equal(parseRFC3339(arrayArg), arrayArg, 'it returns arg if already an array');
-    assert.equal(parseRFC3339(UNIX_TIME), null, 'it returns null parsing a timestamp of the wrong format');
+    assert.strictEqual(parseRFC3339(arrayArg), arrayArg, 'it returns arg if already an array');
+    assert.strictEqual(
+      parseRFC3339(UNIX_TIME),
+      null,
+      'it returns null parsing a timestamp of the wrong format'
+    );
 
     let parsedTimestamp = parseRFC3339(API_TIMESTAMP);
-    assert.equal(parsedTimestamp[0], format(DATE, 'yyyy'), 'first element is a string of the year');
-    assert.equal(
+    assert.strictEqual(parsedTimestamp[0], format(DATE, 'yyyy'), 'first element is a string of the year');
+    assert.strictEqual(
       ARRAY_OF_MONTHS[parsedTimestamp[1]],
       format(DATE, 'MMMM'),
       'second element is an integer of the month'
@@ -48,6 +52,6 @@ module('Integration | Util | date formatters utils', function (hooks) {
   test('formatChartDate: expand chart date to full month and year', async function (assert) {
     assert.expect(1);
     let chartDate = '03/21';
-    assert.equal(formatChartDate(chartDate), 'March 2021', 'it re-formats the date');
+    assert.strictEqual(formatChartDate(chartDate), 'March 2021', 'it re-formats the date');
   });
 });

--- a/ui/tests/unit/adapters/aws-credential-test.js
+++ b/ui/tests/unit/adapters/aws-credential-test.js
@@ -72,9 +72,13 @@ module('Unit | Adapter | aws credential', function (hooks) {
       let adapter = this.owner.lookup('adapter:aws-credential');
       adapter.createRecord(...args);
       let { method, url, requestBody } = this.server.handledRequests[0];
-      assert.equal(url, '/v1/aws/creds/foo', `calls the correct url`);
-      assert.equal(method, expectedMethod, `${description} uses the correct http verb: ${expectedMethod}`);
-      assert.equal(requestBody, JSON.stringify(expectedRequestBody));
+      assert.strictEqual(url, '/v1/aws/creds/foo', `calls the correct url`);
+      assert.strictEqual(
+        method,
+        expectedMethod,
+        `${description} uses the correct http verb: ${expectedMethod}`
+      );
+      assert.strictEqual(requestBody, JSON.stringify(expectedRequestBody));
     });
   });
 });

--- a/ui/tests/unit/adapters/capabilities-test.js
+++ b/ui/tests/unit/adapters/capabilities-test.js
@@ -15,8 +15,8 @@ module('Unit | Adapter | capabilities', function (hooks) {
     });
 
     adapter.findRecord(null, 'capabilities', 'foo');
-    assert.equal(url, '/v1/sys/capabilities-self', 'calls the correct URL');
+    assert.strictEqual(url, '/v1/sys/capabilities-self', 'calls the correct URL');
     assert.deepEqual({ paths: ['foo'] }, options.data, 'data params OK');
-    assert.equal(method, 'POST', 'method OK');
+    assert.strictEqual(method, 'POST', 'method OK');
   });
 });

--- a/ui/tests/unit/adapters/cluster-test.js
+++ b/ui/tests/unit/adapters/cluster-test.js
@@ -14,7 +14,7 @@ module('Unit | Adapter | cluster', function (hooks) {
       },
     });
     adapter.health();
-    assert.equal(url, '/v1/sys/health', 'health url OK');
+    assert.strictEqual(url, '/v1/sys/health', 'health url OK');
     assert.deepEqual(
       {
         standbycode: 200,
@@ -26,28 +26,28 @@ module('Unit | Adapter | cluster', function (hooks) {
       options.data,
       'health data params OK'
     );
-    assert.equal(method, 'GET', 'health method OK');
+    assert.strictEqual(method, 'GET', 'health method OK');
 
     adapter.sealStatus();
-    assert.equal(url, '/v1/sys/seal-status', 'health url OK');
-    assert.equal(method, 'GET', 'seal-status method OK');
+    assert.strictEqual(url, '/v1/sys/seal-status', 'health url OK');
+    assert.strictEqual(method, 'GET', 'seal-status method OK');
 
     let data = { someData: 1 };
     adapter.unseal(data);
-    assert.equal(url, '/v1/sys/unseal', 'unseal url OK');
-    assert.equal(method, 'PUT', 'unseal method OK');
+    assert.strictEqual(url, '/v1/sys/unseal', 'unseal url OK');
+    assert.strictEqual(method, 'PUT', 'unseal method OK');
     assert.deepEqual({ data, unauthenticated: true }, options, 'unseal options OK');
 
     adapter.initCluster(data);
-    assert.equal(url, '/v1/sys/init', 'init url OK');
-    assert.equal(method, 'PUT', 'init method OK');
+    assert.strictEqual(url, '/v1/sys/init', 'init url OK');
+    assert.strictEqual(method, 'PUT', 'init method OK');
     assert.deepEqual({ data, unauthenticated: true }, options, 'init options OK');
 
     data = { token: 'token', password: 'password', username: 'username' };
 
     adapter.authenticate({ backend: 'token', data });
-    assert.equal(url, '/v1/auth/token/lookup-self', 'auth:token url OK');
-    assert.equal(method, 'GET', 'auth:token method OK');
+    assert.strictEqual(url, '/v1/auth/token/lookup-self', 'auth:token url OK');
+    assert.strictEqual(method, 'GET', 'auth:token method OK');
     assert.deepEqual(
       { headers: { 'X-Vault-Token': 'token' }, unauthenticated: true },
       options,
@@ -55,8 +55,8 @@ module('Unit | Adapter | cluster', function (hooks) {
     );
 
     adapter.authenticate({ backend: 'github', data });
-    assert.equal(url, '/v1/auth/github/login', 'auth:github url OK');
-    assert.equal(method, 'POST', 'auth:github method OK');
+    assert.strictEqual(url, '/v1/auth/github/login', 'auth:github url OK');
+    assert.strictEqual(method, 'POST', 'auth:github method OK');
     assert.deepEqual(
       { data: { password: 'password', token: 'token' }, unauthenticated: true },
       options,
@@ -65,8 +65,8 @@ module('Unit | Adapter | cluster', function (hooks) {
 
     data = { jwt: 'token', role: 'test' };
     adapter.authenticate({ backend: 'jwt', data });
-    assert.equal(url, '/v1/auth/jwt/login', 'auth:jwt url OK');
-    assert.equal(method, 'POST', 'auth:jwt method OK');
+    assert.strictEqual(url, '/v1/auth/jwt/login', 'auth:jwt url OK');
+    assert.strictEqual(method, 'POST', 'auth:jwt method OK');
     assert.deepEqual(
       { data: { jwt: 'token', role: 'test' }, unauthenticated: true },
       options,
@@ -75,21 +75,21 @@ module('Unit | Adapter | cluster', function (hooks) {
 
     data = { jwt: 'token', role: 'test', path: 'oidc' };
     adapter.authenticate({ backend: 'jwt', data });
-    assert.equal(url, '/v1/auth/oidc/login', 'auth:jwt custom mount path, url OK');
+    assert.strictEqual(url, '/v1/auth/oidc/login', 'auth:jwt custom mount path, url OK');
 
     data = { token: 'token', password: 'password', username: 'username', path: 'path' };
 
     adapter.authenticate({ backend: 'token', data });
-    assert.equal(url, '/v1/auth/token/lookup-self', 'auth:token url with path OK');
+    assert.strictEqual(url, '/v1/auth/token/lookup-self', 'auth:token url with path OK');
 
     adapter.authenticate({ backend: 'github', data });
-    assert.equal(url, '/v1/auth/path/login', 'auth:github with path url OK');
+    assert.strictEqual(url, '/v1/auth/path/login', 'auth:github with path url OK');
 
     data = { password: 'password', username: 'username' };
 
     adapter.authenticate({ backend: 'userpass', data });
-    assert.equal(url, '/v1/auth/userpass/login/username', 'auth:userpass url OK');
-    assert.equal(method, 'POST', 'auth:userpass method OK');
+    assert.strictEqual(url, '/v1/auth/userpass/login/username', 'auth:userpass url OK');
+    assert.strictEqual(method, 'POST', 'auth:userpass method OK');
     assert.deepEqual(
       { data: { password: 'password' }, unauthenticated: true },
       options,
@@ -97,8 +97,8 @@ module('Unit | Adapter | cluster', function (hooks) {
     );
 
     adapter.authenticate({ backend: 'radius', data });
-    assert.equal(url, '/v1/auth/radius/login/username', 'auth:RADIUS url OK');
-    assert.equal(method, 'POST', 'auth:RADIUS method OK');
+    assert.strictEqual(url, '/v1/auth/radius/login/username', 'auth:RADIUS url OK');
+    assert.strictEqual(method, 'POST', 'auth:RADIUS method OK');
     assert.deepEqual(
       { data: { password: 'password' }, unauthenticated: true },
       options,
@@ -106,8 +106,8 @@ module('Unit | Adapter | cluster', function (hooks) {
     );
 
     adapter.authenticate({ backend: 'LDAP', data });
-    assert.equal(url, '/v1/auth/ldap/login/username', 'ldap:userpass url OK');
-    assert.equal(method, 'POST', 'ldap:userpass method OK');
+    assert.strictEqual(url, '/v1/auth/ldap/login/username', 'ldap:userpass url OK');
+    assert.strictEqual(method, 'POST', 'ldap:userpass method OK');
     assert.deepEqual(
       { data: { password: 'password' }, unauthenticated: true },
       options,
@@ -116,8 +116,8 @@ module('Unit | Adapter | cluster', function (hooks) {
 
     data = { password: 'password', username: 'username', nonce: 'uuid' };
     adapter.authenticate({ backend: 'okta', data });
-    assert.equal(url, '/v1/auth/okta/login/username', 'okta:userpass url OK');
-    assert.equal(method, 'POST', 'ldap:userpass method OK');
+    assert.strictEqual(url, '/v1/auth/okta/login/username', 'okta:userpass url OK');
+    assert.strictEqual(method, 'POST', 'ldap:userpass method OK');
     assert.deepEqual(
       { data: { password: 'password', nonce: 'uuid' }, unauthenticated: true },
       options,
@@ -128,14 +128,14 @@ module('Unit | Adapter | cluster', function (hooks) {
     data = { password: 'password', username: 'username', path: 'path' };
 
     adapter.authenticate({ backend: 'userpass', data });
-    assert.equal(url, '/v1/auth/path/login/username', 'auth:userpass with path url OK');
+    assert.strictEqual(url, '/v1/auth/path/login/username', 'auth:userpass with path url OK');
 
     adapter.authenticate({ backend: 'LDAP', data });
-    assert.equal(url, '/v1/auth/path/login/username', 'auth:LDAP with path url OK');
+    assert.strictEqual(url, '/v1/auth/path/login/username', 'auth:LDAP with path url OK');
 
     data = { password: 'password', username: 'username', path: 'path', nonce: 'uuid' };
     adapter.authenticate({ backend: 'Okta', data });
-    assert.equal(url, '/v1/auth/path/login/username', 'auth:Okta with path url OK');
+    assert.strictEqual(url, '/v1/auth/path/login/username', 'auth:Okta with path url OK');
   });
 
   test('cluster replication api urls', function (assert) {
@@ -148,81 +148,101 @@ module('Unit | Adapter | cluster', function (hooks) {
     });
 
     adapter.replicationStatus();
-    assert.equal(url, '/v1/sys/replication/status', 'replication:status url OK');
-    assert.equal(method, 'GET', 'replication:status method OK');
+    assert.strictEqual(url, '/v1/sys/replication/status', 'replication:status url OK');
+    assert.strictEqual(method, 'GET', 'replication:status method OK');
     assert.deepEqual({ unauthenticated: true }, options, 'replication:status options OK');
 
     adapter.replicationAction('recover', 'dr');
-    assert.equal(url, '/v1/sys/replication/recover', 'replication: recover url OK');
-    assert.equal(method, 'POST', 'replication:recover method OK');
+    assert.strictEqual(url, '/v1/sys/replication/recover', 'replication: recover url OK');
+    assert.strictEqual(method, 'POST', 'replication:recover method OK');
 
     adapter.replicationAction('reindex', 'dr');
-    assert.equal(url, '/v1/sys/replication/reindex', 'replication: reindex url OK');
-    assert.equal(method, 'POST', 'replication:reindex method OK');
+    assert.strictEqual(url, '/v1/sys/replication/reindex', 'replication: reindex url OK');
+    assert.strictEqual(method, 'POST', 'replication:reindex method OK');
 
     adapter.replicationAction('enable', 'dr', 'primary');
-    assert.equal(url, '/v1/sys/replication/dr/primary/enable', 'replication:dr primary:enable url OK');
-    assert.equal(method, 'POST', 'replication:primary:enable method OK');
+    assert.strictEqual(url, '/v1/sys/replication/dr/primary/enable', 'replication:dr primary:enable url OK');
+    assert.strictEqual(method, 'POST', 'replication:primary:enable method OK');
     adapter.replicationAction('enable', 'performance', 'primary');
-    assert.equal(
+    assert.strictEqual(
       url,
       '/v1/sys/replication/performance/primary/enable',
       'replication:performance primary:enable url OK'
     );
 
     adapter.replicationAction('enable', 'dr', 'secondary');
-    assert.equal(url, '/v1/sys/replication/dr/secondary/enable', 'replication:dr secondary:enable url OK');
-    assert.equal(method, 'POST', 'replication:secondary:enable method OK');
+    assert.strictEqual(
+      url,
+      '/v1/sys/replication/dr/secondary/enable',
+      'replication:dr secondary:enable url OK'
+    );
+    assert.strictEqual(method, 'POST', 'replication:secondary:enable method OK');
     adapter.replicationAction('enable', 'performance', 'secondary');
-    assert.equal(
+    assert.strictEqual(
       url,
       '/v1/sys/replication/performance/secondary/enable',
       'replication:performance secondary:enable url OK'
     );
 
     adapter.replicationAction('disable', 'dr', 'primary');
-    assert.equal(url, '/v1/sys/replication/dr/primary/disable', 'replication:dr primary:disable url OK');
-    assert.equal(method, 'POST', 'replication:primary:disable method OK');
+    assert.strictEqual(
+      url,
+      '/v1/sys/replication/dr/primary/disable',
+      'replication:dr primary:disable url OK'
+    );
+    assert.strictEqual(method, 'POST', 'replication:primary:disable method OK');
     adapter.replicationAction('disable', 'performance', 'primary');
-    assert.equal(
+    assert.strictEqual(
       url,
       '/v1/sys/replication/performance/primary/disable',
       'replication:performance primary:disable url OK'
     );
 
     adapter.replicationAction('disable', 'dr', 'secondary');
-    assert.equal(url, '/v1/sys/replication/dr/secondary/disable', 'replication: drsecondary:disable url OK');
-    assert.equal(method, 'POST', 'replication:secondary:disable method OK');
+    assert.strictEqual(
+      url,
+      '/v1/sys/replication/dr/secondary/disable',
+      'replication: drsecondary:disable url OK'
+    );
+    assert.strictEqual(method, 'POST', 'replication:secondary:disable method OK');
     adapter.replicationAction('disable', 'performance', 'secondary');
-    assert.equal(
+    assert.strictEqual(
       url,
       '/v1/sys/replication/performance/secondary/disable',
       'replication: performance:disable url OK'
     );
 
     adapter.replicationAction('demote', 'dr', 'primary');
-    assert.equal(url, '/v1/sys/replication/dr/primary/demote', 'replication: dr primary:demote url OK');
-    assert.equal(method, 'POST', 'replication:primary:demote method OK');
+    assert.strictEqual(url, '/v1/sys/replication/dr/primary/demote', 'replication: dr primary:demote url OK');
+    assert.strictEqual(method, 'POST', 'replication:primary:demote method OK');
     adapter.replicationAction('demote', 'performance', 'primary');
-    assert.equal(
+    assert.strictEqual(
       url,
       '/v1/sys/replication/performance/primary/demote',
       'replication: performance primary:demote url OK'
     );
 
     adapter.replicationAction('promote', 'performance', 'secondary');
-    assert.equal(method, 'POST', 'replication:secondary:promote method OK');
-    assert.equal(
+    assert.strictEqual(method, 'POST', 'replication:secondary:promote method OK');
+    assert.strictEqual(
       url,
       '/v1/sys/replication/performance/secondary/promote',
       'replication:performance secondary:promote url OK'
     );
 
     adapter.replicationDrPromote();
-    assert.equal(url, '/v1/sys/replication/dr/secondary/promote', 'replication:dr secondary:promote url OK');
-    assert.equal(method, 'PUT', 'replication:dr secondary:promote method OK');
+    assert.strictEqual(
+      url,
+      '/v1/sys/replication/dr/secondary/promote',
+      'replication:dr secondary:promote url OK'
+    );
+    assert.strictEqual(method, 'PUT', 'replication:dr secondary:promote method OK');
     adapter.replicationDrPromote({}, { checkStatus: true });
-    assert.equal(url, '/v1/sys/replication/dr/secondary/promote', 'replication:dr secondary:promote url OK');
-    assert.equal(method, 'GET', 'replication:dr secondary:promote method OK');
+    assert.strictEqual(
+      url,
+      '/v1/sys/replication/dr/secondary/promote',
+      'replication:dr secondary:promote url OK'
+    );
+    assert.strictEqual(method, 'GET', 'replication:dr secondary:promote method OK');
   });
 });

--- a/ui/tests/unit/adapters/console-test.js
+++ b/ui/tests/unit/adapters/console-test.js
@@ -8,7 +8,7 @@ module('Unit | Adapter | console', function (hooks) {
     let adapter = this.owner.lookup('adapter:console');
     let sysPath = 'sys/health';
     let awsPath = 'aws/roles/my-other-role';
-    assert.equal(adapter.buildURL(sysPath), '/v1/sys/health');
-    assert.equal(adapter.buildURL(awsPath), '/v1/aws/roles/my-other-role');
+    assert.strictEqual(adapter.buildURL(sysPath), '/v1/sys/health');
+    assert.strictEqual(adapter.buildURL(awsPath), '/v1/aws/roles/my-other-role');
   });
 });

--- a/ui/tests/unit/adapters/identity/entity-alias-test.js
+++ b/ui/tests/unit/adapters/identity/entity-alias-test.js
@@ -22,8 +22,12 @@ module('Unit | Adapter | identity/entity-alias', function (hooks) {
       let adapter = this.owner.lookup('adapter:identity/entity-alias');
       adapter[testCase.adapterMethod](...testCase.args);
       let { url, method } = this.server.handledRequests[0];
-      assert.equal(url, testCase.url, `${testCase.adapterMethod} calls the correct url: ${testCase.url}`);
-      assert.equal(
+      assert.strictEqual(
+        url,
+        testCase.url,
+        `${testCase.adapterMethod} calls the correct url: ${testCase.url}`
+      );
+      assert.strictEqual(
         method,
         testCase.method,
         `${testCase.adapterMethod} uses the correct http verb: ${testCase.method}`

--- a/ui/tests/unit/adapters/identity/entity-merge-test.js
+++ b/ui/tests/unit/adapters/identity/entity-merge-test.js
@@ -23,7 +23,7 @@ module('Unit | Adapter | identity/entity-merge', function (hooks) {
     let adapter = this.owner.lookup('adapter:identity/entity-merge');
     adapter.createRecord(storeMVP, { modelName: 'identity/entity-merge' }, { attr: (x) => x });
     let { url, method } = this.server.handledRequests[0];
-    assert.equal(url, `/v1/identity/entity/merge`, ` calls the correct url`);
-    assert.equal(method, 'POST', `uses the correct http verb: POST`);
+    assert.strictEqual(url, `/v1/identity/entity/merge`, ` calls the correct url`);
+    assert.strictEqual(method, 'POST', `uses the correct http verb: POST`);
   });
 });

--- a/ui/tests/unit/adapters/identity/entity-test.js
+++ b/ui/tests/unit/adapters/identity/entity-test.js
@@ -22,8 +22,12 @@ module('Unit | Adapter | identity/entity', function (hooks) {
       let adapter = this.owner.lookup('adapter:identity/entity');
       adapter[testCase.adapterMethod](...testCase.args);
       let { url, method } = this.server.handledRequests[0];
-      assert.equal(url, testCase.url, `${testCase.adapterMethod} calls the correct url: ${testCase.url}`);
-      assert.equal(
+      assert.strictEqual(
+        url,
+        testCase.url,
+        `${testCase.adapterMethod} calls the correct url: ${testCase.url}`
+      );
+      assert.strictEqual(
         method,
         testCase.method,
         `${testCase.adapterMethod} uses the correct http verb: ${testCase.method}`

--- a/ui/tests/unit/adapters/identity/group-alias-test.js
+++ b/ui/tests/unit/adapters/identity/group-alias-test.js
@@ -22,8 +22,12 @@ module('Unit | Adapter | identity/group-alias', function (hooks) {
       let adapter = this.owner.lookup('adapter:identity/group-alias');
       adapter[testCase.adapterMethod](...testCase.args);
       let { url, method } = this.server.handledRequests[0];
-      assert.equal(url, testCase.url, `${testCase.adapterMethod} calls the correct url: ${testCase.url}`);
-      assert.equal(
+      assert.strictEqual(
+        url,
+        testCase.url,
+        `${testCase.adapterMethod} calls the correct url: ${testCase.url}`
+      );
+      assert.strictEqual(
         method,
         testCase.method,
         `${testCase.adapterMethod} uses the correct http verb: ${testCase.method}`

--- a/ui/tests/unit/adapters/identity/group-test.js
+++ b/ui/tests/unit/adapters/identity/group-test.js
@@ -22,8 +22,12 @@ module('Unit | Adapter | identity/group', function (hooks) {
       let adapter = this.owner.lookup('adapter:identity/group');
       adapter[testCase.adapterMethod](...testCase.args);
       let { url, method } = this.server.handledRequests[0];
-      assert.equal(url, testCase.url, `${testCase.adapterMethod} calls the correct url: ${testCase.url}`);
-      assert.equal(
+      assert.strictEqual(
+        url,
+        testCase.url,
+        `${testCase.adapterMethod} calls the correct url: ${testCase.url}`
+      );
+      assert.strictEqual(
         method,
         testCase.method,
         `${testCase.adapterMethod} uses the correct http verb: ${testCase.method}`

--- a/ui/tests/unit/adapters/oidc/key-test.js
+++ b/ui/tests/unit/adapters/oidc/key-test.js
@@ -25,7 +25,7 @@ module('Unit | Adapter | oidc/key', function (hooks) {
 
     this.server.post(`${this.path}/rotate`, (schema, req) => {
       const json = JSON.parse(req.requestBody);
-      assert.equal(json.verification_ttl, '30m', 'request made to correct endpoint on rotate');
+      assert.strictEqual(json.verification_ttl, '30m', 'request made to correct endpoint on rotate');
     });
 
     await this.store.adapterFor('oidc/key').rotate(this.data.name, '30m');

--- a/ui/tests/unit/adapters/oidc/test-helper.js
+++ b/ui/tests/unit/adapters/oidc/test-helper.js
@@ -35,7 +35,7 @@ export default (test) => {
     const key_info = { [name]: { ...otherAttrs } };
 
     this.server.get(`/identity/${this.modelName}`, (schema, req) => {
-      assert.equal(req.queryParams.list, 'true', 'request is made to correct endpoint on query');
+      assert.strictEqual(req.queryParams.list, 'true', 'request is made to correct endpoint on query');
       if (keyInfoModels.some((model) => this.modelName.includes(model))) {
         return { data: { keys: [name], key_info } };
       } else {
@@ -83,23 +83,27 @@ export default (test) => {
       let testQuery = ['*', 'a123'];
       await this.store
         .query(this.modelName, { paramKey: 'model_id', filterFor: testQuery })
-        .then((resp) => assert.equal(resp.content.length, 3, 'returns all models when ids include glob (*)'));
+        .then((resp) =>
+          assert.strictEqual(resp.content.length, 3, 'returns all models when ids include glob (*)')
+        );
 
       testQuery = ['*'];
       await this.store
         .query(this.modelName, { paramKey: 'model_id', filterFor: testQuery })
-        .then((resp) => assert.equal(resp.content.length, 3, 'returns all models when glob (*) is only id'));
+        .then((resp) =>
+          assert.strictEqual(resp.content.length, 3, 'returns all models when glob (*) is only id')
+        );
 
       testQuery = ['b123'];
       await this.store.query(this.modelName, { paramKey: 'model_id', filterFor: testQuery }).then((resp) => {
-        assert.equal(resp.content.length, 1, 'filters response and returns only matching id');
+        assert.strictEqual(resp.content.length, 1, 'filters response and returns only matching id');
 
-        assert.equal(resp.firstObject.name, 'model-2', 'response contains correct model');
+        assert.strictEqual(resp.firstObject.name, 'model-2', 'response contains correct model');
       });
 
       testQuery = ['b123', 'c123'];
       await this.store.query(this.modelName, { paramKey: 'model_id', filterFor: testQuery }).then((resp) => {
-        assert.equal(resp.content.length, 2, 'filters response when passed multiple ids');
+        assert.strictEqual(resp.content.length, 2, 'filters response when passed multiple ids');
         resp.content.forEach((m) =>
           assert.ok(['model-2', 'model-3'].includes(m.id), `it filters correctly and included: ${m.id}`)
         );

--- a/ui/tests/unit/adapters/secret-engine-test.js
+++ b/ui/tests/unit/adapters/secret-engine-test.js
@@ -54,8 +54,12 @@ module('Unit | Adapter | secret engine', function (hooks) {
       let adapter = this.owner.lookup('adapter:secret-engine');
       adapter[testCase.adapterMethod](...testCase.args);
       let { url, method } = this.server.handledRequests[0];
-      assert.equal(url, testCase.url, `${testCase.adapterMethod} calls the correct url: ${testCase.url}`);
-      assert.equal(
+      assert.strictEqual(
+        url,
+        testCase.url,
+        `${testCase.adapterMethod} calls the correct url: ${testCase.url}`
+      );
+      assert.strictEqual(
         method,
         testCase.method,
         `${testCase.adapterMethod} uses the correct http verb: ${testCase.method}`

--- a/ui/tests/unit/adapters/secret-test.js
+++ b/ui/tests/unit/adapters/secret-test.js
@@ -15,12 +15,12 @@ module('Unit | Adapter | secret', function (hooks) {
     });
 
     adapter.query({}, 'secret', { id: '', backend: 'secret' });
-    assert.equal(url, '/v1/secret/', 'query generic url OK');
-    assert.equal(method, 'GET', 'query generic method OK');
+    assert.strictEqual(url, '/v1/secret/', 'query generic url OK');
+    assert.strictEqual(method, 'GET', 'query generic method OK');
     assert.deepEqual(options, { data: { list: true } }, 'query generic url OK');
 
     adapter.queryRecord({}, 'secret', { id: 'foo', backend: 'secret' });
-    assert.equal(url, '/v1/secret/foo', 'queryRecord generic url OK');
-    assert.equal(method, 'GET', 'queryRecord generic method OK');
+    assert.strictEqual(url, '/v1/secret/foo', 'queryRecord generic url OK');
+    assert.strictEqual(method, 'GET', 'queryRecord generic method OK');
   });
 });

--- a/ui/tests/unit/adapters/secret-v2-test.js
+++ b/ui/tests/unit/adapters/secret-v2-test.js
@@ -59,8 +59,8 @@ module('Unit | Adapter | secret-v2', function (hooks) {
       let adapter = this.owner.lookup('adapter:secret-v2');
       adapter[adapterMethod](store, type, queryOrSnapshot);
       let { url, method } = this.server.handledRequests[0];
-      assert.equal(url, expectedURL, `${adapterMethod} calls the correct url: ${expectedURL}`);
-      assert.equal(
+      assert.strictEqual(url, expectedURL, `${adapterMethod} calls the correct url: ${expectedURL}`);
+      assert.strictEqual(
         method,
         expectedHttpVerb,
         `${adapterMethod} uses the correct http verb: ${expectedHttpVerb}`

--- a/ui/tests/unit/adapters/secret-v2-version-test.js
+++ b/ui/tests/unit/adapters/secret-v2-version-test.js
@@ -83,8 +83,8 @@ module('Unit | Adapter | secret-v2-version', function (hooks) {
         let adapter = this.owner.lookup('adapter:secret-v2-version');
         adapter[adapterMethod](...args);
         let { url, method, requestBody } = this.server.handledRequests[0];
-        assert.equal(url, expectedURL, `${adapterMethod} calls the correct url: ${expectedURL}`);
-        assert.equal(
+        assert.strictEqual(url, expectedURL, `${adapterMethod} calls the correct url: ${expectedURL}`);
+        assert.strictEqual(
           method,
           expectedHttpVerb,
           `${adapterMethod} uses the correct http verb: ${expectedHttpVerb}`

--- a/ui/tests/unit/adapters/tools-test.js
+++ b/ui/tests/unit/adapters/tools-test.js
@@ -17,24 +17,24 @@ module('Unit | Adapter | tools', function (hooks) {
     let clientToken;
     let data = { foo: 'bar' };
     adapter.toolAction('wrap', data, { wrapTTL: '30m' });
-    assert.equal(url, '/v1/sys/wrapping/wrap', 'wrapping:wrap url OK');
-    assert.equal(method, 'POST', 'wrapping:wrap method OK');
+    assert.strictEqual(url, '/v1/sys/wrapping/wrap', 'wrapping:wrap url OK');
+    assert.strictEqual(method, 'POST', 'wrapping:wrap method OK');
     assert.deepEqual({ data: data, wrapTTL: '30m', clientToken }, options, 'wrapping:wrap options OK');
 
     data = { token: 'token' };
     adapter.toolAction('lookup', data);
-    assert.equal(url, '/v1/sys/wrapping/lookup', 'wrapping:lookup url OK');
-    assert.equal(method, 'POST', 'wrapping:lookup method OK');
+    assert.strictEqual(url, '/v1/sys/wrapping/lookup', 'wrapping:lookup url OK');
+    assert.strictEqual(method, 'POST', 'wrapping:lookup method OK');
     assert.deepEqual({ data, clientToken }, options, 'wrapping:lookup options OK');
 
     adapter.toolAction('unwrap', data);
-    assert.equal(url, '/v1/sys/wrapping/unwrap', 'wrapping:unwrap url OK');
-    assert.equal(method, 'POST', 'wrapping:unwrap method OK');
+    assert.strictEqual(url, '/v1/sys/wrapping/unwrap', 'wrapping:unwrap url OK');
+    assert.strictEqual(method, 'POST', 'wrapping:unwrap method OK');
     assert.deepEqual({ data, clientToken }, options, 'wrapping:unwrap options OK');
 
     adapter.toolAction('rewrap', data);
-    assert.equal(url, '/v1/sys/wrapping/rewrap', 'wrapping:rewrap url OK');
-    assert.equal(method, 'POST', 'wrapping:rewrap method OK');
+    assert.strictEqual(url, '/v1/sys/wrapping/rewrap', 'wrapping:rewrap url OK');
+    assert.strictEqual(method, 'POST', 'wrapping:rewrap method OK');
     assert.deepEqual({ data, clientToken }, options, 'wrapping:rewrap options OK');
   });
 
@@ -48,11 +48,11 @@ module('Unit | Adapter | tools', function (hooks) {
     });
 
     adapter.toolAction('hash', { input: 'someBase64' });
-    assert.equal(url, '/v1/sys/tools/hash', 'sys tools hash: url OK');
-    assert.equal(method, 'POST', 'sys tools hash: method OK');
+    assert.strictEqual(url, '/v1/sys/tools/hash', 'sys tools hash: url OK');
+    assert.strictEqual(method, 'POST', 'sys tools hash: method OK');
 
     adapter.toolAction('random', { bytes: '32' });
-    assert.equal(url, '/v1/sys/tools/random', 'sys tools random: url OK');
-    assert.equal(method, 'POST', 'sys tools random: method OK');
+    assert.strictEqual(url, '/v1/sys/tools/random', 'sys tools random: url OK');
+    assert.strictEqual(method, 'POST', 'sys tools random: method OK');
   });
 });

--- a/ui/tests/unit/adapters/transit-key-test.js
+++ b/ui/tests/unit/adapters/transit-key-test.js
@@ -15,27 +15,31 @@ module('Unit | Adapter | transit key', function (hooks) {
     });
 
     adapter.query({}, 'transit-key', { id: '', backend: 'transit' });
-    assert.equal(url, '/v1/transit/keys/', 'query list url OK');
-    assert.equal(method, 'GET', 'query list method OK');
+    assert.strictEqual(url, '/v1/transit/keys/', 'query list url OK');
+    assert.strictEqual(method, 'GET', 'query list method OK');
     assert.deepEqual(options, { data: { list: true } }, 'query generic url OK');
 
     adapter.queryRecord({}, 'transit-key', { id: 'foo', backend: 'transit' });
-    assert.equal(url, '/v1/transit/keys/foo', 'queryRecord generic url OK');
-    assert.equal(method, 'GET', 'queryRecord generic method OK');
+    assert.strictEqual(url, '/v1/transit/keys/foo', 'queryRecord generic url OK');
+    assert.strictEqual(method, 'GET', 'queryRecord generic method OK');
 
     adapter.keyAction('rotate', { backend: 'transit', id: 'foo', payload: {} });
-    assert.equal(url, '/v1/transit/keys/foo/rotate', 'keyAction:rotate url OK');
+    assert.strictEqual(url, '/v1/transit/keys/foo/rotate', 'keyAction:rotate url OK');
 
     adapter.keyAction('encrypt', { backend: 'transit', id: 'foo', payload: {} });
-    assert.equal(url, '/v1/transit/encrypt/foo', 'keyAction:encrypt url OK');
+    assert.strictEqual(url, '/v1/transit/encrypt/foo', 'keyAction:encrypt url OK');
 
     adapter.keyAction('datakey', { backend: 'transit', id: 'foo', payload: { param: 'plaintext' } });
-    assert.equal(url, '/v1/transit/datakey/plaintext/foo', 'keyAction:datakey url OK');
+    assert.strictEqual(url, '/v1/transit/datakey/plaintext/foo', 'keyAction:datakey url OK');
 
     adapter.keyAction('export', { backend: 'transit', id: 'foo', payload: { param: ['hmac'] } });
-    assert.equal(url, '/v1/transit/export/hmac-key/foo', 'transitAction:export, no version url OK');
+    assert.strictEqual(url, '/v1/transit/export/hmac-key/foo', 'transitAction:export, no version url OK');
 
     adapter.keyAction('export', { backend: 'transit', id: 'foo', payload: { param: ['hmac', 10] } });
-    assert.equal(url, '/v1/transit/export/hmac-key/foo/10', 'transitAction:export, with version url OK');
+    assert.strictEqual(
+      url,
+      '/v1/transit/export/hmac-key/foo/10',
+      'transitAction:export, with version url OK'
+    );
   });
 });

--- a/ui/tests/unit/components/auth-jwt-test.js
+++ b/ui/tests/unit/components/auth-jwt-test.js
@@ -55,7 +55,7 @@ module('Unit | Component | auth-jwt', function (hooks) {
     this.component.window.trigger('message', message);
 
     assert.ok(this.errorSpy.notCalled, 'Error handler not triggered while waiting for oidc callback message');
-    assert.equal(
+    assert.strictEqual(
       this.component.exchangeOIDC.performCount,
       1,
       'exchangeOIDC method fires when oidc callback message is received'

--- a/ui/tests/unit/components/identity/edit-form-test.js
+++ b/ui/tests/unit/components/identity/edit-form-test.js
@@ -63,7 +63,7 @@ module('Unit | Component | identity/edit-form', function (hooks) {
 
       component.set('mode', testCase.mode);
       component.set('model', model);
-      assert.equal(component.get('cancelLink'), testCase.expected, 'cancel link is correct');
+      assert.strictEqual(component.get('cancelLink'), testCase.expected, 'cancel link is correct');
     });
   });
 });

--- a/ui/tests/unit/decorators/model-validations-test.js
+++ b/ui/tests/unit/decorators/model-validations-test.js
@@ -33,7 +33,7 @@ module('Unit | Decorators | ModelValidations', function (hooks) {
     try {
       createClass();
     } catch (e) {
-      assert.equal(e.message, 'Validations object must be provided to constructor for setup');
+      assert.strictEqual(e.message, 'Validations object must be provided to constructor for setup');
     }
   });
 
@@ -92,7 +92,7 @@ module('Unit | Decorators | ModelValidations', function (hooks) {
     };
     const fooClass = createClass(validations);
     const v1 = fooClass.validate();
-    assert.equal(
+    assert.strictEqual(
       v1.invalidFormMessage,
       'There are 2 errors with this form.',
       'error message says form as 2 errors'
@@ -100,7 +100,7 @@ module('Unit | Decorators | ModelValidations', function (hooks) {
 
     fooClass.integer = 9;
     const v2 = fooClass.validate();
-    assert.equal(
+    assert.strictEqual(
       v2.invalidFormMessage,
       'There is an error with this form.',
       'error message says form has an error'
@@ -108,6 +108,6 @@ module('Unit | Decorators | ModelValidations', function (hooks) {
 
     fooClass.foo = true;
     const v3 = fooClass.validate();
-    assert.equal(v3.invalidFormMessage, null, 'invalidFormMessage is null when form is valid');
+    assert.strictEqual(v3.invalidFormMessage, null, 'invalidFormMessage is null when form is valid');
   });
 });

--- a/ui/tests/unit/helpers/await-test.js
+++ b/ui/tests/unit/helpers/await-test.js
@@ -29,36 +29,36 @@ module('Unit | Helpers | await', function (hooks) {
 
   test('it returns value when input is not a promise', async function (assert) {
     this.helper.compute(['foo']);
-    assert.equal(this.spy.returnValues[0], 'foo', 'Input value returned when not promise');
+    assert.strictEqual(this.spy.returnValues[0], 'foo', 'Input value returned when not promise');
   });
 
   test('it returns null default value and then resolved value', async function (assert) {
     const promise = new Promise((resolve) => resolve('foo'));
     this.helper.compute([promise]);
     await waitUntil(() => this.spy.returnValues[1]);
-    assert.equal(this.spy.returnValues[0], null, 'Default value returned while promise resolves');
-    assert.equal(this.spy.returnValues[1], 'foo', 'Resolved value is returned');
+    assert.strictEqual(this.spy.returnValues[0], null, 'Default value returned while promise resolves');
+    assert.strictEqual(this.spy.returnValues[1], 'foo', 'Resolved value is returned');
   });
 
   test('it returns rejected value', async function (assert) {
     const promise = new Promise((resolve, reject) => reject('bar'));
     this.helper.compute([promise]);
     await waitUntil(() => this.spy.returnValues[1]);
-    assert.equal(this.spy.returnValues[1], 'bar', 'Rejected value is returned');
+    assert.strictEqual(this.spy.returnValues[1], 'bar', 'Rejected value is returned');
   });
 
   test('it returns then value', async function (assert) {
     const promise = new Promise((resolve) => resolve('foo')).then(() => 'new resolve value');
     this.helper.compute([promise]);
     await waitUntil(() => this.spy.returnValues[1]);
-    assert.equal(this.spy.returnValues[1], 'new resolve value', 'Value from then is returned');
+    assert.strictEqual(this.spy.returnValues[1], 'new resolve value', 'Value from then is returned');
   });
 
   test('it returns catch value', async function (assert) {
     const promise = new Promise((resolve, reject) => reject('bar')).catch(() => 'new reject value');
     this.helper.compute([promise]);
     await waitUntil(() => this.spy.returnValues[1]);
-    assert.equal(this.spy.returnValues[1], 'new reject value', 'Value from catch is returned');
+    assert.strictEqual(this.spy.returnValues[1], 'new reject value', 'Value from catch is returned');
   });
 
   test('it always returns value from latest promise', async function (assert) {
@@ -68,6 +68,6 @@ module('Unit | Helpers | await', function (hooks) {
     this.helper.compute([promise2]);
     // allow first promise time to resolve
     await waitUntil(() => later(() => true, 500));
-    assert.equal(this.spy.returnValues[2], 'bar', 'Latest promise value is returned');
+    assert.strictEqual(this.spy.returnValues[2], 'bar', 'Latest promise value is returned');
   });
 });

--- a/ui/tests/unit/helpers/filter-wildcard-test.js
+++ b/ui/tests/unit/helpers/filter-wildcard-test.js
@@ -6,20 +6,20 @@ module('Unit | Helpers | filter-wildcard', function () {
     let string = { id: 'foo*' };
     let array = ['foobar', 'foozar', 'boo', 'oof'];
     let result = filterWildcard([string, array]);
-    assert.equal(result, 2);
+    assert.strictEqual(result, 2);
   });
 
   test('it returns zero if no wildcard is string', function (assert) {
     let string = { id: 'foo#' };
     let array = ['foobar', 'foozar', 'boo', 'oof'];
     let result = filterWildcard([string, array]);
-    assert.equal(result, 0);
+    assert.strictEqual(result, 0);
   });
 
   test('it escapes function and does not error if no id is in string', function (assert) {
     let string = '*bar*';
     let array = ['foobar', 'foozar', 'boobarboo', 'oof'];
     let result = filterWildcard([string, array]);
-    assert.equal(result, 2);
+    assert.strictEqual(result, 2);
   });
 });

--- a/ui/tests/unit/lib/attach-capabilities-test.js
+++ b/ui/tests/unit/lib/attach-capabilities-test.js
@@ -21,14 +21,14 @@ module('Unit | lib | attach capabilities', function (hooks) {
     });
     let relationship = mc.relationshipsByName.get('updatePath');
 
-    assert.equal(relationship.key, 'updatePath', 'has updatePath relationship');
-    assert.equal(relationship.kind, 'belongsTo', 'kind of relationship is belongsTo');
-    assert.equal(relationship.type, 'capabilities', 'updatePath is a related capabilities model');
+    assert.strictEqual(relationship.key, 'updatePath', 'has updatePath relationship');
+    assert.strictEqual(relationship.kind, 'belongsTo', 'kind of relationship is belongsTo');
+    assert.strictEqual(relationship.type, 'capabilities', 'updatePath is a related capabilities model');
 
     relationship = mc.relationshipsByName.get('deletePath');
-    assert.equal(relationship.key, 'deletePath', 'has deletePath relationship');
-    assert.equal(relationship.kind, 'belongsTo', 'kind of relationship is belongsTo');
-    assert.equal(relationship.type, 'capabilities', 'deletePath is a related capabilities model');
+    assert.strictEqual(relationship.key, 'deletePath', 'has deletePath relationship');
+    assert.strictEqual(relationship.kind, 'belongsTo', 'kind of relationship is belongsTo');
+    assert.strictEqual(relationship.type, 'capabilities', 'deletePath is a related capabilities model');
   });
 
   test('it adds a static method to the model class', function (assert) {
@@ -82,7 +82,7 @@ module('Unit | lib | attach capabilities', function (hooks) {
 
     mc.relatedCapabilities(jsonAPIDocSingle);
 
-    assert.equal(
+    assert.strictEqual(
       Object.keys(jsonAPIDocSingle.data.relationships).length,
       2,
       'document now has 2 relationships'

--- a/ui/tests/unit/lib/kv-object-test.js
+++ b/ui/tests/unit/lib/kv-object-test.js
@@ -79,7 +79,7 @@ module('Unit | Lib | kv object', function () {
       let expected = JSON.stringify(output, null, 2);
       let data = KVObject.create({ content: [] }).fromJSON(input);
       let result = data.toJSONString(includeBlanks);
-      assert.equal(result, expected, 'has expected output string');
+      assert.strictEqual(result, expected, 'has expected output string');
     });
   });
 
@@ -96,7 +96,7 @@ module('Unit | Lib | kv object', function () {
     test(`isAdvanced: ${name}`, function (assert) {
       let data = KVObject.create({ content: [] }).fromJSON(input);
 
-      assert.equal(data.isAdvanced(), expected, 'calculates isAdvanced correctly');
+      assert.strictEqual(data.isAdvanced(), expected, 'calculates isAdvanced correctly');
     });
   });
 });

--- a/ui/tests/unit/machines/auth-machine-test.js
+++ b/ui/tests/unit/machines/auth-machine-test.js
@@ -78,7 +78,7 @@ module('Unit | Machine | auth-machine', function () {
   testCases.forEach((testCase) => {
     test(`transition: ${testCase.event} for currentState ${testCase.currentState} and componentState ${testCase.params}`, function (assert) {
       let result = authMachine.transition(testCase.currentState, testCase.event, testCase.params);
-      assert.equal(result.value, testCase.expectedResults.value);
+      assert.strictEqual(result.value, testCase.expectedResults.value);
       assert.deepEqual(result.actions, testCase.expectedResults.actions);
     });
   });

--- a/ui/tests/unit/machines/policies-machine-test.js
+++ b/ui/tests/unit/machines/policies-machine-test.js
@@ -53,7 +53,7 @@ module('Unit | Machine | policies-machine', function () {
   testCases.forEach((testCase) => {
     test(`transition: ${testCase.event} for currentState ${testCase.currentState} and componentState ${testCase.params}`, function (assert) {
       let result = policiesMachine.transition(testCase.currentState, testCase.event, testCase.params);
-      assert.equal(result.value, testCase.expectedResults.value);
+      assert.strictEqual(result.value, testCase.expectedResults.value);
       assert.deepEqual(result.actions, testCase.expectedResults.actions);
     });
   });

--- a/ui/tests/unit/machines/replication-machine-test.js
+++ b/ui/tests/unit/machines/replication-machine-test.js
@@ -29,7 +29,7 @@ module('Unit | Machine | replication-machine', function () {
   testCases.forEach((testCase) => {
     test(`transition: ${testCase.event} for currentState ${testCase.currentState} and componentState ${testCase.params}`, function (assert) {
       let result = replicationMachine.transition(testCase.currentState, testCase.event, testCase.params);
-      assert.equal(result.value, testCase.expectedResults.value);
+      assert.strictEqual(result.value, testCase.expectedResults.value);
       assert.deepEqual(result.actions, testCase.expectedResults.actions);
     });
   });

--- a/ui/tests/unit/machines/secrets-machine-test.js
+++ b/ui/tests/unit/machines/secrets-machine-test.js
@@ -1063,7 +1063,7 @@ module('Unit | Machine | secrets-machine', function () {
   testCases.forEach((testCase) => {
     test(`transition: ${testCase.event} for currentState ${testCase.currentState} and componentState ${testCase.params}`, function (assert) {
       let result = secretsMachine.transition(testCase.currentState, testCase.event, testCase.params);
-      assert.equal(result.value, testCase.expectedResults.value);
+      assert.strictEqual(result.value, testCase.expectedResults.value);
       assert.deepEqual(result.actions, testCase.expectedResults.actions);
     });
   });

--- a/ui/tests/unit/machines/tools-machine-test.js
+++ b/ui/tests/unit/machines/tools-machine-test.js
@@ -82,7 +82,7 @@ module('Unit | Machine | tools-machine', function () {
   testCases.forEach((testCase) => {
     test(`transition: ${testCase.event} for currentState ${testCase.currentState} and componentState ${testCase.params}`, function (assert) {
       let result = toolsMachine.transition(testCase.currentState, testCase.event, testCase.params);
-      assert.equal(result.value, testCase.expectedResults.value);
+      assert.strictEqual(result.value, testCase.expectedResults.value);
       assert.deepEqual(result.actions, testCase.expectedResults.actions);
     });
   });

--- a/ui/tests/unit/mixins/cluster-route-test.js
+++ b/ui/tests/unit/mixins/cluster-route-test.js
@@ -28,19 +28,19 @@ module('Unit | Mixin | cluster route', function () {
   test('#targetRouteName init', function (assert) {
     let subject = createClusterRoute({ needsInit: true });
     subject.routeName = CLUSTER;
-    assert.equal(subject.targetRouteName(), INIT, 'forwards to INIT when cluster needs init');
+    assert.strictEqual(subject.targetRouteName(), INIT, 'forwards to INIT when cluster needs init');
 
     subject = createClusterRoute({ needsInit: false, sealed: true });
     subject.routeName = CLUSTER;
-    assert.equal(subject.targetRouteName(), UNSEAL, 'forwards to UNSEAL if sealed and initialized');
+    assert.strictEqual(subject.targetRouteName(), UNSEAL, 'forwards to UNSEAL if sealed and initialized');
 
     subject = createClusterRoute({ needsInit: false });
     subject.routeName = CLUSTER;
-    assert.equal(subject.targetRouteName(), AUTH, 'forwards to AUTH if unsealed and initialized');
+    assert.strictEqual(subject.targetRouteName(), AUTH, 'forwards to AUTH if unsealed and initialized');
 
     subject = createClusterRoute({ dr: { isSecondary: true } });
     subject.routeName = CLUSTER;
-    assert.equal(
+    assert.strictEqual(
       subject.targetRouteName(),
       DR_REPLICATION_SECONDARY,
       'forwards to DR_REPLICATION_SECONDARY if is a dr secondary'
@@ -54,10 +54,14 @@ module('Unit | Mixin | cluster route', function () {
     );
 
     subject.routeName = CLUSTER;
-    assert.equal(subject.targetRouteName(), INIT, 'still land on INIT if there are keys on the controller');
+    assert.strictEqual(
+      subject.targetRouteName(),
+      INIT,
+      'still land on INIT if there are keys on the controller'
+    );
 
     subject.routeName = UNSEAL;
-    assert.equal(subject.targetRouteName(), UNSEAL, 'allowed to proceed to unseal');
+    assert.strictEqual(subject.targetRouteName(), UNSEAL, 'allowed to proceed to unseal');
 
     subject = createClusterRoute(
       { needsInit: false, sealed: false },
@@ -65,7 +69,7 @@ module('Unit | Mixin | cluster route', function () {
     );
 
     subject.routeName = AUTH;
-    assert.equal(subject.targetRouteName(), AUTH, 'allowed to proceed to auth');
+    assert.strictEqual(subject.targetRouteName(), AUTH, 'allowed to proceed to auth');
   });
 
   test('#targetRouteName happy path forwards to CLUSTER route', function (assert) {
@@ -74,16 +78,20 @@ module('Unit | Mixin | cluster route', function () {
       { hasKeyData: () => false, authToken: () => 'a token' }
     );
     subject.routeName = INIT;
-    assert.equal(subject.targetRouteName(), CLUSTER, 'forwards when inited and navigating to INIT');
+    assert.strictEqual(subject.targetRouteName(), CLUSTER, 'forwards when inited and navigating to INIT');
 
     subject.routeName = UNSEAL;
-    assert.equal(subject.targetRouteName(), CLUSTER, 'forwards when unsealed and navigating to UNSEAL');
+    assert.strictEqual(subject.targetRouteName(), CLUSTER, 'forwards when unsealed and navigating to UNSEAL');
 
     subject.routeName = AUTH;
-    assert.equal(subject.targetRouteName(), REDIRECT, 'forwards when authenticated and navigating to AUTH');
+    assert.strictEqual(
+      subject.targetRouteName(),
+      REDIRECT,
+      'forwards when authenticated and navigating to AUTH'
+    );
 
     subject.routeName = DR_REPLICATION_SECONDARY;
-    assert.equal(
+    assert.strictEqual(
       subject.targetRouteName(),
       CLUSTER,
       'forwards when not a DR secondary and navigating to DR_REPLICATION_SECONDARY'
@@ -96,16 +104,20 @@ module('Unit | Mixin | cluster route', function () {
       { hasKeyData: () => false, authToken: () => null }
     );
     subject.routeName = INIT;
-    assert.equal(subject.targetRouteName(), AUTH, 'forwards when inited and navigating to INIT');
+    assert.strictEqual(subject.targetRouteName(), AUTH, 'forwards when inited and navigating to INIT');
 
     subject.routeName = UNSEAL;
-    assert.equal(subject.targetRouteName(), AUTH, 'forwards when unsealed and navigating to UNSEAL');
+    assert.strictEqual(subject.targetRouteName(), AUTH, 'forwards when unsealed and navigating to UNSEAL');
 
     subject.routeName = AUTH;
-    assert.equal(subject.targetRouteName(), AUTH, 'forwards when non-authenticated and navigating to AUTH');
+    assert.strictEqual(
+      subject.targetRouteName(),
+      AUTH,
+      'forwards when non-authenticated and navigating to AUTH'
+    );
 
     subject.routeName = DR_REPLICATION_SECONDARY;
-    assert.equal(
+    assert.strictEqual(
       subject.targetRouteName(),
       AUTH,
       'forwards when not a DR secondary and navigating to DR_REPLICATION_SECONDARY'

--- a/ui/tests/unit/models/role-jwt-test.js
+++ b/ui/tests/unit/models/role-jwt-test.js
@@ -9,8 +9,8 @@ module('Unit | Model | role-jwt', function (hooks) {
   test('it exists', function (assert) {
     let model = this.owner.lookup('service:store').createRecord('role-jwt');
     assert.ok(!!model);
-    assert.equal(model.providerName, null, 'no providerName');
-    assert.equal(model.providerButtonComponent, null, 'no providerButtonComponent');
+    assert.strictEqual(model.providerName, null, 'no providerName');
+    assert.strictEqual(model.providerButtonComponent, null, 'no providerButtonComponent');
   });
 
   test('it computes providerName when known provider url match fails', function (assert) {
@@ -18,8 +18,8 @@ module('Unit | Model | role-jwt', function (hooks) {
       authUrl: 'http://example.com',
     });
 
-    assert.equal(model.providerName, null, 'no providerName');
-    assert.equal(model.providerButtonComponent, null, 'no providerButtonComponent');
+    assert.strictEqual(model.providerName, null, 'no providerName');
+    assert.strictEqual(model.providerButtonComponent, null, 'no providerButtonComponent');
   });
 
   test('it provides a providerName for listed known providers', function (assert) {
@@ -30,15 +30,19 @@ module('Unit | Model | role-jwt', function (hooks) {
       });
 
       let expectedName = DOMAIN_STRINGS[domainPart];
-      assert.equal(model.providerName, expectedName, `computes providerName: ${expectedName}`);
+      assert.strictEqual(model.providerName, expectedName, `computes providerName: ${expectedName}`);
       if (PROVIDER_WITH_LOGO.includes(expectedName)) {
-        assert.equal(
+        assert.strictEqual(
           model.providerButtonComponent,
           `auth-button-${domainPart}`,
           `computes providerButtonComponent: ${domainPart}`
         );
       } else {
-        assert.equal(model.providerButtonComponent, null, `computes providerButtonComponent: ${domainPart}`);
+        assert.strictEqual(
+          model.providerButtonComponent,
+          null,
+          `computes providerButtonComponent: ${domainPart}`
+        );
       }
     });
   });

--- a/ui/tests/unit/models/secret-engine-test.js
+++ b/ui/tests/unit/models/secret-engine-test.js
@@ -10,7 +10,7 @@ module('Unit | Model | secret-engine', function (hooks) {
     let model;
     run(() => {
       model = run(() => this.owner.lookup('service:store').createRecord('secret-engine'));
-      assert.equal(model.get('modelTypeForKV'), 'secret');
+      assert.strictEqual(model.get('modelTypeForKV'), 'secret');
     });
   });
 
@@ -24,7 +24,7 @@ module('Unit | Model | secret-engine', function (hooks) {
           type: 'kv',
         })
       );
-      assert.equal(model.get('modelTypeForKV'), 'secret-v2');
+      assert.strictEqual(model.get('modelTypeForKV'), 'secret-v2');
     });
   });
 
@@ -38,7 +38,7 @@ module('Unit | Model | secret-engine', function (hooks) {
           type: 'kv',
         })
       );
-      assert.equal(model.get('modelTypeForKV'), 'secret-v2');
+      assert.strictEqual(model.get('modelTypeForKV'), 'secret-v2');
     });
   });
 });

--- a/ui/tests/unit/serializers/transit-key-test.js
+++ b/ui/tests/unit/serializers/transit-key-test.js
@@ -68,10 +68,10 @@ module('Unit | Serializer | transit-key', function (hooks) {
     let aesExpected = AES.data.keys[1] * 1000;
     let chachaExpected = CHACHA.data.keys[1] * 1000;
     let aesData = serializer.normalizeSecrets({ ...AES });
-    assert.equal(aesData.firstObject.keys[1], aesExpected, 'converts seconds to millis for aes keys');
+    assert.strictEqual(aesData.firstObject.keys[1], aesExpected, 'converts seconds to millis for aes keys');
 
     let chachaData = serializer.normalizeSecrets({ ...CHACHA });
-    assert.equal(
+    assert.strictEqual(
       chachaData.firstObject.keys[1],
       chachaExpected,
       'converts seconds to millis for chacha keys'
@@ -81,6 +81,10 @@ module('Unit | Serializer | transit-key', function (hooks) {
   test('it includes backend from the payload on the normalized data', function (assert) {
     let serializer = this.owner.lookup('serializer:transit-key');
     let data = serializer.normalizeSecrets({ ...AES });
-    assert.equal(data.firstObject.backend, 'its-a-transit', 'pulls backend from the payload onto the data');
+    assert.strictEqual(
+      data.firstObject.backend,
+      'its-a-transit',
+      'pulls backend from the payload onto the data'
+    );
   });
 });

--- a/ui/tests/unit/services/auth-test.js
+++ b/ui/tests/unit/services/auth-test.js
@@ -18,8 +18,8 @@ module('Unit | Service | auth', function (hooks) {
 
       let resp = service.calculateExpiration(response);
 
-      assert.equal(resp.ttl, ttlValue, 'returns the ttl');
-      assert.equal(
+      assert.strictEqual(resp.ttl, ttlValue, 'returns the ttl');
+      assert.strictEqual(
         resp.tokenExpirationEpoch,
         now + ttlValue * 1e3,
         'calculates expiration from ttl as epoch timestamp'

--- a/ui/tests/unit/services/console-test.js
+++ b/ui/tests/unit/services/console-test.js
@@ -9,13 +9,17 @@ module('Unit | Service | console', function (hooks) {
   hooks.afterEach(function () {});
 
   test('#sanitizePath', function (assert) {
-    assert.equal(sanitizePath(' /foo/bar/baz/ '), 'foo/bar/baz', 'removes spaces and slashs on either side');
-    assert.equal(sanitizePath('//foo/bar/baz/'), 'foo/bar/baz', 'removes more than one slash');
+    assert.strictEqual(
+      sanitizePath(' /foo/bar/baz/ '),
+      'foo/bar/baz',
+      'removes spaces and slashs on either side'
+    );
+    assert.strictEqual(sanitizePath('//foo/bar/baz/'), 'foo/bar/baz', 'removes more than one slash');
   });
 
   test('#ensureTrailingSlash', function (assert) {
-    assert.equal(ensureTrailingSlash('foo/bar'), 'foo/bar/', 'adds trailing slash');
-    assert.equal(ensureTrailingSlash('baz/'), 'baz/', 'keeps trailing slash if there is one');
+    assert.strictEqual(ensureTrailingSlash('foo/bar'), 'foo/bar/', 'adds trailing slash');
+    assert.strictEqual(ensureTrailingSlash('baz/'), 'baz/', 'keeps trailing slash if there is one');
   });
 
   let testCases = [
@@ -88,8 +92,8 @@ module('Unit | Service | console', function (hooks) {
     testCases.forEach((testCase) => {
       uiConsole[testCase.method](...testCase.args);
       let [url, verb, options] = ajax.lastCall.args;
-      assert.equal(url, testCase.expectedURL, `${testCase.method}: uses trimmed passed url`);
-      assert.equal(verb, testCase.expectedVerb, `${testCase.method}: uses the correct verb`);
+      assert.strictEqual(url, testCase.expectedURL, `${testCase.method}: uses trimmed passed url`);
+      assert.strictEqual(verb, testCase.expectedVerb, `${testCase.method}: uses the correct verb`);
       assert.deepEqual(options, testCase.expectedOptions, `${testCase.method}: uses the correct options`);
     });
   });

--- a/ui/tests/unit/services/control-group-test.js
+++ b/ui/tests/unit/services/control-group-test.js
@@ -93,8 +93,8 @@ module('Unit | Service | control group', function (hooks) {
         return result.then(
           () => {},
           (err) => {
-            assert.equal(err.token, 'secret');
-            assert.equal(err.accessor, 'lookup');
+            assert.strictEqual(err.token, 'secret');
+            assert.strictEqual(err.accessor, 'lookup');
           }
         );
       },
@@ -191,7 +191,7 @@ module('Unit | Service | control group', function (hooks) {
     let accessor = '12345';
     let path = 'kv/foo/bar';
     let expectedKey = `${CONTROL_GROUP_PREFIX}${accessor}${TOKEN_SEPARATOR}${path}`;
-    assert.equal(storageKey(accessor, path), expectedKey, 'uses expected key');
+    assert.strictEqual(storageKey(accessor, path), expectedKey, 'uses expected key');
   });
 
   test('keyFromAccessor', function (assert) {
@@ -209,8 +209,8 @@ module('Unit | Service | control group', function (hooks) {
     store.setItem(expectedKey, data);
     store.setItem(`${CONTROL_GROUP_PREFIX}2345${TOKEN_SEPARATOR}${path}`, 'ok');
 
-    assert.equal(subject.keyFromAccessor(accessor), expectedKey, 'finds key given the accessor');
-    assert.equal(subject.keyFromAccessor('foo'), null, 'returns null if no key was found');
+    assert.strictEqual(subject.keyFromAccessor(accessor), expectedKey, 'finds key given the accessor');
+    assert.strictEqual(subject.keyFromAccessor('foo'), null, 'returns null if no key was found');
   });
 
   test('storeControlGroupToken', function (assert) {
@@ -245,7 +245,7 @@ module('Unit | Service | control group', function (hooks) {
     let expectedKey = `${CONTROL_GROUP_PREFIX}${accessor}${TOKEN_SEPARATOR}${path}`;
     store.setItem(expectedKey, { one: '2' });
     subject.deleteControlGroupToken(accessor);
-    assert.equal(Object.keys(store.items).length, 0, 'there are no keys stored in storage');
+    assert.strictEqual(Object.keys(store.items).length, 0, 'there are no keys stored in storage');
   });
 
   test('deleteTokens', function (assert) {
@@ -261,10 +261,10 @@ module('Unit | Service | control group', function (hooks) {
     store.setItem(keyOne, { one: '2' });
     store.setItem(keyTwo, { two: '2' });
     store.setItem('value', 'one');
-    assert.equal(Object.keys(store.items).length, 3, 'stores 3 values');
+    assert.strictEqual(Object.keys(store.items).length, 3, 'stores 3 values');
     subject.deleteTokens();
-    assert.equal(Object.keys(store.items).length, 1, 'removes tokens with control group prefix');
-    assert.equal(store.getItem('value'), 'one', 'keeps the non-prefixed value');
+    assert.strictEqual(Object.keys(store.items).length, 1, 'removes tokens with control group prefix');
+    assert.strictEqual(store.getItem('value'), 'one', 'keeps the non-prefixed value');
   });
 
   test('wrapInfoForAccessor', function (assert) {

--- a/ui/tests/unit/services/feature-flag-test.js
+++ b/ui/tests/unit/services/feature-flag-test.js
@@ -11,11 +11,11 @@ module('Unit | Service | feature-flag', function (hooks) {
 
   test('it returns the namespace root when flag is present', function (assert) {
     let service = this.owner.lookup('service:feature-flag');
-    assert.equal(service.managedNamespaceRoot, null, 'Managed namespace root is null by default');
+    assert.strictEqual(service.managedNamespaceRoot, null, 'Managed namespace root is null by default');
     service.setFeatureFlags(['VAULT_CLOUD_ADMIN_NAMESPACE']);
-    assert.equal(service.managedNamespaceRoot, 'admin', 'Managed namespace is admin when flag present');
+    assert.strictEqual(service.managedNamespaceRoot, 'admin', 'Managed namespace is admin when flag present');
     service.setFeatureFlags(['SOMETHING_ELSE']);
-    assert.equal(
+    assert.strictEqual(
       service.managedNamespaceRoot,
       null,
       'Flags were overwritten and root namespace is null again'

--- a/ui/tests/unit/services/path-helper-test.js
+++ b/ui/tests/unit/services/path-helper-test.js
@@ -68,6 +68,6 @@ module('Unit | Service | path-help', function (hooks) {
     const model = this.store.createRecord(modelType);
     model.set('mutableId', 'test');
     await model.save();
-    assert.equal(model.get('id'), 'test', 'model id is set to mutableId value on save success');
+    assert.strictEqual(model.get('id'), 'test', 'model id is set to mutableId value on save success');
   });
 });

--- a/ui/tests/unit/services/permissions-test.js
+++ b/ui/tests/unit/services/permissions-test.js
@@ -139,7 +139,7 @@ module('Unit | Service | permissions', function (hooks) {
       },
     };
     service.set('exactPaths', policyPaths);
-    assert.equal(service.navPathParams('policies').models[0], 'rgp');
+    assert.strictEqual(service.navPathParams('policies').models[0], 'rgp');
   });
 
   test('returns the first allowed nav route for access', function (assert) {
@@ -191,6 +191,6 @@ module('Unit | Service | permissions', function (hooks) {
     });
     this.owner.register('service:namespace', namespaceService);
     let service = this.owner.lookup('service:permissions');
-    assert.equal(service.pathNameWithNamespace('sys/auth'), 'marketing/sys/auth');
+    assert.strictEqual(service.pathNameWithNamespace('sys/auth'), 'marketing/sys/auth');
   });
 });

--- a/ui/tests/unit/services/store-test.js
+++ b/ui/tests/unit/services/store-test.js
@@ -12,7 +12,7 @@ module('Unit | Service | store', function (hooks) {
   setupTest(hooks);
 
   test('normalizeModelName', function (assert) {
-    assert.equal(normalizeModelName('oneThing'), 'one-thing', 'dasherizes modelName');
+    assert.strictEqual(normalizeModelName('oneThing'), 'one-thing', 'dasherizes modelName');
   });
 
   test('keyForCache', function (assert) {
@@ -23,10 +23,10 @@ module('Unit | Service | store', function (hooks) {
   });
 
   test('clamp', function (assert) {
-    assert.equal(clamp('foo', 0, 100), 0, 'returns the min if passed a non-number');
-    assert.equal(clamp(0, 1, 100), 1, 'returns the min when passed number is less than the min');
-    assert.equal(clamp(200, 1, 100), 100, 'returns the max passed number is greater than the max');
-    assert.equal(clamp(50, 1, 100), 50, 'returns the passed number when it is in range');
+    assert.strictEqual(clamp('foo', 0, 100), 0, 'returns the min if passed a non-number');
+    assert.strictEqual(clamp(0, 1, 100), 1, 'returns the min when passed number is less than the min');
+    assert.strictEqual(clamp(200, 1, 100), 100, 'returns the max passed number is greater than the max');
+    assert.strictEqual(clamp(50, 1, 100), 50, 'returns the passed number when it is in range');
   });
 
   test('store.storeDataset', function (assert) {
@@ -47,10 +47,10 @@ module('Unit | Service | store', function (hooks) {
     const arr2 = ['one', 'two', 'three', 'four'];
     store.storeDataset('data', { id: 1 }, {}, arr);
     store.storeDataset('transit-key', { id: 2 }, {}, arr2);
-    assert.equal(store.get('lazyCaches').size, 2, 'it stores both keys');
+    assert.strictEqual(store.get('lazyCaches').size, 2, 'it stores both keys');
 
     store.clearDataset('transit-key');
-    assert.equal(store.get('lazyCaches').size, 1, 'deletes one key');
+    assert.strictEqual(store.get('lazyCaches').size, 1, 'deletes one key');
     assert.notOk(store.get('lazyCaches').has(), 'cache is no longer stored');
   });
 
@@ -60,10 +60,10 @@ module('Unit | Service | store', function (hooks) {
     const arr2 = ['one', 'two', 'three', 'four'];
     store.storeDataset('data', { id: 1 }, {}, arr);
     store.storeDataset('transit-key', { id: 2 }, {}, arr2);
-    assert.equal(store.get('lazyCaches').size, 2, 'it stores both keys');
+    assert.strictEqual(store.get('lazyCaches').size, 2, 'it stores both keys');
 
     store.clearAllDatasets();
-    assert.equal(store.get('lazyCaches').size, 0, 'deletes all of the keys');
+    assert.strictEqual(store.get('lazyCaches').size, 0, 'deletes all of the keys');
     assert.notOk(store.get('lazyCaches').has('transit-key'), 'first cache key is no longer stored');
     assert.notOk(store.get('lazyCaches').has('data'), 'second cache key is no longer stored');
   });
@@ -116,7 +116,7 @@ module('Unit | Service | store', function (hooks) {
       });
     });
 
-    assert.equal(result.get('length'), pageSize, 'returns the correct number of items');
+    assert.strictEqual(result.get('length'), pageSize, 'returns the correct number of items');
     assert.deepEqual(result.mapBy('id'), keys.slice(0, pageSize), 'returns the first page of items');
     assert.deepEqual(
       result.get('meta'),
@@ -220,7 +220,7 @@ module('Unit | Service | store', function (hooks) {
     run(function () {
       store.lazyPaginatedQuery('secret', { page: 1, responsePath: 'data' });
     });
-    assert.equal(queryArgs.size, DEFAULT_PAGE_SIZE, 'calls query with DEFAULT_PAGE_SIZE');
+    assert.strictEqual(queryArgs.size, DEFAULT_PAGE_SIZE, 'calls query with DEFAULT_PAGE_SIZE');
 
     assert.throws(
       () => {

--- a/ui/tests/unit/services/wizard-test.js
+++ b/ui/tests/unit/services/wizard-test.js
@@ -362,7 +362,7 @@ module('Unit | Service | wizard', function (hooks) {
         });
       }
       if (testCase.expectedResults.value !== null && testCase.expectedResults.value !== undefined) {
-        assert.equal(result, testCase.expectedResults.value, `${testCase.method} gives correct value`);
+        assert.strictEqual(result, testCase.expectedResults.value, `${testCase.method} gives correct value`);
       }
     });
   });

--- a/ui/tests/unit/utils/api-path-test.js
+++ b/ui/tests/unit/utils/api-path-test.js
@@ -11,7 +11,7 @@ module('Unit | Util | api path', function () {
     let ret = apiPath`foo/${'one'}/${'two'}`;
     let result = ret({ one: 1, two: 2 });
 
-    assert.equal(result, 'foo/1/2', 'returns the expected string');
+    assert.strictEqual(result, 'foo/1/2', 'returns the expected string');
   });
 
   test('it throws when the key is not found in the context', function (assert) {

--- a/ui/tests/unit/utils/chart-helpers-test.js
+++ b/ui/tests/unit/utils/chart-helpers-test.js
@@ -16,17 +16,17 @@ module('Unit | Utility | chart-helpers', function () {
     const method = formatNumbers();
     assert.ok(method);
     SMALL_NUMBERS.forEach(function (num) {
-      assert.equal(formatNumbers(num), num, `Does not format small number ${num}`);
+      assert.strictEqual(formatNumbers(num), num, `Does not format small number ${num}`);
     });
     Object.keys(LARGE_NUMBERS).forEach(function (num) {
       const expected = LARGE_NUMBERS[num];
-      assert.equal(formatNumbers(num), expected, `Formats ${num} as ${expected}`);
+      assert.strictEqual(formatNumbers(num), expected, `Formats ${num} as ${expected}`);
     });
   });
 
   test('formatTooltipNumber renders number correctly', function (assert) {
     const formatted = formatTooltipNumber(120300200100);
-    assert.equal(formatted.length, 15, 'adds punctuation at proper place for large numbers');
+    assert.strictEqual(formatted.length, 15, 'adds punctuation at proper place for large numbers');
   });
 
   test('calculateAverage is accurate', function (assert) {
@@ -39,21 +39,29 @@ module('Unit | Utility | chart-helpers', function () {
       { label: 'bar', value: 22 },
     ];
     const getAverage = (array) => array.reduce((a, b) => a + b, 0) / array.length;
-    assert.equal(calculateAverage(null), null, 'returns null if dataset it null');
-    assert.equal(calculateAverage([]), null, 'returns null if dataset it empty array');
-    assert.equal(calculateAverage([0]), getAverage([0]), `returns ${getAverage([0])} if array is just 0 0`);
-    assert.equal(calculateAverage([1]), getAverage([1]), `returns ${getAverage([1])} if array is just 1`);
-    assert.equal(
+    assert.strictEqual(calculateAverage(null), null, 'returns null if dataset it null');
+    assert.strictEqual(calculateAverage([]), null, 'returns null if dataset it empty array');
+    assert.strictEqual(
+      calculateAverage([0]),
+      getAverage([0]),
+      `returns ${getAverage([0])} if array is just 0 0`
+    );
+    assert.strictEqual(
+      calculateAverage([1]),
+      getAverage([1]),
+      `returns ${getAverage([1])} if array is just 1`
+    );
+    assert.strictEqual(
       calculateAverage([5, 1, 41, 5]),
       getAverage([5, 1, 41, 5]),
       `returns correct average for array of integers`
     );
-    assert.equal(
+    assert.strictEqual(
       calculateAverage(testArray1, 'value'),
       getAverage([10, 22]),
       `returns correct average for array of objects`
     );
-    assert.equal(
+    assert.strictEqual(
       calculateAverage(testArray2, 'value'),
       getAverage([0, 22]),
       `returns correct average for array of objects containing undefined values`

--- a/ui/tests/unit/utils/common-prefix-test.js
+++ b/ui/tests/unit/utils/common-prefix-test.js
@@ -4,29 +4,29 @@ import { module, test } from 'qunit';
 module('Unit | Util | common prefix', function () {
   test('it returns empty string if called with no args or an empty array', function (assert) {
     let returned = commonPrefix();
-    assert.equal(returned, '', 'returns an empty string');
+    assert.strictEqual(returned, '', 'returns an empty string');
     returned = commonPrefix([]);
-    assert.equal(returned, '', 'returns an empty string for an empty array');
+    assert.strictEqual(returned, '', 'returns an empty string for an empty array');
   });
 
   test('it returns empty string if there are no common prefixes', function (assert) {
     let secrets = ['asecret', 'secret2', 'secret3'].map((s) => ({ id: s }));
     let returned = commonPrefix(secrets);
-    assert.equal(returned, '', 'returns an empty string');
+    assert.strictEqual(returned, '', 'returns an empty string');
   });
 
   test('it returns the longest prefix', function (assert) {
     let secrets = ['secret1', 'secret2', 'secret3'].map((s) => ({ id: s }));
     let returned = commonPrefix(secrets);
-    assert.equal(returned, 'secret', 'finds secret prefix');
+    assert.strictEqual(returned, 'secret', 'finds secret prefix');
     let greetings = ['hello-there', 'hello-hi', 'hello-howdy'].map((s) => ({ id: s }));
     returned = commonPrefix(greetings);
-    assert.equal(returned, 'hello-', 'finds hello- prefix');
+    assert.strictEqual(returned, 'hello-', 'finds hello- prefix');
   });
 
   test('it can compare an attribute that is not "id" to calculate the longest prefix', function (assert) {
     let secrets = ['secret1', 'secret2', 'secret3'].map((s) => ({ name: s }));
     let returned = commonPrefix(secrets, 'name');
-    assert.equal(returned, 'secret', 'finds secret prefix from name attribute');
+    assert.strictEqual(returned, 'secret', 'finds secret prefix from name attribute');
   });
 });

--- a/ui/tests/unit/utils/trim-right-test.js
+++ b/ui/tests/unit/utils/trim-right-test.js
@@ -5,43 +5,43 @@ module('Unit | Util | trim right', function () {
   test('it trims extension array from end of string', function (assert) {
     const trimmedName = trimRight('my-file-name-is-cool.json', ['.json', '.txt', '.hcl', '.policy']);
 
-    assert.equal(trimmedName, 'my-file-name-is-cool');
+    assert.strictEqual(trimmedName, 'my-file-name-is-cool');
   });
 
   test('it only trims extension array from the very end of string', function (assert) {
     const trimmedName = trimRight('my-file-name.json-is-cool.json', ['.json', '.txt', '.hcl', '.policy']);
 
-    assert.equal(trimmedName, 'my-file-name.json-is-cool');
+    assert.strictEqual(trimmedName, 'my-file-name.json-is-cool');
   });
 
   test('it returns string as is if trim array is empty', function (assert) {
     const trimmedName = trimRight('my-file-name-is-cool.json', []);
 
-    assert.equal(trimmedName, 'my-file-name-is-cool.json');
+    assert.strictEqual(trimmedName, 'my-file-name-is-cool.json');
   });
 
   test('it returns string as is if trim array is not passed in', function (assert) {
     const trimmedName = trimRight('my-file-name-is-cool.json');
 
-    assert.equal(trimmedName, 'my-file-name-is-cool.json');
+    assert.strictEqual(trimmedName, 'my-file-name-is-cool.json');
   });
 
   test('it allows the last extension to also be part of the file name', function (assert) {
     const trimmedName = trimRight('my-policy.hcl', ['.json', '.txt', '.hcl', '.policy']);
 
-    assert.equal(trimmedName, 'my-policy');
+    assert.strictEqual(trimmedName, 'my-policy');
   });
 
   test('it allows the last extension to also be part of the file name and the extenstion', function (assert) {
     const trimmedName = trimRight('my-policy.policy', ['.json', '.txt', '.hcl', '.policy']);
 
-    assert.equal(trimmedName, 'my-policy');
+    assert.strictEqual(trimmedName, 'my-policy');
   });
 
   test('it passes endings into the regex unescaped when passing false as the third arg', function (assert) {
     const trimmedName = trimRight('my-policypolicy', ['.json', '.txt', '.hcl', '.policy'], false);
 
     // the . gets interpreted as regex wildcard so it also trims the y character
-    assert.equal(trimmedName, 'my-polic');
+    assert.strictEqual(trimmedName, 'my-polic');
   });
 });


### PR DESCRIPTION
This PR addresses a new lint error added after the Ember upgrade to 4.4 which [disallows the use of the QUnit method assert.equal](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md). Since we already use `deepEqual` where necessary this was just a basic find and replace to `strictEqual`.

In addition, there were quite a few warnings from the [no-console rule](https://eslint.org/docs/latest/rules/no-console) which was explicitly set to `warn` in `.eslintrc`. Rather than have these continue to appear as warnings, I disabled the rule for the individual intended usages and then globally changed the rule to `error` for the future. Any calls to `console` should be removed if used for debugging but if it is necessary to leave them in then disable the rule for the instance by using `// eslint-disable-line` or similar.