### PR TITLE
UI: Scroll to top after PKI form save

### DIFF
--- a/ui/lib/pki/addon/components/pki-generate-csr.ts
+++ b/ui/lib/pki/addon/components/pki-generate-csr.ts
@@ -91,9 +91,11 @@ export default class PkiGenerateCsrComponent extends Component<Args> {
         const useIssuer = yield this.getCapability();
         yield model.save({ adapterOptions: { actionType: 'generate-csr', useIssuer } });
         this.flashMessages.success('Successfully generated CSR.');
+        // This component shows the results, but call `onSave` for any side effects on parent
         if (onSave) {
           onSave();
         }
+        window?.scrollTo(0, 0);
       } else {
         this.modelValidations = state;
         this.alert = invalidFormMessage;

--- a/ui/lib/pki/addon/components/pki-generate-root.ts
+++ b/ui/lib/pki/addon/components/pki-generate-root.ts
@@ -112,9 +112,11 @@ export default class PkiGenerateRootComponent extends Component<Args> {
       // this way an issuer_id exists for backend to interpolate into the template
       yield this.setUrls();
       this.flashMessages.success('Successfully generated root.');
+      // This component shows the results, but call `onSave` for any side effects on parent
       if (this.args.onSave) {
         this.args.onSave();
       }
+      window?.scrollTo(0, 0);
     } catch (e) {
       this.errorBanner = errorMessage(e);
       this.invalidFormAlert = 'There was a problem generating the root.';

--- a/ui/lib/pki/addon/components/pki-import-pem-bundle.ts
+++ b/ui/lib/pki/addon/components/pki-import-pem-bundle.ts
@@ -88,6 +88,7 @@ export default class PkiImportPemBundle extends Component<Args> {
       if (this.args.onSave) {
         this.args.onSave();
       }
+      window?.scrollTo(0, 0);
     } catch (error) {
       this.errorBanner = errorMessage(error);
     }

--- a/ui/lib/pki/addon/components/pki-sign-intermediate-form.ts
+++ b/ui/lib/pki/addon/components/pki-sign-intermediate-form.ts
@@ -40,6 +40,7 @@ export default class PkiSignIntermediateFormComponent extends Component<Args> {
     try {
       yield this.args.model.save();
       this.flashMessages.success('Successfully signed CSR.');
+      window?.scrollTo(0, 0);
     } catch (e) {
       this.errorBanner = errorMessage(e);
       this.inlineFormAlert = 'There was a problem signing the CSR.';


### PR DESCRIPTION
For certain PKI forms we show the results on the same page rather than transitioning to a new page. This PR adds a window scroll back to the top of the page for those forms, so that it feels like other post-save transitions. 