### PR TITLE
Add paths for seal config to cache exceptions.

### DIFF
--- a/sdk/physical/cache.go
+++ b/sdk/physical/cache.go
@@ -32,6 +32,11 @@ var cacheExceptionsPaths = []string{
 	"sys/expire/",
 	"core/poison-pill",
 	"core/raft/tls",
+
+	// Add barrierSealConfigPath and recoverySealConfigPlaintextPath to the cache
+	// exceptions to avoid unseal errors. See VAULT-17227
+	"core/seal-config",
+	"core/recovery-config",
 }
 
 // CacheRefreshContext returns a context with an added value denoting if the


### PR DESCRIPTION
Add barrierSealConfigPath and recoverySealConfigPlaintextPath to cacheExceptionsPaths in order to avoid a race that causes some nodes to always see a nil value.