### PR TITLE
Step three cont. Bulma classes to component files

### DIFF
--- a/ui/app/styles/components/box-label.scss
+++ b/ui/app/styles/components/box-label.scss
@@ -9,12 +9,8 @@ label.box-label {
 
 .box-label {
   @extend .box;
-  // @extend .is-centered;
-  // @extend .is-gapless;
-  justify-content: center;
-  margin-left: 0;
-  margin-right: 0;
-  margin-top: 0;
+  @extend .is-centered;
+  @extend .is-gapless;
 
   border-color: $grey-light;
   border-radius: 3px;

--- a/ui/app/styles/components/icon.scss
+++ b/ui/app/styles/components/icon.scss
@@ -3,6 +3,35 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+.icon {
+  align-items: center;
+  display: inline-flex;
+  height: 1.5rem;
+  justify-content: center;
+  width: 1.5rem;
+}
+
+.icon-blue {
+  color: $blue;
+}
+
+.file-icon {
+  align-items: center;
+  display: flex;
+  height: 1em;
+  justify-content: center;
+  margin-right: 0.5em;
+  width: 1em;
+}
+
+.flight-icon {
+  &.flight-icon-display-inline {
+    vertical-align: middle;
+    margin-left: 4px;
+    margin-right: 4px;
+  }
+}
+
 .hs-icon {
   flex: 0 0 auto;
   display: inline-flex;
@@ -47,16 +76,4 @@
 .hs-icon-xxl {
   width: 32px;
   height: 32px;
-}
-
-.flight-icon {
-  &.flight-icon-display-inline {
-    vertical-align: middle;
-    margin-left: 4px;
-    margin-right: 4px;
-  }
-}
-
-.icon-blue {
-  color: $blue;
 }

--- a/ui/app/styles/components/icon.scss
+++ b/ui/app/styles/components/icon.scss
@@ -27,8 +27,8 @@
 .flight-icon {
   &.flight-icon-display-inline {
     vertical-align: middle;
-    margin-left: 4px;
-    margin-right: 4px;
+    margin-left: $spacing-xxs;
+    margin-right: $spacing-xxs;
   }
 }
 

--- a/ui/app/styles/components/modal.scss
+++ b/ui/app/styles/components/modal.scss
@@ -21,13 +21,13 @@
 }
 
 .modal-background {
-  position: absolute;
+  background: $ui-gray-100;
   bottom: 0;
   left: 0;
+  opacity: 0.9;
+  position: absolute;
   right: 0;
   top: 0;
-  background: $ui-gray-100;
-  opacity: 0.9;
 }
 
 .modal-card {
@@ -86,11 +86,6 @@
 }
 
 .modal-card-body {
-  -webkit-overflow-scrolling: touch;
-  background-color: white;
-  flex-grow: 1;
-  flex-shrink: 1;
-  overflow: auto;
   padding: 20px;
 }
 

--- a/ui/app/styles/components/modal.scss
+++ b/ui/app/styles/components/modal.scss
@@ -85,6 +85,15 @@
   align-items: center;
 }
 
+.modal-card-body {
+  -webkit-overflow-scrolling: touch;
+  background-color: white;
+  flex-grow: 1;
+  flex-shrink: 1;
+  overflow: auto;
+  padding: 20px;
+}
+
 pre {
   background-color: inherit;
 }

--- a/ui/app/styles/components/modal.scss
+++ b/ui/app/styles/components/modal.scss
@@ -14,10 +14,20 @@
   overflow: hidden;
   position: fixed;
   z-index: 20;
+
+  &.is-active {
+    display: flex;
+  }
 }
 
 .modal-background {
-  background: rgba(235, 238, 242, 0.9);
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  top: 0;
+  background: $ui-gray-100;
+  opacity: 0.9;
 }
 
 .modal-card {
@@ -134,5 +144,15 @@ pre {
   &.has-padding-btm-left {
     padding-bottom: $spacing-m;
     padding-left: $spacing-m;
+  }
+}
+
+// responsive css
+@media screen and (min-width: 769px), print {
+  .modal-card,
+  .modal-content {
+    margin: 0 auto;
+    max-height: calc(100vh - 40px);
+    width: 640px;
   }
 }

--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -106,9 +106,9 @@
 @import './components/role-item';
 @import './components/search-select';
 @import './components/selectable-card';
-@import './components/selectable-card-container.scss';
+@import './components/selectable-card-container';
 // action-block extends selectable-card
-@import './components/action-block.scss';
+@import './components/action-block';
 @import './components/shamir-modal-flow';
 @import './components/shamir-progress';
 @import './components/sidebar';
@@ -120,7 +120,7 @@
 @import './components/token-expire-warning';
 @import './components/toolbar';
 @import './components/tool-tip';
-@import './components/transform-edit.scss';
+@import './components/transform-edit';
 @import './components/transit-card';
 @import './components/ttl-picker';
 @import './components/unseal-warning';

--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -73,6 +73,7 @@
 @import './components/form-section';
 @import './components/global-flash';
 @import './components/hover-copy-button';
+@import './components/icon';
 @import './components/init-illustration';
 @import './components/info-table';
 @import './components/info-table-row';
@@ -128,6 +129,3 @@
 @import './components/vault-loading';
 @import './components/vlt-radio';
 @import './components/vlt-table';
-
-// bulma-free-zone
-@import './components/icon';

--- a/ui/app/styles/core/box.scss
+++ b/ui/app/styles/core/box.scss
@@ -4,7 +4,11 @@
  */
 
 .box {
+  background-color: $white;
   box-shadow: 0 0 0 1px rgba($grey-dark, 0.3);
+  color: #4a4a4a;
+  display: block;
+  padding: 1.25rem;
 
   .title {
     &.has-padding-top {

--- a/ui/app/styles/core/box.scss
+++ b/ui/app/styles/core/box.scss
@@ -6,7 +6,7 @@
 .box {
   background-color: $white;
   box-shadow: 0 0 0 1px rgba($grey-dark, 0.3);
-  color: #4a4a4a;
+  color: $ui-gray-900;
   display: block;
   padding: 1.25rem;
 
@@ -20,7 +20,11 @@
       padding-bottom: $spacing-s;
     }
   }
+  &:not(:last-child) {
+    margin-bottom: 1.5rem;
+  }
 }
+
 .box.is-fullwidth {
   padding-left: 0;
   padding-right: 0;

--- a/ui/app/styles/core/bulma-classes.css
+++ b/ui/app/styles/core/bulma-classes.css
@@ -728,15 +728,6 @@ fieldset[disabled] .select select:hover {
   max-width: none;
 }
 
-.file-icon {
-  align-items: center;
-  display: flex;
-  height: 1em;
-  justify-content: center;
-  margin-right: 0.5em;
-  width: 1em;
-}
-
 /* ARG TODO: used is-normal in one place */
 @media screen and (min-width: 769px), print {
   .field-label {
@@ -979,14 +970,6 @@ fieldset[disabled] .button {
   .container:not(.is-max-desktop):not(.is-max-widescreen) {
     max-width: 1344px;
   }
-}
-
-.icon {
-  align-items: center;
-  display: inline-flex;
-  height: 1.5rem;
-  justify-content: center;
-  width: 1.5rem;
 }
 
 .notification {

--- a/ui/app/styles/core/bulma-classes.css
+++ b/ui/app/styles/core/bulma-classes.css
@@ -779,21 +779,6 @@ fieldset[disabled] .select select:hover {
 }
 
 /* BULMA ELEMENTS */
-.box {
-  background-color: white;
-  color: #4a4a4a;
-  display: block;
-  padding: 1.25rem;
-}
-
-a.box:hover, a.box:focus {
-  box-shadow: 0 0.5em 1em -0.125em rgba(10, 10, 10, 0.1), 0 0 0 1px #485fc7;
-}
-
-a.box:active {
-  box-shadow: inset 0 1px 2px rgba(10, 10, 10, 0.2), 0 0 0 1px #485fc7;
-}
-
 .button {
   background-color: white;
   border-color: #dbdbdb;

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -183,7 +183,7 @@ $button-box-shadow-standard: 0 3px 1px 0 rgba($black, 0.12);
     height: 2rem;
     padding: $size-11 $size-8;
   }
-
+  // ARG TODO fix and add to helper, you can see this in the database icon color modal.
   .has-text-info & {
     font-weight: $font-weight-semibold;
   }


### PR DESCRIPTION
This PR finishes up the last of moving Bulma classes into the component files (see first [PR](https://github.com/hashicorp/vault/pull/19683))

Targeting the components before core scss was intentional. There are less issues and only a couple of components with the same names as the Bulma classes (e.g. modal or box).

Below are the components addressed and their relevant pictures:
* `box-label.scss`. An easy fix now that we can use the extends because those helpers exists.
![image](https://user-images.githubusercontent.com/6618863/227236945-e98c2609-7315-46d4-ab00-c5edd3f3cae9.png)


* `icon.scss` this file was orginally "bulma free" but it made sense to me to carry over any bulma classes that impacted the `class="icon"` to be moved here. I alphabetized a little as well. The color is wrong but that's a helper issue I'll address in another PR.
![image](https://user-images.githubusercontent.com/6618863/227237150-78b4e274-7793-43d9-8449-12700122c4a1.png)

* `modal.scss` I just missed a couple of bulma classes here from my last PR. Disabled button is wrong color, but that's a button issue not a modal thing.
![image](https://user-images.githubusercontent.com/6618863/227237453-35067cb6-5762-4af1-ad1f-5f39980a46e7.png)

* `box.scss` Very specific bulma classes that I added into this component. For my process on how I do this, read the first PRs description. In the image below, `.box` is the "border" under the title and at the end of the policy block.
![image](https://user-images.githubusercontent.com/6618863/227237719-00d66df6-bc3a-45c8-9c5d-70799b006adf.png)

