### PR TITLE
VAULT-12542 Add info encouraging users to upgrade if agent version is different to server

### DIFF
--- a/changelog/18684.txt
+++ b/changelog/18684.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: Add note in logs when starting Vault Agent indicating if the version differs to the Vault Server.
+```

--- a/command/agent.go
+++ b/command/agent.go
@@ -267,8 +267,8 @@ func (c *AgentCommand) Run(args []string) int {
 		serverVersion := serverHealth.Version
 		agentVersion := version.GetVersion().VersionNumber()
 		if serverVersion != agentVersion {
-			c.UI.Info("==> Note: Vault Agent is not running with the same version as Vault itself, we recommend you upgrade! " +
-				fmt.Sprintf("Vault Agent version: %s, Vault version: %s", agentVersion, serverVersion))
+			c.UI.Info("==> Note: Vault Agent version does not match Vault server version. " +
+				fmt.Sprintf("Vault Agent version: %s, Vault server version: %s", agentVersion, serverVersion))
 		}
 	}
 

--- a/command/agent.go
+++ b/command/agent.go
@@ -250,7 +250,7 @@ func (c *AgentCommand) Run(args []string) int {
 		return 0
 	}
 
-	// Ignore any setting of agent's address. This client is used by the agent
+	// Ignore any setting of Agent's address. This client is used by the Agent
 	// to reach out to Vault. This should never loop back to agent.
 	c.flagAgentAddress = ""
 	client, err := c.Client()
@@ -259,6 +259,17 @@ func (c *AgentCommand) Run(args []string) int {
 			"Error fetching client: %v",
 			err))
 		return 1
+	}
+
+	serverHealth, err := client.Sys().Health()
+	if err == nil {
+		// We don't exit on error here, as this is not worth stopping Agent over
+		serverVersion := serverHealth.Version
+		agentVersion := version.GetVersion().VersionNumber()
+		if serverVersion != agentVersion {
+			c.UI.Info("==> Note: Vault Agent is not running with the same version as Vault itself, we recommend you upgrade! " +
+				fmt.Sprintf("Vault Agent version: %s, Vault version: %s", agentVersion, serverVersion))
+		}
 	}
 
 	// ctx and cancelFunc are passed to the AuthHandler, SinkServer, and


### PR DESCRIPTION
Appears like this:
```
violet@violet-TX54KFJWXM vault % vault agent -config=../vault_agent.hcl
==> Note: Vault Agent is not running with the same version as Vault itself, we recommend you upgrade! Vault Agent version: 1.13.0-dev1, Vault version: 1.12.0-rc1
==> Vault Agent started! Log data will stream in below:
```

![image](https://user-images.githubusercontent.com/1594272/212153165-5459c58e-d307-475c-9c32-fa48db0c34c8.png)

