### PR TITLE
UI: Fix InfoTableRow args so row value renders with copyable tooltip

### DIFF
--- a/changelog/22519.txt
+++ b/changelog/22519.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-ui: Fix bug in InfoTableRow by changing to Ember Octane syntax
+ui: Fix display for "Last Vault Rotation" timestamp for static database roles which was not rendering or copyable
 ```

--- a/changelog/22519.txt
+++ b/changelog/22519.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix bug in InfoTableRow by changing to Ember Octane syntax
+```

--- a/ui/lib/core/addon/components/info-table-row.hbs
+++ b/ui/lib/core/addon/components/info-table-row.hbs
@@ -87,7 +87,7 @@
           {{#if @tooltipText}}
             <ToolTip @verticalPosition="above" @horizontalPosition="left" as |T|>
               <T.Trigger @tabindex={{false}}>
-                <span class="is-word-break has-text-black" data-test-row-value={{this.label}}>{{this.value}}</span>
+                <span class="is-word-break has-text-black" data-test-row-value={{@label}}>{{@value}}</span>
               </T.Trigger>
               <T.Content @defaultClass="tool-tip">
                 <CopyButton


### PR DESCRIPTION
The component `<InfoTableRow>` is a glimmer component, not a classic component, but some arguments in the handlebars file are still referred to in the classic Ember way. As a result, there is a problem where the "Last Vault Rotation" timestamp for static database roles is not rendering or copyable

 This PR fixes this bug.