### PR TITLE
Copyright Format Update in .hbs Files

### DIFF
--- a/ui/app/components/get-credentials-card.hbs
+++ b/ui/app/components/get-credentials-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" this.transitionToCredential}} class="selectable-card is-rounded no-flex data-test-get-credentials-card">
   <div class="is-flex-between is-fullwidth card-details">

--- a/ui/app/components/modal-form/oidc-assignment-template.hbs
+++ b/ui/app/components/modal-form/oidc-assignment-template.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::AssignmentForm @onSave={{this.onSave}} @model={{this.assignment}} @onCancel={{@onCancel}} />

--- a/ui/app/components/modal-form/policy-template.hbs
+++ b/ui/app/components/modal-form/policy-template.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.policy.policyType}}
   <nav class="tabs has-bottom-margin-l">

--- a/ui/app/components/mount-backend/type-form.hbs
+++ b/ui/app/components/mount-backend/type-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each (array "generic" "cloud" "infra") as |category|}}
   <h3 class="title box-radio-header">

--- a/ui/app/components/policy-form.hbs
+++ b/ui/app/components/policy-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.save)}} data-test-policy-form>
   <div class="box is-bottomless is-fullwidth is-marginless">

--- a/ui/app/components/regex-validator.hbs
+++ b/ui/app/components/regex-validator.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @attr}}
   <div class="field" data-test-regex-validator-pattern>

--- a/ui/app/components/sidebar/frame.hbs
+++ b/ui/app/components/sidebar/frame.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::AppFrame @hasSidebar={{@showSidebar}} @hasHeader={{false}} @hasFooter={{false}} as |Frame|>
   <Frame.Sidebar data-test-sidebar-nav>

--- a/ui/app/components/sidebar/nav/access.hbs
+++ b/ui/app/components/sidebar/nav/access.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::SideNav::Portal @ariaLabel="Access Navigation Links" data-test-sidebar-nav-panel="Access" as |Nav|>
   <Nav.BackLink

--- a/ui/app/components/sidebar/nav/cluster.hbs
+++ b/ui/app/components/sidebar/nav/cluster.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::SideNav::Portal @ariaLabel="Cluster Navigation Links" data-test-sidebar-nav-panel="Cluster" as |Nav|>
   <Nav.Title data-test-sidebar-nav-heading="Vault">Vault</Nav.Title>

--- a/ui/app/components/sidebar/nav/policies.hbs
+++ b/ui/app/components/sidebar/nav/policies.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::SideNav::Portal @ariaLabel="Policies Navigation Links" data-test-sidebar-nav-panel="Policies" as |Nav|>
   <Nav.BackLink

--- a/ui/app/components/sidebar/nav/tools.hbs
+++ b/ui/app/components/sidebar/nav/tools.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::SideNav::Portal @ariaLabel="Tools Navigation Links" data-test-sidebar-nav-panel="Tools" as |Nav|>
   <Nav.BackLink

--- a/ui/app/components/sidebar/user-menu.hbs
+++ b/ui/app/components/sidebar/user-menu.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <BasicDropdown
   @horizontalPosition="right"

--- a/ui/app/components/wrap-ttl.hbs
+++ b/ui/app/components/wrap-ttl.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="field">
   <TtlPicker

--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Sidebar::Frame @showSidebar={{this.auth.isActiveSession}}>
   <div class="page-container">

--- a/ui/app/templates/components/alphabet-edit.hbs
+++ b/ui/app/templates/components/alphabet-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/auth-button-auth0.hbs
+++ b/ui/app/templates/components/auth-button-auth0.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-flex-v-centered auth-button-type-auth0">
   <div class="auth-button-tile is-flex-column is-flex-v-centered">

--- a/ui/app/templates/components/auth-button-gitlab.hbs
+++ b/ui/app/templates/components/auth-button-gitlab.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-flex-v-centered auth-button-type-gitlab">
   {{! template-lint-disable no-forbidden-elements }}

--- a/ui/app/templates/components/auth-button-google.hbs
+++ b/ui/app/templates/components/auth-button-google.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-flex-v-centered auth-button-type-google">
   <svg

--- a/ui/app/templates/components/auth-config-form/config.hbs
+++ b/ui/app/templates/components/auth-config-form/config.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{action (perform this.saveModel) on="submit"}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/auth-config-form/options.hbs
+++ b/ui/app/templates/components/auth-config-form/options.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{action (perform this.saveModel) on="submit"}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/auth-form-options.hbs
+++ b/ui/app/templates/components/auth-form-options.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#unless this.selectedAuthIsPath}}
   <div class="box has-slim-padding is-shadowless">

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="auth-form" data-test-auth-form>
   {{#if (and this.waitingForOktaNumberChallenge (not this.cancelAuthForOktaNumberChallenge))}}

--- a/ui/app/templates/components/auth-jwt.hbs
+++ b/ui/app/templates/components/auth-jwt.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form id="auth-form" onsubmit={{action (if this.isOIDC "startOIDCAuth" @onSubmit) (hash role=this.roleName jwt=this.jwt)}}>
   <div class="field">

--- a/ui/app/templates/components/auth-method/configuration.hbs
+++ b/ui/app/templates/components/auth-method/configuration.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   {{#each @model.attrs as |attr|}}

--- a/ui/app/templates/components/b64-toggle.hbs
+++ b/ui/app/templates/components/b64-toggle.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.isBase64}}
   Decode from base64

--- a/ui/app/templates/components/block-error.hbs
+++ b/ui/app/templates/components/block-error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-sideless has-background-white-bis has-text-grey has-text-centered">
   {{yield}}

--- a/ui/app/templates/components/calendar-widget.hbs
+++ b/ui/app/templates/components/calendar-widget.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <BasicDropdown @class="popup-menu" @horizontalPosition="auto-right" @verticalPosition="below" as |D|>
   <D.Trigger data-test-calendar-widget-trigger class={{concat "toolbar-link" (if D.isOpen " is-active")}} @htmlTag="button">

--- a/ui/app/templates/components/clients/attribution.hbs
+++ b/ui/app/templates/components/clients/attribution.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! only show side-by-side horizontal bar charts if data is from a single, historical month }}
 <div

--- a/ui/app/templates/components/clients/config.hbs
+++ b/ui/app/templates/components/clients/config.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq @mode "edit")}}
   <form onsubmit={{action "onSaveChanges"}} data-test-clients-config-form>

--- a/ui/app/templates/components/clients/dashboard.hbs
+++ b/ui/app/templates/components/clients/dashboard.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-sideless is-fullwidth is-marginless is-bottomless">
   <p class="has-bottom-margin-xl">

--- a/ui/app/templates/components/clients/error.hbs
+++ b/ui/app/templates/components/clients/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <EmptyState
   @title={{if (eq @error.httpStatus 403) "You are not authorized" "Error"}}

--- a/ui/app/templates/components/clients/horizontal-bar-chart.hbs
+++ b/ui/app/templates/components/clients/horizontal-bar-chart.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @dataset}}
   <svg

--- a/ui/app/templates/components/clients/line-chart.hbs
+++ b/ui/app/templates/components/clients/line-chart.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @dataset}}
   <svg

--- a/ui/app/templates/components/clients/monthly-usage.hbs
+++ b/ui/app/templates/components/clients/monthly-usage.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="chart-wrapper single-chart-grid" data-test-monthly-usage>
   <div class="chart-header has-bottom-margin-xl">

--- a/ui/app/templates/components/clients/running-total.hbs
+++ b/ui/app/templates/components/clients/running-total.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (gt @byMonthActivityData.length 1)}}
   <div class="chart-wrapper stacked-charts" data-test-running-total="monthly-charts">

--- a/ui/app/templates/components/clients/usage-stats.hbs
+++ b/ui/app/templates/components/clients/usage-stats.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="chart-wrapper" data-test-usage-stats>
   <div class="chart-header has-header-link has-bottom-margin-m">

--- a/ui/app/templates/components/clients/vertical-bar-chart.hbs
+++ b/ui/app/templates/components/clients/vertical-bar-chart.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @dataset}}
   <svg

--- a/ui/app/templates/components/configure-aws-secret.hbs
+++ b/ui/app/templates/components/configure-aws-secret.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
   <nav class="tabs">

--- a/ui/app/templates/components/configure-ssh-secret.hbs
+++ b/ui/app/templates/components/configure-ssh-secret.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @configured}}
   <div class="box is-fullwidth is-sideless is-marginless">

--- a/ui/app/templates/components/console/command-input.hbs
+++ b/ui/app/templates/components/console/command-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-ui-input" data-test-component="console/command-input">
   {{#if this.isRunning}}

--- a/ui/app/templates/components/console/log-command.hbs
+++ b/ui/app/templates/components/console/log-command.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-flex-center">
   <Icon @name="chevron-right" />

--- a/ui/app/templates/components/console/log-error-with-html.hbs
+++ b/ui/app/templates/components/console/log-error-with-html.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable no-triple-curlies}}
 <div class="console-ui-alert has-text-danger">

--- a/ui/app/templates/components/console/log-error.hbs
+++ b/ui/app/templates/components/console/log-error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-ui-alert has-text-danger">
   <Icon @name="x-circle-fill" />

--- a/ui/app/templates/components/console/log-help.hbs
+++ b/ui/app/templates/components/console/log-help.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable no-whitespace-for-layout }}
 {{! prettier-ignore }}

--- a/ui/app/templates/components/console/log-json.hbs
+++ b/ui/app/templates/components/console/log-json.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-ui-output has-copy-button">
   <JsonEditor

--- a/ui/app/templates/components/console/log-list.hbs
+++ b/ui/app/templates/components/console/log-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-ui-output has-copy-button">
   <pre>

--- a/ui/app/templates/components/console/log-object.hbs
+++ b/ui/app/templates/components/console/log-object.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-ui-output has-copy-button">
   <pre>{{this.columns}}</pre>

--- a/ui/app/templates/components/console/log-success.hbs
+++ b/ui/app/templates/components/console/log-success.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-ui-alert has-text-success">
   <Icon @name="check-circle-fill" />

--- a/ui/app/templates/components/console/log-text.hbs
+++ b/ui/app/templates/components/console/log-text.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-ui-output has-copy-button">
   <pre>{{@content}}</pre>

--- a/ui/app/templates/components/console/output-log.hbs
+++ b/ui/app/templates/components/console/output-log.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each this.outputLog as |message|}}
   {{#unless message.hidden}}

--- a/ui/app/templates/components/console/ui-panel.hbs
+++ b/ui/app/templates/components/console/ui-panel.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-close-button">
   <button type="button" class="button is-ghost" {{action "closeConsole"}} data-test-console-panel-close>

--- a/ui/app/templates/components/control-group-success.hbs
+++ b/ui/app/templates/components/control-group-success.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and this.controlGroupResponse.token this.controlGroupResponse.uiParams.url)}}
   <div class="control-group-success" data-test-navigate-message>

--- a/ui/app/templates/components/control-group.hbs
+++ b/ui/app/templates/components/control-group.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-bottomless is-sideless">
   <MessageError @model={{this.model}} />

--- a/ui/app/templates/components/dashboard/replication-card.hbs
+++ b/ui/app/templates/components/dashboard/replication-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 <Hds::Card::Container @hasBorder={{true}} class="has-padding-l has-bottom-padding-m" data-test-card="replication">
 
   <div class="is-flex-between">

--- a/ui/app/templates/components/dashboard/replication-state-text.hbs
+++ b/ui/app/templates/components/dashboard/replication-state-text.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div>
   <h2 class="is-size-5 has-text-weight-semibold has-bottom-margin-xs" data-test-title={{@title}}>

--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/database-role-edit.hbs
+++ b/ui/app/templates/components/database-role-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/database-role-setting-form.hbs
+++ b/ui/app/templates/components/database-role-setting-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-sideless is-fullwidth is-marginless" data-test-role-settings-section>
   <h3 class="title is-5">Role settings</h3>

--- a/ui/app/templates/components/date-dropdown.hbs
+++ b/ui/app/templates/components/date-dropdown.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="modal-card-custom has-padding-btm-left">
   <BasicDropdown @class="popup-menu" @horizontalPosition="auto-right" @verticalPosition="below" as |D|>

--- a/ui/app/templates/components/diff-version-selector.hbs
+++ b/ui/app/templates/components/diff-version-selector.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! TODO kv engine cleanup }}
 <Toolbar>

--- a/ui/app/templates/components/file-to-array-buffer.hbs
+++ b/ui/app/templates/components/file-to-array-buffer.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="field">
   <div class="control is-expanded">

