### PR TITLE
Fix auto-squash events experiments

### DIFF
--- a/http/events_test.go
+++ b/http/events_test.go
@@ -134,10 +134,7 @@ func TestEventsSubscribe(t *testing.T) {
 
 // TestBexprFilters tests that go-bexpr filters are used to filter events.
 func TestBexprFilters(t *testing.T) {
-	core := vault.TestCoreWithConfig(t, &vault.CoreConfig{
-		Experiments: []string{experiments.VaultExperimentEventsAlpha1},
-	})
-
+	core := vault.TestCoreWithConfig(t, &vault.CoreConfig{})
 	ln, addr := TestServer(t, core)
 	defer ln.Close()
 


### PR DESCRIPTION
When #22835 was merged, it was auto-squashed, so the `experiments` import was removed, but the test still referenced it.

This removes the (now unnecessary) experiment from the test.