### PR TITLE
Wrapped token login bug

### DIFF
--- a/changelog/19036.txt
+++ b/changelog/19036.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes logout route wrapped_token bug
+``

--- a/ui/app/mixins/cluster-route.js
+++ b/ui/app/mixins/cluster-route.js
@@ -29,11 +29,14 @@ export default Mixin.create({
       targetRoute !== transition.targetName &&
       targetRoute !== this.router.currentRouteName
     ) {
+      // there may be query params so check for inclusion rather than exact match
+      const isExcluded = EXCLUDED_REDIRECT_URLS.find((url) => this.router.currentURL.includes(url));
+      // const isExcluded = false;
       if (
         // only want to redirect if we're going to authenticate
         targetRoute === AUTH &&
         transition.targetName !== CLUSTER_INDEX &&
-        !EXCLUDED_REDIRECT_URLS.includes(this.router.currentURL)
+        !isExcluded
       ) {
         return this.transitionTo(targetRoute, { queryParams: { redirect_to: this.router.currentURL } });
       }

--- a/ui/app/mixins/cluster-route.js
+++ b/ui/app/mixins/cluster-route.js
@@ -30,8 +30,7 @@ export default Mixin.create({
       targetRoute !== this.router.currentRouteName
     ) {
       // there may be query params so check for inclusion rather than exact match
-      const isExcluded = EXCLUDED_REDIRECT_URLS.find((url) => this.router.currentURL.includes(url));
-      // const isExcluded = false;
+      const isExcluded = EXCLUDED_REDIRECT_URLS.find((url) => this.router.currentURL?.includes(url));
       if (
         // only want to redirect if we're going to authenticate
         targetRoute === AUTH &&

--- a/ui/tests/acceptance/wrapped-token-test.js
+++ b/ui/tests/acceptance/wrapped-token-test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { settled, currentURL } from '@ember/test-helpers';
+import { settled, currentURL, visit } from '@ember/test-helpers';
 import { create } from 'ember-cli-page-object';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import auth from 'vault/tests/pages/auth';
 import consoleClass from 'vault/tests/pages/components/console/ui-panel';
 
@@ -27,6 +28,7 @@ const setupWrapping = async () => {
 };
 module('Acceptance | wrapped_token query param functionality', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('it authenticates you if the query param is present', async function (assert) {
     const token = await setupWrapping();
@@ -39,6 +41,15 @@ module('Acceptance | wrapped_token query param functionality', function (hooks) 
     const token = await setupWrapping();
     await auth.visit({ wrapped_token: token, with: 'token' });
     await settled();
+    assert.strictEqual(currentURL(), '/vault/secrets', 'authenticates and redirects to home');
+  });
+
+  test('it should authenticate when hitting logout url with wrapped_token when logged out', async function (assert) {
+    this.server.post('/sys/wrapping/unwrap', () => {
+      return { auth: { client_token: 'root' } };
+    });
+
+    await visit(`/vault/logout?wrapped_token=1234`);
     assert.strictEqual(currentURL(), '/vault/secrets', 'authenticates and redirects to home');
   });
 });


### PR DESCRIPTION
As reported in #17355, visiting the logout endpoint with a `wrapped_token` was not automatically logging in if the user was already logged out. The transition to the logout route was not being caught by the `EXCLUDED_REDIRECT_URLS` whitelist because of the query parameter. After the token was unwrapped and auth was successful, the user would be redirected back to logout and then the auth route where the token would again be unwrapped which would fail the second time.

![wrapped-token](https://user-images.githubusercontent.com/24611656/217322980-2a596cc6-2b3c-4597-888f-cf08a467ea9a.gif)

I also discovered while testing this that the wrapped token can be passed to the auth route and it will automatically log in as well.

![wrapped-token2](https://user-images.githubusercontent.com/24611656/217324251-b093c46e-13b8-4e15-b75c-8e1488d97d6f.gif)
