### PR TITLE
Use non-persistent Salter for logging test message

### DIFF
--- a/audit/entry_formatter.go
+++ b/audit/entry_formatter.go
@@ -581,9 +581,8 @@ func doElideListResponseData(data map[string]interface{}) {
 	}
 }
 
-// NewTemporaryFormatNode creates an EntryFormatter instance that is used as a
-// Node and that is cloned nearly as is, with the exception of the Salter.
-func NewTemporaryFormatNode(n *EntryFormatter) *EntryFormatter {
+// newTemporaryEntryFormatter creates a cloned EntryFormatter instance with a non-persistent Salter.
+func newTemporaryEntryFormatter(n *EntryFormatter) *EntryFormatter {
 	return &EntryFormatter{
 		salter:          &nonPersistentSalt{},
 		headerFormatter: n.headerFormatter,

--- a/audit/entry_formatter.go
+++ b/audit/entry_formatter.go
@@ -580,3 +580,14 @@ func doElideListResponseData(data map[string]interface{}) {
 		}
 	}
 }
+
+// NewTemporaryFormatNode creates an EntryFormatter instance that is used as a
+// Node and that is cloned nearly as is, with the exception of the Salter.
+func NewTemporaryFormatNode(n *EntryFormatter) *EntryFormatter {
+	return &EntryFormatter{
+		salter:          &nonPersistentSalt{},
+		headerFormatter: n.headerFormatter,
+		config:          n.config,
+		prefix:          n.prefix,
+	}
+}

--- a/audit/nodes_test.go
+++ b/audit/nodes_test.go
@@ -26,10 +26,10 @@ func TestProcessManual_NilData(t *testing.T) {
 	var ids []eventlogger.NodeID
 	nodes := make(map[eventlogger.NodeID]eventlogger.Node)
 
-	// Filter node
-	filterId, filterNode := newFilterNode(t)
-	ids = append(ids, filterId)
-	nodes[filterId] = filterNode
+	// Formatter node
+	formatterId, formatterNode := newFormatterNode(t)
+	ids = append(ids, formatterId)
+	nodes[formatterId] = formatterNode
 
 	// Sink node
 	sinkId, sinkNode := newSinkNode(t)
@@ -65,9 +65,9 @@ func TestProcessManual_BadIDs(t *testing.T) {
 			t.Parallel()
 			nodes := make(map[eventlogger.NodeID]eventlogger.Node)
 
-			// Filter node
-			filterId, filterNode := newFilterNode(t)
-			nodes[filterId] = filterNode
+			// Formatter node
+			formatterId, formatterNode := newFormatterNode(t)
+			nodes[formatterId] = formatterNode
 
 			// Sink node
 			sinkId, sinkNode := newSinkNode(t)
@@ -92,9 +92,9 @@ func TestProcessManual_NoNodes(t *testing.T) {
 	var ids []eventlogger.NodeID
 	nodes := make(map[eventlogger.NodeID]eventlogger.Node)
 
-	// Filter node
-	filterId, _ := newFilterNode(t)
-	ids = append(ids, filterId)
+	// Formatter node
+	formatterId, _ := newFormatterNode(t)
+	ids = append(ids, formatterId)
 
 	// Sink node
 	sinkId, _ := newSinkNode(t)
@@ -118,10 +118,10 @@ func TestProcessManual_IdNodeMismatch(t *testing.T) {
 	var ids []eventlogger.NodeID
 	nodes := make(map[eventlogger.NodeID]eventlogger.Node)
 
-	// Filter node
-	filterId, filterNode := newFilterNode(t)
-	ids = append(ids, filterId)
-	nodes[filterId] = filterNode
+	// Formatter node
+	formatterId, formatterNode := newFormatterNode(t)
+	ids = append(ids, formatterId)
+	nodes[formatterId] = formatterNode
 
 	// Sink node
 	sinkId, _ := newSinkNode(t)
@@ -145,10 +145,10 @@ func TestProcessManual_NotEnoughNodes(t *testing.T) {
 	var ids []eventlogger.NodeID
 	nodes := make(map[eventlogger.NodeID]eventlogger.Node)
 
-	// Filter node
-	filterId, filterNode := newFilterNode(t)
-	ids = append(ids, filterId)
-	nodes[filterId] = filterNode
+	// Formatter node
+	formatterId, formatterNode := newFormatterNode(t)
+	ids = append(ids, formatterId)
+	nodes[formatterId] = formatterNode
 
 	// Data
 	requestId, err := uuid.GenerateUUID()
@@ -168,12 +168,13 @@ func TestProcessManual_LastNodeNotSink(t *testing.T) {
 	var ids []eventlogger.NodeID
 	nodes := make(map[eventlogger.NodeID]eventlogger.Node)
 
-	// Filter node
-	filterId, filterNode := newFilterNode(t)
-	ids = append(ids, filterId)
-	nodes[filterId] = filterNode
-
+	// Formatter node
 	formatterId, formatterNode := newFormatterNode(t)
+	ids = append(ids, formatterId)
+	nodes[formatterId] = formatterNode
+
+	// Another Formatter node
+	formatterId, formatterNode = newFormatterNode(t)
 	ids = append(ids, formatterId)
 	nodes[formatterId] = formatterNode
 
@@ -195,10 +196,10 @@ func TestProcessManual(t *testing.T) {
 	var ids []eventlogger.NodeID
 	nodes := make(map[eventlogger.NodeID]eventlogger.Node)
 
-	// Filter node
-	filterId, filterNode := newFilterNode(t)
-	ids = append(ids, filterId)
-	nodes[filterId] = filterNode
+	// Formatter node
+	formatterId, formatterNode := newFormatterNode(t)
+	ids = append(ids, formatterId)
+	nodes[formatterId] = formatterNode
 
 	// Sink node
 	sinkId, sinkNode := newSinkNode(t)
@@ -212,20 +213,6 @@ func TestProcessManual(t *testing.T) {
 
 	err = ProcessManual(namespace.RootContext(context.Background()), data, ids, nodes)
 	require.NoError(t, err)
-}
-
-// newFilterNode creates a new UUID and EntryFormatter (filter node).
-func newFilterNode(t *testing.T) (eventlogger.NodeID, *EntryFormatter) {
-	t.Helper()
-
-	filterId, err := event.GenerateNodeID()
-	require.NoError(t, err)
-	cfg, err := NewFormatterConfig()
-	require.NoError(t, err)
-	filterNode, err := NewEntryFormatter(cfg, newStaticSalt(t))
-	require.NoError(t, err)
-
-	return filterId, filterNode
 }
 
 // newSinkNode creates a new UUID and NoopSink (sink node).

--- a/audit/types.go
+++ b/audit/types.go
@@ -257,7 +257,7 @@ type Namespace struct {
 	Path string `json:"path,omitempty"`
 }
 
-// nonPersistentSalt is used for obtaining a salt that is
+// nonPersistentSalt is used for obtaining a salt that is not persisted.
 type nonPersistentSalt struct{}
 
 // Backend interface must be implemented for an audit


### PR DESCRIPTION
This PR fixes an issue discovered while testing the disabling and enabling Audit Devices when the experimental framework is used. The issue prevented the enabling of an Audit Device because during its creation and mounting, its Event Pipeline nodes that make use of the Audit Device's Salt method was being used (For instance, https://github.com/hashicorp/vault/blob/main/audit/entry_formatter.go#L181). This triggered a salt value to be generated and it be written to Storage, but during the enabling and mounting of Audit Devices, the Storage view is placed in _read-only_ mode which prevents data from being written to it.

However, the current framework doesn't suffer from this issue because it generates a different Formatter that uses a different Salt configuration that's not persisted in Storage (See https://github.com/hashicorp/vault/blob/main/audit/entry_formatter_writer.go#L99).

The solution to this issue is to replace the formatter node (`*audit.EntryFormatter`) with a instance that is constructed using all of the same field values except for the **salter** field, which uses an instance of the **nonPersistentSalt** struct, just like the current framework does.