### PR TITLE
docs/policies: update denied_parameters description

### DIFF
--- a/website/content/docs/concepts/policies.mdx
+++ b/website/content/docs/concepts/policies.mdx
@@ -442,8 +442,8 @@ constrain requests, using the following options:
     }
     ```
 
-- `denied_parameters` - Blacklists a list of parameter and values. Any values
-  specified here take precedence over `allowed_parameters`.
+- `denied_parameters` - A list of keys and values that are not permitted on the given 
+  path. Any values specified here take precedence over `allowed_parameters`.
 
   - Setting a parameter with a value of the empty list denies any changes to
     that parameter.


### PR DESCRIPTION
Removing a reference to blacklist in the policy documentation.