### PR TITLE
Fix enabling tidy_acme=true in auto-tidy config

### DIFF
--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -72,23 +72,38 @@ type tidyStatus struct {
 }
 
 type tidyConfig struct {
-	Enabled                 bool          `json:"enabled"`
-	Interval                time.Duration `json:"interval_duration"`
-	CertStore               bool          `json:"tidy_cert_store"`
-	RevokedCerts            bool          `json:"tidy_revoked_certs"`
-	IssuerAssocs            bool          `json:"tidy_revoked_cert_issuer_associations"`
-	ExpiredIssuers          bool          `json:"tidy_expired_issuers"`
-	BackupBundle            bool          `json:"tidy_move_legacy_ca_bundle"`
-	TidyAcme                bool          `json:"tidy_acme"`
+	// AutoTidy config
+	Enabled  bool          `json:"enabled"`
+	Interval time.Duration `json:"interval_duration"`
+
+	// Tidy Operations
+	CertStore         bool `json:"tidy_cert_store"`
+	RevokedCerts      bool `json:"tidy_revoked_certs"`
+	IssuerAssocs      bool `json:"tidy_revoked_cert_issuer_associations"`
+	ExpiredIssuers    bool `json:"tidy_expired_issuers"`
+	BackupBundle      bool `json:"tidy_move_legacy_ca_bundle"`
+	RevocationQueue   bool `json:"tidy_revocation_queue"`
+	CrossRevokedCerts bool `json:"tidy_cross_cluster_revoked_certs"`
+	TidyAcme          bool `json:"tidy_acme"`
+
+	// Safety Buffers
 	SafetyBuffer            time.Duration `json:"safety_buffer"`
 	IssuerSafetyBuffer      time.Duration `json:"issuer_safety_buffer"`
+	QueueSafetyBuffer       time.Duration `json:"revocation_queue_safety_buffer"`
 	AcmeAccountSafetyBuffer time.Duration `json:"acme_account_safety_buffer"`
 	PauseDuration           time.Duration `json:"pause_duration"`
-	MaintainCount           bool          `json:"maintain_stored_certificate_counts"`
-	PublishMetrics          bool          `json:"publish_stored_certificate_count_metrics"`
-	RevocationQueue         bool          `json:"tidy_revocation_queue"`
-	QueueSafetyBuffer       time.Duration `json:"revocation_queue_safety_buffer"`
-	CrossRevokedCerts       bool          `json:"tidy_cross_cluster_revoked_certs"`
+
+	// Metrics.
+	MaintainCount  bool `json:"maintain_stored_certificate_counts"`
+	PublishMetrics bool `json:"publish_stored_certificate_count_metrics"`
+}
+
+func (tc *tidyConfig) IsAnyTidyEnabled() bool {
+	return tc.CertStore || tc.RevokedCerts || tc.IssuerAssocs || tc.ExpiredIssuers || tc.BackupBundle || tc.TidyAcme || tc.CrossRevokedCerts || tc.RevocationQueue
+}
+
+func (tc *tidyConfig) AnyTidyConfig() string {
+	return "tidy_cert_store / tidy_revoked_certs / tidy_revoked_cert_issuer_associations / tidy_expired_issuers / tidy_move_legacy_ca_bundle / tidy_revocation_queue / tidy_cross_cluster_revoked_certs / tidy_acme"
 }
 
 var defaultTidyConfig = tidyConfig{
@@ -809,8 +824,8 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 	b.startTidyOperation(req, config)
 
 	resp := &logical.Response{}
-	if !tidyCertStore && !tidyRevokedCerts && !tidyRevokedAssocs && !tidyExpiredIssuers && !tidyBackupBundle && !tidyRevocationQueue && !tidyCrossRevokedCerts {
-		resp.AddWarning("No targets to tidy; specify tidy_cert_store=true or tidy_revoked_certs=true or tidy_revoked_cert_issuer_associations=true or tidy_expired_issuers=true or tidy_move_legacy_ca_bundle=true or tidy_revocation_queue=true or tidy_cross_cluster_revoked_certs=true to start a tidy operation.")
+	if !config.IsAnyTidyEnabled() {
+		resp.AddWarning("Manual tidy requested but no tidy operations were set. Enable at least one tidy operation to be run (" + config.AnyTidyConfig() + ").")
 	} else {
 		resp.AddWarning("Tidy operation successfully started. Any information from the operation will be printed to Vault's server logs.")
 	}
@@ -1817,8 +1832,12 @@ func (b *backend) pathConfigAutoTidyWrite(ctx context.Context, req *logical.Requ
 		config.CrossRevokedCerts = crossRevokedRaw.(bool)
 	}
 
-	if config.Enabled && !(config.CertStore || config.RevokedCerts || config.IssuerAssocs || config.ExpiredIssuers || config.BackupBundle || config.RevocationQueue || config.CrossRevokedCerts) {
-		return logical.ErrorResponse("Auto-tidy enabled but no tidy operations were requested. Enable at least one tidy operation to be run (tidy_cert_store / tidy_revoked_certs / tidy_revoked_cert_issuer_associations / tidy_expired_issuers / tidy_move_legacy_ca_bundle / tidy_revocation_queue / tidy_cross_cluster_revoked_certs)."), nil
+	if tidyAcmeRaw, ok := d.GetOk("tidy_acme"); ok {
+		config.TidyAcme = tidyAcmeRaw.(bool)
+	}
+
+	if config.Enabled && !config.IsAnyTidyEnabled() {
+		return logical.ErrorResponse("Auto-tidy enabled but no tidy operations were requested. Enable at least one tidy operation to be run (" + config.AnyTidyConfig() + ")."), nil
 	}
 
 	if maintainCountEnabledRaw, ok := d.GetOk("maintain_stored_certificate_counts"); ok {

--- a/builtin/logical/pki/path_tidy_test.go
+++ b/builtin/logical/pki/path_tidy_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,6 +23,41 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestTidyConfigs(t *testing.T) {
+	t.Parallel()
+
+	var cfg tidyConfig
+	operations := strings.Split(cfg.AnyTidyConfig(), " / ")
+	t.Logf("Got tidy operations: %v", operations)
+
+	for _, operation := range operations {
+		b, s := CreateBackendWithStorage(t)
+
+		resp, err := CBWrite(b, s, "config/auto-tidy", map[string]interface{}{
+			"enabled": true,
+			operation: true,
+		})
+		requireSuccessNonNilResponse(t, resp, err, "expected to be able to enable auto-tidy operation "+operation)
+
+		resp, err = CBRead(b, s, "config/auto-tidy")
+		requireSuccessNonNilResponse(t, resp, err, "expected to be able to read auto-tidy operation for operation "+operation)
+		require.True(t, resp.Data[operation].(bool), "expected operation to be enabled after reading auto-tidy config "+operation)
+
+		resp, err = CBWrite(b, s, "tidy", map[string]interface{}{
+			operation: true,
+		})
+		requireSuccessNonNilResponse(t, resp, err, "expected to be able to start tidy operation with "+operation)
+		if len(resp.Warnings) > 0 {
+			t.Logf("got warnings while starting manual tidy: %v", resp.Warnings)
+			for _, warning := range resp.Warnings {
+				if strings.Contains(warning, "Manual tidy requested but no tidy operations were set.") {
+					t.Fatalf("expected to be able to enable tidy operation with just %v but got warning: %v / (resp=%v)", operation, warning, resp)
+				}
+			}
+		}
+	}
+}
 
 func TestAutoTidy(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
This should help to prevent the issue of missing tidy configurations in the future, by placing all related configuration options at the top with common validation logic.

However, short from this approach is ensuring that each config option can be specified independently. Thus, the test allows (for any added and properly tracked tidy operations) verifying that we have enabled proper storage/retention of that attribute.