### PR TITLE
Use absolute path for debug datadir

### DIFF
--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -104,7 +104,7 @@ jobs:
       ENOS_VAR_vault_revision: ${{ inputs.vault-revision }}
       ENOS_VAR_vault_bundle_path: ./support/downloads/${{ inputs.build-artifact-name }}
       ENOS_VAR_vault_license_path: ./support/vault.hclic
-      ENOS_DEBUG_DATA_ROOT_DIR: ./enos/support/debug-data
+      ENOS_DEBUG_DATA_ROOT_DIR: /tmp/enos-debug-data
     steps:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2


### PR DESCRIPTION
Artifact upload action fails to find relative path to upload the debug data directory, so moving it to /tmp for easier find and cleanup