### PR TITLE
pki health-check fails to read in int config values

### DIFF
--- a/changelog/19265.txt
+++ b/changelog/19265.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli/pki: Decode integer values properly in health-check configuration file
+```

--- a/command/pki_health_check.go
+++ b/command/pki_health_check.go
@@ -243,13 +243,16 @@ func (c *PKIHealthCheckCommand) Run(args []string) int {
 	// Handle config merging.
 	external_config := map[string]interface{}{}
 	if c.flagConfig != "" {
-		contents, err := os.ReadFile(c.flagConfig)
+		contents, err := os.Open(c.flagConfig)
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Failed to read configuration file %v: %v", c.flagConfig, err))
 			return pkiRetUsage
 		}
 
-		if err := json.Unmarshal(contents, &external_config); err != nil {
+		decoder := json.NewDecoder(contents)
+		decoder.UseNumber() // Use json.Number instead of float64 values as we are decoding to an interface{}.
+
+		if err := decoder.Decode(&external_config); err != nil {
 			c.UI.Error(fmt.Sprintf("Failed to parse configuration file %v: %v", c.flagConfig, err))
 			return pkiRetUsage
 		}


### PR DESCRIPTION
### Issue Description

While testing the vault pki health-check feature, providing it a configuration file with integer value of say 100 for  `root_issued_leaves.root_issued_leaves` led to the following error. 

```
Failed to build health check configuration: error saving merged config for root_issued_leaves: error parsing root_issued_leaves.certs_to_fetch: could not parse value from input
```

### Fix 

 - Go's default behavior when decoding numbers to an interface{} is to use a float64 type which `parseutil.SafeParseIntRange` does not handle. Switch to having the JSON decoder use `json.Number` which `parseutil` methods properly handle.
 - Tested configuration values as strings, integers work
 - Also tested we get proper error messages for out of bounds integers and float values