### PR TITLE
Revert "Add new clients into the monthly breakdown"

### DIFF
--- a/changelog/18629.txt
+++ b/changelog/18629.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-core/activity: add namespace breakdown for new clients when date range spans multiple months, including the current month.
-```

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1664,7 +1664,6 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 			a.logger.Warn("no month data found, returning query with no namespace attribution for current month")
 		} else {
 			currentMonth.Namespaces = currentMonthNamespaceAttribution[0].Namespaces
-			currentMonth.NewClients = currentMonthNamespaceAttribution[0].NewClients
 		}
 		pq.Months = append(pq.Months, currentMonth)
 		distinctEntitiesResponse += pq.Months[len(pq.Months)-1].NewClients.Counts.EntityClients


### PR DESCRIPTION
Reverts hashicorp/vault#18629. 

This is due to failing tests in the enterprise repository.