### PR TITLE
Kubernetes Configuration View

### DIFF
--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -50,7 +50,7 @@ export default class App extends Application {
     },
     kubernetes: {
       dependencies: {
-        services: ['router', 'store', 'secret-mount-path'],
+        services: ['router', 'store', 'secret-mount-path', 'flashMessages'],
         externalRoutes: {
           secrets: 'vault.cluster.secrets.backends',
         },

--- a/ui/app/styles/core/helpers.scss
+++ b/ui/app/styles/core/helpers.scss
@@ -95,6 +95,9 @@
 .is-auto-width {
   width: auto;
 }
+.is-min-width-0 {
+  min-width: 0;
+}
 
 .is-flex-between,
 .is-grouped-split {
@@ -134,8 +137,19 @@
 .has-tall-padding {
   padding: 2.25rem;
 }
+.has-side-padding-s {
+  padding-left: $spacing-s;
+  padding-right: $spacing-s;
+}
+.has-padding-m {
+  padding: $spacing-m;
+}
 .has-top-bottom-margin {
   margin: 1.25rem 0rem;
+}
+.has-top-bottom-margin-negative-m {
+  margin-top: -$spacing-m;
+  margin-bottom: -$spacing-m;
 }
 
 .is-sideless.has-short-padding {
@@ -152,6 +166,13 @@
   word-wrap: break-word;
   word-break: break-word;
   white-space: pre-wrap;
+}
+.truncate-second-line {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 .is-font-mono {
   font-family: $family-monospace;

--- a/ui/lib/kubernetes/addon/components/config-cta.hbs
+++ b/ui/lib/kubernetes/addon/components/config-cta.hbs
@@ -1,0 +1,9 @@
+<EmptyState
+  data-test-config-cta
+  @title="Kubernetes not configured"
+  @message="Get started by establishing the URL of the Kubernetes API to connect to, along with some additional options."
+>
+  <LinkTo class="has-top-margin-xs" @route="configuration">
+    Configure Kubernetes
+  </LinkTo>
+</EmptyState>

--- a/ui/lib/kubernetes/addon/components/page/configuration.hbs
+++ b/ui/lib/kubernetes/addon/components/page/configuration.hbs
@@ -1,0 +1,49 @@
+<TabPageHeader @model={{@model.backend}}>
+  <ToolbarLink @route="configure" data-test-toolbar-config-action>
+    {{if @model.config "Edit configuration" "Configure Kubernetes"}}
+  </ToolbarLink>
+</TabPageHeader>
+
+{{#if @model.config}}
+  {{#if @model.config.disableLocalCaJwt}}
+    <InfoTableRow @label="Kubernetes host" @value={{@model.config.kubernetesHost}} />
+    <InfoTableRow @label="Certificate">
+      <div class="column is-half box is-rounded">
+        <div class="is-flex-row">
+          <span class="has-left-margin-s">
+            <Icon @name="certificate" @size="24" data-test-certificate-icon />
+          </span>
+          <div class="has-left-margin-m is-min-width-0">
+            <p class="has-text-weight-bold" data-test-certificate-label>
+              PEM Format
+            </p>
+            <code class="is-size-8 truncate-second-line has-text-grey" data-test-certificate-value>
+              {{@model.config.kubernetesCaCert}}
+            </code>
+          </div>
+          <div class="is-flex has-background-grey-lighter has-side-padding-s has-top-bottom-margin-negative-m">
+            <CopyButton
+              data-test-certificate-copy
+              class="button is-transparent is-flex-v-centered"
+              @clipboardText={{@model.config.kubernetesCaCert}}
+              @buttonType="button"
+              @success={{action (set-flash-message "Certificate copied")}}
+            >
+              <Icon @name="clipboard-copy" aria-label="Copy" />
+            </CopyButton>
+          </div>
+        </div>
+      </div>
+    </InfoTableRow>
+  {{else}}
+    <div class="has-top-margin-l" data-test-inferred-message>
+      <Icon @name="check-circle-fill" class="has-text-green" />
+      <span>
+        These details were successfully inferred from Vault’s kubernetes environment and were not explicity set in this
+        config.
+      </span>
+    </div>
+  {{/if}}
+{{else}}
+  <ConfigCta />
+{{/if}}

--- a/ui/lib/kubernetes/addon/components/tab-page-header.hbs
+++ b/ui/lib/kubernetes/addon/components/tab-page-header.hbs
@@ -1,0 +1,38 @@
+<PageHeader as |p|>
+  <p.top>
+    <nav class="breadcrumb" aria-label="breadcrumbs" data-test-breadcrumbs>
+      <ul>
+        <li data-test-crumb="secrets">
+          <span class="sep">/</span>
+          <LinkToExternal @route="secrets">secrets</LinkToExternal>
+        </li>
+        <li>
+          <span class="sep">/</span>
+          <span data-test-crumb="path">{{@model.id}}</span>
+        </li>
+      </ul>
+    </nav>
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3" data-test-header-title>
+      <Icon @name={{@model.icon}} @size="24" class="has-text-grey-light" />
+      {{@model.id}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
+
+<div class="tabs-container box is-bottomless is-marginless is-paddingless">
+  <nav class="tabs" aria-label="kubernetes tabs">
+    <ul>
+      <LinkTo @route="overview" data-test-tab="overview">Overview</LinkTo>
+      <LinkTo @route="roles" data-test-tab="roles">Roles</LinkTo>
+      <LinkTo @route="configuration" data-test-tab="config">Configuration</LinkTo>
+    </ul>
+  </nav>
+</div>
+
+<Toolbar>
+  <ToolbarActions>
+    {{yield}}
+  </ToolbarActions>
+</Toolbar>

--- a/ui/lib/kubernetes/addon/engine.js
+++ b/ui/lib/kubernetes/addon/engine.js
@@ -11,7 +11,7 @@ export default class KubernetesEngine extends Engine {
   modulePrefix = modulePrefix;
   Resolver = Resolver;
   dependencies = {
-    services: ['router', 'store', 'secret-mount-path'],
+    services: ['router', 'store', 'secret-mount-path', 'flashMessages'],
     externalRoutes: ['secrets'],
   };
 }

--- a/ui/lib/kubernetes/addon/routes.js
+++ b/ui/lib/kubernetes/addon/routes.js
@@ -11,7 +11,5 @@ export default buildRoutes(function () {
     });
   });
   this.route('configure');
-  this.route('configuration', function () {
-    this.route('edit');
-  });
+  this.route('configuration');
 });

--- a/ui/lib/kubernetes/addon/routes/configuration.js
+++ b/ui/lib/kubernetes/addon/routes/configuration.js
@@ -1,0 +1,10 @@
+import FetchConfigRoute from './fetch-config';
+
+export default class KubernetesConfigureRoute extends FetchConfigRoute {
+  model() {
+    return {
+      backend: this.modelFor('application'),
+      config: this.configModel,
+    };
+  }
+}

--- a/ui/lib/kubernetes/addon/routes/configuration/edit.js
+++ b/ui/lib/kubernetes/addon/routes/configuration/edit.js
@@ -1,3 +1,0 @@
-import Route from '@ember/routing/route';
-
-export default class KubernetesConfigurationEditRoute extends Route {}

--- a/ui/lib/kubernetes/addon/routes/configuration/index.js
+++ b/ui/lib/kubernetes/addon/routes/configuration/index.js
@@ -1,3 +1,0 @@
-import Route from '@ember/routing/route';
-
-export default class KubernetesConfigurationRoute extends Route {}

--- a/ui/lib/kubernetes/addon/templates/configuration.hbs
+++ b/ui/lib/kubernetes/addon/templates/configuration.hbs
@@ -1,0 +1,1 @@
+<Page::Configuration @model={{this.model}} />

--- a/ui/lib/kubernetes/addon/templates/configuration/edit.hbs
+++ b/ui/lib/kubernetes/addon/templates/configuration/edit.hbs
@@ -1,1 +1,0 @@
-Configuration Edit

--- a/ui/lib/kubernetes/addon/templates/configuration/index.hbs
+++ b/ui/lib/kubernetes/addon/templates/configuration/index.hbs
@@ -1,1 +1,0 @@
-Configuration

--- a/ui/mirage/factories/kubernetes-config.js
+++ b/ui/mirage/factories/kubernetes-config.js
@@ -2,8 +2,9 @@ import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   kubernetes_host: 'https://192.168.99.100:8443',
-  kubernetes_ca_cert: '-----BEGIN CERTIFICATE-----\n.....\n-----END CERTIFICATE-----',
-  disable_local_ca_jwt: false,
+  kubernetes_ca_cert:
+    '-----BEGIN CERTIFICATE-----\nMIIDNTCCAh2gApGgAwIBAgIULNEk+01LpkDeJujfsAgIULNEkAgIULNEckApGgAwIBAg+01LpkDeJuj\n-----END CERTIFICATE-----',
+  disable_local_ca_jwt: true,
 
   // property used only for record lookup and filtered from response payload
   path: null,

--- a/ui/mirage/factories/kubernetes-role.js
+++ b/ui/mirage/factories/kubernetes-role.js
@@ -1,7 +1,7 @@
 import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  name: 'default-role',
+  name: (i) => `role-${i}`,
   allowed_kubernetes_namespaces: () => ['*'],
   allowed_kubernetes_namespace_selector: '',
   token_max_ttl: 86400,

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -1,4 +1,12 @@
+import ENV from 'vault/config/environment';
+const { handler } = ENV['ember-cli-mirage'];
+
 export default function (server) {
   server.create('clients/config');
   server.create('feature', { feature_flags: ['SOME_FLAG', 'VAULT_CLOUD_ADMIN_NAMESPACE'] });
+
+  if (handler === 'kubernetes') {
+    server.create('kubernetes-config', { path: 'kubernetes' });
+    server.createList('kubernetes-role', 5);
+  }
 }

--- a/ui/tests/integration/components/kubernetes/config-cta-test.js
+++ b/ui/tests/integration/components/kubernetes/config-cta-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupEngine } from 'ember-engines/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | kubernetes | ConfigCta', function (hooks) {
+  setupRenderingTest(hooks);
+  setupEngine(hooks, 'kubernetes');
+  setupMirage(hooks);
+
+  test('it should render message and action', async function (assert) {
+    await render(hbs`<ConfigCta />`, { owner: this.engine });
+    assert.dom('[data-test-empty-state-title]').hasText('Kubernetes not configured', 'Title renders');
+    assert
+      .dom('[data-test-empty-state-message]')
+      .hasText(
+        'Get started by establishing the URL of the Kubernetes API to connect to, along with some additional options.',
+        'Message renders'
+      );
+    assert.dom('[data-test-config-cta] a').hasText('Configure Kubernetes', 'Action renders');
+  });
+});

--- a/ui/tests/integration/components/kubernetes/page/configuration-test.js
+++ b/ui/tests/integration/components/kubernetes/page/configuration-test.js
@@ -1,0 +1,82 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupEngine } from 'ember-engines/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | kubernetes | Page::Configuration', function (hooks) {
+  setupRenderingTest(hooks);
+  setupEngine(hooks, 'kubernetes');
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.store.pushPayload('secret-engine', {
+      modelName: 'secret-engine',
+      data: {
+        accessor: 'kubernetes_f3400dee',
+        path: 'kubernetes-test/',
+        type: 'kubernetes',
+      },
+    });
+    this.model = {
+      backend: this.store.peekRecord('secret-engine', 'kubernetes-test'),
+      config: null,
+    };
+    this.setConfig = (disableLocal) => {
+      const data = this.server.create(
+        'kubernetes-config',
+        !disableLocal ? { disable_local_ca_jwt: false } : null
+      );
+      this.store.pushPayload('kubernetes/config', {
+        modelName: 'kubernetes/config',
+        backend: 'kubernetes-test',
+        ...data,
+      });
+      this.model.config = this.store.peekRecord('kubernetes/config', 'kubernetes-test');
+    };
+  });
+
+  test('it should render tab page header and config cta', async function (assert) {
+    await render(hbs`<Page::Configuration @model={{this.model}} />`, { owner: this.engine });
+    assert.dom('.title svg').hasClass('flight-icon-kubernetes', 'Kubernetes icon renders in title');
+    assert.dom('.title').hasText('kubernetes-test', 'Mount path renders in title');
+    assert
+      .dom('[data-test-toolbar-config-action]')
+      .hasText('Configure Kubernetes', 'Toolbar action has correct text');
+    assert.dom('[data-test-config-cta]').exists('Config cta renders');
+  });
+
+  test('it should render message for inferred configuration', async function (assert) {
+    this.setConfig(false);
+    await render(hbs`<Page::Configuration @model={{this.model}} />`, { owner: this.engine });
+    assert
+      .dom('[data-test-inferred-message] svg')
+      .hasClass('flight-icon-check-circle-fill', 'Inferred message icon renders');
+    const message =
+      'These details were successfully inferred from Vault’s kubernetes environment and were not explicity set in this config.';
+    assert.dom('[data-test-inferred-message]').hasText(message, 'Inferred message renders');
+    assert
+      .dom('[data-test-toolbar-config-action]')
+      .hasText('Edit configuration', 'Toolbar action has correct text');
+  });
+
+  test('it should render host and certificate info', async function (assert) {
+    this.setConfig(true);
+    await render(hbs`<Page::Configuration @model={{this.model}} />`, { owner: this.engine });
+    assert.dom('[data-test-row-label="Kubernetes host"]').exists('Kubernetes host label renders');
+    assert
+      .dom('[data-test-row-value="Kubernetes host"]')
+      .hasText(this.model.config.kubernetesHost, 'Kubernetes host value renders');
+    assert.dom('[data-test-row-label="Certificate"]').exists('Certificate label renders');
+    assert
+      .dom('[data-test-certificate-icon]')
+      .hasClass('flight-icon-certificate', 'Certificate card icon renders');
+    assert.dom('[data-test-certificate-label]').hasText('PEM Format', 'Certificate card label renders');
+    assert
+      .dom('[data-test-certificate-value]')
+      .hasText(this.model.config.kubernetesCaCert, 'Certificate card value renders');
+    assert.dom('[data-test-certificate-copy]').exists('Certificate copy button renders');
+  });
+});

