### PR TITLE
Add new PKI api to combine and sign different CRLs from the same issuer

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -177,6 +177,9 @@ func Backend(conf *logical.BackendConfig) *backend {
 			// OCSP APIs
 			buildPathOcspGet(&b),
 			buildPathOcspPost(&b),
+
+			// CRL Signing
+			pathResignCrls(&b),
 		},
 
 		Secrets: []*framework.Secret{

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -40,6 +40,16 @@ type inputBundle struct {
 	apiData *framework.FieldData
 }
 
+type caEntity struct {
+	// TODO: Have the associated keyEntry here as well.
+	issuer   issuerEntry
+	caBundle certutil.CAInfoBundle
+}
+
+func (cae caEntity) PrettyIssuerId() string {
+	return fmt.Sprintf("[id: '%s' name: '%s']", string(cae.issuer.ID), cae.issuer.Name)
+}
+
 var (
 	// labelRegex is a single label from a valid domain name and was extracted
 	// from hostnameRegex below for use in leftWildLabelRegex, without any
@@ -107,32 +117,41 @@ func (sc *storageContext) fetchCAInfo(issuerRef string, usage issuerUsage) (*cer
 // fetchCAInfoByIssuerId will fetch the CA info, will return an error if no ca info exists for the given issuerId.
 // This does support the loading using the legacyBundleShimID
 func (sc *storageContext) fetchCAInfoByIssuerId(issuerId issuerID, usage issuerUsage) (*certutil.CAInfoBundle, error) {
+	entity, err := sc.fetchCAEntityByIssuerId(issuerId, usage)
+	if err != nil {
+		return nil, err
+	}
+	return &entity.caBundle, nil
+}
+
+func (sc *storageContext) fetchCAEntityByIssuerId(issuerId issuerID, usage issuerUsage) (caEntity, error) {
+	var entity caEntity
 	entry, bundle, err := sc.fetchCertBundleByIssuerId(issuerId, true)
 	if err != nil {
 		switch err.(type) {
 		case errutil.UserError:
-			return nil, err
+			return entity, err
 		case errutil.InternalError:
-			return nil, err
+			return entity, err
 		default:
-			return nil, errutil.InternalError{Err: fmt.Sprintf("error fetching CA info: %v", err)}
+			return entity, errutil.InternalError{Err: fmt.Sprintf("error fetching CA info: %v", err)}
 		}
 	}
 
 	if err := entry.EnsureUsage(usage); err != nil {
-		return nil, errutil.InternalError{Err: fmt.Sprintf("error while attempting to use issuer %v: %v", issuerId, err)}
+		return entity, errutil.InternalError{Err: fmt.Sprintf("error while attempting to use issuer %v: %v", issuerId, err)}
 	}
 
 	parsedBundle, err := parseCABundle(sc.Context, sc.Backend, bundle)
 	if err != nil {
-		return nil, errutil.InternalError{Err: err.Error()}
+		return entity, errutil.InternalError{Err: err.Error()}
 	}
 
 	if parsedBundle.Certificate == nil {
-		return nil, errutil.InternalError{Err: "stored CA information not able to be parsed"}
+		return entity, errutil.InternalError{Err: "stored CA information not able to be parsed"}
 	}
 	if parsedBundle.PrivateKey == nil {
-		return nil, errutil.UserError{Err: fmt.Sprintf("unable to fetch corresponding key for issuer %v; unable to use this issuer for signing", issuerId)}
+		return entity, errutil.UserError{Err: fmt.Sprintf("unable to fetch corresponding key for issuer %v; unable to use this issuer for signing", issuerId)}
 	}
 
 	caInfo := &certutil.CAInfoBundle{
@@ -144,11 +163,14 @@ func (sc *storageContext) fetchCAInfoByIssuerId(issuerId issuerID, usage issuerU
 
 	entries, err := entry.GetAIAURLs(sc)
 	if err != nil {
-		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch URL information: %v", err)}
+		return entity, errutil.InternalError{Err: fmt.Sprintf("unable to fetch URL information: %v", err)}
 	}
 	caInfo.URLs = entries
 
-	return caInfo, nil
+	return caEntity{
+		issuer:   *entry,
+		caBundle: *caInfo,
+	}, nil
 }
 
 func fetchCertBySerialBigInt(ctx context.Context, b *backend, req *logical.Request, prefix string, serial *big.Int) (*logical.StorageEntry, error) {

--- a/builtin/logical/pki/path_resign_crls.go
+++ b/builtin/logical/pki/path_resign_crls.go
@@ -1,0 +1,274 @@
+package pki
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/certutil"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const (
+	crlNumberParam      = "crl_number"
+	deltaCrlNumberParam = "delta_crl_number"
+	nextUpdateParam     = "next_update"
+	crlsParam           = "crls"
+	formatParam         = "format"
+)
+
+func pathResignCrls(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "issuer/" + framework.GenericNameRegex(issuerRefParam) + "/resign-crls",
+		Fields: map[string]*framework.FieldSchema{
+			issuerRefParam: {
+				Type: framework.TypeString,
+				Description: `Reference to a existing issuer; either "default"
+for the configured default issuer, an identifier or the name assigned
+to the issuer.`,
+				Default: defaultRef,
+			},
+			crlNumberParam: {
+				Type:        framework.TypeInt,
+				Description: `The sequence number to be written within the CRL Number extension.`,
+			},
+			deltaCrlNumberParam: {
+				Type: framework.TypeInt,
+				Description: `Using a non-zero value specifies the base CRL revision number to encode within
+ a Delta CRL indicator extension, otherwise the extension will not be added.`,
+				Default: 0,
+			},
+			nextUpdateParam: {
+				Type: framework.TypeString,
+				Description: `The amount of time the generated CRL should be
+valid; defaults to 72 hours.`,
+				Default: defaultCrlConfig.Expiry,
+			},
+			crlsParam: {
+				Type:        framework.TypeStringSlice,
+				Description: `A list of PEM encoded CRLs to combine, originally signed by the requested issuer.`,
+			},
+			formatParam: {
+				Type: framework.TypeString,
+				Description: `The format of the combined CRL, can be "pem" or "der". If "der", the value will be
+base64 encoded. Defaults to "pem".`,
+				Default: "pem",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathUpdateResignCrlsHandler,
+			},
+		},
+
+		HelpSynopsis: `Combine and sign with the provided issuer different CRLs `,
+		HelpDescription: `Provide two or more PEM encoded CRLs signed by the issuer, 
+normally from separate Vault clusters to be combined and signed.`,
+	}
+}
+
+func (b *backend) pathUpdateResignCrlsHandler(ctx context.Context, request *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	if b.useLegacyBundleCaStorage() {
+		return logical.ErrorResponse("This API cannot be used until the migration has completed"), nil
+	}
+
+	issuerRef := getIssuerRef(data)
+	crlNumber := data.Get(crlNumberParam).(int)
+	deltaCrlNumber := data.Get(deltaCrlNumberParam).(int)
+	nextUpdateStr := data.Get(nextUpdateParam).(string)
+	rawCrls := data.Get(crlsParam).([]string)
+
+	format, err := getCrlFormat(data.Get(formatParam).(string))
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+
+	nextUpdateOffset, err := time.ParseDuration(nextUpdateStr)
+	if err != nil {
+		return logical.ErrorResponse("invalid value for %s: %v", nextUpdateParam, err), nil
+	}
+
+	if nextUpdateOffset <= 0 {
+		return logical.ErrorResponse("%s parameter must be greater than 0", nextUpdateParam), nil
+	}
+
+	if crlNumber < 0 {
+		return logical.ErrorResponse("%s parameter must be 0 or greater", crlNumberParam), nil
+	}
+	if deltaCrlNumber < 0 {
+		return logical.ErrorResponse("%s parameter must be 0 or greater", deltaCrlNumberParam), nil
+	}
+
+	if issuerRef == "" {
+		return logical.ErrorResponse("%s parameter cannot be blank", issuerRefParam), nil
+	}
+
+	providedCrls, err := decodePemCrls(rawCrls)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+
+	sc := b.makeStorageContext(ctx, request.Storage)
+	issuerEntity, err := getIssuer(sc, issuerRef)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+
+	if err := verifyCrlsAreFromIssuer(issuerEntity, providedCrls); err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+
+	revokedCerts, warnings, err := getAllRevokedCerts(providedCrls)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+
+	now := time.Now()
+	template := &x509.RevocationList{
+		SignatureAlgorithm:  issuerEntity.caBundle.RevocationSigAlg,
+		RevokedCertificates: revokedCerts,
+		Number:              big.NewInt(int64(crlNumber)),
+		ThisUpdate:          now,
+		NextUpdate:          now.Add(nextUpdateOffset),
+	}
+
+	if deltaCrlNumber > 0 {
+		ext, err := certutil.CreateDeltaCRLIndicatorExt(int64(deltaCrlNumber))
+		if err != nil {
+			return nil, fmt.Errorf("could not create crl delta indicator extension: %v", err)
+		}
+		template.ExtraExtensions = []pkix.Extension{ext}
+	}
+
+	crlBytes, err := x509.CreateRevocationList(rand.Reader, template, issuerEntity.caBundle.Certificate, issuerEntity.caBundle.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("error creating new CRL: %w", err)
+	}
+
+	body := encodeResponse(crlBytes, format == "der")
+
+	return &logical.Response{
+		Warnings: warnings,
+		Data: map[string]interface{}{
+			"crl": body,
+		},
+	}, nil
+}
+
+func verifyCrlsAreFromIssuer(entity caEntity, crls []*x509.RevocationList) error {
+	for i, crl := range crls {
+		if err := crl.CheckSignatureFrom(entity.caBundle.Certificate); err != nil {
+			return fmt.Errorf("CRL index: %d was not signed by requested issuer %s", i, entity.PrettyIssuerId())
+		}
+	}
+
+	return nil
+}
+
+func encodeResponse(crlBytes []byte, derFormatRequested bool) string {
+	if derFormatRequested {
+		return base64.StdEncoding.EncodeToString(crlBytes)
+	}
+
+	block := pem.Block{
+		Type:  "X509 CRL",
+		Bytes: crlBytes,
+	}
+	// This is convoluted on purpose to ensure that we don't have trailing
+	// newlines via various paths
+	return strings.TrimSpace(string(pem.EncodeToMemory(&block)))
+}
+
+func getCrlFormat(requestedValue string) (string, error) {
+	format := strings.ToLower(requestedValue)
+	switch format {
+	case "pem", "der":
+		return format, nil
+	default:
+		return "", fmt.Errorf("unknown format value of %s", requestedValue)
+	}
+}
+
+func getAllRevokedCerts(crls []*x509.RevocationList) ([]pkix.RevokedCertificate, []string, error) {
+	uniqueCert := map[string]pkix.RevokedCertificate{}
+	var warnings []string
+	for _, crl := range crls {
+		for _, curCert := range crl.RevokedCertificates {
+			serial := serialFromBigInt(curCert.SerialNumber)
+			// Get rid of any extensions the existing certificate might have had.
+			curCert.Extensions = []pkix.Extension{}
+
+			existingCert, exists := uniqueCert[serial]
+			if !exists {
+				// First time we see the revoked cert
+				uniqueCert[serial] = curCert
+				continue
+			}
+
+			if existingCert.RevocationTime.Equal(curCert.RevocationTime) {
+				// Same revocation times, just skip it
+				continue
+			}
+
+			warn := fmt.Sprintf("Duplicate serial %s with different revocation "+
+				"times detected, using oldest revocation time", serial)
+			warnings = append(warnings, warn)
+
+			if existingCert.RevocationTime.After(curCert.RevocationTime) {
+				uniqueCert[serial] = curCert
+			}
+		}
+	}
+
+	var revokedCerts []pkix.RevokedCertificate
+	for _, cert := range uniqueCert {
+		revokedCerts = append(revokedCerts, cert)
+	}
+
+	return revokedCerts, warnings, nil
+}
+
+func getIssuer(sc *storageContext, issuerRef string) (caEntity, error) {
+	issuerId, err := sc.resolveIssuerReference(issuerRef)
+	if err != nil {
+		return caEntity{}, fmt.Errorf("failed to resolve issuer %s: %w", issuerRefParam, err)
+	}
+
+	entity, err := sc.fetchCAEntityByIssuerId(issuerId, CRLSigningUsage)
+	if err != nil {
+		return entity, fmt.Errorf("failed to fetch issuer with id %s: %w", issuerId, err)
+	}
+
+	return entity, nil
+}
+
+func decodePemCrls(rawCrls []string) ([]*x509.RevocationList, error) {
+	var crls []*x509.RevocationList
+	for i, rawCrl := range rawCrls {
+		crl, err := decodePemCrl(rawCrl)
+		if err != nil {
+			return nil, fmt.Errorf("failed decoding crl %d: %w", i, err)
+		}
+		crls = append(crls, crl)
+	}
+
+	return crls, nil
+}
+
+func decodePemCrl(crl string) (*x509.RevocationList, error) {
+	block, rest := pem.Decode([]byte(crl))
+	if len(rest) != 0 {
+		return nil, errors.New("invalid crl; should be one PEM block only")
+	}
+
+	return x509.ParseRevocationList(block.Bytes)
+}

--- a/builtin/logical/pki/path_resign_crls.go
+++ b/builtin/logical/pki/path_resign_crls.go
@@ -185,9 +185,7 @@ func encodeResponse(crlBytes []byte, derFormatRequested bool) string {
 		Type:  "X509 CRL",
 		Bytes: crlBytes,
 	}
-	// This is convoluted on purpose to ensure that we don't have trailing
-	// newlines via various paths
-	return strings.TrimSpace(string(pem.EncodeToMemory(&block)))
+	return string(pem.EncodeToMemory(&block))
 }
 
 func getCrlFormat(requestedValue string) (string, error) {

--- a/builtin/logical/pki/path_resign_crls_test.go
+++ b/builtin/logical/pki/path_resign_crls_test.go
@@ -1,0 +1,319 @@
+package pki
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResignCrls_ForbidSigningOtherIssuerCRL(t *testing.T) {
+	t.Parallel()
+
+	// Some random CRL from another issuer
+	pem1 := "-----BEGIN X509 CRL-----\nMIIBvjCBpwIBATANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQDExByb290LWV4YW1w\nbGUuY29tFw0yMjEwMjYyMTI5MzlaFw0yMjEwMjkyMTI5MzlaMCcwJQIUSnVf8wsd\nHjOt9drCYFhWxS9QqGoXDTIyMTAyNjIxMjkzOVqgLzAtMB8GA1UdIwQYMBaAFHki\nZ0XDUQVSajNRGXrg66OaIFlYMAoGA1UdFAQDAgEDMA0GCSqGSIb3DQEBCwUAA4IB\nAQBGIdtqTwemnLZF5AoP+jzvKZ26S3y7qvRIzd7f4A0EawzYmWXSXfwqo4TQ4DG3\nnvT+AaA1zCCOlH/1U+ufN9gSSN0j9ax58brSYMnMskMCqhLKIp0qnvS4jr/gopmF\nv8grbvLHEqNYTu1T7umMLdNQUsWT3Qc+EIjfoKj8xD2FHsZwJ+EMbytwl8Unipjr\nhz4rmcES/65vavfdFpOI6YXfi+UAaHBdkTqmHgg4BdpuXfYtlf+iotFSOkygD5fl\n0D+RVFW9uJv2WfbQ7kRt1X/VcFk/onw0AQqxZRVUzvjoMw+EMcxSq3UKOlXcWDxm\nEFz9rFQQ66L388EP8RD7Dh3X\n-----END X509 CRL-----"
+
+	b, s := createBackendWithStorage(t)
+	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
+		"common_name": "test.com",
+		"key_type":    "ec",
+	})
+	requireSuccessNonNilResponse(t, resp, err)
+
+	resp, err = CBWrite(b, s, "issuer/default/resign-crls", map[string]interface{}{
+		"crl_number":  "2",
+		"next_update": "1h",
+		"format":      "pem",
+		"crls":        []string{pem1},
+	})
+	require.ErrorContains(t, err, "was not signed by requested issuer")
+}
+
+func TestResignCrls_NormalCrl(t *testing.T) {
+	t.Parallel()
+	b1, s1 := createBackendWithStorage(t)
+	b2, s2 := createBackendWithStorage(t)
+
+	// Setup two backends, with the same key material/certificate with a different leaf in each that is revoked.
+	caCert, serial1, serial2, crl1, crl2 := setupResignCrlMounts(t, b1, s1, b2, s2)
+
+	// Attempt to combine the CRLs
+	resp, err := CBWrite(b1, s1, "issuer/default/resign-crls", map[string]interface{}{
+		"crl_number":  "2",
+		"next_update": "1h",
+		"format":      "pem",
+		"crls":        []string{crl1, crl2},
+	})
+	requireSuccessNonNilResponse(t, resp, err)
+	requireFieldsSetInResp(t, resp, "crl")
+	pemCrl := resp.Data["crl"].(string)
+	combinedCrl, err := decodePemCrl(pemCrl)
+	require.NoError(t, err, "failed decoding combined CRL")
+	serials := extractSerialsFromCrl(t, combinedCrl)
+
+	require.Contains(t, serials, serial1)
+	require.Contains(t, serials, serial2)
+	require.Equal(t, 2, len(serials), "serials contained more serials than expected")
+
+	require.Equal(t, big.NewInt(int64(2)), combinedCrl.Number)
+	require.Equal(t, combinedCrl.ThisUpdate.Add(1*time.Hour), combinedCrl.NextUpdate)
+
+	extensions := combinedCrl.Extensions
+	requireExtensionOid(t, []int{2, 5, 29, 20}, extensions) // CRL Number Extension
+	requireExtensionOid(t, []int{2, 5, 29, 35}, extensions) // akidOid
+	require.Equal(t, 2, len(extensions))
+
+	err = combinedCrl.CheckSignatureFrom(caCert)
+	require.NoError(t, err, "failed signature check of CRL")
+}
+
+func TestResignCrls_EliminateDuplicates(t *testing.T) {
+	t.Parallel()
+	b1, s1 := createBackendWithStorage(t)
+	b2, s2 := createBackendWithStorage(t)
+
+	// Setup two backends, with the same key material/certificate with a different leaf in each that is revoked.
+	_, serial1, _, crl1, _ := setupResignCrlMounts(t, b1, s1, b2, s2)
+
+	// Pass in the same CRLs to make sure we do not duplicate entries
+	resp, err := CBWrite(b1, s1, "issuer/default/resign-crls", map[string]interface{}{
+		"crl_number":  "2",
+		"next_update": "1h",
+		"format":      "pem",
+		"crls":        []string{crl1, crl1},
+	})
+	requireSuccessNonNilResponse(t, resp, err)
+	requireFieldsSetInResp(t, resp, "crl")
+	pemCrl := resp.Data["crl"].(string)
+	combinedCrl, err := decodePemCrl(pemCrl)
+	require.NoError(t, err, "failed decoding combined CRL")
+
+	// Technically this will die if we have duplicates.
+	serials := extractSerialsFromCrl(t, combinedCrl)
+
+	// We should have no warnings about collisions if they have the same revoked time
+	require.Empty(t, resp.Warnings, "expected no warnings in response")
+
+	require.Contains(t, serials, serial1)
+	require.Equal(t, 1, len(serials), "serials contained more serials than expected")
+}
+
+func TestResignCrls_ConflictingExpiry(t *testing.T) {
+	t.Parallel()
+	b1, s1 := createBackendWithStorage(t)
+	b2, s2 := createBackendWithStorage(t)
+
+	// Setup two backends, with the same key material/certificate with a different leaf in each that is revoked.
+	_, serial1, serial2, crl1, _ := setupResignCrlMounts(t, b1, s1, b2, s2)
+
+	timeAfterMountSetup := time.Now()
+
+	// Read in serial1 from mount 1
+	resp, err := CBRead(b1, s1, "cert/"+serial1)
+	requireSuccessNonNilResponse(t, resp, err, "failed reading serial 1's certificate")
+	requireFieldsSetInResp(t, resp, "certificate")
+	cert1 := resp.Data["certificate"].(string)
+
+	// Wait until at least we have rolled over to the next second to match sure the generated CRL time
+	// on backend 2 for the serial 1 will be different
+	for {
+		if time.Now().After(timeAfterMountSetup.Add(1 * time.Second)) {
+			break
+		}
+	}
+
+	// Use BYOC to revoke the same certificate on backend 2 now
+	resp, err = CBWrite(b2, s2, "revoke", map[string]interface{}{
+		"certificate": cert1,
+	})
+	requireSuccessNonNilResponse(t, resp, err, "failed revoking serial 1 on backend 2")
+
+	// Fetch the new CRL from backend2 now
+	resp, err = CBRead(b2, s2, "cert/crl")
+	requireSuccessNonNilResponse(t, resp, err, "error fetch crl from backend 2")
+	requireFieldsSetInResp(t, resp, "certificate")
+	crl2 := resp.Data["certificate"].(string)
+
+	// Attempt to combine the CRLs
+	resp, err = CBWrite(b1, s1, "issuer/default/resign-crls", map[string]interface{}{
+		"crl_number":  "2",
+		"next_update": "1h",
+		"format":      "pem",
+		"crls":        []string{crl2, crl1}, // Make sure we don't just grab the first colliding entry...
+	})
+	requireSuccessNonNilResponse(t, resp, err)
+	requireFieldsSetInResp(t, resp, "crl")
+	pemCrl := resp.Data["crl"].(string)
+	combinedCrl, err := decodePemCrl(pemCrl)
+	require.NoError(t, err, "failed decoding combined CRL")
+	combinedSerials := extractSerialsFromCrl(t, combinedCrl)
+
+	require.Contains(t, combinedSerials, serial1)
+	require.Contains(t, combinedSerials, serial2)
+	require.Equal(t, 2, len(combinedSerials), "serials contained more serials than expected")
+
+	// Make sure we issued a warning about the time collision
+	require.NotEmpty(t, resp.Warnings, "expected at least one warning")
+	require.Contains(t, resp.Warnings[0], "different revocation times detected")
+
+	// Make sure we have the initial revocation time from backend 1 within the combined CRL.
+	decodedCrl1, err := decodePemCrl(crl1)
+	require.NoError(t, err, "failed decoding crl from backend 1")
+	serialsFromBackend1 := extractSerialsFromCrl(t, decodedCrl1)
+
+	require.Equal(t, serialsFromBackend1[serial1], combinedSerials[serial1])
+
+	// Make sure we have the initial revocation time from backend 1 does not match with backend 2's time
+	decodedCrl2, err := decodePemCrl(crl2)
+	require.NoError(t, err, "failed decoding crl from backend 2")
+	serialsFromBackend2 := extractSerialsFromCrl(t, decodedCrl2)
+
+	require.NotEqual(t, serialsFromBackend1[serial1], serialsFromBackend2[serial1])
+}
+
+func TestResignCrls_DeltaCrl(t *testing.T) {
+	t.Parallel()
+
+	b1, s1 := createBackendWithStorage(t)
+	b2, s2 := createBackendWithStorage(t)
+
+	// Setup two backends, with the same key material/certificate with a different leaf in each that is revoked.
+	caCert, serial1, serial2, crl1, crl2 := setupResignCrlMounts(t, b1, s1, b2, s2)
+
+	resp, err := CBWrite(b1, s1, "issuer/default/resign-crls", map[string]interface{}{
+		"crl_number":       "5",
+		"delta_crl_number": "4",
+		"next_update":      "12h",
+		"format":           "pem",
+		"crls":             []string{crl1, crl2},
+	})
+	requireSuccessNonNilResponse(t, resp, err)
+	requireFieldsSetInResp(t, resp, "crl")
+	pemCrl := resp.Data["crl"].(string)
+	combinedCrl, err := decodePemCrl(pemCrl)
+	require.NoError(t, err, "failed decoding combined CRL")
+	serials := extractSerialsFromCrl(t, combinedCrl)
+
+	require.Contains(t, serials, serial1)
+	require.Contains(t, serials, serial2)
+	require.Equal(t, 2, len(serials), "serials contained more serials than expected")
+
+	require.Equal(t, big.NewInt(int64(5)), combinedCrl.Number)
+	require.Equal(t, combinedCrl.ThisUpdate.Add(12*time.Hour), combinedCrl.NextUpdate)
+
+	extensions := combinedCrl.Extensions
+	requireExtensionOid(t, []int{2, 5, 29, 27}, extensions) // Delta CRL Extension
+	requireExtensionOid(t, []int{2, 5, 29, 20}, extensions) // CRL Number Extension
+	requireExtensionOid(t, []int{2, 5, 29, 35}, extensions) // akidOid
+	require.Equal(t, 3, len(extensions))
+
+	err = combinedCrl.CheckSignatureFrom(caCert)
+	require.NoError(t, err, "failed signature check of CRL")
+}
+
+func setupResignCrlMounts(t *testing.T, b1 *backend, s1 logical.Storage, b2 *backend, s2 logical.Storage) (*x509.Certificate, string, string, string, string) {
+	t.Helper()
+
+	// Setup two mounts with the same CA/key material
+	resp, err := CBWrite(b1, s1, "root/generate/exported", map[string]interface{}{
+		"common_name": "test.com",
+	})
+	requireSuccessNonNilResponse(t, resp, err)
+	requireFieldsSetInResp(t, resp, "certificate", "private_key")
+	pemCaCert := resp.Data["certificate"].(string)
+	caCert := parseCert(t, pemCaCert)
+	privKey := resp.Data["private_key"].(string)
+
+	// Import the above key/cert into another mount
+	resp, err = CBWrite(b2, s2, "config/ca", map[string]interface{}{
+		"pem_bundle": pemCaCert + "\n" + privKey,
+	})
+	requireSuccessNonNilResponse(t, resp, err, "error setting up CA on backend 2")
+
+	// Create the same role in both mounts
+	resp, err = CBWrite(b1, s1, "roles/test", map[string]interface{}{
+		"allowed_domains":  "test.com",
+		"allow_subdomains": "true",
+		"max_ttl":          "1h",
+	})
+	requireSuccessNilResponse(t, resp, err, "error setting up pki role on backend 1")
+
+	resp, err = CBWrite(b2, s2, "roles/test", map[string]interface{}{
+		"allowed_domains":  "test.com",
+		"allow_subdomains": "true",
+		"max_ttl":          "1h",
+	})
+	requireSuccessNilResponse(t, resp, err, "error setting up pki role on backend 2")
+
+	// Issue and revoke a cert in backend 1
+	resp, err = CBWrite(b1, s1, "issue/test", map[string]interface{}{
+		"common_name": "test1.test.com",
+	})
+	requireSuccessNonNilResponse(t, resp, err, "error issuing cert from backend 1")
+	requireFieldsSetInResp(t, resp, "serial_number")
+	serial1 := resp.Data["serial_number"].(string)
+
+	resp, err = CBWrite(b1, s1, "revoke", map[string]interface{}{"serial_number": serial1})
+	requireSuccessNonNilResponse(t, resp, err, "error revoking cert from backend 2")
+
+	// Issue and revoke a cert in backend 2
+	resp, err = CBWrite(b2, s2, "issue/test", map[string]interface{}{
+		"common_name": "test1.test.com",
+	})
+	requireSuccessNonNilResponse(t, resp, err, "error issuing cert from backend 2")
+	requireFieldsSetInResp(t, resp, "serial_number")
+	serial2 := resp.Data["serial_number"].(string)
+
+	resp, err = CBWrite(b2, s2, "revoke", map[string]interface{}{"serial_number": serial2})
+	requireSuccessNonNilResponse(t, resp, err, "error revoking cert from backend 2")
+
+	// Fetch PEM CRLs from each
+	resp, err = CBRead(b1, s1, "cert/crl")
+	requireSuccessNonNilResponse(t, resp, err, "error fetch crl from backend 1")
+	requireFieldsSetInResp(t, resp, "certificate")
+	crl1 := resp.Data["certificate"].(string)
+
+	resp, err = CBRead(b2, s2, "cert/crl")
+	requireSuccessNonNilResponse(t, resp, err, "error fetch crl from backend 2")
+	requireFieldsSetInResp(t, resp, "certificate")
+	crl2 := resp.Data["certificate"].(string)
+	return caCert, serial1, serial2, crl1, crl2
+}
+
+func requireExtensionOid(t *testing.T, identifier asn1.ObjectIdentifier, extensions []pkix.Extension, msgAndArgs ...interface{}) {
+	t.Helper()
+
+	found := false
+	var oidsInExtensions []string
+	for _, extension := range extensions {
+		oidsInExtensions = append(oidsInExtensions, extension.Id.String())
+		if extension.Id.Equal(identifier) {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		msg := fmt.Sprintf("Failed to find matching asn oid %s out of %v", identifier.String(), oidsInExtensions)
+		require.Fail(t, msg, msgAndArgs)
+	}
+}
+
+func extractSerialsFromCrl(t *testing.T, crl *x509.RevocationList) map[string]time.Time {
+	serials := map[string]time.Time{}
+
+	for _, revokedCert := range crl.RevokedCertificates {
+		serial := serialFromBigInt(revokedCert.SerialNumber)
+		if _, exists := serials[serial]; exists {
+			t.Fatalf("Serial number %s was duplicated in CRL", serial)
+		}
+		serials[serial] = revokedCert.RevocationTime
+	}
+	return serials
+}

--- a/builtin/logical/pki/path_resign_crls_test.go
+++ b/builtin/logical/pki/path_resign_crls_test.go
@@ -19,7 +19,7 @@ func TestResignCrls_ForbidSigningOtherIssuerCRL(t *testing.T) {
 	// Some random CRL from another issuer
 	pem1 := "-----BEGIN X509 CRL-----\nMIIBvjCBpwIBATANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQDExByb290LWV4YW1w\nbGUuY29tFw0yMjEwMjYyMTI5MzlaFw0yMjEwMjkyMTI5MzlaMCcwJQIUSnVf8wsd\nHjOt9drCYFhWxS9QqGoXDTIyMTAyNjIxMjkzOVqgLzAtMB8GA1UdIwQYMBaAFHki\nZ0XDUQVSajNRGXrg66OaIFlYMAoGA1UdFAQDAgEDMA0GCSqGSIb3DQEBCwUAA4IB\nAQBGIdtqTwemnLZF5AoP+jzvKZ26S3y7qvRIzd7f4A0EawzYmWXSXfwqo4TQ4DG3\nnvT+AaA1zCCOlH/1U+ufN9gSSN0j9ax58brSYMnMskMCqhLKIp0qnvS4jr/gopmF\nv8grbvLHEqNYTu1T7umMLdNQUsWT3Qc+EIjfoKj8xD2FHsZwJ+EMbytwl8Unipjr\nhz4rmcES/65vavfdFpOI6YXfi+UAaHBdkTqmHgg4BdpuXfYtlf+iotFSOkygD5fl\n0D+RVFW9uJv2WfbQ7kRt1X/VcFk/onw0AQqxZRVUzvjoMw+EMcxSq3UKOlXcWDxm\nEFz9rFQQ66L388EP8RD7Dh3X\n-----END X509 CRL-----"
 
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"common_name": "test.com",
 		"key_type":    "ec",
@@ -37,8 +37,8 @@ func TestResignCrls_ForbidSigningOtherIssuerCRL(t *testing.T) {
 
 func TestResignCrls_NormalCrl(t *testing.T) {
 	t.Parallel()
-	b1, s1 := createBackendWithStorage(t)
-	b2, s2 := createBackendWithStorage(t)
+	b1, s1 := CreateBackendWithStorage(t)
+	b2, s2 := CreateBackendWithStorage(t)
 
 	// Setup two backends, with the same key material/certificate with a different leaf in each that is revoked.
 	caCert, serial1, serial2, crl1, crl2 := setupResignCrlMounts(t, b1, s1, b2, s2)
@@ -75,8 +75,8 @@ func TestResignCrls_NormalCrl(t *testing.T) {
 
 func TestResignCrls_EliminateDuplicates(t *testing.T) {
 	t.Parallel()
-	b1, s1 := createBackendWithStorage(t)
-	b2, s2 := createBackendWithStorage(t)
+	b1, s1 := CreateBackendWithStorage(t)
+	b2, s2 := CreateBackendWithStorage(t)
 
 	// Setup two backends, with the same key material/certificate with a different leaf in each that is revoked.
 	_, serial1, _, crl1, _ := setupResignCrlMounts(t, b1, s1, b2, s2)
@@ -106,8 +106,8 @@ func TestResignCrls_EliminateDuplicates(t *testing.T) {
 
 func TestResignCrls_ConflictingExpiry(t *testing.T) {
 	t.Parallel()
-	b1, s1 := createBackendWithStorage(t)
-	b2, s2 := createBackendWithStorage(t)
+	b1, s1 := CreateBackendWithStorage(t)
+	b2, s2 := CreateBackendWithStorage(t)
 
 	// Setup two backends, with the same key material/certificate with a different leaf in each that is revoked.
 	_, serial1, serial2, crl1, _ := setupResignCrlMounts(t, b1, s1, b2, s2)
@@ -180,8 +180,8 @@ func TestResignCrls_ConflictingExpiry(t *testing.T) {
 func TestResignCrls_DeltaCrl(t *testing.T) {
 	t.Parallel()
 
-	b1, s1 := createBackendWithStorage(t)
-	b2, s2 := createBackendWithStorage(t)
+	b1, s1 := CreateBackendWithStorage(t)
+	b2, s2 := CreateBackendWithStorage(t)
 
 	// Setup two backends, with the same key material/certificate with a different leaf in each that is revoked.
 	caCert, serial1, serial2, crl1, crl2 := setupResignCrlMounts(t, b1, s1, b2, s2)

--- a/builtin/logical/pki/path_resign_crls_test.go
+++ b/builtin/logical/pki/path_resign_crls_test.go
@@ -187,11 +187,11 @@ func TestResignCrls_DeltaCrl(t *testing.T) {
 	caCert, serial1, serial2, crl1, crl2 := setupResignCrlMounts(t, b1, s1, b2, s2)
 
 	resp, err := CBWrite(b1, s1, "issuer/default/resign-crls", map[string]interface{}{
-		"crl_number":       "5",
-		"delta_crl_number": "4",
-		"next_update":      "12h",
-		"format":           "pem",
-		"crls":             []string{crl1, crl2},
+		"crl_number":            "5",
+		"delta_crl_base_number": "4",
+		"next_update":           "12h",
+		"format":                "pem",
+		"crls":                  []string{crl1, crl2},
 	})
 	requireSuccessNonNilResponse(t, resp, err)
 	requireFieldsSetInResp(t, resp, "crl")

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -214,12 +214,21 @@ func requireFieldsSetInResp(t *testing.T, resp *logical.Response, fields ...stri
 
 func requireSuccessNonNilResponse(t *testing.T, resp *logical.Response, err error, msgAndArgs ...interface{}) {
 	require.NoError(t, err, msgAndArgs...)
-	require.False(t, resp.IsError(), msgAndArgs...)
+	if resp.IsError() {
+		errContext := fmt.Sprintf("Expected successful response but got error: %v", resp.Error())
+		require.Falsef(t, resp.IsError(), errContext, msgAndArgs...)
+	}
 	require.NotNil(t, resp, msgAndArgs...)
 }
 
 func requireSuccessNilResponse(t *testing.T, resp *logical.Response, err error, msgAndArgs ...interface{}) {
 	require.NoError(t, err, msgAndArgs...)
-	require.False(t, resp.IsError(), msgAndArgs...)
-	require.Nil(t, resp, msgAndArgs...)
+	if resp.IsError() {
+		errContext := fmt.Sprintf("Expected successful response but got error: %v", resp.Error())
+		require.Falsef(t, resp.IsError(), errContext, msgAndArgs...)
+	}
+	if resp != nil {
+		msg := fmt.Sprintf("expected nil response but got: %v", resp)
+		require.Nilf(t, resp, msg, msgAndArgs...)
+	}
 }

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -69,6 +69,7 @@ update your API calls accordingly.
   - [Set CRL Configuration](#set-crl-configuration)
   - [Rotate CRLs](#rotate-crls)
   - [Rotate Delta CRLs](#rotate-delta-crls)
+  - [Combining CRLs from the same Issuer](#combine-crls-from-the-same-issuer)
   - [Tidy](#tidy)
   - [Configure Automatic Tidy](#configure-automatic-tidy)
   - [Tidy Status](#tidy-status)
@@ -3294,7 +3295,67 @@ $ curl \
 }
 ```
 
+### Combine CRLs From The Same Issuer
 
+This endpoint allows combining multiple different CRLs that have been signed by the
+same issuer into a single signed CRL. This is useful to generate a single authoritative
+CRL of revocations across distinct Vault clusters such as primary and performance replica
+clusters.
+
+
+| Method | Path                                   |
+|:-------|:---------------------------------------|
+| `POST` | `/pki/issuer/<issuer ref>/resign-crls` |
+
+
+#### Parameters
+
+- `issuer_ref` `(string: <required>)` - Reference to an existing issuer,
+  either by Vault-generated identifier, the literal string `default` to
+  refer to the currently configured default issuer, or the name assigned
+  to an issuer. This parameter is part of the request URL.
+- `crls` `(list of strings: <required>)` - A list of PEM encoded CRLs that have been
+  signed by the issuer
+- `crl_number` `(int: <required>)` - The sequence number to be written within the CRL
+  Number extension.
+- `delta_crl_number` `(int: 0)` - Using a non-zero value specifies the base CRL revision
+  number to encode within a Delta CRL indicator extension, otherwise the extension will
+  not be added; defaults to 0.
+- `format` `(string: pem)` - The format of the combined CRL, can be "pem" or "der".
+  If "der", the value will be base64 encoded; Defaults to "pem".
+- `next_update` `(string: 72h)` - The amount of time the generated CRL should be
+  valid; defaults to 72 hours.
+
+#### Sample Payload
+
+```json
+{
+  "crl_number": "10",
+  "next_update": "24h",
+  "crls": ["<PEM crl 1>", "<PEM crl 2>"],
+  "format": "pem"
+}
+```
+
+#### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    -request POST \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/pki/issuer/default/resign-crls
+```
+
+#### Sample Response
+
+```json
+{
+  "data": {
+    "crl": "<PEM encoded crl>"
+  }
+}
+```
 
 ### Tidy
 

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -3318,9 +3318,9 @@ clusters.
   signed by the issuer
 - `crl_number` `(int: <required>)` - The sequence number to be written within the CRL
   Number extension.
-- `delta_crl_number` `(int: 0)` - Using a non-zero value specifies the base CRL revision
+- `delta_crl_base_number` `(int: -1)` - Using a value of 0 or greater specifies the base CRL revision
   number to encode within a Delta CRL indicator extension, otherwise the extension will
-  not be added; defaults to 0.
+  not be added; defaults to -1.
 - `format` `(string: pem)` - The format of the combined CRL, can be "pem" or "der".
   If "der", the value will be base64 encoded; Defaults to "pem".
 - `next_update` `(string: 72h)` - The amount of time the generated CRL should be

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -3303,9 +3303,9 @@ CRL of revocations across distinct Vault clusters such as primary and performanc
 clusters.
 
 
-| Method | Path                                   |
-|:-------|:---------------------------------------|
-| `POST` | `/pki/issuer/<issuer ref>/resign-crls` |
+| Method | Path                                  |
+|:-------|:--------------------------------------|
+| `POST` | `/pki/issuer/:issuer_ref/resign-crls` |
 
 
 #### Parameters


### PR DESCRIPTION
 - Add a new PKI api `/issuer/<issuer ref>/resign-crls` that will allow combining and signing different CRLs that were signed by the same issuer.
 - This allows external actors to combine CRLs into a single CRL across different Vault clusters that share the CA certificate and key material such as performance replica clusters and the primary cluster