### PR TITLE
LDAP Libraries and Roles Delete Bug

### DIFF
--- a/ui/lib/ldap/addon/components/page/libraries.ts
+++ b/ui/lib/ldap/addon/components/page/libraries.ts
@@ -44,7 +44,6 @@ export default class LdapLibrariesPageComponent extends Component<Args> {
     try {
       const message = `Successfully deleted library ${model.name}.`;
       await model.destroyRecord();
-      this.args.libraries.removeObject(model);
       this.flashMessages.success(message);
     } catch (error) {
       this.flashMessages.danger(`Error deleting library \n ${errorMessage(error)}`);

--- a/ui/lib/ldap/addon/components/page/roles.ts
+++ b/ui/lib/ldap/addon/components/page/roles.ts
@@ -55,7 +55,6 @@ export default class LdapRolesPageComponent extends Component<Args> {
     try {
       const message = `Successfully deleted role ${model.name}.`;
       await model.destroyRecord();
-      this.args.roles.removeObject(model);
       this.flashMessages.success(message);
     } catch (error) {
       this.flashMessages.danger(`Error deleting role \n ${errorMessage(error)}`);


### PR DESCRIPTION
When deleting a library or role from an LDAP secrets engine the following error was being caught and displayed in a flash message:

![image](https://github.com/hashicorp/vault/assets/24611656/7f9f914f-e3aa-4291-be60-06fd42aa82bd)

It seems that using `removeObject` on a `RecordArray` is not allowed and also unnecessary since the array is updated automatically on `model.destroyRecord` success. 
