### PR TITLE
Fix docLinks in models

### DIFF
--- a/ui/app/models/database/connection.js
+++ b/ui/app/models/database/connection.js
@@ -54,7 +54,7 @@ export default Model.extend({
     defaultSubText:
       'Unless a custom policy is specified, Vault will use a default: 20 characters with at least 1 uppercase, 1 lowercase, 1 number, and 1 dash character.',
     defaultShown: 'Default',
-    docLink: '/docs/concepts/password-policies',
+    docLink: '/vault/docs/concepts/password-policies',
   }),
 
   // common fields
@@ -106,7 +106,7 @@ export default Model.extend({
     subText: 'Enter the custom username template to use.',
     defaultSubText:
       'Template describing how dynamic usernames are generated. Vault will use the default for this plugin.',
-    docLink: '/docs/concepts/username-templating',
+    docLink: '/vault/docs/concepts/username-templating',
     defaultShown: 'Default',
   }),
   max_open_connections: attr('number', {

--- a/ui/app/models/oidc/provider.js
+++ b/ui/app/models/oidc/provider.js
@@ -20,7 +20,7 @@ export default class OidcProviderModel extends Model {
     subText:
       'The scheme, host, and optional port for your issuer. This will be used to build the URL that validates ID tokens.',
     placeholderText: 'e.g. https://example.com:8200',
-    docLink: '/api-docs/secret/identity/oidc-provider#create-or-update-a-provider',
+    docLink: '/vault/api-docs/secret/identity/oidc-provider#create-or-update-a-provider',
     helpText: `Optional. This defaults to a URL with Vault's api_addr`,
   })
   issuer;

--- a/ui/app/models/pki/role.js
+++ b/ui/app/models/pki/role.js
@@ -128,7 +128,7 @@ export default class PkiRoleModel extends Model {
     subText:
       'Specifies if certificates issued/signed against this role will have Vault leases attached to them.',
     editType: 'boolean',
-    docLink: '/api-docs/secret/pki#create-update-role',
+    docLink: '/vault/api-docs/secret/pki#create-update-role',
   })
   generateLease;
 
@@ -138,7 +138,7 @@ export default class PkiRoleModel extends Model {
     subText:
       'This can improve performance when issuing large numbers of certificates. However, certificates issued in this way cannot be enumerated or revoked.',
     editType: 'boolean',
-    docLink: '/api-docs/secret/pki#create-update-role',
+    docLink: '/vault/api-docs/secret/pki#create-update-role',
   })
   noStore;
 
@@ -210,7 +210,7 @@ export default class PkiRoleModel extends Model {
     label: 'URI Subject Alternative Names (URI SANs)',
     subText: 'Defines allowed URI Subject Alternative Names. Add one item per row',
     editType: 'stringArray',
-    docLink: '/docs/concepts/policies',
+    docLink: '/vault/docs/concepts/policies',
   })
   allowedUriSans;
 
@@ -218,7 +218,7 @@ export default class PkiRoleModel extends Model {
     label: 'Allow URI SANs template',
     subText: 'If true, the URI SANs above may contain templates, as with ACL Path Templating.',
     editType: 'boolean',
-    docLink: '/docs/concepts/policies',
+    docLink: '/vault/docs/concepts/policies',
   })
   allowUriSansTemplate;
 
@@ -329,7 +329,7 @@ export default class PkiRoleModel extends Model {
         footer: {
           text: 'These options can interact intricately with one another. For more information,',
           docText: 'learn more here.',
-          docLink: '/api-docs/secret/pki#allowed_domains',
+          docLink: '/vault/api-docs/secret/pki#allowed_domains',
         },
       },
       'Key parameters': {


### PR DESCRIPTION
Some additional docLinks that needed to be fix alongside [this PR](https://github.com/hashicorp/vault/pull/18641/files).

The below video shows the before and after. I searched all the models for `docLinks` and `learnLinks` (just in case). Fixed and confirmed in the UI the ones I found missing `/vault` at the beginning of the url.

https://user-images.githubusercontent.com/6618863/216445943-b20e4e07-bbd6-44f8-93a0-6450be14aaad.mov