--- a/ui/app/templates/components/form-field-from-model.hbs
+++ b/ui/app/templates/components/form-field-from-model.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-configure simple-unless "warn"  }}
 <div class="field" data-test-form-field-from-model>

--- a/ui/app/templates/components/generate-credentials-database.hbs
+++ b/ui/app/templates/components/generate-credentials-database.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/generate-credentials.hbs
+++ b/ui/app/templates/components/generate-credentials.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/generated-item-list.hbs
+++ b/ui/app/templates/components/generated-item-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/generated-item.hbs
+++ b/ui/app/templates/components/generated-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/hover-copy-button.hbs
+++ b/ui/app/templates/components/hover-copy-button.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class={{if this.alwaysShow "hover-copy-button-static" "hover-copy-button"}} data-test-hover-copy>
   <ToolTip @onClose={{action (mut this.tooltipText) "Copy"}} as |T|>

--- a/ui/app/templates/components/identity/edit-form.hbs
+++ b/ui/app/templates/components/identity/edit-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and (eq this.mode "edit") this.model.canDelete)}}
   <Toolbar>

--- a/ui/app/templates/components/identity/entity-nav.hbs
+++ b/ui/app/templates/components/identity/entity-nav.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/components/identity/item-alias/alias-details.hbs
+++ b/ui/app/templates/components/identity/item-alias/alias-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <InfoTableRow @label="Name" @value={{@model.name}} data-test-alias-name={{true}} />
 <InfoTableRow @label="ID" @value={{@model.id}} />

--- a/ui/app/templates/components/identity/item-alias/alias-metadata.hbs
+++ b/ui/app/templates/components/identity/item-alias/alias-metadata.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each-in @model.metadata as |key value|}}
   <div class="info-table-row is-mobile">

--- a/ui/app/templates/components/identity/item-aliases.hbs
+++ b/ui/app/templates/components/identity/item-aliases.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each (if @model.alias.id (array @model.alias) @model.aliases) as |item|}}
   <LinkedBlock @params={{array "vault.cluster.access.identity.aliases.show" item.id "details"}} class="list-item-row">

--- a/ui/app/templates/components/identity/item-details.hbs
+++ b/ui/app/templates/components/identity/item-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-shadowless is-marginless is-fullwidth">
   {{#if @model.disabled}}

--- a/ui/app/templates/components/identity/item-groups.hbs
+++ b/ui/app/templates/components/identity/item-groups.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @model.groupIds}}
   {{#each @model.directGroupIds as |gid|}}

--- a/ui/app/templates/components/identity/item-members.hbs
+++ b/ui/app/templates/components/identity/item-members.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @model.hasMembers}}
   {{#each @model.memberGroupIds as |gid|}}

--- a/ui/app/templates/components/identity/item-metadata.hbs
+++ b/ui/app/templates/components/identity/item-metadata.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each-in @model.metadata as |key value|}}
   <div class="info-table-row is-mobile">

--- a/ui/app/templates/components/identity/item-parent-groups.hbs
+++ b/ui/app/templates/components/identity/item-parent-groups.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @model.parentGroupIds.length}}
   {{#each @model.parentGroupIds as |gid|}}

--- a/ui/app/templates/components/identity/item-policies.hbs
+++ b/ui/app/templates/components/identity/item-policies.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each @model.policies as |policyName|}}
   <LinkedBlock @params={{array "vault.cluster.policy.show" "acl" policyName}} class="list-item-row">

--- a/ui/app/templates/components/identity/lookup-input.hbs
+++ b/ui/app/templates/components/identity/lookup-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{action (perform this.lookup) on="submit"}}>
   <div class="field is-flex">

--- a/ui/app/templates/components/identity/popup-alias.hbs
+++ b/ui/app/templates/components/identity/popup-alias.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PopupMenu @name="alias-menu">
   <Confirm as |c|>

--- a/ui/app/templates/components/identity/popup-members.hbs
+++ b/ui/app/templates/components/identity/popup-members.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PopupMenu @name="member-edit-menu">
   <nav class="menu">

--- a/ui/app/templates/components/identity/popup-metadata.hbs
+++ b/ui/app/templates/components/identity/popup-metadata.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PopupMenu @name="metadata-edit-menu">
   <nav class="menu">

--- a/ui/app/templates/components/identity/popup-policy.hbs
+++ b/ui/app/templates/components/identity/popup-policy.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PopupMenu @name="policy-menu">
   <nav class="menu">

--- a/ui/app/templates/components/key-version-select.hbs
+++ b/ui/app/templates/components/key-version-select.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (gt this.key.keysForEncryption.length 1)}}
   <div class="field" data-test-transit-key-version-select={{true}}>

--- a/ui/app/templates/components/keymgmt/distribute.hbs
+++ b/ui/app/templates/components/keymgmt/distribute.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @backend}}
   {{#if this.formErrors}}

--- a/ui/app/templates/components/keymgmt/key-edit.hbs
+++ b/ui/app/templates/components/keymgmt/key-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/keymgmt/provider-edit.hbs
+++ b/ui/app/templates/components/keymgmt/provider-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/license-banners.hbs
+++ b/ui/app/templates/components/license-banners.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and this.licenseExpired (not this.expiredDismissed))}}
   <div class="license-banner-wrapper">

--- a/ui/app/templates/components/license-info.hbs
+++ b/ui/app/templates/components/license-info.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/components/link-status.hbs
+++ b/ui/app/templates/components/link-status.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and this.state this.version.isEnterprise)}}
   <div class="link-status {{if (eq this.state 'connected') 'connected' 'warning'}}">

--- a/ui/app/templates/components/logo-edition.hbs
+++ b/ui/app/templates/components/logo-edition.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <svg width="146" height="51" viewBox="0 0 146 51" xmlns="http://www.w3.org/2000/svg">
   <g id="vault-logo-v" fill-rule="nonzero">

--- a/ui/app/templates/components/logo-splash.hbs
+++ b/ui/app/templates/components/logo-splash.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-flex-v-centered is-flex-grow-1">
   <div class="columns is-centered">

--- a/ui/app/templates/components/mfa/login-enforcement-list-item.hbs
+++ b/ui/app/templates/components/mfa/login-enforcement-list-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkedBlock
   class="list-item-row"

--- a/ui/app/templates/components/mfa/method-form.hbs
+++ b/ui/app/templates/components/mfa/method-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-sideless is-fullwidth is-marginless" ...attributes>
   {{#each @model.attrs as |attr|}}

--- a/ui/app/templates/components/mfa/method-list-item.hbs
+++ b/ui/app/templates/components/mfa/method-list-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkedBlock
   class="list-item-row"

--- a/ui/app/templates/components/mfa/mfa-form.hbs
+++ b/ui/app/templates/components/mfa/mfa-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="auth-form" data-test-mfa-form>
   <div class="box is-marginless is-shadowless">

--- a/ui/app/templates/components/mfa/mfa-login-enforcement-form.hbs
+++ b/ui/app/templates/components/mfa/mfa-login-enforcement-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div ...attributes>
   <FormFieldLabel

--- a/ui/app/templates/components/mfa/mfa-login-enforcement-header.hbs
+++ b/ui/app/templates/components/mfa/mfa-login-enforcement-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @isInline}}
   <h3 class="title is-5" data-test-mleh-title>Enforcement</h3>

--- a/ui/app/templates/components/mfa/mfa-setup-step-one.hbs
+++ b/ui/app/templates/components/mfa/mfa-setup-step-one.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div ...attributes>
   <p>

--- a/ui/app/templates/components/mfa/mfa-setup-step-two.hbs
+++ b/ui/app/templates/components/mfa/mfa-setup-step-two.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div ...attributes>
   <p>

--- a/ui/app/templates/components/mfa/nav.hbs
+++ b/ui/app/templates/components/mfa/nav.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
   <nav class="tabs">

--- a/ui/app/templates/components/mount-accessor-select.hbs
+++ b/ui/app/templates/components/mount-accessor-select.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div ...attributes>
   {{#if @label}}

--- a/ui/app/templates/components/mount-backend-form.hbs
+++ b/ui/app/templates/components/mount-backend-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/components/mount-info.hbs
+++ b/ui/app/templates/components/mount-info.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/namespace-link.hbs
+++ b/ui/app/templates/components/namespace-link.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <ExternalLink
   @href={{this.namespaceLink}}

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="namespace-picker" ...attributes>
   <BasicDropdown @horizontalPosition="left" @verticalPosition="above" as |D|>

--- a/ui/app/templates/components/not-found.hbs
+++ b/ui/app/templates/components/not-found.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-shadowless" data-test-not-found>
   <PageHeader as |p|>

--- a/ui/app/templates/components/oidc-callback-splash.hbs
+++ b/ui/app/templates/components/oidc-callback-splash.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="splash-page-container section is-flex-v-centered-tablet is-flex-grow-1 is-fullwidth">
   <div class="columns is-centered is-gapless is-fullwidth">

--- a/ui/app/templates/components/oidc-consent-block.hbs
+++ b/ui/app/templates/components/oidc-consent-block.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.didCancel}}
   <h3 class="title is-3" data-test-consent-title>

--- a/ui/app/templates/components/oidc/assignment-form.hbs
+++ b/ui/app/templates/components/oidc/assignment-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.save)}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/oidc/client-form.hbs
+++ b/ui/app/templates/components/oidc/client-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/oidc/client-list.hbs
+++ b/ui/app/templates/components/oidc/client-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each @model as |client|}}
   <LinkedBlock

--- a/ui/app/templates/components/oidc/key-form.hbs
+++ b/ui/app/templates/components/oidc/key-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/oidc/provider-list.hbs
+++ b/ui/app/templates/components/oidc/provider-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each @model as |provider|}}
   <LinkedBlock

--- a/ui/app/templates/components/oidc/scope-form.hbs
+++ b/ui/app/templates/components/oidc/scope-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/okta-number-challenge.hbs
+++ b/ui/app/templates/components/okta-number-challenge.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="auth-form" data-test-okta-number-challenge>
   <div class="box is-marginless is-shadowless">

--- a/ui/app/templates/components/pagination-controls.hbs
+++ b/ui/app/templates/components/pagination-controls.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-flex-between is-flex-center" ...attributes>
   <div class="is-fullwidth is-flex-center">

--- a/ui/app/templates/components/pgp-file.hbs
+++ b/ui/app/templates/components/pgp-file.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="level is-mobile">
   <div class="level-left">

--- a/ui/app/templates/components/pgp-list.hbs
+++ b/ui/app/templates/components/pgp-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each this.listData as |key index|}}
   <PgpFile @key={{key}} @index={{index}} @onChange={{action "setKey"}} />

--- a/ui/app/templates/components/radial-progress.hbs
+++ b/ui/app/templates/components/radial-progress.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <circle
   data-test-path

--- a/ui/app/templates/components/raft-join.hbs
+++ b/ui/app/templates/components/raft-join.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Alert @type="inline" @color="warning" as |A|>
   <A.Title class="alert-title">Vault is sealed</A.Title>

--- a/ui/app/templates/components/raft-storage-overview.hbs
+++ b/ui/app/templates/components/raft-storage-overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/components/raft-storage-restore.hbs
+++ b/ui/app/templates/components/raft-storage-restore.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/role-aws-edit.hbs
+++ b/ui/app/templates/components/role-aws-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/role-ssh-edit.hbs
+++ b/ui/app/templates/components/role-ssh-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq @mode "create")}}
   <form

--- a/ui/app/templates/components/secret-delete-menu.hbs
+++ b/ui/app/templates/components/secret-delete-menu.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @isV2}}
   {{#if (and this.canUndeleteVersion @modelForData.deleted)}}

--- a/ui/app/templates/components/secret-edit-metadata.hbs
+++ b/ui/app/templates/components/secret-edit-metadata.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form onsubmit={{this.onSaveChanges}}>
   <div

--- a/ui/app/templates/components/secret-edit-toolbar.hbs
+++ b/ui/app/templates/components/secret-edit-toolbar.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-configure simple-unless "warn" }}
 <Toolbar>

--- a/ui/app/templates/components/secret-edit.hbs
+++ b/ui/app/templates/components/secret-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div {{did-insert this.createKvData @model}}>
   <PageHeader as |p|>

