### PR TITLE
added note regarding persistence for log level changes

### DIFF
--- a/website/content/api-docs/system/loggers.mdx
+++ b/website/content/api-docs/system/loggers.mdx
@@ -8,6 +8,10 @@ description: The `/sys/loggers` endpoint is used modify the verbosity level of l
 
 The `/sys/loggers` endpoint is used modify the verbosity level of logging.
 
+!> **NOTE:** Changes made to the log level using this endpoint are not persisted and will be restored 
+to either the default log level (info) or the level specified using `log_level` in vault.hcl or the `VAULT_LOG_LEVEL` 
+environment variable once the Vault service is reloaded or restarted.
+
 ## Modify verbosity level of all loggers
 
 | Method  | Path           |


### PR DESCRIPTION
New functionality was added to Vault to enable changing the log level via an API endpoint, this PR adds a note to advise users that changes made via the endpoint are not persisted as it was unclear before.