### PR TITLE
Docs: Fix link in Lambda Extensions

### DIFF
--- a/website/content/docs/platform/aws/lambda-extension.mdx
+++ b/website/content/docs/platform/aws/lambda-extension.mdx
@@ -53,7 +53,7 @@ to read secrets, which can both be used side-by-side:
 - An instance of Vault accessible from AWS Lambda
 - An authenticated `vault` client
 - A secret in Vault that you want your Lambda to access, and a policy giving read access to it
-- Your Lambda function must use one of the [supported runtimes][https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html] for extensions
+- Your Lambda function must use one of the [supported runtimes](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html) for extensions
 
 #### Step 1. Configure Vault
 


### PR DESCRIPTION
The supported runtimes link is not rendering properly due to incorrect Markdown.