### PR TITLE
Update transit public keys only for Ed25519 support

### DIFF
--- a/builtin/logical/transit/path_export.go
+++ b/builtin/logical/transit/path_export.go
@@ -24,6 +24,7 @@ const (
 	exportTypeEncryptionKey = "encryption-key"
 	exportTypeSigningKey    = "signing-key"
 	exportTypeHMACKey       = "hmac-key"
+	exportTypePublicKey     = "public-key"
 )
 
 func (b *backend) pathExportKeys() *framework.Path {
@@ -39,7 +40,7 @@ func (b *backend) pathExportKeys() *framework.Path {
 		Fields: map[string]*framework.FieldSchema{
 			"type": {
 				Type:        framework.TypeString,
-				Description: "Type of key to export (encryption-key, signing-key, hmac-key)",
+				Description: "Type of key to export (encryption-key, signing-key, hmac-key, public-key)",
 			},
 			"name": {
 				Type:        framework.TypeString,
@@ -69,6 +70,7 @@ func (b *backend) pathPolicyExportRead(ctx context.Context, req *logical.Request
 	case exportTypeEncryptionKey:
 	case exportTypeSigningKey:
 	case exportTypeHMACKey:
+	case exportTypePublicKey:
 	default:
 		return logical.ErrorResponse(fmt.Sprintf("invalid export type: %s", exportType)), logical.ErrInvalidRequest
 	}
@@ -194,6 +196,10 @@ func getExportKey(policy *keysutil.Policy, key *keysutil.KeyEntry, exportType st
 			return ecKey, nil
 
 		case keysutil.KeyType_ED25519:
+			if len(key.Key) == 0 {
+				return "", nil
+			}
+
 			return strings.TrimSpace(base64.StdEncoding.EncodeToString(key.Key)), nil
 
 		case keysutil.KeyType_RSA2048, keysutil.KeyType_RSA3072, keysutil.KeyType_RSA4096:
@@ -203,26 +209,70 @@ func getExportKey(policy *keysutil.Policy, key *keysutil.KeyEntry, exportType st
 			}
 			return rsaKey, nil
 		}
+	case exportTypePublicKey:
+		switch policy.Type {
+		case keysutil.KeyType_ECDSA_P256, keysutil.KeyType_ECDSA_P384, keysutil.KeyType_ECDSA_P521:
+			var curve elliptic.Curve
+			switch policy.Type {
+			case keysutil.KeyType_ECDSA_P384:
+				curve = elliptic.P384()
+			case keysutil.KeyType_ECDSA_P521:
+				curve = elliptic.P521()
+			default:
+				curve = elliptic.P256()
+			}
+			ecKey, err := keyEntryToECPublicKey(key, curve)
+			if err != nil {
+				return "", err
+			}
+			return ecKey, nil
+
+		case keysutil.KeyType_ED25519:
+			return strings.TrimSpace(key.FormattedPublicKey), nil
+
+		case keysutil.KeyType_RSA2048, keysutil.KeyType_RSA3072, keysutil.KeyType_RSA4096:
+			rsaKey, err := encodeRSAPublicKey(key)
+			if err != nil {
+				return "", err
+			}
+			return rsaKey, nil
+		}
 	}
 
-	return "", fmt.Errorf("unknown key type %v", policy.Type)
+	return "", fmt.Errorf("unknown key type %v for export type %v", policy.Type, exportType)
 }
 
 func encodeRSAPrivateKey(key *keysutil.KeyEntry) (string, error) {
+	if key == nil {
+		return "", errors.New("nil KeyEntry provided")
+	}
+
+	if key.IsPrivateKeyMissing() {
+		return "", nil
+	}
+
 	// When encoding PKCS1, the PEM header should be `RSA PRIVATE KEY`. When Go
 	// has PKCS8 encoding support, we may want to change this.
-	var blockType string
-	var derBytes []byte
-	var err error
-	if !key.IsPrivateKeyMissing() {
-		blockType = "RSA PRIVATE KEY"
-		derBytes = x509.MarshalPKCS1PrivateKey(key.RSAKey)
-	} else {
-		blockType = "PUBLIC KEY"
-		derBytes, err = x509.MarshalPKIXPublicKey(key.RSAPublicKey)
-		if err != nil {
-			return "", err
-		}
+	blockType := "RSA PRIVATE KEY"
+	derBytes := x509.MarshalPKCS1PrivateKey(key.RSAKey)
+	pemBlock := pem.Block{
+		Type:  blockType,
+		Bytes: derBytes,
+	}
+
+	pemBytes := pem.EncodeToMemory(&pemBlock)
+	return string(pemBytes), nil
+}
+
+func encodeRSAPublicKey(key *keysutil.KeyEntry) (string, error) {
+	if key == nil {
+		return "", errors.New("nil KeyEntry provided")
+	}
+
+	blockType := "RSA PUBLIC KEY"
+	derBytes, err := x509.MarshalPKIXPublicKey(key.RSAPublicKey)
+	if err != nil {
+		return "", err
 	}
 
 	pemBlock := pem.Block{
@@ -239,38 +289,49 @@ func keyEntryToECPrivateKey(k *keysutil.KeyEntry, curve elliptic.Curve) (string,
 		return "", errors.New("nil KeyEntry provided")
 	}
 
+	if k.IsPrivateKeyMissing() {
+		return "", nil
+	}
+
 	pubKey := ecdsa.PublicKey{
 		Curve: curve,
 		X:     k.EC_X,
 		Y:     k.EC_Y,
 	}
 
-	var blockType string
-	var derBytes []byte
-	var err error
-	if !k.IsPrivateKeyMissing() {
-		blockType = "EC PRIVATE KEY"
-		privKey := &ecdsa.PrivateKey{
-			PublicKey: pubKey,
-			D:         k.EC_D,
-		}
-		derBytes, err = x509.MarshalECPrivateKey(privKey)
-		if err != nil {
-			return "", err
-		}
-		if derBytes == nil {
-			return "", errors.New("no data returned when marshalling to private key")
-		}
-	} else {
-		blockType = "PUBLIC KEY"
-		derBytes, err = x509.MarshalPKIXPublicKey(&pubKey)
-		if err != nil {
-			return "", err
-		}
+	blockType := "EC PRIVATE KEY"
+	privKey := &ecdsa.PrivateKey{
+		PublicKey: pubKey,
+		D:         k.EC_D,
+	}
+	derBytes, err := x509.MarshalECPrivateKey(privKey)
+	if err != nil {
+		return "", err
+	}
 
-		if derBytes == nil {
-			return "", errors.New("no data returned when marshalling to public key")
-		}
+	pemBlock := pem.Block{
+		Type:  blockType,
+		Bytes: derBytes,
+	}
+
+	return strings.TrimSpace(string(pem.EncodeToMemory(&pemBlock))), nil
+}
+
+func keyEntryToECPublicKey(k *keysutil.KeyEntry, curve elliptic.Curve) (string, error) {
+	if k == nil {
+		return "", errors.New("nil KeyEntry provided")
+	}
+
+	pubKey := ecdsa.PublicKey{
+		Curve: curve,
+		X:     k.EC_X,
+		Y:     k.EC_Y,
+	}
+
+	blockType := "PUBLIC KEY"
+	derBytes, err := x509.MarshalPKIXPublicKey(&pubKey)
+	if err != nil {
+		return "", err
 	}
 
 	pemBlock := pem.Block{

--- a/builtin/logical/transit/path_import_test.go
+++ b/builtin/logical/transit/path_import_test.go
@@ -457,8 +457,8 @@ func TestTransit_Import(t *testing.T) {
 				},
 			}
 			_, err = b.HandleRequest(context.Background(), req)
-			if err == nil {
-				t.Fatalf("invalid public_key import incorrectly succeeeded")
+			if err != nil {
+				t.Fatalf("failed to import ed25519 key: %v", err)
 			}
 		})
 

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -2090,7 +2090,25 @@ func (p *Policy) ImportPrivateKeyForVersion(ctx context.Context, storage logical
 	// Parse key
 	parsedPrivateKey, err := x509.ParsePKCS8PrivateKey(key)
 	if err != nil {
-		return fmt.Errorf("error parsing asymmetric key: %s", err)
+		if strings.Contains(err.Error(), "unknown elliptic curve") {
+			var edErr error
+			parsedPrivateKey, edErr = ParsePKCS8Ed25519PrivateKey(key)
+			if edErr != nil {
+				return fmt.Errorf("error parsing asymmetric key:\n - assuming contents are an ed25519 private key: %s\n - original error: %v", edErr, err)
+			}
+
+			// Parsing as Ed25519-in-PKCS8-ECPrivateKey succeeded!
+		} else if strings.Contains(err.Error(), oidSignatureRSAPSS.String()) {
+			var rsaErr error
+			parsedPrivateKey, rsaErr = ParsePKCS8RSAPSSPrivateKey(key)
+			if rsaErr != nil {
+				return fmt.Errorf("error parsing asymmetric key:\n - assuming contents are an RSA/PSS private key: %v\n - original error: %w", rsaErr, err)
+			}
+
+			// Parsing as RSA-PSS in PKCS8 succeeded!
+		} else {
+			return fmt.Errorf("error parsing asymmetric key: %s", err)
+		}
 	}
 
 	switch parsedPrivateKey.(type) {

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -531,6 +531,8 @@ be valid.
   - `encryption-key`
   - `signing-key`
   - `hmac-key`
+  - `public-key`, to return the corresponding public keys of private key
+    asymmetric keys (EC with NIST P-curves or Ed25519 and RSA).
 
 - `name` `(string: <required>)` – Specifies the name of the key to read
   information about. This is specified as part of the URL.

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -109,7 +109,17 @@ $ curl \
 
 This endpoint imports existing key material into a new transit-managed encryption key.
 To import key material into an existing key, see the `import_version/` endpoint.
-// TODO: Has to be updated.
+
+This supports one of two forms:
+
+ 1. Private/Symmetric Key import, requiring the `ciphertext`, `hash_function`
+    parameters be set (and automatically deriving the public key), or
+ 2. Public Key-only import, restricting the operations that can be done with
+    this key, and requiring only the `public_key` parameter.
+
+The remaining parameters (including `name`, `type`, `allow_rotation`,
+`derived`, `context`, `exportable`, `allow_plaintext_backup`, and
+`auto_rotate_period`) remain the same across both versions of this call.
 
 | Method | Path                         |
 | :----- | :--------------------------- |
@@ -153,8 +163,10 @@ the hash function defaults to SHA256.
   - `rsa-3072` - RSA with bit size of 3072 (asymmetric)
   - `rsa-4096` - RSA with bit size of 4096 (asymmetric)
 
-- `public_key` `(string: "", optional)` - A plaintext PEM public key to be imported.
-If `ciphertext` is set, this field is ignored.
+- `public_key` `(string: "", optional)` - A plaintext PEM public key to be
+imported. This limits the operations available under this key to verification
+and encryption, depending on the key type and algorithm, as no private key
+is available.
 
 - `allow_rotation` `(bool: false)` - If set, the imported key can be rotated
 within Vault by using the `rotate` endpoint.
@@ -203,7 +215,12 @@ $ curl \
 ## Import Key Version
 
 This endpoint imports new key material into an existing imported key.
-// TODO: Has to be updated.
+
+See description and note in [Import Key](#import-key) above about importing
+public and private keys.
+
+Notably, using this method, a private key matching a public key can be
+imported at a later date.
 
 | Method | Path                                 |
 | :----- | :----------------------------------- |
@@ -225,15 +242,16 @@ provided AES key. The wrapped AES key should be the first 512 bytes of the
 ciphertext, and the encrypted key material should be the remaining bytes.
 See the BYOK section of the [Transit secrets engine documentation](/vault/docs/secrets/transit#bring-your-own-key-byok)
 for more information on constructing the ciphertext.
-// TODO: Update text
 
 - `hash_function` `(string: "SHA256")` - The hash function used for the
 RSA-OAEP step of creating the ciphertext. Supported hash functions are:
 `SHA1`, `SHA224`, `SHA256`, `SHA384`, and `SHA512`. If not specified,
 the hash function defaults to SHA256.
 
-- `public_key` `(string: "", optional)` - A plaintext PEM public key to be imported.
-  If `ciphertext` is set, this field is ignored.
+- `public_key` `(string: "", optional)` - A plaintext PEM public key to be
+imported. This limits the operations available under this key to verification
+and encryption, depending on the key type and algorithm, as no private key
+is available.
 
 - `bump_version` - By default, each operator will create a new key version.
 If set to "false", will try to update the latest version of the key,


### PR DESCRIPTION
This updates to add missing Ed25519 support to the new Transit public-key only key types that @Gabrielopesantos added in #17934. :-) 

I additionally remove the TODO's from the docs (modifying them slightly), and introduce a new `public-key` export type to the API, allowing callers to fetch just the public keys. 

I think the last remaining item from that PR is to figure out what we want to do with `bump_version` and if we want to keep it or not. 

Not adding a CL as this is covered under the other CL entry IMO. 