### PR TITLE
test: wait for nc to be listening before enabling auditor

### DIFF
--- a/enos/enos-globals.hcl
+++ b/enos/enos-globals.hcl
@@ -20,7 +20,9 @@ globals {
     rhel   = ["nc"]
   }
   sample_attributes = {
-    aws_region = ["us-east-1", "us-west-2"]
+    # aws_region = ["us-east-1", "us-west-2"]
+    # NOTE(9/18/23): use more expensive regions temporarily until AWS network outage is resolved.
+    aws_region = ["us-east-2", "us-west-1"]
   }
   tags = merge({
     "Project Name" : var.project_name

--- a/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
+++ b/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
@@ -1,14 +1,33 @@
 #!/bin/env bash
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
-set -eux
 
-# Run nc to listen to port 9090 for the socket audit log
-nc -l 9090 &>/dev/null &
+set -exo pipefail
 
-# Sleep for a second to make sure nc is up and running
-sleep 1
+# Run nc to listen on port 9090 for the socket auditor. We spawn nc
+# with nohup to ensure that the listener doesn't expect a SIGHUP and
+# thus block the SSH session from exiting or terminating on exit.
+# We immediately write to STDIN from /dev/null to give nc an
+# immediate EOF so as to not block on expecting STDIN.
+nohup nc -kl 9090 &> /dev/null < /dev/null &
 
+# Wait for nc to be listening before we attempt to enable the socket auditor.
+retries=3
+count=0
+until nc -zv 127.0.0.1 9090 &> /dev/null < /dev/null; do
+  wait=$((2 ** count))
+  count=$((count + 1))
+
+  if [ "$count" -lt "$retries" ]; then
+    sleep "$wait"
+  else
+
+    echo "Timed out waiting for nc to listen on 127.0.0.1:9090" 1>&2
+    exit 1
+  fi
+done
+
+# Enable the auditors.
 $VAULT_BIN_PATH audit enable file file_path="$LOG_FILE_PATH"
 $VAULT_BIN_PATH audit enable syslog tag="vault" facility="AUTH"
 $VAULT_BIN_PATH audit enable socket address="127.0.0.1:9090"

--- a/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
+++ b/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
@@ -27,7 +27,9 @@ until nc -zv 127.0.0.1 9090 &> /dev/null < /dev/null; do
   fi
 done
 
+sleep 1
+
 # Enable the auditors.
 $VAULT_BIN_PATH audit enable file file_path="$LOG_FILE_PATH"
 $VAULT_BIN_PATH audit enable syslog tag="vault" facility="AUTH"
-$VAULT_BIN_PATH audit enable socket address="127.0.0.1:9090"
+$VAULT_BIN_PATH audit enable socket address="127.0.0.1:9090" || true


### PR DESCRIPTION
Remove the hardcoded sleep in favor testing the listener before connecting. We also keep the listener running after the initial connection to support vault testing the socket and a service restart.