### PR TITLE
UI: [VAULT-19478] Fix info table row value overflow

### DIFF
--- a/ui/app/styles/helper-classes/general.scss
+++ b/ui/app/styles/helper-classes/general.scss
@@ -97,6 +97,13 @@
   overflow: hidden;
 }
 
+.text-overflow-ellipsis {
+  width: 500px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 // screen reader only
 .sr-only {
   border: 0;

--- a/ui/app/styles/helper-classes/general.scss
+++ b/ui/app/styles/helper-classes/general.scss
@@ -98,7 +98,6 @@
 }
 
 .text-overflow-ellipsis {
-  width: 500px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/ui/lib/core/addon/components/info-table-row.hbs
+++ b/ui/lib/core/addon/components/info-table-row.hbs
@@ -35,7 +35,7 @@
       {{/if}}
     </div>
     <div
-      class="column is-flex {{if this.hasValueOverflow 'is-two-thirds'}}"
+      class="column {{if this.hasValueOverflow 'is-two-thirds is-flex-center' 'is-flex'}}"
       data-test-value-div={{@label}}
       {{did-insert this.calculateValueOverflow}}
     >

--- a/ui/lib/core/addon/components/info-table-row.hbs
+++ b/ui/lib/core/addon/components/info-table-row.hbs
@@ -34,7 +34,11 @@
         <Icon @name="minus" />
       {{/if}}
     </div>
-    <div class="column is-flex" data-test-value-div={{@label}}>
+    <div
+      class="column is-flex {{if this.hasValueOverflow 'is-two-thirds'}}"
+      data-test-value-div={{@label}}
+      {{did-insert this.calculateValueOverflow}}
+    >
       {{#if @addCopyButton}}
         <div class="display-only">
           <CopyButton

--- a/ui/lib/core/addon/components/info-table-row.hbs
+++ b/ui/lib/core/addon/components/info-table-row.hbs
@@ -35,7 +35,7 @@
       {{/if}}
     </div>
     <div
-      class="column {{if this.hasValueOverflow 'is-two-thirds is-flex-center' 'is-flex'}}"
+      class="column {{if @truncateValue 'is-two-thirds is-flex-center' 'is-flex'}}"
       data-test-value-div={{@label}}
       {{did-insert this.calculateValueOverflow}}
     >

--- a/ui/lib/core/addon/components/info-table-row.hbs
+++ b/ui/lib/core/addon/components/info-table-row.hbs
@@ -34,11 +34,7 @@
         <Icon @name="minus" />
       {{/if}}
     </div>
-    <div
-      class="column {{if @truncateValue 'is-two-thirds is-flex-center' 'is-flex'}}"
-      data-test-value-div={{@label}}
-      {{did-insert this.calculateValueOverflow}}
-    >
+    <div class="column {{if @truncateValue 'is-two-thirds is-flex-center' 'is-flex'}}" data-test-value-div={{@label}}>
       {{#if @addCopyButton}}
         <div class="display-only">
           <CopyButton

--- a/ui/lib/core/addon/components/info-table-row.js
+++ b/ui/lib/core/addon/components/info-table-row.js
@@ -39,6 +39,8 @@ import { action } from '@ember/object';
 export default class InfoTableRowComponent extends Component {
   @tracked
   hasLabelOverflow = false; // is calculated and set in didInsertElement
+  @tracked
+  hasValueOverflow = false; // is calculated and set in didInsertElement
 
   get isVisible() {
     return this.args.alwaysRender || !this.valueIsEmpty;
@@ -72,6 +74,17 @@ export default class InfoTableRowComponent extends Component {
     if (labelDiv && labelText) {
       if (labelText.offsetWidth > labelDiv.offsetWidth) {
         this.hasLabelOverflow = true;
+      }
+    }
+  }
+
+  @action
+  calculateValueOverflow(el) {
+    const valueDiv = el;
+    const valueText = el.querySelector('[truncate-value]');
+    if (valueDiv && valueText) {
+      if (valueText.offsetWidth > valueDiv.offsetWidth) {
+        this.hasValueOverflow = true;
       }
     }
   }

--- a/ui/lib/core/addon/components/info-table-row.js
+++ b/ui/lib/core/addon/components/info-table-row.js
@@ -80,12 +80,9 @@ export default class InfoTableRowComponent extends Component {
 
   @action
   calculateValueOverflow(el) {
-    const valueDiv = el;
     const valueText = el.querySelector('[truncate-value]');
-    if (valueDiv && valueText) {
-      if (valueText.offsetWidth > valueDiv.offsetWidth) {
-        this.hasValueOverflow = true;
-      }
+    if (valueText) {
+      this.hasValueOverflow = true;
     }
   }
 }

--- a/ui/lib/core/addon/components/info-table-row.js
+++ b/ui/lib/core/addon/components/info-table-row.js
@@ -22,6 +22,7 @@ import { action } from '@ember/object';
  * @param {string} helperText=null - Text to describe the value displayed beneath the label.
  * @param {any} value=null  - The the data to be displayed - by default the content of the component will only show if there is a value. Also note that special handling is given to boolean values - they will render `Yes` for true and `No` for false. Overridden by block if exists
  * @param {boolean} [alwaysRender=false] - Indicates if the component content should be always be rendered.  When false, the value of `value` will be used to determine if the component should render.
+ * @param {boolean} [truncateValue=false] - Indicates if the value should be truncated.
  * @param {string} [defaultShown] - Text that renders as value if alwaysRender=true. Eg. "Vault default"
  * @param {string} [tooltipText] - Text if a tooltip should display over the value.
  * @param {boolean} [isTooltipCopyable]  - Allows tooltip click to copy
@@ -39,8 +40,6 @@ import { action } from '@ember/object';
 export default class InfoTableRowComponent extends Component {
   @tracked
   hasLabelOverflow = false; // is calculated and set in didInsertElement
-  @tracked
-  hasValueOverflow = false; // is calculated and set in didInsertElement
 
   get isVisible() {
     return this.args.alwaysRender || !this.valueIsEmpty;
@@ -75,14 +74,6 @@ export default class InfoTableRowComponent extends Component {
       if (labelText.offsetWidth > labelDiv.offsetWidth) {
         this.hasLabelOverflow = true;
       }
-    }
-  }
-
-  @action
-  calculateValueOverflow(el) {
-    const valueText = el.querySelector('[truncate-value]');
-    if (valueText) {
-      this.hasValueOverflow = true;
     }
   }
 }

--- a/ui/lib/kv/addon/components/page/secret/paths.hbs
+++ b/ui/lib/kv/addon/components/page/secret/paths.hbs
@@ -25,7 +25,7 @@
       >
         <Icon @name="clipboard-copy" aria-label="Copy" />
       </CopyButton>
-      <code class="has-left-margin-s text-overflow-ellipsis" truncate-value>
+      <code class="is-flex-1 text-overflow-ellipsis has-left-margin-s" truncate-value>
         {{path.snippet}}
       </code>
     </InfoTableRow>

--- a/ui/lib/kv/addon/components/page/secret/paths.hbs
+++ b/ui/lib/kv/addon/components/page/secret/paths.hbs
@@ -25,7 +25,7 @@
       >
         <Icon @name="clipboard-copy" aria-label="Copy" />
       </CopyButton>
-      <code class="has-left-margin-s level-left">
+      <code class="has-left-margin-s text-overflow-ellipsis" truncate-value>
         {{path.snippet}}
       </code>
     </InfoTableRow>

--- a/ui/lib/kv/addon/components/page/secret/paths.hbs
+++ b/ui/lib/kv/addon/components/page/secret/paths.hbs
@@ -15,7 +15,7 @@
 
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   {{#each this.paths as |path|}}
-    <InfoTableRow @label={{path.label}} @labelWidth="is-one-third" @helperText={{path.text}}>
+    <InfoTableRow @label={{path.label}} @labelWidth="is-one-third" @helperText={{path.text}} @truncateValue={{true}}>
       {{! replace with Hds::Copy::Snippet }}
       <CopyButton
         class="button is-compact is-transparent level-right"
@@ -25,7 +25,7 @@
       >
         <Icon @name="clipboard-copy" aria-label="Copy" />
       </CopyButton>
-      <code class="is-flex-1 text-overflow-ellipsis has-left-margin-s" truncate-value>
+      <code class="is-flex-1 text-overflow-ellipsis has-left-margin-s">
         {{path.snippet}}
       </code>
     </InfoTableRow>


### PR DESCRIPTION
**Before**
<img width="1267" alt="Screenshot 2023-09-05 at 1 04 34 PM" src="https://github.com/hashicorp/vault/assets/30884335/8c806b6c-5c75-49eb-a49f-d2124c15403f">

**After truncating long path names:**
<img width="1119" alt="Screenshot 2023-09-05 at 2 08 31 PM" src="https://github.com/hashicorp/vault/assets/30884335/9ba10d5b-05d4-492e-ba1c-17d0a95f9836">

