### PR TITLE
Add openapi response definitions to approle/path_role.go

### DIFF
--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -108,6 +108,12 @@ type roleIDStorageEntry struct {
 func rolePaths(b *backend) []*framework.Path {
 	defTokenFields := tokenutil.TokenFields()
 
+	responseOK := map[int][]framework.Response{
+		http.StatusOK: {{
+			Description: "OK",
+		}},
+	}
+
 	p := &framework.Path{
 		Pattern: "role/" + framework.GenericNameRegex("role_name"),
 		Fields: map[string]*framework.FieldSchema{
@@ -169,11 +175,96 @@ can only be set during role creation and once set, it can't be reset later.`,
 			},
 		},
 		ExistenceCheck: b.pathRoleExistenceCheck,
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.CreateOperation: b.pathRoleCreateUpdate,
-			logical.UpdateOperation: b.pathRoleCreateUpdate,
-			logical.ReadOperation:   b.pathRoleRead,
-			logical.DeleteOperation: b.pathRoleDelete,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback:  b.pathRoleCreateUpdate,
+				Responses: responseOK,
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback:  b.pathRoleCreateUpdate,
+				Responses: responseOK,
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathRoleRead,
+				Responses: map[int][]framework.Response{
+					http.StatusOK: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"bind_secret_id": {
+								Type:        framework.TypeBool,
+								Description: "Impose secret ID to be presented when logging in using this role.",
+							},
+							"secret_id_bound_cidrs": {
+								Type:        framework.TypeCommaStringSlice,
+								Description: "Comma separated string or list of CIDR blocks. If set, specifies the blocks of IP addresses which can perform the login operation.",
+							},
+							"secret_id_num_uses": {
+								Type:        framework.TypeInt,
+								Description: "Number of times a secret ID can access the role, after which the secret ID will expire.",
+							},
+							"secret_id_ttl": {
+								Type:        framework.TypeDurationSecond,
+								Description: "Duration in seconds after which the issued secret ID expires.",
+							},
+							"local_secret_ids": {
+								Type:        framework.TypeBool,
+								Description: "If true, the secret identifiers generated using this role will be cluster local. This can only be set during role creation and once set, it can't be reset later",
+							},
+							"token_bound_cidrs": {
+								Type:        framework.TypeCommaStringSlice,
+								Description: `Comma separated string or JSON list of CIDR blocks. If set, specifies the blocks of IP addresses which are allowed to use the generated token.`,
+							},
+							"token_explicit_max_ttl": {
+								Type:        framework.TypeDurationSecond,
+								Description: "If set, tokens created via this role carry an explicit maximum TTL. During renewal, the current maximum TTL values of the role and the mount are not checked for changes, and any updates to these values will have no effect on the token being renewed.",
+							},
+							"token_max_ttl": {
+								Type:        framework.TypeDurationSecond,
+								Description: "The maximum lifetime of the generated token",
+							},
+							"token_no_default_policy": {
+								Type:        framework.TypeBool,
+								Description: "If true, the 'default' policy will not automatically be added to generated tokens",
+							},
+							"token_period": {
+								Type:        framework.TypeDurationSecond,
+								Description: "If set, tokens created via this role will have no max lifetime; instead, their renewal period will be fixed to this value.",
+							},
+							"token_policies": {
+								Type:        framework.TypeCommaStringSlice,
+								Description: "Comma-separated list of policies",
+							},
+							"token_type": {
+								Type:        framework.TypeString,
+								Default:     "default-service",
+								Description: "The type of token to generate, service or batch",
+							},
+							"token_ttl": {
+								Type:        framework.TypeDurationSecond,
+								Description: "The initial ttl of the token to generate",
+							},
+							"token_num_uses": {
+								Type:        framework.TypeInt,
+								Description: "The maximum number of times a token may be used, a value of zero means unlimited",
+							},
+							"period": {
+								Type:        framework.TypeDurationSecond,
+								Description: tokenutil.DeprecationText("token_period"),
+								Deprecated:  true,
+							},
+							"policies": {
+								Type:        framework.TypeCommaStringSlice,
+								Description: tokenutil.DeprecationText("token_policies"),
+								Deprecated:  true,
+							},
+						},
+					}},
+				},
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback:  b.pathRoleDelete,
+				Responses: responseOK,
+			},
 		},
 		HelpSynopsis:    strings.TrimSpace(roleHelp["role"][0]),
 		HelpDescription: strings.TrimSpace(roleHelp["role"][1]),
