### PR TITLE
CLI: Fix secrets list -detailed headings

### DIFF
--- a/changelog/17577.txt
+++ b/changelog/17577.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-cli: Remove empty table heading for `vault secrets list -detailed`
+cli: Remove empty table heading for `vault secrets list -detailed` output.
 ```

--- a/changelog/17577.txt
+++ b/changelog/17577.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Remove empty table heading for `vault secrets list -detailed`
+```

--- a/command/secrets_list.go
+++ b/command/secrets_list.go
@@ -145,7 +145,7 @@ func (c *SecretsListCommand) detailedMounts(mounts map[string]*api.MountOutput) 
 		}
 	}
 
-	out := []string{"Path | Plugin | Accessor | Default TTL | Max TTL | Force No Cache | Replication | Seal Wrap | External Entropy Access | Options | Description | UUID | Version | Running Version | Running SHA256 | | Deprecation Status"}
+	out := []string{"Path | Plugin | Accessor | Default TTL | Max TTL | Force No Cache | Replication | Seal Wrap | External Entropy Access | Options | Description | UUID | Version | Running Version | Running SHA256 | Deprecation Status"}
 	for _, path := range paths {
 		mount := mounts[path]
 


### PR DESCRIPTION
Fixes empty column in `vault secrets list -detailed` output introduced with #17293.