### PR TITLE
VAULT-8719 Support data array for alias clash error response so UI/machines can understand error

### DIFF
--- a/changelog/17459.txt
+++ b/changelog/17459.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/identity: Add machine-readable output to body of response upon alias clash during entity merge
+```

--- a/http/handler.go
+++ b/http/handler.go
@@ -1178,6 +1178,10 @@ func respondError(w http.ResponseWriter, status int, err error) {
 	logical.RespondError(w, status, err)
 }
 
+func respondErrorAndData(w http.ResponseWriter, status int, data interface{}, err error) {
+	logical.RespondErrorAndData(w, status, data, err)
+}
+
 func respondErrorCommon(w http.ResponseWriter, req *logical.Request, resp *logical.Response, err error) bool {
 	statusCode, newErr := logical.RespondErrorCommon(req, resp, err)
 	if newErr == nil && statusCode == 0 {
@@ -1193,6 +1197,12 @@ func respondErrorCommon(w http.ResponseWriter, req *logical.Request, resp *logic
 		return true
 	}
 
+	if resp != nil {
+		if data := resp.Data["data"]; data != nil {
+			respondErrorAndData(w, statusCode, data, newErr)
+			return true
+		}
+	}
 	respondError(w, statusCode, newErr)
 	return true
 }

--- a/sdk/logical/response.go
+++ b/sdk/logical/response.go
@@ -93,7 +93,7 @@ func (r *Response) AddWarning(warning string) {
 // IsError returns true if this response seems to indicate an error.
 func (r *Response) IsError() bool {
 	// If the response data contains only an 'error' element, or an 'error' and a 'data' element only
-	return r != nil && r.Data != nil && r.Data["error"] != nil && (len(r.Data) == 1 || r.Data["data"] != nil)
+	return r != nil && r.Data != nil && r.Data["error"] != nil && (len(r.Data) == 1 || (r.Data["data"] != nil && len(r.Data) == 2))
 }
 
 func (r *Response) Error() error {

--- a/sdk/logical/response.go
+++ b/sdk/logical/response.go
@@ -92,7 +92,8 @@ func (r *Response) AddWarning(warning string) {
 
 // IsError returns true if this response seems to indicate an error.
 func (r *Response) IsError() bool {
-	return r != nil && r.Data != nil && len(r.Data) == 1 && r.Data["error"] != nil
+	// If the response data contains only an 'error' element, or an 'error' and a 'data' element only
+	return r != nil && r.Data != nil && r.Data["error"] != nil && (len(r.Data) == 1 || r.Data["data"] != nil)
 }
 
 func (r *Response) Error() error {

--- a/sdk/logical/response_util.go
+++ b/sdk/logical/response_util.go
@@ -182,3 +182,23 @@ func RespondError(w http.ResponseWriter, status int, err error) {
 	enc := json.NewEncoder(w)
 	enc.Encode(resp)
 }
+
+func RespondErrorAndData(w http.ResponseWriter, status int, data interface{}, err error) {
+	AdjustErrorStatusCode(&status, err)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	type ErrorAndDataResponse struct {
+		Errors []string    `json:"errors"`
+		Data   interface{} `json:"data""`
+	}
+	resp := &ErrorAndDataResponse{Errors: make([]string, 0, 1)}
+	if err != nil {
+		resp.Errors = append(resp.Errors, err.Error())
+	}
+	resp.Data = data
+
+	enc := json.NewEncoder(w)
+	enc.Encode(resp)
+}

