### PR TITLE
ldaputil: adds comment on available text/template functions

### DIFF
--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -210,6 +210,10 @@ func (c *Client) RenderUserSearchFilter(cfg *ConfigEntry, username string) (stri
 		context.Username = fmt.Sprintf("%s@%s", EscapeLDAPValue(username), cfg.UPNDomain)
 	}
 
+	// Execute the template. Note that the template context contains escaped input and does
+	// not provide behavior via functions. Additionally, no function map has been provided
+	// during template initialization. The only template functions available during execution
+	// are the predefined global functions: https://pkg.go.dev/text/template#hdr-Functions
 	var renderedFilter bytes.Buffer
 	if err := t.Execute(&renderedFilter, context); err != nil {
 		return "", fmt.Errorf("LDAP search failed due to template parsing error: %w", err)
@@ -386,6 +390,10 @@ func (c *Client) performLdapFilterGroupsSearchPaging(cfg *ConfigEntry, conn Pagi
 		ldap.EscapeFilter(username),
 	}
 
+	// Execute the template. Note that the template context contains escaped input and does
+	// not provide behavior via functions. Additionally, no function map has been provided
+	// during template initialization. The only template functions available during execution
+	// are the predefined global functions: https://pkg.go.dev/text/template#hdr-Functions
 	var renderedQuery bytes.Buffer
 	if err := t.Execute(&renderedQuery, context); err != nil {
 		return nil, fmt.Errorf("LDAP search failed due to template parsing error: %w", err)


### PR DESCRIPTION
This PR adds a comment above execution of [text/template](https://pkg.go.dev/text/template) values used in the LDAP auth method for:
- https://developer.hashicorp.com/vault/api-docs/auth/ldap#userfilter
- https://developer.hashicorp.com/vault/api-docs/auth/ldap#groupfilter

The purpose of this is to make it clear that arbitrary functions cannot be invoked via templates. The only functions available within templates are noted within the comment. 