### PR TITLE
Update ACME order status on order fetch API

### DIFF
--- a/builtin/logical/pki/path_acme_order.go
+++ b/builtin/logical/pki/path_acme_order.go
@@ -512,6 +512,13 @@ func (b *backend) acmeGetOrderHandler(ac *acmeContext, _ *logical.Request, field
 		return nil, err
 	}
 
+	if order.Status == ACMEOrderPending {
+		// Lets see if we can update our order status to ready if all the authorizations have been completed.
+		if requiredAuthorizationsCompleted(b, ac, uc, order) {
+			order.Status = ACMEOrderReady
+		}
+	}
+
 	// Per RFC 8555 -> 7.1.3.  Order Objects
 	// For final orders (in the "valid" or "invalid" state), the authorizations that were completed.
 	//

--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -276,7 +276,7 @@ func doAcmeValidationWithGoLibrary(t *testing.T, directoryUrl string, acmeOrderI
 		func(tosURL string) bool { return true })
 	require.NoError(t, err, "failed registering account")
 
-	// Create an ACME order that
+	// Create an ACME order
 	order, err := acmeClient.AuthorizeOrder(testCtx, acmeOrderIdentifiers)
 	require.NoError(t, err, "failed creating ACME order")
 
@@ -323,6 +323,10 @@ func doAcmeValidationWithGoLibrary(t *testing.T, directoryUrl string, acmeOrderI
 		_, err = acmeClient.Accept(testCtx, challenge)
 		require.NoError(t, err, "failed to accept challenge: %v", challenge)
 	}
+
+	// Wait for the order/challenges to be validated.
+	_, err = acmeClient.WaitOrder(testCtx, order.URI)
+	require.NoError(t, err, "failed waiting for order to be ready")
 
 	// Create/sign the CSR and ask ACME server to sign it returning us the final certificate
 	csrKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)


### PR DESCRIPTION
 - When someone is fetching the order to get it's status, compute if we need to bump the status to Ready like we do in finalize handler
 - Add a wait state to the ACME docker test suite to deal with a race condition, this fixes a failure we saw on the main branch for the Test_ACME.group.acme_ip_sans test.