### PR TITLE
ci: unpin terraform in CICD

### DIFF
--- a/.github/workflows/enos-fmt.yml
+++ b/.github/workflows/enos-fmt.yml
@@ -19,9 +19,6 @@ jobs:
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
-          # Terraform 1.4.x introduced an issue that prevents some resources from
-          # planning. Pin to 1.3.x until it is resolved.
-          terraform_version: 1.3.9
       - uses: hashicorp/action-setup-enos@v1
         with:
           github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}

--- a/.github/workflows/enos-run-k8s.yml
+++ b/.github/workflows/enos-run-k8s.yml
@@ -38,9 +38,6 @@ jobs:
           # the Terraform wrapper will break Terraform execution in Enos because
           # it changes the output to text when we expect it to be JSON.
           terraform_wrapper: false
-          # Terraform 1.4.x introduced an issue that prevents some resources from
-          # planning. Pin to 1.3.x until it is resolved.
-          terraform_version: 1.3.9
       - name: Set up Enos
         uses: hashicorp/action-setup-enos@v1
         with:

--- a/.github/workflows/test-enos-scenario-ui.yml
+++ b/.github/workflows/test-enos-scenario-ui.yml
@@ -90,9 +90,6 @@ jobs:
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_wrapper: false
-          # Terraform 1.4.x introduced an issue that prevents some resources from
-          # planning. Pin to 1.3.x until it is resolved.
-          terraform_version: 1.3.9
       - name: Prepare scenario dependencies
         run: |
           mkdir -p ./enos/support/terraform-plugin-cache

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -111,9 +111,6 @@ jobs:
           # the Terraform wrapper will break Terraform execution in Enos because
           # it changes the output to text when we expect it to be JSON.
           terraform_wrapper: false
-          # Terraform 1.4.x introduced an issue that prevents some resources from
-          # planning. Pin to 1.3.x until it is resolved.
-          terraform_version: 1.3.9
       - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}


### PR DESCRIPTION
A prior planning bug was resolved in Terraform 1.4.2 so we can unpin Terraform