### PR TITLE
add upgrade documentation around STS lease_duration issue

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -96,10 +96,9 @@ to the fact that they cannot be revoked or renewed. As part of this change, a bu
 a non-zero lease_duration. This prevents the Vault Agent from refreshing STS credentials and may introduce undesired behaviour
 for anything which relies on a non-zero lease_duration.
 
-There is currently no workaround.
+For applications that can control what value to look for, the ttl value in the response can be used to know when to
+request STS credentials next.
 
 #### Impacted Versions
 
 Affects Vault 1.13.0 only.
-
-

--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -99,6 +99,10 @@ for anything which relies on a non-zero `lease_duration`.
 For applications that can control what value to look for, the `ttl` value in the response can be used to know when to
 request STS credentials next.
 
+An additional workaround for users rendering STS credentials via the Vault Agent is to modify the
+`static-secret-render-interval` for a STS secret to control the frequency of rendering the secrets.
+Setting this to the minimum STS interval (15 minutes) should restore expected behaviour.
+
 #### Impacted Versions
 
 Affects Vault 1.13.0 only.

--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -91,12 +91,12 @@ forwarded to the active node of this cluster.
 As a workaround, submit revocation requests to the active node only.
 
 ### STS credentials do not return a lease_duration
-Vault 1.13.0 introduced a change to the aws secrets engine such that it no longer returns leases for STS credentials due
+Vault 1.13.0 introduced a change to the AWS Secrets Engine such that it no longer returns leases for STS credentials due
 to the fact that they cannot be revoked or renewed. As part of this change, a bug was introduced which no longer returns
-a non-zero lease_duration. This prevents the Vault Agent from refreshing STS credentials and may introduce undesired behaviour
-for anything which relies on a non-zero lease_duration.
+a non-zero `lease_duration`. This prevents the Vault Agent from refreshing STS credentials and may introduce undesired behaviour
+for anything which relies on a non-zero `lease_duration`.
 
-For applications that can control what value to look for, the ttl value in the response can be used to know when to
+For applications that can control what value to look for, the `ttl` value in the response can be used to know when to
 request STS credentials next.
 
 #### Impacted Versions

--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -90,6 +90,16 @@ forwarded to the active node of this cluster.
 
 As a workaround, submit revocation requests to the active node only.
 
+### STS credentials do not return a lease_duration
+Vault 1.13.0 introduced a change to the aws secrets engine such that it no longer returns leases for STS credentials due
+to the fact that they cannot be revoked or renewed. As part of this change, a bug was introduced which no longer returns
+a non-zero lease_duration. This prevents the Vault Agent from refreshing STS credentials and may introduce undesired behaviour
+for anything which relies on a non-zero lease_duration.
+
+There is currently no workaround.
+
 #### Impacted Versions
 
 Affects Vault 1.13.0 only.
+
+

--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -91,9 +91,9 @@ forwarded to the active node of this cluster.
 As a workaround, submit revocation requests to the active node only.
 
 ### STS credentials do not return a lease_duration
-Vault 1.13.0 introduced a change to the AWS Secrets Engine such that it no longer returns leases for STS credentials due
-to the fact that they cannot be revoked or renewed. As part of this change, a bug was introduced which no longer returns
-a non-zero `lease_duration`. This prevents the Vault Agent from refreshing STS credentials and may introduce undesired behaviour
+Vault 1.13.0 introduced a change to the AWS Secrets Engine such that it no longer creates leases for STS credentials due
+to the fact that they cannot be revoked or renewed. As part of this change, a bug was introduced which causes `lease_duration`
+to always return zero. This prevents the Vault Agent from refreshing STS credentials and may introduce undesired behaviour
 for anything which relies on a non-zero `lease_duration`.
 
 For applications that can control what value to look for, the `ttl` value in the response can be used to know when to

--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -99,9 +99,9 @@ for anything which relies on a non-zero `lease_duration`.
 For applications that can control what value to look for, the `ttl` value in the response can be used to know when to
 request STS credentials next.
 
-An additional workaround for users rendering STS credentials via the Vault Agent is to modify the
-`static-secret-render-interval` for a STS secret to control the frequency of rendering the secrets.
-Setting this to the minimum STS interval (15 minutes) should restore expected behaviour.
+An additional workaround for users rendering STS credentials via the Vault Agent is to set the
+`static-secret-render-interval` for a template using the credentials. Setting this configuration to 15 minutes
+accommodates the default minimum duration of an STS token and overrides the default render interval of 5 minutes.
 
 #### Impacted Versions
 


### PR DESCRIPTION
Updates the upgrade guide to include documentation about a known issue causing STS lease_duration to become zero.