### PR TITLE
Add note about transit BYOK key formats

### DIFF
--- a/website/content/docs/secrets/transit/index.mdx
+++ b/website/content/docs/secrets/transit/index.mdx
@@ -285,6 +285,14 @@ the ciphertext for the input of the `import` endpoint:
 
 - Wrap the target key using the ephemeral AES key with AES-KWP.
 
+~> Note: When wrapping a symmetric key (such as an AES or ChaCha20 key), wrap
+   the raw bytes of the key. For instance, with an AES 128-bit key, this'll be
+   a byte array 16 characters in length that will directly be wrapped without
+   base64 or other encodings.<br /><br />When wrapping an asymmetric key
+   (such as a RSA or ECDSA key), wrap the **PKCS8** encoded format of this
+   key, in raw DER/binary form. Do not apply PEM encoding to this blob prior
+   to encryption and do not base64 encode it.
+
 - Wrap the AES key under the Vault wrapping key using RSAES-OAEP with MGF1 and
   either SHA-1, SHA-224, SHA-256, SHA-384, or SHA-512.
 


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

Symmetric keys are in raw format, but asymmetric keys needs to be in PKCS8 format (and not PKCS1). 