### PR TITLE
Ember Template Linting in Tests

### DIFF
--- a/ui/.template-lintrc.js
+++ b/ui/.template-lintrc.js
@@ -16,5 +16,12 @@ module.exports = {
     'require-input-label': 'off',
     'no-array-prototype-extensions': 'off',
   },
-  ignore: ['tests/**'],
+  overrides: [
+    {
+      files: ['**/*-test.js'],
+      rules: {
+        prettier: false,
+      },
+    },
+  ],
 };


### PR DESCRIPTION
First some history. We wanted to tell `ember-template-lint` to not lint test files which works fine using the `ignore` field in the config. Unfortunately, the `ember-language-server` VSCode plugin does not support that field so we had a mismatch between linting via the CLI and what we were seeing in the editor.

To solve this problem, the full rule set from `ember-template-lint` was required in the config and then looped to turn off each rule within tests using the `overrides` config field (see #13632). This worked for a time, until it didn't.

Fast forward and `ember-template-lint` upgraded to use modules (esm) and we could no longer _require_ the rules within the config. A [hacky workaround](https://github.com/hashicorp/vault/pull/14763/files#diff-7cd0cd936ce0b05b5380c1116ddddca6b7ad412d515b8d67b058b42dc5645ce0) to use `readFileSync` on the rules files and then parse to json and set the rules to false for the overrides was put in place which also worked, until it didn't.

Now to the present. After upgrading to Ember 4.12 and upgrading `ember-template-lint`, the format of the rules files changed and broke the hack. The parsing error was being handled so there was no change to the actual linting result or disruptions in CI but the hack was removed in #22310 since it was obviously not a durable solution.

After considering several different approaches and some investigation I came to the conclusion that linting in tests is probably a good thing if it can catch something maybe not so obvious that is causing a test to fail. All of the failures currently were related to prettier so I turned that rule off for tests only. I also removed the `ignore` field from the config so that the CLI and language server are doing the same thing. It's important that if we are seeing an error in the editor that we know it would also cause the CLI, and by extension CI to fail.

_Here's an example of failures all related to prettier for reference which are now gone_
![image](https://github.com/hashicorp/vault/assets/24611656/3e1e90a2-838b-4f21-b9ee-959d78b7f695)

_You will likely need to reload the window in VSCode after pulling these changes for the plugin to reload the config_
 
