### PR TITLE
Instead of looking for a comment that `contains` our signature string…

### DIFF
--- a/.github/scripts/gh_comment.sh
+++ b/.github/scripts/gh_comment.sh
@@ -16,7 +16,8 @@ function update_or_create_comment {
                  -H "Accept: application/vnd.github+json" \
                  -H "X-GitHub-Api-Version: 2022-11-28" \
                  --paginate \
-                 /repos/hashicorp/"$REPO"/issues/"$PR_NUMBER"/comments | jq -r --arg SEARCH_KEY "$SEARCH_KEY" '.[] | select (.body | contains($SEARCH_KEY)) | .id')
+                 /repos/hashicorp/"$REPO"/issues/"$PR_NUMBER"/comments |
+                 jq -r --arg SEARCH_KEY "$SEARCH_KEY" '.[] | select (.body | startswith($SEARCH_KEY)) | .id')
 
   if [[ "$comment_id" != "" ]]; then
     # update the comment with the new body


### PR DESCRIPTION
…, require that it `startswith` that string.

Example motivating this change: https://github.com/hashicorp/vault-enterprise/actions/runs/5626140643/job/15247090023

Here the problem was that Josh quoted the test comment (https://github.com/hashicorp/vault-enterprise/pull/4254#issuecomment-1646188679) and that confused us because now two comments matched our `contains` test.