### PR TITLE
VAULT-12491 Add docs for group policy config

### DIFF
--- a/website/content/api-docs/system/config-group-policy-application.mdx
+++ b/website/content/api-docs/system/config-group-policy-application.mdx
@@ -1,0 +1,78 @@
+---
+layout: api
+page_title: /sys/config/group-policy-application - HTTP API
+description: The '/sys/config/group-policy-application' endpoint is used to configure the global mode for group policy application.
+---
+
+# `/sys/config/group-policy-application`
+
+The `sys/config/group-policy-application` endpoint can be used to configure the
+mode of policy application for identity groups in Vault.
+Currently, it only supports two modes, `within_namespace_hierarchy` (default), which
+restricts policy application to only policies from groups from parent namespaces, and
+`any` which does not restrict policy application, and policies will apply from any namespace,
+irrespective of namespace hierarchy.
+
+Note that this configuration will be replicated between primary and secondaries, that
+is to say, primaries cannot have a different policy application mode to secondaries.
+
+## `Get Group Policy Application Information`
+
+~> **Enterprise Only** – This endpoint requires Vault Enterprise.
+
+This endpoint returns the current group policy application mode, which will be
+either `within_namespace_hierarchy` or `any`.
+
+
+| Method | Path                          |
+| :----- | :---------------------------- |
+| `GET`  | `/sys/config/group-policy-application` |
+
+### Sample Request
+
+```shell-session
+$ curl \
+  --header "X-Vault-Token: ..." \
+    'http://127.0.0.1:8200/v1/sys/config/group-policy-application'
+```
+
+### Sample Response
+
+```json
+{
+   "group_policy_application_mode": "within_namespace_hierarchy"
+}
+```
+
+## `Set Group Policy Application Information`
+
+~> **Enterprise Only** – This endpoint requires Vault Enterprise.
+
+This endpoint allows you to modify the current group policy application mode, which can be
+either `within_namespace_hierarchy` or `any`. `within_namespace_hierarchy`
+restricts policy application to only policies from groups from parent namespaces, and
+`any` does not restrict policy application in any way, and policies will apply from any namespace,
+irrespective of namespace hierarchy.
+
+
+| Method | Path                          |
+| :----- | :---------------------------- |
+| `POST`, `PUT`  | `/sys/config/group-policy-application` |
+
+### Sample Payload
+
+```json
+{
+   "group_policy_application_mode": "any"
+}
+```
+
+### Sample Request
+
+```shell-session
+$ curl \
+  --request POST \
+  --header "X-Vault-Token: ..." \
+  --data @payload.json \
+  'http://127.0.0.1:8200/v1/sys/config/group-policy-application'
+```

--- a/website/content/api-docs/system/config-group-policy-application.mdx
+++ b/website/content/api-docs/system/config-group-policy-application.mdx
@@ -7,11 +7,11 @@ description: The '/sys/config/group-policy-application' endpoint is used to conf
 # `/sys/config/group-policy-application`
 
 The `sys/config/group-policy-application` endpoint can be used to configure the
-mode of policy application for identity groups in Vault.
+mode of policy application for identity groups in Vault. Policy application in this case
+refers to whether or not a policy as defined in a group will apply to a member of that group.
 Currently, it only supports two modes, `within_namespace_hierarchy` (default), which
-restricts policy application to only policies from groups from parent namespaces, and
-`any` which does not restrict policy application, and policies will apply from any namespace,
-irrespective of namespace hierarchy.
+means that policies will only be applied and asserted on from groups in parent namespaces, and
+`any` which means that every policy will be applied, irrespective of namespace hierarchy.
 
 Note that this configuration will be replicated between primary and secondaries, that
 is to say, primaries cannot have a different policy application mode to secondaries.

--- a/website/content/api-docs/system/config-group-policy-application.mdx
+++ b/website/content/api-docs/system/config-group-policy-application.mdx
@@ -6,8 +6,11 @@ description: The '/sys/config/group-policy-application' endpoint is used to conf
 
 # `/sys/config/group-policy-application`
 
+~> **Enterprise Only** – These endpoints require Vault Enterprise Platform.
+
 The `sys/config/group-policy-application` endpoint can be used to configure the
-mode of policy application for identity groups in Vault.
+mode of policy application for identity groups in Vault. This setting dictates
+the behavior across all groups in all namespaces in Vault.
 
 Vault allows you to add entities and groups from any namespace into an identity group.
 However, historically, any policies attached to that group would only apply when the
@@ -21,8 +24,6 @@ Note that this configuration will be replicated between primary and secondaries,
 is to say, primaries cannot have a different policy application mode to secondaries.
 
 ## Get Group Policy Application Information
-
-~> **Enterprise Only** – This endpoint requires Vault Enterprise.
 
 This endpoint returns the current group policy application mode, which will be
 either `within_namespace_hierarchy` or `any`.
