### PR TITLE
Minor follow-ups to #16865

### DIFF
--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -709,7 +709,7 @@ func (sc *storageContext) upgradeIssuerIfRequired(issuer *issuerEntry) *issuerEn
 		// Remove CRL signing usage if it exists on the issuer but doesn't
 		// exist in the KU of the x509 certificate.
 		if hadCRL && (cert.KeyUsage&x509.KeyUsageCRLSign) == 0 {
-			issuer.Usage.ToggleUsage(OCSPSigningUsage)
+			issuer.Usage.ToggleUsage(CRLSigningUsage)
 		}
 
 		// Handle our new OCSPSigning usage flag for earlier versions. If we

--- a/changelog/20220.txt
+++ b/changelog/20220.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+pki: Fix automatically turning off CRL signing on upgrade to Vault >= 1.12, if CA Key Usage disallows it
+```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -2058,7 +2058,7 @@ imported entries present in the same bundle).
    issuers. This means the returned certificate _may_ differ in encoding from
    the one provided on subsequent re-imports of the same issuer or key.
 
-~> Note: This import may fail due to CRL rebuilding issuers or other potential
+~> Note: This import may fail due to CRL rebuilding issues or other potential
    issues; this may impact long-term use of these issuers, but some issuers or
    keys may still be imported as a result of this process.
 
@@ -3901,7 +3901,7 @@ The below parameters are in addition to the regular parameters accepted by the
 
 - `interval_duration` `(string: "")` - Specifies the duration between automatic tidy
   operations; note that this is from the end of one operation to the start of
-  the next so the time of the operation itself does not need to be considered. 
+  the next so the time of the operation itself does not need to be considered.
   Defaults to 12h
 
 #### Sample Payload


### PR DESCRIPTION
Fix PKI issuer upgrade logic when upgrading to 1.12 or later, to
actually turn off the issuer crl-signing usage when it intended to.

Fix minor typo in docs.

Closes #20189