### PR TITLE
UI: Policy JSON Editor Toolbar Styling Fix 

### DIFF
--- a/changelog/23297.txt
+++ b/changelog/23297.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes policy input toolbar scrolling by default
+```

--- a/ui/app/components/policy-form.hbs
+++ b/ui/app/components/policy-form.hbs
@@ -25,7 +25,7 @@
     <div class="field">
       {{#if @model.isNew}}
         <Toolbar>
-          <label class="is-label">Policy</label>
+          <label class="has-text-weight-bold">Policy</label>
           <ToolbarActions>
             <div class="toolbar-separator"></div>
             <div class="control is-flex">


### PR DESCRIPTION
Fixes regression caused by styling changes to `is-label`. Caught one of them in  https://github.com/hashicorp/vault/pull/23120 but missed this one. 
<hr>


## with fix:

<img width="1230" alt="Screenshot 2023-09-26 at 2 01 11 PM" src="https://github.com/hashicorp/vault/assets/68122737/1fa895b4-02a4-467f-9ebd-1a6ec538247b">


## before (toolbar is scrolled by default and upload is not visible)

<img width="1203" alt="Screenshot 2023-09-26 at 2 01 24 PM" src="https://github.com/hashicorp/vault/assets/68122737/fb287bd8-41de-487d-bc9c-dcc4dcaa341a">

