### PR TITLE
feat(oidc): support s_hash claim

### DIFF
--- a/changelog/22562.txt
+++ b/changelog/22562.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/oidc: Support `s_hash` claim in IDToken.
+```

--- a/vault/external_tests/identity/oidc_provider_test.go
+++ b/vault/external_tests/identity/oidc_provider_test.go
@@ -247,7 +247,7 @@ func TestOIDC_Auth_Code_Flow_Default_Resources(t *testing.T) {
 
 			// Assert that claims computed during the flow (i.e., not known
 			// ahead of time in this test) are present as top-level keys
-			for _, claim := range []string{"iat", "exp", "nonce", "at_hash", "c_hash"} {
+			for _, claim := range []string{"iat", "exp", "nonce", "at_hash", "c_hash", "s_hash"} {
 				_, ok := allClaims[claim]
 				require.True(t, ok)
 			}
@@ -586,7 +586,7 @@ func TestOIDC_Auth_Code_Flow_Confidential_CAP_Client(t *testing.T) {
 
 			// Assert that claims computed during the flow (i.e., not known
 			// ahead of time in this test) are present as top-level keys
-			for _, claim := range []string{"iat", "exp", "nonce", "at_hash", "c_hash"} {
+			for _, claim := range []string{"iat", "exp", "nonce", "at_hash", "c_hash", "s_hash"} {
 				_, ok := allClaims[claim]
 				require.True(t, ok)
 			}
@@ -922,7 +922,7 @@ func TestOIDC_Auth_Code_Flow_Public_CAP_Client(t *testing.T) {
 
 			// Assert that claims computed during the flow (i.e., not known
 			// ahead of time in this test) are present as top-level keys
-			for _, claim := range []string{"iat", "exp", "nonce", "at_hash", "c_hash"} {
+			for _, claim := range []string{"iat", "exp", "nonce", "at_hash", "c_hash", "s_hash"} {
 				_, ok := allClaims[claim]
 				require.True(t, ok)
 			}

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -84,6 +84,7 @@ type idToken struct {
 	AuthTime        int64  `json:"auth_time"` // AuthTime given in OIDC authentication requests
 	AccessTokenHash string `json:"at_hash"`   // Access token hash value
 	CodeHash        string `json:"c_hash"`    // Authorization code hash value
+	StateHash       string `json:"s_hash"`    // State hash value - https://openid.net/specs/openid-financial-api-part-2-1_0.html#rfc.section.5.1.1
 }
 
 // discovery contains a subset of the required elements of OIDC discovery needed
@@ -118,7 +119,7 @@ var (
 	reservedClaims = []string{
 		"iat", "aud", "exp", "iss",
 		"sub", "namespace", "nonce",
-		"auth_time", "at_hash", "c_hash",
+		"auth_time", "at_hash", "c_hash", "s_hash",
 	}
 	supportedAlgs = []string{
 		string(jose.RS256),
@@ -1034,6 +1035,9 @@ func (tok *idToken) generatePayload(logger hclog.Logger, templates ...string) ([
 	}
 	if len(tok.CodeHash) > 0 {
 		output["c_hash"] = tok.CodeHash
+	}
+	if len(tok.StateHash) > 0 {
+		output["s_hash"] = tok.StateHash
 	}
 
 	// Merge each of the populated JSON templates into output


### PR DESCRIPTION
# Context

Add support to FAPI `s_hash` claim in ID Token - https://openid.net/specs/openid-financial-api-part-2-1_0.html#rfc.section.5.1.1

# Reference(s)

- https://openid.net/specs/openid-financial-api-part-2-1_0.html#rfc.section.5.1.1