### PR TITLE
handler: allow to disable ratelimit quota

### DIFF
--- a/changelog/22315.txt
+++ b/changelog/22315.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+handler: handler: allow to disable ratelimit quota
+```

--- a/command/server.go
+++ b/command/server.go
@@ -704,6 +704,7 @@ func (c *ServerCommand) runRecoveryMode() int {
 			Core:                  core,
 			ListenerConfig:        ln.Config,
 			DisablePrintableCheck: config.DisablePrintableCheck,
+			DisableRateLimitQuota: config.DisableRateLimitQuota,
 			RecoveryMode:          c.flagRecovery,
 			RecoveryToken:         atomic.NewString(""),
 		})
@@ -3009,6 +3010,7 @@ func startHttpServers(c *ServerCommand, core *vault.Core, config *server.Config,
 			Core:                  core,
 			ListenerConfig:        ln.Config,
 			DisablePrintableCheck: config.DisablePrintableCheck,
+			DisableRateLimitQuota: config.DisableRateLimitQuota,
 			RecoveryMode:          c.flagRecovery,
 		})
 

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -63,6 +63,8 @@ type Config struct {
 	DisableCacheRaw          interface{} `hcl:"disable_cache"`
 	DisablePrintableCheck    bool        `hcl:"-"`
 	DisablePrintableCheckRaw interface{} `hcl:"disable_printable_check"`
+	DisableRateLimitQuota    bool        `hcl:"-"`
+	DisableRateLimitQuotaRaw interface{} `hcl:"disable_ratelimit_quota"`
 
 	EnableUI    bool        `hcl:"-"`
 	EnableUIRaw interface{} `hcl:"ui"`
@@ -315,6 +317,11 @@ func (c *Config) Merge(c2 *Config) *Config {
 	result.DisablePrintableCheck = c.DisablePrintableCheck
 	if c2.DisablePrintableCheckRaw != nil {
 		result.DisablePrintableCheck = c2.DisablePrintableCheck
+	}
+
+	result.DisableRateLimitQuota = c.DisableRateLimitQuota
+	if c2.DisableRateLimitQuotaRaw != nil {
+		result.DisableRateLimitQuota = c2.DisableRateLimitQuota
 	}
 
 	// merge these integers via a MAX operation
@@ -616,6 +623,12 @@ func ParseConfig(d, source string) (*Config, error) {
 
 	if result.DisablePrintableCheckRaw != nil {
 		if result.DisablePrintableCheck, err = parseutil.ParseBool(result.DisablePrintableCheckRaw); err != nil {
+			return nil, err
+		}
+	}
+
+	if result.DisableRateLimitQuotaRaw != nil {
+		if result.DisableRateLimitQuota, err = parseutil.ParseBool(result.DisableRateLimitQuotaRaw); err != nil {
 			return nil, err
 		}
 	}
@@ -1104,6 +1117,7 @@ func (c *Config) Sanitized() map[string]interface{} {
 		"disable_sentinel_trace":  c.DisableSentinelTrace,
 		"disable_cache":           c.DisableCache,
 		"disable_printable_check": c.DisablePrintableCheck,
+		"disable_ratelimit_quota": c.DisableRateLimitQuota,
 
 		"enable_ui": c.EnableUI,
 

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -453,6 +453,8 @@ func testLoadConfigFile(t *testing.T) {
 		DisableCacheRaw:          true,
 		DisablePrintableCheckRaw: true,
 		DisablePrintableCheck:    true,
+		DisableRateLimitQuotaRaw: true,
+		DisableRateLimitQuota:    true,
 		EnableUI:                 true,
 		EnableUIRaw:              true,
 
@@ -771,6 +773,7 @@ func testConfig_Sanitized(t *testing.T) {
 		"plugin_file_uid":                     0,
 		"plugin_file_permissions":             0,
 		"disable_printable_check":             false,
+		"disable_ratelimit_quota":             false,
 		"disable_sealwrap":                    true,
 		"raw_storage_endpoint":                true,
 		"introspection_endpoint":              false,
@@ -1210,6 +1213,8 @@ func testLoadConfigFileLeaseMetrics(t *testing.T) {
 		DisableCacheRaw:          true,
 		DisablePrintableCheckRaw: true,
 		DisablePrintableCheck:    true,
+		DisableRateLimitQuotaRaw: true,
+		DisableRateLimitQuota:    true,
 		EnableUI:                 true,
 		EnableUIRaw:              true,
 

--- a/command/server/test-fixtures/config.hcl
+++ b/command/server/test-fixtures/config.hcl
@@ -49,6 +49,7 @@ raw_storage_endpoint = true
 introspection_endpoint = true
 disable_sealwrap = true
 disable_printable_check = true
+disable_ratelimit_quota = true
 enable_response_header_hostname = true
 enable_response_header_raft_node_id = true
 license_path = "/path/to/license"

--- a/command/server/test-fixtures/config5.hcl
+++ b/command/server/test-fixtures/config5.hcl
@@ -52,3 +52,4 @@ disable_cache = true
  raw_storage_endpoint = true
  disable_sealwrap = true
  disable_printable_check = true
+ disable_ratelimit_quota = true

--- a/http/handler.go
+++ b/http/handler.go
@@ -227,7 +227,12 @@ func handler(props *vault.HandlerProperties) http.Handler {
 	// Wrap the handler in another handler to trigger all help paths.
 	helpWrappedHandler := wrapHelpHandler(mux, core)
 	corsWrappedHandler := wrapCORSHandler(helpWrappedHandler, core)
-	quotaWrappedHandler := rateLimitQuotaWrapping(corsWrappedHandler, core)
+
+	quotaWrappedHandler := corsWrappedHandler
+	if !props.DisableRateLimitQuota {
+		quotaWrappedHandler = rateLimitQuotaWrapping(corsWrappedHandler, core)
+	}
+
 	genericWrappedHandler := genericWrapping(core, quotaWrappedHandler, props)
 
 	// Wrap the handler with PrintablePathCheckHandler to check for non-printable

--- a/http/sys_config_state_test.go
+++ b/http/sys_config_state_test.go
@@ -150,6 +150,7 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 				"disable_mlock":                       false,
 				"disable_performance_standby":         false,
 				"disable_printable_check":             false,
+				"disable_ratelimit_quota":             false,
 				"disable_sealwrap":                    false,
 				"experiments":                         nil,
 				"raw_storage_endpoint":                false,

--- a/sdk/helper/testcluster/types.go
+++ b/sdk/helper/testcluster/types.go
@@ -61,6 +61,7 @@ type VaultNodeConfig struct {
 	CacheSize                      int           `json:"cache_size"`
 	DisableCache                   bool          `json:"disable_cache"`
 	DisablePrintableCheck          bool          `json:"disable_printable_check"`
+	DisableRateLimitQuota          bool          `json:"disable_ratelimit_quota"`
 	EnableUI                       bool          `json:"ui"`
 	MaxLeaseTTL                    time.Duration `json:"max_lease_ttl"`
 	DefaultLeaseTTL                time.Duration `json:"default_lease_ttl"`

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -65,6 +65,7 @@ type HandlerProperties struct {
 	Core                  *Core
 	ListenerConfig        *configutil.Listener
 	DisablePrintableCheck bool
+	DisableRateLimitQuota bool
 	RecoveryMode          bool
 	RecoveryToken         *uberAtomic.String
 }

--- a/website/content/api-docs/system/config-state.mdx
+++ b/website/content/api-docs/system/config-state.mdx
@@ -46,6 +46,7 @@ $ curl \
   "disable_mlock": false,
   "disable_performance_standby": false,
   "disable_printable_check": false,
+  "disable_ratelimit_quota": false,
   "disable_sealwrap": false,
   "enable_ui": true,
   "listeners": [


### PR DESCRIPTION
rateLimitQuotaWrapping could bring ~0.5ms latency on each request. Making it optional to be disabled by config can help to benefit from the performance while it's not needed at all. The effect can also be seen in the cpu profiler.

Closes: #22314 