### PR TITLE
Add HCP tabs, apply Vale suggestions, fix heading case

### DIFF
--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -321,7 +321,7 @@ to use for connection and verification could be configured using:
 - A listener on port `2484` is enabled by adding `SSL` to a RDS option group and applying the option group with SSL to your Oracle RDS instance.
 - Replace `your-rds-endpoint-url` with the endpoint for your RDS instance in the `HOST` and `DN` parameters.
 
--> **Note:** For more information on using SSL/TLS with AWS RDS review the [Using SSL/TLS to encrypt a connetion to a DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) AWS documentation.
+-> **Note:** For more information on using SSL/TLS with AWS RDS, review the [Using SSL/TLS to encrypt a connetion to a DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) AWS documentation.
 
 ```shell-session
 $ vault write database/config/my-oracle-database \

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -9,7 +9,7 @@ description: |-
 
 # Oracle database secrets engine
 
--> The Oracle database plugin is now available for use with the database secrets engine in HCP Vault on all tiers.
+-> The Oracle database plugin is now available for use with the database secrets engine for HCP Vault on AWS.
    The plugin configuration (including installation of the Oracle Instant Client library) is managed
    by HCP. Refer to the HCP Vault tab for more information.
 
@@ -42,7 +42,7 @@ found at its own git repository here:
 
 | Plugin Name                                                          | Root Credential Rotation | Dynamic Roles | Static Roles | Username Customization |
 | -------------------------------------------------------------------- | ------------------------ | ------------- | ------------ | ---------------------- |
-| `vault-plugin-database-oracle`                                       | Yes                      | Yes           | Yes          | Yes (1.7+)             |
+| `vault-plugin-database-oracle`                                       | Yes                      | Yes           | Yes          | Yes                    |
 
 </Tab>
 </Tabs>
@@ -245,7 +245,8 @@ vault write database/config/oracle-west \
     By default, the secrets engine will enable at the name of the engine. To
     enable the secrets engine at a different path, use the `-path` argument.
 
-1. Configure Vault with the proper plugin and connection information:
+1. Configure Vault with the proper plugin and connection information. The `plugin-name` must be set to
+   `vault-plugin-database-oracle`.
 
    ~> **Note:** Replace `your-oracle-host` in the `connection_url` parameter with the hostname of your Oracle server.
 

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -1,20 +1,29 @@
 ---
 layout: docs
-page_title: Oracle - Database - Secrets Engines
+page_title: Oracle - database - secrets engines
 description: |-
   Oracle is one of the supported plugins for the database secrets engine. This
   plugin generates database credentials dynamically based on configured roles
   for the Oracle database.
 ---
 
-# Oracle Database Secrets Engine
+# Oracle database secrets engine
 
-This secrets engine is a part of the Database Secrets Engine. If you have not read the
-[Database Backend](/vault/docs/secrets/databases) page, please do so now as it explains how to set up the database backend and
+-> The Oracle database plugin is now available for use with the database secrets engine in HCP Vault.
+   The plugin configuration (including installation of the Oracle Instant Client library) is managed
+   by HCP. Refer to the HCP Vault tab for more information.
+
+This secrets engine is a part of the database secrets engine. If you have not read the
+[database backend](/vault/docs/secrets/databases) page, please do so now as it explains how to set up the database backend and
 gives an overview of how the engine functions.
 
 Oracle is one of the supported plugins for the database secrets engine. It is capable of dynamically generating
-credentials based on configured roles for Oracle databases. It also supports [Static Roles](/vault/docs/secrets/databases#static-roles).
+credentials based on configured roles for Oracle databases. It also supports [static roles](/vault/docs/secrets/databases#static-roles).
+
+## Capabilities
+
+<Tabs>
+<Tab heading="Vault" group="vault">
 
 ~> The Oracle database plugin is not bundled in the core Vault code tree and can be
 found at its own git repository here:
@@ -22,16 +31,30 @@ found at its own git repository here:
 
 ~> This plugin is not compatible with Alpine Linux out of the box.
 
-## Capabilities
-
 | Plugin Name                                                          | Root Credential Rotation | Dynamic Roles | Static Roles | Username Customization |
 | -------------------------------------------------------------------- | ------------------------ | ------------- | ------------ | ---------------------- |
 | Customizable (see: [Custom Plugins](/vault/docs/secrets/databases/custom)) | Yes                      | Yes           | Yes          | Yes (1.7+)             |
 
+</Tab>
+<Tab heading="HCP Vault" group="hcp">
+
+~> The Oracle Database Plugin is managed by the HCP platform. No extra installation steps are required for HCP Vault.
+
+| Plugin Name                                                          | Root Credential Rotation | Dynamic Roles | Static Roles | Username Customization |
+| -------------------------------------------------------------------- | ------------------------ | ------------- | ------------ | ---------------------- |
+| `vault-plugin-database-oracle`                                       | Yes                      | Yes           | Yes          | Yes (1.7+)             |
+
+</Tab>
+</Tabs>
+
 ## Setup
 
-The Oracle Database Plugin does not live in the core Vault code tree and can be found
-at its own git repository here: [hashicorp/vault-plugin-database-oracle](https://github.com/hashicorp/vault-plugin-database-oracle)
+<Tabs>
+<Tab heading="Vault" group="vault">
+
+The Oracle database plugin is not bundled in the core Vault code tree and can be
+found at its own git repository here:
+[hashicorp/vault-plugin-database-oracle](https://github.com/hashicorp/vault-plugin-database-oracle)
 
 For linux/amd64, pre-built binaries can be found at [the releases page](https://releases.hashicorp.com/vault-plugin-database-oracle)
 
@@ -44,7 +67,7 @@ you will need to enable ipc_lock capabilities for the plugin binary.
 
 1.  Enable the database secrets engine if it is not already enabled:
 
-    ```shell
+    ```shell-session
     $ vault secrets enable database
     Success! Enabled the database secrets engine at: database/
     ```
