### PR TITLE
core: make fmt on inmem_layer

### DIFF
--- a/vault/cluster/inmem_layer.go
+++ b/vault/cluster/inmem_layer.go
@@ -122,14 +122,14 @@ func (l *InmemLayer) Dial(addr string, timeout time.Duration, tlsConfig *tls.Con
 		panic(fmt.Sprintf("%q attempted to dial itself", l.addr))
 	}
 
-        // This simulates an i/o timeout by sleeping for 20 seconds and returning 
-	// an error when the forceTimeout name is the same as the host we are 
-	// currently connecting to. Useful for checking how gRPC connections react 
+	// This simulates an i/o timeout by sleeping for 20 seconds and returning
+	// an error when the forceTimeout name is the same as the host we are
+	// currently connecting to. Useful for checking how gRPC connections react
 	// with timeouts.
 	if l.forceTimeout == addr {
 		l.logger.Debug("forcing timeout", "addr", addr, "me", l.addr)
-		
-		// gRPC sets a deadline of 20 seconds on the dail attempt, so 
+
+		// gRPC sets a deadline of 20 seconds on the dail attempt, so
 		// matching that here.
 		time.Sleep(time.Second * 20)
 		return nil, deadlineError("i/o timeout")


### PR DESCRIPTION
`make fmt` is failing on the release branches due to my recent change.