### PR TITLE
Backport 1.11.x: Use host's uid in container's executor (#17729)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,8 +248,7 @@ jobs:
 
           make prep
 
-          # Permissions have changed inside docker containers; see hack note below.
-          mkdir --mode=777 -p test-results/go-test
+          mkdir -p test-results/go-test
 
           # We don't want VAULT_LICENSE set when running Go tests, because that's
           # not what developers have in their environments and it could break some
@@ -261,7 +260,7 @@ jobs:
           export VAULT_LICENSE_CI="$VAULT_LICENSE"
           VAULT_LICENSE=
 
-          # Create a docker network for our testcontainer
+          # Create a docker network for our test container
           if [ $USE_DOCKER == 1 ]; then
             # Despite the fact that we're using a circleci image (thus getting the
             # version they chose for the docker cli) and that we're specifying a
@@ -270,28 +269,17 @@ jobs:
             # reasons unclear.
             export DOCKER_API_VERSION=1.39
 
-            # Hack: Docker permissions appear to have changed; let's explicitly
-            # chmod the docker certificate path to give other grouped users
-            # access.
-            #
-            # Notably, in this shell pipeline we see:
-            # uid=1001(circleci) gid=1002(circleci) groups=1002(circleci)
-            #
-            # but inside the docker image below, we see:
-            # uid=3434(circleci) gid=3434(circleci) groups=3434(circleci)
-            #
-            # See also: https://github.com/CircleCI-Public/cimg-base/issues/122
-            chmod o+rx -R $DOCKER_CERT_PATH
-
-            export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
+            TEST_DOCKER_NETWORK_NAME="${CIRCLE_WORKFLOW_JOB_ID}-${CIRCLE_NODE_INDEX}"
+            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter="name=${TEST_DOCKER_NETWORK_NAME}")
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
-              TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
+              docker network prune -f
+              TEST_DOCKER_NETWORK_ID=$(docker network create "${TEST_DOCKER_NETWORK_NAME}")
             fi
 
 
 
-            # Start a docker testcontainer to run the tests in
-            docker run -d \
+            # Start a docker test container to run the tests in
+            CONTAINER_ID="$(docker run -d \
               -e TEST_DOCKER_NETWORK_ID \
               -e GOPRIVATE \
               -e DOCKER_CERT_PATH \
@@ -300,19 +288,48 @@ jobs:
               -e DOCKER_TLS_VERIFY \
               -e NO_PROXY \
               -e VAULT_TEST_LOG_DIR=/tmp/testlogs \
-              --network vaulttest --name \
-              testcontainer $GO_IMAGE \
-              tail -f /dev/null
+              --network ${TEST_DOCKER_NETWORK_NAME} \
+              $GO_IMAGE \
+              tail -f /dev/null)"
+            mkdir workspace
+            echo ${CONTAINER_ID} > workspace/container_id
+
+            # Hack: Docker permissions appear to have changed; let's explicitly
+            # add a new user/group with the correct host uid to the docker
+            # container, fixing all of these permissions issues correctly. We
+            # then have to run with this user consistently in the future.
+            #
+            # Notably, in this shell pipeline we see:
+            # uid=1001(circleci) gid=1002(circleci) groups=1002(circleci)
+            #
+            # but inside the docker image below, we see:
+            # uid=3434(circleci) gid=3434(circleci) groups=3434(circleci)
+            #
+            # See also: https://github.com/CircleCI-Public/cimg-base/issues/122
+            export HOST_GID="$(id -g)"
+            export HOST_UID="$(id -u)"
+            export CONT_GID="$(docker exec ${CONTAINER_ID} sh -c 'id -g')"
+            export CONT_GNAME="$(docker exec ${CONTAINER_ID} sh -c 'id -g -n')"
+            export CONT_UID="$(docker exec ${CONTAINER_ID} sh -c 'id -u')"
+            if (( HOST_UID != CONT_UID )); then
+              # Only provision a group if necessary; otherwise reuse the
+              # existing one.
+              if (( HOST_GID != CONT_GID )); then
+                docker exec -e HOST_GID -e CONT_GNAME ${CONTAINER_ID} sh -c 'sudo groupmod -g $HOST_GID $CONT_GNAME'
+              fi
+
+              docker exec -e CONT_GNAME -e HOST_UID ${CONTAINER_ID} sh -c 'sudo usermod -a -G $CONT_GNAME -u $HOST_UID circleci'
+            fi
 
             # Run tests
