### PR TITLE
Create global quotas of each type in every NewTestCluster.  

### DIFF
--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -1302,7 +1302,7 @@ func (h *handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		}
 		h.t.Logf("passing GET request on %s", req.URL.Path)
 	}
-	vaulthttp.Handler(h.props).ServeHTTP(resp, req)
+	vaulthttp.Handler.Handler(h.props).ServeHTTP(resp, req)
 }
 
 // TestAgent_Template_Retry verifies that the template server retries requests
@@ -1325,11 +1325,12 @@ func TestAgent_Template_Retry(t *testing.T) {
 		},
 		&vault.TestClusterOptions{
 			NumCores: 1,
-			HandlerFunc: func(properties *vault.HandlerProperties) http.Handler {
-				h.props = properties
-				h.t = t
-				return &h
-			},
+			HandlerFunc: vaulthttp.HandlerFunc(
+				func(properties *vault.HandlerProperties) http.Handler {
+					h.props = properties
+					h.t = t
+					return &h
+				}),
 		})
 	cluster.Start()
 	defer cluster.Cleanup()
@@ -1612,11 +1613,11 @@ func TestAgent_Cache_Retry(t *testing.T) {
 		},
 		&vault.TestClusterOptions{
 			NumCores: 1,
-			HandlerFunc: func(properties *vault.HandlerProperties) http.Handler {
+			HandlerFunc: vaulthttp.HandlerFunc(func(properties *vault.HandlerProperties) http.Handler {
 				h.props = properties
 				h.t = t
 				return &h
-			},
+			}),
 		})
 	cluster.Start()
 	defer cluster.Cleanup()

