### PR TITLE
Run UI tests on PRs with "ui" label

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,9 @@ jobs:
           MATRIX_MAX_TEST_GROUPS: 5
         run: |
           # shellcheck disable=SC2129
+          echo contains(github.event.pull_request.labels.*.name, 'ui') 
+          echo ${{ github.event.label.name == 'ui' }}
+          echo ${{ github.event.pull_request.label.name == 'ui' }}
           echo "build-date=$(make ci-get-date)" >> "$GITHUB_OUTPUT"
           echo "go-version=$(cat ./.go-version)" >> "$GITHUB_OUTPUT"
           echo "matrix-test-group=$(make ci-get-matrix-group-id)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,9 @@ jobs:
           MATRIX_MAX_TEST_GROUPS: 5
         run: |
           # shellcheck disable=SC2129
-          echo "contains(github.event.pull_request.labels.*.name, 'ui')"
-          echo "${{ github.event.label.name == 'ui' }}"
-          echo "${{ github.event.pull_request.label.name == 'ui' }}"
+          echo "${{ contains(github.event.pull_request.labels.*.name, 'ui') }}"
+          echo "${{ github.event.pull_request.label }}"
+          echo "${{ github.event.pull_request.labels }}"
           echo "build-date=$(make ci-get-date)" >> "$GITHUB_OUTPUT"
           echo "go-version=$(cat ./.go-version)" >> "$GITHUB_OUTPUT"
           echo "matrix-test-group=$(make ci-get-matrix-group-id)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,6 @@ jobs:
           MATRIX_MAX_TEST_GROUPS: 5
         run: |
           # shellcheck disable=SC2129
-          echo "${{ contains(github.event.pull_request.labels.*.name, 'ui') }}"
-          echo "${{ github.event.pull_request.label }}"
-          echo "${{ github.event.pull_request.labels }}"
           echo "build-date=$(make ci-get-date)" >> "$GITHUB_OUTPUT"
           echo "go-version=$(cat ./.go-version)" >> "$GITHUB_OUTPUT"
           echo "matrix-test-group=$(make ci-get-matrix-group-id)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           MATRIX_MAX_TEST_GROUPS: 5
         run: |
           # shellcheck disable=SC2129
-          echo "contains(github.event.pull_request.labels.*.name, 'ui')"" 
+          echo "contains(github.event.pull_request.labels.*.name, 'ui')"
           echo "${{ github.event.label.name == 'ui' }}"
           echo "${{ github.event.pull_request.label.name == 'ui' }}"
           echo "build-date=$(make ci-get-date)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,9 @@ jobs:
           MATRIX_MAX_TEST_GROUPS: 5
         run: |
           # shellcheck disable=SC2129
-          echo contains(github.event.pull_request.labels.*.name, 'ui') 
-          echo ${{ github.event.label.name == 'ui' }}
-          echo ${{ github.event.pull_request.label.name == 'ui' }}
+          echo "contains(github.event.pull_request.labels.*.name, 'ui')"" 
+          echo "${{ github.event.label.name == 'ui' }}"
+          echo "${{ github.event.pull_request.label.name == 'ui' }}"
           echo "build-date=$(make ci-get-date)" >> "$GITHUB_OUTPUT"
           echo "go-version=$(cat ./.go-version)" >> "$GITHUB_OUTPUT"
           echo "matrix-test-group=$(make ci-get-matrix-group-id)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
     # The test-ui job is only run on:
     # - pushes to main and branches starting with "release/"
     # - PRs where the branch starts with "ui/", "backport/ui/", "merge", or when base branch starts with "release/"
-    # - PRs with the "ui" label on github
+    # - PRs with a "ui" label on github
     if: |
       github.ref_name == 'main' ||
       startsWith(github.ref_name, 'release/') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 on:
   pull_request:
+    types: [ labeled, unlabeled ]
   push:
     branches:
       - "main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   pull_request:
-   types: [labeled, unlabeled]
+    types: [opened, labeled, unlabeled]
   push:
     branches:
       - "main"
@@ -19,44 +19,44 @@ jobs:
       enterprise: ${{ steps.setup-outputs.outputs.enterprise }}
       go-build-tags: ${{ steps.setup-outputs.outputs.go-build-tags }}
     steps:
-    - id: setup-outputs
-      name: Setup outputs
-      run: |
-        github_repository="${{ github.repository }}"
+      - id: setup-outputs
+        name: Setup outputs
+        run: |
+          github_repository="${{ github.repository }}"
 
-        if [ "${github_repository##*/}" == "vault-enterprise" ] ; then
-          # shellcheck disable=SC2129
-          echo 'compute-tiny=["self-hosted","ondemand","linux","type=m5.large"]' >> "$GITHUB_OUTPUT"
-          echo 'compute-standard=["self-hosted","ondemand","linux","type=m5.xlarge"]' >> "$GITHUB_OUTPUT"
-          echo 'compute-larger=["self-hosted","ondemand","linux","type=m5.2xlarge"]' >> "$GITHUB_OUTPUT"
-          echo 'compute-huge=["self-hosted","ondemand","linux","type=m5.4xlarge"]' >> "$GITHUB_OUTPUT"
-          echo 'enterprise=1' >> "$GITHUB_OUTPUT"
-          echo 'go-build-tags=ent,enterprise' >> "$GITHUB_OUTPUT"
-        else
-          # shellcheck disable=SC2129
-          echo 'compute-tiny="ubuntu-latest"' >> "$GITHUB_OUTPUT"                         #  2 cores,   7 GB RAM,   14 GB SSD
-          echo 'compute-standard="custom-linux-small-vault-latest"' >> "$GITHUB_OUTPUT"   #  8 cores,  32 GB RAM,  300 GB SSD
-          echo 'compute-larger="custom-linux-medium-vault-latest"' >> "$GITHUB_OUTPUT"    # 16 cores,  64 GB RAM,  600 GB SSD
-          echo 'compute-huge="custom-linux-xl-vault-latest"' >> "$GITHUB_OUTPUT"          # 32-cores, 128 GB RAM, 1200 GB SSD
-          echo 'enterprise=' >> "$GITHUB_OUTPUT"
-          echo 'go-build-tags=' >> "$GITHUB_OUTPUT"
-        fi
+          if [ "${github_repository##*/}" == "vault-enterprise" ] ; then
+            # shellcheck disable=SC2129
+            echo 'compute-tiny=["self-hosted","ondemand","linux","type=m5.large"]' >> "$GITHUB_OUTPUT"
+            echo 'compute-standard=["self-hosted","ondemand","linux","type=m5.xlarge"]' >> "$GITHUB_OUTPUT"
+            echo 'compute-larger=["self-hosted","ondemand","linux","type=m5.2xlarge"]' >> "$GITHUB_OUTPUT"
+            echo 'compute-huge=["self-hosted","ondemand","linux","type=m5.4xlarge"]' >> "$GITHUB_OUTPUT"
+            echo 'enterprise=1' >> "$GITHUB_OUTPUT"
+            echo 'go-build-tags=ent,enterprise' >> "$GITHUB_OUTPUT"
+          else
+            # shellcheck disable=SC2129
+            echo 'compute-tiny="ubuntu-latest"' >> "$GITHUB_OUTPUT"                         #  2 cores,   7 GB RAM,   14 GB SSD
+            echo 'compute-standard="custom-linux-small-vault-latest"' >> "$GITHUB_OUTPUT"   #  8 cores,  32 GB RAM,  300 GB SSD
+            echo 'compute-larger="custom-linux-medium-vault-latest"' >> "$GITHUB_OUTPUT"    # 16 cores,  64 GB RAM,  600 GB SSD
+            echo 'compute-huge="custom-linux-xl-vault-latest"' >> "$GITHUB_OUTPUT"          # 32-cores, 128 GB RAM, 1200 GB SSD
+            echo 'enterprise=' >> "$GITHUB_OUTPUT"
+            echo 'go-build-tags=' >> "$GITHUB_OUTPUT"
+          fi
   semgrep:
     name: Semgrep
     needs:
-    - setup
+      - setup
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     container:
       image: returntocorp/semgrep@sha256:ffc6f3567654f9431456d49fd059dfe548f007c494a7eb6cd5a1a3e50d813fb3
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-    - name: Run Semgrep Rules
-      id: semgrep
-      run: semgrep ci --include '*.go' --config 'tools/semgrep/ci'
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - name: Run Semgrep Rules
+        id: semgrep
+        run: semgrep ci --include '*.go' --config 'tools/semgrep/ci'
   setup-go-cache:
     name: Go Caches
     needs:
-    - setup
+      - setup
     uses: ./.github/workflows/setup-go-cache.yml
     with:
       runs-on: ${{ needs.setup.outputs.compute-standard }}
@@ -64,59 +64,59 @@ jobs:
   fmt:
     name: Check Format
     needs:
