### PR TITLE
[VAULT-20073] Docs: update upgrade guide for 1.15 with information on…

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -89,6 +89,10 @@ FAQ](/vault/docs/deprecation/faq#q-what-are-the-phases-of-deprecation).
 Affects upgrading from any version of Vault to 1.13.x. All other upgrade paths
 are unaffected.
 
+### Application of Sentinel Role Governing Policies (RGPs) via identity groups
+
+@include 'application-of-sentinel-rgps-via-identity-groups.mdx'
+
 ## Known issues
 
 @include 'tokenization-rotation-persistence.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.14.x.mdx
@@ -31,6 +31,10 @@ Official images separately.
 `vault.raft_storage.bolt.write.time` has been corrected from a summary to a counter to more accurately reflect that it
 is measuring cumulative time writing, and not the distribution of individual write times.
 
+### Application of Sentinel Role Governing Policies (RGPs) via identity groups
+
+@include 'application-of-sentinel-rgps-via-identity-groups.mdx'
+
 ## Known issues and workarounds
 
 @include 'known-issues/ui-pki-control-groups.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -40,3 +40,11 @@ To continue measuring `vault.rollback.attempts.{MOUNTPOINT}` and
 metrics in the `telemetry` stanza of your Vault configuration with the
 [`add_mount_point_rollback_metrics`](/vault/docs/configuration/telemetry#add_mount_point_rollback_metrics)
 option.
+
+## Application of Sentinel Role Governing Policies (RGPs) via identity groups
+
+As of versions 1.15, 1.14.4, and 1.13.8, [the Sentinel RGPSs derived from membership in identity groups apply
+only to entities in the same and child namespaces, relative to the identity group](/vault/docs/enterprise/sentinel#rgps-and-namespaces).
+
+Also, the [`group_policy_application_mode`](vault/api-docs/system/config-group-policy-application) only applies to
+to ACL policies. Vault Sentinel Role Governing Policies (RGPs) are not affected by group policy application mode.

--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -43,8 +43,4 @@ option.
 
 ## Application of Sentinel Role Governing Policies (RGPs) via identity groups
 
-As of versions `1.15.0`, `1.14.4`, and `1.13.8`, [the Sentinel RGPSs derived from membership in identity groups apply
-only to entities in the same and child namespaces, relative to the identity group](/vault/docs/enterprise/sentinel#rgps-and-namespaces).
-
-Also, the [`group_policy_application_mode`](/vault/api-docs/system/config-group-policy-application) only applies to
-to ACL policies. Vault Sentinel Role Governing Policies (RGPs) are not affected by group policy application mode.
+@include 'application-of-sentinel-rgps-via-identity-groups.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -46,5 +46,5 @@ option.
 As of versions 1.15, 1.14.4, and 1.13.8, [the Sentinel RGPSs derived from membership in identity groups apply
 only to entities in the same and child namespaces, relative to the identity group](/vault/docs/enterprise/sentinel#rgps-and-namespaces).
 
-Also, the [`group_policy_application_mode`](vault/api-docs/system/config-group-policy-application) only applies to
+Also, the [`group_policy_application_mode`](website/content/api-docs/system/config-group-policy-application.mdx) only applies to
 to ACL policies. Vault Sentinel Role Governing Policies (RGPs) are not affected by group policy application mode.

--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -43,7 +43,7 @@ option.
 
 ## Application of Sentinel Role Governing Policies (RGPs) via identity groups
 
-As of versions 1.15, 1.14.4, and 1.13.8, [the Sentinel RGPSs derived from membership in identity groups apply
+As of versions `1.15.0`, `1.14.4`, and `1.13.8`, [the Sentinel RGPSs derived from membership in identity groups apply
 only to entities in the same and child namespaces, relative to the identity group](/vault/docs/enterprise/sentinel#rgps-and-namespaces).
 
 Also, the [`group_policy_application_mode`](/vault/api-docs/system/config-group-policy-application) only applies to

--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -46,5 +46,5 @@ option.
 As of versions 1.15, 1.14.4, and 1.13.8, [the Sentinel RGPSs derived from membership in identity groups apply
 only to entities in the same and child namespaces, relative to the identity group](/vault/docs/enterprise/sentinel#rgps-and-namespaces).
 
-Also, the [`group_policy_application_mode`](website/content/api-docs/system/config-group-policy-application.mdx) only applies to
+Also, the [`group_policy_application_mode`](/vault/api-docs/system/config-group-policy-application) only applies to
 to ACL policies. Vault Sentinel Role Governing Policies (RGPs) are not affected by group policy application mode.

--- a/website/content/partials/application-of-sentinel-rgps-via-identity-groups.mdx
+++ b/website/content/partials/application-of-sentinel-rgps-via-identity-groups.mdx
@@ -1,0 +1,5 @@
+As of versions `1.15.0`, `1.14.4`, and `1.13.8`, [the Sentinel RGPSs derived from membership in identity groups apply
+only to entities in the same and child namespaces, relative to the identity group](/vault/docs/enterprise/sentinel#rgps-and-namespaces).
+
+Also, the [`group_policy_application_mode`](/vault/api-docs/system/config-group-policy-application) only applies to
+to ACL policies. Vault Sentinel Role Governing Policies (RGPs) are not affected by group policy application mode.


### PR DESCRIPTION
… Sentinel RGP group policy application

Upgrade guide update companion to https://github.com/hashicorp/vault/pull/23090 (Ensure Role Governing Policies are only applied down the namespace hierarchy).

[Document deployed by Vercel](https://vault-c7y3c07i0-hashicorp.vercel.app/vault/docs/upgrading/upgrade-to-1.15.x)