### PR TITLE
test/plugin/mongodb: skip tests on 32bit systems

### DIFF
--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -709,8 +710,8 @@ func TestBackend_StaticRole_Rotations_PostgreSQL(t *testing.T) {
 }
 
 func TestBackend_StaticRole_Rotations_MongoDB(t *testing.T) {
-	if v := os.Getenv("GOARCH"); v == "386" {
-		t.Skip("Skipping for 32bit architecture")
+	if strconv.IntSize == 32 {
+		t.Skip("Skipping for 32-bit architecture")
 	}
 
 	cleanup, connURL := mongodb.PrepareTestContainerWithDatabase(t, "5.0.10", "vaulttestdb")

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -709,6 +709,10 @@ func TestBackend_StaticRole_Rotations_PostgreSQL(t *testing.T) {
 }
 
 func TestBackend_StaticRole_Rotations_MongoDB(t *testing.T) {
+	if v := os.Getenv("GOARCH"); v == "386" {
+		t.Skip("Skipping for 32bit architecture")
+	}
+
 	cleanup, connURL := mongodb.PrepareTestContainerWithDatabase(t, "5.0.10", "vaulttestdb")
 	defer cleanup()
 

--- a/plugins/database/mongodb/mongodb.go
+++ b/plugins/database/mongodb/mongodb.go
@@ -64,6 +64,8 @@ func (m *MongoDB) Initialize(ctx context.Context, req dbplugin.InitializeRequest
 	defer m.Unlock()
 
 	if strconv.IntSize == 32 {
+		// Disable the plugin on 32-bit architectures, otherwise we will get
+		// a panic in the mongo driver due to a field not being 64-bit aligned.
 		return dbplugin.InitializeResponse{}, fmt.Errorf("this plugin is disabled on 32-bit architectures")
 	}
 

--- a/plugins/database/mongodb/mongodb.go
+++ b/plugins/database/mongodb/mongodb.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	log "github.com/hashicorp/go-hclog"
@@ -61,6 +62,10 @@ func (m *MongoDB) Type() (string, error) {
 func (m *MongoDB) Initialize(ctx context.Context, req dbplugin.InitializeRequest) (dbplugin.InitializeResponse, error) {
 	m.Lock()
 	defer m.Unlock()
+
+	if strconv.IntSize == 32 {
+		return dbplugin.InitializeResponse{}, fmt.Errorf("this plugin is disabled on 32-bit architectures")
+	}
 
 	m.RawConfig = req.Config
 

--- a/plugins/database/mongodb/mongodb_test.go
+++ b/plugins/database/mongodb/mongodb_test.go
@@ -8,8 +8,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -29,11 +29,14 @@ import (
 
 const mongoAdminRole = `{ "db": "admin", "roles": [ { "role": "readWrite" } ] }`
 
-func TestMongoDB_Initialize(t *testing.T) {
-	if v := os.Getenv("GOARCH"); v == "386" {
-		t.Skip("Skipping for 32bit architecture")
+func skipIf32Bit(t *testing.T) {
+	if strconv.IntSize == 32 {
+		t.Skip("Skipping for 32-bit architecture")
 	}
+}
 
+func TestMongoDB_Initialize(t *testing.T) {
+	skipIf32Bit(t)
 	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
 	defer cleanup()
 
@@ -64,6 +67,7 @@ func TestMongoDB_Initialize(t *testing.T) {
 }
 
 func TestNewUser_usernameTemplate(t *testing.T) {
+	skipIf32Bit(t)
 	type testCase struct {
 		usernameTemplate string
 
@@ -153,6 +157,7 @@ func TestNewUser_usernameTemplate(t *testing.T) {
 }
 
 func TestMongoDB_CreateUser(t *testing.T) {
+	skipIf32Bit(t)
 	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
 	defer cleanup()
 
@@ -185,6 +190,7 @@ func TestMongoDB_CreateUser(t *testing.T) {
 }
 
 func TestMongoDB_CreateUser_writeConcern(t *testing.T) {
+	skipIf32Bit(t)
 	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
 	defer cleanup()
 
@@ -219,6 +225,7 @@ func TestMongoDB_CreateUser_writeConcern(t *testing.T) {
 }
 
 func TestMongoDB_DeleteUser(t *testing.T) {
+	skipIf32Bit(t)
 	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
 	defer cleanup()
 
@@ -259,6 +266,7 @@ func TestMongoDB_DeleteUser(t *testing.T) {
 }
 
 func TestMongoDB_UpdateUser_Password(t *testing.T) {
+	skipIf32Bit(t)
 	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
 	defer cleanup()
 
@@ -295,6 +303,7 @@ func TestMongoDB_UpdateUser_Password(t *testing.T) {
 }
 
 func TestGetTLSAuth(t *testing.T) {
+	skipIf32Bit(t)
 	ca := certhelpers.NewCert(t,
 		certhelpers.CommonName("certificate authority"),
 		certhelpers.IsCA(true),

--- a/plugins/database/mongodb/mongodb_test.go
+++ b/plugins/database/mongodb/mongodb_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -29,6 +30,10 @@ import (
 const mongoAdminRole = `{ "db": "admin", "roles": [ { "role": "readWrite" } ] }`
 
 func TestMongoDB_Initialize(t *testing.T) {
+	if v := os.Getenv("GOARCH"); v == "386" {
+		t.Skip("Skipping for 32bit architecture")
+	}
+
 	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
 	defer cleanup()
 


### PR DESCRIPTION
Example of the panics we see:

```
=== Failed
=== FAIL: builtin/logical/database TestBackend_StaticRole_Rotations_MongoDB (11.81s)
panic: unaligned 64-bit atomic operation [recovered]
	panic: unaligned 64-bit atomic operation
```

My understanding is that we would need to add some padding to a struct in that package to ensure proper alignment on 32-bit architectures. See https://github.com/golang/go/issues/36606. However, since this is a third party package we will just skip the test on 32bit systems.