### PR TITLE
Fix some pagination issues

### DIFF
--- a/ui/app/templates/vault/cluster/access/leases/list.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/list.hbs
@@ -96,18 +96,18 @@
       <Icon @name={{if item.isFolder "folder" "file"}} class="has-text-grey-light" />
       <span class="has-text-weight-semibold">{{or item.keyWithoutParent item.id}}</span>
     </LinkTo>
+
+    <Hds::Pagination::Numbered
+      @currentPage={{this.model.meta.currentPage}}
+      @currentPageSize={{this.model.meta.pageSize}}
+      @route={{concat "vault.cluster.access.leases.list" (unless this.baseKey.id "-root")}}
+      @showSizeSelector={{false}}
+      @totalItems={{this.model.meta.total}}
+      @queryFunction={{this.paginationQueryParams}}
+    />
   {{else}}
     <EmptyState @title="There are no leases matching &quot;{{this.filter}}&quot;" />
   {{/each}}
 {{else}}
   <EmptyState @title={{this.emptyTitle}} />
 {{/if}}
-
-<Hds::Pagination::Numbered
-  @currentPage={{this.model.meta.currentPage}}
-  @currentPageSize={{this.model.meta.pageSize}}
-  @route={{concat "vault.cluster.access.leases.list" (unless this.baseKey.id "-root")}}
-  @showSizeSelector={{false}}
-  @totalItems={{this.model.meta.total}}
-  @queryFunction={{this.paginationQueryParams}}
-/>

--- a/ui/app/templates/vault/cluster/policies/index.hbs
+++ b/ui/app/templates/vault/cluster/policies/index.hbs
@@ -148,19 +148,18 @@
           </div>
         </LinkedBlock>
       {{/if}}
+
+      <Hds::Pagination::Numbered
+        @currentPage={{this.model.meta.currentPage}}
+        @currentPageSize={{this.model.meta.pageSize}}
+        @route="vault.cluster.policies.index"
+        @showSizeSelector={{false}}
+        @totalItems={{this.model.meta.total}}
+        @queryFunction={{this.paginationQueryParams}}
+      />
     {{else}}
       <EmptyState @title="No policies matching &quot;{{this.pageFilter}}&quot;" />
     {{/each}}
-
-    <Hds::Pagination::Numbered
-      @currentPage={{this.model.meta.currentPage}}
-      @currentPageSize={{this.model.meta.pageSize}}
-      @route="vault.cluster.policies.index"
-      @showSizeSelector={{false}}
-      @totalItems={{this.model.meta.total}}
-      @queryFunction={{this.paginationQueryParams}}
-    />
-
   {{else}}
     <EmptyState
       @title="No {{uppercase this.policyType}} policies yet"

--- a/ui/lib/kv/addon/routes/list-directory.js
+++ b/ui/lib/kv/addon/routes/list-directory.js
@@ -30,7 +30,6 @@ export default class KvSecretsListRoute extends Route {
         backend,
         responsePath: 'data.keys',
         page: Number(params.page) || 1,
-        size: Number(params.currentPageSize),
         pageFilter: params.pageFilter,
         pathToSecret,
       })


### PR DESCRIPTION
Came across these issues while looking at remove PaginationControls.

I needed to move some of the old locations of the pagination component inside the correct conditional, otherwise the page was erroring out because `pageSize` and `currentPage` were not returned as there were no items in the list. 

This was not an issue in the previous iterations of pagination because we wrapped them in a conditional that checked to only show these if they were over 15 || 100, which we decided to remove.