### PR TITLE
Add HCP connectivity info to `vault server` startup logs

### DIFF
--- a/changelog/18315.txt
+++ b/changelog/18315.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+hcp/connectivity: Include HCP organization, project, and resource ID in server startup logs
+```

--- a/command/server.go
+++ b/command/server.go
@@ -1377,6 +1377,17 @@ func (c *ServerCommand) Run(args []string) int {
 		info["fips"] = fipsStatus
 	}
 
+	if config.HCPLinkConf != nil {
+		infoKeys = append(infoKeys, "HCP organization")
+		info["HCP organization"] = config.HCPLinkConf.Resource.Organization
+
+		infoKeys = append(infoKeys, "HCP project")
+		info["HCP project"] = config.HCPLinkConf.Resource.Project
+
+		infoKeys = append(infoKeys, "HCP resource ID")
+		info["HCP resource ID"] = config.HCPLinkConf.Resource.ID
+	}
+
 	sort.Strings(infoKeys)
 	c.UI.Output("==> Vault server configuration:\n")
 
@@ -1446,12 +1457,12 @@ func (c *ServerCommand) Run(args []string) int {
 		return 1
 	}
 
-	hcpLogger := c.logger.Named("hcpLink")
+	hcpLogger := c.logger.Named("hcp-connectivity")
 	hcpLink, err := hcp_link.NewHCPLink(config.HCPLinkConf, core, hcpLogger)
 	if err != nil {
-		c.logger.Error("failed to start HCP Link", "error", err)
+		c.logger.Error("failed to establish HCP connection", "error", err)
 	} else if hcpLink != nil {
-		c.logger.Trace("started HCP link")
+		c.logger.Trace("established HCP connection")
 	}
 
 	if c.flagTestServerConfig {

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -77,6 +77,13 @@ listener "tcp" {
   tls_key_file  = "TMPDIR/reload_key.pem"
 }
 `
+	cloudHCL = `
+cloud {
+      resource_id = "organization/bc58b3d0-2eab-4ab8-abf4-f61d3c9975ff/project/1c78e888-2142-4000-8918-f933bbbc7690/hashicorp.example.resource/example"
+    client_id = "J2TtcSYOyPUkPV2z0mSyDtvitxLVjJmu"
+    client_secret = "N9JtHZyOnHrIvJZs82pqa54vd4jnkyU3xCcqhFXuQKJZZuxqxxbP1xCfBZVB82vY"
+}
+`
 )
 
 func testServerCommand(tb testing.TB) (*cli.MockUi, *ServerCommand) {
@@ -265,6 +272,13 @@ func TestServer(t *testing.T) {
 			"environment_variables_logged",
 			testBaseHCL(t, "") + inmemHCL,
 			"Environment Variables",
+			0,
+			[]string{"-test-verify-only"},
+		},
+		{
+			"cloud_config",
+			testBaseHCL(t, "") + inmemHCL + cloudHCL,
+			"HCP Organization: bc58b3d0-2eab-4ab8-abf4-f61d3c9975ff",
 			0,
 			[]string{"-test-verify-only"},
 		},


### PR DESCRIPTION
The properly formatted `resource_id` found in the `cloud` config stanza will include the organization, project, and user-provided ID of the resource in HCP. This PR modifies the `vault server` command to include this information in the startup logs if a valid `cloud` stanza has been provided.

```
❯ vault server -dev -config=hcp.hcl
==> Vault server configuration:

        HCP Organization: aa048f12-d735-4fe9-9443-40df11799938
             HCP Project: 03d4f563-c136-49cd-9c57-3923a1ef28e9
         HCP Resource ID: test-linked-cluster
             Api Address: http://127.0.0.1:8200
                     Cgo: disabled
         Cluster Address: https://127.0.0.1:8201
   Environment Variables: <....>
              Go Version: go1.19.3
              Listener 1: tcp (addr: "127.0.0.1:8200", cluster address: "127.0.0.1:8201", max_request_duration: "1m30s", max_request_size: "33554432", tls: "disabled")
               Log Level: info
                   Mlock: supported: false, enabled: false
           Recovery Mode: false
                 Storage: inmem
                 Version: Vault v1.13.0-dev1, built 2022-12-12T09:46:09Z
             Version Sha: 8ea899588ab065a0be2375bb0fb6f6983c27e4dd+CHANGES
```