### PR TITLE
Clarify more documentation on audit logging.

### DIFF
--- a/website/content/docs/secrets/pki/considerations.mdx
+++ b/website/content/docs/secrets/pki/considerations.mdx
@@ -385,6 +385,21 @@ Because Vault HMACs audit string keys by default, it is necessary to tune
 PKI secrets mounts to get an accurate view of issuance that is occurring under
 this mount.
 
+~> Note: Depending on usage of Vault, CRLs (and rarely, CA chains) can grow to
+   be rather large. We don't recommend un-HMACing the `crl` field for this
+   reason, but note that the recommendations below suggest to un-HMAC the
+   `certificate` response parameter, which the CRL can be served in via
+   the `/pki/cert/crl` API endpoint. Additionally, the `http_raw_body` can
+   be used to return CRL both in PEM and raw binary DER form, so it is
+   suggested not to un-HMAC that field to not corrupt the log format.<br><br>
+   If this is done with only a [syslog](/docs/audit/syslog) audit device,
+   Vault can deny requests (with an opaque `500 Internal Error` message)
+   after the action has been performed on the server, because it was
+   unable to log the message.<br><br>
+   The suggested workaround is to either leave the `certificate` and `crl`
+   response fields HMACed and/or to also enable the [`file`](/docs/audit/file)
+   audit log type.
+
 Some suggested keys to un-HMAC for requests are as follows:
 
  - `csr` - the requested CSR to sign,


### PR DESCRIPTION
Thanks to Khai Tran for identifying that syslogging has a lower limit on message size and sometimes large CRLs can hit that limit.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`