### PR TITLE
Fix the checkout sha for enos-run workflow

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -73,6 +73,8 @@ jobs:
       MATRIX_TEST_GROUP: ${{ inputs.matrix-test-group }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.vault-revision }}
       - id: metadata
         run: |
           echo "build-date=$(make ci-get-date)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
- enos-run workflow will checkout the `main` branch by default, which would pass incorrect metadata to the workflow so we use the `revision` passed by the calling workflow to checkout the sha and get the relavant metadata`

Signed-off-by: Jaymala Sinha <jaymala@hashicorp.com>