### PR TITLE
Improve docs around enable_rate_limit_response_headers

### DIFF
--- a/website/content/api-docs/system/quotas-config.mdx
+++ b/website/content/api-docs/system/quotas-config.mdx
@@ -21,7 +21,17 @@ The `/sys/quotas/config` endpoint is used to configure rate limit quotas.
 - `enable_rate_limit_audit_logging` `(bool: false)` - If set, starts audit logging
   of requests that get rejected due to rate limit quota rule violations.
 - `enable_rate_limit_response_headers` `(bool: false)` - If set, additional rate
-  limit quota HTTP headers will be added to responses.
+  limit quota HTTP headers will be added to responses. These include:
+  - `Retry-After`: If the request is blocked due to rate limiting, this will
+    be a suggested time, in seconds, to wait before retry after. The time suggested
+    will be the amount of time in seconds remaining before the rate limit quota
+    applicable to this request is reset. Identical to the `X-Ratelimit-Reset` header.
+  - `X-Ratelimit-Limit`: The limit of the rate limit quota applicable to this request.
+  - `X-Ratelimit-Remaining`: The remaining requests in the current interval for the
+    rate limit quota applicable to this request.
+  - `X-Ratelimit-Reset` The amount of time in seconds remaining before the rate limit quota
+    applicable to this request is reset. Identical to the `Retry-After` header.
+
 
 ### Sample payload
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/vault/issues/21904

We have poor documentation around the `enable_rate_limit_response_headers` feature today, where we don't describe what the headers are that are being enabled. I've added documentation describing these headers and what they mean.

https://vault-73hnne0n9-hashicorp.vercel.app/vault/api-docs/system/quotas-config

Updated looks like this:
<img width="703" alt="image" src="https://github.com/hashicorp/vault/assets/1594272/35e2fb91-f5f2-459e-8e51-6593727cb25b">
