### PR TITLE
Fix error in changelog template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGES:
 * plugins: `GET` for `/sys/auth`, `/sys/auth/:path`, `/sys/mounts`, and `/sys/mounts/:path` paths now return additional `plugin_version`, `running_plugin_version` and `running_sha256` fields in the response data for each mount. [[GH-17167](https://github.com/hashicorp/vault/pull/17167)]
 * secrets/aws: do not create leases for non-renewable/non-revocable STS credentials to reduce storage calls [[GH-15869](https://github.com/hashicorp/vault/pull/15869)]
 * ui: Upgrade Ember to version 4.4.0 [[GH-17086](https://github.com/hashicorp/vault/pull/17086)]
+
 FEATURES:
 
 * logging: Vault Agent supports logging to a specified file path via environment variable, CLI or config [[GH-17841](https://github.com/hashicorp/vault/pull/17841)]

--- a/changelog/changelog.tmpl
+++ b/changelog/changelog.tmpl
@@ -22,7 +22,7 @@ CHANGES:
 {{ end -}}
 {{- end -}}
 
-{{- if .NotesByType.feature -}}
+{{- if .NotesByType.feature }}
 FEATURES:
 
 {{range .NotesByType.feature -}}


### PR DESCRIPTION
Too many newlines are stripped, which is responsible for the `FEATURES:`
heading in the current in-progress 1.13.0 changelog entry being
erroneously appended to the end of the last bullet point of the previous
`CHANGES:` section.
