### PR TITLE
New-line and emojify test output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
       - run: |
           tr -d '\n' <<< '${{ toJSON(needs.*.result) }}' | grep -q -v -E '(failure|cancelled)'
 
-  notify-tests-completed-failures-oss:
+  notify-tests-completed-failures-ce:
     if:  |
       always() &&
       github.repository == 'hashicorp/vault' &&
@@ -276,8 +276,7 @@ jobs:
       needs.test-go-testonly.result == 'failure' ||
       needs.test-go-race.result == 'failure' ||
       needs.test-ui.result == 'failure'
-      )
-    # && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/'))
+      ) && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/'))
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -297,7 +296,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
-          channel-id: "C05Q4D5V89W" # sent to #feed-vault-ci-official, use "C05Q4D5V89W"/test-vault-ci-slack-integration for testing
+          channel-id: "C05AABYEA9Y" # sent to #feed-vault-ci-official, use "C05Q4D5V89W"/test-vault-ci-slack-integration for testing
           payload: |
             {
               "text": "CE test failures on ${{ github.ref_name }}",

--- a/vault/quotas/quotas_rate_limit_test.go
+++ b/vault/quotas/quotas_rate_limit_test.go
@@ -131,7 +131,6 @@ func TestRateLimitQuota_Allow(t *testing.T) {
 }
 
 func TestRateLimitQuota_Allow_WithBlock(t *testing.T) {
-	t.Fatal("TODO: Remove me. This is added to test CI")
 	rlq := &RateLimitQuota{
 		Name:          "test-rate-limiter",
 		Type:          TypeRateLimit,


### PR DESCRIPTION
I've made an update to the test output for our tests, to make it cleaner to read. This does have the effect of increasing the amount of lines, but we've collectively decided this was worthwhile.

Example output:
<img width="676" alt="image" src="https://github.com/hashicorp/vault/assets/1594272/d031aa89-59a8-43fa-977b-c7d6f1ea06c5">
