### PR TITLE
remove deleted link proto paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,8 +186,6 @@ proto: bootstrap
 	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative sdk/plugin/pb/*.proto
 	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative vault/tokens/token.proto
 	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative sdk/helper/pluginutil/*.proto
-	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative vault/hcp_link/capabilities/meta/*.proto
-	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative vault/hcp_link/capabilities/link_control/*.proto
 	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative vault/hcp_link/proto/*/*.proto
 
 	# No additional sed expressions should be added to this list. Going forward


### PR DESCRIPTION
`make proto` is currently broken and will return the following error:

```
Could not make proto path relative: vault/hcp_link/capabilities/meta/*.proto: No such file or directory
make: *** [proto] Error 1
```

The `meta` and `link_control` proto paths have been removed from the `proto` make target to resolve this issue.