### PR TITLE
Revoke Token Confirmation Text Fix

### DIFF
--- a/changelog/22390.txt
+++ b/changelog/22390.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes text readability issue in revoke token confirmation dialog
+```

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -17,6 +17,12 @@
       padding: $spacing-xs;
     }
   }
+
+  .confirm-action-message p {
+    padding-top: $size-10;
+    font-weight: $font-weight-semibold;
+    color: $black;
+  }
 }
 
 .link-status {

--- a/website/content/docs/enterprise/hsm/index.mdx
+++ b/website/content/docs/enterprise/hsm/index.mdx
@@ -37,5 +37,9 @@ important information on these differences.
 The [Configuration](/vault/docs/configuration/seal/pkcs11) page contains
 configuration information.
 
-Finally, the [Security](/vault/docs/enterprise/hsm/security) page contains
+The [Security](/vault/docs/enterprise/hsm/security) page contains
 information about deploying Vault's HSM support in a secure fashion.
+
+Finally, the [Vault Interoperability Matrix](/vault/docs/interoperability-matrix) page contains
+information about HashiCorp partner products that have been verified to work with Vault 
+for Auto Unsealing / HSM Support and External Key Management.


### PR DESCRIPTION
Small fix for a styling issue in the revoke token confirmation dialog triggered by the revoke action in the user menu. This was noticed while looking into issue #21390.

Before
![image](https://github.com/hashicorp/vault/assets/24611656/198378d0-d72c-4fbd-8dc1-4a64dea4ee68)

After
![image](https://github.com/hashicorp/vault/assets/24611656/76754de0-8cec-46e4-b9a2-f3440affbf05)
