### PR TITLE
adds fixed height to error-icon class to fix another safari style bug…

### DIFF
--- a/ui/app/styles/components/icon.scss
+++ b/ui/app/styles/components/icon.scss
@@ -75,11 +75,15 @@
   height: 32px;
 }
 
+// if using @stretched on FlightIcon there must be an explicit height set on the parent if used in a flexbox
+// without height set the flexbox will scale out of proportion on Safari
+
 .brand-icon-large {
   width: 62px;
-  height: 62px; // without an explicit height the view breaks in Safari
+  height: 62px;
 }
 
 .error-icon {
   width: 48px;
+  height: 48px;
 }


### PR DESCRIPTION
Relates to #21582

While doing some testing, another Safari style issued was found relating to stretched icons. There was another class missing a defined height used in the error route which has been added.

![image](https://github.com/hashicorp/vault/assets/24611656/aa4015db-b707-404d-ac56-47fa10f30ab7)
