### PR TITLE
Add ACME consideration about entity templating

### DIFF
--- a/website/content/docs/secrets/pki/considerations.mdx
+++ b/website/content/docs/secrets/pki/considerations.mdx
@@ -323,6 +323,11 @@ To solve this issue, there are two possible approaches:
 The choice of approach depends on the policies of the organization wishing
 to use ACME.
 
+Another consequence of the Vault unauthenticated nature of ACME requests
+are that role templating, based on entity information, cannot be used as
+there is no token and thus no entity associated with the request, even when
+EAB binding is used.
+
 ### ACME and the Public Internet
 
 Using ACME is possible over the public internet; public CAs like Let's Encrypt


### PR DESCRIPTION
These don't do anything but reject requests:

> ```
> The server will not issue certificates for the identifier:
> role (something) will not issue certificate for name
> xps15.local.cipherboy.com
> ```