### PR TITLE
Remove oracle banner

### DIFF
--- a/changelog/19019.txt
+++ b/changelog/19019.txt
@@ -1,3 +1,0 @@
-```release-note: improvement
-ui: Add alert-banner about configuring an Oracle DB secret engine if using SSL.
-```

--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -160,18 +160,7 @@
         {{/if}}
       </div>
     {{/unless}}
-    {{#if (eq @model.plugin_name "vault-plugin-database-oracle")}}
-      <AlertBanner
-        @type="info"
-        @title="Connecting using SSL or TNS Names"
-        @message="To create database connections using SSL or TNS names you may need to provide additional Oracle configuration files for your Vault cluster. If you have already provided these files, they may need to updated if you are creating connections to database hosts not covered by the existing configuration files."
-      >
-        <DocLink @path="/vault/docs/secrets/databases/oracle">
-          <Icon @name="learn-link" />
-          Oracle Database Secrets Engine
-        </DocLink>
-      </AlertBanner>
-    {{/if}}
+
     <div class="field is-grouped is-grouped-split is-fullwidth box is-bottomless">
       <div class="field is-grouped">
         <div class="control">

--- a/ui/tests/acceptance/secrets/backend/database/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/database/secret-test.js
@@ -229,12 +229,6 @@ const connectionTests = [
       assert
         .dom('[data-test-input="root_rotation_statements"]')
         .exists(`Root rotation statements exists for ${name}`);
-      assert
-        .dom('[data-test-alert-banner="alert"]')
-        .hasTextContaining(
-          `Warning Please ensure that your Oracle plugin has the default name of vault-plugin-database-oracle. Custom naming is not supported in the UI at this time. If the plugin is already named vault-plugin-database-oracle, disregard this warning.`,
-          'warning banner displays about connections with SSL.'
-        );
     },
   },
 ];
@@ -270,7 +264,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
   });
 
   test('Connection create and edit form for each plugin', async function (assert) {
-    assert.expect(169);
+    assert.expect(160);
     const backend = await mount();
     for (const testCase of connectionTests) {
       await connectionPage.visitCreate({ backend });
@@ -292,11 +286,6 @@ module('Acceptance | secrets/database/*', function (hooks) {
       if (testCase.plugin === 'vault-plugin-database-oracle') {
         testCase.requiredFields(assert, testCase.name);
         continue;
-      }
-      if (testCase.plugin !== 'vault-plugin-database-oracle') {
-        assert
-          .dom('[data-test-alert-banner="alert"]')
-          .doesNotExist('Does not show alert-banners specific only to the Oracle db.');
       }
       testCase.requiredFields(assert, testCase.name);
       await connectionPage.toggleVerify();


### PR DESCRIPTION
Welp, the team decided not to keep the banner. From the JIRA ticket:

>We may decide to include this in the future, but TBD at this time, can we un-merge this for now so it isn’t included in the next release

Removing all changes from [this PR](https://github.com/hashicorp/vault/pull/19019/files). 