### PR TITLE
Vault Status Command Differs Depending on Format 

### DIFF
--- a/website/content/docs/commands/status.mdx
+++ b/website/content/docs/commands/status.mdx
@@ -49,3 +49,23 @@ flags](/vault/docs/commands) included on all commands.
 - `-format` `(string: "table")` - Print the output in the given format. Valid
   formats are "table", "json", or "yaml". This can also be specified via the
   `VAULT_FORMAT` environment variable.
+
+By default, the output is displayed in "table" format.
+
+#### Output Fields
+
+1. The field for unseal nonce is displayed as `"n"` instead of `n` in yaml outputs. 
+2. The following fields in "table" format are displayed only when relevant:
+
+- "Unseal Progress" and "Unseal Nonce" are displayed when vault is sealed.
+- "HCP Link Status" and "HCP Link Resource ID" are displayed  when HCP link is configured.
+- "Seal Migration in Progress" is displayed when it is in progress.
+- "Cluster Name" and "Cluster ID" are displayed if they have a value 
+- "Raft Committed Index", "Raft Applied Index", "Last WAL" are diplayed if they are non-zero
+- "Warnings" are displayed if they exist
+
+- The following fields are displayed only when HA mode is enabled and is unsealed:
+  - "HA Cluster"
+  - "HA Mode"
+  - "Active Since" is displayed if node is active and has valid active time
+  - "Performance Standby" Node and "Performance Standby Last Remote WAL" are displayed for performance standby nodes 

--- a/website/content/docs/commands/status.mdx
+++ b/website/content/docs/commands/status.mdx
@@ -59,11 +59,11 @@ By default, the output is displayed in "table" format.
 - "Unseal Progress" and "Unseal Nonce" are displayed when vault is sealed.
 - "HCP Link Status" and "HCP Link Resource ID" are displayed when HCP link is configured.
 - "Seal Migration in Progress" is displayed when it is in progress.
-- "Cluster Name" and "Cluster ID" are displayed if they have a value 
-- "Raft Committed Index", "Raft Applied Index", "Last WAL" are diplayed if they are non-zero
-- "Warnings" are displayed if they exist
+- "Cluster Name" and "Cluster ID" are displayed if they have a value.
+- "Raft Committed Index", "Raft Applied Index", "Last WAL" are diplayed if they are non-zero.
+- "Warnings" are displayed if the warnings apply.
 - The following fields are displayed only when HA mode is enabled and is unsealed:
-  - "HA Cluster"
-  - "HA Mode"
-  - "Active Since" is displayed if node is active and has valid active time
-  - "Performance Standby" Node and "Performance Standby Last Remote WAL" are displayed for performance standby nodes 
+  - "HA Cluster".
+  - "HA Mode".
+  - "Active Since" is displayed if the node is active and has a valid active time.
+  - "Performance Standby" Node and "Performance Standby Last Remote WAL" are displayed for performance standby nodes.

--- a/website/content/docs/commands/status.mdx
+++ b/website/content/docs/commands/status.mdx
@@ -56,14 +56,12 @@ By default, the output is displayed in "table" format.
 
 1. The field for unseal nonce is displayed as `"n"` instead of `n` in yaml outputs. 
 2. The following fields in "table" format are displayed only when relevant:
-
 - "Unseal Progress" and "Unseal Nonce" are displayed when vault is sealed.
 - "HCP Link Status" and "HCP Link Resource ID" are displayed  when HCP link is configured.
 - "Seal Migration in Progress" is displayed when it is in progress.
 - "Cluster Name" and "Cluster ID" are displayed if they have a value 
 - "Raft Committed Index", "Raft Applied Index", "Last WAL" are diplayed if they are non-zero
 - "Warnings" are displayed if they exist
-
 - The following fields are displayed only when HA mode is enabled and is unsealed:
   - "HA Cluster"
   - "HA Mode"

--- a/website/content/docs/commands/status.mdx
+++ b/website/content/docs/commands/status.mdx
@@ -57,7 +57,7 @@ By default, the output is displayed in "table" format.
 1. The field for unseal nonce is displayed as `"n"` instead of `n` in yaml outputs. 
 2. The following fields in "table" format are displayed only when relevant:
 - "Unseal Progress" and "Unseal Nonce" are displayed when vault is sealed.
-- "HCP Link Status" and "HCP Link Resource ID" are displayed  when HCP link is configured.
+- "HCP Link Status" and "HCP Link Resource ID" are displayed when HCP link is configured.
 - "Seal Migration in Progress" is displayed when it is in progress.
 - "Cluster Name" and "Cluster ID" are displayed if they have a value 
 - "Raft Committed Index", "Raft Applied Index", "Last WAL" are diplayed if they are non-zero

--- a/website/content/docs/commands/status.mdx
+++ b/website/content/docs/commands/status.mdx
@@ -54,7 +54,7 @@ By default, the output is displayed in "table" format.
 
 #### Output Fields
 
-1. The field for unseal nonce is displayed as `"n"` instead of `n` in yaml outputs. 
+1. The field for total shares is displayed as `"n"` instead of `n` in yaml outputs. 
 2. The following fields in "table" format are displayed only when relevant:
 - "Unseal Progress" and "Unseal Nonce" are displayed when vault is sealed.
 - "HCP Link Status" and "HCP Link Resource ID" are displayed when HCP link is configured.


### PR DESCRIPTION
Related GH issue: https://github.com/hashicorp/vault/issues/9185

The issue is about getting different output values for “vault status” command depending on the format selected. 

Though the output looks inconsistent, It looks like we only want to display the relevant fields for "table" format. I posted this on vault-team-sustaining to see what others think about this https://hashicorp.slack.com/archives/C0287E435NE/p1677105285284409.

Mehdi gave some input from support perspective and suggested that we document this and also have an additional flag such as:  vault status -fields=all/* -format=table  - ie some additional parameter that over-rides the current user based adaptive outputs in favor of consistent output to always show all related fields.

For now, I am more inclined towards documenting the expected differences as I feel this would be useful for new users to understand the output. 

We can think of having an additional flag if we have more related issues/ requests regarding this in the future. 