### PR TITLE
Sync CE with Ent: improve slack notifications for test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,9 +273,10 @@ jobs:
       always() &&
       github.repository == 'hashicorp/vault' &&
       (needs.test-go.result == 'failure' ||
-      needs.test-go-fips.result == 'failure' ||
-      needs.test-go-race.result == 'failure') &&
-      (github.ref_name == 'main' || startsWith(github.ref_name, 'release/'))
+      needs.test-go-testonly.result == 'failure' ||
+      needs.test-go-race.result == 'failure' ||
+      needs.test-ui.result == 'failure'
+      ) && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/'))
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -284,8 +285,9 @@ jobs:
       fail-fast: false
     needs:
       - test-go
-      - test-go-fips
+      - test-go-testonly
       - test-go-race
+      - test-ui
     steps:
       - name: send-notification
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
@@ -296,16 +298,49 @@ jobs:
         with:
           channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
           payload: |
-            {"text":"OSS test failures on ${{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":rotating_light: OSS test failures :rotating_light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"test(s) failed on ${{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
+            {
+              "text": "OSS test failures on ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":rotating_light: OSS test failures :rotating_light:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CI failed on ${{ github.ref_name }}, go: ${{ needs.test-go.result }}, race: ${{ needs.test-go-race.result }}, testonly: ${{ needs.test-go-testonly.result }}: ui: ${{ needs.test-ui.result }}"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "View Failing Workflow",
+                      "emoji": true
+                    },
+                    "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
 
   notify-tests-completed-failures-ent:
     if: |
       always() &&
       github.repository == 'hashicorp/vault-enterprise' &&
       (needs.test-go.result == 'failure' ||
+      needs.test-go-testonly.result == 'failure' ||
       needs.test-go-fips.result == 'failure' ||
-      needs.test-go-race.result == 'failure') &&
-      (github.ref_name == 'main' || startsWith(github.ref_name, 'release/'))
+      needs.test-go-race.result == 'failure' ||
+      needs.test-ui.result == 'failure'
+      ) && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/'))
     runs-on: ['self-hosted', 'linux', 'small']
     permissions:
       id-token: write
@@ -314,8 +349,10 @@ jobs:
       fail-fast: false
     needs:
       - test-go
-      - test-go-fips
+      - test-go-testonly
       - test-go-race
+      - test-go-fips
+      - test-ui
     steps:
       - id: vault-auth
         name: Vault Authenticate
@@ -332,10 +369,41 @@ jobs:
       - name: send-notification
         uses: hashicorp/cloud-gha-slack-notifier@730a033037b8e603adf99ebd3085f0fdfe75e2f4 #v1
         with:
-          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official
+          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official, use "C05Q4D5V89W"/test-vault-ci-slack-integration for testing
           slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
           payload: |
-            {"text":"Enterprise test failures on ${{ github.ref_name }}","blocks":[{"type":"header","text":{"type":"plain_text","text":":rotating_light: Enterprise test failures :rotating_light:","emoji":true}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"test(s) failed on ${{ github.ref_name }}"},"accessory":{"type":"button","text":{"type":"plain_text","text":"View Failing Workflow","emoji":true},"url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}}]}
+            {
+              "text": "Enterprise test failures on ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":rotating_light: Enterprise test failures :rotating_light:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CI failed on ${{ github.ref_name }}, go: ${{ needs.test-go.result }}, fips: ${{ needs.test-go-fips.result }}, race: ${{ needs.test-go-race.result }}, testonly: ${{ needs.test-go-testonly.result }}, ui: ${{ needs.test-ui.result }}"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "View Failing Workflow",
+                      "emoji": true
+                    },
+                    "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
 
   test-summary:
     name: Go test failures


### PR DESCRIPTION
I accidentally merged this on the ent side (#4597), but meant to apply it to OSS instead.  This PR consists simply of copying the ci.yml from #4597.