### PR TITLE
Start event plugin skeleton

### DIFF
--- a/.github/scripts/generate-test-package-lists.sh
+++ b/.github/scripts/generate-test-package-lists.sh
@@ -231,6 +231,7 @@ test_packages[9]+=" $base/vault/external_tests/plugin"
 # Total time: 925
 test_packages[10]+=" $base/builtin/credential/ldap"
 test_packages[10]+=" $base/builtin/logical/database"
+test_packages[10]+=" $base/builtin/logical/event"
 test_packages[10]+=" $base/physical/etcd"
 test_packages[10]+=" $base/physical/postgresql"
 

--- a/builtin/logical/event/backend.go
+++ b/builtin/logical/event/backend.go
@@ -1,0 +1,248 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package event
+
+import (
+	"context"
+	"fmt"
+	"net/rpc"
+	"strings"
+	"sync"
+
+	"github.com/armon/go-metrics"
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/helper/metricsutil"
+	"github.com/hashicorp/vault/helper/syncmap"
+	"github.com/hashicorp/vault/internalshared/configutil"
+	"github.com/hashicorp/vault/sdk/event/evplugin"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const (
+	operationPrefixEvent        = "event"
+	operationSuffixSubscription = "subscription"
+	eventSubscriptionPath       = "subscription/"
+)
+
+type subscriptionInstance struct {
+	sync.RWMutex
+	eventPlugin evplugin.EventPlugin
+
+	id     string
+	name   string
+	closed bool
+}
+
+func (s *subscriptionInstance) ID() string {
+	return s.id
+}
+
+func (s *subscriptionInstance) Close() error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+
+	return s.eventPlugin.Close()
+}
+
+func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+	b := Backend(conf).(*eventBackend)
+	if err := b.Setup(ctx, conf); err != nil {
+		return nil, err
+	}
+
+	// collect metrics on number of plugin instances
+	var err error
+	b.gaugeCollectionProcess, err = metricsutil.NewGaugeCollectionProcess(
+		[]string{"event", "pluginInstances", "count"},
+		[]metricsutil.Label{},
+		b.collectPluginInstanceGaugeValues,
+		metrics.Default(),
+		configutil.UsageGaugeDefaultPeriod, // TODO: add config settings for these, or add plumbing to the main config settings
+		configutil.MaximumGaugeCardinalityDefault,
+		b.logger)
+	if err != nil {
+		return nil, err
+	}
+	go b.gaugeCollectionProcess.Run()
+	return b, nil
+}
+
+func Backend(conf *logical.BackendConfig) logical.Backend {
+	var b eventBackend
+	b.Backend = &framework.Backend{
+		Help: strings.TrimSpace(backendHelp),
+
+		PathsSpecial: &logical.Paths{
+			LocalStorage: []string{
+				framework.WALPrefix,
+			},
+			SealWrapStorage: []string{
+				eventSubscriptionPath + "*",
+			},
+		},
+		Paths: framework.PathAppend(
+			[]*framework.Path{
+				pathListSubscription(&b),
+				pathConfigureSubscription(&b),
+				pathResetSubscription(&b),
+			},
+		),
+
+		Clean:       b.clean,
+		Invalidate:  b.invalidate,
+		BackendType: logical.TypeLogical,
+	}
+
+	b.logger = conf.Logger
+	b.subscriptions = syncmap.NewSyncMap[string, *subscriptionInstance]()
+	b.queueCtx, b.cancelQueueCtx = context.WithCancel(context.Background())
+	return &b
+}
+
+func (b *eventBackend) collectPluginInstanceGaugeValues(ctx context.Context) ([]metricsutil.GaugeLabelValues, error) {
+	// copy the map so we can release the lock
+	subscriptionsCopy := b.subscriptions.Values()
+	counts := map[string]int{}
+	for _, v := range subscriptionsCopy {
+		dbType, err := v.eventPlugin.Type(ctx)
+		if err != nil {
+			// there's a chance this will already be closed since we don't hold the lock
+			continue
+		}
+		if _, ok := counts[dbType]; !ok {
+			counts[dbType] = 0
+		}
+		counts[dbType] += 1
+	}
+	var gauges []metricsutil.GaugeLabelValues
+	for k, v := range counts {
+		gauges = append(gauges, metricsutil.GaugeLabelValues{Labels: []metricsutil.Label{{Name: "eventPluginType", Value: k}}, Value: float32(v)})
+	}
+	return gauges, nil
+}
+
+type eventBackend struct {
+	// subscriptions holds configured subscriptions by config name
+	subscriptions *syncmap.SyncMap[string, *subscriptionInstance]
+	logger        log.Logger
+
+	*framework.Backend
+	// queueCtx is the context for the priority queue
+	queueCtx context.Context
+	// cancelQueueCtx is used to terminate the background ticker
+	cancelQueueCtx context.CancelFunc
+
+	// the running gauge collection process
+	gaugeCollectionProcess     *metricsutil.GaugeCollectionProcess
+	gaugeCollectionProcessStop sync.Once
+}
+
+func (b *eventBackend) SubscriptionConfig(ctx context.Context, s logical.Storage, name string) (*SubscriptionConfig, error) {
+	entry, err := s.Get(ctx, fmt.Sprintf("config/%s", name))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read subscription configuration: %w", err)
+	}
+	if entry == nil {
+		return nil, fmt.Errorf("failed to find entry for subscription with name: %q", name)
+	}
+
+	var config SubscriptionConfig
+	if err := entry.DecodeJSON(&config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+func (b *eventBackend) invalidate(_ context.Context, key string) {
+	switch {
+	case strings.HasPrefix(key, eventSubscriptionPath):
+		name := strings.TrimPrefix(key, eventSubscriptionPath)
+		b.ClearSubscription(name)
+	}
+}
+
+func (b *eventBackend) GetSubscription(ctx context.Context, s logical.Storage, name string) (*subscriptionInstance, error) {
+	config, err := b.SubscriptionConfig(ctx, s, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return b.GetSubscriptionWithConfig(ctx, name, config)
+}
+
+func (b *eventBackend) GetSubscriptionWithConfig(ctx context.Context, name string, config *SubscriptionConfig) (*subscriptionInstance, error) {
+	return nil, fmt.Errorf("not implemented yet")
+}
+
+// ClearSubscription closes the subscription connection and
+// removes it from the b.subscriptions map.
+func (b *eventBackend) ClearSubscription(name string) error {
+	db := b.subscriptions.Pop(name)
+	if db != nil {
+		// Ignore error here since the subscription client is always killed
+		db.Close()
+	}
+	return nil
+}
+
+// ClearSubscriptionId closes the subscription connection with a specific id and
+// removes it from the b.subscriptions map.
+func (b *eventBackend) ClearSubscriptionId(name, id string) error {
+	db := b.subscriptions.PopIfEqual(name, id)
+	if db != nil {
+		// Ignore error here since the subscription client is always killed
+		db.Close()
+	}
+	return nil
+}
+
+func (b *eventBackend) CloseIfShutdown(db *subscriptionInstance, err error) {
+	// Plugin has shutdown, close it so next call can reconnect.
+	switch err {
+	case rpc.ErrShutdown:
+		// Put this in a goroutine so that requests can run with the read or write lock
+		// and simply defer the unlock.  Since we are attaching the instance and matching
+		// the id in the subscriptions map, we can safely do this.
+		go func() {
+			db.Close()
+
+			// Delete the subscription if it is still active.
+			b.subscriptions.PopIfEqual(db.name, db.id)
+		}()
+	}
+}
+
+// clean closes all subscriptions
+func (b *eventBackend) clean(_ context.Context) {
+	// kill the queue and terminate the background ticker
+	if b.cancelQueueCtx != nil {
+		b.cancelQueueCtx()
+	}
+
+	subscriptions := b.subscriptions.Clear()
+	for _, db := range subscriptions {
+		go db.Close()
+	}
+	b.gaugeCollectionProcessStop.Do(func() {
+		if b.gaugeCollectionProcess != nil {
+			b.gaugeCollectionProcess.Stop()
+		}
+		b.gaugeCollectionProcess = nil
+	})
+}
+
+const backendHelp = `
+The event backend supports routing events to many different
+subscriptions.
+
+After mounting this backend, configure it using the endpoints within
+the "event/subscription/" path.
+`

--- a/builtin/logical/event/backend_test.go
+++ b/builtin/logical/event/backend_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package event
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/vault/helper/builtinplugins"
+	"github.com/hashicorp/vault/helper/namespace"
+	vaulthttp "github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/sdk/helper/pluginutil"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/vault"
+)
+
+func getCluster(t *testing.T) (*vault.TestCluster, logical.SystemView) {
+	coreConfig := &vault.CoreConfig{
+		LogicalBackends: map[string]logical.Factory{
+			"database": Factory,
+		},
+		BuiltinRegistry: builtinplugins.Registry,
+	}
+
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+	cluster.Start()
+	cores := cluster.Cores
+	vault.TestWaitActive(t, cores[0].Core)
+
+	os.Setenv(pluginutil.PluginCACertPEMEnv, cluster.CACertPEMFile)
+
+	sys := vault.TestDynamicSystemView(cores[0].Core, nil)
+	return cluster, sys
+}
+
+// TestBackend_basic tests basic creating a plugin, then setting up, resetting, and deleting a subscription.
+func TestBackend_basic(t *testing.T) {
+	cluster, sys := getCluster(t)
+	defer cluster.Cleanup()
+
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+	config.System = sys
+
+	b, err := Factory(context.Background(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Cleanup(context.Background())
+
+	// configure a subscription
+	data := map[string]interface{}{
+		"plugin_name": "noop-event-plugin",
+		"settings": map[string]interface{}{
+			"nothing": "here",
+		},
+	}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "subscription/plugin-test",
+		Storage:   config.StorageView,
+		Data:      data,
+	}
+	_, err = b.HandleRequest(namespace.RootContext(nil), req)
+	if err == nil {
+		t.Fatalf("Expected this to fail for now")
+	}
+
+	// reset
+	req = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "reset/plugin-test",
+		Storage:   config.StorageView,
+		Data:      data,
+	}
+	_, err = b.HandleRequest(namespace.RootContext(nil), req)
+	if err == nil {
+		t.Fatalf("Expected this to fail for now")
+	}
+
+	req = &logical.Request{
+		Operation: logical.DeleteOperation,
+		Path:      "subscription/plugin-test",
+		Storage:   config.StorageView,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+}

--- a/builtin/logical/event/path_config_subscription.go
+++ b/builtin/logical/event/path_config_subscription.go
@@ -1,0 +1,273 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package event
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/fatih/structs"
+	"github.com/hashicorp/vault/helper/versions"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const respErrEmptyName = "empty name attribute given"
+
+// SubscriptionConfig is used by the Factory function to configure a Subscription
+// object.
+type SubscriptionConfig struct {
+	PluginName    string `json:"plugin_name" structs:"plugin_name" mapstructure:"plugin_name"`
+	PluginVersion string `json:"plugin_version" structs:"plugin_version" mapstructure:"plugin_version"`
+	// Settings stores the subscription-specific settings needed by each event plugin type.
+	Settings map[string]interface{} `json:"settings" structs:"settings" mapstructure:"settings"`
+}
+
+// pathResetSubscription configures a path to reset a plugin.
+func pathResetSubscription(b *eventBackend) *framework.Path {
+	return &framework.Path{
+		Pattern: fmt.Sprintf("reset/%s", framework.GenericNameRegex("name")),
+
+		DisplayAttrs: &framework.DisplayAttributes{
+			OperationPrefix: operationPrefixEvent,
+			OperationVerb:   "reset",
+			OperationSuffix: operationSuffixSubscription,
+		},
+
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Description: "Name of this subscription",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathSubscriptionReset(),
+			},
+		},
+
+		HelpSynopsis:    pathResetSubscriptionHelpSyn,
+		HelpDescription: pathResetSubscriptionHelpDesc,
+	}
+}
+
+func (b *eventBackend) pathSubscriptionReset() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		name := data.Get("name").(string)
+		if name == "" {
+			return logical.ErrorResponse(respErrEmptyName), nil
+		}
+
+		// Close plugin and delete the entry in the subscriptions cache.
+		if err := b.ClearSubscription(name); err != nil {
+			return nil, err
+		}
+
+		// Execute plugin again, we don't need the object so throw away.
+		if _, err := b.GetSubscription(ctx, req.Storage, name); err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	}
+}
+
+// pathConfigureSubscription returns a configured framework.Path setup to
+// operate on plugins.
+func pathConfigureSubscription(b *eventBackend) *framework.Path {
+	return &framework.Path{
+		Pattern: fmt.Sprintf("%s%s", eventSubscriptionPath, framework.GenericNameRegex("name")),
+
+		DisplayAttrs: &framework.DisplayAttributes{
+			OperationPrefix: operationPrefixEvent,
+		},
+
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Description: "Name of this subscription",
+			},
+
+			"plugin_name": {
+				Type: framework.TypeString,
+				Description: `The name of a builtin or previously registered
+				plugin known to vault. This endpoint will create an instance of
+				that plugin type.`,
+			},
+
+			"plugin_version": {
+				Type:        framework.TypeString,
+				Description: `The version of the plugin to use.`,
+			},
+
+			"verify": {
+				Type:    framework.TypeBool,
+				Default: true,
+				Description: `If true, the subscription settings are verified by
+				actually connecting to the subscription. Defaults to true.`,
+			},
+		},
+
+		ExistenceCheck: b.subscriptionExistenceCheck(),
+
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.subscriptionWriteHandler(),
+				DisplayAttrs: &framework.DisplayAttributes{
+					OperationVerb:   "configure",
+					OperationSuffix: operationSuffixSubscription,
+				},
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.subscriptionWriteHandler(),
+				DisplayAttrs: &framework.DisplayAttributes{
+					OperationVerb:   "configure",
+					OperationSuffix: operationSuffixSubscription,
+				},
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.subscriptionReadHandler(),
+				DisplayAttrs: &framework.DisplayAttributes{
+					OperationVerb:   "read",
+					OperationSuffix: operationSuffixSubscription,
+				},
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.subscriptionDeleteHandler(),
+				DisplayAttrs: &framework.DisplayAttributes{
+					OperationVerb:   "delete",
+					OperationSuffix: operationSuffixSubscription,
+				},
+			},
+		},
+
+		HelpSynopsis:    pathSubscriptionHelpSyn,
+		HelpDescription: pathSubscriptionHelpDesc,
+	}
+}
+
+func (b *eventBackend) subscriptionExistenceCheck() framework.ExistenceFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (bool, error) {
+		name := data.Get("name").(string)
+		if name == "" {
+			return false, errors.New(`missing "name" parameter`)
+		}
+
+		entry, err := req.Storage.Get(ctx, fmt.Sprintf("%s%s", eventSubscriptionPath, name))
+		if err != nil {
+			return false, fmt.Errorf("failed to read subscription configuration: %w", err)
+		}
+
+		return entry != nil, nil
+	}
+}
+
+func pathListSubscription(b *eventBackend) *framework.Path {
+	return &framework.Path{
+		Pattern: fmt.Sprintf(eventSubscriptionPath + "?$"),
+
+		DisplayAttrs: &framework.DisplayAttributes{
+			OperationPrefix: operationPrefixEvent,
+			OperationSuffix: operationSuffixSubscription,
+		},
+
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Callback: b.subscriptionListHandler(),
+			},
+		},
+
+		HelpSynopsis:    pathSubscriptionHelpSyn,
+		HelpDescription: pathSubscriptionHelpDesc,
+	}
+}
+
+func (b *eventBackend) subscriptionListHandler() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		entries, err := req.Storage.List(ctx, eventSubscriptionPath)
+		if err != nil {
+			return nil, err
+		}
+
+		return logical.ListResponse(entries), nil
+	}
+}
+
+// subscriptionReadHandler reads out the subscription configuration
+func (b *eventBackend) subscriptionReadHandler() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		name := data.Get("name").(string)
+		if name == "" {
+			return logical.ErrorResponse(respErrEmptyName), nil
+		}
+
+		entry, err := req.Storage.Get(ctx, fmt.Sprintf("%s%s", eventSubscriptionPath, name))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read subscription configuration: %w", err)
+		}
+		if entry == nil {
+			return nil, nil
+		}
+
+		var config SubscriptionConfig
+		if err := entry.DecodeJSON(&config); err != nil {
+			return nil, err
+		}
+
+		if versions.IsBuiltinVersion(config.PluginVersion) {
+			// This gets treated as though it's empty when mounting, and will get
+			// overwritten to be empty when the config is next written. See #18051.
+			config.PluginVersion = ""
+		}
+
+		return &logical.Response{
+			Data: structs.New(config).Map(),
+		}, nil
+	}
+}
+
+// subscriptionDeleteHandler deletes the subscription configuration
+func (b *eventBackend) subscriptionDeleteHandler() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		name := data.Get("name").(string)
+		if name == "" {
+			return logical.ErrorResponse(respErrEmptyName), nil
+		}
+
+		err := req.Storage.Delete(ctx, fmt.Sprintf("%s%s", eventSubscriptionPath, name))
+		if err != nil {
+			return nil, fmt.Errorf("failed to delete subscription configuration: %w", err)
+		}
+
+		if err := b.ClearSubscription(name); err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	}
+}
+
+// subscriptionWriteHandler returns a handler function for creating and updating
+// both builtin and event plugin types.
+func (b *eventBackend) subscriptionWriteHandler() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		return nil, fmt.Errorf("not implemented yet")
+	}
+}
+
+const pathSubscriptionHelpSyn = `
+Configure subscription details for an event plugin.
+`
+
+const pathSubscriptionHelpDesc = ``
+
+const pathResetSubscriptionHelpSyn = `
+Resets the subscription.
+`
+
+const pathResetSubscriptionHelpDesc = `
+This path resets the subscription by closing the existing event plugin
+instance and running a new one.
+`

