### PR TITLE
UI: View PKI issuer from overview page

### DIFF
--- a/ui/lib/core/addon/components/search-select.hbs
+++ b/ui/lib/core/addon/components/search-select.hbs
@@ -43,20 +43,20 @@
         as |option|
       >
         {{#if this.shouldRenderName}}
-          {{option.name}}
+          {{get option this.nameKey}}
           <small class="search-select-list-key" data-test-smaller-id="true">
             {{get option this.idKey}}
           </small>
         {{else}}
-          {{option.id}}
+          {{get option this.idKey}}
         {{/if}}
       </PowerSelect>
     {{/unless}}
     <ul class="search-select-list">
       {{#each this.selectedOptions as |selected index|}}
         <li class="search-select-list-item" data-test-selected-option={{index}}>
-          {{#if this.shouldRenderName}}
-            {{selected.name}}
+          {{#if (and this.shouldRenderName (get selected this.nameKey))}}
+            {{get selected this.nameKey}}
             <small class="search-select-list-key" data-test-smaller-id={{index}}>
               {{get selected this.idKey}}
             </small>

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -26,22 +26,23 @@ import { filterOptions, defaultMatcher } from 'ember-power-select/utils/group-ut
  *    @disallowNewItems={{true}}
  *    class={{if this.validationError "dropdown-has-error-border"}}
  * />
- * 
+ *
  // * component functionality
  * @param {function} onChange - The onchange action for this form field. ** SEE UTIL ** search-select-has-many.js if selecting models from a hasMany relationship
  * @param {array} [inputValue] - Array of strings corresponding to the input's initial value, e.g. an array of model ids that on edit will appear as selected items below the input
  * @param {boolean} [disallowNewItems=false] - Controls whether or not the user can add a new item if none found
  * @param {boolean} [shouldRenderName=false] - By default an item's id renders in the dropdown, `true` displays the name with its id in smaller text beside it *NOTE: the boolean flips automatically with 'identity' models or if this.idKey !== 'id'
+ * @param {string} [nameKey="name"] - if shouldRenderName=true, you can use this arg to specify which key to use for the rendered name. Defaults to "name".
  * @param {array} [parentManageSelected] - Array of selected items if the parent is keeping track of selections, see mfa-login-enforcement-form.js
- * @param {boolean} [passObject=false] - When true, the onChange callback returns an array of objects with id (string) and isNew (boolean) (and any params from objectKeys). By default - onChange returns an array of id strings. 
+ * @param {boolean} [passObject=false] - When true, the onChange callback returns an array of objects with id (string) and isNew (boolean) (and any params from objectKeys). By default - onChange returns an array of id strings.
  * @param {array} [objectKeys] - Array of values that correlate to model attrs. Used to render attr other than 'id' beside the name if shouldRenderName=true. If passObject=true, objectKeys are added to the passed, selected object.
  * @param {number} [selectLimit] - Sets select limit
- 
+
 // * query params for dropdown items
  * @param {Array} models - An array of model types to fetch from the API.
  * @param {string} [backend] - name of the backend if the query for options needs additional information (eg. secret backend)
  * @param {object} [queryObject] - object passed as query options to this.store.query(). NOTE: will override @backend
- 
+
  // * template only/display args
  * @param {string} id - The name of the form field
  * @param {string} [label] - Label for this form field
@@ -87,11 +88,15 @@ export default class SearchSelect extends Component {
       : false;
   }
 
+  get nameKey() {
+    return this.args.nameKey || 'name';
+  }
+
   addSearchText(optionsToFormat) {
     // maps over array of objects or response from query
     return optionsToFormat.toArray().map((option) => {
       const id = option[this.idKey] ? option[this.idKey] : option.id;
-      option.searchText = `${option.name} ${id}`;
+      option.searchText = `${option[this.nameKey]} ${id}`;
       return option;
     });
   }
@@ -110,7 +115,7 @@ export default class SearchSelect extends Component {
       this.dropdownOptions.removeObject(matchingOption);
       return {
         id: option,
-        name: matchingOption ? matchingOption.name : option,
+        name: matchingOption ? matchingOption[this.nameKey] : option,
         searchText: matchingOption ? matchingOption.searchText : option,
         addTooltip,
         // add additional attrs if we're using a dynamic idKey

--- a/ui/lib/pki/addon/components/page/pki-overview.hbs
+++ b/ui/lib/pki/addon/components/page/pki-overview.hbs
@@ -1,7 +1,4 @@
-<div
-  class="selectable-card-container has-grid has-top-margin-l has-two-col-grid
-    {{if (eq @roles 403) 'has-three-col-grid' 'has-two-col-grid'}}"
->
+<div class="selectable-card-container has-grid has-top-margin-l has-two-col-grid">
   <OverviewCard
     @cardTitle="Issuers"
     @subText="The total number of issuers in this PKI mount. Includes both root and intermediate certificates."
@@ -64,6 +61,33 @@
         disabled={{unless this.certificateValue true}}
         {{on "click" this.transitionToViewCertificates}}
         data-test-view-certificate-button
+      >
+        View
+      </button>
+    </div>
+  </OverviewCard>
+
+  <OverviewCard @cardTitle="View issuer" @subText="Choose or type an issuer name or ID to view its details">
+    <div class="has-top-margin-m is-flex">
+      <SearchSelect
+        class="is-flex-1"
+        @selectLimit="1"
+        @models={{array "pki/issuer"}}
+        @backend={{@engine.id}}
+        @placeholder="Type to find an issuer..."
+        @disallowNewItems={{true}}
+        @onChange={{this.handleIssuerSearch}}
+        @fallbackComponent="input-search"
+        @shouldRenderName={{true}}
+        @nameKey={{"issuerName"}}
+        data-test-issue-issuer-input
+      />
+      <button
+        type="submit"
+        class="button is-secondary has-left-margin-s"
+        disabled={{unless this.issuerValue true}}
+        {{on "click" this.transitionToIssuerDetails}}
+        data-test-view-issuer-button
       >
         View
       </button>

--- a/ui/lib/pki/addon/components/page/pki-overview.ts
+++ b/ui/lib/pki/addon/components/page/pki-overview.ts
@@ -24,6 +24,7 @@ export default class PkiOverview extends Component<Args> {
 
   @tracked rolesValue = '';
   @tracked certificateValue = '';
+  @tracked issuerValue = '';
 
   @action
   transitionToViewCertificates() {
@@ -35,6 +36,11 @@ export default class PkiOverview extends Component<Args> {
   @action
   transitionToIssueCertificates() {
     this.router.transitionTo('vault.cluster.secrets.backend.pki.roles.role.generate', this.rolesValue);
+  }
+
+  @action
+  transitionToIssuerDetails() {
+    this.router.transitionTo('vault.cluster.secrets.backend.pki.issuers.issuer.details', this.issuerValue);
   }
 
   @action
@@ -52,6 +58,15 @@ export default class PkiOverview extends Component<Args> {
       this.certificateValue = certificate[0];
     } else {
       this.certificateValue = certificate;
+    }
+  }
+
+  @action
+  handleIssuerSearch(issuers: string) {
+    if (Array.isArray(issuers)) {
+      this.issuerValue = issuers[0];
+    } else {
+      this.issuerValue = issuers;
     }
   }
 }

--- a/ui/tests/acceptance/pki/pki-overview-test.js
+++ b/ui/tests/acceptance/pki/pki-overview-test.js
@@ -114,4 +114,13 @@ module('Acceptance | pki overview', function (hooks) {
       'vault.cluster.secrets.backend.pki.certificates.certificate.details'
     );
   });
+
+  test('navigates to issuer details page for View Issuer card', async function (assert) {
+    await authPage.login(this.pkiAdminToken);
+    await visit(`/vault/secrets/${this.mountPath}/pki/overview`);
+    await click(SELECTORS.viewIssuerPowerSearch);
+    await click(SELECTORS.firstPowerSelectOption);
+    await click(SELECTORS.viewIssuerButton);
+    assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.pki.issuers.issuer.details');
+  });
 });

--- a/ui/tests/helpers/pki/overview.js
+++ b/ui/tests/helpers/pki/overview.js
@@ -20,5 +20,8 @@ export const SELECTORS = {
   viewCertificateInput: '[data-test-view-certificate-input]',
   viewCertificatePowerSearch: '[data-test-view-certificate-input] span',
   viewCertificateButton: '[data-test-view-certificate-button]',
+  viewIssuerInput: '[data-test-issue-issuer-input]',
+  viewIssuerPowerSearch: '[data-test-issue-issuer-input] span',
+  viewIssuerButton: '[data-test-view-issuer-button]',
   firstPowerSelectOption: '[data-option-index="0"]',
 };

--- a/ui/tests/integration/components/search-select-test.js
+++ b/ui/tests/integration/components/search-select-test.js
@@ -58,6 +58,13 @@ const storeService = Service.extend({
             { id: 'model-c-id', name: 'model-c', uuid: 'c789', type: 'c' },
           ]);
           break;
+        case 'pki/issuer':
+          resolve([
+            { id: 'issuer-a-id', issuerName: 'my-first-issuer' },
+            { id: 'issuer-b-id' },
+            { id: 'issuer-c-id', issuerName: 'my-issuer-again' },
+          ]);
+          break;
         default:
           reject({ httpStatus: 404, message: 'not found' });
           break;
@@ -473,6 +480,52 @@ module('Integration | Component | search select', function (hooks) {
     assert.strictEqual(component.smallOptionIds.length, 3, 'shows 3 smaller id text and the name');
   });
 
+  test('it renders correctly when model keys are not standardized', async function (assert) {
+    const models = ['pki/issuer'];
+    this.set('models', models);
+    this.set('onChange', sinon.spy());
+    this.set('disallowNewItems', true);
+    await render(hbs`
+      <SearchSelect
+        @label="foo"
+        @models={{this.models}}
+        @onChange={{this.onChange}}
+        @inputValue={{this.inputValue}}
+        @shouldRenderName={{true}}
+        @nameKey="issuerName"
+        @disallowNewItems={{this.disallowNewItems}}
+      />
+    `);
+    await clickTrigger();
+    assert.strictEqual(component.options.length, 3, 'shows three options');
+    assert.strictEqual(
+      component.options.objectAt(0).text,
+      'my-first-issuer issuer-a-id',
+      'first option renders custom ID and name'
+    );
+    assert.strictEqual(
+      component.options.objectAt(1).text,
+      'issuer-b-id',
+      `second option renders only id at custom key`
+    );
+    await typeInSearch('issuer-a');
+    await settled();
+    assert.strictEqual(
+      component.options.length,
+      2,
+      'shows two options after filter, filtering on both name and id keys'
+    );
+    this.set('disallowNewItems', false);
+    await typeInSearch('new-issuer');
+    await settled();
+    assert.strictEqual(component.options.length, 1, 'shows suggestion');
+    assert.strictEqual(
+      component.options.objectAt(0).text,
+      'Click to add new item: new-issuer',
+      'Prompts to add new item'
+    );
+  });
+
   test('it does not show name and smaller id for non-identity endpoints', async function (assert) {
     const models = ['policy/acl'];
     this.set('models', models);
@@ -767,7 +820,7 @@ module('Integration | Component | search select', function (hooks) {
       spy.args[1][0],
       expectedArray,
       `onClick is called with array of objects and correct keys.
-      first object: ${Object.keys(expectedArray[0]).join(', ')}, 
+      first object: ${Object.keys(expectedArray[0]).join(', ')},
       second object: ${Object.keys(expectedArray[1]).join(', ')}`
     );
   });


### PR DESCRIPTION
Due to a known issue when using control groups on issuer GET requests, we are adding a box to the overview page that allows a user to go directly to the issuer details page, which will allow control groups to work as expected. 

![pki-view-issuer-from-overview](https://github.com/hashicorp/vault/assets/82459713/daf347ac-c77e-454a-949f-738f931074cc)

