### PR TITLE
Fix incorrect ordering in api-docs-nav-data.json

### DIFF
--- a/website/data/api-docs-nav-data.json
+++ b/website/data/api-docs-nav-data.json
@@ -438,6 +438,10 @@
         "path": "system/control-group"
       },
       {
+        "title": "<code>/sys/decode-token</code>",
+        "path": "system/decode-token"
+      },
+      {
         "title": "<code>/sys/experiments</code>",
         "path": "system/experiments"
       },
@@ -448,10 +452,6 @@
       {
         "title": "<code>/sys/generate-root</code>",
         "path": "system/generate-root"
-      },
-      {
-        "title": "<code>/sys/decode-token</code>",
-        "path": "system/decode-token"
       },
       {
         "title": "<code>/sys/health</code>",


### PR DESCRIPTION
https://github.com/hashicorp/vault/pull/20595/files#diff-9c9c146a6465b0deafac528d60a94bee5f609ac37c203005bd3b5cda6c190882 was a contrib which added a new endpoint, however the ref to the page in api-docs-nav-data.json was incorrectly added and thus appears out of order in the left sidebar, i.e. https://developer.hashicorp.com/vault/api-docs/system/decode-token

![image](https://github.com/hashicorp/vault/assets/86935689/84529fd5-fb5a-4890-8d4f-4d6f67a8b914)

preview: https://vault-j9dk3o0r1-hashicorp.vercel.app/vault/api-docs/system/decode-token
