### PR TITLE
Don't set shutdownDoneCh to nil

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -196,6 +196,7 @@ require (
 	golang.org/x/crypto v0.5.0
 	golang.org/x/net v0.5.0
 	golang.org/x/oauth2 v0.1.0
+	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.4.0
 	golang.org/x/term v0.4.0
 	golang.org/x/tools v0.1.12
@@ -428,7 +429,6 @@ require (
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/vault/core.go
+++ b/vault/core.go
@@ -331,7 +331,7 @@ type Core struct {
 	heldHALock           physical.Lock
 
 	// shutdownDoneCh is used to notify when Shutdown() completes
-	shutdownDoneCh chan struct{}
+	shutdownDoneCh       chan struct{}
 	shutdownDoneChClosed bool
 
 	// unlockInfo has the keys provided to Unseal until the threshold number of parts is available, as well as the operation nonce

--- a/vault/core.go
+++ b/vault/core.go
@@ -968,6 +968,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		rawEnabled:                     conf.EnableRaw,
 		introspectionEnabled:           conf.EnableIntrospection,
 		shutdownDoneCh:                 make(chan struct{}),
+		shutdownDoneChClosed:           false,
 		replicationState:               new(uint32),
 		atomicPrimaryClusterAddrs:      new(atomic.Value),
 		atomicPrimaryFailoverAddrs:     new(atomic.Value),


### PR DESCRIPTION
I had a chat with @mpalmi about #18358. I think his solution should be perfectly safe and should work. 

This is an optional improvement that just makes the code a bit more clear. Instead of setting the channel to nil, I added a `bool` to check whether it's been closed. Reading from a closed channel in `ShutdownWait()` will return immediately.

I don't really know how to test this and I'm not familiar with the code-base. If this change doesn't make sense or is too high risk, I'm totally fine withdrawing the PR :)