### PR TITLE
Added note about Autopilot default values.

### DIFF
--- a/website/content/docs/concepts/integrated-storage/autopilot.mdx
+++ b/website/content/docs/concepts/integrated-storage/autopilot.mdx
@@ -52,7 +52,7 @@ Autopilot automatically.
 
 Autopilot exposes a [configuration
 API](/vault/api-docs/system/storage/raftautopilot#set-configuration) to manage its
-behavior. Autopilot gets initialized with the following default values.
+behavior. Autopilot gets initialized with the following default values. Please note these default values are simply for reference.
 
 - `cleanup_dead_servers` - `false`
   - This controls whether to remove dead servers from

--- a/website/content/docs/concepts/integrated-storage/autopilot.mdx
+++ b/website/content/docs/concepts/integrated-storage/autopilot.mdx
@@ -52,7 +52,7 @@ Autopilot automatically.
 
 Autopilot exposes a [configuration
 API](/vault/api-docs/system/storage/raftautopilot#set-configuration) to manage its
-behavior. Autopilot gets initialized with the following default values. Please note these default values are simply for reference.
+behavior. Autopilot gets initialized with the following default values. If these default values do not meet your expected autopilot behavior, don't forget to set them to your desired values.
 
 - `cleanup_dead_servers` - `false`
   - This controls whether to remove dead servers from


### PR DESCRIPTION
Suggested edit based on ZenDesk ticket #102314. Customer didn't understand the default values are simply a guideline and will not fit every environment.