### PR TITLE
Remove ENOS autopilot tests from 1.10.x branch

### DIFF
--- a/.github/enos-run-matrices/artifactory-ent.json
+++ b/.github/enos-run-matrices/artifactory-ent.json
@@ -31,14 +31,6 @@
     {
       "scenario": "upgrade arch:amd64 artifact_source:artifactory backend:raft consul_version:1.13.2 distro:ubuntu edition:ent seal:awskms artifact_type:bundle",
       "aws_region": "us-east-2"
-    },
-    {
-      "scenario": "autopilot arch:amd64 artifact_source:artifactory distro:ubuntu edition:ent seal:awskms artifact_type:bundle",
-      "aws_region": "us-west-1"
-    },
-    {
-      "scenario": "autopilot arch:arm64 artifact_source:artifactory distro:rhel edition:ent seal:shamir artifact_type:bundle",
-      "aws_region": "us-west-2"
     }
   ]
 }

--- a/.github/enos-run-matrices/crt-ent.json
+++ b/.github/enos-run-matrices/crt-ent.json
@@ -15,10 +15,6 @@
     {
       "scenario": "upgrade backend:consul consul_version:1.12.5 distro:rhel seal:awskms arch:amd64 artifact_source:crt edition:ent artifact_type:bundle",
       "aws_region": "us-west-2"
-    },
-    {
-      "scenario": "autopilot distro:ubuntu seal:shamir arch:amd64 artifact_source:crt edition:ent artifact_type:bundle",
-      "aws_region": "us-west-1"
     }
   ]
 }


### PR DESCRIPTION
 - Replicate the change (ENT commit: [db10d462f979ef2b35f53366c15c1e0e2bb80ee9](https://github.com/hashicorp/vault-enterprise/commit/db10d462f979ef2b35f53366c15c1e0e2bb80ee9)) that was performed in ENT but not in OSS. Due to that a recent OSS->ENT merge brought back the broken test within ENT.
 
 - Update these files in 1.10.x only in OSS so we don't bring back these tests in ENT in the future