### PR TITLE
fix: upgrade vault-plugin-secrets-kubernetes to v0.3.0

### DIFF
--- a/changelog/19084.txt
+++ b/changelog/19084.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/kubernetes: add /check endpoint to determine if environment variables are set
+```

--- a/go.mod
+++ b/go.mod
@@ -130,7 +130,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-azure v0.6.3-0.20221109203402-f955aedc51bf
 	github.com/hashicorp/vault-plugin-secrets-gcp v0.15.0
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.14.0
-	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.0.0-20221215173052-6b1994edb14e
+	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.3.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.14.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.9.0
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -1125,8 +1125,8 @@ github.com/hashicorp/vault-plugin-secrets-gcp v0.15.0 h1:SfYIFmgFg/8p4fgLCV8Yxxk
 github.com/hashicorp/vault-plugin-secrets-gcp v0.15.0/go.mod h1:/eOk7gJ5zvmOKgP5Ih7/5rZm5jOKDvGFpANIRqbr/Mc=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.14.0 h1:eUC5ltK+1bkc+SVMzAUq4tBeNrsDXyCuITH8jeajXcM=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.14.0/go.mod h1:86YCY86XuiQesV1jfjnV4icgoaxQdoUHONzDru+XQHA=
-github.com/hashicorp/vault-plugin-secrets-kubernetes v0.0.0-20221215173052-6b1994edb14e h1:MMmCbKSx6hBSUQlGMzaNa6MvmMW0Dy4qFQT1VsuN+4Q=
-github.com/hashicorp/vault-plugin-secrets-kubernetes v0.0.0-20221215173052-6b1994edb14e/go.mod h1:NJeYBRgLVqjvkrVyZEe42oaqP3+xvVNMYdJoMWVoByU=
+github.com/hashicorp/vault-plugin-secrets-kubernetes v0.3.0 h1:Joz9SBwjpEOGu+Ynv60JC3fAA4UuLJzu7NcrKm6wMMs=
+github.com/hashicorp/vault-plugin-secrets-kubernetes v0.3.0/go.mod h1:NJeYBRgLVqjvkrVyZEe42oaqP3+xvVNMYdJoMWVoByU=
 github.com/hashicorp/vault-plugin-secrets-kv v0.14.0 h1:PbveQUraOp9Bj7SVvFfssnmNYvlNTSHC6d/eLS+Am0c=
 github.com/hashicorp/vault-plugin-secrets-kv v0.14.0/go.mod h1:YLsIcn9enkcyTqtuxmCXZ94nr2aeJCZhC+neHacX8SQ=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.9.0 h1:H3r1gPwzg/lAtXWYpLE2km2eh3tYEbXUxcvV6OyhCEo=


### PR DESCRIPTION
This PR updates vault-plugin-secrets-kubernetes to [v0.3.0](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/releases/tag/v0.3.0).

Steps:
```
go get github.com/hashicorp/vault-plugin-secrets-kubernetes@v0.3.0
go mod tidy
```