### PR TITLE
Add the description front matter

### DIFF
--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -1,6 +1,8 @@
 ---
 layout: docs
 page_title: Documentation
+description: |-
+  Vault reference documentation covering the main Vault concepts, feature FAQs, and CLI usage examples to start managing your secrets.
 ---
 
 # Documentation


### PR DESCRIPTION
🧵 [Slack thread](https://hashicorp.slack.com/archives/CQS78SFQD/p1672863055847219)

This PR adds the missing `description` front matter to the `website/content/docs/index.mdx` file. 