### PR TITLE
LDAP Roles

### DIFF
--- a/ui/app/adapters/ldap/role.js
+++ b/ui/app/adapters/ldap/role.js
@@ -5,8 +5,11 @@
 
 import NamedPathAdapter from 'vault/adapters/named-path';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
+import { inject as service } from '@ember/service';
 
 export default class LdapRoleAdapter extends NamedPathAdapter {
+  @service flashMessages;
+
   getURL(backend, path, name) {
     const base = `${this.buildURL()}/${encodePath(backend)}/${path}`;
     return name ? `${base}/${name}` : base;
@@ -26,12 +29,39 @@ export default class LdapRoleAdapter extends NamedPathAdapter {
     return this.getURL(backend, this.pathForRoleType(type), name);
   }
 
-  query(store, type, query) {
-    const { backend, type: roleType } = query;
-    const url = this.getURL(backend, this.pathForRoleType(roleType));
-    return this.ajax(url, 'GET', { data: { list: true } }).then((resp) => {
-      return resp.data.keys.map((name) => ({ name, backend, type: roleType }));
-    });
+  async query(store, type, query) {
+    const { backend } = query;
+    const roles = [];
+    const errors = [];
+
+    for (const roleType of ['static', 'dynamic']) {
+      const url = this.getURL(backend, this.pathForRoleType(roleType));
+      try {
+        const models = await this.ajax(url, 'GET', { data: { list: true } }).then((resp) => {
+          return resp.data.keys.map((name) => ({ name, backend, type: roleType }));
+        });
+        roles.addObjects(models);
+      } catch (error) {
+        if (error.httpStatus !== 404) {
+          errors.push(error);
+        }
+      }
+    }
+
+    if (errors.length) {
+      const message = `Error fetching roles from ${errors.map((e) => e.path).join(' and ')}`;
+      const errorMessages = errors.map((e) => e.errors).flat();
+      // if only one request fails, surface the error to the user an info level flash message
+      // this may help for permissions errors where a users policy may be incorrect
+      if (errors.length === 1) {
+        this.flashMessages.info(`${message}. ${errorMessages.join(', ')}`);
+      } else {
+        // ignore status code and concat errors to be displayed in Page::Error component with generic message
+        throw { message, errors: errorMessages };
+      }
+    }
+
+    return roles.sortBy('name');
   }
   queryRecord(store, type, query) {
     const { backend, name, type: roleType } = query;

--- a/ui/app/models/ldap/config.js
+++ b/ui/app/models/ldap/config.js
@@ -25,7 +25,7 @@ export default class LdapConfigModel extends Model {
   @attr('string', {
     label: 'Administrator Distinguished Name',
     subText:
-      'Distinguished name of the adminstrator to bind (Bind DN) when performing user and group search. Example: cn=vault,ou=Users,dc=example,dc=com.',
+      'Distinguished name of the administrator to bind (Bind DN) when performing user and group search. Example: cn=vault,ou=Users,dc=example,dc=com.',
   })
   binddn;
 

--- a/ui/lib/core/addon/components/filter-input.hbs
+++ b/ui/lib/core/addon/components/filter-input.hbs
@@ -1,0 +1,12 @@
+<div class="field">
+  <p class="control has-icons-left">
+    <Input
+      class="filter input"
+      placeholder={{this.placeholder}}
+      data-test-filter-input
+      @value={{@value}}
+      {{on "input" this.onInput}}
+    />
+    <Icon @name="search" class="search-icon has-text-grey-light" />
+  </p>
+</div>

--- a/ui/lib/core/addon/components/filter-input.ts
+++ b/ui/lib/core/addon/components/filter-input.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { debounce } from '@ember/runloop';
+
+import type { HTMLElementEvent } from 'vault/forms';
+
+interface Args {
+  placeholder?: string; // defaults to Type to filter results
+  wait?: number; // defaults to 200
+  onInput(value: string): void;
+}
+
+export default class FilterInputComponent extends Component<Args> {
+  get placeholder() {
+    return this.args.placeholder || 'Type to filter results';
+  }
+
+  @action onInput(event: HTMLElementEvent<HTMLInputElement>) {
+    const callback = () => {
+      this.args.onInput(event.target.value);
+    };
+    const wait = this.args.wait || 200;
+    // ts complains when trying to pass object of optional args to callback as 3rd arg to debounce
+    debounce(this, callback, wait);
+  }
+}

--- a/ui/lib/core/app/components/filter-input.js
+++ b/ui/lib/core/app/components/filter-input.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export { default } from 'core/components/filter-input';

--- a/ui/lib/ldap/addon/components/page/roles.hbs
+++ b/ui/lib/ldap/addon/components/page/roles.hbs
@@ -1,0 +1,98 @@
+<TabPageHeader @model={{@backendModel}} @breadcrumbs={{@breadcrumbs}}>
+  <:toolbarFilters>
+    {{#if (and (not @promptConfig) @roles)}}
+      <div class="field">
+        <p class="control has-icons-left">
+          <Input class="filter input" placeholder="Filter roles" data-test-roles-filter {{on "input" this.onFilterInput}} />
+          <Icon @name="search" class="search-icon has-text-grey-light" />
+        </p>
+      </div>
+    {{/if}}
+  </:toolbarFilters>
+  <:toolbarActions>
+    {{#if @promptConfig}}
+      <ToolbarLink @route="configure" data-test-toolbar-action="config">
+        Configure LDAP
+      </ToolbarLink>
+    {{else}}
+      <ToolbarLink @route="roles.create" @type="add" data-test-toolbar-action="role">
+        Create role
+      </ToolbarLink>
+    {{/if}}
+  </:toolbarActions>
+</TabPageHeader>
+
+{{#if @promptConfig}}
+  <ConfigCta />
+{{else if (not this.filteredRoles)}}
+  {{#if this.filterValue}}
+    <EmptyState @title="There are no roles matching &quot;{{this.filterValue}}&quot;" />
+  {{else}}
+    <EmptyState
+      data-test-config-cta
+      @title="No roles created yet"
+      @message="Roles in Vault will allow you to manage LDAP credentials. Create a role to get started."
+    >
+      <LinkTo class="has-top-margin-xs" @route="roles.create">
+        Create role
+      </LinkTo>
+    </EmptyState>
+  {{/if}}
+{{else}}
+  <div class="has-bottom-margin-s">
+    {{#each this.filteredRoles as |role|}}
+      <ListItem @linkPrefix={{this.mountPoint}} @linkParams={{array "roles.role.details" role.type role.name}} as |Item|>
+        <Item.content>
+          <Icon @name="user" />
+          <span data-test-role={{role.name}}>{{role.name}}</span>
+          <Hds::Badge @text={{role.type}} data-test-role-type-badge={{role.name}} />
+        </Item.content>
+        <Item.menu as |Menu|>
+          {{#if role.rolePath.isLoading}}
+            <li class="action">
+              <button disabled type="button" class="link button is-loading is-transparent">
+                loading
+              </button>
+            </li>
+          {{else}}
+            <li class="action">
+              <LinkTo
+                class="has-text-black has-text-weight-semibold"
+                data-test-details
+                @route="roles.role.details"
+                {{! this will force the roles.role model hook to fire since we may only have a partial model loaded in the list view }}
+                @models={{array role.type role.name}}
+                @disabled={{not role.canRead}}
+              >
+                Details
+              </LinkTo>
+            </li>
+            <li class="action">
+              <LinkTo
+                class="has-text-black has-text-weight-semibold"
+                data-test-edit
+                @route="roles.role.edit"
+                @models={{array role.type role.name}}
+                @disabled={{not role.canEdit}}
+              >
+                Edit
+              </LinkTo>
+            </li>
+            {{#if role.canDelete}}
+              <li class="action">
+                <Menu.Message
+                  data-test-delete
+                  @id={{role.id}}
+                  @triggerText="Delete"
+                  @title="Are you sure?"
+                  @message="Deleting this role means that you’ll need to recreate it in order to generate credentials again."
+                  @onConfirm={{fn this.onDelete role}}
+                />
+              </li>
+            {{/if}}
+          {{/if}}
+        </Item.menu>
+      </ListItem>
+    {{/each}}
+  </div>
+{{/if}}

--- a/ui/lib/ldap/addon/components/page/roles.hbs
+++ b/ui/lib/ldap/addon/components/page/roles.hbs
@@ -1,12 +1,7 @@
 <TabPageHeader @model={{@backendModel}} @breadcrumbs={{@breadcrumbs}}>
   <:toolbarFilters>
     {{#if (and (not @promptConfig) @roles)}}
-      <div class="field">
-        <p class="control has-icons-left">
-          <Input class="filter input" placeholder="Filter roles" data-test-roles-filter {{on "input" this.onFilterInput}} />
-          <Icon @name="search" class="search-icon has-text-grey-light" />
-        </p>
-      </div>
+      <FilterInput @placeholder="Filter roles" @onInput={{fn (mut this.filterValue)}} />
     {{/if}}
   </:toolbarFilters>
   <:toolbarActions>

--- a/ui/lib/ldap/addon/components/page/roles.ts
+++ b/ui/lib/ldap/addon/components/page/roles.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { getOwner } from '@ember/application';
+import { debounce } from '@ember/runloop';
+import errorMessage from 'vault/utils/error-message';
+
+import type LdapRoleModel from 'vault/models/ldap/role';
+import type SecretEngineModel from 'vault/models/secret-engine';
+import type FlashMessageService from 'vault/services/flash-messages';
+import type { Breadcrumb, EngineOwner } from 'vault/vault/app-types';
+import type { HTMLElementEvent } from 'vault/forms';
+
+interface Args {
+  roles: Array<LdapRoleModel>;
+  promptConfig: boolean;
+  backendModel: SecretEngineModel;
+  filterValue: string;
+  breadcrumbs: Array<Breadcrumb>;
+}
+
+export default class LdapRolesPageComponent extends Component<Args> {
+  @service declare readonly flashMessages: FlashMessageService;
+
+  @tracked filterValue = '';
+
+  get mountPoint(): string {
+    const owner = getOwner(this) as EngineOwner;
+    return owner.mountPoint;
+  }
+
+  get filteredRoles() {
+    const { roles } = this.args;
+    return this.filterValue
+      ? roles.filter((role) => role.name.toLowerCase().includes(this.filterValue.toLowerCase()))
+      : roles;
+  }
+
+  @action onFilterInput(event: HTMLElementEvent<HTMLInputElement>) {
+    const setFilter = () => {
+      this.filterValue = event.target.value;
+    };
+    debounce(this, setFilter, 200);
+  }
+
+  @action
+  async onDelete(model: LdapRoleModel) {
+    try {
+      const message = `Successfully deleted role ${model.name}.`;
+      await model.destroyRecord();
+      this.args.roles.removeObject(model);
+      this.flashMessages.success(message);
+    } catch (error) {
+      const message = errorMessage(error, 'Error deleting role. Please try again or contact support.');
+      this.flashMessages.danger(message);
+    }
+  }
+}

--- a/ui/lib/ldap/addon/components/page/roles.ts
+++ b/ui/lib/ldap/addon/components/page/roles.ts
@@ -8,14 +8,12 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { getOwner } from '@ember/application';
-import { debounce } from '@ember/runloop';
 import errorMessage from 'vault/utils/error-message';
 
 import type LdapRoleModel from 'vault/models/ldap/role';
 import type SecretEngineModel from 'vault/models/secret-engine';
 import type FlashMessageService from 'vault/services/flash-messages';
 import type { Breadcrumb, EngineOwner } from 'vault/vault/app-types';
-import type { HTMLElementEvent } from 'vault/forms';
 
 interface Args {
   roles: Array<LdapRoleModel>;
@@ -40,13 +38,6 @@ export default class LdapRolesPageComponent extends Component<Args> {
     return this.filterValue
       ? roles.filter((role) => role.name.toLowerCase().includes(this.filterValue.toLowerCase()))
       : roles;
-  }
-
-  @action onFilterInput(event: HTMLElementEvent<HTMLInputElement>) {
-    const setFilter = () => {
-      this.filterValue = event.target.value;
-    };
-    debounce(this, setFilter, 200);
   }
 
   @action

--- a/ui/lib/ldap/addon/routes/error.ts
+++ b/ui/lib/ldap/addon/routes/error.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+import type Transition from '@ember/routing/transition';
+import type AdapterError from 'ember-data/adapter'; // eslint-disable-line ember/use-ember-data-rfc-395-imports
+import type SecretEngineModel from 'vault/models/secret-engine';
+import type { Breadcrumb } from 'vault/vault/app-types';
+import type Controller from '@ember/controller';
+import type SecretMountPath from 'vault/services/secret-mount-path';
+
+interface LdapErrorController extends Controller {
+  breadcrumbs: Array<Breadcrumb>;
+  backend: SecretEngineModel;
+}
+
+export default class LdapErrorRoute extends Route {
+  @service declare readonly secretMountPath: SecretMountPath;
+
+  setupController(controller: LdapErrorController, resolvedModel: AdapterError, transition: Transition) {
+    super.setupController(controller, resolvedModel, transition);
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: this.secretMountPath.currentPath, route: 'overview' },
+    ];
+    controller.backend = this.modelFor('application') as SecretEngineModel;
+  }
+}

--- a/ui/lib/ldap/addon/routes/roles/index.ts
+++ b/ui/lib/ldap/addon/routes/roles/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
+import { hash } from 'rsvp';
+
+import type Store from '@ember-data/store';
+import type SecretMountPath from 'vault/services/secret-mount-path';
+import type Transition from '@ember/routing/transition';
+import type LdapRoleModel from 'vault/models/ldap/role';
+import type SecretEngineModel from 'vault/models/secret-engine';
+import type Controller from '@ember/controller';
+import type { Breadcrumb } from 'vault/vault/app-types';
+
+interface LdapRolesRouteModel {
+  backendModel: SecretEngineModel;
+  promptConfig: boolean;
+  roles: Array<LdapRoleModel>;
+}
+interface LdapConfigurationController extends Controller {
+  breadcrumbs: Array<Breadcrumb>;
+  model: LdapRolesRouteModel;
+}
+
+@withConfig('ldap/config')
+export default class LdapConfigurationRoute extends Route {
+  @service declare readonly store: Store;
+  @service declare readonly secretMountPath: SecretMountPath;
+
+  declare promptConfig: boolean;
+
+  async model() {
+    const backendModel = this.modelFor('application') as SecretEngineModel;
+    return hash({
+      backendModel,
+      promptConfig: this.promptConfig,
+      roles: this.store.query('ldap/role', { backend: backendModel.id }),
+    });
+  }
+
+  setupController(
+    controller: LdapConfigurationController,
+    resolvedModel: LdapRolesRouteModel,
+    transition: Transition
+  ) {
+    super.setupController(controller, resolvedModel, transition);
+
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: resolvedModel.backendModel.id },
+    ];
+  }
+}

--- a/ui/lib/ldap/addon/routes/roles/index.ts
+++ b/ui/lib/ldap/addon/routes/roles/index.ts
@@ -38,7 +38,11 @@ export default class LdapConfigurationRoute extends Route {
     return hash({
       backendModel,
       promptConfig: this.promptConfig,
-      roles: this.store.query('ldap/role', { backend: backendModel.id }),
+      roles: this.store.query(
+        'ldap/role',
+        { backend: backendModel.id },
+        { adapterOptions: { partialErrorInfo: true } }
+      ),
     });
   }
 

--- a/ui/lib/ldap/addon/routes/roles/index.ts
+++ b/ui/lib/ldap/addon/routes/roles/index.ts
@@ -41,7 +41,7 @@ export default class LdapConfigurationRoute extends Route {
       roles: this.store.query(
         'ldap/role',
         { backend: backendModel.id },
-        { adapterOptions: { partialErrorInfo: true } }
+        { adapterOptions: { showPartialError: true } }
       ),
     });
   }

--- a/ui/lib/ldap/addon/routes/roles/role.ts
+++ b/ui/lib/ldap/addon/routes/roles/role.ts
@@ -14,7 +14,7 @@ interface LdapRoleRouteParams {
   type: string;
 }
 
-export default class LdapRoleEditRoute extends Route {
+export default class LdapRoleRoute extends Route {
   @service declare readonly store: Store;
   @service declare readonly secretMountPath: SecretMountPath;
 

--- a/ui/lib/ldap/addon/templates/error.hbs
+++ b/ui/lib/ldap/addon/templates/error.hbs
@@ -1,0 +1,3 @@
+<TabPageHeader @model={{this.backend}} @breadcrumbs={{this.breadcrumbs}} />
+
+<Page::Error @error={{this.model}} />

--- a/ui/lib/ldap/addon/templates/roles/index.hbs
+++ b/ui/lib/ldap/addon/templates/roles/index.hbs
@@ -1,0 +1,6 @@
+<Page::Roles
+  @roles={{this.model.roles}}
+  @promptConfig={{this.model.promptConfig}}
+  @backendModel={{this.model.backendModel}}
+  @breadcrumbs={{this.breadcrumbs}}
+/>

--- a/ui/tests/integration/components/filter-input-test.js
+++ b/ui/tests/integration/components/filter-input-test.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, fillIn } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | filter-input', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should render placeholder and send input event', async function (assert) {
+    assert.expect(2);
+
+    this.onInput = (value) => {
+      assert.strictEqual(value, 'foo', 'onInput event sent with value');
+    };
+
+    await render(hbs`<FilterInput @placeholder="Filter roles" @onInput={{this.onInput}} />`);
+
+    assert
+      .dom('[data-test-filter-input]')
+      .hasAttribute('placeholder', 'Filter roles', 'Placeholder set on input element');
+
+    await fillIn('[data-test-filter-input]', 'foo');
+  });
+});

--- a/ui/tests/integration/components/ldap/page/roles-test.js
+++ b/ui/tests/integration/components/ldap/page/roles-test.js
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupEngine } from 'ember-engines/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { render, click, fillIn } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
+
+module('Integration | Component | ldap | Page::Roles', function (hooks) {
+  setupRenderingTest(hooks);
+  setupEngine(hooks, 'ldap');
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub());
+
+    this.store = this.owner.lookup('service:store');
+    this.store.pushPayload('secret-engine', {
+      modelName: 'secret-engine',
+      data: {
+        accessor: 'ldap_f3400dee',
+        path: 'ldap-test/',
+        type: 'ldap',
+      },
+    });
+    for (const type of ['static', 'dynamic']) {
+      this.store.pushPayload('ldap/role', {
+        modelName: 'ldap/role',
+        backend: 'ldap-test',
+        type,
+        ...this.server.create('ldap-role', type, { name: `${type}-test` }),
+      });
+    }
+    this.backend = this.store.peekRecord('secret-engine', 'ldap-test');
+    this.roles = this.store.peekAll('ldap/role');
+    this.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: this.backend.id },
+    ];
+    this.promptConfig = false;
+
+    this.renderComponent = () => {
+      return render(
+        hbs`<Page::Roles @promptConfig={{this.promptConfig}} @backendModel={{this.backend}} @roles={{this.roles}} @breadcrumbs={{this.breadcrumbs}} />`,
+        { owner: this.engine }
+      );
+    };
+  });
+
+  test('it should render tab page header and config cta', async function (assert) {
+    this.promptConfig = true;
+
+    await this.renderComponent();
+
+    assert.dom('.title svg').hasClass('flight-icon-folder-users', 'LDAP icon renders in title');
+    assert.dom('.title').hasText('ldap-test', 'Mount path renders in title');
+    assert
+      .dom('[data-test-toolbar-action="config"]')
+      .hasText('Configure LDAP', 'Correct toolbar action renders');
+    assert.dom('[data-test-config-cta]').exists('Config cta renders');
+  });
+
+  test('it should render create roles cta', async function (assert) {
+    this.roles = null;
+
+    await this.renderComponent();
+
+    assert.dom('[data-test-toolbar-action="role"]').hasText('Create role', 'Toolbar action has correct text');
+    assert
+      .dom('[data-test-toolbar-action="role"] svg')
+      .hasClass('flight-icon-plus', 'Toolbar action has correct icon');
+    assert
+      .dom('[data-test-roles-filter]')
+      .doesNotExist('Roles filter input is hidden when roles have not been created');
+    assert.dom('[data-test-empty-state-title]').hasText('No roles created yet', 'Title renders');
+    assert
+      .dom('[data-test-empty-state-message]')
+      .hasText(
+        'Roles in Vault will allow you to manage LDAP credentials. Create a role to get started.',
+        'Message renders'
+      );
+    assert.dom('[data-test-empty-state-actions] a').hasText('Create role', 'Action renders');
+  });
+
+  test('it should render roles list', async function (assert) {
+    await this.renderComponent();
+
+    assert.dom('[data-test-list-item-content] svg').hasClass('flight-icon-user', 'List item icon renders');
+    assert
+      .dom('[data-test-role="static-test"]')
+      .hasText(this.roles.firstObject.name, 'List item name renders');
+    assert
+      .dom('[data-test-role-type-badge="static-test"]')
+      .hasText(this.roles.firstObject.type, 'List item type badge renders');
+
+    await click('[data-test-popup-menu-trigger]');
+    assert.dom('[data-test-details]').hasText('Details', 'Details link renders in menu');
+    assert.dom('[data-test-edit]').hasText('Edit', 'Edit link renders in menu');
+    assert.dom('[data-test-delete]').hasText('Delete', 'Details link renders in menu');
+  });
+
+  test('it should filter roles', async function (assert) {
+    await this.renderComponent();
+
+    await fillIn('[data-test-roles-filter]', 'foo');
+    assert
+      .dom('[data-test-empty-state-title]')
+      .hasText('There are no roles matching "foo"', 'Filter message renders');
+
+    await fillIn('[data-test-roles-filter]', 'static');
+    assert.dom('[data-test-list-item-content]').exists({ count: 1 }, 'List is filtered with correct results');
+
+    await fillIn('[data-test-roles-filter]', '');
+    assert
+      .dom('[data-test-list-item-content]')
+      .exists({ count: 2 }, 'All roles are displayed when filter is cleared');
+  });
+});

--- a/ui/tests/integration/components/ldap/page/roles-test.js
+++ b/ui/tests/integration/components/ldap/page/roles-test.js
@@ -75,7 +75,7 @@ module('Integration | Component | ldap | Page::Roles', function (hooks) {
       .dom('[data-test-toolbar-action="role"] svg')
       .hasClass('flight-icon-plus', 'Toolbar action has correct icon');
     assert
-      .dom('[data-test-roles-filter]')
+      .dom('[data-test-filter-input]')
       .doesNotExist('Roles filter input is hidden when roles have not been created');
     assert.dom('[data-test-empty-state-title]').hasText('No roles created yet', 'Title renders');
     assert
@@ -107,15 +107,15 @@ module('Integration | Component | ldap | Page::Roles', function (hooks) {
   test('it should filter roles', async function (assert) {
     await this.renderComponent();
 
-    await fillIn('[data-test-roles-filter]', 'foo');
+    await fillIn('[data-test-filter-input]', 'foo');
     assert
       .dom('[data-test-empty-state-title]')
       .hasText('There are no roles matching "foo"', 'Filter message renders');
 
-    await fillIn('[data-test-roles-filter]', 'static');
+    await fillIn('[data-test-filter-input]', 'static');
     assert.dom('[data-test-list-item-content]').exists({ count: 1 }, 'List is filtered with correct results');
 
-    await fillIn('[data-test-roles-filter]', '');
+    await fillIn('[data-test-filter-input]', '');
     assert
       .dom('[data-test-list-item-content]')
       .exists({ count: 2 }, 'All roles are displayed when filter is cleared');

--- a/ui/tests/unit/adapters/ldap/role-test.js
+++ b/ui/tests/unit/adapters/ldap/role-test.js
@@ -6,6 +6,8 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { Response } from 'miragejs';
+import sinon from 'sinon';
 
 module('Unit | Adapter | ldap/role', function (hooks) {
   setupTest(hooks);
@@ -18,27 +20,72 @@ module('Unit | Adapter | ldap/role', function (hooks) {
   });
 
   test('it should make request to correct endpoints when listing records', async function (assert) {
-    assert.expect(7);
+    assert.expect(6);
 
-    this.server.get('/ldap-test/:path', (schema, req) => {
+    const assertRequest = (schema, req) => {
       assert.ok(req.queryParams.list, 'list query param sent when listing roles');
-      assert.strictEqual(
-        req.params.path,
-        this.path,
-        'GET request made to correct endpoint when listing roles'
-      );
-      return { data: { keys: ['test-role'] } };
-    });
+      const name = req.params.path === 'static-role' ? 'static-test' : 'dynamic-test';
+      return { data: { keys: [name] } };
+    };
 
-    for (const type of ['dynamic', 'static']) {
-      this.models = await this.store.query('ldap/role', { backend: 'ldap-test', type });
-      this.path = 'static-role';
-    }
+    this.server.get('/ldap-test/static-role', assertRequest);
+    this.server.get('/ldap-test/role', assertRequest);
+
+    this.models = await this.store.query('ldap/role', { backend: 'ldap-test' });
 
     const model = this.models.firstObject;
+    assert.strictEqual(this.models.length, 2, 'Returns responses from both endpoints');
     assert.strictEqual(model.backend, 'ldap-test', 'Backend value is set on records returned from query');
-    assert.strictEqual(model.type, 'static', 'Type value is set on records returned from query');
-    assert.strictEqual(model.name, 'test-role', 'Name value is set on records returned from query');
+    // sorted alphabetically by name so dynamic should be first
+    assert.strictEqual(model.type, 'dynamic', 'Type value is set on records returned from query');
+    assert.strictEqual(model.name, 'dynamic-test', 'Name value is set on records returned from query');
+  });
+
+  test('it should conditionally trigger info level flash message for single endpoint error from query', async function (assert) {
+    const flashMessages = this.owner.lookup('service:flashMessages');
+    const flashSpy = sinon.spy(flashMessages, 'info');
+
+    this.server.get('/ldap-test/static-role', () => {
+      return new Response(403, {}, { errors: ['permission denied'] });
+    });
+    this.server.get('/ldap-test/role', () => ({ data: { keys: ['dynamic-test'] } }));
+
+    await this.store.query('ldap/role', { backend: 'ldap-test' });
+    await this.store.query(
+      'ldap/role',
+      { backend: 'ldap-test' },
+      { adapterOptions: { partialErrorInfo: true } }
+    );
+
+    assert.true(
+      flashSpy.calledOnceWith('Error fetching roles from /v1/ldap-test/static-role. permission denied'),
+      'Partial error info only displays when adapter option is passed'
+    );
+  });
+
+  test('it should throw error for query when requests to both endpoints fail', async function (assert) {
+    assert.expect(1);
+
+    this.server.get('/ldap-test/:path', (schema, req) => {
+      const errors = {
+        'static-role': ['permission denied'],
+        role: ['server error'],
+      }[req.params.path];
+      return new Response(req.params.path === 'static-role' ? 403 : 500, {}, { errors });
+    });
+
+    try {
+      await this.store.query('ldap/role', { backend: 'ldap-test' });
+    } catch (error) {
+      assert.deepEqual(
+        error,
+        {
+          message: 'Error fetching roles from /v1/ldap-test/static-role and /v1/ldap-test/role',
+          errors: ['permission denied', 'server error'],
+        },
+        'Error is thrown with correct payload from query'
+      );
+    }
   });
 
   test('it should make request to correct endpoints when querying record', async function (assert) {

--- a/ui/tests/unit/adapters/ldap/role-test.js
+++ b/ui/tests/unit/adapters/ldap/role-test.js
@@ -58,7 +58,7 @@ module('Unit | Adapter | ldap/role', function (hooks) {
     );
 
     assert.true(
-      flashSpy.calledOnceWith('Error fetching roles from /v1/ldap-test/static-role. permission denied'),
+      flashSpy.calledOnceWith('Error fetching roles from /v1/ldap-test/static-role: permission denied'),
       'Partial error info only displays when adapter option is passed'
     );
   });
@@ -80,8 +80,8 @@ module('Unit | Adapter | ldap/role', function (hooks) {
       assert.deepEqual(
         error,
         {
-          message: 'Error fetching roles from /v1/ldap-test/static-role and /v1/ldap-test/role',
-          errors: ['permission denied', 'server error'],
+          message: 'Error fetching roles:',
+          errors: ['/v1/ldap-test/static-role: permission denied', '/v1/ldap-test/role: server error'],
         },
         'Error is thrown with correct payload from query'
       );

--- a/ui/tests/unit/adapters/ldap/role-test.js
+++ b/ui/tests/unit/adapters/ldap/role-test.js
@@ -54,7 +54,7 @@ module('Unit | Adapter | ldap/role', function (hooks) {
     await this.store.query(
       'ldap/role',
       { backend: 'ldap-test' },
-      { adapterOptions: { partialErrorInfo: true } }
+      { adapterOptions: { showPartialError: true } }
     );
 
     assert.true(

--- a/ui/types/vault/app-types.ts
+++ b/ui/types/vault/app-types.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 import type EmberDataModel from '@ember-data/model';
+import type Owner from '@ember/owner';
 
 // Type that comes back from expandAttributeMeta
 export interface FormField {
@@ -76,6 +77,10 @@ export interface Breadcrumb {
   label: string;
   route?: string;
   linkExternal?: boolean;
+}
+
+export interface EngineOwner extends Owner {
+  mountPoint: string;
 }
 
 // Generic interfaces


### PR DESCRIPTION
This PR adds a route for ldap roles as well as a page component and an error route for the ldap engine. Additional error handling was added in the adapter since roles are fetched from different endpoints depending on type (static or dynamic). The partial error info (when only one request fails) can be conditionally enabled through the adapter options. Since the roles card component on the overview route only shows the total number of roles created it was deemed by design that surfacing the partial error is less helpful in that scenario.  

![image](https://github.com/hashicorp/vault/assets/24611656/7bdbb8f6-7470-42e2-987e-72555191c44a)

_error handling when request to one of the roles endpoint fails_
![image](https://github.com/hashicorp/vault/assets/24611656/6effc760-e023-4b0a-851d-5d9bc9b991cb)

_error handling when both requests fail_
![image](https://github.com/hashicorp/vault/assets/24611656/b0299a2a-adb9-4e39-b03a-b0e468e05a14)
