### PR TITLE
use Platform from host info for node status OS

### DIFF
--- a/vault/hcp_link/capabilities/node_status/node_status.go
+++ b/vault/hcp_link/capabilities/node_status/node_status.go
@@ -77,7 +77,7 @@ func (c *NodeStatusReporter) GetNodeStatus(ctx context.Context) (retStatus nodes
 		ReplicationState:       replState.StateStrings(),
 		Hostname:               hostInfo.Hostname,
 		ListenerAddresses:      listenerAddresses,
-		OperatingSystem:        hostInfo.OS,
+		OperatingSystem:        hostInfo.Platform,
 		OperatingSystemVersion: hostInfo.PlatformVersion,
 		LogLevel:               node_status.LogLevel(logLevel),
 		ActiveTime:             timestamppb.New(c.NodeStatusGetter.ActiveTime()),


### PR DESCRIPTION
The `OS` from host info will be less specific than `Platform`. For example, `OS` would be `linux` but `Platform` would be `ubuntu`. The node status correctly uses `PlatformVersion` for the OS version but that does not properly correspond to `OS`.