### PR TITLE
Kubernetes config payload fix

### DIFF
--- a/ui/app/adapters/kubernetes/role.js
+++ b/ui/app/adapters/kubernetes/role.js
@@ -32,7 +32,7 @@ export default class KubernetesRoleAdapter extends NamedPathAdapter {
   }
   generateCredentials(backend, data) {
     const generateCredentialsUrl = `${this.buildURL()}/${encodePath(backend)}/creds/${data.role}`;
-
+    delete data.role;
     return this.ajax(generateCredentialsUrl, 'POST', { data }).then((response) => {
       const { lease_id, lease_duration, data } = response;
 

--- a/ui/app/serializers/kubernetes/config.js
+++ b/ui/app/serializers/kubernetes/config.js
@@ -7,6 +7,12 @@ export default class KubernetesConfigSerializer extends ApplicationSerializer {
     const json = super.serialize(...arguments);
     // remove backend value from payload
     delete json.backend;
+    // ensure that values from a previous manual configuration are unset
+    if (json.disable_local_ca_jwt === false) {
+      json.kubernetes_ca_cert = null;
+      json.kubernetes_host = null;
+      json.service_account_jwt = null;
+    }
     return json;
   }
 }

--- a/ui/tests/integration/components/kubernetes/page/configure-test.js
+++ b/ui/tests/integration/components/kubernetes/page/configure-test.js
@@ -32,6 +32,12 @@ module('Integration | Component | kubernetes | Page::Configure', function (hooks
       { label: 'kubernetes', route: 'overview' },
       { label: 'configure' },
     ];
+    this.expectedInferred = {
+      disable_local_ca_jwt: false,
+      kubernetes_ca_cert: null,
+      kubernetes_host: null,
+      service_account_jwt: null,
+    };
   });
 
   test('it should display proper options when toggling radio cards', async function (assert) {
@@ -223,7 +229,7 @@ module('Integration | Component | kubernetes | Page::Configure', function (hooks
     this.server.get('/:path/check', () => new Response(204, {}));
     this.server.post('/:path/config', (schema, req) => {
       const json = JSON.parse(req.requestBody);
-      assert.deepEqual(json, { disable_local_ca_jwt: false }, 'Values are passed to create endpoint');
+      assert.deepEqual(json, this.expectedInferred, 'Values are passed to create endpoint');
       return new Response(204, {});
     });
 
@@ -248,13 +254,7 @@ module('Integration | Component | kubernetes | Page::Configure', function (hooks
     this.server.get('/:path/check', () => new Response(204, {}));
     this.server.post('/:path/config', (schema, req) => {
       const json = JSON.parse(req.requestBody);
-      const expected = {
-        disable_local_ca_jwt: false,
-        kubernetes_ca_cert: null,
-        kubernetes_host: null,
-        service_account_jwt: null,
-      };
-      assert.deepEqual(json, expected, 'Manual config values are unset in server payload');
+      assert.deepEqual(json, this.expectedInferred, 'Manual config values are unset in server payload');
       return new Response(204, {});
     });
 


### PR DESCRIPTION
After entering in values in the manual configuration form for a Kuberenetes secrets engine and either changing to the local cluster option or saving and then editing and changing to local cluster, the previously entered values would be sent to the server and saved. This was causing issues so the solution was to unset them in the serializer.