### PR TITLE
Do not use possibly nil HttpRequest object in default OCSP error handler

### DIFF
--- a/builtin/logical/pki/ocsp.go
+++ b/builtin/logical/pki/ocsp.go
@@ -239,7 +239,7 @@ func fetchDerEncodedRequest(request *logical.Request, data *framework.FieldData)
 		}
 		return requestBytes, nil
 	default:
-		return nil, fmt.Errorf("unsupported request method: %s", request.HTTPRequest.Method)
+		return nil, fmt.Errorf("unsupported request method: %s", request.Operation)
 	}
 }
 


### PR DESCRIPTION
This nil issue can't actually happen at the moment, until we added possibly say a delete handler to the router for OCSP or something else. Since we know this is a possible issue, fix it up. Thanks to @cipherboy for pointing this out as well.