### PR TITLE
Start counting ACME certificate issuance as client activity

### DIFF
--- a/builtin/logical/pki/acme_billing_hack.go
+++ b/builtin/logical/pki/acme_billing_hack.go
@@ -1,0 +1,25 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package pki
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func (b *backend) doTrackBilling(ctx context.Context, identifiers []*ACMEIdentifier) error {
+	billingView, ok := b.System().(logical.ACMEBillingSystemView)
+	if !ok {
+		return fmt.Errorf("failed to perform cast to ACME billing system view interface")
+	}
+
+	var realized []string
+	for _, identifier := range identifiers {
+		realized = append(realized, fmt.Sprintf("%s/%s", identifier.Type, identifier.OriginalValue))
+	}
+
+	return billingView.CreateActivityCountEventForIdentifiers(ctx, realized)
+}

--- a/builtin/logical/pki/acme_billing_test.go
+++ b/builtin/logical/pki/acme_billing_test.go
@@ -1,0 +1,198 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package pki
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/acme"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/builtin/logical/pki/dnstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAcmeBasicWorkflow a basic test that will validate a basic ACME workflow using the Golang ACME client.
+func TestACMEBilling(t *testing.T) {
+	t.Parallel()
+	cluster, client, _ := setupAcmeBackend(t)
+	defer cluster.Cleanup()
+
+	dns := dnstest.SetupResolver(t, "dadgarcorp.com")
+	defer dns.Cleanup()
+
+	// Enable additional mounts.
+	setupAcmeBackendOnClusterAtPath(t, cluster, client, "pki2")
+	setupAcmeBackendOnClusterAtPath(t, cluster, client, "ns1/pki")
+	setupAcmeBackendOnClusterAtPath(t, cluster, client, "ns2/pki")
+
+	// Enable custom DNS resolver for testing.
+	for _, mount := range []string{"pki", "pki2", "ns1/pki", "ns2/pki"} {
+		_, err := client.Logical().Write(mount+"/config/acme", map[string]interface{}{
+			"dns_resolver": dns.GetLocalAddr(),
+		})
+		require.NoError(t, err, "failed to set local dns resolver address for testing on mount: "+mount)
+	}
+
+	// Enable client counting.
+	_, err := client.Logical().Write("/sys/internal/counters/config", map[string]interface{}{
+		"enabled": "enable",
+	})
+	require.NoError(t, err, "failed to enable client counting")
+
+	// Setup ACME clients. We refresh account keys each time for consistency.
+	acmeClientPKI := getAcmeClientForCluster(t, cluster, "/v1/pki/acme/", nil)
+	acmeClientPKI2 := getAcmeClientForCluster(t, cluster, "/v1/pki2/acme/", nil)
+	acmeClientPKINS1 := getAcmeClientForCluster(t, cluster, "/v1/ns1/pki/acme/", nil)
+	acmeClientPKINS2 := getAcmeClientForCluster(t, cluster, "/v1/ns2/pki/acme/", nil)
+
+	// Get our initial count.
+	expectedCount := validateClientCount(t, client, -1, "initial fetch")
+
+	// Unique identifier: should increase by one.
+	doACMEForDomainWithDNS(t, dns, &acmeClientPKI, []string{"dadgarcorp.com"})
+	expectedCount = validateClientCount(t, client, expectedCount+1, "new certificate")
+
+	// Different identifier; should increase by one.
+	doACMEForDomainWithDNS(t, dns, &acmeClientPKI, []string{"example.dadgarcorp.com"})
+	expectedCount = validateClientCount(t, client, expectedCount+1, "new certificate")
+
+	// While same identifiers, used together and so thus are unique; increase by one.
+	doACMEForDomainWithDNS(t, dns, &acmeClientPKI, []string{"example.dadgarcorp.com", "dadgarcorp.com"})
+	expectedCount = validateClientCount(t, client, expectedCount+1, "new certificate")
+
+	// Same identifiers in different order are not unique; keep the same.
+	doACMEForDomainWithDNS(t, dns, &acmeClientPKI, []string{"dadgarcorp.com", "example.dadgarcorp.com"})
+	expectedCount = validateClientCount(t, client, expectedCount, "new certificate")
+
+	// Using a different mount shouldn't affect counts.
+	doACMEForDomainWithDNS(t, dns, &acmeClientPKI2, []string{"dadgarcorp.com"})
+	expectedCount = validateClientCount(t, client, expectedCount, "different mount; same identifiers")
+
+	// But using a different identifier should.
+	doACMEForDomainWithDNS(t, dns, &acmeClientPKI2, []string{"pki2.dadgarcorp.com"})
+	expectedCount = validateClientCount(t, client, expectedCount+1, "different mount with different identifiers")
+
+	// A new identifier in a unique namespace will affect results.
+	doACMEForDomainWithDNS(t, dns, &acmeClientPKINS1, []string{"unique.dadgarcorp.com"})
+	expectedCount = validateClientCount(t, client, expectedCount+1, "unique identifier in a namespace")
+
+	// But in a different namespace with the existing identifier will not.
+	doACMEForDomainWithDNS(t, dns, &acmeClientPKINS2, []string{"unique.dadgarcorp.com"})
+	expectedCount = validateClientCount(t, client, expectedCount, "existing identifier in a namespace")
+	doACMEForDomainWithDNS(t, dns, &acmeClientPKI2, []string{"unique.dadgarcorp.com"})
+	expectedCount = validateClientCount(t, client, expectedCount, "existing identifier outside of a namespace")
+}
+
+func validateClientCount(t *testing.T, client *api.Client, expected int64, message string) int64 {
+	resp, err := client.Logical().Read("/sys/internal/counters/activity/monthly")
+	require.NoError(t, err, "failed to fetch client count values")
+	t.Logf("got client count numbers: %v", resp)
+
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+	require.Contains(t, resp.Data, "non_entity_clients")
+
+	rawCount := resp.Data["non_entity_clients"].(json.Number)
+	count, err := rawCount.Int64()
+	require.NoError(t, err, "failed to parse number as int64: "+rawCount.String())
+
+	if expected != -1 {
+		require.Equal(t, expected, count, "value of client counts did not match expectations: "+message)
+	}
+
+	return count
+}
+
+func doACMEForDomainWithDNS(t *testing.T, dns *dnstest.TestServer, acmeClient *acme.Client, domains []string) *x509.Certificate {
+	cr := &x509.CertificateRequest{
+		Subject:  pkix.Name{CommonName: domains[0]},
+		DNSNames: domains,
+	}
+
+	accountKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err, "failed to generate account key")
+	acmeClient.Key = accountKey
+
+	testCtx, cancelFunc := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancelFunc()
+
+	// Register the client.
+	_, err = acmeClient.Register(testCtx, &acme.Account{Contact: []string{"mailto:ipsans@dadgarcorp.com"}}, func(tosURL string) bool { return true })
+	require.NoError(t, err, "failed registering account")
+
+	// Create the Order
+	var orderIdentifiers []acme.AuthzID
+	for _, domain := range domains {
+		orderIdentifiers = append(orderIdentifiers, acme.AuthzID{Type: "dns", Value: domain})
+	}
+	order, err := acmeClient.AuthorizeOrder(testCtx, orderIdentifiers)
+	require.NoError(t, err, "failed creating ACME order")
+
+	// Fetch its authorizations.
+	var auths []*acme.Authorization
+	for _, authUrl := range order.AuthzURLs {
+		authorization, err := acmeClient.GetAuthorization(testCtx, authUrl)
+		require.NoError(t, err, "failed to lookup authorization at url: %s", authUrl)
+		auths = append(auths, authorization)
+	}
+
+	// For each dns-01 challenge, place the record in the associated DNS resolver.
+	var challengesToAccept []*acme.Challenge
+	for _, auth := range auths {
+		for _, challenge := range auth.Challenges {
+			if challenge.Status != acme.StatusPending {
+				t.Logf("ignoring challenge not in status pending: %v", challenge)
+				continue
+			}
+
+			if challenge.Type == "dns-01" {
+				challengeBody, err := acmeClient.DNS01ChallengeRecord(challenge.Token)
+				require.NoError(t, err, "failed generating challenge response")
+
+				dns.AddRecord("_acme-challenge."+auth.Identifier.Value, "TXT", challengeBody)
+				defer dns.RemoveRecord("_acme-challenge."+auth.Identifier.Value, "TXT", challengeBody)
+
+				require.NoError(t, err, "failed setting DNS record")
+
+				challengesToAccept = append(challengesToAccept, challenge)
+			}
+		}
+	}
+
+	dns.PushConfig()
+	require.GreaterOrEqual(t, len(challengesToAccept), 1, "Need at least one challenge, got none")
+
+	// Tell the ACME server, that they can now validate those challenges.
+	for _, challenge := range challengesToAccept {
+		_, err = acmeClient.Accept(testCtx, challenge)
+		require.NoError(t, err, "failed to accept challenge: %v", challenge)
+	}
+
+	// Wait for the order/challenges to be validated.
+	_, err = acmeClient.WaitOrder(testCtx, order.URI)
+	require.NoError(t, err, "failed waiting for order to be ready")
+
+	// Create/sign the CSR and ask ACME server to sign it returning us the final certificate
+	csrKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	csr, err := x509.CreateCertificateRequest(rand.Reader, cr, csrKey)
+	require.NoError(t, err, "failed generating csr")
+
+	certs, _, err := acmeClient.CreateOrderCert(testCtx, order.FinalizeURL, csr, false)
+	require.NoError(t, err, "failed to get a certificate back from ACME")
+
+	acmeCert, err := x509.ParseCertificate(certs[0])
+	require.NoError(t, err, "failed parsing acme cert bytes")
+
+	return acmeCert
+}

