### PR TITLE
Let circleci user access files in container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,7 @@ jobs:
           make prep
 
           # Permissions have changed inside docker containers; see hack note below.
-          mkdir --mode=777 -p test-results/go-test
+          mkdir -p test-results/go-test
 
           # We don't want VAULT_LICENSE set when running Go tests, because that's
           # not what developers have in their environments and it could break some
@@ -488,7 +488,7 @@ jobs:
           make prep
 
           # Permissions have changed inside docker containers; see hack note below.
-          mkdir --mode=777 -p test-results/go-test
+          mkdir -p test-results/go-test
 
           # We don't want VAULT_LICENSE set when running Go tests, because that's
           # not what developers have in their environments and it could break some
@@ -700,7 +700,7 @@ jobs:
           make prep
 
           # Permissions have changed inside docker containers; see hack note below.
-          mkdir --mode=777 -p test-results/go-test
+          mkdir -p test-results/go-test
 
           # We don't want VAULT_LICENSE set when running Go tests, because that's
           # not what developers have in their environments and it could break some
@@ -1022,7 +1022,7 @@ jobs:
           make prep
 
           # Permissions have changed inside docker containers; see hack note below.
-          mkdir --mode=777 -p test-results/go-test
+          mkdir -p test-results/go-test
 
           # We don't want VAULT_LICENSE set when running Go tests, because that's
           # not what developers have in their environments and it could break some

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,12 @@ jobs:
     - setup_remote_docker:
         docker_layer_caching: true
         version: 20.10.17
+    - run:
+        command: |
+          sudo groupmod --gid=1002 circleci && \
+          sudo usermod --uid=1001 --gid=circleci circleci
+        name: Match user/group IDs to VM images for consistency
+        no_output_timeout: 60m
     - add_ssh_keys:
         fingerprints:
         - b8:e2:38:f8:5b:1b:82:f3:1f:23:fa:46:6e:95:e7:e9
@@ -401,6 +407,12 @@ jobs:
         name: Check branch name
         working_directory: ~/
     - checkout
+    - run:
+        command: |
+          sudo groupmod --gid=1002 circleci && \
+          sudo usermod --uid=1001 --gid=circleci circleci
+        name: Match user/group IDs to VM images for consistency
+        no_output_timeout: 60m
     - add_ssh_keys:
         fingerprints:
         - b8:e2:38:f8:5b:1b:82:f3:1f:23:fa:46:6e:95:e7:e9
@@ -607,6 +619,12 @@ jobs:
         name: Check branch name
         working_directory: ~/
     - checkout
+    - run:
+        command: |
+          sudo groupmod --gid=1002 circleci && \
+          sudo usermod --uid=1001 --gid=circleci circleci
+        name: Match user/group IDs to VM images for consistency
+        no_output_timeout: 60m
     - add_ssh_keys:
         fingerprints:
         - b8:e2:38:f8:5b:1b:82:f3:1f:23:fa:46:6e:95:e7:e9
@@ -922,6 +940,12 @@ jobs:
     - setup_remote_docker:
         docker_layer_caching: true
         version: 20.10.17
+    - run:
+        command: |
+          sudo groupmod --gid=1002 circleci && \
+          sudo usermod --uid=1001 --gid=circleci circleci
+        name: Match user/group IDs to VM images for consistency
+        no_output_timeout: 60m
     - add_ssh_keys:
         fingerprints:
         - b8:e2:38:f8:5b:1b:82:f3:1f:23:fa:46:6e:95:e7:e9

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -23,6 +23,12 @@ parameters:
     # Only supported for use_docker=false, and only other value allowed is 386
     default: amd64 # must be 386 or amd64
 steps:
+  - run:
+      name: Match user/group IDs to VM images for consistency
+      no_output_timeout: 60m
+      command: |
+        sudo groupmod --gid=1002 circleci && \
+        sudo usermod --uid=1001 --gid=circleci circleci
   - configure-git
   - run:
       name: Compute test cache key

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -103,7 +103,7 @@ steps:
         make prep
 
         # Permissions have changed inside docker containers; see hack note below.
-        mkdir --mode=777 -p test-results/go-test
+        mkdir -p test-results/go-test
 
         # We don't want VAULT_LICENSE set when running Go tests, because that's
         # not what developers have in their environments and it could break some


### PR DESCRIPTION
This commit matches the fix outlined in
https://github.com/CircleCI-Public/cimg-base/commit/aa0824c5f6009bc84024999c0221f410605586af by modifying the circleci user and adding the appropriate gid/uid to resolve fs access issues.

This change is made at run-time, but should continue to work once the new images are available.