### PR TITLE
Fix re-migration of existing CA bundles

### DIFF
--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -88,23 +88,40 @@ func migrateStorage(ctx context.Context, b *backend, s logical.Storage) error {
 	var keyIdentifier keyID
 	sc := b.makeStorageContext(ctx, s)
 	if migrationInfo.legacyBundle != nil {
-		// Generate a unique name for the migrated items in case things were to be re-migrated again
-		// for some weird reason in the future...
-		migrationName := fmt.Sprintf("current-%d", time.Now().Unix())
+		// When the legacy bundle still exists, there's three scenarios we
+		// need to worry about:
+		//
+		// 1. When we have no migration log, we definitely want to migrate.
+		haveNoLog := migrationInfo.migrationLog == nil
+		// 2. When we have an (empty) log and the version is zero, we want to
+		//    migrate.
+		haveOldVersion := !haveNoLog && migrationInfo.migrationLog.MigrationVersion == 0
+		// 3. When we have a log and the version is at least 1 (where this
+		//    migration was introduced), we want to run the migration again
+		//    only if the legacy bundle hash has changed.
+		isCurrentOrBetterVersion := !haveNoLog && migrationInfo.migrationLog.MigrationVersion >= 1
+		haveChange := !haveNoLog && migrationInfo.migrationLog.Hash != migrationInfo.legacyBundleHash
+		haveVersionWithChange := isCurrentOrBetterVersion && haveChange
 
-		b.Logger().Info("performing PKI migration to new keys/issuers layout")
-		anIssuer, aKey, err := sc.writeCaBundle(migrationInfo.legacyBundle, migrationName, migrationName)
-		if err != nil {
-			return err
+		if haveNoLog || haveOldVersion || haveVersionWithChange {
+			// Generate a unique name for the migrated items in case things were to be re-migrated again
+			// for some weird reason in the future...
+			migrationName := fmt.Sprintf("current-%d", time.Now().Unix())
+
+			b.Logger().Info("performing PKI migration to new keys/issuers layout")
+			anIssuer, aKey, err := sc.writeCaBundle(migrationInfo.legacyBundle, migrationName, migrationName)
+			if err != nil {
+				return err
+			}
+			b.Logger().Info("Migration generated the following ids and set them as defaults",
+				"issuer id", anIssuer.ID, "key id", aKey.ID)
+			issuerIdentifier = anIssuer.ID
+			keyIdentifier = aKey.ID
+
+			// Since we do not have all the mount information available we must schedule
+			// the CRL to be rebuilt at a later time.
+			b.crlBuilder.requestRebuildIfActiveNode(b)
 		}
-		b.Logger().Info("Migration generated the following ids and set them as defaults",
-			"issuer id", anIssuer.ID, "key id", aKey.ID)
-		issuerIdentifier = anIssuer.ID
-		keyIdentifier = aKey.ID
-
-		// Since we do not have all the mount information available we must schedule
-		// the CRL to be rebuilt at a later time.
-		b.crlBuilder.requestRebuildIfActiveNode(b)
 	}
 
 	if migrationInfo.migrationLog != nil && migrationInfo.migrationLog.MigrationVersion == 1 {

--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -777,6 +777,98 @@ func TestBackupBundle(t *testing.T) {
 	require.NotEmpty(t, keyIds)
 }
 
+func TestDeletedIssuersPostMigration(t *testing.T) {
+	// We want to simulate the following scenario:
+	//
+	// 1.10.x: -> Create a CA.
+	// 1.11.0: -> Migrate to new issuer layout but version 1.
+	//         -> Delete existing issuers, create new ones.
+	// (now):  -> Migrate to version 2 layout, make sure we don't see
+	//            re-migration.
+
+	t.Parallel()
+	ctx := context.Background()
+	b, s := CreateBackendWithStorage(t)
+	sc := b.makeStorageContext(ctx, s)
+
+	// Reset the version the helper above set to 1.
+	b.pkiStorageVersion.Store(0)
+	require.True(t, b.useLegacyBundleCaStorage(), "pre migration we should have been told to use legacy storage.")
+
+	// Create a legacy CA bundle and write it out.
+	bundle := genCertBundle(t, b, s)
+	json, err := logical.StorageEntryJSON(legacyCertBundlePath, bundle)
+	require.NoError(t, err)
+	err = s.Put(ctx, json)
+	require.NoError(t, err)
+	legacyContents := requireFileExists(t, sc, legacyCertBundlePath, nil)
+
+	// Do a migration; this should provision an issuer and key.
+	initReq := &logical.InitializationRequest{Storage: s}
+	err = b.initialize(ctx, initReq)
+	require.NoError(t, err)
+	requireFileExists(t, sc, legacyCertBundlePath, legacyContents)
+	issuerIds, err := sc.listIssuers()
+	require.NoError(t, err)
+	require.NotEmpty(t, issuerIds)
+	keyIds, err := sc.listKeys()
+	require.NoError(t, err)
+	require.NotEmpty(t, keyIds)
+
+	// Hack: reset the version to 1, to simulate a pre-version-2 migration
+	// log.
+	info, err := getMigrationInfo(sc.Context, sc.Storage)
+	require.NoError(t, err, "failed to read migration info")
+	info.migrationLog.MigrationVersion = 1
+	err = setLegacyBundleMigrationLog(sc.Context, sc.Storage, info.migrationLog)
+	require.NoError(t, err, "failed to write migration info")
+
+	// Now delete all issuers and keys and create some new ones.
+	for _, issuerId := range issuerIds {
+		deleted, err := sc.deleteIssuer(issuerId)
+		require.True(t, deleted, "expected it to be deleted")
+		require.NoError(t, err, "error removing issuer")
+	}
+	for _, keyId := range keyIds {
+		deleted, err := sc.deleteKey(keyId)
+		require.True(t, deleted, "expected it to be deleted")
+		require.NoError(t, err, "error removing key")
+	}
+	emptyIssuers, err := sc.listIssuers()
+	require.NoError(t, err)
+	require.Empty(t, emptyIssuers)
+	emptyKeys, err := sc.listKeys()
+	require.NoError(t, err)
+	require.Empty(t, emptyKeys)
+
+	// Create a new issuer + key.
+	bundle = genCertBundle(t, b, s)
+	_, _, err = sc.writeCaBundle(bundle, "", "")
+	require.NoError(t, err)
+
+	// List which issuers + keys we currently have.
+	postDeletionIssuers, err := sc.listIssuers()
+	require.NoError(t, err)
+	require.NotEmpty(t, postDeletionIssuers)
+	postDeletionKeys, err := sc.listKeys()
+	require.NoError(t, err)
+	require.NotEmpty(t, postDeletionKeys)
+
+	// Now do another migration from 1->2. This should retain the newly
+	// created issuers+keys, but not revive any deleted ones.
+	err = b.initialize(ctx, initReq)
+	require.NoError(t, err)
+	requireFileExists(t, sc, legacyCertBundlePath, legacyContents)
+	postMigrationIssuers, err := sc.listIssuers()
+	require.NoError(t, err)
+	require.NotEmpty(t, postMigrationIssuers)
+	require.Equal(t, postMigrationIssuers, postDeletionIssuers, "regression failed: expected second migration from v1->v2 to not introduce new issuers")
+	postMigrationKeys, err := sc.listKeys()
+	require.NoError(t, err)
+	require.NotEmpty(t, postMigrationKeys)
+	require.Equal(t, postMigrationKeys, postDeletionKeys, "regression failed: expected second migration from v1->v2 to not introduce new keys")
+}
+
 // requireFailInMigration validate that we fail the operation with the appropriate error message to the end-user
 func requireFailInMigration(t *testing.T, b *backend, s logical.Storage, operation logical.Operation, path string) {
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{

--- a/changelog/21316.txt
+++ b/changelog/21316.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Prevent deleted issuers from reappearing when migrating from a version 1 bundle to a version 2 bundle (versions including 1.13.0, 1.12.2, and 1.11.6); when managed keys were removed but referenced in the Vault 1.10 legacy CA bundle, this the error: `no managed key found with uuid`.
+```

--- a/website/content/docs/upgrading/upgrade-to-1.11.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.11.x.mdx
@@ -43,3 +43,5 @@ vault write auth/ldap/config max_page_size=-1
 #### Impacted Versions
 
 Affects Vault 1.11.10.
+
+@include 'pki-double-migration-bug.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.12.x.mdx
@@ -213,3 +213,5 @@ flag for [PKI roles](/vault/api-docs/secret/pki#createupdate-role).
 #### Impacted Versions
 
 Affects Vault 1.12.0+
+
+@include 'pki-double-migration-bug.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -159,3 +159,5 @@ Affects Vault 1.13.0+
 @include 'perf-standby-token-create-forwarding-failure.mdx'
 
 @include 'update-primary-known-issue.mdx'
+
+@include 'pki-double-migration-bug.mdx'

--- a/website/content/partials/pki-double-migration-bug.mdx
+++ b/website/content/partials/pki-double-migration-bug.mdx
@@ -9,18 +9,22 @@ truncating CA chains. This collection of bug fixes introduced Storage v2.
 
 #### Impacted Versions
 
-Issuers created before Vault 1.11, migrated to Storage v1, and deleted
-before upgrading to a Vault version with Storage v2 were incorrectly
-recreated during the upgrade when Vault automatically re-migrated legacy
-issuers. Migration could fail if Vault found managed keys associated with the
-legacy issuers that had been removed from the managed key repository. The
-error appeared in Vault logs as:
+Vault may incorrectly re-migrated legacy issuers created before Vault 1.11 that
+were migrated to Storage v1 and deleted before upgrading to a Vault version with
+Storage v2.
+
+The migration fails when Vault finds managed keys associated with the legacy
+issuers that were removed from the managed key repository prior to the upgrade.
+
+The migration error appears in Vault logs as:
 
 > Error during migration of PKI mount:
 >   failed to lookup public key from managed key:
 >     no managed key found with uuid
 
-Issuers created in Vault 1.11 and later are not impcated. Direct upgrades
-to a Storage v2 layout are not affected.
+<Note>
+Issuers created in Vault 1.11+ and direct upgrades to a Storage v2 layout are
+not affected.
+</Note>
 
 The Storage v1 upgrade bug was fixed in Vault 1.14.1, 1.13.5, and 1.12.9.

--- a/website/content/partials/pki-double-migration-bug.mdx
+++ b/website/content/partials/pki-double-migration-bug.mdx
@@ -2,21 +2,25 @@
 
 Vault 1.11 introduced Storage v1, a new storage layout that supported
 multiple issuers within a single mount. Bug fixes in Vault 1.11.6, 1.12.2,
-and 1.13.0, corrected a write-ordering issue that lead to invalid CA chains.
-Specifically, incorrectly ordered writes would fail and trigger a mass mount
-migration. Too many mounts attempting migration at the same time would result
-in an incorrect CA chain. The collection of bug fixes introduced Storage v2.
+and 1.13.0 corrected a write-ordering issue that lead to invalid CA chains.
+Specifically, incorrectly ordered writes could fail due to load, resulting
+in the mount being re-migrated next time it was loaded or silently
+truncating CA chains. This collection of bug fixes introduced Storage v2.
+
 #### Impacted Versions
 
-Issuers created before Vault 1.11 and migrated to Storage v1 and deleted
+Issuers created before Vault 1.11, migrated to Storage v1, and deleted
 before upgrading to a Vault version with Storage v2 were incorrectly
 recreated during the upgrade when Vault automatically re-migrated legacy
-issuers. Migration failed if Vault found managed keys associated with the
+issuers. Migration could fail if Vault found managed keys associated with the
 legacy issuers that had been removed from the managed key repository. The
 error appeared in Vault logs as:
 
 > Error during migration of PKI mount:
 >   failed to lookup public key from managed key:
 >     no managed key found with uuid
+
+Issuers created in Vault 1.11 and later are not impcated. Direct upgrades
+to a Storage v2 layout are not affected.
 
 This has been fixed in Vault 1.14.0, 1.13.4, 1.12.8, and 1.11.12.

--- a/website/content/partials/pki-double-migration-bug.mdx
+++ b/website/content/partials/pki-double-migration-bug.mdx
@@ -23,4 +23,4 @@ error appeared in Vault logs as:
 Issuers created in Vault 1.11 and later are not impcated. Direct upgrades
 to a Storage v2 layout are not affected.
 
-This has been fixed in Vault 1.14.1, 1.13.5, 1.12.9.
+The Storage v1 upgrade bug was fixed in Vault 1.14.1, 1.13.5, and 1.12.9.

--- a/website/content/partials/pki-double-migration-bug.mdx
+++ b/website/content/partials/pki-double-migration-bug.mdx
@@ -23,4 +23,4 @@ error appeared in Vault logs as:
 Issuers created in Vault 1.11 and later are not impcated. Direct upgrades
 to a Storage v2 layout are not affected.
 
-This has been fixed in Vault 1.14.0, 1.13.4, 1.12.8, and 1.11.12.
+This has been fixed in Vault 1.14.1, 1.13.5, 1.12.9.

--- a/website/content/partials/pki-double-migration-bug.mdx
+++ b/website/content/partials/pki-double-migration-bug.mdx
@@ -8,12 +8,12 @@ migration. Too many mounts attempting migration at the same time would result
 in an incorrect CA chain. The collection of bug fixes introduced Storage v2.
 #### Impacted Versions
 
-If issuers were present pre-1.11, and were subsequently deleted prior to
-upgrading to a Vault version with storage version 2, the initial migration
-of issuers would be re-attempted and these issuers would be recreated. If
-managed keys were associated with these legacy versions (and were
-subsequently removed from the managed key repository), migration would fail
-with an error in the logs:
+Issuers created before Vault 1.11 and migrated to Storage v1 and deleted
+before upgrading to a Vault version with Storage v2 were incorrectly
+recreated during the upgrade when Vault automatically re-migrated legacy
+issuers. Migration failed if Vault found managed keys associated with the
+legacy issuers that had been removed from the managed key repository. The
+error appeared in Vault logs as:
 
 > Error during migration of PKI mount:
 >   failed to lookup public key from managed key:

--- a/website/content/partials/pki-double-migration-bug.mdx
+++ b/website/content/partials/pki-double-migration-bug.mdx
@@ -7,7 +7,7 @@ Specifically, incorrectly ordered writes could fail due to load, resulting
 in the mount being re-migrated next time it was loaded or silently
 truncating CA chains. This collection of bug fixes introduced Storage v2.
 
-#### Impacted Versions
+#### Affected versions
 
 Vault may incorrectly re-migrated legacy issuers created before Vault 1.11 that
 were migrated to Storage v1 and deleted before upgrading to a Vault version with

--- a/website/content/partials/pki-double-migration-bug.mdx
+++ b/website/content/partials/pki-double-migration-bug.mdx
@@ -1,0 +1,22 @@
+### PKI Storage Migration Revives Deleted Issuers
+
+In Vault 1.11, a new storage layout was created to support multiple issuer
+within a single mount, creating storage version 1. In Vault 1.11.6, 1.12.2,
+and 1.13.0, a bug was fixed wherein (due to incorrect ordering of writes),
+the CA chain could be incorrect, due to writes failing when too many mounts
+attempted migration at the same time; this introduced storage version 2.
+
+#### Impacted Versions
+
+If issuers were present pre-1.11, and were subsequently deleted prior to
+upgrading to a Vault version with storage version 2, the initial migration
+of issuers would be re-attempted and these issuers would be recreated. If
+managed keys were associated with these legacy versions (and were
+subsequently removed from the managed key repository), migration would fail
+with an error in the logs:
+
+> Error during migration of PKI mount:
+>   failed to lookup public key from managed key:
+>     no managed key found with uuid
+
+This has been fixed in Vault 1.14.0, 1.13.4, 1.12.8, and 1.11.12.

--- a/website/content/partials/pki-double-migration-bug.mdx
+++ b/website/content/partials/pki-double-migration-bug.mdx
@@ -1,4 +1,4 @@
-### PKI Storage Migration Revives Deleted Issuers
+### PKI storage migration revives deleted issuers
 
 In Vault 1.11, a new storage layout was created to support multiple issuer
 within a single mount, creating storage version 1. In Vault 1.11.6, 1.12.2,

--- a/website/content/partials/pki-double-migration-bug.mdx
+++ b/website/content/partials/pki-double-migration-bug.mdx
@@ -1,11 +1,11 @@
 ### PKI storage migration revives deleted issuers
 
-In Vault 1.11, a new storage layout was created to support multiple issuer
-within a single mount, creating storage version 1. In Vault 1.11.6, 1.12.2,
-and 1.13.0, a bug was fixed wherein (due to incorrect ordering of writes),
-the CA chain could be incorrect, due to writes failing when too many mounts
-attempted migration at the same time; this introduced storage version 2.
-
+Vault 1.11 introduced Storage v1, a new storage layout that supported
+multiple issuers within a single mount. Bug fixes in Vault 1.11.6, 1.12.2,
+and 1.13.0, corrected a write-ordering issue that lead to invalid CA chains.
+Specifically, incorrectly ordered writes would fail and trigger a mass mount
+migration. Too many mounts attempting migration at the same time would result
+in an incorrect CA chain. The collection of bug fixes introduced Storage v2.
 #### Impacted Versions
 
 If issuers were present pre-1.11, and were subsequently deleted prior to


### PR DESCRIPTION
Later in Vault 1.11, 1.12, and 1.13's release, we added a fix for a regression regarding chain building that resulted in a small migration to rebuild all issuer's chains within the mount. This resulted in a second storage migration "version" being created, which was unfortunate as the existing logic resulted in the entire migration being re-attempted:

```go
    if (migrationInfo.migrationLog == nil) ||
        (migrationInfo.migrationLog.Hash != migrationInfo.legacyBundleHash) ||
        (migrationInfo.migrationLog.MigrationVersion != latestMigrationVersion) {  /// <<--- HERE
```

As a result, if the migrated legacy issuers (from storage version 0/1) were deleted prior to version 2's upgrade (to 1.13.0, 1.12.2, and 1.11.6), these would be recreated and would need to be removed again. Additionally, when managed keys were in use (in Vault Enterprise), an error like:

> ```
> Error during migration of PKI mount: failed to lookup public key from managed key: no managed key found with uuid
> ```

would be visible in the logs. This only affects issuers created prior to upgrading to Vault 1.11. 

Related: VAULT-17307