### PR TITLE
Change from default_role to default_directory_policy

### DIFF
--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -333,7 +333,11 @@ func getAcmeRoleAndIssuer(sc *storageContext, data *framework.FieldData, config 
 				Name:    requestedRole,
 			})
 		case Role:
-			role, err = getAndValidateAcmeRole(sc, requestedRole)
+			defaultRole, err := getDefaultDirectoryPolicyRole(config.DefaultDirectoryPolicy)
+			if err != nil {
+				return nil, nil, err
+			}
+			role, err = getAndValidateAcmeRole(sc, defaultRole)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -320,6 +320,9 @@ func getAcmeRoleAndIssuer(sc *storageContext, data *framework.FieldData, config 
 
 	if len(requestedRole) == 0 { // Default Directory
 		policyType, err := getDefaultDirectoryPolicyType(config.DefaultDirectoryPolicy)
+		if err != nil {
+			return nil, nil, err
+		}
 		switch policyType {
 		case Forbid:
 			return nil, nil, fmt.Errorf("%w: default directory not allowed by ACME policy", ErrServerInternal)

--- a/builtin/logical/pki/path_config_acme.go
+++ b/builtin/logical/pki/path_config_acme.go
@@ -342,6 +342,9 @@ func getDefaultDirectoryPolicyType(defaultDirectoryPolicy string) (DefaultDirect
 	case defaultDirectoryPolicy == "sign-verbatim":
 		return SignVerbatim, nil
 	case strings.HasPrefix(defaultDirectoryPolicy, "role:"):
+		if len(defaultDirectoryPolicy) == 5 {
+			return Forbid, fmt.Errorf("no role specified by policy %v", defaultDirectoryPolicy)
+		}
 		return Role, nil
 	default:
 		return Forbid, fmt.Errorf("string %v not a valid Default Directory Policy", defaultDirectoryPolicy)

--- a/builtin/logical/pki/path_config_acme.go
+++ b/builtin/logical/pki/path_config_acme.go
@@ -246,7 +246,8 @@ func (b *backend) pathAcmeWrite(ctx context.Context, req *logical.Request, d *fr
 		if err != nil {
 			return nil, fmt.Errorf("default directory policy role %v is not a valid ACME role: %w", defaultDirectoryRoleName, err)
 		}
-
+	default:
+		return nil, fmt.Errorf("validation for the type of policy defined by %v is undefined", config.DefaultDirectoryPolicy)
 	}
 
 	// Validate Allowed Roles

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -142,17 +142,21 @@ $ certbot certonly --server https://localhost:8200/v1/pki/acme/directory ...
 These endpoints are unauthenticated from a Vault authentication model, but
 internally authenticated via the ACME protocol.
 
-| Method | Path                                                 | Issuer                | Role                                 |
-| :----- | :--------------------------------------------------- | :-------------------- | :----------------------------------- |
-| `ACME` | `/pki/acme/directory`                                | `default`             | Sign-Verbatim or Specified in Config |
-| `ACME` | `/pki/issuer/:issuer_ref/acme/directory`             | `:issuer_ref`         | Sign-Verbatim or Specified in Config |
-| `ACME` | `/pki/roles/:role/acme/directory`                    | Specified by the role | `:role`                              |
-| `ACME` | `/pki/issuer/:issuer_ref/roles/:role/acme/directory` | `:issuer_ref`         | `:role`                              |
+| Method | Path                                                 | Default Directory Policy | Issuer                | Role          |
+|:-------|:-----------------------------------------------------|:-------------------------|:----------------------|:--------------|
+| `ACME` | `/pki/acme/directory`                                | `sign-verbatim`          | `default`             | Sign-Verbatim |
+| `ACME` | `/pki/acme/directory`                                | `role:role_ref`          | Specified by the role | `:role_ref`   |
+| `ACME` | `/pki/issuer/:issuer_ref/acme/directory`             | `sign-verbatim`          | `:issuer_ref`         | Sign-Verbatim |
+| `ACME` | `/pki/issuer/:issuer_ref/acme/directory`             | `role:role_ref`          | `:issuer_ref`         | `:role_ref`   |
+| `ACME` | `/pki/roles/:role/acme/directory`                    | (any)                    | Specified by the role | `:role`       |
+| `ACME` | `/pki/issuer/:issuer_ref/roles/:role/acme/directory` | (any)                    | `:issuer_ref`         | `:role`       |
 
-When a role is not specified (for the first two directory URLs), and no
-`default_role` is specified in the [ACME configuration](#set-acme-configuration),
+When a role is not specified (for the first two directory URLs, or four lines
+in the table), behavior is specified by the `default_directory_policy` in the
+[ACME configuration](#set-acme-configuration).  These directories can also be
+forbidden by setting that policy as `forbid`.  If the policy is `sign-verbatim`
 then _any_ identifier for which the client can prove ownership of will be
-issued for. This is similar to using the [Sign Verbatim](#sign-verbatim)
+issued for.  This is similar to using the [Sign Verbatim](#sign-verbatim)
 endpoint, but with additional verification that the client has proven
 ownership (within the ACME protocol) of the requested certificate
 identifiers.
@@ -340,7 +344,7 @@ $ curl \
     "allowed_roles": [
       "*"
     ],
-    "default_role": "",
+    "default_directory_policy": "sign-verbatim",
     "dns_resolver": "",
     "eab_policy": "not-required",
     "enabled": true
@@ -365,13 +369,14 @@ mount.
    allows every issuer within the mount.
 
  - `allowed_roles` `(list: ["*"])` - Specifies a list of roles to allow to
-   issue certificates via explicit ACME paths. If no `default_role` is
-   specified, sign-verbatim-like issuance on the default ACME directory
-   will still occur.
+   issue certificates via explicit ACME paths.  The default value `*` allows
+   every role within the mount to be used.  If the `default_directory_policy`
+   specifies a role, it must be allowed under this configuration.
 
- - `default_role` `(string: "")` - Optionally specifies a role to enforce
-   on the default ACME directory. Must be present in `allowed_roles` if
-   set.
+ - `default_directory_policy` `(string: "sign-verbatim")` - Specifies the
+   behavior of the default ACME director.  Can be `forbid`, `sign-verbatim`
+   or a role given by `role:<role_name>`.  If a role is used, it must be
+   present in `allowed_roles`.
 
  - `dns_resolver` `(string: "")` - An optional overriding DNS resolver to
    use for challenge verification lookups. When not specified, the default
@@ -423,7 +428,7 @@ $ curl \
     "allowed_roles": [
       "*"
     ],
-    "default_role": "",
+    "default_directory_policy": "sign-verbatim",
     "dns_resolver": "",
     "eab_policy": "not-required",
     "enabled": true


### PR DESCRIPTION
This changes all references to default_role to default_directory_policy which can be set to:
* "role:<role_name>" which behaves exactly the same as default_role did
* "forbid" which prevents usage of the default_directory
* "sign-verbatim" which allows the default_directory to be used like sign-verbatim
This is a more flexible structure for future improvements.

Sign-verbatim functions when allowed_roles are also specified.