### PR TITLE
Remove Async-HVAC from recommended libraries list

### DIFF
--- a/website/content/api-docs/libraries.mdx
+++ b/website/content/api-docs/libraries.mdx
@@ -181,12 +181,6 @@ Install-Module Zyborg.Vault
 $ pip install hvac
 ```
 
-- [Async-HVAC](https://github.com/Aloomaio/async-hvac)
-
-```shell-session
-$ pip install async-hvac
-```
-
 ### R
 
 - [vaultr](https://github.com/vimc/vaultr)


### PR DESCRIPTION
The repository for AsyncHVAC (https://github.com/Aloomaio/async-hvac) no longer exists, so removing a reference to it.