### PR TITLE
docs: Remove XKS proxy TLS setup note

### DIFF
--- a/website/content/docs/enterprise/pkcs11-provider/aws-xks.mdx
+++ b/website/content/docs/enterprise/pkcs11-provider/aws-xks.mdx
@@ -100,7 +100,6 @@ to the XKS proxy. This helps to quickly setup a valid domain and TLS endpoint fo
 
    The important settings to change:
 
-   * `[tls]`: change key and certificate location to point to KMIP certs
    * `[[external_key_stores]]`:
      * change URI path prefix to anything you like
      * choose random access ID


### PR DESCRIPTION
The TLS settings should not need to be modified as xks-proxy should generate the certificate and key itself for listening.