### PR TITLE
UI: PKI routes extend base Route

### DIFF
--- a/ui/lib/pki/addon/routes/application.js
+++ b/ui/lib/pki/addon/routes/application.js
@@ -5,14 +5,24 @@
 
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { hash } from 'rsvp';
 
 export default class PkiRoute extends Route {
   @service pathHelp;
   @service secretMountPath;
 
   beforeModel() {
-    // Must call this promise before the model hook otherwise the model doesn't hydrate from OpenAPI correctly.
-    // only needs to be called once to add the openAPI attributes to the model prototype
-    return this.pathHelp.getNewModel('pki/role', this.secretMountPath.currentPath);
+    // We call pathHelp for all the models in this engine that use OpenAPI before any model hooks
+    // so that the model attributes hydrate correctly. These only need to be called once to add
+    // the openAPI attributes to the model prototype
+    const mountPath = this.secretMountPath.currentPath;
+    return hash({
+      role: this.pathHelp.getNewModel('pki/role', mountPath),
+      urls: this.pathHelp.getNewModel('pki/urls', mountPath),
+      key: this.pathHelp.getNewModel('pki/key', mountPath),
+      signCsr: this.pathHelp.getNewModel('pki/sign-intermediate', mountPath),
+      certGenerate: this.pathHelp.getNewModel('pki/certificate/generate', mountPath),
+      certSign: this.pathHelp.getNewModel('pki/certificate/sign', mountPath),
+    });
   }
 }

--- a/ui/lib/pki/addon/routes/certificates/index.js
+++ b/ui/lib/pki/addon/routes/certificates/index.js
@@ -38,7 +38,7 @@ export default class PkiCertificatesIndexRoute extends Route {
     super.setupController(controller, resolvedModel);
     const certificates = resolvedModel.certificates;
 
-    if (certificates?.length) controller.message = getCliMessage('certificates');
-    else controller.message = getCliMessage();
+    if (certificates?.length) controller.notConfiguredMessage = getCliMessage('certificates');
+    else controller.notConfiguredMessage = getCliMessage();
   }
 }

