### PR TITLE
Remove unreachable code

### DIFF
--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	metrics "github.com/armon/go-metrics"
+	"github.com/armon/go-metrics"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	lru "github.com/hashicorp/golang-lru"
@@ -743,18 +743,6 @@ func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, po
 	}
 
 	return nil
-}
-
-type TemplateError struct {
-	Err error
-}
-
-func (t *TemplateError) WrappedErrors() []error {
-	return []error{t.Err}
-}
-
-func (t *TemplateError) Error() string {
-	return t.Err.Error()
 }
 
 // ACL is used to return an ACL which is built using the

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -243,10 +243,6 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 	// performed on the token's namespace.
 	acl, err := c.policyStore.ACL(tokenCtx, entity, policyNames, policies...)
 	if err != nil {
-		if errwrap.ContainsType(err, new(TemplateError)) {
-			c.logger.Warn("permission denied due to a templated policy being invalid or containing directives not satisfied by the requestor", "error", err)
-			return nil, nil, nil, nil, logical.ErrPermissionDenied
-		}
 		c.logger.Error("failed to construct ACL", "error", err)
 		return nil, nil, nil, nil, ErrInternalError
 	}


### PR DESCRIPTION
I happened to spot that the `TemplateError` type is never instantiated.
Therefore delete it, and code referencing it.
