### PR TITLE
Fix activity log end time

### DIFF
--- a/changelog/17856.txt
+++ b/changelog/17856.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/activity: fix the end_date returned from the activity log endpoint when partial counts are computed
+```

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1515,7 +1515,6 @@ func (a *ActivityLog) DefaultStartTime(endTime time.Time) time.Time {
 
 func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.Time, limitNamespaces int) (map[string]interface{}, error) {
 	var computePartial bool
-	actualEndTime := endTime
 
 	// Change the start time to the beginning of the month, and the end time to be the end
 	// of the month.
@@ -1623,9 +1622,11 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 
 	// If we computed partial counts, we should return the actual end time we computed counts for, not the pre-computed
 	// query end time. If we don't do this, the end_time in the response doesn't match the actual data in the response,
-	// which is confusing.
+	// which is confusing. Note that regardless of what end time is given, if it falls within the current month, it will
+	// be set to the end of the current month. This is definitely suboptimal, and possibly confusing, but still an
+	// improvement over using the pre-computed query end time.
 	if computePartial {
-		responseData["end_time"] = actualEndTime.Format(time.RFC3339)
+		responseData["end_time"] = endTime.Format(time.RFC3339)
 	} else {
 		responseData["end_time"] = pq.EndTime.Format(time.RFC3339)
 	}


### PR DESCRIPTION
From what I can tell, I think the activity log endpoint is returning the correct data, but it's not adjusting the `end_time` that's returned when we calculate partial month counts. Instead, it was always using the end time for the pre-computed query. This meant that the end_time returned didn't accurately reflect the actual data. Now it should.

For more detail see https://hashicorp.atlassian.net/browse/VAULT-9257