### PR TITLE
Use UTC for leaf exceeding CA's notAfter

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -1392,7 +1392,7 @@ func generateCreationBundle(b *backend, data *inputBundle, caSign *certutil.CAIn
 				fallthrough
 			default:
 				return nil, nil, errutil.UserError{Err: fmt.Sprintf(
-					"cannot satisfy request, as TTL would result in notAfter %s that is beyond the expiration of the CA certificate at %s", notAfter.Format(time.RFC3339Nano), caSign.Certificate.NotAfter.Format(time.RFC3339Nano))}
+					"cannot satisfy request, as TTL would result in notAfter of %s that is beyond the expiration of the CA certificate at %s", notAfter.UTC().Format(time.RFC3339Nano), caSign.Certificate.NotAfter.UTC().Format(time.RFC3339Nano))}
 			}
 		}
 	}

--- a/changelog/18984.txt
+++ b/changelog/18984.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: consistently use UTC for CA's notAfter exceeded error message
+```


### PR DESCRIPTION
When generating a leaf which exceeds the CA's validity period, Vault's error message was confusing as the leaf would use the server's time zone, but the CA's notAfter date would use UTC. This could cause user confusion as the leaf's expiry might look before the latter, due to using different time zones. E.g.:

> cannot satisfy request, as TTL would result in notAfter
> 2023-03-06T16:41:09.757694-08:00 that is beyond the expiration of
> the CA certificate at 2023-03-07T00:29:52Z

Consistently use UTC for this instead.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

----

Reported by @hellobontempo, thanks! :-) 