### PR TITLE
Return the partial success code override for all batch error types

### DIFF
--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -520,7 +520,7 @@ func batchRequestResponse(d *framework.FieldData, resp *logical.Response, req *l
 		if codeRaw, ok := d.GetOk("partial_failure_response_code"); ok {
 			newCode := codeRaw.(int)
 			if newCode < 1 || newCode > 599 {
-				resp.AddWarning("invalid HTTP response code override from partial_failure_response_code, reverting to HTTP 400")
+				resp.AddWarning(fmt.Sprintf("invalid HTTP response code override from partial_failure_response_code, reverting to %d", code))
 			} else {
 				code = newCode
 			}

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -517,7 +517,7 @@ func batchRequestResponse(d *framework.FieldData, resp *logical.Response, req *l
 		case internalErrorInBatch:
 			code = http.StatusInternalServerError
 		}
-		if codeRaw, ok := d.GetOk("partial_failure_response_code"); ok {
+		if codeRaw, ok := d.GetOk("partial_failure_response_code"); ok && successesInBatch {
 			newCode := codeRaw.(int)
 			if newCode < 1 || newCode > 599 {
 				resp.AddWarning(fmt.Sprintf("invalid HTTP response code override from partial_failure_response_code, reverting to %d", code))

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -517,6 +517,14 @@ func batchRequestResponse(d *framework.FieldData, resp *logical.Response, req *l
 		case internalErrorInBatch:
 			code = http.StatusInternalServerError
 		}
+		if codeRaw, ok := d.GetOk("partial_failure_response_code"); ok {
+			newCode := codeRaw.(int)
+			if newCode < 1 || newCode > 599 {
+				resp.AddWarning("invalid HTTP response code override from partial_failure_response_code, reverting to HTTP 400")
+			} else {
+				code = newCode
+			}
+		}
 		return logical.RespondWithStatusCode(resp, req, code)
 	}
 

--- a/changelog/18310.txt
+++ b/changelog/18310.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/transit: Honor `partial_success_response_code` on decryption failures.
+```

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -661,10 +661,13 @@ will be returned.
   impact the ciphertext's security.
 
 - `partial_failure_response_code` `(int: 400)` Ordinarily, if a batch item fails 
-to encrypt due to a bad input, but other batch items succeed, the HTTP response 
-code is 400 (Bad Request).  Some applications may want to treat partial failures
-differently.  Providing the parameter returns the given response code integer 
-instead of a 400 in this case. If all values fail HTTP 400 is still returned.
+  to encrypt due to a bad input, but other batch items succeed, the HTTP response 
+  code is 400 (Bad Request).  Some applications may want to treat partial failures
+  differently.  Providing the parameter returns the given response code integer 
+  instead of a failed status code in this case. If all values fail an error
+  code is still returned.  Be warned that some failures (such as failure to
+  decrypt) could be indicative of a security breach and should not be
+  ignored.
 
 ~>**NOTE:** All plaintext data **must be base64-encoded**. The reason for this
 requirement is that Vault does not require that the plaintext is "text". It
@@ -756,10 +759,13 @@ This endpoint decrypts the provided ciphertext using the named key.
   ]
   ```
 - `partial_failure_response_code` `(int: 400)` Ordinarily, if a batch item fails 
-to encrypt due to a bad input, but other batch items succeed, the HTTP response 
-code is 400 (Bad Request).  Some applications may want to treat partial failures
-differently.  Providing the parameter returns the given response code integer 
-instead of a 400 in this case. If all values fail HTTP 400 is still returned.
+  to encrypt due to a bad input, but other batch items succeed, the HTTP response 
+  code is 400 (Bad Request).  Some applications may want to treat partial failures
+  differently.  Providing the parameter returns the given response code integer 
+  instead of a failed status code in this case. If all values fail an error
+  code is still returned.  Be warned that some failures (such as failure to
+  decrypt) could be indicative of a security breach and should not be
+  ignored.
 
 ### Sample Payload
 


### PR DESCRIPTION
Including InternalErrors such as decryption failures.