### PR TITLE
Fix: prevent unrequired CI jobs running when 'docs' label is added

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     # This is insufficient for our needs, since we're skipping stuff on PRs in
     # draft mode.  By adding the ready_for_review type, when a draft pr is marked
     # ready, we run everything, including the stuff we'd have skipped up until now.
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
@@ -24,44 +24,44 @@ jobs:
       enterprise: ${{ steps.setup-outputs.outputs.enterprise }}
       go-build-tags: ${{ steps.setup-outputs.outputs.go-build-tags }}
     steps:
-    - id: setup-outputs
-      name: Setup outputs
-      run: |
-        github_repository="${{ github.repository }}"
+      - id: setup-outputs
+        name: Setup outputs
+        run: |
+          github_repository="${{ github.repository }}"
 
-        if [ "${github_repository##*/}" == "vault-enterprise" ] ; then
-          # shellcheck disable=SC2129
-          echo 'compute-tiny=["self-hosted","ondemand","linux","type=m5.large"]' >> "$GITHUB_OUTPUT"
-          echo 'compute-standard=["self-hosted","ondemand","linux","type=m5.xlarge"]' >> "$GITHUB_OUTPUT"
-          echo 'compute-larger=["self-hosted","ondemand","linux","type=m5.2xlarge"]' >> "$GITHUB_OUTPUT"
-          echo 'compute-huge=["self-hosted","ondemand","linux","type=m5.4xlarge"]' >> "$GITHUB_OUTPUT"
-          echo 'enterprise=1' >> "$GITHUB_OUTPUT"
-          echo 'go-build-tags=ent,enterprise' >> "$GITHUB_OUTPUT"
-        else
-          # shellcheck disable=SC2129
-          echo 'compute-tiny="ubuntu-latest"' >> "$GITHUB_OUTPUT"                         #  2 cores,   7 GB RAM,   14 GB SSD
-          echo 'compute-standard="custom-linux-small-vault-latest"' >> "$GITHUB_OUTPUT"   #  8 cores,  32 GB RAM,  300 GB SSD
-          echo 'compute-larger="custom-linux-medium-vault-latest"' >> "$GITHUB_OUTPUT"    # 16 cores,  64 GB RAM,  600 GB SSD
-          echo 'compute-huge="custom-linux-xl-vault-latest"' >> "$GITHUB_OUTPUT"          # 32-cores, 128 GB RAM, 1200 GB SSD
-          echo 'enterprise=' >> "$GITHUB_OUTPUT"
-          echo 'go-build-tags=' >> "$GITHUB_OUTPUT"
-        fi
+          if [ "${github_repository##*/}" == "vault-enterprise" ] ; then
+            # shellcheck disable=SC2129
+            echo 'compute-tiny=["self-hosted","ondemand","linux","type=m5.large"]' >> "$GITHUB_OUTPUT"
+            echo 'compute-standard=["self-hosted","ondemand","linux","type=m5.xlarge"]' >> "$GITHUB_OUTPUT"
+            echo 'compute-larger=["self-hosted","ondemand","linux","type=m5.2xlarge"]' >> "$GITHUB_OUTPUT"
+            echo 'compute-huge=["self-hosted","ondemand","linux","type=m5.4xlarge"]' >> "$GITHUB_OUTPUT"
+            echo 'enterprise=1' >> "$GITHUB_OUTPUT"
+            echo 'go-build-tags=ent,enterprise' >> "$GITHUB_OUTPUT"
+          else
+            # shellcheck disable=SC2129
+            echo 'compute-tiny="ubuntu-latest"' >> "$GITHUB_OUTPUT"                         #  2 cores,   7 GB RAM,   14 GB SSD
+            echo 'compute-standard="custom-linux-small-vault-latest"' >> "$GITHUB_OUTPUT"   #  8 cores,  32 GB RAM,  300 GB SSD
+            echo 'compute-larger="custom-linux-medium-vault-latest"' >> "$GITHUB_OUTPUT"    # 16 cores,  64 GB RAM,  600 GB SSD
+            echo 'compute-huge="custom-linux-xl-vault-latest"' >> "$GITHUB_OUTPUT"          # 32-cores, 128 GB RAM, 1200 GB SSD
+            echo 'enterprise=' >> "$GITHUB_OUTPUT"
+            echo 'go-build-tags=' >> "$GITHUB_OUTPUT"
+          fi
   semgrep:
     name: Semgrep
     needs:
