### PR TITLE
docs: updates authoring info for custom alerts

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -98,7 +98,7 @@ There is currently a small bug with new page creation - if you create a new page
 
 There are several custom markdown plugins that are available by default that enhance [standard markdown](https://commonmark.org/) to fit our use cases. This set of plugins introduces a couple instances of custom syntax, and a couple specific pitfalls that are not present by default with markdown, detailed below:
 
-- If you see the symbols `~>`, `->`, `=>`, or `!>`, these represent [custom alerts](https://github.com/hashicorp/remark-plugins/tree/master/plugins/paragraph-custom-alerts#paragraph-custom-alerts). These render as colored boxes to draw the user's attention to some type of aside.
+- > **Warning**: We are deprecating the current [paragraph alerts](https://github.com/hashicorp/remark-plugins/tree/master/plugins/paragraph-custom-alerts#paragraph-custom-alerts), in favor of the newer [MDX Inline Alert](#alerts) components. The legacy paragraph alerts are represented by the symbols `~>`, `->`, `=>`, or `!>`. They render as colored boxes to draw the user's attention to some type of aside.
 - If you see `@include '/some/path.mdx'`, this is a [markdown include](https://github.com/hashicorp/remark-plugins/tree/master/plugins/include-markdown#include-markdown-plugin). It's worth noting as well that all includes resolve from `website/content/partials` by default, and that changes to partials will not live-reload the website.
 - If you see `# Headline ((#slug))`, this is an example of an [anchor link alias](https://github.com/hashicorp/remark-plugins/tree/je.anchor-link-adjustments/plugins/anchor-links#anchor-link-aliases). It adds an extra permalink to a headline for compatibility and is removed from the output.
 - Due to [automatically generated permalinks](https://github.com/hashicorp/remark-plugins/tree/je.anchor-link-adjustments/plugins/anchor-links#anchor-links), any text changes to _headlines_ or _list items that begin with inline code_ can and will break existing permalinks. Be very cautious when changing either of these two text items.
@@ -122,6 +122,45 @@ There are several custom markdown plugins that are available by default that enh
 ### Custom Components
 
 A number of custom [mdx components](https://mdxjs.com/) are available for use within any `.mdx` file. Each one is documented below:
+
+#### Alerts
+
+There are custom MDX components available to author alert data. [See the full documentation here](https://developer.hashicorp.com/swingset/components/mdxinlinealert). 
+
+```mdx
+## Alert types
+
+### Tip
+
+<Tip>
+	To provide general information to the user regarding the current context or
+	relevant actions.
+</Tip>
+
+### Highlight
+
+<Highlight>
+	To provide general or promotional information to the user prominently.
+</Highlight>
+
+### Note
+
+<Note>
+	To help users avoid an issue. Provide guidance and actions if possible.
+</Note>
+
+### Warning
+
+<Warning>
+	To indicate critical issues that need immediate action or help users
+	understand something critical.
+</Warning>
+
+## Title override prop
+
+<Note title="Hashiconf 2027">To provide general information.</Note>
+```
+
 
 #### Tabs
 

--- a/website/README.md
+++ b/website/README.md
@@ -125,7 +125,7 @@ A number of custom [mdx components](https://mdxjs.com/) are available for use wi
 
 #### Inline Alerts
 
-There are custom MDX components available to author alert data. [See the full documentation here](https://developer.hashicorp.com/swingset/components/mdxinlinealert). 
+There are custom MDX components available to author alert data. [See the full documentation here](https://developer.hashicorp.com/swingset/components/mdxinlinealert). They render as colored boxes to draw the user's attention to some type of aside.
 
 ```mdx
 ## Alert types

--- a/website/README.md
+++ b/website/README.md
@@ -98,7 +98,7 @@ There is currently a small bug with new page creation - if you create a new page
 
 There are several custom markdown plugins that are available by default that enhance [standard markdown](https://commonmark.org/) to fit our use cases. This set of plugins introduces a couple instances of custom syntax, and a couple specific pitfalls that are not present by default with markdown, detailed below:
 
-- > **Warning**: We are deprecating the current [paragraph alerts](https://github.com/hashicorp/remark-plugins/tree/master/plugins/paragraph-custom-alerts#paragraph-custom-alerts), in favor of the newer [MDX Inline Alert](#alerts) components. The legacy paragraph alerts are represented by the symbols `~>`, `->`, `=>`, or `!>`. They render as colored boxes to draw the user's attention to some type of aside.
+- > **Warning**: We are deprecating the current [paragraph alerts](https://github.com/hashicorp/remark-plugins/tree/master/plugins/paragraph-custom-alerts#paragraph-custom-alerts), in favor of the newer [MDX Inline Alert](#inline-alerts) components. The legacy paragraph alerts are represented by the symbols `~>`, `->`, `=>`, or `!>`. They render as colored boxes to draw the user's attention to some type of aside.
 - If you see `@include '/some/path.mdx'`, this is a [markdown include](https://github.com/hashicorp/remark-plugins/tree/master/plugins/include-markdown#include-markdown-plugin). It's worth noting as well that all includes resolve from `website/content/partials` by default, and that changes to partials will not live-reload the website.
 - If you see `# Headline ((#slug))`, this is an example of an [anchor link alias](https://github.com/hashicorp/remark-plugins/tree/je.anchor-link-adjustments/plugins/anchor-links#anchor-link-aliases). It adds an extra permalink to a headline for compatibility and is removed from the output.
 - Due to [automatically generated permalinks](https://github.com/hashicorp/remark-plugins/tree/je.anchor-link-adjustments/plugins/anchor-links#anchor-links), any text changes to _headlines_ or _list items that begin with inline code_ can and will break existing permalinks. Be very cautious when changing either of these two text items.
@@ -123,7 +123,7 @@ There are several custom markdown plugins that are available by default that enh
 
 A number of custom [mdx components](https://mdxjs.com/) are available for use within any `.mdx` file. Each one is documented below:
 
-#### Alerts
+#### Inline Alerts
 
 There are custom MDX components available to author alert data. [See the full documentation here](https://developer.hashicorp.com/swingset/components/mdxinlinealert). 
 


### PR DESCRIPTION
This updates documentation regarding the new [mdx inline alert components. ](https://developer.hashicorp.com/swingset/components/mdxinlinealert)