### PR TITLE
ui: update engine dependencies and fix file import

### DIFF
--- a/ui/lib/kmip/addon/engine.js
+++ b/ui/lib/kmip/addon/engine.js
@@ -17,7 +17,6 @@ const Eng = Engine.extend({
     services: [
       'auth',
       'download',
-      'flash-messages',
       'namespace',
       'path-help',
       'router',

--- a/ui/lib/kubernetes/addon/engine.js
+++ b/ui/lib/kubernetes/addon/engine.js
@@ -16,7 +16,7 @@ export default class KubernetesEngine extends Engine {
   modulePrefix = modulePrefix;
   Resolver = Resolver;
   dependencies = {
-    services: ['router', 'store', 'secret-mount-path', 'flashMessages'],
+    services: ['router', 'store', 'secret-mount-path'],
     externalRoutes: ['secrets'],
   };
 }

--- a/ui/lib/open-api-explorer/addon/engine.js
+++ b/ui/lib/open-api-explorer/addon/engine.js
@@ -14,7 +14,7 @@ const Eng = Engine.extend({
   modulePrefix,
   Resolver,
   dependencies: {
-    services: ['auth', 'flash-messages', 'namespace', 'router', 'version'],
+    services: ['auth', 'namespace', 'router', 'version'],
   },
 });
 

--- a/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.ts
+++ b/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.ts
@@ -8,7 +8,7 @@ import errorMessage from 'vault/utils/error-message';
 // TYPES
 import Store from '@ember-data/store';
 import Router from '@ember/routing/router';
-import FlashMessageService from 'vault/services/flash-messages';
+import FlashMessageService from 'ember-cli-flash/services/flash-messages';
 import SecretMountPath from 'vault/services/secret-mount-path';
 import PkiIssuerModel from 'vault/models/pki/issuer';
 import PkiActionModel from 'vault/vault/models/pki/action';

--- a/ui/lib/pki/addon/engine.js
+++ b/ui/lib/pki/addon/engine.js
@@ -19,7 +19,6 @@ export default class PkiEngine extends Engine {
     services: [
       'auth',
       'download',
-      'flash-messages',
       'namespace',
       'path-help',
       'router',

--- a/ui/lib/replication/addon/engine.js
+++ b/ui/lib/replication/addon/engine.js
@@ -3,22 +3,20 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Engine from 'ember-engines/engine';
+import Engine from '@ember/engine';
 import loadInitializers from 'ember-load-initializers';
-import Resolver from './resolver';
+import Resolver from 'ember-resolver';
 import config from './config/environment';
 
 const { modulePrefix } = config;
-/* eslint-disable ember/avoid-leaking-state-in-ember-objects */
-const Eng = Engine.extend({
-  modulePrefix,
-  Resolver,
-  dependencies: {
-    services: ['auth', 'flash-messages', 'namespace', 'replication-mode', 'router', 'store', 'version'],
+
+export default class ReplicationEngine extends Engine {
+  modulePrefix = modulePrefix;
+  Resolver = Resolver;
+  dependencies = {
+    services: ['auth', 'namespace', 'replication-mode', 'router', 'store', 'version'],
     externalRoutes: ['replication'],
-  },
-});
+  };
+}
 
-loadInitializers(Eng, modulePrefix);
-
-export default Eng;
+loadInitializers(ReplicationEngine, modulePrefix);


### PR DESCRIPTION
A few cleanup tasks were missed because our UI tests are down. 

While running tests locally my dependency file was outdated and so I missed updating the flash-message import in this PR #19739

I think outdated dependencies also caused us to miss removing the service mappings from the respective `engine.js` files in this PR #19925
