### PR TITLE
Update linux package license to BUSL-1.1

### DIFF
--- a/.github/workflows/build-vault-oss.yml
+++ b/.github/workflows/build-vault-oss.yml
@@ -83,7 +83,7 @@ jobs:
           version: ${{ inputs.vault-version }}
           maintainer: HashiCorp
           homepage: https://github.com/hashicorp/vault
-          license: MPL-2.0
+          license: BUSL-1.1
           binary: dist/${{ inputs.package-name }}
           deb_depends: openssl
           rpm_depends: openssl


### PR DESCRIPTION
This updates the linux package license to BUSL-1.1.
This PR should be merged to main so that the change is included in the next minor release that is cut from main.
License changes are not required on release branches (ongoing patch releases of current minor releases).
