### PR TITLE
[Docs] Mark the 'policies' parameter as deprecated for tokens

### DIFF
--- a/website/content/partials/tokenfields.mdx
+++ b/website/content/partials/tokenfields.mdx
@@ -7,8 +7,9 @@
 - `token_policies` `(array: [] or comma-delimited string: "")` - List of
   token policies to encode onto generated tokens. Depending on the auth method, this
   list may be supplemented by user/group/other values.
-- `policies` `(array: [] or comma-delimited string: "")` - List of token
-  policies to encode onto generated tokens. Depending on the auth method, this
-  list may be supplemented by user/group/other values.
+- `policies` `(array: [] or comma-delimited string: "")` - DEPRECATED: Please
+  use the `token_policies` parameters instead. List of token policies to encode
+  onto generated tokens. Depending on the auth method, this list may be
+  supplemented by user/group/other values.
 
 @include 'tokenstorefields.mdx'

--- a/website/content/partials/tokenfields.mdx
+++ b/website/content/partials/tokenfields.mdx
@@ -8,7 +8,7 @@
   token policies to encode onto generated tokens. Depending on the auth method, this
   list may be supplemented by user/group/other values.
 - `policies` `(array: [] or comma-delimited string: "")` - DEPRECATED: Please
-  use the `token_policies` parameters instead. List of token policies to encode
+  use the `token_policies` parameter instead. List of token policies to encode
   onto generated tokens. Depending on the auth method, this list may be
   supplemented by user/group/other values.
 


### PR DESCRIPTION
🎫 [Github issue](https://github.com/hashicorp/vault/issues/18361)

🔍 [Deploy preview](https://vault-git-docs-update-tokenfields-partial-hashicorp.vercel.app/vault/api-docs/auth/kubernetes#policies)

This PR updates the token fields list, and mark the `policies` parameter as deprecated in favor of `token_policies` (see the [code](https://github.com/hashicorp/vault-plugin-auth-kubernetes/blob/530b5e913097cf7eea6ff1e2d7b977dd3dba2a16/path_role.go#L65-L69)).

See the [Github issue](https://github.com/hashicorp/vault/issues/18361) for more context.