### PR TITLE
Vault Template Lint Plugin

### DIFF
--- a/ui/.template-lintrc.js
+++ b/ui/.template-lintrc.js
@@ -33,14 +33,19 @@ try {
 }
 
 module.exports = {
-  plugins: ['ember-template-lint-plugin-prettier'],
-  extends: ['recommended', 'ember-template-lint-plugin-prettier:recommended'],
+  plugins: ['ember-template-lint-plugin-prettier', 'ember-template-lint-plugin-vault'],
+  extends: [
+    'recommended',
+    'ember-template-lint-plugin-prettier:recommended',
+    'ember-template-lint-plugin-vault:recommended',
+  ],
   rules: {
     'no-action': 'off',
     'no-implicit-this': {
       allow: ['supported-auth-backends'],
     },
     'require-input-label': 'off',
+    'component-attrs-before-args': 'off', // temporarily disabled until fixer can be run across codebase at start of release cycle
   },
   ignore: ['lib/story-md', 'tests/**'],
   // ember language server vscode extension does not currently respect the ignore field

--- a/ui/package.json
+++ b/ui/package.json
@@ -162,6 +162,7 @@
     "ember-svg-jar": "2.4.0",
     "ember-template-lint": "4.8.0",
     "ember-template-lint-plugin-prettier": "4.0.0",
+    "ember-template-lint-plugin-vault": "hashicorp/ember-template-lint-plugin-vault",
     "ember-test-selectors": "6.0.0",
     "ember-tether": "^2.0.1",
     "ember-truth-helpers": "3.0.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -10245,6 +10245,10 @@ ember-template-lint-plugin-prettier@4.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+ember-template-lint-plugin-vault@hashicorp/ember-template-lint-plugin-vault:
+  version "1.0.0"
+  resolved "git+ssh://git@github.com/hashicorp/ember-template-lint-plugin-vault.git#1320c4a67e6a2564c64e1ced65c86b7c26348c8b"
+
 ember-template-lint@4.8.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/ember-template-lint/-/ember-template-lint-4.8.0.tgz#023a4e4117f48acf87fea88d4b902f676b50d9cd"


### PR DESCRIPTION
This PR adds [ember-template-lint-plugin-vault](https://github.com/hashicorp/ember-template-lint-plugin-vault) and enables it in the template lint configuration. Since the plugin is new there is currently only one rule in the recommended set which has been disabled until there is a good time (start of release cycle) to run the fixer across all the template files.