### PR TITLE
Fix test inmem layer unlock bug

### DIFF
--- a/vault/cluster/inmem_layer.go
+++ b/vault/cluster/inmem_layer.go
@@ -132,6 +132,7 @@ func (l *InmemLayer) Dial(addr string, timeout time.Duration, tlsConfig *tls.Con
 		// gRPC sets a deadline of 20 seconds on the dail attempt, so
 		// matching that here.
 		time.Sleep(time.Second * 20)
+		l.l.Unlock()
 		return nil, deadlineError("i/o timeout")
 	}
 


### PR DESCRIPTION
@ncabatoff found a bug where when using forced timeouts in inmem a lock wasn't being released. This was causing instability in tests.