### PR TITLE
[Docs] Add VAULT_LOG_LEVEL to the environment var list

### DIFF
--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -331,6 +331,11 @@ precedence over [#VAULT_LICENSE_PATH](#vault_license_path) and
 [Enterprise, Server only] Specify a path to a license on disk to use for this node.
 This takes precedence over [license_path in config](/docs/configuration#license_path).
 
+### `VAULT_LOG_LEVEL`
+
+Set the Vault server's log level. The supported values are `trace`, `debug`,
+`info`, `warn`, and `err`. The default log leve is `info`.
+
 ### `VAULT_MAX_RETRIES`
 
 Maximum number of retries when certain error codes are encountered. The default


### PR DESCRIPTION
🧵 [Slack thread](https://hashicorp.slack.com/archives/C8DK5PR0B/p1673505578697569)

🔍 [Deploy preview](https://vault-git-docs-add-missing-env-hashicorp.vercel.app/vault/docs/commands#vault_log_level)

It was reported that the `VAULT_LOG_LEVEL` env var is missing from [the docs](https://developer.hashicorp.com/vault/docs/commands#environment-variables).  This PR adds the missing env var definition. 