### PR TITLE
Add issuer reference info on JSON endpoint

### DIFF
--- a/builtin/logical/pki/ca_test.go
+++ b/builtin/logical/pki/ca_test.go
@@ -304,6 +304,14 @@ func runSteps(t *testing.T, rootB, intB *backend, client *api.Client, rootName, 
 			if path == "issuer/default/json" {
 				// Preserves the new line.
 				expected += "\n"
+				_, present := resp.Data["issuer_id"]
+				if !present {
+					t.Fatalf("expected issuer/default/json to include issuer_id")
+				}
+				_, present = resp.Data["issuer_name"]
+				if !present {
+					t.Fatalf("expected issuer/default/json to include issuer_name")
+				}
 			}
 			if diff := deep.Equal(resp.Data["certificate"].(string), expected); diff != nil {
 				t.Fatal(diff)

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -841,6 +841,8 @@ func (b *backend) pathGetRawIssuer(ctx context.Context, req *logical.Request, da
 			Data: map[string]interface{}{
 				"certificate": string(certificate),
 				"ca_chain":    issuer.CAChain,
+				"issuer_id":   issuer.ID,
+				"issuer_name": issuer.Name,
 			},
 		}, nil
 	}

--- a/changelog/18482.txt
+++ b/changelog/18482.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Return issuer_id and issuer_name on /issuer/:issuer_ref/json endpoint.
+```


### PR DESCRIPTION
This endpoint is unauthenticated and shouldn't contain sensitive information. However, listing the issuers (`LIST /issuers`) already returns both the issuer ID and the issuer name (if any) so this information is safe to return here.

When fetching `/pki/issuer/default/json`, it would be nice to know exactly which issuer ID and name it corresponds to, without having to fetch the authenticated endpoint as well.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`