### PR TITLE
Fix rendering of custom response headers

### DIFF
--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -294,7 +294,7 @@ listener "tcp" {
     },
     "301" = {
       "Strict-Transport-Security" = ["max-age=31536000"],
-      “Content-Security-Policy" = ["connect-src https://clusterC.vault.external/"],
+      "Content-Security-Policy" = ["connect-src https://clusterC.vault.external/"],
     },
   }
 }


### PR DESCRIPTION
The double quote used broke syntax highlighting. Replace with a proper double quote.

[Before](https://developer.hashicorp.com/vault/docs/configuration/listener/tcp#configuring-custom-http-response-headers):

![image](https://user-images.githubusercontent.com/6604151/197885968-78b00e31-cb7f-4e56-9e2c-691bd42e49d1.png)
