### PR TITLE
secrets/azure: upgrade to v0.14.2 for bug fix

### DIFF
--- a/changelog/21633.txt
+++ b/changelog/21633.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/azure: Fix intermittent 401s by preventing performance secondary clusters from rotating root credentials. 
+```

--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 	github.com/hashicorp/vault-plugin-mock v0.16.1
 	github.com/hashicorp/vault-plugin-secrets-ad v0.14.1
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.13.0
-	github.com/hashicorp/vault-plugin-secrets-azure v0.14.1
+	github.com/hashicorp/vault-plugin-secrets-azure v0.14.2
 	github.com/hashicorp/vault-plugin-secrets-gcp v0.14.1
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.13.0
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1131,8 +1131,8 @@ github.com/hashicorp/vault-plugin-secrets-ad v0.14.1 h1:XAkEJ9iFJoBwYFYv3wTcdVFq
 github.com/hashicorp/vault-plugin-secrets-ad v0.14.1/go.mod h1:5XIn6cw1+gG+WWxK0SdEAKCDOXTp+MX90PzZ7f3Eks0=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.13.0 h1:eWDAAvZsKHhnXF8uCiyF/wDqT57fflCs54PTIolONBo=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.13.0/go.mod h1:F4KWrlCQZbhP2dFXCkRvbHX2J6CTydlaY0cH+OrLHCE=
-github.com/hashicorp/vault-plugin-secrets-azure v0.14.1 h1:Dh4b7sILU+O17K+g2tWGdeGq9djPw5rqFCOX69JxJbA=
-github.com/hashicorp/vault-plugin-secrets-azure v0.14.1/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
+github.com/hashicorp/vault-plugin-secrets-azure v0.14.2 h1:76n+SYHr2TV1WIfQxcbIrRM8gpAsqIX9BA0DuDcT/Vs=
+github.com/hashicorp/vault-plugin-secrets-azure v0.14.2/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.14.1 h1:e9uQuKQ4hJWwa19IUSNMolhT0BczyoDryMN83gr3dhY=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.14.1/go.mod h1:kRgZfXRD9qUHoGclaR09tKXXwkwNrkY+D76ahetsaB8=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.13.0 h1:R36pNaaN4tJyIrPJej7/355Qt5+Q5XUTB+Az6rGs5xg=


### PR DESCRIPTION
This PR upgrades vault-plugin-secrets-azure to [v0.14.2](https://github.com/hashicorp/vault-plugin-secrets-azure/releases/tag/v0.14.2) to bring in a bug fix from https://github.com/hashicorp/vault-plugin-secrets-azure/pull/150.