### PR TITLE
secrets/azure: adds permissions note on rotate root and change role assignment

### DIFF
--- a/website/content/docs/secrets/azure.mdx
+++ b/website/content/docs/secrets/azure.mdx
@@ -237,6 +237,9 @@ service principals.
 | Application.ReadWrite.OwnedBy | Application |
 | GroupMember.ReadWrite.All     | Application |
 
+~> **Note**: If you plan to use the [rotate root](/vault/api-docs/secret/azure#rotate-root)
+credentials API, you'll need to change `Application.ReadWrite.OwnedBy` to `Application.ReadWrite.All`.
+
 #### Existing Service Principals
 
 | Permission Name               | Type        |
@@ -250,9 +253,9 @@ The following Azure [role assignments](https://learn.microsoft.com/en-us/azure/r
 must be granted in order for the secrets engine to manage role assignments for service
 principles it creates.
 
-| Role  | Scope        | Security Principal                          |
-| ----- | ------------ | ------------------------------------------- |
-| Owner | Subscription | Service Principal ID given in configuration |
+| Role                                           | Scope        | Security Principal                          |
+|------------------------------------------------| ------------ | ------------------------------------------- |
+| [User Access Administrator][user_access_admin] | Subscription | Service Principal ID given in configuration |
 
 ## Choosing between dynamic or existing service principals
 
@@ -320,3 +323,4 @@ for more details.
 [api]: /vault/api-docs/secret/azure
 [config]: /vault/api-docs/secret/azure#configure-access
 [repo]: https://github.com/hashicorp/vault-plugin-secrets-azure
+[user_access_admin]: https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#user-access-administrator


### PR DESCRIPTION
This PR updates the Azure secrets permissions recommendations (again 😄) to:
- Add a note that `Application.ReadWrite.All` is needed for rotate root
- Scope down the role assignment from `Owner` to `User Access Administrator`

Related PR:
- https://github.com/hashicorp/vault-plugin-secrets-azure/pull/158