### PR TITLE
Add TLS-ALPN-01 Challenge Type to ACME

### DIFF
--- a/builtin/logical/pki/acme_challenge_engine.go
+++ b/builtin/logical/pki/acme_challenge_engine.go
@@ -415,6 +415,22 @@ func (ace *ACMEChallengeEngine) _verifyChallenge(sc *storageContext, id string, 
 			err = fmt.Errorf("%w: error validating dns-01 challenge %v: %s", ErrIncorrectResponse, id, err.Error())
 			return ace._verifyChallengeRetry(sc, cv, authzPath, authz, challenge, err, id)
 		}
+	case ACMEALPNChallenge:
+		if authz.Identifier.Type != ACMEDNSIdentifier {
+			err = fmt.Errorf("unsupported identifier type for authorization %v/%v in challenge %v: %v", cv.Account, cv.Authorization, id, authz.Identifier.Type)
+			return ace._verifyChallengeCleanup(sc, err, id)
+		}
+
+		if authz.Wildcard {
+			err = fmt.Errorf("unable to validate wildcard authorization %v/%v in challenge %v via tls-alpn-01 challenge", cv.Account, cv.Authorization, id)
+			return ace._verifyChallengeCleanup(sc, err, id)
+		}
+
+		valid, err = ValidateTLSALPN01Challenge(authz.Identifier.Value, cv.Token, cv.Thumbprint, config)
+		if err != nil {
+			err = fmt.Errorf("%w: error validating tls-alpn-01 challenge %v: %s", ErrIncorrectResponse, id, err.Error())
+			return ace._verifyChallengeRetry(sc, cv, authzPath, authz, challenge, err, id)
+		}
 	default:
 		err = fmt.Errorf("unsupported ACME challenge type %v for challenge %v", cv.ChallengeType, id)
 		return ace._verifyChallengeCleanup(sc, err, id)

--- a/builtin/logical/pki/acme_challenges.go
+++ b/builtin/logical/pki/acme_challenges.go
@@ -1,8 +1,12 @@
 package pki
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/asn1"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -12,7 +16,12 @@ import (
 	"time"
 )
 
-const DNSChallengePrefix = "_acme-challenge."
+const (
+	DNSChallengePrefix = "_acme-challenge."
+	ALPNProtocol       = "acme-tls/1"
+)
+
+var OIDACMEIdentifier = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 31}
 
 // ValidateKeyAuthorization validates that the given keyAuthz from a challenge
 // matches our expectation, returning (true, nil) if so, or (false, err) if
@@ -67,15 +76,28 @@ func buildResolver(config *acmeConfigEntry) (*net.Resolver, error) {
 	}, nil
 }
 
