### PR TITLE
agent: Fix a potential race condition in process supervisor mode

### DIFF
--- a/command/agent/exec/exec.go
+++ b/command/agent/exec/exec.go
@@ -257,7 +257,16 @@ func (s *Server) bounceCmd(newEnvVars []string) error {
 	}
 	s.childProcess = proc
 
-	// listen if the child process exits and bubble it up to the main loop
+	if err := s.childProcess.Start(); err != nil {
+		return fmt.Errorf("error starting the child process: %w", err)
+	}
+
+	s.childProcessState = childProcessStateRunning
+
+	// Listen if the child process exits and bubble it up to the main loop.
+	//
+	// NOTE: this must be invoked after child.Start() to avoid a potential
+	// race condition with ExitCh not being initialized.
 	go func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		s.childProcessExitCodeCloser = cancel
@@ -269,11 +278,6 @@ func (s *Server) bounceCmd(newEnvVars []string) error {
 			return
 		}
 	}()
-
-	if err := s.childProcess.Start(); err != nil {
-		return fmt.Errorf("error starting child process: %w", err)
-	}
-	s.childProcessState = childProcessStateRunning
 
 	return nil
 }


### PR DESCRIPTION
There is a potential issue with the existing code where `<-proc.ExitCh()` can return a `nil` channel. This is because the `ExitCh` is initialized within `Start()`not `New(...)`.

This PR fixes the potential race condition by calling Start() before the `<-proc.ExitCh()` is invoked.