### PR TITLE
UI: PKI Generate Root Form

### DIFF
--- a/ui/app/adapters/pki/action.js
+++ b/ui/app/adapters/pki/action.js
@@ -2,7 +2,7 @@ import { assert } from '@ember/debug';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 import ApplicationAdapter from '../application';
 
-export default class PkiConfigAdapter extends ApplicationAdapter {
+export default class PkiActionAdapter extends ApplicationAdapter {
   namespace = 'v1';
 
   urlForCreateRecord(modelName, snapshot) {

--- a/ui/app/adapters/pki/config.js
+++ b/ui/app/adapters/pki/config.js
@@ -25,4 +25,12 @@ export default class PkiConfigAdapter extends ApplicationAdapter {
         assert('formType must be one of import, generate-root, or generate-csr');
     }
   }
+
+  createRecord(store, type, snapshot) {
+    const serializer = store.serializerFor(type.modelName);
+    const url = this.urlForCreateRecord(type.modelName, snapshot);
+    // Override requestType so that we serialize data based on the endpoint
+    const data = serializer.serialize(snapshot, snapshot.adapterOptions.formType);
+    return this.ajax(url, 'POST', { data });
+  }
 }

--- a/ui/app/decorators/model-form-fields.js
+++ b/ui/app/decorators/model-form-fields.js
@@ -22,17 +22,17 @@ export function withFormFields(propertyNames, groupPropertyNames) {
     return class ModelFormFields extends SuperClass {
       constructor() {
         super(...arguments);
-        if (!Array.isArray(propertyNames) && !Array.isArray(groupPropertyNames)) {
-          throw new Error(
-            'Array of property names and/or array of field groups are required when using withFormFields model decorator'
-          );
-        }
         if (propertyNames) {
           this.formFields = expandAttributeMeta(this, propertyNames);
         }
         if (groupPropertyNames) {
           this.formFieldGroups = fieldToAttrs(this, groupPropertyNames);
         }
+        const allFields = [];
+        this.eachAttribute(function (key) {
+          allFields.push(key);
+        });
+        this.allFields = expandAttributeMeta(this, allFields);
       }
     };
   };

--- a/ui/app/models/pki/action.js
+++ b/ui/app/models/pki/action.js
@@ -20,7 +20,7 @@ const validations = {
 
 @withModelValidations(validations)
 @withFormFields()
-export default class PkiConfigModel extends Model {
+export default class PkiActionModel extends Model {
   @service secretMountPath;
 
   /* formType import */

--- a/ui/app/models/pki/config.js
+++ b/ui/app/models/pki/config.js
@@ -1,12 +1,116 @@
 import Model, { attr } from '@ember-data/model';
 import { inject as service } from '@ember/service';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
+import { withFormFields } from 'vault/decorators/model-form-fields';
 
+@withFormFields()
 export default class PkiConfigModel extends Model {
   @service secretMountPath;
 
+  /* formType import */
   @attr('string') pemBundle;
-  @attr('string') type;
+
+  /* formType generate-root */
+  @attr('string', {
+    possibleValues: ['exported', 'internal', 'existing', 'kms'],
+  })
+  type;
+
+  @attr('string') issuerName; // REQUIRED, cannot be "default"
+
+  @attr('string') keyName; // cannot be "default"
+
+  @attr('string') keyRef; // search-select? only for type=existing
+
+  @attr('string') commonName; // REQUIRED
+
+  @attr('string', {
+    label: 'DNS/Email Subject Alternative Names (SANs)',
+  })
+  altNames; // comma sep strings
+
+  @attr('string', {
+    label: 'IP Subject Alternative Names (SANs)',
+  })
+  ipSans;
+
+  @attr('string') uriSans;
+
+  @attr('string') otherSans;
+
+  @attr('string', {
+    defaultValue: 'pem',
+    possibleValues: ['pem', 'der', 'pem_bundle'],
+  })
+  format;
+
+  @attr('string', {
+    defaultValue: 'der',
+    possibleValues: ['der', 'pkcs8'],
+  })
+  privateKeyFormat;
+
+  @attr('string', {
+    defaultValue: 'rsa',
+    possibleValues: ['rsa', 'ed25519', 'ec'],
+  })
+  keyType;
+
+  @attr('number', {
+    defaultValue: 0,
+    // options management happens in pki-key-parameters
+  })
+  keyBits;
+
+  @attr('number', {
+    defaultValue: -1,
+  })
+  maxPathLength;
+
+  @attr('boolean', {
+    defaultValue: false,
+  })
+  excludeCnFromSans;
+
+  @attr('string', {
+    label: 'Permitted DNS domains',
+  })
+  permittedDnsDomains;
+
+  @attr('string') ou;
+  @attr('string') organization;
+  @attr('string') country;
+  @attr('string') locality;
+  @attr('string') province;
+  @attr('string') streetAddress;
+  @attr('string') postalCode;
+
+  @attr('string') serialNumber;
+
+  @attr({
+    label: 'Backdate validity',
+    detailsLabel: 'Issued certificate backdating',
+    helperTextDisabled: 'Vault will use the default value, 30s',
+    helperTextEnabled:
+      'Also called the not_before_duration property. Allows certificates to be valid for a certain time period before now. This is useful to correct clock misalignment on various systems when setting up your CA.',
+    editType: 'ttl',
+    defaultValue: '30s',
+  })
+  notBeforeDuration;
+
+  @attr('string') managedKeyName;
+  @attr('string') managedKeyId;
+
+  @attr({
+    label: 'Not valid after',
+    detailsLabel: 'Issued certificates expire after',
+    subText:
+      'The time after which this certificate will no longer be valid. This can be a TTL (a range of time from now) or a specific date.',
+    editType: 'yield',
+  })
+  customTtl;
+  @attr('string') ttl;
+  @attr('date') notAfter;
 
   get backend() {
     return this.secretMountPath.currentPath;

--- a/ui/app/serializers/pki/action.js
+++ b/ui/app/serializers/pki/action.js
@@ -8,6 +8,7 @@ export default class PkiActionSerializer extends ApplicationSerializer {
 
   serialize(snapshot, requestType) {
     const data = super.serialize(snapshot);
+    // requestType is a custom value specified from the pki/action adapter
     const allowedPayloadAttributes = this._allowedParamsByType(requestType);
     if (!allowedPayloadAttributes) return data;
 

--- a/ui/app/serializers/pki/action.js
+++ b/ui/app/serializers/pki/action.js
@@ -1,6 +1,6 @@
 import ApplicationSerializer from '../application';
 
-export default class PkiConfigSerializer extends ApplicationSerializer {
+export default class PkiActionSerializer extends ApplicationSerializer {
   attrs = {
     customTtl: { serialize: false },
     type: { serialize: false },

--- a/ui/app/serializers/pki/config.js
+++ b/ui/app/serializers/pki/config.js
@@ -1,3 +1,62 @@
 import ApplicationSerializer from '../application';
 
-export default class PkiConfigSerializer extends ApplicationSerializer {}
+export default class PkiConfigSerializer extends ApplicationSerializer {
+  attrs = {
+    customTtl: { serialize: false },
+    type: { serialize: false },
+  };
+
+  serialize(snapshot, requestType) {
+    const data = super.serialize(snapshot);
+    const allowedPayloadAttributes = this._allowedParamsByType(requestType);
+    if (!allowedPayloadAttributes) return data;
+
+    const payload = {};
+    allowedPayloadAttributes.forEach((key) => {
+      if ('undefined' !== typeof data[key]) {
+        payload[key] = data[key];
+      }
+    });
+    return payload;
+  }
+
+  _allowedParamsByType(formType) {
+    switch (formType) {
+      case 'import':
+        return ['pem_bundle'];
+      case 'generate-root':
+        return [
+          'alt_names',
+          'common_name',
+          'country',
+          'exclude_cn_from_sans',
+          'format',
+          'ip_sans',
+          'issuer_name',
+          'key_bits',
+          'key_name',
+          'key_ref',
+          'key_type',
+          'locality',
+          'managed_key_id',
+          'managed_key_name',
+          'max_path_length',
+          'not_after',
+          'not_before_duration',
+          'organization',
+          'other_sans',
+          'ou',
+          'permitted_dns_domains',
+          'postal_code',
+          'private_key_format',
+          'province',
+          'serial_number',
+          'street_address',
+          'type',
+        ];
+      default:
+        // if type doesn't match, serialize all
+        return null;
+    }
+  }
+}

--- a/ui/lib/pki/addon/components/pki-ca-certificate-import.ts
+++ b/ui/lib/pki/addon/components/pki-ca-certificate-import.ts
@@ -7,7 +7,7 @@ import { tracked } from '@glimmer/tracking';
 import { waitFor } from '@ember/test-waiters';
 import errorMessage from 'vault/utils/error-message';
 import PkiBaseCertificateModel from 'vault/models/pki/certificate/base';
-import PkiConfigModel from 'vault/models/pki/config';
+import PkiActionModel from 'vault/models/pki/action';
 
 /**
  * @module PkiCaCertificateImport
@@ -27,7 +27,7 @@ import PkiConfigModel from 'vault/models/pki/config';
 interface Args {
   onSave: CallableFunction;
   onCancel: CallableFunction;
-  model: PkiBaseCertificateModel | PkiConfigModel;
+  model: PkiBaseCertificateModel | PkiActionModel;
   adapterOptions: object | undefined;
 }
 

--- a/ui/lib/pki/addon/components/pki-configure-form.hbs
+++ b/ui/lib/pki/addon/components/pki-configure-form.hbs
@@ -32,10 +32,15 @@
       @model={{@config}}
       @onCancel={{transition-to "vault.cluster.secrets.backend.pki.overview"}}
       @onSave={{transition-to "vault.cluster.secrets.backend.pki.overview"}}
-      @adapterOptions={{hash formType=this.formType useIssuer=this.shouldUseIssuerEndpoint}}
+      @adapterOptions={{hash formType=this.formType useIssuer=@config.canImportBundle}}
     />
   {{else if (eq this.formType "generate-root")}}
-    <code>POST /root/generate/:type ~or~ /issuers/generate/root/:type</code>
+    <PkiGenerateRoot
+      @model={{@config}}
+      @onSave={{transition-to "vault.cluster.secrets.backend.pki.issuers"}}
+      @onCancel={{this.cancel}}
+      @adapterOptions={{hash formType="generate-root" useIssuer=@config.canGenerateIssuerRoot}}
+    />
   {{else if (eq this.formType "generate-csr")}}
     <code>POST /intermediate/generate/:type ~or~ /issuers/generate/intermediate/:type</code>
   {{else}}

--- a/ui/lib/pki/addon/components/pki-configure-form.hbs
+++ b/ui/lib/pki/addon/components/pki-configure-form.hbs
@@ -45,9 +45,9 @@
         <button type="button" class="button is-primary" disabled={{true}} data-test-pki-config-save>
           Done
         </button>
-        <LinkTo @route="overview" class="button has-left-margin-s" data-test-pki-config-cancel>
+        <button type="button" class="button has-left-margin-s" {{on "click" this.cancel}} data-test-pki-config-cancel>
           Cancel
-        </LinkTo>
+        </button>
       </div>
     </div>
   {{/if}}

--- a/ui/lib/pki/addon/components/pki-configure-form.ts
+++ b/ui/lib/pki/addon/components/pki-configure-form.ts
@@ -4,12 +4,12 @@ import { inject as service } from '@ember/service';
 import Store from '@ember-data/store';
 import Router from '@ember/routing/router';
 import FlashMessageService from 'vault/services/flash-messages';
-import PkiConfigModel from 'vault/models/pki/config';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import PkiActionModel from 'vault/models/pki/action';
 
 interface Args {
-  config: PkiConfigModel;
+  config: PkiActionModel;
 }
 
 /**

--- a/ui/lib/pki/addon/components/pki-configure-form.ts
+++ b/ui/lib/pki/addon/components/pki-configure-form.ts
@@ -6,6 +6,7 @@ import Router from '@ember/routing/router';
 import FlashMessageService from 'vault/services/flash-messages';
 import PkiConfigModel from 'vault/models/pki/config';
 import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 interface Args {
   config: PkiConfigModel;

--- a/ui/lib/pki/addon/components/pki-configure-form.ts
+++ b/ui/lib/pki/addon/components/pki-configure-form.ts
@@ -67,4 +67,9 @@ export default class PkiConfigureForm extends Component<Args> {
         return false;
     }
   }
+
+  @action cancel() {
+    this.args.config.rollbackAttributes();
+    this.router.transitionTo('vault.cluster.secrets.backend.pki.overview');
+  }
 }

--- a/ui/lib/pki/addon/components/pki-generate-root.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-root.hbs
@@ -1,0 +1,75 @@
+<form {{on "submit" this.generateRoot}} data-test-pki-config-generate-root-form>
+  <MessageError @errorMessage={{this.errorBanner}} class="has-top-margin-s" />
+  <h2 class="title is-size-5 has-border-bottom-light page-header">Root parameters</h2>
+  {{#each this.defaultFields as |field|}}
+    {{#let (find-by "name" field @model.allFields) as |attr|}}
+      <FormField data-test-field={{true}} @attr={{attr}} @model={{@model}} data-test-generate-root-field={{field}}>
+        {{#if (eq field "customTtl")}}
+          {{! customTtl attr has editType yield, which will render this }}
+          <PkiNotValidAfterForm @attr={{attr}} @model={{@model}} />
+        {{/if}}
+      </FormField>
+    {{/let}}
+  {{/each}}
+
+  {{! togglable groups }}
+  {{#each-in this.groups as |group fields|}}
+    <ToggleButton
+      @isOpen={{eq this.showGroup group}}
+      @openLabel={{concat "Hide " group}}
+      @closedLabel={{group}}
+      @onClick={{fn this.toggleGroup group}}
+      class="is-block"
+      data-test-toggle-group={{group}}
+    />
+    {{#if (eq this.showGroup group)}}
+      <div class="box is-marginless">
+        {{#if (eq group "Key parameters")}}
+          <PkiKeyParameters @model={{@model}} @fields={{this.keyParamFields}} />
+        {{else}}
+          {{#each fields as |fieldName|}}
+            {{#let (find-by "name" fieldName @model.allFields) as |attr|}}
+              <FormField
+                data-test-field
+                @attr={{attr}}
+                @mode="create"
+                @model={{@model}}
+                {{!-- @onChange={{fn (mut (get @model fieldName))}}
+              @modelValidations={{this.modelValidations}}
+              @onKeyUp={{this.validateForm}} --}}
+              />
+            {{/let}}
+          {{/each}}
+        {{/if}}
+      </div>
+    {{/if}}
+  {{/each-in}}
+
+  <fieldset class="box is-shadowless is-marginless is-borderless is-fullwidth">
+    <h2 class="title is-size-5 has-border-bottom-light page-header">Issuer URLs</h2>
+    {{! TODO: fill in URL fields }}
+    {{! Updating this area of the form will require a secondary call to issuer/:issuer_ref/update once the initial request is complete }}
+  </fieldset>
+
+  <div class="field is-grouped box is-fullwidth is-bottomless">
+    <div class="control">
+      <button type="submit" class="button is-primary" data-test-pki-config-save>
+        Done
+      </button>
+      <button {{on "click" this.cancel}} type="button" class="button has-left-margin-s" data-test-pki-config-cancel>
+        Cancel
+      </button>
+    </div>
+    {{#if this.invalidFormAlert}}
+      <div class="control">
+        <AlertInline
+          @type="danger"
+          @paddingTop={{true}}
+          @message={{this.invalidFormAlert}}
+          @mimicRefresh={{true}}
+          data-test-pki-key-validation-error
+        />
+      </div>
+    {{/if}}
+  </div>
+</form>

--- a/ui/lib/pki/addon/components/pki-generate-root.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-root.hbs
@@ -1,9 +1,17 @@
 <form {{on "submit" this.generateRoot}} data-test-pki-config-generate-root-form>
   <MessageError @errorMessage={{this.errorBanner}} class="has-top-margin-s" />
-  <h2 class="title is-size-5 has-border-bottom-light page-header">Root parameters</h2>
+  <h2 class="title is-size-5 has-border-bottom-light page-header" data-test-generate-root-title="Root parameters">
+    Root parameters
+  </h2>
   {{#each this.defaultFields as |field|}}
     {{#let (find-by "name" field @model.allFields) as |attr|}}
-      <FormField data-test-field={{true}} @attr={{attr}} @model={{@model}} data-test-generate-root-field={{field}}>
+      <FormField
+        @attr={{attr}}
+        @model={{@model}}
+        @modelValidations={{this.modelValidations}}
+        @onChange={{this.checkFormValidity}}
+        data-test-field
+      >
         {{#if (eq field "customTtl")}}
           {{! customTtl attr has editType yield, which will render this }}
           <PkiNotValidAfterForm @attr={{attr}} @model={{@model}} />
@@ -23,21 +31,41 @@
       data-test-toggle-group={{group}}
     />
     {{#if (eq this.showGroup group)}}
-      <div class="box is-marginless">
+      <div class="box is-marginless" data-test-group={{group}}>
         {{#if (eq group "Key parameters")}}
-          <PkiKeyParameters @model={{@model}} @fields={{this.keyParamFields}} />
+          <p class="has-bottom-margin-m" data-test-toggle-group-description>
+            {{#if (eq @model.type "internal")}}
+              This certificate type is internal. This means that the private key will not be returned and cannot be retrieved
+              later. Below, you will name the key and define its type and key bits.
+            {{else if (eq @model.type "kms")}}
+              This certificate type is kms, meaning managed keys will be used. Below, you will name the key and tell Vault
+              where to find it in your KMS or HSM.
+              <DocLink @path="/vault/docs/enterprise/managed-keys">Learn more about managed keys.</DocLink>
+            {{else if (eq @model.type "exported")}}
+              This certificate type is exported. This means the private key will be returned in the response. Below, you will
+              name the key and define its type and key bits.
+            {{else if (eq @model.type "existing")}}
+              You chose to use an existing key. This means that we’ll use the key reference to create the CSR or root. Please
+              provide the reference to the key.
+            {{else}}
+              Please choose a type to see key parameter options.
+            {{/if}}
+          </p>
+          {{#if this.keyParamFields}}
+            <PkiKeyParameters @model={{@model}} @fields={{this.keyParamFields}} />
+          {{/if}}
         {{else}}
+          <p class="has-bottom-margin-m" data-test-toggle-group-description>
+            {{#if (eq group "Subject Alternative Name (SAN) Options")}}
+              SAN fields are an extension that allow you specify additional host names (sites, IP addresses, common names,
+              etc.) to be protected by a single certificate.
+            {{else if (eq group "Additional subject fields")}}
+              These fields provide more information about the client to which the certificate belongs.
+            {{/if}}
+          </p>
           {{#each fields as |fieldName|}}
             {{#let (find-by "name" fieldName @model.allFields) as |attr|}}
-              <FormField
-                data-test-field
-                @attr={{attr}}
-                @mode="create"
-                @model={{@model}}
-                {{!-- @onChange={{fn (mut (get @model fieldName))}}
-              @modelValidations={{this.modelValidations}}
-              @onKeyUp={{this.validateForm}} --}}
-              />
+              <FormField data-test-field @attr={{attr}} @mode="create" @model={{@model}} />
             {{/let}}
           {{/each}}
         {{/if}}
@@ -45,18 +73,18 @@
     {{/if}}
   {{/each-in}}
 
+  {{!-- TODO: this section
   <fieldset class="box is-shadowless is-marginless is-borderless is-fullwidth">
-    <h2 class="title is-size-5 has-border-bottom-light page-header">Issuer URLs</h2>
-    {{! TODO: fill in URL fields }}
+    <h2 class="title is-size-5 has-border-bottom-light page-header" data-test-generate-root-title="Issuer URLs">Issuer URLs</h2>
     {{! Updating this area of the form will require a secondary call to issuer/:issuer_ref/update once the initial request is complete }}
-  </fieldset>
+  </fieldset> --}}
 
   <div class="field is-grouped box is-fullwidth is-bottomless">
     <div class="control">
-      <button type="submit" class="button is-primary" data-test-pki-config-save>
+      <button type="submit" class="button is-primary" data-test-pki-generate-root-save>
         Done
       </button>
-      <button {{on "click" this.cancel}} type="button" class="button has-left-margin-s" data-test-pki-config-cancel>
+      <button {{on "click" this.cancel}} type="button" class="button has-left-margin-s" data-test-pki-generate-root-cancel>
         Cancel
       </button>
     </div>
@@ -67,7 +95,7 @@
           @paddingTop={{true}}
           @message={{this.invalidFormAlert}}
           @mimicRefresh={{true}}
-          data-test-pki-key-validation-error
+          data-test-pki-generate-root-validation-error
         />
       </div>
     {{/if}}

--- a/ui/lib/pki/addon/components/pki-generate-root.js
+++ b/ui/lib/pki/addon/components/pki-generate-root.js
@@ -1,0 +1,71 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import errorMessage from 'vault/utils/error-message';
+
+/**
+ * Pki Config/Generate Root shows only the fields valid for the generate root endpoint.
+ * This form handles the model save and rollback actions, and will call the passed
+ * onSave and onCancel args for transition (passed from parent).
+ * NOTE: not TS because decorator-added items aren't recognized on the model.
+ */
+export default class PkiGenerateRootComponent extends Component {
+  @tracked showGroup = null;
+  @tracked errorBanner;
+  @tracked invalidFormAlert;
+
+  @action
+  toggleGroup(group, isOpen) {
+    this.showGroup = isOpen ? group : null;
+  }
+
+  get defaultFields() {
+    return [
+      'type',
+      'commonName',
+      'issuerName',
+      'customTtl',
+      'notBeforeDuration',
+      'format',
+      'permittedDnsDomains',
+      'maxPathLength',
+    ];
+  }
+  get keyParamFields() {
+    const { type } = this.args.model;
+    let fields = ['keyName', 'keyType', 'keyBits'];
+    if (type === 'existing') {
+      fields = ['keyReference'];
+    } else if (type === 'kms') {
+      fields = ['keyName', 'managedKeyName', 'managedKeyId'];
+    }
+    return fields.map((fieldName) => {
+      return this.args.model.allFields.find((attr) => attr.name === fieldName);
+    });
+  }
+
+  @action cancel() {
+    this.args.model.unloadRecord();
+    this.args.onCancel();
+  }
+  get groups() {
+    return {
+      'Key parameters': this.keyParamFields,
+      'Subject Alternative Name (SAN) Options': [],
+      'Other subject data': [],
+    };
+  }
+
+  @action
+  async generateRoot(event) {
+    event.preventDefault();
+    const useIssuer = this.args.model.canGenerateIssuerRoot;
+    try {
+      await this.args.model.save({ adapterOptions: { formType: 'generate-root', useIssuer } });
+      this.args.onSave();
+    } catch (e) {
+      this.errorBanner = errorMessage(e);
+      this.invalidFormAlert = 'There was a problem importing key.';
+    }
+  }
+}

--- a/ui/lib/pki/addon/components/pki-generate-root.js
+++ b/ui/lib/pki/addon/components/pki-generate-root.js
@@ -17,7 +17,7 @@ import errorMessage from 'vault/utils/error-message';
  * <PkiGenerateRoot @model={{this.model}} @onCancel={{transition-to "vault.cluster"}} @onSave={{transition-to "vault.cluster.secrets"}} @adapterOptions={{hash formType="import" useIssuer=false}} />
  * ```
  *
- * @param {Object} model - pki/config model.
+ * @param {Object} model - pki/action model.
  * @callback onCancel - Callback triggered when cancel button is clicked, after model is unloaded
  * @callback onSave - Callback triggered after model save success.
  * @param {Object} adapterOptions - object passed as adapterOptions on the model.save method

--- a/ui/lib/pki/addon/components/pki-key-parameters.hbs
+++ b/ui/lib/pki/addon/components/pki-key-parameters.hbs
@@ -1,7 +1,12 @@
+{{yield}}
 {{#each @fields as |attr|}}
   {{#if (eq attr.name "keyBits")}}
-    <div class="field">
-      <FormFieldLabel for={{attr.name}} @label={{attr.options.label}} @subText={{attr.options.subText}} />
+    <div class="field" data-test-field="keyBits">
+      <FormFieldLabel
+        for={{attr.name}}
+        @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}}
+        @subText={{attr.options.subText}}
+      />
       <div class="control is-expanded">
         <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
           <T.Trigger tabindex="-1">

--- a/ui/lib/pki/addon/components/pki-key-parameters.js
+++ b/ui/lib/pki/addon/components/pki-key-parameters.js
@@ -23,7 +23,10 @@ const KEY_BITS_OPTIONS = {
 
 export default class PkiKeyParameters extends Component {
   get keyBitOptions() {
-    return KEY_BITS_OPTIONS[this.args.model.keyType];
+    if (Object.keys(KEY_BITS_OPTIONS).includes(this.args.model.keyType)) {
+      return KEY_BITS_OPTIONS[this.args.model.keyType];
+    }
+    return ['0'];
   }
 
   @action handleSelection(name, selection) {

--- a/ui/lib/pki/addon/routes/configuration/create.js
+++ b/ui/lib/pki/addon/routes/configuration/create.js
@@ -6,7 +6,7 @@ export default class PkiConfigurationCreateRoute extends Route {
   @service store;
 
   model() {
-    return this.store.createRecord('pki/config', {});
+    return this.store.createRecord('pki/action', {});
   }
 
   setupController(controller, resolvedModel) {

--- a/ui/lib/pki/addon/routes/issuers/generate-root.js
+++ b/ui/lib/pki/addon/routes/issuers/generate-root.js
@@ -1,3 +1,21 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
-export default class PkiIssuersGenerateRootRoute extends Route {}
+export default class PkiIssuersGenerateRootRoute extends Route {
+  @service secretMountPath;
+  @service store;
+
+  model() {
+    return this.store.createRecord('pki/config', {});
+  }
+
+  setupController(controller, resolvedModel) {
+    super.setupController(controller, resolvedModel);
+    const backend = this.secretMountPath.currentPath || 'pki';
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: backend, route: 'overview' },
+      { label: 'generate root' },
+    ];
+  }
+}

--- a/ui/lib/pki/addon/routes/issuers/generate-root.js
+++ b/ui/lib/pki/addon/routes/issuers/generate-root.js
@@ -6,7 +6,7 @@ export default class PkiIssuersGenerateRootRoute extends Route {
   @service store;
 
   model() {
-    return this.store.createRecord('pki/config', {});
+    return this.store.createRecord('pki/action', {});
   }
 
   setupController(controller, resolvedModel) {

--- a/ui/lib/pki/addon/templates/issuers/generate-root.hbs
+++ b/ui/lib/pki/addon/templates/issuers/generate-root.hbs
@@ -11,6 +11,7 @@
 
 <PkiGenerateRoot
   @model={{this.model}}
-  @onCancel={{transition-to "vault.cluster.secrets.backend.pki.overview"}}
-  @onSave={{transition-to "vault.cluster.secrets.backend.pki.overview"}}
+  @onCancel={{transition-to "vault.cluster.secrets.backend.pki.issuers.index"}}
+  @onSave={{transition-to "vault.cluster.secrets.backend.pki.issuers.index"}}
+  @adapterOptions={{hash formType="generate-root" useIssuer=this.model.canGenerateIssuerRoot}}
 />

--- a/ui/lib/pki/addon/templates/issuers/generate-root.hbs
+++ b/ui/lib/pki/addon/templates/issuers/generate-root.hbs
@@ -1,1 +1,16 @@
-route: issuers.generate-root
+<PageHeader as |p|>
+  <p.top>
+    <Page::Breadcrumbs @breadcrumbs={{this.breadcrumbs}} />
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3" data-test-pki-key-page-title>
+      Generate root
+    </h1>
+  </p.levelLeft>
+</PageHeader>
+
+<PkiGenerateRoot
+  @model={{this.model}}
+  @onCancel={{transition-to "vault.cluster.secrets.backend.pki.overview"}}
+  @onSave={{transition-to "vault.cluster.secrets.backend.pki.overview"}}
+/>

--- a/ui/tests/integration/components/pki-generate-root-test.js
+++ b/ui/tests/integration/components/pki-generate-root-test.js
@@ -1,0 +1,190 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'vault/tests/helpers';
+import { click, fillIn, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupEngine } from 'ember-engines/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import Sinon from 'sinon';
+import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
+
+const SELECTORS = {
+  mainSectionTitle: '[data-test-generate-root-title="Root parameters"]',
+  urlSectionTitle: '[data-test-generate-root-title="Issuer URLs"]',
+  keyParamsGroupToggle: '[data-test-toggle-group="Key parameters"]',
+  sanGroupToggle: '[data-test-toggle-group="Subject Alternative Name (SAN) Options"]',
+  additionalGroupToggle: '[data-test-toggle-group="Additional subject fields"]',
+  toggleGroupDescription: '[data-test-toggle-group-description]',
+  formField: '[data-test-field]',
+  typeField: '[data-test-input="type"]',
+  fieldByName: (name) => `[data-test-field="${name}"]`,
+  saveButton: '[data-test-pki-generate-root-save]',
+  cancelButton: '[data-test-pki-generate-root-cancel]',
+  formInvalidError: '[data-test-pki-generate-root-validation-error]',
+};
+
+module('Integration | Component | pki-generate-root', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+  setupEngine(hooks, 'pki');
+
+  hooks.beforeEach(async function () {
+    this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub());
+    this.store = this.owner.lookup('service:store');
+    this.secretMountPath = this.owner.lookup('service:secret-mount-path');
+    this.secretMountPath.currentPath = 'pki-test';
+    this.model = this.store.createRecord('pki/config', {
+      role: 'my-role',
+    });
+    this.onSave = Sinon.spy();
+    this.onCancel = Sinon.spy();
+  });
+
+  test('it renders with correct sections', async function (assert) {
+    await render(
+      hbs`<PkiGenerateRoot @model={{this.model}} @onSave={{this.onSave}} @onCancel={{this.onCancel}} />`,
+      {
+        owner: this.engine,
+      }
+    );
+
+    // Titles
+    assert.dom('h2').exists({ count: 2 }, 'two H2 titles are visible on page load');
+    assert.dom(SELECTORS.mainSectionTitle).hasText('Root parameters');
+    assert.dom(SELECTORS.urlSectionTitle).hasText('Issuer URLs');
+
+    assert.dom('[data-test-toggle-group]').exists({ count: 3 }, '3 toggle groups shown');
+  });
+
+  test('it shows the appropriate fields under the toggles', async function (assert) {
+    await render(
+      hbs`<PkiGenerateRoot @model={{this.model}} @onSave={{this.onSave}} @onCancel={{this.onCancel}} />`,
+      {
+        owner: this.engine,
+      }
+    );
+
+    await click(SELECTORS.additionalGroupToggle);
+    assert
+      .dom(SELECTORS.toggleGroupDescription)
+      .hasText('These fields provide more information about the client to which the certificate belongs.');
+    assert
+      .dom(`[data-test-group="Additional subject fields"] ${SELECTORS.formField}`)
+      .exists({ count: 7 }, '7 form fields under Additional Fields toggle');
+
+    await click(SELECTORS.sanGroupToggle);
+    assert
+      .dom(SELECTORS.toggleGroupDescription)
+      .hasText(
+        'SAN fields are an extension that allow you specify additional host names (sites, IP addresses, common names, etc.) to be protected by a single certificate.'
+      );
+    assert
+      .dom(`[data-test-group="Subject Alternative Name (SAN) Options"] ${SELECTORS.formField}`)
+      .exists({ count: 6 }, '7 form fields under SANs toggle');
+
+    await click(SELECTORS.keyParamsGroupToggle);
+    assert
+      .dom(SELECTORS.toggleGroupDescription)
+      .hasText(
+        'Please choose a type to see key parameter options.',
+        'Shows empty state description before type is selected'
+      );
+    assert
+      .dom(`[data-test-group="Key parameters"] ${SELECTORS.formField}`)
+      .exists({ count: 0 }, '0 form fields under keyParams toggle');
+  });
+
+  test('it renders the correct form fields in key params', async function (assert) {
+    this.set('type', '');
+    await render(
+      hbs`<PkiGenerateRoot @model={{this.model}} @onSave={{this.onSave}} @onCancel={{this.onCancel}} />`,
+      {
+        owner: this.engine,
+      }
+    );
+    await click(SELECTORS.keyParamsGroupToggle);
+    assert
+      .dom(`[data-test-group="Key parameters"] ${SELECTORS.formField}`)
+      .exists({ count: 0 }, '0 form fields under keyParams toggle');
+
+    this.set('type', 'exported');
+    await fillIn(SELECTORS.typeField, this.type);
+    assert
+      .dom(SELECTORS.toggleGroupDescription)
+      .hasText(
+        'This certificate type is exported. This means the private key will be returned in the response. Below, you will name the key and define its type and key bits.',
+        `has correct description for type=${this.type}`
+      );
+    assert.strictEqual(this.model.type, this.type);
+    assert
+      .dom(`[data-test-group="Key parameters"] ${SELECTORS.formField}`)
+      .exists({ count: 3 }, '3 form fields under keyParams toggle');
+    assert.dom(SELECTORS.fieldByName('keyName')).exists(`Key name field shown when type=${this.type}`);
+    assert.dom(SELECTORS.fieldByName('keyType')).exists(`Key type field shown when type=${this.type}`);
+    assert.dom(SELECTORS.fieldByName('keyBits')).exists(`Key bits field shown when type=${this.type}`);
+
+    this.set('type', 'internal');
+    await fillIn(SELECTORS.typeField, this.type);
+    assert
+      .dom(SELECTORS.toggleGroupDescription)
+      .hasText(
+        'This certificate type is internal. This means that the private key will not be returned and cannot be retrieved later. Below, you will name the key and define its type and key bits.',
+        `has correct description for type=${this.type}`
+      );
+    assert.strictEqual(this.model.type, this.type);
+    assert
+      .dom(`[data-test-group="Key parameters"] ${SELECTORS.formField}`)
+      .exists({ count: 3 }, '3 form fields under keyParams toggle');
+    assert.dom(SELECTORS.fieldByName('keyName')).exists(`Key name field shown when type=${this.type}`);
+    assert.dom(SELECTORS.fieldByName('keyType')).exists(`Key type field shown when type=${this.type}`);
+    assert.dom(SELECTORS.fieldByName('keyBits')).exists(`Key bits field shown when type=${this.type}`);
+
+    this.set('type', 'existing');
+    await fillIn(SELECTORS.typeField, this.type);
+    assert
+      .dom(SELECTORS.toggleGroupDescription)
+      .hasText(
+        'You chose to use an existing key. This means that we’ll use the key reference to create the CSR or root. Please provide the reference to the key.',
+        `has correct description for type=${this.type}`
+      );
+    assert.strictEqual(this.model.type, this.type);
+    assert
+      .dom(`[data-test-group="Key parameters"] ${SELECTORS.formField}`)
+      .exists({ count: 1 }, '1 form field under keyParams toggle');
+    assert.dom(SELECTORS.fieldByName('keyRef')).exists(`Key reference field shown when type=${this.type}`);
+
+    this.set('type', 'kms');
+    await fillIn(SELECTORS.typeField, this.type);
+    assert
+      .dom(SELECTORS.toggleGroupDescription)
+      .hasText(
+        'This certificate type is kms, meaning managed keys will be used. Below, you will name the key and tell Vault where to find it in your KMS or HSM. Learn more about managed keys.',
+        `has correct description for type=${this.type}`
+      );
+    assert.strictEqual(this.model.type, this.type);
+    assert
+      .dom(`[data-test-group="Key parameters"] ${SELECTORS.formField}`)
+      .exists({ count: 3 }, '3 form fields under keyParams toggle');
+    assert.dom(SELECTORS.fieldByName('keyName')).exists(`Key name field shown when type=${this.type}`);
+    assert
+      .dom(SELECTORS.fieldByName('managedKeyName'))
+      .exists(`Managed key name field shown when type=${this.type}`);
+    assert
+      .dom(SELECTORS.fieldByName('managedKeyId'))
+      .exists(`Managed key id field shown when type=${this.type}`);
+  });
+
+  test('it shows errors before submit if form is invalid', async function (assert) {
+    const saveSpy = Sinon.spy();
+    this.set('onSave', saveSpy);
+    await render(
+      hbs`<PkiGenerateRoot @model={{this.model}} @onSave={{this.onSave}} @onCancel={{this.onCancel}} />`,
+      {
+        owner: this.engine,
+      }
+    );
+
+    await click(SELECTORS.saveButton);
+    assert.dom(SELECTORS.formInvalidError).hasText('The form has errors. Please fix before continuing.');
+    assert.ok(saveSpy.notCalled);
+  });
+});

--- a/ui/tests/unit/adapters/pki/action-test.js
+++ b/ui/tests/unit/adapters/pki/action-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'vault/tests/helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
 
-module('Unit | Adapter | pki/config', function (hooks) {
+module('Unit | Adapter | pki/action', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 
@@ -16,7 +16,7 @@ module('Unit | Adapter | pki/config', function (hooks) {
   });
 
   test('it exists', function (assert) {
-    const adapter = this.owner.lookup('adapter:pki/config');
+    const adapter = this.owner.lookup('adapter:pki/action');
     assert.ok(adapter);
   });
 
@@ -51,7 +51,7 @@ module('Unit | Adapter | pki/config', function (hooks) {
       });
 
       await this.store
-        .createRecord('pki/config', this.payload)
+        .createRecord('pki/action', this.payload)
         .save({ adapterOptions: { formType: 'import', useIssuer: false } });
     });
 
@@ -63,7 +63,7 @@ module('Unit | Adapter | pki/config', function (hooks) {
       });
 
       await this.store
-        .createRecord('pki/config', this.payload)
+        .createRecord('pki/action', this.payload)
         .save({ adapterOptions: { formType: 'import', useIssuer: true } });
     });
   });
@@ -90,22 +90,22 @@ module('Unit | Adapter | pki/config', function (hooks) {
       });
 
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'internal',
         })
         .save(adapterOptions);
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'exported',
         })
         .save(adapterOptions);
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'existing',
         })
         .save(adapterOptions);
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'kms',
         })
         .save(adapterOptions);
@@ -132,22 +132,22 @@ module('Unit | Adapter | pki/config', function (hooks) {
       });
 
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'internal',
         })
         .save(adapterOptions);
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'exported',
         })
         .save(adapterOptions);
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'existing',
         })
         .save(adapterOptions);
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'kms',
         })
         .save(adapterOptions);
@@ -176,22 +176,22 @@ module('Unit | Adapter | pki/config', function (hooks) {
       });
 
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'internal',
         })
         .save(adapterOptions);
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'exported',
         })
         .save(adapterOptions);
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'existing',
         })
         .save(adapterOptions);
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'kms',
         })
         .save(adapterOptions);
@@ -218,22 +218,22 @@ module('Unit | Adapter | pki/config', function (hooks) {
       });
 
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'internal',
         })
         .save(adapterOptions);
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'exported',
         })
         .save(adapterOptions);
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'existing',
         })
         .save(adapterOptions);
       await this.store
-        .createRecord('pki/config', {
+        .createRecord('pki/action', {
           type: 'kms',
         })
         .save(adapterOptions);

--- a/ui/tests/unit/serializers/pki/action-test.js
+++ b/ui/tests/unit/serializers/pki/action-test.js
@@ -1,19 +1,19 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'vault/tests/helpers';
 
-module('Unit | Serializer | pki/config', function (hooks) {
+module('Unit | Serializer | pki/action', function (hooks) {
   setupTest(hooks);
 
   test('it exists', function (assert) {
     const store = this.owner.lookup('service:store');
-    const serializer = store.serializerFor('pki/config');
+    const serializer = store.serializerFor('pki/action');
 
     assert.ok(serializer);
   });
 
   test('it serializes records', function (assert) {
     const store = this.owner.lookup('service:store');
-    const record = store.createRecord('pki/config', {});
+    const record = store.createRecord('pki/action', {});
 
     const serializedRecord = record.serialize();
 

--- a/ui/types/vault/models/pki/action.d.ts
+++ b/ui/types/vault/models/pki/action.d.ts
@@ -1,6 +1,6 @@
 import Model from '@ember-data/model';
 
-export default class PkiConfigModel extends Model {
+export default class PkiActionModel extends Model {
   secretMountPath: unknown;
   pemBundle: string;
   type: string;


### PR DESCRIPTION
This PR adds a new component in the PKI engine, `PkiGenerateRoot`. It also renames the model/adapter/serializer `pki/config` to `pki/action` to better represent that the actions it encompasses can happen in places other than initial PKI configuration. 

**Form is rendered on config if Generate Root is selected**
<img width="1285" alt="Screen Shot 2023-01-13 at 4 04 39 PM" src="https://user-images.githubusercontent.com/82459713/212427900-7aea64f7-e1b3-4f07-bd97-45216d0e43d7.png">
<img width="1285" alt="Screen Shot 2023-01-13 at 4 04 47 PM" src="https://user-images.githubusercontent.com/82459713/212427909-cdb2a036-ac48-4e2e-9687-930febc8d55c.png">

**Form is rendered from issuers > generate root selection**
<img width="1285" alt="Screen Shot 2023-01-13 at 4 05 13 PM" src="https://user-images.githubusercontent.com/82459713/212427984-dc0d2a6c-a56c-41b5-ab4d-1d42e59bbd0f.png">
<img width="1285" alt="Screen Shot 2023-01-13 at 4 05 15 PM" src="https://user-images.githubusercontent.com/82459713/212427987-df2e8a12-4817-471d-a599-fca28ca402e5.png">

Follow-on tasks: 
- [ ] Fill out tests for `pki/action` serializer
- [ ] Write tests for `pki-key-parameters`