### PR TITLE
Pin security scan's semgrep version to 1.37.0

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -57,7 +57,7 @@ jobs:
         mv scan-plugin-codeql "$HOME/.bin"
 
         # Semgrep
-        python3 -m pip install semgrep
+        python3 -m pip install semgrep==1.37.0
 
         # CodeQL
         LATEST=$(gh release list --repo https://github.com/github/codeql-action | cut -f 3 | sort --version-sort | tail -n1)


### PR DESCRIPTION
hashicorp/security-scanner#504 tracks the breakage that requires us to pin pre-1.38.0 for now