### PR TITLE
Resolve unused warnings on batch_input parameter in transit

### DIFF
--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -70,6 +70,15 @@ plaintext. On successful decryption, both the ciphertext and the associated
 data are attested not to have been tampered with.
                 `,
 			},
+
+			"batch_input": {
+				Type: framework.TypeSlice,
+				Description: `
+Specifies a list of items to be decrypted in a single batch. When this
+parameter is set, if the parameters 'ciphertext', 'context' and 'nonce' are
+also set, they will be ignored. Any batch output will preserve the order
+of the batch input.`,
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -144,6 +144,14 @@ plaintext. On successful decryption, both the ciphertext and the associated
 data are attested not to have been tampered with.
 				`,
 			},
+
+			"batch_input": {
+				Type: framework.TypeSlice,
+				Description: `
+Specifies a list of items to be encrypted in a single batch. When this parameter
+is set, if the parameters 'plaintext', 'context' and 'nonce' are also set, they
+will be ignored. Any batch output will preserve the order of the batch input.`,
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{

--- a/builtin/logical/transit/path_hmac.go
+++ b/builtin/logical/transit/path_hmac.go
@@ -79,6 +79,14 @@ Defaults to "sha2-256".`,
 Must be 0 (for latest) or a value greater than or equal
 to the min_encryption_version configured on the key.`,
 			},
+
+			"batch_input": {
+				Type: framework.TypeSlice,
+				Description: `
+Specifies a list of items to be  in a single batch. When this parameter
+is set, if the parameter 'input' are also set, they will be ignored.
+Any batch output will preserve the order of the batch input.`,
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -43,6 +43,14 @@ func (b *backend) pathRewrap() *framework.Path {
 Must be 0 (for latest) or a value greater than or equal
 to the min_encryption_version configured on the key.`,
 			},
+
+			"batch_input": {
+				Type: framework.TypeSlice,
+				Description: `
+Specifies a list of items to be re-encrypted in a single batch. When this parameter is set,
+if the parameters 'ciphertext', 'context' and 'nonce' are also set, they will be ignored.
+Any batch output will preserve the order of the batch input.`,
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{

--- a/builtin/logical/transit/path_sign_verify.go
+++ b/builtin/logical/transit/path_sign_verify.go
@@ -146,6 +146,14 @@ Options are 'pss' or 'pkcs1v15'. Defaults to 'pss'`,
 				Description: `The salt length used to sign. Currently only applies to the RSA PSS signature scheme.
 Options are 'auto' (the default used by Golang, causing the salt to be as large as possible when signing), 'hash' (causes the salt length to equal the length of the hash used in the signature), or an integer between the minimum and the maximum permissible salt lengths for the given RSA key size. Defaults to 'auto'.`,
 			},
+
+			"batch_input": {
+				Type: framework.TypeSlice,
+				Description: `Specifies a list of items for processing. When this parameter is set,
+any supplied 'input' or 'context' parameters will be ignored. Responses are returned in the
+'batch_results' array component of the 'data' element of the response. Any batch output will
+preserve the order of the batch input`,
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -240,6 +248,14 @@ Options are 'pss' or 'pkcs1v15'. Defaults to 'pss'`,
 				Default: "auto",
 				Description: `The salt length used to sign. Currently only applies to the RSA PSS signature scheme.
 Options are 'auto' (the default used by Golang, causing the salt to be as large as possible when signing), 'hash' (causes the salt length to equal the length of the hash used in the signature), or an integer between the minimum and the maximum permissible salt lengths for the given RSA key size. Defaults to 'auto'.`,
+			},
+
+			"batch_input": {
+				Type: framework.TypeSlice,
+				Description: `Specifies a list of items for processing. When this parameter is set,
+any supplied  'input', 'hmac' or 'signature' parameters will be ignored. Responses are returned in the
+'batch_results' array component of the 'data' element of the response. Any batch output will
+preserve the order of the batch input`,
 			},
 		},
 

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -819,8 +819,8 @@ functionality to untrusted users or scripts.
   0.6.2+.
 
 - `batch_input` `(array<object>: nil)` – Specifies a list of items to be
-  decrypted in a single batch. When this parameter is set, if the parameters
-  'ciphertext', 'context' and 'nonce' are also set, they will be ignored. 
+  re-encrypted in a single batch. When this parameter is set, if the parameters
+  'ciphertext', 'context' and 'nonce' are also set, they will be ignored.
   Any batch output will preserve the order of the batch input. Format
   for the input goes like this:
 


### PR DESCRIPTION
While playing around with #18243, I noticed operations that properly accepted the `batch_input` parameter were returning warnings about it being an unrecognized parameter. This should fix those issues across the transit APIs. Also fix a little glitch in the transit docs related to a batch_input parameter description.

```
❯ vault secrets enable transit
Success! Enabled the transit secrets engine at: transit/
❯ vault write transit/keys/test type=rsa-4096
Success! Data written to: transit/keys/test
❯ cat input.json | vault write -format=json transit/encrypt/test - | jq
{
  "request_id": "737ad91e-1303-2992-8fdc-d62ff8b35a1d",
  "lease_id": "",
  "lease_duration": 0,
  "renewable": false,
  "data": {
    "batch_results": [
      {
        "ciphertext": "vault:v1:KBnS9or3klQK8co1FYLSW5VrKhbYVgrN83cpY+MuvQtQpLla3rXLocgFs0ZL1XaNSE0Wz0muGRUXg4wk7uPpDS6syL1a1nBeyApo9LCcq3zvMztTN8fGxUiCvzCGRi6GonlhhQ5/d4UGyyDB3tXog84lvrLknTl2T9m6qZrbNKx+oeVA6laSIv4+sQkZORRWFGM+HhnNcWelpB8C+pAfuM/OCtVwoIUdwWWypFNIhQgYc5/Jjrbe7tBTb4GUUr9GqhF5wMiIxkR54EUKMpSTDWd+q6UwTtLnLAf++/rB+pU3cuIU+AhSZPWnhSEfJSXS1Dll7T96VluolCiTdaRZ7x00sNJaVpJ47IYnp9UhpdnIaYzltxbPDn8C+KNZiqpS6SXRODEBUjMiVndIB0vymUIb+i44R+xEA1ymsrtaTl6AJ2Sjzb6x4fta0ReNvQGtMBmRrei+pNQxhW3wOzrESLEcWAMkbjHAripSe4li4qSeWYkbJBoQ7j7LFiFEBgvP8G0VWSCZLSaQAzMHbfMvpZoHmEqsdABnuUSVAc7Z8Bv99BTMfj+86rdrhXyXZKfEq3t0MdDYaKDr0Om/hX6N0bYndimzRijegEB6k4HiN/NG6pA2mB266IkuwAVbQX5A+ADRoXdDoaFWCIP7NlaDQz516BWNi44g8dugNarrsbc=",
        "key_version": 1
      },
      {
        "ciphertext": "vault:v1:bbQrBjkOllJyuYgKb5Aa+nJStcteE3loiPWU1BfAPMk3N1NeiPOa0WCfAgGPMJ/au3x+CvJvxqv6PG3yhy8ABgAaebShAIoi6dAazwB+D3qqKfhCEvuAkSYJssaVM8EfnKY+KKlxFBbZd/3XBPP4O23qJSw+Nu1tJuEMdMRixyvkvW/Wxu3K8t7Mz77gxvY4PeJLhAGexXC2k8K/bPm4dFlI5yA4+eAr0peKqyHx/1XK1qQi7Dw7l1+IB00T3wkWXF+PxUmtn4yFsocmWqI2pPLrui/YkxdEeduzx850PIQ58xdli8zJzxsVTXPqPRD3CsTly3co43SV6crY3i9Ga9lczqt0i3wtaU3Z12Hqmgjl5+Xk/iXhl1clb78ExechnTjmrH5Yr+NCIRt5rhp6AD9HylGfbL3kjXxLjNhSQh3Y9mbFMGy15pW8JjDKPp4cTO96ZnwS5O6oi2ssIEe/Wj1/2lAJPbSMcZWbi5Ih0ne5v1q6zQFvU+cLQwjplIfG6Iz6YzXD34v1lNKwFqxBz+aRyf7HcOPYiUVjjT84F5coCC7G/AwcLMGLcxZgWZO0DUjChXEFxalqIPUjFgnKG5bay6a4EPtI4H1h1vGpDXZ2+F7ALW6+1YawDW1vAs4dSuMia4TTz6yGbt4ZgoFqF0y6qcjFN49HDZkRwbaVJuo=",
        "key_version": 1
      }
    ]
  },
  "warnings": [
    "Endpoint ignored these unrecognized parameters: [batch_input]"
  ]
}
```