### PR TITLE
Add support for HEAD operations

### DIFF
--- a/http/logical.go
+++ b/http/logical.go
@@ -180,8 +180,10 @@ func buildLogicalRequestNoAuth(perfStandby bool, w http.ResponseWriter, r *http.
 		}
 
 		data = parseQuery(r.URL.Query())
-
-	case "OPTIONS", "HEAD":
+	case "HEAD":
+		op = logical.HeaderOperation
+		data = parseQuery(r.URL.Query())
+	case "OPTIONS":
 	default:
 		return nil, nil, http.StatusMethodNotAllowed, nil
 	}

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -366,6 +366,7 @@ const (
 	HelpOperation                     = "help"
 	AliasLookaheadOperation           = "alias-lookahead"
 	ResolveRoleOperation              = "resolve-role"
+	HeaderOperation                   = "header"
 
 	// The operations below are called globally, the path is less relevant.
 	RevokeOperation   Operation = "revoke"

--- a/sdk/logical/response_util.go
+++ b/sdk/logical/response_util.go
@@ -17,7 +17,7 @@ import (
 func RespondErrorCommon(req *Request, resp *Response, err error) (int, error) {
 	if err == nil && (resp == nil || !resp.IsError()) {
 		switch {
-		case req.Operation == ReadOperation:
+		case req.Operation == ReadOperation || req.Operation == HeaderOperation:
 			if resp == nil {
 				return http.StatusNotFound, nil
 			}

--- a/sdk/logical/response_util_test.go
+++ b/sdk/logical/response_util_test.go
@@ -40,6 +40,14 @@ func TestResponseUtil_RespondErrorCommon_basic(t *testing.T) {
 			expectedStatus: 404,
 		},
 		{
+			title: "Header not found",
+			req: &Request{
+				Operation: HeaderOperation,
+			},
+			respErr:        nil,
+			expectedStatus: 404,
+		},
+		{
 			title: "List with response and no keys",
 			req: &Request{
 				Operation: ListOperation,


### PR DESCRIPTION
In support of beginning ACME support, we need to allow Vault plugins to respond to HEAD operations. See [Section 6.5.1](https://datatracker.ietf.org/doc/html/rfc8555#section-6.5.1) and [7.2](https://datatracker.ietf.org/doc/html/rfc8555#section-7.2) for the usage in the ACME protocol.

This operation is implemented like a regular operation and it is up to the plugin to correctly handle responding with only header information without processing other details of the request. Plugins which do not support HEAD operations on a specified endpoint will return 404.