### PR TITLE
Docs: audit file setting 'discard' description update

### DIFF
--- a/website/content/docs/audit/file.mdx
+++ b/website/content/docs/audit/file.mdx
@@ -52,7 +52,7 @@ these device-specific options:
 
   - `stdout` writes the audit log to standard output
 
-  - `discard` writes output (useful in testing scenarios)
+  - `discard` discards output, instead of writing it to a device (useful in testing scenarios)
 
 - `mode` `(string: "0600")` - A string containing an octal number representing
   the bit pattern for the file mode, similar to `chmod`. Set to `"0000"` to


### PR DESCRIPTION
Docs PR to update the text associated with the `discard` setting for a audit file device.

See: https://vault-3zuxpmrs1-hashicorp.vercel.app/vault/docs/audit/file#discard