### PR TITLE
Fix AWS IRSA

### DIFF
--- a/api/auth/aws/aws.go
+++ b/api/auth/aws/aws.go
@@ -149,11 +149,9 @@ func (a *AWSAuth) Login(ctx context.Context, client *api.Client) (*api.Secret, e
 	case iamType:
 		logger := hclog.Default()
 		if a.creds == nil {
-			credsConfig := awsutil.CredentialsConfig{
-				AccessKey:    os.Getenv("AWS_ACCESS_KEY_ID"),
-				SecretKey:    os.Getenv("AWS_SECRET_ACCESS_KEY"),
-				SessionToken: os.Getenv("AWS_SESSION_TOKEN"),
-				Logger:       logger,
+			credsConfig, err := awsutil.NewCredentialsConfig(awsutil.WithLogger(logger))
+			if err != nil {
+				return nil, err
 			}
 
 			// the env vars above will take precedence if they are set, as

--- a/builtin/credential/aws/client.go
+++ b/builtin/credential/aws/client.go
@@ -26,9 +26,12 @@ import (
 // * Environment variables
 // * Instance metadata role
 func (b *backend) getRawClientConfig(ctx context.Context, s logical.Storage, region, clientType string) (*aws.Config, error) {
-	credsConfig := &awsutil.CredentialsConfig{
-		Region: region,
-		Logger: b.Logger(),
+	credsConfig, err := awsutil.NewCredentialsConfig(
+		awsutil.WithRegion(region),
+		awsutil.WithLogger(b.Logger()),
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	// Read the configured secret key and access key

--- a/builtin/credential/aws/path_role_test.go
+++ b/builtin/credential/aws/path_role_test.go
@@ -1012,7 +1012,10 @@ func TestRoleResolutionWithSTSEndpointConfigured(t *testing.T) {
 
 	// Ensure aws credentials are available locally for testing.
 	logger := logging.NewVaultLogger(hclog.Debug)
-	credsConfig := &awsutil.CredentialsConfig{Logger: logger}
+	credsConfig, err := awsutil.NewCredentialsConfig(awsutil.WithLogger(logger))
+	if err != nil {
+		t.Fatal(err)
+	}
 	credsChain, err := credsConfig.GenerateCredentialChain()
 	if err != nil {
 		t.Fatal(err)

--- a/builtin/logical/aws/client.go
+++ b/builtin/logical/aws/client.go
@@ -20,7 +20,10 @@ import (
 
 // NOTE: The caller is required to ensure that b.clientMutex is at least read locked
 func getRootConfig(ctx context.Context, s logical.Storage, clientType string, logger hclog.Logger) (*aws.Config, error) {
-	credsConfig := &awsutil.CredentialsConfig{}
+	credsConfig, err := awsutil.NewCredentialsConfig(awsutil.WithLogger(logger))
+	if err != nil {
+		return nil, err
+	}
 	var endpoint string
 	var maxRetries int = aws.UseServiceDefaultRetries
 

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,8 @@ replace github.com/hashicorp/vault/api/auth/userpass => ./api/auth/userpass
 
 replace github.com/hashicorp/vault/sdk => ./sdk
 
+replace github.com/hashicorp/go-kms-wrapping/wrappers/awskms/v2 => github.com/bdwyertech/go-kms-wrapping/wrappers/awskms/v2 v2.0.2-0.20230719021057-55b7d25830fb
+
 require (
 	cloud.google.com/go/monitoring v1.13.0
 	cloud.google.com/go/spanner v1.45.0

--- a/go.sum
+++ b/go.sum
@@ -821,6 +821,8 @@ github.com/axiomhq/hyperloglog v0.0.0-20220105174342-98591331716a h1:eqjiAL3qoof
 github.com/axiomhq/hyperloglog v0.0.0-20220105174342-98591331716a/go.mod h1:2stgcRjl6QmW+gU2h5E7BQXg4HU0gzxKWDuT5HviN9s=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f h1:ZNv7On9kyUzm7fvRZumSyy/IUiSC7AzL0I1jKKtwooA=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
+github.com/bdwyertech/go-kms-wrapping/wrappers/awskms/v2 v2.0.2-0.20230719021057-55b7d25830fb h1:UQYeNOyaaQO3xyahUgHT6ot6aVr69AGz2+Da5Jj0898=
+github.com/bdwyertech/go-kms-wrapping/wrappers/awskms/v2 v2.0.2-0.20230719021057-55b7d25830fb/go.mod h1:wCd4P4reBCyLksjuE2Gs88sh2hSvz5x0Cw5G+gYQtmI=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -1730,8 +1732,6 @@ github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2 v2.0.7-1 h1:ZV26VJYcITBom0
 github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2 v2.0.7-1/go.mod h1:b99cDSA+OzcyRoBZroSf174/ss/e6gUuS45wue9ZQfc=
 github.com/hashicorp/go-kms-wrapping/wrappers/alicloudkms/v2 v2.0.1 h1:ydUCtmr8f9F+mHZ1iCsvzqFTXqNVpewX3s9zcYipMKI=
 github.com/hashicorp/go-kms-wrapping/wrappers/alicloudkms/v2 v2.0.1/go.mod h1:Sl/ffzV57UAyjtSg1h5Km0rN5+dtzZJm1CUztkoCW2c=
-github.com/hashicorp/go-kms-wrapping/wrappers/awskms/v2 v2.0.7 h1:E3eEWpkofgPNrYyYznfS1+drq4/jFcqHQVNcL7WhUCo=
-github.com/hashicorp/go-kms-wrapping/wrappers/awskms/v2 v2.0.7/go.mod h1:j5vefRoguQUG7iM4reS/hKIZssU1lZRqNPM5Wow6UnM=
 github.com/hashicorp/go-kms-wrapping/wrappers/azurekeyvault/v2 v2.0.7 h1:X27JWuPW6Gmi2l7NMm0pvnp7z7hhtns2TeIOQU93mqI=
 github.com/hashicorp/go-kms-wrapping/wrappers/azurekeyvault/v2 v2.0.7/go.mod h1:i7Dt9mDsVUQG/I639jtdQerliaO2SvvPnpYPhZ8CGZ4=
 github.com/hashicorp/go-kms-wrapping/wrappers/gcpckms/v2 v2.0.8 h1:16I8OqBEuxZIowwn3jiLvhlx+z+ia4dJc9stvz0yUBU=

--- a/physical/dynamodb/dynamodb.go
+++ b/physical/dynamodb/dynamodb.go
@@ -193,12 +193,16 @@ func NewDynamoDBBackend(conf map[string]string, logger log.Logger) (physical.Bac
 		}
 	}
 
-	credsConfig := &awsutil.CredentialsConfig{
-		AccessKey:    conf["access_key"],
-		SecretKey:    conf["secret_key"],
-		SessionToken: conf["session_token"],
-		Logger:       logger,
+	credsConfig, err := awsutil.NewCredentialsConfig(
+		awsutil.WithLogger(logger),
+		awsutil.WithAccessKey(conf["access_key"]),
+		awsutil.WithSecretKey(conf["secret_key"]),
+	)
+	if err != nil {
+		return nil, err
 	}
+	credsConfig.SessionToken = conf["session_token"]
+
 	creds, err := credsConfig.GenerateCredentialChain()
 	if err != nil {
 		return nil, err

--- a/physical/s3/s3_test.go
+++ b/physical/s3/s3_test.go
@@ -40,7 +40,10 @@ func DoS3BackendTest(t *testing.T, kmsKeyId string) {
 
 	logger := logging.NewVaultLogger(log.Debug)
 
-	credsConfig := &awsutil.CredentialsConfig{Logger: logger}
+	credsConfig, err := awsutil.NewCredentialsConfig(awsutil.WithLogger(logger))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	credsChain, err := credsConfig.GenerateCredentialChain()
 	if err != nil {


### PR DESCRIPTION
Resolves: #21465 #21478

Related: https://github.com/hashicorp/go-secure-stdlib/pull/80

The issue is because of how awsutil is used to derive credentials.  The NewCredentialsConfig constructor method needs to be called instead of starting with an empty struct.  The logic to determine which method to use to derive credentials has been moved from GenerateCredentialChain to NewCredentialsConfig.  https://github.com/hashicorp/go-secure-stdlib/commit/1a4b95565d57828244cbb7879b8d3a8f3d20522a


1. The go-kms-wrapping library needs to be updated also to fix the KMS auto unseal.
https://github.com/hashicorp/go-kms-wrapping/pull/178

2. Vault itself needs to be updated to call NewCredentialsConfig instead of sucking in an empty struct.

I have a test image up at `ghcr.io/bdwyertech/vault:dev-ui-560d81d`
