### PR TITLE
Update ACME endpoint help synopsis and description

### DIFF
--- a/builtin/logical/pki/path_acme_account.go
+++ b/builtin/logical/pki/path_acme_account.go
@@ -98,8 +98,8 @@ func patternAcmeNewAccount(b *backend, pattern string) *framework.Path {
 			},
 		},
 
-		HelpSynopsis:    pathOcspHelpSyn,
-		HelpDescription: pathOcspHelpDesc,
+		HelpSynopsis:    pathAcmeHelpSync,
+		HelpDescription: pathAcmeHelpDesc,
 	}
 }
 

--- a/builtin/logical/pki/path_acme_authorizations.go
+++ b/builtin/logical/pki/path_acme_authorizations.go
@@ -41,8 +41,8 @@ func patternAcmeAuthorization(b *backend, pattern string) *framework.Path {
 			},
 		},
 
-		HelpSynopsis:    "",
-		HelpDescription: "",
+		HelpSynopsis:    pathAcmeHelpSync,
+		HelpDescription: pathAcmeHelpDesc,
 	}
 }
 

--- a/builtin/logical/pki/path_acme_challenges.go
+++ b/builtin/logical/pki/path_acme_challenges.go
@@ -48,8 +48,8 @@ func patternAcmeChallenge(b *backend, pattern string) *framework.Path {
 			},
 		},
 
-		HelpSynopsis:    "",
-		HelpDescription: "",
+		HelpSynopsis:    pathAcmeHelpSync,
+		HelpDescription: pathAcmeHelpDesc,
 	}
 }
 

--- a/builtin/logical/pki/path_acme_directory.go
+++ b/builtin/logical/pki/path_acme_directory.go
@@ -13,8 +13,11 @@ import (
 )
 
 const (
-	pathAcmeDirectoryHelpSync = `Read the proper URLs for various ACME operations`
-	pathAcmeDirectoryHelpDesc = `Provide an ACME directory response that contains URLS for various ACME operations.`
+	pathAcmeHelpSync = `An endpoint implementing the standard ACME protocol`
+	pathAcmeHelpDesc = `This API endpoint implementing a subset of the ACME protocol
+ defined in RFC 8555, with its own authentication and argument syntax that
+ does not follow conventional Vault operations. An ACME client tool or library
+ should be used to interact with these endpoints.`
 )
 
 func pathAcmeDirectory(b *backend) []*framework.Path {
@@ -36,8 +39,8 @@ func patternAcmeDirectory(b *backend, pattern string) *framework.Path {
 			},
 		},
 
-		HelpSynopsis:    pathAcmeDirectoryHelpSync,
-		HelpDescription: pathAcmeDirectoryHelpDesc,
+		HelpSynopsis:    pathAcmeHelpSync,
+		HelpDescription: pathAcmeHelpDesc,
 	}
 }
 

--- a/builtin/logical/pki/path_acme_eab.go
+++ b/builtin/logical/pki/path_acme_eab.go
@@ -51,8 +51,9 @@ func pathAcmeEabCreateList(b *backend) *framework.Path {
 			},
 		},
 
-		HelpSynopsis:    "",
-		HelpDescription: "",
+		HelpSynopsis: "Generate or list external account bindings to be used for ACME",
+		HelpDescription: `Generate single use id/key pairs to be used for ACME EAB or list 
+identifiers that have been generated but yet to be used.`,
 	}
 }
 
@@ -83,8 +84,11 @@ func pathAcmeEabDelete(b *backend) *framework.Path {
 			},
 		},
 
-		HelpSynopsis:    "",
-		HelpDescription: "",
+		HelpSynopsis: "Delete an external account binding id prior to its use within an ACME account",
+		HelpDescription: `Allows an operator to delete an external account binding,
+before its bound to a new ACME account. If the identifier provided does not exist or 
+was already consumed by an ACME account a successful response is returned along with 
+a warning that it did not exist.`,
 	}
 }
 

--- a/builtin/logical/pki/path_acme_nonce.go
+++ b/builtin/logical/pki/path_acme_nonce.go
@@ -35,8 +35,8 @@ func patternAcmeNonce(b *backend, pattern string) *framework.Path {
 			},
 		},
 
-		HelpSynopsis:    pathAcmeDirectoryHelpSync,
-		HelpDescription: pathAcmeDirectoryHelpDesc,
+		HelpSynopsis:    pathAcmeHelpSync,
+		HelpDescription: pathAcmeHelpDesc,
 	}
 }
 

--- a/builtin/logical/pki/path_acme_order.go
+++ b/builtin/logical/pki/path_acme_order.go
@@ -58,8 +58,8 @@ func patternAcmeNewOrder(b *backend, pattern string) *framework.Path {
 			},
 		},
 
-		HelpSynopsis:    "",
-		HelpDescription: "",
+		HelpSynopsis:    pathAcmeHelpSync,
+		HelpDescription: pathAcmeHelpDesc,
 	}
 }
 
@@ -79,8 +79,8 @@ func patternAcmeListOrders(b *backend, pattern string) *framework.Path {
 			},
 		},
 
-		HelpSynopsis:    "",
-		HelpDescription: "",
+		HelpSynopsis:    pathAcmeHelpSync,
+		HelpDescription: pathAcmeHelpDesc,
 	}
 }
 
@@ -101,8 +101,8 @@ func patternAcmeGetOrder(b *backend, pattern string) *framework.Path {
 			},
 		},
 
-		HelpSynopsis:    "",
-		HelpDescription: "",
+		HelpSynopsis:    pathAcmeHelpSync,
+		HelpDescription: pathAcmeHelpDesc,
 	}
 }
 
@@ -123,8 +123,8 @@ func patternAcmeFinalizeOrder(b *backend, pattern string) *framework.Path {
 			},
 		},
 
-		HelpSynopsis:    "",
-		HelpDescription: "",
+		HelpSynopsis:    pathAcmeHelpSync,
+		HelpDescription: pathAcmeHelpDesc,
 	}
 }
 
@@ -145,8 +145,8 @@ func patternAcmeFetchOrderCert(b *backend, pattern string) *framework.Path {
 			},
 		},
 
-		HelpSynopsis:    "",
-		HelpDescription: "",
+		HelpSynopsis:    pathAcmeHelpSync,
+		HelpDescription: pathAcmeHelpDesc,
 	}
 }
 

--- a/builtin/logical/pki/path_acme_revoke.go
+++ b/builtin/logical/pki/path_acme_revoke.go
@@ -35,8 +35,8 @@ func patternAcmeRevoke(b *backend, pattern string) *framework.Path {
 			},
 		},
 
-		HelpSynopsis:    "",
-		HelpDescription: "",
+		HelpSynopsis:    pathAcmeHelpSync,
+		HelpDescription: pathAcmeHelpDesc,
 	}
 }
 


### PR DESCRIPTION
 - Use generic help synopsis and help description values for the various ACME endpoints defined.
 - Add missing values for the Vault ACME EAB apis

Fixes VAULT-16265