### PR TITLE
openapi: Add default values to the thing_mount_path parameters

### DIFF
--- a/changelog/18935.txt
+++ b/changelog/18935.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+openapi: Add default values to thing_mount_path parameters
+```

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -910,6 +910,9 @@ func (d *OASDocument) CreateOperationIDs(context string) {
 				continue
 			}
 
+			// Discard "_mount_path" from any {thing_mount_path} parameters
+			path = strings.Replace(path, "_mount_path", "", 1)
+
 			// Space-split on non-words, title case everything, recombine
 			opID := nonWordRe.ReplaceAllString(strings.ToLower(path), " ")
 			opID = strings.Title(opID)

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4606,9 +4606,10 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 						Description: "Path that the backend was mounted at",
 						In:          "path",
 						Schema: &framework.OASSchema{
-							Type: "string",
+							Type:    "string",
+							Default: mountPathParameterName,
 						},
-						Required: true,
+						Required: false,
 					})
 				}
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4607,7 +4607,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 						In:          "path",
 						Schema: &framework.OASSchema{
 							Type:    "string",
-							Default: mountPathParameterName,
+							Default: strings.TrimRight(mount, "/"),
 						},
 						Required: false,
 					})


### PR DESCRIPTION
For `generic_mount_path=true` passed to the openapi endpoint, the following changes will be applied in the `openapi.json` for each _mount_path parameter. These changes are needed for proper library code generation.

```diff
        {
          "name": "alicloud_mount_path",
          "description": "Path that the backend was mounted at",
          "in": "path",
          "schema": {
            "type": "string",
++          "default": "alicloud"
          },
--        "required": true
        }
        "post": {
++        "operationId": "postAuthAlicloudLogin",
--        "operationId": "postAuthAlicloud_mount_pathLogin",
```