### PR TITLE
Only initialize the KMS config map if env map contains values

### DIFF
--- a/internalshared/configutil/kms.go
+++ b/internalshared/configutil/kms.go
@@ -216,7 +216,7 @@ func configureWrapper(configKMS *KMS, infoKeys *[]string, info *map[string]strin
 	var err error
 
 	envConfig := GetEnvConfigFunc(configKMS)
-	if configKMS.Config == nil {
+	if len(envConfig) > 0 && configKMS.Config == nil {
 		configKMS.Config = make(map[string]string)
 	}
 	// transit is a special case, because some config values take precedence over env vars


### PR DESCRIPTION
 - This addresses a test-failure in ENT and a use-case in which we would force a migration for stored configs that had been written with a nil configuration. 
 - This also keeps the behavior consistent if no configuration values exist the map member variable is nil and not an empty map.