### PR TITLE
ACME behavior changes - ExtKeyUsage verification and issuer leaf_not_after

### DIFF
--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -374,6 +374,14 @@ func getAcmeRoleAndIssuer(sc *storageContext, data *framework.FieldData, config 
 		}
 	}
 
+	// Override ExtKeyUsage behavior to force it to only be ServerAuth within ACME issued certs
+	role.ExtKeyUsage = []string{"serverauth"}
+	role.ExtKeyUsageOIDs = []string{}
+	role.ServerFlag = true
+	role.ClientFlag = false
+	role.CodeSigningFlag = false
+	role.EmailProtectionFlag = false
+
 	return role, issuer, nil
 }
 

--- a/builtin/logical/pki/path_acme_order.go
+++ b/builtin/logical/pki/path_acme_order.go
@@ -499,6 +499,13 @@ func issueCertFromCsr(ac *acmeContext, csr *x509.CertificateRequest) (*certutil.
 		return nil, "", fmt.Errorf("verification of parsed bundle failed: %w", err)
 	}
 
+	// We only allow ServerAuth key usage from ACME issued certs.
+	for _, usage := range parsedBundle.Certificate.ExtKeyUsage {
+		if usage != x509.ExtKeyUsageServerAuth {
+			return nil, "", fmt.Errorf("%w: ACME certs only allow ServerAuth key usage", ErrBadCSR)
+		}
+	}
+
 	return parsedBundle, issuerId, err
 }
 

--- a/builtin/logical/pki/path_acme_order.go
+++ b/builtin/logical/pki/path_acme_order.go
@@ -461,6 +461,12 @@ func issueCertFromCsr(ac *acmeContext, csr *x509.CertificateRequest) (*certutil.
 		return nil, "", fmt.Errorf("failed loading CA %s: %w", ac.issuer.ID.String(), err)
 	}
 
