### PR TITLE
Add Slack notification for failed Enos workflow runs 

### DIFF
--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -174,7 +174,6 @@ jobs:
     needs: run
     # Temporary "success" condition for testing on PR; revert to "failure" before merge to main
     if: always() && needs.run.result == 'success'
-    runs-on: ubuntu-latest
     uses: hashicorp/cloud-gha-slack-notifier/.github/workflows/slack-notify-enhanced.yaml@v1
     with:
       channel-id: "C05DBVA4LGZ" # publishes to #feed-vault-enos-failures

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -181,7 +181,7 @@ jobs:
         uses: hashicorp/actions-slack-status@v1
         # if: ${{ steps.run.outcome == 'failure' || steps.run_retry.outcome == 'failure' }}
         # Temporary "failure" test; revert to above statement before merge to main
-        if: ${{ always }}
+        if: ${{ always() }}
         with:
           failure-message: "An Enos scenario run failed. \nRepo: `${{ github.repository }}`"
           status: ${{steps.fake_failure.outcome}}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -175,9 +175,9 @@ jobs:
     # Temporary "success" condition for testing on PR; revert to "failure" before merge to main
     if: always() && needs.run.result == 'success'
     runs-on: ubuntu-latest
+    uses: hashicorp/cloud-gha-slack-notifier/.github/workflows/slack-notify-enhanced.yaml@v1
     steps:
       - name: send-notification
-        uses: hashicorp/cloud-gha-slack-notifier/.github/workflows/slack-notify-enhanced.yaml@v1
         with:
           channel-id: "C05DBVA4LGZ" # publishes to #feed-vault-enos-failures
           payload: |

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -168,3 +168,28 @@ jobs:
           rm -rf /tmp/enos*
           rm -rf ./enos/support
           rm -rf ./enos/.enos
