### PR TITLE
Make config load consistent with config write

### DIFF
--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -1313,9 +1313,10 @@ func (sc *storageContext) getRevocationConfig() (*crlConfig, error) {
 		result.Expiry = defaultCrlConfig.Expiry
 	}
 
-	if !constants.IsEnterprise && (result.UnifiedCRLOnExistingPaths || result.UnifiedCRL || result.UseGlobalQueue) {
+	isLocalMount := sc.Backend.System().LocalMount()
+	if (!constants.IsEnterprise || isLocalMount) && (result.UnifiedCRLOnExistingPaths || result.UnifiedCRL || result.UseGlobalQueue) {
 		// An end user must have had Enterprise, enabled the unified config args and then downgraded to OSS.
-		sc.Backend.Logger().Warn("Not running Vault Enterprise, " +
+		sc.Backend.Logger().Warn("Not running Vault Enterprise or using a local mount, " +
 			"disabling unified_crl, unified_crl_on_existing_paths and cross_cluster_revocation config flags.")
 		result.UnifiedCRLOnExistingPaths = false
 		result.UnifiedCRL = false


### PR DESCRIPTION
When reading the config, we attempt to detect if the running Vault instance has been changed from its Enterprise status on write. Similarly, we should detect if the mount is a local mount instead. While this isn't changeable at runtime, using sys/raw to side-load an invalid config could be possible.