### PR TITLE
Shadow globally defined var to avoid race

### DIFF
--- a/command/format_test.go
+++ b/command/format_test.go
@@ -13,11 +13,10 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 )
 
-var output string
-
 type mockUi struct {
 	t          *testing.T
 	SampleData string
+	outputData *string
 }
 
 func (m mockUi) Ask(_ string) (string, error) {
@@ -29,14 +28,15 @@ func (m mockUi) AskSecret(_ string) (string, error) {
 	m.t.FailNow()
 	return "", nil
 }
-func (m mockUi) Output(s string) { output = s }
+func (m mockUi) Output(s string) { *m.outputData = s }
 func (m mockUi) Info(s string)   { m.t.Log(s) }
 func (m mockUi) Error(s string)  { m.t.Log(s) }
 func (m mockUi) Warn(s string)   { m.t.Log(s) }
 
 func TestJsonFormatter(t *testing.T) {
 	os.Setenv(EnvVaultFormat, "json")
-	ui := mockUi{t: t, SampleData: "something"}
+	var output string
+	ui := mockUi{t: t, SampleData: "something", outputData: &output}
 	if err := outputWithFormat(ui, nil, ui); err != 0 {
 		t.Fatal(err)
 	}
@@ -53,7 +53,8 @@ func TestJsonFormatter(t *testing.T) {
 
 func TestYamlFormatter(t *testing.T) {
 	os.Setenv(EnvVaultFormat, "yaml")
-	ui := mockUi{t: t, SampleData: "something"}
+	var output string
+	ui := mockUi{t: t, SampleData: "something", outputData: &output}
 	if err := outputWithFormat(ui, nil, ui); err != 0 {
 		t.Fatal(err)
 	}
@@ -71,7 +72,8 @@ func TestYamlFormatter(t *testing.T) {
 
 func TestTableFormatter(t *testing.T) {
 	os.Setenv(EnvVaultFormat, "table")
-	ui := mockUi{t: t}
+	var output string
+	ui := mockUi{t: t, outputData: &output}
 
 	// Testing secret formatting
 	s := api.Secret{Data: map[string]interface{}{"k": "something"}}
@@ -88,7 +90,8 @@ func TestTableFormatter(t *testing.T) {
 // fields in the embedded struct explicitly. It also checks the spacing,
 // indentation, and delimiters of table formatting explicitly.
 func TestStatusFormat(t *testing.T) {
-	ui := mockUi{t: t}
+	var output string
+	ui := mockUi{t: t, outputData: &output}
 	os.Setenv(EnvVaultFormat, "table")
 
 	statusHA := getMockStatusData(false)

--- a/command/login_test.go
+++ b/command/login_test.go
@@ -499,7 +499,7 @@ func TestLoginMFASinglePhase(t *testing.T) {
 		if storedToken == "" {
 			t.Fatal("expected non-empty stored token")
 		}
-		output = ui.OutputWriter.String()
+		output := ui.OutputWriter.String()
 		if !strings.Contains(output, storedToken) {
 			t.Fatalf("expected stored token: %q, got: %q", storedToken, output)
 		}
@@ -534,7 +534,7 @@ func TestLoginMFATwoPhase(t *testing.T) {
 	}
 
 	expected := methodID
-	output = ui.OutputWriter.String()
+	output := ui.OutputWriter.String()
 	if !strings.Contains(output, expected) {
 		t.Fatalf("expected stored token: %q, got: %q", expected, output)
 	}
@@ -580,7 +580,7 @@ func TestLoginMFATwoPhaseNonInteractiveMethodName(t *testing.T) {
 		t.Errorf("expected %d to be %d", code, exp)
 	}
 
-	output = ui.OutputWriter.String()
+	output := ui.OutputWriter.String()
 
 	reqIdReg := regexp.MustCompile(`mfa_request_id\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\s+mfa_constraint`)
 	reqIDRaw := reqIdReg.FindAllStringSubmatch(output, -1)


### PR DESCRIPTION
output is defined in format_test.go as a global variable, which the login_test.go tests were unknowingly using. Since these tests execute in parallel, under the correct circumstances, they'd race to write/read from the same variable in separate tests.

Shadow to avoid the race.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

Seen in: https://app.circleci.com/pipelines/github/hashicorp/vault/48890/workflows/b39e0bc2-8099-473e-b4fa-4a2964ebdf30/jobs/579807/steps