### PR TITLE
Run Upload test results to DataDog every time test-go runs

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -272,7 +272,7 @@ jobs:
                 \
               ${test_packages[${{ matrix.runner-index }}]}
       - name: Prepare datadog-ci
-        if: github.repository == 'hashicorp/vault'
+        if: github.repository == 'hashicorp/vault' && always()
         continue-on-error: true
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -286,6 +286,7 @@ jobs:
             export DATADOG_API_KEY=${{ secrets.DATADOG_API_KEY }}
           fi
           datadog-ci junit upload --service "$GITHUB_REPOSITORY" test-results/go-test/results.xml
+        if: always()
       - name: Archive test results
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:


### PR DESCRIPTION
Currently, the step gets auto-skipped because of how GitHub Actions handles [if conditions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif), especially the default behaviour of [status check functions](https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions).