### PR TITLE
PKI cleanup hardcoded mount path value 

### DIFF
--- a/ui/lib/pki/addon/components/page/pki-role-details.ts
+++ b/ui/lib/pki/addon/components/page/pki-role-details.ts
@@ -2,13 +2,13 @@ import { action } from '@ember/object';
 import RouterService from '@ember/routing/router-service';
 import Component from '@glimmer/component';
 import FlashMessageService from 'vault/services/flash-messages';
+import SecretMountPath from 'vault/services/secret-mount-path';
 import { inject as service } from '@ember/service';
 import errorMessage from 'vault/utils/error-message';
 
 // TODO: pull this in from route model once it's TS
 interface Args {
   role: {
-    backend: string;
     id: string;
     rollbackAttributes: () => void;
     destroyRecord: () => void;
@@ -18,11 +18,12 @@ interface Args {
 export default class DetailsPage extends Component<Args> {
   @service declare readonly router: RouterService;
   @service declare readonly flashMessages: FlashMessageService;
+  @service declare readonly secretMountPath: SecretMountPath;
 
   get breadcrumbs() {
     return [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.args.role.backend || 'pki', route: 'overview' },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'roles', route: 'roles.index' },
       { label: this.args.role.id },
     ];

--- a/ui/lib/pki/addon/components/pki-role-form.js
+++ b/ui/lib/pki/addon/components/pki-role-form.js
@@ -22,16 +22,16 @@ import { tracked } from '@glimmer/tracking';
 export default class PkiRoleForm extends Component {
   @service store;
   @service flashMessages;
+  @service secretMountPath;
 
   @tracked errorBanner;
   @tracked invalidFormAlert;
   @tracked modelValidations;
 
   get breadcrumbs() {
-    const backend = this.args.model.backend || 'pki';
     const crumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: backend, route: 'overview' },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'roles', route: 'roles.index' },
     ];
     if (!this.args.model.isNew) {

--- a/ui/lib/pki/addon/routes/certificates/certificate/details.js
+++ b/ui/lib/pki/addon/routes/certificates/certificate/details.js
@@ -11,10 +11,9 @@ export default class PkiCertificateDetailsRoute extends Route {
   }
   setupController(controller, model) {
     super.setupController(controller, model);
-    const backend = this.secretMountPath.currentPath || 'pki';
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: backend, route: 'overview' },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'certificates', route: 'certificates.index' },
       { label: model.id },
     ];

--- a/ui/lib/pki/addon/routes/configuration/create.js
+++ b/ui/lib/pki/addon/routes/configuration/create.js
@@ -21,10 +21,9 @@ export default class PkiConfigurationCreateRoute extends Route {
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-    const backend = this.secretMountPath.currentPath || 'pki';
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: backend, route: 'overview' },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'configure' },
     ];
   }

--- a/ui/lib/pki/addon/routes/error.js
+++ b/ui/lib/pki/addon/routes/error.js
@@ -8,7 +8,7 @@ export default class PkiRolesErrorRoute extends Route {
     super.setupController(...arguments);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath || 'pki', route: 'overview' },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
     ];
     controller.tabs = [
       { label: 'Overview', route: 'overview' },

--- a/ui/lib/pki/addon/routes/issuers/generate-root.js
+++ b/ui/lib/pki/addon/routes/issuers/generate-root.js
@@ -11,10 +11,9 @@ export default class PkiIssuersGenerateRootRoute extends Route {
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-    const backend = this.secretMountPath.currentPath || 'pki';
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: backend, route: 'overview' },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'generate root' },
     ];
   }

--- a/ui/lib/pki/addon/routes/issuers/index.js
+++ b/ui/lib/pki/addon/routes/issuers/index.js
@@ -28,10 +28,9 @@ export default class PkiIssuersListRoute extends PkiOverviewRoute {
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-    const backend = this.secretMountPath.currentPath || 'pki';
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: backend, route: 'overview' },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'issuers', route: 'issuers.index' },
     ];
   }

