### PR TITLE
test: Fix bug in TestAddTestPlugin test helper

### DIFF
--- a/vault/external_tests/plugin/plugin_test.go
+++ b/vault/external_tests/plugin/plugin_test.go
@@ -422,7 +422,9 @@ func testPlugin_continueOnError(t *testing.T, btype logical.BackendType, mismatc
 			core := cluster.Cores[0]
 
 			// Get the registered plugin
-			req := logical.TestRequest(t, logical.ReadOperation, fmt.Sprintf("sys/plugins/catalog/%s/mock-plugin/v0.0.0+mock", pluginType))
+			req := logical.TestRequest(t, logical.ReadOperation, fmt.Sprintf("sys/plugins/catalog/%s/mock-plugin", pluginType))
+			// We are using the mock backend from vault/sdk/plugin/mock/backend.go which sets the plugin version.
+			req.Data["version"] = "v0.0.0+mock"
 			req.ClientToken = core.Client.Token()
 			resp, err := core.HandleRequest(namespace.RootContext(testCtx), req)
 			if err != nil || resp == nil || (resp != nil && resp.IsError()) {

--- a/vault/external_tests/plugin/plugin_test.go
+++ b/vault/external_tests/plugin/plugin_test.go
@@ -422,7 +422,7 @@ func testPlugin_continueOnError(t *testing.T, btype logical.BackendType, mismatc
 			core := cluster.Cores[0]
 
 			// Get the registered plugin
-			req := logical.TestRequest(t, logical.ReadOperation, fmt.Sprintf("sys/plugins/catalog/%s/mock-plugin", pluginType))
+			req := logical.TestRequest(t, logical.ReadOperation, fmt.Sprintf("sys/plugins/catalog/%s/mock-plugin/v0.0.0+mock", pluginType))
 			req.ClientToken = core.Client.Token()
 			resp, err := core.HandleRequest(namespace.RootContext(testCtx), req)
 			if err != nil || resp == nil || (resp != nil && resp.IsError()) {

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -539,6 +539,9 @@ func TestAddTestPlugin(t testing.T, c *Core, name string, pluginType consts.Plug
 		if err != nil {
 			t.Fatal(err)
 		}
+		// Ensure that the file is closed and written. This seems to be
+		// necessary on Linux systems.
+		out.Close()
 
 		dirPath = tempDir
 	}


### PR DESCRIPTION
This PR fixes a bug in TestAddTestPlugin that appears to only manifest on Linux systems. This bug resulted in the test failing on Mac systems but passing on Linux systems because we failed to properly get the plugin version.

Additionally, we update the test to use the plugin version when performing the Read on the plugin catalog since this should now be properly set.

We write the plugin binary file in TestAddTestPlugin and then call file.Close() in a defer statement. However, we need to read the file's SHA256 sum immediately after writing the file so we call file.Sync(). On Linux this was not working as expected because we seem to be reading the sha sum and running the plugin too fast. This caused the call to get the plugin version to fail and to be incorrectly written to storage as un-versioned.