### PR TITLE
Bump go-plugin version 1.4.5->1.4.8

### DIFF
--- a/changelog/19100.txt
+++ b/changelog/19100.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+Bump github.com/hashicorp/go-plugin version from 1.4.5 to 1.4.8
+```
+

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/hashicorp/go-memdb v1.3.3
 	github.com/hashicorp/go-msgpack v1.1.5
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/go-plugin v1.4.5
+	github.com/hashicorp/go-plugin v1.4.8
 	github.com/hashicorp/go-raftchunking v0.6.3-0.20191002164813-7e9e8525653a
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/go-rootcerts v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -1003,8 +1003,9 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/hashicorp/go-plugin v1.4.5 h1:oTE/oQR4eghggRg8VY7PAz3dr++VwDNBGCcOfIvHpBo=
 github.com/hashicorp/go-plugin v1.4.5/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHGUjr2IrTF67s=
+github.com/hashicorp/go-plugin v1.4.8 h1:CHGwpxYDOttQOY7HOWgETU9dyVjOXzniXDqJcYJE1zM=
+github.com/hashicorp/go-plugin v1.4.8/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHGUjr2IrTF67s=
 github.com/hashicorp/go-raftchunking v0.6.3-0.20191002164813-7e9e8525653a h1:FmnBDwGwlTgugDGbVxwV8UavqSMACbGrUpfc98yFLR4=
 github.com/hashicorp/go-raftchunking v0.6.3-0.20191002164813-7e9e8525653a/go.mod h1:xbXnmKqX9/+RhPkJ4zrEx4738HacP72aaUPlT2RZ4sU=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=


### PR DESCRIPTION
[v1.4.8](https://github.com/hashicorp/go-plugin/releases/tag/v1.4.8)
BUG FIXES:

Fix windows build: [https://github.com/hashicorp/go-plugin/pull/227]

[v1.4.7](https://github.com/hashicorp/go-plugin/releases/tag/v1.4.7)
ENHANCEMENTS:

More detailed error message on plugin start failure: [https://github.com/hashicorp/go-plugin/pull/223]

[v1.4.6](https://github.com/hashicorp/go-plugin/releases/tag/v1.4.6)
BUG FIXES:

server: Prevent gRPC broker goroutine leak when using GRPCServer type GracefulStop() or Stop() methods [https://github.com/hashicorp/go-plugin/pull/220]