### PR TITLE
Add vault print token to commands in Vault docs

### DIFF
--- a/website/content/docs/commands/print.mdx
+++ b/website/content/docs/commands/print.mdx
@@ -8,7 +8,11 @@ description: The "print" command prints the Vault token currently in use.
 
 The `print` command prints the Vault token currently in use. The only available subcommand is `token`.
 
+## Examples
+
+Print the current token.
+
 ```shell-session
 $ vault print token
-hvs.XXXXXXXXXXXXXXXXXXXXXXXX
+hvs.CAESICaie3Dm0_Hx001QuMabo1IXnyKkx_FuE14MH7zir_bqGh4KHGh2cy5wQnJsZzZ6WG82b29HUlI3eFdEQ0NPQzQ
 ```

--- a/website/content/docs/commands/print.mdx
+++ b/website/content/docs/commands/print.mdx
@@ -1,0 +1,14 @@
+---
+layout: docs
+page_title: version - Command
+description: The "print" command prints the Vault token currently in use.
+---
+
+# print
+
+The `print` command prints the Vault token currently in use. The only available subcommand is `token`.
+
+```shell-session
+$ vault print token
+hvs.XXXXXXXXXXXXXXXXXXXXXXXX
+```

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -746,6 +746,10 @@
         ]
       },
       {
+        "title": "<code>print</code>",
+        "path": "commands/print"
+      },
+      {
         "title": "<code>read</code>",
         "path": "commands/read"
       },


### PR DESCRIPTION
Documentation Request - description
The Commands (CLI) section of the Vault Documentation does not contain an entry describing the vault print token command.
 
Reference - links
[Link to docs](https://developer.hashicorp.com/vault/docs/commands).
[Link to directory in Vault repo](https://github.com/hashicorp/vault/tree/main/website/content/docs/commands).
[zendesk#99855](https://hashicorp.zendesk.com/agent/tickets/99885)
 
Additional context
n/a