### PR TITLE
ui: update pki link

### DIFF
--- a/ui/app/controllers/vault/cluster/secrets/backend/configuration.js
+++ b/ui/app/controllers/vault/cluster/secrets/backend/configuration.js
@@ -8,7 +8,7 @@ import Controller from '@ember/controller';
 
 export default Controller.extend({
   isConfigurable: computed('model.type', function () {
-    const configurableEngines = ['aws', 'ssh', 'pki'];
+    const configurableEngines = ['aws', 'ssh'];
     return configurableEngines.includes(this.model.type);
   }),
 });

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -95,15 +95,7 @@
           <nav class="menu" aria-label="{{if backend.isSupportedBackend 'supported' 'unsupported'}} secrets engine menu">
             <ul class="menu-list">
               <li class="action">
-                <LinkTo
-                  @route={{if
-                    (eq backend.type "pki")
-                    "vault.cluster.secrets.backend.pki.configuration"
-                    "vault.cluster.secrets.backend.configuration"
-                  }}
-                  @model={{backend.id}}
-                  data-test-engine-config
-                >
+                <LinkTo @route="vault.cluster.secrets.backend.configuration" @model={{backend.id}} data-test-engine-config>
                   View configuration
                 </LinkTo>
               </li>

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -95,7 +95,15 @@
           <nav class="menu" aria-label="{{if backend.isSupportedBackend 'supported' 'unsupported'}} secrets engine menu">
             <ul class="menu-list">
               <li class="action">
-                <LinkTo @route="vault.cluster.secrets.backend.configuration" @model={{backend.id}} data-test-engine-config>
+                <LinkTo
+                  @route={{if
+                    (eq backend.type "pki")
+                    "vault.cluster.secrets.backend.pki.configuration"
+                    "vault.cluster.secrets.backend.configuration"
+                  }}
+                  @model={{backend.id}}
+                  data-test-engine-config
+                >
                   View configuration
                 </LinkTo>
               </li>

--- a/ui/lib/core/addon/helpers/options-for-backend.js
+++ b/ui/lib/core/addon/helpers/options-for-backend.js
@@ -6,7 +6,7 @@
 import { helper as buildHelper } from '@ember/component/helper';
 import { capitalize } from '@ember/string';
 
-// TODO move all pki related logic to the its ember engine
+// TODO move all pki related logic to its ember engine
 // then we can remove use of SecretListHeader there, and use self-managed component like TabPageHeader in k8
 
 const DEFAULT_DISPLAY = {

--- a/ui/lib/core/addon/helpers/options-for-backend.js
+++ b/ui/lib/core/addon/helpers/options-for-backend.js
@@ -6,6 +6,9 @@
 import { helper as buildHelper } from '@ember/component/helper';
 import { capitalize } from '@ember/string';
 
+// TODO move all pki related logic to the its ember engine
+// then we can remove use of SecretListHeader there, and use self-managed component like TabPageHeader in k8
+
 const DEFAULT_DISPLAY = {
   searchPlaceholder: 'Filter secrets',
   item: 'secret',
@@ -15,7 +18,6 @@ const DEFAULT_DISPLAY = {
   listItemPartial: 'secret-list/item',
 };
 
-// TODO used for <SecretListHeader> refactor and make component similar to k8's <TabPageHeader>
 const PKI_ENGINE_BACKEND = {
   displayName: 'PKI',
   navigateTree: false,

--- a/ui/lib/core/addon/helpers/options-for-backend.js
+++ b/ui/lib/core/addon/helpers/options-for-backend.js
@@ -14,6 +14,8 @@ const DEFAULT_DISPLAY = {
   editComponent: 'secret-edit',
   listItemPartial: 'secret-list/item',
 };
+
+// TODO used for <SecretListHeader> refactor and make component similar to k8's <TabPageHeader>
 const PKI_ENGINE_BACKEND = {
   displayName: 'PKI',
   navigateTree: false,


### PR DESCRIPTION
Now that the old pki code has been removed, this is one last piece that was left behind. This configure button is from the backend generator, now all pki related actions live with their own ember engine. 