### PR TITLE
openapi: Ensure mount_path parameters are marked as required

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4609,7 +4609,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 							Type:    "string",
 							Default: strings.TrimRight(mount, "/"),
 						},
-						Required: false,
+						Required: true,
 					})
 				}
 


### PR DESCRIPTION
The path parameters must be `"required": true` per [OpenAPI specification](https://swagger.io/docs/specification/describing-parameters/#path-parameters).