### PR TITLE
Vault 9800 Fix vault read handling for endpoints with no top-level data object 

### DIFF
--- a/api/logical.go
+++ b/api/logical.go
@@ -87,7 +87,30 @@ func (c *Logical) ReadWithDataWithContext(ctx context.Context, path string, data
 		return nil, err
 	}
 
-	return ParseSecret(resp.Body)
+	// vault-9800
+	secret, err := ParseSecret(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if secret.Data == nil {
+		// set param as raw and get output
+		data := make(map[string][]string)
+		dataArray := []string{"raw"}
+		data["-format"] = dataArray
+		resp, err := c.readRawWithDataWithContext(ctx, path, data)
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+		if resp == nil || resp.Body == nil {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		return ParseSecretFromNoData(resp.Body)
+	}
+
+	return secret, err
 }
 
 func (c *Logical) ReadRaw(path string) (*Response, error) {

--- a/api/logical.go
+++ b/api/logical.go
@@ -73,8 +73,7 @@ func (c *Logical) ReadWithDataWithContext(ctx context.Context, path string, data
 	// This would return responses for vault read with or without
 	// -format=raw
 	data = make(map[string][]string)
-	dataArray := []string{"raw"}
-	data["-format"] = dataArray
+	data["-format"] = []string{"raw"}
 
 	resp, err := c.readRawWithDataWithContext(ctx, path, data)
 	if resp != nil {

--- a/api/logical.go
+++ b/api/logical.go
@@ -70,7 +70,8 @@ func (c *Logical) ReadWithDataWithContext(ctx context.Context, path string, data
 	// If no top-level data object from api response, we add
 	// any existing raw data from api response in data part of
 	// the secret to be returned
-	// This would return responses for vault read without -format=raw
+	// This would return responses for vault read with or without
+	// -format=raw
 	data = make(map[string][]string)
 	dataArray := []string{"raw"}
 	data["-format"] = dataArray
@@ -93,12 +94,10 @@ func (c *Logical) ReadWithDataWithContext(ctx context.Context, path string, data
 		}
 		return nil, nil
 	}
-	if resp == nil || resp.Body == nil {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, err
 	}
+
 	return ParseSecret(resp.Body)
 }
 

--- a/api/logical.go
+++ b/api/logical.go
@@ -65,16 +65,6 @@ func (c *Logical) ReadWithDataWithContext(ctx context.Context, path string, data
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	// In order to support responses with both top-level data
-	// and no top-level data objects, get the raw response
-	// If no top-level data object from api response, we add
-	// any existing raw data from api response in data part of
-	// the secret to be returned
-	// This would return responses for vault read with or without
-	// -format=raw
-	data = make(map[string][]string)
-	data["-format"] = []string{"raw"}
-
 	resp, err := c.readRawWithDataWithContext(ctx, path, data)
 	if resp != nil {
 		defer resp.Body.Close()

--- a/api/secret.go
+++ b/api/secret.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/errwrap"
@@ -330,6 +331,14 @@ func ParseSecret(r io.Reader) (*Secret, error) {
 		if err := jsonutil.DecodeJSONFromReader(&teebuf, &data); err != nil {
 			return nil, err
 		}
+		if val, ok := data["errors"]; ok {
+			errString := fmt.Sprintf("%v", val)
+			if strings.Contains(errString, "route entry not found") {
+				return nil, nil
+			}
+			return nil, fmt.Errorf(errString)
+		}
+
 		secret.Data = data
 	}
 

--- a/api/secret.go
+++ b/api/secret.go
@@ -334,9 +334,14 @@ func ParseSecret(r io.Reader) (*Secret, error) {
 			return nil, err
 		}
 		errRaw, errPresent := data["errors"]
+
+		// if only errors are present in the resp.Body return nil
+		// to return value not found as it does not have any raw data
 		if len(data) == 1 && errPresent {
 			return nil, nil
 		}
+
+		// if errors are present along with raw data return the error
 		if errPresent {
 			var errStrArray []string
 			errBytes, err := json.Marshal(errRaw)
@@ -348,6 +353,8 @@ func ParseSecret(r io.Reader) (*Secret, error) {
 			}
 			return nil, fmt.Errorf(strings.Join(errStrArray, " "))
 		}
+
+		// if any raw data is present in resp.Body, add it to secret
 		if len(data) > 0 {
 			secret.Data = data
 		}

--- a/api/secret.go
+++ b/api/secret.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"time"
@@ -315,6 +316,24 @@ func ParseSecret(r io.Reader) (*Secret, error) {
 	if err := jsonutil.DecodeJSONFromReader(&buf, &secret); err != nil {
 		return nil, err
 	}
+
+	return &secret, nil
+}
+
+func ParseSecretFromNoData(r io.Reader) (*Secret, error) {
+	contents, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var secret Secret
+	data := make(map[string]interface{})
+	err = json.Unmarshal(contents, &data)
+	if err != nil {
+		return nil, err
+	}
+
+	secret.Data = data
 
 	return &secret, nil
 }

--- a/changelog/17913.txt
+++ b/changelog/17913.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix vault read handling to return raw data as secret.Data when there is no top-level data object from api response.
+```

--- a/command/read_test.go
+++ b/command/read_test.go
@@ -128,6 +128,33 @@ func TestReadCommand_Run(t *testing.T) {
 		}
 	})
 
+	t.Run("no_data_object_from_api_response", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServer(t)
+		defer closer()
+
+		ui, cmd := testReadCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"sys/health",
+		})
+		if exp := 0; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		expected := []string{
+			"cluster_id", "cluster_name", "initialized", "performance_standby", "replication_dr_mode", "replication_performance_mode", "sealed",
+			"server_time_utc", "standby", "version",
+		}
+		for _, expectedField := range expected {
+			if !strings.Contains(combined, expectedField) {
+				t.Errorf("expected %q to contain %q", combined, expected)
+			}
+		}
+	})
+
 	t.Run("no_tabs", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
https://hashicorp.atlassian.net/browse/VAULT-9800
The response bodies for the sys/health and sys/leader endpoints do not include a top-level data object. The vault read command expects this top-level field unless -format=raw (a recent addition) is used. It is entirely possible that issue exists for other endpoints and solving for these two likely solves for all.

**Issue:** 
vault read sys/health -format=json
{
  "request_id": "",
  "lease_id": "",
  "lease_duration": 0,
  "renewable": false,
  "data": null,
  "warnings": null
}
vault read sys/health
(No response)

**Sample response:**
vault read sys/health
Key                             Value
---                             -----
cluster_id                      9501c424-662b-01ef-c5f0-0f7a2e48575d
cluster_name                    vault-cluster-3d7e0d93
initialized                     true
performance_standby             false
replication_dr_mode             disabled
replication_performance_mode    disabled
sealed                          false
server_time_utc                 1668198854
standby                         false
version                         1.13.0-dev1

 vault read sys/health -format=json
{
  "request_id": "",
  "lease_id": "",
  "lease_duration": 0,
  "renewable": false,
  "data": {
    "cluster_id": "9501c424-662b-01ef-c5f0-0f7a2e48575d",
    "cluster_name": "vault-cluster-3d7e0d93",
    "initialized": true,
    "performance_standby": false,
    "replication_dr_mode": "disabled",
    "replication_performance_mode": "disabled",
    "sealed": false,
    "server_time_utc": 1668198684,
    "standby": false,
    "version": "1.13.0-dev1"
  },
  "warnings": null
}