### PR TITLE
Restore seal startup behavior when not in multi-seal mode

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -2627,6 +2627,11 @@ func setSeal(c *ServerCommand, config *server.Config, infoKeys []string, info ma
 	}
 	sealWrapperInfoKeysMap := make(map[string]infoKeysAndMap)
 
+	sealHaBetaEnabled, err := server.IsSealHABetaEnabled()
+	if err != nil {
+		return nil, err
+	}
+
 	configuredSeals := 0
 	for _, configSeal := range config.Seals {
 		sealTypeEnvVarName := "VAULT_SEAL_TYPE"
@@ -2652,7 +2657,20 @@ func setSeal(c *ServerCommand, config *server.Config, infoKeys []string, info ma
 			}
 			configuredSeals++
 		} else {
-			recordSealConfigWarning(fmt.Errorf("error configuring seal: %v", wrapperConfigError))
+			if sealHaBetaEnabled {
+				recordSealConfigWarning(fmt.Errorf("error configuring seal: %v", wrapperConfigError))
+			} else {
+				// It seems that we are checking for this particular error here is to distinguish between a
+				// mis-configured seal vs one that fails for another reason. Apparently the only other reason is
+				// a key not found error. It seems the intention is for the key not found error to be returned
+				// as a seal specific error later
+				if !errwrap.ContainsType(wrapperConfigError, new(logical.KeyNotFoundError)) {
+					return nil, fmt.Errorf("error parsing Seal configuration: %s", wrapperConfigError)
+				} else {
+					sealLogger.Error("error configuring seal", "name", configSeal.Name, "err", wrapperConfigError)
+					recordSealConfigError(wrapperConfigError)
+				}
+			}
 		}
 
 		sealWrapper := vaultseal.NewSealWrapper(
@@ -2708,12 +2726,6 @@ func setSeal(c *ServerCommand, config *server.Config, infoKeys []string, info ma
 
 	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Compute seal generation
-
-	sealHaBetaEnabled, err := server.IsSealHABetaEnabled()
-	if err != nil {
-		return nil, err
-	}
-
 	sealGenerationInfo, err := c.computeSealGenerationInfo(existingSealGenerationInfo, allSealKmsConfigs, hasPartiallyWrappedPaths, sealHaBetaEnabled)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
 - Only enable the warning mode for seals being unavailable when multiple exist when running within multi-seal mode.
 - This addresses a panic that occurs when a legacy style migration is attempted and the non-disabled seal is unavailable.
 - The fix also reverts back some of the previous logic around ignoring KeyNotFoundErrors that was removed from within [#23192](https://github.com/hashicorp/vault/pull/23192/files#diff-de23c936a9ff46fc796a96721e088734a0d6281da4f7c0fe19c3ca6fc86c5dc4L2634-L2645) 

```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/hashicorp/vault/vault.(*sealWrapMigration).Type(0xc002c852cc?, {0xc3aba50, 0x11f124a0})
	/Users/sclark/git-repos/vault-enterprise/vault/sealwrap_sealmigration_ent.go:42 +0x7b
github.com/hashicorp/vault/vault/seal.NewAccessFromSealWrappers({0xc3f8510, 0xc002f04b40}, 0x1, 0x0, {0xc0034fed58, 0x1, 0x1})
	/Users/sclark/git-repos/vault-enterprise/vault/seal/seal.go:356 +0xcf
github.com/hashicorp/vault/vault.(*Core).initSealsForMigration(0xc002d81200)
	/Users/sclark/git-repos/vault-enterprise/vault/core_util_ent.go:1175 +0x1e5
github.com/hashicorp/vault/vault.(*Core).adjustForSealMigration(0xc002d81200, {0xc3ff788, 0xc002cdee00})
	/Users/sclark/git-repos/vault-enterprise/vault/core.go:2957 +0x5a7
github.com/hashicorp/vault/vault.NewCore(0xc002e02300)
	/Users/sclark/git-repos/vault-enterprise/vault/core.go:1282 +0x12f1
github.com/hashicorp/vault/command.(*ServerCommand).Run(0xc002dd8240, {0xc0000b41a0, 0x2, 0x2})
	/Users/sclark/git-repos/vault-enterprise/command/server.go:1398 +0x2a92
github.com/mitchellh/cli.(*CLI).Run(0xc002cd8dc0)
	/Users/sclark/go/pkg/mod/github.com/mitchellh/cli@v1.1.5/cli.go:262 +0x5b8
github.com/hashicorp/vault/command.RunCustom({0xc0000b4190?, 0x3?, 0x3?}, 0xc0000061a0?)
	/Users/sclark/git-repos/vault-enterprise/command/main.go:241 +0x9fd
github.com/hashicorp/vault/command.Run(...)
	/Users/sclark/git-repos/vault-enterprise/command/main.go:145
main.main()
	/Users/sclark/git-repos/vault-enterprise/main.go:19 +0x47
```