### PR TITLE
Use Hashicorp docker proxy for CI docker images

### DIFF
--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -127,9 +127,8 @@ func SubtestACMECaddy(configTemplate string, enableEAB bool) func(*testing.T, *V
 		// Kick off Caddy container.
 		t.Logf("creating on network: %v", vaultNetwork)
 		caddyRunner, err := hDocker.NewServiceRunner(hDocker.RunOptions{
-			// TODO: Replace with pull-through cache. - schultz
-			ImageRepo:     "library/caddy",
-			ImageTag:      "latest",
+			ImageRepo:     "docker.mirror.hashicorp.services/library/caddy",
+			ImageTag:      "2.6.4",
 			ContainerName: fmt.Sprintf("caddy_test_%s", runID),
 			NetworkName:   vaultNetwork,
 			Ports:         []string{"80/tcp", "443/tcp", "443/udp"},

--- a/helper/testhelpers/consul/consulhelper.go
+++ b/helper/testhelpers/consul/consulhelper.go
@@ -55,7 +55,7 @@ func PrepareTestContainer(t *testing.T, version string, isEnterprise bool, doBoo
 	}
 
 	name := "consul"
-	repo := "consul"
+	repo := "docker.mirror.hashicorp.services/hashicorp/consul"
 	var envVars []string
 	// If running the enterprise container, set the appropriate values below.
 	if isEnterprise {

--- a/helper/testhelpers/consul/consulhelper.go
+++ b/helper/testhelpers/consul/consulhelper.go
@@ -55,7 +55,7 @@ func PrepareTestContainer(t *testing.T, version string, isEnterprise bool, doBoo
 	}
 
 	name := "consul"
-	repo := "docker.mirror.hashicorp.services/hashicorp/consul"
+	repo := "docker.mirror.hashicorp.services/library/consul"
 	var envVars []string
 	// If running the enterprise container, set the appropriate values below.
 	if isEnterprise {


### PR DESCRIPTION
We should be pulling docker images through the Hashicorp Docker proxy and not directly from docker hub.