### PR TITLE
VAULT-13056 fix leasecache usage, add test coverage

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -729,7 +729,12 @@ func (c *AgentCommand) Run(args []string) int {
 			proxyVaultToken = !config.APIProxy.ForceAutoAuthToken
 		}
 
-		muxHandler := cache.ProxyHandler(ctx, apiProxyLogger, apiProxy, inmemSink, proxyVaultToken)
+		var muxHandler http.Handler
+		if leaseCache != nil {
+			muxHandler = cache.ProxyHandler(ctx, apiProxyLogger, leaseCache, inmemSink, proxyVaultToken)
+		} else {
+			muxHandler = cache.ProxyHandler(ctx, apiProxyLogger, apiProxy, inmemSink, proxyVaultToken)
+		}
 
 		// Parse 'require_request_header' listener config option, and wrap
 		// the request handler if necessary


### PR DESCRIPTION
Tagging this as no changelog, as the bug hasn't been released yet. Happy to revise that, but it makes sense to me not to include one, here (there is no 'change' from a previous version).

This was an issue with leaseCache not being used even when it was non-nil. I added a test that fails if this bug is present again, and naturally, it passes now that the fix is in, which also fills in a previous gap in our test coverage!