### PR TITLE
Fix drift, these docs are only in ent repo docs so not public

### DIFF
--- a/website/content/docs/internals/telemetry.mdx
+++ b/website/content/docs/internals/telemetry.mdx
@@ -291,6 +291,9 @@ These metrics relate to [Vault Enterprise Replication](/vault/docs/enterprise/re
 | `vault.replication.rpc.standby.server.register_lease_request` | Duration of time taken by standby register lease request                                                                                   | ms              | summary |
 | `vault.replication.rpc.standby.server.wrap_token_request`     | Duration of time taken by standby wrap token request                                                                                       | ms              | summary |
 
+| `vault.replication.rpc.client.create_token_register_auth_lease`                           | Duration of time taken by client create token request                                                                                      | ms              | summary |
+| `vault.replication.rpc.standby.server.create_token_register_auth_lease_request`           | Duration of time taken by standby create token request                                                                                     | ms              | summary |
+
 ## Secrets engines metrics
 
 These metrics relate to the supported [secrets engines][secrets-engines].


### PR DESCRIPTION
As far as I can see these metrics docs were added in a PR that was merged in our Enterprise repository but never made it to the OSS docs. I think this means they haven't actually been included on our public website.

These metrics are only relevant to Vault Enterprise but we do document all enterprise features in the public docs so should be here!