### PR TITLE
replication: wait longer for replication to resync

### DIFF
--- a/enos/modules/vault_verify_performance_replication/scripts/verify-replication-status.sh
+++ b/enos/modules/vault_verify_performance_replication/scripts/verify-replication-status.sh
@@ -81,5 +81,5 @@ check_pr_status() {
   return 0
 }
 
-# Retry a few times because it can take some time for replication to sync
-retry 5 check_pr_status
+# Retry for a while because it can take some time for replication to sync
+retry 10 check_pr_status


### PR DESCRIPTION
Increase the amount of time we'll wait for replication to sync from 30 seconds to 110. This ought to cover most cases where we fail twice because we're still waiting for replication.