### PR TITLE
VAULT-15840: Allow updates of only entity-alias custom-metadata

### DIFF
--- a/changelog/20368.txt
+++ b/changelog/20368.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/identity: Allow updates of only the custom-metadata for entity alias.
+```

--- a/vault/identity_store_aliases.go
+++ b/vault/identity_store_aliases.go
@@ -211,8 +211,9 @@ func (i *IdentityStore) handleAliasCreateUpdate() framework.OperationFunc {
 				}
 				switch {
 				case mountAccessor == "" && name == "":
-					// Just a canonical ID update, maybe
-					if canonicalID == "" {
+					// Check if the canonicalID or the customMetadata are being
+					// updated
+					if canonicalID == "" && !customMetadataExists {
 						// Nothing to do, so be idempotent
 						return nil, nil
 					}

--- a/vault/identity_store_aliases_test.go
+++ b/vault/identity_store_aliases_test.go
@@ -461,6 +461,46 @@ func TestIdentityStore_AliasUpdate(t *testing.T) {
 				"custom_metadata": map[string]string{},
 			},
 		},
+		{
+			name: "only-metadata",
+			createData: map[string]interface{}{
+				"name":           "only",
+				"mount_accessor": githubAccessor,
+				"custom_metadata": map[string]string{
+					"foo": "bar",
+				},
+			},
+			updateData: map[string]interface{}{
+				"custom_metadata": map[string]string{
+					"bar": "baz",
+				},
+			},
+		},
+		{
+			name: "only-metadata-clear",
+			createData: map[string]interface{}{
+				"name":           "only-clear",
+				"mount_accessor": githubAccessor,
+				"custom_metadata": map[string]string{
+					"foo": "bar",
+				},
+			},
+			updateData: map[string]interface{}{
+				"custom_metadata": map[string]string{},
+			},
+		},
+		{
+			name: "only-metadata-none-before",
+			createData: map[string]interface{}{
+				"name":           "no-metadata",
+				"mount_accessor": githubAccessor,
+			},
+			updateData: map[string]interface{}{
+				"custom_metadata": map[string]string{
+					"foo": "bar",
+				},
+			},
+		},
 	}
 
 	handleRequest := func(t *testing.T, req *logical.Request) *logical.Response {


### PR DESCRIPTION
With these changes, the following works. Previously, the final call would return an empty map:
```sh
$ vault auth enable userpass 
$ MA1=$(vault auth list -format=json | jq -r '."userpass/" | .accessor')
$ EID=$(vault write -field=id identity/entity name=max-winslow policies=entity-policy)
$ AID=$(vault write -field=id identity/entity-alias name=max1 canonical_id=$EID mount_accessor=$MA1)
$ vault write identity/entity-alias/id/$AID \
   - <<<'{"custom_metadata":{"foo":"bar"}}'
$ vault read -field=custom_metadata identity/entity-alias/id/$AID
map[foo:bar]
```

Closes #19434