### PR TITLE
Fix link to template_config page

### DIFF
--- a/website/content/docs/agent/index.mdx
+++ b/website/content/docs/agent/index.mdx
@@ -274,7 +274,7 @@ section.
 For requests from the templating engine, Vaul Agent will reset its retry counter and
 perform retries again once all retries are exhausted. This means that templating
 will retry on failures indefinitely unless `exit_on_retry_failure` from the
-[`template_config`][template-config] stanza is set to `true`.
+[`template_config`][template] stanza is set to `true`.
 
 Here are the options for the `retry` stanza:
 


### PR DESCRIPTION
Existing link goes to https://developer.hashicorp.com/vault/docs/agent/template-config which does not exist

https://developer.hashicorp.com/vault/docs/agent/template is the correct one