### PR TITLE
removing setup-go in build.yml as it is unnecessary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,6 @@ jobs:
       vault-base-version: ${{ steps.get-metadata.outputs.vault-base-version }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
       - name: Get metadata
         id: get-metadata
         run: |


### PR DESCRIPTION
Per discussion in https://github.com/hashicorp/vault-enterprise/pull/3376
Removing an unnecessary substep in build.yml