### PR TITLE
Plugins: Add version info to CLI and server log output

### DIFF
--- a/command/auth_enable.go
+++ b/command/auth_enable.go
@@ -321,6 +321,9 @@ func (c *AuthEnableCommand) Run(args []string) int {
 	if authType == "plugin" {
 		authThing = c.flagPluginName + " plugin"
 	}
+	if c.flagPluginVersion != "" {
+		authThing += " version " + c.flagPluginVersion
+	}
 	c.UI.Output(fmt.Sprintf("Success! Enabled %s at: %s", authThing, authPath))
 	return 0
 }

--- a/command/secrets_enable.go
+++ b/command/secrets_enable.go
@@ -343,6 +343,9 @@ func (c *SecretsEnableCommand) Run(args []string) int {
 	if engineType == "plugin" {
 		thing = c.flagPluginName + " plugin"
 	}
+	if c.flagPluginVersion != "" {
+		thing += " version " + c.flagPluginVersion
+	}
 	c.UI.Output(fmt.Sprintf("Success! Enabled the %s at: %s", thing, mountPath))
 	return 0
 }

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -232,7 +232,7 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 	}
 
 	if c.logger.IsInfo() {
-		c.logger.Info("enabled credential backend", "path", entry.Path, "type", entry.Type)
+		c.logger.Info("enabled credential backend", "path", entry.Path, "type", entry.Type, "version", entry.Version)
 	}
 	return nil
 }
@@ -847,7 +847,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 		}
 
 		if c.logger.IsInfo() {
-			c.logger.Info("successfully enabled credential backend", "type", entry.Type, "path", entry.Path, "namespace", entry.Namespace())
+			c.logger.Info("successfully enabled credential backend", "type", entry.Type, "version", entry.Version, "path", entry.Path, "namespace", entry.Namespace())
 		}
 
 		// Ensure the path is tainted if set in the mount table

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -679,7 +679,7 @@ func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStora
 	}
 
 	if c.logger.IsInfo() {
-		c.logger.Info("successful mount", "namespace", entry.Namespace().Path, "path", entry.Path, "type", entry.Type)
+		c.logger.Info("successful mount", "namespace", entry.Namespace().Path, "path", entry.Path, "type", entry.Type, "version", entry.Version)
 	}
 	return nil
 }
@@ -1495,7 +1495,7 @@ func (c *Core) setupMounts(ctx context.Context) error {
 		}
 
 		if c.logger.IsInfo() {
-			c.logger.Info("successfully mounted backend", "type", entry.Type, "path", entry.Path)
+			c.logger.Info("successfully mounted backend", "type", entry.Type, "version", entry.Version, "path", entry.Path)
 		}
 
 		// Ensure the path is tainted if set in the mount table

--- a/vault/plugin_reload.go
+++ b/vault/plugin_reload.go
@@ -249,6 +249,14 @@ func (c *Core) reloadBackendCommon(ctx context.Context, entry *MountEntry, isAut
 		}
 	}
 
+	if c.logger.IsInfo() {
+		pluginType := "secrets"
+		if isAuth {
+			pluginType = "auth"
+		}
+		c.logger.Info(fmt.Sprintf("successfully reloaded %s backend", pluginType), "type", entry.Type, "version", entry.Version, "path", entry.Path)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Adds some plugin version info to CLI output and server logs to help clarify exactly what's running. I added a log line for reloading because that's going to be a common code path for performing in-place plugin upgrades.