### PR TITLE
Backport: Vault PKI: Fix typo OSCP -> OCS

### DIFF
--- a/ui/app/models/pki/urls.js
+++ b/ui/app/models/pki/urls.js
@@ -30,7 +30,7 @@ export default class PkiUrlsModel extends Model {
   crlDistributionPoints;
 
   @attr({
-    label: 'OSCP Servers',
+    label: 'OCSP Servers',
     subText: 'Specifies the URL values for the OCSP Servers field.',
     showHelpText: false,
     editType: 'stringArray',


### PR DESCRIPTION
Fixes typo, backport(ish) of https://github.com/hashicorp/vault/pull/23316