-            test -d /tmp/go-cache && docker cp /tmp/go-cache testcontainer:/tmp/gocache
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
-            docker cp . testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/
-            docker cp $DOCKER_CERT_PATH/ testcontainer:$DOCKER_CERT_PATH
+            test -d /tmp/go-cache && docker cp /tmp/go-cache ${CONTAINER_ID}:/tmp/gocache
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
+            docker cp . ${CONTAINER_ID}:/home/circleci/go/src/github.com/hashicorp/vault/
+            docker cp $DOCKER_CERT_PATH/ ${CONTAINER_ID}:$DOCKER_CERT_PATH
 
             # Copy the downloaded modules inside the container.
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/pkg'
-            docker cp "$(go env GOPATH)/pkg/mod" testcontainer:/home/circleci/go/pkg/mod
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/pkg'
+            docker cp "$(go env GOPATH)/pkg/mod" ${CONTAINER_ID}:/home/circleci/go/pkg/mod
 
             docker exec -w /home/circleci/go/src/github.com/hashicorp/vault/ \
               -e CIRCLECI -e VAULT_CI_GO_TEST_RACE \
@@ -321,7 +338,7 @@ jobs:
               -e GOPROXY="off" \
               -e VAULT_LICENSE_CI \
               -e GOARCH=amd64 \
-              testcontainer \
+              ${CONTAINER_ID} \
                 gotestsum --format=short-verbose \
                   --junitfile test-results/go-test/results.xml \
                   --jsonfile test-results/go-test/results.json \
@@ -350,8 +367,8 @@ jobs:
         no_output_timeout: 60m
     - run:
         command: |
-          docker cp testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/test-results .
-          docker cp testcontainer:/tmp/gocache /tmp/go-cache
+          docker cp $(cat workspace/container_id):/home/circleci/go/src/github.com/hashicorp/vault/test-results .
+          docker cp $(cat workspace/container_id):/tmp/gocache /tmp/go-cache
         name: Copy test results
         when: always
     - store_artifacts:
@@ -502,8 +519,7 @@ jobs:
 
           make prep
 
-          # Permissions have changed inside docker containers; see hack note below.
-          mkdir --mode=777 -p test-results/go-test
+          mkdir -p test-results/go-test
 
           # We don't want VAULT_LICENSE set when running Go tests, because that's
           # not what developers have in their environments and it could break some
@@ -515,7 +531,7 @@ jobs:
           export VAULT_LICENSE_CI="$VAULT_LICENSE"
           VAULT_LICENSE=
 
-          # Create a docker network for our testcontainer
+          # Create a docker network for our test container
           if [ $USE_DOCKER == 1 ]; then
             # Despite the fact that we're using a circleci image (thus getting the
             # version they chose for the docker cli) and that we're specifying a
@@ -524,28 +540,17 @@ jobs:
             # reasons unclear.
             export DOCKER_API_VERSION=1.39
 
-            # Hack: Docker permissions appear to have changed; let's explicitly
-            # chmod the docker certificate path to give other grouped users
-            # access.
-            #
-            # Notably, in this shell pipeline we see:
-            # uid=1001(circleci) gid=1002(circleci) groups=1002(circleci)
-            #
-            # but inside the docker image below, we see:
-            # uid=3434(circleci) gid=3434(circleci) groups=3434(circleci)
-            #
-            # See also: https://github.com/CircleCI-Public/cimg-base/issues/122
-            chmod o+rx -R $DOCKER_CERT_PATH
-
-            export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
+            TEST_DOCKER_NETWORK_NAME="${CIRCLE_WORKFLOW_JOB_ID}-${CIRCLE_NODE_INDEX}"
+            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter="name=${TEST_DOCKER_NETWORK_NAME}")
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
-              TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
+              docker network prune -f
+              TEST_DOCKER_NETWORK_ID=$(docker network create "${TEST_DOCKER_NETWORK_NAME}")
             fi
 
 
 
