### PR TITLE
docs: Update outdated `vaultproject.io/docs/` links

### DIFF
--- a/.github/ISSUE_TEMPLATE/plugin-submission.md
+++ b/.github/ISSUE_TEMPLATE/plugin-submission.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Please provide details for the plugin to be listed. All fields are required for a submission to be included in the [Plugin Portal](https://www.vaultproject.io/docs/plugin-portal) page.
+Please provide details for the plugin to be listed. All fields are required for a submission to be included in the [Vault Integrations](https://developer.hashicorp.com/vault/integrations) page.
 
 **Plugin Information**
 Name as it would appear listed:

--- a/.release/linux/package/etc/vault.d/vault.hcl
+++ b/.release/linux/package/etc/vault.d/vault.hcl
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-# Full configuration options can be found at https://www.vaultproject.io/docs/configuration
+# Full configuration options can be found at https://developer.hashicorp.com/vault/docs/configuration
 
 ui = true
 

--- a/.release/linux/package/usr/lib/systemd/system/vault.service
+++ b/.release/linux/package/usr/lib/systemd/system/vault.service
@@ -1,6 +1,6 @@
 [Unit]
 Description="HashiCorp Vault - A tool for managing secrets"
-Documentation=https://www.vaultproject.io/docs/
+Documentation=https://developer.hashicorp.com/vault/docs
 Requires=network-online.target
 After=network-online.target
 ConditionFileNotEmpty=/etc/vault.d/vault.hcl

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 -	Website: https://www.vaultproject.io
 -	Announcement list: [Google Groups](https://groups.google.com/group/hashicorp-announce)
 -	Discussion forum: [Discuss](https://discuss.hashicorp.com/c/vault)
-- Documentation: [https://www.vaultproject.io/docs/](https://www.vaultproject.io/docs/)
+- Documentation: [https://developer.hashicorp.com/vault/docs](https://developer.hashicorp.com/vault/docs)
 - Tutorials: [HashiCorp's Learn Platform](https://learn.hashicorp.com/vault)
 - Certification Exam: [Vault Associate](https://www.hashicorp.com/certification/#hashicorp-certified-vault-associate)
 
@@ -52,7 +52,7 @@ The key features of Vault are:
 Documentation, Getting Started, and Certification Exams
 -------------------------------
 
-Documentation is available on the [Vault website](https://www.vaultproject.io/docs/).
+Documentation is available on the [Vault website](https://developer.hashicorp.com/vault/docs).
 
 If you're new to Vault and want to get started with security automation, please
 check out our [Getting Started guides](https://learn.hashicorp.com/collections/vault/getting-started)

--- a/api/README.md
+++ b/api/README.md
@@ -4,6 +4,6 @@ Vault API
 This provides the `github.com/hashicorp/vault/api` package which contains code useful for interacting with a Vault server.
 
 For examples of how to use this module, see the [vault-examples](https://github.com/hashicorp/vault-examples) repo.
-For a step-by-step walkthrough on using these client libraries, see the [developer quickstart](https://www.vaultproject.io/docs/get-started/developer-qs).
+For a step-by-step walkthrough on using these client libraries, see the [developer quickstart](https://developer.hashicorp.com/vault/docs/get-started/developer-qs).
 
 [![GoDoc](https://godoc.org/github.com/hashicorp/vault/api?status.png)](https://godoc.org/github.com/hashicorp/vault/api)

--- a/api/auth/aws/aws.go
+++ b/api/auth/aws/aws.go
@@ -241,7 +241,7 @@ func WithIAMAuth() LoginOption {
 // If this option is not provided, will default to using the PKCS #7 signature.
 // The signature type used should match the type of the public AWS cert Vault
 // has been configured with to verify EC2 instance identity.
-// https://www.vaultproject.io/api/auth/aws#create-certificate-configuration
+// https://developer.hashicorp.com/vault/api-docs/auth/aws#create-certificate-configuration
 func WithIdentitySignature() LoginOption {
 	return func(a *AWSAuth) error {
 		a.signatureType = identityType
@@ -254,7 +254,7 @@ func WithIdentitySignature() LoginOption {
 // PKCS #7 is the default, but this method is provided for additional clarity.
 // The signature type used should match the type of the public AWS cert Vault
 // has been configured with to verify EC2 instance identity.
-// https://www.vaultproject.io/api/auth/aws#create-certificate-configuration
+// https://developer.hashicorp.com/vault/api-docs/auth/aws#create-certificate-configuration
 func WithPKCS7Signature() LoginOption {
 	return func(a *AWSAuth) error {
 		a.signatureType = pkcs7Type

--- a/api/kv.go
+++ b/api/kv.go
@@ -38,7 +38,7 @@ type KVSecret struct {
 // by default when a server is started in -dev mode. See the kvv2 struct.
 //
 // Learn more about the KV secrets engine here:
-// https://www.vaultproject.io/docs/secrets/kv
+// https://developer.hashicorp.com/vault/docs/secrets/kv
 func (c *Client) KVv1(mountPath string) *KVv1 {
 	return &KVv1{c: c, mountPath: mountPath}
 }
@@ -53,7 +53,7 @@ func (c *Client) KVv1(mountPath string) *KVv1 {
 // as these are the default settings when a server is started in -dev mode.
 //
 // Learn more about the KV secrets engine here:
-// https://www.vaultproject.io/docs/secrets/kv
+// https://developer.hashicorp.com/vault/docs/secrets/kv
 func (c *Client) KVv2(mountPath string) *KVv2 {
 	return &KVv2{c: c, mountPath: mountPath}
 }

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -24,7 +24,7 @@ Release notes are text files with three lines:
        might be warranted.
      - `deprecation` - Announcement of a planned future removal of a
        feature. Only use this if a deprecation notice also exists [in the
-       docs](https://www.vaultproject.io/docs/deprecation).
+       docs](https://developer.hashicorp.com/vault/docs/deprecation).
      - `feature` - Large topical additions for a major release. These are
        rarely in minor releases. Formatting for `feature` entries differs
        from normal changelog formatting - see the [new features

--- a/command/agent/README.md
+++ b/command/agent/README.md
@@ -12,4 +12,4 @@ addressing the following challenges:
 
 See the usage documentation on the Vault website here:
 
-- https://www.vaultproject.io/docs/agent/
+- https://developer.hashicorp.com/vault/docs/agent-and-proxy/agent

--- a/ui/app/components/oidc/key-form.js
+++ b/ui/app/components/oidc/key-form.js
@@ -31,7 +31,7 @@ export default class OidcKeyForm extends Component {
   @tracked invalidFormAlert;
   @tracked modelValidations;
   @tracked radioCardGroupValue =
-    // If "*" is provided, all clients are allowed: https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#parameters
+    // If "*" is provided, all clients are allowed: https://developer.hashicorp.com/vault/api-docs/secret/identity/oidc-provider#parameters
     !this.args.model.allowedClientIds || this.args.model.allowedClientIds.includes('*')
       ? 'allow_all'
       : 'limited';

--- a/ui/app/components/oidc/provider-form.js
+++ b/ui/app/components/oidc/provider-form.js
@@ -31,7 +31,7 @@ export default class OidcProviderForm extends Component {
   @tracked errorBanner;
   @tracked invalidFormAlert;
   @tracked radioCardGroupValue =
-    // If "*" is provided, all clients are allowed: https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#parameters
+    // If "*" is provided, all clients are allowed: https://developer.hashicorp.com/vault/api-docs/secret/identity/oidc-provider#parameters
     !this.args.model.allowedClientIds || this.args.model.allowedClientIds.includes('*')
       ? 'allow_all'
       : 'limited';

--- a/ui/app/models/capabilities.js
+++ b/ui/app/models/capabilities.js
@@ -5,7 +5,7 @@
 
 // This model represents the capabilities on a given `path`
 // `path` is also the primaryId
-// https://www.vaultproject.io/docs/concepts/policies.html#capabilities
+// https://developer.hashicorp.com/vault/docs/concepts/policies#capabilities
 
 import Model, { attr } from '@ember-data/model';
 

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -96,7 +96,7 @@ export default Model.extend({
   get showFields() {
     let fields = ['name', 'database', 'type'];
     fields = fields.concat(getRoleFields(this.type)).concat(['creation_statements']);
-    // elasticsearch does not support revocation statements: https://www.vaultproject.io/api-docs/secret/databases/elasticdb#parameters-1
+    // elasticsearch does not support revocation statements: https://developer.hashicorp.com/vault/api-docs/secret/databases/elasticdb#parameters-1
     if (this.database[0] !== 'elasticsearch') {
       fields = fields.concat(['revocation_statements']);
     }

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -8,7 +8,7 @@ import { alias, and, equal } from '@ember/object/computed';
 
 export default Model.extend({
   name: attr('string'),
-  //https://www.vaultproject.io/docs/http/sys-health.html
+  // https://developer.hashicorp.com/vault/api-docs/system/health
   initialized: attr('boolean'),
   sealed: attr('boolean'),
   isSealed: alias('sealed'),
@@ -19,8 +19,8 @@ export default Model.extend({
 
   isLeader: and('initialized', 'isActive'),
 
-  //https://www.vaultproject.io/docs/http/sys-seal-status.html
-  //The "t" parameter is the threshold, and "n" is the number of shares.
+  // https://developer.hashicorp.com/vault/api-docs/system/seal-status
+  // The "t" parameter is the threshold, and "n" is the number of shares.
   t: attr('number'),
   n: attr('number'),
   progress: attr('number'),
@@ -31,7 +31,7 @@ export default Model.extend({
   storageType: attr('string'),
   hcpLinkStatus: attr('string'),
 
-  //https://www.vaultproject.io/docs/http/sys-leader.html
+  // https://developer.hashicorp.com/vault/api-docs/system/leader
   haEnabled: attr('boolean'),
   isSelf: attr('boolean'),
   leaderAddress: attr('string'),

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -11,7 +11,7 @@ import attachCapabilities from 'vault/lib/attach-capabilities';
 
 // these arrays define the order in which the fields will be displayed
 // see
-//https://www.vaultproject.io/api-docs/secret/transform#create-update-transformation
+// https://developer.hashicorp.com/vault/api-docs/secret/transform#create-update-transformation-deprecated-1-6
 const TYPES = [
   {
     value: 'fpe',

--- a/ui/app/templates/vault/cluster/unseal.hbs
+++ b/ui/app/templates/vault/cluster/unseal.hbs
@@ -56,7 +56,7 @@
     <Page.footer>
       <div class="box is-borderless is-shadowless">
         <p>
-          <ExternalLink @href="https://www.vaultproject.io/docs/concepts/seal">
+          <ExternalLink @href="https://developer.hashicorp.com/vault/docs/concepts/seal">
             Seal/unseal documentation
           </ExternalLink>
         </p>

--- a/vault/util.go
+++ b/vault/util.go
@@ -14,7 +14,7 @@ import (
 //
 // Use of memzero is not a guarantee against memory analysis as described in
 // the Vault threat model:
-// https://www.vaultproject.io/docs/internals/security.html .  Vault does not
+// https://developer.hashicorp.com/vault/docs/internals/security .  Vault does not
 // provide guarantees against memory analysis or raw memory dumping by
 // operators, however it does minimize this exposure by zeroing out buffers
 // that contain secrets as soon as they are no longer used.  Starting with Go

--- a/website/content/docs/auth/approle.mdx
+++ b/website/content/docs/auth/approle.mdx
@@ -285,7 +285,7 @@ func getSecretWithAppRole() (string, error) {
 
 	// The Secret ID is a value that needs to be protected, so instead of the
 	// app having knowledge of the secret ID directly, we have a trusted orchestrator (https://learn.hashicorp.com/tutorials/vault/secure-introduction?in=vault/app-integration#trusted-orchestrator)
-	// give the app access to a short-lived response-wrapping token (https://www.vaultproject.io/docs/concepts/response-wrapping).
+	// give the app access to a short-lived response-wrapping token (https://developer.hashicorp.com/vault/docs/concepts/response-wrapping).
 	// Read more at: https://learn.hashicorp.com/tutorials/vault/approle-best-practices?in=vault/auth-methods#secretid-delivery-best-practices
 	secretID := &auth.SecretID{FromFile: "path/to/wrapping-token"}
 
@@ -350,8 +350,8 @@ namespace Examples
         {
             // A combination of a Role ID and Secret ID is required to log in to Vault with an AppRole.
 	        // The Secret ID is a value that needs to be protected, so instead of the app having knowledge of the secret ID directly,
-	        // we have a trusted orchestrator (https://learn.hashicorp.com/tutorials/vault/secure-introduction?in=vault/app-integration#trusted-orchestrator)
-	        // give the app access to a short-lived response-wrapping token (https://www.vaultproject.io/docs/concepts/response-wrapping).
+	        // we have a trusted orchestrator (https://developer.hashicorp.com/vault/tutorials/app-integration/secure-introduction?in=vault%2Fapp-integration#trusted-orchestrator)
+	        // give the app access to a short-lived response-wrapping token (https://developer.hashicorp.com/vault/docs/concepts/response-wrapping).
 	        // Read more at: https://learn.hashicorp.com/tutorials/vault/approle-best-practices?in=vault/auth-methods#secretid-delivery-best-practices
             var vaultAddr = Environment.GetEnvironmentVariable("VAULT_ADDR");
             if(String.IsNullOrEmpty(vaultAddr))

--- a/website/content/docs/concepts/auth.mdx
+++ b/website/content/docs/concepts/auth.mdx
@@ -142,7 +142,7 @@ import (
 // Additionally, enterprise Vault users should be aware that due to eventual
 // consistency, the API may return unexpected errors when running Vault with
 // performance standbys or performance replication, despite the client having
-// a freshly renewed token. See https://www.vaultproject.io/docs/enterprise/consistency#vault-1-7-mitigations
+// a freshly renewed token. See https://developer.hashicorp.com/vault/docs/enterprise/consistency#vault-1-7-mitigations
 // for several ways to mitigate this which are outside the scope of this code sample.
 func renewToken(client *vault.Client) {
 	for {
@@ -168,7 +168,7 @@ func manageTokenLifecycle(client *vault.Client, token *vault.Secret) error {
 
 	watcher, err := client.NewLifetimeWatcher(&vault.LifetimeWatcherInput{
 		Secret:    token,
-		Increment: 3600, // Learn more about this optional value in https://www.vaultproject.io/docs/concepts/lease#lease-durations-and-renewal
+		Increment: 3600, // Learn more about this optional value in https://developer.hashicorp.com/vault/docs/concepts/lease#lease-durations-and-renewal
 	})
 	if err != nil {
 		return fmt.Errorf("unable to initialize new lifetime watcher for renewing auth token: %w", err)

--- a/website/content/docs/interoperability-matrix.mdx
+++ b/website/content/docs/interoperability-matrix.mdx
@@ -6,7 +6,7 @@ description: Guide to viewing which partners Vault integrates with.
 
 # Vault interoperability matrix
 
-Vault integrates with various appliances, platforms and applications for different use cases. Below are two tables indicating the partner’s product that has been verified to work with Vault for [Auto Unsealing](/vault/docs/concepts/seal#auto-unseal) / [HSM Support](/vault/docs/enterprise/hsm) and [External Key Management](https://vaultproject.io/use-cases/key-management).
+Vault integrates with various appliances, platforms and applications for different use cases. Below are two tables indicating the partner’s product that has been verified to work with Vault for [Auto Unsealing](/vault/docs/concepts/seal#auto-unseal) / [HSM Support](/vault/docs/enterprise/hsm) and [External Key Management](https://www.vaultproject.io/use-cases/key-management).
 
 Auto Unseal and HSM Support was developed to aid in reducing the operational complexity of keeping the unseal key secure. This feature delegates the responsibility of securing the unseal key from users to a trusted device or service. At startup Vault will connect to the device or service implementing the seal and ask it to decrypt the root key Vault read from storage.
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -2268,19 +2268,19 @@
       },
       {
         "title": "Feature Deprecation Notice and Plans",
-        "href": "https://www.vaultproject.io/docs/deprecation/faq"
+        "href": "https://developer.hashicorp.com/vault/docs/deprecation/faq"
       },
       {
         "title": "License",
-        "href": "https://www.vaultproject.io/docs/enterprise/license/faq"
+        "href": "https://developer.hashicorp.com/vault/docs/enterprise/license/faq"
       },
       {
         "title": "Client Count",
-        "href": "https://www.vaultproject.io/docs/concepts/client-count/faq"
+        "href": "https://developer.hashicorp.com/vault/docs/concepts/client-count/faq"
       },
       {
         "title": "Login MFA",
-        "href": "https://www.vaultproject.io/docs/auth/login-mfa/faq"
+        "href": "https://developer.hashicorp.com/vault/docs/auth/login-mfa/faq"
       },
       {
         "title": "Server Side Consistent Token",


### PR DESCRIPTION
Update outdated `vaultproject.io/docs/` links that are now redirects to https://developer.hashicorp.com/vault/docs