### PR TITLE
Add known issue about OCSP GET redirection responses

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
@@ -182,3 +182,5 @@ As a workaround, OCSP POST requests can be used which are unaffected.
 Affects version 1.12.3. A fix will be released in 1.12.4.
 
 @include 'tokenization-rotation-persistence.mdx'
+
+@include 'ocsp-redirect.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -79,3 +79,5 @@ are unaffected.
 ## Known Issues
 
 @include 'tokenization-rotation-persistence.mdx'
+
+@include 'ocsp-redirect.mdx'

--- a/website/content/partials/ocsp-redirect.mdx
+++ b/website/content/partials/ocsp-redirect.mdx
@@ -1,0 +1,11 @@
+### PKI OCSP GET requests can return HTTP redirect responses
+
+If a base64 encoded OCSP request contains consecutive '/' characters, the GET request
+will return a 301 permanent redirect response. If the redirection is followed, the
+request will not decode as it will not be a properly base64 encoded request.
+
+As a workaround, OCSP POST requests can be used which are unaffected.
+
+#### Impacted Versions
+
+Affects all current versions of 1.12.x and 1.13.x


### PR DESCRIPTION
Write up the discovered issue of OCSP GET requests that contain multiple '/' characters within the encoded request, being responded with a 301 HTTP Permanent redirect status code instead of a valid OCSP response. 

The workaround for now is to submit the OCSP request using HTTP POST instead of GET which does not suffer from Go's HTTP mux getting in the way and returning the redirection response to the end-user.