### PR TITLE
Moved HeaderFormatter to an Option for NewEntryFormatter, updated tests

### DIFF
--- a/audit/entry_formatter.go
+++ b/audit/entry_formatter.go
@@ -30,7 +30,7 @@ var (
 
 // NewEntryFormatter should be used to create an EntryFormatter.
 // Accepted options: WithPrefix.
-func NewEntryFormatter(config FormatterConfig, salter Salter, headersConfig HeaderFormatter, opt ...Option) (*EntryFormatter, error) {
+func NewEntryFormatter(config FormatterConfig, salter Salter, opt ...Option) (*EntryFormatter, error) {
 	const op = "audit.NewEntryFormatter"
 
 	if salter == nil {
@@ -48,10 +48,10 @@ func NewEntryFormatter(config FormatterConfig, salter Salter, headersConfig Head
 	}
 
 	return &EntryFormatter{
-		salter:        salter,
-		config:        config,
-		headersConfig: headersConfig,
-		prefix:        opts.withPrefix,
+		salter:          salter,
+		config:          config,
+		headerFormatter: opts.withHeaderFormatter,
+		prefix:          opts.withPrefix,
 	}, nil
 }
 

--- a/audit/entry_formatter_test.go
+++ b/audit/entry_formatter_test.go
@@ -127,7 +127,7 @@ func TestNewEntryFormatter(t *testing.T) {
 
 			cfg, err := NewFormatterConfig(tc.Options...)
 			require.NoError(t, err)
-			f, err := NewEntryFormatter(cfg, ss, nil, tc.Options...)
+			f, err := NewEntryFormatter(cfg, ss, tc.Options...)
 
 			switch {
 			case tc.IsErrorExpected:
@@ -150,7 +150,7 @@ func TestEntryFormatter_Reopen(t *testing.T) {
 	cfg, err := NewFormatterConfig()
 	require.NoError(t, err)
 
-	f, err := NewEntryFormatter(cfg, ss, nil)
+	f, err := NewEntryFormatter(cfg, ss)
 	require.NoError(t, err)
 	require.NotNil(t, f)
 	require.NoError(t, f.Reopen())
@@ -162,7 +162,7 @@ func TestEntryFormatter_Type(t *testing.T) {
 	cfg, err := NewFormatterConfig()
 	require.NoError(t, err)
 
-	f, err := NewEntryFormatter(cfg, ss, nil)
+	f, err := NewEntryFormatter(cfg, ss)
 	require.NoError(t, err)
 	require.NotNil(t, f)
 	require.Equal(t, eventlogger.NodeTypeFormatter, f.Type())
@@ -305,7 +305,7 @@ func TestEntryFormatter_Process(t *testing.T) {
 			cfg, err := NewFormatterConfig(WithFormat(tc.RequiredFormat.String()))
 			require.NoError(t, err)
 
-			f, err := NewEntryFormatter(cfg, ss, nil)
+			f, err := NewEntryFormatter(cfg, ss)
 			require.NoError(t, err)
 			require.NotNil(t, f)
 
@@ -372,7 +372,7 @@ func BenchmarkAuditFileSink_Process(b *testing.B) {
 	cfg, err := NewFormatterConfig()
 	require.NoError(b, err)
 	ss := newStaticSalt(b)
-	formatter, err := NewEntryFormatter(cfg, ss, nil)
+	formatter, err := NewEntryFormatter(cfg, ss)
 	require.NoError(b, err)
 	require.NotNil(b, formatter)
 

--- a/audit/entry_formatter_writer.go
+++ b/audit/entry_formatter_writer.go
@@ -96,7 +96,7 @@ func NewTemporaryFormatter(requiredFormat, prefix string) (*EntryFormatterWriter
 		return nil, err
 	}
 
-	eventFormatter, err := NewEntryFormatter(cfg, &nonPersistentSalt{}, nil, WithPrefix(prefix))
+	eventFormatter, err := NewEntryFormatter(cfg, &nonPersistentSalt{}, WithPrefix(prefix))
 	if err != nil {
 		return nil, err
 	}

--- a/audit/entry_formatter_writer_test.go
+++ b/audit/entry_formatter_writer_test.go
@@ -127,7 +127,7 @@ func TestNewEntryFormatterWriter(t *testing.T) {
 
 			var f Formatter
 			if !tc.UseNilFormatter {
-				tempFormatter, err := NewEntryFormatter(cfg, s, nil)
+				tempFormatter, err := NewEntryFormatter(cfg, s)
 				require.NoError(t, err)
 				require.NotNil(t, tempFormatter)
 				f = tempFormatter
@@ -192,7 +192,7 @@ func TestEntryFormatter_FormatRequest(t *testing.T) {
 			ss := newStaticSalt(t)
 			cfg, err := NewFormatterConfig()
 			require.NoError(t, err)
-			f, err := NewEntryFormatter(cfg, ss, nil)
+			f, err := NewEntryFormatter(cfg, ss)
 			require.NoError(t, err)
 
 			var ctx context.Context
@@ -259,7 +259,7 @@ func TestEntryFormatter_FormatResponse(t *testing.T) {
 			ss := newStaticSalt(t)
 			cfg, err := NewFormatterConfig()
 			require.NoError(t, err)
-			f, err := NewEntryFormatter(cfg, ss, nil)
+			f, err := NewEntryFormatter(cfg, ss)
 			require.NoError(t, err)
 
 			var ctx context.Context
@@ -361,7 +361,7 @@ func TestElideListResponses(t *testing.T) {
 
 	formatResponse := func(t *testing.T, config FormatterConfig, operation logical.Operation, inputData map[string]interface{},
 	) {
-		f, err := NewEntryFormatter(config, &tfw, nil)
+		f, err := NewEntryFormatter(config, &tfw)
 		require.NoError(t, err)
 		formatter, err := NewEntryFormatterWriter(config, f, &tfw)
 		require.NoError(t, err)

--- a/audit/options.go
+++ b/audit/options.go
@@ -148,3 +148,11 @@ func WithHMACAccessor(h bool) Option {
 		return nil
 	}
 }
+
+// WithHeaderFormatter provides an Option to supply a HeaderFormatter.
+func WithHeaderFormatter(f HeaderFormatter) Option {
+	return func(o *options) error {
+		o.withHeaderFormatter = f
+		return nil
+	}
+}

--- a/audit/types.go
+++ b/audit/types.go
@@ -50,15 +50,16 @@ type Option func(*options) error
 
 // options are used to represent configuration for a audit related nodes.
 type options struct {
-	withID           string
-	withNow          time.Time
-	withSubtype      subtype
-	withFormat       format
-	withPrefix       string
-	withRaw          bool
-	withElision      bool
-	withOmitTime     bool
-	withHMACAccessor bool
+	withID              string
+	withNow             time.Time
+	withSubtype         subtype
+	withFormat          format
+	withPrefix          string
+	withRaw             bool
+	withElision         bool
+	withOmitTime        bool
+	withHMACAccessor    bool
+	withHeaderFormatter HeaderFormatter
 }
 
 // Salter is an interface that provides a way to obtain a Salt for hashing.
@@ -96,10 +97,10 @@ type HeaderFormatter interface {
 
 // EntryFormatter should be used to format audit requests and responses.
 type EntryFormatter struct {
-	salter        Salter
-	headersConfig HeaderFormatter
-	config        FormatterConfig
-	prefix        string
+	salter          Salter
+	headerFormatter HeaderFormatter
+	config          FormatterConfig
+	prefix          string
 }
 
 // EntryFormatterWriter should be used to format and write out audit requests and responses.

--- a/audit/writer_json_test.go
+++ b/audit/writer_json_test.go
@@ -100,7 +100,7 @@ func TestFormatJSON_formatRequest(t *testing.T) {
 		var buf bytes.Buffer
 		cfg, err := NewFormatterConfig()
 		require.NoError(t, err)
-		f, err := NewEntryFormatter(cfg, ss, nil)
+		f, err := NewEntryFormatter(cfg, ss)
 		require.NoError(t, err)
 		formatter := EntryFormatterWriter{
 			Formatter: f,

--- a/audit/writer_jsonx_test.go
+++ b/audit/writer_jsonx_test.go
@@ -119,7 +119,7 @@ func TestFormatJSONx_formatRequest(t *testing.T) {
 			WithFormat(JSONxFormat.String()),
 		)
 		require.NoError(t, err)
-		f, err := NewEntryFormatter(cfg, tempStaticSalt, nil)
+		f, err := NewEntryFormatter(cfg, tempStaticSalt)
 		require.NoError(t, err)
 		writer := &JSONxWriter{Prefix: tc.Prefix}
 		formatter, err := NewEntryFormatterWriter(cfg, f, writer)

--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -131,7 +131,7 @@ func Factory(ctx context.Context, conf *audit.BackendConfig, useEventLogger bool
 	b.salt.Store((*salt.Salt)(nil))
 
 	// Configure the formatter for either case.
-	f, err := audit.NewEntryFormatter(b.formatConfig, b, headersConfig, audit.WithPrefix(conf.Config["prefix"]))
+	f, err := audit.NewEntryFormatter(b.formatConfig, b, audit.WithHeaderFormatter(headersConfig), audit.WithPrefix(conf.Config["prefix"]))
 	if err != nil {
 		return nil, fmt.Errorf("error creating formatter: %w", err)
 	}

--- a/builtin/audit/socket/backend.go
+++ b/builtin/audit/socket/backend.go
@@ -108,7 +108,7 @@ func Factory(ctx context.Context, conf *audit.BackendConfig, useEventLogger bool
 	}
 
 	// Configure the formatter for either case.
-	f, err := audit.NewEntryFormatter(b.formatConfig, b, headersConfig)
+	f, err := audit.NewEntryFormatter(b.formatConfig, b, audit.WithHeaderFormatter(headersConfig))
 	if err != nil {
 		return nil, fmt.Errorf("error creating formatter: %w", err)
 	}

--- a/builtin/audit/syslog/backend.go
+++ b/builtin/audit/syslog/backend.go
@@ -102,7 +102,7 @@ func Factory(ctx context.Context, conf *audit.BackendConfig, useEventLogger bool
 	}
 
 	// Configure the formatter for either case.
-	f, err := audit.NewEntryFormatter(b.formatConfig, b, headersConfig, audit.WithPrefix(conf.Config["prefix"]))
+	f, err := audit.NewEntryFormatter(b.formatConfig, b, audit.WithHeaderFormatter(headersConfig), audit.WithPrefix(conf.Config["prefix"]))
 	if err != nil {
 		return nil, fmt.Errorf("error creating formatter: %w", err)
 	}

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -252,7 +252,7 @@ func NewNoopAudit(config map[string]string) (*NoopAudit, error) {
 		return nil, err
 	}
 
-	f, err := audit.NewEntryFormatter(cfg, n, nil)
+	f, err := audit.NewEntryFormatter(cfg, n)
 	if err != nil {
 		return nil, fmt.Errorf("error creating formatter: %w", err)
 	}


### PR DESCRIPTION
A bit of clean up as the parameter isn't always required, so moving to an option (reduces `nil` in a lot of tests)