### PR TITLE
Add ACME new account creation handlers

### DIFF
--- a/builtin/logical/pki/acme/errors.go
+++ b/builtin/logical/pki/acme/errors.go
@@ -73,7 +73,7 @@ var errIdMappings = map[error]string{
 
 // Mapping of err->status codes; see table in RFC 8555 Section 6.7. Errors.
 var errCodeMappings = map[error]int{
-	ErrAccountDoesNotExist:     http.StatusNotFound,
+	ErrAccountDoesNotExist:     http.StatusBadRequest, // See RFC 8555 Section 7.3.1. Finding an Account URL Given a Key.
 	ErrAlreadyRevoked:          http.StatusBadRequest,
 	ErrBadCSR:                  http.StatusBadRequest,
 	ErrBadNonce:                http.StatusBadRequest,

--- a/builtin/logical/pki/acme/state.go
+++ b/builtin/logical/pki/acme/state.go
@@ -99,13 +99,23 @@ func (a *ACMEState) TidyNonces() {
 	a.nextExpiry.Store(nextRun.Unix())
 }
 
-func (a *ACMEState) LoadKey(keyID string) (map[string]interface{}, error) {
+func (a *ACMEState) CreateAccount(c *JWSCtx, contact []string, termsOfServiceAgreed bool) (map[string]interface{}, error) {
 	// TODO
 	return nil, nil
 }
 
+func (a *ACMEState) LoadAccount(keyID string) (map[string]interface{}, error) {
+	// TODO
+	return nil, nil
+}
+
+func (a *ACMEState) DoesAccountExist(keyId string) bool {
+	account, err := a.LoadAccount(keyId)
+	return err == nil && len(account) > 0
+}
+
 func (a *ACMEState) LoadJWK(keyID string) ([]byte, error) {
-	key, err := a.LoadKey(keyID)
+	key, err := a.LoadAccount(keyID)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -241,6 +241,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 	for _, acmePrefix := range []string{"", "issuer/+/", "roles/+/", "issuer/+/roles/+/"} {
 		b.PathsSpecial.Unauthenticated = append(b.PathsSpecial.Unauthenticated, acmePrefix+"acme/directory")
 		b.PathsSpecial.Unauthenticated = append(b.PathsSpecial.Unauthenticated, acmePrefix+"acme/new-nonce")
+		b.PathsSpecial.Unauthenticated = append(b.PathsSpecial.Unauthenticated, acmePrefix+"acme/new-account")
 		b.PathsSpecial.Unauthenticated = append(b.PathsSpecial.Unauthenticated, acmePrefix+"acme/new-order")
 		b.PathsSpecial.Unauthenticated = append(b.PathsSpecial.Unauthenticated, acmePrefix+"acme/revoke-cert")
 		b.PathsSpecial.Unauthenticated = append(b.PathsSpecial.Unauthenticated, acmePrefix+"acme/key-change")

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -6812,6 +6812,7 @@ func TestProperAuthing(t *testing.T) {
 	for _, acmePrefix := range []string{"", "issuer/default/", "roles/test/", "issuer/default/roles/test/"} {
 		paths[acmePrefix+"acme/directory"] = shouldBeUnauthedReadList
 		paths[acmePrefix+"acme/new-nonce"] = shouldBeUnauthedReadList
+		paths[acmePrefix+"acme/new-account"] = shouldBeUnauthedWriteOnly
 	}
 
 	for path, checkerType := range paths {

--- a/builtin/logical/pki/path_acme_directory.go
+++ b/builtin/logical/pki/path_acme_directory.go
@@ -19,42 +19,27 @@ const (
 )
 
 func pathAcmeRootDirectory(b *backend) *framework.Path {
-	return patternAcmeDirectory(b, "acme/directory", false /* requireRole */, false /* requireIssuer */)
+	return patternAcmeDirectory(b, "acme/directory")
 }
 
 func pathAcmeRoleDirectory(b *backend) *framework.Path {
-	return patternAcmeDirectory(b, "roles/"+framework.GenericNameRegex("role")+"/acme/directory",
-		true /* requireRole */, false /* requireIssuer */)
+	return patternAcmeDirectory(b, "roles/"+framework.GenericNameRegex("role")+"/acme/directory")
 }
 
 func pathAcmeIssuerDirectory(b *backend) *framework.Path {
-	return patternAcmeDirectory(b, "issuer/"+framework.GenericNameRegex(issuerRefParam)+"/acme/directory",
-		false /* requireRole */, true /* requireIssuer */)
+	return patternAcmeDirectory(b, "issuer/"+framework.GenericNameRegex(issuerRefParam)+"/acme/directory")
 }
 
 func pathAcmeIssuerAndRoleDirectory(b *backend) *framework.Path {
 	return patternAcmeDirectory(b,
-		"issuer/"+framework.GenericNameRegex(issuerRefParam)+"/roles/"+framework.GenericNameRegex(
-			"role")+"/acme/directory",
-		true /* requireRole */, true /* requireIssuer */)
+		"issuer/"+framework.GenericNameRegex(issuerRefParam)+
+			"/roles/"+framework.GenericNameRegex("role")+"/acme/directory")
 }
 
-func patternAcmeDirectory(b *backend, pattern string, requireRole, requireIssuer bool) *framework.Path {
+func patternAcmeDirectory(b *backend, pattern string) *framework.Path {
 	fields := map[string]*framework.FieldSchema{}
-	if requireRole {
-		fields["role"] = &framework.FieldSchema{
-			Type:        framework.TypeString,
-			Description: `The desired role for the acme request`,
-			Required:    true,
-		}
-	}
-	if requireIssuer {
-		fields[issuerRefParam] = &framework.FieldSchema{
-			Type:        framework.TypeString,
-			Description: `Reference to an existing issuer name or issuer id`,
-			Required:    true,
-		}
-	}
+	addFieldsForACMEPath(fields, pattern)
+
 	return &framework.Path{
 		Pattern: pattern,
 		Fields:  fields,

--- a/builtin/logical/pki/path_acme_new_account.go
+++ b/builtin/logical/pki/path_acme_new_account.go
@@ -1,0 +1,159 @@
+package pki
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/vault/builtin/logical/pki/acme"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func pathAcmeRootNewAccount(b *backend) *framework.Path {
+	return patternAcmeNewAccount(b, "acme/directory")
+}
+
+func pathAcmeRoleNewAccount(b *backend) *framework.Path {
+	return patternAcmeNewAccount(b, "roles/"+framework.GenericNameRegex("role")+"/acme/directory")
+}
+
+func pathAcmeIssuerNewAccount(b *backend) *framework.Path {
+	return patternAcmeNewAccount(b, "issuer/"+framework.GenericNameRegex(issuerRefParam)+"/acme/directory")
+}
+
+func pathAcmeIssuerAndRoleNewAccount(b *backend) *framework.Path {
+	return patternAcmeNewAccount(b, "issuer/"+framework.GenericNameRegex(issuerRefParam)+"/roles/"+framework.GenericNameRegex("role")+"/acme/directory")
+}
+
+func patternAcmeNewAccount(b *backend, pattern string) *framework.Path {
+	return &framework.Path{
+		Pattern: pattern,
+		Fields:  map[string]*framework.FieldSchema{},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback:                    b.acmeParsedWrapper(b.acmeNewAccountHandler),
+				ForwardPerformanceSecondary: false,
+				ForwardPerformanceStandby:   true,
+			},
+		},
+
+		HelpSynopsis:    pathOcspHelpSyn,
+		HelpDescription: pathOcspHelpDesc,
+	}
+}
+
+type acmeParsedOperation func(acmeCtx acmeContext, r *logical.Request, fields *framework.FieldData, userCtx *acme.JWSCtx, data map[string]interface{}) (*logical.Response, error)
+
+func (b *backend) acmeParsedWrapper(op acmeParsedOperation) framework.OperationFunc {
+	return b.acmeWrapper(func(acmeCtx acmeContext, r *logical.Request, fields *framework.FieldData) (*logical.Response, error) {
+		user, data, err := b.acme.ParseRequestParams(fields)
+		if err != nil {
+			return nil, err
+		}
+
+		return op(acmeCtx, r, fields, user, data)
+	})
+}
+
+func (b *backend) acmeNewAccountHandler(acmeCtx acmeContext, r *logical.Request, fields *framework.FieldData, userCtx *acme.JWSCtx, data map[string]interface{}) (*logical.Response, error) {
+	// Parameters
+	var ok bool
+	var onlyReturnExisting bool
+	var contact []string
+	var termsOfServiceAgreed bool
+
+	rawContact, present := data["contact"]
+	if present {
+		contact, ok = rawContact.([]string)
+		if !ok {
+			return nil, fmt.Errorf("invalid type for field 'contact': %w", acme.ErrMalformed)
+		}
+	}
+
+	rawTermsOfServiceAgreed, present := data["termsOfServiceAgreed"]
+	if present {
+		termsOfServiceAgreed, ok = rawTermsOfServiceAgreed.(bool)
+		if !ok {
+			return nil, fmt.Errorf("invalid type for field 'termsOfServiceAgreed': %w", acme.ErrMalformed)
+		}
+	}
+
+	rawOnlyReturnExisting, present := data["onlyReturnExisting"]
+	if present {
+		onlyReturnExisting, ok = rawOnlyReturnExisting.(bool)
+		if !ok {
+			return nil, fmt.Errorf("invalid type for field 'onlyReturnExisting': %w", acme.ErrMalformed)
+		}
+	}
+
+	// We ignore the EAB parameter as it is currently not supported.
+
+	// We have two paths here: search or create.
+	if onlyReturnExisting {
+		return b.acmeNewAccountSearchHandler(acmeCtx, r, fields, userCtx, data)
+	}
+
+	return b.acmeNewAccountCreateHandler(acmeCtx, r, fields, userCtx, data, contact, termsOfServiceAgreed)
+}
+
+func formatAccountResponse(location string, status string, contact []string) *logical.Response {
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			"status": status,
+			"orders": location + "/orders",
+		},
+	}
+
+	if len(contact) > 0 {
+		resp.Data["contact"] = contact
+	}
+
+	resp.Headers["Location"] = []string{location}
+
+	return resp
+}
+
+func (b *backend) acmeNewAccountSearchHandler(acmeCtx acmeContext, r *logical.Request, fields *framework.FieldData, userCtx *acme.JWSCtx, data map[string]interface{}) (*logical.Response, error) {
+	if userCtx.Existing || b.acme.DoesAccountExist(userCtx.Kid) {
+		// This account exists; return its details. It would be slightly
+		// weird to specify a kid in the request (and not use an explicit
+		// jwk here), but we might as well support it too.
+		account, err := b.acme.LoadAccount(userCtx.Kid)
+		if err != nil {
+			return nil, fmt.Errorf("error loading account: %w", err)
+		}
+
+		location := acmeCtx.baseUrl.String() + "/acme/account/" + userCtx.Kid
+		return formatAccountResponse(location, account["status"].(string), account["contact"].([]string)), nil
+	}
+
+	// Per RFC 8555 Section 7.3.1. Finding an Account URL Given a Key:
+	//
+	// > If a client sends such a request and an account does not exist,
+	// > then the server MUST return an error response with status code
+	// > 400 (Bad Request) and type "urn:ietf:params:acme:error:accountDoesNotExist".
+	return nil, fmt.Errorf("An account with this key does not exist: %w", acme.ErrAccountDoesNotExist)
+}
+
+func (b *backend) acmeNewAccountCreateHandler(acmeCtx acmeContext, r *logical.Request, fields *framework.FieldData, userCtx *acme.JWSCtx, data map[string]interface{}, contact []string, termsOfServiceAgreed bool) (*logical.Response, error) {
+	if userCtx.Existing {
+		return nil, fmt.Errorf("cannot submit to newAccount with 'kid': %w", acme.ErrMalformed)
+	}
+
+	// If the account already exists, return the existing one.
+	if b.acme.DoesAccountExist(userCtx.Kid) {
+		return b.acmeNewAccountSearchHandler(acmeCtx, r, fields, userCtx, data)
+	}
+
+	// TODO: Limit this only when ToS are required by the operator.
+	if !termsOfServiceAgreed {
+		return nil, fmt.Errorf("terms of service not agreed to: %w", acme.ErrUserActionRequired)
+	}
+
+	account, err := b.acme.CreateAccount(userCtx, contact, termsOfServiceAgreed)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create account: %w", err)
+	}
+
+	location := acmeCtx.baseUrl.String() + "/acme/account/" + userCtx.Kid
+	return formatAccountResponse(location, account["status"].(string), account["contact"].([]string)), nil
+}

--- a/builtin/logical/pki/path_acme_nonce.go
+++ b/builtin/logical/pki/path_acme_nonce.go
@@ -9,42 +9,27 @@ import (
 )
 
 func pathAcmeRootNonce(b *backend) *framework.Path {
-	return patternAcmeNonce(b, "acme/new-nonce", false /* requireRole */, false /* requireIssuer */)
+	return patternAcmeNonce(b, "acme/new-nonce")
 }
 
 func pathAcmeRoleNonce(b *backend) *framework.Path {
-	return patternAcmeNonce(b, "roles/"+framework.GenericNameRegex("role")+"/acme/new-nonce",
-		true /* requireRole */, false /* requireIssuer */)
+	return patternAcmeNonce(b, "roles/"+framework.GenericNameRegex("role")+"/acme/new-nonce")
 }
 
 func pathAcmeIssuerNonce(b *backend) *framework.Path {
-	return patternAcmeNonce(b, "issuer/"+framework.GenericNameRegex(issuerRefParam)+"/acme/new-nonce",
-		false /* requireRole */, true /* requireIssuer */)
+	return patternAcmeNonce(b, "issuer/"+framework.GenericNameRegex(issuerRefParam)+"/acme/new-nonce")
 }
 
 func pathAcmeIssuerAndRoleNonce(b *backend) *framework.Path {
 	return patternAcmeNonce(b,
-		"issuer/"+framework.GenericNameRegex(issuerRefParam)+"/roles/"+framework.GenericNameRegex(
-			"role")+"/acme/new-nonce",
-		true /* requireRole */, true /* requireIssuer */)
+		"issuer/"+framework.GenericNameRegex(issuerRefParam)+
+			"/roles/"+framework.GenericNameRegex("role")+"/acme/new-nonce")
 }
 
-func patternAcmeNonce(b *backend, pattern string, requireRole, requireIssuer bool) *framework.Path {
+func patternAcmeNonce(b *backend, pattern string) *framework.Path {
 	fields := map[string]*framework.FieldSchema{}
-	if requireRole {
-		fields["role"] = &framework.FieldSchema{
-			Type:        framework.TypeString,
-			Description: `The desired role for the acme request`,
-			Required:    true,
-		}
-	}
-	if requireIssuer {
-		fields[issuerRefParam] = &framework.FieldSchema{
-			Type:        framework.TypeString,
-			Description: `Reference to an existing issuer name or issuer id`,
-			Required:    true,
-		}
-	}
+	addFieldsForACMEPath(fields, pattern)
+
 	return &framework.Path{
 		Pattern: pattern,
 		Fields:  fields,


### PR DESCRIPTION
~This builds on top of #19803; will be rebased once that is complete.~

---

We start adding handlers for ACME accounts, and in particular, the New Account mechanism. 

One thing that isn't clear is whether the account path (from the KID) is meant to be fetched directly or not. We'll also need to handle converting the kid into a sanitized/kid-only version (without the URL) to fetch from disk.

This does make it clear though that, barring a single static RR URL for all nodes in a cluster, ACME would require the account KID to point to a specific PR cluster. 