### PR TITLE
[QT-426] Always create the file audit directory

### DIFF
--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -217,31 +217,6 @@ resource "enos_vault_start" "followers" {
   }
 }
 
-# We need to ensure that the directory used for audit logs is present and accessible to the vault
-# user on all nodes, since logging will only happen on the leader.
-resource "enos_remote_exec" "create_audit_log_dir" {
-  depends_on = [
-    enos_vault_start.followers,
-  ]
-  for_each = toset([
-    for idx, host in toset(local.instances) : idx
-    if var.enable_file_audit_device
-  ])
-
-  environment = {
-    LOG_FILE_PATH = local.audit_device_file_path
-    SERVICE_USER  = local.vault_service_user
-  }
-
-  scripts = [abspath("${path.module}/scripts/create_audit_log_dir.sh")]
-
-  transport = {
-    ssh = {
-      host = var.target_hosts[each.value].public_ip
-    }
-  }
-}
-
 resource "enos_vault_init" "leader" {
   depends_on = [
     enos_vault_start.followers,
@@ -286,8 +261,34 @@ resource "enos_vault_unseal" "leader" {
   }
 }
 
+# We need to ensure that the directory used for audit logs is present and accessible to the vault
+# user on all nodes, since logging will only happen on the leader.
+resource "enos_remote_exec" "create_audit_log_dir" {
+  depends_on = [
+    enos_vault_unseal.leader,
+  ]
+  for_each = toset([
+    for idx, host in toset(local.instances) : idx
+    if var.enable_file_audit_device
+  ])
+
+  environment = {
+    LOG_FILE_PATH = local.audit_device_file_path
+    SERVICE_USER  = local.vault_service_user
+  }
+
+  scripts = [abspath("${path.module}/scripts/create_audit_log_dir.sh")]
+
+  transport = {
+    ssh = {
+      host = var.target_hosts[each.value].public_ip
+    }
+  }
+}
+
 resource "enos_remote_exec" "enable_file_audit_device" {
   depends_on = [
+    enos_remote_exec.create_audit_log_dir,
     enos_vault_unseal.leader,
   ]
   for_each = toset([

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -225,7 +225,7 @@ resource "enos_remote_exec" "create_audit_log_dir" {
   ]
   for_each = toset([
     for idx, host in toset(local.instances) : idx
-    if local.enable_audit_device
+    if var.enable_file_audit_device
   ])
 
   environment = {


### PR DESCRIPTION
Updated the `vault-cluster` module to always create the log file directory for the file audit device logs.