### PR TITLE
docs - update x_forwarded_for_authorized_addrs

### DIFF
--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -174,7 +174,11 @@ default value in the `"/sys/config/ui"` [API endpoint](/vault/api-docs/system/co
 - `x_forwarded_for_authorized_addrs` `(string: <required-to-enable>)` –
   Specifies the list of source IP CIDRs for which an X-Forwarded-For header
   will be trusted. Comma-separated list or JSON array. This turns on
-  X-Forwarded-For support.
+  X-Forwarded-For support.  If for example Vault receives connections from the 
+  load balancer's IP of `1.2.3.4`, adding `1.2.3.4` to `x_forwarded_for_authorized_addrs` 
+  will result in the `remote_address` field in the audit log being populated with the 
+  connecting client's IP, for example `3.4.5.6`. Note this requires the load balancer 
+  to send the connecting client's IP in the `X-Forwarded-For` header.
 
 - `x_forwarded_for_hop_skips` `(string: "0")` – The number of addresses that will be
   skipped from the _rear_ of the set of hops. For instance, for a header value


### PR DESCRIPTION
On https://developer.hashicorp.com/vault/docs/configuration/listener/tcp#x_forwarded_for_authorized_addrs we could be clearer in the information we provide in order to help users of Vault log the client IP when fronting Vault with a load balancer, this PR aims to help.