### PR TITLE
secrets/azure: changes permission recommendation to be minimally permissive

### DIFF
--- a/website/content/api-docs/secret/azure.mdx
+++ b/website/content/api-docs/secret/azure.mdx
@@ -36,38 +36,6 @@ service principals. Environment variables will override any parameters set in th
   environment variable. If not specified, Vault will use Azure Public Cloud.
 - `password_policy` `(string: "")` - Specifies a [password policy](/vault/docs/concepts/password-policies) to
   use when creating dynamic credentials. Defaults to generating an alphanumeric password if not set.
-- `use_microsoft_graph_api` `(bool: true)` - Indicates whether the secrets engine should use the
-  [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/use-the-api).
-
-  If set to true, the user specified via the `client_id` and `client_secret` will need to have the following permissions
-  under the **Microsoft Graph API**:
-
-| Permission Name               | Type        |
-| ----------------------------- | ----------- |
-| Application.Read.All          | Application |
-| Application.ReadWrite.All     | Application |
-| Application.ReadWrite.OwnedBy | Application |
-| Directory.Read.All            | Application |
-| Directory.ReadWrite.All       | Application |
-| Group.Read.All                | Application |
-| Group.ReadWrite.All           | Application |
-| GroupMember.Read.All          | Application |
-| GroupMember.ReadWrite.All     | Application |
-
-| Permission Name            | Type      |
-| -------------------------- | --------- |
-| Application.Read.All       | Delegated |
-| Application.ReadWrite.All  | Delegated |
-| Directory.AccessAsUser.All | Delegated |
-| Directory.Read.All         | Delegated |
-| Directory.ReadWrite.All    | Delegated |
-| Group.Read.All             | Delegated |
-| Group.ReadWrite.All        | Delegated |
-| GroupMember.Read.All       | Delegated |
-| GroupMember.ReadWrite.All  | Delegated |
-
-Aside from the permissions listed above, setting this to true should be transparent to users.
-
 - `root_password_ttl` `(string: 182d)` - Specifies how long the root password is valid for in Azure when
   rotate-root generates a new client secret. Uses [duration format strings](/vault/docs/concepts/duration-format).
 
@@ -81,7 +49,6 @@ Aside from the permissions listed above, setting this to true should be transpar
   "client_secret": "9a6346...",
   "environment": "AzureGermanCloud",
   "password_policy": "azure_policy",
-  "use_microsoft_graph_api": true,
   "root_password_ttl": "48d"
 }
 ```

--- a/website/content/docs/secrets/azure.mdx
+++ b/website/content/docs/secrets/azure.mdx
@@ -21,11 +21,6 @@ If an existing service principal is specified as part of the role configuration,
 a new password will be dynamically generated instead of a new service principal.
 The password will be deleted when the lease is revoked.
 
-~> Microsoft is shutting down their Azure Active Directory API and will be retiring it in 2022. If you are currently using this secret engine, you will need to update the
-credentials to include Microsoft Graph API permissions and specify the
-`use_microsoft_graph_api` configuration value as true. See the
-[API Docs](/vault/api-docs/secret/azure#use_microsoft_graph_api) for more details.
-
 ## Setup
 
 Most secrets engines must be configured in advance before they can perform their
@@ -49,8 +44,7 @@ management tool.
        subscription_id=$AZURE_SUBSCRIPTION_ID \
        tenant_id=$AZURE_TENANT_ID \
        client_id=$AZURE_CLIENT_ID \
-       client_secret=$AZURE_CLIENT_SECRET \
-       use_microsoft_graph_api=true
+       client_secret=$AZURE_CLIENT_SECRET
 
    Success! Data written to: azure/config
    ```
