### PR TITLE
pki: ensure default issuer is set before CRL rebuild

### DIFF
--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -819,6 +819,19 @@ func (sc *storageContext) importIssuer(certValue string, issuerName string) (*is
 			// Here, we don't need to stitch together the key entries,
 			// because the last run should've done that for us (or, when
 			// importing a key).
+
+			if len(knownIssuers) == 1 {
+				// This one is the only issuer, ensure that it is set as default
+				issuerDefaultSet, err := sc.isDefaultIssuerSet()
+				if err != nil {
+					return nil, false, err
+				}
+				if !issuerDefaultSet {
+					if err = sc.updateDefaultIssuerId(existingIssuer.ID); err != nil {
+						return nil, false, err
+					}
+				}
+			}
 			return existingIssuer, true, nil
 		}
 

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -819,19 +819,6 @@ func (sc *storageContext) importIssuer(certValue string, issuerName string) (*is
 			// Here, we don't need to stitch together the key entries,
 			// because the last run should've done that for us (or, when
 			// importing a key).
-
-			if len(knownIssuers) == 1 {
-				// This one is the only issuer, ensure that it is set as default
-				issuerDefaultSet, err := sc.isDefaultIssuerSet()
-				if err != nil {
-					return nil, false, err
-				}
-				if !issuerDefaultSet {
-					if err = sc.updateDefaultIssuerId(existingIssuer.ID); err != nil {
-						return nil, false, err
-					}
-				}
-			}
 			return existingIssuer, true, nil
 		}
 

--- a/changelog/19211.txt
+++ b/changelog/19211.txt
@@ -1,3 +1,3 @@
-```release-note:bug
-secrets/pki: ensure default issuer is set
+```release-note:improvement
+secrets/pki: set default issuer before rebuilding the CRL
 ```

--- a/changelog/19211.txt
+++ b/changelog/19211.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: ensure default issuer is set
+```


### PR DESCRIPTION
If the issuer that is being imported already exists **and** this is the only issuer within the PKI backend, then ensure default issuer is set.

Fixes #19210 