### PR TITLE
UI: VAULT-13044 pki cleanup attributes

### DIFF
--- a/ui/app/models/pki-ca-certificate-sign.js
+++ b/ui/app/models/pki-ca-certificate-sign.js
@@ -19,27 +19,27 @@ export default Certificate.extend({
   }),
   ou: attr({
     label: 'OU (OrganizationalUnit)',
-    editType: 'string',
+    editType: 'stringArray',
   }),
   organization: attr({
-    editType: 'string',
+    editType: 'stringArray',
   }),
   country: attr({
-    editType: 'string',
+    editType: 'stringArray',
   }),
   locality: attr({
-    editType: 'string',
+    editType: 'stringArray',
     label: 'Locality/City',
   }),
   province: attr({
-    editType: 'string',
+    editType: 'stringArray',
     label: 'Province/State',
   }),
   streetAddress: attr({
-    editType: 'string',
+    editType: 'stringArray',
   }),
   postalCode: attr({
-    editType: 'string',
+    editType: 'stringArray',
   }),
 
   fieldGroups: computed('useCsrValues', function () {

--- a/ui/app/models/pki-ca-certificate-sign.js
+++ b/ui/app/models/pki-ca-certificate-sign.js
@@ -19,27 +19,27 @@ export default Certificate.extend({
   }),
   ou: attr({
     label: 'OU (OrganizationalUnit)',
-    editType: 'stringArray',
+    editType: 'string',
   }),
   organization: attr({
-    editType: 'stringArray',
+    editType: 'string',
   }),
   country: attr({
-    editType: 'stringArray',
+    editType: 'string',
   }),
   locality: attr({
-    editType: 'stringArray',
+    editType: 'string',
     label: 'Locality/City',
   }),
   province: attr({
-    editType: 'stringArray',
+    editType: 'string',
     label: 'Province/State',
   }),
   streetAddress: attr({
-    editType: 'stringArray',
+    editType: 'string',
   }),
   postalCode: attr({
-    editType: 'stringArray',
+    editType: 'string',
   }),
 
   fieldGroups: computed('useCsrValues', function () {

--- a/ui/app/models/pki/action.js
+++ b/ui/app/models/pki/action.js
@@ -117,30 +117,12 @@ export default class PkiActionModel extends Model {
     editType: 'stringArray',
   })
   ou;
-  @attr({
-    editType: 'stringArray',
-  })
-  organization;
-  @attr({
-    editType: 'stringArray',
-  })
-  country;
-  @attr({
-    editType: 'stringArray',
-  })
-  locality;
-  @attr({
-    editType: 'stringArray',
-  })
-  province;
-  @attr({
-    editType: 'stringArray',
-  })
-  streetAddress;
-  @attr({
-    editType: 'stringArray',
-  })
-  postalCode;
+  @attr({ editType: 'stringArray' }) organization;
+  @attr({ editType: 'stringArray' }) country;
+  @attr({ editType: 'stringArray' }) locality;
+  @attr({ editType: 'stringArray' }) province;
+  @attr({ editType: 'stringArray' }) streetAddress;
+  @attr({ editType: 'stringArray' }) postalCode;
 
   @attr('string', {
     subText: "Specifies the requested Subject's named Serial Number value.",

--- a/ui/app/models/pki/action.js
+++ b/ui/app/models/pki/action.js
@@ -112,14 +112,35 @@ export default class PkiActionModel extends Model {
 
   @attr('string', {
     label: 'Organizational Units (OU)',
+    subText:
+      'A list of allowed serial numbers to be requested during certificate issuance. Shell-style globbing is supported. If empty, custom-specified serial numbers will be forbidden.',
+    editType: 'stringArray',
   })
   ou;
-  @attr('string') organization;
-  @attr('string') country;
-  @attr('string') locality;
-  @attr('string') province;
-  @attr('string') streetAddress;
-  @attr('string') postalCode;
+  @attr({
+    editType: 'stringArray',
+  })
+  organization;
+  @attr({
+    editType: 'stringArray',
+  })
+  country;
+  @attr({
+    editType: 'stringArray',
+  })
+  locality;
+  @attr({
+    editType: 'stringArray',
+  })
+  province;
+  @attr({
+    editType: 'stringArray',
+  })
+  streetAddress;
+  @attr({
+    editType: 'stringArray',
+  })
+  postalCode;
 
   @attr('string', {
     subText: "Specifies the requested Subject's named Serial Number value.",

--- a/ui/app/models/pki/action.js
+++ b/ui/app/models/pki/action.js
@@ -50,21 +50,25 @@ export default class PkiActionModel extends Model {
 
   @attr('string', {
     label: 'Subject Alternative Names (SANs)',
+    editType: 'stringArray',
   })
   altNames; // comma sep strings
 
   @attr('string', {
     label: 'IP Subject Alternative Names (IP SANs)',
+    editType: 'stringArray',
   })
   ipSans;
 
   @attr('string', {
     label: 'URI Subject Alternative Names (URI SANs)',
+    editType: 'stringArray',
   })
   uriSans;
 
   @attr('string', {
     label: 'Other SANs',
+    editType: 'stringArray',
   })
   otherSans;
 

--- a/ui/app/models/pki/issuer.js
+++ b/ui/app/models/pki/issuer.js
@@ -85,12 +85,14 @@ export default class PkiIssuerModel extends PkiCertificateBaseModel {
   @attr('string', {
     label: 'CRL distribution points',
     subText: 'Specifies the URL values for the CRL Distribution Points field.',
+    editType: 'stringArray',
   })
   crlDistributionPoints;
 
   @attr('string', {
     label: 'OCSP servers',
     subText: 'Specifies the URL values for the OCSP Servers field.',
+    editType: 'stringArray',
   })
   ocspServers;
 

--- a/ui/app/models/pki/issuer.js
+++ b/ui/app/models/pki/issuer.js
@@ -39,7 +39,7 @@ export default class PkiIssuerModel extends PkiCertificateBaseModel {
   keyId;
 
   @attr({
-    label: 'Subject Alternative Names',
+    label: 'URI Subject Alternative Names (URI SANs)',
   })
   uriSans;
 

--- a/ui/app/models/pki/role.js
+++ b/ui/app/models/pki/role.js
@@ -159,10 +159,14 @@ export default class PkiRoleModel extends Model {
   })
   allowedDomains;
 
-  @attr('boolean', {
-    label: 'Allow templates in allowed domains',
-  })
-  allowedDomainsTemplate;
+  @attr('boolean') allowedDomainsTemplate;
+  @attr('boolean') allowBareDomains;
+  @attr('boolean') allowSubdomains;
+  @attr('boolean') allowGlobDomains;
+  @attr('boolean') allowWildcardCertificates;
+  @attr('boolean', { defaultValue: 'true' }) allowLocalhost;
+  @attr('boolean') allowAnyName;
+  @attr('boolean', { defaultValue: 'true' }) enforceHostnames;
   /* End of overriding Domain handling options */
 
   /* Overriding OpenApi Key parameters options */

--- a/ui/app/models/pki/role.js
+++ b/ui/app/models/pki/role.js
@@ -159,14 +159,10 @@ export default class PkiRoleModel extends Model {
   })
   allowedDomains;
 
-  @attr('boolean') allowedDomainsTemplate;
-  @attr('boolean') allowBareDomains;
-  @attr('boolean') allowSubdomains;
-  @attr('boolean') allowGlobDomains;
-  @attr('boolean') allowWildcardCertificates;
-  @attr('boolean', { defaultValue: 'true' }) allowLocalhost;
-  @attr('boolean') allowAnyName;
-  @attr('boolean', { defaultValue: 'true' }) enforceHostnames;
+  @attr('boolean', {
+    label: 'Allow templates in allowed domains',
+  })
+  allowedDomainsTemplate;
   /* End of overriding Domain handling options */
 
   /* Overriding OpenApi Key parameters options */

--- a/ui/app/models/pki/role.js
+++ b/ui/app/models/pki/role.js
@@ -266,6 +266,7 @@ export default class PkiRoleModel extends Model {
     label: 'Organization Units (OU)',
     subText:
       'A list of allowed serial numbers to be requested during certificate issuance. Shell-style globbing is supported. If empty, custom-specified serial numbers will be forbidden.',
+    editType: 'stringArray',
   })
   ou;
 
@@ -287,12 +288,12 @@ export default class PkiRoleModel extends Model {
   })
   extKeyUsageOids;
 
-  @attr('string') organization;
-  @attr('string') country;
-  @attr('string') locality;
-  @attr('string') province;
-  @attr('string') streetAddress;
-  @attr('string') postalCode;
+  @attr({ editType: 'stringArray' }) organization;
+  @attr({ editType: 'stringArray' }) country;
+  @attr({ editType: 'stringArray' }) locality;
+  @attr({ editType: 'stringArray' }) province;
+  @attr({ editType: 'stringArray' }) streetAddress;
+  @attr({ editType: 'stringArray' }) postalCode;
   /* End of overriding Additional subject field options */
 
   /* CAPABILITIES

--- a/ui/app/models/pki/urls.js
+++ b/ui/app/models/pki/urls.js
@@ -17,6 +17,7 @@ export default class PkiUrlsModel extends Model {
     subText:
       'The URL values for the Issuing Certificate field. These are different URLs for the same resource, and should be added individually, not in a comma-separated list.',
     showHelpText: false,
+    editType: 'stringArray',
   })
   issuingCertificates;
 
@@ -24,6 +25,7 @@ export default class PkiUrlsModel extends Model {
     label: 'CRL distribution points',
     subText: 'Specifies the URL values for the CRL Distribution Points field.',
     showHelpText: false,
+    editType: 'stringArray',
   })
   crlDistributionPoints;
 
@@ -31,6 +33,7 @@ export default class PkiUrlsModel extends Model {
     label: 'OSCP Servers',
     subText: 'Specifies the URL values for the OCSP Servers field.',
     showHelpText: false,
+    editType: 'stringArray',
   })
   ocspServers;
 

--- a/ui/tests/integration/components/pki/page/pki-issuer-edit-test.js
+++ b/ui/tests/integration/components/pki/page/pki-issuer-edit-test.js
@@ -20,8 +20,8 @@ const selectors = {
   certUrl2: '[data-test-string-list-input="1"]',
   certUrlAdd: '[data-test-string-list-button="add"]',
   certUrlRemove: '[data-test-string-list-button="delete"]',
-  crlDist: '[data-test-input="crlDistributionPoints"]',
-  ocspServers: '[data-test-input="ocspServers"]',
+  crlDist: '[data-test-input="crlDistributionPoints"] [data-test-string-list-input="0"]',
+  ocspServers: '[data-test-input="ocspServers"]  [data-test-string-list-input="0"]',
   save: '[data-test-save]',
   cancel: '[data-test-cancel]',
   error: '[data-test-error] p',
@@ -84,10 +84,10 @@ module('Integration | Component | pki | Page::PkiIssuerEditPage::PkiIssuerEdit',
     const certUrls = this.model.issuingCertificates.split(',');
     assert.dom(selectors.certUrl1).hasValue(certUrls[0], 'Issuing certificate populates');
     assert.dom(selectors.certUrl2).hasValue(certUrls[1], 'Issuing certificate populates');
-    assert
-      .dom(selectors.crlDist)
-      .hasValue(this.model.crlDistributionPoints, 'Crl distribution points populate');
-    assert.dom(selectors.ocspServers).hasValue(this.model.ocspServers, 'Ocsp servers populate');
+    const crlDistributionPoints = this.model.crlDistributionPoints.split(',');
+    assert.dom(selectors.crlDist).hasValue(crlDistributionPoints[0], 'Crl distribution points populate');
+    const ocspServers = this.model.ocspServers.split(',');
+    assert.dom(selectors.ocspServers).hasValue(ocspServers[0], 'Ocsp servers populate');
   });
 
   test('it should rollback model attributes on cancel', async function (assert) {


### PR DESCRIPTION
**Description**:
- update the subText for OU across all areas
- update crlDistributionPoints, ocspServers, and ou to stringArray based on what was filed in the bug bash

stringArray Attribute:
[crlDistributionPoints](https://developer.hashicorp.com/vault/api-docs/secret/pki#crl_distribution_points)
[ocspServers](https://developer.hashicorp.com/vault/api-docs/secret/pki#ocsp_servers-1)
[ou, organization, country, city, state, street, postal code](https://developer.hashicorp.com/vault/api-docs/secret/pki#ou)

Fields Updated in **Create Role**:

<img width="1346" alt="Screenshot 2023-02-01 at 11 04 29 AM" src="https://user-images.githubusercontent.com/30884335/216184409-9267d23b-1831-4636-9ccc-2ff0ff145233.png">

Fields Updated in **Update Issuer**
<img width="1374" alt="Screenshot 2023-02-01 at 11 04 43 AM" src="https://user-images.githubusercontent.com/30884335/216184460-4a0c407e-0e8c-48de-a20d-dcd0b43aca32.png">

Fields Update in "Generate Root"
<img width="1359" alt="Screenshot 2023-02-01 at 3 01 38 PM" src="https://user-images.githubusercontent.com/30884335/216185707-a588fb74-193b-4237-9cb5-7d3c825e6bc2.png">

