### PR TITLE
Docs: remove use_auto_auth token from cache docs

### DIFF
--- a/website/content/docs/agent/caching/persistent-caches/index.mdx
+++ b/website/content/docs/agent/caching/persistent-caches/index.mdx
@@ -39,7 +39,6 @@ Here is an example of a persistent cache configuration.
 # ...
 
 cache {
-  use_auto_auth_token = true
   persist "kubernetes" {
     path = "/vault/agent-cache"
   }


### PR DESCRIPTION
This looks like it was missed in my update that moves `use_auto_auth_token` to the `api_proxy` block. While we support this in the cache block still, for backwards compatibility reasons, this can be confusing for users and should be configured in `api_proxy`.