### PR TITLE
Set VAULT_ADDR in the token helper's environment

### DIFF
--- a/changelog/23209.txt
+++ b/changelog/23209.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli/login: Avoid calling the token helper in `get` mode.
+```

--- a/changelog/23218.txt
+++ b/changelog/23218.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: Always pass `VAULT_ADDR` to the token helper, so the token helper can know
+the address even if it was provided through the `-address` flag.
+```

--- a/command/base.go
+++ b/command/base.go
@@ -186,7 +186,7 @@ func (c *BaseCommand) Client() (*api.Client, error) {
 
 	// If we don't have a token, check the token helper
 	if token == "" {
-		helper, err := c.TokenHelper()
+		helper, err := c.TokenHelper(client.Address())
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get token helper")
 		}
@@ -217,12 +217,12 @@ func (c *BaseCommand) SetTokenHelper(th token.TokenHelper) {
 }
 
 // TokenHelper returns the token helper attached to the command.
-func (c *BaseCommand) TokenHelper() (token.TokenHelper, error) {
+func (c *BaseCommand) TokenHelper(vaultAddr string) (token.TokenHelper, error) {
 	if c.tokenHelper != nil {
 		return c.tokenHelper, nil
 	}
 
-	helper, err := DefaultTokenHelper()
+	helper, err := DefaultTokenHelper(vaultAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/command/base_predict.go
+++ b/command/base_predict.go
@@ -28,7 +28,7 @@ func (p *Predict) Client() *api.Client {
 			client, _ := api.NewClient(nil)
 
 			if client.Token() == "" {
-				helper, err := DefaultTokenHelper()
+				helper, err := DefaultTokenHelper(client.Address())
 				if err != nil {
 					return
 				}

--- a/command/config/util.go
+++ b/command/config/util.go
@@ -9,7 +9,7 @@ import (
 
 // DefaultTokenHelper returns the token helper that is configured for Vault.
 // This helper should only be used for non-server CLI commands.
-func DefaultTokenHelper() (token.TokenHelper, error) {
+func DefaultTokenHelper(vaultAddr string) (token.TokenHelper, error) {
 	config, err := LoadConfig("")
 	if err != nil {
 		return nil, err
@@ -24,5 +24,12 @@ func DefaultTokenHelper() (token.TokenHelper, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &token.ExternalTokenHelper{BinaryPath: path}, nil
+
+	// If the user specifed the address to connect to on the command line instead
+	// of through an environment variable, we propagate the address to the token
+	// helper through an environment variable. Otherwise the token helper may
+	// read VAULT_ADDR and assume a different address than the one we are using.
+	env := []string{"VAULT_ADDR=" + vaultAddr}
+
+	return &token.ExternalTokenHelper{BinaryPath: path, Env: env}, nil
 }

--- a/command/login.go
+++ b/command/login.go
@@ -296,7 +296,7 @@ func (c *LoginCommand) Run(args []string) int {
 
 	if !c.flagNoStore {
 		// Grab the token helper so we can store
-		tokenHelper, err := c.TokenHelper()
+		tokenHelper, err := c.TokenHelper(client.Address())
 		if err != nil {
 			c.UI.Error(wrapAtLength(fmt.Sprintf(
 				"Error initializing token helper. Please verify that the token "+

--- a/command/login.go
+++ b/command/login.go
@@ -212,7 +212,7 @@ func (c *LoginCommand) Run(args []string) int {
 	}
 
 	// Create the client
-	client, err := c.Client()
+	client, err := c.ClientWithoutToken()
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2

--- a/command/server.go
+++ b/command/server.go
@@ -2042,7 +2042,7 @@ func (c *ServerCommand) enableDev(core *vault.Core, coreConfig *vault.CoreConfig
 
 	// Set the token
 	if !c.flagDevNoStoreToken {
-		tokenHelper, err := c.TokenHelper()
+		tokenHelper, err := c.TokenHelper("dev-server")
 		if err != nil {
 			return nil, err
 		}
@@ -2205,7 +2205,7 @@ func (c *ServerCommand) enableThreeNodeDevCluster(base *vault.CoreConfig, info m
 	}
 
 	// Set the token
-	tokenHelper, err := c.TokenHelper()
+	tokenHelper, err := c.TokenHelper("dev-server")
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error getting token helper: %s", err))
 		return 1

--- a/command/util.go
+++ b/command/util.go
@@ -21,8 +21,8 @@ import (
 
 // DefaultTokenHelper returns the token helper that is configured for Vault.
 // This helper should only be used for non-server CLI commands.
-func DefaultTokenHelper() (token.TokenHelper, error) {
-	return config.DefaultTokenHelper()
+func DefaultTokenHelper(vaultAddr string) (token.TokenHelper, error) {
+	return config.DefaultTokenHelper(vaultAddr)
 }
 
 // RawField extracts the raw field from the given data and returns it as a


### PR DESCRIPTION
Fixes #22257.

This builds on top of #23209 because it would conflict otherwise. It looks like it is not possible in GitHub to change the base branch for this pull request to one outside of this repository, so the diff in this PR shows both changes. Only eefe9cef45 is relevant.

### Problem

As explained in #22257, the token helper might inherit `VAULT_ADDR` from the environment, but if the address is configured through the `-address` flag instead, then the token helper has no way of knowing about the address.

### Solution

Propagate the address that is used by the http client to the token helper, and always set `VAULT_ADDR` in its environment.

### Open questions, testing

I tested this manually and confirmed that the helper receives the address passed using `-address` even when `VAULT_ADDR` is already set. If an automated test is needed, how would I go about adding one?

Also, there are two places in the dev server where the token helper is constructed to store a root token. As far as I can tell, no `VAULT_ADDR` is available in these places, so I set a dummy value there, which is not used by the default internal token helper anyway. It feels a bit ugly, I’m open to better solutions.
