### PR TITLE
Address pki::TestAutoRebuild flakiness

### DIFF
--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -271,7 +271,7 @@ func getCRLNumber(t *testing.T, crl pkix.TBSCertificateList) int {
 	t.Helper()
 
 	for _, extension := range crl.Extensions {
-		if extension.Id.Equal(certutil.CRLNumnberOID) {
+		if extension.Id.Equal(certutil.CRLNumberOID) {
 			bigInt := new(big.Int)
 			leftOver, err := asn1.Unmarshal(extension.Value, &bigInt)
 			require.NoError(t, err, "Failed unmarshalling crl number extension")

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -7,11 +7,15 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
 	"io"
+	"math"
+	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
@@ -260,5 +264,62 @@ func requireSuccessNilResponse(t *testing.T, resp *logical.Response, err error, 
 	if resp != nil {
 		msg := fmt.Sprintf("expected nil response but got: %v", resp)
 		require.Nilf(t, resp, msg, msgAndArgs...)
+	}
+}
+
+func getCRLNumber(t *testing.T, crl pkix.TBSCertificateList) int {
+	t.Helper()
+
+	for _, extension := range crl.Extensions {
+		if extension.Id.Equal(certutil.CRLNumnberOID) {
+			bigInt := new(big.Int)
+			leftOver, err := asn1.Unmarshal(extension.Value, &bigInt)
+			require.NoError(t, err, "Failed unmarshalling crl number extension")
+			require.Empty(t, leftOver, "leftover bytes from unmarshalling crl number extension")
+			require.True(t, bigInt.IsInt64(), "parsed crl number integer is not an int64")
+			require.False(t, math.MaxInt <= bigInt.Int64(), "parsed crl number integer can not fit in an int")
+			return int(bigInt.Int64())
+		}
+	}
+
+	t.Fatalf("failed to find crl number extension")
+	return 0
+}
+
+func getCrlReferenceFromDelta(t *testing.T, crl pkix.TBSCertificateList) int {
+	t.Helper()
+
+	for _, extension := range crl.Extensions {
+		if extension.Id.Equal(certutil.DeltaCRLIndicatorOID) {
+			bigInt := new(big.Int)
+			leftOver, err := asn1.Unmarshal(extension.Value, &bigInt)
+			require.NoError(t, err, "Failed unmarshalling delta crl indicator extension")
+			require.Empty(t, leftOver, "leftover bytes from unmarshalling delta crl indicator extension")
+			require.True(t, bigInt.IsInt64(), "parsed delta crl integer is not an int64")
+			require.False(t, math.MaxInt <= bigInt.Int64(), "parsed delta crl integer can not fit in an int")
+			return int(bigInt.Int64())
+		}
+	}
+
+	t.Fatalf("failed to find delta crl indicator extension")
+	return 0
+}
+
+func waitForUpdatedCrl(t *testing.T, client *api.Client, mountPoint string, lastSeenCRLNumber int,
+	maxWait time.Duration) pkix.TBSCertificateList {
+	t.Helper()
+
+	interruptChan := time.After(maxWait)
+	for {
+		select {
+		case <-interruptChan:
+			t.Fatalf("expected CRL to regenerate after %s", maxWait)
+		default:
+			crl := getCrlCertificateList(t, client, mountPoint)
+			thisCRLNumber := getCRLNumber(t, crl)
+			if thisCRLNumber > lastSeenCRLNumber {
+				return crl
+			}
+		}
 	}
 }

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -306,7 +306,8 @@ func getCrlReferenceFromDelta(t *testing.T, crl pkix.TBSCertificateList) int {
 }
 
 func waitForUpdatedCrl(t *testing.T, client *api.Client, mountPoint string, lastSeenCRLNumber int,
-	maxWait time.Duration) pkix.TBSCertificateList {
+	maxWait time.Duration,
+) pkix.TBSCertificateList {
 	t.Helper()
 
 	interruptChan := time.After(maxWait)

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -78,6 +78,11 @@ var InvSignatureAlgorithmNames = map[x509.SignatureAlgorithm]string{
 	x509.PureEd25519:      "Ed25519",
 }
 
+// OID for RFC 5280 CRL Number extension.
+//
+// > id-ce-cRLNumber OBJECT IDENTIFIER ::= { id-ce 20 }
+var CRLNumnberOID = asn1.ObjectIdentifier([]int{2, 5, 29, 20})
+
 // OID for RFC 5280 Delta CRL Indicator CRL extension.
 //
 // > id-ce-deltaCRLIndicator OBJECT IDENTIFIER ::= { id-ce 27 }

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -81,7 +81,7 @@ var InvSignatureAlgorithmNames = map[x509.SignatureAlgorithm]string{
 // OID for RFC 5280 CRL Number extension.
 //
 // > id-ce-cRLNumber OBJECT IDENTIFIER ::= { id-ce 20 }
-var CRLNumnberOID = asn1.ObjectIdentifier([]int{2, 5, 29, 20})
+var CRLNumberOID = asn1.ObjectIdentifier([]int{2, 5, 29, 20})
 
 // OID for RFC 5280 Delta CRL Indicator CRL extension.
 //


### PR DESCRIPTION
Attempt to address failures as of late within the PKI TestAutoRebuild test. This fix has run through around 4K runs of untilfail while prior to the fix, it would trigger on my laptop after a few hundred runs.

The fix is to wait for a CRL change before progressing to the next step after we change configuration. Prior to this we would be racing against the CRL reloading from the configuration change.