### PR TITLE
Vault v1.150.0-rc1 dashboard UI fix

### DIFF
--- a/ui/app/templates/components/dashboard/client-count-card.hbs
+++ b/ui/app/templates/components/dashboard/client-count-card.hbs
@@ -1,4 +1,4 @@
-<Hds::Card::Container @hasBorder={{true}} class="has-padding-l has-bottom-padding-m" data-test-card="client-count">
+<Hds::Card::Container @hasBorder={{true}} class="has-padding-l" data-test-card="client-count">
   <div class="is-flex-between">
     <h3 class="title is-4 has-bottom-margin-xxs" data-test-client-count-title>
       Client count

--- a/ui/app/templates/components/dashboard/replication-card.hbs
+++ b/ui/app/templates/components/dashboard/replication-card.hbs
@@ -2,7 +2,7 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
 ~}}
-<Hds::Card::Container @hasBorder={{true}} class="has-padding-l has-bottom-padding-m" data-test-card="replication">
+<Hds::Card::Container @hasBorder={{true}} class="has-padding-l" data-test-card="replication">
 
   <div class="is-flex-between">
     <h3 class="title is-4 has-bottom-margin-xxs" data-test-client-count-title>


### PR DESCRIPTION
In the new UI Dashboard, there is an inconsistency on the top border of the cards.  

![Border bug in dashboard](https://github.com/hashicorp/vault/assets/3852620/9eb5084f-835c-4163-ac46-1431de65ee22)

Tracing this down, it appears that the `has-bottom-padding-m` triggers an unwanted 
side affect that causes the top border to disappear on the top most card.  
  
Comparing this column to the right column, I see that the same class has not been 
applied there. By removing the specified class on both cards in the left column 
the border is fixed.

![Border fixed](https://github.com/hashicorp/vault/assets/3852620/c0435c17-8ee4-40cb-a85f-b71a617b904e)
