### PR TITLE
Kubernetes Secrets Engine Configuration

### DIFF
--- a/ui/app/adapters/kubernetes/config.js
+++ b/ui/app/adapters/kubernetes/config.js
@@ -32,4 +32,7 @@ export default class KubernetesConfigAdapter extends ApplicationAdapter {
     const url = this.getURL(snapshot.attr('backend'));
     return this.ajax(url, 'POST', { data }).then(() => data);
   }
+  checkConfigVars(backend) {
+    return this.ajax(`${this.getURL(backend)}/vars`, 'GET');
+  }
 }

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -50,7 +50,7 @@ export default class App extends Application {
     },
     kubernetes: {
       dependencies: {
-        services: ['router'],
+        services: ['router', 'store', 'secret-mount-path'],
         externalRoutes: {
           secrets: 'vault.cluster.secrets.backends',
         },

--- a/ui/app/models/kubernetes/config.js
+++ b/ui/app/models/kubernetes/config.js
@@ -20,7 +20,8 @@ export default class KubernetesConfigModel extends Model {
     label: 'Kubernetes CA Certificate',
     subText:
       'PEM-encoded CA certificate to use by the secret engine to verify the Kubernetes API server certificate. Defaults to the local pod’s CA if found.',
+    editType: 'textarea',
   })
   kubernetesCaCert;
-  @attr('boolean') disableLocalCaJwt;
+  @attr('boolean', { defaultValue: false }) disableLocalCaJwt;
 }

--- a/ui/app/styles/components/radio-card.scss
+++ b/ui/app/styles/components/radio-card.scss
@@ -42,6 +42,11 @@
     opacity: 0.6;
     box-shadow: none;
   }
