### PR TITLE
Remove dead licensing code and extra core setup

### DIFF
--- a/vault/testing_util.go
+++ b/vault/testing_util.go
@@ -7,13 +7,10 @@ package vault
 
 import (
 	"crypto/ed25519"
-
-	testing "github.com/mitchellh/go-testing-interface"
 )
 
 func GenerateTestLicenseKeys() (ed25519.PublicKey, ed25519.PrivateKey, error) { return nil, nil, nil }
 func testGetLicensingConfig(key ed25519.PublicKey) *LicensingConfig           { return &LicensingConfig{} }
-func testExtraTestCoreSetup(testing.T, ed25519.PrivateKey, *TestClusterCore)  {}
 func testAdjustUnderlyingStorage(tcc *TestClusterCore) {
 	tcc.UnderlyingStorage = tcc.physical
 }


### PR DESCRIPTION
The extra core setup is no longer needed in Vault Enterprise, and the licensing code here has no effect here or in Vault Enterprise.

I pulled this commit into Vault Enterprise and it still compiled fine, and all tests pass. (Though a few functions can be deleted there as well after this is merged.)