### PR TITLE
add warning for vault lambda extension cache ttl

### DIFF
--- a/changelog/19738.txt
+++ b/changelog/19738.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-website/docs: Add warning about Vault Lambda Extension TTL
-```

--- a/changelog/19738.txt
+++ b/changelog/19738.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+website/docs: Add warning about Vault Lambda Extension TTL
+```

--- a/website/content/docs/platform/aws/lambda-extension.mdx
+++ b/website/content/docs/platform/aws/lambda-extension.mdx
@@ -102,7 +102,7 @@ $ curl --silent https://releases.hashicorp.com/vault-lambda-extension/0.5.0/vaul
   --output vault-lambda-extension.zip
 ```
 
-Unzip the donwloaded binary.
+Unzip the downloaded binary.
 
 ```shell-session
 $ unzip vault-lambda-extension.zip
@@ -248,6 +248,10 @@ cached as though the header `X-Vault-Cache-Control: cache` was present. Setting
 the header to `nocache` on a request will opt-out of caching entirely in this
 configuration. Setting the header to `recache` will skip the cache lookup and
 return and cache the response from Vault as described previously.
+
+~> **Warning!** The cached data lives in-memory of the Vault Lambda Extension
+and will be removed when the Lambda execution environment shuts down.
+In order words, the cache TTL is capped to the duration of the Lambda execution environment.
 
 ## Limitations
 

--- a/website/content/docs/platform/aws/lambda-extension.mdx
+++ b/website/content/docs/platform/aws/lambda-extension.mdx
@@ -249,8 +249,8 @@ the header to `nocache` on a request will opt-out of caching entirely in this
 configuration. Setting the header to `recache` will skip the cache lookup and
 return and cache the response from Vault as described previously.
 
-~> **Warning!** The cached data lives in-memory of the Vault Lambda Extension
-and will be removed when the Lambda execution environment shuts down.
+~> **Warning!** The Vault Lambda Extension's cache is only in-memory
+and will not be persisted when the Lambda execution environment shuts down.
 In order words, the cache TTL is capped to the duration of the Lambda execution environment.
 
 ## Limitations


### PR DESCRIPTION
Add a warning in the Vault Lambda Extension docs about the cache ttl.
