### PR TITLE
More wrapped errors - PKI, SSH, Transit 

### DIFF
--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -1080,7 +1080,7 @@ func writeSpecificRevocationDeltaWALs(sc *storageContext, hyphenSerial string, c
 	var walInfo deltaWALInfo
 	walEntry, err := logical.StorageEntryJSON(pathPrefix+hyphenSerial, walInfo)
 	if err != nil {
-		return fmt.Errorf("unable to create delta CRL WAL entry")
+		return fmt.Errorf("unable to create delta CRL WAL entry: %w", err)
 	}
 
 	if err = sc.Storage.Put(sc.Context, walEntry); err != nil {
@@ -1093,7 +1093,7 @@ func writeSpecificRevocationDeltaWALs(sc *storageContext, hyphenSerial string, c
 	lastRevSerial := lastWALInfo{Serial: colonSerial}
 	lastWALEntry, err := logical.StorageEntryJSON(pathPrefix+deltaWALLastRevokedSerialName, lastRevSerial)
 	if err != nil {
-		return fmt.Errorf("unable to create last delta CRL WAL entry")
+		return fmt.Errorf("unable to create last delta CRL WAL entry: %w", err)
 	}
 	if err = sc.Storage.Put(sc.Context, lastWALEntry); err != nil {
 		return fmt.Errorf("error saving last delta CRL WAL entry: %w", err)

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -1428,7 +1428,7 @@ func (sc *storageContext) fetchRevocationInfo(serial string) (*revocationInfo, e
 	if revEntry != nil {
 		err = revEntry.DecodeJSON(&revInfo)
 		if err != nil {
-			return nil, fmt.Errorf("error decoding existing revocation info")
+			return nil, fmt.Errorf("error decoding existing revocation info: %w", err)
 		}
 	}
 

--- a/builtin/logical/ssh/path_issue_sign.go
+++ b/builtin/logical/ssh/path_issue_sign.go
@@ -501,7 +501,7 @@ func (b *creationBundle) sign() (retCert *ssh.Certificate, retErr error) {
 	// prepare certificate for signing
 	nonce := make([]byte, 32)
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return nil, fmt.Errorf("failed to generate signed SSH key: error generating random nonce")
+		return nil, fmt.Errorf("failed to generate signed SSH key: error generating random nonce: %w", err)
 	}
 	certificate := &ssh.Certificate{
 		Serial:          serialNumber.Uint64(),

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -365,7 +365,7 @@ func (b *backend) pathPolicyRead(ctx context.Context, req *logical.Request, d *f
 						}
 						derived, err := p.GetKey(context, ver, 32)
 						if err != nil {
-							return nil, fmt.Errorf("failed to derive key to return public component")
+							return nil, fmt.Errorf("failed to derive key to return public component: %w", err)
 						}
 						pubKey := ed25519.PrivateKey(derived).Public().(ed25519.PublicKey)
 						key.PublicKey = base64.StdEncoding.EncodeToString(pubKey)


### PR DESCRIPTION
None of these appear to be related to storage issues, so I'm not inclined to backport them. But for completeness, I audited the rest of PKI, SSH, and Transit for errors which are created but don't wrap anything and found a few more places. 

Related to #19624. 