### PR TITLE
UI: add copyable paths for CLI and API commands to kv v2

### DIFF
--- a/changelog/22551.txt
+++ b/changelog/22551.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+**Copyable KV v2 paths in UI**: KV v2 secret paths are copyable for use in CLI commands or API calls
+```

--- a/ui/lib/core/addon/components/code-snippet.hbs
+++ b/ui/lib/core/addon/components/code-snippet.hbs
@@ -3,8 +3,8 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<div class="code-snippet-container">
-  <code data-test-code-snippet class="text-grey-lightest">
+<div data-test-code-snippet class="code-snippet-container" ...attributes>
+  <code class="text-grey-lightest">
     {{@codeBlock}}
   </code>
   {{! replace with Hds::Copy::Button }}

--- a/ui/lib/core/addon/components/code-snippet.hbs
+++ b/ui/lib/core/addon/components/code-snippet.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <div class="code-snippet-container">
-  <code class="text-grey-lightest">
+  <code data-test-code-snippet class="text-grey-lightest">
     {{@codeBlock}}
   </code>
   {{! replace with Hds::Copy::Button }}

--- a/ui/lib/core/addon/components/info-table-row.hbs
+++ b/ui/lib/core/addon/components/info-table-row.hbs
@@ -6,7 +6,7 @@
 {{#if (or (has-block) this.isVisible)}}
   <div class="info-table-row" data-test-component="info-table-row" ...attributes>
     <div
-      class="column is-one-quarter {{if this.hasLabelOverflow 'label-overflow'}}"
+      class="column {{if @labelWidth @labelWidth 'is-one-quarter'}} {{if this.hasLabelOverflow 'label-overflow'}}"
       data-test-label-div
       {{did-insert this.calculateLabelOverflow}}
     >

--- a/ui/lib/core/addon/components/info-table-row.hbs
+++ b/ui/lib/core/addon/components/info-table-row.hbs
@@ -6,7 +6,7 @@
 {{#if (or (has-block) this.isVisible)}}
   <div class="info-table-row" data-test-component="info-table-row" ...attributes>
     <div
-      class="column {{if @labelWidth @labelWidth 'is-one-quarter'}} {{if this.hasLabelOverflow 'label-overflow'}}"
+      class="column {{or @labelWidth 'is-one-quarter'}} {{if this.hasLabelOverflow 'label-overflow'}}"
       data-test-label-div
       {{did-insert this.calculateLabelOverflow}}
     >

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -2,6 +2,7 @@
   <:tabLinks>
     <LinkTo @route="secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
     <LinkTo @route="secret.metadata.index" data-test-secrets-tab="Metadata">Metadata</LinkTo>
+    <LinkTo @route="secret.paths" data-test-secrets-tab="Paths">Paths</LinkTo>
     {{#if @secret.canReadMetadata}}
       <LinkTo @route="secret.metadata.versions" data-test-secrets-tab="Version History">Version History</LinkTo>
     {{/if}}

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
@@ -2,6 +2,7 @@
   <:tabLinks>
     <LinkTo @route="secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
     <LinkTo @route="secret.metadata.index" data-test-secrets-tab="Metadata">Metadata</LinkTo>
+    <LinkTo @route="secret.paths" data-test-secrets-tab="Paths">Paths</LinkTo>
     {{#if @secret.canReadMetadata}}
       <LinkTo @route="secret.metadata.versions" data-test-secrets-tab="Version History">Version History</LinkTo>
     {{/if}}

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
@@ -3,7 +3,7 @@
     <LinkTo @route="secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
     <LinkTo @route="secret.metadata.index" data-test-secrets-tab="Metadata">Metadata</LinkTo>
     <LinkTo @route="secret.paths" data-test-secrets-tab="Paths">Paths</LinkTo>
-    {{#if @canReadMetadata}}
+    {{#if @secret.canReadMetadata}}
       <LinkTo @route="secret.metadata.versions" data-test-secrets-tab="Version History">Version History</LinkTo>
     {{/if}}
   </:tabLinks>

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
@@ -3,7 +3,7 @@
     <LinkTo @route="secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
     <LinkTo @route="secret.metadata.index" data-test-secrets-tab="Metadata">Metadata</LinkTo>
     <LinkTo @route="secret.paths" data-test-secrets-tab="Paths">Paths</LinkTo>
-    {{#if @secret.canReadMetadata}}
+    {{#if @canReadMetadata}}
       <LinkTo @route="secret.metadata.versions" data-test-secrets-tab="Version History">Version History</LinkTo>
     {{/if}}
   </:tabLinks>

--- a/ui/lib/kv/addon/components/page/secret/metadata/version-history.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/version-history.hbs
@@ -2,6 +2,7 @@
   <:tabLinks>
     <LinkTo @route="secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
     <LinkTo @route="secret.metadata.index" data-test-secrets-tab="Metadata">Metadata</LinkTo>
+    <LinkTo @route="secret.paths" data-test-secrets-tab="Paths">Paths</LinkTo>
     <LinkTo @route="secret.metadata.versions" data-test-secrets-tab="Version History">Version History</LinkTo>
   </:tabLinks>
 </KvPageHeader>

--- a/ui/lib/kv/addon/components/page/secret/paths.hbs
+++ b/ui/lib/kv/addon/components/page/secret/paths.hbs
@@ -9,7 +9,7 @@
   </:tabLinks>
 </KvPageHeader>
 
-<h2 class="title is-5 has-top-margin-l">
+<h2 class="title is-5 has-top-margin-xl">
   Paths
 </h2>
 
@@ -32,7 +32,7 @@
   {{/each}}
 </div>
 
-<h2 class="title is-5 has-top-margin-l">
+<h2 class="title is-5 has-top-margin-xl">
   Commands
 </h2>
 
@@ -47,7 +47,7 @@
       learn more.
     </DocLink>
   </p>
-  <CodeSnippet @codeBlock={{this.commands.cli}} />
+  <CodeSnippet data-test-commands="cli" @codeBlock={{this.commands.cli}} />
 
   <h3 class="has-top-margin-l is-label">
     API
@@ -61,5 +61,5 @@
       learn more.
     </DocLink>
   </p>
-  <CodeSnippet @clipboardCode={{this.commands.apiCopy}} @codeBlock={{this.commands.apiDisplay}} />
+  <CodeSnippet data-test-commands="api" @clipboardCode={{this.commands.apiCopy}} @codeBlock={{this.commands.apiDisplay}} />
 </div>

--- a/ui/lib/kv/addon/components/page/secret/paths.hbs
+++ b/ui/lib/kv/addon/components/page/secret/paths.hbs
@@ -3,7 +3,7 @@
     <LinkTo @route="secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
     <LinkTo @route="secret.metadata.index" data-test-secrets-tab="Metadata">Metadata</LinkTo>
     <LinkTo @route="secret.paths" data-test-secrets-tab="Paths">Paths</LinkTo>
-    {{#if @secret.canReadMetadata}}
+    {{#if @canReadMetadata}}
       <LinkTo @route="secret.metadata.versions" data-test-secrets-tab="Version History">Version History</LinkTo>
     {{/if}}
   </:tabLinks>
@@ -21,7 +21,7 @@
         class="button is-compact is-transparent level-right"
         @clipboardText={{path.snippet}}
         @buttonType="button"
-        @success={{action (set-flash-message (concat path.label " copied!"))}}
+        @success={{fn (set-flash-message (concat path.label " copied!"))}}
       >
         <Icon @name="clipboard-copy" aria-label="Copy" />
       </CopyButton>
@@ -42,7 +42,7 @@
     <Hds::Badge @text="kv get" @color="neutral" />
   </h3>
   <p class="helper-text has-text-grey has-bottom-padding-s">
-    This command retrieves the value from K/V secrets engine at the given key name. For other CLI commands,
+    This command retrieves the value from KV secrets engine at the given key name. For other CLI commands,
     <DocLink @path="/vault/docs/commands/kv">
       learn more.
     </DocLink>

--- a/ui/lib/kv/addon/components/page/secret/paths.hbs
+++ b/ui/lib/kv/addon/components/page/secret/paths.hbs
@@ -54,7 +54,7 @@
   </h3>
   <p class="helper-text has-text-grey has-bottom-padding-s">
     This command obtains data and metadata for the latest version of this secret. In this example, Vault is located at
-    http://127.0.0.1:8200. For other API commands,
+    https://127.0.0.1:8200. For other API commands,
     <DocLink @path="/vault/api-docs/secret/kv/kv-v2">
       learn more.
     </DocLink>

--- a/ui/lib/kv/addon/components/page/secret/paths.hbs
+++ b/ui/lib/kv/addon/components/page/secret/paths.hbs
@@ -1,0 +1,66 @@
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle={{@path}}>
+  <:tabLinks>
+    <LinkTo @route="secret.details" data-test-secrets-tab="Secret">Secret</LinkTo>
+    <LinkTo @route="secret.metadata.index" data-test-secrets-tab="Metadata">Metadata</LinkTo>
+    <LinkTo @route="secret.paths" data-test-secrets-tab="Paths">Paths</LinkTo>
+    {{#if @secret.canReadMetadata}}
+      <LinkTo @route="secret.metadata.versions" data-test-secrets-tab="Version History">Version History</LinkTo>
+    {{/if}}
+  </:tabLinks>
+</KvPageHeader>
+
+<h2 class="title is-5 has-bottom-padding-s has-top-margin-l">
+  Paths
+</h2>
+
+<div class="box is-fullwidth is-sideless is-paddingless is-marginless">
+  <InfoTableRow
+    @label="API path"
+    @labelWidth="is-one-third"
+    @helperText="Use this path when referring to this secret in API"
+  >
+    <CopyButton
+      class="button is-compact is-transparent level-right"
+      @clipboardText={{this.paths.data}}
+      @buttonType="button"
+      @success={{action (set-flash-message "API path copied!")}}
+    >
+      <Icon @name="clipboard-copy" aria-label="Copy" />
+    </CopyButton>
+    <code class="level-left">{{this.paths.data}}</code>
+  </InfoTableRow>
+
+  <InfoTableRow
+    @label="CLI path"
+    @labelWidth="is-one-third"
+    @helperText="Use this path when referring to this secret in CLI"
+  >
+    <CopyButton
+      class="button is-compact is-transparent level-right"
+      @clipboardText={{this.paths.cli}}
+      @buttonType="button"
+      @success={{action (set-flash-message "CLI path copied!")}}
+    >
+      <Icon @name="clipboard-copy" aria-label="Copy" />
+    </CopyButton>
+    <code class="level-left">
+      {{this.paths.cli}}
+    </code>
+  </InfoTableRow>
+
+  <InfoTableRow
+    @label="Metadata path"
+    @labelWidth="is-one-third"
+    @helperText="Use this path for viewing secret metadata and permanent deletion."
+  >
+    <CopyButton
+      class="button is-compact is-transparent level-right"
+      @clipboardText={{this.paths.metadata}}
+      @buttonType="button"
+      @success={{action (set-flash-message "Metadata path copied!")}}
+    >
+      <Icon @name="clipboard-copy" aria-label="Copy" />
+    </CopyButton>
+    <code class="level-left">{{this.paths.metadata}}</code>
+  </InfoTableRow>
+</div>

--- a/ui/lib/kv/addon/components/page/secret/paths.hbs
+++ b/ui/lib/kv/addon/components/page/secret/paths.hbs
@@ -50,12 +50,10 @@
   <CodeSnippet data-test-commands="cli" @codeBlock={{this.commands.cli}} />
 
   <h3 class="has-top-margin-l is-label">
-    API
-    <Hds::Badge @text="GET" @color="neutral" />
-    secret version
+    API read secret version
   </h3>
   <p class="helper-text has-text-grey has-bottom-padding-s">
-    This command obtains the secret and its version specific metadata. In this example, Vault is located at
+    This command obtains data and metadata for the latest version of this secret. In this example, Vault is located at
     http://127.0.0.1:8200. For other API commands,
     <DocLink @path="/vault/api-docs/secret/kv/kv-v2">
       learn more.

--- a/ui/lib/kv/addon/components/page/secret/paths.hbs
+++ b/ui/lib/kv/addon/components/page/secret/paths.hbs
@@ -16,11 +16,12 @@
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   {{#each this.paths as |path|}}
     <InfoTableRow @label={{path.label}} @labelWidth="is-one-third" @helperText={{path.text}}>
+      {{! replace with Hds::Copy::Snippet }}
       <CopyButton
         class="button is-compact is-transparent level-right"
         @clipboardText={{path.snippet}}
         @buttonType="button"
-        @success={{action (set-flash-message "{{path.label}} copied!")}}
+        @success={{action (set-flash-message (concat path.label " copied!"))}}
       >
         <Icon @name="clipboard-copy" aria-label="Copy" />
       </CopyButton>

--- a/ui/lib/kv/addon/components/page/secret/paths.hbs
+++ b/ui/lib/kv/addon/components/page/secret/paths.hbs
@@ -14,53 +14,19 @@
 </h2>
 
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
-  <InfoTableRow
-    @label="API path"
-    @labelWidth="is-one-third"
-    @helperText="Use this path when referring to this secret in API"
-  >
-    <CopyButton
-      class="button is-compact is-transparent level-right"
-      @clipboardText={{this.paths.data}}
-      @buttonType="button"
-      @success={{action (set-flash-message "API path copied!")}}
-    >
-      <Icon @name="clipboard-copy" aria-label="Copy" />
-    </CopyButton>
-    <code class="level-left">{{this.paths.data}}</code>
-  </InfoTableRow>
-
-  <InfoTableRow
-    @label="CLI path"
-    @labelWidth="is-one-third"
-    @helperText="Use this path when referring to this secret in CLI"
-  >
-    <CopyButton
-      class="button is-compact is-transparent level-right"
-      @clipboardText={{this.paths.cli}}
-      @buttonType="button"
-      @success={{action (set-flash-message "CLI path copied!")}}
-    >
-      <Icon @name="clipboard-copy" aria-label="Copy" />
-    </CopyButton>
-    <code class="level-left">
-      {{this.paths.cli}}
-    </code>
-  </InfoTableRow>
-
-  <InfoTableRow
-    @label="Metadata path"
-    @labelWidth="is-one-third"
-    @helperText="Use this path for viewing secret metadata and permanent deletion."
-  >
-    <CopyButton
-      class="button is-compact is-transparent level-right"
-      @clipboardText={{this.paths.metadata}}
-      @buttonType="button"
-      @success={{action (set-flash-message "Metadata path copied!")}}
-    >
-      <Icon @name="clipboard-copy" aria-label="Copy" />
-    </CopyButton>
-    <code class="level-left">{{this.paths.metadata}}</code>
-  </InfoTableRow>
+  {{#each-in this.paths as |label value|}}
+    <InfoTableRow @label={{label}} @labelWidth="is-one-third" @helperText={{value.text}}>
+      <CopyButton
+        class="button is-compact is-transparent level-right"
+        @clipboardText={{value.path}}
+        @buttonType="button"
+        @success={{action (set-flash-message "{{label}} copied!")}}
+      >
+        <Icon @name="clipboard-copy" aria-label="Copy" />
+      </CopyButton>
+      <code class="has-left-margin-s level-left">
+        {{value.path}}
+      </code>
+    </InfoTableRow>
+  {{/each-in}}
 </div>

--- a/ui/lib/kv/addon/components/page/secret/paths.hbs
+++ b/ui/lib/kv/addon/components/page/secret/paths.hbs
@@ -9,24 +9,56 @@
   </:tabLinks>
 </KvPageHeader>
 
-<h2 class="title is-5 has-bottom-padding-s has-top-margin-l">
+<h2 class="title is-5 has-top-margin-l">
   Paths
 </h2>
 
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
-  {{#each-in this.paths as |label value|}}
-    <InfoTableRow @label={{label}} @labelWidth="is-one-third" @helperText={{value.text}}>
+  {{#each this.paths as |path|}}
+    <InfoTableRow @label={{path.label}} @labelWidth="is-one-third" @helperText={{path.text}}>
       <CopyButton
         class="button is-compact is-transparent level-right"
-        @clipboardText={{value.path}}
+        @clipboardText={{path.snippet}}
         @buttonType="button"
-        @success={{action (set-flash-message "{{label}} copied!")}}
+        @success={{action (set-flash-message "{{path.label}} copied!")}}
       >
         <Icon @name="clipboard-copy" aria-label="Copy" />
       </CopyButton>
       <code class="has-left-margin-s level-left">
-        {{value.path}}
+        {{path.snippet}}
       </code>
     </InfoTableRow>
-  {{/each-in}}
+  {{/each}}
+</div>
+
+<h2 class="title is-5 has-top-margin-l">
+  Commands
+</h2>
+
+<div class="box is-fullwidth is-sideless">
+  <h3 class="is-label">
+    CLI
+    <Hds::Badge @text="kv get" @color="neutral" />
+  </h3>
+  <p class="helper-text has-text-grey has-bottom-padding-s">
+    This command retrieves the value from K/V secrets engine at the given key name. For other CLI commands,
+    <DocLink @path="/vault/docs/commands/kv">
+      learn more.
+    </DocLink>
+  </p>
+  <CodeSnippet @codeBlock={{this.commands.cli}} />
+
+  <h3 class="has-top-margin-l is-label">
+    API
+    <Hds::Badge @text="GET" @color="neutral" />
+    secret version
+  </h3>
+  <p class="helper-text has-text-grey has-bottom-padding-s">
+    This command obtains the secret and its version specific metadata. In this example, Vault is located at
+    http://127.0.0.1:8200. For other API commands,
+    <DocLink @path="/vault/api-docs/secret/kv/kv-v2">
+      learn more.
+    </DocLink>
+  </p>
+  <CodeSnippet @clipboardCode={{this.commands.apiCopy}} @codeBlock={{this.commands.apiDisplay}} />
 </div>

--- a/ui/lib/kv/addon/components/page/secret/paths.js
+++ b/ui/lib/kv/addon/components/page/secret/paths.js
@@ -17,7 +17,7 @@ import { kvMetadataPath, kvDataPath } from 'vault/utils/kv-path';
  * />
  *
  * @param {model} secret - Ember data model: 'kv/data', the new record for the new secret version saved by the form
- * @param {string} path - kv secret path
+ * @param {string} path - kv secret path for rendering the page title
  * @param {array} breadcrumbs - Array to generate breadcrumbs, passed to the page header component
  */
 
@@ -27,14 +27,23 @@ export default class KvSecretPaths extends Component {
   get paths() {
     const { backend, path } = this.args.secret;
     const namespace = this.namespace.path;
+    const cli = `-mount=${backend} "${path}"`;
     const data = kvDataPath(backend, path);
     const metadata = kvMetadataPath(backend, path);
-    const cli = `-mount=${backend} "${path}"`;
 
     return {
-      data: namespace ? `/v1/${namespace}/${data}` : `/v1/${data}`,
-      metadata: namespace ? `/v1/${namespace}/${metadata}` : `/v1/${metadata}`,
-      cli: namespace ? `-namespace=${namespace} ${cli}` : cli,
+      'CLI path': {
+        path: namespace ? `-namespace=${namespace} ${cli}` : cli,
+        text: 'Use this path when referring to this secret in CLI.',
+      },
+      'API path': {
+        path: namespace ? `/v1/${namespace}/${data}` : `/v1/${data}`,
+        text: 'Use this path when referring to this secret in API.',
+      },
+      'Metadata API path': {
+        path: namespace ? `/v1/${namespace}/${metadata}` : `/v1/${metadata}`,
+        text: 'Use this path for viewing secret metadata and permanent deletion.',
+      },
     };
   }
 }

--- a/ui/lib/kv/addon/components/page/secret/paths.js
+++ b/ui/lib/kv/addon/components/page/secret/paths.js
@@ -54,9 +54,10 @@ export default class KvSecretPaths extends Component {
   }
 
   get commands() {
-    const { snippet: cliPath } = this.paths.findBy('label', 'CLI path');
-    const { snippet: apiPath } = this.paths.findBy('label', 'API path');
+    const cliPath = this.paths.findBy('label', 'CLI path').snippet;
+    const apiPath = this.paths.findBy('label', 'API path').snippet;
     const url = `http://127.0.0.1:8200${apiPath}`;
