### PR TITLE
Console Panel Updates

### DIFF
--- a/ui/app/components/sidebar/frame.hbs
+++ b/ui/app/components/sidebar/frame.hbs
@@ -11,7 +11,7 @@
         <button
           type="button"
           class="button is-transparent has-text-white"
-          {{on "click" (fn (mut this.showConsole) (not this.showConsole))}}
+          {{on "click" (fn (mut this.console.isOpen) (not this.console.isOpen))}}
           data-test-console-toggle
         >
           <Icon @name="terminal-screen" @size="24" />
@@ -31,7 +31,7 @@
   <Frame.Main>
     {{! outlet for app content }}
     <LinkStatus @status={{this.currentCluster.cluster.hcpLinkStatus}} />
-    <div class={{if this.showConsole "panel-open"}}>
+    <div class={{if this.console.isOpen "panel-open"}}>
       <Console::UiPanel @isFullscreen={{this.consoleFullscreen}} />
     </div>
     {{yield}}

--- a/ui/app/components/sidebar/frame.hbs
+++ b/ui/app/components/sidebar/frame.hbs
@@ -31,7 +31,7 @@
   <Frame.Main>
     {{! outlet for app content }}
     <LinkStatus @status={{this.currentCluster.cluster.hcpLinkStatus}} />
-    <div class={{if this.console.isOpen "panel-open"}}>
+    <div data-test-console-panel class={{if this.console.isOpen "panel-open"}}>
       <Console::UiPanel @isFullscreen={{this.consoleFullscreen}} />
     </div>
     {{yield}}

--- a/ui/app/components/sidebar/frame.js
+++ b/ui/app/components/sidebar/frame.js
@@ -3,4 +3,5 @@ import { inject as service } from '@ember/service';
 
 export default class SidebarNavComponent extends Component {
   @service currentCluster;
+  @service console;
 }

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -4,7 +4,7 @@
  */
 
 .console-ui-panel {
-  background: $black;
+  background: var(--token-color-palette-neutral-700);
   height: 0;
   left: 0;
   min-height: 0;

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -86,6 +86,7 @@
     font-weight: $font-weight-bold;
     outline: none;
     padding: $size-10;
+    margin-right: $spacing-xs;
     transition: background-color $speed;
   }
 }

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -4,7 +4,7 @@
  */
 
 .console-ui-panel {
-  background: linear-gradient(to right, #191a1c, #1b212d);
+  background: $black;
   height: 0;
   left: 0;
   min-height: 0;
@@ -19,7 +19,7 @@
   .button {
     background: transparent;
     border: none;
-    color: $grey;
+    color: $white;
     min-width: 0;
     padding: 0 $size-8;
 
@@ -76,14 +76,14 @@
 
   input {
     background-color: rgba($black, 0.5);
-    border: 0;
+    border: 1px solid var(--token-color-palette-neutral-500);
+    border-radius: 2px;
     caret-color: $white;
     color: $white;
     flex: 1 1 auto;
     font-family: $family-monospace;
     font-size: 16px;
     font-weight: $font-weight-bold;
-    margin-left: -$size-10;
     outline: none;
     padding: $size-10;
     transition: background-color $speed;
@@ -146,11 +146,7 @@
 
 .console-close-button {
   position: absolute;
-  top: -3.25rem;
+  top: $spacing-xs;
   right: $spacing-xs;
   z-index: 210;
-
-  @include from($mobile) {
-    display: none;
-  }
 }

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -41,19 +41,19 @@
   font-weight: $font-weight-semibold;
 
   &.connected {
-    background-color: $ui-gray-800;
-    color: #c2c5cb;
+    background-color: var(--token-color-surface-action);
+    color: var(--token-color-foreground-action-active);
 
     a {
-      color: #c2c5cb;
+      color: var(--token-color-foreground-action-active);
     }
   }
   &.warning {
-    background-color: #fcf6ea;
-    color: #975b06;
+    background-color: var(--token-color-surface-warning);
+    color: var(--token-color-palette-amber-300);
 
     a {
-      color: #975b06;
+      color: var(--token-color-palette-amber-300);
     }
   }
 }

--- a/ui/app/templates/components/console/log-command.hbs
+++ b/ui/app/templates/components/console/log-command.hbs
@@ -1,2 +1,4 @@
-{{! using Icon here instead of Chevron because two nested tagless components results in a rendered line break between the tags breaking the layout in the <pre> }}
-<pre class="console-ui-command"><Icon @name="chevron-right" />{{@content}}</pre>
+<div class="is-flex-center">
+  <Icon @name="chevron-right" />
+  <pre class="console-ui-command">{{@content}}</pre>
+</div>

--- a/ui/app/templates/components/console/ui-panel.hbs
+++ b/ui/app/templates/components/console/ui-panel.hbs
@@ -1,4 +1,4 @@
-<button type="button" class="button is-ghost console-close-button" {{action "closeConsole"}}>
+<button type="button" class="button is-ghost console-close-button" {{action "closeConsole"}} data-test-console-panel-close>
   <Icon @name="x" aria-label="Close console" />
 </button>
 <div class="console-ui-panel-content">

--- a/ui/tests/acceptance/console-test.js
+++ b/ui/tests/acceptance/console-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { settled, waitUntil } from '@ember/test-helpers';
+import { settled, waitUntil, click } from '@ember/test-helpers';
 import { create } from 'ember-cli-page-object';
 import { setupApplicationTest } from 'ember-qunit';
 import enginesPage from 'vault/tests/pages/secrets/backends';
@@ -85,5 +85,19 @@ module('Acceptance | console', function (hooks) {
     // have to wrap in a later so that we can wait for the CSS transition to finish
     await waitUntil(() => consoleOut.innerText);
     assert.strictEqual(consoleOut.innerText.match(/^(true|false)$/g).length, 1);
+  });
+
+  test('it should open and close console panel', async function (assert) {
+    await click('[data-test-console-toggle]');
+    assert.dom('[data-test-console-panel]').hasClass('panel-open', 'Sidebar button opens console panel');
+    await click('[data-test-console-toggle]');
+    assert
+      .dom('[data-test-console-panel]')
+      .doesNotHaveClass('panel-open', 'Sidebar button closes console panel');
+    await click('[data-test-console-toggle]');
+    await click('[data-test-console-panel-close]');
+    assert
+      .dom('[data-test-console-panel]')
+      .doesNotHaveClass('panel-open', 'Console panel close button closes console panel');
   });
 });


### PR DESCRIPTION
This PR consists of mostly style updates to the console panel to align with the sidebar navigation. These changes include:

- changed background color to match sidebar
- changed button icon color from grey to white
- added close button in top right of panel
- added white border to input
- align command with chevron icon in log
- panel now pushes content down rather than overlap (no changes in this PR but a product of moving things around)

![image](https://user-images.githubusercontent.com/24611656/227422217-2721ba55-a29d-4591-8afb-d381c2c8b144.png)

![image](https://user-images.githubusercontent.com/24611656/227422267-f21e0c12-e942-4558-8e24-11b0467525f2.png)

The styling for the HCP link banner was also updated:

![image](https://user-images.githubusercontent.com/24611656/227552314-027eba9c-5863-4e0f-a46b-5087c26f78f9.png)

![image](https://user-images.githubusercontent.com/24611656/227552930-4e05a0a6-9e9f-486c-9e9b-fa964bd7028a.png)

 