### PR TITLE
Conditionally install gVisor in CI

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -255,6 +255,36 @@ jobs:
           GOPRIVATE: github.com/hashicorp/*
         run: time make ci-bootstrap dev
       - uses: ./.github/actions/set-up-gotestsum
+      - name: Install gVisor
+        # Enterprise repo runners do not allow sudo, so can't install gVisor there yet.
+        if: ${{ !inputs.enterprise }}
+        run: |
+          (
+            set -e
+            ARCH="$(uname -m)"
+            URL="https://storage.googleapis.com/gvisor/releases/release/latest/${ARCH}"
+            wget --quiet "${URL}/runsc" "${URL}/runsc.sha512" \
+              "${URL}/containerd-shim-runsc-v1" "${URL}/containerd-shim-runsc-v1.sha512"
+            sha512sum -c runsc.sha512 \
+              -c containerd-shim-runsc-v1.sha512
+            rm -f -- *.sha512
+            chmod a+rx runsc containerd-shim-runsc-v1
+            sudo mv runsc containerd-shim-runsc-v1 /usr/local/bin
+          )
+          sudo tee /etc/docker/daemon.json <<EOF
+          {
+            "runtimes": {
+              "runsc": {
+                "path": "/usr/local/bin/runsc",
+                "runtimeArgs": [
+                  "--host-uds=all",
+                  "--host-fifo=open"
+                ]
+              }
+            }
+          }
+          EOF
+          sudo systemctl reload docker
       - id: run-go-tests
         name: Run Go tests
         timeout-minutes: ${{ fromJSON(env.TIMEOUT_IN_MINUTES) }}


### PR DESCRIPTION
This adds back the CI step to install gVisor, but skips it on enterprise where the runners don't allow sudo, see a test run here: https://github.com/hashicorp/vault-enterprise/actions/runs/6120353721/job/16612145892

I'll be working with release engineering to get gVisor installed by default, as well as rootless runtimes and possibly podman, so depending on the outcome of that, this may just a temporary measure to give us some better CI coverage in the meantime.