### PR TITLE
Capture loop var in TestClientDisabledRedirects

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -225,6 +225,7 @@ func TestClientDisableRedirects(t *testing.T) {
 
 	for name, tc := range tests {
 		test := tc
+		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			numReqs := 0


### PR DESCRIPTION
Without this change, test failures only report the last value of `name`:
```
 /Users/mpalmi/scm/vault-enterprise/api/client_test.go:258: Disabled redirects: Moved permanently: expected 3 request(s) but got 1
    /Users/mpalmi/scm/vault-enterprise/api/client_test.go:258: Disabled redirects: Moved permanently: expected 5 request(s) but got 1
    /Users/mpalmi/scm/vault-enterprise/api/client_test.go:258: Disabled redirects: Moved permanently: expected 4 request(s) but got 1
    /Users/mpalmi/scm/vault-enterprise/api/client_test.go:258: Disabled redirects: Moved permanently: expected 6 request(s) but got 2
```

Capturing the loop var results in the following output:
```
  /Users/mpalmi/scm/vault-enterprise/api/client_test.go:258: Disabled redirects: Temporary Redirect: expected 5 request(s) but got 1
    /Users/mpalmi/scm/vault-enterprise/api/client_test.go:258: Disabled redirects: Found: expected 4 request(s) but got 1
    /Users/mpalmi/scm/vault-enterprise/api/client_test.go:258: Disabled redirects: Moved permanently: expected 3 request(s) but got 1
    /Users/mpalmi/scm/vault-enterprise/api/client_test.go:258: Enable redirects: Moved permanently: expected 6 request(s) but got 2
  ``` 