### PR TITLE
VAULT-8436 remove <-time.After statements in for loops

### DIFF
--- a/api/lifetime_watcher.go
+++ b/api/lifetime_watcher.go
@@ -369,9 +369,7 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 		timer := time.NewTimer(sleepDuration)
 		select {
 		case <-r.stopCh:
-			if !timer.Stop() {
-				<-timer.C
-			}
+			timer.Stop()
 			return nil
 		case <-timer.C:
 			continue

--- a/api/lifetime_watcher.go
+++ b/api/lifetime_watcher.go
@@ -366,10 +366,14 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 			return nil
 		}
 
+		timer := time.NewTimer(sleepDuration)
 		select {
 		case <-r.stopCh:
+			if !timer.Stop() {
+				<-timer.C
+			}
 			return nil
-		case <-time.After(sleepDuration):
+		case <-timer.C:
 			continue
 		}
 	}

--- a/builtin/credential/okta/backend.go
+++ b/builtin/credential/okta/backend.go
@@ -272,9 +272,7 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username, pas
 				case <-timer.C:
 					// Continue
 				case <-ctx.Done():
-					if !timer.Stop() {
-						<-timer.C
-					}
+					timer.Stop()
 					return nil, logical.ErrorResponse("exiting pending mfa challenge"), nil, nil
 				}
 			case "REJECTED":

