### PR TITLE
Docs - update ldap page to add clarity around sAMAccountName

### DIFF
--- a/website/content/docs/secrets/ldap.mdx
+++ b/website/content/docs/secrets/ldap.mdx
@@ -225,7 +225,7 @@ password and enable the account.
 Windows NT systems and has a limit of 20 characters. Keep this in mind when defining your `username_template`.
 See [here](https://docs.microsoft.com/en-us/windows/win32/adschema/a-samaccountname) for additional details.
 
-Since the default `username_template` is longer than 20 characters which follows the template of `v_{{.DisplayName}}_{{.RoleName}}_{{random 10}}_{{unix_time}}`, we recommend customising the `username_template` on the role configuration to generate accounts with names less than 20 characters. Please refer to the [username templating document](https://developer.hashicorp.com/vault/docs/concepts/username-templating) for more information.
+Since the default `username_template` is longer than 20 characters which follows the template of `v_{{.DisplayName}}_{{.RoleName}}_{{random 10}}_{{unix_time}}`, we recommend customising the `username_template` on the role configuration to generate accounts with names less than 20 characters. Please refer to the [username templating document](/vault/docs/concepts/username-templating) for more information.
 
 With regard to adding dynamic users to groups, AD doesn't let you directly modify a user's `memberOf` attribute.
 The `member` attribute of a group and `memberOf` attribute of a user are

--- a/website/content/docs/secrets/ldap.mdx
+++ b/website/content/docs/secrets/ldap.mdx
@@ -225,6 +225,8 @@ password and enable the account.
 Windows NT systems and has a limit of 20 characters. Keep this in mind when defining your `username_template`.
 See [here](https://docs.microsoft.com/en-us/windows/win32/adschema/a-samaccountname) for additional details.
 
+Since the default `username_template` is longer than 20 characters which follows the template of `v_{{.DisplayName}}_{{.RoleName}}_{{random 10}}_{{unix_time}}`, we recommend customising the `username_template` on the role configuration to generate accounts with names less than 20 characters. Please refer to the [username templating document](https://developer.hashicorp.com/vault/docs/concepts/username-templating) for more information.
+
 With regard to adding dynamic users to groups, AD doesn't let you directly modify a user's `memberOf` attribute.
 The `member` attribute of a group and `memberOf` attribute of a user are
 [linked attributes](https://docs.microsoft.com/en-us/windows/win32/ad/linked-attributes). Linked attributes are


### PR DESCRIPTION
Updated https://developer.hashicorp.com/vault/docs/secrets/ldap#active-directory-ad-1 to clarify customers configure username properly using username_template when sAMAccountName is involved.

Preview of changes: https://vault-bmlno4dzn-hashicorp.vercel.app/vault/docs/secrets/ldap#active-directory-ad-1