### PR TITLE
Add 1.14 draft docs and UI known issue

### DIFF
--- a/website/content/docs/release-notes/1.14.0.mdx
+++ b/website/content/docs/release-notes/1.14.0.mdx
@@ -1,0 +1,29 @@
+---
+layout: docs
+page_title: 1.14.0
+description: |-
+  This page contains release notes for Vault 1.14.0
+---
+
+# Vault 1.14.0 Release Notes
+
+**Software Release date:** TBD
+
+**Summary:** Vault Release 1.14.0 offers features and enhancements that improve
+the user experience while solving critical  issues previously encountered by our
+customers. We are providing an overview  of improvements in this set of  release
+notes.
+
+~> Note: these are **draft** notes for a future version of Vault. They should not be considered
+official guidance until the release has been completed.
+
+## Known issues
+
+@include 'ui-pki-control-groups-known-issue.mdx'
+
+## Feature Deprecations and EOL
+
+Please refer to the [Deprecation Plans and Notice](/vault/docs/deprecation) page
+for up-to-date information on feature deprecations and plans. A [Feature
+Deprecation FAQ](/vault/docs/deprecation/faq) page addresses questions about
+decisions made about Vault feature deprecations.

--- a/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
@@ -1,0 +1,25 @@
+---
+layout: docs
+page_title: Upgrading to Vault 1.14.x - Guides
+description: |-
+  This page contains the list of deprecations and important or breaking changes
+  for Vault 1.14.x. Please read it carefully.
+---
+
+# Overview
+
+This page contains the list of deprecations and important or breaking changes
+for Vault 1.14.x compared to 1.13. Please read it carefully.
+
+~> Note: these are **draft** notes for a future version of Vault. They should not be considered
+official guidance until the release has been completed.
+
+## Changes
+
+
+
+## Known Issues
+
+@include 'ui-pki-control-groups-known-issue.mdx'
+
+

--- a/website/content/partials/ui-pki-control-groups-known-issue.mdx
+++ b/website/content/partials/ui-pki-control-groups-known-issue.mdx
@@ -1,0 +1,12 @@
+### Control groups on GET requests for PKI issuers does not resolve in UI
+
+If a user is trying to access PKI issuer details from the UI and they have
+a control group for reading them, they will be caught in a loop when trying to
+access the issuer from the issuers list view.
+
+As a workaround, users constrained by control groups can search for an issuer
+from the overview page rather than through the issuers list tab.
+
+#### Impacted Versions
+
+Affects all current versions of 1.14.x

--- a/website/content/partials/ui-pki-control-groups-known-issue.mdx
+++ b/website/content/partials/ui-pki-control-groups-known-issue.mdx
@@ -1,11 +1,11 @@
-### Control groups on GET requests for PKI issuers does not resolve in UI
+### Control Groups with Issuer detail reads only accessible in UI from overview
 
-If a user is trying to access PKI issuer details from the UI and they have
-a control group for reading them, they will be caught in a loop when trying to
-access the issuer from the issuers list view.
+Given a scenario where a user can only read an Issuer's details after Control Group
+approval, they will constantly be directed to the Control Group Access page when
+attempting to link to the Issuer details page from the Issuer list page.
 
-As a workaround, users constrained by control groups can search for an issuer
-from the overview page rather than through the issuers list tab.
+As a workaround, users constrained by Control Groups can select an Issuer to view
+details for from the overview page rather than through the Issuers list page.
 
 #### Impacted Versions
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1821,10 +1821,14 @@
       {
          "title": "Upgrade Vault HA installations",
          "path": "upgrading/vault-ha-upgrade"
-      }, 
+      },
       {
         "title": "Upgrade Plugins",
         "path": "upgrading/plugins"
+      },
+      {
+        "title": "Upgrade to 1.14.x",
+        "path": "upgrading/upgrade-to-1.14.x"
       },
       {
         "title": "Upgrade to 1.13.x",
@@ -2069,6 +2073,10 @@
       {
         "title": "Overview",
         "path": "release-notes"
+      },
+      {
+         "title": "1.14.0",
+         "path": "release-notes/1.14.0"
       },
       {
          "title": "1.13.0",

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1828,7 +1828,8 @@
       },
       {
         "title": "Upgrade to 1.14.x",
-        "path": "upgrading/upgrade-to-1.14.x"
+        "path": "upgrading/upgrade-to-1.14.x",
+        "hidden": true
       },
       {
         "title": "Upgrade to 1.13.x",
@@ -2076,7 +2077,8 @@
       },
       {
          "title": "1.14.0",
-         "path": "release-notes/1.14.0"
+         "path": "release-notes/1.14.0",
+         "hidden": true
       },
       {
          "title": "1.13.0",


### PR DESCRIPTION
We've already identified a known issue for 1.14, so adding these draft docs (based on #18023 🙇)

The Known Issue in question happens when a user has a control group on reading a PKI issuer -- going to the Issuer details page from the list page will result in a UI loop as shown in the gif below:
![pki-view-issuer-control-group-loop](https://github.com/hashicorp/vault/assets/82459713/9cb4bc91-ac20-458e-89a0-8c8c1edb57fc)

The workaround is to access issuer details from the shortcut box on the Overview page: 
![pki-view-issuer-control-group-workaround](https://github.com/hashicorp/vault/assets/82459713/272fc462-3cc4-4f96-842c-deaaeb1f9835)
