### PR TITLE
[Secret Sync Docs] Format & style

### DIFF
--- a/website/content/docs/sync/azurekv.mdx
+++ b/website/content/docs/sync/azurekv.mdx
@@ -25,16 +25,20 @@ which gives sufficient access to manage secrets. For more information, see the [
 When Azure credentials for the service principal have been obtained and it has access to Azure Key Vault,
 Vault can be configured to create an Azure destination, then begin to associate your secrets with this destination.
 
-1.	Configure the sync destination:
+1.	Configure the sync destination.
+
   ```shell-session
   $ vault write sys/sync/stores/azure-kv/my-azure-1 \
-  key_vault_uri=$KEY_VAULT_URI \
-  client_id=$CLIENT_ID \
-  client_secret=$CLIENT_SECRET \
-  tenant_id=$TENANT_ID
+      key_vault_uri=$KEY_VAULT_URI \
+      client_id=$CLIENT_ID \
+      client_secret=$CLIENT_SECRET \
+      tenant_id=$TENANT_ID
   ```
 
-  Output:
+  **Output:**
+
+  <CodeBlockConfig hideClipboard>
+
   ```text
   Key                   Value
   ---                   -----
@@ -43,14 +47,20 @@ Vault can be configured to create an Azure destination, then begin to associate 
   type                  azure-kv
   ```
 
+  </CodeBlockConfig>
+
 ## Usage
 
-1. Store any KV secret into Vault, like so:
+1. Store your KV secret into Vault.
+
   ```shell-session
   $ vault kv put secret/foo mypass=bar
   ```
 
-  Output:
+  **Output:**
+
+  <CodeBlockConfig hideClipboard>
+
   ```
   === Secret Path ===
   secret/data/foo
@@ -65,14 +75,20 @@ Vault can be configured to create an Azure destination, then begin to associate 
   version            1
   ```
 
-1. Set a secret to be associated with the configured secret destination:
+  </CodeBlockConfig>
+
+1. Set a secret to be associated with the configured secret destination.
+
   ```shell-session
   $ vault write sys/sync/destinations/azure-kv/my-azure-1/associations/set \
-  mount='secret' \
-  secret_name='foo'
+      mount='secret' \
+      secret_name='foo'
   ```
 
-  Output:
+  **Output:**
+
+  <CodeBlockConfig hideClipboard>
+
   ```
   Key                   Value
   ---                   -----
@@ -80,6 +96,8 @@ Vault can be configured to create an Azure destination, then begin to associate 
   store_name            my-azure-1
   store_type            azure-kv
   ```
+
+  </CodeBlockConfig>
 
 1. Navigate to [Azure Key Vault](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.KeyVault%2Fvaults) in the Azure portal
 to confirm your secret was successfully created.

--- a/website/content/docs/sync/github.mdx
+++ b/website/content/docs/sync/github.mdx
@@ -11,6 +11,7 @@ This is a low footprint option that enables your applications to benefit from Va
 to connect directly with Vault. This guide walks you through the configuration process.
 
 Prerequisites:
+
 * Ability to read or create KVv2 secrets
 * Ability to create GitHub fine-grained or personal tokens with access to modify repository secrets
 * Ability to create sync destinations and associations on your Vault server
@@ -27,12 +28,16 @@ and allow "Read and Write" access to the repository secrets.
 When credentials for GitHub have been obtained, and it has access to manage secrets in your repository,
 Vault can be configured to create a GitHub destination, then begin to associate your secrets with this destination.
 
-1. Store any KV secret into Vault, like so:
+1. Store any KV secret into Vault.
+
   ```shell-session
   $ vault kv put secret/foo mypass=bar
   ```
 
-  Output:
+  **Output:**
+
+  <CodeBlockConfig hideClipboard>
+
   ```
   === Secret Path ===
   secret/data/foo
@@ -47,15 +52,21 @@ Vault can be configured to create a GitHub destination, then begin to associate 
   version            1
   ```
 
-1.	Configure the sync destination:
+  </CodeBlockConfig>
+
+1.	Configure the sync destination.
+
   ```shell-session
   $ vault write sys/sync/destinations/gh/my-gh-1 \
-  access_token=$ACCESS_TOKEN \
-  repository_owner=$REPOSITORY_OWNER \
-  repository_name=$REPOSITORY_NAME
+      access_token=$ACCESS_TOKEN \
+      repository_owner=$REPOSITORY_OWNER \
+      repository_name=$REPOSITORY_NAME
   ```
 
-  Output:
+  **Output:**
+
+  <CodeBlockConfig hideClipboard>
+
   ```text
   Key                   Value
   ---                   -----
@@ -64,14 +75,20 @@ Vault can be configured to create a GitHub destination, then begin to associate 
   type                  gh
   ```
 
-1.	Set a secret to be associated with the configured secret destination:
+  </CodeBlockConfig>
+
+1.	Set a secret to be associated with the configured secret destination.
+
   ```shell-session
   $ vault write sys/sync/destinations/gh/my-gh-1/associations/set \
-  mount='secret' \
-  secret_name='foo'
+      mount='secret' \
+      secret_name='foo'
   ```
 
-  Output:
+  **Output:**
+
+  <CodeBlockConfig hideClipboard>
+
   ```
   Key                   Value
   ---                   -----
@@ -80,13 +97,15 @@ Vault can be configured to create a GitHub destination, then begin to associate 
   store_type            gh
   ```
 
+  </CodeBlockConfig>
+
 1. Navigate to your GitHub repository settings to confirm your secret was successfully created.
 
 Moving forward, any modification on the Vault secret will be propagated in near real time to its GitHub repository secrets
 counterpart. Creating a new secret version in Vault will create a new version in GitHub. Deleting the secret
 or the association in Vault will delete the secret in GitHub as well.
 
-## Notes
+<Note>
 
 GitHub only supports single value secrets, so KVv2 secrets from Vault will be stored as a JSON string.
 In the example above, the value for secret "foo" will be synced to GitHub as the JSON string `{"mypass":"bar"}`.
@@ -95,6 +114,9 @@ To extract out individual properties in a GitHub action workflow, consider using
 When synced to GitHub:
 * Secret names with unsupported characters will be replaced by an "_".
 * Secret names are capitalized, and case-insensitive.
+
+</Note>
+
 
 ## API
 

--- a/website/content/docs/sync/vercelproject.mdx
+++ b/website/content/docs/sync/vercelproject.mdx
@@ -26,12 +26,18 @@ Prerequisites:
 
   ```shell-session
   $ vault write sys/sync/destinations/vercel-project/my-dest \
-  access_token=<token> \
-  project_id=<project-id> \
-  deployment_environments=development \
-  deployment_environments=preview \
-  deployment_environments=production
+      access_token=<token> \
+      project_id=<project-id> \
+      deployment_environments=development \
+      deployment_environments=preview \
+      deployment_environments=production
+  ```
 
+  **Output:**
+
+  <CodeBlockConfig hideClipboard>
+
+  ```plaintext
   Key                   Value
   ---                   -----
   connection_details    map[access_token:***** deployment_environments:[development preview production] project_id:<project-id>]
@@ -39,14 +45,20 @@ Prerequisites:
   type                  vercel-project
   ```
 
+  </CodeBlockConfig>
+
 ## Usage
 
-1. If you do not already have a KVv2 secret to sync, mount a new KVv2 secrets engine and create a secret.
+1. If you do not already have a KVv2 secret to sync, mount a new KVv2 secrets engine.
 
   ```shell-session
   $ vault secrets enable -path=my-kv kv-v2
   Success! Enabled the kv-v2 secrets engine at: my-kv/
+  ```
 
+1. Store any KV secret into Vault.
+
+  ```shell-session
   $ vault kv put -mount=my-kv my-secret foo=bar
   ==== Secret Path ====
   my-kv/data/my-secret
@@ -61,17 +73,27 @@ Prerequisites:
   version            1
   ```
 
-1. Create an association between your Vercel Project destination and the secret to synchronize
+1. Create an association between your Vercel Project destination and the secret to synchronize.
 
   ```shell-session
-  vault write sys/sync/destinations/vercel-project/my-dest/associations/set mount=my-kv secret_name=my-secret
+  $ vault write sys/sync/destinations/vercel-project/my-dest/associations/set \
+      mount=my-kv \
+      secret_name=my-secret
+  ```
 
+  **Output:**
+
+  <CodeBlockConfig hideClipboard>
+
+  ```plaintext
   Key                   Value
   ---                   -----
   associated_secrets    map[kv_1234/my-secret:map[accessor:kv_1234 secret_name:my-secret sync_status:SYNCED updated_at:<timestamp>>]]
   store_name            my-dest
   store_type            vercel-project
   ```
+
+  </CodeBlockConfig>
 
 1. Navigate to your project's settings under the `Environment Variables` section to confirm your secret was successfully
   created in your Vercel project.


### PR DESCRIPTION
This PR updates the new secret sync docs (https://github.com/hashicorp/vault/pull/23189) to comply with styles for consistency:

🔍 [Deploy preview - Azure](https://vault-git-sync-docs-formats-hashicorp.vercel.app/vault/docs/sync/azurekv)
🔍 [Deploy preview - Github](https://vault-git-sync-docs-formats-hashicorp.vercel.app/vault/docs/sync/github)
🔍 [Deploy preview - Vercel](https://vault-git-sync-docs-formats-hashicorp.vercel.app/vault/docs/sync/vercelproject)

