### PR TITLE
Add storage check upgrade notes

### DIFF
--- a/website/content/docs/concepts/storage.mdx
+++ b/website/content/docs/concepts/storage.mdx
@@ -13,10 +13,9 @@ storage backend is untrusted storage used purely to keep encrypted information.
 
 ## Supported Storage Backends
 
-For enterprise customers, HashiCorp provides official support for Consul and
-Vault's Integrated Storage as storage backends.
+@include 'ent-supported-storage.mdx'
 
-Many other options for storage are available with community support - see our
+Many other options for storage are available with community support for open-source Vault - see our
 [Storage Configuration](/docs/configuration/storage) section for more
 information.
 

--- a/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
@@ -1,0 +1,18 @@
+---
+layout: docs
+page_title: Upgrading to Vault 1.12.x - Guides
+description: |-
+  This page contains the list of deprecations and important or breaking changes
+  for Vault 1.12.x. Please read it carefully.
+---
+
+# Overview
+
+This page contains the list of eprecations and important or breaking changes
+for Vault 1.12.x compared to 1.11. Please read it carefully.
+
+## Supported Storage Backends 
+
+Vault will now perform a supported storage check at startup. There is no impact on open-source Vault users.
+
+@include 'ent-supported-storage.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
@@ -13,6 +13,6 @@ for Vault 1.12.x compared to 1.11. Please read it carefully.
 
 ## Supported Storage Backends 
 
-Vault will now perform a supported storage check at startup. There is no impact on open-source Vault users.
+Vault Enterprise will now perform a supported storage check at startup. There is no impact on open-source Vault users.
 
 @include 'ent-supported-storage.mdx'

--- a/website/content/partials/ent-supported-storage.mdx
+++ b/website/content/partials/ent-supported-storage.mdx
@@ -1,0 +1,3 @@
+For enterprise customers, HashiCorp provides official support for Consul and Vault's Integrated Storage as storage backends. Vault Enterprise will
+no longer startup if configured to use a storage backend other than Consul or Integrated Storage. This is meant to protect against issues caused by using
+unsupported backends that do not support transactional storage.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1698,6 +1698,10 @@
         "path": "upgrading/plugins"
       },
       {
+        "title": "Upgrade to 1.12.x",
+        "path": "upgrading/upgrade-to-1.12.x"
+      },
+      {
         "title": "Upgrade to 1.11.x",
         "path": "upgrading/upgrade-to-1.11.x"
       },


### PR DESCRIPTION
Vault will now perform a supported storage check during startup. There is no impact on Vault OSS but Vault Enterprise will no longer startup if configured to use a storage backend other than `consul` or `raft`. This PR includes the documentation and upgrade notes for 1.12 outlining this change.