### PR TITLE
Add nonce service to sdk/helpers, use in PKI

### DIFF
--- a/.github/scripts/generate-test-package-lists.sh
+++ b/.github/scripts/generate-test-package-lists.sh
@@ -79,6 +79,7 @@ test_packages[5]+=" $base/vault/external_tests/sealmigration"
 if [ "${ENTERPRISE:+x}" == "x" ] ; then
     test_packages[5]+=" $base/vault/external_tests/transform"
 fi
+test_packages[5]+=" $base/sdk/helper/nonce"
 
 # Total time: 588
 test_packages[6]+=" $base"

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -17,12 +17,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/nonce"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
 const (
 	// How long nonces are considered valid.
-	nonceExpiry = 15 * time.Minute
+	nonceExpiry = 15 * time.Second
 
 	// How many bytes are in a token. Per RFC 8555 Section
 	// 8.3. HTTP Challenge and Section 11.3 Token Entropy:
@@ -40,9 +41,11 @@ const (
 )
 
 type acmeState struct {
-	nextExpiry *atomic.Int64
-	nonces     *sync.Map // map[string]time.Time
-	validator  *ACMEChallengeEngine
+	b *backend
+
+	nonces nonce.NonceService
+
+	validator *ACMEChallengeEngine
 
 	configDirty *atomic.Bool
 	_config     sync.RWMutex
@@ -54,17 +57,22 @@ type acmeThumbprint struct {
 	Thumbprint string `json:"-"`
 }
 
-func NewACMEState() *acmeState {
+func NewACMEState(b *backend) (*acmeState, error) {
+	service, err := nonce.NewNonceServiceWithValidity(nonceExpiry)
+	if err != nil {
+		return nil, err
+	}
+
 	state := &acmeState{
-		nextExpiry:  new(atomic.Int64),
-		nonces:      new(sync.Map),
+		b:           b,
+		nonces:      service,
 		validator:   NewACMEChallengeEngine(),
 		configDirty: new(atomic.Bool),
 	}
 	// Config hasn't been loaded yet; mark dirty.
 	state.configDirty.Store(true)
 
-	return state
+	return state, nil
 }
 
 func (a *acmeState) Initialize(b *backend, sc *storageContext) error {
@@ -124,10 +132,6 @@ func (a *acmeState) getConfigWithUpdate(sc *storageContext) (*acmeConfigEntry, e
 	return &configCopy, nil
 }
 
-func generateNonce() (string, error) {
-	return generateRandomBase64(21)
-}
-
 func generateRandomBase64(srcBytes int) (string, error) {
 	data := make([]byte, 21)
 	if _, err := io.ReadFull(rand.Reader, data); err != nil {
@@ -138,66 +142,15 @@ func generateRandomBase64(srcBytes int) (string, error) {
 }
 
 func (a *acmeState) GetNonce() (string, time.Time, error) {
-	now := time.Now()
-	nonce, err := generateNonce()
-	if err != nil {
-		return "", now, err
-	}
-
-	then := now.Add(nonceExpiry)
-	a.nonces.Store(nonce, then)
-
-	nextExpiry := a.nextExpiry.Load()
-	next := time.Unix(nextExpiry, 0)
-	if now.After(next) || then.Before(next) {
-		a.nextExpiry.Store(then.Unix())
-	}
-
-	return nonce, then, nil
+	return a.nonces.Get()
 }
 
 func (a *acmeState) RedeemNonce(nonce string) bool {
-	rawTimeout, present := a.nonces.LoadAndDelete(nonce)
-	if !present {
-		return false
-	}
-
-	timeout := rawTimeout.(time.Time)
-	if time.Now().After(timeout) {
-		return false
-	}
-
-	return true
+	return a.nonces.Redeem(nonce)
 }
 
 func (a *acmeState) DoTidyNonces() {
-	now := time.Now()
-	expiry := a.nextExpiry.Load()
-	then := time.Unix(expiry, 0)
-
-	if expiry == 0 || now.After(then) {
-		a.TidyNonces()
-	}
-}
-
-func (a *acmeState) TidyNonces() {
-	now := time.Now()
-	nextRun := now.Add(nonceExpiry)
-
-	a.nonces.Range(func(key, value any) bool {
-		timeout := value.(time.Time)
-		if now.After(timeout) {
-			a.nonces.Delete(key)
-		}
-
-		if timeout.Before(nextRun) {
-			nextRun = timeout
-		}
-
-		return false /* don't quit looping */
-	})
-
-	a.nextExpiry.Store(nextRun.Unix())
+	a.b.Logger().Debug("nonce tidy operation", "status", a.nonces.Tidy())
 }
 
 type ACMEAccountStatus string

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -22,9 +22,6 @@ import (
 )
 
 const (
-	// How long nonces are considered valid.
-	nonceExpiry = 15 * time.Second
-
 	// How many bytes are in a token. Per RFC 8555 Section
 	// 8.3. HTTP Challenge and Section 11.3 Token Entropy:
 	//
@@ -57,7 +54,7 @@ type acmeThumbprint struct {
 
 func NewACMEState() *acmeState {
 	state := &acmeState{
-		nonces:      nonce.NewNonceServiceWithValidity(nonceExpiry),
+		nonces:      nonce.NewNonceService(),
 		validator:   NewACMEChallengeEngine(),
 		configDirty: new(atomic.Bool),
 	}

--- a/builtin/logical/pki/acme_state_test.go
+++ b/builtin/logical/pki/acme_state_test.go
@@ -12,7 +12,7 @@ import (
 func TestAcmeNonces(t *testing.T) {
 	t.Parallel()
 
-	a := NewACMEState()
+	a, _ := NewACMEState(nil)
 
 	// Simple operation should succeed.
 	nonce, _, err := a.GetNonce()

--- a/builtin/logical/pki/acme_state_test.go
+++ b/builtin/logical/pki/acme_state_test.go
@@ -12,7 +12,8 @@ import (
 func TestAcmeNonces(t *testing.T) {
 	t.Parallel()
 
-	a, _ := NewACMEState(nil)
+	a := NewACMEState()
+	a.nonces.Initialize()
 
 	// Simple operation should succeed.
 	nonce, _, err := a.GetNonce()

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -312,7 +312,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 
 	b.unifiedTransferStatus = newUnifiedTransferStatus()
 
-	b.acmeState, _ = NewACMEState(&b)
+	b.acmeState = NewACMEState()
 	return &b
 }
 

--- a/sdk/helper/nonce/benchmark_test.go
+++ b/sdk/helper/nonce/benchmark_test.go
@@ -2,14 +2,16 @@ package nonce
 
 import (
 	"runtime"
-    "testing"
+	"testing"
 	"time"
 
-    "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
-const benchValidity = 5*time.Second
-const logMemStats = true
+const (
+	benchValidity = 5 * time.Second
+	logMemStats   = true
+)
 
 func benchWrapper(helper func(*testing.B, NonceService), b *testing.B, s NonceService) {
 	err := s.Initialize()
@@ -22,10 +24,10 @@ func benchWrapper(helper func(*testing.B, NonceService), b *testing.B, s NonceSe
 	runtime.ReadMemStats(&m2)
 
 	if logMemStats {
-		b.Logf("in-use memory size:  %v", m2.Alloc - m1.Alloc)
-		b.Logf("total alloc size:    %v", m2.TotalAlloc - m1.TotalAlloc)
-		b.Logf("in-use memory count: %v", (m2.Mallocs - m2.Frees) - (m1.Mallocs - m1.Frees))
-		b.Logf("total alloc count:   %v", m2.Mallocs - m1.Mallocs)
+		b.Logf("in-use memory size:  %v", m2.Alloc-m1.Alloc)
+		b.Logf("total alloc size:    %v", m2.TotalAlloc-m1.TotalAlloc)
+		b.Logf("in-use memory count: %v", (m2.Mallocs-m2.Frees)-(m1.Mallocs-m1.Frees))
+		b.Logf("total alloc count:   %v", m2.Mallocs-m1.Mallocs)
 	}
 	b.Logf("Tidy output: %v", s.Tidy())
 }
@@ -36,7 +38,7 @@ func BenchmarkEncryptedNonceServiceGet(b *testing.B) {
 }
 
 func BenchmarkSyncMapNonceServiceGet(b *testing.B) {
-    s := newSyncMapNonceService(benchValidity)
+	s := newSyncMapNonceService(benchValidity)
 	benchWrapper(benchGet, b, s)
 }
 
@@ -55,7 +57,7 @@ func BenchmarkEncryptedNonceServiceGetRedeem(b *testing.B) {
 }
 
 func BenchmarkSyncMapNonceServiceGetRedeem(b *testing.B) {
-    s := newSyncMapNonceService(benchValidity)
+	s := newSyncMapNonceService(benchValidity)
 	benchWrapper(benchGetRedeem, b, s)
 }
 
@@ -78,7 +80,7 @@ func BenchmarkEncryptedNonceServiceGetRedeemTidy(b *testing.B) {
 }
 
 func BenchmarkSyncMapNonceServiceGetRedeemTidy(b *testing.B) {
-    s := newSyncMapNonceService(benchValidity)
+	s := newSyncMapNonceService(benchValidity)
 	benchWrapper(benchGetRedeemTidy, b, s)
 }
 
@@ -100,7 +102,7 @@ func BenchmarkEncryptedNonceServiceSequentialTidy(b *testing.B) {
 }
 
 func BenchmarkSyncMapNonceServiceSequentialTidy(b *testing.B) {
-    s := newSyncMapNonceService(benchValidity)
+	s := newSyncMapNonceService(benchValidity)
 	benchWrapper(benchGetRedeemSequentialTidy, b, s)
 }
 
@@ -124,7 +126,7 @@ func BenchmarkEncryptedNonceServiceRandomTidy(b *testing.B) {
 }
 
 func BenchmarkSyncMapNonceServiceRandomTidy(b *testing.B) {
-    s := newSyncMapNonceService(benchValidity)
+	s := newSyncMapNonceService(benchValidity)
 	benchWrapper(benchGetRedeemRandomTidy, b, s)
 }
 
@@ -145,98 +147,98 @@ func benchGetRedeemRandomTidy(b *testing.B, s NonceService) {
 }
 
 func BenchmarkEncryptedNonceServiceParallelGet(b *testing.B) {
-    s := newEncryptedNonceService(benchValidity)
-    benchWrapper(benchGetParallelGet, b, s)
+	s := newEncryptedNonceService(benchValidity)
+	benchWrapper(benchGetParallelGet, b, s)
 }
 
 func BenchmarkSyncMapNonceServiceParallelGet(b *testing.B) {
-    s := newSyncMapNonceService(benchValidity)
-    benchWrapper(benchGetParallelGet, b, s)
+	s := newSyncMapNonceService(benchValidity)
+	benchWrapper(benchGetParallelGet, b, s)
 }
 
 func benchGetParallelGet(b *testing.B, s NonceService) {
-    b.ResetTimer()
+	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-	        token, _, err := s.Get()
-    	    require.NoError(b, err)
-        	require.NotEmpty(b, token)
+			token, _, err := s.Get()
+			require.NoError(b, err)
+			require.NotEmpty(b, token)
 		}
-    })
+	})
 }
 
 func BenchmarkEncryptedNonceServiceParallelGetRedeem(b *testing.B) {
-    s := newEncryptedNonceService(benchValidity)
-    benchWrapper(benchGetRedeemParallelGetRedeem, b, s)
+	s := newEncryptedNonceService(benchValidity)
+	benchWrapper(benchGetRedeemParallelGetRedeem, b, s)
 }
 
 func BenchmarkSyncMapNonceServiceParallelGetRedeem(b *testing.B) {
 	s := newSyncMapNonceService(benchValidity)
-    benchWrapper(benchGetRedeemParallelGetRedeem, b, s)
+	benchWrapper(benchGetRedeemParallelGetRedeem, b, s)
 }
 
 func benchGetRedeemParallelGetRedeem(b *testing.B, s NonceService) {
-    b.ResetTimer()
+	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-	        token, _, err := s.Get()
-    	    require.NoError(b, err)
-        	require.NotEmpty(b, token)
+			token, _, err := s.Get()
+			require.NoError(b, err)
+			require.NotEmpty(b, token)
 			ok := s.Redeem(token)
-    	    require.True(b, ok)
+			require.True(b, ok)
 		}
-    })
+	})
 }
 
 func BenchmarkEncryptedNonceServiceParallelGetRedeemTidy(b *testing.B) {
-    s := newEncryptedNonceService(benchValidity)
-    benchWrapper(benchGetRedeemParallelGetRedeemTidy, b, s)
+	s := newEncryptedNonceService(benchValidity)
+	benchWrapper(benchGetRedeemParallelGetRedeemTidy, b, s)
 }
 
 func BenchmarkSyncMapNonceServiceParallelGetRedeemTidy(b *testing.B) {
-    s := newSyncMapNonceService(benchValidity)
-    benchWrapper(benchGetRedeemParallelGetRedeemTidy, b, s)
+	s := newSyncMapNonceService(benchValidity)
+	benchWrapper(benchGetRedeemParallelGetRedeemTidy, b, s)
 }
 
 func benchGetRedeemParallelGetRedeemTidy(b *testing.B, s NonceService) {
-    b.ResetTimer()
+	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-	        token, _, err := s.Get()
-    	    require.NoError(b, err)
-        	require.NotEmpty(b, token)
+			token, _, err := s.Get()
+			require.NoError(b, err)
+			require.NotEmpty(b, token)
 			ok := s.Redeem(token)
-    	    require.True(b, ok)
+			require.True(b, ok)
 			s.Tidy()
 		}
-    })
+	})
 }
 
 func BenchmarkEncryptedNonceServiceParallelTidy(b *testing.B) {
-    s := newEncryptedNonceService(benchValidity)
-    benchWrapper(benchParallelTidy, b, s)
+	s := newEncryptedNonceService(benchValidity)
+	benchWrapper(benchParallelTidy, b, s)
 }
 
 func BenchmarkSyncMapNonceServiceParallelTidy(b *testing.B) {
-    s := newSyncMapNonceService(benchValidity)
-    benchWrapper(benchParallelTidy, b, s)
+	s := newSyncMapNonceService(benchValidity)
+	benchWrapper(benchParallelTidy, b, s)
 }
 
 func benchParallelTidy(b *testing.B, s NonceService) {
-    b.ResetTimer()
+	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-	        token, _, err := s.Get()
-    	    require.NoError(b, err)
-        	require.NotEmpty(b, token)
+			token, _, err := s.Get()
+			require.NoError(b, err)
+			require.NotEmpty(b, token)
 			ok := s.Redeem(token)
-    	    require.True(b, ok)
+			require.True(b, ok)
 		}