@@ -185,8 +276,20 @@ can only be set during role creation and once set, it can't be reset later.`,
 		p,
 		{
 			Pattern: "role/?",
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.ListOperation: b.pathRoleList,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ListOperation: &framework.PathOperation{
+					Callback: b.pathRoleList,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"keys": {
+									Type: framework.TypeStringSlice,
+								},
+							},
+						}},
+					},
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-list"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-list"][1]),
@@ -199,8 +302,21 @@ can only be set during role creation and once set, it can't be reset later.`,
 					Description: fmt.Sprintf("Name of the role. Must be less than %d bytes.", maxHmacInputLength),
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.ReadOperation: b.pathRoleLocalSecretIDsRead,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathRoleLocalSecretIDsRead,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"local_secret_ids": {
+									Type:        framework.TypeBool,
+									Description: "If true, the secret identifiers generated using this role will be cluster local. This can only be set during role creation and once set, it can't be reset later",
+								},
+							},
+						}},
+					},
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-local-secret-ids"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-local-secret-ids"][1]),
@@ -222,10 +338,34 @@ can only be set during role creation and once set, it can't be reset later.`,
 					Description: defTokenFields["token_policies"].Description,
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRolePoliciesUpdate,
-				logical.ReadOperation:   b.pathRolePoliciesRead,
-				logical.DeleteOperation: b.pathRolePoliciesDelete,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:  b.pathRolePoliciesUpdate,
+					Responses: responseOK,
+				},
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathRolePoliciesRead,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"policies": {
+									Type:        framework.TypeCommaStringSlice,
+									Description: tokenutil.DeprecationText("token_policies"),
+									Deprecated:  true,
+								},
+								"token_policies": {
+									Type:        framework.TypeCommaStringSlice,
+									Description: defTokenFields["token_policies"].Description,
+								},
+							},
+						}},
+					},
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback:  b.pathRolePoliciesDelete,
+					Responses: responseOK,
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-policies"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-policies"][1]),
@@ -243,10 +383,30 @@ can only be set during role creation and once set, it can't be reset later.`,
 of CIDR blocks. If set, specifies the blocks of IP addresses which can perform the login operation.`,
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRoleBoundCIDRUpdate,
-				logical.ReadOperation:   b.pathRoleBoundCIDRListRead,
-				logical.DeleteOperation: b.pathRoleBoundCIDRListDelete,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:  b.pathRoleBoundCIDRUpdate,
+					Responses: responseOK,
+				},
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathRoleBoundCIDRListRead,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"bound_cidr_list": {
+									Type:        framework.TypeCommaStringSlice,
+									Deprecated:  true,
+									Description: `Deprecated: Please use "secret_id_bound_cidrs" instead. Comma separated string or list of CIDR blocks. If set, specifies the blocks of IP addresses which can perform the login operation.`,
+								},
+							},
+						}},
+					},
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback:  b.pathRoleBoundCIDRListDelete,
+					Responses: responseOK,
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-bound-cidr-list"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-bound-cidr-list"][1]),
@@ -264,10 +424,29 @@ of CIDR blocks. If set, specifies the blocks of IP addresses which can perform t
 IP addresses which can perform the login operation.`,
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRoleSecretIDBoundCIDRUpdate,
-				logical.ReadOperation:   b.pathRoleSecretIDBoundCIDRRead,
-				logical.DeleteOperation: b.pathRoleSecretIDBoundCIDRDelete,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:  b.pathRoleSecretIDBoundCIDRUpdate,
+					Responses: responseOK,
+				},
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathRoleSecretIDBoundCIDRRead,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"secret_id_bound_cidrs": {
+									Type:        framework.TypeCommaStringSlice,
+									Description: `Comma separated string or list of CIDR blocks. If set, specifies the blocks of IP addresses which can perform the login operation.`,
+								},
+							},
+						}},
+					},
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback:  b.pathRoleSecretIDBoundCIDRDelete,
+					Responses: responseOK,
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["secret-id-bound-cidrs"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["secret-id-bound-cidrs"][1]),
@@ -284,10 +463,29 @@ IP addresses which can perform the login operation.`,
 					Description: defTokenFields["token_bound_cidrs"].Description,
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRoleTokenBoundCIDRUpdate,
-				logical.ReadOperation:   b.pathRoleTokenBoundCIDRRead,
-				logical.DeleteOperation: b.pathRoleTokenBoundCIDRDelete,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:  b.pathRoleTokenBoundCIDRUpdate,
+					Responses: responseOK,
+				},
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathRoleTokenBoundCIDRRead,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"token_bound_cidrs": {
+									Type:        framework.TypeCommaStringSlice,
+									Description: `Comma separated string or list of CIDR blocks. If set, specifies the blocks of IP addresses which can use the returned token. Should be a subset of the token CIDR blocks listed on the role, if any.`,
+								},
+							},
+						}},
+					},
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback:  b.pathRoleTokenBoundCIDRDelete,
+					Responses: responseOK,
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["token-bound-cidrs"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["token-bound-cidrs"][1]),
@@ -305,10 +503,29 @@ IP addresses which can perform the login operation.`,
 					Description: "Impose secret_id to be presented when logging in using this role.",
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRoleBindSecretIDUpdate,
-				logical.ReadOperation:   b.pathRoleBindSecretIDRead,
-				logical.DeleteOperation: b.pathRoleBindSecretIDDelete,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:  b.pathRoleBindSecretIDUpdate,
+					Responses: responseOK,
+				},
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathRoleBindSecretIDRead,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"bind_secret_id": {
+									Type:        framework.TypeBool,
+									Description: "Impose secret_id to be presented when logging in using this role. Defaults to 'true'.",
+								},
+							},
+						}},
+					},
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback:  b.pathRoleBindSecretIDDelete,
+					Responses: responseOK,
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-bind-secret-id"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-bind-secret-id"][1]),
@@ -325,10 +542,29 @@ IP addresses which can perform the login operation.`,
 					Description: "Number of times a SecretID can access the role, after which the SecretID will expire.",
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRoleSecretIDNumUsesUpdate,
-				logical.ReadOperation:   b.pathRoleSecretIDNumUsesRead,
-				logical.DeleteOperation: b.pathRoleSecretIDNumUsesDelete,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:  b.pathRoleSecretIDNumUsesUpdate,
+					Responses: responseOK,
+				},
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathRoleSecretIDNumUsesRead,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"secret_id_num_uses": {
+									Type:        framework.TypeInt,
+									Description: "Number of times a secret ID can access the role, after which the SecretID will expire. Defaults to 0 meaning that the secret ID is of unlimited use.",
+								},
+							},
+						}},
+					},
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback:  b.pathRoleSecretIDNumUsesDelete,
+					Responses: responseOK,
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-secret-id-num-uses"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-secret-id-num-uses"][1]),
@@ -346,10 +582,29 @@ IP addresses which can perform the login operation.`,
 to 0, meaning no expiration.`,
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRoleSecretIDTTLUpdate,
-				logical.ReadOperation:   b.pathRoleSecretIDTTLRead,
-				logical.DeleteOperation: b.pathRoleSecretIDTTLDelete,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:  b.pathRoleSecretIDTTLUpdate,
+					Responses: responseOK,
+				},
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathRoleSecretIDTTLRead,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"secret_id_ttl": {
+									Type:        framework.TypeDurationSecond,
+									Description: "Duration in seconds after which the issued secret ID should expire. Defaults to 0, meaning no expiration.",
+								},
+							},
+						}},
+					},
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback:  b.pathRoleSecretIDTTLDelete,
+					Responses: responseOK,
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-secret-id-ttl"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-secret-id-ttl"][1]),
@@ -371,10 +626,34 @@ to 0, meaning no expiration.`,
 					Description: defTokenFields["token_period"].Description,
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRolePeriodUpdate,
-				logical.ReadOperation:   b.pathRolePeriodRead,
-				logical.DeleteOperation: b.pathRolePeriodDelete,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:  b.pathRolePeriodUpdate,
+					Responses: responseOK,
+				},
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathRolePeriodRead,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"period": {
+									Type:        framework.TypeDurationSecond,
+									Description: tokenutil.DeprecationText("token_period"),
+									Deprecated:  true,
+								},
+								"token_period": {
+									Type:        framework.TypeDurationSecond,
+									Description: defTokenFields["token_period"].Description,
+								},
+							},
+						}},
+					},
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback:  b.pathRolePeriodDelete,
+					Responses: responseOK,
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-period"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-period"][1]),
@@ -391,10 +670,29 @@ to 0, meaning no expiration.`,
 					Description: defTokenFields["token_num_uses"].Description,
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRoleTokenNumUsesUpdate,
-				logical.ReadOperation:   b.pathRoleTokenNumUsesRead,
-				logical.DeleteOperation: b.pathRoleTokenNumUsesDelete,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:  b.pathRoleTokenNumUsesUpdate,
+					Responses: responseOK,
+				},
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathRoleTokenNumUsesRead,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"token_num_uses": {
+									Type:        framework.TypeInt,
+									Description: defTokenFields["token_num_uses"].Description,
+								},
+							},
+						}},
+					},
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback:  b.pathRoleTokenNumUsesDelete,
+					Responses: responseOK,
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-token-num-uses"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-token-num-uses"][1]),
@@ -411,10 +709,29 @@ to 0, meaning no expiration.`,
 					Description: defTokenFields["token_ttl"].Description,
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRoleTokenTTLUpdate,
-				logical.ReadOperation:   b.pathRoleTokenTTLRead,
-				logical.DeleteOperation: b.pathRoleTokenTTLDelete,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:  b.pathRoleTokenTTLUpdate,
+					Responses: responseOK,
+				},
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathRoleTokenTTLRead,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"token_ttl": {
+									Type:        framework.TypeDurationSecond,
+									Description: defTokenFields["token_ttl"].Description,
+								},
+							},
+						}},
+					},
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback:  b.pathRoleTokenTTLDelete,
+					Responses: responseOK,
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-token-ttl"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-token-ttl"][1]),
@@ -431,10 +748,29 @@ to 0, meaning no expiration.`,
 					Description: defTokenFields["token_max_ttl"].Description,
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRoleTokenMaxTTLUpdate,
-				logical.ReadOperation:   b.pathRoleTokenMaxTTLRead,
-				logical.DeleteOperation: b.pathRoleTokenMaxTTLDelete,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:  b.pathRoleTokenMaxTTLUpdate,
+					Responses: responseOK,
+				},
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathRoleTokenMaxTTLRead,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"token_max_ttl": {
+									Type:        framework.TypeDurationSecond,
+									Description: defTokenFields["token_max_ttl"].Description,
+								},
+							},
+						}},
+					},
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback:  b.pathRoleTokenMaxTTLDelete,
+					Responses: responseOK,
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-token-max-ttl"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-token-max-ttl"][1]),
@@ -451,9 +787,25 @@ to 0, meaning no expiration.`,
 					Description: "Identifier of the role. Defaults to a UUID.",
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.ReadOperation:   b.pathRoleRoleIDRead,
-				logical.UpdateOperation: b.pathRoleRoleIDUpdate,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathRoleRoleIDRead,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"role_id": {
+									Type:        framework.TypeString,
+									Description: "Identifier of the role. Defaults to a UUID.",
+								},
+							},
+						}},
+					},
+				},
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:  b.pathRoleRoleIDUpdate,
+					Responses: responseOK,
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-id"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-id"][1]),
@@ -492,9 +844,46 @@ Overrides secret_id_num_uses role option when supplied. May not be higher than r
 Overrides secret_id_ttl role option when supplied. May not be longer than role's secret_id_ttl.`,
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRoleSecretIDUpdate,
-				logical.ListOperation:   b.pathRoleSecretIDList,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback: b.pathRoleSecretIDUpdate,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"secret_id": {
+									Type:        framework.TypeString,
+									Description: "Secret ID attached to the role.",
+								},
+								"secret_id_accessor": {
+									Type:        framework.TypeString,
+									Description: "Accessor of the secret ID",
+								},
+								"secret_id_ttl": {
+									Type:        framework.TypeDurationSecond,
+									Description: "Duration in seconds after which the issued secret ID expires.",
+								},
+								"secret_id_num_uses": {
+									Type:        framework.TypeInt,
+									Description: "Number of times a secret ID can access the role, after which the secret ID will expire.",
+								},
+							},
+						}},
+					},
+				},
+				logical.ListOperation: &framework.PathOperation{
+					Callback: b.pathRoleSecretIDList,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"keys": {
+									Type: framework.TypeStringSlice,
+								},
+							},
+						}},
+					},
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-secret-id"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-secret-id"][1]),
@@ -511,8 +900,49 @@ Overrides secret_id_ttl role option when supplied. May not be longer than role's
 					Description: "SecretID attached to the role.",
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRoleSecretIDLookupUpdate,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback: b.pathRoleSecretIDLookupUpdate,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"secret_id_accessor": {
+									Type:        framework.TypeString,
+									Description: "Accessor of the secret ID",
+								},
+								"secret_id_ttl": {
+									Type:        framework.TypeDurationSecond,
+									Description: "Duration in seconds after which the issued secret ID expires.",
+								},
+								"secret_id_num_uses": {
+									Type:        framework.TypeInt,
+									Description: "Number of times a secret ID can access the role, after which the secret ID will expire.",
+								},
+								"creation_time": {
+									Type: framework.TypeTime,
+								},
+								"expiration_time": {
+									Type: framework.TypeTime,
+								},
+								"last_updated_time": {
+									Type: framework.TypeTime,
+								},
+								"metadata": {
+									Type: framework.TypeMap,
+								},
+								"cidr_list": {
+									Type:        framework.TypeCommaStringSlice,
+									Description: "List of CIDR blocks enforcing secret IDs to be used from specific set of IP addresses. If 'bound_cidr_list' is set on the role, then the list of CIDR blocks listed here should be a subset of the CIDR blocks listed on the role.",
+								},
+								"token_bound_cidrs": {
+									Type:        framework.TypeCommaStringSlice,
+									Description: "List of CIDR blocks. If set, specifies the blocks of IP addresses which can use the returned token. Should be a subset of the token CIDR blocks listed on the role, if any.",
+								},
+							},
+						}},
+					},
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-secret-id-lookup"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-secret-id-lookup"][1]),
@@ -529,9 +959,15 @@ Overrides secret_id_ttl role option when supplied. May not be longer than role's
 					Description: "SecretID attached to the role.",
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRoleSecretIDDestroyUpdateDelete,
-				logical.DeleteOperation: b.pathRoleSecretIDDestroyUpdateDelete,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:  b.pathRoleSecretIDDestroyUpdateDelete,
+					Responses: responseOK,
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback:  b.pathRoleSecretIDDestroyUpdateDelete,
+					Responses: responseOK,
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-secret-id-destroy"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-secret-id-destroy"][1]),
@@ -548,8 +984,49 @@ Overrides secret_id_ttl role option when supplied. May not be longer than role's
 					Description: "Accessor of the SecretID",
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRoleSecretIDAccessorLookupUpdate,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback: b.pathRoleSecretIDAccessorLookupUpdate,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"secret_id_accessor": {
+									Type:        framework.TypeString,
+									Description: "Accessor of the secret ID",
+								},
+								"secret_id_ttl": {
+									Type:        framework.TypeDurationSecond,
+									Description: "Duration in seconds after which the issued secret ID expires.",
+								},
+								"secret_id_num_uses": {
+									Type:        framework.TypeInt,
+									Description: "Number of times a secret ID can access the role, after which the secret ID will expire.",
+								},
+								"creation_time": {
+									Type: framework.TypeTime,
+								},
+								"expiration_time": {
+									Type: framework.TypeTime,
+								},
+								"last_updated_time": {
+									Type: framework.TypeTime,
+								},
+								"metadata": {
+									Type: framework.TypeMap,
+								},
+								"cidr_list": {
+									Type:        framework.TypeCommaStringSlice,
+									Description: "List of CIDR blocks enforcing secret IDs to be used from specific set of IP addresses. If 'bound_cidr_list' is set on the role, then the list of CIDR blocks listed here should be a subset of the CIDR blocks listed on the role.",
+								},
+								"token_bound_cidrs": {
+									Type:        framework.TypeCommaStringSlice,
+									Description: "List of CIDR blocks. If set, specifies the blocks of IP addresses which can use the returned token. Should be a subset of the token CIDR blocks listed on the role, if any.",
+								},
+							},
+						}},
+					},
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-secret-id-accessor"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-secret-id-accessor"][1]),
@@ -566,9 +1043,15 @@ Overrides secret_id_ttl role option when supplied. May not be longer than role's
 					Description: "Accessor of the SecretID",
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRoleSecretIDAccessorDestroyUpdateDelete,
-				logical.DeleteOperation: b.pathRoleSecretIDAccessorDestroyUpdateDelete,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:  b.pathRoleSecretIDAccessorDestroyUpdateDelete,
+					Responses: responseOK,
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback:  b.pathRoleSecretIDAccessorDestroyUpdateDelete,
+					Responses: responseOK,
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-secret-id-accessor"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-secret-id-accessor"][1]),
@@ -612,8 +1095,33 @@ Overrides secret_id_num_uses role option when supplied. May not be higher than r
 Overrides secret_id_ttl role option when supplied. May not be longer than role's secret_id_ttl.`,
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathRoleCustomSecretIDUpdate,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback: b.pathRoleCustomSecretIDUpdate,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"secret_id": {
+									Type:        framework.TypeString,
+									Description: "Secret ID attached to the role.",
+								},
+								"secret_id_accessor": {
+									Type:        framework.TypeString,
+									Description: "Accessor of the secret ID",
+								},
+								"secret_id_ttl": {
+									Type:        framework.TypeDurationSecond,
+									Description: "Duration in seconds after which the issued secret ID expires.",
+								},
+								"secret_id_num_uses": {
+									Type:        framework.TypeInt,
+									Description: "Number of times a secret ID can access the role, after which the secret ID will expire.",
+								},
+							},
+						}},
+					},
+				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-custom-secret-id"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-custom-secret-id"][1]),