+
     return {
       cli: `vault kv get ${cliPath}`,
       /* eslint-disable-next-line no-useless-escape */

--- a/ui/lib/kv/addon/components/page/secret/paths.js
+++ b/ui/lib/kv/addon/components/page/secret/paths.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { kvMetadataPath, kvDataPath } from 'vault/utils/kv-path';
+
+/**
+ * @module KvSecretPaths is used to display copyable secret paths to use on the CLI and API.
+ *
+ * <Page::Secret::Paths
+ *  @path={{this.model.path}}
+ *  @secret={{this.model.secret}}
+ *  @breadcrumbs={{this.breadcrumbs}}
+ * />
+ *
+ * @param {model} secret - Ember data model: 'kv/data', the new record for the new secret version saved by the form
+ * @param {string} path - kv secret path
+ * @param {array} breadcrumbs - Array to generate breadcrumbs, passed to the page header component
+ */
+
+export default class KvSecretPaths extends Component {
+  @service namespace;
+
+  get paths() {
+    const { backend, path } = this.args.secret;
+    const namespace = this.namespace.path;
+    const data = kvDataPath(backend, path);
+    const metadata = kvMetadataPath(backend, path);
+    const cli = `-mount=${backend} ${path}`;
+
+    return {
+      data: namespace ? `${namespace}/${data}` : data,
+      cli: namespace ? `-namespace=${namespace} ${cli}` : cli,
+      metadata: namespace ? `${namespace}/${metadata}` : metadata,
+    };
+  }
+}

--- a/ui/lib/kv/addon/components/page/secret/paths.js
+++ b/ui/lib/kv/addon/components/page/secret/paths.js
@@ -27,7 +27,7 @@ export default class KvSecretPaths extends Component {
   get paths() {
     const { backend, path } = this.args.secret;
     const namespace = this.namespace.path;
-    const cli = `-mount=${backend} "${path}"`;
+    const cli = `-mount="${backend}" "${path}"`;
     const data = kvDataPath(backend, path);
     const metadata = kvMetadataPath(backend, path);
 

--- a/ui/lib/kv/addon/components/page/secret/paths.js
+++ b/ui/lib/kv/addon/components/page/secret/paths.js
@@ -31,19 +31,38 @@ export default class KvSecretPaths extends Component {
     const data = kvDataPath(backend, path);
     const metadata = kvMetadataPath(backend, path);
 
-    return {
-      'API path': {
-        path: namespace ? `/v1/${namespace}/${data}` : `/v1/${data}`,
+    return [
+      {
+        label: 'API path',
+        snippet: namespace ? `/v1/${namespace}/${data}` : `/v1/${data}`,
         text: 'Use this path when referring to this secret in the API.',
       },
-      'CLI path': {
-        path: namespace ? `-namespace=${namespace} ${cli}` : cli,
+      {
+        label: 'CLI path',
+        snippet: namespace ? `-namespace=${namespace} ${cli}` : cli,
         text: 'Use this path when referring to this secret in the CLI.',
       },
-      'API path for metadata': {
-        path: namespace ? `/v1/${namespace}/${metadata}` : `/v1/${metadata}`,
+      {
+        label: 'API path for metadata',
+        snippet: namespace ? `/v1/${namespace}/${metadata}` : `/v1/${metadata}`,
         text: `Use this path when referring to this secret's metadata in the API and permanent secret deletion.`,
       },
+    ];
+  }
+
+  get commands() {
+    const { snippet: cli } = this.paths.findBy('label', 'CLI path');
+    const { snippet: api } = this.paths.findBy('label', 'API path');
+    const { version } = this.args.secret;
+    const url = `http://127.0.0.1:8200${api}?version=${version}`;
+    return {
+      cli: `vault kv get ${cli}`,
+      /* eslint-disable-next-line no-useless-escape */
+      apiCopy: `curl \ --header "X-Vault-Token: ..." \ --request GET \ ${url}`,
+      apiDisplay: `curl \\
+        --header "X-Vault-Token: ..." \\
+        --request GET \\
+      ${url}`,
     };
   }
 }

--- a/ui/lib/kv/addon/components/page/secret/paths.js
+++ b/ui/lib/kv/addon/components/page/secret/paths.js
@@ -9,23 +9,26 @@ import { kvMetadataPath, kvDataPath } from 'vault/utils/kv-path';
 
 /**
  * @module KvSecretPaths is used to display copyable secret paths to use on the CLI and API.
+ * This view is permission agnostic because args come from the views mount path and url params.
  *
  * <Page::Secret::Paths
  *  @path={{this.model.path}}
- *  @secret={{this.model.secret}}
+ *  @backend={{this.model.backend}}
  *  @breadcrumbs={{this.breadcrumbs}}
+ *  @canReadMetadata={{this.model.secret.canReadMetadata}}
  * />
  *
- * @param {model} secret - Ember data model: 'kv/data', the new record for the new secret version saved by the form
- * @param {string} path - kv secret path for rendering the page title
+ * @param {string} path - kv secret path for building the CLI and API paths
+ * @param {string} backend - the secret engine mount path, comes from the secretMountPath service defined in the route
  * @param {array} breadcrumbs - Array to generate breadcrumbs, passed to the page header component
+ * @param {boolean} [canReadMetadata=true] - if true, displays tab for Version History
  */
 
 export default class KvSecretPaths extends Component {
   @service namespace;
 
   get paths() {
-    const { backend, path } = this.args.secret;
+    const { backend, path } = this.args;
     const namespace = this.namespace.path;
     const cli = `-mount="${backend}" "${path}"`;
     const data = kvDataPath(backend, path);
@@ -51,12 +54,11 @@ export default class KvSecretPaths extends Component {
   }
 
   get commands() {
-    const { snippet: cli } = this.paths.findBy('label', 'CLI path');
-    const { snippet: api } = this.paths.findBy('label', 'API path');
-    const { version } = this.args.secret;
-    const url = `http://127.0.0.1:8200${api}?version=${version}`;
+    const { snippet: cliPath } = this.paths.findBy('label', 'CLI path');
+    const { snippet: apiPath } = this.paths.findBy('label', 'API path');
+    const url = `http://127.0.0.1:8200${apiPath}`;
     return {
-      cli: `vault kv get ${cli}`,
+      cli: `vault kv get ${cliPath}`,
       /* eslint-disable-next-line no-useless-escape */
       apiCopy: `curl \ --header "X-Vault-Token: ..." \ --request GET \ ${url}`,
       apiDisplay: `curl \\

--- a/ui/lib/kv/addon/components/page/secret/paths.js
+++ b/ui/lib/kv/addon/components/page/secret/paths.js
@@ -8,7 +8,7 @@ import { inject as service } from '@ember/service';
 import { kvMetadataPath, kvDataPath } from 'vault/utils/kv-path';
 
 /**
- * @module KvSecretPaths is used to display copyable secret paths to use on the CLI and API.
+ * @module KvSecretPaths is used to display copyable secret paths for KV v2 for CLI and API use.
  * This view is permission agnostic because args come from the views mount path and url params.
  *
  * <Page::Secret::Paths
@@ -56,7 +56,8 @@ export default class KvSecretPaths extends Component {
   get commands() {
     const cliPath = this.paths.findBy('label', 'CLI path').snippet;
     const apiPath = this.paths.findBy('label', 'API path').snippet;
-    const url = `http://127.0.0.1:8200${apiPath}`;
+    // as a future improvement, it might be nice to use window.location.protocol here:
+    const url = `https://127.0.0.1:8200${apiPath}`;
 
     return {
       cli: `vault kv get ${cliPath}`,

--- a/ui/lib/kv/addon/components/page/secret/paths.js
+++ b/ui/lib/kv/addon/components/page/secret/paths.js
@@ -32,17 +32,17 @@ export default class KvSecretPaths extends Component {
     const metadata = kvMetadataPath(backend, path);
 
     return {
-      'CLI path': {
-        path: namespace ? `-namespace=${namespace} ${cli}` : cli,
-        text: 'Use this path when referring to this secret in CLI.',
-      },
       'API path': {
         path: namespace ? `/v1/${namespace}/${data}` : `/v1/${data}`,
-        text: 'Use this path when referring to this secret in API.',
+        text: 'Use this path when referring to this secret in the API.',
       },
-      'Metadata API path': {
+      'CLI path': {
+        path: namespace ? `-namespace=${namespace} ${cli}` : cli,
+        text: 'Use this path when referring to this secret in the CLI.',
+      },
+      'API path for metadata': {
         path: namespace ? `/v1/${namespace}/${metadata}` : `/v1/${metadata}`,
-        text: 'Use this path for viewing secret metadata and permanent deletion.',
+        text: `Use this path when referring to this secret's metadata in the API and permanent secret deletion.`,
       },
     };
   }

--- a/ui/lib/kv/addon/components/page/secret/paths.js
+++ b/ui/lib/kv/addon/components/page/secret/paths.js
@@ -29,12 +29,12 @@ export default class KvSecretPaths extends Component {
     const namespace = this.namespace.path;
     const data = kvDataPath(backend, path);
     const metadata = kvMetadataPath(backend, path);
-    const cli = `-mount=${backend} ${path}`;
+    const cli = `-mount=${backend} "${path}"`;
 
     return {
-      data: namespace ? `${namespace}/${data}` : data,
+      data: namespace ? `/v1/${namespace}/${data}` : `/v1/${data}`,
+      metadata: namespace ? `/v1/${namespace}/${metadata}` : `/v1/${metadata}`,
       cli: namespace ? `-namespace=${namespace} ${cli}` : cli,
-      metadata: namespace ? `${namespace}/${metadata}` : metadata,
     };
   }
 }

--- a/ui/lib/kv/addon/routes.js
+++ b/ui/lib/kv/addon/routes.js
@@ -12,6 +12,7 @@ export default buildRoutes(function () {
   this.route('list-directory', { path: '/:path_to_secret/directory' });
   this.route('create');
   this.route('secret', { path: '/:name' }, function () {
+    this.route('paths');
     this.route('details', function () {
       this.route('edit'); // route to create new version of a secret
     });

--- a/ui/lib/kv/addon/routes/secret/paths.js
+++ b/ui/lib/kv/addon/routes/secret/paths.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Route from '@ember/routing/route';
+import { breadcrumbsForSecret } from 'kv/utils/kv-breadcrumbs';
+
+export default class KvSecretPathsRoute extends Route {
+  setupController(controller, resolvedModel) {
+    super.setupController(controller, resolvedModel);
+
+    controller.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: resolvedModel.backend, route: 'list' },
+      ...breadcrumbsForSecret(resolvedModel.path),
+      { label: 'paths' },
+    ];
+  }
+}

--- a/ui/lib/kv/addon/templates/secret/paths.hbs
+++ b/ui/lib/kv/addon/templates/secret/paths.hbs
@@ -1,6 +1,1 @@
-<Page::Secret::Paths
-  @path={{this.model.path}}
-  @secret={{this.model.secret}}
-  @metadata={{this.model.metadata}}
-  @breadcrumbs={{this.breadcrumbs}}
-/>
+<Page::Secret::Paths @path={{this.model.path}} @secret={{this.model.secret}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kv/addon/templates/secret/paths.hbs
+++ b/ui/lib/kv/addon/templates/secret/paths.hbs
@@ -1,0 +1,6 @@
+<Page::Secret::Paths
+  @path={{this.model.path}}
+  @secret={{this.model.secret}}
+  @metadata={{this.model.metadata}}
+  @breadcrumbs={{this.breadcrumbs}}
+/>

--- a/ui/lib/kv/addon/templates/secret/paths.hbs
+++ b/ui/lib/kv/addon/templates/secret/paths.hbs
@@ -1,1 +1,6 @@
-<Page::Secret::Paths @path={{this.model.path}} @secret={{this.model.secret}} @breadcrumbs={{this.breadcrumbs}} />
+<Page::Secret::Paths
+  @path={{this.model.path}}
+  @backend={{this.model.backend}}
+  @breadcrumbs={{this.breadcrumbs}}
+  @canReadMetadata={{this.model.secret.canReadMetadata}}
+/>

--- a/ui/tests/helpers/kv/kv-selectors.js
+++ b/ui/tests/helpers/kv/kv-selectors.js
@@ -59,6 +59,11 @@ export const PAGE = {
   create: {
     metadataSection: '[data-test-metadata-section]',
   },
+  paths: {
+    copyButton: (label) => `${PAGE.infoRowValue(label)} button`,
+    codeSnippet: (section) => `[data-test-code-snippet][data-test-commands="${section}"] code`,
+    snippetCopy: (section) => `[data-test-code-snippet][data-test-commands="${section}"] button`,
+  },
 };
 
 // Form/Interactive selectors that are common between pages and forms

--- a/ui/tests/integration/components/kv/page/kv-page-secret-paths-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-paths-test.js
@@ -12,6 +12,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { kvDataPath } from 'vault/utils/kv-path';
 import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
 import { PAGE } from 'vault/tests/helpers/kv/kv-selectors';
+/* eslint-disable no-useless-escape */
 
 module('Integration | Component | kv-v2 | Page::Secret::Paths', function (hooks) {
   setupRenderingTest(hooks);
@@ -31,31 +32,30 @@ module('Integration | Component | kv-v2 | Page::Secret::Paths', function (hooks)
       id: this.dataId,
       path: this.path,
       backend: this.backend,
-      secret_data: this.secretData,
-      created_time: '2023-07-20T02:12:17.379762Z',
-      custom_metadata: null,
-      deletion_time: '',
-      destroyed: false,
       version: 2,
     });
 
     this.secret = this.store.peekRecord('kv/data', this.dataId);
-
     this.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
       { label: this.backend, route: 'list' },
       { label: this.path },
     ];
+
+    this.assertClipboard = (assert, element, expected) => {
+      assert.dom(element).hasAttribute('data-clipboard-text', expected);
+    };
   });
 
   test('it renders copyable paths', async function (assert) {
     assert.expect(6);
 
-    const expected = {
-      api: `/v1/${this.backend}/data/${this.path}`,
-      cli: `-mount=${this.backend} "${this.path}"`,
-      apiMeta: `/v1/${this.backend}/metadata/${this.path}`,
-    };
+    const paths = [
+      { label: 'API path', expected: `/v1/${this.backend}/data/${this.path}` },
+      { label: 'CLI path', expected: `-mount="${this.backend}" "${this.path}"` },
+      { label: 'API path for metadata', expected: `/v1/${this.backend}/metadata/${this.path}` },
+    ];
+
     await render(
       hbs`
 <Page::Secret::Paths
@@ -66,25 +66,32 @@ module('Integration | Component | kv-v2 | Page::Secret::Paths', function (hooks)
       `,
       { owner: this.engine }
     );
-    assert.dom(PAGE.infoRowValue('API path')).hasText(expected.api);
-    assert.dom(PAGE.infoRowValue('CLI path')).hasText(expected.cli);
-    assert.dom(PAGE.infoRowValue('API path for metadata')).hasText(expected.apiMeta);
-    assert.dom(`${PAGE.infoRowValue('API path')} button`).hasAttribute('data-clipboard-text', expected.api);
-    assert.dom(`${PAGE.infoRowValue('CLI path')} button`).hasAttribute('data-clipboard-text', expected.cli);
-    assert
-      .dom(`${PAGE.infoRowValue('API path for metadata')} button`)
-      .hasAttribute('data-clipboard-text', expected.apiMeta);
+
+    for (const path of paths) {
+      assert.dom(PAGE.infoRowValue(path.label)).hasText(path.expected);
+      this.assertClipboard(assert, PAGE.paths.copyButton(path.label), path.expected);
+    }
   });
 
-  test('it renders copyable encoded paths', async function (assert) {
+  test('it renders copyable encoded mount and secret paths', async function (assert) {
     assert.expect(6);
-    this.path = 'my spacey secret';
+    this.path = `my spacey!"secret`;
+    this.backend = `my fancy!"backend`;
+    this.secret.backend = this.backend;
     this.secret.path = this.path;
-    const expected = {
-      api: `/v1/${this.backend}/data/${encodeURIComponent(this.path)}`,
-      cli: `-mount=${this.backend} "${this.path}"`,
-      apiMeta: `/v1/${this.backend}/metadata/${encodeURIComponent(this.path)}`,
-    };
+
+    const paths = [
+      {
+        label: 'API path',
+        expected: `/v1/${encodeURIComponent(this.backend)}/data/${encodeURIComponent(this.path)}`,
+      },
+      { label: 'CLI path', expected: `-mount="${this.backend}" "${this.path}"` },
+      {
+        label: 'API path for metadata',
+        expected: `/v1/${encodeURIComponent(this.backend)}/metadata/${encodeURIComponent(this.path)}`,
+      },
+    ];
+
     await render(
       hbs`
 <Page::Secret::Paths
@@ -96,48 +103,67 @@ module('Integration | Component | kv-v2 | Page::Secret::Paths', function (hooks)
       { owner: this.engine }
     );
 
-    assert.dom(PAGE.infoRowValue('API path')).hasText(expected.api);
-    assert.dom(PAGE.infoRowValue('CLI path')).hasText(expected.cli);
-    assert.dom(PAGE.infoRowValue('API path for metadata')).hasText(expected.apiMeta);
-    assert.dom(`${PAGE.infoRowValue('API path')} button`).hasAttribute('data-clipboard-text', expected.api);
-    assert.dom(`${PAGE.infoRowValue('CLI path')} button`).hasAttribute('data-clipboard-text', expected.cli);
-    assert
-      .dom(`${PAGE.infoRowValue('API path for metadata')} button`)
-      .hasAttribute('data-clipboard-text', expected.apiMeta);
+    for (const path of paths) {
+      assert.dom(PAGE.infoRowValue(path.label)).hasText(path.expected);
+      this.assertClipboard(assert, PAGE.paths.copyButton(path.label), path.expected);
+    }
   });
 
   test('it renders copyable commands', async function (assert) {
-    assert.expect(6);
-
+    assert.expect(4);
+    const url = `http://127.0.0.1:8200/v1/${this.backend}/data/${this.path}?version=2`;
+    const expected = {
+      cli: `vault kv get -mount="${this.backend}" "${this.path}"`,
+      apiDisplay: `curl \\ --header \"X-Vault-Token: ...\" \\ --request GET \\ ${url}`,
+      apiCopy: `curl  --header \"X-Vault-Token: ...\"  --request GET \ ${url}`,
+    };
     await render(
       hbs`
 <Page::Secret::Paths
-  @path={{this.model.path}}
-  @secret={{this.model.secret}}
+  @path={{this.path}}
+  @secret={{this.secret}}
   @breadcrumbs={{this.breadcrumbs}}
 />
       `,
       { owner: this.engine }
     );
 
-    assert.dom('[data-test-code-snippet]').hasText('');
-    assert.dom('[data-test-code-snippet] button').hasAttribute('data-clipboard-text', '');
+    assert.dom(PAGE.paths.codeSnippet('cli')).hasText(expected.cli);
+    assert.dom(PAGE.paths.snippetCopy('cli')).hasAttribute('data-clipboard-text', expected.cli);
+    assert.dom(PAGE.paths.codeSnippet('api')).hasText(expected.apiDisplay);
+    assert.dom(PAGE.paths.snippetCopy('api')).hasAttribute('data-clipboard-text', expected.apiCopy);
   });
 
   test('it renders copyable encoded commands', async function (assert) {
-    assert.expect(6);
+    assert.expect(4);
+    this.path = `my spacey!"secret`;
+    this.backend = `my fancy!"backend`;
+    this.secret.backend = this.backend;
+    this.secret.path = this.path;
 
+    const backend = encodeURIComponent(this.backend);
+    const path = encodeURIComponent(this.path);
+    const url = `http://127.0.0.1:8200/v1/${backend}/data/${path}?version=2`;
+
+    const expected = {
+      cli: `vault kv get -mount="${this.backend}" "${this.path}"`,
+      apiDisplay: `curl \\ --header \"X-Vault-Token: ...\" \\ --request GET \\ ${url}`,
+      apiCopy: `curl  --header \"X-Vault-Token: ...\"  --request GET \ ${url}`,
+    };
     await render(
       hbs`
 <Page::Secret::Paths
-  @path={{this.model.path}}
-  @secret={{this.model.secret}}
+  @path={{this.path}}
+  @secret={{this.secret}}
   @breadcrumbs={{this.breadcrumbs}}
 />
       `,
       { owner: this.engine }
     );
-    assert.dom('[data-test-code-snippet]').hasText('');
-    assert.dom('[data-test-code-snippet] button').hasAttribute('data-clipboard-text', '');
+
+    assert.dom(PAGE.paths.codeSnippet('cli')).hasText(expected.cli);
+    assert.dom(PAGE.paths.snippetCopy('cli')).hasAttribute('data-clipboard-text', expected.cli);
+    assert.dom(PAGE.paths.codeSnippet('api')).hasText(expected.apiDisplay);
+    assert.dom(PAGE.paths.snippetCopy('api')).hasAttribute('data-clipboard-text', expected.apiCopy);
   });
 });

--- a/ui/tests/integration/components/kv/page/kv-page-secret-paths-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-paths-test.js
@@ -92,7 +92,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Paths', function (hooks)
 
   test('it renders copyable commands', async function (assert) {
     assert.expect(4);
-    const url = `http://127.0.0.1:8200/v1/${this.backend}/data/${this.path}`;
+    const url = `https://127.0.0.1:8200/v1/${this.backend}/data/${this.path}`;
     const expected = {
       cli: `vault kv get -mount="${this.backend}" "${this.path}"`,
       apiDisplay: `curl \\ --header \"X-Vault-Token: ...\" \\ --request GET \\ ${url}`,
@@ -122,7 +122,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Paths', function (hooks)
 
     const backend = encodeURIComponent(this.backend);
     const path = encodeURIComponent(this.path);
-    const url = `http://127.0.0.1:8200/v1/${backend}/data/${path}`;
+    const url = `https://127.0.0.1:8200/v1/${backend}/data/${path}`;
 
     const expected = {
       cli: `vault kv get -mount="${this.backend}" "${this.path}"`,

--- a/ui/tests/integration/components/kv/page/kv-page-secret-paths-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-paths-test.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupEngine } from 'ember-engines/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { kvDataPath } from 'vault/utils/kv-path';
+import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
+import { PAGE } from 'vault/tests/helpers/kv/kv-selectors';
+
+module('Integration | Component | kv-v2 | Page::Secret::Paths', function (hooks) {
+  setupRenderingTest(hooks);
+  setupEngine(hooks, 'kv');
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    this.store = this.owner.lookup('service:store');
+    this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub());
+
+    this.backend = 'kv-engine';
+    this.path = 'my-secret';
+    this.dataId = kvDataPath(this.backend, this.path);
+    this.secretData = { foo: 'bar' };
+    this.store.pushPayload('kv/data', {
+      modelName: 'kv/data',
+      id: this.dataId,
+      path: this.path,
+      backend: this.backend,
+      secret_data: this.secretData,
+      created_time: '2023-07-20T02:12:17.379762Z',
+      custom_metadata: null,
+      deletion_time: '',
+      destroyed: false,
+      version: 2,
+    });
+
+    this.secret = this.store.peekRecord('kv/data', this.dataId);
+
+    this.breadcrumbs = [
+      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: this.backend, route: 'list' },
+      { label: this.path },
+    ];
+  });
+
+  test('it renders copyable paths', async function (assert) {
+    assert.expect(6);
+
+    const expected = {
+      api: `/v1/${this.backend}/data/${this.path}`,
+      cli: `-mount=${this.backend} "${this.path}"`,
+      apiMeta: `/v1/${this.backend}/metadata/${this.path}`,
+    };
+    await render(
+      hbs`
+<Page::Secret::Paths
+  @path={{this.path}}
+  @secret={{this.secret}}
+  @breadcrumbs={{this.breadcrumbs}}
+/>
+      `,
+      { owner: this.engine }
+    );
+    assert.dom(PAGE.infoRowValue('API path')).hasText(expected.api);
+    assert.dom(PAGE.infoRowValue('CLI path')).hasText(expected.cli);
+    assert.dom(PAGE.infoRowValue('API path for metadata')).hasText(expected.apiMeta);
+    assert.dom(`${PAGE.infoRowValue('API path')} button`).hasAttribute('data-clipboard-text', expected.api);
+    assert.dom(`${PAGE.infoRowValue('CLI path')} button`).hasAttribute('data-clipboard-text', expected.cli);
+    assert
+      .dom(`${PAGE.infoRowValue('API path for metadata')} button`)
+      .hasAttribute('data-clipboard-text', expected.apiMeta);
+  });
+
+  test('it renders copyable encoded paths', async function (assert) {
+    assert.expect(6);
+    this.path = 'my spacey secret';
+    this.secret.path = this.path;
+    const expected = {
+      api: `/v1/${this.backend}/data/${encodeURIComponent(this.path)}`,
+      cli: `-mount=${this.backend} "${this.path}"`,
+      apiMeta: `/v1/${this.backend}/metadata/${encodeURIComponent(this.path)}`,
+    };
+    await render(
+      hbs`
+<Page::Secret::Paths
+  @path={{this.path}}
+  @secret={{this.secret}}
+  @breadcrumbs={{this.breadcrumbs}}
+/>
+      `,
+      { owner: this.engine }
+    );
+
+    assert.dom(PAGE.infoRowValue('API path')).hasText(expected.api);
+    assert.dom(PAGE.infoRowValue('CLI path')).hasText(expected.cli);
+    assert.dom(PAGE.infoRowValue('API path for metadata')).hasText(expected.apiMeta);
+    assert.dom(`${PAGE.infoRowValue('API path')} button`).hasAttribute('data-clipboard-text', expected.api);
+    assert.dom(`${PAGE.infoRowValue('CLI path')} button`).hasAttribute('data-clipboard-text', expected.cli);
+    assert
+      .dom(`${PAGE.infoRowValue('API path for metadata')} button`)
+      .hasAttribute('data-clipboard-text', expected.apiMeta);
+  });
+
+  test('it renders copyable commands', async function (assert) {
+    assert.expect(6);
+
+    await render(
+      hbs`
+<Page::Secret::Paths
+  @path={{this.model.path}}
+  @secret={{this.model.secret}}
+  @breadcrumbs={{this.breadcrumbs}}
+/>
+      `,
+      { owner: this.engine }
+    );
+
+    assert.dom('[data-test-code-snippet]').hasText('');
+    assert.dom('[data-test-code-snippet] button').hasAttribute('data-clipboard-text', '');
+  });
+
+  test('it renders copyable encoded commands', async function (assert) {
+    assert.expect(6);
+
+    await render(
+      hbs`
+<Page::Secret::Paths
+  @path={{this.model.path}}
+  @secret={{this.model.secret}}
+  @breadcrumbs={{this.breadcrumbs}}
+/>
+      `,
+      { owner: this.engine }
+    );
+    assert.dom('[data-test-code-snippet]').hasText('');
+    assert.dom('[data-test-code-snippet] button').hasAttribute('data-clipboard-text', '');
+  });
+});


### PR DESCRIPTION
This adds a `paths` tab to the kv engine secret view that gives users the API and CLI paths for copying, plus sample commands
<img width="1248" alt="Screenshot 2023-08-24 at 11 34 05 AM" src="https://github.com/hashicorp/vault/assets/68122737/87253c6f-b9f8-4c6a-af54-d33bb65b068c">

### example: 
![path-copy](https://github.com/hashicorp/vault/assets/68122737/fdfe0fb8-a24b-4767-be79-81e3a9229082)
