### PR TITLE
Add custom DNS resolver to ACME configuration

### DIFF
--- a/builtin/logical/pki/acme_challenge_engine.go
+++ b/builtin/logical/pki/acme_challenge_engine.go
@@ -85,11 +85,11 @@ func (ace *ACMEChallengeEngine) LoadFromStorage(b *backend, sc *storageContext) 
 	return nil
 }
 
-func (ace *ACMEChallengeEngine) Run(b *backend) {
+func (ace *ACMEChallengeEngine) Run(b *backend, state *acmeState) {
 	for true {
 		// err == nil on shutdown.
 		b.Logger().Debug("Starting ACME challenge validation engine")
-		err := ace._run(b)
+		err := ace._run(b, state)
 		if err != nil {
 			b.Logger().Error("Got unexpected error from ACME challenge validation engine", "err", err)
 			time.Sleep(1 * time.Second)
@@ -99,7 +99,7 @@ func (ace *ACMEChallengeEngine) Run(b *backend) {
 	}
 }
 
-func (ace *ACMEChallengeEngine) _run(b *backend) error {
+func (ace *ACMEChallengeEngine) _run(b *backend, state *acmeState) error {
 	// This runner uses a background context for storage operations: we don't
 	// want to tie it to a inbound request and we don't want to set a time
 	// limit, so create a fresh background context.
@@ -177,6 +177,11 @@ func (ace *ACMEChallengeEngine) _run(b *backend) error {
 				continue
 			}
 
+			config, err := state.getConfigWithUpdate(runnerSC)
+			if err != nil {
+				return fmt.Errorf("failed fetching ACME configuration: %w", err)
+			}
+
 			// Since this work item was valid, we won't expect to see it in
 			// the validation queue again until it is executed. Here, we
 			// want to avoid infinite looping above (if we removed the one
@@ -190,7 +195,7 @@ func (ace *ACMEChallengeEngine) _run(b *backend) error {
 			// could have a RetryAfter date we're not aware of (e.g., if the
 			// cluster restarted as we do not read the entries there).
 			channel := make(chan bool, 1)
-			go ace.VerifyChallenge(runnerSC, task.Identifier, channel)
+			go ace.VerifyChallenge(runnerSC, task.Identifier, channel, config)
 			finishedWorkersChannels = append(finishedWorkersChannels, channel)
 			startedWork = true
 		}
@@ -279,11 +284,11 @@ func (ace *ACMEChallengeEngine) AcceptChallenge(sc *storageContext, account stri
 	return nil
 }
 
-func (ace *ACMEChallengeEngine) VerifyChallenge(runnerSc *storageContext, id string, finished chan bool) {
+func (ace *ACMEChallengeEngine) VerifyChallenge(runnerSc *storageContext, id string, finished chan bool, config *acmeConfigEntry) {
 	sc, _ /* cancel func */ := runnerSc.WithFreshTimeout(MaxChallengeTimeout)
 	runnerSc.Backend.Logger().Debug("Starting verification of challenge: %v", id)
 
-	if retry, retryAfter, err := ace._verifyChallenge(sc, id); err != nil {
+	if retry, retryAfter, err := ace._verifyChallenge(sc, id, config); err != nil {
 		// Because verification of this challenge failed, we need to retry
 		// it in the future. Log the error and re-add the item to the queue
 		// to try again later.
@@ -315,7 +320,7 @@ func (ace *ACMEChallengeEngine) VerifyChallenge(runnerSc *storageContext, id str
 	finished <- false
 }
 
-func (ace *ACMEChallengeEngine) _verifyChallenge(sc *storageContext, id string) (bool, time.Time, error) {
+func (ace *ACMEChallengeEngine) _verifyChallenge(sc *storageContext, id string, config *acmeConfigEntry) (bool, time.Time, error) {
 	now := time.Now()
 	path := acmeValidationPrefix + id
 	challengeEntry, err := sc.Storage.Get(sc.Context, path)
@@ -384,7 +389,7 @@ func (ace *ACMEChallengeEngine) _verifyChallenge(sc *storageContext, id string) 
 			return ace._verifyChallengeCleanup(sc, err, id)
 		}
 
-		valid, err = ValidateHTTP01Challenge(authz.Identifier.Value, cv.Token, cv.Thumbprint)
+		valid, err = ValidateHTTP01Challenge(authz.Identifier.Value, cv.Token, cv.Thumbprint, config)
 		if err != nil {
 			err = fmt.Errorf("error validating http-01 challenge %v: %w", id, err)
 			return ace._verifyChallengeRetry(sc, cv, authz, err, id)
@@ -395,7 +400,7 @@ func (ace *ACMEChallengeEngine) _verifyChallenge(sc *storageContext, id string) 
 			return ace._verifyChallengeCleanup(sc, err, id)
 		}
 
-		valid, err = ValidateDNS01Challenge(authz.Identifier.Value, cv.Token, cv.Thumbprint)
+		valid, err = ValidateDNS01Challenge(authz.Identifier.Value, cv.Token, cv.Thumbprint, config)
 		if err != nil {
 			err = fmt.Errorf("error validating dns-01 challenge %v: %w", id, err)
 			return ace._verifyChallengeRetry(sc, cv, authz, err, id)

--- a/builtin/logical/pki/acme_challenges_test.go
+++ b/builtin/logical/pki/acme_challenges_test.go
@@ -126,7 +126,7 @@ func TestAcmeValidateHTTP01Challenge(t *testing.T) {
 				defer ts.Close()
 
 				host := ts.URL[7:]
-				isValid, err := ValidateHTTP01Challenge(host, tc.token, tc.thumbprint)
+				isValid, err := ValidateHTTP01Challenge(host, tc.token, tc.thumbprint, &acmeConfigEntry{})
 				if !isValid && err == nil {
 					t.Fatalf("[tc=%d/handler=%d] expected failure to give reason via err (%v / %v)", handlerIndex, index, isValid, err)
 				}
@@ -159,7 +159,7 @@ func TestAcmeValidateHTTP01Challenge(t *testing.T) {
 	}
 	tooLarge := func(w http.ResponseWriter, r *http.Request) {
 		for i := 0; i < 512; i++ {
-			w.Write([]byte("my-token.my-thumbprint"))
+			w.Write([]byte("my-token.my-thumbprint\n"))
 		}
 	}
 
@@ -175,7 +175,7 @@ func TestAcmeValidateHTTP01Challenge(t *testing.T) {
 			defer ts.Close()
 
 			host := ts.URL[7:]
-			isValid, err := ValidateHTTP01Challenge(host, "my-token", "my-thumbprint")
+			isValid, err := ValidateHTTP01Challenge(host, "my-token", "my-thumbprint", &acmeConfigEntry{})
 			if isValid || err == nil {
 				t.Fatalf("[handler=%d] expected failure validating challenge (%v / %v)", handlerIndex, isValid, err)
 			}

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -76,7 +76,7 @@ func (a *acmeState) Initialize(b *backend, sc *storageContext) error {
 	if err := a.validator.Initialize(b, sc); err != nil {
 		return fmt.Errorf("error initializing ACME engine: %w", err)
 	}
-	go a.validator.Run(b)
+	go a.validator.Run(b, a)
 
 	return nil
 }

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -41,6 +41,10 @@ type acmeState struct {
 	nextExpiry *atomic.Int64
 	nonces     *sync.Map // map[string]time.Time
 	validator  *ACMEChallengeEngine
+
+	configDirty *atomic.Bool
+	_config     sync.RWMutex
+	config      acmeConfigEntry
 }
 
 type acmeThumbprint struct {
@@ -49,21 +53,73 @@ type acmeThumbprint struct {
 }
 
 func NewACMEState() *acmeState {
-	return &acmeState{
-		nextExpiry: new(atomic.Int64),
-		nonces:     new(sync.Map),
-		validator:  NewACMEChallengeEngine(),
+	state := &acmeState{
+		nextExpiry:  new(atomic.Int64),
+		nonces:      new(sync.Map),
+		validator:   NewACMEChallengeEngine(),
+		configDirty: new(atomic.Bool),
 	}
+	// Config hasn't been loaded yet; mark dirty.
+	state.configDirty.Store(true)
+
+	return state
 }
 
 func (a *acmeState) Initialize(b *backend, sc *storageContext) error {
-	if err := a.validator.Initialize(b, sc); err != nil {
+	// Load the ACME config.
+	_, err := a.getConfigWithUpdate(sc)
+	if err != nil {
 		return fmt.Errorf("error initializing ACME engine: %w", err)
 	}
 
+	// Kick off our ACME challenge validation engine.
+	if err := a.validator.Initialize(b, sc); err != nil {
+		return fmt.Errorf("error initializing ACME engine: %w", err)
+	}
 	go a.validator.Run(b)
 
 	return nil
+}
+
+func (a *acmeState) markConfigDirty() {
+	a.configDirty.Store(true)
+}
+
+func (a *acmeState) reloadConfigIfRequired(sc *storageContext) error {
+	if !a.configDirty.Load() {
+		return nil
+	}
+
+	a._config.Lock()
+	defer a._config.Unlock()
+
+	if !a.configDirty.Load() {
+		// Someone beat us to grabbing the above write lock and already
+		// updated the config.
+		return nil
+	}
+
+	config, err := sc.getAcmeConfig()
+	if err != nil {
+		return fmt.Errorf("failed reading config: %w", err)
+	}
+
+	a.config = *config
+	a.configDirty.Store(false)
+
+	return nil
+}
+
+func (a *acmeState) getConfigWithUpdate(sc *storageContext) (*acmeConfigEntry, error) {
+	if err := a.reloadConfigIfRequired(sc); err != nil {
+		return nil, err
+	}
+
+	a._config.RLock()
+	defer a._config.RUnlock()
+
+	configCopy := a.config
+	return &configCopy, nil
 }
 
 func generateNonce() (string, error) {

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -542,6 +542,8 @@ func (b *backend) invalidate(ctx context.Context, key string) {
 	case key == "config/crl":
 		// We may need to reload our OCSP status flag
 		b.crlBuilder.markConfigDirty()
+	case key == storageAcmeConfig:
+		b.acmeState.markConfigDirty()
 	case key == storageIssuerConfig:
 		b.crlBuilder.invalidateCRLBuildTime()
 	case strings.HasPrefix(key, crossRevocationPrefix):

--- a/builtin/logical/pki/dnstest/server.go
+++ b/builtin/logical/pki/dnstest/server.go
@@ -1,0 +1,280 @@
+package dnstest
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
+	"github.com/hashicorp/vault/sdk/helper/docker"
+	"github.com/stretchr/testify/require"
+)
+
+type TestServer struct {
+	t   *testing.T
+	ctx context.Context
+
+	runner  *docker.Runner
+	startup *docker.Service
+
+	serial     int
+	forwarders []string
+	domains    []string
+	records    map[string]map[string][]string // domain -> record -> value(s).
+
+	cleanup func()
+}
+
+func SetupResolver(t *testing.T, domain string) *TestServer {
+	return SetupResolverOnNetwork(t, domain, "")
+}
+
+func SetupResolverOnNetwork(t *testing.T, domain string, network string) *TestServer {
+	var ts TestServer
+	ts.t = t
+	ts.ctx = context.Background()
+	ts.domains = []string{domain}
+	ts.records = map[string]map[string][]string{}
+
+	ts.setupRunner(domain, network)
+	ts.startContainer()
+	ts.PushConfig()
+
+	return &ts
+}
+
+func (ts *TestServer) setupRunner(domain string, network string) {
+	var err error
+	ts.runner, err = docker.NewServiceRunner(docker.RunOptions{
+		ImageRepo:     "ubuntu/bind9",
+		ImageTag:      "latest",
+		ContainerName: "bind9-dns-" + strings.ReplaceAll(domain, ".", "-"),
+		NetworkName:   network,
+		Ports:         []string{"53/udp"},
+		LogConsumer: func(s string) {
+			ts.t.Logf(s)
+		},
+	})
+	require.NoError(ts.t, err)
+}
+
+func (ts *TestServer) startContainer() {
+	connUpFunc := func(ctx context.Context, host string, port int) (docker.ServiceConfig, error) {
+		// Perform a simple connection to this resolver, even though the
+		// default configuration doesn't do anything useful.
+		peer, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", host, port))
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve peer: %v / %v: %w", host, port, err)
+		}
+
+		conn, err := net.DialUDP("udp", nil, peer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to dial peer: %v / %v / %v: %w", host, port, peer, err)
+		}
+		defer conn.Close()
+
+		_, err = conn.Write([]byte("garbage-in"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to write to peer: %v / %v / %v: %w", host, port, peer, err)
+		}
+
+		// Connection worked.
+		return docker.NewServiceHostPort(host, port), nil
+	}
+
+	result, err := ts.runner.StartService(ts.ctx, connUpFunc)
+	require.NoError(ts.t, err, "failed to start dns resolver for "+ts.domains[0])
+	ts.startup = result
+}
+
+func (ts *TestServer) buildNamedConf() string {
+	forwarders := "\n"
+	if len(ts.forwarders) > 0 {
+		forwarders = "\tforwarders {\n"
+		for _, forwarder := range ts.forwarders {
+			forwarders += "\t\t" + forwarder + ";\n"
+		}
+		forwarders += "\t};\n"
+	}
+
+	zones := "\n"
+	for _, domain := range ts.domains {
+		zones += fmt.Sprintf("zone \"%s\" {\n", domain)
+		zones += "\ttype primary;\n"
+		zones += fmt.Sprintf("\tfile \"%s.zone\";\n", domain)
+		zones += "\tallow-update {\n\t\tnone;\n\t};\n"
+		zones += "\tnotify no;\n"
+		zones += "};\n\n"
+	}
+
+	// Reverse lookups are not handles as they're not presently necessary.
+
+	cfg := `options {
+	directory "/var/cache/bind";
+
+	dnssec-validation no;
+
+	` + forwarders + `
+};
+
+` + zones
+
+	return cfg
+}
+
+func (ts *TestServer) buildZoneFile(target string) string {
+	// One second TTL by default to allow quick refreshes.
+	zone := "$TTL 1;\n"
+
+	ts.serial += 1
+	zone += fmt.Sprintf("@\tIN\tSOA\tns.%v.\troot.%v.\t(\n", target, target)
+	zone += fmt.Sprintf("\t\t\t%d;\n\t\t\t1;\n\t\t\t1;\n\t\t\t2;\n\t\t\t1;\n\t\t\t)\n\n", ts.serial)
+	zone += fmt.Sprintf("@\tIN\tNS\tns%d.%v.\n", ts.serial, target)
+	zone += fmt.Sprintf("ns%d.%v.\tIN\tA\t%v\n", ts.serial, target, "127.0.0.1")
+
+	for domain, records := range ts.records {
+		if !strings.HasSuffix(domain, target) {
+			continue
+		}
+
+		for recordType, values := range records {
+			for _, value := range values {
+				zone += fmt.Sprintf("%s.\tIN\t%s\t%s\n", domain, recordType, value)
+			}
+		}
+	}
+
+	return zone
+}
+
+func (ts *TestServer) PushConfig() {
+	contents := docker.NewBuildContext()
+	cfgPath := "/etc/bind/named.conf.options"
+	namedCfg := ts.buildNamedConf()
+	contents[cfgPath] = docker.PathContentsFromString(namedCfg)
+	contents[cfgPath].SetOwners(0, 142) // root, bind
+
+	ts.t.Logf("Generated bind9 config (%s):\n%v\n", cfgPath, namedCfg)
+
+	for _, domain := range ts.domains {
+		path := "/var/cache/bind/" + domain + ".zone"
+		zoneFile := ts.buildZoneFile(domain)
+		contents[path] = docker.PathContentsFromString(zoneFile)
+		contents[path].SetOwners(0, 142) // root, bind
+
+		ts.t.Logf("Generated bind9 zone file for %v (%s):\n%v\n", domain, path, zoneFile)
+	}
+
+	err := ts.runner.CopyTo(ts.startup.Container.ID, "/", contents)
+	require.NoError(ts.t, err, "failed pushing updated configuration to container")
+
+	// Wait until our config has taken.
+	corehelpers.RetryUntil(ts.t, 3*time.Second, func() error {
+		// bind reloads based on file mtime, touch files before starting
+		// to make sure it has been updated more recently than when the
+		// last update was written. Then issue a new SIGHUP.
+		for _, domain := range ts.domains {
+			path := "/var/cache/bind/" + domain + ".zone"
+			touchCmd := []string{"touch", path}
+
+			_, _, _, err := ts.runner.RunCmdWithOutput(ts.ctx, ts.startup.Container.ID, touchCmd)
+			if err != nil {
+				return fmt.Errorf("failed to update zone mtime: %w", err)
+			}
+		}
+		ts.runner.DockerAPI.ContainerKill(ts.ctx, ts.startup.Container.ID, "SIGHUP")
+
+		// Connect to our bind resolver.
+		resolver := &net.Resolver{
+			PreferGo:     true,
+			StrictErrors: false,
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				d := net.Dialer{
+					Timeout: 10 * time.Second,
+				}
+				return d.DialContext(ctx, network, ts.GetLocalAddr())
+			},
+		}
+
+		// last domain has the given serial number, which also appears in the
+		// NS record so we can fetch it via Go.
+		lastDomain := ts.domains[len(ts.domains)-1]
+		records, err := resolver.LookupNS(ts.ctx, lastDomain)
+		if err != nil {
+			return fmt.Errorf("failed to lookup NS record for %v: %w", lastDomain, err)
+		}
+
+		if len(records) != 1 {
+			return fmt.Errorf("expected only 1 NS record for %v, got %v/%v", lastDomain, len(records), records)
+		}
+
+		expectedNS := fmt.Sprintf("ns%d.%v.", ts.serial, lastDomain)
+		if records[0].Host != expectedNS {
+			return fmt.Errorf("expected to find NS %v, got %v indicating reload hadn't completed", expectedNS, records[0])
+		}
+
+		return nil
+	})
+}
+
+func (ts *TestServer) GetLocalAddr() string {
+	return ts.startup.Config.Address()
+}
+
+func (ts *TestServer) GetRemoteAddr() string {
+	return fmt.Sprintf("%s:%d", ts.startup.StartResult.RealIP, 53)
+}
+
+func (ts *TestServer) AddDomain(domain string) {
+	for _, existing := range ts.domains {
+		if existing == domain {
+			return
+		}
+	}
+
+	ts.domains = append(ts.domains, domain)
+}
+
+func (ts *TestServer) AddRecord(domain string, record string, value string) {
+	foundDomain := false
+	for _, existing := range ts.domains {
+		if strings.HasSuffix(domain, existing) {
+			foundDomain = true
+			break
+		}
+	}
+	if !foundDomain {
+		ts.t.Fatalf("cannot add record %v/%v :: [%v] -- no domain zone matching (%v)", record, domain, value, ts.domains)
+	}
+
+	value = strings.TrimSpace(value)
+	if _, present := ts.records[domain]; !present {
+		ts.records[domain] = map[string][]string{}
+	}
+
+	if values, present := ts.records[domain][record]; present {
+		for _, candidate := range values {
+			if candidate == value {
+				break
+			}
+		}
+	}
+
+	ts.records[domain][record] = append(ts.records[domain][record], value)
+}
+
+func (ts *TestServer) RemoveAllRecords() {
+	ts.records = map[string]map[string][]string{}
+}
+
+func (ts *TestServer) Cleanup() {
+	if ts.cleanup != nil {
+		ts.cleanup()
+	}
+	if ts.startup != nil && ts.startup.Cleanup != nil {
+		ts.startup.Cleanup()
+	}
+}


### PR DESCRIPTION
This:

 - Adds a custom DNS resolver for ACME, allowing it to be used in environments where the operator might wish to use a different resolver but not have access to modify the host's resolvers.
 - Adds new config caching to the ACME state, plumbing it through to the validation engine.
 - Adds tests against a new bind9 container to ensure dns-01 challenges work, by providing a custom resolver address pointing to the container image.