### PR TITLE
Fix raw format for other commands, add to docs!

### DIFF
--- a/command/base.go
+++ b/command/base.go
@@ -582,9 +582,14 @@ func (f *FlagSets) Completions() complete.Flags {
 	return f.completions
 }
 
+type (
+	ParseOptions              interface{}
+	ParseOptionAllowRawFormat bool
+)
+
 // Parse parses the given flags, returning any errors.
 // Warnings, if any, regarding the arguments format are sent to stdout
-func (f *FlagSets) Parse(args []string) error {
+func (f *FlagSets) Parse(args []string, opts ...ParseOptions) error {
 	err := f.mainSet.Parse(args)
 
 	warnings := generateFlagWarnings(f.Args())
@@ -592,7 +597,12 @@ func (f *FlagSets) Parse(args []string) error {
 		f.ui.Warn(warnings)
 	}
 
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Now surface any other errors.
+	return generateFlagErrors(f, opts...)
 }
 
 // Parsed reports whether the command-line flags have been parsed.

--- a/command/base.go
+++ b/command/base.go
@@ -518,9 +518,10 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 					Target:     &c.flagFormat,
 					Default:    "table",
 					EnvVar:     EnvVaultFormat,
-					Completion: complete.PredictSet("table", "json", "yaml", "pretty"),
+					Completion: complete.PredictSet("table", "json", "yaml", "pretty", "raw"),
 					Usage: `Print the output in the given format. Valid formats
-						are "table", "json", "yaml", or "pretty".`,
+						are "table", "json", "yaml", or "pretty". "raw" is allowed
+						for 'vault read' operations only.`,
 				})
 			}
 

--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -322,3 +322,20 @@ func generateFlagWarnings(args []string) string {
 		return ""
 	}
 }
+
+func generateFlagErrors(f *FlagSets, opts ...ParseOptions) error {
+	if Format(f.ui) == "raw" {
+		canUseRaw := false
+		for _, opt := range opts {
+			if value, ok := opt.(ParseOptionAllowRawFormat); ok {
+				canUseRaw = bool(value)
+			}
+		}
+
+		if !canUseRaw {
+			return fmt.Errorf("This command does not support the -format=raw option.")
+		}
+	}
+
+	return nil
+}

--- a/command/format.go
+++ b/command/format.go
@@ -132,7 +132,7 @@ type RawFormatter struct{}
 func (r RawFormatter) Format(data interface{}) ([]byte, error) {
 	byte_data, ok := data.([]byte)
 	if !ok {
-		return nil, fmt.Errorf("unable to type assert to []byte: %T; please share the command run", data)
+		return nil, fmt.Errorf("This command does not support the -format=raw option; only `vault read` does.")
 	}
 
 	return byte_data, nil

--- a/command/read.go
+++ b/command/read.go
@@ -59,7 +59,7 @@ func (c *ReadCommand) AutocompleteFlags() complete.Flags {
 func (c *ReadCommand) Run(args []string) int {
 	f := c.Flags()
 
-	if err := f.Parse(args); err != nil {
+	if err := f.Parse(args, ParseOptionAllowRawFormat(true)); err != nil {
 		c.UI.Error(err.Error())
 		return 1
 	}

--- a/command/util.go
+++ b/command/util.go
@@ -104,7 +104,7 @@ func PrintRawField(ui cli.Ui, data interface{}, field string) int {
 	}
 
 	format := Format(ui)
-	if format == "" || format == "table" {
+	if format == "" || format == "table" || format == "raw" {
 		return PrintRaw(ui, fmt.Sprintf("%v", val))
 	}
 

--- a/website/content/docs/commands/read.mdx
+++ b/website/content/docs/commands/read.mdx
@@ -70,8 +70,8 @@ flags](/docs/commands) included on all commands.
   will not have a trailing newline making it ideal for piping to other processes.
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
-  `VAULT_FORMAT` environment variable.
+  formats are "table", "json", "yaml", or "raw". This can also be specified
+  via the `VAULT_FORMAT` environment variable.
 
 For a full list of examples and paths, please see the documentation that
 corresponds to the secrets engine in use.


### PR DESCRIPTION
Figured out how that error message gets triggered!

```
[cipherboy@xps15 vault]$ vault write -format=raw pki/root/generate/internal use_pss=true common_name="hack week demo root"
Could not parse output: unable to type assert to []byte: *api.Secret; please share the command run
```

This also lends itself to a much nicer error message instead:

```
[cipherboy@xps15 vault]$ vault write -format=raw pki/root/generate/internal use_pss=true common_name="hack week demo root"
Could not parse output: This command does not support the -format=raw option; only `vault read` does.
```

Also add the format mode to the website docs page.

---

To support `-format=raw` on other display engines, they'd have to have raw `*Response` variants of all calls (Write/Patch/...), which is less than ideal, IMO. Only `read` really returns data that is not JSON formatted.