### PR TITLE
Fix non-deterministic ordering of 'required' field in OpenAPI spec

### DIFF
--- a/changelog/20881.txt
+++ b/changelog/20881.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+sdk/framework: Fix non-deterministic ordering of 'required' fields in OpenAPI spec
+```

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -383,6 +383,10 @@ func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix st
 					s.Properties[name] = &p
 				}
 
+				// Make the ordering deterministic, so that the generated OpenAPI spec document, observed over several
+				// versions, doesn't contain spurious non-semantic changes.
+				sort.Strings(s.Required)
+
 				// If examples were given, use the first one as the sample
 				// of this schema.
 				if len(props.Examples) > 0 {


### PR DESCRIPTION
Fixes a minor annoyance I discovered whilst comparing before and after
OpenAPI specs whilst working on hashicorp/vault-client-go#180.

Sort the entries in a JSON array which has set semantics, after we
construct it by iterating a map (non-deterministic ordering).
