### PR TITLE
Update consul-template language reference link in docs

### DIFF
--- a/website/content/docs/agent/template.mdx
+++ b/website/content/docs/agent/template.mdx
@@ -316,4 +316,4 @@ template {
 }
 ```
 
-[consul-templating-language]: https://github.com/hashicorp/consul-template/blob/v0.28.1/docs/templating-language.md
+[consul-templating-language]: https://github.com/hashicorp/consul-template/blob/v0.29.5/docs/templating-language.md


### PR DESCRIPTION
Update the docs link to the consul-template version used by Vault instead of an older one.