### PR TITLE
[Docs] Add cross-links to related tutorials

### DIFF
--- a/website/content/docs/agent-and-proxy/agent/generate-config/index.mdx
+++ b/website/content/docs/agent-and-proxy/agent/generate-config/index.mdx
@@ -47,15 +47,23 @@ Generate an agent configuration file which will reference `secret/foo`:
 
 ```shell-session
 $ vault agent generate-config \
-                -type="env-template" \
-                -exec="./my-app arg1 arg2" \
-                -namespace="my/ns/" \
-                -path="secret/foo" \
-                    my-config.hcl
+         -type="env-template" \
+         -exec="./my-app arg1 arg2" \
+         -namespace="my/ns/" \
+         -path="secret/foo" \
+         my-config.hcl
+```
 
+**Expected output:** 
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
 Successfully generated "my-config.hcl" configuration file!
 Warning: the generated file uses 'token_file' authentication method, which is not suitable for production environments.
 ```
+
+</CodeBlockConfig>
 
 This will produce `my-config.hcl` file in the current directory with contents
 similar to the following:
@@ -111,3 +119,10 @@ flags](/vault/docs/commands) included in all commands.
 
 - `-exec` `(string: "env")` - The command to execute in agent process
   supervisor mode.
+
+
+## Tutorial
+
+Refer to the [Vault Agent - secrets as environment
+variables](/vault/tutorials/vault-agent/agent-env-vars) tutorial for an
+end-to-end example.

--- a/website/content/docs/agent-and-proxy/agent/process-supervisor.mdx
+++ b/website/content/docs/agent-and-proxy/agent/process-supervisor.mdx
@@ -149,3 +149,10 @@ exec {
 
 [consul-templating-language]: https://github.com/hashicorp/consul-template/blob/v0.28.1/docs/templating-language.md
 [template-config]: /vault/docs/agent-and-proxy/agent/template#template-configurations
+
+
+## Tutorial
+
+Refer to the [Vault Agent - secrets as environment
+variables](/vault/tutorials/vault-agent/agent-env-vars) tutorial for an
+end-to-end example.

--- a/website/content/docs/auth/jwt/index.mdx
+++ b/website/content/docs/auth/jwt/index.mdx
@@ -360,6 +360,16 @@ A parameter of `"division"` will reference "North America", as this is a top lev
 JSON Pointer can be used as a selector. Refer to the
 [JSON Pointer RFC](https://tools.ietf.org/html/rfc6901) for a full description of the syntax.
 
+## Tutorial
+
+Refer to the following tutorials for OIDC auth method usage examples:
+
+- [OIDC Auth Method](/vault/tutorials/auth-methods/oidc-auth)
+- [Azure Active Directory with OIDC Auth Method and External
+  Groups](/vault/tutorials/auth-methods/oidc-auth-azure)
+- [OIDC Authentication with Okta](/vault/tutorials/auth-methods/vault-oidc-okta)
+- [OIDC Authentication with Google Workspace](/vault/tutorials/auth-methods/google-workspace-oauth)
+
 ## API
 
 The JWT Auth Plugin has a full HTTP API. Please see the

--- a/website/content/docs/platform/k8s/vso/index.mdx
+++ b/website/content/docs/platform/k8s/vso/index.mdx
@@ -272,3 +272,10 @@ spec:
     create: true
     name: dynamic2
 ```
+
+
+## Tutorial
+
+Refer to the [The Vault Secrets Operator on
+Kubernetes](/vault/tutorials/new-release/vault-secrets-operator) tutorial to
+learn the end-to-end workflow using the Vault Secrets Operator.

