### PR TITLE
VAULT-17736 Add HashiCorp contributed label to HC contributed PRs

### DIFF
--- a/.github/workflows/add-hashicorp-contributed-label.yml
+++ b/.github/workflows/add-hashicorp-contributed-label.yml
@@ -10,7 +10,7 @@ name: Add HashiCorp contributed label
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     # Runs on PRs to main
     branches:
       - main

--- a/.github/workflows/add-hashicorp-contributed-label.yml
+++ b/.github/workflows/add-hashicorp-contributed-label.yml
@@ -20,15 +20,9 @@ jobs:
     # Only run if this is NOT coming from a fork of Vault (if this is not true, it's community contributed)
     if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: write # required to add labels
     steps:
-      - name: checkout
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: add label
-        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf #v1.1.3
-        with:
-          labels: hashicorp-contributed-pr
-          github_token: ${{secrets.GITHUB_TOKEN}}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR: ${{ github.event.pull_request.html_url }}
+      run: |
+        gh pr edit $PR --add-label 'hashicorp-contributed-pr'

--- a/.github/workflows/add-hashicorp-contributed-label.yml
+++ b/.github/workflows/add-hashicorp-contributed-label.yml
@@ -25,5 +25,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.html_url }}
-        run: |
-          "gh pr edit $PR --add-label \"hashicorp-contributed-pr\""
+        run: gh pr edit $PR --add-label 'hashicorp-contributed-pr'

--- a/.github/workflows/add-hashicorp-contributed-label.yml
+++ b/.github/workflows/add-hashicorp-contributed-label.yml
@@ -21,8 +21,9 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
     runs-on: ubuntu-latest
     steps:
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PR: ${{ github.event.pull_request.html_url }}
-      run: |
-        gh pr edit $PR --add-label 'hashicorp-contributed-pr'
+      - name: "Add label to PR"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr edit $PR --add-label 'hashicorp-contributed-pr'

--- a/.github/workflows/add-hashicorp-contributed-label.yml
+++ b/.github/workflows/add-hashicorp-contributed-label.yml
@@ -26,4 +26,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.html_url }}
         run: |
-          "gh pr edit $PR --add-label 'hashicorp-contributed-pr'"
+          "gh pr edit $PR --add-label hashicorp-contributed-pr"

--- a/.github/workflows/add-hashicorp-contributed-label.yml
+++ b/.github/workflows/add-hashicorp-contributed-label.yml
@@ -1,0 +1,31 @@
+name: Add HashiCorp contributed label
+
+# The purpose of this job is to label all HashiCorp contributed PRs, so that
+# we can more easily identify community contributed PRs (anything that doesn't
+# have this label)
+# While it might seem like this is the 'reverse' of what we should do, 
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    # Runs on PRs to main
+    branches:
+      - main
+
+jobs:
+  add-hashicorp-contributed-label:
+    # Only run if this is NOT coming from a fork of Vault (if this is not true, it's community contributed)
+    if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write # required to add labels
+    steps:
+      - name: checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: add label
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf #v1.1.3
+        with:
+          labels: hashicorp-contributed-pr
+          github_token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/add-hashicorp-contributed-label.yml
+++ b/.github/workflows/add-hashicorp-contributed-label.yml
@@ -26,4 +26,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.html_url }}
         run: |
-          gh pr edit $PR --add-label 'hashicorp-contributed-pr'
+          "gh pr edit $PR --add-label 'hashicorp-contributed-pr'"

--- a/.github/workflows/add-hashicorp-contributed-label.yml
+++ b/.github/workflows/add-hashicorp-contributed-label.yml
@@ -25,4 +25,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.html_url }}
-        run: gh pr edit $PR --add-label 'hashicorp-contributed-pr'
+        run: gh pr edit "$PR" --add-label 'hashicorp-contributed-pr'

--- a/.github/workflows/add-hashicorp-contributed-label.yml
+++ b/.github/workflows/add-hashicorp-contributed-label.yml
@@ -26,4 +26,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.html_url }}
         run: |
-          "gh pr edit $PR --add-label hashicorp-contributed-pr"
+          "gh pr edit $PR --add-label \"hashicorp-contributed-pr\""

--- a/.github/workflows/add-hashicorp-contributed-label.yml
+++ b/.github/workflows/add-hashicorp-contributed-label.yml
@@ -2,8 +2,11 @@ name: Add HashiCorp contributed label
 
 # The purpose of this job is to label all HashiCorp contributed PRs, so that
 # we can more easily identify community contributed PRs (anything that doesn't
-# have this label)
-# While it might seem like this is the 'reverse' of what we should do, 
+# have this label).
+# While it might seem like this is the 'reverse' of what we should do, GitHub
+# (rightly) does not allow branches from forks to have write permissions, so
+# making PRs from forks self-label themselves as community-contributed is not
+# possible.
 
 on:
   pull_request:


### PR DESCRIPTION
This is the inverse of https://github.com/hashicorp/vault/pull/21600, and was done for reasons explained in the comments of this GHA (forks can't have write permissions). We should be able to find community contributed PRs by adding `-label:hashicorp-contributed-pr` to the search bar.

See also (specifically, the maximum access for forks column is _all_ `read`):
![image](https://github.com/hashicorp/vault/assets/1594272/cc8ad3fb-4f93-48b8-9cbc-9c7efb4d7756)


I'll have to manually go back and update all open PRs with this label, where appropriate, but this one-time cost seems better than the alternate solution of having a cron job have to re-process every PR every time it runs. I'll make sure everything has the correct label.