### PR TITLE
Server: add and support unix listener (UDS)

### DIFF
--- a/changelog/18227.txt
+++ b/changelog/18227.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+**Server UDS Listener**: Adding listener to Vault server to serve http request via unix domain socket
+```

--- a/command/server/listener.go
+++ b/command/server/listener.go
@@ -20,7 +20,8 @@ type ListenerFactory func(*configutil.Listener, io.Writer, cli.Ui) (net.Listener
 
 // BuiltinListeners is the list of built-in listener types.
 var BuiltinListeners = map[string]ListenerFactory{
-	"tcp": tcpListenerFactory,
+	"tcp":  tcpListenerFactory,
+	"unix": unixListenerFactory,
 }
 
 // NewListener creates a new listener of the given type with the given

--- a/command/server/listener_test.go
+++ b/command/server/listener_test.go
@@ -26,6 +26,9 @@ func testListenerImpl(t *testing.T, ln net.Listener, connFn testListenerConnFn, 
 			tlsConn.Handshake()
 		}
 		serverCh <- server
+		if expectedAddr == "" {
+			return
+		}
 		addr, _, err := net.SplitHostPort(server.RemoteAddr().String())
 		if err != nil {
 			t.Error(err)

--- a/command/server/listener_unix.go
+++ b/command/server/listener_unix.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"io"
+	"net"
+
+	"github.com/hashicorp/go-secure-stdlib/reloadutil"
+	"github.com/hashicorp/vault/internalshared/configutil"
+	"github.com/hashicorp/vault/internalshared/listenerutil"
+	"github.com/mitchellh/cli"
+)
+
+func unixListenerFactory(l *configutil.Listener, _ io.Writer, ui cli.Ui) (net.Listener, map[string]string, reloadutil.ReloadFunc, error) {
+	addr := l.Address
+	if addr == "" {
+		addr = "/run/vault.sock"
+	}
+
+	var cfg *listenerutil.UnixSocketsConfig
+	if l.SocketMode != "" &&
+		l.SocketUser != "" &&
+		l.SocketGroup != "" {
+		cfg = &listenerutil.UnixSocketsConfig{
+			Mode:  l.SocketMode,
+			User:  l.SocketUser,
+			Group: l.SocketGroup,
+		}
+	}
+
+	ln, err := listenerutil.UnixSocketListener(addr, cfg)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return ln, map[string]string{}, nil, nil
+}

--- a/command/server/listener_unix_test.go
+++ b/command/server/listener_unix_test.go
@@ -1,0 +1,25 @@
+package server
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/vault/internalshared/configutil"
+	"github.com/mitchellh/cli"
+)
+
+func TestUnixListener(t *testing.T) {
+	ln, _, _, err := unixListenerFactory(&configutil.Listener{
+		Address: filepath.Join(t.TempDir(), "/vault.sock"),
+	}, nil, cli.NewMockUi())
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	connFn := func(lnReal net.Listener) (net.Conn, error) {
+		return net.Dial("unix", ln.Addr().String())
+	}
+
+	testListenerImpl(t, ln, connFn, "", 0, "", false)
+}

--- a/website/content/docs/configuration/listener/index.mdx
+++ b/website/content/docs/configuration/listener/index.mdx
@@ -9,6 +9,9 @@ description: |-
 # `listener` Stanza
 
 The `listener` stanza configures the addresses and ports on which Vault will
-respond to requests. At this time, there is only one listener - [TCP][tcp].
+respond to requests. At this time, there are two listeners: 
+- [TCP][tcp]
+- [Unix Domain Socket][unix]
 
 [tcp]: /docs/configuration/listener/tcp
+[unix]: /docs/configuration/listener/unix

--- a/website/content/docs/configuration/listener/unix.mdx
+++ b/website/content/docs/configuration/listener/unix.mdx
@@ -1,0 +1,69 @@
+---
+layout: docs
+page_title: Unix - Listeners - Configuration
+description: |-
+  The Unix listener configures Vault to listen on the specified Unix domain socket.
+---
+
+# `unix` Listener
+
+The Unix listener configures Vault to listen on the specified Unix domain socket.
+
+```hcl
+listener "unix" {
+  address = "/run/vault.sock"
+}
+```
+
+The `listener` stanza may be specified more than once to make Vault listen on
+multiple sockets.
+
+## `unix` Listener Parameters
+- `address` `(string: "/run/vault.sock", <required>)` – Specifies the address to bind the Unix socket.
+
+- `socket_mode` `(string: "", <optional>)` – Changes the access
+  permissions and the special mode flags of the Unix socket.
+
+- `socket_user` `(string: "", <optional>)` – Changes the user owner of the Unix socket.
+
+- `socket_group` `(string: "", <optional>)` – Changes the group owner of the Unix socket.
+
+
+## `unix` Listener Examples
+
+### Listening on Multiple Sockets
+
+This example shows Vault listening on a specified socket, as well as the default.
+
+```hcl
+listener "unix" {}
+
+listener "unix" {
+  address = "/var/run/vault.sock"
+}
+```
+
+### Listening on Multiple Interfaces
+
+This example shows Vault listening on TCP localhost, as well as Unix socket.
+
+```hcl
+listener "unix" {
+  address = "/var/run/vault.sock"
+}
+
+listener "tcp" {
+  address = "127.0.0.1:8200"
+}
+```
+
+### Configuring Permissions
+This example shows changing access permissions and ownership of the Unix socket.
+```hcl
+listener "unix" {
+  address = "/var/run/vault.sock"
+  socket_mode = "644"
+  socket_user = "1000"
+  socket_group = "1000"
+}
+```

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -214,6 +214,10 @@
           {
             "title": "TCP",
             "path": "configuration/listener/tcp"
+          },
+          {
+            "title": "Unix",
+            "path": "configuration/listener/unix"
           }
         ]
       },


### PR DESCRIPTION
Fix #5491  

hcl config
```text
listener "unix" {}

