### PR TITLE
fix: Fail in goroutine after tests have completed

### DIFF
--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -387,17 +387,17 @@ listener "tcp" {
 		wg.Done()
 	}()
 
-	select {
-	case <-cmd.startedCh:
-	case <-time.After(5 * time.Second):
-		t.Fatalf("timeout")
-	}
-
 	// defer agent shutdown
 	defer func() {
 		cmd.ShutdownCh <- struct{}{}
 		wg.Wait()
 	}()
+
+	select {
+	case <-cmd.startedCh:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timeout")
+	}
 
 	//----------------------------------------------------
 	// Perform the tests
@@ -2624,17 +2624,17 @@ listener "tcp" {
 		wg.Done()
 	}()
 
-	select {
-	case <-cmd.startedCh:
-	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
-	}
-
 	// defer agent shutdown
 	defer func() {
 		cmd.ShutdownCh <- struct{}{}
 		wg.Wait()
 	}()
+
+	select {
+	case <-cmd.startedCh:
+	case <-time.After(5 * time.Second):
+		t.Errorf("timeout")
+	}
 
 	conf := api.DefaultConfig()
 	conf.Address = "http://" + listenAddr
@@ -2920,6 +2920,12 @@ func TestAgent_Config_ReloadTls(t *testing.T) {
 		wg.Done()
 	}()
 
