### PR TITLE
Add more logging to pkiext nginx tests

### DIFF
--- a/builtin/logical/pkiext/nginx_test.go
+++ b/builtin/logical/pkiext/nginx_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -69,6 +70,8 @@ server {
 	ssl_client_certificate /etc/nginx/ssl/root.pem;
 	ssl_crl /etc/nginx/ssl/crl.pem;
 	ssl_verify_client on;
+	ssl_session_cache off;
+	ssl_session_tickets off;
 
 	if ($ssl_client_verify != SUCCESS) {
 		return 403;
@@ -100,6 +103,7 @@ server {
 		ImageTag:      imageTag,
 		ContainerName: containerName,
 		Ports:         []string{"443/tcp"},
+		Entrypoint:    []string{"nginx-debug", "-g", "daemon off;"},
 		LogConsumer: func(s string) {
 			if t.Failed() {
 				t.Logf("container logs: %s", s)
@@ -636,4 +640,6 @@ func verifyCertInCRL(t *testing.T, cert string, crl string) {
 	_cert := parseCert(t, cert)
 	_crl := parseCRL(t, crl)
 	requireSerialNumberInCRL(t, _crl, _cert)
+
+	t.Logf("Verified %v was in CRL\n", hex.EncodeToString(_cert.SerialNumber.Bytes()))
 }

--- a/builtin/logical/pkiext/test_helpers.go
+++ b/builtin/logical/pkiext/test_helpers.go
@@ -65,18 +65,14 @@ func parseKey(t *testing.T, pemKey string) crypto.Signer {
 	return key
 }
 
-func requireSerialNumberInCRL(t *testing.T, revokeList pkix.TBSCertificateList, cert *x509.Certificate) bool {
+func requireSerialNumberInCRL(t *testing.T, revokeList pkix.TBSCertificateList, cert *x509.Certificate) {
 	for _, revokeEntry := range revokeList.RevokedCertificates {
 		if revokeEntry.SerialNumber.Cmp(cert.SerialNumber) == 0 {
-			return true
+			return
 		}
 	}
 
-	if t != nil {
-		t.Fatalf("the serial number for cert %v, was not found in the CRL list containing: %v", cert, revokeList)
-	}
-
-	return false
+	t.Fatalf("the serial number for cert %v, was not found in the CRL list containing: %v", cert, revokeList)
 }
 
 func parseCRL(t *testing.T, crlPem string) pkix.TBSCertificateList {


### PR DESCRIPTION
This adds some more logging & potential that might help.

So far I'm at 24 executions:

> [cipherboy@xps15 vault]$ vgt -c -o pkiext.test ./.../builtin/logical/pkiext && untilfail -delay=2s -parallel=5 ./pkiext.test 
> 24

Which is higher than I've gotten before, but that's not quite out of the weeds. We'll see what CI says about it. 