### PR TITLE
secrets/openldap: add creds/ endpoint to API docs

### DIFF
--- a/website/content/api-docs/secret/ldap.mdx
+++ b/website/content/api-docs/secret/ldap.mdx
@@ -547,6 +547,35 @@ The username template cannot use this function.
 `utf16le` - Encodes the provided value into UTF16-LE.<br />
 **Example:** `{{.FieldName | utf16le}}`
 
+## Dynamic Role Passwords
+
+The `creds` endpoint offers the credential information for a given dynamic role.
+
+| Method | Path                               |
+| :----- | :--------------------------------- |
+| `GET`  | `/ldap/creds/:role_name` |
+
+#### Sample Get Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request GET \
+    http://127.0.0.1:8200/v1/ldap/creds/dynamic-role
+```
+
+#### Sample Get Response
+
+```json
+{
+  "distinguished_names": [
+    "cn=v_token-dispname_testrole_jmZMnjS42a_1680580467,ou=users,dc=hashicorp,dc=com"
+  ],
+  "password": "OWexB3OzYYLFiotWxUS2EheGpriwR20fa2yA7JGTsnBREcxyqpwf73htofMihxcC",
+  "username": "v_token-dispname_testrole_jmZMnjS42a_1680580467"
+}
+```
+
 ## Library Set Management
 
 The `library` endpoint configures the sets of service accounts that Vault will offer for check-out.


### PR DESCRIPTION
The endpoint to [generate dynamic creds](https://github.com/hashicorp/vault-plugin-secrets-openldap/blob/aaefa7ce8d0b0f5c724f6c902534fae533849052/path_dynamic_creds.go#L21) is missing from the [API docs](https://developer.hashicorp.com/vault/api-docs/secret/ldap#dynamic-roles).