### PR TITLE
[VAULT-14497] Ensure Role Governing Policies are only applied down the namespace hierarchy

### DIFF
--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -451,6 +451,32 @@ func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy) error {
 	return nil
 }
 
+// GetNonEGPPolicyType returns a policy's type.
+// It will return an error if the policy doesn't exist in the store or isn't
+// an ACL or a Sentinel Role Governing Policy (RGP).
+//
+// Note: Sentinel Endpoint Governing Policies (EGPs) are not stored within the
+// policyTypeMap. We sometimes need to distinguish between ACLs and RGPs due to
+// them both being token policies, but the logic related to EGPs is separate
+// enough that it is never necessary to look up their type.
+func (ps *PolicyStore) GetNonEGPPolicyType(nsID string, name string) (*PolicyType, error) {
+	sanitizedName := ps.sanitizeName(name)
+	index := path.Join(nsID, sanitizedName)
+
+	pt, ok := ps.policyTypeMap.Load(index)
+	if !ok {
+		// Doesn't exist
+		return nil, fmt.Errorf("policy does not exist in type map: %v", index)
+	}
+
+	policyType, ok := pt.(PolicyType)
+	if !ok {
+		return nil, fmt.Errorf("unknown policy type for: %v", index)
+	}
+
+	return &policyType, nil
+}
+
 // GetPolicy is used to fetch the named policy
 func (ps *PolicyStore) GetPolicy(ctx context.Context, name string, policyType PolicyType) (*Policy, error) {
 	return ps.switchedGetPolicy(ctx, name, policyType, true)

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
 )
 
 func mockPolicyWithCore(t *testing.T, disableCache bool) (*Core, *PolicyStore) {
@@ -351,5 +352,88 @@ func TestPolicyStore_PoliciesByNamespaces(t *testing.T) {
 	expectedResult := []string{"default", "dev"}
 	if !reflect.DeepEqual(expectedResult, out) {
 		t.Fatalf("expected: %v\ngot: %v", expectedResult, out)
+	}
+}
+
+// TestPolicyStore_GetNonEGPPolicyType has five test cases:
+//   - happy-acl and happy-rgp: we store a policy in the policy type map and
+//     then look up its type successfully.
+//   - not-in-map-acl and not-in-map-rgp: ensure that GetNonEGPPolicyType fails
+//     returning a nil and an error when the policy doesn't exist in the map.
+//   - unknown-policy-type: ensures that GetNonEGPPolicyType fails returning a nil
+//     and an error when the policy type in the type map is a value that
+//     does not map to a PolicyType.
+func TestPolicyStore_GetNonEGPPolicyType(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		policyStoreKey       string
+		policyStoreValue     any
+		paramNamespace       string
+		paramPolicyName      string
+		paramPolicyType      PolicyType
+		isErrorExpected      bool
+		expectedErrorMessage string
+	}{
+		"happy-acl": {
+			policyStoreKey:   "1AbcD/policy1",
+			policyStoreValue: PolicyTypeACL,
+			paramNamespace:   "1AbcD",
+			paramPolicyName:  "policy1",
+			paramPolicyType:  PolicyTypeACL,
+		},
+		"happy-rgp": {
+			policyStoreKey:   "1AbcD/policy1",
+			policyStoreValue: PolicyTypeRGP,
+			paramNamespace:   "1AbcD",
+			paramPolicyName:  "policy1",
+			paramPolicyType:  PolicyTypeRGP,
+		},
+		"not-in-map-acl": {
+			policyStoreKey:       "2WxyZ/policy2",
+			policyStoreValue:     PolicyTypeACL,
+			paramNamespace:       "1AbcD",
+			paramPolicyName:      "policy1",
+			isErrorExpected:      true,
+			expectedErrorMessage: "policy does not exist in type map: 1AbcD/policy1",
+		},
+		"not-in-map-rgp": {
+			policyStoreKey:       "2WxyZ/policy2",
+			policyStoreValue:     PolicyTypeRGP,
+			paramNamespace:       "1AbcD",
+			paramPolicyName:      "policy1",
+			isErrorExpected:      true,
+			expectedErrorMessage: "policy does not exist in type map: 1AbcD/policy1",
+		},
+		"unknown-policy-type": {
+			policyStoreKey:       "1AbcD/policy1",
+			policyStoreValue:     7,
+			paramNamespace:       "1AbcD",
+			paramPolicyName:      "policy1",
+			isErrorExpected:      true,
+			expectedErrorMessage: "unknown policy type for: 1AbcD/policy1",
+		},
+	}
+
+	for name, tc := range tests {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, ps := mockPolicyWithCore(t, false)
+			ps.policyTypeMap.Store(tc.policyStoreKey, tc.policyStoreValue)
+			got, err := ps.GetNonEGPPolicyType(tc.paramNamespace, tc.paramPolicyName)
+			if tc.isErrorExpected {
+				require.Error(t, err)
+				require.Nil(t, got)
+				require.EqualError(t, err, tc.expectedErrorMessage)
+
+			}
+			if !tc.isErrorExpected {
+				require.NoError(t, err)
+				require.NotNil(t, got)
+				require.Equal(t, tc.paramPolicyType, *got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR changes how we evaluate Sentinel Role Governing Policies (RGPs) in two ways:
1. From now on, RGPs will not be affected by the [group_policy_application_mode setting](https://developer.hashicorp.com/vault/api-docs/system/config-group-policy-application). At all.
2. RGPs derived from token's memberships in identity groups can only apply to requests in child namespaces in the same hierarchy.
