### PR TITLE
docs: Update retry_join Known Issue versions

### DIFF
--- a/website/content/partials/raft-retry-join-failure.mdx
+++ b/website/content/partials/raft-retry-join-failure.mdx
@@ -15,9 +15,10 @@ and first reported in https://github.com/hashicorp/vault/issues/16486.
 
 #### Impacted Versions
 
-Affects versions 1.11.1 and 1.10.5.  Versions prior to these are unaffected.
+Affects versions 1.11.1, 1.11.2, 1.10.5, and 1.10.6.  Versions prior to these
+are unaffected.
 
-NOTE: This error does not extend to version 1.9.8, which is slightly different
+NOTE: This error does not extend to version 1.9.8+, which is slightly different
 in this portion of the code and does not exhibit the same behavior.
 
 New releases addressing this bug are coming soon.


### PR DESCRIPTION
Update the doc to show affected versions 1.11.2 and 1.10.6.