-    - setup
+      - setup
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     container:
       image: returntocorp/semgrep@sha256:ffc6f3567654f9431456d49fd059dfe548f007c494a7eb6cd5a1a3e50d813fb3
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-    - name: Run Semgrep Rules
-      id: semgrep
-      run: semgrep ci --include '*.go' --config 'tools/semgrep/ci'
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Run Semgrep Rules
+        id: semgrep
+        run: semgrep ci --include '*.go' --config 'tools/semgrep/ci'
   setup-go-cache:
     name: Go Caches
     needs:
-    - setup
+      - setup
     uses: ./.github/workflows/setup-go-cache.yml
     with:
       runs-on: ${{ needs.setup.outputs.compute-standard }}
@@ -69,65 +69,69 @@ jobs:
   fmt:
     name: Check Format
     needs:
-    - setup
+      - setup
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-    - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-      with:
-        go-version-file: ./.go-version
-        cache: true
-    - id: format
-      run: |
-        echo "Using gofumpt version $(go run mvdan.cc/gofumpt -version)"
-        make fmt
-        if ! git diff --exit-code; then
-          echo "Code has formatting errors. Run 'make fmt' to fix"
-          exit 1
-        fi
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version-file: ./.go-version
+          cache: true
+      - id: format
+        run: |
+          echo "Using gofumpt version $(go run mvdan.cc/gofumpt -version)"
+          make fmt
+          if ! git diff --exit-code; then
+            echo "Code has formatting errors. Run 'make fmt' to fix"
+            exit 1
+          fi
   diff-oss-ci:
     name: Diff OSS
     needs:
-    - setup
+      - setup
     if: ${{ needs.setup.outputs.enterprise != '' && github.base_ref != '' }}
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      with:
-        fetch-depth: 0
-    - id: determine-branch
-      run: |
-        branch="${{ github.base_ref }}"
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          fetch-depth: 0
+      - id: determine-branch
+        run: |
+          branch="${{ github.base_ref }}"
 
