### PR TITLE
add nil check for secret id entry on delete via accessor

### DIFF
--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -1849,7 +1849,7 @@ func (b *backend) pathRoleSecretIDDestroyUpdateDelete(ctx context.Context, req *
 		return nil, err
 	}
 	if entry == nil {
-		return nil, nil
+		return logical.ErrorResponse("invalid secret accessor id", logical.ErrPermissionDenied), nil
 	}
 
 	// Delete the accessor of the SecretID first

--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -1849,7 +1849,7 @@ func (b *backend) pathRoleSecretIDDestroyUpdateDelete(ctx context.Context, req *
 		return nil, err
 	}
 	if entry == nil {
-		return logical.ErrorResponse("invalid secret accessor id", logical.ErrPermissionDenied), nil
+		return nil, nil
 	}
 
 	// Delete the accessor of the SecretID first
@@ -1974,7 +1974,7 @@ func (b *backend) pathRoleSecretIDAccessorDestroyUpdateDelete(ctx context.Contex
 		return nil, err
 	}
 	if entry == nil {
-		return nil, nil
+		return logical.ErrorResponse("invalid secret id accessor"), logical.ErrPermissionDenied
 	}
 
 	entryIndex := fmt.Sprintf("%s%s/%s", role.SecretIDPrefix, roleNameHMAC, accessorEntry.SecretIDHMAC)

--- a/builtin/credential/approle/path_role_test.go
+++ b/builtin/credential/approle/path_role_test.go
@@ -2697,6 +2697,8 @@ func TestAppRole_SecretID_WithTTL(t *testing.T) {
 	}
 }
 
+// TestAppRole_RoleSecretIDAccessorCrossDelete tests deleting a secret id via
+// secret id accessor belonging to a different role
 func TestAppRole_RoleSecretIDAccessorCrossDelete(t *testing.T) {
 	var resp *logical.Response
 	var err error

--- a/builtin/credential/approle/path_role_test.go
+++ b/builtin/credential/approle/path_role_test.go
@@ -2739,7 +2739,7 @@ func TestAppRole_RoleSecretIDAccessorCrossDelete(t *testing.T) {
 	})
 
 	// Attempt to destroy role2 secretID accessor using role1 path
-	_ = b.requestNoErr(t, &logical.Request{
+	_, err = b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,
 		Storage:   storage,
 		Path:      "role/role1/secret-id-accessor/destroy",
@@ -2748,12 +2748,7 @@ func TestAppRole_RoleSecretIDAccessorCrossDelete(t *testing.T) {
 		},
 	})
 
-	// Check to see if role2 secretID accessor was deleted
-	accessorHashes, err := storage.List(context.Background(), "accessor/")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(accessorHashes) != 2 {
-		t.Fatalf("unexpected accessor deletion; expected 2 accessors, got %d", len(accessorHashes))
+	if err == nil {
+		t.Fatalf("expected error")
 	}
 }

--- a/changelog/19186.txt
+++ b/changelog/19186.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/approle: Add nil check for the secret ID entry when deleting via secret id accessor preventing cross role secret id deletion
+```


### PR DESCRIPTION
This PR adds a nil check for the secret ID entry when deleting via secret id accessor. This fixes a scenario where a secret_id can be deleted by providing a valid accessor to the destroy endpoint on any role in the same mount. 