### PR TITLE
docs: add note on aws snapstart incompatibility

### DIFF
--- a/website/content/docs/platform/aws/lambda-extension.mdx
+++ b/website/content/docs/platform/aws/lambda-extension.mdx
@@ -270,7 +270,7 @@ token is nearly expired but renewable.
 
 ~> **Note**: The Vault Lambda Extension is currently incompatible with
 [AWS SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html).
-This is becuase AWS SnapStart does not support the Lambda Extensions API.
+This is because AWS SnapStart does not support the Lambda Extensions API.
 
 ## Performance impact
 

--- a/website/content/docs/platform/aws/lambda-extension.mdx
+++ b/website/content/docs/platform/aws/lambda-extension.mdx
@@ -268,7 +268,9 @@ synchronously refresh its own token before proxying requests if the token is
 expired (including a grace window), and it will attempt to renew its token if the
 token is nearly expired but renewable.
 
-~> **Note**: The Vault Lambda Extension is currently incompatible with AWS SnapStart.
+~> **Note**: The Vault Lambda Extension is currently incompatible with
+[AWS SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html).
+This is becuase AWS SnapStart does not support the Lambda Extensions API.
 
 ## Performance impact
 

--- a/website/content/docs/platform/aws/lambda-extension.mdx
+++ b/website/content/docs/platform/aws/lambda-extension.mdx
@@ -268,6 +268,8 @@ synchronously refresh its own token before proxying requests if the token is
 expired (including a grace window), and it will attempt to renew its token if the
 token is nearly expired but renewable.
 
+~> **Note**: The Vault Lambda Extension is currently incompatible with AWS SnapStart.
+
 ## Performance impact
 
 AWS Lambda pricing is based on [number of invocations, time of execution and memory


### PR DESCRIPTION
[AWS SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html) does not support the Lambda Extensions API. This makes the Vault Lambda Extension incompatible with AWS SnapStart. We will update our docs to note this limitation.

Backporting this to 1.12.x so that it makes it to the currently published docs.