### PR TITLE
Add missing kv/metadata adapter test coverage

### DIFF
--- a/ui/app/models/kv/metadata.js
+++ b/ui/app/models/kv/metadata.js
@@ -79,6 +79,7 @@ export default class KvSecretMetadataModel extends Model {
 
   // helps in long logic statements for state of a currentVersion
   get currentSecret() {
+    if (!this.versions || !this.currentVersion) return false;
     const data = this.versions[this.currentVersion];
     const state = data.destroyed ? 'destroyed' : data.deletion_time ? 'deleted' : 'created';
     return {

--- a/ui/lib/kv/addon/components/kv-delete-modal.js
+++ b/ui/lib/kv/addon/components/kv-delete-modal.js
@@ -58,7 +58,7 @@ export default class KvDeleteModal extends Component {
 
   get deleteOptions() {
     const { secret, metadata, version } = this.args;
-    const isDeactivated = secret.canReadMetadata ? metadata?.currentSecret.isDeactivated : false;
+    const isDeactivated = secret.canReadMetadata ? metadata?.currentSecret?.isDeactivated : false;
     return [
       {
         key: 'delete-version',

--- a/ui/tests/unit/adapters/kv/metadata-test.js
+++ b/ui/tests/unit/adapters/kv/metadata-test.js
@@ -113,6 +113,22 @@ module('Unit | Adapter | kv/metadata', function (hooks) {
     );
   });
 
+  test('it should make request to correct endpoint on update record', async function (assert) {
+    assert.expect(1);
+    const data = this.server.create('kv-metadatum');
+    data.id = kvMetadataPath('kv-engine', 'my-secret');
+    this.store.pushPayload('kv/metadata', {
+      modelName: 'kv/metadata',
+      ...data,
+    });
+    this.server.post(kvMetadataPath('kv-engine', 'my-secret'), () => {
+      assert.ok(true, 'request made to correct endpoint on delete metadata.');
+    });
+
+    const record = await this.store.peekRecord('kv/metadata', data.id);
+    await record.save();
+  });
+
   test('it should make request to correct endpoint on queryRecord', async function (assert) {
     assert.expect(13);
     this.server.get(this.endpoint, () => {
@@ -137,6 +153,16 @@ module('Unit | Adapter | kv/metadata', function (hooks) {
       EXAMPLE_KV_METADATA_GET_RESPONSE.data.versions,
       'record has correct versions data'
     );
+  });
+
+  test('it should make request to correct endpoint on query', async function (assert) {
+    assert.expect(1);
+    this.server.get(kvMetadataPath(this.backend, 'directory/'), (schema, req) => {
+      assert.ok(req.queryParams.list, 'list query param sent when listing secrets');
+      return { data: { keys: [] } };
+    });
+
+    this.store.query('kv/metadata', { backend: this.backend, pathToSecret: 'directory/' });
   });
 
   test('it should make request to correct endpoint on delete metadata', async function (assert) {


### PR DESCRIPTION
We first wrote the adapter test before completing the project. We ended up adding a couple of methods and needed to add test coverage for them.

I also came across the selector `getSecret` on the model failing on the test view because we don't have version information at this point. I amended the getter and where the getter was being consumed to prevent any potential issues.