### PR TITLE
ui: Refreshes parent route to fix secret state discrepancies within a namespace for kv v2 

### DIFF
--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -10,7 +10,13 @@
 
   <:toolbarFilters>
     {{#unless this.emptyState}}
-      <Toggle @name="json" @status="success" @size="small" @checked={{this.showJsonView}} @onChange={{this.toggleJsonView}}>
+      <Toggle
+        @name="json"
+        @status="success"
+        @size="small"
+        @checked={{this.showJsonView}}
+        @onChange={{fn (mut this.showJsonView)}}
+      >
         <span class="has-text-grey">JSON</span>
       </Toggle>
     {{/unless}}

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -69,7 +69,6 @@ export default class KvSecretDetails extends Component {
       await secret.destroyRecord({
         adapterOptions: { deleteType: 'undelete', deleteVersions: this.version },
       });
-      this.store.clearDataset('kv/metadata'); // Clear out the store cache so that the metadata/list view is updated.
       this.flashMessages.success(`Successfully undeleted ${secret.path}.`);
       this.refreshRoute();
     } catch (err) {
@@ -84,7 +83,6 @@ export default class KvSecretDetails extends Component {
     const { secret } = this.args;
     try {
       await secret.destroyRecord({ adapterOptions: { deleteType: type, deleteVersions: this.version } });
-      this.store.clearDataset('kv/metadata'); // Clear out the store cache so that the metadata/list view is updated.
       this.flashMessages.success(`Successfully ${secret.state} Version ${this.version} of ${secret.path}.`);
       this.refreshRoute();
     } catch (err) {

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -71,9 +71,7 @@ export default class KvSecretDetails extends Component {
       });
       this.store.clearDataset('kv/metadata'); // Clear out the store cache so that the metadata/list view is updated.
       this.flashMessages.success(`Successfully undeleted ${secret.path}.`);
-      this.router.transitionTo('vault.cluster.secrets.backend.kv.secret', {
-        queryParams: { version: this.version },
-      });
+      this.transition();
     } catch (err) {
       this.flashMessages.danger(
         `There was a problem undeleting ${secret.path}. Error: ${err.errors.join(' ')}.`
@@ -88,9 +86,7 @@ export default class KvSecretDetails extends Component {
       await secret.destroyRecord({ adapterOptions: { deleteType: type, deleteVersions: this.version } });
       this.store.clearDataset('kv/metadata'); // Clear out the store cache so that the metadata/list view is updated.
       this.flashMessages.success(`Successfully ${secret.state} Version ${this.version} of ${secret.path}.`);
-      this.router.transitionTo('vault.cluster.secrets.backend.kv.secret', {
-        queryParams: { version: this.version },
-      });
+      this.transition();
     } catch (err) {
       const verb = type.includes('delete') ? 'deleting' : 'destroying';
       this.flashMessages.danger(
@@ -99,6 +95,12 @@ export default class KvSecretDetails extends Component {
         )}.`
       );
     }
+  }
+
+  transition() {
+    this.router.transitionTo('vault.cluster.secrets.backend.kv.secret', {
+      queryParams: { version: this.version },
+    });
   }
 
   get version() {

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -36,11 +36,6 @@ export default class KvSecretDetails extends Component {
   @tracked wrappedData = null;
 
   @action
-  toggleJsonView() {
-    this.showJsonView = !this.showJsonView;
-  }
-
-  @action
   closeVersionMenu(dropdown) {
     // strange issue where closing dropdown triggers full transition (which redirects to auth screen in production)
     // closing dropdown in next tick of run loop fixes it

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -71,7 +71,7 @@ export default class KvSecretDetails extends Component {
       });
       this.store.clearDataset('kv/metadata'); // Clear out the store cache so that the metadata/list view is updated.
       this.flashMessages.success(`Successfully undeleted ${secret.path}.`);
-      this.transition();
+      this.refreshRoute();
     } catch (err) {
       this.flashMessages.danger(
         `There was a problem undeleting ${secret.path}. Error: ${err.errors.join(' ')}.`
@@ -86,7 +86,7 @@ export default class KvSecretDetails extends Component {
       await secret.destroyRecord({ adapterOptions: { deleteType: type, deleteVersions: this.version } });
       this.store.clearDataset('kv/metadata'); // Clear out the store cache so that the metadata/list view is updated.
       this.flashMessages.success(`Successfully ${secret.state} Version ${this.version} of ${secret.path}.`);
-      this.transition();
+      this.refreshRoute();
     } catch (err) {
       const verb = type.includes('delete') ? 'deleting' : 'destroying';
       this.flashMessages.danger(
@@ -97,7 +97,8 @@ export default class KvSecretDetails extends Component {
     }
   }
 
-  transition() {
+  refreshRoute() {
+    // transition to the parent secret route to refresh both metadata and data models
     this.router.transitionTo('vault.cluster.secrets.backend.kv.secret', {
       queryParams: { version: this.version },
     });

--- a/ui/lib/kv/addon/components/page/secret/edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/edit.hbs
@@ -1,6 +1,12 @@
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle="Create New Version">
   <:toolbarFilters>
-    <Toggle @name="json" @status="success" @size="small" @checked={{this.showJsonView}} @onChange={{this.toggleJsonView}}>
+    <Toggle
+      @name="json"
+      @status="success"
+      @size="small"
+      @checked={{this.showJsonView}}
+      @onChange={{fn (mut this.showJsonView)}}
+    >
       <span class="has-text-grey">JSON</span>
     </Toggle>
   </:toolbarFilters>

--- a/ui/lib/kv/addon/components/page/secret/edit.js
+++ b/ui/lib/kv/addon/components/page/secret/edit.js
@@ -68,11 +68,6 @@ export default class KvSecretEdit extends Component {
       : JSON.stringify(newData, undefined, 2);
   }
 
-  @action
-  toggleJsonView() {
-    this.showJsonView = !this.showJsonView;
-  }
-
   @task
   *save(event) {
     event.preventDefault();

--- a/ui/lib/kv/addon/components/page/secrets/create.hbs
+++ b/ui/lib/kv/addon/components/page/secrets/create.hbs
@@ -1,6 +1,12 @@
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle="Create Secret">
   <:toolbarFilters>
-    <Toggle @name="json" @status="success" @size="small" @checked={{this.showJsonView}} @onChange={{this.toggleJsonView}}>
+    <Toggle
+      @name="json"
+      @status="success"
+      @size="small"
+      @checked={{this.showJsonView}}
+      @onChange={{fn (mut this.showJsonView)}}
+    >
       <span class="has-text-grey">JSON</span>
     </Toggle>
   </:toolbarFilters>

--- a/ui/lib/kv/addon/components/page/secrets/create.js
+++ b/ui/lib/kv/addon/components/page/secrets/create.js
@@ -37,11 +37,6 @@ export default class KvSecretCreate extends Component {
   @tracked invalidFormAlert;
 
   @action
-  toggleJsonView() {
-    this.showJsonView = !this.showJsonView;
-  }
-
-  @action
   pathValidations() {
     // check path attribute warnings on key up
     const { state } = this.args.secret.validate();

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -6,6 +6,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
+import { action } from '@ember/object';
 
 export default class KvSecretRoute extends Route {
   @service secretMountPath;
@@ -31,5 +32,13 @@ export default class KvSecretRoute extends Route {
       secret: this.fetchSecretData(backend, path),
       metadata: this.fetchSecretMetadata(backend, path),
     });
+  }
+
+  @action
+  willTransition(transition) {
+    const { to, from } = transition;
+    if (to.name === 'vault.cluster.secrets.backend.kv.secret.index' || from.localName === 'edit') {
+      this.refresh();
+    }
   }
 }

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -36,8 +36,11 @@ export default class KvSecretRoute extends Route {
 
   @action
   willTransition(transition) {
-    const { to, from } = transition;
-    if (to.name === 'vault.cluster.secrets.backend.kv.secret.index' || from.localName === 'edit') {
+    // refresh the route if transitioning to secret.index (which happens after delete, undelete or destroy)
+    // or transitioning from editing either metadata or secret data (creating a new version)
+    const performedToolbarAction = transition.to.name === 'vault.cluster.secrets.backend.kv.secret.index';
+    const afterEditing = transition.from.localName === 'edit';
+    if (performedToolbarAction || afterEditing) {
       this.refresh();
     }
   }

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -38,9 +38,9 @@ export default class KvSecretRoute extends Route {
   willTransition(transition) {
     // refresh the route if transitioning to secret.index (which happens after delete, undelete or destroy)
     // or transitioning from editing either metadata or secret data (creating a new version)
-    const performedToolbarAction = transition.to.name === 'vault.cluster.secrets.backend.kv.secret.index';
-    const afterEditing = transition.from.localName === 'edit';
-    if (performedToolbarAction || afterEditing) {
+    const isToIndex = transition.to.name === 'vault.cluster.secrets.backend.kv.secret.index';
+    const isFromEdit = transition.from.localName === 'edit';
+    if (isToIndex || isFromEdit) {
       this.refresh();
     }
   }

--- a/ui/lib/kv/addon/routes/secret/details.js
+++ b/ui/lib/kv/addon/routes/secret/details.js
@@ -36,6 +36,7 @@ export default class KvSecretDetailsRoute extends Route {
     return parentModel;
   }
 
+  // breadcrumbs are set in details/index.js
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     const { version } = this.paramsFor(this.routeName);

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -243,6 +243,7 @@ module('Acceptance | kv-v2 workflow | edge cases', function (hooks) {
   });
 });
 
+// NAMESPACE TESTS
 module('Acceptance | Enterprise | kv-v2 workflow | edge cases', function (hooks) {
   setupApplicationTest(hooks);
 
@@ -250,12 +251,34 @@ module('Acceptance | Enterprise | kv-v2 workflow | edge cases', function (hooks)
     await click('[data-test-sidebar-nav-link="Secrets engines"]');
     return await click(PAGE.backends.link(backend));
   };
+
+  const assertDeleteActions = (assert, expected = ['delete', 'destroy']) => {
+    ['delete', 'destroy', 'undelete'].forEach((toolbar) => {
+      if (expected.includes(toolbar)) {
+        assert.dom(PAGE.detail[toolbar]).exists(`${toolbar} toolbar action exists`);
+      } else {
+        assert.dom(PAGE.detail[toolbar]).doesNotExist(`${toolbar} toolbar action not rendered`);
+      }
+    });
+  };
+
+  const assertVersionDropdown = async (assert, deleted = [], versions = [2, 1]) => {
+    assert.dom(PAGE.detail.versionDropdown).hasText(`Version ${versions[0]}`);
+    await click(PAGE.detail.versionDropdown);
+    versions.forEach((num) => {
+      assert.dom(PAGE.detail.version(num)).exists(`renders version ${num} link in dropdown`);
+    });
+    deleted.forEach((num) => {
+      assert.dom(`${PAGE.detail.version(num)} [data-test-icon="x-square"]`);
+    });
+  };
+
+  // each test uses a different secret path
   hooks.beforeEach(async function () {
     const uid = uuidv4();
     this.store = this.owner.lookup('service:store');
     this.backend = `kv-enterprise-edge-${uid}`;
     this.namespace = `ns-${uid}`;
-    this.secretPath = 'my-secret';
     await authPage.login();
     await runCmd([`write sys/namespaces/${this.namespace} -force`]);
     return;
@@ -283,11 +306,11 @@ module('Acceptance | Enterprise | kv-v2 workflow | edge cases', function (hooks)
       await authPage.namespaceInput(''); // clear login form namespace input
     });
 
-    test('it can create a new secret version in a namespace', async function (assert) {
+    test('namespace: it can create a secret and new secret version', async function (assert) {
       assert.expect(15);
       const backend = this.backend;
       const ns = this.namespace;
-      const secret = this.secretPath;
+      const secret = 'my-create-secret';
       await navToEngine(backend);
       assert.strictEqual(
         currentURL(),
@@ -324,16 +347,61 @@ module('Acceptance | Enterprise | kv-v2 workflow | edge cases', function (hooks)
         `/vault/secrets/${backend}/kv/${secret}/details?namespace=${ns}&version=2`,
         'navigates to details'
       );
-      assert.dom(PAGE.detail.versionDropdown).hasText('Version 2');
-      await click(PAGE.detail.versionDropdown);
-      assert.dom(PAGE.detail.version(1)).exists('renders version 1 link in dropdown');
-      assert.dom(PAGE.detail.version(2)).exists('renders version 2 link in dropdown');
+      await assertVersionDropdown(assert);
       assert
         .dom(`${PAGE.detail.version(2)} [data-test-icon="check-circle"]`)
         .exists('renders current version icon');
       assert.dom(PAGE.infoRowValue('foo-two')).hasText('***********');
       await click(PAGE.infoRowToggleMasked('foo-two'));
       assert.dom(PAGE.infoRowValue('foo-two')).hasText('supersecret', 'secret value shows after toggle');
+    });
+
+    test('namespace: it manages state throughout delete and undelete operations', async function (assert) {
+      assert.expect(23);
+      const backend = this.backend;
+      const ns = this.namespace;
+      const secret = 'my-delete-secret';
+      await writeVersionedSecret(backend, secret, 'foo', 'bar', 2, ns);
+      await navToEngine(backend);
+
+      await click(PAGE.list.item(secret));
+      assert.strictEqual(
+        currentURL(),
+        `/vault/secrets/${backend}/kv/${secret}/details?namespace=${ns}&version=2`,
+        'navigates to details'
+      );
+
+      // correct toolbar options & details show
+      assertDeleteActions(assert);
+      await assertVersionDropdown(assert);
+      // delete flow
+      await click(PAGE.detail.delete);
+      await click(PAGE.detail.deleteOption);
+      await click(PAGE.detail.deleteConfirm);
+      // check empty state and toolbar
+      assertDeleteActions(assert, ['undelete', 'destroy']);
+      assert
+        .dom(PAGE.emptyStateTitle)
+        .hasText('Version 2 of this secret has been deleted', 'Shows deleted message');
+      assert.dom(PAGE.detail.versionTimestamp).includesText('Version 2 deleted');
+      await assertVersionDropdown(assert, [2]); // important to test dropdown versions are accurate
+
+      // navigate to sibling route to make sure empty state remains for details tab
+      await click(PAGE.secretTab('Version History'));
+      assert.dom(PAGE.versions.linkedBlock()).exists({ count: 2 });
+
+      // back to secret tab to confirm deleted state
+      await click(PAGE.secretTab('Secret'));
+      // if this assertion fails, the view is rendering a stale model
+      assert.dom(PAGE.emptyStateTitle).exists('still renders empty state!!');
+      await assertVersionDropdown(assert, [2]);
+
+      // undelete flow
+      await click(PAGE.detail.undelete);
+      // details update accordingly
+      assert.dom(PAGE.infoRow).exists('shows secret data');
+      assert.dom(PAGE.detail.versionTimestamp).includesText('Version 2 created');
+      assertDeleteActions(assert, ['delete', 'destroy']);
     });
   });
 });

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -284,7 +284,7 @@ module('Acceptance | Enterprise | kv-v2 workflow | edge cases', function (hooks)
     });
 
     test('it can create a new secret version in a namespace', async function (assert) {
-      assert.expect(11);
+      assert.expect(15);
       const backend = this.backend;
       const ns = this.namespace;
       const secret = this.secretPath;
@@ -324,6 +324,13 @@ module('Acceptance | Enterprise | kv-v2 workflow | edge cases', function (hooks)
         `/vault/secrets/${backend}/kv/${secret}/details?namespace=${ns}&version=2`,
         'navigates to details'
       );
+      assert.dom(PAGE.detail.versionDropdown).hasText('Version 2');
+      await click(PAGE.detail.versionDropdown);
+      assert.dom(PAGE.detail.version(1)).exists('renders version 1 link in dropdown');
+      assert.dom(PAGE.detail.version(2)).exists('renders version 2 link in dropdown');
+      assert
+        .dom(`${PAGE.detail.version(2)} [data-test-icon="check-circle"]`)
+        .exists('renders current version icon');
       assert.dom(PAGE.infoRowValue('foo-two')).hasText('***********');
       await click(PAGE.infoRowToggleMasked('foo-two'));
       assert.dom(PAGE.infoRowValue('foo-two')).hasText('supersecret', 'secret value shows after toggle');

--- a/ui/tests/helpers/kv/kv-run-commands.js
+++ b/ui/tests/helpers/kv/kv-run-commands.js
@@ -9,18 +9,21 @@ import { encodePath } from 'vault/utils/path-encoding-helpers';
 
 // CUSTOM ACTIONS RELEVANT TO KV-V2
 
-export const writeSecret = async function (backend, path, key, val) {
-  await visit(`vault/secrets/${backend}/kv/create`);
+export const writeSecret = async function (backend, path, key, val, ns = null) {
+  const url = `vault/secrets/${backend}/kv/create`;
+  ns ? await visit(url + `?namespace=${ns}`) : await visit(url);
   await fillIn(FORM.inputByAttr('path'), path);
   await fillIn(FORM.keyInput(), key);
   await fillIn(FORM.maskedValueInput(), val);
   return click(FORM.saveBtn);
 };
 
-export const writeVersionedSecret = async function (backend, path, key, val, version = 2) {
-  await writeSecret(backend, path, 'key-1', 'val-1');
+export const writeVersionedSecret = async function (backend, path, key, val, version = 2, ns = null) {
+  await writeSecret(backend, path, 'key-1', 'val-1', ns);
   for (let currentVersion = 2; currentVersion <= version; currentVersion++) {
-    await visit(`/vault/secrets/${backend}/kv/${encodeURIComponent(path)}/details/edit`);
+    const url = `/vault/secrets/${backend}/kv/${encodeURIComponent(path)}/details/edit`;
+    ns ? await visit(url + `?namespace=${ns}`) : await visit(url);
+
     if (currentVersion === version) {
       await fillIn(FORM.keyInput(), key);
       await fillIn(FORM.maskedValueInput(), val);


### PR DESCRIPTION
#### bug description 🐛 
Deleting a secret **in a namespace** initially renders an empty state but if you navigate between sibling routes (click another tab) the stale secret model (`kv/data`) re-renders when you return to the details view (`Secret` tab). The deleted state restores when you refresh the page.
![delete-bug](https://github.com/hashicorp/vault/assets/68122737/b2394a02-118b-4091-a22f-97ec5f3daf68)

<hr>

### after fix 🔧 
![delete-bug](https://github.com/hashicorp/vault/assets/68122737/3ae1e5aa-86f8-4866-b2d3-875750746a73)

