### PR TITLE
Don't verify database connection on `GetConnectionWithConfig`

### DIFF
--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -267,7 +267,7 @@ func (b *databaseBackend) GetConnectionWithConfig(ctx context.Context, name stri
 
 	initReq := v5.InitializeRequest{
 		Config:           config.ConnectionDetails,
-		VerifyConnection: true,
+		VerifyConnection: false,
 	}
 	_, err = dbw.Initialize(ctx, initReq)
 	if err != nil {


### PR DESCRIPTION
Connection verification can take a very long time. Especially if the database is unavailable. At the same time, the connection check in the `GetConnectionWithConfig` method is executed under the `b.connections` write lock.

In this case, we get a situation where create and revoke secrets makes it impossible to change the connections configuration: we wait too many time in `connectionWriteHandler` for `b.connections` write lock and got `context.Timeout` error on `storeConfig`.

## Issue story
We have a vault installation that is used in a test environment.

In particular, it issues temporary secrets for accessing the MongoDB temporary servers.

MongoDB was stopped at one of the test stands, while the services were working and trying to get secrets (and got errors).

At the same time, there were no problems outside this test stand: the `DatabaseWrapper` inside the vault was created and the locks were localized in it.

After restarting vault, we got into a situation where the creation and deletion of new test stands became blocked due to the inability to add/remove MongoDB server configuration in vault: each problematic stand request took a lock on `b.connections` for a one minute (default connection timeout to MongoDB) in an attempt to connect to a non-existent MongoDB server to create new `DatabaseWrapper` in the `GetConnectionWithConfig` method.