### PR TITLE
[Backport] approle naming syntax documentation (#19369)

### DIFF
--- a/website/content/api-docs/auth/approle.mdx
+++ b/website/content/api-docs/auth/approle.mdx
@@ -60,7 +60,8 @@ enabled while creating or updating a role.
 
 ### Parameters
 
-- `role_name` `(string: <required>)` - Name of the AppRole.
+- `role_name` `(string: <required>)` - Name of the AppRole. Must be less than 4096 bytes, accepted characters 
+include a-Z, 0-9, space, hyphen, underscore and periods.
 - `bind_secret_id` `(bool: true)` - Require `secret_id` to be presented when
   logging in using this AppRole.
 - `secret_id_bound_cidrs` `(array: [])` - Comma-separated string or list of CIDR


### PR DESCRIPTION
This backports the changes made by [PR19369](https://github.com/hashicorp/vault/pull/19369).

The [automatic backport PR](https://github.com/hashicorp/vault/pull/19380) failed due to merge conflict. 