### PR TITLE
openapi: Fix generated types for duration strings

### DIFF
--- a/changelog/20841.txt
+++ b/changelog/20841.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+openapi: Fix generated types for duration strings
+```

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -919,7 +919,7 @@ func convertType(t FieldType) schemaType {
 		ret.format = "int64"
 	case TypeDurationSecond, TypeSignedDurationSecond:
 		ret.baseType = "string"
-		ret.format = "seconds"
+		ret.format = "duration"
 	case TypeBool:
 		ret.baseType = "boolean"
 	case TypeMap:

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -918,7 +918,7 @@ func convertType(t FieldType) schemaType {
 		ret.baseType = "integer"
 		ret.format = "int64"
 	case TypeDurationSecond, TypeSignedDurationSecond:
-		ret.baseType = "integer"
+		ret.baseType = "string"
 		ret.format = "seconds"
 	case TypeBool:
 		ret.baseType = "boolean"


### PR DESCRIPTION
Duration are sent as strings today (e.g. `"10s"`, `"20m"`, etc.), which breaks the code generated based on the current OpenAPI spec which encodes them as integers. This small fix addresses the issue.

> **Note**: "duration" is not yet officially supported in the OpenAPI spec [as of v3.0.3](https://spec.openapis.org/oas/v3.0.3#data-types), but it is planned [in future versions](https://github.com/OAI/OpenAPI-Specification/issues/845). For now, this format will be ignored by the openapi-generator.