### PR TITLE
Enable Iron Bank integration

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -268,3 +268,16 @@ event "post-publish-website" {
     on = "always"
   }
 }
+
+event "update-ironbank" {
+  depends = ["promote-production-packaging"]
+  action "update-ironbank" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "update-ironbank"
+  }
+
+  notification {
+    on = "fail"
+  }
+}

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -270,7 +270,7 @@ event "post-publish-website" {
 }
 
 event "update-ironbank" {
-  depends = ["promote-production-packaging"]
+  depends = ["post-publish-website"]
   action "update-ironbank" {
     organization = "hashicorp"
     repository = "crt-workflows-common"


### PR DESCRIPTION
Enables Iron Bank updates after linux artifacts are published.

Matching backports to versions in https://repo1.dso.mil/dsop/hashicorp/vault