### PR TITLE
Fix race accessing b.crls within cert auth

### DIFF
--- a/builtin/credential/cert/backend.go
+++ b/builtin/credential/cert/backend.go
@@ -43,7 +43,7 @@ func Backend() *backend {
 			pathListCRLs(&b),
 			pathCRLs(&b),
 		},
-		AuthRenew:      b.pathLoginRenew,
+		AuthRenew:      b.loginPathWrapper(b.pathLoginRenew),
 		Invalidate:     b.invalidate,
 		BackendType:    logical.TypeCredential,
 		InitializeFunc: b.initialize,
@@ -101,12 +101,12 @@ func (b *backend) initOCSPClient(cacheSize int) {
 	}, cacheSize)
 }
 
-func (b *backend) updatedConfig(config *config) error {
+func (b *backend) updatedConfig(config *config) {
 	b.ocspClientMutex.Lock()
 	defer b.ocspClientMutex.Unlock()
 	b.initOCSPClient(config.OcspCacheSize)
 	b.configUpdated.Store(false)
-	return nil
+	return
 }
 
 func (b *backend) fetchCRL(ctx context.Context, storage logical.Storage, name string, crl *CRLInfo) error {

--- a/builtin/credential/cert/path_crls.go
+++ b/builtin/credential/cert/path_crls.go
@@ -71,6 +71,16 @@ using the same name as specified here.`,
 	}
 }
 
+func (b *backend) populateCrlsIfNil(ctx context.Context, storage logical.Storage) error {
+	b.crlUpdateMutex.RLock()
+	if b.crls == nil {
+		b.crlUpdateMutex.RUnlock()
+		return b.lockThenpopulateCRLs(ctx, storage)
+	}
+	b.crlUpdateMutex.RUnlock()
+	return nil
+}
+
 func (b *backend) lockThenpopulateCRLs(ctx context.Context, storage logical.Storage) error {
 	b.crlUpdateMutex.Lock()
 	defer b.crlUpdateMutex.Unlock()

--- a/builtin/credential/cert/path_crls_test.go
+++ b/builtin/credential/cert/path_crls_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"fmt"
 	"io/ioutil"
 	"math/big"
 	"net/http"
@@ -13,6 +14,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
@@ -162,7 +165,7 @@ func TestCRLFetch(t *testing.T) {
 
 	b.crlUpdateMutex.Lock()
 	if len(b.crls["testcrl"].Serials) != 1 {
-		t.Fatalf("wrong number of certs in CRL")
+		t.Fatalf("wrong number of certs in CRL got %d, expected 1", len(b.crls["testcrl"].Serials))
 	}
 	b.crlUpdateMutex.Unlock()
 
@@ -188,11 +191,14 @@ func TestCRLFetch(t *testing.T) {
 
 	// Give ourselves a little extra room on slower CI systems to ensure we
 	// can fetch the new CRL.
-	time.Sleep(150 * time.Millisecond)
+	corehelpers.RetryUntil(t, 2*time.Second, func() error {
+		b.crlUpdateMutex.Lock()
+		defer b.crlUpdateMutex.Unlock()
 
-	b.crlUpdateMutex.Lock()
-	if len(b.crls["testcrl"].Serials) != 2 {
-		t.Fatalf("wrong number of certs in CRL")
-	}
-	b.crlUpdateMutex.Unlock()
+		serialCount := len(b.crls["testcrl"].Serials)
+		if serialCount != 2 {
+			return fmt.Errorf("CRL refresh did not occur serial count %d", serialCount)
+		}
+		return nil
+	})
 }

--- a/changelog/18945.txt
+++ b/changelog/18945.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/cert: Address a race condition accessing the loaded crls without a lock
+```


### PR DESCRIPTION
 - Discovered by CircleCI the pathLogin, pathLoginRenew paths access and reload the b.crls member variable without a lock.
 - Also discovered that pathLoginResolveRole never populated an empty b.crls before usage within b.verifyCredentials

```
=== RUN   TestCRLFetch
==================
WARNING: DATA RACE
Write at 0x00c0031af8c0 by goroutine 12215:
  github.com/hashicorp/vault/builtin/credential/cert.(*backend).populateCRLs()
      /home/circleci/go/src/github.com/hashicorp/vault/builtin/credential/cert/path_crls.go:85 +0xa5
  github.com/hashicorp/vault/builtin/credential/cert.(*backend).pathLogin()
      /home/circleci/go/src/github.com/hashicorp/vault/builtin/credential/cert/path_login.go:95 +0x145
  github.com/hashicorp/vault/builtin/credential/cert.TestCRLFetch()
      /home/circleci/go/src/github.com/hashicorp/vault/builtin/credential/cert/path_crls_test.go:123 +0x16f2
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Previous read at 0x00c0031af8c0 by goroutine 12216:
  github.com/hashicorp/vault/builtin/credential/cert.(*backend).updateCRLs()
      /home/circleci/go/src/github.com/hashicorp/vault/builtin/credential/cert/backend.go:136 +0xf7
  github.com/hashicorp/vault/builtin/credential/cert.(*backend).updateCRLs-fm()
      <autogenerated>:1 +0x64
  github.com/hashicorp/vault/builtin/credential/cert.TestCRLFetch.func1()
      /home/circleci/go/src/github.com/hashicorp/vault/builtin/credential/cert/path_crls_test.go:42 +0x1e6
```
