### PR TITLE
agent: Don't render templates to stdout in supervisor mode

### DIFF
--- a/command/agent/exec/exec.go
+++ b/command/agent/exec/exec.go
@@ -122,6 +122,9 @@ func (s *Server) Run(ctx context.Context, incomingVaultToken chan string) error 
 		return fmt.Errorf("template server failed to create: %w", err)
 	}
 
+	// prevent the templates from being rendered to stdout in "dry" mode
+	s.runner.SetOutStream(io.Discard)
+
 	s.numberOfTemplates = len(s.runner.TemplateConfigMapping())
 
 	for {
@@ -153,6 +156,10 @@ func (s *Server) Run(ctx context.Context, incomingVaultToken chan string) error 
 					s.logger.Error("template server failed with new Vault token", "error", err)
 					continue
 				}
+
+				// prevent the templates from being rendered to stdout in "dry" mode
+				s.runner.SetOutStream(io.Discard)
+
 				go s.runner.Start()
 			}
 


### PR DESCRIPTION
Since we are running consul-template manager in `dry` mode to render environment variable templates, they are by default [printed to `stdout`](https://github.com/hashicorp/consul-template/blob/29885821b9d62f06b28ce657e33923994069aa18/renderer/renderer.go#L98-L100), which means that secrets could be easily leaked.

___

This is a follow up to https://github.com/hashicorp/vault/pull/20628 and is part of a larger effort to introduce environment variable support in Vault Agent ([VLT-253](https://docs.google.com/document/d/1HLTkPtxUTtW-wMkePWoHmZoGt9lLg2POslt1ranaWE8/edit#)).





[VLT-253]: https://hashicorp.atlassian.net/browse/VLT-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