### PR TITLE
[QT-509] enos: pin to enos-provider < 0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ Vagrantfile
 
 # Enos
 enos/.enos
+enos/enos-local.vars.hcl
 enos/support
 # Enos local Terraform files
 enos/.terraform/*

--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -16,9 +16,7 @@ module "backend_consul" {
   environment     = "ci"
   common_tags     = var.tags
   ssh_aws_keypair = var.aws_ssh_keypair_name
-
-  # Set this to a real license vault if using an Enterprise edition of Consul
-  consul_license = var.backend_license_path == null ? "none" : file(abspath(var.backend_license_path))
+  consul_license  = var.backend_license_path == null ? null : file(abspath(var.backend_license_path))
 }
 
 module "backend_raft" {
@@ -105,7 +103,8 @@ module "vault_verify_agent_output" {
 module "vault_cluster" {
   source = "./modules/vault_cluster"
 
-  install_dir = var.vault_install_dir
+  install_dir    = var.vault_install_dir
+  consul_license = var.backend_license_path == null ? null : file(abspath(var.backend_license_path))
 }
 
 module "vault_get_cluster_ips" {

--- a/enos/enos-terraform.hcl
+++ b/enos/enos-terraform.hcl
@@ -27,7 +27,8 @@ terraform "default" {
     }
 
     enos = {
-      source = "app.terraform.io/hashicorp-qti/enos"
+      source  = "app.terraform.io/hashicorp-qti/enos"
+      version = "< 0.4.0"
     }
   }
 }

--- a/enos/k8s/enos-modules-k8s.hcl
+++ b/enos/k8s/enos-modules-k8s.hcl
@@ -44,7 +44,7 @@ module "k8s_verify_version" {
 module "k8s_verify_write_data" {
   source = "../modules/k8s_vault_verify_write_data"
 
-  vault_instance_count   = var.vault_instance_count
+  vault_instance_count = var.vault_instance_count
 }
 
 module "read_license" {

--- a/enos/k8s/enos-scenario-k8s.hcl
+++ b/enos/k8s/enos-scenario-k8s.hcl
@@ -18,7 +18,7 @@ scenario "k8s" {
     image_path = abspath(var.vault_docker_image_archive)
 
     image_repo = var.vault_image_repository != null ? var.vault_image_repository : matrix.edition == "oss" ? "hashicorp/vault" : "hashicorp/vault-enterprise"
-    image_tag = replace(var.vault_product_version, "+ent", "-ent")
+    image_tag  = replace(var.vault_product_version, "+ent", "-ent")
 
     // The additional '-0' is required in the constraint since without it, the semver function will
     // only compare the non-pre-release parts (Major.Minor.Patch) of the version and the constraint,
@@ -74,7 +74,7 @@ scenario "k8s" {
 
   step "verify_build_date" {
     skip_step = !local.version_includes_build_date
-    module = module.k8s_verify_build_date
+    module    = module.k8s_verify_build_date
 
     variables {
       vault_pods        = step.deploy_vault.vault_pods
@@ -100,7 +100,7 @@ scenario "k8s" {
   }
 
   step "verify_ui" {
-    module = module.k8s_verify_ui
+    module    = module.k8s_verify_ui
     skip_step = matrix.edition == "oss"
 
     variables {

--- a/enos/k8s/enos-terraform-k8s.hcl
+++ b/enos/k8s/enos-terraform-k8s.hcl
@@ -3,13 +3,15 @@
 
 terraform "k8s" {
   required_version = ">= 1.2.0"
+
   required_providers {
     enos = {
-      source = "app.terraform.io/hashicorp-qti/enos"
+      source  = "app.terraform.io/hashicorp-qti/enos"
+      version = "< 0.4.0"
     }
 
     helm = {
-      source  = "hashicorp/helm"
+      source = "hashicorp/helm"
     }
   }
 }

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -122,6 +122,7 @@ resource "enos_consul_start" "consul" {
     retry_join       = ["provider=aws tag_key=Type tag_value=${var.consul_cluster_tag}"]
     server           = false
     bootstrap_expect = 0
+    license          = var.consul_license
     log_level        = "INFO"
     log_file         = var.consul_log_file
   }

--- a/enos/modules/vault_cluster/variables.tf
+++ b/enos/modules/vault_cluster/variables.tf
@@ -51,10 +51,28 @@ variable "consul_install_dir" {
   default     = "/opt/consul/bin"
 }
 
+variable "consul_license" {
+  type        = string
+  sensitive   = true
+  description = "The consul enterprise license"
+  default     = null
+}
+
 variable "consul_log_file" {
   type        = string
   description = "The file where the consul will write log output"
   default     = "/var/log/consul.log"
+}
+
+variable "consul_log_level" {
+  type        = string
+  description = "The consul service log level"
+  default     = "info"
+
+  validation {
+    condition     = contains(["trace", "debug", "info", "warn", "error"], var.consul_log_level)
+    error_message = "The vault_log_level must be one of 'trace', 'debug', 'info', 'warn', or 'error'."
+  }
 }
 
 variable "consul_release" {


### PR DESCRIPTION
Temporarily pin the enos provider to < 0.4.0 to gracefully roll out new provider changes. We also include some minor changes to handle new features coming in the consul module.