### PR TITLE
Replace all remaining time.ParseDurations with parseutil.ParseDurationSeconds

### DIFF
--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+
 	"github.com/aws/aws-sdk-go/aws"
 	awsClient "github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -1291,7 +1293,7 @@ func (b *backend) pathLoginRenewEc2(ctx context.Context, req *logical.Request, _
 	// If the login was made using the role tag, then max_ttl from tag
 	// is cached in internal data during login and used here to cap the
 	// max_ttl of renewal.
-	rTagMaxTTL, err := time.ParseDuration(req.Auth.Metadata["role_tag_max_ttl"])
+	rTagMaxTTL, err := parseutil.ParseDurationSecond(req.Auth.Metadata["role_tag_max_ttl"])
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -19,8 +19,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
 	"github.com/aws/aws-sdk-go/aws"
 	awsClient "github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -29,6 +27,7 @@ import (
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/go-secure-stdlib/awsutil"
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/builtin/credential/aws/pkcs7"

--- a/builtin/credential/aws/path_role_tag.go
+++ b/builtin/credential/aws/path_role_tag.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -347,7 +349,7 @@ func (b *backend) parseAndVerifyRoleTagValue(ctx context.Context, s logical.Stor
 				return nil, err
 			}
 		case strings.HasPrefix(tagItem, "t="):
-			rTag.MaxTTL, err = time.ParseDuration(fmt.Sprintf("%ss", strings.TrimPrefix(tagItem, "t=")))
+			rTag.MaxTTL, err = parseutil.ParseDurationSecond(fmt.Sprintf("%ss", strings.TrimPrefix(tagItem, "t=")))
 			if err != nil {
 				return nil, err
 			}

--- a/builtin/credential/aws/path_role_tag.go
+++ b/builtin/credential/aws/path_role_tag.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/framework"

--- a/builtin/logical/aws/path_config_lease.go
+++ b/builtin/logical/aws/path_config_lease.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -82,12 +84,12 @@ func (b *backend) pathLeaseWrite(ctx context.Context, req *logical.Request, d *f
 		return logical.ErrorResponse("'lease_max' is a required parameter"), nil
 	}
 
-	lease, err := time.ParseDuration(leaseRaw)
+	lease, err := parseutil.ParseDurationSecond(leaseRaw)
 	if err != nil {
 		return logical.ErrorResponse(fmt.Sprintf(
 			"Invalid lease: %s", err)), nil
 	}
