### PR TITLE
reduce calls to DetermineRoleFromLoginRequest from 3 to 1 for aws auth method

### DIFF
--- a/changelog/22583.txt
+++ b/changelog/22583.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/quotas: Reduce the number of times role is calculated for rate limit and lease count quotas.
+```

--- a/changelog/22583.txt
+++ b/changelog/22583.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-core/quotas: Reduce the number of times role is calculated for rate limit and lease count quotas.
+core/quotas: Reduce overhead for role calculation when using cloud auth methods.
 ```

--- a/changelog/22583.txt
+++ b/changelog/22583.txt
@@ -1,3 +1,3 @@
-```release-note:improvement
+```release-note:bug
 core/quotas: Reduce overhead for role calculation when using cloud auth methods.
 ```

--- a/http/util.go
+++ b/http/util.go
@@ -5,6 +5,7 @@ package http
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -59,11 +60,16 @@ func rateLimitQuotaWrapping(handler http.Handler, core *vault.Core) http.Handler
 		}
 		r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
 
+		role := core.DetermineRoleFromLoginRequestFromBytes(mountPath, bodyBytes, r.Context())
+
+		// add an entry to the context to prevent recalculating request role unnecessarily
+		r = r.WithContext(context.WithValue(r.Context(), logical.CtxKeyRequestRole{}, role))
+
 		quotaResp, err := core.ApplyRateLimitQuota(r.Context(), &quotas.Request{
 			Type:          quotas.TypeRateLimit,
 			Path:          path,
 			MountPath:     mountPath,
-			Role:          core.DetermineRoleFromLoginRequestFromBytes(mountPath, bodyBytes, r.Context()),
+			Role:          role,
 			NamespacePath: ns.Path,
 			ClientAddress: parseRemoteIPAddress(r),
 		})

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -447,3 +447,9 @@ type CtxKeyInFlightRequestID struct{}
 func (c CtxKeyInFlightRequestID) String() string {
 	return "in-flight-request-ID"
 }
+
+type CtxKeyRequestRole struct{}
+
+func (c CtxKeyRequestRole) String() string {
+	return "request-role"
+}

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -786,12 +786,19 @@ func (c *Core) LoginMFACreateToken(ctx context.Context, reqPath string, cachedAu
 	// Determine the source of the login
 	mountPoint := c.router.MatchingMount(ctx, reqPath)
 
+	var role string
+	reqRole := ctx.Value(logical.CtxKeyRequestRole{})
+	if reqRole != nil {
+		role = reqRole.(string)
+	} else {
+		role = c.DetermineRoleFromLoginRequest(mountPoint, loginRequestData, ctx)
+	}
+
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("namespace not found: %w", err)
 	}
 
-	role := c.DetermineRoleFromLoginRequest(mountPoint, loginRequestData, ctx)
 	// The request successfully authenticated itself. Run the quota checks on
 	// the original login request path before creating the token.
 	quotaResp, quotaErr := c.applyLeaseCountQuota(ctx, &quotas.Request{

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -792,11 +792,8 @@ func (c *Core) LoginMFACreateToken(ctx context.Context, reqPath string, cachedAu
 	}
 
 	var role string
-	reqRole := ctx.Value(logical.CtxKeyRequestRole{})
-	if reqRole != nil {
+	if reqRole := ctx.Value(logical.CtxKeyRequestRole{}); reqRole != nil {
 		role = reqRole.(string)
-	} else {
-		role = c.DetermineRoleFromLoginRequest(mountPoint, loginRequestData, ctx)
 	}
 
 	// The request successfully authenticated itself. Run the quota checks on

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -817,7 +817,7 @@ func (c *Core) LoginMFACreateToken(ctx context.Context, reqPath string, cachedAu
 	// note that we don't need to handle the error for the following function right away.
 	// The function takes the response as in input variable and modify it. So, the returned
 	// arguments are resp and err.
-	leaseGenerated, resp, err := c.LoginCreateToken(ctx, ns, reqPath, mountPoint, resp, role)
+	leaseGenerated, resp, err := c.LoginCreateToken(ctx, ns, resp, reqPath, mountPoint, role)
 
 	if quotaResp.Access != nil {
 		quotaAckErr := c.ackLeaseQuota(quotaResp.Access, leaseGenerated)

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -824,7 +824,7 @@ func (c *Core) LoginMFACreateToken(ctx context.Context, reqPath string, cachedAu
 	// note that we don't need to handle the error for the following function right away.
 	// The function takes the response as in input variable and modify it. So, the returned
 	// arguments are resp and err.
-	leaseGenerated, resp, err := c.LoginCreateToken(ctx, ns, resp, reqPath, mountPoint, role)
+	leaseGenerated, resp, err := c.LoginCreateToken(ctx, ns, reqPath, mountPoint, resp, role)
 
 	if quotaResp.Access != nil {
 		quotaAckErr := c.ackLeaseQuota(quotaResp.Access, leaseGenerated)

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -824,7 +824,7 @@ func (c *Core) LoginMFACreateToken(ctx context.Context, reqPath string, cachedAu
 	// note that we don't need to handle the error for the following function right away.
 	// The function takes the response as in input variable and modify it. So, the returned
 	// arguments are resp and err.
-	leaseGenerated, resp, err := c.LoginCreateToken(ctx, ns, reqPath, mountPoint, resp, role)
+	leaseGenerated, resp, err := c.LoginCreateToken(ctx, ns, reqPath, mountPoint, role, resp)
 
 	if quotaResp.Access != nil {
 		quotaAckErr := c.ackLeaseQuota(quotaResp.Access, leaseGenerated)

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -786,17 +786,17 @@ func (c *Core) LoginMFACreateToken(ctx context.Context, reqPath string, cachedAu
 	// Determine the source of the login
 	mountPoint := c.router.MatchingMount(ctx, reqPath)
 
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("namespace not found: %w", err)
+	}
+
 	var role string
 	reqRole := ctx.Value(logical.CtxKeyRequestRole{})
 	if reqRole != nil {
 		role = reqRole.(string)
 	} else {
 		role = c.DetermineRoleFromLoginRequest(mountPoint, loginRequestData, ctx)
-	}
-
-	ns, err := namespace.FromContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("namespace not found: %w", err)
 	}
 
 	// The request successfully authenticated itself. Run the quota checks on

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1690,7 +1690,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 		// Attach the display name, might be used by audit backends
 		req.DisplayName = auth.DisplayName
 
-		leaseGen, respTokenCreate, errCreateToken := c.LoginCreateToken(ctx, ns, req.Path, source, resp, role)
+		leaseGen, respTokenCreate, errCreateToken := c.LoginCreateToken(ctx, ns, req.Path, source, role, resp)
 		leaseGenerated = leaseGen
 		if errCreateToken != nil {
 			return respTokenCreate, nil, errCreateToken
@@ -1742,7 +1742,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 // LoginCreateToken creates a token as a result of a login request.
 // If MFA is enforced, mfa/validate endpoint calls this functions
 // after successful MFA validation to generate the token.
-func (c *Core) LoginCreateToken(ctx context.Context, ns *namespace.Namespace, reqPath, mountPoint string, resp *logical.Response, role string) (bool, *logical.Response, error) {
+func (c *Core) LoginCreateToken(ctx context.Context, ns *namespace.Namespace, reqPath, mountPoint, role string, resp *logical.Response) (bool, *logical.Response, error) {
 	auth := resp.Auth
 	source := strings.TrimPrefix(mountPoint, credentialRoutePrefix)
 	source = strings.ReplaceAll(source, "/", "-")

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1684,7 +1684,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 		// Attach the display name, might be used by audit backends
 		req.DisplayName = auth.DisplayName
 
-		leaseGen, respTokenCreate, errCreateToken := c.LoginCreateToken(ctx, ns, req.Path, source, resp, role)
+		leaseGen, respTokenCreate, errCreateToken := c.LoginCreateToken(ctx, ns, resp, req.Path, source, role)
 		leaseGenerated = leaseGen
 		if errCreateToken != nil {
 			return respTokenCreate, nil, errCreateToken
@@ -1736,7 +1736,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 // LoginCreateToken creates a token as a result of a login request.
 // If MFA is enforced, mfa/validate endpoint calls this functions
 // after successful MFA validation to generate the token.
-func (c *Core) LoginCreateToken(ctx context.Context, ns *namespace.Namespace, reqPath, mountPoint string, resp *logical.Response, role string) (bool, *logical.Response, error) {
+func (c *Core) LoginCreateToken(ctx context.Context, ns *namespace.Namespace, resp *logical.Response, reqPath, mountPoint, role string) (bool, *logical.Response, error) {
 	auth := resp.Auth
 	source := strings.TrimPrefix(mountPoint, credentialRoutePrefix)
 	source = strings.ReplaceAll(source, "/", "-")

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1690,7 +1690,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 		// Attach the display name, might be used by audit backends
 		req.DisplayName = auth.DisplayName
 
-		leaseGen, respTokenCreate, errCreateToken := c.LoginCreateToken(ctx, ns, resp, req.Path, source, role)
+		leaseGen, respTokenCreate, errCreateToken := c.LoginCreateToken(ctx, ns, req.Path, source, resp, role)
 		leaseGenerated = leaseGen
 		if errCreateToken != nil {
 			return respTokenCreate, nil, errCreateToken
@@ -1742,7 +1742,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 // LoginCreateToken creates a token as a result of a login request.
 // If MFA is enforced, mfa/validate endpoint calls this functions
 // after successful MFA validation to generate the token.
-func (c *Core) LoginCreateToken(ctx context.Context, ns *namespace.Namespace, resp *logical.Response, reqPath, mountPoint, role string) (bool, *logical.Response, error) {
+func (c *Core) LoginCreateToken(ctx context.Context, ns *namespace.Namespace, reqPath, mountPoint string, resp *logical.Response, role string) (bool, *logical.Response, error) {
 	auth := resp.Auth
 	source := strings.TrimPrefix(mountPoint, credentialRoutePrefix)
 	source = strings.ReplaceAll(source, "/", "-")


### PR DESCRIPTION
The main purpose of this PR is to reduce calls to `c.DetermineRoleFromLoginRequest` in order to reduce the latency of login requests. 

Benchmarking results:
Main `mean: 704.492117ms`:
<img width="690" alt="image" src="https://github.com/hashicorp/vault/assets/29907172/e947070c-bc44-4cde-858c-8556f61fb442">


Main with changes from PR `mean: 341.443427ms`:
<img width="703" alt="image" src="https://github.com/hashicorp/vault/assets/29907172/e20a6ac2-8569-49d1-ae98-1423c41a9fe2">

Vault v1.10.4 `mean: 180.187269ms`:
<img width="723" alt="image" src="https://github.com/hashicorp/vault/assets/29907172/d00ed7d8-c492-4a67-8045-b922b5ce11d4">

