### PR TITLE
Fix link meta panics

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -3804,6 +3804,10 @@ func (c *Core) aliasNameFromLoginRequest(ctx context.Context, req *logical.Reque
 
 // ListMounts will provide a slice containing a deep copy each mount entry
 func (c *Core) ListMounts() ([]*MountEntry, error) {
+	if c.Sealed() {
+		return nil, fmt.Errorf("vault is sealed")
+	}
+
 	c.mountsLock.RLock()
 	defer c.mountsLock.RUnlock()
 
@@ -3823,6 +3827,10 @@ func (c *Core) ListMounts() ([]*MountEntry, error) {
 
 // ListAuths will provide a slice containing a deep copy each auth entry
 func (c *Core) ListAuths() ([]*MountEntry, error) {
+	if c.Sealed() {
+		return nil, fmt.Errorf("vault is sealed")
+	}
+
 	c.mountsLock.RLock()
 	defer c.mountsLock.RUnlock()
 

--- a/vault/hcp_link/capabilities/link_control/link_control.go
+++ b/vault/hcp_link/capabilities/link_control/link_control.go
@@ -115,7 +115,7 @@ func (h *hcpLinkControlHandler) PurgePolicy(ctx context.Context, req *link_contr
 	defer func() {
 		if r := recover(); r != nil {
 			h.logger.Error("panic serving purge policy request", "error", r, "stacktrace", string(debug.Stack()))
-			retErr = fmt.Errorf("internal server error")
+			retErr = vault.ErrInternalError
 		}
 	}()
 

--- a/vault/hcp_link/capabilities/link_control/link_control.go
+++ b/vault/hcp_link/capabilities/link_control/link_control.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -110,7 +111,14 @@ func (h *hcpLinkControlHandler) Stop() error {
 	return nil
 }
 
-func (h *hcpLinkControlHandler) PurgePolicy(ctx context.Context, req *link_control.PurgePolicyRequest) (*link_control.PurgePolicyResponse, error) {
+func (h *hcpLinkControlHandler) PurgePolicy(ctx context.Context, req *link_control.PurgePolicyRequest) (retResp *link_control.PurgePolicyResponse, retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			h.logger.Error("panic serving purge policy request", "error", r, "stacktrace", string(debug.Stack()))
+			retErr = fmt.Errorf("internal server error")
+		}
+	}()
+
 	standby, perfStandby := h.wrappedCore.StandbyStates()
 	// only purging an active node, perf/standby nodes should purge
 	// automatically

--- a/vault/hcp_link/capabilities/meta/meta.go
+++ b/vault/hcp_link/capabilities/meta/meta.go
@@ -37,7 +37,6 @@ type hcpLinkMetaHandler struct {
 
 func NewHCPLinkMetaService(scadaProvider scada.SCADAProvider, c *vault.Core, baseLogger hclog.Logger) *hcpLinkMetaHandler {
 	logger := baseLogger.Named(capabilities.MetaCapability)
-	logger.Info("Setting up HCP Link Meta Service")
 
 	grpcServer := grpc.NewServer(
 		grpc.KeepaliveParams(keepalive.ServerParameters{
@@ -78,7 +77,7 @@ func (h *hcpLinkMetaHandler) Start() error {
 		return fmt.Errorf("no listener found for meta capability")
 	}
 
-	h.logger.Info("starting HCP Link Meta Service")
+	h.logger.Info("starting HCP connectivity meta service")
 	// Start the gRPC server
 	go func() {
 		err = h.grpcServer.Serve(metaListener)
@@ -101,7 +100,7 @@ func (h *hcpLinkMetaHandler) Stop() error {
 	// Give some time for existing RPCs to drain.
 	time.Sleep(cluster.ListenerAcceptDeadline)
 
-	h.logger.Info("Tearing down HCP Link Meta Service")
+	h.logger.Info("tearing down HCP connectivity meta service")
 
 	if h.stopCh != nil {
 		close(h.stopCh)

--- a/vault/hcp_link/capabilities/meta/meta.go
+++ b/vault/hcp_link/capabilities/meta/meta.go
@@ -119,7 +119,7 @@ func (h *hcpLinkMetaHandler) ListNamespaces(ctx context.Context, req *meta.ListN
 	defer func() {
 		if r := recover(); r != nil {
 			h.logger.Error("panic serving list namespaces request", "error", r, "stacktrace", string(debug.Stack()))
-			retErr = fmt.Errorf("internal server error")
+			retErr = vault.ErrInternalError
 		}
 	}()
 
@@ -139,7 +139,7 @@ func (h *hcpLinkMetaHandler) ListMounts(ctx context.Context, req *meta.ListMount
 	defer func() {
 		if r := recover(); r != nil {
 			h.logger.Error("panic serving list mounts request", "error", r, "stacktrace", string(debug.Stack()))
-			retErr = fmt.Errorf("internal server error")
+			retErr = vault.ErrInternalError
 		}
 	}()
 
@@ -178,7 +178,7 @@ func (h *hcpLinkMetaHandler) ListAuths(ctx context.Context, req *meta.ListAuthsR
 	defer func() {
 		if r := recover(); r != nil {
 			h.logger.Error("panic serving list auths request", "error", r, "stacktrace", string(debug.Stack()))
-			retErr = fmt.Errorf("internal server error")
+			retErr = vault.ErrInternalError
 		}
 	}()
 
@@ -217,7 +217,7 @@ func (h *hcpLinkMetaHandler) GetClusterStatus(ctx context.Context, req *meta.Get
 	defer func() {
 		if r := recover(); r != nil {
 			h.logger.Error("panic serving cluster status request", "error", r, "stacktrace", string(debug.Stack()))
-			retErr = fmt.Errorf("internal server error")
+			retErr = vault.ErrInternalError
 		}
 	}()
 

--- a/vault/hcp_link/capabilities/meta/meta.go
+++ b/vault/hcp_link/capabilities/meta/meta.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -114,7 +115,14 @@ func (h *hcpLinkMetaHandler) Stop() error {
 	return nil
 }
 
-func (h *hcpLinkMetaHandler) ListNamespaces(ctx context.Context, req *meta.ListNamespacesRequest) (*meta.ListNamespacesResponse, error) {
+func (h *hcpLinkMetaHandler) ListNamespaces(ctx context.Context, req *meta.ListNamespacesRequest) (retResp *meta.ListNamespacesResponse, retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			h.logger.Error("panic serving list namespaces request", "error", r, "stacktrace", string(debug.Stack()))
+			retErr = fmt.Errorf("internal server error")
+		}
+	}()
+
 	children := h.wrappedCore.ListNamespaces(true)
 
 	var namespaces []string
@@ -127,7 +135,14 @@ func (h *hcpLinkMetaHandler) ListNamespaces(ctx context.Context, req *meta.ListN
 	}, nil
 }
 
-func (h *hcpLinkMetaHandler) ListMounts(ctx context.Context, req *meta.ListMountsRequest) (*meta.ListMountsResponse, error) {
+func (h *hcpLinkMetaHandler) ListMounts(ctx context.Context, req *meta.ListMountsRequest) (retResp *meta.ListMountsResponse, retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			h.logger.Error("panic serving list mounts request", "error", r, "stacktrace", string(debug.Stack()))
+			retErr = fmt.Errorf("internal server error")
+		}
+	}()
+
 	mountEntries, err := h.wrappedCore.ListMounts()
 	if err != nil {
 		return nil, fmt.Errorf("unable to list secret mounts: %w", err)
@@ -159,7 +174,14 @@ func (h *hcpLinkMetaHandler) ListMounts(ctx context.Context, req *meta.ListMount
 	}, nil
 }
 
-func (h *hcpLinkMetaHandler) ListAuths(ctx context.Context, req *meta.ListAuthsRequest) (*meta.ListAuthResponse, error) {
+func (h *hcpLinkMetaHandler) ListAuths(ctx context.Context, req *meta.ListAuthsRequest) (retResp *meta.ListAuthResponse, retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			h.logger.Error("panic serving list auths request", "error", r, "stacktrace", string(debug.Stack()))
+			retErr = fmt.Errorf("internal server error")
+		}
+	}()
+
 	authEntries, err := h.wrappedCore.ListAuths()
 	if err != nil {
 		return nil, fmt.Errorf("unable to list auth mounts: %w", err)
@@ -191,7 +213,14 @@ func (h *hcpLinkMetaHandler) ListAuths(ctx context.Context, req *meta.ListAuthsR
 	}, nil
 }
 
-func (h *hcpLinkMetaHandler) GetClusterStatus(ctx context.Context, req *meta.GetClusterStatusRequest) (*meta.GetClusterStatusResponse, error) {
+func (h *hcpLinkMetaHandler) GetClusterStatus(ctx context.Context, req *meta.GetClusterStatusRequest) (retResp *meta.GetClusterStatusResponse, retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			h.logger.Error("panic serving cluster status request", "error", r, "stacktrace", string(debug.Stack()))
+			retErr = fmt.Errorf("internal server error")
+		}
+	}()
+
 	if h.wrappedCore.HAStateWithLock() != consts.Active {
 		return nil, fmt.Errorf("node not active")
 	}

--- a/vault/hcp_link/capabilities/meta/meta.go
+++ b/vault/hcp_link/capabilities/meta/meta.go
@@ -77,7 +77,7 @@ func (h *hcpLinkMetaHandler) Start() error {
 		return fmt.Errorf("no listener found for meta capability")
 	}
 
-	h.logger.Info("starting HCP connectivity meta service")
+	h.logger.Info("starting HCP meta capability")
 	// Start the gRPC server
 	go func() {
 		err = h.grpcServer.Serve(metaListener)
@@ -100,7 +100,7 @@ func (h *hcpLinkMetaHandler) Stop() error {
 	// Give some time for existing RPCs to drain.
 	time.Sleep(cluster.ListenerAcceptDeadline)
 
-	h.logger.Info("tearing down HCP connectivity meta service")
+	h.logger.Info("tearing down HCP meta capability")
 
 	if h.stopCh != nil {
 		close(h.stopCh)

--- a/vault/hcp_link/capabilities/node_status/node_status.go
+++ b/vault/hcp_link/capabilities/node_status/node_status.go
@@ -2,6 +2,7 @@ package node_status
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/hcp-link/pkg/nodestatus"
 	"github.com/hashicorp/vault/helper/logging"
@@ -20,7 +21,13 @@ type NodeStatusReporter struct {
 	NodeStatusGetter internal.WrappedCoreNodeStatus
 }
 
-func (c *NodeStatusReporter) GetNodeStatus(ctx context.Context) (nodestatus.NodeStatus, error) {
+func (c *NodeStatusReporter) GetNodeStatus(ctx context.Context) (retStatus nodestatus.NodeStatus, retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = fmt.Errorf("internal server error")
+		}
+	}()
+
 	var status nodestatus.NodeStatus
 
 	sealStatus, err := c.NodeStatusGetter.GetSealStatus(ctx)

--- a/vault/hcp_link/link.go
+++ b/vault/hcp_link/link.go
@@ -212,7 +212,7 @@ func (h *HCPLinkVault) start() error {
 
 	h.running = true
 
-	h.logger.Info("started HCP Link")
+	h.logger.Info("established connection to HCP")
 
 	return nil
 }
@@ -333,7 +333,7 @@ func (h *HCPLinkVault) Shutdown() error {
 		h.stopCh = nil
 	}
 
-	h.logger.Info("tearing down HCP Link")
+	h.logger.Info("tearing down connection to HCP")
 
 	var retErr *multierror.Error
 


### PR DESCRIPTION
The meta calls for `ListAuths` and `ListMounts` will panic when Vault is sealed. This PR introduces a change to the underlying methods for these endpoints so that an error is returned when Vault is sealed. A couple minor logging changes are also included.

Edit: It occurred to me that we should add panic recovery to all the capability endpoints to ensure that any HCP functionality does not unexpectedly cause a server to die.