### PR TITLE
ensure -log-level is added to core config

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -3006,6 +3006,7 @@ func createCoreConfig(c *ServerCommand, config *server.Config, backend physical.
 		AuditBackends:                  c.AuditBackends,
 		CredentialBackends:             c.CredentialBackends,
 		LogicalBackends:                c.LogicalBackends,
+		LogLevel:                       config.LogLevel,
 		Logger:                         c.logger,
 		DetectDeadlocks:                config.DetectDeadlocks,
 		ImpreciseLeaseRoleTracking:     config.ImpreciseLeaseRoleTracking,


### PR DESCRIPTION
The `-log-level` flag can be used to specify the log level of a Vault server's base logger. Unlike the `VAULT_LOG_LEVEL` environment variable and `log_level` HCL config parameter, the `-log-level` flag does not impact `CoreConfig.LogLevel`. An example of how the bug impacts logging:

```
# default logging specified via -log-level=debug
❯ vault read sys/loggers/policy
Key       Value
---       -----
policy    debug

❯ vault write sys/loggers/policy level=info
Success! Data written to: sys/loggers/policy

❯ vault read sys/loggers/policy
Key       Value
---       -----
policy    info

❯ vault delete sys/loggers/policy
Success! Data deleted (if it existed) at: sys/loggers/policy

❯ vault read sys/loggers/policy
Key       Value
---       -----
policy    info
```

The default logging level of `info` is used as `Core.LogLevel` remains unset (i.e. `""`). The delete should have reverted to the `-log-level` value of `debug`.

This PR addresses this by modifying the `createCoreConfig` func to set the associated `LogLevel`. The correct behavior:

```
# default logging specified via -log-level=debug
❯ vault read sys/loggers/policy
Key       Value
---       -----
policy    debug

❯ vault write sys/loggers/policy level=info
Success! Data written to: sys/loggers/policy

❯ vault read sys/loggers/policy
Key       Value
---       -----
policy    info

❯ vault delete sys/loggers/policy
Success! Data deleted (if it existed) at: sys/loggers/policy

❯ vault read sys/loggers/policy
Key       Value
---       -----
policy    debug
```

