### PR TITLE
Consolidating our size variables with Bulma's

### DIFF
--- a/ui/app/styles/components/action-block.scss
+++ b/ui/app/styles/components/action-block.scss
@@ -53,7 +53,7 @@
   display: flex;
   flex-wrap: wrap;
   margin: $spacing-m 0;
-  @include until($tablet) {
+  @include until($mobile) {
     display: block;
   }
 }
@@ -67,7 +67,7 @@
 
 .replication-actions-grid-item .action-block {
   width: 100%;
-  @include until($tablet) {
+  @include until($mobile) {
     height: inherit;
   }
 }

--- a/ui/app/styles/components/calendar-widget.scss
+++ b/ui/app/styles/components/calendar-widget.scss
@@ -71,7 +71,7 @@ $dark-gray: #535f73;
       color: black;
       text-align: center;
       border: 1px solid $ui-gray-200;
-      border-radius: $radius-small;
+      border-radius: $radius;
     }
     &.is-current-month {
       border: 1px solid $ui-gray-900;
@@ -104,7 +104,7 @@ $dark-gray: #535f73;
   grid-template-rows: 0.7fr 3fr;
   box-shadow: $box-shadow, $box-shadow-middle;
   background-color: white;
-  border-radius: $radius-small;
+  border-radius: $radius;
 }
 
 .calendar-widget-grid {

--- a/ui/app/styles/components/calendar-widget.scss
+++ b/ui/app/styles/components/calendar-widget.scss
@@ -71,7 +71,7 @@ $dark-gray: #535f73;
       color: black;
       text-align: center;
       border: 1px solid $ui-gray-200;
-      border-radius: 2px;
+      border-radius: $radius-small;
     }
     &.is-current-month {
       border: 1px solid $ui-gray-900;
@@ -104,7 +104,7 @@ $dark-gray: #535f73;
   grid-template-rows: 0.7fr 3fr;
   box-shadow: $box-shadow, $box-shadow-middle;
   background-color: white;
-  border-radius: 2px;
+  border-radius: $radius-small;
 }
 
 .calendar-widget-grid {

--- a/ui/app/styles/components/confirm.scss
+++ b/ui/app/styles/components/confirm.scss
@@ -76,7 +76,7 @@
 }
 
 .confirm-action > span {
-  @include from($tablet) {
+  @include from($mobile) {
     align-items: center;
     display: flex;
   }
@@ -88,7 +88,7 @@
   .confirm-action-text:not(.is-block) {
     text-align: right;
 
-    @include until($tablet) {
+    @include until($mobile) {
       display: block;
       margin-bottom: $size-8;
       text-align: left;

--- a/ui/app/styles/components/confirm.scss
+++ b/ui/app/styles/components/confirm.scss
@@ -6,7 +6,7 @@
 .confirm-wrapper {
   position: relative;
   overflow: hidden;
-  border-radius: 2px;
+  border-radius: $radius-small;
   box-shadow: $box-shadow, $box-shadow-middle;
 }
 

--- a/ui/app/styles/components/confirm.scss
+++ b/ui/app/styles/components/confirm.scss
@@ -6,7 +6,7 @@
 .confirm-wrapper {
   position: relative;
   overflow: hidden;
-  border-radius: $radius-small;
+  border-radius: $radius;
   box-shadow: $box-shadow, $box-shadow-middle;
 }
 

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -37,7 +37,7 @@
   color: $white;
   display: flex;
   flex-direction: column;
-  font-size: $body-size;
+  font-size: $size-8;
   font-weight: $font-weight-semibold;
   justify-content: flex-end;
   min-height: 100%;
@@ -48,19 +48,19 @@
   p {
     background: none;
     color: inherit;
-    font-size: $body-size;
+    font-size: $size-8;
     min-height: 2rem;
     padding: 0;
 
     &:not(.console-ui-command):not(.CodeMirror-line) {
-      padding-left: $console-spacing;
+      padding-left: $size-4;
     }
   }
 
   .cm-s-hashi.CodeMirror {
     background-color: rgba($black, 0.5) !important;
     font-weight: $font-weight-normal;
-    margin-left: $console-spacing;
+    margin-left: $size-4;
     padding: $size-8 $size-4;
   }
 }
@@ -108,7 +108,7 @@
 }
 
 .console-ui-alert {
-  margin-left: calc(#{$console-spacing} - 0.33rem);
+  margin-left: calc(#{$size-4} - 0.33rem);
   position: relative;
 
   svg {

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -11,7 +11,7 @@
   min-height: 0;
   overflow: scroll;
   right: 0;
-  top: $header-height;
+  top: $spacing-xxxl;
   transition: min-height $speed ease-out, transform $speed ease-in;
   will-change: transform, min-height;
   -webkit-overflow-scrolling: touch;

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -12,7 +12,7 @@
   overflow: scroll;
   right: 0;
   top: $spacing-xxxl;
-  transition: min-height $speed ease-out, transform $speed ease-in;
+  transition: min-height $speed $easing, transform $speed ease-in;
   will-change: transform, min-height;
   -webkit-overflow-scrolling: touch;
   width: 100vw;

--- a/ui/app/styles/components/info-table-row.scss
+++ b/ui/app/styles/components/info-table-row.scss
@@ -11,7 +11,7 @@
     box-shadow: none;
   }
 
-  @include from($tablet) {
+  @include from($mobile) {
     display: flex;
   }
 
@@ -63,14 +63,14 @@
 }
 
 .info-table-row:not(.is-mobile) .column {
-  @include until($tablet) {
+  @include until($mobile) {
     padding: 0;
   }
 
   &:first-child {
     padding-left: 0;
 
-    @include until($tablet) {
+    @include until($mobile) {
       padding: $size-8 0 0;
     }
   }
@@ -78,7 +78,7 @@
   &:last-child {
     padding-right: 0;
 
-    @include until($tablet) {
+    @include until($mobile) {
       padding: 0 0 $size-8;
     }
   }
@@ -90,7 +90,7 @@
   color: $grey;
   font-weight: $font-weight-semibold;
 
-  @include until($tablet) {
+  @include until($mobile) {
     display: none;
   }
   .info-table-row:not(.is-mobile) .column:last-child {

--- a/ui/app/styles/components/list-item-row.scss
+++ b/ui/app/styles/components/list-item-row.scss
@@ -41,10 +41,10 @@ a.list-item-row,
   &:hover,
   &:focus,
   &:active {
-    margin-left: #{-$column-gap} !important;
-    margin-right: #{-$column-gap} !important;
-    padding-left: $column-gap;
-    padding-right: $column-gap;
+    margin-left: #{-$size-9} !important;
+    margin-right: #{-$size-9} !important;
+    padding-left: $size-9;
+    padding-right: $size-9;
     position: relative;
     box-shadow: 0 2px 0 -1px $grey-light, 0 -2px 0 -1px $grey-light, $box-link-hover-shadow,
       $box-shadow-middle;

--- a/ui/app/styles/components/list-pagination.scss
+++ b/ui/app/styles/components/list-pagination.scss
@@ -108,7 +108,7 @@
   background: $white;
   max-width: 8rem;
 
-  @include until($tablet) {
+  @include until($mobile) {
     max-width: 2rem;
     padding-left: 0;
     padding-right: 0;
@@ -116,7 +116,7 @@
 
   .pagination-next-label,
   .pagination-previous-label {
-    @include until($tablet) {
+    @include until($mobile) {
       display: none;
     }
   }
@@ -181,7 +181,7 @@
 }
 
 .list-pagination .pagination-next {
-  @include until($tablet) {
+  @include until($mobile) {
     order: 3;
   }
 }

--- a/ui/app/styles/components/page-header.scss
+++ b/ui/app/styles/components/page-header.scss
@@ -15,12 +15,12 @@
     flex-grow: 1;
     flex-shrink: 1;
 
-    @include until($tablet) {
+    @include until($mobile) {
       margin-top: 0.5rem;
     }
   }
   .level-right {
-    @include from($tablet) {
+    @include from($mobile) {
       justify-content: flex-end;
     }
   }

--- a/ui/app/styles/components/popup-menu.scss
+++ b/ui/app/styles/components/popup-menu.scss
@@ -5,11 +5,11 @@
 
 .popup-menu-content,
 .ember-power-select-options {
-  border-radius: $radius-small;
+  border-radius: $radius;
   margin: -2px 0 0 0;
 
   & > .box {
-    border-radius: $radius-small;
+    border-radius: $radius;
     box-shadow: $box-shadow, $box-shadow-middle;
     padding: 0;
     position: relative;

--- a/ui/app/styles/components/popup-menu.scss
+++ b/ui/app/styles/components/popup-menu.scss
@@ -5,11 +5,11 @@
 
 .popup-menu-content,
 .ember-power-select-options {
-  border-radius: 2px;
+  border-radius: $radius-small;
   margin: -2px 0 0 0;
 
   & > .box {
-    border-radius: 2px;
+    border-radius: $radius-small;
     box-shadow: $box-shadow, $box-shadow-middle;
     padding: 0;
     position: relative;

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -99,7 +99,7 @@
         border-right: 4px solid $blue;
       }
     }
-
+    // ARG TODO follow up, only use case of $fullhd
     .tag {
       @include from($fullhd) {
         float: right;

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -10,7 +10,7 @@
   margin: 0.75rem 0.75rem 0.75rem 0;
   padding: 0 0 0 0.75rem;
 
-  @include until($tablet) {
+  @include until($mobile) {
     background-color: $white;
     bottom: 0;
     left: -1.5rem;
@@ -26,7 +26,7 @@
   }
 
   &.is-active {
-    @include until($tablet) {
+    @include until($mobile) {
       transform: translateX(0);
     }
 
@@ -45,7 +45,7 @@
     position: absolute;
     top: 0;
 
-    @include until($tablet) {
+    @include until($mobile) {
       display: block;
     }
 
@@ -59,7 +59,7 @@
     padding-top: 5.25rem;
     position: relative;
 
-    @include until($tablet) {
+    @include until($mobile) {
       padding-top: $size-6;
     }
   }
@@ -77,7 +77,7 @@
     border-top: $base-border;
     padding: $size-9 0;
 
-    @include until($tablet) {
+    @include until($mobile) {
       padding-top: $size-4;
     }
 

--- a/ui/app/styles/components/ui-wizard.scss
+++ b/ui/app/styles/components/ui-wizard.scss
@@ -24,7 +24,7 @@
   padding-right: 324px;
   padding-right: calc(324px + env(safe-area-inset-right));
 
-  @include until($tablet) {
+  @include until($mobile) {
     padding-right: 0;
     padding-bottom: 50vh;
   }
@@ -54,7 +54,7 @@
     z-index: 30;
   }
 
-  @include until($tablet) {
+  @include until($mobile) {
     box-shadow: $box-shadow, 0 0 20px rgba($black, 0.24);
     bottom: 0;
     left: 0;
@@ -80,7 +80,7 @@
   margin: $size-4 0;
   position: relative;
 
-  @include until($tablet) {
+  @include until($mobile) {
     margin-top: 0;
     padding-top: 0;
   }
@@ -106,7 +106,7 @@
   right: $size-8;
   top: calc(#{$header-height} + #{$size-8});
 
-  @include until($tablet) {
+  @include until($mobile) {
     box-shadow: $box-shadow, 0 0 20px rgba($black, 0.24);
     bottom: 0;
     left: 0;

--- a/ui/app/styles/components/ui-wizard.scss
+++ b/ui/app/styles/components/ui-wizard.scss
@@ -39,7 +39,7 @@
   position: fixed;
   right: $size-8;
   bottom: $size-8;
-  top: calc(#{$header-height} + #{$size-8});
+  top: calc(#{$spacing-xxxl} + #{$size-8});
   overflow: auto;
 
   p {
@@ -104,7 +104,7 @@
   padding-bottom: $size-11;
   position: fixed;
   right: $size-8;
-  top: calc(#{$header-height} + #{$size-8});
+  top: calc(#{$spacing-xxxl} + #{$size-8});
 
   @include until($mobile) {
     box-shadow: $box-shadow, 0 0 20px rgba($black, 0.24);

--- a/ui/app/styles/core/breadcrumb.scss
+++ b/ui/app/styles/core/breadcrumb.scss
@@ -18,7 +18,7 @@
   }
 
   .is-sidebar + .column & {
-    @include until($tablet) {
+    @include until($mobile) {
       margin-left: $size-2;
     }
   }

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -11,7 +11,7 @@ $button-box-shadow-standard: 0 3px 1px 0 rgba($black, 0.12);
 .button {
   background-color: $grey-lightest;
   border: 1px solid $grey-light;
-  border-radius: $radius-small;
+  border-radius: $radius;
   box-shadow: $box-shadow-low;
   cursor: pointer;
   color: $ui-gray-800;

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -11,7 +11,7 @@ $button-box-shadow-standard: 0 3px 1px 0 rgba($black, 0.12);
 .button {
   background-color: $grey-lightest;
   border: 1px solid $grey-light;
-  border-radius: 2px;
+  border-radius: $radius-small;
   box-shadow: $box-shadow-low;
   cursor: pointer;
   color: $ui-gray-800;

--- a/ui/app/styles/core/charts.scss
+++ b/ui/app/styles/core/charts.scss
@@ -204,7 +204,7 @@ h2.chart-title {
 
 p.chart-description {
   color: $ui-gray-700;
-  font-size: $body-size;
+  font-size: $size-8;
   line-height: 18px;
   margin-bottom: $spacing-xs;
 }
@@ -219,7 +219,7 @@ p.chart-subtext {
 h3.data-details {
   font-weight: $font-weight-bold;
   font-size: $size-8;
-  line-height: $body-size;
+  line-height: $size-8;
   margin-bottom: $spacing-xs;
 }
 

--- a/ui/app/styles/core/field.scss
+++ b/ui/app/styles/core/field.scss
@@ -48,8 +48,8 @@
       .checkbox,
       .input,
       .select select {
-        border-bottom-left-radius: $input-radius;
-        border-top-left-radius: $input-radius;
+        border-bottom-left-radius: $radius;
+        border-top-left-radius: $radius;
       }
     }
     &:last-child {
@@ -57,8 +57,8 @@
       .checkbox,
       .input,
       .select select {
-        border-bottom-right-radius: $input-radius;
-        border-top-right-radius: $input-radius;
+        border-bottom-right-radius: $radius;
+        border-top-right-radius: $radius;
       }
     }
   }

--- a/ui/app/styles/core/file.scss
+++ b/ui/app/styles/core/file.scss
@@ -10,7 +10,7 @@
 }
 
 .file-name {
-  border-radius: 2px;
+  border-radius: $radius-small;
   border-width: 1px 1px 1px 0 !important;
   border: 1px solid $ui-gray-300;
   box-shadow: 0 4px 1px rgba(10, 10, 10, 0.06) inset;
@@ -52,7 +52,7 @@
 
 .file-cta {
   border: 1px solid $ui-gray-300;
-  border-radius: 2px;
+  border-radius: $radius-small;
   min-width: auto;
   position: relative;
   white-space: nowrap;
@@ -71,7 +71,7 @@
 .file-name {
   @extend .input;
   border: 1px solid $ui-gray-300;
-  border-radius: 2px;
+  border-radius: $radius-small;
 }
 
 .file-delete-button {

--- a/ui/app/styles/core/file.scss
+++ b/ui/app/styles/core/file.scss
@@ -10,7 +10,7 @@
 }
 
 .file-name {
-  border-radius: $radius-small;
+  border-radius: $radius;
   border-width: 1px 1px 1px 0 !important;
   border: 1px solid $ui-gray-300;
   box-shadow: 0 4px 1px rgba(10, 10, 10, 0.06) inset;
@@ -52,7 +52,7 @@
 
 .file-cta {
   border: 1px solid $ui-gray-300;
-  border-radius: $radius-small;
+  border-radius: $radius;
   min-width: auto;
   position: relative;
   white-space: nowrap;
@@ -71,7 +71,7 @@
 .file-name {
   @extend .input;
   border: 1px solid $ui-gray-300;
-  border-radius: $radius-small;
+  border-radius: $radius;
 }
 
 .file-delete-button {

--- a/ui/app/styles/core/inputs.scss
+++ b/ui/app/styles/core/inputs.scss
@@ -7,7 +7,7 @@
 
 .input,
 .textarea {
-  border-radius: $radius-small;
+  border-radius: $radius;
   border: 1px solid $ui-gray-300;
   box-shadow: 0 4px 1px rgba($black, 0.06) inset;
   color: $grey-dark;

--- a/ui/app/styles/core/inputs.scss
+++ b/ui/app/styles/core/inputs.scss
@@ -7,7 +7,7 @@
 
 .input,
 .textarea {
-  border-radius: 2px;
+  border-radius: $radius-small;
   border: 1px solid $ui-gray-300;
   box-shadow: 0 4px 1px rgba($black, 0.06) inset;
   color: $grey-dark;

--- a/ui/app/styles/core/label.scss
+++ b/ui/app/styles/core/label.scss
@@ -14,7 +14,7 @@
 .is-label {
   color: $grey-darker;
   display: inline-block;
-  font-size: $body-size;
+  font-size: $size-8;
   font-weight: $font-weight-bold;
 
   &:not(:last-child) {

--- a/ui/app/styles/core/layout.scss
+++ b/ui/app/styles/core/layout.scss
@@ -9,10 +9,10 @@
   flex-direction: column;
 }
 .page-container {
-  min-height: calc(100vh - #{$header-height});
+  min-height: calc(100vh - #{$spacing-xxxl});
   display: flex;
   flex-direction: column;
-  margin-top: $header-height;
+  margin-top: $spacing-xxxl;
   justify-content: flex-end;
 }
 

--- a/ui/app/styles/core/level.scss
+++ b/ui/app/styles/core/level.scss
@@ -9,7 +9,7 @@
 }
 
 .level code {
-  border-radius: $radius-small;
+  border-radius: $radius;
 }
 
 .level:not(:last-child) {

--- a/ui/app/styles/core/level.scss
+++ b/ui/app/styles/core/level.scss
@@ -9,7 +9,7 @@
 }
 
 .level code {
-  border-radius: 2px;
+  border-radius: $radius-small;
 }
 
 .level:not(:last-child) {

--- a/ui/app/styles/core/navbar.scss
+++ b/ui/app/styles/core/navbar.scss
@@ -42,7 +42,7 @@
 .navbar-actions {
   background-color: $black;
   display: flex;
-  height: $header-height;
+  height: $spacing-xxxl;
   justify-content: flex-start;
   padding: $spacing-xs $spacing-s $spacing-xs 0;
 }
@@ -282,7 +282,7 @@
     left: 0;
     position: absolute;
     right: 0;
-    top: $header-height;
+    top: $spacing-xxxl;
     z-index: 1;
 
     @include from($mobile) {

--- a/ui/app/styles/core/progress.scss
+++ b/ui/app/styles/core/progress.scss
@@ -37,13 +37,13 @@
 .progress[value]::-webkit-progress-value {
   background-color: #4a4a4a;
   border-radius: $radius;
-  transition: width 1s ease-out;
+  transition: width 1s $easing;
 }
 
 // style the bar in firefox
 .progress[value]::-moz-progress-bar {
   border-radius: $radius;
-  transition: width 1s ease-out;
+  transition: width 1s $easing;
 }
 
 .progress::-ms-fill {

--- a/ui/app/styles/core/select.scss
+++ b/ui/app/styles/core/select.scss
@@ -11,7 +11,7 @@ select {
   background-color: $ui-gray-050;
   box-shadow: 0 3px 1px rgba($black, 0.12);
   border-color: $grey-light;
-  border-radius: $radius-small;
+  border-radius: $radius;
   color: $grey-dark;
   cursor: pointer;
   display: block;

--- a/ui/app/styles/core/select.scss
+++ b/ui/app/styles/core/select.scss
@@ -11,7 +11,7 @@ select {
   background-color: $ui-gray-050;
   box-shadow: 0 3px 1px rgba($black, 0.12);
   border-color: $grey-light;
-  border-radius: 2px;
+  border-radius: $radius-small;
   color: $grey-dark;
   cursor: pointer;
   display: block;

--- a/ui/app/styles/core/tag.scss
+++ b/ui/app/styles/core/tag.scss
@@ -8,7 +8,7 @@
 .tag:not(body) {
   align-items: center;
   background-color: $ui-gray-100;
-  border-radius: 2px;
+  border-radius: $radius-small;
   color: $grey;
   display: inline-flex;
   font-size: 0.75rem;

--- a/ui/app/styles/core/tag.scss
+++ b/ui/app/styles/core/tag.scss
@@ -8,7 +8,7 @@
 .tag:not(body) {
   align-items: center;
   background-color: $ui-gray-100;
-  border-radius: $radius-small;
+  border-radius: $radius;
   color: $grey;
   display: inline-flex;
   font-size: 0.75rem;

--- a/ui/app/styles/core/toggle.scss
+++ b/ui/app/styles/core/toggle.scss
@@ -55,7 +55,7 @@
   transform: translate3d(0, 0, 0);
   border-radius: 50%;
   background: white;
-  transition: all 0.25s ease-out;
+  transition: all 0.25s $easing;
   content: '';
 }
 .toggle[type='checkbox']:checked + label::before {

--- a/ui/app/styles/helper-classes/flexbox-and-grid.scss
+++ b/ui/app/styles/helper-classes/flexbox-and-grid.scss
@@ -107,7 +107,7 @@
   grid-template-columns: repeat(3, 1fr);
 }
 .is-medium-height {
-  height: $medium-height;
+  height: 125px;
 }
 .is-grid-column-span-3 {
   grid-column-end: span 3;

--- a/ui/app/styles/helper-classes/flexbox-and-grid.scss
+++ b/ui/app/styles/helper-classes/flexbox-and-grid.scss
@@ -41,7 +41,7 @@
 
 .is-flex-v-centered-tablet {
   // TODO check if this is from or until
-  @include until($tablet) {
+  @include until($mobile) {
     display: flex;
     align-items: center;
     align-self: center;

--- a/ui/app/styles/helper-classes/layout.scss
+++ b/ui/app/styles/helper-classes/layout.scss
@@ -71,7 +71,7 @@
 }
 
 @media screen and (max-width: 1215px) {
-  is-widescreen:not(.is-max-desktop) {
+  .is-widescreen:not(.is-max-desktop) {
     max-width: 1152px;
   }
 }

--- a/ui/app/styles/helper-classes/other.scss
+++ b/ui/app/styles/helper-classes/other.scss
@@ -46,7 +46,7 @@
 
 // other
 .has-background-transition {
-  transition: background-color $easing $speed;
+  transition: background-color ease-out $speed;
 }
 
 .has-current-color-fill {

--- a/ui/app/styles/helper-classes/typography.scss
+++ b/ui/app/styles/helper-classes/typography.scss
@@ -7,31 +7,31 @@
 
 // font size helpers
 .is-size-1 {
-  font-size: 3rem !important;
+  font-size: $size-1 !important;
 }
 
 .is-size-2 {
-  font-size: 2.5rem !important;
+  font-size: $size-2 !important;
 }
 
 .is-size-3 {
-  font-size: 1.71429rem !important;
+  font-size: $size-3 !important;
 }
 
 .is-size-4 {
-  font-size: 1.5rem !important;
+  font-size: $size-4 !important;
 }
 
 .is-size-5 {
-  font-size: 1.25rem !important;
+  font-size: $size-5 !important;
 }
 
 .is-size-6 {
-  font-size: 1rem !important;
+  font-size: $size-6 !important;
 }
 
 .is-size-7 {
-  font-size: 0.92857rem !important;
+  font-size: $size-7 !important;
 }
 
 .is-size-8 {

--- a/ui/app/styles/helper-classes/typography.scss
+++ b/ui/app/styles/helper-classes/typography.scss
@@ -6,7 +6,7 @@
 /* This helper includes styles relating to: font-size, font-family, font-alignment, text-transform, text-weight, font-style, text-decoration. */
 
 // font size helpers
-// ARG TODO future pr once bulma is removed, replace these naming: font-size-xx
+// ARG TODO future pr once bulma is removed, replace these helper names, example: font-size-4
 
 .is-size-4 {
   font-size: $size-4 !important;
@@ -32,6 +32,15 @@
   font-size: $size-9 !important;
 }
 
+// Font weight
+.has-text-weight-semibold {
+  font-weight: $font-weight-semibold !important;
+}
+
+.has-text-weight-bold {
+  font-weight: 700 !important;
+}
+
 // Font family
 .is-font-mono {
   font-family: $family-monospace;
@@ -48,20 +57,6 @@
 }
 .is-no-underline {
   text-decoration: none;
-}
-
-// Text weight
-// ARG TODO: duplicate, need to agree on naming syntax
-.has-text-semibold {
-  font-weight: $font-weight-semibold;
-}
-
-.has-text-weight-semibold {
-  font-weight: 600 !important;
-}
-
-.has-text-weight-bold {
-  font-weight: 700 !important;
 }
 
 // Text transformations

--- a/ui/app/styles/helper-classes/typography.scss
+++ b/ui/app/styles/helper-classes/typography.scss
@@ -38,7 +38,7 @@
 }
 
 .has-text-weight-bold {
-  font-weight: 700 !important;
+  font-weight: $font-weight-bold !important;
 }
 
 // Font family

--- a/ui/app/styles/helper-classes/typography.scss
+++ b/ui/app/styles/helper-classes/typography.scss
@@ -6,17 +6,7 @@
 /* This helper includes styles relating to: font-size, font-family, font-alignment, text-transform, text-weight, font-style, text-decoration. */
 
 // font size helpers
-.is-size-1 {
-  font-size: $size-1 !important;
-}
-
-.is-size-2 {
-  font-size: $size-2 !important;
-}
-
-.is-size-3 {
-  font-size: $size-3 !important;
-}
+// ARG TODO future pr once bulma is removed, replace these naming: font-size-xx
 
 .is-size-4 {
   font-size: $size-4 !important;

--- a/ui/app/styles/utils/_bulma_variables.scss
+++ b/ui/app/styles/utils/_bulma_variables.scss
@@ -234,22 +234,7 @@ $shades: (
   'white-bis': $white-bis,
 ) !default;
 
-// Spacing
-$block-spacing: 1.5rem !default;
-
-// The container horizontal gap, which acts as the offset for breakpoints
-$gap: 32px !default;
-// 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16
-// 960px container + 4rem
-$desktop: 960px + (2 * $gap) !default;
-// 1152px container + 4rem
-$widescreen: 1152px + (2 * $gap) !default;
-$widescreen-enabled: true !default;
-// 1344px container + 4rem
-$fullhd: 1344px + (2 * $gap) !default;
-$fullhd-enabled: true !default;
 // Miscellaneous
-
 $easing: ease-out !default;
 $radius-small: 2px !default;
 $radius: 4px !default;

--- a/ui/app/styles/utils/_bulma_variables.scss
+++ b/ui/app/styles/utils/_bulma_variables.scss
@@ -283,7 +283,6 @@ $family-sans: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto'
 $family-monospace: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 $family-primary: $family-sans;
 $family-code: $family-monospace !default;
-$body-size: 14px;
 $size-3: (24/14) + 0rem; // ~1.714rem ~27px
 $size-4: 1.5rem; // 24px
 $size-5: 1.25rem; // 20px
@@ -292,7 +291,6 @@ $size-8: (12/14) + 0rem; // ~.857rem  ~13.7px
 $size-9: 0.75rem; // 12px
 $size-10: 0.5rem; // 8px
 $size-11: 0.25rem; // 4px
-$console-spacing: 1.5rem; // 24px
 $size-small: $size-8;
 $size-normal: $size-6;
 $size-medium: $size-5;
@@ -339,17 +337,3 @@ $menu-item-active-background-color: transparent;
 
 $box-link-shadow: 0 0 0 1px $ui-gray-200;
 $box-link-hover-shadow: 0 0 0 1px $grey-light;
-
-// Nav
-$drawer-width: 300px;
-
-// animations
-$speed: 150ms;
-$speed-slow: $speed * 2;
-
-// Wizard
-$wizard-progress-bar-height: 6px;
-$wizard-progress-check-size: 16px;
-
-// Div height
-$medium-height: 125px;

--- a/ui/app/styles/utils/_bulma_variables.scss
+++ b/ui/app/styles/utils/_bulma_variables.scss
@@ -234,12 +234,6 @@ $shades: (
   'white-bis': $white-bis,
 ) !default;
 
-// Typography
-$family-sans-serif: BlinkMacSystemFont, -apple-system, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
-  'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif !default;
-$family-monospace: monospace !default;
-$render-mode: optimizeLegibility !default;
-
 // Spacing
 $block-spacing: 1.5rem !default;
 

--- a/ui/app/styles/utils/_bulma_variables.scss
+++ b/ui/app/styles/utils/_bulma_variables.scss
@@ -277,9 +277,6 @@ $border: $grey-light;
 
 $hr-margin: 1rem 0;
 
-$mobile: 769px;
-$header-height: 4rem;
-
 //typography
 $family-sans: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
   'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;

--- a/ui/app/styles/utils/_bulma_variables.scss
+++ b/ui/app/styles/utils/_bulma_variables.scss
@@ -235,23 +235,13 @@ $shades: (
 ) !default;
 
 // Typography
-
 $family-sans-serif: BlinkMacSystemFont, -apple-system, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
   'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif !default;
 $family-monospace: monospace !default;
 $render-mode: optimizeLegibility !default;
 
-$weight-light: 300 !default;
-$weight-normal: 400 !default;
-$weight-medium: 500 !default;
-$weight-semibold: 600 !default;
-$weight-bold: 700 !default;
-
 // Spacing
-
 $block-spacing: 1.5rem !default;
-
-// Responsiveness
 
 // The container horizontal gap, which acts as the offset for breakpoints
 $gap: 32px !default;

--- a/ui/app/styles/utils/_bulma_variables.scss
+++ b/ui/app/styles/utils/_bulma_variables.scss
@@ -250,10 +250,6 @@ $rtl: false !default;
   }
 }
 
-// Manually added
-
-$size-medium: 1.25rem;
-
 /* OVERRIDES START */
 // Color overrides
 $light: $grey-lightest;
@@ -275,29 +271,12 @@ $code: $grey-dark;
 $code-background: transparent;
 $border: $grey-light;
 
-$hr-margin: 1rem 0;
-
 //typography
 $family-sans: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
   'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
 $family-monospace: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 $family-primary: $family-sans;
 $family-code: $family-monospace !default;
-$size-3: (24/14) + 0rem; // ~1.714rem ~27px
-$size-4: 1.5rem; // 24px
-$size-5: 1.25rem; // 20px
-$size-7: (13/14) + 0rem; // ~.929rem ~15px
-$size-8: (12/14) + 0rem; // ~.857rem  ~13.7px
-$size-9: 0.75rem; // 12px
-$size-10: 0.5rem; // 8px
-$size-11: 0.25rem; // 4px
-$size-small: $size-8;
-$size-normal: $size-6;
-$size-medium: $size-5;
-$size-large: $size-4;
-$font-weight-normal: 400;
-$font-weight-semibold: 600;
-$font-weight-bold: 700;
 
 //input
 $input-background-color: $white;

--- a/ui/app/styles/utils/_bulma_variables.scss
+++ b/ui/app/styles/utils/_bulma_variables.scss
@@ -241,14 +241,6 @@ $family-sans-serif: BlinkMacSystemFont, -apple-system, 'Segoe UI', 'Roboto', 'Ox
 $family-monospace: monospace !default;
 $render-mode: optimizeLegibility !default;
 
-$size-1: 3rem !default;
-$size-2: 2.5rem !default;
-$size-3: 2rem !default;
-$size-4: 1.5rem !default;
-$size-5: 1.25rem !default;
-$size-6: 1rem !default;
-$size-7: 0.75rem !default;
-
 $weight-light: 300 !default;
 $weight-normal: 400 !default;
 $weight-medium: 500 !default;

--- a/ui/app/styles/utils/_bulma_variables.scss
+++ b/ui/app/styles/utils/_bulma_variables.scss
@@ -240,7 +240,6 @@ $block-spacing: 1.5rem !default;
 // The container horizontal gap, which acts as the offset for breakpoints
 $gap: 32px !default;
 // 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16
-$tablet: 769px !default;
 // 960px container + 4rem
 $desktop: 960px + (2 * $gap) !default;
 // 1152px container + 4rem
@@ -249,45 +248,6 @@ $widescreen-enabled: true !default;
 // 1344px container + 4rem
 $fullhd: 1344px + (2 * $gap) !default;
 $fullhd-enabled: true !default;
-$breakpoints: (
-  'mobile': (
-    'until': $tablet,
-  ),
-  'tablet': (
-    'from': $tablet,
-  ),
-  'tablet-only': (
-    'from': $tablet,
-    'until': $desktop,
-  ),
-  'touch': (
-    'from': $desktop,
-  ),
-  'desktop': (
-    'from': $desktop,
-  ),
-  'desktop-only': (
-    'from': $desktop,
-    'until': $widescreen,
-  ),
-  'until-widescreen': (
-    'until': $widescreen,
-  ),
-  'widescreen': (
-    'from': $widescreen,
-  ),
-  'widescreen-only': (
-    'from': $widescreen,
-    'until': $fullhd,
-  ),
-  'until-fullhd': (
-    'until': $fullhd,
-  ),
-  'fullhd': (
-    'from': $fullhd,
-  ),
-) !default;
-
 // Miscellaneous
 
 $easing: ease-out !default;

--- a/ui/app/styles/utils/_bulma_variables.scss
+++ b/ui/app/styles/utils/_bulma_variables.scss
@@ -283,9 +283,6 @@ $input-background-color: $white;
 $input-focus-background-color: $white;
 $input-border-color: $grey;
 
-$radius: 2px;
-$radius-large: 4px;
-
 //box
 $box-radius: 0;
 $box-shadow: 0 0 0 1px rgba($black, 0.1);

--- a/ui/app/styles/utils/_bulma_variables.scss
+++ b/ui/app/styles/utils/_bulma_variables.scss
@@ -234,15 +234,6 @@ $shades: (
   'white-bis': $white-bis,
 ) !default;
 
-// Miscellaneous
-$easing: ease-out !default;
-$radius-small: 2px !default;
-$radius: 4px !default;
-$radius-large: 6px !default;
-$radius-rounded: 9999px !default;
-$input-radius: $radius;
-$speed: 86ms !default;
-
 // Flags
 
 $variable-columns: true !default;

--- a/ui/app/styles/utils/_bulma_variables.scss
+++ b/ui/app/styles/utils/_bulma_variables.scss
@@ -284,7 +284,6 @@ $input-focus-background-color: $white;
 $input-border-color: $grey;
 
 //box
-$box-radius: 0;
 $box-shadow: 0 0 0 1px rgba($black, 0.1);
 $box-shadow-low: 0 5px 1px -2px rgba($black, 0.12), 0 3px 2px -1px rgba($black, 0);
 $box-shadow-middle: 0 8px 4px -4px rgba($black, 0.1), 0 6px 8px -2px rgba($black, 0.05);

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -4,7 +4,7 @@
  */
 
 /*
-File notes:
+ARG TODO post bulma removal:
 - size-x and and spacing-x variables often overlap. Ideally, we could combine these to cover all the size requirements.
  */
 
@@ -57,9 +57,7 @@ $fullhd: 1344px + (2 * 32px);
 $speed: 150ms;
 $speed-slow: $speed * 2;
 
-$console-spacing: 1.5rem; // 24px
-
-// Nav
+/* Nav */
 $drawer-width: 300px;
 
 // Wizard

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -41,9 +41,8 @@ $font-weight-semibold: 600;
 $font-weight-bold: 700;
 
 /* Border radius */
-$radius-small: 2px;
-$radius: 4px;
-$radius-large: 6px;
+$radius: 2px;
+$radius-large: 4px;
 
 /* Responsiveness */
 // 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -33,11 +33,17 @@ $spacing-m: 16px;
 $spacing-l: 24px;
 $spacing-xl: 36px;
 $spacing-xxl: 48px;
+$spacing-xxxl: 64px;
 
 /* Font weight */
 $font-weight-normal: 400;
 $font-weight-semibold: 600;
 $font-weight-bold: 700;
+
+/* Border radius */
+$radius-small: 2px;
+$radius: 4px;
+$radius-large: 6px;
 
 /* Responsiveness */
 // 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16
@@ -47,13 +53,9 @@ $desktop: 960px + (2 * 32px);
 // 1344px container + 4rem
 $fullhd: 1344px + (2 * 32px);
 
-/* Miscellaneous sizing*/
-$radius-small: 2px;
-$radius: 4px;
-$radius-large: 6px;
+/* Transition */
 $speed: 86ms;
 
-$header-height: 4rem;
 $body-size: 14px;
 
 $console-spacing: 1.5rem; // 24px

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -41,21 +41,17 @@ $font-weight-bold: 700;
 
 /* Responsiveness */
 // 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16
-$gap: 32px !default; // The container horizontal gap, which acts as the offset for breakpoints
 $mobile: 769px;
 // 960px container + 4rem
-$desktop: 960px + (2 * $gap) !default;
+$desktop: 960px + (2 * 32px);
 // 1344px container + 4rem
-$fullhd: 1344px + (2 * $gap) !default;
+$fullhd: 1344px + (2 * 32px);
 
 /* Miscellaneous sizing*/
-// ARG TODO clean up
-$radius-small: 2px !default;
-$radius: 4px !default;
-$radius-large: 6px !default;
-$radius-rounded: 9999px !default;
-$input-radius: $radius;
-$speed: 86ms !default;
+$radius-small: 2px;
+$radius: 4px;
+$radius-large: 6px;
+$speed: 86ms;
 
 $header-height: 4rem;
 $body-size: 14px;

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -5,7 +5,7 @@
 
 /*
 File notes:
-
+- size-x and and spacing-x variables often overlap. Ideally, we could combine these to cover all the size requirements.
  */
 
 /* General sizing: used in fonts and in padding, margin, etc. */
@@ -25,14 +25,7 @@ $size-normal: $size-6;
 $size-medium: $size-5;
 $size-large: $size-4;
 
-/* Font weight */
-$font-weight-normal: 400;
-$font-weight-semibold: 600;
-$font-weight-bold: 700;
-
 /* Spacing */
-$block-spacing: 1.5rem !default;
-
 $spacing-xxs: 4px;
 $spacing-xs: 8px;
 $spacing-s: 12px;
@@ -41,13 +34,15 @@ $spacing-l: 24px;
 $spacing-xl: 36px;
 $spacing-xxl: 48px;
 
-/* Misc. */
-$column-gap: 0.75rem !default;
-// The container horizontal gap, which acts as the offset for breakpoints
-$gap: 32px !default;
-// 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16
+/* Font weight */
+$font-weight-normal: 400;
+$font-weight-semibold: 600;
+$font-weight-bold: 700;
 
 /* Responsiveness */
+// 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16
+
+$gap: 32px !default; // The container horizontal gap, which acts as the offset for breakpoints
 $mobile: 769px;
 $tablet: 769px !default;
 // 960px container + 4rem

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -4,9 +4,8 @@
  */
 
 /*
- ARG TODO:
- - Good amount of cleanup work, especially towards the bottom of this file. Copy/pasted what was already there. Didn't modify things.
- - Need to discuss the creation of additional variables like $size-small: $size-8;. This is a pattern we use heavily in the app and it would take some work (not hard, but a good chunk of changes) to revert.
+File notes:
+
  */
 
 /* General sizing: used in fonts and in padding, margin, etc. */

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -41,55 +41,12 @@ $font-weight-bold: 700;
 
 /* Responsiveness */
 // 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16
-
 $gap: 32px !default; // The container horizontal gap, which acts as the offset for breakpoints
 $mobile: 769px;
 // 960px container + 4rem
 $desktop: 960px + (2 * $gap) !default;
-// 1152px container + 4rem
-$widescreen: 1152px + (2 * $gap) !default;
-$widescreen-enabled: true !default;
 // 1344px container + 4rem
 $fullhd: 1344px + (2 * $gap) !default;
-$fullhd-enabled: true !default;
-$breakpoints: (
-  'mobile': (
-    'until': $mobile,
-  ),
-  'tablet': (
-    'from': $mobile,
-  ),
-  'tablet-only': (
-    'from': $mobile,
-    'until': $desktop,
-  ),
-  'touch': (
-    'from': $desktop,
-  ),
-  'desktop': (
-    'from': $desktop,
-  ),
-  'desktop-only': (
-    'from': $desktop,
-    'until': $widescreen,
-  ),
-  'until-widescreen': (
-    'until': $widescreen,
-  ),
-  'widescreen': (
-    'from': $widescreen,
-  ),
-  'widescreen-only': (
-    'from': $widescreen,
-    'until': $fullhd,
-  ),
-  'until-fullhd': (
-    'until': $fullhd,
-  ),
-  'fullhd': (
-    'from': $fullhd,
-  ),
-) !default;
 
 /* Miscellaneous sizing*/
 // ARG TODO clean up

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -44,7 +44,6 @@ $font-weight-bold: 700;
 
 $gap: 32px !default; // The container horizontal gap, which acts as the offset for breakpoints
 $mobile: 769px;
-$tablet: 769px !default;
 // 960px container + 4rem
 $desktop: 960px + (2 * $gap) !default;
 // 1152px container + 4rem
@@ -55,13 +54,13 @@ $fullhd: 1344px + (2 * $gap) !default;
 $fullhd-enabled: true !default;
 $breakpoints: (
   'mobile': (
-    'until': $tablet,
+    'until': $mobile,
   ),
   'tablet': (
-    'from': $tablet,
+    'from': $mobile,
   ),
   'tablet-only': (
-    'from': $tablet,
+    'from': $mobile,
     'until': $desktop,
   ),
   'touch': (

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -53,17 +53,16 @@ $desktop: 960px + (2 * 32px);
 // 1344px container + 4rem
 $fullhd: 1344px + (2 * 32px);
 
-/* Transition */
-$speed: 86ms;
-
-$body-size: 14px;
+/* Animations and transitions */
+$speed: 150ms;
+$speed-slow: $speed * 2;
 
 $console-spacing: 1.5rem; // 24px
+
+// Nav
+$drawer-width: 300px;
 
 // Wizard
 // Not being used: https://github.com/hashicorp/vault/pull/19220
 // $wizard-progress-bar-height: 6px;
 // $wizard-progress-check-size: 16px;
-
-// Div height
-$medium-height: 125px;

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -55,6 +55,7 @@ $fullhd: 1344px + (2 * 32px);
 /* Animations and transitions */
 $speed: 150ms;
 $speed-slow: $speed * 2;
+$easing: ease-out;
 
 /* Nav */
 $drawer-width: 300px;

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -26,11 +26,6 @@ $size-medium: $size-5;
 $size-large: $size-4;
 
 /* Font weight */
-$weight-light: 300 !default;
-$weight-normal: 400 !default;
-$weight-medium: 500 !default;
-$weight-semibold: 600 !default;
-$weight-bold: 700 !default;
 $font-weight-normal: 400;
 $font-weight-semibold: 600;
 $font-weight-bold: 700;

--- a/ui/app/templates/components/selectable-card.hbs
+++ b/ui/app/templates/components/selectable-card.hbs
@@ -14,7 +14,7 @@
       <h3 class="title is-5">{{@cardTitle}}</h3>
       <LinkTo
         @route={{@actionTo}}
-        class="has-icon-right is-ghost is-no-underline has-text-semibold"
+        class="has-icon-right is-ghost is-no-underline has-text-weight-semibold"
         @query={{hash itemType=@queryParam}}
         data-test-action-text={{@actionText}}
       >

--- a/ui/app/templates/vault/cluster/access/mfa/methods/create.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/create.hbs
@@ -25,7 +25,7 @@
 </PageHeader>
 <div class="has-border-top-light has-top-padding-l">
   {{#if this.showForms}}
-    <h3 class="is-size-4 has-text-semibold">Settings</h3>
+    <h3 class="is-size-4 has-text-weight-semibold">Settings</h3>
     <p class="has-border-top-light has-top-padding-l">
       {{this.description}}
       <DocLink @path={{concat "/api-docs/secret/identity/mfa/" this.type}}>Learn more.</DocLink>
@@ -66,7 +66,7 @@
                 @size="24"
                 class={{if (eq methodName "TOTP") "has-text-grey"}}
               />
-              <p class="has-text-semibold has-text-align-center {{if (eq methodName 'Okta') 'has-top-margin-xs'}}">
+              <p class="has-text-weight-semibold has-text-align-center {{if (eq methodName 'Okta') 'has-top-margin-xs'}}">
                 {{methodName}}
               </p>
             </div>

--- a/ui/lib/core/addon/components/overview-card.hbs
+++ b/ui/lib/core/addon/components/overview-card.hbs
@@ -3,7 +3,7 @@
     <h3 class="title is-5">{{@cardTitle}}</h3>
     {{#if @actionText}}
       <LinkTo
-        class="has-icon-right is-ghost is-no-underline has-text-semibold"
+        class="has-icon-right is-ghost is-no-underline has-text-weight-semibold"
         @route={{@actionTo}}
         @query={{hash @actionQuery}}
         data-test-action-text={{@actionText}}

--- a/ui/lib/core/addon/templates/components/shamir-modal-flow.hbs
+++ b/ui/lib/core/addon/templates/components/shamir-modal-flow.hbs
@@ -166,7 +166,8 @@
                 </h4>
                 <p class="help has-text-grey has-bottom-margin-xs">
                   This OTP will be used to decode the generated operation token.
-                  <span class="has-text-semibold">Save this</span>, as you will need it later to decode the operation token.
+                  <span class="has-text-weight-semibold">Save this</span>, as you will need it later to decode the operation
+                  token.
                 </p>
                 <div class="message is-list has-copy-button" tabindex="-1">
                   <HoverCopyButton @copyValue={{this.otp}} />

--- a/ui/lib/pki/addon/components/page/pki-role-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-role-details.hbs
@@ -35,7 +35,7 @@
 {{#each @role.formFieldGroups as |fg|}}
   {{#each-in fg as |group fields|}}
     {{#if (not-eq group "default")}}
-      <h3 class="is-size-4 has-text-semibold has-top-margin-m">{{group}}</h3>
+      <h3 class="is-size-4 has-text-weight-semibold has-top-margin-m">{{group}}</h3>
     {{/if}}
     {{#each fields as |attr|}}
       {{#let (get @role attr.name) as |val|}}


### PR DESCRIPTION
This PR looks large, but the changes are all size changes, and revolve around combining our size vars with Bulma's size vars. The end goal is to remove `utils/bulma_variables`. This PR focused on removing the size vars from that file and moving relevant ones into our `utils/size_variables` file.

* Remove `$tablet` and replace with the (exact same sizing) `$mobile`.
* Get to the bottom of the `border-radius` chaos. We overrode and then overrode with vars of the same name. I confirmed on the binary what the final vars were. A simple 2px or large for 4px. Amended for all cases.
* Removed `$header-height` and replaced with `$spacing-xxxl`. It follows the spacing conventions.
* Removed `$body-size` and replaced with `$size-8`. Not exactly the same, but very very similar 14px vs 13.7px. Confirmed in dev that the look was solid.
* Replaced `$console-spacing` with `$size-4`
* Replaced `$column-gap` with `$size-9`
* I had made `$medium-height` in my youth and it was used once. I removed it.
* Removed vars in the `bulma_variables` file that were now duplicates or we never used. Did the same thing to `utils/size_variables` which will become the "master" file for sizes. Eventually the `bulma_variables` file will be removed.
* Removed duplicate `has-text-semibold` for the exact same var `has-text-weight-semibold`.

_Note: given the size of this PR, I decided to make another ticket that will go through pre-existing scss files and replace hard-coded things like 4px with $spacing-xxs or 1.25rem with $size-5._