### PR TITLE
Update userpass.mdx

### DIFF
--- a/website/content/docs/auth/userpass.mdx
+++ b/website/content/docs/auth/userpass.mdx
@@ -72,7 +72,7 @@ management tool.
 1. Configure it with users that are allowed to authenticate:
 
    ```text
-   $ vault write auth/userpass/users/mitchellh \
+   $ vault write auth/<userpass:path>/users/mitchellh \
        password=foo \
        policies=admins
    ```
@@ -80,6 +80,7 @@ management tool.
    This creates a new user "mitchellh" with the password "foo" that will be
    associated with the "admins" policy. This is the only configuration
    necessary.
+
 
 ## API
 

--- a/website/content/docs/auth/userpass.mdx
+++ b/website/content/docs/auth/userpass.mdx
@@ -65,13 +65,19 @@ management tool.
 
 1. Enable the userpass auth method:
 
-   ```text
+   ```shell-session
    $ vault auth enable userpass
+   ```
+   
+   This enables the userpass auth method at `auth/userpass`. To enable it at a different path, use the `-path` flag:
+   
+   ```shell-session
+   $ vault auth enable -path=<path> userpass
    ```
 
 1. Configure it with users that are allowed to authenticate:
 
-   ```text
+   ```shell-session
    $ vault write auth/<userpass:path>/users/mitchellh \
        password=foo \
        policies=admins


### PR DESCRIPTION
In the documentation,
```
vault auth enable userpass
```
```
vault write auth/userpass/users/mitchellh \
    password=foo \
    policies=admins
```

is used, which works but, there should a additional information about the custom path on the doc, or changes on the write command to clarify what is happening.

# Propose addition:

## Custom Path
```
vault auth enable userpass -path=custom_path
```
```
vault write auth/custom_path/users/mitchellh \
    password=foo \
    policies=admins
```

