### PR TITLE
Remove global client assignment in KV tests

### DIFF
--- a/vault/external_tests/api/kv_helpers_test.go
+++ b/vault/external_tests/api/kv_helpers_test.go
@@ -23,18 +23,15 @@ const (
 	secretPath  = "my-secret"
 )
 
-var (
-	client     *api.Client
-	secretData = map[string]interface{}{
-		"foo": "bar",
-	}
-)
+var secretData = map[string]interface{}{
+	"foo": "bar",
+}
 
 // setupKVv2Test creates the secret that will be used in each KV v2 subtest. It
 // returns a function (that should be deferred whenever setupKVv2Test is called)
 // which will perform the cleanup of all existing versions of the secret, as
 // well as the secret that was written for comparison.
-func setupKVv2Test(t *testing.T) (func(t *testing.T), *api.KVSecret) {
+func setupKVv2Test(t *testing.T, client *api.Client) (func(t *testing.T), *api.KVSecret) {
 	writtenSecret, err := client.KVv2(v2MountPath).Put(context.Background(), secretPath, secretData)
 	if err != nil {
 		t.Fatal(err)
@@ -71,7 +68,7 @@ func TestKVHelpers(t *testing.T) {
 
 	cores := cluster.Cores
 	core := cores[0].Core
-	client = cluster.Cores[0].Client
+	client := cluster.Cores[0].Client
 	vault.TestWaitActive(t, core)
 
 	// mount the KVv2 backend
@@ -120,7 +117,7 @@ func TestKVHelpers(t *testing.T) {
 
 	//// v2 ////
 	t.Run("kv v2: get data and full metadata", func(t *testing.T) {
-		teardownTest, originalSecret := setupKVv2Test(t)
+		teardownTest, originalSecret := setupKVv2Test(t, client)
 		defer teardownTest(t)
 
 		secret, err := client.KVv2(v2MountPath).Get(context.Background(), secretPath)
@@ -145,7 +142,7 @@ func TestKVHelpers(t *testing.T) {
 	})
 
 	t.Run("kv v2: get secret that does not exist", func(t *testing.T) {
-		teardownTest, _ := setupKVv2Test(t)
+		teardownTest, _ := setupKVv2Test(t, client)
 		defer teardownTest(t)
 
 		_, err = client.KVv2(v2MountPath).Get(context.Background(), "does/not/exist")
@@ -165,7 +162,7 @@ func TestKVHelpers(t *testing.T) {
 	})
 
 	t.Run("kv v2: multiple versions", func(t *testing.T) {
-		teardownTest, _ := setupKVv2Test(t)
+		teardownTest, _ := setupKVv2Test(t, client)
 		defer teardownTest(t)
 
 		// create a second version
@@ -189,7 +186,7 @@ func TestKVHelpers(t *testing.T) {
 	})
 
 	t.Run("kv v2: delete and undelete", func(t *testing.T) {
-		teardownTest, _ := setupKVv2Test(t)
+		teardownTest, _ := setupKVv2Test(t, client)
 		defer teardownTest(t)
 
 		// create a second version
@@ -244,7 +241,7 @@ func TestKVHelpers(t *testing.T) {
 	})
 
 	t.Run("kv v2: destroy", func(t *testing.T) {
-		teardownTest, _ := setupKVv2Test(t)
+		teardownTest, _ := setupKVv2Test(t, client)
 		defer teardownTest(t)
 
 		err = client.KVv2(v2MountPath).Destroy(context.Background(), secretPath, []int{1})
@@ -263,7 +260,7 @@ func TestKVHelpers(t *testing.T) {
 	})
 
 	t.Run("kv v2: use named functional options and generic WithOption", func(t *testing.T) {
-		teardownTest, _ := setupKVv2Test(t)
+		teardownTest, _ := setupKVv2Test(t, client)
 		defer teardownTest(t)
 
 		// check that KVOption works
@@ -287,7 +284,7 @@ func TestKVHelpers(t *testing.T) {
 	})
 
 	t.Run("kv v2: patch", func(t *testing.T) {
-		teardownTest, _ := setupKVv2Test(t)
+		teardownTest, _ := setupKVv2Test(t, client)
 		defer teardownTest(t)
 
 		// WithMergeMethod Patch (implicit)
@@ -412,7 +409,7 @@ func TestKVHelpers(t *testing.T) {
 	})
 
 	t.Run("kv v2: roll back to an old version", func(t *testing.T) {
-		teardownTest, _ := setupKVv2Test(t)
+		teardownTest, _ := setupKVv2Test(t, client)
 		defer teardownTest(t)
 
 		// create a second version
@@ -461,7 +458,7 @@ func TestKVHelpers(t *testing.T) {
 	})
 
 	t.Run("kv v2: delete all versions of a secret", func(t *testing.T) {
-		teardownTest, _ := setupKVv2Test(t)
+		teardownTest, _ := setupKVv2Test(t, client)
 		defer teardownTest(t)
 
 		// create a second version
@@ -516,7 +513,7 @@ func TestKVHelpers(t *testing.T) {
 	})
 
 	t.Run("kv v2: put and patch metadata", func(t *testing.T) {
-		teardownTest, _ := setupKVv2Test(t)
+		teardownTest, _ := setupKVv2Test(t, client)
 		defer teardownTest(t)
 
 		md, err := client.KVv2(v2MountPath).GetMetadata(context.Background(), secretPath)
@@ -588,7 +585,7 @@ func TestKVHelpers(t *testing.T) {
 	})
 
 	t.Run("kv v2: patch with explicit zero values", func(t *testing.T) {
-		teardownTest, _ := setupKVv2Test(t)
+		teardownTest, _ := setupKVv2Test(t, client)
 		defer teardownTest(t)
 
 		// now let's do another patch to test the "explicit zero value" use case

--- a/vault/external_tests/api/kv_test.go
+++ b/vault/external_tests/api/kv_test.go
@@ -28,7 +28,7 @@ func TestKVV1Get(t *testing.T) {
 	t.Parallel()
 
 	cluster := minimal.NewTestSoloCluster(t, nil)
-	client = cluster.Cores[0].Client
+	client := cluster.Cores[0].Client
 
 	// (the test cluster has already mounted the KVv1 backend at "secret")
 	err := client.KVv1(v1MountPath).Put(context.Background(), secretPath, secretData)
@@ -50,7 +50,7 @@ func TestKVV2Get(t *testing.T) {
 	t.Parallel()
 
 	cluster := minimal.NewTestSoloCluster(t, nil)
-	client = cluster.Cores[0].Client
+	client := cluster.Cores[0].Client
 
 	// mount the KVv2 backend
 	err := client.Sys().Mount(v2MountPath, &api.MountInput{


### PR DESCRIPTION
This was causing a little bit of foot-gunning, so it seems best to remove the global client. The tests from the package all pass locally.