### PR TITLE
Update signed-ssh-certificates.mdx

### DIFF
--- a/website/content/docs/secrets/ssh/signed-ssh-certificates.mdx
+++ b/website/content/docs/secrets/ssh/signed-ssh-certificates.mdx
@@ -108,8 +108,7 @@ team, or configuration management tooling.
 
     Because of the way some SSH certificate features are implemented, options
     are passed as a map. The following example adds the `permit-pty` extension
-    to the certificate, and allows the user to specify their own values for `permit-pty` and `permit-port-forwarding`
-    when requesting the certificate.
+    to the certificate, and allows the user to specify their own values for `permit-pty` when requesting the certificate.
 
     ```text
     $ vault write ssh-client-signer/roles/my-role -<<"EOH"
@@ -117,7 +116,7 @@ team, or configuration management tooling.
       "algorithm_signer": "rsa-sha2-256",
       "allow_user_certificates": true,
       "allowed_users": "*",
-      "allowed_extensions": "permit-pty,permit-port-forwarding",
+      "allowed_extensions": "permit-pty",
       "default_extensions": {
         "permit-pty": ""
       },


### PR DESCRIPTION
Removed the suggestion to do permit port forwarding because the CIS benchmark and most secure posture is to not forward ports i.e. `AllowTcpForwarding = no`