### PR TITLE
Loading Substate Handling Issue

### DIFF
--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -131,7 +131,8 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
       return true;
     },
     loading(transition) {
-      if (transition.queryParamsOnly || Ember.testing) {
+      const isSameRoute = transition.from?.name === transition.to?.name;
+      if (isSameRoute || Ember.testing) {
         return;
       }
       // eslint-disable-next-line ember/no-controller-access-in-routes

--- a/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
+++ b/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
@@ -127,7 +127,7 @@
   <button
     type="submit"
     form="role"
-    class="button is-primary"
+    class="button is-primary {{if this.save.isRunning 'is-loading'}}"
     disabled={{or (not @model.generationPreference) this.save.isRunning}}
     data-test-save
   >


### PR DESCRIPTION
It was observed within the kubernetes engine that the loading screen was not being shown consistently for routes that returned a promise in the model hook. The transition object `queryParamsOnly` property doesn't seem to be reliable in describing a transition where only the query params change so it was decided to check if the `from` and `to` route names are the same instead.