### PR TITLE
Kubernetes Secrets Engine Overview Bug

### DIFF
--- a/ui/lib/kubernetes/addon/routes/overview.js
+++ b/ui/lib/kubernetes/addon/routes/overview.js
@@ -4,11 +4,10 @@ import FetchConfigRoute from './fetch-config';
 export default class KubernetesOverviewRoute extends FetchConfigRoute {
   async model() {
     const backend = this.secretMountPath.get();
-
     return hash({
       config: this.configModel,
       backend: this.modelFor('application'),
-      roles: this.store.query('kubernetes/role', { backend }),
+      roles: this.store.query('kubernetes/role', { backend }).catch(() => []),
     });
   }
 }


### PR DESCRIPTION
When visiting the overview route when no roles have been created, the promise rejection from the roles query was not being handled which resulted in the promise returned by `hash` also being rejected. This resulted in the 404 page being shown. I added a catch to the query and return an empty array if no roles are found.

![image](https://user-images.githubusercontent.com/24611656/206798711-6fff1430-1811-4001-91f0-cfe2406802d5.png)

