### PR TITLE
Update KV-V2 docs to explicitly call out the secret mount path as a parameter

### DIFF
--- a/website/content/api-docs/secret/kv/kv-v2.mdx
+++ b/website/content/api-docs/secret/kv/kv-v2.mdx
@@ -22,7 +22,7 @@ key-value store.
 
 ### Parameters
 
-- `secret-mount-path` `(string: required)` - The path to the KV mount you wish to config,
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount you wish to config,
   such as `secret`. This is specified as part of the URL.
 
 - `max_versions` `(int: 0)` – The number of versions to keep per key. This value

--- a/website/content/api-docs/secret/kv/kv-v2.mdx
+++ b/website/content/api-docs/secret/kv/kv-v2.mdx
@@ -11,21 +11,19 @@ versioned mode. For general information about the usage and operation of the kv
 secrets engine, please see the [Vault kv
 documentation](/vault/docs/secrets/kv).
 
-~> Note: This documentation assumes the kv secrets engine is enabled at the
-`/secret` path in Vault and that versioning has been enabled. Since it is
-possible to enable secrets engines at any location, please update your API calls
-accordingly.
-
 ## Configure the KV Engine
 
 This path configures backend level settings that are applied to every key in the
 key-value store.
 
-| Method | Path             |
-| :----- | :--------------- |
-| `POST` | `/secret/config` |
+| Method | Path                         |
+|:-------|:-----------------------------|
+| `POST` | `/:secret-mount-path/config` |
 
 ### Parameters
+
+- `secret-mount-path` `(string: required)` - The path to the KV mount you wish to config,
+  such as `secret`. This is specified as part of the URL.
 
 - `max_versions` `(int: 0)` – The number of versions to keep per key. This value
   applies to all keys, but a key's metadata setting can overwrite this value.
@@ -65,9 +63,14 @@ $ curl \
 This path retrieves the current configuration for the secrets backend at the
 given path.
 
-| Method | Path             |
-| :----- | :--------------- |
-| `GET`  | `/secret/config` |
+| Method | Path                         |
+|:-------|:-----------------------------|
+| `GET`  | `/:secret-mount-path/config` |
+
+### Parameters
+
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount you wish to read the config,
+  of, such as `secret`. This is specified as part of the URL.
 
 ### Sample Request
 
