### PR TITLE
VAULT-9427: Add read support to `sys/loggers` endpoints

### DIFF
--- a/changelog/17979.txt
+++ b/changelog/17979.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Add read support to `sys/loggers` and `sys/loggers/:name` endpoints
+```

--- a/helper/logging/logger.go
+++ b/helper/logging/logger.go
@@ -112,6 +112,8 @@ func ParseLogFormat(format string) (LogFormat, error) {
 	}
 }
 
+// ParseLogLevel returns the hclog.Level that corresponds with the provided level string.
+// This differs hclog.LevelFromString in that it supports additional level strings.
 func ParseLogLevel(logLevel string) (log.Level, error) {
 	var result log.Level
 	logLevel = strings.ToLower(strings.TrimSpace(logLevel))
@@ -129,6 +131,27 @@ func ParseLogLevel(logLevel string) (log.Level, error) {
 		result = log.Error
 	default:
 		return -1, errors.New(fmt.Sprintf("unknown log level: %s", logLevel))
+	}
+
+	return result, nil
+}
+
+// TranslateLoggerLevel returns the string that corresponds with logging level of the hclog.Logger.
+func TranslateLoggerLevel(logger log.Logger) (string, error) {
+	var result string
+
+	if logger.IsTrace() {
+		result = "trace"
+	} else if logger.IsDebug() {
+		result = "debug"
+	} else if logger.IsInfo() {
+		result = "info"
+	} else if logger.IsWarn() {
+		result = "warn"
+	} else if logger.IsError() {
+		result = "error"
+	} else {
+		return "", fmt.Errorf("unknown log level")
 	}
 
 	return result, nil

--- a/vault/core.go
+++ b/vault/core.go
@@ -2860,6 +2860,7 @@ func (c *Core) AddLogger(logger log.Logger) {
 	c.allLoggers = append(c.allLoggers, logger)
 }
 
+// SetLogLevel sets logging level for all tracked loggers to the level provided
 func (c *Core) SetLogLevel(level log.Level) {
 	c.allLoggersLock.RLock()
 	defer c.allLoggersLock.RUnlock()
@@ -2868,17 +2869,22 @@ func (c *Core) SetLogLevel(level log.Level) {
 	}
 }
 
-func (c *Core) SetLogLevelByName(name string, level log.Level) error {
+// SetLogLevelByName sets the logging level of named logger to level provided
+// if it exists. Core.allLoggers is a slice and as such it is entirely possible
+// that multiple entries exist for the same name. Each instance will be modified.
+func (c *Core) SetLogLevelByName(name string, level log.Level) bool {
 	c.allLoggersLock.RLock()
 	defer c.allLoggersLock.RUnlock()
+
+	found := false
 	for _, logger := range c.allLoggers {
 		if logger.Name() == name {
 			logger.SetLevel(level)
-			return nil
+			found = true
 		}
 	}
 
-	return fmt.Errorf("logger %q does not exist", name)
+	return found
 }
 
 // SetConfig sets core's config object to the newly provided config.

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -20,9 +20,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/hashicorp/vault/helper/versions"
-	"golang.org/x/crypto/sha3"
-
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
@@ -32,10 +29,12 @@ import (
 	semver "github.com/hashicorp/go-version"
 	"github.com/hashicorp/vault/helper/hostutil"
 	"github.com/hashicorp/vault/helper/identity"
+	"github.com/hashicorp/vault/helper/logging"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/monitor"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/random"
+	"github.com/hashicorp/vault/helper/versions"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
@@ -44,6 +43,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/version"
 	"github.com/mitchellh/mapstructure"
+	"golang.org/x/crypto/sha3"
 )
 
 const (
@@ -4828,28 +4828,29 @@ func (b *SystemBackend) handleVersionHistoryList(ctx context.Context, req *logic
 	return logical.ListResponseWithInfo(respKeys, respKeyInfo), nil
 }
 
-// getLogLevel returns the hclog.Level that corresponds with the provided level string.
-// This differs hclog.LevelFromString in that it supports additional level strings so
-// that in remains consistent with the handling found in the "vault server" command.
-func getLogLevel(logLevel string) (log.Level, error) {
-	var level log.Level
+func (b *SystemBackend) handleLoggersRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	b.Core.allLoggersLock.RLock()
+	defer b.Core.allLoggersLock.RUnlock()
 
-	switch logLevel {
-	case "trace":
-		level = log.Trace
-	case "debug":
-		level = log.Debug
-	case "notice", "info", "":
-		level = log.Info
-	case "warn", "warning":
-		level = log.Warn
-	case "err", "error":
-		level = log.Error
-	default:
-		return level, fmt.Errorf("unrecognized log level %q", logLevel)
+	loggers := make(map[string]interface{})
+	warnings := make([]string, 0)
+
+	for _, logger := range b.Core.allLoggers {
+		loggerName := logger.Name()
+		logLevel, err := logging.TranslateLoggerLevel(logger)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("cannot translate level for %q: %s", loggerName, err.Error()))
+		} else {
+			loggers[loggerName] = logLevel
+		}
 	}
 
-	return level, nil
+	resp := &logical.Response{
+		Data:     loggers,
+		Warnings: warnings,
+	}
+
+	return resp, nil
 }
 
 func (b *SystemBackend) handleLoggersWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
@@ -4864,7 +4865,7 @@ func (b *SystemBackend) handleLoggersWrite(ctx context.Context, req *logical.Req
 		return logical.ErrorResponse("level is empty"), nil
 	}
 
-	level, err := getLogLevel(logLevel)
+	level, err := logging.ParseLogLevel(logLevel)
 	if err != nil {
 		return logical.ErrorResponse(fmt.Sprintf("invalid level provided: %s", err.Error())), nil
 	}
@@ -4875,7 +4876,7 @@ func (b *SystemBackend) handleLoggersWrite(ctx context.Context, req *logical.Req
 }
 
 func (b *SystemBackend) handleLoggersDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	level, err := getLogLevel(b.Core.logLevel)
+	level, err := logging.ParseLogLevel(b.Core.logLevel)
 	if err != nil {
 		return logical.ErrorResponse(fmt.Sprintf("log level from config is invalid: %s", err.Error())), nil
 	}
@@ -4883,6 +4884,42 @@ func (b *SystemBackend) handleLoggersDelete(ctx context.Context, req *logical.Re
 	b.Core.SetLogLevel(level)
 
 	return nil, nil
+}
+
+func (b *SystemBackend) handleLoggersByNameRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	nameRaw, nameOk := d.GetOk("name")
+	if !nameOk {
+		return logical.ErrorResponse("name is required"), nil
+	}
+
+	name := nameRaw.(string)
+
+	b.Core.allLoggersLock.RLock()
+	defer b.Core.allLoggersLock.RUnlock()
+
+	loggers := make(map[string]interface{})
+	warnings := make([]string, 0)
+
+	for _, logger := range b.Core.allLoggers {
+		if logger.Name() == name {
+			logLevel, err := logging.TranslateLoggerLevel(logger)
+
+			if err != nil {
+				warnings = append(warnings, fmt.Sprintf("cannot translate level for %q: %s", name, err.Error()))
+			} else {
+				loggers[name] = logLevel
+			}
+
+			break
+		}
+	}
+
+	resp := &logical.Response{
+		Data:     loggers,
+		Warnings: warnings,
+	}
+
+	return resp, nil
 }
 
 func (b *SystemBackend) handleLoggersByNameWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
@@ -4902,14 +4939,15 @@ func (b *SystemBackend) handleLoggersByNameWrite(ctx context.Context, req *logic
 		return logical.ErrorResponse("level is empty"), nil
 	}
 
-	level, err := getLogLevel(logLevel)
+	level, err := logging.ParseLogLevel(logLevel)
 	if err != nil {
 		return logical.ErrorResponse(fmt.Sprintf("invalid level provided: %s", err.Error())), nil
 	}
 
-	err = b.Core.SetLogLevelByName(nameRaw.(string), level)
-	if err != nil {
-		return logical.ErrorResponse(fmt.Sprintf("invalid params: %s", err.Error())), nil
+	name := nameRaw.(string)
+	success := b.Core.SetLogLevelByName(name, level)
+	if !success {
+		return logical.ErrorResponse(fmt.Sprintf("logger %q not found", name)), nil
 	}
 
 	return nil, nil
@@ -4921,14 +4959,15 @@ func (b *SystemBackend) handleLoggersByNameDelete(ctx context.Context, req *logi
 		return logical.ErrorResponse("name is required"), nil
 	}
 
-	level, err := getLogLevel(b.Core.logLevel)
+	level, err := logging.ParseLogLevel(b.Core.logLevel)
 	if err != nil {
 		return logical.ErrorResponse(fmt.Sprintf("log level from config is invalid: %s", err.Error())), nil
 	}
 
-	err = b.Core.SetLogLevelByName(nameRaw.(string), level)
-	if err != nil {
-		return logical.ErrorResponse(fmt.Sprintf("invalid params: %s", err.Error())), nil
+	name := nameRaw.(string)
+	success := b.Core.SetLogLevelByName(name, level)
+	if !success {
+		return logical.ErrorResponse(fmt.Sprintf("logger %q not found", name)), nil
 	}
 
 	return nil, nil

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4985,6 +4985,10 @@ func (b *SystemBackend) handleLoggersByNameDelete(ctx context.Context, req *logi
 	}
 
 	name := nameRaw.(string)
+	if name == "" {
+		return logical.ErrorResponse("name is empty"), nil
+	}
+
 	success := b.Core.SetLogLevelByName(name, level)
 	if !success {
 		return logical.ErrorResponse(fmt.Sprintf("logger %q not found", name)), nil

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -298,6 +298,10 @@ func (b *SystemBackend) configPaths() []*framework.Path {
 				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.handleLoggersRead,
+					Summary:  "Read the log level for all existing loggers.",
+				},
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback: b.handleLoggersWrite,
 					Summary:  "Modify the log level for all existing loggers.",
@@ -322,6 +326,10 @@ func (b *SystemBackend) configPaths() []*framework.Path {
 				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.handleLoggersByNameRead,
+					Summary:  "Read the log level for a single logger.",
+				},
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback: b.handleLoggersByNameWrite,
 					Summary:  "Modify the log level of a single logger.",

--- a/website/content/api-docs/system/loggers.mdx
+++ b/website/content/api-docs/system/loggers.mdx
@@ -8,15 +8,15 @@ description: The `/sys/loggers` endpoint is used modify the verbosity level of l
 
 The `/sys/loggers` endpoint is used modify the verbosity level of logging.
 
-!> **NOTE:** Changes made to the log level using this endpoint are not persisted and will be restored 
-to either the default log level (info) or the level specified using `log_level` in vault.hcl or the `VAULT_LOG_LEVEL` 
+!> **NOTE:** Changes made to the log level using this endpoint are not persisted and will be restored
+to either the default log level (info) or the level specified using `log_level` in vault.hcl or the `VAULT_LOG_LEVEL`
 environment variable once the Vault service is reloaded or restarted.
 
 ## Modify verbosity level of all loggers
 
 | Method  | Path           |
 | :------ | :------------- |
-| `POST`  | `/sys/loggers` |
+| `POST`  | `/sys/loggers` |''
 
 ### Parameters
 
@@ -69,6 +69,52 @@ $ curl \
     --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/loggers/core
+```
+
+## Read verbosity level of all loggers
+
+| Method | Path           |
+| :----- | :------------- |
+| `GET`  | `/sys/loggers` |
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    https://127.0.0.1:8200/v1/sys/loggers
+```
+
+### Sample Response
+
+```json
+{
+    "audit": "trace",
+    "core": "info",
+    "policy": "debug"
+}
+```
+
+## Read verbosity level of a single logger
+
+| Method | Path                 |
+| :----- | :------------------- |
+| `GET`  | `/sys/loggers/:name` |
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    https://127.0.0.1:8200/v1/sys/loggers/core
+```
+
+### Sample Response
+
+```json
+{
+    "core": "info"
+}
 ```
 
 ## Revert verbosity of all loggers to configured level

