### PR TITLE
UI: Enable KV create secret with Control Group

### DIFF
--- a/changelog/22471.txt
+++ b/changelog/22471.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: enables create and update KV secret workflow when control group present
+```

--- a/ui/app/components/secret-create-or-update.js
+++ b/ui/app/components/secret-create-or-update.js
@@ -17,6 +17,7 @@
  *  @isV2=true
  *  @secretData={{@secretData}}
  *  @canCreateSecretMetadata=false
+ *  @buttonDisabled={{this.saving}}
  * />
  * ```
  * @param {string} mode - create, edit, show determines what view to display
@@ -26,6 +27,7 @@
  * @param {boolean} isV2 - whether or not KV1 or KV2
  * @param {object} secretData - class that is created in secret-edit
  * @param {boolean} canUpdateSecretMetadata - based on permissions to the /metadata/ endpoint. If user has secret update. create is not enough for metadata.
+ * @param {boolean} buttonDisabled - if true, disables the submit button on the create/update form
  */
 
 import Component from '@glimmer/component';

--- a/ui/app/components/secret-create-or-update.js
+++ b/ui/app/components/secret-create-or-update.js
@@ -51,6 +51,7 @@ export default class SecretCreateOrUpdate extends Component {
   @tracked validationMessages = null;
 
   @service controlGroup;
+  @service flashMessages;
   @service router;
   @service store;
 
@@ -163,6 +164,7 @@ export default class SecretCreateOrUpdate extends Component {
         if (error instanceof ControlGroupError) {
           const errorMessage = this.controlGroup.logFromError(error);
           this.error = errorMessage.content;
+          this.controlGroup.saveTokenFromError(error);
         }
         throw error;
       });
@@ -233,8 +235,13 @@ export default class SecretCreateOrUpdate extends Component {
       return;
     }
 
+    const secretPath = type === 'create' ? this.args.modelForData.path : this.args.model.id;
     this.persistKey(() => {
-      this.transitionToRoute(SHOW_ROUTE, this.args.model.path || this.args.model.id);
+      // Show flash message in case there's a control group on read
+      this.flashMessages.success(
+        `Secret ${secretPath} ${type === 'create' ? 'created' : 'updated'} successfully.`
+      );
+      this.transitionToRoute(SHOW_ROUTE, secretPath);
     });
   }
   @action

--- a/ui/app/services/control-group.js
+++ b/ui/app/services/control-group.js
@@ -109,6 +109,18 @@ export default Service.extend({
     return this.router.transitionTo('vault.cluster.access.control-group-accessor', accessor);
   },
 
+  // Handle error from non-read request (eg. POST or UPDATE) so it can be retried
+  saveTokenFromError(error) {
+    const { accessor, token, creation_path, creation_time, ttl } = error;
+    const data = { accessor, token, creation_path, creation_time, ttl };
+    // data.uiParams = { url: this.router.currentURL };
+    this.storeControlGroupToken(data);
+    // In the read flow the accessor is marked once the user clicks "Visit" from the control group page
+    // On a POST/UPDATE flow we don't redirect, so we need to mark automatically so that on the next try
+    // the request will attempt unwrap.
+    this.markTokenForUnwrap(accessor);
+  },
+
   logFromError(error) {
     const { accessor, token, creation_path, creation_time, ttl } = error;
     const data = { accessor, token, creation_path, creation_time, ttl };

--- a/ui/app/services/control-group.js
+++ b/ui/app/services/control-group.js
@@ -113,7 +113,6 @@ export default Service.extend({
   saveTokenFromError(error) {
     const { accessor, token, creation_path, creation_time, ttl } = error;
     const data = { accessor, token, creation_path, creation_time, ttl };
-    // data.uiParams = { url: this.router.currentURL };
     this.storeControlGroupToken(data);
     // In the read flow the accessor is marked once the user clicks "Visit" from the control group page
     // On a POST/UPDATE flow we don't redirect, so we need to mark automatically so that on the next try

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -142,12 +142,7 @@
     {{/if}}
     <div class="field is-grouped box is-fullwidth is-bottomless">
       <div class="control">
-        <button
-          type="submit"
-          disabled={{or @buttonDisabled this.validationErrorCount}}
-          class="button is-primary"
-          data-test-secret-save={{true}}
-        >
+        <button type="submit" disabled={{@buttonDisabled}} class="button is-primary" data-test-secret-save={{true}}>
           Save
         </button>
       </div>

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -144,7 +144,7 @@
       <div class="control">
         <button
           type="submit"
-          disabled={{or @buttonDisabled this.validationErrorCount this.error}}
+          disabled={{or @buttonDisabled this.validationErrorCount}}
           class="button is-primary"
           data-test-secret-save={{true}}
         >

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -257,7 +257,7 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
     await deleteEngine(enginePath, assert);
   });
 
-  test('it disables save when validation errors occur', async function (assert) {
+  test('it shows validation errors', async function (assert) {
     assert.expect(5);
     const enginePath = `kv-secret-${this.uid}`;
     const secretPath = 'not-duplicate';
@@ -279,7 +279,7 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
     assert
       .dom('[data-test-input="maxVersions"]')
       .hasClass('has-error-border', 'shows border error on input with error');
-    assert.dom('[data-test-secret-save]').isDisabled('Save button is disabled');
+    assert.dom('[data-test-secret-save]').isNotDisabled('Save button is disabled');
     await fillIn('[data-test-input="maxVersions"]', 20); // fillIn replaces the text, whereas typeIn only adds to it.
     await triggerKeyEvent('[data-test-input="maxVersions"]', 'keyup', 65);
     await editPage.path(secretPath);


### PR DESCRIPTION
This PR fixes the experience in the UI when attempting to create a new secret while a policy utilizing control groups. The example policy below which requires authorization for read, create, and update: 
```
path "kv-test/data/+/root" {
  capabilities = [ "read","create","update" ]
  
  control_group = {
    factor "authorizer" {
      identity {
        group_names = [ "managers" ]
        approvals = 1
      }
    }
  }  
}
```

**Before**
Before, the submit button was disabled if there was an API error:
<img width="1020" alt="Screenshot 2023-08-21 at 12 20 50 PM" src="https://github.com/hashicorp/vault/assets/82459713/c0871753-26ab-42d9-98a1-08c7e01f96ae">

Once resubmit was enabled, there was a loop where each subsequent request to create the secret would generate a new control group accessor (which shows on the error banner):
<img width="1123" alt="Screenshot 2023-08-21 at 12 10 01 PM" src="https://github.com/hashicorp/vault/assets/82459713/cbb70dd5-bd05-417d-994d-ed9f75bce4fb">

**After**
I added notes to the codebase, but essentially we need to mark the token for unwrap when we handle the control group error in the control group, so that the next request attempts to unwrap instead of call the same POST endpoint. 
Since I tested with a control group on read as well, I added a flash message to successful create or update in case the show page redirects to the control group page:
<img width="1123" alt="Screenshot 2023-08-21 at 12 12 58 PM" src="https://github.com/hashicorp/vault/assets/82459713/7fea5c8e-5d05-477c-9ba1-93d2538b63d1">
authorizing this request takes you back to the create page, but fixing that is out of scope of this fix. 

**A note about updating**
This flow also technically enables secret updating via the UI with a control group, but if you navigate to the update page via the UI (rather than a direct link) the redirections will prevent you from ever reaching the update form because the UI re-fetches the secret data on the update page. This flow should be fully fixed with #22426 and the navigation refresh

