### PR TITLE
vault operator init -output-curl-string bug

### DIFF
--- a/command/operator_init.go
+++ b/command/operator_init.go
@@ -237,12 +237,19 @@ func (c *OperatorInitCommand) Run(args []string) int {
 		return 2
 	}
 
+	// -output-curl string returns curl command for seal status
+	// setting this to false and then setting actual value after reading seal status
+	currentOutputCurlString := client.OutputCurlString()
+	client.SetOutputCurlString(false)
+
 	// Set defaults based on use of auto unseal seal
 	sealInfo, err := client.Sys().SealStatus()
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2
 	}
+
+	client.SetOutputCurlString(currentOutputCurlString)
 
 	switch sealInfo.RecoverySeal {
 	case true:


### PR DESCRIPTION
Slack: https://hashicorp.slack.com/archives/CMRSLF924/p1665566769095959
Bug:
vault operator init -key-shares=1 -key-threshold=1 -output-curl-string
curl -H "X-Vault-Request: true" -H "X-Vault-Token: $(vault print token)" http://127.0.0.1:8200/v1/sys/seal-status

Fix:
vault operator init -format=json -key-shares 1 -key-threshold 1 -output-curl-string
curl -X PUT -H "X-Vault-Request: true" -H "X-Vault-Token: $(vault print token)" -d '\''{"secret_shares":1,"secret_threshold":1,"stored_shares":0,"pgp_keys":null,"recovery_shares":0,"recovery_threshold":0,"recovery_pgp_keys":null,"root_token_pgp_key":""}'\'' http://127.0.0.1:8200/v1/sys/init