### PR TITLE
Add mount tuning health checks

### DIFF
--- a/command/healthcheck/pki_allow_if_modified_since.go
+++ b/command/healthcheck/pki_allow_if_modified_since.go
@@ -1,0 +1,103 @@
+package healthcheck
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+)
+
+type AllowIfModifiedSince struct {
+	Enabled            bool
+	UnsupportedVersion bool
+
+	TuneData map[string]interface{}
+}
+
+func NewAllowIfModifiedSinceCheck() Check {
+	return &AllowIfModifiedSince{}
+}
+
+func (h *AllowIfModifiedSince) Name() string {
+	return "allow_if_modified_since"
+}
+
+func (h *AllowIfModifiedSince) IsEnabled() bool {
+	return h.Enabled
+}
+
+func (h *AllowIfModifiedSince) DefaultConfig() map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func (h *AllowIfModifiedSince) LoadConfig(config map[string]interface{}) error {
+	var err error
+
+	h.Enabled, err = parseutil.ParseBool(config["enabled"])
+	if err != nil {
+		return fmt.Errorf("error parsing %v.enabled: %w", h.Name(), err)
+	}
+
+	return nil
+}
+
+func (h *AllowIfModifiedSince) FetchResources(e *Executor) error {
+	exit, _, data, err := fetchMountTune(e, func() {
+		h.UnsupportedVersion = true
+	})
+	if exit {
+		return err
+	}
+
+	h.TuneData = data
+
+	return nil
+}
+
+func (h *AllowIfModifiedSince) Evaluate(e *Executor) (results []*Result, err error) {
+	if h.UnsupportedVersion {
+		ret := Result{
+			Status:   ResultInvalidVersion,
+			Endpoint: "/sys/mounts/{{mount}}/tune",
+			Message:  "This health check requires Vault 1.9+ but an earlier version of Vault Server was contacted, preventing this health check from running.",
+		}
+		return []*Result{&ret}, nil
+	}
+
+	req, err := stringList(h.TuneData["passthrough_request_headers"])
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse value from server for passthrough_request_headers: %w", err)
+	}
+
+	resp, err := stringList(h.TuneData["allowed_response_headers"])
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse value from server for allowed_response_headers: %w", err)
+	}
+
+	var foundIMS bool = false
+	for _, param := range req {
+		if strings.EqualFold(param, "If-Modified-Since") {
+			foundIMS = true
+			break
+		}
+	}
+
+	var foundLM bool = false
+	for _, param := range resp {
+		if strings.EqualFold(param, "Last-Modified") {
+			foundLM = true
+			break
+		}
+	}
+
+	if !foundIMS || !foundLM {
+		ret := Result{
+			Status:   ResultInformational,
+			Endpoint: "/sys/mounts/{{mount}}/tune",
+			Message:  "Mount hasn't enabled If-Modified-Since Request or Last-Modified Response headers; consider enabling these headers to allow clients to fetch CAs and CRLs only when they've changed, reducing total bandwidth.",
+		}
+		results = append(results, &ret)
+	}
+
+	return
+}

