### PR TITLE
sdk: Fix fmt + add FieldType test

### DIFF
--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -753,7 +753,7 @@ func (t FieldType) Zero() interface{} {
 	case TypeInt:
 		return 0
 	case TypeInt64:
-		return int64(0)	 
+		return int64(0)
 	case TypeBool:
 		return false
 	case TypeMap:

--- a/sdk/framework/backend_test.go
+++ b/sdk/framework/backend_test.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -809,5 +810,23 @@ func TestInitializeBackend(t *testing.T) {
 
 	if !inited {
 		t.Fatal("backend should be open")
+	}
+}
+
+func TestFieldTypeMethods(t *testing.T) {
+	unknownFormat := convertType(TypeInvalid).format
+
+	for i := TypeInvalid + 1; i < typeInvalidMax; i++ {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			if i.String() == TypeInvalid.String() {
+				t.Errorf("unknown type string for %d", i)
+			}
+
+			if convertType(i).format == unknownFormat {
+				t.Errorf("unknown schema for %d", i)
+			}
+
+			_ = i.Zero()
+		})
 	}
 }

--- a/sdk/framework/backend_test.go
+++ b/sdk/framework/backend_test.go
@@ -813,6 +813,8 @@ func TestInitializeBackend(t *testing.T) {
 	}
 }
 
+// TestFieldTypeMethods tries to ensure our switch-case statements for the
+// FieldType "enum" are complete.
 func TestFieldTypeMethods(t *testing.T) {
 	unknownFormat := convertType(TypeInvalid).format
 

--- a/sdk/framework/field_type.go
+++ b/sdk/framework/field_type.go
@@ -63,6 +63,10 @@ const (
 	// formatted as a string or a number. The resulting time.Time
 	// is converted to UTC.
 	TypeTime
+
+	// DO NOT USE. Any new values must be inserted before this value.
+	// Used to write tests that ensure type methods handle all possible values.
+	typeInvalidMax
 )
 
 func (t FieldType) String() string {
@@ -75,6 +79,8 @@ func (t FieldType) String() string {
 		return "name string"
 	case TypeInt:
 		return "int"
+	case TypeInt64:
+		return "int64"
 	case TypeBool:
 		return "bool"
 	case TypeMap:


### PR DESCRIPTION
Follow up to #18729 to fix the fmt job (trailing whitespace) and help prevent regressions in the future.