### PR TITLE
Move console panel to bottom

### DIFF
--- a/ui/app/components/sidebar/frame.hbs
+++ b/ui/app/components/sidebar/frame.hbs
@@ -36,13 +36,13 @@
       </Sidebar.Footer>
     </HcAppFrame::Sidenav>
   </Frame.Sidebar>
-  <Frame.Main>
+  <Frame.Main class="is-relative">
     {{! outlet for app content }}
     <div id="modal-wormhole"></div>
     <LinkStatus @status={{this.currentCluster.cluster.hcpLinkStatus}} />
+    {{yield}}
     <div data-test-console-panel class={{if this.console.isOpen "panel-open"}}>
       <Console::UiPanel @isFullscreen={{this.consoleFullscreen}} />
     </div>
-    {{yield}}
   </Frame.Main>
 </HcAppFrame::Frame>

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -5,12 +5,13 @@
 
 .console-ui-panel {
   background: var(--token-color-palette-neutral-700);
+  width: 100%;
   height: 0;
-  left: 0;
   min-height: 0;
   overflow: auto;
+  position: absolute;
   right: 0;
-  top: $header-height;
+  bottom: 0;
   transition: min-height $speed ease-out, transform $speed ease-in;
   will-change: transform, min-height;
   -webkit-overflow-scrolling: touch;
@@ -39,7 +40,7 @@
   font-weight: $font-weight-semibold;
   justify-content: flex-end;
   min-height: 100%;
-  padding: $size-8 $size-8 $size-4;
+  padding: $size-8 $size-8 $size-5;
   transition: justify-content $speed ease-in;
 
   pre,
@@ -124,7 +125,6 @@
 
 .panel-open .console-ui-panel.fullscreen {
   bottom: 0;
-  top: 0;
   min-height: 100vh;
   min-width: 100vh;
   position: fixed;
@@ -146,8 +146,13 @@
 }
 
 .console-close-button {
-  position: absolute;
+  position: sticky;
   top: $spacing-xs;
-  right: $spacing-xs;
+  display: flex;
+  justify-content: flex-end;
   z-index: 210;
+
+  button {
+    margin-right: $spacing-xs;
+  }
 }

--- a/ui/app/templates/components/console/log-command.hbs
+++ b/ui/app/templates/components/console/log-command.hbs
@@ -1,4 +1,4 @@
 <div class="is-flex-center">
   <Icon @name="chevron-right" />
-  <pre class="console-ui-command is-font-mono">{{@content}}</pre>
+  <pre class="console-ui-command">{{@content}}</pre>
 </div>

--- a/ui/app/templates/components/console/ui-panel.hbs
+++ b/ui/app/templates/components/console/ui-panel.hbs
@@ -1,6 +1,8 @@
-<button type="button" class="button is-ghost console-close-button" {{action "closeConsole"}} data-test-console-panel-close>
-  <Icon @name="x" aria-label="Close console" />
-</button>
+<div class="console-close-button">
+  <button type="button" class="button is-ghost" {{action "closeConsole"}} data-test-console-panel-close>
+    <Icon @name="x" aria-label="Close console" />
+  </button>
+</div>
 <div class="console-ui-panel-content">
   <div class="content">
     <p class="has-text-grey is-font-mono">


### PR DESCRIPTION
This PR moves the console panel from the top of the viewport to the bottom to improve UX and give it a more natural feel.

Before
![image](https://user-images.githubusercontent.com/24611656/232145771-d233033a-edac-48a1-8364-80ada37bf5d5.png)
_As you can see in the screenshot the close button is pushed up when the content scrolls. This has been fixed to anchor it to the top right of the panel._

After
![image](https://user-images.githubusercontent.com/24611656/232145977-35a1a39b-ce05-476f-a706-a203b756c4aa.png)

