### PR TITLE
Add a workaround to allow SHA-1 signatures in certs to work for Vault <= 1.11

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/builtin/plugin"
+	"github.com/hashicorp/vault/internal"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/version"
@@ -215,6 +216,11 @@ var (
 
 	initCommandsEnt = func(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {}
 )
+
+func init() {
+	// this is a good place to patch SHA-1 support back into x509, since all Vault CLI commands will run this.
+	internal.PatchSha1()
+}
 
 // Commands is the mapping of all the available commands.
 var Commands map[string]cli.CommandFactory

--- a/command/commands.go
+++ b/command/commands.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/builtin/plugin"
-	"github.com/hashicorp/vault/internal"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/version"
@@ -216,11 +215,6 @@ var (
 
 	initCommandsEnt = func(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {}
 )
-
-func init() {
-	// this is a good place to patch SHA-1 support back into x509, since all Vault CLI commands will run this.
-	internal.PatchSha1()
-}
 
 // Commands is the mapping of all the available commands.
 var Commands map[string]cli.CommandFactory

--- a/internal/go118_sha1_patch.go
+++ b/internal/go118_sha1_patch.go
@@ -1,0 +1,47 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	_ "unsafe" // for go:linkname
+
+	goversion "github.com/hashicorp/go-version"
+	"github.com/hashicorp/vault/sdk/version"
+)
+
+const sha1PatchVersionsBefore = "1.12.0"
+
+var patchSha1 sync.Once
+
+//go:linkname debugAllowSHA1 crypto/x509.debugAllowSHA1
+var debugAllowSHA1 bool
+
+// PatchSha1 patches Go 1.18+ to allow certificates with signatures containing SHA-1 hashes to be allowed.
+// It is safe to call this function multiple times.
+// This is necessary to allow Vault 1.10 and 1.11 to work with Go 1.18+ without breaking backwards compatibility
+// with these certificates. See https://go.dev/doc/go1.18#sha1 and
+// https://developer.hashicorp.com/vault/docs/deprecation/faq#q-what-is-the-impact-of-removing-support-for-x-509-certificates-with-signatures-that-use-sha-1
+// for more details.
+// TODO: remove when Vault <=1.11 is no longer supported
+func PatchSha1() {
+	patchSha1.Do(func() {
+		patchBefore, err := goversion.NewSemver(sha1PatchVersionsBefore)
+		if err != nil {
+			panic(err)
+		}
+
+		patch := false
+		v, err := goversion.NewSemver(version.GetVersion().Version)
+		if err == nil {
+			patch = v.LessThan(patchBefore)
+		} else {
+			fmt.Fprintf(os.Stderr, "Cannot parse version %s; going to apply SHA-1 deprecation patch workaround\n", version.GetVersion().Version)
+			patch = true
+		}
+
+		if patch {
+			debugAllowSHA1 = true
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,13 @@ import (
 	"os"
 
 	"github.com/hashicorp/vault/command"
+	"github.com/hashicorp/vault/internal"
 )
+
+func init() {
+	// this is a good place to patch SHA-1 support back into x509
+	internal.PatchSha1()
+}
 
 func main() {
 	os.Exit(command.Run(os.Args[1:]))


### PR DESCRIPTION
**tl;dr** I'm sorry

This will allow us to upgrade to Go 1.19+ in Vault 1.10 and 1.11, which helps keeps security tools quiet about using older versions with CVE.

## Why
[Go 1.18+ has removed support (by default) for certificates containing signatures with SHA-1.](https://go.dev/doc/go1.18#sha1)
For Vault 1.12+, we've [officially deprecated](https://developer.hashicorp.com/vault/docs/deprecation/faq#q-what-is-the-impact-of-removing-support-for-x-509-certificates-with-signatures-that-use-sha-1) these kinds of signatures and have a runtime workaround using an environment variable that users can set. This is the only official workaround.

## What does this PR do?
This PR patches an internal Go variable (that is also patched by the environment variable mentioned above), but does so permanently and only in code, so that users don't have to set the environment variable.

It only applies the patch is the detected Vault version is <= 1.11.0.

## That's terrible. What other options are there?

There are essentially 4.5 options:

1. Do nothing, don’t upgrade to Go 1.18 or 1.19, and let security scanners be mad while we don’t upgrade Go to 1.19 in Vault 1.10 and 1.11.
2. (This PR) Patch Go 1.19 at runtime to allow SHA-1-based signatures. This has the least impact on users, but is fragile and could stop working at any point since it relies on manipulating internal variables in Go. We would have to maintain this until Vault 1.12 is the oldest supported release in a year or so.
3. Fork `crypto/x509` to continue allowing SHA-1. This is potentially a lot of work, and we’d probably just want to throw away our fork when Vault 1.12 is the oldest supported release.

   a. Alternatively but similarly, we could fork and patch Go itself and use our fork for builds, like how the BoringCrypto fork works. This is probably an even worse idea due to the maintenance burden of maintaining a Go fork for all of the platforms that Vault supports.

4. Upgrade to Go 1.19, but don’t do this PR. This could break users unless they use the environment variable workaround. This probably breaks our [deprecation policy](https://developer.hashicorp.com/vault/docs/deprecation/faq#q-what-are-the-phases-of-deprecation).

If we cannot do option 1, I believe that option 2 (this PR) is the path of least pain and suffering for our users, with hopefully little pain on our part.

## What is the risk of doing this?

If the Go team decides to change the way they implement the SHA-1 deprecation workaround by something as simple as changing the internal variable name they use, we're going to have to come up with a different workaround that is probably even uglier.

## One more alternative

We could also do the patch at link time with the `-ldflags -X` option, [similar to how we hard-code the version and commit](https://github.com/hashicorp/vault/blob/main/scripts/build.sh#L43) of Vault when building. The downside of this approach is that we can't easily write unit tests to verify that the patch worked.

## Testing

I checked out Vault 1.11 (`release/1.11.x`), upgraded to Go 1.19.3, and verified that the tests in `builtin/credential/aws/pkcs7/sign_test.go` that use SHA-1 failed.

I cherry-picked the commit in this PR, and verified that all the tests then passed.

## What next?

After this is merged, we can upgrade to the latest Go 1.19 in the 1.11.x and 1.10.x release branches in subsequent PRs.