### PR TITLE
LDAP Overview Cards

### DIFF
--- a/ui/app/adapters/ldap/library.js
+++ b/ui/app/adapters/ldap/library.js
@@ -45,6 +45,7 @@ export default class LdapLibraryAdapter extends NamedPathAdapter {
         const status = {
           ...resp.data[key],
           account: key,
+          library: name,
         };
         statuses.push(status);
       }

--- a/ui/app/styles/components/overview-card.scss
+++ b/ui/app/styles/components/overview-card.scss
@@ -5,7 +5,6 @@
 
 .overview-card {
   padding: $spacing-l;
-  display: initial;
   line-height: initial;
 
   .title-number {

--- a/ui/app/styles/helper-classes/colors.scss
+++ b/ui/app/styles/helper-classes/colors.scss
@@ -72,6 +72,10 @@ select.has-error-border,
 .has-text-info {
   color: $blue-500 !important;
 }
+// same without the !important
+.has-text-primary {
+  color: $blue-500;
+}
 
 .has-text-success {
   color: $green-500 !important;

--- a/ui/app/styles/helper-classes/flexbox-and-grid.scss
+++ b/ui/app/styles/helper-classes/flexbox-and-grid.scss
@@ -33,6 +33,11 @@
   align-items: center;
 }
 
+.is-flex-align-start {
+  display: flex;
+  align-items: flex-start;
+}
+
 .is-flex-align-baseline {
   display: flex;
   align-items: baseline;

--- a/ui/lib/core/addon/components/overview-card.hbs
+++ b/ui/lib/core/addon/components/overview-card.hbs
@@ -8,6 +8,7 @@
   @hasBorder={{true}}
   class="overview-card border-radius-2"
   data-test-overview-card-container={{@cardTitle}}
+  ...attributes
 >
   <div class="is-flex-between" data-test-overview-card={{@cardTitle}}>
     <h3 class="title is-5">{{@cardTitle}}</h3>

--- a/ui/lib/ldap/addon/components/accounts-checked-out.hbs
+++ b/ui/lib/ldap/addon/components/accounts-checked-out.hbs
@@ -1,21 +1,26 @@
-<Hds::Card::Container @hasBorder={{true}} class="has-padding-l" ...attributes>
-  <h3 class="is-size-4 has-text-weight-semibold">Accounts checked out by this token</h3>
-
-  <p class="has-text-grey">The accounts that are currently on lease with this token</p>
+<OverviewCard
+  @cardTitle="Accounts checked-out"
+  @subText="The accounts that are currently on lease with this token or exist in a library set with check-in enforcement disabled."
+  class="has-padding-l"
+  ...attributes
+>
   <hr class="has-background-gray-200" />
 
   {{#if this.filteredAccounts}}
-    <Hds::Table @model={{this.filteredAccounts}} @columns={{array (hash label="Accounts") (hash label="Action")}}>
+    <Hds::Table @model={{this.filteredAccounts}} @columns={{this.columns}}>
       <:body as |Body|>
         <Body.Tr>
-          <Body.Td data-test-checked-out-account={{Body.data}}>{{Body.data}}</Body.Td>
+          <Body.Td data-test-checked-out-account={{Body.data.account}}>{{Body.data.account}}</Body.Td>
+          {{#if @showLibraryColumn}}
+            <Body.Td data-test-checked-out-library={{Body.data.account}}>{{Body.data.library}}</Body.Td>
+          {{/if}}
           <Body.Td>
             <button
               type="button"
-              class="text-button has-text-info has-text-weight-semibold"
-              disabled={{not @library.canCheckIn}}
-              data-test-checked-out-account-action={{Body.data}}
-              {{on "click" (fn (mut this.checkInAccount) Body.data)}}
+              class="text-button has-text-primary has-text-weight-semibold"
+              disabled={{this.disableCheckIn Body.data.library}}
+              data-test-checked-out-account-action={{Body.data.account}}
+              {{on "click" (fn (mut this.selectedStatus) Body.data)}}
             >
               <Icon @name="queue" />
               Check-in
@@ -31,19 +36,19 @@
       class="is-shadowless"
     />
   {{/if}}
-</Hds::Card::Container>
+</OverviewCard>
 
-{{#if this.checkInAccount}}
+{{#if this.selectedStatus}}
   <Modal
     @title="Account Check-in"
-    @isActive={{this.checkInAccount}}
+    @isActive={{this.selectedStatus}}
     @showCloseButton={{true}}
-    @onClose={{fn (mut this.checkInAccount) ""}}
+    @onClose={{fn (mut this.selectedStatus) undefined}}
   >
     <section class="modal-card-body">
       <p>
         This action will check-in account
-        {{this.checkInAccount}}
+        {{this.selectedStatus.account}}
         back to the library. Do you want to proceed?
       </p>
     </section>
@@ -61,7 +66,7 @@
         type="button"
         class="button"
         disabled={{this.checkIn.isRunning}}
-        {{on "click" (fn (mut this.checkInAccount) "")}}
+        {{on "click" (fn (mut this.selectedStatus) "")}}
       >
         Cancel
       </button>

--- a/ui/lib/ldap/addon/components/accounts-checked-out.ts
+++ b/ui/lib/ldap/addon/components/accounts-checked-out.ts
@@ -12,8 +12,9 @@ import type LdapLibraryModel from 'vault/models/ldap/library';
 import type { LdapLibraryAccountStatus } from 'vault/adapters/ldap/library';
 
 interface Args {
-  library: LdapLibraryModel;
+  libraries: Array<LdapLibraryModel>;
   statuses: Array<LdapLibraryAccountStatus>;
+  showLibraryColumn: boolean;
 }
 
 export default class LdapAccountsCheckedOutComponent extends Component<Args> {
@@ -21,37 +22,51 @@ export default class LdapAccountsCheckedOutComponent extends Component<Args> {
   @service declare readonly router: RouterService;
   @service declare readonly auth: AuthService;
 
-  @tracked checkInAccount = '';
+  @tracked selectedStatus: LdapLibraryAccountStatus | undefined;
+
+  get columns() {
+    const columns = [{ label: 'Account' }, { label: 'Action' }];
+    if (this.args.showLibraryColumn) {
+      columns.splice(1, 0, { label: 'Library' });
+    }
+    return columns;
+  }
 
   get filteredAccounts() {
     // filter status to only show checked out accounts associated to the current user
     // if disable_check_in_enforcement is true on the library set then all checked out accounts are displayed
-    return this.args.statuses.reduce((accounts: Array<string>, status: LdapLibraryAccountStatus) => {
+    return this.args.statuses.filter((status) => {
       const authEntityId = this.auth.authData?.entity_id;
       const isRoot = !status.borrower_entity_id && !authEntityId; // root user will not have an entity id and it won't be populated on status
       const isEntity = status.borrower_entity_id === authEntityId;
-      const enforcementDisabled = this.args.library.disable_check_in_enforcement === 'Disabled';
+      const library = this.findLibrary(status.library);
+      const enforcementDisabled = library.disable_check_in_enforcement === 'Disabled';
 
-      if (!status.available && (enforcementDisabled || isEntity || isRoot)) {
-        accounts.push(status.account);
-      }
-      return accounts;
-    }, []);
+      return !status.available && (enforcementDisabled || isEntity || isRoot);
+    });
+  }
+
+  disableCheckIn = (name: string) => {
+    return !this.findLibrary(name).canCheckIn;
+  };
+
+  findLibrary(name: string): LdapLibraryModel {
+    return this.args.libraries.find((library) => library.name === name) as LdapLibraryModel;
   }
 
   @task
   @waitFor
   *checkIn() {
+    const { library, account } = this.selectedStatus as LdapLibraryAccountStatus;
     try {
-      yield this.args.library.checkInAccount(this.checkInAccount);
-      this.flashMessages.success(`Successfully checked in the account ${this.checkInAccount}.`);
+      const libraryModel = this.findLibrary(library);
+      yield libraryModel.checkInAccount(account);
+      this.flashMessages.success(`Successfully checked in the account ${account}.`);
       // transitioning to the current route to trigger the model hook so we can fetch the updated status
       this.router.transitionTo('vault.cluster.secrets.backend.ldap.libraries.library.details.accounts');
     } catch (error) {
-      this.checkInAccount = '';
-      this.flashMessages.danger(
-        `Error checking in the account ${this.checkInAccount}. \n ${errorMessage(error)}`
-      );
+      this.selectedStatus = undefined;
+      this.flashMessages.danger(`Error checking in the account ${account}. \n ${errorMessage(error)}`);
     }
   }
 }

--- a/ui/lib/ldap/addon/components/page/library/details/accounts.hbs
+++ b/ui/lib/ldap/addon/components/page/library/details/accounts.hbs
@@ -1,7 +1,7 @@
-<div class="has-top-margin-l is-flex-align-baseline">
-  <Hds::Card::Container @hasBorder={{true}} class="has-padding-l is-flex-half">
+<div class="has-top-margin-l is-flex-align-start">
+  <Hds::Card::Container @level="mid" @hasBorder={{true}} class="has-padding-l is-flex-half">
     <div class="is-flex-between">
-      <h3 class="is-size-4 has-text-weight-semibold">All accounts</h3>
+      <h3 class="is-size-5 has-text-weight-semibold">All accounts</h3>
       {{#if @library.canCheckOut}}
         <button
           type="button"
@@ -14,7 +14,7 @@
       {{/if}}
     </div>
 
-    <p class="has-text-grey">The accounts within this library</p>
+    <p class="has-text-grey is-size-8">The accounts within this library</p>
     <hr class="has-background-gray-200" />
 
     <Hds::Table @model={{@statuses}} @columns={{array (hash label="Accounts") (hash label="Status")}}>
@@ -34,13 +34,14 @@
   </Hds::Card::Container>
 
   <div class="has-left-margin-l is-flex-half">
-    <AccountsCheckedOut @library={{@library}} @statuses={{@statuses}} data-test-checked-out-card />
+    <AccountsCheckedOut @libraries={{array @library}} @statuses={{@statuses}} data-test-checked-out-card />
 
-    <Hds::Card::Container @hasBorder={{true}} class="has-padding-l has-top-margin-l">
-      <h3 class="is-size-4 has-text-weight-semibold">To renew a checked-out account</h3>
-      <p class="has-text-grey has-top-margin-m has-bottom-margin-s">Use the CLI command below:</p>
-
-      <div class="has-padding-s has-background-gray-900 border-radius-4 is-flex-between">
+    <OverviewCard
+      @cardTitle="To renew a checked-out account"
+      @subText="Use the CLI command below:"
+      class="has-padding-l has-top-margin-l"
+    >
+      <div class="has-padding-s has-background-gray-900 border-radius-4 is-flex-between has-top-margin-s">
         <code class="has-text-white is-size-7" data-test-cli-command>{{this.cliCommand}}</code>
         <CopyButton
           class="button is-compact is-transparent has-text-grey-light"
@@ -53,7 +54,7 @@
           <Icon @name="clipboard-copy" aria-label="Copy" />
         </CopyButton>
       </div>
-    </Hds::Card::Container>
+    </OverviewCard>
   </div>
 </div>
 

--- a/ui/lib/ldap/addon/components/page/overview.hbs
+++ b/ui/lib/ldap/addon/components/page/overview.hbs
@@ -8,6 +8,9 @@
       <ToolbarLink @route="roles.create" @type="add" data-test-toolbar-action="role">
         Create role
       </ToolbarLink>
+      <ToolbarLink @route="libraries.create" @type="add" data-test-toolbar-action="library">
+        Create library
+      </ToolbarLink>
     {{/if}}
   </:toolbarActions>
 </TabPageHeader>

--- a/ui/lib/ldap/addon/components/page/overview.hbs
+++ b/ui/lib/ldap/addon/components/page/overview.hbs
@@ -15,5 +15,59 @@
 {{#if @promptConfig}}
   <ConfigCta />
 {{else}}
-  {{! add card components here once created }}
+  <div class="is-grid has-top-margin-l grid-2-columns grid-gap-2">
+    <OverviewCard
+      @cardTitle="Roles"
+      @subText="The total number of roles that have been set up in this secret engine in order to generate credentials."
+      @actionText={{if @roles.length "View roles" "Create new"}}
+      @actionTo={{if @roles.length "roles" "roles.create"}}
+    >
+      <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-roles-count>
+        {{or @roles.length "None"}}
+      </h2>
+    </OverviewCard>
+    <OverviewCard
+      @cardTitle="Libraries"
+      @subText="The total number of libraries that have been created for service account management."
+      @actionText={{if @libraries.length "View libraries" "Create new"}}
+      @actionTo={{if @libraries.length "libraries" "libraries.create"}}
+    >
+      <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-libraries-count>
+        {{or @libraries.length "None"}}
+      </h2>
+    </OverviewCard>
+  </div>
+  <div class="is-flex-align-start has-top-margin-l">
+    <AccountsCheckedOut
+      @libraries={{@libraries}}
+      @statuses={{@librariesStatus}}
+      @showLibraryColumn={{true}}
+      class="is-flex-half"
+    />
+
+    <div class="has-left-margin-l is-flex-half">
+      <OverviewCard @cardTitle="Generate credentials" @subText="Quickly generate credentials by typing the role name.">
+        <div class="has-top-margin-m is-flex">
+          <SearchSelect
+            class="is-flex-1"
+            @placeholder="Select a role"
+            @disallowNewItems={{true}}
+            @options={{@roles}}
+            @selectLimit="1"
+            @fallbackComponent="input-search"
+            @onChange={{this.selectRole}}
+          />
+          <button
+            class="button has-left-margin-s"
+            type="button"
+            disabled={{not this.selectedRole}}
+            {{on "click" this.generateCredentials}}
+            data-test-generate-credential-button
+          >
+            Get credentials
+          </button>
+        </div>
+      </OverviewCard>
+    </div>
+  </div>
 {{/if}}

--- a/ui/lib/ldap/addon/components/page/overview.ts
+++ b/ui/lib/ldap/addon/components/page/overview.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+
+import type LdapLibraryModel from 'vault/models/ldap/library';
+import type SecretEngineModel from 'vault/models/secret-engine';
+import type RouterService from '@ember/routing/router-service';
+import type { Breadcrumb } from 'vault/vault/app-types';
+import LdapRoleModel from 'vault/models/ldap/role';
+import { LdapLibraryAccountStatus } from 'vault/vault/adapters/ldap/library';
+
+interface Args {
+  roles: Array<LdapRoleModel>;
+  libraries: Array<LdapLibraryModel>;
+  librariesStatus: Array<LdapLibraryAccountStatus>;
+  promptConfig: boolean;
+  backendModel: SecretEngineModel;
+  breadcrumbs: Array<Breadcrumb>;
+}
+
+export default class LdapLibrariesPageComponent extends Component<Args> {
+  @service declare readonly router: RouterService;
+
+  @tracked selectedRole: LdapRoleModel | undefined;
+
+  @action
+  selectRole([roleName]: Array<string>) {
+    const model = this.args.roles.find((role) => role.name === roleName);
+    this.selectedRole = model;
+  }
+
+  @action
+  generateCredentials() {
+    const { type, name } = this.selectedRole as LdapRoleModel;
+    this.router.transitionTo('vault.cluster.secrets.backend.ldap.roles.role.credentials', type, name);
+  }
+}

--- a/ui/lib/ldap/addon/templates/overview.hbs
+++ b/ui/lib/ldap/addon/templates/overview.hbs
@@ -3,5 +3,6 @@
   @backendModel={{this.model.backendModel}}
   @roles={{this.model.roles}}
   @libraries={{this.model.libraries}}
+  @librariesStatus={{this.model.librariesStatus}}
   @breadcrumbs={{this.breadcrumbs}}
 />

--- a/ui/tests/integration/components/ldap/page/configuration-test.js
+++ b/ui/tests/integration/components/ldap/page/configuration-test.js
@@ -42,7 +42,12 @@ module('Integration | Component | ldap | Page::Configuration', function (hooks) 
 
     this.renderComponent = () => {
       return render(
-        hbs`<Page::Configuration @backendModel={{this.backend}} @configModel={{this.config}} @configError={{this.error}} @breadcrumbs={{this.breadcrumbs}} />`,
+        hbs`<Page::Configuration
+          @backendModel={{this.backend}}
+          @configModel={{this.config}}
+          @configError={{this.error}}
+          @breadcrumbs={{this.breadcrumbs}}
+        />`,
         {
           owner: this.engine,
         }

--- a/ui/tests/integration/components/ldap/page/configure-test.js
+++ b/ui/tests/integration/components/ldap/page/configure-test.js
@@ -11,6 +11,7 @@ import { render, click, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { Response } from 'miragejs';
 import sinon from 'sinon';
+import { generateBreadcrumbs } from 'vault/tests/helpers/ldap';
 
 const selectors = {
   radioCard: '[data-test-radio-card="OpenLDAP"]',
@@ -46,11 +47,7 @@ module('Integration | Component | ldap | Page::Configure', function (hooks) {
       ...this.existingConfig,
     });
     this.editModel = this.store.peekRecord('ldap/config', 'ldap-edit');
-    this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: 'ldap', route: 'overview' },
-      { label: 'configure' },
-    ];
+    this.breadcrumbs = generateBreadcrumbs('ldap', 'configure');
     this.model = this.newModel; // most of the tests use newModel but set this to editModel when needed
     this.renderComponent = () => {
       return render(

--- a/ui/tests/integration/components/ldap/page/libraries-test.js
+++ b/ui/tests/integration/components/ldap/page/libraries-test.js
@@ -10,6 +10,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render, click, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
+import { createSecretsEngine, generateBreadcrumbs } from 'vault/tests/helpers/ldap';
 
 module('Integration | Component | ldap | Page::Libraries', function (hooks) {
   setupRenderingTest(hooks);
@@ -20,16 +21,8 @@ module('Integration | Component | ldap | Page::Libraries', function (hooks) {
     this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub());
 
     this.store = this.owner.lookup('service:store');
-
-    this.store.pushPayload('secret-engine', {
-      modelName: 'secret-engine',
-      data: {
-        accessor: 'ldap_f3400dee',
-        path: 'ldap-test/',
-        type: 'ldap',
-      },
-    });
-    this.backend = this.store.peekRecord('secret-engine', 'ldap-test');
+    this.backend = createSecretsEngine(this.store);
+    this.breadcrumbs = generateBreadcrumbs(this.backend.id);
 
     for (const name of ['foo', 'bar']) {
       this.store.pushPayload('ldap/library', {
@@ -39,16 +32,16 @@ module('Integration | Component | ldap | Page::Libraries', function (hooks) {
       });
     }
     this.libraries = this.store.peekAll('ldap/library');
-
-    this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.backend.id },
-    ];
     this.promptConfig = false;
 
     this.renderComponent = () => {
       return render(
-        hbs`<Page::Libraries @promptConfig={{this.promptConfig}} @backendModel={{this.backend}} @libraries={{this.libraries}} @breadcrumbs={{this.breadcrumbs}} />`,
+        hbs`<Page::Libraries
+          @promptConfig={{this.promptConfig}}
+          @backendModel={{this.backend}}
+          @libraries={{this.libraries}}
+          @breadcrumbs={{this.breadcrumbs}}
+        />`,
         { owner: this.engine }
       );
     };

--- a/ui/tests/integration/components/ldap/page/library/details/accounts-test.js
+++ b/ui/tests/integration/components/ldap/page/library/details/accounts-test.js
@@ -29,8 +29,14 @@ module('Integration | Component | ldap | Page::Library::Details::Accounts', func
     });
     this.model = this.store.peekRecord('ldap/library', 'test-library');
     this.statuses = [
-      { account: 'foo.bar', available: false, borrower_client_token: '123', borrower_entity_id: '456' },
-      { account: 'bar.baz', available: true },
+      {
+        account: 'foo.bar',
+        available: false,
+        library: 'test-library',
+        borrower_client_token: '123',
+        borrower_entity_id: '456',
+      },
+      { account: 'bar.baz', available: true, library: 'test-library' },
     ];
     this.renderComponent = () => {
       return render(

--- a/ui/tests/integration/components/ldap/page/overview-test.js
+++ b/ui/tests/integration/components/ldap/page/overview-test.js
@@ -7,14 +7,10 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupEngine } from 'ember-engines/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { render } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { createSecretsEngine, generateBreadcrumbs } from 'vault/tests/helpers/ldap';
-
-const selectors = {
-  configAction: '[data-test-toolbar-action="config"]',
-  configCta: '[data-test-config-cta]',
-};
+import sinon from 'sinon';
 
 module('Integration | Component | ldap | Page::Overview', function (hooks) {
   setupRenderingTest(hooks);
@@ -24,16 +20,34 @@ module('Integration | Component | ldap | Page::Overview', function (hooks) {
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');
 
-    this.backend = createSecretsEngine(this.store);
-    this.breadcrumbs = generateBreadcrumbs(this.backend.id);
+    this.backendModel = createSecretsEngine(this.store);
+    this.breadcrumbs = generateBreadcrumbs(this.backendModel.id);
+
+    const pushPayload = (type) => {
+      this.store.pushPayload(`ldap/${type}`, {
+        modelName: `ldap/${type}`,
+        backend: 'ldap-test',
+        ...this.server.create(`ldap-${type}`),
+      });
+    };
+
+    ['role', 'library'].forEach((type) => {
+      pushPayload(type);
+      if (type === 'role') {
+        pushPayload(type);
+      }
+      const key = type === 'role' ? 'roles' : 'libraries';
+      this[key] = this.store.peekAll(`ldap/${type}`);
+    });
 
     this.renderComponent = () => {
       return render(
         hbs`<Page::Overview
           @promptConfig={{this.promptConfig}}
-          @backendModel={{this.backend}}
+          @backendModel={{this.backendModel}}
           @roles={{this.roles}}
           @libraries={{this.libraries}}
+          @librariesStatus={{(array)}}
           @breadcrumbs={{this.breadcrumbs}}
         />`,
         {
@@ -50,9 +64,33 @@ module('Integration | Component | ldap | Page::Overview', function (hooks) {
 
     assert.dom('.title svg').hasClass('flight-icon-folder-users', 'LDAP icon renders in title');
     assert.dom('.title').hasText('ldap-test', 'Mount path renders in title');
-    assert.dom(selectors.configAction).hasText('Configure LDAP', 'Correct toolbar action renders');
-    assert.dom(selectors.configCta).exists('Config cta renders');
+    assert
+      .dom('[data-test-toolbar-action="config"]')
+      .hasText('Configure LDAP', 'Correct toolbar action renders');
+    assert.dom('[data-test-config-cta]').exists('Config cta renders');
   });
 
-  // TODO:JLR add test to check that card components render once created and that Create role action renders in toolbar
+  test('it should render toolbar actions and overview cards', async function (assert) {
+    const transitionStub = sinon.stub(this.owner.lookup('service:router'), 'transitionTo');
+
+    await this.renderComponent();
+
+    assert.dom('[data-test-toolbar-action="role"]').hasText('Create role', 'Correct toolbar action renders');
+    assert.dom('[data-test-roles-count]').hasText('2', 'Roles card renders with correct count');
+    assert.dom('[data-test-libraries-count]').hasText('1', 'Libraries card renders with correct count');
+    assert
+      .dom('[data-test-overview-card-container="Accounts checked-out"]')
+      .exists('Accounts checked-out card renders');
+
+    await click('[data-test-component="search-select"] .ember-power-select-trigger');
+    await click('.ember-power-select-option');
+    await click('[data-test-generate-credential-button]');
+
+    const didTransition = transitionStub.calledWith(
+      'vault.cluster.secrets.backend.ldap.roles.role.credentials',
+      this.roles[0].type,
+      this.roles[0].name
+    );
+    assert.true(didTransition, 'Transitions to credentials route when generating credentials');
+  });
 });

--- a/ui/tests/integration/components/ldap/page/overview-test.js
+++ b/ui/tests/integration/components/ldap/page/overview-test.js
@@ -76,6 +76,9 @@ module('Integration | Component | ldap | Page::Overview', function (hooks) {
     await this.renderComponent();
 
     assert.dom('[data-test-toolbar-action="role"]').hasText('Create role', 'Correct toolbar action renders');
+    assert
+      .dom('[data-test-toolbar-action="library"]')
+      .hasText('Create library', 'Correct toolbar action renders');
     assert.dom('[data-test-roles-count]').hasText('2', 'Roles card renders with correct count');
     assert.dom('[data-test-libraries-count]').hasText('1', 'Libraries card renders with correct count');
     assert

--- a/ui/tests/integration/components/ldap/page/roles-test.js
+++ b/ui/tests/integration/components/ldap/page/roles-test.js
@@ -10,6 +10,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render, click, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
+import { createSecretsEngine, generateBreadcrumbs } from 'vault/tests/helpers/ldap';
 
 module('Integration | Component | ldap | Page::Roles', function (hooks) {
   setupRenderingTest(hooks);
@@ -20,14 +21,9 @@ module('Integration | Component | ldap | Page::Roles', function (hooks) {
     this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub());
 
     this.store = this.owner.lookup('service:store');
-    this.store.pushPayload('secret-engine', {
-      modelName: 'secret-engine',
-      data: {
-        accessor: 'ldap_f3400dee',
-        path: 'ldap-test/',
-        type: 'ldap',
-      },
-    });
+    this.backend = createSecretsEngine(this.store);
+    this.breadcrumbs = generateBreadcrumbs(this.backend.id);
+
     for (const type of ['static', 'dynamic']) {
       this.store.pushPayload('ldap/role', {
         modelName: 'ldap/role',
@@ -38,15 +34,16 @@ module('Integration | Component | ldap | Page::Roles', function (hooks) {
     }
     this.backend = this.store.peekRecord('secret-engine', 'ldap-test');
     this.roles = this.store.peekAll('ldap/role');
-    this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.backend.id },
-    ];
     this.promptConfig = false;
 
     this.renderComponent = () => {
       return render(
-        hbs`<Page::Roles @promptConfig={{this.promptConfig}} @backendModel={{this.backend}} @roles={{this.roles}} @breadcrumbs={{this.breadcrumbs}} />`,
+        hbs`<Page::Roles
+          @promptConfig={{this.promptConfig}}
+          @backendModel={{this.backend}}
+          @roles={{this.roles}}
+          @breadcrumbs={{this.breadcrumbs}}
+        />`,
         { owner: this.engine }
       );
     };

--- a/ui/types/vault/adapters/ldap/library.d.ts
+++ b/ui/types/vault/adapters/ldap/library.d.ts
@@ -9,6 +9,7 @@ import { AdapterRegistry } from 'ember-data/adapter';
 export interface LdapLibraryAccountStatus {
   account: string;
   available: boolean;
+  library: string;
   borrower_client_token?: string;
   borrower_entity_id?: string;
 }


### PR DESCRIPTION
This PR adds overview cards for roles, libraries, checked-out accounts and generating credentials to the ldap overview route.

![image](https://github.com/hashicorp/vault/assets/24611656/0c01b9a9-5dbe-4579-9542-9134772eaa75)
