### PR TITLE
backport 5449a99 w/audit device changes to 1.12.x

### DIFF
--- a/enos/ci/aws-nuke.yml
+++ b/enos/ci/aws-nuke.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 regions:
 - eu-north-1
 - ap-south-1

--- a/enos/ci/bootstrap/main.tf
+++ b/enos/ci/bootstrap/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     aws = {

--- a/enos/ci/bootstrap/outputs.tf
+++ b/enos/ci/bootstrap/outputs.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 output "keys" {
   value = {
     "us-east-1" = {

--- a/enos/ci/bootstrap/variables.tf
+++ b/enos/ci/bootstrap/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "aws_ssh_public_key" {
   description = "The public key to use for the ssh key"
   type        = string

--- a/enos/ci/service-user-iam/main.tf
+++ b/enos/ci/service-user-iam/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     aws = {

--- a/enos/ci/service-user-iam/outputs.tf
+++ b/enos/ci/service-user-iam/outputs.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 output "ci_role" {
   value = {
     name = aws_iam_role.role.name

--- a/enos/ci/service-user-iam/providers.tf
+++ b/enos/ci/service-user-iam/providers.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 provider "aws" {
   region = "us-east-1"
   alias  = "us_east_1"

--- a/enos/ci/service-user-iam/service-quotas.tf
+++ b/enos/ci/service-user-iam/service-quotas.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 locals {
   // This is the code of the service quota to request a change for. Each adjustable limit has a
   // unique code. See, https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/servicequotas_service_quota#quota_code
@@ -6,35 +9,35 @@ locals {
 }
 
 resource "aws_servicequotas_service_quota" "vpcs_per_region_us_east_1" {
-  provider     = aws.us_east_2
+  provider     = aws.us_east_1
   quota_code   = local.subnets_per_vpcs_quota
   service_code = "vpc"
-  value        = 50
+  value        = 100
 }
 
 resource "aws_servicequotas_service_quota" "vpcs_per_region_us_east_2" {
   provider     = aws.us_east_2
   quota_code   = local.subnets_per_vpcs_quota
   service_code = "vpc"
-  value        = 50
+  value        = 100
 }
 
 resource "aws_servicequotas_service_quota" "vpcs_per_region_us_west_1" {
   provider     = aws.us_west_1
   quota_code   = local.subnets_per_vpcs_quota
   service_code = "vpc"
-  value        = 50
+  value        = 100
 }
 
 resource "aws_servicequotas_service_quota" "vpcs_per_region_us_west_2" {
   provider     = aws.us_west_2
   quota_code   = local.subnets_per_vpcs_quota
   service_code = "vpc"
-  value        = 50
+  value        = 100
 }
 
 resource "aws_servicequotas_service_quota" "spot_requests_per_region_us_east_1" {
-  provider     = aws.us_east_2
+  provider     = aws.us_east_1
   quota_code   = local.standard_spot_instance_requests_quota
   service_code = "ec2"
   value        = 640

--- a/enos/ci/service-user-iam/variables.tf
+++ b/enos/ci/service-user-iam/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "repository" {
   description = "The GitHub repository, either vault or vault-enterprise"
   type        = string

--- a/enos/enos-globals.hcl
+++ b/enos/enos-globals.hcl
@@ -15,8 +15,14 @@ globals {
     "ubuntu" = var.ubuntu_distro_version
   }
   packages = ["jq"]
+  distro_packages = {
+    ubuntu = ["netcat"]
+    rhel   = ["nc"]
+  }
   sample_attributes = {
-    aws_region = ["us-east-1", "us-west-2"]
+    # aws_region = ["us-east-1", "us-west-2"]
+    # NOTE(9/18/23): use more expensive regions temporarily until AWS network outage is resolved.
+    aws_region = ["us-east-2", "us-west-1"]
   }
   tags = merge({
     "Project Name" : var.project_name

--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 module "autopilot_upgrade_storageconfig" {
   source = "./modules/autopilot_upgrade_storageconfig"
 }

--- a/enos/enos-providers.hcl
+++ b/enos/enos-providers.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 provider "aws" "default" {
   region = var.aws_region
 }

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 scenario "agent" {
   matrix {
     arch            = ["amd64", "arm64"]
@@ -33,11 +36,6 @@ scenario "agent" {
       ubuntu = provider.enos.ubuntu
     }
     install_artifactory_artifact = local.bundle_path == null
-  }
-
-  step "get_local_metadata" {
-    skip_step = matrix.artifact_source != "local"
-    module    = module.get_local_metadata
   }
 
   step "build_vault" {
@@ -111,17 +109,17 @@ scenario "agent" {
     }
 
     variables {
-      artifactory_release      = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
-      awskms_unseal_key_arn    = step.create_vpc.kms_key_arn
-      cluster_name             = step.create_vault_cluster_targets.cluster_name
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      install_dir              = var.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_license.license : null
-      local_artifact_path      = local.bundle_path
-      packages                 = global.packages
-      storage_backend          = "raft"
-      target_hosts             = step.create_vault_cluster_targets.hosts
-      unseal_method            = "shamir"
+      artifactory_release   = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
+      awskms_unseal_key_arn = step.create_vpc.kms_key_arn
+      cluster_name          = step.create_vault_cluster_targets.cluster_name
+      enable_audit_devices  = var.vault_enable_audit_devices
+      install_dir           = var.vault_install_dir
+      license               = matrix.edition != "oss" ? step.read_license.license : null
+      local_artifact_path   = local.bundle_path
+      packages              = concat(global.packages, global.distro_packages[matrix.distro])
+      storage_backend       = "raft"
+      target_hosts          = step.create_vault_cluster_targets.hosts
+      unseal_method         = "shamir"
     }
   }
 

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 scenario "autopilot" {
   matrix {
     arch            = ["amd64", "arm64"]
@@ -112,15 +115,15 @@ scenario "autopilot" {
       cluster_name          = step.create_vault_cluster_targets.cluster_name
       install_dir           = local.vault_install_dir
       license               = matrix.edition != "oss" ? step.read_license.license : null
-      packages              = global.packages
+      packages              = concat(global.packages, global.distro_packages[matrix.distro])
       release               = var.vault_autopilot_initial_release
       storage_backend       = "raft"
       storage_backend_addl_config = {
         autopilot_upgrade_version = var.vault_autopilot_initial_release.version
       }
-      target_hosts             = step.create_vault_cluster_targets.hosts
-      unseal_method            = matrix.seal
-      enable_file_audit_device = var.vault_enable_file_audit_device
+      target_hosts         = step.create_vault_cluster_targets.hosts
+      unseal_method        = matrix.seal
+      enable_audit_devices = var.vault_enable_audit_devices
     }
   }
 
@@ -213,7 +216,7 @@ scenario "autopilot" {
       license                     = matrix.edition != "oss" ? step.read_license.license : null
       local_artifact_path         = local.artifact_path
       manage_service              = local.manage_service
-      packages                    = global.packages
+      packages                    = concat(global.packages, global.distro_packages[matrix.distro])
       root_token                  = step.create_vault_cluster.root_token
       shamir_unseal_keys          = matrix.seal == "shamir" ? step.create_vault_cluster.unseal_keys_hex : null
       storage_backend             = "raft"
@@ -221,7 +224,7 @@ scenario "autopilot" {
       storage_node_prefix         = "upgrade_node"
       target_hosts                = step.create_vault_cluster_upgrade_targets.hosts
       unseal_method               = matrix.seal
-      enable_file_audit_device    = var.vault_enable_file_audit_device
+      enable_audit_devices        = var.vault_enable_audit_devices
     }
   }
 

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 scenario "proxy" {
   matrix {
@@ -101,17 +101,17 @@ scenario "proxy" {
     }
 
     variables {
-      artifactory_release      = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
-      awskms_unseal_key_arn    = step.create_vpc.kms_key_arn
-      cluster_name             = step.create_vault_cluster_targets.cluster_name
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      install_dir              = var.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_license.license : null
-      local_artifact_path      = local.bundle_path
-      packages                 = global.packages
-      storage_backend          = "raft"
-      target_hosts             = step.create_vault_cluster_targets.hosts
-      unseal_method            = "shamir"
+      artifactory_release   = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
+      awskms_unseal_key_arn = step.create_vpc.kms_key_arn
+      cluster_name          = step.create_vault_cluster_targets.cluster_name
+      enable_audit_devices  = var.vault_enable_audit_devices
+      install_dir           = var.vault_install_dir
+      license               = matrix.edition != "oss" ? step.read_license.license : null
+      local_artifact_path   = local.bundle_path
+      packages              = concat(global.packages, global.distro_packages[matrix.distro])
+      storage_backend       = "raft"
+      target_hosts          = step.create_vault_cluster_targets.hosts
+      unseal_method         = "shamir"
     }
   }
 

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 // The replication scenario configures performance replication between two Vault clusters and verifies
 // known_primary_cluster_addrs are updated on secondary Vault cluster with the IP addresses of replaced
 // nodes on primary Vault cluster
@@ -236,15 +239,15 @@ scenario "replication" {
         edition = var.backend_edition
         version = matrix.consul_version
       } : null
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
-      local_artifact_path      = local.artifact_path
-      manage_service           = local.manage_service
-      packages                 = global.packages
-      storage_backend          = matrix.primary_backend
-      target_hosts             = step.create_primary_cluster_targets.hosts
-      unseal_method            = matrix.primary_seal
+      enable_audit_devices = var.vault_enable_audit_devices
+      install_dir          = local.vault_install_dir
+      license              = matrix.edition != "oss" ? step.read_vault_license.license : null
+      local_artifact_path  = local.artifact_path
+      manage_service       = local.manage_service
+      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      storage_backend      = matrix.primary_backend
+      target_hosts         = step.create_primary_cluster_targets.hosts
+      unseal_method        = matrix.primary_seal
     }
   }
 
@@ -293,15 +296,15 @@ scenario "replication" {
         edition = var.backend_edition
         version = matrix.consul_version
       } : null
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
-      local_artifact_path      = local.artifact_path
-      manage_service           = local.manage_service
-      packages                 = global.packages
-      storage_backend          = matrix.secondary_backend
-      target_hosts             = step.create_secondary_cluster_targets.hosts
-      unseal_method            = matrix.secondary_seal
+      enable_audit_devices = var.vault_enable_audit_devices
+      install_dir          = local.vault_install_dir
+      license              = matrix.edition != "oss" ? step.read_vault_license.license : null
+      local_artifact_path  = local.artifact_path
+      manage_service       = local.manage_service
+      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      storage_backend      = matrix.secondary_backend
+      target_hosts         = step.create_secondary_cluster_targets.hosts
+      unseal_method        = matrix.secondary_seal
     }
   }
 
@@ -535,20 +538,20 @@ scenario "replication" {
         edition = var.backend_edition
         version = matrix.consul_version
       } : null
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      force_unseal             = matrix.primary_seal == "shamir"
-      initialize_cluster       = false
-      install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
-      local_artifact_path      = local.artifact_path
-      manage_service           = local.manage_service
-      packages                 = global.packages
-      root_token               = step.create_primary_cluster.root_token
-      shamir_unseal_keys       = matrix.primary_seal == "shamir" ? step.create_primary_cluster.unseal_keys_hex : null
-      storage_backend          = matrix.primary_backend
-      storage_node_prefix      = "newprimary_node"
-      target_hosts             = step.create_primary_cluster_additional_targets.hosts
-      unseal_method            = matrix.primary_seal
+      enable_audit_devices = var.vault_enable_audit_devices
+      force_unseal         = matrix.primary_seal == "shamir"
+      initialize_cluster   = false
+      install_dir          = local.vault_install_dir
+      license              = matrix.edition != "oss" ? step.read_vault_license.license : null
+      local_artifact_path  = local.artifact_path
+      manage_service       = local.manage_service
+      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      root_token           = step.create_primary_cluster.root_token
+      shamir_unseal_keys   = matrix.primary_seal == "shamir" ? step.create_primary_cluster.unseal_keys_hex : null
+      storage_backend      = matrix.primary_backend
+      storage_node_prefix  = "newprimary_node"
+      target_hosts         = step.create_primary_cluster_additional_targets.hosts
+      unseal_method        = matrix.primary_seal
     }
   }
 

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 scenario "smoke" {
   matrix {
     arch            = ["amd64", "arm64"]
@@ -177,15 +180,15 @@ scenario "smoke" {
         edition = var.backend_edition
         version = matrix.consul_version
       } : null
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
-      local_artifact_path      = local.artifact_path
-      manage_service           = local.manage_service
-      packages                 = global.packages
-      storage_backend          = matrix.backend
-      target_hosts             = step.create_vault_cluster_targets.hosts
-      unseal_method            = matrix.seal
+      enable_audit_devices = var.vault_enable_audit_devices
+      install_dir          = local.vault_install_dir
+      license              = matrix.edition != "oss" ? step.read_vault_license.license : null
+      local_artifact_path  = local.artifact_path
+      manage_service       = local.manage_service
+      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      storage_backend      = matrix.backend
+      target_hosts         = step.create_vault_cluster_targets.hosts
+      unseal_method        = matrix.seal
     }
   }
 

--- a/enos/enos-scenario-ui.hcl
+++ b/enos/enos-scenario-ui.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 scenario "ui" {
   matrix {
     edition = ["oss", "ent"]
@@ -37,10 +40,6 @@ scenario "ui" {
     vault_license_path = abspath(var.vault_license_path != null ? var.vault_license_path : joinpath(path.root, "./support/vault.hclic"))
     vault_tag_key      = "Type" // enos_vault_start expects Type as the tag key
     ui_test_filter     = var.ui_test_filter != null && try(trimspace(var.ui_test_filter), "") != "" ? var.ui_test_filter : (matrix.edition == "oss") ? "!enterprise" : null
-  }
-
-  step "get_local_metadata" {
-    module = module.get_local_metadata
   }
 
   step "build_vault" {
@@ -167,13 +166,14 @@ scenario "ui" {
         edition = var.backend_edition
         version = local.consul_version
       } : null
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
-      local_artifact_path      = local.bundle_path
-      storage_backend          = matrix.backend
-      target_hosts             = step.create_vault_cluster_targets.hosts
-      unseal_method            = local.seal
+      enable_audit_devices = var.vault_enable_audit_devices
+      install_dir          = local.vault_install_dir
+      license              = matrix.edition != "oss" ? step.read_vault_license.license : null
+      local_artifact_path  = local.bundle_path
+      packages             = global.distro_packages["ubuntu"]
+      storage_backend      = matrix.backend
+      target_hosts         = step.create_vault_cluster_targets.hosts
+      unseal_method        = local.seal
     }
   }
 

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 scenario "upgrade" {
   matrix {
     arch            = ["amd64", "arm64"]
@@ -177,14 +180,14 @@ scenario "upgrade" {
         edition = var.backend_edition
         version = matrix.consul_version
       } : null
-      enable_file_audit_device = var.vault_enable_file_audit_device
-      install_dir              = local.vault_install_dir
-      license                  = matrix.edition != "oss" ? step.read_vault_license.license : null
-      packages                 = global.packages
-      release                  = var.vault_upgrade_initial_release
-      storage_backend          = matrix.backend
-      target_hosts             = step.create_vault_cluster_targets.hosts
-      unseal_method            = matrix.seal
+      enable_audit_devices = var.vault_enable_audit_devices
+      install_dir          = local.vault_install_dir
+      license              = matrix.edition != "oss" ? step.read_vault_license.license : null
+      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      release              = var.vault_upgrade_initial_release
+      storage_backend      = matrix.backend
+      target_hosts         = step.create_vault_cluster_targets.hosts
+      unseal_method        = matrix.seal
     }
   }
 

--- a/enos/enos-terraform.hcl
+++ b/enos/enos-terraform.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform_cli "default" {
   plugin_cache_dir = var.terraform_plugin_cache_dir != null ? abspath(var.terraform_plugin_cache_dir) : null
 

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -1,11 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
-variable "artifact_path" {
-  type        = string
-  description = "The local path for dev artifact to test"
-  default     = null
-}
+# SPDX-License-Identifier: BUSL-1.1
 
 variable "artifactory_username" {
   type        = string
@@ -148,8 +142,8 @@ variable "vault_build_date" {
   default     = ""
 }
 
-variable "vault_enable_file_audit_device" {
-  description = "If true the file audit device will be enabled at the path /var/log/vault_audit.log"
+variable "vault_enable_audit_devices" {
+  description = "If true every audit device will be enabled"
   type        = bool
   default     = true
 }

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 # artifactory_username is the username to use when testing an artifact stored in artfactory.
 # artifactory_username = "yourname@hashicorp.com"
@@ -87,9 +87,12 @@
 # date to match"
 # vault_build_date = "2023-07-07T14:06:37Z" // make ci-get-date for example
 
-# vault_enable_file_audit_device sets whether or not to enable the 'file' audit device. It true it
-# will be enabled at the path /var/log/vault_audit.log
-# vault_enable_file_audit_device = true
+# vault_enable_audit_devices sets whether or not to enable every audit device. It true
+# a file audit device will be enabled at the path /var/log/vault_audit.log, the syslog
+# audit device will be enabled, and a socket audit device connecting to 127.0.0.1:9090
+# will be enabled. The netcat program is run in listening mode to provide an endpoint
+# that the socket audit device can connect to.
+# vault_enable_audit_devices = true
 
 # vault_install_dir is the directory where the vault binary will be installed on
 # the remote machines.

--- a/enos/k8s/enos-modules-k8s.hcl
+++ b/enos/k8s/enos-modules-k8s.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 module "create_kind_cluster" {
   source = "../modules/local_kind_cluster"
 }

--- a/enos/k8s/enos-providers-k8s.hcl
+++ b/enos/k8s/enos-providers-k8s.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 provider "enos" "default" {}
 
 provider "helm" "default" {

--- a/enos/k8s/enos-scenario-k8s.hcl
+++ b/enos/k8s/enos-scenario-k8s.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 scenario "k8s" {
   matrix {
     edition = ["oss", "ent"]

--- a/enos/k8s/enos-terraform-k8s.hcl
+++ b/enos/k8s/enos-terraform-k8s.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform "k8s" {
   required_version = ">= 1.2.0"
 

--- a/enos/k8s/enos-variables-k8s.hcl
+++ b/enos/k8s/enos-variables-k8s.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "vault_image_repository" {
   description = "The repository for the docker image to load, i.e. hashicorp/vault"
   type        = string

--- a/enos/modules/autopilot_upgrade_storageconfig/main.tf
+++ b/enos/modules/autopilot_upgrade_storageconfig/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "vault_product_version" {}
 
 output "storage_addl_config" {

--- a/enos/modules/backend_consul/main.tf
+++ b/enos/modules/backend_consul/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 terraform {
   required_version = ">= 1.2.0"

--- a/enos/modules/backend_consul/outputs.tf
+++ b/enos/modules/backend_consul/outputs.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 output "private_ips" {
   description = "Consul cluster target host private_ips"

--- a/enos/modules/backend_consul/variables.tf
+++ b/enos/modules/backend_consul/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 variable "cluster_name" {
   type        = string

--- a/enos/modules/backend_raft/main.tf
+++ b/enos/modules/backend_raft/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 // Shim module to handle the fact that Vault doesn't actually need a backend module when we use raft.
 terraform {

--- a/enos/modules/build_crt/main.tf
+++ b/enos/modules/build_crt/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 # Shim module since CRT provided things will use the crt_bundle_path variable
 variable "bundle_path" {
   default = "/tmp/vault.zip"

--- a/enos/modules/build_local/main.tf
+++ b/enos/modules/build_local/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {
@@ -32,35 +35,29 @@ variable "artifactory_host" { default = null }
 variable "artifactory_repo" { default = null }
 variable "artifactory_username" { default = null }
 variable "artifactory_token" { default = null }
-variable "arch" {
-  default = null
-}
-variable "artifact_path" {
-  default = null
-}
-variable "artifact_type" {
-  default = null
-}
-variable "distro" {
-  default = null
-}
-variable "edition" {
-  default = null
-}
-variable "revision" {
-  default = null
-}
-variable "product_version" {
-  default = null
+variable "arch" { default = null }
+variable "artifact_path" { default = null }
+variable "artifact_type" { default = null }
+variable "distro" { default = null }
+variable "edition" { default = null }
+variable "revision" { default = null }
+variable "product_version" { default = null }
+
+module "local_metadata" {
+  source = "../get_local_metadata"
 }
 
 resource "enos_local_exec" "build" {
   scripts = [abspath("${path.module}/scripts/build.sh")]
 
   environment = {
-    BUNDLE_PATH = var.bundle_path,
-    GO_TAGS     = join(" ", var.build_tags)
-    GOARCH      = var.goarch
-    GOOS        = var.goos
+    BASE_VERSION       = module.local_metadata.version_base
+    BIN_PATH           = "dist"
+    BUNDLE_PATH        = var.bundle_path,
+    GO_TAGS            = join(" ", var.build_tags)
+    GOARCH             = var.goarch
+    GOOS               = var.goos
+    PRERELEASE_VERSION = module.local_metadata.version_pre
+    VERSION_METADATA   = module.local_metadata.version_meta
   }
 }

--- a/enos/modules/build_local/scripts/build.sh
+++ b/enos/modules/build_local/scripts/build.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 set -eux -o pipefail
 
 # Install yarn so we can build the UI
@@ -8,5 +11,11 @@ export CGO_ENABLED=0
 
 root_dir="$(git rev-parse --show-toplevel)"
 pushd "$root_dir" > /dev/null
-make ci-build-ui ci-build ci-bundle
+make ci-build-ui ci-build
+
+: "${BIN_PATH:="dist"}"
+: "${BUNDLE_PATH:=$(git rev-parse --show-toplevel)/vault.zip}"
+echo "--> Bundling $BIN_PATH/* to $BUNDLE_PATH"
+zip -r -j "$BUNDLE_PATH" "$BIN_PATH/"
+
 popd > /dev/null

--- a/enos/modules/create_vpc/main.tf
+++ b/enos/modules/create_vpc/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 data "aws_availability_zones" "available" {
   state = "available"
 

--- a/enos/modules/create_vpc/outputs.tf
+++ b/enos/modules/create_vpc/outputs.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 output "vpc_id" {
   description = "Created VPC ID"
   value       = aws_vpc.vpc.id

--- a/enos/modules/create_vpc/variables.tf
+++ b/enos/modules/create_vpc/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "name" {
   type        = string
   default     = "vault-ci"

--- a/enos/modules/ec2_info/main.tf
+++ b/enos/modules/ec2_info/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 locals {
   architectures      = toset(["arm64", "x86_64"])
   canonical_owner_id = "099720109477"

--- a/enos/modules/generate_secondary_token/main.tf
+++ b/enos/modules/generate_secondary_token/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/get_local_metadata/main.tf
+++ b/enos/modules/get_local_metadata/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {
@@ -10,22 +13,46 @@ resource "enos_local_exec" "get_build_date" {
   scripts = [abspath("${path.module}/scripts/build_date.sh")]
 }
 
+resource "enos_local_exec" "get_revision" {
+  inline = ["git rev-parse HEAD"]
+}
+
+resource "enos_local_exec" "get_version" {
+  inline = ["${abspath("${path.module}/scripts/version.sh")} version"]
+}
+
+resource "enos_local_exec" "get_version_base" {
+  inline = ["${abspath("${path.module}/scripts/version.sh")} version-base"]
+}
+
+resource "enos_local_exec" "get_version_pre" {
+  inline = ["${abspath("${path.module}/scripts/version.sh")} version-pre"]
+}
+
+resource "enos_local_exec" "get_version_meta" {
+  inline = ["${abspath("${path.module}/scripts/version.sh")} version-meta"]
+}
+
 output "build_date" {
   value = trimspace(enos_local_exec.get_build_date.stdout)
 }
 
-resource "enos_local_exec" "get_version" {
-  scripts = [abspath("${path.module}/scripts/version.sh")]
+output "revision" {
+  value = trimspace(enos_local_exec.get_revision.stdout)
 }
 
 output "version" {
   value = trimspace(enos_local_exec.get_version.stdout)
 }
 
-resource "enos_local_exec" "get_revision" {
-  inline = ["git rev-parse HEAD"]
+output "version_base" {
+  value = trimspace(enos_local_exec.get_version_base.stdout)
 }
 
-output "revision" {
-  value = trimspace(enos_local_exec.get_revision.stdout)
+output "version_pre" {
+  value = trimspace(enos_local_exec.get_version_pre.stdout)
+}
+
+output "version_meta" {
+  value = trimspace(enos_local_exec.get_version_meta.stdout)
 }

--- a/enos/modules/get_local_metadata/scripts/build_date.sh
+++ b/enos/modules/get_local_metadata/scripts/build_date.sh
@@ -1,4 +1,7 @@
 #!/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 set -eu -o pipefail
 
 pushd "$(git rev-parse --show-toplevel)" > /dev/null

--- a/enos/modules/get_local_metadata/scripts/version.sh
+++ b/enos/modules/get_local_metadata/scripts/version.sh
@@ -1,6 +1,97 @@
 #!/bin/env bash
-set -eu -o pipefail
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
 
-pushd "$(git rev-parse --show-toplevel)" > /dev/null
-make ci-get-version
-popd > /dev/null
+set -euo pipefail
+
+# Get the full version information
+# this is only needed for local enos builds in order to get the default version from version_base.go
+# this should match the default version that the binary has been built with
+# CRT release builds use the new static version from ./release/VERSION
+function version() {
+  local version
+  local prerelease
+  local metadata
+
+  version=$(version_base)
+  prerelease=$(version_pre)
+  metadata=$(version_metadata)
+
+  if [ -n "$metadata" ] && [ -n "$prerelease" ]; then
+    echo "$version-$prerelease+$metadata"
+  elif [ -n "$metadata" ]; then
+    echo "$version+$metadata"
+  elif [ -n "$prerelease" ]; then
+    echo "$version-$prerelease"
+  else
+    echo "$version"
+  fi
+}
+
+# Get the base version
+function version_base() {
+  : "${VAULT_VERSION:=""}"
+
+  if [ -n "$VAULT_VERSION" ]; then
+    echo "$VAULT_VERSION"
+    return
+  fi
+
+  : "${VERSION_FILE:=$(repo_root)/version/VERSION}"
+  awk -F- '{ print $1 }' < "$VERSION_FILE"
+}
+
+# Get the version pre-release
+function version_pre() {
+  : "${VAULT_PRERELEASE:=""}"
+
+  if [ -n "$VAULT_PRERELEASE" ]; then
+    echo "$VAULT_PRERELEASE"
+    return
+  fi
+
+  : "${VERSION_FILE:=$(repo_root)/version/VERSION}"
+  awk -F- '{ print $2 }' < "$VERSION_FILE"
+}
+
+# Get the version metadata, which is commonly the edition
+function version_metadata() {
+  : "${VAULT_METADATA:=""}"
+
+  if [ -n "$VAULT_METADATA" ]; then
+    echo "$VAULT_METADATA"
+    return
+  fi
+
+  : "${VERSION_FILE:=$(repo_root)/version/version_base.go}"
+  awk '$1 == "VersionMetadata" && $2 == "=" { gsub(/"/, "", $3); print $3 }' < "$VERSION_FILE"
+}
+
+# Determine the root directory of the repository
+function repo_root() {
+  git rev-parse --show-toplevel
+}
+
+# Run Enos local
+function main() {
+  case $1 in
+  version)
+    version
+  ;;
+  version-base)
+    version_base
+  ;;
+  version-pre)
+    version_pre
+  ;;
+  version-meta)
+    version_metadata
+  ;;
+  *)
+    echo "unknown sub-command" >&2
+    exit 1
+  ;;
+  esac
+}
+
+main "$@"

--- a/enos/modules/k8s_deploy_vault/main.tf
+++ b/enos/modules/k8s_deploy_vault/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_version = ">= 1.0"
 

--- a/enos/modules/k8s_deploy_vault/variables.tf
+++ b/enos/modules/k8s_deploy_vault/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "context_name" {
   type        = string
   description = "The name of the k8s context for Vault"

--- a/enos/modules/k8s_vault_verify_build_date/main.tf
+++ b/enos/modules/k8s_vault_verify_build_date/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 terraform {
   required_providers {

--- a/enos/modules/k8s_vault_verify_build_date/variables.tf
+++ b/enos/modules/k8s_vault_verify_build_date/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "vault_instance_count" {
   type        = number
   description = "How many vault instances are in the cluster"

--- a/enos/modules/k8s_vault_verify_replication/main.tf
+++ b/enos/modules/k8s_vault_verify_replication/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 terraform {
   required_providers {

--- a/enos/modules/k8s_vault_verify_replication/scripts/smoke-verify-replication.sh
+++ b/enos/modules/k8s_vault_verify_replication/scripts/smoke-verify-replication.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash 
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 # The Vault replication smoke test, documented in
 # https://docs.google.com/document/d/16sjIk3hzFDPyY5A9ncxTZV_9gnpYSF1_Vx6UA1iiwgI/edit#heading=h.kgrxf0f1et25

--- a/enos/modules/k8s_vault_verify_replication/variables.tf
+++ b/enos/modules/k8s_vault_verify_replication/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "vault_instance_count" {
   type        = number
   description = "How many vault instances are in the cluster"

--- a/enos/modules/k8s_vault_verify_ui/main.tf
+++ b/enos/modules/k8s_vault_verify_ui/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 terraform {
   required_providers {

--- a/enos/modules/k8s_vault_verify_ui/scripts/smoke-verify-ui.sh
+++ b/enos/modules/k8s_vault_verify_ui/scripts/smoke-verify-ui.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -e
 

--- a/enos/modules/k8s_vault_verify_ui/variables.tf
+++ b/enos/modules/k8s_vault_verify_ui/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "vault_instance_count" {
   type        = number
   description = "How many vault instances are in the cluster"

--- a/enos/modules/k8s_vault_verify_version/main.tf
+++ b/enos/modules/k8s_vault_verify_version/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 terraform {
   required_providers {

--- a/enos/modules/k8s_vault_verify_version/scripts/get-status.sh
+++ b/enos/modules/k8s_vault_verify_version/scripts/get-status.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -e
 

--- a/enos/modules/k8s_vault_verify_version/scripts/smoke-verify-version.sh
+++ b/enos/modules/k8s_vault_verify_version/scripts/smoke-verify-version.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 # The Vault smoke test to verify the Vault version installed
 

--- a/enos/modules/k8s_vault_verify_version/variables.tf
+++ b/enos/modules/k8s_vault_verify_version/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "vault_instance_count" {
   type        = number
   description = "How many vault instances are in the cluster"

--- a/enos/modules/k8s_vault_verify_write_data/main.tf
+++ b/enos/modules/k8s_vault_verify_write_data/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 terraform {
   required_providers {

--- a/enos/modules/k8s_vault_verify_write_data/variables.tf
+++ b/enos/modules/k8s_vault_verify_write_data/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "vault_instance_count" {
   type        = number
   description = "How many vault instances are in the cluster"

--- a/enos/modules/load_docker_image/main.tf
+++ b/enos/modules/load_docker_image/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/local_kind_cluster/main.tf
+++ b/enos/modules/local_kind_cluster/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/read_license/main.tf
+++ b/enos/modules/read_license/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "file_name" {}
 
 output "license" {

--- a/enos/modules/shutdown_multiple_nodes/main.tf
+++ b/enos/modules/shutdown_multiple_nodes/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/shutdown_node/main.tf
+++ b/enos/modules/shutdown_node/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/target_ec2_fleet/main.tf
+++ b/enos/modules/target_ec2_fleet/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     # We need to specify the provider source in each module until we publish it

--- a/enos/modules/target_ec2_fleet/outputs.tf
+++ b/enos/modules/target_ec2_fleet/outputs.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 output "cluster_name" {
   value = local.cluster_name
 }

--- a/enos/modules/target_ec2_fleet/variables.tf
+++ b/enos/modules/target_ec2_fleet/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "ami_id" {
   description = "The machine image identifier"
   type        = string

--- a/enos/modules/target_ec2_instances/main.tf
+++ b/enos/modules/target_ec2_instances/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     # We need to specify the provider source in each module until we publish it

--- a/enos/modules/target_ec2_instances/outputs.tf
+++ b/enos/modules/target_ec2_instances/outputs.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 output "cluster_name" {
   value = local.cluster_name
 }

--- a/enos/modules/target_ec2_instances/variables.tf
+++ b/enos/modules/target_ec2_instances/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "ami_id" {
   description = "The machine image identifier"
   type        = string

--- a/enos/modules/target_ec2_shim/main.tf
+++ b/enos/modules/target_ec2_shim/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     # We need to specify the provider source in each module until we publish it

--- a/enos/modules/target_ec2_spot_fleet/main.tf
+++ b/enos/modules/target_ec2_spot_fleet/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     # We need to specify the provider source in each module until we publish it

--- a/enos/modules/target_ec2_spot_fleet/outputs.tf
+++ b/enos/modules/target_ec2_spot_fleet/outputs.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 output "cluster_name" {
   value = local.cluster_name
 }

--- a/enos/modules/target_ec2_spot_fleet/variables.tf
+++ b/enos/modules/target_ec2_spot_fleet/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "ami_id" {
   description = "The machine image identifier"
   type        = string

--- a/enos/modules/vault_agent/main.tf
+++ b/enos/modules/vault_agent/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     aws = {

--- a/enos/modules/vault_agent/templates/set-up-approle-and-agent.sh
+++ b/enos/modules/vault_agent/templates/set-up-approle-and-agent.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -e
 

--- a/enos/modules/vault_artifactory_artifact/locals.tf
+++ b/enos/modules/vault_artifactory_artifact/locals.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 locals {
 
   // file name extensions for the install packages of vault for the various architectures, distributions and editions

--- a/enos/modules/vault_artifactory_artifact/main.tf
+++ b/enos/modules/vault_artifactory_artifact/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/vault_artifactory_artifact/outputs.tf
+++ b/enos/modules/vault_artifactory_artifact/outputs.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 output "url" {
   value       = data.enos_artifactory_item.vault.results[0].url

--- a/enos/modules/vault_artifactory_artifact/variables.tf
+++ b/enos/modules/vault_artifactory_artifact/variables.tf
@@ -1,4 +1,5 @@
-
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
 variable "artifactory_username" {
   type        = string
   description = "The username to use when connecting to artifactory"
@@ -25,6 +26,7 @@ variable "artifactory_repo" {
 }
 variable "arch" {}
 variable "artifact_type" {}
+variable "artifact_path" {}
 variable "distro" {}
 variable "edition" {}
 variable "revision" {}

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     # We need to specify the provider source in each module until we publish it
@@ -15,7 +18,7 @@ locals {
   audit_device_file_path = "/var/log/vault/vault_audit.log"
   bin_path               = "${var.install_dir}/vault"
   consul_bin_path        = "${var.consul_install_dir}/consul"
-  enable_audit_device    = var.enable_file_audit_device && var.initialize_cluster
+  enable_audit_devices   = var.enable_audit_devices && var.initialize_cluster
   // In order to get Terraform to plan we have to use collections with keys
   // that are known at plan time. In order for our module to work our var.target_hosts
   // must be a map with known keys at plan time. Here we're creating locals
@@ -277,7 +280,7 @@ resource "enos_remote_exec" "create_audit_log_dir" {
   ]
   for_each = toset([
     for idx, host in toset(local.instances) : idx
-    if var.enable_file_audit_device
+    if var.enable_audit_devices
   ])
 
   environment = {
@@ -294,14 +297,14 @@ resource "enos_remote_exec" "create_audit_log_dir" {
   }
 }
 
-resource "enos_remote_exec" "enable_file_audit_device" {
+resource "enos_remote_exec" "enable_audit_devices" {
   depends_on = [
     enos_remote_exec.create_audit_log_dir,
     enos_vault_unseal.leader,
   ]
   for_each = toset([
     for idx in local.leader : idx
-    if local.enable_audit_device
+    if local.enable_audit_devices
   ])
 
   environment = {

--- a/enos/modules/vault_cluster/outputs.tf
+++ b/enos/modules/vault_cluster/outputs.tf
@@ -1,6 +1,9 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 output "audit_device_file_path" {
   description = "The file path for the audit device, if enabled"
-  value       = var.enable_file_audit_device ? local.audit_device_file_path : "file audit device not enabled"
+  value       = var.enable_audit_devices ? local.audit_device_file_path : "file audit device not enabled"
 }
 
 output "cluster_name" {

--- a/enos/modules/vault_cluster/scripts/create_audit_log_dir.sh
+++ b/enos/modules/vault_cluster/scripts/create_audit_log_dir.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -eux
 

--- a/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
+++ b/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
@@ -1,5 +1,35 @@
-#!/bin/env sh
+#!/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
 
-set -eux
+set -exo pipefail
 
+# Run nc to listen on port 9090 for the socket auditor. We spawn nc
+# with nohup to ensure that the listener doesn't expect a SIGHUP and
+# thus block the SSH session from exiting or terminating on exit.
+# We immediately write to STDIN from /dev/null to give nc an
+# immediate EOF so as to not block on expecting STDIN.
+nohup nc -kl 9090 &> /dev/null < /dev/null &
+
+# Wait for nc to be listening before we attempt to enable the socket auditor.
+retries=3
+count=0
+until nc -zv 127.0.0.1 9090 &> /dev/null < /dev/null; do
+  wait=$((2 ** count))
+  count=$((count + 1))
+
+  if [ "$count" -lt "$retries" ]; then
+    sleep "$wait"
+  else
+
+    echo "Timed out waiting for nc to listen on 127.0.0.1:9090" 1>&2
+    exit 1
+  fi
+done
+
+sleep 1
+
+# Enable the auditors.
 $VAULT_BIN_PATH audit enable file file_path="$LOG_FILE_PATH"
+$VAULT_BIN_PATH audit enable syslog tag="vault" facility="AUTH"
+$VAULT_BIN_PATH audit enable socket address="127.0.0.1:9090" || true

--- a/enos/modules/vault_cluster/templates/install-packages.sh
+++ b/enos/modules/vault_cluster/templates/install-packages.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -ex -o pipefail
 
@@ -38,8 +41,8 @@ if [ -f /etc/debian_version ]; then
 
   cd /tmp
   retry 5 sudo apt update
-  retry 5 sudo apt install -y "$${packages[@]}"
+  retry 5 sudo apt install -y $${packages[@]}
 else
   cd /tmp
-  retry 7 sudo yum -y install "$${packages[@]}"
+  retry 7 sudo yum -y install $${packages[@]}
 fi

--- a/enos/modules/vault_cluster/templates/vault-write-license.sh
+++ b/enos/modules/vault_cluster/templates/vault-write-license.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 license='${license}'
 if test $license = "none"; then

--- a/enos/modules/vault_cluster/variables.tf
+++ b/enos/modules/vault_cluster/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "artifactory_release" {
   type = object({
     username = string
@@ -93,8 +96,8 @@ variable "consul_release" {
   }
 }
 
-variable "enable_file_audit_device" {
-  description = "If true the file audit device will be enabled at the path /var/log/vault_audit.log"
+variable "enable_audit_devices" {
+  description = "If true every audit device will be enabled"
   type        = bool
   default     = true
 }

--- a/enos/modules/vault_get_cluster_ips/main.tf
+++ b/enos/modules/vault_get_cluster_ips/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/vault_get_cluster_ips/scripts/get-leader-private-ip.sh
+++ b/enos/modules/vault_get_cluster_ips/scripts/get-leader-private-ip.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -e
 

--- a/enos/modules/vault_proxy/main.tf
+++ b/enos/modules/vault_proxy/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 terraform {
   required_providers {

--- a/enos/modules/vault_proxy/templates/set-up-approle-and-proxy.sh
+++ b/enos/modules/vault_proxy/templates/set-up-approle-and-proxy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 
 set -e

--- a/enos/modules/vault_proxy/templates/use-proxy.sh
+++ b/enos/modules/vault_proxy/templates/use-proxy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 
 set -e

--- a/enos/modules/vault_raft_remove_peer/main.tf
+++ b/enos/modules/vault_raft_remove_peer/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/vault_raft_remove_peer/templates/raft-remove-peer.sh
+++ b/enos/modules/vault_raft_remove_peer/templates/raft-remove-peer.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -e
 

--- a/enos/modules/vault_setup_perf_primary/main.tf
+++ b/enos/modules/vault_setup_perf_primary/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/vault_setup_perf_primary/scripts/configure-vault-pr-primary.sh
+++ b/enos/modules/vault_setup_perf_primary/scripts/configure-vault-pr-primary.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -e
 

--- a/enos/modules/vault_setup_perf_secondary/main.tf
+++ b/enos/modules/vault_setup_perf_secondary/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/vault_test_ui/main.tf
+++ b/enos/modules/vault_test_ui/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/vault_test_ui/outputs.tf
+++ b/enos/modules/vault_test_ui/outputs.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 output "ui_test_stderr" {
   value = var.ui_run_tests ? enos_local_exec.test_ui[0].stderr : "No std out tests where not run"
 }

--- a/enos/modules/vault_test_ui/scripts/test_ui.sh
+++ b/enos/modules/vault_test_ui/scripts/test_ui.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -eux -o pipefail
 

--- a/enos/modules/vault_test_ui/variables.tf
+++ b/enos/modules/vault_test_ui/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 variable "vault_addr" {
   description = "The host address for the vault instance to test"
   type        = string

--- a/enos/modules/vault_unseal_nodes/main.tf
+++ b/enos/modules/vault_unseal_nodes/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 # This module unseals the replication secondary follower nodes
 terraform {
   required_providers {

--- a/enos/modules/vault_unseal_nodes/scripts/unseal-node.sh
+++ b/enos/modules/vault_unseal_nodes/scripts/unseal-node.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 binpath=${VAULT_INSTALL_DIR}/vault
 

--- a/enos/modules/vault_unseal_nodes/scripts/wait-until-sealed.sh
+++ b/enos/modules/vault_unseal_nodes/scripts/wait-until-sealed.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 binpath=${VAULT_INSTALL_DIR}/vault
 

--- a/enos/modules/vault_upgrade/main.tf
+++ b/enos/modules/vault_upgrade/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     aws = {

--- a/enos/modules/vault_upgrade/templates/get-follower-public-ips.sh
+++ b/enos/modules/vault_upgrade/templates/get-follower-public-ips.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -e
 

--- a/enos/modules/vault_upgrade/templates/get-leader-public-ip.sh
+++ b/enos/modules/vault_upgrade/templates/get-leader-public-ip.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -e
 

--- a/enos/modules/vault_upgrade/templates/restart-vault.sh
+++ b/enos/modules/vault_upgrade/templates/restart-vault.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -eux
 

--- a/enos/modules/vault_verify_agent_output/main.tf
+++ b/enos/modules/vault_verify_agent_output/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/vault_verify_agent_output/templates/verify-vault-agent-output.sh
+++ b/enos/modules/vault_verify_agent_output/templates/verify-vault-agent-output.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -e
 

--- a/enos/modules/vault_verify_autopilot/main.tf
+++ b/enos/modules/vault_verify_autopilot/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/vault_verify_autopilot/templates/smoke-verify-autopilot.sh
+++ b/enos/modules/vault_verify_autopilot/templates/smoke-verify-autopilot.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 token="${vault_token}"
 autopilot_version="${vault_autopilot_upgrade_version}"

--- a/enos/modules/vault_verify_performance_replication/main.tf
+++ b/enos/modules/vault_verify_performance_replication/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/vault_verify_performance_replication/scripts/verify-replication-status.sh
+++ b/enos/modules/vault_verify_performance_replication/scripts/verify-replication-status.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 
 # This script waits for the replication status to be established

--- a/enos/modules/vault_verify_raft_auto_join_voter/main.tf
+++ b/enos/modules/vault_verify_raft_auto_join_voter/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/vault_verify_raft_auto_join_voter/templates/verify-raft-auto-join-voter.sh
+++ b/enos/modules/vault_verify_raft_auto_join_voter/templates/verify-raft-auto-join-voter.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -e
 

--- a/enos/modules/vault_verify_read_data/main.tf
+++ b/enos/modules/vault_verify_read_data/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/vault_verify_read_data/scripts/verify-data.sh
+++ b/enos/modules/vault_verify_read_data/scripts/verify-data.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -e
 

--- a/enos/modules/vault_verify_replication/main.tf
+++ b/enos/modules/vault_verify_replication/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 terraform {
   required_providers {

--- a/enos/modules/vault_verify_replication/templates/smoke-verify-replication.sh
+++ b/enos/modules/vault_verify_replication/templates/smoke-verify-replication.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 # The Vault replication smoke test, documented in
 # https://docs.google.com/document/d/16sjIk3hzFDPyY5A9ncxTZV_9gnpYSF1_Vx6UA1iiwgI/edit#heading=h.kgrxf0f1et25

--- a/enos/modules/vault_verify_replication/variables.tf
+++ b/enos/modules/vault_verify_replication/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 variable "vault_edition" {
   type        = string

--- a/enos/modules/vault_verify_ui/main.tf
+++ b/enos/modules/vault_verify_ui/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 terraform {
   required_providers {

--- a/enos/modules/vault_verify_ui/templates/smoke-verify-ui.sh
+++ b/enos/modules/vault_verify_ui/templates/smoke-verify-ui.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -e
 

--- a/enos/modules/vault_verify_ui/variables.tf
+++ b/enos/modules/vault_verify_ui/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 variable "vault_install_dir" {
   type        = string

--- a/enos/modules/vault_verify_undo_logs/main.tf
+++ b/enos/modules/vault_verify_undo_logs/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/vault_verify_undo_logs/scripts/smoke-verify-undo-logs.sh
+++ b/enos/modules/vault_verify_undo_logs/scripts/smoke-verify-undo-logs.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 function fail() {
 	echo "$1" 1>&2

--- a/enos/modules/vault_verify_unsealed/main.tf
+++ b/enos/modules/vault_verify_unsealed/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/vault_verify_version/main.tf
+++ b/enos/modules/vault_verify_version/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/vault_verify_version/templates/verify-cluster-version.sh
+++ b/enos/modules/vault_verify_version/templates/verify-cluster-version.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 # Verify the Vault "version" includes the correct base version, build date,
 # revision SHA, and edition metadata.
@@ -20,12 +23,7 @@ test -x "$binpath" || fail "unable to locate vault binary at $binpath"
 export VAULT_ADDR='http://127.0.0.1:8200'
 export VAULT_TOKEN='${vault_token}'
 
-# Build date was added in 1.11
-if [[ "$(echo "$version" |awk -F'.' '{print $2}')" -ge 11 ]]; then
-  version_expected="Vault v$version ($sha), built $build_date"
-else
-  version_expected="Vault v$version ($sha)"
-fi
+version_expected="Vault v$version ($sha), built $build_date"
 
 case "$edition" in
   *oss) ;;

--- a/enos/modules/vault_verify_write_data/main.tf
+++ b/enos/modules/vault_verify_write_data/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 terraform {
   required_providers {
     enos = {

--- a/enos/modules/vault_verify_write_data/scripts/smoke-enable-secrets-kv.sh
+++ b/enos/modules/vault_verify_write_data/scripts/smoke-enable-secrets-kv.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -e
 

--- a/enos/modules/vault_verify_write_data/scripts/smoke-write-test-data.sh
+++ b/enos/modules/vault_verify_write_data/scripts/smoke-write-test-data.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -e
 


### PR DESCRIPTION
Rather than assuming a short sleep will work, we instead wait until netcat is listening of the socket. We've also configured the netcat listener to persist after the first connection, which allows Vault and us to check the connection without the process closing.

As we implemented this we also ran into AWS issues in us-east-1 and us-west-2, so we've changed our deploy regions until those issues are resolved.