### PR TITLE
Backport: Add read support to sys/loggers endpoints

### DIFF
--- a/changelog/17979.txt
+++ b/changelog/17979.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Add read support to `sys/loggers` and `sys/loggers/:name` endpoints
+```

--- a/helper/logging/logger.go
+++ b/helper/logging/logger.go
@@ -1,0 +1,135 @@
+package logging
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	log "github.com/hashicorp/go-hclog"
+)
+
+const (
+	UnspecifiedFormat LogFormat = iota
+	StandardFormat
+	JSONFormat
+)
+
+type LogFormat int
+
+// LogConfig should be used to supply configuration when creating a new Vault logger
+type LogConfig struct {
+	name        string
+	logLevel    log.Level
+	logFormat   LogFormat
+	logFilePath string
+}
+
+func NewLogConfig(name string, logLevel log.Level, logFormat LogFormat, logFilePath string) LogConfig {
+	return LogConfig{
+		name:        name,
+		logLevel:    logLevel,
+		logFormat:   logFormat,
+		logFilePath: strings.TrimSpace(logFilePath),
+	}
+}
+
+func (c LogConfig) IsFormatJson() bool {
+	return c.logFormat == JSONFormat
+}
+
+// Stringer implementation
+func (lf LogFormat) String() string {
+	switch lf {
+	case UnspecifiedFormat:
+		return "unspecified"
+	case StandardFormat:
+		return "standard"
+	case JSONFormat:
+		return "json"
+	}
+
+	// unreachable
+	return "unknown"
+}
+
+// noErrorWriter is a wrapper to suppress errors when writing to w.
+type noErrorWriter struct {
+	w io.Writer
+}
+
+func (w noErrorWriter) Write(p []byte) (n int, err error) {
+	_, _ = w.w.Write(p)
+	// We purposely return n == len(p) as if write was successful
+	return len(p), nil
+}
+
+// Setup creates a new logger with the specified configuration and writer
+func Setup(config LogConfig, w io.Writer) (log.InterceptLogger, error) {
+	// Validate the log level
+	if config.logLevel.String() == "unknown" {
+		return nil, fmt.Errorf("invalid log level: %v", config.logLevel)
+	}
+
+	// If out is os.Stdout and Vault is being run as a Windows Service, writes will
+	// fail silently, which may inadvertently prevent writes to other writers.
+	// noErrorWriter is used as a wrapper to suppress any errors when writing to out.
+	writers := []io.Writer{noErrorWriter{w: w}}
+
+	if config.logFilePath != "" {
+		dir, fileName := filepath.Split(config.logFilePath)
+		if fileName == "" {
+			fileName = "vault-agent.log"
+		}
+		logFile := NewLogFile(dir, fileName)
+		if err := logFile.openNew(); err != nil {
+			return nil, fmt.Errorf("failed to set up file logging: %w", err)
+		}
+		writers = append(writers, logFile)
+	}
+
+	logger := log.NewInterceptLogger(&log.LoggerOptions{
+		Name:       config.name,
+		Level:      config.logLevel,
+		Output:     io.MultiWriter(writers...),
+		JSONFormat: config.IsFormatJson(),
+	})
+	return logger, nil
+}
+
+// ParseLogFormat parses the log format from the provided string.
+func ParseLogFormat(format string) (LogFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "":
+		return UnspecifiedFormat, nil
+	case "standard":
+		return StandardFormat, nil
+	case "json":
+		return JSONFormat, nil
+	default:
+		return UnspecifiedFormat, fmt.Errorf("unknown log format: %s", format)
+	}
+}
+
+func ParseLogLevel(logLevel string) (log.Level, error) {
+	var result log.Level
+	logLevel = strings.ToLower(strings.TrimSpace(logLevel))
+
+	switch logLevel {
+	case "trace":
+		result = log.Trace
+	case "debug":
+		result = log.Debug
+	case "notice", "info", "":
+		result = log.Info
+	case "warn", "warning":
+		result = log.Warn
+	case "err", "error":
+		result = log.Error
+	default:
+		return -1, errors.New(fmt.Sprintf("unknown log level: %s", logLevel))
+	}
+
+	return result, nil
+}

--- a/helper/logging/logger.go
+++ b/helper/logging/logger.go
@@ -112,6 +112,8 @@ func ParseLogFormat(format string) (LogFormat, error) {
 	}
 }
 
+// ParseLogLevel returns the hclog.Level that corresponds with the provided level string.
+// This differs hclog.LevelFromString in that it supports additional level strings.
 func ParseLogLevel(logLevel string) (log.Level, error) {
 	var result log.Level
 	logLevel = strings.ToLower(strings.TrimSpace(logLevel))
@@ -129,6 +131,27 @@ func ParseLogLevel(logLevel string) (log.Level, error) {
 		result = log.Error
 	default:
 		return -1, errors.New(fmt.Sprintf("unknown log level: %s", logLevel))
+	}
+
+	return result, nil
+}
+
+// TranslateLoggerLevel returns the string that corresponds with logging level of the hclog.Logger.
+func TranslateLoggerLevel(logger log.Logger) (string, error) {
+	var result string
+
+	if logger.IsTrace() {
+		result = "trace"
+	} else if logger.IsDebug() {
+		result = "debug"
+	} else if logger.IsInfo() {
+		result = "info"
+	} else if logger.IsWarn() {
+		result = "warn"
+	} else if logger.IsError() {
+		result = "error"
+	} else {
+		return "", fmt.Errorf("unknown log level")
 	}
 
 	return result, nil

--- a/vault/core.go
+++ b/vault/core.go
@@ -2860,6 +2860,7 @@ func (c *Core) AddLogger(logger log.Logger) {
 	c.allLoggers = append(c.allLoggers, logger)
 }
 
+// SetLogLevel sets logging level for all tracked loggers to the level provided
 func (c *Core) SetLogLevel(level log.Level) {
 	c.allLoggersLock.RLock()
 	defer c.allLoggersLock.RUnlock()
@@ -2868,17 +2869,22 @@ func (c *Core) SetLogLevel(level log.Level) {
 	}
 }
 
-func (c *Core) SetLogLevelByName(name string, level log.Level) error {
+// SetLogLevelByName sets the logging level of named logger to level provided
+// if it exists. Core.allLoggers is a slice and as such it is entirely possible
+// that multiple entries exist for the same name. Each instance will be modified.
+func (c *Core) SetLogLevelByName(name string, level log.Level) bool {
 	c.allLoggersLock.RLock()
 	defer c.allLoggersLock.RUnlock()
+
+	found := false
 	for _, logger := range c.allLoggers {
 		if logger.Name() == name {
 			logger.SetLevel(level)
-			return nil
+			found = true
 		}
 	}
 
-	return fmt.Errorf("logger %q does not exist", name)
+	return found
 }
 
 // SetConfig sets core's config object to the newly provided config.

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -298,6 +298,10 @@ func (b *SystemBackend) configPaths() []*framework.Path {
 				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.handleLoggersRead,
+					Summary:  "Read the log level for all existing loggers.",
+				},
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback: b.handleLoggersWrite,
 					Summary:  "Modify the log level for all existing loggers.",
@@ -322,6 +326,10 @@ func (b *SystemBackend) configPaths() []*framework.Path {
 				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.handleLoggersByNameRead,
+					Summary:  "Read the log level for a single logger.",
+				},
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback: b.handleLoggersByNameWrite,
 					Summary:  "Modify the log level of a single logger.",

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -4771,66 +4771,60 @@ func TestProcessLimit(t *testing.T) {
 	}
 }
 
-func validateLevel(level string, logger hclog.Logger) bool {
-	switch level {
-	case "trace":
-		return logger.IsTrace()
-	case "debug":
-		return logger.IsDebug()
-	case "notice", "info", "":
-		return logger.IsInfo()
-	case "warn", "warning":
-		return logger.IsWarn()
-	case "err", "error":
-		return logger.IsError()
-	}
-
-	return false
-}
-
 func TestSystemBackend_Loggers(t *testing.T) {
 	testCases := []struct {
-		level       string
-		expectError bool
+		level         string
+		expectedLevel string
+		expectError   bool
 	}{
 		{
+			"trace",
 			"trace",
 			false,
 		},
 		{
 			"debug",
+			"debug",
 			false,
 		},
 		{
 			"notice",
+			"info",
 			false,
 		},
 		{
+			"info",
 			"info",
 			false,
 		},
 		{
 			"warn",
+			"warn",
 			false,
 		},
 		{
 			"warning",
+			"warn",
 			false,
 		},
 		{
 			"err",
+			"error",
 			false,
 		},
 		{
+			"error",
 			"error",
 			false,
 		},
 		{
 			"",
+			"info",
 			true,
 		},
 		{
 			"invalid",
+			"",
 			true,
 		},
 	}
@@ -4843,7 +4837,33 @@ func TestSystemBackend_Loggers(t *testing.T) {
 
 			core, b, _ := testCoreSystemBackend(t)
 
+			// Test core overrides logging level outside of config,
+			// an initial delete will ensure that we an initial read
+			// to get expected values is based off of config and not
+			// the test override that is hidden from this test
 			req := &logical.Request{
+				Path:      "loggers",
+				Operation: logical.DeleteOperation,
+			}
+
+			resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("unexpected error, err: %v, resp: %#v", err, resp)
+			}
+
+			req = &logical.Request{
+				Path:      "loggers",
+				Operation: logical.ReadOperation,
+			}
+
+			resp, err = b.HandleRequest(namespace.RootContext(nil), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("unexpected error, err: %v, resp: %#v", err, resp)
+			}
+
+			initialLoggers := resp.Data
+
+			req = &logical.Request{
 				Path:      "loggers",
 				Operation: logical.UpdateOperation,
 				Data: map[string]interface{}{
@@ -4851,7 +4871,7 @@ func TestSystemBackend_Loggers(t *testing.T) {
 				},
 			}
 
-			resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+			resp, err = b.HandleRequest(namespace.RootContext(nil), req)
 			respIsError := resp != nil && resp.IsError()
 
 			if err != nil || (!tc.expectError && respIsError) {
@@ -4863,15 +4883,32 @@ func TestSystemBackend_Loggers(t *testing.T) {
 			}
 
 			if !tc.expectError {
+				req = &logical.Request{
+					Path:      "loggers",
+					Operation: logical.ReadOperation,
+				}
+
+				resp, err = b.HandleRequest(namespace.RootContext(nil), req)
+				if err != nil || (resp != nil && resp.IsError()) {
+					t.Fatalf("unexpected error, err: %v, resp: %#v", err, resp)
+				}
+
 				for _, logger := range core.allLoggers {
-					if !validateLevel(tc.level, logger) {
-						t.Fatalf("expected logger %q to be %q", logger.Name(), tc.level)
+					loggerName := logger.Name()
+					levelRaw, ok := resp.Data[loggerName]
+
+					if !ok {
+						t.Errorf("logger %q not found in response", loggerName)
+					}
+
+					if levelStr := levelRaw.(string); levelStr != tc.expectedLevel {
+						t.Errorf("unexpected level of logger %q, expected: %s, actual: %s", loggerName, tc.expectedLevel, levelStr)
 					}
 				}
 			}
 
 			req = &logical.Request{
-				Path:      fmt.Sprintf("loggers"),
+				Path:      "loggers",
 				Operation: logical.DeleteOperation,
 			}
 
@@ -4880,9 +4917,29 @@ func TestSystemBackend_Loggers(t *testing.T) {
 				t.Fatalf("unexpected error, err: %v, resp: %#v", err, resp)
 			}
 
+			req = &logical.Request{
+				Path:      "loggers",
+				Operation: logical.ReadOperation,
+			}
+
+			resp, err = b.HandleRequest(namespace.RootContext(nil), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("unexpected error, err: %v, resp: %#v", err, resp)
+			}
+
 			for _, logger := range core.allLoggers {
-				if !validateLevel(core.logLevel, logger) {
-					t.Errorf("expected level of logger %q to match original config", logger.Name())
+				loggerName := logger.Name()
+				levelRaw, currentOk := resp.Data[loggerName]
+				initialLevelRaw, initialOk := initialLoggers[loggerName]
+
+				if !currentOk || !initialOk {
+					t.Errorf("logger %q not found", loggerName)
+				}
+
+				levelStr := levelRaw.(string)
+				initialLevelStr := initialLevelRaw.(string)
+				if levelStr != initialLevelStr {
+					t.Errorf("expected level of logger %q to match original config, expected: %s, actual: %s", loggerName, initialLevelStr, levelStr)
 				}
 			}
 		})
@@ -4893,11 +4950,13 @@ func TestSystemBackend_LoggersByName(t *testing.T) {
 	testCases := []struct {
 		logger            string
 		level             string
+		expectedLevel     string
 		expectWriteError  bool
 		expectDeleteError bool
 	}{
 		{
 			"core",
+			"trace",
 			"trace",
 			false,
 			false,
@@ -4905,17 +4964,20 @@ func TestSystemBackend_LoggersByName(t *testing.T) {
 		{
 			"token",
 			"debug",
+			"debug",
 			false,
 			false,
 		},
 		{
 			"audit",
 			"notice",
+			"info",
 			false,
 			false,
 		},
 		{
 			"expiration",
+			"info",
 			"info",
 			false,
 			false,
@@ -4923,23 +4985,27 @@ func TestSystemBackend_LoggersByName(t *testing.T) {
 		{
 			"policy",
 			"warn",
+			"warn",
 			false,
 			false,
 		},
 		{
 			"activity",
 			"warning",
+			"warn",
 			false,
 			false,
 		},
 		{
 			"identity",
 			"err",
+			"error",
 			false,
 			false,
 		},
 		{
 			"rollback",
+			"error",
 			"error",
 			false,
 			false,
@@ -4947,24 +5013,28 @@ func TestSystemBackend_LoggersByName(t *testing.T) {
 		{
 			"system",
 			"",
+			"does-not-matter",
 			true,
 			false,
 		},
 		{
 			"quotas",
 			"invalid",
+			"does-not-matter",
 			true,
 			false,
 		},
 		{
 			"",
 			"info",
+			"does-not-matter",
 			true,
 			true,
 		},
 		{
 			"does_not_exist",
 			"error",
+			"does-not-matter",
 			true,
 			true,
 		},
@@ -4978,16 +5048,41 @@ func TestSystemBackend_LoggersByName(t *testing.T) {
 
 			core, b, _ := testCoreSystemBackend(t)
 
+			// Test core overrides logging level outside of config,
+			// an initial delete will ensure that we an initial read
+			// to get expected values is based off of config and not
+			// the test override that is hidden from this test
 			req := &logical.Request{
+				Path:      "loggers",
+				Operation: logical.DeleteOperation,
+			}
+
+			resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("unexpected error, err: %v, resp: %#v", err, resp)
+			}
+
+			req = &logical.Request{
+				Path:      "loggers",
+				Operation: logical.ReadOperation,
+			}
+
+			resp, err = b.HandleRequest(namespace.RootContext(nil), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("unexpected error, err: %v, resp: %#v", err, resp)
+			}
+
+			initialLoggers := resp.Data
+
+			req = &logical.Request{
 				Path:      fmt.Sprintf("loggers/%s", tc.logger),
 				Operation: logical.UpdateOperation,
 				Data: map[string]interface{}{
-					"name":  tc.logger,
 					"level": tc.level,
 				},
 			}
 
-			resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+			resp, err = b.HandleRequest(namespace.RootContext(nil), req)
 			respIsError := resp != nil && resp.IsError()
 
 			if err != nil || (!tc.expectWriteError && respIsError) {
@@ -4999,13 +5094,34 @@ func TestSystemBackend_LoggersByName(t *testing.T) {
 			}
 
 			if !tc.expectWriteError {
+				req = &logical.Request{
+					Path:      "loggers",
+					Operation: logical.ReadOperation,
+				}
+
+				resp, err = b.HandleRequest(namespace.RootContext(nil), req)
+				if err != nil || (resp != nil && resp.IsError()) {
+					t.Fatalf("unexpected error, err: %v, resp: %#v", err, resp)
+				}
+
 				for _, logger := range core.allLoggers {
-					if logger.Name() != tc.logger && !validateLevel(core.logLevel, logger) {
-						t.Errorf("expected level of logger %q to be unchanged", logger.Name())
+					loggerName := logger.Name()
+					levelRaw, currentOk := resp.Data[loggerName]
+					initialLevelRaw, initialOk := initialLoggers[loggerName]
+
+					if !currentOk || !initialOk {
+						t.Errorf("logger %q not found", loggerName)
 					}
 
-					if !validateLevel(tc.level, logger) {
-						t.Fatalf("expected logger %q to be %q", logger.Name(), tc.level)
+					levelStr := levelRaw.(string)
+					initialLevelStr := initialLevelRaw.(string)
+
+					if loggerName == tc.logger && levelStr != tc.expectedLevel {
+						t.Fatalf("expected logger %q to be %q, actual: %s", loggerName, tc.expectedLevel, levelStr)
+					}
+
+					if loggerName != tc.logger && levelStr != initialLevelStr {
+						t.Errorf("expected level of logger %q to be unchanged, exepcted: %s, actual: %s", loggerName, initialLevelStr, levelStr)
 					}
 				}
 			}
@@ -5013,9 +5129,6 @@ func TestSystemBackend_LoggersByName(t *testing.T) {
 			req = &logical.Request{
 				Path:      fmt.Sprintf("loggers/%s", tc.logger),
 				Operation: logical.DeleteOperation,
-				Data: map[string]interface{}{
-					"name": tc.logger,
-				},
 			}
 
 			resp, err = b.HandleRequest(namespace.RootContext(nil), req)
@@ -5030,10 +5143,28 @@ func TestSystemBackend_LoggersByName(t *testing.T) {
 			}
 
 			if !tc.expectDeleteError {
-				for _, logger := range core.allLoggers {
-					if !validateLevel(core.logLevel, logger) {
-						t.Errorf("expected level of logger %q to match original config", logger.Name())
-					}
+				req = &logical.Request{
+					Path:      fmt.Sprintf("loggers/%s", tc.logger),
+					Operation: logical.ReadOperation,
+				}
+
+				resp, err = b.HandleRequest(namespace.RootContext(nil), req)
+				if err != nil || (resp != nil && resp.IsError()) {
+					t.Fatalf("unexpected error, err: %v, resp: %#v", err, resp)
+				}
+
+				currentLevel, ok := resp.Data[tc.logger].(string)
+				if !ok {
+					t.Fatalf("expected resp to include %q, resp: %#v", tc.logger, resp)
+				}
+
+				initialLevel, ok := initialLoggers[tc.logger].(string)
+				if !ok {
+					t.Fatalf("expected initial loggers to include %q, resp: %#v", tc.logger, initialLoggers)
+				}
+
+				if currentLevel != initialLevel {
+					t.Errorf("expected level of logger %q to match original config, expected: %s, actual: %s", tc.logger, initialLevel, currentLevel)
 				}
 			}
 		})

--- a/website/content/api-docs/system/loggers.mdx
+++ b/website/content/api-docs/system/loggers.mdx
@@ -8,8 +8,8 @@ description: The `/sys/loggers` endpoint is used modify the verbosity level of l
 
 The `/sys/loggers` endpoint is used modify the verbosity level of logging.
 
-!> **NOTE:** Changes made to the log level using this endpoint are not persisted and will be restored 
-to either the default log level (info) or the level specified using `log_level` in vault.hcl or the `VAULT_LOG_LEVEL` 
+!> **NOTE:** Changes made to the log level using this endpoint are not persisted and will be restored
+to either the default log level (info) or the level specified using `log_level` in vault.hcl or the `VAULT_LOG_LEVEL`
 environment variable once the Vault service is reloaded or restarted.
 
 ## Modify verbosity level of all loggers
@@ -69,6 +69,52 @@ $ curl \
     --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/loggers/core
+```
+
+## Read verbosity level of all loggers
+
+| Method | Path           |
+| :----- | :------------- |
+| `GET`  | `/sys/loggers` |
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    https://127.0.0.1:8200/v1/sys/loggers
+```
+
+### Sample Response
+
+```json
+{
+    "audit": "trace",
+    "core": "info",
+    "policy": "debug"
+}
+```
+
+## Read verbosity level of a single logger
+
+| Method | Path                 |
+| :----- | :------------------- |
+| `GET`  | `/sys/loggers/:name` |
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    https://127.0.0.1:8200/v1/sys/loggers/core
+```
+
+### Sample Response
+
+```json
+{
+    "core": "info"
+}
 ```
 
 ## Revert verbosity of all loggers to configured level


### PR DESCRIPTION
This PR is a manual backport of https://github.com/hashicorp/vault/pull/17979. This was necessary as the the `logging` helper package did not exist on the 1.12.x release branch.