### PR TITLE
Add dns resolver to PKI Binary Cluster

### DIFF
--- a/builtin/logical/pki/path_config_acme.go
+++ b/builtin/logical/pki/path_config_acme.go
@@ -188,10 +188,10 @@ func (b *backend) pathAcmeWrite(ctx context.Context, req *logical.Request, d *fr
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse DNS resolver address: %w", err)
 			}
-			if addr != "" {
+			if addr == "" {
 				return nil, fmt.Errorf("failed to parse DNS resolver address: got empty address")
 			}
-			if net.ParseIP(addr) != nil {
+			if net.ParseIP(addr) == nil {
 				return nil, fmt.Errorf("failed to parse DNS resolver address: expected IPv4/IPv6 address, likely got hostname")
 			}
 		}

--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -30,7 +30,7 @@ import (
 // a bunch of sub-tests against that cluster. It is up to each sub-test to run/configure
 // a new pki mount within the cluster to not interfere with each other.
 func Test_ACME(t *testing.T) {
-	cluster := NewVaultPkiCluster(t)
+	cluster := NewVaultPkiClusterWithDNS(t)
 	defer cluster.Cleanup()
 
 	tc := map[string]func(t *testing.T, cluster *VaultPkiCluster){
@@ -91,7 +91,7 @@ func SubtestACMECertbot(t *testing.T, cluster *VaultPkiCluster) {
 	ipAddr := networks[vaultNetwork]
 	hostname := "acme-client.dadgarcorp.com"
 
-	err = pki.AddNameToHostsFile(ipAddr, hostname, logConsumer, logStdout, logStderr)
+	err = pki.AddHostname(hostname, ipAddr)
 	require.NoError(t, err, "failed to update vault host files")
 
 	certbotCmd := []string{
@@ -197,7 +197,7 @@ func SubTestACMEIPAndDNS(t *testing.T, cluster *VaultPkiCluster) {
 	ipAddr := networks[pki.GetContainerNetworkName()]
 	hostname := "go-lang-acme-client.dadgarcorp.com"
 
-	err = pki.AddNameToHostsFile(ipAddr, hostname, logConsumer, logStdout, logStderr)
+	err = pki.AddHostname(hostname, ipAddr)
 	require.NoError(t, err, "failed to update vault host files")
 
 	// Perform an ACME lifecycle with an order that contains both an IP and a DNS name identifier

--- a/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
+++ b/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
@@ -115,8 +115,17 @@ func (vpc *VaultPkiCluster) AddDNSRecord(hostname, recordType, ip string) error 
 		return fmt.Errorf("no DNS server was provisioned on this cluster group; unable to provision custom records")
 	}
 
-	vpc.Dns.AddRecord(hostname, "A", ip)
+	vpc.Dns.AddRecord(hostname, recordType, ip)
 	vpc.Dns.PushConfig()
+	return nil
+}
+
+func (vpc *VaultPkiCluster) RemoveAllDNSRecords() error {
+	if vpc.Dns == nil {
+		return fmt.Errorf("no DNS server was provisioned on this cluster group; unable to remove all records")
+	}
+
+	vpc.Dns.RemoveAllRecords()
 	return nil
 }
 

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -67,7 +67,7 @@ type DockerCluster struct {
 	// rootToken is the initial root token created when the Vault cluster is
 	// created.
 	rootToken string
-	dockerAPI *docker.Client
+	DockerAPI *docker.Client
 	ID        string
 	Logger    log.Logger
 	builtTags map[string]struct{}
@@ -434,7 +434,7 @@ func NewDockerCluster(ctx context.Context, opts *DockerClusterOptions) (*DockerC
 	}
 
 	dc := &DockerCluster{
-		dockerAPI:   api,
+		DockerAPI:   api,
 		RaftStorage: true,
 		ClusterName: opts.ClusterName,
 		Logger:      opts.Logger,
@@ -466,7 +466,7 @@ type DockerClusterNode struct {
 	WorkDir              string
 	Cluster              *DockerCluster
 	Container            *types.ContainerJSON
-	dockerAPI            *docker.Client
+	DockerAPI            *docker.Client
 	runner               *dockhelper.Runner
 	Logger               log.Logger
 	cleanupContainer     func()
@@ -563,13 +563,13 @@ func (n *DockerClusterNode) cleanup() error {
 
 func (n *DockerClusterNode) Start(ctx context.Context, opts *DockerClusterOptions) error {
 	if n.DataVolumeName == "" {
-		vol, err := n.dockerAPI.VolumeCreate(ctx, volume.CreateOptions{})
+		vol, err := n.DockerAPI.VolumeCreate(ctx, volume.CreateOptions{})
 		if err != nil {
 			return err
 		}
 		n.DataVolumeName = vol.Name
 		n.cleanupVolume = func() {
-			_ = n.dockerAPI.VolumeRemove(ctx, vol.Name, false)
+			_ = n.DockerAPI.VolumeRemove(ctx, vol.Name, false)
 		}
 	}
 	vaultCfg := map[string]interface{}{}
@@ -899,7 +899,7 @@ func (dc *DockerCluster) addNode(ctx context.Context, opts *DockerClusterOptions
 	i := len(dc.ClusterNodes)
 	nodeID := fmt.Sprintf("core-%d", i)
 	node := &DockerClusterNode{
-		dockerAPI: dc.dockerAPI,
+		DockerAPI: dc.DockerAPI,
 		NodeID:    nodeID,
 		Cluster:   dc,
 		WorkDir:   filepath.Join(dc.tmpDir, nodeID),
@@ -987,7 +987,7 @@ FROM %s:%s
 COPY vault /bin/vault
 `, opts.ImageRepo, sourceTag)
 
-	_, err = dockhelper.BuildImage(ctx, dc.dockerAPI, containerFile, bCtx,
+	_, err = dockhelper.BuildImage(ctx, dc.DockerAPI, containerFile, bCtx,
 		dockhelper.BuildRemove(true), dockhelper.BuildForceRemove(true),
 		dockhelper.BuildPullParent(true),
 		dockhelper.BuildTags([]string{opts.ImageRepo + ":" + tag}))


### PR DESCRIPTION
This refactors the test execution environments a little to make executing commands a little easier. It turns out that the issue with loading the DNS server onto the network was fixed by setting `forceLocalAddr`; this does not impact the ability to get a real IP address later (cc @ncabatoff).

I've added another conditional into the DNS server though, so that when no network is specified (i.e., this is the first loaded server), we can get the network address in case we add another container to the same network.

With this, we can then load the DNS resolver helper alongside the Vault cluster, giving us the ability to solve DNS challenges and more cleanly set dependent container's IP addresses (instead of via `/etc/hosts` poking).

Also fixes a bug in the DNS configuration validation code.