### PR TITLE
Update go.mod to use latest 1.11.7 SDK release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,7 @@ require (
 	github.com/hashicorp/vault/api v1.7.2
 	github.com/hashicorp/vault/api/auth/approle v0.1.0
 	github.com/hashicorp/vault/api/auth/userpass v0.1.0
-	github.com/hashicorp/vault/sdk v0.5.3-0.20221102145930-b492c42d46aa
+	github.com/hashicorp/vault/sdk v0.5.3-0.20221130203741-ac9e58893bbf
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/jackc/pgx/v4 v4.15.0
 	github.com/jcmturner/gokrb5/v8 v8.4.2


### PR DESCRIPTION
Update go.mod to latest 1.11.7 SDK version update, along with a no-op `go mod tidy`