### PR TITLE
secrets/ldap: upgrade to v0.9.2 for bug fix

### DIFF
--- a/changelog/22332.txt
+++ b/changelog/22332.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/ldap: Fix bug causing schema and password_policy to be overwritten in config. 
+```

--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.2.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.13.3
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.8.0
-	github.com/hashicorp/vault-plugin-secrets-openldap v0.9.1
+	github.com/hashicorp/vault-plugin-secrets-openldap v0.9.2
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.6.0
 	github.com/hashicorp/vault-testing-stepwise v0.1.2
 	github.com/hashicorp/vault/api v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1155,8 +1155,8 @@ github.com/hashicorp/vault-plugin-secrets-kv v0.13.3 h1:TUKpQY6fmTiUhaZ71/WTamEu
 github.com/hashicorp/vault-plugin-secrets-kv v0.13.3/go.mod h1:ikPuEWi2rHaGQCHZuPdn/6D3Bq/25ElX3G9pGeDr0Yg=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.8.0 h1:VREm+cJGUXcPCakaYVxQt8wTVqTwJclsIIk2XuqpPbs=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.8.0/go.mod h1:PLx2vxXukfsKsDRo/PlG4fxmJ1d+H2h82wT3vf4buuI=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.9.1 h1:qgxKfXQ2WaBohjBr0m4EWYNQJTBO6dkhtqJJZ372YQw=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.9.1/go.mod h1:o7mF9tWgDkAD5OvvXWM3bOCqN+n/cCpaMm1CrEUZkHc=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.9.2 h1:zmvg+QkSAY88xFKM6jsQ3fif3Itsptr7FN5+D90S5ic=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.9.2/go.mod h1:o7mF9tWgDkAD5OvvXWM3bOCqN+n/cCpaMm1CrEUZkHc=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.6.0 h1:N5s1ojXyG8gBZlx6BdqE04LviR0rw4vX1dDDMdnEzX8=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.6.0/go.mod h1:GzYAJYytgbNNyT3S7rspz1cLE53E1oajFbEtaDUlVGU=
 github.com/hashicorp/vault-testing-stepwise v0.1.1/go.mod h1:3vUYn6D0ZadvstNO3YQQlIcp7u1a19MdoOC0NQ0yaOE=


### PR DESCRIPTION
Fix ldap secrets engine bug causing schema and password_policy to be overwritten in config. Bump version to v0.9.2