### PR TITLE
UI: PKI Config via Import

### DIFF
--- a/ui/app/adapters/pki/config/import.js
+++ b/ui/app/adapters/pki/config/import.js
@@ -1,0 +1,19 @@
+import { encodePath } from 'vault/utils/path-encoding-helpers';
+import ApplicationAdapter from '../../application';
+
+export default class PkiConfigImportAdapter extends ApplicationAdapter {
+  namespace = 'v1';
+
+  urlForCreateRecord(modelName, snapshot) {
+    // TODO: may need to check permissions to decide which path to use
+    const { pemBundle, backend } = snapshot.record;
+    if (!backend) {
+      throw new Error('URL for create record is missing required attributes');
+    }
+    const baseUrl = `${this.buildURL()}/${encodePath(backend)}`;
+    if (pemBundle) {
+      return `${baseUrl}/config/ca`;
+    }
+    return `${baseUrl}/intermediate/set-signed`;
+  }
+}

--- a/ui/app/models/pki/config/import.js
+++ b/ui/app/models/pki/config/import.js
@@ -1,0 +1,15 @@
+import Model, { attr } from '@ember-data/model';
+import { inject as service } from '@ember/service';
+
+export default class PkiConfigImportModel extends Model {
+  @service secretMountPath;
+
+  @attr('string') pemBundle;
+  @attr('string') certificate;
+  @attr() importedIssuers;
+  @attr() importedKeys;
+
+  get backend() {
+    return this.secretMountPath.currentPath;
+  }
+}

--- a/ui/app/styles/components/masked-input.scss
+++ b/ui/app/styles/components/masked-input.scss
@@ -56,6 +56,7 @@
 }
 
 .button.masked-input-toggle {
+  padding: 0;
   border-radius: 0 $radius $radius 0;
 }
 

