### PR TITLE
Adding Defaults to Sys endpoints

### DIFF
--- a/changelog/18721.txt
+++ b/changelog/18721.txt
@@ -1,3 +1,3 @@
-```release-note:
+```release-note: improvement
 api: Add missing defaults to parameters for sys endpoints to improve OpenApi Spec accuracy
 ```

--- a/changelog/18721.txt
+++ b/changelog/18721.txt
@@ -1,0 +1,3 @@
+```release-note:
+api: Add missing defaults to parameters for sys endpoints to improve OpenApi Spec accuracy
+```

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -1464,7 +1464,7 @@ func (b *SystemBackend) monitorPath() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Log level to view system logs at. Currently supported values are \"trace\", \"debug\", \"info\", \"warn\", \"error\".",
 				Query:       true,
-				Default:	 "info",
+				Default:     "info",
 			},
 			"log_format": {
 				Type:        framework.TypeString,

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -1445,6 +1445,7 @@ func (b *SystemBackend) metricsPath() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Format to export metrics into. Currently accepts only \"prometheus\".",
 				Query:       true,
+				Default:     "",
 			},
 		},
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -1463,6 +1464,7 @@ func (b *SystemBackend) monitorPath() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Log level to view system logs at. Currently supported values are \"trace\", \"debug\", \"info\", \"warn\", \"error\".",
 				Query:       true,
+				Default:	 "info",
 			},
 			"log_format": {
 				Type:        framework.TypeString,


### PR DESCRIPTION
Adding defaults to sys/metrics and sys/monitor endpoints that are missing the path description. Parameters must either be `required` or have associated `defaults` otherwise this breaks code generation for C#