### PR TITLE
enos: use linux/amd64 for consul storage backend

### DIFF
--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -68,7 +68,7 @@ module "target_ec2_fleet" {
   common_tags      = var.tags
   instance_mem_min = 4096
   instance_cpu_min = 2
-  max_price        = "0.1432" // On-demand cost for RHEL/t3.medium on-demand in us-east
+  max_price        = "0.1432" // On-demand cost for RHEL amd64 on t3.medium in us-east
   project_name     = var.project_name
   ssh_keypair      = var.aws_ssh_keypair_name
 }
@@ -79,7 +79,7 @@ module "target_ec2_spot_fleet" {
   common_tags      = var.tags
   instance_mem_min = 4096
   instance_cpu_min = 2
-  max_price        = "0.1432" // On-demand cost for RHEL/t3.medium on-demand in us-east
+  max_price        = "0.1432" // On-demand cost for RHEL amd64 on t3.medium in us-east
   project_name     = var.project_name
   ssh_keypair      = var.aws_ssh_keypair_name
 }

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -35,12 +35,7 @@ scenario "agent" {
       ubuntu = provider.enos.ubuntu
     }
     install_artifactory_artifact = local.bundle_path == null
-    max_price = {
-      // These prices are based on on-demand cost for t3.large in us-east
-      "rhel"   = "0.1432"
-      "ubuntu" = "0.0832"
-    }
-    packages = ["jq"]
+    packages                     = ["jq"]
     tags = merge({
       "Project Name" : var.project_name
       "Project" : "Enos",
@@ -110,7 +105,6 @@ scenario "agent" {
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_tag_key       = local.vault_tag_key
       common_tags           = local.tags
-      max_price             = local.max_price[matrix.distro]
       vpc_id                = step.create_vpc.vpc_id
     }
   }

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -47,11 +47,6 @@ scenario "autopilot" {
       rhel   = provider.enos.rhel
       ubuntu = provider.enos.ubuntu
     }
-    max_price = {
-      // These prices are based on on-demand cost for t3.large in us-east
-      "rhel"   = "0.1432"
-      "ubuntu" = "0.0832"
-    }
     packages = ["jq"]
     tags = merge({
       "Project Name" : var.project_name
@@ -121,7 +116,6 @@ scenario "autopilot" {
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_tag_key       = local.vault_tag_key
       common_tags           = local.tags
-      max_price             = local.max_price[matrix.distro]
       vpc_id                = step.create_vpc.vpc_id
     }
   }
@@ -215,7 +209,6 @@ scenario "autopilot" {
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       common_tags           = local.tags
       cluster_name          = step.create_vault_cluster_targets.cluster_name
-      max_price             = local.max_price[matrix.distro]
       vpc_id                = step.create_vpc.vpc_id
     }
   }

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -55,11 +55,6 @@ scenario "replication" {
       rhel   = provider.enos.rhel
       ubuntu = provider.enos.ubuntu
     }
-    max_price = {
-      // These prices are based on on-demand cost for t3.large in us-east
-      "rhel"   = "0.1432"
-      "ubuntu" = "0.0832"
-    }
     packages = ["jq"]
     tags = merge({
       "Project Name" : var.project_name
@@ -132,7 +127,6 @@ scenario "replication" {
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_tag_key       = local.vault_tag_key
       common_tags           = local.tags
-      max_price             = local.max_price[matrix.distro]
       vpc_id                = step.create_vpc.vpc_id
     }
   }
@@ -148,11 +142,10 @@ scenario "replication" {
     }
 
     variables {
-      ami_id                = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id                = step.ec2_info.ami_ids["amd64"]["ubuntu"]["22.04"]
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_tag_key       = local.backend_tag_key
       common_tags           = local.tags
-      max_price             = local.max_price["ubuntu"]
       vpc_id                = step.create_vpc.vpc_id
     }
   }
@@ -174,7 +167,6 @@ scenario "replication" {
       cluster_name          = step.create_primary_cluster_targets.cluster_name
       cluster_tag_key       = local.vault_tag_key
       common_tags           = local.tags
-      max_price             = local.max_price[matrix.distro]
       vpc_id                = step.create_vpc.vpc_id
     }
   }
@@ -192,7 +184,6 @@ scenario "replication" {
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_tag_key       = local.vault_tag_key
       common_tags           = local.tags
-      max_price             = local.max_price[matrix.distro]
       vpc_id                = step.create_vpc.vpc_id
     }
   }
