### PR TITLE
License Banner - check for new license

### DIFF
--- a/ui/app/components/license-banners.js
+++ b/ui/app/components/license-banners.js
@@ -31,8 +31,12 @@ export default class LicenseBanners extends Component {
 
   constructor() {
     super(...arguments);
-    // do not dismiss any banners if the user has updated their version
-    const dismissedBanner = localStorage.getItem(`dismiss-license-banner-${this.currentVersion}`); // returns either warning or expired
+    // do not dismiss any banners if the license id has changed indicating a new license has been invoked.
+    // do not dismiss any banners if the user has updated their version, which is indicated by a change in the this.args.expiry.
+
+    const dismissedBanner = localStorage.getItem(
+      `dismiss-license-banner-${this.currentVersion}-${this.args.expiry}`
+    ); // returns either warning or expired
     this.updateDismissType(dismissedBanner);
   }
 
@@ -54,9 +58,12 @@ export default class LicenseBanners extends Component {
   @action
   dismissBanner(dismissAction) {
     // if a client's version changed their old localStorage key will still exists.
-    localStorage.cleanUpStorage('dismiss-license-banner', `dismiss-license-banner-${this.currentVersion}`);
+    localStorage.cleanUpStorage(
+      'dismiss-license-banner',
+      `dismiss-license-banner-${this.currentVersion}-${this.args.expiry}`
+    );
     // updates localStorage and then updates the template by calling updateDismissType
-    localStorage.setItem(`dismiss-license-banner-${this.currentVersion}`, dismissAction);
+    localStorage.setItem(`dismiss-license-banner-${this.currentVersion}-${this.args.expiry}`, dismissAction);
     this.updateDismissType(dismissAction);
   }
 

--- a/ui/app/components/license-banners.js
+++ b/ui/app/components/license-banners.js
@@ -46,6 +46,7 @@ export default class LicenseBanners extends Component {
 
   get licenseExpired() {
     if (!this.args.expiry) return false;
+
     return isAfter(timestamp.now(), new Date(this.args.expiry));
   }
 

--- a/ui/app/templates/vault/cluster.hbs
+++ b/ui/app/templates/vault/cluster.hbs
@@ -1,9 +1,11 @@
 <Sidebar::Nav::Cluster />
-
-<LicenseBanners
-  @expiry={{this.activeCluster.licenseExpiry}}
-  @autoloaded={{eq this.activeCluster.licenseState "autoloaded"}}
-/>
+{{! Only show license banners for Enterprise }}
+{{#unless this.activeCluster.version.isOSS}}
+  <LicenseBanners
+    @expiry={{this.activeCluster.licenseExpiry}}
+    @autoloaded={{eq this.activeCluster.licenseState "autoloaded"}}
+  />
+{{/unless}}
 <div class="global-flash">
   {{#each this.flashMessages.queue as |flash|}}
     <FlashMessage data-test-flash-message={{true}} @flash={{flash}} as |customComponent flash close|>


### PR DESCRIPTION
[Unsure where to point the fix to, 1.14 or 1.14.1 same with backport to 1.13]??
There was a bug on the dismiss license banners for the following flow:

1. I dismiss a warning that my license is going to expire (or has expired).
2. I update my license.
3. For however long that new license works for I never update my version of vault or clear local storage .
4. A year or whatever later I get another warning that the license is going to expire. That banner does not show.

To fix this I tried the following and settled on what turned out to be the easiest approach, appending expiry time to the localStorage key value.

* Appending licenseId. This is bad because we don't expose this.
* Checking for the warnings that show on the license/status endpoint. You see these appear in the flashMessage warnings. Turns out these are captured by the application adapter and are outside the data response and thus hard to add to the license model. 
* WINNER: expiry. If the expiry date is the same for your license every time you hit the license/status endpoint. It only changes if you change the license itself. Even if you keep your same license (I don't know how to do this) and edit the expiry time, we should still remove the localStorage settings of dismissing any banners.

See demo here: 
