### PR TITLE
Add mechanism to disable automatic rollbacks

### DIFF
--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1002,6 +1002,10 @@ func (c *TestClusterCore) stop() error {
 	return nil
 }
 
+func (c *TestClusterCore) StopAutomaticRollbacks() {
+	c.rollback.StopTicker()
+}
+
 func (c *TestClusterCore) GrabRollbackLock() {
 	// Ensure we don't hold this lock while there are in flight rollbacks.
 	c.rollback.inflightAll.Wait()


### PR DESCRIPTION
When testing the rollback mechanism, there's two categories of tests typically written:

 1. Ones in which the rollback manager is entirely left alone, which usually are a bit slower and less predictable. However, it is still sufficient in many scenarios.
 2. Ones in which the rollback manager is explicitly probed by tests and "stepped" to achieve the next rollback.

Here, without a mechanism to fully disable the rollback manager's periodic ticker (without affecting its ability to work!) we'll continue to see races of the sort:

>     --- FAIL: TestRevocationQueue (50.95s)
>     panic: sync: WaitGroup is reused before previous Wait has returned [recovered]
>         panic: sync: WaitGroup is reused before previous Wait has returned

This allows us to disable the ticker, returning control to the test suite entirely.