### PR TITLE
Sidebar nav access bug

### DIFF
--- a/ui/app/templates/vault/cluster/settings/auth.hbs
+++ b/ui/app/templates/vault/cluster/settings/auth.hbs
@@ -1,0 +1,2 @@
+<Sidebar::Nav::Access />
+{{outlet}}

--- a/ui/tests/acceptance/sidebar-nav-test.js
+++ b/ui/tests/acceptance/sidebar-nav-test.js
@@ -109,4 +109,14 @@ module('Acceptance | sidebar navigation', function (hooks) {
       assert.strictEqual(currentURL(), l.route, `${l.label} route renders`);
     }
   });
+
+  test('it should display access nav when mounting and configuring auth methods', async function (assert) {
+    await click(link('Access'));
+    await click('[data-test-auth-enable]');
+    assert.dom('[data-test-sidebar-nav-panel="Access"]').exists('Access nav panel renders');
+    await click(link('Authentication methods'));
+    await click('[data-test-auth-backend-link="token"]');
+    await click('[data-test-configure-link]');
+    assert.dom('[data-test-sidebar-nav-panel="Access"]').exists('Access nav panel renders');
+  });
 });


### PR DESCRIPTION
When mounting or configuring an auth method the route changes to `settings/auth` which is not nested under the access route causing the top level nav panel to activate. While this is technically correct it is not the intended UX and an issue with the route structure in general. Until the route structure can be updated a `settings.auth` template was added with the sidebar access nav component.