### PR TITLE
UI: Fix keyup trigger on masked input

### DIFF
--- a/ui/lib/core/addon/components/masked-input.hbs
+++ b/ui/lib/core/addon/components/masked-input.hbs
@@ -20,7 +20,7 @@
       wrap="off"
       spellcheck="false"
       {{on "change" this.onChange}}
-      {{on "keyup" (fn this.handleKeyUp @name @value)}}
+      {{on "keyup" (fn this.handleKeyUp @name)}}
       data-test-textarea
     />
   {{/if}}

--- a/ui/lib/core/addon/components/masked-input.js
+++ b/ui/lib/core/addon/components/masked-input.js
@@ -53,10 +53,11 @@ export default class MaskedInputComponent extends Component {
     }
   }
 
-  @action handleKeyUp(name, value) {
+  @action handleKeyUp(name, evt) {
     this.updateSize();
-    if (this.onKeyUp) {
-      this.onKeyUp(name, value);
+    const { value } = evt.target;
+    if (this.args.onKeyUp) {
+      this.args.onKeyUp(name, value);
     }
   }
   @action toggleMask() {


### PR DESCRIPTION
The PR which glimmerized Masked Input (#20431) missed the keyUp functionality, which mostly triggers validations. This fixes the issue and adds tests 😄 