### PR TITLE
Log, don't err, on unified delta WAL write failure

### DIFF
--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -996,7 +996,7 @@ func revokeCert(sc *storageContext, config *crlConfig, cert *x509.Certificate) (
 		if ignoreErr != nil {
 			// Just log the error if we fail to write across clusters, a separate background
 			// thread will reattempt it later on as we have the local write done.
-			sc.Backend.Logger().Debug("Failed to write unified revocation entry, will re-attempt later",
+			sc.Backend.Logger().Error("Failed to write unified revocation entry, will re-attempt later",
 				"serial_number", colonSerial, "error", ignoreErr)
 			sc.Backend.unifiedTransferStatus.forceRun()
 		}
@@ -1046,8 +1046,12 @@ func writeRevocationDeltaWALs(sc *storageContext, config *crlConfig, hyphenSeria
 		// listing for the unified CRL rebuild, this revocation will not
 		// appear on either the main or the next delta CRL, but will need to
 		// wait for a subsequent complete CRL rebuild).
-		if err := writeSpecificRevocationDeltaWALs(sc, hyphenSerial, colonSerial, unifiedDeltaWALPath); err != nil {
-			return fmt.Errorf("failed to write cross-cluster delta WAL entry: %w", err)
+		if ignoredErr := writeSpecificRevocationDeltaWALs(sc, hyphenSerial, colonSerial, unifiedDeltaWALPath); ignoredErr != nil {
+			// Just log the error if we fail to write across clusters, a separate background
+			// thread will reattempt it later on as we have the local write done.
+			sc.Backend.Logger().Error("Failed to write cross-cluster delta WAL entry, will re-attempt later",
+				"serial_number", colonSerial, "error", ignoredErr)
+			sc.Backend.unifiedTransferStatus.forceRun()
 		}
 	}
 

--- a/changelog/20057.txt
+++ b/changelog/20057.txt
@@ -1,0 +1,3 @@
+```release-note: bug
+secrets/pki: Ensure cross-cluster delta WAL write failure only logs to avoid unattended forwarding.
+```


### PR DESCRIPTION
When the PBPWF fails on the Active node of a PR Secondary cluster with a read-only failure, there is no value in forwarding this request up to the Active node of the PR Primary cluster: it does not have the local revocation context necessary to write a Delta WAL entry for this request, and would likely end up writing a cross-cluster revocation entry (if it is enabled) or else erring completely.

Instead, log this error like we do when failing to write unified CRL entries. Switch both to using Error instead of Debug for this type of failure.