### PR TITLE
Make experiments API authenticated

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -144,7 +144,6 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 				"unseal",
 				"leader",
 				"health",
-				"experiments",
 				"generate-root/attempt",
 				"generate-root/update",
 				"rekey/init",

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -153,7 +153,12 @@ path "sys/control-group/request" {
 
 # Allow a token to make requests to the Authorization Endpoint for OIDC providers.
 path "identity/oidc/provider/+/authorize" {
-	capabilities = ["read", "update"]
+    capabilities = ["read", "update"]
+}
+
+# Allow checking what experiments are enabled
+path "sys/experiments" {
+    capabilities = ["read"]
 }
 `
 )

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -155,11 +155,6 @@ path "sys/control-group/request" {
 path "identity/oidc/provider/+/authorize" {
     capabilities = ["read", "update"]
 }
-
-# Allow checking what experiments are enabled
-path "sys/experiments" {
-    capabilities = ["read"]
-}
 `
 )
 

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -297,7 +297,6 @@ func TestDefaultPolicy(t *testing.T) {
 		"renew self":             {logical.UpdateOperation, "auth/token/renew-self", true},
 		"revoke self":            {logical.UpdateOperation, "auth/token/revoke-self", true},
 		"check own capabilities": {logical.UpdateOperation, "sys/capabilities-self", true},
-		"experiments":            {logical.ReadOperation, "sys/experiments", true},
 
 		"read arbitrary path":     {logical.ReadOperation, "foo/bar", false},
 		"login at arbitrary path": {logical.UpdateOperation, "auth/foo", false},

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func mockPolicyWithCore(t *testing.T, disableCache bool) (*Core, *PolicyStore) {
@@ -273,4 +274,46 @@ func testPolicyStoreACL(t *testing.T, ps *PolicyStore, ns *namespace.Namespace) 
 		t.Fatalf("err: %v", err)
 	}
 	testLayeredACL(t, acl, ns)
+}
+
+func TestDefaultPolicy(t *testing.T) {
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	policy, err := ParseACLPolicy(namespace.RootNamespace, defaultPolicy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	acl, err := NewACL(ctx, []*Policy{policy})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for name, tc := range map[string]struct {
+		op            logical.Operation
+		path          string
+		expectAllowed bool
+	}{
+		"lookup self":            {logical.ReadOperation, "auth/token/lookup-self", true},
+		"renew self":             {logical.UpdateOperation, "auth/token/renew-self", true},
+		"revoke self":            {logical.UpdateOperation, "auth/token/revoke-self", true},
+		"check own capabilities": {logical.UpdateOperation, "sys/capabilities-self", true},
+		"experiments":            {logical.ReadOperation, "sys/experiments", true},
+
+		"read arbitrary path":     {logical.ReadOperation, "foo/bar", false},
+		"login at arbitrary path": {logical.UpdateOperation, "auth/foo", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			request := new(logical.Request)
+			request.Operation = tc.op
+			request.Path = tc.path
+
+			result := acl.AllowOperation(ctx, request, false)
+			if result.RootPrivs {
+				t.Fatal("unexpected root")
+			}
+			if tc.expectAllowed != result.Allowed {
+				t.Fatalf("Expected %v, got %v", tc.expectAllowed, result.Allowed)
+			}
+		})
+	}
 }


### PR DESCRIPTION
After some discussion internally, we'd prefer not to add new unauthenticated endpoints, especially as this one potentially leaks information about the API surface of Vault.

EDIT: See comment below