### PR TITLE
Adding the summary file for Heimdall

### DIFF
--- a/META.d/_summary.yaml
+++ b/META.d/_summary.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+---
+schema: 1.1
+partition: secure
+category: product
+summary:
+  owner: team-vault
+  description: The repositories holding the Vault OSS & ENT codebase
+  visibility: internal


### PR DESCRIPTION
This file will be shared across the Vault OSS & ENT repos.

Boundary example: https://github.com/hashicorp/boundary/blob/main/META.d/_summary.yaml
Docs: https://github.com/hashicorp/core-sre-heimdall-core/blob/main/docs/SCHEMA.md

I went with "internal" for visibility because it's talking about services, which doesn't really apply to this repo, and because at least the ENT codebase is internal.