### PR TITLE
[QT-527][QT-509] enos: use latest version of enos-provider

### DIFF
--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -105,6 +105,7 @@ module "vault_cluster" {
 
   install_dir    = var.vault_install_dir
   consul_license = var.backend_license_path == null ? null : file(abspath(var.backend_license_path))
+  log_level      = var.vault_log_level
 }
 
 module "vault_get_cluster_ips" {

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -137,12 +137,9 @@ scenario "agent" {
     }
 
     variables {
-      artifactory_release   = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
-      awskms_unseal_key_arn = step.create_vpc.kms_key_arn
-      cluster_name          = step.create_vault_cluster_targets.cluster_name
-      config_env_vars = {
-        VAULT_LOG_LEVEL = var.vault_log_level
-      }
+      artifactory_release      = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
+      awskms_unseal_key_arn    = step.create_vpc.kms_key_arn
+      cluster_name             = step.create_vault_cluster_targets.cluster_name
       install_dir              = var.vault_install_dir
       license                  = matrix.edition != "oss" ? step.read_license.license : null
       local_artifact_path      = local.bundle_path

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -151,14 +151,11 @@ scenario "autopilot" {
     variables {
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_name          = step.create_vault_cluster_targets.cluster_name
-      config_env_vars = {
-        VAULT_LOG_LEVEL = var.vault_log_level
-      }
-      install_dir     = local.vault_install_dir
-      license         = matrix.edition != "oss" ? step.read_license.license : null
-      packages        = local.packages
-      release         = var.vault_autopilot_initial_release
-      storage_backend = "raft"
+      install_dir           = local.vault_install_dir
+      license               = matrix.edition != "oss" ? step.read_license.license : null
+      packages              = local.packages
+      release               = var.vault_autopilot_initial_release
+      storage_backend       = "raft"
       storage_backend_addl_config = {
         autopilot_upgrade_version = var.vault_autopilot_initial_release.version
       }

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -179,10 +179,7 @@ scenario "replication" {
       artifactory_release   = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_name          = step.create_primary_cluster_targets.cluster_name
-      config_env_vars = {
-        VAULT_LOG_LEVEL = var.vault_log_level
-      }
-      consul_cluster_tag = step.create_primary_backend_cluster.consul_cluster_tag
+      consul_cluster_tag    = step.create_primary_backend_cluster.consul_cluster_tag
       consul_release = matrix.primary_backend == "consul" ? {
         edition = var.backend_edition
         version = matrix.consul_version
@@ -253,10 +250,7 @@ scenario "replication" {
       artifactory_release   = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_name          = step.create_secondary_cluster_targets.cluster_name
-      config_env_vars = {
-        VAULT_LOG_LEVEL = var.vault_log_level
-      }
-      consul_cluster_tag = step.create_secondary_backend_cluster.consul_cluster_tag
+      consul_cluster_tag    = step.create_secondary_backend_cluster.consul_cluster_tag
       consul_release = matrix.secondary_backend == "consul" ? {
         edition = var.backend_edition
         version = matrix.consul_version
@@ -513,10 +507,7 @@ scenario "replication" {
       artifactory_release   = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_name          = step.create_primary_cluster_targets.cluster_name
-      config_env_vars = {
-        VAULT_LOG_LEVEL = var.vault_log_level
-      }
-      consul_cluster_tag = step.create_primary_backend_cluster.consul_cluster_tag
+      consul_cluster_tag    = step.create_primary_backend_cluster.consul_cluster_tag
       consul_release = matrix.primary_backend == "consul" ? {
         edition = var.backend_edition
         version = matrix.consul_version

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -182,10 +182,7 @@ scenario "smoke" {
       artifactory_release   = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_name          = step.create_vault_cluster_targets.cluster_name
-      config_env_vars = {
-        VAULT_LOG_LEVEL = var.vault_log_level
-      }
-      consul_cluster_tag = step.create_backend_cluster.consul_cluster_tag
+      consul_cluster_tag    = step.create_backend_cluster.consul_cluster_tag
       consul_release = matrix.backend == "consul" ? {
         edition = var.backend_edition
         version = matrix.consul_version

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -176,10 +176,7 @@ scenario "upgrade" {
     variables {
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_name          = step.create_vault_cluster_targets.cluster_name
-      config_env_vars = {
-        VAULT_LOG_LEVEL = var.vault_log_level
-      }
-      consul_cluster_tag = step.create_backend_cluster.consul_cluster_tag
+      consul_cluster_tag    = step.create_backend_cluster.consul_cluster_tag
       consul_release = matrix.backend == "consul" ? {
         edition = var.backend_edition
         version = matrix.consul_version

--- a/enos/enos-terraform.hcl
+++ b/enos/enos-terraform.hcl
@@ -28,7 +28,7 @@ terraform "default" {
 
     enos = {
       source  = "app.terraform.io/hashicorp-qti/enos"
-      version = "< 0.4.0"
+      version = ">= 0.4.0"
     }
   }
 }

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -4,7 +4,7 @@ terraform {
     # to the public registry
     enos = {
       source  = "app.terraform.io/hashicorp-qti/enos"
-      version = ">= 0.3.2"
+      version = ">= 0.4.0"
     }
   }
 }
@@ -126,7 +126,7 @@ resource "enos_consul_start" "consul" {
     server           = false
     bootstrap_expect = 0
     license          = var.consul_license
-    log_level        = "INFO"
+    log_level        = var.consul_log_level
     log_file         = var.consul_log_file
   }
   unit_name = "consul"
@@ -160,6 +160,7 @@ resource "enos_vault_start" "leader" {
         tls_disable = "true"
       }
     }
+    log_level = var.log_level
     storage = {
       type       = var.storage_backend
       attributes = ({ for key, value in local.storage_config[each.key] : key => value })
@@ -199,6 +200,7 @@ resource "enos_vault_start" "followers" {
         tls_disable = "true"
       }
     }
+    log_level = var.log_level
     storage = {
       type       = var.storage_backend
       attributes = { for key, value in local.storage_config[each.key] : key => value }

--- a/enos/modules/vault_cluster/variables.tf
+++ b/enos/modules/vault_cluster/variables.tf
@@ -71,7 +71,7 @@ variable "consul_log_level" {
 
   validation {
     condition     = contains(["trace", "debug", "info", "warn", "error"], var.consul_log_level)
-    error_message = "The vault_log_level must be one of 'trace', 'debug', 'info', 'warn', or 'error'."
+    error_message = "The consul_log_level must be one of 'trace', 'debug', 'info', 'warn', or 'error'."
   }
 }
 
@@ -116,6 +116,17 @@ variable "local_artifact_path" {
   type        = string
   description = "The path to a locally built vault artifact to install. It can be a zip archive, RPM, or Debian package"
   default     = null
+}
+
+variable "log_level" {
+  type        = string
+  description = "The vault service log level"
+  default     = "info"
+
+  validation {
+    condition     = contains(["trace", "debug", "info", "warn", "error"], var.log_level)
+    error_message = "The log_level must be one of 'trace', 'debug', 'info', 'warn', or 'error'."
+  }
 }
 
 variable "manage_service" {


### PR DESCRIPTION
Use the latest version of enos-provider and upstream consul module. These changes allow us to configure the vault log level in configuration and also support configuring consul with an enterprise license.