### PR TITLE
[QT-426] Add support for enabling the file audit device for enos scenarios

### DIFF
--- a/command/test-backend/main.go
+++ b/command/test-backend/main.go
@@ -1,0 +1,1 @@
+package test_backend

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -143,13 +143,14 @@ scenario "agent" {
       config_env_vars = {
         VAULT_LOG_LEVEL = var.vault_log_level
       }
-      install_dir         = var.vault_install_dir
-      license             = matrix.edition != "oss" ? step.read_license.license : null
-      local_artifact_path = local.bundle_path
-      packages            = local.packages
-      storage_backend     = "raft"
-      target_hosts        = step.create_vault_cluster_targets.hosts
-      unseal_method       = "shamir"
+      install_dir              = var.vault_install_dir
+      license                  = matrix.edition != "oss" ? step.read_license.license : null
+      local_artifact_path      = local.bundle_path
+      packages                 = local.packages
+      storage_backend          = "raft"
+      target_hosts             = step.create_vault_cluster_targets.hosts
+      unseal_method            = "shamir"
+      enable_file_audit_device = var.vault_enable_file_audit_device
     }
   }
 

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -245,4 +245,9 @@ scenario "agent" {
     description = "The Vault cluster unseal keys hex"
     value       = step.create_vault_cluster.unseal_keys_hex
   }
+
+  output "vault_audit_device_file_path" {
+    description = "The file path for the file audit device, if enabled"
+    value       = step.create_vault_cluster.audit_device_file_path
+  }
 }

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -162,8 +162,9 @@ scenario "autopilot" {
       storage_backend_addl_config = {
         autopilot_upgrade_version = var.vault_autopilot_initial_release.version
       }
-      target_hosts  = step.create_vault_cluster_targets.hosts
-      unseal_method = matrix.seal
+      target_hosts             = step.create_vault_cluster_targets.hosts
+      unseal_method            = matrix.seal
+      enable_file_audit_device = var.vault_enable_file_audit_device
     }
   }
 

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -522,4 +522,9 @@ scenario "autopilot" {
     description = "The Vault cluster public IPs"
     value       = step.upgrade_vault_cluster_with_autopilot.public_ips
   }
+
+  output "vault_audit_device_file_path" {
+    description = "The file path for the file audit device, if enabled"
+    value       = step.create_vault_cluster.audit_device_file_path
+  }
 }

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -187,13 +187,14 @@ scenario "replication" {
         edition = var.backend_edition
         version = matrix.consul_version
       } : null
-      install_dir         = local.vault_install_dir
-      license             = matrix.edition != "oss" ? step.read_license.license : null
-      local_artifact_path = local.bundle_path
-      packages            = local.packages
-      storage_backend     = matrix.primary_backend
-      target_hosts        = step.create_primary_cluster_targets.hosts
-      unseal_method       = matrix.primary_seal
+      install_dir              = local.vault_install_dir
+      license                  = matrix.edition != "oss" ? step.read_license.license : null
+      local_artifact_path      = local.bundle_path
+      packages                 = local.packages
+      storage_backend          = matrix.primary_backend
+      target_hosts             = step.create_primary_cluster_targets.hosts
+      unseal_method            = matrix.primary_seal
+      enable_file_audit_device = var.vault_enable_file_audit_device
     }
   }
 
@@ -260,13 +261,14 @@ scenario "replication" {
         edition = var.backend_edition
         version = matrix.consul_version
       } : null
