### PR TITLE
Add documentation for tls_max_version

### DIFF
--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -133,6 +133,13 @@ default value in the `"/sys/config/ui"` [API endpoint](/vault/api-docs/system/co
   `tls_min_version` and `tls_max_version` parameters) are widely considered
   insecure.
 
+- `tls_max_version` `(string: "tls13")` – Specifies the maximum supported
+  version of TLS. Accepted values are "tls10", "tls11", "tls12" or "tls13".
+
+~> **Warning**: TLS 1.1 and lower (`tls10` and `tls11` values for the
+  `tls_min_version` and `tls_max_version` parameters) are widely considered
+  insecure.
+
 - `tls_cipher_suites` `(string: "")` – Specifies the list of supported
   ciphersuites as a comma-separated-list. The list of all available ciphersuites
   is available in the [Golang TLS documentation][golang-tls].


### PR DESCRIPTION
The default value for `tls_max_version` (which is extra interesting due to the note on `tls_cipher_suites`) was not documented.

I _think_ it is defaulting to `tls13` at least that's the value set in `internalshared/listenerutil/listener.go` when the string is empty.