### PR TITLE
Only parse global flags once

### DIFF
--- a/changelog/19816.txt
+++ b/changelog/19816.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: More consistent parsing and handling for output flags `-output-curl-string`, `-output-policy`, `-detailed`, and `-format`.
+```

--- a/command/base.go
+++ b/command/base.go
@@ -71,6 +71,15 @@ type BaseCommand struct {
 	tokenHelper token.TokenHelper
 
 	client *api.Client
+
+	parsedGlobalFlags parsedGlobalFlags
+}
+
+type parsedGlobalFlags struct {
+	outputCurlString bool
+	outputPolicy     bool
+	detailed         bool
+	format           string
 }
 
 // Client returns the HTTP API client. The client is cached on the command to
@@ -458,20 +467,22 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 			})
 
 			f.BoolVar(&BoolVar{
-				Name:    "output-curl-string",
+				Name:    globalFlagOutputCurlString,
 				Target:  &c.flagOutputCurlString,
 				Default: false,
 				Usage: "Instead of executing the request, print an equivalent cURL " +
 					"command string and exit.",
 			})
+			c.flagOutputCurlString = c.parsedGlobalFlags.outputCurlString
 
 			f.BoolVar(&BoolVar{
-				Name:    "output-policy",
+				Name:    globalFlagOutputPolicy,
 				Target:  &c.flagOutputPolicy,
 				Default: false,
 				Usage: "Instead of executing the request, print an example HCL " +
 					"policy that would be required to run this command, and exit.",
 			})
+			c.flagOutputPolicy = c.parsedGlobalFlags.outputPolicy
 
 			f.StringVar(&StringVar{
 				Name:       "unlock-key",
@@ -517,7 +528,7 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 
 			if bit&FlagSetOutputFormat != 0 {
 				outputSet.StringVar(&StringVar{
-					Name:       "format",
+					Name:       globalFlagFormat,
 					Target:     &c.flagFormat,
 					Default:    "table",
 					EnvVar:     EnvVaultFormat,
@@ -526,16 +537,18 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 						are "table", "json", "yaml", or "pretty". "raw" is allowed
 						for 'vault read' operations only.`,
 				})
+				c.flagFormat = c.parsedGlobalFlags.format
 			}
 
 			if bit&FlagSetOutputDetailed != 0 {
 				outputSet.BoolVar(&BoolVar{
-					Name:    "detailed",
+					Name:    globalFlagDetailed,
 					Target:  &c.flagDetailed,
 					Default: false,
 					EnvVar:  EnvVaultDetailed,
 					Usage:   "Enables additional metadata during some operations",
 				})
+				c.flagDetailed = c.parsedGlobalFlags.detailed
 			}
 		}
 

--- a/command/commands.go
+++ b/command/commands.go
@@ -225,7 +225,7 @@ var (
 	initCommandsEnt = func(ui, serverCmdUi cli.Ui, runOpts *RunOptions, commands map[string]cli.CommandFactory) {}
 )
 
-func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.CommandFactory {
+func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions, gf parsedGlobalFlags) map[string]cli.CommandFactory {
 	loginHandlers := map[string]LoginHandler{
 		"alicloud": &credAliCloud.CLIHandler{},
 		"aws":      &credAws.CLIHandler{},
@@ -255,6 +255,8 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 			tokenHelper: runOpts.TokenHelper,
 			flagAddress: runOpts.Address,
 			client:      runOpts.Client,
+
+			parsedGlobalFlags: gf,
 		}
 	}
 

--- a/command/operator_unseal_test.go
+++ b/command/operator_unseal_test.go
@@ -170,9 +170,9 @@ func TestOperatorUnsealCommand_Format(t *testing.T) {
 		Client: client,
 	}
 
-	args, format, _, _, _ := setupEnv([]string{"operator", "unseal", "-format", "json"})
-	if format != "json" {
-		t.Fatalf("expected %q, got %q", "json", format)
+	args, gf := setupEnv([]string{"operator", "unseal", "-format", "json"})
+	if gf.format != "json" {
+		t.Fatalf("expected %q, got %q", "json", gf.format)
 	}
 
 	// Unseal with one key

--- a/command/version_history_test.go
+++ b/command/version_history_test.go
@@ -60,9 +60,9 @@ func TestVersionHistoryCommand_JsonOutput(t *testing.T) {
 		Client: client,
 	}
 
-	args, format, _, _, _ := setupEnv([]string{"version-history", "-format", "json"})
-	if format != "json" {
-		t.Fatalf("expected format to be %q, actual %q", "json", format)
+	args, gf := setupEnv([]string{"version-history", "-format", "json"})
+	if gf.format != "json" {
+		t.Fatalf("expected format to be %q, actual %q", "json", gf.format)
 	}
 
 	code := RunCustom(args, runOpts)


### PR DESCRIPTION
Currently, we parse "global" flags such as `-output-curl-string` and `-format` twice. Once in `setupEnv`, and once in the `flag` package via:

https://github.com/hashicorp/vault/blob/35eb2dd90743eb52287cab9f7efdf7c214a09068/command/base.go#L595-L609

This double-parsing can lead to confusing outputs like the following:

```shell-session
$ vault kv get secret/foo -output-curl-string
Too many arguments (expected 1, got 2)
Unable to generate cURL string from command
```

Clearly, the command in some sense knows that we tried to generate a cURL string, but it also mistakes the cURL string flag for a positional argument. This is pretty confusing to users (myself included).

Under the hood, what happened was our `setupEnv` function recognised and parsed the flag, but the `flag` parsing package was stricter about the positioning of flags being attached to a specific sub-command and interpreted it as a positional arg, giving the "too many arguments error". I'm sure there are also other examples of inconsistencies and confusing errors that this double-parsing introduces.

To fix this, [inspired by Terraform](https://github.com/hashicorp/terraform/blob/31f278b2d84422bddd6c97b3371777a9d3dcc2cc/main.go#L428), I've updated `setupEnv` to remove the global flags from the `args` slice once they've been parsed to prevent them being re-parsed by the `flag` package. The rest of the changes are then basically just threading our parsed values through to the required location where flag values are initialised.

Because our `setupEnv` function is not picky about flag positioning, one serendipitous side effect is that the global flags are now less error-prone. e.g. `vault kv get secret/foo -output-curl-string` works fine.

Note: I'm not sure if this will get accepted in principal, but I'll write some tests written if feedback is positive.