### PR TITLE
VAULT-6714 Provide Enterprise-only Feature Error for Enterprise Paths

### DIFF
--- a/enos/modules/vault_verify_replication/templates/smoke-verify-replication.sh
+++ b/enos/modules/vault_verify_replication/templates/smoke-verify-replication.sh
@@ -15,7 +15,7 @@ function fail() {
 # Replication status endpoint should have data.mode disabled for OSS release
 status=$(curl -s http://localhost:8200/v1/sys/replication/status)
 if [ "$edition" == "oss" ]; then
-  if [ "$(jq -r '.data.mode' <<< "$status")" != "disabled" ]; then
+  if [ "$(jq -r '.errors[0]' <<< "$status")" != "enterprise-only feature" ]; then
     fail "replication data mode is not disabled for OSS release!"
   fi
 else

--- a/vault/logical_system_helpers.go
+++ b/vault/logical_system_helpers.go
@@ -58,21 +58,7 @@ var (
 	}
 
 	entPaths = func(b *SystemBackend) []*framework.Path {
-		return []*framework.Path{
-			{
-				Pattern: "replication/status",
-				Callbacks: map[logical.Operation]framework.OperationFunc{
-					logical.ReadOperation: func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-						resp := &logical.Response{
-							Data: map[string]interface{}{
-								"mode": "disabled",
-							},
-						}
-						return resp, nil
-					},
-				},
-			},
-		}
+		return enterprisePaths
 	}
 	handleGlobalPluginReload = func(context.Context, *Core, string, string, []string) error {
 		return nil
@@ -87,6 +73,10 @@ var (
 	}
 	checkRaw = func(b *SystemBackend, path string) error { return nil }
 )
+
+func enterpriseOnlyErrorOperationFunc(context.Context, *logical.Request, *framework.FieldData) (*logical.Response, error) {
+	return logical.ErrorResponse("enterprise-only feature"), logical.ErrUnsupportedPath
+}
 
 // tuneMount is used to set config on a mount point
 func (b *SystemBackend) tuneMountTTLs(ctx context.Context, path string, me *MountEntry, newDefault, newMax time.Duration) error {

--- a/vault/logical_system_path_generated.go
+++ b/vault/logical_system_path_generated.go
@@ -1,0 +1,17 @@
+package vault
+
+import (
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+var enterprisePaths = []*framework.Path{
+	{
+		Pattern: "replication/status",
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: enterpriseOnlyErrorOperationFunc,
+			},
+		},
+	},
+}


### PR DESCRIPTION
This PR refactors the hook to add enterprise-only paths into the System Backend to facilitate the automatic generation of the set of enterprise-only paths (framework.Path) with a common callback function that returns an error indicating that the path is unsupported with the error message `enterprise-only feature`.

Currently, only the `replication/status` System Backend path is defined in the Open-source version of Vault, so the refactoring done by this PR only affects this path. But all other paths should be able to be added to the open-source version with the above-mentioned callback function.

A new file named *logical_system_path_generated.go* is being introduced as it will contain the automatically generated set of enterprise-only paths. The file should not be modified by any other means than the generator tool used by HashiCorp.

## Testing

Queried the `replication/status` endpoint to confirm that the error message `enterprise-only feature` was returned.

```
$ curl -H "X-Vault-Token: $VAULT_TOKEN" "$VAULT_ADDR/v1/sys/replication/status"
{"errors":["enterprise-only feature"]}
```

## Concerns

This change does result in some behavioural changes in the response provided for paths that are enterprise-only from an Open-source version of Vault. Prior to this change, the response resembled:
```
$ curl -H "X-Vault-Token: $VAULT_TOKEN" "$VAULT_ADDR/v1/sys/replication/status"
{"request_id":"27b395af-7faf-50f7-e137-ba752a01b37b","lease_id":"","renewable":false,"lease_duration":0,"data":{"mode":"disabled"},"wrap_info":null,"warnings":null,"auth":null}
```