### PR TITLE
Add Oracle Cloud auth to the Vault Agent

### DIFF
--- a/changelog/19260.txt
+++ b/changelog/19260.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+**agent/auto-auth:**: Add OCI (Oracle Cloud Infrastructure) auto-auth method
+```

--- a/command/agent.go
+++ b/command/agent.go
@@ -40,6 +40,7 @@ import (
 	"github.com/hashicorp/vault/command/agent/auth/jwt"
 	"github.com/hashicorp/vault/command/agent/auth/kerberos"
 	"github.com/hashicorp/vault/command/agent/auth/kubernetes"
+	"github.com/hashicorp/vault/command/agent/auth/oci"
 	"github.com/hashicorp/vault/command/agent/cache"
 	"github.com/hashicorp/vault/command/agent/cache/cacheboltdb"
 	"github.com/hashicorp/vault/command/agent/cache/cachememdb"
@@ -370,6 +371,8 @@ func (c *AgentCommand) Run(args []string) int {
 			method, err = kubernetes.NewKubernetesAuthMethod(authConfig)
 		case "approle":
 			method, err = approle.NewApproleAuthMethod(authConfig)
+		case "oci":
+			method, err = oci.NewOCIAuthMethod(authConfig, config.Vault.Address)
 		case "token_file":
 			method, err = token_file.NewTokenFileAuthMethod(authConfig)
 		case "pcf": // Deprecated.

--- a/command/agent/auth/oci/oci.go
+++ b/command/agent/auth/oci/oci.go
@@ -234,9 +234,9 @@ func getHomeFolder() string {
 	current, e := user.Current()
 	if e != nil {
 		// Give up and try to return something sensible
-		home := os.Getenv("HOME")
-		if home == "" {
-			home = os.Getenv("USERPROFILE")
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
 		}
 		return home
 	}

--- a/command/agent/auth/oci/oci.go
+++ b/command/agent/auth/oci/oci.go
@@ -1,0 +1,261 @@
+package oci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/user"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/command/agent/auth"
+	"github.com/oracle/oci-go-sdk/common"
+	ociAuth "github.com/oracle/oci-go-sdk/common/auth"
+)
+
+const (
+	typeAPIKey   = "apikey"
+	typeInstance = "instance"
+
+	/*
+
+		IAM creds can be inferred from instance metadata or the container
+		identity service, and those creds expire at varying intervals with
+		new creds becoming available at likewise varying intervals. Let's
+		default to polling once a minute so all changes can be picked up
+		rather quickly. This is configurable, however.
+
+	*/
+	defaultCredCheckFreqSeconds = 60
+
+	defaultConfigFileName    = "config"
+	defaultConfigDirName     = ".oci"
+	configFilePathEnvVarName = "OCI_CONFIG_FILE"
+	secondaryConfigDirName   = ".oraclebmc"
+)
+
+func NewOCIAuthMethod(conf *auth.AuthConfig, vaultAddress string) (auth.AuthMethod, error) {
+	if conf == nil {
+		return nil, errors.New("empty config")
+	}
+	if conf.Config == nil {
+		return nil, errors.New("empty config data")
+	}
+
+	a := &ociMethod{
+		logger:       conf.Logger,
+		vaultAddress: vaultAddress,
+		mountPath:    conf.MountPath,
+		credsFound:   make(chan struct{}),
+		stopCh:       make(chan struct{}),
+	}
+
+	typeRaw, ok := conf.Config["type"]
+	if !ok {
+		return nil, errors.New("missing 'type' value")
+	}
+	authType, ok := typeRaw.(string)
+	if !ok {
+		return nil, errors.New("could not convert 'type' config value to string")
+	}
+
+	roleRaw, ok := conf.Config["role"]
+	if !ok {
+		return nil, errors.New("missing 'role' value")
+	}
+	a.role, ok = roleRaw.(string)
+	if !ok {
+		return nil, errors.New("could not convert 'role' config value to string")
+	}
+
+	// Check for an optional custom frequency at which we should poll for creds.
+	credCheckFreqSec := defaultCredCheckFreqSeconds
+	if checkFreqRaw, ok := conf.Config["credential_poll_interval"]; ok {
+		if credFreq, ok := checkFreqRaw.(int); ok {
+			credCheckFreqSec = credFreq
+		} else {
+			return nil, errors.New("could not convert 'credential_poll_interval' config value to int")
+		}
+	}
+
+	switch {
+	case a.role == "":
+		return nil, errors.New("'role' value is empty")
+	case authType == "":
+		return nil, errors.New("'type' value is empty")
+	case authType != typeAPIKey && authType != typeInstance:
+		return nil, errors.New("'type' value is invalid")
+	case authType == typeAPIKey:
+		defaultConfigFile := getDefaultConfigFilePath()
+		homeFolder := getHomeFolder()
+		secondaryConfigFile := path.Join(homeFolder, secondaryConfigDirName, defaultConfigFileName)
+
+		environmentProvider := common.ConfigurationProviderEnvironmentVariables("OCI", "")
+		defaultFileProvider, _ := common.ConfigurationProviderFromFile(defaultConfigFile, "")
+		secondaryFileProvider, _ := common.ConfigurationProviderFromFile(secondaryConfigFile, "")
+
+		provider, _ := common.ComposingConfigurationProvider([]common.ConfigurationProvider{environmentProvider, defaultFileProvider, secondaryFileProvider})
+		a.configurationProvider = provider
+	case authType == typeInstance:
+		configurationProvider, err := ociAuth.InstancePrincipalConfigurationProvider()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create instance principal configuration provider: %v", err)
+		}
+		a.configurationProvider = configurationProvider
+	}
+
+	// Do an initial population of the creds because we want to err right away if we can't
+	// even get a first set.
+	creds, err := a.configurationProvider.KeyID()
+	if err != nil {
+		return nil, err
+	}
+	a.lastCreds = creds
+
+	go a.pollForCreds(credCheckFreqSec)
+
+	return a, nil
+}
+
+type ociMethod struct {
+	logger       hclog.Logger
+	vaultAddress string
+	mountPath    string
+
+	configurationProvider common.ConfigurationProvider
+	role                  string
+
+	// These are used to share the latest creds safely across goroutines.
+	credLock  sync.Mutex
+	lastCreds string
+
+	// Notifies the outer environment that it should call Authenticate again.
+	credsFound chan struct{}
+
+	// Detects that the outer environment is closing.
+	stopCh chan struct{}
+}
+
+func (a *ociMethod) Authenticate(context.Context, *api.Client) (string, http.Header, map[string]interface{}, error) {
+	a.credLock.Lock()
+	defer a.credLock.Unlock()
+
+	a.logger.Trace("beginning authentication")
+
+	requestPath := fmt.Sprintf("/v1/%s/login/%s", a.mountPath, a.role)
+	requestURL := fmt.Sprintf("%s%s", a.vaultAddress, requestPath)
+
+	request, err := http.NewRequest("GET", requestURL, nil)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("error creating authentication request: %w", err)
+	}
+
+	request.Header.Set("Date", time.Now().UTC().Format(http.TimeFormat))
+
+	signer := common.DefaultRequestSigner(a.configurationProvider)
+
+	err = signer.Sign(request)
+
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("error signing authentication request: %w", err)
+	}
+
+	parsedVaultAddress, err := url.Parse(a.vaultAddress)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("unable to parse vault address: %w", err)
+	}
+
+	request.Header.Set("Host", parsedVaultAddress.Host)
+	request.Header.Set("(request-target)", fmt.Sprintf("%s %s", "get", requestPath))
+
+	data := map[string]interface{}{
+		"request_headers": request.Header,
+	}
+
+	return fmt.Sprintf("%s/login/%s", a.mountPath, a.role), nil, data, nil
+}
+
+func (a *ociMethod) NewCreds() chan struct{} {
+	return a.credsFound
+}
+
+func (a *ociMethod) CredSuccess() {}
+
+func (a *ociMethod) Shutdown() {
+	close(a.credsFound)
+	close(a.stopCh)
+}
+
+func (a *ociMethod) pollForCreds(frequencySeconds int) {
+	ticker := time.NewTicker(time.Duration(frequencySeconds) * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-a.stopCh:
+			a.logger.Trace("shutdown triggered, stopping OCI auth handler")
+			return
+		case <-ticker.C:
+			if err := a.checkCreds(); err != nil {
+				a.logger.Warn("unable to retrieve current creds, retaining last creds", "error", err)
+			}
+		}
+	}
+}
+
+func (a *ociMethod) checkCreds() error {
+	a.credLock.Lock()
+	defer a.credLock.Unlock()
+
+	a.logger.Trace("checking for new credentials")
+	currentCreds, err := a.configurationProvider.KeyID()
+	if err != nil {
+		return err
+	}
+	// These will always have different pointers regardless of whether their
+	// values are identical, hence the use of DeepEqual.
+	if currentCreds == a.lastCreds {
+		a.logger.Trace("credentials are unchanged")
+		return nil
+	}
+	a.lastCreds = currentCreds
+	a.logger.Trace("new credentials detected, triggering Authenticate")
+	a.credsFound <- struct{}{}
+	return nil
+}
+
+func getHomeFolder() string {
+	current, e := user.Current()
+	if e != nil {
+		// Give up and try to return something sensible
+		home := os.Getenv("HOME")
+		if home == "" {
+			home = os.Getenv("USERPROFILE")
+		}
+		return home
+	}
+	return current.HomeDir
+}
+
+func getDefaultConfigFilePath() string {
+	homeFolder := getHomeFolder()
+	defaultConfigFile := path.Join(homeFolder, defaultConfigDirName, defaultConfigFileName)
+	if _, err := os.Stat(defaultConfigFile); err == nil {
+		return defaultConfigFile
+	}
+
+	// Read configuration file path from OCI_CONFIG_FILE env var
+	fallbackConfigFile, existed := os.LookupEnv(configFilePathEnvVarName)
+	if !existed {
+		return defaultConfigFile
+	}
+	if _, err := os.Stat(fallbackConfigFile); os.IsNotExist(err) {
+		return defaultConfigFile
+	}
+	return fallbackConfigFile
+}

--- a/command/agent/oci_end_to_end_test.go
+++ b/command/agent/oci_end_to_end_test.go
@@ -1,0 +1,228 @@
+package agent
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	hclog "github.com/hashicorp/go-hclog"
+	vaultoci "github.com/hashicorp/vault-plugin-auth-oci"
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/command/agent/auth"
+	agentoci "github.com/hashicorp/vault/command/agent/auth/oci"
+	"github.com/hashicorp/vault/command/agent/sink"
+	"github.com/hashicorp/vault/command/agent/sink/file"
+	"github.com/hashicorp/vault/helper/testhelpers"
+	vaulthttp "github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/vault"
+)
+
+const (
+	envVarOCITestTenancyOCID    = "OCI_TEST_TENANCY_OCID"
+	envVarOCITestUserOCID       = "OCI_TEST_USER_OCID"
+	envVarOCITestFingerprint    = "OCI_TEST_FINGERPRINT"
+	envVarOCITestPrivateKeyPath = "OCI_TEST_PRIVATE_KEY_PATH"
+	envVAROCITestOCIDList       = "OCI_TEST_OCID_LIST"
+
+	// The OCI SDK doesn't export its standard env vars so they're captured here.
+	// These are used for the duration of the test to make sure the agent is able to
+	// pick up creds from the env.
+	//
+	// To run this test, do not set these. Only the above ones need to be set.
+	envVarOCITenancyOCID    = "OCI_tenancy_ocid"
+	envVarOCIUserOCID       = "OCI_user_ocid"
+	envVarOCIFingerprint    = "OCI_fingerprint"
+	envVarOCIPrivateKeyPath = "OCI_private_key_path"
+)
+
+func TestOCIEndToEnd(t *testing.T) {
+	if !runAcceptanceTests {
+		t.SkipNow()
+	}
+
+	// Ensure each cred is populated.
+	credNames := []string{
+		envVarOCITestTenancyOCID,
+		envVarOCITestUserOCID,
+		envVarOCITestFingerprint,
+		envVarOCITestPrivateKeyPath,
+		envVAROCITestOCIDList,
+	}
+	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
+
+	logger := logging.NewVaultLogger(hclog.Trace)
+	coreConfig := &vault.CoreConfig{
+		Logger: logger,
+		CredentialBackends: map[string]logical.Factory{
+			"oci": vaultoci.Factory,
+		},
+	}
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	vault.TestWaitActive(t, cluster.Cores[0].Core)
+	client := cluster.Cores[0].Client
+
+	// Setup Vault
+	if err := client.Sys().EnableAuthWithOptions("oci", &api.EnableAuthOptions{
+		Type: "oci",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.Logical().Write("auth/oci/config", map[string]interface{}{
+		"home_tenancy_id": os.Getenv(envVarOCITestTenancyOCID),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.Logical().Write("auth/oci/role/test", map[string]interface{}{
+		"ocid_list": os.Getenv(envVAROCITestOCIDList),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
+	// We're going to feed oci auth creds via env variables.
+	if err := setOCIEnvCreds(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := unsetOCIEnvCreds(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	vaultAddr := "http://" + cluster.Cores[0].Listeners[0].Addr().String()
+
+	am, err := agentoci.NewOCIAuthMethod(&auth.AuthConfig{
+		Logger:    logger.Named("auth.oci"),
+		MountPath: "auth/oci",
+		Config: map[string]interface{}{
+			"type": "apikey",
+			"role": "test",
+		},
+	}, vaultAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ahConfig := &auth.AuthHandlerConfig{
+		Logger: logger.Named("auth.handler"),
+		Client: client,
+	}
+
+	ah := auth.NewAuthHandler(ahConfig)
+	errCh := make(chan error)
+	go func() {
+		errCh <- ah.Run(ctx, am)
+	}()
+	defer func() {
+		select {
+		case <-ctx.Done():
+		case err := <-errCh:
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}()
+
+	tmpFile, err := ioutil.TempFile("", "auth.tokensink.test.")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokenSinkFileName := tmpFile.Name()
+	tmpFile.Close()
+	os.Remove(tokenSinkFileName)
+	t.Logf("output: %s", tokenSinkFileName)
+
+	config := &sink.SinkConfig{
+		Logger: logger.Named("sink.file"),
+		Config: map[string]interface{}{
+			"path": tokenSinkFileName,
+		},
+		WrapTTL: 10 * time.Second,
+	}
+
+	fs, err := file.NewFileSink(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Sink = fs
+
+	ss := sink.NewSinkServer(&sink.SinkServerConfig{
+		Logger: logger.Named("sink.server"),
+		Client: client,
+	})
+	go func() {
+		errCh <- ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config})
+	}()
+	defer func() {
+		select {
+		case <-ctx.Done():
+		case err := <-errCh:
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}()
+
+	// This has to be after the other defers so it happens first. It allows
+	// successful test runs to immediately cancel all of the runner goroutines
+	// and unblock any of the blocking defer calls by the runner's DoneCh that
+	// comes before this and avoid successful tests from taking the entire
+	// timeout duration.
+	defer cancel()
+
+	if stat, err := os.Lstat(tokenSinkFileName); err == nil {
+		t.Fatalf("expected err but got %s", stat)
+	} else if !os.IsNotExist(err) {
+		t.Fatal("expected notexist err")
+	}
+
+	// Wait 2 seconds for the env variables to be detected and an auth to be generated.
+	time.Sleep(time.Second * 2)
+
+	token, err := readToken(tokenSinkFileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if token.Token == "" {
+		t.Fatal("expected token but didn't receive it")
+	}
+}
+
+func setOCIEnvCreds() error {
+	if err := os.Setenv(envVarOCITenancyOCID, os.Getenv(envVarOCITestTenancyOCID)); err != nil {
+		return err
+	}
+	if err := os.Setenv(envVarOCIUserOCID, os.Getenv(envVarOCITestUserOCID)); err != nil {
+		return err
+	}
+	if err := os.Setenv(envVarOCIFingerprint, os.Getenv(envVarOCITestFingerprint)); err != nil {
+		return err
+	}
+	return os.Setenv(envVarOCIPrivateKeyPath, os.Getenv(envVarOCITestPrivateKeyPath))
+}
+
+func unsetOCIEnvCreds() error {
+	if err := os.Unsetenv(envVarOCITenancyOCID); err != nil {
+		return err
+	}
+	if err := os.Unsetenv(envVarOCIUserOCID); err != nil {
+		return err
+	}
+	if err := os.Unsetenv(envVarOCIFingerprint); err != nil {
+		return err
+	}
+	return os.Unsetenv(envVarOCIPrivateKeyPath)
+}

--- a/website/content/docs/agent/autoauth/methods/oci.mdx
+++ b/website/content/docs/agent/autoauth/methods/oci.mdx
@@ -40,4 +40,4 @@ but from experience, credentials are rotated every 10 to 15 minutes.
 
 - `role` `(string: required)` - The role to authenticate against on Vault.
 
-- `credential_poll_interval` `(integer: optional)` - In seconds, how frequently the Vault agent should check for new credentials.
+- `credential_poll_interval` `(duration: "60s", optional)` - In seconds, how frequently the Vault agent should check for new credentials.

--- a/website/content/docs/agent/autoauth/methods/oci.mdx
+++ b/website/content/docs/agent/autoauth/methods/oci.mdx
@@ -1,0 +1,43 @@
+---
+layout: docs
+page_title: Vault Agent Auto-Auth OCI (Oracle Cloud Infrastructure) Method
+description: OCI (Oracle Cloud Infrastructure) Method for Vault Agent Auto-Auth
+---
+
+# Vault Agent Auto-Auth OCI (Oracle Cloud Infrastructure) Method
+
+The `oci` method performs authentication against the [OCI Auth
+method](/vault/docs/auth/oci).
+
+## Credentials
+
+The method use to authenticate is set using the `type` parameter. Valid values are `apikey` to authenticate using
+API Key credentials and `instance` for Instance Principal credentials.
+
+If `apikey` is used, the Vault agent will use the first credential it can successfully obtain in the following order:
+
+1. Environment variables:
+  - `OCI_tenancy_ocid`
+  - `OCI_user_ocid`
+  - `OCI_fingerprint`
+  - `OCI_private_key_path`
+2. Configuration file in `$HOME/.oci/config`
+3. Path to configuration file defined in the `OCI_CONFIG_FILE` environment variable
+4. Configuration file in `$HOME/.obmcs/config`
+
+Wherever possible, we recommend using instance principal for credentials. These are rotated automatically by OCI
+and require no effort on your part to provision, making instance principal the most secure of the three methods. If
+using instance principal _and_ a custom `credential_poll_interval`, be sure the frequency is set to a value that is less
+than OCI's rotation frequency. This is currently documented as
+[multiple times a day](https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm#faq),
+but from experience, credentials are rotated every 10 to 15 minutes.
+
+## Configuration
+
+### General
+
+- `type` `(string: required)` - The type of authentication to use. Valid values are `apikey` and `instance`.
+
+- `role` `(string: required)` - The role to authenticate against on Vault.
+
+- `credential_poll_interval` `(integer: optional)` - In seconds, how frequently the Vault agent should check for new credentials.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -929,6 +929,10 @@
                 "path": "agent/autoauth/methods/kubernetes"
               },
               {
+                "title": "Oracle Cloud Infrastructure",
+                "path": "agent/autoauth/methods/oci"
+              },
+              {
                 "title": "Token File",
                 "path": "agent/autoauth/methods/token_file"
               }


### PR DESCRIPTION
This PR adds the OCI (Oracle Cloud Infrastructure) auto-auth method to the Vault Agent.
It supports authentication via API Keys and Instance Principals.

The end to end test must be executed in an OCI compute instances, as the OCI auth backend in Vault currently only supports Instance Principal authentication. See: https://developer.hashicorp.com/vault/docs/auth/oci#configure-the-oci-tenancy-to-run-vault

To run the tests, set the following environment variables:
- `OCI_TEST_TENANCY_OCID`
- `OCI_TEST_USER_OCID`
- `OCI_TEST_FINGERPRINT`
- `OCI_TEST_PRIVATE_KEY_PATH`
- `OCI_TEST_OCID_LIST`

Test results:
```
$ make testacc TEST=./command/agent TESTARGS="-run=TestOCIEndToEnd"
==> Checking that build is using go version >= 1.20...
==> Using go version 1.20.1...
VAULT_ACC=1 go test -tags='' ./command/agent -v -run=TestOCIEndToEnd -timeout=60m
=== RUN   TestOCIEndToEnd
2023-02-20T14:04:41.452+1100 [DEBUG] core: set config: sanitized config="{\"api_addr\":\"\",\"cache_size\":0,\"cluster_addr\":\"\",\"cluster_cipher_suites\":\"\",\"cluster_name\":\"\",\"default_lease_ttl\":0,\"default_max_request_duration\":0,\"detect_deadlocks\":\"\",\"disable_cache\":false,\"disable_clustering\":false,\"disable_indexing\":false,\"disable_mlock\":false,\"disable_performance_standby\":false,\"disable_printable_check\":false,\"disable_sealwrap\":false,\"disable_sentinel_trace\":false,\"enable_response_header_hostname\":false,\"enable_response_header_raft_node_id\":false,\"enable_ui\":false,\"experiments\":null,\"introspection_endpoint\":false,\"log_format\":\"unspecified\",\"log_level\":\"\",\"log_requests_level\":\"\",\"max_lease_ttl\":0,\"pid_file\":\"\",\"plugin_directory\":\"\",\"plugin_file_permissions\":0,\"plugin_file_uid\":0,\"raw_storage_endpoint\":false}"
2023-02-20T14:04:41.452+1100 [DEBUG] storage.cache: creating LRU cache: size=0
2023-02-20T14:04:41.452+1100 [INFO]  core: Initializing version history cache for core
2023-02-20T14:04:41.452+1100 [DEBUG] core: set config: sanitized config="{\"api_addr\":\"\",\"cache_size\":0,\"cluster_addr\":\"\",\"cluster_cipher_suites\":\"\",\"cluster_name\":\"\",\"default_lease_ttl\":0,\"default_max_request_duration\":0,\"detect_deadlocks\":\"\",\"disable_cache\":false,\"disable_clustering\":false,\"disable_indexing\":false,\"disable_mlock\":false,\"disable_performance_standby\":false,\"disable_printable_check\":false,\"disable_sealwrap\":false,\"disable_sentinel_trace\":false,\"enable_response_header_hostname\":false,\"enable_response_header_raft_node_id\":false,\"enable_ui\":false,\"experiments\":null,\"introspection_endpoint\":false,\"log_format\":\"unspecified\",\"log_level\":\"\",\"log_requests_level\":\"\",\"max_lease_ttl\":0,\"pid_file\":\"\",\"plugin_directory\":\"\",\"plugin_file_permissions\":0,\"plugin_file_uid\":0,\"raw_storage_endpoint\":false}"
2023-02-20T14:04:41.452+1100 [DEBUG] storage.cache: creating LRU cache: size=0
2023-02-20T14:04:41.452+1100 [INFO]  core: Initializing version history cache for core
2023-02-20T14:04:41.452+1100 [DEBUG] core: set config: sanitized config="{\"api_addr\":\"\",\"cache_size\":0,\"cluster_addr\":\"\",\"cluster_cipher_suites\":\"\",\"cluster_name\":\"\",\"default_lease_ttl\":0,\"default_max_request_duration\":0,\"detect_deadlocks\":\"\",\"disable_cache\":false,\"disable_clustering\":false,\"disable_indexing\":false,\"disable_mlock\":false,\"disable_performance_standby\":false,\"disable_printable_check\":false,\"disable_sealwrap\":false,\"disable_sentinel_trace\":false,\"enable_response_header_hostname\":false,\"enable_response_header_raft_node_id\":false,\"enable_ui\":false,\"experiments\":null,\"introspection_endpoint\":false,\"log_format\":\"unspecified\",\"log_level\":\"\",\"log_requests_level\":\"\",\"max_lease_ttl\":0,\"pid_file\":\"\",\"plugin_directory\":\"\",\"plugin_file_permissions\":0,\"plugin_file_uid\":0,\"raw_storage_endpoint\":false}"
2023-02-20T14:04:41.452+1100 [DEBUG] storage.cache: creating LRU cache: size=0
2023-02-20T14:04:41.452+1100 [INFO]  core: Initializing version history cache for core
2023-02-20T14:04:41.453+1100 [INFO]  core: assigning cluster listener for test core: core=0 port=0
2023-02-20T14:04:41.453+1100 [INFO]  core: assigning cluster listener for test core: core=1 port=0
2023-02-20T14:04:41.453+1100 [INFO]  core: assigning cluster listener for test core: core=2 port=0
2023-02-20T14:04:41.453+1100 [INFO]  core: security barrier not initialized
2023-02-20T14:04:41.453+1100 [INFO]  core: security barrier initialized: stored=1 shares=3 threshold=3
2023-02-20T14:04:41.453+1100 [DEBUG] core: cluster name set: name=TestOCIEndToEnd
2023-02-20T14:04:41.453+1100 [DEBUG] core: cluster ID not found, generating new
2023-02-20T14:04:41.454+1100 [DEBUG] core: cluster ID set: id=eb403e83-7ccd-598c-a588-5a797f9f487b
2023-02-20T14:04:41.454+1100 [DEBUG] core: generating cluster private key
2023-02-20T14:04:41.459+1100 [DEBUG] core: generating local cluster certificate: host=fw-3ff7960e-5f03-271a-4513-33d0af917583
2023-02-20T14:04:41.461+1100 [INFO]  core: post-unseal setup starting
2023-02-20T14:04:41.461+1100 [DEBUG] core: clearing forwarding clients
2023-02-20T14:04:41.461+1100 [DEBUG] core: done clearing forwarding clients
2023-02-20T14:04:41.461+1100 [DEBUG] core: persisting feature flags
2023-02-20T14:04:41.461+1100 [INFO]  core: loaded wrapping token key
2023-02-20T14:04:41.461+1100 [INFO]  core: successfully setup plugin catalog: plugin-directory=""
2023-02-20T14:04:41.461+1100 [INFO]  core: no mounts; adding default mount table
2023-02-20T14:04:41.462+1100 [TRACE] core: adding write forwarded paths: paths=[]
2023-02-20T14:04:41.462+1100 [INFO]  core: successfully mounted: type=cubbyhole version="v1.14.0+builtin.vault" path=cubbyhole/ namespace="ID: root. Path: "
2023-02-20T14:04:41.462+1100 [TRACE] core: adding write forwarded paths: paths=[]
2023-02-20T14:04:41.462+1100 [INFO]  core: successfully mounted: type=system version="v1.14.0+builtin.vault" path=sys/ namespace="ID: root. Path: "
2023-02-20T14:04:41.462+1100 [TRACE] core: adding write forwarded paths: paths=[]
2023-02-20T14:04:41.462+1100 [INFO]  core: successfully mounted: type=identity version="v1.14.0+builtin.vault" path=identity/ namespace="ID: root. Path: "
2023-02-20T14:04:41.463+1100 [TRACE] token: no token generation counter found in storage
2023-02-20T14:04:41.463+1100 [TRACE] core: adding write forwarded paths: paths=[]
2023-02-20T14:04:41.463+1100 [INFO]  core: successfully mounted: type=token version="v1.14.0+builtin.vault" path=token/ namespace="ID: root. Path: "
2023-02-20T14:04:41.463+1100 [TRACE] expiration.job-manager: created dispatcher: name=expire-dispatcher num_workers=10
2023-02-20T14:04:41.463+1100 [INFO]  rollback: starting rollback manager
2023-02-20T14:04:41.463+1100 [TRACE] expiration.job-manager: initialized dispatcher: num_workers=10
2023-02-20T14:04:41.463+1100 [TRACE] expiration.job-manager: created job manager: name=expire pool_size=10
2023-02-20T14:04:41.463+1100 [TRACE] expiration.job-manager: starting job manager: name=expire
2023-02-20T14:04:41.463+1100 [TRACE] expiration.job-manager: starting dispatcher
2023-02-20T14:04:41.463+1100 [INFO]  core: restoring leases
2023-02-20T14:04:41.463+1100 [DEBUG] expiration: collecting leases
2023-02-20T14:04:41.463+1100 [DEBUG] expiration: leases collected: num_existing=0
2023-02-20T14:04:41.463+1100 [INFO]  expiration: lease restore complete
2023-02-20T14:04:41.463+1100 [DEBUG] identity: loading entities
2023-02-20T14:04:41.463+1100 [DEBUG] identity: entities collected: num_existing=0
2023-02-20T14:04:41.463+1100 [INFO]  identity: entities restored
2023-02-20T14:04:41.463+1100 [DEBUG] identity: identity loading groups
2023-02-20T14:04:41.463+1100 [DEBUG] identity: groups collected: num_existing=0
2023-02-20T14:04:41.463+1100 [INFO]  identity: groups restored
2023-02-20T14:04:41.463+1100 [DEBUG] identity: identity loading OIDC clients
2023-02-20T14:04:41.463+1100 [TRACE] mfa: loading login MFA configurations
2023-02-20T14:04:41.463+1100 [TRACE] mfa: methods collected: num_existing=0
2023-02-20T14:04:41.463+1100 [TRACE] mfa: configurations restored: namespace="" prefix=login-mfa/method/
2023-02-20T14:04:41.463+1100 [TRACE] mfa: loading login MFA enforcement configurations
2023-02-20T14:04:41.463+1100 [TRACE] mfa: enforcements configs collected: num_existing=0
2023-02-20T14:04:41.463+1100 [TRACE] mfa: enforcement configurations restored: namespace="" prefix=login-mfa/enforcement/
2023-02-20T14:04:41.463+1100 [TRACE] activity: scanned existing logs: out=[]
2023-02-20T14:04:41.463+1100 [INFO]  core: Recorded vault version: vault version=1.14.0 upgrade time="2023-02-20 03:04:41.46374866 +0000 UTC" build date=""
2023-02-20T14:04:41.464+1100 [TRACE] activity: no intent log found
2023-02-20T14:04:41.464+1100 [TRACE] activity: scanned existing logs: out=[]
2023-02-20T14:04:41.464+1100 [INFO]  core: usage gauge collection is disabled
2023-02-20T14:04:41.464+1100 [DEBUG] secrets.identity.identity_a321aa69: wrote OIDC default provider
2023-02-20T14:04:41.507+1100 [DEBUG] secrets.identity.identity_a321aa69: generated OIDC public key to sign JWTs: key_id=6e4a015f-25b6-719d-967a-d5bcc8878f6e
2023-02-20T14:04:41.524+1100 [DEBUG] secrets.identity.identity_a321aa69: generated OIDC public key for future use: key_id=2267ed1b-c613-139d-d14a-35e526b74fea
2023-02-20T14:04:41.524+1100 [DEBUG] secrets.identity.identity_a321aa69: wrote OIDC default key
2023-02-20T14:04:41.524+1100 [DEBUG] secrets.identity.identity_a321aa69: wrote OIDC allow_all assignment
2023-02-20T14:04:41.524+1100 [INFO]  core: post-unseal setup complete
2023-02-20T14:04:41.525+1100 [DEBUG] token: no wal state found when generating token
2023-02-20T14:04:41.525+1100 [INFO]  core: root token generated
2023-02-20T14:04:41.525+1100 [INFO]  core: pre-seal teardown starting
2023-02-20T14:04:41.525+1100 [DEBUG] expiration: stop triggered
2023-02-20T14:04:41.525+1100 [TRACE] expiration.job-manager: terminating job manager...
2023-02-20T14:04:41.525+1100 [TRACE] expiration.job-manager: terminating dispatcher
2023-02-20T14:04:41.525+1100 [DEBUG] expiration: finished stopping
2023-02-20T14:04:41.525+1100 [INFO]  rollback: stopping rollback manager
2023-02-20T14:04:41.525+1100 [INFO]  core: pre-seal teardown complete
2023-02-20T14:04:41.525+1100 [DEBUG] core: unseal key supplied: migrate=false
2023-02-20T14:04:41.525+1100 [DEBUG] core: cannot unseal, not enough keys: keys=1 threshold=3 nonce=6d4d86d6-bcb9-cbbf-e366-aaf66662b018
2023-02-20T14:04:41.525+1100 [DEBUG] core: unseal key supplied: migrate=false
2023-02-20T14:04:41.525+1100 [DEBUG] core: cannot unseal, not enough keys: keys=2 threshold=3 nonce=6d4d86d6-bcb9-cbbf-e366-aaf66662b018
2023-02-20T14:04:41.525+1100 [DEBUG] core: unseal key supplied: migrate=false
2023-02-20T14:04:41.525+1100 [DEBUG] core: starting cluster listeners
2023-02-20T14:04:41.525+1100 [INFO]  core.cluster-listener.tcp: starting listener: listener_address=127.0.0.1:0
2023-02-20T14:04:41.525+1100 [INFO]  core.cluster-listener: serving cluster requests: cluster_listen_address=127.0.0.1:40031
2023-02-20T14:04:41.525+1100 [INFO]  core: vault is unsealed
2023-02-20T14:04:41.525+1100 [INFO]  core: entering standby mode
2023-02-20T14:04:41.525+1100 [INFO]  core: acquired lock, enabling active operation
2023-02-20T14:04:41.525+1100 [DEBUG] core: generating cluster private key
2023-02-20T14:04:41.526+1100 [DEBUG] core: generating local cluster certificate: host=fw-dd8b793d-ebb6-b75c-3aa3-b377ece64937
2023-02-20T14:04:41.528+1100 [INFO]  core: post-unseal setup starting
2023-02-20T14:04:41.528+1100 [DEBUG] core: clearing forwarding clients
2023-02-20T14:04:41.528+1100 [DEBUG] core: done clearing forwarding clients
2023-02-20T14:04:41.528+1100 [DEBUG] core: persisting feature flags
2023-02-20T14:04:41.528+1100 [INFO]  core: loaded wrapping token key
2023-02-20T14:04:41.528+1100 [INFO]  core: successfully setup plugin catalog: plugin-directory=""
2023-02-20T14:04:41.528+1100 [TRACE] core: adding write forwarded paths: paths=[]
2023-02-20T14:04:41.528+1100 [INFO]  core: successfully mounted: type=system version="v1.14.0+builtin.vault" path=sys/ namespace="ID: root. Path: "
2023-02-20T14:04:41.528+1100 [TRACE] core: adding write forwarded paths: paths=[]
2023-02-20T14:04:41.528+1100 [INFO]  core: successfully mounted: type=identity version="v1.14.0+builtin.vault" path=identity/ namespace="ID: root. Path: "
2023-02-20T14:04:41.528+1100 [TRACE] core: adding write forwarded paths: paths=[]
2023-02-20T14:04:41.528+1100 [INFO]  core: successfully mounted: type=cubbyhole version="v1.14.0+builtin.vault" path=cubbyhole/ namespace="ID: root. Path: "
2023-02-20T14:04:41.529+1100 [TRACE] token: no token generation counter found in storage
2023-02-20T14:04:41.529+1100 [TRACE] core: adding write forwarded paths: paths=[]
2023-02-20T14:04:41.529+1100 [INFO]  core: successfully mounted: type=token version="v1.14.0+builtin.vault" path=token/ namespace="ID: root. Path: "
2023-02-20T14:04:41.529+1100 [TRACE] expiration.job-manager: created dispatcher: name=expire-dispatcher num_workers=10
2023-02-20T14:04:41.529+1100 [TRACE] expiration.job-manager: initialized dispatcher: num_workers=10
2023-02-20T14:04:41.529+1100 [TRACE] expiration.job-manager: created job manager: name=expire pool_size=10
2023-02-20T14:04:41.529+1100 [TRACE] expiration.job-manager: starting job manager: name=expire
2023-02-20T14:04:41.529+1100 [TRACE] expiration.job-manager: starting dispatcher
2023-02-20T14:04:41.529+1100 [INFO]  core: restoring leases
2023-02-20T14:04:41.529+1100 [DEBUG] identity: loading entities
2023-02-20T14:04:41.529+1100 [DEBUG] expiration: collecting leases
2023-02-20T14:04:41.529+1100 [DEBUG] expiration: leases collected: num_existing=0
2023-02-20T14:04:41.529+1100 [DEBUG] identity: entities collected: num_existing=0
2023-02-20T14:04:41.529+1100 [INFO]  rollback: starting rollback manager
2023-02-20T14:04:41.529+1100 [INFO]  identity: entities restored
2023-02-20T14:04:41.529+1100 [DEBUG] identity: identity loading groups
2023-02-20T14:04:41.529+1100 [INFO]  expiration: lease restore complete
2023-02-20T14:04:41.529+1100 [DEBUG] identity: groups collected: num_existing=0
2023-02-20T14:04:41.529+1100 [INFO]  identity: groups restored
2023-02-20T14:04:41.529+1100 [DEBUG] identity: identity loading OIDC clients
2023-02-20T14:04:41.529+1100 [TRACE] mfa: loading login MFA configurations
2023-02-20T14:04:41.529+1100 [TRACE] mfa: methods collected: num_existing=0
2023-02-20T14:04:41.529+1100 [TRACE] mfa: configurations restored: namespace="" prefix=login-mfa/method/
2023-02-20T14:04:41.529+1100 [TRACE] mfa: loading login MFA enforcement configurations
2023-02-20T14:04:41.529+1100 [TRACE] mfa: enforcements configs collected: num_existing=0
2023-02-20T14:04:41.529+1100 [TRACE] mfa: enforcement configurations restored: namespace="" prefix=login-mfa/enforcement/
2023-02-20T14:04:41.529+1100 [TRACE] activity: scanned existing logs: out=[]
2023-02-20T14:04:41.529+1100 [DEBUG] core: request forwarding setup function
2023-02-20T14:04:41.529+1100 [DEBUG] core: clearing forwarding clients
2023-02-20T14:04:41.529+1100 [DEBUG] core: done clearing forwarding clients
2023-02-20T14:04:41.529+1100 [DEBUG] core: leaving request forwarding setup function
2023-02-20T14:04:41.529+1100 [TRACE] activity: scanned existing logs: out=[]
2023-02-20T14:04:41.529+1100 [TRACE] activity: no intent log found
2023-02-20T14:04:41.529+1100 [INFO]  core: usage gauge collection is disabled
2023-02-20T14:04:41.529+1100 [INFO]  core: post-unseal setup complete
2023-02-20T14:04:41.530+1100 [TRACE] core: adding write forwarded paths: paths=[]
2023-02-20T14:04:41.530+1100 [INFO]  core: successful mount: namespace="" path=secret/ type=kv version=""
2023-02-20T14:04:41.530+1100 [DEBUG] core: unseal key supplied: migrate=false
2023-02-20T14:04:41.530+1100 [DEBUG] core: cannot unseal, not enough keys: keys=1 threshold=3 nonce=869106d2-3758-a34b-b7b2-b3ec3a1ecfe1
2023-02-20T14:04:41.530+1100 [DEBUG] core: unseal key supplied: migrate=false
2023-02-20T14:04:41.530+1100 [DEBUG] core: cannot unseal, not enough keys: keys=2 threshold=3 nonce=869106d2-3758-a34b-b7b2-b3ec3a1ecfe1
2023-02-20T14:04:41.530+1100 [DEBUG] core: unseal key supplied: migrate=false
2023-02-20T14:04:41.530+1100 [DEBUG] core: starting cluster listeners
2023-02-20T14:04:41.530+1100 [INFO]  core.cluster-listener.tcp: starting listener: listener_address=127.0.0.1:0
2023-02-20T14:04:41.530+1100 [INFO]  core.cluster-listener: serving cluster requests: cluster_listen_address=127.0.0.1:39401
2023-02-20T14:04:41.530+1100 [INFO]  core: vault is unsealed
2023-02-20T14:04:41.530+1100 [DEBUG] core: unseal key supplied: migrate=false
2023-02-20T14:04:41.530+1100 [DEBUG] core: cannot unseal, not enough keys: keys=1 threshold=3 nonce=070582d9-1956-239e-892d-5f356492ffab
2023-02-20T14:04:41.530+1100 [DEBUG] core: unseal key supplied: migrate=false
2023-02-20T14:04:41.530+1100 [DEBUG] core: cannot unseal, not enough keys: keys=2 threshold=3 nonce=070582d9-1956-239e-892d-5f356492ffab
2023-02-20T14:04:41.530+1100 [DEBUG] core: unseal key supplied: migrate=false
2023-02-20T14:04:41.530+1100 [DEBUG] core: starting cluster listeners
2023-02-20T14:04:41.530+1100 [INFO]  core.cluster-listener.tcp: starting listener: listener_address=127.0.0.1:0
2023-02-20T14:04:41.530+1100 [INFO]  core.cluster-listener: serving cluster requests: cluster_listen_address=127.0.0.1:41853
2023-02-20T14:04:41.530+1100 [INFO]  core: vault is unsealed
2023-02-20T14:04:41.530+1100 [INFO]  core: entering standby mode
2023-02-20T14:04:41.530+1100 [INFO]  core: entering standby mode
2023-02-20T14:04:43.531+1100 [TRACE] core: found new active node information, refreshing
2023-02-20T14:04:43.531+1100 [DEBUG] core: parsing information for new active node: active_cluster_addr=https://127.0.0.1:40031 active_redirect_addr=https://127.0.0.1:41207
2023-02-20T14:04:43.531+1100 [DEBUG] core: refreshing forwarding connection: clusterAddr=https://127.0.0.1:40031
2023-02-20T14:04:43.531+1100 [DEBUG] core: clearing forwarding clients
2023-02-20T14:04:43.531+1100 [DEBUG] core: done clearing forwarding clients
2023-02-20T14:04:43.532+1100 [DEBUG] core: done refreshing forwarding connection: clusterAddr=https://127.0.0.1:40031
2023-02-20T14:04:43.532+1100 [TRACE] core: found new active node information, refreshing
2023-02-20T14:04:43.532+1100 [DEBUG] core: parsing information for new active node: active_cluster_addr=https://127.0.0.1:40031 active_redirect_addr=https://127.0.0.1:41207
2023-02-20T14:04:43.532+1100 [DEBUG] core: refreshing forwarding connection: clusterAddr=https://127.0.0.1:40031
2023-02-20T14:04:43.532+1100 [DEBUG] core: clearing forwarding clients
2023-02-20T14:04:43.532+1100 [DEBUG] core: done clearing forwarding clients
2023-02-20T14:04:43.532+1100 [DEBUG] core.cluster-listener: creating rpc dialer: address=127.0.0.1:40031 alpn=req_fw_sb-act_v1 host=fw-dd8b793d-ebb6-b75c-3aa3-b377ece64937
2023-02-20T14:04:43.532+1100 [DEBUG] core: done refreshing forwarding connection: clusterAddr=https://127.0.0.1:40031
2023-02-20T14:04:43.533+1100 [DEBUG] core.cluster-listener: creating rpc dialer: address=127.0.0.1:40031 alpn=req_fw_sb-act_v1 host=fw-dd8b793d-ebb6-b75c-3aa3-b377ece64937
2023-02-20T14:04:43.534+1100 [DEBUG] core.cluster-listener: performing server cert lookup
2023-02-20T14:04:43.535+1100 [INFO]  core: enabled audit backend: path=noop/ type=noop
2023-02-20T14:04:43.537+1100 [INFO]  starting listener for test core: core=0 port=41207
2023-02-20T14:04:43.537+1100 [INFO]  starting listener for test core: core=1 port=45113
2023-02-20T14:04:43.537+1100 [INFO]  starting listener for test core: core=2 port=35051
2023-02-20T14:04:43.540+1100 [TRACE] core: adding write forwarded paths: paths=[]
2023-02-20T14:04:43.540+1100 [INFO]  core: enabled credential backend: path=oci/ type=oci version=""
2023-02-20T14:04:43.541+1100 [DEBUG] core.cluster-listener: performing client cert lookup
    oci_end_to_end_test.go:145: output: /tmp/auth.tokensink.test.50647656