-    })
+	})
 
 	b.StopTimer()
 	time.Sleep(2*time.Second + benchValidity)

--- a/sdk/helper/nonce/benchmark_test.go
+++ b/sdk/helper/nonce/benchmark_test.go
@@ -12,6 +12,9 @@ const benchValidity = 5*time.Second
 const logMemStats = true
 
 func benchWrapper(helper func(*testing.B, NonceService), b *testing.B, s NonceService) {
+	err := s.Initialize()
+	require.NoError(b, err)
+
 	var m1, m2 runtime.MemStats
 	runtime.GC()
 	runtime.ReadMemStats(&m1)
@@ -28,14 +31,12 @@ func benchWrapper(helper func(*testing.B, NonceService), b *testing.B, s NonceSe
 }
 
 func BenchmarkEncryptedNonceServiceGet(b *testing.B) {
-	s, err := newEncryptedNonceService(benchValidity)
-    require.NoError(b, err)
+	s := newEncryptedNonceService(benchValidity)
 	benchWrapper(benchGet, b, s)
 }
 
 func BenchmarkSyncMapNonceServiceGet(b *testing.B) {
-    s, err := newSyncMapNonceService(benchValidity)
-    require.NoError(b, err)
+    s := newSyncMapNonceService(benchValidity)
 	benchWrapper(benchGet, b, s)
 }
 
@@ -49,14 +50,12 @@ func benchGet(b *testing.B, s NonceService) {
 }
 
 func BenchmarkEncryptedNonceServiceGetRedeem(b *testing.B) {
-	s, err := newEncryptedNonceService(benchValidity)
-    require.NoError(b, err)
+	s := newEncryptedNonceService(benchValidity)
 	benchWrapper(benchGetRedeem, b, s)
 }
 
 func BenchmarkSyncMapNonceServiceGetRedeem(b *testing.B) {
-    s, err := newSyncMapNonceService(benchValidity)
-    require.NoError(b, err)
+    s := newSyncMapNonceService(benchValidity)
 	benchWrapper(benchGetRedeem, b, s)
 }
 
@@ -74,14 +73,12 @@ func benchGetRedeem(b *testing.B, s NonceService) {
 }
 
 func BenchmarkEncryptedNonceServiceGetRedeemTidy(b *testing.B) {
-	s, err := newEncryptedNonceService(benchValidity)
-    require.NoError(b, err)
+	s := newEncryptedNonceService(benchValidity)
 	benchWrapper(benchGetRedeemTidy, b, s)
 }
 
 func BenchmarkSyncMapNonceServiceGetRedeemTidy(b *testing.B) {
-    s, err := newSyncMapNonceService(benchValidity)
-    require.NoError(b, err)
+    s := newSyncMapNonceService(benchValidity)
 	benchWrapper(benchGetRedeemTidy, b, s)
 }
 
@@ -98,14 +95,12 @@ func benchGetRedeemTidy(b *testing.B, s NonceService) {
 }
 
 func BenchmarkEncryptedNonceServiceSequentialTidy(b *testing.B) {
-	s, err := newEncryptedNonceService(benchValidity)
-    require.NoError(b, err)
+	s := newEncryptedNonceService(benchValidity)
 	benchWrapper(benchGetRedeemSequentialTidy, b, s)
 }
 
 func BenchmarkSyncMapNonceServiceSequentialTidy(b *testing.B) {
-    s, err := newSyncMapNonceService(benchValidity)
-    require.NoError(b, err)
+    s := newSyncMapNonceService(benchValidity)
 	benchWrapper(benchGetRedeemSequentialTidy, b, s)
 }
 
@@ -124,14 +119,12 @@ func benchGetRedeemSequentialTidy(b *testing.B, s NonceService) {
 }
 
 func BenchmarkEncryptedNonceServiceRandomTidy(b *testing.B) {
-	s, err := newEncryptedNonceService(benchValidity)
-    require.NoError(b, err)
+	s := newEncryptedNonceService(benchValidity)
 	benchWrapper(benchGetRedeemRandomTidy, b, s)
 }
 
 func BenchmarkSyncMapNonceServiceRandomTidy(b *testing.B) {
-    s, err := newSyncMapNonceService(benchValidity)
-    require.NoError(b, err)
+    s := newSyncMapNonceService(benchValidity)
 	benchWrapper(benchGetRedeemRandomTidy, b, s)
 }
 
@@ -152,14 +145,12 @@ func benchGetRedeemRandomTidy(b *testing.B, s NonceService) {
 }
 
 func BenchmarkEncryptedNonceServiceParallelGet(b *testing.B) {
-    s, err := newEncryptedNonceService(benchValidity)
-    require.NoError(b, err)
+    s := newEncryptedNonceService(benchValidity)
     benchWrapper(benchGetParallelGet, b, s)
 }
 
 func BenchmarkSyncMapNonceServiceParallelGet(b *testing.B) {
-    s, err := newSyncMapNonceService(benchValidity)
-    require.NoError(b, err)
+    s := newSyncMapNonceService(benchValidity)
     benchWrapper(benchGetParallelGet, b, s)
 }
 
@@ -176,14 +167,12 @@ func benchGetParallelGet(b *testing.B, s NonceService) {
 }
 
 func BenchmarkEncryptedNonceServiceParallelGetRedeem(b *testing.B) {
-    s, err := newEncryptedNonceService(benchValidity)
-    require.NoError(b, err)
+    s := newEncryptedNonceService(benchValidity)
     benchWrapper(benchGetRedeemParallelGetRedeem, b, s)
 }
 
 func BenchmarkSyncMapNonceServiceParallelGetRedeem(b *testing.B) {
-    s, err := newSyncMapNonceService(benchValidity)
-    require.NoError(b, err)
+	s := newSyncMapNonceService(benchValidity)
     benchWrapper(benchGetRedeemParallelGetRedeem, b, s)
 }
 
@@ -202,14 +191,12 @@ func benchGetRedeemParallelGetRedeem(b *testing.B, s NonceService) {
 }
 
 func BenchmarkEncryptedNonceServiceParallelGetRedeemTidy(b *testing.B) {
-    s, err := newEncryptedNonceService(benchValidity)
-    require.NoError(b, err)
+    s := newEncryptedNonceService(benchValidity)
     benchWrapper(benchGetRedeemParallelGetRedeemTidy, b, s)
 }
 
 func BenchmarkSyncMapNonceServiceParallelGetRedeemTidy(b *testing.B) {
-    s, err := newSyncMapNonceService(benchValidity)
-    require.NoError(b, err)
+    s := newSyncMapNonceService(benchValidity)
     benchWrapper(benchGetRedeemParallelGetRedeemTidy, b, s)
 }
 
@@ -229,14 +216,12 @@ func benchGetRedeemParallelGetRedeemTidy(b *testing.B, s NonceService) {
 }
 
 func BenchmarkEncryptedNonceServiceParallelTidy(b *testing.B) {
-    s, err := newEncryptedNonceService(benchValidity)
-    require.NoError(b, err)
+    s := newEncryptedNonceService(benchValidity)
     benchWrapper(benchParallelTidy, b, s)
 }
 
 func BenchmarkSyncMapNonceServiceParallelTidy(b *testing.B) {
-    s, err := newSyncMapNonceService(benchValidity)
-    require.NoError(b, err)
+    s := newSyncMapNonceService(benchValidity)
     benchWrapper(benchParallelTidy, b, s)
 }
 

--- a/sdk/helper/nonce/benchmark_test.go
+++ b/sdk/helper/nonce/benchmark_test.go
@@ -1,0 +1,261 @@
+package nonce
+
+import (
+	"runtime"
+    "testing"
+	"time"
+
+    "github.com/stretchr/testify/require"
+)
+
+const benchValidity = 5*time.Second
+const logMemStats = true
+
+func benchWrapper(helper func(*testing.B, NonceService), b *testing.B, s NonceService) {
+	var m1, m2 runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&m1)
+	helper(b, s)
+	runtime.ReadMemStats(&m2)
+
+	if logMemStats {
+		b.Logf("in-use memory size:  %v", m2.Alloc - m1.Alloc)
+		b.Logf("total alloc size:    %v", m2.TotalAlloc - m1.TotalAlloc)
+		b.Logf("in-use memory count: %v", (m2.Mallocs - m2.Frees) - (m1.Mallocs - m1.Frees))
+		b.Logf("total alloc count:   %v", m2.Mallocs - m1.Mallocs)
+	}
+	b.Logf("Tidy output: %v", s.Tidy())
+}
+
+func BenchmarkEncryptedNonceServiceGet(b *testing.B) {
+	s, err := newEncryptedNonceService(benchValidity)
+    require.NoError(b, err)
+	benchWrapper(benchGet, b, s)
+}
+
+func BenchmarkSyncMapNonceServiceGet(b *testing.B) {
+    s, err := newSyncMapNonceService(benchValidity)
+    require.NoError(b, err)
+	benchWrapper(benchGet, b, s)
+}
+
+func benchGet(b *testing.B, s NonceService) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		token, _, err := s.Get()
+		require.NoError(b, err)
+		require.NotEmpty(b, token)
+	}
+}
+
+func BenchmarkEncryptedNonceServiceGetRedeem(b *testing.B) {
+	s, err := newEncryptedNonceService(benchValidity)
+    require.NoError(b, err)
+	benchWrapper(benchGetRedeem, b, s)
+}
+
+func BenchmarkSyncMapNonceServiceGetRedeem(b *testing.B) {
+    s, err := newSyncMapNonceService(benchValidity)
+    require.NoError(b, err)
+	benchWrapper(benchGetRedeem, b, s)
+}
+
+func benchGetRedeem(b *testing.B, s NonceService) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		token, _, err := s.Get()
+		require.NoError(b, err)
+		require.NotEmpty(b, token)
+		ok := s.Redeem(token)
+		require.True(b, ok)
+		ok = s.Redeem(token)
+		require.False(b, ok)
+	}
+}
+
+func BenchmarkEncryptedNonceServiceGetRedeemTidy(b *testing.B) {
+	s, err := newEncryptedNonceService(benchValidity)
+    require.NoError(b, err)
+	benchWrapper(benchGetRedeemTidy, b, s)
+}
+
+func BenchmarkSyncMapNonceServiceGetRedeemTidy(b *testing.B) {
+    s, err := newSyncMapNonceService(benchValidity)
+    require.NoError(b, err)
+	benchWrapper(benchGetRedeemTidy, b, s)
+}
+
+func benchGetRedeemTidy(b *testing.B, s NonceService) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		token, _, err := s.Get()
+		require.NoError(b, err)
+		require.NotEmpty(b, token)
+		ok := s.Redeem(token)
+		require.True(b, ok)
+		s.Tidy()
+	}
+}
+
+func BenchmarkEncryptedNonceServiceSequentialTidy(b *testing.B) {
+	s, err := newEncryptedNonceService(benchValidity)
+    require.NoError(b, err)
+	benchWrapper(benchGetRedeemSequentialTidy, b, s)
+}
+
+func BenchmarkSyncMapNonceServiceSequentialTidy(b *testing.B) {
+    s, err := newSyncMapNonceService(benchValidity)
+    require.NoError(b, err)
+	benchWrapper(benchGetRedeemSequentialTidy, b, s)
+}
+
+func benchGetRedeemSequentialTidy(b *testing.B, s NonceService) {
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		token, _, err := s.Get()
+		require.NoError(b, err)
+		require.NotEmpty(b, token)
+		ok := s.Redeem(token)
+		require.True(b, ok)
+	}
+
+	s.Tidy()
+}
+
+func BenchmarkEncryptedNonceServiceRandomTidy(b *testing.B) {
+	s, err := newEncryptedNonceService(benchValidity)
+    require.NoError(b, err)
+	benchWrapper(benchGetRedeemRandomTidy, b, s)
+}
+
+func BenchmarkSyncMapNonceServiceRandomTidy(b *testing.B) {
+    s, err := newSyncMapNonceService(benchValidity)
+    require.NoError(b, err)
+	benchWrapper(benchGetRedeemRandomTidy, b, s)
+}
+
+func benchGetRedeemRandomTidy(b *testing.B, s NonceService) {
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		token, _, err := s.Get()
+		require.NoError(b, err)
+		require.NotEmpty(b, token)
+		if (i % 3) == 1 {
+			ok := s.Redeem(token)
+			require.True(b, ok)
+		}
+	}
+
+	s.Tidy()
+}
+
+func BenchmarkEncryptedNonceServiceParallelGet(b *testing.B) {
+    s, err := newEncryptedNonceService(benchValidity)
+    require.NoError(b, err)
+    benchWrapper(benchGetParallelGet, b, s)
+}
+
+func BenchmarkSyncMapNonceServiceParallelGet(b *testing.B) {
+    s, err := newSyncMapNonceService(benchValidity)
+    require.NoError(b, err)
+    benchWrapper(benchGetParallelGet, b, s)
+}
+
+func benchGetParallelGet(b *testing.B, s NonceService) {
+    b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+	        token, _, err := s.Get()
+    	    require.NoError(b, err)
+        	require.NotEmpty(b, token)
+		}
+    })
+}
+
+func BenchmarkEncryptedNonceServiceParallelGetRedeem(b *testing.B) {
+    s, err := newEncryptedNonceService(benchValidity)
+    require.NoError(b, err)
+    benchWrapper(benchGetRedeemParallelGetRedeem, b, s)
+}
+
+func BenchmarkSyncMapNonceServiceParallelGetRedeem(b *testing.B) {
+    s, err := newSyncMapNonceService(benchValidity)
+    require.NoError(b, err)
+    benchWrapper(benchGetRedeemParallelGetRedeem, b, s)
+}
+
+func benchGetRedeemParallelGetRedeem(b *testing.B, s NonceService) {
+    b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+	        token, _, err := s.Get()
+    	    require.NoError(b, err)
+        	require.NotEmpty(b, token)
+			ok := s.Redeem(token)
+    	    require.True(b, ok)
+		}
+    })
+}
+
+func BenchmarkEncryptedNonceServiceParallelGetRedeemTidy(b *testing.B) {
+    s, err := newEncryptedNonceService(benchValidity)
+    require.NoError(b, err)
+    benchWrapper(benchGetRedeemParallelGetRedeemTidy, b, s)
+}
+
+func BenchmarkSyncMapNonceServiceParallelGetRedeemTidy(b *testing.B) {
+    s, err := newSyncMapNonceService(benchValidity)
+    require.NoError(b, err)
+    benchWrapper(benchGetRedeemParallelGetRedeemTidy, b, s)
+}
+
+func benchGetRedeemParallelGetRedeemTidy(b *testing.B, s NonceService) {
+    b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+	        token, _, err := s.Get()
+    	    require.NoError(b, err)
+        	require.NotEmpty(b, token)
+			ok := s.Redeem(token)
+    	    require.True(b, ok)
+			s.Tidy()
+		}
+    })
+}
+
+func BenchmarkEncryptedNonceServiceParallelTidy(b *testing.B) {
+    s, err := newEncryptedNonceService(benchValidity)
+    require.NoError(b, err)
+    benchWrapper(benchParallelTidy, b, s)
+}
+
+func BenchmarkSyncMapNonceServiceParallelTidy(b *testing.B) {
+    s, err := newSyncMapNonceService(benchValidity)
+    require.NoError(b, err)
+    benchWrapper(benchParallelTidy, b, s)
+}
+
+func benchParallelTidy(b *testing.B, s NonceService) {
+    b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+	        token, _, err := s.Get()
+    	    require.NoError(b, err)
+        	require.NotEmpty(b, token)
+			ok := s.Redeem(token)
+    	    require.True(b, ok)
+		}
+    })
+
+	b.StopTimer()
+	time.Sleep(2*time.Second + benchValidity)
+	runtime.GC()
+	b.StartTimer()
+	s.Tidy()
+}

