### PR TITLE
fix sys/leases panic when lease_id is nil

### DIFF
--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -632,7 +632,7 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 		case "sys/leases/lookup", "sys/leases/renew", "sys/leases/revoke", "sys/leases/revoke-force":
 			leaseID, ok := req.Data["lease_id"]
 			// If lease ID is not present, break out and let the backend handle the error
-			if !ok {
+			if !ok || leaseID == nil {
 				break
 			}
 			_, nsID := namespace.SplitIDFromString(leaseID.(string))


### PR DESCRIPTION
The `sys/leases/lookup`, `sys/leases/revoke`, and `sys/leases/renew` endpoints currently panic when the provided `lease_id` is nil. This PR handles this scenario as if `lease_id` was not provided at all and thus returns a 403 response.

Fixes https://github.com/hashicorp/vault/issues/18850