### PR TITLE
Update docs and error messages to clarify 0 value for min_encryption_version

### DIFF
--- a/builtin/logical/transit/path_hmac.go
+++ b/builtin/logical/transit/path_hmac.go
@@ -144,7 +144,7 @@ func (b *backend) pathHMACWrite(ctx context.Context, req *logical.Request, d *fr
 		ver = p.LatestVersion
 	case ver == p.LatestVersion:
 		// Allowed
-	case p.MinEncryptionVersion > 0 && ver < p.MinEncryptionVersion:
+	case (p.MinEncryptionVersion > 0 && ver < p.MinEncryptionVersion) || (p.MinEncryptionVersion == 0 && ver < p.MinDecryptionVersion):
 		p.Unlock()
 		return logical.ErrorResponse("cannot generate HMAC: version is too old (disallowed by policy)"), logical.ErrInvalidRequest
 	}

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -1084,6 +1084,8 @@ func (p *Policy) SignWithOptions(ver int, context, input []byte, options *Signin
 		return nil, errutil.UserError{Err: "requested version for signing is negative"}
 	case ver > p.LatestVersion:
 		return nil, errutil.UserError{Err: "requested version for signing is higher than the latest key version"}
+	case p.MinEncryptionVersion == 0 && ver < p.MinDecryptionVersion:
+		return nil, errutil.UserError{Err: fmt.Sprintf("requested version for signing is less than the implicit minimum available key version (%d)", p.MinDecryptionVersion)}
 	case p.MinEncryptionVersion > 0 && ver < p.MinEncryptionVersion:
 		return nil, errutil.UserError{Err: "requested version for signing is less than the minimum encryption key version"}
 	}
@@ -1932,7 +1934,9 @@ func (p *Policy) EncryptWithFactory(ver int, context []byte, nonce []byte, value
 		return "", errutil.UserError{Err: "requested version for encryption is negative"}
 	case ver > p.LatestVersion:
 		return "", errutil.UserError{Err: "requested version for encryption is higher than the latest key version"}
-	case ver < p.MinEncryptionVersion:
+	case p.MinEncryptionVersion == 0 && ver < p.MinDecryptionVersion:
+		return "", errutil.UserError{Err: fmt.Sprintf("requested version for encryption is less than the implicit minimum available key version (%d)", p.MinDecryptionVersion)}
+	case p.MinEncryptionVersion > 0 && ver < p.MinEncryptionVersion:
 		return "", errutil.UserError{Err: "requested version for encryption is less than the minimum encryption key version"}
 	}
 

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -420,8 +420,10 @@ are returned during a read operation on the named key.)
 
 - `min_encryption_version` `(int: 0)` – Specifies the minimum version of the
   key that can be used to encrypt plaintext, sign payloads, or generate HMACs.
-  Must be `0` (which will use the latest version) or a value greater or equal
-  to `min_decryption_version`.
+  Must be either: A) a value greater than or equal to `min_decryption_version`,
+  or B) `0` to limit available key versions to those greater than or equal to
+  `min_decryption_version` without deleting key versions less than
+  `min_decryption_version`.
 
 - `deletion_allowed` `(bool: false)` - Specifies if the key is allowed to be
   deleted.
@@ -648,7 +650,7 @@ will be returned.
 
 - `key_version` `(int: 0)` – Specifies the version of the key to use for
   encryption. If not set, uses the latest version. Must be greater than or
-  equal to the key's `min_encryption_version`, if set.
+  equal to the maximum of `min_encryption_version` and `min_decryption_version`.
 
 - `nonce` `(string: "")` – Specifies the **base64 encoded** nonce value. This
   must be provided if convergent encryption is enabled for this key and the key
@@ -859,7 +861,7 @@ functionality to untrusted users or scripts.
 
 - `key_version` `(int: 0)` – Specifies the version of the key to use for the
   operation. If not set, uses the latest version. Must be greater than or equal
-  to the key's `min_encryption_version`, if set.
+  to the maximum of `min_encryption_version` and `min_decryption_version`.
 
 - `nonce` `(string: "")` – Specifies a base64 encoded nonce value used during
   encryption. Must be provided if convergent encryption is enabled for this key
@@ -1112,7 +1114,7 @@ be used.
 
 - `key_version` `(int: 0)` – Specifies the version of the key to use for the
   operation. If not set, uses the latest version. Must be greater than or equal
-  to the key's `min_encryption_version`, if set.
+  to the maximum of `min_encryption_version` and `min_decryption_version`.
 
 - `algorithm` `(string: "sha2-256")` – Specifies the hash algorithm to use. This
   can also be specified as part of the URL. Currently-supported algorithms are:
@@ -1247,7 +1249,7 @@ supports signing.
 
 - `key_version` `(int: 0)` – Specifies the version of the key to use for
   signing. If not set, uses the latest version. Must be greater than or equal
-  to the key's `min_encryption_version`, if set.
+  to the maximum of `min_encryption_version` and `min_decryption_version`.
 
 - `hash_algorithm` `(string: "sha2-256")` – Specifies the hash algorithm to use for
   supporting key types (notably, not including `ed25519` which specifies its


### PR DESCRIPTION
The documentation for the `min_encryption_version` configuration field currently says:

> Must be `0` (which will use the latest version)

This is confusing (or even incorrect?) because cryptographic protection operations (signing, encryption, and HMAC) can take custom key versions, in which case the key version used is not the latest version, but rather the given `key_version`, with the `min_decryption_version` as a lower bound restriction.

I am not super familiar with the Vault codebase yet, but it looks like this is where that `min_decryption_version` lower bound for encrypt/sign/HMAC operations is being imposed: https://github.com/hashicorp/vault/blob/157b9762536f16d77d324dc19efc8c960ee6a4e8/sdk/helper/keysutil/policy.go#L518

This PR updates the documentation to better explain this behavior, and also improves the error messages that result from attempting to use a key version less than `min_decryption_version` if `min_encryption_version == 0`.