### PR TITLE
MongoDB - Fix write_concern param

### DIFF
--- a/changelog/18546.txt
+++ b/changelog/18546.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+database/mongodb: Fix writeConcern set to be applied to any query made on the database
+```

--- a/plugins/database/mongodb/mongodb.go
+++ b/plugins/database/mongodb/mongodb.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 	"io"
 	"strings"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/template"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
+	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 )
 

--- a/plugins/database/mongodb/mongodb.go
+++ b/plugins/database/mongodb/mongodb.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/template"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
-	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 )
 
@@ -210,9 +209,14 @@ func (m *MongoDB) DeleteUser(ctx context.Context, req dbplugin.DeleteUserRequest
 		db = "admin"
 	}
 
+	opts, err := m.getWriteConcern()
+	if err != nil {
+		return dbplugin.DeleteUserResponse{}, err
+	}
+
 	dropUserCmd := &dropUserCommand{
 		Username:     req.Username,
-		WriteConcern: writeconcern.New(writeconcern.WMajority()),
+		WriteConcern: opts.WriteConcern,
 	}
 
 	err = m.runCommandWithRetry(ctx, db, dropUserCmd)


### PR DESCRIPTION
When Vault deletes a user on a MongoDB replica, it always uses `WriteConcern = 'majority'` despite the setting in the connection configuration.

Results from the log without the fix using `write_concern="{\"W\": 1}"`:
```
{"t":{"$date":"2022-12-21T23:58:20.295+00:00"},"s":"I",  "c":"COMMAND",  "id":51803,   "ctx":"conn52","msg":"Slow query","attr":{"type":"command","ns":"admin.$cmd","appName":"mongosh 1.6.1","command":{"dropUser":"v-token-XXXXX-XXXXXXXXXXX-XXXXXX","writeConcern":{"w":"majority"},"lsid":{"id":{"$uuid":"503728f4-f4a7-45bc-bee5-cd9f36bf831b"}},"$clusterTime":{"clusterTime":{"$timestamp":{"t":1671667098,"i":1}},"signature":{"hash":{"$binary":{"base64":"AAAAAAAAAAAAAAAAAAAAAAAAAAA=","subType":"0"}},"keyId":0}},"$db":"admin","$readPreference":{"mode":"primaryPreferred"}},"numYields":0,"reslen":163,"locks":{"ParallelBatchWriterMode":{"acquireCount":{"r":2}},"FeatureCompatibilityVersion":{"acquireCount":{"r":3,"w":2}},"ReplicationStateTransition":{"acquireCount":{"w":5}},"Global":{"acquireCount":{"r":3,"w":2}},"Database":{"acquireCount":{"w":2}},"Collection":{"acquireCount":{"w":2}},"Mutex":{"acquireCount":{"r":2}}},"flowControl":{"acquireCount":2,"timeAcquiringMicros":1},"writeConcern":{"w":"majority","wtimeout":0,"provenance":"clientSupplied"},"storage":{},"remote":"172.24.0.1:62688","protocol":"op_msg","durationMillis":5}}
```

Results from the log with the fix using `write_concern="{\"W\": 1}"`:
```
{"t":{"$date":"2022-12-23T21:26:35.031+00:00"},"s":"I",  "c":"COMMAND",  "id":51803,   "ctx":"conn76","msg":"Slow query","attr":{"type":"command","ns":"admin.$cmd","appName":"mongosh 1.6.1","command":{"dropUser":"v-token-my-role-XXXXX-XXXXXXXXXXX-XXXXXX","writeConcern":{"w":1},"lsid":{"id":{"$uuid":"07037c7b-6701-4cbb-8547-4ee40ba97542"}},"$clusterTime":{"clusterTime":{"$timestamp":{"t":1671830794,"i":1}},"signature":{"hash":{"$binary":{"base64":"AAAAAAAAAAAAAAAAAAAAAAAAAAA=","subType":"0"}},"keyId":0}},"$db":"admin","$readPreference":{"mode":"primaryPreferred"}},"numYields":0,"reslen":163,"locks":{"ParallelBatchWriterMode":{"acquireCount":{"r":2}},"FeatureCompatibilityVersion":{"acquireCount":{"r":3,"w":2}},"ReplicationStateTransition":{"acquireCount":{"w":5}},"Global":{"acquireCount":{"r":3,"w":2}},"Database":{"acquireCount":{"w":2}},"Collection":{"acquireCount":{"w":2}},"Mutex":{"acquireCount":{"r":2}}},"flowControl":{"acquireCount":2,"timeAcquiringMicros":1},"writeConcern":{"w":1,"wtimeout":0,"provenance":"clientSupplied"},"storage":{},"remote":"172.20.0.1:56816","protocol":"op_msg","durationMillis":1}}
```