### PR TITLE
Fix building unified delta WAL, unified delta CRLs

### DIFF
--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -1317,7 +1317,7 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) error {
 }
 
 func getLastWALSerial(sc *storageContext, path string) (string, error) {
-	lastWALEntry, err := sc.Storage.Get(sc.Context, localDeltaWALLastRevokedSerial)
+	lastWALEntry, err := sc.Storage.Get(sc.Context, path)
 	if err != nil {
 		return "", err
 	}

--- a/builtin/logical/pki/periodic.go
+++ b/builtin/logical/pki/periodic.go
@@ -132,7 +132,7 @@ func doUnifiedTransferMissingLocalSerials(sc *storageContext, clusterId string) 
 			err := readRevocationEntryAndTransfer(sc, serialNum)
 			if err != nil {
 				errCount++
-				sc.Backend.Logger().Debug("Failed transferring local revocation to unified space",
+				sc.Backend.Logger().Error("Failed transferring local revocation to unified space",
 					"serial", serialNum, "error", err)
 			}
 		}

--- a/builtin/logical/pki/periodic.go
+++ b/builtin/logical/pki/periodic.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/sdk/helper/consts"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 const (
@@ -90,7 +91,16 @@ func runUnifiedTransfer(sc *storageContext) {
 	if err != nil {
 		b.Logger().Error("an error occurred running unified transfer", "error", err.Error())
 		status.forceRerun.Store(true)
+	} else {
+		if config.EnableDelta {
+			err = doUnifiedTransferMissingDeltaWALSerials(sc, clusterId)
+			if err != nil {
+				b.Logger().Error("an error occurred running unified transfer", "error", err.Error())
+				status.forceRerun.Store(true)
+			}
+		}
 	}
+
 	status.lastRun = time.Now()
 }
 
@@ -130,6 +140,152 @@ func doUnifiedTransferMissingLocalSerials(sc *storageContext, clusterId string) 
 
 	if errCount > 0 {
 		sc.Backend.Logger().Warn(fmt.Sprintf("Failed transfering %d local serials to unified storage", errCount))
+	}
+
+	return nil
+}
+
+func doUnifiedTransferMissingDeltaWALSerials(sc *storageContext, clusterId string) error {
+	// We need to do a similar thing for Delta WAL entry certificates.
+	// When the delta WAL failed to write for one or more entries,
+	// we'll need to replicate these up to the primary cluster. When it
+	// has performed a new delta WAL build, it will empty storage and
+	// update to a last written WAL entry that exceeds what we've seen
+	// locally.
+	thisUnifiedWALEntryPath := unifiedDeltaWALPath + deltaWALLastRevokedSerialName
+	lastUnifiedWALEntry, err := getLastWALSerial(sc, thisUnifiedWALEntryPath)
+	if err != nil {
+		return fmt.Errorf("failed to fetch last cross-cluster unified revoked delta WAL serial number: %w", err)
+	}
+
+	lastLocalWALEntry, err := getLastWALSerial(sc, localDeltaWALLastRevokedSerial)
+	if err != nil {
+		return fmt.Errorf("failed to fetch last locally revoked delta WAL serial number: %w", err)
+	}
+
+	// We now need to transfer all the entries and then write the last WAL
+	// entry at the end. Start by listing all certificates; any missing
+	// certificates will be copied over and then the WAL entry will be
+	// updated once.
+	//
+	// We do not delete entries either locally or remotely, as either
+	// cluster could've rebuilt delta CRLs with out-of-sync information,
+	// removing some entries (and, we cannot differentiate between these
+	// two cases). On next full CRL rebuild (on either cluster), the state
+	// should get synchronized, and future delta CRLs after this function
+	// returns without issue will see the remaining entries.
+	//
+	// Lastly, we need to ensure we don't accidentally write any unified
+	// delta WAL entries that aren't present in the main cross-cluster
+	// revoked storage location. This would mean the above function failed
+	// to copy them for some reason, despite them presumably appearing
+	// locally.
+	_unifiedWALEntries, err := sc.Storage.List(sc.Context, unifiedDeltaWALPath)
+	if err != nil {
+		return fmt.Errorf("failed to list cross-cluster unified delta WAL storage: %w", err)
+	}
+	unifiedWALEntries := sliceToMapKey(_unifiedWALEntries)
+
+	_unifiedRevokedSerials, err := listClusterSpecificUnifiedRevokedCerts(sc, clusterId)
+	if err != nil {
+		return fmt.Errorf("failed to list cross-cluster revoked certificates: %w", err)
+	}
+	unifiedRevokedSerials := sliceToMapKey(_unifiedRevokedSerials)
+
+	localWALEntries, err := sc.Storage.List(sc.Context, localDeltaWALPath)
+	if err != nil {
+		return fmt.Errorf("failed to list local delta WAL storage: %w", err)
+	}
+
+	if lastUnifiedWALEntry == lastLocalWALEntry && len(_unifiedWALEntries) == len(localWALEntries) {
+		// Writing the last revoked WAL entry is the last thing that we do.
+		// Because these entries match (across clusters) and we have the same
+		// number of entries, assume we don't have anything to sync and exit
+		// early.
+		//
+		// We need both checks as, in the event of PBPWF failing and then
+		// returning while more revocations are happening, we could have
+		// been schedule to run, but then skip running (if only the first
+		// condition was checked) because a later revocation succeeded
+		// in writing a unified WAL entry, before we started replicating
+		// the rest back up.
+		//
+		// The downside of this approach is that, if the main cluster
+		// does a full rebuild in the mean time, we could re-sync more
+		// entries back up to the primary cluster that are already
+		// included in the complete CRL. Users can manually rebuild the
+		// full CRL (clearing these duplicate delta CRL entries) if this
+		// affects them.
+		return nil
+	}
+
+	errCount := 0
+	for index, serial := range localWALEntries {
+		if index%25 == 0 {
+			config, _ := sc.Backend.crlBuilder.getConfigWithUpdate(sc)
+			if config != nil && (!config.UnifiedCRL || !config.EnableDelta) {
+				return errors.New("unified or delta CRLs have been disabled after we started, stopping")
+			}
+		}
+
+		if serial == deltaWALLastBuildSerialName || serial == deltaWALLastRevokedSerialName {
+			// Skip our special serial numbers.
+			continue
+		}
+
+		_, isAlreadyPresent := unifiedWALEntries[serial]
+		if isAlreadyPresent {
+			// Serial exists on both local and unified cluster. We're
+			// presuming we don't need to read and re-write these entries
+			// and that only missing entries need to be updated.
+			continue
+		}
+
+		_, isRevokedCopied := unifiedRevokedSerials[serial]
+		if !isRevokedCopied {
+			// We need to wait here to copy over.
+			errCount += 1
+			sc.Backend.Logger().Debug("Delta WAL exists locally, but corresponding cross-cluster full revocation entry is missing; skipping", "serial", serial)
+			continue
+		}
+
+		// All good: read the local entry and write to the remote variant.
+		localPath := localDeltaWALPath + serial
+		unifiedPath := unifiedDeltaWALPath + serial
+
+		entry, err := sc.Storage.Get(sc.Context, localPath)
+		if err != nil || entry == nil {
+			errCount += 1
+			sc.Backend.Logger().Error("Failed reading local delta WAL entry to copy to cross-cluster", "serial", serial, "err", err)
+			continue
+		}
+
+		entry.Key = unifiedPath
+		err = sc.Storage.Put(sc.Context, entry)
+		if err != nil {
+			errCount += 1
+			sc.Backend.Logger().Error("Failed sync local delta WAL entry to cross-cluster unified delta WAL location", "serial", serial, "err", err)
+			continue
+		}
+	}
+
+	if errCount > 0 {
+		// See note above about why we don't fail here.
+		sc.Backend.Logger().Warn(fmt.Sprintf("Failed transfering %d local delta WAL serials to unified storage", errCount))
+		return nil
+	}
+
+	// Everything worked. Here, we can write over the delta WAL last revoked
+	// value. By using the earlier value, even if new revocations have
+	// occurred, we ensure any further missing entries can be handled in the
+	// next round.
+	lastRevSerial := lastWALInfo{Serial: lastLocalWALEntry}
+	lastWALEntry, err := logical.StorageEntryJSON(thisUnifiedWALEntryPath, lastRevSerial)
+	if err != nil {
+		return fmt.Errorf("unable to create cross-cluster unified last delta CRL WAL entry: %w", err)
+	}
+	if err = sc.Storage.Put(sc.Context, lastWALEntry); err != nil {
+		return fmt.Errorf("error saving cross-cluster unified last delta CRL WAL entry: %w", err)
 	}
 
 	return nil

--- a/changelog/20058.txt
+++ b/changelog/20058.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Fix building of unified delta CRLs and recovery during unified delta WAL write failures.
+```


### PR DESCRIPTION
Built on top of #20057; will be rebased once that merges.

---

Perhaps best to review this commit by commit as it should make most sense that way. If short summaries are nice:

 1. We only considered certificates from the current primary cluster when building the unified delta CRL.
 2. We only considered last-revoked serials from the current primary cluster when deciding to build the unified delta CRL.
 3. We only wrote out last-revoked serials to the current primary cluster's last-built entry, meaning if 2 wasn't also a bug, we could potentially rebuild more frequently than necessary (without new revocations).
 4. When doing the build, the last read serial wasn't the current primary cluster's cross-cluster last revoked serial, but instead its local delta WAL last revoked serial. These entries were effectively the same (since the cross-cluster storage writer for the primary cluster should've just been a local write), so this only mattered post 2 being fixed.
 5. Given that there were PBPWF failures in the writer, and given the change in #20057, we need logic similar to the existing full revocation entries for copying delta WAL entries cross-cluster if PBPWF write failed for some reason.
 6. Cleanup commit to switch a log to an error message.
 7. Add warnings to the revocation handler when PBPWF writing fails.
 8. Only attempt writing the unified delta WAL entry if the full entry succeeded. 

But due to an obvious failure in the PBPWF writer, we weren't going to see any of these bugs.