### PR TITLE
Updated connection_url to be pgx library relevant

### DIFF
--- a/website/content/api-docs/secret/databases/postgresql.mdx
+++ b/website/content/api-docs/secret/databases/postgresql.mdx
@@ -27,11 +27,12 @@ has a number of parameters to further configure a connection.
 - `connection_url` `(string: <required>)` - Specifies the PostgreSQL DSN. This field
   can be templated and supports passing the username and password
   parameters in the following format `{{field_name}}`. Certificate authentication
-  can be used by setting `?sslinline=true` and giving the SSL credentials in the
-  `sslrootcert`, `sslcert` and `sslkey` credentials. A templated connection URL
-  is required when using root credential rotation. This field supports both format
-  string types, URI and keyword/value. Both formats support multiple host connection
-  strings.
+  can be used by setting `?sslmode=` to be any of the applicable values as outlined in 
+  the [Postgres SQL documentation](https://www.postgresql.org/docs/11/libpq-ssl.html#LIBPQ-SSL-PROTECTION)
+  and giving the SSL credentials in the `sslrootcert`, `sslcert` and `sslkey` credentials. 
+  A templated connection URL is required when using root credential rotation. This field 
+  supports both format string types, URI and keyword/value. Both formats support multiple 
+  host connection strings.
 
 - `max_open_connections` `(int: 4)` - Specifies the maximum number of open
   connections to the database.


### PR DESCRIPTION
Updated connection_url to be according to the options available in the pgx library instead of the now deprecated use of the lib/pq which was done as part of Vault 1.11 as documented here - https://github.com/hashicorp/vault/blob/main/CHANGELOG.md#june-20-2022