### PR TITLE
Clarify vault helm upgrade instructions in HA mode

### DIFF
--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -453,10 +453,10 @@ Select the active Vault pod:
 $ kubectl get pods -l vault-active=true
 ```
 
-Next, delete every pod that is not the active primary:
+Next, sequentially delete every pod that is not the active primary, ensuring the quorum is maintained at all times:
 
 ```shell-session
-$ kubectl delete pod <name of Vault pods>
+$ kubectl delete pod <name of Vault pod>
 ```
 
 If auto-unseal is not being used, the newly scheduled Vault standby pods needs


### PR DESCRIPTION
Can be beneficial to know for users updating vault helm chart to delete standby pods sequentially to not break quorum and cause downtime.