### PR TITLE
Add a parameter to allow ExtKeyUsage field usage from a role

### DIFF
--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -398,13 +398,16 @@ func getAcmeRoleAndIssuer(sc *storageContext, data *framework.FieldData, config 
 		}
 	}
 
-	// Override ExtKeyUsage behavior to force it to only be ServerAuth within ACME issued certs
-	role.ExtKeyUsage = []string{"serverauth"}
-	role.ExtKeyUsageOIDs = []string{}
-	role.ServerFlag = true
-	role.ClientFlag = false
-	role.CodeSigningFlag = false
-	role.EmailProtectionFlag = false
+	// If not allowed in configuration, override ExtKeyUsage behavior to force it to only be
+	// ServerAuth within ACME issued certs
+	if !config.AllowRoleExtkeyusage {
+		role.ExtKeyUsage = []string{"serverauth"}
+		role.ExtKeyUsageOIDs = []string{}
+		role.ServerFlag = true
+		role.ClientFlag = false
+		role.CodeSigningFlag = false
+		role.EmailProtectionFlag = false
+	}
 
 	return role, issuer, nil
 }

--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -400,7 +400,7 @@ func getAcmeRoleAndIssuer(sc *storageContext, data *framework.FieldData, config 
 
 	// If not allowed in configuration, override ExtKeyUsage behavior to force it to only be
 	// ServerAuth within ACME issued certs
-	if !config.AllowRoleExtkeyusage {
+	if !config.AllowRoleExtKeyUsage {
 		role.ExtKeyUsage = []string{"serverauth"}
 		role.ExtKeyUsageOIDs = []string{}
 		role.ServerFlag = true

--- a/builtin/logical/pki/path_acme_order.go
+++ b/builtin/logical/pki/path_acme_order.go
@@ -589,7 +589,7 @@ func issueCertFromCsr(ac *acmeContext, csr *x509.CertificateRequest) (*certutil.
 		return nil, "", fmt.Errorf("failed to fetch ACME configuration: %w", err)
 	}
 
-	if !config.AllowRoleExtkeyusage {
+	if !config.AllowRoleExtKeyUsage {
 		for _, usage := range parsedBundle.Certificate.ExtKeyUsage {
 			if usage != x509.ExtKeyUsageServerAuth {
 				return nil, "", fmt.Errorf("%w: ACME certs only allow ServerAuth key usage", ErrBadCSR)

--- a/builtin/logical/pki/path_config_acme.go
+++ b/builtin/logical/pki/path_config_acme.go
@@ -27,7 +27,7 @@ type acmeConfigEntry struct {
 	Enabled                bool          `json:"enabled"`
 	AllowedIssuers         []string      `json:"allowed_issuers="`
 	AllowedRoles           []string      `json:"allowed_roles"`
-	AllowRoleExtkeyusage   bool          `json:"allow_role_extkeyusage"`
+	AllowRoleExtKeyUsage   bool          `json:"allow_role_ext_key_usage"`
 	DefaultDirectoryPolicy string        `json:"default_directory_policy"`
 	DNSResolver            string        `json:"dns_resolver"`
 	EabPolicyName          EabPolicyName `json:"eab_policy_name"`
@@ -37,7 +37,7 @@ var defaultAcmeConfig = acmeConfigEntry{
 	Enabled:                false,
 	AllowedIssuers:         []string{"*"},
 	AllowedRoles:           []string{"*"},
-	AllowRoleExtkeyusage:   false,
+	AllowRoleExtKeyUsage:   false,
 	DefaultDirectoryPolicy: "sign-verbatim",
 	DNSResolver:            "",
 	EabPolicyName:          eabPolicyNotRequired,
@@ -100,7 +100,7 @@ func pathAcmeConfig(b *backend) *framework.Path {
 				Description: `which roles are allowed for use with ACME; by default via '*', these will be all roles including sign-verbatim; when concrete role names are specified, any default_directory_policy role must be included to allow usage of the default acme directories under /pki/acme/directory and /pki/issuer/:issuer_id/acme/directory.`,
 				Default:     []string{"*"},
 			},
-			"allow_role_extkeyusage": {
+			"allow_role_ext_key_usage": {
 				Type:        framework.TypeBool,
 				Description: `whether the ExtKeyUsage field from a role is used, defaults to false meaning that certificate will be signed with ServerAuth.`,
 				Default:     false,
@@ -168,7 +168,7 @@ func genResponseFromAcmeConfig(config *acmeConfigEntry, warnings []string) *logi
 	response := &logical.Response{
 		Data: map[string]interface{}{
 			"allowed_roles":            config.AllowedRoles,
-			"allow_role_extkeyusage":   config.AllowRoleExtkeyusage,
+			"allow_role_ext_key_usage": config.AllowRoleExtKeyUsage,
 			"allowed_issuers":          config.AllowedIssuers,
 			"default_directory_policy": config.DefaultDirectoryPolicy,
 			"enabled":                  config.Enabled,
@@ -202,8 +202,8 @@ func (b *backend) pathAcmeWrite(ctx context.Context, req *logical.Request, d *fr
 		}
 	}
 
-	if allowRoleExtKeyUsageRaw, ok := d.GetOk("allow_role_extkeyusage"); ok {
-		config.AllowRoleExtkeyusage = allowRoleExtKeyUsageRaw.(bool)
+	if allowRoleExtKeyUsageRaw, ok := d.GetOk("allow_role_ext_key_usage"); ok {
+		config.AllowRoleExtKeyUsage = allowRoleExtKeyUsageRaw.(bool)
 	}
 
 	if defaultDirectoryPolicyRaw, ok := d.GetOk("default_directory_policy"); ok {

--- a/builtin/logical/pki/path_config_acme.go
+++ b/builtin/logical/pki/path_config_acme.go
@@ -27,6 +27,7 @@ type acmeConfigEntry struct {
 	Enabled                bool          `json:"enabled"`
 	AllowedIssuers         []string      `json:"allowed_issuers="`
 	AllowedRoles           []string      `json:"allowed_roles"`
+	AllowRoleExtkeyusage   bool          `json:"allow_role_extkeyusage"`
 	DefaultDirectoryPolicy string        `json:"default_directory_policy"`
 	DNSResolver            string        `json:"dns_resolver"`
 	EabPolicyName          EabPolicyName `json:"eab_policy_name"`
@@ -36,6 +37,7 @@ var defaultAcmeConfig = acmeConfigEntry{
 	Enabled:                false,
 	AllowedIssuers:         []string{"*"},
 	AllowedRoles:           []string{"*"},
+	AllowRoleExtkeyusage:   false,
 	DefaultDirectoryPolicy: "sign-verbatim",
 	DNSResolver:            "",
 	EabPolicyName:          eabPolicyNotRequired,
@@ -97,6 +99,11 @@ func pathAcmeConfig(b *backend) *framework.Path {
 				Type:        framework.TypeCommaStringSlice,
 				Description: `which roles are allowed for use with ACME; by default via '*', these will be all roles including sign-verbatim; when concrete role names are specified, any default_directory_policy role must be included to allow usage of the default acme directories under /pki/acme/directory and /pki/issuer/:issuer_id/acme/directory.`,
 				Default:     []string{"*"},
+			},
+			"allow_role_extkeyusage": {
+				Type:        framework.TypeBool,
+				Description: `whether the ExtKeyUsage field from a role is used, defaults to false meaning that certificate will be signed with ServerAuth.`,
+				Default:     false,
 			},
 			"default_directory_policy": {
 				Type:        framework.TypeString,
@@ -161,6 +168,7 @@ func genResponseFromAcmeConfig(config *acmeConfigEntry, warnings []string) *logi
 	response := &logical.Response{
 		Data: map[string]interface{}{
 			"allowed_roles":            config.AllowedRoles,
+			"allow_role_extkeyusage":   config.AllowRoleExtkeyusage,
 			"allowed_issuers":          config.AllowedIssuers,
 			"default_directory_policy": config.DefaultDirectoryPolicy,
 			"enabled":                  config.Enabled,
@@ -192,6 +200,10 @@ func (b *backend) pathAcmeWrite(ctx context.Context, req *logical.Request, d *fr
 		if len(config.AllowedRoles) == 0 {
 			return nil, fmt.Errorf("allowed_roles must take a non-zero length value; specify '*' as the value to allow anything or specify enabled=false to disable ACME entirely")
 		}
+	}
+
+	if allowRoleExtKeyUsageRaw, ok := d.GetOk("allow_role_extkeyusage"); ok {
+		config.AllowRoleExtkeyusage = allowRoleExtKeyUsageRaw.(bool)
 	}
 
 	if defaultDirectoryPolicyRaw, ok := d.GetOk("default_directory_policy"); ok {

--- a/changelog/21702.txt
+++ b/changelog/21702.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-secrets/pki: Add a parameter to allow ExtKeyUsage field usage from a role.
+secrets/pki: Add a parameter to allow ExtKeyUsage field usage from a role within ACME.
 ```

--- a/changelog/21702.txt
+++ b/changelog/21702.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Add a parameter to allow ExtKeyUsage field usage from a role.
+```

--- a/ui/app/models/pki/config/acme.js
+++ b/ui/app/models/pki/config/acme.js
@@ -44,7 +44,7 @@ export default class PkiConfigAcmeModel extends Model {
     subText:
       'When enabled, respect the ExtKeyUsage role configuration. Otherwise, ACME certificates are forced to ServerAuth only.',
   })
-  allowRoleExtkeyusage;
+  allowRoleExtKeyUsage;
 
   @attr('array', {
     editType: 'stringArray',

--- a/ui/app/models/pki/config/acme.js
+++ b/ui/app/models/pki/config/acme.js
@@ -40,9 +40,9 @@ export default class PkiConfigAcmeModel extends Model {
   allowedRoles;
 
   @attr('boolean', {
-    label: 'Allow ExtKeyUsage usage',
+    label: 'Allow role ExtKeyUsage',
     subText:
-      'When enabled, respect the ExtKeyUsage role configuration. Otherwise, ACME certificates are forced to ServerAuth only.',
+      "When enabled, respect the role's ExtKeyUsage flags. Otherwise, ACME certificates are forced to ServerAuth.",
   })
   allowRoleExtKeyUsage;
 

--- a/ui/app/models/pki/config/acme.js
+++ b/ui/app/models/pki/config/acme.js
@@ -42,7 +42,7 @@ export default class PkiConfigAcmeModel extends Model {
   @attr('boolean', {
     label: 'Allow ExtKeyUsage usage',
     subText:
-      'When enabled, respect the role configuration. Otherwise, the field is forced to ServerAuth only.',
+      'When enabled, respect the ExtKeyUsage role configuration. Otherwise, ACME certificates are forced to ServerAuth only.',
   })
   allowRoleExtkeyusage;
 

--- a/ui/app/models/pki/config/acme.js
+++ b/ui/app/models/pki/config/acme.js
@@ -39,6 +39,13 @@ export default class PkiConfigAcmeModel extends Model {
   })
   allowedRoles;
 
+  @attr('boolean', {
+    label: 'Allow ExtKeyUsage usage',
+    subText:
+      'When enabled, respect the role configuration. Otherwise, the field is forced to ServerAuth only.',
+  })
+  allowRoleExtkeyusage;
+
   @attr('array', {
     editType: 'stringArray',
     subText:

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -374,6 +374,10 @@ mount.
    an issuer outside this list, it will be allowed. The default value `*`
    allows every issuer within the mount.
 
+  - `allow_role_extkeyusage` `(bool: false)` - whether the ExtKeyUsage field
+   from a role is used, defaults to false meaning that certificate will be
+   signed with ServerAuth.
+
  - `allowed_roles` `(list: ["*"])` - Specifies a list of roles allowed to
    issue certificates via explicit ACME paths.  The default value `*` allows
    every role within the mount to be used.  If the `default_directory_policy`

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -374,7 +374,7 @@ mount.
    an issuer outside this list, it will be allowed. The default value `*`
    allows every issuer within the mount.
 
-  - `allow_role_extkeyusage` `(bool: false)` - whether the ExtKeyUsage field
+  - `allow_role_ext_key_usage` `(bool: false)` - whether the ExtKeyUsage field
    from a role is used, defaults to false meaning that certificate will be
    signed with ServerAuth.
 


### PR DESCRIPTION
As discussed in #21549, there is some use cases where allowing expanding ExtKeyUsage is adequate (eg containers).  
This PR adds a new configuration option on ACME to allow usage of the ExtKeyUsage field defined within a role.