--- a/ui/app/templates/components/secret-form-show.hbs
+++ b/ui/app/templates/components/secret-form-show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! TODO kv engine cleanup : this component can remove all logic related to V2 }}
 {{#if (and @isV2 @modelForData.destroyed)}}

--- a/ui/app/templates/components/secret-link.hbs
+++ b/ui/app/templates/components/secret-link.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkTo @route={{this.link.route}} @models={{this.link.models}} @query={{this.query}} @disabled={{@disabled}} ...attributes>
   {{yield}}

--- a/ui/app/templates/components/secret-list/aws-role-item.hbs
+++ b/ui/app/templates/components/secret-list/aws-role-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkedBlock
   @params={{array (concat "vault.cluster.secrets.backend." "credentials" (unless @item.id "-root")) @item.id}}

--- a/ui/app/templates/components/secret-list/database-list-item.hbs
+++ b/ui/app/templates/components/secret-list/database-list-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkedBlock
   @params={{array "vault.cluster.secrets.backend.show" (if this.keyTypeValue (concat "role/" @item.id) @item.id)}}

--- a/ui/app/templates/components/secret-list/item.hbs
+++ b/ui/app/templates/components/secret-list/item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkedBlock
   @params={{array

--- a/ui/app/templates/components/secret-list/ssh-role-item.hbs
+++ b/ui/app/templates/components/secret-list/ssh-role-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkedBlock
   @params={{array

--- a/ui/app/templates/components/secret-list/transform-list-item.hbs
+++ b/ui/app/templates/components/secret-list/transform-list-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and @item.updatePath.canRead (not this.isBuiltin))}}
   <LinkedBlock

--- a/ui/app/templates/components/secret-list/transform-transformation-item.hbs
+++ b/ui/app/templates/components/secret-list/transform-transformation-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! CBS TODO do not let click if !canRead }}
 {{#if (eq @options.item "transformation")}}

--- a/ui/app/templates/components/secret-version-menu.hbs
+++ b/ui/app/templates/components/secret-version-menu.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! TODO kv engine cleanup : this component can be deleted in favor of <KvVersionDropdown/> }}
 <BasicDropdown @class="popup-menu" @horizontalPosition="auto-right" @verticalPosition="below" as |D|>

--- a/ui/app/templates/components/section-tabs.hbs
+++ b/ui/app/templates/components/section-tabs.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#let (tabs-for-auth-section this.model this.tabType this.paths) as |tabs|}}
   {{#if tabs.length}}

--- a/ui/app/templates/components/selectable-card.hbs
+++ b/ui/app/templates/components/selectable-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! conditional to check if SelectableCard is apart of a CSS Grid, if yes return grid item class }}
 {{#if this.gridContainer}}

--- a/ui/app/templates/components/shamir-progress.hbs
+++ b/ui/app/templates/components/shamir-progress.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="level">
   <div class="level-left">

--- a/ui/app/templates/components/splash-page.hbs
+++ b/ui/app/templates/components/splash-page.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! bypass container styling }}
 {{#if @hasAltContent}}

--- a/ui/app/templates/components/token-expire-warning.hbs
+++ b/ui/app/templates/components/token-expire-warning.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and this.showWarning (is-after (now interval=1000) @expirationDate))}}
   <Hds::Alert @type="page" @color="critical" as |A|>

