### PR TITLE
Add DataDog test visibility to the test-go job

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -166,6 +166,20 @@ jobs:
               ${{ inputs.extra-flags }} \
                 \
               ${test_packages[${{ matrix.runner-index }}]}
+      - name: Prepare datadog-ci
+      #THIS STEP SHOULD NOT FAIL THE PIPELINE ON ERROR
+        if: github.repository == 'hashicorp/vault'
+        run: |
+          curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
+          chmod +x /usr/local/bin/datadog-ci
+      - name: upload coverage
+        env:
+          DD_ENV: ci
+        run: |
+          if [[ ${{ github.repository }} == 'hashicorp/vault' ]]; then
+            export DATADOG_API_KEY=${{ secrets.DATADOG_API_KEY }}
+          fi
+          datadog-ci junit upload --service "$GITHUB_REPOSITORY" test-results/go-test/results.xml
       - name: Archive test results
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -105,6 +105,7 @@ jobs:
           caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
           token: ${{ steps.vault-auth.outputs.token }}
           secrets: |
+            kv/data/github/${{ github.repository }}/datadog-ci DATADOG_API_KEY;
             kv/data/github/${{ github.repository }}/license license_1 | VAULT_LICENSE_CI;
             kv/data/github/${{ github.repository }}/license license_2 | VAULT_LICENSE_2;
             kv/data/github/${{ github.repository }}/hcp-link HCP_API_ADDRESS;

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -167,12 +167,13 @@ jobs:
                 \
               ${test_packages[${{ matrix.runner-index }}]}
       - name: Prepare datadog-ci
-      #THIS STEP SHOULD NOT FAIL THE PIPELINE ON ERROR
         if: github.repository == 'hashicorp/vault'
+        continue-on-error: true
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
           chmod +x /usr/local/bin/datadog-ci
-      - name: upload coverage
+      - name: Upload test results to DataDog
+        continue-on-error: true
         env:
           DD_ENV: ci
         run: |


### PR DESCRIPTION
DataDog CI visibility test view allows you to view metrics and results from your tests in DataDog. It can help you investigate performance problems and test failures that concern you primarily because you work on the related code (and less because you maintain the pipelines they are run in). 