### PR TITLE
docs/db: fix outdated static role information

### DIFF
--- a/website/content/api-docs/secret/databases/index.mdx
+++ b/website/content/api-docs/secret/databases/index.mdx
@@ -479,8 +479,7 @@ $ curl \
 
 This endpoint creates or updates a static role definition. Static Roles are a
 1-to-1 mapping of a Vault Role to a user in a database which are automatically
-rotated based on the configured `rotation_period`. Not all databases support
-Static Roles, please see the database-specific documentation.
+rotated based on the configured `rotation_period`.
 
 ~> This endpoint distinguishes between `create` and `update` ACL capabilities.
 


### PR DESCRIPTION
Backporting to 1.14.x so this change will be available on the website immediately