### PR TITLE
Add t.Helper() to various PKI test helper methods

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -683,6 +683,8 @@ func generateURLSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 }
 
 func generateCSR(t *testing.T, csrTemplate *x509.CertificateRequest, keyType string, keyBits int) (interface{}, []byte, string) {
+	t.Helper()
+
 	var priv interface{}
 	var err error
 	switch keyType {
@@ -814,6 +816,8 @@ func generateCSRSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 }
 
 func generateTestCsr(t *testing.T, keyType certutil.PrivateKeyType, keyBits int) (x509.CertificateRequest, string) {
+	t.Helper()
+
 	csrTemplate := x509.CertificateRequest{
 		Subject: pkix.Name{
 			Country:      []string{"MyCountry"},

--- a/builtin/logical/pki/chain_test.go
+++ b/builtin/logical/pki/chain_test.go
@@ -309,6 +309,8 @@ func (c CBValidateChain) PrettyChain(t testing.TB, chain []string, knownCerts ma
 }
 
 func ToCertificate(t testing.TB, cert string) *x509.Certificate {
+	t.Helper()
+
 	block, _ := pem.Decode([]byte(cert))
 	if block == nil {
 		t.Fatalf("Unable to parse certificate: nil PEM block\n[%v]\n", cert)
@@ -323,6 +325,8 @@ func ToCertificate(t testing.TB, cert string) *x509.Certificate {
 }
 
 func ToCRL(t testing.TB, crl string, issuer *x509.Certificate) *pkix.CertificateList {
+	t.Helper()
+
 	block, _ := pem.Decode([]byte(crl))
 	if block == nil {
 		t.Fatalf("Unable to parse CRL: nil PEM block\n[%v]\n", crl)

--- a/builtin/logical/pki/ocsp_test.go
+++ b/builtin/logical/pki/ocsp_test.go
@@ -488,6 +488,8 @@ func runOcspRequestTest(t *testing.T, requestType string, caKeyType string, caKe
 }
 
 func requireOcspSignatureAlgoForKey(t *testing.T, expected x509.SignatureAlgorithm, actual x509.SignatureAlgorithm) {
+	t.Helper()
+
 	require.Equal(t, expected.String(), actual.String())
 }
 
@@ -570,6 +572,8 @@ func setupOcspEnvWithCaKeyConfig(t *testing.T, keyType string, caKeyBits int, ca
 }
 
 func SendOcspRequest(t *testing.T, b *backend, s logical.Storage, getOrPost string, cert, issuer *x509.Certificate, requestHash crypto.Hash) (*logical.Response, error) {
+	t.Helper()
+
 	ocspRequest := generateRequest(t, requestHash, cert, issuer)
 
 	switch strings.ToLower(getOrPost) {
@@ -604,6 +608,8 @@ func sendOcspPostRequest(b *backend, s logical.Storage, ocspRequest []byte) (*lo
 }
 
 func generateRequest(t *testing.T, requestHash crypto.Hash, cert *x509.Certificate, issuer *x509.Certificate) []byte {
+	t.Helper()
+
 	opts := &ocsp.RequestOptions{Hash: requestHash}
 	ocspRequestDer, err := ocsp.CreateRequest(cert, issuer, opts)
 	require.NoError(t, err, "Failed generating OCSP request")
@@ -611,6 +617,8 @@ func generateRequest(t *testing.T, requestHash crypto.Hash, cert *x509.Certifica
 }
 
 func requireOcspResponseSignedBy(t *testing.T, ocspResp *ocsp.Response, issuer *x509.Certificate) {
+	t.Helper()
+
 	err := ocspResp.CheckSignatureFrom(issuer)
 	require.NoError(t, err, "Failed signature verification of ocsp response: %w", err)
 }

--- a/builtin/logical/pki/path_resign_crls_test.go
+++ b/builtin/logical/pki/path_resign_crls_test.go
@@ -490,6 +490,8 @@ func requireExtensionOid(t *testing.T, identifier asn1.ObjectIdentifier, extensi
 }
 
 func extractSerialsFromCrl(t *testing.T, crl *x509.RevocationList) map[string]time.Time {
+	t.Helper()
+
 	serials := map[string]time.Time{}
 
 	for _, revokedCert := range crl.RevokedCertificates {

--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -790,6 +790,8 @@ func requireFailInMigration(t *testing.T, b *backend, s logical.Storage, operati
 }
 
 func requireFileNotExists(t *testing.T, sc *storageContext, path string) {
+	t.Helper()
+
 	entry, err := sc.Storage.Get(sc.Context, path)
 	require.NoError(t, err)
 	if entry != nil {
@@ -800,6 +802,8 @@ func requireFileNotExists(t *testing.T, sc *storageContext, path string) {
 }
 
 func requireFileExists(t *testing.T, sc *storageContext, path string, contents []byte) []byte {
+	t.Helper()
+
 	entry, err := sc.Storage.Get(sc.Context, path)
 	require.NoError(t, err)
 	require.NotNil(t, entry)

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -21,6 +21,8 @@ import (
 
 // Setup helpers
 func CreateBackendWithStorage(t testing.TB) (*backend, logical.Storage) {
+	t.Helper()
+
 	config := logical.TestBackendConfig()
 	config.StorageView = &logical.InmemStorage{}
 
@@ -36,6 +38,8 @@ func CreateBackendWithStorage(t testing.TB) (*backend, logical.Storage) {
 }
 
 func mountPKIEndpoint(t testing.TB, client *api.Client, path string) {
+	t.Helper()
+
 	err := client.Sys().Mount(path, &api.MountInput{
 		Type: "pki",
 		Config: api.MountConfigInput{
@@ -48,6 +52,8 @@ func mountPKIEndpoint(t testing.TB, client *api.Client, path string) {
 
 // Signing helpers
 func requireSignedBy(t *testing.T, cert *x509.Certificate, signingCert *x509.Certificate) {
+	t.Helper()
+
 	if err := cert.CheckSignatureFrom(signingCert); err != nil {
 		t.Fatalf("signature verification failed: %v", err)
 	}
@@ -55,6 +61,8 @@ func requireSignedBy(t *testing.T, cert *x509.Certificate, signingCert *x509.Cer
 
 // Certificate helper
 func parseCert(t *testing.T, pemCert string) *x509.Certificate {
+	t.Helper()
+
 	block, _ := pem.Decode([]byte(pemCert))
 	require.NotNil(t, block, "failed to decode PEM block")
 
@@ -64,6 +72,8 @@ func parseCert(t *testing.T, pemCert string) *x509.Certificate {
 }
 
 func requireMatchingPublicKeys(t *testing.T, cert *x509.Certificate, key crypto.PublicKey) {
+	t.Helper()
+
 	certPubKey := cert.PublicKey
 	areEqual, err := certutil.ComparePublicKeysAndType(certPubKey, key)
 	require.NoError(t, err, "failed comparing public keys: %#v", err)
@@ -89,17 +99,25 @@ func getSelfSigned(t *testing.T, subject, issuer *x509.Certificate, key *rsa.Pri
 
 // CRL related helpers
 func getCrlCertificateList(t *testing.T, client *api.Client, mountPoint string) pkix.TBSCertificateList {
+	t.Helper()
+
 	path := fmt.Sprintf("/v1/%s/crl", mountPoint)
 	return getParsedCrlAtPath(t, client, path).TBSCertList
 }
 
 func parseCrlPemBytes(t *testing.T, crlPem []byte) pkix.TBSCertificateList {
+	t.Helper()
+
 	certList, err := x509.ParseCRL(crlPem)
 	require.NoError(t, err)
 	return certList.TBSCertList
 }
 
 func requireSerialNumberInCRL(t *testing.T, revokeList pkix.TBSCertificateList, serialNum string) bool {
+	if t != nil {
+		t.Helper()
+	}
+
 	serialsInList := make([]string, 0, len(revokeList.RevokedCertificates))
 	for _, revokeEntry := range revokeList.RevokedCertificates {
 		formattedSerial := certutil.GetHexFormatted(revokeEntry.SerialNumber.Bytes(), ":")
@@ -117,11 +135,15 @@ func requireSerialNumberInCRL(t *testing.T, revokeList pkix.TBSCertificateList, 
 }
 
 func getParsedCrl(t *testing.T, client *api.Client, mountPoint string) *pkix.CertificateList {
+	t.Helper()
+
 	path := fmt.Sprintf("/v1/%s/crl", mountPoint)
 	return getParsedCrlAtPath(t, client, path)
 }
 
 func getParsedCrlAtPath(t *testing.T, client *api.Client, path string) *pkix.CertificateList {
+	t.Helper()
+
 	req := client.NewRequest("GET", path)
 	resp, err := client.RawRequest(req)
 	if err != nil {
@@ -145,6 +167,8 @@ func getParsedCrlAtPath(t *testing.T, client *api.Client, path string) *pkix.Cer
 }
 
 func getParsedCrlFromBackend(t *testing.T, b *backend, s logical.Storage, path string) *pkix.CertificateList {
+	t.Helper()
+
 	resp, err := CBRead(b, s, path)
 	if err != nil {
 		t.Fatal(err)
@@ -201,6 +225,8 @@ func CBDelete(b *backend, s logical.Storage, path string) (*logical.Response, er
 }
 
 func requireFieldsSetInResp(t *testing.T, resp *logical.Response, fields ...string) {
+	t.Helper()
+
 	var missingFields []string
 	for _, field := range fields {
 		value, ok := resp.Data[field]
@@ -213,6 +239,8 @@ func requireFieldsSetInResp(t *testing.T, resp *logical.Response, fields ...stri
 }
 
 func requireSuccessNonNilResponse(t *testing.T, resp *logical.Response, err error, msgAndArgs ...interface{}) {
+	t.Helper()
+
 	require.NoError(t, err, msgAndArgs...)
 	if resp.IsError() {
 		errContext := fmt.Sprintf("Expected successful response but got error: %v", resp.Error())
@@ -222,6 +250,8 @@ func requireSuccessNonNilResponse(t *testing.T, resp *logical.Response, err erro
 }
 
 func requireSuccessNilResponse(t *testing.T, resp *logical.Response, err error, msgAndArgs ...interface{}) {
+	t.Helper()
+
 	require.NoError(t, err, msgAndArgs...)
 	if resp.IsError() {
 		errContext := fmt.Sprintf("Expected successful response but got error: %v", resp.Error())


### PR DESCRIPTION
This has been done to help diagnose PKI test failures in the future so that we get the callers in the trace's
when we fail and not just the helper's trace output. Many of our tests will repeat calls at different stages 
of the test itself so a better calling trace will be helpful.