### PR TITLE
[QT-581] ci: prepare for additional runner groups

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,4 +7,5 @@ self-hosted-runner:
     - small
     - large
     - ondemand
-
+    - linux
+    - x64

--- a/.github/workflows/enos-release-testing-oss.yml
+++ b/.github/workflows/enos-release-testing-oss.yml
@@ -63,7 +63,7 @@ jobs:
     secrets: inherit
 
   save-metadata:
-    runs-on: linux
+    runs-on: ubuntu-latest
     if: always()
     needs: test
     steps:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   scan:
-    runs-on: ['linux', 'large']
+    runs-on: [self-hosted, linux, large, x64]
     if: ${{ github.actor != 'dependabot[bot]' || github.actor != 'hc-github-team-secure-vault-core' }}
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -42,19 +42,19 @@ jobs:
         cd "$GITHUB_WORKSPACE/security-scanner/pkg/sdk/examples/scan-plugin-semgrep"
         go build -o scan-plugin-semgrep .
         mv scan-plugin-semgrep "$HOME/.bin"
-        
+
         cd "$GITHUB_WORKSPACE/security-scanner/pkg/sdk/examples/scan-plugin-codeql"
         go build -o scan-plugin-codeql .
         mv scan-plugin-codeql "$HOME/.bin"
-        
+
         # Semgrep
         python3 -m pip install semgrep
-        
+
         # CodeQL
         LATEST=$(gh release list --repo https://github.com/github/codeql-action | cut -f 3 | sort --version-sort | tail -n1)
         gh release download --repo https://github.com/github/codeql-action --pattern codeql-bundle-linux64.tar.gz "$LATEST"
         tar xf codeql-bundle-linux64.tar.gz -C "$HOME/.bin"
-        
+
         # Add to PATH
         echo "$HOME/.bin" >> "$GITHUB_PATH"
         echo "$HOME/.bin/codeql" >> "$GITHUB_PATH"


### PR DESCRIPTION
Where necessary we now use the appropriate labels to ensure that different runner groups can be safely enabled.