### PR TITLE
agent: Allow for a 'cache' stanza in environment template configuration

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -517,7 +517,7 @@ func (c *AgentCommand) Run(args []string) int {
 	var listeners []net.Listener
 
 	// If there are templates, add an in-process listener
-	if len(config.Templates) > 0 {
+	if len(config.Templates) > 0 || len(config.EnvTemplates) > 0 {
 		config.Listeners = append(config.Listeners, &configutil.Listener{Type: listenerutil.BufConnType})
 	}
 

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -311,7 +311,7 @@ func (c *Config) ValidateConfig() error {
 	}
 
 	if c.Cache != nil {
-		if len(c.Listeners) < 1 && len(c.Templates) < 1 {
+		if len(c.Listeners) < 1 && len(c.Templates) < 1 && len(c.EnvTemplates) < 1 {
 			return fmt.Errorf("enabling the cache requires at least 1 template or 1 listener to be defined")
 		}
 

--- a/command/agent/config/test-fixtures/config-env-templates-complex.hcl
+++ b/command/agent/config/test-fixtures/config-env-templates-complex.hcl
@@ -9,6 +9,8 @@ auto_auth {
   }
 }
 
+cache {}
+
 template_config {
   static_secret_render_interval = "5m"
   exit_on_retry_failure         = true


### PR DESCRIPTION
Without this change we are currently getting the following error when `cache {}` is defined in agent config file:

```sh
error validating configuration: enabling the cache requires at least 1 template or 1 listener to be defined
```

_____

This PR is part of a larger effort to implement secrets as environment variable support in agent ([VLT-253](https://docs.google.com/document/d/1HLTkPtxUTtW-wMkePWoHmZoGt9lLg2POslt1ranaWE8/edit#))

[VLT-253]: https://hashicorp.atlassian.net/browse/VLT-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