### PR TITLE
[DOCS] Add WAF links for metric best practice guide

### DIFF
--- a/website/content/docs/internals/telemetry/enable-telemetry.mdx
+++ b/website/content/docs/internals/telemetry/enable-telemetry.mdx
@@ -62,13 +62,9 @@ telemetry {
 }
 ```
 
-<Tip>
-
-  Many metrics solutions charge by the metric. You can set `filter_default` to
-  false and use the `prefix_filter` parameter to include and exclude specific
-  values based on metric name to avoid paying for irrelevant information.
-
-</Tip>
+Many metrics solutions charge by the metric. You can set `filter_default` to
+false and use the `prefix_filter` parameter to include and exclude specific
+values based on metric name to avoid paying for irrelevant information.
 
 For example, to limit your telemetry to the core token metrics plus the number
 of leases set to expire:
@@ -100,6 +96,9 @@ Popular reporting solutions compatible with Vault:
 
 ## Next steps
 
+- Review the
+  [Key metrics for common health checks](/well-architected-framework/reliability/reliability-vault-monitoring-key-metrics)
+  guide to identify metrics you may want to start monitoring immediately.
 - Review the full list of available
   [telemetry parameters](/vault/docs/configuration/telemetry#telemetry-parameters).
 - Review the [Monitor telemetry and audit device log data](/vault/tutorials/monitoring/monitor-telemetry-audit-splunk)

--- a/website/content/docs/internals/telemetry/index.mdx
+++ b/website/content/docs/internals/telemetry/index.mdx
@@ -13,12 +13,20 @@ of different libraries and subsystems. These metrics are aggregated on a
 metrics, like `vault.kv.secret.count`, report every 10 minutes or at an interval
 configured with in the `telemetry` stanza.
 
+Telemetry from Vault must be streamed and stored in metrics aggregation
+software to monitor Vault and collect durable metrics.
+
 @include 'telemetry/supported-aggregation-agents.mdx'
 
-<Important>
-  Telemetry from Vault must be streamed and stored in metrics aggregation
-  software to monitor Vault and collect durable metrics.
-</Important>
+<Tip title="Start with key health metrics">
+
+  The [Well-Architected Framework](/well-architected-framework) documentation
+  includes a best practices guide on
+  [key Vault metrics for common health checks](/well-architected-framework/reliability/reliability-vault-monitoring-key-metrics).
+  We recommend reviewing the key metric recommendations to identify metrics you
+  may want to start monitoring immediately.
+
+</Tip>
 
 ## Working with raw telemetry data
 


### PR DESCRIPTION
Add links to the best practices guide for telemetry metrics so it's easier for folks to find.

On the Enable telemetry how-to guide:
![image](https://github.com/hashicorp/vault/assets/62406755/0c313b8f-5db5-4fda-8abc-e2ef8e6031ca)


On the telemetry landing page:
![image](https://github.com/hashicorp/vault/assets/62406755/44483aef-f495-48d5-a8e9-26f1a51165c6)
