### PR TITLE
[Backport] Update the HTTP verb for consistency (#20056)

### DIFF
--- a/website/content/api-docs/secret/kv/kv-v2.mdx
+++ b/website/content/api-docs/secret/kv/kv-v2.mdx
@@ -441,9 +441,9 @@ $ curl \
 Permanently removes the specified version data for the provided key and version
 numbers from the key-value store.
 
-| Method | Path                    |
-| :----- | :---------------------- |
-| `POST` | `/secret/destroy/:path` |
+| Method | Path                                |
+|:-------|:------------------------------------|
+| `PUT`  | `/:secret-mount-path/destroy/:path` |
 
 ### Parameters
 
@@ -466,7 +466,7 @@ numbers from the key-value store.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request POST \
+    --request PUT \
     --data @payload.json \
     https://127.0.0.1:8200/v1/secret/destroy/my-secret
 ```


### PR DESCRIPTION
https://github.com/hashicorp/vault/pull/20101 throws CLA check failure which I cannot solve.


So, this PR manually cherry-picks the https://github.com/hashicorp/vault/pull/20056