--- a/sdk/helper/nonce/encrypted_nonce.go
+++ b/sdk/helper/nonce/encrypted_nonce.go
@@ -1,0 +1,361 @@
+// Nonce is a class for generating and validating nonces loosely based off
+// the design of Let's Encrypt's Boulder nonce service here:
+//
+//   https://github.com/letsencrypt/boulder/blob/main/nonce/nonce.go
+
+package nonce
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	nonceSentinel        = "vault0"
+	nonceLength          = 6 + 8 + 16 + 16
+	noncePlaintextLength = 16
+)
+
+type (
+	ensTimestamp uint64
+	ensCounter   uint64
+)
+
+type encryptedNonceService struct {
+	validity time.Duration
+
+	crypt cipher.AEAD
+
+	nextCounter *atomic.Uint64
+
+	issueLock      *sync.Mutex
+	maxIssued      map[ensTimestamp]ensCounter
+	minCounter     *atomic.Uint64
+	redeemedTokens map[ensTimestamp]map[ensCounter]struct{}
+}
+
+func newEncryptedNonceService(validity time.Duration) (*encryptedNonceService, error) {
+	// On startup, create a new AES key. This avoids having issues with the
+	// number of encryptions we can do under this service.
+	key := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return nil, fmt.Errorf("failed to initialize AES key: %w", err)
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize AES cipher: %w", err)
+	}
+
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize AES-GCM: %w", err)
+	}
+
+	return &encryptedNonceService{
+		validity: validity,
+		crypt:    aead,
+
+		// nextCounter.Add(1) returns the _new_ value; by initializing to
+		// zero, we guarantee that nextCounter = minCounter + 1 on the first
+		// read; if it is redeemed right away, we then hold that invariant.
+		nextCounter: new(atomic.Uint64),
+
+		issueLock:      new(sync.Mutex),
+		maxIssued:      make(map[ensTimestamp]ensCounter, validity/time.Second),
+		minCounter:     new(atomic.Uint64),
+		redeemedTokens: make(map[ensTimestamp]map[ensCounter]struct{}, validity/time.Second),
+	}, nil
+}
+
+func (ens *encryptedNonceService) IsStrict() bool    { return true }
+func (ens *encryptedNonceService) IsCrossNode() bool { return false }
+
+func (ens *encryptedNonceService) encryptNonce(counter uint64, expiry time.Time) (token string, err error) {
+	// counter is an 8-byte value and expiry (as a unix timestamp) is
+	// likewise, so we have exactly one block of data.
+	//
+	// We encode in argument order, i.e., (counter, expiry), and in
+	// big endian format.
+
+	// Like Let's Encrypt, we use a 12-byte nonce with the leading four
+	// bytes as zero and the remaining 8 bytes as zeros. This gives us
+	// 2^(8*8)/2 = 2^32 birthday paradox limit to reuse a nonce. However,
+	// note that nonce reuse (in AES-GCM) doesn't leak the key, only the
+	// XOR of the plaintext. Here, as long as they can't forge valid nonces,
+	// we're fine.
+	nonce := make([]byte, 12)
+	for i := 0; i < 4; i++ {
+		nonce[i] = 0
+	}
+	if _, err := io.ReadFull(rand.Reader, nonce[4:]); err != nil {
+		return "", fmt.Errorf("failed to read AEAD nonce: %w", err)
+	}
+
+	plaintext := make([]byte, noncePlaintextLength)
+	binary.BigEndian.PutUint64(plaintext[0:], counter)
+	binary.BigEndian.PutUint64(plaintext[8:], uint64(expiry.Unix()))
+	ciphertext := ens.crypt.Seal(nil, nonce, plaintext, nil)
+
+	// Now, generate the wire format of the nonce. Use a prefix, the nonce,
+	// and then the ciphertext.
+	var wire []byte
+	wire = append(wire, []byte(nonceSentinel)...)
+	wire = append(wire, nonce[4:]...)
+	wire = append(wire, ciphertext...)
+
+	if len(wire) != nonceLength {
+		return "", fmt.Errorf("expected nonce length of %v got %v", nonceLength, len(wire))
+	}
+
+	return base64.RawURLEncoding.EncodeToString(wire), nil
+}
+
+func (ens *encryptedNonceService) recordCounterForTime(counter uint64, expiry time.Time) {
+	timestamp := ensTimestamp(expiry.Unix())
+	value := ensCounter(counter)
+
+	ens.issueLock.Lock()
+	defer ens.issueLock.Unlock()
+
+	lastValue, ok := ens.maxIssued[timestamp]
+	if !ok || lastValue < value {
+		ens.maxIssued[timestamp] = value
+	}
+}
+
+func (ens *encryptedNonceService) Get() (token string, expiry time.Time, err error) {
+	counter := ens.nextCounter.Add(1)
+	now := time.Now()
+	then := now.Add(ens.validity)
+
+	token, err = ens.encryptNonce(counter, then)
+	if err != nil {
+		return "", now, err
+	}
+
+	ens.recordCounterForTime(counter, then)
+	return token, then, nil
+}
+
+func (ens *encryptedNonceService) decryptNonce(token string) (counter uint64, expiry time.Time, ok bool) {
+	zero := time.Time{}
+
+	wire, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return 0, zero, false
+	}
+
+	if len(wire) != nonceLength {
+		return 0, zero, false
+	}
+
+	data := wire
+
+	sentinel := data[0:len(nonceSentinel)]
+	data = data[len(nonceSentinel):]
+	if subtle.ConstantTimeCompare([]byte(nonceSentinel), sentinel) != 1 {
+		return 0, zero, false
+	}
+
+	nonce := make([]byte, 12)
+	for i := 0; i < 4; i++ {
+		nonce[i] = 0
+	}
+	copy(nonce[4:12], data[0:8])
+	data = data[8:]
+
+	ciphertext := data[:]
+
+	plaintext, err := ens.crypt.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return 0, zero, false
+	}
+
+	if len(plaintext) != noncePlaintextLength {
+		return 0, zero, false
+	}
+
+	counter = binary.BigEndian.Uint64(plaintext[0:8])
+	unix := binary.BigEndian.Uint64(plaintext[8:])
+	expiry = time.Unix(int64(unix), 0)
+
+	return counter, expiry, true
+}
+
+func (ens *encryptedNonceService) Redeem(token string) bool {
+	now := time.Now()
+	counter, expiry, ok := ens.decryptNonce(token)
+	if !ok {
+		return false
+	}
+
+	if expiry.Before(now) {
+		return false
+	}
+
+	if counter <= ens.minCounter.Load() {
+		return false
+	}
+
+	timestamp := ensTimestamp(expiry.Unix())
+	counterValue := ensCounter(counter)
+
+	// From here on out, we're doing the expensive checks. This _looks_
+	// like a valid token, but now we want to verify the used-exactly-once
+	// nature.
+	ens.issueLock.Lock()
+	defer ens.issueLock.Unlock()
+
+	minCounter := ens.minCounter.Load()
+	if counter <= minCounter {
+		// Someone else redeemed this token or time has rolled over before we
+		// grabbed this lock. Reject this token.
+		return false
+	}
+
+	// Check if this has already been redeemed.
+	timestampMap, present := ens.redeemedTokens[timestamp]
+	if !present {
+		// No tokens have been redeemed from this token. Provision the
+		// timestamp-specific map, but wait to see if we need to add into
+		// it.
+		timestampMap = make(map[ensCounter]struct{})
+		ens.redeemedTokens[timestamp] = timestampMap
+	}
+
+	_, present = timestampMap[counterValue]
+	if present {
+		// Token was already redeemed. Reject this request.
+		return false
+	}
+
+	// From here on out, the token is valid. Let's start by seeing if we can
+	// free any memory usage.
+	minCounter = ens.tidyMemoryHoldingLock(now, minCounter)
+
+	// Before we add to the map, we should see if we can save memory by just
+	// incrementing the minimum accepted by one, instead of adding to the
+	// timestamp for out of order redemption.
+	if minCounter+1 == counter {
+		minCounter = counter
+	} else {
+		// Otherwise, we've got to flag this counter as valid.
+		timestampMap[counterValue] = struct{}{}
+	}
+
+	// Finally, update our value of minCounter because we held the lock.
+	ens.minCounter.Store(minCounter)
+
+	return true
+}
+
+func (ens *encryptedNonceService) tidyMemoryHoldingLock(now time.Time, minCounter uint64) uint64 {
+	// Quick and dirty tidy: any expired timestamps should be deleted, which
+	// should free the most memory (relatively speaking, given a uniform
+	// usage pattern). This also avoids an expensive iteration over all
+	// redeemed counter values.
+	//
+	// First tidy the redeemed tokens, as that is the largest value.
+	var deleteCandidates []ensTimestamp
+	for candidate := range ens.redeemedTokens {
+		if candidate < ensTimestamp(now.Unix()) {
+			deleteCandidates = append(deleteCandidates, candidate)
+		}
+	}
+	for _, candidate := range deleteCandidates {
+		delete(ens.redeemedTokens, candidate)
+	}
+
+	// Then tidy the last used timestamp values. Here, any removed timestamps
+	// have an expiry time before now, which means they cannot be used. This
+	// means our minCounterValue, if it is
+	deleteCandidates = nil
+	for candidate, lastIssuedInTimestamp := range ens.maxIssued {
+		if candidate < ensTimestamp(now.Unix()) {
+			deleteCandidates = append(deleteCandidates, candidate)
+			if lastIssuedInTimestamp > ensCounter(minCounter) {
+				minCounter = uint64(lastIssuedInTimestamp)
+			}
+		}
+	}
+	for _, candidate := range deleteCandidates {
+		delete(ens.maxIssued, candidate)
+	}
+	return minCounter
+}
+
+func (ens *encryptedNonceService) tidySequentialNonces(now time.Time, minCounter uint64) uint64 {
+	var timestamps []ensTimestamp
+	for timestamp := range ens.redeemedTokens {
+		timestamps = append(timestamps, timestamp)
+	}
+
+	sort.Slice(timestamps, func(i, j int) bool { return timestamps[i] < timestamps[j] })
+	var deleteCandidates []ensTimestamp
+	for _, timestamp := range timestamps {
+		counters := ens.redeemedTokens[timestamp]
+		for len(counters) > 0 {
+			_, present := counters[ensCounter(minCounter+1)]
+			if !present {
+				return minCounter
+			}
+
+			minCounter += 1
+			delete(counters, ensCounter(minCounter))
+		}
+
+		if len(counters) == 0 {
+			deleteCandidates = append(deleteCandidates, timestamp)
+		}
+	}
+	for _, candidate := range deleteCandidates {
+		delete(ens.redeemedTokens, candidate)
+	}
+
+	return minCounter
+}
+
+func (ens *encryptedNonceService) getMessage() string {
+	var message string
+	message += fmt.Sprintf("len(ens.maxIssued): %v\n", len(ens.maxIssued))
+	message += fmt.Sprintf("len(ens.redeemedTokens): %v\n", len(ens.redeemedTokens))
+
+	var total int
+	for timestamp, counters := range ens.redeemedTokens {
+		message += fmt.Sprintf("\tens.redeemedTokens[%v]: %v\n", timestamp, len(counters))
+		total += len(counters)
+	}
+
+	message += fmt.Sprintf("total redeemed tokens: %v\n", total)
+	return message
+}
+
+func (ens *encryptedNonceService) Tidy() *NonceStatus {
+	ens.issueLock.Lock()
+	defer ens.issueLock.Unlock()
+
+	minCounter := ens.minCounter.Load()
+	now := time.Now()
+
+	minCounter = ens.tidyMemoryHoldingLock(now, minCounter)
+	minCounter = ens.tidySequentialNonces(now, minCounter)
+	ens.minCounter.Store(minCounter)
+
+	issued := ens.nextCounter.Load()
+	return &NonceStatus{
+		Issued:      issued,
+		Outstanding: issued - minCounter,
+		Message:     ens.getMessage(),
+	}
+}

