### PR TITLE
docs: Update PKCS#11 provider docs for XKS and RNG

### DIFF
--- a/website/content/docs/enterprise/pkcs11-provider/aws-xks.mdx
+++ b/website/content/docs/enterprise/pkcs11-provider/aws-xks.mdx
@@ -158,11 +158,11 @@ to the XKS proxy. This helps to quickly setup a valid domain and TLS endpoint fo
    max_aad_in_base64 = 16384
 
    [hsm_capabilities]
-   can_generate_iv = true
-   is_zero_iv_required = true
+   can_generate_iv = false
+   is_zero_iv_required = false
    ```
 
-~> **Note**: This uses an IV of zero until the next release of `vault-pkcs11-provider`.
+~> **Note**: `vault-pkcs11-provider` versions of 0.1.0–0.1.2 require the last two lines to be changed to `can_generate_iv = true` and `is_zero_iv_required = true`.
 
 1. Create a file, `/etc/vault-pkcs11.hcl` with the following contents:
 

--- a/website/content/docs/enterprise/pkcs11-provider/index.mdx
+++ b/website/content/docs/enterprise/pkcs11-provider/index.mdx
@@ -292,9 +292,9 @@ Here is the list of supported and unsupported PKCS#11 functions:
   - [ ]  `C_DecryptDigestUpdate`
   - [ ]  `C_SignEncryptUpdate`
   - [ ]  `C_DecryptVerifyUpdate`
-- Random Number Generation
-  - [ ]  `C_SeedRandom`
-  - [ ]  `C_GenerateRandom`
+- Random Number Generation (see note below)
+  - [X]  `C_SeedRandom`
+  - [X]  `C_GenerateRandom`
 
 ## Limitations and Notes
 
@@ -306,3 +306,5 @@ Due to the nature of Vault, the KMIP Secrets Engine, and PKCS#11, there are some
   This is because nearly all PKCS#11 API calls are translated 1-1 to KMIP calls, aside from some object attribute calls (which can be locally cached).
   Multiple sessions can be safely used simultaneously though, and a single Vault server node has been tested as supporting thousands of ongoing sessions.
 - The object attribute cache is valid only for a single object per session, and will be cleared when another object's attributes are queried.
+- The random number generator function, `C_GenerateRandom`, is currently implemented in software in the library by calling out to Go's [`crypto/rand`](https://pkg.go.dev/crypto/rand) package,
+  and does **not** call Vault.


### PR DESCRIPTION
Better IV random generation is supported with XKS in the latest version of the provider (0.1.3).