### PR TITLE
Update api-doc about PKI automatic tidying of issuers and the default issuer

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -3330,9 +3330,8 @@ expiration time.
   log the issuer certificate on removal to allow recovery; no keys are removed
   during this process.
 
-~> Note: When the default issuer expires and is tidied, a new default must be
-   chosen manually by the operator; this process will not select a new one
-   automatically.
+~> Note: The default issuer will not be removed even if it has expired and is
+   past the `issuer_safety_buffer` specified.
 
 - `safety_buffer` `(string: "")` - Specifies a duration using [duration format strings](/docs/concepts/duration-format)
   used as a safety buffer to ensure certificates are not expunged prematurely; as an example, this can keep


### PR DESCRIPTION
Update a note within the PKI API documentation which incorrectly mentioned that the automatic tidying of issuers would remove a `default` issuer. That doesn't happen according to the code, we will simply log the fact that the default issuer is expired but no removal occurs.