### PR TITLE
Start events when core starts if enabled

### DIFF
--- a/vault/eventbus/bus_test.go
+++ b/vault/eventbus/bus_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestBusBasics(t *testing.T) {
-	bus, err := NewEventBus()
+	bus, err := NewEventBus(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +51,7 @@ func TestBusBasics(t *testing.T) {
 }
 
 func TestBus2Subscriptions(t *testing.T) {
-	bus, err := NewEventBus()
+	bus, err := NewEventBus(nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
For example, using:

```sh
vault server -dev -experiment events.beta1
```

Tested by checking that the events were enabled and disabled when the `-experiment events.beta1` flag was present and absent.

Also added a small fix to pass the `hclog.Logger` in now so that the logging hierarchy and levels are respected.