### PR TITLE
UI: refactor pki role form to reuse PkiKeyParameters component

### DIFF
--- a/ui/app/models/pki/role.js
+++ b/ui/app/models/pki/role.js
@@ -119,24 +119,7 @@ export default class PkiRoleModel extends Model {
     label: 'Signature bits',
     subText: `Only applicable for key_type 'RSA'. Ignore for other key types.`,
     defaultValue: 0,
-    possibleValues: [
-      {
-        value: 0,
-        displayName: 'Defaults to 0',
-      },
-      {
-        value: 256,
-        displayName: '256 for SHA-2-256',
-      },
-      {
-        value: 384,
-        displayName: '384 for SHA-2-384',
-      },
-      {
-        value: 512,
-        displayName: '512 for SHA-2-5124',
-      },
-    ],
+    possibleValues: [0, 256, 384, 512],
   })
   signatureBits;
   /* End of overriding Key parameters options */

--- a/ui/app/models/pki/role.js
+++ b/ui/app/models/pki/role.js
@@ -287,6 +287,11 @@ export default class PkiRoleModel extends Model {
           docLink: '/api-docs/secret/pki#allowed_domains',
         },
       },
+      'Key parameters': {
+        header: {
+          text: `These are the parameters for generating or validating the certificate's key material.`,
+        },
+      },
       'Subject Alternative Name (SAN) Options': {
         header: {
           text: `Subject Alternative Names (SANs) are identities (domains, IP addresses, and URIs) Vault attaches to the requested certificates.`,

--- a/ui/lib/pki/addon/components/pki-key-parameters.hbs
+++ b/ui/lib/pki/addon/components/pki-key-parameters.hbs
@@ -1,67 +1,26 @@
-{{#let (camelize (concat "show" @group)) as |prop|}}
-  <ToggleButton
-    @isOpen={{get @model prop}}
-    @openLabel={{concat "Hide " @group}}
-    @closedLabel={{@group}}
-    @onClick={{fn (mut (get @model prop))}}
-    class="is-block"
-    data-test-toggle-group={{@group}}
-  />
-  {{#if (get @model prop)}}
-    <div class="box is-tall is-marginless">
-      <FormFieldLabel
-        for="keyParametersLabel"
-        @subText="These are the parameters for generating or validating the certificate's key material."
-      />
-      {{#each @model.fieldGroups as |fieldGroup|}}
-        {{#each-in fieldGroup as |group fields|}}
-          {{#if (eq group "Key parameters")}}
-            {{#each fields as |attr|}}
-              {{#if (eq attr.name "keyBits")}}
-                <div class="field">
-                  <FormFieldLabel for={{attr.name}} @label={{attr.options.label}} />
-                  <div class="control is-expanded">
-                    <div class="select is-fullwidth">
-                      <select
-                        name={{attr.name}}
-                        id={{attr.name}}
-                        onchange={{this.onKeyBitsChange}}
-                        data-test-input={{attr.name}}
-                      >
-                        {{#each this.keyBitOptions as |val|}}
-                          <option selected={{eq (get @model this.valuePath) (or val.value val)}} value={{val}}>
-                            {{val}}
-                          </option>
-                        {{/each}}
-                      </select>
-                    </div>
-                  </div>
-                </div>
-              {{else}}
-                <div class="field">
-                  <FormFieldLabel for={{attr.name}} @label={{attr.options.label}} />
-                  <div class="control is-expanded">
-                    <div class="select is-fullwidth">
-                      <select
-                        name={{attr.name}}
-                        id={{attr.name}}
-                        onchange={{fn this.onSignatureBitsOrKeyTypeChange attr.name}}
-                        data-test-input={{attr.name}}
-                      >
-                        {{#each (path-or-array attr.options.possibleValues @model) as |val|}}
-                          <option selected={{eq (get @model this.valuePath) (or val.value val)}} value={{val.value}}>
-                            {{or val.displayName val}}
-                          </option>
-                        {{/each}}
-                      </select>
-                    </div>
-                  </div>
-                </div>
-              {{/if}}
+{{#each @fields as |attr|}}
+  {{#if (eq attr.name "keyBits")}}
+    <div class="field">
+      <FormFieldLabel for={{attr.name}} @label={{attr.options.label}} />
+      <div class="control is-expanded">
+        <div class="select is-fullwidth">
+          <select name={{attr.name}} id={{attr.name}} onchange={{this.onKeyBitsChange}} data-test-input={{attr.name}}>
+            {{#each this.keyBitOptions as |val|}}
+              <option selected={{eq (get @model this.valuePath) (or val.value val)}} value={{val}}>
+                {{val}}
+              </option>
             {{/each}}
-          {{/if}}
-        {{/each-in}}
-      {{/each}}
+          </select>
+        </div>
+      </div>
     </div>
+  {{else}}
+    <FormField
+      data-test-field={{true}}
+      @attr={{attr}}
+      @model={{@model}}
+      @modelValidations={{@modelValidations}}
+      @showHelpText={{false}}
+    />
   {{/if}}
-{{/let}}
+{{/each}}

--- a/ui/lib/pki/addon/components/pki-key-parameters.hbs
+++ b/ui/lib/pki/addon/components/pki-key-parameters.hbs
@@ -16,11 +16,12 @@
     </div>
   {{else}}
     <FormField
-      data-test-field={{true}}
+      data-test-field={{attr}}
       @attr={{attr}}
       @model={{@model}}
       @modelValidations={{@modelValidations}}
       @showHelpText={{false}}
+      @onChange={{this.onSignatureBitsOrKeyTypeChange}}
     />
   {{/if}}
 {{/each}}

--- a/ui/lib/pki/addon/components/pki-key-parameters.js
+++ b/ui/lib/pki/addon/components/pki-key-parameters.js
@@ -21,6 +21,7 @@ const KEY_BITS_OPTIONS = {
 };
 
 export default class PkiKeyParameters extends Component {
+  // TODO clarify types here
   get keyBitOptions() {
     return KEY_BITS_OPTIONS[this.args.model.keyType];
   }
@@ -35,10 +36,9 @@ export default class PkiKeyParameters extends Component {
 
   @action onSignatureBitsOrKeyTypeChange(name, selection) {
     if (name === 'signatureBits') {
-      this.args.model.set(name, Number(selection.target.value));
+      this.args.model.set(name, Number(selection));
     }
     if (name === 'keyType') {
-      this.args.model.set(name, selection.target.value);
       this.args.model.set('keyBits', this.keyBitsDefault);
     }
   }

--- a/ui/lib/pki/addon/components/pki-key-parameters.js
+++ b/ui/lib/pki/addon/components/pki-key-parameters.js
@@ -3,14 +3,14 @@ import { action } from '@ember/object';
 
 /**
  * @module PkiKeyParameters
- * PkiKeyParameters components are used to set the default and update the key_bits pki role api param whenever the key_type changes.
- * key_bits is conditional on key_type and should be set as a default value whenever key_type changes.
+ * PkiKeyParameters components are used to display a list of key bit options depending on the selected key type.
+ * If the component renders in a group, other attrs may be passed in and will be rendered using the <FormField> component
  * @example
  * ```js
- * <PkiKeyParameters @model={@model} @group={group}/>
+ * <PkiKeyParameters @model={{@model}} @fields={{fields}}/>
  * ```
  * @param {class} model - The pki/role model.
- * @param {string} group - The name of the group created in the model. In this case, it's the "Key parameters" group.
+ * @param {string} fields - The name of the fields created in the model. In this case, it's the "Key parameters" fields.
  */
 
 const KEY_BITS_OPTIONS = {

--- a/ui/lib/pki/addon/components/pki-key-usage.hbs
+++ b/ui/lib/pki/addon/components/pki-key-usage.hbs
@@ -1,45 +1,31 @@
-{{#let (camelize (concat "show" @group)) as |prop|}}
-  <ToggleButton
-    @isOpen={{get @model prop}}
-    @openLabel={{concat "Hide " @group}}
-    @closedLabel={{@group}}
-    @onClick={{fn (mut (get @model prop))}}
-    class="is-block"
-    data-test-toggle-group={{@group}}
+<CheckboxGrid
+  @name="keyUsage"
+  @label="Key usage"
+  @subText="Specifies the default key usage constraint on the issued certificate. To specify no default key_usage constraints, uncheck every item in this list."
+  @fields={{this.keyUsageFields}}
+  @value={{@model.keyUsage}}
+  @onChange={{this.checkboxChange}}
+  data-test-key-usage-key-usage-checkboxes
+/>
+<CheckboxGrid
+  @name="extKeyUsage"
+  @label="Extended key usage"
+  @subText="Specifies the default key usage constraint on the issued certificate. To specify no default ext_key_usage constraints, uncheck every item in this list."
+  @fields={{this.extKeyUsageFields}}
+  @value={{@model.extKeyUsage}}
+  @onChange={{this.checkboxChange}}
+  class="has-top-margin-s"
+  data-test-key-usage-ext-key-usage-checkboxes
+/>
+<div class="has-top-margin-xxl">
+  <StringList
+    data-test-input="extKeyUsageOids"
+    @label="Extended key usage oids"
+    @inputValue={{get @model "extKeyUsageOids"}}
+    @onChange={{this.onStringListChange}}
+    @attrName="extKeyUsageOids"
+    @subText="A list of extended key usage oids. Add one item per row."
+    @showHelpText={{false}}
+    @hideFormSection={{true}}
   />
-  {{#if (get @model prop)}}
-    <div class="box is-tall is-marginless" data-test-surrounding-div={{@group}}>
-      <CheckboxGrid
-        @name="keyUsage"
-        @label="Key usage"
-        @subText="Specifies the default key usage constraint on the issued certificate. To specify no default key_usage constraints, uncheck every item in this list."
-        @fields={{this.keyUsageFields}}
-        @value={{@model.keyUsage}}
-        @onChange={{this.checkboxChange}}
-        data-test-key-usage-key-usage-checkboxes
-      />
-      <CheckboxGrid
-        @name="extKeyUsage"
-        @label="Extended key usage"
-        @subText="Specifies the default key usage constraint on the issued certificate. To specify no default ext_key_usage constraints, uncheck every item in this list."
-        @fields={{this.extKeyUsageFields}}
-        @value={{@model.extKeyUsage}}
-        @onChange={{this.checkboxChange}}
-        class="has-top-margin-s"
-        data-test-key-usage-ext-key-usage-checkboxes
-      />
-      <div class="has-top-margin-xxl">
-        <StringList
-          data-test-input="extKeyUsageOids"
-          @label="Extended key usage oids"
-          @inputValue={{get @model "extKeyUsageOids"}}
-          @onChange={{this.onStringListChange}}
-          @attrName="extKeyUsageOids"
-          @subText="A list of extended key usage oids. Add one item per row."
-          @showHelpText={{false}}
-          @hideFormSection={{true}}
-        />
-      </div>
-    </div>
-  {{/if}}
-{{/let}}
+</div>

--- a/ui/lib/pki/addon/components/pki-role-form.hbs
+++ b/ui/lib/pki/addon/components/pki-role-form.hbs
@@ -48,10 +48,7 @@
           {{/each}}
         {{else if (eq group "Key usage")}}
           <PkiKeyUsage @model={{@model}} @group={{group}} />
-        {{else if (eq group "Key parameters")}}
-          <PkiKeyParameters @model={{@model}} @group={{group}} />
         {{else}}
-          {{! Groups hidden behind Toggles }}
           {{#let (camelize (concat "show" group)) as |prop|}}
             <ToggleButton
               @isOpen={{get @model prop}}
@@ -63,38 +60,42 @@
             />
             {{#if (get @model prop)}}
               <div class="box is-marginless">
-                {{#let (get @model.fieldGroupsInfo group) as |groupInfo|}}
-                  {{! Header }}
-                  {{#if groupInfo.header}}
+                {{#let (get @model.fieldGroupsInfo group) as |toggleGroup|}}
+                  {{! HEADER }}
+                  {{#if toggleGroup.header}}
                     <div class="has-bottom-margin-s">
                       <FormFieldLabel
-                        for={{groupInfo.header.name}}
-                        @label={{groupInfo.header.label}}
-                        @subText={{groupInfo.header.text}}
-                        @docLink={{groupInfo.header.docLink}}
+                        for={{toggleGroup.header.name}}
+                        @label={{toggleGroup.header.label}}
+                        @subText={{toggleGroup.header.text}}
+                        @docLink={{toggleGroup.header.docLink}}
                       />
                     </div>
                   {{/if}}
-                  {{! Fields }}
-                  {{#each fields as |attr|}}
-                    <FormField
-                      data-test-field={{true}}
-                      @attr={{attr}}
-                      @model={{@model}}
-                      @modelValidations={{@modelValidations}}
-                      @showHelpText={{false}}
-                    >
-                      {{yield attr}}
-                    </FormField>
-                  {{/each}}
-                  {{! Footer }}
-                  {{#if groupInfo.footer}}
+                  {{! FIELDS }}
+                  {{#if (eq group "Key parameters")}}
+                    <PkiKeyParameters @model={{@model}} @fields={{fields}} />
+                  {{else}}
+                    {{#each fields as |attr|}}
+                      <FormField
+                        data-test-field={{true}}
+                        @attr={{attr}}
+                        @model={{@model}}
+                        @modelValidations={{@modelValidations}}
+                        @showHelpText={{false}}
+                      >
+                        {{yield attr}}
+                      </FormField>
+                    {{/each}}
+                  {{/if}}
+                  {{! FOOTER }}
+                  {{#if toggleGroup.footer}}
                     <p class="sub-text">
                       <Icon @name="info" />
-                      {{groupInfo.footer.text}}
-                      {{#if groupInfo.footer.docLink}}
-                        <DocLink @path={{groupInfo.footer.docLink}}>
-                          {{groupInfo.footer.docText}}
+                      {{toggleGroup.footer.text}}
+                      {{#if toggleGroup.footer.docLink}}
+                        <DocLink @path={{toggleGroup.footer.docLink}}>
+                          {{toggleGroup.footer.docText}}
                         </DocLink>
                       {{/if}}
                     </p>

--- a/ui/lib/pki/addon/components/pki-role-form.hbs
+++ b/ui/lib/pki/addon/components/pki-role-form.hbs
@@ -37,7 +37,7 @@
         {{#if (eq group "default")}}
           {{#each fields as |attr|}}
             <FormField
-              data-test-field={{true}}
+              data-test-field={{attr}}
               @attr={{attr}}
               @model={{@model}}
               @modelValidations={{this.modelValidations}}
@@ -46,8 +46,6 @@
               <RadioSelectTtlOrString @attr={{attr}} @model={{@model}} />
             </FormField>
           {{/each}}
-        {{else if (eq group "Key usage")}}
-          <PkiKeyUsage @model={{@model}} @group={{group}} />
         {{else}}
           {{#let (camelize (concat "show" group)) as |prop|}}
             <ToggleButton
@@ -59,7 +57,7 @@
               data-test-toggle-group={{group}}
             />
             {{#if (get @model prop)}}
-              <div class="box is-marginless">
+              <div class="box is-tall is-marginless" data-test-toggle-div={{group}}>
                 {{#let (get @model.fieldGroupsInfo group) as |toggleGroup|}}
                   {{! HEADER }}
                   {{#if toggleGroup.header}}
@@ -73,7 +71,9 @@
                     </div>
                   {{/if}}
                   {{! FIELDS }}
-                  {{#if (eq group "Key parameters")}}
+                  {{#if (eq group "Key usage")}}
+                    <PkiKeyUsage @model={{@model}} />
+                  {{else if (eq group "Key parameters")}}
                     <PkiKeyParameters @model={{@model}} @fields={{fields}} />
                   {{else}}
                     {{#each fields as |attr|}}

--- a/ui/tests/integration/components/pki/pki-key-parameters-test.js
+++ b/ui/tests/integration/components/pki/pki-key-parameters-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, fillIn } from '@ember/test-helpers';
+import { render, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupEngine } from 'ember-engines/test-support';
 import { SELECTORS } from 'vault/tests/helpers/pki-engine';
@@ -13,6 +13,7 @@ module('Integration | Component | pki-key-parameters', function (hooks) {
     this.store = this.owner.lookup('service:store');
     this.model = this.store.createRecord('pki/role');
     this.model.backend = 'pki';
+    [this.fields] = Object.values(this.model.fieldGroups.find((g) => g['Key parameters']));
   });
 
   test('it should render the component and display the correct defaults', async function (assert) {
@@ -22,13 +23,12 @@ module('Integration | Component | pki-key-parameters', function (hooks) {
       <div class="has-top-margin-xxl">
         <PkiKeyParameters
           @model={{this.model}}
-          @group="Key parameters"
+          @fields={{this.fields}}
         />
        </div>
   `,
       { owner: this.engine }
     );
-    await click(SELECTORS.keyParams);
     assert.dom(SELECTORS.keyType).hasValue('rsa');
     assert.dom(SELECTORS.keyBits).hasValue('2048');
     assert.dom(SELECTORS.signatureBits).hasValue('0');
@@ -41,7 +41,7 @@ module('Integration | Component | pki-key-parameters', function (hooks) {
       <div class="has-top-margin-xxl">
         <PkiKeyParameters
           @model={{this.model}}
-          @group="Key parameters"
+          @fields={{this.fields}}
         />
        </div>
   `,
@@ -54,7 +54,6 @@ module('Integration | Component | pki-key-parameters', function (hooks) {
       0,
       'sets the default value for signature_bits on the model.'
     );
-    await click(SELECTORS.keyParams);
     await fillIn(SELECTORS.keyType, 'ec');
     assert.strictEqual(this.model.keyType, 'ec', 'sets the new selected value for key_type on the model.');
     assert.strictEqual(

--- a/ui/tests/integration/components/pki/pki-key-usage-test.js
+++ b/ui/tests/integration/components/pki/pki-key-usage-test.js
@@ -16,33 +16,23 @@ module('Integration | Component | pki-key-usage', function (hooks) {
   });
 
   test('it should render the component', async function (assert) {
-    assert.expect(7);
+    assert.expect(6);
     await render(
       hbs`
       <div class="has-top-margin-xxl">
         <PkiKeyUsage
           @model={{this.model}}
-          @group="Key usage"
         />
        </div>
   `,
       { owner: this.engine }
     );
-    await click(SELECTORS.keyUsage);
     assert.strictEqual(findAll('.b-checkbox').length, 19, 'it render 19 checkboxes');
     assert.dom(SELECTORS.digitalSignature).isChecked('Digital Signature is true by default');
     assert.dom(SELECTORS.keyAgreement).isChecked('Key Agreement is true by default');
     assert.dom(SELECTORS.keyEncipherment).isChecked('Key Encipherment is true by default');
     assert.dom(SELECTORS.any).isNotChecked('Any is false by default');
     assert.dom(SELECTORS.extKeyUsageOids).exists('Extended Key usage oids renders');
-
-    // check is flexbox by checking the height of the box
-    const groupBoxHeight = document.querySelector('[data-test-surrounding-div="Key usage"]').clientHeight;
-    assert.strictEqual(
-      groupBoxHeight,
-      518,
-      'renders the correct height of the box element if the component is rending as a flexbox'
-    );
   });
 
   test('it should set the model properties of key_usage and ext_key_usage based on the checkbox selections', async function (assert) {
@@ -52,14 +42,12 @@ module('Integration | Component | pki-key-usage', function (hooks) {
       <div class="has-top-margin-xxl">
         <PkiKeyUsage
           @model={{this.model}}
-          @group="Key usage"
         />
        </div>
   `,
       { owner: this.engine }
     );
 
-    await click(SELECTORS.keyUsage);
     await click(SELECTORS.digitalSignature);
     await click(SELECTORS.any);
     await click(SELECTORS.serverAuth);

--- a/ui/tests/integration/components/pki/pki-role-form-test.js
+++ b/ui/tests/integration/components/pki/pki-role-form-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, fillIn } from '@ember/test-helpers';
+import { render, click, fillIn, find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupEngine } from 'ember-engines/test-support';
 import { SELECTORS } from 'vault/tests/helpers/pki-engine';
@@ -46,7 +46,7 @@ module('Integration | Component | pki-role-form', function (hooks) {
 
   test('it should save a new pki role with various options selected', async function (assert) {
     // Key usage, Key params and Not valid after options are tested in their respective component tests
-    assert.expect(9);
+    assert.expect(10);
     this.server.post(`/${this.model.backend}/roles/test-role`, (schema, req) => {
       assert.ok(true, 'Request made to save role');
       const request = JSON.parse(req.requestBody);
@@ -101,6 +101,14 @@ module('Integration | Component | pki-role-form', function (hooks) {
     await fillIn(
       '[data-test-input="allowedSerialNumbers"] [data-test-string-list-input="0"]',
       'some-serial-number'
+    );
+    await click(SELECTORS.keyUsage);
+    // check is flexbox by checking the height of the box
+    const groupBoxHeight = find('[data-test-toggle-div="Key usage"]').clientHeight;
+    assert.strictEqual(
+      groupBoxHeight,
+      518,
+      'renders the correct height of the box element if the component is rending as a flexbox'
     );
     await click(SELECTORS.roleCreateButton);
   });


### PR DESCRIPTION
This PR removes any `<ToggleGroup>`-ing from the new pki form components to the parent so they can be reused elsewhere