### PR TITLE
UI: clarify beta configuration info banner

### DIFF
--- a/ui/lib/pki/addon/routes/overview.js
+++ b/ui/lib/pki/addon/routes/overview.js
@@ -10,10 +10,13 @@ export default class PkiOverviewRoute extends Route {
   hasConfig() {
     // When the engine is configured, it creates a default issuer.
     // If the issuers list is empty, we know it hasn't been configured
-    return this.store
-      .query('pki/issuer', { backend: this.secretMountPath.currentPath })
-      .then(() => true)
-      .catch(() => false);
+    return (
+      this.store
+        .query('pki/issuer', { backend: this.secretMountPath.currentPath })
+        .then(() => true)
+        // this endpoint is unauthenticated, so we're not worried about permissions errors
+        .catch(() => false)
+    );
   }
 
   async fetchAllRoles() {

--- a/ui/lib/pki/addon/templates/configuration/index.hbs
+++ b/ui/lib/pki/addon/templates/configuration/index.hbs
@@ -22,7 +22,7 @@
 <AlertBanner
   @type="info"
   @title="PKI beta in use"
-  @message="To configure the engine, you'll have to return to the regular version."
+  @message="To view the secret engine configuration or tune the mount return to the regular version."
   class="has-top-margin-m"
   data-test-pki-configuration-banner
 >

--- a/ui/lib/pki/addon/templates/configuration/index.hbs
+++ b/ui/lib/pki/addon/templates/configuration/index.hbs
@@ -22,7 +22,7 @@
 <AlertBanner
   @type="info"
   @title="PKI beta in use"
-  @message="To view the secret engine configuration or tune the mount return to the regular version."
+  @message="To view the secret engine configuration or tune the mount, you'll have to return to the regular version."
   class="has-top-margin-m"
   data-test-pki-configuration-banner
 >


### PR DESCRIPTION
Small change to clarify UI discrepancy between beta and regular PKI 

#### Before change
<img width="600" alt="Screen Shot 2023-02-08 at 12 31 33 PM" src="https://user-images.githubusercontent.com/68122737/217644404-604fc987-f106-4f1b-88c0-2f2d8a520429.png">

<hr>

#### After change: 

<img width="600" alt="Screen Shot 2023-02-08 at 12 40 11 PM" src="https://user-images.githubusercontent.com/68122737/217646018-7a648a14-911b-4b5d-aa38-6001bcbd93cd.png">

