### PR TITLE
Replace defaultVaultAuthMethod with defaultAuthMethod in Snippet

### DIFF
--- a/website/content/docs/platform/k8s/vso/helm.mdx
+++ b/website/content/docs/platform/k8s/vso/helm.mdx
@@ -240,7 +240,7 @@ and a [Vault Auth Method](/vault/docs/auth/kubernetes) to be setup against the `
 
 defaultVaultConnection:
   enabled: true
-defaultVaultAuthMethod:
+defaultAuthMethod:
   enabled: true
 
 ```


### PR DESCRIPTION
I was wondering why the default VaultAuth CR was not created. It was due the fact that I copy/pasted the snippet from the docs here, which has the wrong key.