### PR TITLE
UI: add SSH role attribute `allowed_domains_template`

### DIFF
--- a/changelog/23119.txt
+++ b/changelog/23119.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Added allowed_domains_template field for CA type role in SSH engine
+```

--- a/ui/app/models/role-ssh.js
+++ b/ui/app/models/role-ssh.js
@@ -31,6 +31,7 @@ const CA_FIELDS = [
   'allowedUsers',
   'allowedUsersTemplate',
   'allowedDomains',
+  'allowedDomainsTemplate',
   'ttl',
   'maxTtl',
   'allowedCriticalOptions',
@@ -81,6 +82,10 @@ export default Model.extend({
   allowedDomains: attr('string', {
     helpText:
       'List of domains for which a client can request a certificate (e.g. `example.com`, or `*` to allow all)',
+  }),
+  allowedDomainsTemplate: attr('boolean', {
+    helpText:
+      'Specifies that Allowed domains can be set using identity template policies. Non-templated domains are also permitted.',
   }),
   cidrList: attr('string', {
     helpText: 'List of CIDR blocks for which this role is applicable',

--- a/ui/app/models/role-ssh.js
+++ b/ui/app/models/role-ssh.js
@@ -77,7 +77,7 @@ export default Model.extend({
   }),
   allowedUsersTemplate: attr('boolean', {
     helpText:
-      'Specifies that Allowed users can be templated e.g. {{identity.entity.aliases.mount_accessor_xyz.name}}',
+      'Specifies that Allowed Users can be templated e.g. {{identity.entity.aliases.mount_accessor_xyz.name}}',
   }),
   allowedDomains: attr('string', {
     helpText:
@@ -85,7 +85,7 @@ export default Model.extend({
   }),
   allowedDomainsTemplate: attr('boolean', {
     helpText:
-      'Specifies that Allowed domains can be set using identity template policies. Non-templated domains are also permitted.',
+      'Specifies that Allowed Domains can be set using identity template policies. Non-templated domains are also permitted.',
   }),
   cidrList: attr('string', {
     helpText: 'List of CIDR blocks for which this role is applicable',


### PR DESCRIPTION
This PR adds the `allowed_domains_attribute` to the UI interface for CA type SSH roles only. 

<img width="1512" alt="Screenshot 2023-09-15 at 3 05 10 PM" src="https://github.com/hashicorp/vault/assets/82459713/fb40f93e-5121-4f32-b4cb-09d5cee9dd9b">
