### PR TITLE
Safer check in http/events validateSubscribeAccessLoop

### DIFF
--- a/http/events.go
+++ b/http/events.go
@@ -298,16 +298,10 @@ func prependNamespacePatterns(patterns []string, requestNamespace *namespace.Nam
 // validateSubscribeAccessLoop continually checks if the request has access to the subscribe endpoint in
 // its namespace. If the access check ever fails, then the cancel function is called and  the function returns.
 func validateSubscribeAccessLoop(core *vault.Core, ctx context.Context, cancel context.CancelFunc, req *logical.Request) {
-	defer func() {
-		if err := recover(); err != nil {
-			core.Logger().Error("Panic while validating subscribe access loop", "err", err)
-			return
-		}
-	}()
 	// if something breaks, default to canceling the websocket
 	defer cancel()
 	for {
-		_, _, err := core.CheckToken(ctx, req, false)
+		_, _, err := core.CheckTokenWithLock(ctx, req, false)
 		if err != nil {
 			core.Logger().Debug("Token does not have access to subscription path in its own namespace, terminating WebSocket subscription", "path", req.Path, "error", err)
 			return

--- a/http/events.go
+++ b/http/events.go
@@ -298,6 +298,12 @@ func prependNamespacePatterns(patterns []string, requestNamespace *namespace.Nam
 // validateSubscribeAccessLoop continually checks if the request has access to the subscribe endpoint in
 // its namespace. If the access check ever fails, then the cancel function is called and  the function returns.
 func validateSubscribeAccessLoop(core *vault.Core, ctx context.Context, cancel context.CancelFunc, req *logical.Request) {
+	defer func() {
+		if err := recover(); err != nil {
+			core.Logger().Error("Panic while validating subscribe access loop", "err", err)
+			return
+		}
+	}()
 	// if something breaks, default to canceling the websocket
 	defer cancel()
 	for {

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -272,7 +272,7 @@ func (c *Core) CheckTokenWithLock(ctx context.Context, req *logical.Request, una
 	// first check that we aren't shutting down
 	if c.Sealed() {
 		return nil, nil, errors.New("core is sealed")
-	} else if c.activeContext.Err() != nil {
+	} else if c.activeContext != nil && c.activeContext.Err() != nil {
 		return nil, nil, c.activeContext.Err()
 	}
 	return c.CheckToken(ctx, req, unauth)


### PR DESCRIPTION
We grab the state lock and check that the core is not shutting down.

This panic mostly seems to happen if Vault is shutting down, usually in a test.