### PR TITLE
VAULT-12798 Correct removal behaviour when JWT is symlink

### DIFF
--- a/changelog/18863.txt
+++ b/changelog/18863.txt
@@ -1,3 +1,3 @@
-```release-note:change
+```release-note:improvement
 agent: JWT auto-auth has a new config option, `remove_jwt_follows_symlinks` (default: false), that, if set to true will now remove the JWT, instead of the symlink to the JWT, if a symlink to a JWT has been provided in the `path` option, and the `remove_jwt_after_reading` config option is set to true (default).
 ```

--- a/changelog/18863.txt
+++ b/changelog/18863.txt
@@ -1,4 +1,3 @@
 ```release-note:change
-agent: JWT auto-auth will now remove the JWT, instead of the symlink to the JWT, if a symlink to a JWT has been
-provided in the `path` option, and the `remove_jwt_after_reading` config option is set to true (default).
+agent: JWT auto-auth has a new config option, `remove_jwt_follows_symlinks` (default: false), that, if set to true will now remove the JWT, instead of the symlink to the JWT, if a symlink to a JWT has been provided in the `path` option, and the `remove_jwt_after_reading` config option is set to true (default).
 ```

--- a/changelog/18863.txt
+++ b/changelog/18863.txt
@@ -1,0 +1,4 @@
+```release-note:change
+agent: JWT auto-auth will now remove the JWT, instead of the symlink to the JWT, if a symlink to a JWT has been
+provided in the `path` option, and the `remove_jwt_after_reading` config option is set to true (default).
+```

--- a/command/agent/auth/jwt/jwt.go
+++ b/command/agent/auth/jwt/jwt.go
@@ -213,6 +213,10 @@ func (j *jwtMethod) ingressToken() {
 	// to read that file by following the link in the os.ReadFile call.
 	if symlink {
 		evalSymlinkPath, err = filepath.EvalSymlinks(j.path)
+		if err != nil {
+			j.logger.Error("error encountered evaluating symlinks", "error", err)
+			return
+		}
 		_, err := os.Lstat(evalSymlinkPath)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/command/agent/auth/jwt/jwt.go
+++ b/command/agent/auth/jwt/jwt.go
@@ -217,7 +217,7 @@ func (j *jwtMethod) ingressToken() {
 			j.logger.Error("error encountered evaluating symlinks", "error", err)
 			return
 		}
-		_, err := os.Lstat(evalSymlinkPath)
+		_, err := os.Stat(evalSymlinkPath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return

--- a/command/agent/jwt_end_to_end_test.go
+++ b/command/agent/jwt_end_to_end_test.go
@@ -163,10 +163,10 @@ func testJWTEndToEnd(t *testing.T, ahWrapping, useSymlink, removeJWTAfterReading
 		Logger:    logger.Named("auth.jwt"),
 		MountPath: "auth/jwt",
 		Config: map[string]interface{}{
-			"path":                      fileNameToUseAsPath,
-			"role":                      "test",
-			"remove_jwt_after_reading":  removeJWTAfterReading,
-			"test_override_read_period": true,
+			"path":                     fileNameToUseAsPath,
+			"role":                     "test",
+			"remove_jwt_after_reading": removeJWTAfterReading,
+			"jwt_read_period":          "0.5s",
 		},
 	})
 	if err != nil {

--- a/command/agent/jwt_end_to_end_test.go
+++ b/command/agent/jwt_end_to_end_test.go
@@ -163,10 +163,11 @@ func testJWTEndToEnd(t *testing.T, ahWrapping, useSymlink, removeJWTAfterReading
 		Logger:    logger.Named("auth.jwt"),
 		MountPath: "auth/jwt",
 		Config: map[string]interface{}{
-			"path":                     fileNameToUseAsPath,
-			"role":                     "test",
-			"remove_jwt_after_reading": removeJWTAfterReading,
-			"jwt_read_period":          "0.5s",
+			"path":                        fileNameToUseAsPath,
+			"role":                        "test",
+			"remove_jwt_after_reading":    removeJWTAfterReading,
+			"remove_jwt_follows_symlinks": true,
+			"jwt_read_period":             "0.5s",
 		},
 	})
 	if err != nil {

--- a/command/agent/jwt_end_to_end_test.go
+++ b/command/agent/jwt_end_to_end_test.go
@@ -30,7 +30,6 @@ func TestJWTEndToEnd(t *testing.T) {
 		useSymlink            bool
 		removeJWTAfterReading bool
 	}{
-		// default behaviour => token expected
 		{false, false, false},
 		{true, false, false},
 		{false, true, false},

--- a/command/agent/testing.go
+++ b/command/agent/testing.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -61,7 +60,7 @@ func GetTestJWT(t *testing.T) (string, *ecdsa.PrivateKey) {
 }
 
 func readToken(fileName string) (*logical.HTTPWrapInfo, error) {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, err
 	}

--- a/website/content/docs/agent/autoauth/methods/jwt.mdx
+++ b/website/content/docs/agent/autoauth/methods/jwt.mdx
@@ -19,3 +19,8 @@ method](/docs/auth/jwt).
   This can be set to `false` to disable the default behavior of removing the
   JWT after it's been read. Note that if `path` is a symlink to a JWT, the JWT,
   not the symlink, will be deleted.
+
+- `jwt_read_period` `(duration: "0.5s", optional)` - The duration after which
+Agent will attempt to read the JWT stored at `path`. Defaults to `1m` if
+`remove_jwt_after_reading` is set to `true`, or `0.5s` otherwise.
+Uses [duration format strings](/docs/concepts/duration-format).

--- a/website/content/docs/agent/autoauth/methods/jwt.mdx
+++ b/website/content/docs/agent/autoauth/methods/jwt.mdx
@@ -17,8 +17,12 @@ method](/docs/auth/jwt).
 
 - `remove_jwt_after_reading` `(bool: optional, defaults to true)` -
   This can be set to `false` to disable the default behavior of removing the
-  JWT after it's been read. Note that if `path` is a symlink to a JWT, the JWT,
-  not the symlink, will be deleted.
+  JWT after it's been read.
+
+- `remove_jwt_follows_symlinks` `(bool: optional, defaults to false)` -
+This can be set to `true` to follow symlinks when removing the JWT after it has been read
+when executing the `remove_jwt_after_reading` behaviour. If set to false, it will delete
+the symlink, not the JWT. Does nothing if `remove_jwt_after_reading` is false.
 
 - `jwt_read_period` `(duration: "0.5s", optional)` - The duration after which
 Agent will attempt to read the JWT stored at `path`. Defaults to `1m` if

--- a/website/content/docs/agent/autoauth/methods/jwt.mdx
+++ b/website/content/docs/agent/autoauth/methods/jwt.mdx
@@ -17,4 +17,5 @@ method](/docs/auth/jwt).
 
 - `remove_jwt_after_reading` `(bool: optional, defaults to true)` -
   This can be set to `false` to disable the default behavior of removing the
-  JWT after it's been read.
+  JWT after it's been read. Note that if `path` is a symlink to a JWT, the JWT,
+  not the symlink, will be deleted.


### PR DESCRIPTION
The current behaviour was:
- Agent would correctly read the JWT by following the symlink
- Agent would then delete the symlink, instead of the JWT (when `remove_jwt_after_reading` is set to true)

In other words, it followed the symlink correctly for reading, but incorrectly for deleting.

I've added a new option, `remove_jwt_follows_symlinks`, that will change this behaviour when set to delete the JWT, instead of the symlink, when removing the JWT.