### PR TITLE
Docs: Patch command ordering

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -655,12 +655,12 @@
         ]
       },
       {
-        "title": "<code>path-help</code>",
-        "path": "commands/path-help"
-      },
-      {
         "title": "<code>patch</code>",
         "path": "commands/patch"
+      },
+      {
+        "title": "<code>path-help</code>",
+        "path": "commands/path-help"
       },
       {
         "title": "<code>plugin</code>",


### PR DESCRIPTION
#17650 introduced some vercel build failures on main, e.g. https://vercel.com/hashicorp/vault/ETjK3dsbZq86oQtLumQRsTyGUZuP

> Error: Unlinked pages found in the ../content/docs directory.

#17676 fixed it, but then also backported it to the release branches which don't have the new file, causing errors like https://vercel.com/hashicorp/vault/2jp5Sh6phpDmdpgaAQ2iZLgJX5g6

> Error: Could not find file to match path "commands/patch". Neither "commands/patch.mdx" or "commands/patch/index.mdx" could be found.

I'm surprised, but it seems like despite that vercel error, `patch` is still showing up on the 1.12.x, 1.11.x and 1.10.x versions of the docs atm, but with an error:

* https://developer.hashicorp.com/vault/docs/commands
* https://developer.hashicorp.com/vault/docs/commands/patch
* https://developer.hashicorp.com/vault/docs/v1.11.x/commands/patch
* https://developer.hashicorp.com/vault/docs/v1.10.x/commands/patch

I'll open separate PRs for the release branches.