### PR TITLE
Vault-12308: Change password policy testing to be deterministic

### DIFF
--- a/helper/random/string_generator.go
+++ b/helper/random/string_generator.go
@@ -70,7 +70,7 @@ func sortCharset(chars string) string {
 	return string(r)
 }
 
-// StringGenerator generats random strings from the provided charset & adhering to a set of rules. The set of rules
+// StringGenerator generates random strings from the provided charset & adhering to a set of rules. The set of rules
 // are things like CharsetRule which requires a certain number of characters from a sub-charset.
 type StringGenerator struct {
 	// Length of the string to generate.

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3041,7 +3041,7 @@ func (*SystemBackend) handlePoliciesPasswordSet(ctx context.Context, req *logica
 
 		char := rule.Chars()[0]
 		for i := len(testPassword); i < policy.Length; i++ {
-			testPassword[i] = char
+			testPassword = append(testPassword, char)
 		}
 	}
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3042,7 +3042,7 @@ func (*SystemBackend) handlePoliciesPasswordSet(ctx context.Context, req *logica
 
 	for _, rule := range policy.Rules {
 		if !rule.Pass(testPassword) {
-			return nil, logical.CodedError(http.StatusBadRequest, "failed to construct test password; password failed to pass all rules")
+			return nil, logical.CodedError(http.StatusBadRequest, "unable to construct test password from provided policy: are the rules impossible?")
 		}
 	}
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3037,7 +3037,7 @@ func (*SystemBackend) handlePoliciesPasswordSet(ctx context.Context, req *logica
 
 	for i := len(testPassword); i < policy.Length; i++ {
 		for _, rule := range policy.Rules {
-			if i >= policy.Length {
+			if len(testPassword) >= policy.Length {
 				break
 			}
 			charsetRule, ok := rule.(random.CharsetRule)


### PR DESCRIPTION
This changes the password policy testing to attempt to construct a test password rather than generating random passwords and checking them against the rules. This stops Vault from erroring out on policies that are restrictive, but still possible.