### PR TITLE
Test: add code that would break ent if merged prior to stubmaker

### DIFF
--- a/vault/test_stubmaker.go
+++ b/vault/test_stubmaker.go
@@ -1,0 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"github.com/hashicorp/vault/vault/cluster"
+)
+
+func test() {
+	testStubmaker(cluster.Listener{})
+	testStubmaker2()
+}

--- a/vault/test_stubmaker_oss.go
+++ b/vault/test_stubmaker_oss.go
@@ -1,0 +1,16 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !enterprise
+
+package vault
+
+import (
+	"github.com/hashicorp/vault/vault/cluster"
+	"github.com/hashicorp/vault/vault/seal"
+)
+
+//go:generate go run github.com/hashicorp/vault/tools/stubmaker
+
+func testStubmaker(_ cluster.Listener) {}
+func testStubmaker2() *seal.Envelope   { return nil }


### PR DESCRIPTION
This change will be reverted, but first I want to commit and merge it to ent, to validate that stubmaker will prevent the build from breaking as a result.  I've done lots of other testing, but now I want to test the real thing.  cf https://github.com/hashicorp/vault/pull/21564