-            # Start a docker testcontainer to run the tests in
-            docker run -d \
+            # Start a docker test container to run the tests in
+            CONTAINER_ID="$(docker run -d \
               -e TEST_DOCKER_NETWORK_ID \
               -e GOPRIVATE \
               -e DOCKER_CERT_PATH \
@@ -554,19 +559,48 @@ jobs:
               -e DOCKER_TLS_VERIFY \
               -e NO_PROXY \
               -e VAULT_TEST_LOG_DIR=/tmp/testlogs \
-              --network vaulttest --name \
-              testcontainer $GO_IMAGE \
-              tail -f /dev/null
+              --network ${TEST_DOCKER_NETWORK_NAME} \
+              $GO_IMAGE \
+              tail -f /dev/null)"
+            mkdir workspace
+            echo ${CONTAINER_ID} > workspace/container_id
+
+            # Hack: Docker permissions appear to have changed; let's explicitly
+            # add a new user/group with the correct host uid to the docker
+            # container, fixing all of these permissions issues correctly. We
+            # then have to run with this user consistently in the future.
+            #
+            # Notably, in this shell pipeline we see:
+            # uid=1001(circleci) gid=1002(circleci) groups=1002(circleci)
+            #
+            # but inside the docker image below, we see:
+            # uid=3434(circleci) gid=3434(circleci) groups=3434(circleci)
+            #
+            # See also: https://github.com/CircleCI-Public/cimg-base/issues/122
+            export HOST_GID="$(id -g)"
+            export HOST_UID="$(id -u)"
+            export CONT_GID="$(docker exec ${CONTAINER_ID} sh -c 'id -g')"
+            export CONT_GNAME="$(docker exec ${CONTAINER_ID} sh -c 'id -g -n')"
+            export CONT_UID="$(docker exec ${CONTAINER_ID} sh -c 'id -u')"
+            if (( HOST_UID != CONT_UID )); then
+              # Only provision a group if necessary; otherwise reuse the
+              # existing one.
+              if (( HOST_GID != CONT_GID )); then
+                docker exec -e HOST_GID -e CONT_GNAME ${CONTAINER_ID} sh -c 'sudo groupmod -g $HOST_GID $CONT_GNAME'
+              fi
+
+              docker exec -e CONT_GNAME -e HOST_UID ${CONTAINER_ID} sh -c 'sudo usermod -a -G $CONT_GNAME -u $HOST_UID circleci'
+            fi
 
             # Run tests
-            test -d /tmp/go-cache && docker cp /tmp/go-cache testcontainer:/tmp/gocache
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
-            docker cp . testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/
-            docker cp $DOCKER_CERT_PATH/ testcontainer:$DOCKER_CERT_PATH
+            test -d /tmp/go-cache && docker cp /tmp/go-cache ${CONTAINER_ID}:/tmp/gocache
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
+            docker cp . ${CONTAINER_ID}:/home/circleci/go/src/github.com/hashicorp/vault/
+            docker cp $DOCKER_CERT_PATH/ ${CONTAINER_ID}:$DOCKER_CERT_PATH
 
             # Copy the downloaded modules inside the container.
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/pkg'
-            docker cp "$(go env GOPATH)/pkg/mod" testcontainer:/home/circleci/go/pkg/mod
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/pkg'
+            docker cp "$(go env GOPATH)/pkg/mod" ${CONTAINER_ID}:/home/circleci/go/pkg/mod
 
             docker exec -w /home/circleci/go/src/github.com/hashicorp/vault/ \
               -e CIRCLECI -e VAULT_CI_GO_TEST_RACE \
@@ -575,7 +609,7 @@ jobs:
               -e GOPROXY="off" \
               -e VAULT_LICENSE_CI \
               -e GOARCH=amd64 \
