### PR TITLE
Small cleanup on pki commands for consistency

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -544,7 +544,7 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 			}, nil
 		},
 		"pki list-intermediates": func() (cli.Command, error) {
-			return &PKIListChildrenCommand{
+			return &PKIListIntermediateCommand{
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},

--- a/command/healthcheck/pki_crl_validity_period.go
+++ b/command/healthcheck/pki_crl_validity_period.go
@@ -169,7 +169,7 @@ func (h *CRLValidityPeriod) Evaluate(e *Executor) (results []*Result, err error)
 			ret.Status = ResultCritical
 			ret.Message = fmt.Sprintf("CRL's validity is outside of suggested rotation window: CRL's next update is expected at %v, but expires within %v%% of validity window (starting on %v and ending on %v). It is suggested to rotate this CRL and start propagating it to hosts to avoid any issues caused by stale CRLs.", crl.NextUpdate.Format("2006-01-02"), h.CRLExpiryPercentage, crl.ThisUpdate.Format("2006-01-02"), expWhen.Format("2006-01-02"))
 
-			if crlDisabled == true {
+			if crlDisabled {
 				ret.Status = ResultInformational
 				ret.Message += " Because the CRL is disabled, this is less of a concern."
 			}
@@ -192,7 +192,7 @@ func (h *CRLValidityPeriod) Evaluate(e *Executor) (results []*Result, err error)
 			ret.Status = ResultCritical
 			ret.Message = fmt.Sprintf("Delta CRL's validity is outside of suggested rotation window: Delta CRL's next update is expected at %v, but expires within %v%% of validity window (starting on %v and ending on %v). It is suggested to rotate this Delta CRL and start propagating it to hosts to avoid any issues caused by stale CRLs.", crl.NextUpdate.Format("2006-01-02"), h.CRLExpiryPercentage, crl.ThisUpdate.Format("2006-01-02"), expWhen.Format("2006-01-02"))
 
-			if crlDisabled == true {
+			if crlDisabled {
 				ret.Status = ResultInformational
 				ret.Message += " Because the CRL is disabled, this is less of a concern."
 			}

--- a/command/pki_list_children_command.go
+++ b/command/pki_list_children_command.go
@@ -240,10 +240,8 @@ func (c *PKIListChildrenCommand) getIssuerListFromMount(client *api.Client, moun
 
 func checkIfResultsMatchFilters(verifyResults, constraintMap map[string]bool) bool {
 	for key, required := range constraintMap {
-		if required == true {
-			if verifyResults[key] == false {
-				return false
-			}
+		if required && !verifyResults[key] {
+			return false
 		}
 	}
 	return true

--- a/command/pki_list_children_command.go
+++ b/command/pki_list_children_command.go
@@ -64,7 +64,7 @@ func (c *PKIListChildrenCommand) Flags() *FlagSets {
 		Target:  &c.flagSubjectMatch,
 		Default: true,
 		EnvVar:  "",
-		Usage:   `Whether the subject name of the potential parent cert matches the issuer name of the child cert`,
+		Usage:   `Whether the subject name of the potential parent cert matches the issuer name of the child cert.`,
 	})
 
 	f.BoolVar(&BoolVar{
@@ -72,7 +72,7 @@ func (c *PKIListChildrenCommand) Flags() *FlagSets {
 		Target:  &c.flagKeyIdMatch,
 		Default: true,
 		EnvVar:  "",
-		Usage:   `Whether the subject key_id of the potential parent cert matches the issuing key id of the child cert`,
+		Usage:   `Whether the subject key id (SKID) of the potential parent cert matches the authority key id (AKID) of the child cert.`,
 	})
 
 	f.BoolVar(&BoolVar{
@@ -80,7 +80,7 @@ func (c *PKIListChildrenCommand) Flags() *FlagSets {
 		Target:  &c.flagPathMatch,
 		Default: false,
 		EnvVar:  "",
-		Usage:   `Whether the potential parent appears in the certificate chain of the issued cert`,
+		Usage:   `Whether the potential parent appears in the certificate chain field (ca_chain) of the issued cert.`,
 	})
 
 	f.BoolVar(&BoolVar{
@@ -88,7 +88,7 @@ func (c *PKIListChildrenCommand) Flags() *FlagSets {
 		Target:  &c.flagSignatureMatch,
 		Default: true,
 		EnvVar:  "",
-		Usage:   `Whether the key of the potential parent signed this issued certificate`,
+		Usage:   `Whether the key of the potential parent directly signed this issued certificate.`,
 	})
 
 	f.BoolVar(&BoolVar{
@@ -96,7 +96,7 @@ func (c *PKIListChildrenCommand) Flags() *FlagSets {
 		Target:  &c.flagIndirectSignMatch,
 		Default: true,
 		EnvVar:  "",
-		Usage:   `Whether trusting the parent certificate is sufficient to trust the child certificate`,
+		Usage:   `Whether trusting the parent certificate is sufficient to trust the child certificate.`,
 	})
 
 	f.BoolVar(&BoolVar{
@@ -104,7 +104,7 @@ func (c *PKIListChildrenCommand) Flags() *FlagSets {
 		Target:  &c.flagUseNames,
 		Default: false,
 		EnvVar:  "",
-		Usage:   `Whether the list of issuers returned is referred to by name when it exists rather than uuid`,
+		Usage:   `Whether the list of issuers returned is referred to by name (when it exists) rather than by uuid.`,
 	})
 
 	return set

--- a/command/pki_list_children_command.go
+++ b/command/pki_list_children_command.go
@@ -36,13 +36,22 @@ func (c *PKIListChildrenCommand) Synopsis() string {
 func (c *PKIListChildrenCommand) Help() string {
 	helpText := `
 Usage: vault pki list-intermediates PARENT [CHILD] [CHILD] [CHILD] ...
-PARENT is the certificate that might be the issuer that everything should be verified against.
-CHILD is a list of paths to certificates to be compared to the PARENT, or pki mounts to look for certificates on.  
-If CHILD is omitted entirely, the list will be constructed from all accessible pki mounts.
-This returns a list of issuing certificates, and whether they are a match. 
-By default, the type of match required is whether the PARENT has the expected subject, key_id, and could have (directly)
-signed this issuer.  The match criteria can be updated by changed the corresponding flag.
-`
+
+  Lists the set of intermediate CAs issued by this parent issuer.
+
+  PARENT is the certificate that might be the issuer that everything should
+  be verified against.
+
+  CHILD is an optional list of paths to certificates to be compared to the
+  PARENT, or pki mounts to look for certificates on. If CHILD is omitted
+  entirely, the list will be constructed from all accessible pki mounts.
+
+  This returns a list of issuing certificates, and whether they are a match.
+  By default, the type of match required is whether the PARENT has the
+  expected subject, key_id, and could have (directly) signed this issuer. 
+  The match criteria can be updated by changed the corresponding flag.
+
+` + c.Flags().Help()
 	return strings.TrimSpace(helpText)
 }
 

--- a/command/pki_list_intermediate_command.go
+++ b/command/pki_list_intermediate_command.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ryanuber/columnize"
 )
 
-type PKIListChildrenCommand struct {
+type PKIListIntermediateCommand struct {
 	*BaseCommand
 
 	flagConfig          string
@@ -29,11 +29,11 @@ type PKIListChildrenCommand struct {
 	flagPathMatch         bool
 }
 
-func (c *PKIListChildrenCommand) Synopsis() string {
+func (c *PKIListIntermediateCommand) Synopsis() string {
 	return "Determine Which (of a List) of Certificates Were Issued by A Given Parent Certificate"
 }
 
-func (c *PKIListChildrenCommand) Help() string {
+func (c *PKIListIntermediateCommand) Help() string {
 	helpText := `
 Usage: vault pki list-intermediates PARENT [CHILD] [CHILD] [CHILD] ...
 
@@ -55,7 +55,7 @@ Usage: vault pki list-intermediates PARENT [CHILD] [CHILD] [CHILD] ...
 	return strings.TrimSpace(helpText)
 }
 
-func (c *PKIListChildrenCommand) Flags() *FlagSets {
+func (c *PKIListIntermediateCommand) Flags() *FlagSets {
 	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
 	f := set.NewFlagSet("Command Options")
 
@@ -110,7 +110,7 @@ func (c *PKIListChildrenCommand) Flags() *FlagSets {
 	return set
 }
 
-func (c *PKIListChildrenCommand) Run(args []string) int {
+func (c *PKIListIntermediateCommand) Run(args []string) int {
 	f := c.Flags()
 	if err := f.Parse(args); err != nil {
 		c.UI.Error(err.Error())
@@ -207,7 +207,7 @@ func (c *PKIListChildrenCommand) Run(args []string) int {
 	return 0
 }
 
-func (c *PKIListChildrenCommand) getIssuerListFromMount(client *api.Client, mountString string) ([]string, error) {
+func (c *PKIListIntermediateCommand) getIssuerListFromMount(client *api.Client, mountString string) ([]string, error) {
 	var issuerList []string
 	issuerListEndpoint := sanitizePath(mountString) + "/issuers"
 	rawIssuersResp, err := client.Logical().List(issuerListEndpoint)
@@ -247,7 +247,7 @@ func checkIfResultsMatchFilters(verifyResults, constraintMap map[string]bool) bo
 	return true
 }
 
-func (c *PKIListChildrenCommand) outputResults(results map[string]bool) error {
+func (c *PKIListIntermediateCommand) outputResults(results map[string]bool) error {
 	switch Format(c.UI) {
 	case "", "table":
 		return c.outputResultsTable(results)
@@ -260,7 +260,7 @@ func (c *PKIListChildrenCommand) outputResults(results map[string]bool) error {
 	}
 }
 
-func (c *PKIListChildrenCommand) outputResultsTable(results map[string]bool) error {
+func (c *PKIListIntermediateCommand) outputResultsTable(results map[string]bool) error {
 	data := []string{"intermediate" + hopeDelim + "match?"}
 	for field, finding := range results {
 		row := field + hopeDelim + strconv.FormatBool(finding)
@@ -274,7 +274,7 @@ func (c *PKIListChildrenCommand) outputResultsTable(results map[string]bool) err
 	return nil
 }
 
-func (c *PKIListChildrenCommand) outputResultsJSON(results map[string]bool) error {
+func (c *PKIListIntermediateCommand) outputResultsJSON(results map[string]bool) error {
 	bytes, err := json.MarshalIndent(results, "", "  ")
 	if err != nil {
 		return err
@@ -284,7 +284,7 @@ func (c *PKIListChildrenCommand) outputResultsJSON(results map[string]bool) erro
 	return nil
 }
 
-func (c *PKIListChildrenCommand) outputResultsYAML(results map[string]bool) error {
+func (c *PKIListIntermediateCommand) outputResultsYAML(results map[string]bool) error {
 	bytes, err := yaml.Marshal(results)
 	if err != nil {
 		return err

--- a/command/pki_list_intermediate_test.go
+++ b/command/pki_list_intermediate_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestPKIListChildren(t *testing.T) {
+func TestPKIListIntermediate(t *testing.T) {
 	t.Parallel()
 
 	client, closer := testVaultServer(t)

--- a/command/pki_verify_sign_command.go
+++ b/command/pki_verify_sign_command.go
@@ -30,15 +30,25 @@ func (c *PKIVerifySignCommand) Synopsis() string {
 func (c *PKIVerifySignCommand) Help() string {
 	helpText := `
 Usage: vault pki verify-sign POSSIBLE-ISSUER POSSIBLE-ISSUED
-Here POSSIBLE-ISSUER and POSSIBLE-ISSUED are the fully name-spaced path to the certificate,
-for instance: 'ns1/mount1/issuer/issuerName/json'
-Returns five fields of information:
-- signature_match: was the key of the issuer used to sign the issued
-- path_match: the possible issuer appears in the valid certificate chain of the issued
-- key_id_match: does the key-id of the issuer match the key_id of the subject
-- subject_match: does the subject name of the issuer match the issuer subject of the issued
-- trust_match: if someone trusted the parent issuer, is the chain provided sufficient to trust the child issued
-`
+
+  Verifies whether the listed issuer has signed the listed issued certificate.
+
+  POSSIBLE-ISSUER and POSSIBLE-ISSUED are the fully name-spaced path to
+  an issuer certificate, for instance: 'ns1/mount1/issuer/issuerName/json'.
+
+  Returns five fields of information:
+
+    - signature_match: was the key of the issuer used to sign the issued.
+    - path_match: the possible issuer appears in the valid certificate chain
+	  of the issued.
+    - key_id_match: does the key-id of the issuer match the key_id of the
+	  subject.
+    - subject_match: does the subject name of the issuer match the issuer
+	  subject of the issued.
+    - trust_match: if someone trusted the parent issuer, is the chain
+	  provided sufficient to trust the child issued.
+
+` + c.Flags().Help()
 	return strings.TrimSpace(helpText)
 }
 


### PR DESCRIPTION
Various minor nits around the new PKI commands I wanted to address. Mostly it was just formatting and consistency with the rest of the commands. :-) Plus a rename of ListChildren to ListIntermediates for consistency with the command name. 