### PR TITLE
[QT-304] Ensure Chrome is only installed for vault-enterprise UI Test workflows

### DIFF
--- a/.github/workflows/test-enos-scenario-ui.yml
+++ b/.github/workflows/test-enos-scenario-ui.yml
@@ -44,14 +44,13 @@ jobs:
         run: |
           echo "go-version=$(cat ./.go-version)" >> $GITHUB_OUTPUT
           echo "node-version=$(cat ./ui/.nvmrc)" >> $GITHUB_OUTPUT
-          echo "chrome-installed=$(chrome --version && echo true || echo false)" >> $GITHUB_OUTPUT
           if ${IS_ENT} == true; then
             echo "detected vault_edition=ent"
             echo "runs-on=['self-hosted', 'ondemand', 'os=linux', 'type=m5d.4xlarge']" >> $GITHUB_OUTPUT
             echo "vault_edition=ent" >> $GITHUB_OUTPUT
           else
             echo "detected vault_edition=oss"
-            echo "runs-on=custom-linux-xl-vault-latest" >> $GITHUB_OUTPUT
+            echo "runs-on=\"custom-linux-xl-vault-latest\"" >> $GITHUB_OUTPUT
             echo "vault_edition=oss" >> $GITHUB_OUTPUT
           fi
 
@@ -100,15 +99,16 @@ jobs:
         if: contains(${{ github.event.repository.name }}, 'ent')
         run: echo "${{ secrets.VAULT_LICENSE }}" > ./enos/support/vault.hclic || true
       - name: Install Chrome Dependencies
-        if: ${{ !needs.get-metadata.outputs.chrome-installed }}
+        if: ${{ needs.get-metadata.outputs.vault_edition == 'ent' }}
         run: |
           sudo apt update
           sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
       - name: Install Chrome
-        if: ${{ !needs.get-metadata.outputs.chrome-installed }}
+        if: ${{ needs.get-metadata.outputs.vault_edition == 'ent' }}
         uses: browser-actions/setup-chrome@v1
-      - run: |
-         chrome --version
+      - name: Chrome Version
+        if: ${{ needs.get-metadata.outputs.vault_edition == 'ent' }}
+        run: chrome --version
       - name: Configure AWS credentials from Test account
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -135,7 +135,6 @@ jobs:
         id: run_ui_tests
         env:
           ENOS_VAR_ui_test_filter: "${{ inputs.test_filter }}"
-        run: enos scenario run --timeout 60m0s --chdir ./enos ui edition:${{ needs.get-metadata.outputs.vault_edition }} backend:${{ inputs.storage_backend }}
       - name: Ensure scenario has been destroyed
         if: ${{ always() }}
         run: enos scenario destroy --timeout 60m0s --chdir ./enos ui edition:${{ needs.get-metadata.outputs.vault_edition }} backend:${{ inputs.storage_backend }}

--- a/.github/workflows/test-enos-scenario-ui.yml
+++ b/.github/workflows/test-enos-scenario-ui.yml
@@ -98,17 +98,20 @@ jobs:
       - name: Set Up Vault Enterprise License
         if: contains(${{ github.event.repository.name }}, 'ent')
         run: echo "${{ secrets.VAULT_LICENSE }}" > ./enos/support/vault.hclic || true
+      - name: Check Chrome Installed
+        id: chrome-check
+        run: echo "chrome-version=$(chrome --version 2> /dev/null || google-chrome --version 2> /dev/null || google-chrome-stable --version 2> /dev/null || echo 'not-installed')" >> $GITHUB_OUTPUT
       - name: Install Chrome Dependencies
-        if: ${{ needs.get-metadata.outputs.vault_edition == 'ent' }}
+        if: steps.chrome-check.outputs.chrome-version == 'not-installed'
         run: |
           sudo apt update
           sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
       - name: Install Chrome
-        if: ${{ needs.get-metadata.outputs.vault_edition == 'ent' }}
+        if: steps.chrome-check.outputs.chrome-version == 'not-installed'
         uses: browser-actions/setup-chrome@v1
-      - name: Chrome Version
-        if: ${{ needs.get-metadata.outputs.vault_edition == 'ent' }}
-        run: chrome --version
+      - name: Installed Chrome Version
+        run: |
+          echo "Installed Chrome Version = [$(chrome --version 2> /dev/null || google-chrome --version 2> /dev/null || google-chrome-stable --version 2> /dev/null)]"
       - name: Configure AWS credentials from Test account
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -135,6 +138,7 @@ jobs:
         id: run_ui_tests
         env:
           ENOS_VAR_ui_test_filter: "${{ inputs.test_filter }}"
+        run: enos scenario run --timeout 60m0s --chdir ./enos ui edition:${{ needs.get-metadata.outputs.vault_edition }} backend:${{ inputs.storage_backend }}
       - name: Ensure scenario has been destroyed
         if: ${{ always() }}
         run: enos scenario destroy --timeout 60m0s --chdir ./enos ui edition:${{ needs.get-metadata.outputs.vault_edition }} backend:${{ inputs.storage_backend }}

--- a/enos/enos-scenario-ui.hcl
+++ b/enos/enos-scenario-ui.hcl
@@ -38,7 +38,7 @@ scenario "ui" {
       ubuntu = "/usr/bin"
     }
     vault_install_dir = var.vault_install_dir
-    ui_test_filter    = var.ui_test_filter != null ? var.ui_test_filter : (matrix.edition == "oss") ? "!enterprise" : null
+    ui_test_filter    = var.ui_test_filter != null && try(trimspace(var.ui_test_filter), "") != "" ? var.ui_test_filter : (matrix.edition == "oss") ? "!enterprise" : null
   }
 
   step "get_local_metadata" {


### PR DESCRIPTION
After testing triggering the UI Tests GitHub Action manually, I noticed two problems:
* Chrome was being installed when the action was run in the `vault` repo, with the custom runner, which was not necessary
* The `ui_test_filter` was not properly set to `!enterprise` in the case when no filter was provided to the workflow.

This PR fixes these two issues, by:
* Changing the criteria for installing Chrome to rather check what repository the workflow is running in. Chrome should only be installed in the `vault-enterprise` repository.
* Updating the local used to set the ui test filter in the scenario to check if the filter is an empty string and if so adding the `!enterprise` filter.