### PR TITLE
Create remove-labels.yml

### DIFF
--- a/.github/workflows/remove-labels.yml
+++ b/.github/workflows/remove-labels.yml
@@ -1,0 +1,19 @@
+name: Autoremove Labels
+
+on:
+  issues:
+    types: [closed]
+  pull_request_target:
+    types: [closed]
+
+jobs:
+
+  RemoveWaitingLabelFromClosedIssueOrPR:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove triaging labels from closed issues and PRs
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: |
+            waiting-for-response


### PR DESCRIPTION
When closing a GitHub issue or PR, remove the `waiting-for-response` label automatically