### PR TITLE
API Explorer Query Params

### DIFF
--- a/changelog/18743.txt
+++ b/changelog/18743.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes query parameters not passed in api explorer test requests
+```

--- a/ui/lib/open-api-explorer/addon/components/swagger-ui.js
+++ b/ui/lib/open-api-explorer/addon/components/swagger-ui.js
@@ -54,10 +54,10 @@ const CONFIG = (SwaggerUIBundle, componentInstance, initialFilter) => {
       // we want to link to the right JSON in swagger UI so
       // it's already been pre-pended
       if (!req.loadSpec) {
-        const { protocol, host, pathname } = parseURL(req.url);
+        const { protocol, host, pathname, search } = parseURL(req.url);
         //paths in the spec don't have /v1 in them, so we need to add that here
         //           http(s):  vlt.io:4200  /sys/mounts
-        req.url = `${protocol}//${host}/v1${pathname}`;
+        req.url = `${protocol}//${host}/v1${pathname}${search}`;
       }
       return req;
     },


### PR DESCRIPTION
As mentioned in #18614, query parameters were not being passed in API explorer test requests due to a custom `requestInterceptor` which was not rebuilding the url with the query parameters.

Before
![image](https://user-images.githubusercontent.com/24611656/213024455-71fbc749-7e38-4e5f-867f-06629fc0fe28.png)

After
![image](https://user-images.githubusercontent.com/24611656/213023965-d247a6f5-ef59-4363-a54d-6016df194791.png)
