### PR TITLE
Configure Ember Data ID Generation

### DIFF
--- a/ui/app/initializers/ember-data-identifiers.js
+++ b/ui/app/initializers/ember-data-identifiers.js
@@ -1,0 +1,17 @@
+import { setIdentifierGenerationMethod } from '@ember-data/store';
+import { v4 as uuidv4 } from 'uuid';
+
+export function initialize() {
+  // see this GH issue for more information https://github.com/emberjs/data/issues/8106
+  // Ember Data uses uuidv4 library to generate ids which relies on the crypto API which is no available in unsecure contexts
+  // the suggested polyfill is not working so we need to define our own id generation method
+  // the uuid library was brought in to replace other usages of crypto in the app so it is safe to use
+  setIdentifierGenerationMethod((resource) => {
+    return resource.lid || uuidv4();
+  });
+}
+
+export default {
+  name: 'ember-data-identifiers',
+  initialize,
+};


### PR DESCRIPTION
Ember Data started using the uuidv4 library for ID generation which uses `crypto.getRandomUUID` which is not available in unsecure contexts. There was a polyfill added in `4.6.2`, but until we can upgrade an initializer was added to configure the id generation method using the `uuid` library which was brought in to replace `crypto` in our codebase.