### PR TITLE
Address a nil panic when writing an empty POST request to the ocsp handler

### DIFF
--- a/builtin/logical/pki/ocsp.go
+++ b/builtin/logical/pki/ocsp.go
@@ -218,7 +218,15 @@ func fetchDerEncodedRequest(request *logical.Request, data *framework.FieldData)
 		return base64.StdEncoding.DecodeString(base64Req)
 	case logical.UpdateOperation:
 		// POST bodies should contain the binary form of the DER request.
+		// NOTE: Writing an empty update request to Vault causes a nil request.HTTPRequest, and that object
+		//       says that it is possible for its Body element to be nil as well, so check both just in case.
+		if request.HTTPRequest == nil {
+			return nil, errors.New("no data in request")
+		}
 		rawBody := request.HTTPRequest.Body
+		if rawBody == nil {
+			return nil, errors.New("no data in request body")
+		}
 		defer rawBody.Close()
 
 		requestBytes, err := io.ReadAll(io.LimitReader(rawBody, maximumRequestSize))

--- a/changelog/18184.txt
+++ b/changelog/18184.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Address nil panic when an empty POST request is sent to the OCSP handler
+```


### PR DESCRIPTION
Identified by @cipherboy thanks!

 - Seems when no body is sent with a POST request Vault will not populate the HTTPRequest member variable which causes a nil panic, it can be reproduced with `vault write -force pki/ocsp`
 - Add a check for it and the Body member variable to be nil before use.