### PR TITLE
openapi: Add display attributes for identity/mfa

### DIFF
--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -148,6 +148,11 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 	return []*framework.Path{
 		{
 			Pattern: "mfa/method" + genericOptionalUUIDRegex("method_id"),
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "mfa",
+				OperationVerb:   "read",
+				OperationSuffix: "method-configuration",
+			},
 			Fields: map[string]*framework.FieldSchema{
 				"method_id": {
 					Type:        framework.TypeString,
@@ -163,6 +168,11 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 		},
 		{
 			Pattern: "mfa/method/?$",
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "mfa",
+				OperationVerb:   "list",
+				OperationSuffix: "methods",
+			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ListOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodListGlobal,
@@ -172,6 +182,9 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 		},
 		{
 			Pattern: "mfa/method/totp" + genericOptionalUUIDRegex("method_id"),
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "mfa",
+			},
 			Fields: map[string]*framework.FieldSchema{
 				"method_name": {
 					Type:        framework.TypeString,
@@ -223,20 +236,37 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodTOTPRead,
-					Summary:  "Read the current configuration for the given MFA method",
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationVerb:   "read",
+						OperationSuffix: "totp-method-configuration",
+					},
+					Summary: "Read the current configuration for the given MFA method",
 				},
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodTOTPUpdate,
-					Summary:  "Update or create a configuration for the given MFA method",
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationVerb:   "configure",
+						OperationSuffix: "totp-method",
+					},
+					Summary: "Update or create a configuration for the given MFA method",
 				},
 				logical.DeleteOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodTOTPDelete,
-					Summary:  "Delete a configuration for the given MFA method",
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationVerb:   "delete",
+						OperationSuffix: "totp-method",
+					},
+					Summary: "Delete a configuration for the given MFA method",
 				},
 			},
 		},
 		{
 			Pattern: "mfa/method/totp/?$",
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "mfa",
+				OperationVerb:   "list",
+				OperationSuffix: "totp-methods",
+			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ListOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodListTOTP,
@@ -246,6 +276,11 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 		},
 		{
 			Pattern: "mfa/method/totp/generate$",
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "mfa",
+				OperationVerb:   "generate",
+				OperationSuffix: "totp-secret",
+			},
 			Fields: map[string]*framework.FieldSchema{
 				"method_id": {
 					Type:        framework.TypeString,
@@ -262,6 +297,11 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 		},
 		{
 			Pattern: "mfa/method/totp/admin-generate$",
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "mfa",
+				OperationVerb:   "admin-generate",
+				OperationSuffix: "totp-secret",
+			},
 			Fields: map[string]*framework.FieldSchema{
 				"method_id": {
 					Type:        framework.TypeString,
@@ -283,6 +323,11 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 		},
 		{
 			Pattern: "mfa/method/totp/admin-destroy$",
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "mfa",
+				OperationVerb:   "admin-destroy",
+				OperationSuffix: "totp-secret",
+			},
 			Fields: map[string]*framework.FieldSchema{
 				"method_id": {
 					Type:        framework.TypeString,
@@ -304,6 +349,9 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 		},
 		{
 			Pattern: "mfa/method/okta" + genericOptionalUUIDRegex("method_id"),
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "mfa",
+			},
 			Fields: map[string]*framework.FieldSchema{
 				"method_name": {
 					Type:        framework.TypeString,
@@ -341,15 +389,27 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodOKTARead,
-					Summary:  "Read the current configuration for the given MFA method",
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationVerb:   "read",
+						OperationSuffix: "okta-method-configuration",
+					},
+					Summary: "Read the current configuration for the given MFA method",
 				},
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodOKTAUpdate,
-					Summary:  "Update or create a configuration for the given MFA method",
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationVerb:   "configure",
+						OperationSuffix: "okta-method",
+					},
+					Summary: "Update or create a configuration for the given MFA method",
 				},
 				logical.DeleteOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodOKTADelete,
-					Summary:  "Delete a configuration for the given MFA method",
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationVerb:   "delete",
+						OperationSuffix: "okta-method",
+					},
+					Summary: "Delete a configuration for the given MFA method",
 				},
 			},
 		},
