### PR TITLE
Reduce memory usage within PKI testing in CI

### DIFF
--- a/builtin/logical/pki/path_tidy_test.go
+++ b/builtin/logical/pki/path_tidy_test.go
@@ -421,8 +421,8 @@ func TestCertStorageMetrics(t *testing.T) {
 
 	// We set up a metrics accumulator
 	inmemSink := metrics.NewInmemSink(
-		2*newPeriod, // A short time period is ideal here to test metrics are emitted every periodic func
-		2000000*time.Hour)
+		2*newPeriod,  // A short time period is ideal here to test metrics are emitted every periodic func
+		10*newPeriod) // Do not keep a huge amount of metrics in the sink forever, clear them out to save memory usage.
 
 	metricsConf := metrics.DefaultConfig("")
 	metricsConf.EnableHostname = false


### PR DESCRIPTION
### Description of issue

 CI is encountering failures running the various PKI unit tests, looks like we are hitting OOM errors based on CircleCI resource usage.

<img width="1114" alt="Screen Shot 2023-02-13 at 4 53 17 PM" src="https://user-images.githubusercontent.com/3989899/218600787-97f54a76-f2c8-4e35-8c6d-d6cedc93ca4a.png">

### Fix description

 - Do not retain a huge amount of intervals within the metrics sink to save on memory usage within CI. Otherwise, with a faster periodic timer as we have, without cleaning up, the memory consumption grows very quickly.  
 - This shows the memory consumption with this fix in place.

<img width="1114" alt="Screen Shot 2023-02-13 at 7 53 57 PM" src="https://user-images.githubusercontent.com/3989899/218610040-7dc0d9ff-6911-4469-9b1f-4d1914b1c41a.png">



