### PR TITLE
[VAULT-17826] Remove mount point from rollback metrics

### DIFF
--- a/changelog/22400.txt
+++ b/changelog/22400.txt
@@ -1,0 +1,3 @@
+```release-note:change
+telemetry: Replace `vault.rollback.attempt.{MOUNT_POINT}` and `vault.route.rollback.{MOUNT_POINT}` metrics with `vault.rollback.attempt` and `vault.route.rollback metrics` by default. Added a telemetry configuration `add_mount_point_rollback_metrics` which, when set to true, causes vault to emit the metrics with mount points in their names.
+```

--- a/command/server/config_telemetry_test.go
+++ b/command/server/config_telemetry_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMetricFilterConfigs(t *testing.T) {
@@ -40,4 +41,36 @@ func TestMetricFilterConfigs(t *testing.T) {
 			assert.Equal(t, tc.expectedPrefixFilter, config.SharedConfig.Telemetry.PrefixFilter)
 		}
 	})
+}
+
+// TestRollbackMountPointMetricsConfig verifies that the add_mount_point_rollback_metrics
+// config option is parsed correctly, when it is set to true. Also verifies that
+// the default for this setting is false
+func TestRollbackMountPointMetricsConfig(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name           string
+		configFile     string
+		wantMountPoint bool
+	}{
+		{
+			name:           "include mount point",
+			configFile:     "./test-fixtures/telemetry/rollback_mount_point.hcl",
+			wantMountPoint: true,
+		},
+		{
+			name:           "exclude mount point",
+			configFile:     "./test-fixtures/telemetry/valid_prefix_filter.hcl",
+			wantMountPoint: false,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			config, err := LoadConfigFile(tc.configFile)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantMountPoint, config.Telemetry.RollbackMetricsIncludeMountPoint)
+		})
+	}
 }

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -846,6 +846,7 @@ func testConfig_Sanitized(t *testing.T) {
 			"lease_metrics_epsilon":                  time.Hour,
 			"num_lease_metrics_buckets":              168,
 			"add_lease_metrics_namespace_labels":     false,
+			"add_mount_point_rollback_metrics":       false,
 		},
 		"administrative_namespace_path": "admin/",
 	}

--- a/command/server/test-fixtures/telemetry/rollback_mount_point.hcl
+++ b/command/server/test-fixtures/telemetry/rollback_mount_point.hcl
@@ -1,0 +1,9 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+disable_mlock = true
+ui            = true
+
+telemetry {
+  add_mount_point_rollback_metrics = true
+}

--- a/helper/metricsutil/wrapped_metrics.go
+++ b/helper/metricsutil/wrapped_metrics.go
@@ -37,9 +37,10 @@ type ClusterMetricSink struct {
 }
 
 type TelemetryConstConfig struct {
-	LeaseMetricsEpsilon         time.Duration
-	NumLeaseMetricsTimeBuckets  int
-	LeaseMetricsNameSpaceLabels bool
+	LeaseMetricsEpsilon              time.Duration
+	NumLeaseMetricsTimeBuckets       int
+	LeaseMetricsNameSpaceLabels      bool
+	RollbackMetricsIncludeMountPoint bool
 }
 
 type Metrics interface {

--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -271,6 +271,7 @@ func (c *SharedConfig) Sanitized() map[string]interface{} {
 			"lease_metrics_epsilon":                  c.Telemetry.LeaseMetricsEpsilon,
 			"num_lease_metrics_buckets":              c.Telemetry.NumLeaseMetricsTimeBuckets,
 			"add_lease_metrics_namespace_labels":     c.Telemetry.LeaseMetricsNameSpaceLabels,
+			"add_mount_point_rollback_metrics":       c.Telemetry.RollbackMetricsIncludeMountPoint,
 		}
 		result["telemetry"] = sanitizedTelemetry
 	}

