### PR TITLE
Re-run Milestone Check when Milestones are Applied

### DIFF
--- a/.github/workflows/milestone-checker.yml
+++ b/.github/workflows/milestone-checker.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
       - release/**
+  issues:
+    types: [milestoned, demilestoned]
 
 jobs:
   # checks that a milestone entry is present for a PR

--- a/.github/workflows/milestone-checker.yml
+++ b/.github/workflows/milestone-checker.yml
@@ -17,7 +17,7 @@ jobs:
   # checks that a milestone entry is present for a PR
   milestone-check:
     # If there is a `pr/no-milestone` label we ignore this check
-    if: "!contains(github.event.pull_request.labels.*.name, 'pr/no-milestone')"
+    if: "! ( contains(github.event.pull_request.labels.*.name, 'pr/no-milestone') || ( github.event.name == 'labeled' && github.event.label == 'pr/no-milestone' ) )"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions


### PR DESCRIPTION
https://github.com/hashicorp/vault/pull/18406 added a check to require a milestone for PRs.  This check needed to be triggered to re-run when a milestone is actually added (or removed)