### PR TITLE
Fix: Ensure log related settings appear in 'sanitized' config

### DIFF
--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -41,12 +41,12 @@ type SharedConfig struct {
 	// LogFormat specifies the log format. Valid values are "standard" and
 	// "json". The values are case-insenstive. If no log format is specified,
 	// then standard format will be used.
+	LogFile              string      `hcl:"log_file"`
 	LogFormat            string      `hcl:"log_format"`
 	LogLevel             string      `hcl:"log_level"`
-	LogFile              string      `hcl:"log_file"`
-	LogRotateDuration    string      `hcl:"log_rotate_duration"`
 	LogRotateBytes       int         `hcl:"log_rotate_bytes"`
 	LogRotateBytesRaw    interface{} `hcl:"log_rotate_bytes"`
+	LogRotateDuration    string      `hcl:"log_rotate_duration"`
 	LogRotateMaxFiles    int         `hcl:"log_rotate_max_files"`
 	LogRotateMaxFilesRaw interface{} `hcl:"log_rotate_max_files"`
 
@@ -171,8 +171,13 @@ func (c *SharedConfig) Sanitized() map[string]interface{} {
 
 		"default_max_request_duration": c.DefaultMaxRequestDuration,
 
-		"log_level":  c.LogLevel,
-		"log_format": c.LogFormat,
+		// Logging related settings
+		"log_file":             c.LogFile,
+		"log_format":           c.LogFormat,
+		"log_level":            c.LogLevel,
+		"log_rotate_bytes":     c.LogRotateBytes,
+		"log_rotate_duration":  c.LogRotateDuration,
+		"log_rotate_max_files": c.LogRotateMaxFiles,
 
 		"pid_file": c.PidFile,
 

--- a/internalshared/configutil/config_test.go
+++ b/internalshared/configutil/config_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package configutil
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// TestSharedConfig_Sanitized_LogFields ensures that 'log related' shared config
+// is sanitized as expected.
+func TestSharedConfig_Sanitized_LogFields(t *testing.T) {
+	tests := map[string]struct {
+		Value                     *SharedConfig
+		IsNilConfigExpected       bool
+		ExpectedLogFile           string
+		ExpectedLogFormat         string
+		ExpectedLogLevel          string
+		ExpectedLogRotateBytes    int
+		ExpectedLogRotateDuration string
+		ExpectedLogRotateMaxFiles int
+	}{
+		"nil": {
+			Value:               nil,
+			IsNilConfigExpected: true,
+		},
+		"empty": {
+			Value: &SharedConfig{},
+		},
+		"valid-log-fields": {
+			Value: &SharedConfig{
+				LogFile:           "vault.log",
+				LogFormat:         "json",
+				LogLevel:          "warn",
+				LogRotateBytes:    1024,
+				LogRotateDuration: "30m",
+				LogRotateMaxFiles: -1,
+			},
+			ExpectedLogFile:           "vault.log",
+			ExpectedLogFormat:         "json",
+			ExpectedLogLevel:          "warn",
+			ExpectedLogRotateBytes:    1024,
+			ExpectedLogRotateDuration: "30m",
+			ExpectedLogRotateMaxFiles: -1,
+		},
+	}
+
+	for name, tc := range tests {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			cfg := tc.Value.Sanitized()
+			switch {
+			case tc.IsNilConfigExpected:
+				require.Nil(t, cfg)
+			default:
+				require.NotNil(t, cfg)
+				require.Equal(t, tc.ExpectedLogFile, cfg["log_file"])
+				require.Equal(t, tc.ExpectedLogFormat, cfg["log_format"])
+				require.Equal(t, tc.ExpectedLogLevel, cfg["log_level"])
+				require.Equal(t, tc.ExpectedLogRotateBytes, cfg["log_rotate_bytes"])
+				require.Equal(t, tc.ExpectedLogRotateDuration, cfg["log_rotate_duration"])
+				require.Equal(t, tc.ExpectedLogRotateMaxFiles, cfg["log_rotate_max_files"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
I was recently made aware that new config should also be handled within `Config.Sanitized()` and therefore `SharedConfig.Sanitized()`. 

https://github.com/hashicorp/vault/pull/18031 and https://github.com/hashicorp/vault/pull/17841 added 'log related' settings which were missed in `Sanitized()`, they have now been added and a test to ensure they're returned as expected.

PR will be backported to `1.13.x` and `1.14.x`.