### PR TITLE
UI: fix redirect after creating new version of a KV v2 secret in a namespace

### DIFF
--- a/ui/lib/kv/addon/components/page/secret/edit.js
+++ b/ui/lib/kv/addon/components/page/secret/edit.js
@@ -58,10 +58,10 @@ export default class KvSecretEdit extends Component {
       this.invalidFormAlert = invalidFormMessage;
       if (isValid) {
         const { secret } = this.args;
-        yield this.args.secret.save();
+        yield secret.save();
         this.flashMessages.success(`Successfully created new version of ${secret.path}.`);
-        this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.details', {
-          queryParams: { version: this.args.secret?.version },
+        this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.details', secret.path, {
+          queryParams: { version: secret?.version },
         });
       }
     } catch (error) {

--- a/ui/lib/kv/addon/components/page/secret/edit.js
+++ b/ui/lib/kv/addon/components/page/secret/edit.js
@@ -60,8 +60,9 @@ export default class KvSecretEdit extends Component {
         const { secret } = this.args;
         yield this.args.secret.save();
         this.flashMessages.success(`Successfully created new version of ${secret.path}.`);
-        // transition to parent secret route to re-query latest version
-        this.router.transitionTo('vault.cluster.secrets.backend.kv.secret');
+        this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.details', {
+          queryParams: { version: this.args.secret?.version },
+        });
       }
     } catch (error) {
       let message = errorMessage(error);

--- a/ui/lib/kv/addon/components/page/secret/edit.js
+++ b/ui/lib/kv/addon/components/page/secret/edit.js
@@ -60,7 +60,7 @@ export default class KvSecretEdit extends Component {
         const { secret } = this.args;
         yield secret.save();
         this.flashMessages.success(`Successfully created new version of ${secret.path}.`);
-        this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.details', secret.path, {
+        this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.details', {
           queryParams: { version: secret?.version },
         });
       }

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -34,7 +34,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
     assert.dom('[data-test-namespace-link]').doesNotExist('Additional namespace have been cleared');
   });
 
-  test('it shows nested namespaces if you log in with a namspace starting with a /', async function (assert) {
+  test('it shows nested namespaces if you log in with a namespace starting with a /', async function (assert) {
     assert.expect(5);
 
     await click('[data-test-namespace-toggle]');

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-create-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-create-test.js
@@ -867,7 +867,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
       // Back to details page
       assert.strictEqual(
         currentURL(),
-        `/vault/secrets/${backend}/kv/${encodeURIComponent(secretPath)}/details`,
+        `/vault/secrets/${backend}/kv/${encodeURIComponent(secretPath)}/details?version=2`,
         'goes back to details page'
       );
       assert.dom(PAGE.detail.versionTimestamp).doesNotExist('Version created does not show');
@@ -988,7 +988,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
 
       assert.strictEqual(
         currentURL(),
-        `/vault/secrets/${backend}/kv/app%2Ffirst/details`,
+        `/vault/secrets/${backend}/kv/app%2Ffirst/details?version=3`,
         'redirects to details page'
       );
       assert.dom(PAGE.secretRow).doesNotExist('does not show data contents');

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -275,8 +275,9 @@ module('Acceptance | Enterprise | kv-v2 workflow | edge cases', function (hooks)
       return;
     });
     hooks.afterEach(async function () {
-      // special logout method clears the namespace field so test suite doesn't bork
-      return await authPage.logoutNs();
+      // visit logout with namespace query param because we're transitioning from within an engine
+      // and navigating directly to /vault/auth was causing test context routing problems
+      await visit(`/vault/logout?namespace=${this.namespace}`);
     });
 
     test('it can create a new secret version in a namespace', async function (assert) {

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -280,6 +280,7 @@ module('Acceptance | Enterprise | kv-v2 workflow | edge cases', function (hooks)
       // visit logout with namespace query param because we're transitioning from within an engine
       // and navigating directly to /vault/auth caused test context routing problems :(
       await visit(`/vault/logout?namespace=${this.namespace}`);
+      await this.namespaceInput(''); // clear login form namespace input
     });
 
     test('it can create a new secret version in a namespace', async function (assert) {

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -280,7 +280,7 @@ module('Acceptance | Enterprise | kv-v2 workflow | edge cases', function (hooks)
       // visit logout with namespace query param because we're transitioning from within an engine
       // and navigating directly to /vault/auth caused test context routing problems :(
       await visit(`/vault/logout?namespace=${this.namespace}`);
-      await this.namespaceInput(''); // clear login form namespace input
+      await authPage.namespaceInput(''); // clear login form namespace input
     });
 
     test('it can create a new secret version in a namespace', async function (assert) {

--- a/ui/tests/integration/components/kv/page/kv-page-secret-edit-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-edit-test.js
@@ -90,7 +90,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Edit', function (hooks) 
     await fillIn(FORM.maskedValueInput(1), 'bar2');
     await click(FORM.saveBtn);
     assert.ok(
-      this.transitionStub.calledWith('vault.cluster.secrets.backend.kv.secret'),
+      this.transitionStub.calledWith('vault.cluster.secrets.backend.kv.secret.details'),
       'router transitions to parent secret route on save'
     );
   });

--- a/ui/tests/integration/components/kv/page/kv-page-secret-edit-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-edit-test.js
@@ -91,7 +91,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Edit', function (hooks) 
     await click(FORM.saveBtn);
     assert.ok(
       this.transitionStub.calledWith('vault.cluster.secrets.backend.kv.secret.details'),
-      'router transitions to parent secret route on save'
+      'router transitions to secret details route on save'
     );
   });
 

--- a/ui/tests/pages/auth.js
+++ b/ui/tests/pages/auth.js
@@ -58,11 +58,12 @@ export default create({
     await this.tokenInput(rootToken).submit();
     return;
   },
-  logoutNs: async function () {
-    // just navigating to the logout URL wasn't working, so clicking manually
+  clickLogout: async function (clearNamespace = false) {
     await click('[data-test-user-menu-trigger]');
     await click('[data-test-user-menu-content] a#logout');
-    await this.namespaceInput('');
+    if (clearNamespace) {
+      await this.namespaceInput('');
+    }
     return;
   },
 });

--- a/ui/tests/pages/auth.js
+++ b/ui/tests/pages/auth.js
@@ -4,7 +4,7 @@
  */
 
 import { create, visitable, fillable, clickable } from 'ember-cli-page-object';
-import { settled } from '@ember/test-helpers';
+import { click, settled } from '@ember/test-helpers';
 import VAULT_KEYS from 'vault/tests/helpers/vault-keys';
 
 const { rootToken } = VAULT_KEYS;
@@ -56,6 +56,13 @@ export default create({
     await this.namespaceInput(ns);
     await settled();
     await this.tokenInput(rootToken).submit();
+    return;
+  },
+  logoutNs: async function () {
+    // just navigating to the logout URL wasn't working, so clicking manually
+    await click('[data-test-user-menu-trigger]');
+    await click('[data-test-user-menu-content] a#logout');
+    await this.namespaceInput('');
     return;
   },
 });


### PR DESCRIPTION
This fixes an issue in a namespace where the UI was not navigating the latest secret version details view after creating a new secret version.

This was also tested in a namespace with a policy that had `CREATE` but no `READ` capabilities

```shell
# sample policy
path "test-ns-1/kv-ns/data/*" {
  capabilities = [ "create", "update", "list" ]
}

path "test-ns-1/kv-ns/metadata/*" {
  capabilities = [ "create", "update", "list"]
}
```

Add-on to work in this PR: https://github.com/hashicorp/vault/pull/22426