### PR TITLE
Protect SealWrapper health fields

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -2642,13 +2642,13 @@ func setSeal(c *ServerCommand, config *server.Config, infoKeys []string, info ma
 			wrapper = aeadwrapper.NewShamirWrapper()
 		}
 
-		sealWrapper := vaultseal.SealWrapper{
-			Wrapper:        wrapper,
-			Priority:       configSeal.Priority,
-			Name:           configSeal.Name,
-			SealConfigType: configSeal.Type,
-			Disabled:       configSeal.Disabled,
-		}
+		sealWrapper := *vaultseal.NewSealWrapper(
+			wrapper,
+			configSeal.Priority,
+			configSeal.Name,
+			configSeal.Type,
+			configSeal.Disabled,
+		)
 
 		if configSeal.Disabled {
 			disabledSealWrappers = append(disabledSealWrappers, sealWrapper)

--- a/helper/testhelpers/seal/sealhelper.go
+++ b/helper/testhelpers/seal/sealhelper.go
@@ -73,13 +73,7 @@ func (tss *TransitSealServer) MakeSeal(t testing.T, key string) (vault.Seal, err
 		t.Fatalf("error setting wrapper config: %v", err)
 	}
 
-	access, err := seal.NewAccessFromSealWrappers(tss.Logger, 1, true, []seal.SealWrapper{
-		{
-			Wrapper:  transitSealWrapper,
-			Priority: 1,
-			Name:     "transit",
-		},
-	})
+	access, err := seal.NewAccessFromWrapper(tss.Logger, transitSealWrapper, vault.SealConfigTypeTransit.String())
 	if err != nil {
 		return nil, err
 	}

--- a/vault/core.go
+++ b/vault/core.go
@@ -1113,13 +1113,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		wrapper := aeadwrapper.NewShamirWrapper()
 		wrapper.SetConfig(context.Background(), awskms.WithLogger(c.logger.Named("shamir")))
 
-		access, err := vaultseal.NewAccessFromSealWrappers(c.logger, 1, true, []vaultseal.SealWrapper{
-			{
-				Wrapper:  wrapper,
-				Priority: 1,
-				Name:     "shamir",
-			},
-		})
+		access, err := vaultseal.NewAccessFromWrapper(c.logger, wrapper, SealConfigTypeShamir.String())
 		if err != nil {
 			return nil, err
 		}
@@ -2885,13 +2879,7 @@ func (c *Core) adjustForSealMigration(unwrapSeal Seal) error {
 
 			// See note about creating a SealGenerationInfo for the unwrap seal in
 			// function setSeal in server.go.
-			sealAccess, err := vaultseal.NewAccessFromSealWrappers(c.logger, 1, true, []vaultseal.SealWrapper{
-				{
-					Wrapper:  aeadwrapper.NewShamirWrapper(),
-					Priority: 1,
-					Name:     "shamir",
-				},
-			})
+			sealAccess, err := vaultseal.NewAccessFromWrapper(c.logger, aeadwrapper.NewShamirWrapper(), SealConfigTypeShamir.String())
 			if err != nil {
 				return err
 			}
@@ -3113,13 +3101,7 @@ func (c *Core) unsealKeyToRootKey(ctx context.Context, seal Seal, combinedKey []
 		if useTestSeal {
 			// Note that the seal generation should not matter, since the only thing we are doing with
 			// this seal is calling GetStoredKeys (i.e. we are not encrypting anything).
-			sealAccess, err := vaultseal.NewAccessFromSealWrappers(c.logger, 1, true, []vaultseal.SealWrapper{
-				{
-					Wrapper:  aeadwrapper.NewShamirWrapper(),
-					Priority: 1,
-					Name:     "shamir",
-				},
-			})
+			sealAccess, err := vaultseal.NewAccessFromWrapper(c.logger, aeadwrapper.NewShamirWrapper(), SealConfigTypeShamir.String())
 			if err != nil {
 				return nil, fmt.Errorf("failed to setup seal wrapper for test barrier config: %w", err)
 			}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4981,14 +4981,15 @@ func (c *Core) GetSealBackendStatus(ctx context.Context) (*SealBackendStatusResp
 		for _, sealWrapper := range a.GetAllSealWrappersByPriority() {
 			b := SealBackendStatus{
 				Name:    sealWrapper.Name,
-				Healthy: sealWrapper.Healthy,
+				Healthy: sealWrapper.IsHealthy(),
 			}
-			if !sealWrapper.Healthy {
-				if !sealWrapper.LastSeenHealthy.IsZero() {
-					b.UnhealthySince = sealWrapper.LastSeenHealthy.String()
+			if !sealWrapper.IsHealthy() {
+				lastSeenHealthy := sealWrapper.LastSeenHealthy()
+				if !lastSeenHealthy.IsZero() {
+					b.UnhealthySince = lastSeenHealthy.String()
 				}
-				if uhMin.IsZero() || uhMin.After(sealWrapper.LastSeenHealthy) {
-					uhMin = sealWrapper.LastSeenHealthy
+				if uhMin.IsZero() || uhMin.After(lastSeenHealthy) {
+					uhMin = lastSeenHealthy
 				}
 			}
 			r.Backends = append(r.Backends, b)

--- a/vault/rekey.go
+++ b/vault/rekey.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	aeadwrapper "github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2"
+
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/helper/pgpkeys"
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -400,16 +401,12 @@ func (c *Core) BarrierRekeyUpdate(ctx context.Context, key []byte, nonce string)
 		}
 	case c.seal.BarrierSealConfigType() == SealConfigTypeShamir:
 		if c.seal.StoredKeysSupported() == seal.StoredKeysSupportedShamirRoot {
-			access, err := seal.NewAccessFromSealWrappers(c.logger, c.seal.GetAccess().Generation(), true, []seal.SealWrapper{
-				{
-					Wrapper:  aeadwrapper.NewShamirWrapper(),
-					Priority: 1,
-					Name:     existingConfig.Name,
-				},
-			})
+			access, err := seal.NewAccessFromWrapper(c.logger, aeadwrapper.NewShamirWrapper(), SealConfigTypeShamir.String())
 			if err != nil {
 				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to setup test seal: %w", err).Error())
 			}
+			access.GetAllSealWrappersByPriority()[0].Name = existingConfig.Name
+
 			testseal := NewDefaultSeal(access)
 			testseal.SetCore(c)
 			err = testseal.GetAccess().SetShamirSealKey(recoveredKey)

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -480,7 +480,7 @@ func (d *autoSeal) StartHealthCheck() {
 					// Seal wrapper is unhealthy
 					d.logger.Warn("seal wrapper health check failed", "seal_name", sealWrapper.Name, "err", err)
 					d.core.MetricSink().SetGaugeWithLabels(autoSealUnavailableDuration,
-						float32(time.Since(sealWrapper.LastSeenHealthy).Milliseconds()), mLabels)
+						float32(time.Since(sealWrapper.LastSeenHealthy()).Milliseconds()), mLabels)
 					allHealthy = false
 				} else {
 					// Seal wrapper is healthy
@@ -488,7 +488,7 @@ func (d *autoSeal) StartHealthCheck() {
 						d.logger.Debug("seal wrapper health test passed", "seal_name", sealWrapper.Name)
 					} else {
 						d.logger.Info("seal wrapper is now healthy again", "downtime", "seal_name", sealWrapper.Name,
-							now.Sub(sealWrapper.LastSeenHealthy).String())
+							now.Sub(sealWrapper.LastSeenHealthy()).String())
 					}
 					allUnhealthy = false
 				}

--- a/vault/seal_autoseal_test.go
+++ b/vault/seal_autoseal_test.go
@@ -181,7 +181,7 @@ func TestAutoSeal_HealthCheck(t *testing.T) {
 	metrics.NewGlobal(metricsConf, inmemSink)
 
 	pBackend := newTestBackend(t)
-	testSealAccess, setErrs := seal.NewToggleableTestSeal(nil)
+	testSealAccess, setErrs := seal.NewToggleableTestSeal(&seal.TestSealOpts{Name: "health-test"})
 	core, _, _ := TestCoreUnsealedWithConfig(t, &CoreConfig{
 		MetricSink: metricsutil.NewClusterMetricSink("", inmemSink),
 		Physical:   pBackend,

--- a/vault/seal_config.go
+++ b/vault/seal_config.go
@@ -144,6 +144,8 @@ const (
 	SealConfigTypePkcs11            = SealConfigType(wrapping.WrapperTypePkcs11)
 	SealConfigTypeAwsKms            = SealConfigType(wrapping.WrapperTypeAwsKms)
 	SealConfigTypeHsmAutoDeprecated = SealConfigType(wrapping.WrapperTypeHsmAuto)
+	SealConfigTypeTransit           = SealConfigType(wrapping.WrapperTypeTransit)
+	SealConfigTypeGcpCkms           = SealConfigType(wrapping.WrapperTypeGcpCkms)
 
 	// SealConfigTypeRecovery is an alias for SealConfigTypeShamir since all recovery seals are
 	// defaultSeals using shamir wrappers.

--- a/vault/seal_testing_util.go
+++ b/vault/seal_testing_util.go
@@ -4,7 +4,7 @@
 package vault
 
 import (
-	aeadwrapper "github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2"
+	"github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2"
 	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/vault/seal"
 	testing "github.com/mitchellh/go-testing-interface"
@@ -17,13 +17,8 @@ func NewTestSeal(t testing.T, opts *seal.TestSealOpts) Seal {
 
 	switch opts.StoredKeys {
 	case seal.StoredKeysSupportedShamirRoot:
-		w := aeadwrapper.NewShamirWrapper()
-		sealAccess, err := seal.NewAccessFromSealWrappers(logger, opts.Generation, true, []seal.SealWrapper{
-			{
-				Wrapper:  w,
-				Priority: 1,
-				Name:     "shamir",
-			},
+		sealAccess, err := seal.NewAccessFromSealWrappers(logger, opts.Generation, true, []*seal.SealWrapper{
+			seal.NewSealWrapper(aead.NewShamirWrapper(), 1, "shamir", "shamir", false),
 		})
 		if err != nil {
 			t.Fatal("error creating test seal", err)
@@ -37,13 +32,8 @@ func NewTestSeal(t testing.T, opts *seal.TestSealOpts) Seal {
 		})
 		return newSeal
 	case seal.StoredKeysNotSupported:
-		w := aeadwrapper.NewShamirWrapper()
-		sealAccess, err := seal.NewAccessFromSealWrappers(logger, opts.Generation, true, []seal.SealWrapper{
-			{
-				Wrapper:  w,
-				Priority: 1,
-				Name:     "shamir",
-			},
+		sealAccess, err := seal.NewAccessFromSealWrappers(logger, opts.Generation, true, []*seal.SealWrapper{
+			seal.NewSealWrapper(aead.NewShamirWrapper(), 1, "shamir", "shamir", false),
 		})
 		if err != nil {
 			t.Fatal("error creating test seal", err)


### PR DESCRIPTION
Create accessors for SealWrapper fields protecteb by the lock.

Make the fields "private" and add accessors and mutators for those fields to ensure proper lock handling.

Use NewSealWrapper constructor to create all seal wrappers.

Add convenience method NewAccessFromWrapper for the common case of creating an Access for single seal wrapper.

Use pointers to SealWrapper rather than direct variables.