### PR TITLE
ui: mfa: use proper request id generation

### DIFF
--- a/changelog/17835.txt
+++ b/changelog/17835.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: mfa: use proper request id generation
+```

--- a/ui/mirage/handlers/mfa-login.js
+++ b/ui/mirage/handlers/mfa-login.js
@@ -93,11 +93,7 @@ export default function (server) {
     } else if (user === 'mfa-j') {
       [mfa_constraints, methods] = generator([m('pingid')]); // use to test push failures
     }
-    const numbers = (length) =>
-      Math.random()
-        .toString()
-        .substring(2, length + 2);
-    const mfa_request_id = `${numbers(8)}-${numbers(4)}-${numbers(4)}-${numbers(4)}-${numbers(12)}`;
+    const mfa_request_id = crypto.randomUUID();
     const mfa_requirement = {
       mfa_request_id,
       mfa_constraints,


### PR DESCRIPTION
Use `crypto.randomUUID()` to generate `mfa_request_id` instead of magic with `Math.random()`.

Fixes: 712cc9ee, ca14c191

Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>