### PR TITLE
UI: Display minus icon for empty MaskedInput value. Show MaskedInput for KV secrets without values

### DIFF
--- a/changelog/22039.txt
+++ b/changelog/22039.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-ui: Display a minus icon when MaskedInput value is empty. Show MaskedInput for KV secrets without values
+ui: Display minus icon for empty MaskedInput value. Show MaskedInput for KV secrets without values
 ```

--- a/changelog/22039.txt
+++ b/changelog/22039.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Display a minus icon when MaskedInput value is empty. Show MaskedInput for KV secrets without values
+```

--- a/ui/app/templates/components/secret-form-show.hbs
+++ b/ui/app/templates/components/secret-form-show.hbs
@@ -65,17 +65,13 @@
     {{#if @modelForData.secretKeyAndValue}}
       {{#each @modelForData.secretKeyAndValue as |secret|}}
         <InfoTableRow @label={{secret.key}} @value={{secret.value}} @alwaysRender={{true}}>
-          {{#if secret.value}}
-            <MaskedInput
-              @name={{secret.key}}
-              @value={{secret.value}}
-              @displayOnly={{true}}
-              @allowCopy={{true}}
-              @allowDownload={{@isV2}}
-            />
-          {{else}}
-            <Icon @name="minus" />
-          {{/if}}
+          <MaskedInput
+            @name={{secret.key}}
+            @value={{secret.value}}
+            @displayOnly={{true}}
+            @allowCopy={{true}}
+            @allowDownload={{@isV2}}
+          />
         </InfoTableRow>
       {{/each}}
     {{else}}

--- a/ui/lib/core/addon/components/masked-input.hbs
+++ b/ui/lib/core/addon/components/masked-input.hbs
@@ -31,8 +31,9 @@
   {{/if}}
   {{#if @allowCopy}}
     <CopyButton
-      @clipboardText={{if (eq @value "") " " @value}}
+      @clipboardText={{@value}}
       @success={{action (set-flash-message "Data copied!")}}
+      @error={{action (set-flash-message "Error copying data" "danger")}}
       class="copy-button button {{if @displayOnly 'is-compact'}}"
       data-test-copy-button
     >

--- a/ui/lib/core/addon/components/masked-input.hbs
+++ b/ui/lib/core/addon/components/masked-input.hbs
@@ -31,7 +31,7 @@
   {{/if}}
   {{#if @allowCopy}}
     <CopyButton
-      @clipboardText={{@value}}
+      @clipboardText={{if (eq @value "") " " @value}}
       @success={{action (set-flash-message "Data copied!")}}
       class="copy-button button {{if @displayOnly 'is-compact'}}"
       data-test-copy-button

--- a/ui/lib/core/addon/components/masked-input.hbs
+++ b/ui/lib/core/addon/components/masked-input.hbs
@@ -6,7 +6,12 @@
 >
   {{#if @displayOnly}}
     {{#if this.showValue}}
-      <pre class="masked-value display-only is-word-break">{{@value}}</pre>
+      {{! Show minus icon if there is no value }}
+      {{#if (eq @value "")}}
+        <Icon class="masked-value" @name="minus" />
+      {{else}}
+        <pre class="masked-value display-only is-word-break">{{@value}}</pre>
+      {{/if}}
     {{else}}
       <pre class="masked-value display-only masked-font">***********</pre>
     {{/if}}
@@ -50,7 +55,7 @@
     type="button"
     aria-label={{if this.showValue "mask value" "show value"}}
     title={{if this.showValue "mask value" "show value"}}
-    class="{{if (eq @value '') 'has-text-grey'}} masked-input-toggle button"
+    class="masked-input-toggle button"
     data-test-button="toggle-masked"
   >
     <Icon @name={{if this.showValue "eye" "eye-off"}} />

--- a/ui/tests/integration/components/masked-input-test.js
+++ b/ui/tests/integration/components/masked-input-test.js
@@ -16,6 +16,13 @@ const component = create(maskedInput);
 module('Integration | Component | masked input', function (hooks) {
   setupRenderingTest(hooks);
 
+  hooks.beforeEach(function () {
+    this.flashMessages = this.owner.lookup('service:flash-messages');
+    this.flashMessages.registerTypes(['success', 'danger']);
+    this.flashSuccessSpy = sinon.spy(this.flashMessages, 'success');
+    this.flashDangerSpy = sinon.spy(this.flashMessages, 'danger');
+  });
+
   test('it renders', async function (assert) {
     await render(hbs`<MaskedInput />`);
     assert.dom('[data-test-masked-input]').exists('shows masked input');
@@ -117,5 +124,35 @@ module('Integration | Component | masked input', function (hooks) {
     assert
       .dom('[data-test-icon="minus"]')
       .exists('shows minus icon when unmasked because value is empty string');
+  });
+
+  test('it shows "success" flash message when the value is successfully copied', async function (assert) {
+    await render(hbs`
+      <MaskedInput
+        @name="key"
+        @value="value"
+        @displayOnly={{true}}
+        @allowCopy={{true}}
+      />
+    `);
+    assert.dom('[data-test-masked-input]').exists('shows masked input');
+    assert.ok(component.copyButtonIsPresent);
+    await component.copyValue();
+    assert.ok(this.flashSuccessSpy.calledWith('Data copied!'), 'Renders correct flash message');
+  });
+
+  test('it shows "danger" flash message when the value fails to be copied (no value)', async function (assert) {
+    await render(hbs`
+      <MaskedInput
+        @name="key"
+        @value=""
+        @displayOnly={{true}}
+        @allowCopy={{true}}
+      />
+    `);
+    assert.dom('[data-test-masked-input]').exists('shows masked input');
+    assert.ok(component.copyButtonIsPresent);
+    await component.copyValue();
+    assert.ok(this.flashDangerSpy.calledWith('Error copying data'), 'Renders correct flash message');
   });
 });

--- a/ui/tests/integration/components/masked-input-test.js
+++ b/ui/tests/integration/components/masked-input-test.js
@@ -108,8 +108,8 @@ module('Integration | Component | masked input', function (hooks) {
       />
     `);
     assert.dom('[data-test-masked-input]').exists('shows masked input');
-    assert.dom('[data-test-copy-button]').exists('shows copy button');
-    assert.dom('[data-test-download-button]').exists('shows download button');
+    assert.ok(component.copyButtonIsPresent);
+    assert.ok(component.downloadButtonIsPresent);
     assert.dom('[data-test-button="toggle-masked"]').exists('shows toggle mask button');
 
     await component.toggleMasked();

--- a/ui/tests/integration/components/masked-input-test.js
+++ b/ui/tests/integration/components/masked-input-test.js
@@ -104,7 +104,7 @@ module('Integration | Component | masked input', function (hooks) {
     assert.strictEqual(unMaskedValue, this.value);
   });
 
-  test('it renders correctly with empty string provided as value', async function (assert) {
+  test('it renders a minus icon when an empty string is provided as a value', async function (assert) {
     await render(hbs`
       <MaskedInput
         @name="key"

--- a/ui/tests/integration/components/masked-input-test.js
+++ b/ui/tests/integration/components/masked-input-test.js
@@ -100,8 +100,8 @@ module('Integration | Component | masked input', function (hooks) {
   test('it renders correctly with empty string provided as value', async function (assert) {
     await render(hbs`
       <MaskedInput
-        @name={{"key"}}
-        @value={{""}}
+        @name="key"
+        @value=""
         @displayOnly={{true}}
         @allowCopy={{true}}
         @allowDownload={{true}}

--- a/ui/tests/integration/components/masked-input-test.js
+++ b/ui/tests/integration/components/masked-input-test.js
@@ -96,4 +96,26 @@ module('Integration | Component | masked input', function (hooks) {
     const unMaskedValue = document.querySelector('.masked-value').value;
     assert.strictEqual(unMaskedValue, this.value);
   });
+
+  test('it renders correctly with empty string provided as value', async function (assert) {
+    await render(hbs`
+      <MaskedInput
+        @name={{"key"}}
+        @value={{""}}
+        @displayOnly={{true}}
+        @allowCopy={{true}}
+        @allowDownload={{true}}
+      />
+    `);
+    assert.dom('[data-test-masked-input]').exists('shows masked input');
+    assert.dom('[data-test-copy-button]').exists('shows copy button');
+    assert.dom('[data-test-download-button]').exists('shows download button');
+    assert.dom('[data-test-button="toggle-masked"]').exists('shows toggle mask button');
+
+    await component.toggleMasked();
+    assert.dom('.masked-value').doesNotHaveClass('masked-font', 'it unmasks when show button is clicked');
+    assert
+      .dom('[data-test-icon="minus"]')
+      .exists('shows minus icon when unmasked because value is empty string');
+  });
 });

--- a/ui/tests/pages/components/masked-input.js
+++ b/ui/tests/pages/components/masked-input.js
@@ -10,4 +10,5 @@ export default {
   copyButtonIsPresent: isPresent('[data-test-copy-button]'),
   downloadButtonIsPresent: isPresent('[data-test-download-button]'),
   toggleMasked: clickable('[data-test-button="toggle-masked"]'),
+  copyValue: clickable('[data-test-copy-button]'),
 };


### PR DESCRIPTION
**Description:**

1. This PR changes what the `<MaskedInput>` component shows when it has no value
  - Before: it showed just a blank space when the "show value" button is pressed. 
  - After: it shows a minus icon (`<Icon @name="minus" />`) so that it is more clear to users that there is simply no value there
    - When downloaded, the content is an empty string
    - When copied, a blank space is copied and a copy success alert shows
2. This PR changes what the KV secrets page shows when there secrets with no value
  - Reproduction Steps: enable KV engine > create a path > create a secret in that path with only a key, no value > view the path so you can see the key/value pairs
  - Before: secrets with only a key and no value showed the minus icon for the value. 
  - After: a key with no value shows the newly updated `<MaskedInput>`. This makes it so that the KV secrets page looks more consistent even if there are keys with no values 

**Pictures:**
_Before:_
<img width="965" alt="Before" src="https://github.com/hashicorp/vault/assets/104539507/84bc6bc5-8958-4bea-8130-0ce8c6766ccb">

_After:_
<img width="970" alt="After 1" src="https://github.com/hashicorp/vault/assets/104539507/6c8594f0-1a18-4bdb-b4e8-11735eea7b72">
<img width="969" alt="After 2" src="https://github.com/hashicorp/vault/assets/104539507/80dba43f-cd84-47ea-b5fd-f618b82dc55e">

