### PR TITLE
Fetch replication status in its own resource

### DIFF
--- a/enos/modules/vault_verify_performance_replication/main.tf
+++ b/enos/modules/vault_verify_performance_replication/main.tf
@@ -44,18 +44,18 @@ variable "wrapping_token" {
 }
 
 locals {
-  primary_replication_status   = jsondecode(enos_remote_exec.verify_replication_on_primary.stdout)
-  secondary_replication_status = jsondecode(enos_remote_exec.verify_replication_on_secondary.stdout)
+  primary_replication_status   = jsondecode(enos_remote_exec.replication_status_on_primary.stdout)
+  secondary_replication_status = jsondecode(enos_remote_exec.replication_status_on_secondary.stdout)
 }
 
-resource "enos_remote_exec" "verify_replication_on_primary" {
+resource "enos_remote_exec" "replication_status_on_primary" {
   environment = {
     VAULT_ADDR        = "http://127.0.0.1:8200"
     VAULT_INSTALL_DIR = var.vault_install_dir
     REPLICATION_MODE  = "primary"
   }
 
-  scripts = ["${path.module}/scripts/verify-performance-replication.sh"]
+  scripts = ["${path.module}/scripts/get-replication-status.sh"]
 
   transport = {
     ssh = {
@@ -73,14 +73,14 @@ output "primary_replication_status" {
   }
 }
 
-resource "enos_remote_exec" "verify_replication_on_secondary" {
+resource "enos_remote_exec" "replication_status_on_secondary" {
   environment = {
     VAULT_ADDR        = "http://127.0.0.1:8200"
     VAULT_INSTALL_DIR = var.vault_install_dir
     REPLICATION_MODE  = "secondary"
   }
 
-  scripts = ["${path.module}/scripts/verify-performance-replication.sh"]
+  scripts = ["${path.module}/scripts/get-replication-status.sh"]
 
   transport = {
     ssh = {

--- a/enos/modules/vault_verify_performance_replication/scripts/get-replication-status.sh
+++ b/enos/modules/vault_verify_performance_replication/scripts/get-replication-status.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# This script waits for the replication status to be established
+# But the replication validations are done by Terraform so this
+# script should always exit success
+
 set -e
 
 binpath=${VAULT_INSTALL_DIR}/vault
@@ -17,7 +21,7 @@ retry() {
       sleep "$wait"
     else
       echo $pr_status
-      return "$exit"
+      return 0
     fi
   done
 

--- a/enos/modules/vault_verify_performance_replication/scripts/get-replication-status.sh
+++ b/enos/modules/vault_verify_performance_replication/scripts/get-replication-status.sh
@@ -5,7 +5,6 @@ set -e
 binpath=${VAULT_INSTALL_DIR}/vault
 
 fail() {
-  echo "$1" 2>&1
   return 1
 }
 
@@ -28,7 +27,7 @@ retry() {
   return 0
 }
 
-test -x "$binpath" || fail "unable to locate vault binary at $binpath"
+test -x "$binpath" || fail
 
 check_pr_status() {
   cluster_state=$($binpath read -format=json sys/replication/performance/status | jq -r '.data.state')
@@ -40,11 +39,11 @@ check_pr_status() {
   fi
 
   if [[ "$connection_status" == 'disconnected' ]]; then
-    fail "expected connection status to be connected"
+    fail
   fi
 
   if [[ "$cluster_state" == 'idle' ]]; then
-    fail "expected cluster state to be not idle"
+    fail
   fi
 }
 


### PR DESCRIPTION
Adding the replication status output to the verification script caused json decode error, so fetch the status in its own resource

Signed-off-by: Jaymala Sinha <jaymala@hashicorp.com>