### PR TITLE
Allow PKI enterprise to influence TestProperAuthing test case

### DIFF
--- a/builtin/logical/pki/backend_oss_test.go
+++ b/builtin/logical/pki/backend_oss_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !enterprise
+
+package pki
+
+func getEntProperAuthingPaths(_ string) map[string]pathAuthChecker {
+	return map[string]pathAuthChecker{}
+}
+
+func entProperAuthingPathReplacer(rawPath string) string {
+	return rawPath
+}

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/helper/testhelpers/teststorage"
+	"golang.org/x/exp/maps"
 
 	"github.com/hashicorp/vault/helper/testhelpers"
 
@@ -6867,6 +6868,9 @@ func TestProperAuthing(t *testing.T) {
 		"eab/" + eabKid:                          shouldBeAuthed,
 	}
 
+	entPaths := getEntProperAuthingPaths(serial)
+	maps.Copy(paths, entPaths)
+
 	// Add ACME based paths to the test suite
 	for _, acmePrefix := range []string{"", "issuer/default/", "roles/test/", "issuer/default/roles/test/"} {
 		paths[acmePrefix+"acme/directory"] = shouldBeUnauthedReadList
@@ -6944,6 +6948,8 @@ func TestProperAuthing(t *testing.T) {
 		if strings.Contains(raw_path, "eab") && strings.Contains(raw_path, "{key_id}") {
 			raw_path = strings.ReplaceAll(raw_path, "{key_id}", eabKid)
 		}
+
+		raw_path = entProperAuthingPathReplacer(raw_path)
 
 		handler, present := paths[raw_path]
 		if !present {


### PR DESCRIPTION
 - Allow enterprise repository to hook into and influence the proper authing test so we don't have to add values to OSS for enterprise work