### PR TITLE
Fix a panic I observed in a sealed node running CollectMetrics

### DIFF
--- a/changelog/21249.txt
+++ b/changelog/21249.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix panic in sealed nodes using raft storage trying to emit raft metrics
+```

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -624,10 +624,13 @@ func (b *RaftBackend) DisableUpgradeMigration() (bool, bool) {
 }
 
 func (b *RaftBackend) CollectMetrics(sink *metricsutil.ClusterMetricSink) {
+	var stats map[string]string
 	b.l.RLock()
 	logstoreStats := b.stableStore.(*raftboltdb.BoltStore).Stats()
 	fsmStats := b.fsm.Stats()
-	stats := b.raft.Stats()
+	if b.raft != nil {
+		stats = b.raft.Stats()
+	}
 	b.l.RUnlock()
 	b.collectMetricsWithStats(logstoreStats, sink, "logstore")
 	b.collectMetricsWithStats(fsmStats, sink, "fsm")
@@ -637,10 +640,12 @@ func (b *RaftBackend) CollectMetrics(sink *metricsutil.ClusterMetricSink) {
 			Value: b.localID,
 		},
 	}
-	for _, key := range []string{"term", "commit_index", "applied_index", "fsm_pending"} {
-		n, err := strconv.ParseUint(stats[key], 10, 64)
-		if err == nil {
-			sink.SetGaugeWithLabels([]string{"raft_storage", "stats", key}, float32(n), labels)
+	if stats != nil {
+		for _, key := range []string{"term", "commit_index", "applied_index", "fsm_pending"} {
+			n, err := strconv.ParseUint(stats[key], 10, 64)
+			if err == nil {
+				sink.SetGaugeWithLabels([]string{"raft_storage", "stats", key}, float32(n), labels)
+			}
 		}
 	}
 }


### PR DESCRIPTION
... where RaftBackend.raft has been set to nil by TeardownCluster:

```
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4: 2023-06-15T10:12:29.670-0400 [INFO]  core: vault is sealed
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4: panic: runtime error: invalid memory address or nil pointer dereference
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x27e2631]
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4: 
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4: goroutine 137 [running]:
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4: github.com/hashicorp/raft.(*Raft).Stats(0x0)
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4:         /Users/runner/go/pkg/mod/github.com/hashicorp/raft@v1.3.10/api.go:1132 +0x31
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4: github.com/hashicorp/vault/physical/raft.(*RaftBackend).CollectMetrics(0xc0006a06e0, 0xc001a46400?)
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4:         /Users/runner/actions-runner/_work/vault-enterprise/vault-enterprise/physical/raft/raft.go:630 +0x125
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4: github.com/hashicorp/vault/vault.(*Core).metricsLoop(0xc000627200, 0xc001110600)
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4:         /Users/runner/actions-runner/_work/vault-enterprise/vault-enterprise/vault/core_metrics.go:121 +0xe8b
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4: github.com/hashicorp/vault/vault.(*Core).runStandby.func7()
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4:         /Users/runner/actions-runner/_work/vault-enterprise/vault-enterprise/vault/ha.go:446 +0x25
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4: github.com/oklog/run.(*Group).Run.func1({0xc0016beac8?, 0xc0016beae0?})
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4:         /Users/runner/go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38 +0x2f
TestVaultExecClusterMigrateShamirToTransit-vault-srv-4: created by github.com/oklog/run.(*Group).Run
```