### PR TITLE
docs/oidc: change user type recommendation for Google workspace integration

### DIFF
--- a/website/content/docs/auth/jwt/oidc-providers/google.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/google.mdx
@@ -10,6 +10,7 @@ Main reference: [Using OAuth 2.0 to Access Google APIs](https://developers.googl
 
 1. Visit the [Google API Console](https://console.developers.google.com).
 1. Create or a select a project.
+1. Navigate to Menu > APIs & Services
 1. Create a new credential via Credentials > Create Credentials > OAuth Client ID.
 1. Configure the OAuth Consent Screen. Application Name is required. Save.
 1. Select application type: "Web Application".
@@ -32,7 +33,9 @@ To set up the Google-specific handling, you'll need:
   for granting domain-wide delegation API client access.
 - The ability to create a service account in [Google Cloud Platform](https://console.developers.google.com/iam-admin/serviceaccounts).
 - To enable the [Admin SDK API](https://console.developers.google.com/apis/api/admin.googleapis.com/overview).
-- An OAuth 2.0 application with an [external user type](https://support.google.com/cloud/answer/10311615#user-type).
+- An OAuth 2.0 application with an [internal user type](https://support.google.com/cloud/answer/10311615#user-type).
+  We do not recommend using an external user type since it would allow _any user_ with a
+  Google account to authenticate with Vault.
 
 The Google-specific handling that's used to fetch Google Workspace groups and user information in Vault uses
 Google Workspace Domain-Wide Delegation of Authority for authentication and authorization. You need to follow

--- a/website/content/docs/auth/jwt/oidc-providers/google.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/google.mdx
@@ -34,7 +34,7 @@ To set up the Google-specific handling, you'll need:
 - The ability to create a service account in [Google Cloud Platform](https://console.developers.google.com/iam-admin/serviceaccounts).
 - To enable the [Admin SDK API](https://console.developers.google.com/apis/api/admin.googleapis.com/overview).
 - An OAuth 2.0 application with an [internal user type](https://support.google.com/cloud/answer/10311615#user-type).
-  We do not recommend using an external user type since it would allow _any user_ with a
+  We **do not** recommend using an external user type since it would allow _any user_ with a
   Google account to authenticate with Vault.
 
 The Google-specific handling that's used to fetch Google Workspace groups and user information in Vault uses


### PR DESCRIPTION
This PR changes the [user type](https://support.google.com/cloud/answer/10311615#user-type) recommendation in the setup documentation for the OIDC and Google workspace integration. This is in response to the discuss post at https://discuss.hashicorp.com/t/potential-security-risk-when-providing-external-access-to-oauth-app-needed-for-oidc-gsuite-backend/48466.

I've tested that using the internal user type works as expected before making this recommendation.