### PR TITLE
Support Enos failure notifications for other workflow triggers 

### DIFF
--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -188,13 +188,13 @@ jobs:
         if: ${{ always() }}
         with:
           failure-message: "An Enos scenario `run_retry` failed. \nTriggering event: `${{ github.event_name }}` \nActor: `${{ github.actor }}`"
-          status: ${{steps.run_retry.outcome}}
-          slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}
+          status: ${{ steps.run_retry.outcome }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       # Send a Slack notification to #feed-vault-enos-failures if the 'destroy' step fails.
       - name: Send Slack notification on Enos destroy failure
         uses: hashicorp/actions-slack-status@v1
         if: ${{ always() }}
         with:
           failure-message: "An Enos scenario `destroy` failed. \nTriggering event: `${{ github.event_name }}` \nActor: `${{ github.actor }}`"
-          status: ${{steps.destroy.outcome}}
-          slack-webhook-url: ${{secrets.SLACK_WEBHOOK_URL}}
+          status: ${{ steps.destroy.outcome }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
There are several workflow triggers on this repo (push, pull_request, repository_dispatch, workflow_dispatch), all with different `github.event` properties, and it's not easy to create a conditional Slack message based on that, so I'm switching this back to just the items that are common to all the workflow triggers. 