-              testcontainer \
+              ${CONTAINER_ID} \
                 gotestsum --format=short-verbose \
                   --junitfile test-results/go-test/results.xml \
                   --jsonfile test-results/go-test/results.json \
@@ -707,8 +741,7 @@ jobs:
 
           make prep
 
-          # Permissions have changed inside docker containers; see hack note below.
-          mkdir --mode=777 -p test-results/go-test
+          mkdir -p test-results/go-test
 
           # We don't want VAULT_LICENSE set when running Go tests, because that's
           # not what developers have in their environments and it could break some
@@ -720,7 +753,7 @@ jobs:
           export VAULT_LICENSE_CI="$VAULT_LICENSE"
           VAULT_LICENSE=
 
-          # Create a docker network for our testcontainer
+          # Create a docker network for our test container
           if [ $USE_DOCKER == 1 ]; then
             # Despite the fact that we're using a circleci image (thus getting the
             # version they chose for the docker cli) and that we're specifying a
@@ -729,28 +762,17 @@ jobs:
             # reasons unclear.
             export DOCKER_API_VERSION=1.39
 
-            # Hack: Docker permissions appear to have changed; let's explicitly
-            # chmod the docker certificate path to give other grouped users
-            # access.
-            #
-            # Notably, in this shell pipeline we see:
-            # uid=1001(circleci) gid=1002(circleci) groups=1002(circleci)
-            #
-            # but inside the docker image below, we see:
-            # uid=3434(circleci) gid=3434(circleci) groups=3434(circleci)
-            #
-            # See also: https://github.com/CircleCI-Public/cimg-base/issues/122
-            chmod o+rx -R $DOCKER_CERT_PATH
-
-            export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
+            TEST_DOCKER_NETWORK_NAME="${CIRCLE_WORKFLOW_JOB_ID}-${CIRCLE_NODE_INDEX}"
+            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter="name=${TEST_DOCKER_NETWORK_NAME}")
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
-              TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
+              docker network prune -f
+              TEST_DOCKER_NETWORK_ID=$(docker network create "${TEST_DOCKER_NETWORK_NAME}")
             fi
 
 
 
-            # Start a docker testcontainer to run the tests in
-            docker run -d \
+            # Start a docker test container to run the tests in
+            CONTAINER_ID="$(docker run -d \
               -e TEST_DOCKER_NETWORK_ID \
               -e GOPRIVATE \
               -e DOCKER_CERT_PATH \
@@ -759,19 +781,48 @@ jobs:
               -e DOCKER_TLS_VERIFY \
               -e NO_PROXY \
               -e VAULT_TEST_LOG_DIR=/tmp/testlogs \
-              --network vaulttest --name \
-              testcontainer $GO_IMAGE \
-              tail -f /dev/null
+              --network ${TEST_DOCKER_NETWORK_NAME} \
+              $GO_IMAGE \
+              tail -f /dev/null)"
+            mkdir workspace
+            echo ${CONTAINER_ID} > workspace/container_id
+
+            # Hack: Docker permissions appear to have changed; let's explicitly
+            # add a new user/group with the correct host uid to the docker
+            # container, fixing all of these permissions issues correctly. We
+            # then have to run with this user consistently in the future.
+            #
+            # Notably, in this shell pipeline we see:
+            # uid=1001(circleci) gid=1002(circleci) groups=1002(circleci)
+            #
+            # but inside the docker image below, we see:
+            # uid=3434(circleci) gid=3434(circleci) groups=3434(circleci)
+            #
+            # See also: https://github.com/CircleCI-Public/cimg-base/issues/122
+            export HOST_GID="$(id -g)"
+            export HOST_UID="$(id -u)"
+            export CONT_GID="$(docker exec ${CONTAINER_ID} sh -c 'id -g')"
+            export CONT_GNAME="$(docker exec ${CONTAINER_ID} sh -c 'id -g -n')"
+            export CONT_UID="$(docker exec ${CONTAINER_ID} sh -c 'id -u')"
+            if (( HOST_UID != CONT_UID )); then
+              # Only provision a group if necessary; otherwise reuse the
+              # existing one.
+              if (( HOST_GID != CONT_GID )); then
+                docker exec -e HOST_GID -e CONT_GNAME ${CONTAINER_ID} sh -c 'sudo groupmod -g $HOST_GID $CONT_GNAME'
+              fi
+
+              docker exec -e CONT_GNAME -e HOST_UID ${CONTAINER_ID} sh -c 'sudo usermod -a -G $CONT_GNAME -u $HOST_UID circleci'
+            fi
 
             # Run tests
