### PR TITLE
build: try creating the go bin directory

### DIFF
--- a/changelog/19862.txt
+++ b/changelog/19862.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+build: Prefer GOBIN when set over GOPATH/bin when building the binary
+```

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -50,13 +50,17 @@ ${GO_CMD} build \
 
 # Move all the compiled things to the $GOPATH/bin
 OLDIFS=$IFS
-IFS=: MAIN_GOPATH=($GOPATH)
+IFS=: FIRST=($GOPATH) MAIN_BIN_PATH=${GOBIN:-$FIRST}
 IFS=$OLDIFS
 
+if [ ! -n "$GOBIN" ]; then
+    MAIN_BIN_PATH+="/bin"
+fi
+
 # Ensure the go bin folder exists
-mkdir -p ${MAIN_GOPATH}/bin
-rm -f ${MAIN_GOPATH}/bin/vault
-cp bin/vault ${MAIN_GOPATH}/bin/
+mkdir -p ${MAIN_BIN_PATH}
+rm -f ${MAIN_BIN_PATH}/vault
+cp bin/vault ${MAIN_BIN_PATH}
 
 # Done!
 echo

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -50,17 +50,13 @@ ${GO_CMD} build \
 
 # Move all the compiled things to the $GOPATH/bin
 OLDIFS=$IFS
-IFS=: FIRST=($GOPATH) MAIN_BIN_PATH=${GOBIN:-$FIRST}
+IFS=: FIRST=($GOPATH) BIN_PATH=${GOBIN:-${FIRST}/bin}
 IFS=$OLDIFS
 
-if [ ! -n "$GOBIN" ]; then
-    MAIN_BIN_PATH+="/bin"
-fi
-
 # Ensure the go bin folder exists
-mkdir -p ${MAIN_BIN_PATH}
-rm -f ${MAIN_BIN_PATH}/vault
-cp bin/vault ${MAIN_BIN_PATH}
+mkdir -p ${BIN_PATH}
+rm -f ${BIN_PATH}/vault
+cp bin/vault ${BIN_PATH}
 
 # Done!
 echo

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -53,6 +53,8 @@ OLDIFS=$IFS
 IFS=: MAIN_GOPATH=($GOPATH)
 IFS=$OLDIFS
 
+# Ensure the go bin folder exists
+mkdir -p ${MAIN_GOPATH}/bin
 rm -f ${MAIN_GOPATH}/bin/vault
 cp bin/vault ${MAIN_GOPATH}/bin/
 


### PR DESCRIPTION
Currently if the $GOPATH/bin directory does not exist, the binary will fail to be copied to the location.

I don't believe an if statement is needed to check for directory existence before the mkdir command, it simply does nothing when the directory already exists.

Closes https://github.com/hashicorp/vault/issues/7170