### PR TITLE
prevent panic on mfa enforcement delete after a namespace is deleted

### DIFF
--- a/changelog/18923.txt
+++ b/changelog/18923.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: prevent panic in login mfa enforcement delete after enforcement's namespace is deleted
+```

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -2700,6 +2700,10 @@ func (b *LoginMFABackend) deleteMFALoginEnforcementConfigByNameAndNamespace(ctx 
 		return err
 	}
 
+	if eConfig == nil {
+		return nil
+	}
+
 	entryIndex := mfaLoginEnforcementPrefix + eConfig.ID
 	barrierView, err := b.Core.barrierViewForNamespace(eConfig.NamespaceID)
 	if err != nil {


### PR DESCRIPTION
Addresses: https://github.com/hashicorp/vault/issues/18849