### PR TITLE
Add new method to access a client config's TLSConfig.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -203,6 +203,7 @@ type Config struct {
 	// commands such as 'vault operator raft snapshot' as this redirects to the
 	// primary node.
 	DisableRedirects bool
+	clientTLSConfig  *tls.Config
 }
 
 // TLSConfig contains the parameters needed to configure TLS on the HTTP client
@@ -337,8 +338,13 @@ func (c *Config) configureTLS(t *TLSConfig) error {
 	if t.TLSServerName != "" {
 		clientTLSConfig.ServerName = t.TLSServerName
 	}
+	c.clientTLSConfig = clientTLSConfig
 
 	return nil
+}
+
+func (c *Config) TLSConfig() *tls.Config {
+	return c.clientTLSConfig.Clone()
 }
 
 // ConfigureTLS takes a set of TLS configurations and applies those to the
@@ -665,6 +671,7 @@ func (c *Client) CloneConfig() *Config {
 	newConfig.CloneHeaders = c.config.CloneHeaders
 	newConfig.CloneToken = c.config.CloneToken
 	newConfig.ReadYourWrites = c.config.ReadYourWrites
+	newConfig.clientTLSConfig = c.config.clientTLSConfig
 
 	// we specifically want a _copy_ of the client here, not a pointer to the original one
 	newClient := *c.config.HttpClient

--- a/api/client.go
+++ b/api/client.go
@@ -344,6 +344,8 @@ func (c *Config) configureTLS(t *TLSConfig) error {
 }
 
 func (c *Config) TLSConfig() *tls.Config {
+	c.modifyLock.RLock()
+	defer c.modifyLock.RUnlock()
 	return c.clientTLSConfig.Clone()
 }
 

--- a/changelog/20265.txt
+++ b/changelog/20265.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+* api: Add Config.TLSConfig method to fetch the TLS configuration from a client config.
+```


### PR DESCRIPTION
Without this method, there's no way to obtain the TLSConfig of a client.

This is extracted from #20224 so that the sdk changes can depend on it.