### PR TITLE
add max_entry_size to sanitized config output (#20044)

### DIFF
--- a/changelog/20044.txt
+++ b/changelog/20044.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+core: Add a `raft` sub-field to the `storage` and `ha_storage` details provided by the
+`/sys/config/state/sanitized` endpoint in order to include the `max_entry_size`.
+```

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -940,23 +940,39 @@ func (c *Config) Sanitized() map[string]interface{} {
 
 	// Sanitize storage stanza
 	if c.Storage != nil {
+		storageType := c.Storage.Type
 		sanitizedStorage := map[string]interface{}{
-			"type":               c.Storage.Type,
+			"type":               storageType,
 			"redirect_addr":      c.Storage.RedirectAddr,
 			"cluster_addr":       c.Storage.ClusterAddr,
 			"disable_clustering": c.Storage.DisableClustering,
 		}
+
+		if storageType == "raft" {
+			sanitizedStorage["raft"] = map[string]interface{}{
+				"max_entry_size": c.Storage.Config["max_entry_size"],
+			}
+		}
+
 		result["storage"] = sanitizedStorage
 	}
 
 	// Sanitize HA storage stanza
 	if c.HAStorage != nil {
+		haStorageType := c.HAStorage.Type
 		sanitizedHAStorage := map[string]interface{}{
-			"type":               c.HAStorage.Type,
+			"type":               haStorageType,
 			"redirect_addr":      c.HAStorage.RedirectAddr,
 			"cluster_addr":       c.HAStorage.ClusterAddr,
 			"disable_clustering": c.HAStorage.DisableClustering,
 		}
+
+		if haStorageType == "raft" {
+			sanitizedHAStorage["raft"] = map[string]interface{}{
+				"max_entry_size": c.HAStorage.Config["max_entry_size"],
+			}
+		}
+
 		result["ha_storage"] = sanitizedHAStorage
 	}
 

--- a/http/sys_config_state_test.go
+++ b/http/sys_config_state_test.go
@@ -6,67 +6,190 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/hashicorp/vault/command/server"
+	"github.com/hashicorp/vault/internalshared/configutil"
 	"github.com/hashicorp/vault/vault"
 )
 
 func TestSysConfigState_Sanitized(t *testing.T) {
-	var resp *http.Response
-
-	core, _, token := vault.TestCoreUnsealed(t)
-	ln, addr := TestServer(t, core)
-	defer ln.Close()
-	TestServerAuth(t, addr, token)
-
-	resp = testHttpGet(t, token, addr+"/v1/sys/config/state/sanitized")
-	testResponseStatus(t, resp, 200)
-
-	var actual map[string]interface{}
-	var expected map[string]interface{}
-
-	configResp := map[string]interface{}{
-		"api_addr":                            "",
-		"cache_size":                          json.Number("0"),
-		"cluster_addr":                        "",
-		"cluster_cipher_suites":               "",
-		"cluster_name":                        "",
-		"default_lease_ttl":                   json.Number("0"),
-		"default_max_request_duration":        json.Number("0"),
-		"disable_cache":                       false,
-		"disable_clustering":                  false,
-		"disable_indexing":                    false,
-		"disable_mlock":                       false,
-		"disable_performance_standby":         false,
-		"disable_printable_check":             false,
-		"disable_sealwrap":                    false,
-		"raw_storage_endpoint":                false,
-		"disable_sentinel_trace":              false,
-		"enable_ui":                           false,
-		"log_format":                          "",
-		"log_level":                           "",
-		"max_lease_ttl":                       json.Number("0"),
-		"pid_file":                            "",
-		"plugin_directory":                    "",
-		"plugin_file_uid":                     json.Number("0"),
-		"plugin_file_permissions":             json.Number("0"),
-		"enable_response_header_hostname":     false,
-		"enable_response_header_raft_node_id": false,
-		"log_requests_level":                  "",
+	cases := []struct {
+		name                    string
+		storageConfig           *server.Storage
+		haStorageConfig         *server.Storage
+		expectedStorageOutput   map[string]interface{}
+		expectedHAStorageOutput map[string]interface{}
+	}{
+		{
+			name: "raft storage",
+			storageConfig: &server.Storage{
+				Type:              "raft",
+				RedirectAddr:      "http://127.0.0.1:8200",
+				ClusterAddr:       "http://127.0.0.1:8201",
+				DisableClustering: false,
+				Config: map[string]string{
+					"path":           "/storage/path/raft",
+					"node_id":        "raft1",
+					"max_entry_size": "2097152",
+				},
+			},
+			haStorageConfig: nil,
+			expectedStorageOutput: map[string]interface{}{
+				"type":               "raft",
+				"redirect_addr":      "http://127.0.0.1:8200",
+				"cluster_addr":       "http://127.0.0.1:8201",
+				"disable_clustering": false,
+				"raft": map[string]interface{}{
+					"max_entry_size": "2097152",
+				},
+			},
+			expectedHAStorageOutput: nil,
+		},
+		{
+			name: "inmem storage, no HA storage",
+			storageConfig: &server.Storage{
+				Type:              "inmem",
+				RedirectAddr:      "http://127.0.0.1:8200",
+				ClusterAddr:       "http://127.0.0.1:8201",
+				DisableClustering: false,
+			},
+			haStorageConfig: nil,
+			expectedStorageOutput: map[string]interface{}{
+				"type":               "inmem",
+				"redirect_addr":      "http://127.0.0.1:8200",
+				"cluster_addr":       "http://127.0.0.1:8201",
+				"disable_clustering": false,
+			},
+			expectedHAStorageOutput: nil,
+		},
+		{
+			name: "inmem storage, raft HA storage",
+			storageConfig: &server.Storage{
+				Type:              "inmem",
+				RedirectAddr:      "http://127.0.0.1:8200",
+				ClusterAddr:       "http://127.0.0.1:8201",
+				DisableClustering: false,
+			},
+			haStorageConfig: &server.Storage{
+				Type:              "raft",
+				RedirectAddr:      "http://127.0.0.1:8200",
+				ClusterAddr:       "http://127.0.0.1:8201",
+				DisableClustering: false,
+				Config: map[string]string{
+					"path":           "/storage/path/raft",
+					"node_id":        "raft1",
+					"max_entry_size": "2097152",
+				},
+			},
+			expectedStorageOutput: map[string]interface{}{
+				"type":               "inmem",
+				"redirect_addr":      "http://127.0.0.1:8200",
+				"cluster_addr":       "http://127.0.0.1:8201",
+				"disable_clustering": false,
+			},
+			expectedHAStorageOutput: map[string]interface{}{
+				"type":               "raft",
+				"redirect_addr":      "http://127.0.0.1:8200",
+				"cluster_addr":       "http://127.0.0.1:8201",
+				"disable_clustering": false,
+				"raft": map[string]interface{}{
+					"max_entry_size": "2097152",
+				},
+			},
+		},
 	}
 
-	expected = map[string]interface{}{
-		"lease_id":       "",
-		"renewable":      false,
-		"lease_duration": json.Number("0"),
-		"wrap_info":      nil,
-		"warnings":       nil,
-		"auth":           nil,
-		"data":           configResp,
-	}
+	for _, tc := range cases {
+		tc := tc
 
-	testResponseBody(t, resp, &actual)
-	expected["request_id"] = actual["request_id"]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	if diff := deep.Equal(actual, expected); len(diff) > 0 {
-		t.Fatalf("bad mismatch response body: diff: %v", diff)
+			var resp *http.Response
+			confRaw := &server.Config{
+				Storage:   tc.storageConfig,
+				HAStorage: tc.haStorageConfig,
+				SharedConfig: &configutil.SharedConfig{
+					Listeners: []*configutil.Listener{
+						{
+							Type:    "tcp",
+							Address: "127.0.0.1",
+						},
+					},
+				},
+			}
+
+			conf := &vault.CoreConfig{
+				RawConfig: confRaw,
+			}
+
+			core, _, token := vault.TestCoreUnsealedWithConfig(t, conf)
+			ln, addr := TestServer(t, core)
+			defer ln.Close()
+			TestServerAuth(t, addr, token)
+
+			resp = testHttpGet(t, token, addr+"/v1/sys/config/state/sanitized")
+			testResponseStatus(t, resp, 200)
+
+			var actual map[string]interface{}
+			var expected map[string]interface{}
+
+			configResp := map[string]interface{}{
+				"api_addr":                            "",
+				"cache_size":                          json.Number("0"),
+				"cluster_addr":                        "",
+				"cluster_cipher_suites":               "",
+				"cluster_name":                        "",
+				"default_lease_ttl":                   json.Number("0"),
+				"default_max_request_duration":        json.Number("0"),
+				"disable_cache":                       false,
+				"disable_clustering":                  false,
+				"disable_indexing":                    false,
+				"disable_mlock":                       false,
+				"disable_performance_standby":         false,
+				"disable_printable_check":             false,
+				"disable_sealwrap":                    false,
+				"raw_storage_endpoint":                false,
+				"disable_sentinel_trace":              false,
+				"enable_ui":                           false,
+				"log_format":                          "",
+				"log_level":                           "",
+				"max_lease_ttl":                       json.Number("0"),
+				"pid_file":                            "",
+				"plugin_directory":                    "",
+				"plugin_file_uid":                     json.Number("0"),
+				"plugin_file_permissions":             json.Number("0"),
+				"enable_response_header_hostname":     false,
+				"enable_response_header_raft_node_id": false,
+				"log_requests_level":                  "",
+				"listeners": []interface{}{
+					map[string]interface{}{
+						"config": nil,
+						"type":   "tcp",
+					},
+				},
+				"storage": tc.expectedStorageOutput,
+			}
+
+			if tc.expectedHAStorageOutput != nil {
+				configResp["ha_storage"] = tc.expectedHAStorageOutput
+			}
+
+			expected = map[string]interface{}{
+				"lease_id":       "",
+				"renewable":      false,
+				"lease_duration": json.Number("0"),
+				"wrap_info":      nil,
+				"warnings":       nil,
+				"auth":           nil,
+				"data":           configResp,
+			}
+
+			testResponseBody(t, resp, &actual)
+			expected["request_id"] = actual["request_id"]
+
+			if diff := deep.Equal(actual, expected); len(diff) > 0 {
+				t.Fatalf("bad mismatch response body: diff: %v", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Backport

This PR is was meant to be auto-generated from #20044 but there were merge conflicts so I am opening up a new PR with a manual cherry-pick.



The below text is copied from the body of the original PR.

---

This PR adds a `raft` sub-field to the [sanitized config](https://developer.hashicorp.com/vault/api-docs/system/config-state#get-sanitized-configuration-state) storage and HA storage details in order to expose Raft's [max_entry_size](https://developer.hashicorp.com/vault/docs/configuration/storage/raft#max_entry_size).

---

<details>
<summary> Overview of commits </summary>

  - ca702745e8bb68994fd2e323dfba78f144abbcb8 

</details>


