### PR TITLE
Merge ACME package back into the PKI package

### DIFF
--- a/builtin/logical/pki/acme_errors.go
+++ b/builtin/logical/pki/acme_errors.go
@@ -1,4 +1,4 @@
-package acme
+package pki
 
 import (
 	"encoding/json"

--- a/builtin/logical/pki/acme_jws.go
+++ b/builtin/logical/pki/acme_jws.go
@@ -1,4 +1,4 @@
-package acme
+package pki
 
 import (
 	"crypto"
@@ -23,7 +23,7 @@ var AllowedOuterJWSTypes = map[string]interface{}{
 }
 
 // This wraps a JWS message structure.
-type JWSCtx struct {
+type jwsCtx struct {
 	Algo     string          `json:"alg"`
 	Kid      string          `json:"kid"`
 	jwk      json.RawMessage `json:"jwk"`
@@ -33,7 +33,7 @@ type JWSCtx struct {
 	Existing bool            `json:"-"`
 }
 
-func (c *JWSCtx) UnmarshalJSON(a *ACMEState, jws []byte) error {
+func (c *jwsCtx) UnmarshalJSON(a *acmeState, jws []byte) error {
 	var err error
 	if err = json.Unmarshal(jws, c); err != nil {
 		return err
@@ -103,7 +103,7 @@ func hasValues(h jose.Header) bool {
 	return h.KeyID != "" || h.JSONWebKey != nil || h.Algorithm != "" || h.Nonce != "" || len(h.ExtraHeaders) > 0
 }
 
-func (c *JWSCtx) VerifyJWS(signature string) (map[string]interface{}, error) {
+func (c *jwsCtx) VerifyJWS(signature string) (map[string]interface{}, error) {
 	// See RFC 8555 Section 6.2. Request Authentication:
 	//
 	// > The JWS Unencoded Payload Option [RFC7797] MUST NOT be used

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -133,10 +133,11 @@ func (a *acmeState) ParseRequestParams(data *framework.FieldData) (*jwsCtx, map[
 	var m map[string]interface{}
 
 	// Parse the key out.
-	jwkBase64, ok := data.GetOk("protected").(string)
+	rawJWKBase64, ok := data.GetOk("protected")
 	if !ok {
 		return nil, nil, fmt.Errorf("missing required field 'protected': %w", ErrMalformed)
 	}
+	jwkBase64 := rawJWKBase64.(string)
 
 	jwkBytes, err := base64.RawURLEncoding.DecodeString(jwkBase64)
 	if err != nil {
@@ -153,15 +154,17 @@ func (a *acmeState) ParseRequestParams(data *framework.FieldData) (*jwsCtx, map[
 		return nil, nil, fmt.Errorf("invalid or reused nonce: %w", ErrBadNonce)
 	}
 
-	payloadBase64, ok := data.Get("payload").(string)
+	rawPayloadBase64, ok := data.GetOk("payload")
 	if !ok {
 		return nil, nil, fmt.Errorf("missing required field 'payload': %w", ErrMalformed)
 	}
+	payloadBase64 := rawPayloadBase64.(string)
 
-	signatureBase64, ok := data.Get("signature").(string)
+	rawSignatureBase64, ok := data.GetOk("signature")
 	if !ok {
 		return nil, nil, fmt.Errorf("missing required field 'signature': %w", ErrMalformed)
 	}
+	signatureBase64 := rawSignatureBase64.(string)
 
 	// go-jose only seems to support compact signature encodings.
 	compactSig := fmt.Sprintf("%v.%v.%v", jwkBase64, payloadBase64, signatureBase64)

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -133,7 +133,11 @@ func (a *acmeState) ParseRequestParams(data *framework.FieldData) (*jwsCtx, map[
 	var m map[string]interface{}
 
 	// Parse the key out.
-	jwkBase64 := data.Get("protected").(string)
+	jwkBase64, ok := data.GetOk("protected").(string)
+	if !ok {
+		return nil, nil, fmt.Errorf("missing required field 'protected': %w", ErrMalformed)
+	}
+
 	jwkBytes, err := base64.RawURLEncoding.DecodeString(jwkBase64)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to base64 parse 'protected': %w", err)
@@ -149,8 +153,15 @@ func (a *acmeState) ParseRequestParams(data *framework.FieldData) (*jwsCtx, map[
 		return nil, nil, fmt.Errorf("invalid or reused nonce")
 	}
 
-	payloadBase64 := data.Get("payload").(string)
-	signatureBase64 := data.Get("signature").(string)
+	payloadBase64, ok := data.Get("payload").(string)
+	if !ok {
+		return nil, nil, fmt.Errorf("missing required field 'payload': %w", ErrMalformed)
+	}
+
+	signatureBase64, ok := data.Get("signature").(string)
+	if !ok {
+		return nil, nil, fmt.Errorf("missing required field 'signature': %w", ErrMalformed)
+	}
 
 	// go-jose only seems to support compact signature encodings.
 	compactSig := fmt.Sprintf("%v.%v.%v", jwkBase64, payloadBase64, signatureBase64)

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -140,7 +140,7 @@ func (a *acmeState) ParseRequestParams(data *framework.FieldData) (*jwsCtx, map[
 
 	jwkBytes, err := base64.RawURLEncoding.DecodeString(jwkBase64)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to base64 parse 'protected': %w", err)
+		return nil, nil, fmt.Errorf("failed to base64 parse 'protected': %s: %w", err, ErrMalformed)
 	}
 	if err = c.UnmarshalJSON(a, jwkBytes); err != nil {
 		return nil, nil, fmt.Errorf("failed to json unmarshal 'protected': %w", err)
@@ -150,7 +150,7 @@ func (a *acmeState) ParseRequestParams(data *framework.FieldData) (*jwsCtx, map[
 	// should read and redeem the nonce here too, to avoid doing any extra
 	// work if it is invalid.
 	if !a.RedeemNonce(c.Nonce) {
-		return nil, nil, fmt.Errorf("invalid or reused nonce")
+		return nil, nil, fmt.Errorf("invalid or reused nonce: %w", ErrBadNonce)
 	}
 
 	payloadBase64, ok := data.Get("payload").(string)

--- a/builtin/logical/pki/acme_state_test.go
+++ b/builtin/logical/pki/acme_state_test.go
@@ -1,4 +1,4 @@
-package acme
+package pki
 
 import (
 	"testing"

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -14,8 +14,6 @@ import (
 
 	atomic2 "go.uber.org/atomic"
 
-	"github.com/hashicorp/vault/builtin/logical/pki/acme"
-
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/vault/helper/constants"
@@ -290,7 +288,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 
 	b.unifiedTransferStatus = newUnifiedTransferStatus()
 
-	b.acmeState = acme.NewACMEState()
+	b.acmeState = NewACMEState()
 	return &b
 }
 
@@ -325,7 +323,7 @@ type backend struct {
 	issuersLock sync.RWMutex
 
 	// Context around ACME operations
-	acmeState *acme.ACMEState
+	acmeState *acmeState
 }
 
 type roleOperation func(ctx context.Context, req *logical.Request, data *framework.FieldData, role *roleEntry) (*logical.Response, error)

--- a/builtin/logical/pki/path_acme_directory.go
+++ b/builtin/logical/pki/path_acme_directory.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/hashicorp/vault/builtin/logical/pki/acme"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -69,7 +68,7 @@ func (b *backend) acmeWrapper(op acmeOperation) framework.OperationFunc {
 
 		if false {
 			// TODO sclark: Check if ACME is enable here
-			return nil, fmt.Errorf("ACME is disabled in configuration: %w", acme.ErrServerInternal)
+			return nil, fmt.Errorf("ACME is disabled in configuration: %w", ErrServerInternal)
 		}
 
 		baseUrl, err := getAcmeBaseUrl(sc, r.Path)
@@ -93,12 +92,12 @@ func getAcmeBaseUrl(sc *storageContext, path string) (*url.URL, error) {
 	}
 
 	if cfg.Path == "" {
-		return nil, fmt.Errorf("ACME feature requires local cluster path configuration to be set: %w", acme.ErrServerInternal)
+		return nil, fmt.Errorf("ACME feature requires local cluster path configuration to be set: %w", ErrServerInternal)
 	}
 
 	baseUrl, err := url.Parse(cfg.Path)
 	if err != nil {
-		return nil, fmt.Errorf("ACME feature a proper URL configured in local cluster path: %w", acme.ErrServerInternal)
+		return nil, fmt.Errorf("ACME feature a proper URL configured in local cluster path: %w", ErrServerInternal)
 	}
 
 	directoryPrefix := ""
@@ -114,7 +113,7 @@ func acmeErrorWrapper(op framework.OperationFunc) framework.OperationFunc {
 	return func(ctx context.Context, r *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		resp, err := op(ctx, r, data)
 		if err != nil {
-			return acme.TranslateError(err)
+			return TranslateError(err)
 		}
 
 		return resp, nil

--- a/builtin/logical/pki/path_acme_new_account.go
+++ b/builtin/logical/pki/path_acme_new_account.go
@@ -49,19 +49,19 @@ func addFieldsForACMERequest(fields map[string]*framework.FieldSchema) map[strin
 	fields["protected"] = &framework.FieldSchema{
 		Type:        framework.TypeString,
 		Description: "ACME request 'protected' value",
-		Required:    true,
+		Required:    false,
 	}
 
 	fields["payload"] = &framework.FieldSchema{
 		Type:        framework.TypeString,
 		Description: "ACME request 'payload' value",
-		Required:    true,
+		Required:    false,
 	}
 
 	fields["signature"] = &framework.FieldSchema{
 		Type:        framework.TypeString,
 		Description: "ACME request 'signature' value",
-		Required:    true,
+		Required:    false,
 	}
 
 	return fields


### PR DESCRIPTION
Based on #19820; will be rebased once that merges. 

```
commit 944588f57a51ad16206d9c7e57b718c96b11f9a6 (HEAD -> merge-acme-package-back-in, upstream/cipherboy-merge-acme-package-back-in)
Author: Alexander Scheel <alex.scheel@hashicorp.com>
Date:   Wed Mar 29 14:53:55 2023 -0400

    Properly format errors for missing parameters
    
    When missing required ACME request parameters, don't return Vault-level
    errors, but drop into the PKI package to return properly-formatted ACME
    error messages.
    
    Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>

commit ff1ad202ac8323d21334144adae723e546da2ba9
Author: Alexander Scheel <alex.scheel@hashicorp.com>
Date:   Wed Mar 29 14:48:48 2023 -0400

    Squash pki/acme package down to pki folder
    
    Without refactoring most of PKI to export the storage layer, which we
    were initially hesitant about, it would be nearly impossible to have the
    ACME layer handle its own storage while being in the acme/ subpackage
    under the pki package.
    
    Thus, merge the two packages together again.
    
    Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>
```