### PR TITLE
Update the notes about Consul Connect CA issue

### DIFF
--- a/website/content/docs/release-notes/1.11.0.mdx
+++ b/website/content/docs/release-notes/1.11.0.mdx
@@ -104,17 +104,9 @@ Previously, KMIP did not support certain operations such as import, decrypt, enc
 
 ## Known issues
 
-If any version of Consul attempts to use Vault 1.11.0 or later as Consul’s Connect CA provider, the intermediate CA will become unable to issue the leaf certificates needed by:
+When you use Vault 1.11.0+ as a Consul's Connect CA, you may encounter an issue generating the leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade your [Consul version that includes the fix](https://support.hashicorp.com/hc/en-us/articles/11308460105491#01GMC24E6PPGXMRX8DMT4HZYTW) to avoid running into this problem. 
 
-- Service mesh: Services in the mesh to communicate with mTLS
-- All use cases: Consul client agents if using [auto-encrypt](/consul/docs/agent/config/config-files#auto_encrypt) or [auto-config](/consul/docs/agent/config/config-files#auto_config), and using [TLS to communicate with Consul server agents](/consul/docs/agent/config/config-files#tls-configuration-reference)
- 
-You are using the Vault CA provider if either of the following configurations exists:
-
-- The Consul server agent configuration option [connect.ca_provider](/consul/docs/agent/config/config-files#connect_ca_provider) is set to “vault”, or
-- The Consul on Kubernetes Helm Chart [global.secretsBackend.vault.connectCA](/consul/docs/k8s/helm#v-global-secretsbackend-vault-connectca) value is configured.
-
--> **NOTE:** Refer to the [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more information about the underlying cause and recommended workaround.
+-> Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
 
 ## Feature Deprecations and EOL
 

--- a/website/content/docs/secrets/pki/index.mdx
+++ b/website/content/docs/secrets/pki/index.mdx
@@ -8,13 +8,7 @@ description: The PKI secrets engine for Vault generates TLS certificates.
 
 @include 'x509-sha1-deprecation.mdx'
 
-!> **Vault 1.11.0+ incompatible as Consul CA provider:** Do not use [Vault
-v1.11.0+](/vault/docs/release-notes/1.11.0#known-issues) as Consul’s Connect CA
-provider — the intermediate CA will become unable to issue the leaf nodes required by service mesh,
-and by Consul client agents if using auto-encrypt or auto-config and using TLS for agent communication.
-If you are already using Vault 1.11+ as a Connect CA, refer to this [Knowledge Base
-article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for
-more information about the underlying cause and recommended workaround.
+-> **Vault as Consul CA provider:** If you are using Vault 1.11.0+ as a Connect CA, run a Consul version which includese the fix for [GH-15525](https://github.com/hashicorp/consul/pull/15525). Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
 
 The PKI secrets engine generates dynamic X.509 certificates. With this secrets
 engine, services can get certificates without going through the usual manual


### PR DESCRIPTION
🧵 [Slack thread](https://hashicorp.slack.com/archives/C04B4TAEQ6L/p1671143425042579)

Now that Consul patch is available, this PR updates:

- Release notes for Vault 1.11.0 (🔍 [Deploy Preview](https://vault-git-docs-update-release-notes-111-hashicorp.vercel.app/vault/docs/release-notes/1.11.0#known-issues))
- Notes on the PKI Secrets Engine (🔍 [Deploy Preview](https://vault-git-docs-update-release-notes-111-hashicorp.vercel.app/vault/docs/secrets/pki))