### PR TITLE
Always enable event system for PKI

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1288,9 +1288,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		return nil, err
 	}
 	c.events = events
-	if c.IsExperimentEnabled(experiments.VaultExperimentEventsAlpha1) {
-		c.events.Start()
-	}
+	c.events.Start(c.IsExperimentEnabled(experiments.VaultExperimentEventsAlpha1))
 
 	minConnectTimeoutRaw := os.Getenv("VAULT_GRPC_MIN_CONNECT_TIMEOUT")
 	if minConnectTimeoutRaw != "" {

--- a/vault/eventbus/bus_test.go
+++ b/vault/eventbus/bus_test.go
@@ -36,7 +36,7 @@ func TestBusBasics(t *testing.T) {
 		t.Errorf("Expected not started error but got: %v", err)
 	}
 
-	bus.Start()
+	bus.Start(true)
 
 	err = bus.SendInternal(ctx, namespace.RootNamespace, nil, eventType, event)
 	if err != nil {
@@ -76,7 +76,7 @@ func TestNamespaceFiltering(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	bus.Start()
+	bus.Start(true)
 	ctx := context.Background()
 
 	eventType := logical.EventType("someType")
@@ -140,7 +140,7 @@ func TestBus2Subscriptions(t *testing.T) {
 
 	eventType1 := logical.EventType("someType1")
 	eventType2 := logical.EventType("someType2")
-	bus.Start()
+	bus.Start(true)
 
 	ch1, cancel1, err := bus.Subscribe(ctx, namespace.RootNamespace, string(eventType1))
 	if err != nil {
@@ -212,7 +212,7 @@ func TestBusSubscriptionsCancel(t *testing.T) {
 				// set the timeout very short to make the test faster if we aren't canceling explicitly
 				bus.SetSendTimeout(100 * time.Millisecond)
 			}
-			bus.Start()
+			bus.Start(true)
 
 			// create and stop a bunch of subscriptions
 			const create = 100
@@ -314,7 +314,7 @@ func TestBusWildcardSubscriptions(t *testing.T) {
 
 	fooEventType := logical.EventType("kv/foo")
 	barEventType := logical.EventType("kv/bar")
-	bus.Start()
+	bus.Start(true)
 
 	ch1, cancel1, err := bus.Subscribe(ctx, namespace.RootNamespace, "kv/*")
 	if err != nil {

--- a/vault/events_test.go
+++ b/vault/events_test.go
@@ -4,17 +4,22 @@
 package vault
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/helper/experiments"
 	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/vault/eventbus"
 )
 
 func TestCanSendEventsFromBuiltinPlugin(t *testing.T) {
-	c, _, _ := TestCoreUnsealed(t)
-
+	c, _, _ := TestCoreUnsealedWithConfig(t, &CoreConfig{
+		Experiments: []string{experiments.VaultExperimentEventsAlpha1},
+	})
 	ctx := namespace.RootContext(nil)
 
 	// subscribe to an event type
@@ -55,5 +60,70 @@ func TestCanSendEventsFromBuiltinPlugin(t *testing.T) {
 
 	case <-time.After(1 * time.Second):
 		t.Error("timeout waiting for event")
+	}
+}
+
+func TestCanAlwaysSendCubbyholeEvents(t *testing.T) {
+	eventbus.EnabledPlugins["cubbyhole"] = struct{}{}
+	t.Cleanup(func() {
+		delete(eventbus.EnabledPlugins, "cubbyhole")
+	})
+	c, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(nil)
+
+	// subscribe to an event type
+	eventType := "someEventType"
+	ch, cancel, err := c.events.Subscribe(ctx, namespace.RootNamespace, eventType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancel()
+
+	// generate the event in a plugin
+	event, err := logical.NewEvent()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.cubbyholeBackend.SendEvent(ctx, logical.EventType(eventType), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check that the event is routed to the subscription
+	select {
+	case receivedEvent := <-ch:
+		received := receivedEvent.Payload.(*logical.EventReceived)
+		if event.Id != received.Event.Id {
+			t.Errorf("Got wrong event: %+v, expected %+v", received, event)
+		}
+		if received.PluginInfo == nil {
+			t.Error("Expected plugin info but got nil")
+		} else {
+			if received.PluginInfo.Plugin != "cubbyhole" {
+				t.Errorf("Expected cubbyhole plugin but got %s", received.PluginInfo.Plugin)
+			}
+		}
+
+	case <-time.After(1 * time.Second):
+		t.Error("timeout waiting for event")
+	}
+}
+
+func TestCannotSendEventsByDefault(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(nil)
+
+	eventType := "someEventType"
+	// generate the event in a plugin
+	event, err := logical.NewEvent()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.systemBackend.SendEvent(ctx, logical.EventType(eventType), event)
+
+	if err == nil {
+		t.Error("Expected error sending event but got nil")
+	} else if !errors.Is(err, eventbus.ErrNotStarted) && !errors.Is(err, framework.ErrNoEvents) {
+		t.Fatal(err)
 	}
 }

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/vault/eventbus"
 	"github.com/mitchellh/copystructure"
 )
 
@@ -1689,7 +1690,7 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 		System:      sysView,
 		BackendUUID: entry.BackendAwareUUID,
 	}
-	if c.IsExperimentEnabled(experiments.VaultExperimentEventsAlpha1) {
+	if c.IsExperimentEnabled(experiments.VaultExperimentEventsAlpha1) || eventbus.IsPluginAlwaysEnabled(conf["plugin_name"]) {
 		config.EventsSender = pluginEventSender
 	}
 

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -40,7 +40,6 @@ import (
 	auditFile "github.com/hashicorp/vault/builtin/audit/file"
 	"github.com/hashicorp/vault/command/server"
 	"github.com/hashicorp/vault/helper/constants"
-	"github.com/hashicorp/vault/helper/experiments"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
@@ -216,7 +215,7 @@ func TestCoreWithSealAndUINoCleanup(t testing.T, opts *CoreConfig) *Core {
 	conf.DisableSSCTokens = opts.DisableSSCTokens
 	conf.PluginDirectory = opts.PluginDirectory
 	conf.DetectDeadlocks = opts.DetectDeadlocks
-	conf.Experiments = []string{experiments.VaultExperimentEventsAlpha1}
+	conf.Experiments = opts.Experiments
 	conf.censusAgent = opts.censusAgent
 
 	if opts.Logger != nil {


### PR DESCRIPTION
We are considering using the event system for internal purposes even if it is not enabled in general.

This adds the option to selectively enable the event system for particular secrets engines (currently set only to `pki`).

This should still have minimal impact if not globally enabled, as the event bus will not even be populated in secrets engines not in the enabled map, and additionally events will be rejected by the event bus when attempting to send.

I tried a few ways to accomplish this, such as specifically allowing only certain event types, but this is what I ultimately found to be the cleanest solution with the fewest surprises.