### PR TITLE
AWS auth login with multi region STS support

### DIFF
--- a/builtin/credential/aws/path_config_client.go
+++ b/builtin/credential/aws/path_config_client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
+
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -59,6 +60,12 @@ func (b *backend) pathConfigClient() *framework.Path {
 				Type:        framework.TypeString,
 				Default:     "",
 				Description: "The region ID for the sts_endpoint, if set.",
+			},
+
+			"sts_region_from_client": {
+				Type:        framework.TypeBool,
+				Default:     false,
+				Description: "Uses the STS region from client requests for making AWS STS API calls.",
 			},
 
 			"iam_server_id_header_value": {
@@ -168,6 +175,7 @@ func (b *backend) pathConfigClientRead(ctx context.Context, req *logical.Request
 			"iam_endpoint":               clientConfig.IAMEndpoint,
 			"sts_endpoint":               clientConfig.STSEndpoint,
 			"sts_region":                 clientConfig.STSRegion,
+			"sts_region_from_client":     clientConfig.STSRegionFromClient,
 			"iam_server_id_header_value": clientConfig.IAMServerIdHeaderValue,
 			"max_retries":                clientConfig.MaxRetries,
 			"allowed_sts_header_values":  clientConfig.AllowedSTSHeaderValues,
@@ -281,6 +289,14 @@ func (b *backend) pathConfigClientCreateUpdate(ctx context.Context, req *logical
 		}
 	}
 
+	stsRegionFromClientRaw, ok := data.GetOk("sts_region_from_client")
+	if ok {
+		if configEntry.STSRegionFromClient != stsRegionFromClientRaw.(bool) {
+			changedCreds = true
+			configEntry.STSRegionFromClient = stsRegionFromClientRaw.(bool)
+		}
+	}
+
 	headerValStr, ok := data.GetOk("iam_server_id_header_value")
 	if ok {
 		if configEntry.IAMServerIdHeaderValue != headerValStr.(string) {
@@ -363,6 +379,7 @@ type clientConfig struct {
 	IAMEndpoint            string   `json:"iam_endpoint"`
 	STSEndpoint            string   `json:"sts_endpoint"`
 	STSRegion              string   `json:"sts_region"`
+	STSRegionFromClient    bool     `json:"sts_region_from_client"`
 	IAMServerIdHeaderValue string   `json:"iam_server_id_header_value"`
 	AllowedSTSHeaderValues []string `json:"allowed_sts_header_values"`
 	MaxRetries             int      `json:"max_retries"`

--- a/builtin/credential/aws/path_config_client.go
+++ b/builtin/credential/aws/path_config_client.go
@@ -62,7 +62,7 @@ func (b *backend) pathConfigClient() *framework.Path {
 				Description: "The region ID for the sts_endpoint, if set.",
 			},
 
-			"sts_region_from_client": {
+			"use_sts_region_from_client": {
 				Type:        framework.TypeBool,
 				Default:     false,
 				Description: "Uses the STS region from client requests for making AWS STS API calls.",
@@ -175,7 +175,7 @@ func (b *backend) pathConfigClientRead(ctx context.Context, req *logical.Request
 			"iam_endpoint":               clientConfig.IAMEndpoint,
 			"sts_endpoint":               clientConfig.STSEndpoint,
 			"sts_region":                 clientConfig.STSRegion,
-			"sts_region_from_client":     clientConfig.STSRegionFromClient,
+			"use_sts_region_from_client": clientConfig.UseSTSRegionFromClient,
 			"iam_server_id_header_value": clientConfig.IAMServerIdHeaderValue,
 			"max_retries":                clientConfig.MaxRetries,
 			"allowed_sts_header_values":  clientConfig.AllowedSTSHeaderValues,
@@ -289,11 +289,11 @@ func (b *backend) pathConfigClientCreateUpdate(ctx context.Context, req *logical
 		}
 	}
 
-	stsRegionFromClientRaw, ok := data.GetOk("sts_region_from_client")
+	useSTSRegionFromClientRaw, ok := data.GetOk("use_sts_region_from_client")
 	if ok {
-		if configEntry.STSRegionFromClient != stsRegionFromClientRaw.(bool) {
+		if configEntry.UseSTSRegionFromClient != useSTSRegionFromClientRaw.(bool) {
 			changedCreds = true
-			configEntry.STSRegionFromClient = stsRegionFromClientRaw.(bool)
+			configEntry.UseSTSRegionFromClient = useSTSRegionFromClientRaw.(bool)
 		}
 	}
 
@@ -379,7 +379,7 @@ type clientConfig struct {
 	IAMEndpoint            string   `json:"iam_endpoint"`
 	STSEndpoint            string   `json:"sts_endpoint"`
 	STSRegion              string   `json:"sts_region"`
-	STSRegionFromClient    bool     `json:"sts_region_from_client"`
+	UseSTSRegionFromClient bool     `json:"use_sts_region_from_client"`
 	IAMServerIdHeaderValue string   `json:"iam_server_id_header_value"`
 	AllowedSTSHeaderValues []string `json:"allowed_sts_header_values"`
 	MaxRetries             int      `json:"max_retries"`

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -21,8 +21,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	awsClient "github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/hashicorp/errwrap"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-retryablehttp"
@@ -30,6 +32,7 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	uuid "github.com/hashicorp/go-uuid"
+
 	"github.com/hashicorp/vault/builtin/credential/aws/pkcs7"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/cidrutil"
@@ -318,6 +321,23 @@ func (b *backend) pathLoginIamGetRoleNameCallerIdAndEntity(ctx context.Context, 
 		}
 	}
 
+	// Extract and use a regional STS endpoint
+	// based on the region set in the Authorization header.
+	if config.STSRegionFromClient {
+		clientSpecifiedRegion, err := awsRegionFromHeader(headers.Get("Authorization"))
+		if err != nil {
+			return "", nil, nil, logical.ErrorResponse("region missing from Authorization header"), nil
+		}
+
+		url, err := stsRegionalEndpoint(clientSpecifiedRegion)
+		if err != nil {
+			return "", nil, nil, logical.ErrorResponse(err.Error()), nil
+		}
+		b.Logger().Debug("sts_region_from_client set; using region specified from header", "region", clientSpecifiedRegion)
+		endpoint = url
+	}
+
+	b.Logger().Debug("submitting caller identity request", "endpoint", endpoint)
 	callerID, err := submitCallerIdentityRequest(ctx, maxRetries, method, endpoint, parsedUrl, body, headers)
 	if err != nil {
 		return "", nil, nil, logical.ErrorResponse(fmt.Sprintf("error making upstream request: %v", err)), nil
@@ -1882,6 +1902,43 @@ func getMetadataValue(fromAuth *logical.Auth, forKey string) (string, error) {
 		return val, nil
 	}
 	return "", fmt.Errorf("%q not found in auth metadata", forKey)
+}
+
+func awsRegionFromHeader(authorizationHeader string) (string, error) {
+	// https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
+	// The Authorization header takes the following form.
+	//  Authorization: AWS4-HMAC-SHA256
+	//	Credential=AKIAIOSFODNN7EXAMPLE/20230719/us-east-1/sts/aws4_request,
+	// 	SignedHeaders=content-length;content-type;host;x-amz-date,
+	//	Signature=fe5f80f77d5fa3beca038a248ff027d0445342fe2855ddc963176630326f1024
+	//
+	// The credential is in the form of "<your-access-key-id>/<date>/<aws-region>/<aws-service>/aws4_request"
+	fields := strings.Split(authorizationHeader, " ")
+	for _, field := range fields {
+		if strings.HasPrefix(field, "Credential=") {
+			fields := strings.Split(field, "/")
+			if len(fields) < 3 {
+				return "", fmt.Errorf("invalid header format")
+			}
+			region := fields[2]
+			return region, nil
+		}
+
+	}
+
+	return "", fmt.Errorf("invalid header format")
+}
+
+func stsRegionalEndpoint(region string) (string, error) {
+	stsService := sts.EndpointsID
+	resolver := endpoints.DefaultResolver()
+	resolvedEndpoint, err := resolver.EndpointFor(stsService, region,
+		endpoints.STSRegionalEndpointOption,
+		endpoints.StrictMatchingOption)
+	if err != nil {
+		return "", fmt.Errorf("unable to get regional STS endpoint for region: %v", region)
+	}
+	return resolvedEndpoint.URL, nil
 }
 
 const iamServerIdHeader = "X-Vault-AWS-IAM-Server-ID"

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -333,6 +333,7 @@ func (b *backend) pathLoginIamGetRoleNameCallerIdAndEntity(ctx context.Context, 
 		if err != nil {
 			return "", nil, nil, logical.ErrorResponse(err.Error()), nil
 		}
+
 		b.Logger().Debug("sts_region_from_client set; using region specified from header", "region", clientSpecifiedRegion)
 		endpoint = url
 	}
@@ -1920,10 +1921,10 @@ func awsRegionFromHeader(authorizationHeader string) (string, error) {
 			if len(fields) < 3 {
 				return "", fmt.Errorf("invalid header format")
 			}
+
 			region := fields[2]
 			return region, nil
 		}
-
 	}
 
 	return "", fmt.Errorf("invalid header format")

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -323,7 +323,7 @@ func (b *backend) pathLoginIamGetRoleNameCallerIdAndEntity(ctx context.Context, 
 
 	// Extract and use a regional STS endpoint
 	// based on the region set in the Authorization header.
-	if config.STSRegionFromClient {
+	if config.UseSTSRegionFromClient {
 		clientSpecifiedRegion, err := awsRegionFromHeader(headers.Get("Authorization"))
 		if err != nil {
 			return "", nil, nil, logical.ErrorResponse("region missing from Authorization header"), nil
@@ -334,7 +334,7 @@ func (b *backend) pathLoginIamGetRoleNameCallerIdAndEntity(ctx context.Context, 
 			return "", nil, nil, logical.ErrorResponse(err.Error()), nil
 		}
 
-		b.Logger().Debug("sts_region_from_client set; using region specified from header", "region", clientSpecifiedRegion)
+		b.Logger().Debug("use_sts_region_from_client set; using region specified from header", "region", clientSpecifiedRegion)
 		endpoint = url
 	}
 

--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -673,9 +673,9 @@ func TestRegionFromHeader(t *testing.T) {
 	})
 
 	t.Run("invalid-region", func(t *testing.T) {
-		region, err := stsRegionalEndpoint("fake-region-1")
+		endpoint, err := stsRegionalEndpoint("fake-region-1")
 		assert.EqualError(t, err, "unable to get regional STS endpoint for region: fake-region-1")
-		assert.Empty(t, region)
+		assert.Empty(t, endpoint)
 	})
 }
 

--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -623,6 +625,58 @@ func TestBackend_defaultAliasMetadata(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRegionFromHeader(t *testing.T) {
+	tcs := map[string]struct {
+		header              string
+		expectedRegion      string
+		expectedSTSEndpoint string
+	}{
+		"us-east-1": {
+			header:              "AWS4-HMAC-SHA256 Credential=AAAAAAAAAAAAAAAAAAAA/20230719/us-east-1/sts/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date, Signature=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expectedRegion:      "us-east-1",
+			expectedSTSEndpoint: "https://sts.us-east-1.amazonaws.com",
+		},
+		"us-west-2": {
+			header:              "AWS4-HMAC-SHA256 Credential=AAAAAAAAAAAAAAAAAAAA/20230719/us-west-2/sts/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date, Signature=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expectedRegion:      "us-west-2",
+			expectedSTSEndpoint: "https://sts.us-west-2.amazonaws.com",
+		},
+		"ap-northeast-3": {
+			header:              "AWS4-HMAC-SHA256 Credential=AAAAAAAAAAAAAAAAAAAA/20230719/ap-northeast-3/sts/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date, Signature=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expectedRegion:      "ap-northeast-3",
+			expectedSTSEndpoint: "https://sts.ap-northeast-3.amazonaws.com",
+		},
+		"us-gov-east-1": {
+			header:              "AWS4-HMAC-SHA256 Credential=AAAAAAAAAAAAAAAAAAAA/20230719/us-gov-east-1/sts/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date, Signature=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expectedRegion:      "us-gov-east-1",
+			expectedSTSEndpoint: "https://sts.us-gov-east-1.amazonaws.com",
+		},
+	}
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			region, err := awsRegionFromHeader(tc.header)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedRegion, region)
+
+			stsEndpoint, err := stsRegionalEndpoint(region)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedSTSEndpoint, stsEndpoint)
+		})
+	}
+
+	t.Run("invalid-header", func(t *testing.T) {
+		region, err := awsRegionFromHeader("this-is-an-invalid-header/foobar")
+		assert.EqualError(t, err, "invalid header format")
+		assert.Empty(t, region)
+	})
+
+	t.Run("invalid-region", func(t *testing.T) {
+		region, err := stsRegionalEndpoint("fake-region-1")
+		assert.EqualError(t, err, "unable to get regional STS endpoint for region: fake-region-1")
+		assert.Empty(t, region)
+	})
 }
 
 func defaultLoginData() (map[string]interface{}, error) {

--- a/changelog/21960.txt
+++ b/changelog/21960.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+aws/auth: Adds a new config field `sts_region_from_client` which allows for using dynamic regional sts endpoints based on Authorization header.
+```

--- a/changelog/21960.txt
+++ b/changelog/21960.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-aws/auth: Adds a new config field `sts_region_from_client` which allows for using dynamic regional sts endpoints based on Authorization header.
+aws/auth: Adds a new config field `sts_region_from_client` which allows for using dynamic regional sts endpoints based on Authorization header when using IAM-based authentication..
 ```

--- a/changelog/21960.txt
+++ b/changelog/21960.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-aws/auth: Adds a new config field `sts_region_from_client` which allows for using dynamic regional sts endpoints based on Authorization header when using IAM-based authentication.
+aws/auth: Adds a new config field `use_sts_region_from_client` which allows for using dynamic regional sts endpoints based on Authorization header when using IAM-based authentication.
 ```

--- a/changelog/21960.txt
+++ b/changelog/21960.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-aws/auth: Adds a new config field `sts_region_from_client` which allows for using dynamic regional sts endpoints based on Authorization header when using IAM-based authentication..
+aws/auth: Adds a new config field `sts_region_from_client` which allows for using dynamic regional sts endpoints based on Authorization header when using IAM-based authentication.
 ```

--- a/website/content/api-docs/auth/aws.mdx
+++ b/website/content/api-docs/auth/aws.mdx
@@ -65,10 +65,10 @@ capabilities, the credentials are fetched automatically.
 - `sts_region` `(string: "")` - Region to override the default region for making
   AWS STS API calls. Should only be set if `sts_endpoint` is set. If so, should
   be set to the region in which the custom `sts_endpoint` resides.
-- `sts_region_from_client` `(boolean: false)` - If set, overrides both `sts_endpoint` and
-  `sts_region` to instead use the region specified in the client request headers. This can
-  be useful when you have client requests coming from different regions and want flexibility
-  in which regional STS API is used.
+- `sts_region_from_client` `(boolean: false)` - If set, overrides both `sts_endpoint`
+  and `sts_region` to instead use the region specified in the client request headers for
+  IAM-based authentication . This can be useful when you have client requests coming from
+  different regions and want flexibility in which regional STS API is used.
 - `iam_server_id_header_value` `(string: "")` - The value to require in the
   `X-Vault-AWS-IAM-Server-ID` header as part of GetCallerIdentity requests that
   are used in the iam auth method. If not set, then no value is required or
@@ -127,7 +127,7 @@ $ curl \
     "iam_endpoint": "",
     "sts_endpoint": "",
     "sts_region": "",
-    "sts_region_from_client": "",
+    "sts_region_from_client": false,
     "iam_server_id_header_value": ""
   }
 }

--- a/website/content/api-docs/auth/aws.mdx
+++ b/website/content/api-docs/auth/aws.mdx
@@ -65,6 +65,10 @@ capabilities, the credentials are fetched automatically.
 - `sts_region` `(string: "")` - Region to override the default region for making
   AWS STS API calls. Should only be set if `sts_endpoint` is set. If so, should
   be set to the region in which the custom `sts_endpoint` resides.
+- `sts_region_from_client` `(boolean: false)` - If set, overrides both `sts_endpoint` and
+  `sts_region` to instead use the region specified in the client request headers. This can
+  be useful when you have client requests coming from different regions and want flexibility
+  in which regional STS API is used.
 - `iam_server_id_header_value` `(string: "")` - The value to require in the
   `X-Vault-AWS-IAM-Server-ID` header as part of GetCallerIdentity requests that
   are used in the iam auth method. If not set, then no value is required or
@@ -123,6 +127,7 @@ $ curl \
     "iam_endpoint": "",
     "sts_endpoint": "",
     "sts_region": "",
+    "sts_region_from_client": "",
     "iam_server_id_header_value": ""
   }
 }

