### PR TITLE
fix race condition in string generator helper

### DIFF
--- a/changelog/19875.txt
+++ b/changelog/19875.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+helper/random: Fix race condition in string generator helper
+```

--- a/helper/random/string_generator.go
+++ b/helper/random/string_generator.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math"
 	"sort"
+	"sync"
 	"time"
 	"unicode"
 
@@ -79,7 +80,8 @@ type StringGenerator struct {
 	Rules serializableRules `mapstructure:"-" json:"rule"` // This is "rule" in JSON so it matches the HCL property type
 
 	// CharsetRule to choose runes from. This is computed from the rules, not directly configurable
-	charset runes
+	charset     runes
+	charsetLock sync.RWMutex
 }
 
 // Generate a random string from the charset and adhering to the provided rules.
@@ -119,7 +121,10 @@ func (g *StringGenerator) generate(rng io.Reader) (str string, err error) {
 	// If performance improvements need to be made, this can be changed to read a batch of
 	// potential strings at once rather than one at a time. This will significantly
 	// improve performance, but at the cost of added complexity.
-	candidate, err := randomRunes(rng, g.charset, g.Length)
+	g.charsetLock.RLock()
+	charset := g.charset
+	g.charsetLock.RUnlock()
+	candidate, err := randomRunes(rng, charset, g.Length)
 	if err != nil {
 		return "", fmt.Errorf("unable to generate random characters: %w", err)
 	}
@@ -232,6 +237,8 @@ func (g *StringGenerator) validateConfig() (err error) {
 		merr = multierror.Append(merr, fmt.Errorf("specified rules require at least %d characters but %d is specified", minLen, g.Length))
 	}
 
+	g.charsetLock.Lock()
+	defer g.charsetLock.Unlock()
 	// Ensure we have a charset & all characters are printable
 	if len(g.charset) == 0 {
 		// Yes this is mutating the generator but this is done so we don't have to compute this on every generation


### PR DESCRIPTION
A data race in vault/helper/random.(*StringGenerator).validateConfig() was exposed by new text coverage that was recently introduced. 

```
WARNING: DATA RACE
Read at 0x00c005d77000 by goroutine 10158:
  github.com/hashicorp/vault/helper/random.(*StringGenerator).validateConfig()
      /home/circleci/go/src/github.com/hashicorp/vault/helper/random/string_generator.go:243 +0x3e6
```

and

```
Previous write at 0x000006f28ae0 by goroutine 10155:
  github.com/hashicorp/vault/helper/random.(*StringGenerator).validateConfig()
      /home/circleci/go/src/github.com/hashicorp/vault/helper/random/string_generator.go:238 +0x293
```

Failure: https://app.circleci.com/pipelines/github/hashicorp/vault/51983/workflows/d654323c-baa8-4985-9838-a4131f8900f5/jobs/607405/steps