### PR TITLE
UI: Handle control group error on SSH

### DIFF
--- a/changelog/23025.txt
+++ b/changelog/23025.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui (enterprise): Fix error message when generating SSH credential with control group
+```

--- a/ui/app/components/generate-credentials.js
+++ b/ui/app/components/generate-credentials.js
@@ -23,6 +23,7 @@ const MODEL_TYPES = {
 };
 
 export default Component.extend({
+  controlGroup: service(),
   store: service(),
   router: service(),
   // set on the component
@@ -89,10 +90,23 @@ export default Component.extend({
     create() {
       const model = this.model;
       this.set('loading', true);
-      this.model.save().finally(() => {
-        model.set('hasGenerated', true);
-        this.set('loading', false);
-      });
+      this.model
+        .save()
+        .then(() => {
+          model.set('hasGenerated', true);
+        })
+        .catch((error) => {
+          // Handle control group AdapterError
+          if (error.message === 'Control Group encountered') {
+            this.controlGroup.saveTokenFromError(error);
+            const err = this.controlGroup.logFromError(error);
+            error.errors = [err.content];
+          }
+          throw error;
+        })
+        .finally(() => {
+          this.set('loading', false);
+        });
     },
 
     codemirrorUpdated(attr, val, codemirror) {


### PR DESCRIPTION
Previous to this change, having a control group on the `ssh/creds/*` path would result in a generic, unhelpful "Adapter Error" message when attempting to generate a credential: 

<img width="1230" alt="Screenshot 2023-09-12 at 3 24 21 PM" src="https://github.com/hashicorp/vault/assets/82459713/9e6e7cad-8495-41d4-91f5-650689b4e628">

After this change, the user sees the full Control Group message and has access to the control group accessor: 

<img width="1230" alt="Screenshot 2023-09-12 at 2 59 44 PM" src="https://github.com/hashicorp/vault/assets/82459713/b6979f74-82c7-4cd3-8a09-bef083e057a4">
