### PR TITLE
TakesArbitraryInput fixes

### DIFF
--- a/vault/logical_cubbyhole.go
+++ b/vault/logical_cubbyhole.go
@@ -61,6 +61,8 @@ func (b *CubbyholeBackend) paths() []*framework.Path {
 				},
 			},
 
+			TakesArbitraryInput: true,
+
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
 					Callback: b.handleRead,


### PR DESCRIPTION
Update the OpenAPI generation code to render TakesArbitraryInput
appropriately.

Mark the cubbyhole write operation as TakesArbitraryInput.

Contributes to fixing
https://github.com/hashicorp/vault-client-go/issues/201.

We will also need
https://github.com/hashicorp/vault-plugin-secrets-kv/pull/114 merged and
a new version of that plugin brought into Vault.
