### PR TITLE
Introduce a wrapper for NewTestCluster that only supports single node

### DIFF
--- a/builtin/credential/aws/backend_e2e_test.go
+++ b/builtin/credential/aws/backend_e2e_test.go
@@ -8,11 +8,8 @@ import (
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
-	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/helper/logging"
-	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	"github.com/hashicorp/vault/vault"
 )
 
@@ -104,27 +101,10 @@ func TestBackend_E2E_Initialize(t *testing.T) {
 
 func setupAwsTestCluster(t *testing.T, _ context.Context) *vault.TestCluster {
 	// create a cluster with the aws auth backend built-in
-	logger := logging.NewVaultLogger(hclog.Trace)
-	coreConfig := &vault.CoreConfig{
-		Logger: logger,
-		CredentialBackends: map[string]logical.Factory{
-			"aws": Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		NumCores:    1,
-		HandlerFunc: vaulthttp.Handler,
-	})
-
-	cluster.Start()
-	if len(cluster.Cores) != 1 {
-		t.Fatalf("expected exactly one core")
-	}
-	core := cluster.Cores[0]
-	vault.TestWaitActive(t, core.Core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 
 	// load the auth plugin
-	if err := core.Client.Sys().EnableAuthWithOptions("aws", &api.EnableAuthOptions{
+	if err := cluster.Cores[0].Client.Sys().EnableAuthWithOptions("aws", &api.EnableAuthOptions{
 		Type: "aws",
 	}); err != nil {
 		t.Fatal(err)

--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -18,10 +18,9 @@ import (
 	"github.com/go-test/deep"
 	"github.com/hashicorp/go-hclog"
 	mongodbatlas "github.com/hashicorp/vault-plugin-database-mongodbatlas"
-	"github.com/hashicorp/vault/helper/builtinplugins"
 	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	postgreshelper "github.com/hashicorp/vault/helper/testhelpers/postgresql"
-	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/plugins/database/mongodb"
 	"github.com/hashicorp/vault/plugins/database/postgresql"
 	v4 "github.com/hashicorp/vault/sdk/database/dbplugin"
@@ -37,19 +36,8 @@ import (
 )
 
 func getCluster(t *testing.T) (*vault.TestCluster, logical.SystemView) {
-	coreConfig := &vault.CoreConfig{
-		LogicalBackends: map[string]logical.Factory{
-			"database": Factory,
-		},
-		BuiltinRegistry: builtinplugins.Registry,
-	}
-
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	cores := cluster.Cores
-	vault.TestWaitActive(t, cores[0].Core)
 
 	os.Setenv(pluginutil.PluginCACertPEMEnv, cluster.CACertPEMFile)
 

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -26,6 +26,7 @@ import (
 	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
 	"github.com/hashicorp/vault/command/agent"
 	agentConfig "github.com/hashicorp/vault/command/agent/config"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	"github.com/hashicorp/vault/helper/useragent"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -2703,24 +2704,7 @@ func TestAgent_Quit(t *testing.T) {
 	//----------------------------------------------------
 	// Start the server and agent
 	//----------------------------------------------------
-	logger := logging.NewVaultLogger(hclog.Error)
-	cluster := vault.NewTestCluster(t,
-		&vault.CoreConfig{
-			Logger: logger,
-			CredentialBackends: map[string]logical.Factory{
-				"approle": credAppRole.Factory,
-			},
-			LogicalBackends: map[string]logical.Factory{
-				"kv": logicalKv.Factory,
-			},
-		},
-		&vault.TestClusterOptions{
-			NumCores: 1,
-		})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	vault.TestWaitActive(t, cluster.Cores[0].Core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	serverClient := cluster.Cores[0].Client
 
 	// Unset the environment variable so that agent picks up the right test
@@ -2759,7 +2743,7 @@ cache {}
 	defer os.Remove(configPath)
 
 	// Start the agent
-	_, cmd := testAgentCommand(t, logger)
+	_, cmd := testAgentCommand(t, nil)
 	cmd.startedCh = make(chan struct{})
 
 	wg := &sync.WaitGroup{}

--- a/command/proxy_test.go
+++ b/command/proxy_test.go
@@ -23,6 +23,7 @@ import (
 	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
 	"github.com/hashicorp/vault/command/agent"
 	proxyConfig "github.com/hashicorp/vault/command/proxy/config"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	"github.com/hashicorp/vault/helper/useragent"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/logging"
@@ -920,24 +921,7 @@ listener "tcp" {
 
 // TestProxy_QuitAPI Tests the /proxy/v1/quit API that can be enabled for the proxy.
 func TestProxy_QuitAPI(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Error)
-	cluster := vault.NewTestCluster(t,
-		&vault.CoreConfig{
-			Logger: logger,
-			CredentialBackends: map[string]logical.Factory{
-				"approle": credAppRole.Factory,
-			},
-			LogicalBackends: map[string]logical.Factory{
-				"kv": logicalKv.Factory,
-			},
-		},
-		&vault.TestClusterOptions{
-			NumCores: 1,
-		})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	vault.TestWaitActive(t, cluster.Cores[0].Core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	serverClient := cluster.Cores[0].Client
 
 	// Unset the environment variable so that proxy picks up the right test
@@ -975,7 +959,7 @@ cache {}
 	configPath := makeTempFile(t, "config.hcl", config)
 	defer os.Remove(configPath)
 
-	_, cmd := testProxyCommand(t, logger)
+	_, cmd := testProxyCommand(t, nil)
 	cmd.startedCh = make(chan struct{})
 
 	wg := &sync.WaitGroup{}

--- a/helper/testhelpers/minimal/minimal.go
+++ b/helper/testhelpers/minimal/minimal.go
@@ -9,6 +9,7 @@ import (
 	auditSyslog "github.com/hashicorp/vault/builtin/audit/syslog"
 	logicalDb "github.com/hashicorp/vault/builtin/logical/database"
 	"github.com/hashicorp/vault/builtin/plugin"
+	"github.com/hashicorp/vault/helper/builtinplugins"
 	"github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -66,8 +67,11 @@ func NewTestSoloCluster(t testing.T, config *vault.CoreConfig) *vault.TestCluste
 			"syslog": auditSyslog.Factory,
 		}
 	}
+	if mycfg.BuiltinRegistry == nil {
+		mycfg.BuiltinRegistry = builtinplugins.Registry
+	}
 
-	cluster := vault.NewTestCluster(t, config, &vault.TestClusterOptions{
+	cluster := vault.NewTestCluster(t, mycfg, &vault.TestClusterOptions{
 		NumCores:    1,
 		HandlerFunc: http.Handler,
 		Logger:      logger,

--- a/helper/testhelpers/minimal/minimal.go
+++ b/helper/testhelpers/minimal/minimal.go
@@ -1,0 +1,77 @@
+package minimal
+
+import (
+	"github.com/hashicorp/go-hclog"
+	logicalKv "github.com/hashicorp/vault-plugin-secrets-kv"
+	"github.com/hashicorp/vault/audit"
+	auditFile "github.com/hashicorp/vault/builtin/audit/file"
+	auditSocket "github.com/hashicorp/vault/builtin/audit/socket"
+	auditSyslog "github.com/hashicorp/vault/builtin/audit/syslog"
+	logicalDb "github.com/hashicorp/vault/builtin/logical/database"
+	"github.com/hashicorp/vault/builtin/plugin"
+	"github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/sdk/physical/inmem"
+	"github.com/hashicorp/vault/vault"
+	"github.com/mitchellh/copystructure"
+	"github.com/mitchellh/go-testing-interface"
+)
+
+// NewTestSoloCluster is a simpler version of NewTestCluster that only creates
+// single-node clusters.  It is intentionally minimalist, if you need something
+// from vault.TestClusterOptions, use NewTestCluster instead.  It should work fine
+// with a nil config argument.  There is no need to call Start or Cleanup or
+// TestWaitActive on the resulting cluster.
+func NewTestSoloCluster(t testing.T, config *vault.CoreConfig) *vault.TestCluster {
+	logger := logging.NewVaultLogger(hclog.Trace).Named(t.Name())
+
+	mycfg := &vault.CoreConfig{}
+
+	if config != nil {
+		// It's rude to modify an input argument as a side-effect
+		copy, err := copystructure.Copy(config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mycfg = copy.(*vault.CoreConfig)
+	}
+	if mycfg.Physical == nil {
+		// Don't use NewTransactionalInmem because that would enable replication,
+		// which we don't care about in our case (use NewTestCluster for that.)
+		inm, err := inmem.NewInmem(nil, logger)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mycfg.Physical = inm
+	}
+	if mycfg.CredentialBackends == nil {
+		mycfg.CredentialBackends = map[string]logical.Factory{
+			"plugin": plugin.Factory,
+		}
+	}
+	if mycfg.LogicalBackends == nil {
+		mycfg.LogicalBackends = map[string]logical.Factory{
+			"plugin":   plugin.Factory,
+			"database": logicalDb.Factory,
+			// This is also available in the plugin catalog, but is here due to the need to
+			// automatically mount it.
+			"kv": logicalKv.Factory,
+		}
+	}
+	if mycfg.AuditBackends == nil {
+		mycfg.AuditBackends = map[string]audit.Factory{
+			"file":   auditFile.Factory,
+			"socket": auditSocket.Factory,
+			"syslog": auditSyslog.Factory,
+		}
+	}
+
+	cluster := vault.NewTestCluster(t, config, &vault.TestClusterOptions{
+		NumCores:    1,
+		HandlerFunc: http.Handler,
+		Logger:      logger,
+	})
+	t.Cleanup(cluster.Cleanup)
+	return cluster
+}

--- a/vault/expiration_integ_test.go
+++ b/vault/expiration_integ_test.go
@@ -9,27 +9,12 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/api"
-	"github.com/hashicorp/vault/builtin/credential/approle"
-	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/hashicorp/vault/vault"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 )
 
 func TestExpiration_RenewToken_TestCluster(t *testing.T) {
-	// Use a TestCluster and the approle backend to test renewal
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"approle": approle.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// Mount the auth backend

--- a/vault/external_tests/approle/wrapped_secretid_test.go
+++ b/vault/external_tests/approle/wrapped_secretid_test.go
@@ -6,41 +6,17 @@ package approle
 import (
 	"testing"
 
-	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
-	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
-	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/hashicorp/vault/vault"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	"github.com/stretchr/testify/require"
 )
 
 func TestApproleSecretId_Wrapped(t *testing.T) {
-	var err error
-	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
-		DisableCache: true,
-		Logger:       log.NewNullLogger(),
-		CredentialBackends: map[string]logical.Factory{
-			"approle": credAppRole.Factory,
-		},
-	}
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
 
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	cores := cluster.Cores
-
-	vault.TestWaitActive(t, cores[0].Core)
-
-	client := cores[0].Client
-	client.SetToken(cluster.RootToken)
-
-	err = client.Sys().EnableAuthWithOptions("approle", &api.EnableAuthOptions{
+	err := client.Sys().EnableAuthWithOptions("approle", &api.EnableAuthOptions{
 		Type: "approle",
 	})
 	if err != nil {
@@ -76,31 +52,11 @@ func TestApproleSecretId_Wrapped(t *testing.T) {
 }
 
 func TestApproleSecretId_NotWrapped(t *testing.T) {
-	var err error
-	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
-		DisableCache: true,
-		Logger:       log.NewNullLogger(),
-		CredentialBackends: map[string]logical.Factory{
-			"approle": credAppRole.Factory,
-		},
-	}
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
 
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	cores := cluster.Cores
-
-	vault.TestWaitActive(t, cores[0].Core)
-
-	client := cores[0].Client
-	client.SetToken(cluster.RootToken)
-
-	err = client.Sys().EnableAuthWithOptions("approle", &api.EnableAuthOptions{
+	err := client.Sys().EnableAuthWithOptions("approle", &api.EnableAuthOptions{
 		Type: "approle",
 	})
 	if err != nil {

--- a/vault/external_tests/expiration/expiration_test.go
+++ b/vault/external_tests/expiration/expiration_test.go
@@ -9,18 +9,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/helper/namespace"
-	vaulthttp "github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	"github.com/hashicorp/vault/vault"
 )
 
 func TestExpiration_irrevocableLeaseCountsAPI(t *testing.T) {
-	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-		NumCores:    1,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 	core := cluster.Cores[0].Core
 
@@ -120,13 +115,8 @@ func TestExpiration_irrevocableLeaseCountsAPI(t *testing.T) {
 }
 
 func TestExpiration_irrevocableLeaseListAPI(t *testing.T) {
-	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-		NumCores:    1,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 	core := cluster.Cores[0].Core
 
@@ -222,13 +212,8 @@ func TestExpiration_irrevocableLeaseListAPI(t *testing.T) {
 }
 
 func TestExpiration_irrevocableLeaseListAPI_includeAll(t *testing.T) {
-	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-		NumCores:    1,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 	core := cluster.Cores[0].Core
 

--- a/vault/external_tests/identity/aliases_test.go
+++ b/vault/external_tests/identity/aliases_test.go
@@ -13,28 +13,13 @@ import (
 
 	"github.com/hashicorp/vault/api"
 	auth "github.com/hashicorp/vault/api/auth/userpass"
-	"github.com/hashicorp/vault/builtin/credential/github"
-	"github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/helper/testhelpers"
-	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/hashicorp/vault/vault"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 )
 
 func TestIdentityStore_ListAlias(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"github": github.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	err := client.Sys().EnableAuthWithOptions("github", &api.EnableAuthOptions{
@@ -183,17 +168,8 @@ func TestIdentityStore_ListAlias(t *testing.T) {
 // returned on an attempt to rename an alias to match another alias with the
 // same mount accessor.  This used to result in a merge entity.
 func TestIdentityStore_RenameAlias_CannotMergeEntity(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"userpass": userpass.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	err := client.Sys().EnableAuthWithOptions("userpass", &api.EnableAuthOptions{
@@ -262,17 +238,8 @@ func TestIdentityStore_RenameAlias_CannotMergeEntity(t *testing.T) {
 }
 
 func TestIdentityStore_MergeEntities_FailsDueToClash(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"userpass": userpass.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	err := client.Sys().EnableAuthWithOptions("userpass", &api.EnableAuthOptions{
@@ -346,18 +313,8 @@ func TestIdentityStore_MergeEntities_FailsDueToClash(t *testing.T) {
 }
 
 func TestIdentityStore_MergeEntities_FailsDueToClashInFromEntities(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"userpass": userpass.Factory,
-			"github":   github.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	err := client.Sys().EnableAuthWithOptions("userpass", &api.EnableAuthOptions{
@@ -426,18 +383,8 @@ func TestIdentityStore_MergeEntities_FailsDueToClashInFromEntities(t *testing.T)
 }
 
 func TestIdentityStore_MergeEntities_FailsDueToDoubleClash(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"userpass": userpass.Factory,
-			"github":   github.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	err := client.Sys().EnableAuthWithOptions("userpass", &api.EnableAuthOptions{
@@ -563,17 +510,8 @@ func TestIdentityStore_MergeEntities_FailsDueToDoubleClash(t *testing.T) {
 }
 
 func TestIdentityStore_MergeEntities_FailsDueToClashInFromEntities_CheckRawRequest(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"userpass": userpass.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	err := client.Sys().EnableAuthWithOptions("userpass", &api.EnableAuthOptions{
@@ -727,17 +665,8 @@ func TestIdentityStore_MergeEntities_FailsDueToClashInFromEntities_CheckRawReque
 }
 
 func TestIdentityStore_MergeEntities_SameMountAccessor_ThenUseAlias(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"userpass": userpass.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	err := client.Sys().EnableAuthWithOptions("userpass", &api.EnableAuthOptions{
@@ -844,18 +773,8 @@ func TestIdentityStore_MergeEntities_SameMountAccessor_ThenUseAlias(t *testing.T
 }
 
 func TestIdentityStore_MergeEntities_FailsDueToMultipleClashMergesAttempted(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"userpass": userpass.Factory,
-			"github":   github.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	err := client.Sys().EnableAuthWithOptions("userpass", &api.EnableAuthOptions{

--- a/vault/external_tests/identity/entities_test.go
+++ b/vault/external_tests/identity/entities_test.go
@@ -9,27 +9,13 @@ import (
 
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault/api"
-	"github.com/hashicorp/vault/builtin/credential/approle"
-	vaulthttp "github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/hashicorp/vault/vault"
 )
 
 func TestIdentityStore_EntityDisabled(t *testing.T) {
-	// Use a TestCluster and the approle backend to get a token and entity for testing
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"approle": approle.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// Mount the auth backend
@@ -180,20 +166,8 @@ func TestIdentityStore_EntityDisabled(t *testing.T) {
 }
 
 func TestIdentityStore_EntityPoliciesInInitialAuth(t *testing.T) {
-	// Use a TestCluster and the approle backend to get a token and entity for testing
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"approle": approle.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// Mount the auth backend

--- a/vault/external_tests/identity/group_aliases_test.go
+++ b/vault/external_tests/identity/group_aliases_test.go
@@ -7,27 +7,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/api"
-	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/hashicorp/vault/vault"
-
-	credLdap "github.com/hashicorp/vault/builtin/credential/ldap"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 )
 
 func TestIdentityStore_GroupAliasLocalMount(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"ldap": credLdap.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// Create a local auth mount

--- a/vault/external_tests/identity/groups_test.go
+++ b/vault/external_tests/identity/groups_test.go
@@ -8,28 +8,11 @@ import (
 
 	"github.com/hashicorp/vault/api"
 	ldaphelper "github.com/hashicorp/vault/helper/testhelpers/ldap"
-	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/hashicorp/vault/vault"
-
-	"github.com/hashicorp/vault/builtin/credential/github"
-	credLdap "github.com/hashicorp/vault/builtin/credential/ldap"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 )
 
 func TestIdentityStore_ListGroupAlias(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"github": github.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	err := client.Sys().EnableAuthWithOptions("github", &api.EnableAuthOptions{
@@ -152,19 +135,7 @@ func TestIdentityStore_ListGroupAlias(t *testing.T) {
 
 // Testing the fix for GH-4351
 func TestIdentityStore_ExternalGroupMembershipsAcrossMounts(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"ldap": credLdap.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// Enable the first LDAP auth

--- a/vault/external_tests/identity/identity_test.go
+++ b/vault/external_tests/identity/identity_test.go
@@ -7,38 +7,21 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/go-secure-stdlib/strutil"
-	"github.com/hashicorp/vault/api"
-	"github.com/hashicorp/vault/sdk/helper/ldaputil"
-	"github.com/hashicorp/vault/sdk/logical"
-
-	"github.com/stretchr/testify/require"
-
-	"github.com/hashicorp/vault/helper/testhelpers/teststorage"
-
 	"github.com/go-ldap/ldap/v3"
 	log "github.com/hashicorp/go-hclog"
-	ldapcred "github.com/hashicorp/vault/builtin/credential/ldap"
+	"github.com/hashicorp/go-secure-stdlib/strutil"
+	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/namespace"
 	ldaphelper "github.com/hashicorp/vault/helper/testhelpers/ldap"
-	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/vault"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
+	"github.com/hashicorp/vault/sdk/helper/ldaputil"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIdentityStore_ExternalGroupMemberships_DifferentMounts(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"ldap": ldapcred.Factory,
-		},
-	}
-	conf, opts := teststorage.ClusterSetup(coreConfig, nil, nil)
-	cluster := vault.NewTestCluster(t, conf, opts)
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
-	vault.TestWaitActive(t, core)
 
 	// Create a entity
 	secret, err := client.Logical().Write("identity/entity", map[string]interface{}{
@@ -146,31 +129,10 @@ func TestIdentityStore_ExternalGroupMemberships_DifferentMounts(t *testing.T) {
 
 func TestIdentityStore_Integ_GroupAliases(t *testing.T) {
 	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
 
-	var err error
-	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
-		DisableCache: true,
-		Logger:       log.NewNullLogger(),
-		CredentialBackends: map[string]logical.Factory{
-			"ldap": ldapcred.Factory,
-		},
-	}
-
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	cores := cluster.Cores
-
-	vault.TestWaitActive(t, cores[0].Core)
-
-	client := cores[0].Client
-
-	err = client.Sys().EnableAuthWithOptions("ldap", &api.EnableAuthOptions{
+	err := client.Sys().EnableAuthWithOptions("ldap", &api.EnableAuthOptions{
 		Type: "ldap",
 	})
 	if err != nil {
@@ -342,7 +304,7 @@ func TestIdentityStore_Integ_GroupAliases(t *testing.T) {
 	assertMember(t, client, entityID, "devops", devopsGroupID, true)
 	assertMember(t, client, entityID, "engineer", devopsGroupID, true)
 
-	identityStore := cores[0].IdentityStore()
+	identityStore := cluster.Cores[0].IdentityStore()
 
 	group, err := identityStore.MemDBGroupByID(shipCrewGroupID, true)
 	if err != nil {
@@ -446,27 +408,10 @@ func TestIdentityStore_Integ_GroupAliases(t *testing.T) {
 
 func TestIdentityStore_Integ_RemoveFromExternalGroup(t *testing.T) {
 	t.Parallel()
-	var err error
-	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
-		DisableCache: true,
-		Logger:       log.NewNullLogger(),
-		CredentialBackends: map[string]logical.Factory{
-			"ldap": ldapcred.Factory,
-		},
-	}
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
 
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	cores := cluster.Cores
-	client := cores[0].Client
-
-	err = client.Sys().EnableAuthWithOptions("ldap", &api.EnableAuthOptions{
+	err := client.Sys().EnableAuthWithOptions("ldap", &api.EnableAuthOptions{
 		Type: "ldap",
 	})
 	if err != nil {

--- a/vault/external_tests/identity/login_mfa_duo_test.go
+++ b/vault/external_tests/identity/login_mfa_duo_test.go
@@ -11,17 +11,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/api"
-	"github.com/hashicorp/vault/builtin/credential/userpass"
-	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/hashicorp/vault/vault"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 )
-
-var identityMFACoreConfigDUO = &vault.CoreConfig{
-	CredentialBackends: map[string]logical.Factory{
-		"userpass": userpass.Factory,
-	},
-}
 
 var (
 	secret_key      = "<secret key for DUO>"
@@ -31,12 +22,7 @@ var (
 
 func TestInteg_PolicyMFADUO(t *testing.T) {
 	t.Skip("This test requires manual intervention and DUO verify on cellphone is needed")
-	cluster := vault.NewTestCluster(t, identityMFACoreConfigDUO, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// Enable Userpass authentication
@@ -158,12 +144,7 @@ path "secret/foo" {
 
 func TestInteg_LoginMFADUO(t *testing.T) {
 	t.Skip("This test requires manual intervention and DUO verify on cellphone is needed")
-	cluster := vault.NewTestCluster(t, identityMFACoreConfigDUO, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// Enable Userpass authentication

--- a/vault/external_tests/identity/login_mfa_okta_test.go
+++ b/vault/external_tests/identity/login_mfa_okta_test.go
@@ -10,11 +10,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/api"
-	"github.com/hashicorp/vault/builtin/credential/okta"
-	"github.com/hashicorp/vault/builtin/credential/userpass"
-	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/hashicorp/vault/vault"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 )
 
 var (
@@ -22,21 +18,9 @@ var (
 	api_token = "<okta api token>"
 )
 
-var identityOktaMFACoreConfig = &vault.CoreConfig{
-	CredentialBackends: map[string]logical.Factory{
-		"userpass": userpass.Factory,
-		"okta":     okta.Factory,
-	},
-}
-
 func TestOktaEngineMFA(t *testing.T) {
 	t.Skip("This test requires manual intervention and OKTA verify on cellphone is needed")
-	cluster := vault.NewTestCluster(t, identityOktaMFACoreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// Enable Okta engine
@@ -73,12 +57,7 @@ func TestOktaEngineMFA(t *testing.T) {
 
 func TestInteg_PolicyMFAOkta(t *testing.T) {
 	t.Skip("This test requires manual intervention and OKTA verify on cellphone is needed")
-	cluster := vault.NewTestCluster(t, identityOktaMFACoreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// Enable Userpass authentication
@@ -203,12 +182,7 @@ path "secret/foo" {
 
 func TestInteg_LoginMFAOkta(t *testing.T) {
 	t.Skip("This test requires manual intervention and OKTA verify on cellphone is needed")
-	cluster := vault.NewTestCluster(t, identityOktaMFACoreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// Enable Userpass authentication

--- a/vault/external_tests/kv/kv_patch_test.go
+++ b/vault/external_tests/kv/kv_patch_test.go
@@ -12,34 +12,14 @@ import (
 	"testing"
 	"time"
 
-	logicalKv "github.com/hashicorp/vault-plugin-secrets-kv"
 	"github.com/hashicorp/vault/api"
-	"github.com/hashicorp/vault/audit"
-	auditFile "github.com/hashicorp/vault/builtin/audit/file"
-	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/hashicorp/vault/vault"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 )
 
 func TestKV_Patch_BadContentTypeHeader(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		LogicalBackends: map[string]logical.Factory{
-			"kv": logicalKv.VersionedKVFactory,
-		},
-	}
-
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	cores := cluster.Cores
-
-	core := cores[0].Core
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	c := cluster.Cores[0].Client
-	vault.TestWaitActive(t, core)
 
 	// Mount a KVv2 backend
 	err := c.Sys().Mount("kv", &api.MountInput{
@@ -122,27 +102,9 @@ func kvRequestWithRetry(t *testing.T, req func() (interface{}, error)) (interfac
 }
 
 func TestKV_Patch_Audit(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		LogicalBackends: map[string]logical.Factory{
-			"kv": logicalKv.VersionedKVFactory,
-		},
-		AuditBackends: map[string]audit.Factory{
-			"file": auditFile.Factory,
-		},
-	}
-
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	cores := cluster.Cores
-
-	core := cores[0].Core
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	c := cluster.Cores[0].Client
-	vault.TestWaitActive(t, core)
 
 	if err := c.Sys().Mount("kv/", &api.MountInput{
 		Type: "kv-v2",
@@ -222,19 +184,9 @@ func TestKV_Patch_Audit(t *testing.T) {
 
 // Verifies that patching works by default with the root token
 func TestKV_Patch_RootToken(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		LogicalBackends: map[string]logical.Factory{
-			"kv": logicalKv.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0]
-	client := core.Client
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
 
 	// make sure this client is using the root token
 	client.SetToken(cluster.RootToken)

--- a/vault/external_tests/kv/kv_subkeys_test.go
+++ b/vault/external_tests/kv/kv_subkeys_test.go
@@ -9,34 +9,16 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	logicalKv "github.com/hashicorp/vault-plugin-secrets-kv"
 	"github.com/hashicorp/vault/api"
-	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/hashicorp/vault/vault"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 )
 
 // TestKV_Subkeys_NotFound issues a read to the subkeys endpoint for a path
 // that does not exist. A 400 status should be returned.
 func TestKV_Subkeys_NotFound(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		LogicalBackends: map[string]logical.Factory{
-			"kv": logicalKv.VersionedKVFactory,
-		},
-	}
-
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	cores := cluster.Cores
-
-	core := cores[0].Core
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	c := cluster.Cores[0].Client
-	vault.TestWaitActive(t, core)
 
 	// Mount a KVv2 backend
 	err := c.Sys().Mount("kv", &api.MountInput{
@@ -70,24 +52,9 @@ func TestKV_Subkeys_NotFound(t *testing.T) {
 // endpoint should return a 400 status with a nil "subkeys" value and the
 // "deletion_time" key in the "metadata" key should be not be empty.
 func TestKV_Subkeys_Deleted(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		LogicalBackends: map[string]logical.Factory{
-			"kv": logicalKv.VersionedKVFactory,
-		},
-	}
-
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	cores := cluster.Cores
-
-	core := cores[0].Core
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	c := cluster.Cores[0].Client
-	vault.TestWaitActive(t, core)
 
 	// Mount a KVv2 backend
 	err := c.Sys().Mount("kv", &api.MountInput{
@@ -169,24 +136,9 @@ func TestKV_Subkeys_Deleted(t *testing.T) {
 // endpoint should return a 400 status with a nil "subkeys" value and the
 // "destroyed" key in the "metadata" key should be set to true.
 func TestKV_Subkeys_Destroyed(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		LogicalBackends: map[string]logical.Factory{
-			"kv": logicalKv.VersionedKVFactory,
-		},
-	}
-
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	cores := cluster.Cores
-
-	core := cores[0].Core
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	c := cluster.Cores[0].Client
-	vault.TestWaitActive(t, core)
 
 	// Mount a KVv2 backend
 	err := c.Sys().Mount("kv", &api.MountInput{
@@ -276,24 +228,9 @@ func TestKV_Subkeys_Destroyed(t *testing.T) {
 // KVv2 secret engine. It ensures that the subkeys endpoint returns a 200 status
 // and current version of the secret.
 func TestKV_Subkeys_CurrentVersion(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		LogicalBackends: map[string]logical.Factory{
-			"kv": logicalKv.VersionedKVFactory,
-		},
-	}
-
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	cores := cluster.Cores
-
-	core := cores[0].Core
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	c := cluster.Cores[0].Client
-	vault.TestWaitActive(t, core)
 
 	// Mount a KVv2 backend
 	err := c.Sys().Mount("kv", &api.MountInput{

--- a/vault/external_tests/kv/kvv2_upgrade_test.go
+++ b/vault/external_tests/kv/kvv2_upgrade_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/vault"
-	"github.com/kr/pretty"
 )
 
 // Tests the regression in
@@ -75,12 +74,6 @@ func TestKVv2_UpgradePaths(t *testing.T) {
 	}
 	basePath := basePaths[0]
 
-	beforeList, err := core.UnderlyingStorage.List(ctx, "logical/"+kvMount+basePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Log(pretty.Sprint(beforeList))
-
 	// Delete policy/archive
 	if err = logical.ClearView(ctx, physical.NewView(core.UnderlyingStorage, "logical/"+kvMount+basePath+"policy/")); err != nil {
 		t.Fatal(err)
@@ -88,12 +81,6 @@ func TestKVv2_UpgradePaths(t *testing.T) {
 	if err = logical.ClearView(ctx, physical.NewView(core.UnderlyingStorage, "logical/"+kvMount+basePath+"archive/")); err != nil {
 		t.Fatal(err)
 	}
-
-	afterList, err := core.UnderlyingStorage.List(ctx, "logical/"+kvMount+basePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Log(pretty.Sprint(afterList))
 
 	testhelpers.EnsureCoresUnsealed(t, cluster)
 

--- a/vault/external_tests/mfa/login_mfa_test.go
+++ b/vault/external_tests/mfa/login_mfa_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
+
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/builtin/credential/userpass"
@@ -18,18 +20,7 @@ import (
 
 // TestLoginMFA_Method_CRUD tests creating/reading/updating/deleting a method config for all the MFA providers
 func TestLoginMFA_Method_CRUD(t *testing.T) {
-	cluster := vault.NewTestCluster(t, &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"userpass": userpass.Factory,
-		},
-	}, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// Enable userpass authentication
@@ -220,18 +211,7 @@ func TestLoginMFA_Method_CRUD(t *testing.T) {
 }
 
 func TestLoginMFAMethodName(t *testing.T) {
-	cluster := vault.NewTestCluster(t, &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"userpass": userpass.Factory,
-		},
-	}, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// Enable userpass authentication
@@ -444,18 +424,7 @@ func TestLoginMFA_ListAllMFAConfigsGlobally(t *testing.T) {
 
 // TestLoginMFA_LoginEnforcement_CRUD tests creating/reading/updating/deleting a login enforcement config
 func TestLoginMFA_LoginEnforcement_CRUD(t *testing.T) {
-	cluster := vault.NewTestCluster(t, &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"userpass": userpass.Factory,
-		},
-	}, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// first create a few configs
@@ -603,14 +572,7 @@ func TestLoginMFA_LoginEnforcement_CRUD(t *testing.T) {
 
 // TestLoginMFA_LoginEnforcement_MethodIdsIsRequired ensures that login enforcements have method ids attached
 func TestLoginMFA_LoginEnforcement_MethodIdsIsRequired(t *testing.T) {
-	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// create a login enforcement config, which should fail
@@ -626,14 +588,7 @@ func TestLoginMFA_LoginEnforcement_MethodIdsIsRequired(t *testing.T) {
 
 // TestLoginMFA_LoginEnforcement_RequiredParameters validates that all of the required fields must be present
 func TestLoginMFA_LoginEnforcement_RequiredParameters(t *testing.T) {
-	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// first create a few configs
@@ -669,14 +624,7 @@ func TestLoginMFA_LoginEnforcement_RequiredParameters(t *testing.T) {
 }
 
 func TestLoginMFA_UpdateNonExistentConfig(t *testing.T) {
-	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	_, err := client.Logical().Write("mfa/method/totp/a51884c6-51f2-bdc3-f4c5-0da64fe4d061", map[string]interface{}{

--- a/vault/external_tests/policy/acl_templating_test.go
+++ b/vault/external_tests/policy/acl_templating_test.go
@@ -8,10 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/api"
-	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
-	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/hashicorp/vault/vault"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 )
 
 func TestPolicyTemplating(t *testing.T) {
@@ -46,19 +43,7 @@ path "secret/{{ identity.groups.names.foobar.name}}/*" {
 }
 `
 
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"userpass": credUserpass.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	resp, err := client.Logical().Write("identity/entity", map[string]interface{}{

--- a/vault/external_tests/policy/policy_test.go
+++ b/vault/external_tests/policy/policy_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
+
 	"github.com/go-test/deep"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
@@ -98,27 +100,8 @@ func TestPolicy_NoDefaultPolicy(t *testing.T) {
 
 func TestPolicy_NoConfiguredPolicy(t *testing.T) {
 	var err error
-	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
-		DisableCache: true,
-		Logger:       hclog.NewNullLogger(),
-		CredentialBackends: map[string]logical.Factory{
-			"ldap": ldap.Factory,
-		},
-	}
-
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	cores := cluster.Cores
-
-	vault.TestWaitActive(t, cores[0].Core)
-
-	client := cores[0].Client
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
 
 	err = client.Sys().EnableAuthWithOptions("ldap", &api.EnableAuthOptions{
 		Type: "ldap",

--- a/vault/external_tests/router/router_ext_test.go
+++ b/vault/external_tests/router/router_ext_test.go
@@ -7,11 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/api"
-	"github.com/hashicorp/vault/builtin/credential/userpass"
-	"github.com/hashicorp/vault/builtin/logical/pki"
-	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/hashicorp/vault/vault"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 )
 
 func TestRouter_MountSubpath_Checks(t *testing.T) {
@@ -21,21 +17,7 @@ func TestRouter_MountSubpath_Checks(t *testing.T) {
 }
 
 func testRouter_MountSubpath(t *testing.T, mountPoints []string) {
-	coreConfig := &vault.CoreConfig{
-		LogicalBackends: map[string]logical.Factory{
-			"pki": pki.Factory,
-		},
-		CredentialBackends: map[string]logical.Factory{
-			"userpass": userpass.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	vault.TestWaitActive(t, cluster.Cores[0].Core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// Test auth

--- a/vault/external_tests/token/batch_token_test.go
+++ b/vault/external_tests/token/batch_token_test.go
@@ -9,30 +9,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/api"
-	"github.com/hashicorp/vault/builtin/credential/approle"
-	vaulthttp "github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	"github.com/hashicorp/vault/sdk/helper/consts"
-	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
 
 func TestBatchTokens(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		LogicalBackends: map[string]logical.Factory{
-			"kv": vault.LeasedPassthroughBackendFactory,
-		},
-		CredentialBackends: map[string]logical.Factory{
-			"approle": approle.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 	rootToken := client.Token()
 	var err error
@@ -203,22 +186,7 @@ path "kv/*" {
 }
 
 func TestBatchToken_ParentLeaseRevoke(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		LogicalBackends: map[string]logical.Factory{
-			"kv": vault.LeasedPassthroughBackendFactory,
-		},
-		CredentialBackends: map[string]logical.Factory{
-			"approle": approle.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 	rootToken := client.Token()
 	var err error
@@ -323,14 +291,7 @@ path "kv/*" {
 }
 
 func TestTokenStore_Roles_Batch(t *testing.T) {
-	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 	rootToken := client.Token()
 

--- a/vault/external_tests/token/batch_token_test.go
+++ b/vault/external_tests/token/batch_token_test.go
@@ -11,11 +11,17 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	"github.com/hashicorp/vault/sdk/helper/consts"
+	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
 
 func TestBatchTokens(t *testing.T) {
-	cluster := minimal.NewTestSoloCluster(t, nil)
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, &vault.CoreConfig{
+		LogicalBackends: map[string]logical.Factory{
+			"kv": vault.LeasedPassthroughBackendFactory,
+		},
+	})
 	client := cluster.Cores[0].Client
 	rootToken := client.Token()
 	var err error
@@ -186,7 +192,12 @@ path "kv/*" {
 }
 
 func TestBatchToken_ParentLeaseRevoke(t *testing.T) {
-	cluster := minimal.NewTestSoloCluster(t, nil)
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, &vault.CoreConfig{
+		LogicalBackends: map[string]logical.Factory{
+			"kv": vault.LeasedPassthroughBackendFactory,
+		},
+	})
 	client := cluster.Cores[0].Client
 	rootToken := client.Token()
 	var err error
@@ -291,6 +302,7 @@ path "kv/*" {
 }
 
 func TestTokenStore_Roles_Batch(t *testing.T) {
+	t.Parallel()
 	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 	rootToken := client.Token()

--- a/vault/external_tests/token/token_test.go
+++ b/vault/external_tests/token/token_test.go
@@ -13,24 +13,14 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/vault/api"
-	credLdap "github.com/hashicorp/vault/builtin/credential/ldap"
-	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/helper/testhelpers/ldap"
-	vaulthttp "github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/hashicorp/vault/vault"
 )
 
 func TestTokenStore_CreateOrphanResponse(t *testing.T) {
-	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	secret, err := client.Auth().Token().CreateOrphan(&api.TokenCreateRequest{
@@ -45,19 +35,7 @@ func TestTokenStore_CreateOrphanResponse(t *testing.T) {
 }
 
 func TestTokenStore_TokenInvalidEntityID(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"userpass": credUserpass.Factory,
-		},
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// Enable userpass auth
@@ -107,20 +85,7 @@ func TestTokenStore_TokenInvalidEntityID(t *testing.T) {
 }
 
 func TestTokenStore_IdentityPolicies(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"ldap": credLdap.Factory,
-		},
-		EnableRaw: true,
-	}
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	// Enable LDAP auth
@@ -378,15 +343,7 @@ path "auth/token/create" {
 	capabilities = ["update"]
 }
 `
-
-	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 	rootToken := client.Token()
 
@@ -527,15 +484,7 @@ path "auth/token/create" {
 }
 
 func TestTokenStore_RevocationOnStartup(t *testing.T) {
-	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-		NumCores:    1,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 	rootToken := client.Token()
 

--- a/vault/external_tests/token/token_test.go
+++ b/vault/external_tests/token/token_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestTokenStore_CreateOrphanResponse(t *testing.T) {
+	t.Parallel()
 	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
@@ -36,6 +37,7 @@ func TestTokenStore_CreateOrphanResponse(t *testing.T) {
 }
 
 func TestTokenStore_TokenInvalidEntityID(t *testing.T) {
+	t.Parallel()
 	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
@@ -86,6 +88,7 @@ func TestTokenStore_TokenInvalidEntityID(t *testing.T) {
 }
 
 func TestTokenStore_IdentityPolicies(t *testing.T) {
+	t.Parallel()
 	cluster := minimal.NewTestSoloCluster(t, &vault.CoreConfig{
 		EnableRaw: true,
 	})
@@ -341,6 +344,7 @@ func TestTokenStore_IdentityPolicies(t *testing.T) {
 }
 
 func TestTokenStore_CIDRBlocks(t *testing.T) {
+	t.Parallel()
 	testPolicy := `
 path "auth/token/create" {
 	capabilities = ["update"]
@@ -487,7 +491,10 @@ path "auth/token/create" {
 }
 
 func TestTokenStore_RevocationOnStartup(t *testing.T) {
-	cluster := minimal.NewTestSoloCluster(t, nil)
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, &vault.CoreConfig{
+		EnableRaw: true,
+	})
 	client := cluster.Cores[0].Client
 	rootToken := client.Token()
 

--- a/vault/external_tests/token/token_test.go
+++ b/vault/external_tests/token/token_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/vault"
 )
 
 func TestTokenStore_CreateOrphanResponse(t *testing.T) {
@@ -85,7 +86,9 @@ func TestTokenStore_TokenInvalidEntityID(t *testing.T) {
 }
 
 func TestTokenStore_IdentityPolicies(t *testing.T) {
-	cluster := minimal.NewTestSoloCluster(t, nil)
+	cluster := minimal.NewTestSoloCluster(t, &vault.CoreConfig{
+		EnableRaw: true,
+	})
 	client := cluster.Cores[0].Client
 
 	// Enable LDAP auth

--- a/vault/logical_system_integ_test.go
+++ b/vault/logical_system_integ_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/physical"
@@ -22,12 +23,7 @@ import (
 
 func TestSystemBackend_InternalUIResultantACL(t *testing.T) {
 	t.Parallel()
-	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-		NumCores:    1,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	resp, err := client.Auth().Token().Create(&api.TokenCreateRequest{
@@ -193,12 +189,7 @@ func TestSystemBackend_HAStatus(t *testing.T) {
 // authenticated and thus a 403 response is expected.
 func TestSystemBackend_VersionHistory_unauthenticated(t *testing.T) {
 	t.Parallel()
-	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-		NumCores:    1,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	client.SetToken("")
@@ -223,12 +214,7 @@ func TestSystemBackend_VersionHistory_unauthenticated(t *testing.T) {
 // core/versions storage entries, a single version entry should exist.
 func TestSystemBackend_VersionHistory_authenticated(t *testing.T) {
 	t.Parallel()
-	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
-		HandlerFunc: vaulthttp.Handler,
-		NumCores:    1,
-	})
-	cluster.Start()
-	defer cluster.Cleanup()
+	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
 	resp, err := client.Logical().List("sys/version-history")


### PR DESCRIPTION
… but has batteries included.  Very often tests call NewTestCluster but never talk to standbys or do anything that motivates a multi-node cluster.  NewTestSoloCluster will be faster and easier for the common case.