--- a/ui/app/templates/components/tool-actions-form.hbs
+++ b/ui/app/templates/components/tool-actions-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form onsubmit={{action "doSubmit"}}>
   {{#if (eq this.selectedAction "hash")}}

--- a/ui/app/templates/components/tool-hash.hbs
+++ b/ui/app/templates/components/tool-hash.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/components/tool-lookup.hbs
+++ b/ui/app/templates/components/tool-lookup.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/components/tool-random.hbs
+++ b/ui/app/templates/components/tool-random.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/components/tool-rewrap.hbs
+++ b/ui/app/templates/components/tool-rewrap.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/components/tool-unwrap.hbs
+++ b/ui/app/templates/components/tool-unwrap.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/components/tool-wrap.hbs
+++ b/ui/app/templates/components/tool-wrap.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/components/toolbar-secret-link.hbs
+++ b/ui/app/templates/components/toolbar-secret-link.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SecretLink
   @mode={{@mode}}

--- a/ui/app/templates/components/transform-advanced-templating.hbs
+++ b/ui/app/templates/components/transform-advanced-templating.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <ToggleButton
   @isOpen={{this.showForm}}

--- a/ui/app/templates/components/transform-create-form.hbs
+++ b/ui/app/templates/components/transform-create-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form onsubmit={{action "createOrUpdate" "create"}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/transform-edit-form.hbs
+++ b/ui/app/templates/components/transform-edit-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form onsubmit={{action "createOrUpdate" "create"}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/transform-role-edit.hbs
+++ b/ui/app/templates/components/transform-role-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   {{#each this.model.transformFieldAttrs as |attr|}}

--- a/ui/app/templates/components/transform-template-edit.hbs
+++ b/ui/app/templates/components/transform-template-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/transformation-edit.hbs
+++ b/ui/app/templates/components/transformation-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/transit-edit.hbs
+++ b/ui/app/templates/components/transit-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/transit-form-create.hbs
+++ b/ui/app/templates/components/transit-form-create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form data-test-transit-create-form onsubmit={{@createOrUpdateKey}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/transit-form-edit.hbs
+++ b/ui/app/templates/components/transit-form-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form data-test-transit-edit-form onsubmit={{@createOrUpdateKey}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/transit-form-show.hbs
+++ b/ui/app/templates/components/transit-form-show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
   <nav class="tabs" aria-label="tabs">

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form onsubmit={{action @doSubmit (hash param=@param context=@context nonce=@nonce bits=@bits)}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form onsubmit={{action @doSubmit (hash ciphertext=@ciphertext context=@context nonce=@nonce)}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form
   onsubmit={{action

--- a/ui/app/templates/components/transit-key-action/export.hbs
+++ b/ui/app/templates/components/transit-key-action/export.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form
   onsubmit={{action

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form
   onsubmit={{action

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form onsubmit={{action @doSubmit (hash ciphertext=@ciphertext context=@context nonce=@nonce key_version=@key_version)}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/transit-key-action/sign.hbs
+++ b/ui/app/templates/components/transit-key-action/sign.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form
   onsubmit={{action

--- a/ui/app/templates/components/transit-key-action/verify.hbs
+++ b/ui/app/templates/components/transit-key-action/verify.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form
   onsubmit={{action

--- a/ui/app/templates/components/transit-key-actions.hbs
+++ b/ui/app/templates/components/transit-key-actions.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq this.selectedAction "rotate")}}
   {{#if this.key.canRotate}}

--- a/ui/app/templates/components/ui-wizard.hbs
+++ b/ui/app/templates/components/ui-wizard.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="app-content {{if (and this.shouldRender this.featureComponent) 'wizard-open'}}">
   {{yield}}

--- a/ui/app/templates/components/wizard-content.hbs
+++ b/ui/app/templates/components/wizard-content.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="wizard-header">
   {{#unless this.hidePopup}}

--- a/ui/app/templates/components/wizard-progress.hbs
+++ b/ui/app/templates/components/wizard-progress.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="progress-container">
   {{#each @progressBar as |bar|}}

--- a/ui/app/templates/components/wizard-section.hbs
+++ b/ui/app/templates/components/wizard-section.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="wizard-section {{@class}}">
   <h2 class="title is-6">

--- a/ui/app/templates/components/wizard/alicloud-engine.hbs
+++ b/ui/app/templates/components/wizard/alicloud-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="AliCloud"

--- a/ui/app/templates/components/wizard/alicloud-method.hbs
+++ b/ui/app/templates/components/wizard/alicloud-method.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="AliCloud"

--- a/ui/app/templates/components/wizard/approle-method.hbs
+++ b/ui/app/templates/components/wizard/approle-method.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="AppRole"

--- a/ui/app/templates/components/wizard/auth-config.hbs
+++ b/ui/app/templates/components/wizard/auth-config.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Configuring your Auth Method"

--- a/ui/app/templates/components/wizard/auth-details.hbs
+++ b/ui/app/templates/components/wizard/auth-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection @headerText="Auth Method Details" @docText="Docs: Authentication Methods" @docPath="/docs/auth/index.html">
   <p>

--- a/ui/app/templates/components/wizard/auth-edit.hbs
+++ b/ui/app/templates/components/wizard/auth-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardSection

--- a/ui/app/templates/components/wizard/auth-enable.hbs
+++ b/ui/app/templates/components/wizard/auth-enable.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Entering Auth Method details"

--- a/ui/app/templates/components/wizard/auth-idle.hbs
+++ b/ui/app/templates/components/wizard/auth-idle.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardSection

--- a/ui/app/templates/components/wizard/auth-list.hbs
+++ b/ui/app/templates/components/wizard/auth-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardSection

--- a/ui/app/templates/components/wizard/aws-engine.hbs
+++ b/ui/app/templates/components/wizard/aws-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="AWS"

--- a/ui/app/templates/components/wizard/aws-method.hbs
+++ b/ui/app/templates/components/wizard/aws-method.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection @headerText="AWS" @headerIcon="aws-color" @docText="Docs: AWS Authentication" @docPath="/docs/auth/aws.html">
   <p>

--- a/ui/app/templates/components/wizard/azure-engine.hbs
+++ b/ui/app/templates/components/wizard/azure-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Azure"

--- a/ui/app/templates/components/wizard/azure-method.hbs
+++ b/ui/app/templates/components/wizard/azure-method.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Azure"

--- a/ui/app/templates/components/wizard/cert-method.hbs
+++ b/ui/app/templates/components/wizard/cert-method.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="TLS Certificates"

--- a/ui/app/templates/components/wizard/ch-engine.hbs
+++ b/ui/app/templates/components/wizard/ch-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection @headerText="Cubbyhole" @docText="Docs: Cubbyhole Secrets" @docPath="/docs/secrets/cubbyhole/index.html">
   <p>

--- a/ui/app/templates/components/wizard/consul-engine.hbs
+++ b/ui/app/templates/components/wizard/consul-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Consul"

--- a/ui/app/templates/components/wizard/database-engine.hbs
+++ b/ui/app/templates/components/wizard/database-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Databases"

--- a/ui/app/templates/components/wizard/features-selection.hbs
+++ b/ui/app/templates/components/wizard/features-selection.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardContent @headerText="Vault Web UI" @glyph="tour" @selectProgress={{this.selectProgress}}>
   <h2 class="title is-6">

--- a/ui/app/templates/components/wizard/gcp-engine.hbs
+++ b/ui/app/templates/components/wizard/gcp-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Google Cloud"

--- a/ui/app/templates/components/wizard/gcp-method.hbs
+++ b/ui/app/templates/components/wizard/gcp-method.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Google Cloud"

--- a/ui/app/templates/components/wizard/gcpkms-engine.hbs
+++ b/ui/app/templates/components/wizard/gcpkms-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Google Cloud KMS"

--- a/ui/app/templates/components/wizard/github-method.hbs
+++ b/ui/app/templates/components/wizard/github-method.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="GitHub"

--- a/ui/app/templates/components/wizard/init-login.hbs
+++ b/ui/app/templates/components/wizard/init-login.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardContent @headerText="Authentication" @glyph="tour">
   <WizardSection @headerText="Authenticate to Vault" @docText="Learn: Initialization" @docPath="/docs/concepts/tokens.html">

--- a/ui/app/templates/components/wizard/init-save-keys.hbs
+++ b/ui/app/templates/components/wizard/init-save-keys.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardContent @headerText="Initialization" @glyph="tour">
   <WizardSection

--- a/ui/app/templates/components/wizard/init-setup.hbs
+++ b/ui/app/templates/components/wizard/init-setup.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardContent @headerText="Initialization" @glyph="tour">
   <WizardSection

--- a/ui/app/templates/components/wizard/init-unseal.hbs
+++ b/ui/app/templates/components/wizard/init-unseal.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardContent @headerText="Initialization" @glyph="tour">
   <WizardSection

--- a/ui/app/templates/components/wizard/keymgmt-engine.hbs
+++ b/ui/app/templates/components/wizard/keymgmt-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Key Management"

--- a/ui/app/templates/components/wizard/kmip-engine.hbs
+++ b/ui/app/templates/components/wizard/kmip-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="KMIP"

--- a/ui/app/templates/components/wizard/kubernetes-method.hbs
+++ b/ui/app/templates/components/wizard/kubernetes-method.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Kubernetes"

--- a/ui/app/templates/components/wizard/kv-engine.hbs
+++ b/ui/app/templates/components/wizard/kv-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Key/Value"

--- a/ui/app/templates/components/wizard/ldap-method.hbs
+++ b/ui/app/templates/components/wizard/ldap-method.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection @headerText="LDAP" @headerIcon="user" @docText="Docs: LDAP Authentication" @docPath="/docs/auth/ldap.html">
   <p>

--- a/ui/app/templates/components/wizard/mounts-wizard.hbs
+++ b/ui/app/templates/components/wizard/mounts-wizard.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardContent @headerText={{capitalize this.currentMachine}} @glyph="tour">
   {{component

--- a/ui/app/templates/components/wizard/nomad-engine.hbs
+++ b/ui/app/templates/components/wizard/nomad-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Nomad"

--- a/ui/app/templates/components/wizard/okta-method.hbs
+++ b/ui/app/templates/components/wizard/okta-method.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Okta"

--- a/ui/app/templates/components/wizard/pki-engine.hbs
+++ b/ui/app/templates/components/wizard/pki-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="PKI"

--- a/ui/app/templates/components/wizard/policies-create.hbs
+++ b/ui/app/templates/components/wizard/policies-create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardContent @headerText="Policies" @glyph="tour">

--- a/ui/app/templates/components/wizard/policies-delete.hbs
+++ b/ui/app/templates/components/wizard/policies-delete.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardContent @headerText="Policies" @glyph="tour">

--- a/ui/app/templates/components/wizard/policies-details.hbs
+++ b/ui/app/templates/components/wizard/policies-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardContent @headerText="Policies" @glyph="tour">

--- a/ui/app/templates/components/wizard/policies-intro.hbs
+++ b/ui/app/templates/components/wizard/policies-intro.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardContent @headerText="Policies" @glyph="tour">

--- a/ui/app/templates/components/wizard/policies-others.hbs
+++ b/ui/app/templates/components/wizard/policies-others.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardContent @headerText="Policies" @glyph="tour">
   <WizardSection @headerText="Other kinds of policies" @docText="Docs: Policies" @docPath="/docs/concepts/policies.html">

--- a/ui/app/templates/components/wizard/rabbitmq-engine.hbs
+++ b/ui/app/templates/components/wizard/rabbitmq-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="RabbitMQ"

--- a/ui/app/templates/components/wizard/radius-method.hbs
+++ b/ui/app/templates/components/wizard/radius-method.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="RADIUS"

--- a/ui/app/templates/components/wizard/replication-setup.hbs
+++ b/ui/app/templates/components/wizard/replication-setup.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardContent @headerText="Replication" @glyph="tour">

--- a/ui/app/templates/components/wizard/secrets-connection-show.hbs
+++ b/ui/app/templates/components/wizard/secrets-connection-show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection @headerText="Create a Role" @instructions="Click “Add role.”">
   <p>

--- a/ui/app/templates/components/wizard/secrets-connection.hbs
+++ b/ui/app/templates/components/wizard/secrets-connection.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Connect a database"

--- a/ui/app/templates/components/wizard/secrets-credentials.hbs
+++ b/ui/app/templates/components/wizard/secrets-credentials.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection @headerText="Generate Credential">
   <p>

--- a/ui/app/templates/components/wizard/secrets-details.hbs
+++ b/ui/app/templates/components/wizard/secrets-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection @headerText="Your Secrets Engine" @instructions="Click on the link to add a {{@nextStep}} in the page header">
   <p>

--- a/ui/app/templates/components/wizard/secrets-display-database-role.hbs
+++ b/ui/app/templates/components/wizard/secrets-display-database-role.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection @headerText="Create a Role" @instructions="Edit the details of your role and click “Create role.”">
   <p>

--- a/ui/app/templates/components/wizard/secrets-display-role.hbs
+++ b/ui/app/templates/components/wizard/secrets-display-role.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection @headerText="Your new role">
   <p>

--- a/ui/app/templates/components/wizard/secrets-display.hbs
+++ b/ui/app/templates/components/wizard/secrets-display.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @isSupported}}
   <WizardSection

--- a/ui/app/templates/components/wizard/secrets-enable.hbs
+++ b/ui/app/templates/components/wizard/secrets-enable.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardSection

--- a/ui/app/templates/components/wizard/secrets-encryption.hbs
+++ b/ui/app/templates/components/wizard/secrets-encryption.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection @headerText="Adding an encryption key">
   <p>

--- a/ui/app/templates/components/wizard/secrets-idle.hbs
+++ b/ui/app/templates/components/wizard/secrets-idle.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardSection

--- a/ui/app/templates/components/wizard/secrets-keymgmt.hbs
+++ b/ui/app/templates/components/wizard/secrets-keymgmt.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection @headerText={{this.headerText}} @instructions={{this.instructions}}>
   <p>

--- a/ui/app/templates/components/wizard/secrets-list.hbs
+++ b/ui/app/templates/components/wizard/secrets-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardSection

--- a/ui/app/templates/components/wizard/secrets-role.hbs
+++ b/ui/app/templates/components/wizard/secrets-role.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardSection @headerText="Adding a role" @instructions='Enter your role details and click "Create role"'>

--- a/ui/app/templates/components/wizard/secrets-secret.hbs
+++ b/ui/app/templates/components/wizard/secrets-secret.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardSection @headerText="Adding a secret" @instructions='Enter the details of your secret and click "Save"'>

--- a/ui/app/templates/components/wizard/ssh-engine.hbs
+++ b/ui/app/templates/components/wizard/ssh-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="SSH"

--- a/ui/app/templates/components/wizard/tools-info.hbs
+++ b/ui/app/templates/components/wizard/tools-info.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardContent @headerText="Tools" @glyph="tour">

--- a/ui/app/templates/components/wizard/tools-lookup.hbs
+++ b/ui/app/templates/components/wizard/tools-lookup.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardContent @headerText="Tools" @glyph="tour">

--- a/ui/app/templates/components/wizard/tools-rewrap.hbs
+++ b/ui/app/templates/components/wizard/tools-rewrap.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardContent @headerText="Tools" @glyph="tour">

--- a/ui/app/templates/components/wizard/tools-rewrapped.hbs
+++ b/ui/app/templates/components/wizard/tools-rewrapped.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardContent @headerText="Tools" @glyph="tour">

--- a/ui/app/templates/components/wizard/tools-unwrap.hbs
+++ b/ui/app/templates/components/wizard/tools-unwrap.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardContent @headerText="Tools" @glyph="tour">

--- a/ui/app/templates/components/wizard/tools-unwrapped.hbs
+++ b/ui/app/templates/components/wizard/tools-unwrapped.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardContent @headerText="Tools" @glyph="tour">
   <WizardSection @headerText="Your unwrapped data" @docText="API: Unwrap Data" @docPath="/api/system/wrapping-unwrap.html">

--- a/ui/app/templates/components/wizard/tools-wrap.hbs
+++ b/ui/app/templates/components/wizard/tools-wrap.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardContent @headerText="Tools" @glyph="tour">

--- a/ui/app/templates/components/wizard/tools-wrapped.hbs
+++ b/ui/app/templates/components/wizard/tools-wrapped.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable quotes }}
 <WizardContent @headerText="Tools" @glyph="tour">

--- a/ui/app/templates/components/wizard/totp-engine.hbs
+++ b/ui/app/templates/components/wizard/totp-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="TOTP"

--- a/ui/app/templates/components/wizard/transit-engine.hbs
+++ b/ui/app/templates/components/wizard/transit-engine.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Transit"

--- a/ui/app/templates/components/wizard/tutorial-active.hbs
+++ b/ui/app/templates/components/wizard/tutorial-active.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable no-yield-only }}
 {{yield}}

--- a/ui/app/templates/components/wizard/tutorial-complete.hbs
+++ b/ui/app/templates/components/wizard/tutorial-complete.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardContent @headerText="Thanks for taking the tour!" @glyph="tour" @class="collapsed">
   <p>

--- a/ui/app/templates/components/wizard/tutorial-error.hbs
+++ b/ui/app/templates/components/wizard/tutorial-error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection @headerText="Oops!">
   <p>

--- a/ui/app/templates/components/wizard/tutorial-idle.hbs
+++ b/ui/app/templates/components/wizard/tutorial-idle.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardContent @headerText="Welcome to Vault" @glyph="tour" @class="collapsed" @hidePopup={{true}}>
   <button type="button" class="button is-transparent icon dismiss-collapsed" {{action @onDismiss}}>

--- a/ui/app/templates/components/wizard/tutorial-paused.hbs
+++ b/ui/app/templates/components/wizard/tutorial-paused.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardContent @headerText="Vault Web UI Guide" @glyph="tour" @class="collapsed" @hidePopup={{true}}>
   <button type="button" class="button is-transparent dismiss-collapsed" {{action @onDismiss}}>

--- a/ui/app/templates/components/wizard/userpass-method.hbs
+++ b/ui/app/templates/components/wizard/userpass-method.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <WizardSection
   @headerText="Username & Password"

--- a/ui/app/templates/loading.hbs
+++ b/ui/app/templates/loading.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.isCallback}}
   <OidcCallbackSplash />

--- a/ui/app/templates/vault.hbs
+++ b/ui/app/templates/vault.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}
 <footer class="footer has-text-grey has-text-centered">

--- a/ui/app/templates/vault/cluster.hbs
+++ b/ui/app/templates/vault/cluster.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Sidebar::Nav::Cluster />
 {{! Only show license banners for Enterprise }}

--- a/ui/app/templates/vault/cluster/access.hbs
+++ b/ui/app/templates/vault/cluster/access.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Sidebar::Nav::Access />
 {{outlet}}

--- a/ui/app/templates/vault/cluster/access/control-group-accessor.hbs
+++ b/ui/app/templates/vault/cluster/access/control-group-accessor.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (has-feature "Control Groups")}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/control-groups-configure.hbs
+++ b/ui/app/templates/vault/cluster/access/control-groups-configure.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (has-feature "Control Groups")}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/control-groups.hbs
+++ b/ui/app/templates/vault/cluster/access/control-groups.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (has-feature "Control Groups")}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/error.hbs
+++ b/ui/app/templates/vault/cluster/access/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq this.model.httpStatus 404)}}
   <NotFound @model={{this.model}} />

--- a/ui/app/templates/vault/cluster/access/identity/aliases/add.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/add.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/identity/aliases/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/identity/aliases/index.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Identity::EntityNav @identityType={{this.identityType}} @model={{this.model}} />
 {{#if this.model.meta.total}}

--- a/ui/app/templates/vault/cluster/access/identity/aliases/show.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/identity/create.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/identity/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/identity/index.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Identity::EntityNav @identityType={{this.identityType}} @model={{this.model}} />
 {{#if this.model.meta.total}}

--- a/ui/app/templates/vault/cluster/access/identity/merge.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/merge.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/identity/show.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/leases/error.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/leases/index.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/leases/list.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/leases/show.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/loading.hbs
+++ b/ui/app/templates/vault/cluster/access/loading.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LayoutLoading />

--- a/ui/app/templates/vault/cluster/access/method/item/create.hbs
+++ b/ui/app/templates/vault/cluster/access/method/item/create.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <GeneratedItem @model={{this.model}} @mode="create" @itemType={{this.model.itemType}} />

--- a/ui/app/templates/vault/cluster/access/method/item/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/method/item/edit.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <GeneratedItem @model={{this.model}} @mode="edit" @itemType={{this.itemType}} />

--- a/ui/app/templates/vault/cluster/access/method/item/list.hbs
+++ b/ui/app/templates/vault/cluster/access/method/item/list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <GeneratedItemList
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/access/method/item/show.hbs
+++ b/ui/app/templates/vault/cluster/access/method/item/show.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <GeneratedItem @model={{this.model}} @itemType={{this.itemType}} @mode="show" />

--- a/ui/app/templates/vault/cluster/access/method/section.hbs
+++ b/ui/app/templates/vault/cluster/access/method/section.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/methods.hbs
+++ b/ui/app/templates/vault/cluster/access/methods.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/mfa/enforcements/create.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/enforcements/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Mfa::MfaLoginEnforcementHeader @heading="New enforcement" />
 <Mfa::MfaLoginEnforcementForm

--- a/ui/app/templates/vault/cluster/access/mfa/enforcements/enforcement/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/enforcements/enforcement/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Mfa::MfaLoginEnforcementHeader @heading="Update enforcement" />
 <Mfa::MfaLoginEnforcementForm

--- a/ui/app/templates/vault/cluster/access/mfa/enforcements/enforcement/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/enforcements/enforcement/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/mfa/enforcements/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/enforcements/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/mfa/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/mfa/methods/create.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft class="has-border-bottom-light">

--- a/ui/app/templates/vault/cluster/access/mfa/methods/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/mfa/methods/method/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/method/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/mfa/methods/method/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/method/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/namespaces.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/app/templates/vault/cluster/access/namespaces/create.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (has-feature "Namespaces")}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/namespaces/index.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (has-feature "Namespaces")}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/oidc.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.header}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/oidc/assignments/assignment/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/assignments/assignment/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/oidc/assignments/assignment/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/assignments/assignment/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/oidc/assignments/create.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/assignments/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/oidc/assignments/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/assignments/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/clients/client.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/clients/client.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.showHeader}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/oidc/clients/client/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/clients/client/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar data-test-oidc-client-toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/clients/client/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/clients/client/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::ClientForm
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/access/oidc/clients/client/providers.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/clients/client/providers.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar />
 {{#if (gt this.model.length 0)}}

--- a/ui/app/templates/vault/cluster/access/oidc/clients/create.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/clients/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::ClientForm
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/access/oidc/clients/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/clients/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-shadowless" data-test-oidc-landing>
   <p>

--- a/ui/app/templates/vault/cluster/access/oidc/keys/create.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::KeyForm
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/access/oidc/keys/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/keys/key.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/key.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.showHeader}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/oidc/keys/key/clients.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/key/clients.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar />
 

--- a/ui/app/templates/vault/cluster/access/oidc/keys/key/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/key/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/keys/key/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/key/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::KeyForm
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/access/oidc/providers/create.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::ProviderForm
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/access/oidc/providers/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/providers/provider.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/provider.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.showHeader}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/oidc/providers/provider/clients.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/provider/clients.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar />
 

--- a/ui/app/templates/vault/cluster/access/oidc/providers/provider/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/provider/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/providers/provider/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/provider/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::ProviderForm
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/access/oidc/scopes/create.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/scopes/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::ScopeForm
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/access/oidc/scopes/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/scopes/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/scopes/scope/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/scopes/scope/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/oidc/scopes/scope/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/scopes/scope/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::ScopeForm
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/auth.hbs
+++ b/ui/app/templates/vault/cluster/auth.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SplashPage @hasAltContent={{this.mfaErrors}} as |Page|>
   <Page.altContent>

--- a/ui/app/templates/vault/cluster/clients.hbs
+++ b/ui/app/templates/vault/cluster/clients.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/clients/config.hbs
+++ b/ui/app/templates/vault/cluster/clients/config.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/clients/dashboard.hbs
+++ b/ui/app/templates/vault/cluster/clients/dashboard.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Clients::Dashboard @model={{@model}} />

--- a/ui/app/templates/vault/cluster/clients/edit.hbs
+++ b/ui/app/templates/vault/cluster/clients/edit.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Clients::Config @model={{@model}} @mode="edit" />

--- a/ui/app/templates/vault/cluster/clients/error.hbs
+++ b/ui/app/templates/vault/cluster/clients/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq @model.httpStatus 404)}}
   <NotFound @model={{this.model}} />

--- a/ui/app/templates/vault/cluster/clients/loading.hbs
+++ b/ui/app/templates/vault/cluster/clients/loading.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LayoutLoading />

--- a/ui/app/templates/vault/cluster/error.hbs
+++ b/ui/app/templates/vault/cluster/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq this.model.httpStatus 404)}}
   <NotFound @model={{this.model}} />

--- a/ui/app/templates/vault/cluster/init.hbs
+++ b/ui/app/templates/vault/cluster/init.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SplashPage as |Page|>
   {{#if (and this.model.usingRaft (not this.prefersInit))}}

--- a/ui/app/templates/vault/cluster/license.hbs
+++ b/ui/app/templates/vault/cluster/license.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LicenseInfo
   @startTime={{this.model.startTime}}

--- a/ui/app/templates/vault/cluster/loading.hbs
+++ b/ui/app/templates/vault/cluster/loading.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LayoutLoading />

--- a/ui/app/templates/vault/cluster/mfa-setup.hbs
+++ b/ui/app/templates/vault/cluster/mfa-setup.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SplashPage @showTruncatedNavBar={{false}} as |Page|>
   <Page.header>

--- a/ui/app/templates/vault/cluster/not-found.hbs
+++ b/ui/app/templates/vault/cluster/not-found.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <NotFound @model={{this.model}} />

--- a/ui/app/templates/vault/cluster/oidc-callback.hbs
+++ b/ui/app/templates/vault/cluster/oidc-callback.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#in-element this.pageContainer}}
   <OidcCallbackSplash />

--- a/ui/app/templates/vault/cluster/oidc-provider-ns.hbs
+++ b/ui/app/templates/vault/cluster/oidc-provider-ns.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="splash-page-container section is-flex-v-centered-tablet is-flex-grow-1 is-fullwidth">
   <div class="columns is-centered is-gapless is-fullwidth">

--- a/ui/app/templates/vault/cluster/oidc-provider.hbs
+++ b/ui/app/templates/vault/cluster/oidc-provider.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="splash-page-container section is-flex-v-centered-tablet is-flex-grow-1 is-fullwidth">
   <div class="columns is-centered is-gapless is-fullwidth">

--- a/ui/app/templates/vault/cluster/policies.hbs
+++ b/ui/app/templates/vault/cluster/policies.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Sidebar::Nav::Policies />
 {{outlet}}

--- a/ui/app/templates/vault/cluster/policies/create.hbs
+++ b/ui/app/templates/vault/cluster/policies/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/policies/index.hbs
+++ b/ui/app/templates/vault/cluster/policies/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (or (eq this.policyType "acl") (has-feature "Sentinel"))}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/policies/loading.hbs
+++ b/ui/app/templates/vault/cluster/policies/loading.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LayoutLoading />

--- a/ui/app/templates/vault/cluster/policy.hbs
+++ b/ui/app/templates/vault/cluster/policy.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Sidebar::Nav::Policies />
 {{outlet}}

--- a/ui/app/templates/vault/cluster/policy/edit.hbs
+++ b/ui/app/templates/vault/cluster/policy/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/policy/error.hbs
+++ b/ui/app/templates/vault/cluster/policy/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq this.model.httpStatus 404)}}
   <NotFound @model={{this.model}} />

--- a/ui/app/templates/vault/cluster/policy/loading.hbs
+++ b/ui/app/templates/vault/cluster/policy/loading.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LayoutLoading />

--- a/ui/app/templates/vault/cluster/policy/show.hbs
+++ b/ui/app/templates/vault/cluster/policy/show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/redirect.hbs
+++ b/ui/app/templates/vault/cluster/redirect.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LogoSplash />

--- a/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
+++ b/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <section class="section">
   <div class="container is-widescreen">

--- a/ui/app/templates/vault/cluster/replication-dr-promote/index.hbs
+++ b/ui/app/templates/vault/cluster/replication-dr-promote/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <section class="section">
   <div class="container is-widescreen">

--- a/ui/app/templates/vault/cluster/secrets/backend/configuration.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/configuration.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SecretListHeader
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/secrets/backend/credentials.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/credentials.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq this.model.backendType "database")}}
   <GenerateCredentialsDatabase

