### PR TITLE
UI: pki only render unable to parse banner on issuer details page

### DIFF
--- a/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
@@ -128,6 +128,20 @@
     {{/each-in}}
   {{/each}}
 </main>
+{{#if (or (eq @issuer.can_parse false) this.parsingErrors)}}
+  <AlertBanner
+    data-test-parsing-error-alert-banner
+    class="has-top-margin-m"
+    @type="info"
+    @title="There was an error parsing certificate metadata"
+  >
+    Vault cannot display unparsed values, but this will not interfere with the certificate's functionality. However, if you
+    wish to cross-sign this issuer it must be done manually using the CLI.
+    {{#if this.parsingErrors}}
+      <p class="sub-text is-font-mono">Parsing error(s): {{this.parsingErrors}} </p>
+    {{/if}}
+  </AlertBanner>
+{{/if}}
 
 {{! ROOT ROTATION MODAL }}
 <Modal

--- a/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
@@ -128,7 +128,7 @@
     {{/each-in}}
   {{/each}}
 </main>
-{{#if (or (eq @issuer.can_parse false) this.parsingErrors)}}
+{{#if (or (eq @issuer.parsedCertificate.can_parse false) this.parsingErrors)}}
   <AlertBanner
     data-test-parsing-error-alert-banner
     class="has-top-margin-m"

--- a/ui/lib/pki/addon/components/page/pki-issuer-details.ts
+++ b/ui/lib/pki/addon/components/page/pki-issuer-details.ts
@@ -13,4 +13,11 @@ interface Args {
 
 export default class PkiIssuerDetailsComponent extends Component<Args> {
   @tracked showRotationModal = false;
+
+  get parsingErrors() {
+    if (this.args.issuer.parsedCertificate?.parsing_errors?.length) {
+      return this.args.issuer.parsedCertificate.parsing_errors.map((e: Error) => e.message).join(', ');
+    }
+    return '';
+  }
 }

--- a/ui/lib/pki/addon/components/parsed-certificate-info-rows.hbs
+++ b/ui/lib/pki/addon/components/parsed-certificate-info-rows.hbs
@@ -7,16 +7,3 @@
     />
   {{/let}}
 {{/each}}
-{{#if (or (eq @model.can_parse false) this.parsingErrors)}}
-  <AlertBanner
-    data-test-parsing-error-alert-banner
-    class="has-top-margin-m"
-    @type="info"
-    @title="There was an error parsing certificate metadata"
-  >
-    Vault cannot display unparsed values, but this will not interfere with the certificate's functionality.
-    {{#if this.parsingErrors}}
-      <p class="sub-text is-font-mono">Parsing error(s): {{this.parsingErrors}} </p>
-    {{/if}}
-  </AlertBanner>
-{{/if}}

--- a/ui/lib/pki/addon/components/parsed-certificate-info-rows.ts
+++ b/ui/lib/pki/addon/components/parsed-certificate-info-rows.ts
@@ -51,11 +51,4 @@ export default class ParsedCertificateInfoRowsComponent extends Component<Args> 
       };
     });
   }
-
-  get parsingErrors() {
-    if (this.args.model?.parsing_errors?.length) {
-      return this.args.model.parsing_errors.map((e) => e.message).join(', ');
-    }
-    return '';
-  }
 }

--- a/ui/tests/helpers/pki/pki-issuer-details.js
+++ b/ui/tests/helpers/pki/pki-issuer-details.js
@@ -4,16 +4,17 @@
  */
 
 export const SELECTORS = {
-  defaultGroup: '[data-test-details-group="default"]',
-  urlsGroup: '[data-test-details-group="Issuer URLs"]',
-  groupTitle: '[data-test-group-title]',
-  row: '[data-test-component="info-table-row"]',
-  rotateRoot: '[data-test-pki-issuer-rotate-root]',
-  crossSign: '[data-test-pki-issuer-cross-sign]',
-  signIntermediate: '[data-test-pki-issuer-sign-int]',
-  download: '[data-test-issuer-download]',
   configure: '[data-test-pki-issuer-configure]',
+  crossSign: '[data-test-pki-issuer-cross-sign]',
+  defaultGroup: '[data-test-details-group="default"]',
+  download: '[data-test-issuer-download]',
+  groupTitle: '[data-test-group-title]',
+  parsingAlertBanner: '[data-test-parsing-error-alert-banner]',
   rotateModal: '[data-test-modal-background="Rotate this root"]',
   rotateModalGenerate: '[data-test-root-rotate-step-one]',
+  rotateRoot: '[data-test-pki-issuer-rotate-root]',
+  row: '[data-test-component="info-table-row"]',
+  signIntermediate: '[data-test-pki-issuer-sign-int]',
+  urlsGroup: '[data-test-details-group="Issuer URLs"]',
   valueByName: (name) => `[data-test-value-div="${name}"]`,
 };

--- a/ui/tests/integration/components/pki/parsed-certificate-info-rows-test.js
+++ b/ui/tests/integration/components/pki/parsed-certificate-info-rows-test.js
@@ -3,8 +3,6 @@ import { setupRenderingTest } from 'vault/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupEngine } from 'ember-engines/test-support';
-import { parseCertificate } from 'vault/utils/parse-pki-cert';
-import { unsupportedOids } from 'vault/tests/helpers/pki/values';
 
 module('Integration | Component | parsed-certificate-info-rows', function (hooks) {
   setupRenderingTest(hooks);
@@ -41,53 +39,5 @@ module('Integration | Component | parsed-certificate-info-rows', function (hooks
     assert
       .dom('[data-test-parsing-error-alert-banner]')
       .doesNotExist('does not render parsing error info banner');
-  });
-
-  test('it renders info banner when parsing fails and no parsing errors', async function (assert) {
-    this.set('parsedCertificate', {
-      can_parse: false,
-    });
-    await render(hbs`<ParsedCertificateInfoRows @model={{this.parsedCertificate}} />`, {
-      owner: this.engine,
-    });
-
-    assert
-      .dom('[data-test-parsing-error-alert-banner]')
-      .hasText(
-        "There was an error parsing certificate metadata Vault cannot display unparsed values, but this will not interfere with the certificate's functionality."
-      );
-  });
-
-  test('it renders info banner when parsing fails and parsing errors exist', async function (assert) {
-    this.set('parsedCertificate', {
-      can_parse: false,
-      parsing_errors: [new Error('some parsing error')],
-    });
-    await render(hbs`<ParsedCertificateInfoRows @model={{this.parsedCertificate}} />`, {
-      owner: this.engine,
-    });
-
-    assert
-      .dom('[data-test-parsing-error-alert-banner]')
-      .hasText(
-        "There was an error parsing certificate metadata Vault cannot display unparsed values, but this will not interfere with the certificate's functionality. Parsing error(s): some parsing error"
-      );
-  });
-
-  test('it renders info banner when parsing is successful but unsupported OIDs return parsing errors', async function (assert) {
-    const { parsing_errors } = parseCertificate(unsupportedOids);
-    this.set('parsedCertificate', {
-      can_parse: true,
-      parsing_errors,
-    });
-    await render(hbs`<ParsedCertificateInfoRows @model={{this.parsedCertificate}} />`, {
-      owner: this.engine,
-    });
-
-    assert
-      .dom('[data-test-parsing-error-alert-banner]')
-      .hasText(
-        "There was an error parsing certificate metadata Vault cannot display unparsed values, but this will not interfere with the certificate's functionality. Parsing error(s): certificate contains unsupported subject OIDs: 1.2.840.113549.1.9.1, certificate contains unsupported extension OIDs: 2.5.29.37"
-      );
   });
 });

--- a/ui/tests/integration/components/pki/pki-issuer-details-test.js
+++ b/ui/tests/integration/components/pki/pki-issuer-details-test.js
@@ -36,6 +36,7 @@ module('Integration | Component | page/pki-issuer-details', function (hooks) {
     assert.dom(SELECTORS.signIntermediate).doesNotExist();
     assert.dom(SELECTORS.download).hasText('Download');
     assert.dom(SELECTORS.configure).doesNotExist();
+    assert.dom(SELECTORS.parsingAlertBanner).doesNotExist();
   });
 
   test('it renders toolbar actions depending on passed capabilities', async function (assert) {
@@ -60,6 +61,7 @@ module('Integration | Component | page/pki-issuer-details', function (hooks) {
       this.context
     );
 
+    assert.dom(SELECTORS.parsingAlertBanner).doesNotExist();
     assert.dom(SELECTORS.rotateRoot).hasText('Rotate this root');
     assert.dom(SELECTORS.crossSign).hasText('Cross-sign issuers');
     assert.dom(SELECTORS.signIntermediate).hasText('Sign Intermediate');
@@ -77,5 +79,92 @@ module('Integration | Component | page/pki-issuer-details', function (hooks) {
     assert.dom(SELECTORS.signIntermediate).doesNotExist();
     assert.dom(SELECTORS.download).hasText('Download');
     assert.dom(SELECTORS.configure).doesNotExist();
+  });
+
+  test('it render parsing error banner if issuer certificate contains unsupported OIDs', async function (assert) {
+    this.issuer.parsedCertificate = {
+      common_name: 'fancy-cert-unsupported-subj-and-ext-oids',
+      subject_serial_number: null,
+      ou: null,
+      organization: 'Acme, Inc',
+      country: 'US',
+      locality: 'Topeka',
+      province: 'Kansas',
+      street_address: null,
+      parsing_errors: [new Error('certificate contains stuff we cannot parse')],
+      can_parse: true,
+    };
+    await render(
+      hbs`
+      <Page::PkiIssuerDetails @issuer={{this.issuer}} />
+      <div id="modal-wormhole"></div>
+      `,
+      this.context
+    );
+
+    assert.dom(SELECTORS.parsingAlertBanner).exists();
+    assert
+      .dom(SELECTORS.parsingAlertBanner)
+      .hasText(
+        "There was an error parsing certificate metadata Vault cannot display unparsed values, but this will not interfere with the certificate's functionality. However, if you wish to cross-sign this issuer it must be done manually using the CLI. Parsing error(s): certificate contains stuff we cannot parse"
+      );
+  });
+
+  test('it render parsing error banner if can_parse=false but no parsing_errors', async function (assert) {
+    this.issuer.parsedCertificate = {
+      common_name: 'fancy-cert-unsupported-subj-and-ext-oids',
+      subject_serial_number: null,
+      ou: null,
+      organization: 'Acme, Inc',
+      country: 'US',
+      locality: 'Topeka',
+      province: 'Kansas',
+      street_address: null,
+      parsing_errors: [],
+      can_parse: false,
+    };
+    await render(
+      hbs`
+      <Page::PkiIssuerDetails @issuer={{this.issuer}} />
+      <div id="modal-wormhole"></div>
+      `,
+      this.context
+    );
+
+    assert.dom(SELECTORS.parsingAlertBanner).exists();
+    assert
+      .dom(SELECTORS.parsingAlertBanner)
+      .hasText(
+        "There was an error parsing certificate metadata Vault cannot display unparsed values, but this will not interfere with the certificate's functionality. However, if you wish to cross-sign this issuer it must be done manually using the CLI."
+      );
+  });
+
+  test('it render parsing error banner if no key for parsing_errors', async function (assert) {
+    this.issuer.parsedCertificate = {
+      common_name: 'fancy-cert-unsupported-subj-and-ext-oids',
+      subject_serial_number: null,
+      ou: null,
+      organization: 'Acme, Inc',
+      country: 'US',
+      locality: 'Topeka',
+      province: 'Kansas',
+      street_address: null,
+      can_parse: false,
+    };
+
+    await render(
+      hbs`
+      <Page::PkiIssuerDetails @issuer={{this.issuer}} />
+      <div id="modal-wormhole"></div>
+      `,
+      this.context
+    );
+
+    assert.dom(SELECTORS.parsingAlertBanner).exists();
+    assert
+      .dom(SELECTORS.parsingAlertBanner)
+      .hasText(
+        "There was an error parsing certificate metadata Vault cannot display unparsed values, but this will not interfere with the certificate's functionality. However, if you wish to cross-sign this issuer it must be done manually using the CLI."
+      );
   });
 });

--- a/ui/tests/integration/components/pki/pki-issuer-details-test.js
+++ b/ui/tests/integration/components/pki/pki-issuer-details-test.js
@@ -81,7 +81,7 @@ module('Integration | Component | page/pki-issuer-details', function (hooks) {
     assert.dom(SELECTORS.configure).doesNotExist();
   });
 
-  test('it render parsing error banner if issuer certificate contains unsupported OIDs', async function (assert) {
+  test('it renders parsing error banner if issuer certificate contains unsupported OIDs', async function (assert) {
     this.issuer.parsedCertificate = {
       common_name: 'fancy-cert-unsupported-subj-and-ext-oids',
       subject_serial_number: null,
@@ -110,7 +110,7 @@ module('Integration | Component | page/pki-issuer-details', function (hooks) {
       );
   });
 
-  test('it render parsing error banner if can_parse=false but no parsing_errors', async function (assert) {
+  test('it renders parsing error banner if can_parse=false but no parsing_errors', async function (assert) {
     this.issuer.parsedCertificate = {
       common_name: 'fancy-cert-unsupported-subj-and-ext-oids',
       subject_serial_number: null,
@@ -139,7 +139,7 @@ module('Integration | Component | page/pki-issuer-details', function (hooks) {
       );
   });
 
-  test('it render parsing error banner if no key for parsing_errors', async function (assert) {
+  test('it renders parsing error banner if no key for parsing_errors', async function (assert) {
     this.issuer.parsedCertificate = {
       common_name: 'fancy-cert-unsupported-subj-and-ext-oids',
       subject_serial_number: null,


### PR DESCRIPTION
This removes the alert banner from leaf certs and only renders it on the issuer details view. Also updates the copy to mention cross-signing must happen manually.
<img width="833" alt="Screenshot 2023-06-01 at 12 52 36 PM" src="https://github.com/hashicorp/vault/assets/68122737/083f1c56-b973-4f40-b3c1-578e64309155">
