### PR TITLE
Remove transform from the transit key import cli help text

### DIFF
--- a/command/transit.go
+++ b/command/transit.go
@@ -27,7 +27,7 @@ Usage: vault transit <subcommand> [options] [args]
   Engine. Here are some simple examples, and more detailed examples are
   available in the subcommands or the documentation.
 
-  To import a key into the specified Transit or Transform mount:
+  To import a key into the specified Transit mount:
 
   $ vault transit import transit/keys/newly-imported @path/to/key type=rsa-2048
 

--- a/command/transit_import_key.go
+++ b/command/transit_import_key.go
@@ -35,18 +35,18 @@ type TransitImportCommand struct {
 }
 
 func (c *TransitImportCommand) Synopsis() string {
-	return "Import a key into the Transit or Transform secrets engines."
+	return "Import a key into the Transit secrets engines."
 }
 
 func (c *TransitImportCommand) Help() string {
 	helpText := `
 Usage: vault transit import PATH KEY [options...]
 
-  Using the Transit or Transform key wrapping system, imports key material from
+  Using the Transit key wrapping system, imports key material from
   the base64 encoded KEY (either directly on the CLI or via @path notation),
   into a new key whose API path is PATH.  To import a new version into an
   existing key, use import_version.  The remaining options after KEY (key=value
-  style) are passed on to the Transit or Transform create key endpoint.  If your
+  style) are passed on to the Transit create key endpoint.  If your
   system or device natively supports the RSA AES key wrap mechanism (such as
   the PKCS#11 mechanism CKM_RSA_AES_KEY_WRAP), you should use it directly
   rather than this command.

--- a/command/transit_import_key_version.go
+++ b/command/transit_import_key_version.go
@@ -20,18 +20,18 @@ type TransitImportVersionCommand struct {
 }
 
 func (c *TransitImportVersionCommand) Synopsis() string {
-	return "Import key material into a new key version in the Transit or Transform secrets engines."
+	return "Import key material into a new key version in the Transit secrets engines."
 }
 
 func (c *TransitImportVersionCommand) Help() string {
 	helpText := `
 Usage: vault transit import-version PATH KEY [...]
 
-  Using the Transit or Transform key wrapping system, imports key material from
+  Using the Transit key wrapping system, imports key material from
   the base64 encoded KEY (either directly on the CLI or via @path notation),
-  into a new key whose API path is PATH.  To import a new Transit or Transform
+  into a new key whose API path is PATH.  To import a new Transit
   key, use the import command instead.  The remaining options after KEY
-  (key=value style) are passed on to the Transit or Transform create key endpoint.
+  (key=value style) are passed on to the Transit create key endpoint.
   If your system or device natively supports the RSA AES key wrap mechanism
   (such as the PKCS#11 mechanism CKM_RSA_AES_KEY_WRAP), you should use it
   directly rather than this command.


### PR DESCRIPTION
 - The transit import and import-version command line help texts referenced that it worked with Transform which it doesn't, so remove them as we now also have a dedicated transform command 
