### PR TITLE
Migrate the FIPS testing job to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
     uses: ./.github/workflows/test-go.yml
     with:
       name: ''
+      total-runners: 16
       go-arch: amd64
       go-build-tags: '${{ needs.setup.outputs.go-build-tags }},deadlock'
       runs-on: ${{ needs.setup.outputs.compute-standard }}
@@ -129,10 +130,37 @@ jobs:
     uses: ./.github/workflows/test-go.yml
     with:
       name: race
+      total-runners: 16
+      env-vars: |
+        {
+          "VAULT_CI_GO_TEST_RACE": 1
+        }
       extra-flags: '-race'
       go-arch: amd64
       go-build-tags: ${{ needs.setup.outputs.go-build-tags }}
       runs-on: ${{ needs.setup.outputs.compute-larger }}
+      enterprise: ${{ needs.setup.outputs.enterprise }}
+    secrets: inherit
+  test-go-fips:
+    name: Run Go tests with FIPS configuration
+    # Only run this job for the enterprise repo if the branch doesn't start with 'ui/', 'docs/', or 'backport/docs/'.
+    if: |
+      needs.setup.outputs.enterprise == 1 &&
+      ! (startsWith( github.ref_name, 'ui/' ) || startsWith( github.ref_name, 'docs/' ) || startsWith( github.ref_name, 'backport/docs/'))
+    needs:
+    - setup
+    - setup-go-cache
+    uses: ./.github/workflows/test-go.yml
+    with:
+      name: fips
+      total-runners: 16
+      env-vars: |
+        {
+          "GOEXPERIMENT": "boringcrypto"
+        }
+      go-arch: amd64
+      go-build-tags: '${{ needs.setup.outputs.go-build-tags }},deadlock,cgo,fips,fips_140_2'
+      runs-on: ${{ needs.setup.outputs.compute-standard }}
       enterprise: ${{ needs.setup.outputs.enterprise }}
     secrets: inherit
   test-ui:

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -9,6 +9,19 @@ on:
         description: The execution architecture (arm, amd64, etc.)
         required: true
         type: string
+      enterprise:
+        description: A flag indicating if this workflow is executing for the enterprise repository.
+        required: true
+        type: string
+      total-runners:
+        description: Number of runners to use for executing the tests on.
+        required: true
+        type: string
+      env-vars:
+        description: A map of environment variables as JSON.
+        required: false
+        type: string
+        default: '{}'
       extra-flags:
         description: A space-separated list of additional build flags.
         required: false
@@ -18,17 +31,12 @@ on:
         required: false
         type: string
         default: ubuntu-latest
-      enterprise:
-        description: A flag indicating if this workflow is executing for the enterprise repository.
-        required: true
-        type: string
       go-build-tags:
         description: A comma-separated list of additional build tags to consider satisfied during the build.
         required: false
         type: string
 
-env:
-  total-runners: 16
+env: ${{ fromJSON(inputs.env-vars) }}
 
 jobs:
   test-generate-test-package-list:
@@ -52,7 +60,7 @@ jobs:
     steps:
     - id: generate-index-list
       run: |
-        INDEX_LIST="$(seq 1 ${{ env.total-runners }})"
+        INDEX_LIST="$(seq 1 ${{ inputs.total-runners }})"
         INDEX_JSON="$(jq --null-input --compact-output '. |= [inputs]' <<< "${INDEX_LIST}")"
         echo "indexes=${INDEX_JSON}" >> "${GITHUB_OUTPUT}"
   test-go:
@@ -117,11 +125,6 @@ jobs:
           # matrix.runner-index value.
           #
           ENTERPRISE=${{ inputs.enterprise }} source .github/scripts/generate-test-package-lists.sh
-
-          # If data race detection is enabled, export a relevant environment variable for use in tests
-          if [[ "${{ inputs.extra-flags }}" =~ "-race" ]]; then
-            export VAULT_CI_GO_TEST_RACE=1
-          fi
 
           # Build the dynamically generated source files.
           make prep


### PR DESCRIPTION
This is an ENT-specific job, so it won't as part of CI here. 

It's worth noting that I am proposing a new way of injecting environment variables to the `test-go` workflow in this one. The Go test FIPS job itself is pretty much the same as our standard `test-go`, but it has some extra build tags and an extra environment variable.