### PR TITLE
[docs] Remove beta tag and update example code

### DIFF
--- a/website/content/docs/platform/k8s/index.mdx
+++ b/website/content/docs/platform/k8s/index.mdx
@@ -65,7 +65,7 @@ There are currently 3 different integrations to help Kubernetes workloads seamle
 - More mature solution, with proven production record and advanced features like templating,
   wider array of auth methods, etc.
 
-#### Vault Secrets Operator (public beta)
+#### Vault Secrets Operator
 
 - More native UX for app developers. Workloads can mount Kubernetes secrets without adding any Vault-specific configuration.
 - Reduced load on Vault. Secrets are synced per CRD instead of per consuming pod.

--- a/website/content/docs/platform/k8s/vso/api-reference.mdx
+++ b/website/content/docs/platform/k8s/vso/api-reference.mdx
@@ -5,8 +5,6 @@ description: >-
   The Vault Secrets Operator allows Pods to consume Vault secrets natively from Kubernetes Secrets.
 ---
 
-@include 'vso-beta-note.mdx'
-
 <!--
   generated with crd-ref-docs --source-path api/v1alpha1 --config docs/config.yaml --renderer=markdown in the vault-secrets-operator repo.
   commit SHA=f3752fbce7be3bb9e73615a10d2ddeb58e2a8cb6

--- a/website/content/docs/platform/k8s/vso/examples.mdx
+++ b/website/content/docs/platform/k8s/vso/examples.mdx
@@ -5,8 +5,6 @@ description: >-
   The Vault Secrets Operator allows Pods to consume Vault secrets natively from Kubernetes Secrets.
 ---
 
-@include 'vso-beta-note.mdx'
-
 # Vault Secrets Operator Examples
 
 The Operator project provides the following examples:

--- a/website/content/docs/platform/k8s/vso/helm.mdx
+++ b/website/content/docs/platform/k8s/vso/helm.mdx
@@ -5,8 +5,6 @@ description: >-
   Configuration for the Vault Secrets Operator Helm chart.
 ---
 
-@include 'vso-beta-note.mdx'
-
 # Vault Secrets Operator Helm Chart
 
 The chart is customizable using

--- a/website/content/docs/platform/k8s/vso/index.mdx
+++ b/website/content/docs/platform/k8s/vso/index.mdx
@@ -5,8 +5,6 @@ description: >-
   The Vault Secrets Operator allows Pods to consume Vault secrets natively from Kubernetes Secrets.
 ---
 
-@include 'vso-beta-note.mdx'
-
 # Vault Secrets Operator
 
 The Vault Secrets Operator (VSO) allows Pods to consume Vault secrets natively from Kubernetes Secrets.
@@ -36,9 +34,6 @@ The following features are supported by the Vault Secrets Operator:
 @include 'kubernetes-supported-versions.mdx'
 
 ## Vault Access and Custom Resource Definitions
-
-~> **Note:** Currently, the Operator only supports the [Kubernetes Auth Method](/vault/docs/auth/kubernetes).
-Over time, we will be adding support for more Vault Auth methods.
 
 The Vault connection and authentication configuration is provided by the `VaultConnection` and `VaultAuth` CRDs. These can be considered as
 foundational Custom Resources that all secret replication type resources will reference.
@@ -151,7 +146,7 @@ metadata:
 spec:
   vaultAuthRef: example
   mount: pki
-  name: default
+  role: default
   commonName: example.com
   format: pem
   expiryOffset: 1s
@@ -178,7 +173,7 @@ metadata:
 spec:
   vaultAuthRef: example
   mount: db
-  role: postgres
+  path: creds/postgres
   destination:
     create: true
     name: dynamic1

--- a/website/content/docs/platform/k8s/vso/installation.mdx
+++ b/website/content/docs/platform/k8s/vso/installation.mdx
@@ -5,14 +5,17 @@ description: >-
   The Vault Secrets Operator can be installed using Helm.
 ---
 
-@include 'vso-beta-note.mdx'
-
 # Installing the Vault Secrets Operator
 
 ## Prerequisites
 
 - Kubernetes 1.22+
-- Vault OSS/Enterprise 1.11+
+- Vault OSS/Enterprise 1.11+ or [HCP Vault](https://www.hashicorp.com/cloud)
+
+## Supported Cloud Providers
+
+The Vault Secrets Operator has been tested for basic compatibility with GKE, EKS, AKS and OpenShift.
+Please report any incompatibilies via a [Github Issue](https://github.com/hashicorp/vault-secrets-operator/issues).
 
 ## Installation using helm
 
@@ -26,15 +29,15 @@ HashiCorp helm repository and ensure you have access to the chart:
 $ helm repo add hashicorp https://helm.releases.hashicorp.com
 "hashicorp" has been added to your repositories
 
-$ helm search repo hashicorp/vault-secrets-operator --devel
+$ helm search repo hashicorp/vault-secrets-operator
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault-secrets-operator	0.1.0-beta       	0.1.0-beta     	Official HashiCorp Vault Secrets Operator Chart
+hashicorp/vault-secrets-operator	0.1.0       	0.1.0     	Official HashiCorp Vault Secrets Operator Chart
 ```
 
 Then install the Operator:
 
 ```shell-session
-$ helm install --create-namespace --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator --version 0.1.0-beta
+$ helm install --create-namespace --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator --version 0.1.0
 ```
 
 

--- a/website/content/docs/platform/k8s/vso/telemetry.mdx
+++ b/website/content/docs/platform/k8s/vso/telemetry.mdx
@@ -5,8 +5,6 @@ description: >-
   The Vault Secrets Operator allows Pods to consume Vault secrets natively from Kubernetes Secrets.
 ---
 
-@include 'vso-beta-note.mdx'
-
 # Telemetry
 
 The Vault Secrets Operator is instrumented with Prometheus metrics.

--- a/website/content/partials/vso-beta-note.mdx
+++ b/website/content/partials/vso-beta-note.mdx
@@ -1,2 +1,0 @@
-~> The Vault Secrets Operator is in public beta. <br />
-  *Please provide your feedback by opening a GitHub issue [here](https://github.com/hashicorp/vault-secrets-operator/issues)*


### PR DESCRIPTION
* Adds HCP vault to supported installation page
* Removes the beta tag everywhere
* Updates an out of date example to use role instead of name for PKI.