### PR TITLE
Adds adjustment factor for assertions in auth enable tests

### DIFF
--- a/command/auth_enable_test.go
+++ b/command/auth_enable_test.go
@@ -14,6 +14,12 @@ import (
 	"github.com/mitchellh/cli"
 )
 
+// credentialBackendAdjustmentFactor allows for adjusting test assertions credential backends.
+// Add 1 to account for the "token" backend, which is visible when you walk the filesystem but
+// is treated as special and excluded from the registry. Subtract 1 to account for "oidc" which
+// is an alias of "jwt" and not a separate plugin.
+var credentialBackendAdjustmentFactor = 1 - 1
+
 func testAuthEnableCommand(tb testing.TB) (*cli.MockUi, *AuthEnableCommand) {
 	tb.Helper()
 
@@ -205,10 +211,7 @@ func TestAuthEnableCommand_Run(t *testing.T) {
 		// of credential backends.
 		backends = append(backends, "pcf")
 
-		// Add 1 to account for the "token" backend, which is visible when you walk the filesystem but
-		// is treated as special and excluded from the registry.
-		// Subtract 1 to account for "oidc" which is an alias of "jwt" and not a separate plugin.
-		expected := len(builtinplugins.Registry.Keys(consts.PluginTypeCredential))
+		expected := len(builtinplugins.Registry.Keys(consts.PluginTypeCredential)) + credentialBackendAdjustmentFactor
 		if len(backends) != expected {
 			t.Fatalf("expected %d credential backends, got %d", expected, len(backends))
 		}

--- a/command/auth_enable_test.go
+++ b/command/auth_enable_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-// credentialBackendAdjustmentFactor allows for adjusting test assertions credential backends.
-// Add 1 to account for the "token" backend, which is visible when you walk the filesystem but
-// is treated as special and excluded from the registry. Subtract 1 to account for "oidc" which
-// is an alias of "jwt" and not a separate plugin.
+// credentialBackendAdjustmentFactor allows for adjusting test assertions for
+// credential backends. Add 1 to account for the "token" backend, which is visible
+// when you walk the filesystem but is treated as special and excluded from the registry.
+// Subtract 1 to account for "oidc" which is an alias of "jwt" and not a separate plugin.
 var credentialBackendAdjustmentFactor = 1 - 1
 
 func testAuthEnableCommand(tb testing.TB) (*cli.MockUi, *AuthEnableCommand) {


### PR DESCRIPTION
This PR adds an adjustment factor for assertions in auth enable tests. This will allow for adjustments to the test assertions when enterprise auth methods are added.

This follows a similar pattern as https://github.com/hashicorp/vault/blob/main/command/secrets_enable_test.go#L19-L22.