### PR TITLE
Refactor CRL Building for unified CRLs

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -98,7 +98,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 
 			LocalStorage: []string{
 				revokedPath,
-				deltaWALPath,
+				localDeltaWALPath,
 				legacyCRLPath,
 				clusterConfigPath,
 				"crls/",

--- a/builtin/logical/pki/config_util.go
+++ b/builtin/logical/pki/config_util.go
@@ -101,7 +101,7 @@ func (sc *storageContext) changeDefaultIssuerTimestamps(oldDefault issuerID, new
 		}
 	}
 
-	// Fetch and update the localCRLConfigEntry (3&4).
+	// Fetch and update the internalCRLConfigEntry (3&4).
 	cfg, err := sc.getLocalCRLConfig()
 	if err != nil {
 		return fmt.Errorf("unable to update local CRL config's modification time: error fetching local CRL config: %w", err)

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -1062,7 +1062,7 @@ func TestAutoRebuild(t *testing.T) {
 	}
 
 	// This serial should exist in the delta WAL section for the mount...
-	resp, err = client.Logical().List("sys/raw/logical/" + pkiMount + "/" + deltaWALPath)
+	resp, err = client.Logical().List("sys/raw/logical/" + pkiMount + "/" + localDeltaWALPath)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotEmpty(t, resp.Data)
@@ -1082,7 +1082,7 @@ func TestAutoRebuild(t *testing.T) {
 		default:
 			// Check and see if there's a storage entry for the last rebuild
 			// serial. If so, validate the delta CRL contains this entry.
-			resp, err = client.Logical().List("sys/raw/logical/" + pkiMount + "/" + deltaWALPath)
+			resp, err = client.Logical().List("sys/raw/logical/" + pkiMount + "/" + localDeltaWALPath)
 			require.NoError(t, err)
 			require.NotNil(t, resp)
 			require.NotEmpty(t, resp.Data)
@@ -1103,7 +1103,7 @@ func TestAutoRebuild(t *testing.T) {
 			}
 
 			// Read the marker and see if its correct.
-			resp, err = client.Logical().Read("sys/raw/logical/" + pkiMount + "/" + deltaWALLastBuildSerial)
+			resp, err = client.Logical().Read("sys/raw/logical/" + pkiMount + "/" + localDeltaWALLastBuildSerial)
 			require.NoError(t, err)
 			if resp == nil {
 				time.Sleep(1 * time.Second)

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -907,7 +907,7 @@ func buildAnyCRLsWithCerts(
 	sc *storageContext,
 	issuersConfig *issuerConfigEntry,
 	globalCRLConfig *crlConfig,
-	internalCRLConfig *localCRLConfigEntry,
+	internalCRLConfig *internalCRLConfigEntry,
 	issuers []issuerID,
 	issuerIDEntryMap map[issuerID]*issuerEntry,
 	keySubjectIssuersMap map[keyID]map[string][]issuerID,

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -164,21 +164,21 @@ func (cb *crlBuilder) checkForAutoRebuild(sc *storageContext) error {
 	//
 	// We store a list of all (unique) CRLs in the cluster-local CRL
 	// configuration along with their expiration dates.
-	crlConfig, err := sc.getLocalCRLConfig()
+	internalCRLConfig, err := sc.getLocalCRLConfig()
 	if err != nil {
 		return fmt.Errorf("error checking for auto-rebuild status: unable to fetch cluster-local CRL configuration: %w", err)
 	}
 
 	// If there's no config, assume we've gotta rebuild it to get this
 	// information.
-	if crlConfig == nil {
+	if internalCRLConfig == nil {
 		cb.forceRebuild.Store(true)
 		return nil
 	}
 
 	// If the map is empty, assume we need to upgrade and schedule a
 	// rebuild.
-	if len(crlConfig.CRLExpirationMap) == 0 {
+	if len(internalCRLConfig.CRLExpirationMap) == 0 {
 		cb.forceRebuild.Store(true)
 		return nil
 	}
@@ -200,7 +200,7 @@ func (cb *crlBuilder) checkForAutoRebuild(sc *storageContext) error {
 		period = defaultPeriod
 	}
 
-	for _, value := range crlConfig.CRLExpirationMap {
+	for _, value := range internalCRLConfig.CRLExpirationMap {
 		if value.IsZero() || now.After(value.Add(-1*period)) {
 			cb.forceRebuild.Store(true)
 			return nil
@@ -665,10 +665,10 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 	}
 
 	if globalCRLConfig.Disable && !forceNew {
-		// We build a single long-lived empty CRL in the event that we disable
-		// the CRL, but we don't keep updating it with newer, more-valid empty
-		// CRLs in the event that we later re-enable it. This is a historical
-		// behavior.
+		// We build a single long-lived (but regular validity) empty CRL in
+		// the event that we disable the CRL, but we don't keep updating it
+		// with newer, more-valid empty CRLs in the event that we later
+		// re-enable it. This is a historical behavior.
 		//
 		// So, since tidy can now associate issuers on revocation entries, we
 		// can skip the rest of this function and exit early without updating
@@ -697,7 +697,7 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 		}
 	}
 
-	config, err := sc.getIssuersConfig()
+	issuersConfig, err := sc.getIssuersConfig()
 	if err != nil {
 		return fmt.Errorf("error building CRLs: while getting the default config: %w", err)
 	}
@@ -753,12 +753,46 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 		keySubjectIssuersMap[thisEntry.KeyID][subject] = append(keySubjectIssuersMap[thisEntry.KeyID][subject], issuer)
 	}
 
-	// Fetch the cluster-local CRL mapping so we know where to write the
-	// CRLs.
-	crlConfig, err := sc.getLocalCRLConfig()
+	// Now we do two calls: building the cluster-local CRL, and potentially
+	// building the global CRL if we're on the active node of the performance
+	// primary.
+	currLocalDeltaSerials, err := buildAnyLocalCRLs(sc, issuersConfig, globalCRLConfig,
+		issuers, issuerIDEntryMap,
+		issuerIDCertMap, keySubjectIssuersMap,
+		wasLegacy, forceNew, isDelta)
 	if err != nil {
-		return fmt.Errorf("error building CRLs: unable to fetch cluster-local CRL configuration: %w", err)
+		return err
 	}
+
+	// Finally, we decide if we need to rebuild the Delta CRLs again, for both
+	// global and local CRLs if necessary.
+	if !isDelta {
+		// After we've confirmed the primary CRLs have built OK, go ahead and
+		// clear the delta CRL WAL and rebuild it.
+		if err := sc.Backend.crlBuilder.clearDeltaWAL(sc, currLocalDeltaSerials); err != nil {
+			return fmt.Errorf("error building CRLs: unable to clear Delta WAL: %w", err)
+		}
+		if err := sc.Backend.crlBuilder.rebuildDeltaCRLsHoldingLock(sc, forceNew); err != nil {
+			return fmt.Errorf("error building CRLs: unable to rebuild empty Delta WAL: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func buildAnyLocalCRLs(
+	sc *storageContext,
+	issuersConfig *issuerConfigEntry,
+	globalCRLConfig *crlConfig,
+	issuers []issuerID,
+	issuerIDEntryMap map[issuerID]*issuerEntry,
+	issuerIDCertMap map[issuerID]*x509.Certificate,
+	keySubjectIssuersMap map[keyID]map[string][]issuerID,
+	wasLegacy bool,
+	forceNew bool,
+	isDelta bool,
+) ([]string, error) {
+	var err error
 
 	// Before we load cert entries, we want to store the last seen delta WAL
 	// serial number. The subsequent List will have at LEAST that certificate
@@ -769,13 +803,13 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 	if isDelta {
 		lastWALEntry, err := sc.Storage.Get(sc.Context, deltaWALLastRevokedSerial)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		if lastWALEntry != nil && lastWALEntry.Value != nil {
 			var walInfo lastWALInfo
 			if err := lastWALEntry.DecodeJSON(&walInfo); err != nil {
-				return err
+				return nil, err
 			}
 
 			lastDeltaSerial = walInfo.Serial
@@ -789,7 +823,7 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 	if !isDelta {
 		currDeltaCerts, err = sc.Backend.crlBuilder.getPresentDeltaWALForClearing(sc)
 		if err != nil {
-			return fmt.Errorf("error building CRLs: unable to get present delta WAL entries for removal: %w", err)
+			return nil, fmt.Errorf("error building CRLs: unable to get present delta WAL entries for removal: %w", err)
 		}
 	}
 
@@ -804,7 +838,7 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 		// a separate pool for those.
 		unassignedCerts, revokedCertsMap, err = getRevokedCertEntries(sc, issuerIDCertMap, isDelta)
 		if err != nil {
-			return fmt.Errorf("error building CRLs: unable to get revoked certificate entries: %w", err)
+			return nil, fmt.Errorf("error building CRLs: unable to get revoked certificate entries: %w", err)
 		}
 
 		if !isDelta {
@@ -817,11 +851,71 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 			// duplicate this serial number on the delta, hence the above
 			// guard for isDelta.
 			if err := augmentWithRevokedIssuers(issuerIDEntryMap, issuerIDCertMap, revokedCertsMap); err != nil {
-				return fmt.Errorf("error building CRLs: unable to parse revoked issuers: %w", err)
+				return nil, fmt.Errorf("error building CRLs: unable to parse revoked issuers: %w", err)
 			}
 		}
 	}
 
+	// Fetch the cluster-local CRL mapping so we know where to write the
+	// CRLs.
+	internalCRLConfig, err := sc.getLocalCRLConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error building CRLs: unable to fetch cluster-local CRL configuration: %w", err)
+	}
+
+	if err := buildAnyCRLsWithCerts(sc, issuersConfig, globalCRLConfig, internalCRLConfig,
+		issuers, issuerIDEntryMap, keySubjectIssuersMap,
+		unassignedCerts, revokedCertsMap,
+		forceNew, isDelta); err != nil {
+		return nil, fmt.Errorf("error building CRLs: %w", err)
+	}
+
+	// Finally, persist our potentially updated local CRL config. Only do this
+	// if we didn't have a legacy CRL bundle.
+	if !wasLegacy {
+		if err := sc.setLocalCRLConfig(internalCRLConfig); err != nil {
+			return nil, fmt.Errorf("error building CRLs: unable to persist updated cluster-local CRL config: %w", err)
+		}
+	}
+
+	if isDelta {
+		// Update our last build time here so we avoid checking for new certs
+		// for a while.
+		sc.Backend.crlBuilder.lastDeltaRebuildCheck = time.Now()
+
+		if len(lastDeltaSerial) > 0 {
+			// When we have a last delta serial, write out the relevant info
+			// so we can skip extra CRL rebuilds.
+			deltaInfo := lastDeltaInfo{Serial: lastDeltaSerial}
+
+			lastDeltaBuildEntry, err := logical.StorageEntryJSON(deltaWALLastBuildSerial, deltaInfo)
+			if err != nil {
+				return nil, fmt.Errorf("error creating last delta CRL rebuild serial entry: %w", err)
+			}
+
+			err = sc.Storage.Put(sc.Context, lastDeltaBuildEntry)
+			if err != nil {
+				return nil, fmt.Errorf("error persisting last delta CRL rebuild info: %w", err)
+			}
+		}
+	}
+
+	return currDeltaCerts, nil
+}
+
+func buildAnyCRLsWithCerts(
+	sc *storageContext,
+	issuersConfig *issuerConfigEntry,
+	globalCRLConfig *crlConfig,
+	internalCRLConfig *localCRLConfigEntry,
+	issuers []issuerID,
+	issuerIDEntryMap map[issuerID]*issuerEntry,
+	keySubjectIssuersMap map[keyID]map[string][]issuerID,
+	unassignedCerts []pkix.RevokedCertificate,
+	revokedCertsMap map[issuerID][]pkix.RevokedCertificate,
+	forceNew bool,
+	isDelta bool,
+) error {
 	// Now we can call buildCRL once, on an arbitrary/representative issuer
 	// from each of these (keyID, subject) sets.
 	for _, subjectIssuersMap := range keySubjectIssuersMap {
@@ -849,7 +943,7 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 				// If it is, we'll also pull in the unassigned certs to remain
 				// compatible with Vault's earlier, potentially questionable
 				// behavior.
-				if issuerId == config.DefaultIssuerId {
+				if issuerId == issuersConfig.DefaultIssuerId {
 					if len(unassignedCerts) > 0 {
 						revokedCerts = append(revokedCerts, unassignedCerts...)
 					}
@@ -869,7 +963,7 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 				}
 
 				// Finally, check our crlIdentifier.
-				if thisCRLId, ok := crlConfig.IssuerIDCRLMap[issuerId]; ok && len(thisCRLId) > 0 {
+				if thisCRLId, ok := internalCRLConfig.IssuerIDCRLMap[issuerId]; ok && len(thisCRLId) > 0 {
 					if len(crlIdentifier) > 0 && crlIdentifier != thisCRLId {
 						return fmt.Errorf("error building CRLs: two issuers with same keys/subjects (%v vs %v) have different internal CRL IDs: %v vs %v", issuerId, crlIdIssuer, thisCRLId, crlIdentifier)
 					}
@@ -889,24 +983,24 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 			if len(crlIdentifier) == 0 {
 				// Create a new random UUID for this CRL if none exists.
 				crlIdentifier = genCRLId()
-				crlConfig.CRLNumberMap[crlIdentifier] = 1
+				internalCRLConfig.CRLNumberMap[crlIdentifier] = 1
 			}
 
 			// Update all issuers in this group to set the CRL Issuer
 			for _, issuerId := range issuersSet {
-				crlConfig.IssuerIDCRLMap[issuerId] = crlIdentifier
+				internalCRLConfig.IssuerIDCRLMap[issuerId] = crlIdentifier
 			}
 
 			// We always update the CRL Number since we never want to
 			// duplicate numbers and missing numbers is fine.
-			crlNumber := crlConfig.CRLNumberMap[crlIdentifier]
-			crlConfig.CRLNumberMap[crlIdentifier] += 1
+			crlNumber := internalCRLConfig.CRLNumberMap[crlIdentifier]
+			internalCRLConfig.CRLNumberMap[crlIdentifier] += 1
 
 			// CRLs (regardless of complete vs delta) are incrementally
 			// numbered. But delta CRLs need to know the number of the
 			// last complete CRL. We assume that's the previous identifier
 			// if no value presently exists.
-			lastCompleteNumber, haveLast := crlConfig.LastCompleteNumberMap[crlIdentifier]
+			lastCompleteNumber, haveLast := internalCRLConfig.LastCompleteNumberMap[crlIdentifier]
 			if !haveLast {
 				// We use the value of crlNumber for the current CRL, so
 				// decrement it by one to find the last one.
@@ -915,9 +1009,9 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 
 			// Update `LastModified`
 			if isDelta {
-				crlConfig.DeltaLastModified = time.Now().UTC()
+				internalCRLConfig.DeltaLastModified = time.Now().UTC()
 			} else {
-				crlConfig.LastModified = time.Now().UTC()
+				internalCRLConfig.LastModified = time.Now().UTC()
 			}
 
 			// Lastly, build the CRL.
@@ -926,13 +1020,13 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 				return fmt.Errorf("error building CRLs: unable to build CRL for issuer (%v): %w", representative, err)
 			}
 
-			crlConfig.CRLExpirationMap[crlIdentifier] = *nextUpdate
+			internalCRLConfig.CRLExpirationMap[crlIdentifier] = *nextUpdate
 			if !isDelta {
-				crlConfig.LastCompleteNumberMap[crlIdentifier] = crlNumber
+				internalCRLConfig.LastCompleteNumberMap[crlIdentifier] = crlNumber
 			} else if !haveLast {
 				// Since we're writing this config anyways, save our guess
 				// as to the last CRL number.
-				crlConfig.LastCompleteNumberMap[crlIdentifier] = lastCompleteNumber
+				internalCRLConfig.LastCompleteNumberMap[crlIdentifier] = lastCompleteNumber
 			}
 		}
 	}
@@ -948,7 +1042,7 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 	// root deletion behavior, but using soft issuer deletes. If there is an
 	// alternate, equivalent issuer however, we'll keep updating the shared
 	// CRL; all equivalent issuers must have their CRLs disabled.
-	for mapIssuerId := range crlConfig.IssuerIDCRLMap {
+	for mapIssuerId := range internalCRLConfig.IssuerIDCRLMap {
 		stillHaveIssuer := false
 		for _, listedIssuerId := range issuers {
 			if mapIssuerId == listedIssuerId {
@@ -958,12 +1052,12 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 		}
 
 		if !stillHaveIssuer {
-			delete(crlConfig.IssuerIDCRLMap, mapIssuerId)
+			delete(internalCRLConfig.IssuerIDCRLMap, mapIssuerId)
 		}
 	}
-	for crlId := range crlConfig.CRLNumberMap {
+	for crlId := range internalCRLConfig.CRLNumberMap {
 		stillHaveIssuerForID := false
-		for _, remainingCRL := range crlConfig.IssuerIDCRLMap {
+		for _, remainingCRL := range internalCRLConfig.IssuerIDCRLMap {
 			if remainingCRL == crlId {
 				stillHaveIssuerForID = true
 				break
@@ -973,45 +1067,6 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 		if !stillHaveIssuerForID {
 			if err := sc.Storage.Delete(sc.Context, "crls/"+crlId.String()); err != nil {
 				return fmt.Errorf("error building CRLs: unable to clean up deleted issuers' CRL: %w", err)
-			}
-		}
-	}
-
-	// Finally, persist our potentially updated local CRL config. Only do this
-	// if we didn't have a legacy CRL bundle.
-	if !wasLegacy {
-		if err := sc.setLocalCRLConfig(crlConfig); err != nil {
-			return fmt.Errorf("error building CRLs: unable to persist updated cluster-local CRL config: %w", err)
-		}
-	}
-
-	if !isDelta {
-		// After we've confirmed the primary CRLs have built OK, go ahead and
-		// clear the delta CRL WAL and rebuild it.
-		if err := sc.Backend.crlBuilder.clearDeltaWAL(sc, currDeltaCerts); err != nil {
-			return fmt.Errorf("error building CRLs: unable to clear Delta WAL: %w", err)
-		}
-		if err := sc.Backend.crlBuilder.rebuildDeltaCRLsHoldingLock(sc, forceNew); err != nil {
-			return fmt.Errorf("error building CRLs: unable to rebuild empty Delta WAL: %w", err)
-		}
-	} else {
-		// Update our last build time here so we avoid checking for new certs
-		// for a while.
-		sc.Backend.crlBuilder.lastDeltaRebuildCheck = time.Now()
-
-		if len(lastDeltaSerial) > 0 {
-			// When we have a last delta serial, write out the relevant info
-			// so we can skip extra CRL rebuilds.
-			deltaInfo := lastDeltaInfo{Serial: lastDeltaSerial}
-
-			lastDeltaBuildEntry, err := logical.StorageEntryJSON(deltaWALLastBuildSerial, deltaInfo)
-			if err != nil {
-				return fmt.Errorf("error creating last delta CRL rebuild serial entry: %w", err)
-			}
-
-			err = sc.Storage.Put(sc.Context, lastDeltaBuildEntry)
-			if err != nil {
-				return fmt.Errorf("error persisting last delta CRL rebuild info: %w", err)
 			}
 		}
 	}

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -175,7 +175,7 @@ type issuerEntry struct {
 	Version              uint                      `json:"version"`
 }
 
-type localCRLConfigEntry struct {
+type internalCRLConfigEntry struct {
 	IssuerIDCRLMap        map[issuerID]crlID  `json:"issuer_id_crl_map"`
 	CRLNumberMap          map[crlID]int64     `json:"crl_number_map"`
 	LastCompleteNumberMap map[crlID]int64     `json:"last_complete_number_map"`
@@ -909,7 +909,7 @@ func areCertificatesEqual(cert1 *x509.Certificate, cert2 *x509.Certificate) bool
 	return bytes.Equal(cert1.Raw, cert2.Raw)
 }
 
-func (sc *storageContext) setLocalCRLConfig(mapping *localCRLConfigEntry) error {
+func (sc *storageContext) setLocalCRLConfig(mapping *internalCRLConfigEntry) error {
 	json, err := logical.StorageEntryJSON(storageLocalCRLConfig, mapping)
 	if err != nil {
 		return err
@@ -918,13 +918,13 @@ func (sc *storageContext) setLocalCRLConfig(mapping *localCRLConfigEntry) error 
 	return sc.Storage.Put(sc.Context, json)
 }
 
-func (sc *storageContext) getLocalCRLConfig() (*localCRLConfigEntry, error) {
+func (sc *storageContext) getLocalCRLConfig() (*internalCRLConfigEntry, error) {
 	entry, err := sc.Storage.Get(sc.Context, storageLocalCRLConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	mapping := &localCRLConfigEntry{}
+	mapping := &internalCRLConfigEntry{}
 	if entry != nil {
 		if err := entry.DecodeJSON(mapping); err != nil {
 			return nil, errutil.InternalError{Err: fmt.Sprintf("unable to decode cluster-local CRL configuration: %v", err)}


### PR DESCRIPTION
This introduces a nasty refactor for `buildAnyCRLs` that splits it into a couple of functions that we can call for each global/local CRL variant, with different parameters and internally handling listing of the correct certificates to revoke.

Not saying this is perfect, but at least the structure is there and should be worthwhile anyways. :-) 

Also renames `localCRLConfigEntry`->`internalCRLConfigEntry` so we can reuse it entirely for unified CRLs. 