### PR TITLE
openapi: A few fixes for display attributes

### DIFF
--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -1077,7 +1077,6 @@ Overrides secret_id_ttl role option when supplied. May not be longer than role's
 			Pattern: "role/" + framework.GenericNameRegex("role_name") + "/secret-id/destroy/?$",
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixAppRole,
-				OperationSuffix: "secret-id",
 				OperationVerb:   "destroy",
 			},
 			Fields: map[string]*framework.FieldSchema{
@@ -1094,6 +1093,9 @@ Overrides secret_id_ttl role option when supplied. May not be longer than role's
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback:  b.pathRoleSecretIDDestroyUpdateDelete,
 					Responses: responseNoContent,
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationSuffix: "secret-id",
+					},
 				},
 				logical.DeleteOperation: &framework.PathOperation{
 					Callback:  b.pathRoleSecretIDDestroyUpdateDelete,
@@ -1183,7 +1185,6 @@ Overrides secret_id_ttl role option when supplied. May not be longer than role's
 			Pattern: "role/" + framework.GenericNameRegex("role_name") + "/secret-id-accessor/destroy/?$",
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixAppRole,
-				OperationSuffix: "secret-id-by-accessor",
 				OperationVerb:   "destroy",
 			},
 			Fields: map[string]*framework.FieldSchema{
@@ -1200,6 +1201,9 @@ Overrides secret_id_ttl role option when supplied. May not be longer than role's
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback:  b.pathRoleSecretIDAccessorDestroyUpdateDelete,
 					Responses: responseNoContent,
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationSuffix: "secret-id-by-accessor",
+					},
 				},
 				logical.DeleteOperation: &framework.PathOperation{
 					Callback:  b.pathRoleSecretIDAccessorDestroyUpdateDelete,

--- a/builtin/credential/aws/path_role.go
+++ b/builtin/credential/aws/path_role.go
@@ -233,7 +233,7 @@ func (b *backend) pathListRoles() *framework.Path {
 
 		DisplayAttrs: &framework.DisplayAttributes{
 			OperationPrefix: operationPrefixAWS,
-			OperationSuffix: "roles2",
+			OperationSuffix: "auth-roles2",
 		},
 
 		Operations: map[logical.Operation]framework.OperationHandler{

--- a/builtin/logical/aws/path_user.go
+++ b/builtin/logical/aws/path_user.go
@@ -57,7 +57,7 @@ func pathUser(b *backend) *framework.Path {
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathCredsRead,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "credentials2|sts-credentials2",
+					OperationSuffix: "credentials-with-parameters|sts-credentials-with-parameters",
 				},
 			},
 		},

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -527,7 +527,8 @@ func oidcProviderPaths(i *IdentityStore) []*framework.Path {
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback: i.pathOIDCAuthorize,
 					DisplayAttrs: &framework.DisplayAttributes{
-						OperationVerb: "authorize2",
+						OperationVerb:   "authorize",
+						OperationSuffix: "with-parameters",
 					},
 					ForwardPerformanceStandby:   true,
 					ForwardPerformanceSecondary: false,

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -2214,7 +2214,7 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback: b.pathInternalOpenAPI,
 					DisplayAttrs: &framework.DisplayAttributes{
-						OperationSuffix: "open-api-document2",
+						OperationSuffix: "open-api-document-with-parameters",
 					},
 				},
 			},


### PR DESCRIPTION
Adding a few small fixes to the existing display attributes that control how [OpenAPI operationID's](https://swagger.io/docs/specification/paths-and-operations/#operationId) are generated. This is mostly to address the issue with `aws-generate-sts-credentials` brought up in https://github.com/hashicorp/vault-client-go/issues/158.