### PR TITLE
CLI: Add expanded output format for large tables

### DIFF
--- a/command/audit_list.go
+++ b/command/audit_list.go
@@ -97,17 +97,17 @@ func (c *AuditListCommand) Run(args []string) int {
 	}
 
 	switch Format(c.UI) {
-	case "table":
+	case "table", "expanded":
 		if len(audits) == 0 {
 			c.UI.Output("No audit devices are enabled.")
 			return 2
 		}
 
 		if c.flagDetailed {
-			c.UI.Output(tableOutput(c.detailedAudits(audits), nil))
+			printTable(c.UI, c.detailedAudits(audits), nil)
 			return 0
 		}
-		c.UI.Output(tableOutput(c.simpleAudits(audits), nil))
+		printTable(c.UI, c.simpleAudits(audits), nil)
 		return 0
 	default:
 		return OutputData(c.UI, audits)

--- a/command/auth_list.go
+++ b/command/auth_list.go
@@ -99,12 +99,12 @@ func (c *AuthListCommand) Run(args []string) int {
 	}
 
 	switch Format(c.UI) {
-	case "table":
+	case "table", "expanded":
 		if c.flagDetailed {
-			c.UI.Output(tableOutput(c.detailedMounts(auths), nil))
+			printTable(c.UI, c.detailedMounts(auths), nil)
 			return 0
 		}
-		c.UI.Output(tableOutput(c.simpleMounts(auths), nil))
+		printTable(c.UI, c.simpleMounts(auths), nil)
 		return 0
 	default:
 		return OutputData(c.UI, auths)

--- a/command/operator_members.go
+++ b/command/operator_members.go
@@ -70,7 +70,7 @@ func (c *OperatorMembersCommand) Run(args []string) int {
 	}
 
 	switch Format(c.UI) {
-	case "table":
+	case "table", "expanded":
 		out := make([]string, 0)
 		cols := []string{"Host Name", "API Address", "Cluster Address", "Active Node", "Version", "Upgrade Version", "Redundancy Zone", "Last Echo"}
 		out = append(out, strings.Join(cols, " | "))
@@ -83,7 +83,7 @@ func (c *OperatorMembersCommand) Run(args []string) int {
 			}
 			out = append(out, strings.Join(cols, " | "))
 		}
-		c.UI.Output(tableOutput(out, nil))
+		printTable(c.UI, out, nil)
 		return 0
 	default:
 		return OutputData(c.UI, resp)

--- a/command/operator_raft_join.go
+++ b/command/operator_raft_join.go
@@ -211,7 +211,7 @@ func (c *OperatorRaftJoinCommand) Run(args []string) int {
 		"Key | Value",
 		fmt.Sprintf("Joined | %t", resp.Joined),
 	}
-	c.UI.Output(tableOutput(out, nil))
+	printTable(c.UI, out, nil)
 
 	return 0
 }

--- a/command/operator_raft_listpeers.go
+++ b/command/operator_raft_listpeers.go
@@ -116,6 +116,6 @@ func (c *OperatorRaftListPeersCommand) Run(args []string) int {
 		out = append(out, fmt.Sprintf("%s | %s | %s | %t", server["node_id"].(string), server["address"].(string), state, server["voter"].(bool)))
 	}
 
-	c.UI.Output(tableOutput(out, nil))
+	printTable(c.UI, out, nil)
 	return 0
 }

