### PR TITLE
Create Job to Track All Required Test Jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,3 +228,9 @@ jobs:
         paths: "ui/test-results/qunit/results.xml"
         show: "fail"
       if: always()
+  tests-completed:
+    needs:
+    - test-go
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-standard) }}
+    steps:
+    - run: echo "All Go test successfully passed"


### PR DESCRIPTION
This PR creates a trivial GitHub Actions Workflow Job that can be made to depend on any Workflow Job that must successfully complete to allow a Pull Request to be merged. This new job will be made into a required status check on protected branches.