### PR TITLE
Fix LDAP auto auth changelog

### DIFF
--- a/changelog/21641.txt
+++ b/changelog/21641.txt
@@ -1,3 +1,3 @@
-```release-note:feature
-auto-auth: support ldap auth
+```release-note:improvement
+auto-auth: added support for LDAP auto-auth
 ```


### PR DESCRIPTION
It wasn't using the right feature format, and also should probably have been an improvement.