### PR TITLE
backports for HLL estimates in ActivityLog 1.11.x

### DIFF
--- a/changelog/16000.txt
+++ b/changelog/16000.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Limit activity log client count usage by namespaces
+```

--- a/changelog/16146.txt
+++ b/changelog/16146.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/activity: generate hyperloglogs containing clientIds for each month during precomputation
+```

--- a/changelog/16162.txt
+++ b/changelog/16162.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/activity: refactor activity log api to reuse partial api functions in activity endpoint when current month is specified
+```

--- a/changelog/16184.txt
+++ b/changelog/16184.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/activity: use monthly hyperloglogs to calculate new clients approximation for current month
+```

--- a/changelog/16447.txt
+++ b/changelog/16447.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-activity: Add timestamp to current month calculation and remove deduplication for current month
-```

--- a/changelog/16447.txt
+++ b/changelog/16447.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+activity: Add timestamp to current month calculation and remove deduplication for current month
+```

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/armon/go-radix v1.0.0
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 	github.com/aws/aws-sdk-go v1.37.19
+	github.com/axiomhq/hyperloglog v0.0.0-20220105174342-98591331716a
 	github.com/cenkalti/backoff/v3 v3.2.2
 	github.com/chrismalek/oktasdk-go v0.0.0-20181212195951-3430665dfaa0
 	github.com/client9/misspell v0.3.4
@@ -251,6 +252,7 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba // indirect
+	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
 	github.com/digitalocean/godo v1.7.5 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/dnephin/pflag v1.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.6.1 h1:1Pls85C5CFjhE3aH+h85/hyAk89kQ
 github.com/aws/aws-sdk-go-v2/service/sts v1.6.1/go.mod h1:hLZ/AnkIKHLuPGjEiyghNEdvJ2PP0MgOxcmv9EBJ4xs=
 github.com/aws/smithy-go v1.7.0 h1:+cLHMRrDZvQ4wk+KuQ9yH6eEg6KZEJ9RI2IkDqnygCg=
 github.com/aws/smithy-go v1.7.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
+github.com/axiomhq/hyperloglog v0.0.0-20220105174342-98591331716a h1:eqjiAL3qooftPm8b9C1GsSSRcmlw7iOva8vdBTmV2PY=
+github.com/axiomhq/hyperloglog v0.0.0-20220105174342-98591331716a/go.mod h1:2stgcRjl6QmW+gU2h5E7BQXg4HU0gzxKWDuT5HviN9s=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f h1:ZNv7On9kyUzm7fvRZumSyy/IUiSC7AzL0I1jKKtwooA=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -462,6 +464,8 @@ github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba h1:p6poVbjHDkK
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc h1:8WFBn63wegobsYAX0YjD+8suexZDga5CctH4CCTx2+8=
+github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/digitalocean/godo v1.7.5 h1:JOQbAO6QT1GGjor0doT0mXefX2FgUDPOpYh2RaXA+ko=
 github.com/digitalocean/godo v1.7.5/go.mod h1:h6faOIcZ8lWIwNQ+DN7b3CgX4Kwby5T+nbpNqkUIozU=
@@ -1021,6 +1025,7 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/influxdata/influxdb v1.7.6/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab h1:HqW4xhhynfjrtEiiSGcQUd6vrK23iMam1FO8rI7mwig=
 github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1570,6 +1570,21 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 		if err != nil {
 			return nil, err
 		}
+		// Add the namespace attribution for the current month to the newly computed current month value. Note
+		// that transformMonthBreakdowns calculates a superstruct of the required namespace struct due to its
+		// primary use-case being for precomputedQueryWorker, but we will reuse this code for brevity and extract
+		// the namespaces from it.
+		currentMonthNamespaceAttribution := a.transformMonthBreakdowns(partialByMonth)
+		// Ensure that there is only one element in this list -- if not, warn.
+		if len(currentMonthNamespaceAttribution) > 1 {
+			a.logger.Warn("more than one month worth of namespace and mount attribution calculated for "+
+				"current month values", "number of months", len(currentMonthNamespaceAttribution))
+		}
+		if len(currentMonthNamespaceAttribution) == 0 {
+			a.logger.Warn("no month data found, returning query with no namespace attribution for current month")
+		} else {
+			currentMonth.Namespaces = currentMonthNamespaceAttribution[0].Namespaces
+		}
 		pq.Months = append(pq.Months, currentMonth)
 		distinctEntitiesResponse += pq.Months[len(pq.Months)-1].NewClients.Counts.EntityClients
 	}

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1504,6 +1504,12 @@ func (a *ActivityLog) DefaultStartTime(endTime time.Time) time.Time {
 
 func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.Time, limitNamespaces int) (map[string]interface{}, error) {
 	var computePartial bool
+
+	// Change the start time to the beginning of the month, and the end time to be the end
+	// of the month.
+	startTime = timeutil.StartOfMonth(startTime)
+	endTime = timeutil.EndOfMonth(endTime)
+
 	// If the endTime of the query is the current month, request data from the queryStore
 	// with the endTime equal to the end of the last month, and add in the current month
 	// data.
@@ -1513,16 +1519,26 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 		computePartial = true
 	}
 
