### PR TITLE
Finish size var clean up

### DIFF
--- a/ui/app/styles/components/masked-input.scss
+++ b/ui/app/styles/components/masked-input.scss
@@ -24,7 +24,7 @@
 // need to be the same font and small
 .masked-input.masked .masked-value {
   font-size: 9px;
-  font-family: $family-primary;
+  font-family: $family-sans;
   line-height: 2.5;
 }
 

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -67,7 +67,7 @@
   .menu-label {
     color: $grey-light;
     font-weight: $font-weight-bold;
-    font-size: $size-small;
+    font-size: $size-8;
     line-height: 1;
     margin-bottom: $size-8;
     padding-left: $size-5;

--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -5,6 +5,7 @@
 
 // Start with Structure & Bulma variables as a foundation
 @import './utils/color_variables';
+@import './utils/font_family_variables';
 @import './utils/size_variables';
 
 // Consolidate Bulma variables and mixins

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -16,7 +16,7 @@ $button-box-shadow-standard: 0 3px 1px 0 rgba($black, 0.12);
   cursor: pointer;
   color: $ui-gray-800;
   display: inline-block;
-  font-size: $size-small;
+  font-size: $size-8;
   font-weight: $font-weight-semibold;
   height: 2.5rem;
   line-height: 1.6;

--- a/ui/app/styles/core/element-styling.scss
+++ b/ui/app/styles/core/element-styling.scss
@@ -92,7 +92,7 @@ button,
 input,
 select,
 textarea {
-  font-family: $family-primary;
+  font-family: $family-sans;
 }
 
 code,

--- a/ui/app/styles/core/label.scss
+++ b/ui/app/styles/core/label.scss
@@ -22,7 +22,7 @@
   }
   // Sizes
   &.is-small {
-    font-size: $size-7;
+    font-size: $size-8;
   }
   &.is-medium {
     font-size: $size-5;

--- a/ui/app/styles/core/label.scss
+++ b/ui/app/styles/core/label.scss
@@ -20,16 +20,6 @@
   &:not(:last-child) {
     margin-bottom: 0.25rem;
   }
-  // Sizes
-  &.is-small {
-    font-size: $size-8;
-  }
-  &.is-medium {
-    font-size: $size-5;
-  }
-  &.is-large {
-    font-size: $size-4;
-  }
 
   &::before,
   &::after {

--- a/ui/app/styles/core/label.scss
+++ b/ui/app/styles/core/label.scss
@@ -8,7 +8,7 @@
 .label {
   color: $grey-darker;
   text-transform: uppercase;
-  font-size: $size-small;
+  font-size: $size-8;
 }
 
 .is-label {
@@ -22,13 +22,13 @@
   }
   // Sizes
   &.is-small {
-    font-size: $size-small;
+    font-size: $size-7;
   }
   &.is-medium {
-    font-size: $size-medium;
+    font-size: $size-5;
   }
   &.is-large {
-    font-size: $size-large;
+    font-size: $size-4;
   }
 
   &::before,

--- a/ui/app/styles/core/message.scss
+++ b/ui/app/styles/core/message.scss
@@ -150,7 +150,7 @@
   }
 
   &.size-small {
-    font-size: $size-7;
+    font-size: $size-8;
   }
 
   &.padding-top {

--- a/ui/app/styles/helper-classes/typography.scss
+++ b/ui/app/styles/helper-classes/typography.scss
@@ -89,7 +89,7 @@
 }
 
 .is-help {
-  font-size: $size-small;
+  font-size: $size-8;
   margin-top: 0.25rem;
 }
 

--- a/ui/app/styles/utils/_bulma_variables.scss
+++ b/ui/app/styles/utils/_bulma_variables.scss
@@ -271,13 +271,6 @@ $code: $grey-dark;
 $code-background: transparent;
 $border: $grey-light;
 
-//typography
-$family-sans: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
-  'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-$family-monospace: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
-$family-primary: $family-sans;
-$family-code: $family-monospace !default;
-
 //input
 $input-background-color: $white;
 $input-focus-background-color: $white;

--- a/ui/app/styles/utils/_font_family_variables.scss
+++ b/ui/app/styles/utils/_font_family_variables.scss
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+$family-sans: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+  'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+
+$family-monospace: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -6,6 +6,8 @@
 /*
 ARG TODO post bulma removal:
 - size-x and and spacing-x variables often overlap. Ideally, we could combine these to cover all the size requirements.
+We need to confirm as a team use cases for px vs rem and how to address missing size values ex: 14px.
+- Figure out when a var is appropriate, should we have $easing?
  */
 
 /* General sizing: used in fonts and in padding, margin, etc. */

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -9,21 +9,17 @@ ARG TODO post bulma removal:
  */
 
 /* General sizing: used in fonts and in padding, margin, etc. */
-$size-1: 3rem !default;
-$size-2: 2.5rem !default;
+$size-1: 3rem; // 48px, same as $spacing-xxl
+$size-2: 2.5rem; // 40px
 $size-3: (24/14) + 0rem; // ~1.714rem ~27px
-$size-4: 1.5rem; // 24px
+$size-4: 1.5rem; // 24px same as $spacing-l
 $size-5: 1.25rem; // 20px
-$size-6: 1rem !default;
+$size-6: 1rem; // 16px same as $spacing-m
 $size-7: (13/14) + 0rem; // ~.929rem ~15px
 $size-8: (12/14) + 0rem; // ~.857rem  ~13.7px
-$size-9: 0.75rem; // 12px
-$size-10: 0.5rem; // 8px
-$size-11: 0.25rem; // 4px
-$size-small: $size-8;
-$size-normal: $size-6;
-$size-medium: $size-5;
-$size-large: $size-4;
+$size-9: 0.75rem; // 12px same as $spacing-s
+$size-10: 0.5rem; // 8px same as $spacing-xs
+$size-11: 0.25rem; // 4px same as spacing-xxs
 
 /* Spacing */
 $spacing-xxs: 4px;


### PR DESCRIPTION
**TLDR**: I am not replacing hard-coded size values. Instead, I cleaned up the remaining size vars, and moved out font-family vars into a separate utils folder.

**Longer version:** Originally, I had intended to replace all hard-coded sizes in the scss files with their corresponding size var (e.g. `width: 2.5rem` with `width: $size-2`). After some internal debate and feedback from teammates, I opted not to do this. At least not now and not in this sidebranch. While, yes, I _could_ replace a lot of hard-coded px and rem values with their respective `size_variable`, I think that work would eventually be overridden. Once we figure out our sizing vars (e.g. rem for size values and px for margins/padding??? or all rem) then we can override the hardcoded values. Any work to do so before this might be replaced. Additional, none of that needs to happen in this sidebranch in order for it to be released.

* Moved out any font-family `utils/bulma_variables` into their own file and replaced overridden values as they were not adding value.

* Replaced all `$size-small`, `$size-medium`, `$size-large`, etc. values with their respective `$size-xx` var, adding clarity to our var system.

This wraps up the size var work. There's a lot more to do, but not in the scope of this sidebranch. Next steps will be to tackle color vars.