### PR TITLE
UI: remove default setting for `max_versions` in kv metadata

### DIFF
--- a/changelog/22394.txt
+++ b/changelog/22394.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes `max_versions` default for secret metadata unintentionally overriding kv engine defaults
+```

--- a/ui/app/models/secret-v2.js
+++ b/ui/app/models/secret-v2.js
@@ -35,7 +35,7 @@ export default SecretV2Model.extend(KeyMixin, {
     subText: 'An optional set of informational key-value pairs that will be stored with all secret versions.',
   }),
   maxVersions: attr('number', {
-    defaultValue: 10,
+    defaultValue: 0,
     label: 'Maximum number of versions',
     subText:
       'The number of versions to keep per key. Once the number of keys exceeds the maximum number set here, the oldest version will be permanently deleted.',


### PR DESCRIPTION
The default value of a secret's metadata was incorrectly setting `max_versions` to 10 which caused unintended side effects. This PR fixes #8656. Instead of setting the metadata's `max_versions` from the engine's config, leaving unset has the same result without manipulating any values under the hood.

The greater number takes precedence if both the engine _and_ secret metadata have `max_versions` configured. Otherwise, `0` means unset and if **neither** have a `max_versions` value, Vault will keep the 10 latest versions. 

| global (engine) | secret metadata | *versions kept - why?! |
| --------------- | --------------- | --------------------------------------------------------------------- |
| 0 | 0 | But are unset so Vault keeps 10 versions |
| 0 | 2* |  The engine has no global `max_versions` so the metadata value is used |
| 8* | 0 | Metadata `max_versions` is unset so the engine's value is used |
| 3 | 5* | Metadata has a higher `max_versions` number |
| 9* | 2 | Yep, you guessed it! The engine config is higher |

Both metadata `READ` responses below have the same kv engine config: 
```bash
# curl kv/config
=> "data": {
    "cas_required": false,
    "delete_version_after": "0s",
    "max_versions": 3
  }
```

```bash
# curl  kv/metadata/max-2
 => "data": {
    "cas_required": false,
    "created_time": "2023-08-17T03:29:14.58914Z",
    "current_version": 4,
    "custom_metadata": null,
    "delete_version_after": "0s",
    "max_versions": 2, # max_versions is 2 but below 3 are kept because that's the engine config
    "oldest_version": 2,
    "updated_time": "2023-08-17T03:31:09.852191Z",
    "versions": {
      "2": {
        "created_time": "2023-08-17T03:29:23.621884Z",
        "deletion_time": "",
        "destroyed": false
      },
      "3": {
        "created_time": "2023-08-17T03:30:58.966954Z",
        "deletion_time": "",
        "destroyed": false
      },
      "4": {
        "created_time": "2023-08-17T03:31:09.852191Z",
        "deletion_time": "",
        "destroyed": false
      }
    }
  }

# curl kv/metadata/max-5
 => "data": {
    "cas_required": false,
    "created_time": "2023-08-17T03:35:15.076621Z",
    "current_version": 6,
    "custom_metadata": null,
    "delete_version_after": "0s",
    "max_versions": 5, # even though the engine max_versions is 3, the metadata max is used because it's greater
    "oldest_version": 2,
    "updated_time": "2023-08-17T03:35:26.416381Z",
    "versions": {
      "2": {
        "created_time": "2023-08-17T03:35:17.780665Z",
        "deletion_time": "",
        "destroyed": false
      },
      "3": {
        "created_time": "2023-08-17T03:35:20.729444Z",
        "deletion_time": "",
        "destroyed": false
      },
      "4": {
        "created_time": "2023-08-17T03:35:22.889623Z",
        "deletion_time": "",
        "destroyed": false
      },
      "5": {
        "created_time": "2023-08-17T03:35:24.658798Z",
        "deletion_time": "",
        "destroyed": false
      },
      "6": {
        "created_time": "2023-08-17T03:35:26.416381Z",
        "deletion_time": "",
        "destroyed": false
      }
    }
```
> Docs for engine [max_versions](https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#max_versions) 
