### PR TITLE
Add the ability to add enterprise only backend features in PKI - OSS

### DIFF
--- a/builtin/logical/pki/backend_oss.go
+++ b/builtin/logical/pki/backend_oss.go
@@ -5,6 +5,24 @@
 
 package pki
 
-func setupEntSpecificBackend(_ *backend) {
-	// ENT hook is not used by OSS.
+import (
+	"context"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+type entBackend struct{}
+
+func (b *backend) initializeEnt(_ *storageContext, _ *logical.InitializationRequest) error {
+	return nil
 }
+
+func (b *backend) invalidateEnt(_ context.Context, _ string) {}
+
+func (b *backend) periodicFuncEnt(_ *storageContext, _ *logical.Request) error {
+	return nil
+}
+
+func (b *backend) cleanupEnt(_ *storageContext) {}
+
+func (b *backend) SetupEnt() {}


### PR DESCRIPTION
To allow us to support CIEPS backend state, allow the backend to contain enterprise only state variables. Also allow us to implement enterprise only hooks into the various backend functions to initialize, periodicFunc, cleanup and invalidate.