### PR TITLE
Fail completed successfully check for failing Enos tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,13 +214,9 @@ jobs:
     # We force a failure if any of the dependent jobs fail,
     # this is a workaround for the issue reported https://github.com/actions/runner/issues/2566
     if: |
-      always() && (needs.test.result == 'failure' ||
-      needs.test-docker-k8s.result == 'failure' ||
-      needs.build-other.result == 'failure' ||
-      needs.build-linux.result == 'failure' ||
-      needs.build-darwin.result == 'failure' ||
-      needs.build-docker.result == 'failure' ||
-      needs.build-ubi.result == 'failure')
+      always() && (cancelled() ||
+      contains(needs.*.result, 'cancelled') ||
+      contains(needs.*.result, 'failure'))
     runs-on: ubuntu-latest
     needs:
       - build-other

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,6 +211,16 @@ jobs:
     secrets: inherit
 
   completed-successfully:
+    # We force a failure if any of the dependent jobs fail,
+    # this is a workaround for the issue reported https://github.com/actions/runner/issues/2566
+    if: |
+      always() && (needs.test.result == 'failure' ||
+      needs.test-docker-k8s.result == 'failure' ||
+      needs.build-other.result == 'failure' ||
+      needs.build-linux.result == 'failure' ||
+      needs.build-darwin.result == 'failure' ||
+      needs.build-docker.result == 'failure' ||
+      needs.build-ubi.result == 'failure')
     runs-on: ubuntu-latest
     needs:
       - build-other
@@ -221,4 +231,6 @@ jobs:
       - test
       - test-docker-k8s
     steps:
-      - run: echo "All required build and test workflows have succeeded!"
+      - run: |
+          echo "Some of the required build and test workflows have failed!"
+          exit 1


### PR DESCRIPTION
The `completed-successfully` required status check is now being skipped if any of the dependent jobs fail.  This commit is a workaround to force the check and fail the status if any of the dependent jobs fail.  If the any of the dependent jobs are skipped the required status check will be skipped as well. 