### PR TITLE
[QT-481] Move env var declaration to called workflow

### DIFF
--- a/.github/workflows/test-acc-dockeronly-nightly.yml
+++ b/.github/workflows/test-acc-dockeronly-nightly.yml
@@ -4,13 +4,10 @@ on:
   # Change to nightly cadence once API-credential-requiring tests are added to the jobs
   workflow_dispatch: 
 
-env:
-  VAULT_ACC: 1
-
 # Currently the jobs here are only for acceptance tests that have no dependencies except for Docker
 jobs:
   plugins-database:
-    uses: ./.github/workflows/test-run-go-tests-for-path.yml
+    uses: ./.github/workflows/test-run-acc-tests-for-path.yml
     strategy:
       matrix:
         name: [mongodb, mysql, postgresql]
@@ -19,7 +16,7 @@ jobs:
       path: plugins/database/${{ matrix.name }}
 
   external:
-    uses: ./.github/workflows/test-run-go-tests-for-path.yml
+    uses: ./.github/workflows/test-run-acc-tests-for-path.yml
     strategy:
       matrix:
         name: [api, identity, token]

--- a/.github/workflows/test-run-acc-tests-for-path.yml
+++ b/.github/workflows/test-run-acc-tests-for-path.yml
@@ -13,6 +13,9 @@ on:
         type: string
     # We will need to add the capacity for receiving passed secrets once we get to the tests that require API credentials
 
+env:
+  VAULT_ACC: 1
+
 jobs:
   go-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Previously, we had made the choice to move the VAULT_ACC env var declaration to the caller workflow as it didn't make sense to have the variable set for the more generically go-test workflow.

Upon reading some documentation today for an unrelated issue, I found [the following information](https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations):

> Any environment variables set in an env context defined at the workflow level in the caller workflow are not propagated to the called workflow.

This change also renames the called workflow file so as to indicate that it is to be used for acceptance tests exclusively.