### PR TITLE
docs / update 'vault plugin deregister' command doc

### DIFF
--- a/website/content/docs/commands/plugin/deregister.mdx
+++ b/website/content/docs/commands/plugin/deregister.mdx
@@ -23,5 +23,8 @@ Success! Deregistered plugin (if it was registered): my-custom-plugin
 
 ## Usage
 
-There are no flags beyond the [standard set of flags](/vault/docs/commands)
-included on all commands.
+The following flags are available in addition to the [standard set of
+flags](/vault/docs/commands) included on all commands.
+
+- `-version` `(string: "")` - Semantic version of the plugin to deregister. 
+  If unset, only an unversioned plugin may be deregistered.


### PR DESCRIPTION
https://developer.hashicorp.com/vault/docs/commands/plugin/deregister does not show the information relevant to the additional parameter `-version=` that is included from Vault 1.12.0 onwards - https://github.com/hashicorp/vault/blob/v1.12.0/command/plugin_deregister.go#L59 and the commit that added it: https://github.com/hashicorp/vault/pull/16856/files#diff-068ff36161239648c34a6fd7e1c450f20e249215ad8e4c7aaf0e6bfcbdb80ebbR59

On the https://github.com/hashicorp/vault/blob/main/CHANGELOG.md as `plugins: Add plugin version to auth register, list, and mount table [https://github.com/hashicorp/vault/pull/16856]`

preview: https://vault-ktctkyqtj-hashicorp.vercel.app/vault/docs/commands/plugin/deregister