### PR TITLE
UI/update auth form to fetchRoles after a namespace is inputted, prior to OIDC auth

### DIFF
--- a/changelog/19541.txt
+++ b/changelog/19541.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes oidc tabs in auth form submitting with the root's default_role value after a namespace has been inputted
+```

--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -32,7 +32,7 @@ export default Component.extend({
     this._super();
     const debounce = !this.oldSelectedAuthPath && !this.selectedAuthPath;
 
-    if (this.oldSelectedAuthPath !== this.selectedAuthPath || debounce) {
+    if (this.oldSelectedAuthPath !== this.selectedAuthPath || debounce || this.namespace) {
       this.fetchRole.perform(this.roleName, { debounce });
     }
 

--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -32,7 +32,7 @@ export default Component.extend({
     this._super();
     const debounce = !this.oldSelectedAuthPath && !this.selectedAuthPath;
 
-    if (this.oldSelectedAuthPath !== this.selectedAuthPath || debounce || this.namespace) {
+    if (this.oldSelectedAuthPath !== this.selectedAuthPath || debounce) {
       this.fetchRole.perform(this.roleName, { debounce });
     }
 
@@ -134,7 +134,7 @@ export default Component.extend({
 
     let { namespace, path, state, code } = oidcState;
 
-    // The namespace can be either be passed as a query paramter, or be embedded
+    // The namespace can be either be passed as a query parameter, or be embedded
     // in the state param in the format `<state_id>,ns=<namespace>`. So if
     // `namespace` is empty, check for namespace in state as well.
     if (namespace === '' || this.featureFlagService.managedNamespaceRoot) {
@@ -171,6 +171,14 @@ export default Component.extend({
       if (e && e.preventDefault) {
         e.preventDefault();
       }
+      try {
+        await this.fetchRole.perform(this.roleName, { debounce: false });
+      } catch (error) {
+        // this task could be cancelled if the instances in didReceiveAttrs resolve after this was started
+        if (error?.name !== 'TaskCancelation') {
+          throw error;
+        }
+      }
       if (!this.isOIDC || !this.role || !this.role.authUrl) {
         let message = this.errorMessage;
         if (!this.role) {
@@ -181,14 +189,6 @@ export default Component.extend({
         }
         this.onError(message);
         return;
-      }
-      try {
-        await this.fetchRole.perform(this.roleName, { debounce: false });
-      } catch (error) {
-        // this task could be cancelled if the instances in didReceiveAttrs resolve after this was started
-        if (error?.name !== 'TaskCancelation') {
-          throw error;
-        }
       }
       const win = this.getWindow();
 

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -19,7 +19,7 @@
                   "is-active"
                   ""
                 }}
-                data-test-auth-method
+                data-test-auth-method={{method.id}}
               >
                 <LinkTo
                   @route="vault.cluster.auth"

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -32,18 +32,16 @@
               </li>
             {{/let}}
           {{/each}}
-          {{#if this.hasMethodsWithPath}}
-            <li class={{unless this.selectedAuthIsPath "is-active" ""}} data-test-auth-method>
-              <LinkTo
-                @route="vault.cluster.auth"
-                @model={{this.cluster.name}}
-                @query={{hash with="token"}}
-                data-test-auth-method-link="other"
-              >
-                Other
-              </LinkTo>
-            </li>
-          {{/if}}
+          <li class={{unless this.selectedAuthIsPath "is-active" ""}} data-test-auth-method>
+            <LinkTo
+              @route="vault.cluster.auth"
+              @model={{this.cluster.name}}
+              @query={{hash with="token"}}
+              data-test-auth-method-link="other"
+            >
+              Other
+            </LinkTo>
+          </li>
         </ul>
       </nav>
     {{/if}}

--- a/ui/app/templates/vault/cluster/auth.hbs
+++ b/ui/app/templates/vault/cluster/auth.hbs
@@ -82,6 +82,7 @@
               <div class="field">
                 <div class="control">
                   <input
+                    data-test-auth-form-ns-input
                     value={{this.namespaceQueryParam}}
                     placeholder="/ (Root)"
                     oninput={{perform this.updateNamespace value="target.value"}}

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -2,6 +2,7 @@ import { click, settled, visit, fillIn, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { create } from 'ember-cli-page-object';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 import consoleClass from 'vault/tests/pages/components/console/ui-panel';
 import authPage from 'vault/tests/pages/auth';
@@ -87,5 +88,85 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
       `/vault/auth?namespace=${encodedNamespace}&with=token`,
       'Does not prepend root to namespace'
     );
+  });
+
+  module('auth form', function (hooks) {
+    setupMirage(hooks);
+    const SELECTORS = {
+      authTab: (path) => `[data-test-auth-method="${path}"] a`,
+      authSubmit: '[data-test-auth-submit]',
+    };
+    hooks.beforeEach(async function () {
+      this.namespace = 'testns';
+      this.rootOidc = 'root-oidc';
+      this.nsOidc = 'ns-oidc';
+
+      const enableOidc = async (path, role = null) => {
+        this.server.post(`/auth/${path}/config`, () => {});
+        const hasRole = role || '';
+        await shell.runCommands([
+          `write sys/auth/${path} type=oidc`,
+          `write auth/${path}/config default_role="${hasRole}" oidc_discovery_url="https://example.com"`,
+          // show method as tab
+          `write sys/auth/${path}/tune listing_visibility="unauth"`,
+        ]);
+      };
+      await authPage.login();
+      // enable oidc in root namespace, without default role
+      await enableOidc(this.rootOidc);
+      // create child namespace to enable oidc
+      await createNS(this.namespace);
+      await logout.visit();
+
+      // enable oidc in child namespace with default role
+      await authPage.loginNs(this.namespace);
+      await enableOidc(this.nsOidc, `${this.nsOidc}-role`);
+      return await authPage.logout();
+    });
+
+    hooks.afterEach(async function () {
+      const disableOidc = async (path) => {
+        await shell.runCommands([`delete /sys/auth/${path}`]);
+      };
+
+      await authPage.loginNs(this.namespace);
+      await visit(`/vault/access?namespace=${this.namespace}`);
+      // disable methods to cleanup test state for re-running
+      await disableOidc(this.rootOidc);
+      await disableOidc(this.nsOidc);
+      await authPage.logout();
+
+      await authPage.login();
+      await shell.runCommands([`delete /sys/auth/${this.namespace}`]);
+    });
+
+    test('auth form updates when a namespace is entered', async function (assert) {
+      assert.expect(5);
+      this.server.post(`/auth/${this.rootOidc}/oidc/auth_url`, (schema, req) => {
+        const request = JSON.parse(req.requestBody);
+        assert.deepEqual(
+          request.redirect_uri,
+          `http://localhost:7357/ui/vault/auth/${this.rootOidc}/oidc/callback`,
+          'request made to auth_url when the login page is visited'
+        );
+      });
+      this.server.post(`/auth/${this.nsOidc}/oidc/auth_url`, (schema, req) => {
+        const request = JSON.parse(req.requestBody);
+        assert.deepEqual(
+          request.redirect_uri,
+          `http://localhost:7357/ui/vault/auth/${this.nsOidc}/oidc/callback?namespace=testns`,
+          'request made to correct auth_url when namespace is filled in'
+        );
+      });
+      await visit('/vault/auth');
+      assert.dom(SELECTORS.authTab(this.rootOidc)).exists('renders oidc method tab for root');
+      await authPage.namespaceInput(this.namespace);
+      assert.strictEqual(
+        currentURL(),
+        `/vault/auth?namespace=${this.namespace}&with=ns-oidc%2F`,
+        'url updates with namespace value'
+      );
+      assert.dom(SELECTORS.authTab(this.nsOidc)).exists('renders oidc method tab for namespace');
+    });
   });
 });

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { create } from 'ember-cli-page-object';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-
+import parseURL from 'core/utils/parse-url';
 import consoleClass from 'vault/tests/pages/components/console/ui-panel';
 import authPage from 'vault/tests/pages/auth';
 import logout from 'vault/tests/pages/logout';
