### PR TITLE
Fix panic when Vault enters recovery mode, added test

### DIFF
--- a/changelog/20418.txt
+++ b/changelog/20418.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+command/server: fixes panic in Vault server command when running in recovery mode
+```

--- a/command/server.go
+++ b/command/server.go
@@ -457,7 +457,7 @@ func (c *ServerCommand) runRecoveryMode() int {
 	}
 
 	// Update the 'log' related aspects of shared config based on config/env var/cli
-	c.Flags().applyLogConfigOverrides(config.SharedConfig)
+	c.flags.applyLogConfigOverrides(config.SharedConfig)
 	l, err := c.configureLogging(config)
 	if err != nil {
 		c.UI.Error(err.Error())
@@ -671,6 +671,12 @@ func (c *ServerCommand) runRecoveryMode() int {
 	}
 
 	c.UI.Output("")
+
+	// Tests might not want to start a vault server and just want to verify
+	// the configuration.
+	if c.flagTestVerifyOnly {
+		return 0
+	}
 
 	for _, ln := range lns {
 		handler := vaulthttp.Handler.Handler(&vault.HandlerProperties{

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -286,6 +286,13 @@ func TestServer(t *testing.T) {
 			0,
 			[]string{"-test-verify-only"},
 		},
+		{
+			"recovery_mode",
+			testBaseHCL(t, "") + inmemHCL,
+			"",
+			0,
+			[]string{"-test-verify-only", "-recovery"},
+		},
 	}
 
 	for _, tc := range cases {
@@ -295,26 +302,21 @@ func TestServer(t *testing.T) {
 			t.Parallel()
 
 			ui, cmd := testServerCommand(t)
-			f, err := ioutil.TempFile("", "")
-			if err != nil {
-				t.Fatalf("error creating temp dir: %v", err)
-			}
-			f.WriteString(tc.contents)
-			f.Close()
-			defer os.Remove(f.Name())
+
+			f, err := os.CreateTemp(t.TempDir(), "")
+			require.NoErrorf(t, err, "error creating temp dir: %v", err)
+
+			_, err = f.WriteString(tc.contents)
+			require.NoErrorf(t, err, "cannot write temp file contents")
+
+			err = f.Close()
+			require.NoErrorf(t, err, "unable to close temp file")
 
 			args := append(tc.args, "-config", f.Name())
-
 			code := cmd.Run(args)
 			output := ui.ErrorWriter.String() + ui.OutputWriter.String()
-
-			if code != tc.code {
-				t.Errorf("expected %d to be %d: %s", code, tc.code, output)
-			}
-
-			if !strings.Contains(output, tc.exp) {
-				t.Fatalf("expected %q to contain %q", output, tc.exp)
-			}
+			require.Equal(t, tc.code, code, "expected %d to be %d: %s", code, tc.code, output)
+			require.Contains(t, output, tc.exp, "expected %q to contain %q", output, tc.exp)
 		})
 	}
 }


### PR DESCRIPTION
Fixes regression in recovery mode where Vault panics, the bug was introduced by log rotation features (1.13) and this PR should correct the issue. 

We're no longer calling `.Flags()` which already happens at the top of our `Server.Run` func, and instead accessing the relevant field (`.flags`). A test case has been added to verify recovery mode (and a flag check which matches the vanilla `Server.Run` path added within `runRecoveryMode`).

Thanks to folks for reporting and assisting with identifying the issue 👍🏼 

Closes #20396
