### PR TITLE
Update version of KV secrets engine plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -143,7 +143,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-gcp v0.16.0
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.15.0
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.5.0
-	github.com/hashicorp/vault-plugin-secrets-kv v0.15.0
+	github.com/hashicorp/vault-plugin-secrets-kv v0.15.1-0.20230723160501-4eb796ea95e4
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.10.0
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.11.0
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -1918,8 +1918,8 @@ github.com/hashicorp/vault-plugin-secrets-gcpkms v0.15.0 h1:CueteKXEuO52qGu1nUaD
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.15.0/go.mod h1:a0Z2DVGd2SPPwLb8edXeHyer3CXei/Y0cb7EFkiFMfA=
 github.com/hashicorp/vault-plugin-secrets-kubernetes v0.5.0 h1:g0W1ybHjO945jDtuDEFcqTINyW/s06wxZarE/7aLumc=
 github.com/hashicorp/vault-plugin-secrets-kubernetes v0.5.0/go.mod h1:2wobeIypBESGQYmhv12vuAorCvfETHpBoMyrb+6QTmQ=
-github.com/hashicorp/vault-plugin-secrets-kv v0.15.0 h1:S2d1t4m4ilDNJRdMUzNUimvyu/+ll8huq5QncVgYz+s=
-github.com/hashicorp/vault-plugin-secrets-kv v0.15.0/go.mod h1:xu/eiT+BB2b2Gh/AZFJ1xCS8E7S29gOQcuh9VMxros8=
+github.com/hashicorp/vault-plugin-secrets-kv v0.15.1-0.20230723160501-4eb796ea95e4 h1:jgBjc1li32d2CCCfOBySw3CIHleXUcD40ygdic8bkqo=
+github.com/hashicorp/vault-plugin-secrets-kv v0.15.1-0.20230723160501-4eb796ea95e4/go.mod h1:xu/eiT+BB2b2Gh/AZFJ1xCS8E7S29gOQcuh9VMxros8=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.10.0 h1:FB860wKclwLBvBHkQb5nq8bGMUAsuw0khrYT1RM0NR0=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.10.0/go.mod h1:6YPhFm57C3DvPueHEGdTLK94g3gZI/gdiRrSwO5Fym8=
 github.com/hashicorp/vault-plugin-secrets-openldap v0.11.0 h1:8J8u7uWLifj3uF5tot9Qj74H8vEwPMNKN+XTLLgSmDw=


### PR DESCRIPTION
Only change is to set the `TakesArbitraryInput` metadata on the KV v1
endpoint, which we need to fix hashicorp/vault-client-go#201.
