### PR TITLE
Enabling all 3 Audit Device types in enos

### DIFF
--- a/enos/enos-globals.hcl
+++ b/enos/enos-globals.hcl
@@ -15,6 +15,10 @@ globals {
     "ubuntu" = var.ubuntu_distro_version
   }
   packages = ["jq"]
+  distro_packages = {
+    ubuntu = ["netcat"]
+    rhel   = ["nc"]
+  }
   sample_attributes = {
     aws_region = ["us-east-1", "us-west-2"]
   }

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -109,17 +109,17 @@ scenario "agent" {
     }
 
     variables {
-      artifactory_release      = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
-      awskms_unseal_key_arn    = step.create_vpc.kms_key_arn
-      cluster_name             = step.create_vault_cluster_targets.cluster_name
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      install_dir              = var.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_license.license : null
-      local_artifact_path      = local.bundle_path
-      packages                 = global.packages
-      storage_backend          = "raft"
-      target_hosts             = step.create_vault_cluster_targets.hosts
-      unseal_method            = "shamir"
+      artifactory_release   = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
+      awskms_unseal_key_arn = step.create_vpc.kms_key_arn
+      cluster_name          = step.create_vault_cluster_targets.cluster_name
+      enable_audit_devices  = var.vault_enable_audit_devices
+      install_dir           = var.vault_install_dir
+      license               = matrix.edition != "oss" ? step.read_license.license : null
+      local_artifact_path   = local.bundle_path
+      packages              = concat(global.packages, global.distro_packages[matrix.distro])
+      storage_backend       = "raft"
+      target_hosts          = step.create_vault_cluster_targets.hosts
+      unseal_method         = "shamir"
     }
   }
 

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -115,15 +115,15 @@ scenario "autopilot" {
       cluster_name          = step.create_vault_cluster_targets.cluster_name
       install_dir           = local.vault_install_dir
       license               = matrix.edition != "oss" ? step.read_license.license : null
-      packages              = global.packages
+      packages              = concat(global.packages, global.distro_packages[matrix.distro])
       release               = var.vault_autopilot_initial_release
       storage_backend       = "raft"
       storage_backend_addl_config = {
         autopilot_upgrade_version = var.vault_autopilot_initial_release.version
       }
-      target_hosts             = step.create_vault_cluster_targets.hosts
-      unseal_method            = matrix.seal
-      enable_file_audit_device = var.vault_enable_file_audit_device
+      target_hosts         = step.create_vault_cluster_targets.hosts
+      unseal_method        = matrix.seal
+      enable_audit_devices = var.vault_enable_audit_devices
     }
   }
 
@@ -216,7 +216,7 @@ scenario "autopilot" {
       license                     = matrix.edition != "oss" ? step.read_license.license : null
       local_artifact_path         = local.artifact_path
       manage_service              = local.manage_service
-      packages                    = global.packages
+      packages                    = concat(global.packages, global.distro_packages[matrix.distro])
       root_token                  = step.create_vault_cluster.root_token
       shamir_unseal_keys          = matrix.seal == "shamir" ? step.create_vault_cluster.unseal_keys_hex : null
       storage_backend             = "raft"
@@ -224,7 +224,7 @@ scenario "autopilot" {
       storage_node_prefix         = "upgrade_node"
       target_hosts                = step.create_vault_cluster_upgrade_targets.hosts
       unseal_method               = matrix.seal
-      enable_file_audit_device    = var.vault_enable_file_audit_device
+      enable_audit_devices        = var.vault_enable_audit_devices
     }
   }
 

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -101,17 +101,17 @@ scenario "proxy" {
     }
 
     variables {
-      artifactory_release      = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
-      awskms_unseal_key_arn    = step.create_vpc.kms_key_arn
-      cluster_name             = step.create_vault_cluster_targets.cluster_name
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      install_dir              = var.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_license.license : null
-      local_artifact_path      = local.bundle_path
-      packages                 = global.packages
-      storage_backend          = "raft"
-      target_hosts             = step.create_vault_cluster_targets.hosts
-      unseal_method            = "shamir"
+      artifactory_release   = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
+      awskms_unseal_key_arn = step.create_vpc.kms_key_arn
+      cluster_name          = step.create_vault_cluster_targets.cluster_name
+      enable_audit_devices  = var.vault_enable_audit_devices
+      install_dir           = var.vault_install_dir
+      license               = matrix.edition != "oss" ? step.read_license.license : null
+      local_artifact_path   = local.bundle_path
+      packages              = concat(global.packages, global.distro_packages[matrix.distro])
+      storage_backend       = "raft"
+      target_hosts          = step.create_vault_cluster_targets.hosts
+      unseal_method         = "shamir"
     }
   }
 

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -239,15 +239,15 @@ scenario "replication" {
         edition = var.backend_edition
         version = matrix.consul_version
       } : null
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
-      local_artifact_path      = local.artifact_path
-      manage_service           = local.manage_service
-      packages                 = global.packages
-      storage_backend          = matrix.primary_backend
-      target_hosts             = step.create_primary_cluster_targets.hosts
-      unseal_method            = matrix.primary_seal
+      enable_audit_devices = var.vault_enable_audit_devices
+      install_dir          = local.vault_install_dir
+      license              = matrix.edition != "oss" ? step.read_vault_license.license : null
+      local_artifact_path  = local.artifact_path
+      manage_service       = local.manage_service
+      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      storage_backend      = matrix.primary_backend
+      target_hosts         = step.create_primary_cluster_targets.hosts
+      unseal_method        = matrix.primary_seal
     }
   }
 
