### PR TITLE
Fix potential panic in audit during header formatting

### DIFF
--- a/audit/options.go
+++ b/audit/options.go
@@ -5,6 +5,7 @@ package audit
 
 import (
 	"errors"
+	"reflect"
 	"strings"
 	"time"
 )
@@ -150,9 +151,13 @@ func WithHMACAccessor(h bool) Option {
 }
 
 // WithHeaderFormatter provides an Option to supply a HeaderFormatter.
+// If the HeaderFormatter interface supplied is nil (type or value), the option will not be applied.
 func WithHeaderFormatter(f HeaderFormatter) Option {
 	return func(o *options) error {
-		o.withHeaderFormatter = f
+		if f != nil && !reflect.ValueOf(f).IsNil() {
+			o.withHeaderFormatter = f
+		}
+
 		return nil
 	}
 }

--- a/changelog/22694.txt
+++ b/changelog/22694.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+audit: Prevent panic due to nil pointer receiver for audit header formatting.
+```


### PR DESCRIPTION
This PR updates the way in which the HeaderFormatter option is applied such that it will not allow interfaces with `nil` type or value to be set. 

The aim of the PR is to prevent the ability for audit code to panic in certain circumstances when the formatter appears to be `!=nil` but ends up as a nil pointer receiver. 