### PR TITLE
clarify that certain policy examples are for KVv1

### DIFF
--- a/website/content/docs/concepts/policies.mdx
+++ b/website/content/docs/concepts/policies.mdx
@@ -84,7 +84,7 @@ user or machine is allowed to access.
 
 [hcl]: https://github.com/hashicorp/hcl
 
-Here is a very simple policy which grants read capabilities to the path
+Here is a very simple policy which grants read capabilities to the [KVv1](/api-docs/secret/kv/kv-v1) path
 `"secret/foo"`:
 
 ```ruby


### PR DESCRIPTION
https://github.com/hashicorp/vault/issues/17733 notes that the examples in the policy concepts docs are a bit misleading. There are policy examples meant for KVv1 but they are not denoted as such. This PR add a callout and links to the KVv1 API docs for further context.