### PR TITLE
Add support for `prefix` in password policies

### DIFF
--- a/changelog/18569.txt
+++ b/changelog/18569.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Password Policies: Add `prefix` attribute, adding a fixed prefix to generated passwords, to enable secret scanning
+```

--- a/helper/random/parser.go
+++ b/helper/random/parser.go
@@ -66,10 +66,7 @@ func (p PolicyParser) ParsePolicy(raw string) (sg StringGenerator, err error) {
 		return sg, fmt.Errorf("unable to parse rules: %w", err)
 	}
 
-	gen = StringGenerator{
-		Length: gen.Length,
-		Rules:  rules,
-	}
+	gen.Rules = rules
 
 	err = gen.validateConfig()
 	if err != nil {

--- a/helper/random/string_generator.go
+++ b/helper/random/string_generator.go
@@ -66,11 +66,16 @@ func sortCharset(chars string) string {
 	return string(r)
 }
 
-// StringGenerator generats random strings from the provided charset & adhering to a set of rules. The set of rules
+// StringGenerator generates random strings from the provided charset & adhering to a set of rules. The set of rules
 // are things like CharsetRule which requires a certain number of characters from a sub-charset.
 type StringGenerator struct {
 	// Length of the string to generate.
 	Length int `mapstructure:"length" json:"length"`
+
+	// Prefix will be prepended to the generated random string. It is not included in the configured length.
+	// It is intended to be used to make the generated string identifiable as a secret, so that detection of passwords
+	// leaked to logging or version control systems can be automated.
+	Prefix string `mapstructure:"prefix" json:"prefix"`
 
 	// Rules the generated strings must adhere to.
 	Rules serializableRules `mapstructure:"-" json:"rule"` // This is "rule" in JSON so it matches the HCL property type
@@ -128,7 +133,7 @@ func (g *StringGenerator) generate(rng io.Reader) (str string, err error) {
 	}
 
 	// Passed all rules
-	return string(candidate), nil
+	return g.Prefix + string(candidate), nil
 }
 
 const (


### PR DESCRIPTION
It is an industry standard practice to generate secrets that include an
identifying fixed prefix, to make it easier to identify secrets that are
mistakenly leaked into logging and version control systems.

This article on the GitHub blog describes the practice, including links
to Slack and Stripe documentation showing those vendors also observe
this practice: https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/

Another widely known example is that Amazon AWS access key IDs start
with `AKIA` (or `ASIA` for short-lived credentials).

The Vault Active Directory secrets engine accidentally implements
the practice already, in its deprecated password generation routine, by
starting all passwords for `?@09AZ` - "accidentally", because the stated
reason is to work around password complexity rules on the server side,
but it also accomplishes this goal too.

However the newer "Password Policies" feature in Vault is incapable of
incorporating fixed prefixes on passwords.

This poses a problem for people who would like to migrate away from
deprecated features - since the warnings generated by
`terraform-provider-vault` are irritatingly unsuppressable - but are
unwilling to sacrifice this security feature.

Therefore, this PR adds in capability to specify a fixed prefix to the
new "Password Policies" generation system.
