### PR TITLE
Missing Auth Methods

### DIFF
--- a/ui/app/components/mount-backend-form.js
+++ b/ui/app/components/mount-backend-form.js
@@ -39,7 +39,7 @@ export default class MountBackendForm extends Component {
     // components are torn down after store is unloaded and will cause an error if attempt to unload record
     const noTeardown = this.store && !this.store.isDestroying;
     if (noTeardown && this.args?.mountModel) {
-      this.args.mountModel.rollbackAttributes();
+      this.args.mountModel.unloadRecord();
     }
     super.willDestroy(...arguments);
   }

--- a/ui/app/components/mount-backend-form.js
+++ b/ui/app/components/mount-backend-form.js
@@ -38,7 +38,7 @@ export default class MountBackendForm extends Component {
   willDestroy() {
     // components are torn down after store is unloaded and will cause an error if attempt to unload record
     const noTeardown = this.store && !this.store.isDestroying;
-    if (noTeardown && this.args?.mountModel) {
+    if (noTeardown && this.args?.mountModel?.isNew) {
       this.args.mountModel.unloadRecord();
     }
     super.willDestroy(...arguments);

--- a/ui/app/components/sidebar/nav/access.hbs
+++ b/ui/app/components/sidebar/nav/access.hbs
@@ -18,7 +18,7 @@
   {{#if (has-permission "access" routeParams="methods")}}
     <Nav.Link
       @route="vault.cluster.access.methods"
-      @current-when="vault.cluster.access.methods vault.cluster.access.method"
+      @current-when="vault.cluster.access.methods vault.cluster.access.method vault.cluster.settings.auth"
       @text="Authentication Methods"
       data-test-sidebar-nav-link="Authentication Methods"
     />

--- a/ui/tests/acceptance/access/methods-test.js
+++ b/ui/tests/acceptance/access/methods-test.js
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { currentRouteName } from '@ember/test-helpers';
+import { currentRouteName, click } from '@ember/test-helpers';
 import { clickTrigger } from 'ember-power-select/test-support/helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import { create } from 'ember-cli-page-object';
 import page from 'vault/tests/pages/access/methods';
 import authEnable from 'vault/tests/pages/settings/auth/enable';
@@ -21,6 +22,7 @@ const searchSelect = create(ss);
 
 module('Acceptance | auth-methods list view', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     this.uid = uuidv4();
@@ -48,7 +50,6 @@ module('Acceptance | auth-methods list view', function (hooks) {
 
     await clickTrigger('#filter-by-auth-type');
     await searchSelect.options.objectAt(0).click();
-
     const rows = document.querySelectorAll('[data-test-auth-backend-link]');
     const rowsUserpass = Array.from(rows).filter((row) => row.innerText.includes('userpass'));
 
@@ -70,5 +71,22 @@ module('Acceptance | auth-methods list view', function (hooks) {
     // cleanup
     await consoleComponent.runCommands([`delete sys/auth/${authPath1}`]);
     await consoleComponent.runCommands([`delete sys/auth/${authPath2}`]);
+  });
+
+  test('it should show all methods in list view', async function (assert) {
+    this.server.get('/sys/auth', () => ({
+      data: {
+        'token/': { accessor: 'auth_token_263b8b4e', type: 'token' },
+        'userpass/': { accessor: 'auth_userpass_87aca1f8', type: 'userpass' },
+      },
+    }));
+    await page.visit();
+    assert.dom('[data-test-auth-backend-link]').exists({ count: 2 }, 'All auth methods appear in list view');
+    await authEnable.visit();
+    await click('[data-test-sidebar-nav-link="OIDC Provider"]');
+    await page.visit();
+    assert
+      .dom('[data-test-auth-backend-link]')
+      .exists({ count: 2 }, 'All auth methods appear in list view after navigating back');
   });
 });


### PR DESCRIPTION
After the [upgrade to Ember 4.12, and specifically updating](https://github.com/hashicorp/vault/commit/8731cee07a0e3120fd7b45f7ee529d5f74c9a4b9#diff-0794c5a33b7a6bfb0e40beb904101eded845f9124dd00b3e39637d451c53d43aL37-L44) to use `rollbackAttributes` in the `mount-backend-form` component, there was an issue where navigating to mount an auth method and then moving to another route would cause the last method in the list to disappear when returning to the auth methods list view (see video). Since we are only dealing with new models here, exclusively using `unloadRecord` should be adequate and fixes the issue. I wasn't able to track down why `rollbackAttributes` was causing this to happen since it should do an `unloadRecord` behind the scenes for new models 🤷‍♂️. 

_Before_

https://github.com/hashicorp/vault/assets/24611656/8ddb3675-054d-475c-8331-63dcf5305231

_After_

https://github.com/hashicorp/vault/assets/24611656/bfafd204-771d-4af6-94a8-be063ae91fa1

I also fixed an issue where the Authentication Methods link was not staying active in the sidebar nav during the auth mount workflow.
