### PR TITLE
VAULT-12299 Use file.Stat when checking file permissions

### DIFF
--- a/command/server/config.go
+++ b/command/server/config.go
@@ -471,7 +471,7 @@ func LoadConfig(path string) (*Config, error) {
 		defer f.Close()
 
 		if enableFilePermissionsCheck {
-			err = osutil.OwnerPermissionsMatch(path, 0, 0)
+			err = osutil.OwnerPermissionsMatchFile(f, path, 0, 0)
 			if err != nil {
 				return nil, err
 			}
@@ -528,7 +528,7 @@ func LoadConfigFile(path string) (*Config, error) {
 
 	if enableFilePermissionsCheck {
 		// check permissions of the config file
-		err = osutil.OwnerPermissionsMatchFile(f, 0, 0)
+		err = osutil.OwnerPermissionsMatchFile(f, path, 0, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -471,7 +471,7 @@ func LoadConfig(path string) (*Config, error) {
 		defer f.Close()
 
 		if enableFilePermissionsCheck {
-			err = osutil.OwnerPermissionsMatchFile(f, path, 0, 0)
+			err = osutil.OwnerPermissionsMatchFile(f, 0, 0)
 			if err != nil {
 				return nil, err
 			}
@@ -528,7 +528,7 @@ func LoadConfigFile(path string) (*Config, error) {
 
 	if enableFilePermissionsCheck {
 		// check permissions of the config file
-		err = osutil.OwnerPermissionsMatchFile(f, path, 0, 0)
+		err = osutil.OwnerPermissionsMatchFile(f, 0, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -810,8 +810,8 @@ func LoadConfigDir(dir string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	defer f.Close()
+
 	fi, err := f.Stat()
 	if err != nil {
 		return nil, err

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -476,7 +476,7 @@ func LoadConfig(path string) (*Config, error) {
 				return nil, err
 			}
 		}
-		return CheckConfig(LoadConfigDir(f))
+		return CheckConfig(LoadConfigDir(f, path))
 	}
 	return CheckConfig(LoadConfigFile(path))
 }
@@ -805,8 +805,7 @@ func mergeExperiments(left, right []string) []string {
 
 // LoadConfigDir loads all the configurations in the given directory
 // in alphabetical order.
-func LoadConfigDir(f *os.File) (*Config, error) {
-	dir := f.Name()
+func LoadConfigDir(f *os.File, dir string) (*Config, error) {
 	fi, err := f.Stat()
 	if err != nil {
 		return nil, err

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -476,7 +476,7 @@ func LoadConfig(path string) (*Config, error) {
 				return nil, err
 			}
 		}
-		return CheckConfig(LoadConfigDir(f, path))
+		return CheckConfig(LoadConfigDir(path))
 	}
 	return CheckConfig(LoadConfigFile(path))
 }
@@ -805,7 +805,13 @@ func mergeExperiments(left, right []string) []string {
 
 // LoadConfigDir loads all the configurations in the given directory
 // in alphabetical order.
-func LoadConfigDir(f *os.File, dir string) (*Config, error) {
+func LoadConfigDir(dir string) (*Config, error) {
+	f, err := os.Open(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	defer f.Close()
 	fi, err := f.Stat()
 	if err != nil {
 		return nil, err

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -654,7 +655,12 @@ func testLoadConfigFile_json(t *testing.T) {
 }
 
 func testLoadConfigDir(t *testing.T) {
-	config, err := LoadConfigDir("./test-fixtures/config-dir")
+	f, err := os.Open("./test-fixtures/config-dir")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer f.Close()
+	config, err := LoadConfigDir(f)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -655,12 +655,13 @@ func testLoadConfigFile_json(t *testing.T) {
 }
 
 func testLoadConfigDir(t *testing.T) {
+	path := "./test-fixtures/config-dir"
 	f, err := os.Open("./test-fixtures/config-dir")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	defer f.Close()
-	config, err := LoadConfigDir(f)
+	config, err := LoadConfigDir(f, path)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -655,13 +654,7 @@ func testLoadConfigFile_json(t *testing.T) {
 }
 
 func testLoadConfigDir(t *testing.T) {
-	path := "./test-fixtures/config-dir"
-	f, err := os.Open("./test-fixtures/config-dir")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer f.Close()
-	config, err := LoadConfigDir(f, path)
+	config, err := LoadConfigDir("./test-fixtures/config-dir")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/helper/osutil/fileinfo.go
+++ b/helper/osutil/fileinfo.go
@@ -66,20 +66,16 @@ func OwnerPermissionsMatch(path string, uid int, permissions int) error {
 }
 
 // OwnerPermissionsMatchFile checks if vault user is the owner and permissions are secure for the input file
-// This function will error if the file is a symbolic link
-func OwnerPermissionsMatchFile(file *os.File, uid int, permissions int) error {
+func OwnerPermissionsMatchFile(file *os.File, path string, uid int, permissions int) error {
 	if file == nil {
 		return fmt.Errorf("could not verify permissions for file. No file provided")
 	}
 
 	info, err := file.Stat()
 	if err != nil {
-		return fmt.Errorf("error stating %q: %w", file.Name(), err)
+		return fmt.Errorf("error stating %q: %w", path, err)
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("file %q is a symbolic link", file.Name())
-	}
-	err = checkPathInfo(info, file.Name(), uid, permissions)
+	err = checkPathInfo(info, path, uid, permissions)
 	if err != nil {
 		return err
 	}

--- a/helper/osutil/fileinfo.go
+++ b/helper/osutil/fileinfo.go
@@ -66,16 +66,12 @@ func OwnerPermissionsMatch(path string, uid int, permissions int) error {
 }
 
 // OwnerPermissionsMatchFile checks if vault user is the owner and permissions are secure for the input file
-func OwnerPermissionsMatchFile(file *os.File, path string, uid int, permissions int) error {
-	if file == nil {
-		return fmt.Errorf("could not verify permissions for file. No file provided")
-	}
-
+func OwnerPermissionsMatchFile(file *os.File, uid int, permissions int) error {
 	info, err := file.Stat()
 	if err != nil {
-		return fmt.Errorf("error stating %q: %w", path, err)
+		return fmt.Errorf("file stat error on path %q: %w", file.Name(), err)
 	}
-	err = checkPathInfo(info, path, uid, permissions)
+	err = checkPathInfo(info, file.Name(), uid, permissions)
 	if err != nil {
 		return err
 	}

--- a/helper/osutil/fileinfo.go
+++ b/helper/osutil/fileinfo.go
@@ -64,3 +64,25 @@ func OwnerPermissionsMatch(path string, uid int, permissions int) error {
 
 	return nil
 }
+
+// OwnerPermissionsMatchFile checks if vault user is the owner and permissions are secure for the input file
+// This function will error if the file is a symbolic link
+func OwnerPermissionsMatchFile(file *os.File, uid int, permissions int) error {
+	if file == nil {
+		return fmt.Errorf("could not verify permissions for file. No file provided")
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("error stating %q: %w", file.Name(), err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("file %q is a symbolic link", file.Name())
+	}
+	err = checkPathInfo(info, file.Name(), uid, permissions)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/helper/osutil/fileinfo_test.go
+++ b/helper/osutil/fileinfo_test.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"testing"
@@ -80,5 +81,71 @@ func TestCheckPathInfo(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+// TestOwnerPermissionsMatchFile creates a file and verifies that the current user of the process is the owner of the
+// file
+func TestOwnerPermissionsMatchFile(t *testing.T) {
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatal("failed to get current user", err)
+	}
+	uid, err := strconv.ParseInt(currentUser.Uid, 0, 64)
+	if err != nil {
+		t.Fatal("failed to convert uid", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "foo")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal("failed to create test file", err)
+	}
+	defer f.Close()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal("failed to stat test file", err)
+	}
+
+	if err := OwnerPermissionsMatchFile(f, int(uid), int(info.Mode())); err != nil {
+		t.Fatalf("expected no error but got %v", err)
+	}
+}
+
+// TestOwnerPermissionsMatchFile_Symlink creates a file and a symlink to that file. The test verifies that the current
+// user of the process is the owner of the file
+func TestOwnerPermissionsMatchFile_Symlink(t *testing.T) {
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatal("failed to get current user", err)
+	}
+	uid, err := strconv.ParseInt(currentUser.Uid, 0, 64)
+	if err != nil {
+		t.Fatal("failed to convert uid", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "foo")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal("failed to create test file", err)
+	}
+	defer f.Close()
+
+	symlink := filepath.Join(dir, "symlink")
+	err = os.Symlink(path, symlink)
+	if err != nil {
+		t.Fatal("failed to symlink file", err)
+	}
+	symlinkedFile, err := os.Open(symlink)
+	if err != nil {
+		t.Fatal("failed to open file", err)
+	}
+	info, err := os.Stat(symlink)
+	if err != nil {
+		t.Fatal("failed to stat test file", err)
+	}
+	if err := OwnerPermissionsMatchFile(symlinkedFile, int(uid), int(info.Mode())); err != nil {
+		t.Fatalf("expected no error but got %v", err)
 	}
 }

--- a/helper/osutil/fileinfo_test.go
+++ b/helper/osutil/fileinfo_test.go
@@ -108,8 +108,37 @@ func TestOwnerPermissionsMatchFile(t *testing.T) {
 		t.Fatal("failed to stat test file", err)
 	}
 
-	if err := OwnerPermissionsMatchFile(f, path, int(uid), int(info.Mode())); err != nil {
+	if err := OwnerPermissionsMatchFile(f, int(uid), int(info.Mode())); err != nil {
 		t.Fatalf("expected no error but got %v", err)
+	}
+}
+
+// TestOwnerPermissionsMatchFile_OtherUser creates a file using the user that started the current process and verifies
+// that a different user is not the owner of the file
+func TestOwnerPermissionsMatchFile_OtherUser(t *testing.T) {
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatal("failed to get current user", err)
+	}
+	uid, err := strconv.ParseInt(currentUser.Uid, 0, 64)
+	if err != nil {
+		t.Fatal("failed to convert uid", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "foo")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal("failed to create test file", err)
+	}
+	defer f.Close()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal("failed to stat test file", err)
+	}
+
+	if err := OwnerPermissionsMatchFile(f, int(uid)+1, int(info.Mode())); err == nil {
+		t.Fatalf("expected error but none")
 	}
 }
 
@@ -145,7 +174,7 @@ func TestOwnerPermissionsMatchFile_Symlink(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to stat test file", err)
 	}
-	if err := OwnerPermissionsMatchFile(symlinkedFile, symlink, int(uid), int(info.Mode())); err != nil {
+	if err := OwnerPermissionsMatchFile(symlinkedFile, int(uid), int(info.Mode())); err != nil {
 		t.Fatalf("expected no error but got %v", err)
 	}
 }

--- a/helper/osutil/fileinfo_test.go
+++ b/helper/osutil/fileinfo_test.go
@@ -108,7 +108,7 @@ func TestOwnerPermissionsMatchFile(t *testing.T) {
 		t.Fatal("failed to stat test file", err)
 	}
 
-	if err := OwnerPermissionsMatchFile(f, int(uid), int(info.Mode())); err != nil {
+	if err := OwnerPermissionsMatchFile(f, path, int(uid), int(info.Mode())); err != nil {
 		t.Fatalf("expected no error but got %v", err)
 	}
 }
@@ -145,7 +145,7 @@ func TestOwnerPermissionsMatchFile_Symlink(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to stat test file", err)
 	}
-	if err := OwnerPermissionsMatchFile(symlinkedFile, int(uid), int(info.Mode())); err != nil {
+	if err := OwnerPermissionsMatchFile(symlinkedFile, symlink, int(uid), int(info.Mode())); err != nil {
 		t.Fatalf("expected no error but got %v", err)
 	}
 }


### PR DESCRIPTION
VAULT_ENABLE_FILE_PERMISSIONS_CHECK can be bypassed if the file is modified in between the time its ownership is checked, and the time it is opened. This PR opens the config files first, then uses the file pointers to perform the ownership checks.

There isn't a test for the actual attack, because any test requires multiple OS users, which is difficult to do from Go test code. To reliably test the time of check vs time of use difference, you'd also need to be able to make a sigaction() syscall to perform the ownership change. It doesn't seem worth it to create an enos scenario for a scenario this simple.

