### PR TITLE
Brute forcing unlock user bug

### DIFF
--- a/builtin/credential/userpass/path_login.go
+++ b/builtin/credential/userpass/path_login.go
@@ -39,7 +39,7 @@ func pathLogin(b *backend) *framework.Path {
 }
 
 func (b *backend) pathLoginAliasLookahead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	username := strings.ToLower(d.Get("username").(string))
+	username := d.Get("username").(string)
 	if username == "" {
 		return nil, fmt.Errorf("missing username")
 	}

--- a/changelog/18890.txt
+++ b/changelog/18890.txt
@@ -1,4 +1,4 @@
 ```release-note:bug
-core: removes string.Lower for alias name from pathLoginAliasLookahead function in userpass. This fixes
+core: removes strings.ToLower for alias name from pathLoginAliasLookahead function in userpass. This fixes
 the storage entry for locked users by having the correct alias name in path. 
 ``

--- a/changelog/18890.txt
+++ b/changelog/18890.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+core: removes string.Lower for alias name from pathLoginAliasLookahead function in userpass. This fixes
+the storage entry for locked users by having the correct alias name in path. 
+``


### PR DESCRIPTION
While testing brute forcing using enos, I noticed that unlocking "testUser" did not work as expected. 
On further investigation, I realized this was creating an entry in "core/login/lockedUsers/root/auth_userpass_2e744f4b/testuser" when it should have been "core/login/lockedUsers/root/auth_userpass_2e744f4b/testUser". The unlock user api endpoint was trying to delete the "core/login/lockedUsers/root/auth_userpass_2e744f4b/testUser" entry.

This was because of using strings.Lower in pathLoginAliasLookahead function. We call this function from request_handling.go to get the alias name from request. I tried creating multiple users with different cases like "testuser", testUser", "Testuser" and it works. Therefore, I removed this from aliasLookahead operation for userpass. 

The aliasname in pathLoginAliasLookahead for ldap is correct. Therefore, no changes were needed there. 