### PR TITLE
Fix database sample payload doc

### DIFF
--- a/changelog/19170.txt
+++ b/changelog/19170.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+website/docs: fix database static-user sample payload
+```

--- a/website/content/api-docs/secret/databases/index.mdx
+++ b/website/content/api-docs/secret/databases/index.mdx
@@ -519,7 +519,7 @@ this in order to know the password.
   "db_name": "mysql",
   "username": "static-database-user",
   "rotation_statements": [
-    "ALTER USER \"{{name}}\" WITH PASSWORD '{{password}}';"
+    "ALTER USER \"{{name}}\" IDENTIFIED BY '{{password}}';"
   ],
   "rotation_period": "1h"
 }
@@ -565,7 +565,7 @@ $ curl \
     "db_name": "mysql",
     "username": "static-user",
     "rotation_statements": [
-      "ALTER USER \"{{name}}\" WITH PASSWORD '{{password}}';"
+      "ALTER USER \"{{name}}\" IDENTIFIED BY '{{password}}';"
     ],
     "rotation_period": "1h"
   }


### PR DESCRIPTION
Fix database sample payload doc. Copy-pasting the provided sample now works with a properly configured MySQL plugin which will help user self-serve and learn how static users can be used.