### PR TITLE
Improve gh_comment.sh

### DIFF
--- a/.github/scripts/gh_comment.sh
+++ b/.github/scripts/gh_comment.sh
@@ -16,7 +16,7 @@ function update_or_create_comment {
   # We only want for the GH bot to place one comment to report build failures
   # and if we rerun a job, that comment needs to be updated.
   # Let's try to find if the GH bot has placed a similar comment
-  printf -v COMMENT_ID_QUERY '.[] | select (.body | startswith(%s)) | .id') "${SEARCH_KEY}"
+  printf -v COMMENT_ID_QUERY '.[] | select (.body | startswith(%s)) | .id' "${SEARCH_KEY}"
   comment_id="$(
     gh api "/repos/hashicorp/${REPO}/issues/${PR_NUMBER}/comments" \
       --header "Accept: application/vnd.github+json" \

--- a/.github/scripts/gh_comment.sh
+++ b/.github/scripts/gh_comment.sh
@@ -7,36 +7,37 @@ set -e
 
 
 function update_or_create_comment {
-  REPO=$1
-  PR_NUMBER=$2
-  SEARCH_KEY=$3
-  BODY=$4
+  local REPO="$1"
+  local PR_NUMBER="$2"
+  local SEARCH_KEY="$3"
+  local BODY="$4"
+  local COMMENT_ID_QUERY
   
   # We only want for the GH bot to place one comment to report build failures
   # and if we rerun a job, that comment needs to be updated.
   # Let's try to find if the GH bot has placed a similar comment
-  comment_id=$(gh api \
-                 -H "Accept: application/vnd.github+json" \
-                 -H "X-GitHub-Api-Version: 2022-11-28" \
-                 --paginate \
-                 /repos/hashicorp/"$REPO"/issues/"$PR_NUMBER"/comments |
-                 jq -r --arg SEARCH_KEY "$SEARCH_KEY" '.[] | select (.body | startswith($SEARCH_KEY)) | .id')
+  printf -v COMMENT_ID_QUERY '.[] | select (.body | startswith(%s)) | .id') "${SEARCH_KEY}"
+  comment_id="$(
+    gh api "/repos/hashicorp/${REPO}/issues/${PR_NUMBER}/comments" \
+      --header "Accept: application/vnd.github+json" \
+      --header "X-GitHub-Api-Version: 2022-11-28" \
+      --paginate \
+      --jq "${COMMENT_ID_QUERY}"
+  )"
 
   if [[ "$comment_id" != "" ]]; then
-    # update the comment with the new body
-    gh api \
+    # Update the comment with the new body
+    gh api "/repos/hashicorp/${REPO}/issues/comments/${comment_id}" \
       --method PATCH \
-      -H "Accept: application/vnd.github+json" \
-      -H "X-GitHub-Api-Version: 2022-11-28" \
-      /repos/hashicorp/"$REPO"/issues/comments/"$comment_id" \
-      -f body="$BODY"
+      --header "Accept: application/vnd.github+json" \
+      --header "X-GitHub-Api-Version: 2022-11-28" \
+      --raw-field "body=${BODY}"
   else
-    # create a comment with the new body
-    gh api \
+    # Create a comment with the new body
+    gh api "/repos/hashicorp/${REPO}/issues/${PR_NUMBER}/comments" \
       --method POST \
-      -H "Accept: application/vnd.github+json" \
-      -H "X-GitHub-Api-Version: 2022-11-28" \
-      /repos/hashicorp/"$REPO"/issues/"$PR_NUMBER"/comments \
-      -f body="$BODY"
+      --header "Accept: application/vnd.github+json" \
+      --header "X-GitHub-Api-Version: 2022-11-28" \
+      --raw-field "body=${BODY}"
   fi
 }


### PR DESCRIPTION
- robust
- readable
- uses GitHub CLI's `--jq` option

BTW GitHub CLI works without adding `--header` options.
