### PR TITLE
VAULT-11862 Kubernetes acceptance tests

### DIFF
--- a/ui/lib/kubernetes/addon/components/page/credentials.hbs
+++ b/ui/lib/kubernetes/addon/components/page/credentials.hbs
@@ -2,11 +2,11 @@
   <p.top>
     <nav class="breadcrumb" aria-label="breadcrumbs">
       <ul>
-        <li>
+        <li data-test-crumb="overview">
           <span class="sep">/</span>
           <LinkTo @route="overview">{{@backend}}</LinkTo>
         </li>
-        <li>
+        <li data-test-crumb="roles">
           <span class="sep">/</span>
           <LinkTo @route="roles">roles</LinkTo>
         </li>
@@ -128,6 +128,7 @@
           type="button"
           disabled={{this.fetchCredentials.isRunning}}
           {{on "click" this.cancel}}
+          data-test-generate-credentials-back
         >
           Back
         </button>

--- a/ui/lib/kubernetes/addon/components/page/overview.hbs
+++ b/ui/lib/kubernetes/addon/components/page/overview.hbs
@@ -41,6 +41,7 @@
             type="button"
             disabled={{not this.selectedRole}}
             {{on "click" this.generateCredential}}
+            data-test-generate-credential-button
           >
             Generate
           </button>

--- a/ui/mirage/scenarios/kubernetes.js
+++ b/ui/mirage/scenarios/kubernetes.js
@@ -1,6 +1,8 @@
-export default function (server) {
+export default function (server, shouldConfigureRoles = true) {
   server.create('kubernetes-config', { path: 'kubernetes' });
-  server.create('kubernetes-role');
-  server.create('kubernetes-role', 'withRoleName');
-  server.create('kubernetes-role', 'withRoleRules');
+  if (shouldConfigureRoles) {
+    server.create('kubernetes-role');
+    server.create('kubernetes-role', 'withRoleName');
+    server.create('kubernetes-role', 'withRoleRules');
+  }
 }

--- a/ui/tests/acceptance/secrets/backend/kubernetes/configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/kubernetes/configuration-test.js
@@ -1,0 +1,51 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import kubernetesScenario from 'vault/mirage/scenarios/kubernetes';
+import ENV from 'vault/config/environment';
+import authPage from 'vault/tests/pages/auth';
+import { visit, click, currentRouteName } from '@ember/test-helpers';
+
+module('Acceptance | kubernetes | configuration', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.before(function () {
+    ENV['ember-cli-mirage'].handler = 'kubernetes';
+  });
+  hooks.beforeEach(function () {
+    kubernetesScenario(this.server);
+    this.visitConfiguration = () => {
+      return visit('/vault/secrets/kubernetes/kubernetes/configuration');
+    };
+    this.validateRoute = (assert, route, message) => {
+      assert.strictEqual(currentRouteName(), `vault.cluster.secrets.backend.kubernetes.${route}`, message);
+    };
+    return authPage.login();
+  });
+  hooks.after(function () {
+    ENV['ember-cli-mirage'].handler = null;
+  });
+
+  test('it should transition to configure page on Edit Configuration click from toolbar', async function (assert) {
+    assert.expect(1);
+    await this.visitConfiguration();
+    await click('[data-test-toolbar-config-action]');
+    this.validateRoute(assert, 'configure', 'Transitions to Configure route on click');
+  });
+  test('it should transition to the configuration page on Save click in Configure', async function (assert) {
+    assert.expect(1);
+    await this.visitConfiguration();
+    await click('[data-test-toolbar-config-action]');
+    await click('[data-test-config-save]');
+    await click('[data-test-config-confirm]');
+    this.validateRoute(assert, 'configuration', 'Transitions to Configuration route on click');
+  });
+  test('it should transition to the configuration page on Cancel click in Configure', async function (assert) {
+    assert.expect(1);
+    await this.visitConfiguration();
+    await click('[data-test-toolbar-config-action]');
+    await click('[data-test-config-cancel]');
+    this.validateRoute(assert, 'configuration', 'Transitions to Configuration route on click');
+  });
+});

