### PR TITLE
fix: Remove .mdx extension from link

### DIFF
--- a/website/content/docs/concepts/client-count/index.mdx
+++ b/website/content/docs/concepts/client-count/index.mdx
@@ -262,7 +262,7 @@ For the UI to be able to modify the configuration settings, it additionally need
 
 The billing period for the activity log API can be specified to include the current month 
 for the end date. For more information, please refer to the 
-[the internal counters API docs](/vault/api-docs/system/internal-counters.mdx) documentation.
+[the internal counters API docs](/vault/api-docs/system/internal-counters) documentation.
 
 When the end date is the current month, the `new_clients` counts will be an approximation of the  
 number of new clients for the month, and not an exact value. Note that the `new_clients` counts for the rest 


### PR DESCRIPTION
Removes an `.mdx` extension from a link, which was causing a 404 when clicked.