### PR TITLE
Add timeout functionality to inmem

### DIFF
--- a/vault/cluster/inmem_layer.go
+++ b/vault/cluster/inmem_layer.go
@@ -31,6 +31,7 @@ type InmemLayer struct {
 
 	connectionCh chan *ConnectionInfo
 	readerDelay  time.Duration
+	forceTimeout string
 }
 
 // NewInmemLayer returns a new in-memory layer configured to listen on the
@@ -71,6 +72,13 @@ func (l *InmemLayer) SetReaderDelay(delay time.Duration) {
 			c.(*delayedConn).SetDelay(delay)
 		}
 	}
+}
+
+func (l *InmemLayer) SetForceTimeout(addr string) {
+	l.l.Lock()
+	defer l.l.Unlock()
+
+	l.forceTimeout = addr
 }
 
 // Addrs implements NetworkLayer.
@@ -114,10 +122,22 @@ func (l *InmemLayer) Dial(addr string, timeout time.Duration, tlsConfig *tls.Con
 		panic(fmt.Sprintf("%q attempted to dial itself", l.addr))
 	}
 
+	if l.forceTimeout == addr {
+		l.logger.Debug("forcing timeout", "addr", addr, "me", l.addr)
+		time.Sleep(time.Second * 20)
+
+		var timeout deadlineError = "i/o timeout"
+		return nil, timeout
+	}
+
 	peer, ok := l.peers[addr]
 	l.l.Unlock()
 	if !ok {
 		return nil, errors.New("inmemlayer: no address found")
+	}
+
+	if timeout < 0 {
+		return nil, fmt.Errorf("inmemlayer: timeout given is less than 0: %d", timeout)
 	}
 
 	alpn := ""
@@ -199,7 +219,7 @@ func (l *InmemLayer) clientConn(addr string) (net.Conn, error) {
 
 	select {
 	case pendingConns <- servConn:
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		return nil, errors.New("inmemlayer: timeout while accepting connection")
 	}
 
@@ -407,6 +427,12 @@ func (ic *InmemLayerCluster) SetConnectionCh(ch chan *ConnectionInfo) {
 func (ic *InmemLayerCluster) SetReaderDelay(delay time.Duration) {
 	for _, node := range ic.layers {
 		node.SetReaderDelay(delay)
+	}
+}
+
+func (ic *InmemLayerCluster) SetForceTimeout(addr string) {
+	for _, node := range ic.layers {
+		node.SetForceTimeout(addr)
 	}
 }
 

--- a/vault/cluster/inmem_layer.go
+++ b/vault/cluster/inmem_layer.go
@@ -128,6 +128,9 @@ func (l *InmemLayer) Dial(addr string, timeout time.Duration, tlsConfig *tls.Con
 	// with timeouts.
 	if l.forceTimeout == addr {
 		l.logger.Debug("forcing timeout", "addr", addr, "me", l.addr)
+		
+		// gRPC sets a deadline of 20 seconds on the dail attempt, so 
+		// matching that here.
 		time.Sleep(time.Second * 20)
 		return nil, deadlineError("i/o timeout")
 	}

--- a/vault/cluster/inmem_layer.go
+++ b/vault/cluster/inmem_layer.go
@@ -126,8 +126,7 @@ func (l *InmemLayer) Dial(addr string, timeout time.Duration, tlsConfig *tls.Con
 		l.logger.Debug("forcing timeout", "addr", addr, "me", l.addr)
 		time.Sleep(time.Second * 20)
 
-		var timeout deadlineError = "i/o timeout"
-		return nil, timeout
+		return nil, deadlineError("i/o timeout")
 	}
 
 	peer, ok := l.peers[addr]

--- a/vault/cluster/inmem_layer.go
+++ b/vault/cluster/inmem_layer.go
@@ -122,10 +122,13 @@ func (l *InmemLayer) Dial(addr string, timeout time.Duration, tlsConfig *tls.Con
 		panic(fmt.Sprintf("%q attempted to dial itself", l.addr))
 	}
 
+        // This simulates an i/o timeout by sleeping for 20 seconds and returning 
+	// an error when the forceTimeout name is the same as the host we are 
+	// currently connecting to. Useful for checking how gRPC connections react 
+	// with timeouts.
 	if l.forceTimeout == addr {
 		l.logger.Debug("forcing timeout", "addr", addr, "me", l.addr)
 		time.Sleep(time.Second * 20)
-
 		return nil, deadlineError("i/o timeout")
 	}
 


### PR DESCRIPTION
This adds the ability to simulate i/o timeouts on specific host names for testing purposes.