### PR TITLE
Fix off by one err in current month client count computation

### DIFF
--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -74,7 +74,7 @@ func (a *ActivityLog) computeCurrentMonthForBillingPeriodInternal(ctx context.Co
 		if len(monthlyComputation) > 1 {
 			a.logger.Warn("monthly in-memory activitylog computation returned multiple months of data", "months returned", len(byMonth))
 		}
-		if len(monthlyComputation) >= 0 {
+		if len(monthlyComputation) > 0 {
 			return monthlyComputation[0], nil
 		}
 	}

--- a/vault/activity_log_util_common_test.go
+++ b/vault/activity_log_util_common_test.go
@@ -125,4 +125,28 @@ func Test_ActivityLog_ComputeCurrentMonthForBillingPeriodInternal(t *testing.T) 
 	if monthRecord.NewClients.Counts.NonEntityClients != 4 {
 		t.Fatalf("wrong number of new non entity clients. Expected 4, got %d", monthRecord.NewClients.Counts.NonEntityClients)
 	}
+
+	// Attempt to compute current month when no records exist
+	endTime = time.Now().UTC()
+	startTime = timeutil.StartOfMonth(endTime)
+	emptyClientsMap := make(map[int64]*processMonth, 0)
+	monthRecord, err = a.computeCurrentMonthForBillingPeriodInternal(context.Background(), emptyClientsMap, mockHLLGetFunc, startTime, endTime)
+	if err != nil {
+		t.Fatalf("failed to compute empty current month, err: %v", err)
+	}
+
+	// We should have 0 entity clients, nonentity clients,new entity clients
+	// and new nonentity clients
+	if monthRecord.Counts.EntityClients != 0 {
+		t.Fatalf("wrong number of entity clients. Expected 0, got %d", monthRecord.Counts.EntityClients)
+	}
+	if monthRecord.Counts.NonEntityClients != 0 {
+		t.Fatalf("wrong number of non entity clients. Expected 0, got %d", monthRecord.Counts.NonEntityClients)
+	}
+	if monthRecord.NewClients.Counts.EntityClients != 0 {
+		t.Fatalf("wrong number of new entity clients. Expected 0, got %d", monthRecord.NewClients.Counts.EntityClients)
+	}
+	if monthRecord.NewClients.Counts.NonEntityClients != 0 {
+		t.Fatalf("wrong number of new non entity clients. Expected 0, got %d", monthRecord.NewClients.Counts.NonEntityClients)
+	}
 }


### PR DESCRIPTION
Vault will panic when requesting the current month's client counts if no records exist.

To reproduce, make a request to `/sys/internal/counters/activity` with `start_time` and `end_time` values that fall within the current month. Example:

```
curl -H "X-Vault-Token: $VAULT_TOKEN" "$VAULT_ADDR/v1/sys/internal/counters/activity?end_time=2022-10-06T00:00:00Z&start_time=2022-10-01T00:00:00Z"
```

