### PR TITLE
Remove duplicate adapter methods

### DIFF
--- a/ui/app/adapters/pki/role.js
+++ b/ui/app/adapters/pki/role.js
@@ -67,29 +67,4 @@ export default class PkiRoleAdapter extends ApplicationAdapter {
     const { id, record } = snapshot;
     return this.ajax(this._urlForRole(record.backend, id), 'DELETE');
   }
-
-  generateCertificate(backend, roleName, data) {
-    const url = `${this.buildURL()}/${encodePath(backend)}/issue/${roleName}`;
-    const options = {
-      data,
-    };
-    return this.ajax(url, 'POST', options).then((resp) => {
-      return resp.data;
-    });
-  }
-
-  signCertificate(backend, roleName, data) {
-    const url = `${this.buildURL()}/${encodePath(backend)}/sign/${roleName}`;
-    const options = {
-      data,
-    };
-    return this.ajax(url, 'POST', options);
-  }
-
-  revokeCertificate(backend, data) {
-    const url = `${this.buildURL()}/${encodePath(backend)}/revoke`;
-    return this.ajax(url, 'POST', {
-      data,
-    });
-  }
 }

--- a/ui/types/vault/adapters/pki/role.d.ts
+++ b/ui/types/vault/adapters/pki/role.d.ts
@@ -5,5 +5,4 @@ export default interface PkiRoleAdapter extends AdapterRegistry {
   namespace: string;
   _urlForRole(backend: string, id: string): string;
   _optionsForQuery(id: string): { data: unknown };
-  generateCertificate(backend: string, roleName: string, data: unknown): unknown;
 }


### PR DESCRIPTION
Went to write tests for the custom adapter methods in the pki/role adpater to find that they were not being used anywhere. Did a search for the methods and because they're custom they would have to specifically be called. Didn't find their use anywhere. It appears that these were written two months ago and then—my guess—[written elsewhere in the following adapters](https://github.com/hashicorp/vault/tree/main/ui/app/models/pki/certificate):

-pki/certificate/sign
-pki/certificate/generate
-pki/certificate/base

