### PR TITLE
update link policy fetch URL

### DIFF
--- a/vault/hcp_link/capabilities/api_capability/token_manager.go
+++ b/vault/hcp_link/capabilities/api_capability/token_manager.go
@@ -87,7 +87,7 @@ func (t *HCPLinkTokenManager) fetchPolicy() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error creating HTTP request: %w", err)
 	}
-	
+
 	retryableReq, err := retryablehttp.FromRequest(req)
 	if err != nil {
 		return "", fmt.Errorf("error adding HTTP request retry wrapping: %w", err)

--- a/vault/hcp_link/capabilities/api_capability/token_manager.go
+++ b/vault/hcp_link/capabilities/api_capability/token_manager.go
@@ -87,11 +87,7 @@ func (t *HCPLinkTokenManager) fetchPolicy() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error creating HTTP request: %w", err)
 	}
-
-	query := req.URL.Query()
-	query.Add("cluster_id", t.scadaConfig.Resource.ID)
-	req.URL.RawQuery = query.Encode()
-
+	
 	retryableReq, err := retryablehttp.FromRequest(req)
 	if err != nil {
 		return "", fmt.Errorf("error adding HTTP request retry wrapping: %w", err)
@@ -165,10 +161,11 @@ func (t *HCPLinkTokenManager) updateInLinePolicy() {
 func NewHCPLinkTokenManager(scadaConfig *scada.Config, core *vault.Core, logger hclog.Logger) (*HCPLinkTokenManager, error) {
 	tokenLogger := logger.Named("token_manager")
 
-	policyURL := fmt.Sprintf("https://%s/vault/2020-11-25/organizations/%s/projects/%s/link/policy",
+	policyURL := fmt.Sprintf("https://%s/vault-link/2022-11-07/organizations/%s/projects/%s/link/policy/%s",
 		scadaConfig.HCPConfig.APIAddress(),
 		scadaConfig.Resource.Location.OrganizationID,
 		scadaConfig.Resource.Location.ProjectID,
+		scadaConfig.Resource.ID,
 	)
 
 	m := &HCPLinkTokenManager{


### PR DESCRIPTION
We are using a new HCP endpoint to fetch the policy associated with the API capability.

Note: converting to draft to prevent merge for now