+	// ACME issued cert will override the TTL values to truncate to the issuer's
+	// expiration if we go beyond, no matter the setting
+	if signingBundle.LeafNotAfterBehavior == certutil.ErrNotAfterBehavior {
+		signingBundle.LeafNotAfterBehavior = certutil.TruncateNotAfterBehavior
+	}
+
 	input := &inputBundle{
 		req:     &logical.Request{},
 		apiData: data,

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -583,6 +583,118 @@ func TestAcmeConfigChecksPublicAcmeEnv(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestAcmeTruncatesToIssuerExpiry make sure that if the selected issuer's expiry is shorter than the
+// CSR's selected TTL value in ACME and the issuer's leaf_not_after_behavior setting is set to Err,
+// we will override the configured behavior and truncate to the issuer's NotAfter
+func TestAcmeTruncatesToIssuerExpiry(t *testing.T) {
+	cluster, client, _ := setupAcmeBackend(t)
+	defer cluster.Cleanup()
+
+	testCtx := context.Background()
+	mount := "pki"
+	resp, err := client.Logical().WriteWithContext(context.Background(), mount+"/issuers/generate/intermediate/internal",
+		map[string]interface{}{
+			"key_name":    "short-key",
+			"key_type":    "ec",
+			"common_name": "test.com",
+		})
+	require.NoError(t, err, "failed creating intermediary CSR")
+	intermediateCSR := resp.Data["csr"].(string)
+
+	// Sign the intermediate CSR using /pki
+	resp, err = client.Logical().Write(mount+"/issuer/root-ca/sign-intermediate", map[string]interface{}{
+		"csr":     intermediateCSR,
+		"ttl":     "10m",
+		"max_ttl": "1h",
+	})
+	require.NoError(t, err, "failed signing intermediary CSR")
+	intermediateCertPEM := resp.Data["certificate"].(string)
+
+	shortCa := parseCert(t, intermediateCertPEM)
+
+	// Configure the intermediate cert as the CA in /pki2
+	resp, err = client.Logical().Write(mount+"/issuers/import/cert", map[string]interface{}{
+		"pem_bundle": intermediateCertPEM,
+	})
+	require.NoError(t, err, "failed importing intermediary cert")
+	importedIssuersRaw := resp.Data["imported_issuers"].([]interface{})
+	require.Len(t, importedIssuersRaw, 1)
+	shortCaUuid := importedIssuersRaw[0].(string)
+
+	_, err = client.Logical().Write(mount+"/issuer/"+shortCaUuid, map[string]interface{}{
+		"leaf_not_after_behavior": "err",
+		"issuer_name":             "short-ca",
+	})
+	require.NoError(t, err, "failed updating issuer name")
+
+	baseAcmeURL := "/v1/pki/issuer/short-ca/acme/"
+	accountKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "failed creating rsa key")
+
+	acmeClient := getAcmeClientForCluster(t, cluster, baseAcmeURL, accountKey)
+
+	// Create new account
+	t.Logf("Testing register on %s", baseAcmeURL)
+	acct, err := acmeClient.Register(testCtx, &acme.Account{}, func(tosURL string) bool { return true })
+	require.NoError(t, err, "failed registering account")
+
+	// Create an order
+	t.Logf("Testing Authorize Order on %s", baseAcmeURL)
+	identifiers := []string{"*.localdomain"}
+	order, err := acmeClient.AuthorizeOrder(testCtx, []acme.AuthzID{
+		{Type: "dns", Value: identifiers[0]},
+	})
+	require.NoError(t, err, "failed creating order")
+
+	// HACK: Update authorization/challenge to completed as we can't really do it properly in this workflow
+	//       test.
+	pkiMount := findStorageMountUuid(t, client, "pki")
+	accountId := acct.URI[strings.LastIndex(acct.URI, "/"):]
+	for _, authURI := range order.AuthzURLs {
+		authId := authURI[strings.LastIndex(authURI, "/"):]
+
+		rawPath := path.Join("/sys/raw/logical/", pkiMount, getAuthorizationPath(accountId, authId))
+		resp, err := client.Logical().ReadWithContext(testCtx, rawPath)
+		require.NoError(t, err, "failed looking up authorization storage")
+		require.NotNil(t, resp, "sys raw response was nil")
+		require.NotEmpty(t, resp.Data["value"], "no value field in sys raw response")
+
+		var authz ACMEAuthorization
+		err = jsonutil.DecodeJSON([]byte(resp.Data["value"].(string)), &authz)
+		require.NoError(t, err, "error decoding authorization: %w", err)
+		authz.Status = ACMEAuthorizationValid
+		for _, challenge := range authz.Challenges {
+			challenge.Status = ACMEChallengeValid
+		}
+
+		encodeJSON, err := jsonutil.EncodeJSON(authz)
+		require.NoError(t, err, "failed encoding authz json")
+		_, err = client.Logical().WriteWithContext(testCtx, rawPath, map[string]interface{}{
+			"value":    base64.StdEncoding.EncodeToString(encodeJSON),
+			"encoding": "base64",
+		})
+		require.NoError(t, err, "failed writing authorization storage")
+	}
+
+	// Build a proper CSR, with the correct name and signed with a different key works.
+	goodCr := &x509.CertificateRequest{DNSNames: []string{identifiers[0]}}
+	csrKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err, "failed generated key for CSR")
+	csr, err := x509.CreateCertificateRequest(rand.Reader, goodCr, csrKey)
+	require.NoError(t, err, "failed generating csr")
+
+	certs, _, err := acmeClient.CreateOrderCert(testCtx, order.FinalizeURL, csr, true)
+	require.NoError(t, err, "failed finalizing order")
+	require.Len(t, certs, 3, "expected full acme chain")
+
+	testAcmeCertSignedByCa(t, client, certs, "short-ca")
+
+	acmeCert, err := x509.ParseCertificate(certs[0])
+	require.NoError(t, err, "failed parsing acme cert")
+
+	require.Equal(t, shortCa.NotAfter, acmeCert.NotAfter, "certificate times aren't the same")
+}
+
 func setupAcmeBackend(t *testing.T) (*vault.TestCluster, *api.Client, string) {
 	cluster, client := setupTestPkiCluster(t)
 

--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -206,8 +206,9 @@ func SubtestACMEIPAndDNS(t *testing.T, cluster *VaultPkiCluster) {
 	err = pki.UpdateRole("ip-dns-sans", map[string]interface{}{
 		"key_type":                    "any",
 		"allowed_domains":             "dadgarcorp.com",
-		"allow_subdomains":            "true",
-		"allow_wildcard_certificates": "false",
+		"allow_subdomains":            true,
+		"allow_wildcard_certificates": false,
+		"client_flag":                 false,
 	})
 	require.NoError(t, err, "failed creating role ip-dns-sans")
 
@@ -268,8 +269,9 @@ func SubtestACMEIPAndDNS(t *testing.T, cluster *VaultPkiCluster) {
 	// Perform an ACME lifecycle with an order that contains just an IP identifier
 	err = pki.UpdateRole("ip-sans", map[string]interface{}{
 		"key_type":            "any",
-		"use_csr_common_name": "false",
-		"require_cn":          "false",
+		"use_csr_common_name": false,
+		"require_cn":          false,
+		"client_flag":         false,
 	})
 	require.NoError(t, err, "failed creating role ip-sans")
 
@@ -429,6 +431,7 @@ func SubtestACMEWildcardDNS(t *testing.T, cluster *VaultPkiCluster) {
 		"allow_subdomains":            true,
 		"allow_bare_domains":          true,
 		"allow_wildcard_certificates": true,
+		"client_flag":                 false,
 	})
 	require.NoError(t, err, "failed creating role wildcard")
 	directoryUrl = basePath + "/roles/wildcard/acme/directory"
@@ -506,6 +509,7 @@ func SubtestACMEPreventsICADNS(t *testing.T, cluster *VaultPkiCluster) {
 		"allow_subdomains":            true,
 		"allow_bare_domains":          true,
 		"allow_wildcard_certificates": true,
+		"client_flag":                 false,
 	})
 	require.NoError(t, err, "failed creating role wildcard")
 	directoryUrl = basePath + "/roles/ica/acme/directory"

--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -208,7 +208,6 @@ func SubtestACMEIPAndDNS(t *testing.T, cluster *VaultPkiCluster) {
 		"allowed_domains":             "dadgarcorp.com",
 		"allow_subdomains":            true,
 		"allow_wildcard_certificates": false,
-		"client_flag":                 false,
 	})
 	require.NoError(t, err, "failed creating role ip-dns-sans")
 


### PR DESCRIPTION
This PR includes two fixes we have been discussing in meetings

- We now override the issuer's `leaf_not_after_behavior` to `truncate` if it is set to `err` to allow certificate issuance when an issuer's `NotAfter` time is approaching. This was mainly done as we currently don't allow ACME clients to specify TTL values
- When signing a certificate, we now validate that the only ExtKeyUsage flag set can be the ServerAuth type. 