### PR TITLE
UI: Fix id fields not allowing update

### DIFF
--- a/ui/app/adapters/role-aws.js
+++ b/ui/app/adapters/role-aws.js
@@ -6,12 +6,16 @@ export default ApplicationAdapter.extend({
   namespace: 'v1',
 
   createOrUpdate(store, type, snapshot, requestType) {
+    const { name, backend } = snapshot.record;
     const serializer = store.serializerFor(type.modelName);
     const data = serializer.serialize(snapshot, requestType);
-    const { id } = snapshot;
-    const url = this.urlForRole(snapshot.record.get('backend'), id);
+    const url = this.urlForRole(backend, name);
 
-    return this.ajax(url, 'POST', { data });
+    return this.ajax(url, 'POST', { data }).then((resp) => {
+      const response = resp || {};
+      response.id = name;
+      return response;
+    });
   },
 
   createRecord() {

--- a/ui/app/adapters/role-ssh.js
+++ b/ui/app/adapters/role-ssh.js
@@ -7,12 +7,16 @@ export default ApplicationAdapter.extend({
   namespace: 'v1',
 
   createOrUpdate(store, type, snapshot, requestType) {
+    const { name, backend } = snapshot.record;
     const serializer = store.serializerFor(type.modelName);
     const data = serializer.serialize(snapshot, requestType);
-    const { id } = snapshot;
-    const url = this.urlForRole(snapshot.record.get('backend'), id);
+    const url = this.urlForRole(backend, name);
 
-    return this.ajax(url, 'POST', { data });
+    return this.ajax(url, 'POST', { data }).then((resp) => {
+      const response = resp || {};
+      response.id = name;
+      return response;
+    });
   },
 
   createRecord() {

--- a/ui/app/adapters/transform.js
+++ b/ui/app/adapters/transform.js
@@ -7,17 +7,15 @@ export default ApplicationAdapter.extend({
   namespace: 'v1',
 
   createOrUpdate(store, type, snapshot) {
+    const { backend, name } = snapshot.record;
     const serializer = store.serializerFor(type.modelName);
     const data = serializer.serialize(snapshot);
-    const id = snapshot.record.name;
-    const url = this.urlForTransformations(snapshot.record.get('backend'), id);
+    const url = this.urlForTransformations(backend, name);
 
-    return this.ajax(url, 'POST', { data }).then(() => {
-      // ember data doesn't like 204s if it's not a DELETE
-      data.id = id; // manually set id since it's not on the record
-      return {
-        data: { ...data },
-      };
+    return this.ajax(url, 'POST', { data }).then((resp) => {
+      const response = resp || {};
+      response.id = name;
+      return response;
     });
   },
 

--- a/ui/app/adapters/transform.js
+++ b/ui/app/adapters/transform.js
@@ -9,10 +9,16 @@ export default ApplicationAdapter.extend({
   createOrUpdate(store, type, snapshot) {
     const serializer = store.serializerFor(type.modelName);
     const data = serializer.serialize(snapshot);
-    const { id } = snapshot;
+    const id = snapshot.record.name;
     const url = this.urlForTransformations(snapshot.record.get('backend'), id);
 
-    return this.ajax(url, 'POST', { data });
+    return this.ajax(url, 'POST', { data }).then(() => {
+      // ember data doesn't like 204s if it's not a DELETE
+      data.id = id; // manually set id since it's not on the record
+      return {
+        data: { ...data },
+      };
+    });
   },
 
   createRecord() {

--- a/ui/app/adapters/transform/base.js
+++ b/ui/app/adapters/transform/base.js
@@ -9,16 +9,15 @@ export default ApplicationAdapter.extend({
   },
 
   createOrUpdate(store, type, snapshot) {
+    const { backend, name } = snapshot.record;
     const serializer = store.serializerFor(type.modelName);
     const data = serializer.serialize(snapshot);
-    const id = snapshot.record.get('name');
-    const url = this.url(snapshot.record.get('backend'), type.modelName, id);
+    const url = this.url(backend, name);
 
-    return this.ajax(url, 'POST', { data }).then(() => {
-      // ember data doesn't like 204s if it's not a DELETE
-      return {
-        data: { ...data, id, name: id }, // set ID manually on response
-      };
+    return this.ajax(url, 'POST', { data }).then((resp) => {
+      const response = resp || {};
+      response.id = name;
+      return response;
     });
   },
 

--- a/ui/app/adapters/transform/base.js
+++ b/ui/app/adapters/transform/base.js
@@ -11,10 +11,15 @@ export default ApplicationAdapter.extend({
   createOrUpdate(store, type, snapshot) {
     const serializer = store.serializerFor(type.modelName);
     const data = serializer.serialize(snapshot);
-    const { id } = snapshot;
+    const id = snapshot.record.get('name');
     const url = this.url(snapshot.record.get('backend'), type.modelName, id);
 
-    return this.ajax(url, 'POST', { data });
+    return this.ajax(url, 'POST', { data }).then(() => {
+      // ember data doesn't like 204s if it's not a DELETE
+      return {
+        data: { ...data, id, name: id }, // set ID manually on response
+      };
+    });
   },
 
   createRecord() {
@@ -45,6 +50,8 @@ export default ApplicationAdapter.extend({
       return {
         ...resp,
         backend,
+        id,
+        name: id,
       };
     });
   },
@@ -58,6 +65,7 @@ export default ApplicationAdapter.extend({
       // CBS TODO: Add name to response and unmap name <> id on models
       return {
         id: query.id,
+        name: query.id,
         ...result,
       };
     });

--- a/ui/app/components/role-aws-edit.js
+++ b/ui/app/components/role-aws-edit.js
@@ -8,7 +8,8 @@ export default RoleEdit.extend({
     createOrUpdate(type, event) {
       event.preventDefault();
 
-      const modelId = this.model.id;
+      // all of the attributes with fieldValue:'id' are called `name`
+      const modelId = this.model.id || this.model.name;
       // prevent from submitting if there's no key
       // maybe do something fancier later
       if (type === 'create' && isBlank(modelId)) {

--- a/ui/app/components/role-edit.js
+++ b/ui/app/components/role-edit.js
@@ -81,7 +81,8 @@ export default Component.extend(FocusOnInsertMixin, {
     createOrUpdate(type, event) {
       event.preventDefault();
 
-      const modelId = this.model.id;
+      // all of the attributes with fieldValue:'id' are called `name`
+      const modelId = this.model.id || this.model.name;
       // prevent from submitting if there's no key
       // maybe do something fancier later
       if (type === 'create' && isBlank(modelId)) {

--- a/ui/app/components/transformation-edit.js
+++ b/ui/app/components/transformation-edit.js
@@ -97,7 +97,7 @@ export default TransformBase.extend({
       event.preventDefault();
 
       this.applyChanges('save', () => {
-        const transformationId = this.model.id;
+        const transformationId = this.model.id || this.model.name;
         const newModelRoles = this.model.allowed_roles || [];
         const initialRoles = this.initialRoles || [];
 

--- a/ui/app/models/pki/pki-role.js
+++ b/ui/app/models/pki/pki-role.js
@@ -11,7 +11,7 @@ export default Model.extend({
   }),
   name: attr('string', {
     label: 'Role name',
-    fieldValue: 'id',
+    fieldValue: 'name',
     readOnly: true,
   }),
   useOpenAPI: true,

--- a/ui/app/models/role-aws.js
+++ b/ui/app/models/role-aws.js
@@ -26,7 +26,6 @@ export default Model.extend({
     label: 'Role name',
     readOnly: true,
   }),
-  useOpenAPI: false,
   // credentialTypes are for backwards compatibility.
   // we use this to populate "credentialType" in
   // the serializer. if there is more than one, the

--- a/ui/app/models/role-aws.js
+++ b/ui/app/models/role-aws.js
@@ -24,7 +24,6 @@ export default Model.extend({
   }),
   name: attr('string', {
     label: 'Role name',
-    fieldValue: 'id',
     readOnly: true,
   }),
   useOpenAPI: false,
@@ -51,6 +50,7 @@ export default Model.extend({
     editType: 'json',
     helpText:
       'A policy is an object in AWS that, when associated with an identity or resource, defines their permissions.',
+    defaultValue: '{\n}',
   }),
   fields: computed('credentialType', function () {
     const credentialType = this.credentialType;

--- a/ui/app/models/role-ssh.js
+++ b/ui/app/models/role-ssh.js
@@ -53,6 +53,7 @@ export default Model.extend({
   }),
   name: attr('string', {
     label: 'Role Name',
+    fieldValue: 'name',
     readOnly: true,
   }),
   keyType: attr('string', {

--- a/ui/app/models/role-ssh.js
+++ b/ui/app/models/role-ssh.js
@@ -53,7 +53,6 @@ export default Model.extend({
   }),
   name: attr('string', {
     label: 'Role Name',
-    fieldValue: 'id',
     readOnly: true,
   }),
   keyType: attr('string', {

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -34,7 +34,6 @@ const TWEAK_SOURCE = [
 ];
 
 const ModelExport = Model.extend({
-  useOpenAPI: false,
   name: attr('string', {
     // CBS TODO: make this required for making a transformation
     label: 'Name',

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -96,5 +96,5 @@ const ModelExport = Model.extend({
 });
 
 export default attachCapabilities(ModelExport, {
-  updatePath: apiPath`${'backend'}/transformation/${'name'}`,
+  updatePath: apiPath`${'backend'}/transformation/${'id'}`,
 });

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -38,7 +38,6 @@ const ModelExport = Model.extend({
   name: attr('string', {
     // CBS TODO: make this required for making a transformation
     label: 'Name',
-    fieldValue: 'id',
     readOnly: true,
     subText: 'The name for your transformation. This cannot be edited later.',
   }),
@@ -97,5 +96,5 @@ const ModelExport = Model.extend({
 });
 
 export default attachCapabilities(ModelExport, {
-  updatePath: apiPath`${'backend'}/transformation/${'id'}`,
+  updatePath: apiPath`${'backend'}/transformation/${'name'}`,
 });

--- a/ui/app/models/transform/alphabet.js
+++ b/ui/app/models/transform/alphabet.js
@@ -12,7 +12,6 @@ const M = Model.extend({
   }),
 
   name: attr('string', {
-    fieldValue: 'name',
     readOnly: true,
     subText: 'The alphabet name. Keep in mind that spaces are not allowed and this cannot be edited later.',
   }),

--- a/ui/app/models/transform/alphabet.js
+++ b/ui/app/models/transform/alphabet.js
@@ -31,5 +31,5 @@ const M = Model.extend({
 });
 
 export default attachCapabilities(M, {
-  updatePath: apiPath`${'backend'}/alphabet/${'name'}`,
+  updatePath: apiPath`${'backend'}/alphabet/${'id'}`,
 });

--- a/ui/app/models/transform/alphabet.js
+++ b/ui/app/models/transform/alphabet.js
@@ -6,13 +6,13 @@ import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 
 const M = Model.extend({
   idPrefix: 'alphabet/',
-  idForNav: computed('id', 'idPrefix', function () {
-    const modelId = this.id || '';
+  idForNav: computed('name', 'idPrefix', function () {
+    const modelId = this.name || '';
     return `${this.idPrefix}${modelId}`;
   }),
 
   name: attr('string', {
-    fieldValue: 'id',
+    fieldValue: 'name',
     readOnly: true,
     subText: 'The alphabet name. Keep in mind that spaces are not allowed and this cannot be edited later.',
   }),
@@ -31,5 +31,5 @@ const M = Model.extend({
 });
 
 export default attachCapabilities(M, {
-  updatePath: apiPath`${'backend'}/alphabet/${'id'}`,
+  updatePath: apiPath`${'backend'}/alphabet/${'name'}`,
 });

--- a/ui/app/models/transform/role.js
+++ b/ui/app/models/transform/role.js
@@ -38,5 +38,5 @@ const ModelExport = Model.extend({
 });
 
 export default attachCapabilities(ModelExport, {
-  updatePath: apiPath`${'backend'}/role/${'name'}`,
+  updatePath: apiPath`${'backend'}/role/${'id'}`,
 });

--- a/ui/app/models/transform/role.js
+++ b/ui/app/models/transform/role.js
@@ -8,15 +8,14 @@ const ModelExport = Model.extend({
   // used for getting appropriate options for backend
   idPrefix: 'role/',
   // the id prefixed with `role/` so we can use it as the *secret param for the secret show route
-  idForNav: computed('id', 'idPrefix', function () {
-    const modelId = this.id || '';
+  idForNav: computed('name', 'idPrefix', function () {
+    const modelId = this.name || '';
     return `${this.idPrefix}${modelId}`;
   }),
 
   name: attr('string', {
     // TODO: make this required for making a transformation
     label: 'Name',
-    fieldValue: 'id',
     readOnly: true,
     subText: 'The name for your role. This cannot be edited later.',
   }),
@@ -39,5 +38,5 @@ const ModelExport = Model.extend({
 });
 
 export default attachCapabilities(ModelExport, {
-  updatePath: apiPath`${'backend'}/role/${'id'}`,
+  updatePath: apiPath`${'backend'}/role/${'name'}`,
 });

--- a/ui/app/models/transform/template.js
+++ b/ui/app/models/transform/template.js
@@ -6,13 +6,12 @@ import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 
 const M = Model.extend({
   idPrefix: 'template/',
-  idForNav: computed('id', 'idPrefix', function () {
-    const modelId = this.id || '';
+  idForNav: computed('name', 'idPrefix', function () {
+    const modelId = this.name || '';
     return `${this.idPrefix}${modelId}`;
   }),
 
   name: attr('string', {
-    fieldValue: 'id',
     readOnly: true,
     subText:
       'Templates allow Vault to determine what and how to capture the value to be transformed. This cannot be edited later.',
@@ -46,5 +45,5 @@ const M = Model.extend({
 });
 
 export default attachCapabilities(M, {
-  updatePath: apiPath`${'backend'}/template/${'id'}`,
+  updatePath: apiPath`${'backend'}/template/${'name'}`,
 });

--- a/ui/app/models/transform/template.js
+++ b/ui/app/models/transform/template.js
@@ -45,5 +45,5 @@ const M = Model.extend({
 });
 
 export default attachCapabilities(M, {
-  updatePath: apiPath`${'backend'}/template/${'name'}`,
+  updatePath: apiPath`${'backend'}/template/${'id'}`,
 });

--- a/ui/app/models/transit-key.js
+++ b/ui/app/models/transit-key.js
@@ -53,7 +53,6 @@ export default Model.extend({
   }),
   name: attr('string', {
     label: 'Name',
-    fieldValue: 'id',
     readOnly: true,
   }),
   autoRotatePeriod: attr({

--- a/ui/app/serializers/transform.js
+++ b/ui/app/serializers/transform.js
@@ -21,6 +21,7 @@ export default ApplicationSerializer.extend({
     return payload.data.keys.map((key) => {
       const model = {
         id: key,
+        name: key,
       };
       if (payload.backend) {
         model.backend = payload.backend;

--- a/ui/app/serializers/transform/alphabet.js
+++ b/ui/app/serializers/transform/alphabet.js
@@ -10,6 +10,7 @@ export default ApplicationSerializer.extend({
     return payload.data.keys.map((key) => {
       const model = {
         id: key,
+        name: key,
       };
       if (payload.backend) {
         model.backend = payload.backend;

--- a/ui/app/serializers/transform/role.js
+++ b/ui/app/serializers/transform/role.js
@@ -5,6 +5,7 @@ export default ApplicationSerializer.extend({
     return payload.data.keys.map((key) => {
       const model = {
         id: key,
+        name: key,
       };
       if (payload.backend) {
         model.backend = payload.backend;

--- a/ui/app/serializers/transform/template.js
+++ b/ui/app/serializers/transform/template.js
@@ -43,6 +43,7 @@ export default ApplicationSerializer.extend({
     return payload.data.keys.map((key) => {
       const model = {
         id: key,
+        name: key,
       };
       if (payload.backend) {
         model.backend = payload.backend;

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -60,9 +60,7 @@ export default class FormFieldComponent extends Component {
   constructor() {
     super(...arguments);
     const { attr, model } = this.args;
-    const fieldValue = attr.options?.fieldValue;
-    // Ember doesn't like when you set the ID directly
-    const valuePath = fieldValue && fieldValue.toLowerCase() !== 'id' ? fieldValue : attr.name;
+    const valuePath = attr.options?.fieldValue || attr.name;
     const modelValue = model[valuePath];
     this.showInput = !!modelValue;
   }
@@ -98,9 +96,7 @@ export default class FormFieldComponent extends Component {
   }
   // both the path to mutate on the model, and the path to read the value from
   get valuePath() {
-    const fieldValue = this.args.attr.options?.fieldValue;
-    // Ember doesn't like when you set the ID directly
-    return fieldValue && fieldValue.toLowerCase() !== 'id' ? fieldValue : this.args.attr.name;
+    return this.args.attr.options?.fieldValue || this.args.attr.name;
   }
   get isReadOnly() {
     const readonly = this.args.attr.options?.readOnly || false;

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -60,7 +60,9 @@ export default class FormFieldComponent extends Component {
   constructor() {
     super(...arguments);
     const { attr, model } = this.args;
-    const valuePath = attr.options?.fieldValue || attr.name;
+    const fieldValue = attr.options?.fieldValue;
+    // Ember doesn't like when you set the ID directly
+    const valuePath = fieldValue && fieldValue.toLowerCase() !== 'id' ? fieldValue : attr.name;
     const modelValue = model[valuePath];
     this.showInput = !!modelValue;
   }
@@ -96,7 +98,9 @@ export default class FormFieldComponent extends Component {
   }
   // both the path to mutate on the model, and the path to read the value from
   get valuePath() {
-    return this.args.attr.options?.fieldValue || this.args.attr.name;
+    const fieldValue = this.args.attr.options?.fieldValue;
+    // Ember doesn't like when you set the ID directly
+    return fieldValue && fieldValue.toLowerCase() !== 'id' ? fieldValue : this.args.attr.name;
   }
   get isReadOnly() {
     const readonly = this.args.attr.options?.readOnly || false;


### PR DESCRIPTION
After the [Ember Upgrade from 3.x to 4.x](https://github.com/hashicorp/vault/pull/17086) it was discovered that Ember now disallows setting the ID on a model, rather than logging a warning as it did previously. 

This showed up as a form seeming to not let you type after the first letter:
![before - bug](https://user-images.githubusercontent.com/82459713/217963489-fd5603b0-e9d1-43e4-8e0a-e31337e964da.gif)

This PR removes `fieldValue: 'id'` from all models that do *not* use OpenAPI, and overrides to match the attribute name on those that do (so that even if it comes back from OpenAPI we do not have this issue). It also ensures that models which do not have an explicit id set one manually on the adapter response. 
![after - fixed](https://user-images.githubusercontent.com/82459713/217963675-b889025d-94d1-41ef-a240-46647ae363cb.gif)
