### PR TITLE
Add External Account Binding support to ACME 

### DIFF
--- a/builtin/logical/pki/acme_eab_policy.go
+++ b/builtin/logical/pki/acme_eab_policy.go
@@ -1,0 +1,69 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package pki
+
+import (
+	"fmt"
+	"strings"
+)
+
+type EabPolicyName string
+
+const (
+	eabPolicyNotRequired        EabPolicyName = "not-required"
+	eabPolicyNewAccountRequired EabPolicyName = "new-account-required"
+	eabPolicyAlwaysRequired     EabPolicyName = "always-required"
+)
+
+func getEabPolicyByString(name string) (EabPolicy, error) {
+	lcName := strings.TrimSpace(strings.ToLower(name))
+	switch lcName {
+	case string(eabPolicyNotRequired):
+		return getEabPolicyByName(eabPolicyNotRequired), nil
+	case string(eabPolicyNewAccountRequired):
+		return getEabPolicyByName(eabPolicyNewAccountRequired), nil
+	case string(eabPolicyAlwaysRequired):
+		return getEabPolicyByName(eabPolicyAlwaysRequired), nil
+	default:
+		return getEabPolicyByName(eabPolicyAlwaysRequired), fmt.Errorf("unknown eab policy name: %s", name)
+	}
+}
+
+func getEabPolicyByName(name EabPolicyName) EabPolicy {
+	return EabPolicy{Name: name}
+}
+
+type EabPolicy struct {
+	Name EabPolicyName
+}
+
+// EnforceForNewAccount for new account creations, should we require an EAB.
+func (ep EabPolicy) EnforceForNewAccount(eabData *eabType) error {
+	if (ep.Name == eabPolicyAlwaysRequired || ep.Name == eabPolicyNewAccountRequired) && eabData == nil {
+		return ErrExternalAccountRequired
+	}
+
+	return nil
+}
+
+// EnforceForExistingAccount for all operations within ACME, does the account being used require an EAB attached to it.
+func (ep EabPolicy) EnforceForExistingAccount(account *acmeAccount) error {
+	if ep.Name == eabPolicyAlwaysRequired && account.Eab == nil {
+		return ErrExternalAccountRequired
+	}
+
+	return nil
+}
+
+// IsExternalAccountRequired for new accounts incoming does is an EAB required
+func (ep EabPolicy) IsExternalAccountRequired() bool {
+	return ep.Name == eabPolicyAlwaysRequired || ep.Name == eabPolicyNewAccountRequired
+}
+
+// OverrideEnvDisablingPublicAcme determines if ACME is enabled but the OS environment variable
+// has said to disable public acme support, if we can override that environment variable to
+// turn on ACME support
+func (ep EabPolicy) OverrideEnvDisablingPublicAcme() bool {
+	return ep.Name == eabPolicyAlwaysRequired
+}

