### PR TITLE
Add 'note' for surpassing dead server threshold time

### DIFF
--- a/website/content/docs/commands/operator/raft.mdx
+++ b/website/content/docs/commands/operator/raft.mdx
@@ -325,8 +325,10 @@ Flags applicable to this command are the following:
   go without leader contact before being considered unhealthy. Defaults to `10s`.
 
 - `dead-server-last-contact-threshold` `(string)` - Limit on the amount of time
-  a server can go without leader contact before being considered failed. This
-  takes effect only when `cleanup_dead_servers` is set. Defaults to `24h`.
+  a server can go without leader contact before being considered failed.
+  This takes effect only when `cleanup_dead_servers` is set as `true`. Defaults to `24h`.
+  
+  -> **Note:** A failed server cannot rejoin the cluster without being reinitialized.  
 
 - `max-trailing-logs` `(int)` - Amount of entries in the Raft Log that a server
   can be behind before being considered unhealthy. Defaults to `1000`.

--- a/website/content/docs/commands/operator/raft.mdx
+++ b/website/content/docs/commands/operator/raft.mdx
@@ -328,7 +328,7 @@ Flags applicable to this command are the following:
   a server can go without leader contact before being considered failed.
   This takes effect only when `cleanup_dead_servers` is set as `true`. Defaults to `24h`.
   
-  -> **Note:** A failed server cannot rejoin the cluster without being reinitialized.  
+  -> **Note:** A failed server that autopilot has removed from the raft configuration cannot rejoin the cluster without being reinitialized.  
 
 - `max-trailing-logs` `(int)` - Amount of entries in the Raft Log that a server
   can be behind before being considered unhealthy. Defaults to `1000`.


### PR DESCRIPTION
Clarify in `docs` that if a server surpasses the `dead-server-last-contact-threshold` then it cannot rejoin the cluster without being reinitialized.