### PR TITLE
secrets/gcp: add documentation for impersonated accounts feature

### DIFF
--- a/website/content/api-docs/secret/gcp.mdx
+++ b/website/content/api-docs/secret/gcp.mdx
@@ -493,7 +493,7 @@ impersonated account.
 - `token_scopes` (`array: []`): List of OAuth scopes to assign to access tokens
   generated under this impersonation account.
 - `ttl` (`duration: ""`): Lifetime of the token generated. Defaults to 1 hour and
-  is limited to a maximum of 12 hours.
+  is limited to a maximum of 12 hours. Uses [duration format strings](/docs/concepts/duration-format).
 
 ### Sample Payload
 

--- a/website/content/api-docs/secret/gcp.mdx
+++ b/website/content/api-docs/secret/gcp.mdx
@@ -636,24 +636,6 @@ $ curl \
     https://127.0.0.1:8200/v1/gcp/roleset/my-token-roleset/token
 ```
 
-### Sample Response
-
-```json
-{
-  "request_id": "<uuid>",
-  "data": {
-    "token": "ya29.c.Elp5Be3ga87...",
-    "expires_at_seconds": 1537400046,
-    "token_ttl": 3599
-  },
-  "wrap_info": null,
-  "warnings": null,
-  "auth": null
-}
-```
-
-### Sample Request
-
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
@@ -666,9 +648,9 @@ $ curl \
 ```json
 {
   "request_id": "<uuid>",
-  "data": 
-    "token": "ya29.c.b0AT7lpjB11...",
-    "expires_at_seconds": 1671671465,
+  "data": {
+    "token": "ya29.c.Elp5Be3ga87...",
+    "expires_at_seconds": 1537400046,
     "token_ttl": 3599
   },
   "wrap_info": null,

--- a/website/content/api-docs/secret/gcp.mdx
+++ b/website/content/api-docs/secret/gcp.mdx
@@ -629,6 +629,7 @@ do not apply.
 
 ### Sample Request
 
+**Roleset:**
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
@@ -636,6 +637,15 @@ $ curl \
     https://127.0.0.1:8200/v1/gcp/roleset/my-token-roleset/token
 ```
 
+**Static account:**
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request GET \
+    https://127.0.0.1:8200/v1/gcp/static-account/my-token-account/token
+```
+
+**Impersonated account:**
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \

--- a/website/content/api-docs/secret/gcp.mdx
+++ b/website/content/api-docs/secret/gcp.mdx
@@ -476,15 +476,144 @@ $ curl \
     https://127.0.0.1:8200/v1/gcp/static-account/my-token-account
 ```
 
+## Create/Update Impersonated Account
+
+| Method | Path                              |
+| :----- | :-------------------------------- |
+| `POST` | `/gcp/impersonated-account/:name` |
+
+This method allows you to create an impersonated account or update an existing
+impersonated account.
+
+### Parameters
+
+- `name` (`string: <required>`): Name of the impersonated account. Cannot be updated.
+- `service_account_email` (`string: <required>`): Email of the GCP service account to
+  manage. Cannot be updated.
+- `token_scopes` (`array: []`): List of OAuth scopes to assign to access tokens
+  generated under this impersonation account.
+- `ttl` (`duration: ""`): Lifetime of the token generated. Defaults to 1h by Google
+  and is limited to a maximum of 12h.
+
+### Sample Payload
+
+```json
+{
+  "service_account_email": "projectOwner@my-project.iam.gserviceaccount.com",
+  "token_scopes": [
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/bigquery"
+  ],
+  "ttl": "2h"
+}
+```
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    --data @payload.json \
+    https://127.0.0.1:8200/v1/gcp/impersonated-account/my-token-impersonate
+```
+
+## Read Impersonated Account
+
+| Method | Path                              |
+| :----- | :-------------------------------- |
+| `GET`  | `/gcp/impersonated-account/:name` |
+
+### Parameters
+
+- `name` (`string:<required>`): Name of the impersonated account to read.
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request GET \
+    https://127.0.0.1:8200/v1/gcp/impersonated-account/my-token-impersonate
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "service_account_email": "projectOwner@my-project.iam.gserviceaccount.com",
+    "service_account_project": "my-project",
+    "token_scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/bigquery"
+    ],
+    "ttl": 7200
+  },
+}
+```
+## List Impersonated Accounts
+
+This endpoint lists the configured Vault roles for impersonated accounts.
+
+| Method | Path                         |
+| :----- | :---------------------       |
+| `LIST` | `/gcp/impersonated-accounts` |
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request LIST \
+    https://127.0.0.1:8200/v1/gcp/impersonated-accounts
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "keys": [
+      "my-token-impersonate",
+      "secondary-role"
+    ]
+  }
+}
+```
+
+## Delete Static Account
+
+This endpoint deletes an existing impersonated account by the given name.
+
+| Method   | Path                              |
+| :------- | :-------------------------------- |
+| `DELETE` | `/gcp/impersonated-account/:name` |
+
+### Parameters
+
+- `name` (`string:<required>`): Name of the impersonated account to delete.
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request DELETE \
+    https://127.0.0.1:8200/v1/gcp/impersonated-account/my-token-impersonate
+```
+
 ## Generate Secret (IAM Service Account Creds): OAuth2 Access Token
 
-| Method         | Path                                        |
-| :------------- | :------------------------------------------ |
-| `GET` / `POST` | `/gcp/roleset/:roleset/token`               |
-| `GET` / `POST` | `/gcp/static-account/:static-account/token` |
-| `GET` / `POST` | `/gcp/token/:roleset` (deprecated)          |
+| Method         | Path                                                    |
+| :------------- | :------------------------------------------------------ |
+| `GET` / `POST` | `/gcp/roleset/:roleset/token`                           |
+| `GET` / `POST` | `/gcp/static-account/:static-account/token`             |
+| `GET` / `POST` | `/gcp/impersonated-account/:impersonated-account/token` |
+| `GET` / `POST` | `/gcp/token/:roleset` (deprecated)                      |
 
-Generates an OAuth2 token with the scopes defined on the roleset or static account. This OAuth access token can
+Generates an OAuth2 token with the scopes defined on the roleset, static
+account, or impersonated account. This OAuth access token can
 be used in GCP API calls, e.g. `curl -H "Authorization: Bearer $TOKEN" ...`
 
 Tokens are non-revocable and non-renewable and have a static TTL of an hour. The TTL configured

--- a/website/content/api-docs/secret/gcp.mdx
+++ b/website/content/api-docs/secret/gcp.mdx
@@ -492,8 +492,8 @@ impersonated account.
   manage. Cannot be updated.
 - `token_scopes` (`array: []`): List of OAuth scopes to assign to access tokens
   generated under this impersonation account.
-- `ttl` (`duration: ""`): Lifetime of the token generated. Defaults to 1h by Google
-  and is limited to a maximum of 12h.
+- `ttl` (`duration: ""`): Lifetime of the token generated. Defaults to 1 hour and
+  is limited to a maximum of 12 hours.
 
 ### Sample Payload
 
@@ -624,6 +624,8 @@ do not apply.
 
 - `roleset` (`string:<required>`): Name of an roleset with secret type `access_token` to generate access_token under.
 - `static-account` (`string:<required>`): Name of the static account with secret type `access_token` to generate access_token under.
+- `impersonated-account` (`string:<required>`): Name of the impersonated account to
+  generate access_token_under.
 
 ### Sample Request
 
@@ -642,6 +644,29 @@ $ curl \
   "data": {
     "token": "ya29.c.Elp5Be3ga87...",
     "expires_at_seconds": 1537400046,
+    "token_ttl": 3599
+  },
+  "wrap_info": null,
+  "warnings": null,
+  "auth": null
+}
+```
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request GET \
+    https://127.0.0.1:8200/v1/gcp/impersonated-account/my-token-impersonate/token
+```
+
+### Sample Response
+
+```json
+{
+  "request_id": "<uuid>",
+  "data": 
+    "token": "ya29.c.b0AT7lpjB11...",
+    "expires_at_seconds": 1671671465,
     "token_ttl": 3599
   },
   "wrap_info": null,