-      install_dir         = local.vault_install_dir
-      license             = matrix.edition != "oss" ? step.read_license.license : null
-      local_artifact_path = local.bundle_path
-      packages            = local.packages
-      storage_backend     = matrix.secondary_backend
-      target_hosts        = step.create_secondary_cluster_targets.hosts
-      unseal_method       = matrix.secondary_seal
+      install_dir              = local.vault_install_dir
+      license                  = matrix.edition != "oss" ? step.read_license.license : null
+      local_artifact_path      = local.bundle_path
+      packages                 = local.packages
+      storage_backend          = matrix.secondary_backend
+      target_hosts             = step.create_secondary_cluster_targets.hosts
+      unseal_method            = matrix.secondary_seal
+      enable_file_audit_device = var.vault_enable_file_audit_device
     }
   }
 

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -737,6 +737,6 @@ scenario "replication" {
 
   output "vault_audit_device_file_path" {
     description = "The file path for the file audit device, if enabled"
-    value       = step.create_vault_cluster.audit_device_file_path
+    value       = step.create_primary_cluster.audit_device_file_path
   }
 }

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -734,4 +734,9 @@ scenario "replication" {
     description = "The Vault updated secondary cluster primaries connection status"
     value       = step.verify_updated_performance_replication.secondary_replication_data_primaries
   }
+
+  output "vault_audit_device_file_path" {
+    description = "The file path for the file audit device, if enabled"
+    value       = step.create_vault_cluster.audit_device_file_path
+  }
 }

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -190,13 +190,14 @@ scenario "smoke" {
         edition = var.backend_edition
         version = matrix.consul_version
       } : null
-      install_dir         = local.vault_install_dir
-      license             = matrix.edition != "oss" ? step.read_license.license : null
-      local_artifact_path = local.bundle_path
-      packages            = local.packages
-      storage_backend     = matrix.backend
-      target_hosts        = step.create_vault_cluster_targets.hosts
-      unseal_method       = matrix.seal
+      install_dir              = local.vault_install_dir
+      license                  = matrix.edition != "oss" ? step.read_license.license : null
+      local_artifact_path      = local.bundle_path
+      packages                 = local.packages
+      storage_backend          = matrix.backend
+      target_hosts             = step.create_vault_cluster_targets.hosts
+      unseal_method            = matrix.seal
+      enable_file_audit_device = var.vault_enable_file_audit_device
     }
   }
 
@@ -383,5 +384,10 @@ scenario "smoke" {
   output "unseal_keys_hex" {
     description = "The Vault cluster unseal keys hex"
     value       = step.create_vault_cluster.unseal_keys_hex
+  }
+
+  output "vault_audit_device_file_path" {
+    description = "The file path for the file audit device, if enabled"
+    value       = step.create_vault_cluster.audit_device_file_path
   }
 }

--- a/enos/enos-scenario-ui.hcl
+++ b/enos/enos-scenario-ui.hcl
@@ -153,12 +153,13 @@ scenario "ui" {
         edition = var.backend_edition
         version = local.consul_version
       } : null
-      install_dir         = local.vault_install_dir
-      license             = matrix.edition != "oss" ? step.read_license.license : null
-      local_artifact_path = local.bundle_path
-      storage_backend     = matrix.backend
-      target_hosts        = step.create_vault_cluster_targets.hosts
-      unseal_method       = local.seal
+      install_dir              = local.vault_install_dir
+      license                  = matrix.edition != "oss" ? step.read_license.license : null
+      local_artifact_path      = local.bundle_path
+      storage_backend          = matrix.backend
+      target_hosts             = step.create_vault_cluster_targets.hosts
+      unseal_method            = local.seal
+      enable_file_audit_device = var.vault_enable_file_audit_device
     }
   }
 

--- a/enos/enos-scenario-ui.hcl
+++ b/enos/enos-scenario-ui.hcl
@@ -244,4 +244,9 @@ scenario "ui" {
     description = "The stdout of the ui tests that ran"
     value       = step.test_ui.ui_test_stdout
   }
+
+  output "vault_audit_device_file_path" {
+    description = "The file path for the file audit device, if enabled"
+    value       = step.create_vault_cluster.audit_device_file_path
+  }
 }

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -184,13 +184,14 @@ scenario "upgrade" {
         edition = var.backend_edition
         version = matrix.consul_version
       } : null
