### PR TITLE
Work around issue with UNIX domain sockets in api.Client addresses

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -545,7 +545,7 @@ func (c *Config) ParseAddress(address string) (*url.URL, error) {
 			// be pointing to the protocol used in the application layer and not to
 			// the transport layer. Hence, setting the fields accordingly.
 			u.Scheme = "http"
-			u.Host = socket
+			u.Host = "localhost"
 			u.Path = ""
 		} else {
 			return nil, fmt.Errorf("attempting to specify unix:// address with non-transport transport")

--- a/changelog/22523.txt
+++ b/changelog/22523.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fix breakage with UNIX domain socket addresses introduced by newest Go versions as a security fix.
+```


### PR DESCRIPTION
The Host part of the URL doesn't actually get used when we initiate connections to UNIX domain sockets.  As of https://github.com/golang/go/issues/60374 (in the latest Go releases at the time of this writing), we must set it to something that looks like a hostname or requests will fail.