--- a/ui/lib/pki/addon/routes/configuration/create.js
+++ b/ui/lib/pki/addon/routes/configuration/create.js
@@ -12,12 +12,6 @@ import { hash } from 'rsvp';
 export default class PkiConfigurationCreateRoute extends Route {
   @service secretMountPath;
   @service store;
-  @service pathHelp;
-
-  beforeModel() {
-    // pki/urls uses openApi to hydrate model
-    return this.pathHelp.getNewModel('pki/urls', this.secretMountPath.currentPath);
-  }
 
   model() {
     return hash({

--- a/ui/lib/pki/addon/routes/configuration/index.js
+++ b/ui/lib/pki/addon/routes/configuration/index.js
@@ -7,7 +7,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { withConfig } from 'pki/decorators/check-config';
 import { hash } from 'rsvp';
-import { PKI_DEFAULT_EMPTY_STATE_MSG } from 'pki/routes/overview';
 
 @withConfig()
 export default class ConfigurationIndexRoute extends Route {
@@ -53,7 +52,5 @@ export default class ConfigurationIndexRoute extends Route {
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-
-    controller.message = PKI_DEFAULT_EMPTY_STATE_MSG;
   }
 }

--- a/ui/lib/pki/addon/routes/issuers/generate-intermediate.js
+++ b/ui/lib/pki/addon/routes/issuers/generate-intermediate.js
@@ -3,17 +3,26 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
-import PkiIssuersIndexRoute from '.';
 
 @withConfirmLeave()
-export default class PkiIssuersGenerateIntermediateRoute extends PkiIssuersIndexRoute {
+export default class PkiIssuersGenerateIntermediateRoute extends Route {
+  @service store;
+  @service secretMountPath;
+
   model() {
     return this.store.createRecord('pki/action', { actionType: 'generate-csr' });
   }
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-    controller.breadcrumbs.push({ label: 'generate CSR' });
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
+      { label: 'issuers', route: 'issuers.index' },
+      { label: 'generate CSR' },
+    ];
   }
 }

--- a/ui/lib/pki/addon/routes/issuers/import.js
+++ b/ui/lib/pki/addon/routes/issuers/import.js
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import PkiIssuersIndexRoute from '.';
+import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave()
-export default class PkiIssuersImportRoute extends PkiIssuersIndexRoute {
+export default class PkiIssuersImportRoute extends Route {
   @service store;
+  @service secretMountPath;
 
   model() {
     return this.store.createRecord('pki/action');
@@ -17,6 +18,11 @@ export default class PkiIssuersImportRoute extends PkiIssuersIndexRoute {
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-    controller.breadcrumbs.push({ label: 'import' });
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
+      { label: 'issuers', route: 'issuers.index' },
+      { label: 'import' },
+    ];
   }
 }

--- a/ui/lib/pki/addon/routes/issuers/index.js
+++ b/ui/lib/pki/addon/routes/issuers/index.js
@@ -33,6 +33,6 @@ export default class PkiIssuersListRoute extends Route {
       { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'issuers', route: 'issuers.index' },
     ];
-    controller.message = PKI_DEFAULT_EMPTY_STATE_MSG;
+    controller.notConfiguredMessage = PKI_DEFAULT_EMPTY_STATE_MSG;
   }
 }

--- a/ui/lib/pki/addon/routes/issuers/index.js
+++ b/ui/lib/pki/addon/routes/issuers/index.js
@@ -10,12 +10,6 @@ import { PKI_DEFAULT_EMPTY_STATE_MSG } from 'pki/routes/overview';
 export default class PkiIssuersListRoute extends Route {
   @service store;
   @service secretMountPath;
-  @service pathHelp;
-
-  beforeModel() {
-    // Must call this promise before the model hook otherwise it doesn't add OpenApi to record.
-    return this.pathHelp.getNewModel('pki/issuer', this.secretMountPath.currentPath);
-  }
 
   model() {
     return this.store

--- a/ui/lib/pki/addon/routes/issuers/issuer.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer.js
@@ -3,10 +3,13 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import PkiIssuersListRoute from '.';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
-// Single issuer index route extends issuers list route
-export default class PkiIssuerIndexRoute extends PkiIssuersListRoute {
+export default class PkiIssuerIndexRoute extends Route {
+  @service store;
+  @service secretMountPath;
+
   model() {
     const { issuer_ref } = this.paramsFor('issuers/issuer');
     return this.store.queryRecord('pki/issuer', {

--- a/ui/lib/pki/addon/routes/issuers/issuer/cross-sign.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/cross-sign.js
@@ -3,16 +3,28 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import PkiIssuerRoute from '../issuer';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave()
-export default class PkiIssuerCrossSignRoute extends PkiIssuerRoute {
+export default class PkiIssuerCrossSignRoute extends Route {
+  @service store;
+  @service secretMountPath;
+
+  model() {
+    return this.modelFor('issuers.issuer');
+  }
+
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-    controller.breadcrumbs.push(
+
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
+      { label: 'issuers', route: 'issuers.index' },
       { label: resolvedModel.id, route: 'issuers.issuer.details' },
-      { label: 'cross-sign' }
-    );
+      { label: 'cross-sign' },
+    ];
   }
 }

--- a/ui/lib/pki/addon/routes/issuers/issuer/details.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/details.js
@@ -3,10 +3,15 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import PkiIssuerRoute from '../issuer';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 import { verifyCertificates } from 'vault/utils/parse-pki-cert';
 import { hash } from 'rsvp';
-export default class PkiIssuerDetailsRoute extends PkiIssuerRoute {
+
+export default class PkiIssuerDetailsRoute extends Route {
+  @service store;
+  @service secretMountPath;
+
   model() {
     const issuer = this.modelFor('issuers.issuer');
     return hash({
@@ -19,7 +24,12 @@ export default class PkiIssuerDetailsRoute extends PkiIssuerRoute {
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-    controller.breadcrumbs.push({ label: resolvedModel.issuer.id });
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
+      { label: 'issuers', route: 'issuers.index' },
+      { label: resolvedModel.issuer.id },
+    ];
   }
 
   /**

--- a/ui/lib/pki/addon/routes/issuers/issuer/edit.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/edit.js
@@ -11,12 +11,6 @@ import { withConfirmLeave } from 'core/decorators/confirm-leave';
 export default class PkiIssuerEditRoute extends Route {
   @service store;
   @service secretMountPath;
-  @service pathHelp;
-
-  beforeModel() {
-    // Must call this promise before the model hook otherwise it doesn't add OpenApi to record.
-    return this.pathHelp.getNewModel('pki/issuer', this.secretMountPath.currentPath);
-  }
 
   model() {
     const { issuer_ref } = this.paramsFor('issuers/issuer');

--- a/ui/lib/pki/addon/routes/issuers/issuer/rotate-root.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/rotate-root.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import PkiIssuerRoute from '../issuer';
+import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { parseCertificate } from 'vault/utils/parse-pki-cert';
@@ -11,7 +11,7 @@ import camelizeKeys from 'vault/utils/camelize-object-keys';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave('model.newRootModel')
-export default class PkiIssuerRotateRootRoute extends PkiIssuerRoute {
+export default class PkiIssuerRotateRootRoute extends Route {
   @service secretMountPath;
   @service store;
 

--- a/ui/lib/pki/addon/routes/issuers/issuer/sign.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/sign.js
@@ -11,12 +11,6 @@ import { withConfirmLeave } from 'core/decorators/confirm-leave';
 export default class PkiIssuerSignRoute extends Route {
   @service store;
   @service secretMountPath;
-  @service pathHelp;
-
-  beforeModel() {
-    // Must call this promise before the model hook otherwise it doesn't add OpenApi to record.
-    return this.pathHelp.getNewModel('pki/sign-intermediate', this.secretMountPath.currentPath);
-  }
 
   model() {
     const { issuer_ref } = this.paramsFor('issuers/issuer');

--- a/ui/lib/pki/addon/routes/keys/create.js
+++ b/ui/lib/pki/addon/routes/keys/create.js
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import PkiKeysIndexRoute from '.';
+import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave()
-export default class PkiKeysCreateRoute extends PkiKeysIndexRoute {
+export default class PkiKeysCreateRoute extends Route {
+  @service secretMountPath;
   @service store;
 
   model() {
@@ -17,6 +18,11 @@ export default class PkiKeysCreateRoute extends PkiKeysIndexRoute {
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-    controller.breadcrumbs.push({ label: 'generate' });
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
+      { label: 'keys', route: 'keys.index' },
+      { label: 'generate' },
+    ];
   }
 }

--- a/ui/lib/pki/addon/routes/keys/import.js
+++ b/ui/lib/pki/addon/routes/keys/import.js
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import PkiKeysIndexRoute from '.';
+import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave()
-export default class PkiKeysImportRoute extends PkiKeysIndexRoute {
+export default class PkiKeysImportRoute extends Route {
+  @service secretMountPath;
   @service store;
 
   model() {
@@ -17,6 +18,11 @@ export default class PkiKeysImportRoute extends PkiKeysIndexRoute {
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-    controller.breadcrumbs.push({ label: 'import' });
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
+      { label: 'keys', route: 'keys.index' },
+      { label: 'import' },
+    ];
   }
 }

--- a/ui/lib/pki/addon/routes/keys/index.js
+++ b/ui/lib/pki/addon/routes/keys/index.js
@@ -35,6 +35,6 @@ export default class PkiKeysIndexRoute extends Route {
       { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'keys', route: 'keys.index' },
     ];
-    controller.message = PKI_DEFAULT_EMPTY_STATE_MSG;
+    controller.notConfiguredMessage = PKI_DEFAULT_EMPTY_STATE_MSG;
   }
 }

--- a/ui/lib/pki/addon/routes/keys/index.js
+++ b/ui/lib/pki/addon/routes/keys/index.js
@@ -13,12 +13,6 @@ import { PKI_DEFAULT_EMPTY_STATE_MSG } from 'pki/routes/overview';
 export default class PkiKeysIndexRoute extends Route {
   @service store;
   @service secretMountPath;
-  @service pathHelp;
-
-  beforeModel() {
-    // Must call this promise before the model hook otherwise it doesn't add OpenApi to record.
-    return this.pathHelp.getNewModel('pki/key', this.secretMountPath.currentPath);
-  }
 
   model() {
     return hash({

--- a/ui/lib/pki/addon/routes/keys/index.js
+++ b/ui/lib/pki/addon/routes/keys/index.js
@@ -11,8 +11,8 @@ import { PKI_DEFAULT_EMPTY_STATE_MSG } from 'pki/routes/overview';
 
 @withConfig()
 export default class PkiKeysIndexRoute extends Route {
-  @service store;
   @service secretMountPath;
+  @service store;
 
   model() {
     return hash({

--- a/ui/lib/pki/addon/routes/keys/key.js
+++ b/ui/lib/pki/addon/routes/keys/key.js
@@ -3,9 +3,13 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import PkiKeysIndexRoute from './index';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
-export default class PkiKeyRoute extends PkiKeysIndexRoute {
+export default class PkiKeyRoute extends Route {
+  @service secretMountPath;
+  @service store;
+
   model() {
     const { key_id } = this.paramsFor('keys/key');
     return this.store.queryRecord('pki/key', {

--- a/ui/lib/pki/addon/routes/keys/key/details.js
+++ b/ui/lib/pki/addon/routes/keys/key/details.js
@@ -3,11 +3,22 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import PkiKeyRoute from '../key';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
-export default class PkiKeyDetailsRoute extends PkiKeyRoute {
+export default class PkiKeyDetailsRoute extends Route {
+  @service secretMountPath;
+
+  model() {
+    return this.modelFor('keys.key');
+  }
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-    controller.breadcrumbs.push({ label: resolvedModel.id });
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
+      { label: 'keys', route: 'keys.index' },
+      { label: resolvedModel.id },
+    ];
   }
 }

--- a/ui/lib/pki/addon/routes/keys/key/edit.js
+++ b/ui/lib/pki/addon/routes/keys/key/edit.js
@@ -4,12 +4,24 @@
  */
 
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
-import PkiKeyRoute from '../key';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 @withConfirmLeave()
-export default class PkiKeyEditRoute extends PkiKeyRoute {
+export default class PkiKeyEditRoute extends Route {
+  @service secretMountPath;
+
+  model() {
+    return this.modelFor('keys.key');
+  }
+
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-    controller.breadcrumbs.push({ label: resolvedModel.id, route: 'keys.key.details' }, { label: 'edit' });
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
+      { label: 'keys', route: 'keys.index' },
+      { label: resolvedModel.id },
+    ];
   }
 }

--- a/ui/lib/pki/addon/routes/overview.js
+++ b/ui/lib/pki/addon/routes/overview.js
@@ -62,10 +62,11 @@ export default class PkiOverviewRoute extends Route {
     const roles = resolvedModel.roles;
     const certificates = resolvedModel.certificates;
 
-    controller.message = getCliMessage();
+    controller.notConfiguredMessage = getCliMessage();
 
-    if (roles?.length) controller.message = getCliMessage('roles');
-    if (certificates?.length) controller.message = getCliMessage('certificates');
-    if (roles?.length && certificates?.length) controller.message = getCliMessage('roles and certificates');
+    if (roles?.length) controller.notConfiguredMessage = getCliMessage('roles');
+    if (certificates?.length) controller.notConfiguredMessage = getCliMessage('certificates');
+    if (roles?.length && certificates?.length)
+      controller.notConfiguredMessage = getCliMessage('roles and certificates');
   }
 }

--- a/ui/lib/pki/addon/routes/roles/index.js
+++ b/ui/lib/pki/addon/routes/roles/index.js
@@ -37,7 +37,7 @@ export default class PkiRolesIndexRoute extends Route {
     super.setupController(controller, resolvedModel);
     const roles = resolvedModel.roles;
 
-    if (roles?.length) controller.message = getCliMessage('roles');
-    else controller.message = getCliMessage();
+    if (roles?.length) controller.notConfiguredMessage = getCliMessage('roles');
+    else controller.notConfiguredMessage = getCliMessage();
   }
 }

--- a/ui/lib/pki/addon/routes/roles/role/generate.js
+++ b/ui/lib/pki/addon/routes/roles/role/generate.js
@@ -11,13 +11,6 @@ withConfirmLeave();
 export default class PkiRoleGenerateRoute extends Route {
   @service store;
   @service secretMountPath;
-  @service pathHelp;
-
-  beforeModel() {
-    // Must call this promise before the model hook otherwise
-    // the model doesn't hydrate from OpenAPI correctly.
-    return this.pathHelp.getNewModel('pki/certificate/generate', this.secretMountPath.currentPath);
-  }
 
   async model() {
     const { role } = this.paramsFor('roles/role');

--- a/ui/lib/pki/addon/routes/roles/role/sign.js
+++ b/ui/lib/pki/addon/routes/roles/role/sign.js
@@ -11,13 +11,6 @@ withConfirmLeave();
 export default class PkiRoleSignRoute extends Route {
   @service store;
   @service secretMountPath;
-  @service pathHelp;
-
-  beforeModel() {
-    // Must call this promise before the model hook otherwise
-    // the model doesn't hydrate from OpenAPI correctly.
-    return this.pathHelp.getNewModel('pki/certificate/sign', this.secretMountPath.currentPath);
-  }
 
   model() {
     const { role } = this.paramsFor('roles/role');

--- a/ui/lib/pki/addon/templates/certificates/index.hbs
+++ b/ui/lib/pki/addon/templates/certificates/index.hbs
@@ -68,7 +68,7 @@
     </EmptyState>
   {{/if}}
 {{else}}
-  <EmptyState @title="PKI not configured" @message={{this.message}}>
+  <EmptyState @title="PKI not configured" @message={{this.notConfiguredMessage}}>
     <LinkTo @route="configuration.create">
       Configure PKI
     </LinkTo>

--- a/ui/lib/pki/addon/templates/issuers/index.hbs
+++ b/ui/lib/pki/addon/templates/issuers/index.hbs
@@ -93,7 +93,7 @@
     </LinkedBlock>
   {{/each}}
 {{else}}
-  <EmptyState @title="PKI not configured" @message={{this.message}}>
+  <EmptyState @title="PKI not configured" @message={{this.notConfiguredMessage}}>
     <LinkTo @route="configuration.create">
       Configure PKI
     </LinkTo>

--- a/ui/lib/pki/addon/templates/keys/index.hbs
+++ b/ui/lib/pki/addon/templates/keys/index.hbs
@@ -19,7 +19,7 @@
   />
 {{else}}
   <Toolbar />
-  <EmptyState @title="PKI not configured" @message={{this.message}}>
+  <EmptyState @title="PKI not configured" @message={{this.notConfiguredMessage}}>
     <LinkTo @route="configuration.create">
       Configure PKI
     </LinkTo>

--- a/ui/lib/pki/addon/templates/overview.hbs
+++ b/ui/lib/pki/addon/templates/overview.hbs
@@ -21,7 +21,7 @@
 {{#if this.model.hasConfig}}
   <Page::PkiOverview @issuers={{this.model.issuers}} @roles={{this.model.roles}} @engine={{this.model.engine}} />
 {{else}}
-  <EmptyState @title="PKI not configured" @message={{this.message}}>
+  <EmptyState @title="PKI not configured" @message={{this.notConfiguredMessage}}>
     <LinkTo @route="configuration.create">
       Configure PKI
     </LinkTo>

--- a/ui/lib/pki/addon/templates/roles/index.hbs
+++ b/ui/lib/pki/addon/templates/roles/index.hbs
@@ -67,7 +67,7 @@
   {{/if}}
 {{else}}
   <Toolbar />
-  <EmptyState @title="PKI not configured" @message={{this.message}}>
+  <EmptyState @title="PKI not configured" @message={{this.notConfiguredMessage}}>
     <LinkTo @route="configuration.create">
       Configure PKI
     </LinkTo>


### PR DESCRIPTION
This PR untangles the routing for the PKI engine. Extending other routes was causing confusion and it wasn't clear why some routes were even extended. As part of this PR, all the PKI models using openAPI are also instantiated at the engine application route so that the models are hydrated and available for the rest of the engine. 