### PR TITLE
Update the command output example

### DIFF
--- a/website/content/docs/commands/operator/key-status.mdx
+++ b/website/content/docs/commands/operator/key-status.mdx
@@ -17,8 +17,9 @@ Get the key status:
 
 ```shell-session
 $ vault operator key-status
-Key Term        2
-Install Time    01 Jan 17 12:30 UTC
+Key Term          2
+Install Time      01 Jan 17 12:30 UTC
+Encryption Count  4494
 ```
 
 ## Usage


### PR DESCRIPTION
🎫 [Jira](https://hashicorp.atlassian.net/browse/VAULT-13949)
🎟️ [Zendesk ticket](https://hashicorp.zendesk.com/agent/tickets/100237)

This PR updates the command output for `vault operator key-status`.

Customer reported that `Encryption Count` is missing in the doc.