### PR TITLE
Update username template description for AWS

### DIFF
--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -64,7 +64,9 @@ valid AWS credentials with proper permissions.
 
   To ensure generated usernames are within length limits for both STS/IAM, the template must adequately handle
   both conditional cases (see [Conditional Templates](https://pkg.go.dev/text/template)). As an example, if no template
-  is provided the field defaults to the template:
+  is provided the field defaults to the template below. It is to be noted that, DisplayName is the name of the vault 
+  authenticated user running the AWS credential generation and PolicyName is the name of the Role for which the 
+  credential is being generated for:
 
   ```
   {{ if (eq .Type "STS") }}


### PR DESCRIPTION
Update username template description for AWS by calling out what DisplayName and PolicyName actually are placeholders for