### PR TITLE
UI: [VAULT-17055] Cleanup TODOs and make sure sidebar tests are up-to-date

### DIFF
--- a/ui/app/components/sidebar/nav/cluster.hbs
+++ b/ui/app/components/sidebar/nav/cluster.hbs
@@ -1,7 +1,6 @@
 <Hds::SideNav::Portal @ariaLabel="Cluster Navigation Links" data-test-sidebar-nav-panel="Cluster" as |Nav|>
   <Nav.Title data-test-sidebar-nav-heading="Vault">Vault</Nav.Title>
 
-  {{! TODO LANDING PAGE: VAULT-17055 hide dashboard nav link when user isn't opted into the new dashboard ui }}
   <Nav.Link @route="vault.cluster.dashboard" @text="Dashboard" data-test-sidebar-nav-link="Dashboard" />
   <Nav.Link
     @route="vault.cluster.secrets"

--- a/ui/app/routes/vault/cluster/secrets/backends.js
+++ b/ui/app/routes/vault/cluster/secrets/backends.js
@@ -11,6 +11,9 @@ export default Route.extend({
 
   model() {
     // TODO LANDING PAGE: VAULT-17008 use peekAll to avoid a network request
+    if (this.store.peekAll('secret-engine', {}).length) {
+      return this.store.peekAll('secret-engine', {});
+    }
 
     return this.store.query('secret-engine', {});
   },

--- a/ui/app/routes/vault/cluster/secrets/backends.js
+++ b/ui/app/routes/vault/cluster/secrets/backends.js
@@ -10,10 +10,6 @@ export default Route.extend({
   store: service(),
 
   model() {
-    if (this.store.peekAll('secret-engine', {}).length) {
-      return this.store.peekAll('secret-engine', {});
-    }
-
     return this.store.query('secret-engine', {});
   },
 });

--- a/ui/app/routes/vault/cluster/secrets/backends.js
+++ b/ui/app/routes/vault/cluster/secrets/backends.js
@@ -10,7 +10,6 @@ export default Route.extend({
   store: service(),
 
   model() {
-    // TODO LANDING PAGE: VAULT-17008 use peekAll to avoid a network request
     if (this.store.peekAll('secret-engine', {}).length) {
       return this.store.peekAll('secret-engine', {});
     }

--- a/ui/app/styles/components/vault-version-title.scss
+++ b/ui/app/styles/components/vault-version-title.scss
@@ -1,6 +1,0 @@
-.new-features-modal-button:hover,
-.new-features-modal-button:active,
-.new-features-modal-button:focus {
-  @extend .hds-highlight-background;
-  @extend .hds-purple-text;
-}

--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -120,5 +120,4 @@
 @import './components/unseal-warning';
 // @import './components/ui-wizard'; // remove, see PR https://github.com/hashicorp/vault/pull/19220
 @import './components/vault-loading';
-@import './components/vault-version-title';
 @import './components/vlt-table';

--- a/ui/app/styles/helper-classes/colors.scss
+++ b/ui/app/styles/helper-classes/colors.scss
@@ -79,10 +79,3 @@ select.has-error-border {
 .has-text-danger {
   color: $red-500 !important;
 }
-
-.hds-highlight-background {
-  background-color: var(--token-color-palette-purple-100);
-}
-.hds-purple-text {
-  color: var(--token-color-palette-purple-300);
-}

--- a/ui/app/templates/components/dashboard/vault-version-title.hbs
+++ b/ui/app/templates/components/dashboard/vault-version-title.hbs
@@ -3,44 +3,6 @@
     {{this.versionHeader}}
   </h1>
   <span class="has-left-margin-xxs">
-    <Hds::Button
-      @text="New"
-      @color="secondary"
-      @size="small"
-      @icon="wand"
-      class="hds-highlight-background hds-purple-text is-borderless is-shadowless is-underline has-text-weight-semibold new-features-modal-button"
-      {{on "click" (fn (mut this.showNewFeatureModal) true)}}
-    />
-  </span>
-  <span class="has-left-margin-xxs">
     <Hds::Badge @text={{this.namespaceDisplay}} @icon="org" data-test-badge-namespace />
   </span>
 </div>
-
-<Modal
-  @title="New dashboard"
-  @onClose={{action (mut this.showNewFeatureModal) false}}
-  @isActive={{this.showNewFeatureModal}}
-  @showCloseButton={{true}}
->
-  <section class="modal-card-body has-top-padding-l has-bottom-padding-l">
-    <div>
-      <div class="has-bottom-margin-s">
-        Vault now has a dashboard that includes, among other things:
-      </div>
-      <ul class="bullet">
-        <li>An overview of Vault's metrics, shortcuts, and at-a-glance information</li>
-        <li>Configuration details such as cluster address, TTL, TLS, log format, and storage type</li>
-        <li>Quick actions: perform important tasks such as finding a secret or generating a leaf certificate</li>
-      </ul>
-      <div class="has-top-margin-s">
-        You can still access the Secrets engines page on the sidebar.
-      </div>
-    </div>
-  </section>
-  <footer class="modal-card-foot modal-card-foot-outlined">
-    <button type="button" class="button is-primary" {{on "click" (fn (mut this.showNewFeatureModal) false)}}>
-      Got it
-    </button>
-  </footer>
-</Modal>

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -108,7 +108,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
     return authPage.login();
   });
 
-  // TODO LANDING PAGE: create a test that will navigate to dashboard if user opts into new dashboard ui
   test('navigate to dashboard on login', async function (assert) {
     assert.strictEqual(currentURL(), '/vault/dashboard');
   });

--- a/ui/tests/integration/components/dashboard/quick-actions-card-test.js
+++ b/ui/tests/integration/components/dashboard/quick-actions-card-test.js
@@ -11,7 +11,7 @@ import { fillIn } from '@ember/test-helpers';
 
 import { selectChoose } from 'ember-power-select/test-support/helpers';
 
-// // TODO LANDING PAGE: create SELECTORS for the data-test attributes
+// TODO LANDING PAGE: create SELECTORS for the data-test attributes
 
 module('Integration | Component | dashboard/quick-actions-card', function (hooks) {
   setupRenderingTest(hooks);

--- a/ui/tests/integration/components/sidebar/nav/cluster-test.js
+++ b/ui/tests/integration/components/sidebar/nav/cluster-test.js
@@ -32,7 +32,6 @@ module('Integration | Component | sidebar-nav-cluster', function (hooks) {
 
   test('it should hide links and headings user does not have access too', async function (assert) {
     await renderComponent();
-    // TODO LANDING PAGE: VAULT-17055 update this test once dashboard has localStorage set up!
     assert
       .dom('[data-test-sidebar-nav-link]')
       .exists({ count: 2 }, 'Nav links are hidden other than secrets and dashboard');


### PR DESCRIPTION
**Description**
- **VAULT-17055** - Remove TODO comments
- **VAULT-17109** - [Explored](https://github.com/hashicorp/vault/pull/22244/commits/a61c7745a4c8a56abd312871d7920d222bc7d354#diff-636c69915fbde5da85569c4c2babdd70021d21c96fd4c9712b7508317f4b06d9) updating the `backends` route to use `peekAll` if the model exists, but ran into issues with the ui console refresh. If the user adds a new engine by running this command `write sys/mounts/console-route-1 type=kv` in the ui console and then type `refresh`, the records are already loaded when we transition to `backends` from the `refreshRoute` in the [ui-panel](https://github.com/hashicorp/vault/blob/263614051db68487b433e6eb2dadb95a1a180648/ui/app/components/console/ui-panel.js#L97) and can't determine whether we want to do a `peekAll` or `query` in the backends route unless we use query params
- Remove New button and modal from the dashboard (the next PR will contain the new modal features)

This branch is from the commits of https://github.com/hashicorp/vault/pull/22244. Going to separate the modal vs minor cleanup tickets.