-	leaseMax, err := time.ParseDuration(leaseMaxRaw)
+	leaseMax, err := parseutil.ParseDurationSecond(leaseMaxRaw)
 	if err != nil {
 		return logical.ErrorResponse(fmt.Sprintf(
 			"Invalid lease_max: %s", err)), nil

--- a/builtin/logical/aws/path_config_lease.go
+++ b/builtin/logical/aws/path_config_lease.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+
 	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
 
 	"github.com/hashicorp/vault/api"
@@ -1068,7 +1070,7 @@ func TestAutoRebuild(t *testing.T) {
 	thisCRLNumber := getCRLNumber(t, crl)
 	requireSerialNumberInCRL(t, crl, leafSerial) // But the old one should.
 	now := time.Now()
-	graceInterval, _ := time.ParseDuration(gracePeriod)
+	graceInterval, _ := parseutil.ParseDurationSecond(gracePeriod)
 	expectedUpdate := lastCRLExpiry.Add(-1 * graceInterval)
 	if requireSerialNumberInCRL(nil, crl, newLeafSerial) {
 		// If we somehow lagged and we ended up needing to rebuild

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -13,14 +13,11 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
-	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
-
 	"github.com/hashicorp/vault/api"
 	vaulthttp "github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
-
 	"github.com/stretchr/testify/require"
 )
 

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+
 	atomic2 "go.uber.org/atomic"
 
 	"github.com/hashicorp/vault/sdk/helper/certutil"
@@ -248,12 +250,12 @@ func (cb *crlBuilder) checkForAutoRebuild(sc *storageContext) error {
 	// the grace period and act accordingly.
 	now := time.Now()
 
-	period, err := time.ParseDuration(cfg.AutoRebuildGracePeriod)
+	period, err := parseutil.ParseDurationSecond(cfg.AutoRebuildGracePeriod)
 	if err != nil {
 		// This may occur if the duration is empty; in that case
 		// assume the default. The default should be valid and shouldn't
 		// error.
-		defaultPeriod, defaultErr := time.ParseDuration(defaultCrlConfig.AutoRebuildGracePeriod)
+		defaultPeriod, defaultErr := parseutil.ParseDurationSecond(defaultCrlConfig.AutoRebuildGracePeriod)
 		if defaultErr != nil {
 			return fmt.Errorf("error checking for auto-rebuild status: unable to parse duration from both config's grace period (%v) and default grace period (%v):\n- config: %v\n- default: %w\n", cfg.AutoRebuildGracePeriod, defaultCrlConfig.AutoRebuildGracePeriod, err, defaultErr)
 		}
@@ -436,7 +438,7 @@ func (cb *crlBuilder) rebuildDeltaCRLsIfForced(sc *storageContext, override bool
 		return nil, nil
 	}
 
-	deltaRebuildDuration, err := time.ParseDuration(cfg.DeltaRebuildInterval)
+	deltaRebuildDuration, err := parseutil.ParseDurationSecond(cfg.DeltaRebuildInterval)
 	if err != nil {
 		return nil, err
 	}
@@ -2118,7 +2120,7 @@ func augmentWithRevokedIssuers(issuerIDEntryMap map[issuerID]*issuerEntry, issue
 func buildCRL(sc *storageContext, crlInfo *crlConfig, forceNew bool, thisIssuerId issuerID, revoked []pkix.RevokedCertificate, identifier crlID, crlNumber int64, isUnified bool, isDelta bool, lastCompleteNumber int64) (*time.Time, error) {
 	var revokedCerts []pkix.RevokedCertificate
 
-	crlLifetime, err := time.ParseDuration(crlInfo.Expiry)
+	crlLifetime, err := parseutil.ParseDurationSecond(crlInfo.Expiry)
 	if err != nil {
 		return nil, errutil.InternalError{Err: fmt.Sprintf("error parsing CRL duration of %s", crlInfo.Expiry)}
 	}

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -15,13 +15,11 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
-	atomic2 "go.uber.org/atomic"
-
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
+	atomic2 "go.uber.org/atomic"
 )
 
 const (

--- a/builtin/logical/pki/path_config_crl.go
+++ b/builtin/logical/pki/path_config_crl.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
 	"github.com/hashicorp/vault/helper/constants"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/errutil"

--- a/builtin/logical/pki/path_config_crl.go
+++ b/builtin/logical/pki/path_config_crl.go
@@ -7,7 +7,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
+
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
 
 	"github.com/hashicorp/vault/helper/constants"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -291,7 +292,7 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 
 	if expiryRaw, ok := d.GetOk("expiry"); ok {
 		expiry := expiryRaw.(string)
-		_, err := time.ParseDuration(expiry)
+		_, err := parseutil.ParseDurationSecond(expiry)
 		if err != nil {
 			return logical.ErrorResponse(fmt.Sprintf("given expiry could not be decoded: %s", err)), nil
 		}
@@ -309,7 +310,7 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 
 	if expiryRaw, ok := d.GetOk("ocsp_expiry"); ok {
 		expiry := expiryRaw.(string)
-		duration, err := time.ParseDuration(expiry)
+		duration, err := parseutil.ParseDurationSecond(expiry)
 		if err != nil {
 			return logical.ErrorResponse(fmt.Sprintf("given ocsp_expiry could not be decoded: %s", err)), nil
 		}
@@ -326,7 +327,7 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 
 	if autoRebuildGracePeriodRaw, ok := d.GetOk("auto_rebuild_grace_period"); ok {
 		autoRebuildGracePeriod := autoRebuildGracePeriodRaw.(string)
-		if _, err := time.ParseDuration(autoRebuildGracePeriod); err != nil {
+		if _, err := parseutil.ParseDurationSecond(autoRebuildGracePeriod); err != nil {
 			return logical.ErrorResponse(fmt.Sprintf("given auto_rebuild_grace_period could not be decoded: %s", err)), nil
 		}
 		config.AutoRebuildGracePeriod = autoRebuildGracePeriod
@@ -339,7 +340,7 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 
 	if deltaRebuildIntervalRaw, ok := d.GetOk("delta_rebuild_interval"); ok {
 		deltaRebuildInterval := deltaRebuildIntervalRaw.(string)
-		if _, err := time.ParseDuration(deltaRebuildInterval); err != nil {
+		if _, err := parseutil.ParseDurationSecond(deltaRebuildInterval); err != nil {
 			return logical.ErrorResponse(fmt.Sprintf("given delta_rebuild_interval could not be decoded: %s", err)), nil
 		}
 		config.DeltaRebuildInterval = deltaRebuildInterval
@@ -362,16 +363,16 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 		return logical.ErrorResponse("unified_crl_on_existing_paths cannot be enabled if unified_crl is disabled"), nil
 	}
 
-	expiry, _ := time.ParseDuration(config.Expiry)
+	expiry, _ := parseutil.ParseDurationSecond(config.Expiry)
 	if config.AutoRebuild {
-		gracePeriod, _ := time.ParseDuration(config.AutoRebuildGracePeriod)
+		gracePeriod, _ := parseutil.ParseDurationSecond(config.AutoRebuildGracePeriod)
 		if gracePeriod >= expiry {
 			return logical.ErrorResponse(fmt.Sprintf("CRL auto-rebuilding grace period (%v) must be strictly shorter than CRL expiry (%v) value when auto-rebuilding of CRLs is enabled", config.AutoRebuildGracePeriod, config.Expiry)), nil
 		}
 	}
 
 	if config.EnableDelta {
-		deltaRebuildInterval, _ := time.ParseDuration(config.DeltaRebuildInterval)
+		deltaRebuildInterval, _ := parseutil.ParseDurationSecond(config.DeltaRebuildInterval)
 		if deltaRebuildInterval >= expiry {
 			return logical.ErrorResponse(fmt.Sprintf("CRL delta rebuild window (%v) must be strictly shorter than CRL expiry (%v) value when delta CRLs are enabled", config.DeltaRebuildInterval, config.Expiry)), nil
 		}

--- a/builtin/logical/pki/path_ocsp.go
+++ b/builtin/logical/pki/path_ocsp.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 
 	"golang.org/x/crypto/ocsp"
@@ -476,7 +478,7 @@ func doesRequestMatchIssuer(parsedBundle *certutil.ParsedCertBundle, req *ocsp.R
 
 func genResponse(cfg *crlConfig, caBundle *certutil.ParsedCertBundle, info *ocspRespInfo, reqHash crypto.Hash, revSigAlg x509.SignatureAlgorithm) ([]byte, error) {
 	curTime := time.Now()
-	duration, err := time.ParseDuration(cfg.OcspExpiry)
+	duration, err := parseutil.ParseDurationSecond(cfg.OcspExpiry)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/path_ocsp.go
+++ b/builtin/logical/pki/path_ocsp.go
@@ -20,14 +20,11 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
-	"github.com/hashicorp/vault/sdk/helper/errutil"
-
-	"golang.org/x/crypto/ocsp"
-
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
+	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
+	"golang.org/x/crypto/ocsp"
 )
 
 const (

--- a/builtin/logical/pki/path_ocsp_test.go
+++ b/builtin/logical/pki/path_ocsp_test.go
@@ -17,13 +17,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
-	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
-
 	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/vault"
-
+	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/vault"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ocsp"
 )

--- a/builtin/logical/pki/path_ocsp_test.go
+++ b/builtin/logical/pki/path_ocsp_test.go
@@ -15,7 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
+
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
 
 	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
 
@@ -581,7 +582,7 @@ func runOcspRequestTest(t *testing.T, requestType string, caKeyType string, caKe
 	require.True(t, thisUpdate.Before(nextUpdate),
 		fmt.Sprintf("thisUpdate %s, should have been before nextUpdate: %s", thisUpdate, nextUpdate))
 	nextUpdateDiff := nextUpdate.Sub(thisUpdate)
-	expectedDiff, err := time.ParseDuration(defaultCrlConfig.OcspExpiry)
+	expectedDiff, err := parseutil.ParseDurationSecond(defaultCrlConfig.OcspExpiry)
 	require.NoError(t, err, "failed to parse default ocsp expiry value")
 	require.Equal(t, expectedDiff, nextUpdateDiff,
 		fmt.Sprintf("the delta between thisUpdate %s and nextUpdate: %s should have been around: %s but was %s",

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -12,6 +12,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-hclog"
 
@@ -768,7 +770,7 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 
 	if pauseDurationStr != "" {
 		var err error
-		pauseDuration, err = time.ParseDuration(pauseDurationStr)
+		pauseDuration, err = parseutil.ParseDurationSecond(pauseDurationStr)
 		if err != nil {
 			return logical.ErrorResponse(fmt.Sprintf("Error parsing pause_duration: %v", err)), nil
 		}
@@ -1792,7 +1794,7 @@ func (b *backend) pathConfigAutoTidyWrite(ctx context.Context, req *logical.Requ
 	}
 
 	if pauseDurationRaw, ok := d.GetOk("pause_duration"); ok {
-		config.PauseDuration, err = time.ParseDuration(pauseDurationRaw.(string))
+		config.PauseDuration, err = parseutil.ParseDurationSecond(pauseDurationRaw.(string))
 		if err != nil {
 			return logical.ErrorResponse(fmt.Sprintf("unable to parse given pause_duration: %v", err)), nil
 		}

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -12,11 +12,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-hclog"
-
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"

--- a/changelog/21357.txt
+++ b/changelog/21357.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fixed issue with some durations not being properly parsed to include days.
+```

--- a/command/base_flags.go
+++ b/command/base_flags.go
@@ -989,33 +989,3 @@ func (d *timeValue) Get() interface{} { return *d.target }
 func (d *timeValue) String() string   { return (*d.target).String() }
 func (d *timeValue) Example() string  { return "time" }
 func (d *timeValue) Hidden() bool     { return d.hidden }
-
-// -- helpers
-func envDefault(key, def string) string {
-	if v, exist := os.LookupEnv(key); exist {
-		return v
-	}
-	return def
-}
-
-func envBoolDefault(key string, def bool) bool {
-	if v, exist := os.LookupEnv(key); exist {
-		b, err := strconv.ParseBool(v)
-		if err != nil {
-			panic(err)
-		}
-		return b
-	}
-	return def
-}
-
-func envDurationDefault(key string, def time.Duration) time.Duration {
-	if v, exist := os.LookupEnv(key); exist {
-		d, err := time.ParseDuration(v)
-		if err != nil {
-			panic(err)
-		}
-		return d
-	}
-	return def
-}

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -18,6 +18,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+
 	"github.com/armon/go-metrics"
 	"github.com/golang/protobuf/proto"
 	log "github.com/hashicorp/go-hclog"
@@ -371,7 +373,7 @@ func NewRaftBackend(conf map[string]string, logger log.Logger) (physical.Backend
 	}
 
 	if delayRaw, ok := conf["apply_delay"]; ok {
-		delay, err := time.ParseDuration(delayRaw)
+		delay, err := parseutil.ParseDurationSecond(delayRaw)
 		if err != nil {
 			return nil, fmt.Errorf("apply_delay does not parse as a duration: %w", err)
 		}
@@ -428,7 +430,7 @@ func NewRaftBackend(conf map[string]string, logger log.Logger) (physical.Backend
 	}
 
 	if delayRaw, ok := conf["snapshot_delay"]; ok {
-		delay, err := time.ParseDuration(delayRaw)
+		delay, err := parseutil.ParseDurationSecond(delayRaw)
 		if err != nil {
 			return nil, fmt.Errorf("snapshot_delay does not parse as a duration: %w", err)
 		}
@@ -447,7 +449,7 @@ func NewRaftBackend(conf map[string]string, logger log.Logger) (physical.Backend
 
 	var reconcileInterval time.Duration
 	if interval := conf["autopilot_reconcile_interval"]; interval != "" {
-		interval, err := time.ParseDuration(interval)
+		interval, err := parseutil.ParseDurationSecond(interval)
 		if err != nil {
 			return nil, fmt.Errorf("autopilot_reconcile_interval does not parse as a duration: %w", err)
 		}
@@ -456,7 +458,7 @@ func NewRaftBackend(conf map[string]string, logger log.Logger) (physical.Backend
 
 	var updateInterval time.Duration
 	if interval := conf["autopilot_update_interval"]; interval != "" {
-		interval, err := time.ParseDuration(interval)
+		interval, err := parseutil.ParseDurationSecond(interval)
 		if err != nil {
 			return nil, fmt.Errorf("autopilot_update_interval does not parse as a duration: %w", err)
 		}
@@ -817,7 +819,7 @@ func (b *RaftBackend) applyConfigSettings(config *raft.Config) error {
 	snapshotIntervalRaw, ok := b.conf["snapshot_interval"]
 	if ok {
 		var err error
-		snapshotInterval, err := time.ParseDuration(snapshotIntervalRaw)
+		snapshotInterval, err := parseutil.ParseDurationSecond(snapshotIntervalRaw)
 		if err != nil {
 			return err
 		}

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -18,13 +18,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
 	"github.com/armon/go-metrics"
 	"github.com/golang/protobuf/proto"
 	log "github.com/hashicorp/go-hclog"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"github.com/hashicorp/go-raftchunking"
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/tlsutil"
 	"github.com/hashicorp/go-uuid"
 	goversion "github.com/hashicorp/go-version"

--- a/physical/raft/raft_autopilot.go
+++ b/physical/raft/raft_autopilot.go
@@ -706,7 +706,7 @@ func (d *ReadableDuration) UnmarshalJSON(raw []byte) (err error) {
 	str := string(raw)
 	if len(str) >= 2 && str[0] == '"' && str[len(str)-1] == '"' {
 		// quoted string
-		dur, err = time.ParseDuration(str[1 : len(str)-1])
+		dur, err = parseutil.ParseDurationSecond(str[1 : len(str)-1])
 		if err != nil {
 			return err
 		}

--- a/sdk/database/dbplugin/v5/testing/test_helpers.go
+++ b/sdk/database/dbplugin/v5/testing/test_helpers.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+
 	"github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 )
 
@@ -22,7 +24,7 @@ func getRequestTimeout(t *testing.T) time.Duration {
 		return 10 * time.Second
 	}
 
-	dur, err := time.ParseDuration(rawDur)
+	dur, err := parseutil.ParseDurationSecond(rawDur)
 	if err != nil {
 		t.Fatalf("Failed to parse custom request timeout %q: %s", rawDur, err)
 	}

--- a/sdk/database/dbplugin/v5/testing/test_helpers.go
+++ b/sdk/database/dbplugin/v5/testing/test_helpers.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
 	"github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 )
 

--- a/sdk/helper/identitytpl/templating.go
+++ b/sdk/helper/identitytpl/templating.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -330,7 +332,7 @@ func performTemplating(input string, p *PopulateStringInput) (string, error) {
 			return "", errors.New("missing time operand")
 
 		case 3:
-			duration, err := time.ParseDuration(opsSplit[2])
+			duration, err := parseutil.ParseDurationSecond(opsSplit[2])
 			if err != nil {
 				return "", errwrap.Wrapf("invalid duration: {{err}}", err)
 			}

--- a/sdk/helper/identitytpl/templating.go
+++ b/sdk/helper/identitytpl/templating.go
@@ -11,9 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 

--- a/sdk/helper/pointerutil/pointer.go
+++ b/sdk/helper/pointerutil/pointer.go
@@ -6,6 +6,8 @@ package pointerutil
 import (
 	"os"
 	"time"
+
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
 )
 
 // StringPtr returns a pointer to a string value
@@ -20,7 +22,7 @@ func BoolPtr(b bool) *bool {
 
 // TimeDurationPtr returns a pointer to a time duration value
 func TimeDurationPtr(duration string) *time.Duration {
-	d, _ := time.ParseDuration(duration)
+	d, _ := parseutil.ParseDurationSecond(duration)
 
 	return &d
 }

--- a/tools/semgrep/ci/time-parse-duration.yml
+++ b/tools/semgrep/ci/time-parse-duration.yml
@@ -1,0 +1,10 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+rules:
+  - id: time-parse-duration
+    patterns:
+      - pattern: time.ParseDuration
+    message: "Usage of time.ParseDuration. Use parseutil.ParseDurationSeconds, instead!"
+    languages: [go]
+    severity: ERROR

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+
 	"github.com/go-test/deep"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -2253,8 +2255,8 @@ func TestOIDC_Path_OIDC_Client_List_KeyInfo(t *testing.T) {
 		expected := clients[name].(map[string]interface{})
 		require.Contains(t, keys, name)
 
-		idTokenTTL, _ := time.ParseDuration(expected["id_token_ttl"].(string))
-		accessTokenTTL, _ := time.ParseDuration(expected["access_token_ttl"].(string))
+		idTokenTTL, _ := parseutil.ParseDurationSecond(expected["id_token_ttl"].(string))
+		accessTokenTTL, _ := parseutil.ParseDurationSecond(expected["access_token_ttl"].(string))
 		require.EqualValues(t, idTokenTTL.Seconds(), actual["id_token_ttl"])
 		require.EqualValues(t, accessTokenTTL.Seconds(), actual["access_token_ttl"])
 		require.Equal(t, expected["redirect_uris"], actual["redirect_uris"])

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -13,9 +13,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
 	"github.com/go-test/deep"
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+
 	"github.com/hashicorp/vault/helper/timeutil"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -222,7 +224,7 @@ func (b *SystemBackend) handleClientExport(ctx context.Context, req *logical.Req
 	// This is to avoid the default 90s context timeout.
 	timeout := 10 * time.Minute
 	if durationRaw := os.Getenv("VAULT_ACTIVITY_EXPORT_DURATION"); durationRaw != "" {
-		d, err := time.ParseDuration(durationRaw)
+		d, err := parseutil.ParseDurationSecond(durationRaw)
 		if err == nil {
 			timeout = d
 		}

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
 	"github.com/hashicorp/vault/helper/timeutil"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -3207,7 +3207,7 @@ func (ts *TokenStore) handleCreateCommon(ctx context.Context, req *logical.Reque
 		te.TTL = dur
 	} else if data.Lease != "" {
 		// This block is compatibility
-		dur, err := time.ParseDuration(data.Lease)
+		dur, err := parseutil.ParseDurationSecond(data.Lease)
 		if err != nil {
 			return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 		}


### PR DESCRIPTION
Vault's duration string format is supports a strict superset of options compared to Go's duration string format: https://developer.hashicorp.com/vault/docs/concepts/duration-format

In particular, we support days, e.g. `5d`, whereas `time.ParseDuration` does not.

We use `parseutil.ParseDurationSeconds` everywhere in the code we can, to support our advertised duration format and to be consistent with ourselves. The majority of our code already uses `parseutil.ParseDurationSeconds`, but there were a few places I found that `time.ParseDuration` was still being used as part of poking around, so I thought I'd fix them all at once.

I'm not worried about the fact this change changes a lot of files. `ParseDurationSeconds` is battle-tested, and there's no valid duration that `time.ParseDuration` supports that we don't also support.