### PR TITLE
Fix plugin list API when audit logging enabled

### DIFF
--- a/changelog/18173.txt
+++ b/changelog/18173.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugins: Listing all plugins while audit logging is enabled will no longer result in an internal server error.
+```

--- a/vault/external_plugin_test.go
+++ b/vault/external_plugin_test.go
@@ -384,8 +384,8 @@ func TestCore_EnableExternalKv_MultipleVersions(t *testing.T) {
 		t.Fatalf("%#v", resp)
 	}
 	found := false
-	for _, plugin := range resp.Data["detailed"].([]pluginutil.VersionedPlugin) {
-		if plugin.Name == pluginName && plugin.Version == "v1.2.3" {
+	for _, plugin := range resp.Data["detailed"].([]map[string]any) {
+		if plugin["name"] == pluginName && plugin["version"] == "v1.2.3" {
 			found = true
 			break
 		}
@@ -437,8 +437,8 @@ func TestCore_EnableExternalNoop_MultipleVersions(t *testing.T) {
 		t.Fatalf("%#v", resp)
 	}
 	found := false
-	for _, plugin := range resp.Data["detailed"].([]pluginutil.VersionedPlugin) {
-		if plugin.Name == "noop" && plugin.Version == "v1.2.3" {
+	for _, plugin := range resp.Data["detailed"].([]map[string]any) {
+		if plugin["name"] == "noop" && plugin["version"] == "v1.2.3" {
 			found = true
 			break
 		}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -440,11 +440,10 @@ func (b *SystemBackend) handlePluginCatalogUntypedList(ctx context.Context, _ *l
 		var detailed []map[string]any
 		for _, p := range versionedPlugins {
 			entry := map[string]any{
-				"type":               p.Type,
-				"name":               p.Name,
-				"version":            p.Version,
-				"builtin":            p.Builtin,
-				"deprecation_status": p.DeprecationStatus,
+				"type":    p.Type,
+				"name":    p.Name,
+				"version": p.Version,
+				"builtin": p.Builtin,
 			}
 			if p.SHA256 != "" {
 				entry["sha256"] = p.SHA256

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -3130,6 +3130,38 @@ func TestSystemBackend_PluginCatalog_CRUD(t *testing.T) {
 	}
 }
 
+func TestSystemBackend_PluginCatalog_ListPlugins_SucceedsWithAuditLogEnabled(t *testing.T) {
+	core, b, root := testCoreSystemBackend(t)
+
+	tempDir := t.TempDir()
+	f, err := os.CreateTemp(tempDir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Enable audit logging.
+	req := logical.TestRequest(t, logical.UpdateOperation, "audit/file")
+	req.Data = map[string]any{
+		"type": "file",
+		"options": map[string]any{
+			"file_path": f.Name(),
+		},
+	}
+	ctx := namespace.RootContext(nil)
+	resp, err := b.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("resp: %#v, err: %v", resp, err)
+	}
+
+	// List plugins
+	req = logical.TestRequest(t, logical.ReadOperation, "sys/plugins/catalog")
+	req.ClientToken = root
+	resp, err = core.HandleRequest(ctx, req)
+	if err != nil || resp == nil || resp.IsError() {
+		t.Fatalf("resp: %#v, err: %v", resp, err)
+	}
+}
+
 func TestSystemBackend_PluginCatalog_CannotRegisterBuiltinPlugins(t *testing.T) {
 	c, b, _ := testCoreSystemBackend(t)
 	// Bootstrap the pluginCatalog

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -34,6 +34,7 @@ import (
 	raftlib "github.com/hashicorp/raft"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/audit"
+	auditFile "github.com/hashicorp/vault/builtin/audit/file"
 	"github.com/hashicorp/vault/builtin/credential/approle"
 	"github.com/hashicorp/vault/command/server"
 	"github.com/hashicorp/vault/helper/constants"
@@ -129,6 +130,9 @@ func TestCoreWithSeal(t testing.T, testSeal Seal, enableRaw bool) *Core {
 		EnableUI:        false,
 		EnableRaw:       enableRaw,
 		BuiltinRegistry: NewMockBuiltinRegistry(),
+		AuditBackends: map[string]audit.Factory{
+			"file": auditFile.Factory,
+		},
 	}
 	return TestCoreWithSealAndUI(t, conf)
 }


### PR DESCRIPTION
Fixes #17722

From 1.12.0 onwards, when the [`GET /v1/sys/plugins/catalog`](https://developer.hashicorp.com/vault/api-docs/system/plugins-catalog#list-plugins) endpoint is hit and audit logging is enabled, Vault panics while HMACing the response in order to audit log it. @jmthvt correctly diagnosed this was due to the SemanticVersion field in the struct included in the response.

The handler now takes a similar approach to [`mountInfo()`](https://github.com/hashicorp/vault/blob/1d7c5db671e6700933663269c476ed98e70b22e3/vault/logical_system.go#L898) and rebuilds the structs as maps composed of primitive values.

<details>
<summary>Logging with panic stack trace added</summary>

```text
2022-11-30T18:06:02.279Z [ERROR] vault.audit: panic during logging: request_path=sys/plugins/catalog error="reflect: reflect.Value.Set using value obtained using unexported field"
  stacktrace=
  | goroutine 944 [running]:
  | runtime/debug.Stack()
  | \t/usr/local/go/src/runtime/debug/stack.go:24 +0x64
  | github.com/hashicorp/vault/vault.(*AuditBroker).LogResponse.func2()
  | \t/Users/tom/code/vault/vault/audit_broker.go:180 +0x68
  | panic({0x106f0a8c0, 0x1400152f220})
  | \t/usr/local/go/src/runtime/panic.go:884 +0x204
  | reflect.flag.mustBeAssignableSlow(0xb1a0?)
  | \t/usr/local/go/src/reflect/value.go:257 +0xb4
  | reflect.flag.mustBeAssignable(...)
  | \t/usr/local/go/src/reflect/value.go:247
  | reflect.Value.Set({0x106f0a8c0?, 0x14001b33540?, 0x14001871b58?}, {0x106f0a8c0?, 0x1400152f210?, 0x1023246ac?})
  | \t/usr/local/go/src/reflect/value.go:2154 +0x54
  | github.com/hashicorp/vault/audit.(*hashWalker).Primitive(0x14001b34460, {0x106f0a8c0?, 0x14001b33540?, 0x14001533b00?})
  | \t/Users/tom/code/vault/audit/hashstructure.go:354 +0x384
  | github.com/mitchellh/reflectwalk.walkPrimitive(...)
  | \t/Users/tom/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.2/reflectwalk.go:270
  | github.com/mitchellh/reflectwalk.walk({0x106f0a8c0?, 0x14001b33540?, 0x14001b34460?}, {0x1079be0e0, 0x14001b34460})
  | \t/Users/tom/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.2/reflectwalk.go:197 +0x580
  | github.com/mitchellh/reflectwalk.walkStruct({0x1079dfa20?, 0x14001b33540?, 0x14001b34460?}, {0x1079be0e0, 0x14001b34460})
  | \t/Users/tom/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.2/reflectwalk.go:404 +0x340
  | github.com/mitchellh/reflectwalk.walk({0x107be4e00?, 0x14001528058?, 0x14001b34460?}, {0x1079be0e0, 0x14001b34460})
  | \t/Users/tom/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.2/reflectwalk.go:206 +0x5e8
  | github.com/mitchellh/reflectwalk.walkStruct({0x107b24120?, 0x14001528000?, 0x14001b34460?}, {0x1079be0e0, 0x14001b34460})
  | \t/Users/tom/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.2/reflectwalk.go:404 +0x340
  | github.com/mitchellh/reflectwalk.walk({0x107b24120?, 0x14001528000?, 0x14001b34460?}, {0x1079be0e0, 0x14001b34460})
  | \t/Users/tom/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.2/reflectwalk.go:206 +0x5e8
  | github.com/mitchellh/reflectwalk.walkSlice({0x106e2aa60?, 0x14001672828?, 0x14001b34460?}, {0x1079be0e0, 0x14001b34460})
  | \t/Users/tom/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.2/reflectwalk.go:302 +0x190
  | github.com/mitchellh/reflectwalk.walk({0x107195be0?, 0x1400152f110?, 0x14001b34460?}, {0x1079be0e0, 0x14001b34460})
  | \t/Users/tom/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.2/reflectwalk.go:203 +0x488
  | github.com/mitchellh/reflectwalk.walkMap({0x1072908c0?, 0x140015220c0?, 0x14001b34460?}, {0x1079be0e0, 0x14001b34460})
  | \t/Users/tom/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.2/reflectwalk.go:252 +0x228
  | github.com/mitchellh/reflectwalk.walk({0x1072908c0?, 0x140015220c0?, 0x14001b34460?}, {0x1079be0e0, 0x14001b34460})
  | \t/Users/tom/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.2/reflectwalk.go:200 +0x4e8
  | github.com/mitchellh/reflectwalk.Walk({0x1072908c0?, 0x140015220c0?}, {0x1079be0e0, 0x14001b34460})
  | \t/Users/tom/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.2/reflectwalk.go:99 +0x158
  | github.com/hashicorp/vault/audit.HashStructure(...)
  | \t/Users/tom/code/vault/audit/hashstructure.go:177
  | github.com/hashicorp/vault/audit.hashMap(0x140012f6fc0, 0x140015220c0?, {0x0, 0x0, 0x0})
  | \t/Users/tom/code/vault/audit/hashstructure.go:97 +0x1dc
  | github.com/hashicorp/vault/audit.HashResponse(0x140016bb1a0, 0x14001b33400, 0x1?, {0x0, 0x0, 0x0})
  | \t/Users/tom/code/vault/audit/hashstructure.go:132 +0x260
  | github.com/hashicorp/vault/audit.(*AuditFormatter).FormatResponse(0x140002fdb10, {0x107f2cec0, 0x140012dd5c0}, {0x107ee8380?, 0x14001522090}, {0x2c?, 0x2c?, 0x0}, 0x140001fc310)
  | \t/Users/tom/code/vault/audit/format.go:206 +0x190
  | github.com/hashicorp/vault/builtin/audit/file.(*Backend).LogResponse(0x140002fdb00, {0x107f2cec0, 0x140012dd5c0}, 0x140012dcab0?)
  | \t/Users/tom/code/vault/builtin/audit/file/backend.go:264 +0x15c
  | github.com/hashicorp/vault/vault.(*AuditBroker).LogResponse(0x140018f4cf0, {0x107f2cec0, 0x140012dd5c0}, 0x140001fc310, 0x13?)
  | \t/Users/tom/code/vault/vault/audit_broker.go:210 +0x35c
  | github.com/hashicorp/vault/vault.(*Core).handleCancelableRequest(0x14000887500, {0x107f2cec0, 0x140012dd260}, 0x14001680480)
  | \t/Users/tom/code/vault/vault/request_handling.go:781 +0x1a00
  | github.com/hashicorp/vault/vault.(*Core).switchedLockHandleRequest(0x14000887500, {0x107f2cec0, 0x140012dcc30}, 0x14001680480, 0x80?)
  | \t/Users/tom/code/vault/vault/request_handling.go:472 +0x48c
  | github.com/hashicorp/vault/vault.(*Core).HandleRequest(...)
  | \t/Users/tom/code/vault/vault/request_handling.go:433
  | github.com/hashicorp/vault/http.request(0x1078a2180?, {0x107f1b718, 0x140012dcb40}, 0x140019a1700, 0x14001680480?)
  | \t/Users/tom/code/vault/http/handler.go:926 +0x6c
  | github.com/hashicorp/vault/http.handleLogicalInternal.func1({0x107f1b718, 0x140012dcb40}, 0x140019a1700)
  | \t/Users/tom/code/vault/http/logical.go:354 +0xa4
  | net/http.HandlerFunc.ServeHTTP(0x14000603298?, {0x107f1b718?, 0x140012dcb40?}, 0x140012b5471?)
  | \t/usr/local/go/src/net/http/server.go:2109 +0x38
  | github.com/hashicorp/vault/http.handleRequestForwarding.func1({0x107f1b718, 0x140012dcb40}, 0x140019a1700)
  | \t/Users/tom/code/vault/http/handler.go:851 +0x2f0
  | net/http.HandlerFunc.ServeHTTP(0x14000603338?, {0x107f1b718?, 0x140012dcb40?}, 0x0?)
  | \t/usr/local/go/src/net/http/server.go:2109 +0x38
  | net/http.(*ServeMux).ServeHTTP(0x140012cbf00?, {0x107f1b718, 0x140012dcb40}, 0x140019a1700)
  | \t/usr/local/go/src/net/http/server.go:2487 +0x140
  | github.com/hashicorp/vault/http.wrapHelpHandler.func1({0x107f1b718, 0x140012dcb40}, 0x140019a1700)
  | \t/Users/tom/code/vault/http/help.go:25 +0x148
  | net/http.HandlerFunc.ServeHTTP(0x140006033e8?, {0x107f1b718?, 0x140012dcb40?}, 0x140012cba40?)
  | \t/usr/local/go/src/net/http/server.go:2109 +0x38
  | github.com/hashicorp/vault/http.wrapCORSHandler.func1({0x107f1b718?, 0x140012dcb40?}, 0x14000b86480?)
  | \t/Users/tom/code/vault/http/cors.go:29 +0x1a4
  | net/http.HandlerFunc.ServeHTTP(0x14000887500?, {0x107f1b718?, 0x140012dcb40?}, 0x14000281380?)
  | \t/usr/local/go/src/net/http/server.go:2109 +0x38
  | github.com/hashicorp/vault/http.rateLimitQuotaWrapping.func1({0x107f1b718, 0x140012dcb40}, 0x140019a1700)
  | \t/Users/tom/code/vault/http/util.go:110 +0x9fc
  | net/http.HandlerFunc.ServeHTTP(0x140012dcab0?, {0x107f1b718?, 0x140012dcb40?}, 0xc0da04c290871828?)
  | \t/usr/local/go/src/net/http/server.go:2109 +0x38
  | github.com/hashicorp/vault/http.wrapGenericHandler.func1({0x107f2a058?, 0x140005b2fc0}, 0x140019a1400)
  | \t/Users/tom/code/vault/http/handler.go:438 +0xb70
  | net/http.HandlerFunc.ServeHTTP(0x140011e1924?, {0x107f2a058?, 0x140005b2fc0?}, 0xffffffffffffffff?)
  | \t/usr/local/go/src/net/http/server.go:2109 +0x38
  | github.com/hashicorp/go-cleanhttp.PrintablePathCheckHandler.func1({0x107f2a058, 0x140005b2fc0}, 0x140019a1400)
  | \t/Users/tom/go/pkg/mod/github.com/hashicorp/go-cleanhttp@v0.5.2/handlers.go:42 +0x88
  | net/http.HandlerFunc.ServeHTTP(0x0?, {0x107f2a058?, 0x140005b2fc0?}, 0x1025c45a8?)
  | \t/usr/local/go/src/net/http/server.go:2109 +0x38
  | net/http.serverHandler.ServeHTTP({0x140012dca80?}, {0x107f2a058, 0x140005b2fc0}, 0x140019a1400)
  | \t/usr/local/go/src/net/http/server.go:2947 +0x2c4
  | net/http.(*conn).serve(0x14001b341e0, {0x107f2cec0, 0x14000ba8600})
  | \t/usr/local/go/src/net/http/server.go:1991 +0x560
  | created by net/http.(*Server).Serve
  | \t/usr/local/go/src/net/http/server.go:3102 +0x444
  
2022-11-30T18:06:02.279Z [ERROR] vault.core: failed to audit response: request_path=sys/plugins/catalog
  error=
  | 1 error occurred:
  | \t* panic generating audit log
  | 
```

</details>