### PR TITLE
Add support for true/false string literals for agent injector

### DIFF
--- a/changelog/22996.txt
+++ b/changelog/22996.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auto-auth/azure: Support setting the `authenticate_from_environment` variable to "true" and "false" string literals, too.
+```

--- a/command/agentproxyshared/auth/azure/azure.go
+++ b/command/agentproxyshared/auth/azure/azure.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+
 	policy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	az "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
@@ -101,20 +103,11 @@ func NewAzureAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 
 	authenticateFromEnvironmentRaw, ok := conf.Config["authenticate_from_environment"]
 	if ok {
-		a.authenticateFromEnvironment, ok = authenticateFromEnvironmentRaw.(bool)
-		if !ok {
-			authFromEnvString, ok := authenticateFromEnvironmentRaw.(string)
-			if !ok {
-				return nil, errors.New("could not convert 'authenticate_from_environment' config value to bool")
-			}
-			if authFromEnvString == "true" {
-				a.authenticateFromEnvironment = true
-			} else if authFromEnvString == "false" {
-				a.authenticateFromEnvironment = false
-			} else {
-				return nil, errors.New("could not convert 'authenticate_from_environment' config value to bool")
-			}
+		authenticateFromEnvironment, err := parseutil.ParseBool(authenticateFromEnvironmentRaw)
+		if err != nil {
+			return nil, fmt.Errorf("could not convert 'authenticate_from_environment' config value to bool: %w", err)
 		}
+		a.authenticateFromEnvironment = authenticateFromEnvironment
 	}
 
 	switch {

--- a/command/agentproxyshared/auth/azure/azure.go
+++ b/command/agentproxyshared/auth/azure/azure.go
@@ -103,7 +103,17 @@ func NewAzureAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 	if ok {
 		a.authenticateFromEnvironment, ok = authenticateFromEnvironmentRaw.(bool)
 		if !ok {
-			return nil, errors.New("could not convert 'authenticate_from_environment' config value to bool")
+			authFromEnvString, ok := authenticateFromEnvironmentRaw.(string)
+			if !ok {
+				return nil, errors.New("could not convert 'authenticate_from_environment' config value to bool")
+			}
+			if authFromEnvString == "true" {
+				a.authenticateFromEnvironment = true
+			} else if authFromEnvString == "false" {
+				a.authenticateFromEnvironment = false
+			} else {
+				return nil, errors.New("could not convert 'authenticate_from_environment' config value to bool")
+			}
 		}
 	}
 

--- a/command/agentproxyshared/auth/azure/azure_test.go
+++ b/command/agentproxyshared/auth/azure/azure_test.go
@@ -62,3 +62,22 @@ func TestAzureAuthMethod_BadConfig(t *testing.T) {
 		t.Fatal("Expected error, got none.")
 	}
 }
+
+func TestAzureAuthMethod_BadAuthFromEnvironment(t *testing.T) {
+	config := &auth.AuthConfig{
+		Logger:    hclog.NewNullLogger(),
+		MountPath: "auth-test",
+		Config: map[string]interface{}{
+			"resource":                      "test",
+			"client_id":                     "test",
+			"role":                          "test",
+			"scope":                         "test",
+			"authenticate_from_environment": "bad_value",
+		},
+	}
+
+	_, err := NewAzureAuthMethod(config)
+	if err == nil {
+		t.Fatal("Expected error, got none.")
+	}
+}

--- a/command/agentproxyshared/auth/azure/azure_test.go
+++ b/command/agentproxyshared/auth/azure/azure_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package azure
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/command/agentproxyshared/auth"
+)
+
+func TestAzureAuthMethod(t *testing.T) {
+	config := &auth.AuthConfig{
+		Logger:    hclog.NewNullLogger(),
+		MountPath: "auth-test",
+		Config: map[string]interface{}{
+			"resource":                      "test",
+			"client_id":                     "test",
+			"role":                          "test",
+			"scope":                         "test",
+			"authenticate_from_environment": true,
+		},
+	}
+
+	_, err := NewAzureAuthMethod(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAzureAuthMethod_StringAuthFromEnvironment(t *testing.T) {
+	config := &auth.AuthConfig{
+		Logger:    hclog.NewNullLogger(),
+		MountPath: "auth-test",
+		Config: map[string]interface{}{
+			"resource":                      "test",
+			"client_id":                     "test",
+			"role":                          "test",
+			"scope":                         "test",
+			"authenticate_from_environment": "true",
+		},
+	}
+
+	_, err := NewAzureAuthMethod(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAzureAuthMethod_BadConfig(t *testing.T) {
+	config := &auth.AuthConfig{
+		Logger:    hclog.NewNullLogger(),
+		MountPath: "auth-test",
+		Config: map[string]interface{}{
+			"bad_value": "abc",
+		},
+	}
+
+	_, err := NewAzureAuthMethod(config)
+	if err == nil {
+		t.Fatal("Expected error, got none.")
+	}
+}

--- a/command/agentproxyshared/auth/azure/azure_test.go
+++ b/command/agentproxyshared/auth/azure/azure_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/hashicorp/vault/command/agentproxyshared/auth"
 )
 
+// TestAzureAuthMethod tests that NewAzureAuthMethod succeeds
+// with valid config.
 func TestAzureAuthMethod(t *testing.T) {
+	t.Parallel()
 	config := &auth.AuthConfig{
 		Logger:    hclog.NewNullLogger(),
 		MountPath: "auth-test",
@@ -29,7 +32,10 @@ func TestAzureAuthMethod(t *testing.T) {
 	}
 }
 
+// TestAzureAuthMethod_StringAuthFromEnvironment tests that NewAzureAuthMethod succeeds
+// with valid config, where authenticate_from_environment is a string literal.
 func TestAzureAuthMethod_StringAuthFromEnvironment(t *testing.T) {
+	t.Parallel()
 	config := &auth.AuthConfig{
 		Logger:    hclog.NewNullLogger(),
 		MountPath: "auth-test",
@@ -48,7 +54,10 @@ func TestAzureAuthMethod_StringAuthFromEnvironment(t *testing.T) {
 	}
 }
 
+// TestAzureAuthMethod_BadConfig tests that NewAzureAuthMethod fails with
+// an invalid config.
 func TestAzureAuthMethod_BadConfig(t *testing.T) {
+	t.Parallel()
 	config := &auth.AuthConfig{
 		Logger:    hclog.NewNullLogger(),
 		MountPath: "auth-test",
@@ -63,7 +72,11 @@ func TestAzureAuthMethod_BadConfig(t *testing.T) {
 	}
 }
 
+// TestAzureAuthMethod_BadAuthFromEnvironment tests that NewAzureAuthMethod fails
+// with otherwise valid config, but where authenticate_from_environment is
+// an invalid string literal.
 func TestAzureAuthMethod_BadAuthFromEnvironment(t *testing.T) {
+	t.Parallel()
 	config := &auth.AuthConfig{
 		Logger:    hclog.NewNullLogger(),
 		MountPath: "auth-test",


### PR DESCRIPTION
The Agent Injector doesn't support boolean literals, so the ability for us to convert string to bool makes things a lot easier to use.

The 1.15.1 milestone doesn't exist, but if it did, I'd put it on this PR.