-      install_dir     = local.vault_install_dir
-      license         = matrix.edition != "oss" ? step.read_license.license : null
-      packages        = local.packages
-      release         = var.vault_upgrade_initial_release
-      storage_backend = matrix.backend
-      target_hosts    = step.create_vault_cluster_targets.hosts
-      unseal_method   = matrix.seal
+      install_dir              = local.vault_install_dir
+      license                  = matrix.edition != "oss" ? step.read_license.license : null
+      packages                 = local.packages
+      release                  = var.vault_upgrade_initial_release
+      storage_backend          = matrix.backend
+      target_hosts             = step.create_vault_cluster_targets.hosts
+      unseal_method            = matrix.seal
+      enable_file_audit_device = var.vault_enable_file_audit_device
     }
   }
 

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -402,4 +402,9 @@ scenario "upgrade" {
     description = "The Vault cluster unseal keys hex"
     value       = step.create_vault_cluster.unseal_keys_hex
   }
+
+  output "vault_audit_device_file_path" {
+    description = "The file path for the file audit device, if enabled"
+    value       = step.create_vault_cluster.audit_device_file_path
+  }
 }

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -200,3 +200,9 @@ variable "ui_run_tests" {
   description = "Whether to run the UI tests or not. If set to false a cluster will be created but no tests will be run"
   default     = true
 }
+
+variable "vault_enable_file_audit_device" {
+  description = "If true the file audit device will be enabled at the path /var/log/vault/vault_audit.log"
+  type        = bool
+  default     = true
+}

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -202,7 +202,7 @@ variable "ui_run_tests" {
 }
 
 variable "vault_enable_file_audit_device" {
-  description = "If true the file audit device will be enabled at the path /var/log/vault/vault_audit.log"
+  description = "If true the file audit device will be enabled at the path /var/log/vault_audit.log"
   type        = bool
   default     = true
 }

--- a/enos/modules/build_local/main.tf
+++ b/enos/modules/build_local/main.tf
@@ -61,7 +61,7 @@ variable "product_version" {
 }
 
 resource "enos_local_exec" "build" {
-  scripts = ["${path.module}/scripts/build.sh"]
+  scripts = [abspath("${path.module}/scripts/build.sh")]
 
   environment = {
     BUNDLE_PATH = var.bundle_path,

--- a/enos/modules/get_local_metadata/main.tf
+++ b/enos/modules/get_local_metadata/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 resource "enos_local_exec" "get_build_date" {
-  scripts = ["${path.module}/scripts/build_date.sh"]
+  scripts = [abspath("${path.module}/scripts/build_date.sh")]
 }
 
 output "build_date" {
@@ -18,7 +18,7 @@ output "build_date" {
 }
 
 resource "enos_local_exec" "get_version" {
-  scripts = ["${path.module}/scripts/version.sh"]
+  scripts = [abspath("${path.module}/scripts/version.sh")]
 }
 
 output "version" {

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -61,7 +61,7 @@ locals {
       path    = "vault"
     })
   ]
-  audit_device_file_path = "/var/log/vault/vault_audit.log"
+  audit_device_file_path = "/var/log/vault_audit.log" # do not change this, SELinux causes issues with files created in other directories
   vault_service_user     = "vault"
 }
 

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -62,6 +62,7 @@ locals {
     })
   ]
   audit_device_file_path = "/var/log/vault/vault_audit.log"
