### PR TITLE
Avoid Vault hang when no communication established with plugin

### DIFF
--- a/changelog/22914.txt
+++ b/changelog/22914.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+plugins: Fix instance where broken/unresponsive plugins could cause Vault to hang.
+```
+```release-note:bug
+plugins: Fix instance where Vault could fail to kill broken/unresponsive plugins.
+```

--- a/helper/testhelpers/pluginhelpers/pluginhelpers.go
+++ b/helper/testhelpers/pluginhelpers/pluginhelpers.go
@@ -154,6 +154,8 @@ func BuildPluginContainerImage(t testing.T, plugin TestPlugin, pluginDir string)
 	ref := plugin.Name
 	if plugin.Version != "" {
 		ref += ":" + strings.TrimPrefix(plugin.Version, "v")
+	} else {
+		ref += ":latest"
 	}
 	args := []string{"build", "--tag=" + ref, "--build-arg=plugin=" + plugin.FileName, "--file=vault/testdata/Dockerfile", pluginDir}
 	cmd := exec.Command("docker", args...)

--- a/sdk/plugin/grpc_backend_client.go
+++ b/sdk/plugin/grpc_backend_client.go
@@ -184,7 +184,7 @@ func (b *backendGRPCPluginClient) Cleanup(ctx context.Context) {
 	defer cancel()
 
 	// Only wait on graceful cleanup if we can establish communication with the
-	// plugin, otherwise b.cleanupCh may never get called.
+	// plugin, otherwise b.cleanupCh may never get closed.
 	if _, err := b.client.Cleanup(ctx, &pb.Empty{}); status.Code(err) != codes.Unavailable {
 		// This will block until Setup has run the function to create a new server
 		// in b.server. If we stop here before it has a chance to actually start


### PR DESCRIPTION
Also fixes a function where we may call go-plugin's client.Client() without ever calling client.Kill(), which could leak plugin processes.

It's pretty tricky to write an automated test for this, I'm still working on it, but wanted to get the change in before code freeze. To test manually, install runsc, and then break it for plugins by removing the additional runsc args we require - i.e. /etc/docker/daemon.json should look like this:

```json
{
    "runtimes": {
        "runsc": {
            "path": "/usr/local/bin/runsc"
        }
    }
}
```

Then run `sudo systemctl reload docker` and run some of the tests in `external_plugin_container_test.go`. Prior to this change it will hang indefinitely and then leave docker containers hanging around if you kill it. After this change, it should fail quickly and clean up after itself.