### PR TITLE
Add timeout for http events tests

### DIFF
--- a/http/events_test.go
+++ b/http/events_test.go
@@ -49,6 +49,8 @@ func TestEventsSubscribe(t *testing.T) {
 	stop := atomic.Bool{}
 
 	const eventType = "abc"
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	// send some events
 	go func() {
@@ -60,8 +62,6 @@ func TestEventsSubscribe(t *testing.T) {
 			pluginInfo := &logical.EventPluginInfo{
 				MountPath: "secret",
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
 			err = core.Events().SendEventInternal(namespace.RootContext(ctx), namespace.RootNamespace, pluginInfo, logical.EventType(eventType), &logical.EventData{
 				Id:        id,
 				Metadata:  nil,
@@ -79,8 +79,6 @@ func TestEventsSubscribe(t *testing.T) {
 		stop.Store(true)
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 	wsAddr := strings.Replace(addr, "http", "ws", 1)
 
 	testCases := []struct {

--- a/http/events_test.go
+++ b/http/events_test.go
@@ -189,7 +189,9 @@ func TestBexprFilters(t *testing.T) {
 		defer close(eventChan)
 
 		// we should get the abc message
-		_, msg, err := conn.Read(ctx)
+		readCtx, readCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer readCancel()
+		_, msg, err := conn.Read(readCtx)
 		if err != nil {
 			t.Error(err)
 			return


### PR DESCRIPTION
This is a bit of a guess, but I've had a couple of CI runs timeout recently, and when I compare the logs of tests that completed with a log of the test order running locally, it looks like TestBexprFilters _might_ be the test that's hanging: https://github.com/hashicorp/vault/actions/runs/6114814016/job/16597219838. Naturally this isn't actually a fix for the test, but hopefully it will more quickly expose any failures.