### PR TITLE
Fixed a typo in the "Environment Variable Example"

### DIFF
--- a/website/content/docs/platform/k8s/injector/examples.mdx
+++ b/website/content/docs/platform/k8s/injector/examples.mdx
@@ -276,7 +276,7 @@ spec:
         vault.hashicorp.com/agent-inject-secret-config: 'secret/data/web'
         # Environment variable export template
         vault.hashicorp.com/agent-inject-template-config: |
-          {{ with secret "secret/data/web" -}}
+          {{- with secret "secret/data/web" -}}
             export api_key="{{ .Data.data.payments_api_key }}"
           {{- end }}
     spec:


### PR DESCRIPTION
Fixed a typo in the "Environment Variable Example" because it was generating a parsing error:

template server error: error="(dynamic): execute: template: :2:30: executing \"\" at <.Data.data.payments_api_key>: can't evaluate field data in type *dependency.Secret"](template.server: template server error: error="(dynamic): parse: template: :1: bad character U+002F '/'"

EDIT: I'm sorry I put the wrong error in the commit message...