### PR TITLE
Add docs for new client cert credential type

### DIFF
--- a/website/content/api-docs/secret/databases/mongodbatlas.mdx
+++ b/website/content/api-docs/secret/databases/mongodbatlas.mdx
@@ -69,8 +69,8 @@ list the plugin does not support that statement type.
   serialized JSON object, or a base64-encoded serialized JSON object.
   The object can optionally contain a `database_name`, the name of
   the authentication database to log into MongoDB. In Atlas deployments of
-  MongoDB, the authentication database is always the admin database. The object
-  must also contain a `roles` array, and from Vault version 1.6.0 (plugin
+  MongoDB, the options for the authentication database include admin (default) and $external database.
+  The object must also contain a `roles` array, and from Vault version 1.6.0 (plugin
   version 0.2.0) may optionally contain a `scopes` array. The `roles` array
   contains objects that hold a series of roles `roleName`, an optional
   `databaseName` and `collectionName` value. The `scopes` array determines

--- a/website/content/docs/secrets/databases/index.mdx
+++ b/website/content/docs/secrets/databases/index.mdx
@@ -136,21 +136,21 @@ and private key pair to authenticate.
 
 | Database                                                               | Root Credential Rotation | Dynamic Roles | Static Roles | Username Customization | Credential Types          |
 | ---------------------------------------------------------------------- | ------------------------ | ------------- | ------------ | ---------------------- |---------------------------|
-| [Cassandra](/vault/docs/secrets/databases/cassandra)                         | Yes                      | Yes           | Yes (1.6+)   | Yes (1.7+)             | password                  |
-| [Couchbase](/vault/docs/secrets/databases/couchbase)                         | Yes                      | Yes           | Yes          | Yes (1.7+)             | password                  |
-| [Elasticsearch](/vault/docs/secrets/databases/elasticdb)                     | Yes                      | Yes           | Yes (1.6+)   | Yes (1.8+)             | password                  |
-| [HanaDB](/vault/docs/secrets/databases/hanadb)                               | Yes (1.6+)               | Yes           | Yes (1.6+)   | Yes (1.12+)            | password                  |
-| [InfluxDB](/vault/docs/secrets/databases/influxdb)                           | Yes                      | Yes           | Yes (1.6+)   | Yes (1.8+)             | password                  |
-| [MongoDB](/vault/docs/secrets/databases/mongodb)                             | Yes                      | Yes           | Yes          | Yes (1.7+)             | password                  |
-| [MongoDB Atlas](/vault/docs/secrets/databases/mongodbatlas)                  | No                       | Yes           | Yes          | Yes (1.8+)             | password                  |
-| [MSSQL](/vault/docs/secrets/databases/mssql)                                 | Yes                      | Yes           | Yes          | Yes (1.7+)             | password                  |
-| [MySQL/MariaDB](/vault/docs/secrets/databases/mysql-maria)                   | Yes                      | Yes           | Yes          | Yes (1.7+)             | password                  |
-| [Oracle](/vault/docs/secrets/databases/oracle)                               | Yes                      | Yes           | Yes          | Yes (1.7+)             | password                  |
-| [PostgreSQL](/vault/docs/secrets/databases/postgresql)                       | Yes                      | Yes           | Yes          | Yes (1.7+)             | password                  |
-| [Redis](/vault/docs/secrets/databases/redis)                                 | Yes                      | Yes           | Yes          | No                     | password                  |
-| [Redis ElastiCache](/vault/docs/secrets/databases/rediselasticache)          | No                       | No            | Yes          | No                     | password                  |
-| [Redshift](/vault/docs/secrets/databases/redshift)                           | Yes                      | Yes           | Yes          | Yes (1.8+)             | password                  |
-| [Snowflake](/vault/docs/secrets/databases/snowflake)                         | Yes                      | Yes           | Yes          | Yes (1.8+)             | password, rsa_private_key |
+| [Cassandra](/vault/docs/secrets/databases/cassandra)                         | Yes                      | Yes           | Yes (1.6+)   | Yes (1.7+)             | password                     |
+| [Couchbase](/vault/docs/secrets/databases/couchbase)                         | Yes                      | Yes           | Yes          | Yes (1.7+)             | password                     |
+| [Elasticsearch](/vault/docs/secrets/databases/elasticdb)                     | Yes                      | Yes           | Yes (1.6+)   | Yes (1.8+)             | password                     |
+| [HanaDB](/vault/docs/secrets/databases/hanadb)                               | Yes (1.6+)               | Yes           | Yes (1.6+)   | Yes (1.12+)            | password                     |
+| [InfluxDB](/vault/docs/secrets/databases/influxdb)                           | Yes                      | Yes           | Yes (1.6+)   | Yes (1.8+)             | password                     |
+| [MongoDB](/vault/docs/secrets/databases/mongodb)                             | Yes                      | Yes           | Yes          | Yes (1.7+)             | password                     |
+| [MongoDB Atlas](/vault/docs/secrets/databases/mongodbatlas)                  | No                       | Yes           | Yes          | Yes (1.8+)             | password, client_certificate |
+| [MSSQL](/vault/docs/secrets/databases/mssql)                                 | Yes                      | Yes           | Yes          | Yes (1.7+)             | password                     |
+| [MySQL/MariaDB](/vault/docs/secrets/databases/mysql-maria)                   | Yes                      | Yes           | Yes          | Yes (1.7+)             | password                     |
+| [Oracle](/vault/docs/secrets/databases/oracle)                               | Yes                      | Yes           | Yes          | Yes (1.7+)             | password                     |
+| [PostgreSQL](/vault/docs/secrets/databases/postgresql)                       | Yes                      | Yes           | Yes          | Yes (1.7+)             | password                     |
+| [Redis](/vault/docs/secrets/databases/redis)                                 | Yes                      | Yes           | Yes          | No                     | password                     |
+| [Redis ElastiCache](/vault/docs/secrets/databases/rediselasticache)          | No                       | No            | Yes          | No                     | password                     |
+| [Redshift](/vault/docs/secrets/databases/redshift)                           | Yes                      | Yes           | Yes          | Yes (1.8+)             | password                     |
+| [Snowflake](/vault/docs/secrets/databases/snowflake)                         | Yes                      | Yes           | Yes          | Yes (1.8+)             | password, rsa_private_key    |
 
 ## Custom Plugins
 

--- a/website/content/docs/secrets/databases/mongodbatlas.mdx
+++ b/website/content/docs/secrets/databases/mongodbatlas.mdx
@@ -19,15 +19,15 @@ more information about setting up the database secrets engine.
 
 ## Capabilities
 
-| Plugin Name                    | Root Credential Rotation | Dynamic Roles | Static Roles | Username Customization |
-| ------------------------------ | ------------------------ | ------------- | ------------ | ---------------------- |
-| `mongodbatlas-database-plugin` | No                       | Yes           | Yes          | Yes (1.8+)             |
+| Plugin Name                    | Root Credential Rotation | Dynamic Roles | Static Roles | Username Customization | Credential Types             |
+| ------------------------------ | ------------------------ | ------------- | ------------ | ---------------------- | ---------------------------- |
+| `mongodbatlas-database-plugin` | No                       | Yes           | Yes          | Yes (1.8+)             | password, client_certificate |
 
 ## Setup
 
 1.  Enable the database secrets engine if it is not already enabled:
 
-    ```text
+    ```shell-session
     $ vault secrets enable database
     Success! Enabled the database secrets engine at: database/
     ```
@@ -37,25 +37,13 @@ more information about setting up the database secrets engine.
 
 1.  Configure Vault with the proper plugin and connection information:
 
-    ```text
+    ```shell-session
     $ vault write database/config/my-mongodbatlas-database \
         plugin_name=mongodbatlas-database-plugin \
-        allowed_roles="my-role" \
+        allowed_roles="*" \
         public_key="jmskfortvf" \
         private_key="ea6acbc7-8a30-4a3f-812e-6f869c08bcd1" \
         project_id="4f96cad208574fd14aa8dda3a"
-    ```
-
-1.  Configure a role that maps a name in Vault to a MongoDB Atlas command that executes and
-    creates the database user credential:
-
-    ```text
-    $ vault write database/roles/my-role \
-        db_name=my-mongodbatlas-database \
-        creation_statements='{"database_name": "admin","roles": [{"databaseName":"admin","roleName":"atlasAdmin"}]}' \
-        default_ttl="1h" \
-        max_ttl="24h"
-    Success! Data written to: database/roles/my-role
     ```
 
 ## Usage
@@ -63,17 +51,84 @@ more information about setting up the database secrets engine.
 After the secrets engine is configured and a user/machine has a Vault token with
 the proper permissions, it can generate credentials.
 
+#### Password Credentials
+
+1.  Configure a role that maps a name in Vault to a MongoDB Atlas command that executes and
+    creates the database user credential:
+
+    ```shell-session
+    $ vault write database/roles/my-password-role \
+        db_name=my-mongodbatlas-database \
+        creation_statements='{"database_name": "admin","roles": [{"databaseName":"admin","roleName":"atlasAdmin"}]}' \
+        default_ttl="1h" \
+        max_ttl="24h"
+    Success! Data written to: database/roles/my-password-role
+    ```
+
 1.  Generate a new credential by reading from the `/creds` endpoint with the name
     of the role:
 
-        $ vault read database/creds/my-role
+    ```shell-session
+    $ vault read database/creds/my-password-role
         Key                Value
         ---                -----
         lease_id           database/creds/my-role/2f6a614c-4aa2-7b19-24b9-ad944a8d4de6
         lease_duration     1h
         lease_renewable    true
         password           FBYwnnh-fwc0quxtKf11
-        username           v-my-role-DKbQEg6uRn
+        username           v-my-password-role-DKbQEg6uRn
+    ```
+
+#### Client Certificate Credentials
+
+1.  Configure a role that maps a name in Vault to a MongoDB Atlas command that executes and
+    creates the X509 type database user credential:
+
+    ```shell-session
+    $ vault write database/roles/my-dynamic-certificate-role \
+      db_name=my-mongodbatlas-database \
+      creation_statements='{"database_name": "$external", "x509Type": "CUSTOMER", "roles": [{"databaseName":"$external","roleName":"readWrite"}]}' \
+      default_ttl="1h" \
+      max_ttl="24h" \
+      credential_type="client_certificate" \
+      credential_config=ca_cert="$(cat path/to/ca_cert.pem)" \
+      credential_config=ca_private_key="$(cat path/to/private_key.pem)" \
+      credential_config=key_type="rsa" \
+      credential_config=key_bits=2048 \
+      credential_config=signature_bits=256 \
+      credential_config=common_name_template="{{.DisplayName}}_{{.RoleName}}_{{unix_time}}"
+    Success! Data written to: database/roles/my-dynamic-certificate-role
+    ```
+
+1.  Generate a new credential by reading from the `/creds` endpoint with the name
+of the role:
+
+    ```shell-session
+    $ vault read database/creds/my-dynamic-certificate-role
+      Key                 Value
+      ---                 -----
+      request_id          b6556b2d-c379-5a92-465d-6597c506c821
+      lease_id            database/creds/my-dynamic-certificate-role/AZ5tao6NjLJctx7fm1bujKEL
+      lease_duration      1h
+      lease_renewable     true
+      client_certificate  -----BEGIN CERTIFICATE-----
+                          ...
+                          -----END CERTIFICATE-----
+      private_key         -----BEGIN PRIVATE KEY-----
+                          ...
+                          -----END PRIVATE KEY-----
+      private_key_type    rsa
+      username            CN=token_my-dynamic-certificate-role_1677262121
+    ```
+
+## Client Certificate Authentication
+
+MongoDB Atlas supports [X.509 client certificate based authentication](https://www.mongodb.com/docs/manual/tutorial/configure-x509-client-authentication/)
+for enhanced authentication security as an alternative to username and password authentication.
+The MongoDB Atlas database plugin can be used to manage client certificate credentials for
+MongoDB Atlas users by using `client_certificate` [credential_type](/api-docs/secret/databases#credential_type).
+
+See the [usage](/docs/secrets/databases/mongodbatlas#usage) section for examples using dynamic roles.
 
 ## API
 

--- a/website/content/docs/secrets/databases/mongodbatlas.mdx
+++ b/website/content/docs/secrets/databases/mongodbatlas.mdx
@@ -126,9 +126,9 @@ of the role:
 MongoDB Atlas supports [X.509 client certificate based authentication](https://www.mongodb.com/docs/manual/tutorial/configure-x509-client-authentication/)
 for enhanced authentication security as an alternative to username and password authentication.
 The MongoDB Atlas database plugin can be used to manage client certificate credentials for
-MongoDB Atlas users by using `client_certificate` [credential_type](/api-docs/secret/databases#credential_type).
+MongoDB Atlas users by using `client_certificate` [credential_type](/vault/api-docs/secret/databases#credential_type).
 
-See the [usage](/docs/secrets/databases/mongodbatlas#usage) section for examples using dynamic roles.
+See the [usage](/vault/docs/secrets/databases/mongodbatlas#usage) section for examples using dynamic roles.
 
 ## API
 

--- a/website/content/partials/db-secrets-credential-types.mdx
+++ b/website/content/partials/db-secrets-credential-types.mdx
@@ -20,15 +20,14 @@
       include: `pkcs8`.
 
   - `client_certificate`
+    - `common_name_template` `(string: "")` - A [username template](/vault/docs/concepts/username-templating)
+       to be used for the client certificate common name.
     - `ca_cert` `(string: "")` - The PEM-encoded CA certificate.
     - `ca_private_key` `(string: "")` - The PEM-encoded private key for the given `ca_cert`.
-    - `key_type` `(string: "rsa")` - Specifies the desired key type. Options include:
+    - `key_type` `(string: <required>")` - Specifies the desired key type. Options include:
       `rsa`, `ed25519`, `ec`.
     - `key_bits` `(int: 2048)` - Number of bits to use for the generated keys. Options include:
       `2048` (default), `3072`, `4096`; with `key_type=ec`, allowed values are: `224`, `256` (default),
       `384`, `521`; ignored with `key_type=ed25519`.
     - `signature_bits` `(int: 256)` - The number of bits to use in the signature algorithm. Options include:
-      `3072` (default), `256`, `384`, `512`.
-    - `common_name_template` `(string: "")` - A [username template](/vault/docs/concepts/username-templating)
-      to be used for the client certificate common name.
-
+      `256` (default), `384`, `512`.

--- a/website/content/partials/db-secrets-credential-types.mdx
+++ b/website/content/partials/db-secrets-credential-types.mdx
@@ -1,5 +1,5 @@
 - `credential_type` `(string: "password")` – Specifies the type of credential that
-  will be generated for the role. Options include: `password`, `rsa_private_key`.
+  will be generated for the role. Options include: `password`, `rsa_private_key`, `client_certificate`.
   See the plugin's API page for credential types supported by individual databases.
 
 - `credential_config` `(map<string|string>: <optional>)` – Specifies the configuration
@@ -18,3 +18,17 @@
     - `format` `(string: "pkcs8")` - The output format of the generated private key
       credential. The private key will be returned from the API in PEM encoding. Options
       include: `pkcs8`.
+
+  - `client_certificate`
+    - `ca_cert` `(string: "")` - The PEM-encoded CA certificate.
+    - `ca_private_key` `(string: "")` - The PEM-encoded private key for the given `ca_cert`.
+    - `key_type` `(string: "rsa")` - Specifies the desired key type. Options include:
+      `rsa`, `ed25519`, `ec`.
+    - `key_bits` `(int: 2048)` - Number of bits to use for the generated keys. Options include:
+      `2048` (default), `3072`, `4096`; with `key_type=ec`, allowed values are: `224`, `256` (default),
+      `384`, `521`; ignored with `key_type=ed25519`.
+    - `signature_bits` `(int: 256)` - The number of bits to use in the signature algorithm. Options include:
+      `3072` (default), `256`, `384`, `512`.
+    - `common_name_template` `(string: "")` - A [username template](https://developer.hashicorp.com/vault/docs/concepts/username-templating)
+      to be used for the client certificate common name.
+

--- a/website/content/partials/db-secrets-credential-types.mdx
+++ b/website/content/partials/db-secrets-credential-types.mdx
@@ -29,6 +29,6 @@
       `384`, `521`; ignored with `key_type=ed25519`.
     - `signature_bits` `(int: 256)` - The number of bits to use in the signature algorithm. Options include:
       `3072` (default), `256`, `384`, `512`.
-    - `common_name_template` `(string: "")` - A [username template](https://developer.hashicorp.com/vault/docs/concepts/username-templating)
+    - `common_name_template` `(string: "")` - A [username template](/vault/docs/concepts/username-templating)
       to be used for the client certificate common name.
 


### PR DESCRIPTION
This PR adds documentation for the new credential type `client_certificate` for MongoDB Atlas Secrets Engine