### PR TITLE
Docs: Updates for vault-mssql-ekm-provider-enterprise release v0.2.1

### DIFF
--- a/website/content/docs/platform/mssql/changelog.mdx
+++ b/website/content/docs/platform/mssql/changelog.mdx
@@ -9,6 +9,13 @@ description: Release notes for the Vault EKM Provider for Microsoft SQL Server.
 Each version is available to download from the
 [releases](https://releases.hashicorp.com/vault-mssql-ekm-provider/) page.
 
+# 0.2.1 (June 30th, 2023)
+
+BUGS
+
+* The provider now correctly uses a previous key version for decryption when the transit key is rotated but the DEK has not yet been re-encrypted.
+* Fixed a bug that prevented the provider from emitting Event logs.
+
 ## 0.2.0 (July 15th, 2022)
 
 BUGS

--- a/website/content/docs/platform/mssql/changelog.mdx
+++ b/website/content/docs/platform/mssql/changelog.mdx
@@ -9,7 +9,7 @@ description: Release notes for the Vault EKM Provider for Microsoft SQL Server.
 Each version is available to download from the
 [releases](https://releases.hashicorp.com/vault-mssql-ekm-provider/) page.
 
-# 0.2.1 (June 30th, 2023)
+## 0.2.1 (June 30th, 2023)
 
 BUGS
 

--- a/website/content/docs/platform/mssql/troubleshooting.mdx
+++ b/website/content/docs/platform/mssql/troubleshooting.mdx
@@ -24,7 +24,7 @@ detailed logs in the same section of Windows Event Viewer.
 If the Vault EKM provider is not generating event logs, you may find some
 information in the SQL Server's error logs. Check for an event with ID
 17111 from "MSSQLSERVER" which details the file location of the error logs,
-e.g. "Logging SQL Server messages in file
+for example "Logging SQL Server messages in file
 'C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\Log\ERRORLOG'."
 
 ## Authenticode error

--- a/website/content/docs/platform/mssql/troubleshooting.mdx
+++ b/website/content/docs/platform/mssql/troubleshooting.mdx
@@ -19,11 +19,37 @@ your issue, you can [enable trace logging](/vault/docs/platform/mssql/configurat
 Restart SQL Server for the config change to take effect, and you should see more
 detailed logs in the same section of Windows Event Viewer.
 
+## Check SQL Server error logs
+
+If the Vault EKM provider is not generating event logs, you may find some
+information in the SQL Server's error logs. Check for an event with ID
+17111 from "MSSQLSERVER" which details the file location of the error logs,
+e.g. "Logging SQL Server messages in file
+'C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\Log\ERRORLOG'."
+
+## Authenticode error
+
+When running the `CREATE CRYPTOGRAPHIC PROVIDER` SQL query, if you get an error
+"Cannot load library", you may see "Failed to verify Authenticode signature on
+DLL" in the error logs. This can normally be remediated by updating the CA trust
+store to include the latest Digicert certificates. Run the following to import
+the required certificates into the Root trust store:
+
+```powershell
+New-Item -ItemType Directory -Path certs
+certutil -syncwithWU .\certs\
+extrac32 -L .\certs\ .\certs\authrootstl.cab
+certutil -f -ent -AddStore Root .\certs\authroot.stl
+certutil -f -ent -AddStore Root .\certs\0563b8630d62d75abbc8ab1e4bdfb5a899b24d43.crt
+certutil -f -ent -AddStore Root .\certs\ddfb16cd4931c973a2037d3fc83a4d7d775d05e4.crt
+Remove-Item -Recurse .\certs\
+```
+
 ## Error Codes
 
 During installation, the EKM provider registers a manifest of coded event logs to aid debugging. You may see the following error codes during operation.
 
-### 2050 License Error
+### 2050 License error
 
 The EKM provider was unable to verify that Vault has the correct license features. This
 could be due to:


### PR DESCRIPTION
v0.2.1 available [here](https://releases.hashicorp.com/vault-mssql-ekm-provider/0.2.1+ent/).

## 0.2.1 (June 30th, 2023)

BUGS

* The provider now correctly uses a previous key version for decryption when the transit key is rotated but the DEK has not yet been re-encrypted.
* Fixed a bug that prevented the provider from emitting Event logs.