### PR TITLE
certutil.ParseHexFormatted fails parsing 80 hex and above

### DIFF
--- a/sdk/helper/certutil/certutil_test.go
+++ b/sdk/helper/certutil/certutil_test.go
@@ -26,7 +26,7 @@ import (
 
 // Tests converting back and forth between a CertBundle and a ParsedCertBundle.
 //
-// Also tests the GetSubjKeyID, GetHexFormatted, and
+// Also tests the GetSubjKeyID, GetHexFormatted, ParseHexFormatted and
 // ParsedCertBundle.getSigner functions.
 func TestCertBundleConversion(t *testing.T) {
 	cbuts := []*CertBundle{
@@ -243,6 +243,10 @@ func compareCertBundleToParsedCertBundle(cbut *CertBundle, pcbut *ParsedCertBund
 
 	if cb.SerialNumber != GetHexFormatted(pcbut.Certificate.SerialNumber.Bytes(), ":") {
 		return fmt.Errorf("bundle serial number does not match")
+	}
+
+	if !bytes.Equal(pcbut.Certificate.SerialNumber.Bytes(), ParseHexFormatted(cb.SerialNumber, ":")) {
+		return fmt.Errorf("failed re-parsing hex formatted number %s", cb.SerialNumber)
 	}
 
 	switch {

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -100,13 +100,13 @@ func GetHexFormatted(buf []byte, sep string) string {
 func ParseHexFormatted(in, sep string) []byte {
 	var ret bytes.Buffer
 	var err error
-	var inBits int64
+	var inBits uint64
 	inBytes := strings.Split(in, sep)
 	for _, inByte := range inBytes {
-		if inBits, err = strconv.ParseInt(inByte, 16, 8); err != nil {
+		if inBits, err = strconv.ParseUint(inByte, 16, 8); err != nil {
 			return nil
 		}
-		ret.WriteByte(byte(inBits))
+		ret.WriteByte(uint8(inBits))
 	}
 	return ret.Bytes()
 }


### PR DESCRIPTION
Switch to using `ParseUint` of 8 bits to parse the hex values properly as `ParseInt` limited to 8 bits will only handle values up to 127 decimal or 7F. Add a test that validates the function can parse properly.

I only see a [single user of this function](https://github.com/hashicorp/vault/blob/f5cc167bff4b489f949fe62076c2a7a81eddc490/builtin/credential/cert/path_crls.go#L114-L113) but that function doesn't seem to be used so will not backport this fix for now. 