### PR TITLE
Fix failing TestHCPLinkConnected Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   setup:
     name: Setup
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON("ubuntu-latest") }}
     outputs:
       runs-on: ${{ steps.setup-outputs.outputs.runs-on }}
       enterprise: ${{ steps.setup-outputs.outputs.enterprise }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           echo 'enterprise=1' >> $GITHUB_OUTPUT
           echo 'go-tags=ent enterprise' >> $GITHUB_OUTPUT
         else
-          echo 'runs-on=ubuntu-latest' >> $GITHUB_OUTPUT
+          echo 'runs-on="ubuntu-latest"' >> $GITHUB_OUTPUT
           echo 'enterprise=' >> $GITHUB_OUTPUT
           echo 'go-tags=' >> $GITHUB_OUTPUT
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   setup:
     name: Setup
-    runs-on: ${{ fromJSON("ubuntu-latest") }}
+    runs-on: ubuntu-latest
     outputs:
       runs-on: ${{ steps.setup-outputs.outputs.runs-on }}
       enterprise: ${{ steps.setup-outputs.outputs.enterprise }}

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ fmtcheck:
 #@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
 fmt:
-	find . -name '*.go' | grep -v pb.go | grep -v vendor | xargs gofumpt -w
+	find . -name '*.go' | grep -v pb.go | grep -v vendor | xargs go run mvdan.cc/gofumpt -w
 
 semgrep:
 	semgrep --include '*.go' --exclude 'vendor' -a -f tools/semgrep .

--- a/command/server/hcp_link_config_test.go
+++ b/command/server/hcp_link_config_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"os"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -10,9 +9,9 @@ import (
 )
 
 func TestHCPLinkConfig(t *testing.T) {
-	os.Unsetenv("HCP_CLIENT_ID")
-	os.Unsetenv("HCP_CLIENT_SECRET")
-	os.Unsetenv("HCP_RESOURCE_ID")
+	t.Setenv("HCP_CLIENT_ID", "")
+	t.Setenv("HCP_CLIENT_SECRET", "")
+	t.Setenv("HCP_RESOURCE_ID", "")
 
 	config, err := LoadConfigFile("./test-fixtures/hcp_link_config.hcl")
 	if err != nil {

--- a/vault/external_tests/hcp_link/hcp_link_test.go
+++ b/vault/external_tests/hcp_link/hcp_link_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestHCPLinkConnected(t *testing.T) {
-	t.Parallel()
 	cluster := getTestCluster(t, 2)
 	defer cluster.Cleanup()
 


### PR DESCRIPTION
This PR introduces a few minor corrections to avoid race conditions with the tests. It also corrects a syntax issue that led to most jobs from the CI GitHub Actions Workflow to be skipped.

In the end, the actual cause of the failing TestHCPLinkConnected test was that the HCP Link resource ended up in the _unlinking_ state, so a new resource needed to be created and the associated secrets were updated.