### PR TITLE
command/healthcheck: fix dropped error

### DIFF
--- a/command/healthcheck/pki_enable_acme_issuance.go
+++ b/command/healthcheck/pki_enable_acme_issuance.go
@@ -74,8 +74,7 @@ func (h *EnableAcmeIssuance) FetchResources(e *Executor) error {
 	}
 
 	h.TotalIssuers, h.RootIssuers, err = doesMountContainOnlyRootIssuers(e)
-
-	return nil
+	return err
 }
 
 func doesMountContainOnlyRootIssuers(e *Executor) (int, int, error) {


### PR DESCRIPTION
This fixes a dropped `err` variable in `command/healthcheck`.