+
+  # Send Slack notification for any failures in job `run`
+  slack-notification:
+    needs: run
+    # Temporary "success" condition for testing on PR; revert to "failure" before merge to main
+    if: ${{ always() && needs.run.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: send-notification
+        uses: hashicorp/cloud-gha-slack-notifier/.github/workflows/slack-notify-enhanced.yaml@v1
+        with:
+          channel-id: "C05DBVA4LGZ" # publishes to #feed-vault-enos-failures
+          payload: |
+            {
+              "text": ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ ${{ github.event.workflow_run.url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the failed run here: ${{ ${{ github.event.workflow_run.url }}"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -176,7 +176,7 @@ jobs:
         if: ${{always()}}
         with:
           # Temporary "success" message; remove before merge to main
-          success-message: ":red_circle: An Enos scenario run succeeded in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ github.event.workflow_run.url }}"
-          failure-message: ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ github.event.workflow_run.url }}"
+          success-message: "An Enos scenario run succeeded. \nRepo: `${{ github.repository }}` \nBranch:`${{ github.event.workflow_run.head_branch }}` \nJob run URL: ${{ github.event.workflow_job.deployment.url }} \nAuthor: ${{ github.event.workflow_job.deployment.creator.name }} \nPR: ${{ github.event.workflow_run.pull_request.name }}"
+          failure-message: "An Enos scenario run failed. \nRepo: `${{ github.repository }}` \nBranch:`${{ github.event.workflow_run.head_branch }}` \nJob run URL: ${{ github.event.workflow_job.deployment.url }} \nAuthor: ${{ github.event.workflow_job.deployment.creator.name }} \nPR: ${{ github.event.workflow_run.pull_request.name }}"
           status: ${{job.status}}
           slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -173,7 +173,7 @@ jobs:
   slack-notification:
     needs: run
     # Temporary "success" condition for testing on PR; revert to "failure" before merge to main
-    if: ${{ always() && needs.run.result == 'success' }}
+    if: always() && needs.run.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: send-notification
@@ -182,13 +182,13 @@ jobs:
           channel-id: "C05DBVA4LGZ" # publishes to #feed-vault-enos-failures
           payload: |
             {
-              "text": ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ ${{ github.event.workflow_run.url }}",
+              "text": ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ github.event.workflow_run.url }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the failed run here: ${{ ${{ github.event.workflow_run.url }}"
+                    "text": ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the failed run here: ${{ github.event.workflow_run.url }}"
                   }
                 }
               ]

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -173,6 +173,7 @@ jobs:
   # There is an incoming webhook set up on the "Enos Vault Failure Bot" Slackbot https://api.slack.com/apps/A05E31CH1LG/incoming-webhooks
   slack-notification:
     needs: run
+    runs-on: ubuntu-latest
     # Temporary "success" condition for testing on PR; revert to "failure" before merge to main
     if: always() && needs.run.result == 'success'
     steps:

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -176,7 +176,7 @@ jobs:
         if: ${{always()}}
         with:
           # Temporary "success" message; remove before merge to main
-          success-message: "An Enos scenario run succeeded. \nRepo: `${{ github.repository }}` \nBranch: `${{ github.event.workflow_run.head_branch }}` \nJob run URL: ${{ github.event.workflow_job.deployment.url }} \nAuthor: ${{ github.event.workflow_job.deployment.creator.name }} \nPR: ${{ github.event.workflow_run.pull_request.name }}"
+          success-message: "An Enos scenario run succeeded. \nRepo: `${{ github.repository }}` \ngithub.event.workflow_run: ${{ github.event.workflow_run }} \nBranch: `${{ github.event.workflow_run.head_branch }}` \nJob run URL: ${{ github.event.workflow_job.deployment.url }} \nAuthor: ${{ github.event.workflow_job.deployment.creator.name }} \nPR: ${{ github.event.workflow_run.pull_request.name }}"
           failure-message: "An Enos scenario run failed. \nRepo: `${{ github.repository }}` \nBranch: `${{ github.event.workflow_run.head_branch }}` \nJob run URL: ${{ github.event.workflow_job.deployment.url }} \nAuthor: ${{ github.event.workflow_job.deployment.creator.name }} \nPR: ${{ github.event.workflow_run.pull_request.name }}"
           status: ${{job.status}}
           slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -198,11 +198,3 @@ jobs:
           failure-message: "An Enos scenario destroy failed."
           status: ${{steps.destroy.outcome}}
           slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}
-      # Send a Slack notification to #feed-vault-enos-failures for if the 'cleanup' step fails.
-      - name: Send Slack notification on Enos cleanup failure
-        uses: hashicorp/actions-slack-status@v1
-        if: ${{ always() }}
-        with:
-          failure-message: "An Enos scenario cleanup failed."
-          status: ${{steps.cleanup.outcome}}
-          slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -168,19 +168,15 @@ jobs:
           rm -rf /tmp/enos*
           rm -rf ./enos/support
           rm -rf ./enos/.enos
-
-    # Send Slack notification to #feed-vault-enos-failures for any failures in the above `run` job.
-    # There is an incoming webhook set up on the "Enos Vault Failure Bot" Slackbot https://api.slack.com/apps/A05E31CH1LG/incoming-webhooks
-    slack-notification:
-      runs-on: ubuntu-latest
-      needs: run
+      # Send Slack notification to #feed-vault-enos-failures for any failures in the above `run` job.
+      # There is an incoming webhook set up on the "Enos Vault Failure Bot" Slackbot https://api.slack.com/apps/A05E31CH1LG/incoming-webhooks
       - name: Send Slack notification on Enos failure
         uses: hashicorp/actions-slack-status@v1
         # Temporary "success" condition for testing on PR; revert to "failure" before merge to main
-        if: ${{ always() && jobs.run.result == 'success' }}
+        if: ${{ always() && steps.run.outcome == 'success' || steps.run_retry.outcome == 'success' }}
         with:
           # Temporary "success" message; remove before merge to main
           success-message: "An Enos scenario run succeeded. \nRepo: `${{ github.repository }}`"
           failure-message: "An Enos scenario run failed. \nRepo: `${{ github.repository }}`"
-          status: ${{jobs.run.result}}
+          status: ${{job.status}}
           slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -181,7 +181,7 @@ jobs:
         uses: hashicorp/actions-slack-status@v1
         # if: ${{ steps.run.outcome == 'failure' || steps.run_retry.outcome == 'failure' }}
         # Temporary "failure" test; revert to above statement before merge to main
-        if: ${{ steps.fake_failure.outcome == 'failure' }}
+        if: ${{ always }}
         with:
           failure-message: "An Enos scenario run failed. \nRepo: `${{ github.repository }}`"
           status: ${{steps.fake_failure.outcome}}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -147,6 +147,7 @@ jobs:
       - name: Retry Enos scenario if necessary
         id: run_retry
         if: steps.run.outcome == 'failure'
+        continue-on-error: true
         run: enos scenario run --timeout 60m0s --chdir ./enos ${{ matrix.scenario }}
       - name: Upload Debug Data
         if: failure()
@@ -156,24 +157,52 @@ jobs:
           name: ${{ steps.prepare_scenario.outputs.debug_data_artifact_name }}
           path: ${{ env.ENOS_DEBUG_DATA_ROOT_DIR }}
           retention-days: 30
+        continue-on-error: true
       - name: Ensure scenario has been destroyed
+        id: destroy
         if: ${{ always() }}
         # With Enos version 0.0.11 the destroy step returns an error if the infrastructure
         # is already destroyed by enos run. So temporarily setting it to continue on error in GHA
         continue-on-error: true
         run: enos scenario destroy --timeout 60m0s --chdir ./enos ${{ matrix.scenario }}
       - name: Clean up Enos runtime directories
+        id: cleanup
         if: ${{ always() }}
+        continue-on-error: true
         run: |
           rm -rf /tmp/enos*
           rm -rf ./enos/support
           rm -rf ./enos/.enos
-      # Send Slack notification to #feed-vault-enos-failures for if the 'run_retry' step fails.
+      # Send a Slack notification to #feed-vault-enos-failures for if the 'run' step fails.
       # There is an incoming webhook set up on the "Enos Vault Failure Bot" Slackbot https://api.slack.com/apps/A05E31CH1LG/incoming-webhooks
-      - name: Send Slack notification on Enos failure
+      - name: Send Slack notification on Enos run failure
         uses: hashicorp/actions-slack-status@v1
         if: ${{ always() }}
         with:
           failure-message: "An Enos scenario run failed."
+          status: ${{steps.run.outcome}}
+          slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}
+      # Send a Slack notification to #feed-vault-enos-failures for if the 'run_retry' step fails.
+      - name: Send Slack notification on Enos run_retry failure
+        uses: hashicorp/actions-slack-status@v1
+        if: ${{ always() }}
+        with:
+          failure-message: "An Enos scenario run_retry failed."
           status: ${{steps.run_retry.outcome}}
+          slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}
+      # Send a Slack notification to #feed-vault-enos-failures for if the 'destroy' step fails.
+      - name: Send Slack notification on Enos destroy failure
+        uses: hashicorp/actions-slack-status@v1
+        if: ${{ always() }}
+        with:
+          failure-message: "An Enos scenario destroy failed."
+          status: ${{steps.destroy.outcome}}
+          slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}
+      # Send a Slack notification to #feed-vault-enos-failures for if the 'cleanup' step fails.
+      - name: Send Slack notification on Enos cleanup failure
+        uses: hashicorp/actions-slack-status@v1
+        if: ${{ always() }}
+        with:
+          failure-message: "An Enos scenario cleanup failed."
+          status: ${{steps.cleanup.outcome}}
           slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -174,10 +174,10 @@ jobs:
   slack-notification:
     needs: run
     runs-on: ubuntu-latest
