### PR TITLE
Initialize kms config map and initialize a typo

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -2589,6 +2589,7 @@ func setSeal(c *ServerCommand, config *server.Config, infoKeys []string, info ma
 
 		var wrapperInfoKeys []string
 		wrapperInfoMap := map[string]string{}
+		configSeal.Config = make(map[string]string)
 		wrapper, wrapperConfigError := configutil.ConfigureWrapper(configSeal, &wrapperInfoKeys, &wrapperInfoMap, sealLogger)
 		if wrapperConfigError != nil {
 			// It seems that we are checking for this particular error here is to distinguish between a

--- a/vault/seal/seal.go
+++ b/vault/seal/seal.go
@@ -165,7 +165,7 @@ type SealWrapper struct {
 	Name     string
 
 	// sealConfigType is the KMS.Type of this wrapper. It is a string rather than a SealConfigType
-	// to avoid a circular go package depency
+	// to avoid a circular go package dependency
 	SealConfigType string
 
 	// Disabled indicates, when true indicates that this wrapper should only be used for decryption.


### PR DESCRIPTION
This PR adds the code to fix the panic when vault starts up using seal config environment variables