--- a/command/commands.go
+++ b/command/commands.go
@@ -43,6 +43,7 @@ import (
 
 	logicalKv "github.com/hashicorp/vault-plugin-secrets-kv"
 	logicalDb "github.com/hashicorp/vault/builtin/logical/database"
+	logicalEv "github.com/hashicorp/vault/builtin/logical/event"
 
 	physAerospike "github.com/hashicorp/vault/physical/aerospike"
 	physAliCloudOSS "github.com/hashicorp/vault/physical/alicloudoss"
@@ -177,6 +178,7 @@ var (
 	logicalBackends = map[string]logical.Factory{
 		"plugin":   plugin.Factory,
 		"database": logicalDb.Factory,
+		"event":    logicalEv.Factory,
 		// This is also available in the plugin catalog, but is here due to the need to
 		// automatically mount it.
 		"kv": logicalKv.Factory,

--- a/command/secrets_enable_test.go
+++ b/command/secrets_enable_test.go
@@ -16,10 +16,11 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-// logicalBackendAdjustmentFactor is set to plus 1 for the database backend
-// which is a plugin but not found in go.mod files, and minus 1 for the ldap
-// and openldap secret backends which have the same underlying plugin.
-var logicalBackendAdjustmentFactor = 1 - 1
+// logicalBackendAdjustmentFactor is set to plus 2 for the database and
+// event backends, which are plugins but not found in go.mod files, and
+// minus 1 for the ldap and openldap secret backends, which have the
+// same underlying plugin.
+var logicalBackendAdjustmentFactor = 2 - 1
 
 func testSecretsEnableCommand(tb testing.TB) (*cli.MockUi, *SecretsEnableCommand) {
 	tb.Helper()

--- a/sdk/event/evplugin/event_plugin.go
+++ b/sdk/event/evplugin/event_plugin.go
@@ -1,0 +1,32 @@
+package evplugin
+
+import "context"
+
+// these are just stubs for now
+
+// EventPlugin allows plugins to enable new ways to subscribe to events.
+// Plugins should implement the server and Vault should implement the client.
+type EventPlugin interface {
+	// Initialize the plugin.
+	Initialize(ctx context.Context, req InitializeRequest) (InitializeResponse, error)
+	// Subscribe creates a new subscription. Only a single subscription will be created per plugin.
+	Subscribe(ctx context.Context, req SubscribeRequest) (SubscribeResponse, error)
+	// ReceiveEvents is called with a stream of events for a single subscription.
+	ReceiveEvents(ctx context.Context, subscriptionID uint32, events <-chan SubscriptionEvent) (ReceiveEventsResponse, error)
+	// Type is used to return the type of the plugin, e.g., "vault-plugin-event-sqs".
+	Type(ctx context.Context) (string, error)
+	// Close is used to close the subscription.
+	Close() error
+}
+
+type InitializeRequest struct{}
+
+type InitializeResponse struct{}
+
+type SubscribeRequest struct{}
+
+type SubscribeResponse struct{}
+
+type SubscriptionEvent struct{}
+
+type ReceiveEventsResponse struct{}

--- a/sdk/helper/consts/plugin_types.go
+++ b/sdk/helper/consts/plugin_types.go
@@ -14,6 +14,7 @@ var PluginTypes = []PluginType{
 	PluginTypeCredential,
 	PluginTypeDatabase,
 	PluginTypeSecrets,
+	PluginTypeEvent,
 }
 
 type PluginType uint32
@@ -33,6 +34,7 @@ const (
 	PluginTypeCredential
 	PluginTypeDatabase
 	PluginTypeSecrets
+	PluginTypeEvent
 )
 
 func (p PluginType) String() string {
@@ -45,6 +47,8 @@ func (p PluginType) String() string {
 		return "database"
 	case PluginTypeSecrets:
 		return "secret"
+	case PluginTypeEvent:
+		return "event"
 	default:
 		return "unsupported"
 	}
@@ -60,6 +64,8 @@ func ParsePluginType(pluginType string) (PluginType, error) {
 		return PluginTypeDatabase, nil
 	case "secret":
 		return PluginTypeSecrets, nil
+	case "event":
+		return PluginTypeEvent, nil
 	default:
 		return PluginTypeUnknown, fmt.Errorf("%q is not a supported plugin type", pluginType)
 	}


### PR DESCRIPTION
This adds a basic stub of the main event plugin with a few endpoints for subscription CRUD.

It adds in enough logic to be able to register it as a builtin plugin and mount it, but not much else.

This is based heavily on `builtin/logical/database`, though with a lot of things removed that we won't need or aren't ready for.