### PR TITLE
Add vault pki command website documentation

### DIFF
--- a/website/content/docs/commands/pki/index.mdx
+++ b/website/content/docs/commands/pki/index.mdx
@@ -1,0 +1,32 @@
+---
+layout: docs
+page_title: pki - Command
+description: |-
+  The "pki" command groups subcommands for interacting with Vault's PKI
+  secrets engine.
+---
+
+# pki
+
+The `pki` command groups subcommands for interacting with Vault's
+[PKI Secrets Engine](/docs/secrets/pki).
+
+## Syntax
+
+Option flags for a given subcommand are provided after the subcommand, but before the arguments.
+
+## Examples
+
+To [health check](/docs/commands/pki/health-check) a mount, use the
+`vault pki health-check <mount>` command:
+
+```
+$ vault pki health-check pki
+ca_validity_period
+------------------
+status    endpoint                                            message
+------    --------                                            -------
+ok        /pki/issuer/da41ffb1-cc6d-5a5c-f147-e4d7beeb1b73    Issuer's validity (2032-12-17) is OK
+
+... more output elided ...
+```

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -544,6 +544,15 @@
         ]
       },
       {
+        "title": "<code>pki</code>",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "commands/pki"
+          }
+        ]
+      },
+      {
         "title": "<code>lease</code>",
         "routes": [
           {


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

This starts a new section of the docs for the `vault pki` top-level command. Health check docs will come in a separate PR, this is just to get started so Kit and I don't conflict too much while writing docs. 