### PR TITLE
Add sigusr2 pprof file dump support

### DIFF
--- a/changelog/19528.txt
+++ b/changelog/19528.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Add support for dumping pprof files to the filesystem using SIGUSR2
+```


### PR DESCRIPTION
This adds support to dump `pprof` outputs to the filesystem when `VAULT_PPROF_SIGUSR2_DUMP` set on the Vault process. This is very useful in situations where HTTP handlers are unresponsive and we cannot use the `sys/pprof` endpoints. I put this behind an environment variable because files are generated each time there's a SIGUSR2 signal to avoid unintentionally generating a lot of files.