### PR TITLE
Include a direct link to the interoperability matrix from Vault HSM page

### DIFF
--- a/website/content/docs/enterprise/hsm/index.mdx
+++ b/website/content/docs/enterprise/hsm/index.mdx
@@ -37,5 +37,9 @@ important information on these differences.
 The [Configuration](/docs/configuration/seal/pkcs11) page contains
 configuration information.
 
-Finally, the [Security](/docs/enterprise/hsm/security) page contains
+The [Security](/docs/enterprise/hsm/security) page contains
 information about deploying Vault's HSM support in a secure fashion.
+
+Finally, the [Vault Interoperability Matrix](/docs/interoperability-matrix) page contains
+information about HashiCorp partner products that have been verified to work with Vault 
+for Auto Unsealing / HSM Support and External Key Management.


### PR DESCRIPTION
I was recently looking for information on the supported HSMs / KMS integrations. I figured it would be good to have a link directly from the HSM content to the Interoperability Matrix, as it is directly applicable to the HSM content.