### PR TITLE
Add crl integraiton to tests

### DIFF
--- a/builtin/logical/pkiext/nginx_test.go
+++ b/builtin/logical/pkiext/nginx_test.go
@@ -486,7 +486,7 @@ func RunNginxRootTest(t *testing.T, caKeyType string, caKeyBits int, caUsePSS bo
 	requireSuccessNonNilResponse(t, resp, err, "failed to create client leaf cert")
 	clientCert := resp.Data["certificate"].(string)
 	clientKey := resp.Data["private_key"].(string) + "\n"
-	clientFullChain := clientCert + "\n" + resp.Data["issuing_ca"].(string) + "\n"
+	clientWireChain := clientCert + "\n" + resp.Data["issuing_ca"].(string) + "\n"
 	clientTrustChain := resp.Data["issuing_ca"].(string) + "\n" + rootCert + "\n"
 	clientCAChain := resp.Data["ca_chain"].([]string)
 
@@ -570,7 +570,7 @@ func RunNginxRootTest(t *testing.T, caKeyType string, caKeyBits int, caUsePSS bo
 
 	// Ensure we can connect with wget/curl.
 	CheckWithClients(t, networkName, networkAddr, containerURL, rootCert, "", "")
-	CheckWithClients(t, networkName, networkAddr, containerProtectedURL, clientTrustChain, clientFullChain, clientKey)
+	CheckWithClients(t, networkName, networkAddr, containerProtectedURL, clientTrustChain, clientWireChain, clientKey)
 
 	// Ensure OpenSSL will validate the delta CRL by revoking our server leaf
 	// and then using it with wget2. This will land on the intermediate's

--- a/builtin/logical/pkiext/test_helpers.go
+++ b/builtin/logical/pkiext/test_helpers.go
@@ -1,10 +1,15 @@
 package pkiext
 
 import (
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/logical"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,6 +44,15 @@ func requireSuccessNilResponse(t *testing.T, resp *logical.Response, err error, 
 		msg := fmt.Sprintf("expected nil response but got: %v", resp)
 		require.Nilf(t, resp, msg, msgAndArgs...)
 	}
+}
+
+func parseCert(t *testing.T, pemCert string) *x509.Certificate {
+	block, _ := pem.Decode([]byte(pemCert))
+	require.NotNil(t, block, "failed to decode PEM block")
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	return cert
 }
 
 func parseKey(t *testing.T, pemKey string) crypto.Signer {

--- a/builtin/logical/pkiext/test_helpers.go
+++ b/builtin/logical/pkiext/test_helpers.go
@@ -40,3 +40,12 @@ func requireSuccessNilResponse(t *testing.T, resp *logical.Response, err error, 
 		require.Nilf(t, resp, msg, msgAndArgs...)
 	}
 }
+
+func parseKey(t *testing.T, pemKey string) crypto.Signer {
+	block, _ := pem.Decode([]byte(pemKey))
+	require.NotNil(t, block, "failed to decode PEM block")
+
+	key, _, err := certutil.ParseDERKey(block.Bytes)
+	require.NoError(t, err)
+	return key
+}


### PR DESCRIPTION
~Blocked on #17320 -- will be rebased once that merges.~

---

This adds tests for CRL status in the integration tests. It appears that `wget2` might have support for Delta CRLs enabled already, so we might try that.