### PR TITLE
Fix Enos Issues Relating to Vault Auditing

### DIFF
--- a/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
+++ b/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
@@ -4,7 +4,10 @@
 set -eux
 
 # Run nc to listen to port 9090 for the socket audit log
-nohup nc -l 9090 &>/dev/null </dev/null &
+nc -l 9090 &>/dev/null &
+
+# Sleep for a second to make sure nc is up and running
+sleep 1
 
 $VAULT_BIN_PATH audit enable file file_path="$LOG_FILE_PATH"
 $VAULT_BIN_PATH audit enable syslog tag="vault" facility="AUTH"


### PR DESCRIPTION
This PR adjusts the enable_audit_logging.sh script to ensure that the **enos_remote_exec** resource that invokes it using an SSH session isn't blocked indefinitely.

I've done some local testing of ssh behaviour when invoking a script that launches **nc** in the background and found that **nohup** didn't have any effect, neither did the redirecting stdin from _/dev/null_. It was redirecting both stdout and stderr to _/dev/null_ (`&> /dev/null`) that stopped the ssh session from being blocked even after the script was done executing.