2023-02-20T14:04:43.541+1100 [INFO]  sink.file: creating file sink
2023-02-20T14:04:43.541+1100 [TRACE] sink.file: enter write_token: path=/tmp/auth.tokensink.test.50647656
2023-02-20T14:04:43.541+1100 [TRACE] sink.file: exit write_token: path=/tmp/auth.tokensink.test.50647656
2023-02-20T14:04:43.542+1100 [INFO]  sink.file: file sink configured: path=/tmp/auth.tokensink.test.50647656 mode=-rw-r-----
2023-02-20T14:04:43.542+1100 [INFO]  sink.server: starting sink server
2023-02-20T14:04:43.542+1100 [INFO]  auth.handler: starting auth handler
2023-02-20T14:04:43.542+1100 [INFO]  auth.handler: authenticating
2023-02-20T14:04:43.542+1100 [TRACE] auth.oci: beginning authentication
2023-02-20T14:04:43.543+1100 [TRACE] auth.oci.auth_oci_05dd1969: 6c9c4319-6c2c-a6cb-5b56-142d111f857a: pathLoginUpdate roleName=test
2023-02-20T14:04:43.543+1100 [TRACE] auth.oci.auth_oci_05dd1969: 6c9c4319-6c2c-a6cb-5b56-142d111f857a: Method:=get targetUrl:=/v1/auth/oci/login/test
2023-02-20T14:04:43.543+1100 [DEBUG] core.request-forward: got request forwarding connection
2023-02-20T14:04:43.544+1100 [DEBUG] core.cluster-listener: performing server cert lookup
2023-02-20T14:04:43.546+1100 [DEBUG] core.cluster-listener: performing client cert lookup
2023-02-20T14:04:43.548+1100 [DEBUG] core.request-forward: got request forwarding connection
2023-02-20T14:04:44.281+1100 [TRACE] auth.oci.auth_oci_05dd1969: Authentication ok: Method:=get targetUrl:=/v1/auth/oci/login/test id=6c9c4319-6c2c-a6cb-5b56-142d111f857a
2023-02-20T14:04:44.397+1100 [TRACE] auth.oci.auth_oci_05dd1969: Login ok: Method:=get targetUrl:=/v1/auth/oci/login/test id=6c9c4319-6c2c-a6cb-5b56-142d111f857a
2023-02-20T14:04:44.397+1100 [DEBUG] identity: creating a new entity: alias="id:\"277fbcd5-173f-c695-7961-50729c517fd9\"  canonical_id:\"b319604d-6152-b402-7a18-b06b669142fd\"  mount_type:\"oci\"  mount_accessor:\"auth_oci_05dd1969\"  mount_path:\"auth/oci/\"  name:\"test\"  creation_time:{seconds:1676862284  nanos:397559776}  last_update_time:{seconds:1676862284  nanos:397559776}  namespace_id:\"root\"  local_bucket_key:\"packer/local-aliases/buckets/217\""
2023-02-20T14:04:44.400+1100 [INFO]  auth.handler: authentication successful, sending token to sinks
2023-02-20T14:04:44.401+1100 [INFO]  auth.handler: starting renewal process
2023-02-20T14:04:44.402+1100 [TRACE] sink.file: enter write_token: path=/tmp/auth.tokensink.test.50647656
2023-02-20T14:04:44.402+1100 [INFO]  sink.file: token written: path=/tmp/auth.tokensink.test.50647656
2023-02-20T14:04:44.402+1100 [TRACE] sink.file: exit write_token: path=/tmp/auth.tokensink.test.50647656
2023-02-20T14:04:45.542+1100 [INFO]  cleaning up vault cluster
2023-02-20T14:04:45.542+1100 [INFO]  sink.server: sink server stopped
2023-02-20T14:04:45.542+1100 [INFO]  core: stopping vault test core
2023-02-20T14:04:45.542+1100 [INFO]  core: stopping vault test core
2023-02-20T14:04:45.542+1100 [INFO]  core: listeners successfully shut down
2023-02-20T14:04:45.542+1100 [DEBUG] core: shutdown called
2023-02-20T14:04:45.542+1100 [INFO]  core: listeners successfully shut down
2023-02-20T14:04:45.542+1100 [DEBUG] core: shutdown called
2023-02-20T14:04:45.542+1100 [INFO]  core: stopping vault test core
2023-02-20T14:04:45.542+1100 [INFO]  core: marked as sealed
2023-02-20T14:04:45.543+1100 [DEBUG] core: clearing forwarding clients
2023-02-20T14:04:45.543+1100 [INFO]  core: listeners successfully shut down
2023-02-20T14:04:45.543+1100 [DEBUG] core: shutdown called
2023-02-20T14:04:45.543+1100 [INFO]  core: marked as sealed
2023-02-20T14:04:45.543+1100 [DEBUG] core: clearing forwarding clients
2023-02-20T14:04:45.542+1100 [INFO]  auth.handler: shutdown triggered, stopping lifetime watcher
2023-02-20T14:04:45.543+1100 [INFO]  auth.handler: auth handler stopped
2023-02-20T14:04:45.543+1100 [DEBUG] core: forwarding: stopping heartbeating
2023-02-20T14:04:45.543+1100 [DEBUG] core: done clearing forwarding clients
2023-02-20T14:04:45.543+1100 [TRACE] auth.oci: shutdown triggered, stopping OCI auth handler
2023-02-20T14:04:45.542+1100 [INFO]  core: marked as sealed
2023-02-20T14:04:45.543+1100 [DEBUG] core: clearing forwarding clients
2023-02-20T14:04:45.543+1100 [DEBUG] core: done clearing forwarding clients
2023-02-20T14:04:45.543+1100 [DEBUG] core: finished triggering standbyStopCh for runStandby
2023-02-20T14:04:45.543+1100 [DEBUG] core: shutting down periodic key rotation checker
2023-02-20T14:04:45.543+1100 [DEBUG] core: shutting down periodic leader refresh
2023-02-20T14:04:45.543+1100 [DEBUG] core: shutting down periodic metrics
2023-02-20T14:04:45.543+1100 [DEBUG] core: shutting down leader elections
2023-02-20T14:04:45.543+1100 [INFO]  core: pre-seal teardown starting
2023-02-20T14:04:45.543+1100 [DEBUG] core: finished triggering standbyStopCh for runStandby
2023-02-20T14:04:45.543+1100 [DEBUG] core: shutting down periodic key rotation checker
2023-02-20T14:04:45.543+1100 [DEBUG] core: shutting down periodic leader refresh
2023-02-20T14:04:45.543+1100 [DEBUG] core: shutting down periodic metrics
2023-02-20T14:04:45.543+1100 [DEBUG] core: shutting down leader elections
2023-02-20T14:04:45.543+1100 [DEBUG] core: done clearing forwarding clients
2023-02-20T14:04:45.543+1100 [DEBUG] core: finished triggering standbyStopCh for runStandby
2023-02-20T14:04:45.543+1100 [DEBUG] core: shutting down periodic key rotation checker
2023-02-20T14:04:45.543+1100 [DEBUG] core: shutting down periodic leader refresh
2023-02-20T14:04:45.543+1100 [DEBUG] core: shutting down periodic metrics
2023-02-20T14:04:45.543+1100 [DEBUG] core: shutting down leader elections
2023-02-20T14:04:45.543+1100 [DEBUG] core: runStandby done
2023-02-20T14:04:45.543+1100 [INFO]  core: stopping cluster listeners
2023-02-20T14:04:45.543+1100 [DEBUG] core: forwarding: stopping heartbeating
2023-02-20T14:04:45.543+1100 [INFO]  core.cluster-listener: forwarding rpc listeners stopped
2023-02-20T14:04:45.543+1100 [DEBUG] core: runStandby done
2023-02-20T14:04:45.543+1100 [INFO]  core: stopping cluster listeners
2023-02-20T14:04:45.543+1100 [INFO]  core.cluster-listener: forwarding rpc listeners stopped
2023-02-20T14:04:46.036+1100 [INFO]  core.cluster-listener: rpc listeners successfully shut down
2023-02-20T14:04:46.036+1100 [INFO]  core.cluster-listener: rpc listeners successfully shut down
2023-02-20T14:04:46.036+1100 [INFO]  core: cluster listeners successfully shut down
2023-02-20T14:04:46.036+1100 [INFO]  core: cluster listeners successfully shut down
2023-02-20T14:04:46.036+1100 [DEBUG] core: sealing barrier
2023-02-20T14:04:46.036+1100 [DEBUG] core: sealing barrier
2023-02-20T14:04:46.036+1100 [INFO]  core: vault is sealed
2023-02-20T14:04:46.036+1100 [INFO]  core: vault test core stopped
2023-02-20T14:04:46.036+1100 [INFO]  core: vault is sealed
2023-02-20T14:04:46.036+1100 [INFO]  core: vault test core stopped
2023-02-20T14:04:46.044+1100 [DEBUG] expiration: stop triggered
2023-02-20T14:04:46.044+1100 [TRACE] expiration.job-manager: terminating job manager...
2023-02-20T14:04:46.044+1100 [TRACE] expiration.job-manager: terminating dispatcher
2023-02-20T14:04:46.044+1100 [DEBUG] expiration: finished stopping
2023-02-20T14:04:46.044+1100 [INFO]  rollback: stopping rollback manager
2023-02-20T14:04:46.044+1100 [INFO]  core: pre-seal teardown complete
2023-02-20T14:04:46.044+1100 [DEBUG] core: runStandby done
2023-02-20T14:04:46.044+1100 [INFO]  core: stopping cluster listeners
2023-02-20T14:04:46.044+1100 [INFO]  core.cluster-listener: forwarding rpc listeners stopped
2023-02-20T14:04:46.053+1100 [INFO]  core.cluster-listener: rpc listeners successfully shut down
2023-02-20T14:04:46.053+1100 [INFO]  core: cluster listeners successfully shut down
2023-02-20T14:04:46.053+1100 [DEBUG] core: sealing barrier
2023-02-20T14:04:46.053+1100 [INFO]  core: vault is sealed
2023-02-20T14:04:46.053+1100 [INFO]  core: vault test core stopped
--- PASS: TestOCIEndToEnd (5.60s)
PASS
ok      github.com/hashicorp/vault/command/agent
```

Closes #19195 