### PR TITLE
Manual Testing: Bug Fixes and Improvements

### DIFF
--- a/ui/lib/kubernetes/addon/components/config-cta.hbs
+++ b/ui/lib/kubernetes/addon/components/config-cta.hbs
@@ -3,7 +3,7 @@
   @title="Kubernetes not configured"
   @message="Get started by establishing the URL of the Kubernetes API to connect to, along with some additional options."
 >
-  <LinkTo class="has-top-margin-xs" @route="configuration">
+  <LinkTo class="has-top-margin-xs" @route="configure">
     Configure Kubernetes
   </LinkTo>
 </EmptyState>

--- a/ui/lib/kubernetes/addon/components/page/configuration.hbs
+++ b/ui/lib/kubernetes/addon/components/page/configuration.hbs
@@ -1,12 +1,12 @@
-<TabPageHeader @model={{@model.backend}}>
+<TabPageHeader @model={{@backend}}>
   <ToolbarLink @route="configure" data-test-toolbar-config-action>
-    {{if @model.config "Edit configuration" "Configure Kubernetes"}}
+    {{if @config "Edit configuration" "Configure Kubernetes"}}
   </ToolbarLink>
 </TabPageHeader>
 
-{{#if @model.config}}
-  {{#if @model.config.disableLocalCaJwt}}
-    <InfoTableRow @label="Kubernetes host" @value={{@model.config.kubernetesHost}} />
+{{#if @config}}
+  {{#if @config.disableLocalCaJwt}}
+    <InfoTableRow @label="Kubernetes host" @value={{@config.kubernetesHost}} />
     <InfoTableRow @label="Certificate">
       <div class="column is-half box is-rounded">
         <div class="is-flex-row">
@@ -18,14 +18,14 @@
               PEM Format
             </p>
             <code class="is-size-8 truncate-second-line has-text-grey" data-test-certificate-value>
-              {{@model.config.kubernetesCaCert}}
+              {{@config.kubernetesCaCert}}
             </code>
           </div>
           <div class="is-flex has-background-grey-lighter has-side-padding-s has-top-bottom-margin-negative-m">
             <CopyButton
               data-test-certificate-copy
               class="button is-transparent is-flex-v-centered"
-              @clipboardText={{@model.config.kubernetesCaCert}}
+              @clipboardText={{@config.kubernetesCaCert}}
               @buttonType="button"
               @success={{action (set-flash-message "Certificate copied")}}
             >

--- a/ui/lib/kubernetes/addon/components/page/overview.hbs
+++ b/ui/lib/kubernetes/addon/components/page/overview.hbs
@@ -1,8 +1,8 @@
-<TabPageHeader @model={{@model.backend}}>
+<TabPageHeader @model={{@backend}}>
   <ToolbarLink @route="configure">Configure Kubernetes</ToolbarLink>
 </TabPageHeader>
 
-{{#if @model.config}}
+{{#if @config}}
   <div class="has-top-margin-m">
     <div class="is-flex">
       <div class="box has-padding-m has-right-margin-m is-rounded column is-flex-half" data-test-roles-card>
@@ -10,7 +10,7 @@
           <h2 class="title is-3">
             Roles
           </h2>
-          {{#if @model.roles.length}}
+          {{#if @roles.length}}
             <LinkTo class="is-no-underline" @route="roles">View Roles</LinkTo>
           {{else}}
             <LinkTo class="is-no-underline" @route="roles.create">Create Role</LinkTo>
@@ -18,7 +18,7 @@
         </div>
         <p>The number of Vault roles being used to generate Kubernetes credentials.</p>
         <h2 class="title has-font-weight-normal is-3 has-top-margin-l">
-          {{or @model.roles.length "None"}}
+          {{or @roles.length "None"}}
         </h2>
       </div>
       <div class="box has-padding-m is-rounded column is-flex-half" data-test-generate-credential-card>

--- a/ui/lib/kubernetes/addon/components/page/overview.js
+++ b/ui/lib/kubernetes/addon/components/page/overview.js
@@ -11,7 +11,7 @@ export default class OverviewPageComponent extends Component {
 
   constructor() {
     super(...arguments);
-    this.roleOptions = this.args.model.roles.map((role) => {
+    this.roleOptions = this.args.roles.map((role) => {
       return { name: role.name, id: role.name };
     });
   }

--- a/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
+++ b/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
@@ -21,7 +21,7 @@
       @icon="token"
       @value={{pref.value}}
       @groupValue={{@model.generationPreference}}
-      @onChange={{fn (mut @model.generationPreference)}}
+      @onChange={{this.changePreference}}
       data-test-radio-card={{pref.value}}
     />
   {{/each}}

--- a/ui/lib/kubernetes/addon/components/page/roles.hbs
+++ b/ui/lib/kubernetes/addon/components/page/roles.hbs
@@ -1,12 +1,12 @@
-<TabPageHeader @model={{@model.backend}} @filterRoles={{true}} @rolesFilterValue={{@filterValue}}>
+<TabPageHeader @model={{@backend}} @filterRoles={{true}} @rolesFilterValue={{@filterValue}}>
   <ToolbarLink @route="roles.create" @type="add" data-test-toolbar-roles-action>
     Create role
   </ToolbarLink>
 </TabPageHeader>
 
-{{#if (not @model.config)}}
+{{#if (not @config)}}
   <ConfigCta />
-{{else if (not @model.roles)}}
+{{else if (not @roles)}}
   {{#if @filterValue}}
     <EmptyState @title="There are no roles matching &quot;{{@filterValue}}&quot;" />
   {{else}}
@@ -22,7 +22,7 @@
   {{/if}}
 {{else}}
   <div class="has-bottom-margin-s">
-    {{#each @model.roles as |role|}}
+    {{#each @roles as |role|}}
       <ListItem @linkPrefix={{this.mountPoint}} @linkParams={{array "roles.role.details" role.name}} as |Item|>
         <Item.content>
           <Icon @name="user" />
@@ -65,7 +65,7 @@
                 @triggerText="Delete"
                 @title="Are you sure?"
                 @message="Deleting this role means that you’ll need to recreate it in order to generate credentials again."
-                @onConfirm={{this.onDelete}}
+                @onConfirm={{fn this.onDelete role}}
               />
             </li>
           {{/if}}

--- a/ui/lib/kubernetes/addon/components/page/roles.js
+++ b/ui/lib/kubernetes/addon/components/page/roles.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { task } from 'ember-concurrency';
-import { waitFor } from '@ember/test-waiters';
+import { action } from '@ember/object';
 import { getOwner } from '@ember/application';
 import errorMessage from 'vault/utils/error-message';
 
@@ -12,12 +11,13 @@ export default class ConfigurePageComponent extends Component {
     return getOwner(this).mountPoint;
   }
 
-  @task
-  @waitFor
-  *onDelete(model) {
+  @action
+  async onDelete(model) {
     try {
-      yield model.destroyRecord();
-      this.args.model.roles.removeObject(model);
+      const message = `Successfully deleted role ${model.name}`;
+      await model.destroyRecord();
+      this.args.roles.removeObject(model);
+      this.flashMessages.success(message);
     } catch (error) {
       const message = errorMessage(error, 'Error deleting role. Please try again or contact support');
       this.flashMessages.danger(message);

--- a/ui/lib/kubernetes/addon/routes/index.js
+++ b/ui/lib/kubernetes/addon/routes/index.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class KubernetesRoute extends Route {
+  @service router;
+
+  redirect() {
+    this.router.transitionTo('vault.cluster.secrets.backend.kubernetes.overview');
+  }
+}

--- a/ui/lib/kubernetes/addon/routes/roles/index.js
+++ b/ui/lib/kubernetes/addon/routes/roles/index.js
@@ -11,7 +11,8 @@ export default class KubernetesRolesRoute extends FetchConfigRoute {
         pageFilter
           ? models.filter((model) => model.name.toLowerCase().includes(pageFilter.toLowerCase()))
           : models
-      );
+      )
+      .catch(() => []);
     return hash({
       backend: this.modelFor('application'),
       config: this.configModel,

--- a/ui/lib/kubernetes/addon/templates/configuration.hbs
+++ b/ui/lib/kubernetes/addon/templates/configuration.hbs
@@ -1,1 +1,1 @@
-<Page::Configuration @model={{this.model}} />
+<Page::Configuration @config={{this.model.config}} @backend={{this.model.backend}} />

--- a/ui/lib/kubernetes/addon/templates/overview.hbs
+++ b/ui/lib/kubernetes/addon/templates/overview.hbs
@@ -1,1 +1,1 @@
-<Page::Overview @model={{this.model}} />
+<Page::Overview @config={{this.model.config}} @backend={{this.model.backend}} @roles={{this.model.roles}} />

--- a/ui/lib/kubernetes/addon/templates/roles/index.hbs
+++ b/ui/lib/kubernetes/addon/templates/roles/index.hbs
@@ -1,1 +1,6 @@
-<Page::Roles @model={{this.model}} @filterValue={{this.pageFilter}} />
+<Page::Roles
+  @roles={{this.model.roles}}
+  @config={{this.model.config}}
+  @backend={{this.model.backend}}
+  @filterValue={{this.pageFilter}}
+/>

--- a/ui/mirage/factories/kubernetes-role.js
+++ b/ui/mirage/factories/kubernetes-role.js
@@ -2,8 +2,8 @@ import { Factory, trait } from 'ember-cli-mirage';
 
 const generated_role_rules = `rules:
 - apiGroups: [""]
-resources: ["secrets", "services"]
-verbs: ["get", "watch", "list", "create", "delete", "deletecollection", "patch", "update"]
+  resources: ["secrets", "services"]
+  verbs: ["get", "watch", "list", "create", "delete", "deletecollection", "patch", "update"]
 `;
 const name_template = '{{.FieldName | lowercase}}';
 const extra_annotations = { foo: 'bar', baz: 'qux' };

--- a/ui/tests/integration/components/kubernetes/page/configuration-test.js
+++ b/ui/tests/integration/components/kubernetes/page/configuration-test.js
@@ -20,10 +20,9 @@ module('Integration | Component | kubernetes | Page::Configuration', function (h
         type: 'kubernetes',
       },
     });
-    this.model = {
-      backend: this.store.peekRecord('secret-engine', 'kubernetes-test'),
-      config: null,
-    };
+    this.backend = this.store.peekRecord('secret-engine', 'kubernetes-test');
+    this.config = null;
+
     this.setConfig = (disableLocal) => {
       const data = this.server.create(
         'kubernetes-config',
@@ -34,12 +33,18 @@ module('Integration | Component | kubernetes | Page::Configuration', function (h
         backend: 'kubernetes-test',
         ...data,
       });
-      this.model.config = this.store.peekRecord('kubernetes/config', 'kubernetes-test');
+      this.config = this.store.peekRecord('kubernetes/config', 'kubernetes-test');
+    };
+
+    this.renderComponent = () => {
+      return render(hbs`<Page::Configuration @backend={{this.backend}} @config={{this.config}} />`, {
+        owner: this.engine,
+      });
     };
   });
 
   test('it should render tab page header and config cta', async function (assert) {
-    await render(hbs`<Page::Configuration @model={{this.model}} />`, { owner: this.engine });
+    await this.renderComponent();
     assert.dom('.title svg').hasClass('flight-icon-kubernetes', 'Kubernetes icon renders in title');
     assert.dom('.title').hasText('kubernetes-test', 'Mount path renders in title');
     assert
@@ -50,7 +55,7 @@ module('Integration | Component | kubernetes | Page::Configuration', function (h
 
   test('it should render message for inferred configuration', async function (assert) {
     this.setConfig(false);
-    await render(hbs`<Page::Configuration @model={{this.model}} />`, { owner: this.engine });
+    await this.renderComponent();
     assert
       .dom('[data-test-inferred-message] svg')
       .hasClass('flight-icon-check-circle-fill', 'Inferred message icon renders');
@@ -64,11 +69,11 @@ module('Integration | Component | kubernetes | Page::Configuration', function (h
 
   test('it should render host and certificate info', async function (assert) {
     this.setConfig(true);
-    await render(hbs`<Page::Configuration @model={{this.model}} />`, { owner: this.engine });
+    await this.renderComponent();
     assert.dom('[data-test-row-label="Kubernetes host"]').exists('Kubernetes host label renders');
     assert
       .dom('[data-test-row-value="Kubernetes host"]')
-      .hasText(this.model.config.kubernetesHost, 'Kubernetes host value renders');
+      .hasText(this.config.kubernetesHost, 'Kubernetes host value renders');
     assert.dom('[data-test-row-label="Certificate"]').exists('Certificate label renders');
     assert
       .dom('[data-test-certificate-icon]')
@@ -76,7 +81,7 @@ module('Integration | Component | kubernetes | Page::Configuration', function (h
     assert.dom('[data-test-certificate-label]').hasText('PEM Format', 'Certificate card label renders');
     assert
       .dom('[data-test-certificate-value]')
-      .hasText(this.model.config.kubernetesCaCert, 'Certificate card value renders');
+      .hasText(this.config.kubernetesCaCert, 'Certificate card value renders');
     assert.dom('[data-test-certificate-copy]').exists('Certificate copy button renders');
   });
 });

--- a/ui/tests/integration/components/kubernetes/page/overview-test.js
+++ b/ui/tests/integration/components/kubernetes/page/overview-test.js
@@ -36,40 +36,44 @@ module('Integration | Component | kubernetes | Page::Overview', function (hooks)
       backend: 'kubernetes-test',
       ...this.server.create('kubernetes-role'),
     });
-    this.model = {
-      backend: this.store.peekRecord('secret-engine', 'kubernetes-test'),
-      config: this.store.peekRecord('kubernetes/config', 'kubernetes-test'),
-      roles: this.store.peekAll('kubernetes/role'),
+    this.backend = this.store.peekRecord('secret-engine', 'kubernetes-test');
+    this.config = this.store.peekRecord('kubernetes/config', 'kubernetes-test');
+    this.roles = this.store.peekAll('kubernetes/role');
+
+    this.renderComponent = () => {
+      return render(
+        hbs`<Page::Overview @config={{this.config}} @backend={{this.backend}} @roles={{this.roles}} />`,
+        { owner: this.engine }
+      );
     };
   });
 
   test('it should display role card', async function (assert) {
-    await render(hbs`<Page::Overview @model={{this.model}} />`, { owner: this.engine });
+    await this.renderComponent();
     assert.dom('[data-test-roles-card] .title').hasText('Roles');
     assert
       .dom('[data-test-roles-card] p')
       .hasText('The number of Vault roles being used to generate Kubernetes credentials.');
     assert.dom('[data-test-roles-card] a').hasText('View Roles');
 
-    this.model.roles = [];
+    this.roles = [];
 
-    await render(hbs`<Page::Overview @model={{this.model}} />`, { owner: this.engine });
-
+    await this.renderComponent();
     assert.dom('[data-test-roles-card] a').hasText('Create Role');
   });
 
   test('it should display correct number of roles in role card', async function (assert) {
-    await render(hbs`<Page::Overview @model={{this.model}} />`, { owner: this.engine });
+    await this.renderComponent();
     assert.dom('[data-test-roles-card] .has-font-weight-normal').hasText('2');
 
-    this.model.roles = [];
+    this.roles = [];
 
-    await render(hbs`<Page::Overview @model={{this.model}} />`, { owner: this.engine });
+    await this.renderComponent();
     assert.dom('[data-test-roles-card] .has-font-weight-normal').hasText('None');
   });
 
   test('it should display generate credentials card', async function (assert) {
-    await render(hbs`<Page::Overview @model={{this.model}} />`, { owner: this.engine });
+    await this.renderComponent();
     assert.dom('[data-test-generate-credential-card] .title').hasText('Generate credentials');
     assert
       .dom('[data-test-generate-credential-card] p')
@@ -77,7 +81,7 @@ module('Integration | Component | kubernetes | Page::Overview', function (hooks)
   });
 
   test('it should show options for SearchSelect', async function (assert) {
-    await render(hbs`<Page::Overview @model={{this.model}} />`, { owner: this.engine });
+    await this.renderComponent();
     await clickTrigger();
     assert.strictEqual(this.element.querySelectorAll('.ember-power-select-option').length, 2);
     await typeInSearch('role-0');
@@ -88,9 +92,9 @@ module('Integration | Component | kubernetes | Page::Overview', function (hooks)
   });
 
   test('it should show ConfigCta when no config is set up', async function (assert) {
-    this.model.config = null;
+    this.config = null;
 
-    await render(hbs`<Page::Overview @model={{this.model}} />`, { owner: this.engine });
+    await this.renderComponent();
     assert.dom('.empty-state .empty-state-title').hasText('Kubernetes not configured');
     assert
       .dom('.empty-state .empty-state-message')

--- a/ui/tests/integration/components/kubernetes/page/role/details-test.js
+++ b/ui/tests/integration/components/kubernetes/page/role/details-test.js
@@ -25,6 +25,11 @@ module('Integration | Component | kubernetes | Page::Role::Details', function (h
 
   hooks.beforeEach(function () {
     const store = this.owner.lookup('service:store');
+    this.server.post('/sys/capabilities-self', () => ({
+      data: {
+        capabilities: ['root'],
+      },
+    }));
     this.renderComponent = (trait) => {
       const data = this.server.create('kubernetes-role', trait);
       store.pushPayload('kubernetes/role', {


### PR DESCRIPTION
During manual testing some bugs were revealed and general improvements were made:
- link in `ConfigCta` component was pointed to incorrect route
- added catch to return empty array in roles model hook
- delete action in roles list menu was not working
- in role create/edit view the generated role rules were not saving
- updated overview, configuration and roles page components to accept args for individual model properties
- fixes page::role::details test broken in previous PR
- adds more test coverage for generated role rules
- adds top level index route that redirects to overview 