### PR TITLE
UI: VAULT-13419 Remove flash message for form errors and use MessageError instead

### DIFF
--- a/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
+++ b/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
@@ -39,6 +39,10 @@
 
 {{#if @model.generationPreference}}
   <form id="role" {{on "submit" this.onSave}} data-test-policy-form>
+    {{#if this.errorBanner}}
+      <MessageError @errorMessage={{this.errorBanner}} class="has-top-margin-s" />
+    {{/if}}
+
     {{#each @model.filteredFormFields as |field|}}
       <FormField @attr={{field}} @model={{@model}} @modelValidations={{this.modelValidations}} />
     {{/each}}
@@ -113,6 +117,11 @@
             </button>
           </JsonEditor>
         {{/let}}
+      </div>
+    {{/if}}
+    {{#if this.invalidFormAlert}}
+      <div class="control">
+        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
       </div>
     {{/if}}
   </form>

--- a/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
+++ b/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
@@ -120,7 +120,7 @@
       </div>
     {{/if}}
     {{#if this.invalidFormAlert}}
-      <div class="control">
+      <div class="control" data-test-invalid-form-alert>
         <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
       </div>
     {{/if}}

--- a/ui/lib/kubernetes/addon/components/page/role/create-and-edit.js
+++ b/ui/lib/kubernetes/addon/components/page/role/create-and-edit.js
@@ -6,7 +6,6 @@ import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import { getRules } from '../../../utils/generated-role-rules';
 import { htmlSafe } from '@ember/template';
-import errorMessage from 'vault/utils/error-message';
 
 /**
  * @module CreateAndEditRolePage
@@ -22,6 +21,8 @@ export default class CreateAndEditRolePageComponent extends Component {
   @tracked roleRulesTemplates;
   @tracked selectedTemplateId;
   @tracked modelValidations;
+  @tracked invalidFormAlert;
+  @tracked errorBanner;
 
   constructor() {
     super(...arguments);
@@ -135,20 +136,21 @@ export default class CreateAndEditRolePageComponent extends Component {
         this.args.model.name
       );
     } catch (error) {
-      const message = errorMessage(error, 'Error saving role. Please try again or contact support');
-      this.flashMessages.danger(message);
+      const message = error.errors ? error.errors.join('. ') : error.message;
+      this.errorBanner = message;
+      this.invalidFormAlert = 'There was an error submitting this form.';
     }
   }
 
   @action
   async onSave(event) {
     event.preventDefault();
-    const { isValid, state } = await this.args.model.validate();
+    const { isValid, state, invalidFormMessage } = await this.args.model.validate();
     if (isValid) {
       this.modelValidations = null;
       this.save.perform();
     } else {
-      this.flashMessages.info('Save not performed. Check form for errors');
+      this.invalidFormAlert = invalidFormMessage;
       this.modelValidations = state;
     }
   }

--- a/ui/lib/kubernetes/addon/components/page/role/create-and-edit.js
+++ b/ui/lib/kubernetes/addon/components/page/role/create-and-edit.js
@@ -6,6 +6,7 @@ import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import { getRules } from '../../../utils/generated-role-rules';
 import { htmlSafe } from '@ember/template';
+import errorMessage from 'vault/utils/error-message';
 
 /**
  * @module CreateAndEditRolePage
@@ -136,7 +137,7 @@ export default class CreateAndEditRolePageComponent extends Component {
         this.args.model.name
       );
     } catch (error) {
-      const message = error.errors ? error.errors.join('. ') : error.message;
+      const message = errorMessage(error, 'Error saving role. Please try again or contact support');
       this.errorBanner = message;
       this.invalidFormAlert = 'There was an error submitting this form.';
     }

--- a/ui/tests/integration/components/kubernetes/page/role/create-and-edit-test.js
+++ b/ui/tests/integration/components/kubernetes/page/role/create-and-edit-test.js
@@ -305,4 +305,20 @@ module('Integration | Component | kubernetes | Page::Role::CreateAndEdit', funct
     assert.ok(rollbackSpy.calledOnce, 'Attributes are rolled back for existing model on cancel');
     assert.ok(this.transitionCalledWith('roles'), 'Transitions to roles list on cancel');
   });
+
+  test('it should check for form errors', async function (assert) {
+    await render(
+      hbs`<Page::Role::CreateAndEdit @model={{this.newModel}} @breadcrumbs={{this.breadcrumbs}}/>`,
+      { owner: this.engine }
+    );
+    await click('[data-test-radio-card="basic"]');
+    await click('[data-test-save]');
+    assert
+      .dom('[data-test-input="name"]')
+      .hasClass('has-error-border', 'shows border error on input with error');
+    assert.dom('[data-test-inline-error-message]').hasText('Name is required');
+    assert
+      .dom('[data-test-invalid-form-alert] [data-test-inline-error-message]')
+      .hasText('There is an error with this form.');
+  });
 });


### PR DESCRIPTION
**Description**
- Add inline form error and `MessageError` block for create/edit role form

Example 1:
<img width="1458" alt="Screenshot 2023-02-08 at 3 02 37 PM" src="https://user-images.githubusercontent.com/30884335/217672061-c8cc889d-9cca-4885-9c15-cab7602b5130.png">
Example 2:
<img width="1471" alt="Screenshot 2023-02-08 at 3 02 48 PM" src="https://user-images.githubusercontent.com/30884335/217672064-3868ae0e-fa39-4927-a9b0-c0b7df04ca40.png">
