### PR TITLE
Duplicate groups creation bug 

### DIFF
--- a/changelog/20964.txt
+++ b/changelog/20964.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity: Fixes duplicate groups creation with the same name but unique IDs. 
+```

--- a/vault/identity_store_groups.go
+++ b/vault/identity_store_groups.go
@@ -69,8 +69,11 @@ func groupPaths(i *IdentityStore) []*framework.Path {
 			},
 
 			Fields: groupPathFields(),
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: i.pathGroupRegister(),
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:                  i.pathGroupRegister(),
+					ForwardPerformanceStandby: true,
+				},
 			},
 
 			HelpSynopsis:    strings.TrimSpace(groupHelp["register"][0]),


### PR DESCRIPTION
https://hashicorp.atlassian.net/browse/VAULT-16649
Vault does not prevent the creation of duplicate groups when multiple "create group" requests with the same group name are sent simultaneously to different nodes. The issue arises because Vault relies on the view of MemDB from IdentityStore, which is independent for each node, to check for the presence of another group with the same name. As a result, when requests occur within a short time frame, the MemDB on each node may not have the group names.

Currently, the request is only forwarded to the active node for writing to storage based on the ID i.e, as part of UpsertGroupInTxn function, we would only forward the write to storage request using SendGroupUpdate https://github.com/hashicorp/vault-enterprise/blob/5e4c01ae563d2ad3f4138171e95cb6bdb2ee9e20/vault/identity_store_util.go#LL1826C1-L1834C4.

Approved ent PR: https://github.com/hashicorp/vault-enterprise/pull/4137