### PR TITLE
Allow ensuring ticker is stopped multiple times

### DIFF
--- a/vault/rollback.go
+++ b/vault/rollback.go
@@ -43,12 +43,13 @@ type RollbackManager struct {
 	inflight     map[string]*rollbackState
 	inflightLock sync.RWMutex
 
-	doneCh       chan struct{}
-	shutdown     bool
-	shutdownCh   chan struct{}
-	shutdownLock sync.Mutex
-	stopTicker   chan struct{}
-	quitContext  context.Context
+	doneCh          chan struct{}
+	shutdown        bool
+	shutdownCh      chan struct{}
+	shutdownLock    sync.Mutex
+	stopTicker      chan struct{}
+	tickerIsStopped bool
+	quitContext     context.Context
 
 	core *Core
 }
@@ -103,7 +104,10 @@ func (m *RollbackManager) Stop() {
 //
 // THIS SHOULD ONLY BE CALLED FROM TEST HELPERS.
 func (m *RollbackManager) StopTicker() {
-	close(m.stopTicker)
+	if !m.tickerIsStopped {
+		close(m.stopTicker)
+		m.tickerIsStopped = true
+	}
 }
 
 // run is a long running routine to periodically invoke rollback


### PR DESCRIPTION
When executing multi-stage, multi-namespace tests, stopping the ticker multiple times (via closing the StopTicker channel) results in a panic.

Store whether or not we've stopped it once, and do not close it again.