### PR TITLE
UI/add allowed response headers secret mount

### DIFF
--- a/changelog/19216.txt
+++ b/changelog/19216.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: adds allowed_response_headers as param for secret engine mount config
+```

--- a/ui/app/models/mount-config.js
+++ b/ui/app/models/mount-config.js
@@ -42,6 +42,13 @@ export default class MountConfigModel extends Model {
   })
   passthroughRequestHeaders;
 
+  @attr({
+    label: 'Allowed response headers',
+    helpText: 'Headers to allow, allowing a plugin to include them in the response.',
+    editType: 'stringArray',
+  })
+  allowedResponseHeaders;
+
   @attr('string', {
     label: 'Token Type',
     helpText:

--- a/ui/app/models/secret-engine.js
+++ b/ui/app/models/secret-engine.js
@@ -83,7 +83,9 @@ export default SecretEngineModel.extend({
     const fields = ['type', 'path', 'description', 'accessor', 'local', 'sealWrap'];
     // no ttl options for keymgmt
     const ttl = type !== 'keymgmt' ? 'defaultLeaseTtl,maxLeaseTtl,' : '';
-    fields.push(`config.{${ttl}auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}`);
+    fields.push(
+      `config.{${ttl}auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders}`
+    );
     if (type === 'kv' || type === 'generic') {
       fields.push('version');
     }
@@ -105,14 +107,14 @@ export default SecretEngineModel.extend({
         optionFields = [
           'version',
           ...CORE_OPTIONS,
-          `config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}`,
+          `config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders}`,
         ];
         break;
       case 'generic':
         optionFields = [
           'version',
           ...CORE_OPTIONS,
-          `config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}`,
+          `config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders}`,
         ];
         break;
       case 'database':
@@ -120,21 +122,21 @@ export default SecretEngineModel.extend({
         defaultFields = ['path', 'config.{defaultLeaseTtl}', 'config.{maxLeaseTtl}'];
         optionFields = [
           ...CORE_OPTIONS,
-          'config.{auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}',
+          'config.{auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders}',
         ];
         break;
       case 'keymgmt':
         // no ttl options for keymgmt
         optionFields = [
           ...CORE_OPTIONS,
-          'config.{auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}',
+          'config.{auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders}',
         ];
         break;
       default:
         defaultFields = ['path'];
         optionFields = [
           ...CORE_OPTIONS,
-          `config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}`,
+          `config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders}`,
         ];
         break;
     }

--- a/ui/app/templates/vault/cluster/secrets/backend/list.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/list.hbs
@@ -129,10 +129,7 @@
     {{else}}
       {{#if (eq this.baseKey.id "")}}
         {{#if (and options.firstStep (not this.tab))}}
-          <EmptyState
-            @title="Get started with {{capitalize this.backendType}}"
-            @message="To use {{this.backendType}}, you'll need to {{options.firstStep}}."
-          >
+          <EmptyState @title="Get started with {{capitalize this.backendType}}" @message={{options.firstStep}}>
             <SecretLink
               @mode="create"
               @secret=""
@@ -145,7 +142,9 @@
         {{else}}
           <EmptyState
             @title="No {{pluralize options.item}} in this backend"
-            @message="Secrets in this backend will be listed here. Add a secret to get started."
+            @message="{{pluralize (capitalize options.item)}}
+            in this backend will be listed here. 
+            {{or options.message (concat 'Add a' options.item 'to get started.')}}"
           >
             <SecretLink
               @mode="create"

--- a/ui/app/templates/vault/cluster/secrets/backend/list.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/list.hbs
@@ -144,7 +144,7 @@
             @title="No {{pluralize options.item}} in this backend"
             @message="{{pluralize (capitalize options.item)}}
             in this backend will be listed here. 
-            {{or options.message (concat 'Add a' options.item 'to get started.')}}"
+            {{or options.message (concat 'Add a ' options.item ' to get started.')}}"
           >
             <SecretLink
               @mode="create"

--- a/ui/lib/core/addon/helpers/options-for-backend.js
+++ b/ui/lib/core/addon/helpers/options-for-backend.js
@@ -67,7 +67,8 @@ const SECRET_BACKENDS = {
         modelPrefix: 'cert/',
         label: 'Certificates',
         searchPlaceholder: 'Filter certificates',
-        item: 'certificates',
+        item: 'certificate',
+        message: 'Issue a certificate from a role.',
         create: 'Create role',
         tab: 'cert',
         listItemPartial: 'secret-list/pki-cert-item',
@@ -141,7 +142,7 @@ const SECRET_BACKENDS = {
     displayName: 'Transformation',
     navigateTree: false,
     listItemPartial: 'secret-list/transform-list-item',
-    firstStep: 'create a transformation and a role',
+    firstStep: `To use transform, you'll need to create a transformation and a role.`,
     tabs: [
       {
         name: 'transformations',
@@ -191,7 +192,7 @@ const SECRET_BACKENDS = {
     navigateTree: false,
     editComponent: 'transit-edit',
     listItemPartial: 'secret-list/item',
-    firstStep: 'create an encryption key',
+    firstStep: `To use transit, you'll need to create an encryption key`,
   },
 };
 

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -1,5 +1,5 @@
 import { currentRouteName, currentURL, settled } from '@ember/test-helpers';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { create } from 'ember-cli-page-object';
 import page from 'vault/tests/pages/settings/mount-secret-backend';
@@ -150,11 +150,11 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
     await settled();
     assert.dom('[data-test-row-value="Maximum number of versions"]').hasText('Not set');
   });
