### PR TITLE
Correct doctype

### DIFF
--- a/ui/app/index.html
+++ b/ui/app/index.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html lang="en">
+<!DOCTYPE html>
 <!--
  Copyright (c) HashiCorp, Inc.
  SPDX-License-Identifier: MPL-2.0
 -->
 
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="cache-control" content="no-store" />


### PR DESCRIPTION
This is not a valid doctype, the 'lang' belongs to the html element.