### PR TITLE
ui: fix empty tooltip rendering when no creation time

### DIFF
--- a/ui/app/templates/components/secret-form-show.hbs
+++ b/ui/app/templates/components/secret-form-show.hbs
@@ -46,17 +46,19 @@
           Value
         </div>
         <div class="th column justify-right" data-test-created-time>
-          <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
-            <T.Trigger data-test-tooltip-trigger tabindex="-1" data-test-created-time>
-              Version created
-              {{date-format @modelForData.createdTime "MMM dd, yyyy hh:mm a"}}
-            </T.Trigger>
-            <T.Content @defaultClass="tool-tip smaller-font">
-              <div class="box" data-test-hover-copy-tooltip-text>
-                {{@modelForData.createdTime}}
-              </div>
-            </T.Content>
-          </ToolTip>
+          {{#if @modelForData.createdTime}}
+            <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
+              <T.Trigger data-test-tooltip-trigger tabindex="-1">
+                Version created
+                {{date-format @modelForData.createdTime "MMM dd, yyyy hh:mm a"}}
+              </T.Trigger>
+              <T.Content @defaultClass="tool-tip smaller-font">
+                <div class="box" data-test-hover-copy-tooltip-text>
+                  {{@modelForData.createdTime}}
+                </div>
+              </T.Content>
+            </ToolTip>
+          {{/if}}
         </div>
       </div>
     </div>

--- a/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
@@ -46,7 +46,7 @@ module('Acceptance | secrets/cubbyhole/create', function (hooks) {
       'vault.cluster.secrets.backend.show',
       'redirects to the show page'
     );
-    assert.dom('[ data-test-created-time]').hasText('', 'it does not render created time if blank');
+    assert.dom('[data-test-created-time]').hasText('', 'it does not render created time if blank');
     assert.ok(showPage.editIsPresent, 'shows the edit button');
   });
 });

--- a/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
@@ -46,6 +46,7 @@ module('Acceptance | secrets/cubbyhole/create', function (hooks) {
       'vault.cluster.secrets.backend.show',
       'redirects to the show page'
     );
+    assert.dom('[ data-test-created-time]').hasText('', 'it does not render created time if blank');
     assert.ok(showPage.editIsPresent, 'shows the edit button');
   });
 });

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -290,7 +290,7 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
     await editPage.createSecret(secretPath, 'foo', 'bar');
     await click('[data-test-popup-menu-trigger="version"]');
 
-    assert.dom('[ data-test-created-time]').includesText('Version created ', 'shows version created time');
+    assert.dom('[data-test-created-time]').includesText('Version created ', 'shows version created time');
 
     await click('[data-test-version-history]');
 


### PR DESCRIPTION
## before fix: 
tooltip + Version time still rendered for secret backends that don't provide that data

![version-bug](https://user-images.githubusercontent.com/68122737/229642103-d050d9e9-484b-4b1f-bd2c-ab2d76b3353a.gif)