@@ -49,8 +50,6 @@ $ curl \
 ```
 
 ## Set Group Policy Application Information
-
-~> **Enterprise Only** – This endpoint requires Vault Enterprise.
 
 This endpoint allows you to modify the current group policy application mode, which can be
 either `within_namespace_hierarchy` or `any`. `within_namespace_hierarchy`

--- a/website/content/api-docs/system/config-group-policy-application.mdx
+++ b/website/content/api-docs/system/config-group-policy-application.mdx
@@ -16,7 +16,7 @@ irrespective of namespace hierarchy.
 Note that this configuration will be replicated between primary and secondaries, that
 is to say, primaries cannot have a different policy application mode to secondaries.
 
-## `Get Group Policy Application Information`
+## Get Group Policy Application Information
 
 ~> **Enterprise Only** – This endpoint requires Vault Enterprise.
 
@@ -44,7 +44,7 @@ $ curl \
 }
 ```
 
-## `Set Group Policy Application Information`
+## Set Group Policy Application Information
 
 ~> **Enterprise Only** – This endpoint requires Vault Enterprise.
 

--- a/website/content/api-docs/system/config-group-policy-application.mdx
+++ b/website/content/api-docs/system/config-group-policy-application.mdx
@@ -7,11 +7,15 @@ description: The '/sys/config/group-policy-application' endpoint is used to conf
 # `/sys/config/group-policy-application`
 
 The `sys/config/group-policy-application` endpoint can be used to configure the
-mode of policy application for identity groups in Vault. Policy application in this case
-refers to whether or not a policy as defined in a group will apply to a member of that group.
-Currently, it only supports two modes, `within_namespace_hierarchy` (default), which
-means that policies will only be applied and asserted on from groups in parent namespaces, and
-`any` which means that every policy will be applied, irrespective of namespace hierarchy.
+mode of policy application for identity groups in Vault.
+
+Vault allows you to add entities and groups from any namespace into an identity group.
+However, historically, any policies attached to that group would only apply when the
+Vault token authorizing a request was created in the same namespace as that group,
+or a descendent namespace. This endpoint allows relaxing that restriction: when the mode is set to the default,
+`within_namespace_hierarchy`, the historical behaviour is maintained,
+but when set to `any`, group policies apply to all members of a group,
+regardless of what namespace the request token came from.
 
 Note that this configuration will be replicated between primary and secondaries, that
 is to say, primaries cannot have a different policy application mode to secondaries.

--- a/website/content/docs/enterprise/namespaces.mdx
+++ b/website/content/docs/enterprise/namespaces.mdx
@@ -67,6 +67,7 @@ There are certain API paths that can only be called from the root namespace:
 - `sys/leader`
 - `sys/health`
 - `sys/metrics`
+- `sys/config/group-policy-application`
 - `sys/config/state`
 - `sys/host-info`
 - `sys/key-status`
@@ -95,7 +96,9 @@ of delegate admins.
 Child namespaces can share policies from their parent namespaces. For example, a child namespace
 may refer to parent identities (entities and groups) when writing policies that function only
 within that child namespace. Similarly, a parent namespace can have policies asserted on child
-identities.
+identities. This behavior can be configured using the [group-policy-application](/api-docs/system/config-group-policy-application") API, and
+can be set to allow policies to be applied irrespective of namespace hierarchy, allowing sharing
+across any namespace.
 
 ## Tutorial
 

--- a/website/content/docs/enterprise/namespaces.mdx
+++ b/website/content/docs/enterprise/namespaces.mdx
@@ -96,7 +96,7 @@ of delegate admins.
 Child namespaces can share policies from their parent namespaces. For example, a child namespace
 may refer to parent identities (entities and groups) when writing policies that function only
 within that child namespace. Similarly, a parent namespace can have policies asserted on child
-identities. This behavior can be configured using the [group-policy-application](/api-docs/system/config-group-policy-application") API, and
+identities. This behavior can be configured using the [group-policy-application](/api-docs/system/config-group-policy-application) API, and
 can be set to allow policies to be applied irrespective of namespace hierarchy, allowing sharing
 across any namespace.
 

--- a/website/data/api-docs-nav-data.json
+++ b/website/data/api-docs-nav-data.json
@@ -422,6 +422,15 @@
         "path": "system/config-cors"
       },
       {
+        "title": "<code>/sys/config/group-policy-application</code>",
+        "path": "system/config-group-policy-application",
+        "badge": {
+          "text": "ENT",
+          "type": "outlined",
+          "color": "neutral"
+        }
+      },
+      {
         "title": "<code>/sys/config/reload</code>",
         "path": "system/config-reload"
       },


### PR DESCRIPTION
The documentation for the group policy configuration API and feature.

I'm pretty sure I covered the salient areas. There didn't seem to be any other references to policy sharing across namespaces I could find.

Feel free to let me know there actually are some other references to sharing that I missed.

The vercel currently has an older version deployed, and I'm not sure how to kick it to deploy again, but the two typos I spotted were corrected.