--- a/website/content/api-docs/secret/gcp.mdx
+++ b/website/content/api-docs/secret/gcp.mdx
@@ -582,7 +582,7 @@ $ curl \
 }
 ```
 
-## Delete Static Account
+## Delete Impersonated Account
 
 This endpoint deletes an existing impersonated account by the given name.
 

--- a/website/content/api-docs/secret/gcp.mdx
+++ b/website/content/api-docs/secret/gcp.mdx
@@ -652,6 +652,8 @@ $ curl \
 }
 ```
 
+### Sample Request
+
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \

--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -243,6 +243,7 @@ was configured, you can generate OAuth2 tokens or service account keys.
 To generate OAuth2 tokens, read from `gcp/.../token`. The role must have been
 created as type `access_token` or must be an impersonated account:
 
+**Roleset:**
 ```shell-session
 $ vault read gcp/roleset/my-token-roleset/token
 
@@ -253,6 +254,18 @@ token                 ya29.c.ElodBmNPwHUNY5gcBpnXcE4ywG4w1k...
 token_ttl             3599
 ```
 
+**Static account:**
+```shell-session
+$ vault read gcp/static-account/my-token-account/token
+
+Key                Value
+---                -----
+expires_at_seconds    1672231587
+token                 ya29.c.b0Aa9VdykAdYoW9S1ImtPZykF_oTi9...
+token_ttl             3599
+```
+
+**Impersonated account:**
 ```shell-session
 $ vault read gcp/impersonated-account/my-token-impersonate/token
 

--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -213,7 +213,7 @@ For more information on creating and managing static accounts, see the
 
 ## Impersonated Accounts
 
-Impersonated accounts are a way to generate a OAuth2 [access token](/docs/secrets/gcp#access-tokens) that is granted
+Impersonated accounts are a way to generate an OAuth2 [access token](/docs/secrets/gcp#access-tokens) that is granted
 the permissions and accesses of another given service account. These access
 tokens do not have the same 10-key limit as service account keys do, yet they
 retain their short-lived nature. By default, their TTL in GCP is 1 hour, but

--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -41,7 +41,7 @@ management tool.
 
 1.  Enable the Google Cloud secrets engine:
 
-    ```text
+    ```shell-session
     $ vault secrets enable gcp
     Success! Enabled the gcp secrets engine at: gcp/
     ```
