### PR TITLE
Fix documentation on CRL fixed version

### DIFF
--- a/website/content/docs/secrets/pki/considerations.mdx
+++ b/website/content/docs/secrets/pki/considerations.mdx
@@ -423,8 +423,8 @@ correctly throughout all parts of the PKI. In particular, CRLs embed a
 track revocation, but note that performance characteristics are different
 between OCSP and CRLs.
 
-~> Note: As of Go 1.19 and Vault 1.12, Go correctly formats the CRL's issuer
-   name and this notice does not apply.
+~> Note: As of Go 1.20 and Vault 1.13, Go correctly formats the CRL's issuer
+   name and this notice [does not apply](https://github.com/golang/go/commit/a367981b4c8e3ae955eca9cc597d9622201155f3).
 
 ## Automate Leaf Certificate Renewal
 


### PR DESCRIPTION
Luckily this is only on the 1.13 version of the docs and isn't yet out.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`