### PR TITLE
openapi: Fix logic for labeling unauthenticated/sudo paths

### DIFF
--- a/changelog/19600.txt
+++ b/changelog/19600.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+openapi: Fix logic for labeling unauthenticated/sudo paths.
+```

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -591,10 +591,8 @@ func specialPathMatch(path string, specialPaths []string) bool {
 		}
 
 		// match +
-		if strings.Contains(sp, "+") {
-			if pathMatchesByParts(pathParts, strings.Split(sp, "/")) {
-				return true
-			}
+		if strings.Contains(sp, "+") && pathMatchesByParts(pathParts, strings.Split(sp, "/")) {
+			return true
 		}
 	}
 

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -251,8 +251,8 @@ func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix st
 			Description: cleanString(p.HelpSynopsis),
 		}
 
-		pi.Sudo = sudoPaths.HasPath(path)
-		pi.Unauthenticated = unauthPaths.HasPath(path)
+		pi.Sudo = sudoPaths.HasExactPath(path)
+		pi.Unauthenticated = unauthPaths.HasExactPath(path)
 		pi.DisplayAttrs = p.DisplayAttrs
 
 		// If the newer style Operations map isn't defined, create one from the legacy fields.

--- a/sdk/framework/openapi_test.go
+++ b/sdk/framework/openapi_test.go
@@ -268,11 +268,18 @@ func TestOpenAPI_SpecialPaths(t *testing.T) {
 			unauthenticatedPaths:    []string{"foo"},
 			unauthenticatedExpected: false,
 		},
-		"ends-with-slash": {
+		"path-ends-with-slash": {
 			pattern:                 "foo/",
 			rootPaths:               []string{"foo/*"},
 			rootExpected:            true,
-			unauthenticatedPaths:    []string{"a", "b", "foo/"},
+			unauthenticatedPaths:    []string{"a", "b", "foo*"},
+			unauthenticatedExpected: true,
+		},
+		"asterisk-match-no-slash": {
+			pattern:                 "foo",
+			rootPaths:               []string{"foo*"},
+			rootExpected:            true,
+			unauthenticatedPaths:    []string{"a", "fo*"},
 			unauthenticatedExpected: true,
 		},
 		"multiple-root-paths": {
@@ -280,6 +287,34 @@ func TestOpenAPI_SpecialPaths(t *testing.T) {
 			rootPaths:               []string{"a", "b", "foo/*"},
 			rootExpected:            true,
 			unauthenticatedPaths:    []string{"foo/baz/*"},
+			unauthenticatedExpected: false,
+		},
+		"plus-match-unauthenticated": {
+			pattern:                 "foo/bar/baz",
+			rootPaths:               []string{"foo/bar"},
+			rootExpected:            false,
+			unauthenticatedPaths:    []string{"foo/+/baz"},
+			unauthenticatedExpected: true,
+		},
+		"plus-match-root": {
+			pattern:                 "foo/bar/baz",
+			rootPaths:               []string{"foo/+/baz"},
+			rootExpected:            true,
+			unauthenticatedPaths:    []string{"foo/bar"},
+			unauthenticatedExpected: false,
+		},
+		"plus-and-asterisk": {
+			pattern:                 "foo/bar/baz/something",
+			rootPaths:               []string{"foo/+/baz/*"},
+			rootExpected:            true,
+			unauthenticatedPaths:    []string{"foo/+/baz*"},
+			unauthenticatedExpected: true,
+		},
+		"double-plus-good": {
+			pattern:                 "foo/bar/baz",
+			rootPaths:               []string{"foo/+/+"},
+			rootExpected:            true,
+			unauthenticatedPaths:    []string{"foo/bar"},
 			unauthenticatedExpected: false,
 		},
 	}
@@ -421,7 +456,7 @@ func TestOpenAPI_Paths(t *testing.T) {
 		}
 
 		sp := &logical.Paths{
-			Root: []string{"foo/*"},
+			Root: []string{"foo*"},
 		}
 		testPath(t, p, sp, expected("operations"))
 	})
@@ -480,7 +515,7 @@ func TestOpenAPI_Paths(t *testing.T) {
 		}
 
 		sp := &logical.Paths{
-			Root: []string{"foo/*"},
+			Root: []string{"foo*"},
 		}
 		testPath(t, p, sp, expected("operations_list"))
 	})


### PR DESCRIPTION
The previous logic for matching unauthenticated & sudo paths in OpenAPI did not take into account the `+` wildcard, so some of the PKI paths were skipped.

With new logic, these are the new unauthenticated paths introduced for builtin plugins:

```sh
❱ diff unauth_before unauth_after2
27a28,30
> "/identity/oidc/provider/{name}/.well-known/keys"
> "/identity/oidc/provider/{name}/.well-known/openid-configuration"
> "/identity/oidc/provider/{name}/token"
57a61,69
> "/{pki_mount_path}/issuer/{issuer_ref}/crl"
> "/{pki_mount_path}/issuer/{issuer_ref}/crl/delta"
> "/{pki_mount_path}/issuer/{issuer_ref}/crl/delta/der"
> "/{pki_mount_path}/issuer/{issuer_ref}/crl/delta/pem"
> "/{pki_mount_path}/issuer/{issuer_ref}/crl/der"
> "/{pki_mount_path}/issuer/{issuer_ref}/crl/pem"
> "/{pki_mount_path}/issuer/{issuer_ref}/der"
> "/{pki_mount_path}/issuer/{issuer_ref}/json"
> "/{pki_mount_path}/issuer/{issuer_ref}/pem"
```

The list of "sudo" paths is unaffected by this PR for builtin plugins.

Resolves: #19581, [VAULT-14576](https://hashicorp.atlassian.net/browse/VAULT-14576)

[VAULT-14576]: https://hashicorp.atlassian.net/browse/VAULT-14576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