### PR TITLE
Allow patching a role to create a new one

### DIFF
--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -855,7 +855,8 @@ func (b *backend) pathRolePatch(ctx context.Context, req *logical.Request, data 
 		return nil, err
 	}
 	if oldEntry == nil {
-		return logical.ErrorResponse("Unable to fetch role entry to patch"), nil
+		// Patch without an existing role is the same as creating a new role.
+		return b.pathRoleCreate(ctx, req, data)
 	}
 
 	entry := &roleEntry{


### PR DESCRIPTION
When PKI's role patch operation was first created, we didn't allow creating a role if it didn't exist. Now that a patch-capable CLI is supported, users might wish to use that instead for high-impact endpoints like role modification.

Support creating roles via patch operation, as per the RFC 5789, it leaves it to us to decide:

    The PATCH method requests that a set of changes described in the
    request entity be applied to the resource identified by the Request-
    URI.  The set of changes is represented in a format called a "patch
    document" identified by a media type.  If the Request-URI does not
    point to an existing resource, the server MAY create a new resource,
    depending on the patch document type (whether it can logically modify
    a null resource) and permissions, etc.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`