### PR TITLE
add draft 1.13.x upgrade guide

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -16,6 +16,8 @@ for Vault 1.13.x compared to 1.12. Please read it carefully.
 
 ## Changes
 
+### AliCloud Auth Role Parameter
+
 The AliCloud auth plugin will now require the `role` parameter on login. This
 has always been documented as a required field but the requirement will now be
 enforced.

--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -1,0 +1,19 @@
+---
+layout: docs
+page_title: Upgrading to Vault 1.13.x - Guides
+description: |-
+  This page contains the list of deprecations and important or breaking changes
+  for Vault 1.13.x. Please read it carefully.
+---
+
+# Overview
+
+This page contains the list of deprecations and important or breaking changes
+for Vault 1.13.x compared to 1.12. Please read it carefully.
+
+## Changes
+
+The AliCloud auth plugin will now require the `role` parameter on login. This
+has always been documented as a required field but the requirement will now be
+enforced.
+

--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -6,6 +6,9 @@ description: |-
   for Vault 1.13.x. Please read it carefully.
 ---
 
+~> Note: these are **draft** notes for a future version of Vault. They should not be considered
+official guidance until the release has been completed.
+
 # Overview
 
 This page contains the list of deprecations and important or breaking changes

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1703,7 +1703,8 @@
       },
       {
         "title": "Upgrade to 1.13.x",
-        "path": "upgrading/upgrade-to-1.13.x"
+        "path": "upgrading/upgrade-to-1.13.x",
+        "hidden": true
       },
       {
         "title": "Upgrade to 1.12.x",

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1702,6 +1702,10 @@
         "path": "upgrading/plugins"
       },
       {
+        "title": "Upgrade to 1.13.x",
+        "path": "upgrading/upgrade-to-1.13.x"
+      },
+      {
         "title": "Upgrade to 1.12.x",
         "path": "upgrading/upgrade-to-1.12.x"
       },


### PR DESCRIPTION
Since we've already identified something for the 1.13 upgrade guide, we'll create the guide now but:

- leave it out of the sidebar
- add a disclaimer to the top