### PR TITLE
Draft: Add option for dark mode

### DIFF
--- a/changelog/20374.txt
+++ b/changelog/20374.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: add option for dark mode
+```

--- a/ui/app/controllers/vault/cluster.js
+++ b/ui/app/controllers/vault/cluster.js
@@ -65,10 +65,18 @@ export default Controller.extend({
       return;
     }
   ),
-
+  
   actions: {
     toggleConsole() {
       this.toggleProperty('consoleOpen');
+    },
+    toggleDark() { // function to toggle between light and dark theme
+      document.documentElement.classList.toggle("dark-theme");
+      if (document.documentElement.classList.contains("dark-theme")){
+        localStorage.setItem("theme", "dark");
+      } else {
+        localStorage.setItem("theme", "light");
+      }
     },
   },
 });

--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -126,3 +126,6 @@
 @import './components/vault-loading';
 @import './components/vlt-radio';
 @import './components/vlt-table';
+
+// dark mode
+@import './core/dark-mode';

--- a/ui/app/styles/core/dark-mode.scss
+++ b/ui/app/styles/core/dark-mode.scss
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-
-
-//  TODO: refactor classes and variables to achieve a more uniform coding
-
 // Define color variables for dark mode
 $background-color: #151515;
+
 $foreground-color: $ui-gray-900;
+$foreground-color-light: $ui-gray-800;
+$foreground-color-lightest: $ui-gray-700;
+
 $text-color: $ui-gray-050;
 
 // Define styles for dark mode
@@ -20,13 +20,13 @@ body {
 
 .toolbar{
     background-color: $foreground-color;
-    border: 1px solid $ui-gray-800;
-    border-bottom-color: $ui-gray-800;
-    border-top-color: $ui-gray-800;
+    border: 1px solid $foreground-color-light;
+    border-bottom-color: $foreground-color-light;
+    border-top-color: $foreground-color-light;
     color: $text-color;
 
     &::after {
-        background: linear-gradient(to left, $ui-gray-900, rgba($ui-gray-010, 0));
+        background: linear-gradient(to left, $foreground-color, rgba($ui-gray-010, 0));
         bottom: 0;
         content: '';
         position: absolute;
@@ -37,23 +37,24 @@ body {
       }
 }
 
-// .field {
-//     background-color: $red;
-// }
+// Text color
+.has-text-grey,
+.has-text-grey-dark {
+    color: $ui-gray-200 !important;
+}
 
 .has-text-black {
     color: $text-color !important;
 }
 
-.has-text-black:hover {
-    color: $ui-gray-800 !important;
-}
-
-.has-text-grey, .has-text-grey-dark {
-    color: $ui-gray-200 !important;
-}
-
-.toolbar-link, .alert-banner-message-body{
+.box,
+.is-label,
+.toolbar-link,
+.title, .title > a,
+.column .menu-list a,
+.alert-banner-message-body,
+.breadcrumb li.is-active a,
+.masked-value.display-only.is-word-break {
     color: $text-color;
 }
 
@@ -62,78 +63,66 @@ body {
 }
 
 .toolbar-link:hover:not(.disabled) {
-    background-color: $ui-gray-800;
+    background-color: $foreground-color-light;
 }
 
-.linked-block, .has-background-white-bis{
+.box,
+.linked-block,
+.list-item-row,
+.has-background-white-bis {
     background-color: $background-color;
 }
 
-.list-item-row{
-    background-color: $background-color;
-}
-
-.is-label {
-    color: $text-color;
-}
-
-.box{
-    background-color: $background-color;
-    color: $text-color;
-}
-
-.empty-state, .chart-wrapper{
+.empty-state,
+.chart-wrapper {
     background-color: $foreground-color;
 }
 
-.breadcrumb li.is-active a {
-    color: $text-color;
-}
-
-.column .menu-list a {
-    color: $text-color;
-}
-
-.title, .title > a {
-    color: $text-color;
-}
-
-.tabs a:hover, .tabs .tab:hover {
+.tabs a:hover,
+.tabs .tab:hover {
     background-color: $foreground-color;
     color: $text-color;
 }
 
-.info-table-row, .action {
+.info-table-row,
+.action {
     background-color: $background-color;
     color: $text-color;
 }
 
-.action > a.ember-view{
+// ember views
+.action > a.ember-view {
     background-color: $background-color;
     color: $text-color;
     &:hover{
         color: $ui-gray-200;
-        background-color: $ui-gray-800;
+        background-color: $foreground-color-light;
     }
 }
-
 a.ember-view.is-destroy {
     background-color: $background-color;
     color: $red;
 }
-
 a.ember-view.toolbar-link {
     background-color: $foreground-color;
     border: 0;
 }
-
 .ember-view.has-text-black {
     color: $text-color !important;
 }
 
-input, textarea, .box-radio, .select select, .control {
+.has-text-black:hover {
+    color: $foreground-color-light !important;
+}
+
+// text inputs and drop-downs
+input,
+textarea,
+.box-radio,
+.select select,
+.control {
     background-color: $foreground-color !important;
-    border: 1px solid $ui-gray-800;
+    border: 1px solid $foreground-color-light;
     color: $text-color !important;
     border-radius: 2px;
 }
@@ -143,29 +132,28 @@ input, textarea, .box-radio, .select select, .control {
     border: 0;
 }
 
-.radio-card-row, .radio-card-container{
+// radio cards
+.radio-card-row,
+.radio-card-container{
     background-color: $foreground-color;
 }
-
-.radio-card-radio-row {
-    background-color: $ui-gray-800;
+.radio-card-radio-row,
+.is-selected .radio-card-container,
+.is-selected .radio-card-row {
+    background-color: $foreground-color-light;
 }
-
 .is-selected .radio-card-radio-row {
-    background-color: $ui-gray-700;
+    background-color: $foreground-color-lightest;
 }
 
-.is-selected .radio-card-container, .is-selected .radio-card-row {
-    background-color: $ui-gray-800;
-}
-
-.button, .button.is-outlined.is-primary {
+.button,
+.button.is-outlined.is-primary {
     background-color: $foreground-color;
     color: $text-color;
-    border: 1px solid $ui-gray-800;
+    border: 1px solid $foreground-color-light;
     &:hover{
         color: $ui-gray-200;
-        background-color: $ui-gray-800;
+        background-color: $foreground-color-light;
     }
 }
 .has-text-grey.masked-input-toggle.button {
@@ -176,42 +164,42 @@ input, textarea, .box-radio, .select select, .control {
     background-color: $foreground-color;
 }
 
-.action > .copy-btn.link{
+.action > .copy-btn.link {
     background-color: $background-color;
     border: 0px;
 }
 
-.masked-value.display-only.is-word-break {
-    color: $text-color;
-}
-
+// messages
 .message, .confirm-action-options {
     background-color: $foreground-color !important;
     color: $text-color !important;
 }
-
 .message-body {
     color: $text-color !important;
 }
 
+// popups
 .popup-menu-content button.link {
     background-color: $foreground-color;
     color: $text-color;
-    border: 1px solid $ui-gray-800;
+    border: 1px solid $foreground-color-light;
     border-radius: 2px;
     &:hover{
         color: $ui-gray-200;
-        background-color: $ui-gray-800;
+        background-color: $foreground-color-light;
     }
 }
 
+// modal cards
 .modal-card-custom.has-padding-btm-left {
     background-color: $background-color;
 }
-
-.modal-card, .modal-card-head, .modal-card-body, .modal-card-foot {
+.modal-card,
+.modal-card-head,
+.modal-card-body,
+.modal-card-foot {
     background-color: $foreground-color !important;
-    border-color: $ui-gray-800;
+    border-color: $foreground-color-light;
 }
 .modal-card-body strong{
     color: $text-color;

--- a/ui/app/styles/core/dark-mode.scss
+++ b/ui/app/styles/core/dark-mode.scss
@@ -5,11 +5,11 @@
 
 
 
-//  TODO: update dropdowns, input text to dark colors
 //  TODO: refactor classes and variables to achieve a more uniform coding
 
 // Define color variables for dark mode
-$background-color: $ui-gray-900;
+$background-color: #151515;
+$foreground-color: $ui-gray-900;
 $text-color: $ui-gray-050;
 
 // Define styles for dark mode
@@ -19,7 +19,7 @@ body {
 }
 
 .toolbar{
-    background-color: #0A0A0A;
+    background-color: $foreground-color;
     border: 1px solid $ui-gray-800;
     border-bottom-color: $ui-gray-800;
     border-top-color: $ui-gray-800;
@@ -45,8 +45,8 @@ body {
     color: $text-color !important;
 }
 
-a.has-text-black:hover {
-    color: $white !important;
+.has-text-black:hover {
+    color: $ui-gray-800 !important;
 }
 
 .has-text-grey, .has-text-grey-dark {
@@ -57,11 +57,15 @@ a.has-text-black:hover {
     color: $text-color;
 }
 
+.toolbar-link {
+    border: 0 !important;
+}
+
 .toolbar-link:hover:not(.disabled) {
     background-color: $ui-gray-800;
 }
 
-.linked-block {
+.linked-block, .has-background-white-bis{
     background-color: $background-color;
 }
 
@@ -73,44 +77,81 @@ a.has-text-black:hover {
     color: $text-color;
 }
 
-.box {
+.box{
     background-color: $background-color;
-    color: $text-color
-}
-
-.empty-state {
-    background-color: #0A0A0A;
-}
-
-.breadcrumb li.is-active a{
     color: $text-color;
 }
 
-.column .menu-list a{
+.empty-state, .chart-wrapper{
+    background-color: $foreground-color;
+}
+
+.breadcrumb li.is-active a {
     color: $text-color;
 }
 
-.title {
+.column .menu-list a {
     color: $text-color;
 }
 
-.tabs a:hover, .tabs .tab:hover{
-    background-color: #0A0A0A;
+.title, .title > a {
     color: $text-color;
 }
 
-.info-table-row {
+.tabs a:hover, .tabs .tab:hover {
+    background-color: $foreground-color;
+    color: $text-color;
+}
+
+.info-table-row, .action {
     background-color: $background-color;
+    color: $text-color;
 }
 
-.input, .box-radio{
-    background-color: $ui-gray-700 !important;
+.action > a.ember-view{
+    background-color: $background-color;
+    color: $text-color;
+    &:hover{
+        color: $ui-gray-200;
+        background-color: $ui-gray-800;
+    }
+}
+
+a.ember-view.is-destroy {
+    background-color: $background-color;
+    color: $red;
+}
+
+a.ember-view.toolbar-link {
+    background-color: $foreground-color;
+    border: 0;
+}
+
+input, textarea, .box-radio, .select select, .control {
+    background-color: $foreground-color !important;
     border: 1px solid $ui-gray-800;
-    color: $text-color;
+    color: $text-color !important;
+    border-radius: 2px;
 }
 
-.button, .button.is-outlined.is-primary{
-    background-color: #0A0A0A;
+.radio-card-row, .radio-card-container{
+    background-color: $foreground-color;
+}
+
+.radio-card-radio-row {
+    background-color: $ui-gray-800;
+}
+
+.is-selected .radio-card-radio-row {
+    background-color: $ui-gray-700;
+}
+
+.is-selected .radio-card-container, .is-selected .radio-card-row {
+    background-color: $ui-gray-800;
+}
+
+.button, .button.is-outlined.is-primary {
+    background-color: $foreground-color;
     color: $text-color;
     border: 1px solid $ui-gray-800;
     &:hover{
@@ -118,24 +159,34 @@ a.has-text-black:hover {
         background-color: $ui-gray-800;
     }
 }
-.has-text-grey.masked-input-toggle.button{
-    background-color: #0A0A0A !important;
+.has-text-grey.masked-input-toggle.button {
+    background-color: $foreground-color !important;
 }
 
 .button.is-ghost:hover {
-    background-color: #0A0A0A;
+    background-color: $foreground-color;
 }
 
-.masked-value.display-only.is-word-break{
+.action > .copy-btn.link{
+    background-color: $background-color;
+    border: 0px;
+}
+
+.masked-value.display-only.is-word-break {
     color: $text-color;
 }
 
 .message, .confirm-action-options {
-    background-color: #0A0A0A !important;
+    background-color: $foreground-color !important;
+    color: $text-color !important;
+}
+
+.message-body {
+    color: $text-color !important;
 }
 
 .popup-menu-content button.link {
-    background-color: #0A0A0A;
+    background-color: $foreground-color;
     color: $text-color;
     border: 1px solid $ui-gray-800;
     border-radius: 2px;
@@ -147,4 +198,12 @@ a.has-text-black:hover {
 
 .modal-card-custom.has-padding-btm-left {
     background-color: $background-color;
+}
+
+.modal-card, .modal-card-head, .modal-card-body, .modal-card-foot {
+    background-color: $foreground-color !important;
+    border-color: $ui-gray-800;
+}
+.modal-background {
+    background-color: $foreground-color;
 }

--- a/ui/app/styles/core/dark-mode.scss
+++ b/ui/app/styles/core/dark-mode.scss
@@ -127,6 +127,10 @@ a.ember-view.toolbar-link {
     border: 0;
 }
 
+.ember-view.has-text-black {
+    color: $text-color !important;
+}
+
 input, textarea, .box-radio, .select select, .control {
     background-color: $foreground-color !important;
     border: 1px solid $ui-gray-800;
@@ -203,6 +207,9 @@ input, textarea, .box-radio, .select select, .control {
 .modal-card, .modal-card-head, .modal-card-body, .modal-card-foot {
     background-color: $foreground-color !important;
     border-color: $ui-gray-800;
+}
+.modal-card-body strong{
+    color: $text-color;
 }
 .modal-background {
     background-color: $foreground-color;

--- a/ui/app/styles/core/dark-mode.scss
+++ b/ui/app/styles/core/dark-mode.scss
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+
+
+//  TODO: update dropdowns, input text to dark colors
+//  TODO: refactor classes and variables to achieve a more uniform coding
+
+// Define color variables for dark mode
+$background-color: $ui-gray-900;
+$text-color: $ui-gray-050;
+
+// Define styles for dark mode
+body {
+  background-color: $background-color;
+  color: $text-color;
+}
+
+.toolbar{
+    background-color: #0A0A0A;
+    border: 1px solid $ui-gray-800;
+    border-bottom-color: $ui-gray-800;
+    border-top-color: $ui-gray-800;
+    color: $text-color;
+
+    &::after {
+        background: linear-gradient(to left, $ui-gray-900, rgba($ui-gray-010, 0));
+        bottom: 0;
+        content: '';
+        position: absolute;
+        right: 0;
+        top: 0;
+        width: $spacing-xxs;
+        z-index: 1;
+      }
+}
+
+// .field {
+//     background-color: $red;
+// }
+
+.has-text-black {
+    color: $text-color !important;
+}
+
+a.has-text-black:hover {
+    color: $white !important;
+}
+
+.has-text-grey, .has-text-grey-dark {
+    color: $ui-gray-200 !important;
+}
+
+.toolbar-link, .alert-banner-message-body{
+    color: $text-color;
+}
+
+.toolbar-link:hover:not(.disabled) {
+    background-color: $ui-gray-800;
+}
+
+.linked-block {
+    background-color: $background-color;
+}
+
+.list-item-row{
+    background-color: $background-color;
+}
+
+.is-label {
+    color: $text-color;
+}
+
+.box {
+    background-color: $background-color;
+    color: $text-color
+}
+
+.empty-state {
+    background-color: #0A0A0A;
+}
+
+.breadcrumb li.is-active a{
+    color: $text-color;
+}
+
+.column .menu-list a{
+    color: $text-color;
+}
+
+.title {
+    color: $text-color;
+}
+
+.tabs a:hover, .tabs .tab:hover{
+    background-color: #0A0A0A;
+    color: $text-color;
+}
+
+.info-table-row {
+    background-color: $background-color;
+}
+
+.input, .box-radio{
+    background-color: $ui-gray-700 !important;
+    border: 1px solid $ui-gray-800;
+    color: $text-color;
+}
+
+.button, .button.is-outlined.is-primary{
+    background-color: #0A0A0A;
+    color: $text-color;
+    border: 1px solid $ui-gray-800;
+    &:hover{
+        color: $ui-gray-200;
+        background-color: $ui-gray-800;
+    }
+}
+.has-text-grey.masked-input-toggle.button{
+    background-color: #0A0A0A !important;
+}
+
+.button.is-ghost:hover {
+    background-color: #0A0A0A;
+}
+
+.masked-value.display-only.is-word-break{
+    color: $text-color;
+}
+
+.message, .confirm-action-options {
+    background-color: #0A0A0A !important;
+}
+
+.popup-menu-content button.link {
+    background-color: #0A0A0A;
+    color: $text-color;
+    border: 1px solid $ui-gray-800;
+    border-radius: 2px;
+    &:hover{
+        color: $ui-gray-200;
+        background-color: $ui-gray-800;
+    }
+}
+
+.modal-card-custom.has-padding-btm-left {
+    background-color: $background-color;
+}

--- a/ui/app/styles/core/dark-mode.scss
+++ b/ui/app/styles/core/dark-mode.scss
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+
+.dark-theme {
 // Define color variables for dark mode
 $background-color: #151515;
 
@@ -49,7 +51,6 @@ body {
 
 .box,
 .is-label,
-.toolbar-link,
 .title, .title > a,
 .column .menu-list a,
 .alert-banner-message-body,
@@ -58,8 +59,12 @@ body {
     color: $text-color;
 }
 
+// not working unless !important
 .toolbar-link {
     border: 0 !important;
+    &:hover {
+        color: $blue-500 !important;
+    }
 }
 
 .toolbar-link:hover:not(.disabled) {
@@ -99,9 +104,9 @@ body {
         background-color: $foreground-color-light;
     }
 }
-a.ember-view.is-destroy {
+.is-destroy {
     background-color: $background-color;
-    color: $red;
+    color: $red !important;
 }
 a.ember-view.toolbar-link {
     background-color: $foreground-color;
@@ -126,7 +131,12 @@ textarea,
     color: $text-color !important;
     border-radius: 2px;
 }
-
+.console-ui-input {
+    input {
+      background-color: rgba($black, 0.5);
+      border: 0;
+    }
+}
 .control.columns {
     background-color: transparent !important;
     border: 0;
@@ -146,8 +156,12 @@ textarea,
     background-color: $foreground-color-lightest;
 }
 
-.button,
-.button.is-outlined.is-primary {
+// buttons
+.button.has-top-margin-s,
+.button.has-left-margin-xs,
+.ember-view.button,
+.button.has-text-grey,
+.is-outlined {
     background-color: $foreground-color;
     color: $text-color;
     border: 1px solid $foreground-color-light;
@@ -156,9 +170,24 @@ textarea,
         background-color: $foreground-color-light;
     }
 }
+.is-transparent{
+    background-color: transparent !important;
+    border: 0 !important;
+}
+// hide/show buttons on editing and viewing pages
+.masked-input.display-only .masked-input-toggle.button {
+    background-color: $background-color;
+    border: 0;
+}
+.masked-input-toggle.button {
+    background-color: $foreground-color;
+    color: $text-color;
+    border: 1px solid $foreground-color-light;
+}
 .has-text-grey.masked-input-toggle.button {
     background-color: $foreground-color !important;
 }
+
 
 .button.is-ghost:hover {
     background-color: $foreground-color;
@@ -206,4 +235,5 @@ textarea,
 }
 .modal-background {
     background-color: $foreground-color;
+}
 }

--- a/ui/app/styles/core/dark-mode.scss
+++ b/ui/app/styles/core/dark-mode.scss
@@ -138,6 +138,11 @@ input, textarea, .box-radio, .select select, .control {
     border-radius: 2px;
 }
 
+.control.columns {
+    background-color: transparent !important;
+    border: 0;
+}
+
 .radio-card-row, .radio-card-container{
     background-color: $foreground-color;
 }

--- a/ui/app/templates/vault/cluster.hbs
+++ b/ui/app/templates/vault/cluster.hbs
@@ -86,6 +86,11 @@
       {{/if}}
       {{! template-lint-enable block-indentation }}
       <div class="navbar-item">
+        <button type="button" class="button is-transparent" {{action "toggleDark"}}>
+          <Icon @name="transit" />
+        </button>
+      </div>
+      <div class="navbar-item">
         <button
           type="button"
           class="button is-transparent nav-console-button{{if this.consoleOpen ' popup-open'}}"


### PR DESCRIPTION
Currently working on adding an option to enable dark mode as mentioned in #17819.

Currently I have only created a new styling sheet for dark mode.

Dark mode UI snippets:
<details>
  <summary>Old dark colors snippets</summary>
  <img src="https://user-images.githubusercontent.com/58087674/234666358-be21664a-50bd-4028-84b8-176a66f3d8d3.png" width="600">
  <img src="https://user-images.githubusercontent.com/58087674/234666502-d55fbe31-b6ef-4be9-9c32-264becf529cd.png" width="600">
  <img src="https://user-images.githubusercontent.com/58087674/234666783-6faa93bb-9cda-482e-be90-874b98627dc2.png" width="600">
</details>
<details>
  <summary>New dark colors snippets</summary>
  <img src="https://user-images.githubusercontent.com/58087674/235166792-6ed20f88-b004-42e3-873e-acd4c31e367a.png" width="600">
  <img src="https://user-images.githubusercontent.com/58087674/235166713-e9f85f52-f0eb-4500-a281-f4613085c596.png" width="600">
  <img src="https://user-images.githubusercontent.com/58087674/235180532-339323c8-ebeb-415c-abfe-ff9b28ff0877.png" width="600">
  <img src="https://user-images.githubusercontent.com/58087674/235177999-e0565b6f-455f-434a-9a11-8aba36863727.png" width="600">
</details>


Tested on Firefox and Chromium
TODO:
- [x] update drop-downs, input text to dark colors
- [ ] refactor classes and variables to achieve uniformity
- [ ] add option in settings or navbar to change themes
