### PR TITLE
docs/pki: add remove_roots_from_chain option to /pki/issue

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -637,6 +637,10 @@ It is suggested to limit access to the path-overridden issue endpoint (on
   `YYYY-MM-ddTHH:MM:SSZ`. Supports the Y10K end date for IEEE 802.1AR-2018
   standard devices, `9999-12-31T23:59:59Z`.
 
+- `remove_roots_from_chain` `(bool: false)` - If true, the returned `ca_chain`
+  field will not include any self-signed CA certificates. Useful if end-users
+  already have the root CA in their trust store.
+
 - `user_ids` `(string: "")` - Specifies the comma-separated list of requested
   User ID (OID 0.9.2342.19200300.100.1.1) Subject values to be placed on the
   signed certificate. This field is validated against `allowed_user_ids` on


### PR DESCRIPTION
Adds the `remove_roots_from_chain` option to the docs for `/pki/issue`, based on [addNonCACommonFields()](https://github.com/hashicorp/vault/blob/4620a301dfe4a9be03f09c51ca8be93d20a60be5/builtin/logical/pki/fields.go#L95).