### PR TITLE
[QT-576] Optimize build workflow (#21486)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,6 +5,15 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels:
     - small
+    - medium
     - large
     - ondemand
-
+    - disk_gb=64
+    - os=linux
+    - type=m5.2xlarge
+    - type=c6a.xlarge
+    - type=c6a.4xlarge
+    - ubuntu-20.04
+    - custom-linux-small-vault-latest
+    - custom-linux-medium-vault-latest
+    - custom-linux-xl-vault-latest

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,15 +1,14 @@
-
 name: Lint GitHub Actions Workflows
 on:
-  push:
   pull_request:
     paths:
-    - '.github/**'
+      - '.github/**'
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: "Check workflow files"
         uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint@sha256:93834930f56ca380be3e9a3377670d7aa5921be251b9c774891a39b3629b83b8

--- a/.github/workflows/build-vault-oss.yml
+++ b/.github/workflows/build-vault-oss.yml
@@ -24,6 +24,12 @@ on:
       goarch:
         required: true
         type: string
+      go-cache:
+        required: true
+        type: string
+      go-mod-cache:
+        required: true
+        type: string
       go-tags:
         type: string
       go-version:
@@ -34,24 +40,44 @@ on:
       vault-version:
         type: string
         required: true
+      web-ui-cache-key:
+        type: string
+        required: true
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: custom-linux-xl-vault-latest
     name: Vault ${{ inputs.goos }} ${{ inputs.goarch }} v${{ inputs.vault-version }}
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: ${{ inputs.go-version }}
-      - name: Set up node and yarn
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+          cache: false # Use our own caching strategy for better cross platform support
+      - name: Set up Go cache key tags
+        id: cache-key-tags
+        run: echo "gotags=$(echo ${{ inputs.go-tags }} | tr ' ' '-')" >> "$GITHUB_ENV"
+      - name: Set up Go cache
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
-          node-version-file: './ui/package.json'
-          cache: yarn
-          cache-dependency-path: ui/yarn.lock
-      - name: Build UI
-        run: make ci-build-ui
+          path: |
+            ${{ inputs.go-cache }}
+            ${{ inputs.go-mod-cache }}
+          # Manage the Go cache for each build workflow individually. This ensures that only relevant
+          # module and build cache for that specific combination kept. This helps reduce our cache
+          # download and speeds up compiling because the build cache is always preserved.
+          key: go-${{ inputs.go-version }}-${{ inputs.goos }}-${{ inputs.goarch }}-${{ env.gotags }}-${{ hashFiles('**/go.sum') }}
+          # We intentionally omit partial restore keys to ensure that we always create a new cache
+          # if we don't get a hit. That ensures that we only keep up-to-date modules and build cache.
+      - name: Restore UI from cache
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+          path: http/web_ui
+          # Only restore the UI asset cache if we haven't modified anything in the ui directory.
+          # Never do a partial restore of the web_ui if we don't get a cache hit.
+          key: ${{ inputs.web-ui-cache-key }}
       - name: Build Vault
         env:
           CGO_ENABLED: ${{ inputs.cgo-enabled }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       is_docs_change: ${{ steps.get-changeddir.outputs.is_docs_change }}
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Use fetch depth 0 for comparing changes to base branch
@@ -46,14 +46,24 @@ jobs:
     outputs:
       build-date: ${{ steps.get-metadata.outputs.build-date }}
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
-      go-version: ${{ steps.get-metadata.outputs.go-version }}
+      go-cache: ${{ steps.get-metadata.outputs.go-cache }}
+      go-mod-cache: ${{ steps.get-metadata.outputs.go-mod-cache }}
+      go-version: ${{ steps.go-version.outputs.go-version }}
       matrix-test-group: ${{ steps.get-metadata.outputs.matrix-test-group }}
       package-name: ${{ steps.get-metadata.outputs.package-name }}
       vault-revision: ${{ steps.get-metadata.outputs.vault-revision }}
       vault-version: ${{ steps.get-metadata.outputs.vault-version }}
       vault-base-version: ${{ steps.get-metadata.outputs.vault-base-version }}
+      web-ui-cache-key: ui-${{ steps.get-metadata.outputs.web-ui-cache-key }}
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Determine Go version
+        id: go-version
+        run: echo "go-version=$(cat ./.go-version)" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          go-version: ${{ steps.go-version.outputs.go-version }}
+          cache: false
       - name: Get metadata
         id: get-metadata
         env:
@@ -64,11 +74,13 @@ jobs:
         run: |
           # shellcheck disable=SC2129
           echo "build-date=$(make ci-get-date)" >> "$GITHUB_OUTPUT"
-          echo "go-version=$(cat ./.go-version)" >> "$GITHUB_OUTPUT"
+          echo "go-cache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "go-mod-cache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
           echo "matrix-test-group=$(make ci-get-matrix-group-id)" >> "$GITHUB_OUTPUT"
           echo "package-name=vault" >> "$GITHUB_OUTPUT"
           echo "vault-base-version=$(make ci-get-version-base)" >> "$GITHUB_OUTPUT"
           echo "vault-revision=$(make ci-get-revision)" >> "$GITHUB_OUTPUT"
+          echo "web-ui-cache-key=$(git ls-tree HEAD ui --object-only)" >> "$GITHUB_OUTPUT"
           echo "vault-version=$(make ci-get-version)" >> "$GITHUB_OUTPUT"
       - uses: hashicorp/actions-generate-metadata@v1
         id: generate-metadata-file
@@ -81,9 +93,42 @@ jobs:
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
           if-no-files-found: error
 
+  build-ui:
+    name: UI
+    runs-on: custom-linux-xl-vault-latest
+    outputs:
+      cache-key: ui-${{ steps.ui-hash.outputs.ui-hash }}
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Get UI hash
+        id: ui-hash
+        run: echo "ui-hash=$(git ls-tree HEAD ui --object-only)" >> "$GITHUB_OUTPUT"
+      - name: Set up UI asset cache
+        id: cache-ui-assets
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          enableCrossOsArchive: true
+          lookup-only: true
+          path: http/web_ui
+          # Only restore the UI asset cache if we haven't modified anything in the ui directory.
+          # Never do a partial restore of the web_ui if we don't get a cache hit.
+          key: ui-${{ steps.ui-hash.outputs.ui-hash }}
+      - if: steps.cache-ui-assets.outputs.cache-hit != 'true'
+        name: Set up node and yarn
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version-file: ui/package.json
+          cache: yarn
+          cache-dependency-path: ui/yarn.lock
+      - if: steps.cache-ui-assets.outputs.cache-hit != 'true'
+        name: Build UI
+        run: make ci-build-ui
+
   build-other:
     name: Other
-    needs: product-metadata
+    needs:
+      - product-metadata
+      - build-ui
     strategy:
       matrix:
         goos: [freebsd, windows, netbsd, openbsd, solaris]
@@ -101,15 +146,20 @@ jobs:
       create-packages: false
       goarch: ${{ matrix.goarch }}
       goos: ${{ matrix.goos }}
+      go-cache: ${{ needs.product-metadata.outputs.go-cache }}
+      go-mod-cache: ${{ needs.product-metadata.outputs.go-mod-cache }}
       go-tags: ui
       go-version: ${{ needs.product-metadata.outputs.go-version }}
       package-name: ${{ needs.product-metadata.outputs.package-name }}
+      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
       vault-version: ${{ needs.product-metadata.outputs.vault-version }}
     secrets: inherit
 
   build-linux:
     name: Linux
-    needs: product-metadata
+    needs:
+      - product-metadata
+      - build-ui
     strategy:
       matrix:
         goos: [linux]
@@ -119,15 +169,20 @@ jobs:
     with:
       goarch: ${{ matrix.goarch }}
       goos: ${{ matrix.goos }}
+      go-cache: ${{ needs.product-metadata.outputs.go-cache }}
+      go-mod-cache: ${{ needs.product-metadata.outputs.go-mod-cache }}
       go-tags: ui
       go-version: ${{ needs.product-metadata.outputs.go-version }}
       package-name: ${{ needs.product-metadata.outputs.package-name }}
+      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
       vault-version: ${{ needs.product-metadata.outputs.vault-version }}
     secrets: inherit
 
   build-darwin:
     name: Darwin
-    needs: product-metadata
+    needs:
+      - product-metadata
+      - build-ui
     strategy:
       matrix:
         goos: [darwin]
@@ -138,9 +193,12 @@ jobs:
       create-packages: false
       goarch: ${{ matrix.goarch }}
       goos: ${{ matrix.goos }}
-      go-tags: ui netcgo
+      go-cache: ${{ needs.product-metadata.outputs.go-cache }}
+      go-mod-cache: ${{ needs.product-metadata.outputs.go-mod-cache }}
+      go-tags: ui
       go-version: ${{ needs.product-metadata.outputs.go-version }}
       package-name: ${{ needs.product-metadata.outputs.package-name }}
+      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
       vault-version: ${{ needs.product-metadata.outputs.vault-version }}
     secrets: inherit
 
@@ -154,7 +212,7 @@ jobs:
       matrix:
         arch: [arm, arm64, 386, amd64]
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: hashicorp/actions-docker-build@v1
         with:
           version: ${{ needs.product-metadata.outputs.vault-version }}
@@ -175,7 +233,7 @@ jobs:
       matrix:
         arch: [amd64]
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: hashicorp/actions-docker-build@v1
         with:
           version: ${{ needs.product-metadata.outputs.vault-version }}

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # by default the checkout action doesn't checkout all branches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     # This is insufficient for our needs, since we're skipping stuff on PRs in
     # draft mode.  By adding the ready_for_review type, when a draft pr is marked
     # ready, we run everything, including the stuff we'd have skipped up until now.
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
@@ -26,44 +26,44 @@ jobs:
       enterprise: ${{ steps.setup-outputs.outputs.enterprise }}
       go-build-tags: ${{ steps.setup-outputs.outputs.go-build-tags }}
     steps:
-    - id: setup-outputs
-      name: Setup outputs
-      run: |
-        github_repository="${{ github.repository }}"
+      - id: setup-outputs
+        name: Setup outputs
+        run: |
+          github_repository="${{ github.repository }}"
 
-        if [ "${github_repository##*/}" == "vault-enterprise" ] ; then
-          # shellcheck disable=SC2129
-          echo 'compute-tiny=["self-hosted","ondemand","linux","type=m5.large"]' >> "$GITHUB_OUTPUT"
-          echo 'compute-standard=["self-hosted","ondemand","linux","type=m5.xlarge"]' >> "$GITHUB_OUTPUT"
-          echo 'compute-larger=["self-hosted","ondemand","linux","type=m5.2xlarge"]' >> "$GITHUB_OUTPUT"
-          echo 'compute-huge=["self-hosted","ondemand","linux","type=m5.4xlarge"]' >> "$GITHUB_OUTPUT"
-          echo 'enterprise=1' >> "$GITHUB_OUTPUT"
-          echo 'go-build-tags=ent,enterprise' >> "$GITHUB_OUTPUT"
-        else
-          # shellcheck disable=SC2129
-          echo 'compute-tiny="ubuntu-latest"' >> "$GITHUB_OUTPUT"                         #  2 cores,   7 GB RAM,   14 GB SSD
-          echo 'compute-standard="custom-linux-small-vault-latest"' >> "$GITHUB_OUTPUT"   #  8 cores,  32 GB RAM,  300 GB SSD
-          echo 'compute-larger="custom-linux-medium-vault-latest"' >> "$GITHUB_OUTPUT"    # 16 cores,  64 GB RAM,  600 GB SSD
-          echo 'compute-huge="custom-linux-xl-vault-latest"' >> "$GITHUB_OUTPUT"          # 32-cores, 128 GB RAM, 1200 GB SSD
-          echo 'enterprise=' >> "$GITHUB_OUTPUT"
-          echo 'go-build-tags=' >> "$GITHUB_OUTPUT"
-        fi
+          if [ "${github_repository##*/}" == "vault-enterprise" ] ; then
+            # shellcheck disable=SC2129
+            echo 'compute-tiny=["self-hosted","ondemand","linux","type=m5.large"]' >> "$GITHUB_OUTPUT"
+            echo 'compute-standard=["self-hosted","ondemand","linux","type=m5.xlarge"]' >> "$GITHUB_OUTPUT"
+            echo 'compute-larger=["self-hosted","ondemand","linux","type=m5.2xlarge"]' >> "$GITHUB_OUTPUT"
+            echo 'compute-huge=["self-hosted","ondemand","linux","type=m5.4xlarge"]' >> "$GITHUB_OUTPUT"
+            echo 'enterprise=1' >> "$GITHUB_OUTPUT"
+            echo 'go-build-tags=ent,enterprise' >> "$GITHUB_OUTPUT"
+          else
+            # shellcheck disable=SC2129
+            echo 'compute-tiny="ubuntu-latest"' >> "$GITHUB_OUTPUT"                         #  2 cores,   7 GB RAM,   14 GB SSD
+            echo 'compute-standard="custom-linux-small-vault-latest"' >> "$GITHUB_OUTPUT"   #  8 cores,  32 GB RAM,  300 GB SSD
+            echo 'compute-larger="custom-linux-medium-vault-latest"' >> "$GITHUB_OUTPUT"    # 16 cores,  64 GB RAM,  600 GB SSD
+            echo 'compute-huge="custom-linux-xl-vault-latest"' >> "$GITHUB_OUTPUT"          # 32-cores, 128 GB RAM, 1200 GB SSD
+            echo 'enterprise=' >> "$GITHUB_OUTPUT"
+            echo 'go-build-tags=' >> "$GITHUB_OUTPUT"
+          fi
   semgrep:
     name: Semgrep
     needs:
-    - setup
+      - setup
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     container:
       image: returntocorp/semgrep@sha256:ffc6f3567654f9431456d49fd059dfe548f007c494a7eb6cd5a1a3e50d813fb3
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-    - name: Run Semgrep Rules
-      id: semgrep
-      run: semgrep ci --include '*.go' --config 'tools/semgrep/ci'
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Run Semgrep Rules
+        id: semgrep
+        run: semgrep ci --include '*.go' --config 'tools/semgrep/ci'
   setup-go-cache:
     name: Go Caches
     needs:
-    - setup
+      - setup
     uses: ./.github/workflows/setup-go-cache.yml
     with:
       runs-on: ${{ needs.setup.outputs.compute-standard }}
@@ -71,65 +71,69 @@ jobs:
   fmt:
     name: Check Format
     needs:
-    - setup
+      - setup
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-    - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-      with:
-        go-version-file: ./.go-version
-        cache: true
-    - id: format
-      run: |
-        echo "Using gofumpt version $(go run mvdan.cc/gofumpt -version)"
-        make fmt
-        if ! git diff --exit-code; then
-          echo "Code has formatting errors. Run 'make fmt' to fix"
-          exit 1
-        fi
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          go-version-file: ./.go-version
+          cache: true
+      - id: format
+        run: |
+          echo "Using gofumpt version $(go run mvdan.cc/gofumpt -version)"
+          make fmt
+          if ! git diff --exit-code; then
+            echo "Code has formatting errors. Run 'make fmt' to fix"
+            exit 1
+          fi
   diff-oss-ci:
     name: Diff OSS
     needs:
-    - setup
+      - setup
     if: ${{ needs.setup.outputs.enterprise != '' && github.base_ref != '' }}
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      with:
-        fetch-depth: 0
-    - id: determine-branch
-      run: |
-        branch="${{ github.base_ref }}"
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          fetch-depth: 0
+      - id: determine-branch
+        run: |
+          branch="${{ github.base_ref }}"
 
-        if [[ $branch = release/* ]] ; then
-          branch=${branch%%+ent}
+          if [[ $branch = release/* ]] ; then
+            branch=${branch%%+ent}
 
-          # Add OSS remote
-          git config --global user.email "github-team-secret-vault-core@hashicorp.com"
-          git config --global user.name "hc-github-team-secret-vault-core"
-          git remote add oss https://github.com/hashicorp/vault.git
-          git fetch oss "$branch"
+            # Add OSS remote
+            git config --global user.email "github-team-secret-vault-core@hashicorp.com"
+            git config --global user.name "hc-github-team-secret-vault-core"
+            git remote add oss https://github.com/hashicorp/vault.git
+            git fetch oss "$branch"
 
-          branch="oss/$branch"
-        else
-          branch="origin/$branch"
-        fi
+            branch="oss/$branch"
+          else
+            branch="origin/$branch"
+          fi
 
-        echo "BRANCH=$branch" >> "$GITHUB_OUTPUT"
-    - id: diff
-      run: |
-        ./.github/scripts/oss-diff.sh ${{ steps.determine-branch.outputs.BRANCH }} HEAD
+          echo "BRANCH=$branch" >> "$GITHUB_OUTPUT"
+      - id: diff
+        run: |
+          ./.github/scripts/oss-diff.sh ${{ steps.determine-branch.outputs.BRANCH }} HEAD
   test-go:
     name: Run Go tests
     needs:
-    - setup
-    - setup-go-cache
-    # Don't run this job for PR branches starting with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
+      - setup
+      - setup-go-cache
+    # Don't run this job for PR branches starting with:
+    # 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
+    # OR
+    # the 'docs' label is present
     if: |
       !startsWith(github.head_ref, 'ui/') &&
       !startsWith(github.head_ref, 'backport/ui/') &&
       !startsWith(github.head_ref, 'docs/') &&
-      !startsWith(github.head_ref, 'backport/docs/')
+      !startsWith(github.head_ref, 'backport/docs/') &&
+      !contains(github.event.pull_request.labels.*.name, 'docs')
     uses: ./.github/workflows/test-go.yml
     with:
       # The regular Go tests use an extra runner to execute the
@@ -144,15 +148,19 @@ jobs:
   test-go-race:
     name: Run Go tests with data race detection
     needs:
-    - setup
-    - setup-go-cache
-    # Don't run this job for PR branches starting with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
+      - setup
+      - setup-go-cache
+    # Don't run this job for PR branches starting with:
+    # 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
+    # OR
+    # the 'docs' label is present
     if: |
       github.event.pull_request.draft == false &&
       !startsWith(github.head_ref, 'ui/') &&
       !startsWith(github.head_ref, 'backport/ui/') &&
       !startsWith(github.head_ref, 'docs/') &&
-      !startsWith(github.head_ref, 'backport/docs/')
+      !startsWith(github.head_ref, 'backport/docs/') &&
+      !contains(github.event.pull_request.labels.*.name, 'docs')
     uses: ./.github/workflows/test-go.yml
     with:
       total-runners: 16
@@ -165,20 +173,25 @@ jobs:
       go-build-tags: ${{ needs.setup.outputs.go-build-tags }}
       runs-on: ${{ needs.setup.outputs.compute-huge }}
       enterprise: ${{ needs.setup.outputs.enterprise }}
+      name: "-race"
     secrets: inherit
   test-go-fips:
     name: Run Go tests with FIPS configuration
-    # Only run this job for the enterprise repo if the PR branch doesn't start with 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
+    # Only run this job for the enterprise repo if the PR branch doesn't start with:
+    # 'ui/', 'backport/ui/', 'docs/', or 'backport/docs/'
+    # OR
+    # the 'docs' label is not present
     if: |
       github.event.pull_request.draft == false &&
       needs.setup.outputs.enterprise == 1 &&
       !startsWith(github.head_ref, 'ui/') &&
       !startsWith(github.head_ref, 'backport/ui/') &&
       !startsWith(github.head_ref, 'docs/') &&
-      !startsWith(github.head_ref, 'backport/docs/')
+      !startsWith(github.head_ref, 'backport/docs/') &&
+      !contains(github.event.pull_request.labels.*.name, 'docs')
     needs:
-    - setup
-    - setup-go-cache
+      - setup
+      - setup-go-cache
     uses: ./.github/workflows/test-go.yml
     with:
       total-runners: 16
@@ -190,6 +203,7 @@ jobs:
       go-build-tags: '${{ needs.setup.outputs.go-build-tags }},deadlock,cgo,fips,fips_140_2'
       runs-on: ${{ needs.setup.outputs.compute-larger }}
       enterprise: ${{ needs.setup.outputs.enterprise }}
+      name: "-fips"
     secrets: inherit
   test-ui:
     name: Test UI
@@ -202,101 +216,99 @@ jobs:
       startsWith(github.ref_name, 'release/') ||
       startsWith(github.head_ref, 'ui/') ||
       startsWith(github.head_ref, 'backport/ui/') ||
-      startsWith(github.head_ref, 'merge') || 
+      startsWith(github.head_ref, 'merge') ||
       contains(github.event.pull_request.labels.*.name, 'ui')
     needs:
-    - setup
+      - setup
     permissions:
       id-token: write
       contents: read
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-larger) }}
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-    - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-      with:
-        go-version-file: ./.go-version
-        cache: true
-    # Setup node.js without caching to allow running npm install -g yarn (next step)
-    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-      with:
-        node-version-file: './ui/package.json'
-    - id: install-yarn
-      run: |
-        npm install -g yarn
-    # Setup node.js with caching using the yarn.lock file
-    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-      with:
-        node-version-file: './ui/package.json'
-        cache: yarn
-        cache-dependency-path: ui/yarn.lock
-    - id: install-browser
-      uses: browser-actions/setup-chrome@c485fa3bab6be59dce18dbc18ef6ab7cbc8ff5f1 # v1.2.0
-    - id: ui-dependencies
-      name: ui-dependencies
-      working-directory: ./ui
-      run: |
-        yarn install --frozen-lockfile
-        npm rebuild node-sass
-    - id: vault-auth
-      name: Authenticate to Vault
-      if: github.repository == 'hashicorp/vault-enterprise'
-      run: vault-auth
-    - id: secrets
-      name: Fetch secrets
-      if: github.repository == 'hashicorp/vault-enterprise'
-      uses: hashicorp/vault-action@130d1f5f4fe645bb6c83e4225c04d64cfb62de6e
-      with:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          go-version-file: ./.go-version
+          cache: true
+      # Setup node.js without caching to allow running npm install -g yarn (next step)
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version-file: './ui/package.json'
+      - id: install-yarn
+        run: |
+          npm install -g yarn
+      # Setup node.js with caching using the yarn.lock file
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version-file: './ui/package.json'
+          cache: yarn
+          cache-dependency-path: ui/yarn.lock
+      - id: install-browser
+        uses: browser-actions/setup-chrome@c485fa3bab6be59dce18dbc18ef6ab7cbc8ff5f1 # v1.2.0
+      - id: ui-dependencies
+        name: ui-dependencies
+        working-directory: ./ui
+        run: |
+          yarn install --frozen-lockfile
+          npm rebuild node-sass
+      - id: vault-auth
+        name: Authenticate to Vault
+        if: github.repository == 'hashicorp/vault-enterprise'
+        run: vault-auth
+      - id: secrets
+        name: Fetch secrets
+        if: github.repository == 'hashicorp/vault-enterprise'
+        uses: hashicorp/vault-action@130d1f5f4fe645bb6c83e4225c04d64cfb62de6e
+        with:
           url: ${{ steps.vault-auth.outputs.addr }}
           caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
           token: ${{ steps.vault-auth.outputs.token }}
           secrets: |
             kv/data/github/hashicorp/vault-enterprise/github-token token | PRIVATE_REPO_GITHUB_TOKEN;
             kv/data/github/hashicorp/vault-enterprise/license license_1 | VAULT_LICENSE;
-    - id: setup-git
-      name: Setup Git
-      if: github.repository == 'hashicorp/vault-enterprise'
-      env:
-        PRIVATE_REPO_GITHUB_TOKEN: ${{ steps.secrets.outputs.PRIVATE_REPO_GITHUB_TOKEN }}
-      run: |
-        git config --global url."https://hc-github-team-secure-vault-core:${PRIVATE_REPO_GITHUB_TOKEN}@github.com".insteadOf https://github.com
-    - id: build-go-dev
-      name: build-go-dev
-      run: |
-        rm -rf ./pkg
-        mkdir ./pkg
+      - id: setup-git
+        name: Setup Git
+        if: github.repository == 'hashicorp/vault-enterprise'
+        run: |
+          git config --global url."https://${{ steps.secrets.outputs.PRIVATE_REPO_GITHUB_TOKEN }}@github.com".insteadOf https://github.com
+      - id: build-go-dev
+        name: build-go-dev
+        run: |
+          rm -rf ./pkg
+          mkdir ./pkg
 
-        make ci-bootstrap dev
-    - id: test-ui
-      name: test-ui
-      env:
-        VAULT_LICENSE: ${{ steps.secrets.outputs.VAULT_LICENSE }}
-      run: |
-        export PATH="${PWD}/bin:${PATH}"
+          make ci-bootstrap dev
+      - id: test-ui
+        name: test-ui
+        env:
+          VAULT_LICENSE: ${{ steps.secrets.outputs.VAULT_LICENSE }}
+        run: |
+          export PATH="${PWD}/bin:${PATH}"
 
-        if [ "${{ github.repository }}" == 'hashicorp/vault' ] ; then
-          export VAULT_LICENSE="${{ secrets.VAULT_LICENSE }}"
-        fi
+          if [ "${{ github.repository }}" == 'hashicorp/vault' ] ; then
+            export VAULT_LICENSE="${{ secrets.VAULT_LICENSE }}"
+          fi
 
-        # Run Ember tests
-        cd ui
-        mkdir -p test-results/qunit
-        yarn test:oss
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-      with:
-        name: test-results-ui
-        path: ui/test-results
-      if: always()
-    - uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f # TSCCR: no entry for repository "test-summary/action"
-      with:
-        paths: "ui/test-results/qunit/results.xml"
-        show: "fail"
-      if: always()
+          # Run Ember tests
+          cd ui
+          mkdir -p test-results/qunit
+          yarn test:oss
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: test-results-ui
+          path: ui/test-results
+        if: success() || failure()
+      - uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f    # TSCCR: no entry for repository "test-summary/action"
+        with:
+          paths: "ui/test-results/qunit/results.xml"
+          show: "fail"
+        if: always()
   tests-completed:
     needs:
-    - setup
-    - setup-go-cache
-    - test-go
-    - test-ui
+      - setup
+      - setup-go-cache
+      - test-go
+      - test-ui
     # We force a failure if any of the dependent jobs fail,
     # this is a workaround for the issue reported https://github.com/actions/runner/issues/2566
     if: |
@@ -305,5 +317,27 @@ jobs:
       contains(needs.*.result, 'failure'))
     runs-on: ${{ fromJSON(needs.setup.outputs.compute-tiny) }}
     steps:
-    - run: |
-        tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)'
+      - run: |
+          tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)'
+
+  notify-tests-completed-failures:
+    if: ${{ always() && needs.tests-completed.result == 'failure' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+    needs:
+      - tests-completed
+    steps:
+      - name: send-notification
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+        # We intentionally aren't using the following here since it's from an internal repo
+        # uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
+          payload: |
+            {"text":"OSS test failures on ${{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":rotating_light: OSS test failures :rotating_light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"test(s) failed on ${{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}

--- a/.github/workflows/drepecated-functions-checker.yml
+++ b/.github/workflows/drepecated-functions-checker.yml
@@ -12,11 +12,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           fetch-depth: 0 # by default the checkout action doesn't checkout all branches
       - name: Setup Go
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: ./.go-version
           cache: true

--- a/.github/workflows/enos-fmt.yml
+++ b/.github/workflows/enos-fmt.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false

--- a/.github/workflows/enos-release-testing-oss.yml
+++ b/.github/workflows/enos-release-testing-oss.yml
@@ -15,7 +15,7 @@ jobs:
       vault-revision: ${{ steps.get-metadata.outputs.vault-revision }}
       vault-version: ${{ steps.get-metadata.outputs.vault-version }}
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           # Check out the repository at the same Git SHA that was used to create
           # the artifacts to get the correct metadata.

--- a/.github/workflows/enos-run-k8s.yml
+++ b/.github/workflows/enos-run-k8s.yml
@@ -31,7 +31,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2
         with:

--- a/.github/workflows/godoc-test-checker.yml
+++ b/.github/workflows/godoc-test-checker.yml
@@ -11,11 +11,11 @@ jobs:
   godoc-test-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           fetch-depth: 0
       - name: Set Up Go
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           cache: true
           go-version-file: ./.go-version

--- a/.github/workflows/milestone-checker.yml
+++ b/.github/workflows/milestone-checker.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           repository: "grafana/grafana-github-actions"
           path: ./actions

--- a/.github/workflows/oss.yml
+++ b/.github/workflows/oss.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: github.event.pull_request != null
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - if: github.event.pull_request != null
         uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changes
@@ -68,7 +68,7 @@ jobs:
       - if: github.event.pull_request != null && steps.changes.outputs.ui == 'true'
         run: echo "PROJECT=171" >> "$GITHUB_ENV"
 
-      - uses: actions/add-to-project@v0.3.0 # TSCCR: no entry for repository "actions/add-to-project"
+      - uses: actions/add-to-project@v0.3.0      # TSCCR: no entry for repository "actions/add-to-project"
         with:
           project-url: https://github.com/orgs/hashicorp/projects/${{ env.PROJECT }}
           github-token: ${{ secrets.TRIAGE_GITHUB_TOKEN }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -13,20 +13,20 @@ jobs:
     runs-on: ['linux', 'large']
     if: ${{ github.actor != 'dependabot[bot]' || github.actor != 'hc-github-team-secure-vault-core' }}
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
     - name: Set up Go
-      uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+      uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
         go-version: 1.18
 
     - name: Set up Python
-      uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b # v4.6.0
+      uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4.6.1
       with:
         python-version: 3.x
 
     - name: Clone Security Scanner repo
-      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       with:
         repository: hashicorp/security-scanner
         token: ${{ secrets.HASHIBOT_PRODSEC_GITHUB_TOKEN }}
@@ -77,6 +77,6 @@ jobs:
         cat results.sarif
 
     - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@9a866ed4524fc3422c3af1e446dab8efa3503411 # codeql-bundle-20230418
+      uses: github/codeql-action/upload-sarif@cdcdbb579706841c47f7063dda365e292e5cad7a # codeql-bundle-v2.13.4
       with:
         sarif_file: results.sarif

--- a/.github/workflows/setup-go-cache.yml
+++ b/.github/workflows/setup-go-cache.yml
@@ -8,10 +8,10 @@ jobs:
   setup-go-cache:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     - id: setup-go
       name: Setup go
-      uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+      uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
         go-version-file: ./.go-version
         cache: true

--- a/.github/workflows/stable-website.yaml
+++ b/.github/workflows/stable-website.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Cherry pick to stable-website branch
     steps:
     - name: Checkout
-      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       with:
         ref: stable-website
     - run: |

--- a/.github/workflows/test-ci-bootstrap.yml
+++ b/.github/workflows/test-ci-bootstrap.yml
@@ -24,11 +24,11 @@ jobs:
       TF_VAR_aws_ssh_public_key: ${{ secrets.SSH_KEY_PUBLIC_CI }}
       TF_TOKEN_app_terraform_io: ${{ secrets.TF_API_TOKEN }}
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}

--- a/.github/workflows/test-ci-cleanup.yml
+++ b/.github/workflows/test-ci-cleanup.yml
@@ -11,7 +11,7 @@ jobs:
       regions: ${{steps.setup.outputs.regions}}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Configure AWS credentials
         id: aws-configure
-        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}
@@ -49,7 +49,7 @@ jobs:
           role-skip-session-tagging: true
           role-duration-seconds: 3600
           mask-aws-account-id: false
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Configure
         run: |
           cp enos/ci/aws-nuke.yml .
@@ -75,7 +75,7 @@ jobs:
         region: ${{ fromJSON(needs.setup.outputs.regions) }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}

--- a/.github/workflows/test-enos-scenario-ui.yml
+++ b/.github/workflows/test-enos-scenario-ui.yml
@@ -35,7 +35,7 @@ jobs:
       runs-on: ${{ steps.get-metadata.outputs.runs-on }}
       vault_edition: ${{ steps.get-metadata.outputs.vault_edition }}
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - id: get-metadata
         env:
           IS_ENT: ${{ startsWith(github.event.repository.name, 'vault-enterprise' ) }}
@@ -67,9 +67,9 @@ jobs:
       GOPRIVATE: github.com/hashicorp
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Set Up Go
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: ./.go-version
       - uses: hashicorp/action-setup-enos@v1
@@ -109,7 +109,7 @@ jobs:
         run: |
           echo "Installed Chrome Version = [$(chrome --version 2> /dev/null || google-chrome --version 2> /dev/null || google-chrome-stable --version 2> /dev/null)]"
       - name: Configure AWS credentials from Test account
-        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -32,6 +32,22 @@ on:
         description: A comma-separated list of additional build tags to consider satisfied during the build.
         required: false
         type: string
+      name:
+        description: A suffix to append to archived test results
+        required: false
+        default: ''
+        type: string
+      go-test-parallelism:
+        description: The parallelism parameter for Go tests
+        required: false
+        default: 20
+        type: number
+      timeout-minutes:
+        description: The maximum number of minutes that this workflow should run 
+        required: false
+        default: 60 
+        type: number
+
 
 env: ${{ fromJSON(inputs.env-vars) }}
 
@@ -43,8 +59,8 @@ jobs:
       id-token: write  # Note: this permission is explicitly required for Vault auth
       contents: read
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-    - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
         go-version-file: ./.go-version
         cache: true
@@ -111,10 +127,10 @@ jobs:
         runner-index: ${{ fromJSON(needs.runner-indexes.outputs.runner-indexes) }}
     env:
       GOPRIVATE: github.com/hashicorp/*
-      TIMEOUT_IN_MINUTES: 60
+      TIMEOUT_IN_MINUTES: ${{ inputs.timeout-minutes }} 
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: ./.go-version
           cache: true
@@ -217,7 +233,7 @@ jobs:
               -- \
               -tags "${{ inputs.go-build-tags }}" \
               -timeout=${{ env.TIMEOUT_IN_MINUTES }}m \
-              -parallel=20 \
+              -parallel=${{ inputs.go-test-parallelism }} \
               ${{ inputs.extra-flags }} \
                 \
               ${test_packages[${{ matrix.runner-index }}]}
@@ -240,11 +256,11 @@ jobs:
       - name: Archive test results
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: test-results-${{ matrix.runner-index }}
+          name: test-results${{ inputs.name }}-${{ matrix.runner-index }}
           path: test-results/
         if: success() || failure() 
       - name: Create a summary of tests
-        uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f # TSCCR: no entry for repository "test-summary/action"
+        uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f    # TSCCR: no entry for repository "test-summary/action"
         with:
           paths: "test-results/go-test/results.xml"
           show: "fail"

--- a/.github/workflows/test-run-acc-tests-for-path.yml
+++ b/.github/workflows/test-run-acc-tests-for-path.yml
@@ -20,9 +20,9 @@ jobs:
   go-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Set Up Go
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: ./.go-version
       - run: go test -v ./${{ inputs.path }}/... 2>&1 | tee ${{ inputs.name }}.txt

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -72,7 +72,7 @@ jobs:
       MATRIX_FILE: ./.github/enos-run-matrices/${{ inputs.matrix-file-name }}.json
       MATRIX_TEST_GROUP: ${{ inputs.matrix-test-group }}
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           ref: ${{ inputs.vault-revision }}
       - id: metadata
@@ -106,13 +106,13 @@ jobs:
       ENOS_VAR_vault_license_path: ./support/vault.hclic
       ENOS_DEBUG_DATA_ROOT_DIR: /tmp/enos-debug-data
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: hashicorp/setup-terraform@v2
         with:
           # the Terraform wrapper will break Terraform execution in Enos because
           # it changes the output to text when we expect it to be JSON.
           terraform_wrapper: false
-      - uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+      - uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}


### PR DESCRIPTION
Improve our build workflow execution time by using custom runners, improved caching and conditional Web UI builds.

Runners
-------
We improve our build times[0] by using larger custom runners[1] when building the UI and Vault.

Caching
-------
We improve Vault caching by keeping a cache for each build job. This strategy has the following properties which should result in faster build times when `go.sum` hasn't been changed from prior builds, or when a pull request is retried or updated after a prior successful build:

* Builds will restore cached Go modules and Go build cache according to the Go version, platform, architecture, go tags, and hash of `go.sum` that relates to each individual build workflow. This reduces the amount of time it will take to download the cache on hits and upload the cache on misses.
* Parallel build workflows won't clobber each others build cache. This results in much faster compile times after cache hits because the Go compiler can reuse the platform, architecture, and tag specific build cache that it created on prior runs.
* Older modules and build cache will not be uploaded when creating a new cache. This should result in lean cache sizes on an ongoing basis.
* On cache misses we will have to upload our compressed module and build cache. This will slightly extend the build time for pull requests that modify `go.sum`.

Web UI
------
We no longer build the web UI in every build workflow. Instead we separate the UI building into its own workflow and cache the resulting assets. The same UI assets are restored from cache during build worklows. This strategy has the following properties:

* If the `ui` directory has not changed from prior builds we'll restore `http/web_ui` from cache and skip building the UI for no reason.
* We continue to use the built-in `yarn` caching functionality in `action/setup-node`. The default mode saves the `yarn` global cache. to improve UI build times if the cache has not been modified.

Changes
-------
* Add per platform/archicture Go module and build caching
* Move UI building into a separate job and cache the result
* Restore UI cache during build
* Pin workflows

Notes
-----
[0] https://hashicorp.atlassian.net/browse/QT-578
[1] https://github.com/hashicorp/vault/actions/runs/5415830307/jobs/9844829929