### PR TITLE
Update Azure 'key_type' description

### DIFF
--- a/website/content/api-docs/system/managed-keys.mdx
+++ b/website/content/api-docs/system/managed-keys.mdx
@@ -214,7 +214,7 @@ $ curl \
 - `key_bits` `(string: <required if allow_generate_key is true>)`: The size in bits for an RSA key.
    This field is required when `key_type` is `RSA`. Supported values are `2048`, `3072`, and `4096`.
 
-- `key_type` `(string: <required>)`: The type of key to use. At this time only supported value is `RSA`.
+- `key_type` `(string: <required>)`: The type of key to use. At this time only supported value is `RSA-HSM`.
 
 #### GCP Cloud KMS Parameters
 - `type` `(string: "gcpckms")` - To select an GCP Cloud KMS backend, the type parameter must be set to `gcpckms`.


### PR DESCRIPTION
Updated the description for the Azure 'key_type' parameter to read 'RSA-HSM' as the only supported value. The existing value in the description reads 'RSA' which returns the following 'Unsupported managed key type' error:

https://github.com/hashicorp/vault-enterprise/blob/5b5f8c0b3d2bc707d9fda9016c8b4c97d558322e/vault/managed_key/azurekeyvault_ent.go#L142