### PR TITLE
Response.ToSecret() + Secret.Age

### DIFF
--- a/api/secret.go
+++ b/api/secret.go
@@ -38,6 +38,10 @@ type Secret struct {
 	// cubbyhole of the given token (which has a TTL of the given number of
 	// seconds)
 	WrapInfo *SecretWrapInfo `json:"wrap_info,omitempty"`
+
+	// Age, means that a secret was retrieved from a remote cache and that the
+	// secret is "Age" seconds old. Age is retrieved from the HTTP "Age" header.
+	Age time.Duration
 }
 
 // TokenID returns the standardized token ID (token) for the given secret.

--- a/api/sys_leases.go
+++ b/api/sys_leases.go
@@ -30,7 +30,7 @@ func (c *Sys) RenewWithContext(ctx context.Context, id string, increment int) (*
 	}
 	defer resp.Body.Close()
 
-	return ParseSecret(resp.Body)
+	return resp.ToSecret()
 }
 
 func (c *Sys) Lookup(id string) (*Secret, error) {


### PR DESCRIPTION
This is more of a "design" idea PR, I'm not a contributor, but I see this as an important fix to enable the Vault Cache. Really looking for input from a maintainer.

Instead of using "ParseSecret" everywhere the type a secret is being parsed from can implement a ToSecret function that can leverage the ParseSecret function, but also extend it.

This is one of _many_ ideas I have had for propagating the Age header into the LifeTimeWatch to correct cached lease expirations.

https://github.com/hashicorp/vault/issues/16439

Perhaps a `"Secretable"` interface is in the future?

Another approach I investigated was adding a `ParseSecretWithHeaders`, but you would have to replace that everywhere and input the new parameters which seemed tedious. `ParseSecretWithHeaders` could potentially also take more data from the response in the future (no idea what) so isn't very future proof.

With `ToSecret()` you just wipe out the `ParseSecret` and no matter what changes need to be made to the Response or how headers are interpreted every call `ToSecret` can adapt to those changes without changing code.


The `Age` field should also never be deserialized/serialized into JSON and therefore there are no `json` tags (unless you want that 😄) . Being a `time.Duration` which is also an `int64` `Age` will default to the default `int64` value of 0.