### PR TITLE
UI: Fix confirm dropdown not rendering on HSM

### DIFF
--- a/ui/lib/core/addon/templates/components/confirm.hbs
+++ b/ui/lib/core/addon/templates/components/confirm.hbs
@@ -1,6 +1,6 @@
 {{! template-lint-disable no-inline-styles}}
 
-<div class="confirm-wrapper" style={{this.style}}>
+<div class="confirm-wrapper" style={{sanitized-html this.style}}>
   <div class="confirm {{if this.openTrigger 'show-confirm'}}" ...attributes>
     {{yield
       (hash


### PR DESCRIPTION
Adds sanitization to computed style on confirm dropdown, which should fix the confirm dropdown not rendering correctly on HSM builds:

![image](https://github.com/hashicorp/vault/assets/82459713/4ba2d1e5-1a1b-4b6b-ad94-7e832aa1b31c)
