### PR TITLE
Kubernetes config prompt bug fix

### DIFF
--- a/ui/lib/kubernetes/addon/decorators/fetch-config.js
+++ b/ui/lib/kubernetes/addon/decorators/fetch-config.js
@@ -31,6 +31,7 @@ export function withConfig() {
             .queryRecord('kubernetes/config', { backend })
             .then((record) => {
               this.configModel = record;
+              this.promptConfig = false;
             })
             .catch((error) => {
               // we need to ignore if the user does not have permission or other failures so as to not block the other operations
@@ -42,6 +43,8 @@ export function withConfig() {
                 this.configError = error;
               }
             });
+        } else {
+          this.promptConfig = false;
         }
       }
     };


### PR DESCRIPTION
Fixes issue where if the config prompt on a route was set to display, the user completed the configuration and then returned to that route, the prompt would still be there. If the config model was found in the store the `promptConfig` property was not being set to `false`. 