### PR TITLE
Fix response structure validation for non-2xx responses

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -5254,12 +5254,8 @@ func TestBackend_IfModifiedSinceHeaders(t *testing.T) {
 		},
 	}
 	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-		// XXX: Schema response validation does not take into account
-		// response codes, preventing non-200 responses from working
-		// properly.
-		//
-		// RequestResponseCallback: schema.ResponseValidatingCallback(t),
+		HandlerFunc:             vaulthttp.Handler,
+		RequestResponseCallback: schema.ResponseValidatingCallback(t),
 	})
 	cluster.Start()
 	defer cluster.Cleanup()

--- a/sdk/helper/testhelpers/schema/response_validation_test.go
+++ b/sdk/helper/testhelpers/schema/response_validation_test.go
@@ -275,6 +275,36 @@ func TestValidateResponse(t *testing.T) {
 			errorExpected: false,
 		},
 
+		"string schema field, response has non-200 http_status_code, strict": {
+			schema: &framework.Response{
+				Fields: map[string]*framework.FieldSchema{
+					"foo": {
+						Type: framework.TypeString,
+					},
+				},
+			},
+			response: map[string]interface{}{
+				"http_status_code": 304,
+			},
+			strict:        true,
+			errorExpected: false,
+		},
+
+		"string schema field, response has non-200 http_status_code, not strict": {
+			schema: &framework.Response{
+				Fields: map[string]*framework.FieldSchema{
+					"foo": {
+						Type: framework.TypeString,
+					},
+				},
+			},
+			response: map[string]interface{}{
+				"http_status_code": 304,
+			},
+			strict:        false,
+			errorExpected: false,
+		},
+
 		"schema has http_raw_body, strict": {
 			schema: &framework.Response{
 				Fields: map[string]*framework.FieldSchema{


### PR DESCRIPTION
Certain responses may come through into `ValidateResponse` with non-2xx status codes (e.g. through `ResponseValidatingCallback`). While these are not always errors (e.g. 3xx redirection codes), we don't consider them for the purposes of schema validation.

Also fixing an example of where this was an issue in PKI test (`TestBackend_IfModifiedSinceHeaders`).