### PR TITLE
Added a note to remove-peer

### DIFF
--- a/website/content/docs/commands/operator/raft.mdx
+++ b/website/content/docs/commands/operator/raft.mdx
@@ -144,6 +144,10 @@ Usage: vault operator raft remove-peer <server_id>
 	  $ vault operator raft remove-peer node1
 ```
 
+<Note>
+  Once a node is removed, its Raft data needs to be removed before it may be rejoined or re-added back into a cluster. This requires a restart of the Vault process on the removed node.
+</Note>
+
 ## snapshot
 
 This command groups subcommands for operators interacting with the snapshot

--- a/website/content/docs/commands/operator/raft.mdx
+++ b/website/content/docs/commands/operator/raft.mdx
@@ -145,7 +145,7 @@ Usage: vault operator raft remove-peer <server_id>
 ```
 
 <Note>
-  Once a node is removed, its Raft data needs to be removed before it may be rejoined or re-added back into a cluster. This requires a restart of the Vault process on the removed node.
+  Once a node is removed, its Raft data needs to be deleted before it may be joined back into an existing cluster. This requires shutting down the Vault process, deleting the data, then restarting the Vault process on the removed node.
 </Note>
 
 ## snapshot


### PR DESCRIPTION
Added a note to the`remove-peer` section stating that the Raft data needs to be removed after a remove and prior to adding the node back to a cluster.
