### PR TITLE
Add more context on the Release Notes landing page

### DIFF
--- a/website/content/docs/release-notes/index.mdx
+++ b/website/content/docs/release-notes/index.mdx
@@ -13,5 +13,5 @@ of the major software packages in the Vault product line.
 
 Please refer to the
 [Changelog](https://github.com/hashicorp/vault/blob/main/CHANGELOG.md) for
-further information on product improvements including a comprehensive list of
+further information on product improvements, including a comprehensive list of
 bug fixes.

--- a/website/content/docs/release-notes/index.mdx
+++ b/website/content/docs/release-notes/index.mdx
@@ -7,3 +7,11 @@ description: Release notes for new Vault versions.
 # Release Notes
 
 Release notes describe major updates in new versions of Vault.
+
+Choose a version from the navigation sidebar to view the release notes for each
+of the major software packages in the Vault product line.
+
+Please refer to the
+[Changelog](https://github.com/hashicorp/vault/blob/main/CHANGELOG.md) for
+further information on product improvements including a comprehensive list of
+bug fixes.


### PR DESCRIPTION
🧵 [Slack thread](https://hashicorp.slack.com/archives/C012RTGJR1V/p1677809199484109)
🎫 [Zendesk ticket](https://hashicorp.slack.com/archives/C012RTGJR1V/p1677809199484109)

🔍 [Deploy preview](https://vault-git-docs-update-rn-landing-page-hashicorp.vercel.app/vault/docs/release-notes)


A customer feedback says the [Release Notes landing page](https://developer.hashicorp.com/vault/docs/release-notes) is empty (one sentence, so it feels empty?). So, I'm adding little more text.

![image](https://user-images.githubusercontent.com/7660718/222822363-2d6ededb-3e60-49e8-a3ba-5c2b6edc7176.png)





