### PR TITLE
Duo Passcode Prepend

### DIFF
--- a/ui/app/adapters/cluster.js
+++ b/ui/app/adapters/cluster.js
@@ -133,7 +133,17 @@ export default ApplicationAdapter.extend({
       data: {
         mfa_request_id,
         mfa_payload: mfa_constraints.reduce((obj, { selectedMethod, passcode }) => {
-          obj[selectedMethod.id] = passcode ? [passcode] : [];
+          let payload = [];
+          if (passcode) {
+            // duo requires passcode= prepended to the actual passcode
+            // this isn't a great UX so we add it behind the scenes to fulfill the requirement
+            // check if user added passcode= to avoid duplication
+            payload =
+              selectedMethod.type === 'duo' && !passcode.includes('passcode=')
+                ? [`passcode=${passcode}`]
+                : [passcode];
+          }
+          obj[selectedMethod.id] = payload;
           return obj;
         }, {}),
       },

--- a/ui/mirage/handlers/mfa-login.js
+++ b/ui/mirage/handlers/mfa-login.js
@@ -31,7 +31,8 @@ export const validationHandler = (schema, req) => {
       // validate totp passcode
       const passcode = mfa_payload[constraintId][0];
       if (method.uses_passcode) {
-        if (passcode !== 'test') {
+        const expectedPasscode = method.type === 'duo' ? 'passcode=test' : 'test';
+        if (passcode !== expectedPasscode) {
           const error =
             {
               used: 'code already used; new code is available in 30 seconds',
@@ -92,6 +93,8 @@ export default function (server) {
       [mfa_constraints, methods] = generator([m('okta'), m('totp')], [m('totp')]); // 2 constraints 1 passcode/1 non-passcode 1 non-passcode
     } else if (user === 'mfa-j') {
       [mfa_constraints, methods] = generator([m('pingid')]); // use to test push failures
+    } else if (user === 'mfa-k') {
+      [mfa_constraints, methods] = generator([m('duo', true)]); // test duo passcode and prepending passcode= to user input
     }
     const mfa_request_id = crypto.randomUUID();
     const mfa_requirement = {

--- a/ui/tests/integration/components/mfa-form-test.js
+++ b/ui/tests/integration/components/mfa-form-test.js
@@ -101,7 +101,7 @@ module('Integration | Component | mfa-form', function (hooks) {
       const json = JSON.parse(req.requestBody);
       const payload = {
         mfa_request_id: 'test-mfa-id',
-        mfa_payload: { [oktaConstraint.id]: [], [duoConstraint.id]: ['test-code'] },
+        mfa_payload: { [oktaConstraint.id]: [], [duoConstraint.id]: ['passcode=test-code'] },
       };
       assert.deepEqual(json, payload, 'Correct mfa payload passed to validate endpoint');
       return {};


### PR DESCRIPTION
Prepends `passcode=` if not provided by user for duo mfa method that uses passcode. 