+func buildDialerConfig(config *acmeConfigEntry) (*net.Dialer, error) {
+	resolver, err := buildResolver(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build resolver: %w", err)
+	}
+
+	return &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: -1 * time.Second,
+		Resolver:  resolver,
+	}, nil
+}
+
 // Validates a given ACME http-01 challenge against the specified domain,
 // per RFC 8555.
 //
 // We attempt to be defensive here against timeouts, extra redirects, &c.
 func ValidateHTTP01Challenge(domain string, token string, thumbprint string, config *acmeConfigEntry) (bool, error) {
 	path := "http://" + domain + "/.well-known/acme-challenge/" + token
-	resolver, err := buildResolver(config)
+	dialer, err := buildDialerConfig(config)
 	if err != nil {
-		return false, fmt.Errorf("failed to build resolver: %w", err)
+		return false, fmt.Errorf("failed to build dialer: %w", err)
 	}
 
 	transport := &http.Transport{
@@ -90,11 +112,7 @@ func ValidateHTTP01Challenge(domain string, token string, thumbprint string, con
 
 		// We'd rather timeout and re-attempt validation later than hang
 		// too many validators waiting for slow hosts.
-		DialContext: (&net.Dialer{
-			Timeout:   10 * time.Second,
-			KeepAlive: -1 * time.Second,
-			Resolver:  resolver,
-		}).DialContext,
+		DialContext:           dialer.DialContext,
 		ResponseHeaderTimeout: 10 * time.Second,
 	}
 
@@ -187,4 +205,248 @@ func ValidateDNS01Challenge(domain string, token string, thumbprint string, conf
 	}
 
 	return false, fmt.Errorf("dns-01: challenge failed against %v records", len(results))
+}
+
+func ValidateTLSALPN01Challenge(domain string, token string, thumbprint string, config *acmeConfigEntry) (bool, error) {
+	// This RFC is defined in RFC 8737 Automated Certificate Management
+	// Environment (ACME) TLS Application‑Layer Protocol Negotiation
+	// (ALPN) Challenge Extension.
+	//
+	// This is conceptually similar to ValidateHTTP01Challenge, but
+	// uses a TLS connection on port 443 with the specified ALPN
+	// protocol.
+
+	cfg := &tls.Config{
+		// Per RFC 8737 Section 3. TLS with Application-Layer Protocol
+		// Negotiation (TLS ALPN) Challenge, the name of the negotiated
+		// protocol is "acme-tls/1".
+		NextProtos: []string{ALPNProtocol},
+
+		// Per RFC 8737 Section 3. TLS with Application-Layer Protocol
+		// Negotiation (TLS ALPN) Challenge:
+		//
+		// > ... and an SNI extension containing only the domain name
+		// > being validated during the TLS handshake.
+		//
+		// According to the Go docs, setting this option (even though
+		// InsecureSkipVerify=true is also specified), allows us to
+		// set the SNI extension to this value.
+		ServerName: domain,
+
+		VerifyConnection: func(connState tls.ConnectionState) error {
+			// We initiated a fresh connection with no session tickets;
+			// even if we did have a session ticket, we do not wish to
+			// use it. Verify that the server has not inadvertently
+			// reused connections between validation attempts or something.
+			if connState.DidResume {
+				return fmt.Errorf("server under test incorrectly reported that handshake was resumed when no session cache was provided; refusing to continue")
+			}
+
+			// Per RFC 8737 Section 3. TLS with Application-Layer Protocol
+			// Negotiation (TLS ALPN) Challenge:
+			//
+			// > The ACME server verifies that during the TLS handshake the
+			// > application-layer protocol "acme-tls/1" was successfully
+			// > negotiated (and that the ALPN extension contained only the
+			// > value "acme-tls/1").
+			if connState.NegotiatedProtocol != ALPNProtocol {
+				return fmt.Errorf("server under test negotiated unexpected ALPN protocol %v", connState.NegotiatedProtocol)
+			}
+
+			// Per RFC 8737 Section 3. TLS with Application-Layer Protocol
+			// Negotiation (TLS ALPN) Challenge:
+			//
+			// > and that the certificate returned
+			//
+			// Because this certificate MUST be self-signed (per earlier
+			// statement in RFC 8737 Section 3), there is no point in sending
+			// more than one certificate, and so we will err early here if
+			// we got more than one.
+			if len(connState.PeerCertificates) > 1 {
+				return fmt.Errorf("server under test returned multiple (%v) certificates when we expected only one", len(connState.PeerCertificates))
+			}
+			cert := connState.PeerCertificates[0]
+
+			// Per RFC 8737 Section 3. TLS with Application-Layer Protocol
+			// Negotiation (TLS ALPN) Challenge:
+			//
+			// > The client prepares for validation by constructing a
+			// > self-signed certificate that MUST contain an acmeIdentifier
+			// > extension and a subjectAlternativeName extension [RFC5280].
+			//
+			// Verify that this is a self-signed certificate that isn't signed
+			// by another certificate (i.e., with the same key material but
+			// different issuer).
+			if err := cert.CheckSignatureFrom(cert); err != nil {
+				return fmt.Errorf("server under test returned a non-self-signed certificate: %w", err)
+			}
+			if !bytes.Equal(cert.RawSubject, cert.RawIssuer) {
+				return fmt.Errorf("server under test returned a non-self-signed certificate: invalid subject (%v) <-> issuer (%v) match", cert.Subject.String(), cert.Issuer.String())
+			}
+
+			// Per RFC 8737 Section 3. TLS with Application-Layer Protocol
+			// Negotiation (TLS ALPN) Challenge:
+			//
+			// > The subjectAlternativeName extension MUST contain a single
+			// > dNSName entry where the value is the domain name being
+			// > validated.
+			//
+			// TODO: this does not validate that there are not other SANs
+			// with unknown (to Go) OIDs.
+			if len(cert.DNSNames) != 1 || len(cert.EmailAddresses) > 0 || len(cert.IPAddresses) > 0 || len(cert.URIs) > 0 {
+				return fmt.Errorf("server under test returned a certificate with too many SANs")
+			}
+			if cert.DNSNames[0] != domain {
+				return fmt.Errorf("server under test returned a certificate with unexpected identifier: %v", cert.DNSNames[0])
+			}
+
+			// Per above, verify that the acmeIdentifier extension is present
+			// exactly once and has the correct value.
+			var foundACMEId bool
+			for _, ext := range cert.Extensions {
+				if !ext.Id.Equal(OIDACMEIdentifier) {
+					continue
+				}
+
+				// There must be only a single ACME extension.
+				if foundACMEId {
+					return fmt.Errorf("server under test returned a certificate with multiple acmeIdentifier extensions")
+				}
+				foundACMEId = true
+
+				// Per RFC 8737 Section 3. TLS with Application-Layer Protocol
+				// Negotiation (TLS ALPN) Challenge:
+				//
+				// > a critical acmeIdentifier extension
+				if !ext.Critical {
+					return fmt.Errorf("server under test returned a certificate with an acmeIdentifier extension marked non-Critical")
+				}
+
+				keyAuthz := string(ext.Value)
+				ok, err := ValidateSHA256KeyAuthorization(keyAuthz, token, thumbprint)
+				if !ok || err != nil {
+					return fmt.Errorf("server under test returned a certificate with an invalid key authorization (%w)", err)
+				}
+			}
+
+			// Per RFC 8737 Section 3. TLS with Application-Layer Protocol
+			// Negotiation (TLS ALPN) Challenge:
+			//
+			// > The ACME server verifies that ... the certificate returned
+			// > contains: ... a critical acmeIdentifier extension containing
+			// > the expected SHA-256 digest computed in step 1.
+			if !foundACMEId {
+				return fmt.Errorf("server under test returned a certificate without the required acmeIdentifier extension")
+			}
+
+			// Remove the handled critical extension and validate that we
+			// have no additional critical extensions left unhandled.
+			var index int = -1
+			for oidIndex, oid := range cert.UnhandledCriticalExtensions {
+				if oid.Equal(OIDACMEIdentifier) {
+					index = oidIndex
+					break
+				}
+			}
+			if index != -1 {
+				// Unlike the foundACMEId case, this is not a failure; if Go
+				// updates to "understand" this critical extension, we do not
+				// wish to fail.
+				cert.UnhandledCriticalExtensions = append(cert.UnhandledCriticalExtensions[0:index], cert.UnhandledCriticalExtensions[index+1:]...)
+			}
+			if len(cert.UnhandledCriticalExtensions) > 0 {
+				return fmt.Errorf("server under test returned a certificate with additional unknown critical extensions (%v)", cert.UnhandledCriticalExtensions)
+			}
+
+			// All good!
+			return nil
+		},
+
+		// We never want to resume a connection; do not provide session
+		// cache storage.
+		ClientSessionCache: nil,
+
+		// Do not trust any system trusted certificates; we're going to be
+		// manually validating the chain, so specifying a non-empty pool
+		// here could only cause additional, unnecessary work.
+		RootCAs: x509.NewCertPool(),
+
+		// Do not bother validating the client's chain; we know it should be
+		// self-signed. This also disables hostname verification, but we do
+		// this verification as part of VerifyConnection(...) ourselves.
+		//
+		// Per Go docs, this option is only safe in conjunction with
+		// VerifyConnection which we define above.
+		InsecureSkipVerify: true,
+
+		// RFC 8737 Section 4. acme-tls/1 Protocol Definition:
+		//
+		// > ACME servers that implement "acme-tls/1" MUST only negotiate
+		// > TLS 1.2 [RFC5246] or higher when connecting to clients for
+		// > validation.
+		MinVersion: tls.VersionTLS12,
+
+		// While RFC 8737 does not place restrictions around allowed cipher
+		// suites, we wish to restrict ourselves to secure defaults. Specify
+		// the Intermediate guideline from Mozilla's TLS config generator to
+		// disable obviously weak ciphers.
+		//
+		// See also: https://ssl-config.mozilla.org/#server=go&version=1.14.4&config=intermediate&guideline=5.7
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		},
+	}
+
+	// Build a dialer using our custom DNS resolver, to ensure domains get
+	// resolved according to configuration.
+	dialer, err := buildDialerConfig(config)
+	if err != nil {
+		return false, fmt.Errorf("failed to build dialer: %w", err)
+	}
+
+	// Per RFC 8737 Section 3. TLS with Application-Layer Protocol
+	// Negotiation (TLS ALPN) Challenge:
+	//
+	// > 2. The ACME server resolves the domain name being validated and
+	// >    chooses one of the IP addresses returned for validation (the
+	// >    server MAY validate against multiple addresses if more than
+	// >    one is returned).
+	// > 3. The ACME server initiates a TLS connection to the chosen IP
+	// >    address. This connection MUST use TCP port 443.
+	address := fmt.Sprintf("%v:443", domain)
+	conn, err := dialer.Dial("tcp", address)
+	if err != nil {
+		return false, fmt.Errorf("tls-alpn-01: failed to dial host: %w", err)
+	}
+
+	// Initiate the connection to the remote peer.
+	client := tls.Client(conn, cfg)
+
+	// We intentionally swallow this error as it isn't useful to the
+	// underlying protocol we perform here. Notably, per RFC 8737
+	// Section 4. acme-tls/1 Protocol Definition:
+	//
+	// > Once the handshake is completed, the client MUST NOT exchange
+	// > any further data with the server and MUST immediately close the
+	// > connection. ... Because of this, an ACME server MAY choose to
+	// > withhold authorization if either the certificate signature is
+	// > invalid or the handshake doesn't fully complete.
+	defer client.Close()
+
+	// We wish to put time bounds on the total time the handshake can
+	// stall for, so build a connection context here.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// See note above about why we can allow Handshake to complete
+	// successfully.
+	if err := client.HandshakeContext(ctx); err != nil {
+		return false, fmt.Errorf("tls-alpn-01: failed to perform handshake: %w", err)
+	}
+	return true, nil
 }

