### PR TITLE
Backport: 1.11.x: Fix flaky token test

### DIFF
--- a/ui/tests/integration/components/token-expire-warning-test.js
+++ b/ui/tests/integration/components/token-expire-warning-test.js
@@ -1,18 +1,18 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { find, render, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { addMinutes } from 'date-fns';
+import { addMinutes, subMinutes } from 'date-fns';
 
 module('Integration | Component | token-expire-warning', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders a warning when the token is expired', async function (assert) {
-    const expirationDate = Date.now();
+    const expirationDate = subMinutes(Date.now(), 30);
     this.set('expirationDate', expirationDate);
 
-    await render(hbs`<TokenExpireWarning @expirationDate={{expirationDate}}/>`);
-
+    await render(hbs`<TokenExpireWarning @expirationDate={{this.expirationDate}}/>`);
+    await waitUntil(() => find('#modal-overlays'));
     assert.dom().includesText('Your auth token expired on');
   });
 
@@ -21,11 +21,11 @@ module('Integration | Component | token-expire-warning', function (hooks) {
     this.set('expirationDate', expirationDate);
 
     await render(hbs`
-      <TokenExpireWarning @expirationDate={{expirationDate}}>
+      <TokenExpireWarning @expirationDate={{this.expirationDate}}>
         <p>Do not worry, your token has not expired.</p>
       </TokenExpireWarning>
     `);
-
+    await waitUntil(() => find('#modal-overlays'));
     assert.dom().doesNotIncludeText('Your auth token expired on');
     assert.dom().includesText('Do not worry');
   });


### PR DESCRIPTION
Looks like there were several prs to try and fix this test. Instead of backporting each one (which on their own did not fix it) I'm just copying from main and pasting the new test here (minus the token header). 

This test is causing problems on the 1.11 branch so pointing the fix for that release.