### PR TITLE
UI: Clean up <JsonEditor> by removing unnecessary test selector

### DIFF
--- a/ui/lib/core/addon/components/json-editor.hbs
+++ b/ui/lib/core/addon/components/json-editor.hbs
@@ -43,7 +43,6 @@
     }}
     class={{if @readOnly "readonly-codemirror"}}
     data-test-component="code-mirror-modifier"
-    data-test-example-modal-json-text
   ></div>
 
   {{#if @helpText}}

--- a/ui/tests/integration/components/policy-example-test.js
+++ b/ui/tests/integration/components/policy-example-test.js
@@ -11,7 +11,7 @@ import { hbs } from 'ember-cli-htmlbars';
 const SELECTORS = {
   policyText: '[data-test-modal-title]',
   policyDescription: (type) => `[data-test-example-modal-text=${type}]`,
-  jsonText: '[data-test-example-modal-json-text]',
+  jsonText: '[data-test-component="code-mirror-modifier"]',
   informationLink: '[data-test-example-modal-information-link]',
 };
 


### PR DESCRIPTION
The component `<JsonEditor>` has an unnecessary test selector `data-test-example-modal-json-text` I added to be used in the tests for the `<PolicyExample>` component. This PR cleans up the code by removing this test selector and using the existing one for the `<PolicyExample>` tests