### PR TITLE
UI: add deletion_time to details

### DIFF
--- a/ui/app/models/kv/data.js
+++ b/ui/app/models/kv/data.js
@@ -72,6 +72,10 @@ export default class KvSecretDataModel extends Model {
   @attr('number', { defaultValue: 0 })
   casVersion;
 
+  get state() {
+    return this.destroyed ? 'destroyed' : this.deletionTime ? 'deleted' : 'created';
+  }
+
   // Permissions
   @lazyCapabilities(apiPath`${'backend'}/data/${'path'}`, 'backend', 'path') dataPath;
   @lazyCapabilities(apiPath`${'backend'}/metadata/${'path'}`, 'backend', 'path') metadataPath;

--- a/ui/lib/kv/addon/components/kv-tooltip-timestamp.hbs
+++ b/ui/lib/kv/addon/components/kv-tooltip-timestamp.hbs
@@ -1,0 +1,14 @@
+{{! renders a human readable date with a tooltip containing the API timestamp}}
+<ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
+  <T.Trigger data-test-kv-version-tooltip-trigger tabindex="-1">
+    {{#if @text}}
+      {{@text}}
+    {{/if}}
+    {{date-format @timestamp "MMM dd, yyyy hh:mm a"}}
+  </T.Trigger>
+  <T.Content @defaultClass="tool-tip smaller-font">
+    <div class="box" data-test-hover-copy-tooltip-text>
+      {{@timestamp}}
+    </div>
+  </T.Content>
+</ToolTip>

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -30,14 +30,14 @@
 {{#if (not-eq @secret.state "destroyed")}}
   <div class="info-table-row-header">
     <div class="info-table-row thead {{if this.showJsonView 'is-shadowless'}} ">
-      {{#if (and (not this.showJsonView) (not this.emptyState))}}
+      {{#unless this.hideHeaders}}
         <div class="th column is-one-quarter">
           Key
         </div>
         <div class="th column">
           Value
         </div>
-      {{/if}}
+      {{/unless}}
       <div class="th column justify-right">
         {{#if (eq @secret.state "created")}}
           <KvTooltipTimestamp

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -27,31 +27,33 @@
   </:toolbarActions>
 </KvPageHeader>
 
-<div class="info-table-row-header">
-  <div class="info-table-row thead {{if this.showJsonView 'is-shadowless'}} ">
-    {{#if (and (not this.showJsonView) (not this.emptyState))}}
-      <div class="th column is-one-quarter">
-        Key
-      </div>
-      <div class="th column">
-        Value
-      </div>
-    {{/if}}
-    <div class="th column justify-right">
-      {{#if (eq @secret.state "created")}}
-        <KvTooltipTimestamp
-          @text="Version {{if @secret.version @secret.version}} created"
-          @timestamp={{@secret.createdTime}}
-        />
-      {{else if (eq @secret.state "deleted")}}
-        <KvTooltipTimestamp
-          @text="Version {{if @secret.version @secret.version}} deleted"
-          @timestamp={{@secret.deletionTime}}
-        />
+{{#if (not-eq @secret.state "destroyed")}}
+  <div class="info-table-row-header">
+    <div class="info-table-row thead {{if this.showJsonView 'is-shadowless'}} ">
+      {{#if (and (not this.showJsonView) (not this.emptyState))}}
+        <div class="th column is-one-quarter">
+          Key
+        </div>
+        <div class="th column">
+          Value
+        </div>
       {{/if}}
+      <div class="th column justify-right">
+        {{#if (eq @secret.state "created")}}
+          <KvTooltipTimestamp
+            @text="Version {{if @secret.version @secret.version}} created"
+            @timestamp={{@secret.createdTime}}
+          />
+        {{else if (eq @secret.state "deleted")}}
+          <KvTooltipTimestamp
+            @text="Version {{if @secret.version @secret.version}} deleted"
+            @timestamp={{@secret.deletionTime}}
+          />
+        {{/if}}
+      </div>
     </div>
   </div>
-</div>
+{{/if}}
 
 {{#if this.emptyState}}
   <EmptyState @title={{this.emptyState.title}} @message={{this.emptyState.message}}>

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -27,44 +27,39 @@
   </:toolbarActions>
 </KvPageHeader>
 
-{{#if this.emptyState}}
-  {{#if (eq @secret.state "deleted")}}
-    <div class="info-table-row-header">
-      <div class="info-table-row thead is-shadowless">
-        <div class="th column justify-right">
-          <KvTooltipTimestamp
-            @text="Version {{if @secret.version @secret.version}} deleted"
-            @timestamp={{@secret.deletionTime}}
-          />
-        </div>
+<div class="info-table-row-header">
+  <div class="info-table-row thead {{if this.showJsonView 'is-shadowless'}} ">
+    {{#if (and (not this.showJsonView) (not this.emptyState))}}
+      <div class="th column is-one-quarter">
+        Key
       </div>
+      <div class="th column">
+        Value
+      </div>
+    {{/if}}
+    <div class="th column justify-right">
+      {{#if (eq @secret.state "created")}}
+        <KvTooltipTimestamp
+          @text="Version {{if @secret.version @secret.version}} created"
+          @timestamp={{@secret.createdTime}}
+        />
+      {{else if (eq @secret.state "deleted")}}
+        <KvTooltipTimestamp
+          @text="Version {{if @secret.version @secret.version}} deleted"
+          @timestamp={{@secret.deletionTime}}
+        />
+      {{/if}}
     </div>
-  {{/if}}
+  </div>
+</div>
+
+{{#if this.emptyState}}
   <EmptyState @title={{this.emptyState.title}} @message={{this.emptyState.message}}>
     {{#if this.emptyState.link}}
       <DocLink @path={{this.emptyState.link}}>Learn more</DocLink>
     {{/if}}
   </EmptyState>
 {{else}}
-  <div class="info-table-row-header">
-    <div class="info-table-row thead {{if this.showJsonView 'is-shadowless'}} ">
-      {{#unless this.showJsonView}}
-        <div class="th column is-one-quarter">
-          Key
-        </div>
-        <div class="th column">
-          Value
-        </div>
-      {{/unless}}
-      <div class="th column justify-right">
-        <KvTooltipTimestamp
-          @text="Version {{if @secret.version @secret.version}} created"
-          @timestamp={{@secret.createdTime}}
-        />
-      </div>
-    </div>
-  </div>
-
   {{#if this.showJsonView}}
     <JsonEditor @title="Version data" @value={{stringify @secret.secretData}} @readOnly={{true}} />
   {{else}}

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -28,6 +28,18 @@
 </KvPageHeader>
 
 {{#if this.emptyState}}
+  {{#if (eq @secret.state "deleted")}}
+    <div class="info-table-row-header">
+      <div class="info-table-row thead is-shadowless">
+        <div class="th column justify-right">
+          <KvTooltipTimestamp
+            @text="Version {{if @secret.version @secret.version}} deleted"
+            @timestamp={{@secret.deletionTime}}
+          />
+        </div>
+      </div>
+    </div>
+  {{/if}}
   <EmptyState @title={{this.emptyState.title}} @message={{this.emptyState.message}}>
     {{#if this.emptyState.link}}
       <DocLink @path={{this.emptyState.link}}>Learn more</DocLink>
@@ -44,20 +56,11 @@
           Value
         </div>
       {{/unless}}
-      <div class="th column justify-right" data-test-created-time>
-        <ToolTip @verticalPosition="below" @horizontalPosition="right" as |T|>
-          <T.Trigger data-test-kv-version-tooltip-trigger tabindex="-1">
-            Version
-            {{if @secret.version @secret.version}}
-            created
-            {{date-format @secret.createdTime "MMM dd, yyyy hh:mm a"}}
-          </T.Trigger>
-          <T.Content @defaultClass="tool-tip smaller-font">
-            <div class="box" data-test-hover-copy-tooltip-text>
-              {{@secret.createdTime}}
-            </div>
-          </T.Content>
-        </ToolTip>
+      <div class="th column justify-right">
+        <KvTooltipTimestamp
+          @text="Version {{if @secret.version @secret.version}} created"
+          @timestamp={{@secret.createdTime}}
+        />
       </div>
     </div>
   </div>

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -39,15 +39,10 @@
         </div>
       {{/unless}}
       <div class="th column justify-right">
-        {{#if (eq @secret.state "created")}}
+        {{#if (or @secret.deletionTime @secret.createdTime)}}
           <KvTooltipTimestamp
-            @text="Version {{if @secret.version @secret.version}} created"
-            @timestamp={{@secret.createdTime}}
-          />
-        {{else if (eq @secret.state "deleted")}}
-          <KvTooltipTimestamp
-            @text="Version {{if @secret.version @secret.version}} deleted"
-            @timestamp={{@secret.deletionTime}}
+            @text="Version {{if @secret.version @secret.version}} {{@secret.state}}"
+            @timestamp={{or @secret.deletionTime @secret.createdTime}}
           />
         {{/if}}
       </div>

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -39,6 +39,10 @@ export default class KvSecretDetails extends Component {
     next(() => dropdown.actions.close());
   }
 
+  get hideHeaders() {
+    return this.showJsonView || this.emptyState;
+  }
+
   get emptyState() {
     if (!this.args.secret.canReadData) {
       return {

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
@@ -2,7 +2,9 @@
   <:tabLinks>
     <LinkTo @route="secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
     <LinkTo @route="secret.metadata.index" data-test-secrets-tab="Metadata">Metadata</LinkTo>
-    <LinkTo @route="secret.metadata.versions" data-test-secrets-tab="Version History">Version History</LinkTo>
+    {{#if @secret.canReadMetadata}}
+      <LinkTo @route="secret.metadata.versions" data-test-secrets-tab="Version History">Version History</LinkTo>
+    {{/if}}
     {{#if (gt @metadata.sortedVersions.length 1)}}
       <LinkTo @route="secret.metadata.diff" data-test-secrets-tab="Version Diff">Version Diff</LinkTo>
     {{/if}}

--- a/ui/lib/kv/addon/components/page/secret/metadata/version-history.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/version-history.hbs
@@ -52,17 +52,7 @@
           </div>
           {{! version created date }}
           <div class="is-size-8 has-text-weight-semibold has-text-grey align-self-center">
-            <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
-              <T.Trigger data-test-kv-version-tooltip-trigger tabindex="-1">
-                Created
-                {{date-format versionData.created_time "MMM dd, yyyy hh:mm a"}}
-              </T.Trigger>
-              <T.Content @defaultClass="tool-tip smaller-font">
-                <div class="box" data-test-hover-copy-tooltip-text>
-                  {{versionData.created_time}}
-                </div>
-              </T.Content>
-            </ToolTip>
+            <KvTooltipTimestamp @text="Created" @timestamp={{versionData.created_time}} />
           </div>
         </div>
 

--- a/ui/tests/acceptance/secrets/backend/kv/kv-create-new-version-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-create-new-version-test.js
@@ -63,6 +63,6 @@ module('Acceptance | kv | creates a secret and a new version', function (hooks) 
       `/vault/secrets/${this.mountPath}/kv/${secretPath}/details?version=2`,
       'list view navigates to latest version'
     );
-    assert.dom(PAGE.detail.versionCreated).hasTextContaining('Version 2');
+    assert.dom(PAGE.detail.versionTooltip).hasTextContaining('Version 2');
   });
 });

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
@@ -196,7 +196,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.dom(PAGE.secretTab('Version History')).doesNotHaveClass('active');
       assert.dom(PAGE.detail.versionDropdown).hasText('Version 3', 'Version dropdown shows current version');
       assert.dom(PAGE.detail.createNewVersion).hasText('Create new version', 'Create version button shows');
-      assert.dom(PAGE.detail.versionCreated).containsText('Version 3 created');
+      assert.dom(PAGE.detail.versionTooltip).containsText('Version 3 created');
       assert.dom(PAGE.infoRowValue('foo')).exists('renders current data');
 
       await click(PAGE.detail.createNewVersion);
@@ -223,7 +223,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         'Goes to detail view for version 1'
       );
       assert.dom(PAGE.detail.versionDropdown).hasText('Version 1', 'Version dropdown shows selected version');
-      assert.dom(PAGE.detail.versionCreated).containsText('Version 1 created');
+      assert.dom(PAGE.detail.versionTooltip).containsText('Version 1 created');
       assert.dom(PAGE.infoRowValue('key-1')).exists('renders previous data');
 
       await click(PAGE.detail.createNewVersion);
@@ -423,7 +423,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       // TODO: hide dropdown
       // assert.dom(PAGE.detail.versionDropdown).doesNotExist('Version dropdown hidden');
       assert.dom(PAGE.detail.createNewVersion).hasText('Create new version', 'Create version button shows');
-      assert.dom(PAGE.detail.versionCreated).containsText('Version 3 created');
+      assert.dom(PAGE.detail.versionTooltip).containsText('Version 3 created');
       assert.dom(PAGE.infoRowValue('foo')).exists('renders current data');
 
       await click(PAGE.detail.createNewVersion);
@@ -446,7 +446,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       await visit(`/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/details?version=1`);
       // TODO: hide version dropdown
       // assert.dom(PAGE.detail.versionDropdown).doesNotExist('Version dropdown does not exist');
-      assert.dom(PAGE.detail.versionCreated).containsText('Version 1 created');
+      assert.dom(PAGE.detail.versionTooltip).containsText('Version 1 created');
       assert.dom(PAGE.infoRowValue('key-1')).exists('renders previous data');
 
       await click(PAGE.detail.createNewVersion);
@@ -640,7 +640,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       // TODO: version dropdown hidden
       // assert.dom(PAGE.detail.versionDropdown).doesNotExist('Version dropdown hidden');
       assert.dom(PAGE.detail.createNewVersion).hasText('Create new version', 'Create version button shows');
-      assert.dom(PAGE.detail.versionCreated).containsText('Version 3 created');
+      assert.dom(PAGE.detail.versionTooltip).containsText('Version 3 created');
       assert.dom(PAGE.infoRowValue('foo')).exists('renders current data');
 
       await click(PAGE.detail.createNewVersion);
@@ -662,7 +662,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       // TODO: version dropdown should be hidden
       // assert.dom(PAGE.detail.versionDropdown).doesNotExist('version dropdown hidden');
       await visit(`/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/details?version=1`);
-      assert.dom(PAGE.detail.versionCreated).containsText('Version 1 created');
+      assert.dom(PAGE.detail.versionTooltip).containsText('Version 1 created');
       assert.dom(PAGE.infoRowValue('key-1')).exists('renders previous data');
 
       await click(PAGE.detail.createNewVersion);
@@ -862,7 +862,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         .hasText('Version current', 'Version dropdown shows current version');
       assert.dom(PAGE.detail.createNewVersion).doesNotExist('Create new version button not shown');
       // TODO: should the created metadata show?
-      assert.dom(PAGE.detail.versionCreated).doesNotExist('Version created text not shown');
+      assert.dom(PAGE.detail.versionTooltip).doesNotExist('Version created text not shown');
       assert.dom(PAGE.infoRowValue('foo')).doesNotExist('does not render current data');
       assert
         .dom(PAGE.emptyStateTitle)
@@ -878,8 +878,8 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       );
       // TODO: version number missing
       // assert.dom(PAGE.detail.versionDropdown).hasText('Version 1', 'Version dropdown shows selected version');
-      // TODO: versionCreated missing
-      // assert.dom(PAGE.detail.versionCreated).containsText('Version 1 created');
+      // TODO: versionTooltip missing
+      // assert.dom(PAGE.detail.versionTooltip).containsText('Version 1 created');
       assert.dom(PAGE.infoRowValue('key-1')).doesNotExist('does not render previous data');
       assert
         .dom(PAGE.emptyStateTitle)
@@ -1060,7 +1060,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.dom(PAGE.secretTab('Version History')).doesNotExist('Version History tab does not render');
       assert.dom(PAGE.detail.versionDropdown).doesNotExist('Version dropdown does not render');
       assert.dom(PAGE.detail.createNewVersion).hasText('Create new version', 'Create version button shows');
-      assert.dom(PAGE.detail.versionCreated).doesNotExist('Version created info is not rendered');
+      assert.dom(PAGE.detail.versionTooltip).doesNotExist('Version created info is not rendered');
       assert.dom(PAGE.infoRowValue('foo')).doesNotExist('current data not rendered');
       assert
         .dom(PAGE.emptyStateTitle)
@@ -1094,7 +1094,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
 
       await visit(`/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/details?version=1`);
       assert.dom(PAGE.detail.versionDropdown).doesNotExist('Version dropdown does not exist');
-      assert.dom(PAGE.detail.versionCreated).doesNotExist('version created data not rendered');
+      assert.dom(PAGE.detail.versionTooltip).doesNotExist('version created data not rendered');
       assert.dom(PAGE.infoRowValue('key-1')).doesNotExist('does not render previous data');
 
       await click(PAGE.detail.createNewVersion);
@@ -1126,7 +1126,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.dom(PAGE.metadata.editBtn).doesNotExist('edit metadata button does not render');
     });
     test('breadcrumbs & page titles are correct', async function (assert) {
-      assert.expect(32);
+      assert.expect(27);
       const backend = this.backend;
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
@@ -1151,9 +1151,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'metadata']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for metadata');
 
-      await click(PAGE.secretTab('Version History'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'version history']);
-      assert.dom(PAGE.title).hasText(secretPath, 'correct page title for version history');
+      assert.dom(PAGE.secretTab('Version History')).doesNotExist('Version history tab not shown');
     });
   });
 

--- a/ui/tests/helpers/kv/kv-selectors.js
+++ b/ui/tests/helpers/kv/kv-selectors.js
@@ -24,7 +24,7 @@ export const PAGE = {
     secretMetadataSection: '[data-test-kv-metadata-section]',
   },
   detail: {
-    versionCreated: '[data-test-kv-version-tooltip-trigger]',
+    versionTooltip: '[data-test-kv-version-tooltip-trigger]',
     versionDropdown: '[data-test-version-dropdown]',
     version: (number) => `[data-test-version="${number}"]`,
     createNewVersion: '[data-test-create-new-version]',

--- a/ui/tests/integration/components/kv/page/kv-page-secret-details-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-details-test.js
@@ -86,12 +86,12 @@ module('Integration | Component | kv-v2 | Page::Secret::Details', function (hook
     await click(FORM.toggleJson);
     assert.propEqual(parseJsonEditor(find), this.secretData, 'json editor renders secret data');
     assert
-      .dom(PAGE.detail.versionCreated)
+      .dom(PAGE.detail.versionTooltip)
       .includesText(`Version ${this.version} created`, 'renders version and time created');
   });
 
   test('it renders deleted empty state', async function (assert) {
-    assert.expect(2);
+    assert.expect(3);
     this.secret.deletionTime = '2023-07-23T02:12:17.379762Z';
     await render(
       hbs`
@@ -110,6 +110,9 @@ module('Integration | Component | kv-v2 | Page::Secret::Details', function (hook
       .hasText(
         'This version has been deleted but can be undeleted. View other versions of this secret by clicking the Version History tab above.'
       );
+    assert
+      .dom(PAGE.detail.versionTooltip)
+      .includesText(`Version ${this.version} deleted`, 'renders version and time deleted');
   });
 
   test('it renders destroyed empty state', async function (assert) {
@@ -149,7 +152,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Details', function (hook
       { owner: this.engine }
     );
 
-    assert.dom(PAGE.detail.versionCreated).includesText(this.version, 'renders version');
+    assert.dom(PAGE.detail.versionTooltip).includesText(this.version, 'renders version');
     assert.dom(PAGE.detail.versionDropdown).hasText(`Version ${this.secret.version}`);
     await click(PAGE.detail.versionDropdown);
 


### PR DESCRIPTION
1. adds `deletion_time` to secret details
2. hides version history tab if no metadata read access
Note: in the gif below I change the version view by updatibg the URL - but we don't give users the ability to navigate to different versions in the UI without metadata `READ` access

### full permissions
![full-perms](https://github.com/hashicorp/vault/assets/68122737/0cb58185-bb43-47aa-ae10-f46f5d55b705)

<hr>

### `READ data` only
```
path "my-kv/metadata/*" {
    capabilities = ["list"]
}

path "my-kv/data/*" {
    capabilities = ["list", "create", "read", "update"]
}
```
![no-read](https://github.com/hashicorp/vault/assets/68122737/025910c6-9243-4c2e-afcd-52158a5c9157)
