### PR TITLE
docs/vault-helm: fix multi-line block copy

### DIFF
--- a/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
@@ -58,7 +58,7 @@ kubectl exec -ti vault-primary-0 -- vault login
 Next, list all the raft peers:
 
 ```shell
-kubectl exec -ti vault-primary-0 -- vault operator raft list-peers
+$ kubectl exec -ti vault-primary-0 -- vault operator raft list-peers
 
 Node                                    Address                        State       Voter
 ----                                    -------                        -----       -----
@@ -110,7 +110,7 @@ kubectl exec -ti vault-secondary-0 -- vault login
 Next, list all the raft peers:
 
 ```shell
-kubectl exec -ti vault-secondary-0 -- vault operator raft list-peers
+$ kubectl exec -ti vault-secondary-0 -- vault operator raft list-peers
 
 Node                                    Address                        State       Voter
 ----                                    -------                        -----       -----

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
@@ -58,7 +58,7 @@ kubectl exec -ti vault-primary-0 -- vault login
 Next, list all the raft peers:
 
 ```shell
-kubectl exec -ti vault-primary-0 -- vault operator raft list-peers
+$ kubectl exec -ti vault-primary-0 -- vault operator raft list-peers
 
 Node                                    Address                        State       Voter
 ----                                    -------                        -----       -----
@@ -109,7 +109,7 @@ kubectl exec -ti vault-secondary-0 -- vault login
 Next, list all the raft peers:
 
 ```shell
-kubectl exec -ti vault-secondary-0 -- vault operator raft list-peers
+$ kubectl exec -ti vault-secondary-0 -- vault operator raft list-peers
 
 Node                                    Address                        State       Voter
 ----                                    -------                        -----       -----

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
@@ -52,7 +52,7 @@ kubectl exec -ti vault-0 -- vault login
 Next, list all the raft peers:
 
 ```shell
-kubectl exec -ti vault-0 -- vault operator raft list-peers
+$ kubectl exec -ti vault-0 -- vault operator raft list-peers
 
 Node                                    Address                        State       Voter
 ----                                    -------                        -----       -----

--- a/website/content/docs/platform/k8s/helm/examples/ha-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/ha-with-raft.mdx
@@ -48,7 +48,7 @@ kubectl exec -ti vault-0 -- vault login
 Next, list all the raft peers:
 
 ```shell
-kubectl exec -ti vault-0 -- vault operator raft list-peers
+$ kubectl exec -ti vault-0 -- vault operator raft list-peers
 
 Node                                    Address                        State       Voter
 ----                                    -------                        -----       -----


### PR DESCRIPTION
Add a `$` before the command in shell blocks that include command output, so that the "Copy" button on the website only copies the command and not the output.

Example of current behavior: https://developer.hashicorp.com/vault/docs/platform/k8s/helm/examples/ha-with-raft
Example from this PR: https://vault-5f7042vor-hashicorp.vercel.app/vault/docs/platform/k8s/helm/examples/ha-with-raft