### PR TITLE
Backport 1.10: secrets/azure: add wal to cleanup role assignments

### DIFF
--- a/changelog/18084.txt
+++ b/changelog/18084.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/azure: add WAL to clean up role assignments if errors occur
+```

--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/hashicorp/vault-plugin-mock v0.16.1
 	github.com/hashicorp/vault-plugin-secrets-ad v0.12.0
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.11.1
-	github.com/hashicorp/vault-plugin-secrets-azure v0.12.0
+	github.com/hashicorp/vault-plugin-secrets-azure v0.12.1
 	github.com/hashicorp/vault-plugin-secrets-gcp v0.12.1
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.11.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -986,8 +986,8 @@ github.com/hashicorp/vault-plugin-secrets-ad v0.12.0 h1:BiqmK2KS5hqcQ9hJYMZaUq/D
 github.com/hashicorp/vault-plugin-secrets-ad v0.12.0/go.mod h1:WwwDLyCMncZnOOtN2GHw6O4pIWauHhJx2DjRFbGYvV4=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.11.1 h1:vuenbRDeUV6Ghn4yFXKLKrIRsY1a9iiXnl8cGIzB19Y=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.11.1/go.mod h1:F4KWrlCQZbhP2dFXCkRvbHX2J6CTydlaY0cH+OrLHCE=
-github.com/hashicorp/vault-plugin-secrets-azure v0.12.0 h1:B2rLk3JxIXSRhZb47DLHSxQfX3yVWDFE6dGGzT6QXaA=
-github.com/hashicorp/vault-plugin-secrets-azure v0.12.0/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
+github.com/hashicorp/vault-plugin-secrets-azure v0.12.1 h1:m8o2v8NGiP1ivIiw3u3BcgNYiQQMTtbBQUoqscs8zAg=
+github.com/hashicorp/vault-plugin-secrets-azure v0.12.1/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.12.1 h1:qeI9ZNdTHjnFUB5DLLwR8sWdhACpPl8A75Mph7auN/o=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.12.1/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.11.0 h1:6MUiyfP5tKicVaYgu7Xi/LpCZh3QR8sjOlhpPKk5DzY=


### PR DESCRIPTION
Backporting https://github.com/hashicorp/vault-plugin-secrets-azure/pull/110 bug fix to 1.10.x.