### PR TITLE
Ignore special HTTP fields in response validation tests

### DIFF
--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -44,18 +44,6 @@ var pathFetchReadSchema = map[int][]framework.Response{
 				Description: `Issuing CA Chain`,
 				Required:    false,
 			},
-			"http_content_type": {
-				Type:     framework.TypeString,
-				Required: false,
-			},
-			"http_raw_body": {
-				Type:     framework.TypeString,
-				Required: false,
-			},
-			"http_status_code": {
-				Type:     framework.TypeString,
-				Required: false,
-			},
 		},
 	}},
 }

--- a/sdk/helper/testhelpers/schema/response_validation.go
+++ b/sdk/helper/testhelpers/schema/response_validation.go
@@ -97,7 +97,7 @@ func validateResponseDataImpl(schema *framework.Response, data map[string]interf
 	return fd.Validate()
 }
 
-// FindResponseSchema is a test helper to extract the response schema from a given framework path / operation
+// FindResponseSchema is a test helper to extract response schema from the given framework path / operation
 func FindResponseSchema(t *testing.T, paths []*framework.Path, pathIdx int, operation logical.Operation) *framework.Response {
 	t.Helper()
 

--- a/sdk/helper/testhelpers/schema/response_validation.go
+++ b/sdk/helper/testhelpers/schema/response_validation.go
@@ -50,6 +50,24 @@ func validateResponseDataImpl(schema *framework.Response, data map[string]interf
 		return nil
 	}
 
+	// these are special fields that will not show up in the final response and
+	// should be ignored
+	for _, field := range []string{
+		logical.HTTPContentType,
+		logical.HTTPRawBody,
+		logical.HTTPStatusCode,
+		logical.HTTPRawBodyAlreadyJSONDecoded,
+		logical.HTTPCacheControlHeader,
+		logical.HTTPPragmaHeader,
+		logical.HTTPWWWAuthenticateHeader,
+	} {
+		delete(data, field)
+
+		if _, ok := schema.Fields[field]; ok {
+			return fmt.Errorf("encountered a reserved field in response schema: %s", field)
+		}
+	}
+
 	// Marshal the data to JSON and back to convert the map's values into
 	// JSON strings expected by Validate() and ValidateStrict(). This is
 	// not efficient and is done for testing purposes only.

--- a/sdk/helper/testhelpers/schema/response_validation.go
+++ b/sdk/helper/testhelpers/schema/response_validation.go
@@ -50,24 +50,6 @@ func validateResponseDataImpl(schema *framework.Response, data map[string]interf
 		return nil
 	}
 
-	// these are special fields that will not show up in the final response and
-	// should be ignored
-	for _, field := range []string{
-		logical.HTTPContentType,
-		logical.HTTPRawBody,
-		logical.HTTPStatusCode,
-		logical.HTTPRawBodyAlreadyJSONDecoded,
-		logical.HTTPCacheControlHeader,
-		logical.HTTPPragmaHeader,
-		logical.HTTPWWWAuthenticateHeader,
-	} {
-		delete(data, field)
-
-		if _, ok := schema.Fields[field]; ok {
-			return fmt.Errorf("encountered a reserved field in response schema: %s", field)
-		}
-	}
-
 	// Marshal the data to JSON and back to convert the map's values into
 	// JSON strings expected by Validate() and ValidateStrict(). This is
 	// not efficient and is done for testing purposes only.
@@ -82,6 +64,24 @@ func validateResponseDataImpl(schema *framework.Response, data map[string]interf
 		&dataWithStringValues,
 	); err != nil {
 		return fmt.Errorf("failed to unmashal data: %w", err)
+	}
+
+	// these are special fields that will not show up in the final response and
+	// should be ignored
+	for _, field := range []string{
+		logical.HTTPContentType,
+		logical.HTTPRawBody,
+		logical.HTTPStatusCode,
+		logical.HTTPRawBodyAlreadyJSONDecoded,
+		logical.HTTPCacheControlHeader,
+		logical.HTTPPragmaHeader,
+		logical.HTTPWWWAuthenticateHeader,
+	} {
+		delete(dataWithStringValues, field)
+
+		if _, ok := schema.Fields[field]; ok {
+			return fmt.Errorf("encountered a reserved field in response schema: %s", field)
+		}
 	}
 
 	// Validate

--- a/sdk/helper/testhelpers/schema/response_validation_test.go
+++ b/sdk/helper/testhelpers/schema/response_validation_test.go
@@ -249,6 +249,60 @@ func TestValidateResponse(t *testing.T) {
 			strict:        false,
 			errorExpected: false,
 		},
+
+		"empty schema, response has http_raw_body, strict": {
+			schema: &framework.Response{
+				Fields: map[string]*framework.FieldSchema{},
+			},
+			response: map[string]interface{}{
+				"http_raw_body": "foo",
+			},
+			strict:        true,
+			errorExpected: false,
+		},
+
+		"empty schema, response has http_raw_body, not strict": {
+			schema: &framework.Response{
+				Fields: map[string]*framework.FieldSchema{},
+			},
+			response: map[string]interface{}{
+				"http_raw_body": "foo",
+			},
+			strict:        false,
+			errorExpected: false,
+		},
+
+		"schema has http_raw_body, strict": {
+			schema: &framework.Response{
+				Fields: map[string]*framework.FieldSchema{
+					"http_raw_body": {
+						Type:     framework.TypeString,
+						Required: false,
+					},
+				},
+			},
+			response: map[string]interface{}{
+				"http_raw_body": "foo",
+			},
+			strict:        true,
+			errorExpected: true,
+		},
+
+		"schema has http_raw_body, not strict": {
+			schema: &framework.Response{
+				Fields: map[string]*framework.FieldSchema{
+					"http_raw_body": {
+						Type:     framework.TypeString,
+						Required: false,
+					},
+				},
+			},
+			response: map[string]interface{}{
+				"http_raw_body": "foo",
+			},
+			strict:        false,
+			errorExpected: true,
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
A number of special fields can get assigned to response data that should not be added to response validation schema. The fields are defined here:

https://github.com/hashicorp/vault/blob/ed08e45069d60fc4452fad7d44bcfd3b2e4c8236/sdk/logical/response.go#L17-L50