--- a/ui/tests/integration/components/kubernetes/page/configure-test.js
+++ b/ui/tests/integration/components/kubernetes/page/configure-test.js
@@ -8,7 +8,7 @@ import { configVarUri } from '../../../../../mirage/handlers/kubernetes';
 import { Response } from 'miragejs';
 import sinon from 'sinon';
 
-module('Integration | Component | kubernetes | Page:Configure', function (hooks) {
+module('Integration | Component | kubernetes | Page::Configure', function (hooks) {
   setupRenderingTest(hooks);
   setupEngine(hooks, 'kubernetes');
   setupMirage(hooks);

--- a/ui/tests/integration/components/kubernetes/tab-page-header-test.js
+++ b/ui/tests/integration/components/kubernetes/tab-page-header-test.js
@@ -1,0 +1,62 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupEngine } from 'ember-engines/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | kubernetes | TabPageHeader', function (hooks) {
+  setupRenderingTest(hooks);
+  setupEngine(hooks, 'kubernetes');
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.store.pushPayload('secret-engine', {
+      modelName: 'secret-engine',
+      data: {
+        accessor: 'kubernetes_f3400dee',
+        path: 'kubernetes-test/',
+        type: 'kubernetes',
+      },
+    });
+    this.model = this.store.peekRecord('secret-engine', 'kubernetes-test');
+    this.mount = this.model.path.slice(0, -1);
+  });
+
+  test('it should render breadcrumbs', async function (assert) {
+    await render(hbs`<TabPageHeader @model={{this.model}} />`, { owner: this.engine });
+    assert.dom('[data-test-crumb="secrets"] a').hasText('secrets', 'Secrets breadcrumb renders');
+    assert.dom('[data-test-crumb="path"]').hasText(this.mount, 'Mount path breadcrumb renders');
+  });
+
+  test('it should render title', async function (assert) {
+    await render(hbs`<TabPageHeader @model={{this.model}} />`, { owner: this.engine });
+    assert
+      .dom('[data-test-header-title] svg')
+      .hasClass('flight-icon-kubernetes', 'Correct icon renders in title');
+    assert.dom('[data-test-header-title]').hasText(this.mount, 'Mount path renders in title');
+  });
+
+  test('it should render tabs', async function (assert) {
+    await render(hbs`<TabPageHeader @model={{this.model}} />`, { owner: this.engine });
+    assert.dom('[data-test-tab="overview"]').hasText('Overview', 'Overview tab renders');
+    assert.dom('[data-test-tab="roles"]').hasText('Roles', 'Roles tab renders');
+    assert.dom('[data-test-tab="config"]').hasText('Configuration', 'Configuration tab renders');
+  });
+
+  test('it should yield block for toolbar actions', async function (assert) {
+    await render(
+      hbs`
+      <TabPageHeader @model={{this.model}}>
+        <span data-test-yield>It yields!</span>
+      </TabPageHeader>
+    `,
+      { owner: this.engine }
+    );
+
+    assert
+      .dom('.toolbar-actions [data-test-yield]')
+      .hasText('It yields!', 'Block is yielded for toolbar actions');
+  });
+});


### PR DESCRIPTION
Configuration view for Kubernetes secrets engine:
- adds `TabPageHeader` component for use in tab (overview, roles, configuration) routes
- adds `ConfigCta` empty state wrapper component for use across tab routes
- adds page component for configuration view
- removes unneeded configuration edit and index routes 
- adds block for kubernetes in mirage default scenario for seeding db