--- a/ui/lib/pki/addon/routes/issuers/issuer/index.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/index.js
@@ -12,10 +12,9 @@ export default class PkiIssuerIndexRoute extends PkiIssuersListRoute {
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-    const backend = this.secretMountPath.currentPath || 'pki';
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: backend, route: 'overview' },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'issuers', route: 'issuers.index' },
     ];
   }

--- a/ui/lib/pki/addon/routes/issuers/issuer/sign.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/sign.js
@@ -17,10 +17,9 @@ export default class PkiIssuerSignRoute extends Route {
   }
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-    const backend = this.secretMountPath.currentPath || 'pki';
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: backend, route: 'overview' },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'issuers', route: 'issuers.index' },
       { label: resolvedModel.issuerRef, route: 'issuers.issuer.details' },
       { label: 'sign intermediate' },

--- a/ui/lib/pki/addon/routes/keys/index.js
+++ b/ui/lib/pki/addon/routes/keys/index.js
@@ -27,10 +27,9 @@ export default class PkiKeysIndexRoute extends PkiOverviewRoute {
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-    const backend = this.secretMountPath.currentPath || 'pki';
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: backend, route: 'overview' },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'keys', route: 'keys.index' },
     ];
   }

--- a/ui/lib/pki/addon/routes/roles/create.js
+++ b/ui/lib/pki/addon/routes/roles/create.js
@@ -15,10 +15,9 @@ export default class PkiRolesCreateRoute extends Route {
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-    const backend = this.secretMountPath.currentPath || 'pki';
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: backend, route: 'overview' },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'roles', route: 'roles.index' },
       { label: 'create' },
     ];

--- a/ui/lib/pki/addon/routes/roles/role/details.js
+++ b/ui/lib/pki/addon/routes/roles/role/details.js
@@ -16,10 +16,9 @@ export default class RolesRoleDetailsRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     const { id } = resolvedModel;
-    const backend = this.secretMountPath.currentPath || 'pki';
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: backend, route: 'overview' },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'roles', route: 'roles.index' },
       { label: id },
     ];

--- a/ui/lib/pki/addon/routes/roles/role/edit.js
+++ b/ui/lib/pki/addon/routes/roles/role/edit.js
@@ -18,10 +18,9 @@ export default class PkiRoleEditRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     const { id } = resolvedModel;
-    const backend = this.secretMountPath.currentPath || 'pki';
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: backend, route: 'overview' },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'roles', route: 'roles.index' },
       { label: id, route: 'roles.role.details' },
       { label: 'edit' },

--- a/ui/lib/pki/addon/routes/roles/role/generate.js
+++ b/ui/lib/pki/addon/routes/roles/role/generate.js
@@ -21,10 +21,9 @@ export default class PkiRoleGenerateRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     const { role } = this.paramsFor('roles/role');
-    const backend = this.secretMountPath.currentPath || 'pki';
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: backend, route: 'overview' },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'roles', route: 'roles.index' },
       { label: role, route: 'roles.role.details' },
       { label: 'generate certificate' },

--- a/ui/lib/pki/addon/routes/roles/role/sign.js
+++ b/ui/lib/pki/addon/routes/roles/role/sign.js
@@ -22,10 +22,9 @@ export default class PkiRoleSignRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     const { role } = this.paramsFor('roles/role');
-    const backend = this.secretMountPath.currentPath || 'pki';
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: backend, route: 'overview' },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'roles', route: 'roles.index' },
       { label: role, route: 'roles.role.details' },
       { label: 'sign certificate' },


### PR DESCRIPTION
While debugging the issue in #18993 we were discussing that in order to get to the pki engine route the `secret-engine` model must be loaded so we will always have the mount path value which is necessary to really do anything within the pki secret engine. This PR cleans up any remaining instances of a hardcoded mount path value. 