### PR TITLE
openapi: Fix ACME-related errors

### DIFF
--- a/builtin/logical/pki/path_acme_account.go
+++ b/builtin/logical/pki/path_acme_account.go
@@ -36,13 +36,6 @@ func addFieldsForACMEPath(fields map[string]*framework.FieldSchema, pattern stri
 			Required:    true,
 		}
 	}
-	if strings.Contains(pattern, uuidNameRegex("kid")) {
-		fields["kid"] = &framework.FieldSchema{
-			Type:        framework.TypeString,
-			Description: `The key identifier provided by the CA`,
-			Required:    true,
-		}
-	}
 	if strings.Contains(pattern, framework.GenericNameRegex(issuerRefParam)) {
 		fields[issuerRefParam] = &framework.FieldSchema{
 			Type:        framework.TypeString,
@@ -77,7 +70,7 @@ func addFieldsForACMERequest(fields map[string]*framework.FieldSchema) map[strin
 }
 
 func addFieldsForACMEKidRequest(fields map[string]*framework.FieldSchema, pattern string) map[string]*framework.FieldSchema {
-	if strings.Contains(pattern, framework.GenericNameRegex("kid")) {
+	if strings.Contains(pattern, uuidNameRegex("kid")) {
 		fields["kid"] = &framework.FieldSchema{
 			Type:        framework.TypeString,
 			Description: `The key identifier provided by the CA`,

--- a/builtin/logical/pki/path_acme_account.go
+++ b/builtin/logical/pki/path_acme_account.go
@@ -36,6 +36,13 @@ func addFieldsForACMEPath(fields map[string]*framework.FieldSchema, pattern stri
 			Required:    true,
 		}
 	}
+	if strings.Contains(pattern, uuidNameRegex("kid")) {
+		fields["kid"] = &framework.FieldSchema{
+			Type:        framework.TypeString,
+			Description: `The key identifier provided by the CA`,
+			Required:    true,
+		}
+	}
 	if strings.Contains(pattern, framework.GenericNameRegex(issuerRefParam)) {
 		fields[issuerRefParam] = &framework.FieldSchema{
 			Type:        framework.TypeString,

--- a/builtin/logical/pki/path_config_acme.go
+++ b/builtin/logical/pki/path_config_acme.go
@@ -84,12 +84,12 @@ func pathAcmeConfig(b *backend) *framework.Path {
 			"allowed_issuers": {
 				Type:        framework.TypeCommaStringSlice,
 				Description: `which issuers are allowed for use with ACME; by default, this will only be the primary (default) issuer`,
-				Default:     "*",
+				Default:     []string{"*"},
 			},
 			"allowed_roles": {
 				Type:        framework.TypeCommaStringSlice,
 				Description: `which roles are allowed for use with ACME; by default via '*', these will be all roles including sign-verbatim; when concrete role names are specified, sign-verbatim is not allowed and a default_role must be specified in order to allow usage of the default acme directories under /pki/acme/directory and /pki/issuer/:issuer_id/acme/directory.`,
-				Default:     "*",
+				Default:     []string{"*"},
 			},
 			"default_role": {
 				Type:        framework.TypeString,


### PR DESCRIPTION
There are a few validation errors related to the new ACME endpoints in the generated OpenAPI spec:

```sh
$  openapi-generator validate -i scripts/openapi.json 
...
        - paths.'/{pki_mount_path}/acme/account/{kid}'. Declared path parameter kid needs to be
          defined as a path parameter in path or operation level
...
        - attribute components.schemas.PkiConfigureAcmeRequest.default is not of type `array`
```

This PR adds a `kid` parameter:

```diff
    "/{pki_mount_path}/acme/account/{kid}": {
      "description": "Query a certificate's revocation status through OCSP'",
      "parameters": [
+        {
+          "name": "kid",
+          "description": "The key identifier provided by the CA",
+          "in": "path",
+          "schema": {
+            "type": "string"
+          },
+          "required": true
+        },
```

... and fixes the default values:

```diff
      "PkiConfigureAcmeRequest": {
        "type": "object",
        "properties": {
          "allowed_issuers": {
             "type": "array",
-            "default": "*"
+            "default": [
+              "*"
+            ]
```
