### PR TITLE
Make TestLogger an InterceptLogger and use it a little more widely

### DIFF
--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -414,7 +414,7 @@ func (n *NoopAudit) RegisterNodesAndPipeline(broker *eventlogger.Broker, _ strin
 }
 
 type TestLogger struct {
-	hclog.Logger
+	hclog.InterceptLogger
 	Path string
 	File *os.File
 	sink hclog.SinkAdapter
@@ -446,6 +446,7 @@ func NewTestLogger(t testing.T) *TestLogger {
 	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
 		Output:            io.Discard,
 		IndependentLevels: true,
+		Name:              t.Name(),
 	})
 	sink := hclog.NewSinkAdapter(&hclog.LoggerOptions{
 		Output:            output,
@@ -454,13 +455,13 @@ func NewTestLogger(t testing.T) *TestLogger {
 	})
 	logger.RegisterSink(sink)
 	return &TestLogger{
-		Path:   logPath,
-		File:   logFile,
-		Logger: logger,
-		sink:   sink,
+		Path:            logPath,
+		File:            logFile,
+		InterceptLogger: logger,
+		sink:            sink,
 	}
 }
 
 func (tl *TestLogger) StopLogging() {
-	tl.Logger.(hclog.InterceptLogger).DeregisterSink(tl.sink)
+	tl.InterceptLogger.DeregisterSink(tl.sink)
 }

--- a/helper/testhelpers/minimal/minimal.go
+++ b/helper/testhelpers/minimal/minimal.go
@@ -1,7 +1,6 @@
 package minimal
 
 import (
-	"github.com/hashicorp/go-hclog"
 	logicalKv "github.com/hashicorp/vault-plugin-secrets-kv"
 	"github.com/hashicorp/vault/audit"
 	auditFile "github.com/hashicorp/vault/builtin/audit/file"
@@ -10,8 +9,8 @@ import (
 	logicalDb "github.com/hashicorp/vault/builtin/logical/database"
 	"github.com/hashicorp/vault/builtin/plugin"
 	"github.com/hashicorp/vault/helper/builtinplugins"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
 	"github.com/hashicorp/vault/vault"
@@ -25,7 +24,7 @@ import (
 // with a nil config argument.  There is no need to call Start or Cleanup or
 // TestWaitActive on the resulting cluster.
 func NewTestSoloCluster(t testing.T, config *vault.CoreConfig) *vault.TestCluster {
-	logger := logging.NewVaultLogger(hclog.Trace).Named(t.Name())
+	logger := corehelpers.NewTestLogger(t)
 
 	mycfg := &vault.CoreConfig{}
 

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -185,12 +185,15 @@ func TestCoreWithSealAndUI(t testing.T, opts *CoreConfig) *Core {
 		if err != nil {
 			t.Logf("shutdown returned error: %v", err)
 		}
+		if tl, ok := c.Logger().(*corehelpers.TestLogger); ok {
+			tl.StopLogging()
+		}
 	})
 	return c
 }
 
 func TestCoreWithSealAndUINoCleanup(t testing.T, opts *CoreConfig) *Core {
-	logger := logging.NewVaultLogger(log.Trace).Named(t.Name())
+	logger := corehelpers.NewTestLogger(t)
 	physicalBackend, err := physInmem.NewInmem(nil, logger)
 	if err != nil {
 		t.Fatal(err)
@@ -441,7 +444,7 @@ func testCoreAddSecretMount(t testing.T, core *Core, token string) {
 
 func TestCoreUnsealedBackend(t testing.T, backend physical.Backend) (*Core, [][]byte, string) {
 	t.Helper()
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.NewTestLogger(t)
 	conf := testCoreConfig(t, backend, logger)
 	conf.Seal = NewTestSeal(t, nil)
 	conf.NumExpirationWorkers = numExpirationWorkersTest


### PR DESCRIPTION
This should get us closer to avoiding all the log noise that occurs in tests after Cleanup.