--- a/command/server.go
+++ b/command/server.go
@@ -688,7 +688,7 @@ func (c *ServerCommand) runRecoveryMode() int {
 	c.UI.Output("")
 
 	for _, ln := range lns {
-		handler := vaulthttp.Handler(&vault.HandlerProperties{
+		handler := vaulthttp.Handler.Handler(&vault.HandlerProperties{
 			Core:                  core,
 			ListenerConfig:        ln.Config,
 			DisablePrintableCheck: config.DisablePrintableCheck,
@@ -1513,7 +1513,7 @@ func (c *ServerCommand) Run(args []string) int {
 	// This needs to happen before we first unseal, so before we trigger dev
 	// mode if it's set
 	core.SetClusterListenerAddrs(clusterAddrs)
-	core.SetClusterHandler(vaulthttp.Handler(&vault.HandlerProperties{
+	core.SetClusterHandler(vaulthttp.Handler.Handler(&vault.HandlerProperties{
 		Core: core,
 	}))
 
@@ -2033,7 +2033,7 @@ func (c *ServerCommand) enableThreeNodeDevCluster(base *vault.CoreConfig, info m
 	c.UI.Output("")
 
 	for _, core := range testCluster.Cores {
-		core.Server.Handler = vaulthttp.Handler(&vault.HandlerProperties{
+		core.Server.Handler = vaulthttp.Handler.Handler(&vault.HandlerProperties{
 			Core: core.Core,
 		})
 		core.SetClusterHandler(core.Server.Handler)
@@ -2890,7 +2890,7 @@ func startHttpServers(c *ServerCommand, core *vault.Core, config *server.Config,
 			return err
 		}
 
-		handler := vaulthttp.Handler(&vault.HandlerProperties{
+		handler := vaulthttp.Handler.Handler(&vault.HandlerProperties{
 			Core:                  core,
 			ListenerConfig:        ln.Config,
 			DisablePrintableCheck: config.DisablePrintableCheck,

--- a/helper/locking/deadlock.go
+++ b/helper/locking/deadlock.go
@@ -1,6 +1,6 @@
 //go:build deadlock
 
-package vault
+package locking
 
 import (
 	"github.com/sasha-s/go-deadlock"

--- a/helper/locking/lock.go
+++ b/helper/locking/lock.go
@@ -1,6 +1,6 @@
 //go:build !deadlock
 
-package vault
+package locking
 
 import (
 	"sync"

--- a/http/forwarded_for_test.go
+++ b/http/forwarded_for_test.go
@@ -46,7 +46,7 @@ func TestHandler_XForwardedFor(t *testing.T) {
 		}
 
 		cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-			HandlerFunc: testHandler,
+			HandlerFunc: HandlerFunc(testHandler),
 		})
 		cluster.Start()
 		defer cluster.Cleanup()
@@ -89,7 +89,7 @@ func TestHandler_XForwardedFor(t *testing.T) {
 		}
 
 		cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-			HandlerFunc: testHandler,
+			HandlerFunc: HandlerFunc(testHandler),
 		})
 		cluster.Start()
 		defer cluster.Cleanup()
@@ -125,7 +125,7 @@ func TestHandler_XForwardedFor(t *testing.T) {
 		}
 
 		cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-			HandlerFunc: testHandler,
+			HandlerFunc: HandlerFunc(testHandler),
 		})
 		cluster.Start()
 		defer cluster.Cleanup()
@@ -159,7 +159,7 @@ func TestHandler_XForwardedFor(t *testing.T) {
 		}
 
 		cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-			HandlerFunc: testHandler,
+			HandlerFunc: HandlerFunc(testHandler),
 		})
 		cluster.Start()
 		defer cluster.Cleanup()
@@ -193,7 +193,7 @@ func TestHandler_XForwardedFor(t *testing.T) {
 		}
 
 		cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-			HandlerFunc: testHandler,
+			HandlerFunc: HandlerFunc(testHandler),
 		})
 		cluster.Start()
 		defer cluster.Cleanup()
@@ -230,7 +230,7 @@ func TestHandler_XForwardedFor(t *testing.T) {
 		}
 
 		cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-			HandlerFunc: testHandler,
+			HandlerFunc: HandlerFunc(testHandler),
 		})
 		cluster.Start()
 		defer cluster.Cleanup()

--- a/http/handler.go
+++ b/http/handler.go
@@ -118,9 +118,25 @@ func init() {
 	})
 }
 
-// Handler returns an http.Handler for the API. This can be used on
+type HandlerAnchor struct{}
+
+func (h HandlerAnchor) Handler(props *vault.HandlerProperties) http.Handler {
+	return handler(props)
+}
+
+var Handler vault.HandlerHandler = HandlerAnchor{}
+
+type HandlerFunc func(props *vault.HandlerProperties) http.Handler
+
+func (h HandlerFunc) Handler(props *vault.HandlerProperties) http.Handler {
+	return h(props)
+}
+
+var _ vault.HandlerHandler = HandlerFunc(func(props *vault.HandlerProperties) http.Handler { return nil })
+
+// handler returns an http.Handler for the API. This can be used on
 // its own to mount the Vault API within another web server.
-func Handler(props *vault.HandlerProperties) http.Handler {
+func handler(props *vault.HandlerProperties) http.Handler {
 	core := props.Core
 
 	// Create the muxer to handle the actual endpoints

--- a/http/testing.go
+++ b/http/testing.go
@@ -31,7 +31,7 @@ func TestServerWithListenerAndProperties(tb testing.TB, ln net.Listener, addr st
 	// for tests.
 	mux := http.NewServeMux()
 	mux.Handle("/_test/auth", http.HandlerFunc(testHandleAuth))
-	mux.Handle("/", Handler(props))
+	mux.Handle("/", Handler.Handler(props))
 
 	server := &http.Server{
 		Addr:     ln.Addr().String(),

--- a/vault/core.go
+++ b/vault/core.go
@@ -38,6 +38,7 @@ import (
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/command/server"
 	"github.com/hashicorp/vault/helper/identity/mfa"
+	"github.com/hashicorp/vault/helper/locking"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/osutil"
@@ -298,7 +299,7 @@ type Core struct {
 	auditBackends map[string]audit.Factory
 
 	// stateLock protects mutable state
-	stateLock DeadlockRWMutex
+	stateLock locking.DeadlockRWMutex
 	sealed    *uint32
 
 	standby              bool

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -15,14 +15,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/vault/helper/locking"
-
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/base62"
 	"github.com/hashicorp/vault/helper/fairshare"
+	"github.com/hashicorp/vault/helper/locking"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/framework"

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -15,6 +15,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/hashicorp/vault/helper/locking"
+
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
@@ -109,7 +111,7 @@ type ExpirationManager struct {
 	pending     sync.Map
 	nonexpiring sync.Map
 	leaseCount  int
-	pendingLock sync.RWMutex
+	pendingLock locking.DeadlockRWMutex
 
 	// A sync.Lock for every active leaseID
 	lockPerLease sync.Map
@@ -137,7 +139,7 @@ type ExpirationManager struct {
 	quitCh             chan struct{}
 
 	// do not hold coreStateLock in any API handler code - it is already held
-	coreStateLock     *DeadlockRWMutex
+	coreStateLock     *locking.DeadlockRWMutex
 	quitContext       context.Context
 	leaseCheckCounter *uint32
 

--- a/vault/external_tests/quotas/quotas_test.go
+++ b/vault/external_tests/quotas/quotas_test.go
@@ -129,6 +129,7 @@ func waitForRemovalOrTimeout(c *api.Client, path string, tick, to time.Duration)
 
 func TestQuotas_RateLimit_DupName(t *testing.T) {
 	conf, opts := teststorage.ClusterSetup(coreConfig, nil, nil)
+	opts.NoDefaultQuotas = true
 	cluster := vault.NewTestCluster(t, conf, opts)
 	cluster.Start()
 	defer cluster.Cleanup()
@@ -163,6 +164,7 @@ func TestQuotas_RateLimit_DupName(t *testing.T) {
 
 func TestQuotas_RateLimit_DupPath(t *testing.T) {
 	conf, opts := teststorage.ClusterSetup(coreConfig, nil, nil)
+	opts.NoDefaultQuotas = true
 	cluster := vault.NewTestCluster(t, conf, opts)
 	cluster.Start()
 	defer cluster.Cleanup()
@@ -201,6 +203,7 @@ func TestQuotas_RateLimit_DupPath(t *testing.T) {
 
 func TestQuotas_RateLimitQuota_ExemptPaths(t *testing.T) {
 	conf, opts := teststorage.ClusterSetup(coreConfig, nil, nil)
+	opts.NoDefaultQuotas = true
 
 	cluster := vault.NewTestCluster(t, conf, opts)
 	cluster.Start()
@@ -340,6 +343,7 @@ func TestQuotas_RateLimitQuota_Mount(t *testing.T) {
 
 func TestQuotas_RateLimitQuota_MountPrecedence(t *testing.T) {
 	conf, opts := teststorage.ClusterSetup(coreConfig, nil, nil)
+	opts.NoDefaultQuotas = true
 	cluster := vault.NewTestCluster(t, conf, opts)
 	cluster.Start()
 	defer cluster.Cleanup()
@@ -426,6 +430,7 @@ func TestQuotas_RateLimitQuota_MountPrecedence(t *testing.T) {
 
 func TestQuotas_RateLimitQuota(t *testing.T) {
 	conf, opts := teststorage.ClusterSetup(coreConfig, nil, nil)
+	opts.NoDefaultQuotas = true
 	cluster := vault.NewTestCluster(t, conf, opts)
 	cluster.Start()
 	defer cluster.Cleanup()

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"path"
 	"strings"
-	"sync"
+
+	"github.com/hashicorp/vault/helper/locking"
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
@@ -167,13 +168,13 @@ type Manager struct {
 	metricSink *metricsutil.ClusterMetricSink
 
 	// quotaLock is a lock for manipulating quotas and anything not covered by a more specific lock
-	quotaLock *sync.RWMutex
+	quotaLock *locking.DeadlockRWMutex
 
 	// quotaConfigLock is a lock for accessing config items, such as RateLimitExemptPaths
-	quotaConfigLock *sync.RWMutex
+	quotaConfigLock *locking.DeadlockRWMutex
 
 	// dbAndCacheLock is a lock for db and path caches that need to be reset during Reset()
-	dbAndCacheLock *sync.RWMutex
+	dbAndCacheLock *locking.DeadlockRWMutex
 }
 
 // QuotaLeaseInformation contains all of the information lease-count quotas require
@@ -281,9 +282,9 @@ func NewManager(logger log.Logger, walkFunc leaseWalkFunc, ms *metricsutil.Clust
 		metricSink:           ms,
 		rateLimitPathManager: pathmanager.New(),
 		config:               new(Config),
-		quotaLock:            new(sync.RWMutex),
-		quotaConfigLock:      new(sync.RWMutex),
-		dbAndCacheLock:       new(sync.RWMutex),
+		quotaLock:            new(locking.DeadlockRWMutex),
+		quotaConfigLock:      new(locking.DeadlockRWMutex),
+		dbAndCacheLock:       new(locking.DeadlockRWMutex),
 	}
 
 	manager.init(walkFunc)

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -7,10 +7,9 @@ import (
 	"path"
 	"strings"
 
-	"github.com/hashicorp/vault/helper/locking"
-
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/vault/helper/locking"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/pathmanager"

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -922,6 +922,12 @@ func (c *TestCluster) start(t testing.T) {
 		c.SetupFunc()
 	}
 
+	if c.opts.SkipInit {
+		// SkipInit implies that vault may not be ready to service requests, or that
+		// we're restarting a cluster from an existing storage.
+		return
+	}
+
 	activeCore := -1
 WAITACTIVE:
 	for i := 0; i < 60; i++ {
@@ -940,9 +946,6 @@ WAITACTIVE:
 
 	switch {
 	case c.opts == nil:
-	case c.opts.SkipInit:
-		// SkipInit implies that vault may not be ready to service requests, or that
-		// we're restarting a cluster from an existing storage
 	case c.opts.NoDefaultQuotas:
 	case c.opts.HandlerFunc == nil:
 	// If no HandlerFunc is provided that means that we can't actually do

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -922,7 +922,7 @@ func (c *TestCluster) start(t testing.T) {
 		c.SetupFunc()
 	}
 
-	if c.opts.SkipInit {
+	if c.opts != nil && c.opts.SkipInit {
 		// SkipInit implies that vault may not be ready to service requests, or that
 		// we're restarting a cluster from an existing storage.
 		return


### PR DESCRIPTION
Also switch some key locks to use DeadlockMutex to make it easier to discover deadlocks in testing.

There's some interesting stuff in testing.go to address the problem of: how do we skip setting up quotas when someone is using a nonstandard handler that might not even implement the quotas endpoint? The challenge is that because we're taking a func pointer to generate the real handler func, we don't have any way to compare that func pointer to the standard handler (github.com/hashicorp/http.Handler) without creating a circular dependency between packages vault and http. The solution is to pass a method instead of an anonymous func pointer so that we can do reflection on it.  I'm not very happy with some of the names that resulted though ("HandlerHandler"? really?), hopefully we can improve that (suggestions welcome).  However I'm hesitant to rename TestClusterOptions.HandlerFunc even if it's no longer a func, due to the disruption that would result.

The other noteworthy change is that now calling Start on a TestCluster is a no-op.  This is kind of nice because it's easy to forget to call Start, and it fits with how things kind of need to work in the docker based NewTestCluster alternative I've been working on.  I can't think of any use case that requires having the cluster built by NewTestCluster not be running until Start is called, but perhaps I've missed something.  The motivation here, btw, is that Start doesn't return an error, and if I started returning one now I'd have hundreds of places I'd need to add error checking to, whereas if we do the quota work (which could yield errors) in NewTestCluster itself we can return errors from there.