### PR TITLE
events: WebSocket subscriptions support go-bexpr expressions

### DIFF
--- a/changelog/22835.txt
+++ b/changelog/22835.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+events: WebSocket subscriptions add support for boolean filter expressions
+```

--- a/go.mod
+++ b/go.mod
@@ -380,6 +380,7 @@ require (
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
 	github.com/hashicorp/cronexpr v1.1.1 // indirect
+	github.com/hashicorp/go-bexpr v0.1.12 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-metrics v0.5.1 // indirect
 	github.com/hashicorp/go-msgpack/v2 v2.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/hashicorp/consul/api v1.23.0
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/eventlogger v0.2.3
+	github.com/hashicorp/go-bexpr v0.1.12
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-discover v0.0.0-20210818145131-c573d69da192
 	github.com/hashicorp/go-gcp-common v0.8.0
@@ -380,7 +381,6 @@ require (
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
 	github.com/hashicorp/cronexpr v1.1.1 // indirect
-	github.com/hashicorp/go-bexpr v0.1.12 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-metrics v0.5.1 // indirect
 	github.com/hashicorp/go-msgpack/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1955,6 +1955,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/eventlogger v0.2.3 h1:HhtM4tGEqd5H3bcI4SdppQBHA8Y5QF8Aje7HODp8/TA=
 github.com/hashicorp/eventlogger v0.2.3/go.mod h1://CHt6/j+Q2lc0NlUB5af4aS2M0c0aVBg9/JfcpAyhM=
+github.com/hashicorp/go-bexpr v0.1.12 h1:XrdVhmwu+9iYxIUWxsGVG7NQwrhzJZ0vR6nbN5bLgrA=
+github.com/hashicorp/go-bexpr v0.1.12/go.mod h1:ACktpcSySkFNpcxWSClFrut7wicd9WzisnvHuw+g9K8=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=

--- a/http/events_test.go
+++ b/http/events_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -88,8 +89,8 @@ func TestEventsSubscribe(t *testing.T) {
 	}{{true}, {false}}
 
 	for _, testCase := range testCases {
-		url := fmt.Sprintf("%s/v1/sys/events/subscribe/%s?namespaces=ns1&namespaces=ns*&json=%v", wsAddr, eventType, testCase.json)
-		conn, _, err := websocket.Dial(ctx, url, &websocket.DialOptions{
+		location := fmt.Sprintf("%s/v1/sys/events/subscribe/%s?namespaces=ns1&namespaces=ns*&json=%v", wsAddr, eventType, testCase.json)
+		conn, _, err := websocket.Dial(ctx, location, &websocket.DialOptions{
 			HTTPHeader: http.Header{"x-vault-token": []string{token}},
 		})
 		if err != nil {
@@ -133,6 +134,90 @@ func TestEventsSubscribe(t *testing.T) {
 			checkRequiredCloudEventsFields(t, event)
 		}
 	}
+}
+
+// TestBexprFilters tests that go-bexpr filters are used to filter events.
+func TestBexprFilters(t *testing.T) {
+	core := vault.TestCoreWithConfig(t, &vault.CoreConfig{
+		Experiments: []string{experiments.VaultExperimentEventsAlpha1},
+	})
+
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+
+	// unseal the core
+	keys, token := vault.TestCoreInit(t, core)
+	for _, key := range keys {
+		_, err := core.Unseal(key)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sendEvent := func(eventType string) error {
+		pluginInfo := &logical.EventPluginInfo{
+			MountPath: "secret",
+		}
+		ns := namespace.RootNamespace
+		id, err := uuid.GenerateUUID()
+		if err != nil {
+			core.Logger().Info("Error generating UUID, exiting sender", "error", err)
+			return err
+		}
+		err = core.Events().SendEventInternal(namespace.RootContext(context.Background()), ns, pluginInfo, logical.EventType(eventType), &logical.EventData{
+			Id:        id,
+			Metadata:  nil,
+			EntityIds: nil,
+			Note:      "testing",
+		})
+		if err != nil {
+			core.Logger().Info("Error sending event, exiting sender", "error", err)
+			return err
+		}
+		return nil
+	}
+	ctx := context.Background()
+	wsAddr := strings.Replace(addr, "http", "ws", 1)
+	bexprFilter := url.QueryEscape("event_type == abc")
+
+	location := fmt.Sprintf("%s/v1/sys/events/subscribe/*?json=true&filter=%s", wsAddr, bexprFilter)
+	conn, _, err := websocket.Dial(ctx, location, &websocket.DialOptions{
+		HTTPHeader: http.Header{"x-vault-token": []string{token}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	err = sendEvent("def")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = sendEvent("xyz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = sendEvent("abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// we should get the abc message
+	_, msg, err := conn.Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	event := map[string]interface{}{}
+	err = json.Unmarshal(msg, &event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "abc", event["data"].(map[string]interface{})["event_type"].(string))
+
+	// and no other messages
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, _, err = conn.Read(ctx)
+	assert.ErrorContains(t, err, "context deadline exceeded")
 }
 
 func TestNamespacePrepend(t *testing.T) {

--- a/sdk/logical/events.go
+++ b/sdk/logical/events.go
@@ -67,3 +67,39 @@ func SendEvent(ctx context.Context, sender EventSender, eventType string, metada
 	}
 	return sender.SendEvent(ctx, EventType(eventType), ev)
 }
+
+// EventReceivedBexpr is used for evaluating boolean expressions with go-bexpr.
+type EventReceivedBexpr struct {
+	EventType         string `bexpr:"event_type"`
+	Operation         string `bexpr:"operation"`
+	SourcePluginMount string `bexpr:"source_plugin_mount"`
+	FullSecretPath    string `bexpr:"full_secret_path"`
+	Namespace         string `bexpr:"namespace"`
+}
+
+// BexprDatum returns a copy of EventReceived formatted for use in evaluating go-bexpr boolean expressions.
+func (x *EventReceived) BexprDatum() any {
+	operation := ""
+	fullSecretPath := ""
+
+	if x.Event != nil {
+		if x.Event.Metadata != nil {
+			operationValue := x.Event.Metadata.Fields[EventMetadataOperation]
+			if operationValue != nil {
+				operation = operationValue.GetStringValue()
+			}
+			fullSecretPathValue := x.Event.Metadata.Fields[EventMetadataDataPath]
+			if fullSecretPathValue != nil {
+				fullSecretPath = fullSecretPathValue.GetStringValue()
+			}
+		}
+	}
+
+	return &EventReceivedBexpr{
+		EventType:         x.EventType,
+		Operation:         operation,
+		SourcePluginMount: x.PluginInfo.MountPath,
+		FullSecretPath:    fullSecretPath,
+		Namespace:         x.Namespace,
+	}
+}

--- a/sdk/logical/events.go
+++ b/sdk/logical/events.go
@@ -73,14 +73,14 @@ type EventReceivedBexpr struct {
 	EventType         string `bexpr:"event_type"`
 	Operation         string `bexpr:"operation"`
 	SourcePluginMount string `bexpr:"source_plugin_mount"`
-	FullSecretPath    string `bexpr:"full_secret_path"`
+	DataPath          string `bexpr:"data_path"`
 	Namespace         string `bexpr:"namespace"`
 }
 
 // BexprDatum returns a copy of EventReceived formatted for use in evaluating go-bexpr boolean expressions.
 func (x *EventReceived) BexprDatum() any {
 	operation := ""
-	fullSecretPath := ""
+	dataPath := ""
 
 	if x.Event != nil {
 		if x.Event.Metadata != nil {
@@ -88,9 +88,9 @@ func (x *EventReceived) BexprDatum() any {
 			if operationValue != nil {
 				operation = operationValue.GetStringValue()
 			}
-			fullSecretPathValue := x.Event.Metadata.Fields[EventMetadataDataPath]
-			if fullSecretPathValue != nil {
-				fullSecretPath = fullSecretPathValue.GetStringValue()
+			dataPathValue := x.Event.Metadata.Fields[EventMetadataDataPath]
+			if dataPathValue != nil {
+				dataPath = dataPathValue.GetStringValue()
 			}
 		}
 	}
@@ -99,7 +99,7 @@ func (x *EventReceived) BexprDatum() any {
 		EventType:         x.EventType,
 		Operation:         operation,
 		SourcePluginMount: x.PluginInfo.MountPath,
-		FullSecretPath:    fullSecretPath,
+		DataPath:          dataPath,
 		Namespace:         x.Namespace,
 	}
 }

--- a/vault/eventbus/bus_test.go
+++ b/vault/eventbus/bus_test.go
@@ -6,6 +6,7 @@ package eventbus
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/hashicorp/eventlogger"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/assert"
@@ -35,7 +37,7 @@ func TestBusBasics(t *testing.T) {
 	}
 
 	err = bus.SendEventInternal(ctx, namespace.RootNamespace, nil, eventType, event)
-	if err != ErrNotStarted {
+	if !errors.Is(err, ErrNotStarted) {
 		t.Errorf("Expected not started error but got: %v", err)
 	}
 
@@ -46,7 +48,7 @@ func TestBusBasics(t *testing.T) {
 		t.Errorf("Expected no error sending: %v", err)
 	}
 
-	ch, cancel, err := bus.Subscribe(ctx, namespace.RootNamespace, string(eventType))
+	ch, cancel, err := bus.Subscribe(ctx, namespace.RootNamespace, string(eventType), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +92,7 @@ func TestSubscribeNonRootNamespace(t *testing.T) {
 		Path: "abc/",
 	}
 
-	ch, cancel, err := bus.Subscribe(ctx, ns, string(eventType))
+	ch, cancel, err := bus.Subscribe(ctx, ns, string(eventType), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +135,7 @@ func TestNamespaceFiltering(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ch, cancel, err := bus.Subscribe(ctx, namespace.RootNamespace, string(eventType))
+	ch, cancel, err := bus.Subscribe(ctx, namespace.RootNamespace, string(eventType), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,13 +191,13 @@ func TestBus2Subscriptions(t *testing.T) {
 	eventType2 := logical.EventType("someType2")
 	bus.Start()
 
-	ch1, cancel1, err := bus.Subscribe(ctx, namespace.RootNamespace, string(eventType1))
+	ch1, cancel1, err := bus.Subscribe(ctx, namespace.RootNamespace, string(eventType1), "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cancel1()
 
-	ch2, cancel2, err := bus.Subscribe(ctx, namespace.RootNamespace, string(eventType2))
+	ch2, cancel2, err := bus.Subscribe(ctx, namespace.RootNamespace, string(eventType2), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,7 +276,7 @@ func TestBusSubscriptionsCancel(t *testing.T) {
 			received := atomic.Int32{}
 
 			for i := 0; i < create; i++ {
-				ch, cancelFunc, err := bus.Subscribe(ctx, namespace.RootNamespace, string(eventType))
+				ch, cancelFunc, err := bus.Subscribe(ctx, namespace.RootNamespace, string(eventType), "")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -363,13 +365,13 @@ func TestBusWildcardSubscriptions(t *testing.T) {
 	barEventType := logical.EventType("kv/bar")
 	bus.Start()
 
-	ch1, cancel1, err := bus.Subscribe(ctx, namespace.RootNamespace, "kv/*")
+	ch1, cancel1, err := bus.Subscribe(ctx, namespace.RootNamespace, "kv/*", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cancel1()
 
-	ch2, cancel2, err := bus.Subscribe(ctx, namespace.RootNamespace, "*/bar")
+	ch2, cancel2, err := bus.Subscribe(ctx, namespace.RootNamespace, "*/bar", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -437,7 +439,7 @@ func TestDataPathIsPrependedWithMount(t *testing.T) {
 	fooEventType := logical.EventType("kv/foo")
 	bus.Start()
 
-	ch, cancel, err := bus.Subscribe(ctx, namespace.RootNamespace, "kv/*")
+	ch, cancel, err := bus.Subscribe(ctx, namespace.RootNamespace, "kv/*", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -543,5 +545,84 @@ func TestDataPathIsPrependedWithMount(t *testing.T) {
 		assert.Equal(t, "auth/kubernetes/my/secret/path", metadata["data_path"])
 	case <-timeout:
 		t.Error("Timeout waiting for event")
+	}
+}
+
+// TestBexpr tests go-bexpr filters are evaluated on an event.
+func TestBexpr(t *testing.T) {
+	bus, err := NewEventBus(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	bus.Start()
+
+	sendEvent := func(eventType string) error {
+		event, err := logical.NewEvent()
+		if err != nil {
+			return err
+		}
+		metadata := map[string]string{
+			logical.EventMetadataDataPath:  "my/secret/path",
+			logical.EventMetadataOperation: "write",
+		}
+		metadataBytes, err := json.Marshal(metadata)
+		if err != nil {
+			return err
+		}
+		event.Metadata = &structpb.Struct{}
+		if err := event.Metadata.UnmarshalJSON(metadataBytes); err != nil {
+			return err
+		}
+		// send with a secrets plugin mounted
+		pluginInfo := logical.EventPluginInfo{
+			MountClass:    "secrets",
+			MountAccessor: "kv_abc",
+			MountPath:     "secret/",
+			Plugin:        "kv",
+			PluginVersion: "v1.13.1+builtin",
+			Version:       "2",
+		}
+		return bus.SendEventInternal(ctx, namespace.RootNamespace, &pluginInfo, logical.EventType(eventType), event)
+	}
+
+	testCases := []struct {
+		name             string
+		filter           string
+		shouldPassFilter bool
+	}{
+		{"empty expression", "", true},
+		{"non-matching expression", "full_secret_path == nothing", false},
+		{"matching expression", "full_secret_path == secret/my/secret/path", true},
+		{"full matching expression", "full_secret_path == secret/my/secret/path and operation != read and source_plugin_mount == secret/ and source_plugin_mount != somethingelse", true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			eventType, err := uuid.GenerateUUID()
+			if err != nil {
+				t.Fatal(err)
+			}
+			ch, cancel, err := bus.Subscribe(ctx, namespace.RootNamespace, eventType, testCase.filter)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cancel()
+			err = sendEvent(eventType)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			timer := time.NewTimer(5 * time.Second)
+			defer timer.Stop()
+			got := false
+			select {
+			case <-ch:
+				got = true
+			case <-timer.C:
+			}
+			assert.Equal(t, testCase.shouldPassFilter, got)
+		})
 	}
 }

--- a/vault/eventbus/bus_test.go
+++ b/vault/eventbus/bus_test.go
@@ -593,9 +593,9 @@ func TestBexpr(t *testing.T) {
 		shouldPassFilter bool
 	}{
 		{"empty expression", "", true},
-		{"non-matching expression", "full_secret_path == nothing", false},
-		{"matching expression", "full_secret_path == secret/my/secret/path", true},
-		{"full matching expression", "full_secret_path == secret/my/secret/path and operation != read and source_plugin_mount == secret/ and source_plugin_mount != somethingelse", true},
+		{"non-matching expression", "data_path == nothing", false},
+		{"matching expression", "data_path == secret/my/secret/path", true},
+		{"full matching expression", "data_path == secret/my/secret/path and operation != read and source_plugin_mount == secret/ and source_plugin_mount != somethingelse", true},
 	}
 
 	for _, testCase := range testCases {

--- a/vault/events_test.go
+++ b/vault/events_test.go
@@ -25,7 +25,7 @@ func TestCanSendEventsFromBuiltinPlugin(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ch, cancel, err := c.events.Subscribe(ctx, namespace.RootNamespace, eventType)
+	ch, cancel, err := c.events.Subscribe(ctx, namespace.RootNamespace, eventType, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Subscribing to events through a WebSocket now support boolean expressions to filter only the events wanted based on the fields

* `event_type`
* `operation`
* `source_plugin_mount`
* `data_path`
* `namespace`

Example expressions:

These can be passed to `vault events subscribe`, e.g.,:
* `event_type == abc`
* `source_plugin_mount == secret/`
* `event_type != def and operation != write`

```sh
vault events subscribe -filter='source_plugin_mount == secret/' 'kv*'
```

The docs for the `vault events subscribe` command and API endpoint will be coming shortly in a different PR, and will include a better specification for these expressions, similar to (or linking to) https://developer.hashicorp.com/boundary/docs/concepts/filtering