### PR TITLE
Kubernetes config validation update

### DIFF
--- a/ui/app/models/kubernetes/config.js
+++ b/ui/app/models/kubernetes/config.js
@@ -3,7 +3,12 @@ import { withFormFields } from 'vault/decorators/model-form-fields';
 import { withModelValidations } from 'vault/decorators/model-validations';
 
 const validations = {
-  kubernetesHost: [{ type: 'presence', message: 'Kubernetes host is required' }],
+  kubernetesHost: [
+    {
+      validator: (model) => (model.disableLocalCaJwt && !model.kubernetesHost ? false : true),
+      message: 'Kubernetes host is required',
+    },
+  ],
 };
 @withModelValidations(validations)
 @withFormFields(['kubernetesHost', 'serviceAccountJwt', 'kubernetesCaCert'])


### PR DESCRIPTION
When validation was added to the manual config form to require `kubernetes_host`, this impacted the inferred config workflow and prevented it from saving. The validator was updated to only require `kubernetes_host` if `disable_local_ca_jwt` is `true`.