### PR TITLE
Dev Ex: Fix git cleaning up .gitkeep file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,10 +28,6 @@ _testmain.go
 /bin/
 /pkg/
 
-# Generated Web UI goes here
-/http/web_ui/*.*
-/http/web_ui/**/*.*
-
 # Vault-specific
 example.hcl
 example.vault.d

--- a/http/.gitignore
+++ b/http/.gitignore
@@ -1,0 +1,5 @@
+# Generated Web UI goes here
+# git check-ignore -v -- http/web_ui/.gitkeep
+web_ui/**
+!web_ui/**/
+!web_ui/**/.gitkeep

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "ember build --environment=production && cp metadata.json ../http/web_ui/metadata.json",
+    "build": "ember build --environment=production && cp metadata.json ../http/web_ui/metadata.json && touch ../http/web_ui/.gitkeep",
     "build:dev": "ember build",
     "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
     "lint:hbs": "ember-template-lint '**/*.hbs'",


### PR DESCRIPTION
Often when working in the UI, we find that the `.gitkeep` file gets unintentionally deleted. Part of this is because it wasn't properly excluded in the .gitignore, which is supposed to keep the `http/web_ui` file structure but ignore all the contents of the folder. I also found that running `npm run build` would delete the `.gitkeep` file, so I added that to the script as well. 

Inspired from [this stackoverflow discussion](https://stackoverflow.com/questions/46301811/gitignore-all-files-in-folders-but-keep-folder-structure), and you can check whether the file is gitignored with the command `git check-ignore -v -- http/web_ui/.gitkeep`