### PR TITLE
ui: add validator to check if string ends in slash

### DIFF
--- a/ui/app/utils/validators.js
+++ b/ui/app/utils/validators.js
@@ -25,9 +25,17 @@ export const number = (value, { nullable = false } = {}) => {
   return !isNaN(value);
 };
 
+/*
+the following validations return false (invalid) if the condition is met
+*/
 export const containsWhiteSpace = (value) => {
   const validation = new RegExp('\\s', 'g'); // search for whitespace
   return !validation.test(value);
 };
 
-export default { presence, length, number, containsWhiteSpace };
+export const endsInSlash = (value) => {
+  const validation = new RegExp('/$');
+  return !validation.test(value);
+};
+
+export default { presence, length, number, containsWhiteSpace, endsInSlash };

--- a/ui/tests/unit/utils/validators-test.js
+++ b/ui/tests/unit/utils/validators-test.js
@@ -92,4 +92,17 @@ module('Unit | Util | validators', function (hooks) {
     check('trailingSpace ');
     assert.false(isValid, 'Invalid when text has trailing whitespace');
   });
+
+  test('it should validate value ends in a slash', function (assert) {
+    let isValid;
+    const check = (prop) => (isValid = validators.endsInSlash(prop));
+    check('validText');
+    assert.true(isValid, 'Valid when text does not end in slash');
+    check('valid/Text');
+    assert.true(isValid, 'Valid when text only contains slash');
+    check('invalid/');
+    assert.false(isValid, 'Invalid when text ends in slash');
+    check('also/invalid/');
+    assert.false(isValid, 'Invalid when text contains and ends in slash');
+  });
 });


### PR DESCRIPTION
PR adds validator to model validation helpers to return `isValid = false` if a string ends in a forward slash