### PR TITLE
Fix transform secrets flaky test

### DIFF
--- a/ui/tests/acceptance/enterprise-transform-test.js
+++ b/ui/tests/acceptance/enterprise-transform-test.js
@@ -160,6 +160,7 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     let transformation = await newTransformation(backend, 'b-transformation', true);
     await newRole(backend, roleName);
     await transformationsPage.visitShow({ backend, id: transformation });
+    await settled();
     assert.dom('[data-test-row-value="Allowed roles"]').hasText(roleName);
   });
 
@@ -170,6 +171,7 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     let transformation = await newTransformation(backend, 'c-transformation', true);
     // create role
     await newRole(backend, roleName);
+    await settled();
     await transformationsPage.visitShow({ backend, id: transformation });
     assert.dom('[data-test-row-value="Allowed roles"]').hasText(roleName);
     // Edit transformation


### PR DESCRIPTION
Good old settled. Inconsistent flakyness but it does fail locally sometimes if I run just Enterprise test or I run the whole suite (not if I just run -f=transform).