### PR TITLE
UI: VAULT-12820 Fix styling for pki beta badge

### DIFF
--- a/ui/app/styles/core/tags.scss
+++ b/ui/app/styles/core/tags.scss
@@ -20,8 +20,12 @@
   }
 
   &.is-success {
-    background-color: $green-100;
+    background-color: $green-050;
     color: $green-700;
+  }
+
+  &.has-extra-padding {
+    padding: $size-11 $spacing-xxs;
   }
 }
 

--- a/ui/lib/core/addon/components/secret-list-header.hbs
+++ b/ui/lib/core/addon/components/secret-list-header.hbs
@@ -29,7 +29,11 @@
         {{#if this.isPki}}
           {{#if @isEngine}}
             <span>
-              <LinkToExternal @route="secretsListRoot" class="tag is-borderless is-underline" data-test-new-pki-beta-button>
+              <LinkToExternal
+                @route="secretsListRoot"
+                class="tag is-borderless is-underline has-text-weight-semibold has-extra-padding"
+                data-test-new-pki-beta-button
+              >
                 <Icon @name="arrow-left" />
                 Return to old PKI
               </LinkToExternal>
@@ -39,7 +43,7 @@
               <span>
                 <LinkTo
                   @route="vault.cluster.secrets.backend.pki.overview"
-                  class="tag is-success is-borderless is-underline"
+                  class="tag is-success is-borderless is-underline has-text-weight-semibold has-extra-padding"
                 >
                   <Icon @name="key" />
                   New PKI UI available
@@ -48,7 +52,7 @@
             {{else}}
               <button
                 type="button"
-                class="tag is-success is-v-centered text-button is-underline"
+                class="tag is-success is-v-centered text-button is-underline has-text-weight-semibold has-extra-padding"
                 {{on "click" (action (mut this.modalOpen) true)}}
                 data-test-old-pki-beta-button
               >

--- a/ui/lib/core/addon/components/secret-list-header.hbs
+++ b/ui/lib/core/addon/components/secret-list-header.hbs
@@ -36,10 +36,15 @@
             </span>
           {{else}}
             {{#if this.shouldHidePkiBetaModal}}
-              <LinkTo @route="vault.cluster.secrets.backend.pki.overview" class="tag is-success is-borderless">
-                <Icon @name="key" />
-                New PKI UI available
-              </LinkTo>
+              <span>
+                <LinkTo
+                  @route="vault.cluster.secrets.backend.pki.overview"
+                  class="tag is-success is-borderless is-underline"
+                >
+                  <Icon @name="key" />
+                  New PKI UI available
+                </LinkTo>
+              </span>
             {{else}}
               <button
                 type="button"

--- a/ui/lib/core/addon/components/secret-list-header.hbs
+++ b/ui/lib/core/addon/components/secret-list-header.hbs
@@ -53,7 +53,7 @@
               <button
                 type="button"
                 class="tag is-success is-v-centered text-button is-underline has-text-weight-semibold has-extra-padding"
-                {{on "click" (action (mut this.modalOpen) true)}}
+                {{on "click" (fn (mut this.modalOpen) true)}}
                 data-test-old-pki-beta-button
               >
                 <Icon @name="key" />
@@ -61,7 +61,7 @@
               </button>
               <Modal
                 @title="New PKI Beta"
-                @onClose={{action (mut this.modalOpen) false}}
+                @onClose={{fn (mut this.modalOpen) false}}
                 @isActive={{this.modalOpen}}
                 @showCloseButton={{true}}
               >


### PR DESCRIPTION
**Description**
- Add underline to beta badge link!
- Fix colors + add bold to text to match designs

**Before:**
<img width="259" alt="Screen Shot 2023-01-20 at 1 36 50 PM" src="https://user-images.githubusercontent.com/30884335/213809828-15db9851-356d-4b19-860d-08c16de029a4.png">

**After:**
<img width="269" alt="Screen Shot 2023-01-20 at 1 38 41 PM" src="https://user-images.githubusercontent.com/30884335/213809893-b188c04d-ad40-4652-abcb-e55ad61bab62.png">
_to compare here are the designs:_
<img width="269" alt="Screen Shot 2023-01-20 at 1 39 12 PM" src="https://user-images.githubusercontent.com/30884335/213809947-2a97d128-0696-4bae-9d20-66ca9a53d64a.png">
