### PR TITLE
Add plugin versioning to 1.12.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ FEATURES:
 * **Transform Key Import (BYOK)**: The transform secrets engine now supports importing keys for tokenization and FPE transformations
 * HCP (enterprise): Adding foundational support for self-managed vault nodes to securely communicate with [HashiCorp Cloud Platform](https://cloud.hashicorp.com) as an opt-in feature
 * ui: UI support for Okta Number Challenge. [[GH-15998](https://github.com/hashicorp/vault/pull/15998)]
+* **Plugin Versioning**: Vault supports registering, managing, and running plugins with semantic versions specified.
 
 IMPROVEMENTS:
 


### PR DESCRIPTION
This has the contents of https://github.com/hashicorp/vault/blob/826b20c1da99fc57ae99cc399ef28c3fbacad0b1/changelog/plugin-versioning.txt. I'm not clear what went wrong, but now that the release is done, we'll need to add it directly instead of relying on the changelog tooling.