### PR TITLE
openapi: Remove 'ad' from gen_openapi.sh

### DIFF
--- a/helper/builtinplugins/registry_test.go
+++ b/helper/builtinplugins/registry_test.go
@@ -292,9 +292,13 @@ func Test_RegistryMatchesGenOpenapi(t *testing.T) {
 	ensureInScript := func(t *testing.T, scriptBackends []string, name string) {
 		t.Helper()
 
-		// "openldap" is an alias for "ldap" secrets engine
-		if name == "openldap" {
-			return
+		for _, excluded := range []string{
+			"openldap", // alias for "ldap"
+			"ad",       // consolidated into "ldap" and deprecated
+		} {
+			if name == excluded {
+				return
+			}
 		}
 
 		if !slices.Contains(scriptBackends, name) {

--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -61,7 +61,6 @@ vault auth enable "radius"
 vault auth enable "userpass"
 
 # Enable secrets plugins
-vault secrets enable "ad"
 vault secrets enable "alicloud"
 vault secrets enable "aws"
 vault secrets enable "azure"


### PR DESCRIPTION
The "ad" plugin has been consolidated into "ldap" and deprecated.