### PR TITLE
Add PKI unified-revocation feture changelog

### DIFF
--- a/changelog/19196.txt
+++ b/changelog/19196.txt
@@ -1,0 +1,5 @@
+```release-note:feature
+**PKI Cross-Cluster Revocations**: Revocation information can now be
+synchronized across primary and performance replica clusters offering
+a unified CRL/OCSP view of revocations across cluster boundaries.
+```


### PR DESCRIPTION
Add missing feature changelog entry for the Enterprise only PKI cross cluster revocation feature.