### PR TITLE
sdk/ldap: update interface to use DialURL

### DIFF
--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -82,9 +82,10 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 			}
 
 			fullAddr := fmt.Sprintf("%s://%s", u.Scheme, net.JoinHostPort(host, port))
-			opt := ldap.DialWithTLSDialer(tlsConfig, &dialer)
+			opt := ldap.DialWithDialer(&dialer)
+			tls := ldap.DialWithTLSConfig(tlsConfig)
 
-			conn, err = c.LDAP.DialURL(fullAddr, opt)
+			conn, err = c.LDAP.DialURL(fullAddr, opt, tls)
 			if err != nil {
 				break
 			}

--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -32,11 +32,6 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 	var conn Connection
 	urls := strings.Split(cfg.Url, ",")
 
-	// Default timeout in the pacakge is 60 seconds, which we default to on our
-	// end. This is useful if you want to take advantage of the URL list to increase
-	// availability of LDAP.
-	ldap.DefaultTimeout = time.Duration(cfg.ConnectionTimeout) * time.Second
-
 	for _, uut := range urls {
 		u, err := url.Parse(uut)
 		if err != nil {

--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -59,8 +59,10 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 				port = "389"
 			}
 
+			fullAddr := fmt.Sprintf("%s://%s", u.Scheme, net.JoinHostPort(host, port))
 			opt := ldap.DialWithDialer(&dialer)
-			conn, err = c.LDAP.Dial(net.JoinHostPort(host, port), opt)
+
+			conn, err = c.LDAP.DialURL(fullAddr, opt)
 			if err != nil {
 				break
 			}
@@ -83,8 +85,11 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 			if err != nil {
 				break
 			}
+
+			fullAddr := fmt.Sprintf("%s://%s", u.Scheme, net.JoinHostPort(host, port))
 			opt := ldap.DialWithTLSDialer(tlsConfig, &dialer)
-			conn, err = c.LDAP.Dial(net.JoinHostPort(host, port), opt)
+
+			conn, err = c.LDAP.DialURL(fullAddr, opt)
 			if err != nil {
 				break
 			}

--- a/sdk/helper/ldaputil/ldap.go
+++ b/sdk/helper/ldaputil/ldap.go
@@ -14,11 +14,11 @@ func NewLDAP() LDAP {
 // LDAP provides ldap functionality, but through an interface
 // rather than statically. This allows faking it for tests.
 type LDAP interface {
-	Dial(addr string, opts ...ldap.DialOpt) (Connection, error)
+	DialURL(addr string, opts ...ldap.DialOpt) (Connection, error)
 }
 
 type ldapIfc struct{}
 
-func (l *ldapIfc) Dial(addr string, opts ...ldap.DialOpt) (Connection, error) {
+func (l *ldapIfc) DialURL(addr string, opts ...ldap.DialOpt) (Connection, error) {
 	return ldap.DialURL(addr, opts...)
 }

--- a/sdk/helper/ldaputil/ldap.go
+++ b/sdk/helper/ldaputil/ldap.go
@@ -4,8 +4,6 @@
 package ldaputil
 
 import (
-	"crypto/tls"
-
 	"github.com/go-ldap/ldap/v3"
 )
 
@@ -16,16 +14,11 @@ func NewLDAP() LDAP {
 // LDAP provides ldap functionality, but through an interface
 // rather than statically. This allows faking it for tests.
 type LDAP interface {
-	Dial(network, addr string) (Connection, error)
-	DialTLS(network, addr string, config *tls.Config) (Connection, error)
+	Dial(addr string, opts ...ldap.DialOpt) (Connection, error)
 }
 
 type ldapIfc struct{}
 
-func (l *ldapIfc) Dial(network, addr string) (Connection, error) {
-	return ldap.Dial(network, addr)
-}
-
-func (l *ldapIfc) DialTLS(network, addr string, config *tls.Config) (Connection, error) {
-	return ldap.DialTLS(network, addr, config)
+func (l *ldapIfc) Dial(addr string, opts ...ldap.DialOpt) (Connection, error) {
+	return ldap.DialURL(addr, opts...)
 }


### PR DESCRIPTION
I recently merged https://github.com/hashicorp/vault/pull/20144 which adds connection timeout configuration, however, this was causing race tests to fail since it was changing a package variable. To fix this, I've changed the LDAP interface to use the suggested `ldap.DialURL` function instead of the deprecated `ldap.Dial` and `ldap.DialTLS` functions.