### PR TITLE
Write delta WAL entries for unified CRLs

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -121,6 +121,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			WriteForwardedStorage: []string{
 				crossRevocationPath,
 				unifiedRevocationWritePathPrefix,
+				unifiedDeltaWALPath,
 			},
 		},
 

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -5482,17 +5482,17 @@ func TestBackend_IfModifiedSinceHeaders(t *testing.T) {
 		lastHeaders = client.Headers()
 	}
 
-	time.Sleep(4 * time.Second)
-
-	beforeDeltaRotation := time.Now().Add(-2 * time.Second)
-
 	// Finally, rebuild the delta CRL and ensure that only that is
-	// invalidated. We first need to enable it though.
+	// invalidated. We first need to enable it though, and wait for
+	// all CRLs to rebuild.
 	_, err = client.Logical().Write("pki/config/crl", map[string]interface{}{
 		"auto_rebuild": true,
 		"enable_delta": true,
 	})
 	require.NoError(t, err)
+	time.Sleep(4 * time.Second)
+	beforeDeltaRotation := time.Now().Add(-2 * time.Second)
+
 	resp, err = client.Logical().Read("pki/crl/rotate-delta")
 	require.NoError(t, err)
 	require.NotNil(t, resp)


### PR DESCRIPTION
When we'd ordinarily write delta WALs for local CRLs, we also need to populate the cross-cluster delta WAL. This could cause revocation to appear to fail if the two clusters are disconnected, but notably regular cross-cluster revocation would also fail.

Notably, this commit also changes us to not write Delta WALs when Delta CRLs is disabled (versus previously doing it when auto rebuild is enabled in case Delta CRLs were later asked for), and instead, triggering rebuilding a complete CRL so we don't need up-to-date Delta WAL info.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

OSS version of Enterprise https://github.com/hashicorp/vault-enterprise/pull/3577. Relies on an un-ported PR from @stevendpclark adding support for unified CRL, so will be rebased once that merges (won't build). 