### PR TITLE
cli/namespace: add detailed flag to namespace list

### DIFF
--- a/changelog/20243.txt
+++ b/changelog/20243.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+cli/namespace: Add detailed flag to output additional namespace information 
+such as namespace IDs and custom metadata.
+```

--- a/command/namespace_list.go
+++ b/command/namespace_list.go
@@ -40,7 +40,18 @@ Usage: vault namespace list [options]
 }
 
 func (c *NamespaceListCommand) Flags() *FlagSets {
-	return c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
+
+	f := set.NewFlagSet("Command Options")
+
+	f.BoolVar(&BoolVar{
+		Name:    "detailed",
+		Target:  &c.flagDetailed,
+		Default: false,
+		Usage:   "Print detailed information such as namespace ID.",
+	})
+
+	return set
 }
 
 func (c *NamespaceListCommand) AutocompleteArgs() complete.Predictor {
@@ -102,6 +113,10 @@ func (c *NamespaceListCommand) Run(args []string) int {
 	if !ok {
 		c.UI.Error("No entries found")
 		return 2
+	}
+
+	if c.flagDetailed && Format(c.UI) != "table" {
+		return OutputData(c.UI, secret.Data["key_info"])
 	}
 
 	return OutputList(c.UI, secret)

--- a/website/content/docs/commands/namespace.mdx
+++ b/website/content/docs/commands/namespace.mdx
@@ -16,6 +16,12 @@ List all namespaces:
 $ vault namespace list
 ```
 
+List all namespaces with additional details such as namespace ID and custom metadata:
+
+```shell-session
+$ vault namespace list -detailed
+```
+
 Create a namespace at the path `ns1/` with no custom metadata:
 
 ```shell-session


### PR DESCRIPTION
This enhances the namespace list command to include a `detailed` flag which will output additional data such as namespace IDs. This is very useful because without this you would either need to use curl or do a `vault namespace lookup` for every namespace you wanted the ID for in a loop. This lets you get all the information in one command:

```bash
$ vault namespace list -detailed
Keys    custom_metadata    id       path
----    ---------------    --       ----
bar/    map[]              yva5e    bar/
foo/    map[]              iZULg    foo/

$ vault namespace list -detailed -format=json
{
  "bar/": {
    "custom_metadata": {},
    "id": "yva5e",
    "path": "bar/"
  },
  "foo/": {
    "custom_metadata": {},
    "id": "iZULg",
    "path": "foo/"
  }
}
```