### PR TITLE
Update wrapping-unwrap.mdx

### DIFF
--- a/website/content/api-docs/system/wrapping-unwrap.mdx
+++ b/website/content/api-docs/system/wrapping-unwrap.mdx
@@ -51,6 +51,15 @@ $ curl \
     http://127.0.0.1:8200/v1/sys/wrapping/unwrap
 ```
 
+Or you can use token to unwrap without authentication in vault
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: abcd1234..." \
+    --request POST \
+    http://127.0.0.1:8200/v1/sys/wrapping/unwrap
+```
+
 ### Sample Response
 
 ```json


### PR DESCRIPTION
### What I did

It is possible to unwrap data without authentication in Vault. I've added an example in the documentation with a curl request.