### PR TITLE
Address various issues related to ACME EAB

### DIFF
--- a/builtin/logical/pki/acme_jws.go
+++ b/builtin/logical/pki/acme_jws.go
@@ -259,7 +259,7 @@ func verifyEabPayload(acmeState *acmeState, ac *acmeContext, outer *jwsCtx, expe
 		return nil, fmt.Errorf("%w: failed to verify eab", ErrUnauthorized)
 	}
 
-	verifiedPayload, err := sig.Verify(eabEntry.MacKey)
+	verifiedPayload, err := sig.Verify(eabEntry.PrivateBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -600,7 +600,7 @@ func (a *acmeState) LoadEab(sc *storageContext, eabKid string) (*eabType, error)
 		return nil, err
 	}
 	if rawEntry == nil {
-		return nil, fmt.Errorf("no eab found for kid %s", eabKid)
+		return nil, fmt.Errorf("%w: no eab found for kid %s", ErrStorageItemNotFound, eabKid)
 	}
 
 	var eab eabType

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -218,7 +218,8 @@ func Backend(conf *logical.BackendConfig) *backend {
 
 			// ACME
 			pathAcmeConfig(&b),
-			pathAcmeEabCreateList(&b),
+			pathAcmeEabCreate(&b),
+			pathAcmeEabList(&b),
 			pathAcmeEabDelete(&b),
 		},
 

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -6862,6 +6862,7 @@ func TestProperAuthing(t *testing.T) {
 		"unified-crl/delta/pem":                  shouldBeUnauthedReadList,
 		"unified-ocsp":                           shouldBeUnauthedWriteOnly,
 		"unified-ocsp/dGVzdAo=":                  shouldBeUnauthedReadList,
+		"acme/new-eab":                           shouldBeAuthed,
 		"acme/eab":                               shouldBeAuthed,
 		"acme/eab/" + eabKid:                     shouldBeAuthed,
 	}

