### PR TITLE
VAULT-17586: Add concurency to ci and build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,9 @@ on:
     branches:
       - main
       - release/**
-
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}-build
+  cancel-in-progress: true
 jobs:
   # verify-changes determines if the changes are only for docs (website)
   verify-changes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ on:
       - main
       - release/**
   workflow_dispatch:
-
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}-ci
+  cancel-in-progress: true
 jobs:
   setup:
     name: Setup
@@ -295,7 +297,7 @@ jobs:
         with:
           name: test-results-ui
           path: ui/test-results
-        if: always()
+        if: success() || failure() 
       - uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f # TSCCR: no entry for repository "test-summary/action"
         with:
           paths: "ui/test-results/qunit/results.xml"
@@ -307,7 +309,12 @@ jobs:
       - setup-go-cache
       - test-go
       - test-ui
-    if: always()
+    # We force a failure if any of the dependent jobs fail,
+    # this is a workaround for the issue reported https://github.com/actions/runner/issues/2566
+    if: |
+      always() && (cancelled() ||
+      contains(needs.*.result, 'cancelled') ||
+      contains(needs.*.result, 'failure'))
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
       - run: |

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -227,7 +227,7 @@ jobs:
                 \
               ${test_packages[${{ matrix.runner-index }}]}
       - name: Prepare datadog-ci
-        if: github.repository == 'hashicorp/vault' && always()
+        if: github.repository == 'hashicorp/vault' && (success() || failure()) 
         continue-on-error: true
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
@@ -241,16 +241,16 @@ jobs:
             export DATADOG_API_KEY=${{ secrets.DATADOG_API_KEY }}
           fi
           datadog-ci junit upload --service "$GITHUB_REPOSITORY" test-results/go-test/results.xml
-        if: always()
+        if: success() || failure()
       - name: Archive test results
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: test-results${{ inputs.name }}-${{ matrix.runner-index }}
           path: test-results/
-        if: always()
+        if: success() || failure() 
       - name: Create a summary of tests
         uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f # TSCCR: no entry for repository "test-summary/action"
         with:
           paths: "test-results/go-test/results.xml"
           show: "fail"
-        if: always()
+        if: success() || failure() 


### PR DESCRIPTION
This PR adds a concurrency parameter to the build.yml and ci.yml workflows. There will only ever be one job running with the same `group` label. The group will either be the head branch, which is only present in PRs, or will be the uniquely assigned runID. That means that if it's a PR, there will only ever one of each of these workflows running for the same branch and an in-progress workflow will be cancelled in favor of a new one. For all other triggers, there will be no cancellation.