@@ -206,11 +197,10 @@ scenario "replication" {
     }
 
     variables {
-      ami_id                = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id                = step.ec2_info.ami_ids["amd64"]["ubuntu"]["22.04"]
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_tag_key       = local.backend_tag_key
       common_tags           = local.tags
-      max_price             = local.max_price["ubuntu"]
       vpc_id                = step.create_vpc.vpc_id
     }
   }

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -51,11 +51,6 @@ scenario "smoke" {
       rhel   = provider.enos.rhel
       ubuntu = provider.enos.ubuntu
     }
-    max_price = {
-      // These prices are based on on-demand cost for t3.large in us-east
-      "rhel"   = "0.1432"
-      "ubuntu" = "0.0832"
-    }
     packages = ["jq"]
     tags = merge({
       "Project Name" : var.project_name
@@ -131,7 +126,6 @@ scenario "smoke" {
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_tag_key       = local.vault_tag_key
       common_tags           = local.tags
-      max_price             = local.max_price[matrix.distro]
       vpc_id                = step.create_vpc.vpc_id
     }
   }
@@ -145,11 +139,10 @@ scenario "smoke" {
     }
 
     variables {
-      ami_id                = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id                = step.ec2_info.ami_ids["amd64"]["ubuntu"]["22.04"]
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_tag_key       = local.backend_tag_key
       common_tags           = local.tags
-      max_price             = local.max_price["ubuntu"]
       vpc_id                = step.create_vpc.vpc_id
     }
   }

--- a/enos/enos-scenario-ui.hcl
+++ b/enos/enos-scenario-ui.hcl
@@ -25,12 +25,7 @@ scenario "ui" {
     bundle_path    = abspath(var.vault_bundle_path)
     distro         = "ubuntu"
     consul_version = "1.14.2"
-    max_price = {
-      // These prices are based on on-demand cost for t3.large in us-east
-      "rhel"   = "0.1432"
-      "ubuntu" = "0.0832"
-    }
-    seal = "awskms"
+    seal           = "awskms"
     tags = merge({
       "Project Name" : var.project_name
       "Project" : "Enos",
@@ -98,7 +93,6 @@ scenario "ui" {
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_tag_key       = local.vault_tag_key
       common_tags           = local.tags
-      max_price             = local.max_price[local.distro]
       vpc_id                = step.create_vpc.vpc_id
     }
   }
@@ -112,11 +106,10 @@ scenario "ui" {
     }
 
     variables {
-      ami_id                = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id                = step.ec2_info.ami_ids["amd64"]["ubuntu"]["22.04"]
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_tag_key       = local.backend_tag_key
       common_tags           = local.tags
-      max_price             = local.max_price["ubuntu"]
       vpc_id                = step.create_vpc.vpc_id
     }
   }

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -45,11 +45,6 @@ scenario "upgrade" {
       rhel   = provider.enos.rhel
       ubuntu = provider.enos.ubuntu
     }
-    max_price = {
-      // These prices are based on on-demand cost for t3.large in us-east
-      "rhel"   = "0.1432"
-      "ubuntu" = "0.0832"
-    }
     packages = ["jq"]
     tags = merge({
       "Project Name" : var.project_name
@@ -126,7 +121,6 @@ scenario "upgrade" {
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_tag_key       = local.vault_tag_key
       common_tags           = local.tags
-      max_price             = local.max_price[matrix.distro]
       vpc_id                = step.create_vpc.vpc_id
     }
   }
@@ -140,11 +134,10 @@ scenario "upgrade" {
     }
 
     variables {
-      ami_id                = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id                = step.ec2_info.ami_ids["amd64"]["ubuntu"]["22.04"]
       awskms_unseal_key_arn = step.create_vpc.kms_key_arn
       cluster_tag_key       = local.backend_tag_key
       common_tags           = local.tags
-      max_price             = local.max_price["ubuntu"]
       vpc_id                = step.create_vpc.vpc_id
     }
   }


### PR DESCRIPTION
We seem to hit occasional capacity issues when attempting to launch spot fleets with arm64 instance types. After checking pricing in the regions that we use, it appears that current and older generation amd64 t2 and t3 instance types are running at quite a discount whereas t4 arm64 instances are barely under on-demand price, suggesting limited capacity for arm64 spot instances at this time. We'll change our default backend instance architecture to amd64 to bid for the cheaper t2 and t3 instances and increase our `max_price` globally to that of a RHEL machine running on-demand with a t3.medium.