--- a/ui/tests/acceptance/secrets/backend/kubernetes/credentials-test.js
+++ b/ui/tests/acceptance/secrets/backend/kubernetes/credentials-test.js
@@ -1,0 +1,77 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import kubernetesScenario from 'vault/mirage/scenarios/kubernetes';
+import ENV from 'vault/config/environment';
+import authPage from 'vault/tests/pages/auth';
+import { fillIn, visit, click, currentRouteName } from '@ember/test-helpers';
+
+module('Acceptance | kubernetes | credentials', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.before(function () {
+    ENV['ember-cli-mirage'].handler = 'kubernetes';
+  });
+  hooks.beforeEach(function () {
+    kubernetesScenario(this.server);
+    this.visitRoleCredentials = () => {
+      return visit('/vault/secrets/kubernetes/kubernetes/roles/role-0/credentials');
+    };
+    this.validateRoute = (assert, route, message) => {
+      assert.strictEqual(currentRouteName(), `vault.cluster.secrets.backend.kubernetes.${route}`, message);
+    };
+    return authPage.login();
+  });
+  hooks.after(function () {
+    ENV['ember-cli-mirage'].handler = null;
+  });
+
+  test('it should have correct breadcrumb links in credentials view', async function (assert) {
+    assert.expect(3);
+    await this.visitRoleCredentials();
+    await click('[data-test-crumb="details"] a');
+    this.validateRoute(assert, 'roles.role.details', 'Transitions to role details route on breadcrumb click');
+    await this.visitRoleCredentials();
+    await click('[data-test-crumb="roles"] a');
+    this.validateRoute(assert, 'roles.index', 'Transitions to roles route on breadcrumb click');
+    await this.visitRoleCredentials();
+    await click('[data-test-crumb="overview"] a');
+    this.validateRoute(assert, 'overview', 'Transitions to overview route on breadcrumb click');
+  });
+
+  test('it should transition to role details view on Back click', async function (assert) {
+    assert.expect(1);
+    await this.visitRoleCredentials();
+    await click('[data-test-generate-credentials-back]');
+
+    await this.validateRoute(assert, 'roles.role.details', 'Transitions to role details on Back click');
+  });
+
+  test('it should transition to role details view on Done click', async function (assert) {
+    assert.expect(1);
+    await this.visitRoleCredentials();
+    this.server.post('/kubernetes-test/creds/role-0', () => {
+      assert.ok('POST request made to generate credentials');
+      return {
+        request_id: '58fefc6c-5195-c17a-94f2-8f889f3df57c',
+        lease_id: 'kubernetes/creds/default-role/aWczfcfJ7NKUdiirJrPXIs38',
+        renewable: false,
+        lease_duration: 3600,
+        data: {
+          service_account_name: 'default',
+          service_account_namespace: 'default',
+          service_account_token: 'eyJhbGciOiJSUzI1NiIsImtpZCI6Imlr',
+        },
+      };
+    });
+    await fillIn('[data-test-kubernetes-namespace]', 'kubernetes-test');
+    await click('[data-test-toggle-input]');
+    await click('[data-test-toggle-input="Time-to-Live (TTL)"]');
+    await fillIn('[data-test-ttl-value="Time-to-Live (TTL)"]', 2);
+    await click('[data-test-generate-credentials-button]');
+    await click('[data-test-generate-credentials-done]');
+
+    await this.validateRoute(assert, 'roles.role.details', 'Transitions to role details on Done click');
+  });
+});

--- a/ui/tests/acceptance/secrets/backend/kubernetes/overview-test.js
+++ b/ui/tests/acceptance/secrets/backend/kubernetes/overview-test.js
@@ -1,0 +1,64 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import kubernetesScenario from 'vault/mirage/scenarios/kubernetes';
+import ENV from 'vault/config/environment';
+import authPage from 'vault/tests/pages/auth';
+import { visit, click, currentRouteName } from '@ember/test-helpers';
+import { selectChoose } from 'ember-power-select/test-support';
+
+module('Acceptance | kubernetes | overview', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.before(function () {
+    ENV['ember-cli-mirage'].handler = 'kubernetes';
+  });
+  hooks.beforeEach(function () {
+    this.createScenario = (shouldConfigureRoles = true) =>
+      shouldConfigureRoles ? kubernetesScenario(this.server) : kubernetesScenario(this.server, false);
+
+    this.visitOverview = () => {
+      return visit('/vault/secrets/kubernetes/kubernetes/overview');
+    };
+    this.validateRoute = (assert, route, message) => {
+      assert.strictEqual(currentRouteName(), `vault.cluster.secrets.backend.kubernetes.${route}`, message);
+    };
+    return authPage.login();
+  });
+  hooks.after(function () {
+    ENV['ember-cli-mirage'].handler = null;
+  });
+
+  test('it should transition to configuration page during empty state', async function (assert) {
+    assert.expect(1);
+    await this.visitOverview();
+    await click('[data-test-component="empty-state"] a');
+    this.validateRoute(assert, 'configure', 'Transitions to Configure route on click');
+  });
+
+  test('it should transition to view roles', async function (assert) {
+    assert.expect(1);
+    this.createScenario();
+    await this.visitOverview();
+    await click('[data-test-roles-card] .is-no-underline');
+    this.validateRoute(assert, 'roles.index', 'Transitions to roles route on View Roles click');
+  });
+
+  test('it should transition to create roles', async function (assert) {
+    assert.expect(1);
+    this.createScenario(false);
+    await this.visitOverview();
+    await click('[data-test-roles-card] .is-no-underline');
+    this.validateRoute(assert, 'roles.create', 'Transitions to roles route on Create Roles click');
+  });
+
+  test('it should transition to generate credentials', async function (assert) {
+    assert.expect(1);
+    await this.createScenario();
+    await this.visitOverview();
+    await selectChoose('.search-select', 'role-0');
+    await click('[data-test-generate-credential-button]');
+    this.validateRoute(assert, 'roles.role.credentials', 'Transitions to roles route on Generate click');
+  });
+});


### PR DESCRIPTION
Acceptance tests for Kubernetes secrets engine workflows. The acceptance tests mainly tests for links and buttons that transition to different pages.

VAULT-12185 Acceptance test for overview
VAULT-12186 Acceptance test for configuration
VAULT-12298 Acceptance test for credentials
