### PR TITLE
Fix: Optionally reload x509 key-pair from disk on agent auto-auth

### DIFF
--- a/command/agent/auth/cert/cert.go
+++ b/command/agent/auth/cert/cert.go
@@ -20,6 +20,7 @@ type certMethod struct {
 	caCert     string
 	clientCert string
 	clientKey  string
+	reload     bool
 
 	// Client is the cached client to use if cert info was provided.
 	client *api.Client
@@ -73,6 +74,14 @@ func NewCertAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 				return nil, errors.New("could not convert 'cert_key' config value to string")
 			}
 		}
+
+		reload, ok := conf.Config["reload"]
+		if ok {
+			c.reload, ok = reload.(bool)
+			if !ok {
+				return nil, errors.New("could not convert 'reload' config value to bool")
+			}
+		}
 	}
 
 	return c, nil
@@ -108,7 +117,7 @@ func (c *certMethod) AuthClient(client *api.Client) (*api.Client, error) {
 
 	if c.caCert != "" || (c.clientKey != "" && c.clientCert != "") {
 		// Return cached client if present
-		if c.client != nil {
+		if c.client != nil && !c.reload {
 			return c.client, nil
 		}
 

--- a/website/content/docs/agent/autoauth/methods/cert.mdx
+++ b/website/content/docs/agent/autoauth/methods/cert.mdx
@@ -30,3 +30,6 @@ Stanza](/vault/docs/agent#vault-stanza).
 
 - `client_key` `(string: optional)` - Path on the local disk to a single
   PEM-encoded private key matching the client certificate from client_cert.
+
+- `reload` `(bool: optional, default: false)` - If true, causes the local x509 key-pair to be reloaded from disk on each authentication attempt.
+  This is useful in situations where client certificates are short-lived and automatically renewed.


### PR DESCRIPTION
This PR fixes #18562. I came to the conclusion that solving it this way would be safest, as it won't affect any existing Vault Agent configurations. I have also updated the documentation to match the new configuration property. 