### PR TITLE
Fix cubbyhole and token revocation for legacy service tokens

### DIFF
--- a/changelog/19416.txt
+++ b/changelog/19416.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/token: Fix cubbyhole and revocation for legacy service tokens
+```

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -1105,7 +1105,7 @@ func (ts *TokenStore) create(ctx context.Context, entry *logical.TokenEntry) err
 			entry.ID = fmt.Sprintf("%s.%s", entry.ID, tokenNS.ID)
 		}
 
-		if tokenNS.ID != namespace.RootNamespaceID || strings.HasPrefix(entry.ID, consts.ServiceTokenPrefix) {
+		if tokenNS.ID != namespace.RootNamespaceID || strings.HasPrefix(entry.ID, consts.ServiceTokenPrefix) || strings.HasPrefix(entry.ID, consts.LegacyServiceTokenPrefix) {
 			if entry.CubbyholeID == "" {
 				cubbyholeID, err := base62.Random(TokenLength)
 				if err != nil {

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -50,11 +50,15 @@ func TestTokenStore_CreateOrphanResponse(t *testing.T) {
 	}
 }
 
+// TestTokenStore_CubbyholeDeletion tests that a token's cubbyhole
+// can be used and that the cubbyhole is removed after the token is revoked.
 func TestTokenStore_CubbyholeDeletion(t *testing.T) {
 	c, _, root := TestCoreUnsealed(t)
 	testTokenStore_CubbyholeDeletion(t, c, root)
 }
 
+// TestTokenStore_CubbyholeDeletionSSCTokensDisabled tests that a legacy token's
+// cubbyhole can be used, and that the cubbyhole is removed after the token is revoked.
 func TestTokenStore_CubbyholeDeletionSSCTokensDisabled(t *testing.T) {
 	c, _, root := TestCoreUnsealed(t)
 	c.disableSSCTokens = true

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -52,6 +52,16 @@ func TestTokenStore_CreateOrphanResponse(t *testing.T) {
 
 func TestTokenStore_CubbyholeDeletion(t *testing.T) {
 	c, _, root := TestCoreUnsealed(t)
+	testTokenStore_CubbyholeDeletion(t, c, root)
+}
+
+func TestTokenStore_CubbyholeDeletionSSCTokensDisabled(t *testing.T) {
+	c, _, root := TestCoreUnsealed(t)
+	c.disableSSCTokens = true
+	testTokenStore_CubbyholeDeletion(t, c, root)
+}
+
+func testTokenStore_CubbyholeDeletion(t *testing.T, c *Core, root string) {
 	ts := c.tokenStore
 
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
Legacy service tokens generated in Vault 1.10+ with env var `VAULT_DISABLE_SERVER_SIDE_CONSISTENT_TOKENS=true` are not assigned a cubbyhole ID. The implication is that `cubbyhole/` cannot be used, nor can the tokens be revoked.

This commit assigns a cubbyhole ID to these tokens and adds a new test case to see that cubbyhole and revocation works correctly.

Fixes #18304