### PR TITLE
UI: Show error if tool action is not recognized

### DIFF
--- a/ui/app/routes/vault/cluster/tools/tool.js
+++ b/ui/app/routes/vault/cluster/tools/tool.js
@@ -7,17 +7,12 @@ import Route from '@ember/routing/route';
 import { toolsActions } from 'vault/helpers/tools-actions';
 
 export default Route.extend({
-  beforeModel(transition) {
-    const supportedActions = toolsActions();
-    const { selected_action: selectedAction } = this.paramsFor(this.routeName);
-    if (!selectedAction || !supportedActions.includes(selectedAction)) {
-      transition.abort();
-      return this.transitionTo(this.routeName, supportedActions[0]);
-    }
-  },
-
   model(params) {
-    return params.selected_action;
+    const supportedActions = toolsActions();
+    if (supportedActions.includes(params.selected_action)) {
+      return params.selected_action;
+    }
+    throw new Error('Given param is not a supported tool action');
   },
 
   setupController(controller, model) {

--- a/ui/app/templates/vault/cluster/tools/error.hbs
+++ b/ui/app/templates/vault/cluster/tools/error.hbs
@@ -1,0 +1,6 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+~}}
+
+<NotFound @model={{this.model}} />


### PR DESCRIPTION
Closes issue #10534 where a mistyped tool name in the URL would not indicate that something was amiss. 

Now, if the URL does not include a valid tool it shows an error message "Not found" with the attempted URL:
<img width="1235" alt="Vault tool error page" src="https://github.com/hashicorp/vault/assets/82459713/2575b22b-4bd7-40db-b770-7332e2a374b0">
