### PR TITLE
change: update the license of shamir to MPLv2.0

### DIFF
--- a/changelog/22350.txt
+++ b/changelog/22350.txt
@@ -1,0 +1,3 @@
+```release-note:change
+shamir: update the license of shamir to MPLv2.0 
+```

--- a/shamir/shamir.go
+++ b/shamir/shamir.go
@@ -1,5 +1,5 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MPL-2.0
 
 package shamir
 

--- a/shamir/shamir_test.go
+++ b/shamir/shamir_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MPL-2.0
 
 package shamir
 


### PR DESCRIPTION
Following the discussion on gh-22318. It was confirmed that the `shamir/` package can be licensed under MPLv2.0