### PR TITLE
Clarify key bits for ssh

### DIFF
--- a/builtin/logical/ssh/path_config_ca.go
+++ b/builtin/logical/ssh/path_config_ca.go
@@ -333,7 +333,7 @@ func generateSSHKeyPair(randomSource io.Reader, keyType string, keyBits int) (st
 			case 521:
 				curve = elliptic.P521()
 			default:
-				return "", "", fmt.Errorf("unknown ECDSA key pair algorithm: %v", keyType)
+				return "", "", fmt.Errorf("unknown ECDSA key pair algorithm and bits: %v / %v", keyType, keyBits)
 			}
 		}
 

--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -935,8 +935,8 @@ parameters of the issued certificate can be further customized in this API call.
 - `key_bits` `(int: 0)` – Specifies the number of bits to use for the
   generated keys. Allowed values are 0 (universal default); with
   `key_type=rsa`, allowed values are: 2048 (default), 3072, or
-  4096; with `key_type=ec`, allowed values are: 224, 256 (default),
-  384, or 521; ignored with `key_type=ed25519`.
+  4096; with `key_type=ec`, allowed values are: 256 (default), 384,
+  or 521; ignored with `key_type=ed25519`.
 
 - `ttl` `(string: "")` – Specifies the Requested Time To Live. Cannot be greater
   than the role's `max_ttl` value. If not provided, the role's `ttl` value will


### PR DESCRIPTION
This does two things:

 - Makes the error on SSH CA generation more obvious that the key bits was unknown, versus the algorithm being unknown ("ec").
 - Removes ECDSA P224 as a supported curve in the documentation. 

Resolves: #18843