### PR TITLE
Disable gVisor in tests (for now)

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -255,35 +255,6 @@ jobs:
           GOPRIVATE: github.com/hashicorp/*
         run: time make ci-bootstrap dev
       - uses: ./.github/actions/set-up-gotestsum
-      - name: Install gVisor
-        run: |
-          (
-            set -e
-            ARCH="$(uname -m)"
-            URL="https://storage.googleapis.com/gvisor/releases/release/latest/${ARCH}"
-            wget --quiet "${URL}/runsc" "${URL}/runsc.sha512" \
-              "${URL}/containerd-shim-runsc-v1" "${URL}/containerd-shim-runsc-v1.sha512"
-            sha512sum -c runsc.sha512 \
-              -c containerd-shim-runsc-v1.sha512
-            rm -f -- *.sha512
-            chmod a+rx runsc containerd-shim-runsc-v1
-            sudo mv runsc containerd-shim-runsc-v1 /usr/local/bin
-          )
-          sudo tee /etc/docker/daemon.json <<EOF
-          {
-            "runtimes": {
-              "runsc": {
-                "path": "/usr/local/bin/runsc",
-                "runtimeArgs": [
-                  "--host-uds=all",
-                  "--host-fifo=open"
-                ]
-              }
-            }
-          }
-          EOF
-
-          sudo systemctl reload docker
       - id: run-go-tests
         name: Run Go tests
         timeout-minutes: ${{ fromJSON(env.TIMEOUT_IN_MINUTES) }}

--- a/vault/external_plugin_container_test.go
+++ b/vault/external_plugin_container_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -56,6 +57,9 @@ func TestExternalPluginInContainer_MountAndUnmount(t *testing.T) {
 			c, plugin := testClusterWithContainerPlugin(t, tc.pluginType, "v1.0.0")
 
 			t.Run("default", func(t *testing.T) {
+				if _, err := exec.LookPath("runsc"); err != nil {
+					t.Skip("Skipping test as runsc not found on path")
+				}
 				mountAndUnmountContainerPlugin_WithRuntime(t, c, plugin, "")
 			})
 
@@ -64,6 +68,9 @@ func TestExternalPluginInContainer_MountAndUnmount(t *testing.T) {
 			})
 
 			t.Run("runsc", func(t *testing.T) {
+				if _, err := exec.LookPath("runsc"); err != nil {
+					t.Skip("Skipping test as runsc not found on path")
+				}
 				mountAndUnmountContainerPlugin_WithRuntime(t, c, plugin, "runsc")
 			})
 		})
@@ -119,6 +126,9 @@ func TestExternalPluginInContainer_GetBackendTypeVersion(t *testing.T) {
 			c, plugin := testClusterWithContainerPlugin(t, tc.pluginType, tc.setRunningVersion)
 			for _, ociRuntime := range []string{"runc", "runsc"} {
 				t.Run(ociRuntime, func(t *testing.T) {
+					if _, err := exec.LookPath(ociRuntime); err != nil {
+						t.Skipf("Skipping test as %s not found on path", ociRuntime)
+					}
 					shaBytes, _ := hex.DecodeString(plugin.ImageSha256)
 					entry := &pluginutil.PluginRunner{
 						Name:     plugin.Name,


### PR DESCRIPTION
We can't use `sudo` on our self-hosted runners at the moment to do the install and Docker reload.

So, we'll disable this for now, which should automatically cause the gVisor-related tests to be skipped.