### PR TITLE
UI: [VAULT-18178] Fix filter/search bug in search secrets engines

### DIFF
--- a/changelog/22810.txt
+++ b/changelog/22810.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes old pki's filter and search roles page bug 
+```

--- a/changelog/22810.txt
+++ b/changelog/22810.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-ui: Fixes old pki's filter and search roles page bug 
-```

--- a/changelog/23123.txt
+++ b/changelog/23123.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes filter and search bug in secrets engines 
+```

--- a/ui/app/services/store.js
+++ b/ui/app/services/store.js
@@ -98,9 +98,10 @@ export default class StoreService extends Store {
 
   filterData(filter, dataset) {
     let newData = dataset || [];
+
     if (filter) {
       newData = dataset.filter(function (item) {
-        const id = item.id || item;
+        const id = item.id || item.name || item;
         return id.toLowerCase().includes(filter.toLowerCase());
       });
     }

--- a/ui/app/services/store.js
+++ b/ui/app/services/store.js
@@ -98,7 +98,6 @@ export default class StoreService extends Store {
 
   filterData(filter, dataset) {
     let newData = dataset || [];
-
     if (filter) {
       newData = dataset.filter(function (item) {
         const id = item.id || item.name || item;


### PR DESCRIPTION
**Description**
**Before bug fix:** <img width="1620" alt="Screenshot 2023-09-06 at 9 47 25 AM" src="https://github.com/hashicorp/vault/assets/30884335/c3179442-5b92-4b98-bf0a-87fccb38116d">

**After:** Fixes pki bug for filtering roles. 

This is the bugfix from https://github.com/hashicorp/vault/pull/22810.