### PR TITLE
Fix command.RunCustom(...) correctly

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -219,13 +219,10 @@ var (
 		"kubernetes": ksr.NewServiceRegistration,
 	}
 
-	initCommandsEnt = func(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {}
+	initCommandsEnt = func(ui, serverCmdUi cli.Ui, runOpts *RunOptions, commands map[string]cli.CommandFactory) {}
 )
 
-// Commands is the mapping of all the available commands.
-var Commands map[string]cli.CommandFactory
-
-func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
+func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.CommandFactory {
 	loginHandlers := map[string]LoginHandler{
 		"alicloud": &credAliCloud.CLIHandler{},
 		"aws":      &credAws.CLIHandler{},
@@ -258,7 +255,7 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 		}
 	}
 
-	Commands = map[string]cli.CommandFactory{
+	commands := map[string]cli.CommandFactory{
 		"agent": func() (cli.Command, error) {
 			return &AgentCommand{
 				BaseCommand: &BaseCommand{
@@ -841,7 +838,8 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 		},
 	}
 
-	initCommandsEnt(ui, serverCmdUi, runOpts)
+	initCommandsEnt(ui, serverCmdUi, runOpts, commands)
+	return commands
 }
 
 // MakeShutdownCh returns a channel that can be used for shutdown

--- a/command/main.go
+++ b/command/main.go
@@ -217,14 +217,14 @@ func RunCustom(args []string, runOpts *RunOptions) int {
 		return 1
 	}
 
-	initCommands(ui, serverCmdUi, runOpts)
+	commands := initCommands(ui, serverCmdUi, runOpts)
 
 	hiddenCommands := []string{"version"}
 
 	cli := &cli.CLI{
 		Name:     "vault",
 		Args:     args,
-		Commands: Commands,
+		Commands: commands,
 		HelpFunc: groupedHelpFunc(
 			cli.BasicHelpFunc("vault"),
 		),

--- a/command/pki_health_check_test.go
+++ b/command/pki_health_check_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestPKIHC_AllGood(t *testing.T) {
+	t.Parallel()
+
 	client, closer := testVaultServer(t)
 	defer closer()
 
@@ -70,6 +72,8 @@ func TestPKIHC_AllGood(t *testing.T) {
 }
 
 func TestPKIHC_AllBad(t *testing.T) {
+	t.Parallel()
+
 	client, closer := testVaultServer(t)
 	defer closer()
 
@@ -130,6 +134,8 @@ func TestPKIHC_AllBad(t *testing.T) {
 }
 
 func TestPKIHC_OnlyIssuer(t *testing.T) {
+	t.Parallel()
+
 	client, closer := testVaultServer(t)
 	defer closer()
 
@@ -152,6 +158,8 @@ func TestPKIHC_OnlyIssuer(t *testing.T) {
 }
 
 func TestPKIHC_NoMount(t *testing.T) {
+	t.Parallel()
+
 	client, closer := testVaultServer(t)
 	defer closer()
 
@@ -166,6 +174,8 @@ func TestPKIHC_NoMount(t *testing.T) {
 }
 
 func TestPKIHC_ExpectedEmptyMount(t *testing.T) {
+	t.Parallel()
+
 	client, closer := testVaultServer(t)
 	defer closer()
 
@@ -186,6 +196,8 @@ func TestPKIHC_ExpectedEmptyMount(t *testing.T) {
 }
 
 func TestPKIHC_NoPerm(t *testing.T) {
+	t.Parallel()
+
 	client, closer := testVaultServer(t)
 	defer closer()
 


### PR DESCRIPTION
When running `initCommands(...)` from multiple tests, they can
race, causing a panic. Test callers needing to set formatting
information must use `RunCustom(...)` instead of directly invoking the
test backend directly. When using `t.Parallel(...)` in these top-level
tests, we thus could race.

This removes the `Commands` global variable, making it a local variable
instead as nothing else appears to use it. We'll update Enterprise to
add in the Enterprise-specific commands to the existing list.

---

Also reverts #18751 to get back some parallelism.

n.b.: because the commands contain embedded copies of `UI`, it isn't possible to put these in a [sync group](https://github.com/hashicorp/vault/pull/18751#issuecomment-1387184409) as each CLI invocation will have different references to the UI.  (Thanks Steve!)