### PR TITLE
Fix tidy-status, tidy-cancel on PR Secondaries

### DIFF
--- a/changelog/17497.txt
+++ b/changelog/17497.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Respond to tidy-status, tidy-cancel on PR Secondary clusters.
+```


### PR DESCRIPTION
PKI's tidy-status included a bug that prevented PR secondary nodes from responding with the status of the running tidy operation: while the operation constructor correctly forwarded the node on PR standby instances, the handler itself forwarded also on PR secondary nodes.

This is incorrect as the PR secondary nodes are the active node in the local PR cluster, and run tidy operations otherwise.

This meant that while auto-tidy and tidy operations would run, there was no insight into the process.

When implementing tidy-cancel, tidy-status's handler logic was reused, duplicating the bug there as well.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`