### PR TITLE
auth/azure: upgrade to v0.15.1 for bug fix

### DIFF
--- a/changelog/21800.txt
+++ b/changelog/21800.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/azure: Fix intermittent 401s by preventing performance secondary clusters from rotating root credentials. 
+```

--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,7 @@ require (
 	github.com/hashicorp/raft-boltdb/v2 v2.0.0-20210421194847-a7e34179d62c
 	github.com/hashicorp/raft-snapshot v1.0.4
 	github.com/hashicorp/vault-plugin-auth-alicloud v0.15.0
-	github.com/hashicorp/vault-plugin-auth-azure v0.15.0
+	github.com/hashicorp/vault-plugin-auth-azure v0.15.1
 	github.com/hashicorp/vault-plugin-auth-centrify v0.15.1
 	github.com/hashicorp/vault-plugin-auth-cf v0.15.0
 	github.com/hashicorp/vault-plugin-auth-gcp v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -1878,8 +1878,8 @@ github.com/hashicorp/serf v0.10.1 h1:Z1H2J60yRKvfDYAOZLd2MU0ND4AH/WDz7xYHDWQsIPY
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
 github.com/hashicorp/vault-plugin-auth-alicloud v0.15.0 h1:R2SVwOeVLG5DXzUx42UWhjfFqS0Z9+ncfebPu+gO9VA=
 github.com/hashicorp/vault-plugin-auth-alicloud v0.15.0/go.mod h1:YQXpa2s4rGYKm3Oa/Nkgh5SuGVfHFNEIUwDDYWyhloE=
-github.com/hashicorp/vault-plugin-auth-azure v0.15.0 h1:OPK3rpRsWUQm/oo8l4N+YS7dka+lUHDT/qxTafSFPzY=
-github.com/hashicorp/vault-plugin-auth-azure v0.15.0/go.mod h1:qRCibAYC0AV4s2+HxEwmLMPNLENK1kx2mrq9ldnGdkY=
+github.com/hashicorp/vault-plugin-auth-azure v0.15.1 h1:CknW0l2O70326KfepWeDuPszuNherhAtVNaSLRBsS4U=
+github.com/hashicorp/vault-plugin-auth-azure v0.15.1/go.mod h1:qRCibAYC0AV4s2+HxEwmLMPNLENK1kx2mrq9ldnGdkY=
 github.com/hashicorp/vault-plugin-auth-centrify v0.15.1 h1:6StAr5tltpySNgyUwWC8czm9ZqkO7NIZfcRmxxtFwQ8=
 github.com/hashicorp/vault-plugin-auth-centrify v0.15.1/go.mod h1:xXs4I5yLxbQ5VHcpvSxkRhShCTXd8Zyrni8qnFrfQ4Y=
 github.com/hashicorp/vault-plugin-auth-cf v0.15.0 h1:zIVGlYXCRBY/ElucWdFC9xF27d2QMGMQPm9wSezGREI=


### PR DESCRIPTION
This PR upgrades vault-plugin-auth-azure to [v0.15.1](https://github.com/hashicorp/vault-plugin-auth-azure/releases/tag/v0.15.1) to bring in a bug fix from https://github.com/hashicorp/vault-plugin-auth-azure/pull/118.