@@ -54,7 +77,7 @@ you will need to enable ipc_lock capabilities for the plugin binary.
 
 1.  Download and register the plugin:
 
-    ```shell
+    ```shell-session
     $ vault write sys/plugins/catalog/database/oracle-database-plugin \
         sha256="..." \
         command=vault-plugin-database-oracle
@@ -62,7 +85,7 @@ you will need to enable ipc_lock capabilities for the plugin binary.
 
 1.  Configure Vault with the proper plugin and connection information:
 
-    ```shell
+    ```shell-session
     $ vault write database/config/my-oracle-database \
         plugin_name=oracle-database-plugin \
         connection_url="{{username}}/{{password}}@localhost:1521/OraDoc.localhost" \
@@ -71,10 +94,10 @@ you will need to enable ipc_lock capabilities for the plugin binary.
         password="myreallysecurepassword"
     ```
 
-If Oracle uses SSL, see the [connecting using SSL](/vault/docs/secrets/databases/oracle#connect-using-ssl) example.
+   If Oracle uses SSL, see the [connecting using SSL](/vault/docs/secrets/databases/oracle#connect-using-ssl) example.
 
-If the version of Oracle you are using has a container database, you will need to connect to one of the
-pluggable databases rather than the container database in the `connection_url` field.
+   If the version of Oracle you are using has a container database, you will need to connect to one of the
+   pluggable databases rather than the container database in the `connection_url` field.
 
 1. It is highly recommended that you immediately rotate the "root" user's password, see
    [Rotate Root Credentials](/vault/api-docs/secret/databases#rotate-root-credentials) for more details.
@@ -82,23 +105,22 @@ pluggable databases rather than the container database in the `connection_url` f
    manipulate dynamic & static credentials.
 
    !> **Use caution:** the root user's password will not be accessible once rotated so it is highly
-   recommended that you create a user for Vault to utilize rather than using the actual root user.
+   recommended that you create a user for Vault to use rather than using the actual root user.
 
 1. Configure a role that maps a name in Vault to an SQL statement to execute to
    create the database credential:
 
-   ```shell
+   ```shell-session
    $ vault write database/roles/my-role \
        db_name=my-oracle-database \
        creation_statements='CREATE USER {{username}} IDENTIFIED BY "{{password}}"; GRANT CONNECT TO {{username}}; GRANT CREATE SESSION TO {{username}};' \
        default_ttl="1h" \
        max_ttl="24h"
-   Success! Data written to: database/roles/my-role
    ```
 
    Note: The `creation_statements` may be specified in a file and interpreted by the Vault CLI using the `@` symbol:
 
-   ```shell
+   ```shell-session
    $ vault write database/roles/my-role \
        creation_statements=@creation_statements.sql \
        ...
