### PR TITLE
Base font-size update to match HDS

### DIFF
--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -3,18 +3,22 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+@function rem($value, $base: 16) {
+  @return calc($value / $base) + 0rem;
+}
+
 /* General sizing in rem values used largely for text sizing.*/
-$size-1: 3rem; // 48px, same as $spacing-xxl
-$size-2: 2.5rem; // 40px
-$size-3: calc(24 / 14) + 0rem; // ~1.714rem ~27px
-$size-4: 1.5rem; // 24px same as $spacing-l
-$size-5: 1.25rem; // 20px
-$size-6: 1rem; // 16px same as $spacing-m
-$size-7: calc(13 / 14) + 0rem; // ~.929rem ~15px
-$size-8: calc(12 / 14) + 0rem; // ~.857rem  ~13.7px
-$size-9: 0.75rem; // 12px same as $spacing-s
-$size-10: 0.5rem; // 8px same as $spacing-xs
-$size-11: 0.25rem; // 4px same as spacing-xxs
+$size-1: rem(42); // 42px or 2.63rem
+$size-2: rem(35); // 35px or 2.19rem
+$size-3: rem(24); // 24px or 1.50rem
+$size-4: rem(21); // 21px or 1.31rem
+$size-5: rem(17.5); // 17.5px or 1.09rem
+$size-6: rem(14); // 14px or 0.88rem
+$size-7: rem(13); // 13px or 0.81rem
+$size-8: rem(12); // 12px or 0.75rem
+$size-9: rem(10.5); // 10.5px or 0.66rem
+$size-10: rem(7); // 7px or 0.44rem
+$size-11: rem(3.25); // 3.5px or 0.22rem
 
 /* Spacing vars in px */
 $spacing-xxs: 4px;


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1-wumjbfivuMFzZqZjWFV0BK2dtqcOl4vYoyWyaTCYac/edit#gid=0

Recalculating rem's considering 16px as base:

<img width="591" alt="image" src="https://github.com/hashicorp/vault/assets/18043357/fdcee0eb-4ca6-475c-8aff-6e24521b9c1d">