--- a/ui/app/templates/vault/cluster/secrets/backend/diff.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/diff.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! TODO kv engine cleanup }}
 <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/secrets/backend/edit-metadata.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/edit-metadata.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.model.canUpdateMetadata}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/secrets/backend/error.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-shadowless">
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/secrets/backend/list.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SecretListHeader
   @isCertTab={{eq this.tab "cert"}}

--- a/ui/app/templates/vault/cluster/secrets/backend/metadata.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/metadata.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/secrets/backend/overview.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SecretListHeader
   @isCertTab={{eq this.tab "cert"}}

--- a/ui/app/templates/vault/cluster/secrets/backend/secret-edit-layout.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/secret-edit-layout.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{component
   (get (options-for-backend this.backendType this.model.idPrefix) "editComponent")

--- a/ui/app/templates/vault/cluster/secrets/backend/sign.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/sign.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/secrets/backend/transit-actions-layout.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/transit-actions-layout.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="columns">
   <div class="column">

--- a/ui/app/templates/vault/cluster/secrets/backend/versions.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/versions.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/settings.hbs
+++ b/ui/app/templates/vault/cluster/settings.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/app/templates/vault/cluster/settings/auth.hbs
+++ b/ui/app/templates/vault/cluster/settings/auth.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Sidebar::Nav::Access />
 {{outlet}}

--- a/ui/app/templates/vault/cluster/settings/auth/configure.hbs
+++ b/ui/app/templates/vault/cluster/settings/auth/configure.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/settings/auth/configure/section.hbs
+++ b/ui/app/templates/vault/cluster/settings/auth/configure/section.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq this.model.section "options")}}
   {{auth-config-form/options this.model.model}}

--- a/ui/app/templates/vault/cluster/settings/auth/enable.hbs
+++ b/ui/app/templates/vault/cluster/settings/auth/enable.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <MountBackendForm @mountModel={{this.model}} @onMountSuccess={{action "onMountSuccess"}} />

--- a/ui/app/templates/vault/cluster/settings/configure-secret-backend.hbs
+++ b/ui/app/templates/vault/cluster/settings/configure-secret-backend.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/settings/mount-secret-backend.hbs
+++ b/ui/app/templates/vault/cluster/settings/mount-secret-backend.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <MountBackendForm @mountModel={{this.model}} @mountType="secret" @onMountSuccess={{action "onMountSuccess"}} />

--- a/ui/app/templates/vault/cluster/settings/seal.hbs
+++ b/ui/app/templates/vault/cluster/settings/seal.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/storage-restore.hbs
+++ b/ui/app/templates/vault/cluster/storage-restore.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <RaftStorageRestore />

--- a/ui/app/templates/vault/cluster/storage.hbs
+++ b/ui/app/templates/vault/cluster/storage.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <RaftStorageOverview @model={{this.model}} />

--- a/ui/app/templates/vault/cluster/tools.hbs
+++ b/ui/app/templates/vault/cluster/tools.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Sidebar::Nav::Tools />
 {{outlet}}

--- a/ui/app/templates/vault/cluster/tools/tool.hbs
+++ b/ui/app/templates/vault/cluster/tools/tool.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <ToolActionsForm @selectedAction={{this.selectedAction}} />

--- a/ui/app/templates/vault/cluster/unseal.hbs
+++ b/ui/app/templates/vault/cluster/unseal.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.showLicenseError}}
   <div class="section is-flex-v-centered-tablet is-flex-grow-1 is-fullwidth">

--- a/ui/app/templates/vault/error.hbs
+++ b/ui/app/templates/vault/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-flex-grow-1 is-flex-v-centered">
   <div class="empty-state-content">

--- a/ui/app/templates/vault/not-found.hbs
+++ b/ui/app/templates/vault/not-found.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <NotFound @model={{this.model}} />

--- a/ui/lib/core/addon/components/alert-inline.hbs
+++ b/ui/lib/core/addon/components/alert-inline.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   {{did-update this.refresh @message}}

--- a/ui/lib/core/addon/components/autocomplete-input.hbs
+++ b/ui/lib/core/addon/components/autocomplete-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div {{did-insert this.setElement}} ...attributes>
   {{#if @label}}

--- a/ui/lib/core/addon/components/box-radio.hbs
+++ b/ui/lib/core/addon/components/box-radio.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @disabled}}
   <div class="box-radio-spacing">

--- a/ui/lib/core/addon/components/certificate-card.hbs
+++ b/ui/lib/core/addon/components/certificate-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container
   @level="mid"

--- a/ui/lib/core/addon/components/checkbox-grid.hbs
+++ b/ui/lib/core/addon/components/checkbox-grid.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div data-test-checkbox-grid ...attributes>
   <FormFieldLabel for={{@name}} @label={{@label}} @subText={{@subText}} />

--- a/ui/lib/core/addon/components/chevron.hbs
+++ b/ui/lib/core/addon/components/chevron.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Icon
   @name={{this.glyph}}

--- a/ui/lib/core/addon/components/choose-pgp-key-form.hbs
+++ b/ui/lib/core/addon/components/choose-pgp-key-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.selectedPgp}}
   <form

--- a/ui/lib/core/addon/components/code-snippet.hbs
+++ b/ui/lib/core/addon/components/code-snippet.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div data-test-code-snippet class="code-snippet-container" ...attributes>
   <code class="text-grey-lightest">

--- a/ui/lib/core/addon/components/confirm-action.hbs
+++ b/ui/lib/core/addon/components/confirm-action.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="confirm-action" ...attributes>
   <BasicDropdown

