### PR TITLE
Namespace Picker Updates

### DIFF
--- a/ui/app/components/namespace-picker.js
+++ b/ui/app/components/namespace-picker.js
@@ -155,7 +155,9 @@ export default Component.extend({
 
   namespaceDisplay: computed('namespacePath', 'accessibleNamespaces', 'accessibleNamespaces.[]', function () {
     const namespace = this.namespacePath;
-    if (!namespace) return '';
+    if (!namespace) {
+      return 'root';
+    }
     const parts = namespace?.split('/');
     return parts[parts.length - 1];
   }),

--- a/ui/app/styles/components/env-banner.scss
+++ b/ui/app/styles/components/env-banner.scss
@@ -10,6 +10,7 @@
   animation: env-banner-color-rotate 8s infinite linear alternate;
   color: $white;
   margin-top: -20px;
+  margin-bottom: 6px;
 
   .hs-icon {
     margin: 0;

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -9,10 +9,6 @@
   display: flex;
   padding: $spacing-xxs $spacing-xs;
   width: 100%;
-
-  svg {
-    // color: var(--token-color-palette-neutral-300);
-  }
 }
 
 .namespace-picker.no-namespaces {
@@ -64,6 +60,11 @@
 
 .namespace-manage-link {
   border-top: 1px solid rgba($black, 0.1);
+
+  button {
+    font-weight: $font-weight-bold;
+    font-size: $body-size;
+  }
 }
 
 .namespace-list {
@@ -81,6 +82,11 @@
 .namespace-link.is-current {
   margin-top: $size-8;
   margin-right: -$size-10;
+
+  svg {
+    margin-top: 2px;
+    color: var(--token-color-border-strong);
+  }
 }
 
 .leaf-panel {

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -5,16 +5,13 @@
 
 .namespace-picker {
   position: relative;
-  color: $white;
+  color: var(--token-color-palette-neutral-300);
   display: flex;
-  fill: $white;
   padding: $spacing-xxs $spacing-xs;
   width: 100%;
 
-  @include from($mobile) {
-    margin-left: -$spacing-xs;
-    padding: $spacing-xxs 0 $spacing-xxs $spacing-s;
-    width: auto;
+  svg {
+    // color: var(--token-color-palette-neutral-300);
   }
 }
 
@@ -22,48 +19,23 @@
   border: none;
   padding-right: 0;
 }
+
 .namespace-picker-trigger {
   align-items: center;
   display: flex;
   flex: 1 1 auto;
   height: 2rem;
   justify-content: space-between;
-  padding: 0;
-  text-align: left;
-
-  @include from($mobile) {
-    height: auto;
-    padding: $spacing-xs $spacing-m;
-  }
-
-  .is-status-chevron {
-    transform: rotate(-90deg);
-
-    @include from($mobile) {
-      transform: rotate(0deg);
-    }
-  }
-
-  &.ember-basic-dropdown-trigger--below .is-status-chevron {
-    transform: rotate(0deg);
-
-    @include from($mobile) {
-      transform: rotate(180deg);
-    }
-  }
+  margin-right: $spacing-xxs;
 }
+
 .namespace-name {
-  display: inline-block;
-  flex: 1 1 auto;
   font-size: 1rem;
-  margin: 0 $spacing-xs;
-
-  @include from($mobile) {
-    margin-left: $size-10;
-  }
+  margin-left: $spacing-xs;
 }
+
 .namespace-picker-content {
-  width: $drawer-width - ($spacing-xs * 2);
+  width: 250px;
   max-height: 300px;
   overflow: auto;
   border-radius: $radius;
@@ -72,11 +44,8 @@
   &.ember-basic-dropdown-content {
     background: $white;
   }
-
-  @include from($mobile) {
-    width: $drawer-width;
-  }
 }
+
 .namespace-picker-content .level-left {
   max-width: 210px;
   overflow-wrap: break-word;
@@ -127,9 +96,11 @@
   bottom: 0;
   z-index: 1;
 }
+
 .leaf-panel-left {
   transform: translateX(-$drawer-width);
 }
+
 .leaf-panel-adding,
 .leaf-panel-current {
   position: relative;
@@ -137,6 +108,7 @@
     margin-bottom: 4px;
   }
 }
+
 .animated-list {
   .leaf-panel-exiting,
   .leaf-panel-adding {
@@ -144,6 +116,7 @@
     z-index: 20;
   }
 }
+
 .leaf-panel-adding {
   z-index: 100;
 }

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -61,7 +61,7 @@
 .namespace-manage-link {
   border-top: 1px solid rgba($black, 0.1);
 
-  button {
+  .level-left {
     font-weight: $font-weight-bold;
     font-size: $body-size;
   }

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -65,6 +65,9 @@
     font-weight: $font-weight-bold;
     font-size: $body-size;
   }
+  .level-right {
+    margin-right: 10px;
+  }
 }
 
 .namespace-list {

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -13,17 +13,6 @@
     </D.Trigger>
     <D.Content @defaultClass="namespace-picker-content">
       <div class="is-mobile level-left">
-        {{#unless this.isUserRootNamespace}}
-          <NamespaceLink
-            @targetNamespace={{or
-              (object-at (dec 2 this.menuLeaves.length) this.lastMenuLeaves)
-              this.auth.authData.userRootNamespace
-            }}
-            @class="namespace-link is-current button is-ghost icon"
-          >
-            <Chevron @direction="left" @class="has-text-grey" />
-          </NamespaceLink>
-        {{/unless}}
         <h5 class="list-header">Current namespace</h5>
       </div>
       <div class="namespace-header-bar level is-mobile">
@@ -32,9 +21,6 @@
             <div class="level is-mobile namespace-link">
               <span class="level-left" data-test-current-namespace>
                 {{if this.namespacePath (concat this.namespacePath "/") "root"}}
-              </span>
-              <span class="level-right">
-                <Icon @name="check-circle" class="has-text-success" />
               </span>
             </div>
           </header>
@@ -48,7 +34,7 @@
                 (object-at (dec 2 this.menuLeaves.length) this.lastMenuLeaves)
                 this.auth.authData.userRootNamespace
               }}
-              @class="namespace-link is-current button is-ghost icon"
+              @class="namespace-link is-current button icon is-transparent"
             >
               <Chevron @direction="left" @class="has-text-grey" />
             </NamespaceLink>
@@ -58,39 +44,37 @@
         {{#if (includes "" this.lastMenuLeaves)}}
           {{! leaf is '' which is the root namespace, and then we need to iterate the root leaves }}
           <div class="leaf-panel {{if (eq '' this.currentLeaf) 'leaf-panel-current' 'leaf-panel-left'}} ">
-            {{~#each this.rootLeaves as |rootLeaf|}}
+            {{#each this.rootLeaves as |rootLeaf|}}
               <NamespaceLink @targetNamespace={{rootLeaf}} @class="namespace-link" @showLastSegment={{true}} />
-            {{/each~}}
+            {{/each}}
           </div>
         {{/if}}
         {{#each this.lastMenuLeaves as |leaf|}}
-          <div
-            class="leaf-panel
-              {{if (eq leaf this.currentLeaf) 'leaf-panel-current' 'leaf-panel-left'}}
-              {{if (and this.isAdding (eq leaf this.changedLeaf)) 'leaf-panel-adding'}}
-              {{if (and (not this.isAdding) (eq leaf this.changedLeaf)) 'leaf-panel-exiting'}}
-              "
-          >
-            {{~#each-in (get this.namespaceTree leaf) as |leafName|}}
-              <NamespaceLink
-                @targetNamespace={{concat leaf "/" leafName}}
-                @class="namespace-link"
-                @showLastSegment={{true}}
-              />
-            {{/each-in~}}
-          </div>
+          {{#if leaf}}
+            <div
+              class="leaf-panel
+                {{if (eq leaf this.currentLeaf) 'leaf-panel-current' 'leaf-panel-left'}}
+                {{if (and this.isAdding (eq leaf this.changedLeaf)) 'leaf-panel-adding'}}
+                {{if (and (not this.isAdding) (eq leaf this.changedLeaf)) 'leaf-panel-exiting'}}
+                "
+            >
+              {{#each-in (get this.namespaceTree leaf) as |leafName|}}
+                <NamespaceLink
+                  @targetNamespace={{concat leaf "/" leafName}}
+                  @class="namespace-link"
+                  @showLastSegment={{true}}
+                />
+              {{/each-in}}
+            </div>
+          {{/if}}
         {{/each}}
         {{#if this.canList}}
           <div class="leaf-panel leaf-panel-current">
             <LinkTo @route="vault.cluster.access.namespaces" class="is-block namespace-link namespace-manage-link">
-              <div class="level is-mobile">
-                <span class="level-left">Manage namespaces</span>
-                <span class="level-right">
-                  <button type="button" class="button is-ghost icon" onclick={{action "refreshNamespaceList"}}>
-                    <Icon @name="reload" class="has-text-grey" />
-                  </button>
-                </span>
-              </div>
+              <button type="button" class="button is-transparent" onclick={{action "refreshNamespaceList"}}>
+                <Icon @name="menu" class="has-text-grey" />
+                Manage Namespaces
+              </button>
             </LinkTo>
           </div>
         {{/if}}

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -1,25 +1,46 @@
-{{#if (and (not this.accessibleNamespaces.length) this.inRootNamespace)}}
-  <div class="namespace-picker no-namespaces">
-    {{! Just yield the logo if they're in the root namespace and only have access to it }}
-    {{yield}}
-  </div>
-{{else}}
-  <div class="namespace-picker">
-    <BasicDropdown @horizontalPosition="auto-left" @verticalPosition="above" as |D|>
-      <D.Trigger
-        @htmlTag="button"
-        class="button is-transparent namespace-picker-trigger has-current-color"
-        data-test-namespace-toggle
-      >
-        {{yield}}
-        {{#if this.namespaceDisplay}}
-          <span class="namespace-name">{{this.namespaceDisplay}}</span>
-        {{else}}
-          <span class="namespace-name is-hidden-tablet">/ (Root)</span>
-        {{/if}}
-        <Chevron @direction="down" @class="has-text-white auto-width is-status-chevron" />
-      </D.Trigger>
-      <D.Content @defaultClass="namespace-picker-content">
+<div class="namespace-picker">
+  <BasicDropdown @horizontalPosition="left" @verticalPosition="above" as |D|>
+    <D.Trigger
+      @htmlTag="button"
+      class="button is-transparent namespace-picker-trigger has-current-color"
+      data-test-namespace-toggle
+    >
+      <div class="is-flex-center">
+        <Icon @name="org" />
+        <span class="namespace-name">{{this.namespaceDisplay}}</span>
+      </div>
+      <Icon @name="caret" />
+    </D.Trigger>
+    <D.Content @defaultClass="namespace-picker-content">
+      <div class="is-mobile level-left">
+        {{#unless this.isUserRootNamespace}}
+          <NamespaceLink
+            @targetNamespace={{or
+              (object-at (dec 2 this.menuLeaves.length) this.lastMenuLeaves)
+              this.auth.authData.userRootNamespace
+            }}
+            @class="namespace-link is-current button is-ghost icon"
+          >
+            <Chevron @direction="left" @class="has-text-grey" />
+          </NamespaceLink>
+        {{/unless}}
+        <h5 class="list-header">Current namespace</h5>
+      </div>
+      <div class="namespace-header-bar level is-mobile">
+        <div class="level-left">
+          <header>
+            <div class="level is-mobile namespace-link">
+              <span class="level-left" data-test-current-namespace>
+                {{if this.namespacePath (concat this.namespacePath "/") "root"}}
+              </span>
+              <span class="level-right">
+                <Icon @name="check-circle" class="has-text-success" />
+              </span>
+            </div>
+          </header>
+        </div>
+      </div>
+      <div class="namespace-list {{if this.isAnimating 'animated-list'}}">
         <div class="is-mobile level-left">
           {{#unless this.isUserRootNamespace}}
             <NamespaceLink
@@ -32,79 +53,48 @@
               <Chevron @direction="left" @class="has-text-grey" />
             </NamespaceLink>
           {{/unless}}
-          <h5 class="list-header">Current namespace</h5>
+          <h5 class="list-header">Namespaces</h5>
         </div>
-        <div class="namespace-header-bar level is-mobile">
-          <div class="level-left">
-            <header>
-              <div class="level is-mobile namespace-link">
-                <span class="level-left" data-test-current-namespace>
-                  {{if this.namespacePath (concat this.namespacePath "/") "root"}}
-                </span>
+        {{#if (includes "" this.lastMenuLeaves)}}
+          {{! leaf is '' which is the root namespace, and then we need to iterate the root leaves }}
+          <div class="leaf-panel {{if (eq '' this.currentLeaf) 'leaf-panel-current' 'leaf-panel-left'}} ">
+            {{~#each this.rootLeaves as |rootLeaf|}}
+              <NamespaceLink @targetNamespace={{rootLeaf}} @class="namespace-link" @showLastSegment={{true}} />
+            {{/each~}}
+          </div>
+        {{/if}}
+        {{#each this.lastMenuLeaves as |leaf|}}
+          <div
+            class="leaf-panel
+              {{if (eq leaf this.currentLeaf) 'leaf-panel-current' 'leaf-panel-left'}}
+              {{if (and this.isAdding (eq leaf this.changedLeaf)) 'leaf-panel-adding'}}
+              {{if (and (not this.isAdding) (eq leaf this.changedLeaf)) 'leaf-panel-exiting'}}
+              "
+          >
+            {{~#each-in (get this.namespaceTree leaf) as |leafName|}}
+              <NamespaceLink
+                @targetNamespace={{concat leaf "/" leafName}}
+                @class="namespace-link"
+                @showLastSegment={{true}}
+              />
+            {{/each-in~}}
+          </div>
+        {{/each}}
+        {{#if this.canList}}
+          <div class="leaf-panel leaf-panel-current">
+            <LinkTo @route="vault.cluster.access.namespaces" class="is-block namespace-link namespace-manage-link">
+              <div class="level is-mobile">
+                <span class="level-left">Manage namespaces</span>
                 <span class="level-right">
-                  <Icon @name="check-circle" class="has-text-success" />
+                  <button type="button" class="button is-ghost icon" onclick={{action "refreshNamespaceList"}}>
+                    <Icon @name="reload" class="has-text-grey" />
+                  </button>
                 </span>
               </div>
-            </header>
+            </LinkTo>
           </div>
-        </div>
-        <div class="namespace-list {{if this.isAnimating 'animated-list'}}">
-          <div class="is-mobile level-left">
-            {{#unless this.isUserRootNamespace}}
-              <NamespaceLink
-                @targetNamespace={{or
-                  (object-at (dec 2 this.menuLeaves.length) this.lastMenuLeaves)
-                  this.auth.authData.userRootNamespace
-                }}
-                @class="namespace-link is-current button is-ghost icon"
-              >
-                <Chevron @direction="left" @class="has-text-grey" />
-              </NamespaceLink>
-            {{/unless}}
-            <h5 class="list-header">Namespaces</h5>
-          </div>
-          {{#if (includes "" this.lastMenuLeaves)}}
-            {{! leaf is '' which is the root namespace, and then we need to iterate the root leaves }}
-            <div class="leaf-panel {{if (eq '' this.currentLeaf) 'leaf-panel-current' 'leaf-panel-left'}} ">
-              {{~#each this.rootLeaves as |rootLeaf|}}
-                <NamespaceLink @targetNamespace={{rootLeaf}} @class="namespace-link" @showLastSegment={{true}} />
-              {{/each~}}
-            </div>
-          {{/if}}
-          {{#each this.lastMenuLeaves as |leaf|}}
-            <div
-              class="leaf-panel
-                {{if (eq leaf this.currentLeaf) 'leaf-panel-current' 'leaf-panel-left'}}
-                {{if (and this.isAdding (eq leaf this.changedLeaf)) 'leaf-panel-adding'}}
-                {{if (and (not this.isAdding) (eq leaf this.changedLeaf)) 'leaf-panel-exiting'}}
-                "
-            >
-              {{~#each-in (get this.namespaceTree leaf) as |leafName|}}
-                <NamespaceLink
-                  @targetNamespace={{concat leaf "/" leafName}}
-                  @class="namespace-link"
-                  @showLastSegment={{true}}
-                />
-              {{/each-in~}}
-            </div>
-          {{/each}}
-          {{#if this.canList}}
-            <div class="leaf-panel leaf-panel-current">
-              <LinkTo @route="vault.cluster.access.namespaces" class="is-block namespace-link namespace-manage-link">
-                <div class="level is-mobile">
-                  <span class="level-left">Manage namespaces</span>
-                  <span class="level-right">
-                    <button type="button" class="button is-ghost icon" onclick={{action "refreshNamespaceList"}}>
-                      <Icon @name="reload" class="has-text-grey" />
-                    </button>
-                  </span>
-                </div>
-              </LinkTo>
-            </div>
-          {{/if}}
-        </div>
-      </D.Content>
-    </BasicDropdown>
-  </div>
-  <div class="navbar-separator"></div>
-{{/if}}
+        {{/if}}
+      </div>
+    </D.Content>
+  </BasicDropdown>
+</div>

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -34,7 +34,7 @@
                 (object-at (dec 2 this.menuLeaves.length) this.lastMenuLeaves)
                 this.auth.authData.userRootNamespace
               }}
-              @class="namespace-link is-current button icon is-transparent"
+              @class="namespace-link is-current button is-transparent icon"
             >
               <Chevron @direction="left" @class="has-text-grey" />
             </NamespaceLink>

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -73,7 +73,6 @@
             <LinkTo @route="vault.cluster.access.namespaces" class="is-block namespace-link namespace-manage-link">
               <div class="level">
                 <span class="level-left">
-                  <Icon @name="menu" class="has-text-grey" />
                   Manage Namespaces
                 </span>
                 <span class="level-right">

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -71,10 +71,17 @@
         {{#if this.canList}}
           <div class="leaf-panel leaf-panel-current">
             <LinkTo @route="vault.cluster.access.namespaces" class="is-block namespace-link namespace-manage-link">
-              <button type="button" class="button is-transparent" onclick={{action "refreshNamespaceList"}}>
-                <Icon @name="menu" class="has-text-grey" />
-                Manage Namespaces
-              </button>
+              <div class="level">
+                <span class="level-left">
+                  <Icon @name="menu" class="has-text-grey" />
+                  Manage Namespaces
+                </span>
+                <span class="level-right">
+                  <button type="button" class="button is-ghost icon" onclick={{action "refreshNamespaceList"}}>
+                    <Icon @name="reload" class="has-text-grey" />
+                  </button>
+                </span>
+              </div>
             </LinkTo>
           </div>
         {{/if}}


### PR DESCRIPTION
The following updates have been made to the namespace picker component for use in the sidebar:

- always display the namespace when user has access to the feature (defaults to root)
- updates icons for current selected namespace
- removes back action from current namespace heading
- removes green check icon from current namespace in menu
- updates menu styling

![image](https://user-images.githubusercontent.com/24611656/228933061-4d465315-48f4-4189-96eb-65f9d0681f1a.png)
![image](https://user-images.githubusercontent.com/24611656/228933636-aedfc746-57ac-40e7-a435-0a41d019593b.png)
