### PR TITLE
docs: in transit secret engine docs, specify order with batch_input param

### DIFF
--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -555,7 +555,8 @@ will be returned.
 
 - `batch_input` `(array<object>: nil)` – Specifies a list of items to be
   encrypted in a single batch. When this parameter is set, if the parameters
-  'plaintext', 'context' and 'nonce' are also set, they will be ignored. The
+  'plaintext', 'context' and 'nonce' are also set, they will be ignored. 
+  Any batch output will preserve the order of the batch input. The
   format for the input is:
 
   ```json
@@ -664,7 +665,8 @@ This endpoint decrypts the provided ciphertext using the named key.
 
 - `batch_input` `(array<object>: nil)` – Specifies a list of items to be
   decrypted in a single batch. When this parameter is set, if the parameters
-  'ciphertext', 'context' and 'nonce' are also set, they will be ignored. Format
+  'ciphertext', 'context' and 'nonce' are also set, they will be ignored. 
+  Any batch output will preserve the order of the batch input. Format
   for the input goes like this:
 
   ```json
@@ -744,7 +746,8 @@ functionality to untrusted users or scripts.
 
 - `batch_input` `(array<object>: nil)` – Specifies a list of items to be
   decrypted in a single batch. When this parameter is set, if the parameters
-  'ciphertext', 'context' and 'nonce' are also set, they will be ignored. Format
+  'ciphertext', 'context' and 'nonce' are also set, they will be ignored. 
+  Any batch output will preserve the order of the batch input. Format
   for the input goes like this:
 
   ```json
@@ -1005,7 +1008,8 @@ be used.
 - `batch_input` `(array<object>: nil)` – Specifies a list of items for processing.
   When this parameter is set, if the parameter 'input' is also set, it will be
   ignored. Responses are returned in the 'batch_results' array component of the
-  'data' element of the response. If the input data value of an item is invalid, the
+  'data' element of the response. Any batch output will preserve the order of 
+  the batch input. If the input data value of an item is invalid, the
   corresponding item in the 'batch_results' will have the key 'error' with a value
   describing the error. The format for batch_input is:
 
@@ -1152,7 +1156,8 @@ supports signing.
 - `batch_input` `(array<object>: nil)` – Specifies a list of items for processing.
   When this parameter is set, any supplied 'input' or 'context' parameters will be
   ignored. Responses are returned in the 'batch_results' array component of the
-  'data' element of the response. If the input data value of an item is invalid, the
+  'data' element of the response. Any batch output will preserve the order of the 
+  batch input. If the input data value of an item is invalid, the
   corresponding item in the 'batch_results' will have the key 'error' with a value
   describing the error. The format for batch_input is:
 
@@ -1338,9 +1343,10 @@ data.
   either an 'hmac' or 'signature' parameter. All items in the batch must consistently
   supply either 'hmac' or 'signature' parameters. It is an error for some items to
   supply 'hmac' while others supply 'signature'. Responses are returned in the
-  'batch_results' array component of the 'data' element of the response. If the
-  input data value of an item is invalid, the corresponding item in the 'batch_results'
-  will have the key 'error' with a value describing the error. The format for batch_input is:
+  'batch_results' array component of the 'data' element of the response. Any batch 
+  output will preserve the order of the batch input. If the input data value of an 
+  item is invalid, the corresponding item in the 'batch_results' will have the key 
+  'error' with a value describing the error. The format for batch_input is:
 
   ```json
   {


### PR DESCRIPTION
Added note about output order to each `batch_input` reference.  I'm not sure I formatted the changes correctly 😬 