### PR TITLE
PKI role create: fix issue with setting default key_bits on init and when key_type changes

### DIFF
--- a/ui/app/models/pki/pki-role-engine.js
+++ b/ui/app/models/pki/pki-role-engine.js
@@ -1,6 +1,5 @@
 import Model, { attr } from '@ember-data/model';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
-import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 import { withModelValidations } from 'vault/decorators/model-validations';
 
 import fieldToAttrs from 'vault/utils/field-to-attrs';
@@ -106,20 +105,7 @@ export default class PkiRoleEngineModel extends Model {
   @attr('string', {
     label: 'Key bits',
   })
-  keyBits;
-
-  // "possibleValues" for the field "keyBits" depends on the value of the selected "keyType"
-  get keyBitsConditional() {
-    const keyBitOptions = {
-      rsa: [2048, 3072, 4096],
-      ec: [256, 224, 384, 521],
-      ed25519: [0],
-      any: [0],
-    };
-    const attrs = expandAttributeMeta(this, ['keyBits']);
-    attrs[0].options['possibleValues'] = keyBitOptions[this.keyType];
-    return attrs[0];
-  }
+  keyBits; // keyBits is a conditional value based on keyType. The model param is handled in the pkiKeyParameters component.
 
   @attr('number', {
     label: 'Signature bits',
@@ -284,11 +270,6 @@ export default class PkiRoleEngineModel extends Model {
           text: 'These options can interact intricately with one another. For more information,',
           docText: 'learn more here.',
           docLink: '/api-docs/secret/pki#allowed_domains',
-        },
-      },
-      'Key parameters': {
-        header: {
-          text: `These are the parameters for generating or validating the certificate's key material.`,
         },
       },
       'Subject Alternative Name (SAN) Options': {

--- a/ui/app/models/pki/pki-role-engine.js
+++ b/ui/app/models/pki/pki-role-engine.js
@@ -104,6 +104,7 @@ export default class PkiRoleEngineModel extends Model {
 
   @attr('string', {
     label: 'Key bits',
+    defaultValue: 2048,
   })
   keyBits; // keyBits is a conditional value based on keyType. The model param is handled in the pkiKeyParameters component.
 

--- a/ui/lib/pki/addon/components/pki-key-parameters.hbs
+++ b/ui/lib/pki/addon/components/pki-key-parameters.hbs
@@ -38,7 +38,8 @@
                     </div>
                   </div>
                 </div>
-              {{else if (eq attr.name "keyType")}}
+                {{! Key type and Signature bits }}
+              {{else}}
                 <div class="field">
                   <FormFieldLabel for={{attr.name}} @label={{attr.options.label}} />
                   <div class="control is-expanded">
@@ -46,7 +47,7 @@
                       <select
                         name={{attr.name}}
                         id={{attr.name}}
-                        onchange={{this.onKeyTypeChange}}
+                        onchange={{fn this.onKeyTypeChange attr.name}}
                         data-test-input={{attr.name}}
                       >
                         {{#each (path-or-array attr.options.possibleValues @model) as |val|}}
@@ -58,14 +59,6 @@
                     </div>
                   </div>
                 </div>
-              {{else}}
-                <FormField
-                  data-test-field={{true}}
-                  @attr={{attr}}
-                  @model={{@model}}
-                  @modelValidations={{this.modelValidations}}
-                  @showHelpText={{false}}
-                />
               {{/if}}
             {{/each}}
           {{/if}}

--- a/ui/lib/pki/addon/components/pki-key-parameters.hbs
+++ b/ui/lib/pki/addon/components/pki-key-parameters.hbs
@@ -15,7 +15,6 @@
       />
       {{#each @model.fieldGroups as |fieldGroup|}}
         {{#each-in fieldGroup as |group fields|}}
-          {{! Key type and signature bits }}
           {{#if (eq group "Key parameters")}}
             {{#each fields as |attr|}}
               {{#if (eq attr.name "keyBits")}}
@@ -38,7 +37,6 @@
                     </div>
                   </div>
                 </div>
-                {{! Key type and Signature bits }}
               {{else}}
                 <div class="field">
                   <FormFieldLabel for={{attr.name}} @label={{attr.options.label}} />
@@ -47,7 +45,7 @@
                       <select
                         name={{attr.name}}
                         id={{attr.name}}
-                        onchange={{fn this.onKeyTypeChange attr.name}}
+                        onchange={{fn this.onSignatureBitsOrKeyTypeChange attr.name}}
                         data-test-input={{attr.name}}
                       >
                         {{#each (path-or-array attr.options.possibleValues @model) as |val|}}

--- a/ui/lib/pki/addon/components/pki-key-parameters.hbs
+++ b/ui/lib/pki/addon/components/pki-key-parameters.hbs
@@ -1,0 +1,76 @@
+{{#let (camelize (concat "show" @group)) as |prop|}}
+  <ToggleButton
+    @isOpen={{get @model prop}}
+    @openLabel={{concat "Hide " @group}}
+    @closedLabel={{@group}}
+    @onClick={{fn (mut (get @model prop))}}
+    class="is-block"
+    data-test-toggle-group={{@group}}
+  />
+  {{#if (get @model prop)}}
+    <div class="box is-tall is-marginless">
+      <FormFieldLabel
+        for="keyParametersLabel"
+        @subText="These are the parameters for generating or validating the certificate's key material."
+      />
+      {{#each @model.fieldGroups as |fieldGroup|}}
+        {{#each-in fieldGroup as |group fields|}}
+          {{! Key type and signature bits }}
+          {{#if (eq group "Key parameters")}}
+            {{#each fields as |attr|}}
+              {{#if (eq attr.name "keyBits")}}
+                <div class="field">
+                  <FormFieldLabel for={{attr.name}} @label={{attr.options.label}} />
+                  <div class="control is-expanded">
+                    <div class="select is-fullwidth">
+                      <select
+                        name={{attr.name}}
+                        id={{attr.name}}
+                        onchange={{this.onKeyBitsChange}}
+                        data-test-input={{attr.name}}
+                      >
+                        {{#each this.keyBitOptions as |val|}}
+                          <option selected={{eq (get @model this.valuePath) (or val.value val)}} value={{val}}>
+                            {{val}}
+                          </option>
+                        {{/each}}
+                      </select>
+                    </div>
+                  </div>
+                </div>
+              {{else if (eq attr.name "keyType")}}
+                <div class="field">
+                  <FormFieldLabel for={{attr.name}} @label={{attr.options.label}} />
+                  <div class="control is-expanded">
+                    <div class="select is-fullwidth">
+                      <select
+                        name={{attr.name}}
+                        id={{attr.name}}
+                        onchange={{this.onKeyTypeChange}}
+                        data-test-input={{attr.name}}
+                      >
+                        {{#each (path-or-array attr.options.possibleValues @model) as |val|}}
+                          <option selected={{eq (get @model this.valuePath) (or val.value val)}} value={{or val.value val}}>
+                            {{or val.displayName val}}
+                          </option>
+                        {{/each}}
+                      </select>
+                    </div>
+                  </div>
+                </div>
+              {{else}}
+                <FormField
+                  data-test-field={{true}}
+                  @attr={{attr}}
+                  @model={{@model}}
+                  @modelValidations={{this.modelValidations}}
+                  @showHelpText={{false}}
+                />
+              {{/if}}
+            {{/each}}
+          {{/if}}
+        {{/each-in}}
+      {{/each}}
+    </div>
+  {{/if}}
+{{/let}}

--- a/ui/lib/pki/addon/components/pki-key-parameters.js
+++ b/ui/lib/pki/addon/components/pki-key-parameters.js
@@ -40,10 +40,11 @@ export default class PkiKeyParameters extends Component {
   }
 
   @action onSignatureBitsOrKeyTypeChange(name, selection) {
-    // set the model for either signatureBits or keyType
-    this.args.model.set(name, selection.target.value);
-
+    if (name === 'signatureBits') {
+      this.args.model.set(name, Number(selection.target.value));
+    }
     if (name === 'keyType') {
+      this.args.model.set(name, selection.target.value);
       this.args.model.set('keyBits', this.keyBitsDefault);
     }
   }

--- a/ui/lib/pki/addon/components/pki-key-parameters.js
+++ b/ui/lib/pki/addon/components/pki-key-parameters.js
@@ -21,12 +21,6 @@ const KEY_BITS_OPTIONS = {
 };
 
 export default class PkiKeyParameters extends Component {
-  constructor() {
-    super(...arguments);
-    // set the default value for keyBits which depends on the keyType shown.
-    this.args.model.set('keyBits', this.keyBitsDefault);
-  }
-
   get keyBitOptions() {
     return KEY_BITS_OPTIONS[this.args.model.keyType];
   }

--- a/ui/lib/pki/addon/components/pki-key-parameters.js
+++ b/ui/lib/pki/addon/components/pki-key-parameters.js
@@ -39,8 +39,12 @@ export default class PkiKeyParameters extends Component {
     this.args.model.set('keyBits', Number(selection.target.value));
   }
 
-  @action onKeyTypeChange(selection) {
-    this.args.model.set('keyType', selection.target.value);
-    this.args.model.set('keyBits', this.keyBitsDefault);
+  @action onKeyTypeChange(name, selection) {
+    // set the model for either signatureBits or keyType
+    this.args.model.set(name, selection.target.value);
+
+    if (name === 'keyType') {
+      this.args.model.set('keyBits', this.keyBitsDefault);
+    }
   }
 }

--- a/ui/lib/pki/addon/components/pki-key-parameters.js
+++ b/ui/lib/pki/addon/components/pki-key-parameters.js
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 /**
  * @module PkiKeyParameters
  * PkiKeyParameters components are used to set the default and update the key_bits pki role api param whenever the key_type changes.
- * key_bits is conditional on key_type and should be set as a default value on init and also update to the new default whenever key_type changes.
+ * key_bits is conditional on key_type and should be set as a default value whenever key_type changes.
  * @example
  * ```js
  * <PkiKeyParameters @model={@model} @group={group}/>

--- a/ui/lib/pki/addon/components/pki-key-parameters.js
+++ b/ui/lib/pki/addon/components/pki-key-parameters.js
@@ -1,0 +1,46 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+/**
+ * @module PkiKeyParameters
+ * PkiKeyParameters components are used to set the default and update the key_bits pki role api param whenever the key_type changes.
+ * key_bits is conditional on key_type and should be set as a default value on init and also update to the new default whenever key_type changes.
+ * @example
+ * ```js
+ * <PkiKeyParameters @model={@model} @group={group}/>
+ * ```
+ * @param {class} model - The pki/pki-role-engine model.
+ * @param {string} group - The name of the group created in the model. In this case, it's the "Key parameters" group.
+ */
+
+const KEY_BITS_OPTIONS = {
+  rsa: [2048, 3072, 4096],
+  ec: [256, 224, 384, 521],
+  ed25519: [0],
+  any: [0],
+};
+
+export default class PkiKeyParameters extends Component {
+  constructor() {
+    super(...arguments);
+    // set the default value for keyBits which depends on the keyType shown.
+    this.args.model.set('keyBits', this.keyBitsDefault);
+  }
+
+  get keyBitOptions() {
+    return KEY_BITS_OPTIONS[this.args.model.keyType];
+  }
+
+  get keyBitsDefault() {
+    return Number(KEY_BITS_OPTIONS[this.args.model.keyType][0]);
+  }
+
+  @action onKeyBitsChange(selection) {
+    this.args.model.set('keyBits', Number(selection.target.value));
+  }
+
+  @action onKeyTypeChange(selection) {
+    this.args.model.set('keyType', selection.target.value);
+    this.args.model.set('keyBits', this.keyBitsDefault);
+  }
+}

--- a/ui/lib/pki/addon/components/pki-key-parameters.js
+++ b/ui/lib/pki/addon/components/pki-key-parameters.js
@@ -39,7 +39,7 @@ export default class PkiKeyParameters extends Component {
     this.args.model.set('keyBits', Number(selection.target.value));
   }
 
-  @action onKeyTypeChange(name, selection) {
+  @action onSignatureBitsOrKeyTypeChange(name, selection) {
     // set the model for either signatureBits or keyType
     this.args.model.set(name, selection.target.value);
 

--- a/ui/lib/pki/addon/components/pki-role-form.hbs
+++ b/ui/lib/pki/addon/components/pki-role-form.hbs
@@ -48,6 +48,8 @@
           {{/each}}
         {{else if (eq group "Key usage")}}
           <PkiKeyUsage @model={{@model}} @group={{group}} />
+        {{else if (eq group "Key parameters")}}
+          <PkiKeyParameters @model={{@model}} @group={{group}} />
         {{else}}
           {{! Groups hidden behind Toggles }}
           {{#let (camelize (concat "show" group)) as |prop|}}
@@ -77,7 +79,7 @@
                   {{#each fields as |attr|}}
                     <FormField
                       data-test-field={{true}}
-                      @attr={{if (eq attr.name "keyBits") @model.keyBitsConditional attr}}
+                      @attr={{attr}}
                       @model={{@model}}
                       @modelValidations={{@modelValidations}}
                       @showHelpText={{false}}

--- a/ui/lib/pki/addon/templates/configuration/index.hbs
+++ b/ui/lib/pki/addon/templates/configuration/index.hbs
@@ -10,10 +10,10 @@
 />
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink @params={{array "configuration.tidy"}}>
+    <ToolbarLink @route="configuration.tidy">
       Tidy
     </ToolbarLink>
-    <ToolbarLink @params={{array "configuration.edit"}}>
+    <ToolbarLink @route="configuration.edit">
       Edit configuration
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/lib/pki/addon/templates/issuers/index.hbs
+++ b/ui/lib/pki/addon/templates/issuers/index.hbs
@@ -10,7 +10,7 @@
 />
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink @params={{array "configuration.create.import-ca"}}>
+    <ToolbarLink @route="configuration.create.import-ca">
       Import
     </ToolbarLink>
     <BasicDropdown @class="popup-menu" @horizontalPosition="auto-right" @verticalPosition="below" as |D|>

--- a/ui/lib/pki/addon/templates/keys/index.hbs
+++ b/ui/lib/pki/addon/templates/keys/index.hbs
@@ -10,10 +10,10 @@
 />
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink @params={{array "keys.import"}} @type="download">
+    <ToolbarLink @route="keys.import" @type="download">
       Import
     </ToolbarLink>
-    <ToolbarLink @params={{array "keys.generate"}} @type="add">
+    <ToolbarLink @route="keys.generate" @type="add">
       Generate
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/lib/pki/addon/templates/overview.hbs
+++ b/ui/lib/pki/addon/templates/overview.hbs
@@ -10,7 +10,7 @@
 />
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink @params={{array "configuration.create.index"}}>
+    <ToolbarLink @route="configuration.create.index">
       Configure PKI
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/lib/pki/addon/templates/roles/index.hbs
+++ b/ui/lib/pki/addon/templates/roles/index.hbs
@@ -10,7 +10,7 @@
 />
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink @type="add" @params={{array "roles.create"}}>
+    <ToolbarLink @type="add" @route="roles.create">
       Create role
     </ToolbarLink>
   </ToolbarActions>


### PR DESCRIPTION
There was an issue where the `keyBit` value was not being set on init nor was it being set when `keyType` changed, even though the dropdown options were changing.

I pulled all the conditional options work out of the model, and moved it all into a component. This should help clarify what's going on, and move semi-complication logic work out of the model. Also, it will help organize testing.

https://user-images.githubusercontent.com/6618863/196794124-31ccdac2-4f38-4b59-95f6-71a936262453.mov

In the API you can see the default key_bits set for each key_type.

![image](https://user-images.githubusercontent.com/6618863/196792330-22715137-0896-4af0-832e-6b296b6f742f.png)

And the default key_type is `rsa`. You can test this in the current PKI. Even though we don't send this default value in the old PKI, the read view shows rsa and 2048.
![image](https://user-images.githubusercontent.com/6618863/196794230-2f205f29-4bfa-481a-8100-a04c0ca8eaba.png)




