### PR TITLE
VAULT-15668: fix windows issues with -dev-tls flag 

### DIFF
--- a/changelog/20257.txt
+++ b/changelog/20257.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+command/server: Fix incorrect paths for `-dev-tls` flag on Windows 
+```

--- a/changelog/20257.txt
+++ b/changelog/20257.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-command/server: Fix incorrect paths for `-dev-tls` flag on Windows 
+command/server: Fix incorrect paths in generated config for `-dev-tls` flag on Windows 
 ```

--- a/command/server.go
+++ b/command/server.go
@@ -995,17 +995,17 @@ func (c *ServerCommand) Run(args []string) int {
 			config, err = server.DevTLSConfig(devStorageType, certDir)
 
 			defer func() {
-				err := os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultDevCAFilename))
+				err := os.Remove(filepath.Join(certDir, server.VaultDevCAFilename))
 				if err != nil {
 					c.UI.Error(err.Error())
 				}
 
-				err = os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultDevCertFilename))
+				err = os.Remove(filepath.Join(certDir, server.VaultDevCertFilename))
 				if err != nil {
 					c.UI.Error(err.Error())
 				}
 
-				err = os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultDevKeyFilename))
+				err = os.Remove(filepath.Join(certDir, server.VaultDevKeyFilename))
 				if err != nil {
 					c.UI.Error(err.Error())
 				}

--- a/command/server.go
+++ b/command/server.go
@@ -995,17 +995,17 @@ func (c *ServerCommand) Run(args []string) int {
 			config, err = server.DevTLSConfig(devStorageType, certDir)
 
 			defer func() {
-				err := os.Remove(filepath.Join(certDir, server.VaultDevCAFilename))
+				err := os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultDevCAFilename))
 				if err != nil {
 					c.UI.Error(err.Error())
 				}
 
-				err = os.Remove(filepath.Join(certDir, server.VaultDevCertFilename))
+				err = os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultDevCertFilename))
 				if err != nil {
 					c.UI.Error(err.Error())
 				}
 
-				err = os.Remove(filepath.Join(certDir, server.VaultDevKeyFilename))
+				err = os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultDevKeyFilename))
 				if err != nil {
 					c.UI.Error(err.Error())
 				}

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -185,18 +185,21 @@ func DevTLSConfig(storageType, certDir string) (*Config, error) {
 		return nil, err
 	}
 
-	if err := os.WriteFile(filepath.Join(certDir, VaultDevCAFilename), []byte(ca.PEM), 0o444); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, VaultDevCAFilename), []byte(ca.PEM), 0o444); err != nil {
 		return nil, err
 	}
 
-	if err := os.WriteFile(filepath.Join(certDir, VaultDevCertFilename), []byte(cert), 0o400); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, VaultDevCertFilename), []byte(cert), 0o400); err != nil {
 		return nil, err
 	}
 
-	if err := os.WriteFile(filepath.Join(certDir, VaultDevKeyFilename), []byte(key), 0o400); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, VaultDevKeyFilename), []byte(key), 0o400); err != nil {
 		return nil, err
 	}
+	return parseDevTLSConfig(storageType, certDir)
+}
 
+func parseDevTLSConfig(storageType, certDir string) (*Config, error) {
 	hclStr := `
 disable_mlock = true
 
@@ -219,8 +222,8 @@ storage "%s" {
 
 ui = true
 `
-
-	hclStr = fmt.Sprintf(hclStr, certDir, certDir, storageType)
+	certDirEscaped := strings.Replace(certDir, "\\", "\\\\", -1)
+	hclStr = fmt.Sprintf(hclStr, certDirEscaped, certDirEscaped, storageType)
 	parsed, err := ParseConfig(hclStr, "")
 	if err != nil {
 		return nil, err

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -185,15 +185,15 @@ func DevTLSConfig(storageType, certDir string) (*Config, error) {
 		return nil, err
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, VaultDevCAFilename), []byte(ca.PEM), 0o444); err != nil {
+	if err := os.WriteFile(filepath.Join(certDir, VaultDevCAFilename), []byte(ca.PEM), 0o444); err != nil {
 		return nil, err
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, VaultDevCertFilename), []byte(cert), 0o400); err != nil {
+	if err := os.WriteFile(filepath.Join(certDir, VaultDevCertFilename), []byte(cert), 0o400); err != nil {
 		return nil, err
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, VaultDevKeyFilename), []byte(key), 0o400); err != nil {
+	if err := os.WriteFile(filepath.Join(certDir, VaultDevKeyFilename), []byte(key), 0o400); err != nil {
 		return nil, err
 	}
 

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"reflect"
 	"strings"
 	"testing"
@@ -183,6 +184,33 @@ func TestMerge(t *testing.T) {
 			if !reflect.DeepEqual(tc.expected, result) {
 				t.Fatalf("Expected %v but got %v", tc.expected, result)
 			}
+		})
+	}
+}
+
+// Test_parseDevTLSConfig verifies that both Windows and Unix directories are correctly escaped when creating a dev TLS
+// configuration in HCL
+func Test_parseDevTLSConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		certDirectory string
+	}{
+		{
+			name:          "windows path",
+			certDirectory: `C:\Users\ADMINI~1\AppData\Local\Temp\2\vault-tls4169358130`,
+		},
+		{
+			name:          "unix path",
+			certDirectory: "/tmp/vault-tls4169358130",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := parseDevTLSConfig("file", tt.certDirectory)
+			require.NoError(t, err)
+			require.Equal(t, fmt.Sprintf("%s/%s", tt.certDirectory, VaultDevCertFilename), cfg.Listeners[0].TLSCertFile)
+			require.Equal(t, fmt.Sprintf("%s/%s", tt.certDirectory, VaultDevKeyFilename), cfg.Listeners[0].TLSKeyFile)
+
 		})
 	}
 }

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -211,7 +211,6 @@ func Test_parseDevTLSConfig(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, fmt.Sprintf("%s/%s", tt.certDirectory, VaultDevCertFilename), cfg.Listeners[0].TLSCertFile)
 			require.Equal(t, fmt.Sprintf("%s/%s", tt.certDirectory, VaultDevKeyFilename), cfg.Listeners[0].TLSKeyFile)
-
 		})
 	}
 }

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -5,10 +5,11 @@ package server
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadConfigFile(t *testing.T) {

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -21,11 +21,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/hashicorp/vault/sdk/physical"
 	physInmem "github.com/hashicorp/vault/sdk/physical/inmem"
 	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/vault/sdk/physical"
 	physInmem "github.com/hashicorp/vault/sdk/physical/inmem"
 	"github.com/mitchellh/cli"
@@ -316,4 +318,14 @@ func TestServer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestServer_DevTLS verifies that a vault server starts up correctly with the -dev-tls flag
+func TestServer_DevTLS(t *testing.T) {
+	ui, cmd := testServerCommand(t)
+	args := []string{"-dev-tls", "-dev-listen-address=127.0.0.1:0", "-test-server-config"}
+	retCode := cmd.Run(args)
+	output := ui.ErrorWriter.String() + ui.OutputWriter.String()
+	require.Equal(t, 0, retCode, output)
+	require.Contains(t, output, `tls: "enabled"`)
 }


### PR DESCRIPTION
The -dev-tls command wasn't working on windows, because the filepaths in the hcl config had unescaped backslashes. This PR adds escaping.

I also tested the changes on a windows VM, and confirmed that they resolved the problem.

Closes #20038 