### PR TITLE
Backport 1.13: Backport 1.13: Update-primary lite changes

### DIFF
--- a/sdk/helper/testcluster/replication.go
+++ b/sdk/helper/testcluster/replication.go
@@ -1,0 +1,66 @@
+package testcluster
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/vault/api"
+)
+
+// PassiveWaitForActiveNodeAndPerfStandbys should be used instead of
+// WaitForActiveNodeAndPerfStandbys when you don't want to do any writes
+// as a side-effect. This returns perfStandby nodes in the cluster and
+// an error.
+func PassiveWaitForActiveNodeAndPerfStandbys(ctx context.Context, pri VaultCluster) (VaultClusterNode, []VaultClusterNode, error) {
+	leaderNode, standbys, err := GetActiveAndStandbys(ctx, pri)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to derive standby nodes, %w", err)
+	}
+
+	for i, node := range standbys {
+		client := node.APIClient()
+		// Make sure we get perf standby nodes
+		if err = EnsureCoreIsPerfStandby(ctx, client); err != nil {
+			return nil, nil, fmt.Errorf("standby node %d is not a perfStandby, %w", i, err)
+		}
+	}
+
+	return leaderNode, standbys, nil
+}
+
+func EnsureCoreIsPerfStandby(ctx context.Context, client *api.Client) error {
+	var err error
+	var health *api.HealthResponse
+	for ctx.Err() == nil {
+		health, err = client.Sys().HealthWithContext(ctx)
+		if err == nil && health.PerformanceStandby {
+			return nil
+		}
+		time.Sleep(time.Millisecond * 500)
+	}
+	if err == nil {
+		err = ctx.Err()
+	}
+	return err
+}
+
+func GetActiveAndStandbys(ctx context.Context, cluster VaultCluster) (VaultClusterNode, []VaultClusterNode, error) {
+	var leaderIndex int
+	var err error
+	if leaderIndex, err = WaitForActiveNode(ctx, cluster); err != nil {
+		return nil, nil, err
+	}
+
+	var leaderNode VaultClusterNode
+	var nodes []VaultClusterNode
+	for i, node := range cluster.Nodes() {
+		if i == leaderIndex {
+			leaderNode = node
+			continue
+		}
+		nodes = append(nodes, node)
+	}
+
+	return leaderNode, nodes, nil
+}

--- a/sdk/helper/testcluster/types.go
+++ b/sdk/helper/testcluster/types.go
@@ -1,0 +1,28 @@
+package testcluster
+
+import (
+	"crypto/tls"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/api"
+)
+
+type VaultClusterNode interface {
+	APIClient() *api.Client
+	TLSConfig() *tls.Config
+}
+
+type VaultCluster interface {
+	Nodes() []VaultClusterNode
+	GetBarrierKeys() [][]byte
+	GetRecoveryKeys() [][]byte
+	GetBarrierOrRecoveryKeys() [][]byte
+	SetBarrierKeys([][]byte)
+	SetRecoveryKeys([][]byte)
+	GetCACertPEMFile() string
+	Cleanup()
+	ClusterID() string
+	NamedLogger(string) hclog.Logger
+	SetRootToken(token string)
+	GetRootToken() string
+}

--- a/sdk/helper/testcluster/util.go
+++ b/sdk/helper/testcluster/util.go
@@ -1,0 +1,31 @@
+package testcluster
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func WaitForActiveNode(ctx context.Context, cluster VaultCluster) (int, error) {
+	for ctx.Err() == nil {
+		if idx, _ := LeaderNode(ctx, cluster); idx != -1 {
+			return idx, nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return -1, ctx.Err()
+}
+
+func LeaderNode(ctx context.Context, cluster VaultCluster) (int, error) {
+	for i, node := range cluster.Nodes() {
+		client := node.APIClient()
+		ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+		resp, err := client.Sys().LeaderWithContext(ctx)
+		cancel()
+		if err != nil || resp == nil || !resp.IsSelf {
+			continue
+		}
+		return i, nil
+	}
+	return -1, fmt.Errorf("no leader found")
+}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -48,6 +48,7 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/helper/pluginutil"
+	"github.com/hashicorp/vault/sdk/helper/testcluster"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
 	physInmem "github.com/hashicorp/vault/sdk/physical/inmem"
@@ -1791,6 +1792,80 @@ func GenerateListenerAddr(t testing.T, opts *TestClusterOptions, certIPs []net.I
 	}
 
 	return baseAddr, certIPs
+}
+
+func (c *TestCluster) GetBarrierOrRecoveryKeys() [][]byte {
+	if c.Cores[0].SealAccess().RecoveryKeySupported() {
+		return c.GetRecoveryKeys()
+	} else {
+		return c.GetBarrierKeys()
+	}
+}
+
+func (c *TestCluster) GetCACertPEMFile() string {
+	return c.CACertPEMFile
+}
+
+func (c *TestCluster) ClusterID() string {
+	return c.ID
+}
+
+func (c *TestCluster) Nodes() []testcluster.VaultClusterNode {
+	ret := make([]testcluster.VaultClusterNode, len(c.Cores))
+	for i, core := range c.Cores {
+		ret[i] = core
+	}
+	return ret
+}
+
+func (c *TestCluster) SetBarrierKeys(keys [][]byte) {
+	c.BarrierKeys = make([][]byte, len(keys))
+	for i, k := range keys {
+		c.BarrierKeys[i] = TestKeyCopy(k)
+	}
+}
+
+func (c *TestCluster) SetRecoveryKeys(keys [][]byte) {
+	c.RecoveryKeys = make([][]byte, len(keys))
+	for i, k := range keys {
+		c.RecoveryKeys[i] = TestKeyCopy(k)
+	}
+}
+
+func (c *TestCluster) GetBarrierKeys() [][]byte {
+	ret := make([][]byte, len(c.BarrierKeys))
+	for i, k := range c.BarrierKeys {
+		ret[i] = TestKeyCopy(k)
+	}
+	return ret
+}
+
+func (c *TestCluster) GetRecoveryKeys() [][]byte {
+	ret := make([][]byte, len(c.RecoveryKeys))
+	for i, k := range c.RecoveryKeys {
+		ret[i] = TestKeyCopy(k)
+	}
+	return ret
+}
+
+func (c *TestCluster) NamedLogger(name string) log.Logger {
+	return c.Logger.Named(name)
+}
+
+func (c *TestCluster) GetRootToken() string {
+	return c.RootToken
+}
+
+func (c *TestCluster) SetRootToken(token string) {
+	c.RootToken = token
+}
+
+func (c *TestClusterCore) Name() string {
+	return c.NodeID
+}
+
+func (c *TestClusterCore) APIClient() *api.Client {
+	return c.Client
 }
 
 // StartCore restarts a TestClusterCore that was stopped, by replacing the


### PR DESCRIPTION
OSS changes for https://github.com/hashicorp/vault-enterprise/pull/4585
Original PR https://github.com/hashicorp/vault-enterprise/pull/4254

The 1.13 ENT backport required a test helper that didn't get backported to 1.13, so these are the OSS changes required for my ENT backport PR.