### PR TITLE
secrets/mysql: Add `tls_server_name` and `tls_skip_verify` parameters

### DIFF
--- a/changelog/18799.txt
+++ b/changelog/18799.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/db/mysql: Add `tls_server_name` and `tls_skip_verify` parameters
+```

--- a/changelog/18799.txt
+++ b/changelog/18799.txt
@@ -1,3 +1,3 @@
-```release-note:bug
+```release-note:improvement
 secrets/db/mysql: Add `tls_server_name` and `tls_skip_verify` parameters
 ```

--- a/plugins/database/mysql/connection_producer.go
+++ b/plugins/database/mysql/connection_producer.go
@@ -24,13 +24,13 @@ type mySQLConnectionProducer struct {
 	MaxOpenConnections       int         `json:"max_open_connections"    mapstructure:"max_open_connections"    structs:"max_open_connections"`
 	MaxIdleConnections       int         `json:"max_idle_connections"    mapstructure:"max_idle_connections"    structs:"max_idle_connections"`
 	MaxConnectionLifetimeRaw interface{} `json:"max_connection_lifetime" mapstructure:"max_connection_lifetime" structs:"max_connection_lifetime"`
-
-	Username string `json:"username" mapstructure:"username" structs:"username"`
-	Password string `json:"password" mapstructure:"password" structs:"password"`
+	Username                 string      `json:"username" mapstructure:"username" structs:"username"`
+	Password                 string      `json:"password" mapstructure:"password" structs:"password"`
 
 	TLSCertificateKeyData []byte `json:"tls_certificate_key" mapstructure:"tls_certificate_key" structs:"-"`
 	TLSCAData             []byte `json:"tls_ca"              mapstructure:"tls_ca"              structs:"-"`
-	TLSServerName         string `json:"tls_server_name"     mapstructure:"tls_server_name"     structs:"-"`
+	TLSServerName         string `json:"tls_server_name" mapstructure:"tls_server_name" structs:"tls_server_name"`
+	TLSSkipVerify         bool   `json:"tls_skip_verify" mapstructure:"tls_skip_verify" structs:"tls_skip_verify"`
 
 	// tlsConfigName is a globally unique name that references the TLS config for this instance in the mysql driver
 	tlsConfigName string
@@ -112,12 +112,12 @@ func (c *mySQLConnectionProducer) Init(ctx context.Context, conf map[string]inte
 	c.Initialized = true
 
 	if verifyConnection {
-		if _, err := c.Connection(ctx); err != nil {
-			return nil, fmt.Errorf("error verifying connection: %w", err)
+		if _, err = c.Connection(ctx); err != nil {
+			return nil, fmt.Errorf("error verifying connection connection: %w", err)
 		}
 
 		if err := c.db.PingContext(ctx); err != nil {
-			return nil, fmt.Errorf("error verifying connection: %w", err)
+			return nil, fmt.Errorf("error verifying connection ping: %w", err)
 		}
 	}
 
@@ -205,12 +205,10 @@ func (c *mySQLConnectionProducer) getTLSAuth() (tlsConfig *tls.Config, err error
 	}
 
 	tlsConfig = &tls.Config{
-		RootCAs:      rootCertPool,
-		Certificates: clientCert,
-	}
-
-	if c.TLSServerName != "" {
-		tlsConfig.ServerName = c.TLSServerName
+		RootCAs:            rootCertPool,
+		Certificates:       clientCert,
+		ServerName:         c.TLSServerName,
+		InsecureSkipVerify: c.TLSSkipVerify,
 	}
 
 	return tlsConfig, nil
@@ -227,6 +225,5 @@ func (c *mySQLConnectionProducer) addTLStoDSN() (connURL string, err error) {
 	}
 
 	connURL = config.FormatDSN()
-
 	return connURL, nil
 }

--- a/plugins/database/mysql/connection_producer.go
+++ b/plugins/database/mysql/connection_producer.go
@@ -117,7 +117,7 @@ func (c *mySQLConnectionProducer) Init(ctx context.Context, conf map[string]inte
 		}
 
 		if err := c.db.PingContext(ctx); err != nil {
-			return nil, fmt.Errorf("error verifying connection ping: %w", err)
+			return nil, fmt.Errorf("error verifying - ping: %w", err)
 		}
 	}
 

--- a/plugins/database/mysql/connection_producer.go
+++ b/plugins/database/mysql/connection_producer.go
@@ -30,6 +30,7 @@ type mySQLConnectionProducer struct {
 
 	TLSCertificateKeyData []byte `json:"tls_certificate_key" mapstructure:"tls_certificate_key" structs:"-"`
 	TLSCAData             []byte `json:"tls_ca"              mapstructure:"tls_ca"              structs:"-"`
+	TLSServerName         string `json:"tls_server_name"     mapstructure:"tls_server_name"     structs:"-"`
 
 	// tlsConfigName is a globally unique name that references the TLS config for this instance in the mysql driver
 	tlsConfigName string
@@ -206,6 +207,10 @@ func (c *mySQLConnectionProducer) getTLSAuth() (tlsConfig *tls.Config, err error
 	tlsConfig = &tls.Config{
 		RootCAs:      rootCertPool,
 		Certificates: clientCert,
+	}
+
+	if c.TLSServerName != "" {
+		tlsConfig.ServerName = c.TLSServerName
 	}
 
 	return tlsConfig, nil

--- a/plugins/database/mysql/connection_producer.go
+++ b/plugins/database/mysql/connection_producer.go
@@ -113,7 +113,7 @@ func (c *mySQLConnectionProducer) Init(ctx context.Context, conf map[string]inte
 
 	if verifyConnection {
 		if _, err = c.Connection(ctx); err != nil {
-			return nil, fmt.Errorf("error verifying connection connection: %w", err)
+			return nil, fmt.Errorf("error verifying - connection: %w", err)
 		}
 
 		if err := c.db.PingContext(ctx); err != nil {

--- a/website/content/api-docs/secret/databases/mysql-maria.mdx
+++ b/website/content/api-docs/secret/databases/mysql-maria.mdx
@@ -52,6 +52,12 @@ has a number of parameters to further configure a connection.
 - `tls_ca` `(string: "")` - x509 CA file for validating the certificate presented by the
   MySQL server. Must be PEM encoded.
 
+- `tls_server_name` `(string: "")` - Specifies the subject alternative name should be present in the 
+  server's certificate.
+
+- `tls_skip_verify` `(boolean: false)` - When set to true, disables the server certificate verification. 
+  Setting this to true is not recommended for production.
+
 - `username_template` `(string)` - [Template](/docs/concepts/username-templating) describing how
   dynamic usernames are generated.
 


### PR DESCRIPTION
The MySQL implementation supports TLS verification and auth, however, when testing against Cloud SQL it was very painful to verify the CA. This is because Cloud SQL does not add IP SANs to the certificate. The SANs available reference internal VM names which aren't easily obtainable as a user. I've added these parameters to make the engine more flexible. Although the connection url does support these, the MySQL driver stores a tls.Config and references it by name in the connection URL, so it makes sense to add these there.