### PR TITLE
Update namespace.FromContext comment

### DIFF
--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -61,11 +61,8 @@ func RootContext(ctx context.Context) context.Context {
 	return ContextWithNamespace(ctx, RootNamespace)
 }
 
-// This function caches the ns to avoid doing a .Value lookup over and over,
-// because it's called a *lot* in the request critical path. .Value is
-// concurrency-safe so uses some kind of locking/atomicity, but it should never
-// be read before first write, plus we don't believe this will be called from
-// different goroutines, so it should be safe.
+// FromContext retrieves the namespace from a context, or an error
+// if there is no namespace in the context.
 func FromContext(ctx context.Context) (*Namespace, error) {
 	if ctx == nil {
 		return nil, errors.New("context was nil")


### PR DESCRIPTION
It looks like namespace context caching was removed in https://github.com/hashicorp/vault/pull/5200
but this comment was left referencing it, which I found confusing at first glance.