### PR TITLE
* added the new redis parameter documentation

### DIFF
--- a/changelog/18752.txt
+++ b/changelog/18752.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+**Redis ElastiCache DB Engine**: Renamed configuration parameters for disambiguation; old parameters still supported for compatibility.
+```

--- a/website/content/api-docs/secret/databases/rediselasticache.mdx
+++ b/website/content/api-docs/secret/databases/rediselasticache.mdx
@@ -25,10 +25,20 @@ has a number of parameters to further configure a connection.
 
 - `url` `(string: <required>)` – Specifies the primary endpoint to connect to.
 
-- `username` `(string)` – Specifies the IAM access_key_id for Vault to use. If omitted, authentication fallbacks on the AWS credentials provider chain and tries to infer authentication from the environment.
+- `access_key_id` `(string)` – Specifies the IAM access_key_id for Vault to use. If omitted, authentication falls back on
+the AWS credentials provider chain and tries to infer authentication from the environment.
 
-- `password` `(string)` – Specifies the IAM secret_access_key corresponding to
-the given access_key_id. If omitted, authentication fallbacks on the AWS credentials provider chain and tries to infer authentication from the environment.
+- `secret_access_key` `(string)` – Specifies the IAM secret_access_key corresponding to the given access_key_id.
+If omitted, authentication falls back on the AWS credentials provider chain and tries to infer authentication from the environment.
+
+- `region` `(string)` – Specifies the AWS region where to ElastiCache cluster is provisioned. If omitted, falls back on
+the context from the environment.
+
+### Deprecated Parameters
+
+- `username` `(string)` – Use access_key_id instead, it is strictly equivalent.
+
+- `secret_access_key` `(string)` – Use secret_access_key instead, it is strictly equivalent.
 
 ### Sample Payload
 
@@ -36,8 +46,9 @@ the given access_key_id. If omitted, authentication fallbacks on the AWS credent
 {
   "plugin_name": "redis-elasticache-database-plugin",
   "url": "primary-endpoint.my-cluster.xxx.yyy.cache.amazonaws.com:6379",
-  "username": "AKI***",
-  "password": "ktriNYvULAWLzUmTGb***",
+  "access_key_id": "AKI***",
+  "secret_access_key": "ktriNYvULAWLzUmTGb***",
+  "region": "us-east-1",
   "allowed-roles": "*"
 }
 ```

--- a/website/content/api-docs/secret/databases/rediselasticache.mdx
+++ b/website/content/api-docs/secret/databases/rediselasticache.mdx
@@ -36,7 +36,7 @@ the context from the environment.
 
 ### Deprecated Parameters
 
-- `username` `(string)` – Use access_key_id instead, it is strictly equivalent.
+- `username` `(string)` – Use `access_key_id` instead, it is strictly equivalent.
 
 - `password` `(string)` – Use secret_access_key instead, it is strictly equivalent.
 

--- a/website/content/api-docs/secret/databases/rediselasticache.mdx
+++ b/website/content/api-docs/secret/databases/rediselasticache.mdx
@@ -28,7 +28,7 @@ has a number of parameters to further configure a connection.
 - `access_key_id` `(string)` – Specifies the IAM `access_key_id` for Vault to use. If omitted, authentication falls back on
 the AWS credentials provider chain and tries to infer authentication from the environment.
 
-- `secret_access_key` `(string)` – Specifies the IAM secret_access_key corresponding to the given access_key_id.
+- `secret_access_key` `(string)` – Specifies the IAM `secret_access_key` corresponding to the given `access_key_id`.
 If omitted, authentication falls back on the AWS credentials provider chain and tries to infer authentication from the environment.
 
 - `region` `(string)` – Specifies the AWS region where to ElastiCache cluster is provisioned. If omitted, falls back on

--- a/website/content/api-docs/secret/databases/rediselasticache.mdx
+++ b/website/content/api-docs/secret/databases/rediselasticache.mdx
@@ -25,7 +25,7 @@ has a number of parameters to further configure a connection.
 
 - `url` `(string: <required>)` – Specifies the primary endpoint to connect to.
 
-- `access_key_id` `(string)` – Specifies the IAM access_key_id for Vault to use. If omitted, authentication falls back on
+- `access_key_id` `(string)` – Specifies the IAM `access_key_id` for Vault to use. If omitted, authentication falls back on
 the AWS credentials provider chain and tries to infer authentication from the environment.
 
 - `secret_access_key` `(string)` – Specifies the IAM secret_access_key corresponding to the given access_key_id.

--- a/website/content/api-docs/secret/databases/rediselasticache.mdx
+++ b/website/content/api-docs/secret/databases/rediselasticache.mdx
@@ -38,7 +38,7 @@ the context from the environment.
 
 - `username` `(string)` – Use `access_key_id` instead, it is strictly equivalent.
 
-- `password` `(string)` – Use secret_access_key instead, it is strictly equivalent.
+- `password` `(string)` – Use `secret_access_key` instead, it is strictly equivalent.
 
 ### Sample Payload
 

