### PR TITLE
UI: fix browser console formatting

### DIFF
--- a/changelog/20064.txt
+++ b/changelog/20064.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes browser console formatting for help command output
+```

--- a/ui/.template-lintrc.js
+++ b/ui/.template-lintrc.js
@@ -47,7 +47,7 @@ module.exports = {
     },
     'require-input-label': 'off',
   },
-  ignore: ['lib/story-md', 'tests/**'],
+  ignore: ['lib/story-md', 'tests/**', 'console/*'],
   // ember language server vscode extension does not currently respect the ignore field
   // override all rules manually as workaround to align with cli
   overrides: [

--- a/ui/.template-lintrc.js
+++ b/ui/.template-lintrc.js
@@ -47,7 +47,7 @@ module.exports = {
     },
     'require-input-label': 'off',
   },
-  ignore: ['tests/**', 'app/templates/components/console/*'],
+  ignore: ['lib/story-md', 'tests/**', 'app/templates/components/console/*'],
   // ember language server vscode extension does not currently respect the ignore field
   // override all rules manually as workaround to align with cli
   overrides: [

--- a/ui/.template-lintrc.js
+++ b/ui/.template-lintrc.js
@@ -47,7 +47,7 @@ module.exports = {
     },
     'require-input-label': 'off',
   },
-  ignore: ['lib/story-md', 'tests/**', 'console/*'],
+  ignore: ['lib/story-md', 'tests/**', 'app/templates/components/console/*'],
   // ember language server vscode extension does not currently respect the ignore field
   // override all rules manually as workaround to align with cli
   overrides: [

--- a/ui/.template-lintrc.js
+++ b/ui/.template-lintrc.js
@@ -47,7 +47,7 @@ module.exports = {
     },
     'require-input-label': 'off',
   },
-  ignore: ['lib/story-md', 'tests/**', 'app/templates/components/console/*'],
+  ignore: ['tests/**', 'app/templates/components/console/*'],
   // ember language server vscode extension does not currently respect the ignore field
   // override all rules manually as workaround to align with cli
   overrides: [

--- a/ui/app/templates/components/console/log-command.hbs
+++ b/ui/app/templates/components/console/log-command.hbs
@@ -1,2 +1,2 @@
 {{! using Icon here instead of Chevron because two nested tagless components results in a rendered line break between the tags breaking the layout in the <pre> }}
-<pre class="console-ui-command"><Icon @name="chevron-right" />{{@content}}</pre>
+<p class="console-ui-command is-font-mono"><Icon @name="chevron-right" />{{@content}}</p>

--- a/ui/app/templates/components/console/log-help.hbs
+++ b/ui/app/templates/components/console/log-help.hbs
@@ -1,3 +1,4 @@
+{{! template-lint-disable }}
 <div class="console-ui-alert has-text-grey">
   <Icon @name="info" />
   <pre>Usage: vault &lt;command&gt; [args] Commands: read Read data and retrieves secrets write Write data, configuration,

--- a/ui/app/templates/components/console/log-help.hbs
+++ b/ui/app/templates/components/console/log-help.hbs
@@ -1,6 +1,7 @@
-{{! template-lint-disable }}
+{{! template-lint-disable  }}
 <div class="console-ui-alert has-text-grey">
   <Icon @name="info" />
+  {{! template-lint-disable no-whitespace-for-layout }}
   <pre>Usage: vault &lt;command&gt; [args] Commands: read Read data and retrieves secrets write Write data, configuration,
     and secrets delete Delete secrets and configuration list List data or secrets Web CLI Commands: api Navigate to the Vault
     API explorer. Use 'api [filter]' to prefilter the list. clear Clear output from the log clearall Clear output and command

--- a/ui/app/templates/components/console/log-help.hbs
+++ b/ui/app/templates/components/console/log-help.hbs
@@ -1,10 +1,20 @@
-{{! template-lint-disable  }}
+{{!-- template-lint-disable  --}}
 <div class="console-ui-alert has-text-grey">
-  <Icon @name="info" />
-  {{! template-lint-disable no-whitespace-for-layout }}
-  <pre>Usage: vault &lt;command&gt; [args] Commands: read Read data and retrieves secrets write Write data, configuration,
-    and secrets delete Delete secrets and configuration list List data or secrets Web CLI Commands: api Navigate to the Vault
-    API explorer. Use 'api [filter]' to prefilter the list. clear Clear output from the log clearall Clear output and command
-    history fullscreen Toggle fullscreen display refresh Refresh the data on the current screen under the CLI window
-  </pre>
+<Icon @name="info" />
+{{!-- template-lint-disable no-whitespace-for-layout --}}
+<pre>Usage: vault &lt;command&gt; [args]
+
+Commands:
+  read        Read data and retrieves secrets
+  write       Write data, configuration, and secrets
+  delete      Delete secrets and configuration
+  list        List data or secrets
+
+Web CLI Commands:
+  api         Navigate to the Vault API explorer. Use 'api [filter]' to prefilter the list.
+  clear       Clear output from the log
+  clearall    Clear output and command history
+  fullscreen  Toggle fullscreen display
+  refresh     Refresh the data on the current screen under the CLI window
+</pre>
 </div>

--- a/ui/app/templates/components/console/log-help.hbs
+++ b/ui/app/templates/components/console/log-help.hbs
@@ -1,20 +1,9 @@
-{{!-- template-lint-disable  --}}
+{{! template-lint-disable no-whitespace-for-layout }}
 <div class="console-ui-alert has-text-grey">
-<Icon @name="info" />
-{{!-- template-lint-disable no-whitespace-for-layout --}}
-<pre>Usage: vault &lt;command&gt; [args]
-
-Commands:
-  read        Read data and retrieves secrets
-  write       Write data, configuration, and secrets
-  delete      Delete secrets and configuration
-  list        List data or secrets
-
-Web CLI Commands:
-  api         Navigate to the Vault API explorer. Use 'api [filter]' to prefilter the list.
-  clear       Clear output from the log
-  clearall    Clear output and command history
-  fullscreen  Toggle fullscreen display
-  refresh     Refresh the data on the current screen under the CLI window
-</pre>
+  <Icon @name="info" />
+  <pre>Usage: vault &lt;command&gt; [args] Commands: read Read data and retrieves secrets write Write data, configuration,
+    and secrets delete Delete secrets and configuration list List data or secrets Web CLI Commands: api Navigate to the Vault
+    API explorer. Use 'api [filter]' to prefilter the list. clear Clear output from the log clearall Clear output and command
+    history fullscreen Toggle fullscreen display refresh Refresh the data on the current screen under the CLI window
+  </pre>
 </div>

--- a/ui/app/templates/components/console/log-help.hbs
+++ b/ui/app/templates/components/console/log-help.hbs
@@ -1,4 +1,4 @@
-{{! template-lint-disable no-whitespace-for-layout }}
+{{! template-lint-disable }}
 <div class="console-ui-alert has-text-grey">
   <Icon @name="info" />
   <pre>Usage: vault &lt;command&gt; [args] Commands: read Read data and retrieves secrets write Write data, configuration,

--- a/ui/app/templates/components/console/log-help.hbs
+++ b/ui/app/templates/components/console/log-help.hbs
@@ -1,9 +1,19 @@
-{{! template-lint-disable }}
+{{!-- template-lint-disable  --}}
 <div class="console-ui-alert has-text-grey">
-  <Icon @name="info" />
-  <pre>Usage: vault &lt;command&gt; [args] Commands: read Read data and retrieves secrets write Write data, configuration,
-    and secrets delete Delete secrets and configuration list List data or secrets Web CLI Commands: api Navigate to the Vault
-    API explorer. Use 'api [filter]' to prefilter the list. clear Clear output from the log clearall Clear output and command
-    history fullscreen Toggle fullscreen display refresh Refresh the data on the current screen under the CLI window
-  </pre>
+<Icon @name="info" />
+<pre>Usage: vault &lt;command&gt; [args]
+
+Commands:
+  read        Read data and retrieves secrets
+  write       Write data, configuration, and secrets
+  delete      Delete secrets and configuration
+  list        List data or secrets
+
+Web CLI Commands:
+  api         Navigate to the Vault API explorer. Use 'api [filter]' to prefilter the list.
+  clear       Clear output from the log
+  clearall    Clear output and command history
+  fullscreen  Toggle fullscreen display
+  refresh     Refresh the data on the current screen under the CLI window
+</pre>
 </div>

--- a/ui/app/templates/components/console/log-list.hbs
+++ b/ui/app/templates/components/console/log-list.hbs
@@ -1,8 +1,10 @@
 <div class="console-ui-output has-copy-button">
-  <pre>Keys
+  <pre>
+    Keys
     {{#each this.list as |item|}}
       {{item}}
 
-    {{/each}}</pre>
+    {{/each}}
+  </pre>
   <HoverCopyButton @copyValue={{multi-line-join this.list}} />
 </div>

--- a/ui/tests/integration/components/console/log-command-test.js
+++ b/ui/tests/integration/components/console/log-command-test.js
@@ -16,7 +16,6 @@ module('Integration | Component | console/log command', function (hooks) {
     this.set('content', commandText);
 
     await render(hbs`{{console/log-command content=this.content}}`);
-
-    assert.dom('pre').includesText(commandText);
+    assert.dom('p').includesText(commandText);
   });
 });


### PR DESCRIPTION
During the Ember upgrade to 3.24 we implemented some linting changes that inadvertently affected the browser console’s output. Each command should be on a separate line. Fixes #19568 

### before 
<img width="1276" alt="Screenshot 2023-04-10 at 10 16 02 AM" src="https://user-images.githubusercontent.com/68122737/230954677-8544785a-4286-43b2-b4c2-52189f4d3903.png">


### after fix
- each command is on a separate line
- previous command displays beside chevron icon `>` (not on line below)
<img width="1757" alt="Screenshot 2023-04-10 at 10 22 58 AM" src="https://user-images.githubusercontent.com/68122737/230955930-77c857ca-15df-484a-94e7-0cadb7f8e48c.png">
