### PR TITLE
docs/vault-k8s: 1.2.0 release updates

### DIFF
--- a/website/content/docs/platform/k8s/injector/annotations.mdx
+++ b/website/content/docs/platform/k8s/injector/annotations.mdx
@@ -28,7 +28,7 @@ them, optional commands to run, etc.
 
 - `vault.hashicorp.com/agent-image` - name of the Vault docker image to use. This
   value overrides the default image configured in the injector and is usually
-  not needed. Defaults to `hashicorp/vault:1.12.1`.
+  not needed. Defaults to `hashicorp/vault:1.12.3`.
 
 - `vault.hashicorp.com/agent-init-first` - configures the pod to run the Vault Agent
   init container first if `true` (last if `false`). This is useful when other init
@@ -192,6 +192,10 @@ them, optional commands to run, etc.
   ~> **Note**: If the first application container in the pod is running as root
   (uid 0), the `run-as-same-user` annotation will fail injection with an error.
 
+- `vault.hashicorp.com/agent-share-process-namespace` - sets
+  [shareProcessNamespace] in the Pod spec where Vault Agent is injected.
+  Defaults to `false`.
+
 - `vault.hashicorp.com/agent-cache-enable` - configures Vault Agent to enable
   [caching](/vault/docs/agent/caching). In Vault 1.7+ this annotation will also enable
   a Vault Agent persistent cache. This persistent cache will be shared between the init
@@ -319,3 +323,4 @@ etc.
   Agents.
 
 [k8s-resources]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
+[shareProcessNamespace]: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/

--- a/website/content/docs/platform/k8s/injector/index.mdx
+++ b/website/content/docs/platform/k8s/injector/index.mdx
@@ -26,6 +26,7 @@ The following [Kubernetes minor releases][k8s-releases] are currently supported.
 The latest version of the injector is tested against each version. It may work
 with other versions of Kubernetes, but those are not supported.
 
+* 1.26
 * 1.25
 * 1.24
 * 1.23


### PR DESCRIPTION
Docs updates to go along with the [v1.2.0 release](https://github.com/hashicorp/vault-k8s/releases/tag/v1.2.0) (along with https://github.com/hashicorp/vault/pull/18681).