### PR TITLE
changelog: Drop entry for no-op

### DIFF
--- a/changelog/19625.txt
+++ b/changelog/19625.txt
@@ -1,4 +1,0 @@
-```release-note:feature
-core (enterprise): Add background worker for automatic reporting of billing
-information.
-```


### PR DESCRIPTION
A changelog entry was pre-emptively added for no-op functionality. Remove it for now.