### PR TITLE
Add missing MongoDB Atlas fields to the docs

### DIFF
--- a/website/content/api-docs/secret/mongodbatlas.mdx
+++ b/website/content/api-docs/secret/mongodbatlas.mdx
@@ -90,6 +90,10 @@ either the MongoDB Atlas Organization or Project level with the designated role(
 
 * `ip_addresses` `(list [string] <Optional>)` - IP address to be added to the whitelist for the API key. This field is mutually exclusive with the cidrBlock field.
 * `cidr_blocks` `(list [string] <Optional>)` - Whitelist entry in CIDR notation to be added for the API key. This field is mutually exclusive with the ipAddress field.
+* `project_roles` `(list [string] <Optional>)` - Roles assigned when an Organization API key is assigned to a Projects API key.
+* `ttl` `(string <Optional>)` - Duration in seconds after which the issued credential should expire. Defaults to 0, in which case the value will fallback to the system/mount defaults.
+* `max_ttl` `(string <Optional>)` - The maximum allowed lifetime of credentials issued using this role.
+
 
 ### Sample Payload
 


### PR DESCRIPTION
Small PR to add missing parameters to MongoDB Atlas api-docs. While working on MongoDB Atlas TFVP, I saw that we are missing `project_roles`, `ttl`, `max_ttl` fields in our docs. 