### PR TITLE
Document adding metadata to entity alias within cert auth

### DIFF
--- a/builtin/credential/cert/path_certs.go
+++ b/builtin/credential/cert/path_certs.go
@@ -143,7 +143,7 @@ All values much match. Supports globbing on "value".`,
 			"allowed_metadata_extensions": {
 				Type: framework.TypeCommaStringSlice,
 				Description: `A comma-separated string or array of oid extensions.
-Upon successfull authentication, these extensions will be added as metadata if they are present
+Upon successful authentication, these extensions will be added as metadata if they are present
 in the certificate. The metadata key will be the string consisting of the oid numbers
 separated by a dash (-) instead of a dot (.) to allow usage in ACL templates.`,
 			},

--- a/website/content/api-docs/auth/cert.mdx
+++ b/website/content/api-docs/auth/cert.mdx
@@ -61,6 +61,11 @@ Sets a CA cert and associated parameters in a role name.
   string or array of `oid:value`. Expects the extension value to be some type
   of ASN1 encoded string. All conditions _must_ be met. Supports globbing on
   `value`.
+- `allowed_metadata_extensions` `(array:[])` - A comma-separated string or
+  array of oid extensions. Upon successful authentication, these extensions
+  will be added as metadata if they are present in the certificate. The
+  metadata key will be the string consisting of the oid numbers separated
+  by a dash (-) instead of a dot (.) to allow usage in ACL templates.
 - `display_name` `(string: "")` - The `display_name` to set on tokens issued
   when authenticating against this CA certificate. If not set, defaults to the
   name of the role.
@@ -328,6 +333,9 @@ Configuration options for the method.
 - `disable_binding` `(boolean: false)` - If set, during renewal, skips the
   matching of presented client identity with the client identity used during
   login.
+- `enable_identity_alias_metadata` `(boolean: false)` - If set, metadata of
+  the certificate including the metadata corresponding to
+  `allowed_metadata_extensions` will be stored in the alias
 
 ### Sample Payload
 

--- a/website/content/api-docs/auth/cert.mdx
+++ b/website/content/api-docs/auth/cert.mdx
@@ -61,7 +61,7 @@ Sets a CA cert and associated parameters in a role name.
   string or array of `oid:value`. Expects the extension value to be some type
   of ASN1 encoded string. All conditions _must_ be met. Supports globbing on
   `value`.
-- `allowed_metadata_extensions` `(array:[])` - A comma-separated string or
+- `allowed_metadata_extensions` `(array:[])` - A comma separated string or
   array of oid extensions. Upon successful authentication, these extensions
   will be added as metadata if they are present in the certificate. The
   metadata key will be the string consisting of the oid numbers separated


### PR DESCRIPTION
Add missing documentation within the cert auth API docs about adding and/or augmenting an entity alias with extensions from the cert used to authorize the vault client. Feature was added in #13348 and #14751

Missing docs was pointed out by @tmanninger in this [issue thread](https://github.com/hashicorp/vault/issues/18212#issuecomment-1346096583)