### PR TITLE
Clarify language around PSS CSR issues

### DIFF
--- a/website/content/docs/secrets/pki/considerations.mdx
+++ b/website/content/docs/secrets/pki/considerations.mdx
@@ -591,11 +591,12 @@ Additionally, some implementations allow rsaPSS OID certificates to contain
 restrictions on signature parameters allowed by this certificate, but Go and
 Vault do not support adding such restrictions.
 
-At this time Go lacks support for CSRs with the PSS signature algorithm. If
-using a GCP managed key with a RSA PSS algorithm as a backing CA key,
-attempting to generate a CSR will fail signature verification. In this case
-the CSR will need to be generated outside of Vault and the signed version
-can be imported into the mount.
+At this time Go lacks support for signing CSRs with the PSS signature
+algorithm. If using a managed key with a RSA PSS algorithm (such as GCP or
+a PKCS#11 HSM) as a backing for an intermediate CA key, attempting to generate
+a CSR (via `pki/intermediate/generate/kms`) will fail signature verification.
+In this case, the CSR will need to be generated outside of Vault and the
+signed final certificate can be imported into the mount.
 
 Go additionally lacks support for creating OCSP responses with the PSS
 signature algorithm. Vault will automatically downgrade issuers with


### PR DESCRIPTION
Also point out that PKCS#11 tokens have the same problem.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`