### PR TITLE
Add available types to API documentation for enable audit

### DIFF
--- a/website/content/api-docs/system/audit.mdx
+++ b/website/content/api-docs/system/audit.mdx
@@ -64,8 +64,8 @@ single word name or a more complex, nested path.
 - `description` `(string: "")` – Specifies a human-friendly description of the
   audit device.
 
-- `options` `(map<string|string>: nil)` – Specifies configuration options to
-  pass to the audit device itself. This is dependent on the audit device type.
+- `options` `(map<string|string>: nil)` – Specifies configuration options to pass to the audit device itself.
+  For more details, please see the relevant page for an audit device `type`, under [Audit Devices docs](/vault/docs/audit).
 
 - `type` `(string: <required>)` – Specifies the type of the audit device.
   Valid types are `file`, `socket` and `syslog`.

--- a/website/content/api-docs/system/audit.mdx
+++ b/website/content/api-docs/system/audit.mdx
@@ -68,6 +68,7 @@ single word name or a more complex, nested path.
   pass to the audit device itself. This is dependent on the audit device type.
 
 - `type` `(string: <required>)` – Specifies the type of the audit device.
+  Valid types are `file`, `socket` and `syslog`.
 
 Additionally, the following options are allowed in Vault open-source, but
 relevant functionality is only supported in Vault Enterprise:


### PR DESCRIPTION
The current API documentation doesn't specify the valid type of audit device (`string`) that can be supplied to Vault when enabling an audit backend. 

See: https://developer.hashicorp.com/vault/api-docs/system/audit#type

Adding the currently supported types available.
https://github.com/hashicorp/vault/blob/main/command/commands.go#L172-L174