### PR TITLE
UI: VAULT-19359 update acceptance test and date format

### DIFF
--- a/ui/app/templates/components/dashboard/client-count-card.hbs
+++ b/ui/app/templates/components/dashboard/client-count-card.hbs
@@ -50,7 +50,7 @@
         />
         <small class="has-left-margin-xs has-text-grey">
           Updated
-          {{date-format this.updatedAt "MMM dd, yyyy HH:mm:SS"}}
+          {{date-format this.updatedAt "MMM dd, yyyy hh:mm:SS"}}
         </small>
       </div>
     {{/if}}

--- a/ui/app/templates/components/dashboard/replication-card.hbs
+++ b/ui/app/templates/components/dashboard/replication-card.hbs
@@ -77,7 +77,7 @@
       />
       <small class="has-left-margin-xs has-text-grey">
         Updated
-        {{date-format @updatedAt "MMM dd, yyyy HH:mm:SS"}}
+        {{date-format @updatedAt "MMM dd, yyyy hh:mm:SS"}}
       </small>
     </div>
   {{else}}

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -67,7 +67,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await settled();
       await visit('/vault/dashboard');
       assert.dom(SECRETS_ENGINE_SELECTORS.cardTitle).hasText('Secrets engines');
-      assert.dom('[data-test-secrets-engines-card-show-all]').doesNotExist();
       // cleanup engine mount
       await consoleComponent.runCommands(deleteEngineCmd('pki'));
     });
@@ -77,7 +76,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await settled();
       await visit('/vault/dashboard');
       assert.dom('[data-test-secrets-engines-row="nomad"] [data-test-view]').doesNotExist();
-      assert.dom('[data-test-secrets-engines-card-show-all]').doesNotExist();
       // cleanup engine mount
       await consoleComponent.runCommands(deleteEngineCmd('nomad'));
     });

