### PR TITLE
fix auth renew panic

### DIFF
--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -456,6 +456,21 @@ func TestBackend_PermittedDNSDomainsIntermediateCA(t *testing.T) {
 	if secret.Auth == nil || secret.Auth.ClientToken == "" {
 		t.Fatalf("expected a successful authentication")
 	}
+
+	// testing pathLoginRenew for cert auth
+	oldAccessor := secret.Auth.Accessor
+	newClient.SetToken(client.Token())
+	secret, err = newClient.Logical().Write("auth/token/renew-accessor", map[string]interface{}{
+		"accessor":  secret.Auth.Accessor,
+		"increment": 3600,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if secret.Auth == nil || secret.Auth.ClientToken != "" || secret.Auth.LeaseDuration != 3600 || secret.Auth.Accessor != oldAccessor {
+		t.Fatalf("unexpected accessor renewal")
+	}
 }
 
 func TestBackend_MetadataBasedACLPolicy(t *testing.T) {

--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -236,7 +236,7 @@ func (b *backend) verifyCredentials(ctx context.Context, req *logical.Request, d
 	var certName string
 	if req.Auth != nil { // It's a renewal, use the saved certName
 		certName = req.Auth.Metadata["cert_name"]
-	} else {
+	} else if d != nil { // d is nil if handleAuthRenew call the authRenew
 		certName = d.Get("name").(string)
 	}
 

--- a/builtin/credential/okta/path_login.go
+++ b/builtin/credential/okta/path_login.go
@@ -143,7 +143,11 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, d *framew
 func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	username := req.Auth.Metadata["username"]
 	password := req.Auth.InternalData["password"].(string)
-	nonce := d.Get("nonce").(string)
+
+	var nonce string
+	if d != nil {
+		nonce = d.Get("nonce").(string)
+	}
 
 	cfg, err := b.getConfig(ctx, req)
 	if err != nil {

--- a/changelog/18011.txt
+++ b/changelog/18011.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/okta: fix a panic for AuthRenew in Okta
+```


### PR DESCRIPTION
Addresses https://github.com/hashicorp/vault/issues/17013

When `handleAuthRenew` is invoked, `b.AuthRenew` is called with nil `framework.FieldData` [here](https://github.com/hashicorp/vault/blob/322ebe5ae1d700bb13f59994bb0455d9db8e7541/sdk/framework/backend.go#LL615-L620C2). This request goes to `pathLoginRenew` and this causes a panic for the case of [Okta](https://github.com/hashicorp/vault/blob/8d14e54b8cf6d9c93a11d2d927726a9bbcb9e0c5/builtin/credential/okta/path_login.go#L146) engine which expects to get a nonce from the field data.
The proposed fix assumes that there could be other code paths that call `pathLoginRenew`. 

```
2022-11-17T09:30:58.576-0800 [INFO]  http: panic serving 127.0.0.1:61385: runtime error: invalid memory address or nil pointer dereference
goroutine 830 [running]:
net/http.(*conn).serve.func1()
        /Users/hamid/.go/src/net/http/server.go:1850 +0xbf
panic({0x59d6c80, 0x9f71ec0})
        /Users/hamid/.go/src/runtime/panic.go:890 +0x262
github.com/hashicorp/vault/sdk/framework.(*FieldData).Get(0x0, {0x658e728, 0x5})
        /Users/hamid/repo/vault/sdk/framework/field_data.go:61 +0x27
github.com/hashicorp/vault/builtin/credential/okta.(*backend).pathLoginRenew(0xc000d1bf50, {0x7109638, 0xc001c5fb60}, 0xc001599500, 0x0)
        /Users/hamid/repo/vault/builtin/credential/okta/path_login.go:147 +0x246
github.com/hashicorp/vault/sdk/framework.(*Backend).handleAuthRenew(0x55bbaa0?, {0x7109638?, 0xc001c5fb60?}, 0x0?)
        /Users/hamid/repo/vault/sdk/framework/backend.go:620 +0xe5
github.com/hashicorp/vault/sdk/framework.(*Backend).handleRevokeRenew(0x0?, {0x7109638?, 0xc001c5fb60?}, 0x106bdf6?)
        /Users/hamid/repo/vault/sdk/framework/backend.go:561 +0x4e
github.com/hashicorp/vault/sdk/framework.(*Backend).HandleRequest(0xc001694000, {0x7109638, 0xc001c5fb60}, 0xc001599500)
        /Users/hamid/repo/vault/sdk/framework/backend.go:198 +0xe7
github.com/hashicorp/vault/builtin/plugin/v5.(*backend).HandleRequest(0xc000dc8780, {0x7109638, 0xc001c5fb60}, 0xc001599500)
        /Users/hamid/repo/vault/builtin/plugin/v5/backend.go:92 +0xce
github.com/hashicorp/vault/vault.(*Router).routeCommon(0xc0001c8af0, {0x7109638, 0xc001c5fb60}, 0xc001599500, 0x0)
        /Users/hamid/repo/vault/vault/router.go:764 +0x160b
github.com/hashicorp/vault/vault.(*Router).Route(...)
        /Users/hamid/repo/vault/vault/router.go:544
github.com/hashicorp/vault/vault.(*ExpirationManager).renewAuthEntry(0xc00001ab40, {0x7109638, 0xc001c5ec60}, 0xc001599200, 0xc000352b60, 0x34630b8a000)
        /Users/hamid/repo/vault/vault/expiration.go:1978 +0x36e
github.com/hashicorp/vault/vault.(*ExpirationManager).RenewToken(0xc00001ab40, {0x7109638, 0xc001c5ec60}, 0xc001a22420?, 0xc001c38b00, 0x659a2be?)
        /Users/hamid/repo/vault/vault/expiration.go:1352 +0x5ad
github.com/hashicorp/vault/vault.(*TokenStore).handleRenew(0xc0005f4780, {0x7109638, 0xc001c5ec60}, 0x9?, 0x18?)
        /Users/hamid/repo/vault/vault/token_store.go:3471 +0x2e5
github.com/hashicorp/vault/vault.(*TokenStore).handleUpdateRenewAccessor(0x0?, {0x7109638, 0xc001c5ec60}, 0x0?, 0xffffffffffffffff?)
        /Users/hamid/repo/vault/vault/token_store.go:2531 +0x33f
github.com/hashicorp/vault/sdk/framework.(*Backend).HandleRequest(0xc000cbb420, {0x7109638, 0xc001c5ec60}, 0xc001599200)
        /Users/hamid/repo/vault/sdk/framework/backend.go:291 +0xa82
github.com/hashicorp/vault/vault.(*Router).routeCommon(0xc0001c8af0, {0x7109638, 0xc001c5ec60}, 0xc001599200, 0x0)
        /Users/hamid/repo/vault/vault/router.go:764 +0x160b
github.com/hashicorp/vault/vault.(*Router).Route(...)
        /Users/hamid/repo/vault/vault/router.go:544
github.com/hashicorp/vault/vault.(*Core).doRouting(0xc00129c000?, {0x7109638?, 0xc001c5ec60?}, 0xc001c5e810?)
        /Users/hamid/repo/vault/vault/request_handling.go:817 +0x2c
github.com/hashicorp/vault/vault.(*Core).handleRequest(0xc00129c000, {0x7109638, 0xc001c5ec60}, 0xc001599200)
        /Users/hamid/repo/vault/vault/request_handling.go:1008 +0x11da
github.com/hashicorp/vault/vault.(*Core).handleCancelableRequest(0xc00129c000, {0x7109638, 0xc001c5e8d0}, 0xc001599200)
        /Users/hamid/repo/vault/vault/request_handling.go:665 +0x1545
github.com/hashicorp/vault/vault.(*Core).switchedLockHandleRequest(0xc00129c000, {0x7109638, 0xc001c5e2a0}, 0xc001599200, 0x80?)
        /Users/hamid/repo/vault/vault/request_handling.go:472 +0x539
github.com/hashicorp/vault/vault.(*Core).HandleRequest(...)
        /Users/hamid/repo/vault/vault/request_handling.go:433
github.com/hashicorp/vault/http.request(0x5f53c80?, {0x70f81e0, 0xc001c5e1b0}, 0xc000345600, 0xc001599200?)
        /Users/hamid/repo/vault/http/handler.go:910 +0x86
github.com/hashicorp/vault/http.handleLogicalInternal.func1({0x70f81e0, 0xc001c5e1b0}, 0xc000345600)
        /Users/hamid/repo/vault/http/logical.go:354 +0xb6
net/http.HandlerFunc.ServeHTTP(0xc001651595?, {0x70f81e0?, 0xc001c5e1b0?}, 0xc001325d40?)
        /Users/hamid/.go/src/net/http/server.go:2109 +0x2f
github.com/hashicorp/vault/http.handleRequestForwarding.func1({0x70f81e0, 0xc001c5e1b0}, 0xc000345600)
        /Users/hamid/repo/vault/http/handler.go:835 +0x39d
net/http.HandlerFunc.ServeHTTP(0xc00188f398?, {0x70f81e0?, 0xc001c5e1b0?}, 0x0?)
        /Users/hamid/.go/src/net/http/server.go:2109 +0x2f
net/http.(*ServeMux).ServeHTTP(0xe?, {0x70f81e0, 0xc001c5e1b0}, 0xc000345600)
        /Users/hamid/.go/src/net/http/server.go:2487 +0x149
github.com/hashicorp/vault/http.wrapHelpHandler.func1({0x70f81e0, 0xc001c5e1b0}, 0xc000345600)
        /Users/hamid/repo/vault/http/help.go:25 +0x129
net/http.HandlerFunc.ServeHTTP(0xc0006d9280?, {0x70f81e0?, 0xc001c5e1b0?}, 0x2559440?)
        /Users/hamid/.go/src/net/http/server.go:2109 +0x2f
github.com/hashicorp/vault/http.wrapCORSHandler.func1({0x70f81e0?, 0xc001c5e1b0?}, 0xc00188f510?)
        /Users/hamid/repo/vault/http/cors.go:29 +0x1e5
net/http.HandlerFunc.ServeHTTP(0xc00129c000?, {0x70f81e0?, 0xc001c5e1b0?}, 0xc000a295c0?)
        /Users/hamid/.go/src/net/http/server.go:2109 +0x2f
github.com/hashicorp/vault/http.rateLimitQuotaWrapping.func1({0x70f81e0, 0xc001c5e1b0}, 0xc000345600)
        /Users/hamid/repo/vault/http/util.go:110 +0xc30
net/http.HandlerFunc.ServeHTTP(0xc001c5e120?, {0x70f81e0?, 0xc001c5e1b0?}, 0xc001a20110?)
        /Users/hamid/.go/src/net/http/server.go:2109 +0x2f
github.com/hashicorp/vault/http.wrapGenericHandler.func1({0x7106b20?, 0xc000350a80}, 0xc000345300)
        /Users/hamid/repo/vault/http/handler.go:422 +0xdb3
net/http.HandlerFunc.ServeHTTP(0xc001651595?, {0x7106b20?, 0xc000350a80?}, 0x9fdb060?)
        /Users/hamid/.go/src/net/http/server.go:2109 +0x2f
github.com/hashicorp/go-cleanhttp.PrintablePathCheckHandler.func1({0x7106b20, 0xc000350a80}, 0xc000345300)
        /Users/hamid/go/pkg/mod/github.com/hashicorp/go-cleanhttp@v0.5.2/handlers.go:42 +0x93
net/http.HandlerFunc.ServeHTTP(0x0?, {0x7106b20?, 0xc000350a80?}, 0x1317a74?)
        /Users/hamid/.go/src/net/http/server.go:2109 +0x2f
net/http.serverHandler.ServeHTTP({0x70f0690?}, {0x7106b20, 0xc000350a80}, 0xc000345300)
        /Users/hamid/.go/src/net/http/server.go:2947 +0x30c
net/http.(*conn).serve(0xc001a89400, {0x7109638, 0xc000cf42a0})
        /Users/hamid/.go/src/net/http/server.go:1991 +0x607
created by net/http.(*Server).Serve
        /Users/hamid/.go/src/net/http/server.go:3102 +0x4db
```