### PR TITLE
Validate no_store=false on role configuration

### DIFF
--- a/builtin/logical/pki/path_config_acme.go
+++ b/builtin/logical/pki/path_config_acme.go
@@ -235,6 +235,10 @@ func (b *backend) pathAcmeWrite(ctx context.Context, req *logical.Request, d *fr
 				return nil, fmt.Errorf("role %v specified in allowed_roles does not exist", name)
 			}
 
+			if role.NoStore {
+				return nil, fmt.Errorf("role %v specifies no_store=true; this prohibits usage with ACME which requires stored certificates", name)
+			}
+
 			if name == config.DefaultRole {
 				foundDefault = true
 			}


### PR DESCRIPTION
These roles cannot be used with ACME; while they can change later, we do still want to validate it at configuration write time.