### PR TITLE
S3 Auto-Snapshot IAM Roles EKS Incompatibility Footnote

### DIFF
--- a/website/content/docs/enterprise/automated-integrated-storage-snapshots.mdx
+++ b/website/content/docs/enterprise/automated-integrated-storage-snapshots.mdx
@@ -35,6 +35,8 @@ and GCP can be used without specifying credentials, by ensuring that the VMs on
 which Vault is running have been granted permission to access the specified
 object store.
 
+It is worth noting that, at the time of writing, Vault does not allow the use of AWS IAM Roles for EKS Service Accounts to authenticate to S3 buckets for the Automated Integrated Storage Snapshots.
+
 # vs Snapshot Agents
 
 Nomad and Consul Enterprise offer the same functionality in a slightly different way.


### PR DESCRIPTION
This is a common source of confusion for customers when setting up S3 auto snapshots on EKS.

Currently internal feature request 0/1182317814772514/1200126608980599 is open for this.

By adding this footnote, we will save our customer's time spent attempting to configure an unsupported feature.