### PR TITLE
Add new API to PKI to list revoked certificates

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -134,6 +134,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathRotateDeltaCRL(&b),
 			pathRevoke(&b),
 			pathRevokeWithKey(&b),
+			pathListCertsRevoked(&b),
 			pathTidy(&b),
 			pathTidyCancel(&b),
 			pathTidyStatus(&b),

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -1216,3 +1216,12 @@ func (sc *storageContext) writeAutoTidyConfig(config *tidyConfig) error {
 
 	return sc.Storage.Put(sc.Context, entry)
 }
+
+func (sc *storageContext) listRevokedCerts() ([]string, error) {
+	list, err := sc.Storage.List(sc.Context, revokedPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed listing revoked certs: %w", err)
+	}
+
+	return list, err
+}

--- a/changelog/17779.txt
+++ b/changelog/17779.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Add a new API that returns the serial numbers of revoked certificates on the local cluster
+```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -966,7 +966,7 @@ This endpoint returns a list of serial numbers that have been revoked on the loc
 
 | Method | Path              |
 |:-------|:------------------|
-| `LIST`  | `/certs/revoked`  |
+| `LIST` | `/certs/revoked`  |
 
 #### Sample Request
 

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -29,6 +29,7 @@ update your API calls accordingly.
   - [Sign Verbatim](#sign-verbatim)
   - [Revoke Certificate](#revoke-certificate)
   - [Revoke Certificate with Private Key](#revoke-certificate-with-private-key)
+  - [List Revoked Certificates](#list-revoked-certificates)
 - [Accessing Authority Information](#accessing-authority-information)
   - [List Issuers](#list-issuers)
   - [Read Issuer Certificate](#read-issuer-certificate)
@@ -954,6 +955,36 @@ $ curl \
 {
   "data": {
     "revocation_time": 1433269787
+  }
+}
+```
+
+
+### List Revoked Certificates
+
+This endpoint returns a list of serial numbers that have been revoked on the local cluster.
+
+| Method | Path              |
+|:-------|:------------------|
+| `LIST`  | `/certs/revoked`  |
+
+#### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request LIST \
+    http://127.0.0.1:8200/v1/pki/certs/revoked
+```
+
+#### Sample Response
+
+```json
+{
+  "data": {
+    "keys": [
+      "3d:80:91:c3:c2:34:3b:81:69:3d:92:a3:80:69:db:53:04:26:ab:b4"
+    ]
   }
 }
 ```


### PR DESCRIPTION
 A new API that will return the list of serial numbers of revoked certificates on the local cluster.

```
❯ curl \
    --header "X-Vault-Token: $VAULT_TOKEN" \
    --request LIST \
    http://127.0.0.1:8200/v1/pki_int/certs/revoked | jq
{
  "request_id": "e221b49c-6c28-0b08-30dc-e2dd2f37d077",
  "lease_id": "",
  "renewable": false,
  "lease_duration": 0,
  "data": {
    "keys": [
      "3d:80:91:c3:c2:34:3b:81:69:3d:92:a3:80:69:db:53:04:26:ab:b4"
    ]
  },
  "wrap_info": null,
  "warnings": null,
  "auth": null
}
```