### PR TITLE
Added secrets sync backend stub

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -83,10 +83,11 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 	db, _ := memdb.NewMemDB(systemBackendMemDBSchema())
 
 	b := &SystemBackend{
-		Core:       core,
-		db:         db,
-		logger:     logger,
-		mfaBackend: NewPolicyMFABackend(core, logger),
+		Core:        core,
+		db:          db,
+		logger:      logger,
+		mfaBackend:  NewPolicyMFABackend(core, logger),
+		syncBackend: NewSecretsSyncBackend(core, logger),
 	}
 
 	b.Backend = &framework.Backend{
@@ -243,10 +244,11 @@ func (b *SystemBackend) rawPaths() []*framework.Path {
 // prefix. Conceptually it is similar to procfs on Linux.
 type SystemBackend struct {
 	*framework.Backend
-	Core       *Core
-	db         *memdb.MemDB
-	logger     log.Logger
-	mfaBackend *PolicyMFABackend
+	Core        *Core
+	db          *memdb.MemDB
+	logger      log.Logger
+	mfaBackend  *PolicyMFABackend
+	syncBackend *SecretsSyncBackend
 }
 
 // handleConfigStateSanitized returns the current configuration state. The configuration

--- a/vault/logical_system_sync_secrets_stub.go
+++ b/vault/logical_system_sync_secrets_stub.go
@@ -1,0 +1,26 @@
+//go:build !enterprise
+
+package vault
+
+import (
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+type SecretsSyncBackend struct {
+	*framework.Backend
+}
+
+func NewSecretsSyncBackend(_ *Core, _ log.Logger) *SecretsSyncBackend {
+	return &SecretsSyncBackend{
+		&framework.Backend{
+			Help:        stubBackendHelp,
+			BackendType: logical.TypeLogical,
+		},
+	}
+}
+
+const stubBackendHelp = `
+Unimplemented stub for the enterprise-only secrets sync feature.
+`


### PR DESCRIPTION
Added secrets sync backend stub. Used so Vault ENT can use the real implementation of the sync backend while makign it clear this is not a dependency that should be used or modified here.