### PR TITLE
add error consistency in link node status resp

### DIFF
--- a/vault/hcp_link/capabilities/node_status/node_status.go
+++ b/vault/hcp_link/capabilities/node_status/node_status.go
@@ -2,10 +2,10 @@ package node_status
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/hcp-link/pkg/nodestatus"
 	"github.com/hashicorp/vault/helper/logging"
+	"github.com/hashicorp/vault/vault"
 	"github.com/hashicorp/vault/vault/hcp_link/internal"
 	"github.com/hashicorp/vault/vault/hcp_link/proto/node_status"
 	"github.com/shirou/gopsutil/v3/host"
@@ -24,7 +24,7 @@ type NodeStatusReporter struct {
 func (c *NodeStatusReporter) GetNodeStatus(ctx context.Context) (retStatus nodestatus.NodeStatus, retErr error) {
 	defer func() {
 		if r := recover(); r != nil {
-			retErr = fmt.Errorf("internal server error")
+			retErr = vault.ErrInternalError
 		}
 	}()
 


### PR DESCRIPTION
Panic handling in Link uses `vault.ErrInternalError` in most cases except `GetNodeStatus`. This PR fixes that by using the appropriate error in `GetNodeStatus`.