--- a/builtin/credential/okta/backend.go
+++ b/builtin/credential/okta/backend.go
@@ -241,6 +241,8 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username, pas
 		if rsp == nil {
 			return nil, logical.ErrorResponse("okta auth backend unexpected failure"), nil, nil
 		}
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
 		for result.Status == "MFA_CHALLENGE" {
 			switch result.FactorResult {
 			case "WAITING":
@@ -268,7 +270,7 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username, pas
 				}
 
 				select {
-				case <-time.After(1 * time.Second):
+				case <-ticker.C:
 					// Continue
 				case <-ctx.Done():
 					return nil, logical.ErrorResponse("exiting pending mfa challenge"), nil, nil

--- a/builtin/credential/okta/cli.go
+++ b/builtin/credential/okta/cli.go
@@ -64,9 +64,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 			timer := time.NewTimer(time.Second)
 			select {
 			case <-doneCh:
-				if !timer.Stop() {
-					<-timer.C
-				}
+				timer.Stop()
 				return
 			case <-timer.C:
 			}

--- a/builtin/credential/okta/cli.go
+++ b/builtin/credential/okta/cli.go
@@ -60,13 +60,15 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	defer close(doneCh)
 
 	go func() {
-		ticker := time.NewTicker(time.Second)
-		defer ticker.Stop()
 		for {
+			timer := time.NewTimer(time.Second)
 			select {
 			case <-doneCh:
+				if !timer.Stop() {
+					<-timer.C
+				}
 				return
-			case <-ticker.C:
+			case <-timer.C:
 			}
 
 			resp, _ := c.Logical().Read(fmt.Sprintf("auth/%s/verify/%s", mount, nonce))

--- a/builtin/credential/okta/cli.go
+++ b/builtin/credential/okta/cli.go
@@ -60,11 +60,13 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	defer close(doneCh)
 
 	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-doneCh:
 				return
-			case <-time.After(time.Second):
+			case <-ticker.C:
 			}
 
 			resp, _ := c.Logical().Read(fmt.Sprintf("auth/%s/verify/%s", mount, nonce))

--- a/command/agent/sink/sink.go
+++ b/command/agent/sink/sink.go
@@ -154,9 +154,7 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 				timer := time.NewTimer(backoff)
 				select {
 				case <-ctx.Done():
-					if !timer.Stop() {
-						<-timer.C
-					}
+					timer.Stop()
 					return nil
 				case <-timer.C:
 					atomic.AddInt32(ss.remaining, 1)

--- a/command/agent/sink/sink.go
+++ b/command/agent/sink/sink.go
@@ -151,10 +151,14 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 			if err := writeSink(st.sink, st.token); err != nil {
 				backoff := 2*time.Second + time.Duration(ss.random.Int63()%int64(time.Second*2)-int64(time.Second))
 				ss.logger.Error("error returned by sink function, retrying", "error", err, "backoff", backoff.String())
+				timer := time.NewTimer(backoff)
 				select {
 				case <-ctx.Done():
+					if !timer.Stop() {
+						<-timer.C
+					}
 					return nil
-				case <-time.After(backoff):
+				case <-timer.C:
 					atomic.AddInt32(ss.remaining, 1)
 					sinkCh <- st
 				}

--- a/command/server.go
+++ b/command/server.go
@@ -2323,9 +2323,7 @@ func (c *ServerCommand) storageMigrationActive(backend physical.Backend) bool {
 		select {
 		case <-timer.C:
 		case <-c.ShutdownCh:
-			if !timer.Stop() {
-				<-timer.C
-			}
+			timer.Stop()
 			return true
 		}
 	}
@@ -2621,9 +2619,7 @@ func runUnseal(c *ServerCommand, core *vault.Core, ctx context.Context) {
 		timer := time.NewTimer(5 * time.Second)
 		select {
 		case <-c.ShutdownCh:
-			if !timer.Stop() {
-				<-timer.C
-			}
+			timer.Stop()
 			return
 		case <-timer.C:
 		}

--- a/command/server.go
+++ b/command/server.go
@@ -2298,6 +2298,8 @@ func (c *ServerCommand) removePidFile(pidPath string) error {
 func (c *ServerCommand) storageMigrationActive(backend physical.Backend) bool {
 	first := true
 
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
 	for {
 		migrationStatus, err := CheckStorageMigration(backend)
 		if err == nil {
@@ -2320,7 +2322,7 @@ func (c *ServerCommand) storageMigrationActive(backend physical.Backend) bool {
 		c.logger.Warn("storage migration check error", "error", err.Error())
 
 		select {
-		case <-time.After(2 * time.Second):
+		case <-ticker.C:
 		case <-c.ShutdownCh:
 			return true
 		}
@@ -2602,6 +2604,8 @@ CLUSTER_SYNTHESIS_COMPLETE:
 }
 
 func runUnseal(c *ServerCommand, core *vault.Core, ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
 	for {
 		err := core.UnsealWithStoredKeys(ctx)
 		if err == nil {
@@ -2617,7 +2621,7 @@ func runUnseal(c *ServerCommand, core *vault.Core, ctx context.Context) {
 		select {
 		case <-c.ShutdownCh:
 			return
-		case <-time.After(5 * time.Second):
+		case <-ticker.C:
 		}
 	}
 }

--- a/physical/zookeeper/zookeeper.go
+++ b/physical/zookeeper/zookeeper.go
@@ -652,9 +652,7 @@ func (i *ZooKeeperHALock) Unlock() error {
 					}
 					continue
 				case <-i.stopCh:
-					if !timer.Stop() {
-						<-timer.C
-					}
+					timer.Stop()
 					return
 				}
 			}

--- a/physical/zookeeper/zookeeper.go
+++ b/physical/zookeeper/zookeeper.go
@@ -636,6 +636,8 @@ func (i *ZooKeeperHALock) Unlock() error {
 			attempts := 0
 			i.logger.Info("launching automated distributed lock release")
 
+			ticker := time.NewTicker(time.Second)
+			defer ticker.Stop()
 			for {
 				if err := i.unlockInternal(); err == nil {
 					i.logger.Info("distributed lock released")
@@ -643,7 +645,7 @@ func (i *ZooKeeperHALock) Unlock() error {
 				}
 
 				select {
-				case <-time.After(time.Second):
+				case <-ticker.C:
 					attempts := attempts + 1
 					if attempts >= 10 {
 						i.logger.Error("release lock max attempts reached. Lock may not be released", "error", err)

--- a/tools/semgrep/ci/loop-time-after.yml
+++ b/tools/semgrep/ci/loop-time-after.yml
@@ -1,0 +1,14 @@
+rules:
+  - id: loop-time-after
+    pattern: |
+      for {
+        select {
+          case <-time.After(...):
+            ...
+        }
+        ...
+      }
+    message: <-time.After() used in for loop, consider using a ticker instead
+    languages:
+      - go
+    severity: WARNING

--- a/tools/semgrep/ci/loop-time-after.yml
+++ b/tools/semgrep/ci/loop-time-after.yml
@@ -1,14 +1,17 @@
 rules:
   - id: loop-time-after
     pattern: |
-      for {
+      for ... {
+        ...
         select {
+          case ...
           case <-time.After(...):
             ...
+          case ...
         }
         ...
       }
-    message: <-time.After() used in for loop, consider using a ticker instead
+    message: <-time.After() used in for loop, consider using a ticker or a timer instead
     languages:
       - go
     severity: WARNING

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -666,10 +666,8 @@ func (c *Core) waitForLeadership(newLeaderCh chan func(), manualStepDownCh, stop
 				timer := time.NewTimer(DefaultMaxRequestDuration)
 				select {
 				case <-activeCtx.Done():
-					if !timer.Stop() {
-						<-timer.C
-					}
-				// Attempt to drain any inflight requests
+					timer.Stop()
+					// Attempt to drain any inflight requests
 				case <-timer.C:
 					activeCtxCancel()
 				}
@@ -835,9 +833,7 @@ func (c *Core) periodicLeaderRefresh(newLeaderCh chan func(), stopCh chan struct
 				atomic.AddInt32(lopCount, -1)
 			}()
 		case <-stopCh:
-			if !timer.Stop() {
-				<-timer.C
-			}
+			timer.Stop()
 			return
 		}
 	}
@@ -908,9 +904,7 @@ func (c *Core) periodicCheckKeyUpgrades(ctx context.Context, stopCh chan struct{
 				return
 			}()
 		case <-stopCh:
-			if !timer.Stop() {
-				<-timer.C
-			}
+			timer.Stop()
 			return
 		}
 	}
@@ -1046,9 +1040,7 @@ func (c *Core) acquireLock(lock physical.Lock, stopCh <-chan struct{}) <-chan st
 		select {
 		case <-timer.C:
 		case <-stopCh:
-			if !timer.Stop() {
-				<-timer.C
-			}
+			timer.Stop()
 			return nil
 		}
 	}
@@ -1123,9 +1115,7 @@ func (c *Core) cleanLeaderPrefix(ctx context.Context, uuid string, leaderLostCh 
 			}
 			keys = keys[1:]
 		case <-leaderLostCh:
-			if !timer.Stop() {
-				<-timer.C
-			}
+			timer.Stop()
 			return
 		}
 	}

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -1990,9 +1990,7 @@ func (c *Core) validateDuo(ctx context.Context, mfaFactors *MFAFactor, mConfig *
 
 		select {
 		case <-ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
+			timer.Stop()
 			return fmt.Errorf("duo push verification operation canceled")
 		case <-timer.C:
 		}
@@ -2123,9 +2121,7 @@ func (c *Core) validateOkta(ctx context.Context, mConfig *mfa.Config, username s
 
 		select {
 		case <-ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
+			timer.Stop()
 			return fmt.Errorf("push verification operation canceled")
 		case <-timer.C:
 		}

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -1966,6 +1966,8 @@ func (c *Core) validateDuo(ctx context.Context, mfaFactors *MFAFactor, mConfig *
 		return fmt.Errorf("failed to get transaction ID for Duo authentication")
 	}
 
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
 	for {
 		// AuthStatus does the long polling until there is a status update. So
 		// there is no need to wait for a second before we invoke this API.
@@ -1990,7 +1992,7 @@ func (c *Core) validateDuo(ctx context.Context, mfaFactors *MFAFactor, mConfig *
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("duo push verification operation canceled")
-		case <-time.After(time.Second):
+		case <-ticker.C:
 		}
 	}
 }
@@ -2090,6 +2092,8 @@ func (c *Core) validateOkta(ctx context.Context, mConfig *mfa.Config, username s
 		return err
 	}
 
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
 	for {
 		// Okta provides an SDK method `GetFactorTransactionStatus` but does not provide the transaction id in
 		// the VerifyFactor respone. This code effectively reimplements that method.
@@ -2119,7 +2123,7 @@ func (c *Core) validateOkta(ctx context.Context, mConfig *mfa.Config, username s
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("push verification operation canceled")
-		case <-time.After(time.Second):
+		case <-ticker.C:
 		}
 	}
 }

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -447,9 +447,7 @@ func (c *Core) raftTLSRotateDirect(ctx context.Context, logger hclog.Logger, sto
 				nextRotationTime = next
 
 			case <-stopCh:
-				if !timer.Stop() {
-					<-timer.C
-				}
+				timer.Stop()
 				return
 			}
 		}

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -433,8 +433,9 @@ func (c *Core) raftTLSRotateDirect(ctx context.Context, logger hclog.Logger, sto
 				backoff = false
 			}
 
+			timer := time.NewTimer(time.Until(nextRotationTime))
 			select {
-			case <-time.After(time.Until(nextRotationTime)):
+			case <-timer.C:
 				// It's time to rotate the keys
 				next, err := rotateKeyring()
 				if err != nil {
@@ -446,6 +447,9 @@ func (c *Core) raftTLSRotateDirect(ctx context.Context, logger hclog.Logger, sto
 				nextRotationTime = next
 
 			case <-stopCh:
+				if !timer.Stop() {
+					<-timer.C
+				}
 				return
 			}
 		}


### PR DESCRIPTION
This PR removes instances where <-time.After is used in select statements within for loops, as this is a potential resource leak. However, the impact of the resource leak is minimal in our case because the loop is exited in the other condition of the select statement, so there won't be a buildup of un-fired timers. 

I also added a semgrep rule to catch these cases in the future. 