### PR TITLE
mysql HA - Use a same session for GET_LOCK(lock) and IS_USED_LOCK(che…

### DIFF
--- a/changelog/20551.txt
+++ b/changelog/20551.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+storage/mysql: Hold the HA lock on a dedicated session so GET_LOCK and IS_USED_LOCK share one connection, preventing the lock from being released when the server reaps the session at wait_timeout
+```

--- a/physical/mysql/mysql.go
+++ b/physical/mysql/mysql.go
@@ -192,7 +192,6 @@ func NewMySQLBackend(conf map[string]string, logger log.Logger) (physical.Backen
 	// Only prepare ha-related statements if we need them
 	if haEnabled {
 		statements["get_lock"] = "SELECT current_leader FROM " + dbLockTable + " WHERE node_job = ?"
-		statements["used_lock"] = "SELECT IS_USED_LOCK(?)"
 	}
 
 	for name, query := range statements {
@@ -593,9 +592,11 @@ func (i *MySQLHALock) Unlock() error {
 }
 
 // hasLock will check if a lock is held by checking the current lock id against our known ID.
+// The check runs on the same session that took the lock, so that polling it also keeps
+// that session from being reaped by the server. See MySQLLock.lockConn.
 func (i *MySQLHALock) hasLock(key string) error {
 	var result sql.NullInt64
-	err := i.in.statements["used_lock"].QueryRow(key).Scan(&result)
+	err := i.lock.lockConn.QueryRowContext(context.Background(), "SELECT IS_USED_LOCK(?)", key).Scan(&result)
 	if err == sql.ErrNoRows || !result.Valid {
 		// This is not an error to us since it just means the lock isn't held
 		return nil
@@ -639,6 +640,13 @@ func (i *MySQLHALock) Value() (bool, string, error) {
 type MySQLLock struct {
 	parentConn *MySQLBackend
 	in         *sql.DB
+	// lockConn is a single connection, pinned out of the pool above for the whole
+	// lifetime of the lock. MySQL releases an advisory lock as soon as the session
+	// that took it goes away, and the server reaps idle sessions once they exceed
+	// wait_timeout. Both GET_LOCK and the periodic IS_USED_LOCK check therefore have
+	// to run on this one session: reusing it for the check is what keeps the session
+	// from ever being idle long enough to be reaped.
+	lockConn   *sql.Conn
 	logger     log.Logger
 	statements map[string]*sql.Stmt
 	key        string
@@ -663,11 +671,22 @@ var (
 func NewMySQLLock(in *MySQLBackend, l log.Logger, key, value string) (*MySQLLock, error) {
 	// Create a new MySQL connection so we can close this and have no effect on
 	// the rest of the MySQL backend and any cleanup that might need to be done.
-	conn, _ := NewMySQLClient(in.conf, in.logger)
+	conn, err := NewMySQLClient(in.conf, in.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	// Pin one connection for the lock session itself. Released in Unlock.
+	lockConn, err := conn.Conn(context.Background())
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
 
 	m := &MySQLLock{
 		parentConn: in,
 		in:         conn,
+		lockConn:   lockConn,
 		logger:     l,
 		statements: make(map[string]*sql.Stmt),
 		key:        key,
@@ -716,7 +735,8 @@ func (i *MySQLLock) Lock() error {
 
 	// Lock timeout math.MaxInt32 instead of -1 solves compatibility issues with
 	// different MySQL flavours i.e. MariaDB
-	rows, err := i.in.Query("SELECT GET_LOCK(?, ?), IS_USED_LOCK(?)", i.key, math.MaxInt32, i.key)
+	rows, err := i.lockConn.QueryContext(context.Background(),
+		"SELECT GET_LOCK(?, ?), IS_USED_LOCK(?)", i.key, math.MaxInt32, i.key)
 	if err != nil {
 		return err
 	}
@@ -763,8 +783,13 @@ func (i *MySQLLock) Lock() error {
 // likely does exist. Closing the connection however ensures we don't ever get into a
 // state where we try to release the lock and it hangs it is also much less code.
 func (i *MySQLLock) Unlock() error {
+	// Release the pinned lock session first, which is what actually drops the
+	// advisory lock. database/sql allows Close to be called concurrently with a
+	// query still running on the connection, which is what the lock monitor may
+	// be doing. Both are closed unconditionally so neither can be leaked.
+	lockConnErr := i.lockConn.Close()
 	err := i.in.Close()
-	if err != nil {
+	if lockConnErr != nil || err != nil {
 		return ErrUnlockFailed
 	}
 

--- a/physical/mysql/mysql_test.go
+++ b/physical/mysql/mysql_test.go
@@ -5,6 +5,8 @@ package mysql
 
 import (
 	"bytes"
+	"database/sql"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -263,6 +265,132 @@ func TestMySQLHABackend_LockFailPanic(t *testing.T) {
 	leaderCh2, err = lock2.Lock(stopCh2)
 	if err == nil {
 		t.Fatalf("expected error, got none, leaderCh2=%v", leaderCh2)
+	}
+}
+
+// TestMySQLHABackend_LockSurvivesWaitTimeout is a regression test for
+// https://github.com/hashicorp/vault/issues/18582. GET_LOCK used to run on an
+// arbitrary connection from the pool and the IS_USED_LOCK check ran on yet another
+// one, so nothing ever kept the session holding the lock busy. Once the server reaped
+// that idle session at wait_timeout, MySQL released the advisory lock, a standby node
+// could take it over, and the active node kept believing it was still the leader.
+//
+// wait_timeout is lowered below the test's idle window but kept above the 5s lock
+// monitor interval, which is what the fix relies on to keep the lock session alive.
+func TestMySQLHABackend_LockSurvivesWaitTimeout(t *testing.T) {
+	// waitTimeout must stay above the monitorLock poll interval (5s), otherwise the
+	// lock session is legitimately idle for longer than the server tolerates.
+	const waitTimeout = 8 * time.Second
+
+	cleanup, connURL := mysqlhelper.PrepareTestContainer(t, false, "secret")
+	defer cleanup()
+
+	cfg, err := mysql.ParseDSN(connURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Reap idle sessions quickly. SET GLOBAL only affects sessions opened after this
+	// point, so it has to happen before the backends are created. The value is
+	// interpolated because MySQL rejects placeholders in SET GLOBAL statements.
+	adminDB, err := sql.Open("mysql", connURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer adminDB.Close()
+
+	var originalWaitTimeout int
+	if err := adminDB.QueryRow("SELECT @@GLOBAL.wait_timeout").Scan(&originalWaitTimeout); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := adminDB.Exec(fmt.Sprintf("SET GLOBAL wait_timeout = %d", int(waitTimeout.Seconds()))); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		adminDB.Exec(fmt.Sprintf("SET GLOBAL wait_timeout = %d", originalWaitTimeout))
+	})
+
+	logger := logging.NewVaultLogger(log.Debug)
+	config := map[string]string{
+		"address":                      cfg.Addr,
+		"database":                     cfg.DBName,
+		"table":                        "test",
+		"username":                     cfg.User,
+		"password":                     cfg.Passwd,
+		"ha_enabled":                   "true",
+		"plaintext_connection_allowed": "true",
+	}
+
+	b, err := NewMySQLBackend(config, logger)
+	if err != nil {
+		t.Fatalf("Failed to create new backend: %v", err)
+	}
+
+	defer func() {
+		mysql := b.(*MySQLBackend)
+		if _, err := mysql.client.Exec("DROP TABLE IF EXISTS " + mysql.dbTable + " ," + mysql.dbLockTable); err != nil {
+			t.Fatalf("Failed to drop table: %v", err)
+		}
+	}()
+
+	b2, err := NewMySQLBackend(config, logger)
+	if err != nil {
+		t.Fatalf("Failed to create new backend: %v", err)
+	}
+
+	lock, err := b.(physical.HABackend).LockWith("foo", "bar")
+	if err != nil {
+		t.Fatalf("initial lock: %v", err)
+	}
+
+	leaderCh, err := lock.Lock(nil)
+	if err != nil {
+		t.Fatalf("lock attempt: %v", err)
+	}
+	if leaderCh == nil {
+		t.Fatal("missing leaderCh")
+	}
+	defer lock.Unlock()
+
+	// Stay idle well past wait_timeout. Only the lock monitor's IS_USED_LOCK poll
+	// touches the lock session during this window.
+	time.Sleep(waitTimeout + 6*time.Second)
+
+	// The active node must still consider itself the leader.
+	select {
+	case <-leaderCh:
+		t.Fatal("leaderCh was closed: the lock session was lost")
+	default:
+	}
+
+	// And a standby must still be unable to take the lock over.
+	lock2, err := b2.(physical.HABackend).LockWith("foo", "baz")
+	if err != nil {
+		t.Fatalf("lock 2: %v", err)
+	}
+
+	stopCh := make(chan struct{})
+	time.AfterFunc(5*time.Second, func() {
+		close(stopCh)
+	})
+
+	leaderCh2, err := lock2.Lock(stopCh)
+	if err != nil {
+		t.Fatalf("stop lock 2: %v", err)
+	}
+	if leaderCh2 != nil {
+		t.Fatal("standby acquired the lock after wait_timeout elapsed: the lock session was reaped")
+	}
+
+	held, val, err := lock.Value()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !held {
+		t.Error("lock should still be held")
+	}
+	if val != "bar" {
+		t.Errorf("expected leader value bar, got %q", val)
 	}
 }
 


### PR DESCRIPTION
Fixes #18582

### Problem

With `storage "mysql" { ha_enabled = "true" }`, the active node loses leadership at regular intervals and the cluster keeps switching active nodes, with no error on either side.

The HA lock is a MySQL advisory lock, and MySQL drops an advisory lock the moment the session that took it goes away. Two things worked against that:

* `MySQLLock.Lock()` ran `GET_LOCK` through `i.in.Query(...)`, i.e. on whatever connection `database/sql` handed out from the lock backend's pool.
* `MySQLHALock.hasLock()`, the 5s liveness check, ran `IS_USED_LOCK` on the *main* backend's prepared statement — a different pool, so a different session.

So the session actually holding the lock issued exactly one statement and then sat idle forever. The server reaps idle sessions once they exceed [`wait_timeout`](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_wait_timeout), the advisory lock is released with it, and:

* a standby's `GET_LOCK` now succeeds, so it becomes active, while
* the original active node's `IS_USED_LOCK` returns `NULL`, which `hasLock` treats as "not an error", so it never steps down.

Two active nodes, and the flapping the issue reports.

### Fix

Pin one connection (`*sql.Conn`) for the lifetime of the lock and run both `GET_LOCK` and the periodic `IS_USED_LOCK` check on it. `monitorLock` polls every 5s, so the lock session is never idle long enough for any sane `wait_timeout` to reap it, and the liveness check now observes the same session that owns the lock.

`Unlock()` closes the pinned connection before the pool. `database/sql` documents that `Conn.Close` may be called concurrently with a running query, which is what the monitor goroutine may be doing.

One related change: `NewMySQLLock` now returns the error from `NewMySQLClient` instead of discarding it, because pinning a connection dereferences the handle immediately.

### Test

`TestMySQLHABackend_LockSurvivesWaitTimeout` lowers the server's `wait_timeout` to 8s — below the test's idle window, above the 5s monitor interval — takes the lock, idles past it, and asserts that the active node still holds the lock and that a standby cannot take it over.

Verified both ways against MySQL 8.4:

```
# on main
--- FAIL: TestMySQLHABackend_LockSurvivesWaitTimeout (14.07s)
    mysql_test.go:382: standby acquired the lock after wait_timeout elapsed: the lock session was reaped

# with this change
--- PASS: TestMySQLHABackend_LockSurvivesWaitTimeout (19.08s)
```

Existing tests still pass (`TestMySQLBackend`, `TestMySQLHABackend`, `TestMySQLPlaintextCatch`, `TestValidateDBTable`). `TestMySQLHABackend_LockFailPanic` covers the `NewMySQLLock` error path (#8203); the new error return keeps it returning an error rather than panicking.

### Scope

Only `physical/mysql`, and only the `ha_enabled = true` path. No config, schema, or API change. Non-HA MySQL storage users are unaffected.

### Follow-ups, deliberately left out of this PR

Both predate this change; happy to open separate PRs if wanted:

* `hasLock` returns `nil` when `IS_USED_LOCK` is `NULL`, so a genuinely lost lock is read as "still fine" and the node never steps down. With the lock session pinned, `NULL` unambiguously means the lock is gone and should probably close `leaderCh`.
* If `MySQLLock.Lock()` fails with `ErrLockHeld`, `attemptLock` drops the `MySQLLock` without closing its connections.
