### PR TITLE
Add support for missing attributes in PKI UI

### DIFF
--- a/ui/app/utils/parse-pki-cert-oids.js
+++ b/ui/app/utils/parse-pki-cert-oids.js
@@ -17,7 +17,6 @@ export const EXTENSION_OIDs = {
   subject_alt_name: '2.5.29.17', // contains SAN_TYPES below
   basic_constraints: '2.5.29.19', // contains max_path_length
   name_constraints: '2.5.29.30', // contains permitted_dns_domains
-  ext_key_usage: '2.5.29.37', // contains EXT_KEY_USAGE_OIDs OIDs below
 };
 
 // these are allowed ext oids, but not parsed and passed to cross-signed certs
@@ -70,16 +69,3 @@ export const KEY_USAGE_BITS = [
   'EncipherOnly',
   'DecipherOnly',
 ];
-
-export const EXT_KEY_USAGE_OIDs = {
-  '2.5.29.37.0': 'Any',
-  '1.3.6.1.5.5.7.3.1': 'ServerAuth',
-  '1.3.6.1.5.5.7.3.2': 'ClientAuth',
-  '1.3.6.1.5.5.7.3.3': 'CodeSigning',
-  '1.3.6.1.5.5.7.3.4': 'EmailProtection',
-  '1.3.6.1.5.5.7.3.5': 'IPSECEndSystem',
-  '1.3.6.1.5.5.7.3.6': 'IPSECTunnel',
-  '1.3.6.1.5.5.7.3.7': 'IPSECUser',
-  '1.3.6.1.5.5.7.3.8': 'TimeStamping',
-  '1.3.6.1.5.5.7.3.9': 'OCSPSigning',
-};

--- a/ui/app/utils/parse-pki-cert-oids.js
+++ b/ui/app/utils/parse-pki-cert-oids.js
@@ -59,6 +59,18 @@ export const SIGNATURE_ALGORITHM_OIDs = {
   '1.3.101.112': '0', // Ed25519
 };
 
