### PR TITLE
Sidebar Animation Glitch Fixes

### DIFF
--- a/ui/app/components/sidebar/nav/access.hbs
+++ b/ui/app/components/sidebar/nav/access.hbs
@@ -38,15 +38,6 @@
       data-test-sidebar-nav-link="Control Groups"
     />
   {{/if}}
-  {{#if (has-permission "policies")}}
-    <Nav.Link
-      @route="vault.cluster.policies"
-      @models={{get (route-params-for "policies") "models"}}
-      @text="Policies"
-      @hasSubItems={{true}}
-      data-test-sidebar-nav-link="Policies"
-    />
-  {{/if}}
 
   <Nav.Title data-test-sidebar-nav-heading="Organization">Organization</Nav.Title>
 

--- a/ui/app/components/sidebar/nav/cluster.hbs
+++ b/ui/app/components/sidebar/nav/cluster.hbs
@@ -17,6 +17,15 @@
       data-test-sidebar-nav-link="Access"
     />
   {{/if}}
+  {{#if (has-permission "policies")}}
+    <Nav.Link
+      @route="vault.cluster.policies"
+      @models={{get (route-params-for "policies") "models"}}
+      @text="Policies"
+      @hasSubItems={{true}}
+      data-test-sidebar-nav-link="Policies"
+    />
+  {{/if}}
   {{#if (has-permission "tools")}}
     <Nav.Link
       @route="vault.cluster.tools.tool"

--- a/ui/app/components/sidebar/nav/policies.hbs
+++ b/ui/app/components/sidebar/nav/policies.hbs
@@ -1,11 +1,10 @@
 <HcAppFrame::SidenavPanel as |Nav|>
   <Nav.BackLink
-    @route={{get (route-params-for "access") "route"}}
-    @models={{get (route-params-for "access") "models"}}
+    @route="vault.cluster"
     @current-when={{false}}
     @icon="arrow-left"
-    @text="Back to access"
-    data-test-sidebar-nav-link="Back to access"
+    @text="Back to main navigation"
+    data-test-sidebar-nav-link="Back to main navigation"
   />
 
   <Nav.Title data-test-sidebar-nav-heading="Policies">Policies</Nav.Title>

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -135,18 +135,5 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
       }
       return true;
     },
-    loading(transition) {
-      const isSameRoute = transition.from?.name === transition.to?.name;
-      if (isSameRoute || Ember.testing) {
-        return;
-      }
-      // eslint-disable-next-line ember/no-controller-access-in-routes
-      const controller = this.controllerFor('vault.cluster');
-      controller.set('currentlyLoading', true);
-
-      transition.finally(function () {
-        controller.set('currentlyLoading', false);
-      });
-    },
   },
 });

--- a/ui/app/routes/vault/cluster/clients.js
+++ b/ui/app/routes/vault/cluster/clients.js
@@ -36,16 +36,6 @@ export default class ClientsRoute extends Route {
   }
 
   @action
-  async loading(transition) {
-    // eslint-disable-next-line ember/no-controller-access-in-routes
-    const controller = this.controllerFor(this.routeName);
-    controller.set('currentlyLoading', true);
-    transition.promise.finally(function () {
-      controller.set('currentlyLoading', false);
-    });
-  }
-
-  @action
   deactivate() {
     // when navigating away from parent route, delete manually inputted license start date
     getStorage().removeItem(INPUTTED_START_DATE);

--- a/ui/app/templates/vault/cluster.hbs
+++ b/ui/app/templates/vault/cluster.hbs
@@ -20,18 +20,15 @@
     </FlashMessage>
   {{/each}}
 </div>
-{{#if this.currentlyLoading}}
-  <LogoSplash />
+
+{{#if this.auth.isActiveSession}}
+  <section class="section">
+    <div class="container is-widescreen">
+      <TokenExpireWarning @expirationDate={{this.auth.tokenExpirationDate}}>
+        {{outlet}}
+      </TokenExpireWarning>
+    </div>
+  </section>
 {{else}}
-  {{#if this.auth.isActiveSession}}
-    <section class="section">
-      <div class="container is-widescreen">
-        <TokenExpireWarning @expirationDate={{this.auth.tokenExpirationDate}}>
-          {{outlet}}
-        </TokenExpireWarning>
-      </div>
-    </section>
-  {{else}}
-    {{outlet}}
-  {{/if}}
+  {{outlet}}
 {{/if}}

--- a/ui/app/templates/vault/cluster/clients.hbs
+++ b/ui/app/templates/vault/cluster/clients.hbs
@@ -20,8 +20,5 @@
     </ul>
   </nav>
 </div>
-{{#if this.currentlyLoading}}
-  <LayoutLoading />
-{{else}}
-  {{outlet}}
-{{/if}}
+
+{{outlet}}

--- a/ui/app/templates/vault/cluster/clients/loading.hbs
+++ b/ui/app/templates/vault/cluster/clients/loading.hbs
@@ -1,0 +1,1 @@
+<LayoutLoading />

--- a/ui/tests/integration/components/sidebar/nav/access-test.js
+++ b/ui/tests/integration/components/sidebar/nav/access-test.js
@@ -44,7 +44,6 @@ module('Integration | Component | sidebar-nav-access', function (hooks) {
       'Multi-factor authentication',
       'OIDC',
       'Control Groups',
-      'Policies',
       'Namespaces',
       'Groups',
       'Entities',

--- a/ui/tests/integration/components/sidebar/nav/cluster-test.js
+++ b/ui/tests/integration/components/sidebar/nav/cluster-test.js
@@ -41,6 +41,7 @@ module('Integration | Component | sidebar-nav-cluster', function (hooks) {
     const links = [
       'Secrets engines',
       'Access',
+      'Policies',
       'Tools',
       'DR Primary',
       'Performance Secondary',

--- a/ui/tests/integration/components/sidebar/nav/policies-test.js
+++ b/ui/tests/integration/components/sidebar/nav/policies-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | sidebar-nav-policies', function (hooks) {
 
   test('it should render nav headings and links', async function (assert) {
     const links = [
-      'Back to access',
+      'Back to main navigation',
       'ACL Policies',
       'Role-Governing Policies',
       'Endpoint Governing Policies',


### PR DESCRIPTION
There were some issues with the sidebar nav animations where the access template was re-rendering each time a child route was navigated to causing the cluster nav to briefly show during the transition. This was caused by the loading event that was handled in the cluster route which was conditionally showing the `LogoSplash` and removing the outlet during the transition. As such the access route would need to render again once the loading event was finished. The loading event handler was removed in favor of using the loading templates, which there were several in place that weren't actually being rendered.

There was also an issue with the animation between the access and policies routes. Since the policies route isn't actually a child of access, the slide animation will not work since it is removed from the dom. Policies have been removed from the access nav and moved to the cluster nav.

![image](https://user-images.githubusercontent.com/24611656/230492649-6957bfa7-ff0c-47cb-815b-e71ec27346ca.png)
