### PR TITLE
Remove ACME bugfix changelog for PR#21115

### DIFF
--- a/changelog/21115.txt
+++ b/changelog/21115.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-secrets/pki: Process pending ACME accepted challenges upon startup
-```


### PR DESCRIPTION
 - Reading the changelog process, it's clear we should not file bug changelogs if we fix issues prior to GA release.

This removes the changelog entry added within PR #21115 as it isn't part of GA release yet. The backport PR for it already removed it for 1.14.x so no need to backport this.