### PR TITLE
core: move rollback period init to NewCore

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1048,6 +1048,11 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	c.reloadFuncsLock.Unlock()
 	conf.ReloadFuncs = &c.reloadFuncs
 
+	c.rollbackPeriod = conf.RollbackPeriod
+	if conf.RollbackPeriod == 0 {
+		c.rollbackPeriod = time.Minute
+	}
+
 	// All the things happening below this are not required in
 	// recovery mode
 	if c.recoveryMode {

--- a/vault/core_util.go
+++ b/vault/core_util.go
@@ -5,7 +5,6 @@ package vault
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/helper/namespace"
@@ -55,10 +54,6 @@ func coreInit(c *Core, conf *CoreConfig) error {
 		c.physical = physical.NewStorageEncoding(c.physical)
 	}
 
-	c.rollbackPeriod = conf.RollbackPeriod
-	if conf.RollbackPeriod == 0 {
-		c.rollbackPeriod = time.Minute
-	}
 	return nil
 }
 


### PR DESCRIPTION
This places the rollback period initialization in a path that is used by enterprise and OSS. The functionality should be consistent between both editions.