### PR TITLE
Remove `generic_mount_paths` field

### DIFF
--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -956,12 +956,6 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 					Type:        framework.TypeString,
 					Description: "Context string appended to every operationId",
 				},
-				"generic_mount_paths": {
-					Type:        framework.TypeBool,
-					Description: "Use generic mount paths",
-					Query:       true,
-					Default:     false,
-				},
 			},
 			Callbacks: map[logical.Operation]framework.OperationFunc{
 				logical.ReadOperation:   b.pathInternalOpenAPI,


### PR DESCRIPTION
PR #17926 already deleted the implementation of the
`generic_mount_paths` field so it needs to be removed from the declared
fields of the path too, so help and OpenAPI isn't misleading.
