### PR TITLE
Add timeouts to ACME test contexts

### DIFF
--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -56,7 +56,8 @@ func TestAcmeBasicWorkflow(t *testing.T) {
 		{"issuer", "issuer/int-ca/acme/"},
 		{"issuer_role", "issuer/int-ca/roles/test-role/acme/"},
 	}
-	testCtx := context.Background()
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -359,7 +360,8 @@ func TestAcmeBasicWorkflowWithEab(t *testing.T) {
 	t.Parallel()
 	cluster, client, _ := setupAcmeBackend(t)
 	defer cluster.Cleanup()
-	testCtx := context.Background()
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 
 	// Enable EAB
 	_, err := client.Logical().WriteWithContext(context.Background(), "pki/config/acme", map[string]interface{}{
@@ -559,7 +561,8 @@ func TestAcmeClusterPathNotConfigured(t *testing.T) {
 		{"issuer", "pki/issuer/default/acme/directory"},
 		{"issuer_role", "pki/issuer/default/roles/test-role/acme/directory"},
 	}
-	testCtx := context.Background()
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -594,7 +597,8 @@ func TestAcmeAccountsCrossingDirectoryPath(t *testing.T) {
 	accountKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "failed creating rsa key")
 
-	testCtx := context.Background()
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 	acmeClient := getAcmeClientForCluster(t, cluster, baseAcmeURL, accountKey)
 
 	// Create new account
@@ -629,7 +633,8 @@ func TestAcmeEabCrossingDirectoryPath(t *testing.T) {
 	accountKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "failed creating rsa key")
 
-	testCtx := context.Background()
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 	acmeClient := getAcmeClientForCluster(t, cluster, baseAcmeURL, accountKey)
 
 	// fetch a new EAB
@@ -716,7 +721,9 @@ func TestAcmeTruncatesToIssuerExpiry(t *testing.T) {
 	cluster, client, _ := setupAcmeBackend(t)
 	defer cluster.Cleanup()
 
-	testCtx := context.Background()
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
 	mount := "pki"
 	resp, err := client.Logical().WriteWithContext(context.Background(), mount+"/issuers/generate/intermediate/internal",
 		map[string]interface{}{
@@ -804,7 +811,8 @@ func TestAcmeRoleExtKeyUsage(t *testing.T) {
 	cluster, client, _ := setupAcmeBackend(t)
 	defer cluster.Cleanup()
 
-	testCtx := context.Background()
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 
 	roleName := "test-role"
 
@@ -907,7 +915,9 @@ func TestIssuerRoleDirectoryAssociations(t *testing.T) {
 	defer cluster.Cleanup()
 
 	// Setup DNS for validations.
-	testCtx := context.Background()
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
 	dns := dnstest.SetupResolver(t, "dadgarcorp.com")
 	defer dns.Cleanup()
 	_, err := client.Logical().WriteWithContext(testCtx, "pki/config/acme", map[string]interface{}{
@@ -1040,7 +1050,9 @@ func TestACMESubjectFieldsAndExtensionsIgnored(t *testing.T) {
 	defer cluster.Cleanup()
 
 	// Setup DNS for validations.
-	testCtx := context.Background()
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
 	dns := dnstest.SetupResolver(t, "dadgarcorp.com")
 	defer dns.Cleanup()
 	_, err := client.Logical().WriteWithContext(testCtx, "pki/config/acme", map[string]interface{}{
@@ -1086,7 +1098,8 @@ func TestAcmeWithCsrIncludingBasicConstraintExtension(t *testing.T) {
 	cluster, client, _ := setupAcmeBackend(t)
 	defer cluster.Cleanup()
 
-	testCtx := context.Background()
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 
 	baseAcmeURL := "/v1/pki/acme/"
 	accountKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -1415,7 +1428,9 @@ func TestAcmeValidationError(t *testing.T) {
 	cluster, _, _ := setupAcmeBackend(t)
 	defer cluster.Cleanup()
 
-	testCtx := context.Background()
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
 	baseAcmeURL := "/v1/pki/acme/"
 	accountKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "failed creating rsa key")
@@ -1521,7 +1536,8 @@ func TestAcmeRevocationAcrossAccounts(t *testing.T) {
 
 	cluster, vaultClient, _ := setupAcmeBackend(t)
 	defer cluster.Cleanup()
-	testCtx := context.Background()
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 
 	baseAcmeURL := "/v1/pki/acme/"
 	accountKey1, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -1748,7 +1764,9 @@ func TestACMEClientRequestLimits(t *testing.T) {
 		},
 	}
 
-	testCtx := context.Background()
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
 	acmeConfig := map[string]interface{}{
 		"enabled":                  true,
 		"allowed_issuers":          "*",

--- a/builtin/logical/pki/path_config_acme_test.go
+++ b/builtin/logical/pki/path_config_acme_test.go
@@ -94,7 +94,7 @@ func TestAcmeConfig(t *testing.T) {
 	testCtx := context.Background()
 
 	for _, tc := range cases {
-		deadline := time.Now().Add(time.Second * 10)
+		deadline := time.Now().Add(1 * time.Minute)
 		subTestCtx, _ := context.WithDeadline(testCtx, deadline)
 
 		_, err := client.Logical().WriteWithContext(subTestCtx, "pki/roles/exists", roleConfig)


### PR DESCRIPTION
 - The Golang ACME library will retry on failures until the passed in context times out. So if a test is broken it will never end until the context expires.
 - The timeouts are rather large to avoid some issues with slow CI runners, that have already triggered on a nightly 32 bit run