### PR TITLE
Skip security-scan and test comment notifications on community PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,7 +357,11 @@ jobs:
       needs.test-go-fips.result == 'success' ||
       needs.test-go-fips.result == 'failure' ||
       needs.test-go-race.result == 'success' ||
-      needs.test-go-race.result == 'failure')
+      needs.test-go-race.result == 'failure') &&
+      (github.repository == 'hashicorp/vault' &&
+      (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name))
+    # The last check ensures this doesn't run on community-contributed PRs, who
+    # won't have the permissions to run this job.
     needs:
       - test-go
       - test-go-fips

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,7 +11,10 @@ on:
 jobs:
   scan:
     runs-on: ['linux', 'large']
-    if: ${{ github.actor != 'dependabot[bot]' || github.actor != 'hc-github-team-secure-vault-core' }}
+    # The first check ensures this doesn't run on community-contributed PRs, who
+    # won't have the permissions to run this job.
+    if: ${{ (github.repository == 'hashicorp/vault' && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name))
+          && (github.actor != 'dependabot[bot]' || github.actor != 'hc-github-team-secure-vault-core') }}
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 


### PR DESCRIPTION
These two jobs would simply fail on community PRs, with no way to make them pass, due to permissions issues. This should skip them.