### PR TITLE
Minor improvements to transit & csrs

### DIFF
--- a/builtin/logical/transit/path_certificates.go
+++ b/builtin/logical/transit/path_certificates.go
@@ -40,13 +40,6 @@ will be used as a basis for the CSR with the key in transit. If not set, an empt
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
-			// NOTE: Create and Update?
-			logical.CreateOperation: &framework.PathOperation{
-				Callback: b.pathCreateCsrWrite,
-				DisplayAttrs: &framework.DisplayAttributes{
-					OperationVerb: "create",
-				},
-			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathCreateCsrWrite,
 				DisplayAttrs: &framework.DisplayAttributes{
@@ -83,13 +76,6 @@ by one or more concatenated PEM blocks and ordered starting from the end-entity 
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
-			// NOTE: Create and Update?
-			logical.CreateOperation: &framework.PathOperation{
-				Callback: b.pathImportCertChainWrite,
-				DisplayAttrs: &framework.DisplayAttributes{
-					OperationVerb: "create",
-				},
-			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathImportCertChainWrite,
 				DisplayAttrs: &framework.DisplayAttributes{

--- a/builtin/logical/transit/path_export_test.go
+++ b/builtin/logical/transit/path_export_test.go
@@ -504,7 +504,6 @@ func testTransit_exportCertificateChain(t *testing.T, apiClient *api.Client, key
 	})
 	require.NoError(t, err)
 
-	// NOTE: Should it be possible for the "import" endpoint to also import the cert chain?
 	// Import cert chain
 	_, err = apiClient.Logical().Write(fmt.Sprintf("transit/keys/%s/set-certificate", keyName), map[string]interface{}{
 		"certificate_chain": leafCertPEM,

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -2511,11 +2511,6 @@ func (p *Policy) ValidateLeafCertKeyMatch(keyVersion int, certPublicKeyAlgorithm
 			Y:     keyEntry.EC_Y,
 		}
 
-		// NOTE: Is it worth having this check?
-		if publicKey.Curve != certPublicKey.Curve {
-			return false, nil
-		}
-
 		return publicKey.Equal(certPublicKey), nil
 
 	case x509.Ed25519:


### PR DESCRIPTION
Fixes a bug in #21081 with CreateOperation without existence check -- I should've updated the branch prior to merging I guess :-) 

Also adds a new test to validate that importing a certificate with invalid key doesn't work. 