### PR TITLE
update diagnose command to no longer require docker dependency

### DIFF
--- a/command/operator_diagnose.go
+++ b/command/operator_diagnose.go
@@ -15,7 +15,6 @@ import (
 
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 
-	"github.com/docker/docker/pkg/ioutils"
 	"github.com/hashicorp/consul/api"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/reloadutil"
@@ -159,7 +158,7 @@ func (c *OperatorDiagnoseCommand) RunWithParsedFlags() int {
 
 	if c.diagnose == nil {
 		if c.flagFormat == "json" {
-			c.diagnose = diagnose.New(&ioutils.NopWriter{})
+			c.diagnose = diagnose.New(io.Discard)
 		} else {
 			c.UI.Output(version.GetVersion().FullVersionNumber(true))
 			c.diagnose = diagnose.New(os.Stdout)


### PR DESCRIPTION
docker dependency should no longer be included in the binary