### PR TITLE
Only log stopping rollback manager once

### DIFF
--- a/vault/rollback.go
+++ b/vault/rollback.go
@@ -96,6 +96,12 @@ func (m *RollbackManager) Stop() {
 	m.inflightAll.Wait()
 }
 
+// StopTicker stops the automatic Rollback manager's ticker, causing us
+// to not do automatic rollbacks. This is useful for testing plugin's
+// periodic function's behavior, without trying to race against the
+// rollback manager proper.
+//
+// THIS SHOULD ONLY BE CALLED FROM TEST HELPERS.
 func (m *RollbackManager) StopTicker() {
 	close(m.stopTicker)
 }
@@ -104,6 +110,7 @@ func (m *RollbackManager) StopTicker() {
 func (m *RollbackManager) run() {
 	m.logger.Info("starting rollback manager")
 	tick := time.NewTicker(m.period)
+	logTestStopOnce := false
 	defer tick.Stop()
 	defer close(m.doneCh)
 	for {
@@ -116,7 +123,10 @@ func (m *RollbackManager) run() {
 			return
 
 		case <-m.stopTicker:
-			m.logger.Info("stopping rollback manager ticker for tests")
+			if !logTestStopOnce {
+				m.logger.Info("stopping rollback manager ticker for tests")
+				logTestStopOnce = true
+			}
 			tick.Stop()
 		}
 	}


### PR DESCRIPTION
When testing the Rollback Manager's one-time invocation in Enterprise, it was noticed that due to the channel being closed, we'd always hit this case and thus spam logs rather quickly with this message.

Switch to a boolean flip to log this once, as it is not executed in parallel and thus doesn't need a `sync.Once`.

This only affected anyone calling the test core's `StopAutomaticRollbacks()` helper.

This was introduced in #19748 though the enterprise counterpart had not merged yet. 