### PR TITLE
UI: update setting version service for sidebar frame test

### DIFF
--- a/ui/tests/integration/components/sidebar/frame-test.js
+++ b/ui/tests/integration/components/sidebar/frame-test.js
@@ -22,7 +22,7 @@ module('Integration | Component | sidebar-frame', function (hooks) {
     const currentCluster = this.owner.lookup('service:currentCluster');
     currentCluster.setCluster({ hcpLinkStatus: 'connected' });
     const version = this.owner.lookup('service:version');
-    version.setVersion({ version: '1.13.0-dev1+ent' });
+    version.version = '1.13.0-dev1+ent';
 
     await render(hbs`
       <Sidebar::Frame @showSidebar={{true}}>

--- a/ui/tests/integration/components/sidebar/frame-test.js
+++ b/ui/tests/integration/components/sidebar/frame-test.js
@@ -55,7 +55,7 @@ module('Integration | Component | sidebar-frame', function (hooks) {
 
   test('it should render namespace picker in sidebar footer', async function (assert) {
     const version = this.owner.lookup('service:version');
-    version.setFeatures({ features: ['Namespaces'] });
+    version.features = ['Namespaces'];
     const auth = this.owner.lookup('service:auth');
     sinon.stub(auth, 'authData').value({});
 

--- a/ui/tests/unit/services/version-test.js
+++ b/ui/tests/unit/services/version-test.js
@@ -11,36 +11,36 @@ module('Unit | Service | version', function (hooks) {
 
   test('setting version computes isOSS properly', function (assert) {
     const service = this.owner.lookup('service:version');
-    service.set('version', '0.9.5');
-    assert.true(service.get('isOSS'));
-    assert.false(service.get('isEnterprise'));
+    service.version = '0.9.5';
+    assert.true(service.isOSS);
+    assert.false(service.isEnterprise);
   });
 
   test('setting version computes isEnterprise properly', function (assert) {
     const service = this.owner.lookup('service:version');
-    service.set('version', '0.9.5+ent');
-    assert.false(service.get('isOSS'));
-    assert.true(service.get('isEnterprise'));
+    service.version = '0.9.5+ent';
+    assert.false(service.isOSS);
+    assert.true(service.isEnterprise);
   });
 
   test('setting version with hsm ending computes isEnterprise properly', function (assert) {
     const service = this.owner.lookup('service:version');
-    service.set('version', '0.9.5+ent.hsm');
-    assert.false(service.get('isOSS'));
-    assert.true(service.get('isEnterprise'));
+    service.version = '0.9.5+ent.hsm';
+    assert.false(service.isOSS);
+    assert.true(service.isEnterprise);
   });
 
   test('hasPerfReplication', function (assert) {
     const service = this.owner.lookup('service:version');
-    assert.false(service.get('hasPerfReplication'));
-    service.set('features', ['Performance Replication']);
-    assert.true(service.get('hasPerfReplication'));
+    assert.false(service.hasPerfReplication);
+    service.features = ['Performance Replication'];
+    assert.true(service.hasPerfReplication);
   });
 
   test('hasDRReplication', function (assert) {
     const service = this.owner.lookup('service:version');
-    assert.false(service.get('hasDRReplication'));
-    service.set('features', ['DR Replication']);
-    assert.true(service.get('hasDRReplication'));
+    assert.false(service.hasDRReplication);
+    service.features = ['DR Replication'];
+    assert.true(service.hasDRReplication);
   });
 });


### PR DESCRIPTION
This fixes some sidebar component test failures caused by updates to the version service from https://github.com/hashicorp/vault/pull/20479 