### PR TITLE
VAULT-8703 Add warning for dangerous undocumented overrides, if used, in status response

### DIFF
--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -93,22 +93,23 @@ func sealStatusRequestWithContext(ctx context.Context, c *Sys, r *Request) (*Sea
 }
 
 type SealStatusResponse struct {
-	Type              string `json:"type"`
-	Initialized       bool   `json:"initialized"`
-	Sealed            bool   `json:"sealed"`
-	T                 int    `json:"t"`
-	N                 int    `json:"n"`
-	Progress          int    `json:"progress"`
-	Nonce             string `json:"nonce"`
-	Version           string `json:"version"`
-	BuildDate         string `json:"build_date"`
-	Migration         bool   `json:"migration"`
-	ClusterName       string `json:"cluster_name,omitempty"`
-	ClusterID         string `json:"cluster_id,omitempty"`
-	RecoverySeal      bool   `json:"recovery_seal"`
-	StorageType       string `json:"storage_type,omitempty"`
-	HCPLinkStatus     string `json:"hcp_link_status,omitempty"`
-	HCPLinkResourceID string `json:"hcp_link_resource_ID,omitempty"`
+	Type              string   `json:"type"`
+	Initialized       bool     `json:"initialized"`
+	Sealed            bool     `json:"sealed"`
+	T                 int      `json:"t"`
+	N                 int      `json:"n"`
+	Progress          int      `json:"progress"`
+	Nonce             string   `json:"nonce"`
+	Version           string   `json:"version"`
+	BuildDate         string   `json:"build_date"`
+	Migration         bool     `json:"migration"`
+	ClusterName       string   `json:"cluster_name,omitempty"`
+	ClusterID         string   `json:"cluster_id,omitempty"`
+	RecoverySeal      bool     `json:"recovery_seal"`
+	StorageType       string   `json:"storage_type,omitempty"`
+	HCPLinkStatus     string   `json:"hcp_link_status,omitempty"`
+	HCPLinkResourceID string   `json:"hcp_link_resource_ID,omitempty"`
+	Warnings          []string `json:"warnings,omitempty"`
 }
 
 type UnsealOpts struct {

--- a/changelog/17855.txt
+++ b/changelog/17855.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Added warning to /sys/seal-status and vault status command if potentially dangerous behaviour overrides are being used.
+```

--- a/command/format.go
+++ b/command/format.go
@@ -402,6 +402,9 @@ func (t TableFormatter) OutputSealStatusStruct(ui cli.Ui, secret *api.Secret, da
 	if status.LastWAL != 0 {
 		out = append(out, fmt.Sprintf("Last WAL | %d", status.LastWAL))
 	}
+	if len(status.Warnings) > 0 {
+		out = append(out, fmt.Sprintf("Warnings | %v", status.Warnings))
+	}
 
 	ui.Output(tableOutput(out, &columnize.Config{
 		Delim: "|",

--- a/command/format_test.go
+++ b/command/format_test.go
@@ -175,7 +175,7 @@ func getMockStatusData(emptyFields bool) SealStatusOutput {
 			ClusterID:    "cluster id",
 			RecoverySeal: true,
 			StorageType:  "storage type",
-			Warnings:     append(make([]string, 0), "warning"),
+			Warnings:     []string{"warning"},
 		}
 
 		// must initialize this struct without explicit field names due to embedding

--- a/command/format_test.go
+++ b/command/format_test.go
@@ -118,7 +118,8 @@ Cluster ID                    cluster id
 HA Enabled                    true
 Raft Committed Index          3
 Raft Applied Index            4
-Last WAL                      2`
+Last WAL                      2
+Warnings                      [warning]`
 
 	if expectedOutputString != output {
 		fmt.Printf("%s\n%+v\n %s\n%+v\n", "output found was: ", output, "versus", expectedOutputString)
@@ -174,6 +175,7 @@ func getMockStatusData(emptyFields bool) SealStatusOutput {
 			ClusterID:    "cluster id",
 			RecoverySeal: true,
 			StorageType:  "storage type",
+			Warnings:     append(make([]string, 0), "warning"),
 		}
 
 		// must initialize this struct without explicit field names due to embedding

--- a/http/sys_seal_test.go
+++ b/http/sys_seal_test.go
@@ -60,6 +60,80 @@ func TestSysSealStatus(t *testing.T) {
 	}
 }
 
+func TestSysSealStatus_Warnings(t *testing.T) {
+	core := vault.TestCore(t)
+	vault.TestCoreInit(t, core)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+
+	// Manually configure DisableSSCTokens to be true
+	core.GetCoreConfigInternal().DisableSSCTokens = true
+
+	resp, err := http.Get(addr + "/v1/sys/seal-status")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	var actual map[string]interface{}
+	expected := map[string]interface{}{
+		"sealed":        true,
+		"t":             json.Number("3"),
+		"n":             json.Number("3"),
+		"progress":      json.Number("0"),
+		"nonce":         "",
+		"type":          "shamir",
+		"recovery_seal": false,
+		"initialized":   true,
+		"migration":     false,
+		"build_date":    version.BuildDate,
+	}
+	testResponseStatus(t, resp, 200)
+	testResponseBody(t, resp, &actual)
+	if actual["version"] == nil {
+		t.Fatalf("expected version information")
+	}
+	expected["version"] = actual["version"]
+	if actual["cluster_name"] == nil {
+		delete(expected, "cluster_name")
+	} else {
+		expected["cluster_name"] = actual["cluster_name"]
+	}
+	if actual["cluster_id"] == nil {
+		delete(expected, "cluster_id")
+	} else {
+		expected["cluster_id"] = actual["cluster_id"]
+	}
+	actualWarnings := actual["warnings"]
+	if actualWarnings == nil {
+		t.Fatalf("expected warnings about SSCToken disabling")
+	}
+
+	actualWarningsArray, ok := actualWarnings.([]interface{})
+	if !ok {
+		t.Fatalf("expected warnings about SSCToken disabling were not in the right format")
+	}
+	if len(actualWarningsArray) != 1 {
+		t.Fatalf("too many warnings were given")
+	}
+	actualWarning, ok := actualWarningsArray[0].(string)
+	if !ok {
+		t.Fatalf("expected warning about SSCToken disabling was not in the right format")
+	}
+
+	expectedWarning := "Server Side Consistent Tokens are disabled, due to the " +
+		"VAULT_DISABLE_SERVER_SIDE_CONSISTENT_TOKENS environment variable being set. " +
+		"It is not recommended to run Vault for an extended period of time with this configuration."
+	if actualWarning != expectedWarning {
+		t.Fatalf("actual warning was not as expected. Expected %s, but got %s", expectedWarning, actualWarning)
+	}
+
+	expected["warnings"] = actual["warnings"]
+
+	if diff := deep.Equal(actual, expected); diff != nil {
+		t.Fatal(diff)
+	}
+}
+
 func TestSysSealStatus_uninit(t *testing.T) {
 	core := vault.TestCore(t)
 	ln, addr := TestServer(t, core)


### PR DESCRIPTION
If this environment variable is set, you will now get the following output:
```
violet@violet-TX54KFJWXM vault % vault status
Key             Value
---             -----
Seal Type       shamir
Initialized     true
Sealed          false
Total Shares    1
Threshold       1
Version         1.13.0-dev1
Build Date      2022-10-31T11:14:49Z
Storage Type    inmem
Cluster Name    vault-cluster-30c0be85
Cluster ID      64a060de-020b-91a7-ec26-0a6686c3beea
HA Enabled      false
Warnings        [Server Side Consistent Tokens are disabled, due to the VAULT_DISABLE_SERVER_SIDE_CONSISTENT_TOKENS environment variable being set. It is not recommended to run Vault for an extended period of time with this configuration.]
```
"Warnings" will not be present if this option is not given.

Also, json output:
```
violet@violet-TX54KFJWXM vault % vault status -format=json
{
  "type": "shamir",
  "initialized": true,
  "sealed": false,
  "t": 1,
  "n": 1,
  "progress": 0,
  "nonce": "",
  "version": "1.13.0-dev1",
  "build_date": "2022-10-31T11:14:49Z",
  "migration": false,
  "cluster_name": "vault-cluster-8c976330",
  "cluster_id": "0d51a6d0-d7c7-9cdb-0693-abc77e063bee",
  "recovery_seal": false,
  "storage_type": "inmem",
  "warnings": [
    "Server Side Consistent Tokens are disabled, due to the VAULT_DISABLE_SERVER_SIDE_CONSISTENT_TOKENS environment variable being set. It is not recommended to run Vault for an extended period of time with this configuration."
  ],
  "ha_enabled": false,
  "active_time": "0001-01-01T00:00:00Z"
}
```

I couldn't find an appropriate docs page to add the note about this new warning option in, but I think it's probably fine without, as it only affects customers that have added out-of-docs options.