### PR TITLE
Simplify tracking of external plugins

### DIFF
--- a/builtin/plugin/backend.go
+++ b/builtin/plugin/backend.go
@@ -86,46 +86,21 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*PluginBackend, 
 		runningVersion = versioner.PluginVersion().Version
 	}
 
-	external := false
-	if externaler, ok := raw.(logical.Externaler); ok {
-		external = externaler.IsExternal()
-	}
-
 	// Cleanup meta plugin backend
 	raw.Cleanup(ctx)
 
 	// Initialize b.Backend with placeholder backend since plugin
 	// backends will need to be lazy loaded.
-	b.Backend = &placeholderBackend{
-		Backend: framework.Backend{
-			PathsSpecial:   paths,
-			BackendType:    btype,
-			RunningVersion: runningVersion,
-		},
-		external: external,
+	b.Backend = &framework.Backend{
+		PathsSpecial:   paths,
+		BackendType:    btype,
+		RunningVersion: runningVersion,
 	}
 
 	b.config = conf
 
 	return &b, nil
 }
-
-// placeholderBackend is used a placeholder before a backend is lazy-loaded.
-// It is mostly used to mark that the backend is an external backend.
-type placeholderBackend struct {
-	framework.Backend
-
-	external bool
-}
-
-func (p *placeholderBackend) IsExternal() bool {
-	return p.external
-}
-
-var (
-	_ logical.Externaler      = (*placeholderBackend)(nil)
-	_ logical.PluginVersioner = (*placeholderBackend)(nil)
-)
 
 // PluginBackend is a thin wrapper around plugin.BackendPluginClient
 type PluginBackend struct {
@@ -326,14 +301,6 @@ func (b *PluginBackend) PluginVersion() logical.PluginVersion {
 	return logical.EmptyPluginVersion
 }
 
-func (b *PluginBackend) IsExternal() bool {
-	if externaler, ok := b.Backend.(logical.Externaler); ok {
-		return externaler.IsExternal()
-	}
-	return false
-}
-
 var (
 	_ logical.PluginVersioner = (*PluginBackend)(nil)
-	_ logical.Externaler      = (*PluginBackend)(nil)
 )

--- a/builtin/plugin/backend.go
+++ b/builtin/plugin/backend.go
@@ -301,6 +301,4 @@ func (b *PluginBackend) PluginVersion() logical.PluginVersion {
 	return logical.EmptyPluginVersion
 }
 
-var (
-	_ logical.PluginVersioner = (*PluginBackend)(nil)
-)
+var _ logical.PluginVersioner = (*PluginBackend)(nil)

--- a/sdk/logical/logical.go
+++ b/sdk/logical/logical.go
@@ -166,11 +166,6 @@ type Auditor interface {
 	AuditResponse(ctx context.Context, input *LogInput) error
 }
 
-// Externaler allows us to check if a backend is running externally (i.e., over GRPC)
-type Externaler interface {
-	IsExternal() bool
-}
-
 type PluginVersion struct {
 	Version string
 }

--- a/sdk/plugin/plugin.go
+++ b/sdk/plugin/plugin.go
@@ -154,6 +154,4 @@ func (b *BackendPluginClient) PluginVersion() logical.PluginVersion {
 	return logical.EmptyPluginVersion
 }
 
-var (
-	_ logical.PluginVersioner = (*BackendPluginClient)(nil)
-)
+var _ logical.PluginVersioner = (*BackendPluginClient)(nil)

--- a/sdk/plugin/plugin.go
+++ b/sdk/plugin/plugin.go
@@ -154,14 +154,6 @@ func (b *BackendPluginClient) PluginVersion() logical.PluginVersion {
 	return logical.EmptyPluginVersion
 }
 
-func (b *BackendPluginClient) IsExternal() bool {
-	if externaler, ok := b.Backend.(logical.Externaler); ok {
-		return externaler.IsExternal()
-	}
-	return true // default to true since this is only used for GRPC plugins
-}
-
 var (
 	_ logical.PluginVersioner = (*BackendPluginClient)(nil)
-	_ logical.Externaler      = (*BackendPluginClient)(nil)
 )

--- a/sdk/plugin/plugin_v5.go
+++ b/sdk/plugin/plugin_v5.go
@@ -57,7 +57,6 @@ func (b *BackendPluginClientV5) PluginVersion() logical.PluginVersion {
 
 var (
 	_ logical.PluginVersioner = (*BackendPluginClientV5)(nil)
-	_ logical.Externaler      = (*BackendPluginClientV5)(nil)
 )
 
 // NewBackendV5 will return an instance of an RPC-based client implementation of

--- a/sdk/plugin/plugin_v5.go
+++ b/sdk/plugin/plugin_v5.go
@@ -55,9 +55,7 @@ func (b *BackendPluginClientV5) PluginVersion() logical.PluginVersion {
 	return logical.EmptyPluginVersion
 }
 
-var (
-	_ logical.PluginVersioner = (*BackendPluginClientV5)(nil)
-)
+var _ logical.PluginVersioner = (*BackendPluginClientV5)(nil)
 
 // NewBackendV5 will return an instance of an RPC-based client implementation of
 // the backend for external plugins, or a concrete implementation of the

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -192,7 +192,7 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 	entry.RunningVersion = entry.Version
 	if entry.RunningVersion == "" {
 		// don't set the running version to a builtin if it is running as an external plugin
-		if externaler, ok := backend.(logical.Externaler); !ok || !externaler.IsExternal() {
+		if entry.RunningSha256 == "" {
 			entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeCredential, entry.Type)
 		}
 	}
@@ -819,7 +819,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 		entry.RunningVersion = entry.Version
 		if entry.RunningVersion == "" {
 			// don't set the running version to a builtin if it is running as an external plugin
-			if externaler, ok := backend.(logical.Externaler); !ok || !externaler.IsExternal() {
+			if entry.RunningSha256 == "" {
 				entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeCredential, entry.Type)
 			}
 		}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -698,7 +698,7 @@ func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStora
 	entry.RunningVersion = entry.Version
 	if entry.RunningVersion == "" {
 		// don't set the running version to a builtin if it is running as an external plugin
-		if externaler, ok := backend.(logical.Externaler); !ok || !externaler.IsExternal() {
+		if entry.RunningSha256 == "" {
 			entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeSecrets, entry.Type)
 		}
 	}
@@ -1512,7 +1512,7 @@ func (c *Core) setupMounts(ctx context.Context) error {
 		entry.RunningVersion = entry.Version
 		if entry.RunningVersion == "" {
 			// don't set the running version to a builtin if it is running as an external plugin
-			if externaler, ok := backend.(logical.Externaler); !ok || !externaler.IsExternal() {
+			if entry.RunningSha256 == "" {
 				entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeSecrets, entry.Type)
 			}
 		}

--- a/vault/plugin_reload.go
+++ b/vault/plugin_reload.go
@@ -197,7 +197,7 @@ func (c *Core) reloadBackendCommon(ctx context.Context, entry *MountEntry, isAut
 	entry.RunningVersion = entry.Version
 	if entry.RunningVersion == "" {
 		// don't set the running version to a builtin if it is running as an external plugin
-		if externaler, ok := backend.(logical.Externaler); !ok || !externaler.IsExternal() {
+		if entry.RunningSha256 == "" {
 			if isAuth {
 				entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeCredential, entry.Type)
 			} else {


### PR DESCRIPTION
Following on from https://github.com/hashicorp/vault/pull/19814#discussion_r1153698708, this PR removes the `logical.Externaler` interface in favour of checking for a running SHA256 value, which will always be populated when the plugin is external, and will always be empty when it's builtin.