### PR TITLE
Use the unified CRL on local CRL paths if UnifiedCRLOnExistingPaths is set

### DIFF
--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -2076,8 +2076,8 @@ WRITE:
 	return &nextUpdate, nil
 }
 
-// shouldLegacyPathUseUnified assuming a legacy path for a CRL/OCSP request, does our
+// shouldLocalPathsUseUnified assuming a legacy path for a CRL/OCSP request, does our
 // configuration say we should be returning the unified response or not
-func shouldLegacyPathUseUnified(cfg *crlConfig) bool {
+func shouldLocalPathsUseUnified(cfg *crlConfig) bool {
 	return cfg.UnifiedCRL && cfg.UnifiedCRLOnExistingPaths
 }

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -2075,3 +2075,9 @@ WRITE:
 
 	return &nextUpdate, nil
 }
+
+// shouldLegacyPathUseUnified assuming a legacy path for a CRL/OCSP request, does our
+// configuration say we should be returning the unified response or not
+func shouldLegacyPathUseUnified(cfg *crlConfig) bool {
+	return cfg.UnifiedCRL && cfg.UnifiedCRLOnExistingPaths
+}

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -221,12 +221,17 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 			contentType = "application/pkix-cert"
 		}
 	case req.Path == "crl" || req.Path == "crl/pem" || req.Path == "crl/delta" || req.Path == "crl/delta/pem" || req.Path == "cert/crl" || req.Path == "cert/crl/raw" || req.Path == "cert/crl/raw/pem" || req.Path == "cert/delta-crl" || req.Path == "cert/delta-crl/raw" || req.Path == "cert/delta-crl/raw/pem" || req.Path == "unified-crl" || req.Path == "unified-crl/pem" || req.Path == "unified-crl/delta" || req.Path == "unified-crl/delta/pem" || req.Path == "cert/unified-crl" || req.Path == "cert/unified-crl/raw" || req.Path == "cert/unified-crl/raw/pem" || req.Path == "cert/unified-delta-crl" || req.Path == "cert/unified-delta-crl/raw" || req.Path == "cert/unified-delta-crl/raw/pem":
+		config, err := b.crlBuilder.getConfigWithUpdate(sc)
+		if err != nil {
+			retErr = err
+			goto reply
+		}
 		var isDelta bool
 		var isUnified bool
 		if strings.Contains(req.Path, "delta") {
 			isDelta = true
 		}
-		if strings.Contains(req.Path, "unified") {
+		if strings.Contains(req.Path, "unified") || shouldLegacyPathUseUnified(config) {
 			isUnified = true
 		}
 

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -231,7 +231,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 		if strings.Contains(req.Path, "delta") {
 			isDelta = true
 		}
-		if strings.Contains(req.Path, "unified") || shouldLegacyPathUseUnified(config) {
+		if strings.Contains(req.Path, "unified") || shouldLocalPathsUseUnified(config) {
 			isUnified = true
 		}
 

--- a/builtin/logical/pki/path_ocsp.go
+++ b/builtin/logical/pki/path_ocsp.go
@@ -181,7 +181,7 @@ func canUseUnifiedStorage(req *logical.Request, cfg *crlConfig) bool {
 
 	// We are operating on the existing /pki/ocsp path, both of these fields need to be enabled
 	// for us to use the unified path.
-	return cfg.UnifiedCRL && cfg.UnifiedCRLOnExistingPaths
+	return shouldLegacyPathUseUnified(cfg)
 }
 
 func isUnifiedOcspPath(req *logical.Request) bool {

--- a/builtin/logical/pki/path_ocsp.go
+++ b/builtin/logical/pki/path_ocsp.go
@@ -181,7 +181,7 @@ func canUseUnifiedStorage(req *logical.Request, cfg *crlConfig) bool {
 
 	// We are operating on the existing /pki/ocsp path, both of these fields need to be enabled
 	// for us to use the unified path.
-	return shouldLegacyPathUseUnified(cfg)
+	return shouldLocalPathsUseUnified(cfg)
 }
 
 func isUnifiedOcspPath(req *logical.Request) bool {

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -357,3 +357,17 @@ func waitForUpdatedCrlUntil(t *testing.T, client *api.Client, crlPath string, la
 		time.Sleep(100 * time.Millisecond)
 	}
 }
+
+// A quick CRL to string to provide better test error messages
+func summarizeCrl(t *testing.T, crl pkix.TBSCertificateList) string {
+	version := getCRLNumber(t, crl)
+	serials := []string{}
+	for _, cert := range crl.RevokedCertificates {
+		serials = append(serials, normalizeSerialFromBigInt(cert.SerialNumber))
+	}
+	return fmt.Sprintf("CRL Version: %d\n"+
+		"This Update: %s\n"+
+		"Next Update: %s\n"+
+		"Revoked Serial Count: %d\n"+
+		"Revoked Serials: %v", version, crl.ThisUpdate, crl.NextUpdate, len(serials), serials)
+}


### PR DESCRIPTION

 - If the crl configuration option unified_crl_on_existing_paths is set to true along with the unified_crl feature, provide the unified crl on the existing CRL paths.
 - Added some test helpers to help debugging, they are being used by the ENT test that validates this feature.