### PR TITLE
Add note to gcp secrets docs to explan service account key encoding

### DIFF
--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -294,8 +294,10 @@ $ curl -H "Authorization: Bearer ya29.c.ElodBmNPwHUNY5gcBpnXcE4ywG4w1k..."
 
 ### Service Account Keys
 
-To generate service account keys, read from `gcp/.../key`. The roleset or static
-account must have been created as type `service_account_key`:
+To generate service account keys, read from `gcp/.../key`. Vault returns the service
+account key data as a base64-encoded string in the `private_key_data` field. This can
+be read by decoding it using `base64 --decode "ewogICJ0e..."` or another base64 tool of
+your choice. The roleset or static account must have been created as type `service_account_key`:
 
 ```shell-session
 $ vault read gcp/roleset/my-key-roleset/key


### PR DESCRIPTION
Adds an explanation to the GCP secret engine docs to mention that service account keys are returned as base64-encoded strings in the response.