### PR TITLE
Provide a better error message around initializing with multiple seals

### DIFF
--- a/command/server_sealgenerationinfo_test.go
+++ b/command/server_sealgenerationinfo_test.go
@@ -96,7 +96,7 @@ func TestMultiSealCases(t *testing.T) {
 				},
 			},
 			isErrorExpected:   true,
-			expectedErrorMsg:  "Initializing a cluster or enabling multi-seal on an existing cluster must occur with a single configured seal",
+			expectedErrorMsg:  "Initializing a cluster or enabling multi-seal on an existing cluster must occur with a single seal before adding additional seals",
 			sealHaBetaEnabled: true,
 		},
 		// none_to_multi_with_disabled_seals_with_beta
@@ -836,7 +836,7 @@ func TestMultiSealCases(t *testing.T) {
 			isRewrapped:              true,
 			hasPartiallyWrappedPaths: false,
 			isErrorExpected:          true,
-			expectedErrorMsg:         "Initializing a cluster or enabling multi-seal on an existing cluster must occur with a single configured seal",
+			expectedErrorMsg:         "Initializing a cluster or enabling multi-seal on an existing cluster must occur with a single seal before adding additional seals",
 		},
 		// have partially wrapped paths
 		{

--- a/command/server_sealgenerationinfo_test.go
+++ b/command/server_sealgenerationinfo_test.go
@@ -96,7 +96,7 @@ func TestMultiSealCases(t *testing.T) {
 				},
 			},
 			isErrorExpected:   true,
-			expectedErrorMsg:  "cannot add more than one seal",
+			expectedErrorMsg:  "Initializing a cluster or enabling multi-seal on an existing cluster must occur with a single configured seal",
 			sealHaBetaEnabled: true,
 		},
 		// none_to_multi_with_disabled_seals_with_beta
@@ -116,8 +116,23 @@ func TestMultiSealCases(t *testing.T) {
 					Disabled: true,
 				},
 			},
-			isErrorExpected:   true,
-			expectedErrorMsg:  "cannot add more than one seal",
+			expectedSealGenInfo: &seal.SealGenerationInfo{
+				Generation: 1,
+				Seals: []*configutil.KMS{
+					{
+						Type:     "pkcs11",
+						Name:     "autoSeal1",
+						Priority: 1,
+					},
+					{
+						Type:     "pkcs11",
+						Name:     "autoSeal2",
+						Priority: 2,
+						Disabled: true,
+					},
+				},
+			},
+			isErrorExpected:   false,
 			sealHaBetaEnabled: true,
 		},
 		// none_to_multi_with_disabled_seals_no_beta
@@ -758,6 +773,70 @@ func TestMultiSealCases(t *testing.T) {
 			isRewrapped:              true,
 			hasPartiallyWrappedPaths: false,
 			isErrorExpected:          false,
+		},
+		// migrate from non-beta single seal to single seal
+		{
+			name:                "none_to_single_seal",
+			existingSealGenInfo: nil,
+			newSealGenInfo: &seal.SealGenerationInfo{
+				Generation: 1,
+				Seals: []*configutil.KMS{
+					{
+						Type:     "shamir",
+						Name:     "shamir",
+						Priority: 1,
+					},
+				},
+			},
+			isRewrapped:              true,
+			hasPartiallyWrappedPaths: false,
+			isErrorExpected:          false,
+		},
+		// migrate from non-beta single seal to multi seal, with one disabled, so perform an old style migration
+		{
+			name:                "none_to_multiple_seals_one_disabled",
+			existingSealGenInfo: nil,
+			newSealGenInfo: &seal.SealGenerationInfo{
+				Generation: 1,
+				Seals: []*configutil.KMS{
+					{
+						Type: "pkcs11",
+						Name: "autoSeal",
+					},
+					{
+						Type:     "pkcs11",
+						Name:     "autoSeal",
+						Disabled: true,
+					},
+				},
+			},
+			isRewrapped:              true,
+			hasPartiallyWrappedPaths: false,
+			isErrorExpected:          false,
+		},
+		// migrate from non-beta single seal to multi seal
+		{
+			name:                "none_to_multiple_seals",
+			existingSealGenInfo: nil,
+			newSealGenInfo: &seal.SealGenerationInfo{
+				Generation: 1,
+				Seals: []*configutil.KMS{
+					{
+						Type:     "pkcs11",
+						Name:     "autoSeal1",
+						Priority: 1,
+					},
+					{
+						Type:     "pkcs11",
+						Name:     "autoSeal2",
+						Priority: 2,
+					},
+				},
+			},
+			isRewrapped:              true,
+			hasPartiallyWrappedPaths: false,
+			isErrorExpected:          true,
+			expectedErrorMsg:         "Initializing a cluster or enabling multi-seal on an existing cluster must occur with a single configured seal",
 		},
 		// have partially wrapped paths
 		{

--- a/command/server_sealgenerationinfo_test.go
+++ b/command/server_sealgenerationinfo_test.go
@@ -116,23 +116,8 @@ func TestMultiSealCases(t *testing.T) {
 					Disabled: true,
 				},
 			},