--- a/command/healthcheck/pki_audit_visibility.go
+++ b/command/healthcheck/pki_audit_visibility.go
@@ -1,0 +1,186 @@
+package healthcheck
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+)
+
+var VisibleReqParams = []string{
+	"csr",
+	"certificate",
+	"issuer_ref",
+	"common_name",
+	"alt_names",
+	"other_sans",
+	"ip_sans",
+	"uri_sans",
+	"ttl",
+	"not_after",
+	"serial_number",
+	"key_type",
+	"private_key_format",
+	"managed_key_name",
+	"managed_key_id",
+	"ou",
+	"organization",
+	"country",
+	"locality",
+	"province",
+	"street_address",
+	"postal_code",
+	"permitted_dns_domains",
+	"policy_identifiers",
+	"ext_key_usage_oids",
+}
+
+var VisibleRespParams = []string{
+	"certificate",
+	"issuing_ca",
+	"serial_number",
+	"error",
+	"ca_chain",
+}
+
+var HiddenReqParams = []string{
+	"private_key",
+	"pem_bundle",
+}
+
+var HiddenRespParams = []string{
+	"private_key",
+	"pem_bundle",
+}
+
+type AuditVisibility struct {
+	Enabled            bool
+	UnsupportedVersion bool
+
+	IgnoredParameters map[string]bool
+	TuneData          map[string]interface{}
+}
+
+func NewAuditVisibilityCheck() Check {
+	return &AuditVisibility{
+		IgnoredParameters: make(map[string]bool),
+	}
+}
+
+func (h *AuditVisibility) Name() string {
+	return "audit_visibility"
+}
+
+func (h *AuditVisibility) IsEnabled() bool {
+	return h.Enabled
+}
+
+func (h *AuditVisibility) DefaultConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"ignored_parameters": []string{},
+	}
+}
+
+func (h *AuditVisibility) LoadConfig(config map[string]interface{}) error {
+	var err error
+
+	coerced, err := stringList(config["ignored_parameters"])
+	if err != nil {
+		return fmt.Errorf("error parsing %v.ignored_parameters: %v", h.Name(), err)
+	}
+	for _, ignored := range coerced {
+		h.IgnoredParameters[ignored] = true
+	}
+
+	h.Enabled, err = parseutil.ParseBool(config["enabled"])
+	if err != nil {
+		return fmt.Errorf("error parsing %v.enabled: %w", h.Name(), err)
+	}
+
+	return nil
+}
+
+func (h *AuditVisibility) FetchResources(e *Executor) error {
+	exit, _, data, err := fetchMountTune(e, func() {
+		h.UnsupportedVersion = true
+	})
+	if exit {
+		return err
+	}
+
+	h.TuneData = data
+
+	return nil
+}
+
+func (h *AuditVisibility) Evaluate(e *Executor) (results []*Result, err error) {
+	if h.UnsupportedVersion {
+		// Shouldn't happen; /certs has been around forever.
+		ret := Result{
+			Status:   ResultInvalidVersion,
+			Endpoint: "/{{mount}}/certs",
+			Message:  "This health check requires Vault 1.11+ but an earlier version of Vault Server was contacted, preventing this health check from running.",
+		}
+		return []*Result{&ret}, nil
+	}
+
+	sourceMap := map[string][]string{
+		"audit_non_hmac_request_keys":  VisibleReqParams,
+		"audit_non_hmac_response_keys": VisibleRespParams,
+	}
+	for source, visibleList := range sourceMap {
+		actual, err := stringList(h.TuneData[source])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing %v from server: %v", source, err)
+		}
+
+		for _, param := range visibleList {
+			found := false
+			for _, tuned := range actual {
+				if param == tuned {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				ret := Result{
+					Status:   ResultInformational,
+					Endpoint: "/sys/mounts/{{mount}}/tune",
+					Message:  fmt.Sprintf("Mount currently HMACs %v because it is not in %v; as this is not a sensitive security parameter, it is encouraged to disable HMACing to allow better auditing of the PKI engine.", param, source),
+				}
+				results = append(results, &ret)
+			}
+		}
+	}
+
+	sourceMap = map[string][]string{
+		"audit_non_hmac_request_keys":  HiddenReqParams,
+		"audit_non_hmac_response_keys": HiddenRespParams,
+	}
+	for source, hiddenList := range sourceMap {
+		actual, err := stringList(h.TuneData[source])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing %v from server: %v", source, err)
+		}
+		for _, param := range hiddenList {
+			found := false
+			for _, tuned := range actual {
+				if param == tuned {
+					found = true
+					break
+				}
+			}
+
+			if found {
+				ret := Result{
+					Status:   ResultWarning,
+					Endpoint: "/sys/mounts/{{mount}}/tune",
+					Message:  fmt.Sprintf("Mount currently doesn't HMAC %v because it is in %v; as this is a sensitive security parameter it is encouraged to HMAC it in the Audit logs.", param, source),
+				}
+				results = append(results, &ret)
+			}
+		}
+	}
+
+	return
+}

--- a/command/healthcheck/shared.go
+++ b/command/healthcheck/shared.go
@@ -1,0 +1,55 @@
+package healthcheck
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func stringList(source interface{}) ([]string, error) {
+	if source == nil {
+		return nil, nil
+	}
+
+	if value, ok := source.([]string); ok {
+		return value, nil
+	}
+
+	if rValues, ok := source.([]interface{}); ok {
+		var result []string
+		for index, rValue := range rValues {
+			value, ok := rValue.(string)
+			if !ok {
+				return nil, fmt.Errorf("unknown source type for []string coercion at index %v: %T", index, rValue)
+			}
+
+			result = append(result, value)
+		}
+
+		return result, nil
+	}
+
+	return nil, fmt.Errorf("unknown source type for []string coercion: %T", source)
+}
+
+func fetchMountTune(e *Executor, versionError func()) (bool, *PathFetch, map[string]interface{}, error) {
+	tuneRet, err := e.FetchIfNotFetched(logical.ReadOperation, "/sys/mounts/{{mount}}/tune")
+	if err != nil {
+		return true, nil, nil, err
+	}
+
+	if !tuneRet.IsSecretOK() {
+		if tuneRet.IsUnsupportedPathError() {
+			versionError()
+		}
+
+		return true, nil, nil, nil
+	}
+
+	var data map[string]interface{} = nil
+	if len(tuneRet.Secret.Data) > 0 {
+		data = tuneRet.Secret.Data
+	}
+
+	return false, tuneRet, data, nil
+}

--- a/command/pki_health_check.go
+++ b/command/pki_health_check.go
@@ -202,6 +202,8 @@ func (c *PKIHealthCheckCommand) Run(args []string) int {
 	executor.AddCheck(healthcheck.NewRoleAllowsLocalhostCheck())
 	executor.AddCheck(healthcheck.NewRoleAllowsGlobWildcardsCheck())
 	executor.AddCheck(healthcheck.NewRoleNoStoreFalseCheck())
+	executor.AddCheck(healthcheck.NewAuditVisibilityCheck())
+	executor.AddCheck(healthcheck.NewAllowIfModifiedSinceCheck())
 	executor.AddCheck(healthcheck.NewEnableAutoTidyCheck())
 	executor.AddCheck(healthcheck.NewTidyLastRunCheck())
 	executor.AddCheck(healthcheck.NewTooManyCertsCheck())


### PR DESCRIPTION
Based on top of #17901 -- will be rebased once that one merges.

This adds two new health checks: 

 - `audit_visibility`, which ensures that relevant parameters are either not HMAC'd or are HMAC'd, depending on [sensitivity](https://developer.hashicorp.com/vault/docs/secrets/pki/considerations#auditing).
 - `allow_if_modified_since`, which ensures the If-Modified-Since request parameter and Last-Modified response parameters are passed-through to/from the plugin.

