### PR TITLE
[docs] Added 'Manually Revocable' to the table

### DIFF
--- a/website/content/docs/concepts/tokens.mdx
+++ b/website/content/docs/concepts/tokens.mdx
@@ -255,6 +255,7 @@ batch tokens.
 | Can Be Root Tokens                                  |                                                     Yes |                                              No |
 | Can Create Child Tokens                             |                                                     Yes |                                              No |
 | Can be Renewable                                    |                                                     Yes |                                              No |
+| Manually Revocable                                  |                                                     Yes |                                              No |
 | Can be Periodic                                     |                                                     Yes |                                              No |
 | Can have Explicit Max TTL                           |                                                     Yes |                    No (always uses a fixed TTL) |
 | Has Accessors                                       |                                                     Yes |                                              No |


### PR DESCRIPTION
🎟️ [Asana](https://app.asana.com/0/563192436488770/1203231828714799/f)
🔍 [Deploy Preview](https://vault-git-docs-update-token-table-hashicorp.vercel.app/vault/docs/concepts/tokens#token-type-comparison)

It was reported that **Manually Revocable** is not mentioned in the service vs. batch token comparison table. This PR adds a row to mention that.

![image](https://user-images.githubusercontent.com/7660718/197655388-0d4806a5-a200-4ace-b4d3-b47bca943801.png)
