### PR TITLE
codeowners: adds identity oidc and token integrations to ecosystem

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,6 +22,9 @@
 /builtin/logical/postgresql/  @hashicorp/vault-ecosystem-applications
 /builtin/logical/rabbitmq/    @hashicorp/vault-ecosystem-applications
 
+# Identity Integrations (OIDC, tokens)
+/vault/identity_store_oidc*   @hashicorp/vault-ecosystem-applications
+
 /plugins/                     @hashicorp/vault-ecosystem
 /vault/plugin_catalog.go      @hashicorp/vault-ecosystem
 


### PR DESCRIPTION
This PR adds the vault-ecosystem-applications team as code owners of Vault OIDC provider and identity tokens.