### PR TITLE
Pass consul license in Enos scenarios that have `backend` in the matrix

### DIFF
--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -231,7 +231,7 @@ scenario "replication" {
     variables {
       cluster_name    = step.create_primary_cluster_backend_targets.cluster_name
       cluster_tag_key = local.backend_tag_key
-      consul_license  = (matrix.primary_backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      license  = (matrix.primary_backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
       release = {
         edition = var.backend_edition
         version = matrix.consul_version
@@ -257,6 +257,7 @@ scenario "replication" {
       awskms_unseal_key_arn   = step.create_vpc.kms_key_arn
       backend_cluster_name    = step.create_primary_cluster_backend_targets.cluster_name
       backend_cluster_tag_key = local.backend_tag_key
+      consul_license  = (matrix.primary_backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
       cluster_name            = step.create_primary_cluster_targets.cluster_name
       consul_release = matrix.primary_backend == "consul" ? {
         edition = var.backend_edition
@@ -286,7 +287,7 @@ scenario "replication" {
     variables {
       cluster_name    = step.create_secondary_cluster_backend_targets.cluster_name
       cluster_tag_key = local.backend_tag_key
-      consul_license  = (matrix.secondary_backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      license  = (matrix.secondary_backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
       release = {
         edition = var.backend_edition
         version = matrix.consul_version
@@ -312,6 +313,7 @@ scenario "replication" {
       awskms_unseal_key_arn   = step.create_vpc.kms_key_arn
       backend_cluster_name    = step.create_secondary_cluster_backend_targets.cluster_name
       backend_cluster_tag_key = local.backend_tag_key
+      consul_license  = (matrix.secondary_backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
       cluster_name            = step.create_secondary_cluster_targets.cluster_name
       consul_release = matrix.secondary_backend == "consul" ? {
         edition = var.backend_edition
@@ -553,6 +555,7 @@ scenario "replication" {
       backend_cluster_name    = step.create_primary_cluster_backend_targets.cluster_name
       backend_cluster_tag_key = local.backend_tag_key
       cluster_name            = step.create_primary_cluster_targets.cluster_name
+      consul_license  = (matrix.primary_backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
       consul_release = matrix.primary_backend == "consul" ? {
         edition = var.backend_edition
         version = matrix.consul_version

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -39,7 +39,9 @@ scenario "replication" {
   ]
 
   locals {
-    backend_tag_key = "VaultStorage"
+    # The path to the backend license file (Consul Enterprise)
+    backend_license_path = abspath(var.backend_license_path != null ? var.backend_license_path : joinpath(path.root, "./support/consul.hclic"))
+    backend_tag_key      = "VaultStorage"
     build_tags = {
       "ent"              = ["ui", "enterprise", "ent"]
       "ent.fips1402"     = ["ui", "enterprise", "cgo", "hsm", "fips", "fips_140_2", "ent.fips1402"]
@@ -103,7 +105,18 @@ scenario "replication" {
     }
   }
 
-  step "read_license" {
+  // This step reads the contents of the backend license if we're using a Consul backend and
+  // the edition is "ent".
+  step "read_backend_license" {
+    skip_step = (matrix.primary_backend == "raft" && matrix.secondary_backend == "raft") ||  var.backend_edition == "oss"
+    module    = module.read_license
+
+    variables {
+      file_name = local.backend_license_path
+    }
+  }
+
+  step "read_vault_license" {
     module = module.read_license
 
     variables {
@@ -218,6 +231,7 @@ scenario "replication" {
     variables {
       cluster_name    = step.create_primary_cluster_backend_targets.cluster_name
       cluster_tag_key = local.backend_tag_key
+      consul_license  = (matrix.primary_backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
       release = {
         edition = var.backend_edition
         version = matrix.consul_version
@@ -250,7 +264,7 @@ scenario "replication" {
       } : null
       enable_file_audit_device = var.vault_enable_file_audit_device
       install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_license.license : null
+      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
       local_artifact_path      = local.bundle_path
       packages                 = local.packages
       storage_backend          = matrix.primary_backend
@@ -272,6 +286,7 @@ scenario "replication" {
     variables {
       cluster_name    = step.create_secondary_cluster_backend_targets.cluster_name
       cluster_tag_key = local.backend_tag_key
+      consul_license  = (matrix.secondary_backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
       release = {
         edition = var.backend_edition
         version = matrix.consul_version
@@ -304,7 +319,7 @@ scenario "replication" {
       } : null
       enable_file_audit_device = var.vault_enable_file_audit_device
       install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_license.license : null
+      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
       local_artifact_path      = local.bundle_path
       packages                 = local.packages
       storage_backend          = matrix.secondary_backend
@@ -545,7 +560,7 @@ scenario "replication" {
       force_unseal        = matrix.primary_seal == "shamir"
       initialize_cluster  = false
       install_dir         = local.vault_install_dir
-      license             = matrix.edition != "oss" ? step.read_license.license : null
+      license             = matrix.edition != "oss" ? step.read_vault_license.license : null
       local_artifact_path = local.bundle_path
       packages            = local.packages
       root_token          = step.create_primary_cluster.root_token

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -162,7 +162,7 @@ scenario "smoke" {
   step "create_backend_cluster" {
     module = "backend_${matrix.backend}"
     depends_on = [
-      step.create_vault_cluster_backend_targets,
+      step.create_vault_cluster_backend_targets
     ]
 
     providers = {
@@ -199,6 +199,7 @@ scenario "smoke" {
       backend_cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       backend_cluster_tag_key = local.backend_tag_key
       cluster_name            = step.create_vault_cluster_targets.cluster_name
+      consul_license  = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
       consul_release = matrix.backend == "consul" ? {
         edition = var.backend_edition
         version = matrix.consul_version

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -34,7 +34,8 @@ scenario "smoke" {
   ]
 
   locals {
-    backend_tag_key = "VaultStorage"
+    backend_license_path = abspath(var.backend_license_path != null ? var.backend_license_path : joinpath(path.root, "./support/consul.hclic"))
+    backend_tag_key      = "VaultStorage"
     build_tags = {
       "oss"              = ["ui"]
       "ent"              = ["ui", "enterprise", "ent"]
@@ -104,7 +105,18 @@ scenario "smoke" {
     }
   }
 
-  step "read_license" {
+  // This step reads the contents of the backend license if we're using a Consul backend and
+  // the edition is "ent".
+  step "read_backend_license" {
+    skip_step = matrix.backend == "raft" || var.backend_edition == "oss"
+    module    = module.read_license
+
+    variables {
+      file_name = local.backend_license_path
+    }
+  }
+
+  step "read_vault_license" {
     skip_step = matrix.edition == "oss"
     module    = module.read_license
 
@@ -160,6 +172,7 @@ scenario "smoke" {
     variables {
       cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       cluster_tag_key = local.backend_tag_key
+      license  = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
       release = {
         edition = var.backend_edition
         version = matrix.consul_version
@@ -192,7 +205,7 @@ scenario "smoke" {
       } : null
       enable_file_audit_device = var.vault_enable_file_audit_device
       install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_license.license : null
+      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
       local_artifact_path      = local.bundle_path
       packages                 = local.packages
       storage_backend          = matrix.backend

--- a/enos/enos-scenario-ui.hcl
+++ b/enos/enos-scenario-ui.hcl
@@ -17,6 +17,7 @@ scenario "ui" {
   locals {
     arch            = "amd64"
     artifact_type   = "bundle"
+    backend_license_path = abspath(var.backend_license_path != null ? var.backend_license_path : joinpath(path.root, "./support/consul.hclic"))
     backend_tag_key = "VaultStorage"
     build_tags = {
       "oss" = ["ui"]
@@ -71,7 +72,18 @@ scenario "ui" {
     }
   }
 
-  step "read_license" {
+  // This step reads the contents of the backend license if we're using a Consul backend and
+  // the edition is "ent".
+  step "read_backend_license" {
+    skip_step = matrix.backend == "raft" || var.backend_edition == "oss"
+    module    = module.read_license
+
+    variables {
+      file_name = local.backend_license_path
+    }
+  }
+
+  step "read_vault_license" {
     skip_step = matrix.edition == "oss"
     module    = module.read_license
 
@@ -127,6 +139,7 @@ scenario "ui" {
     variables {
       cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       cluster_tag_key = local.backend_tag_key
+      license  = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
       release = {
         edition = var.backend_edition
         version = local.consul_version
@@ -152,13 +165,14 @@ scenario "ui" {
       backend_cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       backend_cluster_tag_key = local.backend_tag_key
       cluster_name            = step.create_vault_cluster_targets.cluster_name
+      consul_license  = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
       consul_release = matrix.backend == "consul" ? {
         edition = var.backend_edition
         version = local.consul_version
       } : null
       enable_file_audit_device = var.vault_enable_file_audit_device
       install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_license.license : null
+      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
       local_artifact_path      = local.bundle_path
       storage_backend          = matrix.backend
       target_hosts             = step.create_vault_cluster_targets.hosts

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -28,6 +28,7 @@ scenario "upgrade" {
   ]
 
   locals {
+    backend_license_path = abspath(var.backend_license_path != null ? var.backend_license_path : joinpath(path.root, "./support/consul.hclic"))
     backend_tag_key = "VaultStorage"
     build_tags = {
       "oss"              = ["ui"]
@@ -94,18 +95,24 @@ scenario "upgrade" {
     }
   }
 
-  step "read_license" {
+  // This step reads the contents of the backend license if we're using a Consul backend and
+  // the edition is "ent".
+  step "read_backend_license" {
+    skip_step = matrix.backend == "raft" || var.backend_edition == "oss"
+    module    = module.read_license
+
+    variables {
+      file_name = local.backend_license_path
+    }
+  }
+
+  step "read_vault_license" {
     skip_step = matrix.edition == "oss"
     module    = module.read_license
 
     variables {
       file_name = local.vault_license_path
     }
-  }
-
-  step "get_local_metadata" {
-    skip_step = matrix.artifact_source != "local"
-    module    = module.get_local_metadata
   }
 
   step "create_vault_cluster_targets" {
@@ -155,6 +162,7 @@ scenario "upgrade" {
     variables {
       cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       cluster_tag_key = local.backend_tag_key
+      license  = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
       release = {
         edition = var.backend_edition
         version = matrix.consul_version
@@ -179,6 +187,7 @@ scenario "upgrade" {
       awskms_unseal_key_arn   = step.create_vpc.kms_key_arn
       backend_cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       backend_cluster_tag_key = local.backend_tag_key
+      consul_license  = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
       cluster_name            = step.create_vault_cluster_targets.cluster_name
       consul_release = matrix.backend == "consul" ? {
         edition = var.backend_edition
@@ -186,7 +195,7 @@ scenario "upgrade" {
       } : null
       enable_file_audit_device = var.vault_enable_file_audit_device
       install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_license.license : null
+      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
       packages                 = local.packages
       release                  = var.vault_upgrade_initial_release
       storage_backend          = matrix.backend

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -48,13 +48,13 @@ variable "aws_ssh_private_key_path" {
 variable "backend_edition" {
   description = "The backend release edition if applicable"
   type        = string
-  default     = "oss"
+  default     = "oss" // or "ent"
 }
 
 variable "backend_instance_type" {
   description = "The instance type to use for the Vault backend. Must be arm64/nitro compatible"
-  type        = string
-  default     = "t4g.small"
+  type                  = string
+  default               = "t4g.small"
 }
 
 variable "backend_license_path" {

--- a/enos/modules/backend_raft/main.tf
+++ b/enos/modules/backend_raft/main.tf
@@ -25,6 +25,10 @@ variable "config_dir" {
   default = null
 }
 
+variable "consul_log_level" {
+  default = null
+}
+
 variable "data_dir" {
   default = null
 }

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -129,6 +129,7 @@ resource "enos_consul_start" "consul" {
     log_level        = var.consul_log_level
     log_file         = var.consul_log_file
   }
+  license   = var.consul_license
   unit_name = "consul"
   username  = "consul"
 


### PR DESCRIPTION
Previously we were not able to test Vault with enterprise edition Consul. We added support for this in the vault-cluster module, and now needed to actually begin passing the Consul license in the scenarios that use a Consul backend. 