--- a/website/content/api-docs/auth/aws.mdx
+++ b/website/content/api-docs/auth/aws.mdx
@@ -65,7 +65,7 @@ capabilities, the credentials are fetched automatically.
 - `sts_region` `(string: "")` - Region to override the default region for making
   AWS STS API calls. Should only be set if `sts_endpoint` is set. If so, should
   be set to the region in which the custom `sts_endpoint` resides.
-- `sts_region_from_client` `(boolean: false)` - If set, overrides both `sts_endpoint`
+- `use_sts_region_from_client` `(boolean: false)` - If set, overrides both `sts_endpoint`
   and `sts_region` to instead use the region specified in the client request headers for
   IAM-based authentication . This can be useful when you have client requests coming from
   different regions and want flexibility in which regional STS API is used.
@@ -127,7 +127,7 @@ $ curl \
     "iam_endpoint": "",
     "sts_endpoint": "",
     "sts_region": "",
-    "sts_region_from_client": false,
+    "use_sts_region_from_client": false,
     "iam_server_id_header_value": ""
   }
 }


### PR DESCRIPTION
# Summary
Adds support to the AWS auth plugin so that when the `use_sts_region_from_client` configuration is set, the global STS endpoint (https://sts.amazonaws.com) will be overridden to instead use the [regional STS endpoints](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html) based on the region provided in the `Authorization` header.

This change allows for DR situations and AWS regional outages by supporting flexibility in where the login region is calling from.

Without this change, clients would run into an error message when logging in if there were a region mismatch between client and server:
```
Error authenticating: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/auth/aws/login
Code: 400. Errors:

* error making upstream request: received error code 403 from STS: <ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
  <Error>
    <Type>Sender</Type>
    <Code>SignatureDoesNotMatch</Code>
    <Message>Credential should be scoped to a valid region. </Message>
  </Error>
  <RequestId>b749af7f-ed19-4cea-9885-f60d2422880e</RequestId>
</ErrorResponse>
```


# Testing

For the server side, I've configured the AWS auth plugin with the `use_sts_region_from_client` config set to `true`.
```
vault auth enable aws
Success! Enabled aws auth method at: aws/

vault write auth/aws/config/client \
    secret_key="${AWS_SECRET_ACCESS_KEY}" \
    access_key="${AWS_ACCESS_KEY_ID}" \
use_sts_region_from_client=true
Success! Data written to: auth/aws/config/client

vault write auth/aws/role/dev-role-iam \
    auth_type="iam" \
    bound_iam_principal_arn="arn:aws:iam::XXXXXXXXXXX:user/FOOBAR" \
    policies="default"
Success! Data written to: auth/aws/role/dev-role-iam
```

For the client side, I've tested the login command using a bunch of different regions, `auto` region, and no region specified . Responses omitted for brevity.
```
vault login -method=aws  region=us-east-1 role=dev-role-iam
Success! You are now authenticated. The token information displayed below...

vault login -method=aws  region=us-east-2 role=dev-role-iam
Success! You are now authenticated. The token information displayed below...

vault login -method=aws  region=us-west-1 role=dev-role-iam
Success! You are now authenticated. The token information displayed below...

vault login -method=aws  region=us-west-2 role=dev-role-iam
Success! You are now authenticated. The token information displayed below...

vault login -method=aws  region=auto role=dev-role-iam
Success! You are now authenticated. The token information displayed below...

vault login -method=aws role=dev-role-iam
Success! You are now authenticated. The token information displayed below...
```