### PR TITLE
tools/stubmaker: fix dropped error

### DIFF
--- a/tools/stubmaker/main.go
+++ b/tools/stubmaker/main.go
@@ -62,6 +62,9 @@ func main() {
 	}
 
 	inputLines, err := readLines(bytes.NewBuffer(b))
+	if err != nil {
+		fatal(err)
+	}
 	funcs := getFuncs(inputLines)
 	if needed, err := isStubNeeded(funcs); err != nil {
 		fatal(err)


### PR DESCRIPTION
This fixes a dropped `err` variable in `tools/stubmaker`.