### PR TITLE
DO NOT MERGE: add an endpoint for testing logical.ErrorResponse

### DIFF
--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"context"
 	"strings"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -943,6 +944,17 @@ func (b *SystemBackend) toolsPaths() []*framework.Path {
 
 			HelpSynopsis:    strings.TrimSpace(sysHelp["random"][0]),
 			HelpDescription: strings.TrimSpace(sysHelp["random"][1]),
+		},
+
+		{
+			Pattern: "tools/error-response",
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: func(ctx context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+						return logical.ErrorResponse("this is an error!"), nil
+					},
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
added a quick endpoint to show how `logical.ErrorResponse` is handled by the server

to run
`make dev`
`./bin/vault server -dev`
```
curl \
    -H "X-Vault-Token: <the token>" \
    -X GET \
    http://127.0.0.1:8200/v1/sys/tools/error-response
```

should get 400 response code and the below json
```json
{
    "errors": [
        "this is an error!"
    ]
}
```