--- a/command/operator_rekey.go
+++ b/command/operator_rekey.go
@@ -643,8 +643,8 @@ func (c *OperatorRekeyCommand) printStatus(in interface{}) int {
 	}
 
 	switch Format(c.UI) {
-	case "table":
-		c.UI.Output(tableOutput(out, nil))
+	case "table", "expanded":
+		printTable(c.UI, out, nil)
 		return 0
 	default:
 		return OutputData(c.UI, in)

--- a/command/operator_usage.go
+++ b/command/operator_usage.go
@@ -138,7 +138,7 @@ func (c *OperatorUsageCommand) Run(args []string) int {
 	colConfig := columnize.DefaultConfig()
 	colConfig.Empty = " " // Do not show n/a on intentional blank lines
 	colConfig.Glue = "   "
-	c.UI.Output(tableOutput(out, colConfig))
+	printTable(c.UI, out, colConfig)
 	return 0
 }
 

--- a/command/plugin_list.go
+++ b/command/plugin_list.go
@@ -122,12 +122,12 @@ func (c *PluginListCommand) Run(args []string) int {
 	}
 
 	switch Format(c.UI) {
-	case "table":
+	case "table", "expanded":
 		if c.flagDetailed {
-			c.UI.Output(tableOutput(c.detailedResponse(resp), nil))
+			printTable(c.UI, c.detailedResponse(resp), nil)
 			return 0
 		}
-		c.UI.Output(tableOutput(c.simpleResponse(resp, pluginType), nil))
+		printTable(c.UI, c.simpleResponse(resp, pluginType), nil)
 		return 0
 	default:
 		res := make(map[string]interface{})

--- a/command/plugin_reload_status.go
+++ b/command/plugin_reload_status.go
@@ -88,6 +88,6 @@ func (c *PluginReloadStatusCommand) Run(args []string) int {
 			s.Error == "",
 			s.Error))
 	}
-	c.UI.Output(tableOutput(out, nil))
+	printTable(c.UI, out, nil)
 	return 0
 }

--- a/command/secrets_list.go
+++ b/command/secrets_list.go
@@ -99,12 +99,12 @@ func (c *SecretsListCommand) Run(args []string) int {
 	}
 
 	switch Format(c.UI) {
-	case "table":
+	case "table", "expanded":
 		if c.flagDetailed {
-			c.UI.Output(tableOutput(c.detailedMounts(mounts), nil))
+			printTable(c.UI, c.detailedMounts(mounts), nil)
 			return 0
 		}
-		c.UI.Output(tableOutput(c.simpleMounts(mounts), nil))
+		printTable(c.UI, c.simpleMounts(mounts), nil)
 		return 0
 	default:
 		return OutputData(c.UI, mounts)
@@ -145,7 +145,7 @@ func (c *SecretsListCommand) detailedMounts(mounts map[string]*api.MountOutput) 
 		}
 	}
 
