### PR TITLE
Do not attempt to shutdown ACME thread on non-active nodes

### DIFF
--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -91,6 +91,15 @@ func (a *acmeState) Initialize(b *backend, sc *storageContext) error {
 	return nil
 }
 
+func (a *acmeState) Shutdown(b *backend) {
+	// If we aren't the active node, nothing to shutdown
+	if b.System().ReplicationState().HasState(consts.ReplicationDRSecondary | consts.ReplicationPerformanceStandby) {
+		return
+	}
+
+	a.validator.Closing <- struct{}{}
+}
+
 func (a *acmeState) markConfigDirty() {
 	a.configDirty.Store(true)
 }

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -430,7 +430,8 @@ func (b *backend) initialize(ctx context.Context, ir *logical.InitializationRequ
 
 func (b *backend) cleanup(ctx context.Context) {
 	sc := b.makeStorageContext(ctx, b.storage)
-	b.acmeState.validator.Closing <- struct{}{}
+
+	b.acmeState.Shutdown(b)
 
 	b.cleanupEnt(sc)
 }


### PR DESCRIPTION
Missed this from #23278, we need to optionally close out the plugin if we aren't the active node.