### PR TITLE
UI: KV secret details empty states and permissions

### DIFF
--- a/ui/app/adapters/kv/data.js
+++ b/ui/app/adapters/kv/data.js
@@ -4,6 +4,7 @@
  */
 
 import ApplicationAdapter from '../application';
+import AdapterError from '@ember-data/adapter/error';
 import { kvDataPath, kvDestroyPath, kvMetadataPath, kvUndeletePath } from 'vault/utils/kv-path';
 import { assert } from '@ember/debug';
 
@@ -38,17 +39,38 @@ export default class KvDataAdapter extends ApplicationAdapter {
     const { backend, path, version } = query;
     // ID is the full path for the data (including version)
     const id = kvDataPath(backend, path, version);
-    return this.ajax(this._url(id), 'GET').then((resp) => {
-      return {
-        ...resp,
-        data: {
-          id,
-          backend,
-          path,
-          ...resp.data,
-        },
-      };
-    });
+    return this.ajax(this._url(id), 'GET')
+      .then((resp) => {
+        return {
+          ...resp,
+          data: {
+            id,
+            backend,
+            path,
+            ...resp.data,
+          },
+        };
+      })
+      .catch((errorOrResponse) => {
+        // if it's a legitimate error - throw it!
+        if (errorOrResponse instanceof AdapterError) {
+          throw errorOrResponse;
+        }
+        // in the case of a deleted/destroyed secret the API returns a 404 because { data: null }
+        // however, there could be a metadata block with important information like deletion_time
+        // handleResponse below checks 404 status codes for metadata and updates the code to 200 if it exists.
+        // we still end up in the good ol' catch() block, but instead of a 404 adapter error we've "caught"
+        // the metadata that sneakily tried to hide from us
+        return {
+          ...errorOrResponse,
+          data: {
+            ...errorOrResponse.data, // includes the { metadata } key we want
+            id,
+            backend,
+            path,
+          },
+        };
+      });
   }
 
   /* Five types of delete operations */
@@ -82,5 +104,14 @@ export default class KvDataAdapter extends ApplicationAdapter {
           'deletType must be one of delete-latest-version, delete-specific-version, destroy-specific-version, destroy-everything, undelete-specific-version.'
         );
     }
+  }
+
+  handleResponse(status, headers, payload, requestData) {
+    // after deleting a secret version, data is null and the API returns a 404
+    // but there could be relevant metadata
+    if (status === 404 && payload.data.metadata) {
+      return super.handleResponse(200, headers, payload, requestData);
+    }
+    return super.handleResponse(...arguments);
   }
 }

