### PR TITLE
Add stack trace to audit logging panic recovery

### DIFF
--- a/changelog/18121.txt
+++ b/changelog/18121.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+audit: Include stack trace when audit logging recovers from a panic.
+```

--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -105,7 +106,7 @@ func (a *AuditBroker) LogRequest(ctx context.Context, in *logical.LogInput, head
 
 	defer func() {
 		if r := recover(); r != nil {
-			a.logger.Error("panic during logging", "request_path", in.Request.Path, "error", r)
+			a.logger.Error("panic during logging", "request_path", in.Request.Path, "error", r, "stacktrace", string(debug.Stack()))
 			retErr = multierror.Append(retErr, fmt.Errorf("panic generating audit log"))
 		}
 
@@ -176,7 +177,7 @@ func (a *AuditBroker) LogResponse(ctx context.Context, in *logical.LogInput, hea
 
 	defer func() {
 		if r := recover(); r != nil {
-			a.logger.Error("panic during logging", "request_path", in.Request.Path, "error", r)
+			a.logger.Error("panic during logging", "request_path", in.Request.Path, "error", r, "stacktrace", string(debug.Stack()))
 			retErr = multierror.Append(retErr, fmt.Errorf("panic generating audit log"))
 		}
 

--- a/vault/request_forwarding_rpc.go
+++ b/vault/request_forwarding_rpc.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 	"os"
-	"runtime"
+	"runtime/debug"
 	"sync/atomic"
 	"time"
 
@@ -41,12 +41,8 @@ func (s *forwardedRequestRPCServer) ForwardRequest(ctx context.Context, freq *fo
 
 	runRequest := func() {
 		defer func() {
-			// Logic here comes mostly from the Go source code
 			if err := recover(); err != nil {
-				const size = 64 << 10
-				buf := make([]byte, size)
-				buf = buf[:runtime.Stack(buf, false)]
-				s.core.logger.Error("panic serving forwarded request", "path", req.URL.Path, "error", err, "stacktrace", string(buf))
+				s.core.logger.Error("panic serving forwarded request", "path", req.URL.Path, "error", err, "stacktrace", string(debug.Stack()))
 			}
 		}()
 		s.handler.ServeHTTP(w, req)


### PR DESCRIPTION
Adds a stack trace to the logs when we recover from a panic, otherwise we only get the panic error string, and no code location for where it came from.

The only other bit of production code we add a `recover` to is: https://github.com/hashicorp/vault/blob/c73a6a4a9e5d5b4e27a51102c8243351d40f1386/builtin/logical/ssh/path_issue_sign.go#L477

It wasn't clear to me that we would want a stack trace in that instance, so I've left it alone.