### PR TITLE
JSON Editor Toolbar Styling Fix 

### DIFF
--- a/ui/lib/core/addon/components/json-editor.hbs
+++ b/ui/lib/core/addon/components/json-editor.hbs
@@ -7,7 +7,7 @@
   {{#if this.getShowToolbar}}
     <div data-test-component="json-editor-toolbar">
       <Toolbar>
-        <label class="is-label" data-test-component="json-editor-title">
+        <label class="has-text-weight-bold" data-test-component="json-editor-title">
           {{@title}}
           {{#if @subTitle}}
             <span class="is-size-9 is-lowercase has-text-grey">({{@subTitle}})</span>


### PR DESCRIPTION
This PR fixes an issue with the `json-editor` toolbar scrolling unnecessarily off the page which was caused by some updates to the `is-label` class.

Before (copy icon is overflowing)
![image](https://github.com/hashicorp/vault/assets/24611656/733f9486-0e7b-41fc-a5f8-2fa47a43d9bf)

After
![image](https://github.com/hashicorp/vault/assets/24611656/f86db4d5-1ff8-4ba2-a225-dbccaf4c9cbb)
