### PR TITLE
ci/plugin-update: use rest of repo name as service

### DIFF
--- a/.github/workflows/plugin-update.yml
+++ b/.github/workflows/plugin-update.yml
@@ -84,8 +84,8 @@ jobs:
           PLUGIN_TYPE=$(echo "$PLUGIN" | awk -F- '{print $3}')
           echo "plugin type: $PLUGIN_TYPE"
 
-          # plugin service is the last element in the repo name
-          PLUGIN_SERVICE=$(echo "$PLUGIN" | awk -F- '{print $4}')
+          # plugin service is the rest of the repo name
+          PLUGIN_SERVICE=$(echo "$PLUGIN" | cut -d- -f 4-)
           echo "plugin service: $PLUGIN_SERVICE"
 
           echo "\`\`\`release-note:change


### PR DESCRIPTION
Includes everything after the 3rd position as the PLUGIN_SERVICE, so that plugins like "vault-plugin-database-redis-elasticache" end up with the full name in the changelog entry.

```console
# old way, elasticache is dropped
$ echo "vault-plugin-database-redis-elasticache" | awk -F- '{print $4}'
redis

$ echo "vault-plugin-database-redis-elasticache" | cut -d- -f 4-
redis-elasticache

$ echo "vault-plugin-database-snowflake" | cut -d- -f 4-
snowflake
```