-	// From the precomputed queries stored in the queryStore (computed at the end of each month)
-	// get the query associated with the start and end time specified
-	pq, err := a.queryStore.Get(ctx, startTime, precomputedQueryEndTime)
-	if err != nil {
-		return nil, err
+	pq := &activity.PrecomputedQuery{}
+	if startTime.After(precomputedQueryEndTime) && timeutil.IsCurrentMonth(startTime, time.Now().UTC()) {
+		// We're only calculating the partial month client count. Skip the precomputation
+		// get call.
+		pq = &activity.PrecomputedQuery{
+			StartTime:  startTime,
+			EndTime:    endTime,
+			Namespaces: make([]*activity.NamespaceRecord, 0),
+			Months:     make([]*activity.MonthRecord, 0),
+		}
+	} else {
+		storedQuery, err := a.queryStore.Get(ctx, startTime, precomputedQueryEndTime)
+		if err != nil {
+			return nil, err
+		}
+		if storedQuery == nil {
+			return nil, nil
+		}
+		pq = storedQuery
 	}
-	if pq == nil {
-		return nil, nil
-	}
-
 	// Calculate the namespace response breakdowns and totals for entities and tokens from the initial
 	// namespace data.
 	totalEntities, totalTokens, byNamespaceResponse, err := a.calculateByNamespaceResponseForQuery(ctx, pq.Namespaces)
@@ -1634,7 +1650,7 @@ func modifyResponseMonths(months []*ResponseMonth, start time.Time, end time.Tim
 	if err != nil {
 		return months
 	}
-	for start.Before(firstMonth) {
+	for start.Before(firstMonth) && !timeutil.IsCurrentMonth(start, firstMonth) {
 		monthPlaceholder := &ResponseMonth{Timestamp: start.UTC().Format(time.RFC3339)}
 		modifiedResponseMonths = append(modifiedResponseMonths, monthPlaceholder)
 		start = timeutil.StartOfMonth(start.AddDate(0, 1, 0))
@@ -1645,7 +1661,7 @@ func modifyResponseMonths(months []*ResponseMonth, start time.Time, end time.Tim
 		return modifiedResponseMonths
 	}
 	lastMonth := timeutil.EndOfMonth(lastMonthStart)
-	for lastMonth.Before(end) {
+	for lastMonth.Before(end) && !timeutil.IsCurrentMonth(end, lastMonth) {
 		lastMonth = timeutil.StartOfMonth(lastMonth).AddDate(0, 1, 0)
 		monthPlaceholder := &ResponseMonth{Timestamp: lastMonth.UTC().Format(time.RFC3339)}
 		modifiedResponseMonths = append(modifiedResponseMonths, monthPlaceholder)

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1505,7 +1505,7 @@ func (a *ActivityLog) DefaultStartTime(endTime time.Time) time.Time {
 	return monthStart.AddDate(0, -a.defaultReportMonths+1, 0)
 }
 
-func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.Time) (map[string]interface{}, error) {
+func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.Time, limitNamespaces int) (map[string]interface{}, error) {
 	queryNS, err := namespace.FromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -1557,6 +1557,7 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 			} else {
 				displayPath = ns.Path
 			}
+
 			byNamespace = append(byNamespace, &ResponseNamespace{
 				NamespaceID:   nsRecord.NamespaceID,
 				NamespacePath: displayPath,
@@ -1577,6 +1578,19 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 	sort.Slice(byNamespace, func(i, j int) bool {
 		return byNamespace[i].Counts.Clients > byNamespace[j].Counts.Clients
 	})
+	if limitNamespaces > 0 {
+		if limitNamespaces > len(byNamespace) {
+			limitNamespaces = len(byNamespace)
+		}
+		byNamespace = byNamespace[:limitNamespaces]
+		// recalculate total entities and tokens
+		totalEntities = 0
+		totalTokens = 0
+		for _, namespaceData := range byNamespace {
+			totalEntities += namespaceData.Counts.DistinctEntities
+			totalTokens += namespaceData.Counts.NonEntityTokens
+		}
+	}
 
 	responseData["by_namespace"] = byNamespace
 	responseData["total"] = &ResponseCounts{

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1719,9 +1719,6 @@ func modifyResponseMonths(months []*ResponseMonth, start time.Time, end time.Tim
 		return months
 	}
 	start = timeutil.StartOfMonth(start)
-	if timeutil.IsCurrentMonth(end, time.Now().UTC()) {
-		end = timeutil.StartOfMonth(end).AddDate(0, -1, 0)
-	}
 	end = timeutil.EndOfMonth(end)
 	if timeutil.IsCurrentMonth(end, time.Now().UTC()) {
 		end = timeutil.EndOfMonth(timeutil.StartOfMonth(end).AddDate(0, -1, 0))

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1719,6 +1719,9 @@ func modifyResponseMonths(months []*ResponseMonth, start time.Time, end time.Tim
 		return months
 	}
 	start = timeutil.StartOfMonth(start)
+	if timeutil.IsCurrentMonth(end, time.Now().UTC()) {
+		end = timeutil.StartOfMonth(end).AddDate(0, -1, 0)
+	}
 	end = timeutil.EndOfMonth(end)
 	if timeutil.IsCurrentMonth(end, time.Now().UTC()) {
 		end = timeutil.EndOfMonth(timeutil.StartOfMonth(end).AddDate(0, -1, 0))

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1504,22 +1504,15 @@ type ResponseNamespace struct {
 }
 
 type ResponseMonth struct {
-	Timestamp  string                      `json:"timestamp"`
-	Counts     *ResponseCounts             `json:"counts"`
-	Namespaces []*ResponseMonthlyNamespace `json:"namespaces"`
-	NewClients *ResponseNewClients         `json:"new_clients" mapstructure:"new_clients"`
+	Timestamp  string               `json:"timestamp"`
+	Counts     *ResponseCounts      `json:"counts"`
+	Namespaces []*ResponseNamespace `json:"namespaces"`
+	NewClients *ResponseNewClients  `json:"new_clients" mapstructure:"new_clients"`
 }
 
 type ResponseNewClients struct {
-	Counts     *ResponseCounts             `json:"counts"`
-	Namespaces []*ResponseMonthlyNamespace `json:"namespaces"`
-}
-
-type ResponseMonthlyNamespace struct {
-	NamespaceID   string           `json:"namespace_id"`
-	NamespacePath string           `json:"namespace_path"`
-	Counts        *ResponseCounts  `json:"counts"`
-	Mounts        []*ResponseMount `json:"mounts"`
+	Counts     *ResponseCounts      `json:"counts"`
+	Namespaces []*ResponseNamespace `json:"namespaces"`
 }
 
 type ResponseMount struct {
@@ -1557,12 +1550,19 @@ func (a *ActivityLog) DefaultStartTime(endTime time.Time) time.Time {
 }
 
 func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.Time, limitNamespaces int) (map[string]interface{}, error) {
-	queryNS, err := namespace.FromContext(ctx)
-	if err != nil {
-		return nil, err
+	var computePartial bool
+	// If the endTime of the query is the current month, request data from the queryStore
+	// with the endTime equal to the end of the last month, and add in the current month
+	// data.
+	precomputedQueryEndTime := endTime
+	if timeutil.IsCurrentMonth(endTime, time.Now().UTC()) {
+		precomputedQueryEndTime = timeutil.EndOfMonth(timeutil.MonthsPreviousTo(1, timeutil.StartOfMonth(endTime)))
+		computePartial = true
 	}
 
-	pq, err := a.queryStore.Get(ctx, startTime, endTime)
+	// From the precomputed queries stored in the queryStore (computed at the end of each month)
+	// get the query associated with the start and end time specified
+	pq, err := a.queryStore.Get(ctx, startTime, precomputedQueryEndTime)
 	if err != nil {
 		return nil, err
 	}
@@ -1570,207 +1570,80 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 		return nil, nil
 	}
 
-	responseData := make(map[string]interface{})
-	responseData["start_time"] = pq.StartTime.Format(time.RFC3339)
-	responseData["end_time"] = pq.EndTime.Format(time.RFC3339)
-	byNamespace := make([]*ResponseNamespace, 0)
+	// Calculate the namespace response breakdowns and totals for entities and tokens from the initial
+	// namespace data.
+	totalEntities, totalTokens, byNamespaceResponse, err := a.calculateByNamespaceResponseForQuery(ctx, pq.Namespaces)
+	if err != nil {
+		return nil, err
+	}
 
-	totalEntities := 0
-	totalTokens := 0
+	// If we need to add the current month's client counts into the total, compute the namespace
+	// breakdown for the current month as well.
+	var partialByMonth map[int64]*processMonth
+	var partialByNamespace map[string]*processByNamespace
+	var totalEntitiesCurrent int
+	var totalTokensCurrent int
+	var byNamespaceResponseCurrent []*ResponseNamespace
+	if computePartial {
+		// Traverse through current month's activitylog data and group clients
+		// into months and namespaces
+		partialByMonth, partialByNamespace = a.populateNamespaceAndMonthlyBreakdowns()
 
-	for _, nsRecord := range pq.Namespaces {
-		ns, err := NamespaceByID(ctx, nsRecord.NamespaceID, a.core)
+		// Convert the byNamespace breakdowns into structs that are
+		// consumable by the /activity endpoint, so as to reuse code between these two
+		// endpoints.
+		byNamespaceComputation := a.transformALNamespaceBreakdowns(partialByNamespace)
+
+		// Calculate the namespace response breakdowns and totals for entities and tokens from the initial
+		// namespace data.
+		totalEntitiesCurrent, totalTokensCurrent, byNamespaceResponseCurrent, err = a.calculateByNamespaceResponseForQuery(ctx, byNamespaceComputation)
 		if err != nil {
 			return nil, err
 		}
-		if a.includeInResponse(queryNS, ns) {
-			mountResponse := make([]*ResponseMount, 0, len(nsRecord.Mounts))
-			for _, mountRecord := range nsRecord.Mounts {
-				mountResponse = append(mountResponse, &ResponseMount{
-					MountPath: mountRecord.MountPath,
-					Counts: &ResponseCounts{
-						DistinctEntities: int(mountRecord.Counts.EntityClients),
-						EntityClients:    int(mountRecord.Counts.EntityClients),
-						NonEntityClients: int(mountRecord.Counts.NonEntityClients),
-						NonEntityTokens:  int(mountRecord.Counts.NonEntityClients),
-						Clients:          int(mountRecord.Counts.EntityClients + mountRecord.Counts.NonEntityClients),
-					},
-				})
-			}
-			// Sort the mounts in descending order of usage
-			sort.Slice(mountResponse, func(i, j int) bool {
-				return mountResponse[i].Counts.Clients > mountResponse[j].Counts.Clients
-			})
 
-			var displayPath string
-			if ns == nil {
-				displayPath = fmt.Sprintf("deleted namespace %q", nsRecord.NamespaceID)
-			} else {
-				displayPath = ns.Path
-			}
-
-			byNamespace = append(byNamespace, &ResponseNamespace{
-				NamespaceID:   nsRecord.NamespaceID,
-				NamespacePath: displayPath,
-				Counts: ResponseCounts{
-					DistinctEntities: int(nsRecord.Entities),
-					EntityClients:    int(nsRecord.Entities),
-					NonEntityTokens:  int(nsRecord.NonEntityTokens),
-					NonEntityClients: int(nsRecord.NonEntityTokens),
-					Clients:          int(nsRecord.Entities + nsRecord.NonEntityTokens),
-				},
-				Mounts: mountResponse,
-			})
-			totalEntities += int(nsRecord.Entities)
-			totalTokens += int(nsRecord.NonEntityTokens)
-		}
+		// Add the current month's namespace data the precomputed query namespaces
+		byNamespaceResponse = append(byNamespaceResponse, byNamespaceResponseCurrent...)
 	}
+	// Sort clients within each namespace
+	a.sortALResponseNamespaces(byNamespaceResponse)
 
-	sort.Slice(byNamespace, func(i, j int) bool {
-		return byNamespace[i].Counts.Clients > byNamespace[j].Counts.Clients
-	})
 	if limitNamespaces > 0 {
-		if limitNamespaces > len(byNamespace) {
-			limitNamespaces = len(byNamespace)
-		}
-		byNamespace = byNamespace[:limitNamespaces]
-		// recalculate total entities and tokens
-		totalEntities = 0
-		totalTokens = 0
-		for _, namespaceData := range byNamespace {
-			totalEntities += namespaceData.Counts.DistinctEntities
-			totalTokens += namespaceData.Counts.NonEntityTokens
-		}
+		totalEntities, totalTokens, byNamespaceResponse = a.limitNamespacesInALResponse(byNamespaceResponse, limitNamespaces)
 	}
 
-	responseData["by_namespace"] = byNamespace
+	distinctEntitiesResponse := totalEntities
+	if computePartial {
+		currentMonth, err := a.computeCurrentMonthForBillingPeriod(partialByMonth, startTime, endTime)
+		if err != nil {
+			return nil, err
+		}
+		pq.Months = append(pq.Months, currentMonth)
+		distinctEntitiesResponse += pq.Months[len(pq.Months)-1].NewClients.Counts.EntityClients
+	}
+
+	// Now populate the response based on breakdowns.
+	responseData := make(map[string]interface{})
+	responseData["start_time"] = pq.StartTime.Format(time.RFC3339)
+	responseData["end_time"] = pq.EndTime.Format(time.RFC3339)
+	responseData["by_namespace"] = byNamespaceResponse
 	responseData["total"] = &ResponseCounts{
-		DistinctEntities: totalEntities,
-		EntityClients:    totalEntities,
-		NonEntityTokens:  totalTokens,
-		NonEntityClients: totalTokens,
-		Clients:          totalEntities + totalTokens,
+		DistinctEntities: distinctEntitiesResponse,
+		EntityClients:    totalEntities + totalEntitiesCurrent,
+		NonEntityTokens:  totalTokens + totalTokensCurrent,
+		NonEntityClients: totalTokens + totalTokensCurrent,
+		Clients:          totalEntities + totalEntitiesCurrent + totalTokens + totalTokensCurrent,
 	}
 
-	prepareNSResponse := func(nsRecords []*activity.MonthlyNamespaceRecord) ([]*ResponseMonthlyNamespace, error) {
-		nsResponse := make([]*ResponseMonthlyNamespace, 0, len(nsRecords))
-		for _, nsRecord := range nsRecords {
-			if int(nsRecord.Counts.EntityClients) == 0 && int(nsRecord.Counts.NonEntityClients) == 0 {
-				continue
-			}
-
-			ns, err := NamespaceByID(ctx, nsRecord.NamespaceID, a.core)
-			if err != nil {
-				return nil, err
-			}
-			if a.includeInResponse(queryNS, ns) {
-				mountResponse := make([]*ResponseMount, 0, len(nsRecord.Mounts))
-				for _, mountRecord := range nsRecord.Mounts {
-					if int(mountRecord.Counts.EntityClients) == 0 && int(mountRecord.Counts.NonEntityClients) == 0 {
-						continue
-					}
-
-					mountResponse = append(mountResponse, &ResponseMount{
-						MountPath: mountRecord.MountPath,
-						Counts: &ResponseCounts{
-							EntityClients:    int(mountRecord.Counts.EntityClients),
-							NonEntityClients: int(mountRecord.Counts.NonEntityClients),
-							Clients:          int(mountRecord.Counts.EntityClients + mountRecord.Counts.NonEntityClients),
-						},
-					})
-				}
-
-				var displayPath string
-				if ns == nil {
-					displayPath = fmt.Sprintf("deleted namespace %q", nsRecord.NamespaceID)
-				} else {
-					displayPath = ns.Path
-				}
-				nsResponse = append(nsResponse, &ResponseMonthlyNamespace{
-					NamespaceID:   nsRecord.NamespaceID,
-					NamespacePath: displayPath,
-					Counts: &ResponseCounts{
-						EntityClients:    int(nsRecord.Counts.EntityClients),
-						NonEntityClients: int(nsRecord.Counts.NonEntityClients),
-						Clients:          int(nsRecord.Counts.EntityClients + nsRecord.Counts.NonEntityClients),
-					},
-					Mounts: mountResponse,
-				})
-			}
-		}
-		return nsResponse, nil
+	// Create and populate the month response structs based on the monthly breakdown.
+	months, err := a.prepareMonthsResponseForQuery(ctx, pq.Months)
+	if err != nil {
+		return nil, err
 	}
 
-	months := make([]*ResponseMonth, 0, len(pq.Months))
-	for _, monthsRecord := range pq.Months {
-		newClientsResponse := &ResponseNewClients{}
-		if int(monthsRecord.NewClients.Counts.EntityClients+monthsRecord.NewClients.Counts.NonEntityClients) != 0 {
-			newClientsNSResponse, err := prepareNSResponse(monthsRecord.NewClients.Namespaces)
-			if err != nil {
-				return nil, err
-			}
-			newClientsResponse.Counts = &ResponseCounts{
-				EntityClients:    int(monthsRecord.NewClients.Counts.EntityClients),
-				NonEntityClients: int(monthsRecord.NewClients.Counts.NonEntityClients),
-				Clients:          int(monthsRecord.NewClients.Counts.EntityClients + monthsRecord.NewClients.Counts.NonEntityClients),
-			}
-			newClientsResponse.Namespaces = newClientsNSResponse
-		}
+	// Sort the months and clients within each month before adding the months to the response
+	a.sortActivityLogMonthsResponse(months)
 
-		monthResponse := &ResponseMonth{
-			Timestamp: time.Unix(monthsRecord.Timestamp, 0).UTC().Format(time.RFC3339),
-		}
-		if int(monthsRecord.Counts.EntityClients+monthsRecord.Counts.NonEntityClients) != 0 {
-			nsResponse, err := prepareNSResponse(monthsRecord.Namespaces)
-			if err != nil {
-				return nil, err
-			}
-			monthResponse.Counts = &ResponseCounts{
-				EntityClients:    int(monthsRecord.Counts.EntityClients),
-				NonEntityClients: int(monthsRecord.Counts.NonEntityClients),
-				Clients:          int(monthsRecord.Counts.EntityClients + monthsRecord.Counts.NonEntityClients),
-			}
-			monthResponse.Namespaces = nsResponse
-			monthResponse.NewClients = newClientsResponse
-			months = append(months, monthResponse)
-		}
-	}
-
-	// Sort the months in ascending order of timestamps
-	sort.Slice(months, func(i, j int) bool {
-		firstTimestamp, errOne := time.Parse(time.RFC3339, months[i].Timestamp)
-		secondTimestamp, errTwo := time.Parse(time.RFC3339, months[j].Timestamp)
-		if errOne == nil && errTwo == nil {
-			return firstTimestamp.Before(secondTimestamp)
-		}
-		// Keep the nondeterministic ordering in storage
-		a.logger.Error("unable to parse activity log timestamps", "timestamp",
-			months[i].Timestamp, "error", errOne, "timestamp", months[j].Timestamp, "error", errTwo)
-		return i < j
-	})
-
-	// Within each month sort everything by descending order of activity
-	for _, month := range months {
-		sort.Slice(month.Namespaces, func(i, j int) bool {
-			return month.Namespaces[i].Counts.Clients > month.Namespaces[j].Counts.Clients
-		})
-
-		for _, ns := range month.Namespaces {
-			sort.Slice(ns.Mounts, func(i, j int) bool {
-				return ns.Mounts[i].Counts.Clients > ns.Mounts[j].Counts.Clients
-			})
-		}
-
-		sort.Slice(month.NewClients.Namespaces, func(i, j int) bool {
-			return month.NewClients.Namespaces[i].Counts.Clients > month.NewClients.Namespaces[j].Counts.Clients
-		})
-
-		for _, ns := range month.NewClients.Namespaces {
-			sort.Slice(ns.Mounts, func(i, j int) bool {
-				return ns.Mounts[i].Counts.Clients > ns.Mounts[j].Counts.Clients
-			})
-		}
-	}
+	// Modify the final month output to make response more consumable based on API request
 	months = modifyResponseMonths(months, startTime, endTime)
 	responseData["months"] = months
 
@@ -2227,68 +2100,7 @@ func (a *ActivityLog) precomputedQueryWorker(ctx context.Context) error {
 			Namespaces: make([]*activity.NamespaceRecord, 0, len(byNamespace)),
 			Months:     make([]*activity.MonthRecord, 0, len(byMonth)),
 		}
-
-		processNamespaces := func(nsMap map[string]*processByNamespace) []*activity.MonthlyNamespaceRecord {
-			nsRecord := make([]*activity.MonthlyNamespaceRecord, 0, len(nsMap))
-			for nsID, nsData := range nsMap {
-				// Process mount specific data within a namespace within a given month
-				mountRecord := make([]*activity.MountRecord, 0, len(nsMap[nsID].Mounts))
-				for mountAccessor, mountData := range nsMap[nsID].Mounts {
-					var displayPath string
-					if mountAccessor == "" {
-						displayPath = "no mount accessor (pre-1.10 upgrade?)"
-					} else {
-						valResp := a.core.router.ValidateMountByAccessor(mountAccessor)
-						if valResp == nil {
-							displayPath = fmt.Sprintf("deleted mount; accessor %q", mountAccessor)
-						} else {
-							displayPath = valResp.MountPath
-						}
-					}
-
-					mountRecord = append(mountRecord, &activity.MountRecord{
-						MountPath: displayPath,
-						Counts: &activity.CountsRecord{
-							EntityClients:    len(mountData.Counts.Entities),
-							NonEntityClients: int(mountData.Counts.Tokens) + len(mountData.Counts.NonEntities),
-						},
-					})
-				}
-
-				// Process ns specific data within a given month
-				nsRecord = append(nsRecord, &activity.MonthlyNamespaceRecord{
-					NamespaceID: nsID,
-					Counts: &activity.CountsRecord{
-						EntityClients:    len(nsData.Counts.Entities),
-						NonEntityClients: int(nsData.Counts.Tokens) + len(nsData.Counts.NonEntities),
-					},
-					Mounts: mountRecord,
-				})
-			}
-			return nsRecord
-		}
-
-		for timestamp, monthData := range byMonth {
-			newClientsNSRecord := processNamespaces(monthData.NewClients.Namespaces)
-			newClientRecord := &activity.NewClientRecord{
-				Counts: &activity.CountsRecord{
-					EntityClients:    len(monthData.NewClients.Counts.Entities),
-					NonEntityClients: int(monthData.NewClients.Counts.Tokens) + len(monthData.NewClients.Counts.NonEntities),
-				},
-				Namespaces: newClientsNSRecord,
-			}
-
-			// Process all the months
-			pq.Months = append(pq.Months, &activity.MonthRecord{
-				Timestamp: timestamp,
-				Counts: &activity.CountsRecord{
-					EntityClients:    len(monthData.Counts.Entities),
-					NonEntityClients: int(monthData.Counts.Tokens) + len(monthData.Counts.NonEntities),
-				},
-				Namespaces: processNamespaces(monthData.Namespaces),
-				NewClients: newClientRecord,
-			})
-		}
+		pq.Months = a.transformMonthBreakdowns(byMonth)
 
 		for nsID, entry := range byNamespace {
 			mountRecord := make([]*activity.MountRecord, 0, len(entry.Mounts))
@@ -2442,6 +2254,234 @@ func (c *Core) activeEntityGaugeCollector(ctx context.Context) ([]metricsutil.Ga
 	return a.PartialMonthMetrics(ctx)
 }
 
+// populateNamespaceAndMonthlyBreakdowns traverses the partial month data
+// stored in memory and groups them by months and namespaces.
+func (a *ActivityLog) populateNamespaceAndMonthlyBreakdowns() (map[int64]*processMonth, map[string]*processByNamespace) {
+	// Parse the monthly clients and prepare the breakdowns.
+	byNamespace := make(map[string]*processByNamespace)
+	byMonth := make(map[int64]*processMonth)
+	for _, e := range a.partialMonthClientTracker {
+		processClientRecord(e, byNamespace, byMonth, time.Now())
+	}
+	return byMonth, byNamespace
+}
+
+func (a *ActivityLog) transformMonthBreakdowns(byMonth map[int64]*processMonth) []*activity.MonthRecord {
+	monthly := make([]*activity.MonthRecord, 0)
+	processByNamespaces := func(nsMap map[string]*processByNamespace) []*activity.MonthlyNamespaceRecord {
+		nsRecord := make([]*activity.MonthlyNamespaceRecord, 0, len(nsMap))
+		for nsID, nsData := range nsMap {
+			// Process mount specific data within a namespace within a given month
+			mountRecord := make([]*activity.MountRecord, 0, len(nsMap[nsID].Mounts))
+			for mountAccessor, mountData := range nsMap[nsID].Mounts {
+				var displayPath string
+				if mountAccessor == "" {
+					displayPath = "no mount accessor (pre-1.10 upgrade?)"
+				} else {
+					valResp := a.core.router.ValidateMountByAccessor(mountAccessor)
+					if valResp == nil {
+						displayPath = fmt.Sprintf("deleted mount; accessor %q", mountAccessor)
+					} else {
+						displayPath = valResp.MountPath
+					}
+				}
+
+				mountRecord = append(mountRecord, &activity.MountRecord{
+					MountPath: displayPath,
+					Counts: &activity.CountsRecord{
+						EntityClients:    len(mountData.Counts.Entities),
+						NonEntityClients: int(mountData.Counts.Tokens) + len(mountData.Counts.NonEntities),
+					},
+				})
+			}
+
+			// Process ns specific data within a given month
+			nsRecord = append(nsRecord, &activity.MonthlyNamespaceRecord{
+				NamespaceID: nsID,
+				Counts: &activity.CountsRecord{
+					EntityClients:    len(nsData.Counts.Entities),
+					NonEntityClients: int(nsData.Counts.Tokens) + len(nsData.Counts.NonEntities),
+				},
+				Mounts: mountRecord,
+			})
+		}
+		return nsRecord
+	}
+	for timestamp, monthData := range byMonth {
+		newClientsNSRecord := processByNamespaces(monthData.NewClients.Namespaces)
+		newClientRecord := &activity.NewClientRecord{
+			Counts: &activity.CountsRecord{
+				EntityClients:    len(monthData.NewClients.Counts.Entities),
+				NonEntityClients: int(monthData.NewClients.Counts.Tokens) + len(monthData.NewClients.Counts.NonEntities),
+			},
+			Namespaces: newClientsNSRecord,
+		}
+
+		// Process all the months
+		monthly = append(monthly, &activity.MonthRecord{
+			Timestamp: timestamp,
+			Counts: &activity.CountsRecord{
+				EntityClients:    len(monthData.Counts.Entities),
+				NonEntityClients: int(monthData.Counts.Tokens) + len(monthData.Counts.NonEntities),
+			},
+			Namespaces: processByNamespaces(monthData.Namespaces),
+			NewClients: newClientRecord,
+		})
+	}
+	return monthly
+}
+
+func (a *ActivityLog) calculateByNamespaceResponseForQuery(ctx context.Context, byNamespace []*activity.NamespaceRecord) (int, int, []*ResponseNamespace, error) {
+	queryNS, err := namespace.FromContext(ctx)
+	if err != nil {
+		return 0, 0, nil, err
+	}
+	byNamespaceResponse := make([]*ResponseNamespace, 0)
+	totalEntities := 0
+	totalTokens := 0
+
+	for _, nsRecord := range byNamespace {
+		ns, err := NamespaceByID(ctx, nsRecord.NamespaceID, a.core)
+		if err != nil {
+			return 0, 0, nil, err
+		}
+		if a.includeInResponse(queryNS, ns) {
+			mountResponse := make([]*ResponseMount, 0, len(nsRecord.Mounts))
+			for _, mountRecord := range nsRecord.Mounts {
+				mountResponse = append(mountResponse, &ResponseMount{
+					MountPath: mountRecord.MountPath,
+					Counts: &ResponseCounts{
+						DistinctEntities: int(mountRecord.Counts.EntityClients),
+						EntityClients:    int(mountRecord.Counts.EntityClients),
+						NonEntityClients: int(mountRecord.Counts.NonEntityClients),
+						NonEntityTokens:  int(mountRecord.Counts.NonEntityClients),
+						Clients:          int(mountRecord.Counts.EntityClients + mountRecord.Counts.NonEntityClients),
+					},
+				})
+			}
+			// Sort the mounts in descending order of usage
+			sort.Slice(mountResponse, func(i, j int) bool {
+				return mountResponse[i].Counts.Clients > mountResponse[j].Counts.Clients
+			})
+
+			var displayPath string
+			if ns == nil {
+				displayPath = fmt.Sprintf("deleted namespace %q", nsRecord.NamespaceID)
+			} else {
+				displayPath = ns.Path
+			}
+			byNamespaceResponse = append(byNamespaceResponse, &ResponseNamespace{
+				NamespaceID:   nsRecord.NamespaceID,
+				NamespacePath: displayPath,
+				Counts: ResponseCounts{
+					DistinctEntities: int(nsRecord.Entities),
+					EntityClients:    int(nsRecord.Entities),
+					NonEntityTokens:  int(nsRecord.NonEntityTokens),
+					NonEntityClients: int(nsRecord.NonEntityTokens),
+					Clients:          int(nsRecord.Entities + nsRecord.NonEntityTokens),
+				},
+				Mounts: mountResponse,
+			})
+			totalEntities += int(nsRecord.Entities)
+			totalTokens += int(nsRecord.NonEntityTokens)
+		}
+	}
+	return totalEntities, totalTokens, byNamespaceResponse, nil
+}
+
+func (a *ActivityLog) prepareMonthsResponseForQuery(ctx context.Context, byMonth []*activity.MonthRecord) ([]*ResponseMonth, error) {
+	months := make([]*ResponseMonth, 0, len(byMonth))
+	for _, monthsRecord := range byMonth {
+		newClientsResponse := &ResponseNewClients{}
+		if int(monthsRecord.NewClients.Counts.EntityClients+monthsRecord.NewClients.Counts.NonEntityClients) != 0 {
+			newClientsNSResponse, err := a.prepareNamespaceResponse(ctx, monthsRecord.NewClients.Namespaces)
+			if err != nil {
+				return nil, err
+			}
+			newClientsResponse.Counts = &ResponseCounts{
+				EntityClients:    int(monthsRecord.NewClients.Counts.EntityClients),
+				NonEntityClients: int(monthsRecord.NewClients.Counts.NonEntityClients),
+				Clients:          int(monthsRecord.NewClients.Counts.EntityClients + monthsRecord.NewClients.Counts.NonEntityClients),
+			}
+			newClientsResponse.Namespaces = newClientsNSResponse
+		}
+
+		monthResponse := &ResponseMonth{
+			Timestamp: time.Unix(monthsRecord.Timestamp, 0).UTC().Format(time.RFC3339),
+		}
+		if int(monthsRecord.Counts.EntityClients+monthsRecord.Counts.NonEntityClients) != 0 {
+			nsResponse, err := a.prepareNamespaceResponse(ctx, monthsRecord.Namespaces)
+			if err != nil {
+				return nil, err
+			}
+			monthResponse.Counts = &ResponseCounts{
+				EntityClients:    int(monthsRecord.Counts.EntityClients),
+				NonEntityClients: int(monthsRecord.Counts.NonEntityClients),
+				Clients:          int(monthsRecord.Counts.EntityClients + monthsRecord.Counts.NonEntityClients),
+			}
+			monthResponse.Namespaces = nsResponse
+			monthResponse.NewClients = newClientsResponse
+			months = append(months, monthResponse)
+		}
+	}
+	return months, nil
+}
+
+// prepareNamespaceResponse populates the namespace portion of the activity log response struct
+// from
+func (a *ActivityLog) prepareNamespaceResponse(ctx context.Context, nsRecords []*activity.MonthlyNamespaceRecord) ([]*ResponseNamespace, error) {
+	queryNS, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	nsResponse := make([]*ResponseNamespace, 0, len(nsRecords))
+	for _, nsRecord := range nsRecords {
+		if int(nsRecord.Counts.EntityClients) == 0 && int(nsRecord.Counts.NonEntityClients) == 0 {
+			continue
+		}
+
+		ns, err := NamespaceByID(ctx, nsRecord.NamespaceID, a.core)
+		if err != nil {
+			return nil, err
+		}
+		if a.includeInResponse(queryNS, ns) {
+			mountResponse := make([]*ResponseMount, 0, len(nsRecord.Mounts))
+			for _, mountRecord := range nsRecord.Mounts {
+				if int(mountRecord.Counts.EntityClients) == 0 && int(mountRecord.Counts.NonEntityClients) == 0 {
+					continue
+				}
+
+				mountResponse = append(mountResponse, &ResponseMount{
+					MountPath: mountRecord.MountPath,
+					Counts: &ResponseCounts{
+						EntityClients:    int(mountRecord.Counts.EntityClients),
+						NonEntityClients: int(mountRecord.Counts.NonEntityClients),
+						Clients:          int(mountRecord.Counts.EntityClients + mountRecord.Counts.NonEntityClients),
+					},
+				})
+			}
+
+			var displayPath string
+			if ns == nil {
+				displayPath = fmt.Sprintf("deleted namespace %q", nsRecord.NamespaceID)
+			} else {
+				displayPath = ns.Path
+			}
+			nsResponse = append(nsResponse, &ResponseNamespace{
+				NamespaceID:   nsRecord.NamespaceID,
+				NamespacePath: displayPath,
+				Counts: ResponseCounts{
+					EntityClients:    int(nsRecord.Counts.EntityClients),
+					NonEntityClients: int(nsRecord.Counts.NonEntityClients),
+					Clients:          int(nsRecord.Counts.EntityClients + nsRecord.Counts.NonEntityClients),
+				},
+				Mounts: mountResponse,
+			})
+		}
+	}
+	return nsResponse, nil
+}
+
 // partialMonthClientCount returns the number of clients used so far this month.
 // If activity log is not enabled, the response will be nil
 func (a *ActivityLog) partialMonthClientCount(ctx context.Context) (map[string]interface{}, error) {
@@ -2453,73 +2493,27 @@ func (a *ActivityLog) partialMonthClientCount(ctx context.Context) (map[string]i
 		return nil, nil
 	}
 
-	// Parse the monthly clients and prepare the breakdowns.
-	byNamespace := make(map[string]*processByNamespace)
-	byMonth := make(map[int64]*processMonth)
-	for _, e := range a.partialMonthClientTracker {
-		processClientRecord(e, byNamespace, byMonth, time.Now())
-	}
+	// Traverse through current month's activitylog data and group clients
+	// into months and namespaces
+	byMonth, byNamespace := a.populateNamespaceAndMonthlyBreakdowns()
 
-	queryNS, err := namespace.FromContext(ctx)
+	// Convert the byNamespace breakdowns into structs that are
+	// consumable by the /activity endpoint, so as to reuse code between these two
+	// endpoints.
+	byNamespaceComputation := a.transformALNamespaceBreakdowns(byNamespace)
+
+	// Calculate the namespace response breakdowns and totals for entities and tokens from the initial
+	// namespace data.
+	totalEntities, totalTokens, byNamespaceResponse, err := a.calculateByNamespaceResponseForQuery(ctx, byNamespaceComputation)
 	if err != nil {
 		return nil, err
 	}
 
+	// Sort clients within each namespace
+	a.sortALResponseNamespaces(byNamespaceResponse)
+
 	// Now populate the response based on breakdowns.
 	responseData := make(map[string]interface{})
-
-	byNamespaceResponse := make([]*ResponseNamespace, 0)
-	totalEntities := 0
-	totalTokens := 0
-
-	for nsID, nsRecord := range byNamespace {
-		ns, err := NamespaceByID(ctx, nsID, a.core)
-		if err != nil {
-			return nil, err
-		}
-
-		if a.includeInResponse(queryNS, ns) {
-			mountResponse := make([]*ResponseMount, 0, len(nsRecord.Mounts))
-			for mountPath, mountRecord := range nsRecord.Mounts {
-				mountResponse = append(mountResponse, &ResponseMount{
-					MountPath: mountPath,
-					Counts: &ResponseCounts{
-						EntityClients:    len(mountRecord.Counts.Entities),
-						NonEntityClients: len(mountRecord.Counts.NonEntities),
-						Clients:          len(mountRecord.Counts.Entities) + len(mountRecord.Counts.NonEntities),
-					},
-				})
-			}
-			sort.Slice(mountResponse, func(i, j int) bool {
-				return mountResponse[i].Counts.Clients > mountResponse[j].Counts.Clients
-			})
-
-			var displayPath string
-			if ns == nil {
-				displayPath = fmt.Sprintf("deleted namespace %q", nsID)
-			} else {
-				displayPath = ns.Path
-			}
-			byNamespaceResponse = append(byNamespaceResponse, &ResponseNamespace{
-				NamespaceID:   nsID,
-				NamespacePath: displayPath,
-				Counts: ResponseCounts{
-					DistinctEntities: len(nsRecord.Counts.Entities),
-					EntityClients:    len(nsRecord.Counts.Entities),
-					NonEntityTokens:  len(nsRecord.Counts.NonEntities),
-					NonEntityClients: len(nsRecord.Counts.NonEntities),
-					Clients:          len(nsRecord.Counts.Entities) + len(nsRecord.Counts.NonEntities),
-				},
-				Mounts: mountResponse,
-			})
-			totalEntities += len(nsRecord.Counts.Entities)
-			totalTokens += len(nsRecord.Counts.NonEntities)
-		}
-	}
-
-	sort.Slice(byNamespaceResponse, func(i, j int) bool {
-		return byNamespaceResponse[i].Counts.Clients > byNamespaceResponse[j].Counts.Clients
-	})
 	responseData["by_namespace"] = byNamespaceResponse
 	responseData["distinct_entities"] = totalEntities
 	responseData["entity_clients"] = totalEntities
@@ -2527,126 +2521,31 @@ func (a *ActivityLog) partialMonthClientCount(ctx context.Context) (map[string]i
 	responseData["non_entity_clients"] = totalTokens
 	responseData["clients"] = totalEntities + totalTokens
 
-	months := make([]*ResponseMonth, 0, len(byMonth))
-	prepareNSResponse := func(processedNamespaces map[string]*processByNamespace) ([]*ResponseMonthlyNamespace, error) {
-		nsResponse := make([]*ResponseMonthlyNamespace, 0, len(processedNamespaces))
-		for nsID, nsRecord := range processedNamespaces {
-			if len(nsRecord.Counts.Entities) == 0 && len(nsRecord.Counts.NonEntities) == 0 {
-				continue
-			}
-
-			ns, err := NamespaceByID(ctx, nsID, a.core)
-			if err != nil {
-				return nil, err
-			}
-			if a.includeInResponse(queryNS, ns) {
-				mountResponse := make([]*ResponseMount, 0, len(nsRecord.Mounts))
-				for mountPath, mountRecord := range nsRecord.Mounts {
-					if len(mountRecord.Counts.Entities) == 0 && len(mountRecord.Counts.NonEntities) == 0 {
-						continue
-					}
-
-					mountResponse = append(mountResponse, &ResponseMount{
-						MountPath: mountPath,
-						Counts: &ResponseCounts{
-							EntityClients:    len(mountRecord.Counts.Entities),
-							NonEntityClients: len(mountRecord.Counts.NonEntities),
-							Clients:          len(mountRecord.Counts.Entities) + len(mountRecord.Counts.NonEntities),
-						},
-					})
-				}
-
-				var displayPath string
-				if ns == nil {
-					displayPath = fmt.Sprintf("deleted namespace %q", nsID)
-				} else {
-					displayPath = ns.Path
-				}
-				nsResponse = append(nsResponse, &ResponseMonthlyNamespace{
-					NamespaceID:   nsID,
-					NamespacePath: displayPath,
-					Counts: &ResponseCounts{
-						EntityClients:    len(nsRecord.Counts.Entities),
-						NonEntityClients: len(nsRecord.Counts.NonEntities),
-						Clients:          len(nsRecord.Counts.Entities) + len(nsRecord.Counts.NonEntities),
-					},
-					Mounts: mountResponse,
-				})
-			}
+	// The partialMonthClientCount should not have more than one month worth of data.
+	// If it does, something has gone wrong and we should warn that the activity log data
+	// might be inaccurate.
+	if len(byMonth) != 1 {
+		monthTimestamps := make([]string, 0)
+		for timestamp := range byMonth {
+			dateTimeString := time.Unix(timestamp, 0).UTC().Format(time.RFC3339)
+			monthTimestamps = append(monthTimestamps, dateTimeString)
 		}
-		return nsResponse, nil
+		a.logger.Error("more or less than one month of data recorded in current month's activity log", "timestamps", monthTimestamps)
 	}
 
-	for timestamp, month := range byMonth {
-		newClientsResponse := &ResponseNewClients{}
-		if len(month.NewClients.Counts.Entities) != 0 || len(month.NewClients.Counts.NonEntities) != 0 {
-			newClientsNSResponse, err := prepareNSResponse(month.NewClients.Namespaces)
-			if err != nil {
-				return nil, err
-			}
-			newClientsResponse.Counts = &ResponseCounts{
-				EntityClients:    len(month.NewClients.Counts.Entities),
-				NonEntityClients: len(month.NewClients.Counts.NonEntities),
-				Clients:          len(month.NewClients.Counts.Entities) + len(month.NewClients.Counts.NonEntities),
-			}
-			newClientsResponse.Namespaces = newClientsNSResponse
-		}
+	// Convert the byMonth breakdowns into structs that are
+	// consumable by the /activity endpoint, so as to reuse code between these two
+	// endpoints.
+	monthlyComputation := a.transformMonthBreakdowns(byMonth)
 
-		monthResponse := &ResponseMonth{}
-		if len(month.Counts.Entities) != 0 || len(month.Counts.NonEntities) != 0 {
-			nsResponse, err := prepareNSResponse(month.Namespaces)
-			if err != nil {
-				return nil, err
-			}
-
-			monthResponse.Timestamp = time.Unix(timestamp, 0).UTC().Format(time.RFC3339)
-			monthResponse.Counts = &ResponseCounts{
-				EntityClients:    len(month.Counts.Entities),
-				NonEntityClients: len(month.Counts.NonEntities),
-				Clients:          len(month.Counts.Entities) + len(month.Counts.NonEntities),
-			}
-			monthResponse.Namespaces = nsResponse
-			monthResponse.NewClients = newClientsResponse
-
-			months = append(months, monthResponse)
-		}
+	// Create and populate the month response structs based on the monthly breakdown.
+	months, err := a.prepareMonthsResponseForQuery(ctx, monthlyComputation)
+	if err != nil {
+		return nil, err
 	}
 
-	// Sort the months in ascending order of timestamps
-	sort.Slice(months, func(i, j int) bool {
-		firstTimestamp, errOne := time.Parse(time.RFC3339, months[i].Timestamp)
-		secondTimestamp, errTwo := time.Parse(time.RFC3339, months[j].Timestamp)
-		if errOne == nil && errTwo == nil {
-			return firstTimestamp.Before(secondTimestamp)
-		}
-		// Keep the nondeterministic ordering in storage
-		a.logger.Error("unable to parse activity log timestamps for partial client count",
-			"timestamp", months[i].Timestamp, "error", errOne, "timestamp", months[j].Timestamp, "error", errTwo)
-		return i < j
-	})
-
-	// Within each month sort everything by descending order of activity
-	for _, month := range months {
-		sort.Slice(month.Namespaces, func(i, j int) bool {
-			return month.Namespaces[i].Counts.Clients > month.Namespaces[j].Counts.Clients
-		})
-
-		for _, ns := range month.Namespaces {
-			sort.Slice(ns.Mounts, func(i, j int) bool {
-				return ns.Mounts[i].Counts.Clients > ns.Mounts[j].Counts.Clients
-			})
-		}
-
-		sort.Slice(month.NewClients.Namespaces, func(i, j int) bool {
-			return month.NewClients.Namespaces[i].Counts.Clients > month.NewClients.Namespaces[j].Counts.Clients
-		})
-
-		for _, ns := range month.NewClients.Namespaces {
-			sort.Slice(ns.Mounts, func(i, j int) bool {
-				return ns.Mounts[i].Counts.Clients > ns.Mounts[j].Counts.Clients
-			})
-		}
-	}
+	// Sort the months and clients within each month before adding the months to the response
+	a.sortActivityLogMonthsResponse(months)
 	responseData["months"] = months
 
 	return responseData, nil

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -16,6 +16,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/axiomhq/hyperloglog"
 	"github.com/golang/protobuf/proto"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/helper/metricsutil"
@@ -35,6 +36,9 @@ const (
 	activityQueryBasePath  = "queries/"
 	activityConfigKey      = "config"
 	activityIntentLogKey   = "endofmonth"
+
+	// sketch for each month that stores hash of client ids
+	distinctClientsBasePath = "log/distinctclients/"
 
 	// for testing purposes (public as needed)
 	ActivityLogPrefix = "sys/counters/activity/log/"
@@ -363,6 +367,53 @@ func (a *ActivityLog) saveCurrentSegmentToStorageLocked(ctx context.Context, for
 	return nil
 }
 
+// CreateOrFetchHyperlogLog creates a new hyperlogLog for each startTime (month) if it does not exist in storage.
+// hyperlogLog is used here to solve count-distinct problem i.e, to count the number of distinct clients
+// In activity log, hyperloglog is a sketch containing clientID's in a given month
+func (a *ActivityLog) CreateOrFetchHyperlogLog(ctx context.Context, startTime time.Time) *hyperloglog.Sketch {
+	monthlyHLLPath := fmt.Sprintf("%s%d", distinctClientsBasePath, startTime.Unix())
+	hll := hyperloglog.New()
+	a.logger.Trace("fetching hyperloglog ", "path", monthlyHLLPath)
+	data, err := a.view.Get(ctx, monthlyHLLPath)
+	if err != nil {
+		a.logger.Error("error fetching hyperloglog", "path", monthlyHLLPath, "error", err)
+		return hll
+	}
+	if data == nil {
+		a.logger.Trace("creating hyperloglog ", "path", monthlyHLLPath)
+		err = a.StoreHyperlogLog(ctx, startTime, hll)
+		if err != nil {
+			a.logger.Error("error storing hyperloglog", "path", monthlyHLLPath, "error", err)
+			return hll
+		}
+	} else {
+		err = hll.UnmarshalBinary(data.Value)
+		if err != nil {
+			a.logger.Error("error unmarshaling hyperloglog", "path", monthlyHLLPath, "error", err)
+			return hll
+		}
+	}
+	return hll
+}
+
+// StoreHyperlogLog stores the hyperloglog (a sketch containing client IDs) for startTime (month) in storage
+func (a *ActivityLog) StoreHyperlogLog(ctx context.Context, startTime time.Time, newHll *hyperloglog.Sketch) error {
+	monthlyHLLPath := fmt.Sprintf("%s%d", distinctClientsBasePath, startTime.Unix())
+	a.logger.Trace("storing hyperloglog ", "path", monthlyHLLPath)
+	marshalledHll, err := newHll.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	err = a.view.Put(ctx, &logical.StorageEntry{
+		Key:   monthlyHLLPath,
+		Value: marshalledHll,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // :force: forces a save of tokens/entities even if the in-memory log is empty
 func (a *ActivityLog) saveCurrentSegmentInternal(ctx context.Context, force bool) error {
 	entityPath := fmt.Sprintf("%s%d/%d", activityEntityBasePath, a.currentSegment.startTimestamp, a.currentSegment.clientSequenceNumber)
@@ -515,7 +566,7 @@ func (a *ActivityLog) getLastEntitySegmentNumber(ctx context.Context, startTime 
 }
 
 // WalkEntitySegments loads each of the entity segments for a particular start time
-func (a *ActivityLog) WalkEntitySegments(ctx context.Context, startTime time.Time, walkFn func(*activity.EntityActivityLog, time.Time) error) error {
+func (a *ActivityLog) WalkEntitySegments(ctx context.Context, startTime time.Time, hll *hyperloglog.Sketch, walkFn func(*activity.EntityActivityLog, time.Time, *hyperloglog.Sketch) error) error {
 	basePath := activityEntityBasePath + fmt.Sprint(startTime.Unix()) + "/"
 	pathList, err := a.view.List(ctx, basePath)
 	if err != nil {
@@ -537,7 +588,7 @@ func (a *ActivityLog) WalkEntitySegments(ctx context.Context, startTime time.Tim
 		if err != nil {
 			return fmt.Errorf("unable to parse segment %v%v: %w", basePath, path, err)
 		}
-		err = walkFn(out, startTime)
+		err = walkFn(out, startTime, hll)
 		if err != nil {
 			return fmt.Errorf("unable to walk entities: %w", err)
 		}
@@ -2066,9 +2117,20 @@ func (a *ActivityLog) precomputedQueryWorker(ctx context.Context) error {
 	byNamespace := make(map[string]*processByNamespace)
 	byMonth := make(map[int64]*processMonth)
 
-	walkEntities := func(l *activity.EntityActivityLog, startTime time.Time) error {
+	walkEntities := func(l *activity.EntityActivityLog, startTime time.Time, hll *hyperloglog.Sketch) error {
 		for _, e := range l.Clients {
+
 			processClientRecord(e, byNamespace, byMonth, startTime)
+
+			// We maintain an hyperloglog for each month
+			// hyperloglog is a sketch (hyperloglog data-structure) containing client ID's in a given month
+			// hyperloglog is used in activity log to get the approximate number new clients in the current billing month
+			// by counting the number of distinct clients in all the months including current month
+			// (this can be done by merging the hyperloglog all months with current month hyperloglog)
+			// and subtracting the number of distinct clients in the current month
+			// NOTE: current month here is not the month of startTime but the time period from the start of the current month,
+			// up until the time that this request was made.
+			hll.Insert([]byte(e.ClientID))
 
 			// The byMonth map will be filled in the reverse order of time. For
 			// example, if the billing period is from Jan to June, the byMonth
@@ -2141,10 +2203,16 @@ func (a *ActivityLog) precomputedQueryWorker(ctx context.Context) error {
 			break
 		}
 
-		err = a.WalkEntitySegments(ctx, startTime, walkEntities)
+		hyperloglog := a.CreateOrFetchHyperlogLog(ctx, startTime)
+		err = a.WalkEntitySegments(ctx, startTime, hyperloglog, walkEntities)
 		if err != nil {
 			a.logger.Warn("failed to load previous segments", "error", err)
 			return err
+		}
+		// Store the hyperloglog
+		err = a.StoreHyperlogLog(ctx, startTime, hyperloglog)
+		if err != nil {
+			a.logger.Warn("failed to store hyperloglog for month", "start time", startTime, "error", err)
 		}
 		err = a.WalkTokenSegments(ctx, startTime, walkTokens)
 		if err != nil {
@@ -2643,7 +2711,8 @@ func (a *ActivityLog) writeExport(ctx context.Context, rw http.ResponseWriter, f
 	a.logger.Info("starting activity log export", "start_time", startTime, "end_time", endTime, "format", format)
 
 	dedupedIds := make(map[string]struct{})
-	walkEntities := func(l *activity.EntityActivityLog, startTime time.Time) error {
+
+	walkEntities := func(l *activity.EntityActivityLog, startTime time.Time, hll *hyperloglog.Sketch) error {
 		for _, e := range l.Clients {
 			if _, ok := dedupedIds[e.ClientID]; ok {
 				continue
@@ -2660,8 +2729,9 @@ func (a *ActivityLog) writeExport(ctx context.Context, rw http.ResponseWriter, f
 	}
 
 	// For each month in the filtered list walk all the log segments
+
 	for _, startTime := range filteredList {
-		err := a.WalkEntitySegments(ctx, startTime, walkEntities)
+		err := a.WalkEntitySegments(ctx, startTime, nil, walkEntities)
 		if err != nil {
 			a.logger.Error("failed to load segments for export", "error", err)
 			return fmt.Errorf("failed to load segments for export: %w", err)

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -367,53 +367,6 @@ func (a *ActivityLog) saveCurrentSegmentToStorageLocked(ctx context.Context, for
 	return nil
 }
 
-// CreateOrFetchHyperlogLog creates a new hyperlogLog for each startTime (month) if it does not exist in storage.
-// hyperlogLog is used here to solve count-distinct problem i.e, to count the number of distinct clients
-// In activity log, hyperloglog is a sketch containing clientID's in a given month
-func (a *ActivityLog) CreateOrFetchHyperlogLog(ctx context.Context, startTime time.Time) *hyperloglog.Sketch {
-	monthlyHLLPath := fmt.Sprintf("%s%d", distinctClientsBasePath, startTime.Unix())
-	hll := hyperloglog.New()
-	a.logger.Trace("fetching hyperloglog ", "path", monthlyHLLPath)
-	data, err := a.view.Get(ctx, monthlyHLLPath)
-	if err != nil {
-		a.logger.Error("error fetching hyperloglog", "path", monthlyHLLPath, "error", err)
-		return hll
-	}
-	if data == nil {
-		a.logger.Trace("creating hyperloglog ", "path", monthlyHLLPath)
-		err = a.StoreHyperlogLog(ctx, startTime, hll)
-		if err != nil {
-			a.logger.Error("error storing hyperloglog", "path", monthlyHLLPath, "error", err)
-			return hll
-		}
-	} else {
-		err = hll.UnmarshalBinary(data.Value)
-		if err != nil {
-			a.logger.Error("error unmarshaling hyperloglog", "path", monthlyHLLPath, "error", err)
-			return hll
-		}
-	}
-	return hll
-}
-
-// StoreHyperlogLog stores the hyperloglog (a sketch containing client IDs) for startTime (month) in storage
-func (a *ActivityLog) StoreHyperlogLog(ctx context.Context, startTime time.Time, newHll *hyperloglog.Sketch) error {
-	monthlyHLLPath := fmt.Sprintf("%s%d", distinctClientsBasePath, startTime.Unix())
-	a.logger.Trace("storing hyperloglog ", "path", monthlyHLLPath)
-	marshalledHll, err := newHll.MarshalBinary()
-	if err != nil {
-		return err
-	}
-	err = a.view.Put(ctx, &logical.StorageEntry{
-		Key:   monthlyHLLPath,
-		Value: marshalledHll,
-	})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // :force: forces a save of tokens/entities even if the in-memory log is empty
 func (a *ActivityLog) saveCurrentSegmentInternal(ctx context.Context, force bool) error {
 	entityPath := fmt.Sprintf("%s%d/%d", activityEntityBasePath, a.currentSegment.startTimestamp, a.currentSegment.clientSequenceNumber)
@@ -1613,7 +1566,7 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 
 	distinctEntitiesResponse := totalEntities
 	if computePartial {
-		currentMonth, err := a.computeCurrentMonthForBillingPeriod(partialByMonth, startTime, endTime)
+		currentMonth, err := a.computeCurrentMonthForBillingPeriod(ctx, partialByMonth, startTime, endTime)
 		if err != nil {
 			return nil, err
 		}
@@ -2076,7 +2029,12 @@ func (a *ActivityLog) precomputedQueryWorker(ctx context.Context) error {
 			break
 		}
 
-		hyperloglog := a.CreateOrFetchHyperlogLog(ctx, startTime)
+		hyperloglog, err := a.CreateOrFetchHyperlogLog(ctx, startTime)
+		if err != nil {
+			// We were unable to create or fetch the hll, but we should still
+			// continue with our precomputation
+			a.logger.Warn("unable to create or fetch hyperloglog", "start time", startTime, "error", err)
+		}
 		err = a.WalkEntitySegments(ctx, startTime, hyperloglog, walkEntities)
 		if err != nil {
 			a.logger.Warn("failed to load previous segments", "error", err)

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -496,7 +496,7 @@ func TestActivityLog_StoreAndReadHyperloglog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error storing hyperloglog in storage: %v", err)
 	}
-	fetchedHll := a.CreateOrFetchHyperlogLog(ctx, currentMonth)
+	fetchedHll, err := a.CreateOrFetchHyperlogLog(ctx, currentMonth)
 	// check the distinct count stored from hll
 	if fetchedHll.Estimate() != 4 {
 		t.Fatalf("wrong number of distinct elements: expected: 5 actual: %v", fetchedHll.Estimate())

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/axiomhq/hyperloglog"
 	"github.com/go-test/deep"
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/vault/helper/constants"
@@ -472,6 +473,34 @@ func TestActivityLog_SaveEntitiesToStorage(t *testing.T) {
 		t.Fatalf("could not unmarshal protobuf: %v", err)
 	}
 	expectedEntityIDs(t, out, ids)
+}
+
+// Test to check store hyperloglog and fetch hyperloglog from storage
+func TestActivityLog_StoreAndReadHyperloglog(t *testing.T) {
+	core, _, _ := TestCoreUnsealed(t)
+	ctx := context.Background()
+
+	a := core.activityLog
+	a.SetStandbyEnable(ctx, true)
+	a.SetStartTimestamp(time.Now().Unix()) // set a nonzero segment
+	currentMonth := timeutil.StartOfMonth(time.Now())
+	currentMonthHll := hyperloglog.New()
+	currentMonthHll.Insert([]byte("a"))
+	currentMonthHll.Insert([]byte("a"))
+	currentMonthHll.Insert([]byte("b"))
+	currentMonthHll.Insert([]byte("c"))
+	currentMonthHll.Insert([]byte("d"))
+	currentMonthHll.Insert([]byte("d"))
+
+	err := a.StoreHyperlogLog(ctx, currentMonth, currentMonthHll)
+	if err != nil {
+		t.Fatalf("error storing hyperloglog in storage: %v", err)
+	}
+	fetchedHll := a.CreateOrFetchHyperlogLog(ctx, currentMonth)
+	// check the distinct count stored from hll
+	if fetchedHll.Estimate() != 4 {
+		t.Fatalf("wrong number of distinct elements: expected: 5 actual: %v", fetchedHll.Estimate())
+	}
 }
 
 func TestModifyResponseMonthsNilAppend(t *testing.T) {

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -3829,6 +3829,132 @@ func TestActivityLog_partialMonthClientCount(t *testing.T) {
 	}
 }
 
+func TestActivityLog_partialMonthClientCountUsingHandleQuery(t *testing.T) {
+	timeutil.SkipAtEndOfMonth(t)
+
+	ctx := namespace.RootContext(nil)
+	now := time.Now().UTC()
+	a, clients, _ := setupActivityRecordsInStorage(t, timeutil.StartOfMonth(now), true, true)
+
+	// clients[0] belongs to previous month
+	clients = clients[1:]
+
+	clientCounts := make(map[string]uint64)
+	for _, client := range clients {
+		clientCounts[client.NamespaceID] += 1
+	}
+
+	a.SetEnable(true)
+	var wg sync.WaitGroup
+	err := a.refreshFromStoredLog(ctx, &wg, now)
+	if err != nil {
+		t.Fatalf("error loading clients: %v", err)
+	}
+	wg.Wait()
+
+	results, err := a.handleQuery(ctx, time.Now().UTC(), time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results == nil {
+		t.Fatal("no results to test")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results == nil {
+		t.Fatal("no results to test")
+	}
+
+	byNamespace, ok := results["by_namespace"]
+	if !ok {
+		t.Fatalf("malformed results. got %v", results)
+	}
+
+	clientCountResponse := make([]*ResponseNamespace, 0)
+	err = mapstructure.Decode(byNamespace, &clientCountResponse)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, clientCount := range clientCountResponse {
+		if int(clientCounts[clientCount.NamespaceID]) != clientCount.Counts.DistinctEntities {
+			t.Errorf("bad entity count for namespace %s . expected %d, got %d", clientCount.NamespaceID, int(clientCounts[clientCount.NamespaceID]), clientCount.Counts.DistinctEntities)
+		}
+		totalCount := int(clientCounts[clientCount.NamespaceID])
+		if totalCount != clientCount.Counts.Clients {
+			t.Errorf("bad client count for namespace %s . expected %d, got %d", clientCount.NamespaceID, totalCount, clientCount.Counts.Clients)
+		}
+	}
+
+	totals, ok := results["total"]
+	if !ok {
+		t.Fatalf("malformed results. got %v", results)
+	}
+	totalCounts := ResponseCounts{}
+	err = mapstructure.Decode(totals, &totalCounts)
+	distinctEntities := totalCounts.DistinctEntities
+	if distinctEntities != len(clients) {
+		t.Errorf("bad entity count. expected %d, got %d", len(clients), distinctEntities)
+	}
+
+	clientCount := totalCounts.Clients
+	if clientCount != len(clients) {
+		t.Errorf("bad client count. expected %d, got %d", len(clients), clientCount)
+	}
+	// Ensure that the month response is the same as the totals, because all clients
+	// are new clients and there will be no approximation in the single month partial
+	// case
+	monthsRaw, ok := results["months"]
+	if !ok {
+		t.Fatalf("malformed results. got %v", results)
+	}
+	monthsResponse := make([]ResponseMonth, 0)
+	err = mapstructure.Decode(monthsRaw, &monthsResponse)
+	if len(monthsResponse) != 1 {
+		t.Fatalf("wrong number of months returned. got %v", monthsResponse)
+	}
+	if monthsResponse[0].Counts.Clients != totalCounts.Clients {
+		t.Fatalf("wrong client count. got %v, expected %v", monthsResponse[0].Counts.Clients, totalCounts.Clients)
+	}
+	if monthsResponse[0].Counts.EntityClients != totalCounts.EntityClients {
+		t.Fatalf("wrong entity client count. got %v, expected %v", monthsResponse[0].Counts.EntityClients, totalCounts.EntityClients)
+	}
+	if monthsResponse[0].Counts.NonEntityClients != totalCounts.NonEntityClients {
+		t.Fatalf("wrong non-entity client count. got %v, expected %v", monthsResponse[0].Counts.NonEntityClients, totalCounts.NonEntityClients)
+	}
+	if monthsResponse[0].Counts.NonEntityTokens != totalCounts.NonEntityTokens {
+		t.Fatalf("wrong non-entity client count. got %v, expected %v", monthsResponse[0].Counts.NonEntityTokens, totalCounts.NonEntityTokens)
+	}
+	if monthsResponse[0].Counts.Clients != monthsResponse[0].NewClients.Counts.Clients {
+		t.Fatalf("wrong client count. got %v, expected %v", monthsResponse[0].Counts.Clients, monthsResponse[0].NewClients.Counts.Clients)
+	}
+	if monthsResponse[0].Counts.DistinctEntities != monthsResponse[0].NewClients.Counts.DistinctEntities {
+		t.Fatalf("wrong distinct entities count. got %v, expected %v", monthsResponse[0].Counts.DistinctEntities, monthsResponse[0].NewClients.Counts.DistinctEntities)
+	}
+	if monthsResponse[0].Counts.EntityClients != monthsResponse[0].NewClients.Counts.EntityClients {
+		t.Fatalf("wrong entity client count. got %v, expected %v", monthsResponse[0].Counts.EntityClients, monthsResponse[0].NewClients.Counts.EntityClients)
+	}
+	if monthsResponse[0].Counts.NonEntityClients != monthsResponse[0].NewClients.Counts.NonEntityClients {
+		t.Fatalf("wrong non-entity client count. got %v, expected %v", monthsResponse[0].Counts.NonEntityClients, monthsResponse[0].NewClients.Counts.NonEntityClients)
+	}
+	if monthsResponse[0].Counts.NonEntityTokens != monthsResponse[0].NewClients.Counts.NonEntityTokens {
+		t.Fatalf("wrong non-entity token count. got %v, expected %v", monthsResponse[0].Counts.NonEntityTokens, monthsResponse[0].NewClients.Counts.NonEntityTokens)
+	}
+
+	namespaceResponseMonth := monthsResponse[0].Namespaces
+
+	for _, clientCount := range namespaceResponseMonth {
+		if int(clientCounts[clientCount.NamespaceID]) != clientCount.Counts.EntityClients {
+			t.Errorf("bad entity count for namespace %s . expected %d, got %d", clientCount.NamespaceID, int(clientCounts[clientCount.NamespaceID]), clientCount.Counts.DistinctEntities)
+		}
+		totalCount := int(clientCounts[clientCount.NamespaceID])
+		if totalCount != clientCount.Counts.Clients {
+			t.Errorf("bad client count for namespace %s . expected %d, got %d", clientCount.NamespaceID, totalCount, clientCount.Counts.Clients)
+		}
+	}
+}
+
 // writeEntitySegment writes a single segment file with the given time and index for an entity
 func writeEntitySegment(t *testing.T, core *Core, ts time.Time, index int, item *activity.EntityActivityLog) {
 	t.Helper()

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -1,11 +1,155 @@
 package vault
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"sort"
 	"time"
 
+	"github.com/axiomhq/hyperloglog"
+	"github.com/hashicorp/vault/helper/timeutil"
+	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault/activity"
 )
+
+type HLLGetter func(ctx context.Context, startTime time.Time) (*hyperloglog.Sketch, error)
+
+// computeCurrentMonthForBillingPeriod computes the current month's data with respect
+// to a billing period.
+func (a *ActivityLog) computeCurrentMonthForBillingPeriod(ctx context.Context, byMonth map[int64]*processMonth, startTime time.Time, endTime time.Time) (*activity.MonthRecord, error) {
+	return a.computeCurrentMonthForBillingPeriodInternal(ctx, byMonth, a.CreateOrFetchHyperlogLog, startTime, endTime)
+}
+
+// CreateOrFetchHyperlogLog creates a new hyperlogLog for each startTime (month) if it does not exist in storage.
+// hyperlogLog is used here to solve count-distinct problem i.e, to count the number of distinct clients
+// In activity log, hyperloglog is a sketch containing clientID's in a given month
+func (a *ActivityLog) CreateOrFetchHyperlogLog(ctx context.Context, startTime time.Time) (*hyperloglog.Sketch, error) {
+	monthlyHLLPath := fmt.Sprintf("%s%d", distinctClientsBasePath, startTime.Unix())
+	hll := hyperloglog.New()
+	data, err := a.view.Get(ctx, monthlyHLLPath)
+	if err != nil {
+		// If there is no hll, we should log the error, as having this fire multiple times
+		// is a sign that something is wrong with hll store/get. However, this is not a
+		// critical failure (in fact it is expected during the first month rotation after
+		// this code is deployed), so we will not throw an error.
+		a.logger.Warn("fetch of hyperloglog threw an error at path", monthlyHLLPath, "error", err)
+	}
+	if data == nil {
+		a.logger.Trace("creating hyperloglog ", "path", monthlyHLLPath)
+		err = a.StoreHyperlogLog(ctx, startTime, hll)
+		if err != nil {
+			return hll, fmt.Errorf("error storing hyperloglog at path %s: error %w", monthlyHLLPath, err)
+		}
+	} else {
+		err = hll.UnmarshalBinary(data.Value)
+		if err != nil {
+			return hll, fmt.Errorf("error unmarshaling hyperloglog at path %s: error %w", monthlyHLLPath, err)
+		}
+	}
+	return hll, nil
+}
+
+// StoreHyperlogLog stores the hyperloglog (a sketch containing client IDs) for startTime (month) in storage
+func (a *ActivityLog) StoreHyperlogLog(ctx context.Context, startTime time.Time, newHll *hyperloglog.Sketch) error {
+	monthlyHLLPath := fmt.Sprintf("%s%d", distinctClientsBasePath, startTime.Unix())
+	a.logger.Trace("storing hyperloglog ", "path", monthlyHLLPath)
+	marshalledHll, err := newHll.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	err = a.view.Put(ctx, &logical.StorageEntry{
+		Key:   monthlyHLLPath,
+		Value: marshalledHll,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *ActivityLog) computeCurrentMonthForBillingPeriodInternal(ctx context.Context, byMonth map[int64]*processMonth, hllGetFunc HLLGetter, startTime time.Time, endTime time.Time) (*activity.MonthRecord, error) {
+	// Fetch all hyperloglogs for months from startMonth to endMonth. If a month doesn't have an associated
+	// hll, warn and continue.
+
+	// hllMonthlyTimestamp is the start time of the month corresponding to which a hyperloglog of that month's
+	// client data is stored. The path at which the hyperloglog for a month is stored containes this timestamp.
+	hllMonthlyTimestamp := timeutil.StartOfMonth(startTime)
+	billingPeriodHLL := hyperloglog.New()
+	for hllMonthlyTimestamp.Before(timeutil.StartOfMonth(endTime)) || hllMonthlyTimestamp.Equal(timeutil.StartOfMonth(endTime)) {
+		monthSketch, err := hllGetFunc(ctx, hllMonthlyTimestamp)
+		// If there's an error with the hyperloglog fetch, we should still deduplicate on
+		// the hlls that we have so we will warn that we couldn't find a hll for the month
+		// and continue.
+		if err != nil {
+			a.logger.Warn("no hyperloglog associated with timestamp", "timestamp", hllMonthlyTimestamp)
+			hllMonthlyTimestamp = timeutil.StartOfNextMonth(hllMonthlyTimestamp)
+			continue
+		}
+		// Union the monthly hll into the billing period's hll
+		err = billingPeriodHLL.Merge(monthSketch)
+		if err != nil {
+			// In this case we can't afford to fail silently. Since this error indicates
+			// data corruption, we should not try to do any further deduplication
+			return nil, err
+		}
+		hllMonthlyTimestamp = timeutil.StartOfNextMonth(hllMonthlyTimestamp)
+	}
+
+	// Now we will add the clients for the current month to a copy of the billing period's hll to
+	// see how the cardinality grows.
+	billingPeriodHLLWithCurrentMonthEntityClients := billingPeriodHLL.Clone()
+	billingPeriodHLLWithCurrentMonthNonEntityClients := billingPeriodHLL.Clone()
+
+	// There's at most one month of data here. We should validate this assumption explicitly
+	if len(byMonth) > 1 {
+		return nil, errors.New(fmt.Sprintf("multiple months of data found in partial month's client count breakdowns: %+v\n", byMonth))
+	}
+
+	totalEntities := 0
+	totalNonEntities := 0
+	for _, month := range byMonth {
+
+		if month.NewClients == nil || month.NewClients.Counts == nil || month.Counts == nil {
+			return nil, errors.New("malformed current month used to calculate current month's activity")
+		}
+
+		// Note that the following calculations assume that all clients seen are currently in
+		// the NewClients section of byMonth. It is best to explicitly check this, just verify
+		// our assumptions about the passed in byMonth argument.
+		if len(month.Counts.Entities) != len(month.NewClients.Counts.Entities) ||
+			len(month.Counts.NonEntities) != len(month.NewClients.Counts.NonEntities) {
+			return nil, errors.New("current month clients cache assumes billing period")
+		}
+
+		// All the clients for the current month are in the newClients section, initially.
+		// We need to deduplicate these clients across the billing period by adding them
+		// into the billing period hyperloglogs.
+		entities := month.NewClients.Counts.Entities
+		nonEntities := month.NewClients.Counts.NonEntities
+		if entities != nil {
+			for entityID := range entities {
+				billingPeriodHLLWithCurrentMonthEntityClients.Insert([]byte(entityID))
+				totalEntities += 1
+			}
+		}
+		if nonEntities != nil {
+			for nonEntityID := range nonEntities {
+				billingPeriodHLLWithCurrentMonthNonEntityClients.Insert([]byte(nonEntityID))
+				totalNonEntities += 1
+			}
+		}
+	}
+	// The number of new entities for the current month is approximately the size of the hll with
+	// the current month's entities minus the size of the initial billing period hll.
+	currentMonthNewEntities := billingPeriodHLLWithCurrentMonthEntityClients.Estimate() - billingPeriodHLL.Estimate()
+	currentMonthNewNonEntities := billingPeriodHLLWithCurrentMonthNonEntityClients.Estimate() - billingPeriodHLL.Estimate()
+
+	return &activity.MonthRecord{
+		NewClients: &activity.NewClientRecord{Counts: &activity.CountsRecord{EntityClients: int(currentMonthNewEntities), NonEntityClients: int(currentMonthNewNonEntities)}},
+		Counts:     &activity.CountsRecord{EntityClients: totalEntities, NonEntityClients: totalNonEntities},
+	}, nil
+}
 
 // sortALResponseNamespaces sorts the namespaces for activity log responses.
 func (a *ActivityLog) sortALResponseNamespaces(byNamespaceResponse []*ResponseNamespace) {
@@ -105,16 +249,4 @@ func (a *ActivityLog) sortActivityLogMonthsResponse(months []*ResponseMonth) {
 			})
 		}
 	}
-}
-
-// TODO
-// computeCurrentMonthForBillingPeriod computes the current month's data with respect
-// to a billing period. This function is currently a stub with the bare minimum amount
-// of data to get the pre-existing tests to pass. It will be filled out in a separate PR
-// and this comment will be removed.
-func (a *ActivityLog) computeCurrentMonthForBillingPeriod(byMonth map[int64]*processMonth, startTime time.Time, endTime time.Time) (*activity.MonthRecord, error) {
-	return &activity.MonthRecord{
-		NewClients: &activity.NewClientRecord{Counts: &activity.CountsRecord{EntityClients: 0, NonEntityClients: 0}},
-		Counts:     &activity.CountsRecord{EntityClients: 0, NonEntityClients: 0},
-	}, nil
 }

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -1,0 +1,120 @@
+package vault
+
+import (
+	"sort"
+	"time"
+
+	"github.com/hashicorp/vault/vault/activity"
+)
+
+// sortALResponseNamespaces sorts the namespaces for activity log responses.
+func (a *ActivityLog) sortALResponseNamespaces(byNamespaceResponse []*ResponseNamespace) {
+	sort.Slice(byNamespaceResponse, func(i, j int) bool {
+		return byNamespaceResponse[i].Counts.Clients > byNamespaceResponse[j].Counts.Clients
+	})
+}
+
+// transformALNamespaceBreakdowns takes the namespace breakdowns stored in the intermediary
+// struct used in precomputation segment traversal and to store the current month data and
+// reorganizes it into query structs. This helper is used by the partial month endpoint so as to
+// not have to maintain two separate response data computations for two separate APIs.
+func (a *ActivityLog) transformALNamespaceBreakdowns(nsData map[string]*processByNamespace) []*activity.NamespaceRecord {
+	byNamespace := make([]*activity.NamespaceRecord, 0)
+	for nsID, ns := range nsData {
+
+		nsRecord := activity.NamespaceRecord{
+			NamespaceID:     nsID,
+			Entities:        uint64(len(ns.Counts.Entities)),
+			NonEntityTokens: uint64(len(ns.Counts.NonEntities) + int(ns.Counts.Tokens)),
+			Mounts:          a.transformActivityLogMounts(ns.Mounts),
+		}
+		byNamespace = append(byNamespace, &nsRecord)
+	}
+	return byNamespace
+}
+
+// limitNamespacesInALResponse will truncate the number of namespaces shown in the activity
+// endpoints to the number specified in limitNamespaces (the API filtering parameter)
+func (a *ActivityLog) limitNamespacesInALResponse(byNamespaceResponse []*ResponseNamespace, limitNamespaces int) (int, int, []*ResponseNamespace) {
+	if limitNamespaces > len(byNamespaceResponse) {
+		limitNamespaces = len(byNamespaceResponse)
+	}
+	byNamespaceResponse = byNamespaceResponse[:limitNamespaces]
+	// recalculate total entities and tokens
+	totalEntities := 0
+	totalTokens := 0
+	for _, namespaceData := range byNamespaceResponse {
+		totalEntities += namespaceData.Counts.DistinctEntities
+		totalTokens += namespaceData.Counts.NonEntityTokens
+	}
+	return totalEntities, totalTokens, byNamespaceResponse
+}
+
+// transformActivityLogMounts is a helper used to reformat data for transformMonthlyNamespaceBreakdowns.
+// For more details, please see the function comment for transformMonthlyNamespaceBreakdowns
+func (a *ActivityLog) transformActivityLogMounts(mts map[string]*processMount) []*activity.MountRecord {
+	mounts := make([]*activity.MountRecord, 0)
+	for mountpath, mountCounts := range mts {
+		mount := activity.MountRecord{
+			MountPath: mountpath,
+			Counts: &activity.CountsRecord{
+				EntityClients:    len(mountCounts.Counts.Entities),
+				NonEntityClients: len(mountCounts.Counts.NonEntities) + int(mountCounts.Counts.Tokens),
+			},
+		}
+		mounts = append(mounts, &mount)
+	}
+	return mounts
+}
+
+// sortActivityLogMonthsResponse contains the sorting logic for the months
+// portion of the activity log response.
+func (a *ActivityLog) sortActivityLogMonthsResponse(months []*ResponseMonth) {
+	// Sort the months in ascending order of timestamps
+	sort.Slice(months, func(i, j int) bool {
+		firstTimestamp, errOne := time.Parse(time.RFC3339, months[i].Timestamp)
+		secondTimestamp, errTwo := time.Parse(time.RFC3339, months[j].Timestamp)
+		if errOne == nil && errTwo == nil {
+			return firstTimestamp.Before(secondTimestamp)
+		}
+		// Keep the nondeterministic ordering in storage
+		a.logger.Error("unable to parse activity log timestamps", "timestamp",
+			months[i].Timestamp, "error", errOne, "timestamp", months[j].Timestamp, "error", errTwo)
+		return i < j
+	})
+
+	// Within each month sort everything by descending order of activity
+	for _, month := range months {
+		sort.Slice(month.Namespaces, func(i, j int) bool {
+			return month.Namespaces[i].Counts.Clients > month.Namespaces[j].Counts.Clients
+		})
+
+		for _, ns := range month.Namespaces {
+			sort.Slice(ns.Mounts, func(i, j int) bool {
+				return ns.Mounts[i].Counts.Clients > ns.Mounts[j].Counts.Clients
+			})
+		}
+
+		sort.Slice(month.NewClients.Namespaces, func(i, j int) bool {
+			return month.NewClients.Namespaces[i].Counts.Clients > month.NewClients.Namespaces[j].Counts.Clients
+		})
+
+		for _, ns := range month.NewClients.Namespaces {
+			sort.Slice(ns.Mounts, func(i, j int) bool {
+				return ns.Mounts[i].Counts.Clients > ns.Mounts[j].Counts.Clients
+			})
+		}
+	}
+}
+
+// TODO
+// computeCurrentMonthForBillingPeriod computes the current month's data with respect
+// to a billing period. This function is currently a stub with the bare minimum amount
+// of data to get the pre-existing tests to pass. It will be filled out in a separate PR
+// and this comment will be removed.
+func (a *ActivityLog) computeCurrentMonthForBillingPeriod(byMonth map[int64]*processMonth, startTime time.Time, endTime time.Time) (*activity.MonthRecord, error) {
+	return &activity.MonthRecord{
+		NewClients: &activity.NewClientRecord{Counts: &activity.CountsRecord{EntityClients: 0, NonEntityClients: 0}},
+		Counts:     &activity.CountsRecord{EntityClients: 0, NonEntityClients: 0},
+	}, nil
+}

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -76,7 +76,7 @@ func (a *ActivityLog) computeCurrentMonthForBillingPeriodInternal(ctx context.Co
 	// client data is stored. The path at which the hyperloglog for a month is stored containes this timestamp.
 	hllMonthlyTimestamp := timeutil.StartOfMonth(startTime)
 	billingPeriodHLL := hyperloglog.New()
-	for hllMonthlyTimestamp.Before(timeutil.StartOfMonth(endTime)) || hllMonthlyTimestamp.Equal(timeutil.StartOfMonth(endTime)) {
+	for hllMonthlyTimestamp.Before(timeutil.StartOfMonth(endTime)) {
 		monthSketch, err := hllGetFunc(ctx, hllMonthlyTimestamp)
 		// If there's an error with the hyperloglog fetch, we should still deduplicate on
 		// the hlls that we have so we will warn that we couldn't find a hll for the month
@@ -146,6 +146,7 @@ func (a *ActivityLog) computeCurrentMonthForBillingPeriodInternal(ctx context.Co
 	currentMonthNewNonEntities := billingPeriodHLLWithCurrentMonthNonEntityClients.Estimate() - billingPeriodHLL.Estimate()
 
 	return &activity.MonthRecord{
+		Timestamp:  timeutil.StartOfMonth(endTime).UTC().Unix(),
 		NewClients: &activity.NewClientRecord{Counts: &activity.CountsRecord{EntityClients: int(currentMonthNewEntities), NonEntityClients: int(currentMonthNewNonEntities)}},
 		Counts:     &activity.CountsRecord{EntityClients: totalEntities, NonEntityClients: totalNonEntities},
 	}, nil

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -69,6 +69,15 @@ func (a *ActivityLog) StoreHyperlogLog(ctx context.Context, startTime time.Time,
 }
 
 func (a *ActivityLog) computeCurrentMonthForBillingPeriodInternal(ctx context.Context, byMonth map[int64]*processMonth, hllGetFunc HLLGetter, startTime time.Time, endTime time.Time) (*activity.MonthRecord, error) {
+	if timeutil.IsCurrentMonth(startTime, time.Now().UTC()) {
+		monthlyComputation := a.transformMonthBreakdowns(byMonth)
+		if len(monthlyComputation) > 1 {
+			a.logger.Warn("monthly in-memory activitylog computation returned multiple months of data", "months returned", len(byMonth))
+		}
+		if len(monthlyComputation) >= 0 {
+			return monthlyComputation[0], nil
+		}
+	}
 	// Fetch all hyperloglogs for months from startMonth to endMonth. If a month doesn't have an associated
 	// hll, warn and continue.
 
@@ -144,7 +153,6 @@ func (a *ActivityLog) computeCurrentMonthForBillingPeriodInternal(ctx context.Co
 	// the current month's entities minus the size of the initial billing period hll.
 	currentMonthNewEntities := billingPeriodHLLWithCurrentMonthEntityClients.Estimate() - billingPeriodHLL.Estimate()
 	currentMonthNewNonEntities := billingPeriodHLLWithCurrentMonthNonEntityClients.Estimate() - billingPeriodHLL.Estimate()
-
 	return &activity.MonthRecord{
 		Timestamp:  timeutil.StartOfMonth(endTime).UTC().Unix(),
 		NewClients: &activity.NewClientRecord{Counts: &activity.CountsRecord{EntityClients: int(currentMonthNewEntities), NonEntityClients: int(currentMonthNewNonEntities)}},

--- a/vault/activity_log_util_common_test.go
+++ b/vault/activity_log_util_common_test.go
@@ -1,0 +1,128 @@
+package vault
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/axiomhq/hyperloglog"
+	"github.com/hashicorp/vault/helper/timeutil"
+)
+
+func Test_ActivityLog_ComputeCurrentMonthForBillingPeriodInternal(t *testing.T) {
+	// populate the first month with clients 1-10
+	monthOneHLL := hyperloglog.New()
+	// populate the second month with clients 5-15
+	monthTwoHLL := hyperloglog.New()
+	// populate the third month with clients 10-20
+	monthThreeHLL := hyperloglog.New()
+
+	for i := 0; i < 20; i++ {
+		clientID := []byte(fmt.Sprintf("client_%d", i))
+		if i < 10 {
+			monthOneHLL.Insert(clientID)
+		}
+		if 5 <= i && i < 15 {
+			monthTwoHLL.Insert(clientID)
+		}
+		if 10 <= i && i < 20 {
+			monthThreeHLL.Insert(clientID)
+		}
+	}
+	mockHLLGetFunc := func(ctx context.Context, startTime time.Time) (*hyperloglog.Sketch, error) {
+		currMonthStart := timeutil.StartOfMonth(time.Now())
+		if startTime.Equal(timeutil.MonthsPreviousTo(3, currMonthStart)) {
+			return monthThreeHLL, nil
+		}
+		if startTime.Equal(timeutil.MonthsPreviousTo(2, currMonthStart)) {
+			return monthTwoHLL, nil
+		}
+		if startTime.Equal(timeutil.MonthsPreviousTo(1, currMonthStart)) {
+			return monthOneHLL, nil
+		}
+		return nil, fmt.Errorf("bad start time")
+	}
+
+	// Let's add 2 entities exclusive to month 1 (clients 0,1),
+	// 2 entities shared by month 1 and 2 (clients 5,6),
+	// 2 entities shared by month 2 and 3 (clients 10,11), and
+	// 2 entities exclusive to month 3 (15,16). Furthermore, we can add
+	// 3 new entities (clients 20,21, and 22).
+	entitiesStruct := make(map[string]struct{}, 0)
+	entitiesStruct["client_0"] = struct{}{}
+	entitiesStruct["client_1"] = struct{}{}
+	entitiesStruct["client_5"] = struct{}{}
+	entitiesStruct["client_6"] = struct{}{}
+	entitiesStruct["client_10"] = struct{}{}
+	entitiesStruct["client_11"] = struct{}{}
+	entitiesStruct["client_15"] = struct{}{}
+	entitiesStruct["client_16"] = struct{}{}
+	entitiesStruct["client_20"] = struct{}{}
+	entitiesStruct["client_21"] = struct{}{}
+	entitiesStruct["client_22"] = struct{}{}
+
+	// We will add 3 nonentity clients from month 1 (clients 2,3,4),
+	// 3 shared by months 1 and 2 (7,8,9),
+	// 3 shared by months 2 and 3 (12,13,14), and
+	// 3 exclusive to month 3 (17,18,19). We will also
+	// add 4 new nonentity clients.
+	nonEntitiesStruct := make(map[string]struct{}, 0)
+	nonEntitiesStruct["client_2"] = struct{}{}
+	nonEntitiesStruct["client_3"] = struct{}{}
+	nonEntitiesStruct["client_4"] = struct{}{}
+	nonEntitiesStruct["client_7"] = struct{}{}
+	nonEntitiesStruct["client_8"] = struct{}{}
+	nonEntitiesStruct["client_9"] = struct{}{}
+	nonEntitiesStruct["client_12"] = struct{}{}
+	nonEntitiesStruct["client_13"] = struct{}{}
+	nonEntitiesStruct["client_14"] = struct{}{}
+	nonEntitiesStruct["client_17"] = struct{}{}
+	nonEntitiesStruct["client_18"] = struct{}{}
+	nonEntitiesStruct["client_19"] = struct{}{}
+	nonEntitiesStruct["client_23"] = struct{}{}
+	nonEntitiesStruct["client_24"] = struct{}{}
+	nonEntitiesStruct["client_25"] = struct{}{}
+	nonEntitiesStruct["client_26"] = struct{}{}
+
+	counts := &processCounts{
+		Entities:    entitiesStruct,
+		NonEntities: nonEntitiesStruct,
+	}
+
+	currentMonthClientsMap := make(map[int64]*processMonth, 1)
+	currentMonthClients := &processMonth{
+		Counts:     counts,
+		NewClients: &processNewClients{Counts: counts},
+	}
+	// Technially I think currentMonthClientsMap should have the keys as
+	// unix timestamps, but for the purposes of the unit test it doesn't
+	// matter what the values actually are.
+	currentMonthClientsMap[0] = currentMonthClients
+
+	core, _, _ := TestCoreUnsealed(t)
+	a := core.activityLog
+
+	endTime := timeutil.StartOfMonth(time.Now())
+	startTime := timeutil.MonthsPreviousTo(3, endTime)
+
+	monthRecord, err := a.computeCurrentMonthForBillingPeriodInternal(context.Background(), currentMonthClientsMap, mockHLLGetFunc, startTime, endTime)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We should have 11 entity clients and 16 nonentity clients, and 3 new entity clients
+	// and 4 new nonentity clients
+	if monthRecord.Counts.EntityClients != 11 {
+		t.Fatalf("wrong number of entity clients. Expected 11, got %d", monthRecord.Counts.EntityClients)
+	}
+	if monthRecord.Counts.NonEntityClients != 16 {
+		t.Fatalf("wrong number of non entity clients. Expected 16, got %d", monthRecord.Counts.NonEntityClients)
+	}
+	if monthRecord.NewClients.Counts.EntityClients != 3 {
+		t.Fatalf("wrong number of new entity clients. Expected 3, got %d", monthRecord.NewClients.Counts.EntityClients)
+	}
+	if monthRecord.NewClients.Counts.NonEntityClients != 4 {
+		t.Fatalf("wrong number of new non entity clients. Expected 4, got %d", monthRecord.NewClients.Counts.NonEntityClients)
+	}
+}

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -27,6 +27,11 @@ func (b *SystemBackend) activityQueryPath() *framework.Path {
 				Type:        framework.TypeTime,
 				Description: "End of query interval",
 			},
+			"limit_namespaces": {
+				Type:        framework.TypeInt,
+				Default:     0,
+				Description: "Limit query output by namespaces",
+			},
 		},
 		HelpSynopsis:    strings.TrimSpace(sysHelp["activity-query"][0]),
 		HelpDescription: strings.TrimSpace(sysHelp["activity-query"][1]),
@@ -202,7 +207,12 @@ func (b *SystemBackend) handleClientMetricQuery(ctx context.Context, req *logica
 		return logical.ErrorResponse(err.Error()), nil
 	}
 
-	results, err := a.handleQuery(ctx, startTime, endTime)
+	var limitNamespaces int
+	if limitNamespacesRaw, ok := d.GetOk("limit_namespaces"); ok {
+		limitNamespaces = limitNamespacesRaw.(int)
+	}
+
+	results, err := a.handleQuery(ctx, startTime, endTime, limitNamespaces)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR encapsulates the backports for ActivityLog changes to get more correct current month estimates using HLL sketches.

This is a pre-cursor to the [ActivityLog backport for 1.11.x](https://github.com/hashicorp/vault/pull/21210). Once merged, we can rebase that PR to get feature parity across 1.11-1.14.

Apologies for the large PR. It may be easiest to review by comparing each backport commit with the original. I can split this up if others think it's worthwhile.