### PR TITLE
Revert has-bottom-margin-m on form-field

### DIFF
--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -307,7 +307,7 @@
           {{on "input" this.onChangeWithEvent}}
           {{on "change" this.onChangeWithEvent}}
           {{on "keyup" this.handleKeyUp}}
-          class="input {{if this.validationError 'has-error-border' 'has-bottom-margin-m'}}"
+          class="input {{if this.validationError 'has-error-border'}}"
           maxLength={{@attr.options.characterLimit}}
         />
         {{#if @attr.options.validationAttr}}


### PR DESCRIPTION
The additional `has-margin-bottom-m` was added in an attempt to fix an issue with multiple text files ([see PR and row here](https://github.com/hashicorp/vault/pull/18458/files#diff-d10b01999845cdbb2bb7704e40fc343061f6d2a35d0269fc97fa684d0a2de66aR307)). While I couldn't find the original issue (confirmed with Claire), it is causing all regular text inputs to have a margin medium which added too much spacing between form fields. 

If the original area/issue that is found, we can add a margin for that specific use case. In the meantime, I'm playing it safe and reverting so it doesn't impact the other fields used throughout the application.

**Before:**
![image](https://user-images.githubusercontent.com/6618863/216469630-df93159f-6eca-48f0-8bd0-047a8c9c2eea.png)

**After fix:** 
![image](https://user-images.githubusercontent.com/6618863/216469856-64d80c21-461a-407c-99d8-a5c0a144757d.png)

