### PR TITLE
UI: sets operationNone for a kmip role if no checkboxes are selected

### DIFF
--- a/changelog/19139.txt
+++ b/changelog/19139.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes bug in kmip role form that caused `operation_all` to persist after deselecting all operation checkboxes
+```

--- a/ui/app/models/kmip/role.js
+++ b/ui/app/models/kmip/role.js
@@ -58,7 +58,7 @@ const ModelExport = Model.extend(COMPUTEDS, {
     ];
 
     const attributes = ['operationAddAttribute', 'operationGetAttributes'];
-    const server = ['operationDiscoverVersion'];
+    const server = ['operationDiscoverVersions'];
     const others = this.operationFieldsWithoutSpecial
       .slice()
       .removeObjects(objects.concat(attributes, server));

--- a/ui/lib/kmip/addon/components/edit-form-kmip-role.js
+++ b/ui/lib/kmip/addon/components/edit-form-kmip-role.js
@@ -40,6 +40,10 @@ export default EditForm.extend({
       if (model.operationAll || model.operationNone) {
         model.operationFieldsWithoutSpecial.forEach((field) => model.set(field, null));
       }
+      // set operationNone if user unchecks 'operationAll' instead of toggling the 'operationNone' input
+      // doing here instead of on the 'operationNone' input because a user might deselect all, then reselect some options
+      // and immediately setting operationNone will hide all of the checkboxes in the UI
+      this.model.operationNone = model.operationFieldsWithoutSpecial.every((attr) => !model[attr]);
     },
   },
 });

--- a/ui/lib/kmip/addon/components/edit-form-kmip-role.js
+++ b/ui/lib/kmip/addon/components/edit-form-kmip-role.js
@@ -43,7 +43,8 @@ export default EditForm.extend({
       // set operationNone if user unchecks 'operationAll' instead of toggling the 'operationNone' input
       // doing here instead of on the 'operationNone' input because a user might deselect all, then reselect some options
       // and immediately setting operationNone will hide all of the checkboxes in the UI
-      this.model.operationNone = model.operationFieldsWithoutSpecial.every((attr) => !model[attr]);
+      this.model.operationNone =
+        model.operationFieldsWithoutSpecial.every((attr) => !model[attr]) && !this.model.operationAll;
     },
   },
 });

--- a/ui/tests/integration/components/edit-form-kmip-role-test.js
+++ b/ui/tests/integration/components/edit-form-kmip-role-test.js
@@ -68,35 +68,81 @@ module('Integration | Component | edit form kmip role', function (hooks) {
   });
 
   test('it renders: new model', async function (assert) {
+    assert.expect(3);
     const model = createModel({ isNew: true });
     this.set('model', model);
-    await render(hbs`<EditFormKmipRole @model={{this.model}} />`, this.context);
+    this.onSave = ({ model }) => {
+      assert.false(model.operationNone, 'callback fires with operationNone as false');
+      assert.true(model.operationAll, 'callback fires with operationAll as true');
+    };
+    await render(hbs`<EditFormKmipRole @model={{this.model}} @onSave={{this.onSave}} />`, this.context);
 
     assert.dom('[data-test-input="operationAll"]').isChecked('sets operationAll');
+    await click('[data-test-edit-form-submit]');
   });
 
   test('it renders: operationAll', async function (assert) {
+    assert.expect(3);
     const model = createModel({ operationAll: true });
     this.set('model', model);
-    await render(hbs`<EditFormKmipRole @model={{this.model}} />`, this.context);
+    this.onSave = ({ model }) => {
+      assert.false(model.operationNone, 'callback fires with operationNone as false');
+      assert.true(model.operationAll, 'callback fires with operationAll as true');
+    };
+    await render(hbs`<EditFormKmipRole @model={{this.model}} @onSave={{this.onSave}} />`, this.context);
     assert.dom('[data-test-input="operationAll"]').isChecked('sets operationAll');
+    await click('[data-test-edit-form-submit]');
   });
 
   test('it renders: operationNone', async function (assert) {
-    const model = createModel({ operationNone: true });
+    assert.expect(2);
+    const model = createModel({ operationNone: true, operationAll: undefined });
     this.set('model', model);
-    await render(hbs`<EditFormKmipRole @model={{this.model}} />`, this.context);
 
+    this.onSave = ({ model }) => {
+      assert.true(model.operationNone, 'callback fires with operationNone as true');
+    };
+    await render(hbs`<EditFormKmipRole @model={{this.model}} @onSave={{this.onSave}} />`, this.context);
     assert.dom('[data-test-input="operationNone"]').isNotChecked('sets operationNone');
+    await click('[data-test-edit-form-submit]');
   });
 
   test('it renders: choose operations', async function (assert) {
+    assert.expect(3);
     const model = createModel({ operationGet: true });
     this.set('model', model);
-    await render(hbs`<EditFormKmipRole @model={{this.model}} />`, this.context);
+    this.onSave = ({ model }) => {
+      assert.false(model.operationNone, 'callback fires with operationNone as false');
+    };
+    await render(hbs`<EditFormKmipRole @model={{this.model}} @onSave={{this.onSave}} />`, this.context);
 
     assert.dom('[data-test-input="operationNone"]').isChecked('sets operationNone');
     assert.dom('[data-test-input="operationAll"]').isNotChecked('sets operationAll');
+    await click('[data-test-edit-form-submit]');
+  });
+
+  test('it saves operationNone=true when unchecking operationAll box', async function (assert) {
+    assert.expect(15);
+    const model = createModel({ isNew: true });
+    this.set('model', model);
+    this.onSave = ({ model }) => {
+      assert.true(model.operationNone, 'callback fires with operationNone as true');
+      assert.false(model.operationAll, 'callback fires with operationAll as false');
+    };
+
+    await render(hbs`<EditFormKmipRole @model={{this.model}} @onSave={{this.onSave}} />`, this.context);
+    await click('[data-test-input="operationAll"]');
+    for (const field of model.fields) {
+      const { name } = field;
+      if (name === 'operationNone') continue;
+      assert.dom(`[data-test-input="${name}"]`).isNotChecked(`${name} is unchecked`);
+    }
+
+    assert.dom('[data-test-input="operationAll"]').isNotChecked('sets operationAll');
+    assert
+      .dom('[data-test-input="operationNone"]')
+      .isChecked('operationNone toggle is true which means allow operations');
+    await click('[data-test-edit-form-submit]');
   });
 
   const savingTests = [


### PR DESCRIPTION
This PR fixes a kmip role still allowing all operations even if all of the checkboxes are deselected. This is because `operation_none` was only being set/unset when the blue toggle was clicked (see in gif only after it is toggled, then the operations are removed). But if a user unchecks `Allow this role to perform all operations` the change does not persist and all operations are still allowed. 

This also fixes a typo that made the server operation: `Discover versions` input render without a checkbox 

![kmip-role](https://user-images.githubusercontent.com/68122737/218183697-51f6de47-cac6-4769-9774-42baab2f2d51.gif)
