### PR TITLE
Fix incorrect OpenAPI operation ID

### DIFF
--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -430,7 +430,7 @@ func (ts *TokenStore) paths() []*framework.Path {
 				logical.ReadOperation: &framework.PathOperation{
 					Callback: ts.handleLookup,
 					DisplayAttrs: &framework.DisplayAttributes{
-						OperationSuffix: "self3", // avoid collision with lookup-self
+						OperationSuffix: "2",
 					},
 				},
 				logical.UpdateOperation: &framework.PathOperation{


### PR DESCRIPTION
The operation ID for `GET auth/token/lookup` has been overridden in
a way which *implies* it can only perform lookup-self operations.

This isn't actually the case, as shown:

1) Here is my current token:
```
$ vault read -field=display_name auth/token/lookup
userpass-admin
```

2) I create a second token, with a different display name to distinguish
   it:
```
$ othertoken=$(vault token create -field=token -display-name=testing123)
```

3) I use this operation, still authenticated with the first token, to
   lookup the second token, showing it is not actually a lookup-self operation:
```
$ vault read -field=display_name auth/token/lookup token=$othertoken
token-testing123
```

I have set the new operation ID suffix to `"2"` adhering to current
conventions in `vault-client-go` and `vault-client-dotnet` for secondary
versions of APIs which should be excluded from the generated library
code.

I have confirmed this doesn't give rise to any new clashes between operation IDs.