### PR TITLE
clarify when a entity is created

### DIFF
--- a/changelog/22233.txt
+++ b/changelog/22233.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+docs: Clarify when a entity is created
+```

--- a/website/content/docs/secrets/identity/index.mdx
+++ b/website/content/docs/secrets/identity/index.mdx
@@ -13,7 +13,7 @@ internally maintains the clients who are recognized by Vault. Each client is
 internally termed as an `Entity`. An entity can have multiple `Aliases`. For
 example, a single user who has accounts in both GitHub and LDAP, can be mapped
 to a single entity in Vault that has 2 aliases, one of type GitHub and one of
-type LDAP. When a client authenticates via any of the credential backends
+type LDAP. When a client authenticates successfully via any of the credential backends
 (except the Token backend), Vault creates a new entity and attaches a new
 alias to it, if a corresponding entity doesn't already exist. The entity identifier will
 be tied to the authenticated token. When such tokens are put to use, their


### PR DESCRIPTION
I think it is a good idea to clarify that the entity is only created if the authentication is successful.