### PR TITLE
UI: Update database to connection name on role (#18350)

### DIFF
--- a/changelog/18350.txt
+++ b/changelog/18350.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Update language on database role to "Connection name" [[GH-18261](https://github.com/hashicorp/vault/issues/18261)]
+```

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -18,8 +18,8 @@ export default Model.extend({
     models: ['database/connection'],
     selectLimit: 1,
     onlyAllowExisting: true,
-    subLabel: 'Database name',
-    subText: 'The database for which credentials will be generated.',
+    subLabel: 'Connection name',
+    subText: 'The database connection for which credentials will be generated.',
   }),
   type: attr('string', {
     label: 'Type of role',


### PR DESCRIPTION
## Backport

Manual backport of #18350 due to merge conflicts in generated backport PRs.

The below text is copied from the body of the original PR.

---

Changes the language on database role from `Database` to `Connection name` 

**AFTER**
<img width="1336" alt="Screen Shot 2022-12-13 at 4 27 21 PM" src="https://user-images.githubusercontent.com/82459713/207458350-fade1729-f3f9-4f2f-90a6-bfea1bf38936.png">

**BEFORE**
<img width="1336" alt="Screen Shot 2022-12-13 at 4 27 31 PM" src="https://user-images.githubusercontent.com/82459713/207458373-26782fd5-d80b-4b25-a6c9-93dac05df6c3.png">


---

<details>
<summary> Overview of commits </summary>

  - 58e9f4fcb699102efff3119fb4c8c6613f63784c 

</details>


