### PR TITLE
secret/pki: add known issue for slow startup times

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
@@ -204,8 +204,7 @@ Affects Vault 1.12.6.
 
 There was a regression introduced in 1.12.0 where Vault is slow to start because the 
 PKI secret engine performs a list operation on the stored certificates. If a large number 
-of certificates are stored this can cause long start times, performance degradtion for storage 
-operations and leadership changes.
+of certificates are stored this can cause long start times on active and standby nodes.
 
 There is currently no workaround for this other than limiting the number of certificates stored
 in Vault via the [PKI tidy](/vault/api-docs/secret/pki.mdx#tidy) or using `no_store`

--- a/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
@@ -207,9 +207,9 @@ PKI secret engine performs a list operation on the stored certificates. If a lar
 of certificates are stored this can cause long start times, performance degradtion for storage 
 operations and leadership changes.
 
-There is currently no workaround for this other than limiting the number of certificates stored 
-in Vault via the [PKI tidy](/vault/api-docs/secret/pki.mdx#tidy) or using `no_store` 
-flag for [PKI roles[(/vault/api-docs/secret/pki.mdx#createupdate-role)].
+There is currently no workaround for this other than limiting the number of certificates stored
+in Vault via the [PKI tidy](/vault/api-docs/secret/pki.mdx#tidy) or using `no_store`
+flag for [PKI roles](/vault/api-docs/secret/pki.mdx#createupdate-role).
 
 #### Impacted Versions
 

--- a/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
@@ -202,7 +202,7 @@ Affects Vault 1.12.6.
 
 ### Slow Startup Time When Storing PKI Certificates 
 
-There was a regression introduced in 1.12.4 where Vault is slow to start because the 
+There was a regression introduced in 1.12.0 where Vault is slow to start because the 
 PKI secret engine performs a list operation on the stored certificates. If a large number 
 of certificates are stored this can cause long start times, performance degradtion for storage 
 operations and leadership changes.

--- a/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
@@ -199,3 +199,18 @@ vault write auth/ldap/config max_page_size=-1
 #### Impacted Versions
 
 Affects Vault 1.12.6.
+
+### Slow Startup Time When Storing PKI Certificates 
+
+There was a regression introduced in 1.12.4 where Vault is slow to start because the 
+PKI secret engine performs a list operation on the stored certificates. If a large number 
+of certificates are stored this can cause long start times, performance degradtion for storage 
+operations and leadership changes.
+
+There is currently no workaround for this other than limiting the number of certificates stored 
+in Vault via the [PKI tidy](/vault/api-docs/secret/pki.mdx#tidy) or using `no_store` 
+flag for [PKI roles[(/vault/api-docs/secret/pki.mdx#createupdate-role)].
+
+#### Impacted Versions
+
+Affects Vault 1.12.0+

--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -144,7 +144,7 @@ write cross-cluster.
 
 ### Slow Startup Time When Storing PKI Certificates 
 
-There was a regression introduced in 1.12.4 where Vault is slow to start because the 
+There was a regression introduced in 1.13.0 where Vault is slow to start because the 
 PKI secret engine performs a list operation on the stored certificates. If a large number 
 of certificates are stored this can cause long start times, performance degradtion for storage 
 operations and leadership changes.

--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -144,10 +144,9 @@ write cross-cluster.
 
 ### Slow Startup Time When Storing PKI Certificates 
 
-There was a regression introduced in 1.13.0 where Vault is slow to start because the 
-PKI secret engine performs a list operation on the stored certificates. If a large number 
-of certificates are stored this can cause long start times, performance degradtion for storage 
-operations and leadership changes.
+There was a regression introduced in 1.13.0 where Vault is slow to start because the
+PKI secret engine performs a list operation on the stored certificates. If a large number
+of certificates are stored this can cause long start times on active and standby nodes.
 
 There is currently no workaround for this other than limiting the number of certificates stored 
 in Vault via the [PKI tidy](/vault/api-docs/secret/pki.mdx#tidy) or using `no_store` 

--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -151,7 +151,7 @@ operations and leadership changes.
 
 There is currently no workaround for this other than limiting the number of certificates stored 
 in Vault via the [PKI tidy](/vault/api-docs/secret/pki.mdx#tidy) or using `no_store` 
-flag for [PKI roles[(/vault/api-docs/secret/pki.mdx#createupdate-role)].
+flag for [PKI roles](/vault/api-docs/secret/pki.mdx#createupdate-role).
 
 #### Impacted Versions
 

--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -141,3 +141,18 @@ Affects Vault 1.13.0 to 1.13.2. Fixed in 1.13.3.
 On upgrade, all local revocations will be synchronized between
 clusters; revocation requests are not persisted when failing to
 write cross-cluster.
+
+### Slow Startup Time When Storing PKI Certificates 
+
+There was a regression introduced in 1.12.4 where Vault is slow to start because the 
+PKI secret engine performs a list operation on the stored certificates. If a large number 
+of certificates are stored this can cause long start times, performance degradtion for storage 
+operations and leadership changes.
+
+There is currently no workaround for this other than limiting the number of certificates stored 
+in Vault via the [PKI tidy](/vault/api-docs/secret/pki.mdx#tidy) or using `no_store` 
+flag for [PKI roles[(/vault/api-docs/secret/pki.mdx#createupdate-role)].
+
+#### Impacted Versions
+
+Affects Vault 1.13.0+


### PR DESCRIPTION
Reported in https://github.com/hashicorp/vault/issues/21042 and the [fix](https://github.com/hashicorp/vault/pull/18186) is being backported to 1.12 and 1.13.