### PR TITLE
UI: cleanup unload model logic

### DIFF
--- a/ui/app/mixins/unsaved-model-route.js
+++ b/ui/app/mixins/unsaved-model-route.js
@@ -6,7 +6,6 @@
 import Mixin from '@ember/object/mixin';
 import Ember from 'ember';
 
-// this mixin relies on `unload-model-route` also being used
 export default Mixin.create({
   actions: {
     willTransition(transition) {
@@ -21,7 +20,7 @@ export default Mixin.create({
             'You have unsaved changes. Navigating away will discard these changes. Are you sure you want to discard your changes?'
           )
         ) {
-          this.unloadModel();
+          model.rollbackAttributes();
           return true;
         } else {
           transition.abort();

--- a/ui/app/routes/vault/cluster/access/identity/aliases/add.js
+++ b/ui/app/routes/vault/cluster/access/identity/aliases/add.js
@@ -4,11 +4,10 @@
  */
 
 import Route from '@ember/routing/route';
-import UnloadModelRoute from 'vault/mixins/unload-model-route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
 import { inject as service } from '@ember/service';
 
-export default Route.extend(UnloadModelRoute, UnsavedModelRoute, {
+export default Route.extend(UnsavedModelRoute, {
   store: service(),
 
   model(params) {

--- a/ui/app/routes/vault/cluster/access/identity/aliases/edit.js
+++ b/ui/app/routes/vault/cluster/access/identity/aliases/edit.js
@@ -4,11 +4,10 @@
  */
 
 import Route from '@ember/routing/route';
-import UnloadModelRoute from 'vault/mixins/unload-model-route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
 import { inject as service } from '@ember/service';
 
-export default Route.extend(UnloadModelRoute, UnsavedModelRoute, {
+export default Route.extend(UnsavedModelRoute, {
   store: service(),
 
   model(params) {

--- a/ui/app/routes/vault/cluster/access/identity/create.js
+++ b/ui/app/routes/vault/cluster/access/identity/create.js
@@ -4,11 +4,10 @@
  */
 
 import Route from '@ember/routing/route';
-import UnloadModelRoute from 'vault/mixins/unload-model-route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
 import { inject as service } from '@ember/service';
 
-export default Route.extend(UnloadModelRoute, UnsavedModelRoute, {
+export default Route.extend(UnsavedModelRoute, {
   store: service(),
 
   model() {

--- a/ui/app/routes/vault/cluster/access/identity/edit.js
+++ b/ui/app/routes/vault/cluster/access/identity/edit.js
@@ -4,11 +4,10 @@
  */
 
 import Route from '@ember/routing/route';
-import UnloadModelRoute from 'vault/mixins/unload-model-route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
 import { inject as service } from '@ember/service';
 
-export default Route.extend(UnloadModelRoute, UnsavedModelRoute, {
+export default Route.extend(UnsavedModelRoute, {
   store: service(),
 
   model(params) {

--- a/ui/app/routes/vault/cluster/access/method/item/create.js
+++ b/ui/app/routes/vault/cluster/access/method/item/create.js
@@ -4,12 +4,11 @@
  */
 
 import Route from '@ember/routing/route';
-import UnloadModelRoute from 'vault/mixins/unload-model-route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
 import { singularize } from 'ember-inflector';
 import { inject as service } from '@ember/service';
 
-export default Route.extend(UnloadModelRoute, UnsavedModelRoute, {
+export default Route.extend(UnsavedModelRoute, {
   store: service(),
 
   model() {

--- a/ui/app/routes/vault/cluster/access/method/item/edit.js
+++ b/ui/app/routes/vault/cluster/access/method/item/edit.js
@@ -4,12 +4,11 @@
  */
 
 import Route from '@ember/routing/route';
-import UnloadModelRoute from 'vault/mixins/unload-model-route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
 import { singularize } from 'ember-inflector';
 import { inject as service } from '@ember/service';
 
-export default Route.extend(UnloadModelRoute, UnsavedModelRoute, {
+export default Route.extend(UnsavedModelRoute, {
   store: service(),
 
   model(params) {

--- a/ui/app/routes/vault/cluster/policies/create.js
+++ b/ui/app/routes/vault/cluster/policies/create.js
@@ -5,10 +5,9 @@
 
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import UnloadModelRoute from 'vault/mixins/unload-model-route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
 
-export default Route.extend(UnloadModelRoute, UnsavedModelRoute, {
+export default Route.extend(UnsavedModelRoute, {
   store: service(),
   version: service(),
 

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -9,11 +9,10 @@ import Ember from 'ember';
 import { resolve } from 'rsvp';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import UnloadModelRoute from 'vault/mixins/unload-model-route';
 import { encodePath, normalizePath } from 'vault/utils/path-encoding-helpers';
 import { keyIsFolder, parentKeyForKey } from 'core/utils/key-utils';
 
-export default Route.extend(UnloadModelRoute, {
+export default Route.extend({
   store: service(),
   pathHelp: service('path-help'),
   wizard: service(),
@@ -347,7 +346,6 @@ export default Route.extend(UnloadModelRoute, {
         ) {
           version && version.rollbackAttributes();
           model && model.rollbackAttributes();
-          this.unloadModel();
           return true;
         } else {
           transition.abort();

--- a/ui/lib/core/addon/decorators/confirm-leave.js
+++ b/ui/lib/core/addon/decorators/confirm-leave.js
@@ -57,8 +57,7 @@ export function withConfirmLeave(modelPath = 'model', silentCleanupPaths) {
         const model = this.controller.get(modelPath);
         // we only want to complete rollback if the model is dirty and not saving
         if (model && model.hasDirtyAttributes && !model.isSaving) {
-          const method = model.isNew ? 'unloadRecord' : 'rollbackAttributes';
-          model[method]();
+          model.rollbackAttributes();
         }
       }
 

--- a/ui/lib/core/addon/decorators/confirm-leave.js
+++ b/ui/lib/core/addon/decorators/confirm-leave.js
@@ -57,7 +57,8 @@ export function withConfirmLeave(modelPath = 'model', silentCleanupPaths) {
         const model = this.controller.get(modelPath);
         // we only want to complete rollback if the model is dirty and not saving
         if (model && model.hasDirtyAttributes && !model.isSaving) {
-          model.rollbackAttributes();
+          const method = model.isNew ? 'unloadRecord' : 'rollbackAttributes';
+          model[method]();
         }
       }
 


### PR DESCRIPTION
This PR fixes a unload error when using the `unsaved-model-route` -- it was rolling back changes and then triggering `unloadRecord` from the `unload-model-route` mixin, which seemed to cause issues. Simply rolling back the changes when leaving seems to work well and does not cause the issues we saw. 

Symptom of this problem: 
* Go to edit an existing item (for example, a KV V1 secret)
* Exit before saving eg. by clicking the breadcrumbs
* Go to list view for same type of item you were just editing
* Will see an extra item on the list, meaning the item that you attempted to edit did not get unloaded and got stuck in the cache. 