### PR TITLE
docs: db plugin add link to lease docs

### DIFF
--- a/website/content/docs/secrets/databases/index.mdx
+++ b/website/content/docs/secrets/databases/index.mdx
@@ -15,8 +15,9 @@ configured roles. It works with a number of different databases through a plugin
 interface. There are a number of built-in database types, and an exposed framework
 for running custom database types for extendability. This means that services
 that need to access a database no longer need to hardcode credentials: they can
-request them from Vault, and use Vault's leasing mechanism to more easily roll
-keys. These are referred to as "dynamic roles" or "dynamic secrets".
+request them from Vault, and use Vault's [leasing mechanism](/docs/concepts/lease)
+to more easily roll keys. These are referred to as "dynamic roles" or "dynamic
+secrets".
 
 Since every service is accessing the database with unique credentials, it makes
 auditing much easier when questionable data access is discovered. You can track


### PR DESCRIPTION
This should allow users to more easily discover information on leases and how they relate to db roles/secrets.

Backporting to 1.12.x so that it is available on the website immediately.