--- a/builtin/logical/pki/path_acme_eab.go
+++ b/builtin/logical/pki/path_acme_eab.go
@@ -47,7 +47,7 @@ func pathAcmeEabList(b *backend) *framework.Path {
 
 func pathAcmeEabCreate(b *backend) *framework.Path {
 	return &framework.Path{
-		Pattern: "acme/eab",
+		Pattern: "acme/new-eab",
 
 		DisplayAttrs: &framework.DisplayAttributes{
 			OperationPrefix: operationPrefixPKI,

--- a/builtin/logical/pki/path_acme_eab.go
+++ b/builtin/logical/pki/path_acme_eab.go
@@ -5,12 +5,9 @@ package pki
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/x509"
+	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/go-uuid"
@@ -23,9 +20,9 @@ import (
  * ACME External Account Bindings, this isn't providing any APIs that an ACME
  * client would use.
  */
-func pathAcmeEabCreateList(b *backend) *framework.Path {
+func pathAcmeEabList(b *backend) *framework.Path {
 	return &framework.Path{
-		Pattern: "acme/eab",
+		Pattern: "acme/eab/?$",
 
 		DisplayAttrs: &framework.DisplayAttributes{
 			OperationPrefix: operationPrefixPKI,
@@ -36,16 +33,35 @@ func pathAcmeEabCreateList(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ListOperation: &framework.PathOperation{
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "acme-configuration",
+					OperationVerb:   "list-eab-key",
+					OperationSuffix: "acme",
 				},
 				Callback: b.pathAcmeListEab,
 			},
+		},
+
+		HelpSynopsis:    "list external account bindings to be used for ACME",
+		HelpDescription: `list identifiers that have been generated but yet to be used.`,
+	}
+}
+
+func pathAcmeEabCreate(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "acme/eab",
+
+		DisplayAttrs: &framework.DisplayAttributes{
+			OperationPrefix: operationPrefixPKI,
+		},
+
+		Fields: map[string]*framework.FieldSchema{},
+
+		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback:                    b.pathAcmeCreateEab,
 				ForwardPerformanceSecondary: false,
 				ForwardPerformanceStandby:   true,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationVerb:   "configure",
+					OperationVerb:   "generate-eab-key",
 					OperationSuffix: "acme",
 				},
 			},
@@ -93,11 +109,11 @@ a warning that it did not exist.`,
 }
 
 type eabType struct {
-	KeyID     string    `json:"-"`
-	KeyType   string    `json:"key-type"`
-	KeyBits   string    `json:"key-bits"`
-	MacKey    []byte    `json:"mac-key"`
-	CreatedOn time.Time `json:"created-on"`
+	KeyID        string    `json:"-"`
+	KeyType      string    `json:"key-type"`
+	KeySize      int       `json:"key-size"`
+	PrivateBytes []byte    `json:"private-bytes"`
+	CreatedOn    time.Time `json:"created-on"`
 }
 
 func (b *backend) pathAcmeListEab(ctx context.Context, r *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
@@ -122,7 +138,7 @@ func (b *backend) pathAcmeListEab(ctx context.Context, r *logical.Request, _ *fr
 		keyIds = append(keyIds, eab.KeyID)
 		keyInfos[eab.KeyID] = map[string]interface{}{
 			"key_type":   eab.KeyType,
-			"key_bits":   eab.KeyBits,
+			"key_size":   eab.KeySize,
 			"created_on": eab.CreatedOn.Format(time.RFC3339),
 		}
 	}
@@ -136,17 +152,18 @@ func (b *backend) pathAcmeListEab(ctx context.Context, r *logical.Request, _ *fr
 
 func (b *backend) pathAcmeCreateEab(ctx context.Context, r *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
 	kid := genUuid()
-	macKey, err := generateEabKey(b.GetRandomReader())
+	size := 32
+	bytes, err := uuid.GenerateRandomBytesWithReader(size, rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed generating eab key: %w", err)
 	}
 
 	eab := &eabType{
-		KeyID:     kid,
-		KeyType:   "ec",
-		KeyBits:   "256",
-		MacKey:    macKey,
-		CreatedOn: time.Now(),
+		KeyID:        kid,
+		KeyType:      "HS",
+		KeySize:      size,
+		PrivateBytes: bytes,
+		CreatedOn:    time.Now(),
 	}
 
 	sc := b.makeStorageContext(ctx, r.Storage)
@@ -155,15 +172,15 @@ func (b *backend) pathAcmeCreateEab(ctx context.Context, r *logical.Request, _ *
 		return nil, fmt.Errorf("failed saving generated eab: %w", err)
 	}
 
-	encodedKey := base64.RawURLEncoding.EncodeToString(macKey)
+	encodedKey := base64.RawURLEncoding.EncodeToString(eab.PrivateBytes)
 
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"id":          eab.KeyID,
-			"key_type":    eab.KeyType,
-			"key_bits":    eab.KeyBits,
-			"private_key": encodedKey,
-			"created_on":  eab.CreatedOn.Format(time.RFC3339),
+			"id":         eab.KeyID,
+			"key_type":   eab.KeyType,
+			"key_size":   eab.KeySize,
+			"key":        encodedKey,
+			"created_on": eab.CreatedOn.Format(time.RFC3339),
 		},
 	}, nil
 }
@@ -187,18 +204,4 @@ func (b *backend) pathAcmeDeleteEab(ctx context.Context, r *logical.Request, d *
 		resp.AddWarning("No key id found with id: " + keyId)
 	}
 	return resp, nil
-}
-
-func generateEabKey(random io.Reader) ([]byte, error) {
-	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), random)
-	if err != nil {
-		return nil, err
-	}
-
-	keyBytes, err := x509.MarshalECPrivateKey(ecKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return keyBytes, nil
 }

--- a/builtin/logical/pki/path_acme_eab.go
+++ b/builtin/logical/pki/path_acme_eab.go
@@ -111,7 +111,7 @@ a warning that it did not exist.`,
 type eabType struct {
 	KeyID        string    `json:"-"`
 	KeyType      string    `json:"key-type"`
-	KeySize      int       `json:"key-size"`
+	KeyBits      int       `json:"key-bits"`
 	PrivateBytes []byte    `json:"private-bytes"`
 	CreatedOn    time.Time `json:"created-on"`
 }
@@ -138,7 +138,7 @@ func (b *backend) pathAcmeListEab(ctx context.Context, r *logical.Request, _ *fr
 		keyIds = append(keyIds, eab.KeyID)
 		keyInfos[eab.KeyID] = map[string]interface{}{
 			"key_type":   eab.KeyType,
-			"key_size":   eab.KeySize,
+			"key_bits":   eab.KeyBits,
 			"created_on": eab.CreatedOn.Format(time.RFC3339),
 		}
 	}
@@ -160,8 +160,8 @@ func (b *backend) pathAcmeCreateEab(ctx context.Context, r *logical.Request, _ *
 
 	eab := &eabType{
 		KeyID:        kid,
-		KeyType:      "HS",
-		KeySize:      size,
+		KeyType:      "hs",
+		KeyBits:      size * 8,
 		PrivateBytes: bytes,
 		CreatedOn:    time.Now(),
 	}
@@ -178,7 +178,7 @@ func (b *backend) pathAcmeCreateEab(ctx context.Context, r *logical.Request, _ *
 		Data: map[string]interface{}{
 			"id":         eab.KeyID,
 			"key_type":   eab.KeyType,
-			"key_size":   eab.KeySize,
+			"key_bits":   eab.KeyBits,
 			"key":        encodedKey,
 			"created_on": eab.CreatedOn.Format(time.RFC3339),
 		},

--- a/builtin/logical/pki/path_acme_eab_test.go
+++ b/builtin/logical/pki/path_acme_eab_test.go
@@ -22,9 +22,9 @@ func TestACME_EabVaultAPIs(t *testing.T) {
 	// Generate an EAB
 	resp, err := CBWrite(b, s, "acme/new-eab", map[string]interface{}{})
 	requireSuccessNonNilResponse(t, resp, err, "Failed generating eab")
-	requireFieldsSetInResp(t, resp, "id", "key_type", "key_size", "key", "created_on")
-	require.Equal(t, "HS", resp.Data["key_type"])
-	require.Equal(t, 32, resp.Data["key_size"])
+	requireFieldsSetInResp(t, resp, "id", "key_type", "key_bits", "key", "created_on")
+	require.Equal(t, "hs", resp.Data["key_type"])
+	require.Equal(t, 256, resp.Data["key_bits"])
 	ids = append(ids, resp.Data["id"].(string))
 	_, err = uuid.ParseUUID(resp.Data["id"].(string))
 	require.NoError(t, err, "failed parsing id as a uuid")
@@ -45,16 +45,16 @@ func TestACME_EabVaultAPIs(t *testing.T) {
 	require.ElementsMatch(t, ids, resp.Data["keys"])
 	keyInfo := resp.Data["key_info"].(map[string]interface{})
 	id0Map := keyInfo[ids[0]].(map[string]interface{})
-	require.Equal(t, "HS", id0Map["key_type"])
-	require.Equal(t, 32, id0Map["key_size"])
+	require.Equal(t, "hs", id0Map["key_type"])
+	require.Equal(t, 256, id0Map["key_bits"])
 	require.NotEmpty(t, id0Map["created_on"])
 	_, err = time.Parse(time.RFC3339, id0Map["created_on"].(string))
 	require.NoError(t, err, "failed to parse created_on date: %s", id0Map["created_on"])
 
 	id1Map := keyInfo[ids[1]].(map[string]interface{})
 
-	require.Equal(t, "HS", id1Map["key_type"])
-	require.Equal(t, 32, id1Map["key_size"])
+	require.Equal(t, "hs", id1Map["key_type"])
+	require.Equal(t, 256, id1Map["key_bits"])
 	require.NotEmpty(t, id1Map["created_on"])
 
 	// Delete an EAB

--- a/builtin/logical/pki/path_acme_eab_test.go
+++ b/builtin/logical/pki/path_acme_eab_test.go
@@ -4,7 +4,6 @@
 package pki
 
 import (
-	"crypto/x509"
 	"encoding/base64"
 	"testing"
 	"time"
@@ -23,16 +22,15 @@ func TestACME_EabVaultAPIs(t *testing.T) {
 	// Generate an EAB
 	resp, err := CBWrite(b, s, "acme/eab", map[string]interface{}{})
 	requireSuccessNonNilResponse(t, resp, err, "Failed generating eab")
-	requireFieldsSetInResp(t, resp, "id", "key_type", "key_bits", "private_key", "created_on")
-	require.Equal(t, "ec", resp.Data["key_type"])
-	require.Equal(t, "256", resp.Data["key_bits"])
+	requireFieldsSetInResp(t, resp, "id", "key_type", "key_size", "key", "created_on")
+	require.Equal(t, "HS", resp.Data["key_type"])
+	require.Equal(t, 32, resp.Data["key_size"])
 	ids = append(ids, resp.Data["id"].(string))
 	_, err = uuid.ParseUUID(resp.Data["id"].(string))
 	require.NoError(t, err, "failed parsing id as a uuid")
 
-	key, err := base64.RawURLEncoding.DecodeString(resp.Data["private_key"].(string))
+	_, err = base64.RawURLEncoding.DecodeString(resp.Data["key"].(string))
 	require.NoError(t, err, "failed base64 decoding private key")
-	_, err = x509.ParseECPrivateKey(key)
 	require.NoError(t, err, "failed parsing private key")
 
 	// Generate another EAB
@@ -41,22 +39,22 @@ func TestACME_EabVaultAPIs(t *testing.T) {
 	ids = append(ids, resp.Data["id"].(string))
 
 	// List our EABs
-	resp, err = CBList(b, s, "acme/eab")
+	resp, err = CBList(b, s, "acme/eab/")
 	requireSuccessNonNilResponse(t, resp, err, "failed list")
 
 	require.ElementsMatch(t, ids, resp.Data["keys"])
 	keyInfo := resp.Data["key_info"].(map[string]interface{})
 	id0Map := keyInfo[ids[0]].(map[string]interface{})
-	require.Equal(t, "ec", id0Map["key_type"])
-	require.Equal(t, "256", id0Map["key_bits"])
+	require.Equal(t, "HS", id0Map["key_type"])
+	require.Equal(t, 32, id0Map["key_size"])
 	require.NotEmpty(t, id0Map["created_on"])
 	_, err = time.Parse(time.RFC3339, id0Map["created_on"].(string))
 	require.NoError(t, err, "failed to parse created_on date: %s", id0Map["created_on"])
 
 	id1Map := keyInfo[ids[1]].(map[string]interface{})
 
-	require.Equal(t, "ec", id1Map["key_type"])
-	require.Equal(t, "256", id1Map["key_bits"])
+	require.Equal(t, "HS", id1Map["key_type"])
+	require.Equal(t, 32, id1Map["key_size"])
 	require.NotEmpty(t, id1Map["created_on"])
 
 	// Delete an EAB
@@ -65,7 +63,7 @@ func TestACME_EabVaultAPIs(t *testing.T) {
 	require.Len(t, resp.Warnings, 0, "no warnings should have been set on delete")
 
 	// Make sure it's really gone
-	resp, err = CBList(b, s, "acme/eab")
+	resp, err = CBList(b, s, "acme/eab/")
 	requireSuccessNonNilResponse(t, resp, err, "failed list post delete")
 	require.Len(t, resp.Data["keys"], 1)
 	require.Contains(t, resp.Data["keys"], ids[1])

--- a/builtin/logical/pki/path_acme_eab_test.go
+++ b/builtin/logical/pki/path_acme_eab_test.go
@@ -20,7 +20,7 @@ func TestACME_EabVaultAPIs(t *testing.T) {
 	var ids []string
 
 	// Generate an EAB
-	resp, err := CBWrite(b, s, "acme/eab", map[string]interface{}{})
+	resp, err := CBWrite(b, s, "acme/new-eab", map[string]interface{}{})
 	requireSuccessNonNilResponse(t, resp, err, "Failed generating eab")
 	requireFieldsSetInResp(t, resp, "id", "key_type", "key_size", "key", "created_on")
 	require.Equal(t, "HS", resp.Data["key_type"])
@@ -34,7 +34,7 @@ func TestACME_EabVaultAPIs(t *testing.T) {
 	require.NoError(t, err, "failed parsing private key")
 
 	// Generate another EAB
-	resp, err = CBWrite(b, s, "acme/eab", map[string]interface{}{})
+	resp, err = CBWrite(b, s, "acme/new-eab", map[string]interface{}{})
 	requireSuccessNonNilResponse(t, resp, err, "Failed generating eab")
 	ids = append(ids, resp.Data["id"].(string))
 

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -780,7 +780,7 @@ func getAcmeClientForCluster(t *testing.T, cluster *vault.TestCluster, baseUrl s
 }
 
 func getEABKey(t *testing.T, client *api.Client) (string, []byte) {
-	resp, err := client.Logical().WriteWithContext(ctx, "pki/acme/eab", map[string]interface{}{})
+	resp, err := client.Logical().WriteWithContext(ctx, "pki/acme/new-eab", map[string]interface{}{})
 	require.NoError(t, err, "failed getting eab key")
 	require.NotNil(t, resp, "eab key returned nil response")
 	require.NotEmpty(t, resp.Data["id"], "eab key response missing id field")

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -360,9 +360,9 @@ func TestAcmeBasicWorkflowWithEab(t *testing.T) {
 	require.Contains(t, keyInfo, kid)
 
 	infoForKid := keyInfo[kid].(map[string]interface{})
-	keySize := infoForKid["key_size"].(json.Number)
-	require.Equal(t, "32", keySize.String())
-	require.Equal(t, "HS", infoForKid["key_type"])
+	keyBits := infoForKid["key_bits"].(json.Number)
+	require.Equal(t, "256", keyBits.String())
+	require.Equal(t, "hs", infoForKid["key_type"])
 
 	// Create new account with EAB
 	t.Logf("Testing register on %s", baseAcmeURL)

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -13,6 +13,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-jose/go-jose/v3/json"
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/acme"
@@ -347,13 +347,30 @@ func TestAcmeBasicWorkflowWithEab(t *testing.T) {
 		},
 	}
 
+	// Make sure we can list our key
+	resp, err := client.Logical().ListWithContext(context.Background(), "pki/acme/eab")
+	require.NoError(t, err, "failed to list eab tokens")
+	require.NotNil(t, resp, "list response for eab tokens should not be nil")
+	require.Contains(t, resp.Data, "keys")
+	require.Contains(t, resp.Data, "key_info")
+	require.Len(t, resp.Data["keys"], 1)
+	require.Contains(t, resp.Data["keys"], kid)
+
+	keyInfo := resp.Data["key_info"].(map[string]interface{})
+	require.Contains(t, keyInfo, kid)
+
+	infoForKid := keyInfo[kid].(map[string]interface{})
+	keySize := infoForKid["key_size"].(json.Number)
+	require.Equal(t, "32", keySize.String())
+	require.Equal(t, "HS", infoForKid["key_type"])
+
 	// Create new account with EAB
 	t.Logf("Testing register on %s", baseAcmeURL)
 	_, err = acmeClient.Register(testCtx, acct, func(tosURL string) bool { return true })
 	require.NoError(t, err, "failed registering new account with eab")
 
 	// Make sure our EAB is no longer available
-	resp, err := client.Logical().ListWithContext(context.Background(), "pki/acme/eab")
+	resp, err = client.Logical().ListWithContext(context.Background(), "pki/acme/eab")
 	require.NoError(t, err, "failed to list eab tokens")
 	require.Nil(t, resp, "list response for eab tokens should have been nil due to empty list")
 
@@ -769,8 +786,8 @@ func getEABKey(t *testing.T, client *api.Client) (string, []byte) {
 	require.NotEmpty(t, resp.Data["id"], "eab key response missing id field")
 	kid := resp.Data["id"].(string)
 
-	require.NotEmpty(t, resp.Data["private_key"], "eab key response missing private_key field")
-	base64Key := resp.Data["private_key"].(string)
+	require.NotEmpty(t, resp.Data["key"], "eab key response missing private_key field")
+	base64Key := resp.Data["key"].(string)
 	privateKeyBytes, err := base64.RawURLEncoding.DecodeString(base64Key)
 	require.NoError(t, err, "failed base 64 decoding eab key response")
 

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -19,6 +20,8 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
+
+var ErrStorageItemNotFound = errors.New("storage item not found")
 
 const (
 	storageKeyConfig        = "config/keys"


### PR DESCRIPTION
This still needs a few tests around tidy operations for EAB but the rest should be good to go. Resolve a bunch of things that @cipherboy found when playing with ACME EAB apis.

- The LIST api doesn’t actually work, it isn’t setup correctly
- The EAB key value shouldn’t be an EC key, just random 32 byte data instead
- OpenAPI definitions for the EAB Vault APIs aren’t correct.
- We should clean up the unused EAB values through tidy 