### PR TITLE
update entity-alias doc fix

### DIFF
--- a/website/content/api-docs/secret/identity/entity-alias.mdx
+++ b/website/content/api-docs/secret/identity/entity-alias.mdx
@@ -135,14 +135,14 @@ This endpoint is used to update an existing entity alias.
 
 - `id` `(string: <required>)` – Identifier of the entity alias.
 
-- `name` `(string: <required>)` - Name of the alias. Name should be the identifier
+- `name` `(string: "")` - Name of the alias. Name should be the identifier
   of the client in the authentication source. For example, if the alias belongs
   to userpass backend, the name should be a valid username within userpass
   backend. If alias belongs to GitHub, it should be the GitHub username.
 
-- `canonical_id` `(string: <required>)` - Entity ID to which this alias belongs to.
+- `canonical_id` `(string: "")` - Entity ID to which this alias belongs to.
 
-- `mount_accessor` `(string: <required>)` - Accessor of the mount to which the
+- `mount_accessor` `(string: "")` - Accessor of the mount to which the
   alias should belong to.
 
 - `custom_metadata` `(map<string|string>: <optional>)` - A map of arbitrary string to string valued 


### PR DESCRIPTION
The `name`, `canonical_id`, and `mount_accessor` parameters are not required parameters for updating a entity-alias.

Example:
```
~ vault status -format=json | jq -r '.version'
1.12.2+ent

~ vault read -field=mount_accessor identity/entity-alias/id/$AID 
auth_userpass_29867988

~ vault write identity/entity-alias/id/$AID mount_accessor=$MA2
Key             Value
---             -----
canonical_id    fd098313-4019-c7f1-de82-7fce975bf096
id              b19fe0ef-2aa6-6a44-c103-0d5c92a234cc

~ vault read -field=mount_accessor identity/entity-alias/id/$AID 
auth_userpass_be3e3761
```