### PR TITLE
secrets/db: add rotation error path test

### DIFF
--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -17,12 +17,10 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/go-hclog"
-	mongodbatlas "github.com/hashicorp/vault-plugin-database-mongodbatlas"
 	"github.com/hashicorp/vault/helper/builtinplugins"
 	"github.com/hashicorp/vault/helper/namespace"
 	postgreshelper "github.com/hashicorp/vault/helper/testhelpers/postgresql"
 	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/plugins/database/mongodb"
 	"github.com/hashicorp/vault/plugins/database/postgresql"
 	v4 "github.com/hashicorp/vault/sdk/database/dbplugin"
 	v5 "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
@@ -54,7 +52,7 @@ func getClusterPostgresDB(t *testing.T) (*vault.TestCluster, logical.SystemView)
 	os.Setenv(pluginutil.PluginCACertPEMEnv, cluster.CACertPEMFile)
 
 	sys := vault.TestDynamicSystemView(cores[0].Core, nil)
-	vault.TestAddTestPlugin(t, cores[0].Core, "postgresql-database-plugin", consts.PluginTypeDatabase, "", "TestBackend_PluginMain_Postgres", []string{}, "")
+	vault.TestAddTestPlugin(t, cores[0].Core, "postgresql-database-plugin", consts.PluginTypeDatabase, "", "TestBackend_PluginMain_PostgresMultiplexed", []string{}, "")
 
 	return cluster, sys
 }
@@ -81,67 +79,12 @@ func getCluster(t *testing.T) (*vault.TestCluster, logical.SystemView) {
 	return cluster, sys
 }
 
