### PR TITLE
Login View Fix for Safari

### DIFF
--- a/changelog/21582.txt
+++ b/changelog/21582.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes login screen display issue with Safari browser
+```

--- a/ui/app/styles/components/icon.scss
+++ b/ui/app/styles/components/icon.scss
@@ -77,6 +77,7 @@
 
 .brand-icon-large {
   width: 62px;
+  height: 62px; // without an explicit height the view breaks in Safari
 }
 
 .error-icon {


### PR DESCRIPTION
A display issue was discovered in Safari where on the login screen it appeared that it was not loading on smaller viewports. In reality, there was a style issue where the icon would stretch the height of the parent container and push the content down, potentially out of view. Adding an explicit height to the parent div of the icon fixes the issue. 

https://github.com/hashicorp/vault/assets/24611656/23372ea1-555a-4974-9325-d02b9b8f2c28

![image](https://github.com/hashicorp/vault/assets/24611656/3ad05370-c081-41c4-a9d8-f2e36081111b)

Resolves #21406