--- a/builtin/logical/pki/acme_jws.go
+++ b/builtin/logical/pki/acme_jws.go
@@ -4,6 +4,7 @@
 package pki
 
 import (
+	"bytes"
 	"crypto"
 	"encoding/base64"
 	"encoding/json"
@@ -264,8 +265,7 @@ func verifyEabPayload(acmeState *acmeState, ac *acmeContext, outer *jwsCtx, expe
 	}
 
 	// Make sure how eab payload matches the outer JWK key value
-	base64OuterJwk := base64.RawURLEncoding.EncodeToString(outer.Jwk)
-	if base64OuterJwk != string(verifiedPayload) {
+	if !bytes.Equal(outer.Jwk, verifiedPayload) {
 		return nil, fmt.Errorf("eab payload does not match outer JWK key: %w", ErrMalformed)
 	}
 

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -16,8 +16,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"gopkg.in/square/go-jose.v2"
-
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -525,95 +523,6 @@ func (a *acmeState) ParseRequestParams(ac *acmeContext, req *logical.Request, da
 	return &c, m, nil
 }
 
-func (a *acmeState) verifyEabPayload(ac *acmeContext, outer *jwsCtx, expectedPath string, payload map[string]interface{}) (*eabType, error) {
-	// Parse the key out.
-	rawProtectedBase64, ok := payload["protected"]
-	if !ok {
-		return nil, fmt.Errorf("missing required field 'protected': %w", ErrMalformed)
-	}
-	jwkBase64 := rawProtectedBase64.(string)
-
-	jwkBytes, err := base64.RawURLEncoding.DecodeString(jwkBase64)
-	if err != nil {
-		return nil, fmt.Errorf("failed to base64 parse eab 'protected': %s: %w", err, ErrMalformed)
-	}
-
-	eabJws, err := UnmarshalEabJwsJson(jwkBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to json unmarshal eab 'protected': %w", err)
-	}
-
-	if len(eabJws.Url) == 0 {
-		return nil, fmt.Errorf("missing required parameter 'url' in eab 'protected': %w", ErrMalformed)
-	}
-	expectedUrl := ac.clusterUrl.JoinPath(expectedPath).String()
-	if expectedUrl != eabJws.Url {
-		return nil, fmt.Errorf("invalid value for 'url' in eab 'protected': got '%v' expected '%v': %w", eabJws.Url, expectedUrl, ErrUnauthorized)
-	}
-
-	if len(eabJws.Nonce) != 0 {
-		return nil, fmt.Errorf("nonce should not be provided in eab 'protected': %w", ErrMalformed)
-	}
-
-	rawPayloadBase64, ok := payload["payload"]
-	if !ok {
-		return nil, fmt.Errorf("missing required field eab 'payload': %w", ErrMalformed)
-	}
-	payloadBase64, ok := rawPayloadBase64.(string)
-	if !ok {
-		return nil, fmt.Errorf("failed to parse 'payload' field: %w", ErrMalformed)
-	}
-
-	// Make sure how eab payload matches the outer JWK key value
-	base64OuterJwk := base64.RawURLEncoding.EncodeToString(outer.Jwk)
-	if base64OuterJwk != payloadBase64 {
-		return nil, fmt.Errorf("eab payload does not match outer JWK key: %w", ErrMalformed)
-	}
-
-	rawSignatureBase64, ok := payload["signature"]
-	if !ok {
-		return nil, fmt.Errorf("missing required field 'signature': %w", ErrMalformed)
-	}
-	signatureBase64, ok := rawSignatureBase64.(string)
-	if !ok {
-		return nil, fmt.Errorf("failed to parse 'signature' field: %w", ErrMalformed)
-	}
-
-	// go-jose only seems to support compact signature encodings.
-	compactSig := fmt.Sprintf("%v.%v.%v", jwkBase64, payloadBase64, signatureBase64)
-	sig, err := jose.ParseSigned(compactSig)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing eab signature: %s: %w", err, ErrMalformed)
-	}
-
-	if len(sig.Signatures) > 1 {
-		// See RFC 8555 Section 6.2. Request Authentication:
-		//
-		// > The JWS MUST NOT have multiple signatures
-		return nil, fmt.Errorf("eab had multiple signatures: %w", ErrMalformed)
-	}
-
-	if hasValues(sig.Signatures[0].Unprotected) {
-		// See RFC 8555 Section 6.2. Request Authentication:
-		//
-		// > The JWS Unprotected Header [RFC7515] MUST NOT be used
-		return nil, fmt.Errorf("eab had unprotected headers: %w", ErrMalformed)
-	}
-
-	// Load the EAB to validate the signature against
-	eabEntry, err := a.LoadEab(ac.sc, eabJws.Kid)
-	if err != nil {
-		return nil, fmt.Errorf("%w: failed to verify eab", ErrUnauthorized)
-	}
-
-	_, err = sig.Verify(eabEntry.MacKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return eabEntry, nil
-}
-
 func (a *acmeState) LoadOrder(ac *acmeContext, userCtx *jwsCtx, orderId string) (*acmeOrder, error) {
 	path := getOrderPath(userCtx.Kid, orderId)
 	entry, err := ac.sc.Storage.Get(ac.sc.Context, path)
@@ -766,7 +675,7 @@ func (a *acmeState) DeleteEab(sc *storageContext, eabKid string) (bool, error) {
 
 	err = sc.Storage.Delete(sc.Context, path.Join(acmeEabPrefix, eabKid))
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 	return true, nil
 }

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -555,12 +555,6 @@ func (a *acmeState) verifyEabPayload(ac *acmeContext, outer *jwsCtx, expectedPat
 		return nil, fmt.Errorf("nonce should not be provided in eab 'protected': %w", ErrMalformed)
 	}
 
-	// Load the EAB
-	eabEntry, err := a.LoadEab(ac.sc, eabJws.Kid)
-	if err != nil {
-		return nil, fmt.Errorf("%w: failed to verify eab", ErrUnauthorized)
-	}
-
 	rawPayloadBase64, ok := payload["payload"]
 	if !ok {
 		return nil, fmt.Errorf("missing required field eab 'payload': %w", ErrMalformed)
@@ -604,6 +598,12 @@ func (a *acmeState) verifyEabPayload(ac *acmeContext, outer *jwsCtx, expectedPat
 		//
 		// > The JWS Unprotected Header [RFC7515] MUST NOT be used
 		return nil, fmt.Errorf("eab had unprotected headers: %w", ErrMalformed)
+	}
+
+	// Load the EAB to validate the signature against
+	eabEntry, err := a.LoadEab(ac.sc, eabJws.Kid)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to verify eab", ErrUnauthorized)
 	}
 
 	_, err = sig.Verify(eabEntry.MacKey)

--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -27,6 +27,7 @@ type acmeContext struct {
 	// acmeDirectory is a string that can distinguish the various acme directories we have configured
 	// if something needs to remain locked into a directory path structure.
 	acmeDirectory string
+	requireEab    bool
 }
 
 type (
@@ -87,6 +88,7 @@ func (b *backend) acmeWrapper(op acmeOperation) framework.OperationFunc {
 			role:          role,
 			issuer:        issuer,
 			acmeDirectory: acmeDirectory,
+			requireEab:    config.RequireEAB,
 		}
 
 		return op(acmeCtx, r, data)

--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -27,7 +27,7 @@ type acmeContext struct {
 	// acmeDirectory is a string that can distinguish the various acme directories we have configured
 	// if something needs to remain locked into a directory path structure.
 	acmeDirectory string
-	requireEab    bool
+	eabPolicy     EabPolicy
 }
 
 type (
@@ -61,7 +61,13 @@ func (b *backend) acmeWrapper(op acmeOperation) framework.OperationFunc {
 			return nil, fmt.Errorf("failed to fetch ACME configuration: %w", err)
 		}
 
-		if isAcmeDisabled(sc, config) {
+		// use string form in case someone messes up our config from raw storage.
+		eabPolicy, err := getEabPolicyByString(string(config.EabPolicyName))
+		if err != nil {
+			return nil, err
+		}
+
+		if isAcmeDisabled(sc, config, eabPolicy) {
 			return nil, ErrAcmeDisabled
 		}
 
@@ -88,7 +94,7 @@ func (b *backend) acmeWrapper(op acmeOperation) framework.OperationFunc {
 			role:          role,
 			issuer:        issuer,
 			acmeDirectory: acmeDirectory,
-			requireEab:    config.RequireEAB,
+			eabPolicy:     eabPolicy,
 		}
 
 		return op(acmeCtx, r, data)
@@ -185,6 +191,10 @@ func (b *backend) acmeAccountRequiredWrapper(op acmeAccountRequiredOperation) fr
 		account, err := b.acmeState.LoadAccount(acmeCtx, uc.Kid)
 		if err != nil {
 			return nil, fmt.Errorf("error loading account: %w", err)
+		}
+
+		if err = acmeCtx.eabPolicy.EnforceForExistingAccount(account); err != nil {
+			return nil, err
 		}
 
 		if account.Status != StatusValid {
@@ -375,7 +385,7 @@ func getRequestedAcmeIssuerFromPath(data *framework.FieldData) string {
 	return requestedIssuer
 }
 
-func isAcmeDisabled(sc *storageContext, config *acmeConfigEntry) bool {
+func isAcmeDisabled(sc *storageContext, config *acmeConfigEntry, policy EabPolicy) bool {
 	if !config.Enabled {
 		return true
 	}
@@ -389,8 +399,9 @@ func isAcmeDisabled(sc *storageContext, config *acmeConfigEntry) bool {
 
 		// The OS environment if true will override any configuration option.
 		if disableAcme {
-			// TODO: If EAB is enforced in the configuration, don't mark
-			// ACME as disabled.
+			if policy.OverrideEnvDisablingPublicAcme() {
+				return false
+			}
 			return true
 		}
 	}

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -218,6 +218,8 @@ func Backend(conf *logical.BackendConfig) *backend {
 
 			// ACME
 			pathAcmeConfig(&b),
+			pathAcmeEabCreateList(&b),
+			pathAcmeEabDelete(&b),
 		},
 
 		Secrets: []*framework.Secret{

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -6721,7 +6721,7 @@ func TestProperAuthing(t *testing.T) {
 		t.Fatal(err)
 	}
 	serial := resp.Data["serial_number"].(string)
-
+	eabKid := "13b80844-e60d-42d2-b7e9-152a8e834b90"
 	paths := map[string]pathAuthChecker{
 		"ca_chain":                               shouldBeUnauthedReadList,
 		"cert/ca_chain":                          shouldBeUnauthedReadList,
@@ -6839,6 +6839,8 @@ func TestProperAuthing(t *testing.T) {
 		"unified-crl/delta/pem":                  shouldBeUnauthedReadList,
 		"unified-ocsp":                           shouldBeUnauthedWriteOnly,
 		"unified-ocsp/dGVzdAo=":                  shouldBeUnauthedReadList,
+		"acme/eab":                               shouldBeAuthed,
+		"acme/eab/" + eabKid:                     shouldBeAuthed,
 	}
 
 	// Add ACME based paths to the test suite
@@ -6911,6 +6913,9 @@ func TestProperAuthing(t *testing.T) {
 		}
 		if strings.Contains(raw_path, "acme/") && strings.Contains(raw_path, "{order_id}") {
 			raw_path = strings.ReplaceAll(raw_path, "{order_id}", "13b80844-e60d-42d2-b7e9-152a8e834b90")
+		}
+		if strings.Contains(raw_path, "acme/eab") && strings.Contains(raw_path, "{key_id}") {
+			raw_path = strings.ReplaceAll(raw_path, "{key_id}", eabKid)
 		}
 
 		handler, present := paths[raw_path]

--- a/builtin/logical/pki/path_acme_account.go
+++ b/builtin/logical/pki/path_acme_account.go
@@ -255,7 +255,7 @@ func (b *backend) acmeNewAccountCreateHandler(acmeCtx *acmeContext, userCtx *jws
 			return nil, fmt.Errorf("%w: externalAccountBinding field was unparseable", ErrMalformed)
 		}
 
-		eab, err = b.acmeState.verifyEabPayload(acmeCtx, userCtx, r.Path, eabData)
+		eab, err = verifyEabPayload(b.acmeState, acmeCtx, userCtx, r.Path, eabData)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load account by thumbprint: %w", err)
 		}
@@ -288,7 +288,7 @@ func (b *backend) acmeNewAccountCreateHandler(acmeCtx *acmeContext, userCtx *jws
 	accountByKid, err := b.acmeState.CreateAccount(acmeCtx, userCtx, contact, termsOfServiceAgreed, eab)
 	if err != nil {
 		if eab != nil {
-			return nil, fmt.Errorf("failed to create account, EAB key that was used is no longer available: %w", err)
+			return nil, fmt.Errorf("failed to create account: %w; the EAB key used for this request has been deleted as a result of this operation; fetch a new EAB key before retrying", err)
 		}
 		return nil, fmt.Errorf("failed to create account: %w", err)
 	}

--- a/builtin/logical/pki/path_acme_directory.go
+++ b/builtin/logical/pki/path_acme_directory.go
@@ -50,7 +50,7 @@ func (b *backend) acmeDirectoryHandler(acmeCtx *acmeContext, r *logical.Request,
 		"keyChange":  acmeCtx.baseUrl.JoinPath("key-change").String(),
 		// This is purposefully missing newAuthz as we don't support pre-authorization
 		"meta": map[string]interface{}{
-			"externalAccountRequired": acmeCtx.requireEab,
+			"externalAccountRequired": acmeCtx.eabPolicy.IsExternalAccountRequired(),
 		},
 	})
 	if err != nil {

--- a/builtin/logical/pki/path_acme_directory.go
+++ b/builtin/logical/pki/path_acme_directory.go
@@ -50,7 +50,7 @@ func (b *backend) acmeDirectoryHandler(acmeCtx *acmeContext, r *logical.Request,
 		"keyChange":  acmeCtx.baseUrl.JoinPath("key-change").String(),
 		// This is purposefully missing newAuthz as we don't support pre-authorization
 		"meta": map[string]interface{}{
-			"externalAccountRequired": false,
+			"externalAccountRequired": acmeCtx.requireEab,
 		},
 	})
 	if err != nil {

--- a/builtin/logical/pki/path_acme_directory.go
+++ b/builtin/logical/pki/path_acme_directory.go
@@ -48,6 +48,7 @@ func (b *backend) acmeDirectoryHandler(acmeCtx *acmeContext, r *logical.Request,
 		"newOrder":   acmeCtx.baseUrl.JoinPath("new-order").String(),
 		"revokeCert": acmeCtx.baseUrl.JoinPath("revoke-cert").String(),
 		"keyChange":  acmeCtx.baseUrl.JoinPath("key-change").String(),
+		// This is purposefully missing newAuthz as we don't support pre-authorization
 		"meta": map[string]interface{}{
 			"externalAccountRequired": false,
 		},

--- a/builtin/logical/pki/path_acme_eab.go
+++ b/builtin/logical/pki/path_acme_eab.go
@@ -41,7 +41,9 @@ func pathAcmeEabCreateList(b *backend) *framework.Path {
 				Callback: b.pathAcmeListEab,
 			},
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathAcmeCreateEab,
+				Callback:                    b.pathAcmeCreateEab,
+				ForwardPerformanceSecondary: false,
+				ForwardPerformanceStandby:   true,
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb:   "configure",
 					OperationSuffix: "acme",
@@ -75,7 +77,9 @@ func pathAcmeEabDelete(b *backend) *framework.Path {
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "acme-configuration",
 				},
-				Callback: b.pathAcmeDeleteEab,
+				Callback:                    b.pathAcmeDeleteEab,
+				ForwardPerformanceSecondary: false,
+				ForwardPerformanceStandby:   true,
 			},
 		},
 

--- a/builtin/logical/pki/path_acme_eab.go
+++ b/builtin/logical/pki/path_acme_eab.go
@@ -1,0 +1,196 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package pki
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+/*
+ * This file unlike the other path_acme_xxx.go are VAULT APIs to manage the
+ * ACME External Account Bindings, this isn't providing any APIs that an ACME
+ * client would use.
+ */
+func pathAcmeEabCreateList(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "acme/eab",
+
+		DisplayAttrs: &framework.DisplayAttributes{
+			OperationPrefix: operationPrefixPKI,
+		},
+
+		Fields: map[string]*framework.FieldSchema{},
+
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				DisplayAttrs: &framework.DisplayAttributes{
+					OperationSuffix: "acme-configuration",
+				},
+				Callback: b.pathAcmeListEab,
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathAcmeCreateEab,
+				DisplayAttrs: &framework.DisplayAttributes{
+					OperationVerb:   "configure",
+					OperationSuffix: "acme",
+				},
+			},
+		},
+
+		HelpSynopsis:    "",
+		HelpDescription: "",
+	}
+}
+
+func pathAcmeEabDelete(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "acme/eab/" + uuidNameRegex("key_id"),
+
+		DisplayAttrs: &framework.DisplayAttributes{
+			OperationPrefix: operationPrefixPKI,
+		},
+
+		Fields: map[string]*framework.FieldSchema{
+			"key_id": {
+				Type:        framework.TypeString,
+				Description: "EAB key identifier",
+				Required:    true,
+			},
+		},
+
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.DeleteOperation: &framework.PathOperation{
+				DisplayAttrs: &framework.DisplayAttributes{
+					OperationSuffix: "acme-configuration",
+				},
+				Callback: b.pathAcmeDeleteEab,
+			},
+		},
+
+		HelpSynopsis:    "",
+		HelpDescription: "",
+	}
+}
+
+type eabType struct {
+	KeyID     string    `json:"-"`
+	KeyType   string    `json:"key-type"`
+	KeyBits   string    `json:"key-bits"`
+	MacKey    []byte    `json:"mac-key"`
+	CreatedOn time.Time `json:"created-on"`
+}
+
+func (b *backend) pathAcmeListEab(ctx context.Context, r *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	sc := b.makeStorageContext(ctx, r.Storage)
+
+	eabIds, err := b.acmeState.ListEabIds(sc)
+	if err != nil {
+		return nil, err
+	}
+
+	var warnings []string
+	var keyIds []string
+	keyInfos := map[string]interface{}{}
+
+	for _, eabKey := range eabIds {
+		eab, err := b.acmeState.LoadEab(sc, eabKey)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("failed loading eab entry %s: %v", eabKey, err))
+			continue
+		}
+
+		keyIds = append(keyIds, eab.KeyID)
+		keyInfos[eab.KeyID] = map[string]interface{}{
+			"key_type":   eab.KeyType,
+			"key_bits":   eab.KeyBits,
+			"created_on": eab.CreatedOn.Format(time.RFC3339),
+		}
+	}
+
+	resp := logical.ListResponseWithInfo(keyIds, keyInfos)
+	for _, warning := range warnings {
+		resp.AddWarning(warning)
+	}
+	return resp, nil
+}
+
+func (b *backend) pathAcmeCreateEab(ctx context.Context, r *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	kid := genUuid()
+	macKey, err := generateEabKey(b.GetRandomReader())
+	if err != nil {
+		return nil, fmt.Errorf("failed generating eab key: %w", err)
+	}
+
+	eab := &eabType{
+		KeyID:     kid,
+		KeyType:   "ec",
+		KeyBits:   "256",
+		MacKey:    macKey,
+		CreatedOn: time.Now(),
+	}
+
+	sc := b.makeStorageContext(ctx, r.Storage)
+	err = b.acmeState.SaveEab(sc, eab)
+	if err != nil {
+		return nil, fmt.Errorf("failed saving generated eab: %w", err)
+	}
+
+	encodedKey := base64.RawURLEncoding.EncodeToString(macKey)
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"id":          eab.KeyID,
+			"key_type":    eab.KeyType,
+			"key_bits":    eab.KeyBits,
+			"private_key": encodedKey,
+			"created_on":  eab.CreatedOn.Format(time.RFC3339),
+		},
+	}, nil
+}
+
+func (b *backend) pathAcmeDeleteEab(ctx context.Context, r *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	sc := b.makeStorageContext(ctx, r.Storage)
+	keyId := d.Get("key_id").(string)
+
+	_, err := uuid.ParseUUID(keyId)
+	if err != nil {
+		return nil, fmt.Errorf("badly formatted key_id field")
+	}
+
+	deleted, err := b.acmeState.DeleteEab(sc, keyId)
+	if err != nil {
+		return nil, fmt.Errorf("failed deleting key id: %w", err)
+	}
+
+	resp := &logical.Response{}
+	if !deleted {
+		resp.AddWarning("No key id found with id: " + keyId)
+	}
+	return resp, nil
+}
+
+func generateEabKey(random io.Reader) ([]byte, error) {
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), random)
+	if err != nil {
+		return nil, err
+	}
+
+	keyBytes, err := x509.MarshalECPrivateKey(ecKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return keyBytes, nil
+}

