### PR TITLE
Only run fmtcheck on changed files pre-commit

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -62,14 +62,17 @@ ui_lint() {
 
 backend_lint() {
   # Silently succeed if no changes staged for Go code files.
-  if git diff --name-only --cached --exit-code -- '*.go'; then
+  staged=$(git diff --name-only --cached --exit-code -- '*.go')
+  ret=$?
+  if [ $ret -eq 0 ]; then
     return 0
   fi
 
-  ./scripts/gofmtcheck.sh || block "Backend linting failed; run 'make fmt' to fix."
+  # Get only the staged files
+  ./scripts/gofmtcheck.sh "${staged}" || block "Backend linting failed; run 'make fmt' to fix."
 }
 
 for CHECK in $CHECKS; do
   # Force each check into a subshell to avoid crosstalk.
-  ( $CHECK ) || exit $?
+  ($CHECK) || exit $?
 done

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -68,7 +68,7 @@ backend_lint() {
     return 0
   fi
 
-  # Get only the staged files
+  # Only run fmtcheck on staged files
   ./scripts/gofmtcheck.sh "${staged}" || block "Backend linting failed; run 'make fmt' to fix."
 }
 

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -74,5 +74,5 @@ backend_lint() {
 
 for CHECK in $CHECKS; do
   # Force each check into a subshell to avoid crosstalk.
-  ($CHECK) || exit $?
+  ( $CHECK ) || exit $?
 done

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -2,10 +2,17 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-
 echo "==> Checking that code complies with gofmt requirements..."
 
-gofmt_files="$(find . -name '*.go' | grep -v pb.go | grep -v vendor | xargs go run mvdan.cc/gofumpt -l)"
+files=$(echo $1 | xargs)
+if [ -n "$files" ]; then
+    echo "Checking changed files..."
+    gofmt_files="$(echo $1 | grep -v pb.go | grep -v vendor | xargs go run mvdan.cc/gofumpt -l)"
+else
+    echo "Checking all files..."
+    gofmt_files="$(find . -name '*.go' | grep -v pb.go | grep -v vendor | xargs go run mvdan.cc/gofumpt -l)"
+fi
+
 if [[ -n "${gofmt_files}" ]]; then
     echo 'gofumpt needs running on the following files:'
     echo "${gofmt_files}"


### PR DESCRIPTION
The pre-commit hook was taking quite a while to run. Let's just check changed files to avoid unnecessary `go fmt` on the entire tree.