### PR TITLE
Restore 'server' and 'agent' base loggers to use their original names

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -1253,7 +1253,7 @@ func (c *AgentCommand) newLogger() (log.InterceptLogger, error) {
 	}
 
 	logCfg := &logging.LogConfig{
-		Name:              "vault-agent",
+		Name:              "agent",
 		LogLevel:          logLevel,
 		LogFormat:         logFormat,
 		LogFilePath:       c.config.LogFile,

--- a/command/server.go
+++ b/command/server.go
@@ -1721,7 +1721,6 @@ func (c *ServerCommand) configureLogging(config *server.Config) (hclog.Intercept
 	}
 
 	logCfg := &loghelper.LogConfig{
-		Name:              "vault",
 		LogLevel:          logLevel,
 		LogFormat:         logFormat,
 		LogFilePath:       config.LogFile,


### PR DESCRIPTION
When we added additional logging features to `server` and `agent` in https://github.com/hashicorp/vault/pull/18031, we introduced an unintended change to the base logger names in both commands (setting them to `vault` and `vault-agent` respectively).

This PR restores the original names (in the case of `server` has no name) so that any log ingestion/parsing by downstream systems would not be impacted. Furthermore it also means that endpoints such as `sys/loggers` function as expected and don't require a `vault.` prefix for `server` loggers.