### PR TITLE
Update auto-auth docs to remove tilde for home

### DIFF
--- a/website/content/docs/agent/autoauth/methods/token_file.mdx
+++ b/website/content/docs/agent/autoauth/methods/token_file.mdx
@@ -39,7 +39,7 @@ auto_auth {
     type      = "token_file"
 
     config = {
-      token_file_path = "~/.vault-token"
+      token_file_path = "/home/username/.vault-token"
     }
   }
 }

--- a/website/content/docs/agent/autoauth/methods/token_file.mdx
+++ b/website/content/docs/agent/autoauth/methods/token_file.mdx
@@ -36,7 +36,7 @@ vault {
 
 auto_auth {
   method {
-    type      = "token_file"
+    type = "token_file"
 
     config = {
       token_file_path = "/home/username/.vault-token"


### PR DESCRIPTION
Reported by https://github.com/hashicorp/vault/issues/19539

Just a mistake in the docs. Correcting it, then will backport.