### PR TITLE
Don't return a 204 if there's no historical data

### DIFF
--- a/changelog/17935.txt
+++ b/changelog/17935.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/activity: return partial month counts when querying a historical date range and no historical data exists.
+```


### PR DESCRIPTION
Previously, if a Vault instance only had client count data for the current month, and you queried the activity log endpoint using dates that spanned historical data, you'd just get a 204 empty response. Now, instead, you get back the client counts for the current month. A concrete example might make things clearer:

Today is November 14. My Vault server came online for the first time on November 2. I've been using it ever since. If I query the activity log endpoint for 11/1/22 - 11/14/22, all is well. I get back partial results for this month. But, if I query for 10/1/22 - 11/14/22, previously I would get a 204 empty response. That's not correct though. I do have client count information for the time range requested, it's just all in November. With this patch, if I query for 10/1/22 - 11/14/22, I'll get back the same results that I would've gotten back had I queried from 11/1 - the partial results for November.