### PR TITLE
test: handle occasional lower capacity in zone d

### DIFF
--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -33,9 +33,9 @@ scenario "agent" {
     }
     install_artifactory_artifact = local.bundle_path == null
     spot_price_max = {
-      // These prices are based on on-demand cost for t3.medium in us-east
-      "rhel"   = "0.1016"
-      "ubuntu" = "0.0416"
+      // These prices are based on on-demand cost for t3.large in us-east
+      "rhel"   = "0.1432"
+      "ubuntu" = "0.0832"
     }
     tags = merge({
       "Project Name" : var.project_name

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -45,9 +45,9 @@ scenario "autopilot" {
       ubuntu = provider.enos.ubuntu
     }
     spot_price_max = {
-      // These prices are based on on-demand cost for t3.medium in us-east
-      "rhel"   = "0.1016"
-      "ubuntu" = "0.0416"
+      // These prices are based on on-demand cost for t3.large in us-east
+      "rhel"   = "0.1432"
+      "ubuntu" = "0.0832"
     }
     tags = merge({
       "Project Name" : var.project_name

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -52,9 +52,9 @@ scenario "replication" {
       ubuntu = provider.enos.ubuntu
     }
     spot_price_max = {
-      // These prices are based on on-demand cost for t3.medium in us-east
-      "rhel"   = "0.1016"
-      "ubuntu" = "0.0416"
+      // These prices are based on on-demand cost for t3.large in us-east
+      "rhel"   = "0.1432"
+      "ubuntu" = "0.0832"
     }
     tags = merge({
       "Project Name" : var.project_name

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -48,9 +48,9 @@ scenario "smoke" {
       ubuntu = provider.enos.ubuntu
     }
     spot_price_max = {
-      // These prices are based on on-demand cost for t3.medium in us-east
-      "rhel"   = "0.1016"
-      "ubuntu" = "0.0416"
+      // These prices are based on on-demand cost for t3.large in us-east
+      "rhel"   = "0.1432"
+      "ubuntu" = "0.0832"
     }
     tags = merge({
       "Project Name" : var.project_name

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -42,9 +42,9 @@ scenario "upgrade" {
       ubuntu = provider.enos.ubuntu
     }
     spot_price_max = {
-      // These prices are based on on-demand cost for t3.medium in us-east
-      "rhel"   = "0.1016"
-      "ubuntu" = "0.0416"
+      // These prices are based on on-demand cost for t3.large in us-east
+      "rhel"   = "0.1432"
+      "ubuntu" = "0.0832"
     }
     tags = merge({
       "Project Name" : var.project_name

--- a/enos/modules/vault_cluster/templates/install-packages.sh
+++ b/enos/modules/vault_cluster/templates/install-packages.sh
@@ -31,9 +31,10 @@ function retry {
 
 echo "Installing Dependencies: $packages"
 if [ -f /etc/debian_version ]; then
-  # Make sure cloud-init is not modifying our sources list while we're trying
-  # to install.
-  retry 7 grep ec2 /etc/apt/sources.list
+  # Do our best to make sure that we don't race with cloud-init. Wait a reasonable time until we
+  # see ec2 in the sources list. Very rarely cloud-init will take longer than we wait. In that case
+  # we'll just install our packages.
+  retry 7 grep ec2 /etc/apt/sources.list || true
 
   cd /tmp
   retry 5 sudo apt update


### PR DESCRIPTION
We seen instances where we try to schedule a spot fleet in the us-east-1d of the vault CI AWS account and cannot get capacity for our instance type. That zone currently supports far fewer instance types so we'll bump our max bid to handle cases where slightly more expensive instances are available. Most of the time we'll be using much cheaper instances but it's better to pay a fraction of a cent more than have to retry the pipeline. As such, we increase our max bid price to something that will almost certainly be fullfilled.

We also allow our package installer to go ahead when cloud init does not update sources like we expect. This should handle occasional failures where cloud-init doesn't update the sources within a reasonable amount of time.