### PR TITLE
events: Enable by default, disable flag

### DIFF
--- a/changelog/22815.txt
+++ b/changelog/22815.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+events: Enabled by default
+```

--- a/command/server.go
+++ b/command/server.go
@@ -1176,6 +1176,12 @@ func (c *ServerCommand) Run(args []string) int {
 		return 1
 	}
 
+	for _, experiment := range config.Experiments {
+		if experiments.IsUnused(experiment) {
+			c.UI.Warn(fmt.Sprintf("WARNING! Experiment %s is no longer used", experiment))
+		}
+	}
+
 	// If mlockall(2) isn't supported, show a warning. We disable this in dev
 	// because it is quite scary to see when first using Vault. We also disable
 	// this if the user has explicitly disabled mlock in configuration.

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -791,7 +791,7 @@ func ExperimentsFromEnvAndCLI(config *Config, envKey string, flagExperiments []s
 	return nil
 }
 
-// Validate checks each experiment is a known experiment.
+// validateExperiments checks each experiment is a known experiment.
 func validateExperiments(experiments []string) error {
 	var invalid []string
 

--- a/helper/experiments/experiments.go
+++ b/helper/experiments/experiments.go
@@ -4,9 +4,12 @@
 package experiments
 
 const (
-	VaultExperimentEventsAlpha1          = "events.alpha1"
 	VaultExperimentCoreAuditEventsAlpha1 = "core.audit.events.alpha1"
 	VaultExperimentSecretsSyncAlpha1     = "secrets.sync.alpha1"
+
+	// Unused experiments. We keep them so that we don't break users who include them in their
+	// flags or configs, but they no longer have any effect.
+	VaultExperimentEventsAlpha1 = "events.alpha1"
 )
 
 var validExperiments = []string{

--- a/helper/experiments/experiments.go
+++ b/helper/experiments/experiments.go
@@ -3,6 +3,8 @@
 
 package experiments
 
+import "slices"
+
 const (
 	VaultExperimentCoreAuditEventsAlpha1 = "core.audit.events.alpha1"
 	VaultExperimentSecretsSyncAlpha1     = "secrets.sync.alpha1"
@@ -18,11 +20,18 @@ var validExperiments = []string{
 	VaultExperimentSecretsSyncAlpha1,
 }
 
-// ValidExperiments exposes the list without exposing a mutable global variable.
-// Experiments can only be enabled when starting a server, and will typically
-// enable pre-GA API functionality.
+var unusedExperiments = []string{
+	VaultExperimentEventsAlpha1,
+}
+
+// ValidExperiments exposes the list of valid experiments without exposing a mutable
+// global variable. Experiments can only be enabled when starting a server, and will
+// typically enable pre-GA API functionality.
 func ValidExperiments() []string {
-	result := make([]string, len(validExperiments))
-	copy(result, validExperiments)
-	return result
+	return slices.Clone(validExperiments)
+}
+
+// IsUnused returns true if the given experiment is in the unused list.
+func IsUnused(experiment string) bool {
+	return slices.Contains(unusedExperiments, experiment)
 }

--- a/http/events_test.go
+++ b/http/events_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/audit"
-	"github.com/hashicorp/vault/helper/experiments"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -33,10 +32,7 @@ import (
 // TestEventsSubscribe tests the websocket endpoint for subscribing to events
 // by generating some events.
 func TestEventsSubscribe(t *testing.T) {
-	core := vault.TestCoreWithConfig(t, &vault.CoreConfig{
-		Experiments: []string{experiments.VaultExperimentEventsAlpha1},
-	})
-
+	core := vault.TestCoreWithConfig(t, &vault.CoreConfig{})
 	ln, addr := TestServer(t, core)
 	defer ln.Close()
 
@@ -255,7 +251,6 @@ func TestCanForwardEventConnections(t *testing.T) {
 		t.Fatal(err)
 	}
 	testCluster := vault.NewTestCluster(t, &vault.CoreConfig{
-		Experiments: []string{experiments.VaultExperimentEventsAlpha1},
 		AuditBackends: map[string]audit.Factory{
 			"nop": corehelpers.NoopAuditFactory(nil),
 		},

--- a/http/logical.go
+++ b/http/logical.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/vault/helper/experiments"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -353,21 +352,19 @@ func handleLogicalInternal(core *vault.Core, injectDataIntoTopLevel bool, noForw
 		}
 
 		// Websockets need to be handled at HTTP layer instead of logical requests.
-		if core.IsExperimentEnabled(experiments.VaultExperimentEventsAlpha1) {
-			ns, err := namespace.FromContext(r.Context())
-			if err != nil {
-				respondError(w, http.StatusInternalServerError, err)
-				return
-			}
-			nsPath := ns.Path
-			if ns.ID == namespace.RootNamespaceID {
-				nsPath = ""
-			}
-			if strings.HasPrefix(r.URL.Path, fmt.Sprintf("/v1/%ssys/events/subscribe/", nsPath)) {
-				handler := handleEventsSubscribe(core, req)
-				handler.ServeHTTP(w, r)
-				return
-			}
+		ns, err := namespace.FromContext(r.Context())
+		if err != nil {
+			respondError(w, http.StatusInternalServerError, err)
+			return
+		}
+		nsPath := ns.Path
+		if ns.ID == namespace.RootNamespaceID {
+			nsPath = ""
+		}
+		if strings.HasPrefix(r.URL.Path, fmt.Sprintf("/v1/%ssys/events/subscribe/", nsPath)) {
+			handler := handleEventsSubscribe(core, req)
+			handler.ServeHTTP(w, r)
+			return
 		}
 
 		// Make the internal request. We attach the connection info

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/builtin/plugin"
-	"github.com/hashicorp/vault/helper/experiments"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/versions"
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -1011,14 +1010,12 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *MountEntry, sysV
 	}
 
 	config := &logical.BackendConfig{
-		StorageView: view,
-		Logger:      authLogger,
-		Config:      conf,
-		System:      sysView,
-		BackendUUID: entry.BackendAwareUUID,
-	}
-	if c.IsExperimentEnabled(experiments.VaultExperimentEventsAlpha1) {
-		config.EventsSender = pluginEventSender
+		StorageView:  view,
+		Logger:       authLogger,
+		Config:       conf,
+		System:       sysView,
+		BackendUUID:  entry.BackendAwareUUID,
+		EventsSender: pluginEventSender,
 	}
 
 	b, err := f(ctx, config)

--- a/vault/core.go
+++ b/vault/core.go
@@ -43,7 +43,6 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/command/server"
-	"github.com/hashicorp/vault/helper/experiments"
 	"github.com/hashicorp/vault/helper/identity/mfa"
 	"github.com/hashicorp/vault/helper/locking"
 	"github.com/hashicorp/vault/helper/metricsutil"
@@ -1297,9 +1296,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		return nil, err
 	}
 	c.events = events
-	if c.IsExperimentEnabled(experiments.VaultExperimentEventsAlpha1) {
-		c.events.Start()
-	}
+	c.events.Start()
 
 	// Make sure we're keeping track of the subloggers added above. We haven't
 	// yet registered core to the server command's SubloggerAdder, so any new

--- a/vault/events_test.go
+++ b/vault/events_test.go
@@ -8,16 +8,12 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/vault/helper/experiments"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func TestCanSendEventsFromBuiltinPlugin(t *testing.T) {
-	c, _, _ := TestCoreUnsealedWithConfig(t, &CoreConfig{
-		Experiments: []string{experiments.VaultExperimentEventsAlpha1},
-	})
-
+	c, _, _ := TestCoreUnsealedWithConfig(t, &CoreConfig{})
 	ctx := namespace.RootContext(nil)
 
 	// subscribe to an event type

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/builtin/plugin"
-	"github.com/hashicorp/vault/helper/experiments"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/versions"
@@ -1717,14 +1716,12 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 		return nil, "", err
 	}
 	config := &logical.BackendConfig{
-		StorageView: view,
-		Logger:      backendLogger,
-		Config:      conf,
-		System:      sysView,
-		BackendUUID: entry.BackendAwareUUID,
-	}
-	if c.IsExperimentEnabled(experiments.VaultExperimentEventsAlpha1) {
-		config.EventsSender = pluginEventSender
+		StorageView:  view,
+		Logger:       backendLogger,
+		Config:       conf,
+		System:       sysView,
+		BackendUUID:  entry.BackendAwareUUID,
+		EventsSender: pluginEventSender,
 	}
 
 	ctx = namespace.ContextWithNamespace(ctx, entry.namespace)


### PR DESCRIPTION
The flag `events.alpha1` will no longer do anything, but we keep it to prevent breaking users who have it in their configurations or startup flags, or if it is referenced in other code.