### PR TITLE
Add known issues around transit managed keys

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -176,3 +176,5 @@ Affects Vault 1.13.0+
 @include 'pki-double-migration-bug.mdx'
 
 @include 'known-issues/update-primary-addrs-panic.mdx'
+
+@include 'known-issues/transit-managed-keys-panic.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -177,4 +177,4 @@ Affects Vault 1.13.0+
 
 @include 'known-issues/update-primary-addrs-panic.mdx'
 
-@include 'known-issues/transit-managed-keys-panic.mdx'
+@include 'known-issues/transit-managed-keys-panics.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
@@ -43,7 +43,7 @@ is measuring cumulative time writing, and not the distribution of individual wri
 
 @include 'known-issues/aws-static-roles.mdx'
 
-@include 'known-issues/transit-managed-keys-panic.mdx'
+@include 'known-issues/transit-managed-keys-panics.mdx'
 
 @include 'known-issues/transit-managed-keys-sign-fails.mdx'
 

--- a/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
@@ -43,3 +43,7 @@ is measuring cumulative time writing, and not the distribution of individual wri
 
 @include 'known-issues/aws-static-roles.mdx'
 
+@include 'known-issues/transit-managed-keys-panic.mdx'
+
+@include 'known-issues/transit-managed-keys-sign-fails.mdx'
+

--- a/website/content/partials/known-issues/transit-managed-keys-panics.mdx
+++ b/website/content/partials/known-issues/transit-managed-keys-panics.mdx
@@ -9,7 +9,7 @@
 
 Vault will panic when a Transit encryption API call is backed by a Cloud KMS managed key (Azure, GCP, AWS).
 
-<Note>Encryption and decryption APIs are not affected with PKCS#11 managed keys and non-managed key, key types</Note>
+<Note>Encryption and decryption APIs are not affected with PKCS#11 managed keys and transit native keys</Note>
 
 #### Workaround
 

--- a/website/content/partials/known-issues/transit-managed-keys-panics.mdx
+++ b/website/content/partials/known-issues/transit-managed-keys-panics.mdx
@@ -3,13 +3,19 @@
 #### Affected versions
 
 - 1.13.1+ up to 1.13.7 inclusively
-- 1.14.0+ up to 1.14.3 inclusively.
+- 1.14.0+ up to 1.14.3 inclusively
 
 #### Issue
 
-Vault will panic when a Transit encryption API call is backed by a Cloud KMS managed key (Azure, GCP, AWS).
+Vault panics when it receives a Transit encryption API call that is backed by a Cloud KMS managed key (Azure, GCP, AWS).
 
-<Note>Encryption and decryption APIs are not affected with PKCS#11 managed keys and transit native keys</Note>
+<Note>
+The issue does not affect encryption and decryption with the following key types:
+
+- PKCS#11 managed keys
+- Transit native keys
+
+</Note>
 
 #### Workaround
 

--- a/website/content/partials/known-issues/transit-managed-keys-panics.mdx
+++ b/website/content/partials/known-issues/transit-managed-keys-panics.mdx
@@ -1,0 +1,16 @@
+### Transit Encryption with Cloud KMS managed keys causes a panic
+
+#### Affected versions
+
+- 1.13.1+ up to 1.13.7 inclusively
+- 1.14.0+ up to 1.14.3 inclusively.
+
+#### Issue
+
+Vault will panic when a Transit encryption API call is backed by a Cloud KMS managed key (Azure, GCP, AWS).
+
+<Note>Encryption and decryption APIs are not affected with PKCS#11 managed keys and non-managed key, key types</Note>
+
+#### Workaround
+
+None at this time

--- a/website/content/partials/known-issues/transit-managed-keys-sign-fails.mdx
+++ b/website/content/partials/known-issues/transit-managed-keys-sign-fails.mdx
@@ -1,0 +1,16 @@
+### Transit Sign API calls with managed keys fail
+
+#### Affected versions
+
+- 1.14.0+ up to 1.14.3 inclusively.
+
+#### Issue
+
+The Transit sign API call responds with an error "requested version for signing does not contain a private part" when
+a Transit sign request uses a managed key.
+
+<Note>Signing APIs are not affected with non-managed key, key types</Note>
+
+#### Workaround
+
+None at this time

--- a/website/content/partials/known-issues/transit-managed-keys-sign-fails.mdx
+++ b/website/content/partials/known-issues/transit-managed-keys-sign-fails.mdx
@@ -2,14 +2,19 @@
 
 #### Affected versions
 
-- 1.14.0+ up to 1.14.3 inclusively.
+- 1.14.0+ up to 1.14.3 inclusively
 
 #### Issue
 
-The Transit sign API call responds with an error "requested version for signing does not contain a private part" when
-a Transit sign request uses a managed key.
+Vault responds to Transit sign API calls with the following error when the request uses a managed key:
+`requested version for signing does not contain a private part`
 
-<Note>Signing APIs are not affected with transit native keys</Note>
+<Note>
+The issue does not affect signing with the following key types:
+
+- Transit native keys
+
+</Note>
 
 #### Workaround
 

--- a/website/content/partials/known-issues/transit-managed-keys-sign-fails.mdx
+++ b/website/content/partials/known-issues/transit-managed-keys-sign-fails.mdx
@@ -9,7 +9,7 @@
 The Transit sign API call responds with an error "requested version for signing does not contain a private part" when
 a Transit sign request uses a managed key.
 
-<Note>Signing APIs are not affected with non-managed key, key types</Note>
+<Note>Signing APIs are not affected with transit native keys</Note>
 
 #### Workaround
 

--- a/website/content/partials/known-issues/transit-managed-keys-sign-fails.mdx
+++ b/website/content/partials/known-issues/transit-managed-keys-sign-fails.mdx
@@ -7,6 +7,7 @@
 #### Issue
 
 Vault responds to Transit sign API calls with the following error when the request uses a managed key:
+
 `requested version for signing does not contain a private part`
 
 <Note>


### PR DESCRIPTION
 - Document known issue around managed key encryption failure with Cloud KMS backed keys and the failure to sign with managed keys