### PR TITLE
TestClusterCore's TLSConfig becomes a method and does a Clone

### DIFF
--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -445,7 +445,7 @@ func TestBackend_PermittedDNSDomainsIntermediateCA(t *testing.T) {
 	}
 
 	// Create a new api client with the desired TLS configuration
-	newClient := getAPIClient(cores[0].Listeners[0].Address.Port, cores[0].TLSConfig)
+	newClient := getAPIClient(cores[0].Listeners[0].Address.Port, cores[0].TLSConfig())
 
 	secret, err = newClient.Logical().Write("auth/cert/login", map[string]interface{}{
 		"name": "myvault-dot-com",
@@ -595,7 +595,7 @@ path "kv/ext/{{identity.entity.aliases.%s.metadata.2-1-1-1}}" {
 	}
 
 	// Create a new api client with the desired TLS configuration
-	newClient := getAPIClient(cores[0].Listeners[0].Address.Port, cores[0].TLSConfig)
+	newClient := getAPIClient(cores[0].Listeners[0].Address.Port, cores[0].TLSConfig())
 
 	var secret *api.Secret
 

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -462,7 +462,7 @@ func RaftClusterJoinNodes(t testing.T, cluster *vault.TestCluster) {
 	leaderInfos := []*raft.LeaderJoinInfo{
 		{
 			LeaderAPIAddr: leader.Client.Address(),
-			TLSConfig:     leader.TLSConfig,
+			TLSConfig:     leader.TLSConfig(),
 		},
 	}
 

--- a/http/forwarding_bench_test.go
+++ b/http/forwarding_bench_test.go
@@ -45,7 +45,7 @@ func BenchmarkHTTP_Forwarding_Stress(b *testing.B) {
 	host := fmt.Sprintf("https://127.0.0.1:%d/v1/transit/", cores[0].Listeners[0].Address.Port)
 
 	transport := &http.Transport{
-		TLSClientConfig: cores[0].TLSConfig,
+		TLSClientConfig: cores[0].TLSConfig(),
 	}
 	if err := http2.ConfigureTransport(transport); err != nil {
 		b.Fatal(err)

--- a/http/forwarding_test.go
+++ b/http/forwarding_test.go
@@ -53,7 +53,7 @@ func TestHTTP_Fallback_Bad_Address(t *testing.T) {
 	for _, addr := range addrs {
 		config := api.DefaultConfig()
 		config.Address = addr
-		config.HttpClient.Transport.(*http.Transport).TLSClientConfig = cores[0].TLSConfig
+		config.HttpClient.Transport.(*http.Transport).TLSClientConfig = cores[0].TLSConfig()
 
 		client, err := api.NewClient(config)
 		if err != nil {
@@ -101,7 +101,7 @@ func TestHTTP_Fallback_Disabled(t *testing.T) {
 	for _, addr := range addrs {
 		config := api.DefaultConfig()
 		config.Address = addr
-		config.HttpClient.Transport.(*http.Transport).TLSClientConfig = cores[0].TLSConfig
+		config.HttpClient.Transport.(*http.Transport).TLSClientConfig = cores[0].TLSConfig()
 
 		client, err := api.NewClient(config)
 		if err != nil {
@@ -161,7 +161,7 @@ func testHTTP_Forwarding_Stress_Common(t *testing.T, parallel bool, num uint32) 
 	}
 
 	transport := &http.Transport{
-		TLSClientConfig: cores[0].TLSConfig,
+		TLSClientConfig: cores[0].TLSConfig(),
 	}
 	if err := http2.ConfigureTransport(transport); err != nil {
 		t.Fatal(err)
@@ -459,7 +459,7 @@ func TestHTTP_Forwarding_ClientTLS(t *testing.T) {
 	vault.TestWaitActive(t, core)
 
 	transport := cleanhttp.DefaultTransport()
-	transport.TLSClientConfig = cores[0].TLSConfig
+	transport.TLSClientConfig = cores[0].TLSConfig()
 	if err := http2.ConfigureTransport(transport); err != nil {
 		t.Fatal(err)
 	}
@@ -511,7 +511,7 @@ func TestHTTP_Forwarding_ClientTLS(t *testing.T) {
 		// be to a different address
 		transport = cleanhttp.DefaultTransport()
 		// i starts at zero but cores in addrs start at 1
-		transport.TLSClientConfig = cores[i+1].TLSConfig
+		transport.TLSClientConfig = cores[i+1].TLSConfig()
 		if err := http2.ConfigureTransport(transport); err != nil {
 			t.Fatal(err)
 		}

--- a/vault/external_tests/api/feature_flag_ext_test.go
+++ b/vault/external_tests/api/feature_flag_ext_test.go
@@ -28,7 +28,7 @@ func TestFeatureFlags(t *testing.T) {
 	// Create a raw http connection copying the configuration
 	// created by NewTestCluster
 	transport := cleanhttp.DefaultPooledTransport()
-	transport.TLSClientConfig = cluster.Cores[0].TLSConfig.Clone()
+	transport.TLSClientConfig = cluster.Cores[0].TLSConfig()
 	if err := http2.ConfigureTransport(transport); err != nil {
 		t.Fatal(err)
 	}

--- a/vault/external_tests/pprof/pprof_test.go
+++ b/vault/external_tests/pprof/pprof_test.go
@@ -30,7 +30,7 @@ func TestSysPprof(t *testing.T) {
 	client := cluster.Cores[0].Client
 
 	transport := cleanhttp.DefaultPooledTransport()
-	transport.TLSClientConfig = cluster.Cores[0].TLSConfig.Clone()
+	transport.TLSClientConfig = cluster.Cores[0].TLSConfig()
 	if err := http2.ConfigureTransport(transport); err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func TestSysPprof_MaxRequestDuration(t *testing.T) {
 	client := cluster.Cores[0].Client
 
 	transport := cleanhttp.DefaultPooledTransport()
-	transport.TLSClientConfig = cluster.Cores[0].TLSConfig.Clone()
+	transport.TLSClientConfig = cluster.Cores[0].TLSConfig()
 	if err := http2.ConfigureTransport(transport); err != nil {
 		t.Fatal(err)
 	}

--- a/vault/external_tests/raft/raft_autopilot_test.go
+++ b/vault/external_tests/raft/raft_autopilot_test.go
@@ -405,7 +405,7 @@ func join(t *testing.T, core *vault.TestClusterCore, client *api.Client, cluster
 	_, err := core.JoinRaftCluster(namespace.RootContext(context.Background()), []*raft.LeaderJoinInfo{
 		{
 			LeaderAPIAddr: client.Address(),
-			TLSConfig:     cluster.Cores[0].TLSConfig,
+			TLSConfig:     cluster.Cores[0].TLSConfig(),
 			Retry:         true,
 		},
 	}, false)

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -172,7 +172,7 @@ func TestRaft_RetryAutoJoin(t *testing.T) {
 	leaderInfos := []*raft.LeaderJoinInfo{
 		{
 			AutoJoin:  "provider=aws region=eu-west-1 tag_key=consul tag_value=tag access_key_id=a secret_access_key=a",
-			TLSConfig: leaderCore.TLSConfig,
+			TLSConfig: leaderCore.TLSConfig(),
 			Retry:     true,
 		},
 	}
@@ -218,7 +218,7 @@ func TestRaft_Retry_Join(t *testing.T) {
 	leaderInfos := []*raft.LeaderJoinInfo{
 		{
 			LeaderAPIAddr: leaderAPI,
-			TLSConfig:     leaderCore.TLSConfig,
+			TLSConfig:     leaderCore.TLSConfig(),
 			Retry:         true,
 		},
 	}
@@ -676,7 +676,7 @@ func TestRaft_SnapshotAPI_RekeyRotate_Backward(t *testing.T) {
 			}
 
 			transport := cleanhttp.DefaultPooledTransport()
-			transport.TLSClientConfig = cluster.Cores[0].TLSConfig.Clone()
+			transport.TLSClientConfig = cluster.Cores[0].TLSConfig()
 			if err := http2.ConfigureTransport(transport); err != nil {
 				t.Fatal(err)
 			}
@@ -877,7 +877,7 @@ func TestRaft_SnapshotAPI_RekeyRotate_Forward(t *testing.T) {
 			}
 
 			transport := cleanhttp.DefaultPooledTransport()
-			transport.TLSClientConfig = cluster.Cores[0].TLSConfig.Clone()
+			transport.TLSClientConfig = cluster.Cores[0].TLSConfig()
 			if err := http2.ConfigureTransport(transport); err != nil {
 				t.Fatal(err)
 			}
@@ -1064,7 +1064,7 @@ func TestRaft_SnapshotAPI_DifferentCluster(t *testing.T) {
 	}
 
 	transport := cleanhttp.DefaultPooledTransport()
-	transport.TLSClientConfig = cluster.Cores[0].TLSConfig.Clone()
+	transport.TLSClientConfig = cluster.Cores[0].TLSConfig()
 	if err := http2.ConfigureTransport(transport); err != nil {
 		t.Fatal(err)
 	}
@@ -1100,7 +1100,7 @@ func TestRaft_SnapshotAPI_DifferentCluster(t *testing.T) {
 		leaderClient := cluster2.Cores[0].Client
 
 		transport := cleanhttp.DefaultPooledTransport()
-		transport.TLSClientConfig = cluster2.Cores[0].TLSConfig.Clone()
+		transport.TLSClientConfig = cluster2.Cores[0].TLSConfig()
 		if err := http2.ConfigureTransport(transport); err != nil {
 			t.Fatal(err)
 		}

--- a/vault/external_tests/sealmigration/testshared.go
+++ b/vault/external_tests/sealmigration/testshared.go
@@ -894,7 +894,7 @@ func joinRaftFollowers(t *testing.T, cluster *vault.TestCluster, useStoredKeys b
 	leaderInfos := []*raft.LeaderJoinInfo{
 		{
 			LeaderAPIAddr: leader.Client.Address(),
-			TLSConfig:     leader.TLSConfig,
+			TLSConfig:     leader.TLSConfig(),
 		},
 	}
 

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1129,6 +1129,10 @@ func (c *TestClusterCore) TriggerRollbacks() {
 	c.rollback.triggerRollbacks()
 }
 
+func (c *TestClusterCore) TLSConfig() *tls.Config {
+	return c.tlsConfig.Clone()
+}
+
 func (c *TestCluster) Cleanup() {
 	c.Logger.Info("cleaning up vault cluster")
 	if tl, ok := c.Logger.(*TestLogger); ok {
@@ -1207,7 +1211,7 @@ type TestClusterCore struct {
 	ServerCertPEM        []byte
 	ServerKey            *ecdsa.PrivateKey
 	ServerKeyPEM         []byte
-	TLSConfig            *tls.Config
+	tlsConfig            *tls.Config
 	UnderlyingStorage    physical.Backend
 	UnderlyingRawStorage physical.Backend
 	UnderlyingHAStorage  physical.HABackend
@@ -1826,7 +1830,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 			Listeners:            listeners[i],
 			Handler:              handlers[i],
 			Server:               servers[i],
-			TLSConfig:            tlsConfigs[i],
+			tlsConfig:            tlsConfigs[i],
 			Barrier:              cores[i].barrier,
 			NodeID:               fmt.Sprintf("core-%d", i),
 			UnderlyingRawStorage: coreConfigs[i].Physical,
@@ -1924,7 +1928,7 @@ func (cluster *TestCluster) StartCore(t testing.T, idx int, opts *TestClusterOpt
 	}
 	tcc.Listeners = []*TestListener{
 		{
-			Listener: tls.NewListener(ln, tcc.TLSConfig),
+			Listener: tls.NewListener(ln, tcc.tlsConfig),
 			Address:  ln.Addr().(*net.TCPAddr),
 		},
 	}
@@ -1951,7 +1955,7 @@ func (cluster *TestCluster) StartCore(t testing.T, idx int, opts *TestClusterOpt
 		t, idx, newCore, tcc.CoreConfig,
 		opts, tcc.Listeners, tcc.Handler)
 
-	tcc.Client = cluster.getAPIClient(t, opts, tcc.Listeners[0].Address.Port, tcc.TLSConfig)
+	tcc.Client = cluster.getAPIClient(t, opts, tcc.Listeners[0].Address.Port, tcc.tlsConfig)
 
 	testAdjustUnderlyingStorage(tcc)
 	testExtraTestCoreSetup(t, cluster.LicensePrivateKey, tcc)


### PR DESCRIPTION
This rather trivial PR was factored out from a larger one to make that one less noisy.  It's not changing much, other than making the TLSConfig for a test cluster node be cloned in some cases where it wasn't before.