### PR TITLE
Better transit import export semantics

### DIFF
--- a/builtin/logical/transit/path_export.go
+++ b/builtin/logical/transit/path_export.go
@@ -90,8 +90,8 @@ func (b *backend) pathPolicyExportRead(ctx context.Context, req *logical.Request
 	}
 	defer p.Unlock()
 
-	if !p.Exportable {
-		return logical.ErrorResponse("key is not exportable"), nil
+	if !p.Exportable && exportType != exportTypePublicKey {
+		return logical.ErrorResponse("private key material is not exportable"), nil
 	}
 
 	switch exportType {


### PR DESCRIPTION
This changes the behavior of `import_version` to update the latest version if it is missing a private key, otherwise creating a new version, removing the need for `bump_version`. When an explicit version is specified, we check to see if we can add a private key to that particular key version. This is a follow-on of #17934 by @Gabrielopesantos :-)

Also updates public key exports to not require `exportable` on the key.

This fixes two bugs:

 - Comparison of EC keys and missing Ed25519 key comparison
 - Ensuring RSAPublicKey is always set, allowing us to unconditionally use it in some places. 