### PR TITLE
Fixes found while QA'ing Secret Engines

### DIFF
--- a/ui/app/styles/components/tabs.scss
+++ b/ui/app/styles/components/tabs.scss
@@ -10,7 +10,14 @@
 }
 
 .tabs {
+  align-items: stretch;
   box-shadow: inset 0 -1px 0 $grey-light;
+  display: flex;
+  justify-content: space-between;
+  overflow: hidden;
+  overflow-x: auto;
+  user-select: none;
+  white-space: nowrap;
 
   ul {
     align-items: center;
@@ -29,9 +36,18 @@
       }
     }
     li {
+      // solves for tabs on secret engines
       > a &.active {
-        border-color: $blue;
-        color: $blue !important;
+        border-bottom: 2px solid $blue;
+        color: $blue;
+      }
+      // solves for tabs on auth mounts
+      > a {
+        &.active {
+          color: $blue;
+          background-color: transparent;
+          border-bottom: 2px solid $blue;
+        }
       }
     }
   }
@@ -46,6 +62,13 @@
       border-color: $blue;
       color: $blue;
     }
+  }
+  // important for auth tabs in active state, otherwise the border-bottom will not show.
+  a {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    vertical-align: top;
   }
 
   a,

--- a/ui/app/styles/core/checkbox-and-radio.scss
+++ b/ui/app/styles/core/checkbox-and-radio.scss
@@ -108,8 +108,9 @@
   outline-offset: -2px;
 }
 
-.b-checkbox input[type='checkbox']:disabled,
-.b-checkbox input[type='radio']:disabled {
+.b-checkbox input[type='checkbox']:disabled + label::before,
+.b-checkbox input[type='radio']:disabled + label::before {
+  background-color: $ui-gray-100;
   cursor: not-allowed;
 }
 

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -1,7 +1,7 @@
 <form onsubmit={{action @doSubmit (hash param=@param context=@context nonce=@nonce bits=@bits)}}>
   <div class="box is-sideless is-fullwidth is-marginless">
     <NamespaceReminder @mode="perform" @noun="datakey creation" />
-    <div class="content">
+    <div class="content has-bottom-margin-l">
       <p>Generate a new high-entropy key and value using <code>{{@key.name}}</code> as the encryption key.</p>
     </div>
     <div class="field">

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -1,6 +1,6 @@
 <form onsubmit={{action @doSubmit (hash ciphertext=@ciphertext context=@context nonce=@nonce)}}>
   <div class="box is-sideless is-fullwidth is-marginless">
-    <div class="content">
+    <div class="content has-bottom-margin-l">
       <p>You can decrypt ciphertext using <code>{{@key.name}}</code> as the encryption key.</p>
     </div>
     <div class="field">

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -6,7 +6,7 @@
 >
   <div class="box is-sideless is-fullwidth is-marginless">
     <NamespaceReminder @mode="perform" @noun="encryption" />
-    <div class="content">
+    <div class="content has-bottom-margin-l">
       <p>You can encrypt plaintext data using <code>{{@key.name}}</code> as the encryption key.</p>
     </div>
     <KeyVersionSelect @key={{@key}} @onVersionChange={{action (mut @key_version)}} @key_version={{@key_version}} />

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -6,7 +6,7 @@
 >
   <div class="box is-sideless is-fullwidth is-marginless">
     <NamespaceReminder @mode="perform" @noun="HMAC creation" />
-    <div class="content">
+    <div class="content has-bottom-margin-l">
       <p>
         Generate the digest of given data using the specified hash algorithm and
         <code>{{@key.name}}</code>

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -1,7 +1,7 @@
 <form onsubmit={{action @doSubmit (hash ciphertext=@ciphertext context=@context nonce=@nonce key_version=@key_version)}}>
   <div class="box is-sideless is-fullwidth is-marginless">
     <NamespaceReminder @mode="perform" @noun="rewrap" />
-    <div class="content">
+    <div class="content has-bottom-margin-l">
       <p>
         You can rewrap the provided ciphertext using the latest version of
         <code>{{@key.name}}</code>

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -44,7 +44,7 @@
     {{/if}}
   </div>
   <div class="field box is-fullwidth is-bottomless">
-    <div class="content">
+    <div class="content has-bottom-margin-l">
       <p class="help">
         Submitting this form will update the
         <code>ciphertext</code>

--- a/ui/app/templates/components/transit-key-action/verify.hbs
+++ b/ui/app/templates/components/transit-key-action/verify.hbs
@@ -14,7 +14,7 @@
   }}
 >
   <div class="box is-sideless is-fullwidth is-marginless">
-    <div class="content">
+    <div class="content has-bottom-margin-l">
       <p>Check whether the provided signature is valid for the given data.</p>
     </div>
     <div class="field">


### PR DESCRIPTION
* Fixes current issue with active tabs on auth mounts not showing. While this is a current/main issue, I fixed on this branch as it's wrapped up in the new CSS structure.

Before:
![image](https://user-images.githubusercontent.com/6618863/233157151-86498914-4dee-4523-8f1c-d00547151c4a.png)

After:
![image](https://user-images.githubusercontent.com/6618863/233157204-75540a77-3191-448b-87ea-a58eaf0ee89e.png)

* A fix I'm arguing we shouldn't make. At the very top of the css heirarchy we say that all links should be text underline `a {text-transform: underline}`. We then proceed to override this in most all cases, except when we forget. An example of when we forget (I think) is on `Secret Engine-> Transform -> create an alphabet -> Look at the list view`. Here's a screenshot, binary on the left, my branch on the right. I'm going to argue we keep it `a { text-transform: none}` which was my css to clean up all the overriding. **Thoughts?** 
![image](https://user-images.githubusercontent.com/6618863/233162764-1add776b-737c-4b0a-9022-373e745d1315.png)
