### PR TITLE
core: fix start up policy loading race condition on perf standbys

### DIFF
--- a/changelog/17801.txt
+++ b/changelog/17801.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+core: fix a start up race condition where performance standbys could go into a 
+mount loop if default policies are not yet synced from the active node.
+```

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -259,7 +259,8 @@ func (c *Core) setupPolicyStore(ctx context.Context) error {
 		return err
 	}
 
-	if c.ReplicationState().HasState(consts.ReplicationPerformanceSecondary | consts.ReplicationDRSecondary) {
+	if c.ReplicationState().HasState(consts.ReplicationPerformanceSecondary |
+		consts.ReplicationDRSecondary | consts.ReplicationPerformanceStandby) {
 		// Policies will sync from the primary
 		return nil
 	}

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -259,9 +259,13 @@ func (c *Core) setupPolicyStore(ctx context.Context) error {
 		return err
 	}
 
-	if c.ReplicationState().HasState(consts.ReplicationPerformanceSecondary |
-		consts.ReplicationDRSecondary | consts.ReplicationPerformanceStandby) {
+	if c.ReplicationState().HasState(consts.ReplicationPerformanceSecondary | consts.ReplicationDRSecondary) {
 		// Policies will sync from the primary
+		return nil
+	}
+
+	if c.perfStandby {
+		// Policies will sync from the active
 		return nil
 	}
 


### PR DESCRIPTION
This fixes a start up race condition where recently assigned performance standbys might not yet have received logs from the active node containing policies. This can sometimes result in a mount loop on the performance standbys and would only be fixed by restarting the performance standbys. The fix simply skips performance standbys all together.