### PR TITLE
Clarify that other operations run while tidy is paused

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -3844,7 +3844,7 @@ expiration time.
 
 - `pause_duration` `(string: "0s")` - Specifies the duration to pause
   between tidying individual certificates. This releases the revocation
-  lock and allows other operations to continue while tidy is running.
+  lock and allows other operations to continue while tidy is paused.
   This allows an operator to control tidy's resource utilization within
   a timespan: the LIST operation will remain in memory, but the space
   between reading, parsing, and updates on-disk cert entries will be


### PR DESCRIPTION
From discussion with UI team, this clarifies that the other operations run while tidy is paused (sleeping during this pause duration), not while tidy is not-sleeping.