### PR TITLE
LDAP Disable Name Edit

### DIFF
--- a/ui/app/models/ldap/library.js
+++ b/ui/app/models/ldap/library.js
@@ -19,7 +19,11 @@ const formFields = ['name', 'service_account_names', 'ttl', 'max_ttl', 'disable_
 export default class LdapLibraryModel extends Model {
   @attr('string') backend; // dynamic path of secret -- set on response from value passed to queryRecord
 
-  @attr('string', { label: 'Library name' }) name;
+  @attr('string', {
+    label: 'Library name',
+    editDisabled: true,
+  })
+  name;
 
   @attr('string', {
     editType: 'stringArray',

--- a/ui/app/models/ldap/role.js
+++ b/ui/app/models/ldap/role.js
@@ -73,6 +73,7 @@ export default class LdapRoleModel extends Model {
   @attr('string', {
     label: 'Role name',
     subText: 'The name of the role that will be used in Vault.',
+    editDisabled: true,
   })
   name;
 

--- a/ui/tests/integration/components/ldap/page/library/create-and-edit-test.js
+++ b/ui/tests/integration/components/ldap/page/library/create-and-edit-test.js
@@ -55,7 +55,8 @@ module('Integration | Component | ldap | Page::Library::CreateAndEdit', function
     await this.renderComponent();
 
     assert.dom('[data-test-input="name"]').hasValue(this.libraryData.name, 'Name renders');
-    [0, 1].forEach((index) => {
+    assert.dom('[data-test-input="name"]').isDisabled('Name field is disabled when editing');
+    [(0, 1)].forEach((index) => {
       assert
         .dom(`[data-test-string-list-input="${index}"]`)
         .hasValue(this.libraryData.service_account_names[index], 'Service account renders');

--- a/ui/tests/integration/components/ldap/page/role/create-and-edit-test.js
+++ b/ui/tests/integration/components/ldap/page/role/create-and-edit-test.js
@@ -82,7 +82,7 @@ module('Integration | Component | ldap | Page::Role::CreateAndEdit', function (h
   });
 
   test('it should populate form and disable type cards when editing', async function (assert) {
-    assert.expect(12);
+    assert.expect(13);
 
     const checkFields = (fields, element = 'input:last-child') => {
       fields.forEach((field) => {
@@ -103,6 +103,7 @@ module('Integration | Component | ldap | Page::Role::CreateAndEdit', function (h
     this.model = this.store.peekRecord('ldap/role', 'static-role');
     await this.renderComponent();
     assert.dom('[data-test-radio-card="static"]').isDisabled('Type selection is disabled when editing');
+    assert.dom('[data-test-input="name"]').isDisabled('Name field is disabled when editing');
     checkFields(['name', 'dn', 'username']);
     checkTtl(['rotation_period']);
 
@@ -183,7 +184,6 @@ module('Integration | Component | ldap | Page::Role::CreateAndEdit', function (h
     this.model = this.store.peekRecord('ldap/role', 'static-role');
     await this.renderComponent();
 
-    await fillIn('[data-test-input="name"]', 'test-role');
     await fillIn('[data-test-input="dn"]', 'foo');
     await fillIn('[data-test-input="username"]', 'bar');
     await fillIn('[data-test-ttl-value="Rotation period"]', 30);


### PR DESCRIPTION
Since the name field for LDAP library and roles corresponds to the path, changing the name when editing will actually create a new library or role. This PR updates the name fields to be disabled when editing.

![image](https://github.com/hashicorp/vault/assets/24611656/f5985135-3793-4ce6-ac73-bf6e2d625558)

![image](https://github.com/hashicorp/vault/assets/24611656/992067da-e31f-42a1-b788-661733997bac)
