### PR TITLE
Minor improvements to gen_openapi.sh

### DIFF
--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -24,12 +24,16 @@ then
 fi
 
 vault server -dev -dev-root-token-id=root &
-sleep 5
 VAULT_PID=$!
+
+# Allow time for Vault to start its HTTP listener
+sleep 1
 
 defer_stop_vault() {
     echo "Stopping Vault..."
     kill $VAULT_PID
+    # Allow time for Vault to print final logging and exit,
+    # before this script ends, and the shell prints its next prompt
     sleep 1
 }
 
@@ -80,8 +84,6 @@ vault secrets enable "transit"
 
 # Enable enterprise features
 if [[ -n "${VAULT_LICENSE:-}" ]]; then
-    vault write sys/license text="${VAULT_LICENSE}"
-
     vault secrets enable "keymgmt"
     vault secrets enable "kmip"
     vault secrets enable "transform"


### PR DESCRIPTION
1) Reduce sleep time - in my experience, 1 second is plenty for a dev
   Vault to start up its HTTP listener - having the user wait for
   5 seconds seems excessive.

2) Comment reason for both sleeps.

3) Remove line of code that is obsolete, now the Enterprise transition
   from stored to autoloaded licenses has completed.
