### PR TITLE
Fix .go-version path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GOFMT_FILES?=$$(find . -name '*.go' | grep -v pb.go | grep -v vendor)
 SED?=$(shell command -v gsed || command -v sed)
 
 
-GO_VERSION_MIN=$$(cat $(CURDIR)/.go_version)
+GO_VERSION_MIN=$$(cat $(CURDIR)/.go-version)
 PROTOC_VERSION_MIN=3.21.7
 GO_CMD?=go
 CGO_ENABLED?=0


### PR DESCRIPTION
Typo, I couldn't find any other mentions of `.go_version`