--- a/ui/tests/integration/components/dashboard/secrets-engines-card-test.js
+++ b/ui/tests/integration/components/dashboard/secrets-engines-card-test.js
@@ -14,6 +14,9 @@ module('Integration | Component | dashboard/secrets-engines-card', function (hoo
 
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');
+  });
+
+  test('it should hide show all button', async function (assert) {
     this.store.pushPayload('secret-engine', {
       modelName: 'secret-engine',
       data: {
@@ -22,87 +25,107 @@ module('Integration | Component | dashboard/secrets-engines-card', function (hoo
         type: 'kubernetes',
       },
     });
-    this.store.pushPayload('secret-engine', {
-      modelName: 'secret-engine',
-      data: {
-        accessor: 'pki_i1234dd',
-        path: 'pki-test/',
-        type: 'pki',
-      },
-    });
-    this.store.pushPayload('secret-engine', {
-      modelName: 'secret-engine',
-      data: {
-        accessor: 'secrets_j2350ii',
-        path: 'secrets-test/',
-        type: 'kv',
-      },
-    });
-    this.store.pushPayload('secret-engine', {
-      modelName: 'secret-engine',
-      data: {
-        accessor: 'nomad_123hh',
-        path: 'nomad/',
-        type: 'nomad',
-      },
-    });
-    this.store.pushPayload('secret-engine', {
-      modelName: 'secret-engine',
-      data: {
-        accessor: 'pki_f3400dee',
-        path: 'pki-0-test/',
-        type: 'pki',
-      },
-    });
-    this.store.pushPayload('secret-engine', {
-      modelName: 'secret-engine',
-      data: {
-        accessor: 'pki_i1234dd',
-        path: 'pki-1-test/',
-        description: 'pki-1-path-description',
-        type: 'pki',
-      },
-    });
-    this.store.pushPayload('secret-engine', {
-      modelName: 'secret-engine',
-      data: {
-        accessor: 'secrets_j2350ii',
-        path: 'secrets-1-test/',
-        type: 'kv',
-      },
-    });
 
     this.secretsEngines = this.store.peekAll('secret-engine', {});
 
-    this.renderComponent = () => {
-      return render(hbs`<Dashboard::SecretsEnginesCard @secretsEngines={{this.secretsEngines}} />`);
-    };
+    await render(hbs`<Dashboard::SecretsEnginesCard @secretsEngines={{this.secretsEngines}} />`);
+
+    assert.dom('[data-test-secrets-engines-card-show-all]').doesNotExist();
   });
 
-  test('it should display only five secrets engines', async function (assert) {
-    await this.renderComponent();
-    assert.dom(SELECTORS.cardTitle).hasText('Secrets engines');
-    assert.dom(SELECTORS.secretEnginesTableRows).exists({ count: 5 });
-  });
+  module('secrets engines with 5 or more enabled', function (hooks) {
+    hooks.beforeEach(function () {
+      this.store.pushPayload('secret-engine', {
+        modelName: 'secret-engine',
+        data: {
+          accessor: 'kubernetes_f3400dee',
+          path: 'kubernetes-test/',
+          type: 'kubernetes',
+        },
+      });
+      this.store.pushPayload('secret-engine', {
+        modelName: 'secret-engine',
+        data: {
+          accessor: 'pki_i1234dd',
+          path: 'pki-test/',
+          type: 'pki',
+        },
+      });
+      this.store.pushPayload('secret-engine', {
+        modelName: 'secret-engine',
+        data: {
+          accessor: 'secrets_j2350ii',
+          path: 'secrets-test/',
+          type: 'kv',
+        },
+      });
+      this.store.pushPayload('secret-engine', {
+        modelName: 'secret-engine',
+        data: {
+          accessor: 'nomad_123hh',
+          path: 'nomad/',
+          type: 'nomad',
+        },
+      });
+      this.store.pushPayload('secret-engine', {
+        modelName: 'secret-engine',
+        data: {
+          accessor: 'pki_f3400dee',
+          path: 'pki-0-test/',
+          type: 'pki',
+        },
+      });
+      this.store.pushPayload('secret-engine', {
+        modelName: 'secret-engine',
+        data: {
+          accessor: 'pki_i1234dd',
+          path: 'pki-1-test/',
+          description: 'pki-1-path-description',
+          type: 'pki',
+        },
+      });
+      this.store.pushPayload('secret-engine', {
+        modelName: 'secret-engine',
+        data: {
+          accessor: 'secrets_j2350ii',
+          path: 'secrets-1-test/',
+          type: 'kv',
+        },
+      });
 
-  test('it should display the secrets engines accessor and path', async function (assert) {
-    await this.renderComponent();
-    assert.dom(SELECTORS.cardTitle).hasText('Secrets engines');
-    assert.dom(SELECTORS.secretEnginesTableRows).exists({ count: 5 });
+      this.secretsEngines = this.store.peekAll('secret-engine', {});
 
-    this.secretsEngines.slice(0, 5).forEach((engine) => {
-      assert.dom(SELECTORS.getSecretEngineAccessor(engine.id)).hasText(engine.accessor);
-      if (engine.description) {
-        assert.dom(SELECTORS.getSecretEngineDescription(engine.id)).hasText(engine.description);
-      } else {
-        assert.dom(SELECTORS.getSecretEngineDescription(engine.id)).doesNotExist(engine.description);
-      }
+      this.renderComponent = () => {
+        return render(hbs`<Dashboard::SecretsEnginesCard @secretsEngines={{this.secretsEngines}} />`);
+      };
     });
-  });
 
-  test('it adds disabled css styling to unsupported secret engines', async function (assert) {
-    await this.renderComponent();
-    assert.dom('[data-test-secrets-engines-row="nomad"] [data-test-view]').doesNotExist();
-    assert.dom('[data-test-icon="nomad"]').hasClass('has-text-grey');
+    test('it should display only five secrets engines', async function (assert) {
+      await this.renderComponent();
+      assert.dom(SELECTORS.cardTitle).hasText('Secrets engines');
+      assert.dom(SELECTORS.secretEnginesTableRows).exists({ count: 5 });
+      assert.dom('[data-test-secrets-engines-card-show-all]').exists();
+    });
+
+    test('it should display the secrets engines accessor and path', async function (assert) {
+      await this.renderComponent();
+      assert.dom(SELECTORS.cardTitle).hasText('Secrets engines');
+      assert.dom(SELECTORS.secretEnginesTableRows).exists({ count: 5 });
+
+      this.secretsEngines.slice(0, 5).forEach((engine) => {
+        assert.dom(SELECTORS.getSecretEngineAccessor(engine.id)).hasText(engine.accessor);
+        if (engine.description) {
+          assert.dom(SELECTORS.getSecretEngineDescription(engine.id)).hasText(engine.description);
+        } else {
+          assert.dom(SELECTORS.getSecretEngineDescription(engine.id)).doesNotExist(engine.description);
+        }
+      });
+    });
+
+    test('it adds disabled css styling to unsupported secret engines', async function (assert) {
+      await this.renderComponent();
+      assert.dom('[data-test-secrets-engines-row="nomad"] [data-test-view]').doesNotExist();
+      assert.dom('[data-test-icon="nomad"]').hasClass('has-text-grey');
+    });
   });
 });


### PR DESCRIPTION
**Description**
- Fix client count + replication card date format for "updated at" to be 12 hr format.
- Move Show all button acceptance tests to be in the component tests. Tests were failing locally since we don't delete secrets engines so they were failing on re-run.