### PR TITLE
Fix reading issuer's enable_aia_url_templating value

### DIFF
--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -458,6 +458,7 @@ func respondReadIssuer(issuer *issuerEntry) (*logical.Response, error) {
 		data["issuing_certificates"] = issuer.AIAURIs.IssuingCertificates
 		data["crl_distribution_points"] = issuer.AIAURIs.CRLDistributionPoints
 		data["ocsp_servers"] = issuer.AIAURIs.OCSPServers
+		data["enable_aia_url_templating"] = issuer.AIAURIs.EnableTemplating
 	}
 
 	response := &logical.Response{

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -286,6 +286,11 @@ to be set on all PR secondary clusters.`,
 					Description: `OSCP Servers`,
 					Required:    false,
 				},
+				"enable_aia_url_templating": {
+					Type:        framework.TypeBool,
+					Description: `Whether or not templating is enabled for AIA fields`,
+					Required:    false,
+				},
 			},
 		}},
 	}

--- a/changelog/20354.txt
+++ b/changelog/20354.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Include per-issuer enable_aia_url_templating in issuer read endpoint.
+```


### PR DESCRIPTION
This value was incorrectly left off the issuer's configuration on the read endpoint, when the AIA config was set. Note that modifying/patching per-issuer-AIA templating when no per-issuer AIA urls exist does nothing.

This is the follow up to #20341 with comprehensive PATCH tests for each value. 