### PR TITLE
Output default config output from pki health-check --list as json

### DIFF
--- a/changelog/19269.txt
+++ b/changelog/19269.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli/pki: Change the pki health-check --list default config output to JSON so it's a usable configuration file
+```

--- a/command/pki_health_check.go
+++ b/command/pki_health_check.go
@@ -223,20 +223,19 @@ func (c *PKIHealthCheckCommand) Run(args []string) int {
 
 	// Handle listing, if necessary.
 	if c.flagList {
-		c.UI.Output("Health Checks:")
+		c.UI.Output("Default health check config:")
+		config := map[string]map[string]interface{}{}
 		for _, checker := range executor.Checkers {
-			c.UI.Output(" - " + checker.Name())
-
-			prefix := "   "
-			cfg := checker.DefaultConfig()
-			marshaled, err := json.MarshalIndent(cfg, prefix, " ")
-			if err != nil {
-				c.UI.Error(fmt.Sprintf("Failed to marshal default config for check: %v", err))
-				return pkiRetUsage
-			}
-			c.UI.Output(prefix + string(marshaled))
+			config[checker.Name()] = checker.DefaultConfig()
 		}
 
+		marshaled, err := json.MarshalIndent(config, "", "  ")
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Failed to marshal default config for check: %v", err))
+			return pkiRetUsage
+		}
+
+		c.UI.Output(string(marshaled))
 		return pkiRetOK
 	}
 


### PR DESCRIPTION
 - Change the output of the default configuration as JSON so it's usable as an input to the health-check command
 - Prior to this change only each checker's configuration was output in JSON leading to an end-user needing to manually craft the JSON configuration