### PR TITLE
Fix "vault agent generate-config" documentation URL

### DIFF
--- a/changelog/21466.txt
+++ b/changelog/21466.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Fix "generate-config" command documentation URL
+```

--- a/command/agent_generate_config.go
+++ b/command/agent_generate_config.go
@@ -61,7 +61,7 @@ Usage: vault agent generate-config [options] [path/to/config.hcl]
   In addition to env_template entries, the command generates an 'auto_auth'
   section with 'token_file' authentication method. While this method is very
   convenient for local testing, it should NOT be used in production. Please
-  see https://developer.hashicorp.com/vault/docs/agentandproxy/autoauth for
+  see https://developer.hashicorp.com/vault/docs/agent-and-proxy/autoauth for
   a list of production-ready auto_auth methods that you can use instead.
 
   By default, the file will be generated in the local directory as 'agent.hcl'

--- a/command/agent_generate_config.go
+++ b/command/agent_generate_config.go
@@ -61,8 +61,8 @@ Usage: vault agent generate-config [options] [path/to/config.hcl]
   In addition to env_template entries, the command generates an 'auto_auth'
   section with 'token_file' authentication method. While this method is very
   convenient for local testing, it should NOT be used in production. Please
-  see https://developer.hashicorp.com/vault/docs/agent-and-proxy/autoauth for
-  a list of production-ready auto_auth methods that you can use instead.
+  see https://developer.hashicorp.com/vault/docs/agent-and-proxy/autoauth/methods
+  for a list of production-ready auto_auth methods that you can use instead.
 
   By default, the file will be generated in the local directory as 'agent.hcl'
   unless a path is specified as an argument.


### PR DESCRIPTION
There is a typo in the URL provided, should be "https://developer.hashicorp.com/vault/docs/agent-and-proxy/autoauth" instead of "https://developer.hashicorp.com/vault/docs/agentandproxy/autoauth".