### PR TITLE
Fix core not being unsealed in kv test

### DIFF
--- a/vault/external_tests/api/kv_test.go
+++ b/vault/external_tests/api/kv_test.go
@@ -90,6 +90,7 @@ func TestKVV2Get_RequestForwarding(t *testing.T) {
 	testhelpers.WaitForActiveNodeAndStandbys(t, cluster)
 	standbys := testhelpers.DeriveStandbyCores(t, cluster)
 	standby := standbys[0].Client
+	testhelpers.EnsureCoresUnsealed(t, cluster)
 
 	// mount the KVv2 backend
 	err := client.Sys().Mount(v2MountPath, &api.MountInput{


### PR DESCRIPTION
The mounting failed due to Vault being sealed, so an `EnsureUnsealed` should do the trick.

See here: https://github.com/hashicorp/vault-enterprise/actions/runs/6249822541/job/16967589324

```
FAIL vault/external_tests/api.TestKVV2Get_RequestForwarding (5.21s)
      kv_test.go:99: Error making API request.
          
          URL: POST https://127.0.0.1:37157/v1/sys/mounts/secret-v2
          Code: 503. Errors:
          
          * Vault is sealed
```