--- a/builtin/logical/pki/path_acme_order.go
+++ b/builtin/logical/pki/path_acme_order.go
@@ -284,6 +284,11 @@ func (b *backend) acmeFinalizeOrderHandler(ac *acmeContext, _ *logical.Request, 
 		return nil, fmt.Errorf("failed saving updated order: %w", err)
 	}
 
+	if err := b.doTrackBilling(ac.sc.Context, order.Identifiers); err != nil {
+		b.Logger().Error("failed to track billing for order", "order", orderId, "error", err)
+		err = nil
+	}
+
 	return formatOrderResponse(ac, order), nil
 }
 

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -21,20 +21,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault/sdk/helper/jsonutil"
-
-	"github.com/go-test/deep"
-
-	"github.com/hashicorp/go-cleanhttp"
 	"golang.org/x/crypto/acme"
 	"golang.org/x/net/http2"
 
 	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/helper/constants"
 	vaulthttp "github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/sdk/helper/jsonutil"
+	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 
-	"github.com/hashicorp/vault/sdk/logical"
-
+	"github.com/go-test/deep"
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/square/go-jose.v2/json"
 )
@@ -467,28 +465,63 @@ func TestAcmeDisabledWithEnvVar(t *testing.T) {
 func setupAcmeBackend(t *testing.T) (*vault.TestCluster, *api.Client, string) {
 	cluster, client := setupTestPkiCluster(t)
 
-	// Setting templated AIAs should succeed.
-	pathConfig := client.Address() + "/v1/pki"
+	return setupAcmeBackendOnClusterAtPath(t, cluster, client, "pki")
+}
 
-	_, err := client.Logical().WriteWithContext(context.Background(), "pki/config/cluster", map[string]interface{}{
+func setupAcmeBackendOnClusterAtPath(t *testing.T, cluster *vault.TestCluster, client *api.Client, mount string) (*vault.TestCluster, *api.Client, string) {
+	mount = strings.Trim(mount, "/")
+
+	// Setting templated AIAs should succeed.
+	pathConfig := client.Address() + "/v1/" + mount
+
+	namespace := ""
+	if mount != "pki" {
+		if strings.Contains(mount, "/") && constants.IsEnterprise {
+			ns_pieces := strings.Split(mount, "/")
+			c := len(ns_pieces)
+			// mount is c-1
+			ns_name := ns_pieces[c-2]
+			if len(ns_pieces) > 2 {
+				// Parent's namespaces
+				parent := strings.Join(ns_pieces[0:c-3], "/")
+				_, err := client.WithNamespace(parent).Logical().Write("/sys/namespaces/"+ns_name, nil)
+				require.NoError(t, err, "failed to create nested namespaces "+parent+" -> "+ns_name)
+			} else {
+				_, err := client.Logical().Write("/sys/namespaces/"+ns_name, nil)
+				require.NoError(t, err, "failed to create nested namespace "+ns_name)
+			}
+			namespace = strings.Join(ns_pieces[0:c-2], "/")
+		}
+
+		err := client.WithNamespace(namespace).Sys().Mount(mount, &api.MountInput{
+			Type: "pki",
+			Config: api.MountConfigInput{
+				DefaultLeaseTTL: "16h",
+				MaxLeaseTTL:     "60h",
+			},
+		})
+		require.NoError(t, err, "failed to mount new PKI instance at "+mount)
+	}
+
+	_, err := client.Logical().WriteWithContext(context.Background(), mount+"/config/cluster", map[string]interface{}{
 		"path":     pathConfig,
-		"aia_path": "http://localhost:8200/cdn/pki",
+		"aia_path": "http://localhost:8200/cdn/" + mount,
 	})
 	require.NoError(t, err)
 
-	_, err = client.Logical().WriteWithContext(context.Background(), "pki/config/acme", map[string]interface{}{
+	_, err = client.Logical().WriteWithContext(context.Background(), mount+"/config/acme", map[string]interface{}{
 		"enabled": true,
 	})
 	require.NoError(t, err)
 
 	// Allow certain headers to pass through for ACME support
-	_, err = client.Logical().WriteWithContext(context.Background(), "sys/mounts/pki/tune", map[string]interface{}{
+	_, err = client.WithNamespace(namespace).Logical().WriteWithContext(context.Background(), "sys/mounts/"+mount+"/tune", map[string]interface{}{
 		"allowed_response_headers": []string{"Last-Modified", "Replay-Nonce", "Link", "Location"},
 		"max_lease_ttl":            "920000h",
 	})
 	require.NoError(t, err, "failed tuning mount response headers")
 
-	resp, err := client.Logical().WriteWithContext(context.Background(), "/pki/issuers/generate/root/internal",
+	resp, err := client.Logical().WriteWithContext(context.Background(), mount+"/issuers/generate/root/internal",
 		map[string]interface{}{
 			"issuer_name": "root-ca",
 			"key_name":    "root-key",
@@ -499,7 +532,7 @@ func setupAcmeBackend(t *testing.T) (*vault.TestCluster, *api.Client, string) {
 		})
 	require.NoError(t, err, "failed creating root CA")
 
-	resp, err = client.Logical().WriteWithContext(context.Background(), "/pki/issuers/generate/intermediate/internal",
+	resp, err = client.Logical().WriteWithContext(context.Background(), mount+"/issuers/generate/intermediate/internal",
 		map[string]interface{}{
 			"key_name":    "int-key",
 			"key_type":    "ec",
@@ -509,7 +542,7 @@ func setupAcmeBackend(t *testing.T) (*vault.TestCluster, *api.Client, string) {
 	intermediateCSR := resp.Data["csr"].(string)
 
 	// Sign the intermediate CSR using /pki
-	resp, err = client.Logical().Write("pki/issuer/root-ca/sign-intermediate", map[string]interface{}{
+	resp, err = client.Logical().Write(mount+"/issuer/root-ca/sign-intermediate", map[string]interface{}{
 		"csr":     intermediateCSR,
 		"ttl":     "720h",
 		"max_ttl": "7200h",
@@ -518,7 +551,7 @@ func setupAcmeBackend(t *testing.T) (*vault.TestCluster, *api.Client, string) {
 	intermediateCertPEM := resp.Data["certificate"].(string)
 
 	// Configure the intermediate cert as the CA in /pki2
-	resp, err = client.Logical().Write("/pki/issuers/import/cert", map[string]interface{}{
+	resp, err = client.Logical().Write(mount+"/issuers/import/cert", map[string]interface{}{
 		"pem_bundle": intermediateCertPEM,
 	})
 	require.NoError(t, err, "failed importing intermediary cert")
@@ -526,17 +559,17 @@ func setupAcmeBackend(t *testing.T) (*vault.TestCluster, *api.Client, string) {
 	require.Len(t, importedIssuersRaw, 1)
 	intCaUuid := importedIssuersRaw[0].(string)
 
-	_, err = client.Logical().Write("/pki/issuer/"+intCaUuid, map[string]interface{}{
+	_, err = client.Logical().Write(mount+"/issuer/"+intCaUuid, map[string]interface{}{
 		"issuer_name": "int-ca",
 	})
 	require.NoError(t, err, "failed updating issuer name")
 
-	_, err = client.Logical().Write("/pki/config/issuers", map[string]interface{}{
+	_, err = client.Logical().Write(mount+"/config/issuers", map[string]interface{}{
 		"default": "int-ca",
 	})
 	require.NoError(t, err, "failed updating default issuer")
 
-	_, err = client.Logical().Write("/pki/roles/test-role", map[string]interface{}{
+	_, err = client.Logical().Write(mount+"/roles/test-role", map[string]interface{}{
 		"ttl_duration":                "365h",
 		"max_ttl_duration":            "720h",
 		"key_type":                    "any",
@@ -546,7 +579,7 @@ func setupAcmeBackend(t *testing.T) (*vault.TestCluster, *api.Client, string) {
 	})
 	require.NoError(t, err, "failed creating role test-role")
 
-	_, err = client.Logical().Write("/pki/roles/acme", map[string]interface{}{
+	_, err = client.Logical().Write(mount+"/roles/acme", map[string]interface{}{
 		"ttl_duration":     "365h",
 		"max_ttl_duration": "720h",
 		"key_type":         "any",

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -475,6 +475,7 @@ func setupAcmeBackendOnClusterAtPath(t *testing.T, cluster *vault.TestCluster, c
 	pathConfig := client.Address() + "/v1/" + mount
 
 	namespace := ""
+	mountName := mount
 	if mount != "pki" {
 		if strings.Contains(mount, "/") && constants.IsEnterprise {
 			ns_pieces := strings.Split(mount, "/")
@@ -483,17 +484,18 @@ func setupAcmeBackendOnClusterAtPath(t *testing.T, cluster *vault.TestCluster, c
 			ns_name := ns_pieces[c-2]
 			if len(ns_pieces) > 2 {
 				// Parent's namespaces
-				parent := strings.Join(ns_pieces[0:c-3], "/")
+				parent := strings.Join(ns_pieces[0:c-2], "/")
 				_, err := client.WithNamespace(parent).Logical().Write("/sys/namespaces/"+ns_name, nil)
 				require.NoError(t, err, "failed to create nested namespaces "+parent+" -> "+ns_name)
 			} else {
 				_, err := client.Logical().Write("/sys/namespaces/"+ns_name, nil)
 				require.NoError(t, err, "failed to create nested namespace "+ns_name)
 			}
-			namespace = strings.Join(ns_pieces[0:c-2], "/")
+			namespace = strings.Join(ns_pieces[0:c-1], "/")
+			mountName = ns_pieces[c-1]
 		}
 
-		err := client.WithNamespace(namespace).Sys().Mount(mount, &api.MountInput{
+		err := client.WithNamespace(namespace).Sys().Mount(mountName, &api.MountInput{
 			Type: "pki",
 			Config: api.MountConfigInput{
 				DefaultLeaseTTL: "16h",
@@ -515,7 +517,7 @@ func setupAcmeBackendOnClusterAtPath(t *testing.T, cluster *vault.TestCluster, c
 	require.NoError(t, err)
 
 	// Allow certain headers to pass through for ACME support
-	_, err = client.WithNamespace(namespace).Logical().WriteWithContext(context.Background(), "sys/mounts/"+mount+"/tune", map[string]interface{}{
+	_, err = client.WithNamespace(namespace).Logical().WriteWithContext(context.Background(), "sys/mounts/"+mountName+"/tune", map[string]interface{}{
 		"allowed_response_headers": []string{"Last-Modified", "Replay-Nonce", "Link", "Location"},
 		"max_lease_ttl":            "920000h",
 	})

--- a/sdk/logical/acme_billing.go
+++ b/sdk/logical/acme_billing.go
@@ -1,0 +1,10 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package logical
+
+import "context"
+
+type ACMEBillingSystemView interface {
+	CreateActivityCountEventForIdentifiers(ctx context.Context, identifiers []string) error
+}

--- a/vault/acme_billing_system_view.go
+++ b/vault/acme_billing_system_view.go
@@ -1,0 +1,42 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+type acmeBillingSystemViewImpl struct {
+	extendedSystemView
+	logical.ManagedKeySystemView
+	core *Core
+}
+
+var _ logical.ACMEBillingSystemView = (*acmeBillingSystemViewImpl)(nil)
+
+func (c *Core) NewAcmeBillingSystemView(sysView interface{}) *acmeBillingSystemViewImpl {
+	es := sysView.(extendedSystemView)
+	managed, ok := sysView.(logical.ManagedKeySystemView)
+	if !ok {
+		return &acmeBillingSystemViewImpl{
+			extendedSystemView: es,
+			core:               c,
+		}
+	}
+
+	return &acmeBillingSystemViewImpl{
+		extendedSystemView:           es,
+		ManagedKeySystemView:         managed,
+		core:                         c,
+	}
+}
+
+func (a *acmeBillingSystemViewImpl) CreateActivityCountEventForIdentifiers(ctx context.Context, identifiers []string) error {
+	sort.Strings(identifiers)
+	return fmt.Errorf("got identifiers but not implemented: %v", identifiers)
+}

--- a/vault/acme_billing_system_view.go
+++ b/vault/acme_billing_system_view.go
@@ -25,19 +25,9 @@ type acmeBillingSystemViewImpl struct {
 
 var _ logical.ACMEBillingSystemView = (*acmeBillingSystemViewImpl)(nil)
 
-func (c *Core) NewAcmeBillingSystemView(sysView interface{}) *acmeBillingSystemViewImpl {
+func (c *Core) NewAcmeBillingSystemView(sysView interface{}, managed logical.ManagedKeySystemView) *acmeBillingSystemViewImpl {
 	es := sysView.(extendedSystemViewImpl)
 	des := es.dynamicSystemView
-
-	managed, ok := sysView.(logical.ManagedKeySystemView)
-
-	if !ok {
-		return &acmeBillingSystemViewImpl{
-			extendedSystemView: es,
-			core:               c,
-			entry:              des.mountEntry,
-		}
-	}
 
 	return &acmeBillingSystemViewImpl{
 		extendedSystemView:   es,

--- a/vault/acme_billing_system_view.go
+++ b/vault/acme_billing_system_view.go
@@ -5,9 +5,14 @@ package vault
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"sort"
+	"strings"
+	"time"
 
+	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -30,13 +35,30 @@ func (c *Core) NewAcmeBillingSystemView(sysView interface{}) *acmeBillingSystemV
 	}
 
 	return &acmeBillingSystemViewImpl{
-		extendedSystemView:           es,
-		ManagedKeySystemView:         managed,
-		core:                         c,
+		extendedSystemView:   es,
+		ManagedKeySystemView: managed,
+		core:                 c,
 	}
 }
 
 func (a *acmeBillingSystemViewImpl) CreateActivityCountEventForIdentifiers(ctx context.Context, identifiers []string) error {
+	var te logical.TokenEntry
+	var clientID string
+
+	// Fake our clientID from the identifiers, but ensure it is independent of ordering.
 	sort.Strings(identifiers)
-	return fmt.Errorf("got identifiers but not implemented: %v", identifiers)
+	joinedIdentifiers := strings.Join(identifiers, ".")
+	identifiersHash := sha256.Sum256([]byte(joinedIdentifiers))
+	fakeToken := base64.RawURLEncoding.EncodeToString(identifiersHash[:])
+	prefix := "acme."
+	clientID = prefix + fakeToken
+	te.NamespaceID = namespace.RootNamespaceID
+	te.CreationTime = time.Now().Unix()
+
+	// Log so users can correlate ACME requests to client count tokens.
+	a.core.activityLog.logger.Debug(fmt.Sprintf("Handling ACME client count event for [%v] -> %v", identifiers, clientID))
+
+	a.core.activityLog.HandleTokenUsage(ctx, &te, clientID, true /* isTWE */)
+
+	return nil
 }

--- a/vault/mount_util.go
+++ b/vault/mount_util.go
@@ -64,5 +64,5 @@ func (c *Core) mountEntrySysView(entry *MountEntry) extendedSystemView {
 		},
 	}
 
-	return c.NewAcmeBillingSystemView(esi)
+	return c.NewAcmeBillingSystemView(esi, nil /* managed keys system view */)
 }

--- a/vault/mount_util.go
+++ b/vault/mount_util.go
@@ -56,11 +56,13 @@ func verifyNamespace(*Core, *namespace.Namespace, *MountEntry) error { return ni
 // mount-specific entries; because this should be called when setting
 // up a mountEntry, it doesn't check to ensure that me is not nil
 func (c *Core) mountEntrySysView(entry *MountEntry) extendedSystemView {
-	return extendedSystemViewImpl{
+	esi := extendedSystemViewImpl{
 		dynamicSystemView{
 			core:        c,
 			mountEntry:  entry,
 			perfStandby: c.perfStandby,
 		},
 	}
+
+	return c.NewAcmeBillingSystemView(esi)
 }


### PR DESCRIPTION
This enables client count (activity log events) for ACME certificate issuance. Per consensus reached internally, this creates events based upon the unique identifiers requested during issuance. This interface is presently only intended for ACME billing within the builtin PKI plugin, but changes to system view could be made in the future to make this a more generally available interface, including to external plugins. Today, this goes into the non-entity token bucket.