@@ -174,7 +168,7 @@ $ cat az_roles.json
 $ cat az_groups.json
 [
   {
-    "group_name": "foo",
+    "group_name": "foo"
   },
   {
     "group_name": "This won't matter as it will be overwritten",
@@ -184,10 +178,11 @@ $ cat az_groups.json
 ```
 
 ### Permanently Delete Azure Objects
+
 If dynamic service principals are used, the option to permanently delete the applications and service principals created by Vault may be configured on the Vault role.
 When this option is enabled and a lease is expired or revoked, the application and service principal associated with the lease will be [permanently deleted](https://docs.microsoft.com/en-us/graph/api/directory-deleteditems-delete) from the Azure Active Directory.
 As a result, these objects will not count toward the [quota](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#active-directory-limits) of total resources in an Azure tenant. When this option is not enabled
-and a lease is expired or revoked, the application and service principal associated with the lease will be deleted, but not permanently. These objects will be available to restore for 30 days from deletion. 
+and a lease is expired or revoked, the application and service principal associated with the lease will be deleted, but not permanently. These objects will be available to restore for 30 days from deletion.
 
 Example of role configuration:
 
@@ -205,74 +200,34 @@ EOF
 ## Authentication
 
 The Azure secrets backend must have sufficient permissions to read Azure role information and manage
-service principals. The authentication parameters can be set in the backend configuration or as environment variables. Environment variables will take precedence.
-The individual parameters are described in the [configuration][config] section of the API docs.
+service principals. The authentication parameters can be set in the backend configuration or as environment
+variables. Environment variables will take precedence. The individual parameters are described in the
+[configuration][config] section of the API docs.
 
 If the client ID or secret are not present and Vault is running on an Azure VM, Vault will attempt to use
-[Managed Service Identity (MSI)](https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview) to access Azure. Note that when MSI is used, tenant and subscription IDs must still be explicitly provided in the configuration or environment variables.
+[Managed Service Identity (MSI)](https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview)
+to access Azure. Note that when MSI is used, tenant and subscription IDs must still be explicitly provided
+in the configuration or environment variables.
 
-### MS Graph Permissions
+### MS Graph API Permissions
 
-The following Azure permissions should be assigned to the service principal provided to Vault for managing Azure:
+The following MS Graph [API permissions](https://learn.microsoft.com/en-us/azure/active-directory/develop/permissions-consent-overview#types-of-permissions)
+must be assigned to the service principal provided to Vault for managing Azure:
 
 | Permission Name               | Type        |
 | ----------------------------- | ----------- |
-| Application.Read.All          | Application |
 | Application.ReadWrite.All     | Application |
-| Application.ReadWrite.OwnedBy | Application |
-| Directory.Read.All            | Application |
-| Directory.ReadWrite.All       | Application |
-| Group.Read.All                | Application |
 | Group.ReadWrite.All           | Application |
-| GroupMember.Read.All          | Application |
-| GroupMember.ReadWrite.All     | Application |
 
-| Permission Name            | Type      |
-| -------------------------- | --------- |
-| Application.Read.All       | Delegated |
-| Application.ReadWrite.All  | Delegated |
-| Directory.AccessAsUser.All | Delegated |
-| Directory.Read.All         | Delegated |
-| Directory.ReadWrite.All    | Delegated |
-| Group.Read.All             | Delegated |
-| Group.ReadWrite.All        | Delegated |
-| GroupMember.Read.All       | Delegated |
-| GroupMember.ReadWrite.All  | Delegated |
+### Role Assignments
 
-Additionally the following IAM roles are required and need to be added to the service
-principal using the Azure portal:
+The following Azure [role assignments](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli)
+must be granted in order for the secrets engine to manage role assignments for service
+principles it creates.
 
-- "Owner" role
-
-### Migrating From AAD To Microsoft Graph
-
-In this example we will migrate the Azure secret engine from using Azure Active Directory
-(AAD) to Microsoft Graph.
-
-First, create a new service principal [with the proper permissions](/vault/docs/secrets/azure#authentication)
-for managing Azure accounts. After granting the appropriate permissions, the following will be needed
-from the service principal to configure the secret engine:
-
-1. Application (client) ID
-1. Directory (tenant) ID
-1. Client Secret
-1. Subscription ID
-
-Finally, the Azure secret engine configuration can be updated with the new values:
-
-```shell
-TENANT_ID='<Directory (Tenant) ID Here>'
-CLIENT_ID='Application (Client) ID Here>'
-CLIENT_SECRET='<Client Secret Here>'
-SUBSCRIPTION_ID='<Subcription ID Here>'
-
-vault write azure/config \
-        subscription_id=$SUBSCRIPTION_ID  \
-        client_id=$CLIENT_ID \
-        client_secret=$CLIENT_SECRET \
-        tenant_id=$TENANT_ID \
-        use_microsoft_graph_api=true
-```
+| Role  | Scope        | Security Principal                          |
+| ----- | ------------ | ------------------------------------------- |
+| Owner | Subscription | Service Principal ID given in configuration |
 
 ## Choosing between dynamic or existing service principals
 


### PR DESCRIPTION
This PR updates the Azure secrets engine docs to recommend permissions that are minimally permissive. The current list provides API permissions that aren't needed. I've tested that these permissions work using the Azure secrets engine (see related PR at https://github.com/hashicorp/vault-plugin-secrets-azure/pull/125).

Additionally, this removes documentation for the `use_microsoft_graph_api` parameter. We removed the parameter and fully switch over to MS graph in Vault 1.12. With versioned docs in place, I think it's safe to remove this now.