### PR TITLE
Docs: audit - add warning when disabling device regarding HMAC

### DIFF
--- a/website/content/api-docs/system/audit.mdx
+++ b/website/content/api-docs/system/audit.mdx
@@ -101,6 +101,10 @@ $ curl \
 
 This endpoint disables the audit device at the given path.
 
+~> Note: Once an audit device is disabled, you will no longer be able to HMAC values
+for comparison with entries in the audit logs. This is true even if you re-enable
+the audit device at the same path, as a new salt will be created for hashing.
+
 - **`sudo` required** – This endpoint requires `sudo` capability in addition to
   any path-specific capabilities.
 

--- a/website/content/docs/audit/index.mdx
+++ b/website/content/docs/audit/index.mdx
@@ -85,6 +85,10 @@ An audit device can be limited to only within the node's cluster with the [`loca
 When an audit device is disabled, it will stop receiving logs immediately.
 The existing logs that it did store are untouched.
 
+~> Note: Once an audit device is disabled, you will no longer be able to HMAC values
+for comparison with entries in the audit logs. This is true even if you re-enable
+the audit device at the same path, as a new salt will be created for hashing.
+
 ## Blocked Audit Devices
 
 Audit device logs are critically important and ignoring auditing failures opens an avenue for attack. Vault will not respond to requests when no enabled audit devices can record them.

--- a/website/content/docs/commands/audit/disable.mdx
+++ b/website/content/docs/commands/audit/disable.mdx
@@ -18,6 +18,10 @@ data associated with the audit device is unaffected. For example, if you
 disabled an audit device that was logging to a file, the file would still exist
 and have stored contents.
 
+~> Note: Once an audit device is disabled, you will no longer be able to HMAC values
+for comparison with entries in the audit logs. This is true even if you re-enable
+the audit device at the same path, as a new salt will be created for hashing.
+
 ## Examples
 
 Disable the audit device enabled at "file/":

--- a/website/content/docs/commands/audit/index.mdx
+++ b/website/content/docs/commands/audit/index.mdx
@@ -39,6 +39,10 @@ $ vault audit disable file/
 Success! Disabled audit device (if it was enabled) at: file/
 ```
 
+~> Note: Once an audit device is disabled, you will no longer be able to HMAC values
+for comparison with entries in the audit logs. This is true even if you re-enable
+the audit device at the same path, as a new salt will be created for hashing.
+
 ## Usage
 
 ```text


### PR DESCRIPTION
When a user disables an audit device, they will no longer be able to perform HMACing against it to compare values with entries in the existing audit logs.

Similarly, if they re-enable a disabled audit device, they will face this issue as a new salt is generated for hashing.

It seems sensible to warn users of the pitfalls before the turn off a device.