### PR TITLE
Fix the administrative banner for sys endpoints

### DIFF
--- a/website/content/api-docs/system/auth.mdx
+++ b/website/content/api-docs/system/auth.mdx
@@ -12,8 +12,6 @@ token which can be used for all future requests.
 
 ## List auth methods
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint lists all enabled auth methods.
 
 | Method | Path        |
@@ -82,8 +80,6 @@ $ curl \
 ```
 
 ## Enable auth method
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint enables a new auth method. After enabling, the auth method can
 be accessed and configured via the auth path specified as part of the URL. This
@@ -186,8 +182,6 @@ $ curl \
 
 ## Read auth method configuration
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoints returns the configuration of the auth method at the given path.
 
 | Method | Path              |
@@ -237,8 +231,6 @@ $ curl \
 
 ## Disable auth method
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint disables the auth method at the given auth path.
 
 - **`sudo` required** – This endpoint requires `sudo` capability in addition to
@@ -263,8 +255,6 @@ $ curl \
 ```
 
 ## Read auth method tuning
-
-@include 'alerts/restricted-admin.mdx'
 
 - This endpoint reads the given auth path's configuration. This endpoint requires
 `sudo` capability on the final path, but the same functionality can be achieved
@@ -302,8 +292,6 @@ $ curl \
 ```
 
 ## Tune auth method
-
-@include 'alerts/restricted-admin.mdx'
 
 Tune configuration parameters for a given auth path. _This endpoint
 requires `sudo` capability on the final path, but the same functionality

--- a/website/content/api-docs/system/capabilities-self.mdx
+++ b/website/content/api-docs/system/capabilities-self.mdx
@@ -16,8 +16,6 @@ memberships.
 
 ## Query self capabilities
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns the capabilities of client token on the given paths. The
 client token is the Vault token with which this API call is made. Multiple
 paths are taken in at once and the capabilities of the token for each path is

--- a/website/content/api-docs/system/capabilities.mdx
+++ b/website/content/api-docs/system/capabilities.mdx
@@ -15,8 +15,6 @@ through the entity and entity's group memberships.
 
 ## Query token capabilities
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns the list of capabilities of a given token on the given
 paths. Multiple paths are taken in at once and the capabilities of the token
 for each path is returned. For backwards compatibility, if a single path is

--- a/website/content/api-docs/system/config-control-group.mdx
+++ b/website/content/api-docs/system/config-control-group.mdx
@@ -13,8 +13,6 @@ settings.
 
 ## Read control group settings
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns the current Control Group configuration.
 
 | Method | Path                        |
@@ -38,8 +36,6 @@ $ curl \
 ```
 
 ## Configure control group settings
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint allows configuring control groups.
 
@@ -70,8 +66,6 @@ $ curl \
 ```
 
 ## Delete control group settings
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint removes any control group configuration.
 

--- a/website/content/api-docs/system/control-group.mdx
+++ b/website/content/api-docs/system/control-group.mdx
@@ -7,7 +7,6 @@ description: The '/sys/control-group' endpoint handles the Control Group workflo
 ## Authorize control group request
 
 @include 'alerts/enterprise-and-hcp-plus.mdx'
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint authorizes a control group request.
 
@@ -48,8 +47,6 @@ $ curl \
 ```
 
 ## Check control group request status
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint checks the status of a control group request.
 

--- a/website/content/api-docs/system/ha-status.mdx
+++ b/website/content/api-docs/system/ha-status.mdx
@@ -11,8 +11,6 @@ It lists the active node and the peers that it's heard from since it became acti
 
 ## HA status
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns the HA status of the Vault cluster.
 
 | Method | Path               |

--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -13,8 +13,6 @@ The `/sys/internal/counters` endpoints are used to return data about the number 
 
 ## Entities
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns the total number of Entities.
 
 | Method | Path                              |
@@ -53,8 +51,6 @@ $ curl \
 
 ## Tokens
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns the total number of Tokens.
 
 | Method | Path                            |
