### PR TITLE
Backport 1.11.x: secrets/gcp - Fixes duplicate service account key for rotate root on standby or secondary

### DIFF
--- a/changelog/18110.txt
+++ b/changelog/18110.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/gcp: Fixes duplicate service account key for rotate root on standby or secondary
+```

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-ad v0.13.1
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.12.0
 	github.com/hashicorp/vault-plugin-secrets-azure v0.13.1
-	github.com/hashicorp/vault-plugin-secrets-gcp v0.13.1
+	github.com/hashicorp/vault-plugin-secrets-gcp v0.13.2
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.12.0
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.1
 	github.com/hashicorp/vault-plugin-secrets-kv v0.12.1

--- a/go.sum
+++ b/go.sum
@@ -1000,8 +1000,8 @@ github.com/hashicorp/vault-plugin-secrets-alicloud v0.12.0 h1:4Ke3dtM7ARa9ga2jI2
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.12.0/go.mod h1:F4KWrlCQZbhP2dFXCkRvbHX2J6CTydlaY0cH+OrLHCE=
 github.com/hashicorp/vault-plugin-secrets-azure v0.13.1 h1:zl7v7mUA0b620iS2E8vIygKSJcn0L7/REbsa/MkR0gw=
 github.com/hashicorp/vault-plugin-secrets-azure v0.13.1/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.13.1 h1:6aUi1Y9jGBoWm58wsJnq8xerxAsxXjdeFsgUle1eIqw=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.13.1/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.13.2 h1:i2z3cU2WH2ihfm4hinAf8BBuaaR/UPc/yfpG1CDdj18=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.13.2/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.12.0 h1:MXqB1waq3L18eUhTZ7ng14MbjOiAlwANgZCVUwoLBXo=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.12.0/go.mod h1:6DPwGu8oGR1sZRpjwkcAnrQZWQuAJ/Ph+rQHfUo1Yf4=
 github.com/hashicorp/vault-plugin-secrets-kubernetes v0.1.1 h1:KiYpZpQv7X7Tm9wHUvboC2CyquwmjMhrPU2DvTcPC8o=


### PR DESCRIPTION
This PR backports https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/153 by upgrading the plugin to [v0.13.2](https://github.com/hashicorp/vault-plugin-secrets-gcp/releases/tag/v0.13.2).