### PR TITLE
Add updateRecord to role adapter

### DIFF
--- a/ui/app/adapters/pki/role.js
+++ b/ui/app/adapters/pki/role.js
@@ -62,6 +62,7 @@ export default class PkiRoleAdapter extends ApplicationAdapter {
   queryRecord(store, type, query) {
     return this.fetchByQuery(store, query);
   }
+
   deleteRecord(store, type, snapshot) {
     const { id, record } = snapshot;
     return this.ajax(this._urlForRole(record.backend, id), 'DELETE');

--- a/ui/app/adapters/pki/role.js
+++ b/ui/app/adapters/pki/role.js
@@ -34,6 +34,13 @@ export default class PkiRoleAdapter extends ApplicationAdapter {
     });
   }
 
+  updateRecord(store, type, snapshot) {
+    const { name, backend } = snapshot.record;
+    const data = this.serialize(snapshot);
+    const url = this._urlForRole(backend, name);
+    return this.ajax(url, 'POST', { data });
+  }
+
   fetchByQuery(store, query) {
     const { id, backend } = query;
 

--- a/ui/tests/integration/components/pki/pki-role-form-test.js
+++ b/ui/tests/integration/components/pki/pki-role-form-test.js
@@ -111,7 +111,7 @@ module('Integration | Component | pki-role-form', function (hooks) {
     await click(SELECTORS.roleCreateButton);
   });
 
-  test('meep it should rollback attributes or unload record on cancel', async function (assert) {
+  test('it should rollback attributes or unload record on cancel', async function (assert) {
     assert.expect(5);
     this.onCancel = () => assert.ok(true, 'onCancel callback fires');
     await render(
@@ -132,6 +132,7 @@ module('Integration | Component | pki-role-form', function (hooks) {
     this.store.pushPayload('pki/role', {
       modelName: 'pki/role',
       name: 'test-role',
+      backend: 'pki-test',
       id: 'role-id',
     });
 
@@ -155,11 +156,4 @@ module('Integration | Component | pki-role-form', function (hooks) {
     await click(SELECTORS.roleCreateButton);
     assert.strictEqual(this.model.issuerRef, 'not-default', 'Issuer Ref correctly saved on create');
   });
-
-  // TODO: ('it should update role', async function (assert) {}
-
-  /* FUTURE TEST TODO:
-   * it should update role
-   * it should unload the record on cancel
-   */
 });

--- a/ui/tests/integration/components/pki/pki-role-form-test.js
+++ b/ui/tests/integration/components/pki/pki-role-form-test.js
@@ -111,6 +111,28 @@ module('Integration | Component | pki-role-form', function (hooks) {
     await click(SELECTORS.roleCreateButton);
   });
 
+  test('meep it should rollback attributes or unload record on cancel', async function (assert) {
+    assert.expect(1);
+    this.onCancel = () => assert.ok(true, 'onCancel callback fires');
+    await render(
+      hbs`
+      <PkiRoleForm
+        @model={{this.model}}
+        @onCancel={{this.onCancel}}
+        @onSave={{this.onSave}}
+      />
+      `,
+      { owner: this.engine }
+    );
+
+    await fillIn(SELECTORS.roleName, 'test-role');
+    await click(SELECTORS.roleCancelButton);
+    // console.log(this.model, 'model name');
+    // await this.pauseTest();
+  });
+
+  // TODO: ('it should update role', async function (assert) {}
+
   /* FUTURE TEST TODO:
    * it should update role
    * it should unload the record on cancel

--- a/ui/tests/integration/components/pki/pki-role-form-test.js
+++ b/ui/tests/integration/components/pki/pki-role-form-test.js
@@ -112,7 +112,7 @@ module('Integration | Component | pki-role-form', function (hooks) {
   });
 
   test('it should rollback attributes or unload record on cancel', async function (assert) {
-    assert.expect(5);
+    assert.expect(6);
     this.onCancel = () => assert.ok(true, 'onCancel callback fires');
     await render(
       hbs`
@@ -127,6 +127,7 @@ module('Integration | Component | pki-role-form', function (hooks) {
 
     await fillIn(SELECTORS.roleName, 'dont-save-me');
     await click(SELECTORS.roleCancelButton);
+    assert.notEqual(this.model.roleName, 'dont-save-me');
     assert.true(this.model.isDestroyed, 'new model is unloaded on cancel');
 
     this.store.pushPayload('pki/role', {

--- a/ui/tests/integration/components/pki/pki-role-form-test.js
+++ b/ui/tests/integration/components/pki/pki-role-form-test.js
@@ -6,7 +6,7 @@ import { setupEngine } from 'ember-engines/test-support';
 import { SELECTORS } from 'vault/tests/helpers/pki/pki-role-form';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-module('Integration | Component | pki-role-form', function (hooks) {
+module('Integration | Component | meep pki-role-form', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
   setupEngine(hooks, 'pki'); // https://github.com/ember-engines/ember-engines/pull/653
@@ -111,8 +111,8 @@ module('Integration | Component | pki-role-form', function (hooks) {
     await click(SELECTORS.roleCreateButton);
   });
 
-  test('it should rollback attributes or unload record on cancel', async function (assert) {
-    assert.expect(6);
+  test('it should unload model on cancel', async function (assert) {
+    assert.expect(3);
     this.onCancel = () => assert.ok(true, 'onCancel callback fires');
     await render(
       hbs`
@@ -129,7 +129,10 @@ module('Integration | Component | pki-role-form', function (hooks) {
     await click(SELECTORS.roleCancelButton);
     assert.notEqual(this.model.roleName, 'dont-save-me');
     assert.true(this.model.isDestroyed, 'new model is unloaded on cancel');
+  });
 
+  test('it should save update attributes on update', async function (assert) {
+    assert.expect(1);
     this.store.pushPayload('pki/role', {
       modelName: 'pki/role',
       name: 'test-role',
@@ -150,9 +153,6 @@ module('Integration | Component | pki-role-form', function (hooks) {
       { owner: this.engine }
     );
 
-    await fillIn(SELECTORS.issuerRef, 'not-default');
-    await click(SELECTORS.roleCancelButton);
-    assert.strictEqual(this.model.issuerRef, 'default', 'Issuer Ref rolled back to default on cancel');
     await fillIn(SELECTORS.issuerRef, 'not-default');
     await click(SELECTORS.roleCreateButton);
     assert.strictEqual(this.model.issuerRef, 'not-default', 'Issuer Ref correctly saved on create');

--- a/ui/tests/integration/components/pki/pki-role-form-test.js
+++ b/ui/tests/integration/components/pki/pki-role-form-test.js
@@ -6,7 +6,7 @@ import { setupEngine } from 'ember-engines/test-support';
 import { SELECTORS } from 'vault/tests/helpers/pki/pki-role-form';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-module('Integration | Component | meep pki-role-form', function (hooks) {
+module('Integration | Component | pki-role-form', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
   setupEngine(hooks, 'pki'); // https://github.com/ember-engines/ember-engines/pull/653
@@ -131,7 +131,7 @@ module('Integration | Component | meep pki-role-form', function (hooks) {
     assert.true(this.model.isDestroyed, 'new model is unloaded on cancel');
   });
 
-  test('it should save update attributes on update', async function (assert) {
+  test('it should update attributes on the model on update', async function (assert) {
     assert.expect(1);
     this.store.pushPayload('pki/role', {
       modelName: 'pki/role',

--- a/ui/tests/unit/adapters/pki/role-test.js
+++ b/ui/tests/unit/adapters/pki/role-test.js
@@ -8,36 +8,22 @@ module('Unit | Adapter | pki/role', function (hooks) {
 
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');
-    this.backend = 'pki-test';
     this.store.unloadAll('pki/role');
   });
 
   test('it should make request to correct endpoint when updating a record', async function (assert) {
     assert.expect(1);
-    this.server.post('/pki-test/role/pki-role', () => {});
+    this.server.post('/pki-not-hardcoded/roles/pki-test', () => {
+      assert.ok(true, 'POST request made to correct endpoint when updating a record');
+    });
 
     this.store.pushPayload('pki/role', {
       modelName: 'pki/role',
       backend: 'pki-not-hardcoded',
       id: 'pki-test',
+      name: 'pki-test',
     });
     const record = this.store.peekRecord('pki/role', 'pki-test');
-    const response = await record.save().catch((e) => {
-      return e.path;
-    });
-    // because we're inside an engine we can't force permission capabilities to POST.
-    // To work around this we look at the 403 error and confirm the path posted includes the custom backend name (pki-test and not hardcoded pki).
-    assert.strictEqual(response, '/v1/pki-not-hardcoded/roles');
-  });
-
-  test('meep it should make request to correct endpoint on query', async function (assert) {
-    // THE store.quey method does not seem to hit a permissions issue.
-    assert.expect(1);
-    this.server.get(`${this.backend}/roles`, (schema, req) => {
-      assert.strictEqual(req.queryParams.list, 'true', 'request is made to correct endpoint on query');
-      return {};
-    });
-
-    this.store.query('pki/role', { backend: this.backend });
+    await record.save();
   });
 });

--- a/ui/tests/unit/adapters/pki/role-test.js
+++ b/ui/tests/unit/adapters/pki/role-test.js
@@ -1,0 +1,43 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Unit | Adapter | pki/role', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.backend = 'pki-test';
+    this.store.unloadAll('pki/role');
+  });
+
+  test('it should make request to correct endpoint when updating a record', async function (assert) {
+    assert.expect(1);
+    this.server.post('/pki-test/role/pki-role', () => {});
+
+    this.store.pushPayload('pki/role', {
+      modelName: 'pki/role',
+      backend: 'pki-not-hardcoded',
+      id: 'pki-test',
+    });
+    const record = this.store.peekRecord('pki/role', 'pki-test');
+    const response = await record.save().catch((e) => {
+      return e.path;
+    });
+    // because we're inside an engine we can't force permission capabilities to POST.
+    // To work around this we look at the 403 error and confirm the path posted includes the custom backend name (pki-test and not hardcoded pki).
+    assert.strictEqual(response, '/v1/pki-not-hardcoded/roles');
+  });
+
+  test('meep it should make request to correct endpoint on query', async function (assert) {
+    // THE store.quey method does not seem to hit a permissions issue.
+    assert.expect(1);
+    this.server.get(`${this.backend}/roles`, (schema, req) => {
+      assert.strictEqual(req.queryParams.list, 'true', 'request is made to correct endpoint on query');
+      return {};
+    });
+
+    this.store.query('pki/role', { backend: this.backend });
+  });
+});


### PR DESCRIPTION
Solves problem where the backend was hardcoded when you edited a pki role. 

**Update**: 
- added test coverage to confirm the model is being unloaded or updated correctly. 
- added test coverage to check that the correct endpoint is being hit on updateRecord when the backend is something other than "pki". 
- In future PR will add test coverage for the other custom adapter methods used in pki-role adapter.