### PR TITLE
ui: remove `on input` event from `<input>` in `<FormField>` component

### DIFF
--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -302,7 +302,6 @@
           autocomplete="off"
           spellcheck="false"
           value={{or (get @model this.valuePath) @attr.options.defaultValue}}
-          {{on "input" this.onChangeWithEvent}}
           {{on "change" this.onChangeWithEvent}}
           {{on "keyup" this.handleKeyUp}}
           class="input {{if this.validationError 'has-error-border'}}"


### PR DESCRIPTION
Before fix:
The only way to change the default value was by `cmd + A` and selecting all using the keyboard. Clicking the backspace button reset the input to the default value. In the gif below I'm clicking `backspace` to no avail
![formfield](https://github.com/hashicorp/vault/assets/68122737/ab9114b0-f0a3-4c06-a482-0e7eb6fbb529)

After fix 🔧 
![formfield](https://github.com/hashicorp/vault/assets/68122737/37744585-7f7d-4061-82a4-9fb6f377ec3f)