--- a/internalshared/configutil/telemetry.go
+++ b/internalshared/configutil/telemetry.go
@@ -162,6 +162,10 @@ type Telemetry struct {
 	// PrefixFilter is a list of filter rules to apply for allowing
 	// or blocking metrics by prefix.
 	PrefixFilter []string `hcl:"prefix_filter"`
+
+	// Whether or not telemetry should include the mount point in the rollback
+	// metrics
+	RollbackMetricsIncludeMountPoint bool `hcl:"add_mount_point_rollback_metrics"`
 }
 
 func (t *Telemetry) Validate(source string) []ConfigError {
@@ -402,6 +406,7 @@ func SetupTelemetry(opts *SetupTelemetryOpts) (*metrics.InmemSink, *metricsutil.
 	wrapper.TelemetryConsts.LeaseMetricsEpsilon = opts.Config.LeaseMetricsEpsilon
 	wrapper.TelemetryConsts.LeaseMetricsNameSpaceLabels = opts.Config.LeaseMetricsNameSpaceLabels
 	wrapper.TelemetryConsts.NumLeaseMetricsTimeBuckets = opts.Config.NumLeaseMetricsTimeBuckets
+	wrapper.TelemetryConsts.RollbackMetricsIncludeMountPoint = opts.Config.RollbackMetricsIncludeMountPoint
 
 	// Parse the metric filters
 	telemetryAllowedPrefixes, telemetryBlockedPrefixes, err := parsePrefixFilter(opts.Config.PrefixFilter)

--- a/vault/core.go
+++ b/vault/core.go
@@ -673,7 +673,8 @@ type Core struct {
 	// heartbeating with the active node. Default to the current SDK version.
 	effectiveSDKVersion string
 
-	rollbackPeriod time.Duration
+	rollbackPeriod           time.Duration
+	rollbackMountPathMetrics bool
 
 	experiments []string
 
@@ -1023,6 +1024,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		experiments:                    conf.Experiments,
 		pendingRemovalMountsAllowed:    conf.PendingRemovalMountsAllowed,
 		expirationRevokeRetryBase:      conf.ExpirationRevokeRetryBase,
+		rollbackMountPathMetrics:       conf.MetricSink.TelemetryConsts.RollbackMetricsIncludeMountPoint,
 	}
 
 	c.standbyStopCh.Store(make(chan struct{}))
@@ -1032,6 +1034,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 	c.shutdownDoneCh.Store(make(chan struct{}))
 
 	c.router.logger = c.logger.Named("router")
+	c.router.rollbackMetricsMountName = c.rollbackMountPathMetrics
 
 	c.inFlightReqData = &InFlightRequests{
 		InFlightReqMap:   &sync.Map{},

--- a/vault/rollback.go
+++ b/vault/rollback.go
@@ -39,9 +39,10 @@ type RollbackManager struct {
 	router *Router
 	period time.Duration
 
-	inflightAll  sync.WaitGroup
-	inflight     map[string]*rollbackState
-	inflightLock sync.RWMutex
+	rollbackMetricsMountName bool
+	inflightAll              sync.WaitGroup
+	inflight                 map[string]*rollbackState
+	inflightLock             sync.RWMutex
 
 	doneCh          chan struct{}
 	shutdown        bool
@@ -52,6 +53,8 @@ type RollbackManager struct {
 	quitContext     context.Context
 
 	core *Core
+	// This channel is used for testing
+	rollbacksDoneCh chan struct{}
 }
 
 // rollbackState is used to track the state of a single rollback attempt
@@ -65,16 +68,18 @@ type rollbackState struct {
 // NewRollbackManager is used to create a new rollback manager
 func NewRollbackManager(ctx context.Context, logger log.Logger, backendsFunc func() []*MountEntry, router *Router, core *Core) *RollbackManager {
 	r := &RollbackManager{
-		logger:      logger,
-		backends:    backendsFunc,
-		router:      router,
-		period:      core.rollbackPeriod,
-		inflight:    make(map[string]*rollbackState),
-		doneCh:      make(chan struct{}),
-		shutdownCh:  make(chan struct{}),
-		stopTicker:  make(chan struct{}),
-		quitContext: ctx,
-		core:        core,
+		logger:                   logger,
+		backends:                 backendsFunc,
+		router:                   router,
+		period:                   core.rollbackPeriod,
+		inflight:                 make(map[string]*rollbackState),
+		doneCh:                   make(chan struct{}),
+		shutdownCh:               make(chan struct{}),
+		stopTicker:               make(chan struct{}),
+		quitContext:              ctx,
+		core:                     core,
+		rollbackMetricsMountName: core.rollbackMountPathMetrics,
+		rollbacksDoneCh:          make(chan struct{}),
 	}
 	return r
 }
@@ -121,7 +126,6 @@ func (m *RollbackManager) run() {
 		select {
 		case <-tick.C:
 			m.triggerRollbacks()
-
 		case <-m.shutdownCh:
 			m.logger.Info("stopping rollback manager")
 			return
@@ -179,14 +183,23 @@ func (m *RollbackManager) startOrLookupRollback(ctx context.Context, fullPath st
 	m.inflight[fullPath] = rs
 	rs.Add(1)
 	m.inflightAll.Add(1)
-	go m.attemptRollback(ctx, fullPath, rs, grabStatelock)
+	go func() {
+		m.attemptRollback(ctx, fullPath, rs, grabStatelock)
+		select {
+		case m.rollbacksDoneCh <- struct{}{}:
+		default:
+		}
+	}()
 	return rs
 }
 
 // attemptRollback invokes a RollbackOperation for the given path
 func (m *RollbackManager) attemptRollback(ctx context.Context, fullPath string, rs *rollbackState, grabStatelock bool) (err error) {
-	defer metrics.MeasureSince([]string{"rollback", "attempt"}, time.Now())
-
+	metricName := []string{"rollback", "attempt"}
+	if m.rollbackMetricsMountName {
+		metricName = append(metricName, strings.ReplaceAll(fullPath, "/", "-"))
+	}
+	defer metrics.MeasureSince(metricName, time.Now())
 	defer func() {
 		rs.lastError = err
 		rs.Done()

--- a/vault/rollback.go
+++ b/vault/rollback.go
@@ -185,7 +185,7 @@ func (m *RollbackManager) startOrLookupRollback(ctx context.Context, fullPath st
 
 // attemptRollback invokes a RollbackOperation for the given path
 func (m *RollbackManager) attemptRollback(ctx context.Context, fullPath string, rs *rollbackState, grabStatelock bool) (err error) {
-	defer metrics.MeasureSince([]string{"rollback", "attempt", strings.ReplaceAll(fullPath, "/", "-")}, time.Now())
+	defer metrics.MeasureSince([]string{"rollback", "attempt"}, time.Now())
 
 	defer func() {
 		rs.lastError = err

--- a/vault/rollback_test.go
+++ b/vault/rollback_test.go
@@ -5,14 +5,20 @@ package vault
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/armon/go-metrics"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/stretchr/testify/require"
 )
 
 // mockRollback returns a mock rollback manager
@@ -118,5 +124,85 @@ func TestRollbackManager_Join(t *testing.T) {
 	err := <-errCh
 	if err != nil {
 		t.Fatalf("Error on rollback:%v", err)
+	}
+}
+
+// TestRollbackMetrics verifies that the rollback metrics only include the mount
+// point in their names when RollbackMetricsIncludeMountPoint is true.
+// This test cannot be run in parallel, because we are using the global metrics
+// instance
+func TestRollbackMetrics(t *testing.T) {
+	testCases := []struct {
+		name          string
+		addMountPoint bool
+	}{
+		{
+			name:          "include mount point",
+			addMountPoint: true,
+		},
+		{
+			name:          "exclude mount point",
+			addMountPoint: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inMemSink := metrics.NewInmemSink(10000*time.Hour, 10000*time.Hour)
+			sink := metricsutil.NewClusterMetricSink("test", inMemSink)
+			sink.TelemetryConsts.RollbackMetricsIncludeMountPoint = tc.addMountPoint
+			_, err := metrics.NewGlobal(metrics.DefaultConfig("vault"), inMemSink)
+			require.NoError(t, err)
+			conf := &CoreConfig{
+				MetricSink:     sink,
+				RollbackPeriod: 50 * time.Millisecond,
+				MetricsHelper:  metricsutil.NewMetricsHelper(inMemSink, true),
+			}
+
+			core, _, _ := TestCoreUnsealedWithConfig(t, conf)
+
+			samplesWith := func(intervals []*metrics.IntervalMetrics, with func(string) bool) []metrics.SampledValue {
+				t.Helper()
+				samples := make([]metrics.SampledValue, 0)
+				for _, interval := range intervals {
+					for name, summary := range interval.Samples {
+						if with(name) {
+							samples = append(samples, summary)
+						}
+					}
+				}
+				return samples
+			}
+
+			<-core.rollback.rollbacksDoneCh
+			intervals := inMemSink.Data()
+
+			mountPointAttempts := samplesWith(intervals, func(s string) bool {
+				return strings.HasPrefix(s, "vault.rollback.attempt.")
+			})
+			mountPointRoutes := samplesWith(intervals, func(s string) bool {
+				return strings.HasPrefix(s, "vault.route.rollback.")
+			})
+
+			noMountPointAttempts := samplesWith(intervals, func(s string) bool {
+				return s == "vault.rollback.attempt"
+			})
+			noMountPointRoutes := samplesWith(intervals, func(s string) bool {
+				return s == "vault.route.rollback"
+			})
+			o, err := json.Marshal(intervals)
+			require.NoError(t, err)
+			fmt.Println(string(o))
+			if tc.addMountPoint {
+				require.NotEmpty(t, mountPointAttempts)
+				require.NotEmpty(t, mountPointRoutes)
+				require.Empty(t, noMountPointAttempts)
+				require.Empty(t, noMountPointRoutes)
+			} else {
+				require.Empty(t, mountPointAttempts)
+				require.Empty(t, mountPointRoutes)
+				require.NotEmpty(t, noMountPointAttempts)
+				require.NotEmpty(t, noMountPointRoutes)
+			}
+		})
 	}
 }

--- a/vault/rollback_test.go
+++ b/vault/rollback_test.go
@@ -5,8 +5,6 @@ package vault
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -189,9 +187,6 @@ func TestRollbackMetrics(t *testing.T) {
 			noMountPointRoutes := samplesWith(intervals, func(s string) bool {
 				return s == "vault.route.rollback"
 			})
-			o, err := json.Marshal(intervals)
-			require.NoError(t, err)
-			fmt.Println(string(o))
 			if tc.addMountPoint {
 				require.NotEmpty(t, mountPointAttempts)
 				require.NotEmpty(t, mountPointRoutes)

--- a/vault/router.go
+++ b/vault/router.go
@@ -39,8 +39,9 @@ type Router struct {
 	// storagePrefix maps the prefix used for storage (ala the BarrierView)
 	// to the backend. This is used to map a key back into the backend that owns it.
 	// For example, logical/uuid1/foobar -> secrets/ (kv backend) + foobar
-	storagePrefix *radix.Tree
-	logger        hclog.Logger
+	storagePrefix            *radix.Tree
+	logger                   hclog.Logger
+	rollbackMetricsMountName bool
 }
 
 // NewRouter returns a new router
@@ -582,7 +583,7 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 	req.Path = adjustedPath
 	if !existenceCheck {
 		metricName := []string{"route", string(req.Operation)}
-		if req.Operation != logical.RollbackOperation {
+		if req.Operation != logical.RollbackOperation || r.rollbackMetricsMountName {
 			metricName = append(metricName, strings.ReplaceAll(mount, "/", "-"))
 		}
 		defer metrics.MeasureSince(metricName, time.Now())

--- a/vault/router.go
+++ b/vault/router.go
@@ -581,10 +581,11 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 	}
 	req.Path = adjustedPath
 	if !existenceCheck {
-		defer metrics.MeasureSince([]string{
-			"route", string(req.Operation),
-			strings.ReplaceAll(mount, "/", "-"),
-		}, time.Now())
+		metricName := []string{"route", string(req.Operation)}
+		if req.Operation != logical.RollbackOperation {
+			metricName = append(metricName, strings.ReplaceAll(mount, "/", "-"))
+		}
+		defer metrics.MeasureSince(metricName, time.Now())
 	}
 	re := raw.(*routeEntry)
 

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -244,6 +244,9 @@ func TestCoreWithSealAndUINoCleanup(t testing.T, opts *CoreConfig) *Core {
 	for k, v := range opts.AuditBackends {
 		conf.AuditBackends[k] = v
 	}
+	if opts.RollbackPeriod != time.Duration(0) {
+		conf.RollbackPeriod = opts.RollbackPeriod
+	}
 
 	conf.ActivityLogConfig = opts.ActivityLogConfig
 	testApplyEntBaseConfig(conf, opts)

--- a/website/content/docs/configuration/telemetry.mdx
+++ b/website/content/docs/configuration/telemetry.mdx
@@ -51,6 +51,10 @@ The following options are available on all telemetry configurations.
 - `add_lease_metrics_namespace_labels` `(bool: false)` - If this value is set to true, then `vault.expire.leases.by_expiration`
   will break down expiring leases by both time and namespace. This parameter is disabled by default because enabling it can lead
   to a large-cardinality metric.
+- `add_mount_point_rollback_metrics` `(bool: false)` - If this value is set to true, then `vault.rollback.attempt.{MOUNT_POINT}`
+  and `vault.route.rollback.{MOUNT_POINT}` metrics will be reported for every mount point. If this parameter is false, then
+  `vault.rollback.attempt` and `vault.route.rollback` metrics (which do not have the mount point in the metric name)
+  will be reported instead. This parameter is disabled by default starting in Vault 1.15.
 - `filter_default` `(bool: true)` - This controls whether to allow metrics that have not been specified by the filter.
   Defaults to `true`, which will allow all metrics when no filters are provided.
   When set to `false` with no filters, no metrics will be sent.

--- a/website/content/docs/configuration/telemetry.mdx
+++ b/website/content/docs/configuration/telemetry.mdx
@@ -54,7 +54,8 @@ The following options are available on all telemetry configurations.
 - `add_mount_point_rollback_metrics` `(bool: false)` - If this value is set to true, then `vault.rollback.attempt.{MOUNT_POINT}`
   and `vault.route.rollback.{MOUNT_POINT}` metrics will be reported for every mount point. If this parameter is false, then
   `vault.rollback.attempt` and `vault.route.rollback` metrics (which do not have the mount point in the metric name)
-  will be reported instead. This parameter is disabled by default starting in Vault 1.15.
+  will be reported instead. This parameter is disabled by default starting in Vault 1.15 due to the high cardinality of
+  these metrics.
 - `filter_default` `(bool: true)` - This controls whether to allow metrics that have not been specified by the filter.
   Defaults to `true`, which will allow all metrics when no filters are provided.
   When set to `false` with no filters, no metrics will be sent.

--- a/website/content/docs/internals/telemetry/metrics/all.mdx
+++ b/website/content/docs/internals/telemetry/metrics/all.mdx
@@ -616,6 +616,8 @@ alphabetic order by name.
 
 @include 'telemetry-metrics/vault/rollback/attempt/mountpoint.mdx'
 
+@include 'telemetry-metrics/vault/rollback/attempt.mdx'
+
 @include 'telemetry-metrics/vault/route/create/mountpoint.mdx'
 
 @include 'telemetry-metrics/vault/route/delete/mountpoint.mdx'
@@ -625,6 +627,8 @@ alphabetic order by name.
 @include 'telemetry-metrics/vault/route/read/mountpoint.mdx'
 
 @include 'telemetry-metrics/vault/route/rollback/mountpoint.mdx'
+
+@include 'telemetry-metrics/vault/route/rollback.mdx'
 
 @include 'telemetry-metrics/vault/runtime/alloc_bytes.mdx'
 

--- a/website/content/docs/internals/telemetry/metrics/core-system.mdx
+++ b/website/content/docs/internals/telemetry/metrics/core-system.mdx
@@ -112,6 +112,8 @@ Vault instance.
 
 @include 'telemetry-metrics/vault/rollback/attempt/mountpoint.mdx'
 
+@include 'telemetry-metrics/vault/rollback/attempt.mdx'
+
 ## Route metrics
 
 @include 'telemetry-metrics/route-intro.mdx'
@@ -125,6 +127,8 @@ Vault instance.
 @include 'telemetry-metrics/vault/route/read/mountpoint.mdx'
 
 @include 'telemetry-metrics/vault/route/rollback/mountpoint.mdx'
+
+@include 'telemetry-metrics/vault/route/rollback.mdx'
 
 ## Runtime metrics
 

--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -32,10 +32,8 @@ Please audit your Consul storage stanza to ensure that you either:
 
 ## Rollback metrics
 
-The metrics `vault.rollback.attempts.{MOUNTPOINT}` and `vault.route.rollback.{MOUNTPOINT}`
-are no longer measured by default. They have been replaced by `vault.rollback.attempts`
-and `vault.route.rollback` metrics, which **do not** contain the mount point in
-the metric name.
+Vault no longer measures and reports the metrics `vault.rollback.attempts.{MOUNTPOINT}` and `vault.route.rollback.{MOUNTPOINT}` by default. The new default metrics are `vault.rollback.attempts`
+and `vault.route.rollback`, which **do not** contain the mount point in the metric name.
 
 If you would like to continue measuring `vault.rollback.attempts.{MOUNTPOINT}`
 and `vault.route.rollback.{MOUNTPOINT}`, you can enable these metrics using the

--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -35,7 +35,8 @@ Please audit your Consul storage stanza to ensure that you either:
 Vault no longer measures and reports the metrics `vault.rollback.attempts.{MOUNTPOINT}` and `vault.route.rollback.{MOUNTPOINT}` by default. The new default metrics are `vault.rollback.attempts`
 and `vault.route.rollback`, which **do not** contain the mount point in the metric name.
 
-If you would like to continue measuring `vault.rollback.attempts.{MOUNTPOINT}`
-and `vault.route.rollback.{MOUNTPOINT}`, you can enable these metrics using the
+To continue measuring `vault.rollback.attempts.{MOUNTPOINT}` and
+`vault.route.rollback.{MOUNTPOINT}`, you must explicitly enable mount-specific
+metrics in the `telemetry` stanza of your Vault configuration with the
 [`add_mount_point_rollback_metrics`](/vault/docs/configuration/telemetry#add_mount_point_rollback_metrics)
-configuration option in the telemetry stanza.
+option.

--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -30,5 +30,9 @@ Please audit your Consul storage stanza to ensure that you either:
 * Manually convert your `service_tags` to lowercase if required
 * Ensure that any system that relies on the tags is aware of the new case-preserving behavior
 
+## Rollback metrics
 
-
+The metrics `vault.rollback.attempts.{MOUNTPOINT}` and `vault.route.rollback.{MOUNTPOINT}`
+have been removed in Vault 1.15. They have been replaced by `vault.rollback.attempts`
+and `vault.route.rollback` metrics, which **do not** contain the mount point in
+the metric name.

--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -33,6 +33,11 @@ Please audit your Consul storage stanza to ensure that you either:
 ## Rollback metrics
 
 The metrics `vault.rollback.attempts.{MOUNTPOINT}` and `vault.route.rollback.{MOUNTPOINT}`
-have been removed in Vault 1.15. They have been replaced by `vault.rollback.attempts`
+are no longer measured by default. They have been replaced by `vault.rollback.attempts`
 and `vault.route.rollback` metrics, which **do not** contain the mount point in
 the metric name.
+
+If you would like to continue measuring `vault.rollback.attempts.{MOUNTPOINT}`
+and `vault.route.rollback.{MOUNTPOINT}`, you can enable these metrics using the
+[`add_mount_point_rollback_metrics`](/vault/docs/configuration/telemetry#add_mount_point_rollback_metrics)
+configuration option in the telemetry stanza.

--- a/website/content/partials/telemetry-metrics/rollback-intro.mdx
+++ b/website/content/partials/telemetry-metrics/rollback-intro.mdx
@@ -3,5 +3,7 @@ Metric names convert forward slashes (`/`) in mount names to dashes (`-`). For
 example, if you have the `auth/token` backend configured, the corresponding mount
 point metric string is `auth-token`
 
-Starting in Vault 1.15, rollback metrics do not have the mount point in their
-metric name or in their labels.
+Starting in Vault 1.15, rollback metrics default to not having the mount point
+in their metric name or in their labels. Rollback metrics with the mount point
+can be enabled by setting the [`add_mount_point_rollback_metrics`](/vault/docs/configuration/telemetry#add_mount_point_rollback_metrics)
+configuration option in the telemetry stanza.

--- a/website/content/partials/telemetry-metrics/rollback-intro.mdx
+++ b/website/content/partials/telemetry-metrics/rollback-intro.mdx
@@ -1,4 +1,7 @@
-Rollback metrics for each configured mount point. Metric names convert
-forward slashes (`/`) in mount names to dashes (`-`). For example, if you
-have the `auth/token` backend configured, the corresponding mount point metric
-string is `auth-token`
+Prior to Vault 1.15, rollback metrics are defined for each configured mount point.
+Metric names convert forward slashes (`/`) in mount names to dashes (`-`). For
+example, if you have the `auth/token` backend configured, the corresponding mount
+point metric string is `auth-token`
+
+Starting in Vault 1.15, rollback metrics do not have the mount point in their
+metric name or in their labels.

--- a/website/content/partials/telemetry-metrics/rollback-intro.mdx
+++ b/website/content/partials/telemetry-metrics/rollback-intro.mdx
@@ -1,9 +1,9 @@
-Prior to Vault 1.15, rollback metrics are defined for each configured mount point.
-Metric names convert forward slashes (`/`) in mount names to dashes (`-`). For
-example, if you have the `auth/token` backend configured, the corresponding mount
-point metric string is `auth-token`
+By default, Vault does not separate rollback metrics by mountpoint. To enable
+explictly named metrics for mountpoints, enable the
+[`add_mount_point_rollback_metrics`](/vault/docs/configuration/telemetry#add_mount_point_rollback_metrics)
+option in your `telemetry` configuration stanza.
 
-Starting in Vault 1.15, rollback metrics default to not having the mount point
-in their metric name or in their labels. Rollback metrics with the mount point
-can be enabled by setting the [`add_mount_point_rollback_metrics`](/vault/docs/configuration/telemetry#add_mount_point_rollback_metrics)
-configuration option in the telemetry stanza.
+If you enable named metrics for mountpoints, the metric name converts forward
+slashes (`/`) in mount names to dashes (`-`). For example, if you have the
+`auth/token` backend configured and mountpoint names enabled for telemetry,
+the corresponding mount point metric string is `auth-token`.

--- a/website/content/partials/telemetry-metrics/route-intro.mdx
+++ b/website/content/partials/telemetry-metrics/route-intro.mdx
@@ -2,3 +2,8 @@ Mount-specific route metrics for each configured mount point. Metric names
 convert forward slashes (`/`) in mount names to dashes (`-`). For example, if
 you have the `auth/token` backend configured, the corresponding mount point
 metric string is `auth-token`
+
+Starting in Vault 1.15, the rollback route metric defaults to not having the
+mount point in its name or labels. The metric with the mount point can be
+enabled by setting the [`add_mount_point_rollback_metrics`](/vault/docs/configuration/telemetry#add_mount_point_rollback_metrics)
+configuration option in the telemetry stanza.

--- a/website/content/partials/telemetry-metrics/route-intro.mdx
+++ b/website/content/partials/telemetry-metrics/route-intro.mdx
@@ -3,7 +3,7 @@ convert forward slashes (`/`) in mount names to dashes (`-`). For example, if
 you have the `auth/token` backend configured, the corresponding mount point
 metric string is `auth-token`
 
-Starting in Vault 1.15, the rollback route metric defaults to not having the
-mount point in its name or labels. The metric with the mount point can be
-enabled by setting the [`add_mount_point_rollback_metrics`](/vault/docs/configuration/telemetry#add_mount_point_rollback_metrics)
-configuration option in the telemetry stanza.
+By default, Vault does not separate rollback metrics by mountpoint. To enable
+explictly named metrics for mountpoints, enable the
+[`add_mount_point_rollback_metrics`](/vault/docs/configuration/telemetry#add_mount_point_rollback_metrics)
+option in your `telemetry` configuration stanza.

--- a/website/content/partials/telemetry-metrics/vault/rollback/attempt.mdx
+++ b/website/content/partials/telemetry-metrics/vault/rollback/attempt.mdx
@@ -1,0 +1,5 @@
+### vault.rollback.attempt ((#vault-rollback-attempt))
+
+Metric type | Value | Description
+----------- | ----- | -----------
+summary     | ms    | Time required to perform a rollback operation

--- a/website/content/partials/telemetry-metrics/vault/rollback/attempt/mountpoint.mdx
+++ b/website/content/partials/telemetry-metrics/vault/rollback/attempt/mountpoint.mdx
@@ -1,5 +1,11 @@
-### vault.rollback.attempt.{MOUNTPOINT} ((#vault-rollback-attempt-mountpoint))
+### vault.rollback.attempt.{MOUNTPOINT} ((#vault-rollback-attempt-mountpoint)) (deprecated)
 
 Metric type | Value | Description
 ----------- | ----- | -----------
 summary     | ms    | Time required to perform a rollback operation on the given mount point
+
+### vault.rollback.attempt ((#vault-rollback-attempt)) (introduced in 1.15)
+
+Metric type | Value | Description
+----------- | ----- | -----------
+summary     | ms    | Time required to perform a rollback operation

--- a/website/content/partials/telemetry-metrics/vault/rollback/attempt/mountpoint.mdx
+++ b/website/content/partials/telemetry-metrics/vault/rollback/attempt/mountpoint.mdx
@@ -1,4 +1,4 @@
-### vault.rollback.attempt.{MOUNTPOINT} ((#vault-rollback-attempt-mountpoint)) (deprecated)
+### vault.rollback.attempt.{MOUNTPOINT} ((#vault-rollback-attempt-mountpoint))
 
 Metric type | Value | Description
 ----------- | ----- | -----------

--- a/website/content/partials/telemetry-metrics/vault/rollback/attempt/mountpoint.mdx
+++ b/website/content/partials/telemetry-metrics/vault/rollback/attempt/mountpoint.mdx
@@ -3,9 +3,3 @@
 Metric type | Value | Description
 ----------- | ----- | -----------
 summary     | ms    | Time required to perform a rollback operation on the given mount point
-
-### vault.rollback.attempt ((#vault-rollback-attempt))
-
-Metric type | Value | Description
------------ | ----- | -----------
-summary     | ms    | Time required to perform a rollback operation

--- a/website/content/partials/telemetry-metrics/vault/rollback/attempt/mountpoint.mdx
+++ b/website/content/partials/telemetry-metrics/vault/rollback/attempt/mountpoint.mdx
@@ -4,7 +4,7 @@ Metric type | Value | Description
 ----------- | ----- | -----------
 summary     | ms    | Time required to perform a rollback operation on the given mount point
 
-### vault.rollback.attempt ((#vault-rollback-attempt)) (introduced in 1.15)
+### vault.rollback.attempt ((#vault-rollback-attempt))
 
 Metric type | Value | Description
 ----------- | ----- | -----------

--- a/website/content/partials/telemetry-metrics/vault/route/rollback.mdx
+++ b/website/content/partials/telemetry-metrics/vault/route/rollback.mdx
@@ -1,0 +1,8 @@
+### vault.route.rollback ((#vault-route-rollback))
+
+Metric type | Value | Description
+----------- | ----- | -----------
+summary     | ms    | Time required to send a rollback request to the backend and for the backend to complete the operation
+
+Vault automatically schedules and performs mount point rollback operations to
+clean up partial errors.

--- a/website/content/partials/telemetry-metrics/vault/route/rollback/mountpoint.mdx
+++ b/website/content/partials/telemetry-metrics/vault/route/rollback/mountpoint.mdx
@@ -7,7 +7,7 @@ summary     | ms    | Time required to send a rollback request to the backend an
 Vault automatically schedules and performs mount point rollback operations to
 clean up partial errors.
 
-### vault.route.rollback ((#vault-route-rollback)) (introduced in 1.15)
+### vault.route.rollback ((#vault-route-rollback))
 
 Metric type | Value | Description
 ----------- | ----- | -----------

--- a/website/content/partials/telemetry-metrics/vault/route/rollback/mountpoint.mdx
+++ b/website/content/partials/telemetry-metrics/vault/route/rollback/mountpoint.mdx
@@ -1,4 +1,4 @@
-### vault.route.rollback.{MOUNTPOINT} ((#vault-route-rollback-mountpoint))
+### vault.route.rollback.{MOUNTPOINT} ((#vault-route-rollback-mountpoint)) (deprecated)
 
 Metric type | Value | Description
 ----------- | ----- | -----------
@@ -6,3 +6,14 @@ summary     | ms    | Time required to send a rollback request to the backend an
 
 Vault automatically schedules and performs mount point rollback operations to
 clean up partial errors.
+
+### vault.route.rollback ((#vault-route-rollback)) (introduced in 1.15)
+
+Metric type | Value | Description
+----------- | ----- | -----------
+summary     | ms    | Time required to send a rollback request to the backend and for the backend to complete the operation
+
+Vault automatically schedules and performs mount point rollback operations to
+clean up partial errors.
+
+

--- a/website/content/partials/telemetry-metrics/vault/route/rollback/mountpoint.mdx
+++ b/website/content/partials/telemetry-metrics/vault/route/rollback/mountpoint.mdx
@@ -1,4 +1,4 @@
-### vault.route.rollback.{MOUNTPOINT} ((#vault-route-rollback-mountpoint)) (deprecated)
+### vault.route.rollback.{MOUNTPOINT} ((#vault-route-rollback-mountpoint))
 
 Metric type | Value | Description
 ----------- | ----- | -----------

--- a/website/content/partials/telemetry-metrics/vault/route/rollback/mountpoint.mdx
+++ b/website/content/partials/telemetry-metrics/vault/route/rollback/mountpoint.mdx
@@ -6,14 +6,3 @@ summary     | ms    | Time required to send a rollback request to the backend an
 
 Vault automatically schedules and performs mount point rollback operations to
 clean up partial errors.
-
-### vault.route.rollback ((#vault-route-rollback))
-
-Metric type | Value | Description
------------ | ----- | -----------
-summary     | ms    | Time required to send a rollback request to the backend and for the backend to complete the operation
-
-Vault automatically schedules and performs mount point rollback operations to
-clean up partial errors.
-
-


### PR DESCRIPTION
This PR creates two new metrics, `vault.route.rollback` and `vault.rollback.attempt`. These metrics replace the existing `vault.route.rollback.{MOUNT_POINT}` and `vault.rollback.attempt.{MOUNT_POINT}` metrics. By default, the metrics with the mount point in them are disabled, however they can be enabled with:

```
telemetry {
  add_mount_point_rollback_metrics = true
}
```