### PR TITLE
Add clarification about TLS configuration options needed to enable TL…

### DIFF
--- a/website/content/docs/auth/cert.mdx
+++ b/website/content/docs/auth/cert.mdx
@@ -22,7 +22,7 @@ external source.
 CA certificates are associated with a role; role names and CRL names are normalized to
 lower-case.
 
-Please note that to use this auth method, `tls_disable` must be false in the Vault
+Please note that to use this auth method, `tls_disable` and `tls_disable_client_certs` must be false in the Vault
 configuration. This is because the certificates are sent through TLS communication itself.
 
 ## Revocation checking


### PR DESCRIPTION
…S cert authentication.

Clarification added by a customer's request, as tls_disable_client_certs being set to false was found to also be necessary for TLS cert authentication.