### PR TITLE
WIP: Add some events to PKI Secrets Engine

### DIFF
--- a/sdk/logical/events.go
+++ b/sdk/logical/events.go
@@ -5,6 +5,7 @@ package logical
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/go-uuid"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -66,6 +67,23 @@ func SendEvent(ctx context.Context, sender EventSender, eventType string, metada
 		ev.Metadata.Fields[extraMetadataArgument] = structpb.NewStringValue(metadataPairs[len(metadataPairs)-1])
 	}
 	return sender.SendEvent(ctx, EventType(eventType), ev)
+}
+
+// MakeMetadataPairs is a helper method to extract key–value pairs from a map (e.g., a logical.Response.Data).
+// It coerces each value to a string. If a key is not present in the map, then it will not be present in the
+// return value. The return value is a slice with an even number of strings, suitable to be passed to
+// SendEvent.
+func MakeMetadataPairs(resp map[string]interface{}, keys ...string) []string {
+	pairs := make([]string, 0, len(keys)*2)
+	for _, key := range keys {
+		value, ok := resp[key]
+		if !ok {
+			continue
+		}
+		pairs = append(pairs, key)
+		pairs = append(pairs, fmt.Sprintf("%v", value))
+	}
+	return pairs
 }
 
 // EventReceivedBexpr is used for evaluating boolean expressions with go-bexpr.


### PR DESCRIPTION
This adds events to the following endpoints:

- `pki/root/generate/*`
- `pki/root/sign-intermediate` / `pki/issuer/*/sign-intermediate`
- `pki/root` (DELETE)

This is just a proof-of-concept to gather feedback. There are a *lot* of other endpoints we'd probably want events for, but I wanted to see what the structure of PKI events should look like.

I made some opinionated choices here, especially with regard to metadata:

- Metadata should `issuer_ref` if it is present in the URL
- Metadata should include major, non-sensitive data entries from the response
- Metadata should include any non-sensitive data from the request necessary to understand what this event is related to
- *But*, we should try to remove truly redundant, large fields, like not including `certificate` and `issuer` in the root generating event since they will be the same.
- `data_path` should point to the relevant (e.g., whatever was signed or issued)

Next steps for this would be:

- identify what other endpoints or activities we want to generate events for
- implement those events
- document events that generated
- add tests

Here are examples of what the events look like for these:

```json
{
    "id": "1b06a3ba-dd24-2cd8-3ca9-244b911fc8c8",
    "source": "https://vaultproject.io/",
    "specversion": "1.0",
    "type": "*",
    "data": {
        "event": {
            "id": "1b06a3ba-dd24-2cd8-3ca9-244b911fc8c8",
            "metadata": {
                "certificate": "-----BEGIN CERTIFICATE-----\nMIIDsDCCApigAwIBAgIUDhYqN6206hmdaQMfi33QO9tyL4YwDQYJKoZIhvcNAQEL\nBQAwGTEXMBUGA1UEAxMObXktd2Vic2l0ZS5jb20wHhcNMjMwOTE5MjEwMzA2WhcN\nMjMxMDIxMjEwMzM2WjAZMRcwFQYDVQQDEw5teS13ZWJzaXRlLmNvbTCCASIwDQYJ\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBAM8wAEEj/UnqFyjAM6tFQvRwuKiUUBNG\nFy+bHjv+MLuYjJ1tcqg2OLiDo9OUJ328mCfJmpDbRC3XrEtBBvdQkBDlwjSiUunD\niEG0qEs+rGALlM89GhIyY7waQjEHQsKboSfFMzs5BqDEICJLgqz8tx+capBb3ikA\n3wVCHFtj68s4jru+tUfByUMLNjwocEERNVvy73telQE54PXAfWxwX54JVnAz5tlZ\nJs4qx9QRD0d5OJQ0XjnNxkQCPlve+crEIckqQjfaeNeSjxoTq3+1f7T3DpPnY3La\nKr8RFFA8Sqh5z/fEJEIEri5u0C02TzLW9k6UvVw8f9Vaj3u6nDnnCoECAwEAAaOB\n7zCB7DAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQU\nQWFeSR9CgVn90hGxOeJ4vfpdm9MwHwYDVR0jBBgwFoAUQWFeSR9CgVn90hGxOeJ4\nvfpdm9MwOwYIKwYBBQUHAQEELzAtMCsGCCsGAQUFBzAChh9odHRwOi8vMTI3LjAu\nMC4xOjgyMDAvdjEvcGtpL2NhMBkGA1UdEQQSMBCCDm15LXdlYnNpdGUuY29tMDEG\nA1UdHwQqMCgwJqAkoCKGIGh0dHA6Ly8xMjcuMC4wLjE6ODIwMC92MS9wa2kvY3Js\nMA0GCSqGSIb3DQEBCwUAA4IBAQBaEi40C5WDSnJ20EjDo1hogwkQBQvs448hVtMv\nLtUwU73cbKJQmuYcudAKM1YsKlyuaF7WuPrtxjQhbqvIV3pveh47B7QUfOKtOQu/\nQFOywa4X01AXNh2wjqiBoS7Y0+lom/cpDdFpsQ8Jcoryyd5Xx12EyS/d2vVrmI/V\nRpnmlnncLJtu9l/3//VS+MagDJUFKNq2pn49hTyiLsvKC+zUXBL3CTqaR2eEhISi\n3PokAwcxi1X4aJGULA0PYGOttO5sHiREy+Vtd+FzVw3JjtbZ49CY938G3iHinTpw\nGMWbkZWR0iTcdr4gdr6T1B0CmR7QERK3llqB0hnR6jhivi0C\n-----END CERTIFICATE-----",
                "common_name": "my-website.com",
                "data_path": "pki/issuer/2f02abec-13bc-f181-581f-a4d1df199a81/json",
                "expiration": "1697922216",
                "format": "pem",
                "issuer_id": "2f02abec-13bc-f181-581f-a4d1df199a81",
                "issuer_name": "",
                "key_id": "500547bf-2b74-b7e0-4461-7b88eea23306",
                "key_name": "",
                "operation": "ca-generate-root",
                "serial_number": "0e:16:2a:37:ad:b4:ea:19:9d:69:03:1f:8b:7d:d0:3b:db:72:2f:86"
            }
        },
        "event_type": "pki/ca-generate-root",
        "plugin_info": {
            "mount_class": "secret",
            "mount_accessor": "pki_73138439",
            "mount_path": "pki/",
            "plugin": "pki"
        }
    },
    "datacontentype": "application/cloudevents",
    "time": "2023-09-19T14:03:36.789316-07:00"
}
```

