### PR TITLE
UI: Fix blank secret on KV create > cancel

### DIFF
--- a/changelog/22541.txt
+++ b/changelog/22541.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix blank page or ghost secret when canceling KV secret create
+```

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -346,6 +346,7 @@ export default Route.extend(UnloadModelRoute, {
           )
         ) {
           version && version.rollbackAttributes();
+          model && model.rollbackAttributes();
           this.unloadModel();
           return true;
         } else {


### PR DESCRIPTION
Before this change, if you click "cancel" on the "create secret" form in KV, a ghost secret would appear on the list when you return to the list view: 

<img width="1276" alt="Screenshot 2023-08-23 at 5 24 06 PM" src="https://github.com/hashicorp/vault/assets/82459713/57c57d49-c994-492e-8062-ce9cca3f1d84">

In even older versions, this would cause the page to render a completely blank screen. 