### PR TITLE
VAULT-9863 Kubernetes Overview Page

### DIFF
--- a/ui/app/styles/core/helpers.scss
+++ b/ui/app/styles/core/helpers.scss
@@ -92,6 +92,9 @@
 .is-no-flex-grow {
   flex-grow: 0 !important;
 }
+.is-flex-half {
+  flex: 50%;
+}
 .is-auto-width {
   width: auto;
 }

--- a/ui/lib/kubernetes/addon/components/page/overview.hbs
+++ b/ui/lib/kubernetes/addon/components/page/overview.hbs
@@ -1,0 +1,53 @@
+<TabPageHeader @model={{@model.backend}}>
+  <ToolbarLink @route="configure">Configure Kubernetes</ToolbarLink>
+</TabPageHeader>
+
+{{#if @model.config}}
+  <div class="has-top-margin-m">
+    <div class="is-flex">
+      <div class="box has-padding-m has-right-margin-m is-rounded column is-flex-half" data-test-roles-card>
+        <div class="is-flex-between">
+          <h2 class="title is-3">
+            Roles
+          </h2>
+          {{#if @model.roles.length}}
+            <LinkTo class="is-no-underline" @route="roles">View Roles</LinkTo>
+          {{else}}
+            <LinkTo class="is-no-underline" @route="roles.create">Create Role</LinkTo>
+          {{/if}}
+        </div>
+        <p>The number of Vault roles being used to generate Kubernetes credentials.</p>
+        <h2 class="title has-font-weight-normal is-3 has-top-margin-l">
+          {{if @model.roles.length @model.roles.length "None"}}
+        </h2>
+      </div>
+      <div class="box has-padding-m is-rounded column is-flex-half" data-test-generate-credential-card>
+        <h2 class="title is-3">
+          Generate credentials
+        </h2>
+        <p>Quickly generate credentials by typing the role name.</p>
+        <div class="is-flex-center has-top-margin-s">
+          <SearchSelect
+            class="is-marginless is-flex-1"
+            @placeholder="Type to find a role..."
+            @disallowNewItems={{true}}
+            @options={{this.roleOptions}}
+            @selectLimit="1"
+            @fallbackComponent="input-search"
+            @onChange={{this.selectRole}}
+          />
+          <button
+            class="button has-left-margin-m"
+            type="button"
+            disabled={{this.isDisabled}}
+            {{on "click" this.generateCredential}}
+          >
+            Generate
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+{{else}}
+  <ConfigCta />
+{{/if}}

--- a/ui/lib/kubernetes/addon/components/page/overview.hbs
+++ b/ui/lib/kubernetes/addon/components/page/overview.hbs
@@ -18,7 +18,7 @@
         </div>
         <p>The number of Vault roles being used to generate Kubernetes credentials.</p>
         <h2 class="title has-font-weight-normal is-3 has-top-margin-l">
-          {{if @model.roles.length @model.roles.length "None"}}
+          {{or @model.roles.length @model.roles.length "None"}}
         </h2>
       </div>
       <div class="box has-padding-m is-rounded column is-flex-half" data-test-generate-credential-card>

--- a/ui/lib/kubernetes/addon/components/page/overview.hbs
+++ b/ui/lib/kubernetes/addon/components/page/overview.hbs
@@ -39,7 +39,7 @@
           <button
             class="button has-left-margin-m"
             type="button"
-            disabled={{this.isDisabled}}
+            disabled={{not this.selectedRole}}
             {{on "click" this.generateCredential}}
           >
             Generate

--- a/ui/lib/kubernetes/addon/components/page/overview.hbs
+++ b/ui/lib/kubernetes/addon/components/page/overview.hbs
@@ -18,7 +18,7 @@
         </div>
         <p>The number of Vault roles being used to generate Kubernetes credentials.</p>
         <h2 class="title has-font-weight-normal is-3 has-top-margin-l">
-          {{or @model.roles.length @model.roles.length "None"}}
+          {{or @model.roles.length "None"}}
         </h2>
       </div>
       <div class="box has-padding-m is-rounded column is-flex-half" data-test-generate-credential-card>

--- a/ui/lib/kubernetes/addon/components/page/overview.js
+++ b/ui/lib/kubernetes/addon/components/page/overview.js
@@ -6,20 +6,10 @@ import { action } from '@ember/object';
 export default class OverviewPageComponent extends Component {
   @service router;
 
-  @tracked roles = [];
   @tracked selectedRole = null;
-  @tracked roleOptions = this.roles.map((role) => {
+  @tracked roleOptions = this.args.model.roles.map((role) => {
     return { name: role.name, id: role.name };
   });
-
-  constructor() {
-    super(...arguments);
-    this.roles = this.args.model.roles.toArray();
-  }
-
-  get isDisabled() {
-    return !this.selectedRole;
-  }
 
   @action
   selectRole([roleName]) {
@@ -28,8 +18,9 @@ export default class OverviewPageComponent extends Component {
 
   @action
   generateCredential() {
-    const { selectedRole } = this;
-
-    this.router.transitionTo('vault.cluster.secrets.backend.kubernetes.roles.role.credentials', selectedRole);
+    this.router.transitionTo(
+      'vault.cluster.secrets.backend.kubernetes.roles.role.credentials',
+      this.selectedRole
+    );
   }
 }

--- a/ui/lib/kubernetes/addon/components/page/overview.js
+++ b/ui/lib/kubernetes/addon/components/page/overview.js
@@ -1,0 +1,35 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class OverviewPageComponent extends Component {
+  @service router;
+
+  @tracked roles = [];
+  @tracked selectedRole = null;
+  @tracked roleOptions = this.roles.map((role) => {
+    return { name: role.name, id: role.name };
+  });
+
+  constructor() {
+    super(...arguments);
+    this.roles = this.args.model.roles.toArray();
+  }
+
+  get isDisabled() {
+    return !this.selectedRole;
+  }
+
+  @action
+  selectRole([roleName]) {
+    this.selectedRole = roleName;
+  }
+
+  @action
+  generateCredential() {
+    const { selectedRole } = this;
+
+    this.router.transitionTo('vault.cluster.secrets.backend.kubernetes.roles.role.credentials', selectedRole);
+  }
+}

--- a/ui/lib/kubernetes/addon/components/page/overview.js
+++ b/ui/lib/kubernetes/addon/components/page/overview.js
@@ -7,9 +7,14 @@ export default class OverviewPageComponent extends Component {
   @service router;
 
   @tracked selectedRole = null;
-  @tracked roleOptions = this.args.model.roles.map((role) => {
-    return { name: role.name, id: role.name };
-  });
+  @tracked roleOptions = [];
+
+  constructor() {
+    super(...arguments);
+    this.roleOptions = this.args.model.roles.map((role) => {
+      return { name: role.name, id: role.name };
+    });
+  }
 
   @action
   selectRole([roleName]) {

--- a/ui/lib/kubernetes/addon/routes/overview.js
+++ b/ui/lib/kubernetes/addon/routes/overview.js
@@ -1,3 +1,14 @@
-import Route from '@ember/routing/route';
+import { hash } from 'rsvp';
+import FetchConfigRoute from './fetch-config';
 
-export default class KubernetesOverviewRoute extends Route {}
+export default class KubernetesOverviewRoute extends FetchConfigRoute {
+  async model() {
+    const backend = this.secretMountPath.get();
+
+    return hash({
+      config: this.configModel,
+      backend: this.modelFor('application'),
+      roles: this.store.query('kubernetes/role', { backend }),
+    });
+  }
+}

--- a/ui/lib/kubernetes/addon/templates/overview.hbs
+++ b/ui/lib/kubernetes/addon/templates/overview.hbs
@@ -1,1 +1,1 @@
-Overview
+<Page::Overview @model={{this.model}} />

--- a/ui/tests/integration/components/kubernetes/page/overview-test.js
+++ b/ui/tests/integration/components/kubernetes/page/overview-test.js
@@ -1,0 +1,97 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupEngine } from 'ember-engines/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { render } from '@ember/test-helpers';
+import { typeInSearch, clickTrigger, selectChoose } from 'ember-power-select/test-support/helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | kubernetes | Page::Overview', function (hooks) {
+  setupRenderingTest(hooks);
+  setupEngine(hooks, 'kubernetes');
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.store.pushPayload('secret-engine', {
+      modelName: 'secret-engine',
+      data: {
+        accessor: 'kubernetes_f3400dee',
+        path: 'kubernetes-test/',
+        type: 'kubernetes',
+      },
+    });
+    this.store.pushPayload('kubernetes/config', {
+      modelName: 'kubernetes/config',
+      backend: 'kubernetes-test',
+      ...this.server.create('kubernetes-config'),
+    });
+    this.store.pushPayload('kubernetes/role', {
+      modelName: 'kubernetes/role',
+      backend: 'kubernetes-test',
+      ...this.server.create('kubernetes-role'),
+    });
+    this.store.pushPayload('kubernetes/role', {
+      modelName: 'kubernetes/role',
+      backend: 'kubernetes-test',
+      ...this.server.create('kubernetes-role'),
+    });
+    this.model = {
+      backend: this.store.peekRecord('secret-engine', 'kubernetes-test'),
+      config: this.store.peekRecord('kubernetes/config', 'kubernetes-test'),
+      roles: this.store.peekAll('kubernetes/role'),
+    };
+  });
+
+  test('it should display role card', async function (assert) {
+    await render(hbs`<Page::Overview @model={{this.model}} />`, { owner: this.engine });
+    assert.dom('[data-test-roles-card] .title').hasText('Roles');
+    assert
+      .dom('[data-test-roles-card] p')
+      .hasText('The number of Vault roles being used to generate Kubernetes credentials.');
+    assert.dom('[data-test-roles-card] a').hasText('View Roles');
+
+    this.model = {
+      backend: this.store.peekRecord('secret-engine', 'kubernetes-test'),
+      config: this.store.peekRecord('kubernetes/config', 'kubernetes-test'),
+      roles: [],
+    };
+
+    await render(hbs`<Page::Overview @model={{this.model}} />`, { owner: this.engine });
+
+    assert.dom('[data-test-roles-card] a').hasText('Create Role');
+  });
+
+  test('it should display correct number of roles in role card', async function (assert) {
+    await render(hbs`<Page::Overview @model={{this.model}} />`, { owner: this.engine });
+    assert.dom('[data-test-roles-card] .has-font-weight-normal').hasText('2');
+
+    this.model = {
+      backend: this.store.peekRecord('secret-engine', 'kubernetes-test'),
+      config: this.store.peekRecord('kubernetes/config', 'kubernetes-test'),
+      roles: [],
+    };
+
+    await render(hbs`<Page::Overview @model={{this.model}} />`, { owner: this.engine });
+    assert.dom('[data-test-roles-card] .has-font-weight-normal').hasText('None');
+  });
+
+  test('it should display generate credentials card', async function (assert) {
+    await render(hbs`<Page::Overview @model={{this.model}} />`, { owner: this.engine });
+    assert.dom('[data-test-generate-credential-card] .title').hasText('Generate credentials');
+    assert
+      .dom('[data-test-generate-credential-card] p')
+      .hasText('Quickly generate credentials by typing the role name.');
+  });
+
+  test('it should show options for SearchSelect', async function (assert) {
+    await render(hbs`<Page::Overview @model={{this.model}} />`, { owner: this.engine });
+    await clickTrigger();
+    assert.strictEqual(this.element.querySelectorAll('.ember-power-select-option').length, 2);
+    await typeInSearch('role-0');
+    assert.strictEqual(this.element.querySelectorAll('.ember-power-select-option').length, 1);
+    assert.dom('[data-test-generate-credential-card] button').isDisabled();
+    await selectChoose('', '.ember-power-select-option', 2);
+    assert.dom('[data-test-generate-credential-card] button').isNotDisabled();
+  });
+});

--- a/ui/tests/integration/components/kubernetes/page/overview-test.js
+++ b/ui/tests/integration/components/kubernetes/page/overview-test.js
@@ -5,37 +5,42 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { typeInSearch, clickTrigger, selectChoose } from 'ember-power-select/test-support/helpers';
 import hbs from 'htmlbars-inline-precompile';
-import ENV from 'vault/config/environment';
 
 module('Integration | Component | kubernetes | Page::Overview', function (hooks) {
   setupRenderingTest(hooks);
   setupEngine(hooks, 'kubernetes');
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'kubernetes';
-  });
-
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
-  });
-
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');
+    this.store.pushPayload('secret-engine', {
+      modelName: 'secret-engine',
+      data: {
+        accessor: 'kubernetes_f3400dee',
+        path: 'kubernetes-test/',
+        type: 'kubernetes',
+      },
+    });
+    this.store.pushPayload('kubernetes/config', {
+      modelName: 'kubernetes/config',
+      backend: 'kubernetes-test',
+      ...this.server.create('kubernetes-config'),
+    });
+    this.store.pushPayload('kubernetes/role', {
+      modelName: 'kubernetes/role',
+      backend: 'kubernetes-test',
+      ...this.server.create('kubernetes-role'),
+    });
+    this.store.pushPayload('kubernetes/role', {
+      modelName: 'kubernetes/role',
+      backend: 'kubernetes-test',
+      ...this.server.create('kubernetes-role'),
+    });
     this.model = {
-      config: this.server.create('kubernetes-config'),
-      backend: this.store.createRecord('secret-engine', {
-        modelName: 'secret-engine',
-        data: {
-          accessor: 'kubernetes_f3400dee',
-          path: 'kubernetes-test/',
-          type: 'kubernetes',
-        },
-      }),
-      roles: this.server.createList('kubernetes-role', 2),
+      backend: this.store.peekRecord('secret-engine', 'kubernetes-test'),
+      config: this.store.peekRecord('kubernetes/config', 'kubernetes-test'),
+      roles: this.store.peekAll('kubernetes/role'),
     };
-
-    this.server.createList('kubernetes-role', 2);
   });
 
   test('it should display role card', async function (assert) {


### PR DESCRIPTION
Adds overview page for Kubernetes secrets engine
[Overview Figma Design here](https://www.figma.com/file/rB5gYCA95F9aKMc7I2Qx0d/Kubernetes-Secret-Engine-Handoff?node-id=1%3A719&t=LEZsdtAweDMP5xoW-0)

**Overview when Kubernetes is not configured:**
<img width="1728" alt="Screen Shot 2022-12-05 at 12 47 22 PM" src="https://user-images.githubusercontent.com/30884335/205741713-fd22787b-67d9-479d-92b1-de8ecf025791.png">

**Overview when Kubernetes has no roles:**
<img width="1728" alt="Screen Shot 2022-12-05 at 12 47 38 PM" src="https://user-images.githubusercontent.com/30884335/205741712-595acfb5-f0a4-46c0-9456-4552bdd64662.png">

**Overview when there are roles**

https://user-images.githubusercontent.com/30884335/205747932-015021b7-3891-4ff5-a9ff-e8257bc09205.mov

