### PR TITLE
VAULT-19233 First part of caching static secrets work

### DIFF
--- a/command/agentproxyshared/cache/cacheboltdb/bolt.go
+++ b/command/agentproxyshared/cache/cacheboltdb/bolt.go
@@ -39,6 +39,9 @@ const (
 	// TokenType - Bucket/type for auto-auth tokens
 	TokenType = "token"
 
+	// StaticSecretType - Bucket/type for static secrets
+	StaticSecretType = "static-secret"
+
 	// LeaseType - v2 Bucket/type for auth AND secret leases.
 	//
 	// This bucket stores keys in the same order they were created using

--- a/command/agentproxyshared/cache/cachememdb/index.go
+++ b/command/agentproxyshared/cache/cachememdb/index.go
@@ -22,6 +22,12 @@ type Index struct {
 	// Required: true, Unique: true
 	Token string
 
+	// Tokens is a list of tokens that can access this cached response,
+	// which is used for static secret caching, and enabling multiple
+	// tokens to be able to access the same cache entry for static secrets.
+	// Required: false, Unique: false
+	Tokens []string
+
 	// TokenParent is the parent token of the token held by this index
 	// Required: false, Unique: false
 	TokenParent string

--- a/command/agentproxyshared/cache/cachememdb/index.go
+++ b/command/agentproxyshared/cache/cachememdb/index.go
@@ -81,7 +81,7 @@ type Index struct {
 
 	// IndexLock is a lock held for some indexes to prevent data
 	// races upon update.
-	IndexLock *sync.Mutex
+	IndexLock sync.Mutex
 }
 
 type IndexName uint32

--- a/command/agentproxyshared/cache/cachememdb/index.go
+++ b/command/agentproxyshared/cache/cachememdb/index.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -77,6 +78,10 @@ type Index struct {
 
 	// Type is the index type (token, auth-lease, secret-lease)
 	Type string
+
+	// IndexLock is a lock held for some indexes to prevent data
+	// races upon update.
+	IndexLock *sync.Mutex
 }
 
 type IndexName uint32

--- a/command/agentproxyshared/cache/cachememdb/index_test.go
+++ b/command/agentproxyshared/cache/cachememdb/index_test.go
@@ -17,6 +17,7 @@ func TestSerializeDeserialize(t *testing.T) {
 	testIndex := &Index{
 		ID:            "testid",
 		Token:         "testtoken",
+		Tokens:        []string{"token1", "token2"},
 		TokenParent:   "parent token",
 		TokenAccessor: "test accessor",
 		Namespace:     "test namespace",

--- a/command/proxy.go
+++ b/command/proxy.go
@@ -440,10 +440,11 @@ func (c *ProxyCommand) Run(args []string) int {
 		// Create the lease cache proxier and set its underlying proxier to
 		// the API proxier.
 		leaseCache, err = cache.NewLeaseCache(&cache.LeaseCacheConfig{
-			Client:      proxyClient,
-			BaseContext: ctx,
-			Proxier:     apiProxy,
-			Logger:      cacheLogger.Named("leasecache"),
+			Client:             proxyClient,
+			BaseContext:        ctx,
+			Proxier:            apiProxy,
+			Logger:             cacheLogger.Named("leasecache"),
+			CacheStaticSecrets: config.Cache.CacheStaticSecrets,
 		})
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error creating lease cache: %v", err))

--- a/command/proxy/config/config.go
+++ b/command/proxy/config/config.go
@@ -101,8 +101,9 @@ type APIProxy struct {
 
 // Cache contains any configuration needed for Cache mode
 type Cache struct {
-	Persist      *agentproxyshared.PersistConfig `hcl:"persist"`
-	InProcDialer transportDialer                 `hcl:"-"`
+	Persist            *agentproxyshared.PersistConfig `hcl:"persist"`
+	InProcDialer       transportDialer                 `hcl:"-"`
+	CacheStaticSecrets bool                            `hcl:"cache_static_secrets"`
 }
 
 // AutoAuth is the configured authentication method and sinks

--- a/command/proxy_test.go
+++ b/command/proxy_test.go
@@ -7,9 +7,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -789,31 +787,18 @@ log_level = "trace"
 	require.Equal(t, "HIT", cacheValue)
 
 	// Lastly, we check to make sure the actual data we received is
-	// as we expect. It's a little more awkward because of raw requests,
-	// but we make do.
-	resp1Map := map[string]interface{}{}
-	body, err := io.ReadAll(resp1.Body)
+	// as we expect. We must use ParseSecret due to the raw requests.
+	secret1, err := api.ParseSecret(resp1.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = json.Unmarshal(body, &resp1Map)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp1MapData := resp1Map["data"]
-	require.Equal(t, secretData, resp1MapData)
+	require.Equal(t, secretData, secret1.Data)
 
-	resp2Map := map[string]interface{}{}
-	body, err = io.ReadAll(resp2.Body)
+	secret2, err := api.ParseSecret(resp2.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = json.Unmarshal(body, &resp2Map)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp2MapData := resp2Map["data"]
-	require.Equal(t, resp1MapData, resp2MapData)
+	require.Equal(t, secret1.Data, secret2.Data)
 
 	close(cmd.ShutdownCh)
 	wg.Wait()
@@ -938,43 +923,24 @@ log_level = "trace"
 	require.Equal(t, "HIT", cacheValue)
 
 	// Lastly, we check to make sure the actual data we received is
-	// as we expect. It's a little more awkward because of raw requests,
-	// but we make do.
-	resp1Map := map[string]interface{}{}
-	body, err := io.ReadAll(resp1.Body)
+	// as we expect. We must use ParseSecret due to the raw requests.
+	secret1, err := api.ParseSecret(resp1.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = json.Unmarshal(body, &resp1Map)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp1MapData := resp1Map["data"]
-	require.Equal(t, secretData, resp1MapData)
+	require.Equal(t, secretData, secret1.Data)
 
-	resp2Map := map[string]interface{}{}
-	body, err = io.ReadAll(resp2.Body)
+	secret2, err := api.ParseSecret(resp2.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = json.Unmarshal(body, &resp2Map)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp2MapData := resp2Map["data"]
-	require.Equal(t, secretData2, resp2MapData)
+	require.Equal(t, secretData2, secret2.Data)
 
-	resp3Map := map[string]interface{}{}
-	body, err = io.ReadAll(resp3.Body)
+	secret3, err := api.ParseSecret(resp3.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = json.Unmarshal(body, &resp3Map)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp3MapData := resp2Map["data"]
-	require.Equal(t, secretData2, resp3MapData)
+	require.Equal(t, secret2.Data, secret3.Data)
 
 	close(cmd.ShutdownCh)
 	wg.Wait()

--- a/command/proxy_test.go
+++ b/command/proxy_test.go
@@ -819,6 +819,167 @@ log_level = "trace"
 	wg.Wait()
 }
 
+// TestProxy_Cache_StaticSecretInvalidation Tests that the cache successfully caches a static secret
+// going through the Proxy, and that it gets invalidated by a POST.
+func TestProxy_Cache_StaticSecretInvalidation(t *testing.T) {
+	logger := logging.NewVaultLogger(hclog.Trace)
+	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	serverClient := cluster.Cores[0].Client
+
+	// Unset the environment variable so that proxy picks up the right test
+	// cluster address
+	defer os.Setenv(api.EnvVaultAddress, os.Getenv(api.EnvVaultAddress))
+	os.Unsetenv(api.EnvVaultAddress)
+
+	cacheConfig := `
+cache {
+	cache_static_secrets = true
+}
+`
+	listenAddr := generateListenerAddress(t)
+	listenConfig := fmt.Sprintf(`
+listener "tcp" {
+  address = "%s"
+  tls_disable = true
+}
+`, listenAddr)
+
+	config := fmt.Sprintf(`
+vault {
+  address = "%s"
+  tls_skip_verify = true
+}
+%s
+%s
+log_level = "trace"
+`, serverClient.Address(), cacheConfig, listenConfig)
+	configPath := makeTempFile(t, "config.hcl", config)
+	defer os.Remove(configPath)
+
+	// Start proxy
+	_, cmd := testProxyCommand(t, logger)
+	cmd.startedCh = make(chan struct{})
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		cmd.Run([]string{"-config", configPath})
+		wg.Done()
+	}()
+
+	select {
+	case <-cmd.startedCh:
+	case <-time.After(5 * time.Second):
+		t.Errorf("timeout")
+	}
+
+	proxyClient, err := api.NewClient(api.DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxyClient.SetToken(serverClient.Token())
+	proxyClient.SetMaxRetries(0)
+	err = proxyClient.SetAddress("http://" + listenAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secretData := map[string]interface{}{
+		"foo": "bar",
+	}
+
+	secretData2 := map[string]interface{}{
+		"bar": "baz",
+	}
+
+	// Create kvv1 secret
+	err = serverClient.KVv1("secret").Put(context.Background(), "my-secret", secretData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We use raw requests so we can check the headers for cache hit/miss.
+	req := proxyClient.NewRequest(http.MethodGet, "/v1/secret/my-secret")
+	resp1, err := proxyClient.RawRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cacheValue := resp1.Header.Get("X-Cache")
+	require.Equal(t, "MISS", cacheValue)
+
+	// Update the secret using the proxy client
+	err = proxyClient.KVv1("secret").Put(context.Background(), "my-secret", secretData2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp2, err := proxyClient.RawRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cacheValue = resp2.Header.Get("X-Cache")
+	// This should miss too, as we just updated it
+	require.Equal(t, "MISS", cacheValue)
+
+	resp3, err := proxyClient.RawRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cacheValue = resp3.Header.Get("X-Cache")
+	// This should hit, as the third request should get the cached value
+	require.Equal(t, "HIT", cacheValue)
+
+	// Lastly, we check to make sure the actual data we received is
+	// as we expect. It's a little more awkward because of raw requests,
+	// but we make do.
+	resp1Map := map[string]interface{}{}
+	body, err := io.ReadAll(resp1.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = json.Unmarshal(body, &resp1Map)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp1MapData := resp1Map["data"]
+	require.Equal(t, secretData, resp1MapData)
+
+	resp2Map := map[string]interface{}{}
+	body, err = io.ReadAll(resp2.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = json.Unmarshal(body, &resp2Map)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp2MapData := resp2Map["data"]
+	require.Equal(t, secretData2, resp2MapData)
+
+	resp3Map := map[string]interface{}{}
+	body, err = io.ReadAll(resp3.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = json.Unmarshal(body, &resp3Map)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp3MapData := resp2Map["data"]
+	require.Equal(t, secretData2, resp3MapData)
+
+	close(cmd.ShutdownCh)
+	wg.Wait()
+}
+
 // TestProxy_ApiProxy_Retry Tests the retry functionalities of Vault Proxy's API Proxy
 func TestProxy_ApiProxy_Retry(t *testing.T) {
 	//----------------------------------------------------

--- a/command/proxy_test.go
+++ b/command/proxy_test.go
@@ -581,8 +581,8 @@ vault {
 	wg.Wait()
 }
 
-// TestProxy_Cache_DynamicSecret Tests that the cache successfully caches a dynamic secret
-// going through the Proxy,
+// TestProxy_Cache_DynamicSecret tests that the cache successfully caches a dynamic secret
+// going through the Proxy, and that a subsequent request will be served from the cache.
 func TestProxy_Cache_DynamicSecret(t *testing.T) {
 	logger := logging.NewVaultLogger(hclog.Trace)
 	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{


### PR DESCRIPTION
What this does:
If a new config value is set, then we cache all secrets as static secrets. We check new requests coming in to see if they can share the path. If they have demonstrated they can access this secret before, they'll receive the cached value.

This won't affect any old functionality, as it relies on the new config value being set to true. It's far from a complete solution, but I'd rather have 'smaller' PRs than a couple of thousand line monsters, for reviewers' sanity and also code quality purposes.

What's missing:
- The caching of a token's permissions
  - This will come in the next PR
- The updating of a token's permissions via /sys/capabilities (via the jobmanager approach)
  - This will come in a later PR and is part of a later ticket
- The updating (event system)
  - This will come in a later PR and is part of a later ticket
- A lot of tests, especially around e.g. cache clear

I've set no changelog for this, as I'll do a large one as a `feature` changelog near the end.