### PR TITLE
Switch exported to explicit regex of types

### DIFF
--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -15,7 +15,7 @@ import (
 )
 
 func pathGenerateIntermediate(b *backend) *framework.Path {
-	pattern := "intermediate/generate/" + framework.GenericNameRegex("exported")
+	pattern := "intermediate/generate/" + ExportedNameRegex
 
 	displayAttrs := &framework.DisplayAttributes{
 		OperationPrefix: operationPrefixPKI,

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -19,7 +19,7 @@ import (
 )
 
 func pathIssuerGenerateRoot(b *backend) *framework.Path {
-	pattern := "issuers/generate/root/" + framework.GenericNameRegex("exported")
+	pattern := "issuers/generate/root/" + ExportedNameRegex
 
 	displayAttrs := &framework.DisplayAttributes{
 		OperationPrefix: operationPrefixPKIIssuers,
@@ -31,7 +31,7 @@ func pathIssuerGenerateRoot(b *backend) *framework.Path {
 }
 
 func pathRotateRoot(b *backend) *framework.Path {
-	pattern := "root/rotate/" + framework.GenericNameRegex("exported")
+	pattern := "root/rotate/" + ExportedNameRegex
 
 	displayAttrs := &framework.DisplayAttributes{
 		OperationPrefix: operationPrefixPKI,
@@ -119,7 +119,7 @@ func buildPathGenerateRoot(b *backend, pattern string, displayAttrs *framework.D
 }
 
 func pathIssuerGenerateIntermediate(b *backend) *framework.Path {
-	pattern := "issuers/generate/intermediate/" + framework.GenericNameRegex("exported")
+	pattern := "issuers/generate/intermediate/" + ExportedNameRegex
 
 	displayAttrs := &framework.DisplayAttributes{
 		OperationPrefix: operationPrefixPKIIssuers,

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -29,8 +29,10 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+const ExportedNameRegex = `(?P<exported>exported|internal|kms|existing)`
+
 func pathGenerateRoot(b *backend) *framework.Path {
-	pattern := "root/generate/" + framework.GenericNameRegex("exported")
+	pattern := "root/generate/" + ExportedNameRegex
 
 	displayAttrs := &framework.DisplayAttributes{
 		OperationPrefix: operationPrefixPKI,


### PR DESCRIPTION
This makes the PKI issuer generation APIs much more explicit, listing the key export types explicitly rather than as a generic name regex:

    ^root/generate/(?P<exported>exported|internal|kms|existing)$
        Generate a new CA certificate and private key used for signing.