### PR TITLE
Add canonicalArn as a entity alias name

### DIFF
--- a/builtin/credential/aws/path_config_identity.go
+++ b/builtin/credential/aws/path_config_identity.go
@@ -66,7 +66,7 @@ func (b *backend) pathConfigIdentity() *framework.Path {
 			"iam_alias": {
 				Type:        framework.TypeString,
 				Default:     identityAliasIAMUniqueID,
-				Description: fmt.Sprintf("Configure how the AWS auth method generates entity aliases when using IAM auth. Valid values are %q, %q, and %q. Defaults to %q.", identityAliasRoleID, identityAliasIAMUniqueID, identityAliasIAMFullArn, identityAliasRoleID),
+				Description: fmt.Sprintf("Configure how the AWS auth method generates entity aliases when using IAM auth. Valid values are %q, %q, %q and %q. Defaults to %q.", identityAliasRoleID, identityAliasIAMUniqueID, identityAliasIAMFullArn, identityAliasIAMCanonicalArn, identityAliasRoleID),
 			},
 			iamAuthMetadataFields.FieldName: authmetadata.FieldSchema(iamAuthMetadataFields),
 			"ec2_alias": {
@@ -150,7 +150,7 @@ func pathConfigIdentityUpdate(ctx context.Context, req *logical.Request, data *f
 	iamAliasRaw, ok := data.GetOk("iam_alias")
 	if ok {
 		iamAlias := iamAliasRaw.(string)
-		allowedIAMAliasValues := []string{identityAliasRoleID, identityAliasIAMUniqueID, identityAliasIAMFullArn}
+		allowedIAMAliasValues := []string{identityAliasRoleID, identityAliasIAMUniqueID, identityAliasIAMFullArn, identityAliasIAMCanonicalArn}
 		if !strutil.StrListContains(allowedIAMAliasValues, iamAlias) {
 			return logical.ErrorResponse(fmt.Sprintf("iam_alias of %q not in set of allowed values: %v", iamAlias, allowedIAMAliasValues)), nil
 		}
@@ -194,11 +194,12 @@ type identityConfig struct {
 }
 
 const (
-	identityAliasIAMUniqueID   = "unique_id"
-	identityAliasIAMFullArn    = "full_arn"
-	identityAliasEC2InstanceID = "instance_id"
-	identityAliasEC2ImageID    = "image_id"
-	identityAliasRoleID        = "role_id"
+	identityAliasIAMUniqueID     = "unique_id"
+	identityAliasIAMFullArn      = "full_arn"
+	identityAliasIAMCanonicalArn = "canonical_arn"
+	identityAliasEC2InstanceID   = "instance_id"
+	identityAliasEC2ImageID      = "image_id"
+	identityAliasRoleID          = "role_id"
 )
 
 const pathConfigIdentityHelpSyn = `

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -1396,6 +1396,8 @@ func (b *backend) pathLoginUpdateIam(ctx context.Context, req *logical.Request, 
 		identityAlias = callerUniqueId
 	case identityAliasIAMFullArn:
 		identityAlias = callerID.Arn
+	case identityAliasIAMCanonicalArn:
+		identityAlias = entity.canonicalArn()
 	}
 
 	// If we're just looking up for MFA, return the Alias info

--- a/website/content/api-docs/auth/aws.mdx
+++ b/website/content/api-docs/auth/aws.mdx
@@ -203,16 +203,17 @@ This configures the way that Vault interacts with the
 ### Parameters
 
 - `iam_alias` `(string: "role_id")` - How to generate the identity alias when
-  using the `iam` auth method. Valid choices are `role_id`, `unique_id`, and
-  `full_arn` When `role_id` is selected, the randomly generated ID of the Vault role
+  using the `iam` auth method. Valid choices are `role_id`, `unique_id`, `canonical_arn` and
+  `full_arn`. When `role_id` is selected, the randomly generated ID of the Vault role
   is used. When `unique_id` is selected, the [IAM Unique
   ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers#identifiers-unique-ids)
   of the IAM principal (either the user or role) is used as the identity alias
-  name. When `full_arn` is selected, the ARN returned by the
-  `sts:GetCallerIdentity` call is used as the alias name. This is either
+  name. When `canonical_arn` is selected, the role ARN returned by the `sts:GetCallerIdentity`call 
+  will be used. This will be `arn:aws:iam::<account_id>:role/<role name>`. When `full_arn` is selected, 
+  the ARN returned by the `sts:GetCallerIdentity` call is used as the alias name. This is either
   `arn:aws:iam::<account_id>:user/<optional_path/><user_name>` or
   `arn:aws:sts::<account_id>:assumed-role/<role_name_without_path>/<role_session_name>`.
-  **Note**: if you select `full_arn` and then delete and recreate the IAM role,
+  **Note**: if you select `canonical_arn` or `full_arn` and then delete and recreate the IAM role,
   Vault won't be aware and any identity aliases set up for the role name will
   still be valid.
 

--- a/website/content/docs/concepts/identity.mdx
+++ b/website/content/docs/concepts/identity.mdx
@@ -105,7 +105,7 @@ a particular auth mount point.
 | ------------------- | --------------------------------------------------------------------------------------------------- |
 | AliCloud            | Principal ID                                                                                        |
 | AppRole             | Role ID                                                                                             |
-| AWS IAM             | Configurable via `iam_alias` to one of: Role ID (default), IAM unique ID, Full ARN                  |
+| AWS IAM             | Configurable via `iam_alias` to one of: Role ID (default), IAM unique ID, Canonical ARN, Full ARN   |
 | AWS EC2             | Configurable via `ec2_alias` to one of: Role ID (default), EC2 instance ID, AMI ID                  |
 | Azure               | Subject (from JWT claim)                                                                            |
 | Cloud Foundry       | App ID                                                                                              |

--- a/website/content/partials/authn-names.mdx
+++ b/website/content/partials/authn-names.mdx
@@ -1,24 +1,24 @@
 In addition to custom authentication methods configured with secure plugins,
 Vault supports many standardized authentication methods by default.
 
-| AuthN method                                                            | Unique ID                                           | Configured with     |
-|-------------------------------------------------------------------------|-----------------------------------------------------|---------------------|
-| [AliCloud](/vault/docs/auth/alicloud)                                   | Principal ID                                        | Not configurable    |
-| [AppRole](/vault/api-docs/auth/approle#create-update-approle)           | Role ID                                             | Not configurable    |
-| [AWS IAM](/vault/docs/auth/aws#iam-auth-method)                         | Vault Role ID (default), IAM unique ID, Full ARN    | `iam_alias`         |
-| [AWS EC2](/vault/docs/auth/aws#ec2-auth-method)                         | Vault Role ID (default), EC2 instance ID, AMI ID    | `ec2_alias`         |
-| [Azure](/vault/api-docs/auth/azure#create-role)                         | Subject (from JWT claim)                            | Not configurable    |
-| [Cloud Foundry](/vault/docs/auth/cf)                                    | App ID                                              | Not configurable    |
-| [GitHub](/vault/docs/auth/github)                                       | User login name associated with token               | Not configurable    |
-| [Google Cloud](/vault/api-docs/auth/gcp#create-role)                    | Vault Role ID (default), Service account unique ID  | `iam_alias`         |
-| [JWT/OIDC](/vault/api-docs/auth/jwt#create-role)                        | The presented claims (no default value)             | `user_claim`        |
-| [Kerberos](/vault/docs/auth/kerberos)                                   | Username                                            | Not configurable    |
-| [Kubernetes](/vault/api-docs/auth/kubernetes#create-role)               | Service account UID (default), Service account Name | `alias_name_source` |
-| [LDAP](/vault/docs/auth/ldap)                                           | Username                                            | Not configurable    |
-| [OCI](/vault/api-docs/auth/oci#create-role)                             | Rolename                                            | Not configurable    |
-| [Okta](/vault/api-docs/auth/okta#register-user)                         | Username                                            | Not configurable    |
-| [RADIUS](/vault/docs/auth/radius)                                       | Username                                            | Not configurable    |
-| [SAML](/vault/docs/auth/saml)                                           | Assertion Subject                                   | Not configurable    |
-| [TLS Certificate](/vault/api-docs/auth/cert#create-ca-certificate-role) | Subject CommonName                                  | Not configurable    |
-| [Token](/vault/docs/auth/token)                                         | `entity_alias`                                      | Not configurable    |
-| [Username/Password](/vault/api-docs/auth/userpass#create-update-user)   | Username                                            | Not configurable    |
+| AuthN method                                                            | Unique ID                                                           | Configured with     |
+|-------------------------------------------------------------------------|---------------------------------------------------------------------|---------------------|
+| [AliCloud](/vault/docs/auth/alicloud)                                   | Principal ID                                                        | Not configurable    |
+| [AppRole](/vault/api-docs/auth/approle#create-update-approle)           | Role ID                                                             | Not configurable    |
+| [AWS IAM](/vault/docs/auth/aws#iam-auth-method)                         | Vault Role ID (default), IAM unique ID, Canonical ARN, Full ARN     | `iam_alias`         |
+| [AWS EC2](/vault/docs/auth/aws#ec2-auth-method)                         | Vault Role ID (default), EC2 instance ID, AMI ID                    | `ec2_alias`         |
+| [Azure](/vault/api-docs/auth/azure#create-role)                         | Subject (from JWT claim)                                            | Not configurable    |
+| [Cloud Foundry](/vault/docs/auth/cf)                                    | App ID                                                              | Not configurable    |
+| [GitHub](/vault/docs/auth/github)                                       | User login name associated with token                               | Not configurable    |
+| [Google Cloud](/vault/api-docs/auth/gcp#create-role)                    | Vault Role ID (default), Service account unique ID                  | `iam_alias`         |
+| [JWT/OIDC](/vault/api-docs/auth/jwt#create-role)                        | The presented claims (no default value)                             | `user_claim`        |
+| [Kerberos](/vault/docs/auth/kerberos)                                   | Username                                                            | Not configurable    |
+| [Kubernetes](/vault/api-docs/auth/kubernetes#create-role)               | Service account UID (default), Service account Name                 | `alias_name_source` |
+| [LDAP](/vault/docs/auth/ldap)                                           | Username                                                            | Not configurable    |
+| [OCI](/vault/api-docs/auth/oci#create-role)                             | Rolename                                                            | Not configurable    |
+| [Okta](/vault/api-docs/auth/okta#register-user)                         | Username                                                            | Not configurable    |
+| [RADIUS](/vault/docs/auth/radius)                                       | Username                                                            | Not configurable    |
+| [SAML](/vault/docs/auth/saml)                                           | Assertion Subject                                                   | Not configurable    |
+| [TLS Certificate](/vault/api-docs/auth/cert#create-ca-certificate-role) | Subject CommonName                                                  | Not configurable    |
+| [Token](/vault/docs/auth/token)                                         | `entity_alias`                                                      | Not configurable    |
+| [Username/Password](/vault/api-docs/auth/userpass#create-update-user)   | Username                                                            | Not configurable    |


### PR DESCRIPTION
Hi,

This is another quality of life change. Using the assumed-role arn as the full_arn option has issues,
if you want predictable entity alias names -> in the case of EC2 and Code Build this is not the case.

This change adds canonical_arn as another option for identity configuration in addition to the others for IAM alias.

Thanks