@@ -358,12 +418,20 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ListOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodListOkta,
-					Summary:  "List MFA method configurations for the given MFA method",
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationPrefix: "mfa",
+						OperationVerb:   "list",
+						OperationSuffix: "okta-methods",
+					},
+					Summary: "List MFA method configurations for the given MFA method",
 				},
 			},
 		},
 		{
 			Pattern: "mfa/method/duo" + genericOptionalUUIDRegex("method_id"),
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "mfa",
+			},
 			Fields: map[string]*framework.FieldSchema{
 				"method_name": {
 					Type:        framework.TypeString,
@@ -401,15 +469,27 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodDuoRead,
-					Summary:  "Read the current configuration for the given MFA method",
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationVerb:   "read",
+						OperationSuffix: "duo-method-configuration",
+					},
+					Summary: "Read the current configuration for the given MFA method",
 				},
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodDuoUpdate,
-					Summary:  "Update or create a configuration for the given MFA method",
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationVerb:   "configure",
+						OperationSuffix: "duo-method",
+					},
+					Summary: "Update or create a configuration for the given MFA method",
 				},
 				logical.DeleteOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodDUODelete,
-					Summary:  "Delete a configuration for the given MFA method",
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationVerb:   "delete",
+						OperationSuffix: "duo-method",
+					},
+					Summary: "Delete a configuration for the given MFA method",
 				},
 			},
 		},
@@ -418,12 +498,20 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ListOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodListDuo,
-					Summary:  "List MFA method configurations for the given MFA method",
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationPrefix: "mfa",
+						OperationVerb:   "list",
+						OperationSuffix: "duo-methods",
+					},
+					Summary: "List MFA method configurations for the given MFA method",
 				},
 			},
 		},
 		{
 			Pattern: "mfa/method/pingid" + genericOptionalUUIDRegex("method_id"),
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "mfa",
+			},
 			Fields: map[string]*framework.FieldSchema{
 				"method_name": {
 					Type:        framework.TypeString,
@@ -445,15 +533,27 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodPingIDRead,
-					Summary:  "Read the current configuration for the given MFA method",
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationVerb:   "read",
+						OperationSuffix: "ping-id-method-configuration",
+					},
+					Summary: "Read the current configuration for the given MFA method",
 				},
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodPingIDUpdate,
-					Summary:  "Update or create a configuration for the given MFA method",
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationVerb:   "configure",
+						OperationSuffix: "ping-id-method",
+					},
+					Summary: "Update or create a configuration for the given MFA method",
 				},
 				logical.DeleteOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodPingIDDelete,
-					Summary:  "Delete a configuration for the given MFA method",
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationVerb:   "delete",
+						OperationSuffix: "ping-id-method",
+					},
+					Summary: "Delete a configuration for the given MFA method",
 				},
 			},
 		},