--- a/ui/lib/core/addon/components/text-file.hbs
+++ b/ui/lib/core/addon/components/text-file.hbs
@@ -1,7 +1,7 @@
-{{#unless this.inputOnly}}
+{{#unless @inputOnly}}
   <div class="level is-mobile">
     <div class="level-left">
-      <label class="is-label" data-test-text-label={{true}}>
+      <label class="is-label" data-test-text-file-label>
         {{#if this.label}}
           {{this.label}}
           {{#if @helpText}}
@@ -35,7 +35,7 @@
   </div>
 {{/unless}}
 <div
-  class="field text-file box is-fullwidth is-marginless is-shadowless {{if this.inputOnly 'is-paddingless'}}"
+  class="field text-file box is-fullwidth is-marginless is-shadowless {{if @inputOnly 'is-paddingless'}}"
   data-test-component="text-file"
 >
   {{#if @file.enterAsText}}
@@ -43,13 +43,14 @@
       <textarea
         class="textarea {{unless this.showValue 'masked-font'}}"
         {{on "input" this.updateData}}
-        data-test-text-file-textarea={{true}}
+        data-test-text-file-textarea
       >{{@file.value}}</textarea>
       <button
         {{on "click" this.toggleMask}}
         type="button"
         class="{{if (eq this.value '') 'has-text-grey'}} masked-input-toggle button {{if this.displayOnly 'is-compact'}}"
         data-test-button
+        data-test-text-file-button
       >
         <Icon @name={{if this.showValue "eye" "eye-off"}} />
       </button>
@@ -61,18 +62,12 @@
     <div class="control is-expanded">
       <div class="file has-name is-fullwidth">
         <div class="file-label" aria-label="Choose a file">
-          <Input
-            id="file-input"
-            class="file-input"
-            @type="file"
-            {{on "change" this.pickedFile}}
-            data-test-text-file-input={{true}}
-          />
+          <Input id="file-input" class="file-input" @type="file" {{on "change" this.pickedFile}} data-test-text-file-input />
           <label for="file-input" class="file-cta button">
             <Icon @name="upload" class="has-light-grey-text" />
             Choose a file…
           </label>
-          <span class="file-name has-text-grey-dark" data-test-text-file-input-label={{true}}>
+          <span class="file-name has-text-grey-dark" data-test-text-file-input-label>
             {{#if @file.fileName}}
               {{@file.fileName}}
             {{else}}
@@ -85,7 +80,7 @@
               class="file-delete-button"
               aria-label="Clear file selection"
               {{on "click" this.clearFile}}
-              data-test-text-clear={{true}}
+              data-test-text-clear
             >
               <Icon @name="x-circle" />
             </button>

--- a/ui/lib/core/addon/components/text-file.hbs
+++ b/ui/lib/core/addon/components/text-file.hbs
@@ -14,6 +14,9 @@
         {{else}}
           File
         {{/if}}
+        {{#if @subText}}
+          <p class="sub-text" data-test-text-file-subtext>{{@subText}}</p>
+        {{/if}}
       </label>
     </div>
     <div class="level-right">

--- a/ui/lib/core/addon/components/text-file.js
+++ b/ui/lib/core/addon/components/text-file.js
@@ -16,8 +16,6 @@ import { guidFor } from '@ember/object/internals';
  *  @label={{"string"}}
  * />
  *
- * @param [inputOnly] {bool} - When true, only the file input will be rendered
- * @param [helpText] {string} - Text underneath label.
  * @param file {object} - * Object in the shape of:
  * {
  *   value: 'file contents here',
@@ -25,10 +23,12 @@ import { guidFor } from '@ember/object/internals';
  *   enterAsText: boolean ability to enter as text
  * }
  * @param [onChange=Function.prototype] {Function|action} - A function to call when the value of the input changes.
+ * @param [inputOnly] {bool} - When true, only the file input will be rendered
+ * @param [helpText] {string} - Text underneath label.
  * @param [label=null] {string} - Text to use as the label for the file input. If null, a default will be rendered.
  */
 
-export default class TextFile extends Component {
+export default class TextFileComponent extends Component {
   fileHelpText = 'Select a file from your computer';
   textareaHelpText = 'Enter the value as text';
   elementId = guidFor(this);
@@ -37,9 +37,6 @@ export default class TextFile extends Component {
   @tracked file = null;
   @tracked showValue = false;
 
-  get inputOnly() {
-    return this.args.inputOnly || false;
-  }
   get label() {
     return this.args.label || null;
   }

--- a/ui/lib/core/app/components/text-file.js
+++ b/ui/lib/core/app/components/text-file.js
@@ -1,0 +1,1 @@
+export { default } from 'core/components/text-file';

--- a/ui/lib/pki/addon/components/pki-config/import.hbs
+++ b/ui/lib/pki/addon/components/pki-config/import.hbs
@@ -1,0 +1,19 @@
+<form {{on "submit" this.submitForm}} data-test-pki-config-import-form>
+  <TextFile
+    @subText="Upload a PEM bundle or certificate"
+    @file={{this.file}}
+    @onChange={{this.onFileUploaded}}
+    @label="Import"
+  />
+  {{yield}}
+  <div class="field is-grouped box is-fullwidth is-bottomless">
+    <div class="control">
+      <button type="submit" class="button is-primary" data-test-pki-config-save>
+        Done
+      </button>
+      <LinkTo @route="overview" class="button has-left-margin-s" data-test-pki-config-cancel>
+        Cancel
+      </LinkTo>
+    </div>
+  </div>
+</form>

--- a/ui/lib/pki/addon/components/pki-config/import.ts
+++ b/ui/lib/pki/addon/components/pki-config/import.ts
@@ -1,0 +1,78 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+// Types
+import { HTMLElementEvent } from 'forms';
+import PkiConfigImportModel from 'vault/models/pki/config/import';
+import Store from '@ember-data/store';
+import Router from '@ember/routing/router';
+import FlashMessageService from 'vault/services/flash-messages';
+import errorMessage from 'vault/utils/error-message';
+
+// TODO: validate with Alex what we're looking for here
+// https://developer.hashicorp.com/vault/api-docs/secret/pki#parameters-15
+// https://polarssl.org/kb/cryptography/asn1-key-structures-in-der-and-pem/
+function getCertType(contents: string): string {
+  if (contents.startsWith('-----BEGIN CERTIFICATE-----')) {
+    return 'certificate';
+  }
+  return 'pem';
+}
+
+interface File {
+  value: string;
+  fileName?: string;
+  enterAsText: boolean;
+}
+
+export default class PkiConfigImportComponent extends Component<Record<string, never>> {
+  @service declare readonly store: Store;
+  @service declare readonly router: Router;
+  @service declare readonly flashMessages: FlashMessageService;
+
+  @tracked configModel: PkiConfigImportModel | null = null;
+  @tracked file: File = { value: '', enterAsText: false };
+
+  constructor(owner: unknown, args: Record<string, never>) {
+    super(owner, args);
+    const model = this.store.createRecord('pki/config/import');
+    this.configModel = model;
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    const config = this.configModel;
+    // error is thrown when you attempt to unload a record that is inFlight (isSaving)
+    if ((config?.isNew || config?.hasDirtyAttributes) && !config?.isSaving) {
+      config.unloadRecord();
+    }
+  }
+
+  @action
+  onFileUploaded(_: unknown, file: File) {
+    const type = getCertType(file.value);
+    this.file = file;
+    if (!this.configModel) return;
+    if (type === 'pem') {
+      this.configModel.pemBundle = file.value;
+      this.configModel.certificate = undefined;
+    } else {
+      this.configModel.certificate = file.value;
+      this.configModel.pemBundle = undefined;
+    }
+  }
+
+  @action submitForm(evt: HTMLElementEvent<HTMLFormElement>) {
+    evt.preventDefault();
+    if (!this.configModel) return;
+    this.configModel
+      .save()
+      .then(() => {
+        this.router.transitionTo('vault.cluster.secrets.backend.pki.issuers.index');
+      })
+      .catch((e) => {
+        this.flashMessages.danger(errorMessage(e, 'Could not import the given certificate.'));
+      });
+  }
+}

--- a/ui/lib/pki/addon/components/pki-configure-form.hbs
+++ b/ui/lib/pki/addon/components/pki-configure-form.hbs
@@ -27,7 +27,9 @@
       </div>
     {{/each}}
   </div>
-  {{#if this.configType}}
+  {{#if (eq this.configType "import")}}
+    <PkiConfig::Import />
+  {{else if this.configType}}
     {{! TODO: Forms }}
   {{else}}
     <EmptyState @title="Choose an option" @message="To see configuration options, choose your desired output above." />

--- a/ui/lib/pki/addon/components/pki-role-generate.ts
+++ b/ui/lib/pki/addon/components/pki-role-generate.ts
@@ -8,32 +8,13 @@ import { tracked } from '@glimmer/tracking';
 import errorMessage from 'vault/utils/error-message';
 import FlashMessageService from 'vault/services/flash-messages';
 import DownloadService from 'vault/services/download';
+import PkiCertificateGenerateModel from 'vault/models/pki/certificate/generate';
 
 interface Args {
   onSuccess: CallableFunction;
   model: PkiCertificateGenerateModel;
 }
 
-interface PkiCertificateGenerateModel {
-  name: string;
-  backend: string;
-  serialNumber: string;
-  certificate: string;
-  formFields: FormField[];
-  formFieldsGroup: {
-    [k: string]: FormField[];
-  }[];
-  save: () => void;
-  rollbackAttributes: () => void;
-  unloadRecord: () => void;
-  destroyRecord: () => void;
-  canRevoke: boolean;
-}
-interface FormField {
-  name: string;
-  type: string;
-  options: unknown;
-}
 export default class PkiRoleGenerate extends Component<Args> {
   @service declare readonly router: Router;
   @service declare readonly store: Store;

--- a/ui/lib/pki/addon/templates/issuers/index.hbs
+++ b/ui/lib/pki/addon/templates/issuers/index.hbs
@@ -39,7 +39,11 @@
 </Toolbar>
 {{#if this.model.issuersModel.length}}
   {{#each this.model.issuersModel as |pkiIssuer|}}
-    <LinkedBlock class="list-item-row" @params={{array "roles.role.details" pkiIssuer.id}} @linkPrefix={{this.mountPoint}}>
+    <LinkedBlock
+      class="list-item-row"
+      @params={{array "issuers.issuer.details" pkiIssuer.id}}
+      @linkPrefix={{this.mountPoint}}
+    >
       <div class="level is-mobile">
         <div class="level-left">
           <div>
@@ -63,12 +67,12 @@
               <nav class="menu" aria-label="issuer config options">
                 <ul class="menu-list">
                   <li>
-                    <LinkTo @route="roles.role.details" @model={{pkiIssuer.id}}>
+                    <LinkTo @route="issuers.issuer.details" @model={{pkiIssuer.id}}>
                       Details
                     </LinkTo>
                   </li>
                   <li>
-                    <LinkTo @route="roles.role.edit" @model={{pkiIssuer.id}}>
+                    <LinkTo @route="issuers.issuer.edit" @model={{pkiIssuer.id}}>
                       Edit
                     </LinkTo>
                   </li>

--- a/ui/tests/integration/components/text-file-test.js
+++ b/ui/tests/integration/components/text-file-test.js
@@ -9,6 +9,7 @@ const SELECTORS = {
   toggle: '[data-test-text-toggle]',
   textarea: '[data-test-text-file-textarea]',
   fileUpload: '[data-test-text-file-input]',
+  subText: '[data-test-text-file-subtext]',
 };
 module('Integration | Component | text-file', function (hooks) {
   setupRenderingTest(hooks);
@@ -21,14 +22,19 @@ module('Integration | Component | text-file', function (hooks) {
 
   test('it renders with or without label', async function (assert) {
     this.set('inputOnly', false);
+    this.set('subText', 'Some description here');
 
     await render(
-      hbs`<TextFile @file={{this.file}} @onChange={{this.onChange}} @inputOnly={{this.inputOnly}} />`
+      hbs`<TextFile @file={{this.file}} @onChange={{this.onChange}} @inputOnly={{this.inputOnly}} @subText={{this.subText}} />`
     );
 
     assert.dom(SELECTORS.label).hasText('File', 'renders default label');
     assert.dom(SELECTORS.toggle).exists({ count: 1 }, 'toggle exists');
     assert.dom(SELECTORS.fileUpload).exists({ count: 1 }, 'File input shown');
+    assert.dom(SELECTORS.subText).hasText('Some description here');
+
+    this.set('subText', '');
+    assert.dom(SELECTORS.subText).doesNotExist();
 
     this.set('inputOnly', true);
 

--- a/ui/tests/integration/components/text-file-test.js
+++ b/ui/tests/integration/components/text-file-test.js
@@ -1,0 +1,49 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'vault/tests/helpers';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+const SELECTORS = {
+  label: '[data-test-text-file-label]',
+  toggle: '[data-test-text-toggle]',
+  textarea: '[data-test-text-file-textarea]',
+  fileUpload: '[data-test-text-file-input]',
+};
+module('Integration | Component | text-file', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.set('label', 'Some label');
+    this.set('file', {});
+    this.set('onChange', sinon.spy());
+  });
+
+  test('it renders with or without label', async function (assert) {
+    this.set('inputOnly', false);
+
+    await render(
+      hbs`<TextFile @file={{this.file}} @onChange={{this.onChange}} @inputOnly={{this.inputOnly}} />`
+    );
+
+    assert.dom(SELECTORS.label).hasText('File', 'renders default label');
+    assert.dom(SELECTORS.toggle).exists({ count: 1 }, 'toggle exists');
+    assert.dom(SELECTORS.fileUpload).exists({ count: 1 }, 'File input shown');
+
+    this.set('inputOnly', true);
+
+    assert.dom(SELECTORS.label).doesNotExist('Label no longer rendered');
+    assert.dom(SELECTORS.toggle).doesNotExist('toggle no longer rendered');
+    assert.dom(SELECTORS.fileUpload).exists({ count: 1 }, 'File input shown');
+  });
+
+  test('it toggles between upload and textarea', async function (assert) {
+    await render(hbs`<TextFile @file={{this.file}} @onChange={{this.onChange}} />`);
+
+    assert.dom(SELECTORS.fileUpload).exists({ count: 1 }, 'File input shown');
+    assert.dom(SELECTORS.textarea).doesNotExist('Texarea hidden');
+    await click(SELECTORS.toggle);
+    assert.dom(SELECTORS.textarea).exists({ count: 1 }, 'Textarea shown');
+    assert.dom(SELECTORS.fileUpload).doesNotExist('File upload hidden');
+  });
+});

--- a/ui/types/ember-data/types/registries/model.d.ts
+++ b/ui/types/ember-data/types/registries/model.d.ts
@@ -1,6 +1,12 @@
-/**
- * Catch-all for ember-data.
- */
-export default interface ModelRegistry {
-  [key: string]: any;
+import Model from '@ember-data/model';
+import PkiCertificateGenerateModel from 'vault/models/pki/certificate/generate';
+import PkiConfigImportModel from 'vault/models/pki/config/import';
+
+declare module 'ember-data/types/registries/model' {
+  export default interface ModelRegistry {
+    'pki/config/import': PkiConfigImportModel;
+    'pki/certificate/generate': PkiCertificateGenerateModel;
+    // Catchall for any other models
+    [key: string]: any;
+  }
 }

--- a/ui/types/vault/app-types.ts
+++ b/ui/types/vault/app-types.ts
@@ -1,0 +1,6 @@
+// Type that comes back from expandAttributeMeta
+export interface FormField {
+  name: string;
+  type: string;
+  options: unknown;
+}

--- a/ui/types/vault/models/pki/certificate/generate.d.ts
+++ b/ui/types/vault/models/pki/certificate/generate.d.ts
@@ -1,0 +1,13 @@
+import Model from '@ember-data/model';
+import { FormField } from 'vault/app-types';
+
+export default class PkiCertificateGenerateModel extends Model {
+  name: string;
+  backend: string;
+  serialNumber: string;
+  certificate: string;
+  formFields: FormField[];
+  formFieldsGroup: {
+    [k: string]: FormField[];
+  }[];
+}

--- a/ui/types/vault/models/pki/config/import.d.ts
+++ b/ui/types/vault/models/pki/config/import.d.ts
@@ -1,0 +1,9 @@
+import Model from '@ember-data/model';
+
+export default class PkiConfigImportModel extends Model {
+  backend: string;
+  secretMountPath: unknown;
+  importFile: string;
+  pemBundle: string;
+  certificate: string;
+}


### PR DESCRIPTION
This PR adds the "Import CA" form for PKI Configuration. 

It also fixes the icon button styling for `.masked-input-toggle` which made the icon way too small:
<img width="739" alt="Icon button before changes" src="https://user-images.githubusercontent.com/82459713/207722725-c31434b8-4074-4065-95dd-13b7b2024dfc.png">

## Screenshots of changes:

**Existing config landing screen**
<img width="1285" alt="Existing config landing screen" src="https://user-images.githubusercontent.com/82459713/207722928-08c77601-45c6-43ce-8f47-c47a9bd0a2f0.png">
**After you choose Import and add a file**
<img width="1285" alt="After you choose Import" src="https://user-images.githubusercontent.com/82459713/207722935-74100685-3f2c-4706-8911-9f2f243c025b.png">
**Redirects to issuers on success**
<img width="1285" alt="Redirects to issuers on success" src="https://user-images.githubusercontent.com/82459713/207722938-90326ff6-d03e-4549-b122-1e6e0d27cfb5.png">

