### PR TITLE
Add default to allowed values for algorithm_signer

### DIFF
--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -380,7 +380,7 @@ func pathRoles(b *backend) *framework.Path {
 				When supplied, this value specifies a signing algorithm for the key. Possible values:
 				ssh-rsa, rsa-sha2-256, rsa-sha2-512, default, or the empty string.
 				`,
-				AllowedValues: []interface{}{"", ssh.SigAlgoRSA, ssh.SigAlgoRSASHA2256, ssh.SigAlgoRSASHA2512},
+				AllowedValues: []interface{}{"", DefaultAlgorithmSigner, ssh.SigAlgoRSA, ssh.SigAlgoRSASHA2256, ssh.SigAlgoRSASHA2512},
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Signing Algorithm",
 				},

--- a/changelog/17894.txt
+++ b/changelog/17894.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: allow selection of "default" for ssh algorithm_signer in web interface
+```

--- a/ui/app/models/role-ssh.js
+++ b/ui/app/models/role-ssh.js
@@ -120,6 +120,7 @@ export default Model.extend({
   }),
   algorithmSigner: attr('string', {
     helpText: 'When supplied, this value specifies a signing algorithm for the key',
+    possibleValues: ['default', 'ssh-rsa', 'rsa-sha2-256', 'rsa-sha2-512'],
   }),
 
   showFields: computed('keyType', function () {


### PR DESCRIPTION
* Adds `default` to allowed values for algorithm_signer to ssh plugin API introduced in #10299