### PR TITLE
Attempt to address autoloading issues within Bind backend tests

### DIFF
--- a/builtin/logical/pki/dnstest/server.go
+++ b/builtin/logical/pki/dnstest/server.go
@@ -207,6 +207,9 @@ func (ts *TestServer) PushConfig() {
 	ts.lock.Lock()
 	defer ts.lock.Unlock()
 
+	_, _, _, err := ts.runner.RunCmdWithOutput(ts.ctx, ts.startup.Container.ID, []string{"rndc", "freeze"})
+	require.NoError(ts.t, err, "failed to freeze DNS config")
+
 	// There's two cases here:
 	//
 	// 1. We've added a new top-level domain name. Here, we want to make
@@ -216,6 +219,9 @@ func (ts *TestServer) PushConfig() {
 	//    mostly likely the second push will be a no-op.
 	ts.pushZoneFiles()
 	ts.pushNamedConf()
+
+	_, _, _, err = ts.runner.RunCmdWithOutput(ts.ctx, ts.startup.Container.ID, []string{"rndc", "thaw"})
+	require.NoError(ts.t, err, "failed to thaw DNS config")
 
 	// Wait until our config has taken.
 	corehelpers.RetryUntil(ts.t, 15*time.Second, func() error {


### PR DESCRIPTION
 - We've seen a few issues with bind's auto-loading of configuration too quickly at bad times leading to it having partial configurations or not all files/permissions being restored properly during it's read attempt.
 - See if the freeze/thaw rndc commands will help out with these timing issues