### PR TITLE
Raft Snapshot Download Bug

### DIFF
--- a/changelog/17769.txt
+++ b/changelog/17769.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes issue with not being able to download raft snapshot via service worker
+```

--- a/ui/lib/service-worker-authenticated-download/service-worker-registration/index.js
+++ b/ui/lib/service-worker-authenticated-download/service-worker-registration/index.js
@@ -1,32 +1,6 @@
 import { addSuccessHandler } from 'ember-service-worker/service-worker-registration';
-import Namespace from '@ember/application/namespace';
-
-function getToken() {
-  // fix this later by allowing registration somewhere in the app lifecycle were we can have access to
-  // services, etc.
-  return Namespace.NAMESPACES_BY_ID['vault'].__container__.lookup('service:auth').currentToken;
-}
 
 addSuccessHandler(function (registration) {
-  // attach the handler for the message event so we can send over the auth token
-  navigator.serviceWorker.addEventListener('message', (event) => {
-    let { action } = event.data;
-    let port = event.ports[0];
-
-    if (action === 'getToken') {
-      let token = getToken();
-      if (!token) {
-        console.error('Unable to retrieve Vault tokent'); // eslint-disable-line
-      }
-      port.postMessage({ token: token });
-    } else {
-      console.error('Unknown event', event); // eslint-disable-line
-      port.postMessage({
-        error: 'Unknown request',
-      });
-    }
-  });
-
   // attempt to unregister the service worker on unload because we're not doing any sort of caching
   window.addEventListener('unload', function () {
     registration.unregister();

--- a/ui/tests/integration/components/raft-storage-overview-test.js
+++ b/ui/tests/integration/components/raft-storage-overview-test.js
@@ -2,17 +2,56 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
 
 module('Integration | Component | raft-storage-overview', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function (assert) {
-    let model = [
+  hooks.beforeEach(function () {
+    this.model = [
       { address: '127.0.0.1:8200', voter: true },
       { address: '127.0.0.1:8200', voter: true, leader: true },
     ];
-    this.set('model', model);
+  });
+
+  test('it renders', async function (assert) {
     await render(hbs`<RaftStorageOverview @model={{this.model}} />`);
     assert.dom('[data-raft-row]').exists({ count: 2 });
+  });
+
+  test('it should download snapshot via service worker', async function (assert) {
+    assert.expect(3);
+
+    const token = this.owner.lookup('service:auth').currentToken;
+    const generateMockEvent = (action) => ({
+      data: { action },
+      ports: [
+        {
+          postMessage(message) {
+            const getToken = action === 'getToken';
+            const expected = getToken ? { token } : { error: 'Unknown request' };
+            assert.deepEqual(
+              message,
+              expected,
+              `${
+                getToken ? 'Token' : 'Error'
+              } is returned to service worker in message event listener callback`
+            );
+          },
+        },
+      ],
+    });
+
+    sinon.stub(navigator.serviceWorker, 'getRegistration').resolves(true);
+    sinon.stub(navigator.serviceWorker, 'addEventListener').callsFake((name, cb) => {
+      assert.strictEqual(name, 'message', 'Event listener added for service worker message');
+      cb(generateMockEvent('getToken'));
+      cb(generateMockEvent('unknown'));
+    });
+
+    await render(hbs`<RaftStorageOverview @model={{this.model}} />`);
+    // avoid clicking the download button or the url will change
+    // the service worker invokes the event listener callback when it intercepts the request to /v1/sys/storage/raft/snapshot
+    // for the test we manually fire the callback as soon as it is passed to the addEventListener stub
   });
 });


### PR DESCRIPTION
An uncaught error was causing the service worker to hang when attempting to download a raft snapshot which would eventually result in a permission denied response since the token was not provided to the fetch request.

In the `service-worker-authenticated-download` in-repo addon the `service-worker-registration` is attempting to import from `@ember/application/namespace`. In the generated `sw-registration.js` script this results in that module being accessed from the `Ember` global which has been removed and is undefined.

[Screencast from 2022-11-01 03:27:11 PM.webm](https://user-images.githubusercontent.com/24611656/199345314-0197fbc5-963b-4c69-8ff1-5216ecc92904.webm)

This seems to be an issue with `ember-auto-import` (or babel or webpack by extension) but I just couldn't figure out how to get that import working. I decided to move the event listener to the `raft-storage-overview` component in the parent application which is already doing a check for the service worker registration and where the download action lives. 