-            test -d /tmp/go-cache && docker cp /tmp/go-cache testcontainer:/tmp/gocache
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
-            docker cp . testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/
-            docker cp $DOCKER_CERT_PATH/ testcontainer:$DOCKER_CERT_PATH
+            test -d /tmp/go-cache && docker cp /tmp/go-cache ${CONTAINER_ID}:/tmp/gocache
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
+            docker cp . ${CONTAINER_ID}:/home/circleci/go/src/github.com/hashicorp/vault/
+            docker cp $DOCKER_CERT_PATH/ ${CONTAINER_ID}:$DOCKER_CERT_PATH
 
             # Copy the downloaded modules inside the container.
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/pkg'
-            docker cp "$(go env GOPATH)/pkg/mod" testcontainer:/home/circleci/go/pkg/mod
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/pkg'
+            docker cp "$(go env GOPATH)/pkg/mod" ${CONTAINER_ID}:/home/circleci/go/pkg/mod
 
             docker exec -w /home/circleci/go/src/github.com/hashicorp/vault/ \
               -e CIRCLECI -e VAULT_CI_GO_TEST_RACE \
@@ -780,7 +831,7 @@ jobs:
               -e GOPROXY="off" \
               -e VAULT_LICENSE_CI \
               -e GOARCH=amd64 \
-              testcontainer \
+              ${CONTAINER_ID} \
                 gotestsum --format=short-verbose \
                   --junitfile test-results/go-test/results.xml \
                   --jsonfile test-results/go-test/results.json \
@@ -1033,8 +1084,7 @@ jobs:
 
           make prep
 
-          # Permissions have changed inside docker containers; see hack note below.
-          mkdir --mode=777 -p test-results/go-test
+          mkdir -p test-results/go-test
 
           # We don't want VAULT_LICENSE set when running Go tests, because that's
           # not what developers have in their environments and it could break some
@@ -1046,7 +1096,7 @@ jobs:
           export VAULT_LICENSE_CI="$VAULT_LICENSE"
           VAULT_LICENSE=
 
-          # Create a docker network for our testcontainer
+          # Create a docker network for our test container
           if [ $USE_DOCKER == 1 ]; then
             # Despite the fact that we're using a circleci image (thus getting the
             # version they chose for the docker cli) and that we're specifying a
@@ -1055,28 +1105,17 @@ jobs:
             # reasons unclear.
             export DOCKER_API_VERSION=1.39
 
-            # Hack: Docker permissions appear to have changed; let's explicitly
-            # chmod the docker certificate path to give other grouped users
-            # access.
-            #
-            # Notably, in this shell pipeline we see:
-            # uid=1001(circleci) gid=1002(circleci) groups=1002(circleci)
-            #
-            # but inside the docker image below, we see:
-            # uid=3434(circleci) gid=3434(circleci) groups=3434(circleci)
-            #
-            # See also: https://github.com/CircleCI-Public/cimg-base/issues/122
-            chmod o+rx -R $DOCKER_CERT_PATH
-
-            export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
+            TEST_DOCKER_NETWORK_NAME="${CIRCLE_WORKFLOW_JOB_ID}-${CIRCLE_NODE_INDEX}"
+            export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter="name=${TEST_DOCKER_NETWORK_NAME}")
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
-              TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
+              docker network prune -f
+              TEST_DOCKER_NETWORK_ID=$(docker network create "${TEST_DOCKER_NETWORK_NAME}")
             fi
 
 
 
