### PR TITLE
Remove fullhd var

### DIFF
--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -34,8 +34,6 @@ $radius-large: 4px;
 $mobile: 769px;
 // 960px container + 4rem
 $desktop: 960px + (2 * 32px);
-// 1344px container + 4rem
-$fullhd: 1344px + (2 * 32px);
 
 /* Animations and transitions */
 $speed: 150ms;


### PR DESCRIPTION
The only use case of this var was removed in the sidebar navigation work. This is a follow up task to remove it once that sidebranch was merged.

