### PR TITLE
Properly validate int ca lifetime error, add warning on leaf cert with basic constraints

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2516,7 +2516,7 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 	}
 }
 
-func TestBackend_SignIntermediate_AllowedPastCA(t *testing.T) {
+func TestBackend_SignIntermediate_AllowedPastCAValidity(t *testing.T) {
 	t.Parallel()
 	b_root, s_root := CreateBackendWithStorage(t)
 	b_int, s_int := CreateBackendWithStorage(t)
@@ -2534,6 +2534,7 @@ func TestBackend_SignIntermediate_AllowedPastCA(t *testing.T) {
 	_, err = CBWrite(b_root, s_root, "roles/test", map[string]interface{}{
 		"allow_bare_domains": true,
 		"allow_subdomains":   true,
+		"allow_any_name":     true,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -2555,9 +2556,7 @@ func TestBackend_SignIntermediate_AllowedPastCA(t *testing.T) {
 		"csr":         csr,
 		"ttl":         "60h",
 	})
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	require.ErrorContains(t, err, "that is beyond the expiration of the CA certificate")
 
 	_, err = CBWrite(b_root, s_root, "sign-verbatim/test", map[string]interface{}{
 		"common_name": "myint.com",
@@ -2565,9 +2564,7 @@ func TestBackend_SignIntermediate_AllowedPastCA(t *testing.T) {
 		"csr":         csr,
 		"ttl":         "60h",
 	})
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	require.ErrorContains(t, err, "that is beyond the expiration of the CA certificate")
 
 	resp, err = CBWrite(b_root, s_root, "root/sign-intermediate", map[string]interface{}{
 		"common_name": "myint.com",

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -1002,6 +1002,12 @@ func signCert(b *backend,
 
 	if isCA {
 		creation.Params.PermittedDNSDomains = data.apiData.Get("permitted_dns_domains").([]string)
+	} else {
+		for _, ext := range csr.Extensions {
+			if ext.Id.Equal(certutil.ExtensionBasicConstraintsOID) {
+				warnings = append(warnings, "specified CSR contained a Basic Constraints extension that was ignored during issuance")
+			}
+		}
 	}
 
 	parsedBundle, err := certutil.SignCertificate(creation)

--- a/changelog/20654.txt
+++ b/changelog/20654.txt
@@ -1,0 +1,3 @@
+```release-note:change
+secrets/pki: Warning when issuing leafs from CSRs with basic constraints. In the future, issuance of non-CA leaf certs from CSRs with asserted IsCA Basic Constraints will be prohibited.
+```


### PR DESCRIPTION
* In the tests, make sure we validate the expected error message; over time, the role definition changed to prevent issuance of this ICA leaf.
* Add warning when issuing a leaf cert that looks like it could be an intermediate (has any basic constraint extension).


In the future, we might move to forbidding issuance of leaf certs from CSRs that contain asserted IsCA basic constraints.