### PR TITLE
[QT-523] Remove copyright/license header from raft config used in theDocker/K8S integration test

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -10,5 +10,6 @@ project {
   header_ignore = [
     "builtin/credential/aws/pkcs7/**",
     "ui/node_modules/**",
+    "enos/modules/k8s_deploy_vault/raft-config.hcl",
   ]
 }

--- a/enos/modules/k8s_deploy_vault/raft-config.hcl
+++ b/enos/modules/k8s_deploy_vault/raft-config.hcl
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 ui = true
 listener "tcp" {
   address = "[::]:8200"


### PR DESCRIPTION
The addition of the copyright and license headers to the file: `enos/modules/k8s_deploy_vault/raft-config.hcl` has caused the K8S/Docker integration test to fail since the Vault deployment uses that file when configuring the storage backend. The addition of the header breaks the helm release and therefore the headers have been removed.