### PR TITLE
events: Ensure pipelines are cleaned up on closing subscription

### DIFF
--- a/changelog/23042.txt
+++ b/changelog/23042.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+events: Ensure subscription resources are cleaned up on close.
+```
+

--- a/vault/eventbus/bus.go
+++ b/vault/eventbus/bus.go
@@ -185,10 +185,6 @@ func NewEventBus(logger hclog.Logger) (*EventBus, error) {
 		return nil, err
 	}
 	formatterNodeID := eventlogger.NodeID(formatterID)
-	err = broker.RegisterNode(formatterNodeID, cloudEventsFormatterFilter)
-	if err != nil {
-		return nil, err
-	}
 
 	if logger == nil {
 		logger = hclog.Default().Named("events")
@@ -213,6 +209,11 @@ func (bus *EventBus) Subscribe(ctx context.Context, ns *namespace.Namespace, pat
 func (bus *EventBus) SubscribeMultipleNamespaces(ctx context.Context, namespacePathPatterns []string, pattern string, bexprFilter string) (<-chan *eventlogger.Event, context.CancelFunc, error) {
 	// subscriptions are still stored even if the bus has not been started
 	pipelineID, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = bus.broker.RegisterNode(bus.formatterNodeID, cloudEventsFormatterFilter)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vault/eventbus/bus_test.go
+++ b/vault/eventbus/bus_test.go
@@ -626,3 +626,30 @@ func TestBexpr(t *testing.T) {
 		})
 	}
 }
+
+// TestPipelineCleanedUp ensures pipelines are properly cleaned up after
+// subscriptions are closed.
+func TestPipelineCleanedUp(t *testing.T) {
+	bus, err := NewEventBus(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	eventType := logical.EventType("someType")
+	bus.Start()
+
+	_, cancel, err := bus.Subscribe(context.Background(), namespace.RootNamespace, string(eventType), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bus.broker.IsAnyPipelineRegistered(eventTypeAll) {
+		cancel()
+		t.Fatal()
+	}
+
+	cancel()
+
+	if bus.broker.IsAnyPipelineRegistered(eventTypeAll) {
+		t.Fatal()
+	}
+}


### PR DESCRIPTION
I noticed this while reviewing #23024. It seems the `broker` field was never populated, so we never cleaned up the pipeline on close. However, we only need one method from the broker, so I narrowed the field down to one function as well.