### PR TITLE
Revert URL encoding OCSP GET fix #18938

### DIFF
--- a/builtin/logical/pki/path_ocsp.go
+++ b/builtin/logical/pki/path_ocsp.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"math/big"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -249,12 +248,7 @@ func fetchDerEncodedRequest(request *logical.Request, data *framework.FieldData)
 			return nil, errors.New("request is too large")
 		}
 
-		unescapedBase64, err := url.QueryUnescape(base64Req)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unescape base64 string: %w", err)
-		}
-
-		return base64.StdEncoding.DecodeString(unescapedBase64)
+		return base64.StdEncoding.DecodeString(base64Req)
 	case logical.UpdateOperation:
 		// POST bodies should contain the binary form of the DER request.
 		// NOTE: Writing an empty update request to Vault causes a nil request.HTTPRequest, and that object

--- a/builtin/logical/pki/path_ocsp_test.go
+++ b/builtin/logical/pki/path_ocsp_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -441,7 +440,7 @@ func TestOcsp_HigherLevel(t *testing.T) {
 	require.Equal(t, certToRevoke.SerialNumber, ocspResp.SerialNumber)
 
 	// Test OCSP Get request for ocsp
-	urlEncoded := url.QueryEscape(base64.StdEncoding.EncodeToString(ocspReq))
+	urlEncoded := base64.StdEncoding.EncodeToString(ocspReq)
 	ocspGetReq := client.NewRequest(http.MethodGet, "/v1/pki/ocsp/"+urlEncoded)
 	ocspGetReq.Headers.Set("Content-Type", "application/ocsp-request")
 	rawResp, err = client.RawRequest(ocspGetReq)
@@ -688,7 +687,7 @@ func SendOcspRequest(t *testing.T, b *backend, s logical.Storage, getOrPost stri
 }
 
 func sendOcspGetRequest(b *backend, s logical.Storage, ocspRequest []byte) (*logical.Response, error) {
-	urlEncoded := url.QueryEscape(base64.StdEncoding.EncodeToString(ocspRequest))
+	urlEncoded := base64.StdEncoding.EncodeToString(ocspRequest)
 	return CBRead(b, s, "ocsp/"+urlEncoded)
 }
 


### PR DESCRIPTION
 - The fix within #18938 was incorrect and has caused a regression in OCSP GET request handling, as now the tests and program are double URL encoding the base64 `+` character when using Vault are becoming space characters within the handler and failing base64 decoding.