### PR TITLE
Remove 'openldap' from gen_openapi.sh

### DIFF
--- a/helper/builtinplugins/registry_test.go
+++ b/helper/builtinplugins/registry_test.go
@@ -289,6 +289,11 @@ func Test_RegistryMatchesGenOpenapi(t *testing.T) {
 	ensureInScript := func(t *testing.T, scriptBackends []string, name string) {
 		t.Helper()
 
+		// "openldap" is an alias for "ldap" secrets engine
+		if name == "openldap" {
+			return
+		}
+
 		if !slices.Contains(scriptBackends, name) {
 			t.Fatalf("%q backend could not be found in gen_openapi.sh, please add it there", name)
 		}

--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -21,7 +21,7 @@ then
 fi
 
 vault server -dev -dev-root-token-id=root &
-sleep 2
+sleep 5
 VAULT_PID=$!
 
 defer_stop_vault() {
@@ -71,7 +71,6 @@ vault secrets enable "kv"
 vault secrets enable "ldap"
 vault secrets enable "mongodbatlas"
 vault secrets enable "nomad"
-vault secrets enable "openldap"
 vault secrets enable "pki"
 vault secrets enable "rabbitmq"
 vault secrets enable "ssh"


### PR DESCRIPTION
`openldap` (https://github.com/hashicorp/vault-plugin-secrets-openldap) is an alias for `ldap` secrets engine. It was double-included and generated spurious endpoints.