### PR TITLE
docs: update learn links to point to developer locations

### DIFF
--- a/website/content/docs/agent/autoauth/methods/aws.mdx
+++ b/website/content/docs/agent/autoauth/methods/aws.mdx
@@ -63,4 +63,4 @@ parameters unset in your configuration.
 ## Tutorial
 
 Refer to the [Vault Agent with
-AWS](https://learn.hashicorp.com/vault/identity-access-management/vault-agent-aws) tutorial to learn how to integrate Vault with IAM AWS' native authentication.
+AWS](/vault/tutorials/vault-agent/agent-aws) tutorial to learn how to integrate Vault with IAM AWS' native authentication.

--- a/website/content/docs/agent/autoauth/methods/kubernetes.mdx
+++ b/website/content/docs/agent/autoauth/methods/kubernetes.mdx
@@ -20,5 +20,5 @@ method](/vault/docs/auth/kubernetes/).
 ## Tutorial
 
 Refer to the [Vault Agent with
-Kubernetes](https://learn.hashicorp.com/vault/identity-access-management/vault-agent-k8s)
+Kubernetes](/vault/tutorials/kubernetes/agent-kubernetes)
 tutorial to learn how to authenticate the clients using a Kubernetes Service Account Token and manage the tokens lifecycle.

--- a/website/content/docs/agent/caching/index.mdx
+++ b/website/content/docs/agent/caching/index.mdx
@@ -259,5 +259,5 @@ listener "tcp" {
 ## Tutorial
 
 Refer to the [Vault Agent
-Caching](https://learn.hashicorp.com/vault/identity-access-management/agent-caching)
+Caching](/vault/tutorials/vault-agent/agent-caching)
 tutorial to learn how to use the Vault Agent to increase the availability of tokens and secrets to clients using its Caching function.

--- a/website/content/docs/auth/approle.mdx
+++ b/website/content/docs/auth/approle.mdx
@@ -236,7 +236,7 @@ belonging to configured CIDR blocks on the AppRole.
 ## Tutorial
 
 Refer to the [AppRole Pull
-Authentication](https://learn.hashicorp.com/vault/identity-access-management/iam-authentication)
+Authentication](/vault/tutorials/auth-methods/approle)
 tutorial to learn how to use the AppRole method to generate tokens for machines or apps.
 
 ## API

--- a/website/content/docs/auth/kerberos.mdx
+++ b/website/content/docs/auth/kerberos.mdx
@@ -211,7 +211,7 @@ or by providing it to [HashiCorp Support](https://www.hashicorp.com/support)
 
 ### Additional Troubleshooting Resources
 
-- [Troubleshooting Vault](https://learn.hashicorp.com/vault/operations/troubleshooting-vault)
+- [Troubleshooting Vault](/vault/tutorials/monitoring/troubleshooting-vault)
 - [The plugin's code](https://github.com/hashicorp/vault-plugin-auth-kerberos)
 
 The Vault Kerberos library has a working integration test environment that

--- a/website/content/docs/concepts/dev-server.mdx
+++ b/website/content/docs/concepts/dev-server.mdx
@@ -50,7 +50,7 @@ flags or by specifying a configuration file):
 
 The dev server should be used for experimentation with Vault features, such
 as different auth methods, secrets engines, audit devices, etc.
-If you're new to Vault, you may want to pick up with [Your First Secret](https://learn.hashicorp.com/vault/getting-started/first-secret) in our getting started guide.
+If you're new to Vault, you may want to pick up with [Your First Secret](/vault/tutorials/getting-started/getting-started-first-secret) in our getting started guide.
 
 In addition to experimentation, the dev server is very easy to automate
 for development environments.

--- a/website/content/docs/concepts/integrated-storage/index.mdx
+++ b/website/content/docs/concepts/integrated-storage/index.mdx
@@ -39,7 +39,7 @@ This section will outline how to bootstrap and manage a cluster of Vault nodes
 running Integrated Storage.
 
 Integrated Storage is bootstrapped during the [initialization
-process](https://learn.hashicorp.com/vault/getting-started/deploy#initializing-the-vault),
+process](/vault/tutorials/getting-started/getting-started-deploy#initializing-the-vault),
 and results in a cluster of size 1. Depending on the [desired deployment
 size](/vault/docs/internals/integrated-storage/#deployment-table), nodes can be joined
 to the active Vault node.

--- a/website/content/docs/concepts/password-policies.mdx
+++ b/website/content/docs/concepts/password-policies.mdx
@@ -363,5 +363,5 @@ character from `01234` to be in it, but does not require any characters from `ab
 ## Tutorial
 
 Refer to [User Configurable Password Generation for Secret
-Engines](https://learn.hashicorp.com/vault/secrets-management/password-policies)
+Engines](/vault/tutorials/policies/password-policies)
 for a step-by-step tutorial.

--- a/website/content/docs/concepts/policies.mdx
+++ b/website/content/docs/concepts/policies.mdx
@@ -772,5 +772,5 @@ next time a token, with that policy attached, is used to make a call to Vault.
 
 Refer to the following tutorials for further learning:
 
-- [Vault Policies](https://learn.hashicorp.com/vault/identity-access-management/iam-policies)
-- [ACL Policy Path Templating](https://learn.hashicorp.com/vault/identity-access-management/policy-templating)
+- [Vault Policies](/vault/tutorials/policies/policies)
+- [ACL Policy Path Templating](/vault/tutorials/policies/policy-templating)

--- a/website/content/docs/concepts/resource-quotas.mdx
+++ b/website/content/docs/concepts/resource-quotas.mdx
@@ -69,7 +69,7 @@ resource quotas by updating the `rate_limit_exempt_paths` configuration field.
 ## Tutorial
 
 Refer to [Protecting Vault with Resource
-Quotas](https://learn.hashicorp.com/vault/security/resource-quotas) for a
+Quotas](/vault/tutorials/operations/resource-quotas) for a
 step-by-step tutorial.
 
 ## API

--- a/website/content/docs/configuration/entropy-augmentation.mdx
+++ b/website/content/docs/configuration/entropy-augmentation.mdx
@@ -46,7 +46,7 @@ entropy "seal" {
 }
 ```
 
-For a more detailed tutorial, visit the [HSM Entropy Challenge](https://learn.hashicorp.com/vault/operations/hsm-entropy)
+For a more detailed tutorial, visit the [HSM Entropy Challenge](/vault/tutorials/enterprise/hsm-entropy)
 on HashiCorp's Learn website.
 
 ## `entropy augmentation` Parameters

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -52,7 +52,7 @@ to specify where the configuration is.
   storage backend supports HA coordination and if HA specific options are
   already specified with `storage` parameter. (Refer to [Use Integrated Storage
   for HA
-  Coordination](https://learn.hashicorp.com/vault/operations/raft-ha-storage)
+  Coordination](/vault/tutorials/raft/raft-ha-storage)
   for a usage example.)
 
 - `listener` `([Listener][listener]: <required>)` – Configures how

--- a/website/content/docs/configuration/seal/awskms.mdx
+++ b/website/content/docs/configuration/seal/awskms.mdx
@@ -123,5 +123,5 @@ or set to current under a key alias.
 
 ## Tutorial
 
-Refer to the [Auto-unseal using AWS KMS](https://learn.hashicorp.com/vault/operations/ops-autounseal-aws-kms)
+Refer to the [Auto-unseal using AWS KMS](/vault/tutorials/auto-unseal/autounseal-aws-kms)
 tutorial to learn how to auto-unseal Vault using AWS KMS.

--- a/website/content/docs/configuration/seal/azurekeyvault.mdx
+++ b/website/content/docs/configuration/seal/azurekeyvault.mdx
@@ -88,7 +88,7 @@ and secret. MSI must be
 on the VMs hosting Vault, and it is the preferred configuration since MSI
 prevents your Azure credentials from being stored as clear text. Refer to the
 [Production
-Hardening](https://learn.hashicorp.com/vault/day-one/production-hardening) tutorial
+Hardening](/vault/tutorials/operations/production-hardening) tutorial
 for more best practices.
 
 -> **Note:** If you are using a Managed HSM KeyVault, `AZURE_AD_RESOURCE` or the `resource`
@@ -113,5 +113,5 @@ using Azure Automation Account and Vault will recognize newly rotated keys.
 
 ## Tutorial
 
-Refer to the [Auto-unseal using Azure Key Vault](https://learn.hashicorp.com/vault/operations/autounseal-azure-keyvault)
+Refer to the [Auto-unseal using Azure Key Vault](/vault/tutorials/auto-unseal/autounseal-azure-keyvault)
 tutorial to learn how to use the Azure Key Vault to auto-unseal a Vault server.

--- a/website/content/docs/configuration/seal/gcpckms.mdx
+++ b/website/content/docs/configuration/seal/gcpckms.mdx
@@ -116,5 +116,5 @@ encrypted with the primary key version.
 
 ## Tutorial
 
-Refer to the [Auto-unseal using GCP Cloud KMS](https://learn.hashicorp.com/vault/operations/autounseal-gcp-kms)
+Refer to the [Auto-unseal using GCP Cloud KMS](/vault/tutorials/auto-unseal/autounseal-gcp-kms)
 guide for a step-by-step tutorial.

--- a/website/content/docs/configuration/seal/pkcs11.mdx
+++ b/website/content/docs/configuration/seal/pkcs11.mdx
@@ -275,5 +275,5 @@ rotation is desired for data that was seal wrapped prior to this version must al
 
 ## Tutorial
 
-Refer to the [HSM Integration - Seal Wrap](https://learn.hashicorp.com/vault/operations/ops-seal-wrap)
+Refer to the [HSM Integration - Seal Wrap](/vault/tutorials/auto-unseal/seal-wrap)
 tutorial to learn how to enable the Seal Wrap feature to protect your data.

--- a/website/content/docs/configuration/seal/transit.mdx
+++ b/website/content/docs/configuration/seal/transit.mdx
@@ -127,5 +127,5 @@ used to decrypt older data.
 
 ## Tutorial
 
-Refer to the [Auto-unseal using Transit Secrets Engine](https://learn.hashicorp.com/vault/operations/autounseal-transit)
+Refer to the [Auto-unseal using Transit Secrets Engine](/vault/tutorials/auto-unseal/autounseal-transit)
 tutorial to learn how use the transit secrets engine to automatically unseal Vault.

--- a/website/content/docs/enterprise/control-groups.mdx
+++ b/website/content/docs/enterprise/control-groups.mdx
@@ -206,7 +206,7 @@ happened in the last hour.
 
 ## Tutorial
 
-Refer to the [Control Groups](https://learn.hashicorp.com/vault/identity-access-management/iam-control-groups)
+Refer to the [Control Groups](/vault/tutorials/enterprise/control-groups)
 tutorial to learn how to implement dual controller authorization within your policies.
 
 ## API

--- a/website/content/docs/enterprise/entropy-augmentation.mdx
+++ b/website/content/docs/enterprise/entropy-augmentation.mdx
@@ -60,5 +60,5 @@ for a supported seal type.
 
 ## Tutorial
 
-Refer to the [HSM Integration - Entropy Augmentation](https://learn.hashicorp.com/vault/operations/hsm-entropy) tutorial
+Refer to the [HSM Integration - Entropy Augmentation](/vault/tutorials/enterprise/hsm-entropy) tutorial
 to learn how to use the Entropy Augmentation function to leverage an external Hardware Security Module to augment system entropy.

--- a/website/content/docs/enterprise/lease-count-quotas.mdx
+++ b/website/content/docs/enterprise/lease-count-quotas.mdx
@@ -50,7 +50,7 @@ exposed and through enabling optional audit logging.
 ## Tutorial
 
 Refer to [Protecting Vault with Resource
-Quotas](https://learn.hashicorp.com/vault/security/resource-quotas) for a
+Quotas](/vault/tutorials/operations/resource-quotas) for a
 step-by-step tutorial.
 
 ## API

--- a/website/content/docs/enterprise/namespaces.mdx
+++ b/website/content/docs/enterprise/namespaces.mdx
@@ -102,5 +102,5 @@ across any namespace.
 
 ## Tutorial
 
-Refer to the [Secure Multi-Tenancy with Namespaces](https://learn.hashicorp.com/vault/operations/namespaces)
+Refer to the [Secure Multi-Tenancy with Namespaces](/vault/tutorials/enterprise/namespaces)
 tutorial to learn how to use Vault as a Service to allow organizations(tenants) to manage their own secrets and policies.

--- a/website/content/docs/enterprise/replication.mdx
+++ b/website/content/docs/enterprise/replication.mdx
@@ -231,10 +231,10 @@ cluster port at a load balancer level.
 
 Refer to the following tutorials replication setup and best practices:
 
-- [Setting up Performance Replication](https://learn.hashicorp.com/vault/operations/ops-replication)
-- [Disaster Recovery Replication Setup](https://learn.hashicorp.com/vault/operations/ops-disaster-recovery)
+- [Setting up Performance Replication](/vault/tutorials/enterprise/performance-replication)
+- [Disaster Recovery Replication Setup](/vault/tutorials/enterprise/disaster-recovery)
 - [Performance Replication with Paths Filters](/vault/tutorials/enterprise/paths-filter)
-- [Monitoring Vault Replication](https://learn.hashicorp.com/vault/operations/monitor-replication)
+- [Monitoring Vault Replication](/vault/tutorials/monitoring/monitor-replication)
 
 ## API
 

--- a/website/content/docs/enterprise/sentinel/index.mdx
+++ b/website/content/docs/enterprise/sentinel/index.mdx
@@ -112,5 +112,5 @@ property documentation.
 
 ## Tutorial
 
-Refer to the [Sentinel Policies](https://learn.hashicorp.com/vault/identity-access-management/iam-sentinel)
+Refer to the [Sentinel Policies](/vault/tutorials/policies/sentinel)
 tutorial to learn how to author Sentinel policies in Vault.

--- a/website/content/docs/install.mdx
+++ b/website/content/docs/install.mdx
@@ -79,5 +79,5 @@ on your `PATH` to avoid receiving an error that Vault is not found.
 $ vault -h
 ```
 
-[learn-vault-install]: https://learn.hashicorp.com/vault/getting-started/install
-[learn-vault-dev-server]: https://learn.hashicorp.com/vault/getting-started/dev-server
+[learn-vault-install]: /vault/tutorials/getting-started/getting-started-install
+[learn-vault-dev-server]: /vault/tutorials/getting-started/getting-started-dev-server

--- a/website/content/docs/platform/aws/run.mdx
+++ b/website/content/docs/platform/aws/run.mdx
@@ -10,7 +10,7 @@ description: >-
 
 ## Launching the Vault AMI
 
-When Vault is first launched from an official Marketplace AMI, it will come up in an uninitialized state and must be initialized via the [API](/vault/api-docs/system/init), [CLI](/vault/docs/commands/operator/init), or UI. The Marketplace AMI listens on port 8200 by default. It is recommended to restrict ingress networking to the Vault instance as much as possible when initially deploying Vault (through EC2 security groups or otherwise) because anyone with network access to Vault will be able to initialize it. To learn more about the default listener configuration, or to make changes, please see the [Vault Deployment Guide](https://learn.hashicorp.com/vault/operations/ops-deployment-guide#listener-stanza).
+When Vault is first launched from an official Marketplace AMI, it will come up in an uninitialized state and must be initialized via the [API](/vault/api-docs/system/init), [CLI](/vault/docs/commands/operator/init), or UI. The Marketplace AMI listens on port 8200 by default. It is recommended to restrict ingress networking to the Vault instance as much as possible when initially deploying Vault (through EC2 security groups or otherwise) because anyone with network access to Vault will be able to initialize it. To learn more about the default listener configuration, or to make changes, please see the [Vault Deployment Guide](/vault/tutorials/day-one-consul/deployment-guide#listener-stanza).
 
 Additionally on first launch, a new self-signed [certificate](/vault/docs/configuration/listener/tcp#tls_cert_file) and [key](/vault/docs/configuration/listener/tcp#tls_key_file) (unique to the EC2 instance) will be generated to secure Vault traffic using TLS. This is provided as a “more secure” (vs. unencrypted TCP traffic) temporary solution, but it is strongly recommended to replace these with your own certificate and key. Please note that when using a self-signed certificate, Vault clients will need to [skip](/vault/docs/commands#vault_skip_verify) the verification of Vault’s certificate, which voids Vault’s [security model](/vault/docs/internals/security).
 
@@ -30,7 +30,7 @@ To upgrade a Vault instance launched from an official AWS Marketplace AMI, pleas
 
 HashiCorp’s AWS Marketplace offerings provide an easy way to deploy Vault in a single-instance configuration using the [Filesystem storage backend](/vault/docs/configuration/storage/filesystem), but for production use, we recommend running Vault on AWS with the same [general architecture](/vault/docs/internals/architecture) as running it anywhere else. While the Filesystem storage backend is officially supported by HashiCorp, it does not support High Availability. Because Vault data is stored on disk in this configuration, it is subject to the durability and availability of Amazon Elastic Block Store (EBS) and should be backed up accordingly.
 
-For additional guidance on best practices for running Vault in production, please refer to the [Production Hardening](https://learn.hashicorp.com/vault/day-one/production-hardening) tutorial.
+For additional guidance on best practices for running Vault in production, please refer to the [Production Hardening](/vault/tutorials/operations/production-hardening) tutorial.
 
 # Getting Support
 

--- a/website/content/docs/platform/k8s/helm/examples/development.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/development.mdx
@@ -21,5 +21,5 @@ server:
 ## Tutorial
 
 Refer to the [Injecting Secrets into Kubernetes Pods via Vault Helm
-Sidecar](https://learn.hashicorp.com/vault/getting-started-k8s/sidecar) tutorial
+Sidecar](/vault/tutorials/kubernetes/kubernetes-sidecar) tutorial
 to learn how to set up Vault and the Vault Agent Injector service with the Vault Helm chart.

--- a/website/content/docs/platform/k8s/helm/examples/external.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/external.mdx
@@ -21,5 +21,5 @@ injector:
 ## Learn
 
 Refer to the [Integrate a Kubernetes Cluster with an External
-Vault](https://learn.hashicorp.com/vault/getting-started-k8s/external-vault)
+Vault](/vault/tutorials/kubernetes/kubernetes-external-vault)
 guide for a step-by-step tutorial.

--- a/website/content/docs/platform/k8s/helm/openshift.mdx
+++ b/website/content/docs/platform/k8s/helm/openshift.mdx
@@ -204,5 +204,5 @@ $ helm install vault hashicorp/vault \
 ## Tutorial
 
 Refer to the [Integrate a Kubernetes Cluster with an
-External Vault](https://learn.hashicorp.com/vault/getting-started-k8s/external-vault)
+External Vault](/vault/tutorials/kubernetes/kubernetes-external-vault)
 tutorial to learn how to use an external Vault within a Kubernetes cluster.

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -42,7 +42,7 @@ checklist](/vault/docs/platform/k8s/helm/run#architecture).
 
 Helm must be installed and configured on your machine. Please refer to the [Helm
 documentation](https://helm.sh/) or the [Vault Installation to Minikube via
-Helm](https://learn.hashicorp.com/vault/getting-started-k8s/minikube) tutorial.
+Helm](/vault/tutorials/kubernetes/kubernetes-minikube-consul) tutorial.
 
 To use the Helm chart, add the Hashicorp helm repository and check that you have
 access to the chart:
@@ -127,7 +127,7 @@ $ helm install vault hashicorp/vault \
 ```
 
 Refer to the [Vault Installation to Minikube via
-Helm](https://learn.hashicorp.com/vault/getting-started-k8s/minikube) tutorial
+Helm](/vault/tutorials/kubernetes/kubernetes-minikube-consul) tutorial
 to learn how to set up Consul and Vault in HA mode.
 
 #### External mode
@@ -143,7 +143,7 @@ $ helm install vault hashicorp/vault \
 ```
 
 Refer to the [Integrate a Kubernetes Cluster with an
-External Vault](https://learn.hashicorp.com/vault/getting-started-k8s/external-vault)
+External Vault](/vault/tutorials/kubernetes/kubernetes-external-vault)
 tutorial to learn how to use an external Vault within a Kubernetes cluster.
 
 ### View the Vault UI
@@ -533,7 +533,7 @@ We recommend running Vault on Kubernetes with the same
 [general architecture](/vault/docs/internals/architecture)
 as running it anywhere else. There are some benefits Kubernetes can provide
 that eases operating a Vault cluster and we document those below. The standard
-[production deployment](https://learn.hashicorp.com/vault/day-one/production-hardening) tutorial is still an
+[production deployment](/vault/tutorials/operations/production-hardening) tutorial is still an
 important read even if running Vault within Kubernetes.
 
 ### Production Deployment Checklist

--- a/website/content/docs/platform/k8s/injector/index.mdx
+++ b/website/content/docs/platform/k8s/injector/index.mdx
@@ -206,5 +206,5 @@ An example of mounting a Vault Agent configmap [can be found here](/vault/docs/p
 ## Tutorial
 
 Refer to the [Injecting Secrets into Kubernetes Pods via Vault Helm
-Sidecar](https://learn.hashicorp.com/vault/getting-started-k8s/sidecar) guide
+Sidecar](/vault/tutorials/kubernetes/kubernetes-sidecar) guide
 for a step-by-step tutorial.

--- a/website/content/docs/plugins/plugin-development.mdx
+++ b/website/content/docs/plugins/plugin-development.mdx
@@ -111,7 +111,7 @@ plugin and enable it.
 ## Plugin Development - Resources
 
 For more information on how to register and enable your plugin, refer to the
-[Building Plugin Backends](https://learn.hashicorp.com/vault/developer/plugin-backends)
+[Building Plugin Backends](/vault/tutorials/app-integration/plugin-backends)
 tutorial.
 
 Other HashiCorp plugin development resources:

--- a/website/content/docs/secrets/ad.mdx
+++ b/website/content/docs/secrets/ad.mdx
@@ -284,7 +284,7 @@ check_ins    [fizz@example.com]
 ```
 
 To perform a check-in, Vault verifies that the caller _should_ be able to check in a given service account.
-To do this, Vault looks for either the same [entity ID](https://learn.hashicorp.com/vault/identity-access-management/iam-identity)
+To do this, Vault looks for either the same [entity ID](/vault/tutorials/auth-methods/identity)
 used to check out the service account, or the same client token.
 
 If a caller is unable to check in a service account, or simply doesn't try,
@@ -351,7 +351,7 @@ Active Directory will only support password changes over a secure connection. En
 
 ## Tutorial
 
-Refer to the [Active Directory Service Account Check-out](https://learn.hashicorp.com/vault/secrets-management/ad-secrets) tutorial to learn how to enable a team to share a select set of service accounts.
+Refer to the [Active Directory Service Account Check-out](/vault/tutorials/secrets-management/active-directory) tutorial to learn how to enable a team to share a select set of service accounts.
 
 ## API
 

--- a/website/content/docs/secrets/azure.mdx
+++ b/website/content/docs/secrets/azure.mdx
@@ -284,7 +284,7 @@ Please report issues, add feature requests, and submit contributions to the
 ## Tutorial
 
 Refer to the [Azure Secrets
-Engine](https://learn.hashicorp.com/vault/secrets-management/azure-creds) tutorial
+Engine](/vault/tutorials/secrets-management/azure-secrets) tutorial
 to learn how to use the Azure secrets engine to dynamically generate Azure credentials.
 
 ## API

--- a/website/content/docs/secrets/cubbyhole.mdx
+++ b/website/content/docs/secrets/cubbyhole.mdx
@@ -53,7 +53,7 @@ engine allows for writing keys with arbitrary values.
 
 ## Tutorial
 
-Refer to the [Cubbyhole Response Wrapping](https://learn.hashicorp.com/vault/secrets-management/sm-cubbyhole)
+Refer to the [Cubbyhole Response Wrapping](/vault/tutorials/secrets-management/cubbyhole-response-wrapping)
 tutorial to learn how to securely distribute the initial token to the trusted entity.
 
 ## API

--- a/website/content/docs/secrets/databases/mysql-maria.mdx
+++ b/website/content/docs/secrets/databases/mysql-maria.mdx
@@ -157,7 +157,7 @@ $ vault write database/config/my-mysql-database \
 ```
 
 For a guide in root credential rotation, see [Database Root Credential
-Rotation](https://learn.hashicorp.com/vault/secrets-management/db-root-rotation).
+Rotation](/vault/tutorials/db-credentials/database-root-rotation).
 
 ## API
 

--- a/website/content/docs/secrets/kmip.mdx
+++ b/website/content/docs/secrets/kmip.mdx
@@ -281,7 +281,7 @@ with their client certificate.
 
 ## Tutorial
 
-Refer to the [KMIP Secrets Engine](https://learn.hashicorp.com/vault/secrets-management/kmip-engine)
+Refer to the [KMIP Secrets Engine](/vault/tutorials/adp/kmip-engine)
 guide for a step-by-step tutorial.
 
 [kmip-spec]: http://docs.oasis-open.org/kmip/spec/v1.4/kmip-spec-v1.4.html

--- a/website/content/docs/secrets/kv/kv-v1.mdx
+++ b/website/content/docs/secrets/kv/kv-v1.mdx
@@ -101,7 +101,7 @@ ttl                 30m
 ## Tutorial
 
 Refer to the [Static Secrets: Key/Value Secrets
-Engine](https://learn.hashicorp.com/vault/secrets-management/sm-static-secrets)
+Engine](/vault/tutorials/secrets-management/static-secrets)
 tutorial to learn how to set up a uniform workflow to securely store sensitive information.
 
 ## API

--- a/website/content/docs/secrets/kv/kv-v2.mdx
+++ b/website/content/docs/secrets/kv/kv-v2.mdx
@@ -545,7 +545,7 @@ See the commands below for more information:
 ## Tutorial
 
 Refer to the [Versioned Key/Value Secrets
-Engine](https://learn.hashicorp.com/vault/secrets-management/sm-versioned-kv)
+Engine](/vault/tutorials/secrets-management/versioned-kv)
 tutorial to learn how to use KV secrets engine v2 to version or roll back secrets.
 
 ## API

--- a/website/content/docs/secrets/pki/considerations.mdx
+++ b/website/content/docs/secrets/pki/considerations.mdx
@@ -724,7 +724,7 @@ vault read pki/issuer/default
 
 ## Tutorial
 
-Refer to the [Build Your Own Certificate Authority (CA)](https://learn.hashicorp.com/vault/secrets-management/sm-pki-engine)
+Refer to the [Build Your Own Certificate Authority (CA)](/vault/tutorials/secrets-management/pki-engine)
 guide for a step-by-step tutorial.
 
 Have a look at the [PKI Secrets Engine with Managed Keys](/vault/tutorials/enterprise/managed-key-pki)

--- a/website/content/docs/secrets/pki/index.mdx
+++ b/website/content/docs/secrets/pki/index.mdx
@@ -46,7 +46,7 @@ The PKI Secrets Engine documentation is split into the following pieces:
 
 ## Tutorial
 
-Refer to the [Build Your Own Certificate Authority (CA)](https://learn.hashicorp.com/vault/secrets-management/sm-pki-engine)
+Refer to the [Build Your Own Certificate Authority (CA)](/vault/tutorials/secrets-management/pki-engine)
 guide for a step-by-step tutorial.
 
 Have a look at the [PKI Secrets Engine with Managed Keys](/vault/tutorials/enterprise/managed-key-pki)

--- a/website/content/docs/secrets/pki/quick-start-intermediate-ca.mdx
+++ b/website/content/docs/secrets/pki/quick-start-intermediate-ca.mdx
@@ -259,7 +259,7 @@ OS.
 
 ## Tutorial
 
-Refer to the [Build Your Own Certificate Authority (CA)](https://learn.hashicorp.com/vault/secrets-management/sm-pki-engine)
+Refer to the [Build Your Own Certificate Authority (CA)](/vault/tutorials/secrets-management/pki-engine)
 guide for a step-by-step tutorial.
 
 Have a look at the [PKI Secrets Engine with Managed Keys](/vault/tutorials/enterprise/managed-key-pki)

--- a/website/content/docs/secrets/pki/quick-start-root-ca.mdx
+++ b/website/content/docs/secrets/pki/quick-start-root-ca.mdx
@@ -216,7 +216,7 @@ subpath for interactive help output.
 
 ## Tutorial
 
-Refer to the [Build Your Own Certificate Authority (CA)](https://learn.hashicorp.com/vault/secrets-management/sm-pki-engine)
+Refer to the [Build Your Own Certificate Authority (CA)](/vault/tutorials/secrets-management/pki-engine)
 guide for a step-by-step tutorial.
 
 Have a look at the [PKI Secrets Engine with Managed Keys](/vault/tutorials/enterprise/managed-key-pki)

--- a/website/content/docs/secrets/pki/rotation-primitives.mdx
+++ b/website/content/docs/secrets/pki/rotation-primitives.mdx
@@ -433,7 +433,7 @@ certificates with unique serial numbers.
 
 ## Tutorial
 
-Refer to the [Build Your Own Certificate Authority (CA)](https://learn.hashicorp.com/vault/secrets-management/sm-pki-engine)
+Refer to the [Build Your Own Certificate Authority (CA)](/vault/tutorials/secrets-management/pki-engine)
 guide for a step-by-step tutorial.
 
 Have a look at the [PKI Secrets Engine with Managed Keys](/vault/tutorials/enterprise/managed-key-pki)

--- a/website/content/docs/secrets/pki/setup.mdx
+++ b/website/content/docs/secrets/pki/setup.mdx
@@ -107,7 +107,7 @@ the proper permission, it can generate credentials.
 
 ## Tutorial
 
-Refer to the [Build Your Own Certificate Authority (CA)](https://learn.hashicorp.com/vault/secrets-management/sm-pki-engine)
+Refer to the [Build Your Own Certificate Authority (CA)](/vault/tutorials/secrets-management/pki-engine)
 guide for a step-by-step tutorial.
 
 Have a look at the [PKI Secrets Engine with Managed Keys](/vault/tutorials/enterprise/managed-key-pki)

--- a/website/content/docs/secrets/ssh/one-time-ssh-passwords.mdx
+++ b/website/content/docs/secrets/ssh/one-time-ssh-passwords.mdx
@@ -110,7 +110,7 @@ disabled by setting `-strict-host-key-checking=no`.
 ## Tutorial
 
 Refer to the [SSH Secrets Engine: One-Time SSH
-Password](https://learn.hashicorp.com/vault/secrets-management/sm-ssh-otp) tutorial
+Password](/vault/tutorials/secrets-management/ssh-otp) tutorial
 to learn how to use the Vault SSH secrets engine to secure authentication and authorization for access to machines.
 
 ## API

--- a/website/content/docs/secrets/transform/index.mdx
+++ b/website/content/docs/secrets/transform/index.mdx
@@ -353,7 +353,7 @@ transformations:
 
 ## Tutorial
 
-Refer to the [Transform Secrets Engine](https://learn.hashicorp.com/vault/adp/transform) tutorial to learn how to use the Transform secrets engine to handle secure data transmission and tokenization against provided secrets.
+Refer to the [Transform Secrets Engine](/vault/tutorials/adp/transform) tutorial to learn how to use the Transform secrets engine to handle secure data transmission and tokenization against provided secrets.
 
 ## Bring Your Own Key (BYOK)
 

--- a/website/content/docs/secrets/transit/index.mdx
+++ b/website/content/docs/secrets/transit/index.mdx
@@ -311,7 +311,7 @@ For more details about wrapping the key for import into transit, see the
 ## Tutorial
 
 Refer to the [Encryption as a Service: Transit Secrets
-Engine](https://learn.hashicorp.com/vault/encryption-as-a-service/eaas-transit)
+Engine](/vault/tutorials/encryption-as-a-service/eaas-transit)
 tutorial to learn how to use the transit secrets engine to handle cryptographic functions on data in-transit.
 
 ## API


### PR DESCRIPTION
Updates links pointing at `learn.hashicorp.com` to point at their relative paths on `developer.hashicorp.com`