### PR TITLE
[Docs] Fix the GDPR link

### DIFF
--- a/website/content/docs/enterprise/replication.mdx
+++ b/website/content/docs/enterprise/replication.mdx
@@ -77,7 +77,7 @@ The primary cluster's mount configuration gets replicated across its secondary
 clusters when you enable Performance Replication. In some cases, you may not
 want all data to be replicated. For example, your primary cluster is in the EU
 region, and you have a secondary cluster outside of the EU region. [General Data
-Protection Regulation (GDPR)](https://www.eugdpr.org/) requires that personally
+Protection Regulation (GDPR)](https://gdpr.eu/) requires that personally
 identifiable data not be physically transferred to locations outside the
 European Union unless the region or country has an equal rigor of data
 protection regulation as the EU.


### PR DESCRIPTION
Related to https://github.com/hashicorp/vault/pull/20114

I found one more, and I think this is it. 

The correct GDPR org URL should be https://gdpr.eu/