### PR TITLE
dockerfile: ubi-minimal:8.7 -> 8.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ CMD ["server", "-dev"]
 
 
 ## UBI DOCKERFILE ##
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7 as ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8 as ubi
 
 ARG BIN_NAME
 # PRODUCT_VERSION is the version built dist/$TARGETOS/$TARGETARCH/$BIN_NAME,


### PR DESCRIPTION
Updating the [ubi base image](https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8) and backporting to 1.13, 1.12, 1.11.