### PR TITLE
Backport 1.15.x: Manual to rename delete metadata

### DIFF
--- a/ui/lib/kv/addon/components/kv-delete-modal.js
+++ b/ui/lib/kv/addon/components/kv-delete-modal.js
@@ -46,7 +46,7 @@ export default class KvDeleteModal extends Component {
         };
       case 'delete-metadata':
         return {
-          title: 'Delete metadata?',
+          title: 'Delete metadata and secret data?',
           type: 'danger',
           intro:
             'This will permanently delete the metadata and versions of the secret. All version history will be removed. This cannot be undone.',

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
@@ -11,7 +11,7 @@
   <:toolbarActions>
     {{#if @secret.canDeleteMetadata}}
       <KvDeleteModal @mode="delete-metadata" @metadata={{@metadata}} @onDelete={{this.onDelete}}>
-        Delete metadata
+        Permanently delete
       </KvDeleteModal>
     {{/if}}
     {{#if @secret.canUpdateMetadata}}

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-delete-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-delete-test.js
@@ -137,10 +137,12 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       await visit(`/vault/secrets/${this.backend}/kv/nuke/details`);
       // Check metadata toolbar
       await click(PAGE.secretTab('Metadata'));
-      assert.dom(PAGE.metadata.deleteMetadata).hasText('Delete metadata', 'shows delete metadata button');
+      assert.dom(PAGE.metadata.deleteMetadata).hasText('Permanently delete', 'shows delete metadata button');
       // delete flow
       await click(PAGE.metadata.deleteMetadata);
-      assert.dom(PAGE.detail.deleteModalTitle).includesText('Delete metadata?', 'modal has correct title');
+      assert
+        .dom(PAGE.detail.deleteModalTitle)
+        .includesText('Delete metadata and secret data?', 'modal has correct title');
       await click(PAGE.detail.deleteConfirm);
 
       // redirects to list
@@ -388,10 +390,12 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       await visit(`/vault/secrets/${this.backend}/kv/nuke/details`);
       // Check metadata toolbar
       await click(PAGE.secretTab('Metadata'));
-      assert.dom(PAGE.metadata.deleteMetadata).hasText('Delete metadata', 'shows delete metadata button');
+      assert.dom(PAGE.metadata.deleteMetadata).hasText('Permanently delete', 'shows delete metadata button');
       // delete flow
       await click(PAGE.metadata.deleteMetadata);
-      assert.dom(PAGE.detail.deleteModalTitle).includesText('Delete metadata?', 'modal has correct title');
+      assert
+        .dom(PAGE.detail.deleteModalTitle)
+        .includesText('Delete metadata and secret data?', 'modal has correct title');
       await click(PAGE.detail.deleteConfirm);
 
       // redirects to list

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -245,7 +245,7 @@ module('Acceptance | kv-v2 workflow | edge cases', function (hooks) {
       assert
         .dom(PAGE.detail.deleteModal)
         .hasText(
-          'Delete metadata? This will permanently delete the metadata and versions of the secret. All version history will be removed. This cannot be undone. Confirm Cancel'
+          'Delete metadata and secret data? This will permanently delete the metadata and versions of the secret. All version history will be removed. This cannot be undone. Confirm Cancel'
         );
     });
   });


### PR DESCRIPTION
See original PR [here](https://github.com/hashicorp/vault/pull/22773). 

Did a manual backport because the backport label does not exist yet for this release branch.