### PR TITLE
Backport 1.12: secrets/azure: add wal to cleanup role assignments

### DIFF
--- a/changelog/18086.txt
+++ b/changelog/18086.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/azure: add WAL to clean up role assignments if errors occur
+```

--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 	github.com/hashicorp/vault-plugin-mock v0.16.1
 	github.com/hashicorp/vault-plugin-secrets-ad v0.14.0
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.13.0
-	github.com/hashicorp/vault-plugin-secrets-azure v0.14.0
+	github.com/hashicorp/vault-plugin-secrets-azure v0.14.1
 	github.com/hashicorp/vault-plugin-secrets-gcp v0.14.0
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.13.0
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1128,8 +1128,8 @@ github.com/hashicorp/vault-plugin-secrets-ad v0.14.0 h1:64qTDXSj3tw1li7lWh13OJoY
 github.com/hashicorp/vault-plugin-secrets-ad v0.14.0/go.mod h1:5XIn6cw1+gG+WWxK0SdEAKCDOXTp+MX90PzZ7f3Eks0=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.13.0 h1:eWDAAvZsKHhnXF8uCiyF/wDqT57fflCs54PTIolONBo=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.13.0/go.mod h1:F4KWrlCQZbhP2dFXCkRvbHX2J6CTydlaY0cH+OrLHCE=
-github.com/hashicorp/vault-plugin-secrets-azure v0.14.0 h1:1Az9rwdDHiTXiJSEYSq+Ar+MXeC3Z9v2ltZx3N+DwNY=
-github.com/hashicorp/vault-plugin-secrets-azure v0.14.0/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
+github.com/hashicorp/vault-plugin-secrets-azure v0.14.1 h1:Dh4b7sILU+O17K+g2tWGdeGq9djPw5rqFCOX69JxJbA=
+github.com/hashicorp/vault-plugin-secrets-azure v0.14.1/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.14.0 h1:1yUxhYhFiMQm/miMYCtplnYly6HGBprOKStM6hpk+z0=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.14.0/go.mod h1:kRgZfXRD9qUHoGclaR09tKXXwkwNrkY+D76ahetsaB8=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.13.0 h1:R36pNaaN4tJyIrPJej7/355Qt5+Q5XUTB+Az6rGs5xg=


### PR DESCRIPTION
Backporting https://github.com/hashicorp/vault-plugin-secrets-azure/pull/110 bug fix to 1.12.x.