### PR TITLE
Refactor the PKI revocation handler to prep for unified revocation

### DIFF
--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -527,7 +527,7 @@ func revokeCert(sc *storageContext, cert *x509.Certificate) (*logical.Response, 
 
 	// Add a little wiggle room because leases are stored with a second
 	// granularity
-	if time.Since(cert.NotAfter) > -2*time.Second {
+	if cert.NotAfter.Before(time.Now().Add(2 * time.Second)) {
 		response := &logical.Response{}
 		response.AddWarning(fmt.Sprintf("certificate with serial %s already expired; refusing to add to CRL", colonSerial))
 		return response, nil

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -391,7 +391,7 @@ func (b *backend) pathRevokeWrite(ctx context.Context, req *logical.Request, dat
 	// disk.
 	if writeCert {
 		err := req.Storage.Put(ctx, &logical.StorageEntry{
-			Key:   "certs/" + serial,
+			Key:   "certs/" + normalizeSerial(serial),
 			Value: cert.Raw,
 		})
 		if err != nil {

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -9,8 +9,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"strings"
-
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -420,13 +418,12 @@ func (b *backend) pathRevokeWrite(ctx context.Context, req *logical.Request, dat
 
 	// We store and identify by lowercase colon-separated hex, but other
 	// utilities use dashes and/or uppercase, so normalize
-	serial = strings.ReplaceAll(strings.ToLower(serial), "-", ":")
-
+	colonSerial := denormalizeSerial(serial)
 	b.revokeStorageLock.Lock()
 	defer b.revokeStorageLock.Unlock()
 
 	sc := b.makeStorageContext(ctx, req.Storage)
-	return revokeCert(sc, serial, false)
+	return revokeCert(sc, colonSerial, false)
 }
 
 func (b *backend) pathRotateCRLRead(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/errutil"

--- a/builtin/logical/pki/secret_certs.go
+++ b/builtin/logical/pki/secret_certs.go
@@ -49,7 +49,8 @@ func (b *backend) secretCredsRevoke(ctx context.Context, req *logical.Request, _
 	defer b.revokeStorageLock.Unlock()
 
 	sc := b.makeStorageContext(ctx, req.Storage)
-	resp, err := revokeCert(sc, serialInt.(string), true)
+	colonSerial := denormalizeSerial(serialInt.(string))
+	resp, err := revokeCert(sc, colonSerial, true)
 	if resp == nil && err == nil {
 		b.Logger().Warn("expired certificate revoke failed because not found in storage, treating as success", "serial", serialInt.(string))
 	}

--- a/builtin/logical/pki/secret_certs.go
+++ b/builtin/logical/pki/secret_certs.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/vault/sdk/framework"
-	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -54,12 +53,7 @@ func (b *backend) secretCredsRevoke(ctx context.Context, req *logical.Request, _
 
 	certEntry, err := fetchCertBySerial(sc, "certs/", serialInt.(string))
 	if err != nil {
-		switch err.(type) {
-		case errutil.UserError:
-			return logical.ErrorResponse(err.Error()), nil
-		default:
-			return nil, err
-		}
+		return nil, err
 	}
 	if certEntry == nil {
 		// We can't write to revoked/ or update the CRL anyway because we don't have the cert,
@@ -72,9 +66,6 @@ func (b *backend) secretCredsRevoke(ctx context.Context, req *logical.Request, _
 	cert, err := x509.ParseCertificate(certEntry.Value)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing certificate: %w", err)
-	}
-	if cert == nil {
-		return nil, fmt.Errorf("got a nil certificate")
 	}
 
 	// Compatibility: Don't revoke CAs if they had leases. New CAs going forward aren't issued leases.

--- a/builtin/logical/pki/secret_certs.go
+++ b/builtin/logical/pki/secret_certs.go
@@ -2,9 +2,11 @@ package pki
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 
 	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -49,10 +51,36 @@ func (b *backend) secretCredsRevoke(ctx context.Context, req *logical.Request, _
 	defer b.revokeStorageLock.Unlock()
 
 	sc := b.makeStorageContext(ctx, req.Storage)
-	colonSerial := denormalizeSerial(serialInt.(string))
-	resp, err := revokeCert(sc, colonSerial, true)
-	if resp == nil && err == nil {
-		b.Logger().Warn("expired certificate revoke failed because not found in storage, treating as success", "serial", serialInt.(string))
+
+	certEntry, err := fetchCertBySerial(sc, "certs/", serialInt.(string))
+	if err != nil {
+		switch err.(type) {
+		case errutil.UserError:
+			return logical.ErrorResponse(err.Error()), nil
+		default:
+			return nil, err
+		}
 	}
-	return resp, err
+	if certEntry == nil {
+		// We can't write to revoked/ or update the CRL anyway because we don't have the cert,
+		// and there's no reason to expect this will work on a subsequent
+		// retry.  Just give up and let the lease get deleted.
+		b.Logger().Warn("expired certificate revoke failed because not found in storage, treating as success", "serial", serialInt.(string))
+		return nil, nil
+	}
+
+	cert, err := x509.ParseCertificate(certEntry.Value)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing certificate: %w", err)
+	}
+	if cert == nil {
+		return nil, fmt.Errorf("got a nil certificate")
+	}
+
+	// Compatibility: Don't revoke CAs if they had leases. New CAs going forward aren't issued leases.
+	if cert.IsCA {
+		return nil, nil
+	}
+
+	return revokeCert(sc, cert)
 }


### PR DESCRIPTION
For reviewers: step through this PR commit by commit as trying to decipher/validate this is doing the same thing will be difficult taking in all the changes in one go 

The point of this refactoring is to better isolate the code that does the final storage related to the revocation of a certificate. Many things had been mixed into a single function making it harder to implement the unified storage case than it should have been.

Items done within this refactoring:
- Move out lease specific revocation back into secret_certs.go 
- Load the certificate related to the revocation only once during the revocation process (BYOC we had at least 2 loads from storage and parsing of the certificate)

Code change/fix:
- The last commit fixes a "bug" in which for BYOC we wrote out the certificate if it wasn't stored using the legacy colon separator instead of the hyphen. It wasn't really a problem as we attempt to load using both for compatibility purposes when fetching certificates.