### PR TITLE
Use hclog instead of t.Logf within PKI ACME test suite

### DIFF
--- a/builtin/logical/pki/acme_challenges_test.go
+++ b/builtin/logical/pki/acme_challenges_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/builtin/logical/pki/dnstest"
 
 	"github.com/stretchr/testify/require"
@@ -242,6 +243,8 @@ func TestAcmeValidateTLSALPN01Challenge(t *testing.T) {
 	host := "localhost"
 	config := &acmeConfigEntry{}
 
+	log := hclog.L()
+
 	returnedProtocols := []string{ALPNProtocol}
 	var certificates []*x509.Certificate
 	var privateKey crypto.PrivateKey
@@ -250,7 +253,7 @@ func TestAcmeValidateTLSALPN01Challenge(t *testing.T) {
 	tlsCfg.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
 		var retCfg tls.Config = *tlsCfg
 		retCfg.NextProtos = returnedProtocols
-		t.Logf("[alpn-server] returned protocol: %v", returnedProtocols)
+		log.Info(fmt.Sprintf("[alpn-server] returned protocol: %v", returnedProtocols))
 		return &retCfg, nil
 	}
 	tlsCfg.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
@@ -262,7 +265,7 @@ func TestAcmeValidateTLSALPN01Challenge(t *testing.T) {
 			}
 		}
 		ret.PrivateKey = privateKey
-		t.Logf("[alpn-server] returned certificates: %v", ret)
+		log.Info(fmt.Sprintf("[alpn-server] returned certificates: %v", ret))
 		return &ret, nil
 	}
 
