### PR TITLE
secrets/db: improves error logs for static role rotation

### DIFF
--- a/changelog/22253.txt
+++ b/changelog/22253.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/database: Improves error logging for static role rotations by including the database and role names.
+```


### PR DESCRIPTION
This PR improves the error logs that can result from failed database static role rotations by including the role and database names. This will help Vault operators know where to start troubleshooting when these logs appear.

Fixes: https://github.com/hashicorp/vault/issues/21433