### PR TITLE
doc: add manually import key code example

### DIFF
--- a/website/content/docs/secrets/transit/index.mdx
+++ b/website/content/docs/secrets/transit/index.mdx
@@ -278,12 +278,26 @@ The ciphertext bytes should be base64-encoded.
 
 ### Manual Process
 
-If the target key is not stored in an HSM or KMS, the following steps can be used to construct
-the ciphertext for the input of the `import` endpoint:
+If the target key is not stored in an HSM or KMS, the following steps (using [OpenSSL 
+v3](https://www.openssl.org) as an example) can be used to construct the ciphertext
+for the input of the `import` endpoint:
 
 - Generate an ephemeral 256-bit AES key.
 
-- Wrap the target key using the ephemeral AES key with AES-KWP.
+  ```text
+  $ openssl rand -out ephemeral.key -hex 32
+  ```
+
+- Wrap the target key using the ephemeral AES key with AES-KWP. It will use `A65959A6`
+  as an *Alternate Initial Value* by [RFC 5649](https://tools.ietf.org/html/rfc5649)
+
+  ```text
+  $ openssl enc -id-aes256-wrap-pad \
+    -iv 'A65959A6' \
+    -K "$(cat ephemeral.key)" \
+    -in target.key \
+    -out target.key.wrp
+  ```
 
 ~> Note: When wrapping a symmetric key (such as an AES or ChaCha20 key), wrap
    the raw bytes of the key. For instance, with an AES 128-bit key, this'll be
@@ -295,6 +309,16 @@ the ciphertext for the input of the `import` endpoint:
 
 - Wrap the AES key under the Vault wrapping key using RSAES-OAEP with MGF1 and
   either SHA-1, SHA-224, SHA-256, SHA-384, or SHA-512.
+
+  ```text
+  $ cat ephemeral.key | xxd -r -p \
+    | openssl pkeyutl -encrypt -pubin \
+        -inkey wrapping_key_from_transit_api.pem \
+        -out ephemeral.key.wrp \
+        -pkeyopt rsa_padding_mode:oaep \
+        -pkeyopt rsa_oaep_md:sha256 \
+        -pkeyopt rsa_mgf1_md:sha256
+  ```
 
 - Delete the ephemeral AES key.
 


### PR DESCRIPTION
It cost me an afternoon to figure out the importance of `A65959A6` IV and I think it will be nice to have it in document.

Not sure whether it fit the style of writing in Vault, please let me know if it needs any adjustment.