### PR TITLE
bolt.write.time should actually be a counter, not a gauge

### DIFF
--- a/changelog/22428.txt
+++ b/changelog/22428.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-core/metrics: vault.raft_storage.bolt.write.time should be a gauge not a summary
-```

--- a/changelog/22468.txt
+++ b/changelog/22468.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-core/metrics: vault.raft_storage.bolt.write.time should be a counter not a gauge
+core/metrics: vault.raft_storage.bolt.write.time should be a counter not a summary
 ```

--- a/changelog/22468.txt
+++ b/changelog/22468.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/metrics: vault.raft_storage.bolt.write.time should be a counter not a gauge
+```

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -671,7 +671,7 @@ func (b *RaftBackend) collectMetricsWithStats(stats bolt.Stats, sink *metricsuti
 	sink.SetGaugeWithLabels([]string{"raft_storage", "bolt", "spill", "count"}, float32(txstats.GetSpill()), labels)
 	sink.AddSampleWithLabels([]string{"raft_storage", "bolt", "spill", "time"}, float32(txstats.GetSpillTime().Milliseconds()), labels)
 	sink.SetGaugeWithLabels([]string{"raft_storage", "bolt", "write", "count"}, float32(txstats.GetWrite()), labels)
-	sink.SetGaugeWithLabels([]string{"raft_storage", "bolt", "write", "time"}, float32(txstats.GetWriteTime().Milliseconds()), labels)
+	sink.IncrCounterWithLabels([]string{"raft_storage", "bolt", "write", "time"}, float32(txstats.GetWriteTime().Milliseconds()), labels)
 }
 
 // RaftServer has information about a server in the Raft configuration

--- a/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
@@ -28,7 +28,8 @@ Official images separately.
 
 ## Important changes
 
-There are no major changes to announce at this time.
+`vault.raft_storage.bolt.write.time` has been corrected from a summary to a counter to more accurately reflect that it
+is measuring cumulative time writing, and not time spent per write.
 
 ## Known issues and workarounds
 

--- a/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
@@ -29,7 +29,7 @@ Official images separately.
 ## Important changes
 
 `vault.raft_storage.bolt.write.time` has been corrected from a summary to a counter to more accurately reflect that it
-is measuring cumulative time writing, and not time spent per write.
+is measuring cumulative time writing, and not the distribution of individual write times.
 
 ## Known issues and workarounds
 

--- a/website/content/partials/telemetry-metrics/vault/raft_storage/bolt/write/time.mdx
+++ b/website/content/partials/telemetry-metrics/vault/raft_storage/bolt/write/time.mdx
@@ -2,4 +2,4 @@
 
 Metric type | Value | Description
 ----------- | ----- | -----------
-gauge     | ms    | Total time the Bolt database has spent writing to disk
+counter     | ms    | Total cumulative time the Bolt database has spent writing to disk.


### PR DESCRIPTION
Changing this, per https://github.com/hashicorp/vault/pull/22428#issuecomment-1686230898