### PR TITLE
openapi: Add display attributes for Consul

### DIFF
--- a/builtin/logical/consul/backend.go
+++ b/builtin/logical/consul/backend.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+const operationPrefixConsul = "consul"
+
 // ReportedVersion is used to report a specific version to Vault.
 var ReportedVersion = ""
 

--- a/builtin/logical/consul/path_config.go
+++ b/builtin/logical/consul/path_config.go
@@ -12,6 +12,12 @@ import (
 func pathConfigAccess(b *backend) *framework.Path {
 	return &framework.Path{
 		Pattern: "config/access",
+
+		DisplayAttrs: &framework.DisplayAttributes{
+			OperationPrefix: operationPrefixConsul,
+			OperationSuffix: "access-config",
+		},
+
 		Fields: map[string]*framework.FieldSchema{
 			"address": {
 				Type:        framework.TypeString,

--- a/builtin/logical/consul/path_roles.go
+++ b/builtin/logical/consul/path_roles.go
@@ -14,6 +14,11 @@ func pathListRoles(b *backend) *framework.Path {
 	return &framework.Path{
 		Pattern: "roles/?$",
 
+		DisplayAttrs: &framework.DisplayAttributes{
+			OperationPrefix: operationPrefixConsul,
+			OperationSuffix: "roles",
+		},
+
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.ListOperation: b.pathRoleList,
 		},
@@ -23,6 +28,12 @@ func pathListRoles(b *backend) *framework.Path {
 func pathRoles(b *backend) *framework.Path {
 	return &framework.Path{
 		Pattern: "roles/" + framework.GenericNameRegex("name"),
+
+		DisplayAttrs: &framework.DisplayAttributes{
+			OperationPrefix: operationPrefixConsul,
+			OperationSuffix: "role",
+		},
+
 		Fields: map[string]*framework.FieldSchema{
 			"name": {
 				Type:        framework.TypeString,

--- a/builtin/logical/consul/path_token.go
+++ b/builtin/logical/consul/path_token.go
@@ -18,6 +18,13 @@ const (
 func pathToken(b *backend) *framework.Path {
 	return &framework.Path{
 		Pattern: "creds/" + framework.GenericNameRegex("role"),
+
+		DisplayAttrs: &framework.DisplayAttributes{
+			OperationPrefix: operationPrefixConsul,
+			OperationVerb:   "generate",
+			OperationSuffix: "credentials",
+		},
+
 		Fields: map[string]*framework.FieldSchema{
 			"role": {
 				Type:        framework.TypeString,


### PR DESCRIPTION
Please see https://github.com/hashicorp/vault/pull/19319 for more details on how this will affect the generated OpenAPI schema.

____

### The following OperationID's will be generated for Consul auth:

consul-delete-role
consul-generate-credentials
consul-list-roles
consul-read-access-config
consul-read-role
consul-write-access-config
consul-write-role