### PR TITLE
UI: Fix mount backend type-form enterprise test

### DIFF
--- a/ui/tests/integration/components/mount-backend/type-form-test.js
+++ b/ui/tests/integration/components/mount-backend/type-form-test.js
@@ -60,8 +60,7 @@ module('Integration | Component | mount-backend/type-form', function (hooks) {
     });
 
     test('it renders correct items for enterprise secrets', async function (assert) {
-      await render(hbs`<MountBackend::TypeForm @setMountType={{this.setType}} />`);
-
+      await render(hbs`<MountBackend::TypeForm @mountType="secret" @setMountType={{this.setType}} />`);
       assert
         .dom('[data-test-mount-type]')
         .exists({ count: allSecretTypes.length }, 'Renders all secret engines');


### PR DESCRIPTION
One of the mount-backend/type-form tests were failing but only runs on enterprise