### PR TITLE
Regression bug fix OIDC namespace

### DIFF
--- a/changelog/19460.txt
+++ b/changelog/19460.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Add back native API URLSearchParams for issue with namespace and OIDC login.
+```

--- a/ui/app/routes/vault/cluster/oidc-callback.js
+++ b/ui/app/routes/vault/cluster/oidc-callback.js
@@ -6,7 +6,15 @@ export default Route.extend({
     // left blank so we render the template immediately
   },
   afterModel() {
-    let { auth_path: path, code, state } = this.paramsFor(this.routeName);
+    const queryString = decodeURIComponent(window.location.search);
+    // Since state param can also contain namespace, fetch the values using native url api.
+    // For instance, state params value can be state=st_123456,ns=d4fq
+    // Ember paramsFor will strip out the value after the "=" sign.
+    const urlParams = new URLSearchParams(queryString);
+    let state = urlParams.get('state');
+    const code = urlParams.get('code');
+
+    let { auth_path: path } = this.paramsFor(this.routeName);
     let { namespaceQueryParam: namespace } = this.paramsFor('vault.cluster');
     // only replace namespace param from cluster if state has a namespace
     if (state?.includes(',ns=')) {

--- a/ui/app/routes/vault/cluster/oidc-callback.js
+++ b/ui/app/routes/vault/cluster/oidc-callback.js
@@ -6,19 +6,18 @@ export default Route.extend({
     // left blank so we render the template immediately
   },
   afterModel() {
-    const queryString = decodeURIComponent(window.location.search);
-    // Since state param can also contain namespace, fetch the values using native url api.
-    // For instance, state params value can be state=st_123456,ns=d4fq
-    // Ember paramsFor will strip out the value after the "=" sign.
-    const urlParams = new URLSearchParams(queryString);
-    let state = urlParams.get('state');
-    const code = urlParams.get('code');
-
-    let { auth_path: path } = this.paramsFor(this.routeName);
+    let { auth_path: path, code, state } = this.paramsFor(this.routeName);
     let { namespaceQueryParam: namespace } = this.paramsFor('vault.cluster');
-    // only replace namespace param from cluster if state has a namespace
+    // namespace from state takes precedence over the cluster's ns
     if (state?.includes(',ns=')) {
       [state, namespace] = state.split(',ns=');
+    }
+    // some SSO providers do not return a url-encoded string, check for namespace using URLSearchParams
+    const queryString = decodeURIComponent(window.location.search);
+    const urlParams = new URLSearchParams(queryString);
+    const checkState = urlParams.get('state');
+    if (checkState?.includes(',ns=')) {
+      [state, namespace] = checkState.split(',ns=');
     }
     path = window.decodeURIComponent(path);
     const source = 'oidc-callback'; // required by event listener in auth-jwt component


### PR DESCRIPTION
This is a tricky one. Largely because the environment in which this is failing for a client cannot be reproduced. From the JIRA ticket:
> Unfortunately we have not been able to replicate it yet due to ADFS needing to be set up locally and the configuration is rather difficult.

However, our best guess is that it's a regression bug caused by trying to fix a similar issue in [this PR](https://github.com/hashicorp/vault/pull/16886/files#diff-b3920ec7a8a9e02c3ad323eb540ae241b27907bd763b87a3551652c3a7f18d48L10-L12). Specifically lines 9-13. It appears that the fix in this PR still relied on `paramsFor` which was the issue in a fix from [this PR](https://github.com/hashicorp/vault/pull/15378) (I know, stick with me).  So, without being able to reproduce I've done my best to insert the original fix back in with the newer fix.

Question: the potential regression was backported to 1.9 and 1.10, should I do the same even though we technically only support that latest three releases?

Note: I also tried updating the tests, but the coverage seems to test this specific scenario.