### PR TITLE
Add note related to `cluster_name` being autogenerated in Kubernetes environments

### DIFF
--- a/changelog/20588.txt
+++ b/changelog/20588.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-Add note about a possible issue that might occur when using Kubernetes and Vault with `cluster_name` undeclared. VAULT-15467
-```


### PR DESCRIPTION
A specific issue might happen when using Vault with Kubernetes, leaving the cluster_name empty and querying Prometheus style telemetry can yield an empty named cluster in addition to the generated one. To fix this, the cluster_name must be set explicitly.