### PR TITLE
Refactor plugin catalog set functions

### DIFF
--- a/sdk/helper/pluginutil/runner.go
+++ b/sdk/helper/pluginutil/runner.go
@@ -61,6 +61,20 @@ type PluginRunner struct {
 	BuiltinFactory func() (interface{}, error) `json:"-" structs:"-"`
 }
 
+// SetPluginInput is only used as input for the plugin catalog's set methods.
+// We don't use the very similar PluginRunner struct to avoid confusion about
+// what's settable, which does not include the builtin fields.
+type SetPluginInput struct {
+	Name     string
+	Type     consts.PluginType
+	Version  string
+	Command  string
+	OCIImage string
+	Args     []string
+	Env      []string
+	Sha256   []byte
+}
+
 // Run takes a wrapper RunnerUtil instance along with the go-plugin parameters and
 // returns a configured plugin.Client with TLS Configured and a wrapping token set
 // on PluginUnwrapTokenEnv for plugin process consumption.

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -560,7 +560,7 @@ func (b *SystemBackend) handlePluginCatalogUpdate(ctx context.Context, _ *logica
 		Name:    pluginName,
 		Type:    pluginType,
 		Version: pluginVersion,
-		Command: command,
+		Command: parts[0],
 		Args:    args,
 		Env:     env,
 		Sha256:  sha256Bytes,

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -556,7 +556,15 @@ func (b *SystemBackend) handlePluginCatalogUpdate(ctx context.Context, _ *logica
 		return logical.ErrorResponse("Could not decode SHA-256 value from Hex"), err
 	}
 
-	err = b.Core.pluginCatalog.Set(ctx, pluginName, pluginType, pluginVersion, parts[0], args, env, sha256Bytes)
+	err = b.Core.pluginCatalog.Set(ctx, pluginutil.SetPluginInput{
+		Name:    pluginName,
+		Type:    pluginType,
+		Version: pluginVersion,
+		Command: command,
+		Args:    args,
+		Env:     env,
+		Sha256:  sha256Bytes,
+	})
 	if err != nil {
 		if errors.Is(err, ErrPluginNotFound) || strings.HasPrefix(err.Error(), "plugin version mismatch") {
 			return logical.ErrorResponse(err.Error()), nil

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -2189,7 +2189,15 @@ func TestSystemBackend_tuneAuth(t *testing.T) {
 		if err := file.Close(); err != nil {
 			t.Fatal(err)
 		}
-		err = c.pluginCatalog.Set(context.Background(), "token", consts.PluginTypeCredential, "v1.0.0", "foo", []string{}, []string{}, []byte{})
+		err = c.pluginCatalog.Set(context.Background(), pluginutil.SetPluginInput{
+			Name:    "token",
+			Type:    consts.PluginTypeCredential,
+			Version: "v1.0.0",
+			Command: "foo",
+			Args:    []string{},
+			Env:     []string{},
+			Sha256:  []byte{},
+		})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -5742,7 +5750,15 @@ func TestValidateVersion_HelpfulErrorWhenBuiltinOverridden(t *testing.T) {
 	defer file.Close()
 
 	command := filepath.Base(file.Name())
-	err = core.pluginCatalog.Set(context.Background(), "kubernetes", consts.PluginTypeCredential, "", command, nil, nil, nil)
+	err = core.pluginCatalog.Set(context.Background(), pluginutil.SetPluginInput{
+		Name:    "kubernetes",
+		Type:    consts.PluginTypeCredential,
+		Version: "",
+		Command: command,
+		Args:    nil,
+		Env:     nil,
+		Sha256:  nil,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/plugin_catalog_test.go
+++ b/vault/plugin_catalog_test.go
@@ -79,7 +79,15 @@ func TestPluginCatalog_CRUD(t *testing.T) {
 	defer file.Close()
 
 	command := filepath.Base(file.Name())
-	err = core.pluginCatalog.Set(context.Background(), pluginName, consts.PluginTypeDatabase, "", command, []string{"--test"}, []string{"FOO=BAR"}, []byte{'1'})
+	err = core.pluginCatalog.Set(context.Background(), pluginutil.SetPluginInput{
+		Name:    pluginName,
+		Type:    consts.PluginTypeDatabase,
+		Version: "",
+		Command: command,
+		Args:    []string{"--test"},
+		Env:     []string{"FOO=BAR"},
+		Sha256:  []byte{'1'},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +171,15 @@ func TestPluginCatalog_VersionedCRUD(t *testing.T) {
 	const name = "mysql-database-plugin"
 	const version = "1.0.0"
 	command := fmt.Sprintf("%s", filepath.Base(file.Name()))
-	err = core.pluginCatalog.Set(context.Background(), name, consts.PluginTypeDatabase, version, command, []string{"--test"}, []string{"FOO=BAR"}, []byte{'1'})
+	err = core.pluginCatalog.Set(context.Background(), pluginutil.SetPluginInput{
+		Name:    name,
+		Type:    consts.PluginTypeDatabase,
+		Version: version,
+		Command: command,
+		Args:    []string{"--test"},
+		Env:     []string{"FOO=BAR"},
+		Sha256:  []byte{'1'},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,13 +286,29 @@ func TestPluginCatalog_List(t *testing.T) {
 	defer file.Close()
 
 	command := filepath.Base(file.Name())
-	err = core.pluginCatalog.Set(context.Background(), "mysql-database-plugin", consts.PluginTypeDatabase, "", command, []string{"--test"}, []string{}, []byte{'1'})
+	err = core.pluginCatalog.Set(context.Background(), pluginutil.SetPluginInput{
+		Name:    "mysql-database-plugin",
+		Type:    consts.PluginTypeDatabase,
+		Version: "",
+		Command: command,
+		Args:    []string{"--test"},
+		Env:     []string{},
+		Sha256:  []byte{'1'},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Set another plugin
-	err = core.pluginCatalog.Set(context.Background(), "aaaaaaa", consts.PluginTypeDatabase, "", command, []string{"--test"}, []string{}, []byte{'1'})
+	err = core.pluginCatalog.Set(context.Background(), pluginutil.SetPluginInput{
+		Name:    "aaaaaaa",
+		Type:    consts.PluginTypeDatabase,
+		Version: "",
+		Command: command,
+		Args:    []string{"--test"},
+		Env:     []string{},
+		Sha256:  []byte{'1'},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -341,31 +373,29 @@ func TestPluginCatalog_ListVersionedPlugins(t *testing.T) {
 	defer file.Close()
 
 	command := filepath.Base(file.Name())
-	err = core.pluginCatalog.Set(
-		context.Background(),
-		"mysql-database-plugin",
-		consts.PluginTypeDatabase,
-		"",
-		command,
-		[]string{"--test"},
-		[]string{},
-		[]byte{'1'},
-	)
+	err = core.pluginCatalog.Set(context.Background(), pluginutil.SetPluginInput{
+		Name:    "mysql-database-plugin",
+		Type:    consts.PluginTypeDatabase,
+		Version: "",
+		Command: command,
+		Args:    []string{"--test"},
+		Env:     []string{},
+		Sha256:  []byte{'1'},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Set another plugin, with version information
-	err = core.pluginCatalog.Set(
-		context.Background(),
-		"aaaaaaa",
-		consts.PluginTypeDatabase,
-		"1.1.0",
-		command,
-		[]string{"--test"},
-		[]string{},
-		[]byte{'1'},
-	)
+	err = core.pluginCatalog.Set(context.Background(), pluginutil.SetPluginInput{
+		Name:    "aaaaaaa",
+		Type:    consts.PluginTypeDatabase,
+		Version: "1.1.0",
+		Command: command,
+		Args:    []string{"--test"},
+		Env:     []string{},
+		Sha256:  []byte{'1'},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -458,7 +488,15 @@ func TestPluginCatalog_ListHandlesPluginNamesWithSlashes(t *testing.T) {
 		},
 	}
 	for _, entry := range pluginsToRegister {
-		err = core.pluginCatalog.Set(ctx, entry.Name, consts.PluginTypeCredential, entry.Version, command, nil, nil, nil)
+		err = core.pluginCatalog.Set(ctx, pluginutil.SetPluginInput{
+			Name:    entry.Name,
+			Type:    consts.PluginTypeCredential,
+			Version: entry.Version,
+			Command: command,
+			Args:    nil,
+			Env:     nil,
+			Sha256:  nil,
+		})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -593,7 +593,15 @@ func TestAddTestPlugin(t testing.T, c *Core, name string, pluginType consts.Plug
 	c.pluginCatalog.directory = fullPath
 
 	args := []string{fmt.Sprintf("--test.run=%s", testFunc)}
-	err = c.pluginCatalog.Set(context.Background(), name, pluginType, version, fileName, args, env, sum)
+	err = c.pluginCatalog.Set(context.Background(), pluginutil.SetPluginInput{
+		Name:    name,
+		Type:    pluginType,
+		Version: version,
+		Command: fileName,
+		Args:    args,
+		Env:     env,
+		Sha256:  sum,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Use a struct arg instead of a long list of args. Plugins running in containers will require even more args and it's getting difficult to maintain.