-    # Temporary "success" condition for testing on PR; revert to "failure" before merge to main
-    if: always() && needs.run.result == 'success'
     steps:
       - uses: hashicorp/actions-slack-status@v1
+        # Temporary "success" condition for testing on PR; revert to "failure" before merge to main
+        if: always()
         with:
           # Temporary "success" message; remove before merge to main
           success-message: ":red_circle: An Enos scenario run succeeded in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ github.event.workflow_run.url }}"

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -168,18 +168,15 @@ jobs:
           rm -rf /tmp/enos*
           rm -rf ./enos/support
           rm -rf ./enos/.enos
-
-  # Send Slack notification to #feed-vault-enos-failures for any failures in the above `run` job.
-  # There is an incoming webhook set up on the "Enos Vault Failure Bot" Slackbot https://api.slack.com/apps/A05E31CH1LG/incoming-webhooks
-  slack-notification:
-    needs: run
-    runs-on: ubuntu-latest
-    steps:
-      - uses: hashicorp/actions-slack-status@v1
+      # Send Slack notification to #feed-vault-enos-failures for any failures in the above `run` job.
+      # There is an incoming webhook set up on the "Enos Vault Failure Bot" Slackbot https://api.slack.com/apps/A05E31CH1LG/incoming-webhooks
+      - name: Send Slack notification on Enos failure
+        uses: hashicorp/actions-slack-status@v1
         # Temporary "success" condition for testing on PR; revert to "failure" before merge to main
