### PR TITLE
VAULT-15538: racy LDAP test 

### DIFF
--- a/vault/external_tests/identity/identity_test.go
+++ b/vault/external_tests/identity/identity_test.go
@@ -145,7 +145,6 @@ func TestIdentityStore_ExternalGroupMemberships_DifferentMounts(t *testing.T) {
 }
 
 func TestIdentityStore_Integ_GroupAliases(t *testing.T) {
-	t.Parallel()
 
 	var err error
 	coreConfig := &vault.CoreConfig{

--- a/vault/external_tests/identity/identity_test.go
+++ b/vault/external_tests/identity/identity_test.go
@@ -145,7 +145,6 @@ func TestIdentityStore_ExternalGroupMemberships_DifferentMounts(t *testing.T) {
 }
 
 func TestIdentityStore_Integ_GroupAliases(t *testing.T) {
-
 	var err error
 	coreConfig := &vault.CoreConfig{
 		DisableMlock: true,


### PR DESCRIPTION
The issue is described here: https://github.com/hashicorp/vault/pull/20144/files/0e405c39fb4ad650203c0c7b3b91cf01982b8cd4#diff-cac2ee35ce174c975632d9079d0171a80b3eb76a8d60de091a54094a7195c3dc

This is just a bandaid, any tests that we add that run in parallel and mount LDAP will also trigger the race detector.