### PR TITLE
Identity manager secure context fallback

### DIFF
--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -8,6 +8,7 @@ import { computed } from '@ember/object';
 import { supportedAuthBackends } from 'vault/helpers/supported-auth-backends';
 import { task, timeout } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
+import { v4 as uuidv4 } from 'uuid';
 
 const BACKENDS = supportedAuthBackends();
 
@@ -307,7 +308,7 @@ export default Component.extend(DEFAULTS, {
       }
       // add nonce field for okta backend
       if (backend.type === 'okta') {
-        data.nonce = crypto.randomUUID();
+        data.nonce = uuidv4();
         // add a default path of okta if it doesn't exist to be used for Okta Number Challenge
         if (!data.path) {
           data.path = 'okta';

--- a/ui/app/utils/identity-manager.js
+++ b/ui/app/utils/identity-manager.js
@@ -12,11 +12,19 @@ export default class {
    * @public
    */
   fetch() {
-    let uuid = crypto.randomUUID();
-    // odds are incredibly low that we'll run into a duplicate using crypto.randomUUID()
-    // but just to be safe...
-    while (this.ids.has(uuid)) {
+    let uuid;
+    // check if we can use crypto
+    if (isSecureContext) {
       uuid = crypto.randomUUID();
+      // odds are incredibly low that we'll run into a duplicate using crypto.randomUUID()
+      // but just to be safe...
+      while (this.ids.has(uuid)) {
+        uuid = crypto.randomUUID();
+      }
+    } else {
+      // fallback to incrementing id based on set size
+      // initial size will be 0 so first id will be 1
+      uuid = this.ids.size + 1;
     }
     this.ids.add(uuid);
     return uuid;

--- a/ui/app/utils/identity-manager.js
+++ b/ui/app/utils/identity-manager.js
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 // manage a set of unique ids
 export default class {
   constructor() {
@@ -12,19 +14,10 @@ export default class {
    * @public
    */
   fetch() {
-    let uuid;
-    // check if we can use crypto
-    if (isSecureContext) {
-      uuid = crypto.randomUUID();
-      // odds are incredibly low that we'll run into a duplicate using crypto.randomUUID()
-      // but just to be safe...
-      while (this.ids.has(uuid)) {
-        uuid = crypto.randomUUID();
-      }
-    } else {
-      // fallback to incrementing id based on set size
-      // initial size will be 0 so first id will be 1
-      uuid = this.ids.size + 1;
+    let uuid = uuidv4();
+    // odds are incredibly low that we'll run into a duplicate but just to be safe...
+    while (this.ids.has(uuid)) {
+      uuid = uuidv4();
     }
     this.ids.add(uuid);
     return uuid;

--- a/ui/package.json
+++ b/ui/package.json
@@ -256,6 +256,7 @@
     "highlight.js": "^10.4.1",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.13",
-    "node-notifier": "^8.0.1"
+    "node-notifier": "^8.0.1",
+    "uuid": "^9.0.0"
   }
 }

--- a/ui/tests/unit/serializers/cluster-test.js
+++ b/ui/tests/unit/serializers/cluster-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { validate } from 'uuid';
+
+module('Unit | Serializer | cluster', function (hooks) {
+  setupTest(hooks);
+
+  test('it should generate ids for replication attributes', async function (assert) {
+    const serializer = this.owner.lookup('serializer:cluster');
+    const data = {};
+    serializer.setReplicationId(data);
+    assert.true(validate(data.id), 'UUID is generated for replication attribute');
+  });
+});

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -18579,6 +18579,11 @@ uuid@^8.3.0, uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"


### PR DESCRIPTION
This PR removes `crypto` and adds the [uuid](https://github.com/uuidjs/uuid) package since crypto is only available in secure contexts.

`crytpo.randomUUID()` was used to set an id for `dr` and `performance` replication attribute records returned on the cluster since there is no unique key for Ember Data to store the record. It was also used for the `nonce` value when logging in with the okta auth method when a number challenge is required.