@@ -52,7 +52,7 @@ management tool.
 1.  Configure the secrets engine with account credentials, or leave blank or unwritten
     to use Application Default Credentials.
 
-    ```text
+    ```shell-session
     $ vault write gcp/config credentials=@my-credentials.json
     Success! Data written to: gcp/config
     ```
@@ -107,7 +107,7 @@ For more more information on policy syntax, see the
 
 To configure a roleset that generates OAuth2 access tokens (preferred):
 
-```text
+```shell-session
 $ vault write gcp/roleset/my-token-roleset \
     project="my-project-id" \
     secret_type="access_token"  \
@@ -121,7 +121,7 @@ $ vault write gcp/roleset/my-token-roleset \
 
 To configure a roleset that generates GCP Service Account keys:
 
-```text
+```shell-session
 $ vault write gcp/roleset/my-key-roleset \
     project="my-project" \
     secret_type="service_account_key"  \
@@ -134,7 +134,7 @@ $ vault write gcp/roleset/my-key-roleset \
 
 Alternatively, provide a file for the `bindings` argument like so:
 
-```text
+```shell-session
 $ vault write gcp/roleset/my-roleset
     bindings=@mybindings.hcl
     ...
@@ -168,7 +168,7 @@ account you have created. Service account emails are of the format
 
 To configure a static account that generates OAuth2 access tokens (preferred):
 
-```text
+```shell-session
 $ vault write gcp/static-account/my-token-account \
     service_account_email="account@my-project.iam.gserviceaccount.com" \
     secret_type="access_token"  \
@@ -182,7 +182,7 @@ $ vault write gcp/static-account/my-token-account \
 
 To configure a static account that generates GCP Service Account keys:
 
-```text
+```shell-session
 $ vault write gcp/static-account/my-key-account \
     service_account_email="account@my-project.iam.gserviceaccount.com" \
     secret_type="service_account_key"  \
@@ -195,7 +195,7 @@ $ vault write gcp/static-account/my-key-account \
 
 Alternatively, provide a file for the `bindings` argument like so:
 
-```text
+```shell-session
 $ vault write gcp/static-account/my-account
     bindings=@mybindings.hcl
     ...

--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -245,8 +245,9 @@ was configured, you can generate OAuth2 tokens or service account keys.
 
 To generate OAuth2 [access tokens](https://cloud.google.com/docs/authentication/token-types#access),
 read from the [`gcp/.../token`](/api-docs/secret/gcp#generate-secret-iam-service-account-creds-oauth2-access-token)
-API. The roleset or static account must have been created with a [`secret_type`](/api-docs/secret/gcp#secret_type)
-of `access_token` or must be an impersonated account:
+API. If using a roleset or static account, it must have been created with a
+[`secret_type`](/api-docs/secret/gcp#secret_type) of `access_token`. Impersonated accounts will
+generate OAuth2 tokens by default.
 
 **Roleset:**
 ```shell-session

