### PR TITLE
Kubernetes as mountable/supported secrets engine

### DIFF
--- a/ui/app/components/mount-backend-form.js
+++ b/ui/app/components/mount-backend-form.js
@@ -5,7 +5,7 @@ import { inject as service } from '@ember/service';
 import { action, setProperties } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { methods } from 'vault/helpers/mountable-auth-methods';
-import { engines, KMIP, TRANSFORM, KEYMGMT } from 'vault/helpers/mountable-secret-engines';
+import { mountableEngines, allEngines } from 'vault/helpers/mountable-secret-engines';
 import { waitFor } from '@ember/test-waiters';
 
 /**
@@ -21,7 +21,6 @@ import { waitFor } from '@ember/test-waiters';
  */
 
 const METHODS = methods();
-const ENGINES = engines();
 
 export default class MountBackendForm extends Component {
   @service store;
@@ -59,10 +58,7 @@ export default class MountBackendForm extends Component {
   }
 
   get engines() {
-    if (this.version.isEnterprise) {
-      return ENGINES.concat([KMIP, TRANSFORM, KEYMGMT]);
-    }
-    return ENGINES;
+    return this.version.isEnterprise ? allEngines() : mountableEngines();
   }
 
   willDestroy() {

--- a/ui/app/components/wizard/mounts-wizard.js
+++ b/ui/app/components/wizard/mounts-wizard.js
@@ -2,7 +2,7 @@ import { inject as service } from '@ember/service';
 import { alias, equal } from '@ember/object/computed';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { engines } from 'vault/helpers/mountable-secret-engines';
+import { mountableEngines } from 'vault/helpers/mountable-secret-engines';
 import { methods } from 'vault/helpers/mountable-auth-methods';
 import { supportedSecretBackends } from 'vault/helpers/supported-secret-backends';
 const supportedSecrets = supportedSecretBackends();
@@ -36,7 +36,7 @@ export default Component.extend({
   }),
   mountName: computed('currentMachine', 'mountSubtype', function () {
     if (this.currentMachine === 'secrets') {
-      var secret = engines().find((engine) => {
+      var secret = mountableEngines().find((engine) => {
         return engine.type === this.mountSubtype;
       });
       if (secret) {

--- a/ui/app/controllers/vault/cluster/settings/mount-secret-backend.js
+++ b/ui/app/controllers/vault/cluster/settings/mount-secret-backend.js
@@ -1,30 +1,34 @@
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import { supportedSecretBackends } from 'vault/helpers/supported-secret-backends';
+import { allEngines } from 'vault/helpers/mountable-secret-engines';
+import { action } from '@ember/object';
 
 const SUPPORTED_BACKENDS = supportedSecretBackends();
 
-export default Controller.extend({
-  wizard: service(),
-  actions: {
-    onMountSuccess: function (type, path) {
-      let transition;
-      if (SUPPORTED_BACKENDS.includes(type)) {
-        if (type === 'kmip') {
-          transition = this.transitionToRoute('vault.cluster.secrets.backend.kmip.scopes', path);
-        } else if (type === 'keymgmt') {
-          transition = this.transitionToRoute('vault.cluster.secrets.backend.index', path, {
-            queryParams: { tab: 'provider' },
-          });
-        } else {
-          transition = this.transitionToRoute('vault.cluster.secrets.backend.index', path);
-        }
+export default class MountSecretBackendController extends Controller {
+  @service wizard;
+  @service router;
+
+  @action
+  onMountSuccess(type, path) {
+    let transition;
+    if (SUPPORTED_BACKENDS.includes(type)) {
+      const { engineRoute } = allEngines().findBy('type', type);
+      if (engineRoute) {
+        transition = this.router.transitionTo(`vault.cluster.secrets.backend.${engineRoute}`, path);
+      } else if (type === 'keymgmt') {
+        transition = this.router.transitionTo('vault.cluster.secrets.backend.index', path, {
+          queryParams: { tab: 'provider' },
+        });
       } else {
-        transition = this.transitionToRoute('vault.cluster.secrets.backends');
+        transition = this.router.transitionTo('vault.cluster.secrets.backend.index', path);
       }
-      return transition.followRedirects().then(() => {
-        this.wizard.transitionFeatureMachine(this.wizard.featureState, 'CONTINUE', type);
-      });
-    },
-  },
-});
+    } else {
+      transition = this.router.transitionTo('vault.cluster.secrets.backends');
+    }
+    return transition.followRedirects().then(() => {
+      this.wizard.transitionFeatureMachine(this.wizard.featureState, 'CONTINUE', type);
+    });
+  }
+}

--- a/ui/app/helpers/mountable-secret-engines.js
+++ b/ui/app/helpers/mountable-secret-engines.js
@@ -1,29 +1,30 @@
 import { helper as buildHelper } from '@ember/component/helper';
 
-export const KMIP = {
-  displayName: 'KMIP',
-  value: 'kmip',
-  type: 'kmip',
-  category: 'generic',
-  requiredFeature: 'KMIP',
-};
-
-export const TRANSFORM = {
-  displayName: 'Transform',
-  value: 'transform',
-  type: 'transform',
-  category: 'generic',
-  requiredFeature: 'Transform Secrets Engine',
-};
-
-export const KEYMGMT = {
-  displayName: 'Key Management',
-  value: 'keymgmt',
-  type: 'keymgmt',
-  glyph: 'key',
-  category: 'cloud',
-  requiredFeature: 'Key Management Secrets Engine',
-};
+const ENTERPRISE_SECRET_ENGINES = [
+  {
+    displayName: 'KMIP',
+    value: 'kmip',
+    type: 'kmip',
+    engineRoute: 'kmip.scopes',
+    category: 'generic',
+    requiredFeature: 'KMIP',
+  },
+  {
+    displayName: 'Transform',
+    value: 'transform',
+    type: 'transform',
+    category: 'generic',
+    requiredFeature: 'Transform Secrets Engine',
+  },
+  {
+    displayName: 'Key Management',
+    value: 'keymgmt',
+    type: 'keymgmt',
+    glyph: 'key',
+    category: 'cloud',
+    requiredFeature: 'Key Management Secrets Engine',
+  },
+];
 
 const MOUNTABLE_SECRET_ENGINES = [
   {
@@ -120,10 +121,22 @@ const MOUNTABLE_SECRET_ENGINES = [
     type: 'totp',
     category: 'generic',
   },
+  {
+    displayName: 'Kubernetes',
+    value: 'kubernetes',
+    type: 'kubernetes',
+    engineRoute: 'kubernetes.overview',
+    category: 'generic',
+    glyph: 'kubernetes-color',
+  },
 ];
 
-export function engines() {
+export function mountableEngines() {
   return MOUNTABLE_SECRET_ENGINES.slice();
 }
 
-export default buildHelper(engines);
+export function allEngines() {
+  return [...MOUNTABLE_SECRET_ENGINES, ...ENTERPRISE_SECRET_ENGINES];
+}
+
+export default buildHelper(mountableEngines);

--- a/ui/app/helpers/supported-secret-backends.js
+++ b/ui/app/helpers/supported-secret-backends.js
@@ -12,6 +12,7 @@ const SUPPORTED_SECRET_BACKENDS = [
   'kmip',
   'transform',
   'keymgmt',
+  'kubernetes',
 ];
 
 export function supportedSecretBackends() {


### PR DESCRIPTION
This PR adds Kubernetes as a mountable and supported secrets engine and improves the `mountable-secret-engines` helper to be more flexible. A prop was added to the mountable engines config for `engineRoute` to handle transitioning to secrets engines that are within an Ember engine without adding specific conditions for each.