### PR TITLE
report intermediate error messages during request forwarding

### DIFF
--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -754,7 +754,7 @@ func (cb *crlBuilder) processRevocationQueue(sc *storageContext) error {
 				}
 
 				if err := sc.Storage.Put(sc.Context, confirmedEntry); err != nil {
-					return fmt.Errorf("error persisting cross-cluster revocation confirmation: %w\nThis may occur when the active node of the primary performance replication cluster is unavailable.", err)
+					return fmt.Errorf("error persisting cross-cluster revocation confirmation: %w", err)
 				}
 			} else {
 				// Since we're the active node of the primary cluster, go ahead

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -519,7 +519,7 @@ func (b *backend) maybeRevokeCrossCluster(sc *storageContext, config *crlConfig,
 	}
 
 	if err := sc.Storage.Put(sc.Context, reqEntry); err != nil {
-		return nil, fmt.Errorf("error persisting cross-cluster revocation request: %w\nThis may occur when the active node of the primary performance replication cluster is unavailable.", err)
+		return nil, fmt.Errorf("error persisting cross-cluster revocation request: %w", err)
 	}
 
 	resp := &logical.Response{

--- a/changelog/20643.txt
+++ b/changelog/20643.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: report intermediate error messages during request forwarding
+```

--- a/sdk/logical/response_util.go
+++ b/sdk/logical/response_util.go
@@ -76,10 +76,21 @@ func RespondErrorCommon(req *Request, resp *Response, err error) (int, error) {
 		var allErrors error
 		var codedErr *ReplicationCodedError
 		errwrap.Walk(err, func(inErr error) {
+			// The Walk function does not just traverse leaves, and execute the
+			// callback function on the entire error first. So, if the error is
+			// of type multierror.Error, we may want to skip storing the entire
+			// error first to avoid adding duplicate errors when walking down
+			// the leaf errors
+			if _, ok := inErr.(*multierror.Error); ok {
+				return
+			}
 			newErr, ok := inErr.(*ReplicationCodedError)
 			if ok {
 				codedErr = newErr
 			} else {
+				// if the error is of type fmt.wrapError which is typically
+				// made by calling fmt.Errorf("... %w", err), allErrors will
+				// contain duplicated error messages
 				allErrors = multierror.Append(allErrors, inErr)
 			}
 		})

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -833,7 +833,30 @@ func (c *Core) doRouting(ctx context.Context, req *logical.Request) (*logical.Re
 	// If we're replicating and we get a read-only error from a backend, need to forward to primary
 	resp, err := c.router.Route(ctx, req)
 	if shouldForward(c, resp, err) {
-		return forward(ctx, c, req)
+		fwdResp, fwdErr := forward(ctx, c, req)
+		if fwdErr != nil && err != logical.ErrReadOnly {
+			// When handling the request locally, we got an error that
+			// contained ErrReadOnly, but had additional information.
+			// Since we've now forwarded this request and got _another_
+			// error, we should tell the user about both errors, so
+			// they know about both.
+			//
+			// When there is no error from forwarding, the request
+			// succeeded and so no additional context is necessary. When
+			// the initial error here was only ErrReadOnly, it's likely
+			// the plugin authors intended to forward this request
+			// remotely anyway.
+			repErr, ok := fwdErr.(*logical.ReplicationCodedError)
+			if ok {
+				fwdErr = &logical.ReplicationCodedError{
+					Msg:  fmt.Sprintf("errors from both primary and secondary; primary error was %s; secondary errors follow: %s", repErr.Error(), err.Error()),
+					Code: repErr.Code,
+				}
+			} else {
+				fwdErr = multierror.Append(fwdErr, err)
+			}
+		}
+		return fwdResp, fwdErr
 	}
 	return resp, err
 }


### PR DESCRIPTION
OSS version of https://github.com/hashicorp/vault-enterprise/pull/3937

Addresses [VAULT-15375](https://hashicorp.atlassian.net/browse/VAULT-15375)
Core elides intermediate error messages during request forwarding.

There are two main places where Alex and I find that we need to report the errors considering request forwarding. One is in the request handling where we initially forward the request upon getting a read only error. Two is in the replication code [here](https://github.com/hashicorp/vault-enterprise/blob/6ee821519bf288d7e61c1b3e5c21f3983ace97d2/vault/replication_rpc_ent.go#L869-L875). 

Having aggregate the errors in the above places, we noticed that the reported error has many duplicates. Below is a sample of the existing behaviour:
```
    backend_revocation_queue_ent_test.go:391: error revoking leaf cert, Error making API request.
        
        Namespace: ns1/
        URL: PUT https://127.0.0.1:59296/v1/pki/revoke
        Code: 500. Errors:
        
        * 2 errors occurred:
        	* errors from both primary and secondary; primary error was 2 errors occurred:
        	* 2 errors occurred:
        	* error from primary active: failed to write WAL entries for Delta CRLs: failed to write cross-cluster delta WAL entry: error saving delta CRL WAL entry: forwarded writer lacked replication client: cannot write to readonly storage
        	* error from perf secondary active: error persisting cross-cluster revocation request: refusing to write to write-forwarded storage when not the active node: cannot write to readonly storage
        This may occur when the active node of the primary performance replication cluster is unavailable.
        
        
        	* error from a standby node: error persisting cross-cluster revocation request: refusing to write to write-forwarded storage when not the active node: cannot write to readonly storage
        This may occur when the active node of the primary performance replication cluster is unavailable.
        
        ; secondary errors follow
        	* 2 errors occurred:
        	* 2 errors occurred:
        	* error from primary active: failed to write WAL entries for Delta CRLs: failed to write cross-cluster delta WAL entry: error saving delta CRL WAL entry: forwarded writer lacked replication client: cannot write to readonly storage
        	* error from perf secondary active: error persisting cross-cluster revocation request: refusing to write to write-forwarded storage when not the active node: cannot write to readonly storage
        This may occur when the active node of the primary performance replication cluster is unavailable.
        
        
        	* error from a standby node: error persisting cross-cluster revocation request: refusing to write to write-forwarded storage when not the active node: cannot write to readonly storage
        This may occur when the active node of the primary performance replication cluster is unavailable.
```

It would be very confusing to report such an error to the client. We found that the issue is in respondErrorCommon code where the call back function passed in the errwrap.Walk function will aggregate errors multiple times. Fixing the issue will result in the following reported error:

```
 backend_revocation_queue_ent_test.go:391: error revoking leaf cert, Error making API request.
        
        Namespace: ns1/
        URL: PUT https://127.0.0.1:63885/v1/pki/revoke
        Code: 500. Errors:
        
         errors from both primary and secondary; primary error was 2 errors occurred:
        	* error from primary active: failed to write WAL entries for Delta CRLs: failed to write cross-cluster delta WAL entry: error saving delta CRL WAL entry: forwarded writer lacked replication client: cannot write to readonly storage
        	* error from perf secondary active: error persisting cross-cluster revocation request: refusing to write to write-forwarded storage when not the active node: cannot write to readonly storage
        
        ; secondary errors follow: error from a standby node: error persisting cross-cluster revocation request: refusing to write to write-forwarded storage when not the active node: cannot write to readonly storage

```

[VAULT-15375]: https://hashicorp.atlassian.net/browse/VAULT-15375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
