### PR TITLE
test/plugin: test external database plugin workflows

### DIFF
--- a/helper/testhelpers/pluginhelpers/pluginhelpers.go
+++ b/helper/testhelpers/pluginhelpers/pluginhelpers.go
@@ -71,13 +71,17 @@ func CompilePlugin(t testing.T, typ consts.PluginType, pluginVersion string, plu
 
 	dir := ""
 	var err error
+	pluginRootDir := "builtin"
+	if typ == consts.PluginTypeDatabase {
+		pluginRootDir = "plugins"
+	}
 	for {
 		dir, err = os.Getwd()
 		if err != nil {
 			t.Fatal(err)
 		}
 		// detect if we are in a subdirectory or the root directory and compensate
-		if _, err := os.Stat("builtin"); os.IsNotExist(err) {
+		if _, err := os.Stat(pluginRootDir); os.IsNotExist(err) {
 			err := os.Chdir("..")
 			if err != nil {
 				t.Fatal(err)

--- a/helper/testhelpers/postgresql/postgresqlhelper.go
+++ b/helper/testhelpers/postgresql/postgresqlhelper.go
@@ -22,6 +22,26 @@ func PrepareTestContainer(t *testing.T, version string) (func(), string) {
 	return cleanup, url
 }
 
+// PrepareTestContainerWithVaultUser will setup a test container with a Vault
+// admin user configured so that we can safely call rotate-root without
+// rotating the root DB credentials
+func PrepareTestContainerWithVaultUser(t *testing.T, ctx context.Context, version string) (func(), string) {
+	env := []string{
+		"POSTGRES_PASSWORD=secret",
+		"POSTGRES_DB=database",
+	}
+
+	runner, cleanup, url, id := prepareTestContainer(t, "postgres", "docker.mirror.hashicorp.services/postgres", version, "secret", true, false, false, env)
+
+	cmd := []string{"psql", "-U", "postgres", "-c", "CREATE USER vaultadmin WITH LOGIN PASSWORD 'vaultpass' SUPERUSER"}
+	_, err := runner.RunCmdInBackground(ctx, id, cmd)
+	if err != nil {
+		t.Fatalf("Could not run command (%v) in container: %v", cmd, err)
+	}
+
+	return cleanup, url
+}
+
 func PrepareTestContainerWithPassword(t *testing.T, version, password string) (func(), string) {
 	env := []string{
 		"POSTGRES_PASSWORD=" + password,

--- a/vault/external_tests/plugin/external_plugin_test.go
+++ b/vault/external_tests/plugin/external_plugin_test.go
@@ -275,7 +275,7 @@ func TestExternalPlugin_Database(t *testing.T) {
 	// define a group of parallel tests so we wait for their execution before
 	// continuing on to cleanup
 	// see: https://go.dev/blog/subtests
-	t.Run("group", func(t *testing.T) {
+	t.Run("parallel execution group", func(t *testing.T) {
 		// loop to mount 5 database connections that will each share a single
 		// plugin process
 		for i := 0; i < 5; i++ {
@@ -347,6 +347,9 @@ func TestExternalPlugin_Database(t *testing.T) {
 				// Lookup - expect SUCCESS
 				resp, err = client.Sys().Lookup(revokeLease)
 				if err != nil {
+					t.Fatal(err)
+				}
+				if resp == nil {
 					t.Fatalf("lease lookup response is nil")
 				}
 


### PR DESCRIPTION
This PR tests workflows for external plugins, namely the database secrets engine using Postgres. 

This is a followup to:
- https://github.com/hashicorp/vault/pull/18952
- https://github.com/hashicorp/vault/pull/19090