@@ -296,15 +296,15 @@ scenario "replication" {
         edition = var.backend_edition
         version = matrix.consul_version
       } : null
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
-      local_artifact_path      = local.artifact_path
-      manage_service           = local.manage_service
-      packages                 = global.packages
-      storage_backend          = matrix.secondary_backend
-      target_hosts             = step.create_secondary_cluster_targets.hosts
-      unseal_method            = matrix.secondary_seal
+      enable_audit_devices = var.vault_enable_audit_devices
+      install_dir          = local.vault_install_dir
+      license              = matrix.edition != "oss" ? step.read_vault_license.license : null
+      local_artifact_path  = local.artifact_path
+      manage_service       = local.manage_service
+      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      storage_backend      = matrix.secondary_backend
+      target_hosts         = step.create_secondary_cluster_targets.hosts
+      unseal_method        = matrix.secondary_seal
     }
   }
 
@@ -538,20 +538,20 @@ scenario "replication" {
         edition = var.backend_edition
         version = matrix.consul_version
       } : null
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      force_unseal             = matrix.primary_seal == "shamir"
-      initialize_cluster       = false
-      install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
-      local_artifact_path      = local.artifact_path
-      manage_service           = local.manage_service
-      packages                 = global.packages
-      root_token               = step.create_primary_cluster.root_token
-      shamir_unseal_keys       = matrix.primary_seal == "shamir" ? step.create_primary_cluster.unseal_keys_hex : null
-      storage_backend          = matrix.primary_backend
-      storage_node_prefix      = "newprimary_node"
-      target_hosts             = step.create_primary_cluster_additional_targets.hosts
-      unseal_method            = matrix.primary_seal
+      enable_audit_devices = var.vault_enable_audit_devices
+      force_unseal         = matrix.primary_seal == "shamir"
+      initialize_cluster   = false
+      install_dir          = local.vault_install_dir
+      license              = matrix.edition != "oss" ? step.read_vault_license.license : null
+      local_artifact_path  = local.artifact_path
+      manage_service       = local.manage_service
+      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      root_token           = step.create_primary_cluster.root_token
+      shamir_unseal_keys   = matrix.primary_seal == "shamir" ? step.create_primary_cluster.unseal_keys_hex : null
+      storage_backend      = matrix.primary_backend
+      storage_node_prefix  = "newprimary_node"
+      target_hosts         = step.create_primary_cluster_additional_targets.hosts
+      unseal_method        = matrix.primary_seal
     }
   }
 

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -180,15 +180,15 @@ scenario "smoke" {
         edition = var.backend_edition
         version = matrix.consul_version
       } : null
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
-      local_artifact_path      = local.artifact_path
-      manage_service           = local.manage_service
-      packages                 = global.packages
-      storage_backend          = matrix.backend
-      target_hosts             = step.create_vault_cluster_targets.hosts
-      unseal_method            = matrix.seal
+      enable_audit_devices = var.vault_enable_audit_devices
+      install_dir          = local.vault_install_dir
+      license              = matrix.edition != "oss" ? step.read_vault_license.license : null
+      local_artifact_path  = local.artifact_path
+      manage_service       = local.manage_service
+      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      storage_backend      = matrix.backend
+      target_hosts         = step.create_vault_cluster_targets.hosts
+      unseal_method        = matrix.seal
     }
   }
 

--- a/enos/enos-scenario-ui.hcl
+++ b/enos/enos-scenario-ui.hcl
@@ -166,13 +166,14 @@ scenario "ui" {
         edition = var.backend_edition
         version = local.consul_version
       } : null
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
-      local_artifact_path      = local.bundle_path
-      storage_backend          = matrix.backend
-      target_hosts             = step.create_vault_cluster_targets.hosts
-      unseal_method            = local.seal
+      enable_audit_devices = var.vault_enable_audit_devices
+      install_dir          = local.vault_install_dir
+      license              = matrix.edition != "oss" ? step.read_vault_license.license : null
+      local_artifact_path  = local.bundle_path
+      packages             = global.distro_packages["ubuntu"]
+      storage_backend      = matrix.backend
+      target_hosts         = step.create_vault_cluster_targets.hosts
+      unseal_method        = local.seal
     }
   }
 

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -180,14 +180,14 @@ scenario "upgrade" {
         edition = var.backend_edition
         version = matrix.consul_version
       } : null
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
-      packages                 = global.packages
-      release                  = var.vault_upgrade_initial_release
-      storage_backend          = matrix.backend
-      target_hosts             = step.create_vault_cluster_targets.hosts
-      unseal_method            = matrix.seal
+      enable_audit_devices = var.vault_enable_audit_devices
+      install_dir          = local.vault_install_dir
+      license              = matrix.edition != "oss" ? step.read_vault_license.license : null
+      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      release              = var.vault_upgrade_initial_release
+      storage_backend      = matrix.backend
+      target_hosts         = step.create_vault_cluster_targets.hosts
+      unseal_method        = matrix.seal
     }
   }
 

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -142,8 +142,8 @@ variable "vault_build_date" {
   default     = ""
 }
 
