### PR TITLE
Secret Metadata Breadcrumb Bug

### DIFF
--- a/changelog/19703.txt
+++ b/changelog/19703.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes issue navigating back a level using the breadcrumb from secret metadata view
+```

--- a/ui/app/templates/vault/cluster/secrets/backend/metadata.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/metadata.hbs
@@ -2,7 +2,7 @@
   <p.top>
     <KeyValueHeader
       @baseKey={{hash id=this.id}}
-      @path="vault.cluster.secrets.backend.show"
+      @path="vault.cluster.secrets.backend.list"
       @mode="show"
       @showCurrent={{true}}
       @root={{this.backendCrumb}}

--- a/ui/tests/acceptance/secrets/backend/kv/breadcrumbs-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/breadcrumbs-test.js
@@ -1,0 +1,28 @@
+import { create } from 'ember-cli-page-object';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
+import authPage from 'vault/tests/pages/auth';
+import consoleClass from 'vault/tests/pages/components/console/ui-panel';
+
+const consolePanel = create(consoleClass);
+
+module('Acceptance | kv | breadcrumbs', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('it should route back to parent path from metadata tab', async function (assert) {
+    await authPage.login();
+    await consolePanel.runCommands(['delete sys/mounts/kv', 'write sys/mounts/kv type=kv-v2']);
+    await visit('/vault/secrets/kv/list');
+    await click('[data-test-secret-create]');
+    await fillIn('[data-test-secret-path]', 'foo/bar');
+    await click('[data-test-secret-save]');
+    await click('[data-test-secret-metadata-tab]');
+    await click('[data-test-secret-breadcrumb="foo"]');
+    assert.strictEqual(
+      currentURL(),
+      '/vault/secrets/kv/list/foo/',
+      'Routes back to list view on breadcrumb click'
+    );
+  });
+});

--- a/ui/tests/acceptance/secrets/backend/kv/breadcrumbs-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/breadcrumbs-test.js
@@ -24,5 +24,6 @@ module('Acceptance | kv | breadcrumbs', function (hooks) {
       '/vault/secrets/kv/list/foo/',
       'Routes back to list view on breadcrumb click'
     );
+    await consolePanel.runCommands(['delete sys/mounts/kv']);
   });
 });


### PR DESCRIPTION
It was discovered that a 404 was thrown when navigating back a level from the metadata tab of a secret using the breadcrumbs. The link was pointing to the `show` route in the metadata view rather than `list` route as in secret tab. 

Before:

https://user-images.githubusercontent.com/24611656/227052386-287bf581-34b1-4f3a-8f6e-68d9a2a05b05.mov

After:

https://user-images.githubusercontent.com/24611656/227052440-ae5cf5dd-2390-4189-b693-a8f842230b57.mov



