### PR TITLE
Allow issuance of root certs no AIA when templating is enabled

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -6125,22 +6125,23 @@ func TestPKI_TemplatedAIAs(t *testing.T) {
 	_, err = CBWrite(b, s, "config/urls", aiaData)
 	require.NoError(t, err)
 
-	// But root generation will fail.
+	// Root generation should succeed, but without AIA info.
 	rootData := map[string]interface{}{
 		"common_name": "Long-Lived Root X1",
 		"issuer_name": "long-root-x1",
 		"key_type":    "ec",
 	}
-	_, err = CBWrite(b, s, "root/generate/internal", rootData)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "unable to parse AIA URL")
+	resp, err = CBWrite(b, s, "root/generate/internal", rootData)
+	require.NoError(t, err)
+	_, err = CBDelete(b, s, "root")
+	require.NoError(t, err)
 
-	// Clearing the config and regenerating the root should succeed.
+	// Clearing the config and regenerating the root should still succeed.
 	_, err = CBWrite(b, s, "config/urls", map[string]interface{}{
-		"crl_distribution_points": "",
-		"issuing_certificates":    "",
-		"ocsp_servers":            "",
-		"enable_templating":       false,
+		"crl_distribution_points": "{{cluster_path}}/issuer/my-root-id/crl/der",
+		"issuing_certificates":    "{{cluster_aia_path}}/issuer/my-root-id/der",
+		"ocsp_servers":            "{{cluster_path}}/ocsp",
+		"enable_templating":       true,
 	})
 	require.NoError(t, err)
 	resp, err = CBWrite(b, s, "root/generate/internal", rootData)
@@ -7096,6 +7097,33 @@ func TestPatchIssuer(t *testing.T) {
 			require.Equal(t, []string{id}, resp.Data[testCase.Field], "failed persisting value")
 		}
 	}
+}
+
+func TestGenerateRootCAWithAIA(t *testing.T) {
+	// Generate a root CA at /pki-root
+	b_root, s_root := CreateBackendWithStorage(t)
+
+	// Setup templated AIA information
+	_, err := CBWrite(b_root, s_root, "config/cluster", map[string]interface{}{
+		"path":     "https://localhost:8200",
+		"aia_path": "https://localhost:8200",
+	})
+	require.NoError(t, err, "failed to write AIA settings")
+
+	_, err = CBWrite(b_root, s_root, "config/urls", map[string]interface{}{
+		"crl_distribution_points": "{{cluster_path}}/issuer/{{issuer_id}}/crl/der",
+		"issuing_certificates":    "{{cluster_aia_path}}/issuer/{{issuer_id}}/der",
+		"ocsp_servers":            "{{cluster_path}}/ocsp",
+		"enable_templating":       true,
+	})
+	require.NoError(t, err, "failed to write AIA settings")
+
+	// Write a root issuer, this should succeed.
+	resp, err := CBWrite(b_root, s_root, "root/generate/exported", map[string]interface{}{
+		"common_name": "root myvault.com",
+		"key_type":    "ec",
+	})
+	requireSuccessNonNilResponse(t, resp, err, "expected root generation to succeed")
 }
 
 var (

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -790,6 +790,9 @@ func generateCert(sc *storageContext,
 				}
 
 				uris = &certutil.URLEntries{}
+
+				msg := "When generating root CA, found global AIA configuration with issuer_id template unsuitable for root generation. This AIA configuration has been ignored. To include AIA on this root CA, set the global AIA configuration to not include issuer_id and instead to refer to a static issuer name."
+				warnings = append(warnings, msg)
 			}
 
 			data.Params.URLs = uris

--- a/changelog/21209.txt
+++ b/changelog/21209.txt
@@ -1,0 +1,3 @@
+```release-note:change
+secrets/pki: Allow issuance of root CAs without AIA, when templated AIA information includes issuer_id.
+```


### PR DESCRIPTION
When templating is enabled in `config/urls`, with a URL that includes the best-practice suggestion of `{{issuer_id}}`, we fail to generate root CAs because there is no issuer ID yet. While this is true, the best practice _is_ to include `{{issuer_id}}` on the AIA info, but Root CAs need not specify AIA info; indeed, most public root CAs do not.

Instead of erring, allow this issuance to silently succeed with no AIA information; if AIA information is necessary, it can be manually specified (e.g., using `enable_templating=false` or without `{{issuer_id}}`, such as with a fixed, manually-specified name for this one root certificate).