### PR TITLE
UI: VAULT-13135 Add copyable issuer id row to issuer details

### DIFF
--- a/ui/app/models/pki/issuer.js
+++ b/ui/app/models/pki/issuer.js
@@ -13,6 +13,7 @@ const issuerUrls = ['issuingCertificates', 'crlDistributionPoints', 'ocspServers
         'caChain',
         'commonName',
         'issuerName',
+        'issuerId',
         'serialNumber',
         'keyId',
         'uriSans',

--- a/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
@@ -117,6 +117,7 @@
               @value={{get @issuer attr.name}}
               @formatDate={{if attr.options.formatDate "MMM d yyyy HH:mm:ss a zzzz"}}
               @alwaysRender={{true}}
+              @addCopyButton={{(eq attr.name "issuerId")}}
             />
           {{/if}}
         {{/each}}

--- a/ui/tests/acceptance/pki/pki-engine-workflow-test.js
+++ b/ui/tests/acceptance/pki/pki-engine-workflow-test.js
@@ -427,7 +427,7 @@ module('Acceptance | pki workflow', function (hooks) {
       assert.dom(SELECTORS.issuerDetails.title).hasText('View issuer certificate');
       assert
         .dom(`${SELECTORS.issuerDetails.defaultGroup} ${SELECTORS.issuerDetails.row}`)
-        .exists({ count: 10 }, 'Renders 10 info table items under default group');
+        .exists({ count: 11 }, 'Renders 10 info table items under default group');
       assert
         .dom(`${SELECTORS.issuerDetails.urlsGroup} ${SELECTORS.issuerDetails.row}`)
         .exists({ count: 3 }, 'Renders 4 info table items under URLs group');


### PR DESCRIPTION
**Description**:
- Add issuer id as a field and copyable
<img width="1541" alt="Screenshot 2023-02-07 at 1 32 01 PM" src="https://user-images.githubusercontent.com/30884335/217370496-1f0661d6-d13a-4b09-9e71-1aae961cfa8a.png">
