### PR TITLE
Improve consul secrets plugin error for failed bootstrap

### DIFF
--- a/builtin/logical/consul/path_config.go
+++ b/builtin/logical/consul/path_config.go
@@ -135,7 +135,7 @@ func (b *backend) pathConfigAccessWrite(ctx context.Context, req *logical.Reques
 		}
 		token, _, err := client.ACL().Bootstrap()
 		if err != nil {
-			return logical.ErrorResponse("Token not provided and failed to bootstrap ACLs"), err
+			return logical.ErrorResponse("Token not provided and failed to bootstrap ACLs: %s", err), nil
 		}
 		config.Token = token.SecretID
 	}

--- a/changelog/20891.txt
+++ b/changelog/20891.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+secrets/consul: Improve error message when ACL bootstrapping fails.
+```
+


### PR DESCRIPTION
When returning a logical error, we need to include all of the information the user should see within the response. As seen in #18705, there is currently no indication of _why_ the bootstrapping failed when it does.

Before:

```shell-session
$ vault write consul/config/access \
    address="https://127.0.0.1:8500"
Error writing data to consul/config/access: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/consul/config/access
Code: 400. Errors:

* Token not provided and failed to bootstrap ACLs
```

After:

```shell-session
$ vault write consul/config/access \
    address="https://127.0.0.1:8500"
Error writing data to consul/config/access: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/consul/config/access
Code: 400. Errors:

* Token not provided and failed to bootstrap ACLs: Put "https://127.0.0.1:8500/v1/acl/bootstrap": http: server gave HTTP response to HTTPS client
```