### PR TITLE
Download Application log files and upload as an artifact when enos scenarios fail

### DIFF
--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -104,6 +104,7 @@ jobs:
       ENOS_VAR_vault_revision: ${{ inputs.vault-revision }}
       ENOS_VAR_vault_bundle_path: ./support/downloads/${{ inputs.build-artifact-name }}
       ENOS_VAR_vault_license_path: ./support/vault.hclic
+      ENOS_DEBUG_DATA_ROOT_DIR: ./support/debug-data
     steps:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2
@@ -148,6 +149,14 @@ jobs:
         id: run_retry
         if: steps.run.outcome == 'failure'
         run: enos scenario run --timeout 60m0s --chdir ./enos ${{ matrix.scenario }}
+      - name: Upload Debug Data
+        if: steps.run.outcome == 'failure' || steps.run_retry.outcome == 'failure'
+        uses: actions/upload-artifact@v3
+        with:
+          # The name of the artifact is the same as the matrix scenario name with the spaces removed.
+          name: ${${{ matrix.scenario }}// /_}.zip
+          path: $ENOS_DEBUG_DATA_ROOT_DIR
+          retention-days: 30
       - name: Ensure scenario has been destroyed
         if: ${{ always() }}
         # With Enos version 0.0.11 the destroy step returns an error if the infrastructure

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -104,7 +104,7 @@ jobs:
       ENOS_VAR_vault_revision: ${{ inputs.vault-revision }}
       ENOS_VAR_vault_bundle_path: ./support/downloads/${{ inputs.build-artifact-name }}
       ENOS_VAR_vault_license_path: ./support/vault.hclic
-      ENOS_DEBUG_DATA_ROOT_DIR: ./support/debug-data
+      ENOS_DEBUG_DATA_ROOT_DIR: ./enos/support/debug-data
     steps:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2
@@ -127,10 +127,12 @@ jobs:
         with:
           github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Prepare scenario dependencies
+        id: prepare_scenario
         run: |
           mkdir -p ./enos/support/terraform-plugin-cache
           echo "${{ secrets.SSH_KEY_PRIVATE_CI }}" > ./enos/support/private_key.pem
           chmod 600 ./enos/support/private_key.pem
+          echo "debug_data_artifact_name=enos-debug-data_$(echo ${{ matrix.scenario }} | sed -e 's/ /_/g' | sed -e 's/:/=/g')" >> $GITHUB_OUTPUT
       - if: contains(inputs.matrix-file-name, 'github')
         uses: actions/download-artifact@v3
         with:
@@ -150,12 +152,12 @@ jobs:
         if: steps.run.outcome == 'failure'
         run: enos scenario run --timeout 60m0s --chdir ./enos ${{ matrix.scenario }}
       - name: Upload Debug Data
-        if: steps.run_retry.outcome == 'failure'
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
-          # The name of the artifact is the same as the matrix scenario name with the spaces replaced with underscores.
-          name: ${${{ matrix.scenario }}// /_}.zip
-          path: $ENOS_DEBUG_DATA_ROOT_DIR
+          # The name of the artifact is the same as the matrix scenario name with the spaces replaced with underscores and colons replaced by equals.
+          name: ${{ steps.prepare_scenario.outputs.debug_data_artifact_name }}
+          path: ${{ env.ENOS_DEBUG_DATA_ROOT_DIR }}
           retention-days: 30
       - name: Ensure scenario has been destroyed
         if: ${{ always() }}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -153,7 +153,7 @@ jobs:
         if: steps.run_retry.outcome == 'failure'
         uses: actions/upload-artifact@v3
         with:
-          # The name of the artifact is the same as the matrix scenario name with the spaces removed.
+          # The name of the artifact is the same as the matrix scenario name with the spaces replaced with underscores.
           name: ${${{ matrix.scenario }}// /_}.zip
           path: $ENOS_DEBUG_DATA_ROOT_DIR
           retention-days: 30

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -150,7 +150,7 @@ jobs:
         if: steps.run.outcome == 'failure'
         run: enos scenario run --timeout 60m0s --chdir ./enos ${{ matrix.scenario }}
       - name: Upload Debug Data
-        if: steps.run.outcome == 'failure' || steps.run_retry.outcome == 'failure'
+        if: steps.run_retry.outcome == 'failure'
         uses: actions/upload-artifact@v3
         with:
           # The name of the artifact is the same as the matrix scenario name with the spaces removed.


### PR DESCRIPTION
Recently the enos-provider was updated to add automatic application log file collection for all vault and remote exec resources. This PR updates the enos run workflow to turn on this feature and to add an upload artifact step to store the logs in the build artifacts. The logs will be zipped up in a file that has the same name as the scenario that failed, with spaces being replaced by underscores.