### PR TITLE
Add tests for tls-alpn-01 with acme.sh

### DIFF
--- a/builtin/logical/pki/acme_challenge_engine.go
+++ b/builtin/logical/pki/acme_challenge_engine.go
@@ -430,7 +430,7 @@ func (ace *ACMEChallengeEngine) _verifyChallenge(sc *storageContext, id string, 
 
 		valid, err = ValidateTLSALPN01Challenge(authz.Identifier.Value, cv.Token, cv.Thumbprint, config)
 		if err != nil {
-			err = fmt.Errorf("%w: error validating tls-alpn-01 challenge %v: %s", ErrIncorrectResponse, id, err.Error())
+			err = fmt.Errorf("%w: error validating tls-alpn-01 challenge %v: %v: %v", ErrIncorrectResponse, id, err, ChallengeAttemptFailedMsg)
 			return ace._verifyChallengeRetry(sc, cv, authzPath, authz, challenge, err, id)
 		}
 	default:

--- a/builtin/logical/pkiext/nginx_test.go
+++ b/builtin/logical/pkiext/nginx_test.go
@@ -175,7 +175,7 @@ server {
 
 func buildWgetCurlContainer(t *testing.T, network string) {
 	containerfile := `
-FROM ubuntu:latest
+FROM docker.mirror.hashicorp.services/ubuntu:latest
 
 RUN apt update && DEBIAN_FRONTEND="noninteractive" apt install -y curl wget wget2
 `

--- a/builtin/logical/pkiext/pkiext_binary/acme_sh.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_sh.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package pkiext_binary
 
 import (

--- a/builtin/logical/pkiext/pkiext_binary/acme_sh.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_sh.go
@@ -9,7 +9,7 @@ import (
 )
 
 const ACMEshContainerfile = `
-FROM ubuntu:latest
+FROM docker.mirror.hashicorp.services/ubuntu:latest
 
 RUN apt update && DEBIAN_FRONTEND="noninteractive" apt install -y openssl socat curl coreutils dnsutils tzdata sed tar jq libidn2-0 openssh-client git cron
 

--- a/builtin/logical/pkiext/pkiext_binary/acme_sh.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_sh.go
@@ -1,0 +1,81 @@
+package pkiext_binary
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/helper/docker"
+)
+
+const ACMEshContainerfile = `
+FROM ubuntu:latest
+
+RUN apt update && DEBIAN_FRONTEND="noninteractive" apt install -y openssl socat curl coreutils dnsutils tzdata sed tar jq libidn2-0 openssh-client git cron
+
+RUN git clone https://github.com/acmesh-official/acme.sh.git /acme.sh
+WORKDIR /acme.sh
+
+RUN ./acme.sh --install --home /etc/acmesh --config-home /etc/ssl/data --cert-home /etc/ssl/certs --accountemail "webmaster@dadgarcorp.com"
+`
+
+var (
+	acmeShRunner             *docker.Runner
+	buildAcmeShContainerOnce sync.Once
+)
+
+func buildACMEshContainer(t *testing.T, network string) {
+	bCtx := docker.NewBuildContext()
+
+	imageName := "vault_pki_acme_acme_sh_integration"
+	imageTag := "latest"
+	containerName := "vault_acme_sh_container"
+
+	var err error
+	acmeShRunner, err = docker.NewServiceRunner(docker.RunOptions{
+		ImageRepo:     imageName,
+		ImageTag:      imageTag,
+		ContainerName: containerName,
+		NetworkName:   network,
+		// We want to run sleep in the background so we're not stuck waiting
+		// for the default ubuntu container's shell to prompt for input.
+		//
+		// We choose a slightly longer default sleep, 600s = 10min, as we
+		// potentially want to allow the test to fail validating, which
+		// might take a while.
+		Entrypoint: []string{"sleep", "600"},
+		LogConsumer: func(s string) {
+			if t.Failed() {
+				t.Logf("container logs: %s", s)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Could not provision docker service runner: %s", err)
+	}
+
+	ctx := context.Background()
+	output, err := acmeShRunner.BuildImage(ctx, ACMEshContainerfile, bCtx,
+		docker.BuildRemove(true), docker.BuildForceRemove(true),
+		docker.BuildPullParent(true),
+		docker.BuildTags([]string{imageName + ":" + imageTag}))
+	if err != nil {
+		t.Fatalf("Could not build new image: %v", err)
+	}
+
+	t.Logf("Image build output: %v", string(output))
+}
+
+func GetACMEshContainer(t *testing.T, network string) (*docker.Runner, *docker.StartResult) {
+	buildAcmeShContainerOnce.Do(func() {
+		buildACMEshContainer(t, network)
+	})
+
+	ctx := context.Background()
+	result, err := acmeShRunner.Start(ctx, true, false)
+	if err != nil {
+		t.Fatalf("Could not start acme.sh container: %s", err)
+	}
+
+	return acmeShRunner, result
+}

--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -468,7 +468,12 @@ func (d *Runner) Start(ctx context.Context, addSuffix, forceLocalAddr bool) (*St
 			break
 		}
 	} else {
-		realIP = inspect.NetworkSettings.Networks[d.RunOptions.NetworkName].IPAddress
+		network, present := inspect.NetworkSettings.Networks[d.RunOptions.NetworkName]
+		if present {
+			realIP = network.IPAddress
+		} else {
+			return nil, fmt.Errorf("d.RunOptions.NetworkName failed; network (%s) not found: %v; maybe d.RunOptions.NetworkID was non-empty when d.RunOptions.NetworkName was desired", d.RunOptions.NetworkName, inspect.NetworkSettings.Networks)
+		}
 	}
 
 	return &StartResult{


### PR DESCRIPTION
This adds a basic test to ensure TLS-ALPN-01 challenge works end-to-end using acme.sh as the client. 

I'll have this target `main` once #20943 merges. 