### PR TITLE
Stop vault on exit in gen_openapi.sh

### DIFF
--- a/changelog/19252.txt
+++ b/changelog/19252.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+openapi: Consistently stop Vault server on exit in gen_openapi.sh
+```

--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -25,7 +25,7 @@ sleep 2
 VAULT_PID=$!
 
 defer_stop_vault() {
-    echo "Stopping Vault.."
+    echo "Stopping Vault..."
     kill $VAULT_PID
     sleep 1
 }

--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -25,7 +25,7 @@ sleep 2
 VAULT_PID=$!
 
 defer_stop_vault() {
-    echo "stopping vault"
+    echo "Stopping Vault..."
     kill $VAULT_PID
     sleep 1
 }
@@ -60,7 +60,7 @@ done <../../vault/helper/builtinplugins/registry.go
 
 if [[ -n "${auth_plugin_previous}" ]] ; then
     echo "enabling auth plugin: ${auth_plugin_previous}"
-    vault auth enable "${auth_plugin_previous}"
+    vault auth enable blah
 fi
 
 # Enable secrets plugins

--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -25,7 +25,7 @@ sleep 2
 VAULT_PID=$!
 
 defer_stop_vault() {
-    echo "Stopping Vault..."
+    echo "Stopping Vault.."
     kill $VAULT_PID
     sleep 1
 }
@@ -60,7 +60,7 @@ done <../../vault/helper/builtinplugins/registry.go
 
 if [[ -n "${auth_plugin_previous}" ]] ; then
     echo "enabling auth plugin: ${auth_plugin_previous}"
-    vault auth enable blah
+    vault auth enable ${auth_plugin_previous}
 fi
 
 # Enable secrets plugins

--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -24,6 +24,14 @@ vault server -dev -dev-root-token-id=root &
 sleep 2
 VAULT_PID=$!
 
+defer_stop_vault() {
+    echo "stopping vault"
+    kill $VAULT_PID
+    sleep 1
+}
+
+trap defer_stop_vault INT TERM EXIT
+
 export VAULT_ADDR=http://127.0.0.1:8200
 
 echo "Mounting all builtin plugins..."
@@ -125,8 +133,6 @@ else
             'http://127.0.0.1:8200/v1/sys/internal/specs/openapi' > openapi.json
 fi
 
-kill $VAULT_PID
-sleep 1
-
 echo
 echo "openapi.json generated"
+echo

--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -60,7 +60,7 @@ done <../../vault/helper/builtinplugins/registry.go
 
 if [[ -n "${auth_plugin_previous}" ]] ; then
     echo "enabling auth plugin: ${auth_plugin_previous}"
-    vault auth enable ${auth_plugin_previous}
+    vault auth enable "${auth_plugin_previous}"
 fi
 
 # Enable secrets plugins


### PR DESCRIPTION
This PR ensures that the `vault server -dev` process started by `gen_opeanpi.sh` is always stopped whether the script exists successfully or with an error.