@@ -92,8 +88,6 @@ $ curl \
 ```
 
 ## Client count
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint returns client activity information for a given billing
 period, which is represented by the `start_time` and `end_time` parameters.
@@ -726,8 +720,6 @@ $ curl \
 
 ## Partial month client count
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns the client activity in the current month. The response
 will have activity attributions per namespace, per mount within each namespaces,
 and new clients information.
@@ -871,8 +863,6 @@ $ curl \
 
 ## Update the client count configuration
 
-@include 'alerts/restricted-admin.mdx'
-
 The `/sys/internal/counters/config` endpoint is used to configure logging of active clients.
 
 | Method | Path                            |
@@ -911,8 +901,6 @@ $ curl \
 
 ## Read the client count configuration
 
-@include 'alerts/restricted-admin.mdx'
-
 Reading the configuration shows the current settings, as well as a flag as to whether any data can be queried.
 
 - `enabled` `(string)` - returns `default-enabled` or `default-disabled` if the configuration is `default`.
@@ -949,8 +937,6 @@ $ curl \
 ```
 
 ## Activity export
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint returns an export of the clients that had activity within the
 provided start and end times. The returned set of client information will be

--- a/website/content/api-docs/system/internal-specs-openapi.mdx
+++ b/website/content/api-docs/system/internal-specs-openapi.mdx
@@ -25,8 +25,6 @@ structure, and other endpoints will be modified incrementally.
 
 ## Get OpenAPI document
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns a single OpenAPI document describing all paths visible to the requester.
 
 | Method | Path                          |

--- a/website/content/api-docs/system/internal-ui-feature.mdx
+++ b/website/content/api-docs/system/internal-ui-feature.mdx
@@ -16,8 +16,6 @@ guarantee on backwards compatibility for this endpoint.
 
 ## Get enabled feature flags
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint lists the enabled feature flags relevant to the UI.
 
 | Method | Path                             |

--- a/website/content/api-docs/system/internal-ui-mounts.mdx
+++ b/website/content/api-docs/system/internal-ui-mounts.mdx
@@ -22,8 +22,6 @@ compatibility for this endpoint.
 
 ## Get available visible mounts
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint lists all enabled auth methods.
 
 | Method | Path                      |
@@ -60,8 +58,6 @@ $ curl \
 ```
 
 ## Get single mount details
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint lists details for a specific mount path. This is an
 authenticated endpoint, and is currently only being used internally.

--- a/website/content/api-docs/system/internal-ui-resultant-acl.mdx
+++ b/website/content/api-docs/system/internal-ui-resultant-acl.mdx
@@ -15,8 +15,6 @@ intended usage, there is no guarantee on backwards compatibility for this endpoi
 
 ## Get resultant-acl
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint lists the resultant-acl relevant to the UI.
 
 | Method | Path                             |

--- a/website/content/api-docs/system/leader.mdx
+++ b/website/content/api-docs/system/leader.mdx
@@ -13,8 +13,6 @@ current leader of Vault.
 
 ## Read leader status
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns the high availability status and current leader instance
 of Vault.
 

--- a/website/content/api-docs/system/leases.mdx
+++ b/website/content/api-docs/system/leases.mdx
@@ -10,8 +10,6 @@ The `/sys/leases` endpoints are used to view and manage leases in Vault.
 
 ## Read lease
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint retrieve lease metadata.
 
 | Method | Path                 |
@@ -55,8 +53,6 @@ $ curl \
 
 ## List leases
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns a list of lease ids.
 
 **This endpoint requires 'sudo' capability.**
@@ -85,8 +81,6 @@ $ curl \
 ```
 
 ## Renew lease
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint renews a lease, requesting to extend the lease. Token leases
 cannot be renewed using this endpoint, use instead the auth/token/renew endpoint.
