### PR TITLE
UI: Fix Expected a stable identifier error when leaving & reentering a route

### DIFF
--- a/ui/app/models/identity/entity.js
+++ b/ui/app/models/identity/entity.js
@@ -8,7 +8,6 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import IdentityModel from './_base';
 import apiPath from 'vault/utils/api-path';
-import attachCapabilities from 'vault/lib/attach-capabilities';
 import lazyCapabilities from 'vault/macros/lazy-capabilities';
 
 const Model = IdentityModel.extend({
@@ -45,15 +44,14 @@ const Model = IdentityModel.extend({
   inheritedGroupIds: attr({
     readOnly: true,
   }),
+  updatePath: lazyCapabilities(apiPath`identity/entity/id/${'id'}`, 'id'),
   canDelete: alias('updatePath.canDelete'),
   canEdit: alias('updatePath.canUpdate'),
   canRead: alias('updatePath.canRead'),
+  aliasPath: lazyCapabilities(apiPath`identity/entity-alias`),
   canAddAlias: alias('aliasPath.canCreate'),
   policyPath: lazyCapabilities(apiPath`sys/policies`),
   canCreatePolicies: alias('policyPath.canCreate'),
 });
 
-export default attachCapabilities(Model, {
-  updatePath: apiPath`identity/entity/id/${'id'}`,
-  aliasPath: apiPath`identity/entity-alias`,
-});
+export default Model;

--- a/ui/app/models/identity/entity.js
+++ b/ui/app/models/identity/entity.js
@@ -10,7 +10,7 @@ import IdentityModel from './_base';
 import apiPath from 'vault/utils/api-path';
 import lazyCapabilities from 'vault/macros/lazy-capabilities';
 
-const Model = IdentityModel.extend({
+export default IdentityModel.extend({
   formFields: computed(function () {
     return ['name', 'disabled', 'policies', 'metadata'];
   }),
@@ -53,5 +53,3 @@ const Model = IdentityModel.extend({
   policyPath: lazyCapabilities(apiPath`sys/policies`),
   canCreatePolicies: alias('policyPath.canCreate'),
 });
-
-export default Model;

--- a/ui/app/models/kmip/credential.js
+++ b/ui/app/models/kmip/credential.js
@@ -7,9 +7,9 @@ import Model, { attr } from '@ember-data/model';
 import fieldToAttrs from 'vault/utils/field-to-attrs';
 import { computed } from '@ember/object';
 import apiPath from 'vault/utils/api-path';
-import attachCapabilities from 'vault/lib/attach-capabilities';
+import lazyCapabilities from 'vault/macros/lazy-capabilities';
 
-const ModelExport = Model.extend({
+export default Model.extend({
   backend: attr({ readOnly: true }),
   scope: attr({ readOnly: true }),
   role: attr({ readOnly: true }),
@@ -33,8 +33,10 @@ const ModelExport = Model.extend({
 
     return fieldToAttrs(this, groups);
   }),
-});
-
-export default attachCapabilities(ModelExport, {
-  deletePath: apiPath`${'backend'}/scope/${'scope'}/role/${'role'}/credentials/revoke`,
+  deletePath: lazyCapabilities(
+    apiPath`${'backend'}/scope/${'scope'}/role/${'role'}/credentials/revoke`,
+    'backend',
+    'scope',
+    'role'
+  ),
 });

--- a/ui/app/models/kmip/role.js
+++ b/ui/app/models/kmip/role.js
@@ -7,7 +7,7 @@ import Model, { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 import fieldToAttrs, { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 import apiPath from 'vault/utils/api-path';
-import attachCapabilities from 'vault/lib/attach-capabilities';
+import lazyCapabilities from 'vault/macros/lazy-capabilities';
 
 export const COMPUTEDS = {
   operationFields: computed('newFields', function () {
@@ -34,7 +34,7 @@ export const COMPUTEDS = {
   }),
 };
 
-const ModelExport = Model.extend(COMPUTEDS, {
+export default Model.extend(COMPUTEDS, {
   useOpenAPI: true,
   backend: attr({ readOnly: true }),
   scope: attr({ readOnly: true }),
@@ -85,8 +85,6 @@ const ModelExport = Model.extend(COMPUTEDS, {
   fields: computed('defaultFields', function () {
     return expandAttributeMeta(this, this.defaultFields);
   }),
-});
 
-export default attachCapabilities(ModelExport, {
-  updatePath: apiPath`${'backend'}/scope/${'scope'}/role/${'id'}`,
+  updatePath: lazyCapabilities(apiPath`${'backend'}/scope/${'scope'}/role/${'id'}`, 'backend', 'scope', 'id'),
 });

--- a/ui/app/models/kmip/scope.js
+++ b/ui/app/models/kmip/scope.js
@@ -6,18 +6,15 @@
 import Model, { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 import apiPath from 'vault/utils/api-path';
-import attachCapabilities from 'vault/lib/attach-capabilities';
 
 import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
+import lazyCapabilities from 'vault/macros/lazy-capabilities';
 
-const ModelExport = Model.extend({
+export default Model.extend({
   name: attr('string'),
   backend: attr({ readOnly: true }),
   attrs: computed(function () {
     return expandAttributeMeta(this, ['name']);
   }),
-});
-
-export default attachCapabilities(ModelExport, {
-  updatePath: apiPath`${'backend'}/scope/${'id'}`,
+  updatePath: lazyCapabilities(apiPath`${'backend'}/scope/${'id'}`, 'id'),
 });

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -5,9 +5,8 @@
 
 import Model, { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
-import { apiPath } from 'vault/macros/lazy-capabilities';
+import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
-import attachCapabilities from 'vault/lib/attach-capabilities';
 
 // these arrays define the order in which the fields will be displayed
 // see
@@ -38,7 +37,7 @@ const TWEAK_SOURCE = [
   },
 ];
 
-const ModelExport = Model.extend({
+export default Model.extend({
   name: attr('string', {
     // CBS TODO: make this required for making a transformation
     label: 'Name',
@@ -97,8 +96,5 @@ const ModelExport = Model.extend({
   backend: attr('string', {
     readOnly: true,
   }),
-});
-
-export default attachCapabilities(ModelExport, {
-  updatePath: apiPath`${'backend'}/transformation/${'id'}`,
+  updatePath: lazyCapabilities(apiPath`${'backend'}/transformation/${'id'}`, 'id'),
 });

--- a/ui/app/models/transform/alphabet.js
+++ b/ui/app/models/transform/alphabet.js
@@ -5,11 +5,10 @@
 
 import Model, { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
-import { apiPath } from 'vault/macros/lazy-capabilities';
-import attachCapabilities from 'vault/lib/attach-capabilities';
+import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 
-const M = Model.extend({
+export default Model.extend({
   idPrefix: 'alphabet/',
   idForNav: computed('id', 'idPrefix', function () {
     const modelId = this.id || '';
@@ -32,8 +31,5 @@ const M = Model.extend({
   }),
 
   backend: attr('string', { readOnly: true }),
-});
-
-export default attachCapabilities(M, {
-  updatePath: apiPath`${'backend'}/alphabet/${'id'}`,
+  updatePath: lazyCapabilities(apiPath`${'backend'}/alphabet/${'id'}`, 'backend', 'id'),
 });

--- a/ui/app/models/transform/role.js
+++ b/ui/app/models/transform/role.js
@@ -5,11 +5,10 @@
 
 import Model, { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
-import { apiPath } from 'vault/macros/lazy-capabilities';
+import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
-import attachCapabilities from 'vault/lib/attach-capabilities';
 
-const ModelExport = Model.extend({
+export default Model.extend({
   // used for getting appropriate options for backend
   idPrefix: 'role/',
   // the id prefixed with `role/` so we can use it as the *secret param for the secret show route
@@ -40,8 +39,5 @@ const ModelExport = Model.extend({
   }),
 
   backend: attr('string', { readOnly: true }),
-});
-
-export default attachCapabilities(ModelExport, {
-  updatePath: apiPath`${'backend'}/role/${'id'}`,
+  updatePath: lazyCapabilities(apiPath`${'backend'}/role/${'id'}`, 'backend', 'id'),
 });

--- a/ui/app/models/transform/template.js
+++ b/ui/app/models/transform/template.js
@@ -5,11 +5,10 @@
 
 import Model, { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
-import { apiPath } from 'vault/macros/lazy-capabilities';
-import attachCapabilities from 'vault/lib/attach-capabilities';
+import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 
-const M = Model.extend({
+export default Model.extend({
   idPrefix: 'template/',
   idForNav: computed('id', 'idPrefix', function () {
     const modelId = this.id || '';
@@ -47,8 +46,5 @@ const M = Model.extend({
   writeAttrs: computed(function () {
     return expandAttributeMeta(this, ['name', 'pattern', 'alphabet']);
   }),
-});
-
-export default attachCapabilities(M, {
-  updatePath: apiPath`${'backend'}/template/${'id'}`,
+  updatePath: lazyCapabilities(apiPath`${'backend'}/template/${'id'}`, 'backend', 'id'),
 });


### PR DESCRIPTION
After the Ember 4.12 upgrade and the Ember-Data upgrade that went along with it, we found a strange error popping up intermittently: `Assertion Failed: Expected a stable identifier`

I tracked this down to the `store.unloadAll(modelType)` method failing when called during lazy pagination, and specifically to models which had a capabilities relationship via `attachCapabilities`. On any of the list routes for the models updated in this PR, if I left the list page (which has items) and then returned to it I would see the stable identifier issue. 

There's only one model left which has `attachCapabilities`, and that is `auth-method`. I left it because there is complexity with the path calculation which would require more refactoring than I'm comfortable with this close to a release, and the list page for `auth-method` does not use `lazyPaginatedQuery`. 