### PR TITLE
Secrets/Auth Mount Path Whitespace Warning 

### DIFF
--- a/changelog/19886.txt
+++ b/changelog/19886.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Adds whitespace warning banner to secrets engine and auth method path inputs
+```

--- a/ui/app/components/secret-create-or-update.js
+++ b/ui/app/components/secret-create-or-update.js
@@ -46,7 +46,6 @@ export default class SecretCreateOrUpdate extends Component {
   @tracked codemirrorString = null;
   @tracked error = null;
   @tracked secretPaths = null;
-  @tracked pathWhiteSpaceWarning = false;
   @tracked validationErrorCount = 0;
   @tracked validationMessages = null;
 
@@ -84,8 +83,6 @@ export default class SecretCreateOrUpdate extends Component {
   }
   checkValidation(name, value) {
     if (name === 'path') {
-      // check for whitespace
-      this.pathHasWhiteSpace(value);
       !value
         ? set(this.validationMessages, name, `${name} can't be blank.`)
         : set(this.validationMessages, name, '');
@@ -109,10 +106,6 @@ export default class SecretCreateOrUpdate extends Component {
     } else {
       this.transitionToRoute(LIST_ROOT_ROUTE);
     }
-  }
-  pathHasWhiteSpace(value) {
-    const validation = new RegExp('\\s', 'g'); // search for whitespace
-    this.pathWhiteSpaceWarning = validation.test(value);
   }
   // successCallback is called in the context of the component
   persistKey(successCallback) {

--- a/ui/app/models/auth-method.js
+++ b/ui/app/models/auth-method.js
@@ -25,7 +25,9 @@ const ModelExport = AuthMethodModel.extend({
 
   config: belongsTo('mount-config', { async: false, inverse: null }), // one-to-none that replaces former fragment
   authConfigs: hasMany('auth-config', { polymorphic: true, inverse: 'backend', async: false }),
-  path: attr('string'),
+  path: attr('string', {
+    whitespaceWarning: true,
+  }),
   accessor: attr('string'),
   name: attr('string'),
   type: attr('string'),

--- a/ui/app/models/secret-engine.js
+++ b/ui/app/models/secret-engine.js
@@ -24,7 +24,10 @@ const validations = {
 @withModelValidations(validations)
 @withExpandedAttributes()
 export default class SecretEngineModel extends Model {
-  @attr('string') path;
+  @attr('string', {
+    whitespaceWarning: true,
+  })
+  path;
   @attr('string') type;
   @attr('string', {
     editType: 'textarea',

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -34,12 +34,11 @@
           <code>/</code>
         </p>
       {{/if}}
-      {{#if this.pathWhiteSpaceWarning}}
+      {{#if (has-whitespace (get @modelForData @modelForData.pathAttr))}}
         <div class="has-top-margin-m">
           <AlertBanner
             @type="warning"
             @message="Your secret path contains whitespace. If this is desired, you'll need to encode it with %20 in API calls."
-            @marginTop={{true}}
             data-test-whitespace-warning
           />
         </div>

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -318,6 +318,15 @@
         {{#if this.validationError}}
           <AlertInline @type="danger" @message={{this.validationError}} @paddingTop={{true}} />
         {{/if}}
+        {{#if (and @attr.options.whitespaceWarning (has-whitespace (get @model this.valuePath)))}}
+          <div class="has-top-margin-m">
+            <AlertBanner
+              @type="warning"
+              @message="Value contains whitespace. If this is desired, you'll need to encode it with %20 in API requests."
+              data-test-whitespace-warning
+            />
+          </div>
+        {{/if}}
       {{/if}}
     </div>
   {{else if (eq @attr.type "boolean")}}

--- a/ui/lib/core/addon/helpers/has-whitespace.js
+++ b/ui/lib/core/addon/helpers/has-whitespace.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { helper } from '@ember/component/helper';
+
+function hasWhitespace([string]) {
+  const whitespace = /\s/;
+  return whitespace.test(string);
+}
+
+export default helper(hasWhitespace);

--- a/ui/lib/core/app/helpers/has-whitespace.js
+++ b/ui/lib/core/app/helpers/has-whitespace.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export { default } from 'core/helpers/has-whitespace';

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -210,4 +210,31 @@ module('Integration | Component | form field', function (hooks) {
     assert.dom('[data-test-toggle-input="Foo"]').isChecked('Toggle is initially checked when given value');
     assert.dom('[data-test-ttl-value="Foo"]').hasValue('1', 'Ttl input displays with correct value');
   });
+
+  test('it should show whitespace warning', async function (assert) {
+    this.setProperties({
+      model: EmberObject.create({ foo: null }),
+      attr: createAttr('foo', 'string', { whitespaceWarning: true }),
+      onChange: () => {},
+    });
+
+    await render(hbs`<FormField @attr={{this.attr}} @model={{this.model}} @onChange={{this.onChange}} />`);
+    assert
+      .dom('[data-test-whitespace-warning]')
+      .doesNotExist('Whitespace warning does not render for no value');
+    await fillIn('[data-test-input="foo"]', 'foo');
+    assert
+      .dom('[data-test-whitespace-warning]')
+      .doesNotExist('Whitespace warning does not render for value without whitespace');
+    await fillIn('[data-test-input="foo"]', ' foo');
+    assert.dom('[data-test-whitespace-warning]').exists('Whitespace warning renders with leading whitespace');
+    await fillIn('[data-test-input="foo"]', 'foo ');
+    assert
+      .dom('[data-test-whitespace-warning]')
+      .exists('Whitespace warning renders with trailing whitespace');
+    await fillIn('[data-test-input="foo"]', 'foo bar');
+    assert
+      .dom('[data-test-whitespace-warning]')
+      .exists('Whitespace warning renders with whitespace separating words');
+  });
 });

--- a/ui/tests/integration/utils/field-to-attrs-test.js
+++ b/ui/tests/integration/utils/field-to-attrs-test.js
@@ -11,7 +11,7 @@ import fieldToAttrs, { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 module('Integration | Util | field to attrs', function (hooks) {
   setupTest(hooks);
 
-  const PATH_ATTR = { type: 'string', name: 'path', options: {} };
+  const PATH_ATTR = { type: 'string', name: 'path', options: { whitespaceWarning: true } };
   const DESCRIPTION_ATTR = { type: 'string', name: 'description', options: { editType: 'textarea' } };
   const DEFAULT_LEASE_ATTR = {
     type: undefined,


### PR DESCRIPTION
This PR builds on the alert banner that was added to the secrets path input to warn of values containing whitespace and adds it to the secrets and auth mount path inputs. Since `FormFieldGroups` are used I added an attribute option `whitespaceWarning` and a `has-whitespace` helper to be used in the `FormField` template for the standard text input. This could be expanded to other form field types if need be.

![image](https://user-images.githubusercontent.com/24611656/229020290-e59dc5f7-e154-489c-a15b-0ed9ad8a4627.png)

![image](https://user-images.githubusercontent.com/24611656/229020343-1b5fae54-f267-4e64-875b-962904072466.png)

Closes #8268
