### PR TITLE
Remove extraneous certificate from OCSP response

### DIFF
--- a/builtin/logical/pki/path_ocsp.go
+++ b/builtin/logical/pki/path_ocsp.go
@@ -499,13 +499,19 @@ func genResponse(cfg *crlConfig, caBundle *certutil.ParsedCertBundle, info *ocsp
 		revSigAlg = x509.SHA512WithRSA
 	}
 
+	// Due to a bug in Go's ocsp.ParseResponse(...), we do not provision
+	// Certificate any more on the response to help Go based OCSP clients.
+	// This was technically unnecessary, as the Certificate given here
+	// both signed the OCSP response and issued the leaf cert, and so
+	// should already be trusted by the client.
+	//
+	// See also: https://github.com/golang/go/issues/59641
 	template := ocsp.Response{
 		IssuerHash:         reqHash,
 		Status:             info.ocspStatus,
 		SerialNumber:       info.serialNumber,
 		ThisUpdate:         curTime,
 		NextUpdate:         curTime.Add(duration),
-		Certificate:        caBundle.Certificate,
 		ExtraExtensions:    []pkix.Extension{},
 		SignatureAlgorithm: revSigAlg,
 	}

--- a/builtin/logical/pki/path_ocsp_test.go
+++ b/builtin/logical/pki/path_ocsp_test.go
@@ -365,7 +365,6 @@ func TestOcsp_MultipleMatchingIssuersOneWithoutSigningUsage(t *testing.T) {
 	require.Equal(t, crypto.SHA1, ocspResp.IssuerHash)
 	require.Equal(t, 0, ocspResp.RevocationReason)
 	require.Equal(t, testEnv.leafCertIssuer1.SerialNumber, ocspResp.SerialNumber)
-	require.Equal(t, rotatedCert, ocspResp.Certificate)
 
 	requireOcspSignatureAlgoForKey(t, rotatedCert.SignatureAlgorithm, ocspResp.SignatureAlgorithm)
 	requireOcspResponseSignedBy(t, ocspResp, rotatedCert)
@@ -442,7 +441,6 @@ func TestOcsp_HigherLevel(t *testing.T) {
 	require.NoError(t, err, "parsing ocsp get response")
 
 	require.Equal(t, ocsp.Revoked, ocspResp.Status)
-	require.Equal(t, issuerCert, ocspResp.Certificate)
 	require.Equal(t, certToRevoke.SerialNumber, ocspResp.SerialNumber)
 
 	// Test OCSP Get request for ocsp
@@ -463,7 +461,6 @@ func TestOcsp_HigherLevel(t *testing.T) {
 	require.NoError(t, err, "parsing ocsp get response")
 
 	require.Equal(t, ocsp.Revoked, ocspResp.Status)
-	require.Equal(t, issuerCert, ocspResp.Certificate)
 	require.Equal(t, certToRevoke.SerialNumber, ocspResp.SerialNumber)
 }
 
@@ -527,7 +524,6 @@ func runOcspRequestTest(t *testing.T, requestType string, caKeyType string, caKe
 
 	require.Equal(t, ocsp.Good, ocspResp.Status)
 	require.Equal(t, requestHash, ocspResp.IssuerHash)
-	require.Equal(t, testEnv.issuer1, ocspResp.Certificate)
 	require.Equal(t, 0, ocspResp.RevocationReason)
 	require.Equal(t, testEnv.leafCertIssuer1.SerialNumber, ocspResp.SerialNumber)
 
@@ -552,7 +548,6 @@ func runOcspRequestTest(t *testing.T, requestType string, caKeyType string, caKe
 
 	require.Equal(t, ocsp.Revoked, ocspResp.Status)
 	require.Equal(t, requestHash, ocspResp.IssuerHash)
-	require.Equal(t, testEnv.issuer1, ocspResp.Certificate)
 	require.Equal(t, 0, ocspResp.RevocationReason)
 	require.Equal(t, testEnv.leafCertIssuer1.SerialNumber, ocspResp.SerialNumber)
 
@@ -572,7 +567,6 @@ func runOcspRequestTest(t *testing.T, requestType string, caKeyType string, caKe
 
 	require.Equal(t, ocsp.Good, ocspResp.Status)
 	require.Equal(t, requestHash, ocspResp.IssuerHash)
-	require.Equal(t, testEnv.issuer2, ocspResp.Certificate)
 	require.Equal(t, 0, ocspResp.RevocationReason)
 	require.Equal(t, testEnv.leafCertIssuer2.SerialNumber, ocspResp.SerialNumber)
 


### PR DESCRIPTION
Since the issuer used to sign the certificate also signs the OCSP response, no additional information is added by sending the issuer again in the `certs` field of the `BasicOCSPResponse` structure. Removing it saves bytes and avoids confusing Go-based OCSP verifiers which cannot handle the cert issuer being duplicated in the `certs` field.

---

This complements #20181; if anyone uses a different cluster for Vault PKI from Cert Auth and are running Vault 1.12.x, they could update that cluster to a future 1.12 Vault release, instead of (or in addition to) updating the cluster running Cert Auth to a newer 1.13 version. This additionally improves compatibility with any other Go OCSP validation that may be occurring (e.g., Snowflake or others as reported on the upstream Go issue).