### PR TITLE
Correctly handle issuer tidying in auto-tidy config

### DIFF
--- a/builtin/logical/pki/path_tidy_test.go
+++ b/builtin/logical/pki/path_tidy_test.go
@@ -371,3 +371,36 @@ func TestTidyIssuers(t *testing.T) {
 	require.Equal(t, statusResp.Data["issuer_safety_buffer"], 1)
 	require.Equal(t, statusResp.Data["tidy_expired_issuers"], true)
 }
+
+func TestTidyIssuerConfig(t *testing.T) {
+	t.Parallel()
+
+	b, s := CreateBackendWithStorage(t)
+
+	// Ensure the default auto-tidy config matches expectations
+	resp, err := CBRead(b, s, "config/auto-tidy")
+	requireSuccessNonNilResponse(t, resp, err)
+
+	jsonBlob, err := json.Marshal(&defaultTidyConfig)
+	require.NoError(t, err)
+	var defaultConfigMap map[string]interface{}
+	err = json.Unmarshal(jsonBlob, &defaultConfigMap)
+	require.NoError(t, err)
+
+	// Coerce defaults to API response types.
+	defaultConfigMap["interval_duration"] = int(time.Duration(defaultConfigMap["interval_duration"].(float64)) / time.Second)
+	defaultConfigMap["issuer_safety_buffer"] = int(time.Duration(defaultConfigMap["issuer_safety_buffer"].(float64)) / time.Second)
+	defaultConfigMap["safety_buffer"] = int(time.Duration(defaultConfigMap["safety_buffer"].(float64)) / time.Second)
+	defaultConfigMap["pause_duration"] = time.Duration(defaultConfigMap["pause_duration"].(float64)).String()
+
+	require.Equal(t, defaultConfigMap, resp.Data)
+
+	// Ensure setting issuer-tidy related fields stick.
+	resp, err = CBWrite(b, s, "config/auto-tidy", map[string]interface{}{
+		"tidy_expired_issuers": true,
+		"issuer_safety_buffer": "5s",
+	})
+	requireSuccessNonNilResponse(t, resp, err)
+	require.Equal(t, true, resp.Data["tidy_expired_issuers"])
+	require.Equal(t, 5, resp.Data["issuer_safety_buffer"])
+}

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -3665,6 +3665,14 @@ status endpoint described below.
   performance of OCSP and CRL building, by shifting work to a tidy operation
   instead.
 
+- `tidy_expired_issuers` `(bool: false)` - Set to true to automatically remove
+  expired issuers after the `issuer_safety_buffer` duration has elapsed. We
+  log the issuer certificate on removal to allow recovery; no keys are removed
+  during this process.
+
+~> Note: The default issuer will not be removed even if it has expired and is
+   past the `issuer_safety_buffer` specified.
+
 - `safety_buffer` `(string: "")` - Specifies a duration using [duration format strings](/docs/concepts/duration-format)
   used as a safety buffer to ensure certificates are not expunged prematurely; as an example, this can keep
   certificates from being removed from the CRL that, due to clock skew, might
@@ -3672,6 +3680,24 @@ status endpoint described below.
   the time must be after the expiration time of the certificate (according to
   the local clock) plus the duration of `safety_buffer`. Defaults to `72h`.
 
+- `issuer_safety_buffer` `(string: "")` - Specifies a duration that issuers
+  should be kept for, past their `NotAfter` validity period. Defaults to
+  365 days as hours (`8760h`).
+
+- `pause_duration` `(string: "0s")` - Specifies the duration to pause
+  between tidying individual certificates. This releases the revocation
+  lock and allows other operations to continue while tidy is running.
+  This allows an operator to control tidy's resource utilization within
+  a timespan: the LIST operation will remain in memory, but the space
+  between reading, parsing, and updates on-disk cert entries will be
+  increased, decreasing resource utilization.
+
+  Does not affect `tidy_expired_issuers`.
+
+~> Note: Using too long of a `pause_duration` can result in tidy operations
+   not concluding during this lifetime! Using too short of a pause duration
+   (but non-zero) can lead to lock contention. Use [tidy's cancellation](#cancel-tidy)
+   to stop a running operation after the sleep period is over.
 
 #### Sample Payload
 


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

Thanks @jkirschner-hashicorp for pointing out that the auto-tidy docs section was missing from main.