### PR TITLE
VAULT-15958: Fix pr/no-milestone 

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -12,3 +12,5 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: "Check workflow files"
         uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint@sha256:93834930f56ca380be3e9a3377670d7aa5921be251b9c774891a39b3629b83b8
+        with:
+          args: "-ignore=invalid activity type \"demilestoned\" for \"pull_request\" Webhook event -ignore=invalid activity type \"milestoned\" for \"pull_request\" Webhook event"   

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,4 +13,5 @@ jobs:
       - name: "Check workflow files"
         uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint@sha256:93834930f56ca380be3e9a3377670d7aa5921be251b9c774891a39b3629b83b8
         with:
+          # milestoned and demilestoned work (https://github.com/github/docs/issues/23909) but they aren't listed in the github documentation, so actionlint complains about them 
           args: "-ignore=\"invalid activity type \\\"demilestoned\\\" for \\\"pull_request\\\" Webhook event\" -ignore=\"invalid activity type \\\"milestoned\\\" for \\\"pull_request\\\" Webhook event\""

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,4 +13,4 @@ jobs:
       - name: "Check workflow files"
         uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint@sha256:93834930f56ca380be3e9a3377670d7aa5921be251b9c774891a39b3629b83b8
         with:
-          args: "-ignore=invalid activity type \"demilestoned\" for \"pull_request\" Webhook event -ignore=invalid activity type \"milestoned\" for \"pull_request\" Webhook event"   
+          args: "-ignore=\"invalid activity type \\\"demilestoned\\\" for \\\"pull_request\\\" Webhook event\" -ignore=\"invalid activity type \\\"milestoned\\\" for \\\"pull_request\\\" Webhook event\""

--- a/.github/workflows/milestone-checker.yml
+++ b/.github/workflows/milestone-checker.yml
@@ -5,7 +5,7 @@ name: Check Milestone
 
 on:
   pull_request:
-    types: [opened, synchronize, labeled, unlabeled]
+    types: [opened, synchronize, labeled, unlabeled, milestoned, demilestoned]
     # Runs on PRs to main and release branches
     branches:
       - main
@@ -17,7 +17,7 @@ jobs:
   # checks that a milestone entry is present for a PR
   milestone-check:
     # If there is a `pr/no-milestone` label we ignore this check
-    if: "! ( contains(github.event.pull_request.labels.*.name, 'pr/no-milestone') || ( github.event.name == 'labeled' && github.event.label == 'pr/no-milestone' ) )"
+    if: "! ( contains(github.event.pull_request.labels.*.name, 'pr/no-milestone') || ( github.event.name == 'labeled' && github.event.label != 'pr/no-milestone' ) )"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/milestone-checker.yml
+++ b/.github/workflows/milestone-checker.yml
@@ -5,6 +5,7 @@ name: Check Milestone
 
 on:
   pull_request:
+    # milestoned and demilestoned work (https://github.com/github/docs/issues/23909) but they aren't listed in the github documentation 
     types: [opened, synchronize, labeled, unlabeled, milestoned, demilestoned]
     # Runs on PRs to main and release branches
     branches:

--- a/.github/workflows/milestone-checker.yml
+++ b/.github/workflows/milestone-checker.yml
@@ -10,14 +10,12 @@ on:
     branches:
       - main
       - release/**
-  issues:
-    types: [milestoned, demilestoned]
 
 jobs:
   # checks that a milestone entry is present for a PR
   milestone-check:
     # If there is a `pr/no-milestone` label we ignore this check
-    if: "! ( contains(github.event.pull_request.labels.*.name, 'pr/no-milestone') || ( github.event.name == 'labeled' && github.event.label != 'pr/no-milestone' ) )"
+    if: "!contains(github.event.pull_request.labels.*.name, 'pr/no-milestone')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions


### PR DESCRIPTION
The milestone checker will now be re-evaluated if the `pr/no-milestone` label is added or if a milestone is added to the PR. Github documentation doesn't list `milestoned` and `demilestoned` as valid, but they are working. Actionlint also isn't aware of them, so I added ignores for those particular checks to the actionlint action.