### PR TITLE
Be more clear about bolt write timing

### DIFF
--- a/website/content/partials/telemetry-metrics/vault/raft_storage/bolt/write/time.mdx
+++ b/website/content/partials/telemetry-metrics/vault/raft_storage/bolt/write/time.mdx
@@ -2,4 +2,4 @@
 
 Metric type | Value | Description
 ----------- | ----- | -----------
-summary     | ms    | Time required for the Bolt database to write to disk
+summary     | ms    | Total time the Bolt database has spent writing to disk


### PR DESCRIPTION
The way it was written before made it sound like this is the amount of time it takes Bolt to write to disk _for each write_ when it's actually a cumulative total (not sure why that's useful, but at least let's make it less misleading).