### PR TITLE
Address race in PKI test case

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2136,7 +2136,6 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	oidExtensionSubjectAltName = []int{2, 5, 29, 17}
 	csrReq := &x509.CertificateRequest{
 		Subject: pkix.Name{
 			CommonName: "foo.bar.com",


### PR DESCRIPTION
 - @ncabatoff brought this to our attention, one of the PKI test suites is overwriting the production code's value leading to a data race issue.
 - Remove the setting of the variable with the same value from the test suite.

```
WARNING: DATA RACE
Read at 0x000007d41580 by goroutine 2887:
  github.com/hashicorp/vault/builtin/logical/pki.getOtherSANsFromX509Extensions()
      /home/circleci/go/src/github.com/hashicorp/vault/builtin/logical/pki/cert_util.go:983 +0x13e
  github.com/hashicorp/vault/builtin/logical/pki.generateCreationBundle()
      /home/circleci/go/src/github.com/hashicorp/vault/builtin/logical/pki/cert_util.go:1182 +0xead
  github.com/hashicorp/vault/builtin/logical/pki.signCert()
      /home/circleci/go/src/github.com/hashicorp/vault/builtin/logical/pki/cert_util.go:923 +0x151e
  github.com/hashicorp/vault/builtin/logical/pki.(*backend).pathIssueSignCert()
      /home/circleci/go/src/github.com/hashicorp/vault/builtin/logical/pki/path_issue_sign.go:314 +0x79a
  github.com/hashicorp/vault/builtin/logical/pki.(*backend).pathSignVerbatim()
      /home/circleci/go/src/github.com/hashicorp/vault/builtin/logical/pki/path_issue_sign.go:250 +0x904
  github.com/hashicorp/vault/builtin/logical/pki.(*backend).pathSignVerbatim-fm()
      <autogenerated>:1 +0x7d
  github.com/hashicorp/vault/builtin/logical/pki.(*backend).metricsWrap.func1()
      /home/circleci/go/src/github.com/hashicorp/vault/builtin/logical/pki/backend.go:340 +0x8c3
  github.com/hashicorp/vault/sdk/framework.(*Backend).HandleRequest()
      /home/circleci/go/src/github.com/hashicorp/vault/sdk/framework/backend.go:291 +0x13fe
  github.com/hashicorp/vault/builtin/logical/pki.TestExpectedOpsWork_PreMigration()
      /home/circleci/go/src/github.com/hashicorp/vault/builtin/logical/pki/storage_migrations_test.go:504 +0x3664
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Previous write at 0x000007d41580 by goroutine 8665:
  github.com/hashicorp/vault/builtin/logical/pki.runTestSignVerbatim()
      /home/circleci/go/src/github.com/hashicorp/vault/builtin/logical/pki/backend_test.go:2139 +0x7a4
  github.com/hashicorp/vault/builtin/logical/pki.TestBackend_SignVerbatim.func1()
      /home/circleci/go/src/github.com/hashicorp/vault/builtin/logical/pki/backend_test.go:2105 +0x48
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47
```