### PR TITLE
Make the error and http code clearer when supplying wrong unseal key

### DIFF
--- a/changelog/17836.txt
+++ b/changelog/17836.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: trying to unseal with the wrong key now returns HTTP 400
+```

--- a/http/sys_seal_test.go
+++ b/http/sys_seal_test.go
@@ -275,7 +275,7 @@ func subtestBadMultiKey(t *testing.T, seal vault.Seal) {
 			},
 		},
 		{
-			"mixing unseal keys from different cluster, different key share config",
+			"mixing unseal keys from different cluster, different share config",
 			[]string{
 				"b189d98fdec3a15bed9b1cce5088f82b92896696b788c07bdf03c73da08279a5e8",
 				"0fa98232f034177d8d9c2824899a2ac1e55dc6799348533e10510b856aef99f61a",
@@ -283,7 +283,7 @@ func subtestBadMultiKey(t *testing.T, seal vault.Seal) {
 			},
 		},
 		{
-			"mixing unseal keys from different clusters, same key share config",
+			"mixing unseal keys from different clusters, similar share config",
 			[]string{
 				"b189d98fdec3a15bed9b1cce5088f82b92896696b788c07bdf03c73da08279a5e8",
 				"0fa98232f034177d8d9c2824899a2ac1e55dc6799348533e10510b856aef99f61a",

--- a/http/sys_seal_test.go
+++ b/http/sys_seal_test.go
@@ -178,29 +178,24 @@ func TestSysUnseal_badKey(t *testing.T) {
 	testCases := []struct {
 		description string
 		key         string
-		expected    http.Response
 	}{
 		// hex key tests
 		// hexadecimal strings have 2 symbols per byte; size(0xAA) == 1 byte
 		{
 			"short hex key",
 			strings.Repeat("AA", 8),
-			http.Response{StatusCode: 400},
 		},
 		{
 			"long hex key",
 			strings.Repeat("AA", 34),
-			http.Response{StatusCode: 400},
 		},
 		{
 			"uneven hex key byte length",
 			strings.Repeat("AA", 33),
-			http.Response{StatusCode: 400},
 		},
 		{
 			"valid hex key but wrong cluster",
 			"4482691dd3a710723c4f77c4920ee21b96c226bf4829fa6eb8e8262c180ae933",
-			http.Response{StatusCode: 400},
 		},
 
 		// base64 key tests
@@ -208,34 +203,28 @@ func TestSysUnseal_badKey(t *testing.T) {
 		{
 			"short b64 key",
 			base64.StdEncoding.EncodeToString([]byte(strings.Repeat("m", 8))),
-			http.Response{StatusCode: 400},
 		},
 		{
 			"long b64 key",
 			base64.StdEncoding.EncodeToString([]byte(strings.Repeat("m", 34))),
-			http.Response{StatusCode: 400},
 		},
 		{
 			"uneven b64 key byte length",
 			base64.StdEncoding.EncodeToString([]byte(strings.Repeat("m", 33))),
-			http.Response{StatusCode: 400},
 		},
 		{
 			"valid b64 key but wrong cluster",
 			"RIJpHdOnEHI8T3fEkg7iG5bCJr9IKfpuuOgmLBgK6TM=",
-			http.Response{StatusCode: 400},
 		},
 
 		// other key tests
 		{
 			"empty key",
 			"",
-			http.Response{StatusCode: 400},
 		},
 		{
 			"key with bad format",
 			"ThisKeyIsNeitherB64NorHex",
-			http.Response{StatusCode: 400},
 		},
 	}
 
@@ -244,7 +233,7 @@ func TestSysUnseal_badKey(t *testing.T) {
 			resp := testHttpPut(t, "", addr+"/v1/sys/unseal", map[string]interface{}{
 				"key": tc.key,
 			})
-			testResponseStatus(t, resp, tc.expected.StatusCode)
+			testResponseStatus(t, resp, 400)
 		})
 	}
 }

--- a/vault/core.go
+++ b/vault/core.go
@@ -2788,7 +2788,7 @@ func (c *Core) unsealKeyToMasterKey(ctx context.Context, seal Seal, combinedKey 
 
 		err := seal.GetAccess().Wrapper.(*aeadwrapper.ShamirWrapper).SetAesGcmKeyBytes(combinedKey)
 		if err != nil {
-			return nil, fmt.Errorf("failed to setup unseal key: %w", err)
+			return nil, &ErrInvalidKey{fmt.Sprintf("failed to setup unseal key: %v", err)}
 		}
 		storedKeys, err := seal.GetStoredKeys(ctx)
 		if storedKeys == nil && err == nil && allowMissing {

--- a/vault/core.go
+++ b/vault/core.go
@@ -1549,13 +1549,13 @@ func (c *Core) getUnsealKey(ctx context.Context, seal Seal) ([]byte, error) {
 	} else {
 		unsealKey, err = shamir.Combine(c.unlockInfo.Parts)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compute combined key: %w", err)
+			return nil, &ErrInvalidKey{fmt.Sprintf("failed to compute combined key: %v", err)}
 		}
 	}
 
 	if seal.RecoveryKeySupported() {
 		if err := seal.VerifyRecoveryKey(ctx, unsealKey); err != nil {
-			return nil, err
+			return nil, &ErrInvalidKey{fmt.Sprintf("failed to verify recovery key: %v", err)}
 		}
 	}
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -1299,13 +1299,13 @@ func (c *Core) Unseal(key []byte) (bool, error) {
 }
 
 // unseal takes a key fragment and attempts to use it to unseal Vault.
-// Vault may remain unsealed afterwards even when no error is returned,
+// Vault may remain sealed afterwards even when no error is returned,
 // depending on whether enough key fragments were provided to meet the
 // target threshold.
 //
 // The provided key should be a recovery key fragment if the seal
 // is an autoseal, or a regular seal key fragment for shamir.  In
-// migration scenarios "seal" in the preceding sentance refers to
+// migration scenarios "seal" in the preceding sentence refers to
 // the migration seal in c.migrationInfo.seal.
 //
 // We use getUnsealKey to work out if we have enough fragments,

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -486,7 +486,7 @@ func readStoredKeys(ctx context.Context, storage physical.Backend, encryptor *se
 	pt, err := encryptor.Decrypt(ctx, blobInfo, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "message authentication failed") {
-			return nil, &ErrInvalidKey{Reason: "failed to decrypt keys from storage"}
+			return nil, &ErrInvalidKey{Reason: fmt.Sprintf("failed to decrypt keys from storage: %v", err)}
 		}
 		return nil, &ErrDecrypt{Err: fmt.Errorf("failed to decrypt keys from storage: %w", err)}
 	}

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync/atomic"
 
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
@@ -484,6 +485,9 @@ func readStoredKeys(ctx context.Context, storage physical.Backend, encryptor *se
 
 	pt, err := encryptor.Decrypt(ctx, blobInfo, nil)
 	if err != nil {
+		if strings.Contains(err.Error(), "message authentication failed") {
+			return nil, &ErrInvalidKey{Reason: "failed to decrypt keys from storage"}
+		}
 		return nil, &ErrDecrypt{Err: fmt.Errorf("failed to decrypt keys from storage: %w", err)}
 	}
 


### PR DESCRIPTION
The error message inspection is the same as used elsewhere in the code (vault/barrier_aes_gcm.go).
ErrInvalidKey is already handled as a http 400 response in http/sys_seal.go, so we can simply use it in vault/seal.go to get http 400.

Regarding the error message, omitting the "message authentication failed" part, as it is printed to the end user.

Fixes #17792 