### PR TITLE
The 2 year temporary disabling of this test has come to an end

### DIFF
--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -506,8 +506,6 @@ func TestBackend_Static_QueueWAL_discard_role_not_found(t *testing.T) {
 // Second scenario, WAL contains a role name that does exist, but the role's
 // LastVaultRotation is greater than the WAL has
 func TestBackend_Static_QueueWAL_discard_role_newer_rotation_date(t *testing.T) {
-	t.Skip("temporarily disabled due to intermittent failures")
-
 	cluster, sys := getCluster(t)
 	defer cluster.Cleanup()
 


### PR DESCRIPTION
Part of a test fixing exercise, this test has been disabled for a long time. Enabling it and running tests locally multiple times yielded no failures, so let's reinstate it until it becomes a problem again - then figure out what's wrong.