### PR TITLE
Fix format strings missing an argument

### DIFF
--- a/helper/testhelpers/docker/testhelpers.go
+++ b/helper/testhelpers/docker/testhelpers.go
@@ -509,13 +509,13 @@ func BuildContextFromTarball(reader io.Reader) (BuildContext, error) {
 				break
 			}
 
-			return nil, fmt.Errorf("failed to parse provided tarball: %v")
+			return nil, fmt.Errorf("failed to parse provided tarball: %v", err)
 		}
 
 		data := make([]byte, int(header.Size))
 		read, err := archive.Read(data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse read from provided tarball: %v")
+			return nil, fmt.Errorf("failed to parse read from provided tarball: %v", err)
 		}
 
 		if read != int(header.Size) {


### PR DESCRIPTION
Spotted this as part of hack week, was an easy enough fix so thought I'd just make the PR.