### PR TITLE
secrets/ad: change deprecation status to deprecated

### DIFF
--- a/changelog/19334.txt
+++ b/changelog/19334.txt
@@ -1,0 +1,3 @@
+```release-note:deprecation
+secrets/ad: Marks the Active Directory (AD) secrets engine as deprecated.
+```

--- a/helper/builtinplugins/registry.go
+++ b/helper/builtinplugins/registry.go
@@ -146,7 +146,10 @@ func newRegistry() *registry {
 			"snowflake-database-plugin":         {Factory: dbSnowflake.New},
 		},
 		logicalBackends: map[string]logicalBackend{
-			"ad":       {Factory: logicalAd.Factory},
+			"ad": {
+				Factory:           logicalAd.Factory,
+				DeprecationStatus: consts.Deprecated,
+			},
 			"alicloud": {Factory: logicalAlicloud.Factory},
 			"aws":      {Factory: logicalAws.Factory},
 			"azure":    {Factory: logicalAzure.Factory},


### PR DESCRIPTION
This PR changes the deprecation status to deprecated for the AD secrets engine. This causes Vault to log that it's mounting a deprecated builtin similar to below:

```
2023-02-23T15:30:29.031-0800 [WARN]  core: mounting deprecated builtin: name=ad type=secret path=ad/
```