### PR TITLE
disable ldap tests for arm

### DIFF
--- a/changelog/23118.txt
+++ b/changelog/23118.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ldaputil: Disable tests for ARM64
+```

--- a/helper/testhelpers/ldap/ldaphelper.go
+++ b/helper/testhelpers/ldap/ldaphelper.go
@@ -6,6 +6,8 @@ package ldap
 import (
 	"context"
 	"fmt"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/cap/ldap"
@@ -15,6 +17,12 @@ import (
 )
 
 func PrepareTestContainer(t *testing.T, version string) (cleanup func(), cfg *ldaputil.ConfigEntry) {
+	// note: this image isn't supported on arm64 architecture in CI.
+	// but if you're running on Apple Silicon, feel free to comment out the code below locally.
+	if strings.Contains(runtime.GOARCH, "arm") {
+		t.Skip("Skipping, as this image is not supported on ARM architectures")
+	}
+
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		// Currently set to "michelvocks" until https://github.com/rroemhild/docker-test-openldap/pull/14
 		// has been merged.


### PR DESCRIPTION
This is causing nightly tests to fail on arm64 architecture with:
```
could not start local LDAP docker container: no port mapping found for 389/tcp
```

For now, we'll disable them again.