### PR TITLE
Backport 1.10.x: secrets/gcp - Fixes duplicate service account key for rotate root on standby or secondary

### DIFF
--- a/changelog/18109.txt
+++ b/changelog/18109.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/gcp: Fixes duplicate service account key for rotate root on standby or secondary
+```

--- a/go.mod
+++ b/go.mod
@@ -108,7 +108,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-ad v0.12.0
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.11.1
 	github.com/hashicorp/vault-plugin-secrets-azure v0.12.1
-	github.com/hashicorp/vault-plugin-secrets-gcp v0.12.1
+	github.com/hashicorp/vault-plugin-secrets-gcp v0.12.2
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.11.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.11.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -988,8 +988,8 @@ github.com/hashicorp/vault-plugin-secrets-alicloud v0.11.1 h1:vuenbRDeUV6Ghn4yFX
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.11.1/go.mod h1:F4KWrlCQZbhP2dFXCkRvbHX2J6CTydlaY0cH+OrLHCE=
 github.com/hashicorp/vault-plugin-secrets-azure v0.12.1 h1:m8o2v8NGiP1ivIiw3u3BcgNYiQQMTtbBQUoqscs8zAg=
 github.com/hashicorp/vault-plugin-secrets-azure v0.12.1/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.12.1 h1:qeI9ZNdTHjnFUB5DLLwR8sWdhACpPl8A75Mph7auN/o=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.12.1/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.12.2 h1:hmehfr+H6izIcoa0oX6v5HP8FxDZutug/r+3mDmCXU8=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.12.2/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.11.0 h1:6MUiyfP5tKicVaYgu7Xi/LpCZh3QR8sjOlhpPKk5DzY=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.11.0/go.mod h1:6DPwGu8oGR1sZRpjwkcAnrQZWQuAJ/Ph+rQHfUo1Yf4=
 github.com/hashicorp/vault-plugin-secrets-kv v0.11.0 h1:xSvgh7ObLo3MhVzmGhOxiWND++cTP/QM2LxTmpYim/Q=


### PR DESCRIPTION
This PR backports https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/153 by upgrading the plugin to [v0.12.2](https://github.com/hashicorp/vault-plugin-secrets-gcp/releases/tag/v0.12.2).