### PR TITLE
Adjust CircleCI Makefile for CircleCI CLI Behaviour Change

### DIFF
--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -78,7 +78,7 @@ define GEN_CONFIG
 
 	@$(CIRCLECI) config pack $(SOURCE_DIR) > $(CONFIG_PACKED)
 	@echo "$$GENERATED_FILE_HEADER" > $@.tmp || { rm -f $@; exit 1; }
-	@$(CIRCLECI) config process $(CONFIG_PACKED) >> $@.tmp || { rm -f $@.tmp; exit 1; }
+	@$(CIRCLECI) config process $(CONFIG_PACKED) | sed '/^Processing config with following values/,+1d' >> $@.tmp || { rm -f $@.tmp; exit 1; }
 	@mv -f $@.tmp $@
 endef
 


### PR DESCRIPTION
This PR makes an adjustment to the _Makefile_ in the _.circleci_ directory to account for a [recent behaviour change](https://github.com/CircleCI-Public/circleci-cli/pull/855/commits/4983470d9be6fbc3a759a1a418ec1475a0e936d8) in the CircleCI CLI.

### Background
The CircleCI CLI was changed to output a message and list all of the pipeline values used to process the packed configuration file for both the **config process** and **config validate** commands.

### Change
This change provides a solution that will produce the expected output (only the CircleCI configuration file) while this behaviour is present and continue to work if the recently introduced behaviour is removed.