### PR TITLE
prevent memory leak when using control group factors in a policy

### DIFF
--- a/changelog/17532.txt
+++ b/changelog/17532.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: prevent memory leak when using control group factors in a policy
+```

--- a/vault/acl.go
+++ b/vault/acl.go
@@ -260,7 +260,11 @@ func NewACL(ctx context.Context, policies []*Policy) (*ACL, error) {
 			if pc.Permissions.ControlGroup != nil {
 				if len(pc.Permissions.ControlGroup.Factors) > 0 {
 					if existingPerms.ControlGroup == nil {
-						existingPerms.ControlGroup = pc.Permissions.ControlGroup
+						cg, err := pc.Permissions.ControlGroup.Clone()
+						if err != nil {
+							return nil, err
+						}
+						existingPerms.ControlGroup = cg
 					} else {
 						existingPerms.ControlGroup.Factors = append(existingPerms.ControlGroup.Factors, pc.Permissions.ControlGroup.Factors...)
 					}

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -149,6 +149,17 @@ type ControlGroup struct {
 	Factors []*ControlGroupFactor
 }
 
+func (c *ControlGroup) Clone() (*ControlGroup, error) {
+	clonedControlGroup, err := copystructure.Copy(c)
+	if err != nil {
+		return nil, err
+	}
+
+	cg := clonedControlGroup.(*ControlGroup)
+
+	return cg, nil
+}
+
 type ControlGroupFactor struct {
 	Name                   string
 	Identity               *IdentityFactor `hcl:"identity"`


### PR DESCRIPTION
The problem might actually be that the Policy object is cached in the policy store's LRU. Then, we are assigning existingPerms.ControlGroup = pc.Permissions.ControlGroup. This is a pointer to the policy's control group. Then on next iteration we are appending another policy's control group factors to this one, making the actual policy object in the LRU cache larger. This causes the policy in the cache to no longer match the policy on disk.

Instead of using a map and de-duplicating factors i think we want to clone the original Policy's control group so we aren't reusing the pointer and mutating cache objects. If we clone the control group then any factors that we append to it will only live for the lifetime of the request and be garbage collected afterwards. This behaves similarly to the other data structures embedded in the ACL object.