-    - setup
+      - setup
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-    - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
-      with:
-        go-version-file: ./.go-version
-        cache: true
-    - id: format
-      run: |
-        echo "Using gofumpt version $(go run mvdan.cc/gofumpt -version)"
-        make fmt
-        if ! git diff --exit-code; then
-          echo "Code has formatting errors. Run 'make fmt' to fix"
-          exit 1
-        fi
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
+        with:
+          go-version-file: ./.go-version
+          cache: true
+      - id: format
+        run: |
+          echo "Using gofumpt version $(go run mvdan.cc/gofumpt -version)"
+          make fmt
+          if ! git diff --exit-code; then
+            echo "Code has formatting errors. Run 'make fmt' to fix"
+            exit 1
+          fi
   diff-oss-ci:
     name: Diff OSS
     needs:
-    - setup
+      - setup
     if: ${{ needs.setup.outputs.enterprise != '' && github.base_ref != '' }}
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      with:
-        fetch-depth: 0
-    - id: determine-branch
-      run: |
-        branch="${{ github.base_ref }}"
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          fetch-depth: 0
+      - id: determine-branch
+        run: |
+          branch="${{ github.base_ref }}"
 
-        if [[ $branch = release/* ]] ; then
-          branch=${branch%%+ent}
+          if [[ $branch = release/* ]] ; then
+            branch=${branch%%+ent}
 
-          # Add OSS remote
-          git config --global user.email "github-team-secret-vault-core@hashicorp.com"
-          git config --global user.name "hc-github-team-secret-vault-core"
-          git remote add oss https://github.com/hashicorp/vault.git
-          git fetch oss "$branch"
+            # Add OSS remote
+            git config --global user.email "github-team-secret-vault-core@hashicorp.com"
+            git config --global user.name "hc-github-team-secret-vault-core"
+            git remote add oss https://github.com/hashicorp/vault.git
+            git fetch oss "$branch"
 
-          branch="oss/$branch"
-        else
-          branch="origin/$branch"
-        fi
+            branch="oss/$branch"
+          else
+            branch="origin/$branch"
+          fi
 
-        echo "BRANCH=$branch" >> "$GITHUB_OUTPUT"
-    - id: diff
-      run: |
-        ./.github/scripts/oss-diff.sh ${{ steps.determine-branch.outputs.BRANCH }} HEAD
+          echo "BRANCH=$branch" >> "$GITHUB_OUTPUT"
+      - id: diff
+        run: |
+          ./.github/scripts/oss-diff.sh ${{ steps.determine-branch.outputs.BRANCH }} HEAD
   test-go:
     name: Run Go tests
     needs:
-    - setup
-    - setup-go-cache
+      - setup
+      - setup-go-cache
     # Don't run this job for PR branches starting with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
     if: |
       !startsWith(github.head_ref, 'ui/') &&
@@ -127,15 +127,15 @@ jobs:
     with:
       total-runners: 16
       go-arch: amd64
-      go-build-tags: '${{ needs.setup.outputs.go-build-tags }},deadlock'
+      go-build-tags: "${{ needs.setup.outputs.go-build-tags }},deadlock"
       runs-on: ${{ needs.setup.outputs.compute-larger }}
       enterprise: ${{ needs.setup.outputs.enterprise }}
     secrets: inherit
   test-go-race:
     name: Run Go tests with data race detection
     needs:
-    - setup
-    - setup-go-cache
+      - setup
+      - setup-go-cache
     # Don't run this job for PR branches starting with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
     if: |
       !startsWith(github.head_ref, 'ui/') &&
@@ -149,7 +149,7 @@ jobs:
         {
           "VAULT_CI_GO_TEST_RACE": 1
         }
-      extra-flags: '-race'
+      extra-flags: "-race"
       go-arch: amd64
       go-build-tags: ${{ needs.setup.outputs.go-build-tags }}
       runs-on: ${{ needs.setup.outputs.compute-huge }}
@@ -165,8 +165,8 @@ jobs:
       !startsWith(github.head_ref, 'docs/') &&
       !startsWith(github.head_ref, 'backport/docs/')
     needs:
-    - setup
-    - setup-go-cache
+      - setup
+      - setup-go-cache
     uses: ./.github/workflows/test-go.yml
     with:
       total-runners: 16
@@ -175,7 +175,7 @@ jobs:
           "GOEXPERIMENT": "boringcrypto"
         }
       go-arch: amd64
-      go-build-tags: '${{ needs.setup.outputs.go-build-tags }},deadlock,cgo,fips,fips_140_2'
+      go-build-tags: "${{ needs.setup.outputs.go-build-tags }},deadlock,cgo,fips,fips_140_2"
       runs-on: ${{ needs.setup.outputs.compute-larger }}
       enterprise: ${{ needs.setup.outputs.enterprise }}
     secrets: inherit
@@ -193,101 +193,101 @@ jobs:
       startsWith(github.head_ref, 'merge') || 
       contains(github.event.pull_request.labels.*.name, 'ui')
     needs:
-    - setup
+      - setup
     permissions:
       id-token: write
       contents: read
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-larger) }}
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-    - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
-      with:
-        go-version-file: ./.go-version
-        cache: true
-    # Setup node.js without caching to allow running npm install -g yarn (next step)
-    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
-      with:
-        node-version-file: './ui/package.json'
-    - id: install-yarn
-      run: |
-        npm install -g yarn
-    # Setup node.js with caching using the yarn.lock file
-    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
-      with:
-        node-version-file: './ui/package.json'
-        cache: yarn
-        cache-dependency-path: ui/yarn.lock
-    - id: install-browser-libraries
-      run: sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
-    - id: install-browser
-      uses: browser-actions/setup-chrome@29abc1a83d1d71557708563b4bc962d0f983a376
-    - id: ui-dependencies
-      name: ui-dependencies
-      working-directory: ./ui
-      run: |
-        yarn install --frozen-lockfile
-        npm rebuild node-sass
-    - id: vault-auth
-      name: Authenticate to Vault
-      if: github.repository == 'hashicorp/vault-enterprise'
-      run: vault-auth
-    - id: secrets
-      name: Fetch secrets
-      if: github.repository == 'hashicorp/vault-enterprise'
-      uses: hashicorp/vault-action@130d1f5f4fe645bb6c83e4225c04d64cfb62de6e
-      with:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
+        with:
+          go-version-file: ./.go-version
+          cache: true
+      # Setup node.js without caching to allow running npm install -g yarn (next step)
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        with:
+          node-version-file: "./ui/package.json"
+      - id: install-yarn
+        run: |
+          npm install -g yarn
+      # Setup node.js with caching using the yarn.lock file
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        with:
+          node-version-file: "./ui/package.json"
+          cache: yarn
+          cache-dependency-path: ui/yarn.lock
+      - id: install-browser-libraries
+        run: sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
+      - id: install-browser
+        uses: browser-actions/setup-chrome@29abc1a83d1d71557708563b4bc962d0f983a376
+      - id: ui-dependencies
+        name: ui-dependencies
+        working-directory: ./ui
+        run: |
+          yarn install --frozen-lockfile
+          npm rebuild node-sass
+      - id: vault-auth
+        name: Authenticate to Vault
+        if: github.repository == 'hashicorp/vault-enterprise'
+        run: vault-auth
+      - id: secrets
+        name: Fetch secrets
+        if: github.repository == 'hashicorp/vault-enterprise'
+        uses: hashicorp/vault-action@130d1f5f4fe645bb6c83e4225c04d64cfb62de6e
+        with:
           url: ${{ steps.vault-auth.outputs.addr }}
           caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
           token: ${{ steps.vault-auth.outputs.token }}
           secrets: |
             kv/data/github/hashicorp/vault-enterprise/github-token token | PRIVATE_REPO_GITHUB_TOKEN;
             kv/data/github/hashicorp/vault-enterprise/license license_1 | VAULT_LICENSE;
-    - id: setup-git
-      name: Setup Git
-      if: github.repository == 'hashicorp/vault-enterprise'
-      env:
-        PRIVATE_REPO_GITHUB_TOKEN: ${{ steps.secrets.outputs.PRIVATE_REPO_GITHUB_TOKEN }}
-      run: |
-        git config --global url."https://hc-github-team-secure-vault-core:${PRIVATE_REPO_GITHUB_TOKEN}@github.com".insteadOf https://github.com
-    - id: build-go-dev
-      name: build-go-dev
-      run: |
-        rm -rf ./pkg
-        mkdir ./pkg
+      - id: setup-git
+        name: Setup Git
+        if: github.repository == 'hashicorp/vault-enterprise'
+        env:
+          PRIVATE_REPO_GITHUB_TOKEN: ${{ steps.secrets.outputs.PRIVATE_REPO_GITHUB_TOKEN }}
+        run: |
+          git config --global url."https://hc-github-team-secure-vault-core:${PRIVATE_REPO_GITHUB_TOKEN}@github.com".insteadOf https://github.com
+      - id: build-go-dev
+        name: build-go-dev
+        run: |
+          rm -rf ./pkg
+          mkdir ./pkg
 
-        make ci-bootstrap dev
-    - id: test-ui
-      name: test-ui
-      env:
-        VAULT_LICENSE: ${{ steps.secrets.outputs.VAULT_LICENSE }}
-      run: |
-        export PATH="${PWD}/bin:${PATH}"
+          make ci-bootstrap dev
+      - id: test-ui
+        name: test-ui
+        env:
+          VAULT_LICENSE: ${{ steps.secrets.outputs.VAULT_LICENSE }}
+        run: |
+          export PATH="${PWD}/bin:${PATH}"
 
-        if [ "${{ github.repository }}" == 'hashicorp/vault' ] ; then
-          export VAULT_LICENSE="${{ secrets.VAULT_LICENSE }}"
-        fi
+          if [ "${{ github.repository }}" == 'hashicorp/vault' ] ; then
+            export VAULT_LICENSE="${{ secrets.VAULT_LICENSE }}"
+          fi
 
-        # Run Ember tests
-        cd ui
-        mkdir -p test-results/qunit
-        yarn test:oss
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
-      with:
-        name: test-results-ui
-        path: ui/test-results
-      if: always()
-    - uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f
-      with:
-        paths: "ui/test-results/qunit/results.xml"
-        show: "fail"
-      if: always()
+          # Run Ember tests
+          cd ui
+          mkdir -p test-results/qunit
+          yarn test:oss
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        with:
+          name: test-results-ui
+          path: ui/test-results
+        if: always()
+      - uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f
+        with:
+          paths: "ui/test-results/qunit/results.xml"
+          show: "fail"
+        if: always()
   tests-completed:
     needs:
-    - setup
-    - test-go
-    - test-ui
+      - setup
+      - test-go
+      - test-ui
     if: always()
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-    - run: |
-        tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)' 
+      - run: |
+          tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
     # The test-ui job is only run on:
     # - pushes to main and branches starting with "release/"
     # - PRs where the branch starts with "ui/", "backport/ui/", "merge", or when base branch starts with "release/"
-    # - PRs with a "ui" label on github
+    # - PRs with the "ui" label on github
     if: |
       github.ref_name == 'main' ||
       startsWith(github.ref_name, 'release/') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
     # The test-ui job is only run on:
     # - pushes to main and branches starting with "release/"
     # - PRs where the branch starts with "ui/", "backport/ui/", "merge", or when base branch starts with "release/"
-    # - PRs that include the "ui" label
+    # - PRs that include the "ui" label on github
     if: |
       github.ref_name == 'main' ||
       startsWith(github.ref_name, 'release/') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,44 +18,44 @@ jobs:
       enterprise: ${{ steps.setup-outputs.outputs.enterprise }}
       go-build-tags: ${{ steps.setup-outputs.outputs.go-build-tags }}
     steps:
-      - id: setup-outputs
-        name: Setup outputs
-        run: |
-          github_repository="${{ github.repository }}"
+    - id: setup-outputs
+      name: Setup outputs
+      run: |
+        github_repository="${{ github.repository }}"
 
-          if [ "${github_repository##*/}" == "vault-enterprise" ] ; then
-            # shellcheck disable=SC2129
-            echo 'compute-tiny=["self-hosted","ondemand","linux","type=m5.large"]' >> "$GITHUB_OUTPUT"
-            echo 'compute-standard=["self-hosted","ondemand","linux","type=m5.xlarge"]' >> "$GITHUB_OUTPUT"
-            echo 'compute-larger=["self-hosted","ondemand","linux","type=m5.2xlarge"]' >> "$GITHUB_OUTPUT"
-            echo 'compute-huge=["self-hosted","ondemand","linux","type=m5.4xlarge"]' >> "$GITHUB_OUTPUT"
-            echo 'enterprise=1' >> "$GITHUB_OUTPUT"
-            echo 'go-build-tags=ent,enterprise' >> "$GITHUB_OUTPUT"
-          else
-            # shellcheck disable=SC2129
-            echo 'compute-tiny="ubuntu-latest"' >> "$GITHUB_OUTPUT"                         #  2 cores,   7 GB RAM,   14 GB SSD
-            echo 'compute-standard="custom-linux-small-vault-latest"' >> "$GITHUB_OUTPUT"   #  8 cores,  32 GB RAM,  300 GB SSD
-            echo 'compute-larger="custom-linux-medium-vault-latest"' >> "$GITHUB_OUTPUT"    # 16 cores,  64 GB RAM,  600 GB SSD
-            echo 'compute-huge="custom-linux-xl-vault-latest"' >> "$GITHUB_OUTPUT"          # 32-cores, 128 GB RAM, 1200 GB SSD
-            echo 'enterprise=' >> "$GITHUB_OUTPUT"
-            echo 'go-build-tags=' >> "$GITHUB_OUTPUT"
-          fi
+        if [ "${github_repository##*/}" == "vault-enterprise" ] ; then
+          # shellcheck disable=SC2129
+          echo 'compute-tiny=["self-hosted","ondemand","linux","type=m5.large"]' >> "$GITHUB_OUTPUT"
+          echo 'compute-standard=["self-hosted","ondemand","linux","type=m5.xlarge"]' >> "$GITHUB_OUTPUT"
+          echo 'compute-larger=["self-hosted","ondemand","linux","type=m5.2xlarge"]' >> "$GITHUB_OUTPUT"
+          echo 'compute-huge=["self-hosted","ondemand","linux","type=m5.4xlarge"]' >> "$GITHUB_OUTPUT"
+          echo 'enterprise=1' >> "$GITHUB_OUTPUT"
+          echo 'go-build-tags=ent,enterprise' >> "$GITHUB_OUTPUT"
+        else
+          # shellcheck disable=SC2129
+          echo 'compute-tiny="ubuntu-latest"' >> "$GITHUB_OUTPUT"                         #  2 cores,   7 GB RAM,   14 GB SSD
+          echo 'compute-standard="custom-linux-small-vault-latest"' >> "$GITHUB_OUTPUT"   #  8 cores,  32 GB RAM,  300 GB SSD
+          echo 'compute-larger="custom-linux-medium-vault-latest"' >> "$GITHUB_OUTPUT"    # 16 cores,  64 GB RAM,  600 GB SSD
+          echo 'compute-huge="custom-linux-xl-vault-latest"' >> "$GITHUB_OUTPUT"          # 32-cores, 128 GB RAM, 1200 GB SSD
+          echo 'enterprise=' >> "$GITHUB_OUTPUT"
+          echo 'go-build-tags=' >> "$GITHUB_OUTPUT"
+        fi
   semgrep:
     name: Semgrep
     needs:
-      - setup
+    - setup
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     container:
       image: returntocorp/semgrep@sha256:ffc6f3567654f9431456d49fd059dfe548f007c494a7eb6cd5a1a3e50d813fb3
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - name: Run Semgrep Rules
-        id: semgrep
-        run: semgrep ci --include '*.go' --config 'tools/semgrep/ci'
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+    - name: Run Semgrep Rules
+      id: semgrep
+      run: semgrep ci --include '*.go' --config 'tools/semgrep/ci'
   setup-go-cache:
     name: Go Caches
     needs:
-      - setup
+    - setup
     uses: ./.github/workflows/setup-go-cache.yml
     with:
       runs-on: ${{ needs.setup.outputs.compute-standard }}
@@ -63,59 +63,59 @@ jobs:
   fmt:
     name: Check Format
     needs:
-      - setup
+    - setup
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
-        with:
-          go-version-file: ./.go-version
-          cache: true
-      - id: format
-        run: |
-          echo "Using gofumpt version $(go run mvdan.cc/gofumpt -version)"
-          make fmt
-          if ! git diff --exit-code; then
-            echo "Code has formatting errors. Run 'make fmt' to fix"
-            exit 1
-          fi
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+    - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
+      with:
+        go-version-file: ./.go-version
+        cache: true
+    - id: format
+      run: |
+        echo "Using gofumpt version $(go run mvdan.cc/gofumpt -version)"
+        make fmt
+        if ! git diff --exit-code; then
+          echo "Code has formatting errors. Run 'make fmt' to fix"
+          exit 1
+        fi
   diff-oss-ci:
     name: Diff OSS
     needs:
-      - setup
+    - setup
     if: ${{ needs.setup.outputs.enterprise != '' && github.base_ref != '' }}
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-        with:
-          fetch-depth: 0
-      - id: determine-branch
-        run: |
-          branch="${{ github.base_ref }}"
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      with:
+        fetch-depth: 0
+    - id: determine-branch
+      run: |
+        branch="${{ github.base_ref }}"
 
-          if [[ $branch = release/* ]] ; then
-            branch=${branch%%+ent}
+        if [[ $branch = release/* ]] ; then
+          branch=${branch%%+ent}
 
-            # Add OSS remote
-            git config --global user.email "github-team-secret-vault-core@hashicorp.com"
-            git config --global user.name "hc-github-team-secret-vault-core"
-            git remote add oss https://github.com/hashicorp/vault.git
-            git fetch oss "$branch"
+          # Add OSS remote
+          git config --global user.email "github-team-secret-vault-core@hashicorp.com"
+          git config --global user.name "hc-github-team-secret-vault-core"
+          git remote add oss https://github.com/hashicorp/vault.git
+          git fetch oss "$branch"
 
-            branch="oss/$branch"
-          else
-            branch="origin/$branch"
-          fi
+          branch="oss/$branch"
+        else
+          branch="origin/$branch"
+        fi
 
-          echo "BRANCH=$branch" >> "$GITHUB_OUTPUT"
-      - id: diff
-        run: |
-          ./.github/scripts/oss-diff.sh ${{ steps.determine-branch.outputs.BRANCH }} HEAD
+        echo "BRANCH=$branch" >> "$GITHUB_OUTPUT"
+    - id: diff
+      run: |
+        ./.github/scripts/oss-diff.sh ${{ steps.determine-branch.outputs.BRANCH }} HEAD
   test-go:
     name: Run Go tests
     needs:
-      - setup
-      - setup-go-cache
+    - setup
+    - setup-go-cache
     # Don't run this job for PR branches starting with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
     if: |
       !startsWith(github.head_ref, 'ui/') &&
@@ -126,15 +126,15 @@ jobs:
     with:
       total-runners: 16
       go-arch: amd64
-      go-build-tags: "${{ needs.setup.outputs.go-build-tags }},deadlock"
+      go-build-tags: '${{ needs.setup.outputs.go-build-tags }},deadlock'
       runs-on: ${{ needs.setup.outputs.compute-larger }}
       enterprise: ${{ needs.setup.outputs.enterprise }}
     secrets: inherit
   test-go-race:
     name: Run Go tests with data race detection
     needs:
-      - setup
-      - setup-go-cache
+    - setup
+    - setup-go-cache
     # Don't run this job for PR branches starting with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
     if: |
       !startsWith(github.head_ref, 'ui/') &&
@@ -148,7 +148,7 @@ jobs:
         {
           "VAULT_CI_GO_TEST_RACE": 1
         }
-      extra-flags: "-race"
+      extra-flags: '-race'
       go-arch: amd64
       go-build-tags: ${{ needs.setup.outputs.go-build-tags }}
       runs-on: ${{ needs.setup.outputs.compute-huge }}
@@ -164,8 +164,8 @@ jobs:
       !startsWith(github.head_ref, 'docs/') &&
       !startsWith(github.head_ref, 'backport/docs/')
     needs:
-      - setup
-      - setup-go-cache
+    - setup
+    - setup-go-cache
     uses: ./.github/workflows/test-go.yml
     with:
       total-runners: 16
@@ -174,7 +174,7 @@ jobs:
           "GOEXPERIMENT": "boringcrypto"
         }
       go-arch: amd64
-      go-build-tags: "${{ needs.setup.outputs.go-build-tags }},deadlock,cgo,fips,fips_140_2"
+      go-build-tags: '${{ needs.setup.outputs.go-build-tags }},deadlock,cgo,fips,fips_140_2'
       runs-on: ${{ needs.setup.outputs.compute-larger }}
       enterprise: ${{ needs.setup.outputs.enterprise }}
     secrets: inherit
@@ -192,101 +192,101 @@ jobs:
       startsWith(github.head_ref, 'merge') || 
       contains(github.event.pull_request.labels.*.name, 'ui')
     needs:
-      - setup
+    - setup
     permissions:
       id-token: write
       contents: read
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-larger) }}
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
-        with:
-          go-version-file: ./.go-version
-          cache: true
-      # Setup node.js without caching to allow running npm install -g yarn (next step)
-      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
-        with:
-          node-version-file: "./ui/package.json"
-      - id: install-yarn
-        run: |
-          npm install -g yarn
-      # Setup node.js with caching using the yarn.lock file
-      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
-        with:
-          node-version-file: "./ui/package.json"
-          cache: yarn
-          cache-dependency-path: ui/yarn.lock
-      - id: install-browser-libraries
-        run: sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
-      - id: install-browser
-        uses: browser-actions/setup-chrome@29abc1a83d1d71557708563b4bc962d0f983a376
-      - id: ui-dependencies
-        name: ui-dependencies
-        working-directory: ./ui
-        run: |
-          yarn install --frozen-lockfile
-          npm rebuild node-sass
-      - id: vault-auth
-        name: Authenticate to Vault
-        if: github.repository == 'hashicorp/vault-enterprise'
-        run: vault-auth
-      - id: secrets
-        name: Fetch secrets
-        if: github.repository == 'hashicorp/vault-enterprise'
-        uses: hashicorp/vault-action@130d1f5f4fe645bb6c83e4225c04d64cfb62de6e
-        with:
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+    - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
+      with:
+        go-version-file: ./.go-version
+        cache: true
+    # Setup node.js without caching to allow running npm install -g yarn (next step)
+    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+      with:
+        node-version-file: './ui/package.json'
+    - id: install-yarn
+      run: |
+        npm install -g yarn
+    # Setup node.js with caching using the yarn.lock file
+    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+      with:
+        node-version-file: './ui/package.json'
+        cache: yarn
+        cache-dependency-path: ui/yarn.lock
+    - id: install-browser-libraries
+      run: sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
+    - id: install-browser
+      uses: browser-actions/setup-chrome@29abc1a83d1d71557708563b4bc962d0f983a376
+    - id: ui-dependencies
+      name: ui-dependencies
+      working-directory: ./ui
+      run: |
+        yarn install --frozen-lockfile
+        npm rebuild node-sass
+    - id: vault-auth
+      name: Authenticate to Vault
+      if: github.repository == 'hashicorp/vault-enterprise'
+      run: vault-auth
+    - id: secrets
+      name: Fetch secrets
+      if: github.repository == 'hashicorp/vault-enterprise'
+      uses: hashicorp/vault-action@130d1f5f4fe645bb6c83e4225c04d64cfb62de6e
+      with:
           url: ${{ steps.vault-auth.outputs.addr }}
           caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
           token: ${{ steps.vault-auth.outputs.token }}
           secrets: |
             kv/data/github/hashicorp/vault-enterprise/github-token token | PRIVATE_REPO_GITHUB_TOKEN;
             kv/data/github/hashicorp/vault-enterprise/license license_1 | VAULT_LICENSE;
-      - id: setup-git
-        name: Setup Git
-        if: github.repository == 'hashicorp/vault-enterprise'
-        env:
-          PRIVATE_REPO_GITHUB_TOKEN: ${{ steps.secrets.outputs.PRIVATE_REPO_GITHUB_TOKEN }}
-        run: |
-          git config --global url."https://hc-github-team-secure-vault-core:${PRIVATE_REPO_GITHUB_TOKEN}@github.com".insteadOf https://github.com
-      - id: build-go-dev
-        name: build-go-dev
-        run: |
-          rm -rf ./pkg
-          mkdir ./pkg
+    - id: setup-git
+      name: Setup Git
+      if: github.repository == 'hashicorp/vault-enterprise'
+      env:
+        PRIVATE_REPO_GITHUB_TOKEN: ${{ steps.secrets.outputs.PRIVATE_REPO_GITHUB_TOKEN }}
+      run: |
+        git config --global url."https://hc-github-team-secure-vault-core:${PRIVATE_REPO_GITHUB_TOKEN}@github.com".insteadOf https://github.com
+    - id: build-go-dev
+      name: build-go-dev
+      run: |
+        rm -rf ./pkg
+        mkdir ./pkg
 
-          make ci-bootstrap dev
-      - id: test-ui
-        name: test-ui
-        env:
-          VAULT_LICENSE: ${{ steps.secrets.outputs.VAULT_LICENSE }}
-        run: |
-          export PATH="${PWD}/bin:${PATH}"
+        make ci-bootstrap dev
+    - id: test-ui
+      name: test-ui
+      env:
+        VAULT_LICENSE: ${{ steps.secrets.outputs.VAULT_LICENSE }}
+      run: |
+        export PATH="${PWD}/bin:${PATH}"
 
-          if [ "${{ github.repository }}" == 'hashicorp/vault' ] ; then
-            export VAULT_LICENSE="${{ secrets.VAULT_LICENSE }}"
-          fi
+        if [ "${{ github.repository }}" == 'hashicorp/vault' ] ; then
+          export VAULT_LICENSE="${{ secrets.VAULT_LICENSE }}"
+        fi
 
-          # Run Ember tests
-          cd ui
-          mkdir -p test-results/qunit
-          yarn test:oss
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
-        with:
-          name: test-results-ui
-          path: ui/test-results
-        if: always()
-      - uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f
-        with:
-          paths: "ui/test-results/qunit/results.xml"
-          show: "fail"
-        if: always()
+        # Run Ember tests
+        cd ui
+        mkdir -p test-results/qunit
+        yarn test:oss
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+      with:
+        name: test-results-ui
+        path: ui/test-results
+      if: always()
+    - uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f
+      with:
+        paths: "ui/test-results/qunit/results.xml"
+        show: "fail"
+      if: always()
   tests-completed:
     needs:
-      - setup
-      - test-go
-      - test-ui
+    - setup
+    - test-go
+    - test-ui
     if: always()
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-      - run: |
-          tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)'
+    - run: |
+        tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)' 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
   pull_request:
-    types: [opened, labeled, unlabeled]
   push:
     branches:
       - "main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,7 @@ jobs:
     # The test-ui job is only run on:
     # - pushes to main and branches starting with "release/"
     # - PRs where the branch starts with "ui/", "backport/ui/", "merge", or when base branch starts with "release/"
+    # - PRs that include the "ui" label
     if: |
       github.ref_name == 'main' ||
       startsWith(github.ref_name, 'release/') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,44 +18,44 @@ jobs:
       enterprise: ${{ steps.setup-outputs.outputs.enterprise }}
       go-build-tags: ${{ steps.setup-outputs.outputs.go-build-tags }}
     steps:
-      - id: setup-outputs
-        name: Setup outputs
-        run: |
-          github_repository="${{ github.repository }}"
+    - id: setup-outputs
+      name: Setup outputs
+      run: |
+        github_repository="${{ github.repository }}"
 
-          if [ "${github_repository##*/}" == "vault-enterprise" ] ; then
-            # shellcheck disable=SC2129
-            echo 'compute-tiny=["self-hosted","ondemand","linux","type=m5.large"]' >> "$GITHUB_OUTPUT"
-            echo 'compute-standard=["self-hosted","ondemand","linux","type=m5.xlarge"]' >> "$GITHUB_OUTPUT"
-            echo 'compute-larger=["self-hosted","ondemand","linux","type=m5.2xlarge"]' >> "$GITHUB_OUTPUT"
-            echo 'compute-huge=["self-hosted","ondemand","linux","type=m5.4xlarge"]' >> "$GITHUB_OUTPUT"
-            echo 'enterprise=1' >> "$GITHUB_OUTPUT"
-            echo 'go-build-tags=ent,enterprise' >> "$GITHUB_OUTPUT"
-          else
-            # shellcheck disable=SC2129
-            echo 'compute-tiny="ubuntu-latest"' >> "$GITHUB_OUTPUT"                         #  2 cores,   7 GB RAM,   14 GB SSD
-            echo 'compute-standard="custom-linux-small-vault-latest"' >> "$GITHUB_OUTPUT"   #  8 cores,  32 GB RAM,  300 GB SSD
-            echo 'compute-larger="custom-linux-medium-vault-latest"' >> "$GITHUB_OUTPUT"    # 16 cores,  64 GB RAM,  600 GB SSD
-            echo 'compute-huge="custom-linux-xl-vault-latest"' >> "$GITHUB_OUTPUT"          # 32-cores, 128 GB RAM, 1200 GB SSD
-            echo 'enterprise=' >> "$GITHUB_OUTPUT"
-            echo 'go-build-tags=' >> "$GITHUB_OUTPUT"
-          fi
+        if [ "${github_repository##*/}" == "vault-enterprise" ] ; then
+          # shellcheck disable=SC2129
+          echo 'compute-tiny=["self-hosted","ondemand","linux","type=m5.large"]' >> "$GITHUB_OUTPUT"
+          echo 'compute-standard=["self-hosted","ondemand","linux","type=m5.xlarge"]' >> "$GITHUB_OUTPUT"
+          echo 'compute-larger=["self-hosted","ondemand","linux","type=m5.2xlarge"]' >> "$GITHUB_OUTPUT"
+          echo 'compute-huge=["self-hosted","ondemand","linux","type=m5.4xlarge"]' >> "$GITHUB_OUTPUT"
+          echo 'enterprise=1' >> "$GITHUB_OUTPUT"
+          echo 'go-build-tags=ent,enterprise' >> "$GITHUB_OUTPUT"
+        else
+          # shellcheck disable=SC2129
+          echo 'compute-tiny="ubuntu-latest"' >> "$GITHUB_OUTPUT"                         #  2 cores,   7 GB RAM,   14 GB SSD
+          echo 'compute-standard="custom-linux-small-vault-latest"' >> "$GITHUB_OUTPUT"   #  8 cores,  32 GB RAM,  300 GB SSD
+          echo 'compute-larger="custom-linux-medium-vault-latest"' >> "$GITHUB_OUTPUT"    # 16 cores,  64 GB RAM,  600 GB SSD
+          echo 'compute-huge="custom-linux-xl-vault-latest"' >> "$GITHUB_OUTPUT"          # 32-cores, 128 GB RAM, 1200 GB SSD
+          echo 'enterprise=' >> "$GITHUB_OUTPUT"
+          echo 'go-build-tags=' >> "$GITHUB_OUTPUT"
+        fi
   semgrep:
     name: Semgrep
     needs:
-      - setup
+    - setup
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     container:
       image: returntocorp/semgrep@sha256:ffc6f3567654f9431456d49fd059dfe548f007c494a7eb6cd5a1a3e50d813fb3
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - name: Run Semgrep Rules
-        id: semgrep
-        run: semgrep ci --include '*.go' --config 'tools/semgrep/ci'
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+    - name: Run Semgrep Rules
+      id: semgrep
+      run: semgrep ci --include '*.go' --config 'tools/semgrep/ci'
   setup-go-cache:
     name: Go Caches
     needs:
-      - setup
+    - setup
     uses: ./.github/workflows/setup-go-cache.yml
     with:
       runs-on: ${{ needs.setup.outputs.compute-standard }}
@@ -63,59 +63,59 @@ jobs:
   fmt:
     name: Check Format
     needs:
-      - setup
+    - setup
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
-        with:
-          go-version-file: ./.go-version
-          cache: true
-      - id: format
-        run: |
-          echo "Using gofumpt version $(go run mvdan.cc/gofumpt -version)"
-          make fmt
-          if ! git diff --exit-code; then
-            echo "Code has formatting errors. Run 'make fmt' to fix"
-            exit 1
-          fi
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+    - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
+      with:
+        go-version-file: ./.go-version
+        cache: true
+    - id: format
+      run: |
+        echo "Using gofumpt version $(go run mvdan.cc/gofumpt -version)"
+        make fmt
+        if ! git diff --exit-code; then
+          echo "Code has formatting errors. Run 'make fmt' to fix"
+          exit 1
+        fi
   diff-oss-ci:
     name: Diff OSS
     needs:
-      - setup
+    - setup
     if: ${{ needs.setup.outputs.enterprise != '' && github.base_ref != '' }}
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-        with:
-          fetch-depth: 0
-      - id: determine-branch
-        run: |
-          branch="${{ github.base_ref }}"
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      with:
+        fetch-depth: 0
+    - id: determine-branch
+      run: |
+        branch="${{ github.base_ref }}"
 
-          if [[ $branch = release/* ]] ; then
-            branch=${branch%%+ent}
+        if [[ $branch = release/* ]] ; then
+          branch=${branch%%+ent}
 
-            # Add OSS remote
-            git config --global user.email "github-team-secret-vault-core@hashicorp.com"
-            git config --global user.name "hc-github-team-secret-vault-core"
-            git remote add oss https://github.com/hashicorp/vault.git
-            git fetch oss "$branch"
+          # Add OSS remote
+          git config --global user.email "github-team-secret-vault-core@hashicorp.com"
+          git config --global user.name "hc-github-team-secret-vault-core"
+          git remote add oss https://github.com/hashicorp/vault.git
+          git fetch oss "$branch"
 
-            branch="oss/$branch"
-          else
-            branch="origin/$branch"
-          fi
+          branch="oss/$branch"
+        else
+          branch="origin/$branch"
+        fi
 
-          echo "BRANCH=$branch" >> "$GITHUB_OUTPUT"
-      - id: diff
-        run: |
-          ./.github/scripts/oss-diff.sh ${{ steps.determine-branch.outputs.BRANCH }} HEAD
+        echo "BRANCH=$branch" >> "$GITHUB_OUTPUT"
+    - id: diff
+      run: |
+        ./.github/scripts/oss-diff.sh ${{ steps.determine-branch.outputs.BRANCH }} HEAD
   test-go:
     name: Run Go tests
     needs:
-      - setup
-      - setup-go-cache
+    - setup
+    - setup-go-cache
     # Don't run this job for PR branches starting with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
     if: |
       !startsWith(github.head_ref, 'ui/') &&
@@ -126,15 +126,15 @@ jobs:
     with:
       total-runners: 16
       go-arch: amd64
-      go-build-tags: "${{ needs.setup.outputs.go-build-tags }},deadlock"
+      go-build-tags: '${{ needs.setup.outputs.go-build-tags }},deadlock'
       runs-on: ${{ needs.setup.outputs.compute-larger }}
       enterprise: ${{ needs.setup.outputs.enterprise }}
     secrets: inherit
   test-go-race:
     name: Run Go tests with data race detection
     needs:
-      - setup
-      - setup-go-cache
+    - setup
+    - setup-go-cache
     # Don't run this job for PR branches starting with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
     if: |
       !startsWith(github.head_ref, 'ui/') &&
@@ -148,7 +148,7 @@ jobs:
         {
           "VAULT_CI_GO_TEST_RACE": 1
         }
-      extra-flags: "-race"
+      extra-flags: '-race'
       go-arch: amd64
       go-build-tags: ${{ needs.setup.outputs.go-build-tags }}
       runs-on: ${{ needs.setup.outputs.compute-huge }}
@@ -164,8 +164,8 @@ jobs:
       !startsWith(github.head_ref, 'docs/') &&
       !startsWith(github.head_ref, 'backport/docs/')
     needs:
-      - setup
-      - setup-go-cache
+    - setup
+    - setup-go-cache
     uses: ./.github/workflows/test-go.yml
     with:
       total-runners: 16
@@ -174,7 +174,7 @@ jobs:
           "GOEXPERIMENT": "boringcrypto"
         }
       go-arch: amd64
-      go-build-tags: "${{ needs.setup.outputs.go-build-tags }},deadlock,cgo,fips,fips_140_2"
+      go-build-tags: '${{ needs.setup.outputs.go-build-tags }},deadlock,cgo,fips,fips_140_2'
       runs-on: ${{ needs.setup.outputs.compute-larger }}
       enterprise: ${{ needs.setup.outputs.enterprise }}
     secrets: inherit
@@ -191,101 +191,101 @@ jobs:
       startsWith(github.head_ref, 'merge') || 
       ${{ github.event.label.name == 'ui' }}
     needs:
-      - setup
+    - setup
     permissions:
       id-token: write
       contents: read
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-larger) }}
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
-        with:
-          go-version-file: ./.go-version
-          cache: true
-      # Setup node.js without caching to allow running npm install -g yarn (next step)
-      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
-        with:
-          node-version-file: "./ui/package.json"
-      - id: install-yarn
-        run: |
-          npm install -g yarn
-      # Setup node.js with caching using the yarn.lock file
-      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
-        with:
-          node-version-file: "./ui/package.json"
-          cache: yarn
-          cache-dependency-path: ui/yarn.lock
-      - id: install-browser-libraries
-        run: sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
-      - id: install-browser
-        uses: browser-actions/setup-chrome@29abc1a83d1d71557708563b4bc962d0f983a376
-      - id: ui-dependencies
-        name: ui-dependencies
-        working-directory: ./ui
-        run: |
-          yarn install --frozen-lockfile
-          npm rebuild node-sass
-      - id: vault-auth
-        name: Authenticate to Vault
-        if: github.repository == 'hashicorp/vault-enterprise'
-        run: vault-auth
-      - id: secrets
-        name: Fetch secrets
-        if: github.repository == 'hashicorp/vault-enterprise'
-        uses: hashicorp/vault-action@130d1f5f4fe645bb6c83e4225c04d64cfb62de6e
-        with:
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+    - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
+      with:
+        go-version-file: ./.go-version
+        cache: true
+    # Setup node.js without caching to allow running npm install -g yarn (next step)
+    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+      with:
+        node-version-file: './ui/package.json'
+    - id: install-yarn
+      run: |
+        npm install -g yarn
+    # Setup node.js with caching using the yarn.lock file
+    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+      with:
+        node-version-file: './ui/package.json'
+        cache: yarn
+        cache-dependency-path: ui/yarn.lock
+    - id: install-browser-libraries
+      run: sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
+    - id: install-browser
+      uses: browser-actions/setup-chrome@29abc1a83d1d71557708563b4bc962d0f983a376
+    - id: ui-dependencies
+      name: ui-dependencies
+      working-directory: ./ui
+      run: |
+        yarn install --frozen-lockfile
+        npm rebuild node-sass
+    - id: vault-auth
+      name: Authenticate to Vault
+      if: github.repository == 'hashicorp/vault-enterprise'
+      run: vault-auth
+    - id: secrets
+      name: Fetch secrets
+      if: github.repository == 'hashicorp/vault-enterprise'
+      uses: hashicorp/vault-action@130d1f5f4fe645bb6c83e4225c04d64cfb62de6e
+      with:
           url: ${{ steps.vault-auth.outputs.addr }}
           caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
           token: ${{ steps.vault-auth.outputs.token }}
           secrets: |
             kv/data/github/hashicorp/vault-enterprise/github-token token | PRIVATE_REPO_GITHUB_TOKEN;
             kv/data/github/hashicorp/vault-enterprise/license license_1 | VAULT_LICENSE;
-      - id: setup-git
-        name: Setup Git
-        if: github.repository == 'hashicorp/vault-enterprise'
-        env:
-          PRIVATE_REPO_GITHUB_TOKEN: ${{ steps.secrets.outputs.PRIVATE_REPO_GITHUB_TOKEN }}
-        run: |
-          git config --global url."https://hc-github-team-secure-vault-core:${PRIVATE_REPO_GITHUB_TOKEN}@github.com".insteadOf https://github.com
-      - id: build-go-dev
-        name: build-go-dev
-        run: |
-          rm -rf ./pkg
-          mkdir ./pkg
+    - id: setup-git
+      name: Setup Git
+      if: github.repository == 'hashicorp/vault-enterprise'
+      env:
+        PRIVATE_REPO_GITHUB_TOKEN: ${{ steps.secrets.outputs.PRIVATE_REPO_GITHUB_TOKEN }}
+      run: |
+        git config --global url."https://hc-github-team-secure-vault-core:${PRIVATE_REPO_GITHUB_TOKEN}@github.com".insteadOf https://github.com
+    - id: build-go-dev
+      name: build-go-dev
+      run: |
+        rm -rf ./pkg
+        mkdir ./pkg
 
-          make ci-bootstrap dev
-      - id: test-ui
-        name: test-ui
-        env:
-          VAULT_LICENSE: ${{ steps.secrets.outputs.VAULT_LICENSE }}
-        run: |
-          export PATH="${PWD}/bin:${PATH}"
+        make ci-bootstrap dev
+    - id: test-ui
+      name: test-ui
+      env:
+        VAULT_LICENSE: ${{ steps.secrets.outputs.VAULT_LICENSE }}
+      run: |
+        export PATH="${PWD}/bin:${PATH}"
 
-          if [ "${{ github.repository }}" == 'hashicorp/vault' ] ; then
-            export VAULT_LICENSE="${{ secrets.VAULT_LICENSE }}"
-          fi
+        if [ "${{ github.repository }}" == 'hashicorp/vault' ] ; then
+          export VAULT_LICENSE="${{ secrets.VAULT_LICENSE }}"
+        fi
 
-          # Run Ember tests
-          cd ui
-          mkdir -p test-results/qunit
-          yarn test:oss
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
-        with:
-          name: test-results-ui
-          path: ui/test-results
-        if: always()
-      - uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f
-        with:
-          paths: "ui/test-results/qunit/results.xml"
-          show: "fail"
-        if: always()
+        # Run Ember tests
+        cd ui
+        mkdir -p test-results/qunit
+        yarn test:oss
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+      with:
+        name: test-results-ui
+        path: ui/test-results
+      if: always()
+    - uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f
+      with:
+        paths: "ui/test-results/qunit/results.xml"
+        show: "fail"
+      if: always()
   tests-completed:
     needs:
-      - setup
-      - test-go
-      - test-ui
+    - setup
+    - test-go
+    - test-ui
     if: always()
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-      - run: |
-          tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)'
+    - run: |
+        tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)' 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
   pull_request:
-    types: [ labeled, unlabeled ]
   push:
     branches:
       - "main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
       startsWith(github.head_ref, 'ui/') ||
       startsWith(github.head_ref, 'backport/ui/') ||
       startsWith(github.head_ref, 'merge') || 
-      ${{ contains(github.event.pull_request.labels.*.name, 'ui') }}
+      contains(github.event.pull_request.labels.*.name, 'ui')
     needs:
     - setup
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
       startsWith(github.head_ref, 'ui/') ||
       startsWith(github.head_ref, 'backport/ui/') ||
       startsWith(github.head_ref, 'merge') || 
-      ${{ github.event.label.name == 'ui' }}
+      contains(github.event.pull_request.labels.*.name, 'ui')
     needs:
     - setup
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
       startsWith(github.head_ref, 'ui/') ||
       startsWith(github.head_ref, 'backport/ui/') ||
       startsWith(github.head_ref, 'merge') || 
-      contains(github.event.pull_request.labels.*.name, 'ui')
+      "contains(github.event.pull_request.labels.*.name, 'ui')"
     needs:
     - setup
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
       startsWith(github.head_ref, 'ui/') ||
       startsWith(github.head_ref, 'backport/ui/') ||
       startsWith(github.head_ref, 'merge') || 
+      contains(github.event.pull_request.labels.*.name, 'ui')
     needs:
     - setup
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
       startsWith(github.head_ref, 'ui/') ||
       startsWith(github.head_ref, 'backport/ui/') ||
       startsWith(github.head_ref, 'merge') || 
-      ${{ contains(github.event.pull_request.labels.*.name, 'ui') }}
+      "contains(github.event.pull_request.labels.*.name, 'ui')"
     needs:
     - setup
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,6 @@ jobs:
       startsWith(github.head_ref, 'ui/') ||
       startsWith(github.head_ref, 'backport/ui/') ||
       startsWith(github.head_ref, 'merge') || 
-      "contains(github.event.pull_request.labels.*.name, 'ui')"
     needs:
     - setup
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
       startsWith(github.head_ref, 'ui/') ||
       startsWith(github.head_ref, 'backport/ui/') ||
       startsWith(github.head_ref, 'merge') || 
-      contains(github.event.pull_request.labels.*.name, 'ui')
+      ${{ contains(github.event.pull_request.labels.*.name, 'ui') }}
     needs:
     - setup
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
       startsWith(github.head_ref, 'ui/') ||
       startsWith(github.head_ref, 'backport/ui/') ||
       startsWith(github.head_ref, 'merge') || 
-      "contains(github.event.pull_request.labels.*.name, 'ui')"
+      ${{ contains(github.event.pull_request.labels.*.name, 'ui') }}
     needs:
     - setup
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
     # The test-ui job is only run on:
     # - pushes to main and branches starting with "release/"
     # - PRs where the branch starts with "ui/", "backport/ui/", "merge", or when base branch starts with "release/"
-    # - PRs that include the "ui" label on github
+    # - PRs with the "ui" label on github
     if: |
       github.ref_name == 'main' ||
       startsWith(github.ref_name, 'release/') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,44 +18,44 @@ jobs:
       enterprise: ${{ steps.setup-outputs.outputs.enterprise }}
       go-build-tags: ${{ steps.setup-outputs.outputs.go-build-tags }}
     steps:
-    - id: setup-outputs
-      name: Setup outputs
-      run: |
-        github_repository="${{ github.repository }}"
+      - id: setup-outputs
+        name: Setup outputs
+        run: |
+          github_repository="${{ github.repository }}"
 
-        if [ "${github_repository##*/}" == "vault-enterprise" ] ; then
-          # shellcheck disable=SC2129
-          echo 'compute-tiny=["self-hosted","ondemand","linux","type=m5.large"]' >> "$GITHUB_OUTPUT"
-          echo 'compute-standard=["self-hosted","ondemand","linux","type=m5.xlarge"]' >> "$GITHUB_OUTPUT"
-          echo 'compute-larger=["self-hosted","ondemand","linux","type=m5.2xlarge"]' >> "$GITHUB_OUTPUT"
-          echo 'compute-huge=["self-hosted","ondemand","linux","type=m5.4xlarge"]' >> "$GITHUB_OUTPUT"
-          echo 'enterprise=1' >> "$GITHUB_OUTPUT"
-          echo 'go-build-tags=ent,enterprise' >> "$GITHUB_OUTPUT"
-        else
-          # shellcheck disable=SC2129
-          echo 'compute-tiny="ubuntu-latest"' >> "$GITHUB_OUTPUT"                         #  2 cores,   7 GB RAM,   14 GB SSD
-          echo 'compute-standard="custom-linux-small-vault-latest"' >> "$GITHUB_OUTPUT"   #  8 cores,  32 GB RAM,  300 GB SSD
-          echo 'compute-larger="custom-linux-medium-vault-latest"' >> "$GITHUB_OUTPUT"    # 16 cores,  64 GB RAM,  600 GB SSD
-          echo 'compute-huge="custom-linux-xl-vault-latest"' >> "$GITHUB_OUTPUT"          # 32-cores, 128 GB RAM, 1200 GB SSD
-          echo 'enterprise=' >> "$GITHUB_OUTPUT"
-          echo 'go-build-tags=' >> "$GITHUB_OUTPUT"
-        fi
+          if [ "${github_repository##*/}" == "vault-enterprise" ] ; then
+            # shellcheck disable=SC2129
+            echo 'compute-tiny=["self-hosted","ondemand","linux","type=m5.large"]' >> "$GITHUB_OUTPUT"
+            echo 'compute-standard=["self-hosted","ondemand","linux","type=m5.xlarge"]' >> "$GITHUB_OUTPUT"
+            echo 'compute-larger=["self-hosted","ondemand","linux","type=m5.2xlarge"]' >> "$GITHUB_OUTPUT"
+            echo 'compute-huge=["self-hosted","ondemand","linux","type=m5.4xlarge"]' >> "$GITHUB_OUTPUT"
+            echo 'enterprise=1' >> "$GITHUB_OUTPUT"
+            echo 'go-build-tags=ent,enterprise' >> "$GITHUB_OUTPUT"
+          else
+            # shellcheck disable=SC2129
+            echo 'compute-tiny="ubuntu-latest"' >> "$GITHUB_OUTPUT"                         #  2 cores,   7 GB RAM,   14 GB SSD
+            echo 'compute-standard="custom-linux-small-vault-latest"' >> "$GITHUB_OUTPUT"   #  8 cores,  32 GB RAM,  300 GB SSD
+            echo 'compute-larger="custom-linux-medium-vault-latest"' >> "$GITHUB_OUTPUT"    # 16 cores,  64 GB RAM,  600 GB SSD
+            echo 'compute-huge="custom-linux-xl-vault-latest"' >> "$GITHUB_OUTPUT"          # 32-cores, 128 GB RAM, 1200 GB SSD
+            echo 'enterprise=' >> "$GITHUB_OUTPUT"
+            echo 'go-build-tags=' >> "$GITHUB_OUTPUT"
+          fi
   semgrep:
     name: Semgrep
     needs:
-    - setup
+      - setup
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     container:
       image: returntocorp/semgrep@sha256:ffc6f3567654f9431456d49fd059dfe548f007c494a7eb6cd5a1a3e50d813fb3
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-    - name: Run Semgrep Rules
-      id: semgrep
-      run: semgrep ci --include '*.go' --config 'tools/semgrep/ci'
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - name: Run Semgrep Rules
+        id: semgrep
+        run: semgrep ci --include '*.go' --config 'tools/semgrep/ci'
   setup-go-cache:
     name: Go Caches
     needs:
-    - setup
+      - setup
     uses: ./.github/workflows/setup-go-cache.yml
     with:
       runs-on: ${{ needs.setup.outputs.compute-standard }}
@@ -63,59 +63,59 @@ jobs:
   fmt:
     name: Check Format
     needs:
-    - setup
+      - setup
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-    - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
-      with:
-        go-version-file: ./.go-version
-        cache: true
-    - id: format
-      run: |
-        echo "Using gofumpt version $(go run mvdan.cc/gofumpt -version)"
-        make fmt
-        if ! git diff --exit-code; then
-          echo "Code has formatting errors. Run 'make fmt' to fix"
-          exit 1
-        fi
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
+        with:
+          go-version-file: ./.go-version
+          cache: true
+      - id: format
+        run: |
+          echo "Using gofumpt version $(go run mvdan.cc/gofumpt -version)"
+          make fmt
+          if ! git diff --exit-code; then
+            echo "Code has formatting errors. Run 'make fmt' to fix"
+            exit 1
+          fi
   diff-oss-ci:
     name: Diff OSS
     needs:
-    - setup
+      - setup
     if: ${{ needs.setup.outputs.enterprise != '' && github.base_ref != '' }}
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      with:
-        fetch-depth: 0
-    - id: determine-branch
-      run: |
-        branch="${{ github.base_ref }}"
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          fetch-depth: 0
+      - id: determine-branch
+        run: |
+          branch="${{ github.base_ref }}"
 
-        if [[ $branch = release/* ]] ; then
-          branch=${branch%%+ent}
+          if [[ $branch = release/* ]] ; then
+            branch=${branch%%+ent}
 
-          # Add OSS remote
-          git config --global user.email "github-team-secret-vault-core@hashicorp.com"
-          git config --global user.name "hc-github-team-secret-vault-core"
-          git remote add oss https://github.com/hashicorp/vault.git
-          git fetch oss "$branch"
+            # Add OSS remote
+            git config --global user.email "github-team-secret-vault-core@hashicorp.com"
+            git config --global user.name "hc-github-team-secret-vault-core"
+            git remote add oss https://github.com/hashicorp/vault.git
+            git fetch oss "$branch"
 
-          branch="oss/$branch"
-        else
-          branch="origin/$branch"
-        fi
+            branch="oss/$branch"
+          else
+            branch="origin/$branch"
+          fi
 
-        echo "BRANCH=$branch" >> "$GITHUB_OUTPUT"
-    - id: diff
-      run: |
-        ./.github/scripts/oss-diff.sh ${{ steps.determine-branch.outputs.BRANCH }} HEAD
+          echo "BRANCH=$branch" >> "$GITHUB_OUTPUT"
+      - id: diff
+        run: |
+          ./.github/scripts/oss-diff.sh ${{ steps.determine-branch.outputs.BRANCH }} HEAD
   test-go:
     name: Run Go tests
     needs:
-    - setup
-    - setup-go-cache
+      - setup
+      - setup-go-cache
     # Don't run this job for PR branches starting with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
     if: |
       !startsWith(github.head_ref, 'ui/') &&
@@ -126,15 +126,15 @@ jobs:
     with:
       total-runners: 16
       go-arch: amd64
-      go-build-tags: '${{ needs.setup.outputs.go-build-tags }},deadlock'
+      go-build-tags: "${{ needs.setup.outputs.go-build-tags }},deadlock"
       runs-on: ${{ needs.setup.outputs.compute-larger }}
       enterprise: ${{ needs.setup.outputs.enterprise }}
     secrets: inherit
   test-go-race:
     name: Run Go tests with data race detection
     needs:
-    - setup
-    - setup-go-cache
+      - setup
+      - setup-go-cache
     # Don't run this job for PR branches starting with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
     if: |
       !startsWith(github.head_ref, 'ui/') &&
@@ -148,7 +148,7 @@ jobs:
         {
           "VAULT_CI_GO_TEST_RACE": 1
         }
-      extra-flags: '-race'
+      extra-flags: "-race"
       go-arch: amd64
       go-build-tags: ${{ needs.setup.outputs.go-build-tags }}
       runs-on: ${{ needs.setup.outputs.compute-huge }}
@@ -164,8 +164,8 @@ jobs:
       !startsWith(github.head_ref, 'docs/') &&
       !startsWith(github.head_ref, 'backport/docs/')
     needs:
-    - setup
-    - setup-go-cache
+      - setup
+      - setup-go-cache
     uses: ./.github/workflows/test-go.yml
     with:
       total-runners: 16
@@ -174,7 +174,7 @@ jobs:
           "GOEXPERIMENT": "boringcrypto"
         }
       go-arch: amd64
-      go-build-tags: '${{ needs.setup.outputs.go-build-tags }},deadlock,cgo,fips,fips_140_2'
+      go-build-tags: "${{ needs.setup.outputs.go-build-tags }},deadlock,cgo,fips,fips_140_2"
       runs-on: ${{ needs.setup.outputs.compute-larger }}
       enterprise: ${{ needs.setup.outputs.enterprise }}
     secrets: inherit
@@ -188,103 +188,104 @@ jobs:
       startsWith(github.ref_name, 'release/') ||
       startsWith(github.head_ref, 'ui/') ||
       startsWith(github.head_ref, 'backport/ui/') ||
-      startsWith(github.head_ref, 'merge')
+      startsWith(github.head_ref, 'merge') || 
+      ${{ github.event.label.name == 'ui' }}
     needs:
-    - setup
+      - setup
     permissions:
       id-token: write
       contents: read
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-larger) }}
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-    - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
-      with:
-        go-version-file: ./.go-version
-        cache: true
-    # Setup node.js without caching to allow running npm install -g yarn (next step)
-    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
-      with:
-        node-version-file: './ui/package.json'
-    - id: install-yarn
-      run: |
-        npm install -g yarn
-    # Setup node.js with caching using the yarn.lock file
-    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
-      with:
-        node-version-file: './ui/package.json'
-        cache: yarn
-        cache-dependency-path: ui/yarn.lock
-    - id: install-browser-libraries
-      run: sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
-    - id: install-browser
-      uses: browser-actions/setup-chrome@29abc1a83d1d71557708563b4bc962d0f983a376
-    - id: ui-dependencies
-      name: ui-dependencies
-      working-directory: ./ui
-      run: |
-        yarn install --frozen-lockfile
-        npm rebuild node-sass
-    - id: vault-auth
-      name: Authenticate to Vault
-      if: github.repository == 'hashicorp/vault-enterprise'
-      run: vault-auth
-    - id: secrets
-      name: Fetch secrets
-      if: github.repository == 'hashicorp/vault-enterprise'
-      uses: hashicorp/vault-action@130d1f5f4fe645bb6c83e4225c04d64cfb62de6e
-      with:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613
+        with:
+          go-version-file: ./.go-version
+          cache: true
+      # Setup node.js without caching to allow running npm install -g yarn (next step)
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        with:
+          node-version-file: "./ui/package.json"
+      - id: install-yarn
+        run: |
+          npm install -g yarn
+      # Setup node.js with caching using the yarn.lock file
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        with:
+          node-version-file: "./ui/package.json"
+          cache: yarn
+          cache-dependency-path: ui/yarn.lock
+      - id: install-browser-libraries
+        run: sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
+      - id: install-browser
+        uses: browser-actions/setup-chrome@29abc1a83d1d71557708563b4bc962d0f983a376
+      - id: ui-dependencies
+        name: ui-dependencies
+        working-directory: ./ui
+        run: |
+          yarn install --frozen-lockfile
+          npm rebuild node-sass
+      - id: vault-auth
+        name: Authenticate to Vault
+        if: github.repository == 'hashicorp/vault-enterprise'
+        run: vault-auth
+      - id: secrets
+        name: Fetch secrets
+        if: github.repository == 'hashicorp/vault-enterprise'
+        uses: hashicorp/vault-action@130d1f5f4fe645bb6c83e4225c04d64cfb62de6e
+        with:
           url: ${{ steps.vault-auth.outputs.addr }}
           caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
           token: ${{ steps.vault-auth.outputs.token }}
           secrets: |
             kv/data/github/hashicorp/vault-enterprise/github-token token | PRIVATE_REPO_GITHUB_TOKEN;
             kv/data/github/hashicorp/vault-enterprise/license license_1 | VAULT_LICENSE;
-    - id: setup-git
-      name: Setup Git
-      if: github.repository == 'hashicorp/vault-enterprise'
-      env:
-        PRIVATE_REPO_GITHUB_TOKEN: ${{ steps.secrets.outputs.PRIVATE_REPO_GITHUB_TOKEN }}
-      run: |
-        git config --global url."https://hc-github-team-secure-vault-core:${PRIVATE_REPO_GITHUB_TOKEN}@github.com".insteadOf https://github.com
-    - id: build-go-dev
-      name: build-go-dev
-      run: |
-        rm -rf ./pkg
-        mkdir ./pkg
+      - id: setup-git
+        name: Setup Git
+        if: github.repository == 'hashicorp/vault-enterprise'
+        env:
+          PRIVATE_REPO_GITHUB_TOKEN: ${{ steps.secrets.outputs.PRIVATE_REPO_GITHUB_TOKEN }}
+        run: |
+          git config --global url."https://hc-github-team-secure-vault-core:${PRIVATE_REPO_GITHUB_TOKEN}@github.com".insteadOf https://github.com
+      - id: build-go-dev
+        name: build-go-dev
+        run: |
+          rm -rf ./pkg
+          mkdir ./pkg
 
-        make ci-bootstrap dev
-    - id: test-ui
-      name: test-ui
-      env:
-        VAULT_LICENSE: ${{ steps.secrets.outputs.VAULT_LICENSE }}
-      run: |
-        export PATH="${PWD}/bin:${PATH}"
+          make ci-bootstrap dev
+      - id: test-ui
+        name: test-ui
+        env:
+          VAULT_LICENSE: ${{ steps.secrets.outputs.VAULT_LICENSE }}
+        run: |
+          export PATH="${PWD}/bin:${PATH}"
 
-        if [ "${{ github.repository }}" == 'hashicorp/vault' ] ; then
-          export VAULT_LICENSE="${{ secrets.VAULT_LICENSE }}"
-        fi
+          if [ "${{ github.repository }}" == 'hashicorp/vault' ] ; then
+            export VAULT_LICENSE="${{ secrets.VAULT_LICENSE }}"
+          fi
 
-        # Run Ember tests
-        cd ui
-        mkdir -p test-results/qunit
-        yarn test:oss
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
-      with:
-        name: test-results-ui
-        path: ui/test-results
-      if: always()
-    - uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f
-      with:
-        paths: "ui/test-results/qunit/results.xml"
-        show: "fail"
-      if: always()
+          # Run Ember tests
+          cd ui
+          mkdir -p test-results/qunit
+          yarn test:oss
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        with:
+          name: test-results-ui
+          path: ui/test-results
+        if: always()
+      - uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f
+        with:
+          paths: "ui/test-results/qunit/results.xml"
+          show: "fail"
+        if: always()
   tests-completed:
     needs:
-    - setup
-    - test-go
-    - test-ui
+      - setup
+      - test-go
+      - test-ui
     if: always()
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-    - run: |
-        tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)' 
+      - run: |
+          tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 on:
   pull_request:
+   types: [labeled, unlabeled]
   push:
     branches:
       - "main"

--- a/.github/workflows/milestone-checker.yml
+++ b/.github/workflows/milestone-checker.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   # checks that a milestone entry is present for a PR
   milestone-check:
-    # If there  a `pr/no-milestone` label we ignore this check
+    # If there is a `pr/no-milestone` label we ignore this check
     if: "!contains(github.event.pull_request.labels.*.name, 'pr/no-milestone')"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Right now UI tests only run on: 
   
>   - pushes to main and branches starting with "release/"
>   - PRs where the branch starts with "ui/", "backport/ui/", "merge", or when base branch starts with "release/"

This adds an additional conditional to run tests for PRs that have the `ui` label so tests can run without special branch naming. 
<img width="345" alt="Screenshot 2023-04-17 at 2 38 37 PM" src="https://user-images.githubusercontent.com/68122737/232616694-1cb57658-7962-4482-8a3a-78caebd8153d.png">
