### PR TITLE
Kubernetes config form validation 

### DIFF
--- a/ui/app/models/kubernetes/config.js
+++ b/ui/app/models/kubernetes/config.js
@@ -1,6 +1,11 @@
 import Model, { attr } from '@ember-data/model';
 import { withFormFields } from 'vault/decorators/model-form-fields';
+import { withModelValidations } from 'vault/decorators/model-validations';
 
+const validations = {
+  kubernetesHost: [{ type: 'presence', message: 'Kubernetes host is required' }],
+};
+@withModelValidations(validations)
 @withFormFields(['kubernetesHost', 'serviceAccountJwt', 'kubernetesCaCert'])
 export default class KubernetesConfigModel extends Model {
   @attr('string') backend; // dynamic path of secret -- set on response from value passed to queryRecord

--- a/ui/lib/kubernetes/addon/components/page/configure.hbs
+++ b/ui/lib/kubernetes/addon/components/page/configure.hbs
@@ -73,7 +73,7 @@
 
 <hr class="has-background-gray-200 has-top-margin-l" />
 
-<div class="has-top-margin-s has-bottom-margin-s">
+<div class="has-top-margin-s has-bottom-margin-s is-flex">
   <button
     data-test-config-save
     class="button is-primary"
@@ -92,6 +92,9 @@
   >
     Back
   </button>
+  {{#if this.alert}}
+    <AlertInline @type="danger" @paddingTop={{true}} @message={{this.alert}} @mimicRefresh={{true}} data-test-alert />
+  {{/if}}
 </div>
 
 {{#if this.showConfirm}}

--- a/ui/lib/kubernetes/addon/components/page/configure.js
+++ b/ui/lib/kubernetes/addon/components/page/configure.js
@@ -18,6 +18,7 @@ export default class ConfigurePageComponent extends Component {
 
   @tracked inferredState;
   @tracked modelValidations;
+  @tracked alert;
   @tracked error;
   @tracked showConfirm;
 
@@ -64,6 +65,14 @@ export default class ConfigurePageComponent extends Component {
       return;
     }
     this.showConfirm = false;
+
+    const { isValid, state, invalidFormMessage } = yield this.args.model.validate();
+    if (!isValid) {
+      this.modelValidations = state;
+      this.alert = invalidFormMessage;
+      return;
+    }
+
     try {
       yield this.args.model.save();
       this.leave('configuration');

--- a/ui/tests/integration/components/kubernetes/page/configure-test.js
+++ b/ui/tests/integration/components/kubernetes/page/configure-test.js
@@ -202,4 +202,18 @@ module('Integration | Component | kubernetes | Page::Configure', function (hooks
       );
     await click('[data-test-config-confirm]');
   });
+
+  test('it should validate form and show errors', async function (assert) {
+    await render(hbs`<Page::Configure @model={{this.newModel}} @breadcrumbs={{this.breadcrumbs}} />`, {
+      owner: this.engine,
+    });
+
+    await click('[data-test-radio-card="manual"]');
+    await click('[data-test-config-save]');
+
+    assert
+      .dom('[data-test-inline-error-message]')
+      .hasText('Kubernetes host is required', 'Error renders for required field');
+    assert.dom('[data-test-alert] p').hasText('There is an error with this form.', 'Alert renders');
+  });
 });


### PR DESCRIPTION
It was discovered that when selecting _Manual configuration_ and submitting an empty form, if the necessary environment variables were previously set it would use those for an inferred configuration. Since we have an option for that in the UI we want to be explicit in how the configuration is created and have a clear separation between the two. For those reasons, validation was added to the form to required the `kubernetes_host` field.

![image](https://user-images.githubusercontent.com/24611656/217682739-b105d9dc-29fc-450f-93a4-d152795f4f36.png)
