### PR TITLE
[Docs] ldap auth add VAULT_LDAP_PASSWORD environment variable

### DIFF
--- a/website/content/api-docs/auth/ldap.mdx
+++ b/website/content/api-docs/auth/ldap.mdx
@@ -447,7 +447,9 @@ This endpoint allows you to log in with LDAP credentials
 ### Parameters
 
 - `username` `(string: <required>)` – The username of the LDAP user
-- `password` `(string: <required>)` – The password for the LDAP user
+- `password` `(string: <required>)` – The password for the LDAP user. 
+When authenticating with the Vault CLI, i.e. `vault login -method=ldap username=mitchellh` 
+the password can be supplied via the `VAULT_LDAP_PASSWORD` environment variable.
 
 ### Sample Payload
 

--- a/website/content/api-docs/auth/ldap.mdx
+++ b/website/content/api-docs/auth/ldap.mdx
@@ -449,7 +449,7 @@ This endpoint allows you to log in with LDAP credentials
 - `username` `(string: <required>)` – The username of the LDAP user
 - `password` `(string: <required>)` – The password for the LDAP user. 
 When authenticating with the Vault CLI, i.e. `vault login -method=ldap username=mitchellh` 
-the password can be supplied via the `VAULT_LDAP_PASSWORD` environment variable.
+the password can alternatively be supplied via the `VAULT_LDAP_PASSWORD` environment variable.
 
 ### Sample Payload
 


### PR DESCRIPTION
https://github.com/hashicorp/vault/pull/18225 added the ability to authenticate to Vault using LDAP auth method while supplying the password via the `VAULT_LDAP_PASSWORD` environment variable, however the original PR didn't include any docs update so raising this PR to include a note. This functionality exists in Vault 1.14.0 onwards.

current page: https://developer.hashicorp.com/vault/api-docs/auth/ldap#login-with-ldap-user
preview: https://vault-ktgbkryd6-hashicorp.vercel.app/vault/api-docs/auth/ldap#login-with-ldap-user