### PR TITLE
Fix a typo around custom-metadata in kv put docs

### DIFF
--- a/website/content/docs/commands/kv/metadata.mdx
+++ b/website/content/docs/commands/kv/metadata.mdx
@@ -152,7 +152,7 @@ be applied to new versions.
   the value is greater than the backend's `delete_version_after`, the backend's
   `delete_version_after` will be used. Accepts [duration format strings](/docs/concepts/duration-format).
 
-- -`custom-metadata` `(string: "")` - Specifies a key-value pair for the
+- `-custom-metadata` `(string: "")` - Specifies a key-value pair for the
   `custom_metadata` field. This can be specified multiple times to add multiple
   pieces of metadata.
 

--- a/website/content/docs/commands/kv/metadata.mdx
+++ b/website/content/docs/commands/kv/metadata.mdx
@@ -152,7 +152,7 @@ be applied to new versions.
   the value is greater than the backend's `delete_version_after`, the backend's
   `delete_version_after` will be used. Accepts [duration format strings](/docs/concepts/duration-format).
 
-- `custom-metadata` `(string: "")` - Specifies a key-value pair for the
+- -`custom-metadata` `(string: "")` - Specifies a key-value pair for the
   `custom_metadata` field. This can be specified multiple times to add multiple
   pieces of metadata.
 


### PR DESCRIPTION
There is a missing dash before 'custom-metadata':

    $ vault kv metadata put custom-metadata="foo=bar" secret/hub/config-demo
    Too many arguments (expected 1, got 2)
    $ vault kv metadata put -custom-metadata="foo=bar" secret/hub/config-demo
    Success! Data written to: secret/metadata/hub/config-demo

Signed-off-by: Michele Baldessari <michele@acksyn.org>