-        if [[ $branch = release/* ]] ; then
-          branch=${branch%%+ent}
+          if [[ $branch = release/* ]] ; then
+            branch=${branch%%+ent}
 
-          # Add OSS remote
-          git config --global user.email "github-team-secret-vault-core@hashicorp.com"
-          git config --global user.name "hc-github-team-secret-vault-core"
-          git remote add oss https://github.com/hashicorp/vault.git
-          git fetch oss "$branch"
+            # Add OSS remote
+            git config --global user.email "github-team-secret-vault-core@hashicorp.com"
+            git config --global user.name "hc-github-team-secret-vault-core"
+            git remote add oss https://github.com/hashicorp/vault.git
+            git fetch oss "$branch"
 
-          branch="oss/$branch"
-        else
-          branch="origin/$branch"
-        fi
+            branch="oss/$branch"
+          else
+            branch="origin/$branch"
+          fi
 
-        echo "BRANCH=$branch" >> "$GITHUB_OUTPUT"
-    - id: diff
-      run: |
-        ./.github/scripts/oss-diff.sh ${{ steps.determine-branch.outputs.BRANCH }} HEAD
+          echo "BRANCH=$branch" >> "$GITHUB_OUTPUT"
+      - id: diff
+        run: |
+          ./.github/scripts/oss-diff.sh ${{ steps.determine-branch.outputs.BRANCH }} HEAD
   test-go:
     name: Run Go tests
     needs:
-    - setup
-    - setup-go-cache
-    # Don't run this job for PR branches starting with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
+      - setup
+      - setup-go-cache
+    # Don't run this job for PR branches starting with:
+    # 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
+    # OR
+    # the 'docs' label is present
     if: |
       !startsWith(github.head_ref, 'ui/') &&
       !startsWith(github.head_ref, 'backport/ui/') &&
       !startsWith(github.head_ref, 'docs/') &&
-      !startsWith(github.head_ref, 'backport/docs/')
+      !startsWith(github.head_ref, 'backport/docs/') &&
+      !contains(github.event.pull_request.labels.*.name, 'docs')
     uses: ./.github/workflows/test-go.yml
     with:
       # The regular Go tests use an extra runner to execute the
@@ -142,15 +146,19 @@ jobs:
   test-go-race:
     name: Run Go tests with data race detection
     needs:
-    - setup
-    - setup-go-cache
-    # Don't run this job for PR branches starting with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
+      - setup
+      - setup-go-cache
+    # Don't run this job for PR branches starting with:
+    # 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
+    # OR
+    # the 'docs' label is present
     if: |
       github.event.pull_request.draft == false &&
       !startsWith(github.head_ref, 'ui/') &&
       !startsWith(github.head_ref, 'backport/ui/') &&
       !startsWith(github.head_ref, 'docs/') &&
-      !startsWith(github.head_ref, 'backport/docs/')
+      !startsWith(github.head_ref, 'backport/docs/') &&
+      !contains(github.event.pull_request.labels.*.name, 'docs')
     uses: ./.github/workflows/test-go.yml
     with:
       total-runners: 16
@@ -167,17 +175,21 @@ jobs:
     secrets: inherit
   test-go-fips:
     name: Run Go tests with FIPS configuration
-    # Only run this job for the enterprise repo if the PR branch doesn't start with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
+    # Only run this job for the enterprise repo if the PR branch doesn't start with:
+    # 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
+    # OR
+    # the 'docs' label is not present
     if: |
       github.event.pull_request.draft == false &&
       needs.setup.outputs.enterprise == 1 &&
       !startsWith(github.head_ref, 'ui/') &&
       !startsWith(github.head_ref, 'backport/ui/') &&
       !startsWith(github.head_ref, 'docs/') &&
-      !startsWith(github.head_ref, 'backport/docs/')
+      !startsWith(github.head_ref, 'backport/docs/') &&
+      !contains(github.event.pull_request.labels.*.name, 'docs')
     needs:
-    - setup
-    - setup-go-cache
+      - setup
+      - setup-go-cache
     uses: ./.github/workflows/test-go.yml
     with:
       total-runners: 16
@@ -205,100 +217,100 @@ jobs:
       startsWith(github.head_ref, 'merge') || 
       contains(github.event.pull_request.labels.*.name, 'ui')
     needs:
-    - setup
+      - setup
     permissions:
       id-token: write
       contents: read
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-larger) }}
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-    - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-      with:
-        go-version-file: ./.go-version
-        cache: true
-    # Setup node.js without caching to allow running npm install -g yarn (next step)
-    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-      with:
-        node-version-file: './ui/package.json'
-    - id: install-yarn
-      run: |
-        npm install -g yarn
-    # Setup node.js with caching using the yarn.lock file
-    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-      with:
-        node-version-file: './ui/package.json'
-        cache: yarn
-        cache-dependency-path: ui/yarn.lock
-    - id: install-browser
-      uses: browser-actions/setup-chrome@c485fa3bab6be59dce18dbc18ef6ab7cbc8ff5f1 # v1.2.0
-    - id: ui-dependencies
-      name: ui-dependencies
-      working-directory: ./ui
-      run: |
-        yarn install --frozen-lockfile
-        npm rebuild node-sass
-    - id: vault-auth
-      name: Authenticate to Vault
-      if: github.repository == 'hashicorp/vault-enterprise'
-      run: vault-auth
-    - id: secrets
-      name: Fetch secrets
-      if: github.repository == 'hashicorp/vault-enterprise'
-      uses: hashicorp/vault-action@130d1f5f4fe645bb6c83e4225c04d64cfb62de6e
-      with:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version-file: ./.go-version
+          cache: true
+      # Setup node.js without caching to allow running npm install -g yarn (next step)
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version-file: './ui/package.json'
+      - id: install-yarn
+        run: |
+          npm install -g yarn
+      # Setup node.js with caching using the yarn.lock file
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version-file: './ui/package.json'
+          cache: yarn
+          cache-dependency-path: ui/yarn.lock
+      - id: install-browser
+        uses: browser-actions/setup-chrome@c485fa3bab6be59dce18dbc18ef6ab7cbc8ff5f1 # v1.2.0
+      - id: ui-dependencies
+        name: ui-dependencies
+        working-directory: ./ui
+        run: |
+          yarn install --frozen-lockfile
+          npm rebuild node-sass
+      - id: vault-auth
+        name: Authenticate to Vault
+        if: github.repository == 'hashicorp/vault-enterprise'
+        run: vault-auth
+      - id: secrets
+        name: Fetch secrets
+        if: github.repository == 'hashicorp/vault-enterprise'
+        uses: hashicorp/vault-action@130d1f5f4fe645bb6c83e4225c04d64cfb62de6e
+        with:
           url: ${{ steps.vault-auth.outputs.addr }}
           caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
           token: ${{ steps.vault-auth.outputs.token }}
           secrets: |
             kv/data/github/hashicorp/vault-enterprise/github-token token | PRIVATE_REPO_GITHUB_TOKEN;
             kv/data/github/hashicorp/vault-enterprise/license license_1 | VAULT_LICENSE;
-    - id: setup-git
-      name: Setup Git
-      if: github.repository == 'hashicorp/vault-enterprise'
-      env:
-        PRIVATE_REPO_GITHUB_TOKEN: ${{ steps.secrets.outputs.PRIVATE_REPO_GITHUB_TOKEN }}
-      run: |
-        git config --global url."https://hc-github-team-secure-vault-core:${PRIVATE_REPO_GITHUB_TOKEN}@github.com".insteadOf https://github.com
-    - id: build-go-dev
-      name: build-go-dev
-      run: |
-        rm -rf ./pkg
-        mkdir ./pkg
+      - id: setup-git
+        name: Setup Git
+        if: github.repository == 'hashicorp/vault-enterprise'
+        env:
+          PRIVATE_REPO_GITHUB_TOKEN: ${{ steps.secrets.outputs.PRIVATE_REPO_GITHUB_TOKEN }}
+        run: |
+          git config --global url."https://hc-github-team-secure-vault-core:${PRIVATE_REPO_GITHUB_TOKEN}@github.com".insteadOf https://github.com
+      - id: build-go-dev
+        name: build-go-dev
+        run: |
+          rm -rf ./pkg
+          mkdir ./pkg
 
-        make ci-bootstrap dev
-    - id: test-ui
-      name: test-ui
-      env:
-        VAULT_LICENSE: ${{ steps.secrets.outputs.VAULT_LICENSE }}
-      run: |
-        export PATH="${PWD}/bin:${PATH}"
+          make ci-bootstrap dev
+      - id: test-ui
+        name: test-ui
+        env:
+          VAULT_LICENSE: ${{ steps.secrets.outputs.VAULT_LICENSE }}
+        run: |
+          export PATH="${PWD}/bin:${PATH}"
 
-        if [ "${{ github.repository }}" == 'hashicorp/vault' ] ; then
-          export VAULT_LICENSE="${{ secrets.VAULT_LICENSE }}"
-        fi
+          if [ "${{ github.repository }}" == 'hashicorp/vault' ] ; then
+            export VAULT_LICENSE="${{ secrets.VAULT_LICENSE }}"
+          fi
 
-        # Run Ember tests
-        cd ui
-        mkdir -p test-results/qunit
-        yarn test:oss
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-      with:
-        name: test-results-ui
-        path: ui/test-results
-      if: always()
-    - uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f # TSCCR: no entry for repository "test-summary/action"
-      with:
-        paths: "ui/test-results/qunit/results.xml"
-        show: "fail"
-      if: always()
+          # Run Ember tests
+          cd ui
+          mkdir -p test-results/qunit
+          yarn test:oss
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: test-results-ui
+          path: ui/test-results
+        if: always()
+      - uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f # TSCCR: no entry for repository "test-summary/action"
+        with:
+          paths: "ui/test-results/qunit/results.xml"
+          show: "fail"
+        if: always()
   tests-completed:
     needs:
-    - setup
-    - setup-go-cache
-    - test-go
-    - test-ui
+      - setup
+      - setup-go-cache
+      - test-go
+      - test-ui
     if: always()
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-    - run: |
-        tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)'
+      - run: |
+          tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)'


### PR DESCRIPTION
Currently we rely heavily on branch naming prefixes to decide whether to run specific jobs within the `CI` workflow on open/ready PRs. This knowledge isn't known to all teams or contributors, but they may find the `docs` label more easily during the creation of their PR within GitHub.

This PR also checks for the existence of the `docs` label and if found, skips jobs which are not required.

The PR could be thought of as a more temporary fix as there may be additional use cases for `ui` and `backport` related labels too, and we could also consider our grouping of CI related jobs so that we could simplify using [paths-ignore](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths) for `website/content/**` in the future.

`Prettier` kindly reformatted whitespace (before I uninstalled it as it wanted to tamper with single quotes too), so please review ignoring whitespace changes 😄 