### PR TITLE
pki: add subject key identifier to read key response

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2400,6 +2400,14 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 	require.NotNil(t, resp, "expected ca info")
 	keyId1 := resp.Data["key_id"]
 	issuerId1 := resp.Data["issuer_id"]
+	cert := parseCert(t, resp.Data["certificate"].(string))
+	certSkid := certutil.GetHexFormatted(cert.SubjectKeyId, ":")
+
+	//  -> Validate the SKID matches between the root cert and the key
+	resp, err = CBRead(b, s, "key/" + keyId1.(keyID).String())
+	require.NoError(t, err)
+	require.NotNil(t, resp, "expected a response")
+	require.Equal(t, resp.Data["subject_key_id"], certSkid)
 
 	resp, err = CBRead(b, s, "cert/ca_chain")
 	require.NoError(t, err, "error reading ca_chain: %v", err)
@@ -2414,6 +2422,14 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 	require.NotNil(t, resp, "expected ca info")
 	keyId2 := resp.Data["key_id"]
 	issuerId2 := resp.Data["issuer_id"]
+	cert = parseCert(t, resp.Data["certificate"].(string))
+	certSkid = certutil.GetHexFormatted(cert.SubjectKeyId, ":")
+
+	//  -> Validate the SKID matches between the root cert and the key
+	resp, err = CBRead(b, s, "key/" + keyId2.(keyID).String())
+	require.NoError(t, err)
+	require.NotNil(t, resp, "expected a response")
+	require.Equal(t, resp.Data["subject_key_id"], certSkid)
 
 	// Make sure that we actually generated different issuer and key values
 	require.NotEqual(t, keyId1, keyId2)

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2404,7 +2404,7 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 	certSkid := certutil.GetHexFormatted(cert.SubjectKeyId, ":")
 
 	//  -> Validate the SKID matches between the root cert and the key
-	resp, err = CBRead(b, s, "key/" + keyId1.(keyID).String())
+	resp, err = CBRead(b, s, "key/"+keyId1.(keyID).String())
 	require.NoError(t, err)
 	require.NotNil(t, resp, "expected a response")
 	require.Equal(t, resp.Data["subject_key_id"], certSkid)
@@ -2426,7 +2426,7 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 	certSkid = certutil.GetHexFormatted(cert.SubjectKeyId, ":")
 
 	//  -> Validate the SKID matches between the root cert and the key
-	resp, err = CBRead(b, s, "key/" + keyId2.(keyID).String())
+	resp, err = CBRead(b, s, "key/"+keyId2.(keyID).String())
 	require.NoError(t, err)
 	require.NotNil(t, resp, "expected a response")
 	require.Equal(t, resp.Data["subject_key_id"], certSkid)
@@ -2563,7 +2563,7 @@ func TestBackend_SignIntermediate_AllowedPastCA(t *testing.T) {
 	intKeyId := resp.Data["key_id"].(keyID)
 	csr := resp.Data["csr"]
 
-	resp, err = CBRead(b_int, s_int, "key/" + intKeyId.String())
+	resp, err = CBRead(b_int, s_int, "key/"+intKeyId.String())
 	require.NoError(t, err)
 	require.NotNil(t, resp, "expected a response")
 	intSkid := resp.Data["subject_key_id"].(string)

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -16,6 +16,7 @@ const (
 	keyIdParam     = "key_id"
 	keyTypeParam   = "key_type"
 	keyBitsParam   = "key_bits"
+	skidParam      = "subject_key_id"
 )
 
 // addIssueAndSignCommonFields adds fields common to both CA and non-CA issuing

--- a/builtin/logical/pki/path_fetch_keys.go
+++ b/builtin/logical/pki/path_fetch_keys.go
@@ -147,7 +147,7 @@ func buildPathKey(b *backend, pattern string, displayAttrs *framework.DisplayAtt
 							},
 							"subject_key_id": {
 								Type:        framework.TypeString,
-								Description: `Subject key identifier`,
+								Description: `RFC 5280 Subject Key Identifier of the public counterpart`,
 								Required:    false,
 							},
 							"managed_key_id": {

--- a/changelog/20642.txt
+++ b/changelog/20642.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: add subject key identifier to read key response
+```

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -126,7 +126,7 @@ func GetSubjKeyID(privateKey crypto.Signer) ([]byte, error) {
 	if privateKey == nil {
 		return nil, errutil.InternalError{Err: "passed-in private key is nil"}
 	}
-	return getSubjectKeyID(privateKey.Public())
+	return GetSubjectKeyID(privateKey.Public())
 }
 
 // Returns the explicit SKID when used for cross-signing, else computes a new
@@ -136,10 +136,10 @@ func getSubjectKeyIDFromBundle(data *CreationBundle) ([]byte, error) {
 		return data.Params.SKID, nil
 	}
 
-	return getSubjectKeyID(data.CSR.PublicKey)
+	return GetSubjectKeyID(data.CSR.PublicKey)
 }
 
-func getSubjectKeyID(pub interface{}) ([]byte, error) {
+func GetSubjectKeyID(pub interface{}) ([]byte, error) {
 	var publicKeyBytes []byte
 	switch pub := pub.(type) {
 	case *rsa.PublicKey:


### PR DESCRIPTION
This will be helpful for the Terraform Vault Provider to detect migration of pre-1.11 exported keys (from CA generation) into post-1.11 Vault.