### PR TITLE
More cross cluster queue tweaks

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -261,41 +261,7 @@ type backend struct {
 	issuersLock sync.RWMutex
 }
 
-type (
-	tidyStatusState int
-	roleOperation   func(ctx context.Context, req *logical.Request, data *framework.FieldData, role *roleEntry) (*logical.Response, error)
-)
-
-const (
-	tidyStatusInactive   tidyStatusState = iota
-	tidyStatusStarted                    = iota
-	tidyStatusFinished                   = iota
-	tidyStatusError                      = iota
-	tidyStatusCancelling                 = iota
-	tidyStatusCancelled                  = iota
-)
-
-type tidyStatus struct {
-	// Parameters used to initiate the operation
-	safetyBuffer       int
-	issuerSafetyBuffer int
-	tidyCertStore      bool
-	tidyRevokedCerts   bool
-	tidyRevokedAssocs  bool
-	tidyExpiredIssuers bool
-	tidyBackupBundle   bool
-	pauseDuration      string
-
-	// Status
-	state                   tidyStatusState
-	err                     error
-	timeStarted             time.Time
-	timeFinished            time.Time
-	message                 string
-	certStoreDeletedCount   uint
-	revokedCertDeletedCount uint
-	missingIssuerCertCount  uint
-}
+type roleOperation func(ctx context.Context, req *logical.Request, data *framework.FieldData, role *roleEntry) (*logical.Response, error)
 
 const backendHelp = `
 The PKI backend dynamically generates X509 server and client certificates.

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -480,19 +480,21 @@ func (b *backend) invalidate(ctx context.Context, key string) {
 		if !strings.HasSuffix(key, "/confirmed") {
 			cluster := split[len(split)-2]
 			serial := split[len(split)-1]
-			// Only process confirmations on the perf primary.
 			b.crlBuilder.addCertForRevocationCheck(cluster, serial)
 		} else {
 			if len(split) >= 3 {
 				cluster := split[len(split)-3]
 				serial := split[len(split)-2]
+				// Only process confirmations on the perf primary. The
+				// performance secondaries cannot remove other clusters'
+				// entries, and so do not need to track them (only to
+				// ignore them). On performance primary nodes though,
+				// we do want to track them to remove them.
 				if !isNotPerfPrimary {
 					b.crlBuilder.addCertForRevocationRemoval(cluster, serial)
 				}
 			}
 		}
-
-		b.Logger().Debug("got replicated cross-cluster revocation: " + key)
 	}
 }
 

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -3952,6 +3952,7 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 			"missing_issuer_cert_count":             json.Number("0"),
 			"current_cert_store_count":              json.Number("0"),
 			"current_revoked_cert_count":            json.Number("0"),
+			"revocation_queue_deleted_count":        json.Number("0"),
 		}
 		// Let's copy the times from the response so that we can use deep.Equal()
 		timeStarted, ok := tidyStatus.Data["time_started"]

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -541,11 +541,27 @@ func (cb *crlBuilder) processRevocationQueue(sc *storageContext) error {
 	removalQueue := cb.removalQueue.Iterate()
 
 	sc.Backend.Logger().Debug(fmt.Sprintf("gathered %v revocations and %v confirmation entries", len(revQueue), len(removalQueue)))
+
 	crlConfig, err := cb.getConfigWithUpdate(sc)
 	if err != nil {
 		return err
 	}
+
+	ourClusterId, err := sc.Backend.System().ClusterID(sc.Context)
+	if err != nil {
+		return fmt.Errorf("unable to fetch clusterID to ignore local revocation entries: %w", err)
+	}
+
 	for _, req := range revQueue {
+		// Regardless of whether we're on the perf primary or a secondary
+		// cluster, we can safely ignore revocation requests originating
+		// from our node, because we've already checked them once (when
+		// they were created).
+		if ourClusterId != "" && ourClusterId == req.Cluster {
+			continue
+		}
+
+		// Fetch the revocation entry to ensure it exists.
 		rPath := crossRevocationPrefix + req.Cluster + "/" + req.Serial
 		entry, err := sc.Storage.Get(sc.Context, rPath)
 		if err != nil {

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -508,9 +508,7 @@ func (cb *crlBuilder) maybeGatherQueueForFirstProcess(sc *storageContext, isNotP
 				cb.revQueue.Add(entry)
 			} else if !isNotPerfPrimary {
 				cb.removalQueue.Add(entry)
-			} else {
-				sc.Backend.Logger().Debug(fmt.Sprintf("ignoring confirmed revoked serial %v: %v vs %v ", serial, err, removalEntry))
-			}
+			} // Else, this is a confirmation but we're on a perf secondary so ignore it.
 
 			// Overwrite the error; we don't really care about its contents
 			// at this step.
@@ -548,7 +546,6 @@ func (cb *crlBuilder) processRevocationQueue(sc *storageContext) error {
 		return err
 	}
 	for _, req := range revQueue {
-		sc.Backend.Logger().Debug(fmt.Sprintf("handling revocation request: %v", req))
 		rPath := crossRevocationPrefix + req.Cluster + "/" + req.Serial
 		entry, err := sc.Storage.Get(sc.Context, rPath)
 		if err != nil {
@@ -562,7 +559,6 @@ func (cb *crlBuilder) processRevocationQueue(sc *storageContext) error {
 		}
 
 		resp, err := tryRevokeCertBySerial(sc, crlConfig, req.Serial)
-		sc.Backend.Logger().Debug(fmt.Sprintf("checked local revocation entry: %v / %v", resp, err))
 		if err == nil && resp != nil && !resp.IsError() && resp.Data != nil && resp.Data["state"].(string) == "revoked" {
 			if isNotPerfPrimary {
 				// Write a revocation queue removal entry.
@@ -597,7 +593,9 @@ func (cb *crlBuilder) processRevocationQueue(sc *storageContext) error {
 	}
 
 	if isNotPerfPrimary {
-		sc.Backend.Logger().Debug(fmt.Sprintf("not on perf primary so done; ignoring any revocation confirmations"))
+		sc.Backend.Logger().Debug(fmt.Sprintf("not on perf primary so ignoring any revocation confirmations"))
+
+		// See note in pki/backend.go; this should be empty.
 		cb.removalQueue.RemoveAll()
 		cb.haveInitializedQueue = true
 		return nil
@@ -609,7 +607,6 @@ func (cb *crlBuilder) processRevocationQueue(sc *storageContext) error {
 	}
 
 	for _, entry := range removalQueue {
-		sc.Backend.Logger().Debug(fmt.Sprintf("handling revocation confirmation: %v", entry))
 		// First remove the revocation request.
 		for cIndex, cluster := range clusters {
 			eEntry := crossRevocationPrefix + cluster + entry.Serial

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -19,6 +19,39 @@ import (
 
 var tidyCancelledError = errors.New("tidy operation cancelled")
 
+type tidyStatusState int
+
+const (
+	tidyStatusInactive   tidyStatusState = iota
+	tidyStatusStarted                    = iota
+	tidyStatusFinished                   = iota
+	tidyStatusError                      = iota
+	tidyStatusCancelling                 = iota
+	tidyStatusCancelled                  = iota
+)
+
+type tidyStatus struct {
+	// Parameters used to initiate the operation
+	safetyBuffer       int
+	issuerSafetyBuffer int
+	tidyCertStore      bool
+	tidyRevokedCerts   bool
+	tidyRevokedAssocs  bool
+	tidyExpiredIssuers bool
+	tidyBackupBundle   bool
+	pauseDuration      string
+
+	// Status
+	state                   tidyStatusState
+	err                     error
+	timeStarted             time.Time
+	timeFinished            time.Time
+	message                 string
+	certStoreDeletedCount   uint
+	revokedCertDeletedCount uint
+	missingIssuerCertCount  uint
+}
+
 type tidyConfig struct {
 	Enabled            bool          `json:"enabled"`
 	Interval           time.Duration `json:"interval_duration"`

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -725,9 +725,7 @@ func (b *backend) doTidyRevocationQueue(ctx context.Context, req *logical.Reques
 				return fmt.Errorf("error reading revocation request (%v) to tidy: %w", ePath, err)
 			}
 
-			now := time.Now()
-			afterBuffer := now.Add(-1 * config.QueueSafetyBuffer)
-			if revRequest.RequestedAt.After(afterBuffer) {
+			if time.Since(revRequest.RequestedAt) > config.QueueSafetyBuffer {
 				continue
 			}
 


### PR DESCRIPTION
This:

 - Cleans up logging so its not quite as verbose,
 - Adds missing count to tidy,
 - Switches to `time.Since` for tidy,
 - Allows tidy to remove confirmations as well (in case this wasn't done at plugin startup),
 - Skips revocation requests from our current cluster, and
 - Various commentary about why things were done.