### PR TITLE
documenting missing option

### DIFF
--- a/website/content/docs/audit/socket.mdx
+++ b/website/content/docs/audit/socket.mdx
@@ -39,3 +39,5 @@ these device-specific options:
   with <a href="https://golang.org/pkg/net/#Dial">net.Dial</a> is acceptable. It's
   important to note if TCP is used and the destination socket becomes unavailable
   Vault may become unresponsive per [Blocked Audit Devices](/vault/docs/audit/#blocked-audit-devices).
+
+- `write_timeout` `(string: 2s)` - The (deadline) time in seconds to allow writes to be completed over the socket.

--- a/website/content/docs/audit/socket.mdx
+++ b/website/content/docs/audit/socket.mdx
@@ -41,3 +41,4 @@ these device-specific options:
   Vault may become unresponsive per [Blocked Audit Devices](/vault/docs/audit/#blocked-audit-devices).
 
 - `write_timeout` `(string: 2s)` - The (deadline) time in seconds to allow writes to be completed over the socket.
+  A zero value means that write attempts will *not* time out.


### PR DESCRIPTION
Socket audit device has a configurable setting that doesn't appear in our documentation: `write_timeout`.

This PR updates the docs to reflect the availability of the option (and backports to older versions).