### PR TITLE
agent: Fix bug with early exits during restarts in supervisor mode

### DIFF
--- a/command/agent/exec/exec.go
+++ b/command/agent/exec/exec.go
@@ -320,8 +320,11 @@ func (s *Server) restartChildProcess(newEnvVars []string) error {
 	// race condition with ExitCh not being initialized.
 	go func() {
 		select {
-		case exitCode := <-proc.ExitCh():
-			s.childProcessExitCh <- exitCode
+		case exitCode, ok := <-proc.ExitCh():
+			// ignore ExitCh channel closures caused by our restarts
+			if ok {
+				s.childProcessExitCh <- exitCode
+			}
 		}
 	}()
 


### PR DESCRIPTION
There is an issue with the current agent supervisor mode where it occasionally exits while restarting the child process. The reason for it is that the `ExitCh` is [closed](https://github.com/hashicorp/consul-template/blob/e97a929318455f1ff0d11360a746412d633a004c/child/child.go#L342), which triggers an event causing an exit.

___

This PR is part of a larger effort to implement secrets as environment variable support in agent ([VLT-253](https://docs.google.com/document/d/1HLTkPtxUTtW-wMkePWoHmZoGt9lLg2POslt1ranaWE8/edit#))

[VLT-253]: https://hashicorp.atlassian.net/browse/VLT-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