### PR TITLE
add known issue documentation around STS lease_duration changes

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -90,6 +90,16 @@ forwarded to the active node of this cluster.
 
 As a workaround, submit revocation requests to the active node only.
 
+### STS credentials do not return a lease_duration
+Vault 1.13.0 introduced a change to the aws secrets engine such that it no longer returns leases for STS credentials due
+to the fact that they cannot be revoked or renewed. As part of this change, a bug was introduced which no longer returns
+a non-zero lease_duration. This prevents the Vault Agent from refreshing STS credentials and may introduce undesired behaviour
+for anything which relies on a non-zero lease_duration.
+
+There is currently no workaround.
+
 #### Impacted Versions
 
 Affects Vault 1.13.0 only.
+
+


### PR DESCRIPTION
Updates the upgrade guide to include documentation about a known issue causing STS lease_duration to become zero.