### PR TITLE
Update Create Role heading to Create/Update Role

### DIFF
--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -14,7 +14,7 @@ This documentation assumes the SSH secrets engine is enabled at the `/ssh` path
 in Vault. Since it is possible to enable secrets engines at any location, please
 update your API calls accordingly.
 
-## Create Role
+## Create/Update Role
 
 This endpoint creates or updates a named role.
 


### PR DESCRIPTION
The subheading states you can update a named role but for navigation purposes I think it would also make sense to add it to the heading too.