### PR TITLE
Skip Formatting For NIL Secret

### DIFF
--- a/changelog/18163.txt
+++ b/changelog/18163.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli/kv: skip formatting of nil secrets
+```

--- a/changelog/18163.txt
+++ b/changelog/18163.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-cli/kv: skip formatting of nil secrets
+cli/kv: skip formatting of nil secrets for patch and put with field parameter set
 ```

--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -252,14 +252,20 @@ func (c *KVPatchCommand) Run(args []string) int {
 	if code != 0 {
 		return code
 	}
+	if secret == nil {
+		// Don't output anything if there's no secret
+		return 0
+	}
+
+	if c.flagField != "" {
+		return PrintRawField(c.UI, secret, c.flagField)
+	}
 
 	if Format(c.UI) == "table" {
 		outputPath(c.UI, fullPath, "Secret Path")
-		if secret != nil {
-			metadata := secret.Data
-			c.UI.Info(getHeaderForMap("Metadata", metadata))
-			return OutputData(c.UI, metadata)
-		}
+		metadata := secret.Data
+		c.UI.Info(getHeaderForMap("Metadata", metadata))
+		return OutputData(c.UI, metadata)
 	}
 
 	return OutputSecret(c.UI, secret)

--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -255,9 +255,11 @@ func (c *KVPatchCommand) Run(args []string) int {
 
 	if Format(c.UI) == "table" {
 		outputPath(c.UI, fullPath, "Secret Path")
-		metadata := secret.Data
-		c.UI.Info(getHeaderForMap("Metadata", metadata))
-		return OutputData(c.UI, metadata)
+		if secret != nil {
+			metadata := secret.Data
+			c.UI.Info(getHeaderForMap("Metadata", metadata))
+			return OutputData(c.UI, metadata)
+		}
 	}
 
 	return OutputSecret(c.UI, secret)

--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -218,9 +218,11 @@ func (c *KVPutCommand) Run(args []string) int {
 
 	if Format(c.UI) == "table" {
 		outputPath(c.UI, fullPath, "Secret Path")
-		metadata := secret.Data
-		c.UI.Info(getHeaderForMap("Metadata", metadata))
-		return OutputData(c.UI, metadata)
+		if secret != nil {
+			metadata := secret.Data
+			c.UI.Info(getHeaderForMap("Metadata", metadata))
+			return OutputData(c.UI, metadata)
+		}
 	}
 
 	return OutputSecret(c.UI, secret)

--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -218,11 +218,9 @@ func (c *KVPutCommand) Run(args []string) int {
 
 	if Format(c.UI) == "table" {
 		outputPath(c.UI, fullPath, "Secret Path")
-		if secret != nil {
-			metadata := secret.Data
-			c.UI.Info(getHeaderForMap("Metadata", metadata))
-			return OutputData(c.UI, metadata)
-		}
+		metadata := secret.Data
+		c.UI.Info(getHeaderForMap("Metadata", metadata))
+		return OutputData(c.UI, metadata)
 	}
 
 	return OutputSecret(c.UI, secret)


### PR DESCRIPTION
Vault is currently panicking when trying to `patch` with the `-field` parameter set.  This occurs because we are expecting there to be metadata around the secret, but none is getting returned due to the flag being set.  A check has been added to ensure that the `secret` is populated before trying to access the Data from underneath it.

Previous Error:
```console
$ vault kv patch -field=version  -method=rw -mount=kv /secrets test=- <<< "new"
4
= Secret Path =
kv/data/secrets

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x30 pc=0x103aeab1c]

goroutine 1 [running]:
github.com/hashicorp/vault/command.(*KVPatchCommand).Run(0x14000aca440, {0x140001a0030, 0x5, 0x5})
	/Users/runner/work/vault/vault/command/kv_patch.go:232 +0x3fc
github.com/mitchellh/cli.(*CLI).Run(0x1400062edc0)
	/Users/runner/go/pkg/mod/github.com/mitchellh/cli@v1.1.2/cli.go:262 +0x4a8
github.com/hashicorp/vault/command.RunCustom({0x140001a0010?, 0x7?, 0x7?}, 0x140000021a0?)
 	/Users/runner/work/vault/vault/command/main.go:237 +0x930
github.com/hashicorp/vault/command.Run(...)
	/Users/runner/work/vault/vault/command/main.go:142
main.main()
	/Users/runner/work/vault/vault/main.go:10 +0x54
```

After change: 
```console
$ vault kv patch -field=version  -method=rw -mount=kv /secrets test=- <<< "new2"     
10
= Secret Path =
kv/data/secrets
```

UPDATE:
updated output
```console
$ vault kv put secret/test foo=bar3               
== Secret Path ==
secret/data/test
 
======= Metadata =======
Key                Value
---                -----
created_time       2022-12-01T16:03:45.398495Z
custom_metadata    <nil>
deletion_time      n/a
destroyed          false
version            8

$ vault kv put -field=version secret/test foo=bar3
9

$ vault kv patch -field=version secret/test foo=bar4
10

$ vault kv patch  secret/test foo=bar4 
== Secret Path ==
secret/data/test

======= Metadata =======
Key                Value
---                -----
created_time       2022-12-01T16:04:59.014316Z
custom_metadata    <nil>
deletion_time      n/a
destroyed          false
version            11
```
