### PR TITLE
Add vault print token to commands in Vault docs (#19183)

### DIFF
--- a/website/content/docs/commands/print.mdx
+++ b/website/content/docs/commands/print.mdx
@@ -1,0 +1,18 @@
+---
+layout: docs
+page_title: version - Command
+description: The "print" command prints the Vault token currently in use.
+---
+
+# print
+
+The `print` command prints the Vault token currently in use. The only available subcommand is `token`.
+
+## Examples
+
+Print the current token.
+
+```shell-session
+$ vault print token
+hvs.CAESICaie3Dm0_Hx001QuMabo1IXnyKkx_FuE14MH7zir_bqGh4KHGh2cy5wQnJsZzZ6WG82b29HUlI3eFdEQ0NPQzQ
+```

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -771,6 +771,10 @@
         ]
       },
       {
+        "title": "<code>print</code>",
+        "path": "commands/print"
+      },
+      {
         "title": "<code>read</code>",
         "path": "commands/read"
       },


### PR DESCRIPTION
🎫 [Jira ticket](https://hashicorp.atlassian.net/browse/VAULT-14362)

🔍 [Deploy preview](https://vault-git-docs-cherry-pick-pr19183-hashicorp.vercel.app/vault/docs/commands/print)

It was reported that the `vault print` command doc is missing in the `1.13.x` docs. Looks like the changes made with https://github.com/hashicorp/vault/pull/19183 was not cherry picked into the `release/1.13.x` branch.

![image](https://user-images.githubusercontent.com/7660718/235227110-2b2b5d75-c3f5-4b8f-aa46-8edee230ea56.png)


This PR manually cherry picks the commit.