### PR TITLE
Add home directory to preinst user creation

### DIFF
--- a/.release/linux/preinst
+++ b/.release/linux/preinst
@@ -8,6 +8,7 @@ if ! id -u $USER > /dev/null 2>&1; then
 	useradd \
 		--system \
 		--user-group \
+		--home-dir /opt/vault \
 		--shell /bin/false \
 		$USER
 fi


### PR DESCRIPTION
Vault always uses /opt/vault as it's installation directory. Since a local account is created it's a good idea to set the application home directory to be also /opt/vault, instead of the default /home/vault.