### PR TITLE
Sideport Error Message Util

### DIFF
--- a/ui/app/utils/error-message.js
+++ b/ui/app/utils/error-message.js
@@ -1,0 +1,7 @@
+// accepts an error and returns error.errors joined with a comma, error.message or a fallback message
+export default function (error, fallbackMessage = 'An error occurred, please try again') {
+  if (error?.errors) {
+    return error.errors.join(', ');
+  }
+  return error?.message || fallbackMessage;
+}


### PR DESCRIPTION
Porting `error-message` util from the ui/kubernetes-secrets-engine branch originally created in #18093 