### PR TITLE
Docs: Fix k8s injector templating example

### DIFF
--- a/website/content/docs/platform/k8s/injector/index.mdx
+++ b/website/content/docs/platform/k8s/injector/index.mdx
@@ -139,7 +139,7 @@ vault.hashicorp.com/agent-inject-template-<unique-name>: |
 For example, consider the following:
 
 ```yaml
-vault.hashicorp.com/agent-inject-secret-foo: 'database/roles/app'
+vault.hashicorp.com/agent-inject-secret-foo: 'database/creds/db-app'
 vault.hashicorp.com/agent-inject-template-foo: |
   {{- with secret "database/creds/db-app" -}}
   postgres://{{ .Data.username }}:{{ .Data.password }}@postgres:5432/mydb?sslmode=disable


### PR DESCRIPTION
From every other example I can find, the secret name in the template should match the one in the inject annotation. Indeed the same example appears in the examples page.

https://github.com/hashicorp/vault/blob/main/website/content/docs/platform/k8s/injector/examples.mdx#patching-existing-pods