### PR TITLE
Stop using title capitalization for vault pki synoposis

### DIFF
--- a/command/pki_health_check.go
+++ b/command/pki_health_check.go
@@ -47,7 +47,7 @@ type PKIHealthCheckCommand struct {
 }
 
 func (c *PKIHealthCheckCommand) Synopsis() string {
-	return "Check PKI Secrets Engine health and operational status"
+	return "Check a PKI Secrets Engine mount's health and operational status"
 }
 
 func (c *PKIHealthCheckCommand) Help() string {

--- a/command/pki_issue_intermediate.go
+++ b/command/pki_issue_intermediate.go
@@ -25,7 +25,7 @@ type PKIIssueCACommand struct {
 }
 
 func (c *PKIIssueCACommand) Synopsis() string {
-	return "Given a Parent Certificate, and a List of Generation Parameters, Creates an Issue on a Specified Mount"
+	return "Given a parent certificate, and a list of generation parameters, creates an issuer on a specified mount"
 }
 
 func (c *PKIIssueCACommand) Help() string {

--- a/command/pki_list_intermediate_command.go
+++ b/command/pki_list_intermediate_command.go
@@ -30,7 +30,7 @@ type PKIListIntermediateCommand struct {
 }
 
 func (c *PKIListIntermediateCommand) Synopsis() string {
-	return "Determine Which (of a List) of Certificates Were Issued by A Given Parent Certificate"
+	return "Determine which of a list of certificates, were issued by a given parent certificate"
 }
 
 func (c *PKIListIntermediateCommand) Help() string {

--- a/command/pki_verify_sign_command.go
+++ b/command/pki_verify_sign_command.go
@@ -24,7 +24,7 @@ type PKIVerifySignCommand struct {
 }
 
 func (c *PKIVerifySignCommand) Synopsis() string {
-	return "Check Whether One Certificate Validates Another Specified Certificate"
+	return "Check whether one certificate validates another specified certificate"
 }
 
 func (c *PKIVerifySignCommand) Help() string {


### PR DESCRIPTION
 - Match the existing vault kv capitalization scheme for synopsis help of each sub-command.
 - A few small tweaks to the messages text in a few cases

```
Subcommands:
    health-check          Check a PKI Secrets Engine mount's health and operational status
    issue                 Given a parent certificate, and a list of generation parameters, creates an issuer on a specified mount
    list-intermediates    Determine which of a list of certificates, were issued by a given parent certificate
    verify-sign           Check whether one certificate validates another specified certificate

```