@@ -462,12 +562,21 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ListOperation: &framework.PathOperation{
 					Callback: i.handleMFAMethodListPingID,
-					Summary:  "List MFA method configurations for the given MFA method",
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationPrefix: "mfa",
+						OperationVerb:   "list",
+						OperationSuffix: "ping-id-methods",
+					},
+					Summary: "List MFA method configurations for the given MFA method",
 				},
 			},
 		},
 		{
 			Pattern: "mfa/login-enforcement/" + framework.GenericNameRegex("name"),
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "mfa",
+				OperationSuffix: "login-enforcement",
+			},
 			Fields: map[string]*framework.FieldSchema{
 				"name": {
 					Type:        framework.TypeString,
@@ -513,6 +622,10 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 		},
 		{
 			Pattern: "mfa/login-enforcement/?$",
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "mfa",
+				OperationSuffix: "login-enforcements",
+			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ListOperation: &framework.PathOperation{
 					Callback: i.handleMFALoginEnforcementList,

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -151,7 +151,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: "mfa",
 				OperationVerb:   "read",
-				OperationSuffix: "method-configuration",
+				OperationSuffix: "method-configuration|method-configuration",
 			},
 			Fields: map[string]*framework.FieldSchema{
 				"method_id": {
@@ -238,7 +238,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Callback: i.handleMFAMethodTOTPRead,
 					DisplayAttrs: &framework.DisplayAttributes{
 						OperationVerb:   "read",
-						OperationSuffix: "totp-method-configuration",
+						OperationSuffix: "totp-method-configuration|totp-method-configuration",
 					},
 					Summary: "Read the current configuration for the given MFA method",
 				},
@@ -246,7 +246,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Callback: i.handleMFAMethodTOTPUpdate,
 					DisplayAttrs: &framework.DisplayAttributes{
 						OperationVerb:   "configure",
-						OperationSuffix: "totp-method",
+						OperationSuffix: "totp-method|totp-method",
 					},
 					Summary: "Update or create a configuration for the given MFA method",
 				},
@@ -254,7 +254,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Callback: i.handleMFAMethodTOTPDelete,
 					DisplayAttrs: &framework.DisplayAttributes{
 						OperationVerb:   "delete",
-						OperationSuffix: "totp-method",
+						OperationSuffix: "totp-method|totp-method",
 					},
 					Summary: "Delete a configuration for the given MFA method",
 				},
@@ -391,7 +391,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Callback: i.handleMFAMethodOKTARead,
 					DisplayAttrs: &framework.DisplayAttributes{
 						OperationVerb:   "read",
-						OperationSuffix: "okta-method-configuration",
+						OperationSuffix: "okta-method-configuration|okta-method-configuration",
 					},
 					Summary: "Read the current configuration for the given MFA method",
 				},
@@ -399,7 +399,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Callback: i.handleMFAMethodOKTAUpdate,
 					DisplayAttrs: &framework.DisplayAttributes{
 						OperationVerb:   "configure",
-						OperationSuffix: "okta-method",
+						OperationSuffix: "okta-method|okta-method",
 					},
 					Summary: "Update or create a configuration for the given MFA method",
 				},
@@ -407,7 +407,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Callback: i.handleMFAMethodOKTADelete,
 					DisplayAttrs: &framework.DisplayAttributes{
 						OperationVerb:   "delete",
-						OperationSuffix: "okta-method",
+						OperationSuffix: "okta-method|okta-method",
 					},
 					Summary: "Delete a configuration for the given MFA method",
 				},
@@ -471,7 +471,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Callback: i.handleMFAMethodDuoRead,
 					DisplayAttrs: &framework.DisplayAttributes{
 						OperationVerb:   "read",
-						OperationSuffix: "duo-method-configuration",
+						OperationSuffix: "duo-method-configuration|duo-method-configuration",
 					},
 					Summary: "Read the current configuration for the given MFA method",
 				},
@@ -479,7 +479,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Callback: i.handleMFAMethodDuoUpdate,
 					DisplayAttrs: &framework.DisplayAttributes{
 						OperationVerb:   "configure",
-						OperationSuffix: "duo-method",
+						OperationSuffix: "duo-method|duo-method",
 					},
 					Summary: "Update or create a configuration for the given MFA method",
 				},
@@ -487,7 +487,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Callback: i.handleMFAMethodDUODelete,
 					DisplayAttrs: &framework.DisplayAttributes{
 						OperationVerb:   "delete",
-						OperationSuffix: "duo-method",
+						OperationSuffix: "duo-method|duo-method",
 					},
 					Summary: "Delete a configuration for the given MFA method",
 				},
