### PR TITLE
UI: HDS adoption replace <CopyButton> part 3

### DIFF
--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -351,6 +351,7 @@ a.button.disabled {
     font-weight: $font-weight-bold;
     text-shadow: 0 1px 1px rgba($black, 0.25);
     height: 2.5rem;
+    min-width: 6rem;
 
     svg {
       color: $white;

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -342,7 +342,7 @@ a.button.disabled {
     color: $white;
   }
 
-  &.copy-close {
+  &.is-primary {
     background-color: $blue;
     box-shadow: $box-shadow-low;
     border-radius: $radius;

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -340,4 +340,14 @@ a.button.disabled {
   &.white-icon svg {
     color: $white;
   }
+  &.copy-close {
+    background-color: $blue;
+    box-shadow: $box-shadow-low;
+    border-radius: $radius;
+    border-color: darken($blue, 2%);
+    color: $white;
+    font-weight: $font-weight-bold;
+    text-shadow: 0 1px 1px rgba($black, 0.25);
+    height: 2.5rem;
+  }
 }

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -337,9 +337,11 @@ a.button.disabled {
     min-width: $spacing-l;
     padding: 0;
   }
+
   &.white-icon svg {
     color: $white;
   }
+
   &.copy-close {
     background-color: $blue;
     box-shadow: $box-shadow-low;
@@ -349,5 +351,9 @@ a.button.disabled {
     font-weight: $font-weight-bold;
     text-shadow: 0 1px 1px rgba($black, 0.25);
     height: 2.5rem;
+
+    svg {
+      color: $white;
+    }
   }
 }

--- a/ui/app/styles/helper-classes/flexbox-and-grid.scss
+++ b/ui/app/styles/helper-classes/flexbox-and-grid.scss
@@ -20,6 +20,10 @@
   flex-direction: row;
 }
 
+.has-gap-xxs {
+  gap: $spacing-xxs;
+}
+
 .has-gap-m {
   gap: $spacing-m;
 }

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -79,74 +79,65 @@
     <div class="box is-shadowless is-fullwidth is-sideless">
       {{#if (eq @param "plaintext")}}
         <h2 class="title is-6">Plaintext</h2>
+        {{! HDS Adoption: Replace with Hds::Copy::Snippet }}
         <div class="copy-text level">
           <code class="level-left">{{@plaintext}}</code>
-          <CopyButton
-            class="button is-compact is-transparent level-right"
+          <Hds::Copy::Button
+            @text="Copy"
+            @isIconOnly={{true}}
+            @textToCopy={{@plaintext}}
+            class="hds-copy-button icon-only"
             data-test-button="modal-copy"
-            @clipboardText={{@plaintext}}
-            @buttonType="button"
-            @success={{action (set-flash-message "Plaintext copied!")}}
-          >
-            <Icon @name="clipboard-copy" aria-label="Copy" />
-          </CopyButton>
+          />
         </div>
         <p class="help has-bottom-margin-m">Plaintext is base64 encoded</p>
         <h2 class="title is-6">Ciphertext</h2>
+        {{! HDS Adoption: Replace with Hds::Copy::Snippet }}
         <div class="copy-text level">
           <code class="level-left">{{@ciphertext}}</code>
-          <CopyButton
-            class="button is-compact is-transparent level-right"
+          <Hds::Copy::Button
+            @text="Copy"
+            @isIconOnly={{true}}
+            @textToCopy={{@ciphertext}}
+            class="hds-copy-button icon-only"
             data-test-button="modal-copy"
-            @clipboardText={{@ciphertext}}
-            @buttonType="button"
-            @success={{action (set-flash-message "Ciphertext copied!")}}
-          >
-            <Icon @name="clipboard-copy" aria-label="Copy" />
-          </CopyButton>
+          />
         </div>
-        <CopyButton
-          class="button is-primary"
-          data-test-button="modal-copy-close"
-          @clipboardText={{@plaintext}}
-          @buttonType="button"
-          @success={{action (set-flash-message "Plaintext copied!")}}
-        >
-          Copy Plaintext
-        </CopyButton>
-        <CopyButton
-          class="button is-primary"
-          data-test-button="modal-copy-close"
-          @clipboardText={{@ciphertext}}
-          @buttonType="button"
-          @success={{action (set-flash-message "Ciphertext copied!")}}
-        >
-          Copy Ciphertext
-        </CopyButton>
-        <button type="submit" class="button is-secondary" onclick={{action (mut @isModalActive) false}}>Close</button>
+        <div class="is-flex-align-baseline has-gap-xxs">
+          <Hds::Copy::Button
+            @text="Copy Plaintext"
+            @textToCopy={{@plaintext}}
+            class="hds-copy-button copy-close white-icon"
+            data-test-button="modal-copy-close"
+          />
+          <Hds::Copy::Button
+            @text="Copy Ciphertext"
+            @textToCopy={{@ciphertext}}
+            class="hds-copy-button copy-close white-icon"
+            data-test-button="modal-copy-close"
+          />
+          <button type="submit" class="button is-secondary" onclick={{action (mut @isModalActive) false}}>Close</button>
+        </div>
       {{else}}
         <h2 class="title is-6">Ciphertext</h2>
+        {{! HDS Adoption: Replace with Hds::Copy::Snippet }}
         <div class="copy-text level">
           <code class="level-left">{{@ciphertext}}</code>
-          <CopyButton
-            class="button is-compact is-transparent level-right"
+          <Hds::Copy::Button
+            @text="Copy"
+            @isIconOnly={{true}}
+            @textToCopy={{@ciphertext}}
+            class="hds-copy-button icon-only"
             data-test-button="modal-copy"
-            @clipboardText={{@ciphertext}}
-            @buttonType="button"
-            @success={{action (set-flash-message "Ciphertext copied!")}}
-          >
-            <Icon @name="clipboard-copy" aria-label="Copy" />
-          </CopyButton>
+          />
         </div>
-        <CopyButton
-          class="button is-primary copy-close"
+        <Hds::Copy::Button
+          @text="Copy & Close"
+          @textToCopy={{@ciphertext}}
+          class="hds-copy-button has-top-margin-m"
           data-test-button="modal-copy-close"
-          @clipboardText={{@ciphertext}}
-          @buttonType="button"
-          @success={{action @toggleModal "Ciphertext copied!"}}
-        >
-          Copy &amp; Close
-        </CopyButton>
+          {{on "click" (fn @toggleModal "Ciphertext copied!")}}
+        />
       {{/if}}
     </div>
   </section>

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -134,7 +134,7 @@
         <Hds::Copy::Button
           @text="Copy & Close"
           @textToCopy={{@ciphertext}}
-          class="hds-copy-button has-top-margin-m"
+          class="hds-copy-button copy-close has-top-margin-m"
           data-test-button="modal-copy-close"
           {{on "click" (fn @toggleModal "Ciphertext copied!")}}
         />

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -107,13 +107,13 @@
           <Hds::Copy::Button
             @text="Copy Plaintext"
             @textToCopy={{@plaintext}}
-            class="hds-copy-button copy-close white-icon"
+            class="hds-copy-button is-primary white-icon"
             data-test-button="modal-copy-close"
           />
           <Hds::Copy::Button
             @text="Copy Ciphertext"
             @textToCopy={{@ciphertext}}
-            class="hds-copy-button copy-close white-icon"
+            class="hds-copy-button is-primary white-icon"
             data-test-button="modal-copy-close"
           />
           <button type="submit" class="button is-secondary" onclick={{action (mut @isModalActive) false}}>Close</button>
@@ -134,7 +134,7 @@
         <Hds::Copy::Button
           @text="Copy & Close"
           @textToCopy={{@ciphertext}}
-          class="hds-copy-button copy-close has-top-margin-m"
+          class="hds-copy-button is-primary has-top-margin-m"
           data-test-button="modal-copy-close"
           {{on "click" (fn @toggleModal "Ciphertext copied!")}}
         />

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -78,7 +78,7 @@
       <Hds::Copy::Button
         @text="Copy & Close"
         @textToCopy={{@plaintext}}
-        class="hds-copy-button"
+        class="hds-copy-button copy-close"
         data-test-button="modal-copy-close"
         {{on "click" (fn @toggleModal "Plaintext copied!")}}
       />

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -60,31 +60,28 @@
     <section class="modal-card-body">
       <div class="box is-shadowless is-fullwidth is-sideless">
         <h2 class="title is-6">Plaintext</h2>
+        {{! HDS Adoption: Replace with Hds::Copy::Snippet }}
         <div class="copy-text level">
           <code class="level-left" data-test-encrypted-value="plaintext">{{@plaintext}}</code>
-          <CopyButton
-            class="button is-compact is-transparent level-right"
+          <Hds::Copy::Button
+            @text="Copy"
+            @isIconOnly={{true}}
+            @textToCopy={{@plaintext}}
+            class="hds-copy-button icon-only"
             data-test-button="modal-copy"
-            @clipboardText={{@plaintext}}
-            @buttonType="button"
-            @success={{action (set-flash-message "Plaintext copied!")}}
-          >
-            <Icon @name="clipboard-copy" aria-label="Copy" />
-          </CopyButton>
+          />
         </div>
         <p class="help">Plaintext is base64 encoded</p>
       </div>
     </section>
     <footer class="modal-card-foot">
-      <CopyButton
-        class="button is-primary copy-close"
+      <Hds::Copy::Button
+        @text="Copy & Close"
+        @textToCopy={{@plaintext}}
+        class="hds-copy-button"
         data-test-button="modal-copy-close"
-        @clipboardText={{@plaintext}}
-        @buttonType="button"
-        @success={{action @toggleModal "Plaintext copied!"}}
-      >
-        Copy &amp; Close
-      </CopyButton>
+        {{on "click" (fn @toggleModal "Plaintext copied!")}}
+      />
     </footer>
   </Modal>
 {{/if}}

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -78,7 +78,7 @@
       <Hds::Copy::Button
         @text="Copy & Close"
         @textToCopy={{@plaintext}}
-        class="hds-copy-button copy-close"
+        class="hds-copy-button is-primary"
         data-test-button="modal-copy-close"
         {{on "click" (fn @toggleModal "Plaintext copied!")}}
       />

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -79,28 +79,25 @@
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Ciphertext</h2>
       <div class="copy-text level">
+        {{! HDS Adoption: Replace with Hds::Copy::Snippet }}
         <code class="level-left" data-test-encrypted-value="ciphertext">{{@ciphertext}}</code>
-        <CopyButton
-          class="button is-compact is-transparent level-right"
+        <Hds::Copy::Button
+          @text="Copy"
+          @isIconOnly={{true}}
+          @textToCopy={{@ciphertext}}
+          class="hds-copy-button icon-only"
           data-test-button="modal-copy"
-          @clipboardText={{@ciphertext}}
-          @buttonType="button"
-          @success={{action (set-flash-message "Ciphertext copied!")}}
-        >
-          <Icon @name="clipboard-copy" aria-label="Copy" />
-        </CopyButton>
+        />
       </div>
     </div>
   </section>
   <footer class="modal-card-foot">
-    <CopyButton
-      class="button is-primary copy-close"
+    <Hds::Copy::Button
+      @text="Copy & Close"
+      @textToCopy={{@ciphertext}}
+      class="hds-copy-button"
       data-test-button="modal-copy-close"
-      @clipboardText={{@ciphertext}}
-      @buttonType="button"
-      @success={{action @toggleModal "Ciphertext copied!"}}
-    >
-      Copy &amp; Close
-    </CopyButton>
+      {{on "click" (fn @toggleModal "Ciphertext copied!")}}
+    />
   </footer>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -78,8 +78,8 @@
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Ciphertext</h2>
+      {{! HDS Adoption: Replace with Hds::Copy::Snippet }}
       <div class="copy-text level">
-        {{! HDS Adoption: Replace with Hds::Copy::Snippet }}
         <code class="level-left" data-test-encrypted-value="ciphertext">{{@ciphertext}}</code>
         <Hds::Copy::Button
           @text="Copy"

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -95,7 +95,7 @@
     <Hds::Copy::Button
       @text="Copy & Close"
       @textToCopy={{@ciphertext}}
-      class="hds-copy-button copy-close"
+      class="hds-copy-button is-primary"
       data-test-button="modal-copy-close"
       {{on "click" (fn @toggleModal "Ciphertext copied!")}}
     />

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -95,7 +95,7 @@
     <Hds::Copy::Button
       @text="Copy & Close"
       @textToCopy={{@ciphertext}}
-      class="hds-copy-button"
+      class="hds-copy-button copy-close"
       data-test-button="modal-copy-close"
       {{on "click" (fn @toggleModal "Ciphertext copied!")}}
     />

--- a/ui/app/templates/components/transit-key-action/export.hbs
+++ b/ui/app/templates/components/transit-key-action/export.hbs
@@ -69,29 +69,30 @@
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Wrapped Key</h2>
+      {{! HDS Adoption: Replace with Hds::Copy::Snippet }}
       <div class="copy-text level">
-        <pre data-test-encrypted-value="export" class="level-left">{{if this.wrapTTL @wrappedToken (stringify @keys)}}</pre>
-        <CopyButton
-          class="button is-compact is-transparent level-right"
+        <code data-test-encrypted-value="export" class="level-left">{{if
+            this.wrapTTL
+            @wrappedToken
+            (stringify @keys)
+          }}</code>
+        <Hds::Copy::Button
+          @text="Copy"
+          @isIconOnly={{true}}
+          @textToCopy={{if this.wrapTTL @wrappedToken (stringify @keys)}}
+          class="hds-copy-button icon-only"
           data-test-button="modal-copy"
-          @clipboardText={{if this.wrapTTL @wrappedToken (stringify @keys)}}
-          @buttonType="button"
-          @success={{action (set-flash-message "Token copied!")}}
-        >
-          <Icon @name="clipboard-copy" aria-label="Copy" />
-        </CopyButton>
+        />
       </div>
     </div>
   </section>
   <footer class="modal-card-foot">
-    <CopyButton
-      class="button is-primary copy-close"
+    <Hds::Copy::Button
+      @text="Copy & Close"
+      @textToCopy={{if this.wrapTTL @wrappedToken (stringify @keys)}}
+      class="hds-copy-button copy-close"
       data-test-button="modal-copy-close"
-      @clipboardText={{if this.wrapTTL @wrappedToken (stringify @keys)}}
-      @buttonType="button"
-      @success={{action @toggleModal "Token copied!"}}
-    >
-      Copy &amp; Close
-    </CopyButton>
+      {{on "click" (fn @toggleModal "Token copied!")}}
+    />
   </footer>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/export.hbs
+++ b/ui/app/templates/components/transit-key-action/export.hbs
@@ -88,7 +88,7 @@
     <Hds::Copy::Button
       @text="Copy & Close"
       @textToCopy={{if this.wrapTTL @wrappedToken (stringify @keys)}}
-      class="hds-copy-button copy-close"
+      class="hds-copy-button is-primary"
       data-test-button="modal-copy-close"
       {{on "click" (fn @toggleModal "Token copied!")}}
     />

--- a/ui/app/templates/components/transit-key-action/export.hbs
+++ b/ui/app/templates/components/transit-key-action/export.hbs
@@ -71,11 +71,9 @@
       <h2 class="title is-6">Wrapped Key</h2>
       {{! HDS Adoption: Replace with Hds::Copy::Snippet }}
       <div class="copy-text level">
-        <code data-test-encrypted-value="export" class="level-left">{{if
-            this.wrapTTL
-            @wrappedToken
-            (stringify @keys)
-          }}</code>
+        <code data-test-encrypted-value="export" class="level-left">
+          {{if this.wrapTTL @wrappedToken (stringify @keys)}}
+        </code>
         <Hds::Copy::Button
           @text="Copy"
           @isIconOnly={{true}}

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -62,7 +62,6 @@
           @text="Copy"
           @isIconOnly={{true}}
           @textToCopy={{@hmac}}
-          c
           class="hds-copy-button icon-only"
           data-test-button="modal-copy"
         />

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -55,29 +55,27 @@
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">HMAC</h2>
+      {{! HDS Adoption: Replace with Hds::Copy::Snippet }}
       <div class="copy-text level">
         <code class="level-left" data-test-encrypted-value="hmac">{{@hmac}}</code>
-        <CopyButton
-          class="button is-compact is-transparent level-right"
+        <Hds::Copy::Button
+          @text="Copy"
+          @isIconOnly={{true}}
+          @textToCopy={{@hmac}}
+          c
+          class="hds-copy-button icon-only"
           data-test-button="modal-copy"
-          @clipboardText={{@hmac}}
-          @buttonType="button"
-          @success={{action (set-flash-message "HMAC copied!")}}
-        >
-          <Icon @name="clipboard-copy" aria-label="Copy" />
-        </CopyButton>
+        />
       </div>
     </div>
   </section>
   <footer class="modal-card-foot">
-    <CopyButton
-      class="button is-primary copy-close"
+    <Hds::Copy::Button
+      @text="Copy & Close"
+      @textToCopy={{@hmac}}
+      class="hds-copy-button"
       data-test-button="modal-copy-close"
-      @clipboardText={{@hmac}}
-      @buttonType="button"
-      @success={{action @toggleModal "HMAC copied!"}}
-    >
-      Copy &amp; Close
-    </CopyButton>
+      {{on "click" (fn @toggleModal "HMAC copied!")}}
+    />
   </footer>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -72,7 +72,7 @@
     <Hds::Copy::Button
       @text="Copy & Close"
       @textToCopy={{@hmac}}
-      class="hds-copy-button"
+      class="hds-copy-button copy-close"
       data-test-button="modal-copy-close"
       {{on "click" (fn @toggleModal "HMAC copied!")}}
     />

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -72,7 +72,7 @@
     <Hds::Copy::Button
       @text="Copy & Close"
       @textToCopy={{@hmac}}
-      class="hds-copy-button copy-close"
+      class="hds-copy-button is-primary"
       data-test-button="modal-copy-close"
       {{on "click" (fn @toggleModal "HMAC copied!")}}
     />

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -84,7 +84,7 @@
     <Hds::Copy::Button
       @text="Copy & Close"
       @textToCopy={{@ciphertext}}
-      class="hds-copy-button"
+      class="hds-copy-button copy-close"
       data-test-button="modal-copy-close"
       {{on "click" (fn @toggleModal "Ciphertext copied!")}}
     />

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -84,7 +84,7 @@
     <Hds::Copy::Button
       @text="Copy & Close"
       @textToCopy={{@ciphertext}}
-      class="hds-copy-button copy-close"
+      class="hds-copy-button is-primary"
       data-test-button="modal-copy-close"
       {{on "click" (fn @toggleModal "Ciphertext copied!")}}
     />

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -69,27 +69,23 @@
       <h2 class="title is-6">Ciphertext</h2>
       <div class="copy-text level">
         <code class="level-left" data-test-encrypted-value="ciphertext">{{@ciphertext}}</code>
-        <CopyButton
-          class="button is-compact is-transparent level-right"
+        <Hds::Copy::Button
+          @text="Copy"
+          @isIconOnly={{true}}
+          @textToCopy={{@ciphertext}}
+          class="hds-copy-button icon-only"
           data-test-button="modal-copy"
-          @clipboardText={{@ciphertext}}
-          @buttonType="button"
-          @success={{action (set-flash-message "Ciphertext copied!")}}
-        >
-          <Icon @name="clipboard-copy" aria-label="Copy" />
-        </CopyButton>
+        />
       </div>
     </div>
   </section>
   <footer class="modal-card-foot">
-    <CopyButton
-      class="button is-primary copy-close"
+    <Hds::Copy::Button
+      @text="Copy & Close"
+      @textToCopy={{@ciphertext}}
+      class="hds-copy-button"
       data-test-button="modal-copy-close"
-      @clipboardText={{@ciphertext}}
-      @buttonType="button"
-      @success={{action @toggleModal "Ciphertext copied!"}}
-    >
-      Copy &amp; Close
-    </CopyButton>
+      {{on "click" (fn @toggleModal "Ciphertext copied!")}}
+    />
   </footer>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -67,6 +67,7 @@
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Ciphertext</h2>
+      {{! HDS Adoption: Replace with Hds::Copy::Snippet }}
       <div class="copy-text level">
         <code class="level-left" data-test-encrypted-value="ciphertext">{{@ciphertext}}</code>
         <Hds::Copy::Button

--- a/ui/app/templates/components/transit-key-action/sign.hbs
+++ b/ui/app/templates/components/transit-key-action/sign.hbs
@@ -129,29 +129,26 @@
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Signature</h2>
+      {{! HDS Adoption: Replace with Hds::Copy::Snippet }}
       <div class="copy-text level">
         <code class="level-left" data-test-encrypted-value="signature">{{@signature}}</code>
-        <CopyButton
-          class="button is-compact is-transparent level-right"
+        <Hds::Copy::Button
+          @text="Copy"
+          @isIconOnly={{true}}
+          @textToCopy={{@signature}}
+          class="hds-copy-button icon-only"
           data-test-button="modal-copy"
-          @clipboardText={{@signature}}
-          @buttonType="button"
-          @success={{action (set-flash-message "Signature copied!")}}
-        >
-          <Icon @name="clipboard-copy" aria-label="Copy" />
-        </CopyButton>
+        />
       </div>
     </div>
   </section>
   <footer class="modal-card-foot">
-    <CopyButton
-      class="button is-primary copy-close"
+    <Hds::Copy::Button
+      @text="Copy & Close"
+      @textToCopy={{@signature}}
+      class="hds-copy-button copy-close"
       data-test-button="modal-copy-close"
-      @clipboardText={{@signature}}
-      @buttonType="button"
-      @success={{action @toggleModal "Signature copied!"}}
-    >
-      Copy &amp; Close
-    </CopyButton>
+      {{on "click" (fn @toggleModal "Signature copied!")}}
+    />
   </footer>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/sign.hbs
+++ b/ui/app/templates/components/transit-key-action/sign.hbs
@@ -146,7 +146,7 @@
     <Hds::Copy::Button
       @text="Copy & Close"
       @textToCopy={{@signature}}
-      class="hds-copy-button copy-close"
+      class="hds-copy-button is-primary"
       data-test-button="modal-copy-close"
       {{on "click" (fn @toggleModal "Signature copied!")}}
     />

--- a/ui/tests/integration/components/transit-key-actions-test.js
+++ b/ui/tests/integration/components/transit-key-actions-test.js
@@ -280,8 +280,8 @@ module('Integration | Component | transit key actions', function (hooks) {
     await click('button[type="submit"]');
     assert.dom('.modal.is-active').exists('Modal opens after export');
     assert.deepEqual(
-      find('.modal [data-test-encrypted-value="export"]').innerText,
-      JSON.stringify(response, null, 2),
+      JSON.parse(find('.modal [data-test-encrypted-value="export"]').innerText),
+      response,
       'prints json response'
     );
   });
@@ -296,8 +296,8 @@ module('Integration | Component | transit key actions', function (hooks) {
     await click('button[type="submit"]');
     assert.dom('.modal.is-active').exists('Modal opens after export');
     assert.deepEqual(
-      find('.modal [data-test-encrypted-value="export"]').innerText,
-      JSON.stringify(response, null, 2),
+      JSON.parse(find('.modal [data-test-encrypted-value="export"]').innerText),
+      response,
       'prints json response'
     );
     assert.deepEqual(


### PR DESCRIPTION
This is the 3rd of 5 subtasks for the replacement of the structure `<CopyButton>` with the `<Hds::Copy::Button>`. In this subtask, I replaced the copy buttons in 7 files, namely the files in ui/app/templates/components/transit-key-action. Photos of each before and after are shown in the comments.

Sticking with the plan of making the HDS copy button look similar to the structure copy button until all buttons are replaced, I created a class to mimic the old style of the "Copy & Close" button you'll see in 6 of the 7 changed files. After this PR and all other subtasks are merged into my side branch, I will get feedback from Design about the implementation.

**NOTE:**
The icon of the `<Hds::Copy::Button>` changes to show success or error when it is clicked. Therefore, with the HDS copy button, there are no longer flash messages for success and error.
But, for the Copy & Close buttons you'll see in this PR, I kept the flash message. This is because when you Copy & Close, the modal closes so you aren't able to see the success icon on the copy button