### PR TITLE
Hide Nav Links in Child Namespaces

### DIFF
--- a/changelog/21562.txt
+++ b/changelog/21562.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes issue with certain navigational links incorrectly displaying in child namespaces
+```

--- a/ui/app/components/sidebar/nav/cluster.hbs
+++ b/ui/app/components/sidebar/nav/cluster.hbs
@@ -37,7 +37,12 @@
   {{/if}}
 
   {{#if
-    (and this.version.isEnterprise this.cluster.anyReplicationEnabled (has-permission "status" routeParams="replication"))
+    (and
+      this.version.isEnterprise
+      this.namespace.inRootNamespace
+      this.cluster.anyReplicationEnabled
+      (has-permission "status" routeParams="replication")
+    )
   }}
     <Nav.Title data-test-sidebar-nav-heading="Replication">Replication</Nav.Title>
     <Nav.Link
@@ -59,16 +64,18 @@
 
   {{#if
     (or
-      (has-permission "status" routeParams=(array "replication" "raft" "license" "seal"))
+      (and
+        this.namespace.inRootNamespace (has-permission "status" routeParams=(array "replication" "raft" "license" "seal"))
+      )
       (has-permission "clients" routeParams="activity")
     )
   }}
     <Nav.Title data-test-sidebar-nav-heading="Monitoring">Monitoring</Nav.Title>
   {{/if}}
-  {{#if (and this.version.isEnterprise (has-permission "status" routeParams="replication"))}}
+  {{#if (and this.version.isEnterprise this.namespace.inRootNamespace (has-permission "status" routeParams="replication"))}}
     <Nav.Link @route="vault.cluster.replication.index" @text="Replication" data-test-sidebar-nav-link="Replication" />
   {{/if}}
-  {{#if (and this.cluster.usingRaft (has-permission "status" routeParams="raft"))}}
+  {{#if (and this.cluster.usingRaft this.namespace.inRootNamespace (has-permission "status" routeParams="raft"))}}
     <Nav.Link
       @route="vault.cluster.storage"
       @model={{this.cluster.name}}
@@ -79,7 +86,14 @@
   {{#if (and (has-permission "clients" routeParams="activity") (not this.cluster.dr.isSecondary))}}
     <Nav.Link @route="vault.cluster.clients" @text="Client Count" data-test-sidebar-nav-link="Client Count" />
   {{/if}}
-  {{#if (and this.version.features (has-permission "status" routeParams="license") (not this.cluster.dr.isSecondary))}}
+  {{#if
+    (and
+      this.version.features
+      this.namespace.inRootNamespace
+      (has-permission "status" routeParams="license")
+      (not this.cluster.dr.isSecondary)
+    )
+  }}
     <Nav.Link
       @route="vault.cluster.license"
       @model={{this.cluster.name}}
@@ -87,7 +101,7 @@
       data-test-sidebar-nav-link="License"
     />
   {{/if}}
-  {{#if (and (has-permission "status" routeParams="seal") (not this.cluster.dr.isSecondary))}}
+  {{#if (and this.namespace.inRootNamespace (has-permission "status" routeParams="seal") (not this.cluster.dr.isSecondary))}}
     <Nav.Link
       @route="vault.cluster.settings.seal"
       @model={{this.cluster.name}}

--- a/ui/app/components/sidebar/nav/cluster.js
+++ b/ui/app/components/sidebar/nav/cluster.js
@@ -5,6 +5,7 @@ export default class SidebarNavClusterComponent extends Component {
   @service currentCluster;
   @service version;
   @service auth;
+  @service namespace;
 
   get cluster() {
     return this.currentCluster.cluster;

--- a/ui/tests/helpers/components/sidebar-nav.js
+++ b/ui/tests/helpers/components/sidebar-nav.js
@@ -3,11 +3,13 @@ import sinon from 'sinon';
 
 export const stubFeaturesAndPermissions = (owner, isEnterprise = false, setCluster = false) => {
   const permissions = owner.lookup('service:permissions');
-  sinon.stub(permissions, 'hasNavPermission').returns(true);
+  const hasNavPermission = sinon.stub(permissions, 'hasNavPermission');
+  hasNavPermission.returns(true);
   sinon.stub(permissions, 'navPathParams');
 
   const version = owner.lookup('service:version');
-  sinon.stub(version, 'features').value(allFeatures());
+  const features = sinon.stub(version, 'features');
+  features.value(allFeatures());
   sinon.stub(version, 'isEnterprise').value(isEnterprise);
 
   const auth = owner.lookup('service:auth');
@@ -20,4 +22,6 @@ export const stubFeaturesAndPermissions = (owner, isEnterprise = false, setClust
       usingRaft: true,
     });
   }
+
+  return { hasNavPermission, features };
 };

--- a/ui/tests/integration/components/sidebar/nav/cluster-test.js
+++ b/ui/tests/integration/components/sidebar/nav/cluster-test.js
@@ -64,4 +64,32 @@ module('Integration | Component | sidebar-nav-cluster', function (hooks) {
       assert.dom(`[data-test-sidebar-nav-link="${link}"]`).hasText(link, `${link} link renders`);
     });
   });
+
+  test('it should hide enterprise related links in child namespace', async function (assert) {
+    const links = [
+      'Disaster Recovery',
+      'Performance',
+      'Replication',
+      'Raft Storage',
+      'License',
+      'Seal Vault',
+    ];
+    this.owner.lookup('service:namespace').set('path', 'foo');
+    const stubs = stubFeaturesAndPermissions(this.owner, true, true);
+    stubs.hasNavPermission.callsFake((route) => route !== 'clients');
+
+    await renderComponent();
+
+    assert
+      .dom('[data-test-sidebar-nav-heading="Monitoring"]')
+      .doesNotExist(
+        'Monitoring heading is hidden in child namespace when user does not have access to Client Count'
+      );
+
+    links.forEach((link) => {
+      assert
+        .dom(`[data-test-sidebar-nav-link="${link}"]`)
+        .doesNotExist(`${link} is hidden in child namespace`);
+    });
+  });
 });


### PR DESCRIPTION
A [condition was missed](https://github.com/hashicorp/vault/blob/release/1.13.x/ui/app/templates/vault/cluster.hbs#L71-L86) when moving the navigation links to the new sidebar component which prevented certain enterprise related links from showing when using Vault in a child namespace. This PR adds that condition back in for the relevant links (Disaster Recovery, Performance, Replication, Raft Storage, License, Seal Vault).

![image](https://github.com/hashicorp/vault/assets/24611656/bea62a6d-edf0-4001-ad92-d4a4485c0fde)
