### PR TITLE
Backport docs for retry_join_as_non_voter config option

### DIFF
--- a/website/content/docs/commands/operator/raft.mdx
+++ b/website/content/docs/commands/operator/raft.mdx
@@ -79,6 +79,8 @@ The following flags are available for the `operator raft join` command.
   server not participate in the Raft quorum, and have it only receive the data
   replication stream. This can be used to add read scalability to a cluster in
   cases where a high volume of reads to servers are needed. The default is false.
+  See [`retry_join_as_non_voter`](/docs/configuration/storage/raft#retry_join_as_non_voter)
+  for the equivalent config option when using `retry_join` stanzas instead.
 
 - `-retry` `(bool: false)` - Continuously retry joining the Raft cluster upon
   failures. The default is false.
@@ -325,8 +327,10 @@ Flags applicable to this command are the following:
   go without leader contact before being considered unhealthy. Defaults to `10s`.
 
 - `dead-server-last-contact-threshold` `(string)` - Limit on the amount of time
-  a server can go without leader contact before being considered failed. This
-  takes effect only when `cleanup_dead_servers` is set. Defaults to `24h`.
+  a server can go without leader contact before being considered failed.
+  This takes effect only when `cleanup_dead_servers` is set as `true`. Defaults to `24h`.
+  
+  -> **Note:** A failed server that autopilot has removed from the raft configuration cannot rejoin the cluster without being reinitialized.  
 
 - `max-trailing-logs` `(int)` - Amount of entries in the Raft Log that a server
   can be behind before being considered unhealthy. Defaults to `1000`.

--- a/website/content/docs/commands/operator/raft.mdx
+++ b/website/content/docs/commands/operator/raft.mdx
@@ -327,10 +327,8 @@ Flags applicable to this command are the following:
   go without leader contact before being considered unhealthy. Defaults to `10s`.
 
 - `dead-server-last-contact-threshold` `(string)` - Limit on the amount of time
-  a server can go without leader contact before being considered failed.
-  This takes effect only when `cleanup_dead_servers` is set as `true`. Defaults to `24h`.
-  
-  -> **Note:** A failed server that autopilot has removed from the raft configuration cannot rejoin the cluster without being reinitialized.  
+  a server can go without leader contact before being considered failed. This
+  takes effect only when `cleanup_dead_servers` is set. Defaults to `24h`.
 
 - `max-trailing-logs` `(int)` - Amount of entries in the Raft Log that a server
   can be behind before being considered unhealthy. Defaults to `1000`.

--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -95,6 +95,16 @@ set [`disable_mlock`](/docs/configuration#disable_mlock) to `true`, and to disab
   See [the section below](#retry_join-stanza) that describes the parameters
   accepted by the [`retry_join`](#retry_join-stanza) stanza.
 
+- `retry_join_as_non_voter` `(boolean: false)` - If set, causes any `retry_join`
+  config to join the Raft cluster as a non-voter. The node will not participate
+  in the Raft quorum but will still receive the data replication stream, adding
+  read scalability to a cluster. This option has the same effect as the
+  [`-non-voter`](/docs/commands/operator/raft#non-voter) flag for the
+  `vault operator raft join` command, but only affects voting status when joining
+  via `retry_join` config. This setting can be overridden to true by setting the
+  `VAULT_RAFT_RETRY_JOIN_AS_NON_VOTER` environment variable to any non-empty value.
+  Only valid if there is at least one `retry_join` stanza.
+
 - `max_entry_size` `(integer: 1048576)` - This configures the maximum number of
   bytes for a Raft entry. It applies to both Put operations and transactions.
   Any put or transaction operation exceeding this configuration value will cause


### PR DESCRIPTION
Docs portion of #18030, now that 1.12.2 is released. Picked via:

```shell-session
git checkout main -- website/content/docs/configuration/storage/raft.mdx
```