### PR TITLE
Tighten JWS algorithm lists

### DIFF
--- a/.github/scripts/generate-test-package-lists.sh
+++ b/.github/scripts/generate-test-package-lists.sh
@@ -77,6 +77,7 @@ test_packages[5]+=" $base/vault/external_tests/sealmigration"
 if [ "${ENTERPRISE:+x}" == "x" ] ; then
     test_packages[5]+=" $base/vault/external_tests/transform"
 fi
+test_packages[5]+=" $base/builtin/logical/pki/acme"
 
 # Total time: 588
 test_packages[6]+=" $base"


### PR DESCRIPTION
This fixes the CI execution, to add the new pki/acme subpacakge that was missed in #19778 and adds limits around JWS algorithm selection. 