--- a/builtin/logical/pki/path_acme_eab_test.go
+++ b/builtin/logical/pki/path_acme_eab_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package pki
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestACME_EabVaultAPIs(t *testing.T) {
+	b, s := CreateBackendWithStorage(t)
+
+	var ids []string
+
+	// Generate an EAB
+	resp, err := CBWrite(b, s, "acme/eab", map[string]interface{}{})
+	requireSuccessNonNilResponse(t, resp, err, "Failed generating eab")
+	requireFieldsSetInResp(t, resp, "id", "key_type", "key_bits", "private_key", "created_on")
+	require.Equal(t, "ec", resp.Data["key_type"])
+	require.Equal(t, "256", resp.Data["key_bits"])
+	ids = append(ids, resp.Data["id"].(string))
+	_, err = uuid.ParseUUID(resp.Data["id"].(string))
+	require.NoError(t, err, "failed parsing id as a uuid")
+
+	key, err := base64.RawURLEncoding.DecodeString(resp.Data["private_key"].(string))
+	require.NoError(t, err, "failed base64 decoding private key")
+	_, err = x509.ParseECPrivateKey(key)
+	require.NoError(t, err, "failed parsing private key")
+
+	// Generate another EAB
+	resp, err = CBWrite(b, s, "acme/eab", map[string]interface{}{})
+	requireSuccessNonNilResponse(t, resp, err, "Failed generating eab")
+	ids = append(ids, resp.Data["id"].(string))
+
+	// List our EABs
+	resp, err = CBList(b, s, "acme/eab")
+	requireSuccessNonNilResponse(t, resp, err, "failed list")
+
+	require.ElementsMatch(t, ids, resp.Data["keys"])
+	keyInfo := resp.Data["key_info"].(map[string]interface{})
+	id0Map := keyInfo[ids[0]].(map[string]interface{})
+	require.Equal(t, "ec", id0Map["key_type"])
+	require.Equal(t, "256", id0Map["key_bits"])
+	require.NotEmpty(t, id0Map["created_on"])
+	_, err = time.Parse(time.RFC3339, id0Map["created_on"].(string))
+	require.NoError(t, err, "failed to parse created_on date: %s", id0Map["created_on"])
+
+	id1Map := keyInfo[ids[1]].(map[string]interface{})
+
+	require.Equal(t, "ec", id1Map["key_type"])
+	require.Equal(t, "256", id1Map["key_bits"])
+	require.NotEmpty(t, id1Map["created_on"])
+
+	// Delete an EAB
+	resp, err = CBDelete(b, s, "acme/eab/"+ids[0])
+	requireSuccessNonNilResponse(t, resp, err, "failed deleting eab identifier")
+	require.Len(t, resp.Warnings, 0, "no warnings should have been set on delete")
+
+	// Make sure it's really gone
+	resp, err = CBList(b, s, "acme/eab")
+	requireSuccessNonNilResponse(t, resp, err, "failed list post delete")
+	require.Len(t, resp.Data["keys"], 1)
+	require.Contains(t, resp.Data["keys"], ids[1])
+
+	// Delete the same EAB again, we should just get a warning but still success.
+	resp, err = CBDelete(b, s, "acme/eab/"+ids[0])
+	requireSuccessNonNilResponse(t, resp, err, "failed deleting eab identifier")
+	require.Len(t, resp.Warnings, 1, "expected a warning to be set on repeated delete call")
+}

