### PR TITLE
workflows: update plugin check job to use branch as ref

### DIFF
--- a/.github/scripts/plugin-helper-gh-pr-create.sh
+++ b/.github/scripts/plugin-helper-gh-pr-create.sh
@@ -34,8 +34,8 @@ echo "captured response:"
 echo "$resp" | jq .
 
 # get Vault PR number
-vault_pr_num=$(echo "$resp" | jq '.number')
-vault_pr_url=$(echo "$resp" | jq '.html_url')
+vault_pr_num=$(echo "$resp" | jq -r '.number')
+vault_pr_url=$(echo "$resp" | jq -r '.html_url')
 echo "Vault PR number: $vault_pr_url"
 
 # add labels to Vault PR - this requires a wider permission set than we currently have available as a repo token

--- a/.github/workflows/plugin-update-check.yml
+++ b/.github/workflows/plugin-update-check.yml
@@ -19,8 +19,7 @@ jobs:
       VAULT_BRANCH: "auto-plugin-update/${{inputs.repo}}/${{inputs.plugin_branch}}"
       RUN_ID: "${{github.run_id}}"
     steps:
-      - run: echo "Branch: $PLUGIN_BRANCH of $PLUGIN_REPO"
-
+      - run: echo "Branch $PLUGIN_BRANCH of $PLUGIN_REPO"
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           # We don't use the default token so that checks are executed on the resulting PR

--- a/.github/workflows/plugin-update-check.yml
+++ b/.github/workflows/plugin-update-check.yml
@@ -5,10 +5,6 @@ on:
         type: string
         description: 'The owner and repository name as per the github.repository context property.'
         required: true
-      sha:
-        type: string
-        description: 'The hash of the plugin repository commit to use'
-        required: true
       plugin_branch:
         type: string
         description: 'The name of the plugin branch'
@@ -18,29 +14,33 @@ jobs:
   plugin-update-check:
     runs-on: ubuntu-latest
     env:
-      COMMIT_SHA: "${{inputs.sha}}"
       PLUGIN_REPO: "${{inputs.repo}}"
       PLUGIN_BRANCH: "${{inputs.plugin_branch}}"
-      VAULT_BRANCH: "auto-plugin-update/${{inputs.repo}}/${{inputs.sha}}"
+      VAULT_BRANCH: "auto-plugin-update/${{inputs.repo}}/${{inputs.plugin_branch}}"
       RUN_ID: "${{github.run_id}}"
     steps:
-      - run: echo "would use $COMMIT_SHA of $PLUGIN_REPO"
-        # checkout
+      - run: echo "Branch: $PLUGIN_BRANCH of $PLUGIN_REPO"
+
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           # We don't use the default token so that checks are executed on the resulting PR
           # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
           token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-        # activate go
+
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          go-version-file: .go-version
+
       - name: update plugin
         run: |
-          go get "github.com/$PLUGIN_REPO@$COMMIT_SHA"
+          go get "github.com/$PLUGIN_REPO@$PLUGIN_BRANCH"
           go mod tidy
+
       - name: detect changes
         id: changes
         run: |
           echo "count=$(git status --porcelain=v1 2>/dev/null | wc -l)" >> "$GITHUB_OUTPUT"
+
       - name: commit/push
         if: steps.changes.outputs.count > 0
         run: |
@@ -49,6 +49,7 @@ jobs:
           git add .
           git commit -m "Automated dependency upgrades"
           git push -f origin ${{ github.ref_name }}:"$VAULT_BRANCH"
+
       - name: Open pull request if needed
         if: steps.changes.outputs.count > 0
         env:
@@ -63,5 +64,4 @@ jobs:
 
           else
             echo "Pull request already exists, won't create a new one."
-            exit 1
           fi


### PR DESCRIPTION
Use the plugin branch name as the ref for `go get` so that we can make this callable as a standalone job outsite of auto dep update PRs.