### PR TITLE
[Docs] Fix the title parsing error - userpass

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1446,7 +1446,7 @@
         "path": "auth/token"
       },
       {
-        "title": "Username &amp; Password",
+        "title": "Username and Password",
         "path": "auth/userpass"
       },
       {


### PR DESCRIPTION
It was reported that the `userpass` auth method title appears...

![image](https://user-images.githubusercontent.com/7660718/227055291-f24762eb-1e31-4be7-aacc-64b2fc323051.png)


This PR fixes this issue.

🔍 [Deploy preview](https://vault-git-docs-fix-format-userpass-hashicorp.vercel.app/vault/docs/auth/userpass)




