### PR TITLE
Bug Fix: Surface Error for when cookie settings prevent localStorage

### DIFF
--- a/ui/app/lib/local-storage.js
+++ b/ui/app/lib/local-storage.js
@@ -4,9 +4,27 @@
  */
 
 export default {
+  isLocalStorageSupported() {
+    try {
+      const key = `__storage__test`;
+      window.localStorage.setItem(key, null);
+      window.localStorage.removeItem(key);
+      return true;
+    } catch (e) {
+      // modify the e object so we can customize the error message.
+      // e.message is readOnly.
+      e.errors = [`This is likely due to your browser's cookie settings.`];
+      throw e;
+    }
+  },
+
   getItem(key) {
-    var item = window.localStorage.getItem(key);
-    return item && JSON.parse(item);
+    try {
+      const item = window.localStorage.getItem(key);
+      return item && JSON.parse(item);
+    } catch (e) {
+      return e;
+    }
   },
 
   setItem(key, val) {
@@ -31,3 +49,16 @@ export default {
     });
   },
 };
+
+function isSupported(getStorage) {
+  try {
+    const key = '__some_random_key_you_are_not_going_to_use__';
+    getStorage().setItem(key, key);
+    getStorage().removeItem(key);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+isSupported(() => localStorage); // => true | false

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -10,6 +10,7 @@ import Route from '@ember/routing/route';
 import { task, timeout } from 'ember-concurrency';
 import Ember from 'ember';
 import getStorage from '../../lib/token-storage';
+import localStorage from 'vault/lib/local-storage';
 import ClusterRoute from 'vault/mixins/cluster-route';
 import ModelBoundaryRoute from 'vault/mixins/model-boundary-route';
 
@@ -87,6 +88,9 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
   },
 
   model(params) {
+    // if a user's browser settings block localStorage they will be unable to use Vault. The method will throw the error and the rest of the application will not load.
+    localStorage.isLocalStorageSupported();
+
     const id = this.getClusterId(params);
     return this.store.findRecord('cluster', id);
   },


### PR DESCRIPTION
The new Dismiss License Banner feature uses localStorage. Because they are loaded before a user attempts to login, the app was silently failing if a browsers settings did not permit localStorage.

To reproduce:
1. Under your browsers privacy settings select "block all cookies". 
![image](https://github.com/hashicorp/vault/assets/6618863/02da826c-9f3e-4087-8fd5-87a18f987df8)
2. Load the app. 

Before the Dismiss license banners work we caught this error on login and surfaced it in the Login container. While the app still didn't work, it didn't silently fail on first load.

This fix shows the DomException error thrown and appends a small clarifying message afterwards. I didn't want to add a lot of custom logic to the `error.hbs` template for this one scenario, so it's pretty simple. Thoughts?

Note the error that is thrown is readOnly. [Here](https://udn.realityripple.com/docs/Web/API/DOMException) are the MDN docs on the three params returned. 

![image](https://github.com/hashicorp/vault/assets/6618863/b8139339-e0b9-4031-b6b0-950ef51d5cbc)
