### PR TITLE
Enforce PKI cluster local 'path' argument is set when enabling ACME

### DIFF
--- a/builtin/logical/pki/acme_errors.go
+++ b/builtin/logical/pki/acme_errors.go
@@ -128,13 +128,17 @@ func (e *ErrorResponse) Marshal() (*logical.Response, error) {
 }
 
 func FindType(given error) (err error, id string, code int, found bool) {
+	matchedError := false
 	for err, id = range errIdMappings {
 		if errors.Is(given, err) {
+			matchedError = true
 			break
 		}
 	}
 
-	if err == nil {
+	// If the given error was not matched from one of the standard ACME errors
+	// make this error, force ErrServerInternal
+	if !matchedError {
 		err = ErrServerInternal
 		id = errIdMappings[err]
 	}

--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -238,18 +238,9 @@ func buildAcmeFrameworkPaths(b *backend, patternFunc func(b *backend, pattern st
 }
 
 func getAcmeBaseUrl(sc *storageContext, path string) (*url.URL, *url.URL, error) {
-	cfg, err := sc.getClusterConfig()
+	baseUrl, err := getBasePathFromClusterConfig(sc)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed loading cluster config: %w", err)
-	}
-
-	if cfg.Path == "" {
-		return nil, nil, fmt.Errorf("ACME feature requires local cluster path configuration to be set: %w", ErrServerInternal)
-	}
-
-	baseUrl, err := url.Parse(cfg.Path)
-	if err != nil {
-		return nil, nil, fmt.Errorf("ACME feature a proper URL configured in local cluster path: %w", ErrServerInternal)
+		return nil, nil, err
 	}
 
 	directoryPrefix := ""
@@ -259,6 +250,24 @@ func getAcmeBaseUrl(sc *storageContext, path string) (*url.URL, *url.URL, error)
 	}
 
 	return baseUrl.JoinPath(directoryPrefix, "/acme/"), baseUrl, nil
+}
+
+func getBasePathFromClusterConfig(sc *storageContext) (*url.URL, error) {
+	cfg, err := sc.getClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed loading cluster config: %w", err)
+	}
+
+	if cfg.Path == "" {
+		return nil, fmt.Errorf("ACME feature requires local cluster 'path' field configuration to be set")
+	}
+
+	baseUrl, err := url.Parse(cfg.Path)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing URL configured in local cluster 'path' configuration: %s: %s",
+			cfg.Path, err.Error())
+	}
+	return baseUrl, nil
 }
 
 func getAcmeIssuer(sc *storageContext, issuerName string) (*issuerEntry, error) {

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -440,7 +440,7 @@ func (b *backend) initialize(ctx context.Context, _ *logical.InitializationReque
 	err = b.initializeStoredCertificateCounts(ctx)
 	if err != nil {
 		// Don't block/err initialize/startup for metrics.  Context on this call can time out due to number of certificates.
-		b.Logger().Error("Could not initialize stored certificate counts", err)
+		b.Logger().Error("Could not initialize stored certificate counts", "error", err)
 		b.certCountError = err.Error()
 	}
 

--- a/builtin/logical/pki/path_config_acme.go
+++ b/builtin/logical/pki/path_config_acme.go
@@ -142,7 +142,15 @@ func (b *backend) pathAcmeRead(ctx context.Context, req *logical.Request, _ *fra
 		return nil, err
 	}
 
-	return genResponseFromAcmeConfig(config, nil), nil
+	var warnings []string
+	if config.Enabled {
+		_, err := getBasePathFromClusterConfig(sc)
+		if err != nil {
+			warnings = append(warnings, err.Error())
+		}
+	}
+
+	return genResponseFromAcmeConfig(config, warnings), nil
 }
 
 func genResponseFromAcmeConfig(config *acmeConfigEntry, warnings []string) *logical.Response {

--- a/builtin/logical/pki/path_config_acme.go
+++ b/builtin/logical/pki/path_config_acme.go
@@ -263,6 +263,14 @@ func (b *backend) pathAcmeWrite(ctx context.Context, req *logical.Request, d *fr
 		}
 	}
 
+	// Check to make sure that we have a proper value for the cluster path which ACME requires
+	if config.Enabled {
+		_, err = getBasePathFromClusterConfig(sc)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	var warnings []string
 	// Lastly lets verify that the configuration is honored/invalidated by the public ACME env var.
 	isPublicAcmeDisabledByEnv, err := isPublicACMEDisabledByEnv()

--- a/builtin/logical/pki/path_config_cluster.go
+++ b/builtin/logical/pki/path_config_cluster.go
@@ -155,6 +155,9 @@ func (b *backend) pathWriteCluster(ctx context.Context, req *logical.Request, da
 
 	if value, ok := data.GetOk("path"); ok {
 		cfg.Path = value.(string)
+
+		// This field is required by ACME, if ever we allow un-setting in the
+		// future, this code will need to verify that ACME is not enabled.
 		if !govalidator.IsURL(cfg.Path) {
 			return nil, fmt.Errorf("invalid, non-URL path given to cluster: %v", cfg.Path)
 		}


### PR DESCRIPTION
Two minor fixes within this PR, along with the enforcing of the `path` argument is set when enabling ACME

1. Fix ACME error translation code, if we don't match one of the ACME errors force ErrServerInternal instead of the last element that we iterated over
2. One of the logger statements was missing its argument name being passed into the call.

