### PR TITLE
UI cluster unseal bug

### DIFF
--- a/changelog/20897.txt
+++ b/changelog/20897.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes issue unsealing cluster for seal types other than shamir
+```

--- a/ui/app/controllers/vault/cluster/init.js
+++ b/ui/app/controllers/vault/cluster/init.js
@@ -48,6 +48,7 @@ export default Controller.extend(DEFAULTS, {
         if (isCloudSeal) {
           data.stored_shares = 1;
           data.recovery_shares = shares;
+          delete data.secret_shares; // API will throw an error if secret_shares is passed for seal types other than shamir (transit, AWSKMS etc.)
         }
       }
       if (data.secret_threshold) {
@@ -55,6 +56,7 @@ export default Controller.extend(DEFAULTS, {
         data.secret_threshold = threshold;
         if (isCloudSeal) {
           data.recovery_threshold = threshold;
+          delete data.secret_threshold; // API will throw an error if secret_threshold is passed for seal types other than shamir (transit, AWSKMS etc.)
         }
       }
       if (!data.use_pgp) {
@@ -63,7 +65,6 @@ export default Controller.extend(DEFAULTS, {
       if (data.use_pgp && isCloudSeal) {
         data.recovery_pgp_keys = data.pgp_keys;
       }
-
       if (!data.use_pgp_for_root) {
         delete data.root_token_pgp_key;
       }

--- a/ui/tests/acceptance/init-test.js
+++ b/ui/tests/acceptance/init-test.js
@@ -64,6 +64,22 @@ const SEAL_STATUS_RESPONSE = {
   initialized: false,
 };
 
+const assertRequest = (req, assert, isCloud) => {
+  const json = JSON.parse(req.requestBody);
+  for (const key of ['recovery_shares', 'recovery_threshold']) {
+    assert[isCloud ? 'ok' : 'notOk'](
+      json[key],
+      `requestBody ${isCloud ? 'includes' : 'does not include'} cloud seal specific attribute: ${key}`
+    );
+  }
+  for (const key of ['secret_shares', 'secret_threshold']) {
+    assert[isCloud ? 'notOk' : 'ok'](
+      json[key],
+      `requestBody ${isCloud ? 'does not include' : 'includes'} shamir specific attribute: ${key}`
+    );
+  }
+};
+
 module('Acceptance | init', function (hooks) {
   setupApplicationTest(hooks);
 
@@ -90,36 +106,32 @@ module('Acceptance | init', function (hooks) {
   });
 
   test('cloud seal init', async function (assert) {
-    assert.expect(4);
+    assert.expect(6);
+
     setInitResponse(this.server, CLOUD_SEAL_RESPONSE);
     setStatusResponse(this.server, CLOUD_SEAL_STATUS_RESPONSE);
+
     await initPage.init(5, 3);
+
     assert.strictEqual(
       initPage.keys.length,
       CLOUD_SEAL_RESPONSE.recovery_keys.length,
       'shows all of the recovery keys'
     );
     assert.strictEqual(initPage.buttonText, 'Continue to Authenticate', 'links to authenticate');
-    let { requestBody } = this.server.handledRequests.findBy('url', '/v1/sys/init');
-    requestBody = JSON.parse(requestBody);
-    for (const attr of ['recovery_shares', 'recovery_threshold']) {
-      assert.ok(requestBody[attr], `requestBody includes cloud seal specific attribute: ${attr}`);
-    }
+    assertRequest(this.server.handledRequests.findBy('url', '/v1/sys/init'), assert, true);
   });
 
   test('shamir seal init', async function (assert) {
-    assert.expect(4);
+    assert.expect(6);
+
     setInitResponse(this.server, SEAL_RESPONSE);
     setStatusResponse(this.server, SEAL_STATUS_RESPONSE);
 
     await initPage.init(3, 2);
+
     assert.strictEqual(initPage.keys.length, SEAL_RESPONSE.keys.length, 'shows all of the recovery keys');
     assert.strictEqual(initPage.buttonText, 'Continue to Unseal', 'links to unseal');
-
-    let { requestBody } = this.server.handledRequests.findBy('url', '/v1/sys/init');
-    requestBody = JSON.parse(requestBody);
-    for (const attr of ['recovery_shares', 'recovery_threshold']) {
-      assert.notOk(requestBody[attr], `requestBody does not include cloud seal specific attribute: ${attr}`);
-    }
+    assertRequest(this.server.handledRequests.findBy('url', '/v1/sys/init'), assert, false);
   });
 });


### PR DESCRIPTION
It was discovered that the `secret_shares` and `secret_threshold` properties are no longer allowed to be passed when unsealing a cloud seal type cluster. These properties were being passed in the UI causing the unseal to fail. Removing these properties from the payload for seal types other than `shamir` allows the cluster to be unsealed as expected. 

Error before fix:
![image](https://github.com/hashicorp/vault/assets/24611656/10a4d4a4-77aa-41fa-8a82-62ce7b90a500)

After fix:

https://github.com/hashicorp/vault/assets/24611656/e7270e83-8d94-41b5-ad59-750973c76b84

Resolves #20644
