### PR TITLE
Update version prerelease to rc1

### DIFF
--- a/version/version_base.go
+++ b/version/version_base.go
@@ -12,6 +12,6 @@ var (
 	CgoEnabled bool
 
 	Version           = "1.13.0"
-	VersionPrerelease = "dev1"
+	VersionPrerelease = "rc1"
 	VersionMetadata   = ""
 )


### PR DESCRIPTION
I've mistakenly left the `VersionPrerelease` as `dev1` on this release branch. Now we have improved versioning documentation, so I am fixing it. 