### PR TITLE
Move code block outside of 'tip' to resolving layout issues

### DIFF
--- a/website/content/docs/agent-and-proxy/agent/template.mdx
+++ b/website/content/docs/agent-and-proxy/agent/template.mdx
@@ -162,9 +162,12 @@ parameters found in the template configuration section in the consul-template
 [documentation
 page](https://github.com/hashicorp/consul-template/blob/main/docs/configuration.md#templates)
 can be used here:
+
 <Tip>
+
 The parameters marked with `Δ` below are only applicable to file templates and
 cannot be used with `env_template` entries in process supervisor mode.
+
 </Tip>
 
 - `source` `(string: "")` - Path on disk to use as the input template. This

--- a/website/content/docs/internals/telemetry/enable-telemetry.mdx
+++ b/website/content/docs/internals/telemetry/enable-telemetry.mdx
@@ -57,28 +57,26 @@ telemetry {
   num_lease_metrics_buckets = 168
   add_lease_metrics_namespace_labels = false
   filter_default = true
-  
+
   statsite_address = "mycompany.statsite:8125"
 }
 ```
 
 <Tip heading="Use a prefix filter to reduce the volume of metrics you receive">
-
   Many metrics solutions charge by the metric. You can set `filter_default` to
   false and use the `prefix_filter` parameter to include and exclude specific
   values based on metric name to avoid paying for irrelevant information.
-  
-  For example, to limit your telemetry to the core token metrics plus the number
-  of leases set to expire:
-
-  ```hcl
-  telemetry {
-  filter_default = false
-    prefix_filter = ["+vault.token", "-vault.expire", "+vault.expire.num_leases"]
-  }
-  ```
-
 </Tip>
+
+For example, to limit your telemetry to the core token metrics plus the number
+of leases set to expire:
+
+```hcl
+telemetry {
+  filter_default = false
+  prefix_filter = ["+vault.token", "-vault.expire", "+vault.expire.num_leases"]
+}
+```
 
 ## Step 4: Choose a reporting solution
 

--- a/website/content/docs/internals/telemetry/enable-telemetry.mdx
+++ b/website/content/docs/internals/telemetry/enable-telemetry.mdx
@@ -62,10 +62,12 @@ telemetry {
 }
 ```
 
-<Tip heading="Use a prefix filter to reduce the volume of metrics you receive">
+<Tip>
+
   Many metrics solutions charge by the metric. You can set `filter_default` to
   false and use the `prefix_filter` parameter to include and exclude specific
   values based on metric name to avoid paying for irrelevant information.
+
 </Tip>
 
 For example, to limit your telemetry to the core token metrics plus the number


### PR DESCRIPTION
Currently the presence of a code block within a `<tip>` seems to cause issues with rendering. This PR moves the code block and accompanying text to below the actual tip.

[internals - telemetry - enable](https://developer.hashicorp.com/vault/docs/internals/telemetry/enable-telemetry#step-3-configure-telemetry-collection)

**Before**:

![image](https://github.com/hashicorp/vault/assets/487783/e3fc86ed-2fb4-4ae1-90fc-93b8e965f888)

**After**:

![image](https://github.com/hashicorp/vault/assets/487783/b4daf051-7535-4c4b-9a50-405988de68c8)

Deployed here: https://vault-git-docs-internal-telemetry-enablefix-tip-hashicorp.vercel.app/vault/docs/internals/telemetry/enable-telemetry

---

Note: the 'bug' has been reported to the dev portal/ui team.

---

Additionally, it appears that `<tip>` requires newlines either side of content to ensure formatting is applied on markdown such as code.

See the `tip` section on the [agent template configuration](https://developer.hashicorp.com/vault/docs/agent-and-proxy/agent/template#template-configurations)

**Before**:

![image](https://github.com/hashicorp/vault/assets/487783/8412255b-62a7-4b89-a050-7a1f704ef2bb)

**After**:

![image](https://github.com/hashicorp/vault/assets/487783/ea2512f2-41df-460e-93b2-7a229a94088f)
