### PR TITLE
Small fixes post var and core file work

### DIFF
--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -144,33 +144,6 @@ $button-box-shadow-standard: 0 3px 1px 0 rgba($black, 0.12);
     min-width: 4rem;
   }
 
-  &.is-outlined {
-    background-color: transparent;
-    border-color: $blue;
-    color: $blue;
-
-    &:hover,
-    &:focus {
-      background-color: transparent;
-      border-color: darken($blue, 10%);
-      color: $blue;
-    }
-
-    &:active,
-    &.is-active {
-      background-color: transparent;
-      border-color: darken($blue, 10%);
-      color: darken($blue, 10%);
-    }
-  }
-
-  &.is-outlined[disabled] {
-    background-color: transparent;
-    border-color: $ui-gray-700;
-    box-shadow: none;
-    color: $ui-gray-700;
-  }
-
   &.is-primary {
     background-color: $blue;
     border-color: darken($blue, 2%);
@@ -208,6 +181,33 @@ $button-box-shadow-standard: 0 3px 1px 0 rgba($black, 0.12);
         border-radius: unset;
         color: darken($blue, 10%);
       }
+    }
+    // is-primary.is-outlined the only is-outlined buttons are primary.
+    &.is-outlined {
+      background-color: transparent;
+      border-color: $blue;
+      color: $blue;
+
+      &:hover,
+      &:focus {
+        background-color: transparent;
+        border-color: darken($blue, 10%);
+        color: $blue;
+      }
+
+      &:active,
+      &.is-active {
+        background-color: transparent;
+        border-color: darken($blue, 10%);
+        color: darken($blue, 10%);
+      }
+    }
+
+    &.is-outlined [disabled] {
+      background-color: transparent;
+      border-color: $ui-gray-700;
+      box-shadow: none;
+      color: $ui-gray-700;
     }
   }
 

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -106,7 +106,6 @@ $button-box-shadow-standard: 0 3px 1px 0 rgba($black, 0.12);
     &:hover {
       color: $blue-500;
       background-color: $grey-lightest;
-      text-decoration: underline;
     }
   }
 

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -45,6 +45,10 @@ $button-box-shadow-standard: 0 3px 1px 0 rgba($black, 0.12);
     color: darken($grey-dark, 10%);
   }
 
