### PR TITLE
agent: Prevent multiple restarts of child process in supervisor mode

### DIFF
--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -168,9 +168,10 @@ type TemplateConfig struct {
 }
 
 type ExecConfig struct {
-	Command                []string  `hcl:"command,attr" mapstructure:"command"`
-	RestartOnSecretChanges string    `hcl:"restart_on_secret_changes,optional" mapstructure:"restart_on_secret_changes"`
-	RestartStopSignal      os.Signal `hcl:"-" mapstructure:"restart_stop_signal"`
+	Command                  []string      `hcl:"command,attr" mapstructure:"command"`
+	RestartOnSecretChanges   string        `hcl:"restart_on_secret_changes,optional" mapstructure:"restart_on_secret_changes"`
+	RestartStopSignal        os.Signal     `hcl:"-" mapstructure:"restart_stop_signal"`
+	SecretUpdateWaitDuration time.Duration `hcl:"secret_update_wait_duration"`
 }
 
 func NewConfig() *Config {
@@ -1245,6 +1246,10 @@ func parseExec(result *Config, list *ast.ObjectList) error {
 
 	if execConfig.RestartOnSecretChanges == "" {
 		execConfig.RestartOnSecretChanges = "always"
+	}
+
+	if execConfig.SecretUpdateWaitDuration <= 0 {
+		execConfig.SecretUpdateWaitDuration = 2 * time.Second
 	}
 
 	result.Exec = &execConfig

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -168,10 +168,9 @@ type TemplateConfig struct {
 }
 
 type ExecConfig struct {
-	Command                  []string      `hcl:"command,attr" mapstructure:"command"`
-	RestartOnSecretChanges   string        `hcl:"restart_on_secret_changes,optional" mapstructure:"restart_on_secret_changes"`
-	RestartStopSignal        os.Signal     `hcl:"-" mapstructure:"restart_stop_signal"`
-	SecretUpdateWaitDuration time.Duration `hcl:"secret_update_wait_duration"`
+	Command                []string  `hcl:"command,attr" mapstructure:"command"`
+	RestartOnSecretChanges string    `hcl:"restart_on_secret_changes,optional" mapstructure:"restart_on_secret_changes"`
+	RestartStopSignal      os.Signal `hcl:"-" mapstructure:"restart_stop_signal"`
 }
 
 func NewConfig() *Config {
@@ -1246,10 +1245,6 @@ func parseExec(result *Config, list *ast.ObjectList) error {
 
 	if execConfig.RestartOnSecretChanges == "" {
 		execConfig.RestartOnSecretChanges = "always"
-	}
-
-	if execConfig.SecretUpdateWaitDuration <= 0 {
-		execConfig.SecretUpdateWaitDuration = 2 * time.Second
 	}
 
 	result.Exec = &execConfig

--- a/command/agent/exec/exec.go
+++ b/command/agent/exec/exec.go
@@ -132,9 +132,9 @@ func (s *Server) Run(ctx context.Context, incomingVaultToken chan string) error 
 
 	// We receive multiple events every staticSecretRenderInterval
 	// from <-s.runner.TemplateRenderedCh(), one for each secret. Only the last
-	// event in a batch will contain the latest set of all secrets and
+	// event in a batch will contain the latest set of all secrets and the
 	// corresponding environment variables. This timer will fire after 2 seconds
-	// unless an event comes in which resets the timer back to 2 seconds
+	// unless an event comes in which resets the timer back to 2 seconds.
 	var debounceTimer *time.Timer
 
 	// capture the errors related to restarting the child process

--- a/command/agent/exec/exec.go
+++ b/command/agent/exec/exec.go
@@ -237,7 +237,7 @@ func (s *Server) Run(ctx context.Context, incomingVaultToken chan string) error 
 			if debounceTimer != nil {
 				debounceTimer.Stop()
 			}
-			debounceTimer = time.AfterFunc(s.config.AgentConfig.Exec.SecretUpdateWaitDuration, func() {
+			debounceTimer = time.AfterFunc(5*time.Second, func() {
 				if err := s.bounceCmd(renderedEnvVars); err != nil {
 					bounceErrCh <- fmt.Errorf("unable to bounce command: %w", err)
 				}

--- a/command/agent/exec/exec.go
+++ b/command/agent/exec/exec.go
@@ -242,7 +242,7 @@ func (s *Server) Run(ctx context.Context, incomingVaultToken chan string) error 
 			if debounceTimer != nil {
 				debounceTimer.Stop()
 			}
-			debounceTimer = time.AfterFunc(5*time.Second, func() {
+			debounceTimer = time.AfterFunc(s.config.AgentConfig.Exec.SecretUpdateWaitDuration, func() {
 				if err := s.bounceCmd(renderedEnvVars); err != nil {
 					bounceErrCh <- fmt.Errorf("unable to bounce command: %w", err)
 				}

--- a/command/agent/exec/exec.go
+++ b/command/agent/exec/exec.go
@@ -134,7 +134,7 @@ func (s *Server) Run(ctx context.Context, incomingVaultToken chan string) error 
 	// from <-s.runner.TemplateRenderedCh(), one for each secret. Only the last
 	// event in a batch will contain the latest set of all secrets and
 	// corresponding environment variables. This timer will fire after 2 seconds
-	// unless an even comes in which resets the timer back to 2 seconds
+	// unless an event comes in which resets the timer back to 2 seconds
 	var debounceTimer *time.Timer
 
 	// capture the errors related to restarting the child process

--- a/command/agent/exec/exec_test.go
+++ b/command/agent/exec/exec_test.go
@@ -326,10 +326,10 @@ func TestExecServer_Run(t *testing.T) {
 				t.Log("test app started successfully")
 			}
 
-			// expect the test app to restart after staticSecretRenderInterval due to a password change
+			// expect the test app to restart after staticSecretRenderInterval + debounce timer due to a password change
 			if testCase.staticSecretRenderInterval != 0 {
-				t.Logf("sleeping for %v to wait for application restart", testCase.staticSecretRenderInterval+3*time.Second)
-				time.Sleep(testCase.staticSecretRenderInterval + 3*time.Second)
+				t.Logf("sleeping for %v to wait for application restart", testCase.staticSecretRenderInterval+5*time.Second)
+				time.Sleep(testCase.staticSecretRenderInterval + 5*time.Second)
 			}
 
 			// simulate a shutdown of agent, which, in turn stops the test app

--- a/command/agent/exec/exec_test.go
+++ b/command/agent/exec/exec_test.go
@@ -120,7 +120,6 @@ func TestExecServer_Run(t *testing.T) {
 		expectedError        error
 	}{
 		"ensure_environment_variables_are_injected": {
-			skip: true,
 			envTemplates: []*ctconfig.TemplateConfig{{
 				Contents:                 pointerutil.StringPtr(`{{ with secret "kv/my-app/creds" }}{{ .Data.data.user }}{{ end }}`),
 				MapToEnvironmentVariable: pointerutil.StringPtr("MY_USER"),
@@ -160,7 +159,6 @@ func TestExecServer_Run(t *testing.T) {
 		},
 
 		"test_app_exits_early": {
-			skip: true,
 			envTemplates: []*ctconfig.TemplateConfig{{
 				Contents:                 pointerutil.StringPtr(`{{ with secret "kv/my-app/creds" }}{{ .Data.data.user }}{{ end }}`),
 				MapToEnvironmentVariable: pointerutil.StringPtr("MY_USER"),
@@ -173,7 +171,6 @@ func TestExecServer_Run(t *testing.T) {
 		},
 
 		"test_app_exits_early_non_zero": {
-			skip: true,
 			envTemplates: []*ctconfig.TemplateConfig{{
 				Contents:                 pointerutil.StringPtr(`{{ with secret "kv/my-app/creds" }}{{ .Data.data.user }}{{ end }}`),
 				MapToEnvironmentVariable: pointerutil.StringPtr("MY_USER"),
@@ -186,7 +183,6 @@ func TestExecServer_Run(t *testing.T) {
 		},
 
 		"send_sigterm_expect_test_app_exit": {
-			skip: true,
 			envTemplates: []*ctconfig.TemplateConfig{{
 				Contents:                 pointerutil.StringPtr(`{{ with secret "kv/my-app/creds" }}{{ .Data.data.user }}{{ end }}`),
 				MapToEnvironmentVariable: pointerutil.StringPtr("MY_USER"),
@@ -201,7 +197,6 @@ func TestExecServer_Run(t *testing.T) {
 		},
 
 		"send_sigusr1_expect_test_app_exit": {
-			skip: true,
 			envTemplates: []*ctconfig.TemplateConfig{{
 				Contents:                 pointerutil.StringPtr(`{{ with secret "kv/my-app/creds" }}{{ .Data.data.user }}{{ end }}`),
 				MapToEnvironmentVariable: pointerutil.StringPtr("MY_USER"),

--- a/command/agent/exec/exec_test.go
+++ b/command/agent/exec/exec_test.go
@@ -121,6 +121,7 @@ func TestExecServer_Run(t *testing.T) {
 		expectedError        error
 	}{
 		"ensure_environment_variables_are_injected": {
+			skip: true,
 			envTemplates: []*ctconfig.TemplateConfig{{
 				Contents:                 pointerutil.StringPtr(`{{ with secret "kv/my-app/creds" }}{{ .Data.data.user }}{{ end }}`),
 				MapToEnvironmentVariable: pointerutil.StringPtr("MY_USER"),
@@ -148,7 +149,7 @@ func TestExecServer_Run(t *testing.T) {
 				MapToEnvironmentVariable: pointerutil.StringPtr("MY_PASSWORD"),
 			}},
 			staticSecretRenderInterval: 5 * time.Second,
-			testAppArgs:                []string{"--stop-after", "10s", "--sleep-after-stop-signal", "0s"},
+			testAppArgs:                []string{"--stop-after", "15s", "--sleep-after-stop-signal", "0s"},
 			testAppStopSignal:          syscall.SIGTERM,
 			testAppPort:                34002,
 			expected: map[string]string{
@@ -160,6 +161,7 @@ func TestExecServer_Run(t *testing.T) {
 		},
 
 		"test_app_exits_early": {
+			skip: true,
 			envTemplates: []*ctconfig.TemplateConfig{{
 				Contents:                 pointerutil.StringPtr(`{{ with secret "kv/my-app/creds" }}{{ .Data.data.user }}{{ end }}`),
 				MapToEnvironmentVariable: pointerutil.StringPtr("MY_USER"),
@@ -172,6 +174,7 @@ func TestExecServer_Run(t *testing.T) {
 		},
 
 		"test_app_exits_early_non_zero": {
+			skip: true,
 			envTemplates: []*ctconfig.TemplateConfig{{
 				Contents:                 pointerutil.StringPtr(`{{ with secret "kv/my-app/creds" }}{{ .Data.data.user }}{{ end }}`),
 				MapToEnvironmentVariable: pointerutil.StringPtr("MY_USER"),
@@ -184,6 +187,7 @@ func TestExecServer_Run(t *testing.T) {
 		},
 
 		"send_sigterm_expect_test_app_exit": {
+			skip: true,
 			envTemplates: []*ctconfig.TemplateConfig{{
 				Contents:                 pointerutil.StringPtr(`{{ with secret "kv/my-app/creds" }}{{ .Data.data.user }}{{ end }}`),
 				MapToEnvironmentVariable: pointerutil.StringPtr("MY_USER"),
@@ -198,6 +202,7 @@ func TestExecServer_Run(t *testing.T) {
 		},
 
 		"send_sigusr1_expect_test_app_exit": {
+			skip: true,
 			envTemplates: []*ctconfig.TemplateConfig{{
 				Contents:                 pointerutil.StringPtr(`{{ with secret "kv/my-app/creds" }}{{ .Data.data.user }}{{ end }}`),
 				MapToEnvironmentVariable: pointerutil.StringPtr("MY_USER"),
@@ -345,7 +350,7 @@ func TestExecServer_Run(t *testing.T) {
 			// verify the environment variables
 			t.Logf("verifying test-app's environment variables")
 
-			resp, err := http.Get(testAppAddr)
+			resp, err := retryablehttp.Get(testAppAddr)
 			if err != nil {
 				t.Fatalf("error making request to the test app: %s", err)
 			}

--- a/command/agent/exec/exec_test.go
+++ b/command/agent/exec/exec_test.go
@@ -31,15 +31,16 @@ func fakeVaultServer(t *testing.T) *httptest.Server {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/kv/my-app/creds", func(w http.ResponseWriter, r *http.Request) {
-		// change the password on the second request to trigger an application restart
+		// change the password on the second request to re-render the template
 		var password string
 
 		if firstRequest {
 			password = "s3cr3t"
-			firstRequest = false
 		} else {
 			password = "s3cr3t-two"
 		}
+
+		firstRequest = false
 
 		fmt.Fprintf(w, `{
                 "request_id": "8af096e9-518c-7351-eff5-5ba20554b21f",


### PR DESCRIPTION
We receive multiple events every `staticSecretRenderInterval` from `<-s.runner.TemplateRenderedCh()`, one for each secret. Only the last event in a batch will contain the latest set of all secrets and the corresponding environment variables. To account for this, we are adding "[debouncing](https://en.wikipedia.org/wiki/Switch#Debouncing)" logic with a timer that will fire after 2 seconds unless an event comes in which resets the timer back to 2 seconds.

___

This PR is part of a larger effort to implement secrets as environment variable support in agent ([VLT-253](https://docs.google.com/document/d/1HLTkPtxUTtW-wMkePWoHmZoGt9lLg2POslt1ranaWE8/edit#))


[VLT-253]: https://hashicorp.atlassian.net/browse/VLT-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