### PR TITLE
Require activity log retention months at least the minimum

### DIFF
--- a/changelog/20078.txt
+++ b/changelog/20078.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/activity: error when attempting to update retention configuration below the minimum 
+```

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -352,7 +352,7 @@ func (b *SystemBackend) handleActivityConfigUpdate(ctx context.Context, req *log
 	}
 
 	if a.core.censusLicensingEnabled && config.RetentionMonths < a.configOverrides.MinimumRetentionMonths {
-		return logical.ErrorResponse("retention months must be greater or equal to %d", a.configOverrides.MinimumRetentionMonths), logical.ErrInvalidRequest
+		return logical.ErrorResponse("retention months must be at least %d while Reporting is enabled", a.configOverrides.MinimumRetentionMonths), logical.ErrInvalidRequest
 	}
 
 	// Store the config

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -351,6 +351,10 @@ func (b *SystemBackend) handleActivityConfigUpdate(ctx context.Context, req *log
 		return logical.ErrorResponse("retention_months cannot be 0 while enabled"), logical.ErrInvalidRequest
 	}
 
+	if a.core.censusLicensingEnabled && config.RetentionMonths < a.configOverrides.MinimumRetentionMonths {
+		return logical.ErrorResponse("retention months must be greater or equal to %d", a.configOverrides.MinimumRetentionMonths), logical.ErrInvalidRequest
+	}
+
 	// Store the config
 	entry, err := logical.StorageEntryJSON(path.Join(activitySubPath, activityConfigKey), config)
 	if err != nil {

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -352,7 +352,7 @@ func (b *SystemBackend) handleActivityConfigUpdate(ctx context.Context, req *log
 	}
 
 	if a.core.censusLicensingEnabled && config.RetentionMonths < a.configOverrides.MinimumRetentionMonths {
-		return logical.ErrorResponse("retention months must be at least %d while Reporting is enabled", a.configOverrides.MinimumRetentionMonths), logical.ErrInvalidRequest
+		return logical.ErrorResponse("retention_months must be at least %d while Reporting is enabled", a.configOverrides.MinimumRetentionMonths), logical.ErrInvalidRequest
 	}
 
 	// Store the config


### PR DESCRIPTION
This PR adds a check when updating the activity log config so that the retention months are greater than a minimum value when reporting is enabled.