### PR TITLE
UI: OIDC callback bug.

### DIFF
--- a/changelog/18138.txt
+++ b/changelog/18138.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: wait for wanted message event during OIDC callback instead of using the first message event
+```

--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -94,10 +94,7 @@ export default Component.extend({
     // ensure that postMessage event is from expected source
     while (true) {
       const event = yield waitForEvent(thisWindow, 'message');
-      if (event.origin !== thisWindow.origin || !event.isTrusted) {
-        return this.handleOIDCError();
-      }
-      if (event.data.source === 'oidc-callback') {
+      if (event.origin === thisWindow.origin && event.isTrusted && event.data.source === 'oidc-callback') {
         return this.exchangeOIDC.perform(event.data, oidcWindow);
       }
       // continue to wait for the correct message


### PR DESCRIPTION
When implementing vault with our OIDC provider, the popup window never closes and the OIDC callback never succeeds. This is because the main window is listening for message events from the popup window. However, in our OIDC consent page other message events originating from Intercom are sent and these break the callback handling. This is because the code implemented in https://github.com/hashicorp/vault/pull/13133 will error if the first message event is not the one Vault expects. This PR effectively inverses the `if` statement so that the `while` loop will function properly and wait for the proper event to catch.

The events listed in the browser by executing `monitorEvents(window,"message")` in the browser console:

![image](https://user-images.githubusercontent.com/28541758/204566813-b66eddad-0e96-4c36-8c81-4106d1b217fc.png)

The popup window for the OIDC login flow that is being referred to:
![image](https://user-images.githubusercontent.com/28541758/204567129-807e9c9b-1f3a-4bcd-af76-c987e9332843.png)