This will produce the following panic:
```
2022-10-07T10:11:59.672-0400 [INFO]  http: panic serving 127.0.0.1:51376: runtime error: index out of range [0] with length 0
goroutine 799 [running]:
net/http.(*conn).serve.func1()
        /usr/local/go/src/net/http/server.go:1850 +0xbf
panic({0x6018460, 0xc001392f18})
        /usr/local/go/src/runtime/panic.go:890 +0x262
github.com/hashicorp/vault/vault.(*ActivityLog).computeCurrentMonthForBillingPeriodInternal(0xc000c0a000, {0x6fe4c50, 0xc00139de90}, 0xc0013b4480, 0xc00132df8
0, {0xc0018641e0?, 0x0?, 0x0?}, {0x0, 0xedaf2587f, ...})
        /Users/ccapurso/git/vault/vault/activity_log_util_common.go:78 +0x288
github.com/hashicorp/vault/vault.(*ActivityLog).computeCurrentMonthForBillingPeriod(...)
        /Users/ccapurso/git/vault/vault/activity_log_util_common.go:21
github.com/hashicorp/vault/vault.(*ActivityLog).handleQuery(0xc000c0a000, {0x6fe4c50, 0xc00139de90}, {0x19cd871?, 0xc00132e0d0?, 0x0?}, {0xc00101a745?, 0xc000
da3a90?, 0x0?}, 0x0)
        /Users/ccapurso/git/vault/vault/activity_log.go:1596 +0x752
github.com/hashicorp/vault/vault.(*SystemBackend).handleClientMetricQuery(0x0?, {0x6fe4c50, 0xc00139de90}, 0x0?, 0xffffffffffffffff?)
        /Users/ccapurso/git/vault/vault/logical_system_activity.go:211 +0x205
github.com/hashicorp/vault/sdk/framework.(*Backend).HandleRequest(0xc0002189a0, {0x6fe4c50, 0xc00139de90}, 0xc00102af00)
        /Users/ccapurso/git/vault/sdk/framework/backend.go:291 +0xa82
github.com/hashicorp/vault/vault.(*Router).routeCommon(0xc000114280, {0x6fe4c50, 0xc00139de90}, 0xc00102af00, 0x0)
        /Users/ccapurso/git/vault/vault/router.go:727 +0x160b
github.com/hashicorp/vault/vault.(*Router).Route(...)
        /Users/ccapurso/git/vault/vault/router.go:507
github.com/hashicorp/vault/vault.(*Core).doRouting(0xc000c32000?, {0x6fe4c50?, 0xc00139de90?}, 0xc00139da40?)
        /Users/ccapurso/git/vault/vault/request_handling.go:817 +0x2c
github.com/hashicorp/vault/vault.(*Core).handleRequest(0xc000c32000, {0x6fe4c50, 0xc00139de90}, 0xc00102af00)
        /Users/ccapurso/git/vault/vault/request_handling.go:1008 +0x11da
github.com/hashicorp/vault/vault.(*Core).handleCancelableRequest(0xc000c32000, {0x6fe4c50, 0xc00139db00}, 0xc00102af00)
        /Users/ccapurso/git/vault/vault/request_handling.go:665 +0x1545
github.com/hashicorp/vault/vault.(*Core).switchedLockHandleRequest(0xc000c32000, {0x6fe4c50, 0xc00139d2c0}, 0xc00102af00, 0x60?)
        /Users/ccapurso/git/vault/vault/request_handling.go:472 +0x539
github.com/hashicorp/vault/vault.(*Core).HandleRequest(...)
        /Users/ccapurso/git/vault/vault/request_handling.go:433
github.com/hashicorp/vault/http.request(0x5e6b760?, {0x6fd38d8, 0xc00139d1d0}, 0xc001134d00, 0xc00102af00?)
        /Users/ccapurso/git/vault/http/handler.go:910 +0x86
github.com/hashicorp/vault/http.handleLogicalInternal.func1({0x6fd38d8, 0xc00139d1d0}, 0xc001134d00)
        /Users/ccapurso/git/vault/http/logical.go:354 +0xb6
net/http.HandlerFunc.ServeHTTP(0xc00101a704?, {0x6fd38d8?, 0xc00139d1d0?}, 0xc000877240?)
        /usr/local/go/src/net/http/server.go:2109 +0x2f
github.com/hashicorp/vault/http.handleRequestForwarding.func1({0x6fd38d8, 0xc00139d1d0}, 0xc001134d00)
        /Users/ccapurso/git/vault/http/handler.go:835 +0x39d
net/http.HandlerFunc.ServeHTTP(0xc00135d398?, {0x6fd38d8?, 0xc00139d1d0?}, 0xc00101a727?)
        /usr/local/go/src/net/http/server.go:2109 +0x2f
net/http.(*ServeMux).ServeHTTP(0x5f43820?, {0x6fd38d8, 0xc00139d1d0}, 0xc001134d00)
        /usr/local/go/src/net/http/server.go:2487 +0x149
github.com/hashicorp/vault/http.wrapHelpHandler.func1({0x6fd38d8, 0xc00139d1d0}, 0xc001134d00)
        /Users/ccapurso/git/vault/http/help.go:25 +0x129
net/http.HandlerFunc.ServeHTTP(0xc000569dc0?, {0x6fd38d8?, 0xc00139d1d0?}, 0x2526960?)
        /usr/local/go/src/net/http/server.go:2109 +0x2f
github.com/hashicorp/vault/http.wrapCORSHandler.func1({0x6fd38d8?, 0xc00139d1d0?}, 0xc00135d510?)
        /Users/ccapurso/git/vault/http/cors.go:29 +0x1e5
net/http.HandlerFunc.ServeHTTP(0xc000c32000?, {0x6fd38d8?, 0xc00139d1d0?}, 0xc0001f4840?)
        /usr/local/go/src/net/http/server.go:2109 +0x2f
github.com/hashicorp/vault/http.rateLimitQuotaWrapping.func1({0x6fd38d8, 0xc00139d1d0}, 0xc001134d00)
        /Users/ccapurso/git/vault/http/util.go:110 +0xc30
net/http.HandlerFunc.ServeHTTP(0xc00139d110?, {0x6fd38d8?, 0xc00139d1d0?}, 0xc0013a4350?)
        /usr/local/go/src/net/http/server.go:2109 +0x2f
github.com/hashicorp/vault/http.wrapGenericHandler.func1({0x6fe2218?, 0xc000aa2620}, 0xc001134a00)
        /Users/ccapurso/git/vault/http/handler.go:422 +0xdb3
net/http.HandlerFunc.ServeHTTP(0xc00101a704?, {0x6fe2218?, 0xc000aa2620?}, 0x10a41c0?)
        /usr/local/go/src/net/http/server.go:2109 +0x2f
github.com/hashicorp/go-cleanhttp.PrintablePathCheckHandler.func1({0x6fe2218, 0xc000aa2620}, 0xc001134a00)
        /Users/ccapurso/go/pkg/mod/github.com/hashicorp/go-cleanhttp@v0.5.2/handlers.go:42 +0x93
net/http.HandlerFunc.ServeHTTP(0xc00101a727?, {0x6fe2218?, 0xc000aa2620?}, 0x1069f4e?)
        /usr/local/go/src/net/http/server.go:2109 +0x2f
net/http.serverHandler.ServeHTTP({0xc00139d0b0?}, {0x6fe2218, 0xc000aa2620}, 0xc001134a00)
        /usr/local/go/src/net/http/server.go:2947 +0x30c
net/http.(*conn).serve(0xc000233a40, {0x6fe4c50, 0xc0006780f0})
        /usr/local/go/src/net/http/server.go:1991 +0x607
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:3102 +0x4db
```