### PR TITLE
Backport of Ember Security Vulnerability Patch into release/1.12.x

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -126,7 +126,7 @@
     "ember-router-helpers": "^0.4.0",
     "ember-service-worker": "meirish/ember-service-worker#configurable-scope",
     "ember-sinon": "^4.0.0",
-    "ember-source": "~3.28.8",
+    "ember-source": "3.28.10",
     "ember-svg-jar": "^2.1.0",
     "ember-template-lint": "4.3.0",
     "ember-template-lint-plugin-prettier": "4.0.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9279,10 +9279,10 @@ ember-source-channel-url@^3.0.0:
   dependencies:
     node-fetch "^2.6.0"
 
-ember-source@~3.28.8:
-  version "3.28.8"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.28.8.tgz#c58fd4a1538d6c4b9aebe76c764cabf5396c64d9"
-  integrity sha512-hA15oYzbRdi9983HIemeVzzX2iLcMmSPp6akUiMQhFZYWPrKksbPyLrO6YpZ4hNM8yBjQSDXEkZ1V3yxBRKjUA==
+ember-source@3.28.10:
+  version "3.28.10"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.28.10.tgz#f4be7e2852d421a558f686505748f4c88f6d6ae6"
+  integrity sha512-TH8ug2rRUq6pLwqjciwvnuF8GDKBXNW2v5mvDkkf+k5S84XVHPjn3K0q2uGaR2W/mCDYg+mGmqu/PIGy0STx9Q==
   dependencies:
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/plugin-transform-block-scoping" "^7.8.3"


### PR DESCRIPTION
Manual backport of #17842 since `ember-source` version differs across vault versions.

