### PR TITLE
Add support for revoke by serial number to update the unified CRL

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -118,6 +118,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 
 			WriteForwardedStorage: []string{
 				crossRevocationPath,
+				unifiedRevocationWritePathPrefix,
 			},
 		},
 
@@ -143,6 +144,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathRevokeWithKey(&b),
 			pathListCertsRevoked(&b),
 			pathListCertsRevocationQueue(&b),
+			pathListUnifiedRevoked(&b),
 			pathTidy(&b),
 			pathTidyCancel(&b),
 			pathTidyStatus(&b),

--- a/builtin/logical/pki/secret_certs.go
+++ b/builtin/logical/pki/secret_certs.go
@@ -50,8 +50,9 @@ func (b *backend) secretCredsRevoke(ctx context.Context, req *logical.Request, _
 	defer b.revokeStorageLock.Unlock()
 
 	sc := b.makeStorageContext(ctx, req.Storage)
+	serial := serialInt.(string)
 
-	certEntry, err := fetchCertBySerial(sc, "certs/", serialInt.(string))
+	certEntry, err := fetchCertBySerial(sc, "certs/", serial)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +60,7 @@ func (b *backend) secretCredsRevoke(ctx context.Context, req *logical.Request, _
 		// We can't write to revoked/ or update the CRL anyway because we don't have the cert,
 		// and there's no reason to expect this will work on a subsequent
 		// retry.  Just give up and let the lease get deleted.
-		b.Logger().Warn("expired certificate revoke failed because not found in storage, treating as success", "serial", serialInt.(string))
+		b.Logger().Warn("expired certificate revoke failed because not found in storage, treating as success", "serial", serial)
 		return nil, nil
 	}
 
@@ -73,5 +74,10 @@ func (b *backend) secretCredsRevoke(ctx context.Context, req *logical.Request, _
 		return nil, nil
 	}
 
-	return revokeCert(sc, cert)
+	config, err := sc.Backend.crlBuilder.getConfigWithUpdate(sc)
+	if err != nil {
+		return nil, fmt.Errorf("error revoking serial: %s: failed reading config: %w", serial, err)
+	}
+
+	return revokeCert(sc, config, cert)
 }

--- a/builtin/logical/pki/storage_unified.go
+++ b/builtin/logical/pki/storage_unified.go
@@ -1,0 +1,89 @@
+package pki
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const (
+	unifiedRevocationReadPathPrefix  = "unified-revocation/"
+	unifiedRevocationWritePathPrefix = unifiedRevocationReadPathPrefix + "{{clusterId}}/"
+)
+
+type unifiedRevocationEntry struct {
+	SerialNumber      string    `json:"-"`
+	CertExpiration    time.Time `json:"certificate_expiration_utc"`
+	RevocationTimeUTC time.Time `json:"revocation_time_utc"`
+	CertificateIssuer issuerID  `json:"issuer_id"`
+}
+
+func getUnifiedRevocationBySerial(sc *storageContext, serial string) (*unifiedRevocationEntry, error) {
+	clusterPaths, err := lookupClusterPaths(sc)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, path := range clusterPaths {
+		serialPath := path + serial
+		entryRaw, err := sc.Storage.Get(sc.Context, serialPath)
+		if err != nil {
+			return nil, err
+		}
+
+		if entryRaw != nil {
+			var revEntry unifiedRevocationEntry
+			if err := entryRaw.DecodeJSON(&revEntry); err != nil {
+				return nil, fmt.Errorf("failed json decoding of unified entry at path %s: %w", serialPath, err)
+			}
+			revEntry.SerialNumber = serial
+			return &revEntry, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func writeUnifiedRevocationEntry(sc *storageContext, ure *unifiedRevocationEntry) error {
+	json, err := logical.StorageEntryJSON(unifiedRevocationWritePathPrefix+normalizeSerial(ure.SerialNumber), ure)
+	if err != nil {
+		return err
+	}
+
+	return sc.Storage.Put(sc.Context, json)
+}
+
+func listUnifiedRevokedCerts(sc *storageContext) ([]string, error) {
+	allSerials := []string{}
+
+	clusterPaths, err := lookupClusterPaths(sc)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, path := range clusterPaths {
+		clusterSerials, err := sc.Storage.List(sc.Context, path)
+		if err != nil {
+			return nil, fmt.Errorf("failed listing revoked certs for path %s: %w", path, err)
+		}
+
+		allSerials = append(allSerials, clusterSerials...)
+	}
+	return allSerials, nil
+}
+
+func lookupClusterPaths(sc *storageContext) ([]string, error) {
+	fullPaths := []string{}
+
+	clusterPaths, err := sc.Storage.List(sc.Context, unifiedRevocationReadPathPrefix)
+	if err != nil {
+		return fullPaths, err
+	}
+
+	for _, clusterId := range clusterPaths {
+		fullPaths = append(fullPaths, unifiedRevocationReadPathPrefix+clusterId)
+	}
+
+	return fullPaths, nil
+}


### PR DESCRIPTION
OSS portion of enterprise PR:[3468](https://github.com/hashicorp/vault-enterprise/pull/3468)

Initial work to get revocations sent across multiple clusters working with the revoke by serial API to update the unified CRL.

Add a new LIST /certs/unified-revoked API returns the entry across both PR clusters, and that the second PR cluster does not return any values for the existing LIST /cert/revoked both before and after we "revoked" the certificate on the second PR cluster.
