### PR TITLE
Deduplicate policies prior to generating ACL on request

### DIFF
--- a/changelog/17914.txt
+++ b/changelog/17914.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+policy: Deduplicate policies prior to ACL generation
+```

--- a/changelog/17914.txt
+++ b/changelog/17914.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-policy: Deduplicate policies prior to ACL generation
+auth: Deduplicate policies prior to ACL generation
 ```

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -204,7 +204,7 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 		return nil, nil, nil, nil, ErrInternalError
 	}
 	for nsID, nsPolicies := range identityPolicies {
-		policyNames[nsID] = append(policyNames[nsID], nsPolicies...)
+		policyNames[nsID] = policyutil.SanitizePolicies(append(policyNames[nsID], nsPolicies...), false)
 	}
 
 	// Attach token's namespace information to the context. Wrapping tokens by
@@ -361,7 +361,7 @@ func (c *Core) checkToken(ctx context.Context, req *logical.Request, unauth bool
 	if te != nil {
 		auth.IdentityPolicies = identityPolicies[te.NamespaceID]
 		auth.TokenPolicies = te.Policies
-		auth.Policies = append(te.Policies, identityPolicies[te.NamespaceID]...)
+		auth.Policies = policyutil.SanitizePolicies(append(te.Policies, identityPolicies[te.NamespaceID]...), false)
 		auth.Metadata = te.Meta
 		auth.DisplayName = te.DisplayName
 		auth.EntityID = te.EntityID


### PR DESCRIPTION
This PR solves an issue where a token can have duplicate policies as part of its policy set when using external groups. This scenario is encountered when an external group policy mapping is created in Vault containing duplicate policies to those defined by the authentication method.