### PR TITLE
Fix is-active css on tabs

### DIFF
--- a/ui/app/styles/components/tabs.scss
+++ b/ui/app/styles/components/tabs.scss
@@ -25,9 +25,11 @@
       }
     }
     li {
-      > a &.active {
-        border-color: $blue;
-        color: $blue !important;
+      > a {
+        &.active {
+          border-color: $blue;
+          color: $blue !important;
+        }
       }
     }
   }


### PR DESCRIPTION
Jordan had made this fix in his sidebranch for the navbar work. With his okay, I'm pulling it out and merging ahead of his sidebranch into main. The reason: it helps with some of my bulma removal work. 

**Before the fix:**
![image](https://user-images.githubusercontent.com/6618863/233146420-8c6deaae-86e7-44ea-a15c-4dfbea4c92df.png)

**After the fix:**
![image](https://user-images.githubusercontent.com/6618863/233146362-47dd6f6c-ad14-4a65-a278-0a5f305e1eca.png)

