### PR TITLE
Fix race in fsm.db

### DIFF
--- a/physical/raft/fsm.go
+++ b/physical/raft/fsm.go
@@ -235,7 +235,15 @@ func (f *FSM) openDBFile(dbPath string) error {
 	}
 
 	f.db = boltDB
+
 	return nil
+}
+
+func (f *FSM) Stats() bolt.Stats {
+	f.l.RLock()
+	defer f.l.RUnlock()
+
+	return f.db.Stats()
 }
 
 func (f *FSM) Close() error {

--- a/physical/raft/fsm.go
+++ b/physical/raft/fsm.go
@@ -235,7 +235,6 @@ func (f *FSM) openDBFile(dbPath string) error {
 	}
 
 	f.db = boltDB
-
 	return nil
 }
 

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -612,7 +612,7 @@ func (b *RaftBackend) DisableUpgradeMigration() (bool, bool) {
 func (b *RaftBackend) CollectMetrics(sink *metricsutil.ClusterMetricSink) {
 	b.l.RLock()
 	logstoreStats := b.stableStore.(*raftboltdb.BoltStore).Stats()
-	fsmStats := b.fsm.db.Stats()
+	fsmStats := b.fsm.Stats()
 	stats := b.raft.Stats()
 	b.l.RUnlock()
 	b.collectMetricsWithStats(logstoreStats, sink, "logstore")

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -555,7 +555,7 @@ func (b *RaftBackend) Close() error {
 	b.l.Lock()
 	defer b.l.Unlock()
 
-	if err := b.fsm.db.Close(); err != nil {
+	if err := b.fsm.Close(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
We need a read lock when reading any of the FSM fields. Expose a new fsm.Stats to handle the read lock wrapping and make sure we use it. Also use the FSM's Rlock wrapper for `db` operations consistently.

Co-authored by: Josh Black <raskchanky@users.noreply.github.com>