### PR TITLE
api: remove direct dependency on hclog

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 func init() {
@@ -555,6 +555,18 @@ func TestClientNonTransportRoundTripperUnixAddress(t *testing.T) {
 	}
 }
 
+type nullLogger struct{}
+
+func (l nullLogger) Debug(msg string, args ...interface{}) {}
+
+func (l nullLogger) Info(msg string, args ...interface{}) {}
+
+func (l nullLogger) Warn(msg string, args ...interface{}) {}
+
+func (l nullLogger) Error(msg string, args ...interface{}) {}
+
+var _ retryablehttp.LeveledLogger = nullLogger{}
+
 func TestClone(t *testing.T) {
 	type fields struct{}
 	tests := []struct {
@@ -613,7 +625,7 @@ func TestClone(t *testing.T) {
 			}
 			parent.SetCheckRetry(checkRetry)
 
-			parent.SetLogger(hclog.NewNullLogger())
+			parent.SetLogger(nullLogger{})
 
 			parent.SetLimiter(5.0, 10)
 			parent.SetMaxRetries(5)

--- a/api/go.mod
+++ b/api/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/go-test/deep v1.0.2
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
-	github.com/hashicorp/go-hclog v0.16.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/go-rootcerts v1.0.2
@@ -23,14 +22,13 @@ require (
 )
 
 require (
-	github.com/fatih/color v1.7.0 // indirect
 	github.com/google/go-cmp v0.5.7 // indirect
+	github.com/hashicorp/go-hclog v0.16.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	golang.org/x/crypto v0.6.0 // indirect
-	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -72,7 +72,6 @@ golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
-golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.7.0 h1:4BRB4x83lYWy72KwLD/qYDuTu7q9PjSagHvijDw7cLo=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 h1:NusfzzA6yGQ+ua51ck7E3omNUX/JuqbFSaRGqU8CcLI=


### PR DESCRIPTION
In tests, define a local implementation of a null logger satisfying the [retryablehttp.LeveledLogger interface](https://pkg.go.dev/github.com/hashicorp/go-retryablehttp#LeveledLogger) as a replacement of a reference to [hclog.NewNullLogger()](https://pkg.go.dev/github.com/hashicorp/go-hclog#NewNullLogger). This allows to drop the single *direct* reference to `hclog` and so to reduce dependencies for a leaner impact on downstream modules (see #14017).