### PR TITLE
Fix multi_wrap_value.proto buf lint issues.

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -52,6 +52,7 @@ lint:
       - vault/hcp_link/proto/meta/meta.proto
       - vault/hcp_link/proto/node_status/status.proto
       - vault/replication/replication_resolver_ent.proto
+      - vault/seal/multi_wrap_value.proto
       - vault/tokens/token.proto
     PACKAGE_SAME_DIRECTORY:
       - vault/replication/replication_resolver_ent.proto
@@ -84,6 +85,7 @@ lint:
       - vault/replication/replication_resolver_ent.proto
       - vault/replication_services_ent.proto
       - vault/request_forwarding_service.proto
+      - vault/seal/multi_wrap_value.proto
       - vault/tokens/token.proto
     RPC_REQUEST_RESPONSE_UNIQUE:
       - sdk/database/dbplugin/database.proto


### PR DESCRIPTION
Add the protobuf file to the list of exceptions for PACKAGE_DIRECTORY_MATCH and PACKAGE_VERSION_SUFFIX.