### PR TITLE
Update verify-changes to support external docs branches

### DIFF
--- a/.github/scripts/verify_changes.sh
+++ b/.github/scripts/verify_changes.sh
@@ -3,15 +3,13 @@
 
 event_type=$1 # GH event type (pull_request)
 ref_name=$2 # branch reference that triggered the workflow
-head_ref=$3 # PR branch head ref
-base_ref=$4 # PR branch base ref
+base_ref=$3 # PR branch base ref
 
 changed_dir=""
 
 if [[ "$event_type" == "pull_request" ]]; then
-  git fetch --no-tags --prune origin $head_ref
   git fetch --no-tags --prune origin $base_ref
-  head_commit="origin/$head_ref"
+  head_commit="HEAD"
   base_commit="origin/$base_ref"
 else
   git fetch --no-tags --prune origin $ref_name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,14 +23,16 @@ jobs:
       is_docs_change: ${{ steps.get-changeddir.outputs.is_docs_change }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 # Use fetch depth 0 for comparing changes to base branch
       - name: Get changed directories
         id: get-changeddir
         env:
           TYPE: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
-          HEAD_REF: ${{ github.head_ref }}
           BASE: ${{ github.base_ref }}
-        run: ./.github/scripts/verify_changes.sh ${{ env.TYPE }} ${{ env.REF_NAME }} ${{ env.HEAD_REF }} ${{ env.BASE }}
+        run: ./.github/scripts/verify_changes.sh ${{ env.TYPE }} ${{ env.REF_NAME }} ${{ env.BASE }}
 
   product-metadata:
     # do not run build and test steps for docs changes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,15 @@ jobs:
 
   test:
     name: Test ${{ matrix.build-artifact-name }}
+    # Only run the Enos workflow against branches that are created from the
+    # hashicorp/vault repository. This has the effect of limiting execution of
+    # Enos scenarios to branches that originate from authors that have write
+    # access to hashicorp/vault repository. This is required as Github Actions
+    # will not populate the required secrets for branches created by outside
+    # contributors in order to protect the secrets integrity.
+    # This condition can be removed in future if enos workflow is updated to
+    # workflow_run event
+    if: "! github.event.pull_request.head.repo.fork"
     needs:
       - product-metadata
       - build-linux
@@ -207,6 +216,16 @@ jobs:
 
   test-docker-k8s:
     name: Test Docker K8s
+    # Only run the Enos workflow against branches that are created from the
+    # hashicorp/vault repository. This has the effect of limiting execution of
+    # Enos scenarios to branches that originate from authors that have write
+    # access to hashicorp/vault repository. This is required as Github Actions
+    # will not populate the required secrets for branches created by outside
+    # contributors in order to protect the secrets integrity.
+    # GHA secrets are only ready on workflow_run for public repo
+    # This condition can be removed in future if enos workflow is updated to
+    # workflow_run event
+    if: "! github.event.pull_request.head.repo.fork"
     needs:
       - product-metadata
       - build-docker


### PR DESCRIPTION
This commit updates the verify_changes script to consider forked branches.  This will allow skipping builds for docs changes  from external contributors.  Also reverts QT-545 as the secrets in public repos can only be read in workflow_run events.  