--- a/sdk/framework/path.go
+++ b/sdk/framework/path.go
@@ -227,7 +227,6 @@ type RequestExample struct {
 	Response *Response
 }
 
-// Response describes and optional demonstrations an operation response.
 type Response struct {
 	Description string                  // summary of the the response and should always be provided
 	MediaType   string                  // media type of the response, defaulting to "application/json" if empty

--- a/sdk/framework/path.go
+++ b/sdk/framework/path.go
@@ -227,6 +227,7 @@ type RequestExample struct {
 	Response *Response
 }
 
+// Response describes and optional demonstrations an operation response.
 type Response struct {
 	Description string                  // summary of the the response and should always be provided
 	MediaType   string                  // media type of the response, defaulting to "application/json" if empty


### PR DESCRIPTION
This PR modifies the path schema of `approle/path_role.go`, switching the old `Callbacks` to the equivalent `Operations` objects with a list of response fields for the 200 responses. This will allow us to generate a response structures in openapi.json. This PR is split out from #18055 along with #18192.

### Example

For `GET "/auth/approle/role/{role_name}/bind-secret-id"` path, it will update the response as follows:

```diff
        "responses": {
          "200": {
            "description": "OK",
++            "content": {
++              "application/json": {
++                "schema": {
++                  "$ref": "#/components/schemas/ApproleRoleBindSecretIdResponse"
++                }
++             }
            }
          }
        }
```

And will add the actual response structure:

```diff
++      "ApproleRoleBindSecretIdResponse": {
++        "type": "object",
++        "properties": {
++          "bind_secret_id": {
++            "type": "boolean",
++            "description": "Impose secret_id to be presented when logging in using this role. Defaults to 'true'."
++          }
++        }
++      },
```