### PR TITLE
Fix potential race on core.activityLog

### DIFF
--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -440,7 +440,7 @@ func (c *Core) CheckToken(ctx context.Context, req *logical.Request, unauth bool
 	c.activityLogLock.RUnlock()
 	// If it is an authenticated ( i.e. with vault token ) request, increment client count
 	if !unauth && activityLog != nil {
-		err := c.activityLog.HandleTokenUsage(ctx, te, clientID, isTWE)
+		err := activityLog.HandleTokenUsage(ctx, te, clientID, isTWE)
 		if err != nil {
 			return auth, te, err
 		}


### PR DESCRIPTION
This PR addresses a potential race introduced in https://github.com/hashicorp/vault/pull/18809. We want to make sure the activitylog doesn't change from underneath us, so we should make sure to use the activitylog pointer we've copied in a read lock, rather than `c.activityLog`.