### PR TITLE
Fix order, authorization, challenge status when failing to validate a challenge

### DIFF
--- a/builtin/logical/pki/acme_errors.go
+++ b/builtin/logical/pki/acme_errors.go
@@ -111,6 +111,19 @@ type ErrorResponse struct {
 	Subproblems []*ErrorResponse `json:"subproblems"`
 }
 
+func (e *ErrorResponse) MarshalForStorage() map[string]interface{} {
+	subProblems := []map[string]interface{}{}
+	for _, subProblem := range e.Subproblems {
+		subProblems = append(subProblems, subProblem.MarshalForStorage())
+	}
+	return map[string]interface{}{
+		"status":      e.StatusCode,
+		"type":        e.Type,
+		"detail":      e.Detail,
+		"subproblems": subProblems,
+	}
+}
+
 func (e *ErrorResponse) Marshal() (*logical.Response, error) {
 	body, err := json.Marshal(e)
 	if err != nil {
@@ -157,6 +170,12 @@ func TranslateError(given error) (*logical.Response, error) {
 		return logical.RespondWithStatusCode(nil, nil, http.StatusNotFound)
 	}
 
+	body := TranslateErrorToErrorResponse(given)
+
+	return body.Marshal()
+}
+
+func TranslateErrorToErrorResponse(given error) ErrorResponse {
 	// We're multierror aware here: if we're given a list of errors, assume
 	// they're structured so the first error is the outer error and the inner
 	// subproblems are subsequent in the multierror.
@@ -187,6 +206,5 @@ func TranslateError(given error) (*logical.Response, error) {
 
 		body.Subproblems = append(body.Subproblems, &sub)
 	}
-
-	return body.Marshal()
+	return body
 }

--- a/builtin/logical/pki/path_acme_order.go
+++ b/builtin/logical/pki/path_acme_order.go
@@ -234,11 +234,9 @@ func (b *backend) acmeFinalizeOrderHandler(ac *acmeContext, _ *logical.Request, 
 		return nil, err
 	}
 
-	if order.Status == ACMEOrderPending {
-		// Lets see if we can update our order status to ready if all the authorizations have been completed.
-		if requiredAuthorizationsCompleted(b, ac, uc, order) {
-			order.Status = ACMEOrderReady
-		}
+	order.Status, err = computeOrderStatus(ac, uc, order)
+	if err != nil {
+		return nil, err
 	}
 
 	if order.Status != ACMEOrderReady {
@@ -293,23 +291,62 @@ func (b *backend) acmeFinalizeOrderHandler(ac *acmeContext, _ *logical.Request, 
 	return formatOrderResponse(ac, order), nil
 }
 
-func requiredAuthorizationsCompleted(b *backend, ac *acmeContext, uc *jwsCtx, order *acmeOrder) bool {
-	if len(order.AuthorizationIds) == 0 {
-		return false
+func computeOrderStatus(ac *acmeContext, uc *jwsCtx, order *acmeOrder) (ACMEOrderStatusType, error) {
+	// If we reached a final stage, no use computing anything else
+	if order.Status == ACMEOrderInvalid || order.Status == ACMEOrderValid {
+		return order.Status, nil
 	}
 
+	// We aren't in a final state yet, check for expiry
+	if time.Now().After(order.Expires) {
+		return ACMEOrderInvalid, nil
+	}
+
+	// Intermediary steps passed authorizations should short circuit us as well
+	if order.Status == ACMEOrderReady || order.Status == ACMEOrderProcessing {
+		return order.Status, nil
+	}
+
+	// If we have no authorizations attached to the order, nothing to compute either
+	if len(order.AuthorizationIds) == 0 {
+		return ACMEOrderPending, nil
+	}
+
+	anyFailed := false
+	allPassed := true
 	for _, authId := range order.AuthorizationIds {
-		authorization, err := b.acmeState.LoadAuthorization(ac, uc, authId)
+		authorization, err := ac.getAcmeState().LoadAuthorization(ac, uc, authId)
 		if err != nil {
-			return false
+			return order.Status, fmt.Errorf("failed loading authorization: %s: %w", authId, err)
+		}
+
+		if authorization.Status == ACMEAuthorizationPending {
+			allPassed = false
+			continue
 		}
 
 		if authorization.Status != ACMEAuthorizationValid {
-			return false
+			// Per RFC 8555 - 7.1.6. Status Changes
+			// The order also moves to the "invalid" state if it expires or
+			// one of its authorizations enters a final state other than
+			// "valid" ("expired", "revoked", or "deactivated").
+			allPassed = false
+			anyFailed = true
+			break
 		}
 	}
 
-	return true
+	if anyFailed {
+		return ACMEOrderInvalid, nil
+	}
+
+	if allPassed {
+		return ACMEOrderReady, nil
+	}
+
+	// The order has not expired, no authorizations have yet to be marked as failed
+	// nor have we passed them all.
+	return ACMEOrderPending, nil
 }
 
 func validateCsrNotUsingAccountKey(csr *x509.CertificateRequest, uc *jwsCtx) error {
@@ -551,11 +588,9 @@ func (b *backend) acmeGetOrderHandler(ac *acmeContext, _ *logical.Request, field
 		return nil, err
 	}
 
-	if order.Status == ACMEOrderPending {
-		// Lets see if we can update our order status to ready if all the authorizations have been completed.
-		if requiredAuthorizationsCompleted(b, ac, uc, order) {
-			order.Status = ACMEOrderReady
-		}
+	order.Status, err = computeOrderStatus(ac, uc, order)
+	if err != nil {
+		return nil, err
 	}
 
 	// Per RFC 8555 -> 7.1.3.  Order Objects


### PR DESCRIPTION
 - We now populate the error field within challenges with the error results from the challenge
 - Update the status of the challenge and authorizations to invalid when we give up on the challenge
 - Verify that only a single challenge within a given authorization can be accepted to avoid race conditions.
 - Also address the computed ACME order status 


This addresses: VAULT-16701