### PR TITLE
Remove out of scope changes

### DIFF
--- a/ui/app/styles/components/auth-buttons.scss
+++ b/ui/app/styles/components/auth-buttons.scss
@@ -8,22 +8,19 @@
   width: 31px;
   background: $white;
   border-radius: 1px;
-  box-shadow: 0 0 0 1px rgba($white, 0.4);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.4);
 }
-
 .auth-button-type-google {
   position: relative;
   top: -10px;
   left: -1.05rem;
 }
-
 .auth-button-type-auth0,
 .auth-button-type-gitlab {
   position: relative;
   top: -6px;
-  left: -$size-9;
+  left: -0.75rem;
 }
-
 [class*='auth-button-type'] .text {
   padding-left: $spacing-m;
 }

--- a/ui/app/styles/components/auth-form.scss
+++ b/ui/app/styles/components/auth-form.scss
@@ -17,7 +17,7 @@
   left: -1px;
   right: -1px;
   bottom: -1px;
-  background: rgba($white, 0.8);
+  background: rgba(255, 255, 255, 0.8);
   z-index: 10;
   display: flex;
   justify-content: center;

--- a/ui/app/styles/components/b64-toggle.scss
+++ b/ui/app/styles/components/b64-toggle.scss
@@ -4,17 +4,15 @@
  */
 
 .b64-toggle {
-  padding: $size-9;
+  padding: 0.75rem;
   font-size: $size-9;
 }
-
 .b64-toggle.is-input {
   box-shadow: none;
 }
-
 .b64-toggle.is-textarea {
   @extend .is-compact;
   position: absolute;
-  bottom: $size-11;
-  right: $size-11;
+  bottom: 0.25rem;
+  right: 0.25rem;
 }

--- a/ui/app/styles/components/box-radio.scss
+++ b/ui/app/styles/components/box-radio.scss
@@ -7,17 +7,14 @@
   display: flex;
   flex-wrap: wrap;
 }
-
 .title.box-radio-header {
   font-size: $size-6;
   color: $grey;
   margin: $size-7 0 0 0;
 }
-
 .box-radio-spacing {
   margin: $size-6 $size-3 $size-6 0;
 }
-
 .box-radio {
   box-sizing: border-box;
   flex-basis: 7rem;
@@ -46,7 +43,6 @@
   &.is-disabled {
     opacity: 0.5;
   }
-
   input[type='radio'].radio + label {
     border: 1px solid $grey-light;
     border-radius: 50%;

--- a/ui/app/styles/components/confirm.scss
+++ b/ui/app/styles/components/confirm.scss
@@ -110,7 +110,7 @@
   }
 
   .message-title {
-    font-size: $size-6;
+    font-size: 1rem;
   }
 
   .hs-icon {

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -160,10 +160,10 @@ header .navbar-sections {
   &::after {
     height: auto;
     width: auto;
-    right: $size-11;
-    left: $size-11;
-    top: $size-11;
-    bottom: $size-11;
+    right: 0.25rem;
+    left: 0.25rem;
+    top: 0.25rem;
+    bottom: 0.25rem;
   }
 }
 

--- a/ui/app/styles/components/hover-copy-button.scss
+++ b/ui/app/styles/components/hover-copy-button.scss
@@ -7,7 +7,6 @@
   position: relative;
   color: $grey;
 }
-
 .hover-copy-button,
 .hover-copy-button-static {
   position: absolute;

--- a/ui/app/styles/components/icon.scss
+++ b/ui/app/styles/components/icon.scss
@@ -41,8 +41,8 @@
 }
 
 .hs-icon-button-right {
-  margin-left: $size-11;
-  margin-right: -$size-10;
+  margin-left: 0.25rem;
+  margin-right: -0.5rem;
   align-items: center;
 }
 

--- a/ui/app/styles/components/license-banners.scss
+++ b/ui/app/styles/components/license-banners.scss
@@ -7,5 +7,5 @@
   width: 100%;
   max-width: 1344px;
   margin: $spacing-l auto 0;
-  padding: 0 $size-4;
+  padding: 0 1.5rem;
 }

