### PR TITLE
UI: VAULT-16367 VAULT-16378 Tidy acceptance tests + tidy toolbar cleanup

### DIFF
--- a/ui/lib/pki/addon/components/page/pki-tidy-status.hbs
+++ b/ui/lib/pki/addon/components/page/pki-tidy-status.hbs
@@ -2,32 +2,12 @@
   <ToolbarActions>
     <div class="toolbar-separator"></div>
     {{#if @autoTidyConfig.enabled}}
-      <BasicDropdown @class="popup-menu" @horizontalPosition="auto-right" @verticalPosition="below" as |D|>
-        <D.Trigger
-          class={{concat "toolbar-link" (if D.isOpen " is-active")}}
-          @htmlTag="button"
-          data-test-configure-tidy-dropdown
-        >
-          Tidy
-          <Chevron @direction="down" @isButton={{true}} />
-        </D.Trigger>
-        <D.Content @defaultClass="popup-menu-content">
-          <nav class="box menu" aria-label="generate options">
-            <ul class="menu-list">
-              <li class="action">
-                <LinkTo @route="tidy.manual" {{on "click" (fn this.onLinkClick D)}} data-test-tidy="manual">
-                  Manual tidy
-                </LinkTo>
-              </li>
-              <li class="action">
-                <LinkTo @route="tidy.auto.configure" {{on "click" (fn this.onLinkClick D)}} data-test-tidy="auto">
-                  Automatic tidy
-                </LinkTo>
-              </li>
-            </ul>
-          </nav>
-        </D.Content>
-      </BasicDropdown>
+      <ToolbarLink @route="tidy.auto" data-test-pki-auto-tidy-config>
+        Auto-tidy configuration
+      </ToolbarLink>
+      <ToolbarLink @route="tidy.manual" data-test-pki-manual-tidy-config>
+        Perform manual tidy
+      </ToolbarLink>
     {{else}}
       <button
         type="button"
@@ -38,11 +18,6 @@
         Tidy
         <Icon @name="chevron-right" />
       </button>
-    {{/if}}
-    {{#if @autoTidyConfig.enabled}}
-      <ToolbarLink @route="tidy.auto" data-test-pki-auto-tidy-config>
-        Auto-tidy configuration
-      </ToolbarLink>
     {{/if}}
   </ToolbarActions>
 </Toolbar>

--- a/ui/lib/pki/addon/components/page/pki-tidy-status.hbs
+++ b/ui/lib/pki/addon/components/page/pki-tidy-status.hbs
@@ -86,7 +86,12 @@
     @title="Tidy status unavailable"
     @message="After an initial tidy operation has been performed, information about the current or most recent tidy operation will display here."
   >
-    <button type="button" class="link" {{on "click" (fn (mut this.tidyOptionsModal) true)}}>
+    <button
+      type="button"
+      class="link"
+      {{on "click" (fn (mut this.tidyOptionsModal) true)}}
+      data-test-tidy-empty-state-configure
+    >
       Tidy
     </button>
   </EmptyState>
@@ -142,7 +147,12 @@
     >
       Manual tidy
     </button>
-    <button type="button" class="button is-secondary" {{on "click" (fn (mut this.tidyOptionsModal) false)}}>
+    <button
+      type="button"
+      class="button is-secondary"
+      {{on "click" (fn (mut this.tidyOptionsModal) false)}}
+      data-test-tidy-modal-cancel-button
+    >
       Cancel
     </button>
   </footer>

--- a/ui/lib/pki/addon/components/page/pki-tidy-status.hbs
+++ b/ui/lib/pki/addon/components/page/pki-tidy-status.hbs
@@ -1,15 +1,44 @@
 <Toolbar>
   <ToolbarActions>
     <div class="toolbar-separator"></div>
-    <button
-      type="button"
-      class="toolbar-link"
-      {{on "click" (fn (mut this.tidyOptionsModal) true)}}
-      data-test-pki-tidy-options-modal
-    >
-      Tidy
-      <Icon @name="chevron-right" />
-    </button>
+    {{#if @autoTidyConfig.enabled}}
+      <BasicDropdown @class="popup-menu" @horizontalPosition="auto-right" @verticalPosition="below" as |D|>
+        <D.Trigger
+          class={{concat "toolbar-link" (if D.isOpen " is-active")}}
+          @htmlTag="button"
+          data-test-configure-tidy-dropdown
+        >
+          Tidy
+          <Chevron @direction="down" @isButton={{true}} />
+        </D.Trigger>
+        <D.Content @defaultClass="popup-menu-content">
+          <nav class="box menu" aria-label="generate options">
+            <ul class="menu-list">
+              <li class="action">
+                <LinkTo @route="tidy.manual" {{on "click" (fn this.onLinkClick D)}} data-test-tidy="manual">
+                  Manual tidy
+                </LinkTo>
+              </li>
+              <li class="action">
+                <LinkTo @route="tidy.auto.configure" {{on "click" (fn this.onLinkClick D)}} data-test-tidy="auto">
+                  Automatic tidy
+                </LinkTo>
+              </li>
+            </ul>
+          </nav>
+        </D.Content>
+      </BasicDropdown>
+    {{else}}
+      <button
+        type="button"
+        class="toolbar-link"
+        {{on "click" (fn (mut this.tidyOptionsModal) true)}}
+        data-test-pki-tidy-options-modal
+      >
+        Tidy
+        <Icon @name="chevron-right" />
+      </button>
+    {{/if}}
     {{#if @autoTidyConfig.enabled}}
       <ToolbarLink @route="tidy.auto" data-test-pki-auto-tidy-config>
         Auto-tidy configuration

--- a/ui/lib/pki/addon/components/page/pki-tidy-status.ts
+++ b/ui/lib/pki/addon/components/page/pki-tidy-status.ts
@@ -14,6 +14,7 @@ import type SecretMountPath from 'vault/services/secret-mount-path';
 import type FlashMessageService from 'vault/services/flash-messages';
 import type VersionService from 'vault/services/version';
 import type PkiTidyModel from 'vault/models/pki/tidy';
+import type RouterService from '@ember/routing/router-service';
 
 interface Args {
   autoTidyConfig: PkiTidyModel;
@@ -46,6 +47,7 @@ export default class PkiTidyStatusComponent extends Component<Args> {
   @service declare readonly secretMountPath: SecretMountPath;
   @service declare readonly flashMessages: FlashMessageService;
   @service declare readonly version: VersionService;
+  @service declare readonly router: RouterService;
 
   @tracked tidyOptionsModal = false;
   @tracked confirmCancelTidy = false;
@@ -143,6 +145,7 @@ export default class PkiTidyStatusComponent extends Component<Args> {
     try {
       const tidyAdapter = this.store.adapterFor('pki/tidy');
       yield tidyAdapter.cancelTidy(this.secretMountPath.currentPath);
+      this.router.transitionTo('vault.cluster.secrets.backend.pki.tidy');
     } catch (error) {
       this.flashMessages.danger(errorMessage(error));
     } finally {

--- a/ui/lib/pki/addon/components/page/pki-tidy-status.ts
+++ b/ui/lib/pki/addon/components/page/pki-tidy-status.ts
@@ -8,8 +8,6 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
-import { action } from '@ember/object';
-import { next } from '@ember/runloop';
 import errorMessage from 'vault/utils/error-message';
 
 import type Store from '@ember-data/store';
@@ -44,12 +42,6 @@ interface TidyStatusParams {
   tidy_cross_cluster_revoked_certs: boolean;
   cross_revoked_cert_deleted_count: number;
   revocation_queue_safety_buffer: string;
-}
-
-interface Dropdown {
-  actions: {
-    close: CallableFunction;
-  };
 }
 
 export default class PkiTidyStatusComponent extends Component<Args> {
@@ -147,10 +139,6 @@ export default class PkiTidyStatusComponent extends Component<Args> {
           message: "The system reported no tidy status. It's recommended to perform a new tidy operation.",
         };
     }
-  }
-
-  @action onLinkClick(D: Dropdown) {
-    next(() => D.actions.close());
   }
 
   @task

--- a/ui/lib/pki/addon/components/page/pki-tidy-status.ts
+++ b/ui/lib/pki/addon/components/page/pki-tidy-status.ts
@@ -8,7 +8,10 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
+import { action } from '@ember/object';
+import { next } from '@ember/runloop';
 import errorMessage from 'vault/utils/error-message';
+
 import type Store from '@ember-data/store';
 import type SecretMountPath from 'vault/services/secret-mount-path';
 import type FlashMessageService from 'vault/services/flash-messages';
@@ -42,6 +45,13 @@ interface TidyStatusParams {
   cross_revoked_cert_deleted_count: number;
   revocation_queue_safety_buffer: string;
 }
+
+interface Dropdown {
+  actions: {
+    close: CallableFunction;
+  };
+}
+
 export default class PkiTidyStatusComponent extends Component<Args> {
   @service declare readonly store: Store;
   @service declare readonly secretMountPath: SecretMountPath;
@@ -137,6 +147,10 @@ export default class PkiTidyStatusComponent extends Component<Args> {
           message: "The system reported no tidy status. It's recommended to perform a new tidy operation.",
         };
     }
+  }
+
+  @action onLinkClick(D: Dropdown) {
+    next(() => D.actions.close());
   }
 
   @task

--- a/ui/lib/pki/addon/components/pki-tidy-form.hbs
+++ b/ui/lib/pki/addon/components/pki-tidy-form.hbs
@@ -7,7 +7,7 @@
 
 <MessageError @errorMessage={{this.errorBanner}} class="has-top-margin-s" />
 
-<form class="has-bottom-margin-s" {{on "submit" (perform this.save)}}>
+<form class="has-bottom-margin-s" {{on "submit" (perform this.save)}} data-test-tidy-form={{@tidyType}}>
   {{#if (and (eq @tidyType "auto") this.intervalDurationAttr)}}
     {{#let this.intervalDurationAttr as |attr|}}
       <TtlPicker

--- a/ui/tests/acceptance/pki/pki-tidy-test.js
+++ b/ui/tests/acceptance/pki/pki-tidy-test.js
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { click, currentRouteName, fillIn, visit } from '@ember/test-helpers';
+
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { v4 as uuidv4 } from 'uuid';
+
+import authPage from 'vault/tests/pages/auth';
+import logout from 'vault/tests/pages/logout';
+import enablePage from 'vault/tests/pages/settings/mount-secret-backend';
+import { runCommands } from 'vault/tests/helpers/pki/pki-run-commands';
+import { SELECTORS } from 'vault/tests/helpers/pki/page/pki-tidy';
+
+module('Acceptance | pki tidy', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    await authPage.login();
+    // Setup PKI engine
+    const mountPath = `pki-workflow-${uuidv4()}`;
+    await enablePage.enable('pki', mountPath);
+    this.mountPath = mountPath;
+    await runCommands([
+      `write ${this.mountPath}/root/generate/internal common_name="Hashicorp Test" name="Hashicorp Test"`,
+    ]);
+    await logout.visit();
+  });
+
+  hooks.afterEach(async function () {
+    await logout.visit();
+    await authPage.login();
+    // Cleanup engine
+    await runCommands([`delete sys/mounts/${this.mountPath}`]);
+    await logout.visit();
+  });
+
+  test('it configures a manual tidy operation and shows its details and tidy states', async function (assert) {
+    await authPage.login(this.pkiAdminToken);
+    await visit(`/vault/secrets/${this.mountPath}/pki/tidy`);
+    await click(SELECTORS.tidyEmptyStateConfigure);
+    assert.dom(SELECTORS.tidyConfigureModal.configureTidyModal).exists('Configure tidy modal exists');
+    assert.dom(SELECTORS.tidyConfigureModal.tidyModalAutoButton).exists('Configure auto tidy button exists');
+    assert
+      .dom(SELECTORS.tidyConfigureModal.tidyModalManualButton)
+      .exists('Configure manual tidy button exists');
+    await click(SELECTORS.tidyConfigureModal.tidyModalManualButton);
+    assert.dom(SELECTORS.tidyForm.tidyFormName('manual')).exists('Manual tidy form exists');
+    await click(SELECTORS.tidyForm.inputByAttr('tidyCertStore'));
+    await fillIn(SELECTORS.tidyForm.tidyPauseDuration, '10');
+    await click(SELECTORS.tidyForm.tidySave);
+    await click(SELECTORS.cancelTidyAction);
+    assert.dom(SELECTORS.cancelTidyModalBackground).exists('Confirm cancel tidy modal exits');
+    await click(SELECTORS.tidyConfigureModal.tidyModalCancelButton);
+    // we can't properly test the background refresh fetching of tidy status in testing
+    this.server.get(`${this.mountPath}/tidy-status`, () => {
+      return {
+        request_id: 'dba2d42d-1a6e-1551-80f8-4ddb364ede4b',
+        lease_id: '',
+        renewable: false,
+        lease_duration: 0,
+        data: {
+          acme_account_deleted_count: 0,
+          acme_account_revoked_count: 0,
+          acme_account_safety_buffer: 2592000,
+          acme_orders_deleted_count: 0,
+          cert_store_deleted_count: 0,
+          cross_revoked_cert_deleted_count: 0,
+          current_cert_store_count: null,
+          current_revoked_cert_count: null,
+          error: null,
+          internal_backend_uuid: '964a41f7-a159-53aa-d62e-fc1914e4a7e1',
+          issuer_safety_buffer: 31536000,
+          last_auto_tidy_finished: '2023-05-19T10:27:11.721825-07:00',
+          message: 'Tidying certificate store: checking entry 0 of 1',
+          missing_issuer_cert_count: 0,
+          pause_duration: '1m40s',
+          revocation_queue_deleted_count: 0,
+          revocation_queue_safety_buffer: 36000,
+          revoked_cert_deleted_count: 0,
+          safety_buffer: 2073600,
+          state: 'Cancelled',
+          tidy_acme: false,
+          tidy_cert_store: true,
+          tidy_cross_cluster_revoked_certs: false,
+          tidy_expired_issuers: false,
+          tidy_move_legacy_ca_bundle: false,
+          tidy_revocation_queue: false,
+          tidy_revoked_cert_issuer_associations: false,
+          tidy_revoked_certs: false,
+          time_finished: '2023-05-19T10:28:51.733092-07:00',
+          time_started: '2023-05-19T10:27:11.721846-07:00',
+          total_acme_account_count: 0,
+        },
+        wrap_info: null,
+        warnings: null,
+        auth: null,
+      };
+    });
+    await visit(`/vault/secrets/${this.mountPath}/pki/configuration`);
+    await visit(`/vault/secrets/${this.mountPath}/pki/tidy`);
+    assert.dom(SELECTORS.hdsAlertTitle).hasText('Tidy operation cancelled');
+    assert
+      .dom(SELECTORS.hdsAlertDescription)
+      .hasText(
+        'Your tidy operation has been cancelled. If this was a mistake configure and run another tidy operation.'
+      );
+    assert.dom(SELECTORS.alertUpdatedAt).exists();
+  });
+
+  test('it configures an auto tidy operation and shows its details', async function (assert) {
+    await authPage.login(this.pkiAdminToken);
+    await visit(`/vault/secrets/${this.mountPath}/pki/tidy`);
+    await click(SELECTORS.tidyEmptyStateConfigure);
+    assert.dom(SELECTORS.tidyConfigureModal.configureTidyModal).exists('Configure tidy modal exists');
+    assert.dom(SELECTORS.tidyConfigureModal.tidyModalAutoButton).exists('Configure auto tidy button exists');
+    assert
+      .dom(SELECTORS.tidyConfigureModal.tidyModalManualButton)
+      .exists('Configure manual tidy button exists');
+    await click(SELECTORS.tidyConfigureModal.tidyModalAutoButton);
+    assert.dom(SELECTORS.tidyForm.tidyFormName('auto')).exists('Auto tidy form exists');
+    await click('[data-test-pki-tidy-cancel]');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.pki.tidy.index');
+    await click(SELECTORS.tidyEmptyStateConfigure);
+    await click(SELECTORS.tidyConfigureModal.tidyModalAutoButton);
+    assert.dom(SELECTORS.tidyForm.tidyFormName('auto')).exists('Auto tidy form exists');
+    await click(SELECTORS.tidyForm.toggleLabel('Automatic tidy disabled'));
+    assert
+      .dom(SELECTORS.tidyForm.tidySectionHeader('ACME operations'))
+      .exists('Auto tidy form enabled shows ACME operations field');
+    await click(SELECTORS.tidyForm.inputByAttr('tidyCertStore'));
+    await click(SELECTORS.tidyForm.tidySave);
+    // TODO: test a successful submission of an auto tidy operation here
+    // assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.pki.tidy.auto.index');
+    // await click('[data-test-pki-edit-tidy-auto-link]');
+    // assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.pki.tidy.auto.index');
+  });
+
+  test('it opens a tidy modal when the user clicks on the tidy toolbar action', async function (assert) {
+    await authPage.login(this.pkiAdminToken);
+    await visit(`/vault/secrets/${this.mountPath}/pki/tidy`);
+    await click(SELECTORS.tidyConfigureModal.tidyOptionsModal);
+    assert.dom(SELECTORS.tidyConfigureModal.configureTidyModal).exists('Configure tidy modal exists');
+    assert.dom(SELECTORS.tidyConfigureModal.tidyModalAutoButton).exists('Configure auto tidy button exists');
+    assert
+      .dom(SELECTORS.tidyConfigureModal.tidyModalManualButton)
+      .exists('Configure manual tidy button exists');
+    await click(SELECTORS.tidyConfigureModal.tidyModalCancelButton);
+    assert.dom(SELECTORS.tidyEmptyState).exists();
+  });
+});

--- a/ui/tests/acceptance/pki/pki-tidy-test.js
+++ b/ui/tests/acceptance/pki/pki-tidy-test.js
@@ -135,10 +135,12 @@ module('Acceptance | pki tidy', function (hooks) {
       .exists('Auto tidy form enabled shows ACME operations field');
     await click(SELECTORS.tidyForm.inputByAttr('tidyCertStore'));
     await click(SELECTORS.tidyForm.tidySave);
-    // TODO: test a successful submission of an auto tidy operation here
-    // assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.pki.tidy.auto.index');
-    // await click('[data-test-pki-edit-tidy-auto-link]');
-    // assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.pki.tidy.auto.index');
+    assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.pki.tidy.auto.index');
+    await click(SELECTORS.tidyForm.editAutoTidyButton);
+    assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.pki.tidy.auto.configure');
+    await click(SELECTORS.tidyForm.inputByAttr('tidyRevokedCerts'));
+    await click(SELECTORS.tidyForm.tidySave);
+    assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.pki.tidy.auto.index');
   });
 
   test('it opens a tidy modal when the user clicks on the tidy toolbar action', async function (assert) {
@@ -162,13 +164,18 @@ module('Acceptance | pki tidy', function (hooks) {
       .exists('Configure tidy modal options button exists');
     await click(SELECTORS.tidyConfigureModal.tidyOptionsModal);
     assert.dom(SELECTORS.tidyConfigureModal.configureTidyModal).exists('Configure tidy modal exists');
-    await click(SELECTORS.tidyConfigureModal.tidyModalCancelButton);
-    // TODO configure auto tidy and check if manual tidy + auto config button exists
-    // assert
-    //   .dom(SELECTORS.manualTidyToolbar)
-    //   .exists('Manual tidy toolbar action exists if auto tidy is configured');
-    // assert
-    //   .dom(SELECTORS.autoTidyToolbar)
-    //   .exists('Auto tidy toolbar action exists if auto tidy is configured');
+    await click(SELECTORS.tidyConfigureModal.tidyOptionsModal);
+    await click(SELECTORS.tidyConfigureModal.tidyModalAutoButton);
+    await click(SELECTORS.tidyForm.toggleLabel('Automatic tidy disabled'));
+    await click(SELECTORS.tidyForm.inputByAttr('tidyCertStore'));
+    await click(SELECTORS.tidyForm.inputByAttr('tidyRevokedCerts'));
+    await click(SELECTORS.tidyForm.tidySave);
+    await visit(`/vault/secrets/${this.mountPath}/pki/tidy`);
+    assert
+      .dom(SELECTORS.manualTidyToolbar)
+      .exists('Manual tidy toolbar action exists if auto tidy is configured');
+    assert
+      .dom(SELECTORS.autoTidyToolbar)
+      .exists('Auto tidy toolbar action exists if auto tidy is configured');
   });
 });

--- a/ui/tests/acceptance/pki/pki-tidy-test.js
+++ b/ui/tests/acceptance/pki/pki-tidy-test.js
@@ -157,12 +157,18 @@ module('Acceptance | pki tidy', function (hooks) {
   test('it should show correct toolbar action depending on whether auto tidy is enabled', async function (assert) {
     await authPage.login(this.pkiAdminToken);
     await visit(`/vault/secrets/${this.mountPath}/pki/tidy`);
+    assert
+      .dom(SELECTORS.tidyConfigureModal.tidyOptionsModal)
+      .exists('Configure tidy modal options button exists');
     await click(SELECTORS.tidyConfigureModal.tidyOptionsModal);
     assert.dom(SELECTORS.tidyConfigureModal.configureTidyModal).exists('Configure tidy modal exists');
     await click(SELECTORS.tidyConfigureModal.tidyModalCancelButton);
-    // TODO configure auto tidy and check if dropdown exists
+    // TODO configure auto tidy and check if manual tidy + auto config button exists
     // assert
-    //   .dom(SELECTORS.tidyToolbarActionDropdown)
-    //   .exists('Tidy toolbar action dropdown exists if tidy is configured');
+    //   .dom(SELECTORS.manualTidyToolbar)
+    //   .exists('Manual tidy toolbar action exists if auto tidy is configured');
+    // assert
+    //   .dom(SELECTORS.autoTidyToolbar)
+    //   .exists('Auto tidy toolbar action exists if auto tidy is configured');
   });
 });

--- a/ui/tests/acceptance/pki/pki-tidy-test.js
+++ b/ui/tests/acceptance/pki/pki-tidy-test.js
@@ -124,7 +124,7 @@ module('Acceptance | pki tidy', function (hooks) {
       .exists('Configure manual tidy button exists');
     await click(SELECTORS.tidyConfigureModal.tidyModalAutoButton);
     assert.dom(SELECTORS.tidyForm.tidyFormName('auto')).exists('Auto tidy form exists');
-    await click('[data-test-pki-tidy-cancel]');
+    await click(SELECTORS.tidyForm.tidyCancel);
     assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.pki.tidy.index');
     await click(SELECTORS.tidyEmptyStateConfigure);
     await click(SELECTORS.tidyConfigureModal.tidyModalAutoButton);
@@ -152,5 +152,17 @@ module('Acceptance | pki tidy', function (hooks) {
       .exists('Configure manual tidy button exists');
     await click(SELECTORS.tidyConfigureModal.tidyModalCancelButton);
     assert.dom(SELECTORS.tidyEmptyState).exists();
+  });
+
+  test('it should show correct toolbar action depending on whether auto tidy is enabled', async function (assert) {
+    await authPage.login(this.pkiAdminToken);
+    await visit(`/vault/secrets/${this.mountPath}/pki/tidy`);
+    await click(SELECTORS.tidyConfigureModal.tidyOptionsModal);
+    assert.dom(SELECTORS.tidyConfigureModal.configureTidyModal).exists('Configure tidy modal exists');
+    await click(SELECTORS.tidyConfigureModal.tidyModalCancelButton);
+    // TODO configure auto tidy and check if dropdown exists
+    // assert
+    //   .dom(SELECTORS.tidyToolbarActionDropdown)
+    //   .exists('Tidy toolbar action dropdown exists if tidy is configured');
   });
 });

--- a/ui/tests/helpers/pki/page/pki-tidy-form.js
+++ b/ui/tests/helpers/pki/page/pki-tidy-form.js
@@ -4,6 +4,7 @@
  */
 
 export const SELECTORS = {
+  tidyFormName: (attr) => `[data-test-tidy-form="${attr}"]`,
   inputByAttr: (attr) => `[data-test-input="${attr}"]`,
   toggleInput: (attr) => `[data-test-input="${attr}"] input`,
   intervalDuration: '[data-test-ttl-value="Automatic tidy enabled"]',
@@ -12,4 +13,5 @@ export const SELECTORS = {
   tidySectionHeader: (header) => `[data-test-tidy-header="${header}"]`,
   tidySave: '[data-test-pki-tidy-button]',
   tidyCancel: '[data-test-pki-tidy-cancel]',
+  tidyPauseDuration: '[data-test-ttl-value="Pause duration"]',
 };

--- a/ui/tests/helpers/pki/page/pki-tidy-form.js
+++ b/ui/tests/helpers/pki/page/pki-tidy-form.js
@@ -14,4 +14,5 @@ export const SELECTORS = {
   tidySave: '[data-test-pki-tidy-button]',
   tidyCancel: '[data-test-pki-tidy-cancel]',
   tidyPauseDuration: '[data-test-ttl-value="Pause duration"]',
+  editAutoTidyButton: '[data-test-pki-edit-tidy-auto-link]',
 };

--- a/ui/tests/helpers/pki/page/pki-tidy.js
+++ b/ui/tests/helpers/pki/page/pki-tidy.js
@@ -2,6 +2,7 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
+import { SELECTORS as TIDY_FORM } from './pki-tidy-form';
 
 export const SELECTORS = {
   hdsAlertTitle: '[data-test-hds-alert-title]',
@@ -12,4 +13,16 @@ export const SELECTORS = {
   timeStartedRow: '[data-test-value-div="Time started"]',
   timeFinishedRow: '[data-test-value-div="Time finished"]',
   cancelTidyModalBackground: '[data-test-modal-background="Cancel tidy?"]',
+  tidyEmptyStateConfigure: '[data-test-tidy-empty-state-configure]',
+  tidyConfigureModal: {
+    configureTidyModal: '[data-test-modal-background="Tidy this mount"]',
+    tidyModalAutoButton: '[data-test-tidy-modal-auto-button]',
+    tidyModalManualButton: '[data-test-tidy-modal-manual-button]',
+    tidyModalCancelButton: '[data-test-tidy-modal-cancel-button]',
+    tidyOptionsModal: '[data-test-pki-tidy-options-modal]',
+  },
+  tidyEmptyState: '[data-test-component="empty-state"]',
+  tidyForm: {
+    ...TIDY_FORM,
+  },
 };

--- a/ui/tests/helpers/pki/page/pki-tidy.js
+++ b/ui/tests/helpers/pki/page/pki-tidy.js
@@ -14,7 +14,8 @@ export const SELECTORS = {
   timeFinishedRow: '[data-test-value-div="Time finished"]',
   cancelTidyModalBackground: '[data-test-modal-background="Cancel tidy?"]',
   tidyEmptyStateConfigure: '[data-test-tidy-empty-state-configure]',
-  tidyToolbarActionDropdown: '[data-test-configure-tidy-dropdown]',
+  manualTidyToolbar: '[data-test-pki-manual-tidy-config]',
+  autoTidyToolbar: '[data-test-pki-auto-tidy-config]',
   tidyConfigureModal: {
     configureTidyModal: '[data-test-modal-background="Tidy this mount"]',
     tidyModalAutoButton: '[data-test-tidy-modal-auto-button]',

--- a/ui/tests/helpers/pki/page/pki-tidy.js
+++ b/ui/tests/helpers/pki/page/pki-tidy.js
@@ -9,7 +9,7 @@ export const SELECTORS = {
   hdsAlertDescription: '[data-test-hds-alert-description]',
   alertUpdatedAt: '[data-test-hds-alert-updated-at]',
   cancelTidyAction: '[data-test-cancel-tidy-action]',
-  hdsAlertButtonText: '[data-test-hds-alert-action] .hds-button__text',
+  hdsAlertButtonText: '[data-test-cancel-tidy-action] .hds-button__text',
   timeStartedRow: '[data-test-value-div="Time started"]',
   timeFinishedRow: '[data-test-value-div="Time finished"]',
   cancelTidyModalBackground: '[data-test-modal-background="Cancel tidy?"]',

--- a/ui/tests/helpers/pki/page/pki-tidy.js
+++ b/ui/tests/helpers/pki/page/pki-tidy.js
@@ -14,6 +14,7 @@ export const SELECTORS = {
   timeFinishedRow: '[data-test-value-div="Time finished"]',
   cancelTidyModalBackground: '[data-test-modal-background="Cancel tidy?"]',
   tidyEmptyStateConfigure: '[data-test-tidy-empty-state-configure]',
+  tidyToolbarActionDropdown: '[data-test-configure-tidy-dropdown]',
   tidyConfigureModal: {
     configureTidyModal: '[data-test-modal-background="Tidy this mount"]',
     tidyModalAutoButton: '[data-test-tidy-modal-auto-button]',

--- a/ui/tests/integration/components/pki/page/pki-tidy-status-test.js
+++ b/ui/tests/integration/components/pki/page/pki-tidy-status-test.js
@@ -9,7 +9,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupEngine } from 'ember-engines/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { SELECTORS } from 'vault/tests/helpers/pki/page/pki-tidy-status';
+import { SELECTORS } from 'vault/tests/helpers/pki/page/pki-tidy';
 
 module('Integration | Component | Page::PkiTidyStatus', function (hooks) {
   setupRenderingTest(hooks);

--- a/ui/tests/unit/adapters/pki/tidy-test.js
+++ b/ui/tests/unit/adapters/pki/tidy-test.js
@@ -25,7 +25,7 @@ module('Unit | Adapter | pki/tidy', function (hooks) {
     assert.ok(adapter);
   });
 
-  test('it calls the correct endpoint when tidyType = manual-tidy', async function (assert) {
+  test('it calls the correct endpoint when tidyType = manual', async function (assert) {
     assert.expect(1);
 
     this.server.post(`${this.backend}/tidy`, () => {
@@ -38,24 +38,43 @@ module('Unit | Adapter | pki/tidy', function (hooks) {
       safetyBuffer: '120h',
       backend: this.backend,
     };
-    await this.store
-      .createRecord('pki/tidy', this.payload)
-      .save({ adapterOptions: { tidyType: 'manual-tidy' } });
+    await this.store.createRecord('pki/tidy', this.payload).save({ adapterOptions: { tidyType: 'manual' } });
   });
 
-  test('it calls the correct endpoint when tidyType = auto-tidy', async function (assert) {
+  test('it should make a request to correct endpoint for findRecord', async function (assert) {
     assert.expect(1);
-    this.server.post(`${this.backend}/config/auto-tidy`, () => {
+    this.server.get(`${this.backend}/config/auto-tidy`, () => {
       assert.ok(true, 'request made to correct endpoint on create');
-      return {};
+      return {
+        request_id: '2a4a1f36-20df-e71c-02d6-be15a09656f9',
+        lease_id: '',
+        renewable: false,
+        lease_duration: 0,
+        data: {
+          acme_account_safety_buffer: 2592000,
+          enabled: false,
+          interval_duration: 43200,
+          issuer_safety_buffer: 31536000,
+          maintain_stored_certificate_counts: false,
+          pause_duration: '0s',
+          publish_stored_certificate_count_metrics: false,
+          revocation_queue_safety_buffer: 172800,
+          safety_buffer: 259200,
+          tidy_acme: false,
+          tidy_cert_store: false,
+          tidy_cross_cluster_revoked_certs: false,
+          tidy_expired_issuers: false,
+          tidy_move_legacy_ca_bundle: false,
+          tidy_revocation_queue: false,
+          tidy_revoked_cert_issuer_associations: false,
+          tidy_revoked_certs: false,
+        },
+        wrap_info: null,
+        warnings: null,
+        auth: null,
+      };
     });
-    this.payload = {
-      enabled: true,
-      interval_duration: '72h',
-      backend: this.backend,
-    };
-    await this.store
-      .createRecord('pki/tidy', this.payload)
-      .save({ adapterOptions: { tidyType: 'auto-tidy' } });
+
+    this.store.findRecord('pki/tidy', this.backend);
   });
 });


### PR DESCRIPTION
**Description:**
- Fix failing tests on sidebranch
- Add tidy acceptance tests
- VAULT-16378 Hide `Tidy` action when auto-tidy is enabled

**When auto tidy is enabled:**
<img width="1124" alt="Screenshot 2023-05-22 at 12 25 31 AM" src="https://github.com/hashicorp/vault/assets/30884335/e8b1bb62-7e2b-4a41-b359-06610fea1075">

**When auto tidy not enabled we show a tidy modal w/ manual + auto tidy options:**
<img width="1119" alt="Screenshot 2023-05-22 at 8 30 50 AM" src="https://github.com/hashicorp/vault/assets/30884335/b6471f3d-43aa-42c2-bd5a-b998c668f6b3">
