### PR TITLE
Add permet pool metrics to dynamo db backend

### DIFF
--- a/physical/dynamodb/dynamodb.go
+++ b/physical/dynamodb/dynamodb.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
@@ -120,6 +121,12 @@ type DynamoDBLockRecord struct {
 	Value    []byte
 	Identity []byte
 	Expires  int64
+}
+
+type PermitPoolWithMetrics struct {
+	physical.PermitPool
+	pendingPermits int32
+	poolSize	   int
 }
 
 // NewDynamoDBBackend constructs a DynamoDB backend. If the
@@ -908,4 +915,40 @@ func isConditionCheckFailed(err error) bool {
 	}
 
 	return false
+}
+
+// NewPermitPoolWithMetrics returns a new permit pool with the provided
+// number of permits which emits metrics
+func NewPermitPoolWithMetrics(permits int) *PermitPoolWithMetrics {
+	return &PermitPoolWithMetrics{
+		PermitPool:     *physical.NewPermitPool(permits),
+		pendingPermits: 0,
+		poolSize:       permits,
+	}
+}
+
+// Acquire returns when a permit has been acquired
+func (c *PermitPoolWithMetrics) Acquire() {
+	atomic.AddInt32(&c.pendingPermits, 1)
+	c.emitPermitMetrics()
+	c.PermitPool.Acquire()
+	atomic.AddInt32(&c.pendingPermits, -1)
+	c.emitPermitMetrics()
+}
+
+// Release returns a permit to the pool
+func (c *PermitPoolWithMetrics) Release() {
+	c.PermitPool.Release()
+	c.emitPermitMetrics()
+}
+
+// Get the number of requests in the permit pool
+func (c *PermitPoolWithMetrics) CurrentPermits() int {
+	return c.PermitPool.CurrentPermits()
+}
+
+func (c *PermitPoolWithMetrics) emitPermitMetrics() {
+	metrics.SetGauge([]string{"dynamodb", "permit_pool", "pending_permits"}, float32(c.pendingPermits))
+	metrics.SetGauge([]string{"dynamodb", "permit_pool", "active_permits"}, float32(c.PermitPool.CurrentPermits()))
+	metrics.SetGauge([]string{"dynamodb", "permit_pool", "pool_size"}, float32(c.poolSize))
 }


### PR DESCRIPTION
See https://github.com/hashicorp/vault/issues/21588

To aid in debugging we want to have metrics on the number of requests in the permit pool for the dynamodb backend and the number of waiting requests. This change implements this by adding NewPermitPoolWithMetrics which shadows the existing permit pool definition except with calls to publish metrics on the pool size, active requests. and waiting requests before and after each permit is acquired or released