### PR TITLE
clarify docs in ldap/auth for userfilter

### DIFF
--- a/website/content/api-docs/auth/ldap.mdx
+++ b/website/content/api-docs/auth/ldap.mdx
@@ -74,7 +74,8 @@ This endpoint configures the LDAP auth method.
 - `userfilter` `(string: "")` – An optional LDAP user search filter.
   The template can access the following context variables: UserAttr, Username.
   The default is `({{.UserAttr}}={{.Username}})`, or `({{.UserAttr}}={{.Username@.upndomain}})`
-  if `upndomain` is set.
+  if `upndomain` is set. In order for the `userfilter` to be applied,
+  both `binddn` and `bindpass` must be set, or `discoverdn` must be set to `true`.
 - `anonymous_group_search` `(bool: false)` - Use anonymous binds when performing
   LDAP group searches (note: even when `true`, the initial credentials will still
   be used for the initial connection test).
@@ -447,8 +448,8 @@ This endpoint allows you to log in with LDAP credentials
 ### Parameters
 
 - `username` `(string: <required>)` – The username of the LDAP user
-- `password` `(string: <required>)` – The password for the LDAP user. 
-When authenticating with the Vault CLI, i.e. `vault login -method=ldap username=mitchellh` 
+- `password` `(string: <required>)` – The password for the LDAP user.
+When authenticating with the Vault CLI, i.e. `vault login -method=ldap username=mitchellh`
 the password can alternatively be supplied via the `VAULT_LDAP_PASSWORD` environment variable.
 
 ### Sample payload

--- a/website/content/docs/auth/ldap.mdx
+++ b/website/content/docs/auth/ldap.mdx
@@ -112,6 +112,10 @@ management tool.
 
 There are two alternate methods of resolving the user object used to authenticate the end user: _Search_ or _User Principal Name_. When using _Search_, the bind can be either anonymous or authenticated. User Principal Name is a method of specifying users supported by Active Directory. More information on UPN can be found [here](<https://msdn.microsoft.com/en-us/library/ms677605(v=vs.85).aspx#userPrincipalName>).
 
+`userfilter` works with both authenticated and anonymous _Search_.
+In order for `userfilter` to apply for authenticated searches, `binddn` and `bindpass` must be set.
+For anonymous search, `discoverdn` must be set to `true`, and `deny_null_bind` must be set to false.
+
 #### Binding - authenticated search
 
 - `binddn` (string, optional) - Distinguished name of object to bind when performing user and group search. Example: `cn=vault,ou=Users,dc=example,dc=com`


### PR DESCRIPTION
Provides clarification in the ldap auth docs for `userfilter`. We've had multiple users report that the `userfilter` isn't being applied, or seems to be getting skipped.

Addresses https://github.com/hashicorp/vault/issues/17898.
