### PR TITLE
VAULT-18157: Audit events:  Log Test Message

### DIFF
--- a/audit/nodes.go
+++ b/audit/nodes.go
@@ -5,6 +5,7 @@ package audit
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -19,6 +20,17 @@ import (
 // (Audit) Event will be of RequestType (as opposed to ResponseType).
 // The last node must be a sink node (eventlogger.NodeTypeSink).
 func ProcessManual(ctx context.Context, data *logical.LogInput, ids []eventlogger.NodeID, nodes map[eventlogger.NodeID]eventlogger.Node) error {
+	switch {
+	case data == nil:
+		return errors.New("data cannot be nil")
+	case len(ids) == 0:
+		return errors.New("ids are required")
+	case nodes == nil:
+		return errors.New("nodes cannot be nil")
+	case len(nodes) == 0:
+		return errors.New("nodes are required")
+	}
+
 	// Create an audit event.
 	a, err := NewEvent(RequestType)
 	if err != nil {
@@ -57,7 +69,7 @@ func ProcessManual(ctx context.Context, data *logical.LogInput, ids []eventlogge
 	}
 
 	if lastSeen != eventlogger.NodeTypeSink {
-		return fmt.Errorf("last node must be a sink: %v", lastSeen)
+		return errors.New("last node must be a sink")
 	}
 
 	return nil

--- a/audit/nodes.go
+++ b/audit/nodes.go
@@ -1,0 +1,64 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package audit
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/vault/internal/observability/event"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// ProcessManual will attempt to create an (audit) event with the specified data
+// and manually iterate over the supplied nodes calling Process on each.
+// Order of IDs in the NodeID slice determines the order they are processed.
+// (Audit) Event will be of RequestType (as opposed to ResponseType).
+// The last node must be a sink node (eventlogger.NodeTypeSink).
+func ProcessManual(ctx context.Context, data *logical.LogInput, ids []eventlogger.NodeID, nodes map[eventlogger.NodeID]eventlogger.Node) error {
+	// Create an audit event.
+	a, err := NewEvent(RequestType)
+	if err != nil {
+		return err
+	}
+
+	// Insert the data into the audit event.
+	a.Data = data
+
+	// Create an eventlogger event with the audit event as the payload.
+	e := &eventlogger.Event{
+		Type:      eventlogger.EventType(event.AuditType.String()),
+		CreatedAt: time.Now(),
+		Formatted: make(map[string][]byte),
+		Payload:   a,
+	}
+
+	var lastSeen eventlogger.NodeType
+
+	// Process nodes data order, updating the event with the result.
+	// This means we *should* do:
+	// 1. formatter
+	// 2. sink
+	for _, id := range ids {
+		node, ok := nodes[id]
+		if !ok {
+			return fmt.Errorf("node not found: %v", id)
+		}
+		e, err = node.Process(ctx, e)
+		if err != nil {
+			return err
+		}
+
+		// Track the last node we have processed, as we should end with a sink.
+		lastSeen = node.Type()
+	}
+
+	if lastSeen != eventlogger.NodeTypeSink {
+		return fmt.Errorf("last node must be a sink: %v", lastSeen)
+	}
+
+	return nil
+}

--- a/audit/nodes_test.go
+++ b/audit/nodes_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestProcessManual_NilData tests ProcessManual when nil data is supplied.
 func TestProcessManual_NilData(t *testing.T) {
 	t.Parallel()
 
@@ -40,6 +41,7 @@ func TestProcessManual_NilData(t *testing.T) {
 	require.EqualError(t, err, "data cannot be nil")
 }
 
+// TestProcessManual_NoIds tests ProcessManual when no IDs are supplied
 func TestProcessManual_NoIds(t *testing.T) {
 	t.Parallel()
 
@@ -64,6 +66,7 @@ func TestProcessManual_NoIds(t *testing.T) {
 	require.EqualError(t, err, "ids are required")
 }
 
+// TestProcessManual_NoNodes tests ProcessManual when no nodes are supplied.
 func TestProcessManual_NoNodes(t *testing.T) {
 	t.Parallel()
 
@@ -88,6 +91,8 @@ func TestProcessManual_NoNodes(t *testing.T) {
 	require.EqualError(t, err, "nodes are required")
 }
 
+// TestProcessManual_IdNodeMismatch tests ProcessManual when IDs don't match with
+// the nodes in the supplied map.
 func TestProcessManual_IdNodeMismatch(t *testing.T) {
 	t.Parallel()
 
@@ -113,6 +118,8 @@ func TestProcessManual_IdNodeMismatch(t *testing.T) {
 	require.ErrorContains(t, err, "node not found: ")
 }
 
+// TestProcessManual_LastNodeNotSink tests ProcessManual when the last node (by ID)
+// is not an eventlogger.NodeTypeSink.
 func TestProcessManual_LastNodeNotSink(t *testing.T) {
 	t.Parallel()
 
@@ -135,7 +142,7 @@ func TestProcessManual_LastNodeNotSink(t *testing.T) {
 }
 
 // TestProcessManual ensures that the manual processing of a test message works
-// as expected, covering various inputs.
+// as expected with proper inputs.
 func TestProcessManual(t *testing.T) {
 	t.Parallel()
 

--- a/audit/nodes_test.go
+++ b/audit/nodes_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package audit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/vault/helper/namespace"
+
+	"github.com/hashicorp/go-uuid"
+
+	"github.com/hashicorp/vault/sdk/logical"
+
+	"github.com/hashicorp/eventlogger"
+
+	"github.com/hashicorp/vault/internal/observability/event"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProcessManual ensures that the manual processing of a test message works
+// as expected, covering various inputs.
+func TestProcessManual(t *testing.T) {
+	tests := map[string]struct {
+		IsErrorExpected        bool
+		IsErrorContains        bool
+		ExpectedErrorMessage   string
+		ShouldUseData          bool
+		ShouldUseIDs           bool
+		ShouldUseNodes         bool
+		ShouldCreateFilterNode bool
+		ShouldCreateSinkNode   bool
+		ShouldMatchIdToFilter  bool
+		ShouldMatchIdToSink    bool
+	}{
+		"nil-data": {
+			IsErrorExpected:        true,
+			IsErrorContains:        false,
+			ExpectedErrorMessage:   "data cannot be nil",
+			ShouldUseData:          false,
+			ShouldUseIDs:           false,
+			ShouldUseNodes:         false,
+			ShouldCreateFilterNode: false,
+			ShouldCreateSinkNode:   false,
+			ShouldMatchIdToFilter:  false,
+			ShouldMatchIdToSink:    false,
+		},
+		"no-ids": {
+			IsErrorExpected:        true,
+			IsErrorContains:        false,
+			ExpectedErrorMessage:   "ids are required",
+			ShouldUseData:          true,
+			ShouldUseIDs:           false,
+			ShouldUseNodes:         false,
+			ShouldCreateFilterNode: false,
+			ShouldCreateSinkNode:   false,
+			ShouldMatchIdToFilter:  false,
+			ShouldMatchIdToSink:    false,
+		},
+		"no-nodes": {
+			IsErrorExpected:        true,
+			IsErrorContains:        false,
+			ExpectedErrorMessage:   "nodes are required",
+			ShouldUseData:          true,
+			ShouldUseIDs:           true,
+			ShouldUseNodes:         true,
+			ShouldCreateFilterNode: true,
+			ShouldCreateSinkNode:   true,
+			ShouldMatchIdToFilter:  false,
+			ShouldMatchIdToSink:    false,
+		},
+		"id-node-mismatch": {
+			IsErrorExpected:        true,
+			IsErrorContains:        true,
+			ExpectedErrorMessage:   "node not found",
+			ShouldUseData:          true,
+			ShouldUseIDs:           true,
+			ShouldUseNodes:         true,
+			ShouldCreateFilterNode: true,
+			ShouldMatchIdToFilter:  true,
+			ShouldCreateSinkNode:   true,
+			ShouldMatchIdToSink:    false,
+		},
+		"last-node-not-sink": {
+			IsErrorExpected:        true,
+			IsErrorContains:        false,
+			ExpectedErrorMessage:   "last node must be a sink",
+			ShouldUseData:          true,
+			ShouldUseIDs:           true,
+			ShouldUseNodes:         true,
+			ShouldCreateFilterNode: true,
+			ShouldCreateSinkNode:   false,
+			ShouldMatchIdToFilter:  true,
+			ShouldMatchIdToSink:    false,
+		},
+		"normal-operation": {
+			IsErrorExpected:        false,
+			ShouldUseData:          true,
+			ShouldUseIDs:           true,
+			ShouldUseNodes:         true,
+			ShouldCreateFilterNode: true,
+			ShouldCreateSinkNode:   true,
+			ShouldMatchIdToFilter:  true,
+			ShouldMatchIdToSink:    true,
+		},
+	}
+
+	for name, tc := range tests {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var ids []eventlogger.NodeID
+			var nodes map[eventlogger.NodeID]eventlogger.Node
+			var data *logical.LogInput
+
+			if tc.ShouldUseNodes {
+				nodes = make(map[eventlogger.NodeID]eventlogger.Node)
+
+				if tc.ShouldCreateFilterNode {
+					filterId, filterNode := newFilterNode(t)
+
+					if tc.ShouldUseIDs {
+						ids = append(ids, filterId)
+					}
+
+					if tc.ShouldMatchIdToFilter {
+						nodes[filterId] = filterNode
+					}
+				}
+
+				if tc.ShouldCreateSinkNode {
+					sinkId, sinkNode := newSinkNode(t)
+					if tc.ShouldUseIDs {
+						ids = append(ids, sinkId)
+					}
+
+					if tc.ShouldMatchIdToSink {
+						nodes[sinkId] = sinkNode
+					}
+				}
+			}
+
+			if tc.ShouldUseData {
+				requestId, err := uuid.GenerateUUID()
+				require.NoError(t, err)
+				data = newData(requestId)
+			}
+
+			err := ProcessManual(namespace.RootContext(context.Background()), data, ids, nodes)
+			if tc.IsErrorExpected {
+				require.Error(t, err)
+				if tc.IsErrorContains {
+					require.ErrorContains(t, err, tc.ExpectedErrorMessage)
+				} else {
+					require.EqualError(t, err, tc.ExpectedErrorMessage)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// newFilterNode creates a new UUID and EntryFormatter (filter node).
+func newFilterNode(t *testing.T) (eventlogger.NodeID, *EntryFormatter) {
+	t.Helper()
+
+	filterId, err := event.GenerateNodeID()
+	require.NoError(t, err)
+	cfg, err := NewFormatterConfig()
+	require.NoError(t, err)
+	filterNode, err := NewEntryFormatter(cfg, newStaticSalt(t))
+	require.NoError(t, err)
+
+	return filterId, filterNode
+}
+
+// newSinkNode creates a new UUID and NoopSink (sink node).
+func newSinkNode(t *testing.T) (eventlogger.NodeID, *event.NoopSink) {
+	t.Helper()
+
+	sinkId, err := event.GenerateNodeID()
+	require.NoError(t, err)
+	sinkNode := event.NewNoopSink()
+
+	return sinkId, sinkNode
+}
+
+// newData creates a sample logical.LogInput to be used as data for tests.
+func newData(id string) *logical.LogInput {
+	return &logical.LogInput{
+		Type: "request",
+		Auth: nil,
+		Request: &logical.Request{
+			ID:        id,
+			Operation: "update",
+			Path:      "sys/audit/test",
+		},
+		Response: nil,
+		OuterErr: nil,
+	}
+}

--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/hashicorp/eventlogger"
 	"github.com/hashicorp/vault/audit"
@@ -331,62 +330,30 @@ func (b *Backend) LogResponse(ctx context.Context, in *logical.LogInput) error {
 func (b *Backend) LogTestMessage(ctx context.Context, in *logical.LogInput, config map[string]string) error {
 	// Event logger behavior - manually Process each node
 	if len(b.nodeIDList) > 0 {
-		// Create an audit event.
-		a, err := audit.NewEvent(audit.RequestType)
-		if err != nil {
-			return err
-		}
-
-		// Insert the data into the audit event.
-		a.Data = in
-
-		// Create an eventlogger event with the audit event as the payload.
-		e := &eventlogger.Event{
-			Type:      eventlogger.EventType(event.AuditType.String()),
-			CreatedAt: time.Now(),
-			Formatted: make(map[string][]byte),
-			Payload:   a,
-		}
-
-		// Process nodes in order, updating the event with the result.
-		// This means we *should* do:
-		// 1. formatter
-		// 2. sink
-		for _, id := range b.nodeIDList {
-			node, ok := b.nodeMap[id]
-			if !ok {
-				return fmt.Errorf("node not found: %v", id)
-			}
-			e, err = node.Process(ctx, e)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
-	} else {
-		// Old behavior
-		var writer io.Writer
-		switch b.path {
-		case "stdout":
-			writer = os.Stdout
-		case "discard":
-			return nil
-		}
-
-		var buf bytes.Buffer
-
-		temporaryFormatter, err := audit.NewTemporaryFormatter(config["format"], config["prefix"])
-		if err != nil {
-			return err
-		}
-
-		if err = temporaryFormatter.FormatAndWriteRequest(ctx, &buf, in); err != nil {
-			return err
-		}
-
-		return b.log(ctx, &buf, writer)
+		return audit.ManuallyProcess(ctx, in, b.nodeIDList, b.nodeMap)
 	}
+
+	// Old behavior
+	var writer io.Writer
+	switch b.path {
+	case "stdout":
+		writer = os.Stdout
+	case "discard":
+		return nil
+	}
+
+	var buf bytes.Buffer
+
+	temporaryFormatter, err := audit.NewTemporaryFormatter(config["format"], config["prefix"])
+	if err != nil {
+		return err
+	}
+
+	if err = temporaryFormatter.FormatAndWriteRequest(ctx, &buf, in); err != nil {
+		return err
+	}
+
+	return b.log(ctx, &buf, writer)
 }
 
 // The file lock must be held before calling this

--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -330,7 +330,7 @@ func (b *Backend) LogResponse(ctx context.Context, in *logical.LogInput) error {
 func (b *Backend) LogTestMessage(ctx context.Context, in *logical.LogInput, config map[string]string) error {
 	// Event logger behavior - manually Process each node
 	if len(b.nodeIDList) > 0 {
-		return audit.ManuallyProcess(ctx, in, b.nodeIDList, b.nodeMap)
+		return audit.ProcessManual(ctx, in, b.nodeIDList, b.nodeMap)
 	}
 
 	// Old behavior

--- a/builtin/audit/socket/backend.go
+++ b/builtin/audit/socket/backend.go
@@ -224,32 +224,70 @@ func (b *Backend) LogResponse(ctx context.Context, in *logical.LogInput) error {
 }
 
 func (b *Backend) LogTestMessage(ctx context.Context, in *logical.LogInput, config map[string]string) error {
-	var buf bytes.Buffer
-
-	temporaryFormatter, err := audit.NewTemporaryFormatter(config["format"], config["prefix"])
-	if err != nil {
-		return err
-	}
-
-	if err = temporaryFormatter.FormatAndWriteRequest(ctx, &buf, in); err != nil {
-		return err
-	}
-
-	b.Lock()
-	defer b.Unlock()
-
-	err = b.write(ctx, buf.Bytes())
-	if err != nil {
-		rErr := b.reconnect(ctx)
-		if rErr != nil {
-			err = multierror.Append(err, rErr)
-		} else {
-			// Try once more after reconnecting
-			err = b.write(ctx, buf.Bytes())
+	// Event logger behavior - manually Process each node
+	if len(b.nodeIDList) > 0 {
+		// Create an audit event.
+		a, err := audit.NewEvent(audit.RequestType)
+		if err != nil {
+			return err
 		}
-	}
 
-	return err
+		// Insert the data into the audit event.
+		a.Data = in
+
+		// Create an eventlogger event with the audit event as the payload.
+		e := &eventlogger.Event{
+			Type:      eventlogger.EventType(event.AuditType.String()),
+			CreatedAt: time.Now(),
+			Formatted: make(map[string][]byte),
+			Payload:   a,
+		}
+
+		// Process nodes in order, updating the event with the result.
+		// This means we *should* do:
+		// 1. formatter
+		// 2. sink
+		for _, id := range b.nodeIDList {
+			node, ok := b.nodeMap[id]
+			if !ok {
+				return fmt.Errorf("node not found: %v", id)
+			}
+			e, err = node.Process(ctx, e)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	} else {
+		// Old behavior
+		var buf bytes.Buffer
+
+		temporaryFormatter, err := audit.NewTemporaryFormatter(config["format"], config["prefix"])
+		if err != nil {
+			return err
+		}
+
+		if err = temporaryFormatter.FormatAndWriteRequest(ctx, &buf, in); err != nil {
+			return err
+		}
+
+		b.Lock()
+		defer b.Unlock()
+
+		err = b.write(ctx, buf.Bytes())
+		if err != nil {
+			rErr := b.reconnect(ctx)
+			if rErr != nil {
+				err = multierror.Append(err, rErr)
+			} else {
+				// Try once more after reconnecting
+				err = b.write(ctx, buf.Bytes())
+			}
+		}
+
+		return err
+	}
 }
 
 func (b *Backend) write(ctx context.Context, buf []byte) error {

--- a/builtin/audit/syslog/backend.go
+++ b/builtin/audit/syslog/backend.go
@@ -191,7 +191,7 @@ func (b *Backend) LogResponse(ctx context.Context, in *logical.LogInput) error {
 func (b *Backend) LogTestMessage(ctx context.Context, in *logical.LogInput, config map[string]string) error {
 	// Event logger behavior - manually Process each node
 	if len(b.nodeIDList) > 0 {
-		return audit.ManuallyProcess(ctx, in, b.nodeIDList, b.nodeMap)
+		return audit.ProcessManual(ctx, in, b.nodeIDList, b.nodeMap)
 	}
 
 	// Old behavior

--- a/builtin/audit/syslog/backend.go
+++ b/builtin/audit/syslog/backend.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/hashicorp/eventlogger"
 	gsyslog "github.com/hashicorp/go-syslog"
@@ -192,56 +191,24 @@ func (b *Backend) LogResponse(ctx context.Context, in *logical.LogInput) error {
 func (b *Backend) LogTestMessage(ctx context.Context, in *logical.LogInput, config map[string]string) error {
 	// Event logger behavior - manually Process each node
 	if len(b.nodeIDList) > 0 {
-		// Create an audit event.
-		a, err := audit.NewEvent(audit.RequestType)
-		if err != nil {
-			return err
-		}
+		return audit.ManuallyProcess(ctx, in, b.nodeIDList, b.nodeMap)
+	}
 
-		// Insert the data into the audit event.
-		a.Data = in
+	// Old behavior
+	var buf bytes.Buffer
 
-		// Create an eventlogger event with the audit event as the payload.
-		e := &eventlogger.Event{
-			Type:      eventlogger.EventType(event.AuditType.String()),
-			CreatedAt: time.Now(),
-			Formatted: make(map[string][]byte),
-			Payload:   a,
-		}
-
-		// Process nodes in order, updating the event with the result.
-		// This means we *should* do:
-		// 1. formatter
-		// 2. sink
-		for _, id := range b.nodeIDList {
-			node, ok := b.nodeMap[id]
-			if !ok {
-				return fmt.Errorf("node not found: %v", id)
-			}
-			e, err = node.Process(ctx, e)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
-	} else {
-		// Old behavior
-		var buf bytes.Buffer
-
-		temporaryFormatter, err := audit.NewTemporaryFormatter(config["format"], config["prefix"])
-		if err != nil {
-			return err
-		}
-
-		if err = temporaryFormatter.FormatAndWriteRequest(ctx, &buf, in); err != nil {
-			return err
-		}
-
-		// Send to syslog
-		_, err = b.logger.Write(buf.Bytes())
+	temporaryFormatter, err := audit.NewTemporaryFormatter(config["format"], config["prefix"])
+	if err != nil {
 		return err
 	}
+
+	if err = temporaryFormatter.FormatAndWriteRequest(ctx, &buf, in); err != nil {
+		return err
+	}
+
+	// Send to syslog
+	_, err = b.logger.Write(buf.Bytes())
+	return err
 }
 
 func (b *Backend) Reload(_ context.Context) error {

--- a/builtin/audit/syslog/backend.go
+++ b/builtin/audit/syslog/backend.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/eventlogger"
 	gsyslog "github.com/hashicorp/go-syslog"
@@ -189,20 +190,58 @@ func (b *Backend) LogResponse(ctx context.Context, in *logical.LogInput) error {
 }
 
 func (b *Backend) LogTestMessage(ctx context.Context, in *logical.LogInput, config map[string]string) error {
-	var buf bytes.Buffer
+	// Event logger behavior - manually Process each node
+	if len(b.nodeIDList) > 0 {
+		// Create an audit event.
+		a, err := audit.NewEvent(audit.RequestType)
+		if err != nil {
+			return err
+		}
 
-	temporaryFormatter, err := audit.NewTemporaryFormatter(config["format"], config["prefix"])
-	if err != nil {
+		// Insert the data into the audit event.
+		a.Data = in
+
+		// Create an eventlogger event with the audit event as the payload.
+		e := &eventlogger.Event{
+			Type:      eventlogger.EventType(event.AuditType.String()),
+			CreatedAt: time.Now(),
+			Formatted: make(map[string][]byte),
+			Payload:   a,
+		}
+
+		// Process nodes in order, updating the event with the result.
+		// This means we *should* do:
+		// 1. formatter
+		// 2. sink
+		for _, id := range b.nodeIDList {
+			node, ok := b.nodeMap[id]
+			if !ok {
+				return fmt.Errorf("node not found: %v", id)
+			}
+			e, err = node.Process(ctx, e)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	} else {
+		// Old behavior
+		var buf bytes.Buffer
+
+		temporaryFormatter, err := audit.NewTemporaryFormatter(config["format"], config["prefix"])
+		if err != nil {
+			return err
+		}
+
+		if err = temporaryFormatter.FormatAndWriteRequest(ctx, &buf, in); err != nil {
+			return err
+		}
+
+		// Send to syslog
+		_, err = b.logger.Write(buf.Bytes())
 		return err
 	}
-
-	if err = temporaryFormatter.FormatAndWriteRequest(ctx, &buf, in); err != nil {
-		return err
-	}
-
-	// Send to syslog
-	_, err = b.logger.Write(buf.Bytes())
-	return err
 }
 
 func (b *Backend) Reload(_ context.Context) error {


### PR DESCRIPTION
This PR brings parity for logging a test probe message (unless `skip_test` option is supplied) when enabling an audit device.