### PR TITLE
Change github.base_ref to github.ref_name for Vault-17777

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -238,15 +238,12 @@ jobs:
             export VAULT_BINARY
           fi
 
-          # shellcheck disable=SC2086 # can't quote package list
-
           # On a release branch, add a flag to rerun failed tests
           if [[ "${{ github.ref_name }}" = "release/*" ]]; then
            RERUN_FAILS="--rerun-fails"
           fi
 
-          # shellcheck disable=SC2059:RERUN_FAILS
-          
+          # shellcheck disable=SC2086 # can't quote package list
           GOARCH=${{ inputs.go-arch }} \
             go run gotest.tools/gotestsum --format=short-verbose \
               --junitfile test-results/go-test/results-${{ matrix.id }}.xml \

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -241,7 +241,7 @@ jobs:
           # shellcheck disable=SC2086 # can't quote package list
 
           # On a release branch, add a flag to rerun failed tests
-          if [[ ${{ github.ref_name }} == 'release/*' ]]; then
+          if [[ "${{ github.ref_name }}" == "release/*" ]]; then
            RERUN_FAILS="--rerun-fails"
           fi
 
@@ -250,7 +250,7 @@ jobs:
               --junitfile test-results/go-test/results-${{ matrix.id }}.xml \
               --jsonfile test-results/go-test/results-${{ matrix.id }}.json \
               --jsonfile-timing-events failure-summary-${{ matrix.id }}${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}.json \
-              $RERUN_FAILS \
+              "$RERUN_FAILS" \
               --packages "${{ matrix.packages }}" \
               -- \
               -tags "${{ inputs.go-tags }}" \

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -243,7 +243,7 @@ jobs:
            RERUN_FAILS="--rerun-fails"
           fi
 
-          # shellcheck disable=SC2086 # can't quote package list
+          # shellcheck disable=SC2086 # can't quote RERUN_FAILS
           GOARCH=${{ inputs.go-arch }} \
             go run gotest.tools/gotestsum --format=short-verbose \
               --junitfile test-results/go-test/results-${{ matrix.id }}.xml \

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -241,7 +241,7 @@ jobs:
           # shellcheck disable=SC2086 # can't quote package list
 
           # On a release branch, add a flag to rerun failed tests
-          if [[ "${{ github.ref_name }}" == "release/*" ]]; then
+          if [[ "${{ github.ref_name }}" = "release/*" ]]; then
            RERUN_FAILS="--rerun-fails"
           fi
 

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -245,12 +245,14 @@ jobs:
            RERUN_FAILS="--rerun-fails"
           fi
 
+          # shellcheck disable=SC2059:RERUN_FAILS
+          
           GOARCH=${{ inputs.go-arch }} \
             go run gotest.tools/gotestsum --format=short-verbose \
               --junitfile test-results/go-test/results-${{ matrix.id }}.xml \
               --jsonfile test-results/go-test/results-${{ matrix.id }}.json \
               --jsonfile-timing-events failure-summary-${{ matrix.id }}${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}.json \
-              "$RERUN_FAILS" \
+              $RERUN_FAILS \
               --packages "${{ matrix.packages }}" \
               -- \
               -tags "${{ inputs.go-tags }}" \

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -241,7 +241,7 @@ jobs:
           # shellcheck disable=SC2086 # can't quote package list
 
           # On a release branch, add a flag to rerun failed tests
-          if [[ ${{ github.base_ref }} = release/* ]] ; then
+          if [[ ${{ github.ref_name }} = release/* ]] ; then
            RERUN_FAILS="--rerun-fails"
           fi
 

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -241,7 +241,7 @@ jobs:
           # shellcheck disable=SC2086 # can't quote package list
 
           # On a release branch, add a flag to rerun failed tests
-          if [[ ${{ github.ref_name }} = release/* ]] ; then
+          if [[ ${{ github.ref_name }} == 'release/*' ]]; then
            RERUN_FAILS="--rerun-fails"
           fi
 


### PR DESCRIPTION
Change github.base_ref to github.ref_name as re-run fails flag should be added when the workflow is triggered on release branches.