@@ -97,16 +97,15 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
       authSubmit: '[data-test-auth-submit]',
     };
     hooks.beforeEach(async function () {
-      this.namespace = 'testns';
+      this.namespace = 'test-ns';
       this.rootOidc = 'root-oidc';
       this.nsOidc = 'ns-oidc';
 
-      const enableOidc = async (path, role = null) => {
+      const enableOidc = async (path, role = '') => {
         this.server.post(`/auth/${path}/config`, () => {});
-        const hasRole = role || '';
         await shell.runCommands([
           `write sys/auth/${path} type=oidc`,
-          `write auth/${path}/config default_role="${hasRole}" oidc_discovery_url="https://example.com"`,
+          `write auth/${path}/config default_role="${role}" oidc_discovery_url="https://example.com"`,
           // show method as tab
           `write sys/auth/${path}/tune listing_visibility="unauth"`,
         ]);
@@ -121,6 +120,10 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
       // enable oidc in child namespace with default role
       await authPage.loginNs(this.namespace);
       await enableOidc(this.nsOidc, `${this.nsOidc}-role`);
+      await authPage.logout();
+
+      // end by logging in/out of root so query params are cleared out and don't include namespace
+      await authPage.login();
       return await authPage.logout();
     });
 
@@ -138,35 +141,38 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
 
       await authPage.login();
       await shell.runCommands([`delete /sys/auth/${this.namespace}`]);
+      this.server.shutdown();
     });
 