@@ -136,8 +130,6 @@ $ curl \
 
 ## Revoke lease
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint revokes a lease immediately.
 
 | Method | Path                 |
@@ -174,8 +166,6 @@ $ curl \
 
 ## Revoke force
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint revokes all secrets or tokens generated under a given prefix
 immediately. Unlike `/sys/leases/revoke-prefix`, this path ignores backend errors
 encountered during revocation. This is _potentially very dangerous_ and should
@@ -208,8 +198,6 @@ $ curl \
 
 ## Revoke prefix
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint revokes all secrets (via a lease ID prefix) or tokens (via the
 tokens' path property) generated under a given prefix immediately. This requires
 `sudo` capability and access to it should be tightly controlled as it can be
@@ -240,8 +228,6 @@ $ curl \
 
 ## Tidy leases
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint cleans up the dangling storage entries for leases: for each lease
 entry in storage, Vault will verify that it has an associated valid non-expired
 token in storage, and if not, the lease will be revoked.
@@ -264,8 +250,6 @@ $ curl \
 ```
 
 ## Lease counts
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint returns the total count of a `type` of lease, as well as a count
 per mount point. Note that it currently only supports type "irrevocable".
@@ -296,8 +280,6 @@ $ curl \
 ```
 
 ## Leases list
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint returns the total count of a `type` of lease, as well as a list
 of leases per mount point. Note that it currently only supports type

--- a/website/content/api-docs/system/license.mdx
+++ b/website/content/api-docs/system/license.mdx
@@ -15,8 +15,6 @@ Vault.
 
 ## License status
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns information about licensing. See [license autoloading](/vault/docs/enterprise/license/autoloading) for additional background.
 
 In the response:

--- a/website/content/api-docs/system/managed-keys.mdx
+++ b/website/content/api-docs/system/managed-keys.mdx
@@ -11,8 +11,6 @@ See the [Managed Keys](/vault/docs/enterprise/managed-keys) section for further 
 
 ## List managed keys.
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint lists all the Managed Keys of a certain type within the namespace.
 
 | Method | Path                      |
@@ -44,8 +42,6 @@ $ curl \
 ```
 
 ## Create/Update managed key
-
-@include 'alerts/restricted-admin.mdx'
 
 An endpoint that will create or update a Managed Key within a given namespace. The :type refers to the backend type
 that the key is to use, such as `pkcs11`. The :name argument is unique name within all managed key types in
@@ -266,8 +262,6 @@ $ curl \
 
 ## Read managed key
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns the managed key configuration at the given path.
 
 | Method | Path                            |
@@ -312,8 +306,6 @@ $ curl \
 
 ## Test sign with a managed key
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint allows an operator to validate that a managed key configuration works
 by signing and verifying some randomly generated data. If the call returns a successful HTTP
 status code, the configuration can be considered valid.
@@ -354,8 +346,6 @@ $ curl \
 
 
 ## Delete managed key
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint deletes the managed key at the given path provided it is not
 listed within any mount point's `allowed_managed_keys`.

--- a/website/content/api-docs/system/mfa/index.mdx
+++ b/website/content/api-docs/system/mfa/index.mdx
@@ -8,8 +8,6 @@ description: >-
 
 # `/sys/mfa`
 
-@include 'alerts/restricted-admin.mdx'
-
 The `/sys/mfa` endpoint focuses on managing Multi-factor Authentication (MFA)
 behaviors in Vault Enterprise MFA.
 

--- a/website/content/api-docs/system/monitor.mdx
+++ b/website/content/api-docs/system/monitor.mdx
@@ -13,7 +13,7 @@ some log lines will be dropped.
 
 ## Monitor system logs
 
-@include 'alerts/restricted-admin.mdx'
+- @include 'alerts/restricted-admin.mdx'
 
 This endpoint streams logs back to the client from Vault. Note that unlike most API endpoints in Vault, this one
 does not return JSON by default. This will send back data in whatever log format Vault has been configured with. By

--- a/website/content/api-docs/system/mounts.mdx
+++ b/website/content/api-docs/system/mounts.mdx
@@ -10,8 +10,6 @@ The `/sys/mounts` endpoint is used to manage secrets engines in Vault.
 
 ## List mounted secrets engines
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoints lists all the mounted secrets engines.
 
 | Method | Path          |
@@ -121,8 +119,6 @@ are used by this backend.
 
 ## Enable secrets engine
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint enables a new secrets engine at the given path.
 
 | Method | Path                |
@@ -219,8 +215,6 @@ $ curl \
 
 ## Disable secrets engine
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint disables the mount point specified in the URL.
 
 | Method   | Path                |                    |
@@ -254,8 +248,6 @@ If the underlying secrets were not manually cleaned up, this method might result
 in dangling credentials. This is meant for extreme circumstances.
 
 ## Get the configuration of a secret engine
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint returns the configuration of a specific secret engine.
 
@@ -318,8 +310,6 @@ $ curl \
 
 ## Read mount configuration
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint reads the given mount's configuration. Unlike the `mounts`
 endpoint, this will return the current time in seconds for each TTL, which may
 be the system default or a mount-specific value.
@@ -347,8 +337,6 @@ $ curl \
 ```
 
 ## Tune mount configuration
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint tunes configuration parameters for a given mount point.
 

--- a/website/content/api-docs/system/plugins-catalog.mdx
+++ b/website/content/api-docs/system/plugins-catalog.mdx
@@ -12,8 +12,6 @@ once registered backends can use the plugin by querying the catalog.
 
 ## LIST plugins
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint lists the plugins in the catalog by type.
 
 | Method | Path                   |
@@ -85,8 +83,6 @@ $ curl \
 
 ## LIST plugins
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint lists the plugins in the catalog by type.
 
 | Method | Path                            |
@@ -121,8 +117,6 @@ $ curl \
 ```
 
 ## Register plugin
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint registers a new plugin, or updates an existing one with the
 supplied name.
@@ -181,8 +175,6 @@ $ curl \
 
 ## Read plugin
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns the configuration data for the plugin with the given name.
 
 - **`sudo` required** – This endpoint requires `sudo` capability in addition to
@@ -228,8 +220,6 @@ $ curl \
 ```
 
 ## Remove plugin from catalog
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint removes the plugin with the given name.
 

--- a/website/content/api-docs/system/plugins-reload-backend.mdx
+++ b/website/content/api-docs/system/plugins-reload-backend.mdx
@@ -13,8 +13,6 @@ provided, all mounted paths that use that plugin backend will be reloaded.
 
 ## Reload plugins
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint reloads mounted plugin backends.
 
 | Method | Path -                        |

--- a/website/content/api-docs/system/policies-password.mdx
+++ b/website/content/api-docs/system/policies-password.mdx
@@ -18,8 +18,6 @@ as well as the syntax of the policies themselves.
 
 ## Create/Update password policy
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint adds a new or updates an existing password policy. Once a policy is updated,
 it takes effect immediately to all associated secret engines.
 
@@ -81,8 +79,6 @@ $ vault write sys/policies/password/my-policy policy=@my-policy.hcl
 
 ## List password policies
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoints list the password policies.
 
 | Method  | Path                               |
@@ -120,8 +116,6 @@ $ curl \
 
 ## Read password policy
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint retrieves information about the named password policy.
 
 | Method | Path                           |
@@ -151,8 +145,6 @@ $ curl \
 
 ## Delete password policy
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint deletes the password policy with the given name. This does not check if any
 secret engines are using it prior to deletion, so you should ensure that any engines that
 are utilizing this password policy are changed to a different policy (or to that engines'
@@ -177,8 +169,6 @@ $ curl \
 ```
 
 ## Generate password from password policy
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint generates a password from the specified existing password policy.
 

--- a/website/content/api-docs/system/policies.mdx
+++ b/website/content/api-docs/system/policies.mdx
@@ -18,8 +18,6 @@ Vault Open Source or basic Vault Enterprise installations.
 
 ## List ACL policies
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint lists all configured ACL policies.
 
 | Method | Path                |
@@ -43,8 +41,6 @@ $ curl \
 ```
 
 ## Read ACL policy
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint retrieves information about the named ACL policy.
 
@@ -75,8 +71,6 @@ $ curl \
 ```
 
 ## Create/Update ACL policy
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint adds a new or updates an existing ACL policy. Once a policy is
 updated, it takes effect immediately to all associated users.
@@ -113,8 +107,6 @@ $ curl \
 
 ## Delete ACL policy
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint deletes the ACL policy with the given name. This will immediately
 affect all users associated with this policy. (A deleted policy set on a token
 acts as an empty policy.)
@@ -139,8 +131,6 @@ $ curl \
 
 ## List RGP policies
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint lists all configured RGP policies.
 
 | Method | Path                |
@@ -164,8 +154,6 @@ $ curl \
 ```
 
 ## Read RGP policy
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint retrieves information about the named RGP policy.
 
@@ -197,8 +185,6 @@ $ curl \
 ```
 
 ## Create/Update RGP policy
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint adds a new or updates an existing RGP policy. Once a policy is
 updated, it takes effect immediately to all associated users.
@@ -240,8 +226,6 @@ $ curl \
 
 ## Delete RGP policy
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint deletes the RGP policy with the given name. This will immediately
 affect all users associated with this policy. (A deleted policy set on a token
 acts as an empty policy.)
@@ -265,8 +249,6 @@ $ curl \
 ```
 
 ## List EGP policies
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint lists all configured EGP policies. Since EGP policies act on a
 path, this endpoint returns two identifiers:
@@ -297,8 +279,6 @@ $ curl \
 ```
 
 ## Read EGP policy
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint retrieves information about the named EGP policy.
 
@@ -331,8 +311,6 @@ $ curl \
 ```
 
 ## Create/Update EGP policy
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint adds a new or updates an existing EGP policy. Once a policy is
 updated, it takes effect immediately to all associated users.
@@ -379,8 +357,6 @@ $ curl \
 ```
 
 ## Delete EGP policy
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint deletes the EGP policy with the given name from all paths on which it was configured.
 

--- a/website/content/api-docs/system/policy.mdx
+++ b/website/content/api-docs/system/policy.mdx
@@ -10,8 +10,6 @@ The `/sys/policy` endpoint is used to manage ACL policies in Vault.
 
 ## List policies
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint lists all configured policies.
 
 | Method | Path          |
@@ -35,8 +33,6 @@ $ curl \
 ```
 
 ## Read policy
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint retrieve the policy body for the named policy.
 
@@ -67,8 +63,6 @@ $ curl \
 ```
 
 ## Create/Update policy
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint adds a new or updates an existing policy. Once a policy is
 updated, it takes effect immediately to all associated users.
@@ -103,8 +97,6 @@ $ curl \
 ```
 
 ## Delete policy
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint deletes the policy with the given name. This will immediately
 affect all users associated with this policy.

--- a/website/content/api-docs/system/remount.mdx
+++ b/website/content/api-docs/system/remount.mdx
@@ -12,8 +12,6 @@ The Remount documentation details the endpoints required to trigger and monitor 
 
 ## Move backend
 
-@include 'alerts/restricted-admin.mdx'
-
 The `/sys/remount` endpoint moves an already-mounted backend to a new mount point. Remounting works for both secret
 engines and auth methods.
 
@@ -84,8 +82,6 @@ $ curl \
 ```
 
 ## Monitor migration status
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint is used to monitor the status of a mount migration operation, using the ID returned in the response
 of the `sys/remount` call. The response contains the passed-in ID, the source and target mounts, and a status field

--- a/website/content/api-docs/system/seal-status.mdx
+++ b/website/content/api-docs/system/seal-status.mdx
@@ -10,8 +10,6 @@ The `/sys/seal-status` endpoint is used to check the seal status of a Vault.
 
 ## Seal status
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns the seal status of the Vault. This is an unauthenticated
 endpoint.
 

--- a/website/content/api-docs/system/tools.mdx
+++ b/website/content/api-docs/system/tools.mdx
@@ -10,8 +10,6 @@ The `/sys/tools` endpoints are a general set of tools.
 
 ## Generate random bytes
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns high-quality random bytes of the specified length.
 
 | Method | Path                                   |
@@ -60,8 +58,6 @@ $ curl \
 ```
 
 ## Hash data
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint returns the cryptographic hash of given data using the specified
 algorithm.

--- a/website/content/api-docs/system/user-lockout.mdx
+++ b/website/content/api-docs/system/user-lockout.mdx
@@ -12,8 +12,6 @@ Refer to the [user lockout](/vault/docs/concepts/user-lockout) overview for more
 
 ## List locked users
 
-@include 'alerts/restricted-admin.mdx'
-
 The list endpoint returns information on the users currently locked by Vault.
 
 The response will include all child namespaces of the namespace in which the
@@ -194,8 +192,6 @@ $ curl \
 ```
 
 ## Unlock user
-
-@include 'alerts/restricted-admin.mdx'
 
 The unlock user endpoint frees a locked user with the provided `mount_accessor` and `alias_identifier` in the given namespace.
 The unlock command is idempotent. Calls to the endpoint succeed even if the user matching the provided `mount_accessor` and `alias_identifier` is not currently locked.

--- a/website/content/api-docs/system/version-history.mdx
+++ b/website/content/api-docs/system/version-history.mdx
@@ -13,8 +13,6 @@ The `/sys/version-history` endpoint is used to retrieve the version history of a
 
 ## Read version history
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns the version history of the Vault. The response will contain the following keys:
 
 - `keys`: a list of installed versions in chronological order based on the time installed

--- a/website/content/api-docs/system/wrapping-lookup.mdx
+++ b/website/content/api-docs/system/wrapping-lookup.mdx
@@ -10,8 +10,6 @@ The `/sys/wrapping/lookup` endpoint returns wrapping token properties.
 
 ## Wrapping lookup
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint looks up wrapping properties for the given token.
 
 | Method | Path                   |

--- a/website/content/api-docs/system/wrapping-rewrap.mdx
+++ b/website/content/api-docs/system/wrapping-rewrap.mdx
@@ -13,8 +13,6 @@ refresh its TTL.
 
 ## Wrapping rewrap
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint rewraps a response-wrapped token. The new token will use the same
 creation TTL as the original token and contain the same response. The old token
 will be invalidated. This can be used for long-term storage of a secret in a

--- a/website/content/api-docs/system/wrapping-unwrap.mdx
+++ b/website/content/api-docs/system/wrapping-unwrap.mdx
@@ -10,8 +10,6 @@ The `/sys/wrapping/unwrap` endpoint unwraps a wrapped response.
 
 ## Wrapping unwrap
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint returns the original response inside the given wrapping token.
 Unlike simply reading `cubbyhole/response` (which is deprecated), this endpoint
 provides additional validation checks on the token, returns the original value

--- a/website/content/api-docs/system/wrapping-wrap.mdx
+++ b/website/content/api-docs/system/wrapping-wrap.mdx
@@ -13,8 +13,6 @@ token.
 
 ## Wrapping wrap
 
-@include 'alerts/restricted-admin.mdx'
-
 This endpoint wraps the given user-supplied data inside a response-wrapped
 token.
 


### PR DESCRIPTION
During review of the administrative namespace docs, Violet noticed that the system endpoints documentation had been wrongly marked with the "root and admin only" banner, when in fact only two of them should have been (sys/monitor and sys/audit-hash). This PR fixes the other endpoints by removing the banner from their documentation.