### PR TITLE
doc: fix broken link in transit api

### DIFF
--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -119,6 +119,8 @@ two values: an ephemeral 256-bit AES key wrapped using the wrapping key
 returned by Vault and the encryption of the import key material under the
 provided AES key. The wrapped AES key should be the first 512 bytes of the
 ciphertext, and the encrypted key material should be the remaining bytes.
+See the BYOK section of the [Transit secrets engine documentation](/docs/secrets/transit#bring-your-own-key-byok)
+for more information on constructing the ciphertext.
 
 - `hash_function` `(string: "SHA256")` - The hash function used for the
 RSA-OAEP step of creating the ciphertext. Supported hash functions are:
@@ -210,7 +212,7 @@ two values: an ephemeral 256-bit AES key wrapped using the wrapping key
 returned by Vault and the encryption of the import key material under the
 provided AES key. The wrapped AES key should be the first 512 bytes of the
 ciphertext, and the encrypted key material should be the remaining bytes.
-See the BYOK section of the [Transit secrets engine documentation](/docs/secret/transit)
+See the BYOK section of the [Transit secrets engine documentation](/docs/secrets/transit#bring-your-own-key-byok)
 for more information on constructing the ciphertext.
 
 - `hash_function` `(string: "SHA256")` - The hash function used for the


### PR DESCRIPTION
Also synchronize the doc between two import api:

- `/transit/keys/:name/import`
- `/transit/keys/:name/import_version`