```json
{
    "id": "4384c3b9-2a4b-ff3a-13c0-e6f397113417",
    "source": "https://vaultproject.io/",
    "specversion": "1.0",
    "type": "*",
    "data": {
        "event": {
            "id": "4384c3b9-2a4b-ff3a-13c0-e6f397113417",
            "metadata": {
                "ca_chain": "[-----BEGIN CERTIFICATE-----\nMIIDsjCCApqgAwIBAgIUEaLzr4/4pKvD/+q/pdT0afiDPu0wDQYJKoZIhvcNAQEL\nBQAwGTEXMBUGA1UEAxMObXktd2Vic2l0ZS5jb20wHhcNMjMwOTE5MjEwMzA5WhcN\nMjMxMDIxMjEwMzM5WjAaMRgwFgYDVQQDEw9zdWIuZXhhbXBsZS5jb20wggEiMA0G\nCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDluow5kClY/QFaED1vU31TfJSZT1G0\n0QWV1sZYBpK2fvbklOpnxcxJRij/gWxYZUXs6N+RvXupxeArtlYIvETq4oWNcNlN\nERCCUARiw+YHPfswfIIXwOfOCtG85XIg73Vch6T+fllje3bToYmIxmOCwbl5I9ie\nUGk1gElt5cEz+hwg4uwoNtfRbBy8QigbGbRD6Nmubf8u+AzOHDGEQqntV/FGC3NE\njW0JX2WI4SE0N/XdBaIgRMOo7lBTerNFKrlX7c1bZH2WpDGw1jOWB9B+8IDzzSZ7\nPG0v+774mOC0IntOhp7lkB53AyfxCsr8clUhP3O/mAwtIvJzp17hZwBDAgMBAAGj\ngfAwge0wDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYE\nFPLpjpZd5VNfFLKlnvQPdw4flyV1MB8GA1UdIwQYMBaAFCcnK3QqdW02md95ZuWf\nd656XSuLMDsGCCsGAQUFBwEBBC8wLTArBggrBgEFBQcwAoYfaHR0cDovLzEyNy4w\nLjAuMTo4MjAwL3YxL3BraS9jYTAaBgNVHREEEzARgg9zdWIuZXhhbXBsZS5jb20w\nMQYDVR0fBCowKDAmoCSgIoYgaHR0cDovLzEyNy4wLjAuMTo4MjAwL3YxL3BraS9j\ncmwwDQYJKoZIhvcNAQELBQADggEBAEtd0ICsJVjX+q6Jv1LIUk+A9IYdWSwVh9aW\n9LoggwpIQVww6SVsHjXHj+34C28daq5lMuVvP8IThHJN5jmYZ4/Y+Hab1O1MTL+j\nZ27oWmUtmuqQRATVZFYeOAicm/lAzC35LfU9LP9n+DnsQetIi6ZnsjjfQHvFKmGw\n8iaud53dK2LhCveDF2syG8uvwMpUVoWo6F23CyL+yxSIqmGyKMQD6sQssrCVf7cH\niR004+k4HX5OrKhqOAbXPxw8Uup9yrBqN6XkD8nNapIAtUrjJneL+iE3FSAPxCri\nneB7el7xzE09OkX47YC+0D1n+Y431SbBEyJssicHjdPqTccb6yM=\n-----END CERTIFICATE----- -----BEGIN CERTIFICATE-----\nMIIDPjCCAiagAwIBAgIUFuhcy5b9BqAuRCzJArruXQuMaAAwDQYJKoZIhvcNAQEL\nBQAwGTEXMBUGA1UEAxMObXktd2Vic2l0ZS5jb20wHhcNMjMwOTE5MjEwMjQ4WhcN\nMjMxMDIxMjEwMzE3WjAZMRcwFQYDVQQDEw5teS13ZWJzaXRlLmNvbTCCASIwDQYJ\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPdtVhpzHuegX0IwxqdoT/89WyV24e1W\ngKsNO0kcDO44qT9ZnXTsAr1hgjmDWcI6CmdkOt9aAMLunKlw+WdCDe4i4hKPBWkh\ns3QXjxnkekuhyPs8b2/eQTu1KwRDFmEsTUHdnFXb3y/NIuO4hkxqOIyS0nupect9\n0YIk6mfQU/Bt0tHHlpcBD+JX6N4Jx2e6bzr2nB++LPjq9lDQQorgjKtJt7YRA9NH\n0RPSyMLHVI3rV6/luXVftoVbNgikDN6KC3gximTYGWbbbqiMX3nP9xsKUdXAcOXt\nlV+P3HSLdmJpL9VQDVj+AHzYUAVKG3M7+i30LYmZrlvf1ZuPY0c4JEMCAwEAAaN+\nMHwwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFCcn\nK3QqdW02md95ZuWfd656XSuLMB8GA1UdIwQYMBaAFCcnK3QqdW02md95ZuWfd656\nXSuLMBkGA1UdEQQSMBCCDm15LXdlYnNpdGUuY29tMA0GCSqGSIb3DQEBCwUAA4IB\nAQAWj4Zx4gySy39AvjKxaKxzgPk5Swwpv/1WRMmwtqfgKYCk/i5Uvf6GNGJ69dX2\nrLCCvh3YMGVW3eiqyoYC+eixAB2eGMOmkZIsQkbqsKrrIYtqdEkMLnkMkpNWcdmt\n9E9gLbNw5bspZMdNQkLjrH6/TvtvXZZ2NzWEBKZEsFtidayUn0wTTaEpx+vZ+ux0\nCSHKW0cz3tb2frdZFSPCTyAMKsdEMAGH+Jz+OkcUJJT88sBOrJ3QOU6xps+osr84\nScTp5OM1BnnSsbi+OJpo144IOCCnLIylAGgOr4ihrZmZ22vnj74MTV4euHy2hwm4\nG80mU9aWGtx94+FcoJqnek4r\n-----END CERTIFICATE-----]",
                "certificate": "-----BEGIN CERTIFICATE-----\nMIIDsjCCApqgAwIBAgIUEaLzr4/4pKvD/+q/pdT0afiDPu0wDQYJKoZIhvcNAQEL\nBQAwGTEXMBUGA1UEAxMObXktd2Vic2l0ZS5jb20wHhcNMjMwOTE5MjEwMzA5WhcN\nMjMxMDIxMjEwMzM5WjAaMRgwFgYDVQQDEw9zdWIuZXhhbXBsZS5jb20wggEiMA0G\nCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDluow5kClY/QFaED1vU31TfJSZT1G0\n0QWV1sZYBpK2fvbklOpnxcxJRij/gWxYZUXs6N+RvXupxeArtlYIvETq4oWNcNlN\nERCCUARiw+YHPfswfIIXwOfOCtG85XIg73Vch6T+fllje3bToYmIxmOCwbl5I9ie\nUGk1gElt5cEz+hwg4uwoNtfRbBy8QigbGbRD6Nmubf8u+AzOHDGEQqntV/FGC3NE\njW0JX2WI4SE0N/XdBaIgRMOo7lBTerNFKrlX7c1bZH2WpDGw1jOWB9B+8IDzzSZ7\nPG0v+774mOC0IntOhp7lkB53AyfxCsr8clUhP3O/mAwtIvJzp17hZwBDAgMBAAGj\ngfAwge0wDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYE\nFPLpjpZd5VNfFLKlnvQPdw4flyV1MB8GA1UdIwQYMBaAFCcnK3QqdW02md95ZuWf\nd656XSuLMDsGCCsGAQUFBwEBBC8wLTArBggrBgEFBQcwAoYfaHR0cDovLzEyNy4w\nLjAuMTo4MjAwL3YxL3BraS9jYTAaBgNVHREEEzARgg9zdWIuZXhhbXBsZS5jb20w\nMQYDVR0fBCowKDAmoCSgIoYgaHR0cDovLzEyNy4wLjAuMTo4MjAwL3YxL3BraS9j\ncmwwDQYJKoZIhvcNAQELBQADggEBAEtd0ICsJVjX+q6Jv1LIUk+A9IYdWSwVh9aW\n9LoggwpIQVww6SVsHjXHj+34C28daq5lMuVvP8IThHJN5jmYZ4/Y+Hab1O1MTL+j\nZ27oWmUtmuqQRATVZFYeOAicm/lAzC35LfU9LP9n+DnsQetIi6ZnsjjfQHvFKmGw\n8iaud53dK2LhCveDF2syG8uvwMpUVoWo6F23CyL+yxSIqmGyKMQD6sQssrCVf7cH\niR004+k4HX5OrKhqOAbXPxw8Uup9yrBqN6XkD8nNapIAtUrjJneL+iE3FSAPxCri\nneB7el7xzE09OkX47YC+0D1n+Y431SbBEyJssicHjdPqTccb6yM=\n-----END CERTIFICATE-----",
                "data_path": "pki/cert/11-a2-f3-af-8f-f8-a4-ab-c3-ff-ea-bf-a5-d4-f4-69-f8-83-3e-ed",
                "expiration": "1697922219",
                "format": "pem",
                "issuer_ref": "default",
                "issuer_serial_number": "16:e8:5c:cb:96:fd:06:a0:2e:44:2c:c9:02:ba:ee:5d:0b:8c:68:00",
                "issuing_ca": "-----BEGIN CERTIFICATE-----\nMIIDPjCCAiagAwIBAgIUFuhcy5b9BqAuRCzJArruXQuMaAAwDQYJKoZIhvcNAQEL\nBQAwGTEXMBUGA1UEAxMObXktd2Vic2l0ZS5jb20wHhcNMjMwOTE5MjEwMjQ4WhcN\nMjMxMDIxMjEwMzE3WjAZMRcwFQYDVQQDEw5teS13ZWJzaXRlLmNvbTCCASIwDQYJ\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPdtVhpzHuegX0IwxqdoT/89WyV24e1W\ngKsNO0kcDO44qT9ZnXTsAr1hgjmDWcI6CmdkOt9aAMLunKlw+WdCDe4i4hKPBWkh\ns3QXjxnkekuhyPs8b2/eQTu1KwRDFmEsTUHdnFXb3y/NIuO4hkxqOIyS0nupect9\n0YIk6mfQU/Bt0tHHlpcBD+JX6N4Jx2e6bzr2nB++LPjq9lDQQorgjKtJt7YRA9NH\n0RPSyMLHVI3rV6/luXVftoVbNgikDN6KC3gximTYGWbbbqiMX3nP9xsKUdXAcOXt\nlV+P3HSLdmJpL9VQDVj+AHzYUAVKG3M7+i30LYmZrlvf1ZuPY0c4JEMCAwEAAaN+\nMHwwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFCcn\nK3QqdW02md95ZuWfd656XSuLMB8GA1UdIwQYMBaAFCcnK3QqdW02md95ZuWfd656\nXSuLMBkGA1UdEQQSMBCCDm15LXdlYnNpdGUuY29tMA0GCSqGSIb3DQEBCwUAA4IB\nAQAWj4Zx4gySy39AvjKxaKxzgPk5Swwpv/1WRMmwtqfgKYCk/i5Uvf6GNGJ69dX2\nrLCCvh3YMGVW3eiqyoYC+eixAB2eGMOmkZIsQkbqsKrrIYtqdEkMLnkMkpNWcdmt\n9E9gLbNw5bspZMdNQkLjrH6/TvtvXZZ2NzWEBKZEsFtidayUn0wTTaEpx+vZ+ux0\nCSHKW0cz3tb2frdZFSPCTyAMKsdEMAGH+Jz+OkcUJJT88sBOrJ3QOU6xps+osr84\nScTp5OM1BnnSsbi+OJpo144IOCCnLIylAGgOr4ihrZmZ22vnj74MTV4euHy2hwm4\nG80mU9aWGtx94+FcoJqnek4r\n-----END CERTIFICATE-----",
                "operation": "issuer-sign-intermediate",
                "serial_number": "11:a2:f3:af:8f:f8:a4:ab:c3:ff:ea:bf:a5:d4:f4:69:f8:83:3e:ed"
            }
        },
        "event_type": "pki/issuer-sign-intermediate",
        "plugin_info": {
            "mount_class": "secret",
            "mount_accessor": "pki_73138439",
            "mount_path": "pki/",
            "plugin": "pki"
        }
    },
    "datacontentype": "application/cloudevents",
    "time": "2023-09-19T14:03:39.085358-07:00"
}
```