### PR TITLE
Clarify error message from forwarded requests

### DIFF
--- a/changelog/20042.txt
+++ b/changelog/20042.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Correctly identify intermediate errors when request forwarding.
+```


### PR DESCRIPTION
When forwarding requests due to an unexpected `ErrReadOnly` with context additional context, it helpful to return this additional context rather than silently omitting it. This should help to clarify the incorrect errors from forwarding in PBPWF.