### PR TITLE
Address regression introduced by #15493 for non-raft storage backends.

### DIFF
--- a/changelog/19721.txt
+++ b/changelog/19721.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix regression breaking non-raft clusters whose nodes share the same cluster_addr/api_addr.
+```

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -238,7 +238,7 @@ func (c *Core) Leader() (isLeader bool, leaderAddr, clusterAddr string, err erro
 	// to ourself, there's no point in paying any attention to it.  And by
 	// disregarding it, we can avoid a panic in raft tests using the Inmem network
 	// layer when we try to connect back to ourself.
-	if adv.ClusterAddr == c.ClusterAddr() && adv.RedirectAddr == c.redirectAddr {
+	if adv.ClusterAddr == c.ClusterAddr() && adv.RedirectAddr == c.redirectAddr && c.getRaftBackend() != nil {
 		return false, "", "", nil
 	}
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/vault/issues/17737.