### PR TITLE
UI: VAULT-13136 Update textfile to use native ember Textarea

### DIFF
--- a/ui/lib/core/addon/components/text-file.hbs
+++ b/ui/lib/core/addon/components/text-file.hbs
@@ -32,14 +32,11 @@
 <div class="field text-file box is-fullwidth is-marginless is-shadowless is-paddingless" data-test-component="text-file">
   {{#if this.showTextArea}}
     <div class="control has-icon-right">
-      <textarea
+      <Textarea
         id="input-{{this.elementId}}"
         class="textarea {{if (and (not this.showValue) this.content) 'masked-font'}}"
-        {{on "input" this.handleTextInput}}
-        data-test-text-file-textarea
-      >
-        {{this.content}}
-      </textarea>
+        @value={{this.content}}
+      />
       <button
         type="button"
         class="masked-input-toggle button is-compact"

--- a/ui/lib/core/addon/components/text-file.hbs
+++ b/ui/lib/core/addon/components/text-file.hbs
@@ -34,8 +34,10 @@
     <div class="control has-icon-right">
       <Textarea
         id="input-{{this.elementId}}"
-        class="textarea {{if (and (not this.showValue) this.content) 'masked-font'}}"
         @value={{this.content}}
+        class="textarea {{if (and (not this.showValue) this.content) 'masked-font'}}"
+        {{on "change" this.handleTextInput}}
+        data-test-text-file-textarea
       />
       <button
         type="button"

--- a/ui/lib/core/addon/components/text-file.hbs
+++ b/ui/lib/core/addon/components/text-file.hbs
@@ -36,7 +36,7 @@
         id="input-{{this.elementId}}"
         @value={{this.content}}
         class="textarea {{if (and (not this.showValue) this.content) 'masked-font'}}"
-        {{on "change" this.handleTextInput}}
+        {{on "input" this.handleTextInput}}
         data-test-text-file-textarea
       />
       <button


### PR DESCRIPTION
**Description**
- Update the `text-file` component to use ember's built in `Textarea` form field to avoid weird bugs. See ember doc [here](https://guides.emberjs.com/release/components/built-in-components/)

Before: 
<img width="1422" alt="Screenshot 2023-02-03 at 9 32 03 AM" src="https://user-images.githubusercontent.com/30884335/216669103-cbece136-1740-4266-9036-56a4af951b44.png">

After:
<img width="1395" alt="Screenshot 2023-02-03 at 9 28 00 AM" src="https://user-images.githubusercontent.com/30884335/216669129-505bdfda-366a-4086-af6d-3f66e089886d.png">
