### PR TITLE
fix: Broken docs links for Auto-Auth page

### DIFF
--- a/website/content/docs/agent-and-proxy/agent/apiproxy.mdx
+++ b/website/content/docs/agent-and-proxy/agent/apiproxy.mdx
@@ -29,7 +29,7 @@ request to Vault. See the [caching docs](/vault/docs/agent-and-proxy/agent/cachi
 ## Using Auto-Auth token
 
 Vault Agent allows for easy authentication to Vault in a wide variety of
-environments using [Auto-Auth](/vault/docs/agent-and-proxy/agent/autoauth). By setting the
+environments using [Auto-Auth](/vault/docs/agent-and-proxy/autoauth). By setting the
 `use_auto_auth_token` (see below) configuration, clients will not be required
 to provide a Vault token to the requests made to the Agent. When this
 configuration is set, if the request doesn't already bear a token, then the

--- a/website/content/docs/agent-and-proxy/agent/index.mdx
+++ b/website/content/docs/agent-and-proxy/agent/index.mdx
@@ -386,7 +386,7 @@ template {
 ```
 
 [vault]: /vault/docs/agent-and-proxy/agent#vault-stanza
-[autoauth]: /vault/docs/agent-and-proxy/agent/autoauth
+[autoauth]: /vault/docs/agent-and-proxy/autoauth
 [caching]: /vault/docs/agent-and-proxy/agent/caching
 [apiproxy]: /vault/docs/agent-and-proxy/agent/apiproxy
 [persistent-cache]: /vault/docs/agent-and-proxy/agent/caching/persistent-caches


### PR DESCRIPTION
[:mag: Preview Link for Agent page](https://vault-git-nq-fix-autoauth-docs-links-hashicorp.vercel.app/vault/docs/agent-and-proxy/agent)
[:mag: Preview Link for API proxy page](https://vault-git-nq-fix-autoauth-docs-links-hashicorp.vercel.app/vault/docs/agent-and-proxy/agent/apiproxy)

---

This PR removes `agent` from links to the Auto-Auth docs page, fixing the links.

### Verification

1. Click each of the preview links above.
2. Press `Ctrl+F` and search for "Auto-Auth" to find the relevant links. 
3. Click these links. They should successfully navigate you to [the Auto-Auth page](https://vault-git-nq-fix-autoauth-docs-links-hashicorp.vercel.app/vault/docs/agent-and-proxy/autoauth).