### PR TITLE
Revert "Pin security scan's semgrep version to 1.37.0 (#22731)"

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -57,7 +57,7 @@ jobs:
         mv scan-plugin-codeql "$HOME/.bin"
 
         # Semgrep
-        python3 -m pip install semgrep==1.37.0
+        python3 -m pip install semgrep
 
         # CodeQL
         LATEST=$(gh release list --repo https://github.com/github/codeql-action | cut -f 3 | sort --version-sort | tail -n1)


### PR DESCRIPTION
This reverts commit 980857808644b091f87ecef0527f1a08f903fced (#22731).

Previous issue fixed in returntocorp/semgrep#8604, released in 1.38.1