### PR TITLE
ui: mount pki engine in router 

### DIFF
--- a/ui/app/router.js
+++ b/ui/app/router.js
@@ -154,9 +154,7 @@ Router.map(function () {
         this.route('backend', { path: '/:backend' }, function () {
           this.mount('kmip');
           this.mount('kubernetes');
-          if (config.environment !== 'production') {
-            this.mount('pki');
-          }
+          this.mount('pki');
           this.route('index', { path: '/' });
           this.route('configuration');
           // because globs / params can't be empty,


### PR DESCRIPTION
Before we decided to release a beta pki, this route was hidden from production environments.