### PR TITLE
UI: Remove logic that skips sending object if not changed

### DIFF
--- a/changelog/21739.txt
+++ b/changelog/21739.txt
@@ -1,0 +1,3 @@
+```release-note:bug 
+ui: Fixed an issue where editing an SSH role would clear `default_critical_options` and `default_extension` if left unchanged. 
+```

--- a/ui/app/serializers/application.js
+++ b/ui/app/serializers/application.js
@@ -66,9 +66,6 @@ export default JSONSerializer.extend({
     if (attributes.options.readOnly) {
       return;
     }
-    if (attributes.type === 'object' && val && Object.keys(val).length > 0 && valHasNotChanged) {
-      return;
-    }
     if (valIsBlank && valHasNotChanged) {
       return;
     }


### PR DESCRIPTION
This PR fixes an issue on the UI where editing an SSH role with `default_extension` set causes the `default_extension` to be cleared on edit (#21571)

I spot-checked all the other places where we use `attr('object')` and they seem to work (create, update) fine. Usually on update forms we use `POST` with the entire payload, so I'm not sure why this was the default behavior but if we find instances that this needs to be the case we can override those specific serializers. 