### PR TITLE
ui: small pki issuer details cleanup

### DIFF
--- a/ui/app/models/pki/issuer.js
+++ b/ui/app/models/pki/issuer.js
@@ -30,6 +30,7 @@ export default class PkiIssuerModel extends PkiCertificateBaseModel {
     return false;
   }
 
+  @attr isDefault; // readonly
   @attr('string') issuerId;
   @attr('string', { displayType: 'masked' }) certificate;
   @attr('string', { displayType: 'masked', label: 'CA Chain' }) caChain;

--- a/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
@@ -38,6 +38,16 @@
   </ToolbarActions>
 </Toolbar>
 
+{{#if @issuer.isDefault}}
+  <p class="has-top-margin-m">
+    This is your default issuer certificate. You will see it in your
+    <LinkTo @route="issuers.index">
+      list of Issuers.
+    </LinkTo>
+    You may also want to configure its usage and other behaviors.
+  </p>
+{{/if}}
+
 <main data-test-issuer-details>
   {{#each @issuer.formFieldGroups as |fieldGroup|}}
     {{#each-in fieldGroup as |group fields|}}
@@ -60,7 +70,7 @@
           {{else if (eq attr.name "keyId")}}
             <InfoTableRow @label={{or attr.options.label (humanize (dasherize attr.name))}} @value={{get @issuer attr.name}}>
               {{#if @issuer.keyId}}
-                <LinkTo @route="keys.key" @model={{@issuer.keyId}}>{{@issuer.keyId}}</LinkTo>
+                <LinkTo @route="keys.key.details" @model={{@issuer.keyId}}>{{@issuer.keyId}}</LinkTo>
               {{else}}
                 <Icon @name="minus" />
               {{/if}}


### PR DESCRIPTION
Adds default text and fixes link to key details page

<img width="1416" alt="Screen Shot 2023-01-13 at 3 39 19 PM" src="https://user-images.githubusercontent.com/68122737/212437806-6d5ce217-1f03-4725-b651-ad7b30099088.png">
