### PR TITLE
Correct Issue browser-actions/setup-chrome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
     - id: install-browser-libraries
       run: sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
     - id: install-browser
-      uses: browser-actions/setup-chrome@597130847c84cdac5acceccbd676d612e6f8beb8
+      uses: browser-actions/setup-chrome@29abc1a83d1d71557708563b4bc962d0f983a376
     - id: ui-dependencies
       name: ui-dependencies
       working-directory: ./ui


### PR DESCRIPTION
This PR fixes the issue where the **browser-actions/setup-chrome** action would fail in the **test-ui** workflow job: https://github.com/hashicorp/vault/actions/runs/4575976373/jobs/8079513066

The problem was that an incorrect commit hash was being used. The proposed commit hash is the correct one and it was verified by temporarily removing the **if** condition on the **test-ui** job. This caused the job to execute in this branch: https://github.com/hashicorp/vault/actions/runs/4575747084/jobs/8078976210