### PR TITLE
Pipe MountPoint to audit logs

### DIFF
--- a/audit/format.go
+++ b/audit/format.go
@@ -117,6 +117,7 @@ func (f *AuditFormatter) FormatRequest(ctx context.Context, w io.Writer, config 
 			ClientToken:           req.ClientToken,
 			ClientTokenAccessor:   req.ClientTokenAccessor,
 			Operation:             req.Operation,
+			MountPoint:            req.MountPoint,
 			MountType:             req.MountType,
 			MountAccessor:         req.MountAccessor,
 			MountRunningVersion:   req.MountRunningVersion(),
@@ -320,6 +321,7 @@ func (f *AuditFormatter) FormatResponse(ctx context.Context, w io.Writer, config
 			ClientTokenAccessor:   req.ClientTokenAccessor,
 			ClientID:              req.ClientID,
 			Operation:             req.Operation,
+			MountPoint:            req.MountPoint,
 			MountType:             req.MountType,
 			MountAccessor:         req.MountAccessor,
 			MountRunningVersion:   req.MountRunningVersion(),
@@ -341,6 +343,7 @@ func (f *AuditFormatter) FormatResponse(ctx context.Context, w io.Writer, config
 		},
 
 		Response: &AuditResponse{
+			MountPoint:            req.MountPoint,
 			MountType:             req.MountType,
 			MountAccessor:         req.MountAccessor,
 			MountRunningVersion:   req.MountRunningVersion(),
@@ -409,6 +412,7 @@ type AuditRequest struct {
 	ClientID                      string                 `json:"client_id,omitempty"`
 	ReplicationCluster            string                 `json:"replication_cluster,omitempty"`
 	Operation                     logical.Operation      `json:"operation,omitempty"`
+	MountPoint                    string                 `json:"mount_point,omitempty"`
 	MountType                     string                 `json:"mount_type,omitempty"`
 	MountAccessor                 string                 `json:"mount_accessor,omitempty"`
 	MountRunningVersion           string                 `json:"mount_running_version,omitempty"`
@@ -430,6 +434,7 @@ type AuditRequest struct {
 
 type AuditResponse struct {
 	Auth                  *AuditAuth             `json:"auth,omitempty"`
+	MountPoint            string                 `json:"mount_point,omitempty"`
 	MountType             string                 `json:"mount_type,omitempty"`
 	MountAccessor         string                 `json:"mount_accessor,omitempty"`
 	MountRunningVersion   string                 `json:"mount_running_plugin_version,omitempty"`

--- a/changelog/20411.txt
+++ b/changelog/20411.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+audit: pipes the existing "Request.MountPoint" into audit logs
+```

--- a/changelog/20411.txt
+++ b/changelog/20411.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-audit: pipes the existing "Request.MountPoint" into audit logs
+audit: add a `mount_point` field to audit requests and response entries
 ```


### PR DESCRIPTION
[VAULT-15882](https://hashicorp.atlassian.net/browse/VAULT-15882)
required for Vault Insights, this PR simply pipes the existing `Request.MountPoint` into audit logs

[VAULT-15882]: https://hashicorp.atlassian.net/browse/VAULT-15882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