### PR TITLE
Don't include issuers on delta CRLs

### DIFF
--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -841,10 +841,20 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 		if err != nil {
 			return fmt.Errorf("error building CRLs: unable to get revoked certificate entries: %v", err)
 		}
-	}
 
-	if err := augmentWithRevokedIssuers(issuerIDEntryMap, issuerIDCertMap, revokedCertsMap); err != nil {
-		return fmt.Errorf("error building CRLs: unable to parse revoked issuers: %v", err)
+		if !isDelta {
+			// Revoking an issuer forces us to rebuild our complete CRL,
+			// regardless of whether or not we've enabled auto rebuilding or
+			// delta CRLs. If we elide the above isDelta check, this results
+			// in a non-empty delta CRL, containing the serial of the
+			// now-revoked issuer, even though it was generated _after_ the
+			// complete CRL with the issuer on it. There's no reason to
+			// duplicate this serial number on the delta, hence the above
+			// guard for isDelta.
+			if err := augmentWithRevokedIssuers(issuerIDEntryMap, issuerIDCertMap, revokedCertsMap); err != nil {
+				return fmt.Errorf("error building CRLs: unable to parse revoked issuers: %v", err)
+			}
+		}
 	}
 
 	// Now we can call buildCRL once, on an arbitrary/representative issuer


### PR DESCRIPTION
When revoking an issuer, we immediately force a full rebuild of all CRLs (complete and delta). However, we had forgotten to guard the delta CRL's inclusion of augmented issuers, resulting in double-listing the issuer's serial number on both the complete and the delta CRL. This isn't necessary as the delta's referenced complete CRL number has incremented to the point where the issuer itself was included on the complete CRL.

Avoid this double reference and don't include issuers on delta CRLs; they should always appear only on the complete CRL.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`