### PR TITLE
UI/remove kv2 secret create or update

### DIFF
--- a/ui/app/components/secret-create-or-update.js
+++ b/ui/app/components/secret-create-or-update.js
@@ -14,7 +14,6 @@
  *  @model={{model}}
  *  @showAdvancedMode=true
  *  @modelForData={{@modelForData}}
- *  @isV2=true
  *  @secretData={{@secretData}}
  *  @canCreateSecretMetadata=false
  *  @buttonDisabled={{this.saving}}
@@ -24,7 +23,6 @@
  * @param {object} model - the route model, comes from secret-v2 ember record
  * @param {boolean} showAdvancedMode - whether or not to show the JSON editor
  * @param {object} modelForData - a class that helps track secret data, defined in secret-edit
- * @param {boolean} isV2 - whether or not KV1 or KV2
  * @param {object} secretData - class that is created in secret-edit
  * @param {boolean} canUpdateSecretMetadata - based on permissions to the /metadata/ endpoint. If user has secret update. create is not enough for metadata.
  * @param {boolean} buttonDisabled - if true, disables the submit button on the create/update form
@@ -67,6 +65,7 @@ export default class SecretCreateOrUpdate extends Component {
     if (Ember.testing) {
       this.secretPaths = ['beep', 'bop', 'boop'];
     } else {
+      // TODO should be able to remove the secret-v2 model
       const adapter = this.store.adapterFor('secret-v2');
       const type = { modelName: 'secret-v2' };
       const query = { backend: model.backend };
@@ -121,15 +120,12 @@ export default class SecretCreateOrUpdate extends Component {
   persistKey(successCallback) {
     const secret = this.args.model;
     const secretData = this.args.modelForData;
-    const isV2 = this.args.isV2;
     let key = secretData.get('path') || secret.id;
 
     if (key.startsWith('/')) {
       key = key.replace(/^\/+/g, '');
       secretData.set(secretData.pathAttr, key);
     }
-    const changed = secret.changedAttributes();
-    const changedKeys = Object.keys(changed);
 
     return secretData
       .save()
@@ -138,28 +134,7 @@ export default class SecretCreateOrUpdate extends Component {
           delete secret.selectedVersion.secretData;
         }
         if (!secretData.isError) {
-          if (isV2) {
-            secret.set('id', key);
-          }
-          // this secret.save() saves to the metadata endpoint. Only saved if metadata has been added
-          // and if the currentVersion attr changed that's because we added it (only happens if they don't have read access to metadata on mode = update which does not allow you to change metadata)
-          if (isV2 && changedKeys.length > 0 && changedKeys[0] !== 'currentVersion') {
-            // save secret metadata
-            secret
-              .save()
-              .then(() => {
-                this.saveComplete(successCallback, key);
-              })
-              .catch((e) => {
-                // when mode is not create the metadata error is handled in secret-edit-metadata
-                if (this.args.mode === 'create') {
-                  this.error = e.errors.join(' ');
-                }
-                return;
-              });
-          } else {
-            this.saveComplete(successCallback, key);
-          }
+          this.saveComplete(successCallback, key);
         }
       })
       .catch((error) => {
@@ -176,21 +151,6 @@ export default class SecretCreateOrUpdate extends Component {
   }
   transitionToRoute() {
     return this.router.transitionTo(...arguments);
-  }
-
-  get isCreateNewVersionFromOldVersion() {
-    const model = this.args.model;
-    if (!model) {
-      return false;
-    }
-    if (
-      !model.failedServerRead &&
-      !model.selectedVersion?.failedServerRead &&
-      model.selectedVersion?.version !== model.currentVersion
-    ) {
-      return true;
-    }
-    return false;
   }
 
   @(task(function* (name, value) {

--- a/ui/app/components/secret-create-or-update.js
+++ b/ui/app/components/secret-create-or-update.js
@@ -15,7 +15,6 @@
  *  @showAdvancedMode=true
  *  @modelForData={{@modelForData}}
  *  @secretData={{@secretData}}
- *  @canCreateSecretMetadata=false
  *  @buttonDisabled={{this.saving}}
  * />
  * ```
@@ -24,7 +23,6 @@
  * @param {boolean} showAdvancedMode - whether or not to show the JSON editor
  * @param {object} modelForData - a class that helps track secret data, defined in secret-edit
  * @param {object} secretData - class that is created in secret-edit
- * @param {boolean} canUpdateSecretMetadata - based on permissions to the /metadata/ endpoint. If user has secret update. create is not enough for metadata.
  * @param {boolean} buttonDisabled - if true, disables the submit button on the create/update form
  */
 
@@ -130,9 +128,6 @@ export default class SecretCreateOrUpdate extends Component {
     return secretData
       .save()
       .then(() => {
-        if (!this.args.canReadSecretData && secret.selectedVersion) {
-          delete secret.selectedVersion.secretData;
-        }
         if (!secretData.isError) {
           this.saveComplete(successCallback, key);
         }

--- a/ui/app/components/secret-create-or-update.js
+++ b/ui/app/components/secret-create-or-update.js
@@ -54,7 +54,7 @@ export default class SecretCreateOrUpdate extends Component {
   @service store;
 
   @action
-  setup(elem, [secretData, model, mode]) {
+  setup(elem, [secretData, mode]) {
     this.codemirrorString = secretData.toJSONString();
     this.validationMessages = {
       path: '',
@@ -62,14 +62,6 @@ export default class SecretCreateOrUpdate extends Component {
     // for validation, return array of path names already assigned
     if (Ember.testing) {
       this.secretPaths = ['beep', 'bop', 'boop'];
-    } else {
-      // TODO should be able to remove the secret-v2 model
-      const adapter = this.store.adapterFor('secret-v2');
-      const type = { modelName: 'secret-v2' };
-      const query = { backend: model.backend };
-      adapter.query(this.store, type, query).then((result) => {
-        this.secretPaths = result.data.keys;
-      });
     }
     this.checkRows();
 
@@ -88,12 +80,6 @@ export default class SecretCreateOrUpdate extends Component {
       this.pathHasWhiteSpace(value);
       !value
         ? set(this.validationMessages, name, `${name} can't be blank.`)
-        : set(this.validationMessages, name, '');
-    }
-    // check duplicate on path
-    if (name === 'path' && value) {
-      this.secretPaths?.includes(value)
-        ? set(this.validationMessages, name, `A secret with this ${name} already exists.`)
         : set(this.validationMessages, name, '');
     }
     const values = Object.values(this.validationMessages);
@@ -118,6 +104,7 @@ export default class SecretCreateOrUpdate extends Component {
   persistKey(successCallback) {
     const secret = this.args.model;
     const secretData = this.args.modelForData;
+
     let key = secretData.get('path') || secret.id;
 
     if (key.startsWith('/')) {

--- a/ui/app/components/secret-edit-toolbar.js
+++ b/ui/app/components/secret-edit-toolbar.js
@@ -12,7 +12,6 @@
  * <SecretEditToolbar
  * @mode={{mode}}
  * @model={{this.model}}
- * @isV2={{isV2}}
  * @isWriteWithoutRead={{isWriteWithoutRead}}
  * @secretDataIsAdvanced={{secretDataIsAdvanced}}
  * @showAdvancedMode={{showAdvancedMode}}
@@ -27,12 +26,11 @@
 
  * @param {string} mode - show, create, edit. The view.
  * @param {object} model - the model passed from the parent secret-edit
- * @param {boolean} isV2 - KV type
  * @param {boolean} isWriteWithoutRead - boolean describing permissions
  * @param {boolean} secretDataIsAdvanced - used to determine if show JSON toggle
  * @param {boolean} showAdvancedMode - used for JSON toggle
  * @param {object} modelForData - a modified version of the model with secret data
- * @param {boolean} canUpdateSecretData - permissions that show the create new version button or not.
+ * @param {boolean} canUpdateSecretData - permissions to hide/show edit secret button.
  * @param {object} editActions - actions passed from parent to child
  */
 /* eslint ember/no-computed-properties-in-native-classes: 'warn' */
@@ -62,9 +60,7 @@ export default class SecretEditToolbar extends Component {
     const wrapTTL = { wrapTTL: 1800 };
 
     try {
-      const resp = yield this.args.isV2
-        ? this.store.adapterFor('secret-v2-version').queryRecord(id, wrapTTL)
-        : this.store.adapterFor('secret').queryRecord(null, null, { backend, id, ...wrapTTL });
+      const resp = yield this.store.adapterFor('secret').queryRecord(null, null, { backend, id, ...wrapTTL });
       this.wrappedData = resp.wrap_info.token;
       this.flashMessages.success('Secret successfully wrapped!');
     } catch (e) {

--- a/ui/app/components/secret-edit-toolbar.js
+++ b/ui/app/components/secret-edit-toolbar.js
@@ -16,7 +16,7 @@
  * @secretDataIsAdvanced={{secretDataIsAdvanced}}
  * @showAdvancedMode={{showAdvancedMode}}
  * @modelForData={{this.modelForData}}
- * @canUpdateSecretData={{canUpdateSecretData}}
+ * @canUpdateSecret={{canUpdateSecret}}
  * @editActions={{hash
     toggleAdvanced=(action "toggleAdvanced")
     refresh=(action "refresh")
@@ -30,7 +30,7 @@
  * @param {boolean} secretDataIsAdvanced - used to determine if show JSON toggle
  * @param {boolean} showAdvancedMode - used for JSON toggle
  * @param {object} modelForData - a modified version of the model with secret data
- * @param {boolean} canUpdateSecretData - permissions to hide/show edit secret button.
+ * @param {boolean} canUpdateSecret - permissions to hide/show edit secret button.
  * @param {object} editActions - actions passed from parent to child
  */
 /* eslint ember/no-computed-properties-in-native-classes: 'warn' */

--- a/ui/app/models/secret-v2.js
+++ b/ui/app/models/secret-v2.js
@@ -69,7 +69,6 @@ export default SecretV2Model.extend(KeyMixin, {
 
   canReadSecretData: alias('secretDataPath.canRead'),
   canEditSecretData: alias('secretDataPath.canUpdate'),
-  canDeleteSecretData: alias('secretDataPath.canDelete'),
 
   canUndelete: alias('secretUndeletePath.canUpdate'),
   canDestroyVersion: alias('secretDestroyPath.canUpdate'),

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -33,9 +33,7 @@ export default Route.extend(UnloadModelRoute, {
     const backendModel = this.modelFor('vault.cluster.secrets.backend');
     const backendType = backendModel.engineType;
     let path;
-    if (backendModel.isV2KV) {
-      path = `${backend}/data/${secret}`;
-    } else if (backendType === 'transit') {
+    if (backendType === 'transit') {
       path = backend + '/keys/' + secret;
     } else if (backendType === 'ssh' || backendType === 'aws') {
       path = backend + '/roles/' + secret;

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import AdapterError from '@ember-data/adapter/error';
 import { set } from '@ember/object';
 import Ember from 'ember';
 import { resolve } from 'rsvp';
@@ -15,8 +14,8 @@ import { keyIsFolder, parentKeyForKey } from 'core/utils/key-utils';
 
 export default Route.extend(UnloadModelRoute, {
   store: service(),
+  router: service(),
   pathHelp: service('path-help'),
-  wizard: service(),
 
   secretParam() {
     const { secret } = this.paramsFor(this.routeName);
@@ -82,9 +81,9 @@ export default Route.extend(UnloadModelRoute, {
       const mode = this.routeName.split('.').pop();
       if (mode === 'edit' && keyIsFolder(secret)) {
         if (parentKey) {
-          return this.transitionTo('vault.cluster.secrets.backend.list', encodePath(parentKey));
+          return this.router.transitionTo('vault.cluster.secrets.backend.list', encodePath(parentKey));
         } else {
-          return this.transitionTo('vault.cluster.secrets.backend.list-root');
+          return this.router.transitionTo('vault.cluster.secrets.backend.list-root');
         }
       }
     });
@@ -93,7 +92,7 @@ export default Route.extend(UnloadModelRoute, {
   buildModel(secret, queryParams) {
     const backend = this.enginePathParam();
     const modelType = this.modelType(backend, secret, { queryParams });
-    if (['secret', 'secret-v2'].includes(modelType)) {
+    if (modelType === 'secret') {
       return resolve();
     }
     return this.pathHelp.getNewModel(modelType, backend);
@@ -109,95 +108,11 @@ export default Route.extend(UnloadModelRoute, {
       transform: this.modelTypeForTransform(secret),
       aws: 'role-aws',
       cubbyhole: 'secret',
-      kv: backendModel.modelTypeForKV,
+      kv: 'secret',
       keymgmt: `keymgmt/${options.queryParams?.itemType || 'key'}`,
-      generic: backendModel.modelTypeForKV,
+      generic: 'secret',
     };
     return types[type];
-  },
-
-  getTargetVersion(currentVersion, paramsVersion) {
-    if (currentVersion) {
-      // we have the secret metadata, so we can read the currentVersion but give priority to any
-      // version passed in via the url
-      return parseInt(paramsVersion || currentVersion, 10);
-    } else {
-      // we've got a stub model because don't have read access on the metadata endpoint
-      return paramsVersion ? parseInt(paramsVersion, 10) : null;
-    }
-  },
-
-  async fetchV2Models(capabilities, secretModel, params) {
-    const backend = this.enginePathParam();
-    const backendModel = this.modelFor('vault.cluster.secrets.backend', backend);
-    const targetVersion = this.getTargetVersion(secretModel.currentVersion, params.version);
-
-    // if we have the metadata, a list of versions are part of the payload
-    const version = secretModel.versions && secretModel.versions.findBy('version', targetVersion);
-    // if it didn't fail the server read, and the version is not attached to the metadata,
-    // this should 404
-    if (!version && secretModel.failedServerRead !== true) {
-      const error = new AdapterError();
-      set(error, 'httpStatus', 404);
-      throw error;
-    }
-    // manually set the related model
-    secretModel.set('engine', backendModel);
-
-    secretModel.set(
-      'selectedVersion',
-      await this.fetchV2VersionModel(capabilities, secretModel, version, targetVersion)
-    );
-    return secretModel;
-  },
-
-  async fetchV2VersionModel(capabilities, secretModel, version, targetVersion) {
-    const secret = this.secretParam();
-    const backend = this.enginePathParam();
-
-    // v2 versions have a composite ID, we generated one here if we need to manually set it
-    // after a failed fetch later;
-    const versionId = targetVersion ? [backend, secret, targetVersion] : [backend, secret];
-
-    let versionModel;
-    try {
-      if (secretModel.failedServerRead) {
-        // we couldn't read metadata, so we want to directly fetch the version
-        versionModel = await this.store.findRecord('secret-v2-version', JSON.stringify(versionId), {
-          reload: true,
-        });
-      } else {
-        // we may have previously errored, so roll it back here
-        version.rollbackAttributes();
-        // if metadata read was successful, the version we have is only a partial model
-        // trigger reload to fetch the whole version model
-        versionModel = await version.reload();
-      }
-    } catch (error) {
-      // cannot read the data endpoint but still allow them to see show page to access metadata if they have permissions
-      if (error.httpStatus === 403) {
-        // versionModel is then a partial model from the metadata (if we have read there), or
-        // we need to create one on the client
-        if (version) {
-          version.set('failedServerRead', true);
-          versionModel = version;
-        } else {
-          this.store.push({
-            data: {
-              type: 'secret-v2-version',
-              id: JSON.stringify(versionId),
-              attributes: {
-                failedServerRead: true,
-              },
-            },
-          });
-          versionModel = this.store.peekRecord('secret-v2-version', JSON.stringify(versionId));
-        }
-      } else {
-        throw error;
-      }
-    }
-    return versionModel;
   },
 
   handleSecretModelError(capabilities, secretId, modelType, error) {
@@ -205,8 +120,6 @@ export default Route.extend(UnloadModelRoute, {
     if (!capabilities.get('canUpdate') && modelType === 'secret') {
       throw error;
     }
-    // don't have access to the metadata for v2 or the secret for v1,
-    // so we make a stub model and mark it as `failedServerRead`
     this.store.push({
       data: {
         id: secretId,
@@ -220,16 +133,7 @@ export default Route.extend(UnloadModelRoute, {
     return secretModel;
   },
 
-  // wizard will pause unless we manually continue it
-  updateWizard(params) {
-    // verify that keymgmt tutorial is in progress
-    if (params.itemType === 'provider' && this.wizard.nextStep === 'displayProvider') {
-      this.wizard.transitionFeatureMachine(this.wizard.featureState, 'CONTINUE', 'keymgmt');
-    }
-  },
-
   async model(params, { to: { queryParams } }) {
-    this.updateWizard(params);
     let secret = this.secretParam();
     const backend = this.enginePathParam();
     const modelType = this.modelType(backend, secret, { queryParams });
@@ -249,9 +153,9 @@ export default Route.extend(UnloadModelRoute, {
     try {
       secretModel = await this.store.queryRecord(modelType, { id: secret, backend, type });
     } catch (err) {
-      // we've failed the read request, but if it's a kv-type backend, we want to
+      // we've failed the read request, but if it's a kv-v1 type backend, we want to
       // do additional checks of the capabilities
-      if (err.httpStatus === 403 && (modelType === 'secret-v2' || modelType === 'secret')) {
+      if (err.httpStatus === 403 && modelType === 'secret') {
         await capabilities;
         secretModel = this.handleSecretModelError(capabilities, secret, modelType, err);
       } else {
@@ -259,11 +163,7 @@ export default Route.extend(UnloadModelRoute, {
       }
     }
     await capabilities;
-    if (modelType === 'secret-v2') {
-      // after the the base model fetch, kv-v2 has a second associated
-      // version model that contains the secret data
-      secretModel = await this.fetchV2Models(capabilities, secretModel, params);
-    }
+
     return {
       secret: secretModel,
       capabilities,
@@ -318,32 +218,20 @@ export default Route.extend(UnloadModelRoute, {
       if (!model.hasDirtyAttributes || model.isDeleted) {
         return true;
       }
-      // TODO kv engine cleanup: below is KV v2 logic, remove with engine work
-      const version = model.get('selectedVersion');
+
       const changed = model.changedAttributes();
       const changedKeys = Object.keys(changed);
 
-      // when you don't have read access on metadata we add currentVersion to the model
-      // this makes it look like you have unsaved changes and prompts a browser warning
-      // here we are specifically ignoring it.
-      if (mode === 'edit' && changedKeys.length && changedKeys[0] === 'currentVersion') {
-        version && version.rollbackAttributes();
-        return true;
-      }
       // until we have time to move `backend` on a v1 model to a relationship,
       // it's going to dirty the model state, so we need to look for it
       // and explicity ignore it here
-      if (
-        (mode !== 'show' && changedKeys.length && changedKeys[0] !== 'backend') ||
-        (mode !== 'show' && version && version.hasDirtyAttributes)
-      ) {
+      if (mode !== 'show' && changedKeys.length && changedKeys[0] !== 'backend') {
         if (
           Ember.testing ||
           window.confirm(
             'You have unsaved changes. Navigating away will discard these changes. Are you sure you want to discard your changes?'
           )
         ) {
-          version && version.rollbackAttributes();
           model && model.rollbackAttributes();
           this.unloadModel();
           return true;

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -33,7 +33,6 @@
           @isMarginless={{true}}
         />
       {{/if}}
-      {{! TODO kv engine cleanup }}
       {{#if @modelForData.isFolder}}
         <p class="help has-text-danger">
           The secret path may not end in
@@ -58,7 +57,7 @@
     {{#if @showAdvancedMode}}
       <div class="form-section">
         <JsonEditor
-          @title={{if @isV2 "Version Data" "Secret Data"}}
+          @title="Secret Data"
           @value={{this.codemirrorString}}
           @valueUpdated={{action "codemirrorUpdated"}}
           @onFocusOut={{action "formatJSON"}}
@@ -148,23 +147,14 @@
     <div class="box is-sideless is-fullwidth is-marginless padding-top">
       <MessageError @model={{@modelForData}} @errorMessage={{this.error}} />
       <NamespaceReminder @mode="edit" @noun="secret" />
-      {{#if (or (eq @canReadSecretData false) this.isCreateNewVersionFromOldVersion)}}
+      {{#if (eq @canReadSecretData false)}}
         <Hds::Alert @type="inline" @color="warning" class="has-bottom-margin-s" as |A|>
           <A.Title>Warning</A.Title>
           <A.Description>
-            <ul class={{if (and (eq @canReadSecretData false) this.isCreateNewVersionFromOldVersion) "bullet"}}>
+            <ul class={{if (eq @canReadSecretData false) "bullet"}}>
               {{#if (eq @canReadSecretData false)}}
                 <li data-test-warning-no-read-permissions>
                   You do not have read permissions. If a secret exists at this path creating a new secret will overwrite it.
-                </li>
-              {{/if}}
-              {{#if this.isCreateNewVersionFromOldVersion}}
-                <li>
-                  You are creating a new version based on data from Version
-                  {{@model.selectedVersion.version}}. The current version for
-                  {{@model.id}}
-                  is Version
-                  {{@model.currentVersion}}.
                 </li>
               {{/if}}
             </ul>
@@ -174,7 +164,7 @@
       {{#if @showAdvancedMode}}
         <div class="form-section">
           <JsonEditor
-            @title={{if @isV2 "Version Data" "Secret Data"}}
+            @title="Secret Data"
             @value={{this.codemirrorString}}
             @valueUpdated={{action "codemirrorUpdated"}}
             @onFocusOut={{action "formatJSON"}}
@@ -183,11 +173,7 @@
       {{else}}
         <div class="form-section">
           <label class="title is-5">
-            {{#if @isV2}}
-              Version data
-            {{else}}
-              Secret data
-            {{/if}}
+            Secret data
           </label>
           {{#each @secretData as |secret index|}}
             <div class="columns is-variable has-no-shadow">

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -147,12 +147,12 @@
     <div class="box is-sideless is-fullwidth is-marginless padding-top">
       <MessageError @model={{@modelForData}} @errorMessage={{this.error}} />
       <NamespaceReminder @mode="edit" @noun="secret" />
-      {{#if (eq @canReadSecretData false)}}
+      {{#if (eq @canReadSecret false)}}
         <Hds::Alert @type="inline" @color="warning" class="has-bottom-margin-s" as |A|>
           <A.Title>Warning</A.Title>
           <A.Description>
-            <ul class={{if (eq @canReadSecretData false) "bullet"}}>
-              {{#if (eq @canReadSecretData false)}}
+            <ul class={{if (eq @canReadSecret false) "bullet"}}>
+              {{#if (eq @canReadSecret false)}}
                 <li data-test-warning-no-read-permissions>
                   You do not have read permissions. If a secret exists at this path creating a new secret will overwrite it.
                 </li>

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -8,7 +8,7 @@
     class={{if @showAdvancedMode "advanced-edit" "simple-edit"}}
     onsubmit={{action "createOrUpdateKey" @mode}}
     aria-label="secret create form"
-    {{did-insert this.setup @secretData @model @mode}}
+    {{did-insert this.setup @secretData @mode}}
   >
     <div class="field box is-fullwidth is-sideless is-marginless">
       <NamespaceReminder @mode="create" @noun="secret" />
@@ -142,7 +142,7 @@
   <form
     onsubmit={{action "createOrUpdateKey" "edit"}}
     aria-label="secret edit form"
-    {{did-insert this.setup @secretData @model @mode}}
+    {{did-insert this.setup @secretData @mode}}
   >
     <div class="box is-sideless is-fullwidth is-marginless padding-top">
       <MessageError @model={{@modelForData}} @errorMessage={{this.error}} />

--- a/ui/app/templates/components/secret-edit-toolbar.hbs
+++ b/ui/app/templates/components/secret-edit-toolbar.hbs
@@ -24,7 +24,7 @@
       {{! TODO kv engine cleanup - add conditional to show only for kv1 and move all secret-delete-menu things here. }}
       <SecretDeleteMenu @model={{@model}} />
     {{/if}}
-    {{#if (and (eq @mode "show") @canUpdateSecretData)}}
+    {{#if (and (eq @mode "show") @canUpdateSecret)}}
       {{#unless (or @isWriteWithoutRead @modelForData.deleted)}}
         <CopySecretDropdown
           @clipboardText={{stringify @modelForData.secretData}}
@@ -36,7 +36,7 @@
       {{/unless}}
     {{/if}}
 
-    {{#if (and (eq @mode "show") @canUpdateSecretData)}}
+    {{#if (and (eq @mode "show") @canUpdateSecret)}}
       {{#let (concat "vault.cluster.secrets.backend." (if (eq @mode "show") "edit" "show")) as |targetRoute|}}
         <ToolbarLink @route={{targetRoute}} @model={{@model.id}} @replace={{true}} data-test-secret-edit="true">
           Edit secret

--- a/ui/app/templates/components/secret-edit-toolbar.hbs
+++ b/ui/app/templates/components/secret-edit-toolbar.hbs
@@ -25,8 +25,7 @@
       <SecretDeleteMenu @model={{@model}} />
     {{/if}}
     {{#if (and (eq @mode "show") @canUpdateSecretData)}}
-      {{! TODO kv engine cleanup - remove @isV2 logic }}
-      {{#unless (and @isV2 (or @isWriteWithoutRead @modelForData.destroyed @modelForData.deleted))}}
+      {{#unless (or @isWriteWithoutRead @modelForData.deleted)}}
         <CopySecretDropdown
           @clipboardText={{stringify @modelForData.secretData}}
           @onWrap={{perform this.wrapSecret}}
@@ -39,23 +38,9 @@
 
     {{#if (and (eq @mode "show") @canUpdateSecretData)}}
       {{#let (concat "vault.cluster.secrets.backend." (if (eq @mode "show") "edit" "show")) as |targetRoute|}}
-        {{#if @isV2}}
-          <ToolbarLink
-            {{! Always create new version from latest if no metadata read access }}
-            @route={{targetRoute}}
-            @model={{@model.id}}
-            @query={{hash version=(if @model.canReadMetadata @modelForData.version "")}}
-            @replace={{true}}
-            @type="add"
-            data-test-secret-edit="true"
-          >
-            Create new version
-          </ToolbarLink>
-        {{else}}
-          <ToolbarLink @route={{targetRoute}} @model={{@model.id}} @replace={{true}} data-test-secret-edit="true">
-            Edit secret
-          </ToolbarLink>
-        {{/if}}
+        <ToolbarLink @route={{targetRoute}} @model={{@model.id}} @replace={{true}} data-test-secret-edit="true">
+          Edit secret
+        </ToolbarLink>
       {{/let}}
     {{/if}}
   </ToolbarActions>

--- a/ui/app/templates/components/secret-edit.hbs
+++ b/ui/app/templates/components/secret-edit.hbs
@@ -18,8 +18,6 @@
       <h1 class="title is-3">
         {{#if (eq @mode "create")}}
           Create Secret
-        {{else if (and this.isV2 (eq @mode "edit"))}}
-          Create New Version
         {{else if (eq @mode "edit")}}
           Edit Secret
         {{else}}
@@ -45,7 +43,6 @@
     <SecretEditToolbar
       @mode={{@mode}}
       @model={{@model}}
-      @isV2={{this.isV2}}
       @isWriteWithoutRead={{this.isWriteWithoutRead}}
       @secretDataIsAdvanced={{this.secretDataIsAdvanced}}
       @showAdvancedMode={{this.showAdvancedMode}}
@@ -63,7 +60,6 @@
         @showAdvancedMode={{this.showAdvancedMode}}
         @modelForData={{this.modelForData}}
         @error={{this.error}}
-        @isV2={{this.isV2}}
         @secretData={{this.secretData}}
         @buttonDisabled={{this.buttonDisabled}}
         @canUpdateSecretMetadata={{this.canUpdateSecretMetadata}}

--- a/ui/app/templates/components/secret-edit.hbs
+++ b/ui/app/templates/components/secret-edit.hbs
@@ -47,8 +47,7 @@
       @secretDataIsAdvanced={{this.secretDataIsAdvanced}}
       @showAdvancedMode={{this.showAdvancedMode}}
       @modelForData={{this.modelForData}}
-      @canUpdateSecretData={{this.canUpdateSecretData}}
-      @canReadSecretMetadata={{this.canReadSecretMetadata}}
+      @canUpdateSecret={{this.canUpdateSecret}}
       @codemirrorString={{this.codemirrorString}}
       @editActions={{hash toggleAdvanced=(action "toggleAdvanced") refresh=(action "refresh")}}
     />
@@ -62,9 +61,7 @@
         @error={{this.error}}
         @secretData={{this.secretData}}
         @buttonDisabled={{this.buttonDisabled}}
-        @canUpdateSecretMetadata={{this.canUpdateSecretMetadata}}
-        @canReadSecretData={{this.canReadSecretData}}
-        @canReadSecretMetadata={{this.canReadSecretMetadata}}
+        @canReadSecret={{this.canReadSecret}}
       />
     {{else if (eq @mode "show")}}
       <SecretFormShow

--- a/ui/app/templates/components/secret-form-show.hbs
+++ b/ui/app/templates/components/secret-form-show.hbs
@@ -23,21 +23,6 @@
         <div class="th column">
           Value
         </div>
-        <div class="th column justify-right" data-test-created-time>
-          {{#if @modelForData.createdTime}}
-            <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
-              <T.Trigger data-test-tooltip-trigger tabindex="-1">
-                Version created
-                {{date-format @modelForData.createdTime "MMM dd, yyyy hh:mm a"}}
-              </T.Trigger>
-              <T.Content @defaultClass="tool-tip smaller-font">
-                <div class="box" data-test-hover-copy-tooltip-text>
-                  {{@modelForData.createdTime}}
-                </div>
-              </T.Content>
-            </ToolTip>
-          {{/if}}
-        </div>
       </div>
     </div>
     {{#if @modelForData.secretKeyAndValue}}

--- a/ui/app/templates/components/secret-list/item.hbs
+++ b/ui/app/templates/components/secret-list/item.hbs
@@ -46,7 +46,7 @@
                     </button>
                   </li>
                 {{else}}
-                  {{#if (or @item.canReadSecretData @item.canRead)}}
+                  {{#if @item.canRead}}
                     <li class="action">
                       <SecretLink
                         @mode="show"
@@ -58,7 +58,7 @@
                       </SecretLink>
                     </li>
                   {{/if}}
-                  {{#if (or @item.canEditSecretData @item.canEdit)}}
+                  {{#if @item.canEdit}}
                     <li class="action">
                       <SecretLink
                         @mode="edit"
@@ -66,16 +66,16 @@
                         @queryParams={{secret-query-params @backendModel.type @item.type asQueryParams=true}}
                         class="has-text-black has-text-weight-semibold"
                       >
-                        {{if @backendModel.isV2KV "Create new version" "Edit"}}
+                        Edit
                       </SecretLink>
                     </li>
                   {{/if}}
-                  {{#if (or @item.canDeleteSecretData @item.canDelete)}}
+                  {{#if @item.canDelete}}
                     <li class="action">
                       <c.Message
                         @id={{@item.id}}
-                        @triggerText={{if @backendModel.isV2KV "Permanently delete" "Delete"}}
-                        @message="This will permanently delete this secret and all its versions."
+                        @triggerText="Delete"
+                        @message="This will permanently delete this secret."
                         @onConfirm={{@delete}}
                       />
                     </li>

--- a/ui/tests/acceptance/enterprise-control-groups-test.js
+++ b/ui/tests/acceptance/enterprise-control-groups-test.js
@@ -124,7 +124,7 @@ module('Acceptance | Enterprise | control groups', function (hooks) {
     await settled();
     await setupControlGroup(this);
     await settled();
-    await visit('/vault/secrets/kv-v2-mount/show/foo');
+    await visit('/vault/secrets/kv-v2-mount/kv/foo/details');
 
     assert.ok(
       await waitUntil(() => currentRouteName() === 'vault.cluster.access.control-group-accessor'),

--- a/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
@@ -29,7 +29,7 @@ module('Acceptance | secrets/cubbyhole/create', function (hooks) {
   });
 
   test('it creates and can view a secret with the cubbyhole backend', async function (assert) {
-    assert.expect(5);
+    assert.expect(4);
     const kvPath = `cubbyhole-kv-${this.uid}`;
     const requestPath = `cubbyhole/${kvPath}`;
     await listPage.visitRoot({ backend: 'cubbyhole' });
@@ -49,7 +49,6 @@ module('Acceptance | secrets/cubbyhole/create', function (hooks) {
       'vault.cluster.secrets.backend.show',
       'redirects to the show page'
     );
-    assert.dom('[data-test-created-time]').hasText('', 'it does not render created time if blank');
     assert.ok(showPage.editIsPresent, 'shows the edit button');
 
     await assertSecretWrap(assert, this.server, requestPath);

--- a/ui/tests/acceptance/secrets/backend/generic/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/generic/secret-test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { currentRouteName, visit, click, fillIn } from '@ember/test-helpers';
+import { currentRouteName, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { v4 as uuidv4 } from 'uuid';
@@ -13,7 +13,8 @@ import showPage from 'vault/tests/pages/secrets/backend/kv/show';
 import listPage from 'vault/tests/pages/secrets/backend/list';
 import consolePanel from 'vault/tests/pages/components/console/ui-panel';
 import authPage from 'vault/tests/pages/auth';
-import { FORM, PAGE } from 'vault/tests/helpers/kv/kv-selectors';
+import { writeSecret } from 'vault/tests/helpers/kv/kv-run-commands';
+import { PAGE } from 'vault/tests/helpers/kv/kv-selectors';
 
 import { create } from 'ember-cli-page-object';
 
@@ -70,11 +71,7 @@ module('Acceptance | secrets/generic/create', function (hooks) {
       .dom(PAGE.list.item('foo'))
       .exists('lists secret created under kv1 engine as secret in the kv2 list view');
 
-    await click(PAGE.list.createSecret);
-    await fillIn(FORM.inputByAttr('path'), 'bar');
-    await fillIn(FORM.keyInput(), 'key');
-    await fillIn(FORM.maskedValueInput(), 'value');
-    await click(FORM.saveBtn);
+    await writeSecret(path, 'bar', 'key', 'value');
     await visit(`/vault/secrets/${path}/kv/list`);
 
     ['foo', 'bar'].forEach((secret) => {

--- a/ui/tests/acceptance/secrets/backend/generic/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/generic/secret-test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { currentRouteName } from '@ember/test-helpers';
+import { currentRouteName, visit, click, fillIn } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { v4 as uuidv4 } from 'uuid';
@@ -13,6 +13,7 @@ import showPage from 'vault/tests/pages/secrets/backend/kv/show';
 import listPage from 'vault/tests/pages/secrets/backend/list';
 import consolePanel from 'vault/tests/pages/components/console/ui-panel';
 import authPage from 'vault/tests/pages/auth';
+import { FORM, PAGE } from 'vault/tests/helpers/kv/kv-selectors';
 
 import { create } from 'ember-cli-page-object';
 
@@ -57,24 +58,28 @@ module('Acceptance | secrets/generic/create', function (hooks) {
 
   test('upgrading generic to version 2 lists all existing secrets, and CRUD continues to work', async function (assert) {
     const path = `generic-${this.uid}`;
-    const kvPath = `generic-kv-${this.uid}`;
     await cli.runCommands([
       `write sys/mounts/${path} type=generic`,
       `write ${path}/foo bar=baz`,
       // upgrade to version 2 generic mount
       `write sys/mounts/${path}/tune options=version=2`,
     ]);
-    await listPage.visitRoot({ backend: path });
-    assert.strictEqual(
-      currentRouteName(),
-      'vault.cluster.secrets.backend.list-root',
-      'navigates to the list page'
-    );
-    assert.strictEqual(listPage.secrets.length, 1, 'lists the old secret in the backend');
+    await visit(`/vault/secrets/${path}/kv/list`);
 
-    await listPage.create();
-    await editPage.createSecret(kvPath, 'foo', 'bar');
-    await listPage.visitRoot({ backend: path });
-    assert.strictEqual(listPage.secrets.length, 2, 'lists two secrets in the backend');
+    assert
+      .dom(PAGE.list.item('foo'))
+      .exists('lists secret created under kv1 engine as secret in the kv2 list view');
+
+    await click(PAGE.list.createSecret);
+    await fillIn(FORM.inputByAttr('path'), 'bar');
+    await fillIn(FORM.keyInput(), 'key');
+    await fillIn(FORM.maskedValueInput(), 'value');
+    await click(FORM.saveBtn);
+    await visit(`/vault/secrets/${path}/kv/list`);
+
+    ['foo', 'bar'].forEach((secret) => {
+      assert.dom(PAGE.list.item(secret.path)).exists('lists both records');
+    });
+    assert.dom(PAGE.list.item()).exists({ count: 2 }, 'lists only the two secrets');
   });
 });


### PR DESCRIPTION
Focused on removing all kv v2 logic from the following:
**Routes:**
`secretEdit`
`list`
**Components:**
`secretEdit`
`secretCreateOrUpdate`
`secretEditToolbar`
`secretFormShow`

It was tempting to refactor a lot of this (ex: how we do validations in secret-edit), but holding off refactoring for the refactoring tickets coming later. Keeping the scope to only removal will make refactoring easier, and help us keep track of where regression bugs happened, if they happen.

It's hard to follow what is okay to remove and what is not. I focused on removing anything regarding **version** (e.g. kv v2 or the query param version) as none of the remaining engines that use this flow have the concept of version. **Metadata** is also not relevant anymore. 