### PR TITLE
Fix vault cli namespace patch examples

### DIFF
--- a/changelog/18143.txt
+++ b/changelog/18143.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+command: Fix vault cli namespace patch examples.
+```

--- a/changelog/18143.txt
+++ b/changelog/18143.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-command: Fix vault cli namespace patch examples.
+command/namespace: Fix vault cli namespace patch examples in help text.
 ```

--- a/command/namespace_patch.go
+++ b/command/namespace_patch.go
@@ -37,11 +37,11 @@ Usage: vault namespace patch [options] PATH
 
   Patch an existing child namespace by adding and removing custom-metadata (e.g. ns1/):
 
-      $ vault namespace patch ns1 -custom-metadata=foo=abc -remove-custom-metadata=bar
+      $ vault namespace patch -custom-metadata=foo=abc -remove-custom-metadata=bar ns1
 
   Patch an existing child namespace from a parent namespace (e.g. ns1/ns2/):
 
-      $ vault namespace patch -namespace=ns1 ns2 -custom-metadata=foo=abc
+      $ vault namespace patch -namespace=ns1 -custom-metadata=foo=abc ns2
 
 ` + c.Flags().Help()
 


### PR DESCRIPTION
Correct the help text for Vault CLI namespace patch examples.