### PR TITLE
Ensure base logging uses IndependentLevels

### DIFF
--- a/helper/logging/logger.go
+++ b/helper/logging/logger.go
@@ -139,10 +139,11 @@ func Setup(config *LogConfig, w io.Writer) (log.InterceptLogger, error) {
 	}
 
 	logger := log.NewInterceptLogger(&log.LoggerOptions{
-		Name:       config.Name,
-		Level:      config.LogLevel,
-		Output:     io.MultiWriter(writers...),
-		JSONFormat: config.isFormatJson(),
+		Name:              config.Name,
+		Level:             config.LogLevel,
+		IndependentLevels: true,
+		Output:            io.MultiWriter(writers...),
+		JSONFormat:        config.isFormatJson(),
 	})
 
 	return logger, nil

--- a/helper/logging/logger_test.go
+++ b/helper/logging/logger_test.go
@@ -194,3 +194,28 @@ func TestLogger_SetupLoggerWithInvalidLogFilePath(t *testing.T) {
 		assert.Contains(t, err.Error(), tc.message, "%s: error message does not match: %s", name, err.Error())
 	}
 }
+
+func TestLogger_ChangeLogLevels(t *testing.T) {
+	cfg := &LogConfig{
+		LogLevel: log.Debug,
+		Name:     "test-system",
+	}
+	var buf bytes.Buffer
+
+	logger, err := Setup(cfg, &buf)
+	require.NoError(t, err)
+	require.NotNil(t, logger)
+
+	assert.True(t, logger.IsDebug())
+
+	// Create new named loggers from the base logger and change the levels
+	logger2 := logger.Named("test2")
+	logger3 := logger.Named("test3")
+
+	logger2.SetLevel(log.Info)
+	logger3.SetLevel(log.Error)
+
+	assert.True(t, logger.IsDebug())
+	assert.True(t, logger2.IsInfo())
+	assert.True(t, logger3.IsError())
+}


### PR DESCRIPTION
This was missed as part of the log rotation work (log file/log rotation)