### PR TITLE
UI: dashboard acceptance tests for quick actions, client count, replication

### DIFF
--- a/ui/app/components/dashboard/client-count-card.js
+++ b/ui/app/components/dashboard/client-count-card.js
@@ -45,7 +45,8 @@ export default class DashboardClientCountCard extends Component {
 
   @task
   @waitFor
-  *fetchClientActivity() {
+  *fetchClientActivity(e) {
+    if (e) e.preventDefault();
     this.updatedAt = timestamp.now().toISOString();
     // only make the network request if we have a start_time
     if (!this.licenseStartTime) return {};

--- a/ui/app/components/dashboard/quick-actions-card.js
+++ b/ui/app/components/dashboard/quick-actions-card.js
@@ -50,7 +50,7 @@ export default class DashboardQuickActionsCard extends Component {
           buttonText: 'Read secrets',
           // check kv version to figure out which model to use
           model: this.selectedEngine.version === 2 ? 'secret-v2' : 'secret',
-          route: 'vault.cluster.secrets.backends.show',
+          route: 'vault.cluster.secrets.backend.show',
         };
       case 'Generate credentials for database':
         return {

--- a/ui/app/components/dashboard/quick-actions-card.js
+++ b/ui/app/components/dashboard/quick-actions-card.js
@@ -30,7 +30,7 @@ export default class DashboardQuickActionsCard extends Component {
 
   get actionOptions() {
     switch (this.selectedEngine.type) {
-      case 'kv version 1' || 'kv version 2':
+      case `kv version ${this.selectedEngine?.version}`:
         return ['Find KV secrets'];
       case 'database':
         return ['Generate credentials for database'];

--- a/ui/app/components/dashboard/vault-configuration-details-card.js
+++ b/ui/app/components/dashboard/vault-configuration-details-card.js
@@ -18,7 +18,7 @@ import Component from '@glimmer/component';
 
 export default class DashboardSecretsEnginesCard extends Component {
   get tlsDisabled() {
-    const tlsDisableConfig = this.args.vaultConfiguration.listeners.find((listener) => {
+    const tlsDisableConfig = this.args.vaultConfiguration?.listeners.find((listener) => {
       if (listener.config && listener.config.tls_disable) return listener.config.tls_disable;
     });
 

--- a/ui/app/controllers/vault/cluster/dashboard.js
+++ b/ui/app/controllers/vault/cluster/dashboard.js
@@ -12,7 +12,8 @@ export default class DashboardController extends Controller {
   @tracked replicationUpdatedAt = timestamp.now().toISOString();
 
   @action
-  refreshModel() {
+  refreshModel(e) {
+    if (e) e.preventDefault();
     this.replicationUpdatedAt = timestamp.now().toISOString();
     this.send('refreshRoute');
   }

--- a/ui/app/templates/components/dashboard/client-count-card.hbs
+++ b/ui/app/templates/components/dashboard/client-count-card.hbs
@@ -9,50 +9,50 @@
 
   <hr class="has-background-gray-100" />
 
-  {{#if this.fetchClientActivity.isRunning}}
-    <VaultLogoSpinner />
-  {{/if}}
-
   {{#if this.noActivityData}}
     {{! This will likely not be show since the client activity api was changed to always return data. In the past it
   would return no activity data. Adding this empty state here to match the current client count behavior }}
     <Clients::NoData @config={{this.clientConfig}} />
   {{else}}
-    <div class="is-grid grid-2-columns grid-gap-2 has-top-margin-m grid-align-items-start is-flex-v-centered">
-      <StatText
-        @label="Total"
-        @value={{this.activityData.total.clients}}
-        @size="l"
-        @subText="The number of clients in this billing period ({{date-format
-          this.licenseStartTime
-          'MMM yyyy'
-        }} - {{date-format this.updatedAt 'MMM yyyy'}})."
-        data-test-stat-text="total-clients"
-      />
-      <StatText
-        @label="New"
-        @value={{this.currentMonthActivityTotalCount}}
-        @size="l"
-        @subText="The number of clients new to Vault in the current month."
-        data-test-stat-text="new-clients"
-      />
-    </div>
+    {{#if this.fetchClientActivity.isRunning}}
+      <VaultLogoSpinner />
+    {{else}}
+      <div class="is-grid grid-2-columns grid-gap-2 has-top-margin-m grid-align-items-start is-flex-v-centered">
+        <StatText
+          @label="Total"
+          @value={{this.activityData.total.clients}}
+          @size="l"
+          @subText="The number of clients in this billing period ({{date-format
+            this.licenseStartTime
+            'MMM yyyy'
+          }} - {{date-format this.updatedAt 'MMM yyyy'}})."
+          data-test-stat-text="total-clients"
+        />
+        <StatText
+          @label="New"
+          @value={{this.currentMonthActivityTotalCount}}
+          @size="l"
+          @subText="The number of clients new to Vault in the current month."
+          data-test-stat-text="new-clients"
+        />
+      </div>
 
-    <div class="has-top-margin-l is-flex-center">
-      <Hds::Button
-        @text="Refresh"
-        @isIconOnly={{true}}
-        @color="tertiary"
-        @icon="sync"
-        disabled={{this.fetchClientActivity.isRunning}}
-        class="has-padding-xxs"
-        {{on "click" (perform this.fetchClientActivity)}}
-        data-test-refresh
-      />
-      <small class="has-left-margin-xs has-text-grey">
-        Updated
-        {{date-format this.updatedAt "MMM dd, yyyy HH:mm:SS"}}
-      </small>
-    </div>
+      <div class="has-top-margin-l is-flex-center">
+        <Hds::Button
+          @text="Refresh"
+          @isIconOnly={{true}}
+          @color="tertiary"
+          @icon="sync"
+          disabled={{this.fetchClientActivity.isRunning}}
+          class="has-padding-xxs"
+          {{on "click" (perform this.fetchClientActivity)}}
+          data-test-refresh
+        />
+        <small class="has-left-margin-xs has-text-grey">
+          Updated
+          {{date-format this.updatedAt "MMM dd, yyyy HH:mm:SS"}}
+        </small>
+      </div>
+    {{/if}}
   {{/if}}
 </Hds::Card::Container>

--- a/ui/app/templates/components/dashboard/client-count-card.hbs
+++ b/ui/app/templates/components/dashboard/client-count-card.hbs
@@ -9,52 +9,50 @@
 
   <hr class="has-background-gray-100" />
 
+  {{#if this.fetchClientActivity.isRunning}}
+    <VaultLogoSpinner />
+  {{/if}}
+
   {{#if this.noActivityData}}
     {{! This will likely not be show since the client activity api was changed to always return data. In the past it
   would return no activity data. Adding this empty state here to match the current client count behavior }}
     <Clients::NoData @config={{this.clientConfig}} />
   {{else}}
     <div class="is-grid grid-2-columns grid-gap-2 has-top-margin-m grid-align-items-start is-flex-v-centered">
-      {{#if this.fetchClientActivity.isRunning}}
-        <VaultLogoSpinner />
-      {{else}}
-        <StatText
-          @label="Total"
-          @value={{this.activityData.total.clients}}
-          @size="l"
-          @subText="The number of clients in this billing period ({{date-format
-            this.licenseStartTime
-            'MMM yyyy'
-          }} - {{date-format this.updatedAt 'MMM yyyy'}})."
-          data-test-stat-text="total-clients"
-        />
-        <StatText
-          @label="New"
-          @value={{this.currentMonthActivityTotalCount}}
-          @size="l"
-          @subText="The number of clients new to Vault in the current month."
-          data-test-stat-text="new-clients"
-        />
-      {{/if}}
+      <StatText
+        @label="Total"
+        @value={{this.activityData.total.clients}}
+        @size="l"
+        @subText="The number of clients in this billing period ({{date-format
+          this.licenseStartTime
+          'MMM yyyy'
+        }} - {{date-format this.updatedAt 'MMM yyyy'}})."
+        data-test-stat-text="total-clients"
+      />
+      <StatText
+        @label="New"
+        @value={{this.currentMonthActivityTotalCount}}
+        @size="l"
+        @subText="The number of clients new to Vault in the current month."
+        data-test-stat-text="new-clients"
+      />
     </div>
 
-    {{#unless this.fetchClientActivity.isRunning}}
-      <div class="has-top-margin-l is-flex-center">
-        <Hds::Button
-          @text="Refresh"
-          @isIconOnly={{true}}
-          @color="tertiary"
-          @icon="sync"
-          disabled={{this.fetchClientActivity.isRunning}}
-          class="has-padding-xxs"
-          {{on "click" (perform this.fetchClientActivity)}}
-          data-test-refresh
-        />
-        <small class="has-left-margin-xs has-text-grey">
-          Updated
-          {{date-format this.updatedAt "MMM dd, yyyy HH:mm:SS"}}
-        </small>
-      </div>
-    {{/unless}}
+    <div class="has-top-margin-l is-flex-center">
+      <Hds::Button
+        @text="Refresh"
+        @isIconOnly={{true}}
+        @color="tertiary"
+        @icon="sync"
+        disabled={{this.fetchClientActivity.isRunning}}
+        class="has-padding-xxs"
+        {{on "click" (perform this.fetchClientActivity)}}
+        data-test-refresh
+      />
+      <small class="has-left-margin-xs has-text-grey">
+        Updated
+        {{date-format this.updatedAt "MMM dd, yyyy HH:mm:SS"}}
+      </small>
+    </div>
   {{/if}}
 </Hds::Card::Container>

--- a/ui/app/templates/components/dashboard/client-count-card.hbs
+++ b/ui/app/templates/components/dashboard/client-count-card.hbs
@@ -1,4 +1,4 @@
-<Hds::Card::Container @hasBorder={{true}} class="has-padding-l has-bottom-padding-m">
+<Hds::Card::Container @hasBorder={{true}} class="has-padding-l has-bottom-padding-m" data-test-client-count-card>
   <div class="is-flex-between">
     <h3 class="title is-4 has-bottom-margin-xxs" data-test-client-count-title>
       Client count

--- a/ui/app/templates/components/dashboard/quick-actions-card.hbs
+++ b/ui/app/templates/components/dashboard/quick-actions-card.hbs
@@ -45,6 +45,7 @@
         @fallbackComponent="input-search"
         @nameKey={{this.searchSelectParams.nameKey}}
         @disabled={{not this.searchSelectParams.model}}
+        data-test-param-select
       />
 
       <div>

--- a/ui/app/templates/components/dashboard/quick-actions-card.hbs
+++ b/ui/app/templates/components/dashboard/quick-actions-card.hbs
@@ -60,6 +60,10 @@
       </div>
     {{/if}}
   {{else}}
-    <EmptyState @title="No mount selected" @message="Select a mount above to get started." />
+    <EmptyState
+      @title="No mount selected"
+      @message="Select a mount above to get started."
+      data-test-no-mount-selected-empty
+    />
   {{/if}}
 </Hds::Card::Container>

--- a/ui/app/templates/components/dashboard/quick-actions-card.hbs
+++ b/ui/app/templates/components/dashboard/quick-actions-card.hbs
@@ -14,7 +14,7 @@
       @displayInherit={{true}}
       @shouldRenderName={{true}}
       @passObject={{true}}
-      @objectKeys={{array "type"}}
+      @objectKeys={{array "type" "version"}}
       class="is-marginless"
       data-test-secrets-engines-select
     />
@@ -38,7 +38,7 @@
         class="is-flex-grow-1"
         @selectLimit="1"
         @models={{array this.searchSelectParams.model}}
-        @backend={{this.mountPath}}
+        @backend={{this.selectedEngine.id}}
         @placeholder={{this.searchSelectParams.placeholder}}
         @disallowNewItems={{true}}
         @onChange={{this.handleActionSelect}}

--- a/ui/app/templates/components/dashboard/replication-card.hbs
+++ b/ui/app/templates/components/dashboard/replication-card.hbs
@@ -2,7 +2,7 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
 ~}}
-<Hds::Card::Container @hasBorder={{true}} class="has-padding-l has-bottom-padding-m">
+<Hds::Card::Container @hasBorder={{true}} class="has-padding-l has-bottom-padding-m" data-test-replication-card>
 
   <div class="is-flex-between">
     <h3 class="title is-4 has-bottom-margin-xxs" data-test-client-count-title>

--- a/ui/app/templates/components/dashboard/secrets-engines-card.hbs
+++ b/ui/app/templates/components/dashboard/secrets-engines-card.hbs
@@ -61,7 +61,7 @@
     </:body>
   </Hds::Table>
   {{#if (gt this.filteredSecretsEngines.length 4)}}
-    <div class="is-flex-end has-top-margin-s">
+    <div class="is-flex-end has-top-margin-s" data-test-secrets-engines-card-show-all>
       <Hds::Link::Standalone
         class="has-text-weight-semibold is-no-underline"
         @icon="arrow-right"

--- a/ui/app/templates/components/dashboard/secrets-engines-card.hbs
+++ b/ui/app/templates/components/dashboard/secrets-engines-card.hbs
@@ -60,13 +60,15 @@
       {{/each}}
     </:body>
   </Hds::Table>
-  <div class="is-flex-end has-top-margin-s">
-    <Hds::Link::Standalone
-      class="has-text-weight-semibold is-no-underline"
-      @icon="arrow-right"
-      @iconPosition="trailing"
-      @text="Show all"
-      @route="vault.cluster.secrets.backends"
-    />
-  </div>
+  {{#if (gt this.filteredSecretsEngines.length 4)}}
+    <div class="is-flex-end has-top-margin-s">
+      <Hds::Link::Standalone
+        class="has-text-weight-semibold is-no-underline"
+        @icon="arrow-right"
+        @iconPosition="trailing"
+        @text="Show all"
+        @route="vault.cluster.secrets.backends"
+      />
+    </div>
+  {{/if}}
 </Hds::Card::Container>

--- a/ui/app/templates/components/dashboard/survey-link-text.hbs
+++ b/ui/app/templates/components/dashboard/survey-link-text.hbs
@@ -2,7 +2,8 @@
   <small>
     Don't see what you're looking for on this page? Let us know via our
     <Hds::Link::Inline @icon="external-link" @href="https://hashicorp.sjc1.qualtrics.com/jfe/form/SV_1SNUsZLdWHpfw0e">
-      feedback form.
+      feedback form
     </Hds::Link::Inline>
+    .
   </small>
 </div>

--- a/ui/app/templates/vault/cluster/dashboard.hbs
+++ b/ui/app/templates/vault/cluster/dashboard.hbs
@@ -2,7 +2,7 @@
 
 <div class="has-bottom-margin-xl">
   <div class="is-flex-row has-gap-l">
-    {{#if @model.version.isEnterprise}}
+    {{#if (and @model.version.isEnterprise (or @model.license @model.isRootNamespace))}}
 
       <div class="is-flex-column is-flex-1 has-gap-l">
         {{#if @model.license}}

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -340,7 +340,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
 
     test('shows the correct actions and links associated with kv', async function (assert) {
-      await runCommands(['write sys/mounts/kv-1 type=kv options=version=2', 'write kv-1/foo bar=baz']);
+      await runCommands(['write sys/mounts/kv type=kv options=version=2']);
       await settled();
       await visit('/vault/dashboard');
       await selectChoose(QUICK_ACTION_SELECTORS.secretsEnginesSelect, 'kv');

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -94,7 +94,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       assert.dom('[data-test-learn-more-links] a').exists({ count: 4 });
       assert
         .dom('[data-test-feedback-form]')
-        .hasText("Don't see what you're looking for on this page? Let us know via our feedback form. ");
+        .hasText("Don't see what you're looking for on this page? Let us know via our feedback form .");
     });
   });
 
@@ -315,14 +315,18 @@ module('Acceptance | landing page dashboard', function (hooks) {
       sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
       ENV['ember-cli-mirage'].handler = 'clients';
     });
+
     hooks.beforeEach(async function () {
       this.store = this.owner.lookup('service:store');
-
-      await authPage.login();
     });
+
     hooks.after(function () {
       timestamp.now.restore();
       ENV['ember-cli-mirage'].handler = null;
+    });
+
+    hooks.beforeEach(async function () {
+      await authPage.login();
     });
 
     skip('hides the client count card', async function (assert) {

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -4,135 +4,64 @@
  */
 
 import { module, test } from 'qunit';
-import { visit, currentURL } from '@ember/test-helpers';
+import { visit, currentURL, settled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'vault/tests/helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import authPage from 'vault/tests/pages/auth';
 import SECRETS_ENGINE_SELECTORS from 'vault/tests/helpers/components/dashboard/secrets-engines-card';
-import VAULT_CONFIGURATION_SELECTORS from 'vault/tests/helpers/components/dashboard/vault-configuration-details-card';
+// import VAULT_CONFIGURATION_SELECTORS from 'vault/tests/helpers/components/dashboard/vault-configuration-details-card';
 import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
+import { deleteEngineCmd } from 'vault/tests/helpers/commands';
+import { create } from 'ember-cli-page-object';
+import consoleClass from 'vault/tests/pages/components/console/ui-panel';
+import { selectChoose } from 'ember-power-select/test-support/helpers';
+
+const consoleComponent = create(consoleClass);
 
 module('Acceptance | landing page dashboard', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function () {
-    this.data = {
-      api_addr: 'http://127.0.0.1:8200',
-      cache_size: 0,
-      cluster_addr: 'https://127.0.0.1:8201',
-      cluster_cipher_suites: '',
-      cluster_name: '',
-      default_lease_ttl: 0,
-      default_max_request_duration: 0,
-      detect_deadlocks: '',
-      disable_cache: false,
-      disable_clustering: false,
-      disable_indexing: false,
-      disable_mlock: true,
-      disable_performance_standby: false,
-      disable_printable_check: false,
-      disable_sealwrap: false,
-      disable_sentinel_trace: false,
-      enable_response_header_hostname: false,
-      enable_response_header_raft_node_id: false,
-      enable_ui: true,
-      experiments: null,
-      introspection_endpoint: false,
-      listeners: [
-        {
-          config: {
-            address: '0.0.0.0:8200',
-            cluster_address: '0.0.0.0:8201',
-            tls_disable: true,
-          },
-          type: 'tcp',
-        },
-      ],
-      log_format: '',
-      log_level: 'debug',
-      log_requests_level: '',
-      max_lease_ttl: '48h',
-      pid_file: '',
-      plugin_directory: '',
-      plugin_file_permissions: 0,
-      plugin_file_uid: 0,
-      raw_storage_endpoint: true,
-      seals: [
-        {
-          disabled: false,
-          type: 'shamir',
-        },
-      ],
-      storage: {
-        cluster_addr: 'https://127.0.0.1:8201',
-        disable_clustering: false,
-        raft: {
-          max_entry_size: '',
-        },
-        redirect_addr: 'http://127.0.0.1:8200',
-        type: 'raft',
-      },
-      telemetry: {
-        add_lease_metrics_namespace_labels: false,
-        circonus_api_app: '',
-        circonus_api_token: '',
-        circonus_api_url: '',
-        circonus_broker_id: '',
-        circonus_broker_select_tag: '',
-        circonus_check_display_name: '',
-        circonus_check_force_metric_activation: '',
-        circonus_check_id: '',
-        circonus_check_instance_id: '',
-        circonus_check_search_tag: '',
-        circonus_check_tags: '',
-        circonus_submission_interval: '',
-        circonus_submission_url: '',
-        disable_hostname: true,
-        dogstatsd_addr: '',
-        dogstatsd_tags: null,
-        lease_metrics_epsilon: 3600000000000,
-        maximum_gauge_cardinality: 500,
-        metrics_prefix: '',
-        num_lease_metrics_buckets: 168,
-        prometheus_retention_time: 86400000000000,
-        stackdriver_debug_logs: false,
-        stackdriver_location: '',
-        stackdriver_namespace: '',
-        stackdriver_project_id: '',
-        statsd_address: '',
-        statsite_address: '',
-        usage_gauge_period: 5000000000,
-      },
-    };
-    return authPage.login();
-  });
-
   test('navigate to dashboard on login', async function (assert) {
+    await authPage.login();
     assert.strictEqual(currentURL(), '/vault/dashboard');
   });
 
   test('display the version number for the title', async function (assert) {
+    await authPage.login();
     await visit('/vault/dashboard');
     assert.dom('[data-test-dashboard-version-header]').hasText('Vault v1.9.0 root');
   });
 
-  module('secrets engines card', function () {
+  module('secrets engines card', function (hooks) {
+    hooks.beforeEach(function () {
+      return authPage.login();
+    });
+
     test('shows a secrets engine card', async function (assert) {
       await mountSecrets.enable('pki', 'pki');
+      await settled();
       await visit('/vault/dashboard');
       assert.dom(SECRETS_ENGINE_SELECTORS.cardTitle).hasText('Secrets engines');
       assert.dom(SECRETS_ENGINE_SELECTORS.getSecretEngineAccessor('pki')).exists();
+      // cleanup engine
+      await consoleComponent.runCommands(deleteEngineCmd('pki'));
     });
 
     test('it adds disabled css styling to unsupported secret engines', async function (assert) {
       await mountSecrets.enable('nomad', 'nomad');
+      await settled();
       await visit('/vault/dashboard');
       assert.dom('[data-test-secrets-engines-row="nomad"] [data-test-view]').doesNotExist();
+      // cleanup engine
+      await consoleComponent.runCommands(deleteEngineCmd('nomad'));
     });
   });
 
-  module('learn more card', function () {
+  module('learn more card', function (hooks) {
+    hooks.beforeEach(function () {
+      return authPage.login();
+    });
     test('shows the learn more card', async function (assert) {
       await visit('/vault/dashboard');
       assert.dom('[data-test-learn-more-title]').hasText('Learn more');
@@ -148,53 +77,19 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
   });
 
-  module('configuration details card', function () {
-    test('shows the configuration details card', async function (assert) {
-      this.server.get('sys/config/state/sanitized', () => ({
-        data: this.data,
-        wrap_info: null,
-        warnings: null,
-        auth: null,
-      }));
-      await authPage.login();
-      await visit('/vault/dashboard');
-      assert.dom(VAULT_CONFIGURATION_SELECTORS.cardTitle).hasText('Configuration details');
-      assert.dom(VAULT_CONFIGURATION_SELECTORS.apiAddr).hasText('http://127.0.0.1:8200');
-      assert.dom(VAULT_CONFIGURATION_SELECTORS.defaultLeaseTtl).hasText('0');
-      assert.dom(VAULT_CONFIGURATION_SELECTORS.maxLeaseTtl).hasText('2 days');
-      assert.dom(VAULT_CONFIGURATION_SELECTORS.tlsDisable).hasText('Enabled');
-      assert.dom(VAULT_CONFIGURATION_SELECTORS.logFormat).hasText('None');
-      assert.dom(VAULT_CONFIGURATION_SELECTORS.logLevel).hasText('debug');
-      assert.dom(VAULT_CONFIGURATION_SELECTORS.storageType).hasText('raft');
+  module('quick actions card', function (hooks) {
+    hooks.beforeEach(function () {
+      return authPage.login();
     });
-    test('shows the tls disabled if it is disabled', async function (assert) {
-      this.server.get('sys/config/state/sanitized', () => {
-        this.data.listeners[0].config.tls_disable = false;
-        return {
-          data: this.data,
-          wrap_info: null,
-          warnings: null,
-          auth: null,
-        };
-      });
-      await authPage.login();
-      await visit('/vault/dashboard');
-      assert.dom(VAULT_CONFIGURATION_SELECTORS.tlsDisable).hasText('Disabled');
-    });
-    test('shows the tls disabled if there is no tlsDisabled returned from server', async function (assert) {
-      this.server.get('sys/config/state/sanitized', () => {
-        this.data.listeners = [];
 
-        return {
-          data: this.data,
-          wrap_info: null,
-          warnings: null,
-          auth: null,
-        };
-      });
-      await authPage.login();
+    test('shows the default state of the quick actions card', async function (assert) {
+      await mountSecrets.enable('pki', 'pki');
+      await mountSecrets.enable('database', 'database');
+      await mountSecrets.enable('kv', 'kv');
       await visit('/vault/dashboard');
-      assert.dom(VAULT_CONFIGURATION_SELECTORS.tlsDisable).hasText('Disabled');
+      assert.dom('[data-test-no-mount-selected-empty]').exists();
+      await selectChoose('.search-select', 'pki-0-test');
+      // await this.pauseTest();
     });
   });
 });

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -40,8 +40,11 @@ module('Acceptance | landing page dashboard', function (hooks) {
     await authPage.login();
     await visit('/vault/dashboard');
     const version = this.owner.lookup('service:version');
-    const versionName = version.version.slice(0, version.version.indexOf('+'));
-    assert.dom('[data-test-dashboard-version-header]').hasText(`Vault v${versionName} root`);
+    const versionName = version.version;
+    const versionNameEnd = version.isEnterprise ? versionName.indexOf('+') : versionName.length;
+    assert
+      .dom('[data-test-dashboard-version-header]')
+      .hasText(`Vault v${versionName.slice(0, versionNameEnd)} root`);
   });
 
   module('secrets engines card', function (hooks) {
@@ -357,7 +360,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
     test('shows the replication card empty state in community version', async function (assert) {
       await visit('/vault/dashboard');
       const version = this.owner.lookup('service:version');
-      assert.true(version.isEnterprise, 'vault is enterprise');
+      assert.false(version.isEnterprise, 'vault is enterprise');
       assert.dom(REPLICATION_CARD_SELECTORS.replicationEmptyState).exists();
       assert.dom(REPLICATION_CARD_SELECTORS.replicationEmptyStateTitle).hasText('Replication not set up');
       assert

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import {
   visit,
   currentURL,
@@ -21,6 +21,7 @@ import { deleteEngineCmd } from 'vault/tests/helpers/commands';
 import authPage from 'vault/tests/pages/auth';
 import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
 import consoleClass from 'vault/tests/pages/components/console/ui-panel';
+
 // selectors
 import SECRETS_ENGINE_SELECTORS from 'vault/tests/helpers/components/dashboard/secrets-engines-card';
 import VAULT_CONFIGURATION_SELECTORS from 'vault/tests/helpers/components/dashboard/vault-configuration-details-card';
@@ -334,7 +335,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       assert.dom('[data-test-client-count-card]').doesNotExist();
     });
 
-    test('shows the client count card', async function (assert) {
+    skip('shows the client count card', async function (assert) {
       await authPage.login();
       assert.dom('[data-test-client-count-title]').exists();
       const response = await this.store.peekRecord('clients/activity', 'some-activity-id');
@@ -373,8 +374,8 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
 
     test('it should show replication status if both dr and performance replication are enabled as features in version', async function (assert) {
-      await authPage.login();
-      await click(REPLICATION_CARD_SELECTORS.replicationEmptyStateActionsLink);
+      await visit('/vault/replication');
+      // await click(REPLICATION_CARD_SELECTORS.replicationEmptyStateActionsLink);
       await click('[data-test-replication-type-select="dr"]');
       await fillIn('[data-test-replication-cluster-mode-select]', 'primary');
       await click('[data-test-replication-enable]');

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -305,7 +305,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await consoleComponent.runCommands(deleteEngineCmd('database'));
     });
   });
-  module('client counts card', function (hooks) {
+  skip('client counts card', function (hooks) {
     hooks.before(async function () {
       ENV['ember-cli-mirage'].handler = 'clients';
     });
@@ -370,6 +370,8 @@ module('Acceptance | landing page dashboard', function (hooks) {
       // await visit('/vault/dashboard');
       // await click(REPLICATION_CARD_SELECTORS.replicationEmptyStateActionsLink);
       await click('[data-test-replication-enable]');
+      await pollCluster(this.owner);
+      await settled();
       await visit('/vault/dashboard');
       assert
         .dom(REPLICATION_CARD_SELECTORS.getReplicationTitle('dr-perf', 'DR primary'))

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -339,7 +339,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await consoleComponent.runCommands(deleteEngineCmd('database'));
     });
 
-    test('shows the correct actions and links associated with kv', async function (assert) {
+    test('shows the correct actions and links associated with kv v1', async function (assert) {
       await runCommands(['write sys/mounts/kv type=kv', 'write kv/foo bar=baz']);
       await settled();
       await visit('/vault/dashboard');
@@ -348,10 +348,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
       assert.dom(QUICK_ACTION_SELECTORS.emptyState).doesNotExist();
       assert.dom(QUICK_ACTION_SELECTORS.paramsTitle).hasText('Secret path');
       assert.dom(QUICK_ACTION_SELECTORS.getActionButton('Read secrets')).exists({ count: 1 });
-      await selectChoose(QUICK_ACTION_SELECTORS.paramSelect, '.ember-power-select-option', 0);
-      await click(QUICK_ACTION_SELECTORS.getActionButton('Read secrets'));
-      assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.show');
-      // can't write v2 acceptance tests since there isn't runCommands for v2 create secrets
       await consoleComponent.runCommands(deleteEngineCmd('kv'));
     });
   });

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -67,7 +67,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await settled();
       await visit('/vault/dashboard');
       assert.dom(SECRETS_ENGINE_SELECTORS.cardTitle).hasText('Secrets engines');
-      assert.dom(SECRETS_ENGINE_SELECTORS.getSecretEngineAccessor('pki')).exists();
+      assert.dom('[data-test-secrets-engines-card-show-all]').doesNotExist();
       // cleanup engine mount
       await consoleComponent.runCommands(deleteEngineCmd('pki'));
     });
@@ -77,6 +77,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await settled();
       await visit('/vault/dashboard');
       assert.dom('[data-test-secrets-engines-row="nomad"] [data-test-view]').doesNotExist();
+      assert.dom('[data-test-secrets-engines-card-show-all]').doesNotExist();
       // cleanup engine mount
       await consoleComponent.runCommands(deleteEngineCmd('nomad'));
     });
@@ -254,7 +255,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
 
     test('shows the correct actions and links associated with pki', async function (assert) {
       await mountSecrets.enable('pki', 'pki');
-      // generate role, issuer
       await runCommands([
         `write pki/roles/some-role \
       issuer_ref="default" \

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -306,7 +306,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
   });
   module('client counts card', function (hooks) {
-    setupMirage(hooks);
     hooks.before(async function () {
       ENV['ember-cli-mirage'].handler = 'clients';
     });
@@ -348,7 +347,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
   });
   module('replication card', function (hooks) {
-    setupMirage(hooks);
     hooks.beforeEach(async function () {
       await authPage.login();
       await settled();

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -413,7 +413,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
     test('shows the replication card empty state in enterprise version', async function (assert) {
       await visit('/vault/dashboard');
       const version = this.owner.lookup('service:version');
-      assert.false(version.isEnterprise, 'vault is enterprise');
+      assert.true(version.isEnterprise, 'vault is enterprise');
       assert.dom(REPLICATION_CARD_SELECTORS.replicationEmptyState).exists();
       assert.dom(REPLICATION_CARD_SELECTORS.replicationEmptyStateTitle).hasText('Replication not set up');
       assert

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -23,7 +23,7 @@ import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
 import consoleClass from 'vault/tests/pages/components/console/ui-panel';
 import ENV from 'vault/config/environment';
 import { formatNumber } from 'core/helpers/format-number';
-import { pollCluster } from 'vault/tests/helpers/poll-cluster';
+// import { pollCluster } from 'vault/tests/helpers/poll-cluster';
 import { disableReplication } from 'vault/tests/helpers/replication';
 
 // selectors
@@ -366,13 +366,10 @@ module('Acceptance | landing page dashboard', function (hooks) {
       assert.dom(REPLICATION_CARD_SELECTORS.replicationEmptyStateActions).hasText('Enable replication');
     });
 
-    skip('it should show replication status if both dr and performance replication are enabled as features in version', async function (assert) {
+    test('it should show replication status if both dr and performance replication are enabled as features in version', async function (assert) {
       await visit('/vault/dashboard');
       await click(REPLICATION_CARD_SELECTORS.replicationEmptyStateActionsLink);
-      await click('[data-test-replication-type-select="dr"]');
-      await fillIn('[data-test-replication-cluster-mode-select]', 'primary');
       await click('[data-test-replication-enable]');
-      await pollCluster(this.owner);
       await visit('/vault/dashboard');
       assert
         .dom(REPLICATION_CARD_SELECTORS.getReplicationTitle('dr-perf', 'DR primary'))

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -367,8 +367,8 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
 
     test('it should show replication status if both dr and performance replication are enabled as features in version', async function (assert) {
-      await visit('/vault/dashboard');
-      await click(REPLICATION_CARD_SELECTORS.replicationEmptyStateActionsLink);
+      // await visit('/vault/dashboard');
+      // await click(REPLICATION_CARD_SELECTORS.replicationEmptyStateActionsLink);
       await click('[data-test-replication-enable]');
       await visit('/vault/dashboard');
       assert

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -4,14 +4,7 @@
  */
 
 import { module, test, skip } from 'qunit';
-import {
-  visit,
-  currentURL,
-  settled,
-  fillIn,
-  click,
-  /* currentRouteName */
-} from '@ember/test-helpers';
+import { visit, currentURL, settled, fillIn, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'vault/tests/helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { create } from 'ember-cli-page-object';
@@ -305,7 +298,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await consoleComponent.runCommands(deleteEngineCmd('database'));
     });
   });
-  skip('client counts card', function (hooks) {
+  module('client counts card', function (hooks) {
     hooks.before(async function () {
       ENV['ember-cli-mirage'].handler = 'clients';
     });
@@ -319,17 +312,8 @@ module('Acceptance | landing page dashboard', function (hooks) {
       ENV['ember-cli-mirage'].handler = null;
     });
 
-    skip('hides the client count card', async function (assert) {
-      await authPage.logout();
-      this.server.get(
-        'sys/license/status',
-        () => new Response(403, {}, { errors: ['API returns this error'] })
-      );
-      await authPage.login();
-      assert.dom('[data-test-client-count-card]').doesNotExist();
-    });
-
     test('shows the client count card', async function (assert) {
+      assert.strictEqual(currentURL(), '/vault/clients/dashboard');
       assert.dom('[data-test-client-count-card]').exists();
       const response = await this.store.peekRecord('clients/activity', 'some-activity-id');
       assert.dom('[data-test-client-count-title]').hasText('Client count');
@@ -344,6 +328,15 @@ module('Acceptance | landing page dashboard', function (hooks) {
       assert
         .dom('[data-test-stat-text="new-clients"] .stat-value')
         .hasText(formatNumber([response.byMonth.lastObject.new_clients.clients]));
+    });
+    test('hides the client count card', async function (assert) {
+      await authPage.logout();
+      this.server.get(
+        'sys/license/status',
+        () => new Response(403, {}, { errors: ['API returns this error'] })
+      );
+      await authPage.login();
+      assert.dom('[data-test-client-count-card]').doesNotExist();
     });
   });
   skip('replication card', function (hooks) {
@@ -367,8 +360,10 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
 
     test('it should show replication status if both dr and performance replication are enabled as features in version', async function (assert) {
-      // await visit('/vault/dashboard');
-      // await click(REPLICATION_CARD_SELECTORS.replicationEmptyStateActionsLink);
+      await visit('/vault/dashboard');
+      assert.strictEqual(currentURL(), '/vault/clients/dashboard');
+      await click(REPLICATION_CARD_SELECTORS.replicationEmptyStateActionsLink);
+
       await click('[data-test-replication-enable]');
       await pollCluster(this.owner);
       await settled();

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -313,7 +313,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
 
     test('shows the client count card', async function (assert) {
-      assert.strictEqual(currentURL(), '/vault/clients/dashboard');
+      assert.strictEqual(currentURL(), '/vault/dashboard');
       assert.dom('[data-test-client-count-card]').exists();
       const response = await this.store.peekRecord('clients/activity', 'some-activity-id');
       assert.dom('[data-test-client-count-title]').hasText('Client count');

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -54,8 +54,8 @@ module('Acceptance | landing page dashboard', function (hooks) {
   });
 
   module('secrets engines card', function (hooks) {
-    hooks.beforeEach(function () {
-      return authPage.login();
+    hooks.beforeEach(async function () {
+      await authPage.login();
     });
 
     test('shows a secrets engine card', async function (assert) {
@@ -98,7 +98,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
   });
 
   module('configuration details card', function (hooks) {
-    hooks.beforeEach(function () {
+    hooks.beforeEach(async function () {
       this.data = {
         api_addr: 'http://127.0.0.1:8200',
         cache_size: 0,
@@ -187,7 +187,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
           usage_gauge_period: 5000000000,
         },
       };
-      return authPage.login();
+      await authPage.login();
     });
 
     test('shows the configuration details card', async function (assert) {
@@ -240,8 +240,8 @@ module('Acceptance | landing page dashboard', function (hooks) {
   });
 
   module('quick actions card', function (hooks) {
-    hooks.beforeEach(function () {
-      return authPage.login();
+    hooks.beforeEach(async function () {
+      await authPage.login();
     });
 
     test('shows the default state of the quick actions card', async function (assert) {
@@ -314,10 +314,10 @@ module('Acceptance | landing page dashboard', function (hooks) {
       sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
       ENV['ember-cli-mirage'].handler = 'clients';
     });
-    hooks.beforeEach(function () {
+    hooks.beforeEach(async function () {
       this.store = this.owner.lookup('service:store');
 
-      return authPage.login();
+      await authPage.login();
     });
     hooks.after(function () {
       timestamp.now.restore();

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -325,7 +325,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       ENV['ember-cli-mirage'].handler = null;
     });
 
-    test('hides the client count card', async function (assert) {
+    skip('hides the client count card', async function (assert) {
       await authPage.logout();
       this.server.get(
         'sys/license/status',

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -346,7 +346,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
         .hasText(formatNumber([response.byMonth.lastObject.new_clients.clients]));
     });
   });
-  module('replication card', function (hooks) {
+  skip('replication card', function (hooks) {
     hooks.beforeEach(async function () {
       await authPage.login();
       await settled();

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -340,7 +340,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
 
     test('shows the correct actions and links associated with kv', async function (assert) {
-      // create a secret
       await runCommands(['write sys/mounts/kv-1 type=kv options=version=2', 'write kv-1/foo bar=baz']);
       await settled();
       await visit('/vault/dashboard');

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -349,7 +349,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       assert.dom(QUICK_ACTION_SELECTORS.paramsTitle).hasText('Secret path');
       assert.dom(QUICK_ACTION_SELECTORS.getActionButton('Read secrets')).exists({ count: 1 });
       await selectChoose(QUICK_ACTION_SELECTORS.paramSelect, '.ember-power-select-option', 0);
-      await consoleComponent.runCommands(deleteEngineCmd('database'));
+      await consoleComponent.runCommands(deleteEngineCmd('kv'));
     });
   });
 

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -335,9 +335,8 @@ module('Acceptance | landing page dashboard', function (hooks) {
       assert.dom('[data-test-client-count-card]').doesNotExist();
     });
 
-    skip('shows the client count card', async function (assert) {
-      await authPage.login();
-      assert.dom('[data-test-client-count-title]').exists();
+    test('shows the client count card', async function (assert) {
+      assert.dom('[data-test-client-count-card]').exists();
       const response = await this.store.peekRecord('clients/activity', 'some-activity-id');
       assert.dom('[data-test-client-count-title]').hasText('Client count');
       assert.dom('[data-test-stat-text="total-clients"] .stat-label').hasText('Total');
@@ -373,9 +372,8 @@ module('Acceptance | landing page dashboard', function (hooks) {
       assert.dom(REPLICATION_CARD_SELECTORS.replicationEmptyStateActions).hasText('Enable replication');
     });
 
-    test('it should show replication status if both dr and performance replication are enabled as features in version', async function (assert) {
-      await visit('/vault/replication');
-      // await click(REPLICATION_CARD_SELECTORS.replicationEmptyStateActionsLink);
+    skip('it should show replication status if both dr and performance replication are enabled as features in version', async function (assert) {
+      await click(REPLICATION_CARD_SELECTORS.replicationEmptyStateActionsLink);
       await click('[data-test-replication-type-select="dr"]');
       await fillIn('[data-test-replication-cluster-mode-select]', 'primary');
       await click('[data-test-replication-enable]');

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -332,7 +332,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
 
     test('shows the client count card', async function (assert) {
       const version = this.owner.lookup('service:version');
-      assert.true(version.isEnterprise);
+      assert.true(version.isEnterprise, 'version is enterprise');
       assert.strictEqual(version.version, '1.14.0+ent');
       assert.strictEqual(currentURL(), '/vault/dashboard');
       assert.dom('[data-test-client-count-card]').exists();
@@ -373,7 +373,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
     test('shows the replication card empty state', async function (assert) {
       await visit('/vault/dashboard');
       const version = this.owner.lookup('service:version');
-      assert.true(version.isEnterprise);
+      assert.true(version.isEnterprise, 'vault is enterprise');
       assert.dom(REPLICATION_CARD_SELECTORS.replicationEmptyState).exists();
       assert.dom(REPLICATION_CARD_SELECTORS.replicationEmptyStateTitle).hasText('Replication not set up');
       assert
@@ -384,11 +384,11 @@ module('Acceptance | landing page dashboard', function (hooks) {
 
     test('it should show replication status if both dr and performance replication are enabled as features in version', async function (assert) {
       const version = this.owner.lookup('service:version');
-      assert.true(version.isEnterprise);
-      await visit('/vault/dashboard');
-      assert.strictEqual(currentURL(), '/vault/dashboard');
-      await click(REPLICATION_CARD_SELECTORS.replicationEmptyStateActionsLink);
-
+      assert.true(version.isEnterprise, 'vault is enterprise');
+      await visit('/vault/replication');
+      assert.strictEqual(currentURL(), '/vault/replication');
+      await click('[data-test-replication-type-select="dr"]');
+      await fillIn('[data-test-replication-cluster-mode-select]', 'primary');
       await click('[data-test-replication-enable]');
       await pollCluster(this.owner);
       await settled();

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -305,7 +305,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
 
     hooks.beforeEach(async function () {
       this.store = this.owner.lookup('service:store');
-      this.version = this.owner.lookup('service:version');
       this.server.get('sys/seal-status', function () {
         return {
           type: 'shamir',
@@ -324,6 +323,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
           storage_type: 'inmem_transactional_ha',
         };
       });
+      this.version = this.owner.lookup('service:version');
       await authPage.login();
     });
 
@@ -332,8 +332,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
 
     test('shows the client count card', async function (assert) {
-      assert.true(this.version.isEnterprise);
-      assert.strictEqual(this.version.version, '1.14.0+ent');
+      assert.true(this.version.isEnterprise, 'version is enterprise');
       assert.strictEqual(currentURL(), '/vault/dashboard');
       assert.dom('[data-test-client-count-card]').exists();
       const response = await this.store.peekRecord('clients/activity', 'some-activity-id');
@@ -362,7 +361,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
   });
   module('replication card', function (hooks) {
     hooks.beforeEach(async function () {
-      this.version = this.owner.lookup('service:version');
       this.server.get('sys/seal-status', function () {
         return {
           type: 'shamir',
@@ -381,6 +379,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
           storage_type: 'inmem_transactional_ha',
         };
       });
+      this.version = this.owner.lookup('service:version');
       await authPage.login();
       await settled();
       await disableReplication('dr');
@@ -391,7 +390,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
 
     test('shows the replication card empty state', async function (assert) {
       assert.true(this.version.isEnterprise);
-      assert.strictEqual(this.version.version, '1.14.0+ent');
       await visit('/vault/dashboard');
       assert.dom(REPLICATION_CARD_SELECTORS.replicationEmptyState).exists();
       assert.dom(REPLICATION_CARD_SELECTORS.replicationEmptyStateTitle).hasText('Replication not set up');
@@ -403,7 +401,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
 
     test('it should show replication status if both dr and performance replication are enabled as features in version', async function (assert) {
       assert.true(this.version.isEnterprise);
-      assert.strictEqual(this.version.version, '1.14.0+ent');
       await visit('/vault/dashboard');
       assert.strictEqual(currentURL(), '/vault/clients/dashboard');
       await click(REPLICATION_CARD_SELECTORS.replicationEmptyStateActionsLink);

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -335,6 +335,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
 
     test('shows the client count card', async function (assert) {
+      await authPage.login();
       assert.dom('[data-test-client-count-title]').exists();
       const response = await this.store.peekRecord('clients/activity', 'some-activity-id');
       assert.dom('[data-test-client-count-title]').hasText('Client count');
@@ -372,6 +373,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
 
     test('it should show replication status if both dr and performance replication are enabled as features in version', async function (assert) {
+      await authPage.login();
       await click(REPLICATION_CARD_SELECTORS.replicationEmptyStateActionsLink);
       await click('[data-test-replication-type-select="dr"]');
       await fillIn('[data-test-replication-cluster-mode-select]', 'primary');

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -340,7 +340,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
 
     test('shows the correct actions and links associated with kv', async function (assert) {
-      await runCommands(['write sys/mounts/kv type=kv options=version=2']);
+      await runCommands(['write sys/mounts/kv type=kv', 'write kv/foo bar=baz']);
       await settled();
       await visit('/vault/dashboard');
       await selectChoose(QUICK_ACTION_SELECTORS.secretsEnginesSelect, 'kv');
@@ -349,6 +349,9 @@ module('Acceptance | landing page dashboard', function (hooks) {
       assert.dom(QUICK_ACTION_SELECTORS.paramsTitle).hasText('Secret path');
       assert.dom(QUICK_ACTION_SELECTORS.getActionButton('Read secrets')).exists({ count: 1 });
       await selectChoose(QUICK_ACTION_SELECTORS.paramSelect, '.ember-power-select-option', 0);
+      await click(QUICK_ACTION_SELECTORS.getActionButton('Read secrets'));
+      assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.show');
+      // can't write v2 acceptance tests since there isn't runCommands for v2 create secrets
       await consoleComponent.runCommands(deleteEngineCmd('kv'));
     });
   });

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -47,7 +47,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await visit('/vault/dashboard');
       assert.dom(SECRETS_ENGINE_SELECTORS.cardTitle).hasText('Secrets engines');
       assert.dom(SECRETS_ENGINE_SELECTORS.getSecretEngineAccessor('pki')).exists();
-      // cleanup engine
+      // cleanup engine mount
       await consoleComponent.runCommands(deleteEngineCmd('pki'));
     });
 
@@ -56,7 +56,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await settled();
       await visit('/vault/dashboard');
       assert.dom('[data-test-secrets-engines-row="nomad"] [data-test-view]').doesNotExist();
-      // cleanup engine
+      // cleanup engine mount
       await consoleComponent.runCommands(deleteEngineCmd('nomad'));
     });
   });
@@ -236,10 +236,11 @@ module('Acceptance | landing page dashboard', function (hooks) {
       // generate role, issuer
       await runCommands([`write pki/root/generate/internal common_name="Hashicorp Test"`]);
       await settled();
+      await visit('/vault/dashboard');
       await selectChoose(QUICK_ACTION_SELECTORS.secretsEnginesSelect, 'pki');
       await fillIn(QUICK_ACTION_SELECTORS.actionSelect, 'Issue certificate');
       assert.dom(QUICK_ACTION_SELECTORS.emptyState).doesNotExist();
-      await fillIn(QUICK_ACTION_SELECTORS.paramsTitle, 'Role to use');
+      assert.dom(QUICK_ACTION_SELECTORS.paramsTitle).hasText('Role to use');
       assert.dom(QUICK_ACTION_SELECTORS.getActionButton('Issue leaf certificate')).exists({ count: 1 });
       // select param input, click action, check route (issue cert)
       // await selectChoose(assert.dom(QUICK_ACTION_SELECTORS.paramSelect), 'pki');
@@ -257,7 +258,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       assert.dom(QUICK_ACTION_SELECTORS.getActionButton('View issuer')).exists({ count: 1 });
       // select param input, click action, check route (view issuer)
 
-      // cleanup engine
+      // cleanup engine mount
       await consoleComponent.runCommands(deleteEngineCmd('pki'));
     });
 
@@ -265,13 +266,14 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await mountSecrets.enable('database', 'database');
       // create a role
       await settled();
+      await visit('/vault/dashboard');
       await selectChoose(QUICK_ACTION_SELECTORS.secretsEnginesSelect, 'database');
       await fillIn(QUICK_ACTION_SELECTORS.actionSelect, 'Generate credentials for database');
       assert.dom(QUICK_ACTION_SELECTORS.emptyState).doesNotExist();
-      await fillIn(QUICK_ACTION_SELECTORS.paramsTitle, 'Role to use');
+      assert.dom(QUICK_ACTION_SELECTORS.paramsTitle).hasText('Role to use');
       assert.dom(QUICK_ACTION_SELECTORS.getActionButton('Generate credentials')).exists({ count: 1 });
       // select param input, click action, check route
-      // cleanup engine
+      // cleanup engine mount
       await consoleComponent.runCommands(deleteEngineCmd('database'));
     });
 
@@ -279,13 +281,14 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await mountSecrets.enable('kv', 'kv');
       // create a secret
       await settled();
+      await visit('/vault/dashboard');
       await selectChoose(QUICK_ACTION_SELECTORS.secretsEnginesSelect, 'kv');
       await fillIn(QUICK_ACTION_SELECTORS.actionSelect, 'Find KV secrets');
       assert.dom(QUICK_ACTION_SELECTORS.emptyState).doesNotExist();
-      await fillIn(QUICK_ACTION_SELECTORS.paramsTitle, 'Secret path');
+      assert.dom(QUICK_ACTION_SELECTORS.paramsTitle).hasText('Secret path');
       assert.dom(QUICK_ACTION_SELECTORS.getActionButton('Read secrets')).exists({ count: 1 });
       // select param input, click action, check route
-      // cleanup engine
+      // cleanup engine mount
       await consoleComponent.runCommands(deleteEngineCmd('database'));
     });
   });

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { visit, currentURL, settled, fillIn, click, waitUntil, find } from '@ember/test-helpers';
+import { visit, currentURL, settled, fillIn, click, waitUntil, find, skip } from '@ember/test-helpers';
 import { setupApplicationTest } from 'vault/tests/helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { create } from 'ember-cli-page-object';
@@ -29,6 +29,7 @@ const consoleComponent = create(consoleClass);
 
 module('Acceptance | landing page dashboard', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('navigate to dashboard on login', async function (assert) {
     await authPage.login();
@@ -44,7 +45,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
   });
 
   module('secrets engines card', function (hooks) {
-    setupMirage(hooks);
     hooks.beforeEach(async function () {
       await authPage.login();
     });
@@ -70,7 +70,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
   });
 
   module('learn more card', function (hooks) {
-    setupMirage(hooks);
     hooks.beforeEach(function () {
       return authPage.login();
     });
@@ -90,7 +89,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
   });
 
   module('configuration details card', function (hooks) {
-    setupMirage(hooks);
     hooks.beforeEach(async function () {
       this.data = {
         api_addr: 'http://127.0.0.1:8200',
@@ -233,7 +231,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
   });
 
   module('quick actions card', function (hooks) {
-    setupMirage(hooks);
     hooks.beforeEach(async function () {
       await authPage.login();
     });
@@ -304,7 +301,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
   });
   module('client counts card', function (hooks) {
-    setupMirage(hooks);
     hooks.before(async function () {
       ENV['ember-cli-mirage'].handler = 'clients';
     });
@@ -338,6 +334,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
 
     test('shows the client count card', async function (assert) {
       const version = this.owner.lookup('service:version');
+      assert.strictEqual(version.version, '1.14.0+ent');
       assert.true(version.isEnterprise, 'version is enterprise');
       assert.strictEqual(version.version, '1.14.0+ent');
       assert.strictEqual(currentURL(), '/vault/dashboard');
@@ -366,8 +363,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       assert.dom('[data-test-client-count-card]').doesNotExist();
     });
   });
-  module('replication card', function (hooks) {
-    setupMirage(hooks);
+  skip('replication card', function (hooks) {
     hooks.beforeEach(async function () {
       await authPage.login();
       await settled();

--- a/ui/tests/acceptance/enterprise-replication-test.js
+++ b/ui/tests/acceptance/enterprise-replication-test.js
@@ -12,39 +12,9 @@ import { pollCluster } from 'vault/tests/helpers/poll-cluster';
 import { create } from 'ember-cli-page-object';
 import flashMessage from 'vault/tests/pages/components/flash-message';
 import ss from 'vault/tests/pages/components/search-select';
-
+import { disableReplication } from 'vault/tests/helpers/replication';
 const searchSelect = create(ss);
 const flash = create(flashMessage);
-
-const disableReplication = async (type, assert) => {
-  // disable performance replication
-  await visit(`/vault/replication/${type}`);
-
-  if (findAll('[data-test-replication-link="manage"]').length) {
-    await click('[data-test-replication-link="manage"]');
-
-    await click('[data-test-disable-replication] button');
-
-    const typeDisplay = type === 'dr' ? 'Disaster Recovery' : 'Performance';
-    await fillIn('[data-test-confirmation-modal-input="Disable Replication?"]', typeDisplay);
-    await click('[data-test-confirm-button]');
-    await settled(); // eslint-disable-line
-
-    if (assert) {
-      // bypassing for now -- remove if tests pass reliably
-      // assert.strictEqual(
-      //   flash.latestMessage,
-      //   'This cluster is having replication disabled. Vault will be unavailable for a brief period and will resume service shortly.',
-      //   'renders info flash when disabled'
-      // );
-      assert.ok(
-        await waitUntil(() => currentURL() === '/vault/replication'),
-        'redirects to the replication page'
-      );
-    }
-    await settled();
-  }
-};
 
 module('Acceptance | Enterprise | replication', function (hooks) {
   setupApplicationTest(hooks);

--- a/ui/tests/helpers/components/dashboard/quick-actions-card.js
+++ b/ui/tests/helpers/components/dashboard/quick-actions-card.js
@@ -1,0 +1,11 @@
+const SELECTORS = {
+  searchSelect: '.search-select',
+  secretsEnginesSelect: '[data-test-secrets-engines-select]',
+  actionSelect: '[data-test-select="action-select"]',
+  emptyState: '[data-test-no-mount-selected-empty]',
+  paramsTitle: '[data-test-search-select-params-title]',
+  paramSelect: '[data-test-param-select]',
+  getActionButton: (action) => `[data-test-button="${action}"]`,
+};
+
+export default SELECTORS;

--- a/ui/tests/helpers/components/dashboard/replication-card.js
+++ b/ui/tests/helpers/components/dashboard/replication-card.js
@@ -12,11 +12,15 @@ const SELECTORS = {
   knownSecondariesLabel: '[data-test-stat-text="known secondaries"] .stat-label',
   knownSecondariesSubtext: '[data-test-stat-text="known secondaries"] .stat-text',
   knownSecondariesValue: '[data-test-stat-text="known secondaries"] .stat-value',
-  replicationEmptyState: '[data-test-component="empty-state"]',
-  replicationEmptyStateTitle: '[data-test-component="empty-state"] .empty-state-title',
-  replicationEmptyStateMessage: '[data-test-component="empty-state"] .empty-state-message',
-  replicationEmptyStateActions: '[data-test-component="empty-state"] .empty-state-actions',
-  replicationEmptyStateActionsLink: '[data-test-component="empty-state"] .empty-state-actions a',
+  replicationEmptyState: '[data-test-replication-card] [data-test-component="empty-state"]',
+  replicationEmptyStateTitle:
+    '[data-test-replication-card] [data-test-component="empty-state"] .empty-state-title',
+  replicationEmptyStateMessage:
+    '[data-test-replication-card] [data-test-component="empty-state"] .empty-state-message',
+  replicationEmptyStateActions:
+    '[data-test-replication-card] [data-test-component="empty-state"] .empty-state-actions',
+  replicationEmptyStateActionsLink:
+    '[data-test-replication-card] [data-test-component="empty-state"] .empty-state-actions a',
 };
 
 export default SELECTORS;

--- a/ui/tests/helpers/components/dashboard/replication-card.js
+++ b/ui/tests/helpers/components/dashboard/replication-card.js
@@ -16,6 +16,7 @@ const SELECTORS = {
   replicationEmptyStateTitle: '[data-test-component="empty-state"] .empty-state-title',
   replicationEmptyStateMessage: '[data-test-component="empty-state"] .empty-state-message',
   replicationEmptyStateActions: '[data-test-component="empty-state"] .empty-state-actions',
+  replicationEmptyStateActionsLink: '[data-test-component="empty-state"] .empty-state-actions a',
 };
 
 export default SELECTORS;

--- a/ui/tests/helpers/replication.js
+++ b/ui/tests/helpers/replication.js
@@ -1,0 +1,31 @@
+import { click, fillIn, findAll, currentURL, visit, settled, waitUntil } from '@ember/test-helpers';
+
+export const disableReplication = async (type, assert) => {
+  // disable performance replication
+  await visit(`/vault/replication/${type}`);
+
+  if (findAll('[data-test-replication-link="manage"]').length) {
+    await click('[data-test-replication-link="manage"]');
+
+    await click('[data-test-disable-replication] button');
+
+    const typeDisplay = type === 'dr' ? 'Disaster Recovery' : 'Performance';
+    await fillIn('[data-test-confirmation-modal-input="Disable Replication?"]', typeDisplay);
+    await click('[data-test-confirm-button]');
+    await settled(); // eslint-disable-line
+
+    if (assert) {
+      // bypassing for now -- remove if tests pass reliably
+      // assert.strictEqual(
+      //   flash.latestMessage,
+      //   'This cluster is having replication disabled. Vault will be unavailable for a brief period and will resume service shortly.',
+      //   'renders info flash when disabled'
+      // );
+      assert.ok(
+        await waitUntil(() => currentURL() === '/vault/replication'),
+        'redirects to the replication page'
+      );
+    }
+    await settled();
+  }
+};

--- a/ui/tests/integration/components/dashboard/quick-actions-card-test.js
+++ b/ui/tests/integration/components/dashboard/quick-actions-card-test.js
@@ -8,10 +8,9 @@ import { setupRenderingTest } from 'vault/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { fillIn } from '@ember/test-helpers';
-
 import { selectChoose } from 'ember-power-select/test-support/helpers';
 
-// TODO LANDING PAGE: create SELECTORS for the data-test attributes
+import SELECTORS from 'vault/tests/helpers/components/dashboard/quick-actions-card';
 
 module('Integration | Component | dashboard/quick-actions-card', function (hooks) {
   setupRenderingTest(hooks);
@@ -94,39 +93,39 @@ module('Integration | Component | dashboard/quick-actions-card', function (hooks
   test('it should show quick action empty state if no engine is selected', async function (assert) {
     await this.renderComponent();
     assert.dom('.title').hasText('Quick actions');
-    assert.dom('[data-test-secrets-engines-select]').exists({ count: 1 });
-    assert.dom('[data-test-component="empty-state"]').exists({ count: 1 });
+    assert.dom(SELECTORS.secretsEnginesSelect).exists({ count: 1 });
+    assert.dom(SELECTORS.emptyState).exists({ count: 1 });
   });
 
   test('it should show correct actions for pki', async function (assert) {
     await this.renderComponent();
-    await selectChoose('.search-select', 'pki-0-test');
-    await fillIn('[data-test-select="action-select"]', 'Issue certificate');
-    assert.dom('[data-test-component="empty-state"]').doesNotExist();
-    await fillIn('[data-test-select="action-select"]', 'Issue certificate');
-    assert.dom('[data-test-button="Issue leaf certificate"]').exists({ count: 1 });
-    assert.dom('[data-test-search-select-params-title]').hasText('Role to use');
-    await fillIn('[data-test-select="action-select"]', 'View certificate');
-    assert.dom('[data-test-search-select-params-title]').hasText('Certificate serial number');
-    assert.dom('[data-test-button="View certificate"]').exists({ count: 1 });
-    await fillIn('[data-test-select="action-select"]', 'View issuer');
-    assert.dom('[data-test-search-select-params-title]').hasText('Issuer');
-    assert.dom('[data-test-button="View issuer"]').exists({ count: 1 });
+    await selectChoose(SELECTORS.secretsEnginesSelect, 'pki-0-test');
+    await fillIn(SELECTORS.actionSelect, 'Issue certificate');
+    assert.dom(SELECTORS.emptyState).doesNotExist();
+    await fillIn(SELECTORS.actionSelect, 'Issue certificate');
+    assert.dom(SELECTORS.getActionButton('Issue leaf certificate')).exists({ count: 1 });
+    assert.dom(SELECTORS.paramsTitle).hasText('Role to use');
+    await fillIn(SELECTORS.actionSelect, 'View certificate');
+    assert.dom(SELECTORS.paramsTitle).hasText('Certificate serial number');
+    assert.dom(SELECTORS.getActionButton('View certificate')).exists({ count: 1 });
+    await fillIn(SELECTORS.actionSelect, 'View issuer');
+    assert.dom(SELECTORS.paramsTitle).hasText('Issuer');
+    assert.dom(SELECTORS.getActionButton('View issuer')).exists({ count: 1 });
   });
   test('it should show correct actions for database', async function (assert) {
     await this.renderComponent();
-    await selectChoose('.search-select', 'database-test');
-    assert.dom('[data-test-component="empty-state"]').doesNotExist();
-    await fillIn('[data-test-select="action-select"]', 'Generate credentials for database');
-    assert.dom('[data-test-search-select-params-title]').hasText('Role to use');
-    assert.dom('[data-test-button="Generate credentials"]').exists({ count: 1 });
+    await selectChoose(SELECTORS.secretsEnginesSelect, 'database-test');
+    assert.dom(SELECTORS.emptyState).doesNotExist();
+    await fillIn(SELECTORS.actionSelect, 'Generate credentials for database');
+    assert.dom(SELECTORS.paramsTitle).hasText('Role to use');
+    assert.dom(SELECTORS.getActionButton('Generate credentials')).exists({ count: 1 });
   });
   test('it should show correct actions for kv', async function (assert) {
     await this.renderComponent();
-    await selectChoose('.search-select', 'secrets-1-test');
-    assert.dom('[data-test-component="empty-state"]').doesNotExist();
-    await fillIn('[data-test-select="action-select"]', 'Find KV secrets');
-    assert.dom('[data-test-search-select-params-title]').hasText('Secret path');
-    assert.dom('[data-test-button="Read secrets"]').exists({ count: 1 });
+    await selectChoose(SELECTORS.secretsEnginesSelect, 'secrets-1-test');
+    assert.dom(SELECTORS.emptyState).doesNotExist();
+    await fillIn(SELECTORS.actionSelect, 'Find KV secrets');
+    assert.dom(SELECTORS.paramsTitle).hasText('Secret path');
+    assert.dom(SELECTORS.getActionButton('Read secrets')).exists({ count: 1 });
   });
 });

--- a/ui/tests/integration/components/dashboard/replication-state-text.js
+++ b/ui/tests/integration/components/dashboard/replication-state-text.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'vault/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import SELECTORS from 'vault/tests/helpers/components/dashboard/replication-card';
+
+module('Integration | Component | dashboard/replication-state-text', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.name = 'DR Primary';
+    this.clusterState = {
+      glyph: 'circle-check',
+      isOk: true,
+    };
+  });
+
+  test('it displays replication states', async function (assert) {
+    await render(
+      hbs`
+        <Dashboard::ReplicationStateText 
+          @name={{this.name}} 
+          @version={{this.version}} 
+          @subText={{this.subText}} 
+          @clusterStates={{this.clusterStates}} />
+          `
+    );
+    assert.dom(SELECTORS.getReplicationTitle('dr-perf', 'DR primary')).hasText('DR primary');
+    assert.dom(SELECTORS.getStateTooltipTitle('dr-perf', 'DR primary')).hasText('running');
+    assert.dom(SELECTORS.getStateTooltipIcon('dr-perf', 'DR primary', 'check-circle')).exists();
+
+    this.name = 'DR Primary';
+    this.clusterState = {
+      glyph: 'x-circle',
+      isOk: false,
+    };
+    await render(
+      hbs`
+        <Dashboard::ReplicationStateText 
+          @name={{this.name}} 
+          @version={{this.version}} 
+          @subText={{this.subText}} 
+          @clusterStates={{this.clusterStates}} />
+          `
+    );
+    assert.dom(SELECTORS.getReplicationTitle('dr-perf', 'Perf primary')).hasText('Perf primary');
+    assert.dom(SELECTORS.getStateTooltipTitle('dr-perf', 'Perf primary')).hasText('running');
+    assert.dom(SELECTORS.getStateTooltipIcon('dr-perf', 'Perf primary', 'x-circle')).exists();
+    assert
+      .dom(SELECTORS.getStateTooltipIcon('dr-perf', 'Perf primary', 'x-circle'))
+      .hasClass('has-text-danger');
+  });
+});


### PR DESCRIPTION
**Description**
- Acceptance tests for quick actions, client count, replication, and integration test for replication-state-text.js.
- Added the period for the feedback form to be after the icon
<img width="468" alt="Screenshot 2023-08-23 at 9 57 09 AM" src="https://github.com/hashicorp/vault/assets/30884335/060e9bc9-cfe3-4360-a6a4-8cc69d0d233d">

Other things added:
- kv tests + update to the quick actions kv model, update the id to have `kv version 1/2` 
<img width="443" alt="Screenshot 2023-08-23 at 11 24 08 AM" src="https://github.com/hashicorp/vault/assets/30884335/9ae4066f-2861-4707-bc12-c73d18cfc308">

- some small ui changes: hide show all button for secrets engines card when list < 5
<img width="481" alt="Screenshot 2023-08-23 at 12 30 30 PM" src="https://github.com/hashicorp/vault/assets/30884335/1ff81adf-fa80-4d1c-a4cd-00d55568bffc">
