### PR TITLE
Fix issuer patch of leaf_not_after_behavior

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -4984,12 +4984,13 @@ func TestIssuanceTTLs(t *testing.T) {
 	})
 	require.Error(t, err, "expected issuance to fail due to longer default ttl than cert ttl")
 
-	resp, err = CBWrite(b, s, "issuer/root", map[string]interface{}{
-		"issuer_name":             "root",
+	resp, err = CBPatch(b, s, "issuer/root", map[string]interface{}{
 		"leaf_not_after_behavior": "permit",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+	require.Equal(t, resp.Data["leaf_not_after_behavior"], "permit")
 
 	_, err = CBWrite(b, s, "issue/local-testing", map[string]interface{}{
 		"common_name": "testing",
@@ -5002,6 +5003,8 @@ func TestIssuanceTTLs(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+	require.Equal(t, resp.Data["leaf_not_after_behavior"], "truncate")
 
 	_, err = CBWrite(b, s, "issue/local-testing", map[string]interface{}{
 		"common_name": "testing",

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -783,7 +783,7 @@ func (b *backend) pathPatchIssuer(ctx context.Context, req *logical.Request, dat
 	}
 
 	// Leaf Not After Changes
-	rawLeafBehaviorData, ok := data.GetOk("leaf_not_after_behaivor")
+	rawLeafBehaviorData, ok := data.GetOk("leaf_not_after_behavior")
 	if ok {
 		rawLeafBehavior := rawLeafBehaviorData.(string)
 		var newLeafBehavior certutil.NotAfterBehavior

--- a/changelog/20341.txt
+++ b/changelog/20341.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Fix patching of leaf_not_after_behavior on issuers.
+```


### PR DESCRIPTION
This variable had a spelling mistake in the handler; `GetOk(...)` appears to swallow scheme failures, unlike the regular `Get(...)` which panics. 