### PR TITLE
openapi: Fix response schema for PKI Issue requests

### DIFF
--- a/builtin/logical/pki/integration_test.go
+++ b/builtin/logical/pki/integration_test.go
@@ -237,6 +237,8 @@ func TestIntegration_SetSignedWithBackwardsPemBundles(t *testing.T) {
 	require.False(t, resp.IsError(), "got an error from generating root ca: %#v", resp)
 	rootCert := resp.Data["certificate"].(string)
 
+	schema.ValidateResponse(t, schema.GetResponseSchema(t, rootBackend.Route("issuers/generate/root/internal"), logical.UpdateOperation), resp, true)
+
 	// generate intermediate
 	resp, err = intBackend.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,

--- a/builtin/logical/pki/integration_test.go
+++ b/builtin/logical/pki/integration_test.go
@@ -298,6 +298,8 @@ func TestIntegration_SetSignedWithBackwardsPemBundles(t *testing.T) {
 	require.NoError(t, err, "failed setting up role example")
 	require.NotNil(t, resp, "got nil response from setting up role example: %#v", resp)
 
+	schema.ValidateResponse(t, schema.GetResponseSchema(t, intBackend.Route("roles/example"), logical.UpdateOperation), resp, true)
+
 	// Issue cert
 	resp, err = intBackend.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -312,6 +314,8 @@ func TestIntegration_SetSignedWithBackwardsPemBundles(t *testing.T) {
 	require.NoError(t, err, "failed issuing a leaf cert from int ca")
 	require.NotNil(t, resp, "got nil response issuing a leaf cert from int ca")
 	require.False(t, resp.IsError(), "got an error issuing a leaf cert from int ca: %#v", resp)
+
+	schema.ValidateResponse(t, schema.GetResponseSchema(t, intBackend.Route("issue/example"), logical.UpdateOperation), resp, true)
 }
 
 func TestIntegration_CSRGeneration(t *testing.T) {

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -28,7 +28,7 @@ var pathFetchReadSchema = map[int][]framework.Response{
 				Required:    false,
 			},
 			"revocation_time": {
-				Type:        framework.TypeString,
+				Type:        framework.TypeInt64,
 				Description: `Revocation time`,
 				Required:    false,
 			},
@@ -43,7 +43,7 @@ var pathFetchReadSchema = map[int][]framework.Response{
 				Required:    false,
 			},
 			"ca_chain": {
-				Type:        framework.TypeStringSlice,
+				Type:        framework.TypeString,
 				Description: `Issuing CA Chain`,
 				Required:    false,
 			},

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -249,7 +249,7 @@ to be set on all PR secondary clusters.`,
 					Required:    false,
 				},
 				"usage": {
-					Type:        framework.TypeStringSlice,
+					Type:        framework.TypeString,
 					Description: `Usage`,
 					Required:    false,
 				},

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -75,12 +75,12 @@ func buildPathIssue(b *backend, pattern string, displayAttrs *framework.DisplayA
 							"serial_number": {
 								Type:        framework.TypeString,
 								Description: `Serial Number`,
-								Required:    false,
+								Required:    true,
 							},
 							"expiration": {
-								Type:        framework.TypeString,
+								Type:        framework.TypeInt64,
 								Description: `Time of expiration`,
-								Required:    false,
+								Required:    true,
 							},
 							"private_key": {
 								Type:        framework.TypeString,
@@ -163,7 +163,7 @@ func buildPathSign(b *backend, pattern string, displayAttrs *framework.DisplayAt
 								Required:    true,
 							},
 							"expiration": {
-								Type:        framework.TypeString,
+								Type:        framework.TypeInt64,
 								Description: `Time of expiration`,
 								Required:    true,
 							},
@@ -253,12 +253,12 @@ func buildPathIssuerSignVerbatim(b *backend, pattern string, displayAttrs *frame
 							"serial_number": {
 								Type:        framework.TypeString,
 								Description: `Serial Number`,
-								Required:    false,
+								Required:    true,
 							},
 							"expiration": {
-								Type:        framework.TypeString,
+								Type:        framework.TypeInt64,
 								Description: `Time of expiration`,
-								Required:    false,
+								Required:    true,
 							},
 							"private_key": {
 								Type:        framework.TypeString,

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -34,7 +34,7 @@ func pathRotateRoot(b *backend) *framework.Path {
 	pattern := "root/rotate/" + framework.GenericNameRegex("exported")
 
 	displayAttrs := &framework.DisplayAttributes{
-		OperationPrefix: operationPrefixPKIIssuers,
+		OperationPrefix: operationPrefixPKI,
 		OperationVerb:   "rotate",
 		OperationSuffix: "root",
 	}
@@ -55,7 +55,7 @@ func buildPathGenerateRoot(b *backend, pattern string, displayAttrs *framework.D
 						Description: "OK",
 						Fields: map[string]*framework.FieldSchema{
 							"expiration": {
-								Type:        framework.TypeString,
+								Type:        framework.TypeInt64,
 								Description: `The expiration of the given.`,
 								Required:    true,
 							},

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -56,7 +56,7 @@ func buildPathGenerateRoot(b *backend, pattern string, displayAttrs *framework.D
 						Fields: map[string]*framework.FieldSchema{
 							"expiration": {
 								Type:        framework.TypeInt64,
-								Description: `The expiration of the given.`,
+								Description: `The expiration of the given issuer.`,
 								Required:    true,
 							},
 							"serial_number": {

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -111,7 +111,7 @@ signed by an issuer in this mount.`,
 						Description: "OK",
 						Fields: map[string]*framework.FieldSchema{
 							"revocation_time": {
-								Type:        framework.TypeDurationSecond,
+								Type:        framework.TypeInt64,
 								Description: `Revocation Time`,
 								Required:    false,
 							},
@@ -176,7 +176,7 @@ be in PEM format.`,
 						Description: "OK",
 						Fields: map[string]*framework.FieldSchema{
 							"revocation_time": {
-								Type:        framework.TypeDurationSecond,
+								Type:        framework.TypeInt64,
 								Description: `Revocation Time`,
 								Required:    false,
 							},

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -55,7 +55,7 @@ func pathListRoles(b *backend) *framework.Path {
 func pathRoles(b *backend) *framework.Path {
 	pathRolesResponseFields := map[string]*framework.FieldSchema{
 		"ttl": {
-			Type:     framework.TypeDurationSecond,
+			Type:     framework.TypeInt64,
 			Required: true,
 			Description: `The lease duration (validity period of the
 certificate) if no specific lease duration is requested.
@@ -65,7 +65,7 @@ value or the value of max_ttl, whichever is shorter.`,
 		},
 
 		"max_ttl": {
-			Type:     framework.TypeDurationSecond,
+			Type:     framework.TypeInt64,
 			Required: true,
 			Description: `The maximum allowed lease duration. If not
 set, defaults to the system maximum lease TTL.`,
@@ -384,8 +384,8 @@ information, which must include an oid, and may include a notice and/or cps url,
 			Description: `Mark Basic Constraints valid when issuing non-CA certificates.`,
 		},
 		"not_before_duration": {
-			Type:        framework.TypeDurationSecond,
-			Description: `The duration before now which the certificate needs to be backdated by.`,
+			Type:        framework.TypeInt64,
+			Description: `The duration in seconds before now which the certificate needs to be backdated by.`,
 		},
 		"not_after": {
 			Type: framework.TypeString,

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -279,8 +279,9 @@ func pathTidyCancel(b *backend) *framework.Path {
 								Required: false,
 							},
 							"tidy_cross_cluster_revoked_certs": {
-								Type:     framework.TypeBool,
-								Required: false,
+								Type:        framework.TypeBool,
+								Description: `Tidy the cross-cluster revoked certificate store`,
+								Required:    false,
 							},
 							"tidy_revocation_queue": {
 								Type:     framework.TypeBool,
@@ -387,8 +388,8 @@ func pathTidyStatus(b *backend) *framework.Path {
 								Required:    true,
 							},
 							"tidy_cross_cluster_revoked_certs": {
-								Type:        framework.TypeString,
-								Description: ``,
+								Type:        framework.TypeBool,
+								Description: `Tidy the cross-cluster revoked certificate store`,
 								Required:    false,
 							},
 							"tidy_acme": {
@@ -617,7 +618,7 @@ available on the tidy-status endpoint.`,
 								Required: true,
 							},
 							"revocation_queue_safety_buffer": {
-								Type:     framework.TypeDurationSecond,
+								Type:     framework.TypeInt,
 								Required: true,
 							},
 							"publish_stored_certificate_count_metrics": {
@@ -698,8 +699,9 @@ available on the tidy-status endpoint.`,
 								Required:    true,
 							},
 							"tidy_cross_cluster_revoked_certs": {
-								Type:     framework.TypeBool,
-								Required: true,
+								Type:        framework.TypeBool,
+								Description: `Tidy the cross-cluster revoked certificate store`,
+								Required:    true,
 							},
 							"tidy_revocation_queue": {
 								Type:     framework.TypeBool,
@@ -710,7 +712,7 @@ available on the tidy-status endpoint.`,
 								Required: true,
 							},
 							"revocation_queue_safety_buffer": {
-								Type:     framework.TypeDurationSecond,
+								Type:     framework.TypeInt,
 								Required: true,
 							},
 							"publish_stored_certificate_count_metrics": {

--- a/changelog/21449.txt
+++ b/changelog/21449.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+openapi: Fix response schema for PKI Issue requests
+```


### PR DESCRIPTION
The response schema for `pki/issue/*` requests have expiration represented as `int64` rather than a `string`.

https://github.com/hashicorp/vault/blob/922daee688f62e40da77ed42727958052811f830/builtin/logical/pki/path_issue_sign.go#L418-L421

This PR fixes the corresponding OpenAPI schema and should address https://github.com/hashicorp/vault-client-go/issues/185
