### PR TITLE
GCP Cloud KMS link points to Azure Key Vault page

### DIFF
--- a/website/content/docs/use-cases.mdx
+++ b/website/content/docs/use-cases.mdx
@@ -60,4 +60,4 @@ Working with cloud providers requires that you use their security features, whic
 
 - Try our [Key Management Secrets Engine with Azure Key Vault](https://learn.hashicorp.com/tutorials/vault/key-management-secrets-engine-azure-key-vault?in=vault/adp) to enable management of the Key Vault key with the Key Management secrets engine.
 
-- Try our [Key Management Secrets Engine with GCP Cloud KMS](https://learn.hashicorp.com/tutorials/vault/key-management-secrets-engine-azure-key-vault?in=vault/adp) to enable management of the Key Value key with the Key Management secrets engine.
+- Try our [Key Management Secrets Engine with GCP Cloud KMS](https://learn.hashicorp.com/tutorials/vault/key-management-secrets-engine-gcp-cloud-kms) to enable management of the Key Value key with the Key Management secrets engine.


### PR DESCRIPTION
Fixing the GCP Cloud KMS link that was wrongly pointing to the Azure Key Vault page.