### PR TITLE
Remove t.Parallel() due to initialization race

### DIFF
--- a/command/pki_health_check_test.go
+++ b/command/pki_health_check_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestPKIHC_AllGood(t *testing.T) {
-	t.Parallel()
-
 	client, closer := testVaultServer(t)
 	defer closer()
 
@@ -72,8 +70,6 @@ func TestPKIHC_AllGood(t *testing.T) {
 }
 
 func TestPKIHC_AllBad(t *testing.T) {
-	t.Parallel()
-
 	client, closer := testVaultServer(t)
 	defer closer()
 
@@ -134,8 +130,6 @@ func TestPKIHC_AllBad(t *testing.T) {
 }
 
 func TestPKIHC_OnlyIssuer(t *testing.T) {
-	t.Parallel()
-
 	client, closer := testVaultServer(t)
 	defer closer()
 
@@ -158,8 +152,6 @@ func TestPKIHC_OnlyIssuer(t *testing.T) {
 }
 
 func TestPKIHC_NoMount(t *testing.T) {
-	t.Parallel()
-
 	client, closer := testVaultServer(t)
 	defer closer()
 
@@ -174,8 +166,6 @@ func TestPKIHC_NoMount(t *testing.T) {
 }
 
 func TestPKIHC_ExpectedEmptyMount(t *testing.T) {
-	t.Parallel()
-
 	client, closer := testVaultServer(t)
 	defer closer()
 
@@ -196,8 +186,6 @@ func TestPKIHC_ExpectedEmptyMount(t *testing.T) {
 }
 
 func TestPKIHC_NoPerm(t *testing.T) {
-	t.Parallel()
-
 	client, closer := testVaultServer(t)
 	defer closer()
 


### PR DESCRIPTION
Using `RunCommand(...)` to set format to JSON for PKI HC tests results in multiple `initCommands(...)` being called, overwriting the same global variable. Nobody else calls the test suite in this way, so remove `t.Parallel()` as the CLI isn't really meant to be called in parallel and there might be other issues.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`