--- a/ui/lib/core/addon/components/confirmation-modal.hbs
+++ b/ui/lib/core/addon/components/confirmation-modal.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Modal @title={{@title}} @onClose={{@onClose}} @isActive={{@isActive}} @type={{this.type}} @showCloseButton={{true}}>
   <section class="modal-card-body">

--- a/ui/lib/core/addon/components/download-button.hbs
+++ b/ui/lib/core/addon/components/download-button.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <button data-test-download-button type="button" {{on "click" this.handleDownload}} ...attributes>
   {{yield}}

--- a/ui/lib/core/addon/components/empty-state.hbs
+++ b/ui/lib/core/addon/components/empty-state.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div data-test-component="empty-state" class="empty-state" ...attributes>
   <div class="empty-state-content">

--- a/ui/lib/core/addon/components/external-link.hbs
+++ b/ui/lib/core/addon/components/external-link.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @sameTab}}
   <a href={{this.href}} ...attributes>

--- a/ui/lib/core/addon/components/field-group-show.hbs
+++ b/ui/lib/core/addon/components/field-group-show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   {{#each @model.fieldGroups as |fieldGroup|}}

--- a/ui/lib/core/addon/components/form-error.hbs
+++ b/ui/lib/core/addon/components/form-error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="has-top-margin-s is-flex is-flex-center" data-test-form-error>
   <div class="is-narrow message-icon">

--- a/ui/lib/core/addon/components/form-field-groups-loop.hbs
+++ b/ui/lib/core/addon/components/form-field-groups-loop.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each (get @model this.fieldGroups) as |fieldGroup|}}
   {{#each-in fieldGroup as |group fields|}}

--- a/ui/lib/core/addon/components/form-field-groups.hbs
+++ b/ui/lib/core/addon/components/form-field-groups.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each (get @model this.fieldGroups) as |fieldGroup|}}
   {{#each-in fieldGroup as |group fields|}}

--- a/ui/lib/core/addon/components/form-field-label.hbs
+++ b/ui/lib/core/addon/components/form-field-label.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @label}}
   <label class="is-label" ...attributes>

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-configure simple-unless "warn" }}
 <div class="field" data-test-field={{or @attr.name true}}>

--- a/ui/lib/core/addon/components/icon.hbs
+++ b/ui/lib/core/addon/components/icon.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.isFlightIcon}}
   <FlightIcon @name={{this.name}} @size={{this.size}} @stretched={{@stretched}} ...attributes />

--- a/ui/lib/core/addon/components/info-table-item-array.hbs
+++ b/ui/lib/core/addon/components/info-table-item-array.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! the class linked-block-item is needed for the read-more component }}
 <div data-test-info-table-item-array {{did-insert this.fetchOptions}} class="linked-block-item">

--- a/ui/lib/core/addon/components/info-table-row.hbs
+++ b/ui/lib/core/addon/components/info-table-row.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (or (has-block) this.isVisible)}}
   <div class="info-table-row" data-test-component="info-table-row" ...attributes>

--- a/ui/lib/core/addon/components/info-table.hbs
+++ b/ui/lib/core/addon/components/info-table.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="vlt-table info-table sticky-header" data-test-info-table>
   <table class="is-fullwidth">

--- a/ui/lib/core/addon/components/info-tooltip.hbs
+++ b/ui/lib/core/addon/components/info-tooltip.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <span class="is-inline-block" data-test-component="info-tooltip" data-test-tooltip>
   <ToolTip

--- a/ui/lib/core/addon/components/input-search.hbs
+++ b/ui/lib/core/addon/components/input-search.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="field is-grouped" ...attributes>
   <div class="control is-expanded">

--- a/ui/lib/core/addon/components/json-editor.hbs
+++ b/ui/lib/core/addon/components/json-editor.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div ...attributes>
   {{#if this.getShowToolbar}}

--- a/ui/lib/core/addon/components/key-value-header.hbs
+++ b/ui/lib/core/addon/components/key-value-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <nav class="key-value-header breadcrumb" aria-label="breadcrumbs">
   <ul>

--- a/ui/lib/core/addon/components/kv-object-editor.hbs
+++ b/ui/lib/core/addon/components/kv-object-editor.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="field" ...attributes {{did-insert this.createKvData @value}}>
   <FormFieldLabel

--- a/ui/lib/core/addon/components/layout-loading.hbs
+++ b/ui/lib/core/addon/components/layout-loading.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-flex-v-centered is-flex-grow-1 loader-inner-page" data-test-layout-loading>
   <div class="columns is-centered">

--- a/ui/lib/core/addon/components/linked-block.hbs
+++ b/ui/lib/core/addon/components/linked-block.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class={{unless @disabled "linked-block"}} role="link" {{on "click" this.onClick}} ...attributes>
   {{yield}}

--- a/ui/lib/core/addon/components/list-view.hbs
+++ b/ui/lib/core/addon/components/list-view.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (or (and @items.meta @items.meta.total) @items.length)}}
   <div class="box is-fullwidth is-bottomless is-sideless is-paddingless" data-test-list-view-list>

--- a/ui/lib/core/addon/components/masked-input.hbs
+++ b/ui/lib/core/addon/components/masked-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   class="masked-input {{if @displayOnly 'display-only'}} {{if @allowCopy 'allow-copy'}}"

--- a/ui/lib/core/addon/components/menu-loader.hbs
+++ b/ui/lib/core/addon/components/menu-loader.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <li class="action">
   {{#if @loadingParam}}

--- a/ui/lib/core/addon/components/modal.hbs
+++ b/ui/lib/core/addon/components/modal.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <EmberWormhole @to="modal-wormhole">
   <div class="{{this.modalClass}} {{if this.isActive 'is-active'}}" data-test-modal-div ...attributes>

--- a/ui/lib/core/addon/components/namespace-reminder.hbs
+++ b/ui/lib/core/addon/components/namespace-reminder.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.showMessage}}
   {{#if (has-block)}}

--- a/ui/lib/core/addon/components/navigate-input.hbs
+++ b/ui/lib/core/addon/components/navigate-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="navigate-filter">
   <div class="field" data-test-nav-input>

--- a/ui/lib/core/addon/components/object-list-input.hbs
+++ b/ui/lib/core/addon/components/object-list-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{yield}}
 {{#each this.inputList as |row index|}}

--- a/ui/lib/core/addon/components/overview-card.hbs
+++ b/ui/lib/core/addon/components/overview-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container
   @level="mid"

--- a/ui/lib/core/addon/components/page-header-level.hbs
+++ b/ui/lib/core/addon/components/page-header-level.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable no-yield-only }}
 {{yield}}

--- a/ui/lib/core/addon/components/page-header.hbs
+++ b/ui/lib/core/addon/components/page-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <header class="page-header">
   {{#if this.hasLevel}}

--- a/ui/lib/core/addon/components/page/breadcrumbs.hbs
+++ b/ui/lib/core/addon/components/page/breadcrumbs.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <nav class="breadcrumb" aria-label="breadcrumbs" data-test-breadcrumbs>
   <ul>

--- a/ui/lib/core/addon/components/page/error.hbs
+++ b/ui/lib/core/addon/components/page/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-sideless has-background-white-bis has-text-grey has-text-centered has-tall-padding" data-test-page-error>
   {{#if (eq @error.httpStatus 404)}}

--- a/ui/lib/core/addon/components/policy-example.hbs
+++ b/ui/lib/core/addon/components/policy-example.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="has-bottom-margin-s">
   {{#if (eq @policyType "acl")}}

--- a/ui/lib/core/addon/components/popup-menu.hbs
+++ b/ui/lib/core/addon/components/popup-menu.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <span>
   <BasicDropdown class="popup-menu" horizontalPosition="auto-right" verticalPosition="below" onOpen={{@onOpen}} as |d|>

--- a/ui/lib/core/addon/components/radio-button.hbs
+++ b/ui/lib/core/addon/components/radio-button.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <input
   ...attributes

--- a/ui/lib/core/addon/components/radio-card.hbs
+++ b/ui/lib/core/addon/components/radio-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <label
   for={{dasherize (or @title @value)}}

--- a/ui/lib/core/addon/components/search-select-placeholder.hbs
+++ b/ui/lib/core/addon/components/search-select-placeholder.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div>
   <div class="field">

--- a/ui/lib/core/addon/components/search-select-with-modal.hbs
+++ b/ui/lib/core/addon/components/search-select-with-modal.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   {{did-insert (perform this.fetchOptions)}}

--- a/ui/lib/core/addon/components/search-select.hbs
+++ b/ui/lib/core/addon/components/search-select.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   {{did-insert (perform this.fetchOptions)}}

--- a/ui/lib/core/addon/components/secret-list-header-tab.hbs
+++ b/ui/lib/core/addon/components/secret-list-header-tab.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#unless this.dontShowTab}}
   <LinkTo @route="vault.cluster.secrets.backend.list-root" @query={{hash tab=@tab}} data-test-secret-list-tab={{@label}}>

--- a/ui/lib/core/addon/components/secret-list-header.hbs
+++ b/ui/lib/core/addon/components/secret-list-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#let (options-for-backend @model.engineType) as |options|}}
   <PageHeader as |p|>

--- a/ui/lib/core/addon/components/shamir/dr-token-flow.hbs
+++ b/ui/lib/core/addon/components/shamir/dr-token-flow.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <section class="modal-card-body">
   {{#if this.encodedToken}}

--- a/ui/lib/core/addon/components/shamir/flow.hbs
+++ b/ui/lib/core/addon/components/shamir/flow.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Shamir::Form
   @onSubmit={{this.onSubmitKey}}

--- a/ui/lib/core/addon/components/shamir/form.hbs
+++ b/ui/lib/core/addon/components/shamir/form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form id="shamir" aria-label="shamir form" {{on "submit" (fn this.onSubmit this.key)}} ...attributes>
   {{#if @errors}}

--- a/ui/lib/core/addon/components/stat-text.hbs
+++ b/ui/lib/core/addon/components/stat-text.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   class={{concat "stat-text-container " @size (unless @subText "-no-subText")}}

--- a/ui/lib/core/addon/components/string-list.hbs
+++ b/ui/lib/core/addon/components/string-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   class="field string-list form-section"

--- a/ui/lib/core/addon/components/text-file.hbs
+++ b/ui/lib/core/addon/components/text-file.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#unless @uploadOnly}}
   <div class="level is-mobile">

--- a/ui/lib/core/addon/components/toggle-button.hbs
+++ b/ui/lib/core/addon/components/toggle-button.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <button type="button" class="button is-transparent has-text-info" {{on "click" (fn @onClick (not @isOpen))}} ...attributes>
   {{#if @isOpen}}

--- a/ui/lib/core/addon/components/toggle.hbs
+++ b/ui/lib/core/addon/components/toggle.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Input
   id={{this.safeId}}

--- a/ui/lib/core/addon/components/tool-tip.hbs
+++ b/ui/lib/core/addon/components/tool-tip.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <BasicDropdown
   @renderInPlace={{@renderInPlace}}

--- a/ui/lib/core/addon/components/toolbar-actions.hbs
+++ b/ui/lib/core/addon/components/toolbar-actions.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <nav class="toolbar-actions">
   {{yield}}

--- a/ui/lib/core/addon/components/toolbar-filters.hbs
+++ b/ui/lib/core/addon/components/toolbar-filters.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <nav class="toolbar-filters">
   {{yield}}

--- a/ui/lib/core/addon/components/toolbar-link.hbs
+++ b/ui/lib/core/addon/components/toolbar-link.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and @disabled @disabledTooltip)}}
   <ToolTip @verticalPosition="above" as |T|>

--- a/ui/lib/core/addon/components/toolbar.hbs
+++ b/ui/lib/core/addon/components/toolbar.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <nav class="toolbar" ...attributes>
   <div class="toolbar-scroller">

--- a/ui/lib/core/addon/components/ttl-picker.hbs
+++ b/ui/lib/core/addon/components/ttl-picker.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="has-bottom-margin-m" ...attributes>
   {{#if @hideToggle}}

--- a/ui/lib/core/addon/components/upgrade-page.hbs
+++ b/ui/lib/core/addon/components/upgrade-page.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/lib/core/addon/components/vault-logo-spinner.hbs
+++ b/ui/lib/core/addon/components/vault-logo-spinner.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable no-inline-styles}}
 <svg

--- a/ui/lib/core/addon/templates/components/confirm.hbs
+++ b/ui/lib/core/addon/templates/components/confirm.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable no-inline-styles}}
 

--- a/ui/lib/core/addon/templates/components/confirm/message.hbs
+++ b/ui/lib/core/addon/templates/components/confirm/message.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.showConfirm}}
   {{#maybe-in-element this.wormholeReference false}}

--- a/ui/lib/core/addon/templates/components/edit-form.hbs
+++ b/ui/lib/core/addon/templates/components/edit-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{action (perform this.save this.model) on="submit"}}>
   <MessageError @model={{this.model}} data-test-edit-form-error />

--- a/ui/lib/core/addon/templates/components/form-save-buttons.hbs
+++ b/ui/lib/core/addon/templates/components/form-save-buttons.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="field is-grouped is-grouped-split is-fullwidth box is-bottomless {{if (eq @includeBox false) 'is-shadowless'}}">
   <div class="field is-grouped">

--- a/ui/lib/core/addon/templates/components/list-item.hbs
+++ b/ui/lib/core/addon/templates/components/list-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.componentName}}
   {{component this.componentName item=this.item}}

--- a/ui/lib/core/addon/templates/components/list-item/popup-menu.hbs
+++ b/ui/lib/core/addon/templates/components/list-item/popup-menu.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.hasMenu}}
   <PopupMenu>

--- a/ui/lib/core/addon/templates/components/list-pagination.hbs
+++ b/ui/lib/core/addon/templates/components/list-pagination.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <nav class="pagination is-centered" aria-label="pagination">
   {{#if this.hasPrevious}}

--- a/ui/lib/core/addon/templates/components/message-error.hbs
+++ b/ui/lib/core/addon/templates/components/message-error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.displayErrors}}
   {{#each this.displayErrors as |error|}}

--- a/ui/lib/core/addon/templates/components/read-more.hbs
+++ b/ui/lib/core/addon/templates/components/read-more.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   class="has-text-grey has-font-weight-normal overflow-ellipsis {{if this.isOpen '' 'is-closed'}} "

--- a/ui/lib/core/addon/templates/components/readonly-form-field.hbs
+++ b/ui/lib/core/addon/templates/components/readonly-form-field.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <label for={{@attr.name}} class="is-label" data-test-readonly-label>
   {{this.labelString}}

--- a/ui/lib/core/addon/templates/components/replication-action-demote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-demote.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="action-block is-rounded" data-test-demote-replication>
   <div class="action-block-info">

--- a/ui/lib/core/addon/templates/components/replication-action-disable.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-disable.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="action-block is-rounded" data-test-disable-replication>
   <div class="action-block-info">

--- a/ui/lib/core/addon/templates/components/replication-action-generate-token.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-generate-token.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="action-block is-rounded" data-test-generate-token-replication>
   <div class="action-block-info">

--- a/ui/lib/core/addon/templates/components/replication-action-promote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-promote.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="action-block is-rounded" data-test-promote-replication>
   <div class="action-block-info">

--- a/ui/lib/core/addon/templates/components/replication-action-recover.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-recover.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="action-block is-rounded" data-test-recover-replication>
   <div class="action-block-info">

--- a/ui/lib/core/addon/templates/components/replication-action-reindex.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-reindex.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="action-block is-rounded" data-test-reindex-replication>
   <div class="action-block-info">

--- a/ui/lib/core/addon/templates/components/replication-action-update-primary.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-update-primary.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="action-block is-rounded" data-test-update-primary-replication>
   <div class="action-block-info">

--- a/ui/lib/core/addon/templates/components/replication-actions.hbs
+++ b/ui/lib/core/addon/templates/components/replication-actions.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.loading}}
   <LayoutLoading />

--- a/ui/lib/core/addon/templates/components/replication-dashboard.hbs
+++ b/ui/lib/core/addon/templates/components/replication-dashboard.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="replication-dashboard box is-sideless is-fullwidth is-marginless" data-test-replication-dashboard>
   {{#if this.isReindexing}}

--- a/ui/lib/core/addon/templates/components/replication-header.hbs
+++ b/ui/lib/core/addon/templates/components/replication-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/core/addon/templates/components/replication-mode-summary.hbs
+++ b/ui/lib/core/addon/templates/components/replication-mode-summary.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.isMenu}}
   {{! this is the status menu }}

--- a/ui/lib/core/addon/templates/components/replication-page.hbs
+++ b/ui/lib/core/addon/templates/components/replication-page.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="replication-page" data-test-replication-page>
   {{#if this.isLoadingData}}

--- a/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   class="selectable-card is-rounded card-container {{if this.hasErrorClass 'has-error-border'}}"

--- a/ui/lib/core/addon/templates/components/replication-summary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-summary-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   class="selectable-card is-rounded card-container summary {{if this.hasErrorClass 'has-error-border'}}"

--- a/ui/lib/core/addon/templates/components/replication-table-rows.hbs
+++ b/ui/lib/core/addon/templates/components/replication-table-rows.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="has-top-margin-xl has-bottom-margin-s" data-test-table-rows>
   {{#if (eq this.clusterMode "secondary")}}

--- a/ui/lib/core/addon/templates/components/select.hbs
+++ b/ui/lib/core/addon/templates/components/select.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.label}}
   <label for="select-{{this.elementId}}" class="is-label" data-test-select-label>

--- a/ui/lib/core/addon/templates/components/shamir-flow.hbs
+++ b/ui/lib/core/addon/templates/components/shamir-flow.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.encoded_token}}
   <div class="box is-marginless is-shadowless">

--- a/ui/lib/kmip/addon/components/header-credentials.hbs
+++ b/ui/lib/kmip/addon/components/header-credentials.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/application.hbs
+++ b/ui/lib/kmip/addon/templates/application.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/lib/kmip/addon/templates/components/edit-form-kmip-role.hbs
+++ b/ui/lib/kmip/addon/templates/components/edit-form-kmip-role.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{action (queue (action "preSave" this.model) (perform this.save this.model)) on="submit"}}>
   <MessageError @model={{this.model}} data-test-edit-form-error />

--- a/ui/lib/kmip/addon/templates/components/header-scope.hbs
+++ b/ui/lib/kmip/addon/templates/components/header-scope.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/components/kmip-breadcrumb.hbs
+++ b/ui/lib/kmip/addon/templates/components/kmip-breadcrumb.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <nav class="key-value-header breadcrumb">
   <ul>

--- a/ui/lib/kmip/addon/templates/components/operation-field-display.hbs
+++ b/ui/lib/kmip/addon/templates/components/operation-field-display.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.model.operationAll}}
   <AlertInline @type="info" @message="This role allows all KMIP operations" class="is-marginless" />

