### PR TITLE
LDAP Overview Route and Page Component

### DIFF
--- a/ui/lib/ldap/addon/components/page/overview.hbs
+++ b/ui/lib/ldap/addon/components/page/overview.hbs
@@ -5,7 +5,7 @@
         Configure LDAP
       </ToolbarLink>
     {{else}}
-      <ToolbarLink @route="roles.create" data-test-toolbar-action="role">
+      <ToolbarLink @route="roles.create" @type="add" data-test-toolbar-action="role">
         Create role
       </ToolbarLink>
     {{/if}}

--- a/ui/lib/ldap/addon/components/page/overview.hbs
+++ b/ui/lib/ldap/addon/components/page/overview.hbs
@@ -1,0 +1,19 @@
+<TabPageHeader @model={{@backendModel}} @breadcrumbs={{@breadcrumbs}}>
+  <:toolbarActions>
+    {{#if @promptConfig}}
+      <ToolbarLink @route="configure" data-test-toolbar-action="config">
+        Configure LDAP
+      </ToolbarLink>
+    {{else}}
+      <ToolbarLink @route="roles.create" data-test-toolbar-action="role">
+        Create role
+      </ToolbarLink>
+    {{/if}}
+  </:toolbarActions>
+</TabPageHeader>
+
+{{#if @promptConfig}}
+  <ConfigCta />
+{{else}}
+  {{! add card components here once created }}
+{{/if}}

--- a/ui/lib/ldap/addon/routes/overview.ts
+++ b/ui/lib/ldap/addon/routes/overview.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
+import { hash } from 'rsvp';
+
+import type Store from '@ember-data/store';
+import type SecretMountPath from 'vault/services/secret-mount-path';
+import type Transition from '@ember/routing/transition';
+import type SecretEngineModel from 'vault/models/secret-engine';
+// import type LdapRoleModel from 'vault/models/ldap/role';
+// import type LdapLibraryModel from 'vault/models/ldap/library';
+import type Controller from '@ember/controller';
+import type { Breadcrumb } from 'vault/vault/app-types';
+
+interface LdapOverviewController extends Controller {
+  breadcrumbs: Array<Breadcrumb>;
+}
+interface LdapOverviewRouteModel {
+  backendModel: SecretEngineModel;
+  promptConfig: boolean;
+  // roles: Array<LdapRoleModel>;
+  // libraries: Array<LdapLibraryModel>;
+}
+
+@withConfig('ldap/config')
+export default class LdapConfigureRoute extends Route {
+  @service declare readonly store: Store;
+  @service declare readonly secretMountPath: SecretMountPath;
+
+  declare promptConfig: boolean;
+
+  async model() {
+    // roles and libraries will be needed to pass into card components
+    // add to hash once models have been created
+
+    // const backend = this.secretMountPath.currentPath;
+    return hash({
+      promptConfig: this.promptConfig,
+      backendModel: this.modelFor('application'),
+      // roles: this.store.query('ldap/role', { backend }).catch(() => []),
+      // libraries: this.store.query('ldap/libraries', { backend }).catch(() => []),
+    });
+  }
+
+  setupController(
+    controller: LdapOverviewController,
+    resolvedModel: LdapOverviewRouteModel,
+    transition: Transition
+  ) {
+    super.setupController(controller, resolvedModel, transition);
+
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: resolvedModel.backendModel.id },
+    ];
+  }
+}

--- a/ui/lib/ldap/addon/templates/overview.hbs
+++ b/ui/lib/ldap/addon/templates/overview.hbs
@@ -1,0 +1,7 @@
+<Page::Overview
+  @promptConfig={{this.model.promptConfig}}
+  @backendModel={{this.model.backendModel}}
+  @roles={{this.model.roles}}
+  @libraries={{this.model.libraries}}
+  @breadcrumbs={{this.breadcrumbs}}
+/>

--- a/ui/tests/helpers/ldap.js
+++ b/ui/tests/helpers/ldap.js
@@ -1,0 +1,22 @@
+export const createSecretsEngine = (store) => {
+  store.pushPayload('secret-engine', {
+    modelName: 'secret-engine',
+    data: {
+      accessor: 'ldap_7e838627',
+      path: 'ldap-test/',
+      type: 'ldap',
+    },
+  });
+  return store.peekRecord('secret-engine', 'ldap-test');
+};
+
+export const generateBreadcrumbs = (backend, childRoute) => {
+  const breadcrumbs = [{ label: 'secrets', route: 'secrets', linkExternal: true }];
+  const root = { label: backend };
+  if (childRoute) {
+    root.route = 'overview';
+    breadcrumbs.push({ label: childRoute });
+  }
+  breadcrumbs.splice(1, 0, root);
+  return breadcrumbs;
+};

--- a/ui/tests/integration/components/ldap/page/configuration-test.js
+++ b/ui/tests/integration/components/ldap/page/configuration-test.js
@@ -10,6 +10,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { duration } from 'core/helpers/format-duration';
+import { createSecretsEngine, generateBreadcrumbs } from 'vault/tests/helpers/ldap';
 
 const selectors = {
   rotateAction: '[data-test-toolbar-rotate-action] button',
@@ -29,15 +30,8 @@ module('Integration | Component | ldap | Page::Configuration', function (hooks) 
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');
 
-    this.store.pushPayload('secret-engine', {
-      modelName: 'secret-engine',
-      data: {
-        accessor: 'ldap_7e838627',
-        path: 'ldap-test/',
-        type: 'ldap',
-      },
-    });
-    this.backend = this.store.peekRecord('secret-engine', 'ldap-test');
+    this.backend = createSecretsEngine(this.store);
+    this.breadcrumbs = generateBreadcrumbs(this.backend.id);
 
     this.store.pushPayload('ldap/config', {
       modelName: 'ldap/config',
@@ -45,11 +39,6 @@ module('Integration | Component | ldap | Page::Configuration', function (hooks) 
       ...this.server.create('ldap-config'),
     });
     this.config = this.store.peekRecord('ldap/config', 'ldap-test');
-
-    this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.backend.id },
-    ];
 
     this.renderComponent = () => {
       return render(

--- a/ui/tests/integration/components/ldap/page/overview-test.js
+++ b/ui/tests/integration/components/ldap/page/overview-test.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupEngine } from 'ember-engines/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { createSecretsEngine, generateBreadcrumbs } from 'vault/tests/helpers/ldap';
+
+const selectors = {
+  configAction: '[data-test-toolbar-action="config"]',
+  configCta: '[data-test-config-cta]',
+};
+
+module('Integration | Component | ldap | Page::Overview', function (hooks) {
+  setupRenderingTest(hooks);
+  setupEngine(hooks, 'ldap');
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+
+    this.backend = createSecretsEngine(this.store);
+    this.breadcrumbs = generateBreadcrumbs(this.backend.id);
+
+    this.renderComponent = () => {
+      return render(
+        hbs`<Page::Overview
+          @promptConfig={{this.promptConfig}}
+          @backendModel={{this.backend}}
+          @roles={{this.roles}}
+          @libraries={{this.libraries}}
+          @breadcrumbs={{this.breadcrumbs}}
+        />`,
+        {
+          owner: this.engine,
+        }
+      );
+    };
+  });
+
+  test('it should render tab page header and config cta', async function (assert) {
+    this.promptConfig = true;
+
+    await this.renderComponent();
+
+    assert.dom('.title svg').hasClass('flight-icon-folder-users', 'LDAP icon renders in title');
+    assert.dom('.title').hasText('ldap-test', 'Mount path renders in title');
+    assert.dom(selectors.configAction).hasText('Configure LDAP', 'Correct toolbar action renders');
+    assert.dom(selectors.configCta).exists('Config cta renders');
+  });
+
+  // TODO:JLR add test to check that card components render once created and that Create role action renders in toolbar
+});


### PR DESCRIPTION
This PR adds the LDAP overview route and page component. The necessary card components will be added in a separate PR.

![image](https://github.com/hashicorp/vault/assets/24611656/68a719d2-5adb-4068-a723-e8eadb2604a2)

