### PR TITLE
Calculate namespace prefix before tainting route entries

### DIFF
--- a/changelog/24170.txt
+++ b/changelog/24170.txt
@@ -1,0 +1,3 @@
+```release-note:bug 
+core: Fixed an instance where incorrect route entries would get tainted. We now pre-calculate namespace specific paths to avoid this.
+```

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -879,7 +879,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 			// Calculate any namespace prefixes here, because when Taint() is called, there won't be
 			// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
 			path = entry.Namespace().Path + path
-			c.logger.Debug("tainting a mount", "path", entry.Path, "namespace_path", entry.Namespace().Path)
+			c.logger.Debug("tainting a mount due to it being marked as tainted in mount table", "path", entry.Path, "namespace_path", entry.Namespace().Path)
 			c.router.Taint(ctx, path)
 		}
 

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -879,7 +879,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 			// Calculate any namespace prefixes here, because when Taint() is called, there won't be
 			// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
 			path = entry.Namespace().Path + path
-			c.logger.Debug("tainting a mount", "_path", entry.Path, "namespace_path", entry.Namespace().Path)
+			c.logger.Debug("tainting a mount", "path", entry.Path, "namespace_path", entry.Namespace().Path)
 			c.router.Taint(ctx, path)
 		}
 

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -879,6 +879,14 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 			// Calculate any namespace prefixes here, because when Taint() is called, there won't be
 			// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
 			path = entry.Namespace().Path + path
+			if entry.Path != path {
+				nsfc, err := namespace.FromContext(ctx)
+				if err != nil {
+					c.logger.Error("error when trying to get the namespace from the context", "error", err)
+				} else {
+					c.logger.Debug("tainting a mount but path and namespaced path disagree", "entry_path", entry.Path, "entry_namespace_path", entry.Namespace().Path, "namespace_from_context", nsfc)
+				}
+			}
 			c.router.Taint(ctx, path)
 		}
 

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -879,7 +879,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 			// Calculate any namespace prefixes here, because when Taint() is called, there won't be
 			// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
 			path = entry.Namespace().Path + path
-			c.logger.Debug("tainting a mount due to it being marked as tainted in mount table", "path", entry.Path, "namespace_path", entry.Namespace().Path)
+			c.logger.Debug("tainting a mount due to it being marked as tainted in mount table", "entry.path", entry.Path, "entry.namespace.path", entry.Namespace().Path, "full_path", path)
 			c.router.Taint(ctx, path)
 		}
 

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -879,14 +879,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 			// Calculate any namespace prefixes here, because when Taint() is called, there won't be
 			// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
 			path = entry.Namespace().Path + path
-			if entry.Path != path {
-				nsfc, err := namespace.FromContext(ctx)
-				if err != nil {
-					c.logger.Error("error when trying to get the namespace from the context", "error", err)
-				} else {
-					c.logger.Debug("tainting a mount but path and namespaced path disagree", "entry_path", entry.Path, "entry_namespace_path", entry.Namespace().Path, "namespace_from_context", nsfc)
-				}
-			}
+			c.logger.Debug("tainting a mount", "_path", entry.Path, "namespace_path", entry.Namespace().Path)
 			c.router.Taint(ctx, path)
 		}
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1596,14 +1596,7 @@ func (c *Core) setupMounts(ctx context.Context) error {
 			// Calculate any namespace prefixes here, because when Taint() is called, there won't be
 			// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
 			path := entry.Namespace().Path + entry.Path
-			if entry.Path != path {
-				nsfc, err := namespace.FromContext(ctx)
-				if err != nil {
-					c.logger.Error("error when trying to get the namespace from the context", "error", err)
-				} else {
-					c.logger.Debug("tainting a mount but path and namespaced path disagree", "entry_path", entry.Path, "entry_namespace_path", entry.Namespace().Path, "namespace_from_context", nsfc)
-				}
-			}
+			c.logger.Debug("tainting a mount", "path", entry.Path, "namespace_path", entry.Namespace().Path)
 			c.router.Taint(ctx, path)
 		}
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1596,7 +1596,7 @@ func (c *Core) setupMounts(ctx context.Context) error {
 			// Calculate any namespace prefixes here, because when Taint() is called, there won't be
 			// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
 			path := entry.Namespace().Path + entry.Path
-			c.logger.Debug("tainting a mount due to it being marked as tainted in mount table", "path", entry.Path, "namespace_path", entry.Namespace().Path)
+			c.logger.Debug("tainting a mount due to it being marked as tainted in mount table", "entry.path", entry.Path, "entry.namespace.path", entry.Namespace().Path, "full_path", path)
 			c.router.Taint(ctx, path)
 		}
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1596,7 +1596,7 @@ func (c *Core) setupMounts(ctx context.Context) error {
 			// Calculate any namespace prefixes here, because when Taint() is called, there won't be
 			// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
 			path := entry.Namespace().Path + entry.Path
-			c.logger.Debug("tainting a mount", "path", entry.Path, "namespace_path", entry.Namespace().Path)
+			c.logger.Debug("tainting a mount due to it being marked as tainted in mount table", "path", entry.Path, "namespace_path", entry.Namespace().Path)
 			c.router.Taint(ctx, path)
 		}
 


### PR DESCRIPTION
This is essentially the 'fix' code we used as part of resolving a recent sev 1, where we pre-calculate the namespace path, as we do in the other place we call `c.router.Taint(ctx, path)`. The PR for that change is here: #15067 . I added debug logging including the places where we disagree, and added it to the other place we pre-calculate namespace prefixes.

There may be more adjustments/improvements we want to make to add additional safety to tainting, such as preventing the root "sys/" from ever being tainted, but if we did want to add those, we can do as part of a different PR. I wanted to keep this PR with a small scope, specifically targeting the fix.