### PR TITLE
add nil check for mfa enforcement config namespace on login

### DIFF
--- a/changelog/20375.txt
+++ b/changelog/20375.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: prevent panic on login after namespace is deleted that had mfa enforcement
+```

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -1789,11 +1789,7 @@ ECONFIG_LOOP:
 			return nil, fmt.Errorf("failed to find the MFAEnforcementConfig namespace")
 		}
 
-		if eConfigNS == nil {
-			continue
-		}
-
-		if eConfig == nil || (eConfigNS.ID != ns.ID && !ns.HasParent(eConfigNS)) {
+		if eConfig == nil || eConfigNS == nil || (eConfigNS.ID != ns.ID && !ns.HasParent(eConfigNS)) {
 			continue
 		}
 

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -1788,6 +1788,11 @@ ECONFIG_LOOP:
 		if err != nil {
 			return nil, fmt.Errorf("failed to find the MFAEnforcementConfig namespace")
 		}
+
+		if eConfigNS == nil {
+			continue
+		}
+
 		if eConfig == nil || (eConfigNS.ID != ns.ID && !ns.HasParent(eConfigNS)) {
 			continue
 		}


### PR DESCRIPTION
This PR adds a nil check around the namespace for a MFA enforcement config. This resolves a panic experienced on login after deleting a namespace which contains a MFA enforcement configuration.
Example Panic: 
```
2023-04-26T12:39:37.380-0400 [INFO]  http: panic serving 127.0.0.1:64255: runtime error: invalid memory address or nil pointer dereference
goroutine 930 [running]:
net/http.(*conn).serve.func1()
	/Users/runner/actions-runner/_work/_tool/go/1.19.4/x64/src/net/http/server.go:1850 +0xbf
panic({0x5dfd600, 0xae57de0})
	/Users/runner/actions-runner/_work/_tool/go/1.19.4/x64/src/runtime/panic.go:890 +0x262
github.com/hashicorp/vault/vault.(*Core).buildMFAEnforcementConfigList(0xc000ae6000, {0x7dca1b8, 0xc000adf3e0}, 0xc0012de1c0, {0xc001cf723a, 0x17})
	/Users/runner/actions-runner/_work/vault-enterprise/vault-enterprise/vault/login_mfa.go:1696 +0x2f2
github.com/hashicorp/vault/vault.(*Core).handleLoginRequest(0xc000ae6000, {0x7dca1b8, 0xc000adf3e0}, 0xc00165ec00)
	/Users/runner/actions-runner/_work/vault-enterprise/vault-enterprise/vault/request_handling.go:1506 +0x19e9
github.com/hashicorp/vault/vault.(*Core).handleCancelableRequest(0xc000ae6000, {0x7dca1b8, 0xc000adf3b0}, 0xc00165ec00)
	/Users/runner/actions-runner/_work/vault-enterprise/vault-enterprise/vault/request_handling.go:663 +0x15fe
github.com/hashicorp/vault/vault.(*Core).switchedLockHandleRequest(0xc000ae6000, {0x7dca1b8, 0xc000adee40}, 0xc00165ec00, 0xc0?)
	/Users/runner/actions-runner/_work/vault-enterprise/vault-enterprise/vault/request_handling.go:472 +0x539
github.com/hashicorp/vault/vault.(*Core).HandleRequest(...)
```