### PR TITLE
Fix OpenAPI OperationID for sys/decode-token

### DIFF
--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -482,7 +482,8 @@ func (b *SystemBackend) configPaths() []*framework.Path {
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback: b.handleGenerateRootDecodeTokenUpdate,
 					DisplayAttrs: &framework.DisplayAttributes{
-						OperationVerb: "decode",
+						OperationVerb:   "decode",
+						OperationSuffix: "token",
 					},
 					Summary: "Decodes the encoded token with the otp.",
 					Responses: map[int][]framework.Response{


### PR DESCRIPTION
As mentioned in https://github.com/hashicorp/vault-client-go/pull/188#issuecomment-1626167085, this will change the OpenAPI operation ID to `decode-token` and the corresponding generated method name to `DecodeToken(...)`.