### PR TITLE
[Docs] Add missing parameter in the request

### DIFF
--- a/website/pages/api-docs/system/plugins-reload-backend.mdx
+++ b/website/pages/api-docs/system/plugins-reload-backend.mdx
@@ -41,6 +41,7 @@ This endpoint reloads mounted plugin backends.
 ```
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT
+    --request PUT \
+    --data @payload.json \
     http://127.0.0.1:8200/v1/sys/plugins/reload/backend
 ```


### PR DESCRIPTION
It was reported that the sample request is missing data from the **1.4.x** doc.

🧵 [Slack](https://hashicorp.slack.com/archives/C012RTGJR1V/p1694527942628429)

This PR adds the missing `--data @payload.json` to the request example.