-            # Start a docker testcontainer to run the tests in
-            docker run -d \
+            # Start a docker test container to run the tests in
+            CONTAINER_ID="$(docker run -d \
               -e TEST_DOCKER_NETWORK_ID \
               -e GOPRIVATE \
               -e DOCKER_CERT_PATH \
@@ -1085,19 +1124,48 @@ jobs:
               -e DOCKER_TLS_VERIFY \
               -e NO_PROXY \
               -e VAULT_TEST_LOG_DIR=/tmp/testlogs \
-              --network vaulttest --name \
-              testcontainer $GO_IMAGE \
-              tail -f /dev/null
+              --network ${TEST_DOCKER_NETWORK_NAME} \
+              $GO_IMAGE \
+              tail -f /dev/null)"
+            mkdir workspace
+            echo ${CONTAINER_ID} > workspace/container_id
+
+            # Hack: Docker permissions appear to have changed; let's explicitly
+            # add a new user/group with the correct host uid to the docker
+            # container, fixing all of these permissions issues correctly. We
+            # then have to run with this user consistently in the future.
+            #
+            # Notably, in this shell pipeline we see:
+            # uid=1001(circleci) gid=1002(circleci) groups=1002(circleci)
+            #
+            # but inside the docker image below, we see:
+            # uid=3434(circleci) gid=3434(circleci) groups=3434(circleci)
+            #
+            # See also: https://github.com/CircleCI-Public/cimg-base/issues/122
+            export HOST_GID="$(id -g)"
+            export HOST_UID="$(id -u)"
+            export CONT_GID="$(docker exec ${CONTAINER_ID} sh -c 'id -g')"
+            export CONT_GNAME="$(docker exec ${CONTAINER_ID} sh -c 'id -g -n')"
+            export CONT_UID="$(docker exec ${CONTAINER_ID} sh -c 'id -u')"
+            if (( HOST_UID != CONT_UID )); then
+              # Only provision a group if necessary; otherwise reuse the
+              # existing one.
+              if (( HOST_GID != CONT_GID )); then
+                docker exec -e HOST_GID -e CONT_GNAME ${CONTAINER_ID} sh -c 'sudo groupmod -g $HOST_GID $CONT_GNAME'
+              fi
+
+              docker exec -e CONT_GNAME -e HOST_UID ${CONTAINER_ID} sh -c 'sudo usermod -a -G $CONT_GNAME -u $HOST_UID circleci'
+            fi
 
             # Run tests
-            test -d /tmp/go-cache && docker cp /tmp/go-cache testcontainer:/tmp/gocache
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
-            docker cp . testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/
-            docker cp $DOCKER_CERT_PATH/ testcontainer:$DOCKER_CERT_PATH
+            test -d /tmp/go-cache && docker cp /tmp/go-cache ${CONTAINER_ID}:/tmp/gocache
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
+            docker cp . ${CONTAINER_ID}:/home/circleci/go/src/github.com/hashicorp/vault/
+            docker cp $DOCKER_CERT_PATH/ ${CONTAINER_ID}:$DOCKER_CERT_PATH
 
             # Copy the downloaded modules inside the container.
-            docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/pkg'
-            docker cp "$(go env GOPATH)/pkg/mod" testcontainer:/home/circleci/go/pkg/mod
+            docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/pkg'
+            docker cp "$(go env GOPATH)/pkg/mod" ${CONTAINER_ID}:/home/circleci/go/pkg/mod
 
             docker exec -w /home/circleci/go/src/github.com/hashicorp/vault/ \
               -e CIRCLECI -e VAULT_CI_GO_TEST_RACE \
@@ -1106,7 +1174,7 @@ jobs:
               -e GOPROXY="off" \
               -e VAULT_LICENSE_CI \
               -e GOARCH=amd64 \
-              testcontainer \
+              ${CONTAINER_ID} \
                 gotestsum --format=short-verbose \
                   --junitfile test-results/go-test/results.xml \
                   --jsonfile test-results/go-test/results.json \
