### PR TITLE
ui: add deleted and updated time to kv secret

### DIFF
--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -35,7 +35,6 @@ export default class KvSecretDetails extends Component {
   @tracked showJsonView = false;
   @tracked wrappedData = null;
 
-
   @action
   toggleJsonView() {
     this.showJsonView = !this.showJsonView;

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
@@ -52,6 +52,9 @@
   </h2>
   {{#if @metadata.canReadMetadata}}
     <div class="box is-fullwidth is-sideless is-paddingless is-marginless" data-test-kv-metadata-section>
+      <InfoTableRow @alwaysRender={{true}} @label="Last updated">
+        <KvTooltipTimestamp @timestamp={{@metadata.updatedTime}} />
+      </InfoTableRow>
       <InfoTableRow @alwaysRender={{true}} @label="Maximum versions" @value={{@metadata.maxVersions}} />
       <InfoTableRow @alwaysRender={{true}} @label="Check-and-Set required" @value={{@metadata.casRequired}} />
       <InfoTableRow

--- a/ui/lib/kv/addon/components/page/secret/metadata/version-history.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/version-history.hbs
@@ -5,7 +5,12 @@
     <LinkTo @route="secret.metadata.versions" data-test-secrets-tab="Version History">Version History</LinkTo>
   </:tabLinks>
 </KvPageHeader>
+
+<Toolbar />
 {{#if @metadata.canReadMetadata}}
+  <div class="sub-text has-text-weight-semibold is-flex-end">
+    <KvTooltipTimestamp @text="Secret last updated" @timestamp={{@metadata.updatedTime}} />
+  </div>
   {{#each @metadata.sortedVersions as |versionData|}}
     <LinkedBlock
       class="list-item-row"
@@ -34,7 +39,8 @@
             {{else if versionData.deletion_time}}
               <div>
                 <span class="has-text-grey is-size-8 is-block">
-                  <Icon @name="x-square-fill" />Deleted
+                  <Icon @name="x-square-fill" />
+                  <KvTooltipTimestamp @text="Deleted" @timestamp={{versionData.deletion_time}} />
                 </span>
               </div>
             {{else if (loose-equal versionData.version @metadata.currentVersion)}}

--- a/ui/lib/kv/addon/components/page/secret/metadata/version-history.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/version-history.hbs
@@ -8,7 +8,7 @@
 
 <Toolbar />
 {{#if @metadata.canReadMetadata}}
-  <div class="sub-text has-text-weight-semibold is-flex-end">
+  <div class="sub-text has-text-weight-semibold is-flex-end has-short-padding">
     <KvTooltipTimestamp @text="Secret last updated" @timestamp={{@metadata.updatedTime}} />
   </div>
   {{#each @metadata.sortedVersions as |versionData|}}


### PR DESCRIPTION
All of the timestamps are hover-able and render the ISO timestamp 
- Adds `updated_time` to the metadata details as `Last updated`
- Adds `updated_time` to version history view
- Adds `deletion_time` to deleted secrets in version history

<img width="1074" alt="Screenshot 2023-08-16 at 1 15 14 PM" 
src="https://github.com/hashicorp/vault/assets/68122737/fa8ec7f3-18f3-40b9-98e4-015e8ce4174f">

<img width="1085" alt="Screenshot 2023-08-16 at 1 20 54 PM" src="https://github.com/hashicorp/vault/assets/68122737/d50947fe-b3f1-4fe1-9c5d-b5d011a1366e">
