### PR TITLE
Fix role endpoint in pki health-check warnings

### DIFF
--- a/changelog/19274.txt
+++ b/changelog/19274.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli/pki: Fix path for role health-check warning messages
+```

--- a/command/healthcheck/pki_role_allows_glob_wildcards.go
+++ b/command/healthcheck/pki_role_allows_glob_wildcards.go
@@ -141,7 +141,7 @@ func (h *RoleAllowsGlobWildcards) Evaluate(e *Executor) (results []*Result, err 
 
 		ret := Result{
 			Status:   ResultWarning,
-			Endpoint: "/{{mount}}/role/" + role,
+			Endpoint: "/{{mount}}/roles/" + role,
 			Message:  fmt.Sprintf("Role currently allows wildcard issuance while allowing globs in allowed_domains (%v). Because globs can expand to one or more wildcard character, including wildcards under additional subdomains, these options are dangerous to enable together. If glob domains are required to be enabled, it is suggested to either disable wildcard issuance if not desired, or create two separate roles -- one with wildcard issuance for specified domains and one with glob matching enabled for concrete domain identifiers.", allowedDomains),
 		}
 

--- a/command/healthcheck/pki_role_allows_localhost.go
+++ b/command/healthcheck/pki_role_allows_localhost.go
@@ -115,7 +115,7 @@ func (h *RoleAllowsLocalhost) Evaluate(e *Executor) (results []*Result, err erro
 
 		ret := Result{
 			Status:   ResultWarning,
-			Endpoint: "/{{mount}}/role/" + role,
+			Endpoint: "/{{mount}}/roles/" + role,
 			Message:  fmt.Sprintf("Role currently allows localhost issuance with a non-empty allowed_domains (%v): this role is intended for issuing other hostnames and the allow_localhost=true option may be overlooked by operators. If this role is intended to issue certificates valid for localhost, consider setting allow_localhost=false and explicitly adding localhost to the list of allowed domains.", allowedDomains),
 		}
 

--- a/command/healthcheck/pki_role_no_store_false.go
+++ b/command/healthcheck/pki_role_no_store_false.go
@@ -159,7 +159,7 @@ func (h *RoleNoStoreFalse) Evaluate(e *Executor) (results []*Result, err error) 
 
 		ret := Result{
 			Status:   ResultWarning,
-			Endpoint: "/{{mount}}/role/" + role,
+			Endpoint: "/{{mount}}/roles/" + role,
 			Message:  "Role currently stores every issued certificate (no_store=false). Too many issued and/or revoked certificates can exceed Vault's storage limits and make operations slow. It is encouraged to enable auto-rebuild of CRLs to prevent every revocation from creating a new CRL, and to limit the number of certificates issued under roles with no_store=false: use shorter lifetimes and/or BYOC revocation instead.",
 		}
 


### PR DESCRIPTION
 - The various warning messages point to `{{mount}}/role/<rolename>` which is not a valid PKI path, it should be `{{mount}}/roles/<rolename>`