### PR TITLE
Speculative fix for a panic that might arise during raft teardown

### DIFF
--- a/changelog/18704.txt
+++ b/changelog/18704.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+storage/raft: Fix race with follower heartbeat tracker during teardown.
+```

--- a/physical/raft/raft_autopilot.go
+++ b/physical/raft/raft_autopilot.go
@@ -551,6 +551,13 @@ func (b *RaftBackend) startFollowerHeartbeatTracker() {
 	}
 	for range tickerCh {
 		b.l.RLock()
+		if b.raft == nil {
+			// We could be racing with teardown, which will stop the ticker
+			// but that doesn't guarantee that we won't reach this line with a nil
+			// b.raft.
+			b.l.RUnlock()
+			return
+		}
 		b.followerStates.l.RLock()
 		myAppliedIndex := b.raft.AppliedIndex()
 		for peerID, state := range b.followerStates.followers {


### PR DESCRIPTION
Panic we're trying to fix is here: https://app.circleci.com/pipelines/github/hashicorp/vault/4864/workflows/2ca6331a-2f99-4a50-92eb-2fa7575f8695/jobs/569495/parallel-runs/7

We think we ruled out all other explanations for that panic, landing on the theory that the ticker was still firing one last shot after a teardown, e.g. when we sealed.  I don't think any of the relevant code has changed in a long time, and I haven't seen this failure before, so it's presumably a very narrow race.