### PR TITLE
docs: Fix duration format link in kv-v2 docs page

### DIFF
--- a/website/content/api-docs/secret/kv/kv-v2.mdx
+++ b/website/content/api-docs/secret/kv/kv-v2.mdx
@@ -636,8 +636,8 @@ It does not create a new version.
   to a duration to specify the `deletion_time` for all new versions
   written to this key. If not set, the backend's `delete_version_after` will be
   used. If the value is greater than the backend's `delete_version_after`, the
-  backend's `delete_version_after` will be used. Accepts [Go duration
-  format string][duration-godoc].
+  backend's `delete_version_after` will be used. Accepts [duration format
+  strings](/vault/docs/concepts/duration-format).
 
 - `custom_metadata` `(map<string|string>: nil)` - A map of arbitrary string to string valued user-provided metadata meant
   to describe the secret.


### PR DESCRIPTION
A small link fix