### PR TITLE
VAULT-11829: Add cluster status handler

### DIFF
--- a/changelog/18351.txt
+++ b/changelog/18351.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+hcp/status: Add cluster-level status information 
+```

--- a/go.mod
+++ b/go.mod
@@ -138,7 +138,7 @@ require (
 	github.com/hashicorp/vault/api/auth/approle v0.1.0
 	github.com/hashicorp/vault/api/auth/userpass v0.1.0
 	github.com/hashicorp/vault/sdk v0.6.1
-	github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230103211812-c28545e74f94
+	github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230105183308-048241517ffb
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/jackc/pgx/v4 v4.15.0
 	github.com/jcmturner/gokrb5/v8 v8.4.2

--- a/go.mod
+++ b/go.mod
@@ -138,7 +138,7 @@ require (
 	github.com/hashicorp/vault/api/auth/approle v0.1.0
 	github.com/hashicorp/vault/api/auth/userpass v0.1.0
 	github.com/hashicorp/vault/sdk v0.6.1
-	github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230105183308-048241517ffb
+	github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230106203127-9eaf26716342
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/jackc/pgx/v4 v4.15.0
 	github.com/jcmturner/gokrb5/v8 v8.4.2

--- a/go.mod
+++ b/go.mod
@@ -138,7 +138,7 @@ require (
 	github.com/hashicorp/vault/api/auth/approle v0.1.0
 	github.com/hashicorp/vault/api/auth/userpass v0.1.0
 	github.com/hashicorp/vault/sdk v0.6.1
-	github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20221209165735-a2eed407e08d
+	github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20221213220056-b0613b59f419
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/jackc/pgx/v4 v4.15.0
 	github.com/jcmturner/gokrb5/v8 v8.4.2

--- a/go.mod
+++ b/go.mod
@@ -138,7 +138,7 @@ require (
 	github.com/hashicorp/vault/api/auth/approle v0.1.0
 	github.com/hashicorp/vault/api/auth/userpass v0.1.0
 	github.com/hashicorp/vault/sdk v0.6.1
-	github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20221213220056-b0613b59f419
+	github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230103211812-c28545e74f94
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/jackc/pgx/v4 v4.15.0
 	github.com/jcmturner/gokrb5/v8 v8.4.2

--- a/go.sum
+++ b/go.sum
@@ -1176,6 +1176,8 @@ github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20221209165735-a2eed407e0
 github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20221209165735-a2eed407e08d/go.mod h1:a2crHoMWwY6aiL8GWT8hYj7vKD64uX0EdRPbnsHF5wU=
 github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20221213220056-b0613b59f419 h1:yl6f//YTaTTGKJwyOpRe7v1DDPrzP+NErwgnef6qx7A=
 github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20221213220056-b0613b59f419/go.mod h1:a2crHoMWwY6aiL8GWT8hYj7vKD64uX0EdRPbnsHF5wU=
+github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230103211812-c28545e74f94 h1:Rx4Q2/mOPqJuanzwZYttDkWjdibPv3UpvsvKmOkl6h4=
+github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230103211812-c28545e74f94/go.mod h1:a2crHoMWwY6aiL8GWT8hYj7vKD64uX0EdRPbnsHF5wU=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443 h1:O/pT5C1Q3mVXMyuqg7yuAWUg/jMZR1/0QTzTRdNR6Uw=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443/go.mod h1:bEpDU35nTu0ey1EXjwNwPjI9xErAsoOCmcMb9GKvyxo=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/go.sum
+++ b/go.sum
@@ -1178,6 +1178,8 @@ github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20221213220056-b0613b59f4
 github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20221213220056-b0613b59f419/go.mod h1:a2crHoMWwY6aiL8GWT8hYj7vKD64uX0EdRPbnsHF5wU=
 github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230103211812-c28545e74f94 h1:Rx4Q2/mOPqJuanzwZYttDkWjdibPv3UpvsvKmOkl6h4=
 github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230103211812-c28545e74f94/go.mod h1:a2crHoMWwY6aiL8GWT8hYj7vKD64uX0EdRPbnsHF5wU=
+github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230105183308-048241517ffb h1:PgXcBszV61BvxD0wZzm4QCz9btgTWX74NO4be6S2afU=
+github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230105183308-048241517ffb/go.mod h1:a2crHoMWwY6aiL8GWT8hYj7vKD64uX0EdRPbnsHF5wU=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443 h1:O/pT5C1Q3mVXMyuqg7yuAWUg/jMZR1/0QTzTRdNR6Uw=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443/go.mod h1:bEpDU35nTu0ey1EXjwNwPjI9xErAsoOCmcMb9GKvyxo=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/go.sum
+++ b/go.sum
@@ -1174,6 +1174,8 @@ github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20221202210228-12b2fab875
 github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20221202210228-12b2fab87559/go.mod h1:hsrm1EXNYpQwErumOLeaTY74+Tj7poOwckbR4d+0hEQ=
 github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20221209165735-a2eed407e08d h1:U692VbDl6ww5GQsNFClJVFJDaPeuqtDt1Mwqf21KYek=
 github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20221209165735-a2eed407e08d/go.mod h1:a2crHoMWwY6aiL8GWT8hYj7vKD64uX0EdRPbnsHF5wU=
+github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20221213220056-b0613b59f419 h1:yl6f//YTaTTGKJwyOpRe7v1DDPrzP+NErwgnef6qx7A=
+github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20221213220056-b0613b59f419/go.mod h1:a2crHoMWwY6aiL8GWT8hYj7vKD64uX0EdRPbnsHF5wU=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443 h1:O/pT5C1Q3mVXMyuqg7yuAWUg/jMZR1/0QTzTRdNR6Uw=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443/go.mod h1:bEpDU35nTu0ey1EXjwNwPjI9xErAsoOCmcMb9GKvyxo=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/go.sum
+++ b/go.sum
@@ -1180,6 +1180,10 @@ github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230103211812-c28545e74f
 github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230103211812-c28545e74f94/go.mod h1:a2crHoMWwY6aiL8GWT8hYj7vKD64uX0EdRPbnsHF5wU=
 github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230105183308-048241517ffb h1:PgXcBszV61BvxD0wZzm4QCz9btgTWX74NO4be6S2afU=
 github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230105183308-048241517ffb/go.mod h1:a2crHoMWwY6aiL8GWT8hYj7vKD64uX0EdRPbnsHF5wU=
+github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230106184443-96cfe11e7051 h1:cMQoRbIUMhbM0NsmP6hH3S3ZmAPVgic3g3L8Z55rXCI=
+github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230106184443-96cfe11e7051/go.mod h1:a2crHoMWwY6aiL8GWT8hYj7vKD64uX0EdRPbnsHF5wU=
+github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230106203127-9eaf26716342 h1:9cMwZnaAV/lKs8EZsvBF00wPt350wD3sg/xqWGeN4gM=
+github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230106203127-9eaf26716342/go.mod h1:a2crHoMWwY6aiL8GWT8hYj7vKD64uX0EdRPbnsHF5wU=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443 h1:O/pT5C1Q3mVXMyuqg7yuAWUg/jMZR1/0QTzTRdNR6Uw=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443/go.mod h1:bEpDU35nTu0ey1EXjwNwPjI9xErAsoOCmcMb9GKvyxo=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/vault/cluster.go
+++ b/vault/cluster.go
@@ -388,3 +388,7 @@ func (c *Core) SetClusterListenerAddrs(addrs []*net.TCPAddr) {
 func (c *Core) SetClusterHandler(handler http.Handler) {
 	c.clusterHandler = handler
 }
+
+func (c *Core) ClusterID() string {
+	return c.clusterID.Load()
+}

--- a/vault/core.go
+++ b/vault/core.go
@@ -3586,3 +3586,7 @@ func (c *Core) GetHCPLinkStatus() (string, string) {
 
 	return status, resourceID
 }
+
+func (c *Core) HAEnabled() bool {
+	return c.ha != nil && c.ha.HAEnabled()
+}

--- a/vault/core.go
+++ b/vault/core.go
@@ -3590,3 +3590,13 @@ func (c *Core) GetHCPLinkStatus() (string, string) {
 func (c *Core) HAEnabled() bool {
 	return c.ha != nil && c.ha.HAEnabled()
 }
+
+func (c *Core) GetRaftConfiguration(ctx context.Context) (*raft.RaftConfigurationResponse, error) {
+	raftBackend := c.getRaftBackend()
+
+	if raftBackend == nil {
+		return nil, nil
+	}
+
+	return raftBackend.GetConfiguration(ctx)
+}

--- a/vault/core.go
+++ b/vault/core.go
@@ -662,6 +662,13 @@ func (c *Core) HAState() consts.HAState {
 	}
 }
 
+func (c *Core) HAStateWithLock() consts.HAState {
+	c.stateLock.RLock()
+	c.stateLock.RUnlock()
+
+	return c.HAState()
+}
+
 // CoreConfig is used to parameterize a core
 type CoreConfig struct {
 	entCoreConfig

--- a/vault/core.go
+++ b/vault/core.go
@@ -3600,3 +3600,12 @@ func (c *Core) GetRaftConfiguration(ctx context.Context) (*raft.RaftConfiguratio
 
 	return raftBackend.GetConfiguration(ctx)
 }
+
+func (c *Core) GetRaftAutopilotState(ctx context.Context) (*raft.AutopilotState, error) {
+	raftBackend := c.getRaftBackend()
+	if raftBackend == nil {
+		return nil, nil
+	}
+
+	return raftBackend.GetAutopilotServerState(ctx)
+}

--- a/vault/external_tests/hcp_link/test_helpers.go
+++ b/vault/external_tests/hcp_link/test_helpers.go
@@ -81,8 +81,8 @@ func TestClusterWithHCPLinkEnabled(t *testing.T, cluster *vault.TestCluster, ena
 		t.Skip("HCP client secret not found in env")
 	}
 
-	if _, ok := os.LookupEnv("HCP_API_HOST"); !ok {
-		t.Skip("failed to find HCP_API_HOST in the environment")
+	if _, ok := os.LookupEnv("HCP_API_ADDRESS"); !ok {
+		t.Skip("failed to find HCP_API_ADDRESS in the environment")
 	}
 	if _, ok := os.LookupEnv("HCP_SCADA_ADDRESS"); !ok {
 		t.Skip("failed to find HCP_SCADA_ADDRESS in the environment")

--- a/vault/external_tests/hcp_link/test_helpers.go
+++ b/vault/external_tests/hcp_link/test_helpers.go
@@ -81,8 +81,8 @@ func TestClusterWithHCPLinkEnabled(t *testing.T, cluster *vault.TestCluster, ena
 		t.Skip("HCP client secret not found in env")
 	}
 
-	if _, ok := os.LookupEnv("HCP_API_ADDRESS"); !ok {
-		t.Skip("failed to find HCP_API_ADDRESS in the environment")
+	if _, ok := os.LookupEnv("HCP_API_HOST"); !ok {
+		t.Skip("failed to find HCP_API_HOST in the environment")
 	}
 	if _, ok := os.LookupEnv("HCP_SCADA_ADDRESS"); !ok {
 		t.Skip("failed to find HCP_SCADA_ADDRESS in the environment")

--- a/vault/hcp_link/capabilities/meta/meta.go
+++ b/vault/hcp_link/capabilities/meta/meta.go
@@ -131,7 +131,7 @@ func (h *hcpLinkMetaHandler) ListNamespaces(ctx context.Context, req *meta.ListN
 func (h *hcpLinkMetaHandler) ListMounts(ctx context.Context, req *meta.ListMountsRequest) (*meta.ListMountsResponse, error) {
 	mountEntries, err := h.wrappedCore.ListMounts()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to list secret mounts: %w", err)
 	}
 
 	var mounts []*meta.Mount
@@ -142,7 +142,7 @@ func (h *hcpLinkMetaHandler) ListMounts(ctx context.Context, req *meta.ListMount
 		if nsID != namespace.RootNamespaceID {
 			ns, err := h.wrappedCore.NamespaceByID(ctx, entry.NamespaceID)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("unable to get namespace associated with secret mount: %w", err)
 			}
 
 			path = ns.Path + path
@@ -163,7 +163,7 @@ func (h *hcpLinkMetaHandler) ListMounts(ctx context.Context, req *meta.ListMount
 func (h *hcpLinkMetaHandler) ListAuths(ctx context.Context, req *meta.ListAuthsRequest) (*meta.ListAuthResponse, error) {
 	authEntries, err := h.wrappedCore.ListAuths()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to list auth mounts: %w", err)
 	}
 
 	var auths []*meta.Auth
@@ -174,7 +174,7 @@ func (h *hcpLinkMetaHandler) ListAuths(ctx context.Context, req *meta.ListAuthsR
 		if nsID != namespace.RootNamespaceID {
 			ns, err := h.wrappedCore.NamespaceByID(ctx, entry.NamespaceID)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("unable to get namespace associated with auth mount: %w", err)
 			}
 
 			path = ns.Path + path
@@ -199,7 +199,7 @@ func (h *hcpLinkMetaHandler) GetClusterStatus(ctx context.Context, req *meta.Get
 
 	hostname, err := os.Hostname()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to fetch hostname: %w", err)
 	}
 
 	haEnabled := h.wrappedCore.HAEnabled()
@@ -229,7 +229,7 @@ func (h *hcpLinkMetaHandler) GetClusterStatus(ctx context.Context, req *meta.Get
 	raftStatus := &meta.RaftStatus{}
 	raftConfig, err := h.wrappedCore.GetRaftConfiguration(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to get Raft configuration: %w", err)
 	}
 
 	if raftConfig != nil {
@@ -270,7 +270,7 @@ func (h *hcpLinkMetaHandler) GetClusterStatus(ctx context.Context, req *meta.Get
 
 	raftAutopilotState, err := h.wrappedCore.GetRaftAutopilotState(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to get Raft Autopilot state: %w", err)
 	}
 
 	if raftAutopilotState != nil {

--- a/vault/hcp_link/capabilities/meta/meta.go
+++ b/vault/hcp_link/capabilities/meta/meta.go
@@ -193,7 +193,7 @@ func (h *hcpLinkMetaHandler) ListAuths(ctx context.Context, req *meta.ListAuthsR
 }
 
 func (h *hcpLinkMetaHandler) GetClusterStatus(ctx context.Context, req *meta.GetClusterStatusRequest) (*meta.GetClusterStatusResponse, error) {
-	if h.wrappedCore.HAState() != consts.Active {
+	if h.wrappedCore.HAStateWithLock() != consts.Active {
 		return nil, fmt.Errorf("node not active")
 	}
 

--- a/vault/hcp_link/capabilities/meta/meta.go
+++ b/vault/hcp_link/capabilities/meta/meta.go
@@ -262,7 +262,7 @@ func (h *hcpLinkMetaHandler) GetClusterStatus(ctx context.Context, req *meta.Get
 		}
 
 		if voterCount > 7 {
-			quorumWarnings = append(quorumWarnings, "Warning: Very large cluster detected.")
+			quorumWarnings = append(quorumWarnings, "Very large cluster detected.")
 		}
 
 		raftStatus.QuorumWarnings = quorumWarnings

--- a/vault/hcp_link/capabilities/meta/meta.go
+++ b/vault/hcp_link/capabilities/meta/meta.go
@@ -212,12 +212,15 @@ func (h *hcpLinkMetaHandler) GetClusterStatus(ctx context.Context, req *meta.Get
 			Hostname: hostname,
 		}
 
-		haNodes := make([]*meta.HANode, 0)
-		haNodes = append(nodes, leader)
-		for _, peerNode := range h.wrappedCore.GetHAPeerNodesCached() {
-			haNodes = append(haNodes, &meta.HANode{
+		peers := h.wrappedCore.GetHAPeerNodesCached()
+
+		haNodes := make([]*meta.HANode, len(peers)+1)
+		haNodes[0] = leader
+
+		for i, peerNode := range peers {
+			haNodes[i+1] = &meta.HANode{
 				Hostname: peerNode.Hostname,
-			})
+			}
 		}
 
 		haStatus.Nodes = haNodes

--- a/vault/hcp_link/capabilities/meta/meta.go
+++ b/vault/hcp_link/capabilities/meta/meta.go
@@ -253,6 +253,19 @@ func (h *hcpLinkMetaHandler) GetClusterStatus(ctx context.Context, req *meta.Get
 		raftStatus.RaftConfiguration = &meta.RaftConfiguration{
 			Servers: raftServers,
 		}
+
+		quorumWarnings := make([]string, 0)
+		if voterCount == 0 {
+			quorumWarnings = append(quorumWarnings, "Only one server node found. Vault is not running in high availability mode.")
+		} else if voterCount%2 == 0 {
+			quorumWarnings = append(quorumWarnings, "Vault should have access to an odd number of voter nodes.")
+		}
+
+		if voterCount > 7 {
+			quorumWarnings = append(quorumWarnings, "Warning: Very large cluster detected.")
+		}
+
+		raftStatus.QuorumWarnings = quorumWarnings
 	}
 
 	raftAutopilotState, err := h.wrappedCore.GetRaftAutopilotState(ctx)

--- a/vault/hcp_link/capabilities/meta/meta.go
+++ b/vault/hcp_link/capabilities/meta/meta.go
@@ -254,18 +254,21 @@ func (h *hcpLinkMetaHandler) GetClusterStatus(ctx context.Context, req *meta.Get
 			Servers: raftServers,
 		}
 
-		quorumWarnings := make([]string, 0)
-		if voterCount == 0 {
-			quorumWarnings = append(quorumWarnings, "Only one server node found. Vault is not running in high availability mode.")
+		evenVoterMessage := "Vault should have access to an odd number of voter nodes."
+		largeClusterMessage := "Very large cluster detected."
+		var quorumWarning string
+
+		if voterCount == 1 {
+			quorumWarning = "Only one server node found. Vault is not running in high availability mode."
+		} else if voterCount%2 == 0 && voterCount > 7 {
+			quorumWarning = evenVoterMessage + " " + largeClusterMessage
 		} else if voterCount%2 == 0 {
-			quorumWarnings = append(quorumWarnings, "Vault should have access to an odd number of voter nodes.")
+			quorumWarning = evenVoterMessage
+		} else if voterCount > 7 {
+			quorumWarning = largeClusterMessage
 		}
 
-		if voterCount > 7 {
-			quorumWarnings = append(quorumWarnings, "Very large cluster detected.")
-		}
-
-		raftStatus.QuorumWarnings = quorumWarnings
+		raftStatus.QuorumWarning = quorumWarning
 	}
 
 	raftAutopilotState, err := h.wrappedCore.GetRaftAutopilotState(ctx)

--- a/vault/hcp_link/capabilities/meta/meta.go
+++ b/vault/hcp_link/capabilities/meta/meta.go
@@ -255,6 +255,27 @@ func (h *hcpLinkMetaHandler) GetClusterStatus(ctx context.Context, req *meta.Get
 		}
 	}
 
+	raftAutopilotState, err := h.wrappedCore.GetRaftAutopilotState(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if raftAutopilotState != nil {
+		autopilotStatus := &meta.AutopilotStatus{
+			Healthy: raftAutopilotState.Healthy,
+		}
+
+		autopilotServers := make([]*meta.AutopilotServer, 0)
+		for _, srv := range raftAutopilotState.Servers {
+			autopilotServers = append(autopilotServers, &meta.AutopilotServer{
+				ID:      srv.ID,
+				Healthy: srv.Healthy,
+			})
+		}
+
+		raftStatus.AutopilotStatus = autopilotStatus
+	}
+
 	resp := &meta.GetClusterStatusResponse{
 		HAStatus:   haStatus,
 		RaftStatus: raftStatus,

--- a/vault/hcp_link/capabilities/meta/meta.go
+++ b/vault/hcp_link/capabilities/meta/meta.go
@@ -290,8 +290,9 @@ func (h *hcpLinkMetaHandler) GetClusterStatus(ctx context.Context, req *meta.Get
 	}
 
 	resp := &meta.GetClusterStatusResponse{
-		HAStatus:   haStatus,
-		RaftStatus: raftStatus,
+		HAStatus:    haStatus,
+		RaftStatus:  raftStatus,
+		StorageType: h.wrappedCore.StorageType(),
 	}
 
 	return resp, nil

--- a/vault/hcp_link/capabilities/meta/meta.go
+++ b/vault/hcp_link/capabilities/meta/meta.go
@@ -290,6 +290,7 @@ func (h *hcpLinkMetaHandler) GetClusterStatus(ctx context.Context, req *meta.Get
 	}
 
 	resp := &meta.GetClusterStatusResponse{
+		ClusterID:   h.wrappedCore.ClusterID(),
 		HAStatus:    haStatus,
 		RaftStatus:  raftStatus,
 		StorageType: h.wrappedCore.StorageType(),

--- a/vault/hcp_link/capabilities/meta/meta.go
+++ b/vault/hcp_link/capabilities/meta/meta.go
@@ -232,7 +232,7 @@ func (h *hcpLinkMetaHandler) GetClusterStatus(ctx context.Context, req *meta.Get
 		return nil, err
 	}
 
-	if raftStatus != nil {
+	if raftConfig != nil {
 		raftServers := make([]*meta.RaftServer, len(raftConfig.Servers))
 
 		var voterCount uint32

--- a/vault/hcp_link/internal/wrapped_hcpLink.go
+++ b/vault/hcp_link/internal/wrapped_hcpLink.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/physical/raft"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
@@ -38,6 +39,7 @@ type WrappedCoreMeta interface {
 	HAEnabled() bool
 	HAState() consts.HAState
 	GetHAPeerNodesCached() []vault.PeerNode
+	GetRaftConfiguration(ctx context.Context) (*raft.RaftConfigurationResponse, error)
 }
 
 var _ WrappedCoreMeta = &vault.Core{}

--- a/vault/hcp_link/internal/wrapped_hcpLink.go
+++ b/vault/hcp_link/internal/wrapped_hcpLink.go
@@ -41,6 +41,7 @@ type WrappedCoreMeta interface {
 	GetHAPeerNodesCached() []vault.PeerNode
 	GetRaftConfiguration(ctx context.Context) (*raft.RaftConfigurationResponse, error)
 	GetRaftAutopilotState(ctx context.Context) (*raft.AutopilotState, error)
+	StorageType() string
 }
 
 var _ WrappedCoreMeta = &vault.Core{}

--- a/vault/hcp_link/internal/wrapped_hcpLink.go
+++ b/vault/hcp_link/internal/wrapped_hcpLink.go
@@ -37,7 +37,7 @@ type WrappedCoreMeta interface {
 	ListMounts() ([]*vault.MountEntry, error)
 	ListAuths() ([]*vault.MountEntry, error)
 	HAEnabled() bool
-	HAState() consts.HAState
+	HAStateWithLock() consts.HAState
 	GetHAPeerNodesCached() []vault.PeerNode
 	GetRaftConfiguration(ctx context.Context) (*raft.RaftConfigurationResponse, error)
 	GetRaftAutopilotState(ctx context.Context) (*raft.AutopilotState, error)

--- a/vault/hcp_link/internal/wrapped_hcpLink.go
+++ b/vault/hcp_link/internal/wrapped_hcpLink.go
@@ -40,6 +40,7 @@ type WrappedCoreMeta interface {
 	HAState() consts.HAState
 	GetHAPeerNodesCached() []vault.PeerNode
 	GetRaftConfiguration(ctx context.Context) (*raft.RaftConfigurationResponse, error)
+	GetRaftAutopilotState(ctx context.Context) (*raft.AutopilotState, error)
 }
 
 var _ WrappedCoreMeta = &vault.Core{}

--- a/vault/hcp_link/internal/wrapped_hcpLink.go
+++ b/vault/hcp_link/internal/wrapped_hcpLink.go
@@ -30,14 +30,17 @@ type WrappedCoreHCPToken interface {
 
 var _ WrappedCoreHCPToken = &vault.Core{}
 
-type WrappedCoreListNamespacesMounts interface {
+type WrappedCoreMeta interface {
 	NamespaceByID(ctx context.Context, nsID string) (*namespace.Namespace, error)
 	ListNamespaces(includePath bool) []*namespace.Namespace
 	ListMounts() ([]*vault.MountEntry, error)
 	ListAuths() ([]*vault.MountEntry, error)
+	HAEnabled() bool
+	HAState() consts.HAState
+	GetHAPeerNodesCached() []vault.PeerNode
 }
 
-var _ WrappedCoreListNamespacesMounts = &vault.Core{}
+var _ WrappedCoreMeta = &vault.Core{}
 
 type WrappedCoreHCPLinkStatus interface {
 	WrappedCoreStandbyStates

--- a/vault/hcp_link/internal/wrapped_hcpLink.go
+++ b/vault/hcp_link/internal/wrapped_hcpLink.go
@@ -42,6 +42,7 @@ type WrappedCoreMeta interface {
 	GetRaftConfiguration(ctx context.Context) (*raft.RaftConfigurationResponse, error)
 	GetRaftAutopilotState(ctx context.Context) (*raft.AutopilotState, error)
 	StorageType() string
+	ClusterID() string
 }
 
 var _ WrappedCoreMeta = &vault.Core{}

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -790,7 +790,7 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 	}
 
 	if walState.LocalIndex != 0 || walState.ReplicatedIndex != 0 {
-		walState.ClusterID = c.clusterID.Load()
+		walState.ClusterID = c.ClusterID()
 		if walState.LocalIndex == 0 {
 			if c.perfStandby {
 				walState.LocalIndex = LastRemoteWAL(c)
@@ -2337,7 +2337,7 @@ func (c *Core) checkSSCTokenInternal(ctx context.Context, token string, isPerfSt
 		return plainToken.Random, nil
 	}
 
-	requiredWalState := &logical.WALState{ClusterID: c.clusterID.Load(), LocalIndex: plainToken.LocalIndex, ReplicatedIndex: 0}
+	requiredWalState := &logical.WALState{ClusterID: c.ClusterID(), LocalIndex: plainToken.LocalIndex, ReplicatedIndex: 0}
 	if c.HasWALState(requiredWalState, isPerfStandby) {
 		return plainToken.Random, nil
 	}


### PR DESCRIPTION
The associated PR https://github.com/hashicorp/vault/pull/18316 expands the `meta` proto by introducing the `GetClusterStatus` RPC. This PR implements it.

The `GetClusterStatusResponse` includes the following fields:

- `ClusterID`
- `HAStatus`
- `RaftStatus`
- `StorageType`

A few new `Core` methods have been added for the purpose of de-coupling via `WrappedCoreMeta` (previously called `WrappedCoreListNamespacesMounts`):
- `ClusterID` loads and returns the atomic `Core.clusterID` value
- `HAEnabled` specifies whether high-availability mode is enabled
- `GetRaftConfiguration` exposes the Raft configuration, similar to what is provided via [/sys/storage/raft/configuration](https://developer.hashicorp.com/vault/api-docs/system/storage/raft#read-raft-configuration)
- `GetRaftAutopilotState` exposes the Raft Autopilot state, similar to what is provided via [/sys/storage/raft/autopilot/state](https://developer.hashicorp.com/vault/api-docs/system/storage/raftautopilot#get-cluster-state)

TODO:
- [x] `go get github.com/hashicorp/vault/vault/hcp_link/proto` once https://github.com/hashicorp/vault/pull/18316 since the current version in `go.mod` is pointing to `@vault-11829-meta-get-cluster-status`
- [x] Add changelog entry