### PR TITLE
Return OCSP errors on cert auth login failures

### DIFF
--- a/changelog/20234.txt
+++ b/changelog/20234.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/cert: Better return OCSP validation errors during login to the caller.
+```


### PR DESCRIPTION
This returns OCSP validation errors (that aren't simply a revoked certificate) to the login client, hopefully helping them to understand why their request was rejected (if by OCSP or otherwise). 

We make an attempt to deduplicate these errors. 