### PR TITLE
Fix flaky rollback test

### DIFF
--- a/vault/rollback_test.go
+++ b/vault/rollback_test.go
@@ -242,6 +242,11 @@ func TestRollbackManager_WorkerPool(t *testing.T) {
 			select {
 			case i := <-ran:
 				got[i] = true
+
+				// keep this goroutine running even after there are 10 paths.
+				// More rollback operations might get queued before Stop() is
+				// called, and we don't want them to block on writing the to the
+				// ran channel
 				if len(got) == 10 && !channelClosed {
 					close(gotAllPaths)
 					channelClosed = true


### PR DESCRIPTION
Before, the test didn't know which backends had rolled back and it was possible that if we stopped the rollback manager before rollbacks for the test backends were queued, then the test would fail. It was also possible that the test would check the GreaterOrEqual condition before the element was added to the map.

I've switched up the test to instead require that we get responses from all of the backends before stopping.