### PR TITLE
update changelog type from feature to improvement

### DIFF
--- a/changelog/19814.txt
+++ b/changelog/19814.txt
@@ -1,3 +1,3 @@
-```release-note:feature
+```release-note:improvement
 audit: add plugin metadata, including plugin name, type, version, sha256, and whether plugin is external, to audit logging
 ```


### PR DESCRIPTION
Following our internal changelog process, [the original PR](https://github.com/hashicorp/vault/pull/19814) should have `improvement` as the correct changelog type