@@ -270,26 +273,27 @@ func TestAcmeValidateTLSALPN01Challenge(t *testing.T) {
 	require.NoError(t, err, "failed to listen with TLS config")
 
 	doOneAccept := func() {
-		t.Logf("[alpn-server] starting accept...")
+		log.Info("[alpn-server] starting accept...")
 		connRaw, err := ln.Accept()
 		require.NoError(t, err, "failed to accept TLS connection")
 
-		t.Logf("[alpn-server] got connection...")
+		log.Info("[alpn-server] got connection...")
 		conn := tls.Server(connRaw.(*tls.Conn), tlsCfg)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 		defer func() {
+			log.Info("[alpn-server] canceling listener connection...")
 			cancel()
 		}()
 
-		t.Logf("[alpn-server] starting handshake...")
+		log.Info("[alpn-server] starting handshake...")
 		if err := conn.HandshakeContext(ctx); err != nil {
-			t.Logf("[alpn-server] got non-fatal error while handshaking connection: %v", err)
+			log.Info("[alpn-server] got non-fatal error while handshaking connection: %v", err)
 		}
 
-		t.Logf("[alpn-server] closing connection...")
+		log.Info("[alpn-server] closing connection...")
 		if err := conn.Close(); err != nil {
-			t.Logf("[alpn-server] got non-fatal error while closing connection: %v", err)
+			log.Info("[alpn-server] got non-fatal error while closing connection: %v", err)
 		}
 	}
 
@@ -308,7 +312,7 @@ func TestAcmeValidateTLSALPN01Challenge(t *testing.T) {
 	var alpnTestCases []alpnTestCase
 	// Add all of our keyAuthorizationTestCases into alpnTestCases
 	for index, tc := range keyAuthorizationTestCases {
-		t.Logf("using keyAuthorizationTestCase [tc=%d] as alpnTestCase [tc=%d]...", index, len(alpnTestCases))
+		log.Info(fmt.Sprintf("using keyAuthorizationTestCase [tc=%d] as alpnTestCase [tc=%d]...", index, len(alpnTestCases)))
 		// Properly encode the authorization.
 		checksum := sha256.Sum256([]byte(tc.keyAuthz))
 		authz, err := asn1.Marshal(checksum[:])
@@ -690,7 +694,7 @@ func TestAcmeValidateTLSALPN01Challenge(t *testing.T) {
 	}
 
 	for index, tc := range alpnTestCases {
-		t.Logf("\n\n[tc=%d/name=%s] starting validation", index, tc.name)
+		log.Info(fmt.Sprintf("\n\n[tc=%d/name=%s] starting validation", index, tc.name))
 		certificates = tc.certificates
 		privateKey = tc.privateKey
 		returnedProtocols = tc.protocols
@@ -706,7 +710,7 @@ func TestAcmeValidateTLSALPN01Challenge(t *testing.T) {
 		if expectedValid != isValid {
 			t.Fatalf("[tc=%d/name=%s] got ret=%v (err=%v), expected ret=%v (shouldFail=%v)", index, tc.name, isValid, err, expectedValid, tc.shouldFail)
 		} else if err != nil {
-			t.Logf("[tc=%d/name=%s] got expected failure: err=%v", index, tc.name, err)
+			log.Info(fmt.Sprintf("[tc=%d/name=%s] got expected failure: err=%v", index, tc.name, err))
 		}
 	}
 }

--- a/builtin/logical/pki/dnstest/server.go
+++ b/builtin/logical/pki/dnstest/server.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/sdk/helper/docker"
 	"github.com/stretchr/testify/require"
@@ -20,6 +21,7 @@ import (
 type TestServer struct {
 	t   *testing.T
 	ctx context.Context
+	log hclog.Logger
 
 	runner  *docker.Runner
 	network string
@@ -45,6 +47,7 @@ func SetupResolverOnNetwork(t *testing.T, domain string, network string) *TestSe
 	ts.domains = []string{domain}
 	ts.records = map[string]map[string][]string{}
 	ts.network = network
+	ts.log = hclog.L()
 
 	ts.setupRunner(domain, network)
 	ts.startContainer(network)
@@ -62,7 +65,7 @@ func (ts *TestServer) setupRunner(domain string, network string) {
 		NetworkName:   network,
 		Ports:         []string{"53/udp"},
 		LogConsumer: func(s string) {
-			ts.t.Logf(s)
+			ts.log.Info(s)
 		},
 	})
 	require.NoError(ts.t, err)
@@ -111,7 +114,7 @@ func (ts *TestServer) startContainer(network string) {
 		ts.startup.StartResult.RealIP = mapping[network]
 	}
 
-	ts.t.Logf("[dnsserv] Addresses of DNS resolver: local=%v / container=%v", ts.GetLocalAddr(), ts.GetRemoteAddr())
+	ts.log.Info(fmt.Sprintf("[dnsserv] Addresses of DNS resolver: local=%v / container=%v", ts.GetLocalAddr(), ts.GetRemoteAddr()))
 }
 
 func (ts *TestServer) buildNamedConf() string {
@@ -181,7 +184,7 @@ func (ts *TestServer) pushNamedConf() {
 	contents[cfgPath] = docker.PathContentsFromString(namedCfg)
 	contents[cfgPath].SetOwners(0, 142) // root, bind
 
-	ts.t.Logf("Generated bind9 config (%s):\n%v\n", cfgPath, namedCfg)
+	ts.log.Info(fmt.Sprintf("Generated bind9 config (%s):\n%v\n", cfgPath, namedCfg))
 
 	err := ts.runner.CopyTo(ts.startup.Container.ID, "/", contents)
 	require.NoError(ts.t, err, "failed pushing updated named.conf.options to container")
@@ -196,7 +199,7 @@ func (ts *TestServer) pushZoneFiles() {
 		contents[path] = docker.PathContentsFromString(zoneFile)
 		contents[path].SetOwners(0, 142) // root, bind
 
-		ts.t.Logf("Generated bind9 zone file for %v (%s):\n%v\n", domain, path, zoneFile)
+		ts.log.Info(fmt.Sprintf("Generated bind9 zone file for %v (%s):\n%v\n", domain, path, zoneFile))
 	}
 
 	err := ts.runner.CopyTo(ts.startup.Container.ID, "/", contents)


### PR DESCRIPTION
 - Avoid issues with t.Logf data races if a log message is called post test completion from a background go routine.

Sample data race seen in CI

```
WARNING: DATA RACE
Read at 0x00c00054bd83 by goroutine 148:
  testing.(*common).logDepth()
      /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:992 +0xc4
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:985 +0xa4
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1036 +0x6a
  github.com/hashicorp/vault/builtin/logical/pki.TestAcmeValidateTLSALPN01Challenge.func3()
      /home/runner/work/vault/vault/builtin/logical/pki/acme_challenges_test.go:287 +0x444

Previous write at 0x00c00054bd83 by goroutine 30:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1563 +0x82d
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.20.5/x64/src/runtime/panic.go:476 +0x32
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1629 +0x47
```