### PR TITLE
secrets/aws: create leases by default

### DIFF
--- a/builtin/logical/aws/backend_test.go
+++ b/builtin/logical/aws/backend_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/sts"
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/vault/helper/testhelpers"
 	logicaltest "github.com/hashicorp/vault/helper/testhelpers/logical"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -1469,6 +1469,7 @@ func testAccStepReadIamGroups(t *testing.T, name string, groups []string) logica
 				"permissions_boundary_arn": "",
 				"iam_groups":               groups,
 				"iam_tags":                 map[string]string(nil),
+				"no_lease":                 false,
 			}
 			if !reflect.DeepEqual(resp.Data, expected) {
 				return fmt.Errorf("bad: got: %#v\nexpected: %#v", resp.Data, expected)

--- a/builtin/logical/aws/path_roles.go
+++ b/builtin/logical/aws/path_roles.go
@@ -150,6 +150,12 @@ delimited key pairs.`,
 				},
 				Default: "/",
 			},
+
+			"no_lease": {
+				Type:        framework.TypeBool,
+				Description: "Skip lease creation for \"assumed_role\" and \"federation_token\" credential types",
+				Default:     false,
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -315,6 +321,10 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 
 	if iamTags, ok := d.GetOk("iam_tags"); ok {
 		roleEntry.IAMTags = iamTags.(map[string]string)
+	}
+
+	if noLease, ok := d.GetOk("no_lease"); ok {
+		roleEntry.NoLease = noLease.(bool)
 	}
 
 	if legacyRole != "" {
@@ -510,6 +520,7 @@ type awsRoleEntry struct {
 	MaxSTSTTL                time.Duration     `json:"max_sts_ttl"`                           // Max allowed TTL for STS credentials
 	UserPath                 string            `json:"user_path"`                             // The path for the IAM user when using "iam_user" credential type
 	PermissionsBoundaryARN   string            `json:"permissions_boundary_arn"`              // ARN of an IAM policy to attach as a permissions boundary
+	NoLease                  bool              `json:"no_lease"`                              // Skip lease creation for "assumed_role" and "federation_token" credential types
 }
 
 func (r *awsRoleEntry) toResponseData() map[string]interface{} {
@@ -524,6 +535,7 @@ func (r *awsRoleEntry) toResponseData() map[string]interface{} {
 		"max_sts_ttl":              int64(r.MaxSTSTTL.Seconds()),
 		"user_path":                r.UserPath,
 		"permissions_boundary_arn": r.PermissionsBoundaryARN,
+		"no_lease":                 r.NoLease,
 	}
 
 	if r.InvalidData != "" {

--- a/builtin/logical/aws/path_user.go
+++ b/builtin/logical/aws/path_user.go
@@ -133,9 +133,9 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 		case !strutil.StrListContains(role.RoleArns, roleArn):
 			return logical.ErrorResponse(fmt.Sprintf("role_arn %q not in allowed role arns for Vault role %q", roleArn, roleName)), nil
 		}
-		return b.assumeRole(ctx, req.Storage, req.DisplayName, roleName, roleArn, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl, roleSessionName)
+		return b.assumeRole(ctx, req.Storage, req.DisplayName, roleName, roleArn, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl, roleSessionName, role.NoLease)
 	case federationTokenCred:
-		return b.getFederationToken(ctx, req.Storage, req.DisplayName, roleName, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl)
+		return b.getFederationToken(ctx, req.Storage, req.DisplayName, roleName, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl, role.NoLease)
 	default:
 		return logical.ErrorResponse(fmt.Sprintf("unknown credential_type: %q", credentialType)), nil
 	}


### PR DESCRIPTION
Follow up to https://github.com/hashicorp/vault/pull/15869 because not creating leases is causing issues. (see https://github.com/hashicorp/vault/issues/19513)

This PR adds a `no_lease` option for aws secrets roles that is disabled by default. Only when this option is enabled will leases not be create for assumed role and federated token credentials.

The only other fix I know of is to revert https://github.com/hashicorp/vault/pull/15869