### PR TITLE
Backport 1.12.x: make token test consistent

### DIFF
--- a/ui/tests/integration/components/token-expire-warning-test.js
+++ b/ui/tests/integration/components/token-expire-warning-test.js
@@ -11,7 +11,7 @@ module('Integration | Component | token-expire-warning', function (hooks) {
     const expirationDate = subMinutes(Date.now(), 30);
     this.set('expirationDate', expirationDate);
 
-    await render(hbs`<TokenExpireWarning @expirationDate={{expirationDate}}/>`);
+    await render(hbs`<TokenExpireWarning @expirationDate={{this.expirationDate}}/>`);
     await waitUntil(() => find('#modal-overlays'));
     assert.dom().includesText('Your auth token expired on');
   });
@@ -21,7 +21,7 @@ module('Integration | Component | token-expire-warning', function (hooks) {
     this.set('expirationDate', expirationDate);
 
     await render(hbs`
-      <TokenExpireWarning @expirationDate={{expirationDate}}>
+      <TokenExpireWarning @expirationDate={{this.expirationDate}}>
         <p>Do not worry, your token has not expired.</p>
       </TokenExpireWarning>
     `);


### PR DESCRIPTION
Making the token test consistent through the release branches. Issues with flaky tests (in 1.11). See backport to 1.11.x [here](https://github.com/hashicorp/vault/pull/20812). 