### PR TITLE
agent: Don't print errors on exit 0 in supervisor mode

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -846,7 +846,7 @@ func (c *AgentCommand) Run(args []string) int {
 		}
 
 		if exitCode != 0 {
-			c.logger.Error("runtime error encountered", "error", err)
+			c.logger.Error("runtime error encountered", "error", err, "exitCode", exitCode)
 			c.UI.Error("Error encountered during run, refer to logs for more details.")
 		}
 	}

--- a/command/agent.go
+++ b/command/agent.go
@@ -838,16 +838,21 @@ func (c *AgentCommand) Run(args []string) int {
 
 	var exitCode int
 	if err := g.Run(); err != nil {
-		c.logger.Error("runtime error encountered", "error", err)
-		c.UI.Error("Error encountered during run, refer to logs for more details.")
 		var processExitError *exec.ProcessExitError
 		if errors.As(err, &processExitError) {
 			exitCode = processExitError.ExitCode
 		} else {
 			exitCode = 1
 		}
+
+		if exitCode != 0 {
+			c.logger.Error("runtime error encountered", "error", err)
+			c.UI.Error("Error encountered during run, refer to logs for more details.")
+		}
 	}
+
 	c.notifySystemd(systemd.SdNotifyStopping)
+
 	return exitCode
 }
 


### PR DESCRIPTION
This is a small follow up to #20628 to prevent errors from being printed if the child process exits on its own with error code `0`.