### PR TITLE
events: Remove subscriptions on timeout and cancel

### DIFF
--- a/vault/eventbus/bus_test.go
+++ b/vault/eventbus/bus_test.go
@@ -196,8 +196,8 @@ func TestBusSubscriptionsCancel(t *testing.T) {
 	bus.Start()
 
 	// create and cancel a bunch of subscriptions
-	create := 100
-	cancel := 50
+	const create = 100
+	const cancel = 50
 
 	eventType := logical.EventType("someType")
 

--- a/vault/eventbus/bus_test.go
+++ b/vault/eventbus/bus_test.go
@@ -256,7 +256,7 @@ func TestBusSubscriptionsCancel(t *testing.T) {
 	}
 	waitFor(t, 1*time.Second, func() bool { return received.Load() == int32(create*2-cancel) })
 	// the sends should time out and the subscriptions should drop when the cancelFunc was called
-	waitFor(t, 1*time.Second, func() bool { return subscriptions.Load() == int64(cancel) })
+	waitFor(t, 1*time.Second, func() bool { return subscriptions.Load() == int64(create-cancel) })
 }
 
 // TestBusSubscriptionsBreak verifies that timed out subscriptions are cleaned up.

--- a/vault/eventbus/bus_test.go
+++ b/vault/eventbus/bus_test.go
@@ -221,7 +221,7 @@ func TestBusSubscriptionsCancel(t *testing.T) {
 		go func(i int32) {
 			<-ch
 			received.Add(1)
-			for i < int32(cancel) {
+			if i < int32(cancel) {
 				<-ch
 				received.Add(1)
 			}

--- a/vault/eventbus/bus_test.go
+++ b/vault/eventbus/bus_test.go
@@ -225,8 +225,8 @@ func TestBusSubscriptionsCancel(t *testing.T) {
 				<-ch
 				received.Add(1)
 			}
-			canceled.Add(1)
 			cancelFunc() // cancel explicitly to unsubscribe
+			canceled.Add(1)
 		}(int32(i))
 	}
 

--- a/vault/eventbus/bus_test.go
+++ b/vault/eventbus/bus_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+// TestBusBasics tests that basic event sending and subscribing function.
 func TestBusBasics(t *testing.T) {
 	bus, err := NewEventBus(nil)
 	if err != nil {
@@ -63,6 +64,7 @@ func TestBusBasics(t *testing.T) {
 	}
 }
 
+// TestNamespaceFiltering verifies that events for other namespaces are filtered out by the bus.
 func TestNamespaceFiltering(t *testing.T) {
 	bus, err := NewEventBus(nil)
 	if err != nil {
@@ -122,6 +124,7 @@ func TestNamespaceFiltering(t *testing.T) {
 	}
 }
 
+// TestBus2Subscriptions verifies that events of different types are successfully routed to the correct subscribers.
 func TestBus2Subscriptions(t *testing.T) {
 	bus, err := NewEventBus(nil)
 	if err != nil {
@@ -182,6 +185,7 @@ func TestBus2Subscriptions(t *testing.T) {
 	}
 }
 
+// TestBusSubscriptionsCancel verifies that canceled subscriptions are cleaned up.
 func TestBusSubscriptionsCancel(t *testing.T) {
 	subscriptions.Store(0)
 	bus, err := NewEventBus(nil)
@@ -255,6 +259,7 @@ func TestBusSubscriptionsCancel(t *testing.T) {
 	waitFor(t, 1*time.Second, func() bool { return subscriptions.Load() == int64(cancel) })
 }
 
+// TestBusSubscriptionsBreak verifies that timed out subscriptions are cleaned up.
 func TestBusSubscriptionsBreak(t *testing.T) {
 	subscriptions.Store(0)
 	bus, err := NewEventBus(nil)


### PR DESCRIPTION
When subscriptions are too slow to accept messages on their channels, then we should remove them from the fanout so that we don't have dead subscriptions using up resources.

In addition, when a subscription is explicitly canceled, we should also clean up after it remove the corresponding pipeline.

We also add a new metrics, `events.subscriptions`, to keep track of the number of active subscriptions. This also helps us test.