### PR TITLE
Fix SHA1 patch for Go 1.19.4; patch test

### DIFF
--- a/builtin/credential/aws/pkcs7/sign.go
+++ b/builtin/credential/aws/pkcs7/sign.go
@@ -12,7 +12,13 @@ import (
 	"fmt"
 	"math/big"
 	"time"
+
+	"github.com/hashicorp/vault/internal"
 )
+
+func init() {
+	internal.PatchSha1()
+}
 
 // SignedData is an opaque data structure for creating signed data payloads
 type SignedData struct {

--- a/internal/go118_sha1_patch.go
+++ b/internal/go118_sha1_patch.go
@@ -26,6 +26,15 @@ var debugAllowSHA1 bool
 // TODO: remove when Vault <=1.11 is no longer supported
 func PatchSha1() {
 	patchSha1.Do(func() {
+		// for Go 1.19.4 and later
+		godebug := os.Getenv("GODEBUG")
+		if godebug != "" {
+			godebug += ","
+		}
+		godebug += "x509sha1=1"
+		os.Setenv("GODEBUG", godebug)
+
+		// for Go 1.19.3 and earlier, patch the variable
 		patchBefore, err := goversion.NewSemver(sha1PatchVersionsBefore)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Bad news: the hot patch we were using breaks in Go 1.19.4: https://github.com/golang/go/commit/6109c07ec4cf2b26eba9441ad5148f8dcb8c6497

Good news: we can now patch with an environment variable at runtime.