### PR TITLE
Correct the post-unseal meaning of the seal status type

### DIFF
--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -109,6 +109,7 @@ type SealStatusResponse struct {
 	ClusterName       string   `json:"cluster_name,omitempty"`
 	ClusterID         string   `json:"cluster_id,omitempty"`
 	RecoverySeal      bool     `json:"recovery_seal"`
+	RecoverySealType  string   `json:"recovery_seal_type,omitempty"`
 	StorageType       string   `json:"storage_type,omitempty"`
 	HCPLinkStatus     string   `json:"hcp_link_status,omitempty"`
 	HCPLinkResourceID string   `json:"hcp_link_resource_ID,omitempty"`

--- a/changelog/23022.txt
+++ b/changelog/23022.txt
@@ -1,0 +1,5 @@
+```release-note:improvement
+core: update sys/seal-status (and CLI vault status) to report the type of
+the seal when unsealed, as well as the type of the recovery seal if an
+auto-seal.
+```

--- a/command/format.go
+++ b/command/format.go
@@ -669,7 +669,7 @@ func (t TableFormatter) OutputMap(ui cli.Ui, data map[string]interface{}) error 
 
 // OutputSealStatus will print *api.SealStatusResponse in the CLI according to the format provided
 func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusResponse) int {
-	sealStatusOutput := SealStatusOutput{SealStatusResponse: *status, SealType: status.Type}
+	sealStatusOutput := SealStatusOutput{SealStatusResponse: *status}
 
 	// Mask the 'Vault is sealed' error, since this means HA is enabled, but that
 	// we cannot query for the leader since we are sealed.

--- a/command/format.go
+++ b/command/format.go
@@ -326,13 +326,14 @@ func (t TableFormatter) Output(ui cli.Ui, secret *api.Secret, data interface{}) 
 func (t TableFormatter) OutputSealStatusStruct(ui cli.Ui, secret *api.Secret, data interface{}) error {
 	var status SealStatusOutput = data.(SealStatusOutput)
 	var sealPrefix string
-	if status.RecoverySeal {
-		sealPrefix = "Recovery "
-	}
 
 	out := []string{}
 	out = append(out, "Key | Value")
-	out = append(out, fmt.Sprintf("%sSeal Type | %s", sealPrefix, status.Type))
+	out = append(out, fmt.Sprintf("Seal Type | %s", status.Type))
+	if status.RecoverySeal {
+		sealPrefix = "Recovery "
+		out = append(out, fmt.Sprintf("Recovery Seal Type | %s", status.RecoverySealType))
+	}
 	out = append(out, fmt.Sprintf("Initialized | %t", status.Initialized))
 	out = append(out, fmt.Sprintf("Sealed | %t", status.Sealed))
 	out = append(out, fmt.Sprintf("Total %sShares | %d", sealPrefix, status.N))
@@ -668,7 +669,7 @@ func (t TableFormatter) OutputMap(ui cli.Ui, data map[string]interface{}) error 
 
 // OutputSealStatus will print *api.SealStatusResponse in the CLI according to the format provided
 func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusResponse) int {
-	sealStatusOutput := SealStatusOutput{SealStatusResponse: *status}
+	sealStatusOutput := SealStatusOutput{SealStatusResponse: *status, SealType: status.Type}
 
 	// Mask the 'Vault is sealed' error, since this means HA is enabled, but that
 	// we cannot query for the leader since we are sealed.
@@ -722,4 +723,5 @@ type SealStatusOutput struct {
 	LastWAL                  uint64    `json:"last_wal,omitempty"`
 	RaftCommittedIndex       uint64    `json:"raft_committed_index,omitempty"`
 	RaftAppliedIndex         uint64    `json:"raft_applied_index,omitempty"`
+	SealType                 string    `json:"type,omittempty"`
 }

--- a/command/format.go
+++ b/command/format.go
@@ -723,5 +723,4 @@ type SealStatusOutput struct {
 	LastWAL                  uint64    `json:"last_wal,omitempty"`
 	RaftCommittedIndex       uint64    `json:"raft_committed_index,omitempty"`
 	RaftAppliedIndex         uint64    `json:"raft_applied_index,omitempty"`
-	SealType                 string    `json:"type,omittempty"`
 }

--- a/command/format_test.go
+++ b/command/format_test.go
@@ -108,6 +108,7 @@ func TestStatusFormat(t *testing.T) {
 
 	expectedOutputString := `Key                           Value
 ---                           -----
+Seal Type                     type
 Recovery Seal Type            type
 Initialized                   true
 Sealed                        true
@@ -140,6 +141,7 @@ Warnings                      [warning]`
 
 	expectedOutputString = `Key                           Value
 ---                           -----
+Seal Type                     type
 Recovery Seal Type            type
 Initialized                   true
 Sealed                        true
@@ -167,21 +169,22 @@ func getMockStatusData(emptyFields bool) SealStatusOutput {
 	var sealStatusResponseMock api.SealStatusResponse
 	if !emptyFields {
 		sealStatusResponseMock = api.SealStatusResponse{
-			Type:         "type",
-			Initialized:  true,
-			Sealed:       true,
-			T:            1,
-			N:            2,
-			Progress:     3,
-			Nonce:        "nonce",
-			Version:      "version",
-			BuildDate:    "build date",
-			Migration:    true,
-			ClusterName:  "cluster name",
-			ClusterID:    "cluster id",
-			RecoverySeal: true,
-			StorageType:  "storage type",
-			Warnings:     []string{"warning"},
+			Type:             "type",
+			Initialized:      true,
+			Sealed:           true,
+			T:                1,
+			N:                2,
+			Progress:         3,
+			Nonce:            "nonce",
+			Version:          "version",
+			BuildDate:        "build date",
+			Migration:        true,
+			ClusterName:      "cluster name",
+			ClusterID:        "cluster id",
+			RecoverySeal:     true,
+			RecoverySealType: "type",
+			StorageType:      "storage type",
+			Warnings:         []string{"warning"},
 		}
 
 		// must initialize this struct without explicit field names due to embedding
@@ -200,20 +203,21 @@ func getMockStatusData(emptyFields bool) SealStatusOutput {
 		}
 	} else {
 		sealStatusResponseMock = api.SealStatusResponse{
-			Type:         "type",
-			Initialized:  true,
-			Sealed:       true,
-			T:            1,
-			N:            2,
-			Progress:     3,
-			Nonce:        "nonce",
-			Version:      "version",
-			BuildDate:    "build date",
-			Migration:    true,
-			ClusterName:  "",
-			ClusterID:    "",
-			RecoverySeal: true,
-			StorageType:  "",
+			Type:             "type",
+			Initialized:      true,
+			Sealed:           true,
+			T:                1,
+			N:                2,
+			Progress:         3,
+			Nonce:            "nonce",
+			Version:          "version",
+			BuildDate:        "build date",
+			Migration:        true,
+			ClusterName:      "",
+			ClusterID:        "",
+			RecoverySeal:     true,
+			StorageType:      "",
+			RecoverySealType: "type",
 		}
 
 		// must initialize this struct without explicit field names due to embedding

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4995,7 +4995,9 @@ func (core *Core) GetSealStatus(ctx context.Context) (*SealStatusResponse, error
 		}
 		clusterName = cluster.Name
 		clusterID = cluster.ID
-		recoverySealType = sealType
+		if core.SealAccess().RecoveryKeySupported() {
+			recoverySealType = sealType
+		}
 		sealType = core.seal.BarrierSealConfigType().String()
 	}
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4926,6 +4926,7 @@ type SealStatusResponse struct {
 	HCPLinkStatus     string   `json:"hcp_link_status,omitempty"`
 	HCPLinkResourceID string   `json:"hcp_link_resource_ID,omitempty"`
 	Warnings          []string `json:"warnings,omitempty"`
+	RecoverySealType  string   `json:"recovery_seal_type,omitempty"`
 }
 
 type SealBackendStatus struct {
@@ -4979,6 +4980,9 @@ func (core *Core) GetSealStatus(ctx context.Context) (*SealStatusResponse, error
 		return s, nil
 	}
 
+	var recoverySealType string
+	sealType := sealConfig.Type
+
 	// Fetch the local cluster name and identifier
 	var clusterName, clusterID string
 	if !sealed {
@@ -4991,25 +4995,28 @@ func (core *Core) GetSealStatus(ctx context.Context) (*SealStatusResponse, error
 		}
 		clusterName = cluster.Name
 		clusterID = cluster.ID
+		recoverySealType = sealType
+		sealType = core.seal.BarrierSealConfigType().String()
 	}
 
 	progress, nonce := core.SecretProgress()
 
 	s := &SealStatusResponse{
-		Type:         sealConfig.Type,
-		Initialized:  initialized,
-		Sealed:       sealed,
-		T:            sealConfig.SecretThreshold,
-		N:            sealConfig.SecretShares,
-		Progress:     progress,
-		Nonce:        nonce,
-		Version:      version.GetVersion().VersionNumber(),
-		BuildDate:    version.BuildDate,
-		Migration:    core.IsInSealMigrationMode() && !core.IsSealMigrated(),
-		ClusterName:  clusterName,
-		ClusterID:    clusterID,
-		RecoverySeal: core.SealAccess().RecoveryKeySupported(),
-		StorageType:  core.StorageType(),
+		Type:             sealType,
+		Initialized:      initialized,
+		Sealed:           sealed,
+		T:                sealConfig.SecretThreshold,
+		N:                sealConfig.SecretShares,
+		Progress:         progress,
+		Nonce:            nonce,
+		Version:          version.GetVersion().VersionNumber(),
+		BuildDate:        version.BuildDate,
+		Migration:        core.IsInSealMigrationMode() && !core.IsSealMigrated(),
+		ClusterName:      clusterName,
+		ClusterID:        clusterID,
+		RecoverySeal:     core.SealAccess().RecoveryKeySupported(),
+		RecoverySealType: recoverySealType,
+		StorageType:      core.StorageType(),
 	}
 
 	if resourceIDonHCP != "" {


### PR DESCRIPTION
And at the same time add a RecoverySealType to the response which preserves the old meaning.
Updated the CLI to display both when relevant.