-        if: always()
+        if: ${{always()}}
         with:
           # Temporary "success" message; remove before merge to main
           success-message: ":red_circle: An Enos scenario run succeeded in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ github.event.workflow_run.url }}"
           failure-message: ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ github.event.workflow_run.url }}"
+          status: ${{job.status}}
           slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -183,6 +183,6 @@ jobs:
         # Temporary "failure" test; revert to above statement before merge to main
         if: ${{ always() }}
         with:
-          failure-message: "An Enos scenario run failed. \nRepo: `${{ github.repository }}`"
+          failure-message: "An Enos scenario run failed."
           status: ${{steps.fake_failure.outcome}}
           slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Send Slack notification on Enos failure
         uses: hashicorp/actions-slack-status@v1
         # Temporary "success" condition for testing on PR; revert to "failure" before merge to main
-        if: ${{ always() && steps.run.outcome == 'success' || steps.run_retry.outcome == 'success' }}
+        if: ${{ steps.run.outcome == 'success' || steps.run_retry.outcome == 'success' }}
         with:
           # Temporary "success" message; remove before merge to main
           success-message: "An Enos scenario run succeeded. \nRepo: `${{ github.repository }}`"

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -169,24 +169,15 @@ jobs:
           rm -rf ./enos/support
           rm -rf ./enos/.enos
 
-  # Send Slack notification for any failures in job `run`
+  # Send Slack notification to #feed-vault-enos-failures for any failures in the above `run` job.
+  # There is an incoming webhook set up on the "Enos Vault Failure Bot" Slackbot https://api.slack.com/apps/A05E31CH1LG/incoming-webhooks
   slack-notification:
     needs: run
     # Temporary "success" condition for testing on PR; revert to "failure" before merge to main
     if: always() && needs.run.result == 'success'
-    uses: hashicorp/cloud-gha-slack-notifier/.github/workflows/slack-notify-enhanced.yaml@v1
+    uses: hashicorp/actions-slack-status@v1
     with:
-      channel-id: "C05DBVA4LGZ" # publishes to #feed-vault-enos-failures
-      payload: |
-        {
-          "text": ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ github.event.workflow_run.url }}",
-          "blocks": [
-            {
-              "type": "section",
-              "text": {
-                "type": "mrkdwn",
-                "text": ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the failed run here: ${{ github.event.workflow_run.url }}"
-              }
-            }
-          ]
-        }
+      # Temporary "success" message; remove before merge to main
+      success-message: ":red_circle: An Enos scenario run succeeded in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ github.event.workflow_run.url }}"
+      failure-message: ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ github.event.workflow_run.url }}"
+      slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -168,21 +168,12 @@ jobs:
           rm -rf /tmp/enos*
           rm -rf ./enos/support
           rm -rf ./enos/.enos
-      # Create temporary failure to test failure condition
-      - name: Fake failure step
-        id: fake_failure
-        continue-on-error: true
-        run: |
-          echo "This run failed!" 1>&2
-          exit 1
-      # Send Slack notification to #feed-vault-enos-failures for any failures in the above `run` job.
+      # Send Slack notification to #feed-vault-enos-failures for if the 'run_retry' step fails.
       # There is an incoming webhook set up on the "Enos Vault Failure Bot" Slackbot https://api.slack.com/apps/A05E31CH1LG/incoming-webhooks
       - name: Send Slack notification on Enos failure
         uses: hashicorp/actions-slack-status@v1
