### PR TITLE
audit: remove extra metric

### DIFF
--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -216,14 +216,7 @@ func (a *AuditBroker) LogRequest(ctx context.Context, in *logical.LogInput, head
 
 			e.Data = in
 
-			start := time.Now()
 			_, err = a.broker.Send(ctx, eventlogger.EventType(event.AuditType.String()), e)
-			// TODO: old behavior includes the name (path) for the audit device,
-			// but we cannot know this anymore, do we just omit it, or include
-			// something like 'all'?
-			// If we can later change the semantics of the eventbroker to report back
-			// as sinks complete then we might be able to reinstate the old behavior.
-			metrics.MeasureSince([]string{"audit", "log_request"}, start)
 			if err != nil {
 				retErr = multierror.Append(retErr, err)
 			}
@@ -304,14 +297,7 @@ func (a *AuditBroker) LogResponse(ctx context.Context, in *logical.LogInput, hea
 
 			e.Data = in
 
-			start := time.Now()
 			_, err = a.broker.Send(ctx, eventlogger.EventType(event.AuditType.String()), e)
-			// TODO: old behavior includes the name (path) for the audit device,
-			// but we cannot know this anymore, do we just omit it, or include
-			// something like 'all'?
-			// If we can later change the semantics of the eventbroker to report back
-			// as sinks complete then we might be able to reinstate the old behavior.
-			metrics.MeasureSince([]string{"audit", "log_response"}, start)
 			if err != nil {
 				retErr = multierror.Append(retErr, err)
 			}


### PR DESCRIPTION
This PR removes duplicate metric logging for an audit request and response. 