### PR TITLE
UI: Add missing allowed_user_ids to role form in PKI

### DIFF
--- a/changelog/22191.txt
+++ b/changelog/22191.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: adds allowed_user_ids field to create role form and user_ids to generate certificates form in pki
+```

--- a/ui/app/models/pki/certificate/generate.js
+++ b/ui/app/models/pki/certificate/generate.js
@@ -18,6 +18,7 @@ const generateFromRole = [
       'ipSans',
       'uriSans',
       'otherSans',
+      'userIds',
     ],
   },
 ];

--- a/ui/app/models/pki/certificate/generate.js
+++ b/ui/app/models/pki/certificate/generate.js
@@ -9,7 +9,7 @@ import PkiCertificateBaseModel from './base';
 
 const generateFromRole = [
   {
-    default: ['commonName', 'customTtl', 'format', 'privateKeyFormat'],
+    default: ['commonName', 'userIds', 'customTtl', 'format', 'privateKeyFormat'],
   },
   {
     'Subject Alternative Name (SAN) Options': [
@@ -18,7 +18,6 @@ const generateFromRole = [
       'ipSans',
       'uriSans',
       'otherSans',
-      'userIds',
     ],
   },
 ];

--- a/ui/app/models/pki/role.js
+++ b/ui/app/models/pki/role.js
@@ -55,6 +55,7 @@ const fieldGroups = [
   },
   {
     'Additional subject fields': [
+      'allowedUserIds',
       'allowedSerialNumbers',
       'requireCn',
       'useCsrCommonName',
@@ -293,6 +294,7 @@ export default class PkiRoleModel extends Model {
   })
   extKeyUsageOids;
 
+  @attr({ editType: 'stringArray' }) allowedUserIds;
   @attr({ editType: 'stringArray' }) organization;
   @attr({ editType: 'stringArray' }) country;
   @attr({ editType: 'stringArray' }) locality;


### PR DESCRIPTION
**Description**
Add `allowed_user_ids` under the **Additional subject fields** section of Create Role in PKI
<img width="1137" alt="Screenshot 2023-08-03 at 8 31 47 AM" src="https://github.com/hashicorp/vault/assets/30884335/b4bb0a3e-4aaf-46e5-b955-d55a143fb940">

Add `user_ids` under the **Common name** field in Generate Credentials in PKI
<img width="1075" alt="Screenshot 2023-08-08 at 9 11 51 AM" src="https://github.com/hashicorp/vault/assets/30884335/90399682-4375-4e2e-b7d7-0167bb469a84">

Confirmed with crypto (Alex + Steve) that it makes sense to place the fields in these sections/areas^