-    test('auth form updates when a namespace is entered', async function (assert) {
+    test('oidc: request is made to auth_url when a namespace is inputted', async function (assert) {
       assert.expect(5);
       this.server.post(`/auth/${this.rootOidc}/oidc/auth_url`, (schema, req) => {
-        const request = JSON.parse(req.requestBody);
-        assert.deepEqual(
-          request.redirect_uri,
-          `http://localhost:7357/ui/vault/auth/${this.rootOidc}/oidc/callback`,
+        const { redirect_uri } = JSON.parse(req.requestBody);
+        const { pathname, search } = parseURL(redirect_uri);
+        assert.strictEqual(
+          pathname + search,
+          `/ui/vault/auth/${this.rootOidc}/oidc/callback`,
           'request made to auth_url when the login page is visited'
         );
       });
       this.server.post(`/auth/${this.nsOidc}/oidc/auth_url`, (schema, req) => {
-        const request = JSON.parse(req.requestBody);
-        assert.deepEqual(
-          request.redirect_uri,
-          `http://localhost:7357/ui/vault/auth/${this.nsOidc}/oidc/callback?namespace=testns`,
+        const { redirect_uri } = JSON.parse(req.requestBody);
+        const { pathname, search } = parseURL(redirect_uri);
+        assert.strictEqual(
+          pathname + search,
+          `/ui/vault/auth/${this.nsOidc}/oidc/callback?namespace=${this.namespace}`,
           'request made to correct auth_url when namespace is filled in'
         );
       });
-      await visit('/vault/auth');
+      await visit('/vault/auth?with=oidc%2F');
       assert.dom(SELECTORS.authTab(this.rootOidc)).exists('renders oidc method tab for root');
       await authPage.namespaceInput(this.namespace);
       assert.strictEqual(
         currentURL(),
-        `/vault/auth?namespace=${this.namespace}&with=ns-oidc%2F`,
+        `/vault/auth?namespace=${this.namespace}&with=${this.nsOidc}%2F`,
         'url updates with namespace value'
       );
-      assert.dom(SELECTORS.authTab(this.nsOidc)).exists('renders oidc method tab for namespace');
+      assert.dom(SELECTORS.authTab(this.nsOidc)).exists('renders oidc method tab for child namespace');
     });
   });
 });

--- a/ui/tests/pages/auth.js
+++ b/ui/tests/pages/auth.js
@@ -11,6 +11,7 @@ export default create({
   tokenInput: fillable('[data-test-token]'),
   usernameInput: fillable('[data-test-username]'),
   passwordInput: fillable('[data-test-password]'),
+  namespaceInput: fillable('[data-test-auth-form-ns-input]'),
   login: async function (token) {
     // make sure we're always logged out and logged back in
     await this.logout();
@@ -37,6 +38,19 @@ export default create({
     await settled();
     await this.usernameInput(username);
     await this.passwordInput(password).submit();
+    return;
+  },
+  loginNs: async function (ns) {
+    // make sure we're always logged out and logged back in
+    await this.logout();
+    await settled();
+    // clear session storage to ensure we have a clean state
+    window.localStorage.clear();
+    await this.visit({ with: 'token' });
+    await settled();
+    await this.namespaceInput(ns);
+    await settled();
+    await this.tokenInput(rootToken).submit();
     return;
   },
 });


### PR DESCRIPTION
So this was tricky to reproduce and due to the whack-a-mole nature of these bugs, here is a very thorough breakdown:

The auth form component updates as the namespace changes to show the correct associated login methods (and corresponding button styles, if applicable). This means the form often reverts to the dropdown menu because by default auth methods are not listed as tabs when unauthenticated (this is a separate config option)

Notice in the gif below, there is an `oidc` tab because in `/Root` oidc has been configured so `listing_visibility='unauth'` [(docs)](https://developer.hashicorp.com/vault/api-docs/system/auth#listing_visibility). However, as another namespace is typed, the default form changes because `testns` has no unuath'd methods.

<img src="https://user-images.githubusercontent.com/68122737/225174461-d1a0c4a1-57f8-45d9-9ff7-0a7fed34947b.gif" width="450"/>
<hr>

### the bug 🐛 

For both OIDC and JWT, the `role` is updated when the method is selected and the `AuthJwt` component fires off its `didReceiveAttrs` lifecycle hook which runs the task `fetchRole` with whatever namespace has been set by the url params.

If a user _very quickly_ types in a namespace (`admin`) that has the same method (`oidc`), mounted at the same path (also `oidc`) **but** only one of them have a default role configured (stick with me!) then the UI remains on the `oidc` tab, but the task to fetch for a role is not re-fired with the new namespace value. This is because the `fetchRole` only fires if the auth path has changed. You can see in the gif when we go from root to the `admin` namespace, we get the `Invalid role` error because root does not have a default role. However, after refreshing, the namespace stays in the url params and thus the role is set properly.

![oidc-bug](https://user-images.githubusercontent.com/68122737/225142930-a818d7e3-9127-4b7b-bf3c-5cd5bcc94c2e.gif)

### fix 🔧 
Because the component is often torn down when the namespace changes it doesn't make sense to check if the namespace has changed (like we do for the auth path by `this.oldSelectedAuthPath !== this.selectedAuthPath`). 

Instead, opted to reorder the methods in `startOIDCAuth` and tested with the following situations to insure the bug fixes introduced by #17661 were preserved. 
1. oidc method mounted at `incorrect-uris-oidc/` with missing URI data
2. mounted at `missing-role-oidc` with no role configured
3. mounted at `proper-config-oidc` with a default role setup, properly
![fix-oidc](https://user-images.githubusercontent.com/68122737/225180220-6749ed3a-d20b-4604-ba60-e08a12f2a563.gif)