+
+  &.has-fixed-width {
+    width: 368px;
+    max-width: 368px;
+  }
 }
 .radio-card:first-child {
   margin-left: 0;
@@ -49,9 +54,14 @@
 .radio-card:last-child {
   margin-right: 0;
 }
-
+.radio-card-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
 .radio-card-row {
   display: flex;
+  flex: 1;
   padding: $spacing-m;
 }
 .radio-card-icon {

--- a/ui/app/styles/core/helpers.scss
+++ b/ui/app/styles/core/helpers.scss
@@ -175,6 +175,9 @@
 .has-background-transparent {
   background: transparent !important;
 }
+.has-background-gray-200 {
+  background-color: $ui-gray-200;
+}
 @each $name, $pair in $colors {
   $color: nth($pair, 1);
   .has-background-#{$name} {
@@ -283,6 +286,12 @@ ul.bullet {
 }
 .has-text-grey-400 {
   color: $ui-gray-400;
+}
+.has-text-red {
+  color: $red;
+}
+.has-text-green {
+  color: $green;
 }
 .has-text-align-center {
   text-align: center;

--- a/ui/app/utils/error-message.js
+++ b/ui/app/utils/error-message.js
@@ -1,0 +1,7 @@
+// accepts an error and returns error.errors joined with a comma, error.message or a fallback message
+export default function (error, fallbackMessage = 'An error occurred, please try again') {
+  if (error?.errors) {
+    return error.errors.join(', ');
+  }
+  return error?.message || fallbackMessage;
+}

--- a/ui/lib/core/addon/components/radio-card.hbs
+++ b/ui/lib/core/addon/components/radio-card.hbs
@@ -1,16 +1,16 @@
 <label
-  for={{dasherize @value}}
+  for={{dasherize @title}}
   class="radio-card {{if (eq @value @groupValue) 'is-selected'}} {{if @disabled 'is-disabled'}}"
   ...attributes
 >
   <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
-    <T.Trigger tabindex="-1">
+    <T.Trigger tabindex="-1" class="radio-card-container">
       {{#if (has-block)}}
         {{yield}}
       {{else}}
         <div class="radio-card-row">
           <div>
-            <Icon @name={{@icon}} @size="24" class="has-text-grey-light" />
+            <Icon @name={{@icon}} @size="24" class={{or @iconClass "has-text-grey-light"}} />
           </div>
           <div class="has-left-margin-s">
             <h5 class="radio-card-message-title">
@@ -24,7 +24,7 @@
       {{/if}}
       <div class="radio-card-radio-row">
         <RadioButton
-          id={{dasherize @value}}
+          id={{dasherize @title}}
           name="config-mode"
           class="radio"
           @disabled={{@disabled}}

--- a/ui/lib/core/app/components/radio-card.js
+++ b/ui/lib/core/app/components/radio-card.js
@@ -1,0 +1,1 @@
+export { default } from 'core/components/radio-card';

--- a/ui/lib/kubernetes/addon/components/page/configure.hbs
+++ b/ui/lib/kubernetes/addon/components/page/configure.hbs
@@ -1,0 +1,93 @@
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Configure kubernetes
+    </h1>
+  </p.levelLeft>
+</PageHeader>
+
+<hr class="is-marginless has-background-gray-200" />
+
+<p class="has-top-margin-m">
+  To customize your configuration, specify the type of Kubernetes cluster that credentials will be generated for.
+</p>
+
+<div class="is-flex-row has-top-margin-s">
+  <RadioCard
+    class="has-fixed-width"
+    @title="Local cluster"
+    @description="Generate credentials for the local Kubernetes cluster that Vault is running on, using Vault’s service account."
+    @icon="kubernetes-color"
+    @hasLeftControl={{true}}
+    @value={{false}}
+    @groupValue={{@model.disableLocalCaJwt}}
+    @onChange={{this.onRadioSelect}}
+    data-test-radio-card="local"
+  />
+  <RadioCard
+    class="has-fixed-width"
+    @title="Manual configuration"
+    @description="Generate credentials for an external Kubernetes cluster, using a service account that you specify."
+    @icon="vault"
+    @iconClass="has-text-black"
+    @value={{true}}
+    @groupValue={{@model.disableLocalCaJwt}}
+    @onChange={{this.onRadioSelect}}
+    data-test-radio-card="manual"
+  />
+</div>
+
+<div class="has-top-margin-m" data-test-config>
+  {{#if @model.disableLocalCaJwt}}
+    <MessageError @errorMessage={{this.error}} />
+    {{#each @model.formFields as |attr|}}
+      <FormField @attr={{attr}} @model={{@model}} @modelValidations={{this.modelValidations}} />
+    {{/each}}
+  {{else if (eq this.inferredState "success")}}
+    <Icon @name="check-circle-fill" class="has-text-green" />
+    <span>Configuration values were inferred successfully.</span>
+  {{else if (eq this.inferredState "error")}}
+    <Icon @name="x-square-fill" class="has-text-red" />
+    <span class="has-text-red">
+      Vault could not infer a configuration from your environment variables. Check your configuration file to edit or delete
+      them, or configure manually.
+    </span>
+  {{else}}
+    <p>
+      Configuration values can be inferred from the pod and your local environment variables.
+    </p>
+    <div>
+      <button
+        class="button has-top-margin-s {{if this.fetchInferred.isRunning 'is-loading'}}"
+        type="button"
+        disabled={{this.fetchInferred.isRunning}}
+        {{on "click" (perform this.fetchInferred)}}
+      >
+        Get config values
+      </button>
+    </div>
+  {{/if}}
+</div>
+
+<hr class="has-background-gray-200 has-top-margin-l" />
+
+<div class="has-top-margin-s has-bottom-margin-s">
+  <button
+    data-test-config-save
+    class="button is-primary"
+    type="button"
+    disabled={{this.isDisabled}}
+    {{on "click" (perform this.save)}}
+  >
+    Save
+  </button>
+  <button
+    data-test-config-cancel
+    class="button has-left-margin-xs"
+    type="button"
+    disabled={{or this.save.isRunning this.fetchInferred.isRunning}}
+    {{on "click" this.cancel}}
+  >
+    Back
+  </button>
+</div>

--- a/ui/lib/kubernetes/addon/components/page/configure.js
+++ b/ui/lib/kubernetes/addon/components/page/configure.js
@@ -1,0 +1,71 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { task } from 'ember-concurrency';
+import { waitFor } from '@ember/test-waiters';
+import errorMessage from 'vault/utils/error-message';
+
+export default class ConfigurePageComponent extends Component {
+  @service router;
+  @service store;
+
+  @tracked inferredState;
+  @tracked modelValidations;
+  @tracked error;
+
+  constructor() {
+    super(...arguments);
+    if (!this.args.model.isNew && !this.args.model.disableLocalCaJwt) {
+      this.inferredState = 'success';
+    }
+  }
+
+  get isDisabled() {
+    if (!this.args.model.disableLocalCaJwt && this.inferredState !== 'success') {
+      return true;
+    }
+    return this.save.isRunning || this.fetchInferred.isRunning;
+  }
+
+  leave(route) {
+    this.router.transitionTo(`vault.cluster.secrets.backend.kubernetes.${route}`);
+  }
+
+  @action
+  onRadioSelect(value) {
+    this.args.model.disableLocalCaJwt = value;
+    this.inferredState = null;
+  }
+
+  @task
+  @waitFor
+  *fetchInferred() {
+    try {
+      yield this.store.adapterFor('kubernetes/config').checkConfigVars(this.args.model.backend);
+      this.inferredState = 'success';
+    } catch {
+      this.inferredState = 'error';
+    }
+  }
+
+  @task
+  @waitFor
+  *save() {
+    try {
+      yield this.args.model.save();
+      this.leave('configuration');
+    } catch (error) {
+      this.error = errorMessage(error, 'Error saving configuration. Please try again or contact support');
+    }
+  }
+
+  @action
+  cancel() {
+    const { model } = this.args;
+    const transitionRoute = model.isNew ? 'overview' : 'configuration';
+    const cleanupMethod = model.isNew ? 'unloadRecord' : 'rollbackAttributes';
+    model[cleanupMethod]();
+    this.leave(transitionRoute);
+  }
+}

--- a/ui/lib/kubernetes/addon/engine.js
+++ b/ui/lib/kubernetes/addon/engine.js
@@ -11,7 +11,7 @@ export default class KubernetesEngine extends Engine {
   modulePrefix = modulePrefix;
   Resolver = Resolver;
   dependencies = {
-    services: ['router'],
+    services: ['router', 'store', 'secret-mount-path'],
     externalRoutes: ['secrets'],
   };
 }

--- a/ui/lib/kubernetes/addon/routes/configure.js
+++ b/ui/lib/kubernetes/addon/routes/configure.js
@@ -1,3 +1,8 @@
-import Route from '@ember/routing/route';
+import FetchConfigRoute from './fetch-config';
 
-export default class KubernetesConfigureRoute extends Route {}
+export default class KubernetesConfigureRoute extends FetchConfigRoute {
+  async model() {
+    const backend = this.secretMountPath.get();
+    return this.configModel || this.store.createRecord('kubernetes/config', { backend });
+  }
+}

--- a/ui/lib/kubernetes/addon/routes/fetch-config.js
+++ b/ui/lib/kubernetes/addon/routes/fetch-config.js
@@ -1,0 +1,25 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class KubernetesFetchConfigRoute extends Route {
+  @service store;
+  @service secretMountPath;
+
+  configModel = null;
+
+  async beforeModel() {
+    const backend = this.secretMountPath.get();
+    // check the store for record first
+    this.configModel = this.store.peekRecord('kubernetes/config', backend);
+    if (!this.configModel) {
+      return this.store
+        .queryRecord('kubernetes/config', { backend })
+        .then((record) => {
+          this.configModel = record;
+        })
+        .catch(() => {
+          // it's ok! we don't need to transition to the error route
+        });
+    }
+  }
+}

--- a/ui/lib/kubernetes/addon/templates/configure.hbs
+++ b/ui/lib/kubernetes/addon/templates/configure.hbs
@@ -1,1 +1,1 @@
-Configure
+<Page::Configure @model={{this.model}} />

--- a/ui/lib/kubernetes/package.json
+++ b/ui/lib/kubernetes/package.json
@@ -6,7 +6,9 @@
   ],
   "dependencies": {
     "ember-cli-htmlbars": "*",
-    "ember-cli-babel": "*"
+    "ember-cli-babel": "*",
+    "ember-concurrency": "*",
+    "@ember/test-waiters": "*"
   },
   "ember-addon": {
     "paths": [

--- a/ui/mirage/handlers/kubernetes.js
+++ b/ui/mirage/handlers/kubernetes.js
@@ -1,5 +1,9 @@
 import { Response } from 'miragejs';
 
+// yet to be defined endpoint
+// exporting to use in tests in case it changes
+export const configVarUri = '/:path/config/vars';
+
 export default function (server) {
   const getRecord = (schema, req, dbKey) => {
     const { path, name } = req.params;
@@ -35,6 +39,11 @@ export default function (server) {
   });
   server.delete('/:path/config', (schema, req) => {
     return deleteRecord(schema, req, 'kubernetesConfigs');
+  });
+  // to be defined endpoint for checking for environment variables necessary for inferred config
+  server.get(configVarUri, () => {
+    const status = Math.random() > 0.5 ? 204 : 404;
+    return new Response(status, {});
   });
   server.get('/:path/roles', (schema) => {
     return {

--- a/ui/tests/integration/components/kubernetes/page/configure-test.js
+++ b/ui/tests/integration/components/kubernetes/page/configure-test.js
@@ -1,0 +1,167 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupEngine } from 'ember-engines/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { render, click, waitUntil, find, fillIn } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { configVarUri } from '../../../../../mirage/handlers/kubernetes';
+import { Response } from 'miragejs';
+import sinon from 'sinon';
+
+module('Integration | Component | kubernetes | Page:Configure', function (hooks) {
+  setupRenderingTest(hooks);
+  setupEngine(hooks, 'kubernetes');
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.newModel = this.store.createRecord('kubernetes/config', { backend: 'kubernetes-new' });
+    this.existingConfig = {
+      kubernetes_host: 'https://192.168.99.100:8443',
+      kubernetes_ca_cert: '-----BEGIN CERTIFICATE-----\n.....\n-----END CERTIFICATE-----',
+      service_account_jwt: 'test-jwt',
+      disable_local_ca_jwt: true,
+    };
+    this.store.pushPayload('kubernetes/config', {
+      modelName: 'kubernetes/config',
+      backend: 'kubernetes-edit',
+      ...this.existingConfig,
+    });
+    this.editModel = this.store.peekRecord('kubernetes/config', 'kubernetes-edit');
+  });
+
+  test('it should display proper options when toggling radio cards', async function (assert) {
+    await render(hbs`<Page::Configure @model={{this.newModel}} />`, { owner: this.engine });
+
+    assert
+      .dom('[data-test-radio-card="local"] input')
+      .isChecked('Local cluster radio card is checked by default');
+    assert
+      .dom('[data-test-config] p')
+      .hasText(
+        'Configuration values can be inferred from the pod and your local environment variables.',
+        'Inferred text is displayed'
+      );
+    assert.dom('[data-test-config] button').hasText('Get config values', 'Get config button renders');
+    assert
+      .dom('[data-test-config-save]')
+      .isDisabled('Save button is disabled when config values have not been inferred');
+    assert.dom('[data-test-config-cancel]').hasText('Back', 'Back button renders');
+
+    await click('[data-test-radio-card="manual"]');
+    assert.dom('[data-test-field]').exists({ count: 3 }, 'Form fields render');
+    assert.dom('[data-test-config-save]').isNotDisabled('Save button is enabled');
+    assert.dom('[data-test-config-cancel]').hasText('Back', 'Back button renders');
+  });
+
+  test('it should check for inferred config variables', async function (assert) {
+    assert.expect(8);
+
+    let status = 404;
+    this.server.get(configVarUri, () => {
+      assert.ok(
+        waitUntil(() => find('[data-test-config] button').disabled),
+        'Button is disabled while request is in flight'
+      );
+      return new Response(status, {});
+    });
+
+    await render(hbs`<Page::Configure @model={{this.newModel}} />`, { owner: this.engine });
+
+    await click('[data-test-config] button');
+    assert
+      .dom('[data-test-icon="x-square-fill"]')
+      .hasClass('has-text-red', 'Icon is displayed for error state with correct styling');
+    const error =
+      'Vault could not infer a configuration from your environment variables. Check your configuration file to edit or delete them, or configure manually.';
+    assert.dom('[data-test-config] span').hasText(error, 'Error text is displayed');
+    assert.dom('[data-test-config-save]').isDisabled('Save button is disabled in error state');
+
+    status = 204;
+    await click('[data-test-radio-card="manual"]');
+    await click('[data-test-radio-card="local"]');
+    await click('[data-test-config] button');
+    assert
+      .dom('[data-test-icon="check-circle-fill"]')
+      .hasClass('has-text-green', 'Icon is displayed for success state with correct styling');
+    assert
+      .dom('[data-test-config] span')
+      .hasText('Configuration values were inferred successfully.', 'Success text is displayed');
+    assert.dom('[data-test-config-save]').isNotDisabled('Save button is enabled in success state');
+  });
+
+  test('it should create new manual config', async function (assert) {
+    assert.expect(2);
+
+    this.server.post('/:path/config', (schema, req) => {
+      const json = JSON.parse(req.requestBody);
+      assert.deepEqual(json, this.existingConfig, 'Values are passed to create endpoint');
+      return new Response(204, {});
+    });
+
+    const stub = sinon.stub(this.owner.lookup('service:router'), 'transitionTo');
+
+    await render(hbs`<Page::Configure @model={{this.newModel}} />`, { owner: this.engine });
+
+    await click('[data-test-radio-card="manual"]');
+    await fillIn('[data-test-input="kubernetesHost"]', this.existingConfig.kubernetes_host);
+    await fillIn('[data-test-input="serviceAccountJwt"]', this.existingConfig.service_account_jwt);
+    await fillIn('[data-test-input="kubernetesCaCert"]', this.existingConfig.kubernetes_ca_cert);
+    await click('[data-test-config-save]');
+    assert.ok(
+      stub.calledWith('vault.cluster.secrets.backend.kubernetes.configuration'),
+      'Transitions to configuration route on save success'
+    );
+  });
+
+  test('it should edit existing manual config', async function (assert) {
+    assert.expect(6);
+
+    const stub = sinon.stub(this.owner.lookup('service:router'), 'transitionTo');
+
+    await render(hbs`<Page::Configure @model={{this.editModel}} />`, { owner: this.engine });
+
+    assert.dom('[data-test-radio-card="manual"] input').isChecked('Manual config radio card is checked');
+    assert
+      .dom('[data-test-input="kubernetesHost"]')
+      .hasValue(this.existingConfig.kubernetes_host, 'Host field is populated');
+    assert
+      .dom('[data-test-input="serviceAccountJwt"]')
+      .hasValue(this.existingConfig.service_account_jwt, 'JWT field is populated');
+    assert
+      .dom('[data-test-input="kubernetesCaCert"]')
+      .hasValue(this.existingConfig.kubernetes_ca_cert, 'Cert field is populated');
+
+    await fillIn('[data-test-input="kubernetesHost"]', 'http://localhost:1212');
+    await click('[data-test-config-cancel]');
+
+    assert.ok(
+      stub.calledWith('vault.cluster.secrets.backend.kubernetes.configuration'),
+      'Transitions to configuration route when cancelling edit'
+    );
+    assert.strictEqual(
+      this.editModel.kubernetesHost,
+      this.existingConfig.kubernetes_host,
+      'Model values are rolled back on cancel'
+    );
+  });
+
+  test('it should display inferred success message when editing model using local values', async function (assert) {
+    this.store.pushPayload('kubernetes/config', {
+      modelName: 'kubernetes/config',
+      backend: 'kubernetes-edit-2',
+      disable_local_ca_jwt: false,
+    });
+    this.model = this.store.peekRecord('kubernetes/config', 'kubernetes-edit-2');
+
+    await render(hbs`<Page::Configure @model={{this.model}} />`, { owner: this.engine });
+
+    assert.dom('[data-test-radio-card="local"] input').isChecked('Local cluster radio card is checked');
+    assert
+      .dom('[data-test-icon="check-circle-fill"]')
+      .hasClass('has-text-green', 'Icon is displayed for success state with correct styling');
+    assert
+      .dom('[data-test-config] span')
+      .hasText('Configuration values were inferred successfully.', 'Success text is displayed');
+  });
+});


### PR DESCRIPTION
Adds the configuration view in the kubernetes engine with the following:
- moved `RadioCard` component to core addon so it could be used in engine
- created `FetchConfig` route to be extended by configuration, overview and roles routes. This will peek or fetch the config record in the `beforeModel` hook since all routes need to be aware of it for displayed call to action
- created page component for view
- created `errorMessage` util to standarize error message handling