### PR TITLE
Move pki docker tests to pkiext

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -104,7 +104,7 @@ OzQeADTSCn5VidOfjDkIst9UXjMlrFfV9/oJEw5Eiqa6lkNPCGDhfA8=
 
 func TestPKI_RequireCN(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"common_name": "myvault.com",
@@ -180,7 +180,7 @@ func TestPKI_RequireCN(t *testing.T) {
 
 func TestPKI_DeviceCert(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"common_name":         "myvault.com",
@@ -249,7 +249,7 @@ func TestPKI_DeviceCert(t *testing.T) {
 
 func TestBackend_InvalidParameter(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	_, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"common_name": "myvault.com",
@@ -272,7 +272,7 @@ func TestBackend_InvalidParameter(t *testing.T) {
 func TestBackend_CSRValues(t *testing.T) {
 	t.Parallel()
 	initTest.Do(setCerts)
-	b, _ := createBackendWithStorage(t)
+	b, _ := CreateBackendWithStorage(t)
 
 	testCase := logicaltest.TestCase{
 		LogicalBackend: b,
@@ -289,7 +289,7 @@ func TestBackend_CSRValues(t *testing.T) {
 func TestBackend_URLsCRUD(t *testing.T) {
 	t.Parallel()
 	initTest.Do(setCerts)
-	b, _ := createBackendWithStorage(t)
+	b, _ := CreateBackendWithStorage(t)
 
 	testCase := logicaltest.TestCase{
 		LogicalBackend: b,
@@ -325,7 +325,7 @@ func TestBackend_Roles(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			initTest.Do(setCerts)
-			b, _ := createBackendWithStorage(t)
+			b, _ := CreateBackendWithStorage(t)
 
 			testCase := logicaltest.TestCase{
 				LogicalBackend: b,
@@ -1735,7 +1735,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 
 func TestRolesAltIssuer(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// Create two issuers.
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
@@ -1833,7 +1833,7 @@ func TestRolesAltIssuer(t *testing.T) {
 
 func TestBackend_PathFetchValidRaw(t *testing.T) {
 	t.Parallel()
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -1965,7 +1965,7 @@ func TestBackend_PathFetchValidRaw(t *testing.T) {
 func TestBackend_PathFetchCertList(t *testing.T) {
 	t.Parallel()
 	// create the backend
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	// generate root
 	rootData := map[string]interface{}{
@@ -2109,7 +2109,7 @@ func TestBackend_SignVerbatim(t *testing.T) {
 
 func runTestSignVerbatim(t *testing.T, keyType string) {
 	// create the backend
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	// generate root
 	rootData := map[string]interface{}{
@@ -2365,7 +2365,7 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 
 func TestBackend_Root_Idempotency(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// This is a change within 1.11, we are no longer idempotent across generate/internal calls.
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
@@ -2470,8 +2470,8 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 
 func TestBackend_SignIntermediate_AllowedPastCA(t *testing.T) {
 	t.Parallel()
-	b_root, s_root := createBackendWithStorage(t)
-	b_int, s_int := createBackendWithStorage(t)
+	b_root, s_root := CreateBackendWithStorage(t)
+	b_int, s_int := CreateBackendWithStorage(t)
 	var err error
 
 	// Direct issuing from root
@@ -2539,7 +2539,7 @@ func TestBackend_SignIntermediate_AllowedPastCA(t *testing.T) {
 func TestBackend_ConsulSignLeafWithLegacyRole(t *testing.T) {
 	t.Parallel()
 	// create the backend
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// generate root
 	data, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
@@ -2574,7 +2574,7 @@ func TestBackend_ConsulSignLeafWithLegacyRole(t *testing.T) {
 func TestBackend_SignSelfIssued(t *testing.T) {
 	t.Parallel()
 	// create the backend
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	// generate root
 	rootData := map[string]interface{}{
@@ -2715,7 +2715,7 @@ func TestBackend_SignSelfIssued(t *testing.T) {
 func TestBackend_SignSelfIssued_DifferentTypes(t *testing.T) {
 	t.Parallel()
 	// create the backend
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	// generate root
 	rootData := map[string]interface{}{
@@ -2840,7 +2840,7 @@ func TestBackend_SignSelfIssued_DifferentTypes(t *testing.T) {
 // easy to validate.
 func TestBackend_OID_SANs(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	var err error
 	var resp *logical.Response
@@ -3063,7 +3063,7 @@ func TestBackend_OID_SANs(t *testing.T) {
 
 func TestBackend_AllowedSerialNumbers(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	var err error
 	var resp *logical.Response
@@ -3170,7 +3170,7 @@ func TestBackend_AllowedSerialNumbers(t *testing.T) {
 
 func TestBackend_URI_SANs(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	var err error
 
@@ -4052,7 +4052,7 @@ func TestBackend_Root_FullCAChain(t *testing.T) {
 
 func runFullCAChainTest(t *testing.T, keyType string) {
 	// Generate a root CA at /pki-root
-	b_root, s_root := createBackendWithStorage(t)
+	b_root, s_root := CreateBackendWithStorage(t)
 
 	var err error
 
@@ -4098,7 +4098,7 @@ func runFullCAChainTest(t *testing.T, keyType string) {
 	requireCertInCaChainArray(t, fullChainArray, rootCert, "expected root cert within root issuance pki-root/issue/example")
 
 	// Now generate an intermediate at /pki-intermediate, signed by the root.
-	b_int, s_int := createBackendWithStorage(t)
+	b_int, s_int := CreateBackendWithStorage(t)
 
 	resp, err = CBWrite(b_int, s_int, "intermediate/generate/exported", map[string]interface{}{
 		"common_name": "intermediate myvault.com",
@@ -4178,7 +4178,7 @@ func runFullCAChainTest(t *testing.T, keyType string) {
 
 	// Finally, import this signing cert chain into a new mount to ensure
 	// "external" CAs behave as expected.
-	b_ext, s_ext := createBackendWithStorage(t)
+	b_ext, s_ext := CreateBackendWithStorage(t)
 
 	_, err = CBWrite(b_ext, s_ext, "config/ca", map[string]interface{}{
 		"pem_bundle": intermediateKey + "\n" + intermediateCert + "\n" + rootCert + "\n",
@@ -4517,7 +4517,7 @@ func TestBackend_Roles_IssuanceRegression(t *testing.T) {
 		t.Fatalf("misnumbered test case entries will make it hard to find bugs: %v", len(testCases))
 	}
 
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// We need a RSA key so all signature sizes are valid with it.
 	resp, err := CBWrite(b, s, "root/generate/exported", map[string]interface{}{
@@ -4686,7 +4686,7 @@ func TestBackend_Roles_KeySizeRegression(t *testing.T) {
 		t.Fatalf("misnumbered test case entries will make it hard to find bugs: %v", len(testCases))
 	}
 
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	tested := 0
 	for index, test := range testCases {
@@ -4698,7 +4698,7 @@ func TestBackend_Roles_KeySizeRegression(t *testing.T) {
 
 func TestRootWithExistingKey(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	var err error
 
 	// Fail requests if type is existing, and we specify the key_type param
@@ -4831,7 +4831,7 @@ func TestRootWithExistingKey(t *testing.T) {
 
 func TestIntermediateWithExistingKey(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	var err error
 
@@ -4896,7 +4896,7 @@ func TestIntermediateWithExistingKey(t *testing.T) {
 
 func TestIssuanceTTLs(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"common_name": "root example.com",
@@ -4971,7 +4971,7 @@ func TestIssuanceTTLs(t *testing.T) {
 
 func TestSealWrappedStorageConfigured(t *testing.T) {
 	t.Parallel()
-	b, _ := createBackendWithStorage(t)
+	b, _ := CreateBackendWithStorage(t)
 	wrappedEntries := b.Backend.PathsSpecial.SealWrapStorage
 
 	// Make sure our legacy bundle is within the list
@@ -4983,7 +4983,7 @@ func TestSealWrappedStorageConfigured(t *testing.T) {
 
 func TestBackend_ConfigCA_WithECParams(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// Generated key with OpenSSL:
 	// $ openssl ecparam -out p256.key -name prime256v1 -genkey
@@ -5012,7 +5012,7 @@ AwEHoUQDQgAE57NX8bR/nDoW8yRgLswoXBQcjHrdyfuHS0gPwki6BNnfunUzryVb
 
 func TestPerIssuerAIA(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// Generating a root without anything should not have AIAs.
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
@@ -5087,7 +5087,7 @@ func TestPerIssuerAIA(t *testing.T) {
 
 func TestIssuersWithoutCRLBits(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// Importing a root without CRL signing bits should work fine.
 	customBundleWithoutCRLBits := `
@@ -5532,7 +5532,7 @@ func TestBackend_IfModifiedSinceHeaders(t *testing.T) {
 
 func TestBackend_InitializeCertificateCounts(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	ctx := context.Background()
 
 	// Set up an Issuer and Role
@@ -5638,7 +5638,7 @@ func TestBackend_InitializeCertificateCounts(t *testing.T) {
 // for fields across the two APIs.
 func TestBackend_VerifyIssuerUpdateDefaultsMatchCreation(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"common_name": "myvault.com",
@@ -5667,7 +5667,7 @@ func TestBackend_VerifyIssuerUpdateDefaultsMatchCreation(t *testing.T) {
 
 func TestBackend_VerifyPSSKeysIssuersFailImport(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// PKCS8 parsing fails on this key due to rsaPSS OID
 	rsaOIDKey := `
@@ -5870,7 +5870,7 @@ EBuOIhCv6WiwVyGeTVynuHYkHyw3rIL/zU7N8+zIFV2G2M1UAv5D/eyh/74cr9Of
 
 func TestPKI_EmptyCRLConfigUpgraded(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// Write an empty CRLConfig into storage.
 	crlConfigEntry, err := logical.StorageEntryJSON("config/crl", &crlConfig{})
@@ -5893,7 +5893,7 @@ func TestPKI_EmptyCRLConfigUpgraded(t *testing.T) {
 
 func TestPKI_ListRevokedCerts(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// Test empty cluster
 	resp, err := CBList(b, s, "certs/revoked")

--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestPki_FetchCertBySerial(t *testing.T) {
 	t.Parallel()
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	cases := map[string]struct {
 		Req    *logical.Request

--- a/builtin/logical/pki/chain_test.go
+++ b/builtin/logical/pki/chain_test.go
@@ -1598,7 +1598,7 @@ var chainBuildingTestCases = []CBTestScenario{
 func Test_CAChainBuilding(t *testing.T) {
 	t.Parallel()
 	for testIndex, testCase := range chainBuildingTestCases {
-		b, s := createBackendWithStorage(t)
+		b, s := CreateBackendWithStorage(t)
 
 		knownKeys := make(map[string]string)
 		knownCerts := make(map[string]string)
@@ -1620,7 +1620,7 @@ func BenchmarkChainBuilding(benchies *testing.B) {
 			bench.StopTimer()
 			bench.ResetTimer()
 
-			b, s := createBackendWithStorage(bench)
+			b, s := CreateBackendWithStorage(bench)
 
 			knownKeys := make(map[string]string)
 			knownCerts := make(map[string]string)

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestBackend_CRL_EnableDisableRoot(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"ttl":         "40h",
@@ -35,7 +35,7 @@ func TestBackend_CRL_EnableDisableRoot(t *testing.T) {
 
 func TestBackend_CRLConfigUpdate(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// Write a legacy config to storage.
 	type legacyConfig struct {
@@ -79,7 +79,7 @@ func TestBackend_CRLConfig(t *testing.T) {
 	for _, tc := range tests {
 		name := fmt.Sprintf("%s-%t-%t", tc.expiry, tc.disable, tc.ocspDisable)
 		t.Run(name, func(t *testing.T) {
-			b, s := createBackendWithStorage(t)
+			b, s := CreateBackendWithStorage(t)
 
 			resp, err := CBWrite(b, s, "config/crl", map[string]interface{}{
 				"expiry":                    tc.expiry,
@@ -123,7 +123,7 @@ func TestBackend_CRLConfig(t *testing.T) {
 	for _, tc := range badValueTests {
 		name := fmt.Sprintf("bad-%s-%s-%s", tc.expiry, tc.disable, tc.ocspDisable)
 		t.Run(name, func(t *testing.T) {
-			b, s := createBackendWithStorage(t)
+			b, s := CreateBackendWithStorage(t)
 
 			_, err := CBWrite(b, s, "config/crl", map[string]interface{}{
 				"expiry":                    tc.expiry,
@@ -164,7 +164,7 @@ func TestBackend_CRL_AllKeyTypeSigAlgos(t *testing.T) {
 
 	for index, tc := range testCases {
 		t.Logf("tv %v", index)
-		b, s := createBackendWithStorage(t)
+		b, s := CreateBackendWithStorage(t)
 
 		resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 			"ttl":            "40h",
@@ -207,7 +207,7 @@ func TestBackend_CRL_EnableDisableIntermediateWithoutRoot(t *testing.T) {
 }
 
 func crlEnableDisableIntermediateTestForBackend(t *testing.T, withRoot bool) {
-	b_root, s_root := createBackendWithStorage(t)
+	b_root, s_root := CreateBackendWithStorage(t)
 
 	resp, err := CBWrite(b_root, s_root, "root/generate/internal", map[string]interface{}{
 		"ttl":         "40h",
@@ -218,7 +218,7 @@ func crlEnableDisableIntermediateTestForBackend(t *testing.T, withRoot bool) {
 	}
 	rootSerial := resp.Data["serial_number"].(string)
 
-	b_int, s_int := createBackendWithStorage(t)
+	b_int, s_int := CreateBackendWithStorage(t)
 
 	resp, err = CBWrite(b_int, s_int, "intermediate/generate/internal", map[string]interface{}{
 		"common_name": "intermediate myvault.com",
@@ -371,7 +371,7 @@ func crlEnableDisableTestForBackend(t *testing.T, b *backend, s logical.Storage,
 func TestBackend_Secondary_CRL_Rebuilding(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	sc := b.makeStorageContext(ctx, s)
 
 	// Write out the issuer/key to storage without going through the api call as replication would.
@@ -396,7 +396,7 @@ func TestBackend_Secondary_CRL_Rebuilding(t *testing.T) {
 func TestCrlRebuilder(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	sc := b.makeStorageContext(ctx, s)
 
 	// Write out the issuer/key to storage without going through the api call as replication would.
@@ -443,7 +443,7 @@ func TestCrlRebuilder(t *testing.T) {
 func TestBYOC(t *testing.T) {
 	t.Parallel()
 
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// Create a root CA.
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
@@ -562,7 +562,7 @@ func TestBYOC(t *testing.T) {
 func TestPoP(t *testing.T) {
 	t.Parallel()
 
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// Create a root CA.
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
@@ -722,7 +722,7 @@ func TestPoP(t *testing.T) {
 func TestIssuerRevocation(t *testing.T) {
 	t.Parallel()
 
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// Write a config with auto-rebuilding so that we can verify stuff doesn't
 	// appear on the delta CRL.
@@ -1170,7 +1170,7 @@ func TestAutoRebuild(t *testing.T) {
 func TestTidyIssuerAssociation(t *testing.T) {
 	t.Parallel()
 
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// Create a root CA.
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{

--- a/builtin/logical/pki/integation_test.go
+++ b/builtin/logical/pki/integation_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestIntegration_RotateRootUsesNext(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,
 		Path:      "root/rotate/internal",
@@ -84,7 +84,7 @@ func TestIntegration_RotateRootUsesNext(t *testing.T) {
 
 func TestIntegration_ReplaceRootNormal(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// generate roots
 	genTestRootCa(t, b, s)
@@ -122,7 +122,7 @@ func TestIntegration_ReplaceRootNormal(t *testing.T) {
 
 func TestIntegration_ReplaceRootDefaultsToNext(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// generate roots
 	genTestRootCa(t, b, s)
@@ -159,7 +159,7 @@ func TestIntegration_ReplaceRootDefaultsToNext(t *testing.T) {
 
 func TestIntegration_ReplaceRootBadIssuer(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// generate roots
 	genTestRootCa(t, b, s)
@@ -209,8 +209,8 @@ func TestIntegration_ReplaceRootBadIssuer(t *testing.T) {
 
 func TestIntegration_SetSignedWithBackwardsPemBundles(t *testing.T) {
 	t.Parallel()
-	rootBackend, rootStorage := createBackendWithStorage(t)
-	intBackend, intStorage := createBackendWithStorage(t)
+	rootBackend, rootStorage := CreateBackendWithStorage(t)
+	intBackend, intStorage := CreateBackendWithStorage(t)
 
 	// generate root
 	resp, err := rootBackend.HandleRequest(context.Background(), &logical.Request{
@@ -306,7 +306,7 @@ func TestIntegration_SetSignedWithBackwardsPemBundles(t *testing.T) {
 
 func TestIntegration_CSRGeneration(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	testCases := []struct {
 		keyType               string
 		usePss                bool
@@ -359,7 +359,7 @@ func TestIntegration_CSRGeneration(t *testing.T) {
 
 func TestIntegration_AutoIssuer(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// Generate two roots. The first should become default under the existing
 	// behavior; when we update the config and generate a second, it should

--- a/builtin/logical/pki/ocsp_test.go
+++ b/builtin/logical/pki/ocsp_test.go
@@ -61,7 +61,7 @@ func TestOcsp_UnknownIssuerWithNoDefault(t *testing.T) {
 
 	_, _, testEnv := setupOcspEnv(t, "ec")
 	// Create another completely empty mount so the created issuer/certificate above is unknown
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	resp, err := sendOcspRequest(t, b, s, "get", testEnv.leafCertIssuer1, testEnv.issuer1, crypto.SHA1)
 	require.NoError(t, err)
@@ -510,7 +510,7 @@ func setupOcspEnv(t *testing.T, keyType string) (*backend, logical.Storage, *ocs
 }
 
 func setupOcspEnvWithCaKeyConfig(t *testing.T, keyType string, caKeyBits int, caKeySigBits int) (*backend, logical.Storage, *ocspTestEnv) {
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	var issuerCerts []*x509.Certificate
 	var leafCerts []*x509.Certificate
 	var issuerIds []issuerID

--- a/builtin/logical/pki/path_manage_keys_test.go
+++ b/builtin/logical/pki/path_manage_keys_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestPKI_PathManageKeys_GenerateInternalKeys(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	tests := []struct {
 		name           string
@@ -83,7 +83,7 @@ func TestPKI_PathManageKeys_GenerateInternalKeys(t *testing.T) {
 func TestPKI_PathManageKeys_GenerateExportedKeys(t *testing.T) {
 	t.Parallel()
 	// We tested a lot of the logic above within the internal test, so just make sure we honor the exported contract
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -115,7 +115,7 @@ func TestPKI_PathManageKeys_GenerateExportedKeys(t *testing.T) {
 
 func TestPKI_PathManageKeys_ImportKeyBundle(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	bundle1, err := certutil.CreateKeyBundle("ec", 224, rand.Reader)
 	require.NoError(t, err, "failed generating an ec key bundle")
@@ -248,7 +248,7 @@ func TestPKI_PathManageKeys_ImportKeyBundle(t *testing.T) {
 
 func TestPKI_PathManageKeys_DeleteDefaultKeyWarns(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation:  logical.UpdateOperation,
@@ -276,7 +276,7 @@ func TestPKI_PathManageKeys_DeleteDefaultKeyWarns(t *testing.T) {
 
 func TestPKI_PathManageKeys_DeleteUsedKeyFails(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation:  logical.UpdateOperation,
@@ -303,7 +303,7 @@ func TestPKI_PathManageKeys_DeleteUsedKeyFails(t *testing.T) {
 
 func TestPKI_PathManageKeys_UpdateKeyDetails(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation:  logical.UpdateOperation,
@@ -356,7 +356,7 @@ func TestPKI_PathManageKeys_UpdateKeyDetails(t *testing.T) {
 
 func TestPKI_PathManageKeys_ImportKeyBundleBadData(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -390,7 +390,7 @@ func TestPKI_PathManageKeys_ImportKeyBundleBadData(t *testing.T) {
 
 func TestPKI_PathManageKeys_ImportKeyRejectsMultipleKeys(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	bundle1, err := certutil.CreateKeyBundle("ec", 224, rand.Reader)
 	require.NoError(t, err, "failed generating an ec key bundle")

--- a/builtin/logical/pki/path_roles_test.go
+++ b/builtin/logical/pki/path_roles_test.go
@@ -20,7 +20,7 @@ func TestPki_RoleGenerateLease(t *testing.T) {
 	t.Parallel()
 	var resp *logical.Response
 	var err error
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	roleData := map[string]interface{}{
 		"allowed_domains": "myvault.com",
@@ -125,7 +125,7 @@ func TestPki_RoleKeyUsage(t *testing.T) {
 	t.Parallel()
 	var resp *logical.Response
 	var err error
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	roleData := map[string]interface{}{
 		"allowed_domains": "myvault.com",
@@ -216,7 +216,7 @@ func TestPki_RoleOUOrganizationUpgrade(t *testing.T) {
 	t.Parallel()
 	var resp *logical.Response
 	var err error
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	roleData := map[string]interface{}{
 		"allowed_domains": "myvault.com",
@@ -322,7 +322,7 @@ func TestPki_RoleAllowedDomains(t *testing.T) {
 	t.Parallel()
 	var resp *logical.Response
 	var err error
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	roleData := map[string]interface{}{
 		"allowed_domains": []string{"foobar.com", "*example.com"},
@@ -410,7 +410,7 @@ func TestPki_RoleAllowedURISANs(t *testing.T) {
 	t.Parallel()
 	var resp *logical.Response
 	var err error
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	roleData := map[string]interface{}{
 		"allowed_uri_sans": []string{"http://foobar.com", "spiffe://*"},
@@ -445,7 +445,7 @@ func TestPki_RolePkixFields(t *testing.T) {
 	t.Parallel()
 	var resp *logical.Response
 	var err error
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	roleData := map[string]interface{}{
 		"ttl":            "5h",
@@ -537,7 +537,7 @@ func TestPki_RoleNoStore(t *testing.T) {
 	t.Parallel()
 	var resp *logical.Response
 	var err error
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	roleData := map[string]interface{}{
 		"allowed_domains": "myvault.com",
@@ -658,7 +658,7 @@ func TestPki_CertsLease(t *testing.T) {
 	t.Parallel()
 	var resp *logical.Response
 	var err error
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	caData := map[string]interface{}{
 		"common_name": "myvault.com",
@@ -949,7 +949,7 @@ func TestPki_RolePatch(t *testing.T) {
 		},
 	}
 
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	for index, testCase := range testCases {
 		var resp *logical.Response
@@ -1045,7 +1045,7 @@ func TestPKI_RolePolicyInformation_Flat(t *testing.T) {
 		},
 	}
 
-	b, storage := createBackendWithStorage(t)
+	b, storage := CreateBackendWithStorage(t)
 
 	caData := map[string]interface{}{
 		"common_name": "myvault.com",

--- a/builtin/logical/pki/path_tidy_test.go
+++ b/builtin/logical/pki/path_tidy_test.go
@@ -192,7 +192,7 @@ func TestTidyCancellation(t *testing.T) {
 
 	numLeaves := 100
 
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// Create a root, a role, and a bunch of leaves.
 	_, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
@@ -268,7 +268,7 @@ func TestTidyCancellation(t *testing.T) {
 func TestTidyIssuers(t *testing.T) {
 	t.Parallel()
 
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 
 	// Create a root that expires quickly and one valid for longer.
 	_, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{

--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -15,7 +15,7 @@ func Test_migrateStorageEmptyStorage(t *testing.T) {
 	t.Parallel()
 	startTime := time.Now()
 	ctx := context.Background()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	sc := b.makeStorageContext(ctx, s)
 
 	// Reset the version the helper above set to 1.
@@ -64,7 +64,7 @@ func Test_migrateStorageOnlyKey(t *testing.T) {
 	t.Parallel()
 	startTime := time.Now()
 	ctx := context.Background()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	sc := b.makeStorageContext(ctx, s)
 
 	// Reset the version the helper above set to 1.
@@ -146,7 +146,7 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 	t.Parallel()
 	startTime := time.Now()
 	ctx := context.Background()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	sc := b.makeStorageContext(ctx, s)
 
 	// Reset the version the helper above set to 1.
@@ -252,7 +252,7 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 func TestMigration_OnceChainRebuild(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	sc := b.makeStorageContext(ctx, s)
 
 	// Create a legacy CA bundle that we'll migrate to the new layout. We call
@@ -362,7 +362,7 @@ func TestMigration_OnceChainRebuild(t *testing.T) {
 func TestExpectedOpsWork_PreMigration(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	// Reset the version the helper above set to 1.
 	b.pkiStorageVersion.Store(0)
 	require.True(t, b.useLegacyBundleCaStorage(), "pre migration we should have been told to use legacy storage.")

--- a/builtin/logical/pki/storage_test.go
+++ b/builtin/logical/pki/storage_test.go
@@ -15,7 +15,7 @@ var ctx = context.Background()
 
 func Test_ConfigsRoundTrip(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	sc := b.makeStorageContext(ctx, s)
 
 	// Create an empty key, issuer for testing.
@@ -59,7 +59,7 @@ func Test_ConfigsRoundTrip(t *testing.T) {
 
 func Test_IssuerRoundTrip(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	sc := b.makeStorageContext(ctx, s)
 	issuer1, key1 := genIssuerAndKey(t, b, s)
 	issuer2, key2 := genIssuerAndKey(t, b, s)
@@ -105,7 +105,7 @@ func Test_IssuerRoundTrip(t *testing.T) {
 
 func Test_KeysIssuerImport(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	sc := b.makeStorageContext(ctx, s)
 
 	issuer1, key1 := genIssuerAndKey(t, b, s)
@@ -174,7 +174,7 @@ func Test_KeysIssuerImport(t *testing.T) {
 
 func Test_IssuerUpgrade(t *testing.T) {
 	t.Parallel()
-	b, s := createBackendWithStorage(t)
+	b, s := CreateBackendWithStorage(t)
 	sc := b.makeStorageContext(ctx, s)
 
 	// Make sure that we add OCSP signing to v0 issuers if CRLSigning is enabled

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Setup helpers
-func createBackendWithStorage(t testing.TB) (*backend, logical.Storage) {
+func CreateBackendWithStorage(t testing.TB) (*backend, logical.Storage) {
 	config := logical.TestBackendConfig()
 	config.StorageView = &logical.InmemStorage{}
 

--- a/builtin/logical/pkiext/README.md
+++ b/builtin/logical/pkiext/README.md
@@ -1,0 +1,9 @@
+# What is `pkiext`?
+
+`pkiext` exists to split the Docker tests into a separate package from the
+main PKI tests. Because the Docker tests execute in a smaller runner with
+fewer resources, and we were hitting timeouts waiting for the entire PKI
+test suite to run, we need to split the larger non-Docker PKI tests from
+the smaller Docker tests, to ensure the former can execute.
+
+This package should lack any non-test related targets.

--- a/builtin/logical/pkiext/zlint_test.go
+++ b/builtin/logical/pkiext/zlint_test.go
@@ -1,4 +1,4 @@
-package pki
+package pkiext
 
 import (
 	"context"
@@ -6,9 +6,10 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/hashicorp/vault/builtin/logical/pki"
 	"github.com/hashicorp/vault/helper/testhelpers/docker"
+
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -67,7 +68,7 @@ func RunZLintContainer(t *testing.T, certificate string) []byte {
 	// container so we can run commands in it. We'd ideally like to skip this
 	// step and only build a new image, but the zlint output would be
 	// intermingled with container build stages, so its not that useful.
-	ctr, _, _, err := runner.Start(ctx, true, false)
+	ctr, _, _, err := runner.Start(context.Background(), true, false)
 	if err != nil {
 		t.Fatalf("Could not start golang container for zlint: %s", err)
 	}
@@ -81,7 +82,7 @@ func RunZLintContainer(t *testing.T, certificate string) []byte {
 
 	// Run the zlint command and save the output.
 	cmd := []string{"/go/bin/zlint", "/go/cert.pem"}
-	stdout, stderr, retcode, err := runner.RunCmdWithOutput(ctx, ctr.ID, cmd)
+	stdout, stderr, retcode, err := runner.RunCmdWithOutput(context.Background(), ctr.ID, cmd)
 	if err != nil {
 		t.Fatalf("Could not run command in container: %v", err)
 	}
@@ -104,9 +105,9 @@ func RunZLintContainer(t *testing.T, certificate string) []byte {
 }
 
 func RunZLintRootTest(t *testing.T, keyType string, keyBits int, usePSS bool, ignored []string) {
-	b, s := createBackendWithStorage(t)
+	b, s := pki.CreateBackendWithStorage(t)
 
-	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
+	resp, err := pki.CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"common_name":  "Root X1",
 		"country":      "US",
 		"organization": "Dadgarcorp",

--- a/command/secrets_enable_test.go
+++ b/command/secrets_enable_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -215,6 +216,10 @@ func TestSecretsEnableCommand_Run(t *testing.T) {
 		for _, f := range files {
 			if f.IsDir() {
 				if f.Name() == "plugin" {
+					continue
+				}
+				if _, err := os.Stat("../builtin/logical/" + f.Name() + "/backend.go"); errors.Is(err, os.ErrNotExist) {
+					// Skip ext test packages (fake plugins without backends).
 					continue
 				}
 				backends = append(backends, f.Name())


### PR DESCRIPTION
As discussed on the test fixing call, we should move the PKI Docker tests to a new package so they get executed on a different runner than the main (non-Docker) PKI tests. 