### PR TITLE
Adds stubbed InitializeFunc to the system backend

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -225,6 +225,7 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 	}
 
 	b.Backend.Invalidate = sysInvalidate(b)
+	b.Backend.InitializeFunc = sysInitialize(b)
 	return b
 }
 

--- a/vault/logical_system_helpers.go
+++ b/vault/logical_system_helpers.go
@@ -30,6 +30,10 @@ var (
 		return nil
 	}
 
+	sysInitialize = func(b *SystemBackend) func(context.Context, *logical.InitializationRequest) error {
+		return nil
+	}
+
 	getSystemSchemas = func() []func() *memdb.TableSchema { return nil }
 
 	getEGPListResponseKeyInfo = func(*SystemBackend, *namespace.Namespace) map[string]interface{} { return nil }


### PR DESCRIPTION
This PR adds a stubbed `InitializeFunc` to the system backend. This follows the same pattern as the `Invalidate` function. The intent it to have an enterprise-only `InitializeFunc` on the system backend for specific features.