-variable "vault_enable_file_audit_device" {
-  description = "If true the file audit device will be enabled at the path /var/log/vault_audit.log"
+variable "vault_enable_audit_devices" {
+  description = "If true every audit device will be enabled"
   type        = bool
   default     = true
 }

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -87,9 +87,12 @@
 # date to match"
 # vault_build_date = "2023-07-07T14:06:37Z" // make ci-get-date for example
 
-# vault_enable_file_audit_device sets whether or not to enable the 'file' audit device. It true it
-# will be enabled at the path /var/log/vault_audit.log
-# vault_enable_file_audit_device = true
+# vault_enable_audit_devices sets whether or not to enable every audit device. It true
+# a file audit device will be enabled at the path /var/log/vault_audit.log, the syslog
+# audit device will be enabled, and a socket audit device connecting to 127.0.0.1:9090
+# will be enabled. The netcat program is run in listening mode to provide an endpoint
+# that the socket audit device can connect to.
+# vault_enable_audit_devices = true
 
 # vault_install_dir is the directory where the vault binary will be installed on
 # the remote machines.

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -18,7 +18,7 @@ locals {
   audit_device_file_path = "/var/log/vault/vault_audit.log"
   bin_path               = "${var.install_dir}/vault"
   consul_bin_path        = "${var.consul_install_dir}/consul"
-  enable_audit_device    = var.enable_file_audit_device && var.initialize_cluster
+  enable_audit_devices   = var.enable_audit_devices && var.initialize_cluster
   // In order to get Terraform to plan we have to use collections with keys
   // that are known at plan time. In order for our module to work our var.target_hosts
   // must be a map with known keys at plan time. Here we're creating locals
@@ -280,7 +280,7 @@ resource "enos_remote_exec" "create_audit_log_dir" {
   ]
   for_each = toset([
     for idx, host in toset(local.instances) : idx
-    if var.enable_file_audit_device
+    if var.enable_audit_devices
   ])
 
   environment = {
@@ -297,14 +297,14 @@ resource "enos_remote_exec" "create_audit_log_dir" {
   }
 }
 
-resource "enos_remote_exec" "enable_file_audit_device" {
+resource "enos_remote_exec" "enable_audit_devices" {
   depends_on = [
     enos_remote_exec.create_audit_log_dir,
     enos_vault_unseal.leader,
   ]
   for_each = toset([
     for idx in local.leader : idx
-    if local.enable_audit_device
+    if local.enable_audit_devices
   ])
 
   environment = {

--- a/enos/modules/vault_cluster/outputs.tf
+++ b/enos/modules/vault_cluster/outputs.tf
@@ -3,7 +3,7 @@
 
 output "audit_device_file_path" {
   description = "The file path for the audit device, if enabled"
-  value       = var.enable_file_audit_device ? local.audit_device_file_path : "file audit device not enabled"
+  value       = var.enable_audit_devices ? local.audit_device_file_path : "file audit device not enabled"
 }
 
 output "cluster_name" {

--- a/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
+++ b/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
@@ -5,4 +5,11 @@
 
 set -eux
 
+LOG_DIR="$(dirname "$LOG_FILE_PATH")"
+
+# Run nc to listen to port 9090
+nc -l 9090 &
+
 $VAULT_BIN_PATH audit enable file file_path="$LOG_FILE_PATH"
+$VAULT_BIN_PATH audit enable syslog tag="vault" facility="AUTH"
+$VAULT_BIN_PATH audit enable socket address="127.0.0.1:9090"

--- a/enos/modules/vault_cluster/templates/install-packages.sh
+++ b/enos/modules/vault_cluster/templates/install-packages.sh
@@ -44,5 +44,5 @@ if [ -f /etc/debian_version ]; then
   retry 5 sudo apt install -y "$${packages[@]}"
 else
   cd /tmp
-  retry 7 sudo yum -y install "$${packages[@]}"
+  retry 7 sudo yum -y install $${packages[@]}
 fi

--- a/enos/modules/vault_cluster/variables.tf
+++ b/enos/modules/vault_cluster/variables.tf
@@ -96,8 +96,8 @@ variable "consul_release" {
   }
 }
 
-variable "enable_file_audit_device" {
-  description = "If true the file audit device will be enabled at the path /var/log/vault_audit.log"
+variable "enable_audit_devices" {
+  description = "If true every audit device will be enabled"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
This PR also enables the **syslog** and **socket** Audit Devices in the *vault_cluster* module of the enos scenarios.