### PR TITLE
Fix link formatting in Vault lambda extension docs

### DIFF
--- a/changelog/22396.txt
+++ b/changelog/22396.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+website/docs: Fix link formatting in Vault lambda extension docs
+```

--- a/website/content/docs/platform/aws/lambda-extension.mdx
+++ b/website/content/docs/platform/aws/lambda-extension.mdx
@@ -53,7 +53,7 @@ to read secrets, which can both be used side-by-side:
 - An instance of Vault accessible from AWS Lambda
 - An authenticated `vault` client
 - A secret in Vault that you want your Lambda to access, and a policy giving read access to it
-- Your Lambda function must use one of the [supported runtimes][https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html] for extensions
+- Your Lambda function must use one of the [supported runtimes](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html) for extensions
 
 #### Step 1. configure Vault
 


### PR DESCRIPTION
The link pointing to supported lambda runtimes does not use correct markdown formatting so it is not rendered as a link on developer.hashicorp.com. This commit renders it as a link again.

|Before|After|
|-|-|
|![Screen Shot 2023-08-17 at 14 32 19](https://github.com/hashicorp/vault/assets/663247/a8ec50c7-6a20-480e-9101-273fae7c50e4)|![Screen Shot 2023-08-17 at 14 32 07](https://github.com/hashicorp/vault/assets/663247/fee950fa-a90f-4530-9d5d-815330f8c01d)|

