### PR TITLE
Store the unified crl in a path that is not cluster local

### DIFF
--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -1969,7 +1969,7 @@ WRITE:
 		writePath = legacyCRLPath
 	} else {
 		if isUnified {
-			writePath += unifiedCRLPathSuffix
+			writePath = unifiedCRLPathPrefix + writePath
 		}
 
 		if isDelta {

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -33,7 +33,7 @@ const (
 	deltaCRLPathSuffix          = "-delta"
 	unifiedCRLPath              = "unified-crl"
 	unifiedDeltaCRLPath         = "unified-delta-crl"
-	unifiedCRLPathSuffix        = "-unified"
+	unifiedCRLPathPrefix        = "unified-"
 
 	autoTidyConfigPath = "config/auto-tidy"
 	clusterConfigPath  = "config/cluster"
@@ -1118,7 +1118,7 @@ func (sc *storageContext) resolveIssuerCRLPath(reference string, unified bool) (
 	if crlId, ok := crlConfig.IssuerIDCRLMap[issuer]; ok && len(crlId) > 0 {
 		path := fmt.Sprintf("crls/%v", crlId)
 		if unified {
-			path += unifiedCRLPathSuffix
+			path = unifiedCRLPathPrefix + path
 		}
 
 		return path, nil


### PR DESCRIPTION
 - I missed this in the original review, that we were storing the unified CRL in a cluster-local storage area (/crls/) so none of the other hosts would receive it.
 - Discovered while writing unit tests, the main cluster had the unified CRL but the other clusters would return an empty response