### PR TITLE
docs: remove Consul data plane warning from Consul Secrets Engine page

### DIFF
--- a/website/content/docs/secrets/consul.mdx
+++ b/website/content/docs/secrets/consul.mdx
@@ -8,8 +8,6 @@ description: The Consul secrets engine for Vault generates tokens for Consul dyn
 
 @include 'x509-sha1-deprecation.mdx'
 
-@include 'consul-dataplane-compat.mdx'
-
 The Consul secrets engine generates [Consul](https://www.consul.io/) API tokens
 dynamically based on Consul ACL policies.
 


### PR DESCRIPTION
Consul 1.14.0 comes with a new model for deploying Consul without agents on K8s. Removing this warning since this is not relevant to Consul Secrets agent as the warning is only needed for the instance where Consul is used as backend storage to Vault. 