### PR TITLE
Events: Drop log level for events to debug

### DIFF
--- a/changelog/22997.txt
+++ b/changelog/22997.txt
@@ -1,0 +1,4 @@
+```release-note:change
+events: Log level for processing an event dropped from info to debug.
+```
+

--- a/vault/eventbus/bus.go
+++ b/vault/eventbus/bus.go
@@ -127,7 +127,7 @@ func (bus *EventBus) SendEventInternal(ctx context.Context, ns *namespace.Namesp
 		EventType:  string(eventType),
 		PluginInfo: pluginInfo,
 	}
-	bus.logger.Info("Sending event", "event", eventReceived)
+	bus.logger.Debug("Sending event", "event", eventReceived)
 
 	// We can't easily know when the SendEvent is complete, so we can't call the cancel function.
 	// But, it is called automatically after bus.timeout, so there won't be any leak as long as bus.timeout is not too long.


### PR DESCRIPTION
Now that events are enabled by default in 1.15.0, it seems a bit too noisy to log each event at info level.