### PR TITLE
Fix path typo in Generate Intermediate CSR PKI docs

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1725,11 +1725,11 @@ generated depending on the `type` request parameter.
    CSR and complete the signing before the signed intermediate certificate is
    [imported](#import-ca-certificate-and-keys) into this mount.
 
-| Method | Path                               | Private key source (`type`) |
-| :----- | :--------------------------------- | :-------------------------- |
-| `POST` | `/pki/intermediate/generate/:type` | specified per request       |
-| `POST` | `/pki/generate/intermediate/:type` | specified per request       |
-| `POST` | `/pki/intermediate/cross-sign`     | `existing`                  |
+| Method | Path                                       | Private key source (`type`) |
+| :----- |:-------------------------------------------| :-------------------------- |
+| `POST` | `/pki/intermediate/generate/:type`         | specified per request       |
+| `POST` | `/pki/issuers/generate/intermediate/:type` | specified per request       |
+| `POST` | `/pki/intermediate/cross-sign`             | `existing`                  |
 
 #### Parameters
 


### PR DESCRIPTION
 - Within the table specifying the various paths to generate a CSR in the PKI api-docs, the new issuers based API has a typo in it missing the issuers/ prefix.
 - Brought to our attention by Chelsea and Claire, thanks!