### PR TITLE
openapi: Fix response schema for pki list roles

### DIFF
--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -37,9 +37,9 @@ func pathListRoles(b *backend) *framework.Path {
 						Description: "OK",
 						Fields: map[string]*framework.FieldSchema{
 							"keys": {
-								Type:        framework.TypeMap,
-								Description: `List of keys`,
-								Required:    false,
+								Type:        framework.TypeStringSlice,
+								Description: "List of roles",
+								Required:    true,
 							},
 						},
 					}},
@@ -53,7 +53,7 @@ func pathListRoles(b *backend) *framework.Path {
 }
 
 func pathRoles(b *backend) *framework.Path {
-	pathRolesResponse := map[string]*framework.FieldSchema{
+	pathRolesResponseFields := map[string]*framework.FieldSchema{
 		"ttl": {
 			Type:     framework.TypeDurationSecond,
 			Required: true,
@@ -826,7 +826,7 @@ serviced by this role.`,
 				Responses: map[int][]framework.Response{
 					http.StatusOK: {{
 						Description: "OK",
-						Fields:      pathRolesResponse,
+						Fields:      pathRolesResponseFields,
 					}},
 				},
 			},
@@ -835,7 +835,7 @@ serviced by this role.`,
 				Responses: map[int][]framework.Response{
 					http.StatusOK: {{
 						Description: "OK",
-						Fields:      pathRolesResponse,
+						Fields:      pathRolesResponseFields,
 					}},
 				},
 				// Read more about why these flags are set in backend.go.
@@ -858,7 +858,7 @@ serviced by this role.`,
 				Responses: map[int][]framework.Response{
 					http.StatusOK: {{
 						Description: "OK",
-						Fields:      pathRolesResponse,
+						Fields:      pathRolesResponseFields,
 					}},
 				},
 				// Read more about why these flags are set in backend.go.

--- a/builtin/logical/pki/path_roles_test.go
+++ b/builtin/logical/pki/path_roles_test.go
@@ -12,10 +12,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
-
 	"github.com/go-errors/errors"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
+	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -146,14 +145,14 @@ func TestPki_RoleKeyUsage(t *testing.T) {
 	}
 
 	resp, err = b.HandleRequest(context.Background(), roleReq)
-	schema.ValidateResponse(t, schema.GetResponseSchema(t, b.Route("roles/testrole"), logical.UpdateOperation), resp, true)
+	schema.ValidateResponse(t, schema.GetResponseSchema(t, b.Route(roleReq.Path), logical.UpdateOperation), resp, true)
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("bad: err: %v resp: %#v", err, resp)
 	}
 
 	roleReq.Operation = logical.ReadOperation
 	resp, err = b.HandleRequest(context.Background(), roleReq)
-	schema.ValidateResponse(t, schema.GetResponseSchema(t, b.Route("roles/testrole"), logical.ReadOperation), resp, true)
+	schema.ValidateResponse(t, schema.GetResponseSchema(t, b.Route(roleReq.Path), logical.ReadOperation), resp, true)
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("bad: err: %v resp: %#v", err, resp)
 	}


### PR DESCRIPTION
This is a small fix to address an issue with the generated response brought up in https://github.com/hashicorp/vault-client-go/issues/175.