--- a/builtin/logical/pki/path_acme_eab_test.go
+++ b/builtin/logical/pki/path_acme_eab_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestACME_EabVaultAPIs verify the various Vault auth'd APIs for EAB work as expected,
+// with creation, listing and deletions.
 func TestACME_EabVaultAPIs(t *testing.T) {
 	b, s := CreateBackendWithStorage(t)
 

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -73,6 +73,7 @@ func TestAcmeBasicWorkflow(t *testing.T) {
 			require.Equal(t, discoveryBaseUrl+"new-order", discovery.OrderURL)
 			require.Equal(t, discoveryBaseUrl+"revoke-cert", discovery.RevokeURL)
 			require.Equal(t, discoveryBaseUrl+"key-change", discovery.KeyChangeURL)
+			require.False(t, discovery.ExternalAccountRequired, "bad value for external account required in directory")
 
 			// Attempt to update prior to creating an account
 			t.Logf("Testing updates with no proper account fail on %s", baseAcmeURL)
@@ -310,6 +311,74 @@ func TestAcmeBasicWorkflow(t *testing.T) {
 	}
 }
 
+func TestAcmeBasicWorkflowWithEab(t *testing.T) {
+	t.Parallel()
+	cluster, client, _ := setupAcmeBackend(t)
+	defer cluster.Cleanup()
+	testCtx := context.Background()
+
+	// Enable EAB
+	_, err := client.Logical().WriteWithContext(context.Background(), "pki/config/acme", map[string]interface{}{
+		"enabled":     true,
+		"require_eab": true,
+	})
+	require.NoError(t, err)
+
+	baseAcmeURL := "/v1/pki/acme/"
+	accountKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err, "failed creating ec key")
+
+	acmeClient := getAcmeClientForCluster(t, cluster, baseAcmeURL, accountKey)
+
+	t.Logf("Testing discover on %s", baseAcmeURL)
+	discovery, err := acmeClient.Discover(testCtx)
+	require.NoError(t, err, "failed acme discovery call")
+	require.True(t, discovery.ExternalAccountRequired, "bad value for external account required in directory")
+
+	// Create new account without EAB, should fail
+	t.Logf("Testing register on %s", baseAcmeURL)
+	_, err = acmeClient.Register(testCtx, &acme.Account{}, func(tosURL string) bool { return true })
+	require.ErrorContains(t, err, "urn:ietf:params:acme:error:externalAccountRequired",
+		"expected failure creating an account without eab")
+
+	kid, eabKeyBytes := getEABKey(t, client)
+	acct := &acme.Account{
+		ExternalAccountBinding: &acme.ExternalAccountBinding{
+			KID: kid,
+			Key: eabKeyBytes,
+		},
+	}
+
+	// Create new account with EAB
+	t.Logf("Testing register on %s", baseAcmeURL)
+	_, err = acmeClient.Register(testCtx, acct, func(tosURL string) bool { return true })
+	require.NoError(t, err, "failed registering new account with eab")
+
+	// Make sure our EAB is no longer available
+	resp, err := client.Logical().ListWithContext(context.Background(), "pki/acme/eab")
+	require.NoError(t, err, "failed to list eab tokens")
+	require.Nil(t, resp, "list response for eab tokens should have been nil due to empty list")
+
+	// Attempt to create another account with the same EAB as before -- should fail
+	accountKey2, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err, "failed creating ec key")
+
+	acmeClient2 := getAcmeClientForCluster(t, cluster, baseAcmeURL, accountKey2)
+	acct2 := &acme.Account{
+		ExternalAccountBinding: &acme.ExternalAccountBinding{
+			KID: kid,
+			Key: eabKeyBytes,
+		},
+	}
+
+	_, err = acmeClient2.Register(testCtx, acct2, func(tosURL string) bool { return true })
+	require.ErrorContains(t, err, "urn:ietf:params:acme:error:unauthorized", "should fail due to EAB re-use")
+
+	// We can lookup/find an existing account without EAB if we have the account key
+	_, err = acmeClient.GetReg(testCtx /* unused url */, "")
+	require.NoError(t, err, "expected to lookup existing account without eab")
+}
+
 // TestAcmeNonce a basic test that will validate we get back a nonce with the proper status codes
 // based on the
 func TestAcmeNonce(t *testing.T) {
@@ -477,7 +546,8 @@ func setupAcmeBackend(t *testing.T) (*vault.TestCluster, *api.Client, string) {
 	require.NoError(t, err)
 
 	_, err = client.Logical().WriteWithContext(context.Background(), "pki/config/acme", map[string]interface{}{
-		"enabled": true,
+		"enabled":     true,
+		"require_eab": false,
 	})
 	require.NoError(t, err)
 
@@ -620,4 +690,19 @@ func getAcmeClientForCluster(t *testing.T, cluster *vault.TestCluster, baseUrl s
 		HTTPClient:   httpClient,
 		DirectoryURL: baseAcmeURL + "directory",
 	}
+}
+
+func getEABKey(t *testing.T, client *api.Client) (string, []byte) {
+	resp, err := client.Logical().WriteWithContext(ctx, "pki/acme/eab", map[string]interface{}{})
+	require.NoError(t, err, "failed getting eab key")
+	require.NotNil(t, resp, "eab key returned nil response")
+	require.NotEmpty(t, resp.Data["id"], "eab key response missing id field")
+	kid := resp.Data["id"].(string)
+
+	require.NotEmpty(t, resp.Data["private_key"], "eab key response missing private_key field")
+	base64Key := resp.Data["private_key"].(string)
+	privateKeyBytes, err := base64.RawURLEncoding.DecodeString(base64Key)
+	require.NoError(t, err, "failed base 64 decoding eab key response")
+
+	return kid, privateKeyBytes
 }

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -311,6 +311,7 @@ func TestAcmeBasicWorkflow(t *testing.T) {
 	}
 }
 
