### PR TITLE
Set uniform supported Kubernetes versions for all integrations

### DIFF
--- a/website/content/docs/platform/k8s/csi/index.mdx
+++ b/website/content/docs/platform/k8s/csi/index.mdx
@@ -35,6 +35,8 @@ The following features are supported by the Vault CSI Provider:
 - Syncing secrets to Kubernetes secrets to be used as environment variables.
 - Installation via [Vault Helm](/vault/docs/platform/k8s/helm)
 
+@include kubernetes-supported-versions.mdx
+
 ## Authenticating with Vault
 
 The primary method of authentication with Vault when using the Vault CSI Provider

--- a/website/content/docs/platform/k8s/helm/index.mdx
+++ b/website/content/docs/platform/k8s/helm/index.mdx
@@ -20,6 +20,8 @@ This page assumes general knowledge of [Helm](https://helm.sh/) and
 how to use it. Using Helm to install Vault requires that Helm is
 properly installed and configured with your Kubernetes cluster.
 
+@include kubernetes-supported-versions.mdx
+
 ## Using the Helm Chart
 
 Helm must be installed and configured on your machine. Please refer to the [Helm

--- a/website/content/docs/platform/k8s/injector/index.mdx
+++ b/website/content/docs/platform/k8s/injector/index.mdx
@@ -20,20 +20,7 @@ the request. This functionality is provided by the [vault-k8s](https://github.co
 project and can be automatically installed and configured using the
 [Vault Helm](https://github.com/hashicorp/vault-helm) chart.
 
-## Supported Kubernetes Versions
-
-The following [Kubernetes minor releases][k8s-releases] are currently supported.
-The latest version of the injector is tested against each version. It may work
-with other versions of Kubernetes, but those are not supported.
-
-* 1.26
-* 1.25
-* 1.24
-* 1.23
-* 1.22
-* 1.21
-
-[k8s-releases]: https://kubernetes.io/releases/
+@include kubernetes-supported-versions.mdx
 
 ## Overview
 

--- a/website/content/docs/platform/k8s/vso/index.mdx
+++ b/website/content/docs/platform/k8s/vso/index.mdx
@@ -32,6 +32,8 @@ The following features are supported by the Vault Secrets Operator:
 - Supported installation methods: `Helm`, `Kustomize`<br />
 *see the [installation](/vault/docs/platform/k8s/vso/installation.mdx) docs for more details*
 
+@include kubernetes-supported-versions.mdx
+
 ## Vault Access and Custom Resource Definitions
 
 ~> **Note:** Currently, the Operator only supports the [Kubernetes Auth Method](/vault/docs/auth/kubernetes).

--- a/website/content/partials/kubernetes-supported-versions.mdx
+++ b/website/content/partials/kubernetes-supported-versions.mdx
@@ -1,0 +1,13 @@
+## Supported Kubernetes Versions
+
+The following [Kubernetes minor releases][k8s-releases] are currently supported.
+The latest version is tested against each Kubernetes version. It may work with
+other versions of Kubernetes, but those are not supported.
+
+* 1.26
+* 1.25
+* 1.24
+* 1.23
+* 1.22
+
+[k8s-releases]: https://kubernetes.io/releases/


### PR DESCRIPTION
Currently we only publish supported versions for injector, but we test against 1.22-1.26 for all integrations. This covers all versions supported by [Kubernetes](https://kubernetes.io/releases/), [AKS](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar), [EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html), and [GKE](https://cloud.google.com/kubernetes-engine/versioning#version-support).

Test references:
* [Operator](https://github.com/hashicorp/vault-secrets-operator/blob/b12fd701bc6aaf1da4e779b27eca197e25d178ab/.github/workflows/tests.yaml#L91)
* [Injector](https://github.com/hashicorp/vault-k8s/blob/e3883c1caa0c2da2e56ea6ea5e77ac25be911d5a/.github/workflows/tests.yaml#L47)
* [Helm chart](https://github.com/hashicorp/vault-helm/blob/fc7d4326fcc5bbaa1b42aa4120d01d39e64e75a5/.github/workflows/acceptance.yaml#L10)
* [CSI](https://github.com/hashicorp/vault-csi-provider/blob/1a7ac889f9c047bc108dff0547b129f54250f648/.github/workflows/tests.yaml#L73)