### PR TITLE
UI: Fix cancel button on role transform form

### DIFF
--- a/changelog/19135.txt
+++ b/changelog/19135.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix cancel button from transform engine role creation page
+```

--- a/changelog/19135.txt
+++ b/changelog/19135.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-ui: Fix cancel button from transform engine role creation page
+ui (enterprise): Fix cancel button from transform engine role creation page
 ```

--- a/ui/app/templates/components/transform-role-edit.hbs
+++ b/ui/app/templates/components/transform-role-edit.hbs
@@ -75,13 +75,15 @@
             Save
           {{/if}}
         </button>
-        <SecretLink
-          @mode={{if (eq this.mode "create") "list" "show"}}
-          class="button"
-          @secret={{concat "role/" this.model.id}}
-        >
-          Cancel
-        </SecretLink>
+        {{#if (eq this.mode "create")}}
+          <LinkTo @route={{"vault.cluster.secrets.backend.list-root"}} @query={{hash tab="role"}} class="button">
+            Cancel
+          </LinkTo>
+        {{else if (eq this.mode "edit")}}
+          <LinkTo @route="vault.cluster.secrets.backend.show" @model={{concat "role/" this.model.id}} class="button">
+            Cancel
+          </LinkTo>
+        {{/if}}
       </div>
     </div>
   </form>

--- a/ui/app/templates/components/transform-role-edit.hbs
+++ b/ui/app/templates/components/transform-role-edit.hbs
@@ -58,7 +58,11 @@
       <MessageError @model={{this.model}} />
       <NamespaceReminder @mode={{this.mode}} @noun="Transform role" />
       {{#each this.model.attrs as |attr|}}
-        <FormField data-test-field @attr={{attr}} @model={{this.model}} />
+        {{#if (and (eq this.mode "edit") attr.options.readOnly)}}
+          <ReadonlyFormField @attr={{attr}} @value={{get this.model attr.name}} />
+        {{else}}
+          <FormField data-test-field @attr={{attr}} @model={{this.model}} />
+        {{/if}}
       {{/each}}
     </div>
     <div class="field is-grouped-split box is-fullwidth is-bottomless">


### PR DESCRIPTION
Before this change, clicking "Cancel" from the create transform role page would result in this error: 

<img width="1552" alt="Error screen after cancel" src="https://user-images.githubusercontent.com/82459713/218167538-f5c2318e-55ad-401c-be1a-72bbe6841961.png">

After the change, clicking Cancel from both the edit and create screens properly redirects to the show or list pages, respectively. 