### PR TITLE
clarify that init recovery options are only available for auto unseal

### DIFF
--- a/website/content/api-docs/system/init.mdx
+++ b/website/content/api-docs/system/init.mdx
@@ -66,11 +66,11 @@ Additionally, the following options are only supported using Auto Unseal:
   be the same as `secret_shares`.
 
 - `recovery_shares` `(int: 0)` – Specifies the number of shares to
-  split the recovery key into. Only available when using Auto Unseal.
+  split the recovery key into. This is only available when using Auto Unseal.
 
 - `recovery_threshold` `(int: 0)` – Specifies the number of shares
   required to reconstruct the recovery key. This must be less than or equal to
-  `recovery_shares`. Only available when using Auto Unseal.
+  `recovery_shares`. This is only available when using Auto Unseal.
 
 - `recovery_pgp_keys` `(array<string>: nil)` – Specifies an array of PGP public
   keys used to encrypt the output recovery keys. Ordering is preserved. The keys

--- a/website/content/api-docs/system/init.mdx
+++ b/website/content/api-docs/system/init.mdx
@@ -75,7 +75,7 @@ Additionally, the following options are only supported using Auto Unseal:
 - `recovery_pgp_keys` `(array<string>: nil)` – Specifies an array of PGP public
   keys used to encrypt the output recovery keys. Ordering is preserved. The keys
   must be base64-encoded from their original binary representation. The size of
-  this array must be the same as `recovery_shares`. Only available when using Auto Unseal.
+  this array must be the same as `recovery_shares`. This is only available when using Auto Unseal.
 
 ### Sample Payload
 

--- a/website/content/api-docs/system/init.mdx
+++ b/website/content/api-docs/system/init.mdx
@@ -35,7 +35,7 @@ $ curl \
 
 This endpoint initializes a new Vault. The Vault must not have been previously
 initialized. The recovery options, as well as the stored shares option, are only
-available when using Auto Unseal.
+available when using [Auto Unseal](/docs/concepts/seal#auto-unseal).
 
 | Method | Path        |
 | :----- | :---------- |
@@ -65,17 +65,17 @@ Additionally, the following options are only supported using Auto Unseal:
   should be encrypted by the HSM and stored for auto-unsealing. Currently must
   be the same as `secret_shares`.
 
-- `recovery_shares` `(int: <required>)` – Specifies the number of shares to
-  split the recovery key into.
+- `recovery_shares` `(int: 0)` – Specifies the number of shares to
+  split the recovery key into. Only available when using Auto Unseal.
 
-- `recovery_threshold` `(int: <required>)` – Specifies the number of shares
+- `recovery_threshold` `(int: 0)` – Specifies the number of shares
   required to reconstruct the recovery key. This must be less than or equal to
-  `recovery_shares`.
+  `recovery_shares`. Only available when using Auto Unseal.
 
 - `recovery_pgp_keys` `(array<string>: nil)` – Specifies an array of PGP public
   keys used to encrypt the output recovery keys. Ordering is preserved. The keys
   must be base64-encoded from their original binary representation. The size of
-  this array must be the same as `recovery_shares`.
+  this array must be the same as `recovery_shares`. Only available when using Auto Unseal.
 
 ### Sample Payload
 

--- a/website/content/docs/commands/operator/init.mdx
+++ b/website/content/docs/commands/operator/init.mdx
@@ -109,13 +109,13 @@ flags](/docs/commands) included on all commands.
 ### HSM and KMS Options
 
 - `-recovery-pgp-keys` `(string: "...")` - Behaves like `-pgp-keys`, but for the
-  recovery key shares. This is only used with Auto Unseal seals (HSM, KMS and Transit seals).
+  recovery key shares. This is only available with [Auto Unseal](/docs/concepts/seal#auto-unseal) seals (HSM, KMS and Transit seals).
 
 - `-recovery-shares` `(int: 5)` - Number of key shares to split the recovery key
-  into. This is only used with Auto Unseal seals (HSM, KMS and Transit seals).
+  into. This is only available with [Auto Unseal](/docs/concepts/seal#auto-unseal) seals (HSM, KMS and Transit seals).
 
 - `-recovery-threshold` `(int: 3)` - Number of key shares required to
-  reconstruct the recovery key. This is only used with Auto Unseal seals (HSM, KMS and Transit seals).
+  reconstruct the recovery key. This is only available with [Auto Unseal](/docs/concepts/seal#auto-unseal) seals (HSM, KMS and Transit seals).
 
 - `-stored-shares` `(int: 0)` - Number of unseal keys to store on an HSM. This
   must be equal to `-key-shares`.


### PR DESCRIPTION
https://github.com/hashicorp/vault/issues/17764 noted that the recent validation changes to the `sys/init` endpoint around the recovery options were not clearly documented. This PR clarifies that the recovery options are only available if auto unseal is in use.