### PR TITLE
OpenAPI attributes not populating on pki/role model

### DIFF
--- a/ui/lib/pki/addon/routes/application.js
+++ b/ui/lib/pki/addon/routes/application.js
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class PkiRoute extends Route {
+  @service pathHelp;
+  @service secretMountPath;
+
+  beforeModel() {
+    // Must call this promise before the model hook otherwise the model doesn't hydrate from OpenAPI correctly.
+    // only needs to be called once to add the openAPI attributes to the model prototype
+    return this.pathHelp.getNewModel('pki/role', this.secretMountPath.currentPath);
+  }
+}

--- a/ui/lib/pki/addon/routes/overview.js
+++ b/ui/lib/pki/addon/routes/overview.js
@@ -7,26 +7,13 @@ export default class PkiOverviewRoute extends Route {
   @service auth;
   @service store;
 
-  get win() {
-    return this.window || window;
-  }
-
   hasConfig() {
     // When the engine is configured, it creates a default issuer.
     // If the issuers list is empty, we know it hasn't been configured
-    const endpoint = `${this.win.origin}/v1/${this.secretMountPath.currentPath}/issuers?list=true`;
-
-    return this.auth
-      .ajax(endpoint, 'GET', {})
+    return this.store
+      .query('pki/issuer', { backend: this.secretMountPath.currentPath })
       .then(() => true)
       .catch(() => false);
-  }
-
-  async fetchEngine() {
-    const model = await this.store.query('secret-engine', {
-      path: this.secretMountPath.currentPath,
-    });
-    return model.get('firstObject');
   }
 
   async fetchAllRoles() {
@@ -48,7 +35,7 @@ export default class PkiOverviewRoute extends Route {
   async model() {
     return hash({
       hasConfig: this.hasConfig(),
-      engine: this.fetchEngine(),
+      engine: this.modelFor('application'),
       roles: this.fetchAllRoles(),
       issuers: this.fetchAllIssuers(),
     });

--- a/ui/lib/pki/addon/routes/roles/create.js
+++ b/ui/lib/pki/addon/routes/roles/create.js
@@ -1,9 +1,9 @@
+import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
-import PkiRolesIndexRoute from '.';
 
 @withConfirmLeave()
-export default class PkiRolesCreateRoute extends PkiRolesIndexRoute {
+export default class PkiRolesCreateRoute extends Route {
   @service store;
   @service secretMountPath;
 

--- a/ui/lib/pki/addon/routes/roles/index.js
+++ b/ui/lib/pki/addon/routes/roles/index.js
@@ -5,13 +5,6 @@ import { hash } from 'rsvp';
 export default class PkiRolesIndexRoute extends PkiOverviewRoute {
   @service store;
   @service secretMountPath;
-  @service pathHelp;
-
-  beforeModel() {
-    // Must call this promise before the model hook otherwise
-    // the model doesn't hydrate from OpenAPI correctly.
-    return this.pathHelp.getNewModel('pki/role', this.secretMountPath.currentPath);
-  }
 
   async fetchRoles() {
     try {

--- a/ui/lib/pki/addon/routes/roles/role/details.js
+++ b/ui/lib/pki/addon/routes/roles/role/details.js
@@ -1,6 +1,6 @@
-import PkiRolesIndexRoute from '../index';
+import Route from '@ember/routing/route';
 
-export default class RolesRoleDetailsRoute extends PkiRolesIndexRoute {
+export default class RolesRoleDetailsRoute extends Route {
   model() {
     const { role } = this.paramsFor('roles/role');
     return this.store.queryRecord('pki/role', {

--- a/ui/lib/pki/addon/routes/roles/role/details.js
+++ b/ui/lib/pki/addon/routes/roles/role/details.js
@@ -1,6 +1,10 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class RolesRoleDetailsRoute extends Route {
+  @service store;
+  @service secretMountPath;
+
   model() {
     const { role } = this.paramsFor('roles/role');
     return this.store.queryRecord('pki/role', {

--- a/ui/lib/pki/addon/routes/roles/role/edit.js
+++ b/ui/lib/pki/addon/routes/roles/role/edit.js
@@ -1,8 +1,8 @@
+import Route from '@ember/routing/route';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
-import PkiRolesIndexRoute from '../index';
 
 @withConfirmLeave()
-export default class PkiRoleEditRoute extends PkiRolesIndexRoute {
+export default class PkiRoleEditRoute extends Route {
   model() {
     const { role } = this.paramsFor('roles/role');
     return this.store.queryRecord('pki/role', {

--- a/ui/lib/pki/addon/routes/roles/role/edit.js
+++ b/ui/lib/pki/addon/routes/roles/role/edit.js
@@ -1,8 +1,12 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave()
 export default class PkiRoleEditRoute extends Route {
+  @service store;
+  @service secretMountPath;
+
   model() {
     const { role } = this.paramsFor('roles/role');
     return this.store.queryRecord('pki/role', {


### PR DESCRIPTION
OpenAPI attributes were not consistently being populated on the pki/role model. Specifically, if you were to refresh on the overview page, navigate to roles and then create a role you would notice missing check boxes in the _Domain handling_ section.

![image](https://user-images.githubusercontent.com/24611656/216636657-9dc3da6a-6993-4a20-b15c-8b12ed2ccd1f.png)

I'm not sure why exactly, but since the overview route was doing a query for roles and the call to `getNewModel` was happening in the roles routes, for whatever reason Ember was not using the newly registered model with the OpenAPI attributes. Since the `getNewModel` method from the `pathHelp` service only needs to be called once in order to re-register the new model with the properties from OpenAPI, I moved it to the application route of the engine to ensure it gets called before any calls to the store for the `pki/role` model happen. After the change the model has all the attributes as expected.

![image](https://user-images.githubusercontent.com/24611656/216638533-b2a33498-3974-4ab1-b743-4f185eb7217b.png)


