### PR TITLE
UI docs: Add ember engine creation documentation

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -155,6 +155,7 @@ Hello and thank you for contributing to the Vault UI! Below is a list of pattern
 - [components](docs/components.md)
 - [forms](docs/forms.md)
 - [css](docs/css.md)
+- [ember engines](docs/engines.md)
 
 ## Further Reading / Useful Links
 

--- a/ui/docs/ember-engines.md
+++ b/ui/docs/ember-engines.md
@@ -148,4 +148,11 @@ If you used `ember g in-repo-engine <engine-name>` to generate the engine’s bl
 - To add `package.json` **dependencies** or **devDependencies**, you can copy + paste the dependency into corresponding sections. Most of the time, we will want to use "\*" in place of the version number to ensure all the dependencies have the latest version.
 - In order to link to the other routes in the main app using the `LinkToExternal` component from your engine, you need to add the route to the `app/app.js` and your engine’s `addon/engine.js`. More information on [Linking to An External Context.](https://ember-engines.com/docs/link-to-external)
 
+### Common blueprint commands:
+
+- #### Generating In-repo engines routes: `ember generate route <route-name> --in-repo <in-repo-name>` - _generates tests and route files and templates_
+- #### Remove In-repo engines routes: `ember destroy route <route-name> --in-repo <in-repo-name>` - _removes tests and route files and templates_
+- #### Generating In-repo engines components: `ember generate component <component-name> --in-repo <in-repo-name>`- _generates tests and component files and templates_
+- #### Remove In-repo engines components: `ember destroy component <component-name> --in-repo <in-repo-name>`- _removes tests and component files and templates_
+
 [^1]: https://ember-engines.com/docs/quickstart#create-as-in-repo-engine

--- a/ui/docs/ember-engines.md
+++ b/ui/docs/ember-engines.md
@@ -150,9 +150,9 @@ If you used `ember g in-repo-engine <engine-name>` to generate the engine’s bl
 
 ### Common blueprint commands:
 
-- #### Generating In-repo engines routes: `ember generate route <route-name> --in-repo <in-repo-name>` - _generates tests and route files and templates_
-- #### Remove In-repo engines routes: `ember destroy route <route-name> --in-repo <in-repo-name>` - _removes tests and route files and templates_
-- #### Generating In-repo engines components: `ember generate component <component-name> --in-repo <in-repo-name>`- _generates tests and component files and templates_
-- #### Remove In-repo engines components: `ember destroy component <component-name> --in-repo <in-repo-name>`- _removes tests and component files and templates_
+- **Generating In-repo engines routes:** `ember generate route <route-name> --in-repo <in-repo-name>` - _generates tests and route files and templates_
+- **Remove In-repo engines routes:** `ember destroy route <route-name> --in-repo <in-repo-name>` - _removes tests and route files and templates_
+- **Generating In-repo engines components:** `ember generate component <component-name> --in-repo <in-repo-name>`- _generates tests and component files and templates_
+- **Remove In-repo engines components:** `ember destroy component <component-name> --in-repo <in-repo-name>`- _removes tests and component files and templates_
 
 [^1]: https://ember-engines.com/docs/quickstart#create-as-in-repo-engine

--- a/ui/docs/ember-engines.md
+++ b/ui/docs/ember-engines.md
@@ -104,7 +104,7 @@ export default class <EngineName>Engine extends Engine {
 loadInitializers(<EngineName>Engine, modulePrefix);
 ```
 
-The services in the example above are common services that we often use in our engines. Any other services that are in our main app that is needed for your engine should be added in the dependencies services array.
+The services in the example above are common services that we often use in our engines. If your engine requires other services from the main application, add them to the services array.
 
 Optional step: Add some text in the engine’s `application.hbs` file (to see if your engine was set up correctly).
 
@@ -146,7 +146,7 @@ If you used `ember g in-repo-engine <engine-name>` to generate the engine’s bl
 
 - Anytime a new engine is created, you will need to **RESTART** ember server!
 - To add `package.json` **dependencies** or **devDependencies**, you can copy + paste the dependency into corresponding sections. Most of the time, we will want to use "\*" in place of the version number to ensure all the dependencies have the latest version.
-- In order to link to the other routes in the main app using the `LinkToExternal` component from your engine, you need to add the route to the `app/app.js` and your engine’s `addon/engine.js`. More information on [Linking to An External Context.](https://ember-engines.com/docs/link-to-external)
+- In order to link to the other routes in the main app using the `LinkToExternal` component from your engine, you need to add the route to the `app/app.js` and your engine’s `addon/engine.js`. More information on [Linking to An External Context.](https://ember-engines.com/docs/link-to-external).
 
 ### Common blueprint commands:
 

--- a/ui/docs/ember-engines.md
+++ b/ui/docs/ember-engines.md
@@ -2,15 +2,11 @@
 
 ## Create a new in-repo engine:
 
----
-
 `ember g in-repo-engine <engine-name>`
 
 _This blueprint in-repo engine command will add a new folder `lib/<engine-name>` and add the engine to our main app’s `package.json`_
 
 ## Engine’s package.json:
-
----
 
 ```json
 {
@@ -34,8 +30,6 @@ For our application, we want to include the **ember-addon** path `../core`
 By adding this **ember-addon** path, we are able to share elements between your in-repo addon and the Vault application[^1].
 
 ## Configure your Engine
-
----
 
 In the engine’s `index.js` file:
 
@@ -115,8 +109,6 @@ The services in the example above are common services that we often use in our e
 Optional step: Add some text in the engine’s `application.hbs` file (to see if your engine was set up correctly).
 
 ## Register your engine with our main application:
-
----
 
 In our `app/app.js` in the engines object, add your engine’s name and dependencies.
 

--- a/ui/docs/ember-engines.md
+++ b/ui/docs/ember-engines.md
@@ -33,7 +33,7 @@ By adding this **ember-addon** path, we are able to share elements between your 
 
 In the engine’s `index.js` file:
 
-```jsx
+```js
 /**
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
@@ -53,9 +53,9 @@ module.exports = buildEngine({
 });
 ```
 
-Within your Engine’s `app/config/environment.js` file:
+Within your Engine’s `config/environment.js` file:
 
-```jsx
+```js
 /**
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
@@ -77,7 +77,7 @@ module.exports = function (environment) {
 
 Within your Engine’s `addon/engine.js` file:
 
-```jsx
+```js
 /**
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
@@ -104,15 +104,33 @@ export default class <EngineName>Engine extends Engine {
 loadInitializers(<EngineName>Engine, modulePrefix);
 ```
 
+### Service Dependencies:
+
 The services in the example above are common services that we often use in our engines. If your engine requires other services from the main application, add them to the services array.
 
-Optional step: Add some text in the engine’s `application.hbs` file (to see if your engine was set up correctly).
+#### Notes:
+
+- Service dependencies are OPTIONAL. If your engine does not use any external services, you do not need to include a services dependency array.
+- Remember to include any dependencies here in the engine's dependencies in app/app.js
+
+### External Route Dependencies:
+
+The external route dependencies allow you to link to a route outside of your engine. In this example, we list 'secrets' in the externalRoute and the route is defined in the `app.js` file.
+
+#### Notes:
+
+- In order to link to the other routes in the main app using the `LinkToExternal` component from your engine, you need to add the route to the `app/app.js` and your engine’s `addon/engine.js`. More information on [Linking to An External Context.](https://ember-engines.com/docs/link-to-external).
+
+## Additional info about your engine's `application.hbs`:
+
+- Optional step: Add some text in the engine’s `application.hbs` file (to see if your engine was set up correctly).
+- **NOTE: Most of our existing engines do not keep the generated `application.hbs` template file. If nothing will be added to it and it remains as just an `{{outlet}}` it can safely be removed.**
 
 ## Register your engine with our main application:
 
 In our `app/app.js` file in the engines object, add your engine’s name and dependencies.
 
-```jsx
+```js
 /**
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
@@ -144,9 +162,8 @@ If you used `ember g in-repo-engine <engine-name>` to generate the engine’s bl
 
 ### Important Notes:
 
-- Anytime a new engine is created, you will need to **RESTART** ember server!
+- Anytime a new engine is created, you will need to `yarn install` and **RESTART** ember server!
 - To add `package.json` **dependencies** or **devDependencies**, you can copy + paste the dependency into corresponding sections. Most of the time, we will want to use "\*" in place of the version number to ensure all the dependencies have the latest version.
-- In order to link to the other routes in the main app using the `LinkToExternal` component from your engine, you need to add the route to the `app/app.js` and your engine’s `addon/engine.js`. More information on [Linking to An External Context.](https://ember-engines.com/docs/link-to-external).
 
 ### Common blueprint commands:
 

--- a/ui/docs/ember-engines.md
+++ b/ui/docs/ember-engines.md
@@ -1,5 +1,7 @@
 # [Ember Engines](https://ember-engines.com/docs)
 
+This is a quickstart guide on how to set up an ember engine in Vault!
+
 ## Create a new in-repo engine:
 
 `ember g in-repo-engine <engine-name>`

--- a/ui/docs/ember-engines.md
+++ b/ui/docs/ember-engines.md
@@ -1,6 +1,6 @@
 # [Ember Engines](https://ember-engines.com/docs)
 
-This is a quickstart guide on how to set up an ember engine in Vault!
+This is a quickstart guide inspired by [ember engine quickstart](https://ember-engines.com/docs/quickstart) on how to set up an ember engine in Vault!
 
 ## Create a new in-repo engine:
 
@@ -12,7 +12,7 @@ _This blueprint in-repo engine command will add a new folder `lib/<engine-name>`
 
 ```json
 {
-  "name": <engine-name>,
+  "name": "<engine-name>",
 
   "dependencies": {
     "ember-cli-htmlbars": "*",
@@ -20,9 +20,7 @@ _This blueprint in-repo engine command will add a new folder `lib/<engine-name>`
   },
 
   "ember-addon": {
-    "paths": [
-      "../core"
-    ]
+    "paths": ["../core"]
   }
 }
 ```
@@ -112,7 +110,7 @@ Optional step: Add some text in the engine’s `application.hbs` file (to see if
 
 ## Register your engine with our main application:
 
-In our `app/app.js` in the engines object, add your engine’s name and dependencies.
+In our `app/app.js` file in the engines object, add your engine’s name and dependencies.
 
 ```jsx
 /**

--- a/ui/docs/ember-engines.md
+++ b/ui/docs/ember-engines.md
@@ -1,0 +1,159 @@
+# [Ember Engines](https://ember-engines.com/docs)
+
+## Create a new in-repo engine:
+
+---
+
+`ember g in-repo-engine <engine-name>`
+
+_This blueprint in-repo engine command will add a new folder `lib/<engine-name>` and add the engine to our main app’s `package.json`_
+
+## Engine’s package.json:
+
+---
+
+```json
+{
+  "name": <engine-name>,
+
+  "dependencies": {
+    "ember-cli-htmlbars": "*",
+    "ember-cli-babel": "*"
+  },
+
+  "ember-addon": {
+    "paths": [
+      "../core"
+    ]
+  }
+}
+```
+
+For our application, we want to include the **ember-addon** path `../core`
+
+By adding this **ember-addon** path, we are able to share elements between your in-repo addon and the Vault application[^1].
+
+## Configure your Engine
+
+---
+
+In the engine’s `index.js` file:
+
+```jsx
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/* eslint-disable node/no-extraneous-require */
+const { buildEngine } = require('ember-engines/lib/engine-addon');
+
+module.exports = buildEngine({
+  name: '<engine-name>',
+  lazyLoading: {
+    enabled: false,
+  },
+  isDevelopingAddon() {
+    return true;
+  },
+});
+```
+
+Within your Engine’s `app/config/environment.js` file:
+
+```jsx
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// config/environment.js
+
+'use strict';
+
+module.exports = function (environment) {
+  const ENV = {
+    modulePrefix: '<engine-name>',
+    environment: environment,
+  };
+
+  return ENV;
+};
+```
+
+Within your Engine’s `addon/engine.js` file:
+
+```jsx
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Engine from '@ember/engine';
+
+import loadInitializers from 'ember-load-initializers';
+import Resolver from 'ember-resolver';
+
+import config from './config/environment';
+
+const { modulePrefix } = config;
+
+export default class <EngineName>Engine extends Engine {
+  modulePrefix = modulePrefix;
+  Resolver = Resolver;
+  dependencies = {
+    services: ['router', 'store', 'secret-mount-path', 'flash-messages'],
+    externalRoutes: ['secrets'],
+  };
+}
+
+loadInitializers(<EngineName>Engine, modulePrefix);
+```
+
+The services in the example above are common services that we often use in our engines. Any other services that are in our main app that is needed for your engine should be added in the dependencies services array.
+
+Optional step: Add some text in the engine’s `application.hbs` file (to see if your engine was set up correctly).
+
+## Register your engine with our main application:
+
+---
+
+In our `app/app.js` in the engines object, add your engine’s name and dependencies.
+
+```jsx
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Application from '@ember/application';
+import Resolver from 'ember-resolver';
+import loadInitializers from 'ember-load-initializers';
+import config from 'vault/config/environment';
+
+export default class App extends Application {
+	...
+  engines = {
+    <engine-name>: {
+      dependencies: {
+        services: ['router', 'store', 'secret-mount-path', 'flash-messages', <any-other-dependencies-you-have>],
+        externalRoutes: {
+          secrets: 'vault.cluster.secrets.backends',
+        },
+      },
+    },
+  };
+}
+
+loadInitializers(App, config.modulePrefix);
+```
+
+If you used `ember g in-repo-engine <engine-name>` to generate the engine’s blueprint, it should have added `this.mount(<engine-name>)` to the main app’s `router.js` file (this adds your engine and its associated routes). \*Move `this.mount(<engine-name>)` to match your engine’s route structure. For more information about [Routable Engines](https://ember-engines.com/docs/quickstart#routable-engines).
+
+### Important Notes:
+
+- Anytime a new engine is created, you will need to **RESTART** ember server!
+- To add `package.json` **dependencies** or **devDependencies**, you can copy + paste the dependency into corresponding sections. Most of the time, we will want to use "\*" in place of the version number to ensure all the dependencies have the latest version.
+- In order to link to the other routes in the main app using the `LinkToExternal` component from your engine, you need to add the route to the `app/app.js` and your engine’s `addon/engine.js`. More information on [Linking to An External Context.](https://ember-engines.com/docs/link-to-external)
+
+[^1]: https://ember-engines.com/docs/quickstart#create-as-in-repo-engine


### PR DESCRIPTION
**Description:**
Add some documentation on how to create an engine in Vault.

This PR contains the cherry-picked commits from https://github.com/hashicorp/vault/pull/20749 and addresses some of the newer comments made in the previous PR.

