### PR TITLE
Add unified storage support to OCSP handler

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -91,9 +91,11 @@ func Backend(conf *logical.BackendConfig) *backend {
 				"issuer/+/pem",
 				"issuer/+/der",
 				"issuer/+/json",
-				"issuers/", // LIST operations append a '/' to the requested path
-				"ocsp",     // OCSP POST
-				"ocsp/*",   // OCSP GET
+				"issuers/",       // LIST operations append a '/' to the requested path
+				"ocsp",           // OCSP POST
+				"ocsp/*",         // OCSP GET
+				"unified-ocsp",   // Unified OCSP POST
+				"unified-ocsp/*", // Unified OCSP GET
 			},
 
 			LocalStorage: []string{
@@ -187,6 +189,8 @@ func Backend(conf *logical.BackendConfig) *backend {
 			// OCSP APIs
 			buildPathOcspGet(&b),
 			buildPathOcspPost(&b),
+			buildPathUnifiedOcspGet(&b),
+			buildPathUnifiedOcspPost(&b),
 
 			// CRL Signing
 			pathResignCrls(&b),

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -43,6 +43,10 @@ func serialFromBigInt(serial *big.Int) string {
 	return strings.TrimSpace(certutil.GetHexFormatted(serial.Bytes(), ":"))
 }
 
+func normalizeSerialFromBigInt(serial *big.Int) string {
+	return strings.TrimSpace(certutil.GetHexFormatted(serial.Bytes(), "-"))
+}
+
 func normalizeSerial(serial string) string {
 	return strings.ReplaceAll(strings.ToLower(serial), ":", "-")
 }


### PR DESCRIPTION
OSS portion of ENT PRs:[3542](https://github.com/hashicorp/vault-enterprise/pull/3542) and [3575](https://github.com/hashicorp/vault-enterprise/pull/3575)

Update the OCSP handler with new URLs for unified storage, add the ability to return responses from the local and/or the unified storage if either configuration is enabled or someone hit the /unified-ocsp/ path.

The unified-ocsp path will always prefer local storage entries if they exist.

Also add checks that none of the cross-cluster revocation features can be enabled on non-enterprise Vault versions.
