### PR TITLE
Use buffered channel for inmemlayer's pendingConns to fix timeout errors

### DIFF
--- a/vault/cluster/inmem_layer.go
+++ b/vault/cluster/inmem_layer.go
@@ -107,7 +107,7 @@ func (l *InmemLayer) Listeners() []NetworkListener {
 
 	l.listener = &inmemListener{
 		addr:         l.addr,
-		pendingConns: make(chan net.Conn),
+		pendingConns: make(chan net.Conn, 1),
 
 		stopped: atomic.NewBool(false),
 		stopCh:  make(chan struct{}),


### PR DESCRIPTION
Error in question is "transport: Error while dialing: inmemlayer: timeout while accepting connection".  Example failure: https://github.com/hashicorp/vault-enterprise/actions/runs/5221660248/jobs/9426294453