### PR TITLE
do not print the token by default on login

### DIFF
--- a/changelog/19579.txt
+++ b/changelog/19579.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: stop printing token by default for CLI login runs and instead make it optional
+```

--- a/command/agent/auth/oci/oci.go
+++ b/command/agent/auth/oci/oci.go
@@ -12,9 +12,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agent/auth"
 	"github.com/oracle/oci-go-sdk/common"

--- a/command/agent/auth/oci/oci.go
+++ b/command/agent/auth/oci/oci.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -12,6 +11,8 @@ import (
 	"path"
 	"sync"
 	"time"
+
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"

--- a/command/login.go
+++ b/command/login.go
@@ -26,6 +26,7 @@ type LoginCommand struct {
 	flagPath       string
 	flagNoStore    bool
 	flagPrintToken bool
+	flagNoPrint    bool
 	flagTokenOnly  bool
 
 	testStdin io.Reader // for tests
@@ -112,6 +113,14 @@ func (c *LoginCommand) Flags() *FlagSets {
 	})
 
 	f.BoolVar(&BoolVar{
+		Name:    "no-print",
+		Target:  &c.flagNoPrint,
+		Default: false,
+		Usage: "Do not display the token. The token will be still be stored to the " +
+			"configured token helper.",
+	})
+
+	f.BoolVar(&BoolVar{
 		Name:    "print-token",
 		Target:  &c.flagPrintToken,
 		Default: false,
@@ -158,7 +167,7 @@ func (c *LoginCommand) Run(args []string) int {
 
 	if c.flagNoStore && !c.flagPrintToken {
 		c.UI.Error(wrapAtLength(
-			"-no-store and the absence of -print-token cannot be used together"))
+			"-no-store cannot be used without -print-token"))
 		return 1
 	}
 
@@ -319,6 +328,10 @@ func (c *LoginCommand) Run(args []string) int {
 			"The token was not stored in token helper. Set the VAULT_TOKEN "+
 				"environment variable or pass the token below with each request to "+
 				"Vault.") + "\n")
+	}
+
+	if c.flagNoPrint {
+		return 0
 	}
 
 	if !c.flagPrintToken {

--- a/website/content/docs/agent/autoauth/methods/token_file.mdx
+++ b/website/content/docs/agent/autoauth/methods/token_file.mdx
@@ -36,10 +36,10 @@ vault {
 
 auto_auth {
   method {
-    type      = "token_file"
+    type = "token_file"
 
     config = {
-      token_file_path = "~/.vault-token"
+      token_file_path = "/home/username/.vault-token"
     }
   }
 }


### PR DESCRIPTION
We want to stop printing the token, in plain text, used to login by default as this is a security concern when potentially screen sharing. However there may still be cases where this is useful for which there is now a flag `-print-token` which will continue the existing behavior and print the token to stdout. This flag does replace the `-no-print` flag as this is no longer needed. 