### PR TITLE
Fix duplicate definition of path `sys/internal/specs/openapi`

### DIFF
--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -967,15 +967,7 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 				logical.ReadOperation:   b.pathInternalOpenAPI,
 				logical.UpdateOperation: b.pathInternalOpenAPI,
 			},
-		},
-		{
-			Pattern: "internal/specs/openapi",
-			Operations: map[logical.Operation]framework.OperationHandler{
-				logical.ReadOperation: &framework.PathOperation{
-					Callback: b.pathInternalOpenAPI,
-					Summary:  "Generate an OpenAPI 3 document of all mounted paths.",
-				},
-			},
+			HelpSynopsis: "Generate an OpenAPI 3 document of all mounted paths.",
 		},
 		{
 			Pattern: "internal/ui/feature-flags",


### PR DESCRIPTION
This was accidentally duplicated in #5687.

Remove the second definition, which was shadowed by the first, and move the documentation that was part of the second to the surviving version.