### PR TITLE
add max_entry_size to sanitized config output

### DIFF
--- a/changelog/20044.txt
+++ b/changelog/20044.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+core: Add a `raft` sub-field to the `storage` and `ha_storage` details provided by the
+`/sys/config/state/sanitized` endpoint in order to include the `max_entry_size`.
+```

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -1133,23 +1133,39 @@ func (c *Config) Sanitized() map[string]interface{} {
 
 	// Sanitize storage stanza
 	if c.Storage != nil {
+		storageType := c.Storage.Type
 		sanitizedStorage := map[string]interface{}{
-			"type":               c.Storage.Type,
+			"type":               storageType,
 			"redirect_addr":      c.Storage.RedirectAddr,
 			"cluster_addr":       c.Storage.ClusterAddr,
 			"disable_clustering": c.Storage.DisableClustering,
 		}
+
+		if storageType == "raft" {
+			sanitizedStorage["raft"] = map[string]interface{}{
+				"max_entry_size": c.Storage.Config["max_entry_size"],
+			}
+		}
+
 		result["storage"] = sanitizedStorage
 	}
 
 	// Sanitize HA storage stanza
 	if c.HAStorage != nil {
+		haStorageType := c.HAStorage.Type
 		sanitizedHAStorage := map[string]interface{}{
-			"type":               c.HAStorage.Type,
+			"type":               haStorageType,
 			"redirect_addr":      c.HAStorage.RedirectAddr,
 			"cluster_addr":       c.HAStorage.ClusterAddr,
 			"disable_clustering": c.HAStorage.DisableClustering,
 		}
+
+		if haStorageType == "raft" {
+			sanitizedHAStorage["raft"] = map[string]interface{}{
+				"max_entry_size": c.HAStorage.Config["max_entry_size"],
+			}
+		}
+
 		result["ha_storage"] = sanitizedHAStorage
 	}
 

--- a/http/sys_config_state_test.go
+++ b/http/sys_config_state_test.go
@@ -9,70 +9,174 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/hashicorp/vault/command/server"
+	"github.com/hashicorp/vault/internalshared/configutil"
 	"github.com/hashicorp/vault/vault"
 )
 
 func TestSysConfigState_Sanitized(t *testing.T) {
-	var resp *http.Response
-
-	core, _, token := vault.TestCoreUnsealed(t)
-	ln, addr := TestServer(t, core)
-	defer ln.Close()
-	TestServerAuth(t, addr, token)
-
-	resp = testHttpGet(t, token, addr+"/v1/sys/config/state/sanitized")
-	testResponseStatus(t, resp, 200)
-
-	var actual map[string]interface{}
-	var expected map[string]interface{}
-
-	configResp := map[string]interface{}{
-		"api_addr":                            "",
-		"cache_size":                          json.Number("0"),
-		"cluster_addr":                        "",
-		"cluster_cipher_suites":               "",
-		"cluster_name":                        "",
-		"default_lease_ttl":                   json.Number("0"),
-		"default_max_request_duration":        json.Number("0"),
-		"disable_cache":                       false,
-		"disable_clustering":                  false,
-		"disable_indexing":                    false,
-		"disable_mlock":                       false,
-		"disable_performance_standby":         false,
-		"disable_printable_check":             false,
-		"disable_sealwrap":                    false,
-		"experiments":                         nil,
-		"raw_storage_endpoint":                false,
-		"detect_deadlocks":                    "",
-		"introspection_endpoint":              false,
-		"disable_sentinel_trace":              false,
-		"enable_ui":                           false,
-		"log_format":                          "",
-		"log_level":                           "",
-		"max_lease_ttl":                       json.Number("0"),
-		"pid_file":                            "",
-		"plugin_directory":                    "",
-		"plugin_file_uid":                     json.Number("0"),
-		"plugin_file_permissions":             json.Number("0"),
-		"enable_response_header_hostname":     false,
-		"enable_response_header_raft_node_id": false,
-		"log_requests_level":                  "",
+	cases := []struct {
+		name                    string
+		storageConfig           *server.Storage
+		haStorageConfig         *server.Storage
+		expectedStorageOutput   map[string]interface{}
+		expectedHAStorageOutput map[string]interface{}
+	}{
+		{
+			"raft storage",
+			&server.Storage{
+				Type:              "raft",
+				RedirectAddr:      "http://127.0.0.1:8200",
+				ClusterAddr:       "http://127.0.0.1:8201",
+				DisableClustering: false,
+				Config: map[string]string{
+					"path":           "/storage/path/raft",
+					"node_id":        "raft1",
+					"max_entry_size": "2097152",
+				},
+			},
+			nil,
+			map[string]interface{}{
+				"type":               "raft",
+				"redirect_addr":      "http://127.0.0.1:8200",
+				"cluster_addr":       "http://127.0.0.1:8201",
+				"disable_clustering": false,
+				"raft": map[string]interface{}{
+					"max_entry_size": "2097152",
+				},
+			},
+			nil,
+		},
+		{
+			"inmem storage, raft HA storage",
+			&server.Storage{
+				Type:              "inmem",
+				RedirectAddr:      "http://127.0.0.1:8200",
+				ClusterAddr:       "http://127.0.0.1:8201",
+				DisableClustering: false,
+			},
+			&server.Storage{
+				Type:              "raft",
+				RedirectAddr:      "http://127.0.0.1:8200",
+				ClusterAddr:       "http://127.0.0.1:8201",
+				DisableClustering: false,
+				Config: map[string]string{
+					"path":           "/storage/path/raft",
+					"node_id":        "raft1",
+					"max_entry_size": "2097152",
+				},
+			},
+			map[string]interface{}{
+				"type":               "inmem",
+				"redirect_addr":      "http://127.0.0.1:8200",
+				"cluster_addr":       "http://127.0.0.1:8201",
+				"disable_clustering": false,
+			},
+			map[string]interface{}{
+				"type":               "raft",
+				"redirect_addr":      "http://127.0.0.1:8200",
+				"cluster_addr":       "http://127.0.0.1:8201",
+				"disable_clustering": false,
+				"raft": map[string]interface{}{
+					"max_entry_size": "2097152",
+				},
+			},
+		},
 	}
 
-	expected = map[string]interface{}{
-		"lease_id":       "",
-		"renewable":      false,
-		"lease_duration": json.Number("0"),
-		"wrap_info":      nil,
-		"warnings":       nil,
-		"auth":           nil,
-		"data":           configResp,
-	}
+	for _, tc := range cases {
+		tc := tc
 
-	testResponseBody(t, resp, &actual)
-	expected["request_id"] = actual["request_id"]
+		t.Run(tc.name, func(t *testing.T) {
+			var resp *http.Response
+			confRaw := &server.Config{
+				Storage:   tc.storageConfig,
+				HAStorage: tc.haStorageConfig,
+				SharedConfig: &configutil.SharedConfig{
+					Listeners: []*configutil.Listener{
+						{
+							Type:    "tcp",
+							Address: "127.0.0.1",
+						},
+					},
+				},
+			}
 
-	if diff := deep.Equal(actual, expected); len(diff) > 0 {
-		t.Fatalf("bad mismatch response body: diff: %v", diff)
+			conf := &vault.CoreConfig{
+				RawConfig: confRaw,
+			}
+
+			core, _, token := vault.TestCoreUnsealedWithConfig(t, conf)
+			ln, addr := TestServer(t, core)
+			defer ln.Close()
+			TestServerAuth(t, addr, token)
+
+			resp = testHttpGet(t, token, addr+"/v1/sys/config/state/sanitized")
+			testResponseStatus(t, resp, 200)
+
+			var actual map[string]interface{}
+			var expected map[string]interface{}
+
+			configResp := map[string]interface{}{
+				"api_addr":                            "",
+				"cache_size":                          json.Number("0"),
+				"cluster_addr":                        "",
+				"cluster_cipher_suites":               "",
+				"cluster_name":                        "",
+				"default_lease_ttl":                   json.Number("0"),
+				"default_max_request_duration":        json.Number("0"),
+				"disable_cache":                       false,
+				"disable_clustering":                  false,
+				"disable_indexing":                    false,
+				"disable_mlock":                       false,
+				"disable_performance_standby":         false,
+				"disable_printable_check":             false,
+				"disable_sealwrap":                    false,
+				"experiments":                         nil,
+				"raw_storage_endpoint":                false,
+				"detect_deadlocks":                    "",
+				"introspection_endpoint":              false,
+				"disable_sentinel_trace":              false,
+				"enable_ui":                           false,
+				"log_format":                          "",
+				"log_level":                           "",
+				"max_lease_ttl":                       json.Number("0"),
+				"pid_file":                            "",
+				"plugin_directory":                    "",
+				"plugin_file_uid":                     json.Number("0"),
+				"plugin_file_permissions":             json.Number("0"),
+				"enable_response_header_hostname":     false,
+				"enable_response_header_raft_node_id": false,
+				"log_requests_level":                  "",
+				"listeners": []interface{}{
+					map[string]interface{}{
+						"config": nil,
+						"type":   "tcp",
+					},
+				},
+				"storage": tc.expectedStorageOutput,
+			}
+
+			if tc.expectedHAStorageOutput != nil {
+				configResp["ha_storage"] = tc.expectedHAStorageOutput
+			}
+
+			expected = map[string]interface{}{
+				"lease_id":       "",
+				"renewable":      false,
+				"lease_duration": json.Number("0"),
+				"wrap_info":      nil,
+				"warnings":       nil,
+				"auth":           nil,
+				"data":           configResp,
+			}
+
+			testResponseBody(t, resp, &actual)
+			expected["request_id"] = actual["request_id"]
+
+			if diff := deep.Equal(actual, expected); len(diff) > 0 {
+				t.Fatalf("bad mismatch response body: diff: %v", diff)
+			}
+		})
 	}
 }

--- a/http/sys_config_state_test.go
+++ b/http/sys_config_state_test.go
@@ -88,6 +88,8 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			var resp *http.Response
 			confRaw := &server.Config{
 				Storage:   tc.storageConfig,

--- a/http/sys_config_state_test.go
+++ b/http/sys_config_state_test.go
@@ -48,6 +48,23 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 			nil,
 		},
 		{
+			"inmem storage, no HA storage",
+			&server.Storage{
+				Type:              "inmem",
+				RedirectAddr:      "http://127.0.0.1:8200",
+				ClusterAddr:       "http://127.0.0.1:8201",
+				DisableClustering: false,
+			},
+			nil,
+			map[string]interface{}{
+				"type":               "inmem",
+				"redirect_addr":      "http://127.0.0.1:8200",
+				"cluster_addr":       "http://127.0.0.1:8201",
+				"disable_clustering": false,
+			},
+			nil,
+		},
+		{
 			"inmem storage, raft HA storage",
 			&server.Storage{
 				Type:              "inmem",

--- a/http/sys_config_state_test.go
+++ b/http/sys_config_state_test.go
@@ -23,8 +23,8 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 		expectedHAStorageOutput map[string]interface{}
 	}{
 		{
-			"raft storage",
-			&server.Storage{
+			name: "raft storage",
+			storageConfig: &server.Storage{
 				Type:              "raft",
 				RedirectAddr:      "http://127.0.0.1:8200",
 				ClusterAddr:       "http://127.0.0.1:8201",
@@ -35,8 +35,8 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 					"max_entry_size": "2097152",
 				},
 			},
-			nil,
-			map[string]interface{}{
+			haStorageConfig: nil,
+			expectedStorageOutput: map[string]interface{}{
 				"type":               "raft",
 				"redirect_addr":      "http://127.0.0.1:8200",
 				"cluster_addr":       "http://127.0.0.1:8201",
@@ -45,34 +45,34 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 					"max_entry_size": "2097152",
 				},
 			},
-			nil,
+			expectedHAStorageOutput: nil,
 		},
 		{
-			"inmem storage, no HA storage",
-			&server.Storage{
+			name: "inmem storage, no HA storage",
+			storageConfig: &server.Storage{
 				Type:              "inmem",
 				RedirectAddr:      "http://127.0.0.1:8200",
 				ClusterAddr:       "http://127.0.0.1:8201",
 				DisableClustering: false,
 			},
-			nil,
-			map[string]interface{}{
+			haStorageConfig: nil,
+			expectedStorageOutput: map[string]interface{}{
 				"type":               "inmem",
 				"redirect_addr":      "http://127.0.0.1:8200",
 				"cluster_addr":       "http://127.0.0.1:8201",
 				"disable_clustering": false,
 			},
-			nil,
+			expectedHAStorageOutput: nil,
 		},
 		{
-			"inmem storage, raft HA storage",
-			&server.Storage{
+			name: "inmem storage, raft HA storage",
+			storageConfig: &server.Storage{
 				Type:              "inmem",
 				RedirectAddr:      "http://127.0.0.1:8200",
 				ClusterAddr:       "http://127.0.0.1:8201",
 				DisableClustering: false,
 			},
-			&server.Storage{
+			haStorageConfig: &server.Storage{
 				Type:              "raft",
 				RedirectAddr:      "http://127.0.0.1:8200",
 				ClusterAddr:       "http://127.0.0.1:8201",
@@ -83,13 +83,13 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 					"max_entry_size": "2097152",
 				},
 			},
-			map[string]interface{}{
+			expectedStorageOutput: map[string]interface{}{
 				"type":               "inmem",
 				"redirect_addr":      "http://127.0.0.1:8200",
 				"cluster_addr":       "http://127.0.0.1:8201",
 				"disable_clustering": false,
 			},
-			map[string]interface{}{
+			expectedHAStorageOutput: map[string]interface{}{
 				"type":               "raft",
 				"redirect_addr":      "http://127.0.0.1:8200",
 				"cluster_addr":       "http://127.0.0.1:8201",


### PR DESCRIPTION
This PR adds a `raft` sub-field to the [sanitized config](https://developer.hashicorp.com/vault/api-docs/system/config-state#get-sanitized-configuration-state) storage and HA storage details in order to expose Raft's [max_entry_size](https://developer.hashicorp.com/vault/docs/configuration/storage/raft#max_entry_size).