### PR TITLE
Fix flaky auth test

### DIFF
--- a/ui/tests/acceptance/auth-test.js
+++ b/ui/tests/acceptance/auth-test.js
@@ -50,7 +50,6 @@ module('Acceptance | auth', function (hooks) {
 
   test('it clears token when changing selected auth method', async function (assert) {
     await visit('/vault/auth');
-    assert.strictEqual(currentURL(), '/vault/auth?with=token');
     await component.token('token').selectMethod('github');
     await component.selectMethod('token');
     assert.strictEqual(component.tokenValue, '', 'it clears the token value when toggling methods');


### PR DESCRIPTION
This test is now flaky because we removed the login/logout in the test hooks for the[ Ember upgrade.](https://github.com/hashicorp/vault/pull/22122/files#diff-502ad095ef43cf3ff2bf2bdd5fa7ca44e498d0f74d2a44c0970e570ab956386e)

Because we don't consistently login/logout this test holds onto the github login from the previous flow and instead of showing the queryParam of token, it shows github. I confirmed by checking past Vault versions that this _is_ expected behavior. 

I think it's safe to remove this line because we're testing similar functionality in the test before it, with the "auth query params".


