### PR TITLE
fix TestBackendAcc_LoginWithCallerIdentity

### DIFF
--- a/builtin/credential/aws/backend_test.go
+++ b/builtin/credential/aws/backend_test.go
@@ -1521,6 +1521,7 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 		return
 	}
 
+	ctx := context.Background()
 	storage := &logical.InmemStorage{}
 	config := logical.TestBackendConfig()
 	config.StorageView = storage
@@ -1599,7 +1600,7 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 		Storage:   storage,
 		Data:      clientConfigData,
 	}
-	_, err = b.HandleRequest(context.Background(), clientRequest)
+	_, err = b.HandleRequest(ctx, clientRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1613,7 +1614,7 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 		Storage:   storage,
 		Data:      configIdentityData,
 	}
-	resp, err := b.HandleRequest(context.Background(), configIdentityRequest)
+	resp, err := b.HandleRequest(ctx, configIdentityRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1633,7 +1634,7 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 		Storage:   storage,
 		Data:      roleData,
 	}
-	resp, err = b.HandleRequest(context.Background(), roleRequest)
+	resp, err = b.HandleRequest(ctx, roleRequest)
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("bad: failed to create role: resp:%#v\nerr:%v", resp, err)
 	}
@@ -1650,7 +1651,7 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 		Storage:   storage,
 		Data:      roleDataEc2,
 	}
-	resp, err = b.HandleRequest(context.Background(), roleRequestEc2)
+	resp, err = b.HandleRequest(ctx, roleRequestEc2)
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("bad: failed to create role; resp:%#v\nerr:%v", resp, err)
 	}
@@ -1688,7 +1689,7 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 		Storage:   storage,
 		Data:      loginData,
 	}
-	resp, err = b.HandleRequest(context.Background(), loginRequest)
+	resp, err = b.HandleRequest(ctx, loginRequest)
 	if err != nil || resp == nil || !resp.IsError() {
 		t.Errorf("bad: expected failed login due to missing header: resp:%#v\nerr:%v", resp, err)
 	}
@@ -1711,7 +1712,7 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 		Storage:   storage,
 		Data:      loginData,
 	}
-	resp, err = b.HandleRequest(context.Background(), loginRequest)
+	resp, err = b.HandleRequest(ctx, loginRequest)
 	if err != nil || resp == nil || !resp.IsError() {
 		t.Errorf("bad: expected failed login due to invalid header: resp:%#v\nerr:%v", resp, err)
 	}
@@ -1730,13 +1731,13 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 		Storage:   storage,
 		Data:      loginData,
 	}
-	resp, err = b.HandleRequest(context.Background(), loginRequest)
+	resp, err = b.HandleRequest(ctx, loginRequest)
 	if err != nil || resp == nil || !resp.IsError() {
 		t.Errorf("bad: expected failed login due to invalid role: resp:%#v\nerr:%v", resp, err)
 	}
 
 	loginData["role"] = "ec2only"
-	resp, err = b.HandleRequest(context.Background(), loginRequest)
+	resp, err = b.HandleRequest(ctx, loginRequest)
 	if err != nil || resp == nil || !resp.IsError() {
 		t.Errorf("bad: expected failed login due to bad auth type: resp:%#v\nerr:%v", resp, err)
 	}
@@ -1744,7 +1745,7 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 	// finally, the happy path test :)
 
 	loginData["role"] = testValidRoleName
-	resp, err = b.HandleRequest(context.Background(), loginRequest)
+	resp, err = b.HandleRequest(ctx, loginRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1767,7 +1768,7 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 		Schema: b.pathLogin().Fields,
 	}
 	// ensure we can renew
-	resp, err = b.pathLoginRenew(context.Background(), renewReq, emptyLoginFd)
+	resp, err = b.pathLoginRenew(ctx, renewReq, emptyLoginFd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1785,17 +1786,17 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 	// pick up the fake user ID
 	roleData["bound_iam_principal_arn"] = entity.canonicalArn()
 	roleRequest.Path = "role/" + testValidRoleName
-	resp, err = b.HandleRequest(context.Background(), roleRequest)
+	resp, err = b.HandleRequest(ctx, roleRequest)
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("bad: failed to recreate role: resp:%#v\nerr:%v", resp, err)
 	}
-	resp, err = b.HandleRequest(context.Background(), loginRequest)
+	resp, err = b.HandleRequest(ctx, loginRequest)
 	if err != nil || resp == nil || !resp.IsError() {
 		t.Errorf("bad: expected failed login due to changed AWS role ID: resp: %#v\nerr:%v", resp, err)
 	}
 
 	// and ensure a renew no longer works
