### PR TITLE
fixes oracle plugin whitespace

### DIFF
--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -114,7 +114,7 @@ plugin will require additional configuration using the `connection_url` paramete
 ```shell
 vault write database/config/oracle \
   plugin_name=vault-plugin-database-oracle \
-  connection_url='{{ username }}/{{ password }}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=<host>)(PORT=<port>))(CONNECT_DATA=(SERVICE_NAME=<service_name>))(SECURITY=(SSL_SERVER_CERT_DN="<cert_dn>")(MY_WALLET_DIRECTORY=<path_to_wallet>)))' \
+  connection_url='{{username}}/{{password}}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=<host>)(PORT=<port>))(CONNECT_DATA=(SERVICE_NAME=<service_name>))(SECURITY=(SSL_SERVER_CERT_DN="<cert_dn>")(MY_WALLET_DIRECTORY=<path_to_wallet>)))' \
   allowed_roles="my-role" \
   username="admin" \
   password="password"
@@ -126,7 +126,7 @@ to use for connection and verification could be configured using:
 ```shell
 vault write database/config/oracle \
   plugin_name=vault-plugin-database-oracle \
-  connection_url='{{ username }}/{{ password }}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=hashicorp.com)(PORT=1523))(CONNECT_DATA=(SERVICE_NAME=ORCL))(SECURITY=(SSL_SERVER_CERT_DN="CN=hashicorp.com,OU=TestCA,O=HashiCorp=com")(MY_WALLET_DIRECTORY=/etc/oracle/wallets)))' \
+  connection_url='{{username}}/{{password}}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=hashicorp.com)(PORT=1523))(CONNECT_DATA=(SERVICE_NAME=ORCL))(SECURITY=(SSL_SERVER_CERT_DN="CN=hashicorp.com,OU=TestCA,O=HashiCorp=com")(MY_WALLET_DIRECTORY=/etc/oracle/wallets)))' \
   allowed_roles="my-role" \
   username="admin" \
   password="password"
@@ -197,14 +197,14 @@ Finally, use the alias in the `connection_url` parameter on the database configu
 ```
 vault write database/config/oracle-east \
     plugin_name=vault-plugin-database-oracle \
-    connection_url="{{ username }}/{{ password }}@AWSEAST" \
+    connection_url="{{username}}/{{password}}@AWSEAST" \
     allowed_roles="my-role" \
     username="VAULT_SUPER_USER" \
     password="myreallysecurepassword"
 
 vault write database/config/oracle-west \
     plugin_name=vault-plugin-database-oracle \
-    connection_url="{{ username }}/{{ password }}@AWSWEST" \
+    connection_url="{{username}}/{{password}}@AWSWEST" \
     allowed_roles="my-role" \
     username="VAULT_SUPER_USER" \
     password="myreallysecurepassword"


### PR DESCRIPTION
This PR fixes Oracle Plugin documentation where whitespace was wrapped around various `{{username}}` or `{{password}}` fields.

Confirmed fix working at customer site.