### PR TITLE
Implement ACME CSR signing and certificate retrieval

### DIFF
--- a/builtin/logical/pki/acme_authorizations.go
+++ b/builtin/logical/pki/acme_authorizations.go
@@ -37,6 +37,7 @@ const (
 	ACMEOrderProcessing ACMEOrderStatusType = "processing"
 	ACMEOrderValid      ACMEOrderStatusType = "valid"
 	ACMEOrderInvalid    ACMEOrderStatusType = "invalid"
+	ACMEOrderReady      ACMEOrderStatusType = "ready"
 )
 
 type ACMEChallengeType string

--- a/builtin/logical/pki/acme_errors.go
+++ b/builtin/logical/pki/acme_errors.go
@@ -22,7 +22,7 @@ var ErrAccountDoesNotExist = errors.New("The request specified an account that d
 
 var (
 	ErrAlreadyRevoked          = errors.New("The request specified a certificate to be revoked that has already been revoked")
-	ErrBadCSR                  = errors.New("The CSR is unacceptable (e.g., due to a short key)")
+	ErrBadCSR                  = errors.New("The CSR is unacceptable")
 	ErrBadNonce                = errors.New("The client sent an unacceptable anti-replay nonce")
 	ErrBadPublicKey            = errors.New("The JWS was signed by a public key the server does not support")
 	ErrBadRevocationReason     = errors.New("The revocation reason provided is not allowed by the server")

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -165,14 +166,32 @@ type acmeOrder struct {
 	OrderId                 string              `json:"-"`
 	AccountId               string              `json:"account-id"`
 	Status                  ACMEOrderStatusType `json:"status"`
-	Expires                 string              `json:"expires"`
-	NotBefore               string              `json:"not-before"`
-	NotAfter                string              `json:"not-after"`
+	Expires                 time.Time           `json:"expires"`
 	Identifiers             []*ACMEIdentifier   `json:"identifiers"`
 	AuthorizationIds        []string            `json:"authorization-ids"`
 	CertificateSerialNumber string              `json:"cert-serial-number"`
 	CertificateExpiry       time.Time           `json:"cert-expiry"`
 	IssuerId                issuerID            `json:"issuer-id"`
+}
+
+func (o acmeOrder) getIdentifierDNSValues() []string {
+	var identifiers []string
+	for _, value := range o.Identifiers {
+		if value.Type == ACMEDNSIdentifier {
+			identifiers = append(identifiers, value.Value)
+		}
+	}
+	return identifiers
+}
+
+func (o acmeOrder) getIdentifierIPValues() []net.IP {
+	var identifiers []net.IP
+	for _, value := range o.Identifiers {
+		if value.Type == ACMEIPIdentifier {
+			identifiers = append(identifiers, net.ParseIP(value.Value))
+		}
+	}
+	return identifiers
 }
 
 func (a *acmeState) CreateAccount(ac *acmeContext, c *jwsCtx, contact []string, termsOfServiceAgreed bool) (*acmeAccount, error) {

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -162,14 +162,17 @@ type acmeAccount struct {
 }
 
 type acmeOrder struct {
-	OrderId          string              `json:"-"`
-	AccountId        string              `json:"account-id"`
-	Status           ACMEOrderStatusType `json:"status"`
-	Expires          string              `json:"expires"`
-	NotBefore        string              `json:"not-before"`
-	NotAfter         string              `json:"not-after"`
-	Identifiers      []*ACMEIdentifier   `json:"identifiers"`
-	AuthorizationIds []string            `json:"authorization-ids"`
+	OrderId                 string              `json:"-"`
+	AccountId               string              `json:"account-id"`
+	Status                  ACMEOrderStatusType `json:"status"`
+	Expires                 string              `json:"expires"`
+	NotBefore               string              `json:"not-before"`
+	NotAfter                string              `json:"not-after"`
+	Identifiers             []*ACMEIdentifier   `json:"identifiers"`
+	AuthorizationIds        []string            `json:"authorization-ids"`
+	CertificateSerialNumber string              `json:"cert-serial-number"`
+	CertificateExpiry       time.Time           `json:"cert-expiry"`
+	IssuerId                issuerID            `json:"issuer-id"`
 }
 
 func (a *acmeState) CreateAccount(ac *acmeContext, c *jwsCtx, contact []string, termsOfServiceAgreed bool) (*acmeAccount, error) {

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -239,6 +239,8 @@ func Backend(conf *logical.BackendConfig) *backend {
 	acmePaths = append(acmePaths, pathAcmeGetOrder(&b)...)
 	acmePaths = append(acmePaths, pathAcmeListOrders(&b)...)
 	acmePaths = append(acmePaths, pathAcmeNewOrder(&b)...)
+	acmePaths = append(acmePaths, pathAcmeFinalizeOrder(&b)...)
+	acmePaths = append(acmePaths, pathAcmeFetchOrderCert(&b)...)
 	acmePaths = append(acmePaths, pathAcmeChallenge(&b)...)
 	acmePaths = append(acmePaths, pathAcmeAuthorization(&b)...)
 
@@ -259,6 +261,8 @@ func Backend(conf *logical.BackendConfig) *backend {
 		b.PathsSpecial.Unauthenticated = append(b.PathsSpecial.Unauthenticated, acmePrefix+"acme/challenge/+/+")
 		b.PathsSpecial.Unauthenticated = append(b.PathsSpecial.Unauthenticated, acmePrefix+"acme/orders")
 		b.PathsSpecial.Unauthenticated = append(b.PathsSpecial.Unauthenticated, acmePrefix+"acme/order/+")
+		b.PathsSpecial.Unauthenticated = append(b.PathsSpecial.Unauthenticated, acmePrefix+"acme/order/+/finalize")
+		b.PathsSpecial.Unauthenticated = append(b.PathsSpecial.Unauthenticated, acmePrefix+"acme/order/+/cert")
 	}
 
 	if constants.IsEnterprise {

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -6819,6 +6819,8 @@ func TestProperAuthing(t *testing.T) {
 		paths[acmePrefix+"acme/authorization/29da8c38-7a09-465e-b9a6-3d76802b1afd"] = shouldBeUnauthedWriteOnly
 		paths[acmePrefix+"acme/challenge/29da8c38-7a09-465e-b9a6-3d76802b1afd/http-01"] = shouldBeUnauthedWriteOnly
 		paths[acmePrefix+"acme/order/13b80844-e60d-42d2-b7e9-152a8e834b90"] = shouldBeUnauthedWriteOnly
+		paths[acmePrefix+"acme/order/13b80844-e60d-42d2-b7e9-152a8e834b90/finalize"] = shouldBeUnauthedWriteOnly
+		paths[acmePrefix+"acme/order/13b80844-e60d-42d2-b7e9-152a8e834b90/cert"] = shouldBeUnauthedWriteOnly
 	}
 
 	for path, checkerType := range paths {

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -1044,13 +1044,7 @@ func TestAutoRebuild(t *testing.T) {
 	// each revocation. Pull the storage from the cluster (via the sys/raw
 	// endpoint which requires the mount UUID) and verify the revInfo contains
 	// a matching issuer.
-	resp, err = client.Logical().Read("sys/mounts/pki")
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	require.NotNil(t, resp.Data)
-	require.NotEmpty(t, resp.Data["uuid"])
-	pkiMount := resp.Data["uuid"].(string)
-	require.NotEmpty(t, pkiMount)
+	pkiMount := findStorageMountUuid(t, client, "pki")
 	revEntryPath := "logical/" + pkiMount + "/" + revokedPath + normalizeSerial(newLeafSerial)
 
 	// storage from cluster.Core[0] is a physical storage copy, not a logical
@@ -1176,6 +1170,17 @@ func TestAutoRebuild(t *testing.T) {
 	crl = waitForUpdatedCrl(t, client, defaultCrlPath, lastCRLNumber, lastCRLExpiry.Sub(now)+delta)
 	requireSerialNumberInCRL(t, crl, leafSerial)
 	requireSerialNumberInCRL(t, crl, newLeafSerial)
+}
+
+func findStorageMountUuid(t *testing.T, client *api.Client, mount string) string {
+	resp, err := client.Logical().Read("sys/mounts/" + mount)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+	require.NotEmpty(t, resp.Data["uuid"])
+	pkiMount := resp.Data["uuid"].(string)
+	require.NotEmpty(t, pkiMount)
+	return pkiMount
 }
 
 func TestTidyIssuerAssociation(t *testing.T) {


### PR DESCRIPTION
Implement ACME CSR signing and certificate retrieval. This at the moment will only use the default issuer along with a sign-verbatim style role. Leveraging the proper issuer/role will come in a later PR. 


