### PR TITLE
VAULT-13220 use decorator instead of extending overview route

### DIFF
--- a/ui/lib/pki/addon/decorators/check-config.js
+++ b/ui/lib/pki/addon/decorators/check-config.js
@@ -1,0 +1,36 @@
+import Route from '@ember/routing/route';
+
+/**
+ * the overview, roles, issuers, certificates, and key routes all need to be aware of the whether there is a config for the engine
+ * if the user has not configured they are prompted to do so in each of the routes
+ * decorate the necessary routes to perform the check in the beforeModel hook since that may change what is returned for the model
+ */
+
+export function withConfig() {
+  return function decorator(SuperClass) {
+    if (!Object.prototype.isPrototypeOf.call(Route, SuperClass)) {
+      // eslint-disable-next-line
+      console.error(
+        'withConfig decorator must be used on an instance of ember Route class. Decorator not applied to returned class'
+      );
+      return SuperClass;
+    }
+    return class CheckConfig extends SuperClass {
+      shouldPromptConfig = false;
+
+      async beforeModel() {
+        super.beforeModel(...arguments);
+
+        // When the engine is configured, it creates a default issuer.
+        // If the issuers list is empty, we know it hasn't been configured
+        return (
+          this.store
+            .query('pki/issuer', { backend: this.secretMountPath.currentPath })
+            .then(() => (this.shouldPromptConfig = true))
+            // this endpoint is unauthenticated, so we're not worried about permissions errors
+            .catch(() => (this.shouldPromptConfig = false))
+        );
+      }
+    };
+  };
+}

--- a/ui/lib/pki/addon/routes/certificates/index.js
+++ b/ui/lib/pki/addon/routes/certificates/index.js
@@ -1,8 +1,10 @@
-import PkiOverviewRoute from '../overview';
+import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { withConfig } from 'pki/decorators/check-config';
 import { hash } from 'rsvp';
 
-export default class PkiCertificatesIndexRoute extends PkiOverviewRoute {
+@withConfig()
+export default class PkiCertificatesIndexRoute extends Route {
   @service store;
   @service secretMountPath;
 
@@ -20,7 +22,7 @@ export default class PkiCertificatesIndexRoute extends PkiOverviewRoute {
 
   model() {
     return hash({
-      hasConfig: this.hasConfig(),
+      hasConfig: this.shouldPromptConfig,
       certificates: this.fetchCertificates(),
       parentModel: this.modelFor('certificates'),
     });

--- a/ui/lib/pki/addon/routes/issuers/index.js
+++ b/ui/lib/pki/addon/routes/issuers/index.js
@@ -1,7 +1,7 @@
-import PkiOverviewRoute from '../overview';
+import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
-export default class PkiIssuersListRoute extends PkiOverviewRoute {
+export default class PkiIssuersListRoute extends Route {
   @service store;
   @service secretMountPath;
   @service pathHelp;

--- a/ui/lib/pki/addon/routes/keys/index.js
+++ b/ui/lib/pki/addon/routes/keys/index.js
@@ -1,7 +1,10 @@
-import PkiOverviewRoute from '../overview';
+import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { withConfig } from 'pki/decorators/check-config';
 import { hash } from 'rsvp';
-export default class PkiKeysIndexRoute extends PkiOverviewRoute {
+
+@withConfig()
+export default class PkiKeysIndexRoute extends Route {
   @service store;
   @service secretMountPath;
   @service pathHelp;
@@ -13,7 +16,7 @@ export default class PkiKeysIndexRoute extends PkiOverviewRoute {
 
   model() {
     return hash({
-      hasConfig: this.hasConfig(),
+      hasConfig: this.shouldPromptConfig,
       parentModel: this.modelFor('keys'),
       keyModels: this.store.query('pki/key', { backend: this.secretMountPath.currentPath }).catch((err) => {
         if (err.httpStatus === 404) {

--- a/ui/lib/pki/addon/routes/overview.js
+++ b/ui/lib/pki/addon/routes/overview.js
@@ -1,23 +1,13 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { withConfig } from 'pki/decorators/check-config';
 import { hash } from 'rsvp';
 
+@withConfig()
 export default class PkiOverviewRoute extends Route {
   @service secretMountPath;
   @service auth;
   @service store;
-
-  hasConfig() {
-    // When the engine is configured, it creates a default issuer.
-    // If the issuers list is empty, we know it hasn't been configured
-    return (
-      this.store
-        .query('pki/issuer', { backend: this.secretMountPath.currentPath })
-        .then(() => true)
-        // this endpoint is unauthenticated, so we're not worried about permissions errors
-        .catch(() => false)
-    );
-  }
 
   async fetchAllRoles() {
     try {
@@ -37,7 +27,7 @@ export default class PkiOverviewRoute extends Route {
 
   async model() {
     return hash({
-      hasConfig: this.hasConfig(),
+      hasConfig: this.shouldPromptConfig,
       engine: this.modelFor('application'),
       roles: this.fetchAllRoles(),
       issuers: this.fetchAllIssuers(),

--- a/ui/lib/pki/addon/routes/roles/index.js
+++ b/ui/lib/pki/addon/routes/roles/index.js
@@ -1,8 +1,10 @@
-import PkiOverviewRoute from '../overview';
+import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { withConfig } from 'pki/decorators/check-config';
 import { hash } from 'rsvp';
 
-export default class PkiRolesIndexRoute extends PkiOverviewRoute {
+@withConfig()
+export default class PkiRolesIndexRoute extends Route {
   @service store;
   @service secretMountPath;
 
@@ -20,7 +22,7 @@ export default class PkiRolesIndexRoute extends PkiOverviewRoute {
 
   model() {
     return hash({
-      hasConfig: this.hasConfig(),
+      hasConfig: this.shouldPromptConfig,
       roles: this.fetchRoles(),
       parentModel: this.modelFor('roles'),
     });


### PR DESCRIPTION
**Description**
- Use decorator instead of extending the overview route to check for config. Props to Jordan for setting up this pattern in k8s 🎉