### PR TITLE
Backport of docs/pki: add remove_roots_from_chain option to /pki/issue into release/1.12.x

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -291,6 +291,10 @@ It is suggested to limit access to the path-overridden issue endpoint (on
   `YYYY-MM-ddTHH:MM:SSZ`. Supports the Y10K end date for IEEE 802.1AR-2018
   standard devices, `9999-12-31T23:59:59Z`.
 
+- `remove_roots_from_chain` `(bool: false)` - If true, the returned `ca_chain`
+  field will not include any self-signed CA certificates. Useful if end-users
+  already have the root CA in their trust store.
+
 #### Sample Payload
 
 ```json


### PR DESCRIPTION
Backporting #21161 into release/1.12.x (since the [automated backport](https://github.com/hashicorp/vault/pull/21182) failed).