### PR TITLE
Fix tests - Update MongoDB driver

### DIFF
--- a/helper/testhelpers/mongodb/mongodbhelper.go
+++ b/helper/testhelpers/mongodb/mongodbhelper.go
@@ -2,19 +2,15 @@ package mongodb
 
 import (
 	"context"
-	"crypto/tls"
-	"errors"
 	"fmt"
-	"net"
-	"net/url"
 	"os"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/vault/helper/testhelpers/docker"
-	"gopkg.in/mgo.v2"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
 )
 
 // PrepareTestContainer calls PrepareTestContainerWithDatabase without a
@@ -44,20 +40,14 @@ func PrepareTestContainerWithDatabase(t *testing.T, version, dbName string) (fun
 		if dbName != "" {
 			connURL = fmt.Sprintf("%s/%s", connURL, dbName)
 		}
-		dialInfo, err := ParseMongoURL(connURL)
+
+		ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
+		client, err := mongo.Connect(ctx, options.Client().ApplyURI(connURL))
 		if err != nil {
 			return nil, err
 		}
 
-		session, err := mgo.DialWithInfo(dialInfo)
-		if err != nil {
-			return nil, err
-		}
-		defer session.Close()
-
-		session.SetSyncTimeout(1 * time.Minute)
-		session.SetSocketTimeout(1 * time.Minute)
-		err = session.Ping()
+		err = client.Ping(ctx, readpref.Primary())
 		if err != nil {
 			return nil, err
 		}
@@ -69,73 +59,4 @@ func PrepareTestContainerWithDatabase(t *testing.T, version, dbName string) (fun
 	}
 
 	return svc.Cleanup, svc.Config.URL().String()
-}
-
-// ParseMongoURL will parse a connection string and return a configured dialer
-func ParseMongoURL(rawURL string) (*mgo.DialInfo, error) {
-	url, err := url.Parse(rawURL)
-	if err != nil {
-		return nil, err
-	}
-
-	info := mgo.DialInfo{
-		Addrs:    strings.Split(url.Host, ","),
-		Database: strings.TrimPrefix(url.Path, "/"),
-		Timeout:  10 * time.Second,
-	}
-
-	if url.User != nil {
-		info.Username = url.User.Username()
-		info.Password, _ = url.User.Password()
-	}
-
-	query := url.Query()
-	for key, values := range query {
-		var value string
-		if len(values) > 0 {
-			value = values[0]
-		}
-
-		switch key {
-		case "authSource":
-			info.Source = value
-		case "authMechanism":
-			info.Mechanism = value
-		case "gssapiServiceName":
-			info.Service = value
-		case "replicaSet":
-			info.ReplicaSetName = value
-		case "maxPoolSize":
-			poolLimit, err := strconv.Atoi(value)
-			if err != nil {
-				return nil, errors.New("bad value for maxPoolSize: " + value)
-			}
-			info.PoolLimit = poolLimit
-		case "ssl":
-			// Unfortunately, mgo doesn't support the ssl parameter in its MongoDB URI parsing logic, so we have to handle that
-			// ourselves. See https://github.com/go-mgo/mgo/issues/84
-			ssl, err := strconv.ParseBool(value)
-			if err != nil {
-				return nil, errors.New("bad value for ssl: " + value)
-			}
-			if ssl {
-				info.DialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {
-					return tls.Dial("tcp", addr.String(), &tls.Config{})
-				}
-			}
-		case "connect":
-			if value == "direct" {
-				info.Direct = true
-				break
-			}
-			if value == "replicaSet" {
-				break
-			}
-			fallthrough
-		default:
-			return nil, errors.New("unsupported connection URL option: " + key + "=" + value)
-		}
-	}
-
-	return &info, nil
 }

--- a/helper/testhelpers/mongodb/mongodbhelper.go
+++ b/helper/testhelpers/mongodb/mongodbhelper.go
@@ -41,15 +41,15 @@ func PrepareTestContainerWithDatabase(t *testing.T, version, dbName string) (fun
 			connURL = fmt.Sprintf("%s/%s", connURL, dbName)
 		}
 
-		ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, _ = context.WithTimeout(context.Background(), 1*time.Minute)
 		client, err := mongo.Connect(ctx, options.Client().ApplyURI(connURL))
 		if err != nil {
 			return nil, err
 		}
 
 		err = client.Ping(ctx, readpref.Primary())
