### PR TITLE
Fix malformed timing files

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -123,9 +123,14 @@ jobs:
           restore-keys: |
             ${{ inputs.test-timing-cache-key }}-
             go-test-reports-
-      - name: List cached results
-        id: list-cached-results
-        run: ls -lhR test-results/go-test
+      - name: Sanitize timing files
+        id: sanitize-timing-files
+        run: |
+          # Prune invalid timing files
+          find test-results/go-test -mindepth 1 -type f -name "*.json" -exec sh -c '
+            file="$1";
+            jq . "$file" || rm "$file"
+          ' shell {} \; > /dev/null 2>&1
       - name: Build matrix excluding binary, integration, and testonly tests
         id: build-non-binary
         if: ${{ !inputs.testonly }}
@@ -427,4 +432,11 @@ jobs:
       - run: |
           ls -lhR test-results/go-test
           find test-results/go-test -mindepth 1 -mtime +3 -delete
+
+          # Prune invalid timing files
+          find test-results/go-test -mindepth 1 -type f -name "*.json" -exec sh -c '
+            file="$1";
+            jq . "$file" || rm "$file"
+          ' shell {} \; > /dev/null 2>&1
+
           ls -lhR test-results/go-test


### PR DESCRIPTION
If any of the timing files end up being corrupted, we'd like to handle it gracefully without failing the test runner. In the worst case, we should fall back to building the default test matrix and persist any new entries in the cache. To prevent failure, we can check that all timing files are processed with `jq` at the time of `gotestsum` invocation.

As an extra precaution, we can also clear any bad timing files from the cache before they're persisted.