### PR TITLE
storage/raft: Add retry_join_as_non_voter config option

### DIFF
--- a/changelog/18030.txt
+++ b/changelog/18030.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+storage/raft: Add `retry_join_as_non_voter` config option.
+```

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -43,6 +43,10 @@ const (
 
 	// EnvVaultRaftPath is used to fetch the path where Raft data is stored from the environment.
 	EnvVaultRaftPath = "VAULT_RAFT_PATH"
+
+	// EnvVaultRaftNonVoter is used to override the non_voter config option, telling Vault to join as a non-voter (i.e. read replica).
+	EnvVaultRaftNonVoter  = "VAULT_RAFT_RETRY_JOIN_AS_NON_VOTER"
+	raftNonVoterConfigKey = "retry_join_as_non_voter"
 )
 
 var getMmapFlags = func(string) int { return 0 }
@@ -171,6 +175,10 @@ type RaftBackend struct {
 
 	// redundancyZone specifies a redundancy zone for autopilot.
 	redundancyZone string
+
+	// nonVoter specifies whether the node should join the cluster as a non-voter. Non-voters get
+	// replicated to and can serve reads, but do not take part in leader elections.
+	nonVoter bool
 
 	effectiveSDKVersion string
 }
@@ -473,6 +481,22 @@ func NewRaftBackend(conf map[string]string, logger log.Logger) (physical.Backend
 		}
 	}
 
+	var nonVoter bool
+	if v := os.Getenv(EnvVaultRaftNonVoter); v != "" {
+		// Consistent with handling of other raft boolean env vars
+		// VAULT_RAFT_AUTOPILOT_DISABLE and VAULT_RAFT_FREELIST_SYNC
+		nonVoter = true
+	} else if v, ok := conf[raftNonVoterConfigKey]; ok {
+		nonVoter, err = strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %s config value %q as a boolean: %w", raftNonVoterConfigKey, v, err)
+		}
+	}
+
+	if nonVoter && conf["retry_join"] == "" {
+		return nil, fmt.Errorf("setting %s to true is only valid if at least one retry_join stanza is specified", raftNonVoterConfigKey)
+	}
+
 	return &RaftBackend{
 		logger:                     logger,
 		fsm:                        fsm,
@@ -489,6 +513,7 @@ func NewRaftBackend(conf map[string]string, logger log.Logger) (physical.Backend
 		autopilotReconcileInterval: reconcileInterval,
 		autopilotUpdateInterval:    updateInterval,
 		redundancyZone:             conf["autopilot_redundancy_zone"],
+		nonVoter:                   nonVoter,
 		upgradeVersion:             upgradeVersion,
 	}, nil
 }
@@ -552,6 +577,13 @@ func (b *RaftBackend) RedundancyZone() string {
 	defer b.l.RUnlock()
 
 	return b.redundancyZone
+}
+
+func (b *RaftBackend) NonVoter() bool {
+	b.l.RLock()
+	defer b.l.RUnlock()
+
+	return b.nonVoter
 }
 
 func (b *RaftBackend) EffectiveVersion() string {

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -853,7 +853,7 @@ func (c *Core) InitiateRetryJoin(ctx context.Context) error {
 
 	c.logger.Info("raft retry join initiated")
 
-	if _, err = c.JoinRaftCluster(ctx, leaderInfos, false); err != nil {
+	if _, err = c.JoinRaftCluster(ctx, leaderInfos, raftBackend.NonVoter()); err != nil {
 		return err
 	}
 

--- a/website/content/docs/commands/operator/raft.mdx
+++ b/website/content/docs/commands/operator/raft.mdx
@@ -79,6 +79,8 @@ The following flags are available for the `operator raft join` command.
   server not participate in the Raft quorum, and have it only receive the data
   replication stream. This can be used to add read scalability to a cluster in
   cases where a high volume of reads to servers are needed. The default is false.
+  See [`retry_join_as_non_voter`](/docs/configuration/storage/raft#retry_join_as_non_voter)
+  for the equivalent config option when using `retry_join` stanzas instead.
 
 - `-retry` `(bool: false)` - Continuously retry joining the Raft cluster upon
   failures. The default is false.

--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -95,6 +95,16 @@ set [`disable_mlock`](/docs/configuration#disable_mlock) to `true`, and to disab
   See [the section below](#retry_join-stanza) that describes the parameters
   accepted by the [`retry_join`](#retry_join-stanza) stanza.
 
+- `retry_join_as_non_voter` `(boolean: false)` - If set, causes any `retry_join`
+  config to join the Raft cluster as a non-voter. The node will not participate
+  in the Raft quorum but will still receive the data replication stream, adding
+  read scalability to a cluster. This option has the same effect as the
+  [`-non-voter`](/docs/commands/operator/raft#non-voter) flag for the
+  `vault operator raft join` command, but only affects voting status when joining
+  via `retry_join` config. This setting can be overridden to true by setting the
+  `VAULT_RAFT_RETRY_JOIN_AS_NON_VOTER` environment variable to any non-empty value.
+  Only valid if there is at least one `retry_join` stanza.
+
 - `max_entry_size` `(integer: 1048576)` - This configures the maximum number of
   bytes for a Raft entry. It applies to both Put operations and transactions.
   Any put or transaction operation exceeding this configuration value will cause


### PR DESCRIPTION
Adds `retry_join_as_non_voter` config option for raft storage, including an environment variable override `VAULT_RAFT_RETRY_JOIN_AS_NON_VOTER`. Has the same effect as `vault operator raft join -non-voter`, but only applies to joins performed due to `retry_join` config.