### PR TITLE
use github token if present when fetching org id

### DIFF
--- a/builtin/credential/github/path_config.go
+++ b/builtin/credential/github/path_config.go
@@ -36,6 +36,10 @@ API-compatible authentication server.`,
 					Group: "GitHub Options",
 				},
 			},
+			"token": {
+				Type:        framework.TypeString,
+				Description: "GitHub personal API token",
+			},
 			"ttl": {
 				Type:        framework.TypeDurationSecond,
 				Description: tokenutil.DeprecationText("token_ttl"),
@@ -96,9 +100,7 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 	if c.OrganizationID == 0 {
 		var githubToken string
 		if token, ok := data.GetOk("token"); ok {
-			if t, ok := token.(string); ok {
-				githubToken = t
-			}
+			githubToken = token.(string)
 		}
 		client, err := b.Client(githubToken)
 		if err != nil {

--- a/builtin/credential/github/path_config.go
+++ b/builtin/credential/github/path_config.go
@@ -95,7 +95,7 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 	}
 
 	if c.OrganizationID == 0 {
-		githubToken := os.Getenv("VAULT_AUTH_GITHUB_TOKEN")
+		githubToken := os.Getenv("VAULT_AUTH_CONFIG_GITHUB_TOKEN")
 		client, err := b.Client(githubToken)
 		if err != nil {
 			return nil, err

--- a/builtin/credential/github/path_config.go
+++ b/builtin/credential/github/path_config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -35,10 +36,6 @@ API-compatible authentication server.`,
 					Name:  "Base URL",
 					Group: "GitHub Options",
 				},
