### PR TITLE
Update AWS secrets tests

### DIFF
--- a/builtin/logical/aws/backend_test.go
+++ b/builtin/logical/aws/backend_test.go
@@ -666,11 +666,18 @@ func testAccStepReadSTSResponse(name string, maximumTTL uint64) logicaltest.Test
 			if resp.Secret != nil {
 				return fmt.Errorf("bad: STS tokens should return a nil secret, received: %+v", resp.Secret)
 			}
-			ttl := resp.Data["ttl"].(uint64)
-			if ttl > maximumTTL {
-				return fmt.Errorf("bad: ttl of %d greater than maximum of %d", ttl, maximumTTL)
+
+			if ttl, exists := resp.Data["ttl"]; exists {
+				ttlVal := ttl.(uint64)
+
+				if ttlVal > maximumTTL {
+					return fmt.Errorf("bad: ttl of %d greater than maximum of %d", ttl, maximumTTL)
+				}
+
+				return nil
 			}
-			return nil
+
+			return fmt.Errorf("response data missing ttl, received: %+v", resp.Data)
 		},
 	}
 }

--- a/builtin/logical/aws/stepwise_test.go
+++ b/builtin/logical/aws/stepwise_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"os"
+	"sync"
 	"testing"
 
 	stepwise "github.com/hashicorp/vault-testing-stepwise"
@@ -9,6 +10,8 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/mitchellh/mapstructure"
 )
+
+var stepwiseSetup sync.Once
 
 func TestAccBackend_Stepwise_basic(t *testing.T) {
 	t.Parallel()
@@ -82,7 +85,7 @@ func testAccStepwiseRead(t *testing.T, path, name string, credentialTests []cred
 }
 
 func testAccStepwisePreCheck(t *testing.T) {
-	initSetup.Do(func() {
+	stepwiseSetup.Do(func() {
 		if v := os.Getenv("AWS_DEFAULT_REGION"); v == "" {
 			t.Logf("[INFO] Test: Using us-west-2 as test region")
 			os.Setenv("AWS_DEFAULT_REGION", "us-west-2")


### PR DESCRIPTION
AWS STS secrets were changed to no longer create a lease. This updates a test case relying on checking for a secret in the response. Also fixes a sync.Once object being used in two locations.