### PR TITLE
Use a UUID for ACME kid instead of a key fingerprint

### DIFF
--- a/builtin/logical/pki/acme_jws.go
+++ b/builtin/logical/pki/acme_jws.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	jose "gopkg.in/square/go-jose.v2"
 )
@@ -31,6 +32,14 @@ type jwsCtx struct {
 	Url      string          `json:"url"`
 	Key      jose.JSONWebKey `json:"-"`
 	Existing bool            `json:"-"`
+}
+
+func (c *jwsCtx) GetKeyThumbprint() (string, error) {
+	keyThumbprint, err := c.Key.Thumbprint(crypto.SHA256)
+	if err != nil {
+		return "", fmt.Errorf("failed creating thumbprint: %w", err)
+	}
+	return base64.URLEncoding.EncodeToString(keyThumbprint), nil
 }
 
 func (c *jwsCtx) UnmarshalJSON(a *acmeState, ac *acmeContext, jws []byte) error {
@@ -70,10 +79,12 @@ func (c *jwsCtx) UnmarshalJSON(a *acmeState, ac *acmeContext, jws []byte) error 
 
 	if c.Kid != "" {
 		// Load KID from storage first.
-		c.Jwk, err = a.LoadJWK(ac, c.Kid)
+		kid := getKeyIdFromAccountUrl(c.Kid)
+		c.Jwk, err = a.LoadJWK(ac, kid)
 		if err != nil {
 			return err
 		}
+		c.Kid = kid // Use the uuid itself, not the full account url that was originally provided to us.
 		c.Existing = true
 	}
 
@@ -86,17 +97,16 @@ func (c *jwsCtx) UnmarshalJSON(a *acmeState, ac *acmeContext, jws []byte) error 
 	}
 
 	if c.Kid == "" {
-		// Create a key ID
-		kid, err := c.Key.Thumbprint(crypto.SHA256)
-		if err != nil {
-			return fmt.Errorf("failed creating thumbprint: %w", err)
-		}
-
-		c.Kid = base64.URLEncoding.EncodeToString(kid)
+		c.Kid = genUuid()
 		c.Existing = false
 	}
 
 	return nil
+}
+
+func getKeyIdFromAccountUrl(accountUrl string) string {
+	pieces := strings.Split(accountUrl, "/")
+	return pieces[len(pieces)-1]
 }
 
 func hasValues(h jose.Header) bool {

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -135,9 +135,11 @@ type acmeAccount struct {
 
 func (a *acmeState) CreateAccount(ac *acmeContext, c *jwsCtx, contact []string, termsOfServiceAgreed bool) (*acmeAccount, error) {
 	// Write out the thumbprint value/entry out first, if we get an error mid-way through
-	// this is easier to recover from if we have an entry in this table with no corresponding
-	// kid entry, as the end-user will most likely retry with the same key but will have a
-	// newly generated kid value.
+	// this is easier to recover from. The new kid with the same existing public key
+	// will rewrite the thumbprint entry. This goes in hand with LoadAccountByKey that
+	// will return a nil, nil value if the referenced kid in a loaded thumbprint does not
+	// exist. This effectively makes this self-healing IF the end-user re-attempts the
+	// account creation with the same public key.
 	thumbprint, err := c.GetKeyThumbprint()
 	if err != nil {
 		return nil, fmt.Errorf("failed generating thumbprint: %w", err)

--- a/builtin/logical/pki/path_acme_new_account.go
+++ b/builtin/logical/pki/path_acme_new_account.go
@@ -337,7 +337,7 @@ func (b *backend) acmeNewAccountCreateHandler(acmeCtx *acmeContext, userCtx *jws
 	//	return nil, fmt.Errorf("terms of service not agreed to: %w", ErrUserActionRequired)
 	//}
 
-	accountByKid, err := b.acmeState.CreateAccount(acmeCtx, userCtx, thumbprint, contact, termsOfServiceAgreed)
+	accountByKid, err := b.acmeState.CreateAccount(acmeCtx, userCtx, contact, termsOfServiceAgreed)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create account: %w", err)
 	}
@@ -360,10 +360,6 @@ func (b *backend) acmeNewAccountUpdateHandler(acmeCtx *acmeContext, userCtx *jws
 	account, err := b.acmeState.LoadAccount(acmeCtx, userCtx.Kid)
 	if err != nil {
 		return nil, fmt.Errorf("error loading account: %w", err)
-	}
-
-	if account == nil {
-		return nil, fmt.Errorf("account not found: %w", ErrAccountDoesNotExist)
 	}
 
 	// Per RFC 8555 7.3.6 Account deactivation, if we were previously deactivated, we should return


### PR DESCRIPTION
Based on top of #19949, switch out the existing kid value being a thumbprint of the public key to a UUID generated value so we can properly support the key-change ACME semantics at a later time. This is required as the kid should not change when the backing account key changes.