--- a/ui/lib/kmip/addon/templates/configuration.hbs
+++ b/ui/lib/kmip/addon/templates/configuration.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <HeaderScope />
 <Toolbar>

--- a/ui/lib/kmip/addon/templates/configure.hbs
+++ b/ui/lib/kmip/addon/templates/configure.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/credentials/generate.hbs
+++ b/ui/lib/kmip/addon/templates/credentials/generate.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/credentials/index.hbs
+++ b/ui/lib/kmip/addon/templates/credentials/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <HeaderCredentials @role={{this.role}} @scope={{this.scope}} />
 <Toolbar>

--- a/ui/lib/kmip/addon/templates/credentials/show.hbs
+++ b/ui/lib/kmip/addon/templates/credentials/show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/role.hbs
+++ b/ui/lib/kmip/addon/templates/role.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <HeaderCredentials @role={{this.role}} @scope={{this.scope}} />
 <Toolbar>

--- a/ui/lib/kmip/addon/templates/role/edit.hbs
+++ b/ui/lib/kmip/addon/templates/role/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/scope/roles.hbs
+++ b/ui/lib/kmip/addon/templates/scope/roles.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/scope/roles/create.hbs
+++ b/ui/lib/kmip/addon/templates/scope/roles/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/scopes.hbs
+++ b/ui/lib/kmip/addon/templates/scopes.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/lib/kmip/addon/templates/scopes/create.hbs
+++ b/ui/lib/kmip/addon/templates/scopes/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/lib/kmip/addon/templates/scopes/index.hbs
+++ b/ui/lib/kmip/addon/templates/scopes/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <HeaderScope />
 <Toolbar>

--- a/ui/lib/kubernetes/addon/components/config-cta.hbs
+++ b/ui/lib/kubernetes/addon/components/config-cta.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <EmptyState
   data-test-config-cta

--- a/ui/lib/kubernetes/addon/components/page/configuration.hbs
+++ b/ui/lib/kubernetes/addon/components/page/configuration.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <TabPageHeader @model={{@backend}} @breadcrumbs={{@breadcrumbs}}>
   <ToolbarLink @route="configure" data-test-toolbar-config-action>

--- a/ui/lib/kubernetes/addon/components/page/configure.hbs
+++ b/ui/lib/kubernetes/addon/components/page/configure.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kubernetes/addon/components/page/credentials.hbs
+++ b/ui/lib/kubernetes/addon/components/page/credentials.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kubernetes/addon/components/page/overview.hbs
+++ b/ui/lib/kubernetes/addon/components/page/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <TabPageHeader @model={{@backend}} @breadcrumbs={{@breadcrumbs}}>
   <ToolbarLink @route="configure">Configure Kubernetes</ToolbarLink>

--- a/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
+++ b/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kubernetes/addon/components/page/role/details.hbs
+++ b/ui/lib/kubernetes/addon/components/page/role/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kubernetes/addon/components/page/roles.hbs
+++ b/ui/lib/kubernetes/addon/components/page/roles.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <TabPageHeader
   @model={{@backend}}

--- a/ui/lib/kubernetes/addon/components/tab-page-header.hbs
+++ b/ui/lib/kubernetes/addon/components/tab-page-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kubernetes/addon/templates/configuration.hbs
+++ b/ui/lib/kubernetes/addon/templates/configuration.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Configuration @config={{this.model.config}} @backend={{this.model.backend}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kubernetes/addon/templates/configure.hbs
+++ b/ui/lib/kubernetes/addon/templates/configure.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Configure @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kubernetes/addon/templates/error.hbs
+++ b/ui/lib/kubernetes/addon/templates/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <TabPageHeader @model={{this.backend}} @breadcrumbs={{this.breadcrumbs}} />
 

--- a/ui/lib/kubernetes/addon/templates/overview.hbs
+++ b/ui/lib/kubernetes/addon/templates/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Overview
   @promptConfig={{this.model.promptConfig}}

--- a/ui/lib/kubernetes/addon/templates/roles/create.hbs
+++ b/ui/lib/kubernetes/addon/templates/roles/create.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Role::CreateAndEdit @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kubernetes/addon/templates/roles/index.hbs
+++ b/ui/lib/kubernetes/addon/templates/roles/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Roles
   @roles={{this.model.roles}}

--- a/ui/lib/kubernetes/addon/templates/roles/role/credentials.hbs
+++ b/ui/lib/kubernetes/addon/templates/roles/role/credentials.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Credentials @roleName={{this.model.roleName}} @backend={{this.model.backend}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kubernetes/addon/templates/roles/role/details.hbs
+++ b/ui/lib/kubernetes/addon/templates/roles/role/details.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Role::Details @model={{@model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kubernetes/addon/templates/roles/role/edit.hbs
+++ b/ui/lib/kubernetes/addon/templates/roles/role/edit.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Role::CreateAndEdit @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/open-api-explorer/addon/templates/application.hbs
+++ b/ui/lib/open-api-explorer/addon/templates/application.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/lib/open-api-explorer/addon/templates/components/swagger-ui.hbs
+++ b/ui/lib/open-api-explorer/addon/templates/components/swagger-ui.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/lib/open-api-explorer/addon/templates/index.hbs
+++ b/ui/lib/open-api-explorer/addon/templates/index.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SwaggerUi @onFilterChange={{action (mut this.filter)}} @initialFilter={{this.filter}} />

--- a/ui/lib/pki/addon/components/page/pki-certificate-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-certificate-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/lib/pki/addon/components/page/pki-configuration-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-configuration-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @hasConfig}}
   <Toolbar>

--- a/ui/lib/pki/addon/components/page/pki-configuration-edit.hbs
+++ b/ui/lib/pki/addon/components/page/pki-configuration-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-sideless is-fullwidth is-marginless">
   {{#if this.errors}}

--- a/ui/lib/pki/addon/components/page/pki-configure-create.hbs
+++ b/ui/lib/pki/addon/components/page/pki-configure-create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/lib/pki/addon/components/page/pki-issuer-edit.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.save)}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/lib/pki/addon/components/page/pki-issuer-generate-intermediate.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-generate-intermediate.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-issuer-generate-root.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-generate-root.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-issuer-import.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-import.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-issuer-list.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each @issuers as |pkiIssuer idx|}}
   <LinkedBlock class="list-item-row" @params={{array "issuers.issuer.details" pkiIssuer.id}} @linkPrefix={{@mountPoint}}>

