### PR TITLE
Setup Go before calling the test package test script

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -47,6 +47,9 @@ jobs:
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+      with:
+        go-version-file: ./.go-version
+        cache: true
     - id: test
       working-directory: .github/scripts
       run: |

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -46,6 +46,7 @@ jobs:
     name: Verify Test Package Distribution
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+    - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
     - id: test
       working-directory: .github/scripts
       run: |


### PR DESCRIPTION
It seems like this must've been lost somehow, though I haven't dug into how.  I changed the script yesterday, but it's always depended on having Go present.