### PR TITLE
Add walkSecretsTree helper function

### DIFF
--- a/changelog/20464.txt
+++ b/changelog/20464.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-cli: Add listSecretsRecursive helper function, which produces a recursive list of secrets rooted at the given path
+cli: Add walkSecretsTree helper function, which recursively walks secrets rooted at the given path
 ```

--- a/changelog/20464.txt
+++ b/changelog/20464.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-cli: add listRecursive helper
+cli: Add listSecretsRecursive helper function, which produces a recursive list of secrets rooted at the given path
 ```

--- a/changelog/20464.txt
+++ b/changelog/20464.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: add listRecursive helper
+```

--- a/command/kv_helpers.go
+++ b/command/kv_helpers.go
@@ -200,11 +200,11 @@ func padEqualSigns(header string, totalLen int) string {
 	return fmt.Sprintf("%s %s %s", strings.Repeat("=", equalSigns/2), header, strings.Repeat("=", equalSigns/2))
 }
 
-// listRecursive dfs-traverses the secrets tree rooted at the given path and
-// returns a list of the leaf paths. Note: for kv-v2, a "metadata" path is
+// listSecretsRecursive dfs-traverses the secrets tree rooted at the given path
+// and returns a list of the leaf paths. Note: for kv-v2, a "metadata" path is
 // expected and "metadata" paths will be returned. If includeDirectories is
 // specified, the output will include non-leaf nodes with "/" suffixes.
-func listRecursive(ctx context.Context, client *api.Client, path string, includeDirectories bool) ([]string, error) {
+func listSecretsRecursive(ctx context.Context, client *api.Client, path string, includeDirectories bool) ([]string, error) {
 	var descendants []string
 
 	resp, err := client.Logical().ListWithContext(ctx, path)
@@ -250,7 +250,7 @@ func listRecursive(ctx context.Context, client *api.Client, path string, include
 			}
 
 			// this is not a leaf node: we need to go deeper...
-			d, err := listRecursive(ctx, client, child, includeDirectories)
+			d, err := listSecretsRecursive(ctx, client, child, includeDirectories)
 			if err != nil {
 				return nil, err
 			}

--- a/command/kv_test.go
+++ b/command/kv_test.go
@@ -1524,6 +1524,7 @@ func TestPadEqualSigns(t *testing.T) {
 	}
 }
 
+// TestListRecursive tests the listRecursive helper function
 func TestListRecursive(t *testing.T) {
 	// test setup
 	client, closer := testVaultServer(t)

--- a/command/kv_test.go
+++ b/command/kv_test.go
@@ -1524,8 +1524,8 @@ func TestPadEqualSigns(t *testing.T) {
 	}
 }
 
-// TestListRecursive tests the listRecursive helper function
-func TestListRecursive(t *testing.T) {
+// TestListSecretsRecursive tests the listSecretsRecursive helper function
+func TestListSecretsRecursive(t *testing.T) {
 	// test setup
 	client, closer := testVaultServer(t)
 	defer closer()
@@ -1710,7 +1710,7 @@ func TestListRecursive(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := listRecursive(ctx, client, tc.path, tc.includeDirectories)
+			actual, err := listSecretsRecursive(ctx, client, tc.path, tc.includeDirectories)
 
 			if tc.expectedError {
 				if err == nil {

--- a/command/kv_test.go
+++ b/command/kv_test.go
@@ -1571,26 +1571,30 @@ func TestListRecursive(t *testing.T) {
 	}
 
 	cases := []struct {
-		name          string
-		path          string
-		expected      []string
-		expectedError bool
+		name               string
+		path               string
+		includeDirectories bool
+		expected           []string
+		expectedError      bool
 	}{
 		{
-			name:          "kv-v1-simple",
-			path:          "kv-v1/app-1/nested/x/y",
-			expected:      []string{"kv-v1/app-1/nested/x/y/z"},
-			expectedError: false,
+			name:               "kv-v1-simple",
+			path:               "kv-v1/app-1/nested/x/y",
+			includeDirectories: false,
+			expected:           []string{"kv-v1/app-1/nested/x/y/z"},
+			expectedError:      false,
 		},
 		{
-			name:          "kv-v2-simple",
-			path:          "kv-v2/metadata/app-1/nested/x/y",
-			expected:      []string{"kv-v2/metadata/app-1/nested/x/y/z"},
-			expectedError: false,
+			name:               "kv-v2-simple",
+			path:               "kv-v2/metadata/app-1/nested/x/y",
+			includeDirectories: false,
+			expected:           []string{"kv-v2/metadata/app-1/nested/x/y/z"},
+			expectedError:      false,
 		},
 		{
-			name: "kv-v1-nested",
-			path: "kv-v1/app-1/nested/",
+			name:               "kv-v1-nested",
+			path:               "kv-v1/app-1/nested/",
+			includeDirectories: false,
 			expected: []string{
 				"kv-v1/app-1/nested/bar",
 				"kv-v1/app-1/nested/x/y",
@@ -1599,8 +1603,9 @@ func TestListRecursive(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "kv-v2-nested",
-			path: "kv-v2/metadata/app-1/nested/",
+			name:               "kv-v2-nested",
+			path:               "kv-v2/metadata/app-1/nested/",
+			includeDirectories: false,
 			expected: []string{
 				"kv-v2/metadata/app-1/nested/bar",
 				"kv-v2/metadata/app-1/nested/x/y",
@@ -1609,8 +1614,9 @@ func TestListRecursive(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "kv-v1-all",
-			path: "kv-v1",
+			name:               "kv-v1-all",
+			path:               "kv-v1",
+			includeDirectories: false,
 			expected: []string{
 				"kv-v1/app-1/bar",
 				"kv-v1/app-1/foo",
@@ -1622,8 +1628,9 @@ func TestListRecursive(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "kv-v2-all",
-			path: "kv-v2/metadata",
+			name:               "kv-v2-all",
+			path:               "kv-v2/metadata",
+			includeDirectories: false,
 			expected: []string{
 				"kv-v2/metadata/app-1/bar",
 				"kv-v2/metadata/app-1/foo",
@@ -1635,34 +1642,74 @@ func TestListRecursive(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name:          "kv-v1-not-found",
-			path:          "kv-v1/does/not/exist",
-			expected:      nil,
-			expectedError: true,
+			name:               "kv-v1-all-include-directories",
+			path:               "kv-v1",
+			includeDirectories: true,
+			expected: []string{
+				"kv-v1/app-1/",
+				"kv-v1/app-1/bar",
+				"kv-v1/app-1/foo",
+				"kv-v1/app-1/nested/",
+				"kv-v1/app-1/nested/bar",
+				"kv-v1/app-1/nested/x/",
+				"kv-v1/app-1/nested/x/y",
+				"kv-v1/app-1/nested/x/y/",
+				"kv-v1/app-1/nested/x/y/z",
+				"kv-v1/foo",
+			},
+			expectedError: false,
 		},
 		{
-			name:          "kv-v2-not-found",
-			path:          "kv-v2/metadata/does/not/exist",
-			expected:      nil,
-			expectedError: true,
+			name:               "kv-v2-all-include-directories",
+			path:               "kv-v2/metadata",
+			includeDirectories: true,
+			expected: []string{
+				"kv-v2/metadata/app-1/",
+				"kv-v2/metadata/app-1/bar",
+				"kv-v2/metadata/app-1/foo",
+				"kv-v2/metadata/app-1/nested/",
+				"kv-v2/metadata/app-1/nested/bar",
+				"kv-v2/metadata/app-1/nested/x/",
+				"kv-v2/metadata/app-1/nested/x/y",
+				"kv-v2/metadata/app-1/nested/x/y/",
+				"kv-v2/metadata/app-1/nested/x/y/z",
+				"kv-v2/metadata/foo",
+			},
+			expectedError: false,
 		},
 		{
-			name:          "kv-v1-not-listable-leaf-node",
-			path:          "kv-v1/foo",
-			expected:      nil,
-			expectedError: true,
+			name:               "kv-v1-not-found",
+			path:               "kv-v1/does/not/exist",
+			includeDirectories: false,
+			expected:           nil,
+			expectedError:      true,
 		},
 		{
-			name:          "kv-v2-not-listable-leaf-node",
-			path:          "kv-v2/metadata/foo",
-			expected:      nil,
-			expectedError: true,
+			name:               "kv-v2-not-found",
+			path:               "kv-v2/metadata/does/not/exist",
+			includeDirectories: false,
+			expected:           nil,
+			expectedError:      true,
+		},
+		{
+			name:               "kv-v1-not-listable-leaf-node",
+			path:               "kv-v1/foo",
+			includeDirectories: false,
+			expected:           nil,
+			expectedError:      true,
+		},
+		{
+			name:               "kv-v2-not-listable-leaf-node",
+			path:               "kv-v2/metadata/foo",
+			includeDirectories: false,
+			expected:           nil,
+			expectedError:      true,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := listRecursive(ctx, client, tc.path)
+			actual, err := listRecursive(ctx, client, tc.path, tc.includeDirectories)
 
 			if tc.expectedError {
 				if err == nil {


### PR DESCRIPTION
The `walkSecretsTree` helper function will be used by `vault agent generate-config` to produce a recursive list of secrets rooted at the given path. The output of `walkSecretsTree` is DFS sorted by keys at each level.