### PR TITLE
Ignore errors from rollback manager invocations

### DIFF
--- a/changelog/22235.txt
+++ b/changelog/22235.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Log rollback manager failures during unmount, remount to prevent replication failures on secondary clusters.
+```

--- a/vault/external_tests/router/router_ext_test.go
+++ b/vault/external_tests/router/router_ext_test.go
@@ -70,7 +70,7 @@ func TestRouter_UnmountRollbackIsntFatal(t *testing.T) {
 	if _, err := client.Logical().Write("sys/plugins/reload/backend", map[string]interface{}{
 		"mounts": "noop",
 	}); err != nil {
-		t.Fatalf("expected remount of noop with broken periodic func to succeed; got err=%v", err)
+		t.Fatalf("expected reload of noop with broken periodic func to succeed; got err=%v", err)
 	}
 
 	if _, err := client.Logical().Write("sys/remount", map[string]interface{}{

--- a/vault/external_tests/router/router_ext_test.go
+++ b/vault/external_tests/router/router_ext_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/testhelpers/minimal"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/vault"
 )
 
 func TestRouter_MountSubpath_Checks(t *testing.T) {
@@ -49,4 +51,35 @@ func testRouter_MountSubpath(t *testing.T, mountPoints []string) {
 	cluster.EnsureCoresSealed(t)
 	cluster.UnsealCores(t)
 	t.Logf("Done: %#v", mountPoints)
+}
+
+func TestRouter_UnmountRollbackIsntFatal(t *testing.T) {
+	cluster := minimal.NewTestSoloCluster(t, &vault.CoreConfig{
+		LogicalBackends: map[string]logical.Factory{
+			"noop": vault.NoopBackendRollbackErrFactory,
+		},
+	})
+	client := cluster.Cores[0].Client
+
+	if err := client.Sys().Mount("noop", &api.MountInput{
+		Type: "noop",
+	}); err != nil {
+		t.Fatalf("failed to mount PKI: %v", err)
+	}
+
+	if _, err := client.Logical().Write("sys/plugins/reload/backend", map[string]interface{}{
+		"mounts": "noop",
+	}); err != nil {
+		t.Fatalf("expected remount of noop with broken periodic func to succeed; got err=%v", err)
+	}
+
+	if _, err := client.Logical().Write("sys/remount", map[string]interface{}{
+		"from": "noop",
+		"to":   "noop-to",
+	}); err != nil {
+		t.Fatalf("expected remount of noop with broken periodic func to succeed; got err=%v", err)
+	}
+
+	cluster.EnsureCoresSealed(t)
+	cluster.UnsealCores(t)
 }

--- a/vault/router_testing.go
+++ b/vault/router_testing.go
@@ -29,15 +29,25 @@ type NoopBackend struct {
 	DefaultLeaseTTL time.Duration
 	MaxLeaseTTL     time.Duration
 	BackendType     logical.BackendType
+
+	RollbackErrs bool
 }
 
 func NoopBackendFactory(_ context.Context, _ *logical.BackendConfig) (logical.Backend, error) {
 	return &NoopBackend{}, nil
 }
 
+func NoopBackendRollbackErrFactory(_ context.Context, _ *logical.BackendConfig) (logical.Backend, error) {
+	return &NoopBackend{RollbackErrs: true}, nil
+}
+
 func (n *NoopBackend) HandleRequest(ctx context.Context, req *logical.Request) (*logical.Response, error) {
 	if req.TokenEntry() != nil {
 		panic("got a non-nil TokenEntry")
+	}
+
+	if n.RollbackErrs && req.Operation == "rollback" {
+		return nil, fmt.Errorf("no-op backend rollback has erred out")
 	}
 
 	var err error


### PR DESCRIPTION
During reload and mount move operations, we want to ensure that errors created by the final Rollback are not fatal (which risk failing replication in Enterprise when the core/mounts table gets invalidated). This mirrors the behavior of the periodic rollback manager, which only logs the error.

This updates the noop backend to allow failing just rollback operations, which we can use in tests to verify this behavior and ensure the core operations (plugin reload, plugin move, and seal/unseal) are not broken by this. Note that most of these operations were asynchronous from the client's PoV and thus did not fail anyways prior to this change.

reg: VAULT-18857