### PR TITLE
Keep symbols by default

### DIFF
--- a/changelog/20519.txt
+++ b/changelog/20519.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Add debug symbols back to builds to fix Dynatrace support
+```

--- a/scripts/ci-helper.sh
+++ b/scripts/ci-helper.sh
@@ -154,17 +154,16 @@ function build() {
   prerelease=$(version_pre)
   build_date=$(build_date)
   : "${GO_TAGS:=""}"
-  : "${KEEP_SYMBOLS:=""}"
+  : "${REMOVE_SYMBOLS:=""}"
 
   # Build our ldflags
   msg="--> Building Vault v$version, revision $revision, built $build_date"
 
   # Keep the symbol and dwarf information by default
-  # TODO: maybe add REMOVE_SYMBOLS?
-  if [ -n "$KEEP_SYMBOLS" ]; then
+  if [ -n "$REMOVE_SYMBOLS" ]; then
     ldflags="-s -w "
   else
-    ldflags="-s -w "
+    ldflags=""
   fi
 
   ldflags="${ldflags}-X github.com/hashicorp/vault/version.Version=$version -X github.com/hashicorp/vault/version.GitCommit=$revision -X github.com/hashicorp/vault/version.BuildDate=$build_date"


### PR DESCRIPTION
By reversing the logic and adding a `REMOVE_SYMBOLS` environment variable that, when set, will remove symbols.

This has been requested to re-enable Dynatrace support, which requires symbols are intact.

Sadly this increases the size (on my mac) from 192,609,682 bytes to 236,696,722 bytes (+23% increase).

I confirmed that this adds symbols back, and that `dlv` will load the Vault binary.