### PR TITLE
command/agent/auth: fix clobbered error

### DIFF
--- a/command/agent/auth/auth.go
+++ b/command/agent/auth/auth.go
@@ -259,7 +259,8 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 		if secret.Auth == nil {
 			isTokenFileMethod = path == "auth/token/lookup-self"
 			if isTokenFileMethod {
-				token, _ := data["token"].(string)
+				var token string
+				token, _ = data["token"].(string)
 				lookupSelfClient, err := clientToUse.Clone()
 				if err != nil {
 					ah.logger.Error("failed to clone client to perform token lookup")


### PR DESCRIPTION
This fixes an `err` variable that was getting redeclared inside a block with an `:=` operator, preventing it from being returned in the outer scope.