### PR TITLE
Add acme account storage

### DIFF
--- a/builtin/logical/pki/acme_jws.go
+++ b/builtin/logical/pki/acme_jws.go
@@ -85,7 +85,7 @@ func (c *jwsCtx) UnmarshalJSON(a *acmeState, ac *acmeContext, jws []byte) error 
 		return fmt.Errorf("received invalid jwk: %w", ErrMalformed)
 	}
 
-	if c.Kid != "" {
+	if c.Kid == "" {
 		// Create a key ID
 		kid, err := c.Key.Thumbprint(crypto.SHA256)
 		if err != nil {

--- a/builtin/logical/pki/acme_jws.go
+++ b/builtin/logical/pki/acme_jws.go
@@ -26,20 +26,20 @@ var AllowedOuterJWSTypes = map[string]interface{}{
 type jwsCtx struct {
 	Algo     string          `json:"alg"`
 	Kid      string          `json:"kid"`
-	jwk      json.RawMessage `json:"jwk"`
+	Jwk      json.RawMessage `json:"jwk"`
 	Nonce    string          `json:"nonce"`
 	Url      string          `json:"url"`
-	key      jose.JSONWebKey `json:"-"`
+	Key      jose.JSONWebKey `json:"-"`
 	Existing bool            `json:"-"`
 }
 
-func (c *jwsCtx) UnmarshalJSON(a *acmeState, jws []byte) error {
+func (c *jwsCtx) UnmarshalJSON(a *acmeState, ac *acmeContext, jws []byte) error {
 	var err error
 	if err = json.Unmarshal(jws, c); err != nil {
 		return err
 	}
 
-	if c.Kid != "" && len(c.jwk) > 0 {
+	if c.Kid != "" && len(c.Jwk) > 0 {
 		// See RFC 8555 Section 6.2. Request Authentication:
 		//
 		// > The "jwk" and "kid" fields are mutually exclusive.  Servers MUST
@@ -47,7 +47,7 @@ func (c *jwsCtx) UnmarshalJSON(a *acmeState, jws []byte) error {
 		return fmt.Errorf("invalid header: got both account 'kid' and 'jwk' in the same message; expected only one: %w", ErrMalformed)
 	}
 
-	if c.Kid == "" && len(c.jwk) == 0 {
+	if c.Kid == "" && len(c.Jwk) == 0 {
 		// See RFC 8555 Section 6.2. Request Authentication:
 		//
 		// > Either "jwk" (JSON Web Key) or "kid" (Key ID) as specified
@@ -70,24 +70,24 @@ func (c *jwsCtx) UnmarshalJSON(a *acmeState, jws []byte) error {
 
 	if c.Kid != "" {
 		// Load KID from storage first.
-		c.jwk, err = a.LoadJWK(c.Kid)
+		c.Jwk, err = a.LoadJWK(ac, c.Kid)
 		if err != nil {
 			return err
 		}
 		c.Existing = true
 	}
 
-	if err = c.key.UnmarshalJSON(c.jwk); err != nil {
+	if err = c.Key.UnmarshalJSON(c.Jwk); err != nil {
 		return err
 	}
 
-	if !c.key.Valid() {
+	if !c.Key.Valid() {
 		return fmt.Errorf("received invalid jwk: %w", ErrMalformed)
 	}
 
 	if c.Kid != "" {
 		// Create a key ID
-		kid, err := c.key.Thumbprint(crypto.SHA256)
+		kid, err := c.Key.Thumbprint(crypto.SHA256)
 		if err != nil {
 			return fmt.Errorf("failed creating thumbprint: %w", err)
 		}
@@ -128,7 +128,7 @@ func (c *jwsCtx) VerifyJWS(signature string) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("request had unprotected headers: %w", ErrMalformed)
 	}
 
-	payload, err := sig.Verify(c.key)
+	payload, err := sig.Verify(c.Key)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -108,18 +108,19 @@ func (a *acmeState) TidyNonces() {
 }
 
 type ACMEStates string
+
 const (
-  StatusValid = "valid"
-  StatusDeactivated = "deactivated"
-  StatusRevoked = "revoked"
+	StatusValid       = "valid"
+	StatusDeactivated = "deactivated"
+	StatusRevoked     = "revoked"
 )
 
 type acmeAccount struct {
-	KeyId                string   `json:"-"`
-	Status                ACMEStates   `json:"state"`
-	Contact              []string `json:"contact"`
-	TermsOfServiceAgreed bool     `json:"termsOfServiceAgreed"`
-	Jwk                  []byte   `json:"jwk"`
+	KeyId                string     `json:"-"`
+	Status               ACMEStates `json:"state"`
+	Contact              []string   `json:"contact"`
+	TermsOfServiceAgreed bool       `json:"termsOfServiceAgreed"`
+	Jwk                  []byte     `json:"jwk"`
 }
 
 func (a *acmeState) CreateAccount(ac *acmeContext, c *jwsCtx, contact []string, termsOfServiceAgreed bool) (*acmeAccount, error) {

--- a/builtin/logical/pki/path_acme_directory.go
+++ b/builtin/logical/pki/path_acme_directory.go
@@ -55,7 +55,7 @@ func patternAcmeDirectory(b *backend, pattern string) *framework.Path {
 	}
 }
 
-type acmeOperation func(acmeCtx acmeContext, r *logical.Request, _ *framework.FieldData) (*logical.Response, error)
+type acmeOperation func(acmeCtx *acmeContext, r *logical.Request, _ *framework.FieldData) (*logical.Response, error)
 
 type acmeContext struct {
 	baseUrl *url.URL
@@ -76,7 +76,7 @@ func (b *backend) acmeWrapper(op acmeOperation) framework.OperationFunc {
 			return nil, err
 		}
 
-		acmeCtx := acmeContext{
+		acmeCtx := &acmeContext{
 			baseUrl: baseUrl,
 			sc:      sc,
 		}
@@ -120,7 +120,7 @@ func acmeErrorWrapper(op framework.OperationFunc) framework.OperationFunc {
 	}
 }
 
-func (b *backend) acmeDirectoryHandler(acmeCtx acmeContext, r *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+func (b *backend) acmeDirectoryHandler(acmeCtx *acmeContext, r *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
 	rawBody, err := json.Marshal(map[string]interface{}{
 		"newNonce":   acmeCtx.baseUrl.JoinPath("new-nonce").String(),
 		"newAccount": acmeCtx.baseUrl.JoinPath("new-account").String(),

--- a/builtin/logical/pki/path_acme_nonce.go
+++ b/builtin/logical/pki/path_acme_nonce.go
@@ -51,7 +51,7 @@ func patternAcmeNonce(b *backend, pattern string) *framework.Path {
 	}
 }
 
-func (b *backend) acmeNonceHandler(ctx acmeContext, r *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+func (b *backend) acmeNonceHandler(ctx *acmeContext, r *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
 	nonce, _, err := b.acmeState.GetNonce()
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (b *backend) acmeNonceHandler(ctx acmeContext, r *logical.Request, _ *frame
 	}, nil
 }
 
-func genAcmeLinkHeader(ctx acmeContext) []string {
+func genAcmeLinkHeader(ctx *acmeContext) []string {
 	path := fmt.Sprintf("<%s>;rel=\"index\"", ctx.baseUrl.JoinPath("directory").String())
 	return []string{path}
 }


### PR DESCRIPTION
This finishes adding ACME Account storage to the engine. 


---

<details>

<summary> Testing with CertBot </summary>

```
Saving debug log to /home/cipherboy/GitHub/cipherboy/vault/letsencrypt.log

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Would you be willing, once your first certificate is successfully issued, to
share your email address with the Electronic Frontier Foundation, a founding
partner of the Let's Encrypt project and the non-profit organization that
develops Certbot? We'd like to send you email about our work encrypting the web,
EFF news, campaigns, and ways to support digital freedom.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
(Y)es/(N)o: y
Account registered.
Requesting a certificate for xps15.local.cipherboy.com
An unexpected error occurred:
acme.messages.Error: about:blank
Ask for help or search for solutions at https://community.letsencrypt.org. See the logfile /home/cipherboy/GitHub/cipherboy/vault/letsencrypt.log or re-run Certbot with -v for more details.
2023-04-03 12:23:19,164:DEBUG:certbot._internal.main:certbot version: 1.21.0
2023-04-03 12:23:19,164:DEBUG:certbot._internal.main:Location of certbot entry point: /usr/bin/certbot
2023-04-03 12:23:19,164:DEBUG:certbot._internal.main:Arguments: ['--config-dir=.', '--work-dir=.', '--logs-dir=.', '--server', 'http://localhost:8200/v1/pki/acme/directory', '--standalone', '-d', 'xps15.local.cipherboy.com', '--email', 'alex.scheel@hashicorp.com', '--agree-tos']
2023-04-03 12:23:19,164:DEBUG:certbot._internal.main:Discovered plugins: PluginsRegistry(PluginEntryPoint#manual,PluginEntryPoint#null,PluginEntryPoint#standalone,PluginEntryPoint#webroot)
2023-04-03 12:23:19,169:DEBUG:certbot._internal.log:Root logging level set at 30
2023-04-03 12:23:19,170:DEBUG:certbot._internal.plugins.selection:Requested authenticator standalone and installer None
2023-04-03 12:23:19,170:DEBUG:certbot._internal.plugins.selection:Single candidate plugin: * standalone
Description: Spin up a temporary webserver
Interfaces: Authenticator, Plugin
Entry point: standalone = certbot._internal.plugins.standalone:Authenticator
Initialized: <certbot._internal.plugins.standalone.Authenticator object at 0x7fd20ecee740>
Prep: True
2023-04-03 12:23:19,170:DEBUG:certbot._internal.plugins.selection:Selected authenticator <certbot._internal.plugins.standalone.Authenticator object at 0x7fd20ecee740> and installer None
2023-04-03 12:23:19,170:INFO:certbot._internal.plugins.selection:Plugins selected: Authenticator standalone, Installer None
2023-04-03 12:23:19,314:DEBUG:acme.client:Sending GET request to http://localhost:8200/v1/pki/acme/directory.
2023-04-03 12:23:19,315:DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): localhost:8200
2023-04-03 12:23:19,316:DEBUG:urllib3.connectionpool:http://localhost:8200 "GET /v1/pki/acme/directory HTTP/1.1" 200 337
2023-04-03 12:23:19,316:DEBUG:acme.client:Received response:
HTTP 200
Cache-Control: no-store
Content-Type: application/json
Strict-Transport-Security: max-age=31536000; includeSubDomains
Date: Mon, 03 Apr 2023 16:23:19 GMT
Content-Length: 337

{"keyChange":"http://localhost:8200/v1/pki/acme/key-change","meta":{"externalAccountRequired":false},"newAccount":"http://localhost:8200/v1/pki/acme/new-account","newNonce":"http://localhost:8200/v1/pki/acme/new-nonce","newOrder":"http://localhost:8200/v1/pki/acme/new-order","revokeCert":"http://localhost:8200/v1/pki/acme/revoke-cert"}
2023-04-03 12:23:19,316:DEBUG:acme.client:Requesting fresh nonce
2023-04-03 12:23:19,316:DEBUG:acme.client:Sending HEAD request to http://localhost:8200/v1/pki/acme/new-nonce.
2023-04-03 12:23:19,317:DEBUG:urllib3.connectionpool:http://localhost:8200 "HEAD /v1/pki/acme/new-nonce HTTP/1.1" 200 0
2023-04-03 12:23:19,317:DEBUG:acme.client:Received response:
HTTP 200
Cache-Control: no-store, no-store
Link: <http://localhost:8200/v1/pki/acme/directory>;rel="index"
Replay-Nonce: KhM6d0uVHJsFBl8ghNEN3N7Ty3UI
Strict-Transport-Security: max-age=31536000; includeSubDomains
Date: Mon, 03 Apr 2023 16:23:19 GMT


2023-04-03 12:23:19,317:DEBUG:acme.client:Storing nonce: KhM6d0uVHJsFBl8ghNEN3N7Ty3UI
2023-04-03 12:23:19,317:DEBUG:acme.client:JWS payload:
b'{\n  "contact": [\n    "mailto:alex.scheel@hashicorp.com"\n  ],\n  "termsOfServiceAgreed": true\n}'
2023-04-03 12:23:19,319:DEBUG:acme.client:Sending POST request to http://localhost:8200/v1/pki/acme/new-account:
{
  "protected": "eyJhbGciOiAiUlMyNTYiLCAiandrIjogeyJuIjogIm5QbFdxWEpRM20tVzdORlhlelZLOFpaUG5LSEJXUW96QXgzbjJtVHp6UE5FcVE4QU1ERVV6a0swWXlqeUdKVnFfZlY1Zy12MVQ0RzcydGZUdkd4VHNxeUtET01ITUdCRnBsWi02OTR3XzhzVV9NWnAyMTRXTzAxZERCaExGdVRfY0U0MlNMdTB3LXhfcHRMNlJWdFJNQk1QY0VIZkhmY3BDQlMyenItUlc2RlB6VkxyWnhmN2FDLXlhbGJhRVIzVVBBejlZOTNWNGVZcmRoTDUyS1JhNU1aN3lxLTZVTkZHYlJydjFDcUlKVmJLQUt0Mi1nZkdBRFFWZUVrUTBoNUhGelB3ZERrRDVyUE00QnlaNnlsU0dmcElvZXcxQk5oZExYTXkzdmtUcDlZNU85ekk5Q0w4UU9SV1g3WDdVRGVpcnlaeU1QRXBPeFg0SjcyM2RUdkZWdyIsICJlIjogIkFRQUIiLCAia3R5IjogIlJTQSJ9LCAibm9uY2UiOiAiS2hNNmQwdVZISnNGQmw4Z2hORU4zTjdUeTNVSSIsICJ1cmwiOiAiaHR0cDovL2xvY2FsaG9zdDo4MjAwL3YxL3BraS9hY21lL25ldy1hY2NvdW50In0",
  "signature": "j9h-MMiOD1798DCuTEnXilugvOsWIEDq_gpOq-sJZeFpVvq-Jzx33EK6TXJ2LhugpvpNeK8KDqOW6pYmsyknOJ7q7oJtoSWVGtFdTEWrtKWDS-h9a19wx4QG1njFf_h4rkKAU38VorqJMUNCsnaL4g3ZBN_bXe1hffYnTNbWGyJsVlj3e7ZRxhJQK9VAphm0UEoYc1uRTOSmVokDNQRa9IqsNU79BWokLgpzqKwgaIqFbKr9kxMysKGpi99d8qCA9iT2040X8wnbo6T8znmYnFoFjoWVr8FLkrKo7R_Vu9q4johEXSxH0a0m2FazXUyo5fD3BKIWrLLRvIQyTKzBDQ",
  "payload": "ewogICJjb250YWN0IjogWwogICAgIm1haWx0bzphbGV4LnNjaGVlbEBoYXNoaWNvcnAuY29tIgogIF0sCiAgInRlcm1zT2ZTZXJ2aWNlQWdyZWVkIjogdHJ1ZQp9"
}
2023-04-03 12:23:19,320:DEBUG:urllib3.connectionpool:http://localhost:8200 "POST /v1/pki/acme/new-account HTTP/1.1" 201 165
2023-04-03 12:23:19,320:DEBUG:acme.client:Received response:
HTTP 201
Cache-Control: no-store
Content-Type: application/json
Link: <http://localhost:8200/v1/pki/acme/directory>;rel="index"
Location: http://localhost:8200/v1/pki/acme/account/HKenVs-uRITEk-Mb3Lx2yGiH0zjXEfswNHxOrAaW4sc=
Replay-Nonce: 2QPWbov06uO_WE6bSRLHQVqmxncb
Strict-Transport-Security: max-age=31536000; includeSubDomains
Date: Mon, 03 Apr 2023 16:23:19 GMT
Content-Length: 165

{"contact":["mailto:alex.scheel@hashicorp.com"],"orders":"http://localhost:8200/v1/pki/acme/account/HKenVs-uRITEk-Mb3Lx2yGiH0zjXEfswNHxOrAaW4sc=/orders","status":""}
2023-04-03 12:23:19,320:DEBUG:acme.client:Storing nonce: 2QPWbov06uO_WE6bSRLHQVqmxncb
2023-04-03 12:23:20,524:DEBUG:certbot._internal.display.obj:Notifying user: Account registered.
2023-04-03 12:23:20,524:DEBUG:certbot._internal.main:Picked account: <Account(RegistrationResource(body=Registration(key=None, contact=('mailto:alex.scheel@hashicorp.com',), agreement=None, status='', terms_of_service_agreed=None, only_return_existing=None, external_account_binding=None), uri='http://localhost:8200/v1/pki/acme/account/HKenVs-uRITEk-Mb3Lx2yGiH0zjXEfswNHxOrAaW4sc=', new_authzr_uri=None, terms_of_service=None), 66a3854e5115201cf74e75cdd04b62e0, Meta(creation_dt=datetime.datetime(2023, 4, 3, 16, 23, 19, tzinfo=<UTC>), creation_host='xps15.local.cipherboy.com', register_to_eff='alex.scheel@hashicorp.com'))>
2023-04-03 12:23:20,524:DEBUG:certbot._internal.display.obj:Notifying user: Requesting a certificate for xps15.local.cipherboy.com
2023-04-03 12:23:20,636:DEBUG:certbot.crypto_util:Generating RSA key (2048 bits): /home/cipherboy/GitHub/cipherboy/vault/keys/0000_key-certbot.pem
2023-04-03 12:23:20,639:DEBUG:certbot.crypto_util:Creating CSR: /home/cipherboy/GitHub/cipherboy/vault/csr/0000_csr-certbot.pem
2023-04-03 12:23:20,640:DEBUG:acme.client:JWS payload:
b'{\n  "identifiers": [\n    {\n      "type": "dns",\n      "value": "xps15.local.cipherboy.com"\n    }\n  ]\n}'
2023-04-03 12:23:20,641:DEBUG:acme.client:Sending POST request to http://localhost:8200/v1/pki/acme/new-order:
{
  "protected": "eyJhbGciOiAiUlMyNTYiLCAia2lkIjogImh0dHA6Ly9sb2NhbGhvc3Q6ODIwMC92MS9wa2kvYWNtZS9hY2NvdW50L0hLZW5Wcy11UklURWstTWIzTHgyeUdpSDB6alhFZnN3Tkh4T3JBYVc0c2M9IiwgIm5vbmNlIjogIjJRUFdib3YwNnVPX1dFNmJTUkxIUVZxbXhuY2IiLCAidXJsIjogImh0dHA6Ly9sb2NhbGhvc3Q6ODIwMC92MS9wa2kvYWNtZS9uZXctb3JkZXIifQ",
  "signature": "F-A3qUW_cci1VSDn0JuHmMA1P1NiBS4T-Ia0xx9hbeJL3xNkZGLLhDZiEe9fJq8tEgrf7_cZPXMFOdCGD30wCp4Pdl9nZAAvx5kNHSDU24yKLYfH0Rl32AltIJsV48nm9FSrn-ED3NWpPG8mR1pPnGp1ONszKI-Md1NGUADmOXVeSglx_J7_dYhqekyb_tM_9I90-xpgltPQy5K0gzA-iy6sRM01jgDiepTLO4iss8e_Zxc-t0kK9XbaHQVX4gebiRmwlgpgL23Qz3R9iYJ89SY-0KA9Q2ULylV-3uOv4wluIsAllWC-rZT9iFafnolcfqwihpn0YpoR3O8vSlRDzg",
  "payload": "ewogICJpZGVudGlmaWVycyI6IFsKICAgIHsKICAgICAgInR5cGUiOiAiZG5zIiwKICAgICAgInZhbHVlIjogInhwczE1LmxvY2FsLmNpcGhlcmJveS5jb20iCiAgICB9CiAgXQp9"
}
2023-04-03 12:23:20,642:DEBUG:urllib3.connectionpool:http://localhost:8200 "POST /v1/pki/acme/new-order HTTP/1.1" 404 32
2023-04-03 12:23:20,642:DEBUG:acme.client:Received response:
HTTP 404
Cache-Control: no-store
Content-Type: application/json
Strict-Transport-Security: max-age=31536000; includeSubDomains
Date: Mon, 03 Apr 2023 16:23:20 GMT
Content-Length: 32

{"errors":["unsupported path"]}

2023-04-03 12:23:20,643:DEBUG:acme.client:Ignoring wrong Content-Type ('application/json') for JSON Error
2023-04-03 12:23:20,643:DEBUG:certbot._internal.log:Exiting abnormally:
Traceback (most recent call last):
  File "/usr/bin/certbot", line 33, in <module>
    sys.exit(load_entry_point('certbot==1.21.0', 'console_scripts', 'certbot')())
  File "/usr/lib/python3/dist-packages/certbot/main.py", line 15, in main
    return internal_main.main(cli_args)
  File "/usr/lib/python3/dist-packages/certbot/_internal/main.py", line 1574, in main
    return config.func(config, plugins)
  File "/usr/lib/python3/dist-packages/certbot/_internal/main.py", line 1434, in certonly
    lineage = _get_and_save_cert(le_client, config, domains, certname, lineage)
  File "/usr/lib/python3/dist-packages/certbot/_internal/main.py", line 133, in _get_and_save_cert
    lineage = le_client.obtain_and_enroll_certificate(domains, certname)
  File "/usr/lib/python3/dist-packages/certbot/_internal/client.py", line 459, in obtain_and_enroll_certificate
    cert, chain, key, _ = self.obtain_certificate(domains)
  File "/usr/lib/python3/dist-packages/certbot/_internal/client.py", line 389, in obtain_certificate
    orderr = self._get_order_and_authorizations(csr.data, self.config.allow_subset_of_names)
  File "/usr/lib/python3/dist-packages/certbot/_internal/client.py", line 421, in _get_order_and_authorizations
    orderr = self.acme.new_order(csr_pem)
  File "/usr/lib/python3/dist-packages/acme/client.py", line 936, in new_order
    return cast(ClientV2, self.client).new_order(csr_pem)
  File "/usr/lib/python3/dist-packages/acme/client.py", line 702, in new_order
    response = self._post(self.directory['newOrder'], order)
  File "/usr/lib/python3/dist-packages/acme/client.py", line 101, in _post
    return self.net.post(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/acme/client.py", line 1269, in post
    return self._post_once(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/acme/client.py", line 1283, in _post_once
    response = self._check_response(response, content_type=content_type)
  File "/usr/lib/python3/dist-packages/acme/client.py", line 1128, in _check_response
    raise messages.Error.from_json(jobj)
acme.messages.Error: about:blank
2023-04-03 12:23:20,643:ERROR:certbot._internal.log:An unexpected error occurred:
2023-04-03 12:23:20,643:ERROR:certbot._internal.log:acme.messages.Error: about:blank
```

</details>