-func TestBackend_PluginMain_Postgres(t *testing.T) {
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
-		return
-	}
-
-	dbType, err := postgresql.New()
-	if err != nil {
-		t.Fatalf("Failed to initialize postgres: %s", err)
-	}
-
-	v5.Serve(dbType.(v5.Database))
-}
-
 func TestBackend_PluginMain_PostgresMultiplexed(t *testing.T) {
 	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
 	v5.ServeMultiplex(postgresql.New)
-}
-
-func TestBackend_PluginMain_Mongo(t *testing.T) {
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
-		return
-	}
-
-	dbType, err := mongodb.New()
-	if err != nil {
-		t.Fatalf("Failed to initialize mongodb: %s", err)
-	}
-
-	v5.Serve(dbType.(v5.Database))
-}
-
-func TestBackend_PluginMain_MongoMultiplexed(t *testing.T) {
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
-		return
-	}
-
-	v5.ServeMultiplex(mongodb.New)
-}
-
-func TestBackend_PluginMain_MongoAtlas(t *testing.T) {
-	if os.Getenv(pluginutil.PluginUnwrapTokenEnv) == "" {
-		return
-	}
-
-	dbType, err := mongodbatlas.New()
-	if err != nil {
-		t.Fatalf("Failed to initialize mongodbatlas: %s", err)
-	}
-
-	v5.Serve(dbType.(v5.Database))
-}
-
-func TestBackend_PluginMain_MongoAtlasMultiplexed(t *testing.T) {
-	if os.Getenv(pluginutil.PluginUnwrapTokenEnv) == "" {
-		return
-	}
-
-	v5.ServeMultiplex(mongodbatlas.New)
 }
 
 func TestBackend_RoleUpgrade(t *testing.T) {

--- a/builtin/logical/database/path_config_connection_test.go
+++ b/builtin/logical/database/path_config_connection_test.go
@@ -127,7 +127,7 @@ func TestWriteConfig_PluginVersionInStorage(t *testing.T) {
 }
 
 func TestWriteConfig_HelpfulErrorMessageWhenBuiltinOverridden(t *testing.T) {
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	t.Cleanup(cluster.Cleanup)
 
 	config := logical.TestBackendConfig()

--- a/builtin/logical/database/path_roles_test.go
+++ b/builtin/logical/database/path_roles_test.go
@@ -205,7 +205,7 @@ func TestBackend_Roles_CredentialTypes(t *testing.T) {
 }
 
 func TestBackend_StaticRole_Config(t *testing.T) {
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
 	config := logical.TestBackendConfig()
@@ -470,7 +470,7 @@ func TestBackend_StaticRole_Config(t *testing.T) {
 }
 
 func TestBackend_StaticRole_ReadCreds(t *testing.T) {
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
 	config := logical.TestBackendConfig()
@@ -650,7 +650,7 @@ func TestBackend_StaticRole_ReadCreds(t *testing.T) {
 }
 
 func TestBackend_StaticRole_Updates(t *testing.T) {
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
 	config := logical.TestBackendConfig()
@@ -949,7 +949,7 @@ func TestBackend_StaticRole_Updates_RotationSchedule(t *testing.T) {
 }
 
 func TestBackend_StaticRole_Role_name_check(t *testing.T) {
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
 	config := logical.TestBackendConfig()

--- a/builtin/logical/database/rollback_test.go
+++ b/builtin/logical/database/rollback_test.go
@@ -27,7 +27,7 @@ const (
 //   - Password has been altered on the database
 //   - Password has not been updated in storage
 func TestBackend_RotateRootCredentials_WAL_rollback(t *testing.T) {
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
 	config := logical.TestBackendConfig()
@@ -170,7 +170,7 @@ func TestBackend_RotateRootCredentials_WAL_rollback(t *testing.T) {
 //   - Password has not been altered on the database
 //   - Password has not been updated in storage
 func TestBackend_RotateRootCredentials_WAL_no_rollback_1(t *testing.T) {
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
 	config := logical.TestBackendConfig()
@@ -274,7 +274,7 @@ func TestBackend_RotateRootCredentials_WAL_no_rollback_1(t *testing.T) {
 //   - Password has been altered on the database
 //   - Password has been updated in storage
 func TestBackend_RotateRootCredentials_WAL_no_rollback_2(t *testing.T) {
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
 	config := logical.TestBackendConfig()

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -246,6 +246,9 @@ func TestBackend_StaticRole_Rotation_basic(t *testing.T) {
 	}
 }
 
+// TestBackend_StaticRole_Rotation_Schedule_ErrorRecover tests that failed
+// rotations can successfully recover and that they do not occur outside of a
+// rotation window.
 func TestBackend_StaticRole_Rotation_Schedule_ErrorRecover(t *testing.T) {
 	cluster, sys := getClusterPostgresDB(t)
 	t.Cleanup(cluster.Cleanup)

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -36,12 +36,12 @@ import (
 const (
 	dbUser                       = "vaultstatictest"
 	dbUserDefaultPassword        = "password"
-	testMinRotationWindowSeconds = 10
+	testMinRotationWindowSeconds = 5
 	testScheduleParseOptions     = cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow
 )
 
 func TestBackend_StaticRole_Rotation_basic(t *testing.T) {
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
 	config := logical.TestBackendConfig()
@@ -246,11 +246,172 @@ func TestBackend_StaticRole_Rotation_basic(t *testing.T) {
 	}
 }
 
+func TestBackend_StaticRole_Rotation_Schedule_ErrorRecover(t *testing.T) {
+	cluster, sys := getClusterPostgresDB(t)
+	t.Cleanup(cluster.Cleanup)
+
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+	config.System = sys
+
+	lb, err := Factory(context.Background(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, ok := lb.(*databaseBackend)
+	if !ok {
+		t.Fatal("could not convert to db backend")
+	}
+	defer b.Cleanup(context.Background())
+
+	b.schedule = &TestSchedule{}
+
+	_, cleanup, connURL, _ := postgreshelper.PrepareTestContainerRunner(t, "")
+	t.Cleanup(cleanup)
+
+	// create the database user
+	createTestPGUser(t, connURL, dbUser, dbUserDefaultPassword, testRoleStaticCreate)
+	verifyPgConn(t, dbUser, dbUserDefaultPassword, connURL)
+
+	// Configure a connection
+	connectionData := map[string]interface{}{
+		"connection_url":    connURL,
+		"plugin_name":       "postgresql-database-plugin",
+		"verify_connection": false,
+		"allowed_roles":     []string{"*"},
+		"name":              "plugin-test",
+	}
+	configureConnection(t, b, config.StorageView, connectionData)
+
+	// create the role that will rotate every 10th second
+	// rotations will not be allowed after 5s
+	data := map[string]interface{}{
+		"name":                "plugin-role-test",
+		"db_name":             "plugin-test",
+		"rotation_statements": testRoleStaticUpdate,
+		"rotation_schedule":   "*/10 * * * * *",
+		"rotation_window":     "5s",
+		"username":            dbUser,
+	}
+	req := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "static-roles/plugin-role-test",
+		Storage:   config.StorageView,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	// Read the creds
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "static-creds/plugin-role-test",
+		Storage:   config.StorageView,
+	}
+	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	username := resp.Data["username"].(string)
+	originalPassword := resp.Data["password"].(string)
+	if username == "" || originalPassword == "" {
+		t.Fatalf("empty username (%s) or password (%s)", username, originalPassword)
+	}
+
+	// Verify username/password
+	verifyPgConn(t, dbUser, originalPassword, connURL)
+
+	// Set invalid connection URL so we fail to rotate
+	connectionData["connection_url"] = strings.Replace(connURL, "postgres:secret", "postgres:foo", 1)
+	configureConnection(t, b, config.StorageView, connectionData)
+
+	// determine next rotation schedules based on current test time
+	rotationSchedule := data["rotation_schedule"].(string)
+	schedule, err := b.schedule.Parse(rotationSchedule)
+	if err != nil {
+		t.Fatalf("could not parse rotation_schedule: %s", err)
+	}
+	next := schedule.Next(time.Now()) // the next rotation time we expect
+	time.Sleep(next.Sub(time.Now()))
+
+	// Re-Read the creds after schedule expiration
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "static-creds/plugin-role-test",
+		Storage:   config.StorageView,
+	}
+	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	checkPassword := resp.Data["password"].(string)
+	if originalPassword != checkPassword {
+		// should match because rotations should be failing
+		t.Fatalf("expected passwords to match, got (%s)", checkPassword)
+	}
+
+	// wait until we are outside the rotation window so that rotations will not occur
+	next = schedule.Next(time.Now()) // the next rotation time after now
+	time.Sleep(next.Add(time.Second * 6).Sub(time.Now()))
+
+	// reset to valid connection URL so we do not fail to rotate anymore
+	connectionData["connection_url"] = connURL
+	configureConnection(t, b, config.StorageView, connectionData)
+
+	// we are outside a rotation window, Re-Read the creds
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "static-creds/plugin-role-test",
+		Storage:   config.StorageView,
+	}
+	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	checkPassword = resp.Data["password"].(string)
+	if originalPassword != checkPassword {
+		// should match because rotations should not occur outside the rotation window
+		t.Fatalf("expected passwords to match, got (%s)", checkPassword)
+	}
+
+	// Verify new username/password
+	verifyPgConn(t, username, checkPassword, connURL)
+
+	// sleep until the next rotation time with a buffer to ensure we had time to rotate
+	next = schedule.Next(time.Now()) // the next rotation time we expect
+	time.Sleep(next.Add(time.Second * 5).Sub(time.Now()))
+
+	// Re-Read the creds
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "static-creds/plugin-role-test",
+		Storage:   config.StorageView,
+	}
+	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	checkPassword = resp.Data["password"].(string)
+	if originalPassword == checkPassword {
+		// should differ because we slept until the next rotation time
+		t.Fatalf("expected passwords to differ, got (%s)", checkPassword)
+	}
+
+	// Verify new username/password
+	verifyPgConn(t, username, checkPassword, connURL)
+}
+
 // Sanity check to make sure we don't allow an attempt of rotating credentials
 // for non-static accounts, which doesn't make sense anyway, but doesn't hurt to
 // verify we return an error
 func TestBackend_StaticRole_Rotation_NonStaticError(t *testing.T) {
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
 	config := logical.TestBackendConfig()
@@ -354,7 +515,7 @@ func TestBackend_StaticRole_Rotation_NonStaticError(t *testing.T) {
 }
 
 func TestBackend_StaticRole_Rotation_Revoke_user(t *testing.T) {
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
 	config := logical.TestBackendConfig()
@@ -532,7 +693,7 @@ func verifyPgConn(t *testing.T, username, password, connURL string) {
 //
 // First scenario, WAL contains a role name that does not exist.
 func TestBackend_StaticRole_Rotation_QueueWAL_discard_role_not_found(t *testing.T) {
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
 	ctx := context.Background()
@@ -573,7 +734,7 @@ func TestBackend_StaticRole_Rotation_QueueWAL_discard_role_not_found(t *testing.
 // Second scenario, WAL contains a role name that does exist, but the role's
 // LastVaultRotation is greater than the WAL has
 func TestBackend_StaticRole_Rotation_QueueWAL_discard_role_newer_rotation_date(t *testing.T) {
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
 	ctx := context.Background()
@@ -846,7 +1007,7 @@ func testBackend_StaticRole_Rotations(t *testing.T, createUser userCreator, opts
 		}
 	}()
 
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
 	config := logical.TestBackendConfig()
@@ -1010,7 +1171,7 @@ type createUserCommand struct {
 
 // Demonstrates a bug fix for the credential rotation not releasing locks
 func TestBackend_StaticRole_Rotation_LockRegression(t *testing.T) {
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
 	config := logical.TestBackendConfig()
@@ -1089,7 +1250,7 @@ func TestBackend_StaticRole_Rotation_LockRegression(t *testing.T) {
 }
 
 func TestBackend_StaticRole_Rotation_Invalid_Role(t *testing.T) {
-	cluster, sys := getCluster(t)
+	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
 	config := logical.TestBackendConfig()
@@ -1535,6 +1696,19 @@ func capturePasswords(t *testing.T, b logical.Backend, config *logical.BackendCo
 	}
 
 	return pws
+}
+
+func configureConnection(t *testing.T, b *databaseBackend, s logical.Storage, data map[string]interface{}) {
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/" + data["name"].(string),
+		Storage:   s,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
 }
 
 func newBoolPtr(b bool) *bool {

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -269,7 +269,7 @@ func TestBackend_StaticRole_Rotation_Schedule_ErrorRecover(t *testing.T) {
 
 	b.schedule = &TestSchedule{}
 
-	_, cleanup, connURL, _ := postgreshelper.PrepareTestContainerRunner(t, "")
+	cleanup, connURL := postgreshelper.PrepareTestContainer(t, "")
 	t.Cleanup(cleanup)
 
 	// create the database user

--- a/helper/testhelpers/postgresql/postgresqlhelper.go
+++ b/helper/testhelpers/postgresql/postgresqlhelper.go
@@ -15,14 +15,18 @@ import (
 )
 
 func PrepareTestContainer(t *testing.T, version string) (func(), string) {
+	_, cleanup, url, _ := PrepareTestContainerRunner(t, version)
+
+	return cleanup, url
+}
+
+func PrepareTestContainerRunner(t *testing.T, version string) (*docker.Runner, func(), string, string) {
 	env := []string{
 		"POSTGRES_PASSWORD=secret",
 		"POSTGRES_DB=database",
 	}
 
-	_, cleanup, url, _ := prepareTestContainer(t, "postgres", "docker.mirror.hashicorp.services/postgres", version, "secret", true, false, false, env)
-
-	return cleanup, url
+	return prepareTestContainer(t, "postgres", "docker.mirror.hashicorp.services/postgres", version, "secret", true, false, false, env)
 }
 
 // PrepareTestContainerWithVaultUser will setup a test container with a Vault

--- a/helper/testhelpers/postgresql/postgresqlhelper.go
+++ b/helper/testhelpers/postgresql/postgresqlhelper.go
@@ -15,18 +15,14 @@ import (
 )
 
 func PrepareTestContainer(t *testing.T, version string) (func(), string) {
-	_, cleanup, url, _ := PrepareTestContainerRunner(t, version)
-
-	return cleanup, url
-}
-
-func PrepareTestContainerRunner(t *testing.T, version string) (*docker.Runner, func(), string, string) {
 	env := []string{
 		"POSTGRES_PASSWORD=secret",
 		"POSTGRES_DB=database",
 	}
 
-	return prepareTestContainer(t, "postgres", "docker.mirror.hashicorp.services/postgres", version, "secret", true, false, false, env)
+	_, cleanup, url, _ := prepareTestContainer(t, "postgres", "docker.mirror.hashicorp.services/postgres", version, "secret", true, false, false, env)
+
+	return cleanup, url
 }
 
 // PrepareTestContainerWithVaultUser will setup a test container with a Vault


### PR DESCRIPTION
We add a test to verify that failed rotations can successfully recover and that they do not occur outside of a rotation window. Additionally, we remove registering some external plugins in `getCluster()` that shaves off about 5 minutes from the database package tests.