### PR TITLE
Move activityType to a constant, set precedence

### DIFF
--- a/builtin/logical/pki/acme_billing_test.go
+++ b/builtin/logical/pki/acme_billing_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/vault/builtin/logical/pki/dnstest"
 	"github.com/hashicorp/vault/helper/constants"
 	"github.com/hashicorp/vault/helper/timeutil"
+	"github.com/hashicorp/vault/vault"
 	"github.com/hashicorp/vault/vault/activity"
 
 	"github.com/stretchr/testify/require"
@@ -119,8 +120,8 @@ func validateAcmeClientTypes(t *testing.T, fragment *activity.LogFragment, expec
 	}
 
 	for _, ac := range fragment.Clients {
-		if ac.ClientType != "acme" {
-			t.Fatalf("Couldn't find expected 'acme' client_type in %v", fragment.Clients)
+		if ac.ClientType != vault.ACMEActivityType {
+			t.Fatalf("Couldn't find expected '%v' client_type in %v", vault.ACMEActivityType, fragment.Clients)
 		}
 	}
 }

--- a/vault/acme_billing_system_view.go
+++ b/vault/acme_billing_system_view.go
@@ -20,6 +20,15 @@ import (
 // See comment in command/format.go
 const hopeDelim = "♨"
 
+// Modifying this constant will result in previous activities not being
+// associated with future activities of this same type. A storage
+// migration would need to occur to fix this.
+//
+// Suggested naming precedence: <plugin name>-<client type>. Since this
+// comes from the builtin PKI plugin, and we're counting ACME certificates,
+// this becomes pki-acme.
+const ACMEActivityType = "pki-acme"
+
 // acmeBillingImpl is the (single) implementation of the actual client
 // counting interface. It needs a reference to core (as per discussions
 // with Mike, in the future the activityLog reference will no longer be
@@ -121,7 +130,6 @@ func (a *acmeBillingImpl) CreateActivityCountEventForIdentifiers(ctx context.Con
 	clientID := base64.RawURLEncoding.EncodeToString(identifiersHash[:])
 
 	// Log so users can correlate ACME requests to client count tokens.
-	activityType := "acme"
 	a.core.activityLogLock.RLock()
 	activityLog := a.core.activityLog
 	a.core.activityLogLock.RUnlock()
@@ -129,7 +137,7 @@ func (a *acmeBillingImpl) CreateActivityCountEventForIdentifiers(ctx context.Con
 		return nil
 	}
 	activityLog.logger.Debug(fmt.Sprintf("Handling ACME client count event for [%v] -> %v", identifiers, clientID))
-	activityLog.AddActivityToFragment(clientID, a.entry.NamespaceID, time.Now().Unix(), activityType, a.entry.Accessor)
+	activityLog.AddActivityToFragment(clientID, a.entry.NamespaceID, time.Now().Unix(), ACMEActivityType, a.entry.Accessor)
 
 	return nil
 }


### PR DESCRIPTION
See suggested naming convention in the code. This moves this `acme` activity count type to `pki-acme`, defining a constant for it and noting that changing it would result in problems.

In particular, naming things both by the client type (`acme` certificates) and the plugin name `pki` could help disambiguate things in the future, if this gets opened to other use cases.