### PR TITLE
ci: restore old timing before saving new cache

### DIFF
--- a/.github/actions/set-up-go/action.yml
+++ b/.github/actions/set-up-go/action.yml
@@ -25,7 +25,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     - id: go-version
       shell: bash
       run: echo "go-version=$(cat ./.go-version)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -375,6 +375,11 @@ jobs:
     needs: test-go
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: test-results/go-test
+          key: go-test-reports-${{ github.run_number }}
+          restore-keys: go-test-reports-
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: test-results
@@ -383,7 +388,3 @@ jobs:
           ls -lhR test-results/go-test
           find test-results/go-test -mindepth 1 -mtime +3 -delete
           ls -lhR test-results/go-test
-      - uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        with:
-          path: test-results/go-test
-          key: go-test-reports-${{ github.run_number }}


### PR DESCRIPTION
* restore old timing results before saving new cache
* don't do an unecessary checkout in set-up-go