### PR TITLE
secrets/gcp: use feature format for changelog entry of impersonated accounts

### DIFF
--- a/changelog/19018.txt
+++ b/changelog/19018.txt
@@ -1,5 +1,5 @@
-```release-note:improvement
-secrets/gcp: added support for impersonated accounts
+```release-note:feature
+**GCP Secrets Impersonated Account Support**: Add support for GCP service account impersonation, allowing callers to generate a GCP access token without requiring Vault to store or retrieve a GCP service account key for each role.
 ```
 
 ```release-note:bug


### PR DESCRIPTION
This PR changes the changelog format for an upcoming 1.13 feature in the GCP secrets engine.