### PR TITLE
ui: addressing flaky transit backend and userpass tests

### DIFF
--- a/ui/app/templates/components/generated-item.hbs
+++ b/ui/app/templates/components/generated-item.hbs
@@ -79,7 +79,7 @@
           type="submit"
           data-test-save-config="true"
           class="button is-primary {{if this.saveModel.isRunning 'loading'}}"
-          disabled={{or this.saveModel.isRunning this.isFormInvalid}}
+          disabled={{this.saveModel.isRunning}}
         >
           Save
         </button>

--- a/ui/app/templates/components/transit-key-actions.hbs
+++ b/ui/app/templates/components/transit-key-actions.hbs
@@ -11,7 +11,7 @@
       @confirmMessage="After rotation, all key actions will default to using the newest version of the key."
       @confirmButtonText="Rotate"
       @onConfirmAction={{action "doSubmit"}}
-      data-test-transit-key-rotate="true"
+      data-test-transit-key-rotate
     >
       Rotate encryption key
     </ConfirmAction>

--- a/ui/tests/acceptance/auth-list-test.js
+++ b/ui/tests/acceptance/auth-list-test.js
@@ -4,7 +4,7 @@
  */
 
 /* eslint qunit/no-conditional-assertions: "warn" */
-import { click, fillIn, settled, visit, triggerKeyEvent, find, waitUntil } from '@ember/test-helpers';
+import { click, fillIn, settled, visit, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { v4 as uuidv4 } from 'uuid';
@@ -13,74 +13,67 @@ import authPage from 'vault/tests/pages/auth';
 import enablePage from 'vault/tests/pages/settings/auth/enable';
 import { supportedAuthBackends } from 'vault/helpers/supported-auth-backends';
 import { supportedManagedAuthBackends } from 'vault/helpers/supported-managed-auth-backends';
-import { create } from 'ember-cli-page-object';
-import consoleClass from 'vault/tests/pages/components/console/ui-panel';
+import { deleteAuthCmd, mountAuthCmd, runCmd } from 'vault/tests/helpers/commands';
 
-const consoleComponent = create(consoleClass);
-
+const SELECTORS = {
+  backendLink: (path) => `[data-test-auth-backend-link="${path}"]`,
+  createUser: '[data-test-entity-create-link="user"]',
+  input: (attr) => `[data-test-input="${attr}"]`,
+  password: '[data-test-textarea]',
+  saveBtn: '[data-test-save-config]',
+  methods: '[data-test-access-methods]',
+  listItem: '[data-test-list-item-content]',
+};
 module('Acceptance | auth backend list', function (hooks) {
   setupApplicationTest(hooks);
 
-  hooks.beforeEach(function () {
-    return authPage.login();
+  hooks.beforeEach(async function () {
+    await authPage.login();
+    this.path1 = `userpass-${uuidv4()}`;
+    this.path2 = `userpass-${uuidv4()}`;
+    this.user1 = 'user1';
+    this.user2 = 'user2';
+
+    await runCmd(mountAuthCmd('userpass', this.path1));
+    await runCmd(mountAuthCmd('userpass', this.path2));
+  });
+
+  hooks.afterEach(async function () {
+    await authPage.login();
+    await runCmd(deleteAuthCmd(this.path1));
+    await runCmd(deleteAuthCmd(this.path2));
+    return;
   });
 
   test('userpass secret backend', async function (assert) {
-    let n = Math.random();
-    const path1 = `userpass-${++n}`;
-    const path2 = `userpass-${++n}`;
-    const user1 = 'user1';
-    const user2 = 'user2';
+    assert.expect(5);
+    // enable a user in first userpass backend
+    await visit('/vault/access');
+    await click(SELECTORS.backendLink(this.path1));
+    await click(SELECTORS.createUser);
+    await fillIn(SELECTORS.input('username'), this.user1);
+    await fillIn(SELECTORS.password, this.user1);
+    await click(SELECTORS.saveBtn);
+    assert.strictEqual(currentURL(), `/vault/access/${this.path1}/item/user`);
 
-    // enable the first userpass method with one username
-    await enablePage.enable('userpass', path1);
-    await settled();
-    await click('[data-test-save-config="true"]');
+    await click(SELECTORS.methods);
+    assert.strictEqual(currentURL(), '/vault/access');
 
-    await visit(`/vault/access/${path1}/item/user/create`);
-    await waitUntil(() => find('[data-test-input="username"]') && find('[data-test-textarea]'));
-    await fillIn('[data-test-input="username"]', user1);
-    await triggerKeyEvent('[data-test-input="username"]', 'keyup', 65);
-    await fillIn('[data-test-textarea]', user1);
-    await triggerKeyEvent('[data-test-textarea]', 'keyup', 65);
-    await click('[data-test-save-config="true"]');
-
-    // enable the first userpass method with one username
-    await visit(`/vault/settings/auth/enable`);
-
-    await click('[data-test-mount-type="userpass"]');
-
-    await click('[data-test-mount-next]');
-
-    await fillIn('[data-test-input="path"]', path2);
-
-    await click('[data-test-mount-submit="true"]');
-
-    await click('[data-test-save-config="true"]');
-
-    await click(`[data-test-auth-backend-link="${path2}"]`);
-
-    await click('[data-test-entity-create-link="user"]');
-
-    await fillIn('[data-test-input="username"]', user2);
-    await triggerKeyEvent('[data-test-input="username"]', 'keyup', 65);
-    await fillIn('[data-test-textarea]', user2);
-    await triggerKeyEvent('[data-test-textarea]', 'keyup', 65);
-
-    await click('[data-test-save-config="true"]');
+    // enable a user in second userpass backend
+    await click(SELECTORS.backendLink(this.path2));
+    await click(SELECTORS.createUser);
+    await fillIn(SELECTORS.input('username'), this.user2);
+    await fillIn(SELECTORS.password, this.user2);
+    await click(SELECTORS.saveBtn);
+    assert.strictEqual(currentURL(), `/vault/access/${this.path2}/item/user`);
 
     // Confirm that the user was created. There was a bug where the apiPath was not being updated when toggling between auth routes.
-    assert
-      .dom('[data-test-list-item-content]')
-      .hasText(user2, 'user just created shows in current auth list');
+    assert.dom(SELECTORS.listItem).hasText(this.user2, 'user2 exists in the list');
 
     // Confirm that the auth method 1 shows user1. There was a bug where the user was not listed when toggling between auth routes.
-    await click('[data-test-access-methods]');
-    await visit(`/vault/access/${path1}/item/user`);
-
-    assert
-      .dom('[data-test-list-item-content]')
-      .hasText(user1, 'first user created shows in current auth list');
+    await click(SELECTORS.methods);
+    await click(SELECTORS.backendLink(this.path1));
+    assert.dom(SELECTORS.listItem).hasText(this.user1, 'user1 exists in the list');
   });
 
   test('auth methods are linkable and link to correct view', async function (assert) {
@@ -116,7 +109,7 @@ module('Acceptance | auth backend list', function (hooks) {
           .dom('[data-test-auth-section-tab]')
           .exists({ count: expectedTabs }, `has management tabs for ${type} auth method`);
         // cleanup method
-        await consoleComponent.runCommands(`delete sys/auth/${path}`);
+        await runCmd(deleteAuthCmd(path));
       }
     }
   });

--- a/ui/tests/acceptance/transit-test.js
+++ b/ui/tests/acceptance/transit-test.js
@@ -6,13 +6,11 @@
 import { click, fillIn, find, currentURL, settled, visit, waitUntil, findAll } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { create } from 'ember-cli-page-object';
 import { v4 as uuidv4 } from 'uuid';
 
 import { encodeString } from 'vault/utils/b64';
 import authPage from 'vault/tests/pages/auth';
-import consoleClass from 'vault/tests/pages/components/console/ui-panel';
-import { deleteEngineCmd, mountEngineCmd } from '../helpers/commands';
+import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/commands';
 
 const SELECTORS = {
   secretLink: '[data-test-secret-link]',
@@ -26,7 +24,6 @@ const SELECTORS = {
   },
 };
 
-const consoleComponent = create(consoleClass);
 const groupOne = [
   {
     name: (ts) => `aes-convergent-${ts}`,
@@ -316,13 +313,14 @@ module('Acceptance | transit', function (hooks) {
     this.uid = uid;
     this.path = `transit-${uid}`;
 
-    await consoleComponent.runCommands(mountEngineCmd('transit', this.path));
+    await runCmd(mountEngineCmd('transit', this.path));
     // Start test on backend main page
     return visit(`/vault/secrets/${this.path}/list`);
   });
 
-  hooks.afterEach(function () {
-    return consoleComponent.runCommands(deleteEngineCmd(this.path));
+  hooks.afterEach(async function () {
+    await authPage.login();
+    await runCmd(deleteEngineCmd(this.mountPath));
   });
 
   test(`transit backend: list menu`, async function (assert) {


### PR DESCRIPTION
- Separates the larger `keyTypes` array into smaller groups to remove some of the conditionals from the test loop. 
- Changes some assertions from general `assert.ok()` that just return a boolean to clearer methods like `exists()` to more easily track down any future flakiness
- Updates userpass auth test 