--- a/sdk/helper/nonce/nonce.go
+++ b/sdk/helper/nonce/nonce.go
@@ -1,0 +1,66 @@
+// Nonce is a class for generating and validating nonces loosely based off
+// the design of Let's Encrypt's Boulder nonce service here:
+//
+//   https://github.com/letsencrypt/boulder/blob/main/nonce/nonce.go
+
+package nonce
+
+import (
+	"time"
+)
+
+// NonceService is an interface for issuing and redeeming nonces, with
+// a hook to periodically free resources when no redemptions have happened
+// recently.
+//
+// Notably, nonces are not guaranteed to be stored or persisted; nonces
+// from one startup will not necessarily be valid from another.
+type NonceService interface {
+	// Get a nonce; returns three values:
+	//
+	// 1. The nonce itself, a base64-url-no-padding opaque value.
+	// 2. A time at which the nonce will expire, based on the validity
+	//    period specified at construction. By default, the service issues
+	//    short-lived nonces.
+	// 3. An error if one occurred during generation of the nonce.
+	Get() (string, time.Time, error)
+
+	// Redeem the given nonce, returning whether or not it was accepted. A
+	// nonce given twice will be rejected if the service is a strict nonce
+	// service, but potentially accepted if the nonce service is loose
+	// (i.e., temporal revocation only).
+	Redeem(string) bool
+
+	// A hook to tidy the memory usage of the underlying implementation; is
+	// implementation dependent. Some implementations may not return status
+	// information.
+	Tidy() *NonceStatus
+
+	// If true, this is a strict only-once redemption service implementation,
+	// else a nonce could be accepted more than once within some safety
+	// window.
+	IsStrict() bool
+
+	// Whether or not this service is usable across nodes.
+	IsCrossNode() bool
+}
+
+func NewNonceService() (NonceService, error) {
+	// By default, we create an encrypted nonce service that is strict but not
+	// cross node, using a default window of 90 seconds (equal to the default
+	// context request timeout window).
+	return NewNonceServiceWithValidity(90 * time.Second)
+}
+
+func NewNonceServiceWithValidity(validity time.Duration) (NonceService, error) {
+	return newEncryptedNonceService(validity)
+}
+
+// Status information about the number of nonces in this service, perhaps
+// local to this node. Presumably, the delta roughly correlates to present
+// memory usage.
+type NonceStatus struct {
+	Issued      uint64
+	Outstanding uint64
+	Message     string
+}

