### PR TITLE
Kubernetes roles toolbar actions when not configured

### DIFF
--- a/ui/lib/kubernetes/addon/components/page/roles.hbs
+++ b/ui/lib/kubernetes/addon/components/page/roles.hbs
@@ -1,7 +1,14 @@
-<TabPageHeader @model={{@backend}} @filterRoles={{true}} @rolesFilterValue={{@filterValue}} @breadcrumbs={{@breadcrumbs}}>
-  <ToolbarLink @route="roles.create" @type="add" data-test-toolbar-roles-action>
-    Create role
-  </ToolbarLink>
+<TabPageHeader
+  @model={{@backend}}
+  @filterRoles={{if @config true false}}
+  @rolesFilterValue={{@filterValue}}
+  @breadcrumbs={{@breadcrumbs}}
+>
+  {{#if @config}}
+    <ToolbarLink @route="roles.create" @type="add" data-test-toolbar-roles-action>
+      Create role
+    </ToolbarLink>
+  {{/if}}
 </TabPageHeader>
 
 {{#if (not @config)}}

--- a/ui/tests/integration/components/kubernetes/page/roles-test.js
+++ b/ui/tests/integration/components/kubernetes/page/roles-test.js
@@ -52,17 +52,23 @@ module('Integration | Component | kubernetes | Page::Roles', function (hooks) {
     await this.renderComponent();
     assert.dom('.title svg').hasClass('flight-icon-kubernetes', 'Kubernetes icon renders in title');
     assert.dom('.title').hasText('kubernetes-test', 'Mount path renders in title');
-    assert.dom('[data-test-toolbar-roles-action]').hasText('Create role', 'Toolbar action has correct text');
     assert
-      .dom('[data-test-toolbar-roles-action] svg')
-      .hasClass('flight-icon-plus', 'Toolbar action has correct icon');
-    assert.dom('[data-test-nav-input]').exists('Roles filter input renders');
+      .dom('[data-test-toolbar-roles-action]')
+      .doesNotExist('Create role', 'Toolbar action does not render when not configured');
+    assert
+      .dom('[data-test-nav-input]')
+      .doesNotExist('Roles filter input does not render when not configured');
     assert.dom('[data-test-config-cta]').exists('Config cta renders');
   });
 
   test('it should render create roles cta', async function (assert) {
     this.roles = null;
     await this.renderComponent();
+    assert.dom('[data-test-toolbar-roles-action]').hasText('Create role', 'Toolbar action has correct text');
+    assert
+      .dom('[data-test-toolbar-roles-action] svg')
+      .hasClass('flight-icon-plus', 'Toolbar action has correct icon');
+    assert.dom('[data-test-nav-input]').exists('Roles filter input renders');
     assert.dom('[data-test-empty-state-title]').hasText('No roles yet', 'Title renders');
     assert
       .dom('[data-test-empty-state-message]')


### PR DESCRIPTION
Updates the Kubernetes roles view to hide the toolbar actions when the secrets engine has not been configured.

![image](https://user-images.githubusercontent.com/24611656/217621813-d95e4138-427b-4693-858a-3a3ab960ed39.png)
