### PR TITLE
Fix PKI Synopsis, add Transit help text and casing fixes

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -704,6 +704,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"transit": func() (cli.Command, error) {
+			return &TransitCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"transit import": func() (cli.Command, error) {
 			return &TransitImportCommand{
 				BaseCommand: getBaseCommand(),

--- a/command/pki.go
+++ b/command/pki.go
@@ -13,7 +13,7 @@ type PKICommand struct {
 }
 
 func (c *PKICommand) Synopsis() string {
-	return "Interact with Vault's Key-Value storage"
+	return "Interact with Vault's PKI Secrets Engine"
 }
 
 func (c *PKICommand) Help() string {

--- a/command/transit.go
+++ b/command/transit.go
@@ -1,0 +1,39 @@
+package command
+
+import (
+	"strings"
+
+	"github.com/mitchellh/cli"
+)
+
+var _ cli.Command = (*TransitCommand)(nil)
+
+type TransitCommand struct {
+	*BaseCommand
+}
+
+func (c *TransitCommand) Synopsis() string {
+	return "Interact with Vault's Transit Secrets Engine"
+}
+
+func (c *TransitCommand) Help() string {
+	helpText := `
+Usage: vault transit <subcommand> [options] [args]
+
+  This command has subcommands for interacting with Vault's Transit Secrets
+  Engine. Here are some simple examples, and more detailed examples are
+  available in the subcommands or the documentation.
+
+  To import a key into the specified Transit or Transform mount:
+
+  $ vault transit import transit/keys/newly-imported @path/to/key type=rsa-2048
+
+  Please see the individual subcommand help for detailed usage information.
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *TransitCommand) Run(args []string) int {
+	return cli.RunResultHelp
+}

--- a/command/transit_import_key.go
+++ b/command/transit_import_key.go
@@ -42,10 +42,11 @@ Usage: vault transit import PATH KEY [options...]
   the base64 encoded KEY (either directly on the CLI or via @path notation),
   into a new key whose API path is PATH.  To import a new version into an
   existing key, use import_version.  The remaining options after KEY (key=value
-  style) are passed on to the transit/transform create key endpoint.  If your
+  style) are passed on to the Transit or Transform create key endpoint.  If your
   system or device natively supports the RSA AES key wrap mechanism (such as
   the PKCS#11 mechanism CKM_RSA_AES_KEY_WRAP), you should use it directly
   rather than this command.
+
 ` + c.Flags().Help()
 
 	return strings.TrimSpace(helpText)

--- a/command/transit_import_key_version.go
+++ b/command/transit_import_key_version.go
@@ -26,12 +26,13 @@ Usage: vault transit import-version PATH KEY [...]
 
   Using the Transit or Transform key wrapping system, imports key material from
   the base64 encoded KEY (either directly on the CLI or via @path notation),
-  into a new key whose API path is PATH.  To import a new transit/transform
+  into a new key whose API path is PATH.  To import a new Transit or Transform
   key, use the import command instead.  The remaining options after KEY
-  (key=value style) are passed on to the transit/transform create key endpoint.
+  (key=value style) are passed on to the Transit or Transform create key endpoint.
   If your system or device natively supports the RSA AES key wrap mechanism
   (such as the PKCS#11 mechanism CKM_RSA_AES_KEY_WRAP), you should use it
   directly rather than this command.
+
 ` + c.Flags().Help()
 
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
As reported by @miagilepner, thank you!

---

This fixes the typo in the PKI synopsis, incorrectly reporting it as a K/V helper. We introduce a matching one for Transit and clarify a few help texts.


```
[cipherboy@xps15 vault]$ vault -help
Usage: vault <command> [args]

Common commands:
    read        Read data and retrieves secrets
    write       Write data, configuration, and secrets
    delete      Delete secrets and configuration
    list        List data or secrets
    login       Authenticate locally
    agent       Start a Vault agent
    server      Start a Vault server
    status      Print seal and HA status
    unwrap      Unwrap a wrapped secret

Other commands:
    audit                Interact with audit devices
    auth                 Interact with auth methods
    debug                Runs the debug command
    events               
    kv                   Interact with Vault's Key-Value storage
    lease                Interact with leases
    monitor              Stream log messages from a Vault server
    namespace            Interact with namespaces
    operator             Perform operator-specific tasks
    patch                Patch data, configuration, and secrets
    path-help            Retrieve API help for paths
    pki                  Interact with Vault's PKI Secrets Engine
    plugin               Interact with Vault plugins and catalog
    policy               Interact with policies
    print                Prints runtime configurations
    secrets              Interact with secrets engines
    ssh                  Initiate an SSH session
    token                Interact with tokens
    transit              Interact with Vault's Transit Secrets Engine
    version-history      Prints the version history of the target Vault server
[cipherboy@xps15 vault]$ vault transit -help
Usage: vault transit <subcommand> [options] [args]

  This command has subcommands for interacting with Vault's Transit Secrets
  Engine. Here are some simple examples, and more detailed examples are
  available in the subcommands or the documentation.

  To import a key into the specified Transit or Transform mount:

  $ vault transit import transit/keys/newly-imported @path/to/key type=rsa-2048

  Please see the individual subcommand help for detailed usage information.

Subcommands:
    import            Import a key into the Transit or Transform secrets engines.
    import-version    Import key material into a new key version in the Transit or Transform secrets engines.
[cipherboy@xps15 vault]$ vault transit import -help
Usage: vault transit import PATH KEY [options...]

  Using the Transit or Transform key wrapping system, imports key material from
  the base64 encoded KEY (either directly on the CLI or via @path notation),
  into a new key whose API path is PATH.  To import a new version into an
  existing key, use import_version.  The remaining options after KEY (key=value
  style) are passed on to the Transit or Transform create key endpoint.  If your
  system or device natively supports the RSA AES key wrap mechanism (such as
  the PKCS#11 mechanism CKM_RSA_AES_KEY_WRAP), you should use it directly
  rather than this command.

HTTP Options:

  -address=<string>
      Address of the Vault server. The default is https://127.0.0.1:8200. This
      can also be specified via the VAULT_ADDR environment variable.

...snip...
```