### PR TITLE
[Docs] Update the KV v2 API docs 

### DIFF
--- a/website/content/api-docs/secret/kv/kv-v2.mdx
+++ b/website/content/api-docs/secret/kv/kv-v2.mdx
@@ -469,7 +469,7 @@ numbers from the key-value store.
 
 | Method | Path                                |
 |:-------|:------------------------------------|
-| `POST` | `/:secret-mount-path/destroy/:path` |
+| `PUT`  | `/:secret-mount-path/destroy/:path` |
 
 ### Parameters
 
@@ -495,7 +495,7 @@ numbers from the key-value store.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request POST \
+    --request PUT \
     --data @payload.json \
     https://127.0.0.1:8200/v1/secret/destroy/my-secret
 ```


### PR DESCRIPTION

🔍 [Deploy preview](https://vault-git-docs-update-kv-destroy-doc-hashicorp.vercel.app/vault/api-docs/secret/kv/kv-v2#destroy-secret-versions)

This PR fixes an issue reported by https://hashicorp.atlassian.net/browse/VAULT-15124

**Summary:**
The `-output-curl-string` command returns `PUT` as the HTTP verb, but the API doc uses `POST`. Since it works either `PUT` or `POST`, updates the doc for consistency.