### PR TITLE
Account for mount counts when de-duplicating current and historical month data

### DIFF
--- a/changelog/18598.txt
+++ b/changelog/18598.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/activity: include mount counts when de-duplicating current and historical month data
+```

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1598,15 +1598,37 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 		}
 
 		// Rather than blindly appending, which will create duplicates, check our existing counts against the current
-		// month counts, and append or update as necessary.
+		// month counts, and append or update as necessary. We also want to account for mounts and their counts.
 		for _, nrc := range byNamespaceResponseCurrent {
 			if ndx, ok := nsrMap[nrc.NamespaceID]; ok {
 				existingRecord := byNamespaceResponse[ndx]
+
+				// Create a map of the existing mounts, so we don't duplicate them
+				mountMap := make(map[string]*ResponseCounts)
+				for _, erm := range existingRecord.Mounts {
+					mountMap[erm.MountPath] = erm.Counts
+				}
+
 				existingRecord.Counts.EntityClients += nrc.Counts.EntityClients
 				existingRecord.Counts.Clients += nrc.Counts.Clients
 				existingRecord.Counts.DistinctEntities += nrc.Counts.DistinctEntities
 				existingRecord.Counts.NonEntityClients += nrc.Counts.NonEntityClients
 				existingRecord.Counts.NonEntityTokens += nrc.Counts.NonEntityTokens
+
+				// Check the current month mounts against the existing mounts and if there are matches, update counts
+				// accordingly. If there is no match, append the new mount to the existing mounts, so it will be counted
+				// later.
+				for _, nrcMount := range nrc.Mounts {
+					if existingRecordMountCounts, ook := mountMap[nrcMount.MountPath]; ook {
+						existingRecordMountCounts.EntityClients += nrcMount.Counts.EntityClients
+						existingRecordMountCounts.Clients += nrcMount.Counts.Clients
+						existingRecordMountCounts.DistinctEntities += nrcMount.Counts.DistinctEntities
+						existingRecordMountCounts.NonEntityClients += nrcMount.Counts.NonEntityClients
+						existingRecordMountCounts.NonEntityTokens += nrcMount.Counts.NonEntityTokens
+					} else {
+						existingRecord.Mounts = append(existingRecord.Mounts, nrcMount)
+					}
+				}
 			} else {
 				byNamespaceResponse = append(byNamespaceResponse, nrc)
 			}


### PR DESCRIPTION
In https://github.com/hashicorp/vault/pull/18452 I failed to account for mount counts, which meant that when you did a CSV export in the UI, while the total was correct, if you added up all the totals for all the mounts, it fell short of the total by the exact amount from the current month data. This corrects that oversight. It would be super awesome to get some tests around all this stuff at some point but the current unit tests for this section of the code are a bit rough. I'm not sure if we want to hold up this PR for adding them, or add them at a later date.