### PR TITLE
Make request objects required

### DIFF
--- a/changelog/17909.txt
+++ b/changelog/17909.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+openapi: Mark request body objects as required 
+```

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -146,7 +146,7 @@ type OASParameter struct {
 
 type OASRequestBody struct {
 	Description string     `json:"description,omitempty"`
-	Required	bool		`json:"required,omitempty"`
+	Required    bool       `json:"required,omitempty"`
 	Content     OASContent `json:"content,omitempty"`
 }
 

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -146,6 +146,7 @@ type OASParameter struct {
 
 type OASRequestBody struct {
 	Description string     `json:"description,omitempty"`
+	Required	bool		`json:"required,omitempty"`
 	Content     OASContent `json:"content,omitempty"`
 }
 
@@ -391,6 +392,7 @@ func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix st
 					requestName := constructRequestName(requestResponsePrefix, path)
 					doc.Components.Schemas[requestName] = s
 					op.RequestBody = &OASRequestBody{
+						Required: true,
 						Content: OASContent{
 							"application/json": &OASMediaTypeObject{
 								Schema: &OASSchema{Ref: fmt.Sprintf("#/components/schemas/%s", requestName)},

--- a/sdk/framework/testdata/legacy.json
+++ b/sdk/framework/testdata/legacy.json
@@ -38,6 +38,7 @@
         "summary": "Synopsis",
         "tags": ["secrets"],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {

--- a/sdk/framework/testdata/operations.json
+++ b/sdk/framework/testdata/operations.json
@@ -63,6 +63,7 @@
         "summary": "Update Summary",
         "description": "Update Description",
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {


### PR DESCRIPTION
Making request objects required. This cleans up the C# generated code by not allowing defaults