### PR TITLE
Remove timeout logic from ReadRaw functions and add ReadRawWithContext

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -114,7 +114,11 @@ type Config struct {
 	// of three tries).
 	MaxRetries int
 
-	// Timeout is for setting custom timeout parameter in the HttpClient
+	// Timeout, given a non-negative value, will apply the request timeout
+	// to each request function unless an earlier deadline is passed to the
+	// request function through context.Context. Note that this timeout is
+	// not applicable to Logical().ReadRaw* (raw response) functions.
+	// Defaults to 60 seconds.
 	Timeout time.Duration
 
 	// If there is an error when creating the configuration, this will be the

--- a/api/logical.go
+++ b/api/logical.go
@@ -69,20 +69,46 @@ func (c *Logical) ReadWithDataWithContext(ctx context.Context, path string, data
 	return c.ParseRawResponseAndCloseBody(resp, err)
 }
 
+// ReadRaw attempts to read the value stored at the given Vault path
+// (without '/v1/' prefix) and returns a raw *http.Response.
+//
+// Note: the raw-response functions do not respect the client-configured
+// request timeout; if a timeout is desired, please use ReadRawWithContext
+// instead and set the timeout through context.WithTimeout or context.WithDeadline.
 func (c *Logical) ReadRaw(path string) (*Response, error) {
-	return c.ReadRawWithData(path, nil)
+	return c.ReadRawWithDataWithContext(context.Background(), path, nil)
 }
 
+// ReadRawWithContext attempts to read the value stored at the give Vault path
+// (without '/v1/' prefix) and returns a raw *http.Response.
+//
+// Note: the raw-response functions do not respect the client-configured
+// request timeout; if a timeout is desired, please set it through
+// context.WithTimeout or context.WithDeadline.
+func (c *Logical) ReadRawWithContext(ctx context.Context, path string) (*Response, error) {
+	return c.ReadRawWithDataWithContext(ctx, path, nil)
+}
+
+// ReadRawWithData attempts to read the value stored at the given Vault
+// path (without '/v1/' prefix) and returns a raw *http.Response. The 'data' map
+// is added as query parameters to the request.
+//
+// Note: the raw-response functions do not respect the client-configured
+// request timeout; if a timeout is desired, please use
+// ReadRawWithDataWithContext instead and set the timeout through
+// context.WithTimeout or context.WithDeadline.
 func (c *Logical) ReadRawWithData(path string, data map[string][]string) (*Response, error) {
 	return c.ReadRawWithDataWithContext(context.Background(), path, data)
 }
 
+// ReadRawWithDataWithContext attempts to read the value stored at the given
+// Vault path (without '/v1/' prefix) and returns a raw *http.Response. The 'data'
+// map is added as query parameters to the request.
+//
+// Note: the raw-response functions do not respect the client-configured
+// request timeout; if a timeout is desired, please set it through
+// context.WithTimeout or context.WithDeadline.
 func (c *Logical) ReadRawWithDataWithContext(ctx context.Context, path string, data map[string][]string) (*Response, error) {
-	// See note in client.go, RawRequestWithContext for why we do not call
-	// Cancel here. The difference between these two methods are that the
-	// former takes a Request object directly, whereas this builds one
-	// up for the caller.
-	ctx, _ = c.c.withConfiguredTimeout(ctx)
 	return c.readRawWithDataWithContext(ctx, path, data)
 }
 

--- a/changelog/18708.txt
+++ b/changelog/18708.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Remove timeout logic from ReadRaw functions and add ReadRawWithContext
+```

--- a/command/healthcheck/healthcheck.go
+++ b/command/healthcheck/healthcheck.go
@@ -164,7 +164,7 @@ func (e *Executor) FetchIfNotFetched(op logical.Operation, rawPath string) (*Pat
 		return nil, fmt.Errorf("unknown operation: %v on %v", op, path)
 	}
 
-	// client.ReadRaw* functions require a manual timeout override
+	// client.ReadRaw* methods require a manual timeout override
 	ctx, cancel := context.WithTimeout(context.Background(), e.Client.ClientTimeout())
 	defer cancel()
 

--- a/command/healthcheck/healthcheck.go
+++ b/command/healthcheck/healthcheck.go
@@ -28,7 +28,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/logical"

--- a/command/healthcheck/healthcheck.go
+++ b/command/healthcheck/healthcheck.go
@@ -136,9 +136,6 @@ func (e *Executor) templatePath(path string) string {
 }
 
 func (e *Executor) FetchIfNotFetched(op logical.Operation, rawPath string) (*PathFetch, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
 	path := e.templatePath(rawPath)
 
 	byOp, present := e.Resources[path]
@@ -166,6 +163,10 @@ func (e *Executor) FetchIfNotFetched(op logical.Operation, rawPath string) (*Pat
 	} else if op != logical.ReadOperation {
 		return nil, fmt.Errorf("unknown operation: %v on %v", op, path)
 	}
+
+	// client.ReadRaw* functions require a manual timeout override
+	ctx, cancel := context.WithTimeout(context.Background(), e.Client.ClientTimeout())
+	defer cancel()
 
 	response, err := e.Client.Logical().ReadRawWithDataWithContext(ctx, path, data)
 	ret.Response = response

--- a/command/read.go
+++ b/command/read.go
@@ -79,7 +79,7 @@ func (c *ReadCommand) Run(args []string) int {
 		return 2
 	}
 
-	// client.ReadRaw* functions require a manual timeout override
+	// client.ReadRaw* methods require a manual timeout override
 	ctx, cancel := context.WithTimeout(context.Background(), client.ClientTimeout())
 	defer cancel()
 

--- a/command/read.go
+++ b/command/read.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"

--- a/command/read.go
+++ b/command/read.go
@@ -59,9 +59,6 @@ func (c *ReadCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *ReadCommand) Run(args []string) int {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
 	f := c.Flags()
 
 	if err := f.Parse(args, ParseOptionAllowRawFormat(true)); err != nil {
@@ -81,6 +78,10 @@ func (c *ReadCommand) Run(args []string) int {
 		c.UI.Error(err.Error())
 		return 2
 	}
+
+	// client.ReadRaw* functions require a manual timeout override
+	ctx, cancel := context.WithTimeout(context.Background(), client.ClientTimeout())
+	defer cancel()
 
 	// Pull our fake stdin if needed
 	stdin := (io.Reader)(os.Stdin)


### PR DESCRIPTION
Removing the timeout logic from raw-response functions and adding documentation comments. The following functions are affected:

- `ReadRaw`
- `ReadRawWithContext` (newly added)
- `ReadRawWithData`
- `ReadRawWithDataWithContext`

The previous logic of using `ctx, _ = c.c.withConfiguredTimeout(ctx)` could cause a potential [context leak](https://pkg.go.dev/context):

> Failing to call the CancelFunc leaks the child and its children until the parent is canceled or the timer fires. The go vet tool checks that CancelFuncs are used on all control-flow paths.

Cancelling the context would have caused more issues since the context would be cancelled before the request body is closed.

Resolves: #18658 