### PR TITLE
test: fix netcat install and listen for socket audit device

### DIFF
--- a/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
+++ b/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
@@ -1,14 +1,10 @@
-#!/bin/env sh
+#!/bin/env bash
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
-
-
 set -eux
 
-LOG_DIR="$(dirname "$LOG_FILE_PATH")"
-
-# Run nc to listen to port 9090
-nc -l 9090 &
+# Run nc to listen to port 9090 for the socket audit log
+nohup nc -l 9090 &>/dev/null </dev/null &
 
 $VAULT_BIN_PATH audit enable file file_path="$LOG_FILE_PATH"
 $VAULT_BIN_PATH audit enable syslog tag="vault" facility="AUTH"

--- a/enos/modules/vault_cluster/templates/install-packages.sh
+++ b/enos/modules/vault_cluster/templates/install-packages.sh
@@ -41,7 +41,7 @@ if [ -f /etc/debian_version ]; then
 
   cd /tmp
   retry 5 sudo apt update
-  retry 5 sudo apt install -y "$${packages[@]}"
+  retry 5 sudo apt install -y $${packages[@]}
 else
   cd /tmp
   retry 7 sudo yum -y install $${packages[@]}


### PR DESCRIPTION
Fix an issue where netcat would not be installed correctly with certain package managers. We also fix an issue where SSH cannot exit because nc is waitaing for SIGHUP, resulting in scenarios running forever.