### PR TITLE
pre-commit hook for formatting backend code

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -35,7 +35,7 @@ block() {
 
 # Add all check functions to this space separated list.
 # They are executed in this order (see end of file).
-CHECKS="ui_lint"
+CHECKS="ui_lint backend_lint"
 
 # Run ui linter if changes in that dir detected.
 ui_lint() {
@@ -58,6 +58,15 @@ ui_lint() {
   # Run the linter from the UI dir.
   cd $DIR
   $LINTER || block "UI lint failed"
+}
+
+backend_lint() {
+  # Silently succeed if no changes staged for Go code files.
+  if git diff --name-only --cached --exit-code -- '*.go'; then
+    return 0
+  fi
+
+  ./scripts/gofmtcheck.sh || block "Backend linting failed; run 'make fmt' to fix."
 }
 
 for CHECK in $CHECKS; do

--- a/Makefile
+++ b/Makefile
@@ -238,8 +238,7 @@ proto: bootstrap
 	protoc-go-inject-tag -input=./helper/identity/mfa/types.pb.go
 
 fmtcheck:
-	@true
-#@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
+	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
 fmt: ci-bootstrap
 	find . -name '*.go' | grep -v pb.go | grep -v vendor | xargs go run mvdan.cc/gofumpt -w

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -1021,23 +1021,23 @@ func TestACMESubjectFieldsAndExtensionsIgnored(t *testing.T) {
 	acmeClient := getAcmeClientForCluster(t, cluster, directory, nil)
 	cr := &x509.CertificateRequest{
 		Subject:  pkix.Name{CommonName: domains[0], OrganizationalUnit: []string{"DadgarCorp IT"}},
-        DNSNames: domains,
-    }
+		DNSNames: domains,
+	}
 	cert := doACMEForCSRWithDNS(t, dns, acmeClient, domains, cr)
 	t.Logf("Got certificate: %v", cert)
 	require.Empty(t, cert.Subject.OrganizationalUnit)
 
-    // Use the default sign-verbatim policy and ensure extension does not get set.
-    domains = []string{"no-ext.dadgarcorp.com"}
+	// Use the default sign-verbatim policy and ensure extension does not get set.
+	domains = []string{"no-ext.dadgarcorp.com"}
 	extension, err := certutil.CreateDeltaCRLIndicatorExt(12345)
 	require.NoError(t, err)
-    cr = &x509.CertificateRequest{
-        Subject:  pkix.Name{CommonName: domains[0]},
-        DNSNames: domains,
+	cr = &x509.CertificateRequest{
+		Subject:         pkix.Name{CommonName: domains[0]},
+		DNSNames:        domains,
 		ExtraExtensions: []pkix.Extension{extension},
-    }
-    cert = doACMEForCSRWithDNS(t, dns, acmeClient, domains, cr)
-    t.Logf("Got certificate: %v", cert)
+	}
+	cert = doACMEForCSRWithDNS(t, dns, acmeClient, domains, cr)
+	t.Logf("Got certificate: %v", cert)
 	for _, ext := range cert.Extensions {
 		require.False(t, ext.Id.Equal(certutil.DeltaCRLIndicatorOID))
 	}

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -5,9 +5,9 @@
 
 echo "==> Checking that code complies with gofmt requirements..."
 
-gofmt_files=$(gofmt -l `find . -name '*.go' | grep -v vendor`)
-if [[ -n ${gofmt_files} ]]; then 
-    echo 'gofmt needs running on the following files:'
+gofmt_files="$(find . -name '*.go' | grep -v pb.go | grep -v vendor | xargs go run mvdan.cc/gofumpt -l)"
+if [[ -n "${gofmt_files}" ]]; then
+    echo 'gofumpt needs running on the following files:'
     echo "${gofmt_files}"
     echo "You can use the command: \`make fmt\` to reformat code."
     exit 1


### PR DESCRIPTION
This adds/updates the pre-commit hook to add a backend format checking prior to commit, similar to the existing UI check.

This should reduce the number of PR authors (mostly, myself) who commit things without checking that `fmt` CI has passed... :-) 