--- a/website/content/docs/secrets/ldap.mdx
+++ b/website/content/docs/secrets/ldap.mdx
@@ -462,6 +462,12 @@ olcPPolicyHashCleartext: TRUE
 olcPPolicyUseLockout: TRUE
 ```
 
+## Tutorial
+
+Refer to the [LDAP Secrets Engine](/vault/tutorials/secrets-management/openldap)
+tutorial to learn how to configure and use the LDAP secrets engine.
+
+
 ## API
 
 The LDAP secrets engine has a full HTTP API. Please see the [LDAP secrets engine API docs](/vault/api-docs/secret/ldap)

--- a/website/content/docs/secrets/pki/index.mdx
+++ b/website/content/docs/secrets/pki/index.mdx
@@ -46,11 +46,13 @@ The PKI Secrets Engine documentation is split into the following pieces:
 
 ## Tutorial
 
-Refer to the [Build Your Own Certificate Authority (CA)](/vault/tutorials/secrets-management/pki-engine)
-guide for a step-by-step tutorial.
+Refer to the following tutorials to learn more:
 
-Have a look at the [PKI Secrets Engine with Managed Keys](/vault/tutorials/enterprise/managed-key-pki)
-for more about how to use externally managed keys with PKI.
+- [Build Your Own Certificate Authority (CA)](/vault/tutorials/secrets-management/pki-engine)
+- [Build Certificate Authority (CA) in Vault with an offline Root](/vault/tutorials/secrets-management/pki-engine-external-ca)
+- [Enable ACME with PKI secrets engine](/vault/tutorials/new-release/pki-acme-caddy)
+- [PKI Secrets Engine with Managed Keys](/vault/tutorials/enterprise/managed-key-pki)
+- [PKI Unified CRL and OCSP With Cross Cluster Revocation](/vault/tutorials/secrets-management/pki-unified-crl-ocsp-cross-cluster)
 
 ## API
 

--- a/website/content/docs/secrets/pki/index.mdx
+++ b/website/content/docs/secrets/pki/index.mdx
@@ -46,13 +46,19 @@ The PKI Secrets Engine documentation is split into the following pieces:
 
 ## Tutorial
 
-Refer to the following tutorials to learn more:
+Refer to the following tutorials for PKI secrets engine usage examples:
 
 - [Build Your Own Certificate Authority (CA)](/vault/tutorials/secrets-management/pki-engine)
 - [Build Certificate Authority (CA) in Vault with an offline Root](/vault/tutorials/secrets-management/pki-engine-external-ca)
 - [Enable ACME with PKI secrets engine](/vault/tutorials/new-release/pki-acme-caddy)
 - [PKI Secrets Engine with Managed Keys](/vault/tutorials/enterprise/managed-key-pki)
-- [PKI Unified CRL and OCSP With Cross Cluster Revocation](/vault/tutorials/secrets-management/pki-unified-crl-ocsp-cross-cluster)
+- [PKI Unified CRL and OCSP With Cross Cluster
+  Revocation](/vault/tutorials/secrets-management/pki-unified-crl-ocsp-cross-cluster)
+- [Configure Vault as a Certificate Manager in Kubernetes with
+  Helm](/vault/tutorials/kubernetes/kubernetes-cert-manager)
+- [Generate mTLS Certificates for Nomad using
+  Vault](/vault/tutorials/secrets-management/vault-pki-nomad)
+
 
 ## API
 


### PR DESCRIPTION
This PR adds **Tutorial** section to those doc pages that has related tutorial(s).

🔍 [Deploy preview - PKI secrets engine](https://vault-git-docs-add-tutorial-links-hashicorp.vercel.app/vault/docs/secrets/pki#tutorial)

🔍 [Deploy preview - Vault Agent](https://vault-git-docs-add-tutorial-links-hashicorp.vercel.app/vault/docs/agent-and-proxy/agent/process-supervisor#tutorial)

🔍 [Deploy preview - OIDC auth](https://vault-git-docs-add-tutorial-links-hashicorp.vercel.app/vault/docs/auth/jwt#tutorial)

🔍 [Deploy preview - VSO](https://vault-git-docs-add-tutorial-links-hashicorp.vercel.app/vault/docs/platform/k8s/vso#tutorial)

🔍 [Deploy preview - LDAP secrets engine](https://vault-git-docs-add-tutorial-links-hashicorp.vercel.app/vault/docs/secrets/ldap#tutorial)