### PR TITLE
docs - approle naming syntax update

### DIFF
--- a/website/content/api-docs/auth/approle.mdx
+++ b/website/content/api-docs/auth/approle.mdx
@@ -60,7 +60,8 @@ enabled while creating or updating a role.
 
 ### Parameters
 
-- `role_name` `(string: <required>)` - Name of the AppRole. Must be less than 4096 bytes.
+- `role_name` `(string: <required>)` - Name of the AppRole. Must be less than 4096 bytes, accepted characters 
+include a-Z, 0-9, space, hyphen, underscore and periods.
 - `bind_secret_id` `(bool: true)` - Require `secret_id` to be presented when
   logging in using this AppRole.
 - `secret_id_bound_cidrs` `(array: [])` - Comma-separated string or list of CIDR


### PR DESCRIPTION
Documentation does not currently detail the accepted naming scheme for approle roles, this aims to provide clarity based on customer feedback. https://github.com/hashicorp/vault/blob/main/sdk/framework/path.go#L16-L18 details the regex used.