### PR TITLE
Clean up dev cert construction

### DIFF
--- a/command/server/tls_util.go
+++ b/command/server/tls_util.go
@@ -66,6 +66,18 @@ func GenerateCert(caCertTemplate *x509.Certificate, caSigner crypto.Signer) (str
 		SubjectKeyId:   signerKeyId,
 	}
 
+	// Only add our hostname to SANs if it isn't found.
+	foundHostname := false
+	for _, value := range template.DNSNames {
+		if value == hostname {
+			foundHostname = true
+			break
+		}
+	}
+	if !foundHostname {
+		template.DNSNames = append(template.DNSNames, hostname)
+	}
+
 	bs, err := x509.CreateCertificate(
 		rand.Reader, &template, caCertTemplate, signer.Public(), caSigner)
 	if err != nil {
@@ -113,7 +125,6 @@ func GenerateCA() (*CaCert, error) {
 		NotBefore:             time.Now().Add(-1 * time.Minute),
 		AuthorityKeyId:        signerKeyId,
 		SubjectKeyId:          signerKeyId,
-		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
 	}
 
 	bs, err := x509.CreateCertificate(


### PR DESCRIPTION
Vault's new TLS `devvault` mode has two nits with certificate construction that I missed on the initial review:

 1. The CA doesn't need to include any SANs, as these aren't checked. Technically this means the CA could be reused as a leaf certificate for the one specified IP SAN, which is less desirable.
 2. Add hostname to SANs in addition to CNs. This is a best practice, as (when the CN is a hostname), it is preferable to have everything in SANs as well.

Neither of these are major changes.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`