### PR TITLE
Store login token with token helper on MFA logins

### DIFF
--- a/changelog/17494.txt
+++ b/changelog/17494.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-auth/token: login command now stores token with token handler on MFA logins
+auth/mfa: login command now stores token with token handler on MFA logins
 ```

--- a/changelog/17494.txt
+++ b/changelog/17494.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/token: login command now stores token with token handler on MFA logins
+```

--- a/command/write.go
+++ b/command/write.go
@@ -159,7 +159,8 @@ func (c *WriteCommand) Run(args []string) int {
 			// request is validated interactively
 			methodInfo := c.getMFAMethodInfo(secret.Auth.MFARequirement.MFAConstraints)
 			if methodInfo.methodID != "" {
-				return c.validateMFA(secret.Auth.MFARequirement.MFARequestID, methodInfo)
+				result, _ := c.validateMFA(secret.Auth.MFARequirement.MFARequestID, methodInfo)
+				return result
 			}
 		}
 		c.UI.Warn(wrapAtLength("A login request was issued that is subject to "+


### PR DESCRIPTION
Fixes #16928

- in `command/login.go` 
  - defines helper function `storeTokenWithHelper` which is simply a copy of part of the functionality of the Run method
  - removes the corresponding functionality in the Run method and replaces it with a call to `storeTokenWithHelper`
  - adds another call to `storeTokenWithHelper` in the Run method during the part where it handles MFA logins
    - the part where MFA logins are handled always returns early from the Run method, so this second call to `storeTokenWithHelper` is to simply ensure that it is called as part of the Run method whether or not we are doing MFA, since we want to store the token on all logins, not just non-MFA ones
    -  this second call to `storeTokenWithHelper` needs the value for `secret` determined by the function `validateMFA` in `base/command.go`
      - `validateMFA` is modified to add a second return value which is the secret
        - `commd/write.go` is the only other place that calls `validateMFA`, so it is modified to handle 2 return values instead of 1