### PR TITLE
UI: pki remove ui-only params from issuer serializer

### DIFF
--- a/ui/app/serializers/pki/issuer.js
+++ b/ui/app/serializers/pki/issuer.js
@@ -12,11 +12,13 @@ export default class PkiIssuerSerializer extends ApplicationSerializer {
   attrs = {
     caChain: { serialize: false },
     certificate: { serialize: false },
+    commonName: { serialize: false },
+    isDefault: { serialize: false },
+    isRoot: { serialize: false },
     issuerId: { serialize: false },
     keyId: { serialize: false },
     parsedCertificate: { serialize: false },
-    commonName: { serialize: false },
-    isRoot: { serialize: false },
+    serialNumber: { serialize: false },
   };
 
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {


### PR DESCRIPTION
Removes these params so this flash message no longer renders:
![image](https://github.com/hashicorp/vault/assets/68122737/0c3bd36f-62f3-4da1-9a95-266627a13de2)
