### PR TITLE
Delete on Metadata and KvListFilter clean up

### DIFF
--- a/ui/app/adapters/kv/metadata.js
+++ b/ui/app/adapters/kv/metadata.js
@@ -70,8 +70,7 @@ export default class KvMetadataAdapter extends ApplicationAdapter {
 
   deleteRecord(store, type, snapshot) {
     const { backend, path, fullSecretPath } = snapshot.record;
-    // fullSecretPath is used when deleting from the LIST view.
-    // fullSecretPath is only defined from the LIST view via the serializer.
+    // fullSecretPath is used when deleting from the LIST view and is defined via the serializer
     // path is used when deleting from the metadata details view.
     return this.ajax(this._url(kvMetadataPath(backend, fullSecretPath || path)), 'DELETE');
   }

--- a/ui/app/adapters/kv/metadata.js
+++ b/ui/app/adapters/kv/metadata.js
@@ -69,7 +69,10 @@ export default class KvMetadataAdapter extends ApplicationAdapter {
   }
 
   deleteRecord(store, type, snapshot) {
-    const { backend, path } = snapshot.record;
-    return this.ajax(this._url(kvMetadataPath(backend, path)), 'DELETE');
+    const { backend, path, fullSecretPath } = snapshot.record;
+    // fullSecretPath is used when deleting from the LIST view.
+    // fullSecretPath is only defined from the LIST view via the serializer.
+    // path is used when deleting from the metadata details view.
+    return this.ajax(this._url(kvMetadataPath(backend, fullSecretPath || path)), 'DELETE');
   }
 }

--- a/ui/lib/kv/addon/components/kv-delete-modal.js
+++ b/ui/lib/kv/addon/components/kv-delete-modal.js
@@ -87,5 +87,6 @@ export default class KvDeleteModal extends Component {
   onDelete() {
     const type = this.args.mode === 'delete' ? this.deleteType : this.args.mode;
     this.args.onDelete(type);
+    this.modalOpen = false;
   }
 }

--- a/ui/lib/kv/addon/components/kv-list-filter.hbs
+++ b/ui/lib/kv/addon/components/kv-list-filter.hbs
@@ -18,20 +18,18 @@
     </p>
   </div>
 </div>
