### PR TITLE
update API docs for kubernetes secrets engine

### DIFF
--- a/website/content/api-docs/secret/kubernetes.mdx
+++ b/website/content/api-docs/secret/kubernetes.mdx
@@ -145,6 +145,9 @@ Only one of `service_account_name`, `kubernetes_role_name` or
 - `token_default_ttl` `(string: "")` - The default TTL for generated Kubernetes
   tokens, specified in seconds or as a Go duration format string, e.g. `"1h"`.
   If not set or set to 0, the [system default](/vault/docs/configuration#default_lease_ttl) will be used.
+- `token_default_audiences` `(string: "")` - The default intended audiences for generated Kubernetes
+  tokens, specified by a comma separated string. e.g `"vault,vaultsecretoperator"`.
+  If not set or set to `""`, the Kubernetes cluster default for audiences of service account tokens will be used.
 - `service_account_name` `(string: "")` - The pre-existing service account to
   generate tokens for. Mutually exclusive with all role parameters. If set, only
   a Kubernetes token will be created when credentials are requested. See the
@@ -369,8 +372,9 @@ Generate a service account token.
 ### Parameters
 
 - `role` `(string: <required>)` - Name of the role to generate credentials for.
-- `kubernetes_namespace` `(string: <required>)` - The name of the Kubernetes
-  namespace in which to generate the credentials.
+- `kubernetes_namespace` `(string)` - The name of the Kubernetes
+  namespace in which to generate the credentials. Optional if the Vault role is configured
+  with a single namespace that is not `"*"`; required otherwise.
 - `cluster_role_binding` `(bool: false)` - If true, generate a ClusterRoleBinding
   to grant permissions across the whole cluster instead of within a namespace.
   Requires the Vault role to have `kubernetes_role_type` set to ClusterRole.
@@ -378,6 +382,10 @@ Generate a service account token.
   specified in seconds or as a Go duration format string, e.g. `"1h"`. The TTL
   returned may be different from the TTL specified due to limits specified in
   Kubernetes, Vault system-wide controls, or role-specific controls.
+- `audiences` `(string: "")` - A comma separated string containing the intended audiences
+  of the generated Kubernetes service account the token, e.g.  `"vault,vaultsecretoperator"`.
+  If not set or set to `""`,
+  the [token_default_audiences](/vault/api-docs/secret/kubernetes#token_default_audiences) will be used.
 
 ### Sample Payload
 

--- a/website/content/api-docs/secret/kubernetes.mdx
+++ b/website/content/api-docs/secret/kubernetes.mdx
@@ -146,7 +146,7 @@ Only one of `service_account_name`, `kubernetes_role_name` or
   tokens, specified in seconds or as a Go duration format string, e.g. `"1h"`.
   If not set or set to 0, the [system default](/vault/docs/configuration#default_lease_ttl) will be used.
 - `token_default_audiences` `(string: "")` - The default intended audiences for generated Kubernetes
-  tokens, specified by a comma separated string. e.g `"vault,vaultsecretoperator"`.
+  tokens, specified by a comma separated string. e.g `"custom-audience-0,custom-audience-1"`.
   If not set or set to `""`, the Kubernetes cluster default for audiences of service account tokens will be used.
 - `service_account_name` `(string: "")` - The pre-existing service account to
   generate tokens for. Mutually exclusive with all role parameters. If set, only
@@ -383,7 +383,7 @@ Generate a service account token.
   returned may be different from the TTL specified due to limits specified in
   Kubernetes, Vault system-wide controls, or role-specific controls.
 - `audiences` `(string: "")` - A comma separated string containing the intended audiences
-  of the generated Kubernetes service account the token, e.g.  `"vault,vaultsecretoperator"`.
+  of the generated Kubernetes service account the token, e.g.  `"custom-audience-0,custom-audience-1"`.
   If not set or set to `""`,
   the [token_default_audiences](/vault/api-docs/secret/kubernetes#token_default_audiences) will be used.
 

--- a/website/content/docs/secrets/kubernetes.mdx
+++ b/website/content/docs/secrets/kubernetes.mdx
@@ -304,6 +304,7 @@ $ echo 'eyJhbGc...' | cut -d'.' -f2 | base64 -d  | jq -r '.iat,.exp|todate'
 ```
 
 ## Audiences
+
 Kubernetes service account tokens have audiences.
 
 You can set default audiences (`token_default_audiences`) when creating or tuning the Vault role.

--- a/website/content/docs/secrets/kubernetes.mdx
+++ b/website/content/docs/secrets/kubernetes.mdx
@@ -314,7 +314,7 @@ The Kubernetes cluster default audiences for service account tokens will be used
 $ vault write kubernetes/roles/my-role \
     allowed_kubernetes_namespaces="*" \
     service_account_name="new-service-account-with-generated-token" \
-    token_default_audiences="vault"
+    token_default_audiences="custom-audience"
 ```
 
 You can also set audiences (`audiences`) when you generate the token from the credentials endpoint.

--- a/website/content/docs/secrets/kubernetes.mdx
+++ b/website/content/docs/secrets/kubernetes.mdx
@@ -335,7 +335,7 @@ service_account_namespace  test
 service_account_token      eyJHbGci0iJSUzI1NiIsImtpZCI6ImlrUEE...
 ```
 
-You can verify the token's audiences by decoding the JWT token.
+You can verify the token's audiences by decoding the JWT.
 
 ```shell-session
 $ echo 'eyJhbGc...' | cut -d'.' -f2 | base64 -d

--- a/website/content/docs/secrets/kubernetes.mdx
+++ b/website/content/docs/secrets/kubernetes.mdx
@@ -323,7 +323,7 @@ The audiences of the token will be given the default audiences if not specified.
 ```shell-session
 $ vault write kubernetes/creds/my-role \
     kubernetes_namespace=test \
-    audiences="vaultsecretsoperator"
+    audiences="another-custom-audience"
 
 Key                        Value
 –--                        -----
@@ -339,7 +339,7 @@ You can verify the token's audiences by decoding the JWT.
 
 ```shell-session
 $ echo 'eyJhbGc...' | cut -d'.' -f2 | base64 -d
-{"aud":["vaultsecretsoperator"]...
+{"aud":["another-custom-audience"]...
 ```
 
 ## Automatically Managing Roles and Service Accounts

--- a/website/content/docs/secrets/kubernetes.mdx
+++ b/website/content/docs/secrets/kubernetes.mdx
@@ -303,6 +303,44 @@ $ echo 'eyJhbGc...' | cut -d'.' -f2 | base64 -d  | jq -r '.iat,.exp|todate'
 2022-05-20T17:34:50Z
 ```
 
+## Audiences
+Kubernetes service account tokens have audiences.
+
+You can set default audiences (`token_default_audiences`) when creating or tuning the Vault role.
+The Kubernetes cluster default audiences for service account tokens will be used if not specified.
+
+```shell-session
+$ vault write kubernetes/roles/my-role \
+    allowed_kubernetes_namespaces="*" \
+    service_account_name="new-service-account-with-generated-token" \
+    token_default_audiences="vault"
+```
+
+You can also set audiences (`audiences`) when you generate the token from the credentials endpoint.
+The audiences of the token will be given the default audiences if not specified.
+
+```shell-session
+$ vault write kubernetes/creds/my-role \
+    kubernetes_namespace=test \
+    audiences="vaultsecretsoperator"
+
+Key                        Value
+–--                        -----
+lease_id                   kubernetes/creds/my-role/SriWQf0bPZ...
+lease_duration             768h
+lease_renwable             false
+service_account_name       new-service-account-with-generated-token
+service_account_namespace  test
+service_account_token      eyJHbGci0iJSUzI1NiIsImtpZCI6ImlrUEE...
+```
+
+You can verify the token's audiences by decoding the JWT token.
+
+```shell-session
+$ echo 'eyJhbGc...' | cut -d'.' -f2 | base64 -d
+{"aud":["vaultsecretsoperator"]...
+```
+
 ## Automatically Managing Roles and Service Accounts
 
 When configuring the Vault role, you can pass in parameters to specify that you want to


### PR DESCRIPTION
* Add an option to set audiences on token create VAULT-6292
* Allow omitting kubernetes_namespace on token create VAULT-6293