### PR TITLE
openapi: Remove pcf plugin from gen_openapi.sh

### DIFF
--- a/helper/builtinplugins/registry_test.go
+++ b/helper/builtinplugins/registry_test.go
@@ -295,7 +295,6 @@ func Test_RegistryMatchesGenOpenapi(t *testing.T) {
 		for _, excluded := range []string{
 			"oidc",     // alias for "jwt"
 			"openldap", // alias for "ldap"
-			"ad",       // consolidated into "ldap" and deprecated
 		} {
 			if name == excluded {
 				return
@@ -313,19 +312,23 @@ func Test_RegistryMatchesGenOpenapi(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, b := range scriptCredentialBackends {
-		ensureInRegistry(t, b, consts.PluginTypeCredential)
+	for _, name := range scriptCredentialBackends {
+		ensureInRegistry(t, name, consts.PluginTypeCredential)
 	}
 
-	for _, b := range scriptSecretsBackends {
-		ensureInRegistry(t, b, consts.PluginTypeSecrets)
+	for _, name := range scriptSecretsBackends {
+		ensureInRegistry(t, name, consts.PluginTypeSecrets)
 	}
 
-	for _, b := range Registry.Keys(consts.PluginTypeCredential) {
-		ensureInScript(t, scriptCredentialBackends, b)
+	for name, backend := range Registry.credentialBackends {
+		if backend.DeprecationStatus == consts.Supported {
+			ensureInScript(t, scriptCredentialBackends, name)
+		}
 	}
 
-	for _, b := range Registry.Keys(consts.PluginTypeSecrets) {
-		ensureInScript(t, scriptSecretsBackends, b)
+	for name, backend := range Registry.logicalBackends {
+		if backend.DeprecationStatus == consts.Supported {
+			ensureInScript(t, scriptSecretsBackends, name)
+		}
 	}
 }

--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -55,7 +55,6 @@ vault auth enable "kubernetes"
 vault auth enable "ldap"
 vault auth enable "oci"
 vault auth enable "okta"
-vault auth enable "pcf"
 vault auth enable "radius"
 vault auth enable "userpass"
 


### PR DESCRIPTION
Removing deprecated plugin `pfc` from the `gen_openapi.sh` and fixing the related test to not check for deprecated plugins.