### PR TITLE
Generate ACME EAB tokens that do not start with '-'

### DIFF
--- a/builtin/logical/pki/path_acme_eab.go
+++ b/builtin/logical/pki/path_acme_eab.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"path"
 	"time"
 
 	"github.com/hashicorp/go-uuid"
@@ -152,7 +153,7 @@ func (b *backend) pathAcmeListEab(ctx context.Context, r *logical.Request, _ *fr
 		keyIds = append(keyIds, eab.KeyID)
 		keyInfos[eab.KeyID] = map[string]interface{}{
 			"key_type":       eab.KeyType,
-			"acme_directory": eab.AcmeDirectory,
+			"acme_directory": path.Join(eab.AcmeDirectory, "directory"),
 			"created_on":     eab.CreatedOn.Format(time.RFC3339),
 		}
 	}
@@ -198,7 +199,7 @@ func (b *backend) pathAcmeCreateEab(ctx context.Context, r *logical.Request, dat
 			"id":             eab.KeyID,
 			"key_type":       eab.KeyType,
 			"key":            encodedKey,
-			"acme_directory": eab.AcmeDirectory,
+			"acme_directory": path.Join(eab.AcmeDirectory, "directory"),
 			"created_on":     eab.CreatedOn.Format(time.RFC3339),
 		},
 	}, nil

--- a/builtin/logical/pki/path_acme_eab.go
+++ b/builtin/logical/pki/path_acme_eab.go
@@ -16,12 +16,17 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-var decodedTokenPrefix = mustBase64Decode("vault-eab0-")
+var decodedTokenPrefix = mustBase64Decode("vault-eab-0-")
 
 func mustBase64Decode(s string) []byte {
 	bytes, err := base64.RawURLEncoding.DecodeString(s)
 	if err != nil {
 		panic(fmt.Sprintf("Token prefix value: %s failed decoding: %v", s, err))
+	}
+
+	// Should be dividable by 3 otherwise our prefix will not be properly honored.
+	if len(bytes)%3 != 0 {
+		panic(fmt.Sprintf("Token prefix value: %s is not dividable by 3, will not prefix properly", s))
 	}
 	return bytes
 }

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -402,7 +402,7 @@ func TestAcmeBasicWorkflowWithEab(t *testing.T) {
 
 			infoForKid := keyInfo[kid].(map[string]interface{})
 			require.Equal(t, "hs", infoForKid["key_type"])
-			require.Equal(t, tc.prefixUrl, infoForKid["acme_directory"])
+			require.Equal(t, tc.prefixUrl+"directory", infoForKid["acme_directory"])
 
 			// Create new account with EAB
 			t.Logf("Testing register on %s", baseAcmeURL)
@@ -1200,7 +1200,7 @@ func getEABKey(t *testing.T, client *api.Client, baseUrl string) (string, []byte
 	require.NoError(t, err, "failed base 64 decoding eab key response")
 
 	require.Equal(t, "hs", resp.Data["key_type"], "eab key_type field mis-match")
-	require.Equal(t, baseUrl, resp.Data["acme_directory"], "eab acme_directory field mis-match")
+	require.Equal(t, baseUrl+"directory", resp.Data["acme_directory"], "eab acme_directory field mis-match")
 	require.NotEmpty(t, resp.Data["created_on"], "empty created_on field")
 	_, err = time.Parse(time.RFC3339, resp.Data["created_on"].(string))
 	require.NoError(t, err, "failed parsing eab created_on field")

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -1195,7 +1195,7 @@ func getEABKey(t *testing.T, client *api.Client, baseUrl string) (string, []byte
 
 	require.NotEmpty(t, resp.Data["key"], "eab key response missing private_key field")
 	base64Key := resp.Data["key"].(string)
-	require.False(t, strings.HasPrefix(base64Key, "-"), "%s should have had a prefix of -", base64Key)
+	require.True(t, strings.HasPrefix(base64Key, "vault-eab-0-"), "%s should have had a prefix of vault-eab-0-", base64Key)
 	privateKeyBytes, err := base64.RawURLEncoding.DecodeString(base64Key)
 	require.NoError(t, err, "failed base 64 decoding eab key response")
 

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -224,11 +224,16 @@ This endpoint returns a new ACME binding token. The `id` response field can
 be used as the key identifier and the `key` response field be used as the
 EAB HMAC key in the ACME Client.
 
-Each call to this endpoint will generate and return a new EAB binding token.
+Each call to this endpoint will generate and return a new EAB binding token
+that is linked to the specific ACME directory it resides under. EAB tokens
+are not usable across different ACME directories.
 
-| Method | Path                |
-| :----- | :------------------ |
-| `POST` | `/pki/acme/new-eab` |
+| Method | Path                                               |
+|:-------|:---------------------------------------------------|
+| `POST` | `/pki/acme/new-eab`                                |
+| `POST` | `/pki/issuer/:issuer_ref/acme/new-eab`             |
+| `POST` | `/pki/roles/:role/acme/new-eab`                    |
+| `POST` | `/pki/issuer/:issuer_ref/roles/:role/acme/new-eab` |
 
 #### Parameters
 
@@ -250,8 +255,8 @@ $ curl \
   "data": {
     "created_on": "2023-05-24T14:33:00-04:00",
     "id": "bc8088d9-3816-5177-ae8e-d8393265f7dd",
-    "key_bits": "256",
     "key_type": "hs",
+    "acme_directory": "acme/",
     "key": "MHcCAQE... additional data elided ...",
   }
 }
@@ -283,8 +288,8 @@ $ curl \
     "key_info": {
       "bc8088d9-3816-5177-ae8e-d8393265f7dd": {
         "created_on": "2023-05-24T14:33:00-04:00",
-        "key_bits": "256",
-        "key_type": "hs"
+        "key_type": "hs",
+        "acme_directory": "acme/"
       }
     },
     "keys": [

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -256,7 +256,7 @@ $ curl \
     "created_on": "2023-05-24T14:33:00-04:00",
     "id": "bc8088d9-3816-5177-ae8e-d8393265f7dd",
     "key_type": "hs",
-    "acme_directory": "acme/",
+    "acme_directory": "acme/directory",
     "key": "MHcCAQE... additional data elided ...",
   }
 }
@@ -289,7 +289,7 @@ $ curl \
       "bc8088d9-3816-5177-ae8e-d8393265f7dd": {
         "created_on": "2023-05-24T14:33:00-04:00",
         "key_type": "hs",
-        "acme_directory": "acme/"
+        "acme_directory": "acme/directory"
       }
     },
     "keys": [


### PR DESCRIPTION
 - To avoid people having issues copying EAB tokens and using them on command lines when they start with - from the base64 encoded values, append a prefix.
 - Remove the key_bits data from the eab api, not really useful and now technically wrong
 - Fix up some issues with tests not running in parallel.
 - Update docs to reflect new EAB apis.