### PR TITLE
Add approle's remaining response schema definitions

### DIFF
--- a/builtin/credential/approle/path_login.go
+++ b/builtin/credential/approle/path_login.go
@@ -3,6 +3,7 @@ package approle
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -29,12 +30,33 @@ func pathLogin(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathLoginUpdate,
+				Responses: map[int][]framework.Response{
+					http.StatusOK: {{
+						Description: http.StatusText(http.StatusOK),
+					}},
+				},
 			},
 			logical.AliasLookaheadOperation: &framework.PathOperation{
 				Callback: b.pathLoginUpdateAliasLookahead,
+				Responses: map[int][]framework.Response{
+					http.StatusOK: {{
+						Description: http.StatusText(http.StatusOK),
+					}},
+				},
 			},
 			logical.ResolveRoleOperation: &framework.PathOperation{
 				Callback: b.pathLoginResolveRole,
+				Responses: map[int][]framework.Response{
+					http.StatusOK: {{
+						Description: http.StatusText(http.StatusOK),
+						Fields: map[string]*framework.FieldSchema{
+							"role": {
+								Type:     framework.TypeString,
+								Required: true,
+							},
+						},
+					}},
+				},
 			},
 		},
 		HelpSynopsis:    pathLoginHelpSys,

--- a/builtin/credential/approle/path_tidy_user_id.go
+++ b/builtin/credential/approle/path_tidy_user_id.go
@@ -17,8 +17,15 @@ func pathTidySecretID(b *backend) *framework.Path {
 	return &framework.Path{
 		Pattern: "tidy/secret-id$",
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.pathTidySecretIDUpdate,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathTidySecretIDUpdate,
+				Responses: map[int][]framework.Response{
+					http.StatusAccepted: {{
+						Description: http.StatusText(http.StatusAccepted),
+					}},
+				},
+			},
 		},
 
 		HelpSynopsis:    pathTidySecretIDSyn,

--- a/builtin/credential/approle/path_tidy_user_id_test.go
+++ b/builtin/credential/approle/path_tidy_user_id_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -15,6 +17,8 @@ func TestAppRole_TidyDanglingAccessors_Normal(t *testing.T) {
 	var resp *logical.Response
 	var err error
 	b, storage := createBackendWithStorage(t)
+
+	paths := []*framework.Path{pathTidySecretID(b)}
 
 	// Create a role
 	createRole(t, b, storage, "role1", "a,b,c")
@@ -73,12 +77,18 @@ func TestAppRole_TidyDanglingAccessors_Normal(t *testing.T) {
 		t.Fatalf("bad: len(accessorHashes); expect 3, got %d", len(accessorHashes))
 	}
 
-	_, err = b.tidySecretID(context.Background(), &logical.Request{
+	secret, err := b.tidySecretID(context.Background(), &logical.Request{
 		Storage: storage,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
+	schema.ValidateResponse(
+		t,
+		schema.FindResponseSchema(t, paths, 0, logical.UpdateOperation),
+		secret,
+		true,
+	)
 
 	// It runs async so we give it a bit of time to run
 	time.Sleep(10 * time.Second)
@@ -96,6 +106,8 @@ func TestAppRole_TidyDanglingAccessors_RaceTest(t *testing.T) {
 	var resp *logical.Response
 	var err error
 	b, storage := createBackendWithStorage(t)
+
+	paths := []*framework.Path{pathTidySecretID(b)}
 
 	// Create a role
 	createRole(t, b, storage, "role1", "a,b,c")
@@ -116,12 +128,18 @@ func TestAppRole_TidyDanglingAccessors_RaceTest(t *testing.T) {
 	start := time.Now()
 	for time.Now().Sub(start) < 10*time.Second {
 		if time.Now().Sub(start) > 100*time.Millisecond && atomic.LoadUint32(b.tidySecretIDCASGuard) == 0 {
-			_, err = b.tidySecretID(context.Background(), &logical.Request{
+			secret, err := b.tidySecretID(context.Background(), &logical.Request{
 				Storage: storage,
 			})
 			if err != nil {
 				t.Fatal(err)
 			}
+			schema.ValidateResponse(
+				t,
+				schema.FindResponseSchema(t, paths, 0, logical.UpdateOperation),
+				secret,
+				true,
+			)
 		}
 		wg.Add(1)
 		go func() {
@@ -173,6 +191,12 @@ func TestAppRole_TidyDanglingAccessors_RaceTest(t *testing.T) {
 	if err != nil || len(secret.Warnings) > 0 {
 		t.Fatal(err, secret.Warnings)
 	}
+	schema.ValidateResponse(
+		t,
+		schema.FindResponseSchema(t, paths, 0, logical.UpdateOperation),
+		secret,
+		true,
+	)
 
 	// Wait for tidy to start
 	for atomic.LoadUint32(b.tidySecretIDCASGuard) == 0 {

--- a/sdk/helper/testhelpers/schema/response_validation.go
+++ b/sdk/helper/testhelpers/schema/response_validation.go
@@ -100,8 +100,9 @@ func FindResponseSchema(t *testing.T, paths []*framework.Path, pathIdx int, oper
 	var schemaResponses []framework.Response
 
 	for _, status := range []int{
-		http.StatusOK,
-		http.StatusNoContent,
+		http.StatusOK,        // 200
+		http.StatusAccepted,  // 202
+		http.StatusNoContent, // 204
 	} {
 		schemaResponses, ok = schemaOperation.Properties().Responses[status]
 		if ok {


### PR DESCRIPTION
Adding response schema definitions (and the corresponding tests) for following two path files. These response field definitions will be used to generate better OpenAPI spec in Vault (see VLT-234).

- `approle/path_login.go`
- `approle/path_tidy_user_id.go`

The response schemas for `approle/path_role.go` have already been added in #18198 and #18636.