### PR TITLE
Better docs on PKI key stuff

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -578,7 +578,7 @@ when signing an externally-owned intermediate.
 - `signature_bits` `(int: 0)` - Specifies the number of bits to use in
   the signature algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384,
   and 512 for SHA-2-512. Defaults to 0 to automatically detect based
-  on key length (SHA-2-256 for RSA keys, and matching the curve size
+  on issuer's key length (SHA-2-256 for RSA keys, and matching the curve size
   for NIST P-Curves).
 
 ~> **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
@@ -782,7 +782,7 @@ have access.**
 - `signature_bits` `(int: 0)` - Specifies the number of bits to use in
   the signature algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384,
   and 512 for SHA-2-512. Defaults to 0 to automatically detect based
-  on key length (SHA-2-256 for RSA keys, and matching the curve size
+  on issuer's key length (SHA-2-256 for RSA keys, and matching the curve size
   for NIST P-Curves).
 
 ~> **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
@@ -1768,7 +1768,7 @@ generated depending on the `type` request parameter.
 - `signature_bits` `(int: 0)` - Specifies the number of bits to use in
   the signature algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384,
   and 512 for SHA-2-512. Defaults to 0 to automatically detect based
-  on key length (SHA-2-256 for RSA keys, and matching the curve size
+  on issuer's key length (SHA-2-256 for RSA keys, and matching the curve size
   for NIST P-Curves).
 
 ~> **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
@@ -2649,7 +2649,7 @@ request is denied.
 - `signature_bits` `(int: 0)` - Specifies the number of bits to use in
   the signature algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384,
   and 512 for SHA-2-512. Defaults to 0 to automatically detect based
-  on key length (SHA-2-256 for RSA keys, and matching the curve size
+  on issuer's key length (SHA-2-256 for RSA keys, and matching the curve size
   for NIST P-Curves).
 
 ~> **Note**: ECDSA and Ed25519 issuers do not follow configuration of the

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -2635,6 +2635,8 @@ request is denied.
   Currently, `rsa`, `ec`, and `ed25519` are supported, or when signing
   existing CSRs, `any` can be specified to allow keys of either type
   and with any bit size (subject to >=2048 bits for RSA keys or >= 224 for EC keys).
+  When `any` is used, this role cannot generate certificates and can only
+  be used to sign CSRs.
 
 ~> **Note**: In FIPS 140-2 mode, the following algorithms are not certified
    and thus should not be used: `ed25519`.


### PR DESCRIPTION
Addresses two feedback items on API docs: 

 - `signature_bits` applies relative to the _issuer's_ key type.
 - `key_type=any` doesn't allow generation of keys/certs, only allows signing arbitrary CSRs.