-        # if: ${{ steps.run.outcome == 'failure' || steps.run_retry.outcome == 'failure' }}
-        # Temporary "failure" test; revert to above statement before merge to main
         if: ${{ always() }}
         with:
           failure-message: "An Enos scenario run failed."
-          status: ${{steps.fake_failure.outcome}}
+          status: ${{steps.run_retry.outcome}}
           slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -176,7 +176,7 @@ jobs:
         if: ${{always()}}
         with:
           # Temporary "success" message; remove before merge to main
-          success-message: "An Enos scenario run succeeded. \nRepo: `${{ github.repository }}` \nBranch:`${{ github.event.workflow_run.head_branch }}` \nJob run URL: ${{ github.event.workflow_job.deployment.url }} \nAuthor: ${{ github.event.workflow_job.deployment.creator.name }} \nPR: ${{ github.event.workflow_run.pull_request.name }}"
-          failure-message: "An Enos scenario run failed. \nRepo: `${{ github.repository }}` \nBranch:`${{ github.event.workflow_run.head_branch }}` \nJob run URL: ${{ github.event.workflow_job.deployment.url }} \nAuthor: ${{ github.event.workflow_job.deployment.creator.name }} \nPR: ${{ github.event.workflow_run.pull_request.name }}"
+          success-message: "An Enos scenario run succeeded. \nRepo: `${{ github.repository }}` \nBranch: `${{ github.event.workflow_run.head_branch }}` \nJob run URL: ${{ github.event.workflow_job.deployment.url }} \nAuthor: ${{ github.event.workflow_job.deployment.creator.name }} \nPR: ${{ github.event.workflow_run.pull_request.name }}"
+          failure-message: "An Enos scenario run failed. \nRepo: `${{ github.repository }}` \nBranch: `${{ github.event.workflow_run.head_branch }}` \nJob run URL: ${{ github.event.workflow_job.deployment.url }} \nAuthor: ${{ github.event.workflow_job.deployment.creator.name }} \nPR: ${{ github.event.workflow_run.pull_request.name }}"
           status: ${{job.status}}
           slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -184,5 +184,5 @@ jobs:
         if: ${{ steps.fake_failure.outcome == 'failure' }}
         with:
           failure-message: "An Enos scenario run failed. \nRepo: `${{ github.repository }}`"
-          status: ${{job.status}}
+          status: ${{steps.fake_failure.outcome}}
           slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -176,20 +176,18 @@ jobs:
     if: always() && needs.run.result == 'success'
     runs-on: ubuntu-latest
     uses: hashicorp/cloud-gha-slack-notifier/.github/workflows/slack-notify-enhanced.yaml@v1
-    steps:
-      - name: send-notification
-        with:
-          channel-id: "C05DBVA4LGZ" # publishes to #feed-vault-enos-failures
-          payload: |
+    with:
+      channel-id: "C05DBVA4LGZ" # publishes to #feed-vault-enos-failures
+      payload: |
+        {
+          "text": ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ github.event.workflow_run.url }}",
+          "blocks": [
             {
-              "text": ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ github.event.workflow_run.url }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the failed run here: ${{ github.event.workflow_run.url }}"
-                  }
-                }
-              ]
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the failed run here: ${{ github.event.workflow_run.url }}"
+              }
             }
+          ]
+        }

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -171,6 +171,7 @@ jobs:
       # Create temporary failure to test failure condition
       - name: Fake failure step
         id: fake_failure
+        continue-on-error: true
         run: |
           echo "This run failed!" 1>&2
           exit 1

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -168,15 +168,20 @@ jobs:
           rm -rf /tmp/enos*
           rm -rf ./enos/support
           rm -rf ./enos/.enos
+      # Create temporary failure to test failure condition
+      - name: Fake failure step
+        id: fake_failure
+        run: |
+          echo "This run failed!" 1>&2
+          exit 1
       # Send Slack notification to #feed-vault-enos-failures for any failures in the above `run` job.
       # There is an incoming webhook set up on the "Enos Vault Failure Bot" Slackbot https://api.slack.com/apps/A05E31CH1LG/incoming-webhooks
       - name: Send Slack notification on Enos failure
         uses: hashicorp/actions-slack-status@v1