-			},
-			"token": {
-				Type:        framework.TypeString,
-				Description: "GitHub personal API token",
 			},
 			"ttl": {
 				Type:        framework.TypeDurationSecond,
@@ -98,10 +95,7 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 	}
 
 	if c.OrganizationID == 0 {
-		var githubToken string
-		if token, ok := data.GetOk("token"); ok {
-			githubToken = token.(string)
-		}
+		githubToken := os.Getenv("VAULT_AUTH_GITHUB_TOKEN")
 		client, err := b.Client(githubToken)
 		if err != nil {
 			return nil, err

--- a/builtin/credential/github/path_config.go
+++ b/builtin/credential/github/path_config.go
@@ -94,7 +94,13 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 	}
 
 	if c.OrganizationID == 0 {
-		client, err := b.Client("")
+		var githubToken string
+		if token, ok := data.GetOk("token"); ok {
+			if t, ok := token.(string); ok {
+				githubToken = t
+			}
+		}
+		client, err := b.Client(githubToken)
 		if err != nil {
 			return nil, err
 		}

--- a/builtin/credential/github/path_config_test.go
+++ b/builtin/credential/github/path_config_test.go
@@ -129,7 +129,7 @@ func TestGitHub_WriteReadConfig_Token(t *testing.T) {
 	ts := setupTestServer(t)
 	defer ts.Close()
 
-	err := os.Setenv("VAULT_AUTH_GITHUB_TOKEN", "foobar")
+	err := os.Setenv("VAULT_AUTH_CONFIG_GITHUB_TOKEN", "foobar")
 	assert.NoError(t, err)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{

--- a/builtin/credential/github/path_config_test.go
+++ b/builtin/credential/github/path_config_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -121,19 +122,21 @@ func TestGitHub_WriteReadConfig_OrgID(t *testing.T) {
 }
 
 // TestGitHub_WriteReadConfig_Token tests that we can successfully read and
-// write the github auth config with a token param
+// write the github auth config with a token environment variable
 func TestGitHub_WriteReadConfig_Token(t *testing.T) {
 	b, s := createBackendWithStorage(t)
 	// use a test server to return our mock GH org info
 	ts := setupTestServer(t)
 	defer ts.Close()
 
+	err := os.Setenv("VAULT_AUTH_GITHUB_TOKEN", "foobar")
+	assert.NoError(t, err)
+
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Path:      "config",
 		Operation: logical.UpdateOperation,
 		Data: map[string]interface{}{
 			"organization": "foo-org",
-			"token":        "foo-token",
 			"base_url":     ts.URL, // base_url will call the test server
 		},
 		Storage: s,

--- a/changelog/19244.txt
+++ b/changelog/19244.txt
@@ -1,4 +1,4 @@
 ```release-note:improvement
 auth/github: Allow for an optional Github auth token to make authenticated requests when fetching org id
-website/docs: Add docs for `token` parameter when writing Github config
+website/docs: Add docs for `VAULT_AUTH_GITHUB_TOKEN` environment variable when writing Github config
 ```

--- a/changelog/19244.txt
+++ b/changelog/19244.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+auth/github: Allow for an optional Github auth token to make authenticated requests when fetching org id
+website/docs: Add docs for `token` parameter when writing Github config
+```

--- a/changelog/19244.txt
+++ b/changelog/19244.txt
@@ -1,4 +1,4 @@
 ```release-note:improvement
-auth/github: Allow for an optional Github auth token to make authenticated requests when fetching org id
-website/docs: Add docs for `VAULT_AUTH_GITHUB_TOKEN` environment variable when writing Github config
+auth/github: Allow for an optional Github auth token environment variable to make authenticated requests when fetching org id
+website/docs: Add docs for `VAULT_AUTH_CONFIG_GITHUB_TOKEN` environment variable when writing Github config
 ```

--- a/website/content/api-docs/auth/github.mdx
+++ b/website/content/api-docs/auth/github.mdx
@@ -31,9 +31,12 @@ distinction between the `create` and `update` capabilities inside ACL policies.
   of. Vault will attempt to fetch and set this value if it is not provided.
 - `base_url` `(string: "")` - The API endpoint to use. Useful if you are running
   GitHub Enterprise or an API-compatible authentication server.
-- `token` `(string: "")` - An optional GitHub token used to make authenticated GitHub API requests.
-  This can be useful for bypassing GitHub's rate-limiting during automation flows
-  when the `organization_id` is not provided. We encourage you to provide the `organization_id` instead of the `token`.
+
+### Environment variables
+- `VAULT_AUTH_GITHUB_TOKEN` `(string: "")` - An optional GitHub token used to make
+  authenticated GitHub API requests. This can be useful for bypassing GitHub's
+  rate-limiting during automation flows when the `organization_id` is not provided.
+  We encourage you to provide the `organization_id` instead of relying on this environment variable.
 
 @include 'tokenfields.mdx'
 

--- a/website/content/api-docs/auth/github.mdx
+++ b/website/content/api-docs/auth/github.mdx
@@ -31,6 +31,9 @@ distinction between the `create` and `update` capabilities inside ACL policies.
   of. Vault will attempt to fetch and set this value if it is not provided.
 - `base_url` `(string: "")` - The API endpoint to use. Useful if you are running
   GitHub Enterprise or an API-compatible authentication server.
+- `token` `(string: "")` - An optional GitHub token used to make authenticated GitHub API requests.
+  This can be useful for bypassing GitHub's rate-limiting during automation flows
+  when the `organization_id` is not provided. We encourage you to provide the `organization_id` instead of the `token`.
 
 @include 'tokenfields.mdx'
 

--- a/website/content/api-docs/auth/github.mdx
+++ b/website/content/api-docs/auth/github.mdx
@@ -33,7 +33,7 @@ distinction between the `create` and `update` capabilities inside ACL policies.
   GitHub Enterprise or an API-compatible authentication server.
 
 ### Environment variables
-- `VAULT_AUTH_GITHUB_TOKEN` `(string: "")` - An optional GitHub token used to make
+- `VAULT_AUTH_CONFIG_GITHUB_TOKEN` `(string: "")` - An optional GitHub token used to make
   authenticated GitHub API requests. This can be useful for bypassing GitHub's
   rate-limiting during automation flows when the `organization_id` is not provided.
   We encourage you to provide the `organization_id` instead of relying on this environment variable.


### PR DESCRIPTION
When running our acceptance tests in other repos, we often hit the rate limit for GitHub's API. See https://github.com/hashicorp/terraform-provider-vault/actions/runs/3767881277/jobs/6405863202#step:5:349 as an example. This change takes in the Github token (if present) when creating the GH client so that we can make authenticated requests, which bumps the rate limit to 5k requests per hour, instead of the 60/hour that we're currently exceeding.