### PR TITLE
VAULT-14847 Skip cetain tests on ARM

### DIFF
--- a/builtin/credential/radius/backend_test.go
+++ b/builtin/credential/radius/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -30,6 +31,10 @@ const (
 )
 
 func prepareRadiusTestContainer(t *testing.T) (func(), string, int) {
+	if strings.Contains(runtime.GOARCH, "arm") {
+		t.Skip("Skipping, as this image is not supported on ARM architectures")
+	}
+
 	if os.Getenv(envRadiusRadiusHost) != "" {
 		port, _ := strconv.Atoi(os.Getenv(envRadiusPort))
 		return func() {}, os.Getenv(envRadiusRadiusHost), port

--- a/builtin/logical/nomad/backend_test.go
+++ b/builtin/logical/nomad/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -38,6 +39,11 @@ func (c *Config) Client() (*nomadapi.Client, error) {
 }
 
 func prepareTestContainer(t *testing.T, bootstrap bool) (func(), *Config) {
+	// Skipping on ARM, as this image can't run on ARM architecture
+	if strings.Contains(runtime.GOARCH, "arm") {
+		t.Skip("Skipping, as this image is not supported on ARM architectures")
+	}
+
 	if retAddress := os.Getenv("NOMAD_ADDR"); retAddress != "" {
 		s, err := docker.NewServiceURLParse(retAddress)
 		if err != nil {

--- a/helper/testhelpers/cassandra/cassandrahelper.go
+++ b/helper/testhelpers/cassandra/cassandrahelper.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -80,6 +82,12 @@ func (h Host) ConnectionURL() string {
 
 func PrepareTestContainer(t *testing.T, opts ...ContainerOpt) (Host, func()) {
 	t.Helper()
+
+	// Skipping on ARM, as this image can't run on ARM architecture
+	if strings.Contains(runtime.GOARCH, "arm") {
+		t.Skip("Skipping, as this image is not supported on ARM architectures")
+	}
+
 	if os.Getenv("CASSANDRA_HOSTS") != "" {
 		host, port, err := net.SplitHostPort(os.Getenv("CASSANDRA_HOSTS"))
 		if err != nil {

--- a/helper/testhelpers/ldap/ldaphelper.go
+++ b/helper/testhelpers/ldap/ldaphelper.go
@@ -6,6 +6,8 @@ package ldap
 import (
 	"context"
 	"fmt"
+	"runtime"
+	"strings"
 	"testing"
 
 	hclog "github.com/hashicorp/go-hclog"
@@ -14,6 +16,11 @@ import (
 )
 
 func PrepareTestContainer(t *testing.T, version string) (cleanup func(), cfg *ldaputil.ConfigEntry) {
+	// Skipping on ARM, as this image can't run on ARM architecture
+	if strings.Contains(runtime.GOARCH, "arm") {
+		t.Skip("Skipping, as this image is not supported on ARM architectures")
+	}
+
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		// Currently set to "michelvocks" until https://github.com/rroemhild/docker-test-openldap/pull/14
 		// has been merged.

--- a/helper/testhelpers/mssql/mssqlhelper.go
+++ b/helper/testhelpers/mssql/mssqlhelper.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/helper/docker"
@@ -22,6 +24,10 @@ const mssqlPassword = "yourStrong(!)Password"
 const numRetries = 3
 
 func PrepareMSSQLTestContainer(t *testing.T) (cleanup func(), retURL string) {
+	if strings.Contains(runtime.GOARCH, "arm") {
+		t.Skip("Skipping, as this image is not supported on ARM architectures")
+	}
+
 	if os.Getenv("MSSQL_URL") != "" {
 		return func() {}, os.Getenv("MSSQL_URL")
 	}

--- a/helper/testhelpers/mysql/mysqlhelper.go
+++ b/helper/testhelpers/mysql/mysqlhelper.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -24,6 +25,12 @@ var _ docker.ServiceConfig = &Config{}
 func PrepareTestContainer(t *testing.T, legacy bool, pw string) (func(), string) {
 	if os.Getenv("MYSQL_URL") != "" {
 		return func() {}, os.Getenv("MYSQL_URL")
+	}
+
+	// ARM64 is only supported on MySQL 8.0 and above. If we update
+	// our image and support to 8.0, we can unskip these tests.
+	if strings.Contains(runtime.GOARCH, "arm") {
+		t.Skip("Skipping, as MySQL 5.7 is not supported on ARM architectures")
 	}
 
 	imageVersion := "5.7"

--- a/physical/aerospike/aerospike_test.go
+++ b/physical/aerospike/aerospike_test.go
@@ -6,6 +6,8 @@ package aerospike
 import (
 	"context"
 	"math/bits"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -47,6 +49,11 @@ type aerospikeConfig struct {
 }
 
 func prepareAerospikeContainer(t *testing.T) (func(), *aerospikeConfig) {
+	// Skipping on ARM, as this image can't run on ARM architecture
+	if strings.Contains(runtime.GOARCH, "arm") {
+		t.Skip("Skipping, as this image is not supported on ARM architectures")
+	}
+
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		ImageRepo:     "docker.mirror.hashicorp.services/aerospike/aerospike-server",
 		ContainerName: "aerospikedb",

--- a/physical/cockroachdb/cockroachdb_test.go
+++ b/physical/cockroachdb/cockroachdb_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"runtime"
+	"strings"
 	"testing"
 
 	log "github.com/hashicorp/go-hclog"
@@ -26,6 +28,11 @@ type Config struct {
 var _ docker.ServiceConfig = &Config{}
 
 func prepareCockroachDBTestContainer(t *testing.T) (func(), *Config) {
+	// Skipping, as this image can't run on arm architecture
+	if strings.Contains(runtime.GOARCH, "arm") {
+		t.Skip("Skipping, as CockroachDB 1.0 is not supported on ARM architectures")
+	}
+
 	if retURL := os.Getenv("CR_URL"); retURL != "" {
 		s, err := docker.NewServiceURLParse(retURL)
 		if err != nil {

--- a/physical/couchdb/couchdb_test.go
+++ b/physical/couchdb/couchdb_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -78,6 +79,13 @@ func (c couchDB) URL() *url.URL {
 var _ docker.ServiceConfig = &couchDB{}
 
 func prepareCouchdbDBTestContainer(t *testing.T) (func(), *couchDB) {
+	// ARM64 is only supported on CouchDB 2 and above. If we update
+	// our image and support to 2 and above, we can unskip these:
+	// https://hub.docker.com/r/arm64v8/couchdb/
+	if strings.Contains(runtime.GOARCH, "arm") {
+		t.Skip("Skipping, as CouchDB 1.6 is not supported on ARM architectures")
+	}
+
 	// If environment variable is set, assume caller wants to target a real
 	// DynamoDB.
 	if os.Getenv("COUCHDB_ENDPOINT") != "" {

--- a/physical/dynamodb/dynamodb_test.go
+++ b/physical/dynamodb/dynamodb_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -373,6 +375,11 @@ type Config struct {
 var _ docker.ServiceConfig = &Config{}
 
 func prepareDynamoDBTestContainer(t *testing.T) (func(), *Config) {
+	// Skipping on ARM, as this image can't run on ARM architecture
+	if strings.Contains(runtime.GOARCH, "arm") {
+		t.Skip("Skipping, as this image is not supported on ARM architectures")
+	}
+
 	// If environment variable is set, assume caller wants to target a real
 	// DynamoDB.
 	if endpoint := os.Getenv("AWS_DYNAMODB_ENDPOINT"); endpoint != "" {

--- a/plugins/database/influxdb/influxdb_test.go
+++ b/plugins/database/influxdb/influxdb_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -51,6 +52,11 @@ func (c *Config) connectionParams() map[string]interface{} {
 }
 
 func prepareInfluxdbTestContainer(t *testing.T) (func(), *Config) {
+	// Skipping on ARM, as this image can't run on ARM architecture
+	if strings.Contains(runtime.GOARCH, "arm") {
+		t.Skip("Skipping, as this image is not supported on ARM architectures")
+	}
+
 	c := &Config{
 		Username: "influx-root",
 		Password: "influx-root",


### PR DESCRIPTION
The OSS portion of the changes required to enable ARM tests nightly. Repeating the salient part from the enterprise PR:

As part of this, I've needed to skip a lot of OSS tests with docker images because of incompatible images (to use an example: we use MySQL 5.7, which doesn't support ARM64, and we'd need to upgrade to 8.0 to have that).