### PR TITLE
Refactor the seal wrapper health check

### DIFF
--- a/vault/seal/seal.go
+++ b/vault/seal/seal.go
@@ -164,7 +164,7 @@ func (sgi *SealGenerationInfo) UnmarshalJSON(b []byte) error {
 
 // SealWrapper contains a Wrapper and related information needed by the seal that uses it.
 type SealWrapper struct {
-	wrapping.Wrapper
+	Wrapper  wrapping.Wrapper
 	Priority int
 	Name     string
 

--- a/vault/seal/seal.go
+++ b/vault/seal/seal.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -160,32 +159,6 @@ func (sgi *SealGenerationInfo) UnmarshalJSON(b []byte) error {
 	sgi.SetRewrapped(value.Rewrapped)
 
 	return nil
-}
-
-// SealWrapper contains a Wrapper and related information needed by the seal that uses it.
-type SealWrapper struct {
-	Wrapper  wrapping.Wrapper
-	Priority int
-	Name     string
-
-	// sealConfigType is the KMS.Type of this wrapper. It is a string rather than a SealConfigType
-	// to avoid a circular go package depency
-	SealConfigType string
-
-	// Disabled indicates, when true indicates that this wrapper should only be used for decryption.
-	Disabled bool
-
-	HcLock          sync.RWMutex
-	LastHealthCheck time.Time
-	LastSeenHealthy time.Time
-	Healthy         bool
-}
-
-func (sw *SealWrapper) keyId(ctx context.Context) string {
-	if id, err := sw.Wrapper.KeyId(ctx); err == nil {
-		return id
-	}
-	return ""
 }
 
 // Access is the embedded implementation of autoSeal that contains logic

--- a/vault/seal/seal_wrapper.go
+++ b/vault/seal/seal_wrapper.go
@@ -1,0 +1,26 @@
+package seal
+
+import (
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"sync"
+	"time"
+)
+
+// SealWrapper contains a Wrapper and related information needed by the seal that uses it.
+type SealWrapper struct {
+	Wrapper  wrapping.Wrapper
+	Priority int
+	Name     string
+
+	// sealConfigType is the KMS.Type of this wrapper. It is a string rather than a SealConfigType
+	// to avoid a circular go package depency
+	SealConfigType string
+
+	// Disabled indicates, when true indicates that this wrapper should only be used for decryption.
+	Disabled bool
+
+	HcLock          sync.RWMutex
+	LastHealthCheck time.Time
+	LastSeenHealthy time.Time
+	Healthy         bool
+}

--- a/vault/seal/seal_wrapper.go
+++ b/vault/seal/seal_wrapper.go
@@ -1,7 +1,12 @@
 package seal
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	mathrand "math/rand"
 	"sync"
 	"time"
 )
@@ -23,4 +28,49 @@ type SealWrapper struct {
 	LastHealthCheck time.Time
 	LastSeenHealthy time.Time
 	Healthy         bool
+}
+
+func (sw *SealWrapper) IsHealthy() bool {
+	sw.HcLock.RLock()
+	defer sw.HcLock.RUnlock()
+
+	return sw.Healthy
+}
+
+var (
+	// vars for unit testing
+	HealthTestIntervalNominal   = 10 * time.Minute
+	HealthTestIntervalUnhealthy = 1 * time.Minute
+	HealthTestTimeout           = 1 * time.Minute
+)
+
+func (sw *SealWrapper) CheckHealth(ctx context.Context, checkTime time.Time) error {
+	sw.HcLock.Lock()
+	defer sw.HcLock.Unlock()
+
+	sw.LastHealthCheck = checkTime
+
+	// Assume the wrapper is unhealthy, if we make it to the end we'll set it to true
+	sw.Healthy = false
+
+	testVal := fmt.Sprintf("Heartbeat %d", mathrand.Intn(1000))
+	ciphertext, err := sw.Wrapper.Encrypt(ctx, []byte(testVal), nil)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt test value, seal wrapper may be unreachable: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, HealthTestTimeout)
+	defer cancel()
+	plaintext, err := sw.Wrapper.Decrypt(ctx, ciphertext, nil)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt test value, seal wrapper may be unreachable: %w", err)
+	}
+	if !bytes.Equal([]byte(testVal), plaintext) {
+		return errors.New("failed to decrypt health test value to expected result")
+	}
+
+	sw.LastSeenHealthy = checkTime
+	sw.Healthy = true
+
+	return nil
 }

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -488,7 +488,7 @@ func (d *autoSeal) StartHealthCheck() {
 						sealWrapper.Healthy = false
 						d.core.MetricSink().SetGaugeWithLabels(autoSealUnavailableDuration, float32(time.Since(sealWrapper.LastSeenHealthy).Milliseconds()), mLabels)
 					}
