### PR TITLE
Use config's service registration in test cluster

### DIFF
--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1544,6 +1544,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		coreConfig.ClusterName = base.ClusterName
 		coreConfig.DisableAutopilot = base.DisableAutopilot
 		coreConfig.AdministrativeNamespacePath = base.AdministrativeNamespacePath
+		coreConfig.ServiceRegistration = base.ServiceRegistration
 
 		if base.BuiltinRegistry != nil {
 			coreConfig.BuiltinRegistry = base.BuiltinRegistry


### PR DESCRIPTION
I missed this small testing update required for the enterprise repo's test of #21642.