### PR TITLE
UI: Update to test helper runCmd

### DIFF
--- a/ui/tests/acceptance/secrets/backend/database/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/database/secret-test.js
@@ -14,7 +14,6 @@ import connectionPage from 'vault/tests/pages/secrets/backend/database/connectio
 import rolePage from 'vault/tests/pages/secrets/backend/database/role';
 import authPage from 'vault/tests/pages/auth';
 import logout from 'vault/tests/pages/logout';
-import consoleClass from 'vault/tests/pages/components/console/ui-panel';
 import searchSelect from 'vault/tests/pages/components/search-select';
 import {
   createPolicyCmd,
@@ -25,7 +24,6 @@ import {
 } from 'vault/tests/helpers/commands';
 
 const searchSelectComponent = create(searchSelect);
-const consoleComponent = create(consoleClass);
 
 const newConnection = async (backend, plugin = 'mongodb-database-plugin') => {
   const name = `connection-${Date.now()}`;
@@ -231,10 +229,10 @@ module('Acceptance | secrets/database/*', function (hooks) {
   hooks.beforeEach(async function () {
     this.backend = `database-testing`;
     await authPage.login();
-    return consoleComponent.runCommands(mountEngineCmd('database', this.backend));
+    return runCmd(mountEngineCmd('database', this.backend), false);
   });
   hooks.afterEach(function () {
-    return consoleComponent.runCommands(deleteEngineCmd(this.backend));
+    return runCmd(deleteEngineCmd(this.backend), false);
   });
 
   test('can enable the database secrets engine', async function (assert) {
@@ -256,7 +254,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
     assert.dom('[data-test-secret-list-tab="Roles"]').exists('Has Roles tab');
     await visit('/vault/secrets');
     // Cleanup backend
-    await consoleComponent.runCommands(deleteEngineCmd(backend));
+    await runCmd(deleteEngineCmd(backend), false);
   });
 
   for (const testCase of connectionTests) {
@@ -451,9 +449,9 @@ module('Acceptance | secrets/database/*', function (hooks) {
         capabilities = ["delete"]
       }
     `;
-    const token = await runCmd(consoleComponent, [
-      ...createPolicyCmd('test-policy', CONNECTION_VIEW_ONLY),
-      ...tokenWithPolicyCmd('test-policy'),
+    const token = await runCmd([
+      createPolicyCmd('test-policy', CONNECTION_VIEW_ONLY),
+      tokenWithPolicyCmd('test-policy'),
     ]);
     await navToConnection(backend, connection);
     assert
@@ -540,9 +538,9 @@ module('Acceptance | secrets/database/*', function (hooks) {
         capabilities = ["list", "create", "read", "update"]
       }
     `;
-    const token = await runCmd(consoleComponent, [
-      ...createPolicyCmd('test-policy', NO_ROLES_POLICY),
-      ...tokenWithPolicyCmd('test-policy'),
+    const token = await runCmd([
+      createPolicyCmd('test-policy', NO_ROLES_POLICY),
+      tokenWithPolicyCmd('test-policy'),
     ]);
 
     // test root user flow first

--- a/ui/tests/helpers/commands.js
+++ b/ui/tests/helpers/commands.js
@@ -1,61 +1,68 @@
+import consoleClass from 'vault/tests/pages/components/console/ui-panel';
+import { create } from 'ember-cli-page-object';
 /**
  * Helper functions to run common commands in the consoleComponent during tests.
- * Please note that a user must be logged in during the test context for the commands to run
+ * Please note that a user must be logged in during the test context for the commands to run.
+ * By default runCmd throws an error if the last log includes "Error". To override this,
+ * pass boolean false to run the commands and not throw errors
  *
  * Example:
  *
  * import { v4 as uuidv4 } from 'uuid';
- * import { create } from 'ember-cli-page-object';
- * import consoleClass from 'vault/tests/pages/components/console/ui-panel';
  * import { runCmd, mountEngineCmd } from 'vault/tests/helpers/commands';
  *
- * const consoleComponent = create(consoleClass);
  *
  * async function mountEngineExitOnError() {
  *    const backend = `pki-${uuidv4()}`;
- *    await runCmd(consoleComponent, mountEngineCmd('pki', backend));
+ *    await runCmd(mountEngineCmd('pki', backend));
  *    return backend;
  * }
  *
  * async function mountEngineSquashErrors() {
  *    const backend = `pki-${uuidv4()}`;
- *    await consoleComponent.runCommands(mountEngineCmd('pki', backend));
+ *    await runCmd(mountEngineCmd('pki', backend), false);
  *    return backend;
  * }
  */
 
+const cc = create(consoleClass);
+
+/**
+ * runCmd is used to run commands and throw an error if the output includes "Error"
+ * @param {string || string[]} commands array of commands that should run
+ * @param {boolean} throwErrors
+ * @returns the last log output. Throws an error if it includes an error
+ */
+export async function runCmd(commands, throwErrors = true) {
+  if (!commands) {
+    throw new Error('runCmd requires commands array passed in');
+  }
+  if (!Array.isArray(commands)) {
+    commands = [commands];
+  }
+  await cc.runCommands(commands);
+  const lastOutput = cc.lastLogOutput;
+  if (throwErrors && lastOutput.includes('Error')) {
+    throw new Error(`Error occurred while running commands: "${commands.join('; ')}" - ${lastOutput}`);
+  }
+  return lastOutput;
+}
+
+// Common commands
 export function mountEngineCmd(type, customName = '') {
   const name = customName || type;
-  return [`write sys/mounts/${name} type=${type}`];
+  return `write sys/mounts/${name} type=${type}`;
 }
 
 export function deleteEngineCmd(name) {
-  return [`delete sys/mounts/${name}`];
+  return `delete sys/mounts/${name}`;
 }
 
 export function createPolicyCmd(name, contents) {
   const policyContent = window.btoa(contents);
-  return [`write sys/policies/acl/${name} policy=${policyContent}`];
+  return `write sys/policies/acl/${name} policy=${policyContent}`;
 }
 
 export function tokenWithPolicyCmd(policyName = 'default') {
-  return [`write -field=client_token auth/token/create policies=${policyName} ttl=1h`];
-}
-
-/**
- * runCmd is used to run commands and throw an error if the output includes "Error"
- * @param {Component} console instance
- * @param {Array<string>} commands array of commands that should be run
- * @returns the last log output. Throws an error if it includes an error
- */
-export async function runCmd(component, commands) {
-  if (!component || !commands) {
-    throw new Error('runCmd requires consoleComponent and commands passed in');
-  }
-  await component.runCommands(commands);
-  const lastOutput = component.lastLogOutput;
-  if (lastOutput.includes('Error')) {
-    throw new Error(`Error occurred while running commands: "${commands.join('; ')}" - ${lastOutput}`);
-  }
-  return lastOutput;
+  return `write -field=client_token auth/token/create policies=${policyName} ttl=1h`;
 }

--- a/ui/tests/helpers/commands.js
+++ b/ui/tests/helpers/commands.js
@@ -51,11 +51,23 @@ export async function runCmd(commands, throwErrors = true) {
 // Common commands
 export function mountEngineCmd(type, customName = '') {
   const name = customName || type;
+  if (type === 'kv-v2') {
+    return `write sys/mounts/${name} type=kv options=version=2`;
+  }
   return `write sys/mounts/${name} type=${type}`;
 }
 
 export function deleteEngineCmd(name) {
   return `delete sys/mounts/${name}`;
+}
+
+export function mountAuthCmd(type, customName = '') {
+  const name = customName || type;
+  return `write sys/auth/${name} type=${type}`;
+}
+
+export function deleteAuthCmd(name) {
+  return `delete sys/auth/${name}`;
 }
 
 export function createPolicyCmd(name, contents) {


### PR DESCRIPTION
Some improvements to the `runCmd` test helper. 

- It now allows a string or an array of strings
- Each of the individual command helpers return a single string. Future helpers could return an array if they do multiple things
- Usage is cleaner due to the above changes