### PR TITLE
Backport: 1.11.x: Don't panic on unknown raft ops (#17732)

### DIFF
--- a/changelog/17732.txt
+++ b/changelog/17732.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+storage/raft: Don't panic on unknown raft ops
+```

--- a/physical/raft/fsm.go
+++ b/physical/raft/fsm.go
@@ -92,6 +92,7 @@ type FSM struct {
 
 	localID         string
 	desiredSuffrage string
+	unknownOpTypes  sync.Map
 }
 
 // NewFSM constructs a FSM using the given directory
@@ -580,19 +581,19 @@ func (f *FSM) ApplyBatch(logs []*raft.Log) []interface{} {
 	// Do the unmarshalling first so we don't hold locks
 	var latestConfiguration *ConfigurationValue
 	commands := make([]interface{}, 0, len(logs))
-	for _, log := range logs {
-		switch log.Type {
+	for _, l := range logs {
+		switch l.Type {
 		case raft.LogCommand:
 			command := &LogData{}
-			err := proto.Unmarshal(log.Data, command)
+			err := proto.Unmarshal(l.Data, command)
 			if err != nil {
 				f.logger.Error("error proto unmarshaling log data", "error", err)
 				panic("error proto unmarshaling log data")
 			}
 			commands = append(commands, command)
 		case raft.LogConfiguration:
-			configuration := raft.DecodeConfiguration(log.Data)
-			config := raftConfigurationToProtoConfiguration(log.Index, configuration)
+			configuration := raft.DecodeConfiguration(l.Data)
+			config := raftConfigurationToProtoConfiguration(l.Index, configuration)
 
 			commands = append(commands, config)
 
@@ -601,7 +602,7 @@ func (f *FSM) ApplyBatch(logs []*raft.Log) []interface{} {
 			latestConfiguration = config
 
 		default:
-			panic(fmt.Sprintf("got unexpected log type: %d", log.Type))
+			panic(fmt.Sprintf("got unexpected log type: %d", l.Type))
 		}
 	}
 
@@ -647,7 +648,10 @@ func (f *FSM) ApplyBatch(logs []*raft.Log) []interface{} {
 							go f.restoreCb(context.Background())
 						}
 					default:
-						return fmt.Errorf("%q is not a supported transaction operation", op.OpType)
+						if _, ok := f.unknownOpTypes.Load(op.OpType); !ok {
+							f.logger.Error("unsupported transaction operation", "op", op.OpType)
+							f.unknownOpTypes.Store(op.OpType, struct{}{})
+						}
 					}
 					if err != nil {
 						return err


### PR DESCRIPTION
* Don't panic on unknown raft ops

* avoid excessive logging

* track at the struct level, not the function level

* add changelog