### PR TITLE
ui: add input as event for text form field

### DIFF
--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -302,8 +302,9 @@
           autocomplete="off"
           spellcheck="false"
           value={{or (get @model this.valuePath) @attr.options.defaultValue}}
-          onchange={{this.onChangeWithEvent}}
-          onkeyup={{this.handleKeyUp}}
+          {{on "input" this.onChangeWithEvent}}
+          {{on "change" this.onChangeWithEvent}}
+          {{on "keyUp" this.handleKeyUp}}
           class="input {{if this.validationError 'has-error-border'}} has-bottom-margin-m"
           maxLength={{@attr.options.characterLimit}}
         />

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -304,7 +304,7 @@
           value={{or (get @model this.valuePath) @attr.options.defaultValue}}
           {{on "input" this.onChangeWithEvent}}
           {{on "change" this.onChangeWithEvent}}
-          {{on "keyUp" this.handleKeyUp}}
+          {{on "keyup" this.handleKeyUp}}
           class="input {{if this.validationError 'has-error-border'}} has-bottom-margin-m"
           maxLength={{@attr.options.characterLimit}}
         />


### PR DESCRIPTION
While smoke testing the pki key workflow, I noticed the model name wasn't updating as the text changed in the input field. 