### PR TITLE
VAULT-6368 Metrics-only listener for Agent

### DIFF
--- a/changelog/18101.txt
+++ b/changelog/18101.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-agent: Agent listeners can now be configured to be a `metrics_only_listener`, serving only metrics, as part of the listener's telemetry configuration .
+agent: Agent listeners can now be to be the `metrics_only` role, serving only metrics, as part of the listener's new top level `role` option.
 ```

--- a/changelog/18101.txt
+++ b/changelog/18101.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: Agent listeners can now be configured to be a `metrics_only_listener`, serving only metrics, as part of the listener's telemetry configuration .
+```

--- a/command/agent.go
+++ b/command/agent.go
@@ -700,7 +700,7 @@ func (c *AgentCommand) Run(args []string) int {
 			// Parse 'require_request_header' listener config option, and wrap
 			// the request handler if necessary
 			muxHandler := cacheHandler
-			if lnConfig.RequireRequestHeader {
+			if lnConfig.RequireRequestHeader && !lnConfig.Telemetry.MetricsOnlyListener {
 				muxHandler = verifyRequestHeader(muxHandler)
 			}
 
@@ -708,10 +708,12 @@ func (c *AgentCommand) Run(args []string) int {
 			mux := http.NewServeMux()
 			quitEnabled := lnConfig.AgentAPI != nil && lnConfig.AgentAPI.EnableQuit
 
-			mux.Handle(consts.AgentPathCacheClear, leaseCache.HandleCacheClear(ctx))
-			mux.Handle(consts.AgentPathQuit, c.handleQuit(quitEnabled))
 			mux.Handle(consts.AgentPathMetrics, c.handleMetrics())
-			mux.Handle("/", muxHandler)
+			if !lnConfig.Telemetry.MetricsOnlyListener {
+				mux.Handle(consts.AgentPathCacheClear, leaseCache.HandleCacheClear(ctx))
+				mux.Handle(consts.AgentPathQuit, c.handleQuit(quitEnabled))
+				mux.Handle("/", muxHandler)
+			}
 
 			scheme := "https://"
 			if tlsConf == nil {

--- a/command/agent.go
+++ b/command/agent.go
@@ -700,7 +700,7 @@ func (c *AgentCommand) Run(args []string) int {
 			// Parse 'require_request_header' listener config option, and wrap
 			// the request handler if necessary
 			muxHandler := cacheHandler
-			if lnConfig.RequireRequestHeader && !lnConfig.Telemetry.MetricsOnlyListener {
+			if lnConfig.RequireRequestHeader && !("metrics_only" == lnConfig.Role) {
 				muxHandler = verifyRequestHeader(muxHandler)
 			}
 
@@ -709,7 +709,7 @@ func (c *AgentCommand) Run(args []string) int {
 			quitEnabled := lnConfig.AgentAPI != nil && lnConfig.AgentAPI.EnableQuit
 
 			mux.Handle(consts.AgentPathMetrics, c.handleMetrics())
-			if !lnConfig.Telemetry.MetricsOnlyListener {
+			if !("metrics_only" == lnConfig.Role) {
 				mux.Handle(consts.AgentPathCacheClear, leaseCache.HandleCacheClear(ctx))
 				mux.Handle(consts.AgentPathQuit, c.handleQuit(quitEnabled))
 				mux.Handle("/", muxHandler)

--- a/command/agent.go
+++ b/command/agent.go
@@ -700,7 +700,7 @@ func (c *AgentCommand) Run(args []string) int {
 			// Parse 'require_request_header' listener config option, and wrap
 			// the request handler if necessary
 			muxHandler := cacheHandler
-			if lnConfig.RequireRequestHeader && !("metrics_only" == lnConfig.Role) {
+			if lnConfig.RequireRequestHeader && ("metrics_only" != lnConfig.Role) {
 				muxHandler = verifyRequestHeader(muxHandler)
 			}
 
@@ -709,7 +709,7 @@ func (c *AgentCommand) Run(args []string) int {
 			quitEnabled := lnConfig.AgentAPI != nil && lnConfig.AgentAPI.EnableQuit
 
 			mux.Handle(consts.AgentPathMetrics, c.handleMetrics())
-			if !("metrics_only" == lnConfig.Role) {
+			if "metrics_only" != lnConfig.Role {
 				mux.Handle(consts.AgentPathCacheClear, leaseCache.HandleCacheClear(ctx))
 				mux.Handle(consts.AgentPathQuit, c.handleQuit(quitEnabled))
 				mux.Handle("/", muxHandler)

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -37,13 +37,12 @@ func TestLoadConfigFile_AgentCache(t *testing.T) {
 				{
 					Type:       "tcp",
 					Address:    "127.0.0.1:3000",
+					Role:       "metrics_only",
 					TLSDisable: true,
-					Telemetry: configutil.ListenerTelemetry{
-						MetricsOnlyListener: true,
-					},
 				},
 				{
 					Type:        "tcp",
+					Role:        "default",
 					Address:     "127.0.0.1:8400",
 					TLSKeyFile:  "/path/to/cakey.pem",
 					TLSCertFile: "/path/to/cacert.pem",

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -35,6 +35,14 @@ func TestLoadConfigFile_AgentCache(t *testing.T) {
 					TLSDisable: true,
 				},
 				{
+					Type:       "tcp",
+					Address:    "127.0.0.1:3000",
+					TLSDisable: true,
+					Telemetry: configutil.ListenerTelemetry{
+						MetricsOnlyListener: true,
+					},
+				},
+				{
 					Type:        "tcp",
 					Address:     "127.0.0.1:8400",
 					TLSKeyFile:  "/path/to/cakey.pem",

--- a/command/agent/config/test-fixtures/config-cache-embedded-type.hcl
+++ b/command/agent/config/test-fixtures/config-cache-embedded-type.hcl
@@ -46,6 +46,15 @@ listener {
 
 listener {
     type = "tcp"
+    address = "127.0.0.1:3000"
+    tls_disable = true
+    telemetry {
+       metrics_only_listener = true
+    }
+}
+
+listener {
+    type = "tcp"
     address = "127.0.0.1:8400"
     tls_key_file = "/path/to/cakey.pem"
     tls_cert_file = "/path/to/cacert.pem"

--- a/command/agent/config/test-fixtures/config-cache-embedded-type.hcl
+++ b/command/agent/config/test-fixtures/config-cache-embedded-type.hcl
@@ -48,13 +48,12 @@ listener {
     type = "tcp"
     address = "127.0.0.1:3000"
     tls_disable = true
-    telemetry {
-       metrics_only_listener = true
-    }
+    role = "metrics_only"
 }
 
 listener {
     type = "tcp"
+    role = "default"
     address = "127.0.0.1:8400"
     tls_key_file = "/path/to/cakey.pem"
     tls_cert_file = "/path/to/cacert.pem"

--- a/command/agent/config/test-fixtures/config-cache.hcl
+++ b/command/agent/config/test-fixtures/config-cache.hcl
@@ -47,12 +47,11 @@ listener {
     type = "tcp"
     address = "127.0.0.1:3000"
     tls_disable = true
-    telemetry {
-       metrics_only_listener = true
-    }
+    role = "metrics_only"
 }
 
 listener "tcp" {
+    role = "default"
     address = "127.0.0.1:8400"
     tls_key_file = "/path/to/cakey.pem"
     tls_cert_file = "/path/to/cacert.pem"

--- a/command/agent/config/test-fixtures/config-cache.hcl
+++ b/command/agent/config/test-fixtures/config-cache.hcl
@@ -43,6 +43,15 @@ listener "tcp" {
     tls_disable = true
 }
 
+listener {
+    type = "tcp"
+    address = "127.0.0.1:3000"
+    tls_disable = true
+    telemetry {
+       metrics_only_listener = true
+    }
+}
+
 listener "tcp" {
     address = "127.0.0.1:8400"
     tls_key_file = "/path/to/cakey.pem"

--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -2,7 +2,6 @@ package configutil
 
 import (
 	"fmt"
-	"io/ioutil"
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
@@ -20,6 +19,8 @@ type SharedConfig struct {
 	EntSharedConfig
 
 	Listeners []*Listener `hcl:"-"`
+
+	MetricsListeners []*Listener `hcl:"metric_listener"`
 
 	UserLockouts []*UserLockout `hcl:"-"`
 
@@ -45,25 +46,6 @@ type SharedConfig struct {
 	PidFile string `hcl:"pid_file"`
 
 	ClusterName string `hcl:"cluster_name"`
-}
-
-// LoadConfigFile loads the configuration from the given file.
-func LoadConfigFile(path string) (*SharedConfig, error) {
-	// Read the file
-	d, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	return ParseConfig(string(d))
-}
-
-func LoadConfigKMSes(path string) ([]*KMS, error) {
-	// Read the file
-	d, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	return ParseKMSes(string(d))
 }
 
 func ParseConfig(d string) (*SharedConfig, error) {

--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -20,8 +20,6 @@ type SharedConfig struct {
 
 	Listeners []*Listener `hcl:"-"`
 
-	MetricsListeners []*Listener `hcl:"metric_listener"`
-
 	UserLockouts []*UserLockout `hcl:"-"`
 
 	Seals   []*KMS   `hcl:"-"`

--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -22,6 +22,8 @@ type ListenerTelemetry struct {
 	UnusedKeys                      UnusedKeyMap `hcl:",unusedKeyPositions"`
 	UnauthenticatedMetricsAccess    bool         `hcl:"-"`
 	UnauthenticatedMetricsAccessRaw interface{}  `hcl:"unauthenticated_metrics_access,alias:UnauthenticatedMetricsAccess"`
+	MetricsOnlyListener             bool         `hcl:"-"`
+	MetricsOnlyListenerAccessRaw    interface{}  `hcl:"metrics_only_listener,alias:MetricsOnlyListener"`
 }
 
 type ListenerProfiling struct {
@@ -347,6 +349,14 @@ func ParseListeners(result *SharedConfig, list *ast.ObjectList) error {
 				}
 
 				l.Telemetry.UnauthenticatedMetricsAccessRaw = nil
+			}
+
+			if l.Telemetry.MetricsOnlyListenerAccessRaw != nil {
+				if l.Telemetry.MetricsOnlyListener, err = parseutil.ParseBool(l.Telemetry.MetricsOnlyListenerAccessRaw); err != nil {
+					return multierror.Prefix(fmt.Errorf("invalid value for telemetry.metrcs_only_listener: %w", err), fmt.Sprintf("listeners.%d", i))
+				}
+
+				l.Telemetry.MetricsOnlyListenerAccessRaw = nil
 			}
 		}
 

--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -188,7 +188,7 @@ func ParseListeners(result *SharedConfig, list *ast.ObjectList) error {
 			case "default", "metrics_only", "":
 				result.found(l.Type, l.Type)
 			default:
-				return multierror.Prefix(fmt.Errorf("unsupported listener role %q", l.Type), fmt.Sprintf("listeners.%d:", i))
+				return multierror.Prefix(fmt.Errorf("unsupported listener role %q", l.Role), fmt.Sprintf("listeners.%d:", i))
 			}
 		}
 

--- a/sdk/helper/consts/agent.go
+++ b/sdk/helper/consts/agent.go
@@ -4,7 +4,7 @@ package consts
 // endpoint.
 const AgentPathCacheClear = "/agent/v1/cache-clear"
 
-// AgentPathMetrics is the path the the agent will use to expose its internal
+// AgentPathMetrics is the path the agent will use to expose its internal
 // metrics.
 const AgentPathMetrics = "/agent/v1/metrics"
 

--- a/website/content/docs/agent/caching/index.mdx
+++ b/website/content/docs/agent/caching/index.mdx
@@ -227,7 +227,9 @@ These are common configuration values that live within the `persist` block:
 There can be one or more `listener` blocks at the top level. These configuration
 values are common to both `tcp` and `unix` listener blocks. Blocks of type
 `tcp` support the standard `tcp` [listener](/docs/configuration/listener/tcp)
-options.
+options. Additionally, the `metrics_only_listener` boolean option is available
+as part of the listener `telemetry` block, enabling you to have a listener that
+only serves metrics.
 
 - `type` `(string: required)` - The type of the listener to use. Valid values
   are `tcp` and `unix`.
@@ -249,7 +251,7 @@ options.
 
 ### Example Configuration
 
-Here is an example of a cache configuration.
+Here is an example of a cache configuration alongside a listener that only serves metrics.
 
 ```hcl
 # Other Vault Agent configuration blocks
@@ -257,6 +259,14 @@ Here is an example of a cache configuration.
 
 cache {
   use_auto_auth_token = true
+}
+
+listener "tcp" {
+    address = "127.0.0.1:3000"
+    tls_disable = true
+    telemetry {
+      metrics_only_listener = true
+    }
 }
 ```
 

--- a/website/content/docs/agent/caching/index.mdx
+++ b/website/content/docs/agent/caching/index.mdx
@@ -229,7 +229,7 @@ values are common to both `tcp` and `unix` listener blocks. Blocks of type
 `tcp` support the standard `tcp` [listener](/docs/configuration/listener/tcp)
 options. Additionally, the `role` string option is available as part of the top level
 of the `listener` block, which can be configured to `metrics_only` to serve only metrics,
-the default role, `default`, serves everything (including metrics).
+or the default role, `default`, which serves everything (including metrics).
 
 - `type` `(string: required)` - The type of the listener to use. Valid values
   are `tcp` and `unix`.

--- a/website/content/docs/agent/caching/index.mdx
+++ b/website/content/docs/agent/caching/index.mdx
@@ -227,9 +227,9 @@ These are common configuration values that live within the `persist` block:
 There can be one or more `listener` blocks at the top level. These configuration
 values are common to both `tcp` and `unix` listener blocks. Blocks of type
 `tcp` support the standard `tcp` [listener](/docs/configuration/listener/tcp)
-options. Additionally, the `metrics_only_listener` boolean option is available
-as part of the listener `telemetry` block, enabling you to have a listener that
-only serves metrics.
+options. Additionally, the `role` string option is available as part of the top level
+of the `listener` block, which can be configured to `metrics_only` to serve only metrics,
+the default role, `default`, serves everything (including metrics).
 
 - `type` `(string: required)` - The type of the listener to use. Valid values
   are `tcp` and `unix`.
@@ -264,9 +264,7 @@ cache {
 listener "tcp" {
     address = "127.0.0.1:3000"
     tls_disable = true
-    telemetry {
-      metrics_only_listener = true
-    }
+    role = "metrics_only"
 }
 ```
 


### PR DESCRIPTION
This introduces a new option for the Agent HCL config, `metrics_only_listener`. It defaults to false. If set to true, it will make the defined listener only serve metrics. It can be put alongside other listener blocks, too, like so:

```
cache {
 enforce_consistency = "always"
 use_auto_auth_token = true
}

listener "tcp" {
    address = "127.0.0.1:8100"
    tls_disable = true
}

listener "tcp" {
    address = "127.0.0.1:3000"
    tls_disable = true
    telemetry {
      metrics_only_listener = true
    }
}
```

Using the above, you can e.g. cURL the metrics (but nothing else). This shows an example with an auth failure:
```
curl http://127.0.0.1:3000/agent/v1/metrics
{"Timestamp":"2022-11-23 17:41:50 +0000 UTC","Gauges":[{"Name":"vault.runtime.alloc_bytes","Value":10344560,"Labels":{}},{"Name":"vault.runtime.free_count","Value":52367,"Labels":{}},{"Name":"vault.runtime.heap_objects","Value":45838,"Labels":{}},{"Name":"vault.runtime.malloc_count","Value":98205,"Labels":{}},{"Name":"vault.runtime.num_goroutines","Value":13,"Labels":{}},{"Name":"vault.runtime.sys_bytes","Value":30328072,"Labels":{}},{"Name":"vault.runtime.total_gc_pause_ns","Value":375709,"Labels":{}},{"Name":"vault.runtime.total_gc_runs","Value":5,"Labels":{}}],"Points":[],"Counters":[{"Name":"vault.agent.auth.failure","Count":1,"Rate":0.1,"Sum":1,"Min":1,"Max":1,"Mean":1,"Stddev":0,"Labels":{}}],"Samples":[]}
```

Note that we still do need a cache block for this listener, though we have a separate work item tracked to enable listeners without a cache, and I felt it best to keep the two work items distinct.