--- a/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-key-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-key-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/lib/pki/addon/components/page/pki-key-list.hbs
+++ b/ui/lib/pki/addon/components/page/pki-key-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/lib/pki/addon/components/page/pki-overview.hbs
+++ b/ui/lib/pki/addon/components/page/pki-overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-grid grid-2-columns grid-gap-2 has-top-margin-l">
   <OverviewCard

--- a/ui/lib/pki/addon/components/page/pki-role-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-role-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/lib/pki/addon/components/page/pki-tidy-auto-configure.hbs
+++ b/ui/lib/pki/addon/components/page/pki-tidy-auto-configure.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-tidy-auto-settings.hbs
+++ b/ui/lib/pki/addon/components/page/pki-tidy-auto-settings.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-tidy-manual.hbs
+++ b/ui/lib/pki/addon/components/page/pki-tidy-manual.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-tidy-status.hbs
+++ b/ui/lib/pki/addon/components/page/pki-tidy-status.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/lib/pki/addon/components/parsed-certificate-info-rows.hbs
+++ b/ui/lib/pki/addon/components/parsed-certificate-info-rows.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each this.possibleFields as |field|}}
   {{#let (get @model field.key) as |value|}}

--- a/ui/lib/pki/addon/components/pki-generate-csr.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-csr.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @model.id}}
   {{! Model only has ID once form has been submitted and saved }}

--- a/ui/lib/pki/addon/components/pki-generate-root.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-root.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! Show results if model has an ID, which is only generated after save }}
 {{#if @model.id}}

--- a/ui/lib/pki/addon/components/pki-generate-toggle-groups.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-toggle-groups.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each-in this.groups as |group fields|}}
   <ToggleButton

--- a/ui/lib/pki/addon/components/pki-import-pem-bundle.hbs
+++ b/ui/lib/pki/addon/components/pki-import-pem-bundle.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.importedResponse}}
   <div class="is-flex-start has-top-margin-xs">

--- a/ui/lib/pki/addon/components/pki-info-table-rows.hbs
+++ b/ui/lib/pki/addon/components/pki-info-table-rows.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each @displayFields as |field|}}
   {{#let (find-by "name" field @model.allFields) as |attr|}}

--- a/ui/lib/pki/addon/components/pki-issuer-cross-sign.hbs
+++ b/ui/lib/pki/addon/components/pki-issuer-cross-sign.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <h3 class="title is-4">Intermediates</h3>
 <div class="box is-fullwidth has-only-top-shadow">

--- a/ui/lib/pki/addon/components/pki-key-form.hbs
+++ b/ui/lib/pki/addon/components/pki-key-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.save)}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/lib/pki/addon/components/pki-key-import.hbs
+++ b/ui/lib/pki/addon/components/pki-key-import.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.submitForm)}} data-test-pki-key-import-form>
   <MessageError @errorMessage={{this.errorBanner}} class="has-top-margin-s" />

--- a/ui/lib/pki/addon/components/pki-key-parameters.hbs
+++ b/ui/lib/pki/addon/components/pki-key-parameters.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{yield}}
 {{#each @fields as |attr|}}

--- a/ui/lib/pki/addon/components/pki-key-usage.hbs
+++ b/ui/lib/pki/addon/components/pki-key-usage.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <CheckboxGrid
   @name="keyUsage"

--- a/ui/lib/pki/addon/components/pki-not-valid-after-form.hbs
+++ b/ui/lib/pki/addon/components/pki-not-valid-after-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="column is-narrow is-flex-align-baseline has-text-grey has-right-margin-s has-padding-xs">
   <RadioButton

--- a/ui/lib/pki/addon/components/pki-page-header.hbs
+++ b/ui/lib/pki/addon/components/pki-page-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/pki-role-form.hbs
+++ b/ui/lib/pki/addon/components/pki-role-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.save)}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/lib/pki/addon/components/pki-role-generate.hbs
+++ b/ui/lib/pki/addon/components/pki-role-generate.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @model.serialNumber}}
   <Page::PkiCertificateDetails @model={{@model}} @onRevoke={{this.cancel}} @onBack={{this.cancel}} />

--- a/ui/lib/pki/addon/components/pki-sign-intermediate-form.hbs
+++ b/ui/lib/pki/addon/components/pki-sign-intermediate-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @model.id}}
   {{! Model only has ID once form has been submitted and saved }}

--- a/ui/lib/pki/addon/components/pki-tidy-form.hbs
+++ b/ui/lib/pki/addon/components/pki-tidy-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <hr class="is-marginless has-background-gray-200" />
 

--- a/ui/lib/pki/addon/templates/application.hbs
+++ b/ui/lib/pki/addon/templates/application.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/lib/pki/addon/templates/certificates/certificate/details.hbs
+++ b/ui/lib/pki/addon/templates/certificates/certificate/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/certificates/index.hbs
+++ b/ui/lib/pki/addon/templates/certificates/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPageHeader @backend={{this.model.parentModel}} />
 

--- a/ui/lib/pki/addon/templates/configuration.hbs
+++ b/ui/lib/pki/addon/templates/configuration.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/lib/pki/addon/templates/configuration/create.hbs
+++ b/ui/lib/pki/addon/templates/configuration/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiConfigureCreate
   @breadcrumbs={{this.breadcrumbs}}

--- a/ui/lib/pki/addon/templates/configuration/edit.hbs
+++ b/ui/lib/pki/addon/templates/configuration/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/configuration/index.hbs
+++ b/ui/lib/pki/addon/templates/configuration/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPageHeader @backend={{this.model.engine}} />
 

--- a/ui/lib/pki/addon/templates/error.hbs
+++ b/ui/lib/pki/addon/templates/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/issuers/generate-intermediate.hbs
+++ b/ui/lib/pki/addon/templates/issuers/generate-intermediate.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiIssuerGenerateIntermediate @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/pki/addon/templates/issuers/generate-root.hbs
+++ b/ui/lib/pki/addon/templates/issuers/generate-root.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiIssuerGenerateRoot @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/pki/addon/templates/issuers/import.hbs
+++ b/ui/lib/pki/addon/templates/issuers/import.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiIssuerImport @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/pki/addon/templates/issuers/index.hbs
+++ b/ui/lib/pki/addon/templates/issuers/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPageHeader @backend={{this.model.parentModel}} />
 

--- a/ui/lib/pki/addon/templates/issuers/issuer/cross-sign.hbs
+++ b/ui/lib/pki/addon/templates/issuers/issuer/cross-sign.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/issuers/issuer/details.hbs
+++ b/ui/lib/pki/addon/templates/issuers/issuer/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/issuers/issuer/edit.hbs
+++ b/ui/lib/pki/addon/templates/issuers/issuer/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/issuers/issuer/rotate-root.hbs
+++ b/ui/lib/pki/addon/templates/issuers/issuer/rotate-root.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiIssuerRotateRoot
   @oldRoot={{this.model.oldRoot}}

--- a/ui/lib/pki/addon/templates/issuers/issuer/sign.hbs
+++ b/ui/lib/pki/addon/templates/issuers/issuer/sign.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/keys/create.hbs
+++ b/ui/lib/pki/addon/templates/keys/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/keys/import.hbs
+++ b/ui/lib/pki/addon/templates/keys/import.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/keys/index.hbs
+++ b/ui/lib/pki/addon/templates/keys/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPageHeader @backend={{this.model.parentModel}} />
 

--- a/ui/lib/pki/addon/templates/keys/key/details.hbs
+++ b/ui/lib/pki/addon/templates/keys/key/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/keys/key/edit.hbs
+++ b/ui/lib/pki/addon/templates/keys/key/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/overview.hbs
+++ b/ui/lib/pki/addon/templates/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPageHeader @backend={{this.model.engine}} />
 

--- a/ui/lib/pki/addon/templates/roles/create.hbs
+++ b/ui/lib/pki/addon/templates/roles/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/roles/index.hbs
+++ b/ui/lib/pki/addon/templates/roles/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPageHeader @backend={{this.model.parentModel}} />
 

--- a/ui/lib/pki/addon/templates/roles/role/details.hbs
+++ b/ui/lib/pki/addon/templates/roles/role/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/roles/role/edit.hbs
+++ b/ui/lib/pki/addon/templates/roles/role/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/roles/role/generate.hbs
+++ b/ui/lib/pki/addon/templates/roles/role/generate.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/roles/role/sign.hbs
+++ b/ui/lib/pki/addon/templates/roles/role/sign.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/tidy.hbs
+++ b/ui/lib/pki/addon/templates/tidy.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/lib/pki/addon/templates/tidy/auto.hbs
+++ b/ui/lib/pki/addon/templates/tidy/auto.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/lib/pki/addon/templates/tidy/auto/configure.hbs
+++ b/ui/lib/pki/addon/templates/tidy/auto/configure.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiTidyAutoConfigure @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/pki/addon/templates/tidy/auto/index.hbs
+++ b/ui/lib/pki/addon/templates/tidy/auto/index.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiTidyAutoSettings @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/pki/addon/templates/tidy/index.hbs
+++ b/ui/lib/pki/addon/templates/tidy/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPageHeader @backend={{this.model.engine}} />
 

--- a/ui/lib/pki/addon/templates/tidy/manual.hbs
+++ b/ui/lib/pki/addon/templates/tidy/manual.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiTidyManual @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/replication/addon/templates/application.hbs
+++ b/ui/lib/replication/addon/templates/application.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
+++ b/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="selectable-card is-rounded secondaries">
   <div class="level">

--- a/ui/lib/replication/addon/templates/components/known-secondaries-table.hbs
+++ b/ui/lib/replication/addon/templates/components/known-secondaries-table.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="replication vlt-table sticky-header" data-test-known-secondaries-table>
   <table class="is-fullwidth">

--- a/ui/lib/replication/addon/templates/components/path-filter-config-list.hbs
+++ b/ui/lib/replication/addon/templates/components/path-filter-config-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <h4 class="title is-5">
   Filtered paths

--- a/ui/lib/replication/addon/templates/components/replication-primary-card.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-primary-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="selectable-card is-rounded {{dasherize this.title}} {{if this.hasError 'has-error-border'}}">
   <h3 class="card-title title is-5">{{this.title}}</h3>

--- a/ui/lib/replication/addon/templates/components/replication-summary.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-summary.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (not (has-feature "DR Replication"))}}
   <UpgradePage @title="Replication" />

--- a/ui/lib/replication/addon/templates/index.hbs
+++ b/ui/lib/replication/addon/templates/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <section class="section">
   <div class="container is-widescreen">

--- a/ui/lib/replication/addon/templates/mode.hbs
+++ b/ui/lib/replication/addon/templates/mode.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <section class="section">
   <div class="container is-widescreen">

--- a/ui/lib/replication/addon/templates/mode/index.hbs
+++ b/ui/lib/replication/addon/templates/mode/index.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <ReplicationSummary @cluster={{this.model}} @initialReplicationMode={{this.replicationMode}} />

--- a/ui/lib/replication/addon/templates/mode/manage.hbs
+++ b/ui/lib/replication/addon/templates/mode/manage.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <ReplicationActions @model={{this.model}} @onDisable={{action "onDisable"}} @replicationMode={{this.replicationMode}} />

--- a/ui/lib/replication/addon/templates/mode/secondaries/add.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/add.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{action "onSubmit" "secondary-token" "primary" (hash ttl=this.ttl id=this.id) on="submit"}}>
   <div class="box is-fullwidth is-shadowless is-marginless">

--- a/ui/lib/replication/addon/templates/mode/secondaries/config-create.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/config-create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-shadowless is-marginless">
   <h4 class="title is-5 is-marginless">

--- a/ui/lib/replication/addon/templates/mode/secondaries/config-edit.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/config-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar />
 <div class="box is-fullwidth is-shadowless is-marginless">

--- a/ui/lib/replication/addon/templates/mode/secondaries/config-show.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/config-show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/lib/replication/addon/templates/mode/secondaries/index.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.model.replicationAttrs.isPrimary}}
   <Toolbar>

--- a/ui/lib/replication/addon/templates/mode/secondaries/revoke.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/revoke.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-shadowless is-marginless">
   <h4 class="title is-5">


### PR DESCRIPTION
Babel was complaining about the format of the copyright comment in hbs files, specifically about the `~` character at the end. This PR removes the extra character which cleans up the build output and satisfies Babel.

![image](https://github.com/hashicorp/vault/assets/24611656/70798b65-7f7e-4d77-b184-30bdbb6e4d0f)