### PR TITLE
Fix transit panic with invalid PEM

### DIFF
--- a/changelog/22753.txt
+++ b/changelog/22753.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/transit: fix panic when providing non-PEM formatted public key for import
+```

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -2181,6 +2181,9 @@ func (p *Policy) ImportPrivateKeyForVersion(ctx context.Context, storage logical
 	case *ecdsa.PrivateKey:
 		ecdsaKey := parsedPrivateKey.(*ecdsa.PrivateKey)
 		pemBlock, _ := pem.Decode([]byte(keyEntry.FormattedPublicKey))
+		if pemBlock == nil {
+			return fmt.Errorf("failed to parse key entry public key: invalid PEM blob")
+		}
 		publicKey, err := x509.ParsePKIXPublicKey(pemBlock.Bytes)
 		if err != nil || publicKey == nil {
 			return fmt.Errorf("failed to parse key entry public key: %v", err)

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -1535,9 +1535,13 @@ func (p *Policy) ImportPublicOrPrivate(ctx context.Context, storage logical.Stor
 			}
 		} else {
 			pemBlock, _ := pem.Decode(key)
+			if pemBlock == nil {
+				return fmt.Errorf("error parsing public key: not in PEM format")
+			}
+
 			parsedKey, err = x509.ParsePKIXPublicKey(pemBlock.Bytes)
 			if err != nil {
-				return fmt.Errorf("error parsing public key: %s", err)
+				return fmt.Errorf("error parsing public key: %w", err)
 			}
 		}
 


### PR DESCRIPTION
When an invalid (non-PEM) public key is given to Transit's import, this fails with a panic in server logs:

    2023-09-05T08:11:11.526-0400 [INFO]  http: panic serving 127.0.0.1:42414: runtime error: invalid memory address or nil pointer dereference
    goroutine 950 [running]:
    net/http.(*conn).serve.func1()
	    /usr/local/go/src/net/http/server.go:1868 +0xb9
    panic({0x8371620?, 0x1050b390?})
	    /usr/local/go/src/runtime/panic.go:920 +0x270
    github.com/hashicorp/vault/sdk/helper/keysutil.(*Policy).ImportPublicOrPrivate(0xc003fff440, {0xaf02918, 0xc004509920}, {0xaf03670, 0xc0032e4180}, {0xc004532ea0, 0x188, 0x1a0}, 0x0, {0xae7f5e0, ...})
	    /home/cipherboy/GitHub/cipherboy/vault/sdk/helper/keysutil/policy.go:1538 +0x687
    github.com/hashicorp/vault/sdk/helper/keysutil.(*LockManager).ImportPolicy(0xc001a29410, {0xaf02918, 0xc004509920}, {{0xaf03670, 0xc0032e4180}, {0xc003eb5ab5, 0xb}, 0x3, 0x0, 0x0, ...}, ...)
	    /home/cipherboy/GitHub/cipherboy/vault/sdk/helper/keysutil/lock_manager.go:517 +0x38a

This is unfortunate and doesn't reveal the cause of the failure: input was not provided in PEM format, per docs.