### PR TITLE
Add support for VAULT_TOKEN_FILE env var

### DIFF
--- a/changelog/21015.txt
+++ b/changelog/21015.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Support VAULT_TOKEN_FILE environment variable.
+```


### PR DESCRIPTION
In some situations, I've found it makes more sense to read the vault token from a local file (e.g. to avoid logging `env VAULT_TOKEN=...`)

I've skimmed the token helper documentation, and I'm not 100% it fulfills my use-case, since it _also_ requires a file in `$HOME`, but if running under a user created with either a shared/nonexistant/RO `$HOME` there could be some trickiness setting up a `~/.vault` file.

#20272 

TODOs:
- [x] Changelog entry
- [ ] Add tests