### PR TITLE
Adds LDAP as Mountable and Supported Secrets Engine

### DIFF
--- a/ui/app/helpers/mountable-secret-engines.js
+++ b/ui/app/helpers/mountable-secret-engines.js
@@ -111,8 +111,14 @@ const MOUNTABLE_SECRET_ENGINES = [
     category: 'generic',
   },
   {
+    displayName: 'LDAP',
+    type: 'ldap',
+    engineRoute: 'ldap.overview',
+    category: 'generic',
+    glyph: 'folder-users',
+  },
+  {
     displayName: 'Kubernetes',
-    value: 'kubernetes',
     type: 'kubernetes',
     engineRoute: 'kubernetes.overview',
     category: 'generic',

--- a/ui/app/helpers/supported-secret-backends.js
+++ b/ui/app/helpers/supported-secret-backends.js
@@ -18,6 +18,7 @@ const SUPPORTED_SECRET_BACKENDS = [
   'transform',
   'keymgmt',
   'kubernetes',
+  'ldap',
 ];
 
 export function supportedSecretBackends() {

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -44,7 +44,7 @@
   <LinkedBlock
     @params={{array backend.backendLink backend.id}}
     class="list-item-row linkable-item is-no-underline"
-    data-test-auth-backend-link={{backend.id}}
+    data-test-secrets-backend-link={{backend.id}}
     @disabled={{if backend.isSupportedBackend false true}}
   >
     <div class="linkable-item-content" data-test-linkable-item-content>

--- a/ui/lib/ldap/addon/engine.js
+++ b/ui/lib/ldap/addon/engine.js
@@ -5,7 +5,7 @@
 
 import Engine from 'ember-engines/engine';
 import loadInitializers from 'ember-load-initializers';
-import Resolver from './resolver';
+import Resolver from 'ember-resolver';
 import config from './config/environment';
 
 const { modulePrefix } = config;

--- a/ui/tests/acceptance/secrets/backend/engines-test.js
+++ b/ui/tests/acceptance/secrets/backend/engines-test.js
@@ -64,7 +64,7 @@ module('Acceptance | secret-engine list view', function (hooks) {
     await backendsPage.visit();
     await settled();
 
-    const rows = document.querySelectorAll('[data-test-auth-backend-link]');
+    const rows = document.querySelectorAll('[data-test-secrets-backend-link]');
     const rowUnsupported = Array.from(rows).filter((row) => row.innerText.includes('nomad'));
     const rowSupported = Array.from(rows).filter((row) => row.innerText.includes('cubbyhole'));
     assert
@@ -92,7 +92,7 @@ module('Acceptance | secret-engine list view', function (hooks) {
     await clickTrigger('#filter-by-engine-type');
     await searchSelect.options.objectAt(0).click();
 
-    const rows = document.querySelectorAll('[data-test-auth-backend-link]');
+    const rows = document.querySelectorAll('[data-test-secrets-backend-link]');
     const rowsAws = Array.from(rows).filter((row) => row.innerText.includes('aws'));
 
     assert.strictEqual(rows.length, rowsAws.length, 'all rows returned are aws');
@@ -100,12 +100,12 @@ module('Acceptance | secret-engine list view', function (hooks) {
     await clickTrigger('#filter-by-engine-name');
     const firstItemToSelect = searchSelect.options.objectAt(0).text;
     await searchSelect.options.objectAt(0).click();
-    const singleRow = document.querySelectorAll('[data-test-auth-backend-link]');
+    const singleRow = document.querySelectorAll('[data-test-secrets-backend-link]');
     assert.strictEqual(singleRow.length, 1, 'returns only one row');
     assert.dom(singleRow[0]).includesText(firstItemToSelect, 'shows the filtered by name engine');
     // clear filter by engine name
     await searchSelect.deleteButtons.objectAt(1).click();
-    const rowsAgain = document.querySelectorAll('[data-test-auth-backend-link]');
+    const rowsAgain = document.querySelectorAll('[data-test-secrets-backend-link]');
     assert.ok(rowsAgain.length > 1, 'filter has been removed');
 
     // cleanup

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -708,7 +708,7 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
     await authPage.login(userToken);
     await settled();
     // test if metadata tab there with no read access message and no ability to edit.
-    await click(`[data-test-auth-backend-link=${enginePath}]`);
+    await click(`[data-test-secrets-backend-link=${enginePath}]`);
     assert
       .dom('[data-test-get-credentials]')
       .exists(

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -126,7 +126,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
     await page.secretList();
     await settled();
     assert
-      .dom(`[data-test-auth-backend-link=${path}]`)
+      .dom(`[data-test-secrets-backend-link=${path}]`)
       .exists({ count: 1 }, 'renders only one instance of the engine');
   });
 

--- a/ui/tests/pages/secrets/backends.js
+++ b/ui/tests/pages/secrets/backends.js
@@ -9,7 +9,7 @@ import uiPanel from 'vault/tests/pages/components/console/ui-panel';
 export default create({
   consoleToggle: clickable('[data-test-console-toggle]'),
   visit: visitable('/vault/secrets'),
-  rows: collection('[data-test-auth-backend-link]', {
+  rows: collection('[data-test-secrets-backend-link]', {
     path: text('[data-test-secret-path]'),
     menu: clickable('[data-test-popup-menu-trigger]'),
   }),


### PR DESCRIPTION
This PR adds LDAP as a mountable and supported secrets engine under the _generic_ section of the engines list.

![image](https://github.com/hashicorp/vault/assets/24611656/27f355f9-288a-4c80-b823-91827b2ae585)
