### PR TITLE
Updated the example config with api_addr parameter (#19985)

### DIFF
--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -13,15 +13,21 @@ The format of this file is [HCL](https://github.com/hashicorp/hcl) or JSON.
 
 An example configuration is shown below:
 
-```javascript
+```hcl
+ui            = true
+cluster_addr  = "https://127.0.0.1:8201"
+api_addr      = "https://127.0.0.1:8200"
+disable_mlock = true
+
 storage "consul" {
   address = "127.0.0.1:8500"
   path    = "vault/"
 }
 
 listener "tcp" {
-  address     = "127.0.0.1:8200"
-  tls_disable = 1
+  address       = "127.0.0.1:8200"
+  tls_cert_file = "/path/to/full-chain.pem"
+  tls_key_file  = "/path/to/private-key.pem"
 }
 
 telemetry {


### PR DESCRIPTION
The automatic backport did not get triggered for [PR 19985](https://github.com/hashicorp/vault/pull/19985). 😢
So, this PR manually cherry-picks the commit.