+// TestAcmeBasicWorkflowWithEab verify that new accounts require EAB's if enforced by configuration.
 func TestAcmeBasicWorkflowWithEab(t *testing.T) {
 	t.Parallel()
 	cluster, client, _ := setupAcmeBackend(t)

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -319,8 +319,8 @@ func TestAcmeBasicWorkflowWithEab(t *testing.T) {
 
 	// Enable EAB
 	_, err := client.Logical().WriteWithContext(context.Background(), "pki/config/acme", map[string]interface{}{
-		"enabled":     true,
-		"require_eab": true,
+		"enabled":    true,
+		"eab_policy": "always-required",
 	})
 	require.NoError(t, err)
 
@@ -546,8 +546,8 @@ func setupAcmeBackend(t *testing.T) (*vault.TestCluster, *api.Client, string) {
 	require.NoError(t, err)
 
 	_, err = client.Logical().WriteWithContext(context.Background(), "pki/config/acme", map[string]interface{}{
-		"enabled":     true,
-		"require_eab": false,
+		"enabled":    true,
+		"eab_policy": "not-required",
 	})
 	require.NoError(t, err)
 

--- a/builtin/logical/pki/path_config_acme.go
+++ b/builtin/logical/pki/path_config_acme.go
@@ -208,7 +208,8 @@ func (b *backend) pathAcmeWrite(ctx context.Context, req *logical.Request, d *fr
 	if eabPolicyRaw, ok := d.GetOk("eab_policy"); ok {
 		eabPolicy, err := getEabPolicyByString(eabPolicyRaw.(string))
 		if err != nil {
-			return nil, fmt.Errorf("invalid eab policy name provided")
+			return nil, fmt.Errorf("invalid eab policy name provided, valid values are '%s', '%s', '%s'",
+				eabPolicyNotRequired, eabPolicyNewAccountRequired, eabPolicyAlwaysRequired)
 		}
 		config.EabPolicyName = eabPolicy.Name
 	}

--- a/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
+++ b/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
@@ -190,7 +190,7 @@ func (vpc *VaultPkiCluster) CreateAcmeMount(mountName string) (*VaultPkiMount, e
 	}
 
 	cfg := map[string]interface{}{
-		"require_eab": false,
+		"eab_policy": "not-required",
 	}
 	if vpc.Dns != nil {
 		cfg["dns_resolver"] = vpc.Dns.GetRemoteAddr()

--- a/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
+++ b/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
@@ -189,7 +189,9 @@ func (vpc *VaultPkiCluster) CreateAcmeMount(mountName string) (*VaultPkiMount, e
 		return nil, fmt.Errorf("failed updating cluster config: %w", err)
 	}
 
-	cfg := map[string]interface{}{}
+	cfg := map[string]interface{}{
+		"require_eab": false,
+	}
 	if vpc.Dns != nil {
 		cfg["dns_resolver"] = vpc.Dns.GetRemoteAddr()
 	}


### PR DESCRIPTION
Add support for external account bindings within the PKI ACME code base. This will only verify against keys that were generated within the same PKI mount using the new authenticated Vault API `/pki/acme/eab`. The API will return a single use key to associate an ACME account with this EAB token which will prevent anonymous users from creating ACME accounts.

The following Vault PKI APIs have been added within this PR

- LIST `/pki/acme/eab` - This will list the various EAB ids generated and waiting to be used within storage. The detailed view contains details of creation time, key type and key bits
- UPDATE `/pki/acme/eab` - Generate a one-time key, returning the EAB id, private_key in base64 url encoded
- DELETE `/pki/acme/eab/{{key_id}}` - Allows an operator to delete a generated one-time key before it is used within ACME

Changes 

- ACME configuration now has a new key called `require_eab` that is enabled by default, so if someone does enable ACME support within configuration the default will be to not accept anonymous account creation unless this flag is disabled.
- Add EAB verification within the new-account code path which will validate the request against the stored key. If it accepts it, the key will be deleted from the eab storage area and associated directly to the account. 