### PR TITLE
VAULT-14735: write mock activity log entity files

### DIFF
--- a/vault/logical_system_activity_write_testonly_test.go
+++ b/vault/logical_system_activity_write_testonly_test.go
@@ -7,6 +7,7 @@ package vault
 
 import (
 	"context"
+	"sort"
 	"testing"
 
 	"github.com/hashicorp/vault/helper/namespace"
@@ -14,6 +15,8 @@ import (
 	"github.com/hashicorp/vault/vault/activity"
 	"github.com/hashicorp/vault/vault/activity/generation"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 // TestSystemBackend_handleActivityWriteData calls the activity log write endpoint and confirms that the inputs are
@@ -24,6 +27,7 @@ func TestSystemBackend_handleActivityWriteData(t *testing.T) {
 		operation logical.Operation
 		input     map[string]interface{}
 		wantError error
+		wantPaths int
 	}{
 		{
 			name:      "read fails",
@@ -70,6 +74,12 @@ func TestSystemBackend_handleActivityWriteData(t *testing.T) {
 			operation: logical.CreateOperation,
 			input:     map[string]interface{}{"input": `{"write":["WRITE_PRECOMPUTED_QUERIES"],"data":[{"current_month":true,"all":{"clients":[{"count":5}]}}]}`},
 		},
+		{
+			name:      "entities with multiple segments",
+			operation: logical.CreateOperation,
+			input:     map[string]interface{}{"input": `{"write":["WRITE_ENTITIES"],"data":[{"current_month":true,"num_segments":3,"all":{"clients":[{"count":5}]}}]}`},
+			wantPaths: 3,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -81,6 +91,8 @@ func TestSystemBackend_handleActivityWriteData(t *testing.T) {
 				require.Equal(t, tc.wantError, err, resp.Error())
 			} else {
 				require.NoError(t, err)
+				paths := resp.Data["paths"].([]string)
+				require.Len(t, paths, tc.wantPaths)
 			}
 		})
 	}
@@ -427,4 +439,138 @@ func Test_singleMonthActivityClients_populateSegments(t *testing.T) {
 			require.Equal(t, tc.wantSegments, gotSegments)
 		})
 	}
