### PR TITLE
core: add pre-seal debug logs

### DIFF
--- a/vault/cluster/cluster.go
+++ b/vault/cluster/cluster.go
@@ -170,6 +170,7 @@ func (cl *Listener) AddHandler(alpn string, handler Handler) {
 // calls stop on the handler.
 func (cl *Listener) StopHandler(alpn string) {
 	cl.l.Lock()
+	cl.logger.Debug("stopping forwarding", "alpn", alpn)
 	handler, ok := cl.handlers[alpn]
 	delete(cl.handlers, alpn)
 	cl.l.Unlock()

--- a/vault/cluster/cluster.go
+++ b/vault/cluster/cluster.go
@@ -170,7 +170,7 @@ func (cl *Listener) AddHandler(alpn string, handler Handler) {
 // calls stop on the handler.
 func (cl *Listener) StopHandler(alpn string) {
 	cl.l.Lock()
-	cl.logger.Debug("stopping forwarding", "alpn", alpn)
+	cl.logger.Debug("stopping handler", "alpn", alpn)
 	handler, ok := cl.handlers[alpn]
 	delete(cl.handlers, alpn)
 	cl.l.Unlock()

--- a/vault/core.go
+++ b/vault/core.go
@@ -2542,14 +2542,11 @@ func (c *Core) preSeal() error {
 	}
 	var result error
 
-	c.logger.Debug("stopping forwarding")
 	c.stopForwarding()
 
-	c.logger.Debug("stopping raft active node")
 	c.stopRaftActiveNode()
 
 	c.clusterParamsLock.Lock()
-	c.logger.Debug("stopping replication")
 	if err := stopReplication(c); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error stopping replication: %w", err))
 	}
@@ -2559,7 +2556,6 @@ func (c *Core) preSeal() error {
 	if err := c.teardownAudits(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error tearing down audits: %w", err))
 	}
-	c.logger.Trace("stopping expiration manager")
 	if err := c.stopExpiration(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error stopping expiration: %w", err))
 	}


### PR DESCRIPTION
Adding more logs to pre-seal to help debug slow leader step downs.