### PR TITLE
adv ttl mgmt: consider rotation window

### DIFF
--- a/builtin/logical/database/path_roles.go
+++ b/builtin/logical/database/path_roles.go
@@ -880,12 +880,12 @@ func (s *staticAccount) IsInsideRotationWindow(t time.Time) bool {
 // ShouldRotate returns true if a given static account should have its
 // credentials rotated.
 //
-// This will return true when the priority is less than the current Unix time.
-// If this static account is schedule-based with a rotation window, this method
-// will return false if now is outside the rotation window.
+// This will return true when the priority <= the current Unix time. If this
+// static account is schedule-based with a rotation window, this method will
+// return false if now is outside the rotation window.
 func (s *staticAccount) ShouldRotate(priority int64) bool {
 	now := time.Now()
-	return priority < now.Unix() && s.IsInsideRotationWindow(now)
+	return priority <= now.Unix() && s.IsInsideRotationWindow(now)
 }
 
 // SetNextVaultRotation

--- a/builtin/logical/database/path_roles_test.go
+++ b/builtin/logical/database/path_roles_test.go
@@ -902,6 +902,25 @@ func TestWALsDeletedOnRoleDeletion(t *testing.T) {
 	requireWALs(t, storage, 1)
 }
 
+func TestIsInsideRotationWindow(t *testing.T) {
+	ctx := context.Background()
+	b, storage, mockDB := getBackend(t)
+	defer b.Cleanup(ctx)
+	configureDBMount(t, storage)
+
+	data := map[string]interface{}{
+		"username":          "hashicorp",
+		"db_name":           "mockv5",
+		"rotation_schedule": "0 0 */2 * * *",
+		"rotation_window":   "1h",
+	}
+	createRoleWithData(t, b, storage, mockDB, "hashicorp", data)
+	role, err := b.StaticRole(ctx, storage, "hashicorp")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func createRole(t *testing.T, b *databaseBackend, storage logical.Storage, mockDB *mockNewDatabase, roleName string) {
 	t.Helper()
 	mockDB.On("UpdateUser", mock.Anything, mock.Anything).

--- a/builtin/logical/database/path_roles_test.go
+++ b/builtin/logical/database/path_roles_test.go
@@ -902,25 +902,6 @@ func TestWALsDeletedOnRoleDeletion(t *testing.T) {
 	requireWALs(t, storage, 1)
 }
 
-func TestIsInsideRotationWindow(t *testing.T) {
-	ctx := context.Background()
-	b, storage, mockDB := getBackend(t)
-	defer b.Cleanup(ctx)
-	configureDBMount(t, storage)
-
-	data := map[string]interface{}{
-		"username":          "hashicorp",
-		"db_name":           "mockv5",
-		"rotation_schedule": "0 0 */2 * * *",
-		"rotation_window":   "1h",
-	}
-	createRoleWithData(t, b, storage, mockDB, "hashicorp", data)
-	role, err := b.StaticRole(ctx, storage, "hashicorp")
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
 func createRole(t *testing.T, b *databaseBackend, storage logical.Storage, mockDB *mockNewDatabase, roleName string) {
 	t.Helper()
 	mockDB.On("UpdateUser", mock.Anything, mock.Anything).

--- a/builtin/logical/database/rotation.go
+++ b/builtin/logical/database/rotation.go
@@ -96,9 +96,6 @@ func (b *databaseBackend) populateQueue(ctx context.Context, s logical.Storage) 
 			} else {
 				// previous rotation attempt was interrupted, so we set the
 				// Priority as highest to be processed immediately
-
-				// TODO(JM): ensure we don't process schedule-based rotations
-				// outside the rotation_window
 				log.Info("found WAL for role", "role", item.Key, "WAL ID", walEntry.walID)
 				item.Value = walEntry.walID
 				item.Priority = time.Now().Unix()
@@ -270,6 +267,7 @@ func (b *databaseBackend) rotateCredential(ctx context.Context, s logical.Storag
 		lvr = time.Now()
 	}
 
+	// Update priority and push updated Item to the queue
 	item.Priority = role.StaticAccount.NextRotationTimeFromInput(lvr).Unix()
 
 	if err := b.pushItem(item); err != nil {


### PR DESCRIPTION
Description

This PR adds support for the rotation window. The `rotation_window` will define the window of time in which rotations are allowed to occur starting from a given `rotation_schedule`.  Any static role credentials that are not rotated during this window, due to a failure or otherwise, must wait to be rotated until the next rotation schedule.