+}
+
+// Test_multipleMonthsActivityClients_write_entities writes 4 months of data
+// splitting some months across segments and using empty segments and skipped
+// segments. Entities are written and then storage is queried. The test verifies
+// that the correct timestamps are present in the activity log and that the correct
+// segment numbers for each month contain the correct number of clients
+func Test_multipleMonthsActivityClients_write_entities(t *testing.T) {
+	index5 := int32(5)
+	index4 := int32(4)
+	data := &generation.ActivityLogMockInput{
+		Write: []generation.WriteOptions{
+			generation.WriteOptions_WRITE_ENTITIES,
+		},
+		Data: []*generation.Data{
+			{
+				// segments: 0:[x,y], 1:[z]
+				Month:       &generation.Data_MonthsAgo{MonthsAgo: 3},
+				Clients:     &generation.Data_All{All: &generation.Clients{Clients: []*generation.Client{{Count: 3}}}},
+				NumSegments: 2,
+			},
+			{
+				// segments: 1:[a,b,c], 2:[d,e]
+				Month:              &generation.Data_MonthsAgo{MonthsAgo: 2},
+				Clients:            &generation.Data_All{All: &generation.Clients{Clients: []*generation.Client{{Count: 5}}}},
+				NumSegments:        3,
+				SkipSegmentIndexes: []int32{0},
+			},
+			{
+				// segments: 5:[f,g]
+				Month: &generation.Data_MonthsAgo{MonthsAgo: 1},
+				Clients: &generation.Data_Segments{
+					Segments: &generation.Segments{Segments: []*generation.Segment{{
+						SegmentIndex: &index5,
+						Clients:      &generation.Clients{Clients: []*generation.Client{{Count: 2}}},
+					}}},
+				},
+			},
+			{
+				// segments: 1:[], 2:[], 4:[n], 5:[o]
+				Month:               &generation.Data_CurrentMonth{},
+				EmptySegmentIndexes: []int32{1, 2},
+				Clients: &generation.Data_Segments{
+					Segments: &generation.Segments{Segments: []*generation.Segment{
+						{
+							SegmentIndex: &index5,
+							Clients:      &generation.Clients{Clients: []*generation.Client{{Count: 1}}},
+						},
+						{
+							SegmentIndex: &index4,
+							Clients:      &generation.Clients{Clients: []*generation.Client{{Count: 1}}},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	core, _, _ := TestCoreUnsealed(t)
+	marshaled, err := protojson.Marshal(data)
+	require.NoError(t, err)
+	req := logical.TestRequest(t, logical.CreateOperation, "internal/counters/activity/write")
+	req.Data = map[string]interface{}{"input": string(marshaled)}
+	resp, err := core.systemBackend.HandleRequest(namespace.RootContext(nil), req)
+	require.NoError(t, err)
+	paths := resp.Data["paths"].([]string)
+	require.Len(t, paths, 9)
+
+	times, err := core.activityLog.availableLogs(context.Background())
+	require.NoError(t, err)
+	require.Len(t, times, 4)
+
+	sortPaths := func(monthPaths []string) {
+		sort.Slice(monthPaths, func(i, j int) bool {
+			iVal, _ := parseSegmentNumberFromPath(monthPaths[i])
+			jVal, _ := parseSegmentNumberFromPath(monthPaths[j])
+			return iVal < jVal
+		})
+	}
+
+	month0Paths := paths[0:4]
+	month1Paths := paths[4:5]
+	month2Paths := paths[5:7]
+	month3Paths := paths[7:9]
+	sortPaths(month0Paths)
+	sortPaths(month1Paths)
+	sortPaths(month2Paths)
+	sortPaths(month3Paths)
+	entities := func(paths []string) map[int][]*activity.EntityRecord {
+		segments := make(map[int][]*activity.EntityRecord)
+		for _, path := range paths {
+			segmentNum, _ := parseSegmentNumberFromPath(path)
+			entry, err := core.activityLog.view.Get(context.Background(), path)
+			require.NoError(t, err)
+			if entry == nil {
+				segments[segmentNum] = []*activity.EntityRecord{}
+				continue
+			}
+			activities := &activity.EntityActivityLog{}
+			err = proto.Unmarshal(entry.Value, activities)
+			require.NoError(t, err)
+			segments[segmentNum] = activities.Clients
+		}
+		return segments
+	}
+	month0Entities := entities(month0Paths)
+	require.Len(t, month0Entities, 4)
+	require.Contains(t, month0Entities, 1)
+	require.Contains(t, month0Entities, 2)
+	require.Contains(t, month0Entities, 4)
+	require.Contains(t, month0Entities, 5)
+	require.Len(t, month0Entities[1], 0)
+	require.Len(t, month0Entities[2], 0)
+	require.Len(t, month0Entities[4], 1)
+	require.Len(t, month0Entities[5], 1)
+
+	month1Entities := entities(month1Paths)
+	require.Len(t, month1Entities, 1)
+	require.Contains(t, month1Entities, 5)
+	require.Len(t, month1Entities[5], 2)
+
+	month2Entities := entities(month2Paths)
+	require.Len(t, month2Entities, 2)
+	require.Contains(t, month2Entities, 1)
+	require.Contains(t, month2Entities, 2)
+	require.Len(t, month2Entities[1], 3)
+	require.Len(t, month2Entities[2], 2)
+
+	month3Entities := entities(month3Paths)
+	require.Len(t, month3Entities, 2)
+	require.Contains(t, month3Entities, 0)
+	require.Contains(t, month3Entities, 1)
+	require.Len(t, month3Entities[0], 2)
+	require.Len(t, month3Entities[1], 1)
 }


### PR DESCRIPTION
This PR adds support for writing the entity data from the activity log data generation endpoint. The activity log's segment writing code needed to be refactored a bit to support force writing only entities. 