### PR TITLE
docs/vault-k8s: update env example

### DIFF
--- a/website/content/docs/platform/k8s/injector/examples.mdx
+++ b/website/content/docs/platform/k8s/injector/examples.mdx
@@ -284,8 +284,10 @@ spec:
       containers:
         - name: web
           image: alpine:latest
+          command:
+            ['sh', '-c']
           args:
-            ['sh', '-c', 'source /vault/secrets/config && <entrypoint script>']
+            ['source /vault/secrets/config && <entrypoint script>']
           ports:
             - containerPort: 9090
 ```


### PR DESCRIPTION
Specifying only `args` will just append them to the container image's entrypoint instead of replacing it: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#container-v1-core. So this example wasn't actually setting the env variable in the app's env.

Setting `command` overrides the entrypoint, and `args` is then appended to the command.

Related to https://github.com/hashicorp/vault-k8s/issues/45