### PR TITLE
Don't run build workflow on draft PRs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ name: build
 on:
   workflow_dispatch:
   pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
   push:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   # verify-changes determines if the changes are only for docs (website)
   verify-changes:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       is_docs_change: ${{ steps.get-changeddir.outputs.is_docs_change }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ name: build
 on:
   workflow_dispatch:
   pull_request:
-    types: [ opened, synchronize, reopened, ready_for_review ]
   push:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ name: build
 on:
   workflow_dispatch:
   pull_request:
+    # ready_for_review is not included in the default types for pull_request, and since we're skipping
+    # building in draft mode, we want that so that when a draft pr is marked ready, we run everything
+    types: [ opened, synchronize, reopened, ready_for_review ]
   push:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,10 @@ name: build
 on:
   workflow_dispatch:
   pull_request:
-    # ready_for_review is not included in the default types for pull_request, and since we're skipping
-    # building in draft mode, we want that so that when a draft pr is marked ready, we run everything
+    # The default types for pull_request are [ opened, synchronize, reopened ].
+    # This is insufficient for our needs, since we're skipping stuff on PRs in
+    # draft mode.  By adding the ready_for_review type, when a draft pr is marked
+    # ready, we run everything, including the stuff we'd have skipped up until now.
     types: [ opened, synchronize, reopened, ready_for_review ]
   push:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
     - setup-go-cache
     # Don't run this job for PR branches starting with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
     if: |
-      github.event.pull_request.draft != false &&
+      github.event.pull_request.draft == false &&
       !startsWith(github.head_ref, 'ui/') &&
       !startsWith(github.head_ref, 'backport/ui/') &&
       !startsWith(github.head_ref, 'docs/') &&
@@ -162,7 +162,7 @@ jobs:
     name: Run Go tests with FIPS configuration
     # Only run this job for the enterprise repo if the PR branch doesn't start with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
     if: |
-      github.event.pull_request.draft != false &&
+      github.event.pull_request.draft == false &&
       needs.setup.outputs.enterprise == 1 &&
       !startsWith(github.head_ref, 'ui/') &&
       !startsWith(github.head_ref, 'backport/ui/') &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 on:
   pull_request:
+    # ready_for_review is not included in the default types for pull_request, and since we're skipping
+    # some things in draft mode, we want that so that when a draft pr is marked ready, we run everything
+    types: [ opened, synchronize, reopened, ready_for_review ]
   push:
     branches:
       - "main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
     - setup-go-cache
     # Don't run this job for PR branches starting with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
     if: |
+      github.event.pull_request.draft != false &&
       !startsWith(github.head_ref, 'ui/') &&
       !startsWith(github.head_ref, 'backport/ui/') &&
       !startsWith(github.head_ref, 'docs/') &&
@@ -161,6 +162,7 @@ jobs:
     name: Run Go tests with FIPS configuration
     # Only run this job for the enterprise repo if the PR branch doesn't start with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
     if: |
+      github.event.pull_request.draft != false &&
       needs.setup.outputs.enterprise == 1 &&
       !startsWith(github.head_ref, 'ui/') &&
       !startsWith(github.head_ref, 'backport/ui/') &&
@@ -292,4 +294,4 @@ jobs:
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
     - run: |
-        tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)' 
+        tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 on:
   pull_request:
-    # ready_for_review is not included in the default types for pull_request, and since we're skipping
-    # some things in draft mode, we want that so that when a draft pr is marked ready, we run everything
+    # The default types for pull_request are [ opened, synchronize, reopened ].
+    # This is insufficient for our needs, since we're skipping stuff on PRs in
+    # draft mode.  By adding the ready_for_review type, when a draft pr is marked
+    # ready, we run everything, including the stuff we'd have skipped up until now.
     types: [ opened, synchronize, reopened, ready_for_review ]
   push:
     branches:


### PR DESCRIPTION
I validated that after my last push, the build and test-go-race/test-go-fips workflows/jobs were skipped.  Then once I clicked ready for review, new workflows were launched without skipping those.