### PR TITLE
Document pki cross cluster behavior

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -3846,6 +3846,13 @@ expiration time.
    (but non-zero) can lead to lock contention. Use [tidy's cancellation](#cancel-tidy)
    to stop a running operation after the sleep period is over.
 
+- `revocation_queue_safety_buffer` `(string: "")` - Specifies a duration
+  after which cross-cluster revocation requests will be removed as expired.
+  This should be set high enough that, if a cluster disappears for a while
+  but later comes back, any revocation requests which it should process will
+  still be there, but not too long as to fill up storage with too many invalid
+  requests. Defaults to `48h`.
+
 #### Sample Payload
 
 ```json

--- a/website/content/docs/secrets/pki/considerations.mdx
+++ b/website/content/docs/secrets/pki/considerations.mdx
@@ -26,6 +26,8 @@ generating the CA to use with this secrets engine.
  - [You must configure issuing/CRL/OCSP information _in advance_](#you-must-configure-issuingcrlocsp-information-_in-advance_)
  - [Distribution of CRLs and OCSP](#distribution-of-crls-ocsp)
  - [Automate CRL Building and Tidying](#automate-crl-building-and-tidying)
+ - [Spectrum of Revocation Support](#spectrum-of-revocation-support)
+   - [What Are Cross-Cluster CRLs?](#what-are-cross-cluster-crls)
  - [Issuer Subjects and CRLs](#issuer-subjects-and-crls)
  - [Automate Leaf Certificate Renewal](#automate-leaf-certificate-renewal)
  - [Safe Minimums](#safe-minimums)
@@ -351,6 +353,64 @@ stored unified or sharded CRLs. If a single external unified CRL becomes
 unreasonably large, each cluster's certificates could have AIA info point
 to an externally stored and maintained, sharded CRL. However, 
 Vault has no mechanism to sign OCSP requests at this time.
+
+### What Are Cross-Cluster CRLs?
+
+Vault Enterprise supports a clustering mode called [Performance
+Replication](/vault/docs/enterprise/replication#performance-replication). In
+a replicated PKI Secrets Engine mount, issuer and role information is synced
+between the Performance Primary and all Performance Secondary clusters.
+However, each Performance Secondary cluster has its own local storage of
+issued certificates and revocations which is not synced. In Vault versions
+before 1.13, this meant that each of these clusters had its own CRL and
+OCSP data, and any revocation requests needed to be processed on the
+cluster that issued it (or BYOC used).
+
+Starting with Vault 1.13, we've added [two
+features](/vault/api-docs/secret/pki#read-crl-configuration) to Vault
+Enterprise to help manage this setup more correctly and easily: revocation
+request queues (`cross_cluster_revocation=true` in `config/crl`) and unified
+revocation entries (`unified_crl=true` in `config/crl`).
+
+The former allows operators (revoking by serial number) to request a
+certificate be revoked regardless of which cluster it was issued on. For
+example, if a request goes into the Performance Primary, but it didn't
+issue the certificate, it'll write a cross-cluster revocation request,
+and mark the results as pending. If another cluster already has this
+certificate in storage, it will revoke it and confirm the revocation back
+to the main cluster. An operator can [list pending
+revocations](/vault/api-docs/secret/pki#list-revocation-requests) to see
+the status of these requests. To clean up invalid requests (e.g., if the
+cluster which had that certificate disappeared, if that certificate was
+issued with `no_store=true` on the role, or if it was an invalid serial
+number), an operator can [use tidy](/vault/api-docs/secret/pki#tidy) with
+`tidy_revocation_queue=true`, optionally shortening
+`revocation_queue_safety_buffer` to remove them quicker.
+
+The latter allows all clusters to have a unified view of revocations,
+that is, to have access to a list of revocations performed by other clusters.
+While the configuration parameter includes `crl` in the description, this
+applies to [both CRLs](/vault/api-docs/secret/pki#read-issuer-crl) and the
+[OCSP responder](/vault/api-docs/secret/pki#ocsp-request). When this
+revocation replication occurs, if any cluster considers a cert revoked when
+another doesn't (e.g., via BYOC revocation of a `no_store=false` certificate),
+all clusters will now consider it revoked assuming it hasn't expired. Notably,
+the active node of the primary cluster will be used to rebuild the CRL; as
+this can grow large if many clusters have lots of revoked certs, an operator
+might need to disable CRL building (`disabled=true` in `config/crl`) or
+increase the [storage size](/vault/docs/configuration/storage/raft#max_entry_size).
+
+As an aside, all new cross-cluster writes (from Performance Secondary up to
+the Performance Primary) are performed synchronously. This gives the caller
+confidence that the request actually went through, at the expense of incurring
+a bit higher overhead for revoking certificates. When a node loses its GRPC
+connection (e.g., during leadership election or being otherwise unable to
+contact the active primary), errors will occur though the local portion of the
+write (if any) will still succeed. For cross-cluster revocation requests, due
+to there being no local write, this means that the operation will need to be
+retried, but in the event of an issue writing a cross-cluster revocation entry
+when the cert existed locally, the revocation will eventually be synced across
+clusters when the connection comes back.
 
 ## Issuer Subjects and CRLs
 


### PR DESCRIPTION
Talks more about what cross-cluster revocation is, and docs a missing tidy parameter. 