### PR TITLE
Remove pinned builtin plugin versions from storage

### DIFF
--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
+	"github.com/hashicorp/go-hclog"
 	mongodbatlas "github.com/hashicorp/vault-plugin-database-mongodbatlas"
 	"github.com/hashicorp/vault/helper/builtinplugins"
 	"github.com/hashicorp/vault/helper/namespace"
@@ -1549,6 +1550,15 @@ func TestBackend_AsyncClose(t *testing.T) {
 	case <-timeout.C:
 		t.Error("Hanging plugin caused Close() to take longer than 750ms")
 	case <-done:
+	}
+}
+
+func TestNewDatabaseWrapper_IgnoresBuiltinVersion(t *testing.T) {
+	cluster, sys := getCluster(t)
+	t.Cleanup(cluster.Cleanup)
+	_, err := newDatabaseWrapper(context.Background(), "hana-database-plugin", "v1.0.0+builtin", sys, hclog.Default())
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-test/deep"
 	mongodbatlas "github.com/hashicorp/vault-plugin-database-mongodbatlas"
+	"github.com/hashicorp/vault/helper/builtinplugins"
 	"github.com/hashicorp/vault/helper/namespace"
 	postgreshelper "github.com/hashicorp/vault/helper/testhelpers/postgresql"
 	vaulthttp "github.com/hashicorp/vault/http"
@@ -36,6 +37,7 @@ func getCluster(t *testing.T) (*vault.TestCluster, logical.SystemView) {
 		LogicalBackends: map[string]logical.Factory{
 			"database": Factory,
 		},
+		BuiltinRegistry: builtinplugins.Registry,
 	}
 
 	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{

--- a/builtin/logical/database/path_config_connection.go
+++ b/builtin/logical/database/path_config_connection.go
@@ -319,7 +319,7 @@ func (b *databaseBackend) connectionWriteHandler() framework.OperationFunc {
 			if config.PluginVersion == versions.GetBuiltinVersion(consts.PluginTypeDatabase, config.PluginName) {
 				if builtinShadowed {
 					return logical.ErrorResponse("database plugin %q, version %s not found, as it is"+
-						" overridden by an unversioned plugin of the same name", config.PluginName, config.PluginVersion), nil
+						" overridden by an unversioned plugin of the same name. Omit `plugin_version` to use the unversioned plugin", config.PluginName, config.PluginVersion), nil
 				}
 
 				config.PluginVersion = ""
@@ -458,6 +458,8 @@ func (b *databaseBackend) connectionWriteHandler() framework.OperationFunc {
 }
 
 func storeConfig(ctx context.Context, storage logical.Storage, name string, config *DatabaseConfig) error {
+	// 1.12.0 and 1.12.1 stored builtin plugins in storage, but 1.12.2 reverted
+	// that, so clean up any pre-existing stored builtin versions on write.
 	if versions.IsBuiltinVersion(config.PluginVersion) {
 		config.PluginVersion = ""
 	}

--- a/builtin/logical/database/path_config_connection.go
+++ b/builtin/logical/database/path_config_connection.go
@@ -229,6 +229,12 @@ func (b *databaseBackend) connectionReadHandler() framework.OperationFunc {
 			}
 		}
 
+		if versions.IsBuiltinVersion(config.PluginVersion) {
+			// This gets treated as though it's empty when mounting, and will get
+			// overwritten to be empty when the config is next written. See #18051.
+			config.PluginVersion = ""
+		}
+
 		delete(config.ConnectionDetails, "password")
 		delete(config.ConnectionDetails, "private_key")
 

--- a/builtin/logical/database/path_config_connection_test.go
+++ b/builtin/logical/database/path_config_connection_test.go
@@ -30,6 +30,7 @@ func TestWriteConfig_PluginVersionInStorage(t *testing.T) {
 
 	// Configure a connection
 	writePluginVersion := func() {
+		t.Helper()
 		req := &logical.Request{
 			Operation: logical.UpdateOperation,
 			Path:      "config/plugin-test",
@@ -49,6 +50,7 @@ func TestWriteConfig_PluginVersionInStorage(t *testing.T) {
 	writePluginVersion()
 
 	getPluginVersionFromAPI := func() string {
+		t.Helper()
 		req := &logical.Request{
 			Operation: logical.ReadOperation,
 			Path:      "config/plugin-test",
@@ -85,6 +87,7 @@ func TestWriteConfig_PluginVersionInStorage(t *testing.T) {
 
 	// Check the underlying data, which should still have the version in storage.
 	getPluginVersionFromStorage := func() string {
+		t.Helper()
 		entry, err := config.StorageView.Get(context.Background(), "config/plugin-test")
 		if err != nil {
 			t.Fatal(err)

--- a/builtin/logical/database/path_config_connection_test.go
+++ b/builtin/logical/database/path_config_connection_test.go
@@ -1,0 +1,125 @@
+package database
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/helper/versions"
+	"github.com/hashicorp/vault/sdk/helper/consts"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func TestWriteConfig_PluginVersionInStorage(t *testing.T) {
+	cluster, sys := getCluster(t)
+	defer cluster.Cleanup()
+
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+	config.System = sys
+
+	b, err := Factory(context.Background(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Cleanup(context.Background())
+
+	const hdb = "hana-database-plugin"
+	hdbBuiltin := versions.GetBuiltinVersion(consts.PluginTypeDatabase, hdb)
+
+	// Configure a connection
+	data := map[string]interface{}{
+		"connection_url":    "test",
+		"plugin_name":       hdb,
+		"plugin_version":    hdbBuiltin,
+		"verify_connection": false,
+	}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/plugin-test",
+		Storage:   config.StorageView,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "config/plugin-test",
+		Storage:   config.StorageView,
+		Data:      data,
+	}
+
+	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	if resp.Data["plugin_version"] != "" {
+		t.Fatalf("expected plugin_version empty but got %s", resp.Data["plugin_version"])
+	}
+
+	// Directly store config to get the builtin plugin version into storage,
+	// simulating a write that happened before upgrading to 1.12.2+
+	err = storeConfig(context.Background(), config.StorageView, "plugin-test", &DatabaseConfig{
+		PluginName:    hdb,
+		PluginVersion: hdbBuiltin,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Now replay the read request, and we still shouldn't get the builtin version back.
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	if resp.Data["plugin_version"] != "" {
+		t.Fatalf("expected plugin_version empty but got %s", resp.Data["plugin_version"])
+	}
+}
+
+func TestWriteConfig_HelpfulErrorMessageWhenBuiltinOverridden(t *testing.T) {
+	cluster, sys := getCluster(t)
+	defer cluster.Cleanup()
+
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+	config.System = sys
+
+	b, err := Factory(context.Background(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Cleanup(context.Background())
+
+	const pg = "postgresql-database-plugin"
+	pgBuiltin := versions.GetBuiltinVersion(consts.PluginTypeDatabase, pg)
+
+	// Configure a connection
+	data := map[string]interface{}{
+		"connection_url":    "test",
+		"plugin_name":       pg,
+		"plugin_version":    pgBuiltin,
+		"verify_connection": false,
+	}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/plugin-test",
+		Storage:   config.StorageView,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || !resp.IsError() {
+		t.Fatalf("resp:%#v", resp)
+	}
+	if !strings.Contains(resp.Error().Error(), "overridden by an unversioned plugin") {
+		t.Fatalf("expected overridden error but got: %s", resp.Error())
+	}
+}

--- a/builtin/logical/database/path_config_connection_test.go
+++ b/builtin/logical/database/path_config_connection_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestWriteConfig_PluginVersionInStorage(t *testing.T) {
 	cluster, sys := getCluster(t)
-	defer cluster.Cleanup()
+	t.Cleanup(cluster.Cleanup)
 
 	config := logical.TestBackendConfig()
 	config.StorageView = &logical.InmemStorage{}
@@ -122,7 +122,7 @@ func TestWriteConfig_PluginVersionInStorage(t *testing.T) {
 
 func TestWriteConfig_HelpfulErrorMessageWhenBuiltinOverridden(t *testing.T) {
 	cluster, sys := getCluster(t)
-	defer cluster.Cleanup()
+	t.Cleanup(cluster.Cleanup)
 
 	config := logical.TestBackendConfig()
 	config.StorageView = &logical.InmemStorage{}

--- a/builtin/logical/database/path_rotate_credentials.go
+++ b/builtin/logical/database/path_rotate_credentials.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/vault/helper/versions"
 	v5 "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -137,6 +138,11 @@ func (b *databaseBackend) pathRotateRootCredentialsUpdate() framework.OperationF
 			config.ConnectionDetails = newConfigDetails
 		}
 
+		// 1.12.0 and 1.12.1 stored builtin plugins in storage, but 1.12.2 reverted
+		// that, so clean up any pre-existing stored builtin versions on write.
+		if versions.IsBuiltinVersion(config.PluginVersion) {
+			config.PluginVersion = ""
+		}
 		err = storeConfig(ctx, req.Storage, name, config)
 		if err != nil {
 			return nil, err

--- a/builtin/logical/database/version_wrapper.go
+++ b/builtin/logical/database/version_wrapper.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/vault/helper/versions"
 	v4 "github.com/hashicorp/vault/sdk/database/dbplugin"
 	v5 "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/helper/pluginutil"
@@ -24,6 +25,12 @@ var _ logical.PluginVersioner = databaseVersionWrapper{}
 // newDatabaseWrapper figures out which version of the database the pluginName is referring to and returns a wrapper object
 // that can be used to make operations on the underlying database plugin.
 func newDatabaseWrapper(ctx context.Context, pluginName string, pluginVersion string, sys pluginutil.LookRunnerUtil, logger log.Logger) (dbw databaseVersionWrapper, err error) {
+	// 1.12.0 and 1.12.1 stored plugin version in the config, but that stored
+	// builtin version may disappear from the plugin catalog when Vault is
+	// upgraded, so always reference builtin plugins by an empty version.
+	if versions.IsBuiltinVersion(pluginVersion) {
+		pluginVersion = ""
+	}
 	newDB, err := v5.PluginFactoryVersion(ctx, pluginName, pluginVersion, sys, logger)
 	if err == nil {
 		dbw = databaseVersionWrapper{

--- a/builtin/logical/database/version_wrapper.go
+++ b/builtin/logical/database/version_wrapper.go
@@ -23,7 +23,8 @@ type databaseVersionWrapper struct {
 var _ logical.PluginVersioner = databaseVersionWrapper{}
 
 // newDatabaseWrapper figures out which version of the database the pluginName is referring to and returns a wrapper object
-// that can be used to make operations on the underlying database plugin.
+// that can be used to make operations on the underlying database plugin. If a builtin pluginVersion is provided, it will
+// be ignored.
 func newDatabaseWrapper(ctx context.Context, pluginName string, pluginVersion string, sys pluginutil.LookRunnerUtil, logger log.Logger) (dbw databaseVersionWrapper, err error) {
 	// 1.12.0 and 1.12.1 stored plugin version in the config, but that stored
 	// builtin version may disappear from the plugin catalog when Vault is

--- a/changelog/18051.txt
+++ b/changelog/18051.txt
@@ -1,0 +1,6 @@
+```release-note:change
+plugins: Mounts can no longer be pinned to a specific _builtin_ version. Mounts previously pinned to a specific builtin version will now automatically upgrade to the latest builtin version, and may now be overridden if an unversioned plugin of the same name and type is registered. Mounts using plugin versions without `builtin` in their metadata remain unaffected.
+```
+```release-note:bug
+plugins: Vault upgrades will no longer fail if a mount has been created using an explicit builtin plugin version.
+```

--- a/helper/versions/version.go
+++ b/helper/versions/version.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	semver "github.com/hashicorp/go-version"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/version"
 )
@@ -51,4 +52,20 @@ func GetBuiltinVersion(pluginType consts.PluginType, pluginName string) string {
 	}
 
 	return DefaultBuiltinVersion
+}
+
+func IsBuiltinVersion(v string) bool {
+	semanticVersion, err := semver.NewSemver(v)
+	if err != nil {
+		return false
+	}
+
+	metadataIdentifiers := strings.Split(semanticVersion.Metadata(), ".")
+	for _, identifier := range metadataIdentifiers {
+		if identifier == "builtin" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/helper/versions/version_test.go
+++ b/helper/versions/version_test.go
@@ -1,0 +1,23 @@
+package versions
+
+import "testing"
+
+func TestIsBuiltinVersion(t *testing.T) {
+	for _, tc := range []struct {
+		version string
+		builtin bool
+	}{
+		{"v1.0.0+builtin", true},
+		{"v2.3.4+builtin.vault", true},
+		{"1.0.0+builtin.anythingelse", true},
+		{"v1.0.0+other.builtin", true},
+		{"v1.0.0+builtinbutnot", false},
+		{"v1.0.0", false},
+		{"not-a-semver", false},
+	} {
+		builtin := IsBuiltinVersion(tc.version)
+		if builtin != tc.builtin {
+			t.Fatalf("%s should give: %v, but got %v", tc.version, tc.builtin, builtin)
+		}
+	}
+}

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -636,6 +636,12 @@ func (c *Core) loadCredentials(ctx context.Context) error {
 			needPersist = true
 		}
 
+		// Don't store built-in version in the mount table, to make upgrades smoother.
+		if versions.IsBuiltinVersion(entry.Version) {
+			entry.Version = ""
+			needPersist = true
+		}
+
 		if entry.NamespaceID == "" {
 			entry.NamespaceID = namespace.RootNamespaceID
 			needPersist = true

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -635,20 +635,12 @@ func getVersion(d *framework.FieldData) (version string, builtin bool, err error
 			return "", false, fmt.Errorf("version %q is not a valid semantic version: %w", version, err)
 		}
 
-		metadataIdentifiers := strings.Split(semanticVersion.Metadata(), ".")
-		for _, identifier := range metadataIdentifiers {
-			if identifier == "builtin" {
-				builtin = true
-				break
-			}
-		}
-
 		// Canonicalize the version string.
 		// Add the 'v' back in, since semantic version strips it out, and we want to be consistent with internal plugins.
 		version = "v" + semanticVersion.String()
 	}
 
-	return version, builtin, nil
+	return version, versions.IsBuiltinVersion(version), nil
 }
 
 func (b *SystemBackend) handlePluginReloadUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2634,7 +2634,7 @@ func (b *SystemBackend) validateVersion(ctx context.Context, version string, plu
 			if err == nil && !unversionedPlugin.Builtin {
 				// Builtin is overridden, return "not found" error.
 				return "", logical.ErrorResponse("%s plugin %q, version %s not found, as it is"+
-					" overridden by an unversioned plugin of the same name", pluginType.String(), pluginName, version), nil
+					" overridden by an unversioned plugin of the same name. Omit `plugin_version` to use the unversioned plugin", pluginType.String(), pluginName, version), nil
 			}
 
 			// Don't put the builtin version in storage. Ensures that builtins

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -5200,6 +5200,7 @@ func TestCanUnseal_WithNonExistentBuiltinPluginVersion_InMountStorage(t *testing
 		{"approle", consts.PluginTypeCredential, "auth"},
 	}
 	readMountConfig := func(pluginName, mountTable string) map[string]interface{} {
+		t.Helper()
 		req := logical.TestRequest(t, logical.ReadOperation, mountTable+"/"+pluginName)
 		resp, err := core.systemBackend.HandleRequest(ctx, req)
 		if err != nil {
@@ -5272,11 +5273,11 @@ func TestCanUnseal_WithNonExistentBuiltinPluginVersion_InMountStorage(t *testing
 
 	for _, tc := range testCases {
 		// Storage should have been upgraded during the unseal, so plugin version
-		//should be empty again.
+		// should be empty again.
 		config := readMountConfig(tc.pluginName, tc.mountTable)
 		pluginVersion, ok := config["plugin_version"]
 		if !ok || pluginVersion != "" {
-			t.Fatalf("expected empty plugin version in config: %#v", config)
+			t.Errorf("expected empty plugin version in config: %#v", config)
 		}
 	}
 }

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -5122,26 +5122,68 @@ func TestValidateVersion(t *testing.T) {
 		pluginName         string
 		pluginVersion      string
 		pluginType         consts.PluginType
-		expectLogicalError bool
+		expectLogicalError string
 		expectedVersion    string
 	}{
-		"default, nothing in nothing out": {"kubernetes", "", consts.PluginTypeCredential, false, ""},
-		"builtin specified, empty out":    {"kubernetes", k8sAuthBuiltin, consts.PluginTypeCredential, false, ""},
-		"not canonical is ok":             {"kubernetes", "1.0.0", consts.PluginTypeCredential, false, "v1.0.0"},
-		"not a semantic version, error":   {"kubernetes", "not-a-version", consts.PluginTypeCredential, true, ""},
+		"default, nothing in nothing out":   {"kubernetes", "", consts.PluginTypeCredential, "", ""},
+		"builtin specified, empty out":      {"kubernetes", k8sAuthBuiltin, consts.PluginTypeCredential, "", ""},
+		"not canonical is ok":               {"kubernetes", "1.0.0", consts.PluginTypeCredential, "", "v1.0.0"},
+		"not a semantic version, error":     {"kubernetes", "not-a-version", consts.PluginTypeCredential, "not a valid semantic version", ""},
+		"can't select non-builtin token":    {"token", "v1.0.0", consts.PluginTypeCredential, "cannot select non-builtin version", ""},
+		"can't select non-builtin identity": {"identity", "v1.0.0", consts.PluginTypeSecrets, "cannot select non-builtin version", ""},
 	} {
 		t.Run(name, func(t *testing.T) {
 			version, resp, err := b.validateVersion(context.Background(), tc.pluginVersion, tc.pluginName, tc.pluginType)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if tc.expectLogicalError {
+			if tc.expectLogicalError != "" {
 				if resp == nil || !resp.IsError() || resp.Error() == nil {
 					t.Errorf("expected logical error but got none, resp: %#v", resp)
+				}
+				if !strings.Contains(resp.Error().Error(), tc.expectLogicalError) {
+					t.Errorf("expected logical error to contain %q, but got: %s", tc.expectLogicalError, resp.Error())
 				}
 			} else if version != tc.expectedVersion {
 				t.Errorf("expected version %q but got %q", tc.expectedVersion, version)
 			}
 		})
+	}
+}
+
+func TestValidateVersion_HelpfulErrorWhenBuiltinOverridden(t *testing.T) {
+	core, _, _ := TestCoreUnsealed(t)
+	tempDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	core.pluginCatalog.directory = tempDir
+	b := core.systemBackend
+
+	// Shadow a builtin and test getting a helpful error back.
+	file, err := ioutil.TempFile(tempDir, "temp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	command := filepath.Base(file.Name())
+	err = core.pluginCatalog.Set(context.Background(), "kubernetes", consts.PluginTypeCredential, "", command, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// When we validate the version now, we should get a special error message
+	// about why the builtin isn't there.
+	k8sAuthBuiltin := versions.GetBuiltinVersion(consts.PluginTypeCredential, "kubernetes")
+	_, resp, err := b.validateVersion(context.Background(), k8sAuthBuiltin, "kubernetes", consts.PluginTypeCredential)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || !resp.IsError() || resp.Error() == nil {
+		t.Errorf("expected logical error but got none, resp: %#v", resp)
+	}
+	if !strings.Contains(resp.Error().Error(), "overridden by an unversioned plugin of the same name") {
+		t.Errorf("expected logical error to contain overridden message, but got: %s", resp.Error())
 	}
 }

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -727,8 +727,7 @@ func (c *Core) builtinTypeFromMountEntry(ctx context.Context, entry *MountEntry)
 		return consts.PluginTypeUnknown
 	}
 
-	// Builtin plugins should contain the "builtin" string in their RunningVersion
-	if !strings.Contains(entry.RunningVersion, "builtin") {
+	if !versions.IsBuiltinVersion(entry.RunningVersion) {
 		return consts.PluginTypeUnknown
 	}
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1317,6 +1317,11 @@ func (c *Core) runMountUpdates(ctx context.Context, needPersist bool) error {
 			needPersist = true
 		}
 
+		// Don't store built-in version in the mount table, to make upgrades smoother.
+		if versions.IsBuiltinVersion(entry.Version) {
+			entry.Version = ""
+			needPersist = true
+		}
 	}
 	// Done if we have restored the mount table and we don't need
 	// to persist

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/helper/versions"
 	"github.com/hashicorp/vault/sdk/helper/compressutil"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -206,7 +207,7 @@ func TestCore_Mount_secrets_builtin_RunningVersion(t *testing.T) {
 
 	raw, _ := c.router.root.Get(match)
 	// we override the running version of builtins
-	if !strings.Contains(raw.(*routeEntry).mountEntry.RunningVersion, "builtin") {
+	if !versions.IsBuiltinVersion(raw.(*routeEntry).mountEntry.RunningVersion) {
 		t.Errorf("Expected mount to have builtin version but got %s", raw.(*routeEntry).mountEntry.RunningVersion)
 	}
 }

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -832,15 +832,15 @@ func (c *PluginCatalog) get(ctx context.Context, name string, pluginType consts.
 	}
 
 	builtinVersion := versions.GetBuiltinVersion(pluginType, name)
-	if version == builtinVersion {
-		// Don't return the builtin if it's shadowed by an unversioned plugin.
-		unversioned, err := c.get(ctx, name, pluginType, "")
-		if err == nil && unversioned != nil && !unversioned.Builtin {
-			return nil, nil
+	if version == "" || version == builtinVersion {
+		if version == builtinVersion {
+			// Don't return the builtin if it's shadowed by an unversioned plugin.
+			unversioned, err := c.get(ctx, name, pluginType, "")
+			if err == nil && unversioned != nil && !unversioned.Builtin {
+				return nil, nil
+			}
 		}
-		version = ""
-	}
-	if version == "" {
+
 		// Look for builtin plugins
 		if factory, ok := c.builtinRegistry.Get(name, pluginType); ok {
 			return &pluginutil.PluginRunner{

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -832,7 +832,15 @@ func (c *PluginCatalog) get(ctx context.Context, name string, pluginType consts.
 	}
 
 	builtinVersion := versions.GetBuiltinVersion(pluginType, name)
-	if version == "" || version == builtinVersion {
+	if version == builtinVersion {
+		// Don't return the builtin if it's shadowed by an unversioned plugin.
+		unversioned, err := c.get(ctx, name, pluginType, "")
+		if err == nil && unversioned != nil && !unversioned.Builtin {
+			return nil, nil
+		}
+		version = ""
+	}
+	if version == "" {
 		// Look for builtin plugins
 		if factory, ok := c.builtinRegistry.Get(name, pluginType); ok {
 			return &pluginutil.PluginRunner{

--- a/vault/plugin_catalog_test.go
+++ b/vault/plugin_catalog_test.go
@@ -40,11 +40,18 @@ func TestPluginCatalog_CRUD(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 
+	// Get it again, explicitly specifying builtin version
+	builtinVersion := versions.GetBuiltinVersion(consts.PluginTypeDatabase, pluginName)
+	p2, err := core.pluginCatalog.Get(context.Background(), pluginName, consts.PluginTypeDatabase, builtinVersion)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
 	expectedBuiltin := &pluginutil.PluginRunner{
 		Name:    pluginName,
 		Type:    consts.PluginTypeDatabase,
 		Builtin: true,
-		Version: versions.GetBuiltinVersion(consts.PluginTypeDatabase, pluginName),
+		Version: builtinVersion,
 	}
 	expectedBuiltin.BuiltinFactory, _ = builtinplugins.Registry.Get(pluginName, consts.PluginTypeDatabase)
 
@@ -53,8 +60,12 @@ func TestPluginCatalog_CRUD(t *testing.T) {
 	}
 	expectedBuiltin.BuiltinFactory = nil
 	p.BuiltinFactory = nil
+	p2.BuiltinFactory = nil
 	if !reflect.DeepEqual(p, expectedBuiltin) {
 		t.Fatalf("expected did not match actual, got %#v\n expected %#v\n", p, expectedBuiltin)
+	}
+	if !reflect.DeepEqual(p2, expectedBuiltin) {
+		t.Fatalf("expected did not match actual, got %#v\n expected %#v\n", p2, expectedBuiltin)
 	}
 
 	// Set a plugin, test overwriting a builtin plugin
@@ -74,6 +85,16 @@ func TestPluginCatalog_CRUD(t *testing.T) {
 	p, err = core.pluginCatalog.Get(context.Background(), pluginName, consts.PluginTypeDatabase, "")
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+
+	// Get it again, explicitly specifying builtin version.
+	// This time it should fail because it was overwritten.
+	p2, err = core.pluginCatalog.Get(context.Background(), pluginName, consts.PluginTypeDatabase, builtinVersion)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if p2 != nil {
+		t.Fatalf("expected no result, got: %#v", p2)
 	}
 
 	expected := &pluginutil.PluginRunner{

--- a/vault/plugin_catalog_test.go
+++ b/vault/plugin_catalog_test.go
@@ -383,7 +383,7 @@ func TestPluginCatalog_ListVersionedPlugins(t *testing.T) {
 			if !plugin.Builtin {
 				t.Fatalf("expected %v plugin to be builtin", plugin)
 			}
-			if plugin.SemanticVersion.Metadata() != "builtin" && plugin.SemanticVersion.Metadata() != "builtin.vault" {
+			if !versions.IsBuiltinVersion(plugin.Version) {
 				t.Fatalf("expected +builtin metadata but got %s", plugin.Version)
 			}
 		}


### PR DESCRIPTION
Addresses bug described in the 1.12 upgrade guide: https://developer.hashicorp.com/vault/docs/upgrading/upgrade-to-1.12.x#pinning-to-builtin-plugin-versions-may-cause-failure-on-upgrade.

In a nutshell, when we try to start a plugin after upgrading, if it has a builtin version stored in the mount table and that version subsequently disappeared from catalog due to the upgrade, we won't be able to mount it. To fix this, the main idea is to stop storing version information for builtin plugins, and rely on the pre-existing behaviour that not specifying a version selects the builtin (unless it's been shadowed by an unversioned external plugin).

2 main changes, that need to be done for each of the 3 plugin types:
- Stop storing the builtin version for newly mounted plugins
- Clean up storage in existing mounts where we stored the builtin version

Stopping storage for new mounts is easy enough. Cleaning up existing auth and secrets mounts also seems relatively straightforward thanks to some existing logic for upgrading their storage.

Unfortunately, database plugins don't seem to have any such existing capability, instead this relies on fixing storage whenever it's next written to for each db plugin. That means databases also need an extra shim to stop mounting from failing, because we may mount a plugin before the config has been fixed in storage. We also delete builtin plugin versions from a config read response, so the out of date storage is invisible to users unless they poke around in raw endpoints.

The approach also means users who have a builtin version pinned, and an unversioned plugin of the same name registered, will start running the unversioned plugin on upgrading. That deserves a callout in the changelog, but I don't expect it to be problematic for many people, as most people using versions for builtins will probably also use versions for externals. Plus it's still a very new feature, and the delta between the builtin and external versions is likely small.

I've also updated the plugin catalog to not return a builtin if it has been shadowed by an unversioned external plugin of the same name.