### PR TITLE
Template lint warning clean up

### DIFF
--- a/ui/.template-lintrc.js
+++ b/ui/.template-lintrc.js
@@ -36,15 +36,11 @@ module.exports = {
   plugins: ['ember-template-lint-plugin-prettier'],
   extends: ['recommended', 'ember-template-lint-plugin-prettier:recommended'],
   rules: {
-    'no-bare-strings': 'off',
     'no-action': 'off',
-    'no-duplicate-landmark-elements': 'warn',
     'no-implicit-this': {
       allow: ['supported-auth-backends'],
     },
     'require-input-label': 'off',
-    'no-down-event-binding': 'warn',
-    'self-closing-void-elements': 'off',
   },
   ignore: ['lib/story-md', 'tests/**'],
   // ember language server vscode extension does not currently respect the ignore field

--- a/ui/app/components/diff-version-selector.js
+++ b/ui/app/components/diff-version-selector.js
@@ -3,6 +3,7 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { htmlSafe } from '@ember/string';
 
 /**
  * @module DiffVersionSelector
@@ -57,10 +58,11 @@ export default class DiffVersionSelector extends Component {
     let delta = diffpatcher.diff(rightSideVersionData, leftSideVersionData);
     if (delta === undefined) {
       this.statesMatch = true;
-      this.visualDiff = JSON.stringify(leftSideVersionData, undefined, 2); // params: value, replacer (all properties included), space (white space and indentation, line break, etc.)
+      // params: value, replacer (all properties included), space (white space and indentation, line break, etc.)
+      this.visualDiff = htmlSafe(JSON.stringify(leftSideVersionData, undefined, 2));
     } else {
       this.statesMatch = false;
-      this.visualDiff = jsondiffpatch.formatters.html.format(delta, rightSideVersionData);
+      this.visualDiff = htmlSafe(jsondiffpatch.formatters.html.format(delta, rightSideVersionData));
     }
   }
 

--- a/ui/app/templates/components/clients/history.hbs
+++ b/ui/app/templates/components/clients/history.hbs
@@ -198,7 +198,7 @@
             <Chevron @direction="down" @isButton={{true}} />
           </D.Trigger>
           <D.Content @defaultClass="popup-menu-content is-wide">
-            <nav class="box menu scroll">
+            <nav class="box menu scroll" aria-label="months">
               <ul class="menu-list">
                 {{#each this.months as |month index|}}
                   <button
@@ -225,7 +225,7 @@
             <Chevron @direction="down" @isButton={{true}} />
           </D.Trigger>
           <D.Content @defaultClass="popup-menu-content is-wide">
-            <nav class="box menu">
+            <nav class="box menu" aria-label="years">
               <ul class="menu-list">
                 {{#each this.years as |year|}}
                   <button

--- a/ui/app/templates/components/configure-aws-secret.hbs
+++ b/ui/app/templates/components/configure-aws-secret.hbs
@@ -22,7 +22,11 @@
 </div>
 
 {{#if (eq @tab "leases")}}
-  <form onsubmit={{action "saveLease" (hash lease=@model.lease lease_max=@model.leaseMax)}} data-test-aws-leases-form="true">
+  <form
+    onsubmit={{action "saveLease" (hash lease=@model.lease lease_max=@model.leaseMax)}}
+    aria-label="save lease form"
+    data-test-aws-leases-form="true"
+  >
     <div class="box is-fullwidth is-shadowless is-marginless">
       <NamespaceReminder @mode="saved" @noun="configuration" />
       <MessageError @model={{@model}} />

--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -89,7 +89,7 @@
     </AlertBanner>
   {{/if}}
 
-  <form {{on "submit" this.handleCreateConnection}}>
+  <form {{on "submit" this.handleCreateConnection}} aria-label="create connection form">
     {{#each @model.fieldAttrs as |attr|}}
       {{#if (not-eq attr.options.readOnly true)}}
         <FormField data-test-field={{true}} @attr={{attr}} @model={{@model}} />
@@ -177,7 +177,7 @@
     </div>
   </form>
 {{else if (and (eq @mode "edit") @model.isAvailablePlugin)}}
-  <form {{on "submit" this.handleUpdateConnection}}>
+  <form {{on "submit" this.handleUpdateConnection}} aria-label="plugin config form">
     {{#each @model.fieldAttrs as |attr|}}
       {{#if (or (eq attr.name "name") (eq attr.name "plugin_name"))}}
         <ReadonlyFormField @attr={{attr}} @value={{get @model attr.name}} />
@@ -272,7 +272,7 @@
     </div>
 
     {{! Statements Edit Section }}
-    {{#unless (and @model.plugin_name (not @model.statementFields))}}
+    {{#if (not (and @model.plugin_name (not @model.statementFields)))}}
       <div class="form-section box is-shadowless is-fullwidth">
         <fieldset class="form-fieldset">
           <legend class="title is-5">Statements</legend>
@@ -281,7 +281,7 @@
           {{/each}}
         </fieldset>
       </div>
-    {{/unless}}
+    {{/if}}
 
     <div class="field is-grouped is-grouped-split is-fullwidth box is-bottomless">
       <div class="field is-grouped">

--- a/ui/app/templates/components/database-role-setting-form.hbs
+++ b/ui/app/templates/components/database-role-setting-form.hbs
@@ -19,17 +19,17 @@
 {{#unless (and @roleType (not this.statementFields))}}
   <div class="box is-sideless is-fullwidth is-marginless" data-test-statements-section>
     <h3 class="title is-5">Statements</h3>
-    {{#unless this.statementFields}}
-      <EmptyState
-        @title="No role type selected"
-        @message="Select a type of role to be able to add statements for creation, revocation, and/or rotation."
-      />
-    {{else}}
+    {{#if this.statementFields}}
       <div class="form-section">
         {{#each this.statementFields as |attr|}}
           <FormField data-test-field={{true}} @attr={{attr}} @model={{@model}} />
         {{/each}}
       </div>
-    {{/unless}}
+    {{else}}
+      <EmptyState
+        @title="No role type selected"
+        @message="Select a type of role to be able to add statements for creation, revocation, and/or rotation."
+      />
+    {{/if}}
   </div>
 {{/unless}}

--- a/ui/app/templates/components/date-dropdown.hbs
+++ b/ui/app/templates/components/date-dropdown.hbs
@@ -8,7 +8,7 @@
     <Chevron @direction="down" @isButton={{true}} />
   </D.Trigger>
   <D.Content @defaultClass="popup-menu-content is-wide">
-    <nav class="box menu scroll">
+    <nav class="box menu scroll" aria-label="months">
       <ul data-test-month-list class="menu-list">
         {{#each this.months as |month index|}}
           <button
@@ -34,7 +34,7 @@
     <Chevron @direction="down" @isButton={{true}} />
   </D.Trigger>
   <D.Content @defaultClass="popup-menu-content is-wide">
-    <nav class="box menu">
+    <nav class="box menu" aria-label="years">
       <ul data-test-year-list class="menu-list">
         {{#each this.years as |year|}}
           <button

--- a/ui/app/templates/components/diff-version-selector.hbs
+++ b/ui/app/templates/components/diff-version-selector.hbs
@@ -12,7 +12,7 @@
         <Chevron @direction="down" @isButton={{true}} />
       </D.Trigger>
       <D.Content @defaultClass="popup-menu-content">
-        <nav class="box menu">
+        <nav class="box menu" aria-label="version">
           <ul class="menu-list">
             {{#each (reverse @model.versions) as |leftSideSecretVersion|}}
               <li class="action" data-test-leftSide-version={{leftSideSecretVersion.version}}>
@@ -55,7 +55,7 @@
         <Chevron @direction="down" @isButton={{true}} />
       </D.Trigger>
       <D.Content @defaultClass="popup-menu-content">
-        <nav class="box menu">
+        <nav class="box menu" aria-label="versions to diff">
           <ul class="menu-list">
             {{#each (reverse @model.versions) as |rightSideSecretVersion|}}
               <li class="action">
@@ -98,6 +98,5 @@
 </Toolbar>
 
 <div class="form-section visual-diff">
-  {{! template-lint-configure no-triple-curlies "warn" }}
-  <pre>{{{this.visualDiff}}}</pre>
+  <pre>{{this.visualDiff}}</pre>
 </div>

--- a/ui/app/templates/components/file-to-array-buffer.hbs
+++ b/ui/app/templates/components/file-to-array-buffer.hbs
@@ -6,7 +6,7 @@
       {{/if}}
     </label>
     <div class="file has-name is-fullwidth">
-      <label class="file-label">
+      <div class="file-label">
         <input class="file-input" type="file" onchange={{action "pickedFile"}} data-test-file-input />
         <span class="file-cta button">
           <Icon @name="upload" class="has-light-grey-text" />
@@ -16,13 +16,11 @@
           {{or this.fileName "No file chosen"}}
         </span>
         {{#if this.fileName}}
-          {{! template-lint-configure no-nested-interactive "warn" }}
           <button type="button" class="file-delete-button" {{action "clearFile"}} data-test-text-clear>
             <Icon @name="x-circle" />
           </button>
-          {{! template-lint-configure no-nested-interactive "on" }}
         {{/if}}
-      </label>
+      </div>
     </div>
   </div>
   {{#if this.fileName}}

--- a/ui/app/templates/components/generate-credentials-database.hbs
+++ b/ui/app/templates/components/generate-credentials-database.hbs
@@ -1,6 +1,6 @@
 <PageHeader as |p|>
   <p.top>
-    <nav class="breadcrumb">
+    <nav class="breadcrumb" aria-label="breadcrumbs">
       <ul>
         <li>
           <span class="sep">&#x0002f;</span>
@@ -28,7 +28,7 @@
       @bottomBorder={{true}}
       @message={{@model.errorMessage}}
     >
-      <nav class="breadcrumb">
+      <nav class="breadcrumb" aria-label="help breadcrumb">
         <ul class="is-grouped-split">
           <li>
             {{! Empty because they can't go "back" anywhere }}

--- a/ui/app/templates/components/namespace-link.hbs
+++ b/ui/app/templates/components/namespace-link.hbs
@@ -5,11 +5,7 @@
     <div class="level is-mobile">
       <span class="level-left">{{this.namespaceDisplay}}</span>
       <span class="level-right">
-        {{! template-lint-configure no-nested-interactive "warn" }}
-        <button type="button" class="button is-ghost icon">
-          <Chevron @isButton={{true}} class="has-text-grey" />
-        </button>
-        {{! template-lint-configure no-nested-interactive "on" }}
+        <Chevron @isButton={{true}} class="button is-ghost icon has-text-grey" />
       </span>
     </div>
   {{/if}}

--- a/ui/app/templates/components/pgp-file.hbs
+++ b/ui/app/templates/components/pgp-file.hbs
@@ -45,7 +45,7 @@
   {{else}}
     <div class="control is-expanded">
       <div class="file">
-        <label class="file-label is-fullwidth">
+        <div class="file-label is-fullwidth">
           <input class="file-input" type="file" onchange={{action "pickedFile"}} data-test-pgp-file-input={{true}} />
           <span class="file-cta is-fullwidth">
             <span class="file-icon has-text-grey-dark">
@@ -59,14 +59,12 @@
               {{/if}}
             </span>
             {{#if this.key.fileName}}
-              {{! template-lint-configure no-nested-interactive "warn" }}
               <button type="button" class="file-delete-button" {{action "clearKey"}} data-test-pgp-clear={{true}}>
                 <Icon @name="x" aria-label="Close" />
               </button>
-              {{! template-lint-configure no-nested-interactive "on" }}
             {{/if}}
           </span>
-        </label>
+        </div>
       </div>
     </div>
     <p class="help has-text-grey">

--- a/ui/app/templates/components/pki/config-pki-ca.hbs
+++ b/ui/app/templates/components/pki/config-pki-ca.hbs
@@ -61,7 +61,7 @@
       </div>
     </div>
   {{else}}
-    <form {{action "saveCA" on="submit"}} data-test-generate-root-cert="true">
+    <form {{action "saveCA" on="submit"}} aria-label="ca form" data-test-generate-root-cert="true">
       <NamespaceReminder @mode="save" @noun="PKI change" />
       <FormFieldGroupsLoop @model={{this.model}} @mode={{this.mode}} />
       <div class="field is-grouped is-grouped-split box is-fullwidth is-bottomless">
@@ -136,7 +136,7 @@
     <h2 data-test-title class="title is-3">Sign intermediate</h2>
     <NamespaceReminder @mode="save" @noun="PKI change" />
     <MessageError @model={{this.model}} @errors={{this.errors}} />
-    <form {{action "saveCA" on="submit"}} data-test-sign-intermediate-form="true">
+    <form {{action "saveCA" on="submit"}} data-test-sign-intermediate-form="true" aria-label="sign intermediate form">
       <FormFieldGroupsLoop @model={{this.model}} @mode={{this.mode}} />
       <div class="field is-grouped box is-fullwidth is-bottomless">
         <div class="control">
@@ -164,7 +164,11 @@
   <p class="has-text-grey-dark">
     Submit a signed CA certificate corresponding to a generated private key.
   </p>
-  <form {{action "saveCA" "setSignedIntermediate" on="submit"}} data-test-set-signed-intermediate-form="true">
+  <form
+    {{action "saveCA" "setSignedIntermediate" on="submit"}}
+    aria-label="set signed intermediate form"
+    data-test-set-signed-intermediate-form="true"
+  >
     <div class="field">
       <label for="certificate" class="is-label">
         Signed Intermediate Certificate

--- a/ui/app/templates/components/raft-storage-overview.hbs
+++ b/ui/app/templates/components/raft-storage-overview.hbs
@@ -17,7 +17,7 @@
         <Chevron @direction="down" @isButton={{true}} />
       </D.Trigger>
       <D.Content @defaultClass="popup-menu-content">
-        <nav class="box menu">
+        <nav class="box menu" aria-label="snapshots actions">
           <ul class="menu-list">
             <li class="action">
               {{#if this.useServiceWorker}}
@@ -78,7 +78,7 @@
         <td class="middle no-padding has-text-right">
           <PopupMenu>
             <Confirm as |c|>
-              <nav>
+              <nav aria-label="remove peer">
                 <ul>
                   <li class="action">
                     <c.Message

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -1,5 +1,9 @@
 {{#if (eq @mode "create")}}
-  <form class={{if @showAdvancedMode "advanced-edit" "simple-edit"}} onsubmit={{action "createOrUpdateKey" @mode}}>
+  <form
+    class={{if @showAdvancedMode "advanced-edit" "simple-edit"}}
+    onsubmit={{action "createOrUpdateKey" @mode}}
+    aria-label="secret create form"
+  >
     <div class="field box is-fullwidth is-sideless is-marginless">
       <NamespaceReminder @mode="create" @noun="secret" />
       <MessageError @model={{@modelForData}} @errorMessage={{this.error}} />
@@ -149,7 +153,7 @@
 
 {{#if (eq @mode "edit")}}
   {{! no metadata option because metadata is version agnostic }}
-  <form onsubmit={{action "createOrUpdateKey" "edit"}}>
+  <form onsubmit={{action "createOrUpdateKey" "edit"}} aria-label="secret edit form">
     <div class="box is-sideless is-fullwidth is-marginless padding-top">
       <MessageError @model={{@modelForData}} @errorMessage={{this.error}} />
       {{#if (eq @canReadSecretData false)}}

--- a/ui/app/templates/components/text-file.hbs
+++ b/ui/app/templates/components/text-file.hbs
@@ -60,7 +60,7 @@
   {{else}}
     <div class="control is-expanded">
       <div class="file has-name is-fullwidth">
-        <label class="file-label">
+        <div class="file-label">
           <input class="file-input" type="file" {{on "change" this.pickedFile}} data-test-text-file-input={{true}} />
           <span class="file-cta button">
             <Icon @name="upload" class="has-light-grey-text" />
@@ -74,13 +74,11 @@
             {{/if}}
           </span>
           {{#if @file.fileName}}
-            {{! template-lint-configure no-nested-interactive "warn" }}
             <button type="button" class="file-delete-button" {{on "click" this.clearFile}} data-test-text-clear={{true}}>
               <Icon @name="x-circle" />
             </button>
-            {{! template-lint-configure no-nested-interactive "on" }}
           {{/if}}
-        </label>
+        </div>
       </div>
     </div>
     <p class="help has-text-grey">

--- a/ui/app/templates/components/transit-form-show.hbs
+++ b/ui/app/templates/components/transit-form-show.hbs
@@ -1,5 +1,5 @@
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
-  <nav class="tabs">
+  <nav class="tabs" aria-label="tabs">
     <ul>
       <li class={{if (eq @tab "actions") "is-active"}}>
         <SecretLink
@@ -147,7 +147,7 @@
           </div>
           <div class="column is-1 is-flex-end">
             <PopupMenu name="secret-menu">
-              <nav class="menu">
+              <nav class="menu" aria-label="copy public key">
                 <ul class="menu-list">
                   <li class="action">
                     <CopyButton

--- a/ui/app/templates/vault/cluster/access/identity/aliases/show.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/show.hbs
@@ -1,6 +1,6 @@
 <PageHeader as |p|>
   <p.top>
-    <nav class="breadcrumb">
+    <nav class="breadcrumb" aria-label="breadcrumbs">
       <ul>
         <li>
           <span class="sep">&#x0002f;</span>
@@ -18,7 +18,7 @@
   </p.levelLeft>
 </PageHeader>
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
-  <nav class="tabs sub-nav">
+  <nav class="tabs sub-nav" aria-label="tabs">
     <ul>
       {{#each (tabs-for-identity-show this.model.identityType) as |tab|}}
         <LinkTo @route="vault.cluster.access.identity.aliases.show" @models={{array this.model.id tab}}>

--- a/ui/app/templates/vault/cluster/access/identity/show.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/show.hbs
@@ -1,6 +1,6 @@
 <PageHeader as |p|>
   <p.top>
-    <nav class="breadcrumb">
+    <nav class="breadcrumb" aria-label="breadcrumbs">
       <ul>
         <li>
           <span class="sep">&#x0002f;</span>
@@ -18,7 +18,7 @@
   </p.levelLeft>
 </PageHeader>
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
-  <nav class="tabs sub-nav">
+  <nav class="tabs sub-nav" aria-label="tabs">
     <ul>
       {{#each (tabs-for-identity-show this.model.identityType this.model.type) as |tab|}}
         <LinkTo
@@ -34,7 +34,7 @@
 </div>
 <Toolbar>
   <ToolbarActions>
-    {{! template-lint-configure simple-unless "warn" }}
+    {{! template-lint-disable simple-unless }}
     {{#unless (or (and (eq this.model.identityType "group") (eq this.model.type "internal")) this.model.alias)}}
       <ToolbarLink
         @route="vault.cluster.access.identity.aliases.add"
@@ -45,6 +45,7 @@
         Add alias
       </ToolbarLink>
     {{/unless}}
+    {{! template-lint-enable simple-unless }}
     <ToolbarLink
       @route="vault.cluster.access.identity.edit"
       @models={{array (pluralize this.model.identityType) this.model.id}}

--- a/ui/app/templates/vault/cluster/access/leases/list.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/list.hbs
@@ -31,9 +31,9 @@
       @placeholder="Filter leases"
     />
     {{#if this.filterFocused}}
-      {{!template-lint-configure no-whitespace-for-layout "warn"}}
+      {{! template-lint-disable no-whitespace-for-layout }}
       &nbsp; &nbsp;
-      {{!template-lint-configure no-whitespace-for-layout "on"}}
+      {{! template-lint-enable no-whitespace-for-layout }}
       {{#if this.filterMatchesKey}}
         {{#unless this.filterIsFolder}}
           <p class="help has-text-grey is-size-8">

--- a/ui/app/templates/vault/cluster/access/mfa/methods/method/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/method/index.hbs
@@ -1,6 +1,6 @@
 <PageHeader as |p|>
   <p.top>
-    <nav class="breadcrumb">
+    <nav class="breadcrumb" aria-label="breadcrumbs">
       <ul>
         <li>
           <span class="sep">&#x0002f;</span>
@@ -20,7 +20,7 @@
 </PageHeader>
 
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
-  <nav class="tabs">
+  <nav class="tabs" aria-label="tabs">
     <ul>
       <LinkTo @route="vault.cluster.access.mfa.methods.method" @query={{hash tab="config"}} data-test-tab="config">
         Configuration

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -37,7 +37,7 @@
       <Li.menu>
         <PopupMenu @name="engine-menu">
           <Confirm as |c|>
-            <nav class="menu">
+            <nav class="menu" aria-label="supported secrets engine menu">
               <ul class="menu-list">
                 <li class="action">
                   <LinkTo @route="vault.cluster.secrets.backend.configuration" @model={{backend.id}}>
@@ -85,7 +85,7 @@
     <Li.menu>
       <PopupMenu name="engine-menu">
         <Confirm as |c|>
-          <nav class="menu">
+          <nav class="menu" aria-label="unsupported secrets engine menu">
             <ul class="menu-list">
               <li class="action">
                 <LinkTo @route="vault.cluster.secrets.backend.configuration" @model={{backend.id}} data-test-engine-config>

--- a/ui/lib/core/addon/templates/components/masked-input.hbs
+++ b/ui/lib/core/addon/templates/components/masked-input.hbs
@@ -19,6 +19,7 @@
       data-test-input
     />
   {{else}}
+    {{! template-lint-disable no-down-event-binding }}
     <textarea
       class="input masked-value {{unless this.showValue 'masked-font'}}"
       rows={{1}}
@@ -30,6 +31,7 @@
       spellcheck="false"
       data-test-textarea
     ></textarea>
+    {{! template-lint-enable no-down-event-binding }}
   {{/if}}
   {{#if this.allowCopy}}
     <CopyButton

--- a/ui/lib/core/addon/templates/components/navigate-input.hbs
+++ b/ui/lib/core/addon/templates/components/navigate-input.hbs
@@ -1,5 +1,6 @@
 <div class="field" data-test-nav-input>
   <p class="control has-icons-left">
+    {{! template-lint-disable no-down-event-binding }}
     <input
       class="filter input"
       disabled={{this.disabled}}
@@ -13,6 +14,7 @@
       onfocus={{action "setFilterFocused" true}}
       onblur={{action "setFilterFocused" false}}
     />
+    {{! template-lint-enable no-down-event-binding }}
     <Icon @name="search" class="search-icon has-text-grey-light" />
   </p>
 </div>

--- a/ui/lib/core/addon/templates/components/shamir-flow.hbs
+++ b/ui/lib/core/addon/templates/components/shamir-flow.hbs
@@ -47,7 +47,7 @@
     </button>
   </div>
 {{else if (and this.generateAction (not this.started))}}
-  <form {{action "startGenerate" (hash pgp_key=this.pgp_key) on="submit"}} id="shamir">
+  <form {{action "startGenerate" (hash pgp_key=this.pgp_key) on="submit"}} id="shamir" aria-label="shamir generate form">
     <MessageError @errors={{this.errors}} />
     {{#if (eq this.generateStep "chooseMethod")}}
       <div class="box is-marginless is-shadowless">
@@ -128,7 +128,7 @@
     {{/if}}
   </form>
 {{else}}
-  <form {{action "onSubmit" (hash key=this.key) on="submit"}} id="shamir">
+  <form {{action "onSubmit" (hash key=this.key) on="submit"}} id="shamir" aria-label="shamir form">
     <div class="box is-shadowless">
       {{#if this.errors}}
         <div class="box is-shadowless is-marginless no-padding-top is-fullwidth">

--- a/ui/lib/core/addon/templates/components/shamir-modal-flow.hbs
+++ b/ui/lib/core/addon/templates/components/shamir-modal-flow.hbs
@@ -75,7 +75,7 @@
         </button>
       </div>
     {{else if (and this.generateAction (not this.started))}}
-      <form {{action "startGenerate" (hash pgp_key=this.pgp_key) on="submit"}} id="shamir">
+      <form {{action "startGenerate" (hash pgp_key=this.pgp_key) on="submit"}} id="shamir" aria-label="shamir generate form">
         <MessageError @errors={{this.errors}} />
         {{#if (eq this.generateStep "chooseMethod")}}
           <div class="has-bottom-margin-m" data-test-shamir-modal-body>
@@ -151,7 +151,7 @@
         {{/if}}
       </form>
     {{else}}
-      <form {{action "onSubmit" (hash key=this.key) on="submit"}} id="shamir">
+      <form {{action "onSubmit" (hash key=this.key) on="submit"}} id="shamir" aria-label="shamir form">
         <div class="has-bottom-margin-m">
           {{#if this.errors}}
             <div class="box is-shadowless is-marginless no-padding-top is-fullwidth">

--- a/ui/lib/replication/addon/templates/components/replication-summary.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-summary.hbs
@@ -1,5 +1,4 @@
-{{! template-lint-configure simple-unless "warn" }}
-{{#unless (has-feature "DR Replication")}}
+{{#if (not (has-feature "DR Replication"))}}
   <UpgradePage @title="Replication" />
 {{else if (or this.cluster.allReplicationDisabled this.cluster.replicationAttrs.replicationDisabled)}}
   <PageHeader as |p|>
@@ -49,15 +48,15 @@
             <Icon @size="24" @name="replication-perf" />
             Performance Replication
           </h3>
-          {{#unless (has-feature "Performance Replication")}}
-            <p class="help has-text-grey-dark">
-              Performance Replication is a feature of Vault Enterprise Premium
-            </p>
-          {{else}}
+          {{#if (has-feature "Performance Replication")}}
             <p class="help has-text-grey-dark">
               {{replication-mode-description "performance"}}
             </p>
-          {{/unless}}
+          {{else}}
+            <p class="help has-text-grey-dark">
+              Performance Replication is a feature of Vault Enterprise Premium
+            </p>
+          {{/if}}
         {{/if}}
       {{else}}
         <p class="has-text-grey-dark box is-shadowless is-fullwidth has-slim-padding">
@@ -212,9 +211,9 @@
             <div class="field">
               <label for="primary_api_addr" class="is-label">
                 Primary API address
-                {{#unless (and this.token (not this.tokenIncludesAPIAddr))}}
+                {{#if (not (and this.token (not this.tokenIncludesAPIAddr)))}}
                   <em class="is-optional">(optional)</em>
-                {{/unless}}
+                {{/if}}
               </label>
               <div class="control">
                 <Input @value={{this.primary_api_addr}} id="primary_api_addr" name="primary_api_addr" class="input" />
@@ -288,7 +287,7 @@
     {{/if}}
   </form>
 {{else if this.showModeSummary}}
-  {{#unless (and this.cluster.dr.replicationEnabled this.cluster.performance.replicationEnabled)}}
+  {{#if (not (and this.cluster.dr.replicationEnabled this.cluster.performance.replicationEnabled))}}
     <PageHeader as |p|>
       <p.levelLeft>
         <h1 class="title is-3">
@@ -296,7 +295,7 @@
         </h1>
       </p.levelLeft>
     </PageHeader>
-  {{/unless}}
+  {{/if}}
 
   {{#if (and (eq this.cluster.dr.mode "primary") (eq this.cluster.performance.mode "primary"))}}
     <ReplicationPage @model={{this.cluster}} as |Page|>
@@ -324,7 +323,7 @@
         <ReplicationModeSummary @mode="dr" @cluster={{this.cluster}} @tagName="div" />
       {{/if}}
     </div>
-    {{#unless (and this.submit.isRunning (eq this.cluster.dr.mode "bootstrapping"))}}
+    {{#if (not (and this.submit.isRunning (eq this.cluster.dr.mode "bootstrapping")))}}
       <div class="box is-bottomless is-fullwidth is-marginless">
         <h3 class="title is-flex-center is-5 is-marginless">
           <Icon @size="24" @name="replication-perf" />
@@ -334,7 +333,7 @@
           <ReplicationModeSummary @mode="performance" @cluster={{this.cluster}} @tagName="span" />
         </LinkTo>
       </div>
-    {{/unless}}
+    {{/if}}
   {{/if}}
 {{else}}
   {{#if (eq this.replicationAttrs.mode "initializing")}}
@@ -373,4 +372,4 @@
       </ReplicationPage>
     </div>
   {{/if}}
-{{/unless}}
+{{/if}}

--- a/ui/lib/replication/addon/templates/mode.hbs
+++ b/ui/lib/replication/addon/templates/mode.hbs
@@ -1,7 +1,7 @@
 <section class="section">
   <div class="container is-widescreen">
     {{#if (and (eq this.model.drMode "secondary") (eq this.model.drModeInit "primary"))}}
-      <nav class="navbar"></nav>
+      <nav class="navbar" aria-label="loading nav"></nav>
       <LayoutLoading />
     {{else}}
       {{#if this.model.replicationAttrs.replicationEnabled}}


### PR DESCRIPTION
There were no new template lint errors after the Ember 4.4 upgrade but warnings left over from the previous upgrade were cleaned up. 