### PR TITLE
agent: Fail fast if agent doesn't start

### DIFF
--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -390,7 +390,7 @@ listener "tcp" {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Fatalf("timeout")
 	}
 
 	// defer agent shutdown


### PR DESCRIPTION
If the agent fails to start, for example when a port conflict occurs, we want the test to fail fast, rather than continuing until the test times out.

If this 5-second timeout occurs waiting for the agent to start up, then it does not make logical sense to continue the test. So, we use `t.Fatalf` to trigger the failure.