### PR TITLE
Fix the title header - What is Vault

### DIFF
--- a/website/content/docs/what-is-vault.mdx
+++ b/website/content/docs/what-is-vault.mdx
@@ -7,7 +7,7 @@ description: >-
   compares to existing software, and contains a quick start for using Vault.
 ---
 
-## What is Vault?
+# What is Vault?
 
 HashiCorp Vault is an identity-based secrets and encryption management system. A _secret_ is anything that you want to tightly control access to, such as API encryption keys, passwords, and certificates. Vault provides encryption services that are gated by authentication and authorization methods. Using Vault’s UI, CLI, or HTTP API, access to secrets and other sensitive data can be securely stored and managed, tightly controlled (restricted), and auditable.
 


### PR DESCRIPTION
It was reported that the "What is Vault?" page header is not parsing correctly. This PR fixes the page title.

![image](https://user-images.githubusercontent.com/7660718/235732889-e0fab653-8590-4cfa-88b8-0195218f80e3.png)


🔍 [Deploy preview](https://vault-git-docs-fix-docs-title-hashicorp.vercel.app/vault/docs/what-is-vault)


