### PR TITLE
Add OpenAPI Go and C#

### DIFF
--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -544,7 +544,8 @@ s, err := client.Secrets.KVv2Read(context.Background(), "my-secret-password")
 if err != nil {
    log.Fatal(err)
 }
-log.Println("secret retrieved:", s.Data)
+
+log.Println("Secret retrieved:", s.Data)
 ```
 
 </Tab>

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -199,7 +199,6 @@ import (
 
 The Nuget packages are hosted in an internal Nuget feed that can be found in [Artifactory](https://artifactory.hashicorp.engineering/ui/repos/tree/General/vault-devex-nuget-local). You can use the Dotnet CLI or Nuget CLI to retrieve the package.
 
-You need to add the private Nuget feed as a source in either CLI. You can also generate an [access token](https://www.jfrog.com/confluence/display/JFROG/User+Profile#UserProfile-IdentityTokenidentitytoken) that can be used in lieu of a password.
 
 ```shell-session
 $ nuget sources add \

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -174,7 +174,6 @@ import org.springframework.vault.core.VaultTemplate;
 [OpenAPI Go](https://github.com/hashicorp/vault-client-go) (Beta) client library:
 
 ```shell-session
-$ export GOPRIVATE=github.com/hashicorp/vault-client-go
 $ go get github.com/hashicorp/vault-client-go
 ```
 

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -194,10 +194,10 @@ import (
 
 
 </Tab>
-<Tab heading="OpenAPI C# (Beta)" group="openAPI-cs">
+<Tab heading="OpenAPI .NET (Beta)" group="openAPI-dotnet">
 
 
-[OpenAPI C#](https://github.com/hashicorp/vault-client-dotnet) (Beta) client library:
+[OpenAPI .NET](https://github.com/hashicorp/vault-client-dotnet) (Beta) client library:
 
 Vault is a package available at [Hashicorp Nuget](https://www.nuget.org/profiles/hashicorp).
 
@@ -322,7 +322,7 @@ if err := client.SetToken("dev-only-token"); err != nil {
 ```
 
 </Tab>
-<Tab heading="OpenAPI C# (Beta)" group="openAPI-cs">
+<Tab heading="OpenAPI .NET (Beta)" group="openAPI-dotnet">
 
 ```cs
 string address = "http://127.0.0.1:8200";
@@ -437,7 +437,7 @@ log.Println("Secret written successfully.")
 ```
 
 </Tab>
-<Tab heading="OpenAPI C# (Beta)" group="openAPI-cs">
+<Tab heading="OpenAPI .NET (Beta)" group="openAPI-dotnet">
 
 ```cs
 var secretData = new Dictionary<string, string> { { "mypass", "pass" } };
@@ -543,7 +543,7 @@ log.Println("Secret retrieved:", s.Data)
 ```
 
 </Tab>
-<Tab heading="OpenAPI C# (Beta)" group="openAPI-cs">
+<Tab heading="OpenAPI .NET (Beta)" group="openAPI-dotnet">
 
 ```cs
 VaultResponse<Object> resp = vaultClient.Secrets.KVv2Read("mypath");

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -15,6 +15,8 @@ The complete code samples for the steps below are available here:
 - [C#](https://github.com/hashicorp/vault-examples/blob/main/examples/_quick-start/dotnet/Example.cs)
 - [Python](https://github.com/hashicorp/vault-examples/blob/main/examples/_quick-start/python/example.py)
 - [Java (Spring)](https://github.com/hashicorp/vault-examples/blob/main/examples/_quick-start/java/Example.java)
+- [OpenAPI-based Go](https://github.com/hashicorp/vault-client-go/#getting-started)
+- [OpenAPI-based .NET](https://github.com/hashicorp/vault-client-dotnet/#getting-started)
 
 For an out-of-the-box runnable demo application showcasing these concepts and more, see the hello-vault repositories ([Go](https://github.com/hashicorp/hello-vault-go), [C#](https://github.com/hashicorp/hello-vault-dotnet) and [Java/Spring Boot](https://github.com/hashicorp/hello-vault-spring)).
 
@@ -306,7 +308,7 @@ VaultTemplate vaultTemplate = new VaultTemplate(
 <Tab heading="Bash" group="bash">
 
 ```shell-session
-export VAULT_TOKEN="dev-only-token"
+$ export VAULT_TOKEN="dev-only-token"
 ```
 
 </Tab>
@@ -417,7 +419,7 @@ System.out.println("Secret written successfully.");
 <Tab heading="Bash" group="bash">
 
 ```shell-session
-curl \
+$ curl \
     --header "X-Vault-Token: $VAULT_TOKEN" \
     --header "Content-Type: application/json" \
     --request POST \
@@ -530,7 +532,7 @@ if (readResponse != null && readResponse.hasData()) {
 <Tab heading="Bash" group="bash">
 
 ```shell-session
-curl \
+$ curl \
     --header "X-Vault-Token: $VAULT_TOKEN" \
     http://127.0.0.1:8200/v1/secret/data/my-secret-password > secrets.json
 ```
@@ -617,7 +619,7 @@ System.out.println("Access granted!");
 <Tab heading="Bash" group="bash">
 
 ```shell-session
-    cat secrets.json | jq '.data.data'
+$ cat secrets.json | jq '.data.data'
 ```
 
 </Tab>

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -316,7 +316,7 @@ $ export VAULT_TOKEN="dev-only-token"
 
 ```go
 client, err := vault.New(
-   vault.WithBaseAddress("http://127.0.0.1:8200"),
+   vault.WithAddress("http://127.0.0.1:8200"),
    vault.WithRequestTimeout(30*time.Second),
 )
 if err != nil {

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -445,7 +445,7 @@ var secretData = new Dictionary<string, string> { { "password", "Hashi123" } };
 // Write a secret
 var kvRequestData = new KVv2WriteRequest(secretData);
 
-vaultClient.Secrets.KVv2Write("mypath", kvRequestData);
+vaultClient.Secrets.KVv2Write("my-secret-password", kvRequestData);
 ```
 
 </Tab>

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -329,7 +329,7 @@ string address = "http://127.0.0.1:8200";
 VaultConfiguration config = new VaultConfiguration(address);
 
 VaultClient vaultClient = new VaultClient(config);
-vaultClient.SetToken("my-token");
+vaultClient.SetToken("dev-only-token");
 ```
 
 </Tab>

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -430,7 +430,7 @@ curl \
 <Tab heading="OpenAPI Go (Beta)" group="openAPI-go">
 
 ```go
-_, err = client.Secrets.KVv2Write(ctx, "my-secret", schema.KVv2WriteRequest{
+_, err = client.Secrets.KVv2Write(context.Background(), "my-secret-password", schema.KVv2WriteRequest{
    Data: map[string]any{
       "password1": "abc123",
       "password2": "correct horse battery staple",

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -322,8 +322,7 @@ if err != nil {
    log.Fatal(err)
 }
 
-// authenticate with a root token (insecure)
-if err := client.SetToken("my-token"); err != nil {
+if err := client.SetToken("dev-only-token"); err != nil {
    log.Fatal(err)
 }
 ```

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -211,7 +211,7 @@ Vault is a package available at [Hashicorp Nuget](https://www.nuget.org/profiles
 **Or:**
 
 ```shell-session
-$ dotnet nuget add source https://artifactory.hashicorp.engineering/artifactory/api/nuget/v3/vault-devex-nuget-local \
+dotnet add package Hashicorp.Vault -version "0.1.0-beta" 
     --name HashicorpArtifactory \
     --username "myusername" \
     --password "mypassword"

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -203,20 +203,13 @@ Vault is a package available at [Hashicorp Nuget](https://www.nuget.org/profiles
 
 
 ```shell-session
- nuget install HashiCorp.Vault -Version "0.1.0-beta"
-    -name HashicorpArtifactory \ 
-    -source https://artifactory.hashicorp.engineering/ui/repos/tree/General/vault-devex-nuget-local \
-    -username "myusername" \
-    -password "mypassword"
+$ nuget install HashiCorp.Vault -Version "0.1.0-beta"
 ```
 
 **Or:**
 
 ```shell-session
-dotnet add package Hashicorp.Vault -version "0.1.0-beta" 
-    --name HashicorpArtifactory \
-    --username "myusername" \
-    --password "mypassword"
+$ dotnet add package Hashicorp.Vault -version "0.1.0-beta" 
 ```
 
 Now, let's add the import statements for the client library to the top of the file.

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -440,7 +440,7 @@ log.Println("Secret written successfully.")
 <Tab heading="OpenAPI .NET (Beta)" group="openAPI-dotnet">
 
 ```cs
-var secretData = new Dictionary<string, string> { { "mypass", "pass" } };
+var secretData = new Dictionary<string, string> { { "password", "Hashi123" } };
 
 // Write a secret
 var kvRequestData = new KVv2WriteRequest(secretData);

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -432,8 +432,7 @@ curl \
 ```go
 _, err = client.Secrets.KVv2Write(context.Background(), "my-secret-password", schema.KVv2WriteRequest{
    Data: map[string]any{
-      "password1": "abc123",
-      "password2": "correct horse battery staple",
+      "password": "Hashi123",
    },
 })
 if err != nil {

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -540,9 +540,7 @@ curl \
 <Tab heading="OpenAPI Go (Beta)" group="openAPI-go">
 
 ```go
-ctx := context.Background()
-
-s, err := client.Secrets.KVv2Read(ctx, "my-secret")
+s, err := client.Secrets.KVv2Read(context.Background(), "my-secret-password")
 if err != nil {
    log.Fatal(err)
 }

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -201,7 +201,7 @@ Vault is a package available at [Hashicorp Nuget](https://www.nuget.org/profiles
 
 
 ```shell-session
-$ nuget sources add \
+ nuget install HashiCorp.Vault -Version "0.1.0-beta"
     -name HashicorpArtifactory \ 
     -source https://artifactory.hashicorp.engineering/ui/repos/tree/General/vault-devex-nuget-local \
     -username "myusername" \

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -314,7 +314,6 @@ export VAULT_TOKEN="dev-only-token"
 <Tab heading="OpenAPI Go (Beta)" group="openAPI-go">
 
 ```go
-// prepare a client with the given base address
 client, err := vault.New(
    vault.WithBaseAddress("http://127.0.0.1:8200"),
    vault.WithRequestTimeout(30*time.Second),

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -546,7 +546,7 @@ log.Println("Secret retrieved:", s.Data)
 <Tab heading="OpenAPI .NET (Beta)" group="openAPI-dotnet">
 
 ```cs
-VaultResponse<Object> resp = vaultClient.Secrets.KVv2Read("mypath");
+VaultResponse<Object> resp = vaultClient.Secrets.KVv2Read("my-secret-password");
 Console.WriteLine(resp.Data);
 ```
 

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -57,7 +57,7 @@ Let's install the Vault client library for your language of choice.
 -> **Note**: Some of these libraries are currently community-maintained.
 
 <Tabs>
-<Tab heading="Go">
+<Tab heading="Go" group="go">
 
 [Go](https://pkg.go.dev/github.com/hashicorp/vault/api) (official) client library:
    
@@ -76,7 +76,7 @@ import vault "github.com/hashicorp/vault/api"
 </CodeBlockConfig>
 
 </Tab>
-<Tab heading="Ruby">
+<Tab heading="Ruby" group="ruby">
 
    
 [Ruby](https://github.com/hashicorp/vault-ruby) (official) client library:
@@ -96,7 +96,7 @@ require "vault"
 </CodeBlockConfig>
 
 </Tab>
-<Tab heading="C#">
+<Tab heading="C#" group="cs">
 
    
 [C#](https://github.com/rajanadar/VaultSharp) client library:
@@ -119,7 +119,7 @@ using VaultSharp.V1.Commons;
 </CodeBlockConfig>
 
 </Tab>
-<Tab heading="Python">
+<Tab heading="Python" group="python">
 
    
 [Python](https://github.com/hvac/hvac) client library:
@@ -139,7 +139,7 @@ import hvac
 </CodeBlockConfig>
 
 </Tab>
-<Tab heading="Java">
+<Tab heading="Java" group="java">
 
    
 [Java (Spring)](https://spring.io/projects/spring-vault) client library:
@@ -167,6 +167,68 @@ import org.springframework.vault.core.VaultTemplate;
 
 </CodeBlockConfig>
 
+</Tab>
+<Tab heading="OpenAPI Go (Beta)" group="openAPI-go">
+
+
+[OpenAPI Go](https://github.com/hashicorp/vault-client-go) (Beta) client library:
+
+```shell-session
+$ export GOPRIVATE=github.com/hashicorp/vault-client-go
+$ go get github.com/hashicorp/vault-client-go
+```
+
+Now, let's add the import statements for the client library to the top of the file.
+
+<CodeBlockConfig heading="import statements for client library" lineNumbers>
+
+```go
+import (
+	"github.com/hashicorp/vault-client-go"
+	"github.com/hashicorp/vault-client-go/schema"
+)
+```
+
+</CodeBlockConfig>
+
+
+</Tab>
+<Tab heading="OpenAPI C# (Beta)" group="openAPI-cs">
+
+
+[OpenAPI C#](https://github.com/hashicorp/vault-client-dotnet) (Beta) client library:
+
+The Nuget packages are hosted in an internal Nuget feed that can be found in [Artifactory](https://artifactory.hashicorp.engineering/ui/repos/tree/General/vault-devex-nuget-local). You can use the Dotnet CLI or Nuget CLI to retrieve the package.
+
+You need to add the private Nuget feed as a source in either CLI. You can also generate an [access token](https://www.jfrog.com/confluence/display/JFROG/User+Profile#UserProfile-IdentityTokenidentitytoken) that can be used in lieu of a password.
+
+```shell-session
+$ nuget sources add \
+    -name HashicorpArtifactory \ 
+    -source https://artifactory.hashicorp.engineering/ui/repos/tree/General/vault-devex-nuget-local \
+    -username "myusername" \
+    -password "mypassword"
+```
+
+**Or:**
+
+```shell-session
+$ dotnet nuget add source https://artifactory.hashicorp.engineering/artifactory/api/nuget/v3/vault-devex-nuget-local \
+    --name HashicorpArtifactory \
+    --username "myusername" \
+    --password "mypassword"
+```
+
+Now, let's add the import statements for the client library to the top of the file.
+
+<CodeBlockConfig heading="import statements for client library" lineNumbers>
+
+```cs
+using Vault;
+using Vault.Client;
+```
+
+</CodeBlockConfig>
 
 </Tab>
 </Tabs>
@@ -179,7 +241,8 @@ A variety of [authentication methods](/vault/docs/auth) can be used to prove you
 To keep things simple for our example, we'll just use the root token created in **Step 1**.
 Paste the following code to initialize a new Vault client that will use token-based authentication for all its requests:
 
-<CodeTabs heading="initialize a new vault client">
+<Tabs>
+<Tab heading="Go">
 
 ```go
 config := vault.DefaultConfig()
@@ -194,12 +257,18 @@ if err != nil {
 client.SetToken("dev-only-token")
 ```
 
+</Tab>
+<Tab heading="Ruby" group="ruby">
+
 ```ruby
 Vault.configure do |config|
     config.address = "http://127.0.0.1:8200"
     config.token = "dev-only-token"
 end
 ```
+
+</Tab>
+<Tab heading="C#" group="cs">
 
 ```cs
 IAuthMethodInfo authMethod = new TokenAuthMethodInfo(vaultToken: "dev-only-token");
@@ -209,12 +278,18 @@ VaultClientSettings("http://127.0.0.1:8200", authMethod);
 IVaultClient vaultClient = new VaultClient(vaultClientSettings);
 ```
 
+</Tab>
+<Tab heading="Python" group="python">
+
 ```Python
 client = hvac.Client(
     url='http://127.0.0.1:8200',
     token='dev-only-token',
 )
 ```
+
+</Tab>
+<Tab heading="Java" group="java">
 
 ```Java
 VaultEndpoint vaultEndpoint = new VaultEndpoint();
@@ -229,11 +304,45 @@ VaultTemplate vaultTemplate = new VaultTemplate(
 );
 ```
 
+</Tab>
+<Tab heading="Bash" group="bash">
+
 ```shell-session
 export VAULT_TOKEN="dev-only-token"
 ```
 
-</CodeTabs>
+</Tab>
+<Tab heading="OpenAPI Go (Beta)" group="openAPI-go">
+
+```go
+// prepare a client with the given base address
+client, err := vault.New(
+   vault.WithBaseAddress("http://127.0.0.1:8200"),
+   vault.WithRequestTimeout(30*time.Second),
+)
+if err != nil {
+   log.Fatal(err)
+}
+
+// authenticate with a root token (insecure)
+if err := client.SetToken("my-token"); err != nil {
+   log.Fatal(err)
+}
+```
+
+</Tab>
+<Tab heading="OpenAPI C# (Beta)" group="openAPI-cs">
+
+```cs
+string address = "http://127.0.0.1:8200";
+VaultConfiguration config = new VaultConfiguration(address);
+
+VaultClient vaultClient = new VaultClient(config);
+vaultClient.SetToken("my-token");
+```
+
+</Tab>
+</Tabs>
 
 ## Step 4: Store a secret
 
@@ -241,7 +350,8 @@ Secrets are sensitive data like API keys and passwords that we shouldn’t be st
 
 We'll use the Vault client we just initialized to write a secret to Vault, like so:
 
-<CodeTabs heading="write a secret to vault">
+<Tabs>
+<Tab heading="Go">
 
 ```go
 secretData := map[string]interface{}{
@@ -257,12 +367,18 @@ if err != nil {
 fmt.Println("Secret written successfully.")
 ```
 
+</Tab>
+<Tab heading="Ruby" group="ruby">
+
 ```ruby
 secret_data = {data: {password: "Hashi123"}}
 Vault.logical.write("secret/data/my-secret-password", secret_data)
 
 puts "Secret written successfully."
 ```
+
+</Tab>
+<Tab heading="C#" group="cs">
 
 ```cs
 var secretData = new Dictionary<string, object> { { "password", "Hashi123" } };
@@ -275,6 +391,9 @@ vaultClient.V1.Secrets.KeyValue.V2.WriteSecretAsync(
 Console.WriteLine("Secret written successfully.");
 ```
 
+</Tab>
+<Tab heading="Python" group="python">
+
 ```Python
 create_response = client.secrets.kv.v2.create_or_update_secret(
     path='my-secret-password',
@@ -283,6 +402,9 @@ create_response = client.secrets.kv.v2.create_or_update_secret(
 
 print('Secret written successfully.')
 ```
+
+</Tab>
+<Tab heading="Java" group="java">
 
 ```Java
 Map<String, String> data = new HashMap<>();
@@ -295,6 +417,9 @@ Versioned.Metadata createResponse = vaultTemplate
 System.out.println("Secret written successfully.");
 ```
 
+</Tab>
+<Tab heading="Bash" group="bash">
+
 ```shell-session
 curl \
     --header "X-Vault-Token: $VAULT_TOKEN" \
@@ -304,7 +429,36 @@ curl \
     http://127.0.0.1:8200/v1/secret/data/my-secret-password
 ```
 
-</CodeTabs>
+</Tab>
+<Tab heading="OpenAPI Go (Beta)" group="openAPI-go">
+
+```go
+_, err = client.Secrets.KVv2Write(ctx, "my-secret", schema.KVv2WriteRequest{
+   Data: map[string]any{
+      "password1": "abc123",
+      "password2": "correct horse battery staple",
+   },
+})
+if err != nil {
+   log.Fatal(err)
+}
+log.Println("secret written successfully")
+```
+
+</Tab>
+<Tab heading="OpenAPI C# (Beta)" group="openAPI-cs">
+
+```cs
+var secretData = new Dictionary<string, string> { { "mypass", "pass" } };
+
+// Write a secret
+var kvRequestData = new KVv2WriteRequest(secretData);
+
+vaultClient.Secrets.KVv2Write("mypath", kvRequestData);
+```
+
+</Tab>
+</Tabs>
 
 A common way of storing secrets is as key-value pairs using the [KV secrets engine (v2)](/vault/docs/secrets/kv/kv-v2). In the code we've just added, `password` is the key in the key-value pair, and `Hashi123` is the value.
 
@@ -318,7 +472,8 @@ Now that we know how to write a secret, let's practice reading one.
 
 Underneath the line where you wrote a secret to Vault, let's add a few more lines, where we will be retrieving the secret and unpacking the value:
 
-<CodeTabs heading="read a secret">
+<Tabs>
+<Tab heading="Go">
 
 ```go
 secret, err := client.KVv2("secret").Get(context.Background(), "my-secret-password")
@@ -332,10 +487,16 @@ log.Fatalf("value type assertion failed: %T %#v", secret.Data["password"], secre
 }
 ```
 
+</Tab>
+<Tab heading="Ruby" group="ruby">
+
 ```ruby
 secret = Vault.logical.read("secret/data/my-secret-password")
 password = secret.data[:data][:password]
 ```
+
+</Tab>
+<Tab heading="C#" group="cs">
 
 ```cs
 Secret<SecretData> secret = vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(
@@ -346,11 +507,17 @@ Secret<SecretData> secret = vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(
 var password = secret.Data.Data["password"];
 ```
 
+</Tab>
+<Tab heading="Python" group="python">
+
 ```Python
 read_response = client.secrets.kv.read_secret_version(path='my-secret-password')
 
 password = read_response['data']['data']['password']
 ```
+
+</Tab>
+<Tab heading="Java" group="java">
 
 ```Java
 Versioned<Map<String, Object>> readResponse = vaultTemplate
@@ -363,17 +530,43 @@ if (readResponse != null && readResponse.hasData()) {
 }
 ```
 
+</Tab>
+<Tab heading="Bash" group="bash">
+
 ```shell-session
 curl \
     --header "X-Vault-Token: $VAULT_TOKEN" \
     http://127.0.0.1:8200/v1/secret/data/my-secret-password > secrets.json
 ```
 
-</CodeTabs>
+</Tab>
+<Tab heading="OpenAPI Go (Beta)" group="openAPI-go">
+
+```go
+ctx := context.Background()
+
+s, err := client.Secrets.KVv2Read(ctx, "my-secret")
+if err != nil {
+   log.Fatal(err)
+}
+log.Println("secret retrieved:", s.Data)
+```
+
+</Tab>
+<Tab heading="OpenAPI C# (Beta)" group="openAPI-cs">
+
+```cs
+VaultResponse<Object> resp = vaultClient.Secrets.KVv2Read("mypath");
+Console.WriteLine(resp.Data);
+```
+
+</Tab>
+</Tabs>
 
 Last, confirm that the value we unpacked from the read response is correct:
 
-<CodeTabs heading="confirm value">
+<Tabs>
+<Tab heading="Go">
 
 ```go
 if value != "Hashi123" {
@@ -383,11 +576,17 @@ if value != "Hashi123" {
 fmt.Println("Access granted!")
 ```
 
+</Tab>
+<Tab heading="Ruby" group="ruby">
+
 ```ruby
 abort "Unexpected password" if password != "Hashi123"
 
 puts "Access granted!"
 ```
+
+</Tab>
+<Tab heading="C#" group="cs">
 
 ```cs
 if (password.ToString() != "Hashi123")
@@ -398,12 +597,18 @@ if (password.ToString() != "Hashi123")
 Console.WriteLine("Access granted!");
 ```
 
+</Tab>
+<Tab heading="Python" group="python">
+
 ```Python
 if password != 'Hashi123':
     sys.exit('unexpected password')
 
 print('Access granted!')
 ```
+
+</Tab>
+<Tab heading="Java" group="java">
 
 ```Java
 if (!password.equals("Hashi123")) {
@@ -413,10 +618,15 @@ if (!password.equals("Hashi123")) {
 System.out.println("Access granted!");
 ```
 
+</Tab>
+<Tab heading="Bash" group="bash">
+
 ```shell-session
     cat secrets.json | jq '.data.data'
 ```
-</CodeTabs>
+
+</Tab>
+</Tabs>
 
 If the secret was fetched successfully, you should see the `Access granted!` message after you run the code. If not, check to see if you provided the correct path to your secret.
 

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -438,7 +438,8 @@ _, err = client.Secrets.KVv2Write(context.Background(), "my-secret-password", sc
 if err != nil {
    log.Fatal(err)
 }
-log.Println("secret written successfully")
+
+log.Println("Secret written successfully.")
 ```
 
 </Tab>

--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -197,7 +197,7 @@ import (
 
 [OpenAPI C#](https://github.com/hashicorp/vault-client-dotnet) (Beta) client library:
 
-The Nuget packages are hosted in an internal Nuget feed that can be found in [Artifactory](https://artifactory.hashicorp.engineering/ui/repos/tree/General/vault-devex-nuget-local). You can use the Dotnet CLI or Nuget CLI to retrieve the package.
+Vault is a package available at [Hashicorp Nuget](https://www.nuget.org/profiles/hashicorp).
 
 
 ```shell-session


### PR DESCRIPTION
# Vault 1.13 Deliverable

🎫 [Jira](https://hashicorp.atlassian.net/browse/VAULT-12522)
🎟️ [Asana](https://app.asana.com/0/563192436488770/1203633559435202/f)

🔍 [Deploy preview](https://vault-git-docs-add-openapi-sdks-hashicorp.vercel.app/vault/docs/get-started/developer-qs)

Update the [Developer Quick Start](https://developer.hashicorp.com/vault/docs/get-started/developer-qs) page by adding new tabs in the Install Client Library, Authenticate to Vault, Store a secret & Retrieve a Secret for "**OpenAPI Go (Beta)**", and "**OpenAPI C# (Beta)**"

**What's missing:** 

- No example code in the [vault-examples](https://github.com/hashicorp/vault-examples/tree/main) repo for OpenAPI Go and OpenAPI C#.
- No code example equivalent to:
  
   ```
   if value != "Hashi123" {
       log.Fatalf("unexpected password value %q retrieved from vault", value)
   }
   ```

---

**NOTE:**
Had to switch `<CodeTabs>` to `<Tabs>` since the tab heading can NOT be customized using `<CodeTabs>`. 

![image](https://user-images.githubusercontent.com/7660718/215544535-f281e4aa-bcc2-4ad2-929f-ae7ce6fbbff8.png)

