### PR TITLE
Fix support on Podman service

### DIFF
--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -435,7 +435,13 @@ func (d *Runner) Start(ctx context.Context, addSuffix, forceLocalAddr bool) (*st
 
 	var realIP string
 	if d.RunOptions.NetworkID == "" {
-		realIP = inspect.NetworkSettings.Networks["bridge"].IPAddress
+		if len(inspect.NetworkSettings.Networks) > 1 {
+			return nil, fmt.Errorf("Set d.RunOptions.NetworkName instead for container with multiple networks: %v", inspect.NetworkSettings.Networks)
+		}
+		for _, network := range inspect.NetworkSettings.Networks {
+			realIP = network.IPAddress
+			break
+		}
 	} else {
 		realIP = inspect.NetworkSettings.Networks[d.RunOptions.NetworkName].IPAddress
 	}

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -732,7 +732,14 @@ func (n *dockerClusterNode) start(ctx context.Context, caDir string, opts *Docke
 	n.container = svc.Container
 	netName := opts.NetworkName
 	if netName == "" {
-		netName = "bridge"
+		if len(svc.Container.NetworkSettings.Networks) > 1 {
+			return fmt.Errorf("Set d.RunOptions.NetworkName instead for container with multiple networks: %v", svc.Container.NetworkSettings.Networks)
+		}
+		for netName = range svc.Container.NetworkSettings.Networks {
+			// Networks above is a map; we just need to find the first and
+			// only key of this map (network name). The range handles this
+			// for us, but we need a loop construction in order to use range.
+		}
 	}
 	n.RealAPIAddr = "https://" + svc.Container.NetworkSettings.Networks[netName].IPAddress + ":8200"
 	n.cleanupContainer = svc.Cleanup


### PR DESCRIPTION
When using the podman service runner (creating a socket equivalent to Docker's), tests fail with a nil pointer exception since the bridge network is named "podman", not "bridge".

Allow single networked containers and use whatever name the container runner assigns to it.