### PR TITLE
Move cert auth backend setup into initialize

### DIFF
--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -1103,6 +1103,11 @@ func testFactory(t *testing.T) logical.Backend {
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
+	if err := b.Initialize(context.Background(), &logical.InitializationRequest{
+		Storage: storage,
+	}); err != nil {
+		t.Fatalf("error: %s", err)
+	}
 	return b
 }
 

--- a/changelog/18885.txt
+++ b/changelog/18885.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+auth/cert: Load config, crls from InitializeFunc to allow parallel processing.
+```


### PR DESCRIPTION
In further review with new understanding after #18244, loading configuration and CRLs within the backend's initialize function is the ideal approach: Factory construction is strictly serial, resulting in backend initialization blocking until config and CRLs are loaded. By using an InitializeFunc(...), we delay loading until after all backends are constructed (either right on startup in 1.12+, else during the initial PeriodicFunc(...) invocation on 1.11 and earlier).

We also invoke initialize automatically on test Factory construction.

Resolves: #17847

Co-authored-by: @valli0x 
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

@sgmiller I'm inclined not to backport this? 