### PR TITLE
docs/oidc: fixes Azure user.read permission link

### DIFF
--- a/website/content/docs/auth/jwt/oidc-providers/azuread.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/azuread.mdx
@@ -123,7 +123,7 @@ To set the proper permissions on the Azure app:
 1. Add a permission
 1. Select "Microsoft Graph"
 1. Select "Delegated permissions"
-1. Add the [User.Read](https://learn.microsoft.com/en-us/graph/permissions-reference#delegated-permissions-86) permission
+1. Add the [User.Read](https://learn.microsoft.com/en-us/graph/permissions-reference#delegated-permissions-93) permission
 1. Check the "Grant admin consent for Default Directory" checkbox
 
 Next, configure the OIDC auth method in Vault by setting `"provider_config"` to Azure.


### PR DESCRIPTION
This PR fixes the link to the permission for MS graph `User.Read` in the Azure OIDC provider documentation.