--- a/builtin/logical/pki/path_acme_order.go
+++ b/builtin/logical/pki/path_acme_order.go
@@ -799,7 +799,7 @@ func generateAuthorization(acct *acmeAccount, identifier *ACMEIdentifier) (*ACME
 	// Certain challenges have certain restrictions: DNS challenges cannot
 	// be used to validate IP addresses, and only DNS challenges can be used
 	// to validate wildcards.
-	allowedChallenges := []ACMEChallengeType{ACMEHTTPChallenge, ACMEDNSChallenge}
+	allowedChallenges := []ACMEChallengeType{ACMEHTTPChallenge, ACMEDNSChallenge, ACMEALPNChallenge}
 	if identifier.Type == ACMEIPIdentifier {
 		allowedChallenges = []ACMEChallengeType{ACMEHTTPChallenge}
 	} else if identifier.IsWildcard {

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -184,7 +184,7 @@ func TestAcmeBasicWorkflow(t *testing.T) {
 			require.False(t, domainAuth.Wildcard, "should not be a wildcard")
 			require.True(t, domainAuth.Expires.IsZero(), "authorization should only have expiry set on valid status")
 
-			require.Len(t, domainAuth.Challenges, 2, "expected two challenges")
+			require.Len(t, domainAuth.Challenges, 3, "expected three challenges")
 			require.Equal(t, acme.StatusPending, domainAuth.Challenges[0].Status)
 			require.True(t, domainAuth.Challenges[0].Validated.IsZero(), "validated time should be 0 on challenge")
 			require.Equal(t, "http-01", domainAuth.Challenges[0].Type)
@@ -193,6 +193,10 @@ func TestAcmeBasicWorkflow(t *testing.T) {
 			require.True(t, domainAuth.Challenges[1].Validated.IsZero(), "validated time should be 0 on challenge")
 			require.Equal(t, "dns-01", domainAuth.Challenges[1].Type)
 			require.NotEmpty(t, domainAuth.Challenges[1].Token, "missing challenge token")
+			require.Equal(t, acme.StatusPending, domainAuth.Challenges[2].Status)
+			require.True(t, domainAuth.Challenges[2].Validated.IsZero(), "validated time should be 0 on challenge")
+			require.Equal(t, "tls-alpn-01", domainAuth.Challenges[2].Type)
+			require.NotEmpty(t, domainAuth.Challenges[2].Token, "missing challenge token")
 
 			// Test the values for the wildcard authentication
 			require.Equal(t, acme.StatusPending, wildcardAuth.Status)
@@ -201,7 +205,7 @@ func TestAcmeBasicWorkflow(t *testing.T) {
 			require.True(t, wildcardAuth.Wildcard, "should be a wildcard")
 			require.True(t, wildcardAuth.Expires.IsZero(), "authorization should only have expiry set on valid status")
 
-			require.Len(t, wildcardAuth.Challenges, 1, "expected two challenges")
+			require.Len(t, wildcardAuth.Challenges, 1, "expected one challenge")
 			require.Equal(t, acme.StatusPending, domainAuth.Challenges[0].Status)
 			require.True(t, wildcardAuth.Challenges[0].Validated.IsZero(), "validated time should be 0 on challenge")
 			require.Equal(t, "dns-01", wildcardAuth.Challenges[0].Type)
@@ -1076,7 +1080,7 @@ func TestAcmeValidationError(t *testing.T) {
 		authorizations = append(authorizations, auth)
 	}
 	require.Len(t, authorizations, 1, "expected a certain number of authorizations")
-	require.Len(t, authorizations[0].Challenges, 2, "expected a certain number of challenges associated with authorization")
+	require.Len(t, authorizations[0].Challenges, 3, "expected a certain number of challenges associated with authorization")
 
 	acceptedAuth, err := acmeClient.Accept(testCtx, authorizations[0].Challenges[0])
 	require.NoError(t, err, "Should have been allowed to accept challenge 1")

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -161,8 +161,9 @@ identifiers.
 
 Vault supports the following ACME challenge types presently:
 
- - `http-01`, supporting both `dns` and `ip` identifiers,
+ - `http-01`, supporting both `dns` and `ip` identifiers.
  - `dns-01`, supporting `dns` identifiers including wildcards.
+ - `tls-alpn-01`, supporting only non-wildcard `dns` identifiers.
 
 A custom DNS resolver used by the server for looking up DNS names for use
 with both mechanisms can be added via the [ACME configuration](#set-acme-configuration).


### PR DESCRIPTION
This adds the last missing (widely supported) challenge type to the PKI ACME instance: TLS-ALPN-01. This should allow a nicer experience for anyone using Caddy, nginx, or similar server which natively supports ACME cert issuance without reloads or modifying their HTTP router to server `.well-known/acme-challenge/` from another location. 