### PR TITLE
VAULT-1603 add sys/quotas to root-only api path docs

### DIFF
--- a/website/content/docs/enterprise/namespaces.mdx
+++ b/website/content/docs/enterprise/namespaces.mdx
@@ -72,6 +72,7 @@ There are certain API paths that can only be called from the root namespace:
 - `sys/key-status`
 - `sys/storage`
 - `sys/storage/raft`
+- `sys/quotas`
 
 ## Architecture
 


### PR DESCRIPTION
You cannot interact with this API from a non-root namespace, and it was missing from this list as a result.