### PR TITLE
Provide IP Address in Duo Request

### DIFF
--- a/changelog/18811.txt
+++ b/changelog/18811.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth: Provide an IP address of the requests from Vault to a Duo challenge after successful authentication.
+```

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -1951,6 +1951,7 @@ func (c *Core) validateDuo(ctx context.Context, mfaFactors *MFAFactor, mConfig *
 		}
 	}
 
+	options = append(options, authapi.AuthIpAddr(reqConnectionRemoteAddr))
 	options = append(options, authapi.AuthUsername(username))
 	options = append(options, authapi.AuthAsync())
 


### PR DESCRIPTION
Addresses https://hashicorp.atlassian.net/browse/VAULT-12661

This PR is to provide the IP address of the request coming from Vault to a Duo challenge after successful authentication. This is to implement IP address restrictions for an instance of Vault. 
Currently, when a Duo challenge request is made, there is no IP address (IPv4 or v6) passed with that request, i.e., 0.0.0.0 is sent)