--- a/ui/app/styles/components/list-pagination.scss
+++ b/ui/app/styles/components/list-pagination.scss
@@ -59,8 +59,8 @@
 
   a {
     text-decoration: none;
-    height: $size-4;
-    min-width: $size-4;
+    height: 1.5rem;
+    min-width: 1.5rem;
     border: none;
   }
   a.pagination-link {

--- a/ui/app/styles/components/masked-input.scss
+++ b/ui/app/styles/components/masked-input.scss
@@ -41,7 +41,7 @@
 //override bulma's pre styling
 .masked-input .display-only {
   line-height: 1.5;
-  font-size: $size-6;
+  font-size: 1rem;
   padding-top: 0;
   padding-bottom: 0;
   padding-left: $spacing-s;

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -57,7 +57,7 @@
 .namespace-name {
   display: inline-block;
   flex: 1 1 auto;
-  font-size: $size-6;
+  font-size: 1rem;
   margin: 0 $spacing-xs;
 
   @include from($mobile) {
@@ -139,7 +139,7 @@
 .leaf-panel-current {
   position: relative;
   & .namespace-link:last-child {
-    margin-bottom: $spacing-xxs;
+    margin-bottom: 4px;
   }
 }
 

--- a/ui/app/styles/components/page-header.scss
+++ b/ui/app/styles/components/page-header.scss
@@ -16,7 +16,7 @@
     flex-shrink: 1;
 
     @include until($mobile) {
-      margin-top: $size-10;
+      margin-top: 0.5rem;
     }
   }
   .level-right {

--- a/ui/app/styles/components/popup-menu.scss
+++ b/ui/app/styles/components/popup-menu.scss
@@ -22,7 +22,7 @@
 
   .confirm-action span .button {
     display: block;
-    margin: $size-11 auto;
+    margin: 0.25rem auto;
     width: 95%;
   }
 
@@ -125,15 +125,15 @@
 .info-table-row,
 .wizard-dismiss-menu {
   .popup-menu-trigger {
-    height: $size-2;
+    height: 2.5rem;
     min-width: 0;
     padding: 0;
-    width: $size-2;
+    width: 2.5rem;
   }
 }
 
 .status-menu-content {
-  margin-top: $spacing-xs;
+  margin-top: 8px;
 
   .box {
     @include until($mobile) {

--- a/ui/app/styles/components/tabs.scss
+++ b/ui/app/styles/components/tabs.scss
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
- // this file defines the classes for .tabs-container, .tabs and .tab
+// this file defines the classes for .tabs-container, .tabs and .tab
 
 .page-header + .tabs-container {
   box-shadow: none;
@@ -62,8 +62,8 @@
     }
 
     &:hover {
-      color: $grey-darkest;
       background-color: $ui-gray-050;
+      color: $grey-darkest;
     }
   }
 

--- a/ui/app/styles/components/vlt-table.scss
+++ b/ui/app/styles/components/vlt-table.scss
@@ -12,7 +12,7 @@
   &.sticky-header {
     thead th {
       position: sticky;
-      background: $white;
+      background: #fff;
       box-shadow: 0 1px 0px 0px rgba($grey-dark, 0.3);
       top: 0;
     }
@@ -20,7 +20,7 @@
 
   table {
     border-collapse: collapse;
-    border-spacing: 0
+    border-spacing: 0;
   }
 
   th,

--- a/ui/app/styles/core/breadcrumb.scss
+++ b/ui/app/styles/core/breadcrumb.scss
@@ -6,7 +6,7 @@
 .breadcrumb {
   display: flex;
   user-select: text;
-  min-height: $size-4;
+  min-height: 1.5rem;
   margin: 0;
   overflow-x: auto;
   white-space: nowrap;
@@ -73,7 +73,7 @@
     &::before {
       color: $blue;
       content: '❮';
-      font-size: $size-6;
+      font-size: 1rem;
       line-height: 1;
       opacity: 0.33;
     }

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -14,7 +14,7 @@
   display: inline-block;
   font-size: $size-8;
   font-weight: $font-weight-semibold;
-  height: $size-2;
+  height: 2.5rem;
   line-height: 1.6;
   min-width: 6rem;
   padding: $size-10 $size-8;

--- a/ui/app/styles/core/file.scss
+++ b/ui/app/styles/core/file.scss
@@ -26,7 +26,7 @@
   white-space: nowrap;
 
   &.button {
-    height: $size-2; // in older parts of the code, like shamir-modal-flow this class is not a button. In newer parts of the code it is and the height needs to match the heigh of a button (2.5rem).
+    height: $size-2; // in older parts of the code (Ex: shamir-modal-flow) this class is not a button. In newer parts of the code it is, and height needs to match the height of a button (2.5rem).
   }
 
   &:disabled {

--- a/ui/app/styles/core/footer.scss
+++ b/ui/app/styles/core/footer.scss
@@ -11,7 +11,7 @@
 
   span:not(:first-child) {
     display: inline-block;
-    padding: 0 $size-10;
+    padding: 0 0.5rem;
 
     @include until($mobile) {
       display: none;

--- a/ui/app/styles/core/inputs.scss
+++ b/ui/app/styles/core/inputs.scss
@@ -38,7 +38,6 @@
   }
 
   @include until($desktop) {
-    // TODO change to rem value
     font-size: $spacing-m;
   }
 

--- a/ui/app/styles/core/level.scss
+++ b/ui/app/styles/core/level.scss
@@ -57,7 +57,7 @@
     flex: 0 1 auto;
   }
   .level-item {
-    padding-right: $size-4;
+    padding-right: 1.5rem;
   }
   .level-item.is-fixed-25 {
     flex-basis: 25%;

--- a/ui/app/styles/core/progress.scss
+++ b/ui/app/styles/core/progress.scss
@@ -17,7 +17,7 @@
   width: 100%;
 
   &.is-small {
-    height: $size-10;
+    height: 0.5rem;
   }
   &.is-narrow {
     width: 30px;

--- a/ui/app/styles/core/toggle.scss
+++ b/ui/app/styles/core/toggle.scss
@@ -39,20 +39,20 @@
   display: block;
   top: 0;
   left: 0;
-  width: $size-1;
-  height: $size-4;
+  width: 3rem;
+  height: 1.5rem;
   border: 0.1rem solid transparent;
-  border-radius: $size-9;
+  border-radius: 0.75rem;
   background: $ui-gray-300;
   content: '';
 }
 .toggle[type='checkbox'] + label::after {
   display: block;
   position: absolute;
-  top: $size-11;
-  left: $size-11;
-  width: $size-6;
-  height: $size-6;
+  top: 0.25rem;
+  left: 0.25rem;
+  width: 1rem;
+  height: 1rem;
   transform: translate3d(0, 0, 0);
   border-radius: 50%;
   background: $white;
@@ -72,7 +72,7 @@
     + label {
       font-size: $size-7;
       padding-left: $size-8 * 2.5;
-      margin: 0 $size-11;
+      margin: 0 0.25rem;
       &::before {
         top: $size-8 / 5;
         height: $size-8;

--- a/ui/app/styles/utils/_font_variables.scss
+++ b/ui/app/styles/utils/_font_variables.scss
@@ -3,9 +3,14 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-// Currently, only font-family vars exist here. But later, if we want a font-weight var for example we could put it in this file. E.g. anything font, we could had to this file.
+// vars relating to font-family or font-weight.
 
 $family-sans: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
   'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
 
 $family-monospace: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+
+/* Font weight */
+$font-weight-normal: 400;
+$font-weight-semibold: 600;
+$font-weight-bold: 700;

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-
 /* General sizing in rem values used largely for text sizing.*/
 $size-1: 3rem; // 48px, same as $spacing-xxl
 $size-2: 2.5rem; // 40px
@@ -25,11 +24,6 @@ $spacing-m: 16px;
 $spacing-l: 24px;
 $spacing-xl: 36px;
 $spacing-xxl: 48px;
-
-/* Font weight */
-$font-weight-normal: 400;
-$font-weight-semibold: 600;
-$font-weight-bold: 700;
 
 /* Border radius */
 $radius: 2px;

--- a/ui/tests/integration/components/kubernetes/page/configure-test.js
+++ b/ui/tests/integration/components/kubernetes/page/configure-test.js
@@ -101,7 +101,7 @@ module('Integration | Component | kubernetes | Page::Configure', function (hooks
     await click('[data-test-config] button');
     assert
       .dom('[data-test-icon="check-circle-fill"]')
-      .hasClass('has-text-green', 'Icon is displayed for success state with correct styling');
+      .hasClass('has-text-success', 'Icon is displayed for success state with correct styling');
     assert
       .dom('[data-test-config] span')
       .hasText('Configuration values were inferred successfully.', 'Success text is displayed');
@@ -183,7 +183,7 @@ module('Integration | Component | kubernetes | Page::Configure', function (hooks
     assert.dom('[data-test-radio-card="local"] input').isChecked('Local cluster radio card is checked');
     assert
       .dom('[data-test-icon="check-circle-fill"]')
-      .hasClass('has-text-green', 'Icon is displayed for success state with correct styling');
+      .hasClass('has-text-success', 'Icon is displayed for success state with correct styling');
     assert
       .dom('[data-test-config] span')
       .hasText('Configuration values were inferred successfully.', 'Success text is displayed');

--- a/ui/tests/integration/components/pki/pki-role-form-test.js
+++ b/ui/tests/integration/components/pki/pki-role-form-test.js
@@ -118,7 +118,7 @@ module('Integration | Component | pki-role-form', function (hooks) {
     const groupBoxHeight = find('[data-test-toggle-div="Key usage"]').clientHeight;
     assert.strictEqual(
       groupBoxHeight,
-      567,
+      572,
       'renders the correct height of the box element if the component is rending as a flexbox'
     );
     await click(SELECTORS.roleCreateButton);


### PR DESCRIPTION
**TLDR** 
* This pr removes any out of scope changes from my side branch. This includes changing hardcode values to vars and adding extra spaces between class definitions.
* Small changes to get tests passing.

Jordan had left a comment on my[ last PR](https://github.com/hashicorp/vault/pull/20196/files#diff-e4a6c8154565bc0b278bb723063e63dbe12a4a035070225aa3770e96a8ae0100) about changing hardcode px or rem values to vars. Ex: `padding: 1rem` to `padding: $size-6`. After looking at my sidebranch diff against main I saw how doing this extra work had done a number on the already large file count. If we decide as a team that it's worth going through all previously hard-coded rem and px and replacing them with size vars when applicable we can do that. However, to keep the scope of this PR as focused as possible I removed all these changes I made over the course of working on this project.

