### PR TITLE
Documentation for bug in MdxInlineAlert

### DIFF
--- a/website/content/docs/agent-and-proxy/agent/process-supervisor.mdx
+++ b/website/content/docs/agent-and-proxy/agent/process-supervisor.mdx
@@ -12,12 +12,16 @@ Vault Agent's Process Supervisor Mode allows Vault secrets to be injected into
 a process via environment variables using
 [Consul Template markup][consul-templating-language].
 
--> If you are running your applications in a Kubernetes cluster, we recommend
+<Tip title="Kubernetes">
+  If you are running your applications in a Kubernetes cluster, we recommend
   evaluating the [Vault Secrets Operator](/vault/docs/platform/k8s/vso) and
   the [Vault Agent Sidecar Injector](/vault/docs/platform/k8s/injector).
+</Tip>
 
-!> Vault Agent's Process Supervisor Mode is in public beta. Please provide your
-   feedback by opening a GitHub issue [here](https://github.com/hashicorp/vault/issues).
+<Warning>
+  Vault Agent's Process Supervisor Mode is in public beta. Please provide your
+  feedback by opening a GitHub issue [here](https://github.com/hashicorp/vault/issues).
+</Warning>
 
 ## Functionality
 


### PR DESCRIPTION
Documentation/example to show the markdown links do not render properly inside the `<Tip>` and `<Warning>` components

![image](https://github.com/hashicorp/vault/assets/5751944/cf415083-82bd-44b9-a823-f5fb0cdb8e00)
