### PR TITLE
normalize LDAP auth HTTP responses

### DIFF
--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-secure-stdlib/strutil"
+
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/ldaputil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -96,7 +97,7 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username stri
 		if b.Logger().IsDebug() {
 			b.Logger().Debug("error getting user bind DN", "error", err)
 		}
-		return "", nil, logical.ErrorResponse(errUserBindFailed), nil, nil
+		return "", nil, logical.ErrorResponse(errUserBindFailed), nil, logical.ErrInvalidCredentials
 	}
 
 	if b.Logger().IsDebug() {

--- a/builtin/credential/ldap/path_login.go
+++ b/builtin/credential/ldap/path_login.go
@@ -83,17 +83,8 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, d *framew
 	password := d.Get("password").(string)
 
 	effectiveUsername, policies, resp, groupNames, err := b.Login(ctx, req, username, password, cfg.UsernameAsAlias)
-	// Handle an internal error
-	if err != nil {
-		return nil, err
-	}
-	if resp != nil {
-		// Handle a logical error
-		if resp.IsError() {
-			return resp, nil
-		}
-	} else {
-		resp = &logical.Response{}
+	if err != nil || (resp != nil && resp.IsError()) {
+		return resp, err
 	}
 
 	auth := &logical.Auth{

--- a/changelog/21282.txt
+++ b/changelog/21282.txt
@@ -1,3 +1,3 @@
-```release-note:bug
+```release-note:change
 auth/ldap: Normalize HTTP response codes when invalid credentials are provided
 ```

--- a/changelog/21282.txt
+++ b/changelog/21282.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/ldap: Normalize HTTP response codes when invalid credentials are provided
+```

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -21,6 +21,8 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/go-sockaddr"
 	"github.com/hashicorp/go-uuid"
+	uberAtomic "go.uber.org/atomic"
+
 	"github.com/hashicorp/vault/command/server"
 	"github.com/hashicorp/vault/helper/identity"
 	"github.com/hashicorp/vault/helper/identity/mfa"
@@ -36,7 +38,6 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault/quotas"
 	"github.com/hashicorp/vault/vault/tokens"
-	uberAtomic "go.uber.org/atomic"
 )
 
 const (
@@ -1406,7 +1407,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 				return nil, nil, err
 			}
 		}
-		return nil, nil, resp.Error()
+		return resp, nil, routeErr
 	}
 
 	if resp != nil {


### PR DESCRIPTION
Attempts to fix https://github.com/hashicorp/vault/issues/20923.

With this change, every combination of an invalid username or invalid password when authenticating against LDAP should return an `HTTP 400` with the error message:

```json
{
    "errors": [
        "ldap operation failed: failed to bind as user"
    ]
}
```

Demo: 

https://github.com/hashicorp/vault/assets/6120955/3c3cc77a-054b-4efe-b86d-6d3cc57a21e7

