### PR TITLE
add app_roles to azure secrets engine docs

### DIFF
--- a/website/content/api-docs/secret/azure.mdx
+++ b/website/content/api-docs/secret/azure.mdx
@@ -198,6 +198,7 @@ information about roles.
 - `azure_roles` (`string: ""`) - List of Azure roles to be assigned to the generated service
   principal. The array must be in JSON format, properly escaped as a string. See [roles docs][roles]
   for details on role definition.
+- `app_roles` (`string: ""`) - List of Azure Active Directory App roles to assign to the generated service principal. The array must be in JSON format, properly escaped as a string
 - `azure_groups` (`string: ""`) - List of Azure groups that the generated service principal will be
   assigned to. The array must be in JSON format, properly escaped as a string. See [groups docs][groups]
   for more details.
@@ -225,6 +226,16 @@ information about roles.
     {
       \"role_id\": \"/subscriptions/<uuid>/providers/Microsoft.Authorization/roleDefinitions/<uuid>\",
       \"scope\":  \"/subscriptions/<uuid>\"
+    }
+  ]",
+  "app_roles": "[
+    {   
+      \"app_id\": \"<uuid>\",
+      \"roles\":[
+        {
+          \"role_name\": \"Directory.Read.All\"
+        }
+      ]
     }
   ]",
   "ttl": 3600,


### PR DESCRIPTION
Adds the documentation related to https://github.com/hashicorp/vault-plugin-secrets-azure/pull/137

I am not sure how to update [this page](https://developer.hashicorp.com/vault/docs/secrets/azure) to fully describe the new block as well as update the need graphAPI permissions to include `AppRoleAssignment.ReadWrite.All`