### PR TITLE
Remove redundant sudo check

### DIFF
--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -3295,16 +3295,6 @@ func (ts *TokenStore) handleRevokeOrphan(ctx context.Context, req *logical.Reque
 		return logical.ErrorResponse("missing token ID"), logical.ErrInvalidRequest
 	}
 
-	// TODO #21772 makes the sudo check below redundant, by correcting the TokenStore's PathsSpecial.Root to match this endpoint
-
-	// Check if the client token has sudo/root privileges for the requested path
-	isSudo := ts.System().(extendedSystemView).SudoPrivilege(ctx, req.MountPoint+req.Path, req.ClientToken)
-
-	if !isSudo {
-		return logical.ErrorResponse("root or sudo privileges required to revoke and orphan"),
-			logical.ErrInvalidRequest
-	}
-
 	// Do a lookup. Among other things, that will ensure that this is either
 	// running in the same namespace or a parent.
 	te, err := ts.Lookup(ctx, id)


### PR DESCRIPTION
This is a follow-up to #21772.

Historically, for some reason, `auth/token/revoke-orphan` was
sudo-protected by writing custom code in its handler function, instead
of via the usual declarative PathsSpecial.Root mechanism.

In fact, there was a declaration mentioning revoke-orphan in the token
backend's PathsSpecial.Root, but it was incorrect! That was corrected
in #21772, making the custom code in the handler function redundant.
However, removal of the now-redundant code was deferred to this
follow-up PR, out of an abundance of caution, and wanting extra eyes on
a change deleting a security check.
