### PR TITLE
Azure secrets doc enhancement

### DIFF
--- a/changelog/23078.txt
+++ b/changelog/23078.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/azure: Added note to documentation that environment variables take precedence over API configuration.
+```

--- a/website/content/docs/secrets/azure.mdx
+++ b/website/content/docs/secrets/azure.mdx
@@ -23,6 +23,9 @@ The password will be deleted when the lease is revoked.
 
 ## Setup
 
+~> **Note**: Configuration can be provided via the API or through well-known environment variables
+such as `AZURE_CLIENT_ID` or `AZURE_CLIENT_SECRET`. **Environment variables take precedence over API values**.
+
 Most secrets engines must be configured in advance before they can perform their
 functions. These steps are usually completed by an operator or configuration
 management tool.

--- a/website/content/docs/secrets/databases/elasticdb.mdx
+++ b/website/content/docs/secrets/databases/elasticdb.mdx
@@ -130,6 +130,16 @@ Now, Elasticsearch is configured and ready to be used with Vault.
        client_key=$ES_HOME/config/certs/elastic-certificates.key.pem
    ```
 
+## Usage
+
+After the secrets engine is configured and a user/machine has a Vault token with
+the proper permission, it can generate or rotate credentials.
+
+### Dynamic Roles
+
+Dynamic roles generate new users and credentials on demand.
+The credentials are unique for each client and created when queried.
+
 1. Configure a role that maps a name in Vault to a role definition in Elasticsearch.
    This is considered the most secure type of role because nobody can perform
    a privilege escalation by editing a role's privileges out-of-band in
@@ -154,11 +164,6 @@ Now, Elasticsearch is configured and ready to be used with Vault.
          max_ttl="24h"
    ```
 
-## Usage
-
-After the secrets engine is configured and a user/machine has a Vault token with
-the proper permission, it can generate credentials.
-
 1. Generate a new credential by reading from the `/creds` endpoint with the name
    of the role:
 
@@ -171,6 +176,33 @@ the proper permission, it can generate credentials.
    lease_renewable    true
    password           0ZsueAP-dqCNGZo35M0n
    username           v-vaultuser-my-role-AgIViC5TdQHBdeiCxae0-1602541724
+   ```
+
+### Static Roles
+
+Static roles rotate the password of an existing user at the specified frequency.
+Each client will receive the same username and password when querying credentials.
+
+1. Configure a static role that maps a name in Vault to a pre-existing user in Elasticsearch:
+
+   ```shell-session
+   $ vault write database/static-roles/my-static-role\
+         db_name=my-elasticsearch-database \
+         username=my-existing-elasticsearch-uername \
+         rotation_period="24h"
+   ```
+
+1. Retrieve the current username and password from the `/static-creds` endpoint:
+
+   ```shell-session
+   $ vault read database/static-creds/my-static-role
+   Key                    Value
+   ---                    -----
+   last_vault_rotation    2023-09-14T08:24:39.650491913-04:00
+   password               current-password
+   rotation_period        24h
+   ttl                    23h59m59s
+   username               my-existing-elasticsearch-uername
    ```
 
 ## API


### PR DESCRIPTION
Using environment variables over config provided explicitely through the API is counter-intuitve. Unfortunately changing this behavior would be a significant breaking change. As a short term mitigation solution we are adding a more explicit note in the documentaiton to help people avoid this pitfall.

Preview:

![azure_secret_note](https://github.com/hashicorp/vault/assets/109547106/05983e05-3a13-47e3-8d8c-106321507445)
