### PR TITLE
api-docs/pki: common_name is no longer required.

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -242,10 +242,12 @@ It is suggested to limit access to the path-overridden issue endpoint (on
 ~> Note: This parameter is not present on the `/pki/issue/:name` path and
    takes its value from the role's `issuer_ref` field.
 
-- `common_name` `(string: <required>)` - Specifies the requested CN for the
+- `common_name` `(string: "")` - Specifies the requested CN for the
   certificate. If the CN is allowed by role policy, it will be issued. If more
   than one `common_name` is desired, specify the alternative names in the
   `alt_names` list.
+
+~> Note: A value for `common_name` is required when [require_cn](#require_cn) is set to `true`
 
 - `alt_names` `(string: "")` - Specifies requested Subject Alternative Names, in
   a comma-delimited list. These can be host names or email addresses; they will


### PR DESCRIPTION
The current api-docs for the PKI secrets engine mark `common_name` as being a required parameter when requesting a certificate to be issued. It is only required if `require_cn` is set to true on the role.