### PR TITLE
Updated go-hclog to v1.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-discover v0.0.0-20210818145131-c573d69da192
 	github.com/hashicorp/go-gcp-common v0.8.0
-	github.com/hashicorp/go-hclog v1.3.1
+	github.com/hashicorp/go-hclog v1.4.0
 	github.com/hashicorp/go-kms-wrapping/v2 v2.0.5
 	github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2 v2.0.4
 	github.com/hashicorp/go-kms-wrapping/wrappers/alicloudkms/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -981,8 +981,9 @@ github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.16.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.3.1 h1:vDwF1DFNZhntP4DAjuTpOw3uEgMUpXh1pB5fW9DqHpo=
 github.com/hashicorp/go-hclog v1.3.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-hclog v1.4.0 h1:ctuWFGrhFha8BnnzxqeRGidlEcQkDyL5u8J8t5eA11I=
+github.com/hashicorp/go-hclog v1.4.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=

--- a/helper/logging/logger.go
+++ b/helper/logging/logger.go
@@ -189,21 +189,12 @@ func ParseLogLevel(logLevel string) (log.Level, error) {
 
 // TranslateLoggerLevel returns the string that corresponds with logging level of the hclog.Logger.
 func TranslateLoggerLevel(logger log.Logger) (string, error) {
-	var result string
+	logLevel := logger.GetLevel()
 
-	if logger.IsTrace() {
-		result = "trace"
-	} else if logger.IsDebug() {
-		result = "debug"
-	} else if logger.IsInfo() {
-		result = "info"
-	} else if logger.IsWarn() {
-		result = "warn"
-	} else if logger.IsError() {
-		result = "error"
-	} else {
+	switch logLevel {
+	case log.Trace, log.Debug, log.Info, log.Warn, log.Error:
+		return logLevel.String(), nil
+	default:
 		return "", fmt.Errorf("unknown log level")
 	}
-
-	return result, nil
 }

--- a/helper/logging/logger_test.go
+++ b/helper/logging/logger_test.go
@@ -206,7 +206,7 @@ func TestLogger_ChangeLogLevels(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, logger)
 
-	assert.True(t, logger.IsDebug())
+	assert.Equal(t, log.Debug, logger.GetLevel())
 
 	// Create new named loggers from the base logger and change the levels
 	logger2 := logger.Named("test2")
@@ -215,7 +215,7 @@ func TestLogger_ChangeLogLevels(t *testing.T) {
 	logger2.SetLevel(log.Info)
 	logger3.SetLevel(log.Error)
 
-	assert.True(t, logger.IsDebug())
-	assert.True(t, logger2.IsInfo())
-	assert.True(t, logger3.IsError())
+	assert.Equal(t, log.Debug, logger.GetLevel())
+	assert.Equal(t, log.Info, logger2.GetLevel())
+	assert.Equal(t, log.Error, logger3.GetLevel())
 }


### PR DESCRIPTION
* `hc-log` updated to version `v1.4.0` (bumped by 1 version) to allow access to `.GetLevel()`.  No breaking changes.
* Refactored `TranslateLoggerLevel` to reduce risk we ever change the order to the `Is...` checks + tests