### PR TITLE
Adds an ACME validation failure test for certbot.

### DIFF
--- a/builtin/logical/pkiext/test_helpers.go
+++ b/builtin/logical/pkiext/test_helpers.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/helper/certutil"
@@ -83,4 +84,10 @@ func (l LogConsumerWriter) Write(p []byte) (n int, err error) {
 		l.Consumer(scanner.Text())
 	}
 	return len(p), nil
+}
+
+// IsLocalOrNightlyRegression returns true when the tests are running locally (not in CI), or when
+// the nightly regression env var is provided.
+func IsLocalOrNightlyRegression() bool {
+	return os.Getenv("CI") == "" || os.Getenv("VAULT_NIGHTLY_REGRESSION") == "true"
 }

--- a/builtin/logical/pkiext/test_helpers.go
+++ b/builtin/logical/pkiext/test_helpers.go
@@ -10,7 +10,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/helper/certutil"
@@ -84,10 +83,4 @@ func (l LogConsumerWriter) Write(p []byte) (n int, err error) {
 		l.Consumer(scanner.Text())
 	}
 	return len(p), nil
-}
-
-// IsLocalOrNightlyRegression returns true when the tests are running locally (not in CI), or when
-// the nightly regression env var is provided.
-func IsLocalOrNightlyRegression() bool {
-	return os.Getenv("CI") == "" || os.Getenv("VAULT_NIGHTLY_REGRESSION") == "true"
 }

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -1047,3 +1047,9 @@ func WaitForNodesExcludingSelectedStandbys(t testing.T, cluster *vault.TestClust
 		}
 	}
 }
+
+// IsLocalOrRegressionTests returns true when the tests are running locally (not in CI), or when
+// the regression test env var (VAULT_REGRESSION_TESTS) is provided.
+func IsLocalOrRegressionTests() bool {
+	return os.Getenv("CI") == "" || os.Getenv("VAULT_REGRESSION_TESTS") == "true"
+}


### PR DESCRIPTION
#Summary
Adds an ACME validation failure test for certbot that doesn't run in CI unless a particular regression test env var is provided. Also includes a helper function to determine whether or not CI is running and if the regression test env var is provided.