@@ -97,12 +100,14 @@ specific. The `custom_metadata` field is part of the secret's key metadata and
 is included in the response whether or not the calling token has `read` access to
 the associated [metadata endpoint](/vault/api-docs/secret/kv/kv-v2#read-secret-metadata).
 
-| Method | Path                                         |
-| :----- | :------------------------------------------- |
-| `GET`  | `/secret/data/:path?version=:version-number` |
+| Method | Path                                                     |
+|:-------|:---------------------------------------------------------|
+| `GET`  | `/:secret-mount-path/data/:path?version=:version-number` |
 
 ### Parameters
 
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
+  the secret you wish to read, such as `secret`. This is specified as part of the URL.
 - `path` `(string: <required>)` – Specifies the path of the secret to read.
   This is specified as part of the URL.
 - `version` `(int: 0)` - Specifies the version to return. If not set the latest
@@ -145,11 +150,17 @@ the value does not yet exist, the calling token must have an ACL policy granting
 the `create` capability. If the value already exists, the calling token must
 have an ACL policy granting the `update` capability.
 
-| Method | Path                 |
-| :----- | :------------------- |
-| `POST` | `/secret/data/:path` |
+| Method | Path                             |
+|:-------|:---------------------------------|
+| `POST` | `/:secret-mount-path/data/:path` |
 
 ### Parameters
+
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
+  the secret you wish to update, such as `secret`. This is specified as part of the URL.
+
+- `path` `(string: <required>)` – Specifies the path of the secret to update.
+  This is specified as part of the URL.
 
 - `options` `(Map: <optional>)` – An object that holds option settings.
 
@@ -216,11 +227,17 @@ is supported and must be specified using a `Content-Type` header value of
 `application/merge-patch+json`. A new version will be created upon successfully
 applying a patch with the provided data.
 
-| Method  | Path                 |
-| :------ | :------------------- |
-| `PATCH` | `/secret/data/:path` |
+| Method  | Path                             |
+|:--------|:---------------------------------|
+| `PATCH` | `/:secret-mount-path/data/:path` |
 
 ### Parameters
+
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
+   the secret you wish to patch, such as `secret`. This is specified as part of the URL.
+
+- `path` `(string: <required>)` – Specifies the path of the secret to patch.
+   This is specified as part of the URL.
 
 - `options` `(Map: <optional>)` – An object that holds option settings.
 
@@ -283,12 +300,14 @@ at the requested path. The secret entry at this path will be retrieved
 and stripped of all data by replacing underlying values of leaf keys
 (i.e. non-map keys or map keys with no underlying subkeys) with `null`.
 
-| Method | Path                    |
-| :----- | :---------------------- |
-| `GET`  | `/secret/subkeys/:path` |
+| Method | Path                                |
+|:-------|:------------------------------------|
+| `GET`  | `/:secret-mount-path/subkeys/:path` |
 
 ### Parameters
 
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
+  the secret you wish to read, such as `secret`. This is specified as part of the URL.
 - `path` `(string: <required>)` – Specifies the path of the secret to read.
   This is specified as part of the URL.
 - `version` `(int: 0)` - Specifies the version to return. If not set the latest
@@ -348,10 +367,12 @@ delete can be undone using the `undelete` path.
 
 | Method   | Path                 |
 | :------- | :------------------- |
-| `DELETE` | `/secret/data/:path` |
+| `DELETE` | `/:secret-mount-path/data/:path` |
 
 ### Parameters
 
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
+  the secret you wish to delete, such as `secret`. This is specified as part of the URL.
 - `path` `(string: <required>)` – Specifies the path of the secret to delete.
   This is specified as part of the URL.
 
@@ -371,12 +392,14 @@ marks the versions as deleted and will stop them from being returned from reads,
 but the underlying data will not be removed. A delete can be undone using the
 `undelete` path.
 
-| Method | Path                   |
-| :----- | :--------------------- |
-| `POST` | `/secret/delete/:path` |
+| Method | Path                               |
+|:-------|:-----------------------------------|
+| `POST` | `/:secret-mount-path/delete/:path` |
 
 ### Parameters
 
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
+  the secret you wish to delete, such as `secret`. This is specified as part of the URL.
 - `path` `(string: <required>)` – Specifies the path of the secret to delete.
   This is specified as part of the URL.
 - `versions` `([]int: <required>)` - The versions to be deleted. The versioned
@@ -406,11 +429,14 @@ $ curl \
 Undeletes the data for the provided version and path in the key-value store.
 This restores the data, allowing it to be returned on get requests.
 
-| Method | Path                     |
-| :----- | :----------------------- |
-| `POST` | `/secret/undelete/:path` |
+| Method | Path                                 |
+|:-------|:-------------------------------------|
+| `POST` | `/:secret-mount-path/undelete/:path` |
 
 ### Parameters
+
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
+  the secret you wish to undelete, such as `secret`. This is specified as part of the URL.
 
 - `path` `(string: <required>)` – Specifies the path of the secret to undelete.
   This is specified as part of the URL.
@@ -441,11 +467,14 @@ $ curl \
 Permanently removes the specified version data for the provided key and version
 numbers from the key-value store.
 
-| Method | Path                    |
-| :----- | :---------------------- |
-| `POST` | `/secret/destroy/:path` |
+| Method | Path                                |
+|:-------|:------------------------------------|
+| `POST` | `/:secret-mount-path/destroy/:path` |
 
 ### Parameters
+
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
+  the secret you wish to destroy, such as `secret`. This is specified as part of the URL.
 
 - `path` `(string: <required>)` – Specifies the path of the secret to destroy.
   This is specified as part of the URL.
@@ -479,11 +508,14 @@ value. Note that no policy-based filtering is performed on keys; do not encode
 sensitive information in key names. The values themselves are not accessible via
 this command.
 
-| Method | Path                     |
-| :----- | :----------------------- |
-| `LIST` | `/secret/metadata/:path` |
+| Method | Path                                 |
+|:-------|:-------------------------------------|
+| `LIST` | `/:secret-mount-path/metadata/:path` |
 
 ### Parameters
+
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
+the secret you wish to list, such as `secret`. This is specified as part of the URL.
 
 - `path` `(string: <required>)` – Specifies the path of the secrets to list.
   This is specified as part of the URL.
@@ -516,11 +548,14 @@ entries.
 This endpoint retrieves the metadata and versions for the secret at the
 specified path. Metadata is version-agnostic.
 
-| Method | Path                     |
-| :----- | :----------------------- |
-| `GET`  | `/secret/metadata/:path` |
+| Method | Path                                 |
+|:-------|:-------------------------------------|
+| `GET`  | `/:secret-mount-path/metadata/:path` |
 
 ### Parameters
+
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
+  the secret you wish to read, such as `secret`. This is specified as part of the URL.
 
 - `path` `(string: <required>)` – Specifies the path of the secret to read.
   This is specified as part of the URL.
@@ -576,11 +611,17 @@ $ curl \
 This endpoint creates or updates the metadata of a secret at the specified location.
 It does not create a new version.
 
-| Method | Path                     |
-| :----- | :----------------------- |
-| `POST` | `/secret/metadata/:path` |
+| Method | Path                                 |
+|:-------|:-------------------------------------|
+| `POST` | `/:secret-mount-path/metadata/:path` |
 
 ### Parameters
+
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
+  the secret you wish to update, such as `secret`. This is specified as part of the URL.
+
+- `path` `(string: <required>)` – Specifies the path of the secret to update.
+  This is specified as part of the URL.
 
 - `max_versions` `(int: 0)` – The number of versions to keep per key. If not
   set, the backend’s configured max version is used. Once a key has more than
@@ -634,11 +675,17 @@ capability. Currently, only JSON merge patch is supported and must be specified
 using a `Content-Type` header value of `application/merge-patch+json`. It does
 not create a new version.
 
-| Method  | Path                     |
-| :------ | :----------------------- |
-| `PATCH` | `/secret/metadata/:path` |
+| Method  | Path                                 |
+|:--------|:-------------------------------------|
+| `PATCH` | `/:secret-mount-path/metadata/:path` |
 
 ### Parameters
+
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
+  the secret you wish to patch, such as `secret`. This is specified as part of the URL.
+
+- `path` `(string: <required>)` – Specifies the path of the secret to patch.
+  This is specified as part of the URL.
 
 - `max_versions` `(int: 0)` – The number of versions to keep per key. If not
   set, the backend’s configured max version is used. Once a key has more than
@@ -687,10 +734,13 @@ This endpoint permanently deletes the key metadata and all version data for the
 specified key. All version history will be removed.
 
 | Method   | Path                     |
-| :------- | :----------------------- |
+|:---------|:-------------------------|
 | `DELETE` | `/secret/metadata/:path` |
 
 ### Parameters
+
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
+  the secret you wish to delete, such as `secret`. This is specified as part of the URL.
 
 - `path` `(string: <required>)` – Specifies the path of the secret to delete.
   This is specified as part of the URL.

--- a/website/content/api-docs/secret/kv/kv-v2.mdx
+++ b/website/content/api-docs/secret/kv/kv-v2.mdx
@@ -22,7 +22,7 @@ key-value store.
 
 ### Parameters
 
-- `secret-mount-path` `(string: <required>)` - The path to the KV mount you wish to config,
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount to config,
   such as `secret`. This is specified as part of the URL.
 
 - `max_versions` `(int: 0)` – The number of versions to keep per key. This value
@@ -69,7 +69,7 @@ given path.
 
 ### Parameters
 
-- `secret-mount-path` `(string: <required>)` - The path to the KV mount you wish to read the config,
+- `secret-mount-path` `(string: <required>)` - The path to the KV mount to read the config,
   of, such as `secret`. This is specified as part of the URL.
 
 ### Sample Request
@@ -107,7 +107,7 @@ the associated [metadata endpoint](/vault/api-docs/secret/kv/kv-v2#read-secret-m
 ### Parameters
 
 - `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
-  the secret you wish to read, such as `secret`. This is specified as part of the URL.
+  the secret to read, such as `secret`. This is specified as part of the URL.
 - `path` `(string: <required>)` – Specifies the path of the secret to read.
   This is specified as part of the URL.
 - `version` `(int: 0)` - Specifies the version to return. If not set the latest
@@ -157,7 +157,7 @@ have an ACL policy granting the `update` capability.
 ### Parameters
 
 - `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
-  the secret you wish to update, such as `secret`. This is specified as part of the URL.
+  the secret to update, such as `secret`. This is specified as part of the URL.
 
 - `path` `(string: <required>)` – Specifies the path of the secret to update.
   This is specified as part of the URL.
@@ -234,7 +234,7 @@ applying a patch with the provided data.
 ### Parameters
 
 - `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
-   the secret you wish to patch, such as `secret`. This is specified as part of the URL.
+   the secret to patch, such as `secret`. This is specified as part of the URL.
 
 - `path` `(string: <required>)` – Specifies the path of the secret to patch.
    This is specified as part of the URL.
@@ -307,7 +307,7 @@ and stripped of all data by replacing underlying values of leaf keys
 ### Parameters
 
 - `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
-  the secret you wish to read, such as `secret`. This is specified as part of the URL.
+  the secret to read, such as `secret`. This is specified as part of the URL.
 - `path` `(string: <required>)` – Specifies the path of the secret to read.
   This is specified as part of the URL.
 - `version` `(int: 0)` - Specifies the version to return. If not set the latest
@@ -372,7 +372,7 @@ delete can be undone using the `undelete` path.
 ### Parameters
 
 - `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
-  the secret you wish to delete, such as `secret`. This is specified as part of the URL.
+  the secret to delete, such as `secret`. This is specified as part of the URL.
 - `path` `(string: <required>)` – Specifies the path of the secret to delete.
   This is specified as part of the URL.
 
@@ -399,7 +399,7 @@ but the underlying data will not be removed. A delete can be undone using the
 ### Parameters
 
 - `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
-  the secret you wish to delete, such as `secret`. This is specified as part of the URL.
+  the secret to delete, such as `secret`. This is specified as part of the URL.
 - `path` `(string: <required>)` – Specifies the path of the secret to delete.
   This is specified as part of the URL.
 - `versions` `([]int: <required>)` - The versions to be deleted. The versioned
@@ -436,7 +436,7 @@ This restores the data, allowing it to be returned on get requests.
 ### Parameters
 
 - `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
-  the secret you wish to undelete, such as `secret`. This is specified as part of the URL.
+  the secret to undelete, such as `secret`. This is specified as part of the URL.
 
 - `path` `(string: <required>)` – Specifies the path of the secret to undelete.
   This is specified as part of the URL.
@@ -474,7 +474,7 @@ numbers from the key-value store.
 ### Parameters
 
 - `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
-  the secret you wish to destroy, such as `secret`. This is specified as part of the URL.
+  the secret to destroy, such as `secret`. This is specified as part of the URL.
 
 - `path` `(string: <required>)` – Specifies the path of the secret to destroy.
   This is specified as part of the URL.
@@ -515,7 +515,7 @@ this command.
 ### Parameters
 
 - `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
-the secret you wish to list, such as `secret`. This is specified as part of the URL.
+the secret to list, such as `secret`. This is specified as part of the URL.
 
 - `path` `(string: <required>)` – Specifies the path of the secrets to list.
   This is specified as part of the URL.
@@ -555,7 +555,7 @@ specified path. Metadata is version-agnostic.
 ### Parameters
 
 - `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
-  the secret you wish to read, such as `secret`. This is specified as part of the URL.
+  the secret to read, such as `secret`. This is specified as part of the URL.
 
 - `path` `(string: <required>)` – Specifies the path of the secret to read.
   This is specified as part of the URL.
@@ -618,7 +618,7 @@ It does not create a new version.
 ### Parameters
 
 - `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
-  the secret you wish to update, such as `secret`. This is specified as part of the URL.
+  the secret to update, such as `secret`. This is specified as part of the URL.
 
 - `path` `(string: <required>)` – Specifies the path of the secret to update.
   This is specified as part of the URL.
@@ -682,7 +682,7 @@ not create a new version.
 ### Parameters
 
 - `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
-  the secret you wish to patch, such as `secret`. This is specified as part of the URL.
+  the secret to patch, such as `secret`. This is specified as part of the URL.
 
 - `path` `(string: <required>)` – Specifies the path of the secret to patch.
   This is specified as part of the URL.
@@ -740,7 +740,7 @@ specified key. All version history will be removed.
 ### Parameters
 
 - `secret-mount-path` `(string: <required>)` - The path to the KV mount containing
-  the secret you wish to delete, such as `secret`. This is specified as part of the URL.
+  the secret to delete, such as `secret`. This is specified as part of the URL.
 
 - `path` `(string: <required>)` – Specifies the path of the secret to delete.
   This is specified as part of the URL.


### PR DESCRIPTION
This came in as part of https://github.com/hashicorp/vault/issues/19599

We used to have a note at the top telling customers to sub out `/secret` for the path to their mount of interest, but if you were linked to a specific API, you could miss it.

I feel like, especially for API docs, we should call this out explicitly, so I've tried to do so. We also missed calling out `path` in a few places, so I added that too. Do feel free to tell me if you feel like this is the wrong idea, though. I'm totally open to not merging this if folks feel like it makes things more confusing instead of more clear.

See: https://vault-7r5tqdn4k-hashicorp.vercel.app/vault/api-docs/secret/kv/kv-v2 for a direct link.