### PR TITLE
website: restrict node engines to <= 16.x

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
   },
   "engines": {
     "npm": ">=7.0.0",
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <= 16.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Restrict the node engines declaration for the website so it only uses up to 16.x.