### PR TITLE
Address memory consumption from TestCertStorageMetrics

### DIFF
--- a/builtin/logical/pki/path_tidy_test.go
+++ b/builtin/logical/pki/path_tidy_test.go
@@ -422,8 +422,8 @@ func TestCertStorageMetrics(t *testing.T) {
 
 	// We set up a metrics accumulator
 	inmemSink := metrics.NewInmemSink(
-		2*newPeriod, // A short time period is ideal here to test metrics are emitted every periodic func
-		2000000*time.Hour)
+		2*newPeriod,  // A short time period is ideal here to test metrics are emitted every periodic func
+		10*newPeriod) // Do not keep a huge amount of metrics in the sink forever, clear them out to save memory usage.
 
 	metricsConf := metrics.DefaultConfig("")
 	metricsConf.EnableHostname = false


### PR DESCRIPTION
This fix seems to have been missed on the 1.13.x branch, as these are the values used on [1.12.x](https://github.com/hashicorp/vault/blob/release/1.12.x/builtin/logical/pki/path_tidy_test.go#L256-L257), [1.14.x](https://github.com/hashicorp/vault/blob/release/1.14.x/builtin/logical/pki/path_tidy_test.go#L584-L585)