### PR TITLE
Add new clients into the monthly breakdown

### DIFF
--- a/changelog/18766.txt
+++ b/changelog/18766.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/activity: add namespace breakdown for new clients when date range spans multiple months, including the current month.
+```

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1664,6 +1664,7 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 			a.logger.Warn("no month data found, returning query with no namespace attribution for current month")
 		} else {
 			currentMonth.Namespaces = currentMonthNamespaceAttribution[0].Namespaces
+			currentMonth.NewClients.Namespaces = currentMonthNamespaceAttribution[0].NewClients.Namespaces
 		}
 		pq.Months = append(pq.Months, currentMonth)
 		distinctEntitiesResponse += pq.Months[len(pq.Months)-1].NewClients.Counts.EntityClients


### PR DESCRIPTION
First I opened https://github.com/hashicorp/vault/pull/18629 to solve this problem, but then it was reverted https://github.com/hashicorp/vault/pull/18726 because it broke enterprise only tests. This is a change to accomplish the same goals, but it doesn't break the enterprise tests, as confirmed here https://github.com/hashicorp/vault-enterprise/pull/3580