### PR TITLE
Leader godoc comment

### DIFF
--- a/vault/ha.go
+++ b/vault/ha.go
@@ -135,7 +135,10 @@ func (c *Core) getHAMembers() ([]HAStatusNode, error) {
 	return nodes, nil
 }
 
-// Leader is used to get the current active leader
+// Leader is used to get information about the current active leader in relation to the current node (core).
+// It utilizes a state lock on the Core by attempting to acquire a read lock. Care should be taken not to
+// call this method if a read lock on this Core's state lock is currently held, as this can cause deadlock.
+// e.g. if called from within request handling.
 func (c *Core) Leader() (isLeader bool, leaderAddr, clusterAddr string, err error) {
 	// Check if HA enabled. We don't need the lock for this check as it's set
 	// on startup and never modified


### PR DESCRIPTION
The `Core.Leader` method can be used to retrieve information on whether the current node is the leader, and obtain leader and cluster addresses. However, the implementation of this method uses a struct field level lock on `Core` which means if we call this method while the state lock is already held by another reader we could deadlock. 

https://pkg.go.dev/sync#RWMutex.RLock

> It should not be used for recursive read locking; a blocked Lock call excludes new readers from acquiring the lock

Therefore the godoc comment for Leader has been updated to give developers some warning up front.