### PR TITLE
UI: allow navigation to subdirectory

### DIFF
--- a/ui/lib/core/addon/components/input-search.hbs
+++ b/ui/lib/core/addon/components/input-search.hbs
@@ -15,7 +15,7 @@
       id={{@id}}
       class="input"
       @type="text"
-      @value={{this.searchInput}}
+      @value={{@value}}
       {{on "keyup" this.inputChanged}}
       placeholder={{@placeholder}}
     />

--- a/ui/lib/core/addon/components/input-search.hbs
+++ b/ui/lib/core/addon/components/input-search.hbs
@@ -15,7 +15,7 @@
       id={{@id}}
       class="input"
       @type="text"
-      @value={{@value}}
+      @value={{this.searchInput}}
       {{on "keyup" this.inputChanged}}
       placeholder={{@placeholder}}
     />

--- a/ui/lib/core/addon/components/input-search.js
+++ b/ui/lib/core/addon/components/input-search.js
@@ -22,7 +22,6 @@ import { tracked } from '@glimmer/tracking';
  * @param {string} [placeholder] - placeholder text for the input
  * @param {string} [label] - label for the input 
  * @param {string} [subtext] - displays below the label
- * @param {number} [selectLimit] - Sets select limit
 
  */
 

--- a/ui/lib/core/addon/components/input-search.js
+++ b/ui/lib/core/addon/components/input-search.js
@@ -5,6 +5,26 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+/**
+ * @module InputSearch
+ * This component renders an input that fires a callback on "keyup" containing the input's value
+ *
+ * @example
+ * <InputSearch
+ * @initialValue="secret/path/"
+ * @onChange={{this.handleSearch}}
+ * @placeholder="search..."
+ * />
+ * @param {string} [id] - unique id for the input
+ * @param {string} [initialValue] - initial search value, i.e. a secret path prefix, that pre-fills the input field
+ * @param {string} [placeholder] - placeholder text for the input
+ * @param {string} [label] - label for the input 
+ * @param {string} [subtext] - displays below the label
+ * @param {number} [selectLimit] - Sets select limit
+
+ */
 
 export default class InputSearch extends Component {
   /*
@@ -14,8 +34,16 @@ export default class InputSearch extends Component {
    * Function called when any of the inputs change
    *
    */
+
+  @tracked searchInput;
+
+  constructor() {
+    super(...arguments);
+    this.searchInput = this.args?.initialValue;
+  }
+
   @action
-  inputChanged(e) {
-    this.args.onChange(e.target.value);
+  inputChanged() {
+    this.args.onChange(this.searchInput);
   }
 }

--- a/ui/lib/core/addon/components/input-search.js
+++ b/ui/lib/core/addon/components/input-search.js
@@ -20,9 +20,8 @@ import { tracked } from '@glimmer/tracking';
  * @param {string} [id] - unique id for the input
  * @param {string} [initialValue] - initial search value, i.e. a secret path prefix, that pre-fills the input field
  * @param {string} [placeholder] - placeholder text for the input
- * @param {string} [label] - label for the input 
+ * @param {string} [label] - label for the input
  * @param {string} [subtext] - displays below the label
-
  */
 
 export default class InputSearch extends Component {

--- a/ui/lib/core/addon/components/input-search.js
+++ b/ui/lib/core/addon/components/input-search.js
@@ -5,9 +5,8 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 
-export default class inputSelect extends Component {
+export default class InputSearch extends Component {
   /*
    * @public
    * @param Function
@@ -15,9 +14,8 @@ export default class inputSelect extends Component {
    * Function called when any of the inputs change
    *
    */
-  @tracked searchInput = '';
   @action
-  inputChanged() {
-    this.args.onChange(this.searchInput);
+  inputChanged(e) {
+    this.args.onChange(e.target.value);
   }
 }

--- a/ui/lib/kv/addon/components/page/list.hbs
+++ b/ui/lib/kv/addon/components/page/list.hbs
@@ -35,6 +35,7 @@
         <div class="has-top-margin-m is-flex">
           <InputSearch
             @id="search-input-kv-secret"
+            @value={{this.secretPath}}
             @onChange={{this.handleSecretPathInput}}
             @placeholder="secret/"
             data-test-search-roles

--- a/ui/lib/kv/addon/components/page/list.hbs
+++ b/ui/lib/kv/addon/components/page/list.hbs
@@ -35,10 +35,10 @@
         <div class="has-top-margin-m is-flex">
           <InputSearch
             @id="search-input-kv-secret"
-            @value={{this.secretPath}}
+            @initialValue={{@model.pathToSecret}}
             @onChange={{this.handleSecretPathInput}}
             @placeholder="secret/"
-            data-test-search-roles
+            data-test-view-secret
           />
           <button
             type="button"

--- a/ui/lib/kv/addon/components/page/list.hbs
+++ b/ui/lib/kv/addon/components/page/list.hbs
@@ -28,7 +28,10 @@
 {{#if @noMetadataListPermissions}}
   <div class="box is-fullwidth is-shadowless has-tall-padding">
     <div class="selectable-card-container one-card">
-      <OverviewCard @cardTitle="View secret" @subText="Type the path of the secret you want to read.">
+      <OverviewCard
+        @cardTitle="View secret"
+        @subText="Type the path of the secret you want to view. Include a trailing slash to navigate to the list view."
+      >
         <div class="has-top-margin-m is-flex">
           <InputSearch
             @id="search-input-kv-secret"
@@ -39,11 +42,11 @@
           <button
             type="button"
             class="button is-secondary"
-            disabled={{(not this.secretPath)}}
+            disabled={{not this.secretPath}}
             {{on "click" this.transitionToSecretDetail}}
             data-test-get-secret-detail
           >
-            View secret
+            {{this.buttonText}}
           </button>
         </div>
       </OverviewCard>

--- a/ui/lib/kv/addon/components/page/list.js
+++ b/ui/lib/kv/addon/components/page/list.js
@@ -10,7 +10,7 @@ import { tracked } from '@glimmer/tracking';
 import { getOwner } from '@ember/application';
 import { ancestorKeysForKey } from 'core/utils/key-utils';
 import errorMessage from 'vault/utils/error-message';
-import { pathIsDirectory } from 'vault/lib/kv-breadcrumbs';
+import { pathIsDirectory } from 'kv/utils/kv-breadcrumbs';
 
 /**
  * @module List

--- a/ui/lib/kv/addon/components/page/list.js
+++ b/ui/lib/kv/addon/components/page/list.js
@@ -27,11 +27,6 @@ export default class KvListPageComponent extends Component {
 
   @tracked secretPath;
 
-  constructor() {
-    super(...arguments);
-    this.secretPath = this.args.model?.pathToSecret;
-  }
-
   get mountPoint() {
     // mountPoint tells the LinkedBlock component where to start the transition. In this case, mountPoint will always be vault.cluster.secrets.backend.kv.
     return getOwner(this).mountPoint;

--- a/ui/lib/kv/addon/components/page/list.js
+++ b/ui/lib/kv/addon/components/page/list.js
@@ -10,6 +10,7 @@ import { tracked } from '@glimmer/tracking';
 import { getOwner } from '@ember/application';
 import { ancestorKeysForKey } from 'core/utils/key-utils';
 import errorMessage from 'vault/utils/error-message';
+import { pathIsDirectory } from 'vault/lib/kv-breadcrumbs';
 
 /**
  * @module List
@@ -29,6 +30,10 @@ export default class KvListPageComponent extends Component {
   get mountPoint() {
     // mountPoint tells the LinkedBlock component where to start the transition. In this case, mountPoint will always be vault.cluster.secrets.backend.kv.
     return getOwner(this).mountPoint;
+  }
+
+  get buttonText() {
+    return pathIsDirectory(this.secretPath) ? 'View directory' : 'View secret';
   }
 
   @action
@@ -56,6 +61,8 @@ export default class KvListPageComponent extends Component {
 
   @action
   transitionToSecretDetail() {
-    this.router.transitionTo(`${this.mountPoint}.secret.details`, this.secretPath);
+    pathIsDirectory(this.secretPath)
+      ? this.router.transitionTo('vault.cluster.secrets.backend.kv.list-directory', this.secretPath)
+      : this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.details', this.secretPath);
   }
 }

--- a/ui/lib/kv/addon/components/page/list.js
+++ b/ui/lib/kv/addon/components/page/list.js
@@ -25,7 +25,12 @@ export default class KvListPageComponent extends Component {
   @service flashMessages;
   @service router;
 
-  @tracked secretPath = '';
+  @tracked secretPath;
+
+  constructor() {
+    super(...arguments);
+    this.secretPath = this.args.model?.pathToSecret;
+  }
 
   get mountPoint() {
     // mountPoint tells the LinkedBlock component where to start the transition. In this case, mountPoint will always be vault.cluster.secrets.backend.kv.

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -49,7 +49,7 @@
   </:toolbarActions>
 </KvPageHeader>
 
-{{#if (not-eq @secret.state "destroyed")}}
+{{#if (and (not this.emptyState) (not-eq @secret.state "destroyed"))}}
   <div class="info-table-row-header">
     <div class="info-table-row thead {{if this.showJsonView 'is-shadowless'}} ">
       {{#unless this.hideHeaders}}

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -49,7 +49,7 @@
   </:toolbarActions>
 </KvPageHeader>
 
-{{#if (and (not this.emptyState) (not-eq @secret.state "destroyed"))}}
+{{#if (or (not @secret.canReadMetadata) (not-eq @secret.state "destroyed"))}}
   <div class="info-table-row-header">
     <div class="info-table-row thead {{if this.showJsonView 'is-shadowless'}} ">
       {{#unless this.hideHeaders}}

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -49,7 +49,7 @@
   </:toolbarActions>
 </KvPageHeader>
 
-{{#if (or (not @secret.canReadMetadata) (not-eq @secret.state "destroyed"))}}
+{{#if (or @secret.deletionTime (not this.emptyState))}}
   <div class="info-table-row-header">
     <div class="info-table-row thead {{if this.showJsonView 'is-shadowless'}} ">
       {{#unless this.hideHeaders}}

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -1,0 +1,143 @@
+import { module, skip, test } from 'qunit';
+import { v4 as uuidv4 } from 'uuid';
+import { click, currentURL, findAll, typeIn, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'vault/tests/helpers';
+import authPage from 'vault/tests/pages/auth';
+import {
+  createPolicyCmd,
+  deleteEngineCmd,
+  mountEngineCmd,
+  runCmd,
+  createTokenCmd,
+} from 'vault/tests/helpers/commands';
+import { dataPolicy, metadataPolicy } from 'vault/tests/helpers/policy-generator/kv';
+import { writeSecret } from 'vault/tests/helpers/kv/kv-run-commands';
+import { PAGE } from 'vault/tests/helpers/kv/kv-selectors';
+
+/**
+ * This test set is for testing edge cases, such as specific bug fixes or reported user workflows
+ */
+module('Acceptance | kv-v2 workflow | edge cases', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(async function () {
+    const uid = uuidv4();
+    this.backend = `kv-nav-${uid}`;
+    this.rootSecret = 'root-directory';
+    this.fullSecretPath = `${this.rootSecret}/nested/child-secret`;
+    await authPage.login();
+    await runCmd(mountEngineCmd('kv-v2', this.backend), false);
+    await writeSecret(this.backend, this.fullSecretPath, 'foo', 'bar');
+    return;
+  });
+
+  hooks.afterEach(async function () {
+    await authPage.login();
+    await runCmd(deleteEngineCmd(this.backend));
+    return;
+  });
+
+  module('persona with read and list access on the secret level', function (hooks) {
+    // see github request for use case https://github.com/hashicorp/vault/issues/5362
+    hooks.beforeEach(async function () {
+      const secretPath = `${this.rootSecret}/*`; // user has LIST and READ access within this root secret directory
+      const capabilities = ['list', 'read'];
+      const backend = this.backend;
+      const token = await runCmd([
+        createPolicyCmd(
+          'nested-secret-list-reader',
+          metadataPolicy({ backend, secretPath, capabilities }) +
+            dataPolicy({ backend, secretPath, capabilities })
+        ),
+        createTokenCmd('nested-secret-list-reader'),
+      ]);
+      await authPage.login(token);
+    });
+
+    test('it can navigate to secrets within a secret directory', async function (assert) {
+      assert.expect(19);
+      const backend = this.backend;
+      const [root, subdirectory, secret] = this.fullSecretPath.split('/');
+
+      await visit(`/vault/secrets/${backend}/kv/list`);
+      assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list`, 'lands on secrets list page');
+
+      await typeIn(PAGE.list.overviewInput, `${root}/`); // add slash because this is a directory
+      await click(PAGE.list.overviewButton);
+
+      // URL correct
+      assert.strictEqual(
+        currentURL(),
+        `/vault/secrets/${backend}/kv/${root}%2F/directory`,
+        'visits list-directory of root'
+      );
+
+      // Title correct
+      assert.dom(PAGE.title).hasText(`${backend} Version 2`);
+      // Tabs correct
+      assert.dom(PAGE.secretTab('list-directory')).hasText('Secrets');
+      assert.dom(PAGE.secretTab('list-directory')).hasClass('active');
+      assert.dom(PAGE.secretTab('Configuration')).hasText('Configuration');
+      assert.dom(PAGE.secretTab('Configuration')).doesNotHaveClass('active');
+      // Toolbar correct
+      assert.dom(PAGE.toolbarAction).exists({ count: 1 }, 'toolbar only renders create secret action');
+      assert.dom(PAGE.list.filter).hasValue(`${root}/`);
+      // List content correct
+      assert.dom(PAGE.list.item(`${subdirectory}/`)).exists('renders linked block for subdirectory');
+      await click(PAGE.list.item(`${subdirectory}/`));
+      assert.dom(PAGE.list.item(secret)).exists('renders linked block for child secret');
+      await click(PAGE.list.item(secret));
+      // Secret details visible
+      assert.dom(PAGE.title).hasText(this.fullSecretPath);
+      assert.dom(PAGE.secretTab('Secret')).hasText('Secret');
+      assert.dom(PAGE.secretTab('Secret')).hasClass('active');
+      assert.dom(PAGE.secretTab('Metadata')).hasText('Metadata');
+      assert.dom(PAGE.secretTab('Metadata')).doesNotHaveClass('active');
+      assert.dom(PAGE.secretTab('Version History')).hasText('Version History');
+      assert.dom(PAGE.secretTab('Version History')).doesNotHaveClass('active');
+      assert.dom(PAGE.toolbarAction).exists({ count: 5 }, 'toolbar renders all actions');
+    });
+
+    test('it navigates back to engine index route via breadcrumbs from secret details', async function (assert) {
+      assert.expect(6);
+      const backend = this.backend;
+      const [root, subdirectory, secret] = this.fullSecretPath.split('/');
+
+      await visit(`vault/secrets/${backend}/kv/${encodeURIComponent(this.fullSecretPath)}/details?version=1`);
+      // navigate back through crumbs
+      let previousCrumb = findAll('[data-test-breadcrumbs] li').length - 2;
+      await click(PAGE.breadcrumbAtIdx(previousCrumb));
+      assert.strictEqual(
+        currentURL(),
+        `/vault/secrets/${backend}/kv/${root}%2F${subdirectory}%2F/directory`,
+        'goes back to subdirectory list'
+      );
+      assert.dom(PAGE.list.filter).hasValue(`${root}/${subdirectory}/`);
+      assert.dom(PAGE.list.item(secret)).exists('renders linked block for child secret');
+
+      // back again
+      previousCrumb = findAll('[data-test-breadcrumbs] li').length - 2;
+      await click(PAGE.breadcrumbAtIdx(previousCrumb));
+      assert.strictEqual(
+        currentURL(),
+        `/vault/secrets/${backend}/kv/${root}%2F/directory`,
+        'goes back to root directory'
+      );
+      assert.dom(PAGE.list.item(`${subdirectory}/`)).exists('renders linked block for subdirectory');
+
+      // and back to the engine list view
+      previousCrumb = findAll('[data-test-breadcrumbs] li').length - 2;
+      await click(PAGE.breadcrumbAtIdx(previousCrumb));
+      assert.strictEqual(
+        currentURL(),
+        `/vault/secrets/${backend}/kv/list`,
+        'navigates back to engine list from crumbs'
+      );
+    });
+
+    // TODO after error sub-states are added
+    skip('it handles errors when secrets are not found', async function () {
+      // TODO: assert `[data-test-page-error]` renders `404` if secret directory is typed incorrectly (without slash)
+    });
+  });
+});

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -22,7 +22,7 @@ module('Acceptance | kv-v2 workflow | edge cases', function (hooks) {
 
   hooks.beforeEach(async function () {
     const uid = uuidv4();
-    this.backend = `kv-nav-${uid}`;
+    this.backend = `kv-edge-${uid}`;
     this.rootSecret = 'root-directory';
     this.fullSecretPath = `${this.rootSecret}/nested/child-secret`;
     await authPage.login();

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
@@ -570,7 +570,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       );
     });
     test('can access nested secret (dlr)', async function (assert) {
-      assert.expect(26);
+      assert.expect(27);
       const backend = this.backend;
       await navToBackend(backend);
       assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'title text correct');
@@ -585,12 +585,10 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.dom(PAGE.title).hasText(`${backend} Version 2`);
       assert.dom(PAGE.list.filter).doesNotExist('List filter hidden since no nested list access');
 
-      // TODO: overview card with pageFilter
-      // assert
-      //   .dom(PAGE.list.overviewInput)
-      //   .hasValue('app/', 'overview card is pre-filled with directory param');
-      // await typeIn(PAGE.list.overviewInput, 'nested/secret');
-      await typeIn(PAGE.list.overviewInput, 'app/nested/secret'); // this is a workaround
+      assert
+        .dom(PAGE.list.overviewInput)
+        .hasValue('app/', 'overview card is pre-filled with directory param');
+      await typeIn(PAGE.list.overviewInput, 'nested/secret');
       await click(PAGE.list.overviewButton);
 
       assert.strictEqual(

--- a/ui/tests/helpers/kv/kv-selectors.js
+++ b/ui/tests/helpers/kv/kv-selectors.js
@@ -36,7 +36,7 @@ export const PAGE = {
     item: (secret) => (!secret ? '[data-test-list-item]' : `[data-test-list-item="${secret}"]`),
     filter: `[data-test-component="kv-list-filter"]`,
     overviewCard: '[data-test-overview-card-container="View secret"]',
-    overviewInput: '[data-test-search-roles] input',
+    overviewInput: '[data-test-view-secret] input',
     overviewButton: '[data-test-get-secret-detail]',
   },
   versions: {


### PR DESCRIPTION
This partially fixes the request here https://github.com/hashicorp/vault/issues/5362 so users can `LIST` at the secret level in the UI. 

Fixes https://github.com/hashicorp/vault/issues/20563 and https://github.com/hashicorp/vault/issues/13188 and https://github.com/hashicorp/vault/issues/20563

The user in the gif has the following policy where they can only `LIST` at the `my-secret/` level. Previously a user had to know the full secret path to view this list of secrets, now they just need the top-level secret path:
```
path "my-kv/metadata/my-secret/*" { capabilities = ["list", "read"] }
path "my-kv/data/my-secret/*" { capabilities = ["list", "read"] }
```
![list-withinsecret](https://github.com/hashicorp/vault/assets/68122737/5c7d74e9-322e-4831-aa3a-498ea256d9ed)

<hr>

If a user can only list metadata at the top level, so with a policy that looks something like: 
```
path "my-kv/data/*" {
  capabilities = ["read", "list", "delete"]
}
path "my-kv/metadata" {
  capabilities = ["list"]
}
```
The input in the card pre-fills with the path selected from the list view 
![fill-path](https://github.com/hashicorp/vault/assets/68122737/c027ab4d-ec39-4572-9a64-42d73a86f256)