-{{#if this.filterIsFocused}}
-  {{#if this.isFilterMatch}}
-    <p class="help has-text-grey is-size-8 has-left-padding-xs" data-test-help-enter>
-      <kbd>ENTER</kbd>
-      to go to see details.
-      <kbd>ESC</kbd>
-      to clear input.
-    </p>
-  {{else}}
-    <p class="help has-text-grey is-size-8 has-left-padding-xs" data-test-help-tab>
-      <kbd>TAB</kbd>
-      to autocomplete.
-      <kbd>ESC</kbd>
-      to clear input.
-    </p>
-  {{/if}}
+{{#if (and this.filterIsFocused this.isFilterMatch)}}
+  <p class="help has-text-grey is-size-8 has-left-padding-xs" data-test-help-enter>
+    <kbd>ENTER</kbd>
+    to go to see details.
+    <kbd>ESC</kbd>
+    to clear input.
+  </p>
+{{else}}
+  <p class="help has-text-grey is-size-8 has-left-padding-xs" data-test-help-tab>
+    <kbd>TAB</kbd>
+    to autocomplete.
+    <kbd>ESC</kbd>
+    to clear input.
+  </p>
 {{/if}}

--- a/ui/lib/kv/addon/components/kv-list-filter.hbs
+++ b/ui/lib/kv/addon/components/kv-list-filter.hbs
@@ -5,7 +5,7 @@
         id="secret-filter"
         class="filter input"
         placeholder="Filter secrets"
-        @value={{@model.filterValue}}
+        @value={{@filterValue}}
         @type="text"
         data-test-component="kv-list-filter"
         {{on "input" this.handleInput}}
@@ -19,7 +19,7 @@
   </div>
 </div>
 {{#if this.filterIsFocused}}
-  {{#if this.filterMatchesASecretPath}}
+  {{#if this.isFilterMatch}}
     <p class="help has-text-grey is-size-8 has-left-padding-xs" data-test-help-enter>
       <kbd>ENTER</kbd>
       to go to see details.

--- a/ui/lib/kv/addon/components/kv-list-filter.js
+++ b/ui/lib/kv/addon/components/kv-list-filter.js
@@ -54,7 +54,7 @@ export default class KvListFilterComponent extends Component {
     // If pageFilter is empty we replace it with an empty string because you cannot pass 'undefined' to RegEx.
     const value = !this.args.pageFilter ? '' : this.args.pageFilter;
     const reg = new RegExp('^' + escapeStringRegexp(value));
-    const match = this.args.secrets.filter((path) => reg.test(path.fullSecretPath))[0];
+    const match = this.args.secrets?.filter((path) => reg.test(path.fullSecretPath))[0];
     if (this.isFilterMatch || !match) return null;
 
     return match.fullSecretPath;

--- a/ui/lib/kv/addon/components/kv-list-filter.js
+++ b/ui/lib/kv/addon/components/kv-list-filter.js
@@ -54,7 +54,7 @@ export default class KvListFilterComponent extends Component {
     // If pageFilter is empty we replace it with an empty string because you cannot pass 'undefined' to RegEx.
     const value = !this.args.pageFilter ? '' : this.args.pageFilter;
     const reg = new RegExp('^' + escapeStringRegexp(value));
-    const match = this.args.secrets?.filter((path) => reg.test(path.fullSecretPath))[0];
+    const match = this.args.secrets.filter((path) => reg.test(path.fullSecretPath))[0];
     if (this.isFilterMatch || !match) return null;
 
     return match.fullSecretPath;

--- a/ui/lib/kv/addon/components/page/list.hbs
+++ b/ui/lib/kv/addon/components/page/list.hbs
@@ -31,7 +31,7 @@
         <div class="has-top-margin-m is-flex">
           <InputSearch
             @id="search-input-kv-secret"
-            @initialValue={{@model.pathToSecret}}
+            @initialValue={{@pathToSecret}}
             @onChange={{this.handleSecretPathInput}}
             @placeholder="secret/"
             data-test-view-secret

--- a/ui/lib/kv/addon/components/page/list.hbs
+++ b/ui/lib/kv/addon/components/page/list.hbs
@@ -7,7 +7,7 @@
   <:toolbarFilters>
     {{#unless @noMetadataListPermissions}}
       <KvListFilter
-        @secrets={{@model.secrets}}
+        @secrets={{@secrets}}
         @mountPoint={{this.mountPoint}}
         @filterValue={{@filterValue}}
         @pageFilter={{@pageFilter}}
@@ -16,7 +16,7 @@
   </:toolbarFilters>
 
   <:toolbarActions>
-    <ToolbarLink data-test-toolbar-create-secret @route="create" @query={{hash initialKey=@pathToSecret}} @type="add">Create
+    <ToolbarLink data-test-toolbar-create-secret @route="create" @query={{hash initialKey=@filterValue}} @type="add">Create
       secret</ToolbarLink>
   </:toolbarActions>
 </KvPageHeader>

--- a/ui/lib/kv/addon/components/page/list.hbs
+++ b/ui/lib/kv/addon/components/page/list.hbs
@@ -1,4 +1,4 @@
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @model={{@model}} @isEngineView={{true}} @pageTitle={{@model.backend}}>
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @isEngineView={{true}} @pageTitle={{@backend}}>
   <:tabLinks>
     <LinkTo @route={{@routeName}} data-test-secrets-tab={{@routeName}}>Secrets</LinkTo>
     <LinkTo @route="configuration" data-test-secrets-tab="Configuration">Configuration</LinkTo>
@@ -7,7 +7,7 @@
   <:toolbarFilters>
     {{#unless @noMetadataListPermissions}}
       <KvListFilter
-        @model={{@model}}
+        @secrets={{@model.secrets}}
         @mountPoint={{this.mountPoint}}
         @filterValue={{@filterValue}}
         @pageFilter={{@pageFilter}}
@@ -16,12 +16,8 @@
   </:toolbarFilters>
 
   <:toolbarActions>
-    <ToolbarLink
-      data-test-toolbar-create-secret
-      @route="create"
-      @query={{hash initialKey=@model.pathToSecret}}
-      @type="add"
-    >Create secret</ToolbarLink>
+    <ToolbarLink data-test-toolbar-create-secret @route="create" @query={{hash initialKey=@pathToSecret}} @type="add">Create
+      secret</ToolbarLink>
   </:toolbarActions>
 </KvPageHeader>
 
@@ -50,8 +46,8 @@
     </div>
   </div>
 {{else}}
-  {{#if @model.secrets}}
-    {{#each @model.secrets as |secret|}}
+  {{#if @secrets}}
+    {{#each @secrets as |secret|}}
       <LinkedBlock
         data-test-list-item={{secret.path}}
         class="list-item-row"

--- a/ui/lib/kv/addon/components/page/list.hbs
+++ b/ui/lib/kv/addon/components/page/list.hbs
@@ -51,11 +51,11 @@
   </div>
 {{else}}
   {{#if @secrets}}
-    {{#each @secrets as |secret|}}
+    {{#each @secrets as |metadata|}}
       <LinkedBlock
-        data-test-list-item={{secret.path}}
+        data-test-list-item={{metadata.path}}
         class="list-item-row"
-        @params={{array (if secret.pathIsDirectory "list-directory" "secret.details") secret.fullSecretPath}}
+        @params={{array (if metadata.pathIsDirectory "list-directory" "secret.details") metadata.fullSecretPath}}
         @linkPrefix={{this.mountPoint}}
       >
         <div class="level is-mobile">
@@ -63,7 +63,7 @@
             <div>
               <Icon @name="user" class="has-text-grey-light" />
               <span class="has-text-weight-semibold is-underline">
-                {{secret.path}}
+                {{metadata.path}}
               </span>
             </div>
           </div>
@@ -72,38 +72,37 @@
               <PopupMenu>
                 <nav class="menu">
                   <ul class="menu-list">
-                    {{#if secret.pathIsDirectory}}
+                    {{#if metadata.pathIsDirectory}}
                       <li>
-                        <LinkTo @route="list-directory" @model={{secret.fullSecretPath}}>
+                        <LinkTo @route="list-directory" @model={{metadata.fullSecretPath}}>
                           Content
                         </LinkTo>
                       </li>
                     {{else}}
                       <li>
-                        <LinkTo @route="secret.details" @model={{secret.fullSecretPath}}>
+                        <LinkTo @route="secret.details" @model={{metadata.fullSecretPath}}>
                           Details
                         </LinkTo>
                       </li>
-                      {{#if secret.canReadMetadata}}
+                      {{#if metadata.canReadMetadata}}
                         <li>
-                          <LinkTo @route="secret.metadata.versions" @model={{secret.fullSecretPath}}>
+                          <LinkTo @route="secret.metadata.versions" @model={{metadata.fullSecretPath}}>
                             View version history
                           </LinkTo>
                         </li>
                       {{/if}}
-                      {{! ARG TODO check that you don't also need create (this checks for update) }}
-                      {{#if secret.canEditData}}
+                      {{#if metadata.canEditData}}
                         <li>
-                          <LinkTo @route="secret.details.edit" @model={{secret.fullSecretPath}}>
+                          <LinkTo @route="secret.details.edit" @model={{metadata.fullSecretPath}}>
                             Create new version
                           </LinkTo>
                         </li>
                       {{/if}}
-                      {{#if secret.canDeleteMetadata}}
+                      {{#if metadata.canDeleteMetadata}}
                         <li>
                           <ConfirmAction
                             @buttonClasses="link is-destroy"
-                            @onConfirmAction={{fn this.onDelete secret}}
+                            @onConfirmAction={{fn this.onDelete metadata}}
                             @confirmMessage="This will permanently delete this secret and all its versions."
                             @cancelButtonText="Cancel"
                             data-test-secret-delete="true"

--- a/ui/lib/kv/addon/components/page/list.js
+++ b/ui/lib/kv/addon/components/page/list.js
@@ -15,33 +15,45 @@ import errorMessage from 'vault/utils/error-message';
  * @module List
  * ListPage component is a component to show a list of kv/metadata secrets.
  *
- * @param {array} model - An array of models generated form kv/metadata query.
- * @param {array} breadcrumbs - Breadcrumbs as an array of objects that contain label, route, and modelId. They are updated via the util kv-breadcrumbs to handle dynamic *pathToSecret on the list-directory route.
+ * @param {array} secrets - An array of models generated form kv/metadata query.
+ * @param {string} backend - The name of the kv secret engine.
+ * @param {string} pathToSecret - The directory name that the secret belongs to ex: beep/boop/
+ * @param {string} pageFilter - The input on the kv-list-filter. Does not include a directory name.
+ * @param {string} filterValue - The concatenation of the pathToSecret and pageFilter ex: beep/boop/my-
  * @param {boolean} noMetadataListPermissions - true if the return to query metadata LIST is 403, indicating the user does not have permissions to that endpoint.
+ * @param {array} breadcrumbs - Breadcrumbs as an array of objects that contain label, route, and modelId. They are updated via the util kv-breadcrumbs to handle dynamic *pathToSecret on the list-directory route.
+ * @param {string} routeName - Either list or list-directory.
+ * @param {object} meta - Object with values needed for pagination, created by LazyPaginatedQuery on the store service.
  */
 
 export default class KvListPageComponent extends Component {
   @service flashMessages;
   @service router;
+  @service store;
 
   @tracked secretPath = '';
 
   get mountPoint() {
-    // mountPoint tells the LinkedBlock component where to start the transition. In this case, mountPoint will always be vault.cluster.secrets.backend.kv.
+    // mountPoint tells transition where to start. In this case, mountPoint will always be vault.cluster.secrets.backend.kv.
     return getOwner(this).mountPoint;
   }
 
   @action
   async onDelete(model) {
     try {
-      const message = `Successfully deleted the metadata and all version data of the secret ${model.fullSecretPath}.`;
+      // The model passed in is a kv/metadata model
       await model.destroyRecord();
+      this.store.clearDataset('kv/metadata'); // Clear out the store cache so that the metadata/list view is updated.
+      const message = `Successfully deleted the metadata and all version data of the secret ${model.fullSecretPath}.`;
       this.flashMessages.success(message);
       // if you've deleted a secret from within a directory, transition to its parent directory.
       if (this.args.routeName === 'list-directory') {
         const ancestors = ancestorKeysForKey(model.fullSecretPath);
         const nearest = ancestors.pop();
         this.router.transitionTo(`${this.mountPoint}.list-directory`, nearest);
+      } else {
+        // Transition to refresh the model
+        this.router.transitionTo(`${this.mountPoint}.list`);
       }
     } catch (error) {
       const message = errorMessage(error, 'Error deleting secret. Please try again or contact support.');

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -74,6 +74,7 @@ export default class KvSecretDetails extends Component {
       await secret.destroyRecord({
         adapterOptions: { deleteType: 'undelete', deleteVersions: secret.version },
       });
+      this.store.clearDataset('kv/metadata'); // Clear out the store cache so that the metadata/list view is updated.
       this.flashMessages.success(`Successfully undeleted ${secret.path}.`);
       this.router.transitionTo('vault.cluster.secrets.backend.kv.secret', {
         queryParams: { version: secret.version },
@@ -90,6 +91,7 @@ export default class KvSecretDetails extends Component {
     const { secret } = this.args;
     try {
       await secret.destroyRecord({ adapterOptions: { deleteType: type, deleteVersions: secret.version } });
+      this.store.clearDataset('kv/metadata'); // Clear out the store cache so that the metadata/list view is updated.
       this.flashMessages.success(`Successfully ${secret.state} Version ${secret.version} of ${secret.path}.`);
       this.router.transitionTo('vault.cluster.secrets.backend.kv.secret', {
         queryParams: { version: secret.version },

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
@@ -9,7 +9,7 @@
 
   <:toolbarActions>
     {{#if @metadata.canDeleteMetadata}}
-      <KvDeleteModal @mode="delete-metadata" @metadata={{@metadata}} @onDelete={{this.handleDelete}}>
+      <KvDeleteModal @mode="delete-metadata" @metadata={{@metadata}} @onDelete={{fn this.onDelete @metadata}}>
         Delete metadata
       </KvDeleteModal>
     {{/if}}

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
@@ -9,7 +9,7 @@
 
   <:toolbarActions>
     {{#if @metadata.canDeleteMetadata}}
-      <KvDeleteModal @mode="delete-metadata" @metadata={{@metadata}} @onDelete={{fn this.onDelete @metadata}}>
+      <KvDeleteModal @mode="delete-metadata" @metadata={{@metadata}} @onDelete={{this.onDelete}}>
         Delete metadata
       </KvDeleteModal>
     {{/if}}

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.js
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.js
@@ -5,7 +5,6 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
 /**
@@ -25,23 +24,23 @@ import { inject as service } from '@ember/service';
  */
 
 export default class KvSecretMetadataDetails extends Component {
-  @tracked deleteModalOpen = false;
   @service flashMessages;
   @service router;
   @service store;
 
   @action
-  async onDelete(model) {
+  async onDelete() {
     // The only delete option from this view is delete on metadata.
+    const { metadata } = this.args;
     try {
-      await model.destroyRecord();
+      await metadata.destroyRecord();
       this.store.clearDataset('kv/metadata'); // Clear out the store cache so that the metadata/list view is updated.
       this.flashMessages.success(
-        `Successfully deleted the metadata and all version data for the secret ${model.path}.`
+        `Successfully deleted the metadata and all version data for the secret ${metadata.path}.`
       );
-      return this.router.transitionTo('vault.cluster.secrets.backend.kv.list');
+      this.router.transitionTo('vault.cluster.secrets.backend.kv.list');
     } catch (err) {
-      this.flashMessages.danger(`There was an issue deleting ${model.path} metadata.`);
+      this.flashMessages.danger(`There was an issue deleting ${metadata.path} metadata.`);
     }
   }
 }

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.js
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.js
@@ -28,19 +28,20 @@ export default class KvSecretMetadataDetails extends Component {
   @tracked deleteModalOpen = false;
   @service flashMessages;
   @service router;
+  @service store;
 
-  @action async handleDelete() {
-    // the only delete option from this view is delete on metadata.
+  @action
+  async onDelete(model) {
+    // The only delete option from this view is delete on metadata.
     try {
-      await this.args.metadata.destroyRecord({
-        adapterOptions: { deleteType: 'delete-metadata' },
-      });
+      await model.destroyRecord();
+      this.store.clearDataset('kv/metadata'); // Clear out the store cache so that the metadata/list view is updated.
       this.flashMessages.success(
-        `Successfully deleted the metadata and all version data for the secret ${this.args.metadata.path}.`
+        `Successfully deleted the metadata and all version data for the secret ${model.path}.`
       );
       return this.router.transitionTo('vault.cluster.secrets.backend.kv.list');
     } catch (err) {
-      this.flashMessages.danger(`There was an issue deleting ${this.args.metadata.path} metadata.`);
+      this.flashMessages.danger(`There was an issue deleting ${model.path} metadata.`);
     }
   }
 }

--- a/ui/lib/kv/addon/components/page/secrets/create.js
+++ b/ui/lib/kv/addon/components/page/secrets/create.js
@@ -28,6 +28,7 @@ import errorMessage from 'vault/utils/error-message';
 export default class KvSecretCreate extends Component {
   @service flashMessages;
   @service router;
+  @service store;
 
   @tracked showJsonView = false;
   @tracked errorMessage; // only renders for kv/data API errors
@@ -63,6 +64,7 @@ export default class KvSecretCreate extends Component {
       try {
         // try saving secret data first
         yield secret.save();
+        this.store.clearDataset('kv/metadata'); // Clear out the store cache so that the metadata/list view is updated.
         this.flashMessages.success(`Successfully saved secret data for: ${secret.path}.`);
       } catch (error) {
         this.errorMessage = errorMessage(error);

--- a/ui/lib/kv/addon/routes/list-directory.js
+++ b/ui/lib/kv/addon/routes/list-directory.js
@@ -78,7 +78,7 @@ export default class KvSecretsListRoute extends Route {
 
   resetController(controller, isExiting) {
     if (isExiting) {
-      controller.set('pageFilter', '');
+      controller.set('pageFilter', null);
     }
   }
 }

--- a/ui/lib/kv/addon/templates/list-directory.hbs
+++ b/ui/lib/kv/addon/templates/list-directory.hbs
@@ -1,8 +1,10 @@
 <Page::List
-  @model={{this.model}}
-  @breadcrumbs={{this.breadcrumbs}}
-  @routeName={{this.routeName}}
+  @secrets={{this.model.secrets}}
+  @backend={{this.model.backend}}
+  @pathToSecret={{this.model.pathToSecret}}
   @pageFilter={{this.model.pageFilter}}
   @filterValue={{this.model.filterValue}}
   @noMetadataListPermissions={{this.model.noMetadataListPermissions}}
+  @breadcrumbs={{this.breadcrumbs}}
+  @routeName={{this.routeName}}
 />

--- a/ui/lib/kv/addon/templates/list.hbs
+++ b/ui/lib/kv/addon/templates/list.hbs
@@ -1,8 +1,10 @@
 <Page::List
-  @model={{this.model}}
-  @breadcrumbs={{this.breadcrumbs}}
-  @routeName={{this.routeName}}
+  @secrets={{this.model.secrets}}
+  @backend={{this.model.backend}}
+  @pathToSecret={{this.model.pathToSecret}}
   @pageFilter={{this.model.pageFilter}}
   @filterValue={{this.model.filterValue}}
   @noMetadataListPermissions={{this.model.noMetadataListPermissions}}
+  @breadcrumbs={{this.breadcrumbs}}
+  @routeName={{this.routeName}}
 />

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-create-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-create-test.js
@@ -227,12 +227,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
         'Redirects to detail after save'
       );
       await click(PAGE.breadcrumbAtIdx(2));
-      // TODO: Pagefilter should not be present if empty
-      assert.strictEqual(
-        currentURL(),
-        `/vault/secrets/${backend}/kv/app%2F/directory?pageFilter=`,
-        'sub-dir page'
-      );
+      assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/app%2F/directory`, 'sub-dir page');
       assert.dom(PAGE.list.item('new')).exists('Lists new secret in sub-dir');
     });
     test('create new version of secret from older version (a)', async function (assert) {
@@ -1030,12 +1025,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
         'Redirects to detail after save'
       );
       await click(PAGE.breadcrumbAtIdx(2));
-      // TODO: Pagefilter should not be present if empty
-      assert.strictEqual(
-        currentURL(),
-        `/vault/secrets/${backend}/kv/app%2F/directory?pageFilter=`,
-        'sub-dir page'
-      );
+      assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/app%2F/directory`, 'sub-dir page');
       assert.dom(PAGE.list.item()).doesNotExist('Does not list any secrets');
     });
     test('create new version of secret from older version (sc)', async function (assert) {

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
@@ -348,10 +348,9 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
 
       // Click cancel btn
       await click(FORM.cancelBtn);
-      // TODO: pageFilter should not show on query params if empty
       assert.strictEqual(
         currentURL(),
-        `/vault/secrets/${backend}/kv/list?pageFilter=`,
+        `/vault/secrets/${backend}/kv/list`,
         `url includes /vault/secrets/${backend}/kv/list`
       );
     });
@@ -993,7 +992,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       // TODO: qp should not be present if empty
       assert.strictEqual(
         currentURL(),
-        `/vault/secrets/${backend}/kv/list?pageFilter=`,
+        `/vault/secrets/${backend}/kv/list`,
         `url includes /vault/secrets/${backend}/kv/list`
       );
     });

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
@@ -989,7 +989,6 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
 
       // Click cancel btn
       await click(FORM.cancelBtn);
-      // TODO: qp should not be present if empty
       assert.strictEqual(
         currentURL(),
         `/vault/secrets/${backend}/kv/list`,

--- a/ui/tests/integration/components/kv/kv-list-filter-test.js
+++ b/ui/tests/integration/components/kv/kv-list-filter-test.js
@@ -57,7 +57,7 @@ module('Integration | Component | kv | kv-list-filter', function (hooks) {
       },
     });
 
-    await render(hbs`<KvListFilter @model={{this.model}} @mountPoint={{this.mountPoint}} />`, {
+    await render(hbs`<KvListFilter @secrets={{this.model.secrets}} @mountPoint={{this.mountPoint}} />`, {
       owner: this.engine,
     });
 
@@ -82,7 +82,7 @@ module('Integration | Component | kv | kv-list-filter', function (hooks) {
     });
 
     await render(
-      hbs`<KvListFilter @model={{this.model}} @mountPoint={{this.mountPoint}} @pageFilter="my-" />`,
+      hbs`<KvListFilter @secrets={{this.model.secrets}} @mountPoint={{this.mountPoint}} @pageFilter="my-" />`,
       {
         owner: this.engine,
       }
@@ -102,7 +102,7 @@ module('Integration | Component | kv | kv-list-filter', function (hooks) {
     });
 
     await render(
-      hbs`<KvListFilter @model={{this.model}} @mountPoint={{this.mountPoint}} @filterValue="beep/" @pageFilter=""/>`,
+      hbs`<KvListFilter @secrets={{this.model.secrets}} @mountPoint={{this.mountPoint}} @filterValue="beep/" @pageFilter=""/>`,
       {
         owner: this.engine,
       }
@@ -129,7 +129,7 @@ module('Integration | Component | kv | kv-list-filter', function (hooks) {
       transitionTo(route, pathToSecret, { queryParams: { pageFilter } }) {
         assert.strictEqual(route, `${MOUNT_POINT}.list-directory`, 'Still on a directory route.');
         assert.strictEqual(pathToSecret, 'beep/', 'Parent directory still shown.');
-        assert.deepEqual(pageFilter, '', 'Clears pageFilter on escape.');
+        assert.deepEqual(pageFilter, null, 'Clears pageFilter on escape.');
       },
     });
     // trigger escape
@@ -148,7 +148,7 @@ module('Integration | Component | kv | kv-list-filter', function (hooks) {
     });
 
     await render(
-      hbs`<KvListFilter @model={{this.model}} @mountPoint={{this.mountPoint}} @filterValue="beep/boop/"/>`,
+      hbs`<KvListFilter @secrets={{this.model.secrets}} @mountPoint={{this.mountPoint}} @filterValue="beep/boop/"/>`,
       {
         owner: this.engine,
       }
@@ -185,7 +185,7 @@ module('Integration | Component | kv | kv-list-filter', function (hooks) {
     });
 
     await render(
-      hbs`<KvListFilter @model={{this.model}} @mountPoint={{this.mountPoint}} @filterValue="beep/boop/bop"/>`,
+      hbs`<KvListFilter @secrets={{this.model.secrets}} @mountPoint={{this.mountPoint}} @filterValue="beep/boop/bop"/>`,
       {
         owner: this.engine,
       }

--- a/ui/tests/unit/adapters/kv/metadata-test.js
+++ b/ui/tests/unit/adapters/kv/metadata-test.js
@@ -153,9 +153,7 @@ module('Unit | Adapter | kv/metadata', function (hooks) {
 
     let record = await this.store.peekRecord('kv/metadata', data.id);
 
-    await record.destroyRecord({
-      adapterOptions: { deleteType: 'delete-metadata' },
-    });
+    await record.destroyRecord();
     assert.true(record.isDestroyed, 'record is destroyed');
     record = await this.store.peekRecord('kv/metadata', this.id);
     assert.strictEqual(record, null, 'record is no longer in store');


### PR DESCRIPTION
I came across these 🧹 up tasks while working on the LIST Pagination functionality. I would like to address these changes before I open that PR for review.

Cleaned up:

* There was some lingering DELETE on kv/metadata issues. You can DELETE on metadata from two locations: the list view and the edit metadata view. I cleaned up the adapter destroyRecord and added comments to explain.
* Cleaned up KvListFilter by adding a navigate method.
* Solved issue of the queryParam pageFilter= when value was not set.