### PR TITLE
Replace the Plugin Portal link to point Vault Integrations

### DIFF
--- a/website/content/docs/partnerships.mdx
+++ b/website/content/docs/partnerships.mdx
@@ -160,7 +160,7 @@ Once the integration has been verified, the partner is requested to sign the Has
 
 At this stage, it is expected that the integration is fully complete, the necessary documentation has been written, and HashiCorp has reviewed the integration.
 
-For Auth or Secret Engine plugins specifically, once the plugin has been verified by HashiCorp, it is recommended the plugin be hosted on Github so it can more easily be downloaded and installed within Vault. We also encourage partners to list their plugin on the [Vault Integrations](/vault/integrations). This is in addition to the listing of the plugin on the technology partners’ dedicated HashiCorp partner page. To have the plugin listed on the portal page, please do a pull request via the “edit in GitHub” link on the bottom of the page and add the plugin in the partner section.
+For Auth or Secret Engine plugins specifically, once the plugin has been verified by HashiCorp, it is recommended the plugin be hosted on Github so it can more easily be downloaded and installed within Vault. We also encourage partners to list their plugin on the [Vault Integrations](/vault/integrations) page. This is in addition to the listing of the plugin on the technology partners’ dedicated HashiCorp partner page. To have the plugin listed on the portal page, please do a pull request via the “edit in GitHub” link on the bottom of the page and add the plugin in the partner section.
 
 For HCP Vault verifications, the partner will be issued an HCP Vault Verified badge and will have this displayed on their partner page.
 

--- a/website/content/docs/partnerships.mdx
+++ b/website/content/docs/partnerships.mdx
@@ -20,7 +20,7 @@ There are two main types of integrations with Vault. The first is Runtime Integr
 
 The second type is where a partner develops a custom plugin. Vault has a secure [plugin](/vault/docs/plugins) architecture. Vault’s plugins are completely separate, standalone applications that Vault executes and communicates with over RPC. 
 
-Plugins can be broken into two categories, Secrets Engines and Auth Methods. They can be built-in and bundled with the Vault binary, or be external that has to be manually registered. Built-in plugins are developed by HashiCorp, while external plugins can be developed by HashiCorp, technology partners, or the community. There is a curated collection of all plugins, both built-in and external, located on the [Plugin Portal](/vault/docs/plugins/plugin-portal).
+Plugins can be broken into two categories, Secrets Engines and Auth Methods. They can be built-in and bundled with the Vault binary, or be external that has to be manually registered. Built-in plugins are developed by HashiCorp, while external plugins can be developed by HashiCorp, technology partners, or the community. There is a curated collection of all plugins, both built-in and external, located on the [Vault Integrations](/vault/integrations) page.
 
 The diagram below depicts the key Vault integration categories and types.
 
@@ -160,7 +160,7 @@ Once the integration has been verified, the partner is requested to sign the Has
 
 At this stage, it is expected that the integration is fully complete, the necessary documentation has been written, and HashiCorp has reviewed the integration.
 
-For Auth or Secret Engine plugins specifically, once the plugin has been verified by HashiCorp, it is recommended the plugin be hosted on Github so it can more easily be downloaded and installed within Vault. We also encourage partners to list their plugin on the [Vault Plugin Portal](/vault/docs/plugins/plugin-portal). This is in addition to the listing of the plugin on the technology partners’ dedicated HashiCorp partner page. To have the plugin listed on the portal page, please do a pull request via the “edit in GitHub” link on the bottom of the page and add the plugin in the partner section.
+For Auth or Secret Engine plugins specifically, once the plugin has been verified by HashiCorp, it is recommended the plugin be hosted on Github so it can more easily be downloaded and installed within Vault. We also encourage partners to list their plugin on the [Vault Integrations](/vault/integrations). This is in addition to the listing of the plugin on the technology partners’ dedicated HashiCorp partner page. To have the plugin listed on the portal page, please do a pull request via the “edit in GitHub” link on the bottom of the page and add the plugin in the partner section.
 
 For HCP Vault verifications, the partner will be issued an HCP Vault Verified badge and will have this displayed on their partner page.
 

--- a/website/content/docs/plugins/index.mdx
+++ b/website/content/docs/plugins/index.mdx
@@ -42,6 +42,9 @@ plugins can be made to implement [plugin multiplexing](/vault/docs/plugins/plugi
 to improve performance. Plugin multiplexing allows plugin processes to be
 reused across all mounts of a given type.
 
+-> **NOTE:** See the [Vault Integrations](/vault/integrations) page to find a
+curated collection of official, partner, and community Vault plugins. 
+
 ## Plugin Versioning
 
 Vault supports managing, running and upgrading plugins using semantic version

--- a/website/content/docs/plugins/plugin-architecture.mdx
+++ b/website/content/docs/plugins/plugin-architecture.mdx
@@ -16,6 +16,9 @@ It is possible to enable a custom plugin with a name that's identical to a
 built-in plugin. In such a situation, Vault will always choose the custom plugin
 when enabling it.
 
+-> **NOTE:** See the [Vault Integrations](/vault/integrations) page to find a
+curated collection of official, partner, and community Vault plugins.
+
 ## External Plugin Lifecycle
 
 Vault external plugins are long-running processes that remain running once they are

--- a/website/content/docs/plugins/plugin-development.mdx
+++ b/website/content/docs/plugins/plugin-development.mdx
@@ -121,6 +121,6 @@ Other HashiCorp plugin development resources:
 
 ### Plugin Development - Resources - Community
 
-See the [Plugin Portal](/vault/docs/plugins/plugin-portal#community) to find
-Community plugin examples/guides developed by community members. HashiCorp does
-not validate these for correctness.
+See the [Vault Integrations](/vault/integrations) page to find Community
+plugin examples/guides developed by community members. HashiCorp does not
+validate these for correctness.


### PR DESCRIPTION
# Vault Integrations page go live on Jan 31

🎟️ [Asana](https://app.asana.com/0/563192436488770/1203703363879992/f)

This PR replaces the Plugin Portal link to point the new Vault Integrations page. 

