### PR TITLE
MFA Create Enforcement Bug

### DIFF
--- a/changelog/20603.txt
+++ b/changelog/20603.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes issue creating mfa login enforcement from method enforcements tab
+```

--- a/ui/app/templates/vault/cluster/access/mfa/methods/method/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/method/index.hbs
@@ -78,7 +78,7 @@
 {{else if (eq this.tab "enforcements")}}
   <Toolbar>
     <ToolbarActions>
-      <ToolbarLink @type="add" @params={{array "vault.cluster.access.mfa.enforcements.create"}}>
+      <ToolbarLink @route="vault.cluster.access.mfa.enforcements.create" @type="add" data-test-enforcement-create>
         New enforcement
       </ToolbarLink>
     </ToolbarActions>

--- a/ui/tests/acceptance/mfa-method-test.js
+++ b/ui/tests/acceptance/mfa-method-test.js
@@ -294,4 +294,16 @@ module('Acceptance | mfa-method', function (hooks) {
       .dom('[data-test-row-value="Max validation attempts"]')
       .hasText('10', 'Max validation attempts field is updated');
   });
+
+  test('it should navigate to enforcements create route from method enforcement tab', async function (assert) {
+    await visit('/vault/access/mfa/methods');
+    await click('[data-test-mfa-method-list-item]');
+    await click('[data-test-tab="enforcements"]');
+    await click('[data-test-enforcement-create]');
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.access.mfa.enforcements.create',
+      'Navigates to enforcements create route from toolbar action'
+    );
+  });
 });


### PR DESCRIPTION
The toolbar action for creating a new enforcement from the mfa method enforcements tab was broken and did not transition to the enforcements create route. This PR fixes that link and adds a test.