### PR TITLE
Plugins: Add -version flag to 'vault plugin info'

### DIFF
--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -133,7 +133,8 @@ type GetPluginInput struct {
 	Name string `json:"-"`
 
 	// Type of the plugin. Required.
-	Type consts.PluginType `json:"type"`
+	Type    consts.PluginType `json:"type"`
+	Version string            `json:"version"`
 }
 
 // GetPluginResponse is the response from the GetPlugin call.
@@ -144,6 +145,7 @@ type GetPluginResponse struct {
 	Name              string   `json:"name"`
 	SHA256            string   `json:"sha256"`
 	DeprecationStatus string   `json:"deprecation_status,omitempty"`
+	Version           string   `json:"version,omitempty"`
 }
 
 // GetPlugin wraps GetPluginWithContext using context.Background.
@@ -158,6 +160,9 @@ func (c *Sys) GetPluginWithContext(ctx context.Context, i *GetPluginInput) (*Get
 
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodGet, path)
+	if i.Version != "" {
+		req.Params.Set("version", i.Version)
+	}
 
 	resp, err := c.c.rawRequestWithContext(ctx, req)
 	if err != nil {

--- a/api/sys_plugins_test.go
+++ b/api/sys_plugins_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -114,6 +115,141 @@ func TestListPlugins(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPlugin(t *testing.T) {
+	for name, tc := range map[string]struct {
+		version  string
+		body     string
+		expected GetPluginResponse
+	}{
+		"builtin": {
+			body: getResponse,
+			expected: GetPluginResponse{
+				Args:              nil,
+				Builtin:           true,
+				Command:           "",
+				Name:              "azure",
+				SHA256:            "",
+				DeprecationStatus: "supported",
+				Version:           "v0.14.0+builtin",
+			},
+		},
+		"external": {
+			version: "v1.0.0",
+			body:    getResponseExternal,
+			expected: GetPluginResponse{
+				Args:              []string{},
+				Builtin:           false,
+				Command:           "azure-plugin",
+				Name:              "azure",
+				SHA256:            "8ba442dba253803685b05e35ad29dcdebc48dec16774614aa7a4ebe53c1e90e1",
+				DeprecationStatus: "",
+				Version:           "v1.0.0",
+			},
+		},
+		"old server": {
+			body: getResponseOldServerVersion,
+			expected: GetPluginResponse{
+				Args:              nil,
+				Builtin:           true,
+				Command:           "",
+				Name:              "azure",
+				SHA256:            "",
+				DeprecationStatus: "",
+				Version:           "",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			mockVaultServer := httptest.NewServer(http.HandlerFunc(mockVaultHandlerInfo(tc.body)))
+			defer mockVaultServer.Close()
+
+			cfg := DefaultConfig()
+			cfg.Address = mockVaultServer.URL
+			client, err := NewClient(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			input := GetPluginInput{
+				Name: "azure",
+				Type: consts.PluginTypeSecrets,
+			}
+			if tc.version != "" {
+				input.Version = tc.version
+			}
+
+			info, err := client.Sys().GetPluginWithContext(context.Background(), &input)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(tc.expected, *info) {
+				t.Errorf("expected: %#v\ngot: %#v", tc.expected, info)
+			}
+		})
+	}
+}
+
+func mockVaultHandlerInfo(body string) func(w http.ResponseWriter, _ *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+const getResponse = `{
+    "request_id": "e93d3f93-8e4f-8443-a803-f1c97c495241",
+    "lease_id": "",
+    "renewable": false,
+    "lease_duration": 0,
+    "data": {
+        "args": null,
+        "builtin": true,
+        "command": "",
+        "deprecation_status": "supported",
+        "name": "azure",
+        "sha256": "",
+        "version": "v0.14.0+builtin"
+    },
+    "wrap_info": null,
+    "warnings": null,
+    "auth": null
+}`
+
+const getResponseExternal = `{
+    "request_id": "e93d3f93-8e4f-8443-a803-f1c97c495241",
+    "lease_id": "",
+    "renewable": false,
+    "lease_duration": 0,
+    "data": {
+        "args": [],
+        "builtin": false,
+        "command": "azure-plugin",
+        "name": "azure",
+        "sha256": "8ba442dba253803685b05e35ad29dcdebc48dec16774614aa7a4ebe53c1e90e1",
+        "version": "v1.0.0"
+    },
+    "wrap_info": null,
+    "warnings": null,
+    "auth": null
+}`
+
+const getResponseOldServerVersion = `{
+    "request_id": "e93d3f93-8e4f-8443-a803-f1c97c495241",
+    "lease_id": "",
+    "renewable": false,
+    "lease_duration": 0,
+    "data": {
+        "args": null,
+        "builtin": true,
+        "command": "",
+        "name": "azure",
+        "sha256": ""
+    },
+    "wrap_info": null,
+    "warnings": null,
+    "auth": null
+}`
 
 func mockVaultHandlerList(w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write([]byte(listUntypedResponse))

--- a/command/plugin_deregister_test.go
+++ b/command/plugin_deregister_test.go
@@ -84,7 +84,7 @@ func TestPluginDeregisterCommand_Run(t *testing.T) {
 		defer closer()
 
 		pluginName := "my-plugin"
-		_, sha256Sum := testPluginCreateAndRegister(t, client, pluginDir, pluginName, consts.PluginTypeCredential)
+		_, sha256Sum := testPluginCreateAndRegister(t, client, pluginDir, pluginName, consts.PluginTypeCredential, "")
 
 		ui, cmd := testPluginDeregisterCommand(t)
 		cmd.client = client

--- a/command/plugin_info.go
+++ b/command/plugin_info.go
@@ -17,6 +17,8 @@ var (
 
 type PluginInfoCommand struct {
 	*BaseCommand
+
+	flagVersion string
 }
 
 func (c *PluginInfoCommand) Synopsis() string {
@@ -41,7 +43,18 @@ Usage: vault plugin info [options] TYPE NAME
 }
 
 func (c *PluginInfoCommand) Flags() *FlagSets {
-	return c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat)
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat)
+
+	f := set.NewFlagSet("Command Options")
+
+	f.StringVar(&StringVar{
+		Name:       "version",
+		Target:     &c.flagVersion,
+		Completion: complete.PredictAnything,
+		Usage:      "Semantic version of the plugin. Optional.",
+	})
+
+	return set
 }
 
 func (c *PluginInfoCommand) AutocompleteArgs() complete.Predictor {
@@ -93,8 +106,9 @@ func (c *PluginInfoCommand) Run(args []string) int {
 	pluginName := strings.TrimSpace(pluginNameRaw)
 
 	resp, err := client.Sys().GetPlugin(&api.GetPluginInput{
-		Name: pluginName,
-		Type: pluginType,
+		Name:    pluginName,
+		Type:    pluginType,
+		Version: c.flagVersion,
 	})
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error reading plugin named %s: %s", pluginName, err))
@@ -113,6 +127,7 @@ func (c *PluginInfoCommand) Run(args []string) int {
 		"name":               resp.Name,
 		"sha256":             resp.SHA256,
 		"deprecation_status": resp.DeprecationStatus,
+		"version":            resp.Version,
 	}
 
 	if c.flagField != "" {

--- a/command/plugin_reload_test.go
+++ b/command/plugin_reload_test.go
@@ -90,7 +90,7 @@ func TestPluginReloadCommand_Run(t *testing.T) {
 		defer closer()
 
 		pluginName := "my-plugin"
-		_, sha256Sum := testPluginCreateAndRegister(t, client, pluginDir, pluginName, consts.PluginTypeCredential)
+		_, sha256Sum := testPluginCreateAndRegister(t, client, pluginDir, pluginName, consts.PluginTypeCredential, "")
 
 		ui, cmd := testPluginReloadCommand(t)
 		cmd.client = client

--- a/command/plugin_test.go
+++ b/command/plugin_test.go
@@ -38,7 +38,7 @@ func testPluginCreate(tb testing.TB, dir, name string) (string, string) {
 }
 
 // testPluginCreateAndRegister creates a plugin and registers it in the catalog.
-func testPluginCreateAndRegister(tb testing.TB, client *api.Client, dir, name string, pluginType consts.PluginType) (string, string) {
+func testPluginCreateAndRegister(tb testing.TB, client *api.Client, dir, name string, pluginType consts.PluginType, version string) (string, string) {
 	tb.Helper()
 
 	pth, sha256Sum := testPluginCreate(tb, dir, name)
@@ -48,6 +48,7 @@ func testPluginCreateAndRegister(tb testing.TB, client *api.Client, dir, name st
 		Type:    pluginType,
 		Command: name,
 		SHA256:  sha256Sum,
+		Version: version,
 	}); err != nil {
 		tb.Fatal(err)
 	}


### PR DESCRIPTION
Adds `-version` flag for querying, and reported version to output:

Versioned plugin:

```shell-session
$ vault plugin info -version=1.0.0 secret consul
Key                   Value
---                   -----
args                  []
builtin               false
command               vault-plugin-secrets-consul-1
deprecation_status    n/a
name                  consul
sha256                1684ab47eae06ec5dc6e17089f2ce669b6bbd30e6b9c9670692a5bb2e37eb4db
version               v1.0.0
```

Builtin plugin:
```shell-session
$ vault plugin info secret azure
Key                   Value
---                   -----
args                  []
builtin               true
command               n/a
deprecation_status    supported
name                  azure
sha256                n/a
version               v0.14.0+builtin
```

Unversioned plugin:

```shell-session
$ vault plugin info auth kubernetes
Key                   Value
---                   -----
args                  []
builtin               false
command               vault-plugin-auth-kubernetes
deprecation_status    n/a
name                  kubernetes
sha256                04ce575260fa3a2cfc477d13ac327108c50838a03917ec4d6df38ecdc64452d1
version               n/a
```