### PR TITLE
[QT-517] Skip builds for docs PRs

### DIFF
--- a/.github/scripts/verify_changes.sh
+++ b/.github/scripts/verify_changes.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+event_type=$1
+base_ref=$2
+
+changed_dir=""
+
+if [[ "$1" == "pull_request" ]]; then
+  change_count=$(git diff --merge-base $2 --name-only |xargs dirname |awk -F"/" '{ print $1}' |uniq |wc -l)
+  if [[ $change_count -eq 1 ]]; then
+    changed_dir=$(git diff --merge-base $2 --name-only |xargs dirname |awk -F"/" '{ print $1}' |uniq)
+  fi
+else
+  change_count=$(git show --oneline --dirstat=files,0 |grep "%" |awk '{print $2}' |awk -F"/" '{print $1}' |uniq |wc -l)
+  if [[ $change_count -eq 1 ]]; then
+    changed_dir=$(git show --oneline --dirstat=files,0 |grep "%" |awk '{print $2}' |awk -F"/" '{print $1}' |uniq)
+  fi
+fi
+
+if [[ "$changed_dir" == "website" ]]; then
+  echo "is_docs_change=true" >> "$GITHUB_OUTPUT"
+else
+  echo "is_docs_change=false" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/scripts/verify_changes.sh
+++ b/.github/scripts/verify_changes.sh
@@ -1,20 +1,28 @@
 #!/bin/bash
+#  This script validates if the git diff contains on docs changes
 
-event_type=$1
-base_ref=$2
+event_type=$1 # GH event type (pull_request)
+ref_name=$2 # branch reference that triggered the workflow
+head_ref=$3 # PR branch head ref
+base_ref=$4 # PR branch base ref
 
 changed_dir=""
 
-if [[ "$1" == "pull_request" ]]; then
-  change_count=$(git diff --merge-base $2 --name-only |xargs dirname |awk -F"/" '{ print $1}' |uniq |wc -l)
-  if [[ $change_count -eq 1 ]]; then
-    changed_dir=$(git diff --merge-base $2 --name-only |xargs dirname |awk -F"/" '{ print $1}' |uniq)
-  fi
+if [[ "$event_type" == "pull_request" ]]; then
+  git fetch --no-tags --prune origin $head_ref
+  git fetch --no-tags --prune origin $base_ref
+  head_commit="origin/$head_ref"
+  prev_commit="origin/$base_ref"
 else
-  change_count=$(git show --oneline --dirstat=files,0 |grep "%" |awk '{print $2}' |awk -F"/" '{print $1}' |uniq |wc -l)
-  if [[ $change_count -eq 1 ]]; then
-    changed_dir=$(git show --oneline --dirstat=files,0 |grep "%" |awk '{print $2}' |awk -F"/" '{print $1}' |uniq)
-  fi
+  git fetch --no-tags --prune origin $ref_name
+  head_commit=$(git log origin/$ref_name --oneline | head -1 | awk '{print $1}')
+  prev_commit=$(git log origin/$ref_name --oneline | head -2 | awk 'NR==2 {print $1}')
+fi
+
+change_count=$(git diff $head_commit..$prev_commit --name-only | awk -F"/" '{ print $1}' | uniq | wc -l)
+
+if [[ $change_count -eq 1 ]]; then
+  changed_dir=$(git diff $head_commit..$prev_commit --name-only | awk -F"/" '{ print $1}' | uniq)
 fi
 
 if [[ "$changed_dir" == "website" ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,26 @@ on:
       - release/**
 
 jobs:
-  product-metadata:
+  # verify-changes determines if the changes are only for docs (website)
+  verify-changes:
     runs-on: ubuntu-latest
+    outputs:
+      is_docs_change: ${{ steps.get-changeddir.outputs.is_docs_change }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get changed directories
+        id: get-changeddir
+        env:
+          TYPE: ${{ github.event_name }}
+          BASE: ${{ github.base_ref }}
+        run: ./.github/scripts/verify_changes.sh ${{ env.TYPE }} ${{ env.BASE }}
+  product-metadata:
+    # do not run build and test steps for docs changes
+    # Following https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+    # we conditionally skip the build and tests for docs(website) changes
+    if: ${{ needs.verify-changes.outputs.is_docs_change == 'false' }}
+    runs-on: ubuntu-latest
+    needs: verify-changes
     outputs:
       build-date: ${{ steps.get-metadata.outputs.build-date }}
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,13 +173,6 @@ jobs:
 
   test:
     name: Test ${{ matrix.build-artifact-name }}
-    # Only run the Enos workflow against branches that are created from the
-    # hashicorp/vault repository. This has the effect of limiting execution of
-    # Enos scenarios to branches that originate from authors that have write
-    # access to hashicorp/vault repository. This is required as Github Actions
-    # will not populate the required secrets for branches created by outside
-    # contributors in order to protect the secrets integrity.
-    if: "! github.event.pull_request.head.repo.fork"
     needs:
       - product-metadata
       - build-linux
@@ -203,13 +196,6 @@ jobs:
 
   test-docker-k8s:
     name: Test Docker K8s
-    # Only run the Enos workflow against branches that are created from the
-    # hashicorp/vault repository. This has the effect of limiting execution of
-    # Enos scenarios to branches that originate from authors that have write
-    # access to hashicorp/vault repository. This is required as Github Actions
-    # will not populate the required secrets for branches created by outside
-    # contributors in order to protect the secrets integrity.
-    if: "! github.event.pull_request.head.repo.fork"
     needs:
       - product-metadata
       - build-docker

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,11 @@ jobs:
         id: get-changeddir
         env:
           TYPE: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          HEAD_REF: ${{ github.head_ref }}
           BASE: ${{ github.base_ref }}
-        run: ./.github/scripts/verify_changes.sh ${{ env.TYPE }} ${{ env.BASE }}
+        run: ./.github/scripts/verify_changes.sh ${{ env.TYPE }} ${{ env.REF_NAME }} ${{ env.HEAD_REF }} ${{ env.BASE }}
+
   product-metadata:
     # do not run build and test steps for docs changes
     # Following https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks


### PR DESCRIPTION
Skip builds and Enos tests for docs PRs.  Following https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks we conditionally skip the jobs.