listener "tcp" {
  address       = "127.0.0.1:8300"
  tls_cert_file = ""
  tls_key_file  = ""
  tls_disable   = 1
}

api_addr     = "http://127.0.0.1:8300"
cluster_addr = "http://127.0.0.1:8300"

storage "file" {
  path           = "/tmp/vault/storage"
  connection_url = ""
  ha_enabled     = false
}
```


Vault server logs: 
```sh
==> Vault server configuration:

             Api Address: http://127.0.0.1:8300
                     Cgo: disabled
         Cluster Address: https://127.0.0.1:8301
   Environment Variables: DBUS_SESSION_BUS_ADDRESS, HOME, LANG, LC_CTYPE, LOGNAME, MOTD_SHOWN, OLDPWD, PATH, PWD, SHELL, SHLVL, SSH_CLIENT, SSH_CONNECTION, SSH_TTY, TERM, USER, XDG_DATA_DIRS, XDG_RUNTIME_DIR, XDG_SESSION_CLASS, XDG_SESSION_ID, XDG_SESSION_TYPE, _
              Go Version: go1.19.3
              Listener 1: unix (max_request_duration: "1m30s", max_request_size: "33554432")
              Listener 2: tcp (addr: "127.0.0.1:8300", cluster address: "127.0.0.1:8301", max_request_duration: "1m30s", max_request_size: "33554432", tls: "disabled")
               Log Level: info
                   Mlock: supported: true, enabled: false
           Recovery Mode: false
                 Storage: file
                 Version: Vault v1.13.0-dev1, built 2022-12-02T16:02:28Z
             Version Sha: 12b2fab87559d6da9ff38247902a540992867827+CHANGES

==> Vault server started! Log data will stream in below:

2022-12-05T18:20:16.511+0200 [INFO]  vault: proxy environment: http_proxy="" https_proxy="" no_proxy=""
2022-12-05T18:20:16.512+0200 [INFO]  vault.core: Initializing version history cache for core
```

Curl Example 
```sh
curl --silent -XGET --unix-socket /run/vault.sock http://localhost/v1/sys/health | jq
{
  "initialized": false,
  "sealed": true,
  "standby": true,
  "performance_standby": false,
  "replication_performance_mode": "unknown",
  "replication_dr_mode": "unknown",
  "server_time_utc": 1670257271,
  "version": "1.13.0-dev1"
}
```


