### PR TITLE
Document the 'convergent' tokenization transform option

### DIFF
--- a/website/content/api-docs/secret/transform.mdx
+++ b/website/content/api-docs/secret/transform.mdx
@@ -333,6 +333,13 @@ transformation exists, it will be updated with the new attributes.
   for all plaintexts to be decoded via the export-decoded endpoint
   in an emergency.
 
+- `convergent` `(bool: false)` - 
+  Specifies whether to use convergent tokenization, where tokenization of the same
+  plaintext more than once results in the same token.  Defaults to false as unique
+  tokens are more desirable from a security standpoint if there isn't a use-case
+  need for convergence.  This property cannot be changed after the transform
+  is created.
+
 - `max_ttl`: `(duration: "0")` -
   The maximum TTL of a token. If 0 or unspecified, tokens may have no expiration.
 


### PR DESCRIPTION
Somehow this slipped through the cracks.