### PR TITLE
VAULT-11595: Augment forwarded requests with host:port info (from/to nodes) (Enterprise)

### DIFF
--- a/audit/format.go
+++ b/audit/format.go
@@ -92,9 +92,9 @@ func (f *AuditFormatter) FormatRequest(ctx context.Context, w io.Writer, config 
 		reqType = "request"
 	}
 	reqEntry := &AuditRequestEntry{
-		Type:  reqType,
-		Error: errString,
-
+		Type:          reqType,
+		Error:         errString,
+		ForwardedFrom: req.ForwardedFrom,
 		Auth: &AuditAuth{
 			ClientToken:               auth.ClientToken,
 			Accessor:                  auth.Accessor,
@@ -297,8 +297,9 @@ func (f *AuditFormatter) FormatResponse(ctx context.Context, w io.Writer, config
 		respType = "response"
 	}
 	respEntry := &AuditResponseEntry{
-		Type:  respType,
-		Error: errString,
+		Type:        respType,
+		Error:       errString,
+		ForwardedTo: req.ForwardedTo,
 		Auth: &AuditAuth{
 			ClientToken:               auth.ClientToken,
 			Accessor:                  auth.Accessor,
@@ -397,6 +398,8 @@ type AuditRequestEntry struct {
 	Auth    *AuditAuth    `json:"auth,omitempty"`
 	Request *AuditRequest `json:"request,omitempty"`
 	Error   string        `json:"error,omitempty"`
+	// Populated in Enterprise when a request is forwarded
+	ForwardedFrom string `json:"forwarded_from,omitempty"`
 }
 
 // AuditResponseEntry is the structure of a response audit log entry in Audit.
@@ -407,6 +410,8 @@ type AuditResponseEntry struct {
 	Request  *AuditRequest  `json:"request,omitempty"`
 	Response *AuditResponse `json:"response,omitempty"`
 	Error    string         `json:"error,omitempty"`
+	// Populated in Enterprise when a request is forwarded
+	ForwardedTo string `json:"forwarded_to,omitempty"`
 }
 
 type AuditRequest struct {

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -243,6 +243,12 @@ type Request struct {
 	// InboundSSCToken is the token that arrives on an inbound request, supplied
 	// by the vault user.
 	InboundSSCToken string
+
+	// When a request has been forwarded, contains information of the host the request was forwarded 'from'
+	ForwardedFrom string `json:"forwarded_from,omitempty"`
+
+	// When a request has been forwarded, contains information of the host the request was forwarded 'to'
+	ForwardedTo string `json:"forwarded_to,omitempty"`
 }
 
 // Clone returns a deep copy of the request by using copystructure


### PR DESCRIPTION
**Enterprise only**: 

When a perf-standby node receives a request and eventually forwards it to the primary node, audit logs can be written on the the perf-standby and the primary node for both the incoming request, and outgoing response (max 4 entries in total, 2 per each node).

1. Performance Standby node logs request
2. Primary node logs (forwarded) request
3. Primary node logs response to (forwarded) request
4. Performance Standby node logs response to request

In order to make it clearer in the audit logs that a request was forwarded this PR will add forwarded data to the request object that is used to generate audit log entries. The forwarded data will contain the host (:) of the node that the request is either forwarded from or the primary node it is forwarded to.

e.g.

`"forwarded_from": "10.0.0.2:8200"`

`"forwarded_to": "10.0.0.1:8200"`

`forwarded_from` can be added to audit requests logged on a primary (1. above), `forwarded_to` can be added to audit responses, although it should currently be noted they are added to both response (3. and 4. above).

Enterprise PR will cover the population of the data for these fields: https://github.com/hashicorp/vault-enterprise/pull/4064