### PR TITLE
secrets/database: advanced TTL management for static roles

### DIFF
--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/queue"
+	"github.com/robfig/cron/v3"
 )
 
 const (
@@ -127,6 +128,11 @@ func Backend(conf *logical.BackendConfig) *databaseBackend {
 	b.connections = syncmap.NewSyncMap[string, *dbPluginInstance]()
 	b.queueCtx, b.cancelQueueCtx = context.WithCancel(context.Background())
 	b.roleLocks = locksutil.CreateLocks()
+
+	parser := cron.NewParser(
+		cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.DowOptional | cron.Descriptor,
+	)
+	b.scheduleParser = parser
 	return &b
 }
 
@@ -176,6 +182,8 @@ type databaseBackend struct {
 	// the running gauge collection process
 	gaugeCollectionProcess     *metricsutil.GaugeCollectionProcess
 	gaugeCollectionProcessStop sync.Once
+
+	scheduleParser cron.Parser
 }
 
 func (b *databaseBackend) DatabaseConfig(ctx context.Context, s logical.Storage, name string) (*DatabaseConfig, error) {

--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -129,8 +129,10 @@ func Backend(conf *logical.BackendConfig) *databaseBackend {
 	b.queueCtx, b.cancelQueueCtx = context.WithCancel(context.Background())
 	b.roleLocks = locksutil.CreateLocks()
 
+	// TODO(JM): don't allow seconds in production, this is helpful for
+	// development/testing though
 	parser := cron.NewParser(
-		cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.DowOptional | cron.Descriptor,
+		cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.DowOptional,
 	)
 	b.scheduleParser = parser
 	return &b

--- a/builtin/logical/database/path_creds_create.go
+++ b/builtin/logical/database/path_creds_create.go
@@ -249,8 +249,16 @@ func (b *databaseBackend) pathStaticCredsRead() framework.OperationFunc {
 		respData := map[string]interface{}{
 			"username":            role.StaticAccount.Username,
 			"ttl":                 role.StaticAccount.CredentialTTL().Seconds(),
-			"rotation_period":     role.StaticAccount.RotationPeriod.Seconds(),
 			"last_vault_rotation": role.StaticAccount.LastVaultRotation,
+		}
+
+		if role.StaticAccount.UsesRotationPeriod() {
+			respData["rotation_period"] = role.StaticAccount.RotationPeriod.Seconds()
+		} else if role.StaticAccount.UsesRotationSchedule() {
+			respData["rotation_schedule"] = role.StaticAccount.RotationSchedule
+			if role.StaticAccount.RotationWindow.Seconds() != 0 {
+				respData["rotation_window"] = role.StaticAccount.RotationWindow.Seconds()
+			}
 		}
 
 		switch role.CredentialType {

--- a/builtin/logical/database/path_roles.go
+++ b/builtin/logical/database/path_roles.go
@@ -549,6 +549,7 @@ func (b *databaseBackend) pathStaticRoleCreateUpdate(ctx context.Context, req *l
 	rotationScheduleOk := rotationSchedule != ""
 
 	if rotationScheduleOk && rotationPeriodOk {
+		// TODO(JM): handle mutual exclusion
 		response.AddWarning("mutually exclusive fields rotation_period and rotation_schedule were both specified; rotation_period takes priority")
 	} else if createRole && (!rotationScheduleOk && !rotationPeriodOk) {
 		return logical.ErrorResponse("one of rotation_schedule or rotation_period must be provided to create a static account"), nil
@@ -665,10 +666,7 @@ func (b *databaseBackend) pathStaticRoleCreateUpdate(ctx context.Context, req *l
 		return nil, err
 	}
 
-	if response.IsError() {
-		return response, nil
-	}
-	return nil, nil
+	return response, nil
 }
 
 type roleEntry struct {

--- a/builtin/logical/database/path_roles.go
+++ b/builtin/logical/database/path_roles.go
@@ -197,12 +197,18 @@ func staticFields() map[string]*framework.FieldSchema {
 			Type: framework.TypeDurationSecond,
 			Description: `Period for automatic
 	credential rotation of the given username. Not valid unless used with
-	"username".`,
+	"username". Mutually exclusive with "rotation_schedule."`,
 		},
 		"rotation_schedule": {
 			Type: framework.TypeString,
 			Description: `Schedule for automatic credential rotation of the
-	given username.`,
+	given username. Mutually exclusive with "rotation_period."`,
+		},
+		"rotation_window": {
+			Type: framework.TypeDurationSecond,
+			Description: `The window of time in which rotations are allowed to
+	occur starting from a given "rotation_schedule". Requires "rotation_schedule"
+	to be specified`,
 		},
 		"rotation_statements": {
 			Type: framework.TypeStringSlice,
@@ -299,11 +305,20 @@ func (b *databaseBackend) pathStaticRoleRead(ctx context.Context, req *logical.R
 	if role.StaticAccount != nil {
 		data["username"] = role.StaticAccount.Username
 		data["rotation_statements"] = role.Statements.Rotation
-		data["rotation_period"] = role.StaticAccount.RotationPeriod.Seconds()
 		if !role.StaticAccount.LastVaultRotation.IsZero() {
 			data["last_vault_rotation"] = role.StaticAccount.LastVaultRotation
 		}
-		data["rotation_schedule"] = role.StaticAccount.RotationSchedule
+
+		// only return one of the mutually exclusive fields in the response
+		if role.StaticAccount.RotationPeriod != 0 {
+			data["rotation_period"] = role.StaticAccount.RotationPeriod.Seconds()
+		} else if role.StaticAccount.RotationSchedule != "" {
+			data["rotation_schedule"] = role.StaticAccount.RotationSchedule
+			// rotation_window is only valid with rotation_schedule
+			if role.StaticAccount.RotationWindow != 0 {
+				data["rotation_window"] = role.StaticAccount.RotationWindow.Seconds()
+			}
+		}
 	}
 
 	if len(role.CredentialConfig) > 0 {
@@ -547,6 +562,7 @@ func (b *databaseBackend) pathStaticRoleCreateUpdate(ctx context.Context, req *l
 	rotationPeriodSecondsRaw, rotationPeriodOk := data.GetOk("rotation_period")
 	rotationSchedule := data.Get("rotation_schedule").(string)
 	rotationScheduleOk := rotationSchedule != ""
+	rotationWindowSecondsRaw, rotationWindowOk := data.GetOk("rotation_window")
 
 	if rotationScheduleOk && rotationPeriodOk {
 		return logical.ErrorResponse("mutually exclusive fields rotation_period and rotation_schedule were both specified; only one of them can be provided"), nil
@@ -565,6 +581,10 @@ func (b *databaseBackend) pathStaticRoleCreateUpdate(ctx context.Context, req *l
 		role.StaticAccount.RotationPeriod = time.Duration(rotationPeriodSeconds) * time.Second
 		// Unset rotation schedule if rotation period is set
 		role.StaticAccount.RotationSchedule = ""
+
+		if rotationWindowOk {
+			return logical.ErrorResponse("rotation_window is invalid with use of rotation_period"), nil
+		}
 	}
 
 	if rotationScheduleOk {
@@ -581,6 +601,14 @@ func (b *databaseBackend) pathStaticRoleCreateUpdate(ctx context.Context, req *l
 		role.StaticAccount.Schedule = *sched
 		// Unset rotation period if rotation schedule is set
 		role.StaticAccount.RotationPeriod = 0
+
+		if rotationWindowOk {
+			rotationWindowSeconds := rotationWindowSecondsRaw.(int)
+			if rotationWindowSeconds < minRotationWindowSeconds {
+				return logical.ErrorResponse(fmt.Sprintf("rotation_window must be %d seconds or more", minRotationWindowSeconds)), nil
+			}
+			role.StaticAccount.RotationWindow = time.Duration(rotationWindowSeconds) * time.Second
+		}
 	}
 
 	if rotationStmtsRaw, ok := data.GetOk("rotation_statements"); ok {
@@ -654,10 +682,12 @@ func (b *databaseBackend) pathStaticRoleCreateUpdate(ctx context.Context, req *l
 		}
 	}
 
-	if rotationPeriodOk {
+	_, rotationPeriodChanged := data.Raw["rotation_period"]
+	_, rotationScheduleChanged := data.Raw["rotation_schedule"]
+	if rotationPeriodChanged {
 		b.logger.Debug("init priority for RotationPeriod", "lvr", lvr, "next", lvr.Add(role.StaticAccount.RotationPeriod))
 		item.Priority = lvr.Add(role.StaticAccount.RotationPeriod).Unix()
-	} else {
+	} else if rotationScheduleChanged {
 		next := role.StaticAccount.Schedule.Next(lvr)
 		b.logger.Debug("init priority for Schedule", "lvr", lvr)
 		b.logger.Debug("init priority for Schedule", "next", next)
@@ -783,6 +813,12 @@ type staticAccount struct {
 	// day.
 	RotationSchedule string `json:"rotation_schedule"`
 
+	// RotationWindow is number in seconds in which rotations are allowed to
+	// occur starting from a given rotation_schedule.
+	RotationWindow time.Duration `json:"rotation_window"`
+
+	// Schedule holds the parsed "chron style" string representing the allowed
+	// schedule for each rotation.
 	Schedule cron.SpecSchedule `json:"schedule"`
 
 	// RevokeUser is a boolean flag to indicate if Vault should revoke the

--- a/builtin/logical/database/path_roles.go
+++ b/builtin/logical/database/path_roles.go
@@ -839,6 +839,15 @@ func (s *staticAccount) NextRotationTime() time.Time {
 	return s.Schedule.Next(s.LastVaultRotation)
 }
 
+// NextRotationTimeFromInput calculates the next rotation time for period and
+// schedule-based roles based on the input.
+func (s *staticAccount) NextRotationTimeFromInput(input time.Time) time.Time {
+	if s.UsesRotationPeriod() {
+		return input.Add(s.RotationPeriod)
+	}
+	return s.Schedule.Next(input)
+}
+
 // UsesRotationSchedule returns true if the given static account has been
 // configured to rotate credentials on a schedule (i.e. NOT on a rotation period).
 func (s *staticAccount) UsesRotationSchedule() bool {

--- a/builtin/logical/database/path_roles.go
+++ b/builtin/logical/database/path_roles.go
@@ -802,6 +802,10 @@ type staticAccount struct {
 	// LastVaultRotation represents the last time Vault rotated the password
 	LastVaultRotation time.Time `json:"last_vault_rotation"`
 
+	// NextVaultRotation represents the next time Vault is expected to rotate
+	// the password
+	NextVaultRotation time.Time `json:"next_vault_rotation"`
+
 	// RotationPeriod is number in seconds between each rotation, effectively a
 	// "time to live". This value is compared to the LastVaultRotation to
 	// determine if a password needs to be rotated
@@ -858,6 +862,39 @@ func (s *staticAccount) UsesRotationSchedule() bool {
 // configured to rotate credentials on a period (i.e. NOT on a rotation schedule).
 func (s *staticAccount) UsesRotationPeriod() bool {
 	return s.RotationPeriod != 0 && s.RotationSchedule == ""
+}
+
+// IsInsideRotationWindow returns true if the current time t is within a given
+// static account's rotation window.
+//
+// Returns true if the rotation window is not set. In this case, the rotation
+// window is effectively the span of time between two consecutive rotation
+// schedules and we should not prevent rotation.
+func (s *staticAccount) IsInsideRotationWindow(t time.Time) bool {
+	if s.UsesRotationSchedule() && s.RotationWindow != 0 {
+		return t.Before(s.NextVaultRotation.Add(s.RotationWindow))
+	}
+	return true
+}
+
+// ShouldRotate returns true if a given static account should have its
+// credentials rotated.
+//
+// This will return true when the priority <= the current Unix time. If this
+// static account is schedule-based with a rotation window, this method will
+// return false if now is outside the rotation window.
+func (s *staticAccount) ShouldRotate(priority int64) bool {
+	now := time.Now()
+	return priority <= now.Unix() && s.IsInsideRotationWindow(now)
+}
+
+// SetNextVaultRotation
+func (s *staticAccount) SetNextVaultRotation(t time.Time) {
+	if s.UsesRotationPeriod() {
+		s.NextVaultRotation = t.Add(s.RotationPeriod)
+	} else {
+		s.NextVaultRotation = s.Schedule.Next(t)
+	}
 }
 
 // CredentialTTL calculates the approximate time remaining until the credential is

--- a/builtin/logical/database/path_roles.go
+++ b/builtin/logical/database/path_roles.go
@@ -549,8 +549,7 @@ func (b *databaseBackend) pathStaticRoleCreateUpdate(ctx context.Context, req *l
 	rotationScheduleOk := rotationSchedule != ""
 
 	if rotationScheduleOk && rotationPeriodOk {
-		// TODO(JM): handle mutual exclusion
-		response.AddWarning("mutually exclusive fields rotation_period and rotation_schedule were both specified; rotation_period takes priority")
+		return logical.ErrorResponse("mutually exclusive fields rotation_period and rotation_schedule were both specified; only one of them can be provided"), nil
 	} else if createRole && (!rotationScheduleOk && !rotationPeriodOk) {
 		return logical.ErrorResponse("one of rotation_schedule or rotation_period must be provided to create a static account"), nil
 	}
@@ -564,6 +563,8 @@ func (b *databaseBackend) pathStaticRoleCreateUpdate(ctx context.Context, req *l
 			return logical.ErrorResponse(fmt.Sprintf("rotation_period must be %d seconds or more", defaultQueueTickSeconds)), nil
 		}
 		role.StaticAccount.RotationPeriod = time.Duration(rotationPeriodSeconds) * time.Second
+		// Unset rotation schedule if rotation period is set
+		role.StaticAccount.RotationSchedule = ""
 	}
 
 	if rotationScheduleOk {
@@ -578,6 +579,8 @@ func (b *databaseBackend) pathStaticRoleCreateUpdate(ctx context.Context, req *l
 			return logical.ErrorResponse("could not parse rotation_schedule"), nil
 		}
 		role.StaticAccount.Schedule = *sched
+		// Unset rotation period if rotation schedule is set
+		role.StaticAccount.RotationPeriod = 0
 	}
 
 	if rotationStmtsRaw, ok := data.GetOk("rotation_statements"); ok {

--- a/builtin/logical/database/path_roles_test.go
+++ b/builtin/logical/database/path_roles_test.go
@@ -276,6 +276,15 @@ func TestBackend_StaticRole_Config(t *testing.T) {
 			path: "plugin-role-test",
 			err:  errors.New("one of rotation_schedule or rotation_period must be provided to create a static account"),
 		},
+		"rotation_period with rotation_schedule": {
+			account: map[string]interface{}{
+				"username":          dbUser,
+				"rotation_period":   "5400s",
+				"rotation_schedule": "* * * * *",
+			},
+			path: "plugin-role-test",
+			err:  errors.New("mutually exclusive fields rotation_period and rotation_schedule were both specified; only one of them can be provided"),
+		},
 		"rotation window invalid with rotation_period": {
 			account: map[string]interface{}{
 				"username":        dbUser,

--- a/builtin/logical/database/path_roles_test.go
+++ b/builtin/logical/database/path_roles_test.go
@@ -922,6 +922,22 @@ func createRole(t *testing.T, b *databaseBackend, storage logical.Storage, mockD
 	}
 }
 
+func createRoleWithData(t *testing.T, b *databaseBackend, s logical.Storage, mockDB *mockNewDatabase, roleName string, data map[string]interface{}) {
+	t.Helper()
+	mockDB.On("UpdateUser", mock.Anything, mock.Anything).
+		Return(v5.UpdateUserResponse{}, nil).
+		Once()
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "static-roles/" + roleName,
+		Storage:   s,
+		Data:      data,
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(resp, err)
+	}
+}
+
 const testRoleStaticCreate = `
 CREATE ROLE "{{name}}" WITH
   LOGIN

--- a/builtin/logical/database/path_roles_test.go
+++ b/builtin/logical/database/path_roles_test.go
@@ -904,12 +904,6 @@ func TestWALsDeletedOnRoleDeletion(t *testing.T) {
 }
 
 func TestIsInsideRotationWindow(t *testing.T) {
-	rotationPeriodData := map[string]interface{}{
-		"username":        "hashicorp",
-		"db_name":         "mockv5",
-		"rotation_period": "86400s",
-	}
-
 	for _, tc := range []struct {
 		name         string
 		expected     bool
@@ -920,7 +914,9 @@ func TestIsInsideRotationWindow(t *testing.T) {
 		{
 			"always returns true for rotation_period type",
 			true,
-			rotationPeriodData,
+			map[string]interface{}{
+				"rotation_period": "86400s",
+			},
 			time.Now(),
 			nil,
 		},
@@ -928,8 +924,6 @@ func TestIsInsideRotationWindow(t *testing.T) {
 			"always returns true for rotation_schedule when no rotation_window set",
 			true,
 			map[string]interface{}{
-				"username":          "hashicorp",
-				"db_name":           "mockv5",
 				"rotation_schedule": "0 0 */2 * * *",
 			},
 			time.Now(),
@@ -939,8 +933,6 @@ func TestIsInsideRotationWindow(t *testing.T) {
 			"returns true for rotation_schedule when inside rotation_window",
 			true,
 			map[string]interface{}{
-				"username":          "hashicorp",
-				"db_name":           "mockv5",
 				"rotation_schedule": "0 0 */2 * * *",
 				"rotation_window":   "3600s",
 			},
@@ -954,8 +946,6 @@ func TestIsInsideRotationWindow(t *testing.T) {
 			"returns false for rotation_schedule when outside rotation_window",
 			false,
 			map[string]interface{}{
-				"username":          "hashicorp",
-				"db_name":           "mockv5",
 				"rotation_schedule": "0 0 */2 * * *",
 				"rotation_window":   "3600s",
 			},
@@ -988,13 +978,14 @@ func TestIsInsideRotationWindow(t *testing.T) {
 				testTime = tc.timeModifier(next2)
 			}
 
+			tc.data["username"] = "hashicorp"
+			tc.data["db_name"] = "mockv5"
 			createRoleWithData(t, b, s, mockDB, "test-role", tc.data)
 			role, err := b.StaticRole(ctx, s, "test-role")
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			// testTime := sched.Next(time.Now()).tc.timeModifier()
 			isInsideWindow := role.StaticAccount.IsInsideRotationWindow(testTime)
 			if tc.expected != isInsideWindow {
 				t.Fatalf("expected %t, got %t", tc.expected, isInsideWindow)

--- a/builtin/logical/database/path_rotate_credentials.go
+++ b/builtin/logical/database/path_rotate_credentials.go
@@ -224,7 +224,7 @@ func (b *databaseBackend) pathRotateRoleCredentialsUpdate() framework.OperationF
 				item.Value = resp.WALID
 			}
 		} else {
-			item.Priority = resp.RotationTime.Add(role.StaticAccount.RotationPeriod).Unix()
+			item.Priority = role.StaticAccount.NextRotationTimeFromInput(resp.RotationTime).Unix()
 			// Clear any stored WAL ID as we must have successfully deleted our WAL to get here.
 			item.Value = ""
 		}

--- a/builtin/logical/database/rotation.go
+++ b/builtin/logical/database/rotation.go
@@ -22,6 +22,9 @@ const (
 	// Default interval to check the queue for items needing rotation
 	defaultQueueTickSeconds = 5
 
+	// Minimum allowed value for rotation_window
+	minRotationWindowSeconds = 3600
+
 	// Config key to set an alternate interval
 	queueTickIntervalKey = "rotation_queue_tick_interval"
 

--- a/builtin/logical/database/rotation.go
+++ b/builtin/logical/database/rotation.go
@@ -94,6 +94,11 @@ func (b *databaseBackend) populateQueue(ctx context.Context, s logical.Storage) 
 					log.Warn("unable to delete WAL", "error", err, "WAL ID", walEntry.walID)
 				}
 			} else {
+				// previous rotation attempt was interrupted, so we set the
+				// Priority as highest to be processed immediately
+
+				// TODO(JM): ensure we don't process schedule-based rotations
+				// outside the rotation_window
 				log.Info("found WAL for role", "role", item.Key, "WAL ID", walEntry.walID)
 				item.Value = walEntry.walID
 				item.Priority = time.Now().Unix()
@@ -220,6 +225,8 @@ func (b *databaseBackend) rotateCredential(ctx context.Context, s logical.Storag
 
 	// If "now" is less than the Item priority, then this item does not need to
 	// be rotated
+	// TODO(JM): ensure we don't process schedule-based rotations
+	// outside the rotation_window
 	if time.Now().Unix() < item.Priority {
 		if err := b.pushItem(item); err != nil {
 			logger.Error("unable to push item on to queue", "error", err)
@@ -267,19 +274,15 @@ func (b *databaseBackend) rotateCredential(ctx context.Context, s logical.Storag
 	}
 
 	// Update priority and push updated Item to the queue
-	if role.StaticAccount.RotationSchedule != "" {
-		schedule, err := b.scheduleParser.Parse(role.StaticAccount.RotationSchedule)
-		if err != nil {
-			b.logger.Error("could not parse rotation_schedule", "error", err)
-			return true
-		}
-		next := schedule.Next(lvr)
-		b.logger.Debug("update priority for Schedule", "lvr", lvr)
-		b.logger.Debug("update priority for Schedule", "next", next)
-		item.Priority = schedule.Next(lvr).Unix()
-	} else {
-		b.logger.Debug("update priority for RotationPeriod", "lvr", lvr, "next", lvr.Add(role.StaticAccount.RotationPeriod))
+	if role.StaticAccount.UsesRotationSchedule() {
+		next := role.StaticAccount.Schedule.Next(lvr)
+		logger.Debug("update priority for Schedule", "next", next)
+		item.Priority = role.StaticAccount.Schedule.Next(lvr).Unix()
+	} else if role.StaticAccount.UsesRotationPeriod() {
+		logger.Debug("update priority for RotationPeriod", "lvr", lvr, "next", lvr.Add(role.StaticAccount.RotationPeriod))
 		item.Priority = lvr.Add(role.StaticAccount.RotationPeriod).Unix()
+	} else {
+		logger.Error("rotation has not been properly configured")
 	}
 
 	if err := b.pushItem(item); err != nil {

--- a/changelog/22484.txt
+++ b/changelog/22484.txt
@@ -1,0 +1,4 @@
+```release-note:feature
+**Database Static Role Advanced TTL Management**: Adds the ability to rotate
+static roles on a defined schedule.
+```

--- a/go.mod
+++ b/go.mod
@@ -190,6 +190,7 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/common v0.37.0
 	github.com/rboyer/safeio v0.2.1
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/ryanuber/columnize v2.1.0+incompatible
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/sasha-s/go-deadlock v0.2.0
@@ -459,8 +460,6 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 // indirect
-	github.com/robfig/cron v1.2.0 // indirect
-	github.com/robfig/cron/v3 v3.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -459,6 +459,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 // indirect
+	github.com/robfig/cron v1.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -460,6 +460,7 @@ require (
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 // indirect
 	github.com/robfig/cron v1.2.0 // indirect
+	github.com/robfig/cron/v3 v3.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2576,6 +2576,8 @@ github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 h1:Wdi9nwnhFNAlseAOe
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03/go.mod h1:gRAiPF5C5Nd0eyyRdqIu9qTiFSoZzpTq727b5B8fkkU=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
+github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
+github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/go.sum
+++ b/go.sum
@@ -2574,6 +2574,8 @@ github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqn
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 h1:Wdi9nwnhFNAlseAOekn6B5G/+GMtks9UKbvRU/CMM/o=
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03/go.mod h1:gRAiPF5C5Nd0eyyRdqIu9qTiFSoZzpTq727b5B8fkkU=
+github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
+github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/go.sum
+++ b/go.sum
@@ -2574,10 +2574,8 @@ github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqn
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 h1:Wdi9nwnhFNAlseAOekn6B5G/+GMtks9UKbvRU/CMM/o=
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03/go.mod h1:gRAiPF5C5Nd0eyyRdqIu9qTiFSoZzpTq727b5B8fkkU=
-github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
-github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
-github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
-github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=


### PR DESCRIPTION
This PR enables schedule-based auto-rotation of static roles for the Database Secrets engine. This rotation mechanism will be “embedded” in the Database Secrets engine and will not be reusable by other engines. In particular, this approach allows for exclusion windows (e.g. market hours) in which automatic rotations will not occur.

We add a new field `rotation_schedule` to the [create static role](https://developer.hashicorp.com/vault/api-docs/secret/databases#create-static-role) endpoint. This field can be set with a cron-style string that will define the schedule on which rotations should occur:

```
// set rotations to occur on Saturday at 00:00
vault write database/static-roles/test-role \
    db_name=postgresql \
    username="vault" \
    rotation_schedule="0 0 * * SAT"
```

Additionally, we add a new `rotation_window` field on the [create static role](https://developer.hashicorp.com/vault/api-docs/secret/databases#create-static-role) endpoint. It will be optional when `rotation_schedule` is set and disallowed when `rotation_period` is set. This field can be set with a [time duration string](https://developer.hashicorp.com/vault/docs/concepts/duration-format) with a minimum of 1 hour. The `rotation_window` will define the window of time in which rotations are allowed to occur starting from a given `rotation_schedule`:

```
// set rotations to occur on Saturday at 00:00, but allow up to Sunday at 23:59
vault write database/static-roles/test-role \
    db_name=postgresql \
    username="vault" \
    rotation_schedule="0 0 * * SAT" \
    rotation_window="24h"
```