### PR TITLE
plugin: use gh token for plugin workflow

### DIFF
--- a/.github/workflows/plugin-update-check.yml
+++ b/.github/workflows/plugin-update-check.yml
@@ -49,6 +49,8 @@ jobs:
           git commit -m "Automated dependency upgrades"
           git push -f origin ${{ github.ref_name }}:"$BRANCH_NAME"
       - name: Open pull request if needed
+        env:
+          GITHUB_TOKEN: ${{secrets.ELEVATED_GITHUB_TOKEN}}
         if: steps.changes.outputs.count > 0
         # Only open a PR if the branch is not attached to an existing one
         run: |

--- a/.github/workflows/plugin-update-check.yml
+++ b/.github/workflows/plugin-update-check.yml
@@ -30,6 +30,10 @@ jobs:
       - run: echo "would use $COMMIT_SHA of $REPO_NAME"
         # checkout
       - uses: actions/checkout@v3 # should be a sha, but eh
+        with:
+          # We don't use the default token so that checks are executed on the resulting PR
+          # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+          token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
         # activate go
       - uses: actions/setup-go@v4
       - name: update plugin
@@ -49,9 +53,9 @@ jobs:
           git commit -m "Automated dependency upgrades"
           git push -f origin ${{ github.ref_name }}:"$BRANCH_NAME"
       - name: Open pull request if needed
+        if: steps.changes.outputs.count > 0
         env:
           GITHUB_TOKEN: ${{secrets.ELEVATED_GITHUB_TOKEN}}
-        if: steps.changes.outputs.count > 0
         # Only open a PR if the branch is not attached to an existing one
         run: |
           PR=$(gh pr list --head "$BRANCH_NAME" --json number -q '.[0].number')


### PR DESCRIPTION
The plugin dependency automation (ref: https://github.com/hashicorp/vault/pull/21491) needs a GH token set so that we can use the GH CLI. See failure here: https://github.com/hashicorp/vault/actions/runs/5405229617/jobs/9820485201