### PR TITLE
Yarn start cleanup

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -22,7 +22,7 @@
     "fmt:js": "prettier --config .prettierrc.js --write '{app,tests,config,lib}/**/*.js'",
     "fmt:hbs": "prettier --config .prettierrc.js --write '**/*.hbs'",
     "fmt:styles": "prettier --write app/styles/**/*.*",
-    "start": "export VAULT_ADDR=http://localhost:8200; ember server --proxy=$VAULT_ADDR",
+    "start": "VAULT_ADDR=http://localhost:8200; ember server --proxy=$VAULT_ADDR",
     "start2": "ember server --proxy=http://localhost:8202 --port=4202",
     "start:mirage": "start () { MIRAGE_DEV_HANDLER=$1 yarn run start; }; start",
     "test": "npm-run-all lint:js:quiet lint:hbs:quiet && node scripts/start-vault.js",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9499,9 +9499,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000792, caniuse-lite@npm:^1.0.30000805, caniuse-lite@npm:^1.0.30000844, caniuse-lite@npm:^1.0.30001219, caniuse-lite@npm:^1.0.30001264, caniuse-lite@npm:^1.0.30001280, caniuse-lite@npm:^1.0.30001304, caniuse-lite@npm:^1.0.30001317, caniuse-lite@npm:^1.0.30001349":
-  version: 1.0.30001419
-  resolution: "caniuse-lite@npm:1.0.30001419"
-  checksum: 7a4dc2794a6773574b5aebcd1c9c0d56159654821714152d8a0b04e261e1522bfd3d86589b8406ce81c7bf5b706118b73b2cb85d577ae433e303dd48ac9ff65f
+  version: 1.0.30001487
+  resolution: "caniuse-lite@npm:1.0.30001487"
+  checksum: b5a9e72ec165765fb3e07913cc389685ce8a30ac48967f99baec773a4353d2037fb534241e87b3c95d40a5081079be2263710b784883183bb2998b73f7202233
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Cleans up some errors and warnings from the `yarn start` output:

- Removes export in the `yarn start` command which is unnecessary since `VAULT_ADDR` env var will be passed directly to the script execution
 
![image](https://github.com/hashicorp/vault/assets/24611656/801e0c78-399f-4ab6-936f-46d956d40ccc)

- Updates caniuse-lite to get rid of the warnings

![image](https://github.com/hashicorp/vault/assets/24611656/f8d0b545-190a-4e26-a59e-f03d5108f9ab)
