### PR TITLE
Set proper namespace in context given to backend InitializeFunc

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -240,7 +240,8 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 		// Initialize() if necessary
 		view.setReadOnlyErr(origViewReadOnlyErr)
 		// initialize, using the core's active context.
-		err := backend.Initialize(c.activeContext, &logical.InitializationRequest{Storage: view})
+		nsActiveContext := namespace.ContextWithNamespace(c.activeContext, ns)
+		err := backend.Initialize(nsActiveContext, &logical.InitializationRequest{Storage: view})
 		if err != nil {
 			return err
 		}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -758,8 +758,10 @@ func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStora
 		// restore the original readOnlyErr, so we can write to the view in
 		// Initialize() if necessary
 		view.setReadOnlyErr(origReadOnlyErr)
+
 		// initialize, using the core's active context.
-		err := backend.Initialize(c.activeContext, &logical.InitializationRequest{Storage: view})
+		nsActiveContext := namespace.ContextWithNamespace(c.activeContext, ns)
+		err := backend.Initialize(nsActiveContext, &logical.InitializationRequest{Storage: view})
 		if err != nil {
 			return err
 		}
@@ -1603,7 +1605,8 @@ func (c *Core) setupMounts(ctx context.Context) error {
 					view.setReadOnlyErr(origReadOnlyErr)
 				}
 
-				err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})
+				nsActiveContext := namespace.ContextWithNamespace(c.activeContext, localEntry.Namespace())
+				err := backend.Initialize(nsActiveContext, &logical.InitializationRequest{Storage: view})
 				if err != nil {
 					postUnsealLogger.Error("failed to initialize mount backend", "error", err)
 				}


### PR DESCRIPTION
This PR sets the namespace context key for backend `InitializeFunc` calls. The storage view is properly set for the namespace, but I noticed that the namespace associated with the context is always the root namespace. This allows backend `InitializeFunc` implementations to know which namespace they're being initialized in.