### PR TITLE
disable printing flags warning message for the ssh command

### DIFF
--- a/changelog/20502.txt
+++ b/changelog/20502.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: disable printing flags warnings messages for the ssh command
+```

--- a/command/base.go
+++ b/command/base.go
@@ -588,6 +588,7 @@ func (f *FlagSets) Completions() complete.Flags {
 type (
 	ParseOptions              interface{}
 	ParseOptionAllowRawFormat bool
+	DisableDisplayFlagWarning bool
 )
 
 // Parse parses the given flags, returning any errors.
@@ -595,9 +596,17 @@ type (
 func (f *FlagSets) Parse(args []string, opts ...ParseOptions) error {
 	err := f.mainSet.Parse(args)
 
-	warnings := generateFlagWarnings(f.Args())
-	if warnings != "" && Format(f.ui) == "table" {
-		f.ui.Warn(warnings)
+	displayFlagWarningsDisabled := false
+	for _, opt := range opts {
+		if value, ok := opt.(DisableDisplayFlagWarning); ok {
+			displayFlagWarningsDisabled = bool(value)
+		}
+	}
+	if !displayFlagWarningsDisabled {
+		warnings := generateFlagWarnings(f.Args())
+		if warnings != "" && Format(f.ui) == "table" {
+			f.ui.Warn(warnings)
+		}
 	}
 
 	if err != nil {

--- a/command/ssh.go
+++ b/command/ssh.go
@@ -241,7 +241,7 @@ type SSHCredentialResp struct {
 func (c *SSHCommand) Run(args []string) int {
 	f := c.Flags()
 
-	if err := f.Parse(args); err != nil {
+	if err := f.Parse(args, DisableDisplayFlagWarning(true)); err != nil {
 		c.UI.Error(err.Error())
 		return 1
 	}

--- a/command/ssh_test.go
+++ b/command/ssh_test.go
@@ -219,6 +219,8 @@ func TestIsSingleSSHArg(t *testing.T) {
 	}
 }
 
+// TestSSHCommandOmitFlagWarning checks if flags warning messages are printed
+// in the output of the CLI command or not. If so, it will fail.
 func TestSSHCommandOmitFlagWarning(t *testing.T) {
 	t.Parallel()
 

--- a/command/ssh_test.go
+++ b/command/ssh_test.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/mitchellh/cli"
@@ -215,5 +216,21 @@ func TestIsSingleSSHArg(t *testing.T) {
 				t.Errorf("arg %q got %v want %v", test.arg, got, test.want)
 			}
 		})
+	}
+}
+
+func TestSSHCommandOmitFlagWarning(t *testing.T) {
+	t.Parallel()
+
+	ui, cmd := testSSHCommand(t)
+
+	code := cmd.Run([]string{"-mode", "ca", "-role", "otp_key_role", "user@1.2.3.4", "-extraFlag", "bug"})
+	if code != 2 {
+		t.Fatalf("expected %d to be %d", code, 2)
+	}
+
+	combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+	if strings.Contains(combined, "Command flags must be provided before positional arguments. The following arguments will not be parsed as flags") {
+		t.Fatalf("ssh command displayed flag warnings")
 	}
 }

--- a/command/ssh_test.go
+++ b/command/ssh_test.go
@@ -226,10 +226,7 @@ func TestSSHCommandOmitFlagWarning(t *testing.T) {
 
 	ui, cmd := testSSHCommand(t)
 
-	code := cmd.Run([]string{"-mode", "ca", "-role", "otp_key_role", "user@1.2.3.4", "-extraFlag", "bug"})
-	if code != 2 {
-		t.Fatalf("expected %d to be %d", code, 2)
-	}
+	_ = cmd.Run([]string{"-mode", "ca", "-role", "otp_key_role", "user@1.2.3.4", "-extraFlag", "bug"})
 
 	combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
 	if strings.Contains(combined, "Command flags must be provided before positional arguments. The following arguments will not be parsed as flags") {


### PR DESCRIPTION
Addresses https://github.com/hashicorp/vault/issues/19785

Echoing what @maxb has mentioned in the ticket:
```
The vault ssh command has the unusual purpose of being a wrapper that invokes the real ssh command (after obtaining credentials). 
Moreover, the ssh command can take another command on its command line, to run on the remote machine. 
Because of this, there are multiple ways in which it can be a normal use-case for there to be option-like arguments later in the command line, 
which are deliberately intended either for ssh, or for a command being run via ssh on the remote machine.

This is quite unlike most other commands, where option-like things occurring after positional arguments are often a mistake.
```