### PR TITLE
add error message when trying to rotate mssql root without password in configuration

### DIFF
--- a/builtin/logical/database/path_rotate_credentials.go
+++ b/builtin/logical/database/path_rotate_credentials.go
@@ -74,6 +74,11 @@ func (b *databaseBackend) pathRotateRootCredentialsUpdate() framework.OperationF
 			return nil, fmt.Errorf("unable to rotate root credentials: no username in configuration")
 		}
 
+		rootPassword, ok := config.ConnectionDetails["password"].(string)
+		if !ok || rootPassword == "" {
+			return nil, fmt.Errorf("unable to rotate root credentials: no password in configuration")
+		}
+
 		dbi, err := b.GetConnection(ctx, req.Storage, name)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Previously when trying to rotate the root credential in mssql, a user would see this error:
```
vault write -f database/rotate-root/mydb ;
  # Error writing data to database/rotate-root/mydb: Put "http://127.0.0.1:8200/v1/database/rotate-root/mydb": EOF
```

This fix returns a more helpful message: 
```
vault write -f database/rotate-root/mydb ;                  10:39:53

Error writing data to database/rotate-root/mydb: Error making API request.

URL: PUT http://localhost:8200/v1/database/rotate-root/mydb
Code: 500. Errors:

* 1 error occurred:
	* unable to rotate root credentials: no password in configuration
```
