### PR TITLE
Error saving Kubernetes role edits

### DIFF
--- a/ui/lib/kubernetes/addon/components/page/role/create-and-edit.js
+++ b/ui/lib/kubernetes/addon/components/page/role/create-and-edit.js
@@ -27,7 +27,10 @@ export default class CreateAndEditRolePageComponent extends Component {
 
   constructor() {
     super(...arguments);
-    this.initRoleRules();
+    // generated role rules are only rendered for the full object chain option
+    if (this.args.model.generationPreference === 'full') {
+      this.initRoleRules();
+    }
     // if editing and annotations or labels exist expand the section
     const { extraAnnotations, extraLabels } = this.args.model;
     if (extraAnnotations || extraLabels) {
@@ -127,7 +130,7 @@ export default class CreateAndEditRolePageComponent extends Component {
   *save() {
     try {
       // set generatedRoleRoles to value of selected template
-      const selectedTemplate = this.roleRulesTemplates.findBy('id', this.selectedTemplateId);
+      const selectedTemplate = this.roleRulesTemplates?.findBy('id', this.selectedTemplateId);
       if (selectedTemplate) {
         this.args.model.generatedRoleRules = selectedTemplate.rules;
       }

--- a/ui/tests/integration/components/kubernetes/page/role/create-and-edit-test.js
+++ b/ui/tests/integration/components/kubernetes/page/role/create-and-edit-test.js
@@ -321,4 +321,30 @@ module('Integration | Component | kubernetes | Page::Role::CreateAndEdit', funct
       .dom('[data-test-invalid-form-alert] [data-test-inline-error-message]')
       .hasText('There is an error with this form.');
   });
+
+  test('it should save edited role with correct properties', async function (assert) {
+    assert.expect(1);
+
+    this.role = this.getRole();
+
+    this.server.post('/kubernetes-test/roles/:name', (schema, req) => {
+      const data = JSON.parse(req.requestBody);
+      const expected = {
+        name: 'role-0',
+        service_account_name: 'demo',
+        kubernetes_role_type: 'Role',
+        allowed_kubernetes_namespaces: '*',
+        token_max_ttl: 86400,
+        token_default_ttl: 600,
+      };
+      assert.deepEqual(expected, data, 'POST request made to save role with correct properties');
+    });
+
+    await render(hbs`<Page::Role::CreateAndEdit @model={{this.role}} @breadcrumbs={{this.breadcrumbs}} />`, {
+      owner: this.engine,
+    });
+
+    await fillIn('[data-test-input="serviceAccountName"]', 'demo');
+    await click('[data-test-save]');
+  });
 });


### PR DESCRIPTION
When editing a role the generated role rules where initialized to the example value in the component. When saving a role that didn't use the rules the default value was slipping through in the request and causing an error on the backend. Now the role rule templates are only setup if the generation preference is set to `full`.

![image](https://user-images.githubusercontent.com/24611656/218165580-e1196f31-4403-4d1a-9d93-eecf0fdea7e0.png)
