### PR TITLE
UI: add issuerRef getter in case issuer is nameless

### DIFF
--- a/ui/app/adapters/pki/action.js
+++ b/ui/app/adapters/pki/action.js
@@ -7,7 +7,7 @@ export default class PkiActionAdapter extends ApplicationAdapter {
 
   urlForCreateRecord(modelName, snapshot) {
     const { type } = snapshot.record;
-    const { actionType, useIssuer, issuerName, mount } = snapshot.adapterOptions;
+    const { actionType, useIssuer, issuerRef, mount } = snapshot.adapterOptions;
     // if the backend mount is passed, we want that to override the URL's mount path
     const backend = mount || snapshot.record.backend;
     if (!backend || !actionType) {
@@ -24,7 +24,7 @@ export default class PkiActionAdapter extends ApplicationAdapter {
           ? `${baseUrl}/issuers/generate/intermediate/${type}`
           : `${baseUrl}/intermediate/generate/${type}`;
       case 'sign-intermediate':
-        return `${baseUrl}/issuer/${encodePath(issuerName)}/sign-intermediate`;
+        return `${baseUrl}/issuer/${encodePath(issuerRef)}/sign-intermediate`;
       default:
         assert('actionType must be one of import, generate-root, generate-csr or sign-intermediate');
     }

--- a/ui/app/models/pki/issuer.js
+++ b/ui/app/models/pki/issuer.js
@@ -30,6 +30,10 @@ export default class PkiIssuerModel extends PkiCertificateBaseModel {
     return false;
   }
 
+  get issuerRef() {
+    return this.issuerName || this.issuerId;
+  }
+
   @attr isDefault; // readonly
   @attr('string') issuerId;
 

--- a/ui/lib/pki/addon/components/pki-issuer-cross-sign.hbs
+++ b/ui/lib/pki/addon/components/pki-issuer-cross-sign.hbs
@@ -50,7 +50,7 @@
                       @route="externalMountIssuer"
                       @models={{array (get crossSignRow "intermediateMount") data.issuerId}}
                     >
-                      {{data.issuerName}}
+                      {{data.issuerRef}}
                     </LinkToExternal>
                   {{/if}}
                 </div>

--- a/ui/lib/pki/addon/components/pki-issuer-cross-sign.js
+++ b/ui/lib/pki/addon/components/pki-issuer-cross-sign.js
@@ -21,7 +21,7 @@ import { parseCertificate } from 'vault/utils/parse-pki-cert';
  * 2. Create a new CSR based on this existing issuer ID
  *    -> POST /:intermediateMount/intermediate/generate/existing
  * 3. Sign it with the new parent issuer, minting a new certificate.
- *    -> POST /this.args.parentIssuer.backend/issuer/this.args.parentIssuer.issuerName/sign-intermediate
+ *    -> POST /this.args.parentIssuer.backend/issuer/this.args.parentIssuer.issuerRef/sign-intermediate
  * 4. Import it back into the existing mount
  *    -> POST /:intermediateMount/issuers/import/bundle
  * 5. Read the imported issuer
@@ -138,7 +138,7 @@ export default class PkiIssuerCrossSign extends Component {
         adapterOptions: {
           actionType: 'sign-intermediate',
           mount: this.args.parentIssuer.backend,
-          issuerName: this.args.parentIssuer.issuerName,
+          issuerRef: this.args.parentIssuer.issuerRef,
         },
       })
       .then(({ caChain }) => caChain.join('\n'));

--- a/ui/lib/pki/addon/templates/issuers/index.hbs
+++ b/ui/lib/pki/addon/templates/issuers/index.hbs
@@ -49,7 +49,7 @@
           <div>
             <Icon @name="certificate" class="has-text-grey-light" />
             <span class="has-text-weight-semibold is-underline">
-              {{or pkiIssuer.issuerName pkiIssuer.id}}
+              {{pkiIssuer.issuerRef}}
             </span>
             <div class="is-flex-row has-left-margin-l has-top-margin-xs">
               {{#if pkiIssuer.isDefault}}

--- a/ui/lib/pki/addon/templates/issuers/issuer/cross-sign.hbs
+++ b/ui/lib/pki/addon/templates/issuers/issuer/cross-sign.hbs
@@ -21,7 +21,7 @@
       <ol class="has-left-margin-m has-bottom-margin-s">
         <li>You identify which intermediates need to be cross-signed.</li>
         <li>The new CSR for your intermediate(s) will be generated.</li>
-        <li>The CSR is signed with the root <strong>{{this.model.issuerName}}</strong>.</li>
+        <li>The CSR is signed with the root <strong>{{this.model.issuerRef}}</strong>.</li>
         <li>Your new intermediate(s) are imported into any existing mount(s).</li>
       </ol>
       Then, you can begin re-issuing leaf certs and phase out the old root.

--- a/ui/tests/unit/serializers/pki/action-test.js
+++ b/ui/tests/unit/serializers/pki/action-test.js
@@ -22,7 +22,7 @@ module('Unit | Serializer | pki/action', function (hooks) {
       const store = this.owner.lookup('service:store');
       const record = store.createRecord('pki/action', {
         pemBundle: this.pemBundle,
-        issuerName: 'do-not-send',
+        issuerRef: 'do-not-send',
         keyType: 'do-not-send',
       });
       const expectedResult = {
@@ -68,7 +68,7 @@ module('Unit | Serializer | pki/action', function (hooks) {
         privateKeyFormat: 'der',
         type: 'external', // only used for endpoint in adapter
         customTtl: '40m', // UI-only value
-        issuerName: 'my issuer',
+        issuerRef: 'my issuer',
         commonName: undefined,
         foo: 'bar',
       });
@@ -91,7 +91,7 @@ module('Unit | Serializer | pki/action', function (hooks) {
         ...this.allKeyFields,
         type: 'external',
         customTtl: '40m',
-        issuerName: 'my issuer',
+        issuerRef: 'my issuer',
         commonName: 'my common name',
       });
       const expectedResult = {
@@ -113,7 +113,7 @@ module('Unit | Serializer | pki/action', function (hooks) {
         ...this.allKeyFields,
         type: 'internal',
         customTtl: '40m',
-        issuerName: 'my issuer',
+        issuerRef: 'my issuer',
         commonName: 'my common name',
       });
       const expectedResult = {
@@ -135,7 +135,7 @@ module('Unit | Serializer | pki/action', function (hooks) {
         ...this.allKeyFields,
         type: 'existing',
         customTtl: '40m',
-        issuerName: 'my issuer',
+        issuerRef: 'my issuer',
         commonName: 'my common name',
       });
       const expectedResult = {
@@ -155,7 +155,7 @@ module('Unit | Serializer | pki/action', function (hooks) {
         ...this.allKeyFields,
         type: 'kms',
         customTtl: '40m',
-        issuerName: 'my issuer',
+        issuerRef: 'my issuer',
         commonName: 'my common name',
       });
       const expectedResult = {

--- a/ui/tests/unit/serializers/pki/action-test.js
+++ b/ui/tests/unit/serializers/pki/action-test.js
@@ -68,7 +68,7 @@ module('Unit | Serializer | pki/action', function (hooks) {
         privateKeyFormat: 'der',
         type: 'external', // only used for endpoint in adapter
         customTtl: '40m', // UI-only value
-        issuerRef: 'my issuer',
+        issuerName: 'my issuer',
         commonName: undefined,
         foo: 'bar',
       });
@@ -91,7 +91,7 @@ module('Unit | Serializer | pki/action', function (hooks) {
         ...this.allKeyFields,
         type: 'external',
         customTtl: '40m',
-        issuerRef: 'my issuer',
+        issuerName: 'my issuer',
         commonName: 'my common name',
       });
       const expectedResult = {
@@ -113,7 +113,7 @@ module('Unit | Serializer | pki/action', function (hooks) {
         ...this.allKeyFields,
         type: 'internal',
         customTtl: '40m',
-        issuerRef: 'my issuer',
+        issuerName: 'my issuer',
         commonName: 'my common name',
       });
       const expectedResult = {
@@ -135,7 +135,7 @@ module('Unit | Serializer | pki/action', function (hooks) {
         ...this.allKeyFields,
         type: 'existing',
         customTtl: '40m',
-        issuerRef: 'my issuer',
+        issuerName: 'my issuer',
         commonName: 'my common name',
       });
       const expectedResult = {
@@ -155,7 +155,7 @@ module('Unit | Serializer | pki/action', function (hooks) {
         ...this.allKeyFields,
         type: 'kms',
         customTtl: '40m',
-        issuerRef: 'my issuer',
+        issuerName: 'my issuer',
         commonName: 'my common name',
       });
       const expectedResult = {

--- a/ui/types/vault/models/pki/issuer.d.ts
+++ b/ui/types/vault/models/pki/issuer.d.ts
@@ -4,7 +4,7 @@ export default class PkiIssuerModel extends PkiCertificateBaseModel {
   useOpenAPI(): boolean;
   issuerId: string;
   issuerName: string;
-  issuerRef: string;
+  issuerRef(): string;
   keyId: string;
   uriSans: string;
   leafNotAfterBehavior: string;

--- a/ui/types/vault/models/pki/issuer.d.ts
+++ b/ui/types/vault/models/pki/issuer.d.ts
@@ -3,9 +3,10 @@ import { FormField, FormFieldGroups, ModelValidations } from 'vault/app-types';
 export default class PkiIssuerModel extends PkiCertificateBaseModel {
   useOpenAPI(): boolean;
   issuerId: string;
+  issuerName: string;
+  issuerRef: string;
   keyId: string;
   uriSans: string;
-  issuerName: string;
   leafNotAfterBehavior: string;
   usage: string;
   manualChain: string;


### PR DESCRIPTION
If an issuer is nameless we want to fallback and reference the `issuerId` - this PR adds a getter to fallback on the id consistently throughout the PKI engine. This fixes a bug where cross-signing fails if attempted from a nameless parent issuer.