### PR TITLE
Delete iron bank update event for Vault 1.9.x

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -268,16 +268,3 @@ event "post-publish-website" {
     on = "always"
   }
 }
-
-event "update-ironbank" {
-  depends = ["post-publish-website"]
-  action "update-ironbank" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "update-ironbank"
-  }
-
-  notification {
-    on = "fail"
-  }
-}


### PR DESCRIPTION
Iron Bank won't be offering this version of Vault anymore, so this workflow is not necessary.