### PR TITLE
Only accept an ACME challenge when payload is an empty JSON object not an empty string 

### DIFF
--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -191,7 +191,7 @@ func TestAcmeBasicWorkflow(t *testing.T) {
 			require.Equal(t, "dns-01", domainAuth.Challenges[1].Type)
 			require.NotEmpty(t, domainAuth.Challenges[1].Token, "missing challenge token")
 
-			// Test the values for the wilcard authentication
+			// Test the values for the wildcard authentication
 			require.Equal(t, acme.StatusPending, wildcardAuth.Status)
 			require.Equal(t, "dns", wildcardAuth.Identifier.Type)
 			require.Equal(t, "localdomain", wildcardAuth.Identifier.Value) // Make sure we strip the *. in auth responses
@@ -204,8 +204,15 @@ func TestAcmeBasicWorkflow(t *testing.T) {
 			require.Equal(t, "dns-01", wildcardAuth.Challenges[0].Type)
 			require.NotEmpty(t, domainAuth.Challenges[0].Token, "missing challenge token")
 
-			// Load a challenge directly; this triggers validation to start.
+			// Make sure that getting a challenge does not start it.
 			challenge, err := acmeClient.GetChallenge(testCtx, domainAuth.Challenges[0].URI)
+			require.NoError(t, err, "failed to load challenge")
+			require.Equal(t, acme.StatusPending, challenge.Status)
+			require.True(t, challenge.Validated.IsZero(), "validated time should be 0 on challenge")
+			require.Equal(t, "http-01", challenge.Type)
+
+			// Accept a challenge; this triggers validation to start.
+			challenge, err = acmeClient.Accept(testCtx, domainAuth.Challenges[0])
 			require.NoError(t, err, "failed to load challenge")
 			require.Equal(t, acme.StatusProcessing, challenge.Status)
 			require.True(t, challenge.Validated.IsZero(), "validated time should be 0 on challenge")


### PR DESCRIPTION
 Within the ACME spec section [7.5.1 Responding to Challenges](https://www.rfc-editor.org/rfc/rfc8555#section-7.5.1), mentions "{}" payload means client is accepting the challenge 

>  The client indicates to the server that it is ready for the challenge
>  validation by sending an empty JSON body ("{}") carried in a POST
>  request to the challenge URL (not the authorization URL).

But [6.3 GET and POST-as-GET Requests](https://www.rfc-editor.org/rfc/rfc8555#section-6.3), talks about "" as a payload

>  If a client wishes to fetch a resource from the server (which would
>  otherwise be done with a GET), then it MUST send a POST request with
>  a JWS body as described above, where the payload of the JWS is a
>  zero-length octet string.  In other words, the "payload" field of the
>  JWS object MUST be present and set to the empty string ("").

So this fix changes the behavior for the GetChallenge handler to return the challenge object and not accept it if the payload was "" and will only accept it if the payload was "{}"
