### PR TITLE
Approle: Fix CIDR validation for /32 masks on Token Bound CIDRs

### DIFF
--- a/builtin/credential/approle/path_role_test.go
+++ b/builtin/credential/approle/path_role_test.go
@@ -619,6 +619,66 @@ func TestAppRole_CIDRSubset(t *testing.T) {
 	}
 }
 
+func TestAppRole_TokenBoundCIDRSubset32Mask(t *testing.T) {
+	var resp *logical.Response
+	var err error
+
+	b, storage := createBackendWithStorage(t)
+
+	roleData := map[string]interface{}{
+		"role_id":           "role-id-123",
+		"policies":          "a,b",
+		"token_bound_cidrs": "127.0.0.1/32",
+	}
+
+	roleReq := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "role/testrole1",
+		Storage:   storage,
+		Data:      roleData,
+	}
+
+	resp, err = b.HandleRequest(context.Background(), roleReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err: %v resp: %#v", err, resp)
+	}
+
+	secretIDData := map[string]interface{}{
+		"token_bound_cidrs": "127.0.0.1/32",
+	}
+	secretIDReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Storage:   storage,
+		Path:      "role/testrole1/secret-id",
+		Data:      secretIDData,
+	}
+
+	resp, err = b.HandleRequest(context.Background(), secretIDReq)
+	if err != nil {
+		t.Fatalf("err: %v resp: %#v", err, resp)
+	}
+
+	secretIDData = map[string]interface{}{
+		"token_bound_cidrs": "127.0.0.1/24",
+	}
+	secretIDReq = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Storage:   storage,
+		Path:      "role/testrole1/secret-id",
+		Data:      secretIDData,
+	}
+
+	resp, err = b.HandleRequest(context.Background(), secretIDReq)
+	if resp != nil {
+		t.Fatalf("resp:%#v", resp)
+	}
+
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+}
+
 func TestAppRole_RoleConstraints(t *testing.T) {
 	var resp *logical.Response
 	var err error

--- a/builtin/credential/approle/path_role_test.go
+++ b/builtin/credential/approle/path_role_test.go
@@ -676,7 +676,6 @@ func TestAppRole_TokenBoundCIDRSubset32Mask(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error")
 	}
-
 }
 
 func TestAppRole_RoleConstraints(t *testing.T) {

--- a/changelog/18145.txt
+++ b/changelog/18145.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/approle: Fix `token_bound_cidrs` validation when using /32 blocks for role and secret ID
+```


### PR DESCRIPTION
This PR fixes an issue when attempting to use /32 CIDR blocks for Token Bound CIDR restrictions and Secret ID CIDR restrictions. When setting `token_bound_cidrs` on a role definition containing a CIDR block with the /32 mask, the block gets stored as a single IP address string. When setting `token_bound_cidrs` when generating a new Secret ID, Vault validates that the blocks defined in the Secret ID configuration are a subset of the CIDR blocks defined on the role. In the case of a /32 mask, since we store it as a single IP without the mask, this validation fails. This change checks for any blocks that may exist in the `token_bound_cidrs` configuration on the role definition that do not have a mask, and append a `/32` to the block to allow for proper validation.