@@ -1135,8 +1203,8 @@ jobs:
         no_output_timeout: 60m
     - run:
         command: |
-          docker cp testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/test-results .
-          docker cp testcontainer:/tmp/gocache /tmp/go-cache
+          docker cp $(cat workspace/container_id):/home/circleci/go/src/github.com/hashicorp/vault/test-results .
+          docker cp $(cat workspace/container_id):/tmp/gocache /tmp/go-cache
         name: Copy test results
         when: always
     - store_artifacts:

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -93,8 +93,7 @@ steps:
 
         make prep
 
-        # Permissions have changed inside docker containers; see hack note below.
-        mkdir --mode=777 -p test-results/go-test
+        mkdir -p test-results/go-test
 
         # We don't want VAULT_LICENSE set when running Go tests, because that's
         # not what developers have in their environments and it could break some
@@ -106,7 +105,7 @@ steps:
         export VAULT_LICENSE_CI="$VAULT_LICENSE"
         VAULT_LICENSE=
 
-        # Create a docker network for our testcontainer
+        # Create a docker network for our test container
         if [ $USE_DOCKER == 1 ]; then
           # Despite the fact that we're using a circleci image (thus getting the
           # version they chose for the docker cli) and that we're specifying a
@@ -115,28 +114,17 @@ steps:
           # reasons unclear.
           export DOCKER_API_VERSION=1.39
 
-          # Hack: Docker permissions appear to have changed; let's explicitly
-          # chmod the docker certificate path to give other grouped users
-          # access.
-          #
-          # Notably, in this shell pipeline we see:
-          # uid=1001(circleci) gid=1002(circleci) groups=1002(circleci)
-          #
-          # but inside the docker image below, we see:
-          # uid=3434(circleci) gid=3434(circleci) groups=3434(circleci)
-          #
-          # See also: https://github.com/CircleCI-Public/cimg-base/issues/122
-          chmod o+rx -R $DOCKER_CERT_PATH
-
-          export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
+          TEST_DOCKER_NETWORK_NAME="${CIRCLE_WORKFLOW_JOB_ID}-${CIRCLE_NODE_INDEX}"
+          export TEST_DOCKER_NETWORK_ID=$(docker network list --quiet --no-trunc --filter="name=${TEST_DOCKER_NETWORK_NAME}")
           if [ -z $TEST_DOCKER_NETWORK_ID ]; then
-            TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
+            docker network prune -f
+            TEST_DOCKER_NETWORK_ID=$(docker network create "${TEST_DOCKER_NETWORK_NAME}")
           fi
 
 
 
-          # Start a docker testcontainer to run the tests in
-          docker run -d \
+          # Start a docker test container to run the tests in
+          CONTAINER_ID="$(docker run -d \
             -e TEST_DOCKER_NETWORK_ID \
             -e GOPRIVATE \
             -e DOCKER_CERT_PATH \
@@ -145,19 +133,48 @@ steps:
             -e DOCKER_TLS_VERIFY \
             -e NO_PROXY \
             -e VAULT_TEST_LOG_DIR=<< parameters.log_dir >> \