-  // TODO JR: enable once kubernetes routes are defined
-  skip('it should transition to engine route on success if defined in mount config', async function (assert) {
+
+  test('it should transition to engine route on success if defined in mount config', async function (assert) {
     await consoleComponent.runCommands([
       // delete any previous mount with same name
-      `delete sys/mounts/kmip`,
+      `delete sys/mounts/kubernetes`,
     ]);
     await mountSecrets.visit();
     await mountSecrets.selectType('kubernetes');

--- a/ui/tests/unit/models/secret-engine-test.js
+++ b/ui/tests/unit/models/secret-engine-test.js
@@ -59,7 +59,7 @@ module('Unit | Model | secret-engine', function (hooks) {
             'config.listingVisibility',
             'local',
             'sealWrap',
-            'config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}',
+            'config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders}',
           ],
         },
       ]);
@@ -84,7 +84,7 @@ module('Unit | Model | secret-engine', function (hooks) {
             'config.listingVisibility',
             'local',
             'sealWrap',
-            'config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}',
+            'config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders}',
           ],
         },
       ]);
@@ -109,7 +109,7 @@ module('Unit | Model | secret-engine', function (hooks) {
             'config.listingVisibility',
             'local',
             'sealWrap',
-            'config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}',
+            'config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders}',
           ],
         },
       ]);
@@ -133,7 +133,7 @@ module('Unit | Model | secret-engine', function (hooks) {
             'config.listingVisibility',
             'local',
             'sealWrap',
-            'config.{auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}',
+            'config.{auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders}',
           ],
         },
       ]);
@@ -157,7 +157,7 @@ module('Unit | Model | secret-engine', function (hooks) {
             'config.listingVisibility',
             'local',
             'sealWrap',
-            'config.{auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}',
+            'config.{auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders}',
           ],
         },
       ]);


### PR DESCRIPTION
Adds `allowed_response_headers` to mount config for secret engines. [docs](https://developer.hashicorp.com/vault/api-docs/system/mounts#allowed_response_headers). Allows things like `Last-Modified` as a header to be on responses to fetching pki CA/CRLs.


Also updates empty state to include the item type in the message, instead of just 'Secret' for each tab
### PKI empty state:

<img width="871" alt="Screenshot 2023-02-16 at 7 48 08 AM" src="https://user-images.githubusercontent.com/68122737/219416830-c1d35c48-4d89-4faf-855d-7df50ee4cc01.png">

<img width="862" alt="Screenshot 2023-02-16 at 7 48 35 AM" src="https://user-images.githubusercontent.com/68122737/219416962-a81e5959-bd60-4f9e-a036-23ab84762839.png">

<hr>

### transit: 
<img width="876" alt="Screenshot 2023-02-16 at 7 48 58 AM" src="https://user-images.githubusercontent.com/68122737/219417086-c59f945c-4704-45ea-8d14-9c1eb0a07b5a.png">
<hr>
### transform:
![Uploading Screenshot 2023-02-16 at 7.49.21 AM.png…]()
