### PR TITLE
[VAULT-1324] Fix the CLI failing to return wrapping information for KV PUT and PATCH operations when format is set to 'table'

### DIFF
--- a/changelog/22818.txt
+++ b/changelog/22818.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-cli: Fix the CLI failing to return wrapping information for KV PUTs and PATCHes when format is set to `table`.
+cli: Fix the CLI failing to return wrapping information for KV PUT and PATCH operations when format is set to `table`.
 ```

--- a/changelog/22818.txt
+++ b/changelog/22818.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix the CLI failing to return wrapping information for KV PUTs and PATCHes when format is set to `table`.
+```

--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -264,6 +264,11 @@ func (c *KVPatchCommand) Run(args []string) int {
 		return PrintRawField(c.UI, secret, c.flagField)
 	}
 
+	// If the secret is wrapped, return the wrapped response.
+	if secret != nil && secret.WrapInfo != nil && secret.WrapInfo.TTL != 0 {
+		return OutputSecret(c.UI, secret)
+	}
+
 	if Format(c.UI) == "table" {
 		outputPath(c.UI, fullPath, "Secret Path")
 		metadata := secret.Data

--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -265,7 +265,7 @@ func (c *KVPatchCommand) Run(args []string) int {
 	}
 
 	// If the secret is wrapped, return the wrapped response.
-	if secret != nil && secret.WrapInfo != nil && secret.WrapInfo.TTL != 0 {
+	if secret.WrapInfo != nil && secret.WrapInfo.TTL != 0 {
 		return OutputSecret(c.UI, secret)
 	}
 

--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -220,7 +220,7 @@ func (c *KVPutCommand) Run(args []string) int {
 	}
 
 	// If the secret is wrapped, return the wrapped response.
-	if secret != nil && secret.WrapInfo != nil && secret.WrapInfo.TTL != 0 {
+	if secret.WrapInfo != nil && secret.WrapInfo.TTL != 0 {
 		return OutputSecret(c.UI, secret)
 	}
 

--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -219,6 +219,11 @@ func (c *KVPutCommand) Run(args []string) int {
 		return PrintRawField(c.UI, secret, c.flagField)
 	}
 
+	// If the secret is wrapped, return the wrapped response.
+	if secret != nil && secret.WrapInfo != nil && secret.WrapInfo.TTL != 0 {
+		return OutputSecret(c.UI, secret)
+	}
+
 	if Format(c.UI) == "table" {
 		outputPath(c.UI, fullPath, "Secret Path")
 		metadata := secret.Data


### PR DESCRIPTION
The CLI currently fails to output the wrapping info for `vault kv patch` and `vault kv put` commands.

Output before:
![image](https://github.com/hashicorp/vault/assets/26430548/2f176969-80b2-4f14-aa1f-cac45aa75ef8)


Output after:
![image](https://github.com/hashicorp/vault/assets/26430548/3ecef79b-cfa9-4d08-812f-64596e12e40f)


The fix was copied from a PR that fixed the same problem for `vault kv list`: https://github.com/hashicorp/vault/pull/12031
