### PR TITLE
Correctly search for namespace path, not id

### DIFF
--- a/builtin/logical/pki/acme_billing_test.go
+++ b/builtin/logical/pki/acme_billing_test.go
@@ -147,12 +147,12 @@ func validateClientCount(t *testing.T, client *api.Client, mount string, expecte
 	// Validate this mount's namespace is included in the namespaces list,
 	// if this is enterprise. Otherwise, if its OSS or we don't have a
 	// namespace, we default to the value root.
-	mountNamespace := "root"
+	mountNamespace := ""
 	mountPath := mount + "/"
 	if constants.IsEnterprise && strings.Contains(mount, "/") {
 		pieces := strings.Split(mount, "/")
 		require.Equal(t, 2, len(pieces), "we do not support nested namespaces in this test")
-		mountNamespace = pieces[0]
+		mountNamespace = pieces[0] + "/"
 		mountPath = pieces[1] + "/"
 	}
 
@@ -161,11 +161,11 @@ func validateClientCount(t *testing.T, client *api.Client, mount string, expecte
 	foundNamespace := false
 	for index, namespaceRaw := range monthlyNamespaces {
 		namespace := namespaceRaw.(map[string]interface{})
-		require.Contains(t, namespace, "namespace_id", "expected monthly.namespaces[%v] to contain a namespace_id key", index)
-		namespaceId := namespace["namespace_id"].(string)
+		require.Contains(t, namespace, "namespace_path", "expected monthly.namespaces[%v] to contain a namespace_path key", index)
+		namespacePath := namespace["namespace_path"].(string)
 
-		if namespaceId != mountNamespace {
-			t.Logf("skipping non-matching namespace %v: %v != %v / %v", index, namespaceId, mountNamespace, namespace)
+		if namespacePath != mountNamespace {
+			t.Logf("skipping non-matching namespace %v: %v != %v / %v", index, namespacePath, mountNamespace, namespace)
 			continue
 		}
 


### PR DESCRIPTION
Namespace ID is a random value that would involve querying the namespace `sys/` endpoint to correlate.