### PR TITLE
Add AD mode to Transit's AEAD ciphers

### DIFF
--- a/changelog/17638.txt
+++ b/changelog/17638.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/transit: Add associated_data parameter for additional authenticated data in AEAD ciphers
+```

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -535,6 +535,10 @@ will be returned.
 - `plaintext` `(string: <required>)` – Specifies **base64 encoded** plaintext to
   be encoded.
 
+- `associated_data` `(string: "")` - Specifies **base64 encoded** associated
+  data (also known as additional data or AAD) to also be authenticated with
+  AEAD ciphers (`aes128-gcm96`, `aes256-gcm`, and `chacha20-poly1305`).
+
 - `context` `(string: "")` – Specifies the **base64 encoded** context for key
   derivation. This is required if key derivation is enabled for this key.
 
@@ -645,6 +649,10 @@ This endpoint decrypts the provided ciphertext using the named key.
   decrypt against. This is specified as part of the URL.
 
 - `ciphertext` `(string: <required>)` – Specifies the ciphertext to decrypt.
+
+- `associated_data` `(string: "")` - Specifies **base64 encoded** associated
+  data (also known as additional data or AAD) to also be authenticated with
+  AEAD ciphers (`aes128-gcm96`, `aes256-gcm`, and `chacha20-poly1305`).
 
 - `context` `(string: "")` – Specifies the **base64 encoded** context for key
   derivation. This is required if key derivation is enabled.


### PR DESCRIPTION
Project I started during hack week, but didn't quite finish... (something something, tests) :-) 

This adds a new parameter, `associated_data` to be passed when using an AEAD cipher (AES+GCM, ChaCha20+Poly1305). This is authenticated, but need not be transited in ciphertext.



