### PR TITLE
Add support for TTLs to token roles

### DIFF
--- a/changelog/18256.txt
+++ b/changelog/18256.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/token: Allow per-role configurable `token_ttl` and `token_max_ttl`
+```


### PR DESCRIPTION
We recently became interested in using the Token auth backend roles.

However, our use-case has been stymied, because the Token auth method lacks support for per-role configuration of `token_ttl` and `token_max_ttl`, unlike other major auth backends.

There doesn't seem to be an obvious reason for this, and it looks fairly easy to plumb through the parameters to where they need to be used.

----

There are obviously a few things missing in this PR - documentation, tests.

For now, the intent is to start a conversation with HashiCorp about the proposed implementation, and get that validated before filling in the rest.