### PR TITLE
Change gen_openapi.sh to generate schema with generic mount paths

### DIFF
--- a/changelog/18934.txt
+++ b/changelog/18934.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+openapi: Change gen_openapi.sh to generate schema with generic mount paths
+```

--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -20,7 +20,7 @@ then
     exit 1
 fi
 
-../bin/vault server -dev -dev-root-token-id=root &
+vault server -dev -dev-root-token-id=root &
 sleep 2
 VAULT_PID=$!
 

--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -20,7 +20,7 @@ then
     exit 1
 fi
 
-vault server -dev -dev-root-token-id=root &
+../bin/vault server -dev -dev-root-token-id=root &
 sleep 2
 VAULT_PID=$!
 
@@ -36,7 +36,7 @@ while read -r line; do
         codeLinesStarted=true
     elif [[ $line == *"databasePlugins:"* ]] ; then
         break
-    elif [ $codeLinesStarted = true ] && [[ $line == *"consts.Deprecated"* || $line == *"consts.PendingRemoval"* ]] ; then
+    elif [ $codeLinesStarted = true ] && [[ $line == *"consts.Deprecated"* || $line == *"consts.PendingRemoval"* || $line == *"consts.Removed"* ]] ; then
         auth_plugin_previous=""
     elif [ $codeLinesStarted = true ] && [[ $line =~ ^\s*\"(.*)\"\:.*$ ]] ; then
         auth_plugin_current=${BASH_REMATCH[1]}
@@ -63,7 +63,7 @@ while read -r line; do
         codeLinesStarted=true
     elif [[ $line == *"addExternalPlugins("* ]] ; then
         break
-    elif [ $codeLinesStarted = true ] && [[ $line == *"consts.Deprecated"* || $line == *"consts.PendingRemoval"* ]] ; then
+    elif [ $codeLinesStarted = true ] && [[ $line == *"consts.Deprecated"* || $line == *"consts.PendingRemoval"* || $line == *"consts.Removed"* ]] ; then
         secrets_plugin_previous=""
     elif [ $codeLinesStarted = true ] && [[ $line =~ ^\s*\"(.*)\"\:.*$ ]] ; then
         secrets_plugin_current=${BASH_REMATCH[1]}
@@ -94,7 +94,7 @@ if [ -f $entRegFile ] && [[ -n "${VAULT_LICENSE}" ]]; then
             codeLinesStarted=true
         elif [[ $line == *"addExtPluginsEntImpl("* ]] ; then
             break
-        elif [ $codeLinesStarted = true ] && [[ $line == *"consts.Deprecated"* || $line == *"consts.PendingRemoval"* ]] ; then
+        elif [ $codeLinesStarted = true ] && [[ $line == *"consts.Deprecated"* || $line == *"consts.PendingRemoval"* || $line == *"consts.Removed"* ]] ; then
             secrets_plugin_previous=""
         elif [ $codeLinesStarted = true ] && [[ $line =~ ^\s*\"(.*)\"\:.*$ ]] ; then
             ent_plugin_current=${BASH_REMATCH[1]}
@@ -116,9 +116,13 @@ fi
 
 # Output OpenAPI, optionally formatted
 if [ "$1" == "-p" ]; then
-  curl -H "X-Vault-Token: root" "http://127.0.0.1:8200/v1/sys/internal/specs/openapi" | jq > openapi.json
+    curl --header 'X-Vault-Token: root' \
+         --data '{"generic_mount_paths": true}' \
+            'http://127.0.0.1:8200/v1/sys/internal/specs/openapi' | jq > openapi.json
 else
-  curl -H "X-Vault-Token: root" "http://127.0.0.1:8200/v1/sys/internal/specs/openapi" > openapi.json
+    curl --header 'X-Vault-Token: root' \
+         --data '{"generic_mount_paths": true}' \
+            'http://127.0.0.1:8200/v1/sys/internal/specs/openapi' > openapi.json
 fi
 
 kill $VAULT_PID


### PR DESCRIPTION
`gen_openapi.sh` is a script used to generate `OpenAPI` schema for all built-in plugins. The resultant `openapi.json` schema is then used for client library generation.

This pull request fixes a couple issues:
- The script will now ignore plugins marked as "Removed" (these were causing script failures)
- The will now generate schema with `generic_mount_paths` set to true, inserting `/{thing_mount_path}/` elements into the paths for certain plugins. This was the default behavior before https://github.com/hashicorp/vault/pull/18617. We are now re-enabling the behavior but specifically for the schemas generated using this script.