@@ -535,7 +535,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Callback: i.handleMFAMethodPingIDRead,
 					DisplayAttrs: &framework.DisplayAttributes{
 						OperationVerb:   "read",
-						OperationSuffix: "ping-id-method-configuration",
+						OperationSuffix: "ping-id-method-configuration|ping-id-method-configuration",
 					},
 					Summary: "Read the current configuration for the given MFA method",
 				},
@@ -543,7 +543,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Callback: i.handleMFAMethodPingIDUpdate,
 					DisplayAttrs: &framework.DisplayAttributes{
 						OperationVerb:   "configure",
-						OperationSuffix: "ping-id-method",
+						OperationSuffix: "ping-id-method|ping-id-method",
 					},
 					Summary: "Update or create a configuration for the given MFA method",
 				},
@@ -551,7 +551,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Callback: i.handleMFAMethodPingIDDelete,
 					DisplayAttrs: &framework.DisplayAttributes{
 						OperationVerb:   "delete",
-						OperationSuffix: "ping-id-method",
+						OperationSuffix: "ping-id-method|ping-id-method",
 					},
 					Summary: "Delete a configuration for the given MFA method",
 				},


### PR DESCRIPTION
Please see https://github.com/hashicorp/vault/pull/19319 for more details on how this will affect the generated OpenAPI schema.

____

The following Operation IDs will be added for identity/mfa:

| Path | Method | Operation ID |
| ---- | ------ | ------------ |
| "/identity/mfa/login-enforcement" | "get" | "mfa-list-login-enforcements" |
| "/identity/mfa/login-enforcement/{name}" | "get" | "mfa-read-login-enforcement" |
| "/identity/mfa/login-enforcement/{name}" | "post" | "mfa-write-login-enforcement" |
| "/identity/mfa/login-enforcement/{name}" | "delete" | "mfa-delete-login-enforcement" |
| "/identity/mfa/method" | "get" | "mfa-list-methods" |
| "/identity/mfa/method/duo" | "get" | "mfa-list-duo-methods" |
| "/identity/mfa/method/duo/{method_id}" | "get" | "mfa-read-duo-method-configuration" |
| "/identity/mfa/method/duo/{method_id}" | "post" | "mfa-configure-duo-method" |
| "/identity/mfa/method/duo/{method_id}" | "delete" | "mfa-delete-duo-method" |
| "/identity/mfa/method/okta" | "get" | "mfa-list-okta-methods" |
| "/identity/mfa/method/okta/{method_id}" | "get" | "mfa-read-okta-method-configuration" |
| "/identity/mfa/method/okta/{method_id}" | "post" | "mfa-configure-okta-method" |
| "/identity/mfa/method/okta/{method_id}" | "delete" | "mfa-delete-okta-method" |
| "/identity/mfa/method/pingid" | "get" | "mfa-list-ping-id-methods" |
| "/identity/mfa/method/pingid/{method_id}" | "get" | "mfa-read-ping-id-method-configuration" |
| "/identity/mfa/method/pingid/{method_id}" | "post" | "mfa-configure-ping-id-method" |
| "/identity/mfa/method/pingid/{method_id}" | "delete" | "mfa-delete-ping-id-method" |
| "/identity/mfa/method/totp" | "get" | "mfa-list-totp-methods" |
| "/identity/mfa/method/totp/admin-destroy" | "post" | "mfa-admin-destroy-totp-secret" |
| "/identity/mfa/method/totp/admin-generate" | "post" | "mfa-admin-generate-totp-secret" |
| "/identity/mfa/method/totp/generate" | "post" | "mfa-generate-totp-secret" |
| "/identity/mfa/method/totp/{method_id}" | "get" | "mfa-read-totp-method-configuration" |
| "/identity/mfa/method/totp/{method_id}" | "post" | "mfa-configure-totp-method" |
| "/identity/mfa/method/totp/{method_id}" | "delete" | "mfa-delete-totp-method" |
| "/identity/mfa/method/{method_id}" | "get" | "mfa-read-method-configuration" |
