### PR TITLE
Run HashiCorp contributed labeler on every branch

### DIFF
--- a/.github/workflows/add-hashicorp-contributed-label.yml
+++ b/.github/workflows/add-hashicorp-contributed-label.yml
@@ -9,11 +9,9 @@ name: Add HashiCorp contributed label
 # possible.
 
 on:
+  # On every pull request, on every branch
   pull_request:
     types: [opened, synchronize, reopened]
-    # Runs on PRs to main
-    branches:
-      - main
 
 jobs:
   add-hashicorp-contributed-label:


### PR DESCRIPTION
We don't want backports etc showing up :)