### PR TITLE
LDAP Secrets Engine Header Component

### DIFF
--- a/ui/app/models/secret-engine.js
+++ b/ui/app/models/secret-engine.js
@@ -129,13 +129,14 @@ export default class SecretEngineModel extends Model {
   }
 
   get icon() {
-    if (!this.engineType || this.engineType === 'kmip') {
-      return 'secrets';
-    }
-    if (this.engineType === 'keymgmt') {
-      return 'key';
-    }
-    return this.engineType;
+    const defaultIcon = this.engineType || 'secrets';
+    return (
+      {
+        keymgmt: 'key',
+        kmip: 'secrets',
+        ldap: 'folder-users',
+      }[this.engineType] || defaultIcon
+    );
   }
 
   get engineType() {

--- a/ui/lib/ldap/addon/components/tab-page-header.hbs
+++ b/ui/lib/ldap/addon/components/tab-page-header.hbs
@@ -1,0 +1,31 @@
+<PageHeader as |p|>
+  <p.top>
+    <Page::Breadcrumbs @breadcrumbs={{@breadcrumbs}} />
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3" data-test-header-title>
+      <Icon @name={{@model.icon}} @size="24" class="has-text-grey-light" />
+      {{@model.id}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
+
+<div class="tabs-container box is-bottomless is-marginless is-paddingless">
+  <nav class="tabs" aria-label="ldap tabs">
+    <ul>
+      <LinkTo @route="overview" data-test-tab="overview">Overview</LinkTo>
+      <LinkTo @route="roles" data-test-tab="roles">Roles</LinkTo>
+      <LinkTo @route="libraries" data-test-tab="libraries">Libraries</LinkTo>
+      <LinkTo @route="configuration" data-test-tab="config">Configuration</LinkTo>
+    </ul>
+  </nav>
+</div>
+
+<Toolbar>
+  <ToolbarFilters>
+    {{yield to="toolbarFilters"}}
+  </ToolbarFilters>
+  <ToolbarActions>
+    {{yield to="toolbarActions"}}
+  </ToolbarActions>
+</Toolbar>

--- a/ui/tests/integration/components/ldap/tab-page-header-test.js
+++ b/ui/tests/integration/components/ldap/tab-page-header-test.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupEngine } from 'ember-engines/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | ldap | TabPageHeader', function (hooks) {
+  setupRenderingTest(hooks);
+  setupEngine(hooks, 'ldap');
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.store.pushPayload('secret-engine', {
+      modelName: 'secret-engine',
+      data: {
+        accessor: 'ldap_64e858b1',
+        path: 'ldap-test/',
+        type: 'ldap',
+      },
+    });
+    this.model = this.store.peekRecord('secret-engine', 'ldap-test');
+    this.mount = this.model.path.slice(0, -1);
+    this.breadcrumbs = [{ label: 'secrets', route: 'secrets', linkExternal: true }, { label: this.mount }];
+  });
+
+  test('it should render breadcrumbs', async function (assert) {
+    await render(hbs`<TabPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />`, {
+      owner: this.engine,
+    });
+    assert.dom('[data-test-breadcrumbs] li:nth-child(1) a').hasText('secrets', 'Secrets breadcrumb renders');
+
+    assert
+      .dom('[data-test-breadcrumbs] li:nth-child(2)')
+      .containsText(this.mount, 'Mount path breadcrumb renders');
+  });
+
+  test('it should render title', async function (assert) {
+    await render(hbs`<TabPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />`, {
+      owner: this.engine,
+    });
+    assert
+      .dom('[data-test-header-title] svg')
+      .hasClass('flight-icon-folder-users', 'Correct icon renders in title');
+    assert.dom('[data-test-header-title]').hasText(this.mount, 'Mount path renders in title');
+  });
+
+  test('it should render tabs', async function (assert) {
+    await render(hbs`<TabPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />`, {
+      owner: this.engine,
+    });
+    assert.dom('[data-test-tab="overview"]').hasText('Overview', 'Overview tab renders');
+    assert.dom('[data-test-tab="roles"]').hasText('Roles', 'Roles tab renders');
+    assert.dom('[data-test-tab="libraries"]').hasText('Libraries', 'Libraries tab renders');
+    assert.dom('[data-test-tab="config"]').hasText('Configuration', 'Configuration tab renders');
+  });
+
+  test('it should yield toolbar blocks', async function (assert) {
+    await render(
+      hbs`
+      <TabPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}}>
+        <:toolbarFilters>
+          <span data-test-filters>Toolbar filters</span>
+        </:toolbarFilters>
+        <:toolbarActions>
+          <span data-test-actions>Toolbar actions</span>
+        </:toolbarActions>
+      </TabPageHeader>
+    `,
+      { owner: this.engine }
+    );
+
+    assert
+      .dom('.toolbar-filters [data-test-filters]')
+      .hasText('Toolbar filters', 'Block is yielded for toolbar filters');
+    assert
+      .dom('.toolbar-actions [data-test-actions]')
+      .hasText('Toolbar actions', 'Block is yielded for toolbar actions');
+  });
+});


### PR DESCRIPTION
This PR adds a header component for the LDAP secrets engine pages with breadcrumbs, tabs, toolbar filters and actions.

![image](https://github.com/hashicorp/vault/assets/24611656/b400f747-8b42-41b3-8e1e-d884da716009)
