### PR TITLE
Add fix for Go x/crypto/ocsp failure case

### DIFF
--- a/changelog/20181.txt
+++ b/changelog/20181.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+sdk/helper/ocsp: Workaround bug in Go's ocsp.ParseResponse(...), causing validation to fail with embedded CA certificates.
+auth/cert: Fix OCSP validation against Vault's PKI engine.
+```


### PR DESCRIPTION
When calling `ocsp.ParseRequest(req, issue)` with a non-nil `issuer` on a ocsp request which _unknowingly_ contains an entry in the `BasicOCSPResponse`'s `certs` field, Go incorrectly assumes that the issuer is a direct parent of the _first_ certificate in the `certs` field, discarding the rest.

As documented in the Go issue, this is not a valid assumption and thus causes OCSP verification to fail in Vault with an error like:

> ```
> bad OCSP signature: crypto/rsa: verification error
> ```

which ultimately leads to a cert auth login error of:

> ```
> no chain matching all constraints could be found for this login certificate
> ```

We address this by using the unsafe `issuer=nil` argument, taking on the task of validating the OCSP response's signature as best we can in the absence of full chain information on either side (both the trusted certificate whose OCSP response we're verifying and the lack of any additional certs the OCSP responder may have sent).

See also: https://github.com/golang/go/issues/59641