### PR TITLE
VAULT-13763 normalize activity log mount paths 

### DIFF
--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -4017,9 +4017,11 @@ func TestActivityLog_handleQuery_normalizedMountPaths(t *testing.T) {
 	err = core.router.Mount(&NoopBackend{}, "auth/bar", &MountEntry{UUID: uuid2, Accessor: accessor2, NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace, Path: pathWithoutSlash}, view)
 	require.NoError(t, err)
 
-	// handle token usage for each of them mount paths
+	// handle token usage for each of the mount paths
 	a.HandleTokenUsage(ctx, &logical.TokenEntry{Path: pathWithSlash, NamespaceID: namespace.RootNamespaceID}, "id1", false)
 	a.HandleTokenUsage(ctx, &logical.TokenEntry{Path: pathWithoutSlash, NamespaceID: namespace.RootNamespaceID}, "id2", false)
+	// and have client 2 use both mount paths
+	a.HandleTokenUsage(ctx, &logical.TokenEntry{Path: pathWithSlash, NamespaceID: namespace.RootNamespaceID}, "id2", false)
 
 	// query the data for the month
 	results, err := a.handleQuery(ctx, timeutil.StartOfMonth(now), timeutil.EndOfMonth(now), 0)

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -4057,7 +4057,7 @@ func TestActivityLog_partialMonthClientCountWithMultipleMountPaths(t *testing.T)
 	}
 
 	a := core.activityLog
-	path := "auth/foo/bar"
+	path := "auth/foo/bar/"
 	accessor := "authfooaccessor"
 
 	// we mount a path using the accessor 'authfooaccessor' which has mount path "auth/foo/bar"

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/axiomhq/hyperloglog"
@@ -277,6 +278,9 @@ func (a *ActivityLog) mountAccessorToMountPath(mountAccessor string) string {
 			displayPath = fmt.Sprintf(deletedMountFmt, mountAccessor)
 		} else {
 			displayPath = valResp.MountPath
+			if !strings.HasSuffix(displayPath, "/") {
+				displayPath += "/"
+			}
 		}
 	}
 	return displayPath


### PR DESCRIPTION
Mount paths "auth/foo/" and "auth/foo" should both be represented as "auth/foo/" by the activity log responses, with the clients in those paths getting correctly deduplicated.

I didn't create a changelog entry since there's already one for the original change: https://github.com/hashicorp/vault/pull/18916

