### PR TITLE
VAULT-12264: Fix log rotation params which require an integer

### DIFF
--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -2131,8 +2131,10 @@ func TestAgent_LogFile_Config(t *testing.T) {
 
 	// Sanity check that the config value is the current value
 	assert.Equal(t, "TMPDIR/juan.log", cfg.LogFile, "sanity check on log config failed")
-	assert.Equal(t, 2, cfg.LogRotateMaxFiles)
-	assert.Equal(t, 1048576, cfg.LogRotateBytes)
+	assert.True(t, cfg.LogRotateMaxFiles != nil)
+	assert.Equal(t, 2, *cfg.LogRotateMaxFiles)
+	assert.True(t, cfg.LogRotateBytes != nil)
+	assert.Equal(t, 1048576, *cfg.LogRotateBytes)
 
 	// Parse the cli flags (but we pass in an empty slice)
 	cmd := &AgentCommand{BaseCommand: &BaseCommand{}}
@@ -2146,8 +2148,10 @@ func TestAgent_LogFile_Config(t *testing.T) {
 	cmd.applyConfigOverrides(f, cfg)
 
 	assert.Equal(t, "TMPDIR/juan.log", cfg.LogFile, "actual config check")
-	assert.Equal(t, 2, cfg.LogRotateMaxFiles)
-	assert.Equal(t, 1048576, cfg.LogRotateBytes)
+	assert.True(t, cfg.LogRotateMaxFiles != nil)
+	assert.Equal(t, 2, *cfg.LogRotateMaxFiles)
+	assert.True(t, cfg.LogRotateBytes != nil)
+	assert.Equal(t, 1048576, *cfg.LogRotateBytes)
 }
 
 func TestAgent_Config_NewLogger_Default(t *testing.T) {

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -2131,10 +2131,8 @@ func TestAgent_LogFile_Config(t *testing.T) {
 
 	// Sanity check that the config value is the current value
 	assert.Equal(t, "TMPDIR/juan.log", cfg.LogFile, "sanity check on log config failed")
-	assert.True(t, cfg.LogRotateMaxFiles != nil)
-	assert.Equal(t, 2, *cfg.LogRotateMaxFiles)
-	assert.True(t, cfg.LogRotateBytes != nil)
-	assert.Equal(t, 1048576, *cfg.LogRotateBytes)
+	assert.Equal(t, 2, cfg.LogRotateMaxFiles)
+	assert.Equal(t, 1048576, cfg.LogRotateBytes)
 
 	// Parse the cli flags (but we pass in an empty slice)
 	cmd := &AgentCommand{BaseCommand: &BaseCommand{}}
@@ -2148,10 +2146,8 @@ func TestAgent_LogFile_Config(t *testing.T) {
 	cmd.applyConfigOverrides(f, cfg)
 
 	assert.Equal(t, "TMPDIR/juan.log", cfg.LogFile, "actual config check")
-	assert.True(t, cfg.LogRotateMaxFiles != nil)
-	assert.Equal(t, 2, *cfg.LogRotateMaxFiles)
-	assert.True(t, cfg.LogRotateBytes != nil)
-	assert.Equal(t, 1048576, *cfg.LogRotateBytes)
+	assert.Equal(t, 2, cfg.LogRotateMaxFiles)
+	assert.Equal(t, 1048576, cfg.LogRotateBytes)
 }
 
 func TestAgent_Config_NewLogger_Default(t *testing.T) {

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -2110,7 +2110,7 @@ func TestAgent_LogFile_CliOverridesConfig(t *testing.T) {
 	}
 
 	// Update the config based on the inputs.
-	cmd.updateConfig(f, cfg)
+	cmd.applyConfigOverrides(f, cfg)
 
 	assert.NotEqual(t, "TMPDIR/juan.log", cfg.LogFile)
 	assert.NotEqual(t, "/squiggle/logs.txt", cfg.LogFile)
@@ -2136,7 +2136,7 @@ func TestAgent_LogFile_Config(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd.updateConfig(f, cfg)
+	cmd.applyConfigOverrides(f, cfg)
 
 	assert.Equal(t, "TMPDIR/juan.log", cfg.LogFile, "actual config check")
 }

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -38,6 +38,8 @@ const (
 	BasicHclConfig = `
 log_file = "TMPDIR/juan.log"
 log_level="warn"
+log_rotate_max_files=2
+log_rotate_bytes=1048576
 vault {
 	address = "http://127.0.0.1:8200"
 	retry {
@@ -54,6 +56,8 @@ listener "tcp" {
 	BasicHclConfig2 = `
 log_file = "TMPDIR/juan.log"
 log_level="debug"
+log_rotate_max_files=-1
+log_rotate_bytes=1048576
 vault {
 	address = "http://127.0.0.1:8200"
 	retry {
@@ -2127,6 +2131,8 @@ func TestAgent_LogFile_Config(t *testing.T) {
 
 	// Sanity check that the config value is the current value
 	assert.Equal(t, "TMPDIR/juan.log", cfg.LogFile, "sanity check on log config failed")
+	assert.Equal(t, 2, cfg.LogRotateMaxFiles)
+	assert.Equal(t, 1048576, cfg.LogRotateBytes)
 
 	// Parse the cli flags (but we pass in an empty slice)
 	cmd := &AgentCommand{BaseCommand: &BaseCommand{}}
@@ -2136,9 +2142,12 @@ func TestAgent_LogFile_Config(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Should change nothing...
 	cmd.applyConfigOverrides(f, cfg)
 
 	assert.Equal(t, "TMPDIR/juan.log", cfg.LogFile, "actual config check")
+	assert.Equal(t, 2, cfg.LogRotateMaxFiles)
+	assert.Equal(t, 1048576, cfg.LogRotateBytes)
 }
 
 func TestAgent_Config_NewLogger_Default(t *testing.T) {

--- a/command/base_flags.go
+++ b/command/base_flags.go
@@ -249,14 +249,14 @@ func (i *intValue) Set(s string) error {
 		return err
 	}
 	if v >= math.MinInt && v <= math.MaxInt {
-		*i.target = int(v)
+		*i.target = v
 		return nil
 	}
 	return fmt.Errorf("Incorrect conversion of a 64-bit integer to a lower bit size. Value %d is not within bounds for int32", v)
 }
 
-func (i *intValue) Get() interface{} { return int(*i.target) }
-func (i *intValue) String() string   { return strconv.Itoa(int(*i.target)) }
+func (i *intValue) Get() interface{} { return *i.target }
+func (i *intValue) String() string   { return strconv.Itoa(*i.target) }
 func (i *intValue) Example() string  { return "int" }
 func (i *intValue) Hidden() bool     { return i.hidden }
 

--- a/command/log_flags.go
+++ b/command/log_flags.go
@@ -3,7 +3,7 @@ package command
 import (
 	"flag"
 	"os"
-	"strings"
+	"strconv"
 
 	"github.com/hashicorp/vault/internalshared/configutil"
 	"github.com/posener/complete"
@@ -15,20 +15,18 @@ type logFlags struct {
 	flagLogLevel          string
 	flagLogFormat         string
 	flagLogFile           string
-	flagLogRotateBytes    string
+	flagLogRotateBytes    int
 	flagLogRotateDuration string
-	flagLogRotateMaxFiles string
+	flagLogRotateMaxFiles int
 }
-
-type provider = func(key string) (string, bool)
 
 // valuesProvider has the intention of providing a way to supply a func with a
 // way to retrieve values for flags and environment variables without having to
-// directly call a specific implementation. The reasoning for its existence is
-// to facilitate testing.
+// directly call a specific implementation.
+// The reasoning for its existence is to facilitate testing.
 type valuesProvider struct {
-	flagProvider   provider
-	envVarProvider provider
+	flagProvider   func(string) (flag.Value, bool)
+	envVarProvider func(string) (string, bool)
 }
 
 // addLogFlags will add the set of 'log' related flags to a flag set.
@@ -65,7 +63,7 @@ func (f *FlagSet) addLogFlags(l *logFlags) {
 		Usage:  "Path to the log file that Vault should use for logging",
 	})
 
-	f.StringVar(&StringVar{
+	f.IntVar(&IntVar{
 		Name:   flagNameLogRotateBytes,
 		Target: &l.flagLogRotateBytes,
 		Usage: "Number of bytes that should be written to a log before it needs to be rotated. " +
@@ -79,23 +77,34 @@ func (f *FlagSet) addLogFlags(l *logFlags) {
 			"Must be a duration value such as 30s",
 	})
 
-	f.StringVar(&StringVar{
+	f.IntVar(&IntVar{
 		Name:   flagNameLogRotateMaxFiles,
 		Target: &l.flagLogRotateMaxFiles,
 		Usage:  "The maximum number of older log file archives to keep",
 	})
 }
 
-// getValue will attempt to find the flag with the corresponding flag name (key)
-// and return the value along with a bool representing whether of not the flag had been found/set.
-func (f *FlagSets) getValue(flagName string) (string, bool) {
-	var result string
+// envVarValue attempts to get a named value from the environment variables.
+// The value will be returned as a string along with a boolean value indiciating
+// to the caller whether the named env var existed.
+func envVarValue(key string) (string, bool) {
+	if key == "" {
+		return "", false
+	}
+	return os.LookupEnv(key)
+}
+
+// flagValue attempts to find the named flag in a set of FlagSets.
+// The flag.Value is returned if it was specified, and the boolean value indicates
+// to the caller if the flag was specified by the end user.
+func (f *FlagSets) flagValue(flagName string) (flag.Value, bool) {
+	var result flag.Value
 	var isFlagSpecified bool
 
 	if f != nil {
 		f.Visit(func(fl *flag.Flag) {
 			if fl.Name == flagName {
-				result = fl.Value.String()
+				result = fl.Value
 				isFlagSpecified = true
 			}
 		})
@@ -104,51 +113,63 @@ func (f *FlagSets) getValue(flagName string) (string, bool) {
 	return result, isFlagSpecified
 }
 
-// getAggregatedConfigValue uses the provided keys to check CLI flags and environment
+// overrideValue uses the provided keys to check CLI flags and environment
 // variables for values that may be used to override any specified configuration.
-// If nothing can be found in flags/env vars or config, the 'fallback' (default) value will be provided.
-func (p *valuesProvider) getAggregatedConfigValue(flagKey, envVarKey, current, fallback string) string {
+func (p *valuesProvider) overrideValue(flagKey, envVarKey string) (string, bool) {
 	var result string
-	current = strings.TrimSpace(current)
+	found := true
 
 	flg, flgFound := p.flagProvider(flagKey)
 	env, envFound := p.envVarProvider(envVarKey)
 
 	switch {
 	case flgFound:
-		result = flg
+		result = flg.String()
 	case envFound:
-		// Use value from env var
 		result = env
-	case current != "":
-		// Use value from config
-		result = current
 	default:
-		// Use the default value
-		result = fallback
+		found = false
 	}
 
-	return result
+	return result, found
 }
 
-// updateLogConfig will accept a shared config and specifically attempt to update the 'log' related config keys.
-// For each 'log' key we aggregate file config/env vars and CLI flags to select the one with the highest precedence.
+// applyLogConfigOverrides will accept a shared config and specifically attempt to update the 'log' related config keys.
+// For each 'log' key, we aggregate file config, env vars and CLI flags to select the one with the highest precedence.
 // This method mutates the config object passed into it.
-func (f *FlagSets) updateLogConfig(config *configutil.SharedConfig) {
+func (f *FlagSets) applyLogConfigOverrides(config *configutil.SharedConfig) {
 	p := &valuesProvider{
-		flagProvider: func(key string) (string, bool) { return f.getValue(key) },
-		envVarProvider: func(key string) (string, bool) {
-			if key == "" {
-				return "", false
-			}
-			return os.LookupEnv(key)
-		},
+		flagProvider:   f.flagValue,
+		envVarProvider: envVarValue,
 	}
 
-	config.LogLevel = p.getAggregatedConfigValue(flagNameLogLevel, EnvVaultLogLevel, config.LogLevel, "info")
-	config.LogFormat = p.getAggregatedConfigValue(flagNameLogFormat, EnvVaultLogFormat, config.LogFormat, "")
-	config.LogFile = p.getAggregatedConfigValue(flagNameLogFile, "", config.LogFile, "")
-	config.LogRotateDuration = p.getAggregatedConfigValue(flagNameLogRotateDuration, "", config.LogRotateDuration, "")
-	config.LogRotateBytes = p.getAggregatedConfigValue(flagNameLogRotateBytes, "", config.LogRotateBytes, "")
-	config.LogRotateMaxFiles = p.getAggregatedConfigValue(flagNameLogRotateMaxFiles, "", config.LogRotateMaxFiles, "")
+	// Update log level
+	if val, found := p.overrideValue(flagNameLogLevel, EnvVaultLogLevel); found {
+		config.LogLevel = val
+	}
+
+	// Update log format
+	if val, found := p.overrideValue(flagNameLogFormat, EnvVaultLogFormat); found {
+		config.LogFormat = val
+	}
+
+	// Update log file name
+	if val, found := p.overrideValue(flagNameLogFile, ""); found {
+		config.LogFile = val
+	}
+
+	// Update log rotation duration
+	if val, found := p.overrideValue(flagNameLogRotateDuration, ""); found {
+		config.LogRotateDuration = val
+	}
+
+	// Update log max files
+	if val, found := p.overrideValue(flagNameLogRotateMaxFiles, ""); found {
+		config.LogRotateMaxFiles, _ = strconv.Atoi(val)
+	}
+
+	// Update log rotation max bytes
+	if val, found := p.overrideValue(flagNameLogRotateBytes, ""); found {
+		config.LogRotateBytes, _ = strconv.Atoi(val)
+	}
 }

--- a/command/log_flags.go
+++ b/command/log_flags.go
@@ -165,11 +165,13 @@ func (f *FlagSets) applyLogConfigOverrides(config *configutil.SharedConfig) {
 
 	// Update log max files
 	if val, found := p.overrideValue(flagNameLogRotateMaxFiles, ""); found {
-		config.LogRotateMaxFiles, _ = strconv.Atoi(val)
+		n, _ := strconv.Atoi(val)
+		config.LogRotateMaxFiles = &n
 	}
 
 	// Update log rotation max bytes
 	if val, found := p.overrideValue(flagNameLogRotateBytes, ""); found {
-		config.LogRotateBytes, _ = strconv.Atoi(val)
+		n, _ := strconv.Atoi(val)
+		config.LogRotateBytes = &n
 	}
 }

--- a/command/log_flags.go
+++ b/command/log_flags.go
@@ -165,13 +165,11 @@ func (f *FlagSets) applyLogConfigOverrides(config *configutil.SharedConfig) {
 
 	// Update log max files
 	if val, found := p.overrideValue(flagNameLogRotateMaxFiles, ""); found {
-		n, _ := strconv.Atoi(val)
-		config.LogRotateMaxFiles = &n
+		config.LogRotateMaxFiles, _ = strconv.Atoi(val)
 	}
 
 	// Update log rotation max bytes
 	if val, found := p.overrideValue(flagNameLogRotateBytes, ""); found {
-		n, _ := strconv.Atoi(val)
-		config.LogRotateBytes = &n
+		config.LogRotateBytes, _ = strconv.Atoi(val)
 	}
 }

--- a/command/server.go
+++ b/command/server.go
@@ -433,7 +433,7 @@ func (c *ServerCommand) runRecoveryMode() int {
 	}
 
 	// Update the 'log' related aspects of shared config based on config/env var/cli
-	c.Flags().updateLogConfig(config.SharedConfig)
+	c.Flags().applyLogConfigOverrides(config.SharedConfig)
 	l, err := c.configureLogging(config)
 	if err != nil {
 		c.UI.Error(err.Error())
@@ -1039,7 +1039,7 @@ func (c *ServerCommand) Run(args []string) int {
 		return 1
 	}
 
-	f.updateLogConfig(config.SharedConfig)
+	f.applyLogConfigOverrides(config.SharedConfig)
 
 	// Set 'trace' log level for the following 'dev' clusters
 	if c.flagDevThreeNode || c.flagDevFourCluster {
@@ -1696,24 +1696,14 @@ func (c *ServerCommand) configureLogging(config *server.Config) (hclog.Intercept
 		return nil, err
 	}
 
-	logRotateBytes, err := parseutil.ParseInt(config.LogRotateBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	logRotateMaxFiles, err := parseutil.ParseInt(config.LogRotateMaxFiles)
-	if err != nil {
-		return nil, err
-	}
-
 	logCfg := &loghelper.LogConfig{
 		Name:              "vault",
 		LogLevel:          logLevel,
 		LogFormat:         logFormat,
 		LogFilePath:       config.LogFile,
 		LogRotateDuration: logRotateDuration,
-		LogRotateBytes:    int(logRotateBytes),
-		LogRotateMaxFiles: int(logRotateMaxFiles),
+		LogRotateBytes:    config.LogRotateBytes,
+		LogRotateMaxFiles: config.LogRotateMaxFiles,
 	}
 
 	return loghelper.Setup(logCfg, c.logWriter)

--- a/helper/logging/logger.go
+++ b/helper/logging/logger.go
@@ -41,10 +41,10 @@ type LogConfig struct {
 	LogRotateDuration time.Duration
 
 	// LogRotateBytes is the user specified byte limit to rotate logs
-	LogRotateBytes int
+	LogRotateBytes *int
 
 	// LogRotateMaxFiles is the maximum number of past archived log files to keep
-	LogRotateMaxFiles int
+	LogRotateMaxFiles *int
 }
 
 func (c *LogConfig) isLevelInvalid() bool {
@@ -122,12 +122,21 @@ func Setup(config *LogConfig, w io.Writer) (log.InterceptLogger, error) {
 		if config.LogRotateDuration == 0 {
 			config.LogRotateDuration = defaultRotateDuration
 		}
+
+		if config.LogRotateBytes == nil {
+			config.LogRotateBytes = new(int)
+		}
+
+		if config.LogRotateMaxFiles == nil {
+			config.LogRotateMaxFiles = new(int)
+		}
+
 		logFile := &LogFile{
 			fileName:         fileName,
 			logPath:          dir,
 			duration:         config.LogRotateDuration,
-			maxBytes:         config.LogRotateBytes,
-			maxArchivedFiles: config.LogRotateMaxFiles,
+			maxBytes:         *config.LogRotateBytes,
+			maxArchivedFiles: *config.LogRotateMaxFiles,
 		}
 		if err := logFile.pruneFiles(); err != nil {
 			return nil, fmt.Errorf("failed to prune log files: %w", err)

--- a/helper/logging/logger.go
+++ b/helper/logging/logger.go
@@ -41,10 +41,10 @@ type LogConfig struct {
 	LogRotateDuration time.Duration
 
 	// LogRotateBytes is the user specified byte limit to rotate logs
-	LogRotateBytes *int
+	LogRotateBytes int
 
 	// LogRotateMaxFiles is the maximum number of past archived log files to keep
-	LogRotateMaxFiles *int
+	LogRotateMaxFiles int
 }
 
 func (c *LogConfig) isLevelInvalid() bool {
@@ -123,20 +123,12 @@ func Setup(config *LogConfig, w io.Writer) (log.InterceptLogger, error) {
 			config.LogRotateDuration = defaultRotateDuration
 		}
 
-		if config.LogRotateBytes == nil {
-			config.LogRotateBytes = new(int)
-		}
-
-		if config.LogRotateMaxFiles == nil {
-			config.LogRotateMaxFiles = new(int)
-		}
-
 		logFile := &LogFile{
 			fileName:         fileName,
 			logPath:          dir,
 			duration:         config.LogRotateDuration,
-			maxBytes:         *config.LogRotateBytes,
-			maxArchivedFiles: *config.LogRotateMaxFiles,
+			maxBytes:         config.LogRotateBytes,
+			maxArchivedFiles: config.LogRotateMaxFiles,
 		}
 		if err := logFile.pruneFiles(); err != nil {
 			return nil, fmt.Errorf("failed to prune log files: %w", err)

--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -41,9 +41,9 @@ type SharedConfig struct {
 	LogFormat         string `hcl:"log_format"`
 	LogLevel          string `hcl:"log_level"`
 	LogFile           string `hcl:"log_file"`
-	LogRotateBytes    string `hcl:"log_rotate_bytes"`
+	LogRotateBytes    int    `hcl:"log_rotate_bytes"`
 	LogRotateDuration string `hcl:"log_rotate_duration"`
-	LogRotateMaxFiles string `hcl:"log_rotate_max_files"`
+	LogRotateMaxFiles int    `hcl:"log_rotate_max_files"`
 
 	PidFile string `hcl:"pid_file"`
 

--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -38,12 +38,14 @@ type SharedConfig struct {
 	// LogFormat specifies the log format. Valid values are "standard" and
 	// "json". The values are case-insenstive. If no log format is specified,
 	// then standard format will be used.
-	LogFormat         string `hcl:"log_format"`
-	LogLevel          string `hcl:"log_level"`
-	LogFile           string `hcl:"log_file"`
-	LogRotateBytes    *int   `hcl:"log_rotate_bytes"`
-	LogRotateDuration string `hcl:"log_rotate_duration"`
-	LogRotateMaxFiles *int   `hcl:"log_rotate_max_files"`
+	LogFormat            string      `hcl:"log_format"`
+	LogLevel             string      `hcl:"log_level"`
+	LogFile              string      `hcl:"log_file"`
+	LogRotateDuration    string      `hcl:"log_rotate_duration"`
+	LogRotateBytes       int         `hcl:"log_rotate_bytes"`
+	LogRotateBytesRaw    interface{} `hcl:"log_rotate_bytes"`
+	LogRotateMaxFiles    int         `hcl:"log_rotate_max_files"`
+	LogRotateMaxFilesRaw interface{} `hcl:"log_rotate_max_files"`
 
 	PidFile string `hcl:"pid_file"`
 

--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -41,9 +41,9 @@ type SharedConfig struct {
 	LogFormat         string `hcl:"log_format"`
 	LogLevel          string `hcl:"log_level"`
 	LogFile           string `hcl:"log_file"`
-	LogRotateBytes    int    `hcl:"log_rotate_bytes"`
+	LogRotateBytes    *int   `hcl:"log_rotate_bytes"`
 	LogRotateDuration string `hcl:"log_rotate_duration"`
-	LogRotateMaxFiles int    `hcl:"log_rotate_max_files"`
+	LogRotateMaxFiles *int   `hcl:"log_rotate_max_files"`
 
 	PidFile string `hcl:"pid_file"`
 

--- a/internalshared/configutil/merge.go
+++ b/internalshared/configutil/merge.go
@@ -68,19 +68,15 @@ func (c *SharedConfig) Merge(c2 *SharedConfig) *SharedConfig {
 		result.LogFile = c2.LogFile
 	}
 
-	// TODO: PW: Is this the behavior we want.
-	result.LogRotateBytes = c2.LogRotateBytes
-	//result.LogRotateBytes = c.LogRotateBytes
-	//if c2.LogRotateBytes != "" {
-	//	result.LogRotateBytes = c2.LogRotateBytes
-	//}
+	result.LogRotateBytes = c.LogRotateBytes
+	if c2.LogRotateBytes != nil {
+		result.LogRotateBytes = c2.LogRotateBytes
+	}
 
-	// TODO: PW: Is this the behavior we want.
-	result.LogRotateMaxFiles = c2.LogRotateMaxFiles
-	//result.LogRotateMaxFiles = c.LogRotateMaxFiles
-	//if c2.LogRotateMaxFiles != "" {
-	//	result.LogRotateMaxFiles = c2.LogRotateMaxFiles
-	//}
+	result.LogRotateMaxFiles = c.LogRotateMaxFiles
+	if c2.LogRotateMaxFiles != nil {
+		result.LogRotateMaxFiles = c2.LogRotateMaxFiles
+	}
 
 	result.LogRotateDuration = c.LogRotateDuration
 	if c2.LogRotateDuration != "" {

--- a/internalshared/configutil/merge.go
+++ b/internalshared/configutil/merge.go
@@ -68,15 +68,19 @@ func (c *SharedConfig) Merge(c2 *SharedConfig) *SharedConfig {
 		result.LogFile = c2.LogFile
 	}
 
-	result.LogRotateBytes = c.LogRotateBytes
-	if c2.LogRotateBytes != "" {
-		result.LogRotateBytes = c2.LogRotateBytes
-	}
+	// TODO: PW: Is this the behavior we want.
+	result.LogRotateBytes = c2.LogRotateBytes
+	//result.LogRotateBytes = c.LogRotateBytes
+	//if c2.LogRotateBytes != "" {
+	//	result.LogRotateBytes = c2.LogRotateBytes
+	//}
 
-	result.LogRotateMaxFiles = c.LogRotateMaxFiles
-	if c2.LogRotateMaxFiles != "" {
-		result.LogRotateMaxFiles = c2.LogRotateMaxFiles
-	}
+	// TODO: PW: Is this the behavior we want.
+	result.LogRotateMaxFiles = c2.LogRotateMaxFiles
+	//result.LogRotateMaxFiles = c.LogRotateMaxFiles
+	//if c2.LogRotateMaxFiles != "" {
+	//	result.LogRotateMaxFiles = c2.LogRotateMaxFiles
+	//}
 
 	result.LogRotateDuration = c.LogRotateDuration
 	if c2.LogRotateDuration != "" {

--- a/internalshared/configutil/merge.go
+++ b/internalshared/configutil/merge.go
@@ -69,13 +69,15 @@ func (c *SharedConfig) Merge(c2 *SharedConfig) *SharedConfig {
 	}
 
 	result.LogRotateBytes = c.LogRotateBytes
-	if c2.LogRotateBytes != nil {
+	if c2.LogRotateBytesRaw != nil {
 		result.LogRotateBytes = c2.LogRotateBytes
+		result.LogRotateBytesRaw = c2.LogRotateBytesRaw
 	}
 
 	result.LogRotateMaxFiles = c.LogRotateMaxFiles
-	if c2.LogRotateMaxFiles != nil {
+	if c2.LogRotateMaxFilesRaw != nil {
 		result.LogRotateMaxFiles = c2.LogRotateMaxFiles
+		result.LogRotateMaxFilesRaw = c2.LogRotateMaxFilesRaw
 	}
 
 	result.LogRotateDuration = c.LogRotateDuration


### PR DESCRIPTION
Two of the configuration values related to log rotation are currently set up to expect `string`, however they should be handled as `int` (`log_rotate_bytes` and `log_rotate_max_files`). 

This PR should address this so we expect integers (or in the case of environment variables, strings which can satisfactorily be parsed to integers). 

* Adjusted `log_flags` to expect `int` for max files and max bytes
* Updated `server` and `agent`
*  Renamed updateConfig (and updateLogConfig)
