### PR TITLE
LDAP Role Credentials Error Handling

### DIFF
--- a/ui/lib/ldap/addon/components/page/role/credentials.hbs
+++ b/ui/lib/ldap/addon/components/page/role/credentials.hbs
@@ -11,54 +11,58 @@
 
 <hr class="is-marginless has-background-gray-200" />
 
-{{#if (eq @credentials.type "dynamic")}}
-  <Hds::Alert @type="inline" @color="warning" class="has-top-margin-m" as |Alert|>
-    <Alert.Title>Warning</Alert.Title>
-    <Alert.Description data-test-alert-description>
-      You won’t be able to access these credentials later, so please copy them now.
-    </Alert.Description>
-  </Hds::Alert>
+{{#if @error}}
+  <Page::Error @error={{@error}} />
+{{else}}
+  {{#if (eq @credentials.type "dynamic")}}
+    <Hds::Alert @type="inline" @color="warning" class="has-top-margin-m" as |Alert|>
+      <Alert.Title>Warning</Alert.Title>
+      <Alert.Description data-test-alert-description>
+        You won’t be able to access these credentials later, so please copy them now.
+      </Alert.Description>
+    </Hds::Alert>
+  {{/if}}
+
+  <div class="has-top-margin-m">
+    {{#each this.fields as |field|}}
+      {{#let (get @credentials field.key) as |value|}}
+        {{#if field.hasBlock}}
+          <InfoTableRow @label={{field.label}}>
+            {{#if (eq field.hasBlock "masked")}}
+              <MaskedInput @value={{value}} @displayOnly={{true}} @allowCopy={{true}} />
+            {{else if (eq field.hasBlock "check")}}
+              <div class="is-flex-v-centered">
+                <Icon
+                  @name={{if value "check-circle" "x-circle"}}
+                  class="is-marginless {{if value 'has-text-success' 'has-text-danger'}}"
+                />
+                <span class="has-left-margin-xs">
+                  {{if value "True" "False"}}
+                </span>
+              </div>
+            {{/if}}
+          </InfoTableRow>
+        {{else}}
+          <InfoTableRow
+            @label={{field.label}}
+            @value={{value}}
+            @formatDate={{field.formatDate}}
+            @formatTtl={{field.formatTtl}}
+            @type={{field.type}}
+          />
+        {{/if}}
+      {{/let}}
+    {{/each}}
+  </div>
+
+  <div class="has-top-margin-xl has-bottom-margin-l">
+    <button
+      data-test-done
+      class="button is-primary"
+      type="button"
+      {{on "click" (transition-to "vault.cluster.secrets.backend.ldap.roles.role.details")}}
+    >
+      Done
+    </button>
+  </div>
 {{/if}}
-
-<div class="has-top-margin-m">
-  {{#each this.fields as |field|}}
-    {{#let (get @credentials field.key) as |value|}}
-      {{#if field.hasBlock}}
-        <InfoTableRow @label={{field.label}}>
-          {{#if (eq field.hasBlock "masked")}}
-            <MaskedInput @value={{value}} @displayOnly={{true}} @allowCopy={{true}} />
-          {{else if (eq field.hasBlock "check")}}
-            <div class="is-flex-v-centered">
-              <Icon
-                @name={{if value "check-circle" "x-circle"}}
-                class="is-marginless {{if value 'has-text-success' 'has-text-danger'}}"
-              />
-              <span class="has-left-margin-xs">
-                {{if value "True" "False"}}
-              </span>
-            </div>
-          {{/if}}
-        </InfoTableRow>
-      {{else}}
-        <InfoTableRow
-          @label={{field.label}}
-          @value={{value}}
-          @formatDate={{field.formatDate}}
-          @formatTtl={{field.formatTtl}}
-          @type={{field.type}}
-        />
-      {{/if}}
-    {{/let}}
-  {{/each}}
-</div>
-
-<div class="has-top-margin-xl has-bottom-margin-l">
-  <button
-    data-test-done
-    class="button is-primary"
-    type="button"
-    {{on "click" (transition-to "vault.cluster.secrets.backend.ldap.roles.role.details")}}
-  >
-    Done
-  </button>
-</div>

--- a/ui/lib/ldap/addon/components/page/role/credentials.ts
+++ b/ui/lib/ldap/addon/components/page/role/credentials.ts
@@ -5,9 +5,11 @@ import type {
   LdapDynamicRoleCredentials,
 } from 'ldap/routes/roles/role/credentials';
 import { Breadcrumb } from 'vault/vault/app-types';
+import type AdapterError from 'ember-data/adapter'; // eslint-disable-line ember/use-ember-data-rfc-395-imports
 
 interface Args {
   credentials: LdapStaticRoleCredentials | LdapDynamicRoleCredentials;
+  error: AdapterError;
   breadcrumbs: Array<Breadcrumb>;
 }
 

--- a/ui/lib/ldap/addon/templates/roles/role/credentials.hbs
+++ b/ui/lib/ldap/addon/templates/roles/role/credentials.hbs
@@ -1,1 +1,1 @@
-<Page::Role::Credentials @credentials={{@model}} @breadcrumbs={{this.breadcrumbs}} />
+<Page::Role::Credentials @credentials={{@model.credentials}} @error={{@model.error}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/tests/integration/components/ldap/page/role/credentials-test.js
+++ b/ui/tests/integration/components/ldap/page/role/credentials-test.js
@@ -29,7 +29,7 @@ module('Integration | Component | ldap | Page::Role::Credentials', function (hoo
   });
 
   test('it should render page title and breadcrumbs', async function (assert) {
-    this.creds = [];
+    this.creds = {};
     await render(
       hbs`<Page::Role::Credentials @credentials={{this.creds}} @breadcrumbs={{this.breadcrumbs}} />`,
       { owner: this.engine }
@@ -46,6 +46,16 @@ module('Integration | Component | ldap | Page::Role::Credentials', function (hoo
     assert
       .dom('[data-test-breadcrumbs] li:nth-child(4)')
       .containsText('credentials', 'Credentials breadcrumb renders');
+  });
+
+  test('it should render error', async function (assert) {
+    this.error = { errors: ['Failed to fetch credentials for role'] };
+
+    await render(hbs`<Page::Role::Credentials @error={{this.error}} @breadcrumbs={{this.breadcrumbs}} />`, {
+      owner: this.engine,
+    });
+
+    assert.dom('[data-test-page-error-details]').hasText(this.error.errors[0], 'Error renders');
   });
 
   test('it should render fields for static role', async function (assert) {


### PR DESCRIPTION
This PR moves the error handling for fetching LDAP role credentials to the credentials route rather than deferring to the top level error route for the engine.

_Before_
![852ee14e-3c36-47ea-a596-04b5f7535466](https://github.com/hashicorp/vault/assets/24611656/41d2f084-0d7a-48c1-ae0e-c2c70808379e)

_After_
![image](https://github.com/hashicorp/vault/assets/24611656/acf4770a-371c-4f97-819f-f67caea32ea5)
