### PR TITLE
Add new clients into the monthly breakdown

### DIFF
--- a/changelog/18629.txt
+++ b/changelog/18629.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/activity: add namespace breakdown for new clients when date range spans multiple months, including the current month.
+```

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1664,6 +1664,7 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 			a.logger.Warn("no month data found, returning query with no namespace attribution for current month")
 		} else {
 			currentMonth.Namespaces = currentMonthNamespaceAttribution[0].Namespaces
+			currentMonth.NewClients = currentMonthNamespaceAttribution[0].NewClients
 		}
 		pq.Months = append(pq.Months, currentMonth)
 		distinctEntitiesResponse += pq.Months[len(pq.Months)-1].NewClients.Counts.EntityClients


### PR DESCRIPTION
When viewing the `monthly` breakdown in the output, if you looked under `new_clients`:
* if you were viewing the current month only, you would see a namespace breakdown
* if you were viewing historical data only, you would see a namespace breakdown
* if you were viewing a date range that spanned both historical data as well as the current month, you'd see nothing

This PR rectifies this by showing the namespace breakdown for new clients in all 3 date range permutations, instead of only the first 2.