@@ -106,12 +128,12 @@ pluggable databases rather than the container database in the `connection_url` f
 
    See the [Commands](/vault/docs/commands#files) docs for more details.
 
-### Connect Using SSL
+### Connect using SSL
 
 If the Oracle server Vault is trying to connect to uses an SSL listener, the database
-plugin will require additional configuration using the `connection_url` parameter:
+plugin will require extra configuration using the `connection_url` parameter:
 
-```shell
+```shell-session
 vault write database/config/oracle \
   plugin_name=vault-plugin-database-oracle \
   connection_url='{{username}}/{{password}}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=<host>)(PORT=<port>))(CONNECT_DATA=(SERVICE_NAME=<service_name>))(SECURITY=(SSL_SERVER_CERT_DN="<cert_dn>")(MY_WALLET_DIRECTORY=<path_to_wallet>)))' \
@@ -123,7 +145,7 @@ vault write database/config/oracle \
 For example, the SSL server certificate distinguished name and path to the Oracle Wallet
 to use for connection and verification could be configured using:
 
-```shell
+```shell-session
 vault write database/config/oracle \
   plugin_name=vault-plugin-database-oracle \
   connection_url='{{username}}/{{password}}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=hashicorp.com)(PORT=1523))(CONNECT_DATA=(SERVICE_NAME=ORCL))(SECURITY=(SSL_SERVER_CERT_DN="CN=hashicorp.com,OU=TestCA,O=HashiCorp=com")(MY_WALLET_DIRECTORY=/etc/oracle/wallets)))' \
@@ -132,30 +154,30 @@ vault write database/config/oracle \
   password="password"
 ```
 
-#### Wallet Permissions
+#### Wallet permissions
 
 ~> **Note**: The wallets used when connecting via SSL should be available on every Vault
 server when using high availability clusters.
 
-The wallet used by Vault should be in a well known location with the proper filesystem permissions. For example, if Vault is running as the `vault` user, 
+The wallet used by Vault should be in a well known location with the proper filesystem permissions. For example, if Vault is running as the `vault` user,
 the wallet directory may be setup as follows:
 
-```shell
+```shell-session
 mkdir -p /etc/vault/wallets
 cp cwallet.sso /etc/vault/wallets/cwallet.sso
 chown -R vault:vault /etc/vault
 chmod 600 /etc/vault/wallets/cwallet.sso
 ```
 
-### Using TNS Names
+### Using TNS names
 
 ~> **Note**: The `tnsnames.ora` file and environment variable used when connecting via SSL should
 be available on every Vault server when using high availability clusters.
 
-Vault can optionally use TNS Names in the connection string when connecting to Oracle databases using a `tnsnames.ora` file. An example
+Vault can optionally use TNS names in the connection string when connecting to Oracle databases using a `tnsnames.ora` file. An example
 of a `tnsnames.ora` file may look like the following:
 
-```shell
+```shell-session
 AWSEAST=
 (DESCRIPTION =
   (ADDRESS = (PROTOCOL = TCPS)(HOST = hashicorp.us-east-1.rds.amazonaws.com)(PORT = 1523))
@@ -185,14 +207,14 @@ AWSWEST=
 
 To configure Vault to use TNS names, set the following environment variable on the Vault server:
 
-```shell
+```shell-session
 TNS_ADMIN=/path/to/tnsnames/directory
 ```
 
 ~> **Note**: If Vault returns a "could not open file" error, double check that
 the `TNS_ADMIN` environment variable is available to the Vault server.
 
-Finally, use the alias in the `connection_url` parameter on the database configuration:
+Use the alias in the `connection_url` parameter on the database configuration:
 
 ```
 vault write database/config/oracle-east \
@@ -210,9 +232,112 @@ vault write database/config/oracle-west \
     password="myreallysecurepassword"
 ```
 
+</Tab>
+<Tab heading="HCP Vault" group="hcp">
+
+1. Enable the database secrets engine if it is not already enabled:
+
+    ```shell-session
+    $ vault secrets enable database
+    Success! Enabled the database secrets engine at: database/
+    ```
+
+    By default, the secrets engine will enable at the name of the engine. To
+    enable the secrets engine at a different path, use the `-path` argument.
+
+1. Configure Vault with the proper plugin and connection information:
+
+   ~> **Note:** Replace `your-oracle-host` in the `connection_url` parameter with the hostname of your Oracle server.
+
+    ```shell-session
+    $ vault write database/config/my-oracle-database \
+        plugin_name=vault-plugin-database-oracle \
+        connection_url="{{username}}/{{password}}@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=your-oracle-host)(PORT=1521))(CONNECT_DATA=(SID=ORCL)))" \
+        allowed_roles="my-role" \
+        username="VAULT_SUPER_USER" \
+        password="myreallysecurepassword"
+    ```
+
+   HCP Vault currently supports SSL connections for Oracle on Amazon Web Services (AWS) Relational Database Service (RDS).
+   If Oracle is deployed on AWS RDS, and uses SSL, see the [connecting with HCP Vault using SSL](#connect-with-hcp-vault-using-ssl) example.
+
+   If the version of Oracle you are using has a container database, you will need to connect to one of the
+   pluggable databases rather than the container database in the `connection_url` field.
+
+1. It is highly recommended that you immediately rotate the "root" user's password, see
+   [Rotate Root Credentials](/vault/api-docs/secret/databases#rotate-root-credentials) for more details.
+   This will ensure that only Vault is able to access the "root" user that Vault uses to
+   manipulate dynamic & static credentials.
+
+   !> **Use caution:** the "root" user's password will not be accessible once rotated so it is highly
+   recommended that you create a user for Vault to use rather than the actual `root` user.
+
+1. Configure a role that maps a name in Vault to a SQL statement to execute and
+   create the database credential:
+
+   ```shell-session
+   $ vault write database/roles/my-role \
+       db_name=my-oracle-database \
+       creation_statements='CREATE USER {{username}} IDENTIFIED BY "{{password}}"; GRANT CONNECT TO {{username}}; GRANT CREATE SESSION TO {{username}};' \
+       default_ttl="1h" \
+       max_ttl="24h"
+   ```
+
+   Note: The `creation_statements` may be specified in a file and interpreted by the Vault CLI using the `@` symbol:
+
+   ```shell-session
+   $ vault write database/roles/my-role \
+       creation_statements=@creation_statements.sql \
+       ...
+   ```
+
+   See the [Commands](/vault/docs/commands#files) docs for more details.
+
+### Connect with HCP Vault using SSL
+
+When configuring the Oracle RDS options group for SSL, you must set the following:
+
+- `SQLNET.SSL_VERSION` to `1.2`
+- `SQLNET.CIPHER_SUITE` to one of `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384`, `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`, `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`, `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256`, `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`, or `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`
+
+If the AWS RDS Oracle instance Vault is trying to connect to uses an SSL listener, the database
+plugin will require extra configuration using the `connection_url` parameter:
+
+```shell-session
+vault write database/config/oracle \
+  plugin_name=vault-plugin-database-oracle \
+  connection_url='{{username}}/{{password}}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=<host>)(PORT=<port>))(CONNECT_DATA=(SERVICE_NAME=<service_name>))(SECURITY=(SSL_SERVER_CERT_DN="<cert_dn>")(MY_WALLET_DIRECTORY=<path_to_wallet>)))' \
+  allowed_roles="my-role" \
+  username="VAULT_SUPER_USER" \
+  password="myreallysecurepassword"
+```
+
+For example, the SSL server certificate distinguished name for AWS RDS and path to the Oracle Wallet
+to use for connection and verification could be configured using:
+
+- Wallet location and permissions are managed by the HCP platform. The wallet is available at `/etc/vault.d/plugin/oracle/ssl_wallet`.
+- The distinguished name for the current AWS RDS CA is in the format `SECURITY=(SSL_SERVER_CERT_DN="C=US,ST=Washington,L=Seattle,O=Amazon.com,OU=RDS,CN=your-rds-endpoint-url")`.
+- Replace `your-rds-endpoint-url` with the endpoint for your RDS instance in the `HOST` and `DN` parameters.
+
+-> **Note:** For more information on using SSL/TLS with AWS RDS review the [Using SSL/TLS to encrypt a connetion to a DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) AWS documentation.
+
+```shell-session
+vault write database/config/my-oracle-database \
+  plugin_name=vault-plugin-database-oracle \
+  connection_url="{{username}}/{{password}}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=your-rds-endpoint-url)(PORT=2484))(CONNECT_DATA=(SERVICE_NAME=ORCL))(SECURITY=(SSL_SERVER_CERT_DN="C=US,ST=Washington,L=Seattle,O=Amazon.com,OU=RDS,CN=your-rds-endpoint-url")(MY_WALLET_DIRECTORY=/etc/vault.d/plugin/oracle/ssl_wallet)))" \
+  allowed_roles="my-role" \
+  username="admin" \
+  password="password"
+```
+
+~> **Using TNS names:** `tnsnames.ora` configuration is not currently available with HCP Vault.
+
+</Tab>
+</Tabs>
+
 ## Usage
 
-### Dynamic Credentials
+### Dynamic credentials
 
 After the secrets engine is configured and a user/machine has a Vault token with
 the proper permission, it can generate credentials.

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -305,7 +305,7 @@ If the AWS RDS Oracle instance Vault is trying to connect to uses an SSL listene
 plugin will require extra configuration using the `connection_url` parameter:
 
 ```shell-session
-vault write database/config/oracle \
+$ vault write database/config/oracle \
   plugin_name=vault-plugin-database-oracle \
   connection_url='{{username}}/{{password}}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=<host>)(PORT=<port>))(CONNECT_DATA=(SERVICE_NAME=<service_name>))(SECURITY=(SSL_SERVER_CERT_DN="<cert_dn>")(MY_WALLET_DIRECTORY=<path_to_wallet>)))' \
   allowed_roles="my-role" \

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -9,7 +9,7 @@ description: |-
 
 # Oracle database secrets engine
 
--> The Oracle database plugin is now available for use with the database secrets engine in HCP Vault.
+-> The Oracle database plugin is now available for use with the database secrets engine in HCP Vault on all tiers.
    The plugin configuration (including installation of the Oracle Instant Client library) is managed
    by HCP. Refer to the HCP Vault tab for more information.
 
@@ -295,7 +295,7 @@ vault write database/config/oracle-west \
 
 ### Connect with HCP Vault using SSL
 
-When configuring the Oracle RDS options group for SSL, you must set the following:
+Before using SSL with Oracle RDS, you must configure a option group with SSL and set the following:
 
 - `SQLNET.SSL_VERSION` to `1.2`
 - `SQLNET.CIPHER_SUITE` to one of `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384`, `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`, `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`, `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256`, `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`, or `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`
@@ -317,6 +317,7 @@ to use for connection and verification could be configured using:
 
 - Wallet location and permissions are managed by the HCP platform. The wallet is available at `/etc/vault.d/plugin/oracle/ssl_wallet`.
 - The distinguished name for the current AWS RDS CA is in the format `SECURITY=(SSL_SERVER_CERT_DN="C=US,ST=Washington,L=Seattle,O=Amazon.com,OU=RDS,CN=your-rds-endpoint-url")`.
+- A listener on port `2484` is enabled by adding `SSL` to a RDS option group and applying the option group with SSL to your Oracle RDS instance.
 - Replace `your-rds-endpoint-url` with the endpoint for your RDS instance in the `HOST` and `DN` parameters.
 
 -> **Note:** For more information on using SSL/TLS with AWS RDS review the [Using SSL/TLS to encrypt a connetion to a DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) AWS documentation.

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -324,7 +324,7 @@ to use for connection and verification could be configured using:
 -> **Note:** For more information on using SSL/TLS with AWS RDS review the [Using SSL/TLS to encrypt a connetion to a DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) AWS documentation.
 
 ```shell-session
-vault write database/config/my-oracle-database \
+$ vault write database/config/my-oracle-database \
   plugin_name=vault-plugin-database-oracle \
   connection_url="{{username}}/{{password}}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=your-rds-endpoint-url)(PORT=2484))(CONNECT_DATA=(SERVICE_NAME=ORCL))(SECURITY=(SSL_SERVER_CERT_DN="C=US,ST=Washington,L=Seattle,O=Amazon.com,OU=RDS,CN=your-rds-endpoint-url")(MY_WALLET_DIRECTORY=/etc/vault.d/plugin/oracle/ssl_wallet)))" \
   allowed_roles="my-role" \


### PR DESCRIPTION
# DO NOT MERGE UNTIL 5/1

🔍 [Deploy preview](https://vault-e17o7dppd-hashicorp.vercel.app/vault/docs/secrets/databases/oracle)

- Add tabs with steps and callouts specific to HCP Vault.
   -- I opted for tabs in each section to maintain the right hand navigation based on section headers to stay consistent with other docs in the database secret engine category.
- Apply Vale language suggestions
- Switch to sentence case for section headings and title
- Minor numbering sequence fix for Vault steps
- Validate ciper suites for Oracle on RDS