### PR TITLE
ui: remove a changelog entry for 1.15

### DIFF
--- a/changelog/_22640.txt
+++ b/changelog/_22640.txt
@@ -1,3 +1,0 @@
-```release-note:feature
-ui: Add support for SAML login flow
-```


### PR DESCRIPTION
This PR removes a changelog entry for 1.15 which came from https://github.com/hashicorp/vault/pull/22640. It will be replace by another changelog entry.