--- a/ui/app/models/kv/data.js
+++ b/ui/app/models/kv/data.js
@@ -37,14 +37,8 @@ const formFieldProps = ['path', 'data'];
 @withFormFields(formFieldProps)
 export default class KvSecretDataModel extends Model {
   @attr('string') backend; // dynamic path of secret -- set on response from value passed to queryRecord.
-
-  @attr('string', {
-    label: 'Path for this secret',
-  })
-  path;
-
-  @attr('object')
-  secretData;
+  @attr('string', { label: 'Path for this secret' }) path;
+  @attr('object') secretData; // { key: value } data of the secret version
 
   // Params returned on the GET response.
   @attr('string') createdTime;

--- a/ui/app/models/kv/data.js
+++ b/ui/app/models/kv/data.js
@@ -60,30 +60,30 @@ export default class KvSecretDataModel extends Model {
   @lazyCapabilities(apiPath`${'backend'}/undelete/${'path'}`, 'backend', 'path') undeletePath;
 
   get canDeleteLatestVersion() {
-    return this.dataPath.get('canDelete');
+    return this.dataPath.get('canDelete') !== false;
   }
   get canDeleteVersion() {
-    return this.deletePath.get('canUpdate');
+    return this.deletePath.get('canUpdate') !== false;
   }
   get canUndelete() {
-    return this.undeletePath.get('canUpdate');
+    return this.undeletePath.get('canUpdate') !== false;
   }
   get canDestroyVersion() {
-    return this.destroyPath.get('canUpdate');
+    return this.destroyPath.get('canUpdate') !== false;
   }
   get canEditData() {
-    return this.dataPath.get('canUpdate');
+    return this.dataPath.get('canUpdate') !== false;
   }
   get canReadData() {
-    return this.dataPath.get('canRead');
+    return this.dataPath.get('canRead') !== false;
   }
   get canReadMetadata() {
-    return this.metadataPath.get('canRead');
+    return this.metadataPath.get('canRead') !== false;
   }
   get canUpdateMetadata() {
-    return this.metadataPath.get('canUpdate');
+    return this.metadataPath.get('canUpdate') !== false;
   }
   get canListMetadata() {
-    return this.metadataPath.get('canList');
+    return this.metadataPath.get('canList') !== false;
   }
 }

--- a/ui/app/serializers/kv/data.js
+++ b/ui/app/serializers/kv/data.js
@@ -22,7 +22,6 @@ export default class KvDataSerializer extends ApplicationSerializer {
     return {
       ...payload,
       data: {
-        ...payload.data,
         id,
         backend,
         path,

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -2,10 +2,10 @@
   <:tabLinks>
     <LinkTo @route="secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
     <LinkTo @route="secret.metadata.index" data-test-secrets-tab="Metadata">Metadata</LinkTo>
-    {{#unless @noMetadataPermission}}
+    {{#if @secret.canReadMetadata}}
       <LinkTo @route="secret.metadata.versions" data-test-secrets-tab="Version History">Version History</LinkTo>
       <LinkTo @route="secret.metadata.diff" data-test-secrets-tab="Version Diff">Version Diff</LinkTo>
-    {{/unless}}
+    {{/if}}
   </:tabLinks>
 
   <:toolbarFilters>

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -2,8 +2,10 @@
   <:tabLinks>
     <LinkTo @route="secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
     <LinkTo @route="secret.metadata.index" data-test-secrets-tab="Metadata">Metadata</LinkTo>
-    <LinkTo @route="secret.metadata.versions" data-test-secrets-tab="Version History">Version History</LinkTo>
-    <LinkTo @route="secret.metadata.diff" data-test-secrets-tab="Version Diff">Version Diff</LinkTo>
+    {{#unless @noMetadataPermission}}
+      <LinkTo @route="secret.metadata.versions" data-test-secrets-tab="Version History">Version History</LinkTo>
+      <LinkTo @route="secret.metadata.diff" data-test-secrets-tab="Version Diff">Version Diff</LinkTo>
+    {{/unless}}
   </:tabLinks>
 
   <:toolbarFilters>

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -7,60 +7,70 @@
   </:tabLinks>
 
   <:toolbarFilters>
-    <Toggle
-      data-test-json-view-toggle
-      @name="json"
-      @status="success"
-      @size="small"
-      @checked={{this.showJsonView}}
-      @onChange={{this.toggleJsonView}}
-    >
-      <span class="has-text-grey">JSON</span>
-    </Toggle>
+    {{#unless this.emptyState}}
+      <Toggle
+        data-test-json-view-toggle
+        @name="json"
+        @status="success"
+        @size="small"
+        @checked={{this.showJsonView}}
+        @onChange={{this.toggleJsonView}}
+      >
+        <span class="has-text-grey">JSON</span>
+      </Toggle>
+    {{/unless}}
   </:toolbarFilters>
   <:toolbarActions>
     <ToolbarLink @route="secret.edit" @type="add">Create new version</ToolbarLink>
   </:toolbarActions>
 </KvPageHeader>
 
-<div class="info-table-row-header">
-  <div class="info-table-row thead {{if this.showJsonView 'is-shadowless'}} ">
-    {{#unless this.showJsonView}}
-      <div class="th column is-one-quarter">
-        Key
+{{#if this.emptyState}}
+  <EmptyState @title={{this.emptyState.title}} @message={{this.emptyState.message}}>
+    {{#if this.emptyState.link}}
+      <DocLink @path={{this.emptyState.link}}>Learn more</DocLink>
+    {{/if}}
+  </EmptyState>
+{{else}}
+  <div class="info-table-row-header">
+    <div class="info-table-row thead {{if this.showJsonView 'is-shadowless'}} ">
+      {{#unless this.showJsonView}}
+        <div class="th column is-one-quarter">
+          Key
+        </div>
+        <div class="th column">
+          Value
+        </div>
+      {{/unless}}
+      <div class="th column justify-right" data-test-created-time>
+        {{#if @secret.createdTime}}
+          <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
+            <T.Trigger data-test-tooltip-trigger tabindex="-1">
+              Version
+              {{if @secret.version @secret.version}}
+              created
+              {{date-format @secret.createdTime "MMM dd, yyyy hh:mm a"}}
+            </T.Trigger>
+            <T.Content @defaultClass="tool-tip smaller-font">
+              <div class="box" data-test-hover-copy-tooltip-text>
+                {{@secret.createdTime}}
+              </div>
+            </T.Content>
+          </ToolTip>
+        {{/if}}
       </div>
-      <div class="th column">
-        Value
-      </div>
-    {{/unless}}
-    <div class="th column justify-right" data-test-created-time>
-      {{#if @secret.createdTime}}
-        <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
-          <T.Trigger data-test-tooltip-trigger tabindex="-1">
-            Version
-            {{if @secret.version @secret.version}}
-            created
-            {{date-format @secret.createdTime "MMM dd, yyyy hh:mm a"}}
-          </T.Trigger>
-          <T.Content @defaultClass="tool-tip smaller-font">
-            <div class="box" data-test-hover-copy-tooltip-text>
-              {{@secret.createdTime}}
-            </div>
-          </T.Content>
-        </ToolTip>
-      {{/if}}
     </div>
   </div>
-</div>
 
-{{#if this.showJsonView}}
-  <JsonEditor @title="Version data" @value={{stringify @secret.secretData}} @readOnly={{true}} />
-{{else}}
-  {{#each-in @secret.secretData as |key value|}}
-    <InfoTableRow @label={{key}} @value={{value}} @alwaysRender={{true}}>
-      <MaskedInput @name={{key}} @value={{value}} @displayOnly={{true}} @allowCopy={{true}} @allowDownload={{true}} />
-    </InfoTableRow>
+  {{#if this.showJsonView}}
+    <JsonEditor @title="Version data" @value={{stringify @secret.secretData}} @readOnly={{true}} />
   {{else}}
-    <InfoTableRow @label="" @value="" @alwaysRender={{true}} />
-  {{/each-in}}
+    {{#each-in @secret.secretData as |key value|}}
+      <InfoTableRow @label={{key}} @value={{value}} @alwaysRender={{true}}>
+        <MaskedInput @name={{key}} @value={{value}} @displayOnly={{true}} @allowCopy={{true}} @allowDownload={{true}} />
+      </InfoTableRow>
+    {{else}}
+      <InfoTableRow @label="" @value="" @alwaysRender={{true}} />
+    {{/each-in}}
+  {{/if}}
 {{/if}}

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -45,21 +45,19 @@
         </div>
       {{/unless}}
       <div class="th column justify-right" data-test-created-time>
-        {{#if @secret.createdTime}}
-          <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
-            <T.Trigger data-test-tooltip-trigger tabindex="-1">
-              Version
-              {{if @secret.version @secret.version}}
-              created
-              {{date-format @secret.createdTime "MMM dd, yyyy hh:mm a"}}
-            </T.Trigger>
-            <T.Content @defaultClass="tool-tip smaller-font">
-              <div class="box" data-test-hover-copy-tooltip-text>
-                {{@secret.createdTime}}
-              </div>
-            </T.Content>
-          </ToolTip>
-        {{/if}}
+        <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
+          <T.Trigger data-test-tooltip-trigger tabindex="-1">
+            Version
+            {{if @secret.version @secret.version}}
+            created
+            {{date-format @secret.createdTime "MMM dd, yyyy hh:mm a"}}
+          </T.Trigger>
+          <T.Content @defaultClass="tool-tip smaller-font">
+            <div class="box" data-test-hover-copy-tooltip-text>
+              {{@secret.createdTime}}
+            </div>
+          </T.Content>
+        </ToolTip>
       </div>
     </div>
   </div>

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -33,27 +33,34 @@ export default class KvSecretDetails extends Component {
   }
 
   get emptyState() {
-    const { version, canReadData, destroyed, deletionTime } = this.args.secret;
-    if (!canReadData) {
+    if (!this.args.secret.canReadData) {
       return {
         title: 'You do not have permission to read this secret',
         message:
           'Your policies may permit you to write a new version of this secret, but do not allow you to read its current contents.',
       };
     }
+    // only destructure if we can read secret data
+    const { version, destroyed, deletionTime } = this.args.secret;
     if (destroyed) {
       return {
         title: `Version ${version} of this secret has been permanently destroyed`,
-        message:
-          'A version that has been permanently deleted cannot be restored. You can view other versions of this secret in the Version History tab above.',
+        message: `A version that has been permanently deleted cannot be restored. ${
+          this.args.secret.canReadMetadata
+            ? ' You can view other versions of this secret in the Version History tab above.'
+            : ''
+        }`,
         link: '/vault/docs/secrets/kv/kv-v2',
       };
     }
     if (deletionTime) {
       return {
         title: `Version ${version} of this secret has been deleted`,
-        message:
-          'This version has been deleted but can be undeleted. View other versions of this secret by clicking the Version History tab above.',
+        message: `This version has been deleted but can be undeleted. ${
+          this.args.secret.canReadMetadata
+            ? 'View other versions of this secret by clicking the Version History tab above.'
+            : ''
+        }`,
         link: '/vault/docs/secrets/kv/kv-v2',
       };
     }

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -25,8 +25,37 @@ import { tracked } from '@glimmer/tracking';
 
 export default class KvSecretDetails extends Component {
   @tracked showJsonView = false;
+
   @action
   toggleJsonView() {
     this.showJsonView = !this.showJsonView;
+  }
+
+  get emptyState() {
+    const { version, canReadData, destroyed, deletionTime } = this.args.secret;
+    if (!canReadData) {
+      return {
+        title: 'You do not have permission to read this secret',
+        message:
+          'Your policies may permit you to write a new version of this secret, but do not allow you to read its current contents.',
+      };
+    }
+    if (destroyed) {
+      return {
+        title: `Version ${version} of this secret has been permanently destroyed`,
+        message:
+          'A version that has been permanently deleted cannot be restored. You can view other versions of this secret in the Version History tab above.',
+        link: '/vault/docs/secrets/kv/kv-v2',
+      };
+    }
+    if (deletionTime) {
+      return {
+        title: `Version ${version} of this secret has been deleted`,
+        message:
+          'This version has been deleted but can be undeleted. View other versions of this secret by clicking the Version History tab above.',
+        link: '/vault/docs/secrets/kv/kv-v2',
+      };
+    }
+    return false;
   }
 }

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -14,12 +14,14 @@ import { tracked } from '@glimmer/tracking';
  *  @secretPath={{this.model.path}}
  *  @secret={{this.model.secret}}
  *  @metadata={{this.model.metadata}}
+ *  @noMetadataPermission={{eq this.model.metadata 403}}
  *  @breadcrumbs={{this.breadcrumbs}}
   /> 
  *
  * @param {string} secretPath - path of kv secret 'my/secret' used as the title for the KV page header 
  * @param {model} secret - Ember data model: 'kv/data'  
  * @param {model} metadata - Ember data model: 'kv/metadata'
+ * @param {boolean} noMetadataPermission - True if we received a 403 from the kv/metadata network request
  * @param {array} breadcrumbs - Array to generate breadcrumbs, passed to the page header component
  */
 

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -14,7 +14,6 @@ import { tracked } from '@glimmer/tracking';
  *  @secretPath={{this.model.path}}
  *  @secret={{this.model.secret}}
  *  @metadata={{this.model.metadata}}
- *  @noMetadataPermission={{eq this.model.metadata 403}}
  *  @breadcrumbs={{this.breadcrumbs}}
   /> 
  *

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -16,7 +16,8 @@ export default class KvSecretRoute extends Route {
   }
 
   async fetchSecretMetadata(backend, path) {
-    return await this.store.queryRecord('kv/metadata', { backend, path }).catch((error) => error.httpStatus);
+    // catch error and do nothing because kv/data model handles metadata capabilities
+    return await this.store.queryRecord('kv/metadata', { backend, path }).catch(() => {});
   }
 
   model() {

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -12,7 +12,10 @@ export default class KvSecretRoute extends Route {
   @service secretMountPath;
 
   async fetchSecretData(backend, path) {
-    return await this.store.queryRecord('kv/data', { backend, path }).catch((error) => error.httpStatus);
+    return await this.store.queryRecord('kv/data', { backend, path }).catch(() => {
+      // return empty record to access capability getters on model
+      return this.store.createRecord('kv/data', { backend, path });
+    });
   }
 
   async fetchSecretMetadata(backend, path) {
@@ -23,6 +26,7 @@ export default class KvSecretRoute extends Route {
   model() {
     const backend = this.secretMountPath.currentPath;
     const { name: path } = this.paramsFor('secret');
+
     return hash({
       path,
       backend,

--- a/ui/lib/kv/addon/templates/secret/details.hbs
+++ b/ui/lib/kv/addon/templates/secret/details.hbs
@@ -2,6 +2,5 @@
   @secretPath={{this.model.path}}
   @secret={{this.model.secret}}
   @metadata={{this.model.metadata}}
-  @noMetadataPermission={{eq this.model.metadata 403}}
   @breadcrumbs={{this.breadcrumbs}}
 />

--- a/ui/lib/kv/addon/templates/secret/details.hbs
+++ b/ui/lib/kv/addon/templates/secret/details.hbs
@@ -2,5 +2,6 @@
   @secretPath={{this.model.path}}
   @secret={{this.model.secret}}
   @metadata={{this.model.metadata}}
+  @noMetadataPermission={{eq this.model.metadata 403}}
   @breadcrumbs={{this.breadcrumbs}}
 />

--- a/ui/tests/acceptance/secrets/backend/kv/kv-engine-permissions-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-engine-permissions-test.js
@@ -93,7 +93,7 @@ module('Acceptance | kv permissions', function (hooks) {
       });
 
       test('it shows empty state when cannot read secret data', async function (assert) {
-        assert.expect(5);
+        assert.expect(7);
         await authPage.login(this.cannotReadData);
         await visit(`/vault/secrets/${this.mountPath}/kv/${this.secretPath}/details`);
         assert.strictEqual(currentURL(), `/vault/secrets/${this.mountPath}/kv/${this.secretPath}/details`);

--- a/ui/tests/acceptance/secrets/backend/kv/kv-engine-permissions-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-engine-permissions-test.js
@@ -11,8 +11,13 @@ import authPage from 'vault/tests/pages/auth';
 import logout from 'vault/tests/pages/logout';
 import enablePage from 'vault/tests/pages/settings/mount-secret-backend';
 import { currentURL, visit } from '@ember/test-helpers';
-import { adminPolicy } from 'vault/tests/helpers/policy-generator/kv';
+import {
+  adminPolicy,
+  dataSecretPathCreateReadUpdate,
+  metadataListOnly,
+} from 'vault/tests/helpers/policy-generator/kv';
 import { tokenWithPolicy, runCommands, writeSecret } from 'vault/tests/helpers/kv/kv-run-commands';
+import { SELECTORS } from 'vault/tests/helpers/kv/kv-general-selectors';
 
 // This test module should test KV permissions views, each sub-module is a separate tab (i.e. secret, metadata)
 
@@ -39,17 +44,39 @@ module('Acceptance | kv permissions', function (hooks) {
   module('secret', function (hooks) {
     hooks.beforeEach(async function () {
       await authPage.login();
+      this.secretPath = `my-secret-${uuidv4()}`;
+      await writeSecret(this.mountPath, this.secretPath, 'foo', 'bar');
+
       const kv_admin_policy = adminPolicy(this.mountPath);
       this.kvAdminToken = await tokenWithPolicy('kv-admin', kv_admin_policy);
+
+      const no_metadata_read_policy =
+        metadataListOnly(this.mountPath) + dataSecretPathCreateReadUpdate(this.mountPath, this.secretPath);
+      this.kvNoMetadataRead = await tokenWithPolicy('kv-no-metadata-read', no_metadata_read_policy);
+
       await logout.visit();
     });
 
     test('it shows all tabs for admin policy', async function (assert) {
+      assert.expect(5);
       await authPage.login(this.kvAdminToken);
-      const secretPath = `my-secret-${uuidv4()}`;
-      await writeSecret(this.mountPath, secretPath, 'foo', 'bar');
-      await visit(`/vault/secrets/${this.mountPath}/kv/${secretPath}/details`);
-      assert.strictEqual(currentURL(), `/vault/secrets/${this.mountPath}/kv/${secretPath}/details`);
+      await visit(`/vault/secrets/${this.mountPath}/kv/${this.secretPath}/details`);
+      assert.strictEqual(currentURL(), `/vault/secrets/${this.mountPath}/kv/${this.secretPath}/details`);
+      assert.dom(SELECTORS.secretTab('Secret')).exists();
+      assert.dom(SELECTORS.secretTab('Metadata')).exists();
+      assert.dom(SELECTORS.secretTab('Version History')).exists();
+      assert.dom(SELECTORS.secretTab('Version Diff')).exists();
+    });
+
+    test('it hides tabs when no metadata read', async function (assert) {
+      assert.expect(5);
+      await authPage.login(this.kvNoMetadataRead);
+      await visit(`/vault/secrets/${this.mountPath}/kv/${this.secretPath}/details`);
+      assert.strictEqual(currentURL(), `/vault/secrets/${this.mountPath}/kv/${this.secretPath}/details`);
+      assert.dom(SELECTORS.secretTab('Secret')).exists();
+      assert.dom(SELECTORS.secretTab('Metadata')).exists();
+      assert.dom(SELECTORS.secretTab('Version History')).doesNotExist();
+      assert.dom(SELECTORS.secretTab('Version Diff')).doesNotExist();
     });
   });
 });

--- a/ui/tests/acceptance/secrets/backend/kv/kv-engine-permissions-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-engine-permissions-test.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { v4 as uuidv4 } from 'uuid';
+
+import authPage from 'vault/tests/pages/auth';
+import logout from 'vault/tests/pages/logout';
+import enablePage from 'vault/tests/pages/settings/mount-secret-backend';
+import { currentURL, visit } from '@ember/test-helpers';
+import { adminPolicy } from 'vault/tests/helpers/policy-generator/kv';
+import { tokenWithPolicy, runCommands, writeSecret } from 'vault/tests/helpers/kv/kv-run-commands';
+
+// This test module should test KV permissions views, each sub-module is a separate tab (i.e. secret, metadata)
+
+module('Acceptance | kv permissions', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(async function () {
+    await authPage.login();
+    // Setup KV engine
+    const mountPath = `kv-engine-${uuidv4()}`;
+    await enablePage.enable('kv', mountPath);
+    this.mountPath = mountPath;
+    await logout.visit();
+  });
+
+  hooks.afterEach(async function () {
+    await logout.visit();
+    await authPage.login();
+    // Cleanup engine
+    await runCommands([`delete sys/mounts/${this.mountPath}`]);
+    await logout.visit();
+  });
+
+  module('secret', function (hooks) {
+    hooks.beforeEach(async function () {
+      await authPage.login();
+      const kv_admin_policy = adminPolicy(this.mountPath);
+      this.kvAdminToken = await tokenWithPolicy('kv-admin', kv_admin_policy);
+      await logout.visit();
+    });
+
+    test('it shows all tabs for admin policy', async function (assert) {
+      await authPage.login(this.kvAdminToken);
+      const secretPath = `my-secret-${uuidv4()}`;
+      await writeSecret(this.mountPath, secretPath, 'foo', 'bar');
+      await visit(`/vault/secrets/${this.mountPath}/kv/${secretPath}/details`);
+      assert.strictEqual(currentURL(), `/vault/secrets/${this.mountPath}/kv/${secretPath}/details`);
+    });
+  });
+});

--- a/ui/tests/acceptance/secrets/backend/kv/kv-engine-permissions-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-engine-permissions-test.js
@@ -11,11 +11,7 @@ import authPage from 'vault/tests/pages/auth';
 import logout from 'vault/tests/pages/logout';
 import enablePage from 'vault/tests/pages/settings/mount-secret-backend';
 import { currentURL, visit } from '@ember/test-helpers';
-import {
-  adminPolicy,
-  dataSecretPathCreateReadUpdate,
-  metadataListOnly,
-} from 'vault/tests/helpers/policy-generator/kv';
+import { adminPolicy, dataPolicy, metadataPolicy } from 'vault/tests/helpers/policy-generator/kv';
 import { tokenWithPolicy, runCommands, writeSecret } from 'vault/tests/helpers/kv/kv-run-commands';
 import { SELECTORS } from 'vault/tests/helpers/kv/kv-general-selectors';
 
@@ -50,10 +46,10 @@ module('Acceptance | kv permissions', function (hooks) {
       const kv_admin_policy = adminPolicy(this.mountPath);
       this.kvAdminToken = await tokenWithPolicy('kv-admin', kv_admin_policy);
 
-      const no_metadata_read_policy =
-        metadataListOnly(this.mountPath) + dataSecretPathCreateReadUpdate(this.mountPath, this.secretPath);
-      this.kvNoMetadataRead = await tokenWithPolicy('kv-no-metadata-read', no_metadata_read_policy);
-
+      const no_metadata_read =
+        dataPolicy({ backend: this.mountPath, secretPath: this.secretPath }) +
+        metadataPolicy({ backend: this.mountPath, capabilities: ['list'] });
+      this.kvNoMetadataRead = await tokenWithPolicy('kv-no-metadata-read', no_metadata_read);
       await logout.visit();
     });
 

--- a/ui/tests/helpers/kv/kv-general-selectors.js
+++ b/ui/tests/helpers/kv/kv-general-selectors.js
@@ -10,6 +10,7 @@ export const SELECTORS = {
   tooltipTrigger: '[data-test-tooltip-trigger]',
   pageTitle: '[data-test-header-title]',
   infoRowValue: (label) => `[data-test-value-div="${label}"]`,
+  secretTab: (tab) => `[data-test-secrets-tab="${tab}"]`,
 };
 
 export const parseJsonEditor = (find) => {

--- a/ui/tests/helpers/kv/kv-general-selectors.js
+++ b/ui/tests/helpers/kv/kv-general-selectors.js
@@ -11,6 +11,8 @@ export const SELECTORS = {
   pageTitle: '[data-test-header-title]',
   infoRowValue: (label) => `[data-test-value-div="${label}"]`,
   secretTab: (tab) => `[data-test-secrets-tab="${tab}"]`,
+  emptyStateTitle: '[data-test-empty-state-title]',
+  emptyStateMessage: '[data-test-empty-state-message]',
 };
 
 export const parseJsonEditor = (find) => {

--- a/ui/tests/helpers/kv/kv-run-commands.js
+++ b/ui/tests/helpers/kv/kv-run-commands.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import consoleClass from 'vault/tests/pages/components/console/ui-panel';
+import { create } from 'ember-cli-page-object';
+import editPage from 'vault/tests/pages/secrets/backend/kv/edit-secret';
+import listPage from 'vault/tests/pages/secrets/backend/list';
+
+// TODO update writeSecret with create flow from KV ember engine when built
+export const writeSecret = async function (backend, path, key, val) {
+  await listPage.visitRoot({ backend });
+  await listPage.create();
+  return editPage.createSecret(path, key, val);
+};
+
+const consoleComponent = create(consoleClass);
+
+export const tokenWithPolicy = async function (name, policy) {
+  await consoleComponent.runCommands([
+    `write sys/policies/acl/${name} policy=${btoa(policy)}`,
+    `write -field=client_token auth/token/create policies=${name}`,
+  ]);
+  return consoleComponent.lastLogOutput;
+};
+
+export const runCommands = async function (commands) {
+  try {
+    await consoleComponent.runCommands(commands);
+    const res = consoleComponent.lastLogOutput;
+    if (res.includes('Error')) {
+      throw new Error(res);
+    }
+    return res;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `The following occurred when trying to run the command(s):\n ${commands.join('\n')} \n\n ${
+        consoleComponent.lastLogOutput
+      }`
+    );
+    throw error;
+  }
+};

--- a/ui/tests/helpers/policy-generator/kv.js
+++ b/ui/tests/helpers/policy-generator/kv.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export const adminPolicy = (backend) => {
+  return `
+    path "${backend}/*" {
+      capabilities = ["create", "read", "update", "delete", "list"]
+    },
+  `;
+};
+
+export const secretPathCreateReadUpdate = (backend, secretPath) => {
+  return `
+    path "${backend}/metadata/*" {
+      capabilities = ["list"]
+    }
+    path "${backend}/data/${secretPath}" {
+      capabilities = ["create", "read", "update"]
+    }
+  `;
+};
+
+export const dataCRUDandMetadataUpdateDelete = (backend) => {
+  return `
+    path "${backend}/metadata/*" {
+      capabilities = ["update","delete"]
+    }
+    path "${backend}/data/*" {
+      capabilities = ["create", "read", "update", "delete"]
+    }
+  `;
+};

--- a/ui/tests/helpers/policy-generator/kv.js
+++ b/ui/tests/helpers/policy-generator/kv.js
@@ -11,24 +11,20 @@ export const adminPolicy = (backend) => {
   `;
 };
 
-export const secretPathCreateReadUpdate = (backend, secretPath) => {
+// DATA POLICIES
+export const dataSecretPathCreateReadUpdate = (backend, secretPath) => {
   return `
-    path "${backend}/metadata/*" {
-      capabilities = ["list"]
-    }
     path "${backend}/data/${secretPath}" {
       capabilities = ["create", "read", "update"]
     }
   `;
 };
 
-export const dataCRUDandMetadataUpdateDelete = (backend) => {
+// METADATA POLICIES
+export const metadataListOnly = (backend) => {
   return `
     path "${backend}/metadata/*" {
-      capabilities = ["update","delete"]
-    }
-    path "${backend}/data/*" {
-      capabilities = ["create", "read", "update", "delete"]
+      capabilities = ["list"]
     }
   `;
 };

--- a/ui/tests/helpers/policy-generator/kv.js
+++ b/ui/tests/helpers/policy-generator/kv.js
@@ -3,28 +3,31 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+const root = ['create', 'read', 'update', 'delete', 'list'];
+
+// returns a string with each capability wrapped in double quotes => ["create", "read"]
+const format = (array) => array.map((c) => `"${c}"`).join(', ');
+
 export const adminPolicy = (backend) => {
   return `
     path "${backend}/*" {
-      capabilities = ["create", "read", "update", "delete", "list"]
+      capabilities = [${format(root)}]
     },
   `;
 };
 
-// DATA POLICIES
-export const dataSecretPathCreateReadUpdate = (backend, secretPath) => {
+export const dataPolicy = ({ backend, secretPath = '*', capabilities = root }) => {
   return `
     path "${backend}/data/${secretPath}" {
-      capabilities = ["create", "read", "update"]
+      capabilities = [${format(capabilities)}]
     }
   `;
 };
 
-// METADATA POLICIES
-export const metadataListOnly = (backend) => {
+export const metadataPolicy = ({ backend, secretPath = '*', capabilities = root }) => {
   return `
-    path "${backend}/metadata/*" {
-      capabilities = ["list"]
+    path "${backend}/metadata/${secretPath}" {
+        capabilities = [${format(capabilities)}]
     }
   `;
 };

--- a/ui/tests/integration/components/kv/page/kv-page-secret-details-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-details-test.js
@@ -69,4 +69,46 @@ module('Integration | Component | kv | Page::Secret::Details', function (hooks) 
     assert.propEqual(parseJsonEditor(find), this.secretData, 'json editor renders secret data');
     assert.dom(SELECTORS.tooltipTrigger).includesText(this.version, 'renders version');
   });
+
+  test('it renders deleted empty state', async function (assert) {
+    assert.expect(2);
+    this.secret.deletionTime = '2023-07-23T02:12:17.379762Z';
+    await render(
+      hbs`
+       <Page::Secret::Details
+        @secretPath={{this.model.path}}
+        @secret={{this.model.secret}}
+        @breadcrumbs={{this.breadcrumbs}}
+      />
+      `,
+      { owner: this.engine }
+    );
+    assert.dom(SELECTORS.emptyStateTitle).hasText('Version 2 of this secret has been deleted');
+    assert
+      .dom(SELECTORS.emptyStateMessage)
+      .hasText(
+        'This version has been deleted but can be undeleted. View other versions of this secret by clicking the Version History tab above.'
+      );
+  });
+
+  test('it renders destroyed empty state', async function (assert) {
+    assert.expect(2);
+    this.secret.destroyed = true;
+    await render(
+      hbs`
+       <Page::Secret::Details
+        @secretPath={{this.model.path}}
+        @secret={{this.model.secret}}
+        @breadcrumbs={{this.breadcrumbs}}
+      />
+      `,
+      { owner: this.engine }
+    );
+    assert.dom(SELECTORS.emptyStateTitle).hasText('Version 2 of this secret has been permanently destroyed');
+    assert
+      .dom(SELECTORS.emptyStateMessage)
+      .hasText(
+        'A version that has been permanently deleted cannot be restored. You can view other versions of this secret in the Version History tab above.'
+      );
+  });
 });

--- a/ui/tests/integration/components/kv/page/kv-page-secret-details-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-details-test.js
@@ -34,8 +34,7 @@ module('Integration | Component | kv | Page::Secret::Details', function (hooks) 
     });
     this.secret = this.store.peekRecord('kv/data', this.id);
 
-    // this is a route model, not ember data model
-
+    // this is the route model, not an ember data model
     this.model = {
       backend: this.backend,
       path: this.path,


### PR DESCRIPTION
- Hides tabs if no metadata access
- Shows empty state if no read permission
<img width="988" alt="Screenshot 2023-07-20 at 8 07 14 PM" src="https://github.com/hashicorp/vault/assets/68122737/6340b8aa-c007-4e9b-91ac-6f9fe0c77683">
<hr>

- shows empty state if version is deleted
<img width="980" alt="Screenshot 2023-07-20 at 8 07 56 PM" src="https://github.com/hashicorp/vault/assets/68122737/1c8090b9-d6fe-4484-9f96-980ba20efdaf">

<hr>

- and if destroyed
<img width="969" alt="Screenshot 2023-07-20 at 8 09 29 PM" src="https://github.com/hashicorp/vault/assets/68122737/b19770b7-f507-45e9-a0f5-def1b2b7d96f">
 

