### PR TITLE
Sideport RadioCard

### DIFF
--- a/ui/app/styles/components/radio-card.scss
+++ b/ui/app/styles/components/radio-card.scss
@@ -42,6 +42,11 @@
     opacity: 0.6;
     box-shadow: none;
   }
+
+  &.has-fixed-width {
+    width: 368px;
+    max-width: 368px;
+  }
 }
 .radio-card:first-child {
   margin-left: 0;
@@ -49,9 +54,14 @@
 .radio-card:last-child {
   margin-right: 0;
 }
-
+.radio-card-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
 .radio-card-row {
   display: flex;
+  flex: 1;
   padding: $spacing-m;
 }
 .radio-card-icon {

--- a/ui/app/templates/components/oidc/client-form.hbs
+++ b/ui/app/templates/components/oidc/client-form.hbs
@@ -39,6 +39,7 @@
     <h4 class="title is-4">Assign access</h4>
     <div class="is-flex-row">
       <RadioCard
+        data-test-oidc-radio="allow-all"
         @title="Allow everyone to access existing"
         @description="All Vault entities can authenticate through this application."
         @icon="org"
@@ -47,6 +48,7 @@
         @onChange={{this.handleAssignmentSelection}}
       />
       <RadioCard
+        data-test-oidc-radio="limited"
         @title="Limit access to selected users"
         @description="Choose or create an assignment to give access to selected entities."
         @icon="users"
@@ -60,12 +62,12 @@
         @id="assignments"
         @label="Assignment name"
         @subText="Search for an existing assignment, or type a new name to create it."
-        @models={{array "oidc/assignment"}}
+        @model="oidc/assignment"
         @inputValue={{this.modelAssignments}}
         @onChange={{this.handleAssignmentSelection}}
         @excludeOptions={{array "allow_all"}}
         @fallbackComponent="string-list"
-        @modalFormTemplate="modal-form/oidc-assignment-template"
+        @modalFormComponent="oidc/assignment-form"
         @modalSubtext="Use assignment to specify which Vault entities and groups are allowed to authenticate."
       />
     {{/if}}

--- a/ui/app/templates/components/oidc/key-form.hbs
+++ b/ui/app/templates/components/oidc/key-form.hbs
@@ -37,6 +37,7 @@
     <h4 class="title is-4">Allowed applications</h4>
     <div class="is-flex-row">
       <RadioCard
+        data-test-oidc-radio="allow-all"
         @title="Allow every application to use"
         @description="All applications can use this key for authentication requests."
         @icon="globe"
@@ -45,6 +46,7 @@
         @onChange={{this.handleClientSelection}}
       />
       <RadioCard
+        data-test-oidc-radio="limited"
         @title="Limit access to selected application"
         @description="Only selected applications can use this key for authentication requests."
         @icon="globe-private"

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -67,6 +67,7 @@
     <h4 class="title is-4">Allowed applications</h4>
     <div class="is-flex-row">
       <RadioCard
+        data-test-oidc-radio="allow-all"
         @title="Allow every application to use"
         @description="All applications can use this provider for authentication requests."
         @icon="globe"
@@ -75,6 +76,7 @@
         @onChange={{this.handleClientSelection}}
       />
       <RadioCard
+        data-test-oidc-radio="limited"
         @title="Limit access to selected application"
         @description="Only selected applications can use this provider for authentication requests."
         @icon="globe-private"

--- a/ui/lib/core/addon/components/radio-card.hbs
+++ b/ui/lib/core/addon/components/radio-card.hbs
@@ -1,16 +1,16 @@
 <label
-  for={{dasherize @value}}
+  for={{dasherize (or @title @value)}}
   class="radio-card {{if (eq @value @groupValue) 'is-selected'}} {{if @disabled 'is-disabled'}}"
   ...attributes
 >
   <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
-    <T.Trigger tabindex="-1">
+    <T.Trigger tabindex="-1" class="radio-card-container">
       {{#if (has-block)}}
         {{yield}}
       {{else}}
         <div class="radio-card-row">
           <div>
-            <Icon @name={{@icon}} @size="24" class="has-text-grey-light" />
+            <Icon @name={{@icon}} @size="24" class={{or @iconClass "has-text-grey-light"}} />
           </div>
           <div class="has-left-margin-s">
             <h5 class="radio-card-message-title">
@@ -24,7 +24,7 @@
       {{/if}}
       <div class="radio-card-radio-row">
         <RadioButton
-          id={{dasherize @value}}
+          id={{dasherize (or @title @value)}}
           name="config-mode"
           class="radio"
           @disabled={{@disabled}}

--- a/ui/lib/core/app/components/radio-card.js
+++ b/ui/lib/core/app/components/radio-card.js
@@ -1,0 +1,1 @@
+export { default } from 'core/components/radio-card';

--- a/ui/tests/acceptance/oidc-config/clients-assignments-test.js
+++ b/ui/tests/acceptance/oidc-config/clients-assignments-test.js
@@ -135,7 +135,7 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
     await fillIn('[data-test-input="redirectUris"] [data-test-string-list-input="0"]', 'some-url.com');
 
     // limit access & create new assignment inline
-    await click('label[for=limited]');
+    await click('[data-test-oidc-radio="limited"]');
     await clickTrigger();
     await fillIn('.ember-power-select-search input', 'assignment-inline');
     await searchSelect.options.objectAt(0).click();
@@ -168,7 +168,7 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
     // edit back to allow_all
     await click(SELECTORS.clientEditButton);
     assert.dom(SELECTORS.clientSaveButton).hasText('Update', 'form button renders correct text');
-    await click('label[for=allow-all]');
+    await click('[data-test-oidc-radio="allow-all"]');
     await click(SELECTORS.clientSaveButton);
     assert
       .dom('[data-test-value-div="Assignment"]')
@@ -207,7 +207,7 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
   });
 
   test('it creates, updates, and deletes an assignment', async function (assert) {
-    assert.expect(14);
+    assert.expect(12);
     await visit(OIDC_BASE_URL + '/assignments');
 
     //* ensure clean test state
@@ -220,7 +220,6 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
       'vault.cluster.access.oidc.assignments.create',
       'navigates to create form'
     );
-    assert.dom('[data-test-oidc-assignment-title]').hasText('Create assignment', 'Form title renders');
     await fillIn('[data-test-input="name"]', 'test-assignment');
     await click('[data-test-component="search-select"]#entities .ember-basic-dropdown-trigger');
     await click('.ember-power-select-option');
@@ -247,7 +246,6 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
       'vault.cluster.access.oidc.assignments.assignment.edit',
       'navigates to the assignment edit page from details'
     );
-    assert.dom('[data-test-oidc-assignment-title]').hasText('Edit assignment', 'Form title renders');
     await click('[data-test-component="search-select"]#groups .ember-basic-dropdown-trigger');
     await click('.ember-power-select-option');
     assert.dom('[data-test-oidc-assignment-save]').hasText('Update');

--- a/ui/tests/acceptance/oidc-config/clients-keys-test.js
+++ b/ui/tests/acceptance/oidc-config/clients-keys-test.js
@@ -139,7 +139,7 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
       'vault.cluster.access.oidc.keys.key.edit',
       'key linked block popup menu navigates to edit'
     );
-    await click('label[for=limited]');
+    await click('[data-test-oidc-radio="limited"]');
     await clickTrigger();
     assert.strictEqual(searchSelect.options.length, 1, 'dropdown has only application that uses this key');
     assert
@@ -166,7 +166,7 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
     // edit back to allow all
     await click(SELECTORS.keyDetailsTab);
     await click(SELECTORS.keyEditButton);
-    await click('label[for=allow-all]');
+    await click('[data-test-oidc-radio="allow-all"]');
     await click(SELECTORS.keySaveButton);
     await click(SELECTORS.keyClientsTab);
     assert.notEqual(
@@ -199,8 +199,12 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
     // toggle ttls to false, testing it sets correct default duration
     await click('[data-test-input="rotationPeriod"]');
     await click('[data-test-input="verificationTtl"]');
-    assert.dom('input#limited').isDisabled('limiting access radio button is disabled on create');
-    assert.dom('label[for=limited]').hasClass('is-disabled', 'limited radio button label has disabled class');
+    assert
+      .dom('[data-test-oidc-radio="limited"] input')
+      .isDisabled('limiting access radio button is disabled on create');
+    assert
+      .dom('[data-test-oidc-radio="limited"]')
+      .hasClass('is-disabled', 'limited radio button label has disabled class');
     await click(SELECTORS.keySaveButton);
     assert.strictEqual(
       flashMessage.latestMessage,

--- a/ui/tests/acceptance/oidc-config/providers-scopes-test.js
+++ b/ui/tests/acceptance/oidc-config/providers-scopes-test.js
@@ -273,7 +273,7 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
       'vault.cluster.access.oidc.providers.provider.edit',
       'navigates to provider edit page from details'
     );
-    await click('label[for=limited]');
+    await click('[data-test-oidc-radio="limited"]');
     await click('[data-test-component="search-select"]#allowedClientIds .ember-basic-dropdown-trigger');
     await fillIn('.ember-power-select-search input', 'test-app');
     await searchSelect.options.objectAt(0).click();
@@ -302,7 +302,7 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
     // edit back to allow all
     await click(SELECTORS.providerDetailsTab);
     await click(SELECTORS.providerEditButton);
-    await click('label[for=allow-all]');
+    await click('[data-test-oidc-radio="allow-all"]');
     await click(SELECTORS.providerSaveButton);
     await click(SELECTORS.providerClientsTab);
     assert.strictEqual(

--- a/ui/tests/integration/components/oidc/client-form-test.js
+++ b/ui/tests/integration/components/oidc/client-form-test.js
@@ -81,7 +81,9 @@ module('Integration | Component | oidc/client-form', function (hooks) {
       .hasText('Create application', 'Form title renders correct text');
     assert.dom(SELECTORS.clientSaveButton).hasText('Create', 'Save button has correct text');
     assert.strictEqual(findAll('[data-test-field]').length, 6, 'renders all attribute fields');
-    assert.dom('input#allow-all').isChecked('Allow all radio button selected by default');
+    assert
+      .dom('[data-test-oidc-radio="allow-all"] input')
+      .isChecked('Allow all radio button selected by default');
     assert.dom('[data-test-ttl-value="ID Token TTL"]').hasValue('1', 'ttl defaults to 24h');
     assert.dom('[data-test-ttl-value="Access Token TTL"]').hasValue('1', 'ttl defaults to 24h');
     assert.dom('[data-test-selected-option]').hasText('default', 'Search select has default key selected');
@@ -103,7 +105,7 @@ module('Integration | Component | oidc/client-form', function (hooks) {
     await fillIn('.ember-power-select-search input', 'default');
     await searchSelect.options.objectAt(0).click();
 
-    await click('label[for=limited]');
+    await click('[data-test-oidc-radio="limited"]');
     assert
       .dom('[data-test-search-select-with-modal]')
       .exists('Limited radio button shows assignments search select');
@@ -149,7 +151,7 @@ module('Integration | Component | oidc/client-form', function (hooks) {
     assert
       .dom('[data-test-input="clientType"] input#confidential')
       .isChecked('Correct radio button is selected');
-    assert.dom('input#allow-all').isChecked('Allow all radio button is selected');
+    assert.dom('[data-test-oidc-radio="allow-all"] input').isChecked('Allow all radio button is selected');
     await click(SELECTORS.clientSaveButton);
   });
 
@@ -192,7 +194,7 @@ module('Integration | Component | oidc/client-form', function (hooks) {
   });
 
   test('it should show create assignment modal', async function (assert) {
-    assert.expect(3);
+    assert.expect(2);
     this.model = this.store.createRecord('oidc/client');
 
     await render(hbs`
@@ -203,14 +205,13 @@ module('Integration | Component | oidc/client-form', function (hooks) {
       />
       <div id="modal-wormhole"></div>
     `);
-    await click('label[for=limited]');
+    await click('[data-test-oidc-radio="limited"]');
     await clickTrigger();
     await fillIn('.ember-power-select-search input', 'test-new');
     await searchSelect.options.objectAt(0).click();
-    assert.dom('[data-test-modal-div]').hasClass('is-active', 'modal with form opens');
     assert.dom('[data-test-modal-title]').hasText('Create new assignment', 'Create assignment modal renders');
     await click(SELECTORS.assignmentCancelButton);
-    assert.dom('[data-test-modal-div]').doesNotExist('modal disappears onCancel');
+    assert.dom('[data-test-modal-div]').doesNotExist('Modal disappears after clicking cancel');
   });
 
   test('it should render fallback for search select', async function (assert) {
@@ -225,7 +226,7 @@ module('Integration | Component | oidc/client-form', function (hooks) {
       />
     `);
 
-    await click('label[for=limited]');
+    await click('[data-test-oidc-radio="limited"]');
     assert
       .dom('[data-test-component="string-list"]')
       .exists('Radio toggle shows assignments string-list input');

--- a/ui/tests/integration/components/oidc/key-form-test.js
+++ b/ui/tests/integration/components/oidc/key-form-test.js
@@ -60,7 +60,7 @@ module('Integration | Component | oidc/key-form', function (hooks) {
       .hasText('Name is required. Name cannot contain whitespace.', 'Validation messages are shown for name');
     assert.dom(validationErrors[1]).hasText('There are 2 errors with this form.', 'Renders form error count');
 
-    assert.dom('label[for=limited] input').isDisabled('limit radio button disabled on create');
+    assert.dom('[data-test-oidc-radio="limited"] input').isDisabled('limit radio button disabled on create');
     await fillIn('[data-test-input="name"]', 'test-key');
     await click(SELECTORS.keySaveButton);
   });
@@ -94,9 +94,9 @@ module('Integration | Component | oidc/key-form', function (hooks) {
     assert.dom(SELECTORS.keySaveButton).hasText('Update', 'Save button has correct text');
     assert.dom('[data-test-input="name"]').isDisabled('Name input is disabled when editing');
     assert.dom('[data-test-input="name"]').hasValue('test-key', 'Name input is populated with model value');
-    assert.dom('input#allow-all').isChecked('Allow all radio button is selected');
+    assert.dom('[data-test-oidc-radio="allow-all"] input').isChecked('Allow all radio button is selected');
 
-    await click('label[for=limited]');
+    await click('[data-test-oidc-radio="limited"]');
     assert
       .dom('[data-test-component="search-select"]#allowedClientIds')
       .exists('Limited radio button shows clients search select');
@@ -107,7 +107,7 @@ module('Integration | Component | oidc/key-form', function (hooks) {
       .hasTextContaining('app-1', 'dropdown contains client that references key');
     assert.dom('[data-test-smaller-id]').exists('renders smaller client id in dropdown');
 
-    await click('label[for=allow-all]');
+    await click('[data-test-oidc-radio="allow-all"]');
     assert
       .dom('[data-test-component="search-select"]#allowedClientIds')
       .doesNotExist('Allow all radio button hides search select');
@@ -147,7 +147,7 @@ module('Integration | Component | oidc/key-form', function (hooks) {
       />
     `);
 
-    await click('label[for=limited]');
+    await click('[data-test-oidc-radio="limited"]');
     await click(SELECTORS.keyCancelButton);
     assert.strictEqual(this.model.allowed_client_ids, undefined, 'Model attributes rolled back on cancel');
   });
@@ -177,7 +177,7 @@ module('Integration | Component | oidc/key-form', function (hooks) {
       />
     `);
 
-    await click('label[for=limited]');
+    await click('[data-test-oidc-radio="limited"]');
     assert
       .dom('[data-test-component="search-select"]#allowedClientIds [data-test-component="string-list"]')
       .exists('Radio toggle shows client string-list input');

--- a/ui/tests/integration/components/oidc/provider-form-test.js
+++ b/ui/tests/integration/components/oidc/provider-form-test.js
@@ -83,7 +83,7 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
       .hasText('Name is required. Name cannot contain whitespace.', 'Validation messages are shown for name');
     assert.dom(validationErrors[1]).hasText('There are 2 errors with this form.', 'Renders form error count');
 
-    await click('label[for=limited]');
+    await click('[data-test-oidc-radio="limited"]');
     assert
       .dom('[data-test-component="search-select"]#allowedClientIds')
       .exists('Limited radio button shows clients search select');
@@ -91,7 +91,7 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
     assert.dom('li.ember-power-select-option').hasTextContaining('test-app', 'dropdown renders client name');
     assert.dom('[data-test-smaller-id]').exists('renders smaller client id in dropdown');
 
-    await click('label[for=allow-all]');
+    await click('[data-test-oidc-radio="allow-all"]');
     assert
       .dom('[data-test-component="search-select"]#allowedClientIds')
       .doesNotExist('Allow all radio button hides search select');
@@ -138,7 +138,7 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
       .hasValue(parseURL(ISSUER_URL).origin, 'issuer value is just scheme://host:port portion of full URL');
 
     assert.dom('[data-test-selected-option]').hasText('test-scope', 'model scope is selected');
-    assert.dom('input#allow-all').isChecked('Allow all radio button is selected');
+    assert.dom('[data-test-oidc-radio="allow-all"] input').isChecked('Allow all radio button is selected');
     await click(SELECTORS.providerSaveButton);
   });
 
@@ -176,7 +176,7 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
       />
     `);
 
-    await click('label[for=limited]');
+    await click('[data-test-oidc-radio="limited"]');
     await click(SELECTORS.providerCancelButton);
     assert.strictEqual(this.model.allowed_client_ids, undefined, 'Model attributes rolled back on cancel');
   });
@@ -197,7 +197,7 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
     assert
       .dom('[data-test-component="search-select"]#scopesSupported [data-test-component="string-list"]')
       .exists('renders fall back for scopes search select');
-    await click('label[for=limited]');
+    await click('[data-test-oidc-radio="limited"]');
     assert
       .dom('[data-test-component="search-select"]#allowedClientIds [data-test-component="string-list"]')
       .exists('Radio toggle shows assignments string-list input');


### PR DESCRIPTION
Porting changes to `RadioCard` component from ui/kubernetes-secrets-engine side branch originally done in #18093 