### PR TITLE
Address Test-ui suite failure for package install issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,8 @@ jobs:
         node-version-file: './ui/package.json'
         cache: yarn
         cache-dependency-path: ui/yarn.lock
-    - id: install-browser-libraries
-      run: sudo apt update && sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
+    # - id: install-browser-libraries
+    #   run: sudo apt update && sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
     - id: install-browser
       uses: browser-actions/setup-chrome@c485fa3bab6be59dce18dbc18ef6ab7cbc8ff5f1 # v1.2.0
     - id: ui-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,6 @@ jobs:
         node-version-file: './ui/package.json'
         cache: yarn
         cache-dependency-path: ui/yarn.lock
-    # - id: install-browser-libraries
-    #   run: sudo apt update && sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
     - id: install-browser
       uses: browser-actions/setup-chrome@c485fa3bab6be59dce18dbc18ef6ab7cbc8ff5f1 # v1.2.0
     - id: ui-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
         cache: yarn
         cache-dependency-path: ui/yarn.lock
     - id: install-browser-libraries
-      run: sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
+      run: sudo apt update && install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
     - id: install-browser
       uses: browser-actions/setup-chrome@c485fa3bab6be59dce18dbc18ef6ab7cbc8ff5f1 # v1.2.0
     - id: ui-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
         cache: yarn
         cache-dependency-path: ui/yarn.lock
     - id: install-browser-libraries
-      run: sudo apt update && install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
+      run: sudo apt update && sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
     - id: install-browser
       uses: browser-actions/setup-chrome@c485fa3bab6be59dce18dbc18ef6ab7cbc8ff5f1 # v1.2.0
     - id: ui-dependencies


### PR DESCRIPTION
Another option: to remove the packages instead. Release team did a test run on their end and it worked without it. The id seems to indicate that these are for browser actions and the test will run without them. Running this option on the third commit to also test. Second commit is with the `apt update command`.

Note: may need to backport as recent changes in this file were also backported—[see here](https://github.com/hashicorp/vault/issues/20360).

See failure [here](https://github.com/hashicorp/vault/actions/runs/5072296967/jobs/9109884829?pr=20747).

Step for failure
```
run: sudo apt install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
```

Error:
```
E: Failed to fetch [http://azure.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libegl-mesa0_22.2.5-0ubuntu0.1%7e22.04.1_amd64.deb](http://azure.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libegl-mesa0_22.2.5-0ubuntu0.1~22.04.1_amd64.deb)  404  Not Found [IP: 52.147.219.192 80]
E: Failed to fetch [http://azure.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libegl1-mesa-dev_22.2.5-0ubuntu0.1%7e22.04.1_amd64.deb](http://azure.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libegl1-mesa-dev_22.2.5-0ubuntu0.1~22.04.1_amd64.deb)  404  Not Found [IP: 52.147.219.192 80]
```

Noticed the enos test had already done something to fix this issue—[see here](https://github.com/hashicorp/vault/blob/main/.github/workflows/test-enos-scenario-ui.yml#L103).