### PR TITLE
plugin automation: fix branch name

### DIFF
--- a/.github/scripts/plugin-helper-gh-pr-create.sh
+++ b/.github/scripts/plugin-helper-gh-pr-create.sh
@@ -2,15 +2,16 @@
 
 # this script expects the following env vars to be set
 #  - GITHUB_TOKEN
-#  - PLUGIN_REPO_NAME
-#  - BRANCH_NAME
+#  - PLUGIN_REPO
+#  - VAULT_BRANCH
+#  - PLUGIN_BRANCH
 #  - RUN_ID
 
 # we are using the GH API directly so that we can get the resluting
 # PR URL from the JSON response
 
 reviewers="fairclothjm,kpcraig"
-resp=$(curl -L \
+resp=$(curl -sL \
   -X POST \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: Bearer ${GITHUB_TOKEN}"\
@@ -18,9 +19,9 @@ resp=$(curl -L \
   https://api.github.com/repos/hashicorp/vault/pulls \
   --data @<(cat <<EOF
 {
-  "title":"[DO NOT MERGE]: $PLUGIN_REPO_NAME Automated plugin update check",
-  "body":"Updates $PLUGIN_REPO_NAME to verify vault CI. Full log: https://github.com/hashicorp/vault/actions/runs/$RUN_ID",
-  "head":"$BRANCH_NAME",
+  "title":"[DO NOT MERGE]: $PLUGIN_REPO Automated plugin update check",
+  "body":"Updates $PLUGIN_REPO to verify vault CI. Full log: https://github.com/hashicorp/vault/actions/runs/$RUN_ID",
+  "head":"$VAULT_BRANCH",
   "base":"master",
   "label": "dependencies,pr/no-changelog,pr/no-milestone",
   "reviewer": "$reviewers",
@@ -33,7 +34,7 @@ EOF
 vault_pr_url=$(echo "$resp" | jq '.html_url')
 
 # get Plugin PR number
-plugin_pr_num=$(gh pr list --head "$BRANCH_NAME" --json number --repo hashicorp/vault-plugin-database-snowflake -q '.[0].number')
+plugin_pr_num=$(gh pr list --head "$PLUGIN_BRANCH" --json number --repo hashicorp/$PLUGIN_REPO -q '.[0].number')
 
 # make a comment on the plugin repo's PR
-gh pr comment $plugin_pr_num --body "Vault CI check PR: $vault_pr_url" --repo hashicorp/$PLUGIN_REPO_NAME
+gh pr comment $plugin_pr_num --body "Vault CI check PR: $vault_pr_url" --repo hashicorp/$PLUGIN_REPO

--- a/.github/workflows/plugin-update-check.yml
+++ b/.github/workflows/plugin-update-check.yml
@@ -29,7 +29,7 @@ jobs:
       #  }
       COMMIT_SHA: "${{inputs.sha}}"
       PLUGIN_REPO: "${{inputs.repo}}"
-      PLUGIN_BRANCH: "${{inputs.plugin-branch}}"
+      PLUGIN_BRANCH: "${{inputs.plugin_branch}}"
       VAULT_BRANCH: "auto-plugin-update/${{inputs.repo}}/${{inputs.sha}}"
       RUN_ID: "${{github.run_id}}"
     steps:

--- a/.github/workflows/plugin-update-check.yml
+++ b/.github/workflows/plugin-update-check.yml
@@ -9,6 +9,10 @@ on:
         type: string
         description: the hash of the plugin repo commit to use
         required: true
+      plugin_branch:
+        type: string
+        description: the name of the plugin branch
+        required: true
 
 jobs:
   plugin-update-check:
@@ -24,11 +28,12 @@ jobs:
       #    }
       #  }
       COMMIT_SHA: "${{inputs.sha}}"
-      PLUGIN_REPO_NAME: "${{inputs.repo}}"
+      PLUGIN_REPO: "${{inputs.repo}}"
+      PLUGIN_BRANCH: "${{inputs.plugin-branch}}"
+      VAULT_BRANCH: "auto-plugin-update/${{inputs.repo}}/${{inputs.sha}}"
       RUN_ID: "${{github.run_id}}"
-      BRANCH_NAME: "auto-plugin-update-${{inputs.repo}}-${{inputs.sha}}"
     steps:
-      - run: echo "would use $COMMIT_SHA of $PLUGIN_REPO_NAME"
+      - run: echo "would use $COMMIT_SHA of $PLUGIN_REPO"
         # checkout
       - uses: actions/checkout@v3 # should be a sha, but eh
         with:
@@ -39,7 +44,7 @@ jobs:
       - uses: actions/setup-go@v4
       - name: update plugin
         run: |
-          go get "github.com/hashicorp/$PLUGIN_REPO_NAME@$COMMIT_SHA"
+          go get "github.com/hashicorp/$PLUGIN_REPO@$COMMIT_SHA"
           go mod tidy
       - name: detect changes
         id: changes
@@ -52,14 +57,14 @@ jobs:
           git config user.email hc-github-team-secure-vault-ecosystem@users.noreply.github.com
           git add .
           git commit -m "Automated dependency upgrades"
-          git push -f origin ${{ github.ref_name }}:"$BRANCH_NAME"
+          git push -f origin ${{ github.ref_name }}:"$VAULT_BRANCH"
       - name: Open pull request if needed
         if: steps.changes.outputs.count > 0
         env:
           GITHUB_TOKEN: ${{secrets.ELEVATED_GITHUB_TOKEN}}
         # Only open a PR if the branch is not attached to an existing one
         run: |
-          PR=$(gh pr list --head "$BRANCH_NAME" --json number -q '.[0].number')
+          PR=$(gh pr list --head "$VAULT_BRANCH" --json number -q '.[0].number')
 
           if [ -z "$PR" ]; then
             # call the script to create the plugin update PR on Vault


### PR DESCRIPTION
We were passing the Vault Branch when attempting to get Plugin PR number. This makes sure we pass the plugin branch name and also makes the plugin branch name an input to the Vault workflow