### PR TITLE
heading level 3 to level 2 for list and delete

### DIFF
--- a/website/content/api-docs/secret/identity/entity-alias.mdx
+++ b/website/content/api-docs/secret/identity/entity-alias.mdx
@@ -182,7 +182,7 @@ $ curl \
 }
 ```
 
-### Delete Entity Alias by ID
+## Delete Entity Alias by ID
 
 This endpoint deletes an alias from its corresponding entity.
 
@@ -203,7 +203,7 @@ $ curl \
     http://127.0.0.1:8200/v1/identity/entity-alias/id/34982d3d-e3ce-5d8b-6e5f-b9bb34246c31
 ```
 
-### List Entity Aliases by ID
+## List Entity Aliases by ID
 
 This endpoint returns a list of available entity aliases by their identifiers.
 


### PR DESCRIPTION
https://developer.hashicorp.com/vault/api-docs/secret/identity/entity-alias misses **Delete Entity Alias by ID** and **List Entity Aliases by ID** in the navigation bar on the right.

Looks like these were written with heading level 3- changed to level 2