### PR TITLE
Remove OCSP GET support from the PKI engine

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -194,7 +194,6 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathFetchListCerts(&b),
 
 			// OCSP APIs
-			buildPathOcspGet(&b),
 			buildPathOcspPost(&b),
 
 			// CRL Signing
@@ -219,7 +218,6 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathListCertsRevocationQueue(&b),
 			pathListUnifiedRevoked(&b),
 			pathFetchUnifiedCRL(&b),
-			buildPathUnifiedOcspGet(&b),
 			buildPathUnifiedOcspPost(&b),
 		}
 		b.Backend.Paths = append(b.Backend.Paths, entOnly...)

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1358,14 +1358,13 @@ At this time there are certain limitations of the OCSP implementation at this pa
  1. Ed25519 backed CA's are not supported for OCSP requests,
  1. Note that this API will not work with the Vault client as both request and responses are DER encoded, and
  1. Note that KMS based issuers which require PSS support are not supported either (such as PKCS#11 HSMs or GCP in certain scenarios).
+ 1. At this time, Vault only support POST OCSP requests
 
 These are unauthenticated endpoints.
 
 | Method | Path                                                       | Response Format                                                                   | Source  |
 | :----- | :--------------------------------------------------------- | :-------------------------------------------------------------------------------- | :------ |
-| `GET`  | `/pki/ocsp/<base 64+URL encoded ocsp DER request>`         | DER [\[1\]](#vault-cli-with-der-pem-responses "Vault CLI With DER/PEM Responses") | Local   |
 | `POST` | `/pki/ocsp`                                                | DER [\[1\]](#vault-cli-with-der-pem-responses "Vault CLI With DER/PEM Responses") | Local   |
-| `GET`  | `/pki/unified-ocsp/<base 64+URL encoded ocsp DER request>` | DER [\[1\]](#vault-cli-with-der-pem-responses "Vault CLI With DER/PEM Responses") | Unified |
 | `POST` | `/pki/unified-ocsp`                                        | DER [\[1\]](#vault-cli-with-der-pem-responses "Vault CLI With DER/PEM Responses") | Unified |
 
 #### Parameters
@@ -3901,7 +3900,7 @@ The below parameters are in addition to the regular parameters accepted by the
 
 - `interval_duration` `(string: "")` - Specifies the duration between automatic tidy
   operations; note that this is from the end of one operation to the start of
-  the next so the time of the operation itself does not need to be considered. 
+  the next so the time of the operation itself does not need to be considered.
   Defaults to 12h
 
 #### Sample Payload

--- a/website/content/docs/secrets/pki/considerations.mdx
+++ b/website/content/docs/secrets/pki/considerations.mdx
@@ -351,7 +351,7 @@ volumes, this could be the best option.
 Notably, this last approach can either be used for the creation of externally
 stored unified or sharded CRLs. If a single external unified CRL becomes
 unreasonably large, each cluster's certificates could have AIA info point
-to an externally stored and maintained, sharded CRL. However, 
+to an externally stored and maintained, sharded CRL. However,
 Vault has no mechanism to sign OCSP requests at this time.
 
 ### What Are Cross-Cluster CRLs?
@@ -607,7 +607,6 @@ For these personas, we suggest the following ACLs, in condensed, tabular form:
 | `/issuer/:issuer_ref/(json¦der¦pem)` | Read | Yes | Yes | Yes | Yes | Yes |
 | `/issuer/:issuer_ref/crl(/der¦/pem)?` | Read | Yes | Yes | Yes | Yes | Yes |
 | `/issuer/:issuer_ref/crl/delta(/der¦/pem)?` | Read | Yes | Yes | Yes | Yes | Yes |
-| `/ocsp/<request>` | Read | Yes | Yes | Yes | Yes | Yes |
 | `/ocsp` | Write | Yes | Yes | Yes | Yes | Yes |
 | `/certs` | List | Yes | Yes | Yes | Yes | |
 | `/revoke-with-key` | Write | Yes | Yes | Yes | Yes | |


### PR DESCRIPTION
We've identified some issues with the GET based OCSP request handler. It is possible to have an OCSP query encoded within standard base64 encoding that will contain multiple consecutive `/` characters of which the standard Go library's HTTP server mux will attempt to clean up the path and issue a 301 permanent redirection notice for. Because of this the PKI engine doesn't get the original request and if the client actually does follow the redirect, the base64 request is now corrupted. 

So at this time, the safest option that has been decided is to remove the GET support for OCSP, keeping support for the POST version of the handler only. 