### PR TITLE
VAULT-9451 Fix data race in entity merge

### DIFF
--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -1092,18 +1092,6 @@ func (i *IdentityStore) MemDBEntityByIDInTxn(txn *memdb.Txn, entityID string, cl
 	return entity, nil
 }
 
-func (i *IdentityStore) UpdateEntityWithMountInformation(entity *identity.Entity) {
-	if entity != nil {
-		for _, alias := range entity.Aliases {
-			mountValidationResp := i.router.ValidateMountByAccessor(alias.MountAccessor)
-			if mountValidationResp != nil {
-				alias.MountType = mountValidationResp.MountType
-				alias.MountPath = mountValidationResp.MountPath
-			}
-		}
-	}
-}
-
 func (i *IdentityStore) MemDBEntityByID(entityID string, clone bool) (*identity.Entity, error) {
 	if entityID == "" {
 		return nil, fmt.Errorf("missing entity id")


### PR DESCRIPTION
I ran `TestReplicationApi_ApproleLocal_MultiNodeMultiLogin` a bunch of times (which showed this race) and can't seem to reproduce this race any more (and can't see how it would occur any more).

Do let me know if there's any other test i should be running.

This also changes so that `ValidateMountByAccessor` is only called when required, which should be better anyway.