### PR TITLE
Introduce Experiment to Toggle Between Legacy Auditing Backends/EventLogger

### DIFF
--- a/changelog/21628.txt
+++ b/changelog/21628.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+audit: add core audit events experiment
+```

--- a/helper/experiments/experiments.go
+++ b/helper/experiments/experiments.go
@@ -3,10 +3,14 @@
 
 package experiments
 
-const VaultExperimentEventsAlpha1 = "events.alpha1"
+const (
+	VaultExperimentEventsAlpha1          = "events.alpha1"
+	VaultExperimentCoreAuditEventsAlpha1 = "core.audit.events.alpha1"
+)
 
 var validExperiments = []string{
 	VaultExperimentEventsAlpha1,
+	VaultExperimentCoreAuditEventsAlpha1,
 }
 
 // ValidExperiments exposes the list without exposing a mutable global variable.

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -12,6 +12,7 @@ import (
 
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/audit"
+	"github.com/hashicorp/vault/helper/experiments"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
@@ -155,7 +156,7 @@ func (c *Core) enableAudit(ctx context.Context, entry *MountEntry, updateStorage
 	c.audit = newTable
 
 	// Register the backend
-	c.auditBroker.Register(entry.Path, backend, entry.Local)
+	c.auditBroker.Register(entry.Path, backend, entry.Local, c.IsExperimentEnabled(experiments.VaultExperimentCoreAuditEventsAlpha1))
 	if c.logger.IsInfo() {
 		c.logger.Info("enabled audit backend", "path", entry.Path, "type", entry.Type)
 	}
@@ -208,7 +209,7 @@ func (c *Core) disableAudit(ctx context.Context, path string, updateStorage bool
 	c.audit = newTable
 
 	// Unmount the backend
-	c.auditBroker.Deregister(path)
+	c.auditBroker.Deregister(path, c.IsExperimentEnabled(experiments.VaultExperimentCoreAuditEventsAlpha1))
 	if c.logger.IsInfo() {
 		c.logger.Info("disabled audit backend", "path", path)
 	}
@@ -416,7 +417,7 @@ func (c *Core) setupAudits(ctx context.Context) error {
 		}
 
 		// Mount the backend
-		broker.Register(entry.Path, backend, entry.Local)
+		broker.Register(entry.Path, backend, entry.Local, c.IsExperimentEnabled(experiments.VaultExperimentCoreAuditEventsAlpha1))
 
 		successCount++
 	}

--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -40,20 +40,28 @@ func NewAuditBroker(log log.Logger) *AuditBroker {
 }
 
 // Register is used to add new audit backend to the broker
-func (a *AuditBroker) Register(name string, b audit.Backend, local bool) {
-	a.Lock()
-	defer a.Unlock()
-	a.backends[name] = backendEntry{
-		backend: b,
-		local:   local,
+func (a *AuditBroker) Register(name string, b audit.Backend, local bool, useEventLogger bool) {
+	if useEventLogger {
+		// TODO: Coming soon
+	} else {
+		a.Lock()
+		defer a.Unlock()
+		a.backends[name] = backendEntry{
+			backend: b,
+			local:   local,
+		}
 	}
 }
 
 // Deregister is used to remove an audit backend from the broker
-func (a *AuditBroker) Deregister(name string) {
-	a.Lock()
-	defer a.Unlock()
-	delete(a.backends, name)
+func (a *AuditBroker) Deregister(name string, useEventLogger bool) {
+	if useEventLogger {
+		// TODO: Coming soon
+	} else {
+		a.Lock()
+		defer a.Unlock()
+		delete(a.backends, name)
+	}
 }
 
 // IsRegistered is used to check if a given audit backend is registered

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -343,8 +343,8 @@ func TestAuditBroker_LogRequest(t *testing.T) {
 	b := NewAuditBroker(l)
 	a1 := corehelpers.TestNoopAudit(t, nil)
 	a2 := corehelpers.TestNoopAudit(t, nil)
-	b.Register("foo", a1, false)
-	b.Register("bar", a2, false)
+	b.Register("foo", a1, false, false)
+	b.Register("bar", a2, false, false)
 
 	auth := &logical.Auth{
 		ClientToken: "foo",
@@ -430,8 +430,8 @@ func TestAuditBroker_LogResponse(t *testing.T) {
 	b := NewAuditBroker(l)
 	a1 := corehelpers.TestNoopAudit(t, nil)
 	a2 := corehelpers.TestNoopAudit(t, nil)
-	b.Register("foo", a1, false)
-	b.Register("bar", a2, false)
+	b.Register("foo", a1, false, false)
+	b.Register("bar", a2, false, false)
 
 	auth := &logical.Auth{
 		NumUses:     10,
@@ -537,8 +537,8 @@ func TestAuditBroker_AuditHeaders(t *testing.T) {
 	view := NewBarrierView(barrier, "headers/")
 	a1 := corehelpers.TestNoopAudit(t, nil)
 	a2 := corehelpers.TestNoopAudit(t, nil)
-	b.Register("foo", a1, false)
-	b.Register("bar", a2, false)
+	b.Register("foo", a1, false, false)
+	b.Register("bar", a2, false, false)
 
 	auth := &logical.Auth{
 		ClientToken: "foo",


### PR DESCRIPTION
This PR introduces an experiment that will allow the incremental addition of eventlogger-based implementation changes without impacting the code base until the legacy backend implementations can be completely removed to complete the migration.