### PR TITLE
Add a last issued date on ACME accounts

### DIFF
--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -207,9 +207,9 @@ func (aas ACMEAccountStatus) String() string {
 }
 
 const (
-	StatusValid       ACMEAccountStatus = "valid"
-	StatusDeactivated ACMEAccountStatus = "deactivated"
-	StatusRevoked     ACMEAccountStatus = "revoked"
+	AccountStatusValid       ACMEAccountStatus = "valid"
+	AccountStatusDeactivated ACMEAccountStatus = "deactivated"
+	AccountStatusRevoked     ACMEAccountStatus = "revoked"
 )
 
 type acmeAccount struct {
@@ -292,7 +292,7 @@ func (a *acmeState) CreateAccount(ac *acmeContext, c *jwsCtx, contact []string, 
 		Contact:              contact,
 		TermsOfServiceAgreed: termsOfServiceAgreed,
 		Jwk:                  c.Jwk,
-		Status:               StatusValid,
+		Status:               AccountStatusValid,
 		AcmeDirectory:        ac.acmeDirectory,
 		AccountCreatedDate:   time.Now(),
 		Eab:                  eab,

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -216,11 +216,12 @@ type acmeAccount struct {
 	KeyId                string            `json:"-"`
 	Status               ACMEAccountStatus `json:"status"`
 	Contact              []string          `json:"contact"`
-	TermsOfServiceAgreed bool              `json:"termsOfServiceAgreed"`
+	TermsOfServiceAgreed bool              `json:"terms-of-service-agreed"`
 	Jwk                  []byte            `json:"jwk"`
 	AcmeDirectory        string            `json:"acme-directory"`
-	AccountCreatedDate   time.Time         `json:"account_created_date"`
-	AccountRevokedDate   time.Time         `json:"account_revoked_date"`
+	AccountCreatedDate   time.Time         `json:"account-created-date"`
+	MaxCertExpiry        time.Time         `json:"account-max-cert-expiry"`
+	AccountRevokedDate   time.Time         `json:"account-revoked-date"`
 	Eab                  *eabType          `json:"eab"`
 }
 
@@ -596,7 +597,7 @@ type acmeCertEntry struct {
 }
 
 func (a *acmeState) TrackIssuedCert(ac *acmeContext, accountId string, serial string, orderId string) error {
-	path := acmeAccountPrefix + accountId + "/certs/" + normalizeSerial(serial)
+	path := getAcmeSerialToAccountTrackerPath(accountId, serial)
 	entry := acmeCertEntry{
 		Order: orderId,
 	}
@@ -694,6 +695,10 @@ func (a *acmeState) ListEabIds(sc *storageContext) ([]string, error) {
 	}
 
 	return ids, nil
+}
+
+func getAcmeSerialToAccountTrackerPath(accountId string, serial string) string {
+	return acmeAccountPrefix + accountId + "/certs/" + normalizeSerial(serial)
 }
 
 func getAuthorizationPath(accountId string, authId string) string {

--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -197,7 +197,7 @@ func (b *backend) acmeAccountRequiredWrapper(op acmeAccountRequiredOperation) fr
 			return nil, err
 		}
 
-		if account.Status != StatusValid {
+		if account.Status != AccountStatusValid {
 			// Treating "revoked" and "deactivated" as the same here.
 			return nil, fmt.Errorf("%w: account in status: %s", ErrUnauthorized, account.Status)
 		}

--- a/builtin/logical/pki/path_acme_order.go
+++ b/builtin/logical/pki/path_acme_order.go
@@ -285,18 +285,6 @@ func (b *backend) acmeFinalizeOrderHandler(ac *acmeContext, _ *logical.Request, 
 		return nil, fmt.Errorf("failed saving updated order: %w", err)
 	}
 
-	if account.MaxCertExpiry.Before(order.CertificateExpiry) {
-		b.acmeAccountLock.RLock() // Prevents Account Updates and Tidy Interfering
-		defer b.acmeAccountLock.RUnlock()
-
-		account.MaxCertExpiry = order.CertificateExpiry
-		if ignoreErr := b.acmeState.UpdateAccount(ac, account); ignoreErr != nil {
-			// we shouldn't fail everything if we simply fail to update the timestamp
-			// on the account, it's not a huge deal if we lose this update.
-			b.Logger().Debug("failed updating account last issued date", "error", ignoreErr.Error())
-		}
-	}
-
 	return formatOrderResponse(ac, order), nil
 }
 
@@ -898,25 +886,30 @@ func parseOrderIdentifiers(data map[string]interface{}) ([]*ACMEIdentifier, erro
 	return identifiers, nil
 }
 
-func (b *backend) acmeTidyOrder(ac *acmeContext, accountId string, orderPath string, certTidyBuffer time.Duration) (bool, error) {
+func (b *backend) acmeTidyOrder(ac *acmeContext, accountId string, orderPath string, certTidyBuffer time.Duration) (bool, time.Time, error) {
 	// First we get the order; note that the orderPath includes the account
 	// It's only accessed at acme/orders/<order_id> with the account context
 	// It's saved at acme/<account_id>/orders/<orderId>
 	entry, err := ac.sc.Storage.Get(ac.sc.Context, orderPath)
 	if err != nil {
-		return false, fmt.Errorf("error loading order: %w", err)
+		return false, time.Time{}, fmt.Errorf("error loading order: %w", err)
 	}
 	if entry == nil {
-		return false, fmt.Errorf("order does not exist: %w", ErrMalformed)
+		return false, time.Time{}, fmt.Errorf("order does not exist: %w", ErrMalformed)
 	}
 	var order acmeOrder
 	err = entry.DecodeJSON(&order)
 	if err != nil {
-		return false, fmt.Errorf("error decoding order: %w", err)
+		return false, time.Time{}, fmt.Errorf("error decoding order: %w", err)
 	}
 
 	// Determine whether we should tidy this order
 	shouldTidy := false
+
+	// Track either the order expiry or certificate expiry to return to the caller, this
+	// can be used to influence the account's expiry
+	orderExpiry := order.CertificateExpiry
+
 	// It is faster to check certificate information on the order entry rather than fetch the cert entry to parse:
 	if !order.CertificateExpiry.IsZero() {
 		// This implies that a certificate exists
@@ -930,9 +923,10 @@ func (b *backend) acmeTidyOrder(ac *acmeContext, accountId string, orderPath str
 		if time.Now().After(order.Expires) {
 			shouldTidy = true
 		}
+		orderExpiry = order.Expires
 	}
 	if shouldTidy == false {
-		return shouldTidy, nil
+		return shouldTidy, orderExpiry, nil
 	}
 
 	// Tidy this Order
@@ -943,22 +937,22 @@ func (b *backend) acmeTidyOrder(ac *acmeContext, accountId string, orderPath str
 	for _, authorizationId := range order.AuthorizationIds {
 		err = ac.sc.Storage.Delete(ac.sc.Context, getAuthorizationPath(accountId, authorizationId))
 		if err != nil {
-			return false, err
+			return false, orderExpiry, err
 		}
 	}
 
 	// Normal Tidy will Take Care of the Certificate, we need to clean up the certificate to account tracker though
 	err = ac.sc.Storage.Delete(ac.sc.Context, getAcmeSerialToAccountTrackerPath(accountId, order.CertificateSerialNumber))
 	if err != nil {
-		return false, err
+		return false, orderExpiry, err
 	}
 
 	// And Finally, the order:
 	err = ac.sc.Storage.Delete(ac.sc.Context, orderPath)
 	if err != nil {
-		return false, err
+		return false, orderExpiry, err
 	}
 	b.tidyStatusIncDelAcmeOrderCount()
 
-	return true, nil
+	return true, orderExpiry, nil
 }

--- a/builtin/logical/pki/path_acme_revoke.go
+++ b/builtin/logical/pki/path_acme_revoke.go
@@ -160,7 +160,7 @@ func (b *backend) acmeRevocationByAccount(acmeCtx *acmeContext, r *logical.Reque
 	if err != nil {
 		return nil, fmt.Errorf("failed to lookup account: %w", err)
 	}
-	if account.Status != StatusValid {
+	if account.Status != AccountStatusValid {
 		return nil, fmt.Errorf("account isn't presently valid: %w", ErrUnauthorized)
 	}
 


### PR DESCRIPTION
 - When we issue a new ACME certificate, attempt to update the account's last issued field
 - Within ACME account tidy, use both account creation and last issue date to provide a buffer before we mark the account as revoked.
 - Cleanup the cert serial to account tracker
 - Misc formatting fixes in JSON objects