### PR TITLE
docs(postgresql): Update Postgresql SE API doco

### DIFF
--- a/website/content/api-docs/secret/databases/postgresql.mdx
+++ b/website/content/api-docs/secret/databases/postgresql.mdx
@@ -33,6 +33,8 @@ has a number of parameters to further configure a connection.
   A templated connection URL is required when using root credential rotation. This field 
   supports both format string types, URI and keyword/value. Both formats support multiple 
   host connection strings.
+  Due to how `pgx` works under the hood, parameters such as `sslrootcert`, `sslcert`, `sslkey` are treated as paths
+  on the Vault server.
 
 - `max_open_connections` `(int: 4)` - Specifies the maximum number of open
   connections to the database.
@@ -59,7 +61,7 @@ has a number of parameters to further configure a connection.
 - `password_authentication` `(string: "password")` - When set to "scram-sha-256", passwords will be hashed by Vault and stored as-is by PostgreSQL.
   Using "scram-sha-256" requires a minimum version of PostgreSQL 10. Available options are "scram-sha-256" and "password". The default is "password".
   When set to "password", passwords will be sent to PostgresSQL in plaintext format and may appear in PostgreSQL logs as-is.
-  For more information, please refer to the [https://www.postgresql.org/docs/current/sql-createrole.html#password](PostgreSQL documentation).
+  For more information, please refer to the (https://www.postgresql.org/docs/current/sql-createrole.html#password)[PostgreSQL documentation].
 
 
 <details>

--- a/website/content/api-docs/secret/databases/postgresql.mdx
+++ b/website/content/api-docs/secret/databases/postgresql.mdx
@@ -61,7 +61,7 @@ has a number of parameters to further configure a connection.
 - `password_authentication` `(string: "password")` - When set to "scram-sha-256", passwords will be hashed by Vault and stored as-is by PostgreSQL.
   Using "scram-sha-256" requires a minimum version of PostgreSQL 10. Available options are "scram-sha-256" and "password". The default is "password".
   When set to "password", passwords will be sent to PostgresSQL in plaintext format and may appear in PostgreSQL logs as-is.
-  For more information, please refer to the (https://www.postgresql.org/docs/current/sql-createrole.html#password)[PostgreSQL documentation].
+  For more information, please refer to the [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-createrole.html#password).
 
 
 <details>

--- a/website/content/api-docs/secret/databases/postgresql.mdx
+++ b/website/content/api-docs/secret/databases/postgresql.mdx
@@ -33,7 +33,7 @@ has a number of parameters to further configure a connection.
   A templated connection URL is required when using root credential rotation. This field 
   supports both format string types, URI and keyword/value. Both formats support multiple 
   host connection strings.
-  Due to how `pgx` works under the hood, parameters such as `sslrootcert`, `sslcert`, `sslkey` are treated as paths
+  Due to how `pgx` works, parameters such as `sslrootcert`, `sslcert`, `sslkey` are treated as paths
   on the Vault server.
 
 - `max_open_connections` `(int: 4)` - Specifies the maximum number of open


### PR DESCRIPTION
Update the postgresql secret engine API docs to include some "caveats"
of the pgx library. In particular, this enhances the docs to inform the
user that if any sslcreds are supplied as a part of the Database
connection string, the user/vault admin will need to ensure that the
certificates are present at those paths.
