### PR TITLE
Fix link to API Explorer in console 

### DIFF
--- a/ui/app/components/console/ui-panel.js
+++ b/ui/app/components/console/ui-panel.js
@@ -51,6 +51,7 @@ export default Component.extend({
     this.set('inputValue', '');
     const service = this.console;
     let serviceArgs;
+
     if (
       executeUICommand(command, (args) => this.logAndOutput(args), {
         api: () => this.routeToExplore.perform(command),

--- a/ui/app/components/console/ui-panel.js
+++ b/ui/app/components/console/ui-panel.js
@@ -51,7 +51,6 @@ export default Component.extend({
     this.set('inputValue', '');
     const service = this.console;
     let serviceArgs;
-
     if (
       executeUICommand(command, (args) => this.logAndOutput(args), {
         api: () => this.routeToExplore.perform(command),
@@ -115,7 +114,7 @@ export default Component.extend({
       content = `Welcome to the Vault API explorer! \nWe've filtered the list of endpoints for '${filter}'.`;
     }
     try {
-      yield this.router.transitionTo('vault.cluster.open-api-explorer.index', {
+      yield this.router.transitionTo('vault.cluster.tools.open-api-explorer', {
         queryParams: { filter },
       });
       this.logAndOutput(null, {


### PR DESCRIPTION
In [this PR](https://github.com/hashicorp/vault/pull/21578), I missed the hardcoded route link in the console. The "api" keyword wasn't working in the console, now it is. 