### PR TITLE
Refactor logic on applying leaf_not_after_behavior

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -1618,6 +1618,16 @@ func getCertificateNotAfter(b *backend, data *inputBundle, caSign *certutil.CAIn
 	} else {
 		notAfter = time.Now().Add(ttl)
 	}
+	notAfter, err = applyIssuerLeafNotAfterBehavior(caSign, notAfter)
+	if err != nil {
+		return time.Time{}, warnings, err
+	}
+	return notAfter, warnings, nil
+}
+
+// applyIssuerLeafNotAfterBehavior resets a certificate's notAfter time or errors out based on the
+// issuer's notAfter date along with the LeafNotAfterBehavior configuration
+func applyIssuerLeafNotAfterBehavior(caSign *certutil.CAInfoBundle, notAfter time.Time) (time.Time, error) {
 	if caSign != nil && notAfter.After(caSign.Certificate.NotAfter) {
 		// If it's not self-signed, verify that the issued certificate
 		// won't be valid past the lifetime of the CA certificate, and
@@ -1631,11 +1641,11 @@ func getCertificateNotAfter(b *backend, data *inputBundle, caSign *certutil.CAIn
 		case certutil.ErrNotAfterBehavior:
 			fallthrough
 		default:
-			return time.Time{}, warnings, errutil.UserError{Err: fmt.Sprintf(
+			return time.Time{}, errutil.UserError{Err: fmt.Sprintf(
 				"cannot satisfy request, as TTL would result in notAfter of %s that is beyond the expiration of the CA certificate at %s", notAfter.UTC().Format(time.RFC3339Nano), caSign.Certificate.NotAfter.UTC().Format(time.RFC3339Nano))}
 		}
 	}
-	return notAfter, warnings, nil
+	return notAfter, nil
 }
 
 func convertRespToPKCS8(resp *logical.Response) error {


### PR DESCRIPTION
 - Allow us to call and apply an issuer's leaf_not_after_behavior to a leaf certificate from various locations.