### PR TITLE
UI: Small styling fix when viewing KMIP credentials

### DIFF
--- a/ui/lib/kmip/addon/templates/credentials/show.hbs
+++ b/ui/lib/kmip/addon/templates/credentials/show.hbs
@@ -52,13 +52,7 @@
         <A.Title>Warning</A.Title>
         <A.Description>You will not be able to access the private key later, so please copy the information below.</A.Description>
       </Hds::Alert>
-      <MaskedInput
-        @value={{this.model.privateKey}}
-        @name="Private key"
-        @allowCopy={{true}}
-        @displayOnly={{true}}
-        class="is-block"
-      />
+      <MaskedInput @value={{this.model.privateKey}} @name="Private key" @allowCopy={{true}} @displayOnly={{true}} />
     </div>
   </InfoTableRow>
   <InfoTableRow @label="Certificate" @value={{this.model.certificate}}>


### PR DESCRIPTION
When viewing credentials in KMIP, there is a small styling problem. The `<MaskedInput>` in the "Private Key" row doesn't look right.

Reproduction steps:

1. Enable KMIP engine and configure it
2. Create scope
3. Click on scope and create role
4. Click on role and generate credentials in any format
5. View credentials

Before:
![Screenshot 2023-09-07 at 6 23 56 PM](https://github.com/hashicorp/vault/assets/104539507/5f3e5eda-a431-4f22-b315-86ecefd1a72f)
After:
![Screenshot 2023-09-07 at 6 24 18 PM](https://github.com/hashicorp/vault/assets/104539507/1511cbbf-acee-4f2d-80bd-d068e47deb58)