--- a/sdk/helper/nonce/nonce.go
+++ b/sdk/helper/nonce/nonce.go
@@ -16,6 +16,10 @@ import (
 // Notably, nonces are not guaranteed to be stored or persisted; nonces
 // from one startup will not necessarily be valid from another.
 type NonceService interface {
+	// Before using a nonce service, it must be initialized. Failure to
+	// initialize might result in panics or other unexpected results.
+	Initialize() error
+
 	// Get a nonce; returns three values:
 	//
 	// 1. The nonce itself, a base64-url-no-padding opaque value.
@@ -45,14 +49,14 @@ type NonceService interface {
 	IsCrossNode() bool
 }
 
-func NewNonceService() (NonceService, error) {
+func NewNonceService() NonceService {
 	// By default, we create an encrypted nonce service that is strict but not
 	// cross node, using a default window of 90 seconds (equal to the default
 	// context request timeout window).
 	return NewNonceServiceWithValidity(90 * time.Second)
 }
 
-func NewNonceServiceWithValidity(validity time.Duration) (NonceService, error) {
+func NewNonceServiceWithValidity(validity time.Duration) NonceService {
 	return newEncryptedNonceService(validity)
 }
 

--- a/sdk/helper/nonce/nonce_test.go
+++ b/sdk/helper/nonce/nonce_test.go
@@ -90,7 +90,3 @@ func TestNonceExpiry(t *testing.T) {
 	// Original nonce should fail on second use.
 	require.False(t, s.Redeem(original))
 }
-
-func TestParallelNonceRedemption(t *testing.T) {
-	t.Parallel()
-}

--- a/sdk/helper/nonce/nonce_test.go
+++ b/sdk/helper/nonce/nonce_test.go
@@ -9,7 +9,8 @@ import (
 func TestNonceService(t *testing.T) {
 	t.Parallel()
 
-	s, err := NewNonceService()
+	s := NewNonceService()
+	err := s.Initialize()
 	require.NoError(t, err)
 
 	nonce, _, err := s.Get()

--- a/sdk/helper/nonce/nonce_test.go
+++ b/sdk/helper/nonce/nonce_test.go
@@ -1,0 +1,47 @@
+package nonce
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNonceService(t *testing.T) {
+	t.Parallel()
+
+	s, err := NewNonceService()
+	require.NoError(t, err)
+
+	nonce, _, err := s.Get()
+	require.NoError(t, err)
+	require.NotEmpty(t, nonce)
+
+	require.True(t, s.Redeem(nonce))
+	require.False(t, s.Redeem(nonce))
+
+	// Redeeming in opposite order should work.
+	var nonces []string
+	numNonces := 100
+	for i := 0; i < numNonces; i++ {
+		nonce, _, err = s.Get()
+		require.NoError(t, err)
+		require.NotEmpty(t, nonce)
+
+		nonces = append(nonces, nonce)
+	}
+
+	for i := len(nonces) - 1; i >= 0; i-- {
+		nonce = nonces[i]
+		require.True(t, s.Redeem(nonce))
+	}
+
+	for i := 0; i < len(nonces); i++ {
+		nonce = nonces[i]
+		require.False(t, s.Redeem(nonce))
+	}
+
+    status := s.Tidy()
+    require.NotNil(t, status)
+    require.Equal(t, uint64(1 + numNonces), status.Issued)
+    require.Equal(t, uint64(0), status.Outstanding)
+}

--- a/sdk/helper/nonce/sync_map_nonce.go
+++ b/sdk/helper/nonce/sync_map_nonce.go
@@ -1,0 +1,105 @@
+package nonce
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type syncMapNonceService struct {
+	validity time.Duration
+	issued     *atomic.Uint64
+    nextExpiry *atomic.Int64
+    nonces     *sync.Map // map[string]time.Time
+}
+var _ NonceService = &syncMapNonceService{}
+
+func newSyncMapNonceService(validity time.Duration) (*syncMapNonceService, error) {
+	return &syncMapNonceService{
+		validity:   validity,
+		issued:     new(atomic.Uint64),
+		nextExpiry: new(atomic.Int64),
+		nonces:     new(sync.Map),
+	}, nil
+}
+
+func (a *syncMapNonceService) IsStrict() bool { return true }
+func (a *syncMapNonceService) IsCrossNode() bool { return false }
+
+func generateNonce() (string, error) {
+    return generateRandomBase64(21)
+}
+
+func generateRandomBase64(srcBytes int) (string, error) {
+    data := make([]byte, 21)
+    if _, err := io.ReadFull(rand.Reader, data); err != nil {
+        return "", err
+    }
+
+    return base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func (a *syncMapNonceService) Get() (string, time.Time, error) {
+    now := time.Now()
+    nonce, err := generateNonce()
+    if err != nil {
+        return "", now, err
+    }
+
+    then := now.Add(a.validity)
+    a.nonces.Store(nonce, then)
+
+    nextExpiry := a.nextExpiry.Load()
+    next := time.Unix(nextExpiry, 0)
+    if then.Before(next) {
+        a.nextExpiry.Store(then.Unix())
+    }
+
+	a.issued.Add(1)
+
+    return nonce, then, nil
+}
+
+func (a *syncMapNonceService) Redeem(nonce string) bool {
+    rawTimeout, present := a.nonces.LoadAndDelete(nonce)
+    if !present {
+        return false
+    }
+
+    timeout := rawTimeout.(time.Time)
+    if time.Now().After(timeout) {
+        return false
+    }
+
+    return true
+}
+
+func (a *syncMapNonceService) Tidy() *NonceStatus {
+    now := time.Now()
+    nextRun := now.Add(a.validity)
+	var outstanding uint64
+    a.nonces.Range(func(key, value any) bool {
+        timeout := value.(time.Time)
+        if now.After(timeout) {
+            a.nonces.Delete(key)
+        } else {
+			outstanding += 1
+		}
+
+        if timeout.Before(nextRun) {
+            nextRun = timeout
+        }
+
+        return false /* don't quit looping */
+    })
+
+    a.nextExpiry.Store(nextRun.Unix())
+
+	return &NonceStatus{
+		Issued: a.issued.Load(),
+		Outstanding: outstanding,
+	}
+}

--- a/sdk/helper/nonce/sync_map_nonce.go
+++ b/sdk/helper/nonce/sync_map_nonce.go
@@ -10,11 +10,12 @@ import (
 )
 
 type syncMapNonceService struct {
-	validity time.Duration
+	validity   time.Duration
 	issued     *atomic.Uint64
-    nextExpiry *atomic.Int64
-    nonces     *sync.Map // map[string]time.Time
+	nextExpiry *atomic.Int64
+	nonces     *sync.Map // map[string]time.Time
 }
+
 var _ NonceService = &syncMapNonceService{}
 
 func newSyncMapNonceService(validity time.Duration) *syncMapNonceService {
@@ -27,80 +28,80 @@ func newSyncMapNonceService(validity time.Duration) *syncMapNonceService {
 }
 
 func (a *syncMapNonceService) Initialize() error { return nil }
-func (a *syncMapNonceService) IsStrict() bool { return true }
+func (a *syncMapNonceService) IsStrict() bool    { return true }
 func (a *syncMapNonceService) IsCrossNode() bool { return false }
 
 func generateNonce() (string, error) {
-    return generateRandomBase64(21)
+	return generateRandomBase64(21)
 }
 
 func generateRandomBase64(srcBytes int) (string, error) {
-    data := make([]byte, 21)
-    if _, err := io.ReadFull(rand.Reader, data); err != nil {
-        return "", err
-    }
+	data := make([]byte, 21)
+	if _, err := io.ReadFull(rand.Reader, data); err != nil {
+		return "", err
+	}
 
-    return base64.RawURLEncoding.EncodeToString(data), nil
+	return base64.RawURLEncoding.EncodeToString(data), nil
 }
 
 func (a *syncMapNonceService) Get() (string, time.Time, error) {
-    now := time.Now()
-    nonce, err := generateNonce()
-    if err != nil {
-        return "", now, err
-    }
+	now := time.Now()
+	nonce, err := generateNonce()
+	if err != nil {
+		return "", now, err
+	}
 
-    then := now.Add(a.validity)
-    a.nonces.Store(nonce, then)
+	then := now.Add(a.validity)
+	a.nonces.Store(nonce, then)
 
-    nextExpiry := a.nextExpiry.Load()
-    next := time.Unix(nextExpiry, 0)
-    if then.Before(next) {
-        a.nextExpiry.Store(then.Unix())
-    }
+	nextExpiry := a.nextExpiry.Load()
+	next := time.Unix(nextExpiry, 0)
+	if then.Before(next) {
+		a.nextExpiry.Store(then.Unix())
+	}
 
 	a.issued.Add(1)
 
-    return nonce, then, nil
+	return nonce, then, nil
 }
 
 func (a *syncMapNonceService) Redeem(nonce string) bool {
-    rawTimeout, present := a.nonces.LoadAndDelete(nonce)
-    if !present {
-        return false
-    }
+	rawTimeout, present := a.nonces.LoadAndDelete(nonce)
+	if !present {
+		return false
+	}
 
-    timeout := rawTimeout.(time.Time)
-    if time.Now().After(timeout) {
-        return false
-    }
+	timeout := rawTimeout.(time.Time)
+	if time.Now().After(timeout) {
+		return false
+	}
 
-    return true
+	return true
 }
 
 func (a *syncMapNonceService) Tidy() *NonceStatus {
-    now := time.Now()
-    nextRun := now.Add(a.validity)
+	now := time.Now()
+	nextRun := now.Add(a.validity)
 	var outstanding uint64
-    a.nonces.Range(func(key, value any) bool {
-        timeout := value.(time.Time)
-        if now.After(timeout) {
-            a.nonces.Delete(key)
-        } else {
+	a.nonces.Range(func(key, value any) bool {
+		timeout := value.(time.Time)
+		if now.After(timeout) {
+			a.nonces.Delete(key)
+		} else {
 			outstanding += 1
 		}
 
-        if timeout.Before(nextRun) {
-            nextRun = timeout
-        }
+		if timeout.Before(nextRun) {
+			nextRun = timeout
+		}
 
-        return false /* don't quit looping */
-    })
+		return false /* don't quit looping */
+	})
 
-    a.nextExpiry.Store(nextRun.Unix())
+	a.nextExpiry.Store(nextRun.Unix())
 
 	return &NonceStatus{
-		Issued: a.issued.Load(),
+		Issued:      a.issued.Load(),
 		Outstanding: outstanding,
 	}
 }

--- a/sdk/helper/nonce/sync_map_nonce.go
+++ b/sdk/helper/nonce/sync_map_nonce.go
@@ -17,15 +17,16 @@ type syncMapNonceService struct {
 }
 var _ NonceService = &syncMapNonceService{}
 
-func newSyncMapNonceService(validity time.Duration) (*syncMapNonceService, error) {
+func newSyncMapNonceService(validity time.Duration) *syncMapNonceService {
 	return &syncMapNonceService{
 		validity:   validity,
 		issued:     new(atomic.Uint64),
 		nextExpiry: new(atomic.Int64),
 		nonces:     new(sync.Map),
-	}, nil
+	}
 }
 
+func (a *syncMapNonceService) Initialize() error { return nil }
 func (a *syncMapNonceService) IsStrict() bool { return true }
 func (a *syncMapNonceService) IsCrossNode() bool { return false }
 


### PR DESCRIPTION
This adds a new nonce service inspired in part by the design of the Let's Encrypt nonce service used in Boulder. This has the nice property that new nonce issuance consumes effectively no memory and is relatively fast. Only redemption of valid (unexpired) nonces consumes memory.

In the case of ACME, an external user can quickly acquire nonces (via `/get-nonce`) and redeem them (via `/new-account`); this mostly shifts the burden of memory. However, by using a time-bucketed redemption tracker, we can quickly expire the used nonce list by simply deleting the corresponding map entry.

Because the redemption map is short-lived, but can grow in size within that window, it can be freed back by Go's GC to the host when it shrinks. However, the two long-lived maps are bounded in size by some combination of (tidy interval or redemption frequency) and the validity period of any given nonce.

For ACME in particular, if a client detects its nonce is not valid, it will re-fetch a new nonce before use.

The old implementation was left around (but not exposed in implementations) for benchmarking purposes.

More comprehensive docs and tests might be nice. :-) 

<details>

<summary> Benchmark </summary>

```
goos: linux
goarch: amd64
pkg: github.com/hashicorp/vault/sdk/helper/nonce
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
BenchmarkEncryptedNonceServiceParallelGet
    benchmark_test.go:25: in-use memory size:  5456
    benchmark_test.go:26: total alloc size:    5456
    benchmark_test.go:27: in-use memory count: 43
    benchmark_test.go:28: total alloc count:   44
    benchmark_test.go:30: Tidy output: &{1 1 len(ens.maxIssued): 1
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 102ns
        time to tidy memory: 392ns
        time to tidy sequential: 340ns
        time to build message: 576ns
        }
    benchmark_test.go:25: in-use memory size:  36192
    benchmark_test.go:26: total alloc size:    36192
    benchmark_test.go:27: in-use memory count: 899
    benchmark_test.go:28: total alloc count:   947
    benchmark_test.go:30: Tidy output: &{100 100 len(ens.maxIssued): 1
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 74ns
        time to tidy memory: 680ns
        time to tidy sequential: 315ns
        time to build message: 530ns
        }
    benchmark_test.go:25: in-use memory size:  2806064
    benchmark_test.go:26: total alloc size:    2806064
    benchmark_test.go:27: in-use memory count: 85045
    benchmark_test.go:28: total alloc count:   90044
    benchmark_test.go:30: Tidy output: &{10000 10000 len(ens.maxIssued): 1
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 79ns
        time to tidy memory: 1.563µs
        time to tidy sequential: 847ns
        time to build message: 694ns
        }
    benchmark_test.go:25: in-use memory size:  2347480
    benchmark_test.go:26: total alloc size:    280011624
    benchmark_test.go:27: in-use memory count: 71101
    benchmark_test.go:28: total alloc count:   9000116
    benchmark_test.go:30: Tidy output: &{1000000 1000000 len(ens.maxIssued): 2
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 53ns
        time to tidy memory: 1.528µs
        time to tidy sequential: 750ns
        time to build message: 831ns
        }
    benchmark_test.go:25: in-use memory size:  1496512
    benchmark_test.go:26: total alloc size:    9064267680
    benchmark_test.go:27: in-use memory count: 44346
    benchmark_test.go:28: total alloc count:   291345497
    benchmark_test.go:30: Tidy output: &{32371548 3634205 len(ens.maxIssued): 6
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 69ns
        time to tidy memory: 6.451µs
        time to tidy sequential: 604ns
        time to build message: 843ns
        }
BenchmarkEncryptedNonceServiceParallelGet-10              	32371548	      1403 ns/op	     280 B/op	       9 allocs/op
BenchmarkSyncMapNonceServiceParallelGet
    benchmark_test.go:25: in-use memory size:  4648
    benchmark_test.go:26: total alloc size:    4648
    benchmark_test.go:27: in-use memory count: 43
    benchmark_test.go:28: total alloc count:   44
    benchmark_test.go:30: Tidy output: &{1 1 }
    benchmark_test.go:25: in-use memory size:  32040
    benchmark_test.go:26: total alloc size:    32040
    benchmark_test.go:27: in-use memory count: 945
    benchmark_test.go:28: total alloc count:   946
    benchmark_test.go:30: Tidy output: &{100 1 }
    benchmark_test.go:25: in-use memory size:  2816600
    benchmark_test.go:26: total alloc size:    2816600
    benchmark_test.go:27: in-use memory count: 90307
    benchmark_test.go:28: total alloc count:   90308
    benchmark_test.go:30: Tidy output: &{10000 1 }
    benchmark_test.go:25: in-use memory size:  199921528
    benchmark_test.go:26: total alloc size:    307873544
    benchmark_test.go:27: in-use memory count: 5611347
    benchmark_test.go:28: total alloc count:   9038467
    benchmark_test.go:30: Tidy output: &{1000000 1 }
    benchmark_test.go:25: in-use memory size:  4495550656
    benchmark_test.go:26: total alloc size:    6222360136
    benchmark_test.go:27: in-use memory count: 151704012
    benchmark_test.go:28: total alloc count:   206536540
    benchmark_test.go:30: Tidy output: &{22862035 0 }
BenchmarkSyncMapNonceServiceParallelGet-10                	22862035	      1949 ns/op	     272 B/op	       9 allocs/op
BenchmarkEncryptedNonceServiceParallelGetRedeem
    benchmark_test.go:25: in-use memory size:  5840
    benchmark_test.go:26: total alloc size:    5840
    benchmark_test.go:27: in-use memory count: 51
    benchmark_test.go:28: total alloc count:   52
    benchmark_test.go:30: Tidy output: &{1 0 len(ens.maxIssued): 1
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 131ns
        time to tidy memory: 458ns
        time to tidy sequential: 1.413µs
        time to build message: 2.332µs
        }
    benchmark_test.go:25: in-use memory size:  50408
    benchmark_test.go:26: total alloc size:    50408
    benchmark_test.go:27: in-use memory count: 1305
    benchmark_test.go:28: total alloc count:   1354
    benchmark_test.go:30: Tidy output: &{100 0 len(ens.maxIssued): 1
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 120ns
        time to tidy memory: 388ns
        time to tidy sequential: 6.073µs
        time to build message: 2.192µs
        }
    benchmark_test.go:25: in-use memory size:  1793184
    benchmark_test.go:26: total alloc size:    4633928
    benchmark_test.go:27: in-use memory count: 44556
    benchmark_test.go:28: total alloc count:   130307
    benchmark_test.go:30: Tidy output: &{10000 0 len(ens.maxIssued): 1
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 61ns
        time to tidy memory: 262ns
        time to tidy sequential: 313.471µs
        time to build message: 810ns
        }
    benchmark_test.go:25: in-use memory size:  15818048
    benchmark_test.go:26: total alloc size:    456811904
    benchmark_test.go:27: in-use memory count: 26402
    benchmark_test.go:28: total alloc count:   13040216
    benchmark_test.go:30: Tidy output: &{1000000 0 len(ens.maxIssued): 4
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 78ns
        time to tidy memory: 460ns
        time to tidy sequential: 60.609742ms
        time to build message: 4.658µs
        }
    benchmark_test.go:25: in-use memory size:  57993392
    benchmark_test.go:26: total alloc size:    7409470760
    benchmark_test.go:27: in-use memory count: 785178
    benchmark_test.go:28: total alloc count:   210965743
    benchmark_test.go:30: Tidy output: &{16180567 0 len(ens.maxIssued): 6
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 125ns
        time to tidy memory: 737ns
        time to tidy sequential: 135.374888ms
        time to build message: 5.664µs
        }
BenchmarkEncryptedNonceServiceParallelGetRedeem-10        	16180567	      2600 ns/op	     457 B/op	      13 allocs/op
BenchmarkSyncMapNonceServiceParallelGetRedeem
    benchmark_test.go:25: in-use memory size:  1336
    benchmark_test.go:26: total alloc size:    1336
    benchmark_test.go:27: in-use memory count: 36
    benchmark_test.go:28: total alloc count:   37
    benchmark_test.go:30: Tidy output: &{1 0 }
    benchmark_test.go:25: in-use memory size:  25920
    benchmark_test.go:26: total alloc size:    25920
    benchmark_test.go:27: in-use memory count: 995
    benchmark_test.go:28: total alloc count:   996
    benchmark_test.go:30: Tidy output: &{100 0 }
    benchmark_test.go:25: in-use memory size:  2448848
    benchmark_test.go:26: total alloc size:    2448848
    benchmark_test.go:27: in-use memory count: 94732
    benchmark_test.go:28: total alloc count:   94733
    benchmark_test.go:30: Tidy output: &{10000 0 }
    benchmark_test.go:25: in-use memory size:  2158424
    benchmark_test.go:26: total alloc size:    243513072
    benchmark_test.go:27: in-use memory count: 82991
    benchmark_test.go:28: total alloc count:   9486918
    benchmark_test.go:30: Tidy output: &{1000000 0 }
    benchmark_test.go:25: in-use memory size:  2600592
    benchmark_test.go:26: total alloc size:    3979103936
    benchmark_test.go:27: in-use memory count: 100846
    benchmark_test.go:28: total alloc count:   155065060
    benchmark_test.go:30: Tidy output: &{16343270 0 }
BenchmarkSyncMapNonceServiceParallelGetRedeem-10          	16343270	      2538 ns/op	     243 B/op	       9 allocs/op
BenchmarkEncryptedNonceServiceParallelGetRedeemTidy
    benchmark_test.go:25: in-use memory size:  8584
    benchmark_test.go:26: total alloc size:    8584
    benchmark_test.go:27: in-use memory count: 76
    benchmark_test.go:28: total alloc count:   81
    benchmark_test.go:30: Tidy output: &{1 0 len(ens.maxIssued): 1
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 138ns
        time to tidy memory: 372ns
        time to tidy sequential: 475ns
        time to build message: 973ns
        }
    benchmark_test.go:25: in-use memory size:  193048
    benchmark_test.go:26: total alloc size:    193048
    benchmark_test.go:27: in-use memory count: 3405
    benchmark_test.go:28: total alloc count:   3841
    benchmark_test.go:30: Tidy output: &{100 0 len(ens.maxIssued): 1
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 102ns
        time to tidy memory: 331ns
        time to tidy sequential: 334ns
        time to build message: 1.13µs
        }
    benchmark_test.go:25: in-use memory size:  108504
    benchmark_test.go:26: total alloc size:    18641976
    benchmark_test.go:27: in-use memory count: 1661
    benchmark_test.go:28: total alloc count:   379756
    benchmark_test.go:30: Tidy output: &{10000 0 len(ens.maxIssued): 1
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 92ns
        time to tidy memory: 275ns
        time to tidy sequential: 375ns
        time to build message: 772ns
        }
    benchmark_test.go:25: in-use memory size:  1390856
    benchmark_test.go:26: total alloc size:    1927102672
    benchmark_test.go:27: in-use memory count: 24562
    benchmark_test.go:28: total alloc count:   39060861
    benchmark_test.go:30: Tidy output: &{1000000 0 len(ens.maxIssued): 6
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 77ns
        time to tidy memory: 294ns
        time to tidy sequential: 267ns
        time to build message: 718ns
        }
    benchmark_test.go:25: in-use memory size:  1393128
    benchmark_test.go:26: total alloc size:    12950472240
    benchmark_test.go:27: in-use memory count: 24744
    benchmark_test.go:28: total alloc count:   263317704
    benchmark_test.go:30: Tidy output: &{6799441 0 len(ens.maxIssued): 6
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 80ns
        time to tidy memory: 175ns
        time to tidy sequential: 154ns
        time to build message: 624ns
        }
BenchmarkEncryptedNonceServiceParallelGetRedeemTidy-10    	 6799441	      5873 ns/op	    1904 B/op	      38 allocs/op
BenchmarkSyncMapNonceServiceParallelGetRedeemTidy
    benchmark_test.go:25: in-use memory size:  1384
    benchmark_test.go:26: total alloc size:    1384
    benchmark_test.go:27: in-use memory count: 38
    benchmark_test.go:28: total alloc count:   39
    benchmark_test.go:30: Tidy output: &{1 0 }
    benchmark_test.go:25: in-use memory size:  43936
    benchmark_test.go:26: total alloc size:    43936
    benchmark_test.go:27: in-use memory count: 1353
    benchmark_test.go:28: total alloc count:   1354
    benchmark_test.go:30: Tidy output: &{100 0 }
    benchmark_test.go:25: in-use memory size:  1563104
    benchmark_test.go:26: total alloc size:    4791888
    benchmark_test.go:27: in-use memory count: 44032
    benchmark_test.go:28: total alloc count:   133219
    benchmark_test.go:30: Tidy output: &{10000 0 }
    benchmark_test.go:25: in-use memory size:  795312
    benchmark_test.go:26: total alloc size:    486327808
    benchmark_test.go:27: in-use memory count: 21820
    benchmark_test.go:28: total alloc count:   13371939
    benchmark_test.go:30: Tidy output: &{1000000 0 }
    benchmark_test.go:25: in-use memory size:  1419320
    benchmark_test.go:26: total alloc size:    7944124864
    benchmark_test.go:27: in-use memory count: 39784
    benchmark_test.go:28: total alloc count:   219218063
    benchmark_test.go:30: Tidy output: &{16423978 0 }
BenchmarkSyncMapNonceServiceParallelGetRedeemTidy-10      	16423978	      2854 ns/op	     483 B/op	      13 allocs/op
BenchmarkEncryptedNonceServiceParallelTidy
    benchmark_test.go:25: in-use memory size:  3096
    benchmark_test.go:26: total alloc size:    4400
    benchmark_test.go:27: in-use memory count: 30
    benchmark_test.go:28: total alloc count:   72
    benchmark_test.go:30: Tidy output: &{1 0 len(ens.maxIssued): 0
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 54ns
        time to tidy memory: 134ns
        time to tidy sequential: 217ns
        time to build message: 437ns
        }
    benchmark_test.go:25: in-use memory size:  7552
    benchmark_test.go:26: total alloc size:    52040
    benchmark_test.go:27: in-use memory count: 42
    benchmark_test.go:28: total alloc count:   1375
    benchmark_test.go:30: Tidy output: &{100 0 len(ens.maxIssued): 0
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 64ns
        time to tidy memory: 114ns
        time to tidy sequential: 180ns
        time to build message: 435ns
        }
    benchmark_test.go:25: in-use memory size:  188584
    benchmark_test.go:26: total alloc size:    4636624
    benchmark_test.go:27: in-use memory count: 44
    benchmark_test.go:28: total alloc count:   130317
    benchmark_test.go:30: Tidy output: &{10000 0 len(ens.maxIssued): 0
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 59ns
        time to tidy memory: 167ns
        time to tidy sequential: 215ns
        time to build message: 433ns
        }
    benchmark_test.go:25: in-use memory size:  21025240
    benchmark_test.go:26: total alloc size:    462471064
    benchmark_test.go:27: in-use memory count: 15920
    benchmark_test.go:28: total alloc count:   13039831
    benchmark_test.go:30: Tidy output: &{1000000 0 len(ens.maxIssued): 0
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 60ns
        time to tidy memory: 142ns
        time to tidy sequential: 161ns
        time to build message: 530ns
        }
    benchmark_test.go:25: in-use memory size:  34512144
    benchmark_test.go:26: total alloc size:    8175493248
    benchmark_test.go:27: in-use memory count: 9783
    benchmark_test.go:28: total alloc count:   231726308
    benchmark_test.go:30: Tidy output: &{17770612 0 len(ens.maxIssued): 0
        len(ens.redeemedTokens): 0
        total redeemed tokens: 0
        time to grab lock: 68ns
        time to tidy memory: 111ns
        time to tidy sequential: 122ns
        time to build message: 603ns
        }
BenchmarkEncryptedNonceServiceParallelTidy-10             	17770612	      2551 ns/op	     460 B/op	      13 allocs/op
BenchmarkSyncMapNonceServiceParallelTidy
    benchmark_test.go:25: in-use memory size:  1240
    benchmark_test.go:26: total alloc size:    2312
    benchmark_test.go:27: in-use memory count: 8
    benchmark_test.go:28: total alloc count:   43
    benchmark_test.go:30: Tidy output: &{1 0 }
    benchmark_test.go:25: in-use memory size:  2280
    benchmark_test.go:26: total alloc size:    28816
    benchmark_test.go:27: in-use memory count: 44
    benchmark_test.go:28: total alloc count:   1022
    benchmark_test.go:30: Tidy output: &{100 0 }
    benchmark_test.go:25: in-use memory size:  4768
    benchmark_test.go:26: total alloc size:    2455696
    benchmark_test.go:27: in-use memory count: 18
    benchmark_test.go:28: total alloc count:   94969
    benchmark_test.go:30: Tidy output: &{10000 0 }
    benchmark_test.go:25: in-use memory size:  9472
    benchmark_test.go:26: total alloc size:    243541680
    benchmark_test.go:27: in-use memory count: 67
    benchmark_test.go:28: total alloc count:   9490426
    benchmark_test.go:30: Tidy output: &{1000000 0 }
    benchmark_test.go:25: in-use memory size:  1184
    benchmark_test.go:26: total alloc size:    4648462896
    benchmark_test.go:27: in-use memory count: 18446744073709551610
    benchmark_test.go:28: total alloc count:   181016504
    benchmark_test.go:30: Tidy output: &{19082120 0 }
BenchmarkSyncMapNonceServiceParallelTidy-10               	19082120	      2431 ns/op	     243 B/op	       9 allocs/op
PASS
ok  	github.com/hashicorp/vault/sdk/helper/nonce	444.135s
[cipherboy@xps15 vault]$ 
```

</details>