### PR TITLE
enos: use amd64 for consul backend

### DIFF
--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -81,7 +81,7 @@ scenario "agent" {
     module = module.create_vpc
 
     variables {
-      ami_architectures  = [matrix.arch]
+      ami_architectures  = distinct([matrix.arch, "amd64"])
       availability_zones = step.find_azs.availability_zones
       common_tags        = local.tags
     }
@@ -105,7 +105,7 @@ scenario "agent" {
     }
 
     variables {
-      ami_id        = step.create_vpc.ami_ids["ubuntu"][matrix.arch]
+      ami_id        = step.create_vpc.ami_ids["ubuntu"]["amd64"]
       common_tags   = local.tags
       instance_type = var.backend_instance_type
       kms_key_arn   = step.create_vpc.kms_key_arn

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -84,7 +84,7 @@ scenario "smoke" {
     module = module.create_vpc
 
     variables {
-      ami_architectures  = [matrix.arch]
+      ami_architectures  = distinct([matrix.arch, "amd64"])
       availability_zones = step.find_azs.availability_zones
       common_tags        = local.tags
     }
@@ -108,7 +108,7 @@ scenario "smoke" {
     }
 
     variables {
-      ami_id      = step.create_vpc.ami_ids["ubuntu"][matrix.arch]
+      ami_id      = step.create_vpc.ami_ids["ubuntu"]["amd64"]
       common_tags = local.tags
       consul_release = {
         edition = var.backend_edition

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -79,7 +79,7 @@ scenario "upgrade" {
     module = module.create_vpc
 
     variables {
-      ami_architectures  = [matrix.arch]
+      ami_architectures  = distinct([matrix.arch, "amd64"])
       availability_zones = step.find_azs.availability_zones
       common_tags        = local.tags
     }
@@ -108,7 +108,7 @@ scenario "upgrade" {
     }
 
     variables {
-      ami_id      = step.create_vpc.ami_ids["ubuntu"][matrix.arch]
+      ami_id      = step.create_vpc.ami_ids["ubuntu"]["amd64"]
       common_tags = local.tags
       consul_release = {
         edition = var.backend_edition


### PR DESCRIPTION
Previously we'd pass the matrix variant to the backend cluster module which is currently unsupported by the consul module. Instead we'll always pass the ubuntu/amd64 AMI ID to the consul backend module.

This should resolve the enos-verify-stable matrix failures here https://github.com/hashicorp/vault/actions/runs/3448137968/jobs/5754873688#step:11:191

Signed-off-by: Ryan Cragun <me@ryan.ec>