### PR TITLE
Fix test failures

### DIFF
--- a/ui/lib/kv/addon/components/page/list.hbs
+++ b/ui/lib/kv/addon/components/page/list.hbs
@@ -19,7 +19,7 @@
     <ToolbarLink
       data-test-toolbar-create-secret
       @route="create"
-      @query={{hash initialKey=@model.pathToSecret}}
+      @query={{if @model.pathToSecret (hash initialKey=@model.pathToSecret)}}
       @type="add"
     >Create secret</ToolbarLink>
   </:toolbarActions>

--- a/ui/lib/kv/addon/components/page/secrets/create.js
+++ b/ui/lib/kv/addon/components/page/secrets/create.js
@@ -43,7 +43,7 @@ export default class KvSecretCreate extends Component {
   pathValidations() {
     // check path attribute warnings on key up
     const { state } = this.args.secret.validate();
-    if (state?.path?.warnings) {
+    if (state?.path?.warnings.length) {
       // only set model validations if warnings exist
       this.modelValidations = state;
     }

--- a/ui/tests/acceptance/secrets/backend/kv/kv-create-new-version-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-create-new-version-test.js
@@ -32,11 +32,7 @@ module('Acceptance | kv | creates a secret and a new version', function (hooks) 
       .dom(`${PAGE.emptyStateActions} a`)
       .hasAttribute('href', `/ui/vault/secrets/${this.mountPath}/kv/create`);
     await click(PAGE.list.createSecret);
-    assert.strictEqual(
-      currentURL(),
-      `/vault/secrets/${this.mountPath}/kv/create?initialKey=`,
-      'url is correct'
-    );
+    assert.strictEqual(currentURL(), `/vault/secrets/${this.mountPath}/kv/create`, 'url is correct');
 
     await fillIn(FORM.inputByAttr('path'), secretPath);
     await fillIn(FORM.keyInput(), 'foo-1');

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
@@ -339,10 +339,9 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
 
       // click toolbar CTA
       await click(PAGE.list.createSecret);
-      // TODO: initialKey should not show on query params if empty
       assert.strictEqual(
         currentURL(),
-        `/vault/secrets/${backend}/kv/create?initialKey=`,
+        `/vault/secrets/${backend}/kv/create`,
         `url includes /vault/secrets/${backend}/kv/create`
       );
 
@@ -981,10 +980,9 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
 
       // click toolbar CTA
       await click(PAGE.list.createSecret);
-      // TODO: qp should not be present if empty
       assert.strictEqual(
         currentURL(),
-        `/vault/secrets/${backend}/kv/create?initialKey=`,
+        `/vault/secrets/${backend}/kv/create`,
         `goes to /vault/secrets/${backend}/kv/create`
       );
 


### PR DESCRIPTION
* Fixed the validation messages not working, it was sending the errors, not the warnings on the conditional.
* Fixed initialKey being an empty param on create secret.