--- a/website/content/api-docs/system/loggers.mdx
+++ b/website/content/api-docs/system/loggers.mdx
@@ -16,7 +16,7 @@ environment variable once the Vault service is reloaded or restarted.
 
 | Method  | Path           |
 | :------ | :------------- |
-| `POST`  | `/sys/loggers` |''
+| `POST`  | `/sys/loggers` |
 
 ### Parameters
 


### PR DESCRIPTION
PR https://github.com/hashicorp/vault/pull/16111 added support to modify server logging verbosity both globally and for individual loggers. It did not, however, add the ability to read the current state of the logger verbosity levels. This PR introduces read handlers for the `sys/loggers` and `sys/loggers/:name` endpoints.

Additional more low-level changes:
- Modified `Core.SetLogLevelByName` to account for the potential of `Core.allLoggers` including loggers that share the same name
- Modified existing `sys/loggers` handlers to use `ParseLogLevel` from the logging helper package to remove redundant code
- Added checks to ensure `sys/loggers` endpoints do not handle base logger (name == `""`)
- Added a `TranslateLoggerLevel` func to the logging helper package to determine the logging verbosity of an `hclog.Logger`

Example output on a dev server (`vault server -dev`):

```
# Set policy logger to trace level
❯ curl -XPUT -H "X-Vault-Token: $VAULT_TOKEN" -d '{"level":"trace"}' "$VAULT_ADDR/v1/sys/loggers/policy"

# Fetch verbosity level of all loggers
❯ curl -s -XGET -H "X-Vault-Token: $VAULT_TOKEN" "$VAULT_ADDR/v1/sys/loggers" | jq .data
{
  "activity": "info",
  "audit": "info",
  "auth.token.auth_token_cf840257": "info",
  "core": "info",
  "core.cluster-listener": "info",
  "core.cluster-listener.tcp": "info",
  "core.router": "info",
  "expiration": "info",
  "expiration.job-manager": "info",
  "grpclogfaker": "info",
  "identity": "info",
  "identity.storagepacker.entities": "info",
  "identity.storagepacker.groups": "info",
  "identity.storagepacker.local-aliases": "info",
  "mfa": "info",
  "policy": "trace",
  "quotas": "info",
  "rollback": "info",
  "seal.shamir": "info",
  "secrets.cubbyhole.cubbyhole_079cd5ab": "info",
  "secrets.identity.identity_7b1c0163": "info",
  "secrets.kv.kv_efb8658b": "info",
  "secrets.system.system_3ae59f37": "info",
  "storage.cache": "info",
  "storage.inmem": "info",
  "storage.sealunwrapper": "info",
  "system": "info",
  "token": "info"
}

# Get verbosity level of just the policy logger
❯ curl -s -XGET -H "X-Vault-Token: $VAULT_TOKEN" "$VAULT_ADDR/v1/sys/loggers/policy" | jq .data
{
  "policy": "trace"
}

# Revert verbosity level of just the policy logger to what is provided in config
❯ curl -s -XDELETE -H "X-Vault-Token: $VAULT_TOKEN" "$VAULT_ADDR/v1/sys/loggers/policy"

# Get verbosity level of just the policy logger
❯ curl -s -XGET -H "X-Vault-Token: $VAULT_TOKEN" "$VAULT_ADDR/v1/sys/loggers/policy" | jq .data
{
  "policy": "info"
}
```