+  vault_service_user     = "vault"
 }
 
 resource "enos_remote_exec" "install_packages" {
@@ -166,7 +167,7 @@ resource "enos_vault_start" "leader" {
   }
   license        = var.license
   manage_service = var.manage_service
-  username       = "vault"
+  username       = local.vault_service_user
   unit_name      = "vault"
 
   transport = {
@@ -205,7 +206,7 @@ resource "enos_vault_start" "followers" {
   }
   license        = var.license
   manage_service = var.manage_service
-  username       = "vault"
+  username       = local.vault_service_user
   unit_name      = "vault"
 
   transport = {
@@ -273,6 +274,7 @@ resource "enos_remote_exec" "enable_file_audit_device" {
     VAULT_ADDR     = "http://127.0.0.1:8200"
     VAULT_BIN_PATH = local.bin_path
     LOG_FILE_PATH  = local.audit_device_file_path
+    SERVICE_USER   = local.vault_service_user
   }
 
   scripts = [abspath("${path.module}/scripts/enable_audit_logging.sh")]

--- a/enos/modules/vault_cluster/outputs.tf
+++ b/enos/modules/vault_cluster/outputs.tf
@@ -53,3 +53,8 @@ output "cluster_name" {
   description = "The Vault cluster name"
   value       = var.cluster_name
 }
+
+output "audit_device_file_path" {
+  description = "The file path for the audit device, if enabled"
+  value       = var.enable_file_audit_device ? local.audit_device_file_path : "file audit device not enabled"
+}

--- a/enos/modules/vault_cluster/scripts/create_audit_log_dir.sh
+++ b/enos/modules/vault_cluster/scripts/create_audit_log_dir.sh
@@ -1,0 +1,8 @@
+#!/bin/env sh
+
+set -eux
+
+LOG_DIR=$(dirname "$LOG_FILE_PATH")
+
+sudo mkdir -p "$LOG_DIR"
+sudo chown "$SERVICE_USER":"$SERVICE_USER" "$LOG_DIR"

--- a/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
+++ b/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
@@ -1,0 +1,10 @@
+#!/bin/env sh
+
+set -eux
+
+LOG_DIR=$(dirname "$LOG_FILE_PATH")
+
+sudo mkdir -p "$LOG_DIR"
+sudo chown vault:vault "$LOG_DIR"
+
+"$VAULT_BIN_PATH" audit enable file file_path="$LOG_FILE_PATH"

--- a/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
+++ b/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
@@ -5,6 +5,6 @@ set -eux
 LOG_DIR=$(dirname "$LOG_FILE_PATH")
 
 sudo mkdir -p "$LOG_DIR"
-sudo chown vault:vault "$LOG_DIR"
+sudo chown "$SERVICE_USER":"$SERVICE_USER" "$LOG_DIR"
 
 "$VAULT_BIN_PATH" audit enable file file_path="$LOG_FILE_PATH"

--- a/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
+++ b/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
@@ -4,7 +4,17 @@ set -eux
 
 LOG_DIR=$(dirname "$LOG_FILE_PATH")
 
-sudo mkdir -p "$LOG_DIR"
-sudo chown "$SERVICE_USER":"$SERVICE_USER" "$LOG_DIR"
+# setup dir
+if [ ! -d "$LOG_DIR" ]
+then
+  sudo mkdir -p "$LOG_DIR"
+  sudo chmod 600 "$LOG_DIR"
+  sudo chown "$SERVICE_USER":"$SERVICE_USER" "$LOG_DIR"
+fi
 
-"$VAULT_BIN_PATH" audit enable file file_path="$LOG_FILE_PATH"
+# create log file
+sudo touch "$LOG_FILE_PATH"
+sudo chmod 600 "$LOG_FILE_PATH"
+sudo chown "$SERVICE_USER":"$SERVICE_USER" "$LOG_FILE_PATH"
+
+sudo su vault -c "VAULT_TOKEN=$VAULT_TOKEN VAULT_ADDR=$VAULT_ADDR $VAULT_BIN_PATH audit enable file file_path=$LOG_FILE_PATH"

--- a/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
+++ b/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
@@ -2,21 +2,4 @@
 
 set -eux
 
-LOG_DIR=$(dirname "$LOG_FILE_PATH")
-FILE_NAME=$(basename "$LOG_FILE_PATH")
-
-# setup dir
-if [ ! -d "$LOG_DIR" ]
-then
-  sudo mkdir -p "$LOG_DIR"
-  sudo chmod 600 "$LOG_DIR"
-  sudo chown "$SERVICE_USER":"$SERVICE_USER" "$LOG_DIR"
-fi
-
-# create log file
-sudo touch /tmp/"$FILE_NAME"
-sudo mv /tmp/"$FILE_NAME" "$LOG_FILE_PATH"
-sudo chmod 600 "$LOG_FILE_PATH"
-sudo chown "$SERVICE_USER":"$SERVICE_USER" "$LOG_FILE_PATH"
-
-sudo su vault -c "VAULT_TOKEN=$VAULT_TOKEN VAULT_ADDR=$VAULT_ADDR $VAULT_BIN_PATH audit enable file file_path=$LOG_FILE_PATH"
+sudo su "$SERVICE_USER" -c "VAULT_TOKEN=$VAULT_TOKEN VAULT_ADDR=$VAULT_ADDR $VAULT_BIN_PATH audit enable file file_path=$LOG_FILE_PATH"

--- a/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
+++ b/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
@@ -3,6 +3,7 @@
 set -eux
 
 LOG_DIR=$(dirname "$LOG_FILE_PATH")
+FILE_NAME=$(basename "$LOG_FILE_PATH")
 
 # setup dir
 if [ ! -d "$LOG_DIR" ]
@@ -13,7 +14,8 @@ then
 fi
 
 # create log file
-sudo touch "$LOG_FILE_PATH"
+sudo touch /tmp/"$FILE_NAME"
+sudo mv /tmp/"$FILE_NAME" "$LOG_FILE_PATH"
 sudo chmod 600 "$LOG_FILE_PATH"
 sudo chown "$SERVICE_USER":"$SERVICE_USER" "$LOG_FILE_PATH"
 

--- a/enos/modules/vault_cluster/variables.tf
+++ b/enos/modules/vault_cluster/variables.tf
@@ -174,3 +174,9 @@ variable "unseal_method" {
     error_message = "The unseal_method must be either awskms or shamir. No other unseal methods are supported."
   }
 }
+
+variable "enable_file_audit_device" {
+  description = "If true the file audit device will be enabled at the path /var/log/vault/vault_audit.log"
+  type        = bool
+  default     = false
+}

--- a/enos/modules/vault_cluster/variables.tf
+++ b/enos/modules/vault_cluster/variables.tf
@@ -178,5 +178,5 @@ variable "unseal_method" {
 variable "enable_file_audit_device" {
   description = "If true the file audit device will be enabled at the path /var/log/vault/vault_audit.log"
   type        = bool
-  default     = false
+  default     = true
 }

--- a/enos/modules/vault_cluster/variables.tf
+++ b/enos/modules/vault_cluster/variables.tf
@@ -176,7 +176,7 @@ variable "unseal_method" {
 }
 
 variable "enable_file_audit_device" {
-  description = "If true the file audit device will be enabled at the path /var/log/vault/vault_audit.log"
+  description = "If true the file audit device will be enabled at the path /var/log/vault_audit.log"
   type        = bool
   default     = true
 }

--- a/enos/modules/vault_get_cluster_ips/main.tf
+++ b/enos/modules/vault_get_cluster_ips/main.tf
@@ -77,7 +77,7 @@ resource "enos_remote_exec" "get_leader_private_ip" {
     VAULT_INSTANCE_PRIVATE_IPS = jsonencode(local.instance_private_ips)
   }
 
-  scripts = ["${path.module}/scripts/get-leader-private-ip.sh"]
+  scripts = [abspath("${path.module}/scripts/get-leader-private-ip.sh")]
 
   transport = {
     ssh = {

--- a/enos/modules/vault_setup_perf_primary/main.tf
+++ b/enos/modules/vault_setup_perf_primary/main.tf
@@ -42,7 +42,7 @@ resource "enos_remote_exec" "configure_pr_primary" {
     vault_install_dir = var.vault_install_dir
   }
 
-  scripts = ["${path.module}/scripts/configure-vault-pr-primary.sh"]
+  scripts = [abspath("${path.module}/scripts/configure-vault-pr-primary.sh")]
 
   transport = {
     ssh = {

--- a/enos/modules/vault_unseal_nodes/main.tf
+++ b/enos/modules/vault_unseal_nodes/main.tf
@@ -48,7 +48,7 @@ resource "enos_remote_exec" "wait_until_sealed" {
     VAULT_INSTALL_DIR = var.vault_install_dir
   }
 
-  scripts = ["${path.module}/scripts/wait-until-sealed.sh"]
+  scripts = [abspath("${path.module}/scripts/wait-until-sealed.sh")]
 
   transport = {
     ssh = {
@@ -92,7 +92,7 @@ resource "enos_remote_exec" "unseal_followers" {
     UNSEAL_KEYS       = join(",", var.vault_unseal_keys)
   }
 
-  scripts = ["${path.module}/scripts/unseal-node.sh"]
+  scripts = [abspath("${path.module}/scripts/unseal-node.sh")]
 
   transport = {
     ssh = {
@@ -117,7 +117,7 @@ resource "enos_remote_exec" "unseal_followers_again" {
     UNSEAL_KEYS       = join(",", var.vault_unseal_keys)
   }
 
-  scripts = ["${path.module}/scripts/unseal-node.sh"]
+  scripts = [abspath("${path.module}/scripts/unseal-node.sh")]
 
   transport = {
     ssh = {

--- a/enos/modules/vault_verify_performance_replication/main.tf
+++ b/enos/modules/vault_verify_performance_replication/main.tf
@@ -59,7 +59,7 @@ resource "enos_remote_exec" "verify_replication_status_on_primary" {
     SECONDARY_LEADER_PRIV_IP = var.secondary_leader_private_ip
   }
 
-  scripts = ["${path.module}/scripts/verify-replication-status.sh"]
+  scripts = [abspath("${path.module}/scripts/verify-replication-status.sh")]
 
   transport = {
     ssh = {
@@ -76,7 +76,7 @@ resource "enos_remote_exec" "verify_replication_status_on_secondary" {
     SECONDARY_LEADER_PRIV_IP = var.secondary_leader_private_ip
   }
 
-  scripts = ["${path.module}/scripts/verify-replication-status.sh"]
+  scripts = [abspath("${path.module}/scripts/verify-replication-status.sh")]
 
   transport = {
     ssh = {

--- a/enos/modules/vault_verify_read_data/main.tf
+++ b/enos/modules/vault_verify_read_data/main.tf
@@ -38,7 +38,7 @@ resource "enos_remote_exec" "verify_kv_on_node" {
     VAULT_INSTALL_DIR = var.vault_install_dir
   }
 
-  scripts = ["${path.module}/scripts/verify-data.sh"]
+  scripts = [abspath("${path.module}/scripts/verify-data.sh")]
 
   transport = {
     ssh = {

--- a/enos/modules/vault_verify_write_data/main.tf
+++ b/enos/modules/vault_verify_write_data/main.tf
@@ -63,7 +63,7 @@ resource "enos_remote_exec" "smoke-enable-secrets-kv" {
     VAULT_INSTALL_DIR = var.vault_install_dir
   }
 
-  scripts = ["${path.module}/scripts/smoke-enable-secrets-kv.sh"]
+  scripts = [abspath("${path.module}/scripts/smoke-enable-secrets-kv.sh")]
 
   transport = {
     ssh = {
@@ -85,7 +85,7 @@ resource "enos_remote_exec" "smoke-write-test-data" {
     TEST_VALUE        = "fire"
   }
 
-  scripts = ["${path.module}/scripts/smoke-write-test-data.sh"]
+  scripts = [abspath("${path.module}/scripts/smoke-write-test-data.sh")]
 
   transport = {
     ssh = {


### PR DESCRIPTION
- Updated the `vault_cluster` enos module to add support for enabling the file audit device. 
- Updated the all scenarios to add support for enabling the file audit device.