### PR TITLE
Add UI safari login screen known issue

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
@@ -38,6 +38,5 @@ There are no major changes to announce at this time.
 
 @include 'known-issues/update-primary-addrs-panic.mdx'
 
-## Known Issues
+@include 'known-issues/ui-safari-login-screen-known-issue.mdx'
 
-@include 'ui-safari-login-screen-known-issue.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
@@ -38,5 +38,5 @@ There are no major changes to announce at this time.
 
 @include 'known-issues/update-primary-addrs-panic.mdx'
 
-@include 'known-issues/ui-safari-login-screen-known-issue.mdx'
+@include 'known-issues/ui-safari-login-screen.mdx'
 

--- a/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
@@ -37,3 +37,7 @@ There are no major changes to announce at this time.
 @include 'known-issues/update-primary-data-loss.mdx'
 
 @include 'known-issues/update-primary-addrs-panic.mdx'
+
+## Known Issues
+
+@include 'ui-safari-login-screen-known-issue.mdx'

--- a/website/content/partials/known-issues/ui-safari-login-screen.mdx
+++ b/website/content/partials/known-issues/ui-safari-login-screen.mdx
@@ -1,0 +1,13 @@
+### Safari login screen appears broken on the UI
+
+#### Affected versions
+
+- 1.14.0
+
+#### Issue
+
+The login screen on Safari appears to be broken, presenting as a large white screen.
+
+#### Workaround
+
+Scroll down to find the login section.

--- a/website/content/partials/known-issues/ui-safari-login-screen.mdx
+++ b/website/content/partials/known-issues/ui-safari-login-screen.mdx
@@ -6,7 +6,7 @@
 
 #### Issue
 
-The login screen on Safari appears to be broken, presenting as a large white screen.
+The login screen on Safari appears to be broken, presenting as a blank white screen.
 
 #### Workaround
 

--- a/website/content/partials/safari-login-screen.mdx
+++ b/website/content/partials/safari-login-screen.mdx
@@ -1,0 +1,9 @@
+### Safari login screen white screen on UI
+
+The login screen on safari appears to be broken, presenting as a large white screen.
+While you can scroll down and find the login section, it's not immediately apparent.
+
+#### Affected Versions
+
+This issue affects Vault Enterprise with ADP versions 1.10.x and higher.  A
+fix will be released in Vault 1.11.9, 1.12.5, and 1.13.1.

--- a/website/content/partials/safari-login-screen.mdx
+++ b/website/content/partials/safari-login-screen.mdx
@@ -1,9 +1,0 @@
-### Safari login screen white screen on UI
-
-The login screen on safari appears to be broken, presenting as a large white screen.
-While you can scroll down and find the login section, it's not immediately apparent.
-
-#### Affected Versions
-
-This issue affects Vault Enterprise with ADP versions 1.10.x and higher.  A
-fix will be released in Vault 1.11.9, 1.12.5, and 1.13.1.

--- a/website/content/partials/ui-safari-login-screen.mdx
+++ b/website/content/partials/ui-safari-login-screen.mdx
@@ -1,0 +1,13 @@
+### Safari login screen appears broken on the UI
+
+#### Affected versions
+
+- 1.14.0
+
+#### Issue
+
+The login screen on Safari appears to be broken, presenting as a large white screen.
+
+#### Workaround
+
+Scroll down to find the login section.

--- a/website/content/partials/ui-safari-login-screen.mdx
+++ b/website/content/partials/ui-safari-login-screen.mdx
@@ -6,7 +6,7 @@
 
 #### Issue
 
-The login screen on Safari appears to be broken, presenting as a large white screen.
+The login screen on Safari appears to be broken, presenting as a blank white screen.
 
 #### Workaround
 


### PR DESCRIPTION
There is a known issue on the 1.14 release for the Safari browser. When you navigate to the UI login screen there appears to be a large white screen. If you scroll down you can find the login area, but it's not immediately apparent. 

https://github.com/hashicorp/vault/assets/6618863/1283c19c-7a95-40c2-b5d5-62543964319c

