### PR TITLE
Add generate_lease field to CIEPS response

### DIFF
--- a/sdk/helper/certutil/cieps.go
+++ b/sdk/helper/certutil/cieps.go
@@ -141,6 +141,7 @@ type CIEPSResponse struct {
 	ParsedCertificate *x509.Certificate `json:"-"`
 	IssuerRef         string            `json:"issuer_ref,omitempty"`
 	StoreCert         bool              `json:"store_certificate"`
+	GenerateLease     bool              `json:"generate_lease"`
 }
 
 func (c *CIEPSResponse) MarshalCertificate() error {


### PR DESCRIPTION
Add the new field to the OSS CIEPS response object to allow lease generation to be supported by sign/issue CIEPS API endpoints.