### PR TITLE
Escape the ACME eab key in the certbot command line within integration tests

### DIFF
--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -235,7 +235,7 @@ func SubtestACMECertbotEab(t *testing.T, cluster *VaultPkiCluster) {
 		"--no-eff-email",
 		"--email", "certbot.client@dadgarcorp.com",
 		"--eab-kid", eabId,
-		"--eab-hmac-key", base64EabKey,
+		"--eab-hmac-key='" + base64EabKey + "'",
 		"--agree-tos",
 		"--no-verify-ssl",
 		"--standalone",


### PR DESCRIPTION
 - Saw a test failure when we generated an EAB key that started with -

```
acme_test.go:249: Certbot Issue Command: [certbot certonly
--no-eff-email --email certbot.client@dadgarcorp.com --eab-kid
0246913b-4382-10fc-bf57-b05f2dad0f13 --eab-hmac-key
-Avt5q_KUWWWL8slYJn_MdmiCA-jzvif6Tpt45gQNR0 --agree-tos --no-verify-ssl
--standalone --non-interactive --server

...

certbot: error: argument --eab-hmac-key: expected one argument
```