### PR TITLE
Backport 1.11: secrets/azure: add wal to cleanup role assignments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/hashicorp/vault-plugin-mock v0.16.1
 	github.com/hashicorp/vault-plugin-secrets-ad v0.13.1
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.12.0
-	github.com/hashicorp/vault-plugin-secrets-azure v0.13.0
+	github.com/hashicorp/vault-plugin-secrets-azure v0.13.1
 	github.com/hashicorp/vault-plugin-secrets-gcp v0.13.1
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.12.0
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -998,8 +998,8 @@ github.com/hashicorp/vault-plugin-secrets-ad v0.13.1 h1:zxIaGsl8FI7B5GKJkXev56HS
 github.com/hashicorp/vault-plugin-secrets-ad v0.13.1/go.mod h1:5XIn6cw1+gG+WWxK0SdEAKCDOXTp+MX90PzZ7f3Eks0=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.12.0 h1:4Ke3dtM7ARa9ga2jI2rW/TouXWZ45hjfwwtcILoErA4=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.12.0/go.mod h1:F4KWrlCQZbhP2dFXCkRvbHX2J6CTydlaY0cH+OrLHCE=
-github.com/hashicorp/vault-plugin-secrets-azure v0.13.0 h1:35JsvhKhvuATkP6vVQisA4prHd2gjzX4AT0CPvPXJ7I=
-github.com/hashicorp/vault-plugin-secrets-azure v0.13.0/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
+github.com/hashicorp/vault-plugin-secrets-azure v0.13.1 h1:zl7v7mUA0b620iS2E8vIygKSJcn0L7/REbsa/MkR0gw=
+github.com/hashicorp/vault-plugin-secrets-azure v0.13.1/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.13.1 h1:6aUi1Y9jGBoWm58wsJnq8xerxAsxXjdeFsgUle1eIqw=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.13.1/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.12.0 h1:MXqB1waq3L18eUhTZ7ng14MbjOiAlwANgZCVUwoLBXo=


### PR DESCRIPTION
Backporting https://github.com/hashicorp/vault-plugin-secrets-azure/pull/110 bug fix to 1.11.x.