### PR TITLE
UI: Fix details view on role (old PKI)

### DIFF
--- a/ui/app/templates/components/pki/role-pki-edit.hbs
+++ b/ui/app/templates/components/pki/role-pki-edit.hbs
@@ -83,7 +83,7 @@
   </form>
 {{else}}
   <div class="box is-sideless is-fullwidth is-marginless">
-    {{#each this.model.formFieldGroups as |fieldGroup|}}
+    {{#each this.model.fieldGroups as |fieldGroup|}}
       {{#each-in fieldGroup as |group fields|}}
         {{#if (or (eq group "default") (eq group "Options"))}}
           {{#each fields as |attr|}}


### PR DESCRIPTION
This PR fixes a bug [introduced](https://github.com/hashicorp/vault/pull/18229/files#diff-3596b087468b53afc2f7d781a5c3d0c1ba240fc3a3d39f74c4e3ca9da7508bac) during development for the new PKI engine. 

After: renders all field groups on role > details correctly
<img width="1321" alt="How to get to role details" src="https://user-images.githubusercontent.com/82459713/214350778-79709045-52d5-4aec-b936-39c0bf86753e.png">
<img width="1321" alt="Role details screen" src="https://user-images.githubusercontent.com/82459713/214350796-a4a1919a-e5af-472f-82c0-2180900b0072.png">

Before: no fields are rendered for role details
<img width="1126" alt="Role details before" src="https://user-images.githubusercontent.com/82459713/214351092-042b0ea9-cb9a-4ba5-8679-1406f8cf09f4.png">
