### PR TITLE
UI: Add PKI readme and changelog for UI improvements

### DIFF
--- a/changelog/pki-ui-improvements.txt
+++ b/changelog/pki-ui-improvements.txt
@@ -1,10 +1,3 @@
 ```release-note:feature
-**UI PKI Workflow Improvements**: Completes rollout of new PKI UI that provides smoother mount configuration and a more guided user experience
-Included in this release is:
-- Mount overview page with issuer and role counts and quick actions to do the following: issue a certificate from a role, navigate to certificate details by serial number, view an issuer by its name or ID
-- Multiple issuers can now be generated and managed in the UI
-- Added issuer metadata in the list view that includes a default issuer tag, whether it is a root or intermediate, serial number and the common name
-- Guided root rotation by either using old root settings or customizing a new root certificate
-- Perform cross-signing of multiple intermediates in a single step from a parent issuer
-- Parses and displays more certificate metadata
-- Surfaces more mount configuration parameters to allow setting URLs and revocation configuration
+**NEW PKI Workflow in UI**: Completes generally available rollout of new PKI UI that provides smoother mount configuration and a more guided user experience
+```

--- a/changelog/pki-ui-improvements.txt
+++ b/changelog/pki-ui-improvements.txt
@@ -1,9 +1,10 @@
 ```release-note:feature
 **UI PKI Workflow Improvements**: Completes rollout of new PKI UI that provides smoother mount configuration and a more guided user experience
 Included in this release is:
-- Mount overview page with issuer and role counts and quick actions to issue or view a certificate from a dropdown
+- Mount overview page with issuer and role counts and quick actions to do the following: issue a certificate from a role, navigate to certificate details by serial number, view an issuer by its name or ID
 - Multiple issuers can now be generated and managed in the UI
 - Added issuer metadata in the list view that includes a default issuer tag, whether it is a root or intermediate, serial number and the common name
 - Guided root rotation by either using old root settings or customizing a new root certificate
 - Perform cross-signing of multiple intermediates in a single step from a parent issuer
 - Parses and displays more certificate metadata
+- Surfaces more mount configuration parameters to allow setting URLs and revocation configuration

--- a/changelog/pki-ui-improvements.txt
+++ b/changelog/pki-ui-improvements.txt
@@ -3,5 +3,7 @@
 Included in this release is:
 - Mount overview page with issuer and role counts and quick actions to issue or view a certificate from a dropdown
 - Multiple issuers can now be generated and managed in the UI
+- Added issuer metadata in the list view that includes a default issuer tag, whether it is a root or intermediate, serial number and the common name
+- Guided root rotation by either using old root settings or customizing a new root certificate
 - Perform cross-signing of multiple intermediates in a single step from a parent issuer
 - Parses and displays more certificate metadata

--- a/changelog/pki-ui-improvements.txt
+++ b/changelog/pki-ui-improvements.txt
@@ -1,2 +1,7 @@
 ```release-note:feature
-**UI PKI Workflow Improvements**: Introduces a mount overview page, multiple issuer generation and management, cross-signing multiple intermediates in single step, more certificate metadata
+**UI PKI Workflow Improvements**: Completes rollout of new PKI UI that provides smoother mount configuration and a more guided user experience
+Included in this release is:
+- Mount overview page with issuer and role counts and quick actions to issue or view a certificate from a dropdown
+- Multiple issuers can now be generated and managed in the UI
+- Perform cross-signing of multiple intermediates in a single step from a parent issuer
+- Parses and displays more certificate metadata