--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -214,12 +214,11 @@ For more information on creating and managing static accounts, see the
 ## Impersonated Accounts
 
 Impersonated accounts are a way to generate a GCP access token that is granted
-the permissions and accesses of another given service account, hence the name
-"impersonated". Vault can attach principals to service accounts which allows
-the creation of these access tokens as that principal. These do not have the
-same limit of 10 as service account keys do, yet retain their short-lived
-nature. By default, their TTL in GCP is 1 hour, but this may be configured to
-be up to 12 hours.
+the permissions and accesses of another given service account. These access
+tokens do not have the same 10-key limit as service account keys do, yet they
+retain their short-lived nature. By default, their TTL in GCP is 1 hour, but
+this may be configured to be up to 12 hours
+[as per Google Cloud documentation.](https://cloud.google.com/iam/docs/create-short-lived-credentials-delegated#sa-credentials-oauth)
 
 ### Examples
 
@@ -235,10 +234,8 @@ $ vault write gcp/impersonated-account/my-token-impersonate \
 
 ## Usage
 
-### Rolesets
-
 After the secrets engine is configured and a user/machine has a Vault token with
-the proper permission, it can generate credentials. Depending on how the roleset
+the proper permission, it can generate credentials. Depending on how the Vault role
 was configured, you can generate OAuth2 tokens or service account keys.
 
 ### Access Tokens
@@ -278,8 +275,8 @@ $ curl -H "Authorization: Bearer ya29.c.ElodBmNPwHUNY5gcBpnXcE4ywG4w1k..."
 
 ### Service Account Keys
 
-To generate service account keys, read from `gcp/.../key`. The roleset must have
-been created as type `service_account_key`:
+To generate service account keys, read from `gcp/.../key`. The roleset or static
+account must have been created as type `service_account_key`:
 
 ```shell-session
 $ vault read gcp/roleset/my-key-roleset/key
@@ -295,7 +292,7 @@ private_key_data    ewogICJ0eXBlIjogInNlcnZpY2VfYWNjb3VudCIsC...
 ```
 
 This endpoint generates a new [GCP IAM service account key][iam-keys] associated
-with the roleset's Service Account. When the lease expires (or is revoked
+with the role's Service Account. When the lease expires (or is revoked
 early), the Service Account key will be deleted.
 
 **There is a default limit of 10 keys per Service Account.** For more

