### PR TITLE
UI: Use uuid dependency instead of crypto.randomUUID()

### DIFF
--- a/changelog/19410.txt
+++ b/changelog/19410.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes reliance on secure context (https) by removing methods using the Crypto interface
+```

--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -8,6 +8,7 @@ import { computed } from '@ember/object';
 import { supportedAuthBackends } from 'vault/helpers/supported-auth-backends';
 import { task, timeout } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
+import { v4 as uuidv4 } from 'uuid';
 
 const BACKENDS = supportedAuthBackends();
 
@@ -308,7 +309,7 @@ export default Component.extend(DEFAULTS, {
       }
       // add nonce field for okta backend
       if (backend.type === 'okta') {
-        data.nonce = crypto.randomUUID();
+        data.nonce = uuidv4();
         // add a default path of okta if it doesn't exist to be used for Okta Number Challenge
         if (!data.path) {
           data.path = 'okta';

--- a/ui/package.json
+++ b/ui/package.json
@@ -223,6 +223,7 @@
     "highlight.js": "^10.4.1",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.13",
-    "node-notifier": "^8.0.1"
+    "node-notifier": "^8.0.1",
+    "uuid": "^9.0.0"
   }
 }

--- a/ui/tests/integration/components/auth-form-test.js
+++ b/ui/tests/integration/components/auth-form-test.js
@@ -6,6 +6,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import fetch from 'fetch';
 import sinon from 'sinon';
 import Pretender from 'pretender';
 import { create } from 'ember-cli-page-object';
@@ -13,6 +14,14 @@ import authForm from '../../pages/components/auth-form';
 import { validate } from 'uuid';
 
 const component = create(authForm);
+
+const authService = Service.extend({
+  async authenticate() {
+    return fetch('http://localhost:2000');
+  },
+  handleError() {},
+  setLastFetch() {},
+});
 
 const workingAuthService = Service.extend({
   authenticate() {
@@ -36,25 +45,37 @@ module('Integration | Component | auth form', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
+    this.owner.lookup('service:csp-event').attach();
     this.owner.register('service:router', routerService);
     this.router = this.owner.lookup('service:router');
+  });
+
+  hooks.afterEach(function () {
+    this.owner.lookup('service:csp-event').remove();
   });
 
   const CSP_ERR_TEXT = `Error This is a standby Vault node but can't communicate with the active node via request forwarding. Sign in at the active node to use the Vault UI.`;
   test('it renders error on CSP violation', async function (assert) {
     assert.expect(2);
+    this.owner.unregister('service:auth');
+    this.owner.register('service:auth', authService);
+    this.auth = this.owner.lookup('service:auth');
     this.set('cluster', EmberObject.create({ standby: true }));
     this.set('selectedAuth', 'token');
-    await render(hbs`{{auth-form cluster=this.cluster selectedAuth=this.selectedAuth}}`);
+    await render(hbs`{{auth-form cluster=cluster selectedAuth=selectedAuth}}`);
     assert.false(component.errorMessagePresent, false);
-    this.owner.lookup('service:csp-event').events.addObject({ violatedDirective: 'connect-src' });
-    await settled();
-    assert.strictEqual(component.errorText, CSP_ERR_TEXT);
+    component.login();
+    // because this is an ember-concurrency backed service,
+    // we have to manually force settling the run queue
+    later(() => cancelTimers(), 50);
+    return settled().then(() => {
+      assert.equal(component.errorText, CSP_ERR_TEXT);
+    });
   });
 
   test('it renders with vault style errors', async function (assert) {
     assert.expect(1);
-    const server = new Pretender(function () {
+    let server = new Pretender(function () {
       this.get('/v1/auth/**', () => {
         return [
           400,
@@ -64,56 +85,54 @@ module('Integration | Component | auth form', function (hooks) {
           }),
         ];
       });
-      this.get('/v1/sys/internal/ui/mounts', this.passthrough);
     });
 
     this.set('cluster', EmberObject.create({}));
     this.set('selectedAuth', 'token');
-    await render(hbs`{{auth-form cluster=this.cluster selectedAuth=this.selectedAuth}}`);
+    await render(hbs`{{auth-form cluster=cluster selectedAuth=selectedAuth}}`);
     return component.login().then(() => {
-      assert.strictEqual(component.errorText, 'Error Authentication failed: Not allowed');
+      assert.equal(component.errorText, 'Error Authentication failed: Not allowed');
       server.shutdown();
     });
   });
 
   test('it renders AdapterError style errors', async function (assert) {
     assert.expect(1);
-    const server = new Pretender(function () {
+    let server = new Pretender(function () {
       this.get('/v1/auth/**', () => {
         return [400, { 'Content-Type': 'application/json' }];
       });
-      this.get('/v1/sys/internal/ui/mounts', this.passthrough);
     });
 
     this.set('cluster', EmberObject.create({}));
     this.set('selectedAuth', 'token');
-    await render(hbs`{{auth-form cluster=this.cluster selectedAuth=this.selectedAuth}}`);
+    await render(hbs`{{auth-form cluster=cluster selectedAuth=selectedAuth}}`);
     // ARG TODO research and see if adapter errors changed, but null used to be Bad Request
     return component.login().then(() => {
-      assert.strictEqual(component.errorText, 'Error Authentication failed: null');
+      assert.equal(component.errorText, 'Error Authentication failed: null');
       server.shutdown();
     });
   });
 
   test('it renders no tabs when no methods are passed', async function (assert) {
-    const methods = {
+    let methods = {
       'approle/': {
         type: 'approle',
       },
     };
-    const server = new Pretender(function () {
+    let server = new Pretender(function () {
       this.get('/v1/sys/internal/ui/mounts', () => {
         return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: { auth: methods } })];
       });
     });
-    await render(hbs`<AuthForm @cluster={{this.cluster}} />`);
+    await render(hbs`<AuthForm @cluster={{cluster}} />`);
 
-    assert.strictEqual(component.tabs.length, 0, 'renders a tab for every backend');
+    assert.equal(component.tabs.length, 0, 'renders a tab for every backend');
     server.shutdown();
   });
 
   test('it renders all the supported methods and Other tab when methods are present', async function (assert) {
-    const methods = {
+    let methods = {
       'foo/': {
         type: 'userpass',
       },
@@ -121,41 +140,37 @@ module('Integration | Component | auth form', function (hooks) {
         type: 'approle',
       },
     };
-    const server = new Pretender(function () {
+    let server = new Pretender(function () {
       this.get('/v1/sys/internal/ui/mounts', () => {
         return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: { auth: methods } })];
       });
     });
 
     this.set('cluster', EmberObject.create({}));
-    await render(hbs`{{auth-form cluster=this.cluster }}`);
+    await render(hbs`{{auth-form cluster=cluster }}`);
 
-    assert.strictEqual(component.tabs.length, 2, 'renders a tab for userpass and Other');
-    assert.strictEqual(component.tabs.objectAt(0).name, 'foo', 'uses the path in the label');
-    assert.strictEqual(component.tabs.objectAt(1).name, 'Other', 'second tab is the Other tab');
+    assert.equal(component.tabs.length, 2, 'renders a tab for userpass and Other');
+    assert.equal(component.tabs.objectAt(0).name, 'foo', 'uses the path in the label');
+    assert.equal(component.tabs.objectAt(1).name, 'Other', 'second tab is the Other tab');
     server.shutdown();
   });
 
   test('it renders the description', async function (assert) {
-    const methods = {
+    let methods = {
       'approle/': {
         type: 'userpass',
         description: 'app description',
       },
     };
-    const server = new Pretender(function () {
+    let server = new Pretender(function () {
       this.get('/v1/sys/internal/ui/mounts', () => {
         return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: { auth: methods } })];
       });
     });
     this.set('cluster', EmberObject.create({}));
-    await render(hbs`{{auth-form cluster=this.cluster }}`);
+    await render(hbs`{{auth-form cluster=cluster }}`);
 
-    assert.strictEqual(
-      component.descriptionText,
-      'app description',
-      'renders a description for auth methods'
-    );
+    assert.equal(component.descriptionText, 'app description', 'renders a description for auth methods');
     server.shutdown();
   });
 
@@ -163,13 +178,13 @@ module('Integration | Component | auth form', function (hooks) {
     this.owner.unregister('service:auth');
     this.owner.register('service:auth', workingAuthService);
     this.auth = this.owner.lookup('service:auth');
-    const authSpy = sinon.spy(this.auth, 'authenticate');
-    const methods = {
+    let authSpy = sinon.spy(this.auth, 'authenticate');
+    let methods = {
       'foo/': {
         type: 'userpass',
       },
     };
-    const server = new Pretender(function () {
+    let server = new Pretender(function () {
       this.get('/v1/sys/internal/ui/mounts', () => {
         return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: { auth: methods } })];
       });
@@ -177,40 +192,40 @@ module('Integration | Component | auth form', function (hooks) {
 
     this.set('cluster', EmberObject.create({}));
     this.set('selectedAuth', 'foo/');
-    await render(hbs`{{auth-form cluster=this.cluster selectedAuth=this.selectedAuth}}`);
+    await render(hbs`{{auth-form cluster=cluster selectedAuth=selectedAuth}}`);
     await component.login();
 
     await settled();
     assert.ok(authSpy.calledOnce, 'a call to authenticate was made');
-    const { data } = authSpy.getCall(0).args[0];
-    assert.strictEqual(data.path, 'foo', 'uses the id for the path');
+    let { data } = authSpy.getCall(0).args[0];
+    assert.equal(data.path, 'foo', 'uses the id for the path');
     authSpy.restore();
     server.shutdown();
   });
 
   test('it renders no tabs when no supported methods are present in passed methods', async function (assert) {
-    const methods = {
+    let methods = {
       'approle/': {
         type: 'approle',
       },
     };
-    const server = new Pretender(function () {
+    let server = new Pretender(function () {
       this.get('/v1/sys/internal/ui/mounts', () => {
         return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: { auth: methods } })];
       });
     });
     this.set('cluster', EmberObject.create({}));
-    await render(hbs`<AuthForm @cluster={{this.cluster}} />`);
+    await render(hbs`<AuthForm @cluster={{cluster}} />`);
 
     server.shutdown();
-    assert.strictEqual(component.tabs.length, 0, 'renders a tab for every backend');
+    assert.equal(component.tabs.length, 0, 'renders a tab for every backend');
   });
 
   test('it makes a request to unwrap if passed a wrappedToken and logs in', async function (assert) {
     this.owner.register('service:auth', workingAuthService);
     this.auth = this.owner.lookup('service:auth');
-    const authSpy = sinon.spy(this.auth, 'authenticate');
-    const server = new Pretender(function () {
+    let authSpy = sinon.spy(this.auth, 'authenticate');
+    let server = new Pretender(function () {
       this.post('/v1/sys/wrapping/unwrap', () => {
         return [
           200,
@@ -224,18 +239,14 @@ module('Integration | Component | auth form', function (hooks) {
       });
     });
 
-    const wrappedToken = '54321';
+    let wrappedToken = '54321';
     this.set('wrappedToken', wrappedToken);
     this.set('cluster', EmberObject.create({}));
-    await render(hbs`<AuthForm @cluster={{this.cluster}} @wrappedToken={{this.wrappedToken}} />`);
+    await render(hbs`<AuthForm @cluster={{cluster}} @wrappedToken={{wrappedToken}} />`);
     later(() => cancelTimers(), 50);
     await settled();
-    assert.strictEqual(
-      server.handledRequests[0].url,
-      '/v1/sys/wrapping/unwrap',
-      'makes call to unwrap the token'
-    );
-    assert.strictEqual(
+    assert.equal(server.handledRequests[0].url, '/v1/sys/wrapping/unwrap', 'makes call to unwrap the token');
+    assert.equal(
       server.handledRequests[0].requestHeaders['X-Vault-Token'],
       wrappedToken,
       'uses passed wrapped token for the unwrap'
@@ -246,7 +257,7 @@ module('Integration | Component | auth form', function (hooks) {
   });
 
   test('it shows an error if unwrap errors', async function (assert) {
-    const server = new Pretender(function () {
+    let server = new Pretender(function () {
       this.post('/v1/sys/wrapping/unwrap', () => {
         return [
           400,
@@ -259,11 +270,11 @@ module('Integration | Component | auth form', function (hooks) {
     });
 
     this.set('wrappedToken', '54321');
-    await render(hbs`{{auth-form cluster=this.cluster wrappedToken=this.wrappedToken}}`);
+    await render(hbs`{{auth-form cluster=cluster wrappedToken=wrappedToken}}`);
     later(() => cancelTimers(), 50);
 
     await settled();
-    assert.strictEqual(
+    assert.equal(
       component.errorText,
       'Error Token unwrap failed: There was an error unwrapping!',
       'shows the error'

--- a/ui/tests/integration/components/auth-form-test.js
+++ b/ui/tests/integration/components/auth-form-test.js
@@ -6,21 +6,13 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import fetch from 'fetch';
 import sinon from 'sinon';
 import Pretender from 'pretender';
 import { create } from 'ember-cli-page-object';
 import authForm from '../../pages/components/auth-form';
+import { validate } from 'uuid';
 
 const component = create(authForm);
-
-const authService = Service.extend({
-  async authenticate() {
-    return fetch('http://localhost:2000');
-  },
-  handleError() {},
-  setLastFetch() {},
-});
 
 const workingAuthService = Service.extend({
   authenticate() {
@@ -44,37 +36,25 @@ module('Integration | Component | auth form', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    this.owner.lookup('service:csp-event').attach();
     this.owner.register('service:router', routerService);
     this.router = this.owner.lookup('service:router');
-  });
-
-  hooks.afterEach(function () {
-    this.owner.lookup('service:csp-event').remove();
   });
 
   const CSP_ERR_TEXT = `Error This is a standby Vault node but can't communicate with the active node via request forwarding. Sign in at the active node to use the Vault UI.`;
   test('it renders error on CSP violation', async function (assert) {
     assert.expect(2);
-    this.owner.unregister('service:auth');
-    this.owner.register('service:auth', authService);
-    this.auth = this.owner.lookup('service:auth');
     this.set('cluster', EmberObject.create({ standby: true }));
     this.set('selectedAuth', 'token');
-    await render(hbs`{{auth-form cluster=cluster selectedAuth=selectedAuth}}`);
+    await render(hbs`{{auth-form cluster=this.cluster selectedAuth=this.selectedAuth}}`);
     assert.false(component.errorMessagePresent, false);
-    component.login();
-    // because this is an ember-concurrency backed service,
-    // we have to manually force settling the run queue
-    later(() => cancelTimers(), 50);
-    return settled().then(() => {
-      assert.equal(component.errorText, CSP_ERR_TEXT);
-    });
+    this.owner.lookup('service:csp-event').events.addObject({ violatedDirective: 'connect-src' });
+    await settled();
+    assert.strictEqual(component.errorText, CSP_ERR_TEXT);
   });
 
   test('it renders with vault style errors', async function (assert) {
     assert.expect(1);
-    let server = new Pretender(function () {
+    const server = new Pretender(function () {
       this.get('/v1/auth/**', () => {
         return [
           400,
@@ -84,54 +64,56 @@ module('Integration | Component | auth form', function (hooks) {
           }),
         ];
       });
+      this.get('/v1/sys/internal/ui/mounts', this.passthrough);
     });
 
     this.set('cluster', EmberObject.create({}));
     this.set('selectedAuth', 'token');
-    await render(hbs`{{auth-form cluster=cluster selectedAuth=selectedAuth}}`);
+    await render(hbs`{{auth-form cluster=this.cluster selectedAuth=this.selectedAuth}}`);
     return component.login().then(() => {
-      assert.equal(component.errorText, 'Error Authentication failed: Not allowed');
+      assert.strictEqual(component.errorText, 'Error Authentication failed: Not allowed');
       server.shutdown();
     });
   });
 
   test('it renders AdapterError style errors', async function (assert) {
     assert.expect(1);
-    let server = new Pretender(function () {
+    const server = new Pretender(function () {
       this.get('/v1/auth/**', () => {
         return [400, { 'Content-Type': 'application/json' }];
       });
+      this.get('/v1/sys/internal/ui/mounts', this.passthrough);
     });
 
     this.set('cluster', EmberObject.create({}));
     this.set('selectedAuth', 'token');
-    await render(hbs`{{auth-form cluster=cluster selectedAuth=selectedAuth}}`);
+    await render(hbs`{{auth-form cluster=this.cluster selectedAuth=this.selectedAuth}}`);
     // ARG TODO research and see if adapter errors changed, but null used to be Bad Request
     return component.login().then(() => {
-      assert.equal(component.errorText, 'Error Authentication failed: null');
+      assert.strictEqual(component.errorText, 'Error Authentication failed: null');
       server.shutdown();
     });
   });
 
   test('it renders no tabs when no methods are passed', async function (assert) {
-    let methods = {
+    const methods = {
       'approle/': {
         type: 'approle',
       },
     };
-    let server = new Pretender(function () {
+    const server = new Pretender(function () {
       this.get('/v1/sys/internal/ui/mounts', () => {
         return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: { auth: methods } })];
       });
     });
-    await render(hbs`<AuthForm @cluster={{cluster}} />`);
+    await render(hbs`<AuthForm @cluster={{this.cluster}} />`);
 
-    assert.equal(component.tabs.length, 0, 'renders a tab for every backend');
+    assert.strictEqual(component.tabs.length, 0, 'renders a tab for every backend');
     server.shutdown();
   });
 
   test('it renders all the supported methods and Other tab when methods are present', async function (assert) {
-    let methods = {
+    const methods = {
       'foo/': {
         type: 'userpass',
       },
@@ -139,37 +121,41 @@ module('Integration | Component | auth form', function (hooks) {
         type: 'approle',
       },
     };
-    let server = new Pretender(function () {
+    const server = new Pretender(function () {
       this.get('/v1/sys/internal/ui/mounts', () => {
         return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: { auth: methods } })];
       });
     });
 
     this.set('cluster', EmberObject.create({}));
-    await render(hbs`{{auth-form cluster=cluster }}`);
+    await render(hbs`{{auth-form cluster=this.cluster }}`);
 
-    assert.equal(component.tabs.length, 2, 'renders a tab for userpass and Other');
-    assert.equal(component.tabs.objectAt(0).name, 'foo', 'uses the path in the label');
-    assert.equal(component.tabs.objectAt(1).name, 'Other', 'second tab is the Other tab');
+    assert.strictEqual(component.tabs.length, 2, 'renders a tab for userpass and Other');
+    assert.strictEqual(component.tabs.objectAt(0).name, 'foo', 'uses the path in the label');
+    assert.strictEqual(component.tabs.objectAt(1).name, 'Other', 'second tab is the Other tab');
     server.shutdown();
   });
 
   test('it renders the description', async function (assert) {
-    let methods = {
+    const methods = {
       'approle/': {
         type: 'userpass',
         description: 'app description',
       },
     };
-    let server = new Pretender(function () {
+    const server = new Pretender(function () {
       this.get('/v1/sys/internal/ui/mounts', () => {
         return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: { auth: methods } })];
       });
     });
     this.set('cluster', EmberObject.create({}));
-    await render(hbs`{{auth-form cluster=cluster }}`);
+    await render(hbs`{{auth-form cluster=this.cluster }}`);
 
-    assert.equal(component.descriptionText, 'app description', 'renders a description for auth methods');
+    assert.strictEqual(
+      component.descriptionText,
+      'app description',
+      'renders a description for auth methods'
+    );
     server.shutdown();
   });
 
@@ -177,13 +163,13 @@ module('Integration | Component | auth form', function (hooks) {
     this.owner.unregister('service:auth');
     this.owner.register('service:auth', workingAuthService);
     this.auth = this.owner.lookup('service:auth');
-    let authSpy = sinon.spy(this.auth, 'authenticate');
-    let methods = {
+    const authSpy = sinon.spy(this.auth, 'authenticate');
+    const methods = {
       'foo/': {
         type: 'userpass',
       },
     };
-    let server = new Pretender(function () {
+    const server = new Pretender(function () {
       this.get('/v1/sys/internal/ui/mounts', () => {
         return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: { auth: methods } })];
       });
@@ -191,40 +177,40 @@ module('Integration | Component | auth form', function (hooks) {
 
     this.set('cluster', EmberObject.create({}));
     this.set('selectedAuth', 'foo/');
-    await render(hbs`{{auth-form cluster=cluster selectedAuth=selectedAuth}}`);
+    await render(hbs`{{auth-form cluster=this.cluster selectedAuth=this.selectedAuth}}`);
     await component.login();
 
     await settled();
     assert.ok(authSpy.calledOnce, 'a call to authenticate was made');
-    let { data } = authSpy.getCall(0).args[0];
-    assert.equal(data.path, 'foo', 'uses the id for the path');
+    const { data } = authSpy.getCall(0).args[0];
+    assert.strictEqual(data.path, 'foo', 'uses the id for the path');
     authSpy.restore();
     server.shutdown();
   });
 
   test('it renders no tabs when no supported methods are present in passed methods', async function (assert) {
-    let methods = {
+    const methods = {
       'approle/': {
         type: 'approle',
       },
     };
-    let server = new Pretender(function () {
+    const server = new Pretender(function () {
       this.get('/v1/sys/internal/ui/mounts', () => {
         return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: { auth: methods } })];
       });
     });
     this.set('cluster', EmberObject.create({}));
-    await render(hbs`<AuthForm @cluster={{cluster}} />`);
+    await render(hbs`<AuthForm @cluster={{this.cluster}} />`);
 
     server.shutdown();
-    assert.equal(component.tabs.length, 0, 'renders a tab for every backend');
+    assert.strictEqual(component.tabs.length, 0, 'renders a tab for every backend');
   });
 
   test('it makes a request to unwrap if passed a wrappedToken and logs in', async function (assert) {
     this.owner.register('service:auth', workingAuthService);
     this.auth = this.owner.lookup('service:auth');
-    let authSpy = sinon.spy(this.auth, 'authenticate');
-    let server = new Pretender(function () {
+    const authSpy = sinon.spy(this.auth, 'authenticate');
+    const server = new Pretender(function () {
       this.post('/v1/sys/wrapping/unwrap', () => {
         return [
           200,
@@ -238,14 +224,18 @@ module('Integration | Component | auth form', function (hooks) {
       });
     });
 
-    let wrappedToken = '54321';
+    const wrappedToken = '54321';
     this.set('wrappedToken', wrappedToken);
     this.set('cluster', EmberObject.create({}));
-    await render(hbs`<AuthForm @cluster={{cluster}} @wrappedToken={{wrappedToken}} />`);
+    await render(hbs`<AuthForm @cluster={{this.cluster}} @wrappedToken={{this.wrappedToken}} />`);
     later(() => cancelTimers(), 50);
     await settled();
-    assert.equal(server.handledRequests[0].url, '/v1/sys/wrapping/unwrap', 'makes call to unwrap the token');
-    assert.equal(
+    assert.strictEqual(
+      server.handledRequests[0].url,
+      '/v1/sys/wrapping/unwrap',
+      'makes call to unwrap the token'
+    );
+    assert.strictEqual(
       server.handledRequests[0].requestHeaders['X-Vault-Token'],
       wrappedToken,
       'uses passed wrapped token for the unwrap'
@@ -256,7 +246,7 @@ module('Integration | Component | auth form', function (hooks) {
   });
 
   test('it shows an error if unwrap errors', async function (assert) {
-    let server = new Pretender(function () {
+    const server = new Pretender(function () {
       this.post('/v1/sys/wrapping/unwrap', () => {
         return [
           400,
@@ -269,11 +259,11 @@ module('Integration | Component | auth form', function (hooks) {
     });
 
     this.set('wrappedToken', '54321');
-    await render(hbs`{{auth-form cluster=cluster wrappedToken=wrappedToken}}`);
+    await render(hbs`{{auth-form cluster=this.cluster wrappedToken=this.wrappedToken}}`);
     later(() => cancelTimers(), 50);
 
     await settled();
-    assert.equal(
+    assert.strictEqual(
       component.errorText,
       'Error Token unwrap failed: There was an error unwrapping!',
       'shows the error'
@@ -321,6 +311,37 @@ module('Integration | Component | auth form', function (hooks) {
     await component.oidcRole('foo');
     await component.oidcMoreOptions();
     await component.oidcMountPath('foo-oidc');
+    await component.login();
+
+    server.shutdown();
+  });
+
+  test('it should set nonce value as uuid for okta method type', async function (assert) {
+    assert.expect(1);
+
+    const server = new Pretender(function () {
+      this.post('/v1/auth/okta/login/foo', (req) => {
+        const { nonce } = JSON.parse(req.requestBody);
+        assert.true(validate(nonce), 'Nonce value passed as uuid for okta login');
+        return [
+          200,
+          { 'content-type': 'application/json' },
+          JSON.stringify({
+            auth: {
+              client_token: '12345',
+            },
+          }),
+        ];
+      });
+      this.get('/v1/sys/internal/ui/mounts', this.passthrough);
+    });
+
+    this.set('cluster', EmberObject.create({}));
+    await render(hbs`<AuthForm @cluster={{this.cluster}} />`);
+
+    await component.selectMethod('okta');
+    await component.username('foo');
+    await component.password('bar');
     await component.login();
 
     server.shutdown();

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -17379,6 +17379,11 @@ uuid@^8.3.0, uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"


### PR DESCRIPTION
Similar to the changes made in #19403

This PR removes using the crypto interface which requires secure context [MDN docs here](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) and adds the [uuid](https://github.com/uuidjs/uuid) package since crypto is only available in secure contexts.