+  &:focus:not(:active) {
+    box-shadow: 0 0 0 0.125em rgba(21, 99, 255, 0.25);
+  }
+
   &:disabled {
     background-color: $white;
     border-color: #dbdbdb;

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -7,6 +7,7 @@
 $button-box-shadow-standard: 0 3px 1px 0 rgba($black, 0.12);
 
 .button {
+  align-items: center;
   background-color: $grey-lightest;
   border: 1px solid $grey-light;
   border-radius: $radius;

--- a/ui/app/styles/core/columns.scss
+++ b/ui/app/styles/core/columns.scss
@@ -151,14 +151,7 @@
   width: 25%;
 }
 
-// responsive css column
-@media screen and (min-width: 1024px) {
-  .column.is-4-desktop {
-    flex: none;
-    width: 33.33333%;
-  }
-}
-
+// responsive css column (order matters here because some columns have several of these classes and they need to override in the correct order).
 @media screen and (min-width: 769px), print {
   .column.is-5 {
     flex: none;
@@ -171,6 +164,13 @@
   .column.is-6-tablet {
     flex: none;
     width: 50%;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .column.is-4-desktop {
+    flex: none;
+    width: 33.33333%;
   }
 }
 

--- a/ui/app/styles/core/control.scss
+++ b/ui/app/styles/core/control.scss
@@ -10,6 +10,10 @@
   height: 2.5rem;
 }
 
+.control.has-icons-right .input {
+  padding-right: 2.25em;
+}
+
 .control {
   font-size: 1rem;
   max-width: 100%;

--- a/ui/app/styles/core/field.scss
+++ b/ui/app/styles/core/field.scss
@@ -124,6 +124,13 @@ fieldset.form-fieldset {
     flex-basis: 0;
     flex-grow: 5;
     flex-shrink: 1;
+
+    > .field:not(:last-child) {
+      margin-right: $size-9;
+    }
+    .field:not(.is-narrow) {
+      flex-grow: 1;
+    }
   }
 
   .field-label {

--- a/ui/app/styles/core/field.scss
+++ b/ui/app/styles/core/field.scss
@@ -115,6 +115,17 @@ fieldset.form-fieldset {
 // responsive css
 /* ARG TODO: used is-normal in one place */
 @media screen and (min-width: 769px), print {
+  .field.is-horizontal {
+    display: flex;
+  }
+
+  .field-body {
+    display: flex;
+    flex-basis: 0;
+    flex-grow: 5;
+    flex-shrink: 1;
+  }
+
   .field-label {
     flex-basis: 0;
     flex-grow: 1;

--- a/ui/app/styles/core/inputs.scss
+++ b/ui/app/styles/core/inputs.scss
@@ -7,15 +7,20 @@
 
 .input,
 .textarea {
+  align-items: center;
   border-radius: $radius;
   border: $base-border;
   box-shadow: 0 4px 1px rgba($black, 0.06) inset;
   color: $grey-dark;
+  display: inline-flex;
   font-size: $size-6;
   height: 2.5rem;
+  line-height: 1.5;
   max-width: 100%;
+  padding-bottom: calc(0.375em - 1px);
   padding-left: $size-8;
   padding-right: $size-8;
+  padding-top: calc(0.375em - 1px);
   width: 100%;
 
   &:focus,

--- a/ui/app/styles/core/inputs.scss
+++ b/ui/app/styles/core/inputs.scss
@@ -52,6 +52,11 @@
   }
 }
 
+.textarea:not([rows]) {
+  max-height: 600px;
+  min-height: 120px;
+}
+
 // custom input
 .input-hint {
   padding: 0 $size-9;

--- a/ui/app/styles/core/inputs.scss
+++ b/ui/app/styles/core/inputs.scss
@@ -11,6 +11,7 @@
   border: $base-border;
   box-shadow: 0 4px 1px rgba($black, 0.06) inset;
   color: $grey-dark;
+  font-size: $size-6;
   height: 2.5rem;
   max-width: 100%;
   padding-left: $size-8;

--- a/ui/app/styles/core/label.scss
+++ b/ui/app/styles/core/label.scss
@@ -14,7 +14,7 @@
 .is-label {
   color: $grey-darkest;
   display: inline-block;
-  font-size: $size-8;
+  font-size: 14px;
   font-weight: $font-weight-bold;
 
   &:not(:last-child) {

--- a/ui/app/styles/core/layout.scss
+++ b/ui/app/styles/core/layout.scss
@@ -20,8 +20,7 @@
   display: flex;
   flex-grow: 1;
   flex-direction: column;
-  padding-top: 0;
-  padding-bottom: 0;
+  padding: 0 $size-4;
 
   > .container {
     display: flex;

--- a/ui/app/styles/core/menu.scss
+++ b/ui/app/styles/core/menu.scss
@@ -29,6 +29,5 @@
   &:hover,
   &.is-active {
     color: $blue;
-    background-color: $blue-500;
   }
 }

--- a/ui/app/styles/core/navbar.scss
+++ b/ui/app/styles/core/navbar.scss
@@ -42,7 +42,7 @@
 .navbar-actions {
   background-color: $black;
   display: flex;
-  height: $spacing-xxxl;
+  height: 4rem;
   justify-content: flex-start;
   padding: $spacing-xs $spacing-s $spacing-xs 0;
 }
@@ -294,5 +294,14 @@
 .navbar-drawer .ember-basic-dropdown-content {
   @include until($mobile) {
     position: relative;
+  }
+}
+
+// responsive css
+@media screen and (min-width: 1024px) {
+  .navbar-item,
+  .navbar-link {
+    align-items: center;
+    display: flex;
   }
 }

--- a/ui/app/styles/core/select.scss
+++ b/ui/app/styles/core/select.scss
@@ -46,6 +46,10 @@ select {
   }
 }
 
+.select select:not([multiple]) {
+  padding-right: $size-2;
+}
+
 .select select[disabled] {
   border-color: $grey-light;
   background-color: $ui-gray-100;

--- a/ui/app/styles/core/tag.scss
+++ b/ui/app/styles/core/tag.scss
@@ -11,14 +11,15 @@
   border-radius: $radius;
   color: $grey;
   display: inline-flex;
-  font-size: 0.75rem;
-  font-weight: normal;
+  font-size: $size-8;
+  font-weight: $font-weight-normal;
   height: auto;
   justify-content: center;
   line-height: 1.5;
   margin-right: 0.5rem;
   padding: 0 $size-10;
   white-space: nowrap;
+  vertical-align: middle;
 
   code {
     color: $grey;

--- a/ui/app/styles/helper-classes/flexbox-and-grid.scss
+++ b/ui/app/styles/helper-classes/flexbox-and-grid.scss
@@ -40,8 +40,7 @@
 }
 
 .is-flex-v-centered-tablet {
-  // TODO check if this is from or until
-  @include until($mobile) {
+  @include from($mobile) {
     display: flex;
     align-items: center;
     align-self: center;


### PR DESCRIPTION
I suspected there would be some regression after I did all the var and core file work. There was, and while I have tickets for specifically broken things (that have always been broken on this branch), I wanted to tackle some of these regressions before moving forward.

* splash screen page-container (tested desktop, mobile and tablet)
![image](https://user-images.githubusercontent.com/6618863/230498833-9baa5f3b-b91e-438f-bc9d-6d6706c3bfbf.png)

* fixed `button.is-primary.is-outlined` styles.
![image](https://user-images.githubusercontent.com/6618863/230524625-44210c9f-315a-4c37-9d0b-6029f8f785e8.png)

* fixed some issues on inputs. They now all seem to look good (not the final qa but so far so good).
![image](https://user-images.githubusercontent.com/6618863/230524784-1007f7b5-50af-4559-bf55-f02b375e1b16.png)

* fixed a status menu alignment issue. 
![image](https://user-images.githubusercontent.com/6618863/230524831-2fbc46f5-3270-4d38-baab-5688b0bd778a.png)

* I thought I could get away with a 13.75 px value instead of 14px and that backfired. Fixed on labels.

I know each of these changes won't make a lot of sense at this point because it's nearly impossible to tell from this PR what is bulma and what was original scss. Apologies, but anticipate more PRs like this. Small tweaks and fixes that came about because CSS ordering changed or I missed a line of bulma code. I'll try to include screenshots when I think they'll be helpful.
