### PR TITLE
CLI to take days as a unit of time

### DIFF
--- a/command/base_flags.go
+++ b/command/base_flags.go
@@ -594,7 +594,7 @@ type DurationVar struct {
 func (f *FlagSet) DurationVar(i *DurationVar) {
 	initial := i.Default
 	if v, exist := os.LookupEnv(i.EnvVar); exist {
-		if d, err := time.ParseDuration(appendDurationSuffix(v)); err == nil {
+		if d, err := parseutil.ParseDurationSecond(v); err == nil {
 			initial = d
 		}
 	}
@@ -634,7 +634,7 @@ func (d *durationValue) Set(s string) error {
 		s = "-1"
 	}
 
-	v, err := time.ParseDuration(appendDurationSuffix(s))
+	v, err := parseutil.ParseDurationSecond(s)
 	if err != nil {
 		return err
 	}

--- a/command/token_create_test.go
+++ b/command/token_create_test.go
@@ -71,6 +71,12 @@ func TestTokenCreateCommand_Run(t *testing.T) {
 			"not present in secret",
 			1,
 		},
+		{
+			"ttl",
+			[]string{"-ttl", "1d", "-explicit-max-ttl", "2d"},
+			"token",
+			0,
+		},
 	}
 
 	t.Run("validations", func(t *testing.T) {


### PR DESCRIPTION
For an example: `vault token create -policy=mypolicy -ttl=1d`
fails with error:
`invalid value "1d" for flag -ttl: time: unknown unit "ds" in duration "1ds"`

Currently, the CLI uses `time.ParseDuration(appendDurationSuffix(s))` instead of `parseutil.ParseDurationSecond(s)`. The fix is to use the latter instead.