### PR TITLE
Normalize error response to stop information leakage

### DIFF
--- a/builtin/credential/approle/path_login.go
+++ b/builtin/credential/approle/path_login.go
@@ -99,7 +99,7 @@ func (b *backend) pathLoginResolveRole(ctx context.Context, req *logical.Request
 		return nil, err
 	}
 	if roleIDIndex == nil {
-		return logical.ErrorResponse("invalid role ID"), nil
+		return logical.ErrorResponse("invalid role or secret ID"), nil
 	}
 
 	roleName := roleIDIndex.Name
@@ -113,7 +113,7 @@ func (b *backend) pathLoginResolveRole(ctx context.Context, req *logical.Request
 		return nil, err
 	}
 	if role == nil {
-		return logical.ErrorResponse("invalid role ID"), nil
+		return logical.ErrorResponse("invalid role or secret ID"), nil
 	}
 
 	return logical.ResolveRoleResponse(roleName)
@@ -134,7 +134,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, dat
 		return nil, err
 	}
 	if roleIDIndex == nil {
-		return logical.ErrorResponse("invalid role ID"), nil
+		return logical.ErrorResponse("invalid role or secret ID"), nil
 	}
 
 	roleName := roleIDIndex.Name
@@ -148,7 +148,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, dat
 		return nil, err
 	}
 	if role == nil {
-		return logical.ErrorResponse("invalid role ID"), nil
+		return logical.ErrorResponse("invalid role or secret ID"), nil
 	}
 
 	metadata := make(map[string]string)
@@ -184,7 +184,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, dat
 			return nil, err
 		}
 		if entry == nil {
-			return logical.ErrorResponse("invalid secret id"), logical.ErrInvalidCredentials
+			return logical.ErrorResponse("invalid role or secret ID"), logical.ErrInvalidCredentials
 		}
 
 		// If a secret ID entry does not have a corresponding accessor
@@ -204,7 +204,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, dat
 				return nil, err
 			}
 			if entry == nil {
-				return logical.ErrorResponse("invalid secret id"), nil
+				return logical.ErrorResponse("invalid role or secret ID"), nil
 			}
 
 			accessorEntry, err := b.secretIDAccessorEntry(ctx, req.Storage, entry.SecretIDAccessor, role.SecretIDPrefix)
@@ -217,7 +217,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, dat
 					return nil, fmt.Errorf("error deleting secret ID %q from storage: %w", secretIDHMAC, err)
 				}
 			}
-			return logical.ErrorResponse("invalid secret id"), nil
+			return logical.ErrorResponse("invalid role or secret ID"), nil
 		}
 
 		switch {

--- a/builtin/credential/approle/path_login_test.go
+++ b/builtin/credential/approle/path_login_test.go
@@ -354,7 +354,7 @@ func TestAppRole_RoleDoesNotExist(t *testing.T) {
 		t.Fatal("Error not part of response.")
 	}
 
-	if !strings.Contains(errString, "invalid role ID") {
-		t.Fatalf("Error was not due to invalid role ID. Error: %s", errString)
+	if !strings.Contains(errString, "invalid role or secret ID") {
+		t.Fatalf("Error was not due to invalid role or secret ID. Error: %s", errString)
 	}
 }

--- a/changelog/23072.txt
+++ b/changelog/23072.txt
@@ -1,0 +1,3 @@
+```release-note:security
+auth/approle: This removes the possiblity of enumerating through role_ids to discover valid roles. Normalization of the returned error message for both a correct `role_id` and incorrect `secret_id`, and incorrect `role_id` and incorrect `secret_id`.
+```


### PR DESCRIPTION
Further to the work done in this [PR](https://github.com/hashicorp/vault/pull/21282) to stop information leakage via HTTP error codes with partially correct log ins. This PR normalizes the returned error message for the same reasons.