### PR TITLE
Allow tidy to backup legacy CA bundles

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -112,6 +112,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 
 			SealWrapStorage: []string{
 				legacyCertBundlePath,
+				legacyCertBundleBackupPath,
 				keyPrefix,
 			},
 		},
@@ -271,6 +272,7 @@ type tidyStatus struct {
 	tidyRevokedCerts   bool
 	tidyRevokedAssocs  bool
 	tidyExpiredIssuers bool
+	tidyBackupBundle   bool
 	pauseDuration      string
 
 	// Status

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -3940,6 +3940,7 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 			"tidy_revoked_certs":                    true,
 			"tidy_revoked_cert_issuer_associations": false,
 			"tidy_expired_issuers":                  false,
+			"tidy_move_legacy_ca_bundle":            false,
 			"pause_duration":                        "0s",
 			"state":                                 "Finished",
 			"error":                                 nil,

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -461,6 +461,23 @@ past the issuer_safety_buffer. No keys will be removed as part of this
 operation.`,
 	}
 
+	fields["tidy_move_legacy_ca_bundle"] = &framework.FieldSchema{
+		Type: framework.TypeBool,
+		Description: `Set to true to move the legacy ca_bundle from
+/config/ca_bundle to /config/ca_bundle.bak. This prevents downgrades
+to pre-Vault 1.11 versions (as older PKI engines do not know about
+the new multi-issuer storage layout), but improves the performance
+on seal wrapped PKI mounts. This will only occur if at least
+issuer_safety_buffer time has occurred after the initial storage
+migration.
+
+This backup is saved in case of an issue in future migrations.
+Operators may consider removing it via sys/raw if they desire.
+The backup will be removed via a DELETE /root call, but note that
+this removes ALL issuers within the mount (and is thus not desirable
+in most operational scenarios).`,
+	}
+
 	fields["safety_buffer"] = &framework.FieldSchema{
 		Type: framework.TypeDurationSecond,
 		Description: `The amount of extra time that must have passed

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -80,8 +80,12 @@ func (b *backend) pathCADeleteRoot(ctx context.Context, req *logical.Request, _ 
 		}
 	}
 
-	// Delete legacy CA bundle.
+	// Delete legacy CA bundle and its backup, if any.
 	if err := req.Storage.Delete(ctx, legacyCertBundlePath); err != nil {
+		return nil, err
+	}
+
+	if err := req.Storage.Delete(ctx, legacyCertBundleBackupPath); err != nil {
 		return nil, err
 	}
 

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -25,6 +25,7 @@ const (
 
 	legacyMigrationBundleLogKey = "config/legacyMigrationBundleLog"
 	legacyCertBundlePath        = "config/ca_bundle"
+	legacyCertBundleBackupPath  = "config/ca_bundle.bak"
 	legacyCRLPath               = "crl"
 	deltaCRLPath                = "delta-crl"
 	deltaCRLPathSuffix          = "-delta"

--- a/changelog/18645.txt
+++ b/changelog/18645.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Allow tidying of the legacy ca_bundle, improving startup on post-migrated, seal-wrapped PKI mounts.
+```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -3614,6 +3614,14 @@ expiration time.
 ~> Note: The default issuer will not be removed even if it has expired and is
    past the `issuer_safety_buffer` specified.
 
+- `tidy_move_legacy_ca_bundle` `(bool: false)` - Set to true to backup any
+  legacy CA/issuers bundle (from Vault versions earlier than 1.11) to
+  `config/ca_bundle.bak`. This can be restored with `sys/raw` back to
+  `config/ca_bundle` if necessary, but won't impact mount startup (as
+  mounts will attempt to read the latter and do a migration of CA issuers
+  if present). Migration will only occur after `issuer_safety_buffer` has
+  passed since the last successful migration.
+
 - `safety_buffer` `(string: "")` - Specifies a duration using [duration format strings](/docs/concepts/duration-format)
   used as a safety buffer to ensure certificates are not expunged prematurely; as an example, this can keep
   certificates from being removed from the CRL that, due to clock skew, might
@@ -3697,6 +3705,14 @@ status endpoint described below.
 
 ~> Note: The default issuer will not be removed even if it has expired and is
    past the `issuer_safety_buffer` specified.
+
+- `tidy_move_legacy_ca_bundle` `(bool: false)` - Set to true to backup any
+  legacy CA/issuers bundle (from Vault versions earlier than 1.11) to
+  `config/ca_bundle.bak`. This can be restored with `sys/raw` back to
+  `config/ca_bundle` if necessary, but won't impact mount startup (as
+  mounts will attempt to read the latter and do a migration of CA issuers
+  if present). Migration will only occur after `issuer_safety_buffer` has
+  passed since the last successful migration.
 
 - `safety_buffer` `(string: "")` - Specifies a duration using [duration format strings](/docs/concepts/duration-format)
   used as a safety buffer to ensure certificates are not expunged prematurely; as an example, this can keep


### PR DESCRIPTION
With the new `tidy_move_legacy_ca_bundle` option, we'll use tidy to move the legacy CA bundle from `/config/ca_bundle` to `/config/ca_bundle.bak`. This does two things:

 1. Removes `ca_bundle` from the hot-path of initialization after initial migration has completed. Because this entry is seal wrapped, this may result in performance improvements.
 2. Allows recovery of this value in the event of some other failure with migration.

Notably, this cannot occur during migration in the unlikely (and largely unsupported) case that the operator immediately downgrades to Vault <1.11.x. Thus, we reuse `issuer_safety_buffer`; while potentially long, tidy can always be run manually with a shorter buffer (and only this flag) to manually move the bundle if necessary.

In the event of needing to recover or undo this operation, it is sufficient to use `sys/raw` to read the backed up value and subsequently write it to its old path (`/config/ca_bundle`).

The new entry remains seal wrapped, but otherwise isn't used within the code and so has better performance characteristics.

Performing a fat deletion (`DELETE /root`) will again remove the backup like the old legacy bundle, preserving its wipe characteristics.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`