-            --network vaulttest --name \
-            testcontainer $GO_IMAGE \
-            tail -f /dev/null
+            --network ${TEST_DOCKER_NETWORK_NAME} \
+            $GO_IMAGE \
+            tail -f /dev/null)"
+          mkdir workspace
+          echo ${CONTAINER_ID} > workspace/container_id
+
+          # Hack: Docker permissions appear to have changed; let's explicitly
+          # add a new user/group with the correct host uid to the docker
+          # container, fixing all of these permissions issues correctly. We
+          # then have to run with this user consistently in the future.
+          #
+          # Notably, in this shell pipeline we see:
+          # uid=1001(circleci) gid=1002(circleci) groups=1002(circleci)
+          #
+          # but inside the docker image below, we see:
+          # uid=3434(circleci) gid=3434(circleci) groups=3434(circleci)
+          #
+          # See also: https://github.com/CircleCI-Public/cimg-base/issues/122
+          export HOST_GID="$(id -g)"
+          export HOST_UID="$(id -u)"
+          export CONT_GID="$(docker exec ${CONTAINER_ID} sh -c 'id -g')"
+          export CONT_GNAME="$(docker exec ${CONTAINER_ID} sh -c 'id -g -n')"
+          export CONT_UID="$(docker exec ${CONTAINER_ID} sh -c 'id -u')"
+          if (( HOST_UID != CONT_UID )); then
+            # Only provision a group if necessary; otherwise reuse the
+            # existing one.
+            if (( HOST_GID != CONT_GID )); then
+              docker exec -e HOST_GID -e CONT_GNAME ${CONTAINER_ID} sh -c 'sudo groupmod -g $HOST_GID $CONT_GNAME'
+            fi
+
+            docker exec -e CONT_GNAME -e HOST_UID ${CONTAINER_ID} sh -c 'sudo usermod -a -G $CONT_GNAME -u $HOST_UID circleci'
+          fi
 
           # Run tests
-          test -d << parameters.cache_dir >> && docker cp << parameters.cache_dir >> testcontainer:/tmp/gocache
-          docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
-          docker cp . testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/
-          docker cp $DOCKER_CERT_PATH/ testcontainer:$DOCKER_CERT_PATH
+          test -d << parameters.cache_dir >> && docker cp << parameters.cache_dir >> ${CONTAINER_ID}:/tmp/gocache
+          docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/src/github.com/hashicorp/vault'
+          docker cp . ${CONTAINER_ID}:/home/circleci/go/src/github.com/hashicorp/vault/
+          docker cp $DOCKER_CERT_PATH/ ${CONTAINER_ID}:$DOCKER_CERT_PATH
 
           # Copy the downloaded modules inside the container.
-          docker exec testcontainer sh -c 'mkdir -p /home/circleci/go/pkg'
-          docker cp "$(go env GOPATH)/pkg/mod" testcontainer:/home/circleci/go/pkg/mod
+          docker exec ${CONTAINER_ID} sh -c 'mkdir -p /home/circleci/go/pkg'
+          docker cp "$(go env GOPATH)/pkg/mod" ${CONTAINER_ID}:/home/circleci/go/pkg/mod
 
           docker exec -w /home/circleci/go/src/github.com/hashicorp/vault/ \
             -e CIRCLECI -e VAULT_CI_GO_TEST_RACE \
@@ -166,7 +183,7 @@ steps:
             -e GOPROXY="off" \
             -e VAULT_LICENSE_CI \
             -e GOARCH=<< parameters.arch >> \
-            testcontainer \
+            ${CONTAINER_ID} \
               gotestsum --format=short-verbose \
                 --junitfile test-results/go-test/results.xml \
                 --jsonfile test-results/go-test/results.json \
@@ -197,8 +214,8 @@ steps:
             name: Copy test results
             when: always
             command: |
-              docker cp testcontainer:/home/circleci/go/src/github.com/hashicorp/vault/test-results .
-              docker cp testcontainer:/tmp/gocache << parameters.cache_dir >>
+              docker cp $(cat workspace/container_id):/home/circleci/go/src/github.com/hashicorp/vault/test-results .
+              docker cp $(cat workspace/container_id):/tmp/gocache << parameters.cache_dir >>
   - when:
       condition: << parameters.save_cache >>
       steps:
@@ -206,4 +223,4 @@ steps:
             when: always
             key: go-test-cache-date-v1-{{ checksum "/tmp/go-cache-key" }}
             paths:
-            - << parameters.cache_dir >>
+              - << parameters.cache_dir >>


### PR DESCRIPTION
Backport of  #17729 for 1.11.x, I accidentally closed the original backport PR.

When copying data into the container, due to the id changes pointed out in the previous attempt, the container couldn't read this data.

By creating a new user in the container, matching the host's UID/GID, we can successfully copy data in/out of the container without worrying about differing UID/GIDs.

See also: https://github.com/hashicorp/vault/pull/17658

Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>

Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>