### PR TITLE
When copying test binary, delete first

### DIFF
--- a/vault/testing.go
+++ b/vault/testing.go
@@ -526,6 +526,9 @@ func TestAddTestPlugin(t testing.T, c *Core, name string, pluginType consts.Plug
 
 		// Copy over the file to the temp dir
 		dst := filepath.Join(tempDir, fileName)
+
+		// delete the file first to avoid notary failures in macOS
+		_ = os.Remove(dst) // ignore error
 		out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fi.Mode())
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
For plugin tests, we copy the test binary. On macOS, if the destination binary already exists, then copying over it will result in an invalid signature.

The easiest workaround is to delete the file before copying.