### PR TITLE
Onboard Vault to the prepare workflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,17 +3,16 @@ name: build
 
 on:
   workflow_dispatch:
-  # pull_request:
-  #   # The default types for pull_request are [ opened, synchronize, reopened ].
-  #   # This is insufficient for our needs, since we're skipping stuff on PRs in
-  #   # draft mode.  By adding the ready_for_review type, when a draft pr is marked
-  #   # ready, we run everything, including the stuff we'd have skipped up until now.
-  #   types: [ opened, synchronize, reopened, ready_for_review ]
+  pull_request:
+    # The default types for pull_request are [ opened, synchronize, reopened ].
+    # This is insufficient for our needs, since we're skipping stuff on PRs in
+    # draft mode.  By adding the ready_for_review type, when a draft pr is marked
+    # ready, we run everything, including the stuff we'd have skipped up until now.
+    types: [ opened, synchronize, reopened, ready_for_review ]
   push:
     branches:
       - main
       - release/**
-      - add-crt-prepare
 
 jobs:
   # verify-changes determines if the changes are only for docs (website)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,16 +3,17 @@ name: build
 
 on:
   workflow_dispatch:
-  pull_request:
-    # The default types for pull_request are [ opened, synchronize, reopened ].
-    # This is insufficient for our needs, since we're skipping stuff on PRs in
-    # draft mode.  By adding the ready_for_review type, when a draft pr is marked
-    # ready, we run everything, including the stuff we'd have skipped up until now.
-    types: [ opened, synchronize, reopened, ready_for_review ]
+  # pull_request:
+  #   # The default types for pull_request are [ opened, synchronize, reopened ].
+  #   # This is insufficient for our needs, since we're skipping stuff on PRs in
+  #   # draft mode.  By adding the ready_for_review type, when a draft pr is marked
+  #   # ready, we run everything, including the stuff we'd have skipped up until now.
+  #   types: [ opened, synchronize, reopened, ready_for_review ]
   push:
     branches:
       - main
       - release/**
+      - add-crt-prepare
 
 jobs:
   # verify-changes determines if the changes are only for docs (website)

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -32,145 +32,13 @@ event "build" {
   }
 }
 
-event "upload-dev" {
+event "prepare" {
   depends = ["build"]
-  action "upload-dev" {
+  action "prepare" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "upload-dev"
-    depends = ["build"]
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "quality-tests" {
-  depends = ["upload-dev"]
-  action "quality-tests" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "quality-tests"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "security-scan-binaries" {
-  depends = ["quality-tests"]
-  action "security-scan-binaries" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "security-scan-binaries"
-    config = "security-scan.hcl"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "security-scan-containers" {
-  depends = ["security-scan-binaries"]
-  action "security-scan-containers" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "security-scan-containers"
-    config = "security-scan.hcl"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-darwin-amd64" {
-  depends = ["security-scan-containers"]
-  action "notarize-darwin-amd64" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-darwin-amd64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-darwin-arm64" {
-  depends = ["notarize-darwin-amd64"]
-  action "notarize-darwin-arm64" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-darwin-arm64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-windows-386" {
-  depends = ["notarize-darwin-arm64"]
-  action "notarize-windows-386" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-windows-386"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-windows-amd64" {
-  depends = ["notarize-windows-386"]
-  action "notarize-windows-amd64" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-windows-amd64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "sign" {
-  depends = ["notarize-windows-amd64"]
-  action "sign" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "sign"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "sign-linux-rpms" {
-  depends = ["sign"]
-  action "sign-linux-rpms" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "sign-linux-rpms"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "verify" {
-  depends = ["sign-linux-rpms"]
-  action "verify" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "verify"
+    repository   = "crt-workflows-common"
+    workflow     = "prepare"
+    depends      = ["build"]
   }
 
   notification {
@@ -179,7 +47,7 @@ event "verify" {
 }
 
 event "enos-release-testing-oss" {
-  depends = ["verify"]
+  depends = ["prepare"]
   action "enos-release-testing-oss" {
     organization = "hashicorp"
     repository = "vault"

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -14,6 +14,7 @@ project "vault" {
     release_branches = [
       "main",
       "release/**",
+	  "add-crt-prepare"
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -13,8 +13,7 @@ project "vault" {
     repository = "vault"
     release_branches = [
       "main",
-      "release/**",
-	  "add-crt-prepare"
+      "release/**"
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -13,7 +13,7 @@ project "vault" {
     repository = "vault"
     release_branches = [
       "main",
-      "release/**"
+      "release/**",
     ]
   }
 }


### PR DESCRIPTION
Finally! 😄 
Sorry that this was missed with all the CircleCI migration work.

This reduces all of the binary processing common workflows (sign, notarize etc..) to just the one `prepare` workflow. More runs in parallel, so execution time is cut down. See [here](https://hashicorp.atlassian.net/wiki/spaces/RELENG/pages/2489712686/Dec+7th+2022+-+Introducing+the+new+Prepare+workflow) for more info.

This is the result of the prepare workflow run from this branch - https://github.com/hashicorp/crt-workflows-common/actions/runs/5258231286