### PR TITLE
[Backport] Update interoperability-matrix.mdx (#20501)

### DIFF
--- a/website/content/docs/interoperability-matrix.mdx
+++ b/website/content/docs/interoperability-matrix.mdx
@@ -20,13 +20,14 @@ The below table shows the partner product and if the partner’s technology work
 | ----------------- | -------------------------------------- | ------------ | -------------------- | ------------ |-------------- | --------------------------- |
 | AliCloud          | AliCloud KMS                           | Yes          | No                   | Yes          | No            | 0.11.2                      |
 | Atos              | Trustway Proteccio HSM                 | Yes          | Yes                  | Yes          | No            | 1.9                         |
-| AWS               | AWS KMS                                | Yes          | No                   | Yes          | Yes           | 0.9                         |
+| AWS               | AWS KMS                                | Yes          | Yes                  | Yes          | Yes           | 0.9                         |
 | Crypto4a          | QxEDGE™️ HSP                            | Yes          | Yes                  | Yes          | Yes           | 1.9                         |
 | Entrust           | nShield HSM                            | Yes          | Yes                  | Yes          | Yes           | 1.3                         |
 | Fortanix          | FX2200 Series                          | Yes          | Yes                  | Yes          | No            | 0.10                        |
 | FutureX           | Vectera Plus, KMES Series 3            | Yes          | Yes                  | Yes          | Yes           | 1.5                         |
 | FutureX           | VirtuCrypt cloud HSM                   | Yes          | Yes                  | Yes          | Yes           | 1.5                         |
 | Google            | GCP Cloud KMS                          | Yes          | No                   | Yes          | Yes           | 0.9                         |
+| Marvell           | Cavium HSM                             | Yes          | Yes                  | Yes          | Yes           | 1.11                        |
 | Microsoft         | Azure Key Vault                        | Yes          | No                   | Yes          | Yes           | 0.10.2                      |
 | Oracle            | OCI KMS                                | Yes          | No                   | Yes          | No            | 1.2.3                       |
 | PrimeKey          | SignServer Hardware Appliance          | Yes          | Yes                  | Yes          | No            | 1.6                         |
@@ -38,7 +39,7 @@ The below table shows the partner product and if the partner’s technology work
 | Thales            | CipherTrust Manager                    | Yes          | Yes                  | Yes          | No            | 1.7                         |
 | Utimaco           | HSM                                    | Yes          | Yes                  | Yes          | Yes           | 1.4                         |
 | Yubico            | YubiHSM 2                              | Yes          | Yes                  | Yes          | No            | 1.5                         |
-<span style={{display:'block', textAlign:'right', fontSize:'12px'}}><em>Last Updated September 29, 2022</em></span>
+<span style={{display:'block', textAlign:'right', fontSize:'12px'}}><em>Last Updated May 03, 2023</em></span>
 
 ## Vault as an External Key Management System (EKMS)
 
@@ -50,37 +51,42 @@ Partners who integrate with Vault to have Vault store and/or manage encryption k
 Vault Secrets Engine Key: K/V = <a href="/docs/secrets/kv">K/V secrets engine</a>; KMSE = <a href="/docs/secrets/key-management">Key Management Secrets Engine</a>; KMIP = <a href="/docs/secrets/kmip">KMIP Secrets Engine</a>; Transit = <a href="/docs/secrets/transit">Transit Secrets Engine</a>
 </span>
 
-| Partner           | Product                | Vault Secrets Engine | Min. Vault Version Verified | HCP Vault Verified |
-| ----------------- | ---------------------- | -------------------- | --------------------------- | ------------------- |
-| AWS               | AWS KMS                | KMSE                 | 1.8                         | Yes                 |
-| Baffle            | Shield                 | K/V                  | 1.3                         | No                  |
-| Bloombase         | StoreSafe              | KMIP                 | 1.9                         | N/A                 |
-| Cockroach Labs    | Cockroach Cloud DB     | KMSE                 | 1.10                        | N/A                 |
-| Cockroach Labs    | Cockroach DB           | Transit              | 1.10                        | Yes                 |
-| Commvault Systems | CommVault              | KMIP                 | 1.9                         | N/A                 |
-| Cribl             | Cribl Stream           | K/V                  | 1.8                         | Yes                 |
-| DataStax          | DataStax Enterprise    | KMIP                 | 1.11                        | Yes                 |
-| Dell              | PowerMax               | KMIP                 | 1.12.1                      | N/A                 |
-| Garantir          | GaraSign               | Transit              | 1.5                         | Yes                 |
-| Google            | Google KMS             | KMSE                 | 1.9                         | N/A                 |
-| HPE               | Exmeral Data Fabric    | KMIP                 | 1.2                         | N/A                 |
-| Intel             | Key Broker Service     | KMIP                 | 1.11                        | N/A                 |
-| Micro Focus       | Connected Mx           | Transit              | 1.7                         | No                  |
-| Microsoft         | Azure Key Vault        | KMSE                 | 1.6                         | N/A                 |
-| MinIO             | Key Encryption Service | K/V                  | 1.11                        | No                  |
-| MongoDB           | Atlas                  | KMSE                 | 1.6                         | N/A                 |
-| MongoDB           | MongoDB Enterprise     | KMIP                 | 1.2                         | N/A                 |
-| MongoDB           | Client Libraries       | KMIP                 | 1.9                         | N/A                 |
-| NetApp            | ONTAP                  | KMIP                 | 1.2                         | N/A                 |
-| Nutanix           | AHV/AOS 6.5.1.6        | KMIP                 | 1.12                        | N/A                 |
-| Ondat             | Trousseau              | Transit              | 1.9                         | Yes                 |
-| Percona           | Server 8.0             | KMIP                 | 1.9                         | N/A                 |
-| Percona           | XtraBackup 8.0         | KMIP                 | 1.9                         | N/A                 |
-| Snowflake         | Snowflake              | KMSE                 | 1.6                         | N/A                 |
-| VMware            | vSphere 7.0, 8.0       | KMIP                 | 1.2                         | N/A                 |
-| VMware            | vSan 7.0, 8.0          | KMIP                 | 1.2                         | N/A                 |
-| Yugabyte          | Yugabyte Platform      | Transit              | 1.9                         | No                  |
-<span style={{display:'block', textAlign:'right', fontSize:'12px'}}><em>Last Updated November 30, 2022</em></span>
+| Partner           | Product                  | Vault Secrets Engine | Min. Vault Version Verified | HCP Vault Verified |
+| ----------------- | ------------------------ | -------------------- | --------------------------- | ------------------- |
+| AWS               | AWS KMS                  | KMSE                 | 1.8                         | Yes                 |
+| Baffle            | Shield                   | K/V                  | 1.3                         | No                  |
+| Bloombase         | StoreSafe                | KMIP                 | 1.9                         | N/A                 |
+| Cloudian          | HyperStore 7.5.1         | KMIP                 | 1.12                        | N/A                 |
+| Cockroach Labs    | Cockroach Cloud DB       | KMSE                 | 1.10                        | N/A                 |
+| Cockroach Labs    | Cockroach DB             | Transit              | 1.10                        | Yes                 |
+| Commvault Systems | CommVault                | KMIP                 | 1.9                         | N/A                 |
+| Cribl             | Cribl Stream             | K/V                  | 1.8                         | Yes                 |
+| DataStax          | DataStax Enterprise      | KMIP                 | 1.11                        | Yes                 |
+| Dell              | PowerMax                 | KMIP                 | 1.12.1                      | N/A                 |
+| EnterpriseDB      | Postgres Advanced Server | KMIP                 | 1.12.6                      | N/A                 |
+| Garantir          | GaraSign                 | Transit              | 1.5                         | Yes                 |
+| Google            | Google KMS               | KMSE                 | 1.9                         | N/A                 |
+| HPE               | Exmeral Data Fabric      | KMIP                 | 1.2                         | N/A                 |
+| Intel             | Key Broker Service       | KMIP                 | 1.11                        | N/A                 |
+| JumpWire          | JumpWire                 | K/V                  | 1.12                        | Yes                 |
+| Micro Focus       | Connected Mx             | Transit              | 1.7                         | No                  |
+| Microsoft         | Azure Key Vault          | KMSE                 | 1.6                         | N/A                 |
+| MinIO             | Key Encryption Service   | K/V                  | 1.11                        | No                  |
+| MongoDB           | Atlas                    | KMSE                 | 1.6                         | N/A                 |
+| MongoDB           | MongoDB Enterprise       | KMIP                 | 1.2                         | N/A                 |
+| MongoDB           | Client Libraries         | KMIP                 | 1.9                         | N/A                 |
+| NetApp            | ONTAP                    | KMIP                 | 1.2                         | N/A                 |
+| NetApp            | StorageGrid              | KMIP                 | 1.2                         | N/A                 |
+| Nutanix           | AHV/AOS 6.5.1.6          | KMIP                 | 1.12                        | N/A                 |
+| Ondat             | Trousseau                | Transit              | 1.9                         | Yes                 |
+| Oracle            | MySQL                    | KMIP                 | 1.2                         | N/A                 |
+| Percona           | Server 8.0               | KMIP                 | 1.9                         | N/A                 |
+| Percona           | XtraBackup 8.0           | KMIP                 | 1.9                         | N/A                 |
+| Snowflake         | Snowflake                | KMSE                 | 1.6                         | N/A                 |
+| VMware            | vSphere 7.0, 8.0         | KMIP                 | 1.2                         | N/A                 |
+| VMware            | vSan 7.0, 8.0            | KMIP                 | 1.2                         | N/A                 |
+| Yugabyte          | Yugabyte Platform        | Transit              | 1.9                         | No                  |
+<span style={{display:'block', textAlign:'right', fontSize:'12px'}}><em>Last Updated May 03, 2023</em></span>
 
 Please reach out to [technologypartners@hashicorp.com](mailto:technologypartners@hashicorp.com) if there are any questions on the above tables. 
 


### PR DESCRIPTION
Automatic backport with `backport/1.12.x` label failed for https://github.com/hashicorp/vault/pull/20501. So, this PR manually cherry pick the commit made by the https://github.com/hashicorp/vault/pull/20501.

