### PR TITLE
Fixes events subscribe for non-root namespaces

### DIFF
--- a/vault/eventbus/bus.go
+++ b/vault/eventbus/bus.go
@@ -202,7 +202,7 @@ func NewEventBus(logger hclog.Logger) (*EventBus, error) {
 }
 
 func (bus *EventBus) Subscribe(ctx context.Context, ns *namespace.Namespace, pattern string) (<-chan *eventlogger.Event, context.CancelFunc, error) {
-	return bus.SubscribeMultipleNamespaces(ctx, []string{ns.Path}, pattern)
+	return bus.SubscribeMultipleNamespaces(ctx, []string{strings.Trim(ns.Path, "/")}, pattern)
 }
 
 func (bus *EventBus) SubscribeMultipleNamespaces(ctx context.Context, namespacePathPatterns []string, pattern string) (<-chan *eventlogger.Event, context.CancelFunc, error) {


### PR DESCRIPTION
This PR fixes `EventBus.Subscribe()` for non-root namespaces without requiring callers to modify the `Path` field of the passed `namespace.Namespace`. It's most common for the namespace path to contain a trailing slash. The [filter node predicate](https://github.com/hashicorp/vault/blob/main/vault/eventbus/bus.go#L270) trims leading/trailing slashes which resulted in the events being filtered.

Added a test that would fail before this change.