### PR TITLE
UI: Create .gitignore file on postBuild

### DIFF
--- a/ui/lib/keep-gitkeep/index.js
+++ b/ui/lib/keep-gitkeep/index.js
@@ -1,0 +1,15 @@
+'use strict';
+const fs = require('fs');
+module.exports = {
+  name: require('./package').name,
+
+  isDevelopingAddon() {
+    return true;
+  },
+
+  postBuild(result) {
+    // We gitignore the contents of our output directory http/web_ui
+    // but we need to keep the folder structure for the Vault build
+    fs.writeFileSync(result.directory + '/.gitkeep', '');
+  },
+};

--- a/ui/lib/keep-gitkeep/package.json
+++ b/ui/lib/keep-gitkeep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "keep-gitkeep",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -239,6 +239,7 @@
     "paths": [
       "lib/core",
       "lib/css",
+      "lib/keep-gitkeep",
       "lib/kmip",
       "lib/open-api-explorer",
       "lib/pki",


### PR DESCRIPTION
A .gitkeep file was added to `http/web_ui` in order to make the folder compliant with Go's native embedding ([#14246](https://github.com/hashicorp/vault/pull/14246)). However, ever since then while developing on the UI the file would get deleted locally, which caused frustration and overhead for developers to remember not to commit those changes. 

The root cause is that the contents of that folder are generated on hot reload whenever we run the ember server, and the folder contents get overwritten. This PR adds and in-repo addon which writes the .gitkeep file after build for all build types (development, production). 