### PR TITLE
command/server: add VAULT_CLUSTER_NAME environment variable support

### DIFF
--- a/changelog/20564.txt
+++ b/changelog/20564.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+command/server: add VAULT_CLUSTER_NAME environment variable support
+```

--- a/command/server.go
+++ b/command/server.go
@@ -1106,7 +1106,7 @@ func (c *ServerCommand) Run(args []string) int {
 
 	logProxyEnvironmentVariables(c.logger)
 
-   	if clusterName := os.Getenv("VAULT_CLUSTER_NAME"); clusterName != "" {
+	if clusterName := os.Getenv("VAULT_CLUSTER_NAME"); clusterName != "" {
 		var err error
 		config.ClusterName = clusterName
 		if err != nil {

--- a/command/server.go
+++ b/command/server.go
@@ -1106,6 +1106,15 @@ func (c *ServerCommand) Run(args []string) int {
 
 	logProxyEnvironmentVariables(c.logger)
 
+   	if clusterName := os.Getenv("VAULT_CLUSTER_NAME"); clusterName != "" {
+		var err error
+		config.ClusterName = clusterName
+		if err != nil {
+			c.UI.Output("Error parsing the environment variable VAULT_CLUSTER_NAME")
+			return 1
+		}
+	}
+
 	if envMlock := os.Getenv("VAULT_DISABLE_MLOCK"); envMlock != "" {
 		var err error
 		config.DisableMlock, err = strconv.ParseBool(envMlock)

--- a/command/server.go
+++ b/command/server.go
@@ -1107,12 +1107,7 @@ func (c *ServerCommand) Run(args []string) int {
 	logProxyEnvironmentVariables(c.logger)
 
 	if clusterName := os.Getenv("VAULT_CLUSTER_NAME"); clusterName != "" {
-		var err error
 		config.ClusterName = clusterName
-		if err != nil {
-			c.UI.Output("Error parsing the environment variable VAULT_CLUSTER_NAME")
-			return 1
-		}
 	}
 
 	if envMlock := os.Getenv("VAULT_DISABLE_MLOCK"); envMlock != "" {

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -74,7 +74,8 @@ to specify where the configuration is.
 
 - `cluster_name` `(string: <generated>)` – Specifies the identifier for the
   Vault cluster. If omitted, Vault will generate a value. When connecting to
-  Vault Enterprise, this value will be used in the interface.
+  Vault Enterprise, this value will be used in the interface. This can also be 
+  provided via the environment variable `VAULT_CLUSTER_NAME`.
 
 - `cache_size` `(string: "131072")` – Specifies the size of the read cache used
   by the physical storage subsystem. The value is in number of entries, so the


### PR DESCRIPTION
This adds a new environment variable `VAULT_CLUSTER_NAME` support for the [cluster_name](https://developer.hashicorp.com/vault/docs/configuration#cluster_name) configurable. This makes it easier to configure the `cluster_name` in our Vault Helm project. 

If the leader changes without `cluster_name` configured, the new leader will call [NewClusterMetricSink](https://github.com/hashicorp/vault/blob/main/helper/metricsutil/wrapped_metrics.go#L124-L132) and cluster name will be empty for some time. If you're parsing telemetry this will lead to noise in the data:

```
vault_core_replication_dr_primary{cluster="",host="vault-1"} 0
vault_core_replication_dr_primary{cluster="vault-cluster-c24ee36f",host="vault-1"} 0
```