### PR TITLE
LDAP Overview Responsive Layout

### DIFF
--- a/ui/lib/ldap/addon/components/page/overview.hbs
+++ b/ui/lib/ldap/addon/components/page/overview.hbs
@@ -33,7 +33,7 @@
       </h2>
     </OverviewCard>
   </div>
-  <div class="is-flex-align-start has-top-margin-l">
+  <div class="is-grid has-top-margin-l grid-2-columns grid-gap-2">
     <AccountsCheckedOut
       @libraries={{@libraries}}
       @statuses={{@librariesStatus}}
@@ -41,8 +41,7 @@
       @onCheckInSuccess={{transition-to "vault.cluster.secrets.backend.ldap.overview"}}
       class="is-flex-half"
     />
-
-    <div class="has-left-margin-l is-flex-half">
+    <div>
       <OverviewCard @cardTitle="Generate credentials" @subText="Quickly generate credentials by typing the role name.">
         <div class="has-top-margin-m is-flex">
           <SearchSelect


### PR DESCRIPTION
The second row of cards on the LDAP overview route were not using the responsive grid classes which was causing the view to be partially broken on smaller viewports. This PR updates the classes and now the cards are stacked in a full width column.

![image](https://github.com/hashicorp/vault/assets/24611656/65146e33-4167-419a-b4ac-9317dff0b67e)