-		if err != nil {
-			return nil, err
+		if err = client.Disconnect(ctx); err != nil {
+			t.Fatal()
 		}
 
 		return docker.NewServiceURLParse(connURL)

--- a/plugins/database/mongodb/connection_producer_test.go
+++ b/plugins/database/mongodb/connection_producer_test.go
@@ -213,7 +213,7 @@ func startMongoWithTLS(t *testing.T, version string, confDir string) (retURL str
 	// exponential backoff-retry
 	err = pool.Retry(func() error {
 		var err error
-		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, _ := context.WithTimeout(context.Background(), 1*time.Minute)
 		client, err := mongo.Connect(ctx, options.Client().ApplyURI(retURL))
 		if err != nil {
 			return err

--- a/plugins/database/mongodb/connection_producer_test.go
+++ b/plugins/database/mongodb/connection_producer_test.go
@@ -14,13 +14,11 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/helper/testhelpers/certhelpers"
-	"github.com/hashicorp/vault/helper/testhelpers/mongodb"
 	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/ory/dockertest"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
-	"gopkg.in/mgo.v2"
 )
 
 func TestInit_clientTLS(t *testing.T) {
@@ -215,19 +213,12 @@ func startMongoWithTLS(t *testing.T, version string, confDir string) (retURL str
 	// exponential backoff-retry
 	err = pool.Retry(func() error {
 		var err error
-		dialInfo, err := mongodb.ParseMongoURL(retURL)
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+		client, err := mongo.Connect(ctx, options.Client().ApplyURI(retURL))
 		if err != nil {
 			return err
 		}
-
-		session, err := mgo.DialWithInfo(dialInfo)
-		if err != nil {
-			return err
-		}
-		defer session.Close()
-		session.SetSyncTimeout(1 * time.Minute)
-		session.SetSocketTimeout(1 * time.Minute)
-		return session.Ping()
+		return client.Ping(ctx, readpref.Primary())
 	})
 	if err != nil {
 		cleanup()

--- a/plugins/database/mongodb/connection_producer_test.go
+++ b/plugins/database/mongodb/connection_producer_test.go
@@ -215,8 +215,8 @@ func startMongoWithTLS(t *testing.T, version string, confDir string) (retURL str
 		var err error
 		ctx, _ := context.WithTimeout(context.Background(), 1*time.Minute)
 		client, err := mongo.Connect(ctx, options.Client().ApplyURI(retURL))
-		if err != nil {
-			return err
+		if err = client.Disconnect(ctx); err != nil {
+			t.Fatal()
 		}
 		return client.Ping(ctx, readpref.Primary())
 	})

--- a/plugins/database/mongodb/mongodb_test.go
+++ b/plugins/database/mongodb/mongodb_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-
 	"github.com/hashicorp/vault/helper/testhelpers/certhelpers"
 	"github.com/hashicorp/vault/helper/testhelpers/mongodb"
 	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
@@ -27,7 +26,7 @@ import (
 const mongoAdminRole = `{ "db": "admin", "roles": [ { "role": "readWrite" } ] }`
 
 func TestMongoDB_Initialize(t *testing.T) {
-	cleanup, connURL := mongodb.PrepareTestContainer(t, "5.0.10")
+	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
 	defer cleanup()
 
 	db := new()
@@ -120,7 +119,7 @@ func TestNewUser_usernameTemplate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			cleanup, connURL := mongodb.PrepareTestContainer(t, "5.0.10")
+			cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
 			defer cleanup()
 
 			db := new()
@@ -146,7 +145,7 @@ func TestNewUser_usernameTemplate(t *testing.T) {
 }
 
 func TestMongoDB_CreateUser(t *testing.T) {
-	cleanup, connURL := mongodb.PrepareTestContainer(t, "5.0.10")
+	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
 	defer cleanup()
 
 	db := new()
@@ -178,7 +177,7 @@ func TestMongoDB_CreateUser(t *testing.T) {
 }
 
 func TestMongoDB_CreateUser_writeConcern(t *testing.T) {
-	cleanup, connURL := mongodb.PrepareTestContainer(t, "5.0.10")
+	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
 	defer cleanup()
 
 	initReq := dbplugin.InitializeRequest{
@@ -212,7 +211,7 @@ func TestMongoDB_CreateUser_writeConcern(t *testing.T) {
 }
 
 func TestMongoDB_DeleteUser(t *testing.T) {
-	cleanup, connURL := mongodb.PrepareTestContainer(t, "5.0.10")
+	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
 	defer cleanup()
 
 	db := new()
@@ -252,7 +251,7 @@ func TestMongoDB_DeleteUser(t *testing.T) {
 }
 
 func TestMongoDB_UpdateUser_Password(t *testing.T) {
-	cleanup, connURL := mongodb.PrepareTestContainer(t, "5.0.10")
+	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
 	defer cleanup()
 
 	// The docker test method PrepareTestContainer defaults to a database "test"


### PR DESCRIPTION
Related PR: https://github.com/hashicorp/vault/pull/16880 

MongoDB tests started failing when Mongo released v6 docker version. I updated MongoDB driver from [mgo](https://github.com/go-mgo/mgo) unmaintained driver to the official [MongoDB driver](https://github.com/mongodb/mongo-go-driver).

Updating the driver and deleting the standalone secrets engine fixed the problem. Results from running tests with the "_latest_" tag:
<img width="1675" alt="Screen Shot 2022-10-24 at 10 24 14 AM" src="https://user-images.githubusercontent.com/60530402/197587904-3ad5a820-5113-47a4-9277-5011ca1b012c.png">