--- a/changelog/pki-ui-improvements.txt
+++ b/changelog/pki-ui-improvements.txt
@@ -1,0 +1,2 @@
+```release-note:feature
+**UI PKI Workflow Improvements**: Introduces a mount overview page, multiple issuer generation and management, cross-signing multiple intermediates in single step, more certificate metadata

--- a/ui/app/models/pki/certificate/base.js
+++ b/ui/app/models/pki/certificate/base.js
@@ -14,8 +14,8 @@ import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
  * The base certificate model contains shared attributes that make up a certificate's content.
  * Other models under pki/certificate will extend this model and include additional attributes
  * and associated adapter methods for performing various generation and signing actions.
- * This model also displays leaf certs and their parsed attributes (parsed parameters only
- * render if included in certDisplayFields below).
+ * This model also displays leaf certs and their parsed attributes (which exist as an object in
+ * the attribute `parsedCertificate`)
  */
 
 // also displays parsedCertificate values in the template

--- a/ui/lib/pki/README.md
+++ b/ui/lib/pki/README.md
@@ -14,7 +14,7 @@ If you couldn't tell from the documentation above, PKI is _complex_. As such, th
 
 - ### [pki/action](../../app/models/pki/action.js)
 
-  This model is used to perform different `POST` requests that receive similar parameters but don't create a single item (which would be a record in Ember data). These various actions may create multiple items, each with different parameters than those submitted in the `POST` request. For example:
+  This model is used to perform different `POST` requests that receive similar parameters but don't create a single item (which would be a record in Ember data). These various actions may create multiple items that contain different attributes than those submitted in the `POST` request. For example:
 
   > - `POST pki/generate/root/:type` creates a new self-signed CA certificate (an issuer) and private key, which is only returned if `type = exported`
   > - `POST pki/issuer/:issuer_ref/sign-intermediate` creates a certificate, and returns issuing CA and CA chain data that is only available once

--- a/ui/lib/pki/README.md
+++ b/ui/lib/pki/README.md
@@ -10,24 +10,48 @@ The [Vault PKI Secrets Engine](https://developer.hashicorp.com/vault/api-docs/se
 
 ## About the UI engine
 
-If you couldn't tell from the documentation above, PKI is _complex_. As such, the data doesn't map cleanly to a CRUD model and so the first thing you might notice is that the models and adapters for PKI (which [live in the main app](https://ember-engines.com/docs/addons#using-ember-data), not the engine) have some custom logic that differentiate it from most other secret engines. Below are the model
+If you couldn't tell from the documentation above, PKI is _complex_. As such, the data doesn't map cleanly to a CRUD model and so the first thing you might notice is that the models and adapters for PKI (which [live in the main app](https://ember-engines.com/docs/addons#using-ember-data), not the engine) have some custom logic that differentiate it from most other secret engines. Below are the models used throughout PKI and how they are used to interact with the mount. Aside from `pki/action`, each model has a corresponding tab in the UI that takes you to its `LIST` view.
 
-### pki/key
+- ### [pki/action](../../app/models/pki/action.js)
 
-TBD
+  This model is used to perform different `POST` requests that don't necessarily create a single item, but use lots of similar parameters to perform a variety of actions that may create multiple items with parameters that differ from those submitted in the `POST` request. For example:
 
-### pki/role
+  > - `pki/generate/root/:type` creates a new self-signed CA certificate (an issuer) and private key, which is only returned if `type = exported`.
+  > - `pki/issuer/:issuer_ref/sign-intermediate` creates a certificate, and returns issuing CA and CA chain data that is only available once
 
-TBD
+  The `pki/action`[adapter](../../app/adapters/pki/action.js) is used to map the desired action to the corresponding endpoint, and the `pki/action` [serializer](../../app/serializers/pki/action.js) is leveraged to only send relevant attributes. The following PKI workflows use this model:
 
-### pki/issuer
+  - [Root generation and rotation](https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-root) generates a new self-signed CA certificate (an issuer) and private key (key data is only returned if type = `exported`)
+  - [Import CA cert and keys](https://developer.hashicorp.com/vault/api-docs/secret/pki#import-ca-certificates-and-keys)
+  - [Generate intermediate CSR](https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-intermediate-csr)
+  - [Sign intermediate](https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-intermediate)
 
-TBD
+- ### [pki/certificate/base](../../app/models/pki/certificate/base.js)
 
-### pki/certificate/\*
+  This model is for specific interactions with certificate data. The base model contains attributes that make up a certificate's content. The other models that extend this model [certificate/generate](../../app/models/pki/certificate/generate.js) and [certificate/sign](../../app/models/pki/certificate/sign.js) include additional attributes to perform their relevant requests.
 
-TBD
+  The `parsedCertificate` attribute is an object that houses all of the parsed certificate data returned by the [parse-pki-cert.js](../../app/utils/parse-pki-cert.js) util.
 
-### pki/action
+> The following models more closely follow a CRUD pattern:
 
-TBD
+- ### [pki/issuer](../../app/models/pki/issuer.js)
+
+  > Issuers are created by the `pki/action` model, by [importing a CA](https://developer.hashicorp.com/vault/api-docs/secret/pki#import-ca-certificates-and-keys) or [generating a root](https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-root)
+
+  - [UPDATE](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-issuer-certificate)
+  - [READ](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-issuer-certificate)
+  - [LIST](https://developer.hashicorp.com/vault/api-docs/secret/pki#list-issuers)
+
+- ### [pki/role](../../app/models/pki/role.js)
+
+  - [CREATE/UPDATE](https://developer.hashicorp.com/vault/api-docs/secret/pki#create-update-role)
+  - [READ](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-role)
+  - [LIST](https://developer.hashicorp.com/vault/api-docs/secret/pki#list-roles)
+
+- ### pki/key
+
+  - `CREATE` has two options:
+    - [GENERATE](https://developer.hashicorp.com/vault/api-docs/secret/pki#import-ca-certificates-and-keys)
+    - [IMPORT](https://developer.hashicorp.com/vault/api-docs/secret/pki#import-key)
+  - [READ](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-key)
+  - [LIST](https://developer.hashicorp.com/vault/api-docs/secret/pki#list-keys)

--- a/ui/lib/pki/README.md
+++ b/ui/lib/pki/README.md
@@ -16,12 +16,12 @@ If you couldn't tell from the documentation above, PKI is _complex_. As such, th
 
   This model is used to perform different `POST` requests that receive similar parameters but don't create a single item (which would be a record in Ember data). These various actions may create multiple items, each with different parameters than those submitted in the `POST` request. For example:
 
-  > - `pki/generate/root/:type` creates a new self-signed CA certificate (an issuer) and private key, which is only returned if `type = exported`.
-  > - `pki/issuer/:issuer_ref/sign-intermediate` creates a certificate, and returns issuing CA and CA chain data that is only available once
+  > - `POST pki/generate/root/:type` creates a new self-signed CA certificate (an issuer) and private key, which is only returned if `type = exported`
+  > - `POST pki/issuer/:issuer_ref/sign-intermediate` creates a certificate, and returns issuing CA and CA chain data that is only available once
 
-  The `pki/action`[adapter](../../app/adapters/pki/action.js) is used to map the desired action to the corresponding endpoint, and the `pki/action` [serializer](../../app/serializers/pki/action.js) is leveraged to only send relevant attributes. The following PKI workflows use this model:
+  The `pki/action`[adapter](../../app/adapters/pki/action.js) is used to map the desired action to the corresponding endpoint, and the `pki/action` [serializer](../../app/serializers/pki/action.js) includes logic to send the relevant attributes. The following PKI workflows use this model:
 
-  - [Root generation and rotation](https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-root) generates a new self-signed CA certificate (an issuer) and private key (key data is only returned if type = `exported`)
+  - [Root generation and rotation](https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-root)
   - [Import CA cert and keys](https://developer.hashicorp.com/vault/api-docs/secret/pki#import-ca-certificates-and-keys)
   - [Generate intermediate CSR](https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-intermediate-csr)
   - [Sign intermediate](https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-intermediate)
@@ -32,26 +32,26 @@ If you couldn't tell from the documentation above, PKI is _complex_. As such, th
 
   The `parsedCertificate` attribute is an object that houses all of the parsed certificate data returned by the [parse-pki-cert.js](../../app/utils/parse-pki-cert.js) util.
 
-> The following models more closely follow a CRUD pattern:
+> _The following models more closely follow a CRUD pattern:_
 
 - ### [pki/issuer](../../app/models/pki/issuer.js)
 
-  > Issuers are created by the `pki/action` model, by [importing a CA](https://developer.hashicorp.com/vault/api-docs/secret/pki#import-ca-certificates-and-keys) or [generating a root](https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-root)
+  > _Issuers are created by the `pki/action` model by either [importing a CA](https://developer.hashicorp.com/vault/api-docs/secret/pki#import-ca-certificates-and-keys) or [generating a root](https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-root)_
 
-  - [UPDATE](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-issuer-certificate)
-  - [READ](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-issuer-certificate)
-  - [LIST](https://developer.hashicorp.com/vault/api-docs/secret/pki#list-issuers)
+  - [update](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-issuer-certificate)
+  - [read](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-issuer-certificate)
+  - [list](https://developer.hashicorp.com/vault/api-docs/secret/pki#list-issuers)
 
 - ### [pki/role](../../app/models/pki/role.js)
 
-  - [CREATE/UPDATE](https://developer.hashicorp.com/vault/api-docs/secret/pki#create-update-role)
-  - [READ](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-role)
-  - [LIST](https://developer.hashicorp.com/vault/api-docs/secret/pki#list-roles)
+  - [create/update](https://developer.hashicorp.com/vault/api-docs/secret/pki#create-update-role)
+  - [read](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-role)
+  - [list](https://developer.hashicorp.com/vault/api-docs/secret/pki#list-roles)
 
-- ### pki/key
+- ### [pki/key](../../app/models/pki/key.js)
 
   - `CREATE` has two options:
-    - [GENERATE](https://developer.hashicorp.com/vault/api-docs/secret/pki#import-ca-certificates-and-keys)
-    - [IMPORT](https://developer.hashicorp.com/vault/api-docs/secret/pki#import-key)
-  - [READ](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-key)
-  - [LIST](https://developer.hashicorp.com/vault/api-docs/secret/pki#list-keys)
+    - [generate](https://developer.hashicorp.com/vault/api-docs/secret/pki#import-ca-certificates-and-keys)
+    - [import](https://developer.hashicorp.com/vault/api-docs/secret/pki#import-key)
+  - [read](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-key)
+  - [list](https://developer.hashicorp.com/vault/api-docs/secret/pki#list-keys)

--- a/ui/lib/pki/README.md
+++ b/ui/lib/pki/README.md
@@ -14,7 +14,7 @@ If you couldn't tell from the documentation above, PKI is _complex_. As such, th
 
 - ### [pki/action](../../app/models/pki/action.js)
 
-  This model is used to perform different `POST` requests that don't necessarily create a single item, but use lots of similar parameters to perform a variety of actions that may create multiple items with parameters that differ from those submitted in the `POST` request. For example:
+  This model is used to perform different `POST` requests that receive similar parameters but don't create a single item (which would be a record in Ember data). These various actions may create multiple items, each with different parameters than those submitted in the `POST` request. For example:
 
   > - `pki/generate/root/:type` creates a new self-signed CA certificate (an issuer) and private key, which is only returned if `type = exported`.
   > - `pki/issuer/:issuer_ref/sign-intermediate` creates a certificate, and returns issuing CA and CA chain data that is only available once


### PR DESCRIPTION
## Phase 2 PKI Improvements
Included in this release is:
- Mount overview page with issuer and role counts and quick actions to do the following: issue a certificate from a role, navigate to certificate details by serial number, view an issuer by its name or ID
- Multiple issuers can now be generated and managed in the UI
- Adds issuer metadata in the list view that includes a default issuer tag, whether it is a root or intermediate, serial number and the common name
- Guided root rotation by either using old root settings or customizing a new root certificate
- Perform cross-signing of multiple intermediates in a single step from a parent issuer
- Parses and displays more certificate metadata
- Surfaces more mount configuration parameters to allow setting URLs and revocation configuration

#19281
#19312
#19425
#19672
#19672
#19677
#19739
#19756
#19791
#19840
#19925
#19990
#20043
#20062
#20163
#20164
#20179
#20245
#20246
#20474
#20478
#20479
#20495
#20533
#20630
#20635
#20655