### PR TITLE
Handle permission issue on pki health-check tune checkers

### DIFF
--- a/changelog/19276.txt
+++ b/changelog/19276.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli/pki: Properly report permission issues within health-check mount tune checks
+```

--- a/command/healthcheck/pki_allow_if_modified_since.go
+++ b/command/healthcheck/pki_allow_if_modified_since.go
@@ -11,7 +11,7 @@ type AllowIfModifiedSince struct {
 	Enabled            bool
 	UnsupportedVersion bool
 
-	TuneData map[string]interface{}
+	TuneData *PathFetch
 }
 
 func NewAllowIfModifiedSinceCheck() Check {
@@ -42,15 +42,14 @@ func (h *AllowIfModifiedSince) LoadConfig(config map[string]interface{}) error {
 }
 
 func (h *AllowIfModifiedSince) FetchResources(e *Executor) error {
-	exit, _, data, err := fetchMountTune(e, func() {
+	pathFetch, err := fetchMountTune(e, func() {
 		h.UnsupportedVersion = true
 	})
-	if exit {
+	if err != nil {
 		return err
 	}
 
-	h.TuneData = data
-
+	h.TuneData = pathFetch
 	return nil
 }
 
@@ -59,22 +58,44 @@ func (h *AllowIfModifiedSince) Evaluate(e *Executor) (results []*Result, err err
 		ret := Result{
 			Status:   ResultInvalidVersion,
 			Endpoint: "/sys/mounts/{{mount}}/tune",
-			Message:  "This health check requires Vault 1.9+ but an earlier version of Vault Server was contacted, preventing this health check from running.",
+			Message:  "This health check requires Vault 1.12+ but an earlier version of Vault Server was contacted, preventing this health check from running.",
 		}
 		return []*Result{&ret}, nil
 	}
 
-	req, err := StringList(h.TuneData["passthrough_request_headers"])
+	if h.TuneData.IsSecretPermissionsError() {
+		ret := Result{
+			Status:   ResultInsufficientPermissions,
+			Endpoint: "/sys/mounts/{{mount}}/tune",
+			Message:  "Without this information, this health check is unable to function.",
+		}
+
+		if e.Client.Token() == "" {
+			ret.Message = "No token available so unable read the tune endpoint for this mount. " + ret.Message
+		} else {
+			ret.Message = "This token lacks permission to read the tune endpoint for this mount. " + ret.Message
+		}
+
+		results = append(results, &ret)
+		return
+	}
+
+	var tuneData map[string]interface{} = nil
+	if len(h.TuneData.Secret.Data) > 0 {
+		tuneData = h.TuneData.Secret.Data
+	}
+
+	req, err := StringList(tuneData["passthrough_request_headers"])
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse value from server for passthrough_request_headers: %w", err)
 	}
 
-	resp, err := StringList(h.TuneData["allowed_response_headers"])
+	resp, err := StringList(tuneData["allowed_response_headers"])
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse value from server for allowed_response_headers: %w", err)
 	}
 
-	var foundIMS bool = false
+	foundIMS := false
 	for _, param := range req {
 		if strings.EqualFold(param, "If-Modified-Since") {
 			foundIMS = true
@@ -82,7 +103,7 @@ func (h *AllowIfModifiedSince) Evaluate(e *Executor) (results []*Result, err err
 		}
 	}
 
-	var foundLM bool = false
+	foundLM := false
 	for _, param := range resp {
 		if strings.EqualFold(param, "Last-Modified") {
 			foundLM = true

--- a/command/healthcheck/pki_audit_visibility.go
+++ b/command/healthcheck/pki_audit_visibility.go
@@ -57,7 +57,7 @@ type AuditVisibility struct {
 	UnsupportedVersion bool
 
 	IgnoredParameters map[string]bool
-	TuneData          map[string]interface{}
+	TuneData          *PathFetch
 }
 
 func NewAuditVisibilityCheck() Check {
@@ -100,27 +100,47 @@ func (h *AuditVisibility) LoadConfig(config map[string]interface{}) error {
 }
 
 func (h *AuditVisibility) FetchResources(e *Executor) error {
-	exit, _, data, err := fetchMountTune(e, func() {
+	pathFetch, err := fetchMountTune(e, func() {
 		h.UnsupportedVersion = true
 	})
-	if exit {
+	if err != nil {
 		return err
 	}
 
-	h.TuneData = data
-
+	h.TuneData = pathFetch
 	return nil
 }
 
 func (h *AuditVisibility) Evaluate(e *Executor) (results []*Result, err error) {
 	if h.UnsupportedVersion {
-		// Shouldn't happen; /certs has been around forever.
 		ret := Result{
 			Status:   ResultInvalidVersion,
-			Endpoint: "/{{mount}}/certs",
-			Message:  "This health check requires Vault 1.11+ but an earlier version of Vault Server was contacted, preventing this health check from running.",
+			Endpoint: "/sys/mounts/{{mount}}/tune",
+			Message:  "This health check requires Vault 1.9+ but an earlier version of Vault Server was contacted, preventing this health check from running.",
 		}
 		return []*Result{&ret}, nil
+	}
+
+	if h.TuneData.IsSecretPermissionsError() {
+		ret := Result{
+			Status:   ResultInsufficientPermissions,
+			Endpoint: "/sys/mounts/{{mount}}/tune",
+			Message:  "Without this information, this health check is unable to function.",
+		}
+
+		if e.Client.Token() == "" {
+			ret.Message = "No token available so unable read the tune endpoint for this mount. " + ret.Message
+		} else {
+			ret.Message = "This token lacks permission to read the tune endpoint for this mount. " + ret.Message
+		}
+
+		results = append(results, &ret)
+		return
+	}
+
+	var tuneData map[string]interface{} = nil
+	if len(h.TuneData.Secret.Data) > 0 {
+		tuneData = h.TuneData.Secret.Data
 	}
 
 	sourceMap := map[string][]string{
@@ -128,7 +148,7 @@ func (h *AuditVisibility) Evaluate(e *Executor) (results []*Result, err error) {
 		"audit_non_hmac_response_keys": VisibleRespParams,
 	}
 	for source, visibleList := range sourceMap {
-		actual, err := StringList(h.TuneData[source])
+		actual, err := StringList(tuneData[source])
 		if err != nil {
 			return nil, fmt.Errorf("error parsing %v from server: %v", source, err)
 		}
@@ -158,7 +178,7 @@ func (h *AuditVisibility) Evaluate(e *Executor) (results []*Result, err error) {
 		"audit_non_hmac_response_keys": HiddenRespParams,
 	}
 	for source, hiddenList := range sourceMap {
-		actual, err := StringList(h.TuneData[source])
+		actual, err := StringList(tuneData[source])
 		if err != nil {
 			return nil, fmt.Errorf("error parsing %v from server: %v", source, err)
 		}

--- a/command/healthcheck/pki_tidy_last_run.go
+++ b/command/healthcheck/pki_tidy_last_run.go
@@ -93,7 +93,7 @@ func (h *TidyLastRun) Evaluate(e *Executor) (results []*Result, err error) {
 		ret := Result{
 			Status:   ResultInsufficientPermissions,
 			Endpoint: "/{{mount}}/tidy-status",
-			Message:  "Without this information, this health check is unable tof unction.",
+			Message:  "Without this information, this health check is unable to function.",
 		}
 
 		if e.Client.Token() == "" {

--- a/command/healthcheck/shared.go
+++ b/command/healthcheck/shared.go
@@ -32,24 +32,17 @@ func StringList(source interface{}) ([]string, error) {
 	return nil, fmt.Errorf("unknown source type for []string coercion: %T", source)
 }
 
-func fetchMountTune(e *Executor, versionError func()) (bool, *PathFetch, map[string]interface{}, error) {
+func fetchMountTune(e *Executor, versionError func()) (*PathFetch, error) {
 	tuneRet, err := e.FetchIfNotFetched(logical.ReadOperation, "/sys/mounts/{{mount}}/tune")
 	if err != nil {
-		return true, nil, nil, err
+		return nil, fmt.Errorf("failed to fetch mount tune information: %w", err)
 	}
 
 	if !tuneRet.IsSecretOK() {
 		if tuneRet.IsUnsupportedPathError() {
 			versionError()
 		}
-
-		return true, nil, nil, nil
 	}
 
-	var data map[string]interface{} = nil
-	if len(tuneRet.Secret.Data) > 0 {
-		data = tuneRet.Secret.Data
-	}
-
-	return false, tuneRet, data, nil
+	return tuneRet, nil
 }


### PR DESCRIPTION
 - Prior to this fix, if the end-user's Vault token did not have permission to the mount's tune api, we would return as if the tunable params had not been set.
 - Now check to see if we encountered a permission issue and report that back to the end-user like the other checks do.