### PR TITLE
Code Cleanup Around Audit Backends

### DIFF
--- a/changelog/20933.txt
+++ b/changelog/20933.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: remove unnecessary *BarrierView field from backendEntry struct
+```

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -155,7 +155,7 @@ func (c *Core) enableAudit(ctx context.Context, entry *MountEntry, updateStorage
 	c.audit = newTable
 
 	// Register the backend
-	c.auditBroker.Register(entry.Path, backend, view, entry.Local)
+	c.auditBroker.Register(entry.Path, backend, entry.Local)
 	if c.logger.IsInfo() {
 		c.logger.Info("enabled audit backend", "path", entry.Path, "type", entry.Type)
 	}
@@ -416,7 +416,7 @@ func (c *Core) setupAudits(ctx context.Context) error {
 		}
 
 		// Mount the backend
-		broker.Register(entry.Path, backend, view, entry.Local)
+		broker.Register(entry.Path, backend, entry.Local)
 
 		successCount++
 	}

--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -19,7 +19,6 @@ import (
 
 type backendEntry struct {
 	backend audit.Backend
-	view    *BarrierView
 	local   bool
 }
 
@@ -41,12 +40,11 @@ func NewAuditBroker(log log.Logger) *AuditBroker {
 }
 
 // Register is used to add new audit backend to the broker
-func (a *AuditBroker) Register(name string, b audit.Backend, v *BarrierView, local bool) {
+func (a *AuditBroker) Register(name string, b audit.Backend, local bool) {
 	a.Lock()
 	defer a.Unlock()
 	a.backends[name] = backendEntry{
 		backend: b,
-		view:    v,
 		local:   local,
 	}
 }

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -44,7 +44,7 @@ func TestAudit_ReadOnlyViewDuringMount(t *testing.T) {
 		Path:  "foo",
 		Type:  "noop",
 	}
-	err := c.enableAudit(namespace.RootContext(nil), me, true)
+	err := c.enableAudit(namespace.RootContext(context.TODO()), me, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestCore_EnableAudit(t *testing.T) {
 		Path:  "foo",
 		Type:  "noop",
 	}
-	err := c.enableAudit(namespace.RootContext(nil), me, true)
+	err := c.enableAudit(namespace.RootContext(context.TODO()), me, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -239,7 +239,7 @@ func TestCore_DisableAudit(t *testing.T) {
 	c, keys, _ := TestCoreUnsealed(t)
 	c.auditBackends["noop"] = corehelpers.NoopAuditFactory(nil)
 
-	existed, err := c.disableAudit(namespace.RootContext(nil), "foo", true)
+	existed, err := c.disableAudit(namespace.RootContext(context.TODO()), "foo", true)
 	if existed && err != nil {
 		t.Fatalf("existed: %v; err: %v", existed, err)
 	}
@@ -249,12 +249,12 @@ func TestCore_DisableAudit(t *testing.T) {
 		Path:  "foo",
 		Type:  "noop",
 	}
-	err = c.enableAudit(namespace.RootContext(nil), me, true)
+	err = c.enableAudit(namespace.RootContext(context.TODO()), me, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	existed, err = c.disableAudit(namespace.RootContext(nil), "foo", true)
+	existed, err = c.disableAudit(namespace.RootContext(context.TODO()), "foo", true)
 	if !existed || err != nil {
 		t.Fatalf("existed: %v; err: %v", existed, err)
 	}
@@ -403,8 +403,8 @@ func TestAuditBroker_LogRequest(t *testing.T) {
 		if !reflect.DeepEqual(a.Req[0], req) {
 			t.Fatalf("Bad: %#v\n wanted %#v", a.Req[0], req)
 		}
-		if !reflect.DeepEqual(a.ReqErrs[0], reqErrs) {
-			t.Fatalf("Bad: %#v", a.ReqErrs[0])
+		if a.ReqErrs[0].Error() != reqErrs.Error() {
+			t.Fatalf("expected %v, got %v", a.ReqErrs[0].Error(), reqErrs.Error())
 		}
 	}
 
@@ -504,8 +504,8 @@ func TestAuditBroker_LogResponse(t *testing.T) {
 		if !reflect.DeepEqual(a.Resp[0], resp) {
 			t.Fatalf("Bad: %#v", a.Resp[0])
 		}
-		if !reflect.DeepEqual(a.RespErrs[0], respErr) {
-			t.Fatalf("Expected\n%v\nGot\n%#v", respErr, a.RespErrs[0])
+		if a.RespErrs[0].Error() != respErr.Error() {
+			t.Fatalf("expected %v, got %v", respErr, a.RespErrs[0])
 		}
 	}
 

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -343,8 +343,8 @@ func TestAuditBroker_LogRequest(t *testing.T) {
 	b := NewAuditBroker(l)
 	a1 := corehelpers.TestNoopAudit(t, nil)
 	a2 := corehelpers.TestNoopAudit(t, nil)
-	b.Register("foo", a1, nil, false)
-	b.Register("bar", a2, nil, false)
+	b.Register("foo", a1, false)
+	b.Register("bar", a2, false)
 
 	auth := &logical.Auth{
 		ClientToken: "foo",
@@ -430,8 +430,8 @@ func TestAuditBroker_LogResponse(t *testing.T) {
 	b := NewAuditBroker(l)
 	a1 := corehelpers.TestNoopAudit(t, nil)
 	a2 := corehelpers.TestNoopAudit(t, nil)
-	b.Register("foo", a1, nil, false)
-	b.Register("bar", a2, nil, false)
+	b.Register("foo", a1, false)
+	b.Register("bar", a2, false)
 
 	auth := &logical.Auth{
 		NumUses:     10,
@@ -537,8 +537,8 @@ func TestAuditBroker_AuditHeaders(t *testing.T) {
 	view := NewBarrierView(barrier, "headers/")
 	a1 := corehelpers.TestNoopAudit(t, nil)
 	a2 := corehelpers.TestNoopAudit(t, nil)
-	b.Register("foo", a1, nil, false)
-	b.Register("bar", a2, nil, false)
+	b.Register("foo", a1, false)
+	b.Register("bar", a2, false)
 
 	auth := &logical.Auth{
 		ClientToken: "foo",

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -44,7 +44,7 @@ func TestAudit_ReadOnlyViewDuringMount(t *testing.T) {
 		Path:  "foo",
 		Type:  "noop",
 	}
-	err := c.enableAudit(namespace.RootContext(context.TODO()), me, true)
+	err := c.enableAudit(namespace.RootContext(context.Background()), me, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestCore_EnableAudit(t *testing.T) {
 		Path:  "foo",
 		Type:  "noop",
 	}
-	err := c.enableAudit(namespace.RootContext(context.TODO()), me, true)
+	err := c.enableAudit(namespace.RootContext(context.Background()), me, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -239,7 +239,7 @@ func TestCore_DisableAudit(t *testing.T) {
 	c, keys, _ := TestCoreUnsealed(t)
 	c.auditBackends["noop"] = corehelpers.NoopAuditFactory(nil)
 
-	existed, err := c.disableAudit(namespace.RootContext(context.TODO()), "foo", true)
+	existed, err := c.disableAudit(namespace.RootContext(context.Background()), "foo", true)
 	if existed && err != nil {
 		t.Fatalf("existed: %v; err: %v", existed, err)
 	}
@@ -249,12 +249,12 @@ func TestCore_DisableAudit(t *testing.T) {
 		Path:  "foo",
 		Type:  "noop",
 	}
-	err = c.enableAudit(namespace.RootContext(context.TODO()), me, true)
+	err = c.enableAudit(namespace.RootContext(context.Background()), me, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	existed, err = c.disableAudit(namespace.RootContext(context.TODO()), "foo", true)
+	existed, err = c.disableAudit(namespace.RootContext(context.Background()), "foo", true)
 	if !existed || err != nil {
 		t.Fatalf("existed: %v; err: %v", existed, err)
 	}


### PR DESCRIPTION
This PR cleans up an unused field in the **backendEntry** struct and removes function arguments that were only needed to initialize that unnecessary field in the struct.

As an added bonus, the few compiler warnings that were reported in the _audit_test.go_ file were also resolved.