### PR TITLE
Avoid raft join failing when the first challenge fetch fails

### DIFF
--- a/changelog/18005.txt
+++ b/changelog/18005.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+storage/raft: avoid raft joining failures when a node queries itself for a raft bootstrap challenge
+```

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -1141,7 +1141,7 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case raftInfo := <-challengeCh: // channel returns nil on function error
+			case raftInfo := <-challengeCh:
 				if raftInfo != nil {
 					err = answerChallenge(ctx, raftInfo)
 					if err == nil {

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -1137,7 +1137,7 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 			close(challengeCh)
 		}()
 
-		for _ = range expandedJoinInfos {
+		for range expandedJoinInfos {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()


### PR DESCRIPTION
This is an attempt at fixing the issue I've describe in #18004. There's a longer explanation in the issue, but the gist of it is:

- When using AWS-based peer discovery, a node considers itself as a possible leader to connect to join. 
- Part of the join process is fetching the "raft challenge" from `sys/storage/raft/bootstrap/challenge`, from a healthy, unsealed node. Vault queries ALL of the discovered nodes. 
- When reading responses from this fetch, only one response is considered. If it succeeded, good, if not, the other responses are discarded!
- Sometimes, a new node will query itself for the challenge, which returns HTTP 503.
- Because the result from only one challenge fetch is considered, the join function bails out and retries later.

This change causes the raft join process to consider _ALL_ of the raft challenge fetch responses. If a fetch failed or answering the challenge fails, the next response is tried until a working one is found OR we run out of responses and an error is returned. It appears to have completely fixed the problem I was having in #18004.

Edit: it looks like the circleci tests are failing against files I didn't modify?