-					ciphertext, err := sealWrapper.Encrypt(ctx, []byte(testVal), nil)
+					ciphertext, err := sealWrapper.Wrapper.Encrypt(ctx, []byte(testVal), nil)
 					checkTime := time.Now()
 					sealWrapper.LastHealthCheck = checkTime
 
@@ -499,7 +499,7 @@ func (d *autoSeal) StartHealthCheck() {
 						func() {
 							ctx, cancel := context.WithTimeout(ctx, sealHealthTestTimeout)
 							defer cancel()
-							plaintext, err := sealWrapper.Decrypt(ctx, ciphertext, nil)
+							plaintext, err := sealWrapper.Wrapper.Decrypt(ctx, ciphertext, nil)
 							if err != nil {
 								fail("failed to decrypt seal health test value, seal backend may be unreachable", "error", err, "seal_name", sealWrapper.Name)
 							}

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -4,11 +4,9 @@
 package vault
 
 import (
-	"bytes"
 	"context"
 	"crypto/subtle"
 	"fmt"
-	mathrand "math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -25,10 +23,6 @@ import (
 var (
 	barrierTypeUpgradeCheck     = func(_ SealConfigType, _ *SealConfig) {}
 	autoSealUnavailableDuration = []string{"seal", "unreachable", "time"}
-	// vars for unit testings
-	sealHealthTestIntervalNominal   = 10 * time.Minute
-	sealHealthTestIntervalUnhealthy = 1 * time.Minute
-	sealHealthTestTimeout           = 1 * time.Minute
 )
 
 // autoSeal is a Seal implementation that contains logic for encrypting and
@@ -463,66 +457,62 @@ func (d *autoSeal) StartHealthCheck() {
 	d.hcLock.Lock()
 	defer d.hcLock.Unlock()
 
-	healthCheck := time.NewTicker(sealHealthTestIntervalNominal)
+	healthCheck := time.NewTicker(seal.HealthTestIntervalNominal)
 	d.healthCheckStop = make(chan struct{})
 	healthCheckStop := d.healthCheckStop
 	ctx := d.core.activeContext
 
 	go func() {
-		check := func(t time.Time) {
-			ctx, cancel := context.WithTimeout(ctx, sealHealthTestTimeout)
+		lastTestOk := true
+		lastSeenOk := time.Now()
+
+		check := func(now time.Time) {
+			ctx, cancel := context.WithTimeout(ctx, seal.HealthTestTimeout)
 			defer cancel()
 
-			testVal := fmt.Sprintf("Heartbeat %d", mathrand.Intn(1000))
-			anyUnhealthy := false
+			allHealthy := true
+			allUnhealthy := true
 			for _, sealWrapper := range d.Access.GetAllSealWrappersByPriority() {
-				func() {
-					sealWrapper.HcLock.Lock()
-					defer sealWrapper.HcLock.Unlock()
-					mLabels := []metrics.Label{{Name: "seal_name", Value: sealWrapper.Name}}
-					fail := func(msg string, args ...interface{}) {
-						d.logger.Warn(msg, args...)
-						if sealWrapper.Healthy {
-							healthCheck.Reset(sealHealthTestIntervalUnhealthy)
-						}
-						sealWrapper.Healthy = false
-						d.core.MetricSink().SetGaugeWithLabels(autoSealUnavailableDuration, float32(time.Since(sealWrapper.LastSeenHealthy).Milliseconds()), mLabels)
-					}
-					ciphertext, err := sealWrapper.Wrapper.Encrypt(ctx, []byte(testVal), nil)
-					checkTime := time.Now()
-					sealWrapper.LastHealthCheck = checkTime
+				mLabels := []metrics.Label{{Name: "seal_wrapper_name", Value: sealWrapper.Name}}
 
-					if err != nil {
-						fail("failed to encrypt seal health test value, seal backend may be unreachable", "error", err, "seal_name", sealWrapper.Name)
-						anyUnhealthy = true
+				wasHealthy := sealWrapper.IsHealthy()
+				if err := sealWrapper.CheckHealth(ctx, now); err != nil {
+					// Seal wrapper is unhealthy
+					d.logger.Warn("seal wrapper health check failed", "seal_name", sealWrapper.Name, "err", err)
+					d.core.MetricSink().SetGaugeWithLabels(autoSealUnavailableDuration,
+						float32(time.Since(sealWrapper.LastSeenHealthy).Milliseconds()), mLabels)
+					allHealthy = false
+				} else {
+					// Seal wrapper is healthy
+					if wasHealthy {
+						d.logger.Debug("seal wrapper health test passed", "seal_name", sealWrapper.Name)
 					} else {
-						func() {
-							ctx, cancel := context.WithTimeout(ctx, sealHealthTestTimeout)
-							defer cancel()
-							plaintext, err := sealWrapper.Wrapper.Decrypt(ctx, ciphertext, nil)
-							if err != nil {
-								fail("failed to decrypt seal health test value, seal backend may be unreachable", "error", err, "seal_name", sealWrapper.Name)
-							}
-							if !bytes.Equal([]byte(testVal), plaintext) {
-								fail("seal health test value failed to decrypt to expected value", "seal_name", sealWrapper.Name)
-							} else {
-								d.logger.Debug("seal health test passed", "seal_name", sealWrapper.Name)
-								if !sealWrapper.Healthy {
-									d.logger.Info("seal backend is now healthy again", "downtime", t.Sub(sealWrapper.LastSeenHealthy).String(), "seal_name", sealWrapper.Name)
-									healthCheck.Reset(sealHealthTestIntervalNominal)
-								}
-
-								sealWrapper.Healthy = true
-								sealWrapper.LastSeenHealthy = checkTime
-								d.core.MetricSink().SetGaugeWithLabels(autoSealUnavailableDuration, 0, mLabels)
-							}
-						}()
+						d.logger.Info("seal wrapper is now healthy again", "downtime", "seal_name", sealWrapper.Name,
+							now.Sub(sealWrapper.LastSeenHealthy).String())
 					}
-				}()
+					allUnhealthy = false
+				}
 			}
+			if allHealthy {
+				if !lastTestOk {
+					d.logger.Info("seal backend is fully healthy again", "downtime", now.Sub(lastSeenOk).String())
+				}
+				lastTestOk = true
+				lastSeenOk = now
+				healthCheck.Reset(seal.HealthTestIntervalNominal)
+				d.core.MetricSink().SetGauge(autoSealUnavailableDuration, 0)
+			} else {
+				if lastTestOk && allUnhealthy {
+					d.logger.Info("seal backend is completely unhealthy (all seal wrappers all unhealthy)", "downtime", now.Sub(lastSeenOk).String())
+				}
+				lastTestOk = false
+				healthCheck.Reset(seal.HealthTestIntervalUnhealthy)
+				d.core.MetricSink().SetGauge(autoSealUnavailableDuration, float32(time.Since(lastSeenOk).Milliseconds()))
+			}
+
 			d.hcLock.Lock()
 			defer d.hcLock.Unlock()
-			d.allSealsHealthy = !anyUnhealthy
+			d.allSealsHealthy = allHealthy
 		}
 
 		for {

--- a/vault/seal_autoseal_test.go
+++ b/vault/seal_autoseal_test.go
@@ -186,8 +186,8 @@ func TestAutoSeal_HealthCheck(t *testing.T) {
 		MetricSink: metricsutil.NewClusterMetricSink("", inmemSink),
 		Physical:   pBackend,
 	})
-	sealHealthTestIntervalNominal = 10 * time.Millisecond
-	sealHealthTestIntervalUnhealthy = 10 * time.Millisecond
+	seal.HealthTestIntervalNominal = 10 * time.Millisecond
+	seal.HealthTestIntervalUnhealthy = 10 * time.Millisecond
 	autoSeal := NewAutoSeal(testSealAccess)
 	autoSeal.SetCore(core)
 	core.seal = autoSeal


### PR DESCRIPTION
Extract method SealWrapper.CheckHealth out of StartHealthCheck.

Restore the metrics around overall seal health, so that we have metrics for
individual seal wrappers as well as the backend itself.
