### PR TITLE
Fix ci-config for go-version bumps

### DIFF
--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -55,6 +55,7 @@ $(SOURCE_DIR):
 # Make sure our .tmp dir exists.
 $(shell [ -d .tmp ] || mkdir .tmp)
 
+.PHONY: $(OUT)
 .PHONY: $(CONFIG)
 $(CONFIG): $(OUT) $(GO_VERSION_FILE)
 

--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -55,7 +55,6 @@ $(SOURCE_DIR):
 # Make sure our .tmp dir exists.
 $(shell [ -d .tmp ] || mkdir .tmp)
 
-.PHONY: $(OUT)
 .PHONY: $(CONFIG)
 $(CONFIG): $(OUT) $(GO_VERSION_FILE)
 
@@ -83,6 +82,7 @@ define GEN_CONFIG
 	@mv -f $@.tmp $@
 endef
 
+.PHONY: $(OUT)
 $(OUT): $(CONFIG_SOURCE) 
 	$(GEN_CONFIG)
 	@echo "$@ updated"


### PR DESCRIPTION
The removal of the phony $(OUT) target was preventing `make ci-config` from recognizing changes to .go-version. Reintroduce this change to fix go version bumps.