### PR TITLE
add noop ent supported storage check

### DIFF
--- a/command/server_util.go
+++ b/command/server_util.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	adjustCoreConfigForEnt = adjustCoreConfigForEntNoop
-	checkStorageTypeForEnt = checkStorageTypeForEntNoop
+	storageSupportedForEnt = checkStorageTypeForEntNoop
 )
 
 func adjustCoreConfigForEntNoop(config *server.Config, coreConfig *vault.CoreConfig) {
@@ -19,6 +19,6 @@ func getFIPSInfoKeyNoop() string {
 	return ""
 }
 
-func checkStorageTypeForEntNoop(coreConfig *vault.CoreConfig) error {
-	return nil
+func checkStorageTypeForEntNoop(coreConfig *vault.CoreConfig) bool {
+	return true
 }


### PR DESCRIPTION
A change was added to the `vault server` command in 1.12 that would prevent startup (when not in dev mode) if configured to use an unsupported storage backend. HashiCorp currently supports Consul (consul) and Integrated Storage (raft). We are modifying this change so that it will instead log a warning. This PR includes the changes to the `vault server` command and an associated NOOP check as there is no support restriction on storage backend in OSS.

The check could be disabled using an environment variable, `VAULT_DISABLE_SUPPORTED_STORAGE_CHECK`.  This environment variable has been removed as there is no longer any need to disable the check as its only effect is that a warning will be logged.

Docs PR: https://github.com/hashicorp/vault/pull/17885