+	// defer agent shutdown
+	defer func() {
+		cmd.ShutdownCh <- struct{}{}
+		wg.Wait()
+	}()
+
 	testCertificateName := func(cn string) error {
 		conn, err := tls.Dial("tcp", "127.0.0.1:8100", &tls.Config{
 			RootCAs: certPool,
@@ -2979,11 +2985,6 @@ func TestAgent_Config_ReloadTls(t *testing.T) {
 	if err := testCertificateName("bar.example.com"); err != nil {
 		t.Fatalf("certificate name didn't check out: %s", err)
 	}
-
-	// Shut down
-	cmd.ShutdownCh <- struct{}{}
-
-	wg.Wait()
 }
 
 // TestAgent_NonTLSListener_SIGHUP tests giving a SIGHUP signal to a listener
@@ -3037,6 +3038,12 @@ vault {
 		wg.Done()
 	}()
 
+	// defer agent shutdown
+	defer func() {
+		cmd.ShutdownCh <- struct{}{}
+		wg.Wait()
+	}()
+
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
@@ -3050,9 +3057,6 @@ vault {
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timeout")
 	}
-
-	close(cmd.ShutdownCh)
-	wg.Wait()
 }
 
 // Get a randomly assigned port and then free it again before returning it.

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -376,10 +376,11 @@ listener "tcp" {
 	cmd.startedCh = make(chan struct{})
 
 	var output string
+	var code int
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		code := cmd.Run([]string{"-config", configPath})
+		code = cmd.Run([]string{"-config", configPath})
 		if code != 0 {
 			output = ui.ErrorWriter.String() + ui.OutputWriter.String()
 		}
@@ -396,8 +397,8 @@ listener "tcp" {
 	defer func() {
 		cmd.ShutdownCh <- struct{}{}
 		wg.Wait()
-		if output != "" {
-			t.Fatalf("got a non-zero exit status: %s", output)
+		if code != 0 {
+			t.Fatalf("got a non-zero exit status: %d, stdout/stderr: %s", code, output)
 		}
 	}()
 
@@ -2615,10 +2616,11 @@ listener "tcp" {
 	cmd.startedCh = make(chan struct{})
 
 	var output string
+	var code int
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		code := cmd.Run([]string{"-config", configPath})
+		code = cmd.Run([]string{"-config", configPath})
 		if code != 0 {
 			output = ui.ErrorWriter.String() + ui.OutputWriter.String()
 		}
@@ -2635,8 +2637,8 @@ listener "tcp" {
 	defer func() {
 		cmd.ShutdownCh <- struct{}{}
 		wg.Wait()
-		if output != "" {
-			t.Fatalf("got a non-zero exit status: %s", output)
+		if code != 0 {
+			t.Fatalf("got a non-zero exit status: %d, stdout/stderr: %s", code, output)
 		}
 	}()
 
@@ -2915,10 +2917,11 @@ func TestAgent_Config_ReloadTls(t *testing.T) {
 	ui, cmd := testAgentCommand(t, logger)
 
 	var output string
+	var code int
 	wg.Add(1)
 	args := []string{"-config", configFile.Name()}
 	go func() {
-		if code := cmd.Run(args); code != 0 {
+		if code = cmd.Run(args); code != 0 {
 			output = ui.ErrorWriter.String() + ui.OutputWriter.String()
 		}
 		wg.Done()
@@ -2988,8 +2991,8 @@ func TestAgent_Config_ReloadTls(t *testing.T) {
 	cmd.ShutdownCh <- struct{}{}
 	wg.Wait()
 
-	if output != "" {
-		t.Fatalf("got a non-zero exit status: %s", output)
+	if code != 0 {
+		t.Fatalf("got a non-zero exit status: %d, stdout/stderr: %s", code, output)
 	}
 }
 
@@ -3035,10 +3038,11 @@ vault {
 	cmd.startedCh = make(chan struct{})
 
 	var output string
+	var code int
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		if code := cmd.Run([]string{"-config", configPath}); code != 0 {
+		if code = cmd.Run([]string{"-config", configPath}); code != 0 {
 			output = ui.ErrorWriter.String() + ui.OutputWriter.String()
 		}
 		wg.Done()
@@ -3061,8 +3065,8 @@ vault {
 	close(cmd.ShutdownCh)
 	wg.Wait()
 
-	if output != "" {
-		t.Fatalf("got a non-zero exit status: %s", output)
+	if code != 0 {
+		t.Fatalf("got a non-zero exit status: %d, stdout/stderr: %s", code, output)
 	}
 }
 

--- a/command/proxy_test.go
+++ b/command/proxy_test.go
@@ -1181,6 +1181,12 @@ func TestProxy_Config_ReloadTls(t *testing.T) {
 		wg.Done()
 	}()
 
+	defer func() {
+		// Shut down
+		cmd.ShutdownCh <- struct{}{}
+		wg.Wait()
+	}()
+
 	testCertificateName := func(cn string) error {
 		conn, err := tls.Dial("tcp", "127.0.0.1:8100", &tls.Config{
 			RootCAs: certPool,
@@ -1240,9 +1246,4 @@ func TestProxy_Config_ReloadTls(t *testing.T) {
 	if err := testCertificateName("bar.example.com"); err != nil {
 		t.Fatalf("certificate name didn't check out: %s", err)
 	}
-
-	// Shut down
-	cmd.ShutdownCh <- struct{}{}
-
-	wg.Wait()
 }

--- a/command/proxy_test.go
+++ b/command/proxy_test.go
@@ -1172,10 +1172,11 @@ func TestProxy_Config_ReloadTls(t *testing.T) {
 	ui, cmd := testProxyCommand(t, logger)
 
 	var output string
+	var code int
 	wg.Add(1)
 	args := []string{"-config", configFile.Name()}
 	go func() {
-		if code := cmd.Run(args); code != 0 {
+		if code = cmd.Run(args); code != 0 {
 			output = ui.ErrorWriter.String() + ui.OutputWriter.String()
 		}
 		wg.Done()
@@ -1245,7 +1246,7 @@ func TestProxy_Config_ReloadTls(t *testing.T) {
 	cmd.ShutdownCh <- struct{}{}
 	wg.Wait()
 
-	if output != "" {
-		t.Fatalf("got a non-zero exit status: %s", output)
+	if code != 0 {
+		t.Fatalf("got a non-zero exit status: %d, stdout/stderr: %s", code, output)
 	}
 }


### PR DESCRIPTION
```
panic: Fail in goroutine after TestProxy_Config_ReloadTls has completed

goroutine 262000 [running]:
testing.(*common).Fail(0xc00abffa00)
	/home/runner/actions-runner/_work/_tool/go/1.21.1/x64/src/testing/testing.go:952 +0xd4
testing.(*common).Errorf(0xc00abffa00, {0xa9c2b7a?, 0x121?}, {0xc00689bfc0?, 0xc00546b760?, 0x3e0cb25?})
	/home/runner/actions-runner/_work/_tool/go/1.21.1/x64/src/testing/testing.go:1069 +0x5e
github.com/hashicorp/vault/command.TestProxy_Config_ReloadTls.func1()
	/home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/command/proxy_test.go:1179 +0x115
created by github.com/hashicorp/vault/command.TestProxy_Config_ReloadTls in goroutine 261997
	/home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/command/proxy_test.go:1176 +0xa1f
```