### PR TITLE
Add canonicalArn as a entity alias name

### DIFF
--- a/builtin/credential/aws/path_config_identity.go
+++ b/builtin/credential/aws/path_config_identity.go
@@ -66,7 +66,7 @@ func (b *backend) pathConfigIdentity() *framework.Path {
 			"iam_alias": {
 				Type:        framework.TypeString,
 				Default:     identityAliasIAMUniqueID,
-				Description: fmt.Sprintf("Configure how the AWS auth method generates entity aliases when using IAM auth. Valid values are %q, %q, and %q. Defaults to %q.", identityAliasRoleID, identityAliasIAMUniqueID, identityAliasIAMFullArn, identityAliasRoleID),
+				Description: fmt.Sprintf("Configure how the AWS auth method generates entity aliases when using IAM auth. Valid values are %q, %q, %q and %q. Defaults to %q.", identityAliasRoleID, identityAliasIAMUniqueID, identityAliasIAMFullArn, identityAliasIAMCanonicalArn, identityAliasRoleID),
 			},
 			iamAuthMetadataFields.FieldName: authmetadata.FieldSchema(iamAuthMetadataFields),
 			"ec2_alias": {
@@ -150,7 +150,7 @@ func pathConfigIdentityUpdate(ctx context.Context, req *logical.Request, data *f
 	iamAliasRaw, ok := data.GetOk("iam_alias")
 	if ok {
 		iamAlias := iamAliasRaw.(string)
-		allowedIAMAliasValues := []string{identityAliasRoleID, identityAliasIAMUniqueID, identityAliasIAMFullArn}
+		allowedIAMAliasValues := []string{identityAliasRoleID, identityAliasIAMUniqueID, identityAliasIAMFullArn, identityAliasIAMCanonicalArn}
 		if !strutil.StrListContains(allowedIAMAliasValues, iamAlias) {
 			return logical.ErrorResponse(fmt.Sprintf("iam_alias of %q not in set of allowed values: %v", iamAlias, allowedIAMAliasValues)), nil
 		}
@@ -194,11 +194,12 @@ type identityConfig struct {
 }
 
 const (
-	identityAliasIAMUniqueID   = "unique_id"
-	identityAliasIAMFullArn    = "full_arn"
-	identityAliasEC2InstanceID = "instance_id"
-	identityAliasEC2ImageID    = "image_id"
-	identityAliasRoleID        = "role_id"
+	identityAliasIAMUniqueID     = "unique_id"
+	identityAliasIAMFullArn      = "full_arn"
+	identityAliasIAMCanonicalArn = "canonical_arn"
+	identityAliasEC2InstanceID   = "instance_id"
+	identityAliasEC2ImageID      = "image_id"
+	identityAliasRoleID          = "role_id"
 )
 
 const pathConfigIdentityHelpSyn = `

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -1397,6 +1397,8 @@ func (b *backend) pathLoginUpdateIam(ctx context.Context, req *logical.Request, 
 		identityAlias = callerUniqueId
 	case identityAliasIAMFullArn:
 		identityAlias = callerID.Arn
+	case identityAliasIAMCanonicalArn:
+		identityAlias = entity.canonicalArn()
 	}
 
 	// If we're just looking up for MFA, return the Alias info


### PR DESCRIPTION
Hi,

This is another quality of life change. Using the assumed-role arn as the full_arn option has issues,
if you want predictable entity alias names -> in the case of EC2 and Code Build this is not the case.

This change adds canonical_arn as another option for identity configuration in addition to the others for IAM alias.


Thanks
