### PR TITLE
Fix broken quotas metrics links

### DIFF
--- a/website/content/docs/concepts/resource-quotas.mdx
+++ b/website/content/docs/concepts/resource-quotas.mdx
@@ -49,7 +49,7 @@ to a non-zero value, any client that hits a rate limit threshold will be blocked
 from all subsequent requests for a duration of `block_interval` seconds.
 
 Vault also allows the inspection of the state of rate limiting in a Vault node
-through various [metrics](/vault/docs/internals/telemetry#Resource-Quota-Metrics) exposed
+through various [metrics](/vault/docs/internals/telemetry/metrics/core-system#quota-metrics) exposed
 and through enabling optional audit logging.
 
 ## Exempt routes

--- a/website/content/docs/enterprise/lease-count-quotas.mdx
+++ b/website/content/docs/enterprise/lease-count-quotas.mdx
@@ -46,7 +46,7 @@ further restrict usages in a specific namespace or mount, that can be done
 using the precedence model too.
 
 Vault also allows the inspection into the state of lease count quotas in a Vault
-cluster through various [metrics](/vault/docs/internals/telemetry#Resource-Quota-Metrics)
+cluster through various [metrics](/vault/docs/internals/telemetry/metrics/core-system#quota-metrics)
 exposed and through enabling optional audit logging.
 
 ## Tutorial


### PR DESCRIPTION
Correct link: https://developer.hashicorp.com/vault/docs/internals/telemetry/metrics/core-system#quota-metrics

Incorrect link: https://developer.hashicorp.com/vault/docs/internals/telemetry#Resource-Quota-Metrics