### PR TITLE
UI: fix default values resetting form inputs

### DIFF
--- a/changelog/22458.txt
+++ b/changelog/22458.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes model defaults overwriting input value when user tries to clear form input
+```

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -306,8 +306,10 @@
           disabled={{and @attr.options.editDisabled (not @model.isNew)}}
           autocomplete="off"
           spellcheck="false"
-          value={{or (get @model this.valuePath) @attr.options.defaultValue}}
+          {{!-- value={{or (get @model this.valuePath) @attr.options.defaultValue}} --}}
+          value={{get @model this.valuePath}}
           {{on "change" this.onChangeWithEvent}}
+          {{on "input" this.onChangeWithEvent}}
           {{on "keyup" this.handleKeyUp}}
           class="input {{if this.validationError 'has-error-border'}}"
           maxLength={{@attr.options.characterLimit}}

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -306,7 +306,6 @@
           disabled={{and @attr.options.editDisabled (not @model.isNew)}}
           autocomplete="off"
           spellcheck="false"
-          {{!-- value={{or (get @model this.valuePath) @attr.options.defaultValue}} --}}
           value={{get @model this.valuePath}}
           {{on "change" this.onChangeWithEvent}}
           {{on "input" this.onChangeWithEvent}}

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -26,7 +26,8 @@ module('Integration | Component | form field', function (hooks) {
   };
 
   const setup = async function (attr) {
-    const model = EmberObject.create({});
+    // ember sets model attrs from the defaultValue key, mimicking that behavior here
+    const model = EmberObject.create({ [attr.name]: attr.options.defaultValue });
     const spy = sinon.spy();
     this.set('onChange', spy);
     this.set('model', model);

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -27,7 +27,7 @@ module('Integration | Component | form field', function (hooks) {
 
   const setup = async function (attr) {
     // ember sets model attrs from the defaultValue key, mimicking that behavior here
-    const model = EmberObject.create({ [attr.name]: attr.options.defaultValue });
+    const model = EmberObject.create({ [attr.name]: attr.options?.defaultValue });
     const spy = sinon.spy();
     this.set('onChange', spy);
     this.set('model', model);


### PR DESCRIPTION
This reverts the work in this PR #22243 and actually solves the issue where the model default was overwriting the input and disallowing a user to clear the input

This line is redundant because `get @model this.valuePath` grabs the model default if there was one, so this was setting it again. Ember sets a model's attribute using the `defaultValue` and wherever we use `FormField` we also pass in the `@model` 

🐛 in the gif I'm clicking `backspace` but as soon as the input is cleared the value is replaced by the `defaultValue` - which is frustrating UX. For consistency the input should reflect the user's changes (which exist on the model)

![model-overwrite](https://github.com/hashicorp/vault/assets/68122737/54754548-dd44-495a-ba1e-548b30f3960d)
