### PR TITLE
disable printing flags warning message for the ssh command (#20502)

### DIFF
--- a/changelog/20502.txt
+++ b/changelog/20502.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: disable printing flags warnings messages for the ssh command
+```

--- a/command/base.go
+++ b/command/base.go
@@ -581,14 +581,27 @@ func (f *FlagSets) Completions() complete.Flags {
 	return f.completions
 }
 
+type (
+	ParseOptions              interface{}
+	DisableDisplayFlagWarning bool
+)
+
 // Parse parses the given flags, returning any errors.
 // Warnings, if any, regarding the arguments format are sent to stdout
-func (f *FlagSets) Parse(args []string) error {
+func (f *FlagSets) Parse(args []string, opts ...ParseOptions) error {
 	err := f.mainSet.Parse(args)
 
-	warnings := generateFlagWarnings(f.Args())
-	if warnings != "" && Format(f.ui) == "table" {
-		f.ui.Warn(warnings)
+	displayFlagWarningsDisabled := false
+	for _, opt := range opts {
+		if value, ok := opt.(DisableDisplayFlagWarning); ok {
+			displayFlagWarningsDisabled = bool(value)
+		}
+	}
+	if !displayFlagWarningsDisabled {
+		warnings := generateFlagWarnings(f.Args())
+		if warnings != "" && Format(f.ui) == "table" {
+			f.ui.Warn(warnings)
+		}
 	}
 
 	return err

--- a/command/ssh.go
+++ b/command/ssh.go
@@ -238,7 +238,7 @@ type SSHCredentialResp struct {
 func (c *SSHCommand) Run(args []string) int {
 	f := c.Flags()
 
-	if err := f.Parse(args); err != nil {
+	if err := f.Parse(args, DisableDisplayFlagWarning(true)); err != nil {
 		c.UI.Error(err.Error())
 		return 1
 	}

--- a/command/ssh_test.go
+++ b/command/ssh_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/mitchellh/cli"
@@ -212,5 +213,20 @@ func TestIsSingleSSHArg(t *testing.T) {
 				t.Errorf("arg %q got %v want %v", test.arg, got, test.want)
 			}
 		})
+	}
+}
+
+// TestSSHCommandOmitFlagWarning checks if flags warning messages are printed
+// in the output of the CLI command or not. If so, it will fail.
+func TestSSHCommandOmitFlagWarning(t *testing.T) {
+	t.Parallel()
+
+	ui, cmd := testSSHCommand(t)
+
+	_ = cmd.Run([]string{"-mode", "ca", "-role", "otp_key_role", "user@1.2.3.4", "-extraFlag", "bug"})
+
+	combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+	if strings.Contains(combined, "Command flags must be provided before positional arguments. The following arguments will not be parsed as flags") {
+		t.Fatalf("ssh command displayed flag warnings")
 	}
 }


### PR DESCRIPTION
This is the backport of https://github.com/hashicorp/vault/pull/20502

* disable printing flags warning message for the ssh command

* adding a test

* CL

* add go doc on the test