### PR TITLE
agent: Fix agent generate-config to accept namespace

### DIFF
--- a/changelog/21297.txt
+++ b/changelog/21297.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Fix agent generate-config to accept -namespace, VAULT_NAMESPACE, and other client-modifying flags. 
+```

--- a/command/agent_generate_config.go
+++ b/command/agent_generate_config.go
@@ -87,7 +87,8 @@ Usage: vault agent generate-config [options] [path/to/config.hcl]
 }
 
 func (c *AgentGenerateConfigCommand) Flags() *FlagSets {
-	set := NewFlagSets(c.UI)
+	// Include client-modifying flags (-address, -namespace, etc.)
+	set := c.flagSet(FlagSetHTTP)
 
 	// Common Options
 	f := set.NewFlagSet("Command Options")

--- a/website/content/docs/agent-and-proxy/agent/generate-config/index.mdx
+++ b/website/content/docs/agent-and-proxy/agent/generate-config/index.mdx
@@ -49,6 +49,7 @@ Generate an agent configuration file which will reference `secret/foo`:
 $ vault agent generate-config \
                 -type="env-template" \
                 -exec="./my-app arg1 arg2" \
+                -namespace="my/ns/" \
                 -path="secret/foo" \
                     my-config.hcl
 


### PR DESCRIPTION
Fixing `vault agent generate-config` to accept `-namespace`, `VAULT_NAMESPACE`, and other client-modifying flags.

```sh
$ export VAULT_NAMESPACE="admin"
$ vault agent generate-config -type="env-template" -path="path/without/namespace" ...
```

OR

```sh
$ vault agent generate-config -type="env-template" -path="path/without/namespace" -namespace="admin" ...
```


This addresses VAULT-17295

