### PR TITLE
Allow use of `token` metadata when templating

### DIFF
--- a/sdk/helper/identitytpl/templating.go
+++ b/sdk/helper/identitytpl/templating.go
@@ -352,9 +352,6 @@ func performTemplating(input string, p *PopulateStringInput) (string, error) {
 
 	performTokenTemplating := func(trimmed string) (string, error) {
 		switch {
-		case trimmed == "display_name":
-			return p.templateHandler(p.Token.DisplayName)
-
 		case trimmed == "metadata":
 			return p.templateHandler(p.Token.Meta)
 

--- a/sdk/helper/identitytpl/templating.go
+++ b/sdk/helper/identitytpl/templating.go
@@ -351,6 +351,9 @@ func performTemplating(input string, p *PopulateStringInput) (string, error) {
 	}
 
 	performTokenTemplating := func(trimmed string) (string, error) {
+		if p.Token == nil {
+			return "", ErrTemplateValueNotFound
+		}
 		switch {
 		case trimmed == "metadata":
 			return p.templateHandler(p.Token.Meta)

--- a/vault/capabilities.go
+++ b/vault/capabilities.go
@@ -79,7 +79,7 @@ func (c *Core) Capabilities(ctx context.Context, token, path string) ([]string, 
 	// Construct the corresponding ACL object. ACL construction should be
 	// performed on the token's namespace.
 	tokenCtx := namespace.ContextWithNamespace(ctx, tokenNS)
-	acl, err := c.policyStore.ACL(tokenCtx, entity, policyNames, policies...)
+	acl, err := c.policyStore.ACL(tokenCtx, te, entity, policyNames, policies...)
 	if err != nil {
 		return nil, err
 	}

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -118,7 +118,7 @@ func (e extendedSystemViewImpl) SudoPrivilege(ctx context.Context, path string, 
 
 	// Construct the corresponding ACL object. Derive and use a new context that
 	// uses the req.ClientToken's namespace
-	acl, err := e.core.policyStore.ACL(tokenCtx, entity, policyNames, policies...)
+	acl, err := e.core.policyStore.ACL(tokenCtx, te, entity, policyNames, policies...)
 	if err != nil {
 		e.core.logger.Error("failed to retrieve ACL for token's policies", "token_policies", te.Policies, "error", err)
 		return false

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -878,6 +878,9 @@ func (i *IdentityStore) pathOIDCGenerateToken(ctx context.Context, req *logical.
 		return nil, err
 	}
 
+	// Resolve the token
+	te, _ := i.tokenStorer.LookupToken(ctx, req.ClientToken)
+
 	roleName := d.Get("name").(string)
 
 	role, err := i.getOIDCRole(ctx, req.Storage, roleName)
@@ -952,6 +955,7 @@ func (i *IdentityStore) pathOIDCGenerateToken(ctx context.Context, req *logical.
 		String:      role.Template,
 		Entity:      identity.ToSDKEntity(e),
 		Groups:      identity.ToSDKGroups(groups),
+		Token:       te,
 		NamespaceID: ns.ID,
 	})
 	if err != nil {
@@ -1194,6 +1198,7 @@ func (i *IdentityStore) pathOIDCCreateUpdateRole(ctx context.Context, req *logic
 			String: role.Template,
 			Entity: new(logical.Entity),
 			Groups: make([]*logical.Group, 0),
+			Token:  new(logical.TokenEntry),
 			// namespace?
 		})
 		if err != nil {

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -803,7 +803,7 @@ func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, po
 
 // ACL is used to return an ACL which is built using the
 // named policies and pre-fetched policies if given.
-func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyNames map[string][]string, additionalPolicies ...*Policy) (*ACL, error) {
+func (ps *PolicyStore) ACL(ctx context.Context, token *logical.TokenEntry, entity *identity.Entity, policyNames map[string][]string, additionalPolicies ...*Policy) (*ACL, error) {
 	var allPolicies []*Policy
 
 	// Fetch the named policies
@@ -844,7 +844,7 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 					groups = append(directGroups, inheritedGroups...)
 				}
 			}
-			p, err := parseACLPolicyWithTemplating(policy.namespace, policy.Raw, true, entity, groups)
+			p, err := parseACLPolicyWithTemplating(policy.namespace, policy.Raw, true, token, entity, groups)
 			if err != nil {
 				return nil, fmt.Errorf("error parsing templated policy %q: %w", policy.Name, err)
 			}

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -272,7 +272,7 @@ func testPolicyStoreACL(t *testing.T, ps *PolicyStore, ns *namespace.Namespace) 
 	}
 
 	ctx = namespace.ContextWithNamespace(context.Background(), ns)
-	acl, err := ps.ACL(ctx, nil, map[string][]string{ns.ID: {"dev", "ops"}})
+	acl, err := ps.ACL(ctx, nil, nil, map[string][]string{ns.ID: {"dev", "ops"}})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -255,7 +255,7 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 
 	// Construct the corresponding ACL object. ACL construction should be
 	// performed on the token's namespace.
-	acl, err := c.policyStore.ACL(tokenCtx, entity, policyNames, policies...)
+	acl, err := c.policyStore.ACL(tokenCtx, te, entity, policyNames, policies...)
 	if err != nil {
 		c.logger.Error("failed to construct ACL", "error", err)
 		return nil, nil, nil, nil, ErrInternalError


### PR DESCRIPTION
Based on the change proposed in https://github.com/hashicorp/vault/pull/7761, and aiming to address issue https://github.com/hashicorp/vault/issues/22335

Allow the usage of `token.metadata` in templating of ACL policies and OIDC claims.