--- a/vault/identity_lookup_test.go
+++ b/vault/identity_lookup_test.go
@@ -45,6 +45,19 @@ func TestIdentityStore_Lookup_Entity(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if len(entity.Aliases) != 1 {
+		t.Fatalf("unexpected number of aliases in entity: %x", entity)
+	}
+
+	alias := entity.Aliases[0]
+	if alias.MountPath != "auth/github/" {
+		t.Fatalf("alias mountpath was not as expected - expected auth/github/ but got %q", alias.MountPath)
+	}
+
+	if alias.MountType != "github" {
+		t.Fatalf("alias mountpath was not as expected - expected github but got %q", alias.MountPath)
+	}
+
 	lookupReq := &logical.Request{
 		Path:      "lookup/entity",
 		Operation: logical.UpdateOperation,

--- a/vault/identity_lookup_test.go
+++ b/vault/identity_lookup_test.go
@@ -45,19 +45,6 @@ func TestIdentityStore_Lookup_Entity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(entity.Aliases) != 1 {
-		t.Fatalf("unexpected number of aliases in entity: %x", entity)
-	}
-
-	alias := entity.Aliases[0]
-	if alias.MountPath != "auth/github/" {
-		t.Fatalf("alias mountpath was not as expected - expected auth/github/ but got %q", alias.MountPath)
-	}
-
-	if alias.MountType != "github" {
-		t.Fatalf("alias mountpath was not as expected - expected github but got %q", alias.MountPath)
-	}
-
 	lookupReq := &logical.Request{
 		Path:      "lookup/entity",
 		Operation: logical.UpdateOperation,

--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -791,6 +791,8 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 	// can be understood by the UI
 	aliasesInvolvedInClashes := make([]aliasClashInformation, 0)
 
+	i.UpdateEntityWithMountInformation(toEntity)
+
 	// An error detailing if any alias clashes happen (shared mount accessor)
 	var aliasClashError error
 
@@ -811,6 +813,8 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 		if fromEntity.NamespaceID != toEntity.NamespaceID {
 			return errors.New("entity id to merge from does not belong to this namespace"), nil, nil
 		}
+
+		i.UpdateEntityWithMountInformation(fromEntity)
 
 		// If we're not resolving a conflict, we check to see if
 		// any aliases conflict between the toEntity and this fromEntity:

--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -190,9 +190,21 @@ func (i *IdentityStore) pathEntityMergeID() framework.OperationFunc {
 			return nil, err
 		}
 
-		userErr, intErr := i.mergeEntity(ctx, txn, toEntity, fromEntityIDs, conflictingAliasIDsToKeep, force, false, false, true, false)
+		userErr, intErr, aliases := i.mergeEntity(ctx, txn, toEntity, fromEntityIDs, conflictingAliasIDsToKeep, force, false, false, true, false)
 		if userErr != nil {
-			return logical.ErrorResponse(userErr.Error()), nil
+			// Not an error due to alias clash, return like normal
+			if len(aliases) == 0 {
+				return logical.ErrorResponse(userErr.Error()), nil
+			}
+			// Alias clash error, so include additional details
+			resp := &logical.Response{
+				Data: map[string]interface{}{
+					"error": userErr.Error(),
+					"data":  aliases,
+				},
+			}
+
+			return resp, nil
 		}
 		if intErr != nil {
 			return nil, intErr
@@ -734,29 +746,40 @@ func (i *IdentityStore) handlePathEntityListCommon(ctx context.Context, req *log
 }
 
 func (i *IdentityStore) mergeEntityAsPartOfUpsert(ctx context.Context, txn *memdb.Txn, toEntity *identity.Entity, fromEntityID string, persist bool) (error, error) {
-	return i.mergeEntity(ctx, txn, toEntity, []string{fromEntityID}, []string{}, true, false, true, persist, true)
+	err1, err2, _ := i.mergeEntity(ctx, txn, toEntity, []string{fromEntityID}, []string{}, true, false, true, persist, true)
+	return err1, err2
 }
 
-func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntity *identity.Entity, fromEntityIDs, conflictingAliasIDsToKeep []string, force, grabLock, mergePolicies, persist, forceMergeAliases bool) (error, error) {
+// A small type to return useful information to the UI after an entity clash
+// Every alias involved in a clash will be returned.
+type aliasClashInformation struct {
+	Alias     string `json:"alias"`
+	Entity    string `json:"entity"`
+	EntityId  string `json:"entity_id"`
+	Mount     string `json:"mount"`
+	MountPath string `json:"mount_path"`
+}
+
+func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntity *identity.Entity, fromEntityIDs, conflictingAliasIDsToKeep []string, force, grabLock, mergePolicies, persist, forceMergeAliases bool) (error, error, []aliasClashInformation) {
 	if grabLock {
 		i.lock.Lock()
 		defer i.lock.Unlock()
 	}
 
 	if toEntity == nil {
-		return errors.New("entity id to merge to is invalid"), nil
+		return errors.New("entity id to merge to is invalid"), nil, nil
 	}
 
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, err, nil
 	}
 	if toEntity.NamespaceID != ns.ID {
-		return errors.New("entity id to merge into does not belong to the request's namespace"), nil
+		return errors.New("entity id to merge into does not belong to the request's namespace"), nil, nil
 	}
 
 	if len(fromEntityIDs) > 1 && len(conflictingAliasIDsToKeep) > 1 {
-		return errors.New("aliases conflicts cannot be resolved with multiple from entity ids - merge one entity at a time"), nil
+		return errors.New("aliases conflicts cannot be resolved with multiple from entity ids - merge one entity at a time"), nil, nil
 	}
 
 	sanitizedFromEntityIDs := strutil.RemoveDuplicates(fromEntityIDs, false)
@@ -764,25 +787,29 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 	// A map to check if there are any clashes between mount accessors for any of the sanitizedFromEntityIDs
 	fromEntityAccessors := make(map[string]string)
 
+	// A list detailing all aliases where a clash has occurred, so that the error
+	// can be understood by the UI
+	aliasesInvolvedInClashes := make([]aliasClashInformation, 0)
+
 	// An error detailing if any alias clashes happen (shared mount accessor)
 	var aliasClashError error
 
 	for _, fromEntityID := range sanitizedFromEntityIDs {
 		if fromEntityID == toEntity.ID {
-			return errors.New("to_entity_id should not be present in from_entity_ids"), nil
+			return errors.New("to_entity_id should not be present in from_entity_ids"), nil, nil
 		}
 
 		fromEntity, err := i.MemDBEntityByID(fromEntityID, false)
 		if err != nil {
-			return nil, err
+			return nil, err, nil
 		}
 
 		if fromEntity == nil {
-			return errors.New("entity id to merge from is invalid"), nil
+			return errors.New("entity id to merge from is invalid"), nil, nil
 		}
 
 		if fromEntity.NamespaceID != toEntity.NamespaceID {
-			return errors.New("entity id to merge from does not belong to this namespace"), nil
+			return errors.New("entity id to merge from does not belong to this namespace"), nil, nil
 		}
 
 		// If we're not resolving a conflict, we check to see if
@@ -793,7 +820,7 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 					// First, check to see if this alias clashes with an alias from any of the other fromEntities:
 					id, mountAccessorInAnotherFromEntity := fromEntityAccessors[fromAlias.MountAccessor]
 					if mountAccessorInAnotherFromEntity && (id != fromEntityID) {
-						return fmt.Errorf("mount accessor %s found in multiple fromEntities, merge should be done with one fromEntity at a time", fromAlias.MountAccessor), nil
+						return fmt.Errorf("mount accessor %s found in multiple fromEntities, merge should be done with one fromEntity at a time", fromAlias.MountAccessor), nil, nil
 					}
 
 					fromEntityAccessors[fromAlias.MountAccessor] = fromEntityID
@@ -806,6 +833,22 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 						aliasClashError = multierror.Append(aliasClashError,
 							fmt.Errorf("mountAccessor: %s, toEntity ID: %s, fromEntity ID: %s, conflicting toEntity alias ID: %s, conflicting fromEntity alias ID: %s",
 								toAlias.MountAccessor, toEntity.ID, fromEntityID, toAlias.ID, fromAlias.ID))
+
+						// Also add both to our summary of all clashes:
+						aliasesInvolvedInClashes = append(aliasesInvolvedInClashes, aliasClashInformation{
+							Entity:    toEntity.Name,
+							EntityId:  toEntity.ID,
+							Alias:     toAlias.Name,
+							Mount:     toAlias.MountType,
+							MountPath: toAlias.MountPath,
+						})
+						aliasesInvolvedInClashes = append(aliasesInvolvedInClashes, aliasClashInformation{
+							Entity:    fromEntity.Name,
+							EntityId:  fromEntityID,
+							Alias:     fromAlias.Name,
+							Mount:     fromAlias.MountType,
+							MountPath: fromAlias.MountPath,
+						})
 					}
 				}
 			}
@@ -814,7 +857,7 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 		for configID, configSecret := range fromEntity.MFASecrets {
 			_, ok := toEntity.MFASecrets[configID]
 			if ok && !force {
-				return nil, fmt.Errorf("conflicting MFA config ID %q in entity ID %q", configID, fromEntity.ID)
+				return nil, fmt.Errorf("conflicting MFA config ID %q in entity ID %q", configID, fromEntity.ID), nil
 			} else {
 				if toEntity.MFASecrets == nil {
 					toEntity.MFASecrets = make(map[string]*mfa.Secret)
@@ -826,7 +869,7 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 
 	// Check alias clashes after validating every fromEntity, so that we have a full list of errors
 	if aliasClashError != nil {
-		return aliasClashError, nil
+		return aliasClashError, nil, aliasesInvolvedInClashes
 	}
 
 	isPerfSecondaryOrStandby := i.localNode.ReplicationState().HasState(consts.ReplicationPerformanceSecondary) ||
@@ -849,20 +892,20 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 
 	for _, fromEntityID := range sanitizedFromEntityIDs {
 		if fromEntityID == toEntity.ID {
-			return errors.New("to_entity_id should not be present in from_entity_ids"), nil
+			return errors.New("to_entity_id should not be present in from_entity_ids"), nil, nil
 		}
 
 		fromEntity, err := i.MemDBEntityByID(fromEntityID, true)
 		if err != nil {
-			return nil, err
+			return nil, err, nil
 		}
 
 		if fromEntity == nil {
-			return errors.New("entity id to merge from is invalid"), nil
+			return errors.New("entity id to merge from is invalid"), nil, nil
 		}
 
 		if fromEntity.NamespaceID != toEntity.NamespaceID {
-			return errors.New("entity id to merge from does not belong to this namespace"), nil
+			return errors.New("entity id to merge from does not belong to this namespace"), nil, nil
 		}
 
 		for _, fromAlias := range fromEntity.Aliases {
@@ -877,13 +920,13 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 						i.logger.Info("Deleting to_entity alias during entity merge", "to_entity", toEntity.ID, "deleted_alias", toAliasId)
 						err := i.MemDBDeleteAliasByIDInTxn(txn, toAliasId, false)
 						if err != nil {
-							return nil, fmt.Errorf("failed to delete orphaned alias during merge: %w", err)
+							return nil, fmt.Errorf("failed to delete orphaned alias during merge: %w", err), nil
 						}
 					} else if strutil.StrListContains(conflictingAliasIDsToKeep, toAliasId) {
 						i.logger.Info("Deleting from_entity alias during entity merge", "from_entity", fromEntityID, "deleted_alias", fromAlias.ID)
 						err := i.MemDBDeleteAliasByIDInTxn(txn, fromAlias.ID, false)
 						if err != nil {
-							return nil, fmt.Errorf("failed to delete orphaned alias during merge: %w", err)
+							return nil, fmt.Errorf("failed to delete orphaned alias during merge: %w", err), nil
 						}
 
 						// Continue to next alias, as there's no alias to merge left in the from_entity
@@ -892,10 +935,10 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 						i.logger.Info("Deleting to_entity alias during entity merge", "to_entity", toEntity.ID, "deleted_alias", toAliasId)
 						err := i.MemDBDeleteAliasByIDInTxn(txn, toAliasId, false)
 						if err != nil {
-							return nil, fmt.Errorf("failed to delete orphaned alias during merge: %w", err)
+							return nil, fmt.Errorf("failed to delete orphaned alias during merge: %w", err), nil
 						}
 					} else {
-						return fmt.Errorf("conflicting mount accessors in following alias IDs and neither were present in conflicting_alias_ids_to_keep: %s, %s", fromAlias.ID, toAliasId), nil
+						return fmt.Errorf("conflicting mount accessors in following alias IDs and neither were present in conflicting_alias_ids_to_keep: %s, %s", fromAlias.ID, toAliasId), nil, nil
 					}
 				}
 			}
@@ -907,7 +950,7 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 
 			err = i.MemDBUpsertAliasInTxn(txn, fromAlias, false)
 			if err != nil {
-				return nil, fmt.Errorf("failed to update alias during merge: %w", err)
+				return nil, fmt.Errorf("failed to update alias during merge: %w", err), nil
 			}
 
 			// Add the alias to the desired entity
@@ -932,13 +975,13 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 		// internal and external
 		groups, err := i.MemDBGroupsByMemberEntityIDInTxn(txn, fromEntity.ID, true, false)
 		if err != nil {
-			return nil, err
+			return nil, err, nil
 		}
 		for _, group := range groups {
 			group.MemberEntityIDs = strutil.StrListDelete(group.MemberEntityIDs, fromEntity.ID)
 			err = i.UpsertGroupInTxn(ctx, txn, group, persist && !isPerfSecondaryOrStandby)
 			if err != nil {
-				return nil, err
+				return nil, err, nil
 			}
 
 			fromEntityGroups = append(fromEntityGroups, group)
@@ -947,14 +990,14 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 		// Delete the entity which we are merging from in MemDB using the same transaction
 		err = i.MemDBDeleteEntityByIDInTxn(txn, fromEntity.ID)
 		if err != nil {
-			return nil, err
+			return nil, err, nil
 		}
 
 		if persist && !isPerfSecondaryOrStandby {
 			// Delete the entity which we are merging from in storage
 			err = i.entityPacker.DeleteItem(ctx, fromEntity.ID)
 			if err != nil {
-				return nil, err
+				return nil, err, nil
 			}
 		}
 	}
@@ -962,14 +1005,14 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 	// Update MemDB with changes to the entity we are merging to
 	err = i.MemDBUpsertEntityInTxn(txn, toEntity)
 	if err != nil {
-		return nil, err
+		return nil, err, nil
 	}
 
 	for _, group := range fromEntityGroups {
 		group.MemberEntityIDs = append(group.MemberEntityIDs, toEntity.ID)
 		err = i.UpsertGroupInTxn(ctx, txn, group, persist && !isPerfSecondaryOrStandby)
 		if err != nil {
-			return nil, err
+			return nil, err, nil
 		}
 	}
 
@@ -977,7 +1020,7 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 		// Persist the entity which we are merging to
 		toEntityAsAny, err := ptypes.MarshalAny(toEntity)
 		if err != nil {
-			return nil, err
+			return nil, err, nil
 		}
 		item := &storagepacker.Item{
 			ID:      toEntity.ID,
@@ -986,11 +1029,11 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 
 		err = i.entityPacker.PutItem(ctx, item)
 		if err != nil {
-			return nil, err
+			return nil, err, nil
 		}
 	}
 
-	return nil, nil
+	return nil, nil, nil
 }
 
 var entityHelp = map[string][2]string{

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -1092,17 +1092,7 @@ func (i *IdentityStore) MemDBEntityByIDInTxn(txn *memdb.Txn, entityID string, cl
 	return entity, nil
 }
 
-func (i *IdentityStore) MemDBEntityByID(entityID string, clone bool) (*identity.Entity, error) {
-	if entityID == "" {
-		return nil, fmt.Errorf("missing entity id")
-	}
-
-	txn := i.db.Txn(false)
-
-	entity, err := i.MemDBEntityByIDInTxn(txn, entityID, clone)
-	if err != nil {
-		return entity, err
-	}
+func (i *IdentityStore) UpdateEntityWithMountInformation(entity *identity.Entity) {
 	if entity != nil {
 		for _, alias := range entity.Aliases {
 			mountValidationResp := i.router.ValidateMountByAccessor(alias.MountAccessor)
@@ -1112,7 +1102,16 @@ func (i *IdentityStore) MemDBEntityByID(entityID string, clone bool) (*identity.
 			}
 		}
 	}
-	return entity, nil
+}
+
+func (i *IdentityStore) MemDBEntityByID(entityID string, clone bool) (*identity.Entity, error) {
+	if entityID == "" {
+		return nil, fmt.Errorf("missing entity id")
+	}
+
+	txn := i.db.Txn(false)
+
+	return i.MemDBEntityByIDInTxn(txn, entityID, clone)
 }
 
 func (i *IdentityStore) MemDBEntityByName(ctx context.Context, entityName string, clone bool) (*identity.Entity, error) {


### PR DESCRIPTION
Note that I did need to do a little black magic here. The response as read by the logical framework is the same (nil response, non-nil error), but raw API requests give the full data array. This seems like a pretty good solution to me, as it doesn't return both a resp and an error to the logical framework, but I'm open to other thoughts and opinions and as to whether or not this is the right kind of black magic. 

The approach is broadly extensible, in the sense that we can follow the same method again in the future, too.

The body of a response after this change will look a little like this (in the case of a double clash):
```
{
   "errors":[
      "3 errors occurred:\n\t* toEntity and at least one fromEntity have aliases with the same mount accessor, repeat the merge request specifying exactly one fromEntity, clashes: \n\t* mountAccessor: auth_github_41e995e1, toEntity ID: f41ba0e4-4492-04a5-e850-0715c39d600c, fromEntity ID: 12239930-f672-37ab-cd3d-668b79c51043, conflicting toEntity alias ID: a24f4921-27e6-e9dd-8a5a-e08ade178e49, conflicting fromEntity alias ID: 920efcfc-9406-a5c7-3061-283e3935fcc4\n\t* mountAccessor: auth_userpass_c13afd8e, toEntity ID: f41ba0e4-4492-04a5-e850-0715c39d600c, fromEntity ID: 79fcbd36-c92d-60ba-bd3e-af9836311eea, conflicting toEntity alias ID: 2d6617ee-4dd6-8445-c818-7b484e95b433, conflicting fromEntity alias ID: dc843aed-df0e-49d7-0ab7-e0b105d7b5db\n\n"
   ],
   "data":[
      {
         "alias":"bob-github",
         "entity":"bob-smith",
         "entity_id":"f41ba0e4-4492-04a5-e850-0715c39d600c",
         "mount":"github",
         "mount_path":"auth/github/"
      },
      {
         "alias":"clara",
         "entity":"clara-smith",
         "entity_id":"12239930-f672-37ab-cd3d-668b79c51043",
         "mount":"github",
         "mount_path":"auth/github/"
      },
      {
         "alias":"bob",
         "entity":"bob-smith",
         "entity_id":"f41ba0e4-4492-04a5-e850-0715c39d600c",
         "mount":"userpass",
         "mount_path":"auth/userpass/"
      },
      {
         "alias":"alice",
         "entity":"alice-smith",
         "entity_id":"79fcbd36-c92d-60ba-bd3e-af9836311eea",
         "mount":"userpass",
         "mount_path":"auth/userpass/"
      }
   ]
}
```