-	out := []string{"Path | Plugin | Accessor | Default TTL | Max TTL | Force No Cache | Replication | Seal Wrap | External Entropy Access | Options | Description | UUID | Version | Running Version | Running SHA256 | | Deprecation Status"}
+	out := []string{"Path | Plugin | Accessor | Default TTL | Max TTL | Force No Cache | Replication | Seal Wrap | External Entropy Access | Options | Description | UUID | Version | Running Version | Running SHA256 | Deprecation Status"}
 	for _, path := range paths {
 		mount := mounts[path]
 

--- a/command/version_history.go
+++ b/command/version_history.go
@@ -125,7 +125,7 @@ func (c *VersionHistoryCommand) Run(args []string) int {
 	c.UI.Warn("")
 	c.UI.Warn(versionTrackingWarning)
 	c.UI.Warn("")
-	c.UI.Output(tableOutput(table, columnConfig))
+	printTable(c.UI, table, columnConfig)
 
 	return 0
 }


### PR DESCRIPTION
Thanks @mpalmi and `psql` ([example](https://stackoverflow.com/questions/9604723/alternate-output-format-for-psql)) for the inspiration for this one. Some table outputs from the Vault CLI are getting too wide for any reasonable monitor sizes, this PR introduces a new format option `expanded` to try to alleviate that in a scalable way. Examples down below. I've included a variety of table widths in the examples for illustration, but I'd only expect this formatter to _actually_ get used for the very widest tables.

This is a draft PR to gather early feedback. There's definitely some documentation to update, and probably some details to tweak if we go forwards with it.

## List secret mounts

<details><summary>vault secrets list -detailed</summary>
<p>

```shell-session
$ vault secrets list -detailed
Path          Plugin       Accessor              Default TTL    Max TTL    Force No Cache    Replication    Seal Wrap    External Entropy Access    Options           Description                                                UUID                                    Version    Running Version          Running SHA256    Deprecation Status
----          ------       --------              -----------    -------    --------------    -----------    ---------    -----------------------    -------           -----------                                                ----                                    -------    ---------------          --------------    ------------------
cubbyhole/    cubbyhole    cubbyhole_f209eddb    n/a            n/a        false             local          false        false                      map[]             per-token private secret storage                           54868022-9a8c-7eec-8cd1-79197a2cf6b7    n/a        v1.13.0+builtin.vault    n/a               n/a
identity/     identity     identity_165e7162     system         system     false             replicated     false        false                      map[]             identity store                                             09495e26-50d9-f421-52a3-2ca61ebd4dee    n/a        v1.13.0+builtin.vault    n/a               n/a
secret/       kv           kv_c538698b           system         system     false             replicated     false        false                      map[version:2]    key/value secret storage                                   51d78d10-11d1-957b-8d4c-6cd80d5ebd4f    n/a        v0.13.3+builtin          n/a               supported
sys/          system       system_3180869e       n/a            n/a        false             replicated     true         false                      map[]             system endpoints used for control, policy and debugging    9a7430f7-0dd6-ad2a-abbd-2bee87c5be51    n/a        v1.13.0+builtin.vault    n/a               n/a
```

</p>
</details>

<details><summary>vault secrets list -detailed -format=expanded</summary>
<p>

```shell-session
$ vault secrets list -detailed -format=expanded
ROW 1

Heading                    Value
-------                    -----
Path                       cubbyhole/
Plugin                     cubbyhole
Accessor                   cubbyhole_f209eddb
Default TTL                n/a
Max TTL                    n/a
Force No Cache             false
Replication                local
Seal Wrap                  false
External Entropy Access    false
Options                    map[]
Description                per-token private secret storage
UUID                       54868022-9a8c-7eec-8cd1-79197a2cf6b7
Version                    n/a
Running Version            v1.13.0+builtin.vault
Running SHA256             n/a
Deprecation Status         n/a

ROW 2

Heading                    Value
-------                    -----
Path                       identity/
Plugin                     identity
Accessor                   identity_165e7162
Default TTL                system
Max TTL                    system
Force No Cache             false
Replication                replicated
Seal Wrap                  false
External Entropy Access    false
Options                    map[]
Description                identity store
UUID                       09495e26-50d9-f421-52a3-2ca61ebd4dee
Version                    n/a
Running Version            v1.13.0+builtin.vault
Running SHA256             n/a
Deprecation Status         n/a

ROW 3

Heading                    Value
-------                    -----
Path                       secret/
Plugin                     kv
Accessor                   kv_c538698b
Default TTL                system
Max TTL                    system
Force No Cache             false
Replication                replicated
Seal Wrap                  false
External Entropy Access    false
Options                    map[version:2]
Description                key/value secret storage
UUID                       51d78d10-11d1-957b-8d4c-6cd80d5ebd4f
Version                    n/a
Running Version            v0.13.3+builtin
Running SHA256             n/a
Deprecation Status         supported

ROW 4

Heading                    Value
-------                    -----
Path                       sys/
Plugin                     system
Accessor                   system_3180869e
Default TTL                n/a
Max TTL                    n/a
Force No Cache             false
Replication                replicated
Seal Wrap                  true
External Entropy Access    false
Options                    map[]
Description                system endpoints used for control, policy and debugging
UUID                       9a7430f7-0dd6-ad2a-abbd-2bee87c5be51
Version                    n/a
Running Version            v1.13.0+builtin.vault
Running SHA256             n/a
Deprecation Status         n/a
```

</p>
</details>

## List plugins

Not really the table width this is intended for, but included for illustration:

<details><summary>vault plugin list -detailed</summary>
<p>

```shell-session
$ vault plugin list -detailed
Name                                 Type        Version                  Deprecation Status
----                                 ----        -------                  ------------------
alicloud                             auth        v0.13.0+builtin          supported
app-id                               auth        v1.13.0+builtin.vault    pending removal
approle                              auth        v1.13.0+builtin.vault    supported
aws                                  auth        v1.13.0+builtin.vault    supported
azure                                auth        v0.12.0+builtin          supported
centrify                             auth        v0.13.0+builtin          supported
cert                                 auth        v1.13.0+builtin.vault    supported
cf                                   auth        v0.13.0+builtin          supported
gcp                                  auth        v0.14.0+builtin          supported
github                               auth        v1.13.0+builtin.vault    supported
jwt                                  auth        v0.14.0+builtin          supported
kerberos                             auth        v0.8.0+builtin           supported
kubernetes                           auth        v0.14.0+builtin          supported
ldap                                 auth        v1.13.0+builtin.vault    supported
oci                                  auth        v0.12.0+builtin          supported
oidc                                 auth        v1.13.0+builtin.vault    supported
okta                                 auth        v1.13.0+builtin.vault    supported
pcf                                  auth        v1.13.0+builtin.vault    deprecated
radius                               auth        v1.13.0+builtin.vault    supported
userpass                             auth        v1.13.0+builtin.vault    supported
cassandra-database-plugin            database    v1.13.0+builtin.vault    supported
couchbase-database-plugin            database    v0.8.0+builtin           supported
elasticsearch-database-plugin        database    v0.12.0+builtin          supported
hana-database-plugin                 database    v1.13.0+builtin.vault    supported
influxdb-database-plugin             database    v1.13.0+builtin.vault    supported
mongodb-database-plugin              database    v1.13.0+builtin.vault    supported
mongodbatlas-database-plugin         database    v0.8.0+builtin           supported
mssql-database-plugin                database    v1.13.0+builtin.vault    supported
mysql-aurora-database-plugin         database    v1.13.0+builtin.vault    supported
mysql-database-plugin                database    v1.13.0+builtin.vault    supported
mysql-legacy-database-plugin         database    v1.13.0+builtin.vault    supported
mysql-rds-database-plugin            database    v1.13.0+builtin.vault    supported
postgresql-database-plugin           database    v1.13.0+builtin.vault    supported
redis-database-plugin                database    v0.1.0+builtin           supported
redis-elasticache-database-plugin    database    v0.1.0+builtin           supported
redshift-database-plugin             database    v1.13.0+builtin.vault    supported
snowflake-database-plugin            database    v0.6.0+builtin           supported
ad                                   secret      v0.14.0+builtin          supported
alicloud                             secret      v0.13.0+builtin          supported
aws                                  secret      v1.13.0+builtin.vault    supported
azure                                secret      v0.14.0+builtin          supported
cassandra                            secret      v1.13.0+builtin.vault    pending removal
consul                               secret      v1.13.0+builtin.vault    supported
gcp                                  secret      v0.14.0+builtin          supported
gcpkms                               secret      v0.13.0+builtin          supported
kubernetes                           secret      v0.2.0+builtin           supported
kv                                   secret      v0.13.3+builtin          supported
ldap                                 secret      v1.13.0+builtin.vault    supported
mongodb                              secret      v1.13.0+builtin.vault    pending removal
mongodbatlas                         secret      v0.8.0+builtin           supported
mssql                                secret      v1.13.0+builtin.vault    pending removal
mysql                                secret      v1.13.0+builtin.vault    pending removal
nomad                                secret      v1.13.0+builtin.vault    supported
openldap                             secret      v0.9.0+builtin           supported
pki                                  secret      v1.13.0+builtin.vault    supported
postgresql                           secret      v1.13.0+builtin.vault    pending removal
rabbitmq                             secret      v1.13.0+builtin.vault    supported
ssh                                  secret      v1.13.0+builtin.vault    supported
terraform                            secret      v0.6.0+builtin           supported
totp                                 secret      v1.13.0+builtin.vault    supported
transit                              secret      v1.13.0+builtin.vault    supported
```

</p>
</details>

<details><summary>vault plugin list -detailed -format=expanded</summary>
<p>

```shell-session
ROW 1

Heading               Value
-------               -----
Name                  alicloud
Type                  auth
Version               v0.13.0+builtin
Deprecation Status    supported

ROW 2

Heading               Value
-------               -----
Name                  app-id
Type                  auth
Version               v1.13.0+builtin.vault
Deprecation Status    pending removal

ROW 3

Heading               Value
-------               -----
Name                  approle
Type                  auth
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 4

Heading               Value
-------               -----
Name                  aws
Type                  auth
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 5

Heading               Value
-------               -----
Name                  azure
Type                  auth
Version               v0.12.0+builtin
Deprecation Status    supported

ROW 6

Heading               Value
-------               -----
Name                  centrify
Type                  auth
Version               v0.13.0+builtin
Deprecation Status    supported

ROW 7

Heading               Value
-------               -----
Name                  cert
Type                  auth
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 8

Heading               Value
-------               -----
Name                  cf
Type                  auth
Version               v0.13.0+builtin
Deprecation Status    supported

ROW 9

Heading               Value
-------               -----
Name                  gcp
Type                  auth
Version               v0.14.0+builtin
Deprecation Status    supported

ROW 10

Heading               Value
-------               -----
Name                  github
Type                  auth
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 11

Heading               Value
-------               -----
Name                  jwt
Type                  auth
Version               v0.14.0+builtin
Deprecation Status    supported

ROW 12

Heading               Value
-------               -----
Name                  kerberos
Type                  auth
Version               v0.8.0+builtin
Deprecation Status    supported

ROW 13

Heading               Value
-------               -----
Name                  kubernetes
Type                  auth
Version               v0.14.0+builtin
Deprecation Status    supported

ROW 14

Heading               Value
-------               -----
Name                  ldap
Type                  auth
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 15

Heading               Value
-------               -----
Name                  oci
Type                  auth
Version               v0.12.0+builtin
Deprecation Status    supported

ROW 16

Heading               Value
-------               -----
Name                  oidc
Type                  auth
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 17

Heading               Value
-------               -----
Name                  okta
Type                  auth
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 18

Heading               Value
-------               -----
Name                  pcf
Type                  auth
Version               v1.13.0+builtin.vault
Deprecation Status    deprecated

ROW 19

Heading               Value
-------               -----
Name                  radius
Type                  auth
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 20

Heading               Value
-------               -----
Name                  userpass
Type                  auth
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 21

Heading               Value
-------               -----
Name                  cassandra-database-plugin
Type                  database
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 22

Heading               Value
-------               -----
Name                  couchbase-database-plugin
Type                  database
Version               v0.8.0+builtin
Deprecation Status    supported

ROW 23

Heading               Value
-------               -----
Name                  elasticsearch-database-plugin
Type                  database
Version               v0.12.0+builtin
Deprecation Status    supported

ROW 24

Heading               Value
-------               -----
Name                  hana-database-plugin
Type                  database
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 25

Heading               Value
-------               -----
Name                  influxdb-database-plugin
Type                  database
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 26

Heading               Value
-------               -----
Name                  mongodb-database-plugin
Type                  database
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 27

Heading               Value
-------               -----
Name                  mongodbatlas-database-plugin
Type                  database
Version               v0.8.0+builtin
Deprecation Status    supported

ROW 28

Heading               Value
-------               -----
Name                  mssql-database-plugin
Type                  database
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 29

Heading               Value
-------               -----
Name                  mysql-aurora-database-plugin
Type                  database
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 30

Heading               Value
-------               -----
Name                  mysql-database-plugin
Type                  database
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 31

Heading               Value
-------               -----
Name                  mysql-legacy-database-plugin
Type                  database
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 32

Heading               Value
-------               -----
Name                  mysql-rds-database-plugin
Type                  database
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 33

Heading               Value
-------               -----
Name                  postgresql-database-plugin
Type                  database
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 34

Heading               Value
-------               -----
Name                  redis-database-plugin
Type                  database
Version               v0.1.0+builtin
Deprecation Status    supported

ROW 35

Heading               Value
-------               -----
Name                  redis-elasticache-database-plugin
Type                  database
Version               v0.1.0+builtin
Deprecation Status    supported

ROW 36

Heading               Value
-------               -----
Name                  redshift-database-plugin
Type                  database
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 37

Heading               Value
-------               -----
Name                  snowflake-database-plugin
Type                  database
Version               v0.6.0+builtin
Deprecation Status    supported

ROW 38

Heading               Value
-------               -----
Name                  ad
Type                  secret
Version               v0.14.0+builtin
Deprecation Status    supported

ROW 39

Heading               Value
-------               -----
Name                  alicloud
Type                  secret
Version               v0.13.0+builtin
Deprecation Status    supported

ROW 40

Heading               Value
-------               -----
Name                  aws
Type                  secret
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 41

Heading               Value
-------               -----
Name                  azure
Type                  secret
Version               v0.14.0+builtin
Deprecation Status    supported

ROW 42

Heading               Value
-------               -----
Name                  cassandra
Type                  secret
Version               v1.13.0+builtin.vault
Deprecation Status    pending removal

ROW 43

Heading               Value
-------               -----
Name                  consul
Type                  secret
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 44

Heading               Value
-------               -----
Name                  gcp
Type                  secret
Version               v0.14.0+builtin
Deprecation Status    supported

ROW 45

Heading               Value
-------               -----
Name                  gcpkms
Type                  secret
Version               v0.13.0+builtin
Deprecation Status    supported

ROW 46

Heading               Value
-------               -----
Name                  kubernetes
Type                  secret
Version               v0.2.0+builtin
Deprecation Status    supported

ROW 47

Heading               Value
-------               -----
Name                  kv
Type                  secret
Version               v0.13.3+builtin
Deprecation Status    supported

ROW 48

Heading               Value
-------               -----
Name                  ldap
Type                  secret
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 49

Heading               Value
-------               -----
Name                  mongodb
Type                  secret
Version               v1.13.0+builtin.vault
Deprecation Status    pending removal

ROW 50

Heading               Value
-------               -----
Name                  mongodbatlas
Type                  secret
Version               v0.8.0+builtin
Deprecation Status    supported

ROW 51

Heading               Value
-------               -----
Name                  mssql
Type                  secret
Version               v1.13.0+builtin.vault
Deprecation Status    pending removal

ROW 52

Heading               Value
-------               -----
Name                  mysql
Type                  secret
Version               v1.13.0+builtin.vault
Deprecation Status    pending removal

ROW 53

Heading               Value
-------               -----
Name                  nomad
Type                  secret
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 54

Heading               Value
-------               -----
Name                  openldap
Type                  secret
Version               v0.9.0+builtin
Deprecation Status    supported

ROW 55

Heading               Value
-------               -----
Name                  pki
Type                  secret
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 56

Heading               Value
-------               -----
Name                  postgresql
Type                  secret
Version               v1.13.0+builtin.vault
Deprecation Status    pending removal

ROW 57

Heading               Value
-------               -----
Name                  rabbitmq
Type                  secret
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 58

Heading               Value
-------               -----
Name                  ssh
Type                  secret
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 59

Heading               Value
-------               -----
Name                  terraform
Type                  secret
Version               v0.6.0+builtin
Deprecation Status    supported

ROW 60

Heading               Value
-------               -----
Name                  totp
Type                  secret
Version               v1.13.0+builtin.vault
Deprecation Status    supported

ROW 61

Heading               Value
-------               -----
Name                  transit
Type                  secret
Version               v1.13.0+builtin.vault
Deprecation Status    supported

```

</p>
</details>

## Seal status

Still uses normal table formatter if there are only 2 columns:

<details><summary>vault status</summary>
<p>

```shell-session
$ vault status
Key             Value
---             -----
Seal Type       shamir
Initialized     true
Sealed          false
Total Shares    1
Threshold       1
Version         1.13.0-dev1
Build Date      2022-10-17T09:18:02Z
Storage Type    inmem
Cluster Name    vault-cluster-97d5f713
Cluster ID      3c8b5d61-ea82-6b5b-55b4-ce2354b64bfb
HA Enabled      false
```

</p>
</details>

<details><summary>vault status -format=expanded</summary>
<p>

```shell-session
$ vault status -format=expanded
Key             Value
---             -----
Seal Type       shamir
Initialized     true
Sealed          false
Total Shares    1
Threshold       1
Version         1.13.0-dev1
Build Date      2022-10-17T09:18:02Z
Storage Type    inmem
Cluster Name    vault-cluster-97d5f713
Cluster ID      3c8b5d61-ea82-6b5b-55b4-ce2354b64bfb
HA Enabled      false
```

</p>
</details>