--- a/website/content/api-docs/secret/databases/rediselasticache.mdx
+++ b/website/content/api-docs/secret/databases/rediselasticache.mdx
@@ -38,7 +38,7 @@ the context from the environment.
 
 - `username` `(string)` – Use access_key_id instead, it is strictly equivalent.
 
-- `secret_access_key` `(string)` – Use secret_access_key instead, it is strictly equivalent.
+- `password` `(string)` – Use secret_access_key instead, it is strictly equivalent.
 
 ### Sample Payload
 

--- a/website/content/docs/secrets/databases/rediselasticache.mdx
+++ b/website/content/docs/secrets/databases/rediselasticache.mdx
@@ -48,7 +48,7 @@ more information about setting up the database secrets engine.
 on the AWS credentials provider chain.
 
 ~> **Deprecated**: The username & password parameters are deprecated but supported for backward compatibility. They are replaced
-by the equivalent access_key_id & secret_access_key parameters respectively.
+by the equivalent `access_key_id` and `secret_access_key` parameters respectively.
 
 The Redis ElastiCache secrets engine must use AWS credentials that have sufficient permissions to manage ElastiCache users.
 This IAM policy sample can be used as an example. Note that &lt;region&gt; and &lt;account-id&gt;

--- a/website/content/docs/secrets/databases/rediselasticache.mdx
+++ b/website/content/docs/secrets/databases/rediselasticache.mdx
@@ -44,7 +44,7 @@ more information about setting up the database secrets engine.
     allowed_roles="*"
   ```
 
-~> **Note**: The access_key_id, secret_access_key & region parameters are optional. If omitted, authentication falls back
+~> **Note**: The `access_key_id`, `secret_access_key` and `region` parameters are optional. If omitted, authentication falls back
 on the AWS credentials provider chain.
 
 ~> **Deprecated**: The username & password parameters are deprecated but supported for backward compatibility. They are replaced

--- a/website/content/docs/secrets/databases/rediselasticache.mdx
+++ b/website/content/docs/secrets/databases/rediselasticache.mdx
@@ -38,14 +38,38 @@ more information about setting up the database secrets engine.
   $ vault write database/config/my-redis-elasticache-cluster \
     plugin_name="redis-elasticache-database-plugin" \
     url="primary-endpoint.my-cluster.xxx.yyy.cache.amazonaws.com:6379" \
-    username="AKI***" \
-    password="ktriNYvULAWLzUmTGb***" \
+    access_key_id="AKI***" \
+    secret_access_key="ktriNYvULAWLzUmTGb***" \
+    region=us-east-1 \
     allowed_roles="*"
   ```
 
-~> **Note**: The username and password parameters are optional. If omitted, authentication falls back on the AWS credentials provider chain.
-  Using a [temporary credential](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html) stored in the proper environment
-  variable is the preferred configuration method.
+~> **Note**: The access_key_id, secret_access_key & region parameters are optional. If omitted, authentication falls back
+on the AWS credentials provider chain.
+
+~> **Deprecated**: The username & password parameters are deprecated but supported for backward compatibility. They are replaced
+by the equivalent access_key_id & secret_access_key parameters respectively.
+
+The Redis ElastiCache secrets engine must use AWS credentials that have sufficient permissions to manage ElastiCache users.
+This IAM policy sample can be used as an example. Note that &lt;region&gt; and &lt;account-id&gt;
+must correspond to your own environment.
+
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "",
+        "Effect": "Allow",
+        "Action": [
+          "elasticache:ModifyUser",
+          "elasticache:DescribeUsers"
+        ],
+        "Resource": "arn:aws:elasticache:<region>:<account-id>:user:*"
+      }
+    ]
+  }
+  ```
 
 ## Usage
 

--- a/website/content/docs/secrets/databases/rediselasticache.mdx
+++ b/website/content/docs/secrets/databases/rediselasticache.mdx
@@ -47,7 +47,7 @@ more information about setting up the database secrets engine.
 ~> **Note**: The `access_key_id`, `secret_access_key` and `region` parameters are optional. If omitted, authentication falls back
 on the AWS credentials provider chain.
 
-~> **Deprecated**: The username & password parameters are deprecated but supported for backward compatibility. They are replaced
+~> **Deprecated**: The `username` & `password` parameters are deprecated but supported for backward compatibility. They are replaced
 by the equivalent `access_key_id` and `secret_access_key` parameters respectively.
 
 The Redis ElastiCache secrets engine must use AWS credentials that have sufficient permissions to manage ElastiCache users.


### PR DESCRIPTION
* Changed username & password to access_key_id & secret_access_key since the parameter naming caused confusion. This has been reported by customers who had trouble setting up the plugin.
* Username & password are still supported for backward compatibility.
* Provided a IAM policy sample that the Vault role requires to manage users, this has also caused friction to some users.
* Various minor spelling corrections

**Question**: Should I only add the changelog when the plugin gets updated for Vault 1.13 release?

Docs
![redis_doc](https://user-images.githubusercontent.com/109547106/213200906-4df0457a-5520-4fd2-812a-ad816e44d93b.png)

Api-Docs
![redi_api-docs](https://user-images.githubusercontent.com/109547106/213201100-fe7e8200-1005-4fb5-a228-c3a00ea04385.png)

