### PR TITLE
Add a comment around why we are grabbing a lock to update an atomic boolean

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -416,6 +416,12 @@ func (b *backend) updatePkiStorageVersion(ctx context.Context, grabIssuersLock b
 		return
 	}
 
+	// If this method is called outside the initialize function, like say an
+	// invalidate func on a performance replica cluster, we should be grabbing
+	// the issuers lock to offer a consistent view of the storage version while
+	// other events are processing things. Its unknown what might happen during
+	// a single event if one part thinks we are in legacy mode, and then later
+	// on we aren't.
 	if grabIssuersLock {
 		b.issuersLock.Lock()
 		defer b.issuersLock.Unlock()

--- a/changelog/19037.txt
+++ b/changelog/19037.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Revert fix for PR [18938](https://github.com/hashicorp/vault/pull/18938)
+```


### PR DESCRIPTION
@cipherboy was asking why we grabbed the PKI issuers lock, just to update an atomic boolean in some circumstances. The answer wasn't immediately obvious to me, so add a code comment to explain the reasoning for future me. 

Also bring up a changelog that was added on the 1.12.x backport PR for the revert fix within #19069 as I missed adding one within the original PR#19037 that got merged to main. 