### PR TITLE
Turn off undo logs for enos auto-upgrade scenario pre-v1.13

### DIFF
--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -40,7 +40,7 @@ scenario "autopilot" {
       arm64 = "t4g.small"
     }
 
-    enable_undo_logs = matrix.undo_logs_status == "1" && semverconstraint(var.vault_product_version, ">=1.12.0-0") ? true : false
+    enable_undo_logs = matrix.undo_logs_status == "1" && semverconstraint(var.vault_product_version, ">=1.13.0-0") ? true : false
 
     vault_instance_type = coalesce(var.vault_instance_type, local.vault_instance_types[matrix.arch])
     vault_license_path  = abspath(var.vault_license_path != null ? var.vault_license_path : joinpath(path.root, "./support/vault.hclic"))
@@ -240,7 +240,7 @@ scenario "autopilot" {
   }
 
   step "verify_undo_logs_status" {
-    skip_step = semverconstraint(var.vault_product_version, "<1.12.0-0")
+    skip_step = semverconstraint(var.vault_product_version, "<1.13.0-0")
     module    = module.vault_verify_undo_logs
     depends_on = [
       step.upgrade_vault_cluster_with_autopilot,


### PR DESCRIPTION
This turns off undo_logs for the enos autopilot scenario pre-v1.13.

**Background**

When we perform an auto-upgrade, autopilot does the following:

1. Spins up N new nodes (where N is the size of the old cluster)
2. Demotes each old follower node 1 by 1, preventing quorum from being broken. These nodes are kept unsealed and marked as non-voters.
3. Once all of the followers have been demoted, one of the new nodes is promoted to leader.  The old leader is then demoted to follower/non-voter, at which point the auto-upgrade is complete.

**Issue**

Once raft has transferred to the new nodes on 1.12.x, the WAL will contain entries with the new raft operation, which is not supported on older versions of Vault. Since we cannot anticipate every vault version in production, this means that any old node that has been upgraded to a version of vault with undo logs enabled will be unable to process the new raft operation. As a result, all old nodes will panic and immediately seal.