### PR TITLE
[docs] Link to the Nomad tutorial for Vault as OIDC provider

### DIFF
--- a/website/content/docs/secrets/identity/oidc-provider.mdx
+++ b/website/content/docs/secrets/identity/oidc-provider.mdx
@@ -150,6 +150,7 @@ for details on configuring OIDC authentication for other HashiCorp products:
 - [Boundary](/boundary/tutorials/access-management/oidc-auth)
 - [Consul](/consul/docs/security/acl/auth-methods/oidc)
 - [Waypoint](/waypoint/docs/server/auth/oidc)
+- [Nomad](/nomad/tutorials/single-sign-on/sso-oidc-vault)
 
 Otherwise, refer to the documentation of the specific OIDC relying party for usage details.
 


### PR DESCRIPTION
Adds a link to the Nomad tutorial for Vault as OIDC Provider from https://developer.hashicorp.com/vault/docs/secrets/identity/oidc-provider

(Note: when running this locally, it didn't look like it was pulling the latest Nomad docs references. But the tutorial is up @ https://developer.hashicorp.com/nomad/tutorials/single-sign-on/sso-oidc-vault