### PR TITLE
Update SDK and API for 1.14 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -147,10 +147,10 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.11.0
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.7.1
 	github.com/hashicorp/vault-testing-stepwise v0.1.3
-	github.com/hashicorp/vault/api v1.9.1
+	github.com/hashicorp/vault/api v1.9.2
 	github.com/hashicorp/vault/api/auth/approle v0.1.0
 	github.com/hashicorp/vault/api/auth/userpass v0.1.0
-	github.com/hashicorp/vault/sdk v0.9.0
+	github.com/hashicorp/vault/sdk v0.9.1
 	github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230201201504-b741fa893d77
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/jackc/pgx/v4 v4.15.0


### PR DESCRIPTION
Pointing the go.mod to the updated SDK and API releases, then ran a go mod tidy.