### PR TITLE
Refactor Code Focused on DevTLS Mode into New Function

### DIFF
--- a/command/server_test.go
+++ b/command/server_test.go
@@ -330,3 +330,65 @@ func TestServer_DevTLS(t *testing.T) {
 	require.Equal(t, 0, retCode, output)
 	require.Contains(t, output, `tls: "enabled"`)
 }
+
+// TestConfigureDevTLS verifies the various logic paths that flow through the
+// configureDevTLS function.
+func TestConfigureDevTLS(t *testing.T) {
+	testcases := []struct {
+		ServerCommand   *ServerCommand
+		DeferFuncNotNil bool
+		ConfigNotNil    bool
+		TLSDisable      bool
+		CertPathEmpty   bool
+		ErrNotNil       bool
+	}{
+		// flagDev is false, nothing will be configured.
+		{
+			ServerCommand: &ServerCommand{
+				flagDevTLS: false,
+			},
+			ConfigNotNil:  true,
+			TLSDisable:    true,
+			CertPathEmpty: true,
+			ErrNotNil:     false,
+		},
+		// flagDevTLSCertDir is empty.
+		{
+			ServerCommand: &ServerCommand{
+				flagDevTLS:        true,
+				flagDevTLSCertDir: "",
+			},
+			DeferFuncNotNil: true,
+			ConfigNotNil:    true,
+			ErrNotNil:       false,
+		},
+		// flagDevTLSCertDir is set to something invalid
+		{
+			ServerCommand: &ServerCommand{
+				flagDevTLS:        true,
+				flagDevTLSCertDir: "@/#",
+			},
+			CertPathEmpty: true,
+			ErrNotNil:     true,
+		},
+	}
+
+	for i, testcase := range testcases {
+		fun, cfg, certPath, err := configureDevTLS(testcase.ServerCommand)
+		if fun != nil {
+			// If a function is returned, call it right away to clean up
+			// files created in the temporary directory before anything else has
+			// a chance to fail this test.
+			fun()
+		}
+
+		require.Equal(t, testcase.DeferFuncNotNil, (fun != nil), "Iteration %d", i)
+		require.Equal(t, testcase.ConfigNotNil, cfg != nil, "Iteration %d", i)
+		if testcase.ConfigNotNil {
+			require.True(t, len(cfg.Listeners) > 0, "Iteration %d", i)
+			require.Equal(t, testcase.TLSDisable, cfg.Listeners[0].TLSDisable, "Iteration %d", i)
+		}
+		require.Equal(t, testcase.CertPathEmpty, len(certPath) == 0, "Iteration %d", i)
+		require.Equal(t, testcase.ErrNotNil, (err != nil), "Iteration %d", i)
+	}
+}

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -341,18 +341,18 @@ func TestConfigureDevTLS(t *testing.T) {
 		TLSDisable      bool
 		CertPathEmpty   bool
 		ErrNotNil       bool
+		TestDescription string
 	}{
-		// flagDev is false, nothing will be configured.
 		{
 			ServerCommand: &ServerCommand{
 				flagDevTLS: false,
 			},
-			ConfigNotNil:  true,
-			TLSDisable:    true,
-			CertPathEmpty: true,
-			ErrNotNil:     false,
+			ConfigNotNil:    true,
+			TLSDisable:      true,
+			CertPathEmpty:   true,
+			ErrNotNil:       false,
+			TestDescription: "flagDev is false, nothing will be configured",
 		},
-		// flagDevTLSCertDir is empty.
 		{
 			ServerCommand: &ServerCommand{
 				flagDevTLS:        true,
@@ -361,19 +361,20 @@ func TestConfigureDevTLS(t *testing.T) {
 			DeferFuncNotNil: true,
 			ConfigNotNil:    true,
 			ErrNotNil:       false,
+			TestDescription: "flagDevTLSCertDir is empty",
 		},
-		// flagDevTLSCertDir is set to something invalid
 		{
 			ServerCommand: &ServerCommand{
 				flagDevTLS:        true,
 				flagDevTLSCertDir: "@/#",
 			},
-			CertPathEmpty: true,
-			ErrNotNil:     true,
+			CertPathEmpty:   true,
+			ErrNotNil:       true,
+			TestDescription: "flagDevTLSCertDir is set to something invalid",
 		},
 	}
 
-	for i, testcase := range testcases {
+	for _, testcase := range testcases {
 		fun, cfg, certPath, err := configureDevTLS(testcase.ServerCommand)
 		if fun != nil {
 			// If a function is returned, call it right away to clean up
@@ -382,13 +383,13 @@ func TestConfigureDevTLS(t *testing.T) {
 			fun()
 		}
 
-		require.Equal(t, testcase.DeferFuncNotNil, (fun != nil), "Iteration %d", i)
-		require.Equal(t, testcase.ConfigNotNil, cfg != nil, "Iteration %d", i)
+		require.Equal(t, testcase.DeferFuncNotNil, (fun != nil), "test description %s", testcase.TestDescription)
+		require.Equal(t, testcase.ConfigNotNil, cfg != nil, "test description %s", testcase.TestDescription)
 		if testcase.ConfigNotNil {
-			require.True(t, len(cfg.Listeners) > 0, "Iteration %d", i)
-			require.Equal(t, testcase.TLSDisable, cfg.Listeners[0].TLSDisable, "Iteration %d", i)
+			require.True(t, len(cfg.Listeners) > 0, "test description %s", testcase.TestDescription)
+			require.Equal(t, testcase.TLSDisable, cfg.Listeners[0].TLSDisable, "test description %s", testcase.TestDescription)
 		}
-		require.Equal(t, testcase.CertPathEmpty, len(certPath) == 0, "Iteration %d", i)
-		require.Equal(t, testcase.ErrNotNil, (err != nil), "Iteration %d", i)
+		require.Equal(t, testcase.CertPathEmpty, len(certPath) == 0, "test description %s", testcase.TestDescription)
+		require.Equal(t, testcase.ErrNotNil, (err != nil), "test description %s", testcase.TestDescription)
 	}
 }


### PR DESCRIPTION
This PR proposes moving logic from the **(*ServerCommand) Run(args []string)** function that relates specifically to configuring TLS when the Vault server is being launched in *dev* mode, into its own function in order to facilitate testing of that logic and clearing some of the noise from the Run function.