### PR TITLE
adding testonly CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,25 @@ jobs:
       enterprise: ${{ needs.setup.outputs.enterprise }}
     secrets: inherit
 
+  test-go-testonly:
+    name: Run Go tests tagged with testonly
+    needs:
+      - setup
+      - verify-changes
+    # Don't run this job for docs/ui only PRs
+    if: |
+      needs.verify-changes.outputs.is_docs_change == 'false' &&
+      needs.verify-changes.outputs.is_ui_change == 'false'
+    uses: ./.github/workflows/test-go.yml
+    with:
+      testonly: true
+      total-runners: 2 # test runners cannot be less than 2
+      go-arch: amd64
+      go-tags: '${{ needs.setup.outputs.go-tags }},deadlock,testonly'
+      runs-on: ${{ needs.setup.outputs.compute-large }}
+      enterprise: ${{ needs.setup.outputs.enterprise }}
+    secrets: inherit
+
   test-go-race:
     name: Run Go tests with data race detection
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
       - test-go
       - test-ui
     if: always()
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
     steps:
       - run: |
           tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
       total-runners: 2 # test runners cannot be less than 2
       go-arch: amd64
       go-tags: '${{ needs.setup.outputs.go-tags }},deadlock,testonly'
-      runs-on: ${{ needs.setup.outputs.compute-large }}
+      runs-on: ${{ needs.setup.outputs.compute-small }}
       enterprise: ${{ needs.setup.outputs.enterprise }}
     secrets: inherit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
       total-runners: 2 # test runners cannot be less than 2
       go-arch: amd64
       go-tags: '${{ needs.setup.outputs.go-tags }},deadlock,testonly'
-      runs-on: ${{ needs.setup.outputs.compute-small }}
+      runs-on: ${{ needs.setup.outputs.compute-large }}
       enterprise: ${{ needs.setup.outputs.enterprise }}
     secrets: inherit
 
@@ -292,7 +292,7 @@ jobs:
       - test-go
       - test-ui
     if: always()
-    runs-on: ${{ fromJSON(needs.setup.outputs.compute-large) }}
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
     steps:
       - run: |
           tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)'

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -135,7 +135,7 @@ jobs:
           # testonly tagged tests need an additional tag to be included
           # also running some extra tests for sanity checking with the testonly build tag
           (
-            go list -tags=testonly ./... | grep -E -i 'external_tests/kv|external_tests/token|testonly|external_tests/replication-perf|^github.com/hashicorp/vault/vault$' | gotestsum tool ci-matrix --debug \
+            go list -tags=testonly ./vault/external_tests/{kv,token,*replication-perf*,*testonly*} ./vault/ | gotestsum tool ci-matrix --debug \
               --partitions "${{ inputs.total-runners }}" \
               --timing-files 'test-results/go-test/*.json' > matrix.json
           )

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -131,7 +131,7 @@ jobs:
           GOPRIVATE: github.com/hashicorp/*
         run: |
           set -exo pipefail
-          
+          shopt -s nullglob
           # testonly tagged tests need an additional tag to be included
           # also running some extra tests for sanity checking with the testonly build tag
           (

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -52,6 +52,11 @@ on:
         required: false
         default: 60
         type: number
+      testonly:
+        description: Whether to run the tests tagged with testonly.
+        required: false
+        default: false
+        type: boolean
 
 env: ${{ fromJSON(inputs.env-vars) }}
 
@@ -108,13 +113,29 @@ jobs:
       - name: List cached results
         id: list-cached-results
         run: ls -lhR test-results/go-test
-      - name: Build matrix excluding binary and integration tests
+      - name: Build matrix excluding binary, integration, and testonly tests
         id: build-non-binary
+        if: ${{ !inputs.testonly }}
         env:
           GOPRIVATE: github.com/hashicorp/*
         run: |
+          # testonly tests need additional build tag though let's exclude them anyway for clarity
           (
-            go list ./... | grep -v "_binary" | grep -v "vault/integ" | gotestsum tool ci-matrix --debug \
+            go list ./... | grep -v "_binary" | grep -v "vault/integ" | grep -v "testonly" | gotestsum tool ci-matrix --debug \
+              --partitions "${{ inputs.total-runners }}" \
+              --timing-files 'test-results/go-test/*.json' > matrix.json
+          )
+      - name: Build matrix for tests tagged with testonly
+        if: ${{ inputs.testonly }}
+        env:
+          GOPRIVATE: github.com/hashicorp/*
+        run: |
+          set -exo pipefail
+          
+          # testonly tagged tests need an additional tag to be included
+          # also running some extra tests for sanity checking with the testonly build tag
+          (
+            go list -tags=testonly ./... | grep -E -i 'external_tests/kv|external_tests/token|testonly|external_tests/replication-perf|^github.com/hashicorp/vault/vault$' | gotestsum tool ci-matrix --debug \
               --partitions "${{ inputs.total-runners }}" \
               --timing-files 'test-results/go-test/*.json' > matrix.json
           )

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -131,6 +131,7 @@ jobs:
           GOPRIVATE: github.com/hashicorp/*
         run: |
           set -exo pipefail
+          # enable glob expansion
           shopt -s nullglob
           # testonly tagged tests need an additional tag to be included
           # also running some extra tests for sanity checking with the testonly build tag
@@ -139,6 +140,8 @@ jobs:
               --partitions "${{ inputs.total-runners }}" \
               --timing-files 'test-results/go-test/*.json' > matrix.json
           )
+          # disable glob expansion
+          shopt -u nullglob
       - name: Capture list of binary tests
         if: inputs.binary-tests
         id: list-binary-tests

--- a/vault/logical_system_activity_write_testonly_test.go
+++ b/vault/logical_system_activity_write_testonly_test.go
@@ -619,7 +619,7 @@ func Test_handleActivityWriteData(t *testing.T) {
 		})
 		require.NoError(t, err)
 		now := time.Now().UTC()
-		req := logical.TestRequest(t, logical.CreateOperation, "internal/counters/activity/write")
+		req := logical.TestRequest(t, logical.UpdateOperation, "internal/counters/activity/write")
 		req.Data = map[string]interface{}{"input": string(marshaled)}
 		_, err = core.systemBackend.HandleRequest(namespace.RootContext(nil), req)
 		require.NoError(t, err)


### PR DESCRIPTION
Addresses https://hashicorp.atlassian.net/browse/VAULT-19122
There is a new build tag that is intended for testing purposes only. This PR adds a job to run some selected tests with the testonly build tag in addition to the explicit tests that are tagged with testonly.