### PR TITLE
License banner - check for new license on localStorage.

### DIFF
--- a/ui/app/components/license-banners.js
+++ b/ui/app/components/license-banners.js
@@ -33,9 +33,9 @@ export default class LicenseBanners extends Component {
     super(...arguments);
     // reset and show a previously dismissed license banner if:
     // the version has been updated or the license has been updated (indicated by a change in the expiry date).
-    const dismissedBanner = localStorage.getItem(this.dismissedBannerKey); // returns either warning or expired
+    const bannerType = localStorage.getItem(this.dismissedBannerKey); // returns either warning or expired
 
-    this.updateDismissType(dismissedBanner);
+    this.updateDismissType(bannerType);
   }
 
   get currentVersion() {

--- a/ui/app/components/license-banners.js
+++ b/ui/app/components/license-banners.js
@@ -31,17 +31,19 @@ export default class LicenseBanners extends Component {
 
   constructor() {
     super(...arguments);
-    // do not dismiss any banners if the user has updated their license, which is indicated by a change in the this.args.expiry.
-    // do not dismiss any banners if the user has updated their version.
-    const dismissedBanner = localStorage.getItem(
-      `dismiss-license-banner-${this.currentVersion}-${this.args.expiry}`
-    ); // returns either warning or expired`); // returns either warning or expired
+    // reset and show a previously dismissed license banner if:
+    // the version has been updated or the license has been updated (indicated by a change in the expiry date).
+    const dismissedBanner = localStorage.getItem(this.dismissedBannerKey); // returns either warning or expired
 
     this.updateDismissType(dismissedBanner);
   }
 
   get currentVersion() {
     return this.version.version;
+  }
+
+  get dismissedBannerKey() {
+    return `dismiss-license-banner-${this.currentVersion}-${this.args.expiry}`;
   }
 
   get licenseExpired() {
@@ -58,12 +60,9 @@ export default class LicenseBanners extends Component {
   @action
   dismissBanner(dismissAction) {
     // if a client's version changed their old localStorage key will still exists.
-    localStorage.cleanUpStorage(
-      'dismiss-license-banner',
-      `dismiss-license-banner-${this.currentVersion}-${this.args.expiry}`
-    );
+    localStorage.cleanupStorage('dismiss-license-banner', this.dismissedBannerKey);
     // updates localStorage and then updates the template by calling updateDismissType
-    localStorage.setItem(`dismiss-license-banner-${this.currentVersion}-${this.args.expiry}`, dismissAction);
+    localStorage.setItem(this.dismissedBannerKey, dismissAction);
     this.updateDismissType(dismissAction);
   }
 

--- a/ui/app/components/license-banners.js
+++ b/ui/app/components/license-banners.js
@@ -31,8 +31,8 @@ export default class LicenseBanners extends Component {
 
   constructor() {
     super(...arguments);
-    // do not dismiss any banners if the license id has changed indicating a new license has been invoked.
-    // do not dismiss any banners if the user has updated their version, which is indicated by a change in the this.args.expiry.
+    // do not dismiss any banners if the user has updated their license, which is indicated by a change in the this.args.expiry.
+    // do not dismiss any banners if the user has updated their version.
     const dismissedBanner = localStorage.getItem(
       `dismiss-license-banner-${this.currentVersion}-${this.args.expiry}`
     ); // returns either warning or expired`); // returns either warning or expired

--- a/ui/app/components/license-banners.js
+++ b/ui/app/components/license-banners.js
@@ -31,8 +31,12 @@ export default class LicenseBanners extends Component {
 
   constructor() {
     super(...arguments);
-    // do not dismiss any banners if the user has updated their version
-    const dismissedBanner = localStorage.getItem(`dismiss-license-banner-${this.currentVersion}`); // returns either warning or expired
+    // do not dismiss any banners if the license id has changed indicating a new license has been invoked.
+    // do not dismiss any banners if the user has updated their version, which is indicated by a change in the this.args.expiry.
+    const dismissedBanner = localStorage.getItem(
+      `dismiss-license-banner-${this.currentVersion}-${this.args.expiry}`
+    ); // returns either warning or expired`); // returns either warning or expired
+
     this.updateDismissType(dismissedBanner);
   }
 
@@ -54,9 +58,12 @@ export default class LicenseBanners extends Component {
   @action
   dismissBanner(dismissAction) {
     // if a client's version changed their old localStorage key will still exists.
-    localStorage.cleanUpStorage('dismiss-license-banner', `dismiss-license-banner-${this.currentVersion}`);
+    localStorage.cleanUpStorage(
+      'dismiss-license-banner',
+      `dismiss-license-banner-${this.currentVersion}-${this.args.expiry}`
+    );
     // updates localStorage and then updates the template by calling updateDismissType
-    localStorage.setItem(`dismiss-license-banner-${this.currentVersion}`, dismissAction);
+    localStorage.setItem(`dismiss-license-banner-${this.currentVersion}-${this.args.expiry}`, dismissAction);
     this.updateDismissType(dismissAction);
   }
 

--- a/ui/app/lib/local-storage.js
+++ b/ui/app/lib/local-storage.js
@@ -21,7 +21,7 @@ export default {
     return Object.keys(window.localStorage);
   },
 
-  cleanUpStorage(string, keyToKeep) {
+  cleanupStorage(string, keyToKeep) {
     if (!string) return;
     const relevantKeys = this.keys().filter((str) => str.startsWith(string));
     relevantKeys?.forEach((key) => {

--- a/ui/app/templates/vault/cluster.hbs
+++ b/ui/app/templates/vault/cluster.hbs
@@ -1,9 +1,11 @@
 <Sidebar::Nav::Cluster />
-
-<LicenseBanners
-  @expiry={{this.activeCluster.licenseExpiry}}
-  @autoloaded={{eq this.activeCluster.licenseState "autoloaded"}}
-/>
+{{! Only show license banners for Enterprise }}
+{{#unless this.activeCluster.version.isOSS}}
+  <LicenseBanners
+    @expiry={{this.activeCluster.licenseExpiry}}
+    @autoloaded={{eq this.activeCluster.licenseState "autoloaded"}}
+  />
+{{/unless}}
 <div class="global-flash">
   {{#each this.flashMessages.queue as |flash|}}
     <FlashMessage data-test-flash-message={{true}} @flash={{flash}} as |customComponent flash close|>

--- a/ui/app/templates/vault/cluster.hbs
+++ b/ui/app/templates/vault/cluster.hbs
@@ -1,11 +1,11 @@
 <Sidebar::Nav::Cluster />
 {{! Only show license banners for Enterprise }}
-{{#unless this.activeCluster.version.isOSS}}
+{{#if this.activeCluster.version.isEnterprise}}
   <LicenseBanners
     @expiry={{this.activeCluster.licenseExpiry}}
     @autoloaded={{eq this.activeCluster.licenseState "autoloaded"}}
   />
-{{/unless}}
+{{/if}}
 <div class="global-flash">
   {{#each this.flashMessages.queue as |flash|}}
     <FlashMessage data-test-flash-message={{true}} @flash={{flash}} as |customComponent flash close|>

--- a/ui/tests/unit/lib/local-storage-test.js
+++ b/ui/tests/unit/lib/local-storage-test.js
@@ -17,7 +17,7 @@ module('Unit | lib | local-storage', function (hooks) {
   test('it does not error if nothing is in local storage', async function (assert) {
     assert.expect(1);
     assert.strictEqual(
-      LocalStorage.cleanUpStorage('something', 'something-key'),
+      LocalStorage.cleanupStorage('something', 'something-key'),
       undefined,
       'returns undefined and does not throw an error when method is called and nothing exist in localStorage.'
     );
@@ -29,7 +29,7 @@ module('Unit | lib | local-storage', function (hooks) {
     LocalStorage.setItem('beep-boop-bop-key', 'beep-boop-bop-value');
     LocalStorage.setItem('string-key', 'string-key-value');
     const storageLengthBefore = window.localStorage.length;
-    LocalStorage.cleanUpStorage('string', 'string-key');
+    LocalStorage.cleanupStorage('string', 'string-key');
     const storageLengthAfter = window.localStorage.length;
     assert.strictEqual(
       storageLengthBefore - storageLengthAfter,


### PR DESCRIPTION
There was a bug on the dismiss license banners for the following flow:

1. I dismiss a warning that my license is going to expire (or has expired).
2. I update my license.
3. For however long that new license works for I never update my version of vault or clear local storage .
4. A year or whatever later I get another warning that the license is going to expire. That banner does not show.

To fix this I had to be careful about the data I used to add to the key in local storage. I couldn't safely use anything from the `sys/license` endpoint because what if a user didn't have permissions to that but the user before them on the same computer did? They technically could see something saved in local storage from that endpoint. Thus, I went with the `expiry_time` which comes off the unauthenticated health endpoint. 

Questions:
1. Is my conditional for enterprise only okay? Makes complete sense to me, and we essentially did this before in the component, but now we don't even hit the component logic.
2. Does anyone know why we want to show this banner on unauthenticated views (see the video)?

See the short demo here:
https://github.com/hashicorp/vault/assets/6618863/804667a7-4013-4862-bdb5-5ed3b756204a

