### PR TITLE
Vault Docs Autopilot Typo

### DIFF
--- a/website/content/docs/concepts/integrated-storage/autopilot.mdx
+++ b/website/content/docs/concepts/integrated-storage/autopilot.mdx
@@ -80,7 +80,7 @@ behavior. Autopilot gets initialized with the following default values.
   - Minimum amount of time a server must be in a healthy state before it can become a voter. Until that happens,
     it will be visible as a peer in the cluster, but as a non-voter, meaning it won't contribute to quorum.
 
-- `disable-upgrade-migration` - `false`
+- `disable_upgrade_migration` - `false`
   - Controls whether to disable automated upgrade migrations, an Enterprise-only feature.
 
 ~> **Note**: Autopilot in Vault does similar things to what autopilot does in


### PR DESCRIPTION
Replace the hyphens with underscores in the `disable_upgrade_migration` parameter.