### PR TITLE
Refactor PKI to use shared storage context

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -483,7 +483,7 @@ func (b *backend) periodicFunc(ctx context.Context, request *logical.Request) er
 		}
 
 		// Then attempt to rebuild the CRLs if required.
-		if err := b.crlBuilder.rebuildIfForced(ctx, b, request); err != nil {
+		if err := b.crlBuilder.rebuildIfForced(sc); err != nil {
 			return err
 		}
 

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -1,7 +1,6 @@
 package pki
 
 import (
-	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -151,8 +150,8 @@ func (sc *storageContext) fetchCAInfoByIssuerId(issuerId issuerID, usage issuerU
 	return caInfo, nil
 }
 
-func fetchCertBySerialBigInt(ctx context.Context, b *backend, req *logical.Request, prefix string, serial *big.Int) (*logical.StorageEntry, error) {
-	return fetchCertBySerial(ctx, b, req, prefix, serialFromBigInt(serial))
+func fetchCertBySerialBigInt(sc *storageContext, prefix string, serial *big.Int) (*logical.StorageEntry, error) {
+	return fetchCertBySerial(sc, prefix, serialFromBigInt(serial))
 }
 
 // Allows fetching certificates from the backend; it handles the slightly
@@ -160,7 +159,7 @@ func fetchCertBySerialBigInt(ctx context.Context, b *backend, req *logical.Reque
 //
 // Support for fetching CA certificates was removed, due to the new issuers
 // changes.
-func fetchCertBySerial(ctx context.Context, b *backend, req *logical.Request, prefix, serial string) (*logical.StorageEntry, error) {
+func fetchCertBySerial(sc *storageContext, prefix, serial string) (*logical.StorageEntry, error) {
 	var path, legacyPath string
 	var err error
 	var certEntry *logical.StorageEntry
@@ -175,10 +174,9 @@ func fetchCertBySerial(ctx context.Context, b *backend, req *logical.Request, pr
 		legacyPath = "revoked/" + colonSerial
 		path = "revoked/" + hyphenSerial
 	case serial == legacyCRLPath || serial == deltaCRLPath:
-		if err = b.crlBuilder.rebuildIfForced(ctx, b, req); err != nil {
+		if err = sc.Backend.crlBuilder.rebuildIfForced(sc); err != nil {
 			return nil, err
 		}
-		sc := b.makeStorageContext(ctx, req.Storage)
 		path, err = sc.resolveIssuerCRLPath(defaultRef)
 		if err != nil {
 			return nil, err
@@ -196,7 +194,7 @@ func fetchCertBySerial(ctx context.Context, b *backend, req *logical.Request, pr
 		path = "certs/" + hyphenSerial
 	}
 
-	certEntry, err = req.Storage.Get(ctx, path)
+	certEntry, err = sc.Storage.Get(sc.Context, path)
 	if err != nil {
 		return nil, errutil.InternalError{Err: fmt.Sprintf("error fetching certificate %s: %s", serial, err)}
 	}
@@ -216,7 +214,7 @@ func fetchCertBySerial(ctx context.Context, b *backend, req *logical.Request, pr
 	// always manifest on Windows, and thus the initial check for a revoked
 	// cert fails would return an error when the cert isn't revoked, preventing
 	// the happy path from working.
-	certEntry, _ = req.Storage.Get(ctx, legacyPath)
+	certEntry, _ = sc.Storage.Get(sc.Context, legacyPath)
 	if certEntry == nil {
 		return nil, nil
 	}
@@ -226,17 +224,17 @@ func fetchCertBySerial(ctx context.Context, b *backend, req *logical.Request, pr
 
 	// Update old-style paths to new-style paths
 	certEntry.Key = path
-	certsCounted := b.certsCounted.Load()
-	if err = req.Storage.Put(ctx, certEntry); err != nil {
+	certsCounted := sc.Backend.certsCounted.Load()
+	if err = sc.Storage.Put(sc.Context, certEntry); err != nil {
 		return nil, errutil.InternalError{Err: fmt.Sprintf("error saving certificate with serial %s to new location", serial)}
 	}
-	if err = req.Storage.Delete(ctx, legacyPath); err != nil {
+	if err = sc.Storage.Delete(sc.Context, legacyPath); err != nil {
 		// If we fail here, we have an extra (copy) of a cert in storage, add to metrics:
 		switch {
 		case strings.HasPrefix(prefix, "revoked/"):
-			b.incrementTotalRevokedCertificatesCount(certsCounted, path)
+			sc.Backend.incrementTotalRevokedCertificatesCount(certsCounted, path)
 		default:
-			b.incrementTotalCertificatesCount(certsCounted, path)
+			sc.Backend.incrementTotalCertificatesCount(certsCounted, path)
 		}
 		return nil, errutil.InternalError{Err: fmt.Sprintf("error deleting certificate with serial %s from old location", serial)}
 	}

--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -14,6 +14,7 @@ import (
 func TestPki_FetchCertBySerial(t *testing.T) {
 	t.Parallel()
 	b, storage := CreateBackendWithStorage(t)
+	sc := b.makeStorageContext(ctx, storage)
 
 	cases := map[string]struct {
 		Req    *logical.Request
@@ -47,7 +48,7 @@ func TestPki_FetchCertBySerial(t *testing.T) {
 			t.Fatalf("error writing to storage on %s colon-based storage path: %s", name, err)
 		}
 
-		certEntry, err := fetchCertBySerial(context.Background(), b, tc.Req, tc.Prefix, tc.Serial)
+		certEntry, err := fetchCertBySerial(sc, tc.Prefix, tc.Serial)
 		if err != nil {
 			t.Fatalf("error on %s for colon-based storage path: %s", name, err)
 		}
@@ -82,7 +83,7 @@ func TestPki_FetchCertBySerial(t *testing.T) {
 			t.Fatalf("error writing to storage on %s hyphen-based storage path: %s", name, err)
 		}
 
-		certEntry, err := fetchCertBySerial(context.Background(), b, tc.Req, tc.Prefix, tc.Serial)
+		certEntry, err := fetchCertBySerial(sc, tc.Prefix, tc.Serial)
 		if err != nil || certEntry == nil {
 			t.Fatalf("error on %s for hyphen-based storage path: err: %v, entry: %v", name, err, certEntry)
 		}

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -404,18 +404,17 @@ func TestCrlRebuilder(t *testing.T) {
 	_, _, err := sc.writeCaBundle(bundle, "", "")
 	require.NoError(t, err)
 
-	req := &logical.Request{Storage: s}
 	cb := newCRLBuilder(true /* can rebuild and write CRLs */)
 
 	// Force an initial build
-	err = cb.rebuild(ctx, b, req, true)
+	err = cb.rebuild(sc, true)
 	require.NoError(t, err, "Failed to rebuild CRL")
 
 	resp := requestCrlFromBackend(t, s, b)
 	crl1 := parseCrlPemBytes(t, resp.Data["http_raw_body"].([]byte))
 
 	// We shouldn't rebuild within this call.
-	err = cb.rebuildIfForced(ctx, b, req)
+	err = cb.rebuildIfForced(sc)
 	require.NoError(t, err, "Failed to rebuild if forced CRL")
 	resp = requestCrlFromBackend(t, s, b)
 	crl2 := parseCrlPemBytes(t, resp.Data["http_raw_body"].([]byte))
@@ -432,7 +431,7 @@ func TestCrlRebuilder(t *testing.T) {
 
 	// This should rebuild the CRL
 	cb.requestRebuildIfActiveNode(b)
-	err = cb.rebuildIfForced(ctx, b, req)
+	err = cb.rebuildIfForced(sc)
 	require.NoError(t, err, "Failed to rebuild if forced CRL")
 	resp = requestCrlFromBackend(t, s, b)
 	crl3 := parseCrlPemBytes(t, resp.Data["http_raw_body"].([]byte))

--- a/builtin/logical/pki/ocsp.go
+++ b/builtin/logical/pki/ocsp.go
@@ -253,7 +253,7 @@ func logAndReturnInternalError(b *backend, err error) *logical.Response {
 }
 
 func getOcspStatus(sc *storageContext, request *logical.Request, ocspReq *ocsp.Request) (*ocspRespInfo, error) {
-	revEntryRaw, err := fetchCertBySerialBigInt(sc.Context, sc.Backend, request, revokedPath, ocspReq.SerialNumber)
+	revEntryRaw, err := fetchCertBySerialBigInt(sc, revokedPath, ocspReq.SerialNumber)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/path_config_crl.go
+++ b/builtin/logical/pki/path_config_crl.go
@@ -216,7 +216,7 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 	if oldDisable != config.Disable || (oldAutoRebuild && !config.AutoRebuild) {
 		// It wasn't disabled but now it is (or equivalently, we were set to
 		// auto-rebuild and we aren't now), so rotate the CRL.
-		crlErr := b.crlBuilder.rebuild(ctx, b, req, true)
+		crlErr := b.crlBuilder.rebuild(sc, true)
 		if crlErr != nil {
 			switch crlErr.(type) {
 			case errutil.UserError:

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -280,7 +280,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 		goto reply
 	}
 
-	certEntry, funcErr = fetchCertBySerial(ctx, b, req, req.Path, serial)
+	certEntry, funcErr = fetchCertBySerial(sc, req.Path, serial)
 	if funcErr != nil {
 		switch funcErr.(type) {
 		case errutil.UserError:
@@ -308,7 +308,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 		certificate = []byte(strings.TrimSpace(string(pem.EncodeToMemory(&block))))
 	}
 
-	revokedEntry, funcErr = fetchCertBySerial(ctx, b, req, "revoked/", serial)
+	revokedEntry, funcErr = fetchCertBySerial(sc, "revoked/", serial)
 	if funcErr != nil {
 		switch funcErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -971,14 +971,14 @@ func (b *backend) pathGetIssuerCRL(ctx context.Context, req *logical.Request, da
 		return logical.ErrorResponse("missing issuer reference"), nil
 	}
 
-	if err := b.crlBuilder.rebuildIfForced(ctx, b, req); err != nil {
+	sc := b.makeStorageContext(ctx, req.Storage)
+	if err := b.crlBuilder.rebuildIfForced(sc); err != nil {
 		return nil, err
 	}
 
 	var certificate []byte
 	var contentType string
 
-	sc := b.makeStorageContext(ctx, req.Storage)
 	response := &logical.Response{}
 	var crlType ifModifiedReqType = ifModifiedCRL
 	if strings.Contains(req.Path, "delta") {

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -243,7 +243,7 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 	}
 
 	if len(createdIssuers) > 0 {
-		err := b.crlBuilder.rebuild(ctx, b, req, true)
+		err := b.crlBuilder.rebuild(sc, true)
 		if err != nil {
 			// Before returning, check if the error message includes the
 			// string "PSS". If so, it indicates we might've wanted to modify
@@ -432,7 +432,7 @@ func (b *backend) pathRevokeIssuer(ctx context.Context, req *logical.Request, da
 	// include both in two separate CRLs. Hence, the former is the condition
 	// we check in CRL building, but this step satisfies other guarantees
 	// within Vault.
-	certEntry, err := fetchCertBySerial(ctx, b, req, "certs/", issuer.SerialNumber)
+	certEntry, err := fetchCertBySerial(sc, "certs/", issuer.SerialNumber)
 	if err == nil && certEntry != nil {
 		// We've inverted this error check as it doesn't matter; we already
 		// consider this certificate revoked.
@@ -475,7 +475,7 @@ func (b *backend) pathRevokeIssuer(ctx context.Context, req *logical.Request, da
 	}
 
 	// Rebuild the CRL to include the newly revoked issuer.
-	crlErr := b.crlBuilder.rebuild(ctx, b, req, false)
+	crlErr := b.crlBuilder.rebuild(sc, false)
 	if crlErr != nil {
 		switch crlErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -183,7 +183,8 @@ func (b *backend) pathRevokeWriteHandleCertificate(ctx context.Context, req *log
 	//
 	// Start with the latter since its cheaper. Fetch the cert (by serial)
 	// and if it exists, compare the contents.
-	certEntry, err := fetchCertBySerial(ctx, b, req, req.Path, serial)
+	sc := b.makeStorageContext(ctx, req.Storage)
+	certEntry, err := fetchCertBySerial(sc, "certs/", serial)
 	if err != nil {
 		return serial, false, nil, err
 	}
@@ -215,7 +216,6 @@ func (b *backend) pathRevokeWriteHandleCertificate(ctx context.Context, req *log
 	// parameter (except in error cases) should cause the cert to write out.
 	//
 	// Fetch and iterate through each issuer.
-	sc := b.makeStorageContext(ctx, req.Storage)
 	issuers, err := sc.listIssuers()
 	if err != nil {
 		return serial, false, nil, err
@@ -356,7 +356,8 @@ func (b *backend) pathRevokeWrite(ctx context.Context, req *logical.Request, dat
 		}
 
 		// Here, fetch the certificate from disk to validate we can revoke it.
-		certEntry, err := fetchCertBySerial(ctx, b, req, req.Path, serial)
+		sc := b.makeStorageContext(ctx, req.Storage)
+		certEntry, err := fetchCertBySerial(sc, "certs/", serial)
 		if err != nil {
 			switch err.(type) {
 			case errutil.UserError:
@@ -424,14 +425,16 @@ func (b *backend) pathRevokeWrite(ctx context.Context, req *logical.Request, dat
 	b.revokeStorageLock.Lock()
 	defer b.revokeStorageLock.Unlock()
 
-	return revokeCert(ctx, b, req, serial, false)
+	sc := b.makeStorageContext(ctx, req.Storage)
+	return revokeCert(sc, serial, false)
 }
 
 func (b *backend) pathRotateCRLRead(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
 	b.revokeStorageLock.RLock()
 	defer b.revokeStorageLock.RUnlock()
 
-	crlErr := b.crlBuilder.rebuild(ctx, b, req, false)
+	sc := b.makeStorageContext(ctx, req.Storage)
+	crlErr := b.crlBuilder.rebuild(sc, false)
 	if crlErr != nil {
 		switch crlErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -270,7 +270,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 	b.incrementTotalCertificatesCount(certsCounted, key)
 
 	// Build a fresh CRL
-	err = b.crlBuilder.rebuild(ctx, b, req, true)
+	err = b.crlBuilder.rebuild(sc, true)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -451,7 +451,7 @@ func (b *backend) doTidyRevocationStore(ctx context.Context, req *logical.Reques
 		}
 
 		if !config.AutoRebuild {
-			if err := b.crlBuilder.rebuild(ctx, b, req, false); err != nil {
+			if err := b.crlBuilder.rebuild(sc, false); err != nil {
 				return err
 			}
 		}
@@ -557,7 +557,7 @@ func (b *backend) doTidyExpiredIssuers(ctx context.Context, req *logical.Request
 		b.revokeStorageLock.Lock()
 		defer b.revokeStorageLock.Unlock()
 
-		if err := b.crlBuilder.rebuild(ctx, b, req, false); err != nil {
+		if err := b.crlBuilder.rebuild(sc, false); err != nil {
 			return err
 		}
 	}

--- a/builtin/logical/pki/secret_certs.go
+++ b/builtin/logical/pki/secret_certs.go
@@ -48,5 +48,10 @@ func (b *backend) secretCredsRevoke(ctx context.Context, req *logical.Request, _
 	b.revokeStorageLock.Lock()
 	defer b.revokeStorageLock.Unlock()
 
-	return revokeCert(ctx, b, req, serialInt.(string), true)
+	sc := b.makeStorageContext(ctx, req.Storage)
+	resp, err := revokeCert(sc, serialInt.(string), true)
+	if resp == nil && err == nil {
+		b.Logger().Warn("expired certificate revoke failed because not found in storage, treating as success", "serial", serialInt.(string))
+	}
+	return resp, err
 }


### PR DESCRIPTION
A lot of places took a `(context, backend, request)` tuple, ignoring the request proper and only using it for its storage. This (modified) tuple is exactly the set of elements in the shared storage context, so we should be using that instead of manually passing all three elements around.

This simplifies a few places where we'd generate a storage context at the request level and then split it apart only to recreate it again later (e.g., CRL building).

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

This also fixes the `path_revoke` to correctly use `certs/` as the prefix to fetchCertBySerial rather than `req.Path` :o 