### PR TITLE
Remove an extremely noisy log line

### DIFF
--- a/vault/eventbus/bus.go
+++ b/vault/eventbus/bus.go
@@ -127,7 +127,6 @@ func (bus *EventBus) SendEventInternal(ctx context.Context, ns *namespace.Namesp
 		EventType:  string(eventType),
 		PluginInfo: pluginInfo,
 	}
-	bus.logger.Debug("Sending event", "event", eventReceived)
 
 	// We can't easily know when the SendEvent is complete, so we can't call the cancel function.
 	// But, it is called automatically after bus.timeout, so there won't be any leak as long as bus.timeout is not too long.


### PR DESCRIPTION
We're now generating 300MB log files for some test runs, making the UI difficult to use.  In one that I looked at, 80% of the lines in the file (450k/564k) were this one.