### PR TITLE
Remove bump_version from transit import docs

### DIFF
--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -253,12 +253,9 @@ imported. This limits the operations available under this key to verification
 and encryption, depending on the key type and algorithm, as no private key
 is available.
 
-- `bump_version` - By default, each operator will create a new key version.
-If set to "false", will try to update the latest version of the key,
-unless changed in parameter `version`.
-
-- `version` - Key version to be updated, if left empty "Latest" version will be updated.
-If `bump_version` is set to "true", this field is ignored.
+- `version` `(int, optional)` - Key version to be updated, if left empty,
+a new version will be created unless a private key is specified and the
+'Latest' key is missing a private key.
 
 ### Sample Payload
 


### PR DESCRIPTION
 - The argument `bump_version` was removed within #20814 along the development path, but the documentation update was missed.