### PR TITLE
[QT-309] Ensure environment variables are populated before proceeding

### DIFF
--- a/builtin/credential/okta/backend_test.go
+++ b/builtin/credential/okta/backend_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/helper/testhelpers"
 	logicaltest "github.com/hashicorp/vault/helper/testhelpers/logical"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/helper/policyutil"
@@ -35,6 +36,15 @@ func TestBackend_Config(t *testing.T) {
 	if os.Getenv("VAULT_ACC") == "" {
 		t.SkipNow()
 	}
+
+	// Ensure each cred is populated.
+	credNames := []string{
+		"OKTA_USERNAME",
+		"OKTA_PASSWORD",
+		"OKTA_API_TOKEN",
+	}
+	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
+
 	defaultLeaseTTLVal := time.Hour * 12
 	maxLeaseTTLVal := time.Hour * 24
 	b, err := Factory(context.Background(), &logical.BackendConfig{

--- a/command/agent/alicloud_end_to_end_test.go
+++ b/command/agent/alicloud_end_to_end_test.go
@@ -20,6 +20,7 @@ import (
 	agentalicloud "github.com/hashicorp/vault/command/agent/auth/alicloud"
 	"github.com/hashicorp/vault/command/agent/sink"
 	"github.com/hashicorp/vault/command/agent/sink/file"
+	"github.com/hashicorp/vault/helper/testhelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -36,6 +37,14 @@ func TestAliCloudEndToEnd(t *testing.T) {
 	if !runAcceptanceTests {
 		t.SkipNow()
 	}
+
+	// Ensure each cred is populated.
+	credNames := []string{
+		envVarAlicloudAccessKey,
+		envVarAlicloudSecretKey,
+		envVarAlicloudRoleArn,
+	}
+	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
 	logger := logging.NewVaultLogger(hclog.Trace)
 	coreConfig := &vault.CoreConfig{

--- a/command/agent/aws_end_to_end_test.go
+++ b/command/agent/aws_end_to_end_test.go
@@ -19,6 +19,7 @@ import (
 	agentaws "github.com/hashicorp/vault/command/agent/auth/aws"
 	"github.com/hashicorp/vault/command/agent/sink"
 	"github.com/hashicorp/vault/command/agent/sink/file"
+	"github.com/hashicorp/vault/helper/testhelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -46,6 +47,14 @@ func TestAWSEndToEnd(t *testing.T) {
 	if !runAcceptanceTests {
 		t.SkipNow()
 	}
+
+	// Ensure each cred is populated.
+	credNames := []string{
+		envVarAwsTestAccessKey,
+		envVarAwsTestSecretKey,
+		envVarAwsTestRoleArn,
+	}
+	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
 	logger := logging.NewVaultLogger(hclog.Trace)
 	coreConfig := &vault.CoreConfig{

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -9,6 +9,8 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/url"
+	"os"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -973,4 +975,14 @@ func SetupLoginMFATOTP(t testing.T, client *api.Client) (*api.Client, string, st
 
 	SetupMFALoginEnforcement(t, client, enforcementConfig)
 	return entityClient, entityID, methodID
+}
+
+func SkipUnlessEnvVarsSet(t testing.T, envVars []string) {
+	t.Helper()
+
+	for _, i := range envVars {
+		if os.Getenv(i) == "" {
+			t.Skipf("%s must be set for this test to run", strings.Join(envVars, " "))
+		}
+	}
 }

--- a/plugins/database/redshift/redshift_test.go
+++ b/plugins/database/redshift/redshift_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/helper/testhelpers"
 	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	dbtesting "github.com/hashicorp/vault/sdk/database/dbplugin/v5/testing"
 	"github.com/hashicorp/vault/sdk/helper/dbtxn"
@@ -70,6 +71,14 @@ func TestRedshift_Initialize(t *testing.T) {
 		t.SkipNow()
 	}
 
+	// Ensure each cred is populated.
+	credNames := []string{
+		keyRedshiftURL,
+		keyRedshiftUser,
+		keyRedshiftPassword,
+	}
+	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
+
 	connURL, _, _, _, err := redshiftEnv()
 	if err != nil {
 		t.Fatal(err)
@@ -107,6 +116,14 @@ func TestRedshift_NewUser(t *testing.T) {
 	if os.Getenv(vaultACC) != "1" {
 		t.SkipNow()
 	}
+
+	// Ensure each cred is populated.
+	credNames := []string{
+		keyRedshiftURL,
+		keyRedshiftUser,
+		keyRedshiftPassword,
+	}
+	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
 	connURL, url, _, _, err := redshiftEnv()
 	if err != nil {
@@ -158,6 +175,14 @@ func TestRedshift_NewUser_NoCreationStatement_ShouldError(t *testing.T) {
 		t.SkipNow()
 	}
 
+	// Ensure each cred is populated.
+	credNames := []string{
+		keyRedshiftURL,
+		keyRedshiftUser,
+		keyRedshiftPassword,
+	}
+	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
+
 	connURL, _, _, _, err := redshiftEnv()
 	if err != nil {
 		t.Fatal(err)
@@ -200,6 +225,14 @@ func TestRedshift_UpdateUser_Expiration(t *testing.T) {
 	if os.Getenv(vaultACC) != "1" {
 		t.SkipNow()
 	}
+
+	// Ensure each cred is populated.
+	credNames := []string{
+		keyRedshiftURL,
+		keyRedshiftUser,
+		keyRedshiftPassword,
+	}
+	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
 	connURL, url, _, _, err := redshiftEnv()
 	if err != nil {
@@ -261,6 +294,14 @@ func TestRedshift_UpdateUser_Password(t *testing.T) {
 		t.SkipNow()
 	}
 
+	// Ensure each cred is populated.
+	credNames := []string{
+		keyRedshiftURL,
+		keyRedshiftUser,
+		keyRedshiftPassword,
+	}
+	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
+
 	connURL, url, _, _, err := redshiftEnv()
 	if err != nil {
 		t.Fatal(err)
@@ -314,6 +355,14 @@ func TestRedshift_DeleteUser(t *testing.T) {
 	if os.Getenv(vaultACC) != "1" {
 		t.SkipNow()
 	}
+
+	// Ensure each cred is populated.
+	credNames := []string{
+		keyRedshiftURL,
+		keyRedshiftUser,
+		keyRedshiftPassword,
+	}
+	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
 	connURL, url, _, _, err := redshiftEnv()
 	if err != nil {
@@ -380,6 +429,14 @@ func TestRedshift_DefaultUsernameTemplate(t *testing.T) {
 		t.SkipNow()
 	}
 
+	// Ensure each cred is populated.
+	credNames := []string{
+		keyRedshiftURL,
+		keyRedshiftUser,
+		keyRedshiftPassword,
+	}
+	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
+
 	connURL, url, _, _, err := redshiftEnv()
 	if err != nil {
 		t.Fatal(err)
@@ -427,6 +484,14 @@ func TestRedshift_CustomUsernameTemplate(t *testing.T) {
 	if os.Getenv(vaultACC) != "1" {
 		t.SkipNow()
 	}
+
+	// Ensure each cred is populated.
+	credNames := []string{
+		keyRedshiftURL,
+		keyRedshiftUser,
+		keyRedshiftPassword,
+	}
+	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
 	connURL, url, _, _, err := redshiftEnv()
 	if err != nil {

--- a/plugins/database/redshift/redshift_test.go
+++ b/plugins/database/redshift/redshift_test.go
@@ -42,6 +42,12 @@ var (
 	keyRedshiftUser     = "REDSHIFT_USER"
 	keyRedshiftPassword = "REDSHIFT_PASSWORD"
 
+	credNames = []string{
+		keyRedshiftURL,
+		keyRedshiftUser,
+		keyRedshiftPassword,
+	}
+
 	vaultACC = "VAULT_ACC"
 )
 
@@ -72,11 +78,6 @@ func TestRedshift_Initialize(t *testing.T) {
 	}
 
 	// Ensure each cred is populated.
-	credNames := []string{
-		keyRedshiftURL,
-		keyRedshiftUser,
-		keyRedshiftPassword,
-	}
 	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
 	connURL, _, _, _, err := redshiftEnv()
@@ -118,11 +119,6 @@ func TestRedshift_NewUser(t *testing.T) {
 	}
 
 	// Ensure each cred is populated.
-	credNames := []string{
-		keyRedshiftURL,
-		keyRedshiftUser,
-		keyRedshiftPassword,
-	}
 	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
 	connURL, url, _, _, err := redshiftEnv()
@@ -176,11 +172,6 @@ func TestRedshift_NewUser_NoCreationStatement_ShouldError(t *testing.T) {
 	}
 
 	// Ensure each cred is populated.
-	credNames := []string{
-		keyRedshiftURL,
-		keyRedshiftUser,
-		keyRedshiftPassword,
-	}
 	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
 	connURL, _, _, _, err := redshiftEnv()
@@ -227,11 +218,6 @@ func TestRedshift_UpdateUser_Expiration(t *testing.T) {
 	}
 
 	// Ensure each cred is populated.
-	credNames := []string{
-		keyRedshiftURL,
-		keyRedshiftUser,
-		keyRedshiftPassword,
-	}
 	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
 	connURL, url, _, _, err := redshiftEnv()
@@ -295,11 +281,6 @@ func TestRedshift_UpdateUser_Password(t *testing.T) {
 	}
 
 	// Ensure each cred is populated.
-	credNames := []string{
-		keyRedshiftURL,
-		keyRedshiftUser,
-		keyRedshiftPassword,
-	}
 	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
 	connURL, url, _, _, err := redshiftEnv()
@@ -357,11 +338,6 @@ func TestRedshift_DeleteUser(t *testing.T) {
 	}
 
 	// Ensure each cred is populated.
-	credNames := []string{
-		keyRedshiftURL,
-		keyRedshiftUser,
-		keyRedshiftPassword,
-	}
 	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
 	connURL, url, _, _, err := redshiftEnv()
@@ -430,11 +406,6 @@ func TestRedshift_DefaultUsernameTemplate(t *testing.T) {
 	}
 
 	// Ensure each cred is populated.
-	credNames := []string{
-		keyRedshiftURL,
-		keyRedshiftUser,
-		keyRedshiftPassword,
-	}
 	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
 	connURL, url, _, _, err := redshiftEnv()
@@ -486,11 +457,6 @@ func TestRedshift_CustomUsernameTemplate(t *testing.T) {
 	}
 
 	// Ensure each cred is populated.
-	credNames := []string{
-		keyRedshiftURL,
-		keyRedshiftUser,
-		keyRedshiftPassword,
-	}
 	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
 	connURL, url, _, _, err := redshiftEnv()


### PR DESCRIPTION
This PR represents the first body of work in the process of ensuring that credentials are set in order for certain acceptance tests to be run. There are some subtle distinctions between environment variables being set and the credentials being valid. This work only adds the former.

You will find a test helper that has been added in order to DRY up this process. The test helper is then used in acceptance tests that need cloud credentials set in their environment.

Some tests that need credentials are either not available in the Vault OSS repository or require extended logic to fully check that their credentials are not available. Those are not included in this PR though they are a part of the larger QT-309 task. I have provided a simple table that indicates what should be in this PR and what shouldn't.

<img width="375" alt="image" src="https://user-images.githubusercontent.com/5498095/201429996-65763a1e-e064-4d64-baf6-26beb33a3601.png">

"No failures" indicates that the only requirement for the test to not fail is that Docker must be locally available. We have decided that this is an implicit requirement.