### PR TITLE
Add an anchor link to policy override section

### DIFF
--- a/website/content/docs/enterprise/sentinel/index.mdx
+++ b/website/content/docs/enterprise/sentinel/index.mdx
@@ -46,12 +46,11 @@ appropriately when introducing Sentinel policies.
 
 Sentinel policies have three enforcement levels to choose from.
 
-| Level          | Description                                                                |
-| -------------- | -------------------------------------------------------------------------- |
-| advisory       | The policy is allowed to fail. Can be used as a tool to educate new users. |
-| soft-mandatory | The policy must pass unless an override is specified.                      |
-| hard-mandatory | The policy must pass.                                       |
-
+| Level          | Description                                                                 |
+| -------------- | --------------------------------------------------------------------------- |
+| advisory       | The policy is allowed to fail. Can be used as a tool to educate new users.  |
+| soft-mandatory | The policy must pass unless an [override](#policy-overriding) is specified. |
+| hard-mandatory | The policy must pass.                                                       |
 
 ## Policy evaluation
 


### PR DESCRIPTION
Forgot to add the link to the **Policy override** section to explain how soft-mandatory works. 

This PR simply adds the link to the `override` text in the table. 

![image](https://github.com/hashicorp/vault/assets/7660718/90a9c103-2d05-4aef-a778-510caa521146)
