### PR TITLE
UI: [VAULT-18126] adding style to prevent namespace to overflow on sidebar

### DIFF
--- a/changelog/_22733.txt
+++ b/changelog/_22733.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes long namespace names overflow in the sidebar
+```

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -25,11 +25,6 @@
   margin-right: $spacing-xxs;
 }
 
-.namespace-name {
-  font-size: 1rem;
-  margin-left: $spacing-xs;
-}
-
 .namespace-picker-content {
   width: 250px;
   max-height: 300px;

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -28,10 +28,6 @@
 .namespace-name {
   font-size: 1rem;
   margin-left: $spacing-xs;
-  word-break: break-word;
-  white-space: pre-wrap;
-  text-align: left;
-  flex: 1;
 }
 
 .namespace-picker-content {

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -28,6 +28,10 @@
 .namespace-name {
   font-size: 1rem;
   margin-left: $spacing-xs;
+  word-break: break-word;
+  white-space: pre-wrap;
+  text-align: left;
+  flex: 1;
 }
 
 .namespace-picker-content {
@@ -47,7 +51,6 @@
   overflow-wrap: break-word;
   word-wrap: break-word;
   word-break: break-all;
-  word-break: break-word;
 }
 
 .namespace-header-bar {

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -41,7 +41,7 @@
   max-width: 210px;
   overflow-wrap: break-word;
   word-wrap: break-word;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .namespace-header-bar {

--- a/ui/app/styles/helper-classes/typography.scss
+++ b/ui/app/styles/helper-classes/typography.scss
@@ -75,6 +75,10 @@
   text-align: right !important;
 }
 
+.has-text-left {
+  text-align: left;
+}
+
 .has-text-centered {
   text-align: center !important;
 }

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -12,7 +12,9 @@
     >
       <div class="is-flex-center is-flex-1">
         <Icon @name="org" />
-        <span class="namespace-name is-flex-1 is-word-break has-text-left">{{this.namespaceDisplay}}</span>
+        <span class="is-flex-1 is-word-break has-text-left is-size-6 has-left-margin-xs">
+          {{this.namespaceDisplay}}
+        </span>
       </div>
       <Icon @name="caret" />
     </D.Trigger>

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -10,7 +10,7 @@
       class="button is-transparent namespace-picker-trigger has-current-color"
       data-test-namespace-toggle
     >
-      <div class="is-flex-center">
+      <div class="is-flex-center is-flex-1">
         <Icon @name="org" />
         <span class="namespace-name">{{this.namespaceDisplay}}</span>
       </div>

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -12,9 +12,7 @@
     >
       <div class="is-flex-center is-flex-1">
         <Icon @name="org" />
-        <span class="is-flex-1 is-word-break has-text-left is-size-6 has-left-margin-xs">
-          {{this.namespaceDisplay}}
-        </span>
+        <span class="is-flex-1 is-word-break has-text-left is-size-6 has-left-margin-xs">{{this.namespaceDisplay}}</span>
       </div>
       <Icon @name="caret" />
     </D.Trigger>

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -12,7 +12,7 @@
     >
       <div class="is-flex-center is-flex-1">
         <Icon @name="org" />
-        <span class="namespace-name">{{this.namespaceDisplay}}</span>
+        <span class="namespace-name is-flex-1 is-word-break has-text-left">{{this.namespaceDisplay}}</span>
       </div>
       <Icon @name="caret" />
     </D.Trigger>


### PR DESCRIPTION
Before: 

<img width="698" alt="image" src="https://github.com/hashicorp/vault/assets/18043357/4f83b3e8-c0e8-4e4f-86b5-8f56a57d3b20">

<img width="698" alt="image" src="https://github.com/hashicorp/vault/assets/18043357/cea0eae3-5b42-468c-86db-2d1b82f65c35">


After: 

<img width="700" alt="image" src="https://github.com/hashicorp/vault/assets/18043357/ddff6318-046c-4cb2-97af-69ac87d5a13f">

<img width="703" alt="image" src="https://github.com/hashicorp/vault/assets/18043357/60f4b6a0-6e2a-458f-a1ae-617ac44941a5">