--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -243,8 +243,10 @@ was configured, you can generate OAuth2 tokens or service account keys.
 
 ### Access Tokens
 
-To generate OAuth2 tokens, read from `gcp/.../token`. The role must have been
-created as type `access_token` or must be an impersonated account:
+To generate OAuth2 [access tokens](https://cloud.google.com/docs/authentication/token-types#access),
+read from the [`gcp/.../token`](/api-docs/secret/gcp#generate-secret-iam-service-account-creds-oauth2-access-token)
+API. The roleset or static account must have been created with a [`secret_type`](/api-docs/secret/gcp#secret_type)
+of `access_token` or must be an impersonated account:
 
 **Roleset:**
 ```shell-session

--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -488,14 +488,11 @@ iam.serviceAccountKeys.get
 iam.serviceAccountKeys.list
 ```
 
-When using static accounts, Vault must have the following permissions at the service account level:
+When using static accounts or impersonated accounts, Vault must have the following permissions
+at the service account level:
 
 ```text
-# Service account key admin
-# This is provided in the `roles/iam.serviceAccountKeyAdmin` role
-iam.serviceAccounts.get
-
-# For `access_token` secrets
+# For `access_token` secrets and impersonated accounts
 iam.serviceAccounts.getAccessToken
 
 # For `service_account_keys` secrets
@@ -528,15 +525,6 @@ compute.*.setIamPolicy
 # BigQuery Datasets
 bigquery.datasets.get
 bigquery.datasets.update
-```
-
-When using service account impersonation, Vault must have the following additional
-permissions:
-
-```text
-# impersonation
-roles/iam.serviceAccountTokenCreator
-roles/iam.workloadIdentityUser
 ```
 
 You can either:

--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -217,8 +217,11 @@ Impersonated accounts are a way to generate a OAuth2 [access token](/docs/secret
 the permissions and accesses of another given service account. These access
 tokens do not have the same 10-key limit as service account keys do, yet they
 retain their short-lived nature. By default, their TTL in GCP is 1 hour, but
-this may be configured to be up to 12 hours
-[as per Google Cloud documentation.](https://cloud.google.com/iam/docs/create-short-lived-credentials-delegated#sa-credentials-oauth)
+this may be configured to be up to 12 hours as explained in Google's 
+[short-lived credentials documentation.](https://cloud.google.com/iam/docs/create-short-lived-credentials-delegated#sa-credentials-oauth)
+
+For more information regarding service account impersonation in GCP, consider starting
+with their documentation [available here.](https://cloud.google.com/iam/docs/impersonating-service-accounts)
 
 ### Examples
 

--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -264,7 +264,7 @@ token_ttl             59m59s
 ```
 
 This endpoint generates a non-renewable, non-revocable static OAuth2 access token
-with a lifetime of one hour, where `token_ttl` is given in seconds and the
+with a max lifetime of one hour, where `token_ttl` is given in seconds and the
 `expires_at_seconds` is the expiry time for the token, given as a Unix timestamp.
 The `token` value then can be used as a HTTP Authorization Bearer token in requests
 to GCP APIs:

--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -211,7 +211,31 @@ below.
 For more information on creating and managing static accounts, see the
 [GCP secrets engine API docs][api] docs.
 
+## Impersonated Accounts
+
+Impersonated accounts are a way to generate a GCP access token that is granted
+the permissions and accesses of another given service account, hence the name
+"impersonated". Vault can attach principals to service accounts which allows
+the creation of these access tokens as that principal. These do not have the
+same limit of 10 as service account keys do, yet retain their short-lived
+nature. By default, their TTL in GCP is 1 hour, but this may be configured to
+be up to 12 hours.
+
+### Examples
+
+To configure a Vault role that impersonates the administrator on the Google
+Cloud project with the cloud platform and compute scopes:
+
+```shell-session
+$ vault write gcp/impersonated-account/my-token-impersonate \
+    service_account_email="projectAdmin@my-project.iam.gserviceaccount.com" \
+    token_scopes="https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/compute" \
+    ttl="6h"
+```
+
 ## Usage
+
+### Rolesets
 
 After the secrets engine is configured and a user/machine has a Vault token with
 the proper permission, it can generate credentials. Depending on how the roleset
@@ -219,8 +243,8 @@ was configured, you can generate OAuth2 tokens or service account keys.
 
 ### Access Tokens
 
-To generate OAuth2 tokens, read from `gcp/token/...`. The roleset must have been
-created as type `access_token`:
+To generate OAuth2 tokens, read from `gcp/.../token`. The role must have been
+created as type `access_token` or must be an impersonated account:
 
 ```shell-session
 $ vault read gcp/roleset/my-token-roleset/token
@@ -230,6 +254,16 @@ Key                Value
 expires_at_seconds    1537402548
 token                 ya29.c.ElodBmNPwHUNY5gcBpnXcE4ywG4w1k...
 token_ttl             3599
+```
+
+```shell-session
+$ vault read gcp/impersonated-account/my-token-impersonate/token
+
+Key                Value
+---                -----
+expires_at_seconds    1671667844
+token                 ya29.c.b0AT7lpjBRmO7ghBEyMV18evd016hq...
+token_ttl             59m59s
 ```
 
 This endpoint generates a non-renewable, non-revocable static OAuth2 access token
@@ -244,7 +278,7 @@ $ curl -H "Authorization: Bearer ya29.c.ElodBmNPwHUNY5gcBpnXcE4ywG4w1k..."
 
 ### Service Account Keys
 
-To generate service account keys, read from `gcp/key/...`. The roleset must have
+To generate service account keys, read from `gcp/.../key`. The roleset must have
 been created as type `service_account_key`:
 
 ```shell-session
@@ -455,7 +489,7 @@ iam.serviceAccountKeys.get
 iam.serviceAccountKeys.list
 ```
 
-When using rolesets or static accounts with bindings,  Vault must have the following permissions:
+When using rolesets or static accounts with bindings, Vault must have the following permissions:
 
 ```text
 # IAM Policy Changes
@@ -478,6 +512,15 @@ compute.*.setIamPolicy
 # BigQuery Datasets
 bigquery.datasets.get
 bigquery.datasets.update
+```
+
+When using service account impersonation, Vault must have the following additional
+permissions:
+
+```text
+# impersonation
+roles/iam.serviceAccountTokenCreator
+roles/iam.workloadIdentityUser
 ```
 
 You can either:

--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -213,7 +213,7 @@ For more information on creating and managing static accounts, see the
 
 ## Impersonated Accounts
 
-Impersonated accounts are a way to generate a GCP access token that is granted
+Impersonated accounts are a way to generate a OAuth2 [access token](/docs/secrets/gcp#access-tokens) that is granted
 the permissions and accesses of another given service account. These access
 tokens do not have the same 10-key limit as service account keys do, yet they
 retain their short-lived nature. By default, their TTL in GCP is 1 hour, but

--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -218,10 +218,10 @@ the permissions and accesses of another given service account. These access
 tokens do not have the same 10-key limit as service account keys do, yet they
 retain their short-lived nature. By default, their TTL in GCP is 1 hour, but
 this may be configured to be up to 12 hours as explained in Google's 
-[short-lived credentials documentation.](https://cloud.google.com/iam/docs/create-short-lived-credentials-delegated#sa-credentials-oauth)
+[short-lived credentials documentation](https://cloud.google.com/iam/docs/create-short-lived-credentials-delegated#sa-credentials-oauth).
 
 For more information regarding service account impersonation in GCP, consider starting
-with their documentation [available here.](https://cloud.google.com/iam/docs/impersonating-service-accounts)
+with their documentation [available here](https://cloud.google.com/iam/docs/impersonating-service-accounts).
 
 ### Examples
 


### PR DESCRIPTION
Adds docs and api-docs coverage for GCP secrets engine service account impersonation.