### PR TITLE
Prevent a deadlock in expiration

### DIFF
--- a/changelog/22374.txt
+++ b/changelog/22374.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+expiration: Fix a deadlock that could occur when a revocation failure happens while restoring leases on startup.
+```

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -241,11 +241,11 @@ func (r *revocationJob) OnFailure(err error) {
 
 	r.m.pendingLock.Lock()
 	pendingRaw, ok := r.m.pending.Load(r.leaseID)
+	r.m.pendingLock.Unlock()
 	if !ok {
 		r.m.logger.Warn("failed to find lease in pending map for revocation retry", "lease_id", r.leaseID)
 		return
 	}
-	r.m.pendingLock.Unlock()
 
 	pending := pendingRaw.(pendingInfo)
 	pending.revokesAttempted++

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -269,7 +269,9 @@ func (r *revocationJob) OnFailure(err error) {
 			return
 		}
 
+		r.m.pendingLock.Lock()
 		r.m.markLeaseIrrevocable(r.nsCtx, le, err)
+		r.m.pendingLock.Unlock()
 		return
 	} else {
 		r.m.logger.Error("failed to revoke lease", "lease_id", r.leaseID, "error", err,


### PR DESCRIPTION
Deadlock occurs when Restore grabs lease lock then pending lock, while a revocationJob's OnFailure grabs those lock in the reverse order.