### PR TITLE
Add minimum_retention_months to config endpoint

### DIFF
--- a/changelog/20150.txt
+++ b/changelog/20150.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+api: `/sys/internal/counters/config` endpoint now contains read-only
+`minimum_retention_months`.
+```

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -834,12 +834,13 @@ func TestActivityLog_API_ConfigCRUD(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		defaults := map[string]interface{}{
-			"default_report_months":   12,
-			"retention_months":        24,
-			"enabled":                 activityLogEnabledDefaultValue,
-			"queries_available":       false,
-			"reporting_enabled":       core.censusLicensingEnabled,
-			"billing_start_timestamp": core.GetBillingStart(),
+			"default_report_months":    12,
+			"retention_months":         24,
+			"enabled":                  activityLogEnabledDefaultValue,
+			"queries_available":        false,
+			"reporting_enabled":        core.censusLicensingEnabled,
+			"billing_start_timestamp":  core.GetBillingStart(),
+			"minimum_retention_months": core.activityLog.configOverrides.MinimumRetentionMonths,
 		}
 
 		if diff := deep.Equal(resp.Data, defaults); len(diff) > 0 {
@@ -917,12 +918,13 @@ func TestActivityLog_API_ConfigCRUD(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		expected := map[string]interface{}{
-			"default_report_months":   1,
-			"retention_months":        2,
-			"enabled":                 "enable",
-			"queries_available":       false,
-			"reporting_enabled":       false,
-			"billing_start_timestamp": core.GetBillingStart(),
+			"default_report_months":    1,
+			"retention_months":         2,
+			"enabled":                  "enable",
+			"queries_available":        false,
+			"reporting_enabled":        core.censusLicensingEnabled,
+			"billing_start_timestamp":  core.GetBillingStart(),
+			"minimum_retention_months": core.activityLog.configOverrides.MinimumRetentionMonths,
 		}
 
 		if diff := deep.Equal(resp.Data, expected); len(diff) > 0 {
@@ -955,12 +957,13 @@ func TestActivityLog_API_ConfigCRUD(t *testing.T) {
 		}
 
 		defaults := map[string]interface{}{
-			"default_report_months":   12,
-			"retention_months":        24,
-			"enabled":                 activityLogEnabledDefaultValue,
-			"queries_available":       false,
-			"reporting_enabled":       false,
-			"billing_start_timestamp": core.GetBillingStart(),
+			"default_report_months":    12,
+			"retention_months":         24,
+			"enabled":                  activityLogEnabledDefaultValue,
+			"queries_available":        false,
+			"reporting_enabled":        core.censusLicensingEnabled,
+			"billing_start_timestamp":  core.GetBillingStart(),
+			"minimum_retention_months": core.activityLog.configOverrides.MinimumRetentionMonths,
 		}
 
 		if diff := deep.Equal(resp.Data, defaults); len(diff) > 0 {

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -304,12 +304,13 @@ func (b *SystemBackend) handleActivityConfigRead(ctx context.Context, req *logic
 
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"default_report_months":   config.DefaultReportMonths,
-			"retention_months":        config.RetentionMonths,
-			"enabled":                 config.Enabled,
-			"queries_available":       qa,
-			"reporting_enabled":       b.Core.censusLicensingEnabled,
-			"billing_start_timestamp": b.Core.GetBillingStart(),
+			"default_report_months":    config.DefaultReportMonths,
+			"retention_months":         config.RetentionMonths,
+			"enabled":                  config.Enabled,
+			"queries_available":        qa,
+			"reporting_enabled":        b.Core.censusLicensingEnabled,
+			"billing_start_timestamp":  b.Core.GetBillingStart(),
+			"minimum_retention_months": a.configOverrides.MinimumRetentionMonths,
 		},
 	}, nil
 }


### PR DESCRIPTION
This PR cleans up the expected results from the last config endpoint update and adds a new field for use in the UI.

Changelog to come.