### PR TITLE
Add missing cert auth ocsp read data

### DIFF
--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -1968,6 +1968,27 @@ func testAccStepCertWithExtraParams(t *testing.T, name string, cert []byte, poli
 	}
 }
 
+func testAccStepReadCertPolicy(t *testing.T, name string, expectError bool, expected map[string]interface{}) logicaltest.TestStep {
+	return logicaltest.TestStep{
+		Operation: logical.ReadOperation,
+		Path:      "certs/" + name,
+		ErrorOk:   expectError,
+		Data:      nil,
+		Check: func(resp *logical.Response) error {
+			if (resp == nil || len(resp.Data) == 0) && expectError {
+				return fmt.Errorf("expected error but received nil")
+			}
+			for key, expectedValue := range expected {
+				actualValue := resp.Data[key]
+				if expectedValue != actualValue {
+					return fmt.Errorf("Expected to get [%v]=[%v] but read [%v]=[%v] from server for certs/%v: %v", key, expectedValue, key, actualValue, name, resp)
+				}
+			}
+			return nil
+		},
+	}
+}
+
 func testAccStepCertLease(
 	t *testing.T, name string, cert []byte, policies string,
 ) logicaltest.TestStep {

--- a/builtin/credential/cert/path_certs.go
+++ b/builtin/credential/cert/path_certs.go
@@ -288,6 +288,11 @@ func (b *backend) pathCertRead(ctx context.Context, req *logical.Request, d *fra
 		"allowed_organizational_units": cert.AllowedOrganizationalUnits,
 		"required_extensions":          cert.RequiredExtensions,
 		"allowed_metadata_extensions":  cert.AllowedMetadataExtensions,
+		"ocsp_ca_certificates":         cert.OcspCaCertificates,
+		"ocsp_enabled":                 cert.OcspEnabled,
+		"ocsp_servers_override":        cert.OcspServersOverride,
+		"ocsp_fail_open":               cert.OcspFailOpen,
+		"ocsp_query_all_servers":       cert.OcspQueryAllServers,
 	}
 	cert.PopulateTokenData(data)
 

--- a/builtin/credential/cert/path_login_test.go
+++ b/builtin/credential/cert/path_login_test.go
@@ -348,6 +348,7 @@ func TestCert_RoleResolveOCSP(t *testing.T) {
 				Steps: []logicaltest.TestStep{
 					testAccStepCertWithExtraParams(t, "web", ca, "foo", allowed{dns: "example.com"}, false,
 						map[string]interface{}{"ocsp_enabled": true, "ocsp_fail_open": c.failOpen}),
+					testAccStepReadCertPolicy(t, "web", false, map[string]interface{}{"ocsp_enabled": true, "ocsp_fail_open": c.failOpen}),
 					loginStep,
 					resolveStep,
 				},

--- a/changelog/20154.txt
+++ b/changelog/20154.txt
@@ -1,0 +1,2 @@
+```release-note:bug
+auth/cert: Include OCSP parameters in read CA certificate role response.


### PR DESCRIPTION
Per conversation with @hellobontempo, cert auth UI uses the open API data to determine fields. In our case, these fields were already present, but we needed to return them from the read API response status for them to be visible in the UI. Otherwise, they'd be set server side (on the first submission), but any further changes would potentially overwrite them as the UI would use default/zero values for the fields it doesn't see.