### PR TITLE
Backport: Add paths for seal config to cache exceptions. (#21223)

### DIFF
--- a/changelog/21223.txt
+++ b/changelog/21223.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Do not cache seal configuration to fix a bug that resulted in sporadic auto unseal failures.
+```

--- a/sdk/physical/cache.go
+++ b/sdk/physical/cache.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 
 	metrics "github.com/armon/go-metrics"
+
 	log "github.com/hashicorp/go-hclog"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
@@ -30,6 +31,11 @@ var cacheExceptionsPaths = []string{
 	"core/poison-pill",
 	"core/raft/tls",
 	"core/license",
+
+	// Add barrierSealConfigPath and recoverySealConfigPlaintextPath to the cache
+	// exceptions to avoid unseal errors. See VAULT-17227
+	"core/seal-config",
+	"core/recovery-config",
 }
 
 // CacheRefreshContext returns a context with an added value denoting if the


### PR DESCRIPTION
Add paths for seal config to cache exceptions.

Add barrierSealConfigPath and recoverySealConfigPlaintextPath to cacheExceptionsPaths in order to avoid a race that causes some nodes to always see a nil value.