### PR TITLE
Use hashicorp mirror for container pulls

### DIFF
--- a/builtin/credential/radius/backend_test.go
+++ b/builtin/credential/radius/backend_test.go
@@ -57,7 +57,7 @@ client 128.0.0.0/1 {
 `
 
 	containerfile := `
-FROM jumanjiman/radiusd:latest
+FROM docker.mirror.hashicorp.services/jumanjiman/radiusd:latest
 
 COPY clients.conf /etc/raddb/clients.conf
 `

--- a/builtin/logical/pki/zlint_test.go
+++ b/builtin/logical/pki/zlint_test.go
@@ -18,7 +18,7 @@ var (
 
 func buildZLintContainer(t *testing.T) {
 	containerfile := `
-FROM golang:latest
+FROM docker.mirror.hashicorp.services/library/golang:latest
 
 RUN go install github.com/zmap/zlint/v3/cmd/zlint@latest
 `

--- a/builtin/logical/rabbitmq/backend_test.go
+++ b/builtin/logical/rabbitmq/backend_test.go
@@ -36,7 +36,7 @@ func prepareRabbitMQTestContainer(t *testing.T) (func(), string) {
 	}
 
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
-		ImageRepo:     "rabbitmq",
+		ImageRepo:     "docker.mirror.hashicorp.services/library/rabbitmq",
 		ImageTag:      "3-management",
 		ContainerName: "rabbitmq",
 		Ports:         []string{"15672/tcp"},

--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -137,7 +137,7 @@ func prepareTestContainer(t *testing.T, tag, caPublicKeyPEM string) (func(), str
 	}
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		ContainerName: "openssh",
-		ImageRepo:     "linuxserver/openssh-server",
+		ImageRepo:     "docker.mirror.hashicorp.services/linuxserver/openssh-server",
 		ImageTag:      tag,
 		Env: []string{
 			"DOCKER_MODS=linuxserver/mods:openssh-server-openssh-client",

--- a/command/server/server_seal_transit_acc_test.go
+++ b/command/server/server_seal_transit_acc_test.go
@@ -131,8 +131,9 @@ func prepareTestContainer(t *testing.T) (func(), *DockerVaultConfig) {
 	}
 
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
-		ImageRepo: "vault",
-		ImageTag:  "latest",
+		ContainerName: "vault",
+		ImageRepo:     "docker.mirror.hashicorp.services/hashicorp/vault",
+		ImageTag:      "latest",
 		Cmd: []string{
 			"server", "-log-level=trace", "-dev", fmt.Sprintf("-dev-root-token-id=%s", rootToken),
 			"-dev-listen-address=0.0.0.0:8200",

--- a/helper/testhelpers/cassandra/cassandrahelper.go
+++ b/helper/testhelpers/cassandra/cassandrahelper.go
@@ -90,9 +90,10 @@ func PrepareTestContainer(t *testing.T, opts ...ContainerOpt) (Host, func()) {
 	}
 
 	containerCfg := &containerConfig{
-		imageName: "cassandra",
-		version:   "3.11",
-		env:       []string{"CASSANDRA_BROADCAST_ADDRESS=127.0.0.1"},
+		imageName:     "docker.mirror.hashicorp.services/library/cassandra",
+		containerName: "cassandra",
+		version:       "3.11",
+		env:           []string{"CASSANDRA_BROADCAST_ADDRESS=127.0.0.1"},
 	}
 
 	for _, opt := range opts {

--- a/helper/testhelpers/consul/consulhelper.go
+++ b/helper/testhelpers/consul/consulhelper.go
@@ -58,7 +58,7 @@ func PrepareTestContainer(t *testing.T, version string, isEnterprise bool, doBoo
 	if isEnterprise {
 		version += "-ent"
 		name = "consul-enterprise"
-		repo = "hashicorp/consul-enterprise"
+		repo = "docker.mirror.hashicorp.services/hashicorp/consul-enterprise"
 		license, hasLicense := os.LookupEnv("CONSUL_LICENSE")
 		envVars = append(envVars, "CONSUL_LICENSE="+license)
 

--- a/helper/testhelpers/fakegcsserver/fake-gcs-server.go
+++ b/helper/testhelpers/fakegcsserver/fake-gcs-server.go
@@ -27,7 +27,7 @@ func PrepareTestContainer(t *testing.T, version string) (func(), docker.ServiceC
 	}
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		ContainerName: "fake-gcs-server",
-		ImageRepo:     "fsouza/fake-gcs-server",
+		ImageRepo:     "docker.mirror.hashicorp.services/fsouza/fake-gcs-server",
 		ImageTag:      version,
 		Cmd:           []string{"-scheme", "http", "-public-host", "storage.gcs.127.0.0.1.nip.io:4443"},
 		Ports:         []string{"4443/tcp"},

--- a/helper/testhelpers/ldap/ldaphelper.go
+++ b/helper/testhelpers/ldap/ldaphelper.go
@@ -14,7 +14,7 @@ func PrepareTestContainer(t *testing.T, version string) (cleanup func(), cfg *ld
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		// Currently set to "michelvocks" until https://github.com/rroemhild/docker-test-openldap/pull/14
 		// has been merged.
-		ImageRepo:     "michelvocks/docker-test-openldap",
+		ImageRepo:     "docker.mirror.hashicorp.services/michelvocks/docker-test-openldap",
 		ImageTag:      version,
 		ContainerName: "ldap",
 		Ports:         []string{"389/tcp"},

--- a/helper/testhelpers/minio/miniohelper.go
+++ b/helper/testhelpers/minio/miniohelper.go
@@ -32,7 +32,7 @@ func PrepareTestContainer(t *testing.T, version string) (func(), *Config) {
 	}
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		ContainerName: "minio",
-		ImageRepo:     "minio/minio",
+		ImageRepo:     "docker.mirror.hashicorp.services/minio/minio",
 		ImageTag:      version,
 		Env: []string{
 			"MINIO_ACCESS_KEY=" + accessKeyID,

--- a/helper/testhelpers/mongodb/mongodbhelper.go
+++ b/helper/testhelpers/mongodb/mongodbhelper.go
@@ -27,9 +27,10 @@ func PrepareTestContainerWithDatabase(t *testing.T, version, dbName string) (fun
 	}
 
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
-		ImageRepo: "mongo",
-		ImageTag:  version,
-		Ports:     []string{"27017/tcp"},
+		ContainerName: "mongo",
+		ImageRepo:     "docker.mirror.hashicorp.services/library/mongo",
+		ImageTag:      version,
+		Ports:         []string{"27017/tcp"},
 	})
 	if err != nil {
 		t.Fatalf("could not start docker mongo: %s", err)

--- a/helper/testhelpers/mysql/mysqlhelper.go
+++ b/helper/testhelpers/mysql/mysqlhelper.go
@@ -29,10 +29,11 @@ func PrepareTestContainer(t *testing.T, legacy bool, pw string) (func(), string)
 	}
 
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
-		ImageRepo: "mysql",
-		ImageTag:  imageVersion,
-		Ports:     []string{"3306/tcp"},
-		Env:       []string{"MYSQL_ROOT_PASSWORD=" + pw},
+		ContainerName: "mysql",
+		ImageRepo:     "docker.mirror.hashicorp.services/library/mysql",
+		ImageTag:      imageVersion,
+		Ports:         []string{"3306/tcp"},
+		Env:           []string{"MYSQL_ROOT_PASSWORD=" + pw},
 	})
 	if err != nil {
 		t.Fatalf("could not start docker mysql: %s", err)

--- a/helper/testhelpers/postgresql/postgresqlhelper.go
+++ b/helper/testhelpers/postgresql/postgresqlhelper.go
@@ -17,7 +17,7 @@ func PrepareTestContainer(t *testing.T, version string) (func(), string) {
 		"POSTGRES_DB=database",
 	}
 
-	_, cleanup, url, _ := prepareTestContainer(t, "postgres", "postgres", version, "secret", true, false, false, env)
+	_, cleanup, url, _ := prepareTestContainer(t, "postgres", "docker.mirror.hashicorp.services/postgres", version, "secret", true, false, false, env)
 
 	return cleanup, url
 }
@@ -28,7 +28,7 @@ func PrepareTestContainerWithPassword(t *testing.T, version, password string) (f
 		"POSTGRES_DB=database",
 	}
 
-	_, cleanup, url, _ := prepareTestContainer(t, "postgres", "postgres", version, password, true, false, false, env)
+	_, cleanup, url, _ := prepareTestContainer(t, "postgres", "docker.mirror.hashicorp.services/postgres", version, password, true, false, false, env)
 
 	return cleanup, url
 }
@@ -40,7 +40,7 @@ func PrepareTestContainerRepmgr(t *testing.T, name, version string, envVars []st
 		"REPMGR_PASSWORD=repmgrpass",
 		"POSTGRESQL_PASSWORD=secret")
 
-	return prepareTestContainer(t, name, "bitnami/postgresql-repmgr", version, "secret", false, true, true, env)
+	return prepareTestContainer(t, name, "docker.mirror.hashicorp.services/bitnami/postgresql-repmgr", version, "secret", false, true, true, env)
 }
 
 func prepareTestContainer(t *testing.T, name, repo, version, password string,

--- a/physical/aerospike/aerospike_test.go
+++ b/physical/aerospike/aerospike_test.go
@@ -41,7 +41,7 @@ type aerospikeConfig struct {
 
 func prepareAerospikeContainer(t *testing.T) (func(), *aerospikeConfig) {
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
-		ImageRepo:     "aerospike/aerospike-server",
+		ImageRepo:     "docker.mirror.hashicorp.services/aerospike/aerospike-server",
 		ContainerName: "aerospikedb",
 		ImageTag:      "5.6.0.5",
 		Ports:         []string{"3000/tcp", "3001/tcp", "3002/tcp", "3003/tcp"},

--- a/physical/cockroachdb/cockroachdb_test.go
+++ b/physical/cockroachdb/cockroachdb_test.go
@@ -36,7 +36,7 @@ func prepareCockroachDBTestContainer(t *testing.T) (func(), *Config) {
 	}
 
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
-		ImageRepo:     "cockroachdb/cockroach",
+		ImageRepo:     "docker.mirror.hashicorp.services/cockroachdb/cockroach",
 		ImageTag:      "release-1.0",
 		ContainerName: "cockroachdb",
 		Cmd:           []string{"start", "--insecure"},

--- a/physical/couchdb/couchdb_test.go
+++ b/physical/couchdb/couchdb_test.go
@@ -86,7 +86,8 @@ func prepareCouchdbDBTestContainer(t *testing.T) (func(), *couchDB) {
 	}
 
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
-		ImageRepo:       "couchdb",
+		ContainerName:   "couchdb",
+		ImageRepo:       "docker.mirror.hashicorp.services/library/couchdb",
 		ImageTag:        "1.6",
 		Ports:           []string{"5984/tcp"},
 		DoNotAutoRemove: true,

--- a/physical/dynamodb/dynamodb_test.go
+++ b/physical/dynamodb/dynamodb_test.go
@@ -381,7 +381,7 @@ func prepareDynamoDBTestContainer(t *testing.T) (func(), *Config) {
 	}
 
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
-		ImageRepo:     "cnadiminti/dynamodb-local",
+		ImageRepo:     "docker.mirror.hashicorp.services/cnadiminti/dynamodb-local",
 		ImageTag:      "latest",
 		ContainerName: "dynamodb",
 		Ports:         []string{"8000/tcp"},


### PR DESCRIPTION
When running the test suite in CI (where requests are centralized from relatively few IPs), we'd occasionally hit Dockerhub's rate limits. Luckily Hashicorp runs a (limited) public mirror of the containers we need, so we can switch to them here in the tests.

For consistency between developer and CI, we've opted to have the tests always pull from the Hashicorp mirror, rather than updating the CI runner to prefer the mirror.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

I'm inclined to give this a little testing first and then backport it later if it works on `main` consistently well.