### PR TITLE
[Docs] Update the tutorial links

### DIFF
--- a/website/content/docs/platform/k8s/vso/index.mdx
+++ b/website/content/docs/platform/k8s/vso/index.mdx
@@ -277,5 +277,5 @@ spec:
 ## Tutorial
 
 Refer to the [The Vault Secrets Operator on
-Kubernetes](/vault/tutorials/new-release/vault-secrets-operator) tutorial to
+Kubernetes](/vault/tutorials/kubernetes/vault-secrets-operator) tutorial to
 learn the end-to-end workflow using the Vault Secrets Operator.

--- a/website/content/docs/secrets/pki/index.mdx
+++ b/website/content/docs/secrets/pki/index.mdx
@@ -50,7 +50,7 @@ Refer to the following tutorials for PKI secrets engine usage examples:
 
 - [Build Your Own Certificate Authority (CA)](/vault/tutorials/secrets-management/pki-engine)
 - [Build Certificate Authority (CA) in Vault with an offline Root](/vault/tutorials/secrets-management/pki-engine-external-ca)
-- [Enable ACME with PKI secrets engine](/vault/tutorials/new-release/pki-acme-caddy)
+- [Enable ACME with PKI secrets engine](/vault/tutorials/secrets-management/pki-acme-caddy)
 - [PKI Secrets Engine with Managed Keys](/vault/tutorials/enterprise/managed-key-pki)
 - [PKI Unified CRL and OCSP With Cross Cluster
   Revocation](/vault/tutorials/secrets-management/pki-unified-crl-ocsp-cross-cluster)


### PR DESCRIPTION
Accidentally, I pointed to the tutorial in the [Vault 1.14 Release highlights](https://developer.hashicorp.com/vault/tutorials/new-release) collection. 

This PR points to the respective permanent collection link for those tutorials. 

- `/vault/tutorials/new-release/...` --> `/vault/tutorials/kubernetes/...` 
- `/vault/tutorials/new-release/...` -->  `/vault/tutorials/secrets-management/...`

