### PR TITLE
Capitlization Policy: First word only for `title is-5`

### DIFF
--- a/ui/app/templates/components/keymgmt/key-edit.hbs
+++ b/ui/app/templates/components/keymgmt/key-edit.hbs
@@ -168,7 +168,7 @@
     {{/each}}
   {{else}}
     <div class="has-top-margin-xl has-bottom-margin-s">
-      <h2 class="title is-5 has-border-bottom-light">Key details</h2>
+      <h2 class="title is-5 has-border-bottom-light has-bottom-padding-s">Key details</h2>
       {{#each @model.showFields as |attr|}}
         <InfoTableRow
           @alwaysRender={{true}}
@@ -181,7 +181,7 @@
     </div>
     <div class="has-top-margin-xl has-bottom-margin-s">
       <h2 class="title is-5 {{if @model.distribution 'has-border-bottom-light' 'is-borderless'}}">
-        Distribution Details
+        Distribution details
       </h2>
       {{#if @model.provider.permissionsError}}
         <EmptyState

--- a/ui/app/templates/components/secret-delete-menu.hbs
+++ b/ui/app/templates/components/secret-delete-menu.hbs
@@ -31,7 +31,7 @@
   {{/if}}
 
   <Modal
-    @title="Delete Secret?"
+    @title="Delete secret?"
     @onClose={{action (mut this.showDeleteModal) false}}
     @isActive={{this.showDeleteModal}}
     @type="warning"

--- a/ui/app/templates/vault/cluster/secrets/backend/metadata.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/metadata.hbs
@@ -70,7 +70,7 @@
 {{#unless this.noReadAccess}}
   <div class="form-section">
     <label class="title is-5 has-top-padding-m">
-      Secret Metadata
+      Secret metadata
     </label>
   </div>
   <div class="box is-fullwidth is-sideless is-paddingless is-marginless">

--- a/ui/lib/core/addon/components/modal.hbs
+++ b/ui/lib/core/addon/components/modal.hbs
@@ -12,7 +12,7 @@
               data-test-modal-glyph={{this.glyph.glyph}}
             />
           {{/if}}
-          <span class={{if this.glyph "has-left-padding-xs"}}>{{@title}}</span>
+          <span class={{if this.glyph "has-left-padding-xs"}}>{{capitalize @title}}</span>
         </h2>
         {{#if this.showCloseButton}}
           <button

--- a/ui/lib/core/addon/templates/components/replication-action-demote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-demote.hbs
@@ -1,9 +1,9 @@
 <div class="action-block is-rounded" data-test-demote-replication>
   <div class="action-block-info">
-    <h4 class="title is-5 is-marginless">
+    <h3 class="title is-5 is-marginless">
       Demote cluster
-    </h4>
-    <p>
+    </h3>
+    <p class="has-top-padding-s">
       Demote this
       {{this.model.replicationModeForDisplay}}
       primary to a secondary.

--- a/ui/lib/core/addon/templates/components/replication-action-disable.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-disable.hbs
@@ -1,9 +1,9 @@
 <div class="action-block is-rounded" data-test-disable-replication>
   <div class="action-block-info">
-    <h4 class="title is-5 is-marginless">
-      Disable Replication
-    </h4>
-    <p>
+    <h3 class="title is-5 is-marginless">
+      Disable replication
+    </h3>
+    <p class="has-top-padding-s">
       Disable
       {{this.model.replicationModeForDisplay}}
       Replication entirely on the cluster.

--- a/ui/lib/core/addon/templates/components/replication-action-disable.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-disable.hbs
@@ -1,7 +1,7 @@
 <div class="action-block is-rounded" data-test-disable-replication>
   <div class="action-block-info">
     <h3 class="title is-5 is-marginless">
-      Disable replication
+      Disable Replication
     </h3>
     <p class="has-top-padding-s">
       Disable

--- a/ui/lib/core/addon/templates/components/replication-action-promote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-promote.hbs
@@ -1,9 +1,9 @@
 <div class="action-block is-rounded" data-test-promote-replication>
   <div class="action-block-info">
-    <h4 class="title is-5 is-marginless">
+    <h3 class="title is-5 is-marginless">
       Promote cluster
-    </h4>
-    <p>
+    </h3>
+    <p class="has-top-padding-s">
       Promote this cluster to a
       {{this.model.replicationModeForDisplay}}
       primary

--- a/ui/lib/core/addon/templates/components/replication-action-recover.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-recover.hbs
@@ -1,9 +1,9 @@
 <div class="action-block is-rounded" data-test-recover-replication>
   <div class="action-block-info">
-    <h4 class="title is-5 is-marginless">
+    <h3 class="title is-5 is-marginless">
       Recover
-    </h4>
-    <p>
+    </h3>
+    <p class="has-top-padding-s">
       Attempt recovery if replication is in a bad state.
     </p>
   </div>

--- a/ui/lib/core/addon/templates/components/replication-action-reindex.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-reindex.hbs
@@ -1,10 +1,10 @@
 <div class="action-block is-rounded" data-test-reindex-replication>
   <div class="action-block-info">
-    <h4 class="title is-5 is-marginless">
+    <h3 class="title is-5 is-marginless">
       Reindex
-    </h4>
-    <p>
-      Reindex the local data storage
+    </h3>
+    <p class="has-top-padding-s">
+      Reindex the local data storage.
     </p>
   </div>
   <div class="action-block-action">

--- a/ui/lib/core/addon/templates/components/replication-action-update-primary.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-update-primary.hbs
@@ -1,10 +1,10 @@
 <div class="action-block is-rounded" data-test-update-primary-replication>
   <div class="action-block-info">
-    <h4 class="title is-5 is-marginless">
+    <h3 class="title is-5 is-marginless">
       Update primary
-    </h4>
-    <p>
-      Change this secondary's assigned primary cluster
+    </h3>
+    <p class="has-top-padding-s">
+      Change this secondary's assigned primary cluster.
     </p>
   </div>
 

--- a/ui/lib/kmip/addon/templates/role.hbs
+++ b/ui/lib/kmip/addon/templates/role.hbs
@@ -23,7 +23,7 @@
   <FieldGroupShow @model={{this.model}} @showAllFields={{false}} />
   <div class="box is-fullwidth is-shadowless">
     <h2 class="title is-5">
-      Allowed Operations
+      Allowed operations
     </h2>
     <OperationFieldDisplay @model={{this.model}} />
   </div>

--- a/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
+++ b/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
@@ -1,6 +1,6 @@
 <div class="selectable-card is-rounded secondaries">
   <div class="level">
-    <h3 class="card-title title is-5">{{this.replicationAttrs.secondaries.length}} Known Secondaries</h3>
+    <h3 class="card-title title is-5">{{this.replicationAttrs.secondaries.length}} Known secondaries</h3>
     <ToolbarLink @route="mode.secondaries" @model={{this.cluster.replicationMode}} data-test-manage-link>
       View all
     </ToolbarLink>

--- a/ui/tests/integration/components/replication-actions-test.js
+++ b/ui/tests/integration/components/replication-actions-test.js
@@ -181,7 +181,7 @@ module('Integration | Component | replication actions', function (hooks) {
         `
       );
 
-      const selector = oldVersion ? 'h4' : `[data-test-${action}-replication] h4`;
+      const selector = oldVersion ? 'h3' : `[data-test-${action}-replication] h3`;
       assert
         .dom(selector)
         .hasText(headerText, `${testKey}: renders the correct component header (${oldVersion})`);


### PR DESCRIPTION
For all titles that are not form titles (largely denoted in our app by the `class="title is-5"`) only the first word is capitalized. Below are some screenshot examples.

In overview cards
![image](https://github.com/hashicorp/vault/assets/6618863/562970cc-50f3-4e88-b1e0-bed41e505edd)

In detail pages broken up by sections
![image](https://github.com/hashicorp/vault/assets/6618863/57e518d2-e0ed-4f1a-960b-0742a8ca28ff)

The title for modals
![image](https://github.com/hashicorp/vault/assets/6618863/9cae7679-e19e-4a01-a1d8-84a134e5d919)

Ran the enterprise test suite locally ✅
