### PR TITLE
release: remove concurrency groups from release testing

### DIFF
--- a/.github/workflows/enos-release-testing-oss.yml
+++ b/.github/workflows/enos-release-testing-oss.yml
@@ -6,11 +6,6 @@ on:
       - enos-release-testing-oss
       - enos-release-testing-oss::*
 
-# cancel existing runs of the same workflow on the same ref
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   product-metadata:
     if: ${{ startsWith(github.event.client_payload.payload.branch, 'release/') }}


### PR DESCRIPTION
The CRT orchestrator triggers the release testing workflows for all release versions using the same main ref. Therefore, if we have concurrency controls in place we could cancel them if more than one release branch is executing workflows.