### PR TITLE
ui: pki prevent user from self cross-signing root issuer

### DIFF
--- a/ui/lib/pki/addon/components/pki-issuer-cross-sign.js
+++ b/ui/lib/pki/addon/components/pki-issuer-cross-sign.js
@@ -129,6 +129,11 @@ export default class PkiIssuerCrossSign extends Component {
       id: intName,
     });
 
+    // Return if user is attempting to self-sign issuer
+    if (existingIssuer.issuerId === this.args.parentIssuer.issuerId) {
+      throw new Error('Cross-signing a root issuer with itself must be performed manually using the CLI.');
+    }
+
     // Translate certificate values to API parameters to pass along: CSR -> Signed CSR -> Cross-Signed issuer
     // some of these values do not apply to a CSR, but pass anyway. If there is any issue parsing the certificate,
     // (ex. the certificate contains unsupported values) direct user to manually cross-sign via CLI


### PR DESCRIPTION
Before catching this error, step 4 was renaming the existing issuer instead of the new one. This is because during the issuer mapping process we use the key material of the existing issuer to find the new `issuer_id`, however in self-cross-signing this mapped to the existing `issuer_id` instead.

After discussing with @cipherboy we decided it best to prevents a user from cross-signing an issuer against itself in the UI. This is a more complex operation that should be handled manually by using the CLI. Now we check if the issuer inputted in "current issuer name" matches the id of the root issuer (where this cross-signing process begins) then we return and throw the error for that row. 

Note, any other valid issuers will still be cross-signed, this will only throw an error for invalid issuers. 

<img width="1047" alt="Screenshot 2023-05-30 at 2 33 09 PM" src="https://github.com/hashicorp/vault/assets/68122737/0159950f-e0da-44fd-8306-e14a8d5f1212">

