### PR TITLE
docs: highlight paragraph about default path in kv secrets engines docs.

### DIFF
--- a/website/content/api-docs/secret/kv/kv-v1.mdx
+++ b/website/content/api-docs/secret/kv/kv-v1.mdx
@@ -10,7 +10,7 @@ This is the API documentation for the Vault KV secrets engine. For general
 information about the usage and operation of the kv secrets engine, please
 see the [Vault kv documentation](/docs/secrets/kv).
 
-This documentation assumes the kv secrets engine is enabled at the
+~> Note: This documentation assumes the kv secrets engine is enabled at the
 `/secret` path in Vault. Since it is possible to enable secrets engines at any
 location, please update your API calls accordingly.
 

--- a/website/content/api-docs/secret/kv/kv-v2.mdx
+++ b/website/content/api-docs/secret/kv/kv-v2.mdx
@@ -11,7 +11,7 @@ versioned mode. For general information about the usage and operation of the kv
 secrets engine, please see the [Vault kv
 documentation](/docs/secrets/kv).
 
-This documentation assumes the kv secrets engine is enabled at the
+~> Note: This documentation assumes the kv secrets engine is enabled at the
 `/secret` path in Vault and that versioning has been enabled. Since it is
 possible to enable secrets engines at any location, please update your API calls
 accordingly.


### PR DESCRIPTION
For kv secrets enving version 1 and 2 docs, highlight the fact that the secrets engine is enabled at `/secret` path. 

https://github.com/hashicorp/vault/issues/17425