### PR TITLE
Fix enterprise failure of TestCRLIssuerRemoval

### DIFF
--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -1452,6 +1452,7 @@ func TestCRLIssuerRemoval(t *testing.T) {
 		// unified CRLs get built.
 		_, err := CBWrite(b, s, "config/crl", map[string]interface{}{
 			"cross_cluster_revocation": true,
+			"auto_rebuild":             true,
 		})
 		require.NoError(t, err, "failed enabling unified CRLs on enterprise")
 	}


### PR DESCRIPTION
 This fixes the enterprise failure of the test introduced through #23007
 ```
  === FAIL: builtin/logical/pki TestCRLIssuerRemoval (0.00s)
     crl_test.go:1456:
         	Error Trace:	/home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/builtin/logical/pki/crl_test.go:1456
         	Error:      	Received unexpected error:
         	            	Global, cross-cluster revocation queue cannot be enabled when auto rebuilding is disabled as the local cluster may not have the certificate entry!
         	Test:       	TestCRLIssuerRemoval
         	Messages:   	failed enabling unified CRLs on enterprise

 ```