### PR TITLE
Use config's service registration in test cluster (#21907)

### DIFF
--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1604,6 +1604,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		coreConfig.DisableSentinelTrace = base.DisableSentinelTrace
 		coreConfig.ClusterName = base.ClusterName
 		coreConfig.DisableAutopilot = base.DisableAutopilot
+		coreConfig.ServiceRegistration = base.ServiceRegistration
 
 		if base.BuiltinRegistry != nil {
 			coreConfig.BuiltinRegistry = base.BuiltinRegistry


### PR DESCRIPTION
Backports #21907, to enable a test in the enterprise repo. Manually resolves the conflicts that happened in #21908

Closes #21911