### PR TITLE
Error during config parsing for malformed listener values.

### DIFF
--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -34,6 +34,7 @@ func TestConfig_Sanitized(t *testing.T) {
 
 func TestParseListeners(t *testing.T) {
 	testParseListeners(t)
+	testParseListenersWithErrors(t)
 }
 
 func TestParseUserLockouts(t *testing.T) {

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -849,7 +849,10 @@ listener "tcp" {
 	}
 	list, _ := obj.Node.(*ast.ObjectList)
 	objList := list.Filter("listener")
-	configutil.ParseListeners(config.SharedConfig, objList)
+	err := configutil.ParseListeners(config.SharedConfig, objList)
+	if err != nil {
+		t.Fatal(err)
+	}
 	listeners := config.Listeners
 	if len(listeners) == 0 {
 		t.Fatalf("expected at least one listener in the config")
@@ -890,6 +893,27 @@ listener "tcp" {
 	config.Prune()
 	if diff := deep.Equal(config, *expected); diff != nil {
 		t.Fatal(diff)
+	}
+}
+
+func testParseListenersWithErrors(t *testing.T) {
+	obj, _ := hcl.Parse(strings.TrimSpace(`
+listener "tcp" {
+  address = "127.0.0.1:443"
+  x_forwarded_for_authorized_addrs = "$10.69.0.0/16"
+}`))
+
+	config := Config{
+		SharedConfig: &configutil.SharedConfig{},
+	}
+	list, _ := obj.Node.(*ast.ObjectList)
+	objList := list.Filter("listener")
+	err := configutil.ParseListeners(config.SharedConfig, objList)
+	if err == nil {
+		t.Fatal("should have errored but didn't")
+	}
+	if !strings.Contains(err.Error(), "error parsing x_forwarded_for_authorized_addrs") {
+		t.Fatal("should have received an error about parsing x_forwarded_for_authorized_addrs but didn't")
 	}
 }
 

--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -315,6 +315,18 @@ func ParseListeners(result *SharedConfig, list *ast.ObjectList) error {
 					return multierror.Prefix(fmt.Errorf("error parsing x_forwarded_for_authorized_addrs: %w", err), fmt.Sprintf("listeners.%d", i))
 				}
 
+				for _, m := range l.XForwardedForAuthorizedAddrs {
+					if _, ok := m.SockAddr.(sockaddr.UnixSock); ok {
+						// X-Forwarded-For headers should only be used with proxies/load balancers, and these mechanisms
+						// are TCP based, not unix socket based. If any of our parsed addresses type check as unix
+						// sockets, that almost certainly means they are malformed, because the parsing logic in
+						// the sockaddr library tries IPv4 first, then IPv6, then assumes it's a unix socket if it
+						// has a / in it (which any IPv4 address in CIDR notation will). Therefore, error here, rather
+						// than accepting it and letting Vault panic at run time.
+						return multierror.Prefix(fmt.Errorf("error parsing x_forwarded_for_authorized_addrs: %v does not appear to be valid", m), fmt.Sprintf("listeners.%d", i))
+					}
+				}
+
 				l.XForwardedForAuthorizedAddrsRaw = nil
 			}
 


### PR DESCRIPTION
Specifically, x_forwarded_for_authorized_addrs.

Closes https://github.com/hashicorp/vault/issues/18226