### PR TITLE
return 403 for wrapping requests when no token provided

### DIFF
--- a/changelog/18859.txt
+++ b/changelog/18859.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/auth: Return a 403 instead of a 500 for wrapping requests when token is provided
+```

--- a/changelog/18859.txt
+++ b/changelog/18859.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-core/auth: Return a 403 instead of a 500 for wrapping requests when token is provided
+core/auth: Return a 403 instead of a 500 for wrapping requests when token is not provided
 ```

--- a/http/sys_wrapping_test.go
+++ b/http/sys_wrapping_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -378,7 +379,8 @@ func TestHTTP_Wrapping(t *testing.T) {
 		t.Fatal("expected error")
 	}
 
-	if respError, ok := err.(*api.ResponseError); !ok || respError.StatusCode != 403 {
+	var respError *api.ResponseError
+	if errors.As(err, &respError); respError.StatusCode != 403 {
 		t.Fatalf("expected 403 response, actual: %d", respError.StatusCode)
 	}
 }

--- a/http/sys_wrapping_test.go
+++ b/http/sys_wrapping_test.go
@@ -366,4 +366,19 @@ func TestHTTP_Wrapping(t *testing.T) {
 	}) {
 		t.Fatalf("secret data did not match expected: %#v", secret.Data)
 	}
+
+	// Ensure that wrapping lookup without a client token responds correctly
+	client.ClearToken()
+	secret, err = client.Logical().Read("sys/wrapping/lookup")
+	if secret != nil {
+		t.Fatalf("expected no response: %#v", secret)
+	}
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if respError, ok := err.(*api.ResponseError); !ok || respError.StatusCode != 403 {
+		t.Fatalf("expected 403 response, actual: %d", respError.StatusCode)
+	}
 }

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -561,7 +561,7 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 			// be revoked after the call. So we have to do the validation here.
 			valid, err := c.validateWrappingToken(ctx, req)
 			if err != nil {
-				return logical.ErrorResponse(fmt.Errorf("error validating wrapping token: %w", err).Error()), logical.ErrPermissionDenied
+				return logical.ErrorResponse(fmt.Sprintf("error validating wrapping token: %s", err.Error())), logical.ErrPermissionDenied
 			}
 			if !valid {
 				return nil, consts.ErrInvalidWrappingToken

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -561,7 +561,7 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 			// be revoked after the call. So we have to do the validation here.
 			valid, err := c.validateWrappingToken(ctx, req)
 			if err != nil {
-				return nil, fmt.Errorf("error validating wrapping token: %w", err)
+				return logical.ErrorResponse(fmt.Errorf("error validating wrapping token: %w", err).Error()), logical.ErrPermissionDenied
 			}
 			if !valid {
 				return nil, consts.ErrInvalidWrappingToken


### PR DESCRIPTION
Requests to wrapping APIs will respond with a 500 status code if a token is not provided. This PR ensures that Vault properly responds with a 403.

Fixes https://github.com/hashicorp/vault/issues/18852