### PR TITLE
fix sys/raft doc headings

### DIFF
--- a/website/content/api-docs/system/storage/raft.mdx
+++ b/website/content/api-docs/system/storage/raft.mdx
@@ -7,6 +7,11 @@ description: |-
   backend.
 ---
 
+# `/sys/storage/raft`
+
+The `/sys/storage/raft` endpoints are used to manage Vault's Raft storage
+backend.
+
 ## Join a raft cluster
 
 This endpoint joins a new server node to the Raft cluster. When using Shamir

--- a/website/content/api-docs/system/storage/raftautosnapshots.mdx
+++ b/website/content/api-docs/system/storage/raftautosnapshots.mdx
@@ -9,7 +9,7 @@ description: |-
   This is an Enterprise-only feature.
 ---
 
-# /sys/storage/raft/snapshot-auto
+# `/sys/storage/raft/snapshot-auto`
 
 The `/sys/storage/raft/snapshot-auto` endpoints are used to manage automated
 snapshots with Vault's Raft storage backend.

--- a/website/content/api-docs/system/storage/raftautosnapshots.mdx
+++ b/website/content/api-docs/system/storage/raftautosnapshots.mdx
@@ -9,6 +9,11 @@ description: |-
   This is an Enterprise-only feature.
 ---
 
+# /sys/storage/raft/snapshot-auto
+
+The `/sys/storage/raft/snapshot-auto` endpoints are used to manage automated
+snapshots with Vault's Raft storage backend.
+
 ## Create/update an automated snapshots config
 
 -> **Note**: This feature requires [Vault Enterprise](https://www.hashicorp.com/products/vault/)


### PR DESCRIPTION
The header for the raft and raft/snapshot-auto API docs don't match the format conventions for other pages:
https://developer.hashicorp.com/vault/api-docs/system/storage/raft
https://developer.hashicorp.com/vault/api-docs/system/storage/raftautosnapshots

Expected:
![Screenshot 2023-07-05 at 12 23 00 PM](https://github.com/hashicorp/vault/assets/43095669/36b34a3f-6d15-452a-b7e8-ef355fa59898)

![Screenshot 2023-07-05 at 12 23 21 PM](https://github.com/hashicorp/vault/assets/43095669/146a1a68-e767-4371-9097-ee25ac43bf6c)

Actual (to-be-fixed)
![Screenshot 2023-07-05 at 12 23 07 PM](https://github.com/hashicorp/vault/assets/43095669/545dd6c7-6a1b-42e4-91c6-10be3cd5b745)

![Screenshot 2023-07-05 at 12 23 15 PM](https://github.com/hashicorp/vault/assets/43095669/ae1ac3f4-486b-46ef-98d9-9ccd68cb640a)
