### PR TITLE
KvPageHeader component

### DIFF
--- a/ui/app/adapters/kv/metadata.js
+++ b/ui/app/adapters/kv/metadata.js
@@ -31,7 +31,7 @@ export default class KvMetadataAdapter extends ApplicationAdapter {
   query(store, type, query) {
     const { backend } = query;
     return this.ajax(this._url(`${encodePath(backend)}/metadata?list=1`), 'GET').then((resp) => {
-      resp.data.backend = backend;
+      resp.backend = backend;
       return resp;
     });
   }

--- a/ui/app/adapters/kv/metadata.js
+++ b/ui/app/adapters/kv/metadata.js
@@ -31,7 +31,7 @@ export default class KvMetadataAdapter extends ApplicationAdapter {
   query(store, type, query) {
     const { backend } = query;
     return this.ajax(this._url(`${encodePath(backend)}/metadata?list=1`), 'GET').then((resp) => {
-      resp.backend = backend;
+      resp.data.backend = backend;
       return resp;
     });
   }

--- a/ui/app/serializers/kv/metadata.js
+++ b/ui/app/serializers/kv/metadata.js
@@ -18,8 +18,8 @@ export default class KvMetadataSerializer extends ApplicationSerializer {
 
   normalizeItems(payload) {
     if (payload.data.keys) {
-      assert('payload.backend must be provided on kv/metadata list response', !!payload.data.backend);
-      const backend = payload.data.backend;
+      assert('payload.backend must be provided on kv/metadata list response', !!payload.backend);
+      const backend = payload.backend;
       payload.data.keys = payload.data.keys.map((path) => {
         return {
           id: kvMetadataPath(backend, path),

--- a/ui/app/serializers/kv/metadata.js
+++ b/ui/app/serializers/kv/metadata.js
@@ -18,8 +18,8 @@ export default class KvMetadataSerializer extends ApplicationSerializer {
 
   normalizeItems(payload) {
     if (payload.data.keys) {
-      assert('payload.backend must be provided on kv/metadata list response', !!payload.backend);
-      const backend = payload.backend;
+      assert('payload.backend must be provided on kv/metadata list response', !!payload.data.backend);
+      const backend = payload.data.backend;
       payload.data.keys = payload.data.keys.map((path) => {
         return {
           id: kvMetadataPath(backend, path),

--- a/ui/app/serializers/kv/metadata.js
+++ b/ui/app/serializers/kv/metadata.js
@@ -17,7 +17,7 @@ export default class KvMetadataSerializer extends ApplicationSerializer {
   };
 
   normalizeItems(payload) {
-    if (payload.data.keys) {
+    if (payload.keys) {
       assert('payload.backend must be provided on kv/metadata list response', !!payload.backend);
       const backend = payload.backend;
       payload.data.keys = payload.data.keys.map((path) => {

--- a/ui/app/serializers/kv/metadata.js
+++ b/ui/app/serializers/kv/metadata.js
@@ -17,7 +17,7 @@ export default class KvMetadataSerializer extends ApplicationSerializer {
   };
 
   normalizeItems(payload) {
-    if (payload.keys) {
+    if (payload.data.keys) {
       assert('payload.backend must be provided on kv/metadata list response', !!payload.backend);
       const backend = payload.backend;
       payload.data.keys = payload.data.keys.map((path) => {

--- a/ui/lib/core/addon/components/page/breadcrumbs.hbs
+++ b/ui/lib/core/addon/components/page/breadcrumbs.hbs
@@ -6,9 +6,15 @@
         {{#if breadcrumb.linkExternal}}
           <LinkToExternal @route={{breadcrumb.route}}>{{breadcrumb.label}}</LinkToExternal>
         {{else if breadcrumb.route}}
-          <LinkTo @route={{breadcrumb.route}}>
-            {{breadcrumb.label}}
-          </LinkTo>
+          {{#if breadcrumb.model}}
+            <LinkTo @route={{breadcrumb.route}} @model={{breadcrumb.model}}>
+              {{breadcrumb.label}}
+            </LinkTo>
+          {{else}}
+            <LinkTo @route={{breadcrumb.route}}>
+              {{breadcrumb.label}}
+            </LinkTo>
+          {{/if}}
         {{else}}
           {{breadcrumb.label}}
         {{/if}}

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -17,7 +17,13 @@
   </p.levelLeft>
 </PageHeader>
 
-{{yield to="tabs"}}
+<div class="tabs-container box is-bottomless is-marginless is-paddingless">
+  <nav class="tabs" aria-label="kv tabs">
+    <ul>
+      {{yield to="tabLinks"}}
+    </ul>
+  </nav>
+</div>
 
 {{! TODO checks for if list >0 show filter }}
 {{#if (or (has-block "toolbarFilters") (has-block "toolbarActions"))}}

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -6,9 +6,11 @@
     <h1 class="title is-3" data-test-header-title>
       <Icon @name={{@model.icon}} @size="24" class="has-text-grey-light" />
       {{@model.id}}
-      <span class="tag">
-        Version 2
-      </span>
+      {{#if @showVersionTag}}
+        <span class="tag">
+          Version 2
+        </span>
+      {{/if}}
     </h1>
   </p.levelLeft>
 </PageHeader>

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -27,9 +27,9 @@
 {{! TODO checks for if list >0 show filter }}
 {{#if @showToolbar}}
   <Toolbar>
-    {{#if (has-block "toolbarFilter")}}
+    {{#if (has-block "toolbarFilters")}}
       {{! <ToolbarFilters> }}
-      {{yield to="toolbarFilter"}}
+      {{yield to="toolbarFilters"}}
       {{! </ToolbarFilters> }}
     {{/if}}
     <ToolbarActions>

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -28,9 +28,7 @@
 {{#if @showToolbar}}
   <Toolbar>
     {{#if (has-block "toolbarFilters")}}
-      {{! <ToolbarFilters> }}
       {{yield to="toolbarFilters"}}
-      {{! </ToolbarFilters> }}
     {{/if}}
     <ToolbarActions>
       {{#if (has-block "toolbarActions")}}

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -17,7 +17,6 @@
   </p.levelLeft>
 </PageHeader>
 
-{{! Tabs section, which changes based on route. }}
 {{yield to="tabs"}}
 
 {{! TODO checks for if list >0 show filter }}

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -4,18 +4,14 @@
   </p.top>
   <p.levelLeft>
     <h1 class="title is-3" data-test-header-title>
-      {{#if @model.icon}}
+      {{#if @isEngineView}}
         <Icon @name={{@model.icon}} @size="24" class="has-text-grey-light" />
-      {{/if}}
-      {{#if @model.pageTitle}}
-        {{@model.pageTitle}}
-      {{else}}
-        {{@model.id}}
-      {{/if}}
-      {{#if @showVersionTag}}
+        {{@model.backend}}
         <span class="tag">
           Version 2
         </span>
+      {{else}}
+        {{@pageTitle}}
       {{/if}}
     </h1>
   </p.levelLeft>
@@ -25,7 +21,7 @@
 {{yield to="tabs"}}
 
 {{! TODO checks for if list >0 show filter }}
-{{#if @showToolbar}}
+{{#if (or (has-block "toolbarFilters") (has-block "toolbarActions"))}}
   <Toolbar>
     {{#if (has-block "toolbarFilters")}}
       {{yield to="toolbarFilters"}}

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -5,7 +5,7 @@
   <p.levelLeft>
     <h1 class="title is-3" data-test-header-title>
       {{#if @isEngineView}}
-        <Icon @name={{@model.icon}} @size="24" class="has-text-grey-light" />
+        <Icon @name="kv" @size="24" class="has-text-grey-light" />
         {{@model.backend}}
         <span class="tag">
           Version 2
@@ -24,7 +24,9 @@
 {{#if (or (has-block "toolbarFilters") (has-block "toolbarActions"))}}
   <Toolbar>
     {{#if (has-block "toolbarFilters")}}
-      {{yield to="toolbarFilters"}}
+      <ToolbarFilters>
+        {{yield to="toolbarFilters"}}
+      </ToolbarFilters>
     {{/if}}
     <ToolbarActions>
       {{#if (has-block "toolbarActions")}}

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -4,8 +4,14 @@
   </p.top>
   <p.levelLeft>
     <h1 class="title is-3" data-test-header-title>
-      <Icon @name={{@model.icon}} @size="24" class="has-text-grey-light" />
-      {{@model.id}}
+      {{#if @model.icon}}
+        <Icon @name={{@model.icon}} @size="24" class="has-text-grey-light" />
+      {{/if}}
+      {{#if @model.pageTitle}}
+        {{@model.pageTitle}}
+      {{else}}
+        {{@model.id}}
+      {{/if}}
       {{#if @showVersionTag}}
         <span class="tag">
           Version 2

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -17,13 +17,15 @@
   </p.levelLeft>
 </PageHeader>
 
-<div class="tabs-container box is-bottomless is-marginless is-paddingless">
-  <nav class="tabs" aria-label="kv tabs">
-    <ul>
-      {{yield to="tabLinks"}}
-    </ul>
-  </nav>
-</div>
+{{#if (has-block "tabLinks")}}
+  <div class="tabs-container box is-bottomless is-marginless is-paddingless">
+    <nav class="tabs" aria-label="kv tabs">
+      <ul>
+        {{yield to="tabLinks"}}
+      </ul>
+    </nav>
+  </div>
+{{/if}}
 
 {{! TODO checks for if list >0 show filter }}
 {{#if (or (has-block "toolbarFilters") (has-block "toolbarActions"))}}

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -1,41 +1,30 @@
 <PageHeader as |p|>
   <p.top>
-    <nav class="breadcrumb" aria-label="breadcrumbs">
-      <ul>
-        <li>
-          <span class="sep">/</span>
-          <LinkToExternal @route="secrets">secrets</LinkToExternal>
-        </li>
-        <li>
-          <span class="sep">/</span>
-          <span>{{@model.id}}</span>
-        </li>
-      </ul>
-    </nav>
+    <Page::Breadcrumbs @breadcrumbs={{@breadcrumbs}} />
   </p.top>
   <p.levelLeft>
     <h1 class="title is-3" data-test-header-title>
       <Icon @name={{@model.icon}} @size="24" class="has-text-grey-light" />
       {{@model.id}}
+      <span class="tag">
+        Version 2
+      </span>
     </h1>
   </p.levelLeft>
 </PageHeader>
 
 {{! Tabs section, which changes based on route. }}
 {{yield to="tabs"}}
+
+{{! TODO checks for if list >0 show filter }}
 <Toolbar>
-  {{#if (has-block "filter")}}
-    <ToolbarFilters>
-      {{!-- <NavigateInput
-        @filter={{@rolesFilterValue}}
-        @placeholder="Filter roles"
-        @urls={{hash list="vault.cluster.secrets.backend.kubernetes.roles"}}
-      /> --}}
-    </ToolbarFilters>
+  {{#if (has-block "toolbarFilter")}}
+    {{! <ToolbarFilters> }}
+    {{yield to="toolbarFilter"}}
+    {{! </ToolbarFilters> }}
   {{/if}}
   <ToolbarActions>
     {{#if (has-block "toolbarActions")}}
-
       {{yield to="toolbarActions"}}
     {{/if}}
   </ToolbarActions>

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -21,11 +21,22 @@
   </p.levelLeft>
 </PageHeader>
 
-<div class="tabs-container box is-bottomless is-marginless is-paddingless">
-  <nav class="tabs" aria-label="kv tabs">
-    <ul>
-      <LinkTo @route="secrets" data-test-secret-list-tab="Secrets">Secrets</LinkTo>
-      <LinkTo @route="configuration" data-test-secret-list-tab="Configuration">Configuration</LinkTo>
-    </ul>
-  </nav>
-</div>
+{{! Tabs section, which changes based on route. }}
+{{yield to="tabs"}}
+<Toolbar>
+  {{#if (has-block "filter")}}
+    <ToolbarFilters>
+      {{!-- <NavigateInput
+        @filter={{@rolesFilterValue}}
+        @placeholder="Filter roles"
+        @urls={{hash list="vault.cluster.secrets.backend.kubernetes.roles"}}
+      /> --}}
+    </ToolbarFilters>
+  {{/if}}
+  <ToolbarActions>
+    {{#if (has-block "toolbarActions")}}
+
+      {{yield to="toolbarActions"}}
+    {{/if}}
+  </ToolbarActions>
+</Toolbar>

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -1,0 +1,31 @@
+<PageHeader as |p|>
+  <p.top>
+    <nav class="breadcrumb" aria-label="breadcrumbs">
+      <ul>
+        <li>
+          <span class="sep">/</span>
+          <LinkToExternal @route="secrets">secrets</LinkToExternal>
+        </li>
+        <li>
+          <span class="sep">/</span>
+          <span>{{@model.id}}</span>
+        </li>
+      </ul>
+    </nav>
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3" data-test-header-title>
+      <Icon @name={{@model.icon}} @size="24" class="has-text-grey-light" />
+      {{@model.id}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
+
+<div class="tabs-container box is-bottomless is-marginless is-paddingless">
+  <nav class="tabs" aria-label="kv tabs">
+    <ul>
+      <LinkTo @route="secrets" data-test-secret-list-tab="Secrets">Secrets</LinkTo>
+      <LinkTo @route="configuration" data-test-secret-list-tab="Configuration">Configuration</LinkTo>
+    </ul>
+  </nav>
+</div>

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -17,15 +17,17 @@
 {{yield to="tabs"}}
 
 {{! TODO checks for if list >0 show filter }}
-<Toolbar>
-  {{#if (has-block "toolbarFilter")}}
-    {{! <ToolbarFilters> }}
-    {{yield to="toolbarFilter"}}
-    {{! </ToolbarFilters> }}
-  {{/if}}
-  <ToolbarActions>
-    {{#if (has-block "toolbarActions")}}
-      {{yield to="toolbarActions"}}
+{{#if @showToolbar}}
+  <Toolbar>
+    {{#if (has-block "toolbarFilter")}}
+      {{! <ToolbarFilters> }}
+      {{yield to="toolbarFilter"}}
+      {{! </ToolbarFilters> }}
     {{/if}}
-  </ToolbarActions>
-</Toolbar>
+    <ToolbarActions>
+      {{#if (has-block "toolbarActions")}}
+        {{yield to="toolbarActions"}}
+      {{/if}}
+    </ToolbarActions>
+  </Toolbar>
+{{/if}}

--- a/ui/lib/kv/addon/components/page/configuration.hbs
+++ b/ui/lib/kv/addon/components/page/configuration.hbs
@@ -1,4 +1,4 @@
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}}>
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @showVersionTag="true">
   <:tabs>
     <div class="tabs-container box is-bottomless is-marginless is-paddingless">
       <nav class="tabs" aria-label="kv tabs">

--- a/ui/lib/kv/addon/components/page/configuration.hbs
+++ b/ui/lib/kv/addon/components/page/configuration.hbs
@@ -1,6 +1,6 @@
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @isEngineView={{true}}>
-  <:tabs>
+  <:tabLinks>
     <LinkTo @route="secrets" data-test-secrets-tab="Secrets">Secrets</LinkTo>
     <LinkTo @route="configuration" data-test-secrets-tab="Configuration">Configuration</LinkTo>
-  </:tabs>
+  </:tabLinks>
 </KvPageHeader>

--- a/ui/lib/kv/addon/components/page/configuration.hbs
+++ b/ui/lib/kv/addon/components/page/configuration.hbs
@@ -1,12 +1,6 @@
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @isEngineView="true">
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @isEngineView={{true}}>
   <:tabs>
-    <div class="tabs-container box is-bottomless is-marginless is-paddingless">
-      <nav class="tabs" aria-label="kv tabs">
-        <ul>
-          <LinkTo @route="secrets" data-test-secrets-tab="Secrets">Secrets</LinkTo>
-          <LinkTo @route="configuration" data-test-secrets-tab="Configuration">Configuration</LinkTo>
-        </ul>
-      </nav>
-    </div>
+    <LinkTo @route="secrets" data-test-secrets-tab="Secrets">Secrets</LinkTo>
+    <LinkTo @route="configuration" data-test-secrets-tab="Configuration">Configuration</LinkTo>
   </:tabs>
 </KvPageHeader>

--- a/ui/lib/kv/addon/components/page/configuration.hbs
+++ b/ui/lib/kv/addon/components/page/configuration.hbs
@@ -3,8 +3,8 @@
     <div class="tabs-container box is-bottomless is-marginless is-paddingless">
       <nav class="tabs" aria-label="kv tabs">
         <ul>
-          <LinkTo @route="secrets" data-test-secret-list-tab="Secrets">Secrets</LinkTo>
-          <LinkTo @route="configuration" data-test-secret-list-tab="Configuration">Configuration</LinkTo>
+          <LinkTo @route="secrets" data-test-secrets-tab="Secrets">Secrets</LinkTo>
+          <LinkTo @route="configuration" data-test-secrets-tab="Configuration">Configuration</LinkTo>
         </ul>
       </nav>
     </div>

--- a/ui/lib/kv/addon/components/page/configuration.hbs
+++ b/ui/lib/kv/addon/components/page/configuration.hbs
@@ -1,4 +1,4 @@
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @showVersionTag="true">
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @isEngineView="true">
   <:tabs>
     <div class="tabs-container box is-bottomless is-marginless is-paddingless">
       <nav class="tabs" aria-label="kv tabs">

--- a/ui/lib/kv/addon/components/page/configuration.hbs
+++ b/ui/lib/kv/addon/components/page/configuration.hbs
@@ -1,4 +1,4 @@
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @showToolbar="true">
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}}>
   <:tabs>
     <div class="tabs-container box is-bottomless is-marginless is-paddingless">
       <nav class="tabs" aria-label="kv tabs">
@@ -9,14 +9,4 @@
       </nav>
     </div>
   </:tabs>
-
-  <:toolbarFilter>
-    {{! TODO NavbarInput with autocomplete }}
-  </:toolbarFilter>
-
-  <:toolbarActions>
-    <ToolbarLink @route="secrets.create" @type="add">Create secret</ToolbarLink>
-  </:toolbarActions>
 </KvPageHeader>
-
-{{! TODO: iterate over secret list }}

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -1,4 +1,4 @@
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @showToolbar="true">
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @pageTitle={{@model.path}}>
   <:tabs>
     <div class="tabs-container box is-bottomless is-marginless is-paddingless">
       <nav class="tabs" aria-label="kv secret tabs">

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -1,8 +1,8 @@
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @pageTitle={{@model.path}}>
-  <:tabs>
+  <:tabLinks>
     <LinkTo @route="secrets.secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
     <LinkTo @route="secrets.secret.metadata.index" data-test-secret-tab="Metadata">Metadata</LinkTo>
-  </:tabs>
+  </:tabLinks>
 
   <:toolbarFilters>
     {{! TODO add JSON toggle }}

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -10,9 +10,11 @@
     </div>
   </:tabs>
 
-  {{! TODO add JSON toggle }}
+  <:toolbarFilters>
+    {{! TODO add JSON toggle }}
+  </:toolbarFilters>
+
   <:toolbarActions>
-    {{! ARG TODO a lot more here and conditionals }}
     <ToolbarLink @route="secrets.secret.edit" @type="add">Create new version</ToolbarLink>
   </:toolbarActions>
 </KvPageHeader>

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -1,13 +1,7 @@
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @pageTitle={{@model.path}}>
   <:tabs>
-    <div class="tabs-container box is-bottomless is-marginless is-paddingless">
-      <nav class="tabs" aria-label="kv secret tabs">
-        <ul>
-          <LinkTo @route="secrets.secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
-          <LinkTo @route="secrets.secret.metadata.index" data-test-secret-tab="Metadata">Metadata</LinkTo>
-        </ul>
-      </nav>
-    </div>
+    <LinkTo @route="secrets.secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
+    <LinkTo @route="secrets.secret.metadata.index" data-test-secret-tab="Metadata">Metadata</LinkTo>
   </:tabs>
 
   <:toolbarFilters>

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -3,8 +3,8 @@
     <div class="tabs-container box is-bottomless is-marginless is-paddingless">
       <nav class="tabs" aria-label="kv secret tabs">
         <ul>
-          <LinkTo @route="secrets.secret.details" data-test-secret-list-tab="Secret">Secret</LinkTo>
-          <LinkTo @route="secrets.secret.metadata.index" data-test-secret-list-tab="Metadata">Metadata</LinkTo>
+          <LinkTo @route="secrets.secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
+          <LinkTo @route="secrets.secret.metadata.index" data-test-secret-tab="Metadata">Metadata</LinkTo>
         </ul>
       </nav>
     </div>

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -1,0 +1,18 @@
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @showToolbar="true">
+  <:tabs>
+    <div class="tabs-container box is-bottomless is-marginless is-paddingless">
+      <nav class="tabs" aria-label="kv secret tabs">
+        <ul>
+          <LinkTo @route="secrets.secret.details" data-test-secret-list-tab="Secret">Secret</LinkTo>
+          <LinkTo @route="secrets.secret.metadata.details" data-test-secret-list-tab="Metadata">Metadata</LinkTo>
+        </ul>
+      </nav>
+    </div>
+  </:tabs>
+
+  {{! TODO add JSON toggle }}
+  <:toolbarActions>
+    {{! ARG TODO a lot more here and conditionals }}
+    <ToolbarLink @route="secrets.secret.edit" @type="add">Create new version</ToolbarLink>
+  </:toolbarActions>
+</KvPageHeader>

--- a/ui/lib/kv/addon/components/page/secret/edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/edit.hbs
@@ -1,3 +1,5 @@
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @pageTitle="Create new version">
-  {{! TODO add JSON toggle }}
+  <:toolbarFilters>
+    {{! TODO add JSON toggle }}
+  </:toolbarFilters>
 </KvPageHeader>

--- a/ui/lib/kv/addon/components/page/secret/edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/edit.hbs
@@ -1,0 +1,3 @@
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @showToolbar="true">
+  {{! TODO add JSON toggle }}
+</KvPageHeader>

--- a/ui/lib/kv/addon/components/page/secret/edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/edit.hbs
@@ -1,4 +1,4 @@
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @pageTitle="Create new version">
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @pageTitle="Create New Version">
   <:toolbarFilters>
     {{! TODO add JSON toggle }}
   </:toolbarFilters>

--- a/ui/lib/kv/addon/components/page/secret/edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/edit.hbs
@@ -1,3 +1,3 @@
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @showToolbar="true">
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @pageTitle="Create new version">
   {{! TODO add JSON toggle }}
 </KvPageHeader>

--- a/ui/lib/kv/addon/components/page/secret/metadata-details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata-details.hbs
@@ -1,13 +1,7 @@
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @pageTitle={{@model.path}}>
   <:tabs>
-    <div class="tabs-container box is-bottomless is-marginless is-paddingless">
-      <nav class="tabs" aria-label="kv secret tabs">
-        <ul>
-          <LinkTo @route="secrets.secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
-          <LinkTo @route="secrets.secret.metadata.index" data-test-secrets-tab="Metadata">Metadata</LinkTo>
-        </ul>
-      </nav>
-    </div>
+    <LinkTo @route="secrets.secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
+    <LinkTo @route="secrets.secret.metadata.index" data-test-secrets-tab="Metadata">Metadata</LinkTo>
   </:tabs>
 
   <:toolbarActions>

--- a/ui/lib/kv/addon/components/page/secret/metadata-details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata-details.hbs
@@ -1,8 +1,8 @@
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @pageTitle={{@model.path}}>
-  <:tabs>
+  <:tabLinks>
     <LinkTo @route="secrets.secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
     <LinkTo @route="secrets.secret.metadata.index" data-test-secrets-tab="Metadata">Metadata</LinkTo>
-  </:tabs>
+  </:tabLinks>
 
   <:toolbarActions>
     <ToolbarLink @route="secrets.secret.metadata.edit">Edit metadata</ToolbarLink>

--- a/ui/lib/kv/addon/components/page/secret/metadata-details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata-details.hbs
@@ -1,4 +1,4 @@
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @showToolbar="true">
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @pageTitle={{@model.path}}>
   <:tabs>
     <div class="tabs-container box is-bottomless is-marginless is-paddingless">
       <nav class="tabs" aria-label="kv secret tabs">

--- a/ui/lib/kv/addon/components/page/secret/metadata-details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata-details.hbs
@@ -3,8 +3,8 @@
     <div class="tabs-container box is-bottomless is-marginless is-paddingless">
       <nav class="tabs" aria-label="kv secret tabs">
         <ul>
-          <LinkTo @route="secrets.secret.details" data-test-secret-list-tab="Secret">Secret</LinkTo>
-          <LinkTo @route="secrets.secret.metadata.index" data-test-secret-list-tab="Metadata">Metadata</LinkTo>
+          <LinkTo @route="secrets.secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
+          <LinkTo @route="secrets.secret.metadata.index" data-test-secrets-tab="Metadata">Metadata</LinkTo>
         </ul>
       </nav>
     </div>
@@ -12,7 +12,6 @@
 
   {{! TODO add JSON toggle }}
   <:toolbarActions>
-    {{! ARG TODO a lot more here and conditionals }}
     <ToolbarLink @route="secrets.secret.metadata.edit">Edit metadata</ToolbarLink>
   </:toolbarActions>
 </KvPageHeader>

--- a/ui/lib/kv/addon/components/page/secret/metadata-details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata-details.hbs
@@ -10,7 +10,6 @@
     </div>
   </:tabs>
 
-  {{! TODO add JSON toggle }}
   <:toolbarActions>
     <ToolbarLink @route="secrets.secret.metadata.edit">Edit metadata</ToolbarLink>
   </:toolbarActions>

--- a/ui/lib/kv/addon/components/page/secret/metadata-details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata-details.hbs
@@ -13,6 +13,6 @@
   {{! TODO add JSON toggle }}
   <:toolbarActions>
     {{! ARG TODO a lot more here and conditionals }}
-    <ToolbarLink @route="secrets.secret.edit" @type="add">Create new version</ToolbarLink>
+    <ToolbarLink @route="secrets.secret.metadata.edit">Edit metadata</ToolbarLink>
   </:toolbarActions>
 </KvPageHeader>

--- a/ui/lib/kv/addon/components/page/secret/metadata-edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata-edit.hbs
@@ -1,4 +1,4 @@
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} />
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @pageTitle="Edit Secret Metadata" />
 
 <hr class="is-marginless has-background-gray-200" />
 <p class="has-top-margin-m">

--- a/ui/lib/kv/addon/components/page/secret/metadata-edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata-edit.hbs
@@ -1,0 +1,7 @@
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} />
+
+<hr class="is-marginless has-background-gray-200" />
+
+<p class="has-top-margin-m">
+  The options below are all version-agnostic; they apply to all versions of this secret.
+</p>

--- a/ui/lib/kv/addon/components/page/secret/metadata-edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata-edit.hbs
@@ -1,7 +1,6 @@
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} />
 
 <hr class="is-marginless has-background-gray-200" />
-
 <p class="has-top-margin-m">
   The options below are all version-agnostic; they apply to all versions of this secret.
 </p>

--- a/ui/lib/kv/addon/components/page/secrets.hbs
+++ b/ui/lib/kv/addon/components/page/secrets.hbs
@@ -1,13 +1,7 @@
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @isEngineView="true">
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @isEngineView={{true}}>
   <:tabs>
-    <div class="tabs-container box is-bottomless is-marginless is-paddingless">
-      <nav class="tabs" aria-label="kv tabs">
-        <ul>
-          <LinkTo @route="secrets" data-test-secrets-tab="Secrets">Secrets</LinkTo>
-          <LinkTo @route="configuration" data-test-secrets-tab="Configuration">Configuration</LinkTo>
-        </ul>
-      </nav>
-    </div>
+    <LinkTo @route="secrets" data-test-secrets-tab="Secrets">Secrets</LinkTo>
+    <LinkTo @route="configuration" data-test-secrets-tab="Configuration">Configuration</LinkTo>
   </:tabs>
 
   <:toolbarFilters>

--- a/ui/lib/kv/addon/components/page/secrets.hbs
+++ b/ui/lib/kv/addon/components/page/secrets.hbs
@@ -1,4 +1,4 @@
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @showToolbar="true">
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @showToolbar="true" @showVersionTag="true">
   <:tabs>
     <div class="tabs-container box is-bottomless is-marginless is-paddingless">
       <nav class="tabs" aria-label="kv tabs">

--- a/ui/lib/kv/addon/components/page/secrets.hbs
+++ b/ui/lib/kv/addon/components/page/secrets.hbs
@@ -10,9 +10,9 @@
     </div>
   </:tabs>
 
-  <:toolbarFilter>
-    {{! TODO NavbarInput with autocomplete }}
-  </:toolbarFilter>
+  <:toolbarFilters>
+    {{! TODO add JSON toggle }}
+  </:toolbarFilters>
 
   <:toolbarActions>
     <ToolbarLink @route="secrets.create" @type="add">Create secret</ToolbarLink>

--- a/ui/lib/kv/addon/components/page/secrets.hbs
+++ b/ui/lib/kv/addon/components/page/secrets.hbs
@@ -1,4 +1,4 @@
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @showToolbar="true" @showVersionTag="true">
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @isEngineView="true">
   <:tabs>
     <div class="tabs-container box is-bottomless is-marginless is-paddingless">
       <nav class="tabs" aria-label="kv tabs">

--- a/ui/lib/kv/addon/components/page/secrets.hbs
+++ b/ui/lib/kv/addon/components/page/secrets.hbs
@@ -3,8 +3,8 @@
     <div class="tabs-container box is-bottomless is-marginless is-paddingless">
       <nav class="tabs" aria-label="kv tabs">
         <ul>
-          <LinkTo @route="secrets" data-test-secret-list-tab="Secrets">Secrets</LinkTo>
-          <LinkTo @route="configuration" data-test-secret-list-tab="Configuration">Configuration</LinkTo>
+          <LinkTo @route="secrets" data-test-secrets-tab="Secrets">Secrets</LinkTo>
+          <LinkTo @route="configuration" data-test-secrets-tab="Configuration">Configuration</LinkTo>
         </ul>
       </nav>
     </div>
@@ -18,5 +18,3 @@
     <ToolbarLink @route="secrets.create" @type="add">Create secret</ToolbarLink>
   </:toolbarActions>
 </KvPageHeader>
-
-{{! TODO: iterate over secret list }}

--- a/ui/lib/kv/addon/components/page/secrets.hbs
+++ b/ui/lib/kv/addon/components/page/secrets.hbs
@@ -1,8 +1,8 @@
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @isEngineView={{true}}>
-  <:tabs>
+  <:tabLinks>
     <LinkTo @route="secrets" data-test-secrets-tab="Secrets">Secrets</LinkTo>
     <LinkTo @route="configuration" data-test-secrets-tab="Configuration">Configuration</LinkTo>
-  </:tabs>
+  </:tabLinks>
 
   <:toolbarFilters>
     {{! TODO add JSON toggle }}

--- a/ui/lib/kv/addon/components/page/secrets.hbs
+++ b/ui/lib/kv/addon/components/page/secrets.hbs
@@ -1,0 +1,6 @@
+<KvPageHeader @model={{@model}}>
+  {{! ARG TODO will need filter }}
+  <ToolbarLink @route="secret.create">Create secret</ToolbarLink>
+</KvPageHeader>
+
+{{! iterate over secret list }}

--- a/ui/lib/kv/addon/components/page/secrets.hbs
+++ b/ui/lib/kv/addon/components/page/secrets.hbs
@@ -1,6 +1,18 @@
 <KvPageHeader @model={{@model}}>
   {{! ARG TODO will need filter }}
-  <ToolbarLink @route="secret.create">Create secret</ToolbarLink>
+  <:tabs>
+    <div class="tabs-container box is-bottomless is-marginless is-paddingless">
+      <nav class="tabs" aria-label="kv tabs">
+        <ul>
+          <LinkTo @route="secrets" data-test-secret-list-tab="Secrets">Secrets</LinkTo>
+          <LinkTo @route="configuration" data-test-secret-list-tab="Configuration">Configuration</LinkTo>
+        </ul>
+      </nav>
+    </div>
+  </:tabs>
+  <:toolbarActions>
+    <ToolbarLink @route="secrets.create" @type="add">Create secret</ToolbarLink>
+  </:toolbarActions>
 </KvPageHeader>
 
 {{! iterate over secret list }}

--- a/ui/lib/kv/addon/components/page/secrets.hbs
+++ b/ui/lib/kv/addon/components/page/secrets.hbs
@@ -1,5 +1,4 @@
-<KvPageHeader @model={{@model}}>
-  {{! ARG TODO will need filter }}
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}}>
   <:tabs>
     <div class="tabs-container box is-bottomless is-marginless is-paddingless">
       <nav class="tabs" aria-label="kv tabs">
@@ -10,9 +9,14 @@
       </nav>
     </div>
   </:tabs>
+
+  <:toolbarFilter>
+    {{! TODO NavbarInput with autocomplete }}
+  </:toolbarFilter>
+
   <:toolbarActions>
     <ToolbarLink @route="secrets.create" @type="add">Create secret</ToolbarLink>
   </:toolbarActions>
 </KvPageHeader>
 
-{{! iterate over secret list }}
+{{! TODO: iterate over secret list }}

--- a/ui/lib/kv/addon/components/page/secrets/create.hbs
+++ b/ui/lib/kv/addon/components/page/secrets/create.hbs
@@ -1,0 +1,12 @@
+<PageHeader as |p|>
+  <p.top>
+    <Page::Breadcrumbs @breadcrumbs={{@breadcrumbs}} />
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Create Secret
+    </h1>
+  </p.levelLeft>
+</PageHeader>
+
+<hr class="is-marginless has-background-gray-200" />

--- a/ui/lib/kv/addon/routes.js
+++ b/ui/lib/kv/addon/routes.js
@@ -12,7 +12,6 @@ export default buildRoutes(function () {
       this.route('details');
       this.route('edit');
       this.route('metadata', function () {
-        this.route('details');
         this.route('edit');
       });
       this.route('versions');

--- a/ui/lib/kv/addon/routes/configuration.js
+++ b/ui/lib/kv/addon/routes/configuration.js
@@ -13,17 +13,16 @@ export default class KvConfigurationRoute extends Route {
 
   model() {
     const backend = this.secretMountPath.get();
-    // TODO: model for configuration comes from secret-engine but maybe we should make our own because it combines two endpoints?
+    // TODO: bring in model from secret-engine.
     return hash({
       backend,
-      id: backend,
       icon: 'kv',
     });
   }
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-
+    controller.pageTitle = resolvedModel.backend;
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend },

--- a/ui/lib/kv/addon/routes/configuration.js
+++ b/ui/lib/kv/addon/routes/configuration.js
@@ -16,7 +16,6 @@ export default class KvConfigurationRoute extends Route {
     // TODO: bring in model from secret-engine.
     return hash({
       backend,
-      icon: 'kv',
     });
   }
 

--- a/ui/lib/kv/addon/routes/configuration.js
+++ b/ui/lib/kv/addon/routes/configuration.js
@@ -4,5 +4,29 @@
  */
 
 import Route from '@ember/routing/route';
+import { hash } from 'rsvp';
+import { inject as service } from '@ember/service';
 
-export default class KvConfigurationRoute extends Route {}
+export default class KvConfigurationRoute extends Route {
+  @service store;
+  @service secretMountPath;
+
+  model() {
+    const backend = this.secretMountPath.get();
+    // TODO: model for configuration comes from secret-engine but maybe we should make our own because it combines two endpoints?
+    return hash({
+      backend,
+      id: backend,
+      icon: 'kv',
+    });
+  }
+
+  setupController(controller, resolvedModel) {
+    super.setupController(controller, resolvedModel);
+
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: resolvedModel.backend },
+    ];
+  }
+}

--- a/ui/lib/kv/addon/routes/secrets/create.js
+++ b/ui/lib/kv/addon/routes/secrets/create.js
@@ -16,7 +16,6 @@ export default class KvSecretsCreateRoute extends Route {
     const backend = this.secretMountPath.get();
     return hash({
       backend,
-      icon: 'kv',
     });
   }
 

--- a/ui/lib/kv/addon/routes/secrets/create.js
+++ b/ui/lib/kv/addon/routes/secrets/create.js
@@ -4,5 +4,29 @@
  */
 
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { hash } from 'rsvp';
 
-export default class KvSecretsCreateRoute extends Route {}
+export default class KvSecretsCreateRoute extends Route {
+  @service store;
+  @service secretMountPath;
+
+  model() {
+    // TODO return model for query on kv/data.
+    const backend = this.secretMountPath.get();
+    return hash({
+      id: backend,
+      backend,
+      icon: 'kv',
+    });
+  }
+
+  setupController(controller, resolvedModel) {
+    super.setupController(controller, resolvedModel);
+
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: resolvedModel.backend },
+    ];
+  }
+}

--- a/ui/lib/kv/addon/routes/secrets/create.js
+++ b/ui/lib/kv/addon/routes/secrets/create.js
@@ -12,10 +12,9 @@ export default class KvSecretsCreateRoute extends Route {
   @service secretMountPath;
 
   model() {
-    // TODO return model for query on kv/data.
+    // TODO return model for query on kv/data
     const backend = this.secretMountPath.get();
     return hash({
-      id: backend,
       backend,
       icon: 'kv',
     });
@@ -23,10 +22,6 @@ export default class KvSecretsCreateRoute extends Route {
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-
-    controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backend },
-    ];
+    controller.breadcrumbs = [{ label: resolvedModel.backend, route: 'secrets' }, { label: 'create' }];
   }
 }

--- a/ui/lib/kv/addon/routes/secrets/index.js
+++ b/ui/lib/kv/addon/routes/secrets/index.js
@@ -15,7 +15,6 @@ export default class KvSecretsRoute extends Route {
     // TODO add filtering and return model for query on kv/metadata.
     const backend = this.secretMountPath.get();
     return hash({
-      id: backend,
       backend,
       icon: 'kv',
     });
@@ -23,7 +22,7 @@ export default class KvSecretsRoute extends Route {
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
-
+    controller.pageTitle = resolvedModel.backend;
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend },

--- a/ui/lib/kv/addon/routes/secrets/index.js
+++ b/ui/lib/kv/addon/routes/secrets/index.js
@@ -16,7 +16,6 @@ export default class KvSecretsRoute extends Route {
     const backend = this.secretMountPath.get();
     return hash({
       backend,
-      icon: 'kv',
     });
   }
 

--- a/ui/lib/kv/addon/routes/secrets/index.js
+++ b/ui/lib/kv/addon/routes/secrets/index.js
@@ -12,20 +12,12 @@ export default class KvSecretsRoute extends Route {
   @service secretMountPath;
 
   model() {
-    // TODO: filter secrets based on queryParams value
+    // TODO add filtering and return model for query on kv/metadata.
     const backend = this.secretMountPath.get();
-    const secrets = this.store.query('kv/metadata', { backend }).catch((error) => {
-      if (error.httpStatus === 404) {
-        return [];
-      }
-      throw error;
-    });
-
     return hash({
       id: backend,
       backend,
       icon: 'kv',
-      secrets,
     });
   }
 

--- a/ui/lib/kv/addon/routes/secrets/index.js
+++ b/ui/lib/kv/addon/routes/secrets/index.js
@@ -4,5 +4,37 @@
  */
 
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { hash } from 'rsvp';
 
-export default class KvSecretsIndexRoute extends Route {}
+export default class KvSecretsRoute extends Route {
+  @service store;
+  @service secretMountPath;
+
+  model() {
+    // TODO: filter secrets based on queryParams value
+    const backend = this.secretMountPath.get();
+    const secrets = this.store.query('kv/metadata', { backend }).catch((error) => {
+      if (error.httpStatus === 404) {
+        return [];
+      }
+      throw error;
+    });
+
+    return hash({
+      id: backend,
+      backend,
+      icon: 'kv',
+      secrets,
+    });
+  }
+
+  setupController(controller, resolvedModel) {
+    super.setupController(controller, resolvedModel);
+
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: resolvedModel.backend },
+    ];
+  }
+}

--- a/ui/lib/kv/addon/routes/secrets/secret/details.js
+++ b/ui/lib/kv/addon/routes/secrets/secret/details.js
@@ -18,7 +18,6 @@ export default class KvSecretDetailsRoute extends Route {
     return hash({
       id: name,
       backend,
-      icon: 'kv',
     });
   }
 
@@ -27,7 +26,8 @@ export default class KvSecretDetailsRoute extends Route {
 
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backend },
+      { label: resolvedModel.backend, route: 'secrets' },
+      { label: resolvedModel.id },
     ];
   }
 }

--- a/ui/lib/kv/addon/routes/secrets/secret/details.js
+++ b/ui/lib/kv/addon/routes/secrets/secret/details.js
@@ -16,7 +16,7 @@ export default class KvSecretDetailsRoute extends Route {
     const backend = this.secretMountPath.get();
     const { name } = this.paramsFor('secrets.secret');
     return hash({
-      id: name,
+      path: name,
       backend,
     });
   }
@@ -27,7 +27,7 @@ export default class KvSecretDetailsRoute extends Route {
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'secrets' },
-      { label: resolvedModel.id },
+      { label: resolvedModel.path },
     ];
   }
 }

--- a/ui/lib/kv/addon/routes/secrets/secret/details.js
+++ b/ui/lib/kv/addon/routes/secrets/secret/details.js
@@ -4,5 +4,30 @@
  */
 
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { hash } from 'rsvp';
 
-export default class KvSecretDetailsRoute extends Route {}
+export default class KvSecretDetailsRoute extends Route {
+  @service store;
+  @service secretMountPath;
+
+  model() {
+    // TODO return model for query on kv/data.
+    const backend = this.secretMountPath.get();
+    const { name } = this.paramsFor('secrets.secret');
+    return hash({
+      id: name,
+      backend,
+      icon: 'kv',
+    });
+  }
+
+  setupController(controller, resolvedModel) {
+    super.setupController(controller, resolvedModel);
+
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: resolvedModel.backend },
+    ];
+  }
+}

--- a/ui/lib/kv/addon/routes/secrets/secret/edit.js
+++ b/ui/lib/kv/addon/routes/secrets/secret/edit.js
@@ -11,9 +11,8 @@ export default class KvSecretEditRoute extends Route {
     const backend = this.secretMountPath.get();
     const { name } = this.paramsFor('secrets.secret');
     return hash({
-      id: name,
+      path: name,
       backend,
-      pageTitle: 'Create New Version',
     });
   }
 
@@ -23,7 +22,7 @@ export default class KvSecretEditRoute extends Route {
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'secrets' },
-      { label: resolvedModel.id, route: 'secrets.secret.details', model: resolvedModel.id },
+      { label: resolvedModel.path, route: 'secrets.secret.details', model: resolvedModel.path },
       { label: 'edit' },
     ];
   }

--- a/ui/lib/kv/addon/routes/secrets/secret/edit.js
+++ b/ui/lib/kv/addon/routes/secrets/secret/edit.js
@@ -1,8 +1,30 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
- */
-
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { hash } from 'rsvp';
 
-export default class KvSecretEditRoute extends Route {}
+export default class KvSecretEditRoute extends Route {
+  @service store;
+  @service secretMountPath;
+
+  model() {
+    // TODO add model. Needs to include a queryParam for version.
+    const backend = this.secretMountPath.get();
+    const { name } = this.paramsFor('secrets.secret');
+    return hash({
+      id: name,
+      backend,
+      pageTitle: 'Create new version',
+    });
+  }
+
+  setupController(controller, resolvedModel) {
+    super.setupController(controller, resolvedModel);
+
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: resolvedModel.backend, route: 'secrets' },
+      { label: resolvedModel.id, route: 'secrets.secret.details', model: resolvedModel.id },
+      { label: 'edit' },
+    ];
+  }
+}

--- a/ui/lib/kv/addon/routes/secrets/secret/edit.js
+++ b/ui/lib/kv/addon/routes/secrets/secret/edit.js
@@ -13,7 +13,7 @@ export default class KvSecretEditRoute extends Route {
     return hash({
       id: name,
       backend,
-      pageTitle: 'Create new version',
+      pageTitle: 'Create New Version',
     });
   }
 

--- a/ui/lib/kv/addon/routes/secrets/secret/metadata/details.js
+++ b/ui/lib/kv/addon/routes/secrets/secret/metadata/details.js
@@ -1,8 +1,0 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
- */
-
-import Route from '@ember/routing/route';
-
-export default class KvSecretMetadataDetailsRoute extends Route {}

--- a/ui/lib/kv/addon/routes/secrets/secret/metadata/edit.js
+++ b/ui/lib/kv/addon/routes/secrets/secret/metadata/edit.js
@@ -4,5 +4,32 @@
  */
 
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { hash } from 'rsvp';
 
-export default class KvSecretMetadataEditRoute extends Route {}
+export default class KvSecretMetadataEditRoute extends Route {
+  @service store;
+  @service secretMountPath;
+
+  model() {
+    // TODO return model for query on kv/metadata.
+    const backend = this.secretMountPath.get();
+    const { name } = this.paramsFor('secrets.secret');
+    return hash({
+      id: name,
+      backend,
+      pageTitle: 'Edit Secret Metadata',
+    });
+  }
+
+  setupController(controller, resolvedModel) {
+    super.setupController(controller, resolvedModel);
+
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: resolvedModel.backend, route: 'secrets' },
+      { label: resolvedModel.id, route: 'secrets.secret.details', model: resolvedModel.id },
+      { label: 'edit-metadata' },
+    ];
+  }
+}

--- a/ui/lib/kv/addon/routes/secrets/secret/metadata/edit.js
+++ b/ui/lib/kv/addon/routes/secrets/secret/metadata/edit.js
@@ -16,9 +16,8 @@ export default class KvSecretMetadataEditRoute extends Route {
     const backend = this.secretMountPath.get();
     const { name } = this.paramsFor('secrets.secret');
     return hash({
-      id: name,
+      path: name,
       backend,
-      pageTitle: 'Edit Secret Metadata',
     });
   }
 
@@ -28,7 +27,7 @@ export default class KvSecretMetadataEditRoute extends Route {
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'secrets' },
-      { label: resolvedModel.id, route: 'secrets.secret.details', model: resolvedModel.id },
+      { label: resolvedModel.path, route: 'secrets.secret.details', model: resolvedModel.path },
       { label: 'edit-metadata' },
     ];
   }

--- a/ui/lib/kv/addon/routes/secrets/secret/metadata/index.js
+++ b/ui/lib/kv/addon/routes/secrets/secret/metadata/index.js
@@ -16,7 +16,7 @@ export default class KvSecretMetadataIndexRoute extends Route {
     const backend = this.secretMountPath.get();
     const { name } = this.paramsFor('secrets.secret');
     return hash({
-      id: name,
+      path: name,
       backend,
     });
   }
@@ -27,7 +27,7 @@ export default class KvSecretMetadataIndexRoute extends Route {
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'secrets' },
-      { label: resolvedModel.id, route: 'secrets.secret.details', model: resolvedModel.id },
+      { label: resolvedModel.path, route: 'secrets.secret.details', model: resolvedModel.path },
       { label: 'metadata' },
     ];
   }

--- a/ui/lib/kv/addon/routes/secrets/secret/metadata/index.js
+++ b/ui/lib/kv/addon/routes/secrets/secret/metadata/index.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { hash } from 'rsvp';
+
+export default class KvSecretMetadataIndexRoute extends Route {
+  @service store;
+  @service secretMountPath;
+
+  model() {
+    // TODO return model for query on kv/metadata.
+    const backend = this.secretMountPath.get();
+    const { name } = this.paramsFor('secrets.secret');
+    return hash({
+      id: name,
+      backend,
+    });
+  }
+
+  setupController(controller, resolvedModel) {
+    super.setupController(controller, resolvedModel);
+
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: resolvedModel.backend, route: 'secrets' },
+      { label: resolvedModel.id, route: 'secrets.secret.details', model: resolvedModel.id },
+      { label: 'metadata' },
+    ];
+  }
+}

--- a/ui/lib/kv/addon/templates/configuration.hbs
+++ b/ui/lib/kv/addon/templates/configuration.hbs
@@ -1,1 +1,1 @@
-<Page::Configuration @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />
+<Page::Configuration @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} @pageTitle={{this.pageTitle}} />

--- a/ui/lib/kv/addon/templates/configuration.hbs
+++ b/ui/lib/kv/addon/templates/configuration.hbs
@@ -1,1 +1,1 @@
-configuration
+<Page::Configuration @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kv/addon/templates/secrets/create.hbs
+++ b/ui/lib/kv/addon/templates/secrets/create.hbs
@@ -1,1 +1,1 @@
-secrets.create
+<Page::Secrets::Create @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kv/addon/templates/secrets/index.hbs
+++ b/ui/lib/kv/addon/templates/secrets/index.hbs
@@ -1,1 +1,1 @@
-<Page::Secrets @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />
+<Page::Secrets @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} @pageTitle={{this.pageTitle}} />

--- a/ui/lib/kv/addon/templates/secrets/index.hbs
+++ b/ui/lib/kv/addon/templates/secrets/index.hbs
@@ -1,1 +1,1 @@
-secrets.index
+<Page::Secrets @model={{this.model}} />

--- a/ui/lib/kv/addon/templates/secrets/index.hbs
+++ b/ui/lib/kv/addon/templates/secrets/index.hbs
@@ -1,1 +1,1 @@
-<Page::Secrets @model={{this.model}} />
+<Page::Secrets @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kv/addon/templates/secrets/secret/details.hbs
+++ b/ui/lib/kv/addon/templates/secrets/secret/details.hbs
@@ -1,1 +1,1 @@
-secrets.secret.details
+<Page::Secret::Details @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kv/addon/templates/secrets/secret/edit.hbs
+++ b/ui/lib/kv/addon/templates/secrets/secret/edit.hbs
@@ -1,1 +1,1 @@
-secrets.secret.edit
+<Page::Secret::Edit @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kv/addon/templates/secrets/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/templates/secrets/secret/metadata/details.hbs
@@ -1,1 +1,0 @@
-secrets.secret.metadata.details

--- a/ui/lib/kv/addon/templates/secrets/secret/metadata/edit.hbs
+++ b/ui/lib/kv/addon/templates/secrets/secret/metadata/edit.hbs
@@ -1,1 +1,1 @@
-secrets.secret.metadata.edit
+<Page::Secret::MetadataEdit @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kv/addon/templates/secrets/secret/metadata/index.hbs
+++ b/ui/lib/kv/addon/templates/secrets/secret/metadata/index.hbs
@@ -1,0 +1,1 @@
+<Page::Secret::MetadataDetails @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/tests/integration/components/kv-page-header-test.js
+++ b/ui/tests/integration/components/kv-page-header-test.js
@@ -1,0 +1,128 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'vault/tests/helpers';
+import { setupEngine } from 'ember-engines/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { kvDataPath } from 'vault/utils/kv-path';
+
+module('Integration | Component | kv | kv-page-header', function (hooks) {
+  setupRenderingTest(hooks);
+  setupEngine(hooks, 'kv');
+  setupMirage(hooks);
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.backend = 'kv-engine';
+    this.path = 'my-secret';
+    this.version = 2;
+    this.id = kvDataPath(this.backend, this.path, this.version);
+    this.payload = {
+      backend: this.backend,
+      path: this.path,
+      version: 2,
+    };
+    this.store.pushPayload('kv/data', {
+      modelName: 'kv/data',
+      id: this.id,
+      ...this.payload,
+    });
+
+    this.model = this.store.peekRecord('kv/data', this.id);
+    this.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: this.model.backend, route: 'secrets' },
+      { label: this.model.path, route: 'secrets.secret.details', model: this.model.path },
+      { label: 'edit' },
+    ];
+  });
+
+  test('it renders breadcrumbs', async function (assert) {
+    await render(
+      hbs`<KvPageHeader @breadcrumbs={{this.breadcrumbs}} @model={{this.model}} @pageTitle="Create new version"/>`,
+      {
+        owner: this.engine,
+      }
+    );
+    assert.dom('[data-test-breadcrumbs] li:nth-child(1) a').hasText('secrets', 'Secrets breadcrumb renders');
+    assert.dom('[data-test-breadcrumbs] li:nth-child(2) a').hasText(this.backend, 'engine name renders');
+    assert.dom('[data-test-breadcrumbs] li:nth-child(3) a').hasText(this.path, 'secret path renders');
+    assert
+      .dom('[data-test-breadcrumbs] li:nth-child(4)')
+      .hasText('/ edit', 'final breadcrumb renders and it is not a link.');
+  });
+
+  test('it renders a custom title for a non engine view', async function (assert) {
+    await render(
+      hbs`<KvPageHeader @breadcrumbs={{this.breadcrumbs}} @model={{this.model}} @pageTitle="Create new version"/>`,
+      {
+        owner: this.engine,
+      }
+    );
+    assert.dom('[data-test-header-title]').hasText('Create new version', 'displays custom title.');
+    assert.dom('[data-test-header-title] svg').doesNotExist('Does not show icon if not at engine level.');
+  });
+
+  test('it renders a title, icon and tag if engine view', async function (assert) {
+    await render(
+      hbs`<KvPageHeader @breadcrumbs={{this.breadcrumbs}} @model={{this.model}} @isEngineView="true"/>`,
+      {
+        owner: this.engine,
+      }
+    );
+    assert
+      .dom('[data-test-header-title]')
+      .hasText(`${this.backend} Version 2`, 'Mount path and Version tag render for title.');
+    assert.dom('[data-test-header-title] span').hasClass('hs-icon', 'An icon renders next to title.');
+  });
+
+  test('it renders tabs', async function (assert) {
+    await render(
+      hbs`<KvPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} @isEngineView="true" >
+    <:tabs>
+    <div class="tabs-container box is-bottomless is-marginless is-paddingless">
+      <nav class="tabs">
+        <ul>
+          <LinkTo @route="secrets" data-test-secrets-tab="Secrets">Secrets</LinkTo>
+          <LinkTo @route="configuration" data-test-secrets-tab="Configuration">Configuration</LinkTo>
+        </ul>
+      </nav>
+    </div>
+  </:tabs>
+  </KvPageHeader>
+    `,
+      {
+        owner: this.engine,
+      }
+    );
+    assert.dom('[data-test-secrets-tab="Secrets"]').hasText('Secrets', 'Secrets tab renders');
+    assert
+      .dom('[data-test-secrets-tab="Configuration"]')
+      .hasText('Configuration', 'Configuration tab renders');
+  });
+
+  test('it should yield block for toolbar actions', async function (assert) {
+    await render(
+      hbs`<KvPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} @isEngineView="true" >
+      <:toolbarActions>
+      <ToolbarLink @route="secrets.create" @type="add">Create secret</ToolbarLink>
+    </:toolbarActions>
+  </KvPageHeader>
+    `,
+      { owner: this.engine }
+    ),
+      assert.dom('.toolbar-actions').exists('Block is yielded for toolbar actions');
+  });
+
+  test('it should yield block for toolbar filters', async function (assert) {
+    await render(
+      hbs`<KvPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} @isEngineView="true" >
+      <:toolbarFilters>
+      <p>stuff here</p>
+    </:toolbarFilters>
+  </KvPageHeader>
+    `,
+      { owner: this.engine }
+    ),
+      assert.dom('.toolbar-filters').exists('Block is yielded for toolbar filters');
+  });
+});

--- a/ui/tests/integration/components/kv-page-header-test.js
+++ b/ui/tests/integration/components/kv-page-header-test.js
@@ -77,7 +77,7 @@ module('Integration | Component | kv | kv-page-header', function (hooks) {
 
   test('it renders tabs', async function (assert) {
     await render(
-      hbs`<KvPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} @isEngineView="true" >
+      hbs`<KvPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} @isEngineView={{true}} >
     <:tabs>
     <div class="tabs-container box is-bottomless is-marginless is-paddingless">
       <nav class="tabs">
@@ -102,7 +102,7 @@ module('Integration | Component | kv | kv-page-header', function (hooks) {
 
   test('it should yield block for toolbar actions', async function (assert) {
     await render(
-      hbs`<KvPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} @isEngineView="true" >
+      hbs`<KvPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} @isEngineView={{true}} >
       <:toolbarActions>
       <ToolbarLink @route="secrets.create" @type="add">Create secret</ToolbarLink>
     </:toolbarActions>
@@ -115,7 +115,7 @@ module('Integration | Component | kv | kv-page-header', function (hooks) {
 
   test('it should yield block for toolbar filters', async function (assert) {
     await render(
-      hbs`<KvPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} @isEngineView="true" >
+      hbs`<KvPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} @isEngineView={{true}} >
       <:toolbarFilters>
       <p>stuff here</p>
     </:toolbarFilters>

--- a/ui/tests/integration/components/kv-page-header-test.js
+++ b/ui/tests/integration/components/kv-page-header-test.js
@@ -78,16 +78,10 @@ module('Integration | Component | kv | kv-page-header', function (hooks) {
   test('it renders tabs', async function (assert) {
     await render(
       hbs`<KvPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} @isEngineView={{true}} >
-    <:tabs>
-    <div class="tabs-container box is-bottomless is-marginless is-paddingless">
-      <nav class="tabs">
-        <ul>
+    <:tabLinks>
           <LinkTo @route="secrets" data-test-secrets-tab="Secrets">Secrets</LinkTo>
           <LinkTo @route="configuration" data-test-secrets-tab="Configuration">Configuration</LinkTo>
-        </ul>
-      </nav>
-    </div>
-  </:tabs>
+  </:tabLinks>
   </KvPageHeader>
     `,
       {


### PR DESCRIPTION
**Note:** I have not tackled permissions here. For my brain to handle that, I need to have the models setup for each route so I can access the permission capabilities. I have added the permissions tasks as acceptance criteria on relevant tickets.

This PR creates the `KvPageHeader` component and adds it to the following views. The component is responsible for breadcrumbs, title, icon, version-tag, tabs, and toolbar actions/filters.

1. Secrets LIST view.
![image](https://github.com/hashicorp/vault/assets/6618863/f7bacdc6-cdb2-43ef-bfdb-eb3b047ab931)
2. Configuration view. No toolbar in this view.
![image](https://github.com/hashicorp/vault/assets/6618863/53069b2b-20c3-4d4c-9ffc-d0b1c641c01b)
3. Create secret view. A toolbar will be added, once I handle the JSON functionality.
![image](https://github.com/hashicorp/vault/assets/6618863/599d6773-b0e8-4952-8f5b-63a108088978)
4. Secret Create new version/edit view. Toolbar actions in another PR.
![image](https://github.com/hashicorp/vault/assets/6618863/4b63be40-b5bd-4f71-98c4-4e0158dbc3fb)
5. Secret Details view
![image](https://github.com/hashicorp/vault/assets/6618863/074910fc-1788-47fa-a6f9-d7a6d9d52ae8)
6. Secret Metadata Details/index view.
![image](https://github.com/hashicorp/vault/assets/6618863/61d926ac-bdbd-467c-b2f9-b699f07b71a7)
7. Secret Metadata Edit view.
![image](https://github.com/hashicorp/vault/assets/6618863/c304baa0-9fa9-46cb-ab4c-f298b61cc0c2)

**One last note:**
In another PR I'll address adding this component to the version diff and version history views. This ticket stuck to the current views/page-headers.
