### PR TITLE
Optionally create the vault user in packaging post-install

### DIFF
--- a/.release/linux/postrm
+++ b/.release/linux/postrm
@@ -2,7 +2,9 @@
 
 if [ "$1" = "purge" ]
 then
-  userdel vault
+	if command -v userdel &> /dev/null; then
+		userdel vault
+	fi
 fi
 
 exit 0

--- a/.release/linux/preinst
+++ b/.release/linux/preinst
@@ -5,9 +5,11 @@ set -eu
 USER="vault"
 
 if ! id -u $USER > /dev/null 2>&1; then
-	useradd \
-		--system \
-		--user-group \
-		--shell /bin/false \
-		$USER
+	if command -v useradd &> /dev/null; then
+		useradd \
+			--system \
+			--user-group \
+			--shell /bin/false \
+			$USER
+	fi
 fi


### PR DESCRIPTION
 - Only create the `vault` user if the `useradd` command is present on the system, similarly for the purge option on the package removal, call `userdel` only if the command is present on the system

 - This will help rpm/deb installation on minimal containers that people want to use the `vault` as a command line application and not as a server.

DRAFT: I'm creating this PR to see the resulting rpm/deb's created by CRT