+export const KEY_USAGE_BITS = [
+  'DigitalSignature',
+  'ContentCommitment',
+  'KeyEncipherment',
+  'DataEncipherment',
+  'KeyAgreement',
+  'CertSign',
+  'CRLSign',
+  'EncipherOnly',
+  'DecipherOnly',
+];
+
 export const EXT_KEY_USAGE_OIDs = {
   '2.5.29.37.0': 'Any',
   '1.3.6.1.5.5.7.3.1': 'ServerAuth',

--- a/ui/app/utils/parse-pki-cert-oids.js
+++ b/ui/app/utils/parse-pki-cert-oids.js
@@ -13,10 +13,11 @@ export const SUBJECT_OIDs = {
 };
 
 export const EXTENSION_OIDs = {
-  key_usage: '2.5.29.15',
+  key_usage: '2.5.29.15', // contains keyUsage values
   subject_alt_name: '2.5.29.17', // contains SAN_TYPES below
   basic_constraints: '2.5.29.19', // contains max_path_length
   name_constraints: '2.5.29.30', // contains permitted_dns_domains
+  ext_key_usage: '2.5.29.37', // contains EXT_KEY_USAGE_OIDs OIDs below
 };
 
 // these are allowed ext oids, but not parsed and passed to cross-signed certs
@@ -52,4 +53,17 @@ export const SIGNATURE_ALGORITHM_OIDs = {
   '1.2.840.10045.4.3.3': '384', // ECDSA-SHA384
   '1.2.840.10045.4.3.4': '512', // ECDSA-SHA512
   '1.3.101.112': '0', // Ed25519
+};
+
+export const EXT_KEY_USAGE_OIDs = {
+  '2.5.29.37.0': 'Any',
+  '1.3.6.1.5.5.7.3.1': 'ServerAuth',
+  '1.3.6.1.5.5.7.3.2': 'ClientAuth',
+  '1.3.6.1.5.5.7.3.3': 'CodeSigning',
+  '1.3.6.1.5.5.7.3.4': 'EmailProtection',
+  '1.3.6.1.5.5.7.3.5': 'IPSECEndSystem',
+  '1.3.6.1.5.5.7.3.6': 'IPSECTunnel',
+  '1.3.6.1.5.5.7.3.7': 'IPSECUser',
+  '1.3.6.1.5.5.7.3.8': 'TimeStamping',
+  '1.3.6.1.5.5.7.3.9': 'OCSPSigning',
 };

--- a/ui/app/utils/parse-pki-cert-oids.js
+++ b/ui/app/utils/parse-pki-cert-oids.js
@@ -22,8 +22,12 @@ export const EXTENSION_OIDs = {
 
 // these are allowed ext oids, but not parsed and passed to cross-signed certs
 export const IGNORED_OIDs = {
-  subject_key_identifier: '2.5.29.14',
+  // These two extensions are controlled by the parent authority.
   authority_key_identifier: '2.5.29.35',
+  authority_access_info: '1.3.6.1.5.5.7.1.1',
+  // This extension is based off the key material of the new issuer, which
+  // will automatically match the existing issuer's key material.
+  subject_key_identifier: '2.5.29.14',
 };
 
 // SubjectAltName/GeneralName types (scroll up to page 38 -> https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.7 )

--- a/ui/app/utils/parse-pki-cert.js
+++ b/ui/app/utils/parse-pki-cert.js
@@ -134,8 +134,10 @@ export function parseExtensions(extensions) {
   const values = {};
   const errors = [];
   const allowedOids = Object.values({ ...EXTENSION_OIDs, ...IGNORED_OIDs });
-  if (extensions.any((ext) => !allowedOids.includes(ext.extnID))) {
-    errors.push(new Error('certificate contains unsupported extension OIDs'));
+  const isKnownExtension = (ext) => !allowedOids.includes(ext.extnID);
+  if (extensions.any(isKnownExtension)) {
+    const unknown = extensions.filter(isKnownExtension).map((ext) => ext.extnID);
+    errors.push(new Error('certificate contains unsupported extension OIDs: ' + unknown.join(', ')));
   }
 
   // make each extension its own key/value pair

--- a/ui/app/utils/parse-pki-cert.js
+++ b/ui/app/utils/parse-pki-cert.js
@@ -1,5 +1,5 @@
 import * as asn1js from 'asn1js';
-import { fromBase64, stringToArrayBuffer, arrayBufferToString } from 'pvutils';
+import { fromBase64, stringToArrayBuffer } from 'pvutils';
 import { Certificate } from 'pkijs';
 import { differenceInHours, getUnixTime } from 'date-fns';
 import {
@@ -250,7 +250,7 @@ export function parseExtensions(extensions) {
     // We can thus take our enumeration (KEY_USAGE_BITS), check whether the
     // bits are asserted, and push in our pretty names as appropriate.
     const unused = values.key_usage.valueBlock.unusedBits;
-    const keyUsage = arrayBufferToString(values.key_usage.valueBlock.valueHex);
+    const keyUsage = new Uint8Array(values.key_usage.valueBlock.valueHex);
 
     const computedKeyUsages = [];
     for (const enumIndex in KEY_USAGE_BITS) {
@@ -265,13 +265,13 @@ export function parseExtensions(extensions) {
         break;
       }
 
-      let codePoint = keyUsage.codePointAt(byteIndex); // Handle "unicode"-looking strings.
+      let enumByte = keyUsage[byteIndex];
       const needsAdjust = byteIndex + 1 === keyUsage.length && unused > 0;
       if (needsAdjust) {
-        codePoint = parseInt(codePoint << unused);
+        enumByte = parseInt(enumByte << unused);
       }
 
-      const isSet = (mask & codePoint) === mask;
+      const isSet = (mask & enumByte) === mask;
       if (isSet) {
         computedKeyUsages.push(enumName);
       }

--- a/ui/app/utils/parse-pki-cert.js
+++ b/ui/app/utils/parse-pki-cert.js
@@ -219,7 +219,8 @@ export function parseExtensions(extensions) {
         const ip_addr = ip.join('.');
         parsed_ips.push(ip_addr);
       } else if (ip.length === 16) {
-        const hex = ip.map((value) => '0' + new Number(value).toString(16));
+        const src = new Array(ip);
+        const hex = src.map((value) => '0' + new Number(value).toString(16));
         const trimmed = hex.map((value) => value.substr(value.length - 2, 2));
         const coloned = trimmed.map((index, value) => (index % 2 === 0 ? value : value + ':'));
         const ip_addr = coloned.join('');
@@ -281,10 +282,12 @@ export function parseExtensions(extensions) {
     // generation, but will allow it if it comes in via an externally
     // generated CSR. Validate that key_usage matches expectations and
     // prune accordingly.
-    if (computedKeyUsages !== ['CertSign', 'CRLSign']) {
-      errors.push(
-        new Error('unsupported key usage value on issuer certificate: ' + computedKeyUsages.join(', '))
-      );
+    const expectedUsages = ['CertSign', 'CRLSign'];
+    const isUnexpectedKeyUsage = (ext) => !expectedUsages.includes(ext);
+
+    if (computedKeyUsages.any(isUnexpectedKeyUsage)) {
+      const unknown = computedKeyUsages.filter(isUnexpectedKeyUsage);
+      errors.push(new Error('unsupported key usage value on issuer certificate: ' + unknown.join(', ')));
     }
 
     values.key_usage = computedKeyUsages;

--- a/ui/app/utils/parse-pki-cert.js
+++ b/ui/app/utils/parse-pki-cert.js
@@ -219,11 +219,14 @@ export function parseExtensions(extensions) {
         const ip_addr = ip.join('.');
         parsed_ips.push(ip_addr);
       } else if (ip.length === 16) {
-        const src = new Array(ip);
+        const src = new Array(...ip);
         const hex = src.map((value) => '0' + new Number(value).toString(16));
         const trimmed = hex.map((value) => value.substr(value.length - 2, 2));
-        const coloned = trimmed.map((index, value) => (index % 2 === 0 ? value : value + ':'));
-        const ip_addr = coloned.join('');
+        const coloned = trimmed.map((value, index) => (index % 2 === 0 ? value : value + ':'));
+        let ip_addr = coloned.join('');
+        if (ip_addr.charAt(ip_addr.length - 1) === ':') {
+          ip_addr = ip_addr.substr(0, ip_addr.length - 1); // Remove trailing :, if any.
+        }
         parsed_ips.push(ip_addr);
       } else {
         errors.push(

--- a/ui/app/utils/parse-pki-cert.js
+++ b/ui/app/utils/parse-pki-cert.js
@@ -247,10 +247,6 @@ export function parseExtensions(extensions) {
     values.key_usage = computedKeyUsages;
   }
 
-  if (values.ext_key_usage) {
-    // TODO parse ext_key_usage
-  }
-
   delete values.subject_alt_name;
   delete values.basic_constraints;
   delete values.name_constraints;

--- a/ui/app/utils/parse-pki-cert.js
+++ b/ui/app/utils/parse-pki-cert.js
@@ -277,6 +277,16 @@ export function parseExtensions(extensions) {
       }
     }
 
+    // Vault currently doesn't allow setting key_usage during issuer
+    // generation, but will allow it if it comes in via an externally
+    // generated CSR. Validate that key_usage matches expectations and
+    // prune accordingly.
+    if (computedKeyUsages !== ['CertSign', 'CRLSign']) {
+      errors.push(
+        new Error('unsupported key usage value on issuer certificate: ' + computedKeyUsages.join(', '))
+      );
+    }
+
     values.key_usage = computedKeyUsages;
   }
 

--- a/ui/app/utils/parse-pki-cert.js
+++ b/ui/app/utils/parse-pki-cert.js
@@ -209,6 +209,10 @@ export function parseExtensions(extensions) {
     // TODO parse key_usage
   }
 
+  if (values.ext_key_usage) {
+    // TODO parse ext_key_usage
+  }
+
   delete values.subject_alt_name;
   delete values.basic_constraints;
   delete values.name_constraints;

--- a/ui/lib/pki/addon/components/pki-issuer-cross-sign.js
+++ b/ui/lib/pki/addon/components/pki-issuer-cross-sign.js
@@ -99,6 +99,8 @@ export default class PkiIssuerCrossSign extends Component {
   @action
   async crossSignIntermediate(intMount, intName, newCrossSignedIssuer) {
     // 1. Fetch issuer we want to sign
+    //
+    // What/Recovery: any failure is early enough that you can bail safely/normally.
     const existingIssuer = await this.store.queryRecord('pki/issuer', {
       backend: intMount,
       id: intName,
@@ -115,6 +117,8 @@ export default class PkiIssuerCrossSign extends Component {
     }
 
     // 2. Create the new CSR
+    //
+    // What/Recovery: any failure is early enough that you can bail safely/normally.
     const newCsr = await this.store
       .createRecord('pki/action', {
         keyRef: existingIssuer.keyId,
@@ -127,7 +131,10 @@ export default class PkiIssuerCrossSign extends Component {
       })
       .then(({ csr }) => csr);
 
-    // 3. Sign newCSR with correct parent to create cross-signed cert
+    // 3. Sign newCSR with correct parent to create cross-signed cert, "issuing"
+    // an intermediate certificate.
+    //
+    // What/Recovery: any failure is early enough that you can bail safely/normally.
     const signedCaChain = await this.store
       .createRecord('pki/action', {
         csr: newCsr,
@@ -144,6 +151,35 @@ export default class PkiIssuerCrossSign extends Component {
       .then(({ caChain }) => caChain.join('\n'));
 
     // 4. Import the newly cross-signed cert to become an issuer
+    //
+    // What/Recovery:
+    //
+    //   1. Permission issue -> give the cert (`signedCaChain`) to the user,
+    //      let them import & name. (Issue you have is that you already issued
+    //      it (step 3) and so "undo" would mean revoking the cert, which
+    //      you might not have permissions to do either).
+    //
+    //   2. CRL rebuilding fails ("the CRL" in error message). Server returns
+    //      an error, we wanted the CRL rebuilt -- but the issuer was still
+    //      imported anyways. Only way to detect would be to do a list issuers
+    //      before and after. Recovery would be on the operator in this case;
+    //      reproduce the error and let them deal with it.
+    //
+    // End result: user should solve this issue, but we shouldn't undo anything
+    // either.
+    //
+    //    -> For 1 though, make sure to give the `signedCaChain` in the
+    //       error message for them.
+    //    -> For 2, you could list before and after to find the id of the
+    //       new issuer(s) so they can name them and fix any issues with
+    //       them.
+    //
+    // If its not a permissions error _and_ you did two lists, not finding
+    // a new issuer...
+    //
+    //    -> Unknown error. Could give them `signedCaChain` and serial of
+    //       the newly issued intermediate CA, so that they can do recovery
+    //       as they'd like.
     const issuerId = await this.store
       .createRecord('pki/issuer', { pemBundle: signedCaChain })
       .save({ adapterOptions: { import: true, mount: intMount } })
@@ -155,9 +191,15 @@ export default class PkiIssuerCrossSign extends Component {
       });
 
     // 5. Fetch issuer imported above by issuer_id, name and save
+    // Recovery: cosmetic issue; can let the user deal with it. Usually
+    // fails because the name is in use.
+    // Pre-fix: list all issuers, check the desired name isn't either
+    // an existing issuer_id or an issuer_name.
     const crossSignedIssuer = await this.store.queryRecord('pki/issuer', { backend: intMount, id: issuerId });
     crossSignedIssuer.issuerName = newCrossSignedIssuer;
-    crossSignedIssuer.save({ adapterOptions: { mount: intMount } });
+    await crossSignedIssuer.save({ adapterOptions: { mount: intMount } });
+
+    // 6. Return the data to our caller.
     return {
       intermediateIssuer: existingIssuer,
       newCrossSignedIssuer: crossSignedIssuer,


### PR DESCRIPTION
This adds `keyUsage` and `ip_sans` as supported, parsed values for cross signing. Partial support for extKeyUsage was started, but later removed as it was realized the API doesn't support it and doesn't set it by default on Vault-created issuers. While `keyUsage` is present by default, its value isn't controllable via API either, but could be set via an external CSR/issuer, so we still need to validate it.

Also embedded are notes I took on error recovery during cross-signing from a pairing session with Claire.