-        # Temporary "success" condition for testing on PR; revert to "failure" before merge to main
-        if: ${{ steps.run.outcome == 'success' || steps.run_retry.outcome == 'success' }}
+        # if: ${{ steps.run.outcome == 'failure' || steps.run_retry.outcome == 'failure' }}
+        # Temporary "failure" test; revert to above statement before merge to main
+        if: ${{ steps.fake_failure.outcome == 'failure' }}
         with:
-          # Temporary "success" message; remove before merge to main
-          success-message: "An Enos scenario run succeeded. \nRepo: `${{ github.repository }}`"
           failure-message: "An Enos scenario run failed. \nRepo: `${{ github.repository }}`"
           status: ${{job.status}}
           slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -168,15 +168,19 @@ jobs:
           rm -rf /tmp/enos*
           rm -rf ./enos/support
           rm -rf ./enos/.enos
-      # Send Slack notification to #feed-vault-enos-failures for any failures in the above `run` job.
-      # There is an incoming webhook set up on the "Enos Vault Failure Bot" Slackbot https://api.slack.com/apps/A05E31CH1LG/incoming-webhooks
+
+    # Send Slack notification to #feed-vault-enos-failures for any failures in the above `run` job.
+    # There is an incoming webhook set up on the "Enos Vault Failure Bot" Slackbot https://api.slack.com/apps/A05E31CH1LG/incoming-webhooks
+    slack-notification:
+      runs-on: ubuntu-latest
+      needs: run
       - name: Send Slack notification on Enos failure
         uses: hashicorp/actions-slack-status@v1
         # Temporary "success" condition for testing on PR; revert to "failure" before merge to main
-        if: ${{always()}}
+        if: ${{ always() && jobs.run.result == 'success' }}
         with:
           # Temporary "success" message; remove before merge to main
-          success-message: "An Enos scenario run succeeded. \nRepo: `${{ github.repository }}` \ngithub.event.workflow_run: ${{ github.event.workflow_run }} \nBranch: `${{ github.event.workflow_run.head_branch }}` \nJob run URL: ${{ github.event.workflow_job.deployment.url }} \nAuthor: ${{ github.event.workflow_job.deployment.creator.name }} \nPR: ${{ github.event.workflow_run.pull_request.name }}"
-          failure-message: "An Enos scenario run failed. \nRepo: `${{ github.repository }}` \nBranch: `${{ github.event.workflow_run.head_branch }}` \nJob run URL: ${{ github.event.workflow_job.deployment.url }} \nAuthor: ${{ github.event.workflow_job.deployment.creator.name }} \nPR: ${{ github.event.workflow_run.pull_request.name }}"
-          status: ${{job.status}}
+          success-message: "An Enos scenario run succeeded. \nRepo: `${{ github.repository }}`"
+          failure-message: "An Enos scenario run failed. \nRepo: `${{ github.repository }}`"
+          status: ${{jobs.run.result}}
           slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -175,9 +175,10 @@ jobs:
     needs: run
     # Temporary "success" condition for testing on PR; revert to "failure" before merge to main
     if: always() && needs.run.result == 'success'
-    uses: hashicorp/actions-slack-status@v1
-    with:
-      # Temporary "success" message; remove before merge to main
-      success-message: ":red_circle: An Enos scenario run succeeded in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ github.event.workflow_run.url }}"
-      failure-message: ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ github.event.workflow_run.url }}"
-      slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}
+    steps:
+      - uses: hashicorp/actions-slack-status@v1
+        with:
+          # Temporary "success" message; remove before merge to main
+          success-message: ":red_circle: An Enos scenario run succeeded in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ github.event.workflow_run.url }}"
+          failure-message: ":red_circle: An Enos scenario run failed in the ${{ github.repository }} repo on the ${{ github.ref_name }} branch. See the run here: ${{ github.event.workflow_run.url }}"
+          slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}


### PR DESCRIPTION
This PR adds Slack notifications for failed Enos `run`, `run_retry` and `destroy` steps so we can more easily and quickly notice and troubleshoot failures. Notifications are currently sent to the #feed-vault-enos-failures channel.