### PR TITLE
Add LICENSE back to pkcs7

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,14 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2015
+
+  # (OPTIONAL) A list of globs that should not have copyright/license headers.
+  # Supports doublestar glob patterns for more flexibility in defining which
+  # files or folders should be ignored
+  header_ignore = [
+    "builtin/credentials/aws/pkcs7/**",
+    "ui/node_modules/**",
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ Vagrantfile
 
 # Configs
 *.hcl
+!.copywrite.hcl
 !.release/ci.hcl
 !.release/security-scan.hcl
 !.release/linux/package/etc/vault.d/vault.hcl

--- a/builtin/credential/aws/pkcs7/LICENSE
+++ b/builtin/credential/aws/pkcs7/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Andrew Smith
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This was not copied over when the this code was
copied in https://github.com/hashicorp/vault/pull/12340.

Also adds a stub for the `.copywrite.hcl` file (for when Vault is onboarded to Copywrite) and adds the `pkcs7` and `ui/node_modules` to the ignore pattern.