### PR TITLE
Add more parallelism to raft tests.

### DIFF
--- a/vault/external_tests/raft/raft_autopilot_test.go
+++ b/vault/external_tests/raft/raft_autopilot_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestRaft_Autopilot_Disable(t *testing.T) {
+	t.Parallel()
 	cluster, _ := raftCluster(t, &RaftClusterOpts{
 		DisableFollowerJoins: true,
 		InmemCluster:         true,
@@ -44,6 +45,7 @@ func TestRaft_Autopilot_Disable(t *testing.T) {
 }
 
 func TestRaft_Autopilot_Stabilization_And_State(t *testing.T) {
+	t.Parallel()
 	cluster, _ := raftCluster(t, &RaftClusterOpts{
 		DisableFollowerJoins: true,
 		InmemCluster:         true,
@@ -115,6 +117,7 @@ func TestRaft_Autopilot_Stabilization_And_State(t *testing.T) {
 }
 
 func TestRaft_Autopilot_Configuration(t *testing.T) {
+	t.Parallel()
 	cluster, _ := raftCluster(t, &RaftClusterOpts{
 		DisableFollowerJoins: true,
 		InmemCluster:         true,
@@ -202,6 +205,7 @@ func TestRaft_Autopilot_Configuration(t *testing.T) {
 // TestRaft_Autopilot_Stabilization_Delay verifies that if a node takes a long
 // time to become ready, it doesn't get promoted to voter until then.
 func TestRaft_Autopilot_Stabilization_Delay(t *testing.T) {
+	t.Parallel()
 	conf, opts := teststorage.ClusterSetup(nil, nil, teststorage.RaftBackendSetup)
 	conf.DisableAutopilot = false
 	opts.InmemClusterLayers = true
@@ -307,6 +311,7 @@ func TestRaft_Autopilot_Stabilization_Delay(t *testing.T) {
 }
 
 func TestRaft_AutoPilot_Peersets_Equivalent(t *testing.T) {
+	t.Parallel()
 	cluster, _ := raftCluster(t, &RaftClusterOpts{
 		InmemCluster:         true,
 		EnableAutopilot:      true,
@@ -355,6 +360,7 @@ func TestRaft_AutoPilot_Peersets_Equivalent(t *testing.T) {
 // TestRaft_VotersStayVoters ensures that autopilot doesn't demote a node just
 // because it hasn't been heard from in some time.
 func TestRaft_VotersStayVoters(t *testing.T) {
+	t.Parallel()
 	cluster, _ := raftCluster(t, &RaftClusterOpts{
 		DisableFollowerJoins: true,
 		InmemCluster:         true,
@@ -410,6 +416,7 @@ func TestRaft_VotersStayVoters(t *testing.T) {
 // The expected behavior is that removing a node from a 3 node cluster wouldn't
 // remove it from Raft until a replacement voter had joined and stabilized/been promoted.
 func TestRaft_Autopilot_DeadServerCleanup(t *testing.T) {
+	t.Parallel()
 	conf, opts := teststorage.ClusterSetup(nil, nil, teststorage.RaftBackendSetup)
 	conf.DisableAutopilot = false
 	opts.NumCores = 4
@@ -495,6 +502,7 @@ func TestRaft_Autopilot_DeadServerCleanup(t *testing.T) {
 }
 
 func joinAndStabilizeAndPromote(t *testing.T, core *vault.TestClusterCore, client *api.Client, cluster *vault.TestCluster, config *api.AutopilotConfig, nodeID string, numServers int) {
+	t.Helper()
 	joinAndStabilize(t, core, client, cluster, config, nodeID, numServers)
 
 	// Now that the server is stable, wait for autopilot to reconcile and
@@ -551,6 +559,7 @@ func joinAndStabilize(t *testing.T, core *vault.TestClusterCore, client *api.Cli
 // joinAsVoterAndUnseal joins the specified core to the specified cluster as a voter and unseals it.
 // It will wait (up to a timeout) for the core to be fully unsealed before returning
 func joinAsVoterAndUnseal(t *testing.T, core *vault.TestClusterCore, cluster *vault.TestCluster) {
+	t.Helper()
 	joinAndUnseal(t, core, cluster, false, true)
 }
 
@@ -558,6 +567,7 @@ func joinAsVoterAndUnseal(t *testing.T, core *vault.TestClusterCore, cluster *va
 // You can specify if the core should be joined as a voter/non-voter,
 // and whether to wait (up to a timeout) for the core to be unsealed before returning.
 func joinAndUnseal(t *testing.T, core *vault.TestClusterCore, cluster *vault.TestCluster, nonVoter bool, waitForUnseal bool) {
+	t.Helper()
 	leader, leaderAddr := clusterLeader(t, cluster)
 	_, err := core.JoinRaftCluster(namespace.RootContext(context.Background()), []*raft.LeaderJoinInfo{
 		{
@@ -577,6 +587,7 @@ func joinAndUnseal(t *testing.T, core *vault.TestClusterCore, cluster *vault.Tes
 
 // clusterLeader gets the leader node and its address from the specified cluster
 func clusterLeader(t *testing.T, cluster *vault.TestCluster) (*vault.TestClusterCore, string) {
+	t.Helper()
 	for _, core := range cluster.Cores {
 		isLeader, addr, _, err := core.Leader()
 		require.NoError(t, err)
@@ -592,6 +603,7 @@ func clusterLeader(t *testing.T, cluster *vault.TestCluster) (*vault.TestCluster
 // setupLeaderAndUnseal configures and unseals the leader node.
 // It will wait until the node is active before returning the core and the address of the leader.
 func setupLeaderAndUnseal(t *testing.T, cluster *vault.TestCluster) (*vault.TestClusterCore, *testhelpers.TestRaftServerAddressProvider) {
+	t.Helper()
 	leader, _ := clusterLeader(t, cluster)
 
 	// Lots of tests seem to do this when they deal with a TestRaftServerAddressProvider, it makes the test work rather than error out.
@@ -609,6 +621,7 @@ func setupLeaderAndUnseal(t *testing.T, cluster *vault.TestCluster) (*vault.Test
 // waitForCoreUnseal waits until the specified core is unsealed.
 // It fails the calling test if the deadline has elapsed and the core is still sealed.
 func waitForCoreUnseal(t *testing.T, core *vault.TestClusterCore) {
+	t.Helper()
 	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
 		if !core.Sealed() {
@@ -622,6 +635,7 @@ func waitForCoreUnseal(t *testing.T, core *vault.TestClusterCore) {
 // isHealthyAfterStabilization will use the supplied leader core to query the
 // health of Raft Autopilot just after the specified deadline.
 func isHealthyAfterStabilization(t *testing.T, leaderCore *vault.TestClusterCore, stabilizationTime time.Duration) bool {
+	t.Helper()
 	timeoutGrace := 2 * time.Second
 	time.Sleep(stabilizationTime + timeoutGrace)
 	state, err := leaderCore.Client.Sys().RaftAutopilotState()

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -567,6 +567,7 @@ func TestRaft_SnapshotAPI_MidstreamFailure(t *testing.T) {
 }
 
 func TestRaft_SnapshotAPI_RekeyRotate_Backward(t *testing.T) {
+	t.Parallel()
 	type testCase struct {
 		Name               string
 		Rekey              bool
@@ -753,6 +754,7 @@ func TestRaft_SnapshotAPI_RekeyRotate_Backward(t *testing.T) {
 }
 
 func TestRaft_SnapshotAPI_RekeyRotate_Forward(t *testing.T) {
+	t.Parallel()
 	type testCase struct {
 		Name               string
 		Rekey              bool


### PR DESCRIPTION
The raft tests are our slowest test package, which means speeding them up speeds up our feedback loop, since test CI is as slow as the slowest package.  I might be making them flakier by doing this, but let's try it, we can always revert.