### PR TITLE
docs: note that env vars must be set on the vault process and can be checked in 1.13

### DIFF
--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -272,7 +272,9 @@ this file at any time to "logout" of Vault.
 
 The CLI reads the following environment variables to set behavioral defaults.
 This can alleviate the need to repetitively type a flag. Flags always take
-precedence over the environment variables.
+precedence over the environment variables. Each of the following environment 
+variables must be set on the Vault process.  In Vault 1.13+, all environment 
+variables available to the Vault process will be logged during startup.
 
 ### `VAULT_TOKEN`
 


### PR DESCRIPTION
Vault environment variables can be set many ways. In 1.13 we can verify what environment variables have been set. 

`> vault server -dev`
![image](https://user-images.githubusercontent.com/29907172/211663067-9a88fb21-716a-45ac-af32-52c228d0ccd3.png)

