### PR TITLE
Don't allow write perms to plugins in test

### DIFF
--- a/vault/external_plugin_test.go
+++ b/vault/external_plugin_test.go
@@ -139,7 +139,7 @@ func compilePlugin(t *testing.T, typ consts.PluginType, pluginVersion string, pl
 	// write the cached plugin if necessary
 	var err error
 	if _, err := os.Stat(pluginPath); os.IsNotExist(err) {
-		err = os.WriteFile(pluginPath, pluginBytes, 0o777)
+		err = os.WriteFile(pluginPath, pluginBytes, 0o755)
 	}
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
We are specifically checking that the writes are now allowed for group and other.

I don't know how this test was passing on non-arm64 platforms, but hopefully this should fix it.