### PR TITLE
Backport of Bump up period and skew to prevent timeouts into release/1.10.x

### DIFF
--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -951,10 +951,10 @@ func SetupLoginMFATOTP(t testing.T, client *api.Client) (*api.Client, string, st
 	// Configure a default TOTP method
 	totpConfig := map[string]interface{}{
 		"issuer":                  "yCorp",
-		"period":                  5,
+		"period":                  20,
 		"algorithm":               "SHA256",
 		"digits":                  6,
-		"skew":                    0,
+		"skew":                    1,
 		"key_size":                20,
 		"qr_size":                 200,
 		"max_validation_attempts": 5,


### PR DESCRIPTION
Backup assistant failed to kick off the backport PRs, so I had to cherry-pick the commit onto all of the relevant release branches.

Give the default SetupLoginMFATOTP helper a more robust period/skew. 403 failures on test-go-race are likely due to TOTP code timeouts being too aggressive.