### PR TITLE
Better ACME wildcard validation

### DIFF
--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -178,7 +178,10 @@ func (o acmeOrder) getIdentifierDNSValues() []string {
 	var identifiers []string
 	for _, value := range o.Identifiers {
 		if value.Type == ACMEDNSIdentifier {
-			identifiers = append(identifiers, value.Value)
+			// Here, because of wildcard processing, we need to use the
+			// original value provided by the caller rather than the
+			// post-modification (trimmed '*.' prefix) value.
+			identifiers = append(identifiers, value.OriginalValue)
 		}
 	}
 	return identifiers

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -336,6 +336,71 @@ func validateCommonName(b *backend, data *inputBundle, name string) string {
 	return ""
 }
 
+func isWildcardDomain(name string) bool {
+	// Per RFC 6125 Section 6.4.3, and explicitly contradicting the earlier
+	// RFC 2818 which no modern client will validate against, there are two
+	// main types of wildcards, each with a single wildcard specifier (`*`,
+	// functionally different from the `*` used as a glob from the
+	// AllowGlobDomains parsing path) in the left-most label:
+	//
+	//  1. Entire label is a single wildcard character (most common and
+	//     well-supported),
+	//  2. Part of the label contains a single wildcard character (e.g. per
+	//     RFC 6125: baz*.example.net, *baz.example.net, or b*z.example.net).
+	//
+	// We permit issuance of both but not the older RFC 2818 style under
+	// the new AllowWildcardCertificates option. However, anything with a
+	// glob character is technically a wildcard, though not a valid one.
+
+	return strings.Contains(name, "*")
+}
+
+func validateWildcardDomain(name string) (string, string, error) {
+	// See note in isWildcardDomain(...) about the definition of a wildcard
+	// domain.
+	var wildcardLabel string
+	var reducedName string
+
+	if strings.Count(name, "*") > 1 {
+		// As mentioned above, only one wildcard character is permitted
+		// under RFC 6125 semantics.
+		return wildcardLabel, reducedName, fmt.Errorf("expected only one wildcard identifier in the given domain name")
+	}
+
+	// Split the Common Name into two parts: a left-most label and the
+	// remaining segments (if present).
+	splitLabels := strings.SplitN(name, ".", 2)
+	if len(splitLabels) != 2 {
+		// We've been given a single-part domain name that consists
+		// entirely of a wildcard. This is a little tricky to handle,
+		// but EnforceHostnames validates both the wildcard-containing
+		// label and the reduced name, but _only_ the latter if it is
+		// non-empty. This allows us to still validate the only label
+		// component matches hostname expectations still.
+		wildcardLabel = splitLabels[0]
+		reducedName = ""
+	} else {
+		// We have a (at least) two label domain name. But before we can
+		// update our names, we need to validate the wildcard ended up
+		// in the segment we expected it to. While this is (kinda)
+		// validated under EnforceHostnames's leftWildLabelRegex, we
+		// still need to validate it in the non-enforced mode.
+		//
+		// By validated assumption above, we know there's strictly one
+		// wildcard in this domain so we only need to check the wildcard
+		// label or the reduced name (as one is equivalent to the other).
+		// Because we later assume reducedName _lacks_ wildcard segments,
+		// we validate that.
+		wildcardLabel = splitLabels[0]
+		reducedName = splitLabels[1]
+		if strings.Contains(reducedName, "*") {
+			return wildcardLabel, reducedName, fmt.Errorf("expected wildcard to only be present in left-most domain label")
+		}
+	}
+
+	return wildcardLabel, reducedName, nil
+}
+
 // Given a set of requested names for a certificate, verifies that all of them
 // match the various toggles set in the role for controlling issuance.
 // If one does not pass, it is returned in the string argument.
@@ -370,21 +435,7 @@ func validateNames(b *backend, data *inputBundle, names []string) string {
 			isEmail = true
 		}
 
-		// Per RFC 6125 Section 6.4.3, and explicitly contradicting the earlier
-		// RFC 2818 which no modern client will validate against, there are two
-		// main types of wildcards, each with a single wildcard specifier (`*`,
-		// functionally different from the `*` used as a glob from the
-		// AllowGlobDomains parsing path) in the left-most label:
-		//
-		//  1. Entire label is a single wildcard character (most common and
-		//     well-supported),
-		//  2. Part of the label contains a single wildcard character (e.g. per
-		///    RFC 6125: baz*.example.net, *baz.example.net, or b*z.example.net).
-		//
-		// We permit issuance of both but not the older RFC 2818 style under
-		// the new AllowWildcardCertificates option. However, anything with a
-		// glob character is technically a wildcard.
-		if strings.Contains(reducedName, "*") {
+		if isWildcardDomain(reducedName) {
 			// Regardless of later rejections below, this common name contains
 			// a wildcard character and is thus technically a wildcard name.
 			isWildcard = true
@@ -399,41 +450,11 @@ func validateNames(b *backend, data *inputBundle, names []string) string {
 				return name
 			}
 
-			if strings.Count(reducedName, "*") > 1 {
-				// As mentioned above, only one wildcard character is permitted
-				// under RFC 6125 semantics.
+			// Check that this domain is well-formatted per RFC 6125.
+			var err error
+			wildcardLabel, reducedName, err = validateWildcardDomain(reducedName)
+			if err != nil {
 				return name
-			}
-
-			// Split the Common Name into two parts: a left-most label and the
-			// remaining segments (if present).
-			splitLabels := strings.SplitN(reducedName, ".", 2)
-			if len(splitLabels) != 2 {
-				// We've been given a single-part domain name that consists
-				// entirely of a wildcard. This is a little tricky to handle,
-				// but EnforceHostnames validates both the wildcard-containing
-				// label and the reduced name, but _only_ the latter if it is
-				// non-empty. This allows us to still validate the only label
-				// component matches hostname expectations still.
-				wildcardLabel = splitLabels[0]
-				reducedName = ""
-			} else {
-				// We have a (at least) two label domain name. But before we can
-				// update our names, we need to validate the wildcard ended up
-				// in the segment we expected it to. While this is (kinda)
-				// validated under EnforceHostnames's leftWildLabelRegex, we
-				// still need to validate it in the non-enforced mode.
-				//
-				// By validated assumption above, we know there's strictly one
-				// wildcard in this domain so we only need to check the wildcard
-				// label or the reduced name (as one is equivalent to the other).
-				// Because we later assume reducedName _lacks_ wildcard segments,
-				// we validate that.
-				wildcardLabel = splitLabels[0]
-				reducedName = splitLabels[1]
-				if strings.Contains(reducedName, "*") {
-					return name
-				}
 			}
 		}
 


### PR DESCRIPTION
This refactors `pki/cert_util.go`'s wildcard validation, moving it into separate helper functions for use by ACME.

Per RFC 8555, various limitations around wildcards are enforced and authorizations should not include the original label in the identifier (just the non-wildcard domain suffix and asserting `wildcard` on the authz entry). 

We additionally enforce that DNS-typed entries are not IP addresses, as `idna.ValidateForRegistration(...)` does not enforce this for IPv4 addresses.  

Lastly, we restrict challenge types for IP and wildcard authorizations. 