-	resp, err = b.pathLoginRenew(context.Background(), renewReq, emptyLoginFd)
+	resp, err = b.pathLoginRenew(ctx, renewReq, emptyLoginFd)
 	if err == nil || (resp != nil && !resp.IsError()) {
 		t.Errorf("bad: expected failed renew due to changed AWS role ID: resp: %#v", resp)
 	}
@@ -1808,13 +1809,13 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 	wildcardEntity.FriendlyName = "*"
 	roleData["bound_iam_principal_arn"] = []string{wildcardEntity.canonicalArn(), "arn:aws:iam::123456789012:role/DoesNotExist/Vault_Fake_Role*"}
 	roleRequest.Path = "role/" + wildcardRoleName
-	resp, err = b.HandleRequest(context.Background(), roleRequest)
+	resp, err = b.HandleRequest(ctx, roleRequest)
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("bad: failed to create wildcard roles: resp:%#v\nerr:%v", resp, err)
 	}
 
 	loginData["role"] = wildcardRoleName
-	resp, err = b.HandleRequest(context.Background(), loginRequest)
+	resp, err = b.HandleRequest(ctx, loginRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1823,7 +1824,7 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 	}
 	// and ensure we can renew
 	renewReq = generateRenewRequest(storage, resp.Auth)
-	resp, err = b.pathLoginRenew(context.Background(), renewReq, emptyLoginFd)
+	resp, err = b.pathLoginRenew(ctx, renewReq, emptyLoginFd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1834,7 +1835,17 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 		t.Fatalf("got error when renewing: %#v", *resp)
 	}
 	// ensure the cache is populated
-	cachedArn := b.getCachedUserId(resp.Auth.Metadata["client_user_id"])
+
+	clientUserIDRaw, ok := resp.Auth.InternalData["client_user_id"]
+	if !ok {
+		t.Errorf("client_user_id not found in response")
+	}
+	clientUserID, ok := clientUserIDRaw.(string)
+	if !ok {
+		t.Errorf("client_user_id is not a string: %#v", clientUserIDRaw)
+	}
+
+	cachedArn := b.getCachedUserId(clientUserID)
 	if cachedArn == "" {
 		t.Errorf("got empty ARN back from user ID cache; expected full arn")
 	}
@@ -1843,13 +1854,13 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 	period := 600 * time.Second
 	roleData["period"] = period.String()
 	roleRequest.Path = "role/" + testValidRoleName
-	resp, err = b.HandleRequest(context.Background(), roleRequest)
+	resp, err = b.HandleRequest(ctx, roleRequest)
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("bad: failed to create wildcard role: resp:%#v\nerr:%v", resp, err)
 	}
 
 	loginData["role"] = testValidRoleName
-	resp, err = b.HandleRequest(context.Background(), loginRequest)
+	resp, err = b.HandleRequest(ctx, loginRequest)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Pulls the `client_user_id` from `resp.Auth.InternalData` instead of `resp.Auth.Metadata`.

Local Test run:
```
➜  vault git:(main) ✗ make testacc TEST=./builtin/credential/aws TESTARGS="-run=TestBackendAcc -count 1"
==> Checking that build is using go version >= 1.20...
==> Using go version 1.20...
go: downloading github.com/hashicorp/go-kms-wrapping/v2 v2.0.7
...
VAULT_ACC=1 go test -tags='' ./builtin/credential/aws -v -run=TestBackendAcc -count 1 -timeout=60m
=== RUN   TestBackendAcc_LoginWithInstanceIdentityDocAndAccessListIdentity
    backend_test.go:1063: env var TEST_AWS_EC2_RSA2048 not set, skipping test
--- SKIP: TestBackendAcc_LoginWithInstanceIdentityDocAndAccessListIdentity (0.00s)
=== RUN   TestBackendAcc_LoginWithCallerIdentity
2023-02-15T11:01:24.993-0800 [DEBUG] no stsRole found for 048951102592
2023-02-15T11:01:24.993-0800 [DEBUG] no cached client for region us-east-1 and stsRole 
2023-02-15T11:01:27.290-0800 [DEBUG] no stsRole found for 048951102592
2023-02-15T11:01:27.290-0800 [DEBUG] returning cached client for region us-east-1 and stsRole 
--- PASS: TestBackendAcc_LoginWithCallerIdentity (3.29s)
PASS
ok      github.com/hashicorp/vault/builtin/credential/aws       4.253s
```