### PR TITLE
UI: fix secret with % in path

### DIFF
--- a/changelog/20430.txt
+++ b/changelog/20430.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix secret render when path includes %. Resolves #11616.
+```

--- a/ui/app/utils/path-encoding-helpers.js
+++ b/ui/app/utils/path-encoding-helpers.js
@@ -3,14 +3,25 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import RouteRecognizer from 'route-recognizer';
-
-const {
-  Normalizer: { normalizePath, encodePathSegment },
-} = RouteRecognizer;
-
-export function encodePath(path) {
-  return path ? path.split('/').map(encodePathSegment).join('/') : path;
+function encodePath(path) {
+  return path
+    ? path
+        .split('/')
+        .map((segment) => encodeURIComponent(segment))
+        .join('/')
+    : path;
 }
 
-export { normalizePath, encodePathSegment };
+function normalizePath(path) {
+  // Unlike normalizePath from route-recognizer, this method assumes
+  // we do not have percent-encoded data octets as defined in
+  // https://datatracker.ietf.org/doc/html/rfc3986
+  return path
+    ? path
+        .split('/')
+        .map((segment) => decodeURIComponent(segment))
+        .join('/')
+    : '';
+}
+
+export { normalizePath, encodePath };

--- a/ui/lib/core/addon/components/key-value-header.js
+++ b/ui/lib/core/addon/components/key-value-header.js
@@ -83,7 +83,7 @@ export default class KeyValueHeader extends Component {
         label: parts[index],
         text: this.stripTrailingSlash(parts[index]),
         path: path,
-        model: ancestor,
+        model: encodePath(ancestor),
       });
     });
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -190,7 +190,6 @@
     "pvutils": "^1.0.17",
     "qunit": "^2.19.1",
     "qunit-dom": "^2.0.0",
-    "route-recognizer": "^0.3.4",
     "sass-svg-uri": "^1.0.0",
     "shell-quote": "^1.6.1",
     "string.prototype.endswith": "^0.2.0",

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -515,6 +515,37 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
     assert.strictEqual(currentURL(), `/vault/secrets/${enginePath}/show/${encodedSecretPath}?version=1`);
   });
 
+  test('UI handles secret with % in path correctly', async function (assert) {
+    const enginePath = `kv-engine-${this.uid}`;
+    const secretPath = 'per%cent/%fu ll';
+    const [firstPath, secondPath] = secretPath.split('/');
+    const commands = [`write sys/mounts/${enginePath} type=kv`, `write '${enginePath}/${secretPath}' 3=4`];
+    await consoleComponent.runCommands(commands);
+    await listPage.visitRoot({ backend: enginePath });
+    assert.dom(`[data-test-secret-link="${firstPath}/"]`).exists('First section item exists');
+    await click(`[data-test-secret-link="${firstPath}/"]`);
+
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets/${enginePath}/list/${encodeURIComponent(firstPath)}/`,
+      'First part of path is encoded in URL'
+    );
+    assert.dom(`[data-test-secret-link="${secretPath}"]`).exists('Link to secret exists');
+    await click(`[data-test-secret-link="${secretPath}"]`);
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets/${enginePath}/show/${encodeURIComponent(firstPath)}/${encodeURIComponent(secondPath)}`,
+      'secret path is encoded in URL'
+    );
+    assert.dom('h1').hasText(secretPath, 'Path renders correctly on show page');
+    await click(`[data-test-secret-breadcrumb="${firstPath}"]`);
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets/${enginePath}/list/${encodeURIComponent(firstPath)}/`,
+      'Breadcrumb link encodes correctly'
+    );
+  });
+
   // the web cli does not handle a quote as part of a path, so we test it here via the UI
   test('creating a secret with a single or double quote works properly', async function (assert) {
     assert.expect(4);


### PR DESCRIPTION
Fixes #11616 where the UI fails to list or view details for secrets with `%` in the path name. This is because the path encoder and decoder we are using does not encode or decode `%` in the path. We have replaced this library with `encodeUriComponent` and `decodeUriComponent` for each of the path pieces. 

After fix:
<img width="1133" alt="List with %" src="https://user-images.githubusercontent.com/82459713/235228746-3573b2ec-912b-4ba3-975b-f704f7a4c4f8.png">
<img width="1133" alt="Secet show with %" src="https://user-images.githubusercontent.com/82459713/235228757-749e5537-05db-4f30-81f7-ec22a5d99c31.png">

Before:
<img width="1133" alt="Screenshot 2023-04-28 at 1 45 02 PM" src="https://user-images.githubusercontent.com/82459713/235228711-9388a2eb-10c1-46b1-be52-3eb0678542a2.png">
