### PR TITLE
Fix autopilot scenario failures

### DIFF
--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -269,6 +269,7 @@ scenario "autopilot" {
       storage_node_prefix         = "upgrade_node"
       target_hosts                = step.create_vault_cluster_upgrade_targets.hosts
       unseal_method               = matrix.seal
+      enable_file_audit_device    = var.vault_enable_file_audit_device
     }
   }
 

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -182,7 +182,7 @@ scenario "autopilot" {
     }
 
     variables {
-      vault_instances   = step.create_vault_cluster_targets.hosts
+      vault_instances   = step.create_vault_cluster.target_hosts
       vault_install_dir = local.vault_install_dir
       vault_root_token  = step.create_vault_cluster.root_token
     }
@@ -203,7 +203,7 @@ scenario "autopilot" {
     variables {
       leader_public_ip  = step.get_vault_cluster_ips.leader_public_ip
       leader_private_ip = step.get_vault_cluster_ips.leader_private_ip
-      vault_instances   = step.create_vault_cluster_targets.hosts
+      vault_instances   = step.create_vault_cluster.target_hosts
       vault_install_dir = local.vault_install_dir
       vault_root_token  = step.create_vault_cluster.root_token
     }
@@ -286,7 +286,7 @@ scenario "autopilot" {
 
     variables {
       vault_install_dir = local.vault_install_dir
-      vault_instances   = step.create_vault_cluster_upgrade_targets.hosts
+      vault_instances   = step.upgrade_vault_cluster_with_autopilot.target_hosts
     }
   }
 
@@ -303,7 +303,7 @@ scenario "autopilot" {
 
     variables {
       vault_install_dir = local.vault_install_dir
-      vault_instances   = step.create_vault_cluster_upgrade_targets.hosts
+      vault_instances   = step.upgrade_vault_cluster_with_autopilot.target_hosts
       vault_root_token  = step.upgrade_vault_cluster_with_autopilot.root_token
     }
   }
@@ -324,7 +324,7 @@ scenario "autopilot" {
       vault_autopilot_upgrade_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_autopilot_upgrade_status  = "await-server-removal"
       vault_install_dir               = local.vault_install_dir
-      vault_instances                 = step.create_vault_cluster_upgrade_targets.hosts
+      vault_instances                 = step.create_vault_cluster_upgrade_targets.target_hosts
       vault_root_token                = step.upgrade_vault_cluster_with_autopilot.root_token
     }
   }
@@ -343,11 +343,11 @@ scenario "autopilot" {
     }
 
     variables {
-      vault_instances       = step.create_vault_cluster_targets.hosts
+      vault_instances       = step.create_vault_cluster.target_hosts
       vault_install_dir     = local.vault_install_dir
       vault_root_token      = step.create_vault_cluster.root_token
       node_public_ip        = step.get_vault_cluster_ips.leader_public_ip
-      added_vault_instances = step.create_vault_cluster_targets.hosts
+      added_vault_instances = step.upgrade_vault_cluster_with_autopilot.target_hosts
     }
   }
 
@@ -386,7 +386,7 @@ scenario "autopilot" {
 
     variables {
       operator_instance      = step.get_updated_vault_cluster_ips.leader_public_ip
-      remove_vault_instances = step.create_vault_cluster_targets.hosts
+      remove_vault_instances = step.create_vault_cluster.target_hosts
       vault_install_dir      = local.vault_install_dir
       vault_instance_count   = 3
       vault_root_token       = step.create_vault_cluster.root_token
@@ -405,7 +405,7 @@ scenario "autopilot" {
     }
 
     variables {
-      old_vault_instances  = step.create_vault_cluster_targets.hosts
+      old_vault_instances  = step.create_vault_cluster.target_hosts
       vault_instance_count = 3
     }
   }
@@ -427,7 +427,7 @@ scenario "autopilot" {
       vault_autopilot_upgrade_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_autopilot_upgrade_status  = "idle"
       vault_install_dir               = local.vault_install_dir
-      vault_instances                 = step.create_vault_cluster_upgrade_targets.hosts
+      vault_instances                 = step.upgrade_vault_cluster_with_autopilot.target_hosts
       vault_root_token                = step.create_vault_cluster.root_token
     }
   }
@@ -448,7 +448,7 @@ scenario "autopilot" {
 
     variables {
       vault_install_dir = local.vault_install_dir
-      vault_instances   = step.create_vault_cluster_upgrade_targets.hosts
+      vault_instances   = step.upgrade_vault_cluster_with_autopilot.target_hosts
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -61,7 +61,7 @@ locals {
       path    = "vault"
     })
   ]
-  audit_device_file_path = "/var/log/vault_audit.log"
+  audit_device_file_path = "/var/log/vault/vault_audit.log"
   vault_service_user     = "vault"
   enable_audit_device    = var.enable_file_audit_device && var.initialize_cluster
 }

--- a/enos/modules/vault_cluster/scripts/create_audit_log_dir.sh
+++ b/enos/modules/vault_cluster/scripts/create_audit_log_dir.sh
@@ -4,5 +4,27 @@ set -eux
 
 LOG_DIR=$(dirname "$LOG_FILE_PATH")
 
+function retry {
+  local retries=$1
+  shift
+  local count=0
+
+  until "$@"; do
+    exit=$?
+    wait=10
+    count=$((count + 1))
+
+    if [ "$count" -lt "$retries" ]; then
+      sleep "$wait"
+    else
+      return "$exit"
+    fi
+  done
+
+  return 0
+}
+
+retry 7 id -a $SERVICE_USER
+
 sudo mkdir -p "$LOG_DIR"
-sudo chown "$SERVICE_USER":"$SERVICE_USER" "$LOG_DIR"
+sudo chown -R "$SERVICE_USER":"$SERVICE_USER" "$LOG_DIR"

--- a/enos/modules/vault_cluster/scripts/create_audit_log_dir.sh
+++ b/enos/modules/vault_cluster/scripts/create_audit_log_dir.sh
@@ -1,4 +1,4 @@
-#!/bin/env sh
+#!/usr/bin/env bash
 
 set -eux
 
@@ -24,7 +24,7 @@ function retry {
   return 0
 }
 
-retry 7 id -a $SERVICE_USER
+retry 7 id -a "$SERVICE_USER"
 
 sudo mkdir -p "$LOG_DIR"
 sudo chown -R "$SERVICE_USER":"$SERVICE_USER" "$LOG_DIR"


### PR DESCRIPTION
- The `get_updated_cluster_ips` step for autopilot was corrected to check for the leader IP in the upgraded cluster hosts
- Updated the path to the audit log file to `/var/log/vault`
- Added a retry to allow time for the vault user creation to complete before creating the vault audit log directory