### PR TITLE
plugins: Mount missing plugin entries and skip loading

### DIFF
--- a/changelog/18189.txt
+++ b/changelog/18189.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugins: Skip loading but still mount data associated with missing plugins on unseal.
+```

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -802,7 +802,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 			c.logger.Error("failed to create credential entry", "path", entry.Path, "error", err)
 
 			if c.isMountable(ctx, entry, consts.PluginTypeCredential) {
-				c.logger.Warn("skipping plugin-based mount entry", "path", entry.Path)
+				c.logger.Warn("skipping plugin-based credential entry", "path", entry.Path)
 				goto ROUTER_MOUNT
 			}
 			return errLoadAuthFailed

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -801,19 +801,11 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 		if err != nil {
 			c.logger.Error("failed to create credential entry", "path", entry.Path, "error", err)
 
-			// Consult the plugin catalog to see if we can do a lazy mount. We
-			// error out if the plugin catalog returns an error or a builtin
-			// plugin. Otherwise, we can check the plugin type and proceeed
-			// mounting without initializing the backend if the plugin is
-			// external or nil.
-			plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential, entry.Version)
-			builtin := plug != nil && plug.Builtin
-			if plugerr != nil || builtin {
-				return errLoadMountsFailed
-			} else {
+			if c.isMountable(ctx, entry, consts.PluginTypeCredential) {
 				c.logger.Warn("skipping plugin-based mount entry", "path", entry.Path)
 				goto ROUTER_MOUNT
 			}
+			return errLoadMountsFailed
 		}
 		if backend == nil {
 			return fmt.Errorf("nil backend returned from %q factory", entry.Type)

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -804,7 +804,8 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 			// Consult the plugin catalog to see if we can do a lazy mount. We
 			// error out if the plugin catalog returns an error or a builtin
 			// plugin. Otherwise, we can check the plugin type and proceeed
-			// mounting without initializing the backend.
+			// mounting without initializing the backend if the plugin is
+			// external or nil.
 			plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential, entry.Version)
 			builtin := plug != nil && plug.Builtin
 			if plugerr != nil || builtin {

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -801,10 +801,11 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 		if err != nil {
 			c.logger.Error("failed to create credential entry", "path", entry.Path, "error", err)
 			plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential, "")
-			if plugerr == nil && (plug == nil || plug != nil && !plug.Builtin) {
-				// If we encounter an error instantiating the backend,
-				// skip backend initialization but register the entry to the mount table
-				// to preserve storage and path.
+			builtin := plug != nil && plug.Builtin
+			if plugerr == nil && !builtin {
+				// If we encounter an error instantiating an external plugin
+				// backend, skip backend initialization but register the entry
+				// to the mount table to preserve storage and path.
 				c.logger.Warn("skipping plugin-based credential entry", "path", entry.Path)
 				goto ROUTER_MOUNT
 			}

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -801,7 +801,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 		if err != nil {
 			c.logger.Error("failed to create credential entry", "path", entry.Path, "error", err)
 			plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential, "")
-			if plugerr == nil && plug != nil && !plug.Builtin {
+			if plugerr == nil && (plug == nil || plug != nil && !plug.Builtin) {
 				// If we encounter an error instantiating the backend due to an error,
 				// skip backend initialization but register the entry to the mount table
 				// to preserve storage and path.

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -800,7 +800,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 		backend, entry.RunningSha256, err = c.newCredentialBackend(ctx, entry, sysView, view)
 		if err != nil {
 			c.logger.Error("failed to create credential entry", "path", entry.Path, "error", err)
-			plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential, "")
+			plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential, entry.Version)
 			builtin := plug != nil && plug.Builtin
 			if plugerr == nil && !builtin {
 				// If we encounter an error instantiating an external plugin

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -802,7 +802,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 			c.logger.Error("failed to create credential entry", "path", entry.Path, "error", err)
 			plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential, "")
 			if plugerr == nil && (plug == nil || plug != nil && !plug.Builtin) {
-				// If we encounter an error instantiating the backend due to an error,
+				// If we encounter an error instantiating the backend,
 				// skip backend initialization but register the entry to the mount table
 				// to preserve storage and path.
 				c.logger.Warn("skipping plugin-based credential entry", "path", entry.Path)

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -809,12 +809,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 			builtin := plug != nil && plug.Builtin
 			if plugerr != nil || builtin {
 				return errLoadMountsFailed
-			}
-
-			// In the event that newLogicalBackend returned an error and we have
-			// an external plugin or no plugin, mount the entry but skip the
-			// backend initialization.
-			if plug == nil || !plug.Builtin {
+			} else {
 				c.logger.Warn("skipping plugin-based mount entry", "path", entry.Path)
 				goto ROUTER_MOUNT
 			}

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -805,7 +805,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 				c.logger.Warn("skipping plugin-based mount entry", "path", entry.Path)
 				goto ROUTER_MOUNT
 			}
-			return errLoadMountsFailed
+			return errLoadAuthFailed
 		}
 		if backend == nil {
 			return fmt.Errorf("nil backend returned from %q factory", entry.Type)

--- a/vault/core.go
+++ b/vault/core.go
@@ -3052,7 +3052,7 @@ func (c *Core) isMountable(ctx context.Context, entry *MountEntry, pluginType co
 	plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeSecrets, entry.Version)
 
 	builtin := plug != nil && plug.Builtin
-	return plugerr == nil || !builtin
+	return plugerr == nil && !builtin
 }
 
 // MatchingMount returns the path of the mount that will be responsible for

--- a/vault/core.go
+++ b/vault/core.go
@@ -3042,6 +3042,19 @@ func (c *Core) readFeatureFlags(ctx context.Context) (*FeatureFlags, error) {
 	return &flags, nil
 }
 
+// isMountable tells us whether or not we can continue mounting a plugin-based
+// mount entry after failing to instantiate a backend.
+//
+// We can proceed mounting without initializing the backend if the plugin
+// catalog returns no error and an external or nil plugin. We cannot proceed
+// mounting if the plugin catalog returns an error or a builtin plugin.
+func (c *Core) isMountable(ctx context.Context, entry *MountEntry, pluginType consts.PluginType) bool {
+	plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeSecrets, entry.Version)
+
+	builtin := plug != nil && plug.Builtin
+	return plugerr != nil || builtin
+}
+
 // MatchingMount returns the path of the mount that will be responsible for
 // handling the given request path.
 func (c *Core) MatchingMount(ctx context.Context, reqPath string) string {

--- a/vault/core.go
+++ b/vault/core.go
@@ -3052,7 +3052,7 @@ func (c *Core) isMountable(ctx context.Context, entry *MountEntry, pluginType co
 	plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeSecrets, entry.Version)
 
 	builtin := plug != nil && plug.Builtin
-	return plugerr != nil || builtin
+	return plugerr == nil || !builtin
 }
 
 // MatchingMount returns the path of the mount that will be responsible for

--- a/vault/core.go
+++ b/vault/core.go
@@ -3047,7 +3047,7 @@ func (c *Core) readFeatureFlags(ctx context.Context) (*FeatureFlags, error) {
 // the storage and path when a plugin is missing or has otherwise been
 // misconfigured. This allows users to recover from errors when starting Vault
 // with misconfigured plugins. It should not be possible for existing builtins
-// to be misconfigured, so that is a fatal error
+// to be misconfigured, so that is a fatal error.
 func (c *Core) isMountable(ctx context.Context, entry *MountEntry, pluginType consts.PluginType) bool {
 	// Prevent a panic early on
 	if entry == nil || c.pluginCatalog == nil {

--- a/vault/core.go
+++ b/vault/core.go
@@ -3049,7 +3049,7 @@ func (c *Core) readFeatureFlags(ctx context.Context) (*FeatureFlags, error) {
 // catalog returns no error and an external or nil plugin. We cannot proceed
 // mounting if the plugin catalog returns an error or a builtin plugin.
 func (c *Core) isMountable(ctx context.Context, entry *MountEntry, pluginType consts.PluginType) bool {
-	plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeSecrets, entry.Version)
+	plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, pluginType, entry.Version)
 
 	builtin := plug != nil && plug.Builtin
 	return plugerr == nil && !builtin

--- a/vault/external_plugin_test.go
+++ b/vault/external_plugin_test.go
@@ -299,6 +299,10 @@ func TestCore_EnableExternalPlugin_Deregister_SealUnseal(t *testing.T) {
 	// Register a plugin
 	registerPlugin(t, c.systemBackend, pluginName, consts.PluginTypeCredential.String(), "", plugin.sha256, plugin.fileName)
 	mountPlugin(t, c.systemBackend, pluginName, consts.PluginTypeCredential, "", "")
+	plugct := len(c.pluginCatalog.externalPlugins)
+	if plugct != 1 {
+		t.Fatalf("expected a single external plugin entry after registering, got: %d", plugct)
+	}
 
 	// Now pull the rug out from underneath us
 	deregisterPlugin(t, c.systemBackend, pluginName, consts.PluginTypeCredential.String(), "", "", "")
@@ -314,6 +318,27 @@ func TestCore_EnableExternalPlugin_Deregister_SealUnseal(t *testing.T) {
 		if i+1 == len(keys) && !unseal {
 			t.Fatalf("err: should be unsealed")
 		}
+	}
+
+	plugct = len(c.pluginCatalog.externalPlugins)
+	if plugct != 0 {
+		t.Fatalf("expected no plugin entries after unseal, got: %d", plugct)
+	}
+
+	found := false
+	mounts, err := c.ListAuths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mount := range mounts {
+		if mount.Type == pluginName {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected to find %s mount, but got none", pluginName)
 	}
 }
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1468,10 +1468,11 @@ func (c *Core) setupMounts(ctx context.Context) error {
 		if err != nil {
 			c.logger.Error("failed to create mount entry", "path", entry.Path, "error", err)
 			plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeSecrets, "")
-			if plugerr == nil && (plug == nil || plug != nil && !plug.Builtin) {
-				// If we encounter an error instantiating the backend due to an error,
-				// skip backend initialization but register the entry to the mount table
-				// to preserve storage and path.
+			builtin := plug != nil && plug.Builtin
+			if plugerr == nil && !builtin {
+				// If we encounter an error instantiating an external plugin
+				// backend, skip backend initialization but register the entry
+				// to the mount table to preserve storage and path.
 				c.logger.Warn("skipping plugin-based mount entry", "path", entry.Path)
 				goto ROUTER_MOUNT
 			}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1467,7 +1467,8 @@ func (c *Core) setupMounts(ctx context.Context) error {
 		backend, entry.RunningSha256, err = c.newLogicalBackend(ctx, entry, sysView, view)
 		if err != nil {
 			c.logger.Error("failed to create mount entry", "path", entry.Path, "error", err)
-			if !c.builtinRegistry.Contains(entry.Type, consts.PluginTypeSecrets) {
+			plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeSecrets, "")
+			if plugerr == nil && (plug == nil || plug != nil && !plug.Builtin) {
 				// If we encounter an error instantiating the backend due to an error,
 				// skip backend initialization but register the entry to the mount table
 				// to preserve storage and path.

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1471,7 +1471,8 @@ func (c *Core) setupMounts(ctx context.Context) error {
 			// Consult the plugin catalog to see if we can do a lazy mount. We
 			// error out if the plugin catalog returns an error or a builtin
 			// plugin. Otherwise, we can check the plugin type and proceeed
-			// mounting without initializing the backend.
+			// mounting without initializing the backend if the plugin is
+			// external or nil.
 			plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeSecrets, entry.Version)
 			builtin := plug != nil && plug.Builtin
 			if plugerr != nil || builtin {

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1467,7 +1467,7 @@ func (c *Core) setupMounts(ctx context.Context) error {
 		backend, entry.RunningSha256, err = c.newLogicalBackend(ctx, entry, sysView, view)
 		if err != nil {
 			c.logger.Error("failed to create mount entry", "path", entry.Path, "error", err)
-			plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeSecrets, "")
+			plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeSecrets, entry.Version)
 			builtin := plug != nil && plug.Builtin
 			if plugerr == nil && !builtin {
 				// If we encounter an error instantiating an external plugin

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1467,16 +1467,24 @@ func (c *Core) setupMounts(ctx context.Context) error {
 		backend, entry.RunningSha256, err = c.newLogicalBackend(ctx, entry, sysView, view)
 		if err != nil {
 			c.logger.Error("failed to create mount entry", "path", entry.Path, "error", err)
+
+			// Consult the plugin catalog to see if we can do a lazy mount. We
+			// error out if the plugin catalog returns an error or a builtin
+			// plugin. Otherwise, we can check the plugin type and proceeed
+			// mounting without initializing the backend.
 			plug, plugerr := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeSecrets, entry.Version)
 			builtin := plug != nil && plug.Builtin
-			if plugerr == nil && !builtin {
-				// If we encounter an error instantiating an external plugin
-				// backend, skip backend initialization but register the entry
-				// to the mount table to preserve storage and path.
+			if plugerr != nil || builtin {
+				return errLoadMountsFailed
+			}
+
+			// In the event that newLogicalBackend returned an error and we have
+			// an external plugin or no plugin, mount the entry but skip the
+			// backend initialization.
+			if plug == nil || !plug.Builtin {
 				c.logger.Warn("skipping plugin-based mount entry", "path", entry.Path)
 				goto ROUTER_MOUNT
 			}
-			return errLoadMountsFailed
 		}
 		if backend == nil {
 			return fmt.Errorf("created mount entry of type %q is nil", entry.Type)

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1476,12 +1476,7 @@ func (c *Core) setupMounts(ctx context.Context) error {
 			builtin := plug != nil && plug.Builtin
 			if plugerr != nil || builtin {
 				return errLoadMountsFailed
-			}
-
-			// In the event that newLogicalBackend returned an error and we have
-			// an external plugin or no plugin, mount the entry but skip the
-			// backend initialization.
-			if plug == nil || !plug.Builtin {
+			} else {
 				c.logger.Warn("skipping plugin-based mount entry", "path", entry.Path)
 				goto ROUTER_MOUNT
 			}


### PR DESCRIPTION
This PR fixes an inconsistency and logic issue in the previous unseal logic. We now consistently check the plugincatalog for secrets engines and auth methods and appropriately skip the backend startup for deregistered plugins.

This probably needs an unseal test to prevent regression.

This PR should resolve VAULT-11858