### PR TITLE
Update version to 1.14.0 and version prerelease to beta1

### DIFF
--- a/version/version_base.go
+++ b/version/version_base.go
@@ -11,7 +11,7 @@ var (
 	// Whether cgo is enabled or not; set at build time
 	CgoEnabled bool
 
-	Version           = "1.13.0"
-	VersionPrerelease = "dev1"
+	Version           = "1.14.0"
+	VersionPrerelease = "beta1"
 	VersionMetadata   = ""
 )


### PR DESCRIPTION
Missed this when cutting the release branch. Updating the version now to keep it matching ENT.