### PR TITLE
only update SCADA metadata if status changes

### DIFF
--- a/changelog/18585.txt
+++ b/changelog/18585.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+hcp/connectivity: Only update SCADA session metadata if status changes
+```

--- a/vault/hcp_link/link.go
+++ b/vault/hcp_link/link.go
@@ -222,6 +222,8 @@ func (h *HCPLinkVault) start() error {
 // API. In addition, it checks replication status of Vault and sets that in
 // Scada provider metadata status
 func (h *HCPLinkVault) reportStatus() {
+	var currentNodeStatus string
+
 	ticker := time.NewTicker(SetLinkStatusCadence)
 	defer ticker.Stop()
 	for {
@@ -249,7 +251,11 @@ func (h *HCPLinkVault) reportStatus() {
 				nodeStatus = activeStatus
 			}
 
-			h.linkConfig.SCADAProvider.UpdateMeta(map[string]string{metaDataNodeStatus: nodeStatus})
+			// Only update SCADA session metadata if status has changed
+			if currentNodeStatus != nodeStatus {
+				currentNodeStatus = nodeStatus
+				h.linkConfig.SCADAProvider.UpdateMeta(map[string]string{metaDataNodeStatus: currentNodeStatus})
+			}
 		}
 	}
 }


### PR DESCRIPTION
Vault nodes use SCADA session metadata to denote whether they are `ACTIVE`, `STANDBY`, or `PERF-STANDBY`. Providing this metadata is done by calling `UpdateMeta` on the SCADA provider. This is currently done every 5 seconds. A Vault node should only update its SCADA metadata if its status changes (i.e. leadership in the cluster has shifted).