### PR TITLE
enos: remove old initial version from upgrades

### DIFF
--- a/.github/workflows/enos-lint.yml
+++ b/.github/workflows/enos-lint.yml
@@ -44,6 +44,8 @@ jobs:
       - uses: hashicorp/action-setup-enos@v1
         with:
           github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+      - name: Ensure shellcheck is available for linting
+        run: which shellcheck || (sudo apt update && sudo apt install -y shellcheck)
       - name: lint
         working-directory: ./enos
         env:

--- a/enos/enos-samples-ce-build.hcl
+++ b/enos/enos-samples-ce-build.hcl
@@ -41,12 +41,6 @@ sample "build_ce_linux_amd64_deb" {
       artifact_type   = ["package"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
-
-      exclude {
-        // Don't test from these versions in the build pipeline because of known issues
-        // in those older versions.
-        initial_version = ["1.8.12", "1.9.10", "1.10.11"]
-      }
     }
   }
 }
@@ -91,12 +85,6 @@ sample "build_ce_linux_arm64_deb" {
       artifact_type   = ["package"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
-
-      exclude {
-        // Don't test from these versions in the build pipeline because of known issues
-        // in those older versions.
-        initial_version = ["1.8.12", "1.9.10", "1.10.11"]
-      }
     }
   }
 }
@@ -141,12 +129,6 @@ sample "build_ce_linux_arm64_rpm" {
       artifact_type   = ["package"]
       distro          = ["rhel"]
       edition         = ["ce"]
-
-      exclude {
-        // Don't test from these versions in the build pipeline because of known issues
-        // in those older versions.
-        initial_version = ["1.8.12", "1.9.10", "1.10.11"]
-      }
     }
   }
 }
@@ -237,12 +219,6 @@ sample "build_ce_linux_amd64_zip" {
       artifact_type   = ["bundle"]
       artifact_source = ["crt"]
       edition         = ["ce"]
-
-      exclude {
-        // Don't test from these versions in the build pipeline because of known issues
-        // in those older versions.
-        initial_version = ["1.8.12", "1.9.10", "1.10.11"]
-      }
     }
   }
 }
@@ -283,12 +259,6 @@ sample "build_ce_linux_arm64_zip" {
       artifact_source = ["crt"]
       artifact_type   = ["bundle"]
       edition         = ["ce"]
-
-      exclude {
-        // Don't test from these versions in the build pipeline because of known issues
-        // in those older versions.
-        initial_version = ["1.8.12", "1.9.10", "1.10.11"]
-      }
     }
   }
 }

--- a/enos/enos-samples-ce-release.hcl
+++ b/enos/enos-samples-ce-release.hcl
@@ -41,12 +41,6 @@ sample "release_ce_linux_amd64_deb" {
       artifact_type   = ["package"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
-
-      exclude {
-        // Don't test from these versions in the release pipeline because of known issues
-        // in those older versions.
-        initial_version = ["1.8.12", "1.9.10", "1.10.11"]
-      }
     }
   }
 }
@@ -91,12 +85,6 @@ sample "release_ce_linux_arm64_deb" {
       artifact_type   = ["package"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
-
-      exclude {
-        // Don't test from these versions in the release pipeline because of known issues
-        // in those older versions.
-        initial_version = ["1.8.12", "1.9.10", "1.10.11"]
-      }
     }
   }
 }
@@ -141,12 +129,6 @@ sample "release_ce_linux_arm64_rpm" {
       artifact_type   = ["package"]
       distro          = ["rhel"]
       edition         = ["ce"]
-
-      exclude {
-        // Don't test from these versions in the release pipeline because of known issues
-        // in those older versions.
-        initial_version = ["1.8.12", "1.9.10", "1.10.11"]
-      }
     }
   }
 }
@@ -191,12 +173,6 @@ sample "release_ce_linux_amd64_rpm" {
       artifact_type   = ["package"]
       distro          = ["rhel"]
       edition         = ["ce"]
-
-      exclude {
-        // Don't test from these versions in the release pipeline because of known issues
-        // in those older versions.
-        initial_version = ["1.8.12", "1.9.10", "1.10.11"]
-      }
     }
   }
 }
@@ -237,12 +213,6 @@ sample "release_ce_linux_amd64_zip" {
       artifact_type   = ["bundle"]
       artifact_source = ["artifactory"]
       edition         = ["ce"]
-
-      exclude {
-        // Don't test from these versions in the release pipeline because of known issues
-        // in those older versions.
-        initial_version = ["1.8.12", "1.9.10", "1.10.11"]
-      }
     }
   }
 }
@@ -283,12 +253,6 @@ sample "release_ce_linux_arm64_zip" {
       artifact_source = ["artifactory"]
       artifact_type   = ["bundle"]
       edition         = ["ce"]
-
-      exclude {
-        // Don't test from these versions in the release pipeline because of known issues
-        // in those older versions.
-        initial_version = ["1.8.12", "1.9.10", "1.10.11"]
-      }
     }
   }
 }

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -14,7 +14,7 @@ scenario "upgrade" {
     // are a higher minor version that our release candidate. Also, prior to 1.11.x the
     // /v1/sys/seal-status API has known issues that could cause this scenario to fail when using
     // those earlier versions.
-    initial_version = ["1.8.12", "1.9.10", "1.10.11", "1.11.12", "1.12.11", "1.13.6", "1.14.2"]
+    initial_version = ["1.11.12", "1.12.11", "1.13.6", "1.14.2"]
     seal            = ["awskms", "shamir"]
 
     # Our local builder always creates bundles


### PR DESCRIPTION
Remove the old initial versions as they are unreliable.