### PR TITLE
Backport 1.13.x: License banner fix with expiry on localStorage key name

### DIFF
--- a/ui/app/components/license-banners.js
+++ b/ui/app/components/license-banners.js
@@ -25,13 +25,19 @@ export default class LicenseBanners extends Component {
 
   constructor() {
     super(...arguments);
-    // do not dismiss any banners if the user has updated their version
-    const dismissedBanner = localStorage.getItem(`dismiss-license-banner-${this.currentVersion}`); // returns either warning or expired
-    this.updateDismissType(dismissedBanner);
+    // reset and show a previously dismissed license banner if:
+    // the version has been updated or the license has been updated (indicated by a change in the expiry date).
+    const bannerType = localStorage.getItem(this.dismissedBannerKey); // returns either warning or expired
+
+    this.updateDismissType(bannerType);
   }
 
   get currentVersion() {
     return this.version.version;
+  }
+
+  get dismissedBannerKey() {
+    return `dismiss-license-banner-${this.currentVersion}-${this.args.expiry}`;
   }
 
   get licenseExpired() {
@@ -48,9 +54,9 @@ export default class LicenseBanners extends Component {
   @action
   dismissBanner(dismissAction) {
     // if a client's version changed their old localStorage key will still exists.
-    localStorage.cleanUpStorage('dismiss-license-banner', `dismiss-license-banner-${this.currentVersion}`);
+    localStorage.cleanupStorage('dismiss-license-banner', this.dismissedBannerKey);
     // updates localStorage and then updates the template by calling updateDismissType
-    localStorage.setItem(`dismiss-license-banner-${this.currentVersion}`, dismissAction);
+    localStorage.setItem(this.dismissedBannerKey, dismissAction);
     this.updateDismissType(dismissAction);
   }
 

--- a/ui/app/lib/local-storage.js
+++ b/ui/app/lib/local-storage.js
@@ -16,7 +16,7 @@ export default {
     return Object.keys(window.localStorage);
   },
 
-  cleanUpStorage(string, keyToKeep) {
+  cleanupStorage(string, keyToKeep) {
     if (!string) return;
     const relevantKeys = this.keys().filter((str) => str.startsWith(string));
     relevantKeys?.forEach((key) => {

--- a/ui/tests/unit/lib/local-storage-test.js
+++ b/ui/tests/unit/lib/local-storage-test.js
@@ -12,7 +12,7 @@ module('Unit | lib | local-storage', function (hooks) {
   test('it does not error if nothing is in local storage', async function (assert) {
     assert.expect(1);
     assert.strictEqual(
-      LocalStorage.cleanUpStorage('something', 'something-key'),
+      LocalStorage.cleanupStorage('something', 'something-key'),
       undefined,
       'returns undefined and does not throw an error when method is called and nothing exist in localStorage.'
     );
@@ -24,7 +24,7 @@ module('Unit | lib | local-storage', function (hooks) {
     LocalStorage.setItem('beep-boop-bop-key', 'beep-boop-bop-value');
     LocalStorage.setItem('string-key', 'string-key-value');
     const storageLengthBefore = window.localStorage.length;
-    LocalStorage.cleanUpStorage('string', 'string-key');
+    LocalStorage.cleanupStorage('string', 'string-key');
     const storageLengthAfter = window.localStorage.length;
     assert.strictEqual(
       storageLengthBefore - storageLengthAfter,


### PR DESCRIPTION
License banner - check for new license on localStorage.[ (#20999)](https://github.com/hashicorp/vault/pull/20999/files)

Manual backport. Did not include the conditional around the LicenseBanners in the cluster.hbs. This file is significantly different because of the sidebar work from 1.14. And it was a nice to have anyways, there is no change in functionality.