### PR TITLE
VAULT-17590 Add failure notifications for OSS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,4 +280,4 @@ jobs:
         with:
           channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
           payload: |
-            {"text":"OSS build failures on ${{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build(s) failed on ${{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
+            {"text":"OSS build failures on ${{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":rotating_light: OSS build failures :rotating_light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build(s) failed on ${{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,8 +279,9 @@ jobs:
           payload: |
             {"text":"OSS build-other failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build-other failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
 
+#TODO: Change violethynes/VAULT-17590 to main
   notify-build-linux-failures:
-    if: ${{ always() && needs.build-linux.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+    if: ${{ always() && needs.build-linux.result == 'failure' && (github.ref_name == 'violethynes/VAULT-17590' || startsWith(github.ref_name, 'release/')) }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,9 +279,12 @@ jobs:
           payload: |
             {"text":"OSS build-other failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build-other failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
 
-#TODO: Change violethynes/VAULT-17590 to main
+# TODO: Change from
+# github.head_ref == 'violethynes/VAULT-17590'
+# to
+# github.ref_name == 'main'
   notify-build-linux-failures:
-    if: ${{ always() && needs.build-linux.result == 'failure' && (github.ref_name == 'violethynes/VAULT-17590' || startsWith(github.ref_name, 'release/')) }}
+    if: ${{ always() && needs.build-linux.result == 'failure' && (github.head_ref == 'violethynes/VAULT-17590' || startsWith(github.ref_name, 'release/')) }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -355,9 +358,14 @@ jobs:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {"text":"OSS build-ubi failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build-ubi failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
+  
 
+  # TODO: Change from
+  # github.head_ref == 'violethynes/VAULT-17590'
+  # to
+  # github.ref_name == 'main'
   notify-test-failures:
-    if: ${{ always() && needs.test.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+    if: ${{ always() && needs.test.result == 'failure' && (github.head_ref == 'violethynes/VAULT-17590' || startsWith(github.ref_name, 'release/')) }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,4 +285,4 @@ jobs:
         with:
           channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
           payload: |
-            {"text":"OSS build failures on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build(s) failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
+            {"text":"OSS build failures on ${{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build(s) failed on ${{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,13 +260,8 @@ jobs:
           echo "Some of the required build and test workflows have failed!"
           exit 1
 
-
-  # TODO: Change from
-  # github.head_ref == 'violethynes/VAULT-17590'
-  # to
-  # github.ref_name == 'main'
   notify-completed-successfully-failures:
-    if: ${{ always() && needs.completed-successfully.result == 'failure' && (github.head_ref == 'violethynes/VAULT-17590' || startsWith(github.ref_name, 'release/')) }}
+    if: ${{ always() && needs.completed-successfully.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,9 +277,12 @@ jobs:
       - completed-successfully
     steps:
       - name: send-notification
-        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
+        # We intentionally aren't using the following here since it's from an internal repo
+        # uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
-          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {"text":"OSS build failures on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build(s) failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,3 +259,136 @@ jobs:
       - run: |
           echo "Some of the required build and test workflows have failed!"
           exit 1
+
+  notify-build-other-failures:
+    if: ${{ always() && needs.build-other.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+    needs:
+      - build-other
+    steps:
+      - name: send-notification
+        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
+        with:
+          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {"text":"OSS build-other failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build-other failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
+
+  notify-build-linux-failures:
+    if: ${{ always() && needs.build-linux.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+    needs:
+      - build-linux
+    steps:
+      - name: send-notification
+        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
+        with:
+          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {"text":"OSS build-linux failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build-linux failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
+
+  notify-build-darwin-failures:
+    if: ${{ always() && needs.build-darwin.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+    needs:
+      - build-darwin
+    steps:
+      - name: send-notification
+        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
+        with:
+          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {"text":"OSS build-darwin failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build-darwin failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
+
+  notify-build-docker-failures:
+    if: ${{ always() && needs.build-docker.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+    needs:
+      - build-docker
+    steps:
+      - name: send-notification
+        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
+        with:
+          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {"text":"OSS build-docker failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build-docker failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
+
+  notify-build-ubi-failures:
+    if: ${{ always() && needs.build-ubi.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+    needs:
+      - build-ubi
+    steps:
+      - name: send-notification
+        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
+        with:
+          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {"text":"OSS build-ubi failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build-ubi failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
+
+  notify-test-failures:
+    if: ${{ always() && needs.test.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+    needs:
+      - test
+    steps:
+      - name: send-notification
+        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
+        with:
+          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {"text":"OSS test failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS test failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"test failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
+
+  notify-test-docker-k8s-failures:
+    if: ${{ always() && needs.test-docker-k8s.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+    needs:
+      - test-docker-k8s
+    steps:
+      - name: send-notification
+        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
+        with:
+          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {"text":"OSS test-docker-k8s failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS test failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"test-docker-k8s failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,112 +260,13 @@ jobs:
           echo "Some of the required build and test workflows have failed!"
           exit 1
 
-  notify-build-other-failures:
-    if: ${{ always() && needs.build-other.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-    needs:
-      - build-other
-    steps:
-      - name: send-notification
-        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
-        with:
-          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
-          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {"text":"OSS build-other failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build-other failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
-
-# TODO: Change from
-# github.head_ref == 'violethynes/VAULT-17590'
-# to
-# github.ref_name == 'main'
-  notify-build-linux-failures:
-    if: ${{ always() && needs.build-linux.result == 'failure' && (github.head_ref == 'violethynes/VAULT-17590' || startsWith(github.ref_name, 'release/')) }}
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-    needs:
-      - build-linux
-    steps:
-      - name: send-notification
-        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
-        with:
-          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
-          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {"text":"OSS build-linux failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build-linux failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
-
-  notify-build-darwin-failures:
-    if: ${{ always() && needs.build-darwin.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-    needs:
-      - build-darwin
-    steps:
-      - name: send-notification
-        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
-        with:
-          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
-          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {"text":"OSS build-darwin failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build-darwin failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
-
-  notify-build-docker-failures:
-    if: ${{ always() && needs.build-docker.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-    needs:
-      - build-docker
-    steps:
-      - name: send-notification
-        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
-        with:
-          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
-          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {"text":"OSS build-docker failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build-docker failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
-
-  notify-build-ubi-failures:
-    if: ${{ always() && needs.build-ubi.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-    needs:
-      - build-ubi
-    steps:
-      - name: send-notification
-        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
-        with:
-          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
-          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {"text":"OSS build-ubi failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build-ubi failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
-  
 
   # TODO: Change from
   # github.head_ref == 'violethynes/VAULT-17590'
   # to
   # github.ref_name == 'main'
-  notify-test-failures:
-    if: ${{ always() && needs.test.result == 'failure' && (github.head_ref == 'violethynes/VAULT-17590' || startsWith(github.ref_name, 'release/')) }}
+  notify-completed-successfully-failures:
+    if: ${{ always() && needs.completed-successfully.result == 'failure' && (github.head_ref == 'violethynes/VAULT-17590' || startsWith(github.ref_name, 'release/')) }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -373,7 +274,7 @@ jobs:
     strategy:
       fail-fast: false
     needs:
-      - test
+      - completed-successfully
     steps:
       - name: send-notification
         uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
@@ -381,23 +282,4 @@ jobs:
           channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            {"text":"OSS test failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS test failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"test failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
-
-  notify-test-docker-k8s-failures:
-    if: ${{ always() && needs.test-docker-k8s.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-    needs:
-      - test-docker-k8s
-    steps:
-      - name: send-notification
-        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
-        with:
-          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
-          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {"text":"OSS test-docker-k8s failed on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS test failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"test-docker-k8s failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
+            {"text":"OSS build failures on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS build failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"build(s) failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,3 +341,4 @@ jobs:
           channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
           payload: |
             {"text":"OSS test failures on ${{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS test failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"test(s) failed on ${{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
+            

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,7 @@ jobs:
           tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)'
 
   notify-tests-completed-failures:
-    if: ${{ always() && needs.tests-completed.result == 'failure' && (github.head_ref == github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+    if: ${{ always() && needs.tests-completed.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -341,4 +341,3 @@ jobs:
           channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
           payload: |
             {"text":"OSS test failures on ${{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":rotating_light: OSS test failures :rotating_light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"test(s) failed on ${{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
-            

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,12 +320,8 @@ jobs:
       - run: |
           tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)'
 
-  # TODO: Change from
-  # github.head_ref == 'violethynes/VAULT-17590'
-  # to
-  # github.ref_name == 'main'
   notify-tests-completed-failures:
-    if: ${{ always() && needs.tests-completed.result == 'failure' && (github.head_ref == 'violethynes/VAULT-17590' || startsWith(github.ref_name, 'release/')) }}
+    if: ${{ always() && needs.tests-completed.result == 'failure' && (github.head_ref == github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,4 +344,4 @@ jobs:
         with:
           channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
           payload: |
-            {"text":"OSS test failures on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS test failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"test(s) failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
+            {"text":"OSS test failures on ${{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS test failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"test(s) failed on ${{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,3 +319,26 @@ jobs:
     steps:
       - run: |
           tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)'
+
+  # TODO: Change from
+  # github.head_ref == 'violethynes/VAULT-17590'
+  # to
+  # github.ref_name == 'main'
+  notify-tests-completed-failures:
+    if: ${{ always() && needs.tests-completed.result == 'failure' && (github.head_ref == 'violethynes/VAULT-17590' || startsWith(github.ref_name, 'release/')) }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+    needs:
+      - tests-completed
+    steps:
+      - name: send-notification
+        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
+        with:
+          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {"text":"OSS test failures on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS test failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"test(s) failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,9 +336,12 @@ jobs:
       - tests-completed
     steps:
       - name: send-notification
-        uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
+        # We intentionally aren't using the following here since it's from an internal repo
+        # uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
-          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {"text":"OSS test failures on {{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS test failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"test(s) failed on {{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,5 +340,5 @@ jobs:
         with:
           channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
           payload: |
-            {"text":"OSS test failures on ${{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":flashing-light: OSS test failures :flashing-light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"test(s) failed on ${{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
+            {"text":"OSS test failures on ${{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":rotating_light: OSS test failures :rotating_light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"test(s) failed on ${{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
             

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -64,7 +64,7 @@ var (
 type HandlerProperties struct {
 	Core                  *Core
 	ListenerConfig        *configutil.Listener
-	DisableP  rintableCheck bool
+	DisablePrintableCheck bool
 	RecoveryMode          bool
 	RecoveryToken         *uberAtomic.String
 }

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -64,7 +64,7 @@ var (
 type HandlerProperties struct {
 	Core                  *Core
 	ListenerConfig        *configutil.Listener
-	DisablePrintableCheck bool
+	DisableP  rintableCheck bool
 	RecoveryMode          bool
 	RecoveryToken         *uberAtomic.String
 }


### PR DESCRIPTION
This uses GitHub secrets as Vault is not yet available in the `vault` repo. The `vault-enterprise` file will use the secret in Vault.

Upon a failure on `main` or a release branch, a failure notification will be sent to `#feed-vault-ci-official`. Some examples are in that channel already, although instead of saying e.g. `21561/merge` it will say the branch it was from, e.g. `main`, or `release/1.14.x` etc.

What's left is to merge this PR, do an OSS merge, then update these notifications so that they use the CI Vault for Ent and say they're an ent run etc. Note that while this will mean we do have 'drift', we have differences in these files for OSS/ent already, so this is 'expected'.