-			expectedSealGenInfo: &seal.SealGenerationInfo{
-				Generation: 1,
-				Seals: []*configutil.KMS{
-					{
-						Type:     "pkcs11",
-						Name:     "autoSeal1",
-						Priority: 1,
-					},
-					{
-						Type:     "pkcs11",
-						Name:     "autoSeal2",
-						Priority: 2,
-						Disabled: true,
-					},
-				},
-			},
-			isErrorExpected:   false,
+			isErrorExpected:   true,
+			expectedErrorMsg:  "Initializing a cluster or enabling multi-seal on an existing cluster must occur with a single seal before adding additional seals",
 			sealHaBetaEnabled: true,
 		},
 		// none_to_multi_with_disabled_seals_no_beta
@@ -793,6 +778,7 @@ func TestMultiSealCases(t *testing.T) {
 			isErrorExpected:          false,
 		},
 		// migrate from non-beta single seal to multi seal, with one disabled, so perform an old style migration
+		// we do not support this use-case at this time so trap the error
 		{
 			name:                "none_to_multiple_seals_one_disabled",
 			existingSealGenInfo: nil,
@@ -812,7 +798,8 @@ func TestMultiSealCases(t *testing.T) {
 			},
 			isRewrapped:              true,
 			hasPartiallyWrappedPaths: false,
-			isErrorExpected:          false,
+			isErrorExpected:          true,
+			expectedErrorMsg:         "Initializing a cluster or enabling multi-seal on an existing cluster must occur with a single seal before adding additional seals",
 		},
 		// migrate from non-beta single seal to multi seal
 		{

--- a/vault/seal/seal.go
+++ b/vault/seal/seal.go
@@ -63,20 +63,12 @@ type SealGenerationInfo struct {
 func (sgi *SealGenerationInfo) Validate(existingSgi *SealGenerationInfo, hasPartiallyWrappedPaths bool) error {
 	existingSealsLen := 0
 	numConfiguredSeals := len(sgi.Seals)
-
-	numConfiguredEnabledSeals := 0
-	for _, seal := range sgi.Seals {
-		if !seal.Disabled {
-			numConfiguredEnabledSeals++
-		}
-	}
-
 	configuredSealNameAndType := sealNameAndTypeAsStr(sgi.Seals)
 
 	// If no previous generation info exists, make sure we perform the initial migration/setup
 	// check for enabled configured seals to allow an old style seal migration configuration
 	if existingSgi == nil {
-		if numConfiguredEnabledSeals > 1 {
+		if numConfiguredSeals > 1 {
 			return fmt.Errorf("Initializing a cluster or enabling multi-seal on an existing "+
 				"cluster must occur with a single seal before adding additional seals\n"+
 				"Configured seals: %v", configuredSealNameAndType)


### PR DESCRIPTION
 - Specifically callout during cluster initialization or initial beta seal migration that we can only have a single seal enabled with the following error message:

   `Initializing a cluster or enabling multi-seal on an existing cluster must occur with a single seal before adding additional seals`

 ~- Handle the use case that we have multiple seals configured, but some are disabled, leaving a single enabled seal. This is the legacy seal migratation case that works without the BETA flag set, so should work with it set as well.~ Reverted after some internal discussions.