### PR TITLE
Document OCSP GET known issue

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
@@ -160,3 +160,15 @@ https://github.com/hashicorp/vault/commit/76165052e54f884ed0aa2caa496083dc84ad1c
 #### Impacted Versions
 
 Affects versions 1.12.0, 1.12.1, and 1.12.2. A fix will be released in 1.12.3.
+
+### PKI OCSP GET requests return malformed request responses
+
+If an OCSP GET request contains a '+' character, a malformed request response will be
+returned instead of properly processing the request due to a double decoding issue within the
+handler.
+
+As a workaround, OCSP POST requests can be used which are unaffected.
+
+#### Impacted Versions
+
+Affects version 1.12.3. A fix will be released in 1.12.4.


### PR DESCRIPTION
Add to the known issues for the 1.12.x upgrading guide about the discovered regression within the PKI OCSP GET handler in 1.12.3.