### PR TITLE
Share the same mssql container across all four subtests.

### DIFF
--- a/plugins/database/mssql/mssql_test.go
+++ b/plugins/database/mssql/mssql_test.go
@@ -192,13 +192,13 @@ func TestUpdateUser_password(t *testing.T) {
 		expectedPassword string
 	}
 
-	dbUser := "vaultuser"
+	cleanup, connURL := mssqlhelper.PrepareMSSQLTestContainer(t)
+	defer cleanup()
 	initPassword := "p4$sw0rd"
 
 	tests := map[string]testCase{
 		"missing password": {
 			req: dbplugin.UpdateUserRequest{
-				Username: dbUser,
 				Password: &dbplugin.ChangePassword{
 					NewPassword: "",
 					Statements:  dbplugin.Statements{},
@@ -209,7 +209,6 @@ func TestUpdateUser_password(t *testing.T) {
 		},
 		"empty rotation statements": {
 			req: dbplugin.UpdateUserRequest{
-				Username: dbUser,
 				Password: &dbplugin.ChangePassword{
 					NewPassword: "N90gkKLy8$angf",
 					Statements:  dbplugin.Statements{},
@@ -220,7 +219,6 @@ func TestUpdateUser_password(t *testing.T) {
 		},
 		"username rotation": {
 			req: dbplugin.UpdateUserRequest{
-				Username: dbUser,
 				Password: &dbplugin.ChangePassword{
 					NewPassword: "N90gkKLy8$angf",
 					Statements: dbplugin.Statements{
@@ -235,7 +233,6 @@ func TestUpdateUser_password(t *testing.T) {
 		},
 		"bad statements": {
 			req: dbplugin.UpdateUserRequest{
-				Username: dbUser,
 				Password: &dbplugin.ChangePassword{
 					NewPassword: "N90gkKLy8$angf",
 					Statements: dbplugin.Statements{
@@ -250,11 +247,9 @@ func TestUpdateUser_password(t *testing.T) {
 		},
 	}
 
+	i := 0
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			cleanup, connURL := mssqlhelper.PrepareMSSQLTestContainer(t)
-			defer cleanup()
-
 			initReq := dbplugin.InitializeRequest{
 				Config: map[string]interface{}{
 					"connection_url": connURL,
@@ -266,6 +261,9 @@ func TestUpdateUser_password(t *testing.T) {
 			dbtesting.AssertInitializeCircleCiTest(t, db, initReq)
 			defer dbtesting.AssertClose(t, db)
 
+			dbUser := fmt.Sprintf("vaultuser%d", i)
+			test.req.Username = dbUser
+			i++
 			err := createTestMSSQLUser(connURL, dbUser, initPassword, testMSSQLLogin)
 			if err != nil {
 				t.Fatalf("Failed to create user: %s", err)


### PR DESCRIPTION
I don't know if this will make the test less flaky or not, but we're seeing a lot of timeouts, and I know the container is quite heavyweight.  If nothing else this will make CI cheaper.