### PR TITLE
Kubernetes host form field description change

### DIFF
--- a/ui/app/models/kubernetes/config.js
+++ b/ui/app/models/kubernetes/config.js
@@ -11,8 +11,7 @@ export default class KubernetesConfigModel extends Model {
   @attr('string') backend; // dynamic path of secret -- set on response from value passed to queryRecord
   @attr('string', {
     label: 'Kubernetes host',
-    subText:
-      'Kubernetes API URL to connect to. Defaults to https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT if those environment variables are set.',
+    subText: 'Kubernetes API URL to connect to.',
   })
   kubernetesHost;
   @attr('string', {


### PR DESCRIPTION
In #19097 we added form validation to require `kubernetes_host` in the manual configuration workflow. The description for the field is now misleading since it can't default to the environment variables if the field is required to submit the form. That part of the copy has been removed. 