### PR TITLE
Add pki acme load tests

### DIFF
--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"path"
 	"sync"
 	"testing"
@@ -626,6 +627,10 @@ func SubtestACMEWildcardDNS(t *testing.T, cluster *VaultPkiCluster) {
 }
 
 func SubtestACMELoadDNS(t *testing.T, cluster *VaultPkiCluster) {
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping somewhat expensive tests in CI")
+	}
+
 	// Count controls how many clients are used in each cohort, and groups
 	// controls the number of test executions to do.
 	count := 100
@@ -733,6 +738,10 @@ func SubtestACMELoadDNS(t *testing.T, cluster *VaultPkiCluster) {
 }
 
 func SubtestACMELoadHTTP(t *testing.T, cluster *VaultPkiCluster) {
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping somewhat expensive tests in CI")
+	}
+
 	// Count controls how many clients are used in each cohort, and groups
 	// controls the number of test executions to do.
 	count := 100

--- a/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
+++ b/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
@@ -89,6 +89,23 @@ func (vpc *VaultPkiCluster) AddHostname(hostname, ip string) error {
 	}
 }
 
+func (vpc *VaultPkiCluster) AddHostnameLazy(hostname, ip string) error {
+	if vpc.Dns != nil {
+		vpc.Dns.AddRecord(hostname, "A", ip)
+		return nil
+	} else {
+		return vpc.AddNameToHostFiles(hostname, ip)
+	}
+}
+
+func (vpc *VaultPkiCluster) PushHostnameConfig() error {
+	if vpc.Dns != nil {
+		vpc.Dns.PushConfig()
+	}
+
+	return nil
+}
+
 func (vpc *VaultPkiCluster) AddNameToHostFiles(hostname, ip string) error {
 	updateHostsCmd := []string{
 		"sh", "-c",

--- a/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
+++ b/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
@@ -82,8 +82,7 @@ func (vpc *VaultPkiCluster) GetActiveNode() *api.Client {
 
 func (vpc *VaultPkiCluster) AddHostname(hostname, ip string) error {
 	if vpc.Dns != nil {
-		vpc.Dns.AddRecord(hostname, "A", ip)
-		vpc.Dns.PushConfig()
+		vpc.Dns.AddRecordAndPush(hostname, "A", ip)
 		return nil
 	} else {
 		return vpc.AddNameToHostFiles(hostname, ip)
@@ -115,8 +114,7 @@ func (vpc *VaultPkiCluster) AddDNSRecord(hostname, recordType, ip string) error 
 		return fmt.Errorf("no DNS server was provisioned on this cluster group; unable to provision custom records")
 	}
 
-	vpc.Dns.AddRecord(hostname, recordType, ip)
-	vpc.Dns.PushConfig()
+	vpc.Dns.AddRecordAndPush(hostname, recordType, ip)
 	return nil
 }
 

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -419,6 +419,10 @@ func NewTestDockerCluster(t *testing.T, opts *DockerClusterOptions) *DockerClust
 		t.Fatal(err)
 	}
 	dc.Logger.Trace("cluster started", "helpful_env", fmt.Sprintf("VAULT_TOKEN=%s VAULT_CACERT=/vault/config/ca.pem", dc.GetRootToken()))
+	for index, node := range dc.ClusterNodes {
+		client := node.APIClient()
+		dc.Logger.Trace("cluster started", "node", index, "helpful_env", fmt.Sprintf("VAULT_ADDR=%s", client.Address()))
+	}
 	return dc
 }
 


### PR DESCRIPTION
This adds two ACME load tests, one using DNS challenges and one using HTTP challenges:

```
        --- PASS: Test_ACME/group/acme_prevents_ica (1.29s)
        --- PASS: Test_ACME/group/acme_wildcard (1.41s)
        --- PASS: Test_ACME/group/acme_ip_sans (4.86s)
        --- PASS: Test_ACME/group/acme_load_test_dns (8.41s)
        --- PASS: Test_ACME/group/acme_load_test_http (11.88s)
        --- PASS: Test_ACME/group/certbot_eab (14.07s)
        --- PASS: Test_ACME/group/certbot (14.92s)
```

Similar numbers for both challenge types:

```
    acme_test.go:812: [2] load test took 2.288646207s for 100 clients
    acme_test.go:831: run=0 took 2.332964974s for 100 clients
    acme_test.go:831: run=1 took 2.24362303s for 100 clients
    acme_test.go:831: run=2 took 2.288646207s for 100 clients
    acme_test.go:837: min=2.24362303s@1 / max=2.332964974s@0 / avg=2.288411403s / total=6.865234211s / count=3
```

1k scales linearly to about 20s-24s:

```
    acme_test.go:831: run=0 took 21.570145217s for 1000 clients
    acme_test.go:831: run=1 took 20.938812558s for 1000 clients
    acme_test.go:831: run=2 took 21.238084219s for 1000 clients
    acme_test.go:831: run=3 took 20.800369828s for 1000 clients
    acme_test.go:831: run=4 took 21.256111543s for 1000 clients
    acme_test.go:831: run=5 took 21.420903625s for 1000 clients
    acme_test.go:831: run=6 took 21.451213967s for 1000 clients
    acme_test.go:831: run=7 took 20.595338714s for 1000 clients
    acme_test.go:831: run=8 took 20.936932941s for 1000 clients
    acme_test.go:831: run=9 took 21.418942558s for 1000 clients
    acme_test.go:837: min=20.595338714s@7 / max=21.570145217s@0 / avg=21.162685517s / total=3m31.62685517s / count=10
```