### PR TITLE
UI: Part 1 - hds adoption replace <Modal>

### DIFF
--- a/ui/app/components/database-connection.js
+++ b/ui/app/components/database-connection.js
@@ -73,16 +73,14 @@ export default class DatabaseConnectionEdit extends Component {
   }
 
   @action
-  continueWithoutRotate(evt) {
-    evt.preventDefault();
+  continueWithoutRotate() {
     this.showSaveModal = false;
     const { name } = this.args.model;
     this.transitionToRoute(SHOW_ROUTE, name);
   }
 
   @action
-  continueWithRotate(evt) {
-    evt.preventDefault();
+  continueWithRotate() {
     this.showSaveModal = false;
     const { backend, name } = this.args.model;
     this.rotateCredentials(backend, name)

--- a/ui/app/components/database-connection.js
+++ b/ui/app/components/database-connection.js
@@ -75,6 +75,7 @@ export default class DatabaseConnectionEdit extends Component {
   @action
   continueWithoutRotate(evt) {
     evt.preventDefault();
+    this.showSaveModal = false;
     const { name } = this.args.model;
     this.transitionToRoute(SHOW_ROUTE, name);
   }
@@ -82,6 +83,7 @@ export default class DatabaseConnectionEdit extends Component {
   @action
   continueWithRotate(evt) {
     evt.preventDefault();
+    this.showSaveModal = false;
     const { backend, name } = this.args.model;
     this.rotateCredentials(backend, name)
       .then(() => {

--- a/ui/app/components/policy-form.hbs
+++ b/ui/app/components/policy-form.hbs
@@ -23,11 +23,24 @@
       </div>
     {{/if}}
     <div class="field">
-      {{#if @model.isNew}}
-        <Toolbar>
-          <label class="has-text-weight-bold">Policy</label>
-          <ToolbarActions>
-            <div class="toolbar-separator"></div>
+      <Toolbar>
+        <label class="has-text-weight-bold has-right-margin-xxs">Policy</label>
+        {{#if @renderPolicyExampleModal}}
+          {{! only true in policy create and edit routes }}
+          <ToolbarFilters>
+            <Hds::Button
+              @text="How to write a policy"
+              @icon="bulb"
+              @size="small"
+              @color="tertiary"
+              {{on "click" (fn (mut this.showTemplateModal))}}
+              data-test-policy-example-button
+            />
+          </ToolbarFilters>
+        {{/if}}
+        <ToolbarActions>
+          <div class="toolbar-separator"></div>
+          {{#if @model.isNew}}
             <div class="control is-flex">
               <Input
                 id="fileUploadToggle"
@@ -40,25 +53,24 @@
               />
               <label for="fileUploadToggle">Upload file</label>
             </div>
-          </ToolbarActions>
-        </Toolbar>
-        {{#if this.showFileUpload}}
-          <TextFile @uploadOnly={{true}} @onChange={{this.setPolicyFromFile}} />
-        {{else}}
-          <JsonEditor
-            @title="Policy"
-            @showToolbar={{false}}
-            @value={{@model.policy}}
-            @valueUpdated={{action (mut @model.policy)}}
-            @mode="ruby"
-            @extraKeys={{hash Shift-Enter=(perform this.save)}}
-            data-test-policy-editor
-          />
-        {{/if}}
+          {{else}}
+            {{! EDITING - no file upload toggle}}
+            <Hds::Copy::Button
+              @text="Copy"
+              @isIconOnly={{true}}
+              @textToCopy={{@model.policy}}
+              class="transparent"
+              data-test-copy-button
+            />
+          {{/if}}
+        </ToolbarActions>
+      </Toolbar>
+      {{#if this.showFileUpload}}
+        <TextFile @uploadOnly={{true}} @onChange={{this.setPolicyFromFile}} />
       {{else}}
-        {{! EDITING - no file upload toggle}}
         <JsonEditor
           @title="Policy"
+          @showToolbar={{false}}
           @value={{@model.policy}}
           @valueUpdated={{action (mut @model.policy)}}
           @mode="ruby"
@@ -70,36 +82,6 @@
         <span class="is-size-9 has-text-grey has-bottom-margin-l">
           You can use Alt+Tab (Option+Tab on MacOS) in the code editor to skip to the next field.
         </span>
-        {{! Only renders button (and modal) if not already in the "create policy" modal }}
-        {{#if @renderPolicyExampleModal}}
-          <span class="is-size-9 has-text-grey has-bottom-margin-l">
-            See
-            <button
-              type="button"
-              class="text-button has-text-info"
-              {{on "click" (fn (mut this.showTemplateModal))}}
-              data-test-policy-example-button
-            >
-              example template
-            </button>.
-          </span>
-          {{! Only renders more information if already in the "create policy" modal }}
-        {{else}}
-          <p class="has-top-margin-l">
-            More information about
-            {{uppercase @model.policyType}}
-            policies can be found
-            <DocLink
-              @path={{if
-                (eq @model.policyType "acl")
-                "/vault/docs/concepts/policies#capabilities"
-                "/vault/tutorials/policies/sentinel#role-governing-policies-rgps"
-              }}
-            >
-              here.
-            </DocLink>
-          </p>
-        {{/if}}
       </div>
     </div>
     {{#each @model.additionalAttrs as |attr|}}
@@ -128,26 +110,26 @@
     </div>
   </div>
 </form>
-{{! SAMPLE POLICY MODAL. Only renders modal if not already in create policy modal }}
-{{#if @renderPolicyExampleModal}}
-  <Modal
-    @title="Example {{uppercase @model.policyType}} Policy"
+
+{{! SAMPLE POLICY MODAL. Only renders in policy create and edit routes }}
+{{#if this.showTemplateModal}}
+  <Hds::Modal
+    id="policy-example-modal"
+    @size="large"
     @onClose={{fn (mut this.showTemplateModal) false}}
-    @isActive={{this.showTemplateModal}}
-    @showCloseButton={{true}}
     data-test-policy-example-modal
+    as |M|
   >
-    <section class="modal-card-body">
-      {{! code-mirror modifier does not render value initially until focus event fires }}
-      {{! wait until the Modal is rendered and then show the PolicyExample (contains JsonEditor) }}
-      {{#if this.showTemplateModal}}
-        <PolicyExample @policyType={{@model.policyType}} />
-      {{/if}}
-    </section>
-    <div class="modal-card-head has-border-top-light">
-      <button type="button" class="button" {{on "click" (fn (mut this.showTemplateModal) false)}} data-test-close-modal>
-        Close
-      </button>
-    </div>
-  </Modal>
+    <M.Header>
+      Example
+      {{uppercase @model.policyType}}
+      Policy
+    </M.Header>
+    <M.Body>
+      <PolicyExample @policyType={{@model.policyType}} />
+    </M.Body>
+    <M.Footer as |F|>
+      <Hds::Button @text="Close" {{on "click" F.close}} data-test-close-modal />
+    </M.Footer>
+  </Hds::Modal>
 {{/if}}

--- a/ui/app/components/policy-form.hbs
+++ b/ui/app/components/policy-form.hbs
@@ -120,7 +120,7 @@
     data-test-policy-example-modal
     as |M|
   >
-    <M.Header>
+    <M.Header data-test-modal-title>
       Example
       {{uppercase @model.policyType}}
       Policy
@@ -129,7 +129,7 @@
       <PolicyExample @policyType={{@model.policyType}} />
     </M.Body>
     <M.Footer as |F|>
-      <Hds::Button @text="Close" {{on "click" F.close}} data-test-close-modal />
+      <Hds::Button @text="Close" {{on "click" F.close}} data-test-modal-close-button />
     </M.Footer>
   </Hds::Modal>
 {{/if}}

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -24,29 +24,3 @@
     color: $black;
   }
 }
-
-.link-status {
-  height: 40px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: $size-7;
-  font-weight: $font-weight-semibold;
-
-  &.connected {
-    background-color: var(--token-color-surface-action);
-    color: var(--token-color-foreground-action-active);
-
-    a {
-      color: var(--token-color-foreground-action-active);
-    }
-  }
-  &.warning {
-    background-color: var(--token-color-surface-warning);
-    color: var(--token-color-palette-amber-300);
-
-    a {
-      color: var(--token-color-palette-amber-300);
-    }
-  }
-}

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -401,19 +401,4 @@ a.button.disabled {
       color: $blue;
     }
   }
-  &.hds-text-button {
-    padding: unset;
-    border: none;
-    background-color: inherit;
-    color: inherit;
-    font-size: inherit;
-    font-weight: inherit;
-    display: inline;
-    text-decoration: underline;
-    cursor: pointer;
-    &:hover:not(.disabled) {
-      border: 0;
-      color: $blue;
-    }
-  }
 }

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -399,4 +399,19 @@ a.button.disabled {
       color: $blue;
     }
   }
+  &.hds-text-button {
+    padding: unset;
+    border: none;
+    background-color: inherit;
+    color: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    display: inline;
+    text-decoration: underline;
+    cursor: pointer;
+    &:hover:not(.disabled) {
+      border: 0;
+      color: $blue;
+    }
+  }
 }

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -332,6 +332,7 @@ a.button.disabled {
   }
 }
 
+// TODO HDS adoption cleanup: audit styles with design and see what to keep/remove once buttons are fully HDS
 // Existing class on <Hds::Copy::Button> component, modifying to match existing UI Structure buttons
 .hds-copy-button {
   font-weight: $font-weight-semibold;
@@ -387,6 +388,7 @@ a.button.disabled {
   }
 }
 
+// Existing class on <Hds::Button> component, modifying to match existing UI Structure buttons
 .hds-button {
   &.toolbar-button {
     font-weight: $font-weight-semibold;

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -386,3 +386,17 @@ a.button.disabled {
     }
   }
 }
+
+.hds-button {
+  &.toolbar-button {
+    font-weight: $font-weight-semibold;
+    background: none;
+    border: none;
+    box-shadow: none;
+    &:hover:not(.disabled) {
+      background-color: $ui-gray-100;
+      border: 0;
+      color: $blue;
+    }
+  }
+}

--- a/ui/app/templates/components/clients/attribution.hbs
+++ b/ui/app/templates/components/clients/attribution.hbs
@@ -15,14 +15,12 @@
     </div>
     <div class="header-right">
       {{#if this.hasCsvData}}
-        <button
+        <Hds::Button
           data-test-attribution-export-button
-          type="button"
-          class="button is-secondary"
+          @text="Export attribution data"
+          @color="secondary"
           {{on "click" (fn (mut this.showCSVDownloadModal) true)}}
-        >
-          Export attribution data
-        </button>
+        />
       {{/if}}
     </div>
   </div>
@@ -91,41 +89,40 @@
 </div>
 
 {{! MODAL FOR CSV DOWNLOAD }}
-<Modal
-  @title="Export attribution data"
-  @type="info"
-  @isActive={{this.showCSVDownloadModal}}
-  @showCloseButton={{true}}
-  @onClose={{action (mut this.showCSVDownloadModal) false}}
->
-  <section class="modal-card-body">
-    <p class="has-bottom-margin-s">
-      This export will include the namespace path, authentication method path, and the associated total, entity, and
-      non-entity clients for the below
-      {{if this.formattedEndDate "date range" "month"}}.
-    </p>
-    <p class="has-bottom-margin-s is-subtitle-gray">SELECTED DATE {{if this.formattedEndDate " RANGE"}}</p>
-    <p class="has-bottom-margin-s">{{this.formattedStartDate}} {{if this.formattedEndDate "-"}} {{this.formattedEndDate}}</p>
-  </section>
-  <footer class="modal-card-foot modal-card-foot-outlined">
-    <button type="button" class="button is-primary" {{on "click" (fn this.exportChartData this.formattedCsvFileName)}}>
-      Export
-    </button>
-    <button type="button" class="button is-secondary" onclick={{action (mut this.showCSVDownloadModal) false}}>
-      Cancel
-    </button>
-    {{#if @upgradeExplanation}}
-      <div class="has-text-grey is-size-8">
-        <AlertInline @type="warning" @isMarginless={{true}}>
-          Your data contains an upgrade.
-          <DocLink
-            @path="/vault/docs/concepts/client-count/faq#q-which-vault-version-reflects-the-most-accurate-client-counts"
-          >
-            Learn more here.
-          </DocLink>
-        </AlertInline>
-        <p class="has-left-padding-l">{{@upgradeExplanation}}</p>
-      </div>
-    {{/if}}
-  </footer>
-</Modal>
+{{#if this.showCSVDownloadModal}}
+  <Hds::Modal id="attribution-csv-download-modal" @onClose={{fn (mut this.showCSVDownloadModal) false}} as |M|>
+    <M.Header @icon="info">
+      Export attribution data
+    </M.Header>
+    <M.Body>
+      <p class="has-bottom-margin-s">
+        This export will include the namespace path, authentication method path, and the associated total, entity, and
+        non-entity clients for the below
+        {{if this.formattedEndDate "date range" "month"}}.
+      </p>
+      <p class="has-bottom-margin-s is-subtitle-gray">SELECTED DATE {{if this.formattedEndDate " RANGE"}}</p>
+      <p class="has-bottom-margin-s">{{this.formattedStartDate}}
+        {{if this.formattedEndDate "-"}}
+        {{this.formattedEndDate}}</p>
+    </M.Body>
+    <M.Footer as |F|>
+      <Hds::ButtonSet>
+        <Hds::Button @text="Export" {{on "click" (fn this.exportChartData this.formattedCsvFileName)}} />
+        <Hds::Button @text="Cancel" @color="secondary" {{on "click" F.close}} />
+      </Hds::ButtonSet>
+      {{#if @upgradeExplanation}}
+        <div class="has-text-grey is-size-8 has-top-padding-m">
+          <AlertInline @type="warning">
+            Your data contains an upgrade.
+            <DocLink
+              @path="/vault/docs/concepts/client-count/faq#q-which-vault-version-reflects-the-most-accurate-client-counts"
+            >
+              Learn more here.
+            </DocLink>
+          </AlertInline>
+          <p class="has-left-padding-l">{{@upgradeExplanation}}</p>
+        </div>
+      {{/if}}
+    </M.Footer>
+  </Hds::Modal>
+{{/if}}

--- a/ui/app/templates/components/clients/attribution.hbs
+++ b/ui/app/templates/components/clients/attribution.hbs
@@ -91,7 +91,7 @@
 {{! MODAL FOR CSV DOWNLOAD }}
 {{#if this.showCSVDownloadModal}}
   <Hds::Modal id="attribution-csv-download-modal" @onClose={{fn (mut this.showCSVDownloadModal) false}} as |M|>
-    <M.Header @icon="info">
+    <M.Header @icon="info" data-test-export-modal-title>
       Export attribution data
     </M.Header>
     <M.Body>
@@ -101,7 +101,8 @@
         {{if this.formattedEndDate "date range" "month"}}.
       </p>
       <p class="has-bottom-margin-s is-subtitle-gray">SELECTED DATE {{if this.formattedEndDate " RANGE"}}</p>
-      <p class="has-bottom-margin-s">{{this.formattedStartDate}}
+      <p class="has-bottom-margin-s" data-test-export-date-range>
+        {{this.formattedStartDate}}
         {{if this.formattedEndDate "-"}}
         {{this.formattedEndDate}}</p>
     </M.Body>

--- a/ui/app/templates/components/clients/config.hbs
+++ b/ui/app/templates/components/clients/config.hbs
@@ -49,7 +49,7 @@
 
   {{#if this.modalOpen}}
     <Hds::Modal id="clients-config-modal" @color="warning" @onClose={{fn (mut this.modalOpen) false}} as |M|>
-      <M.Header @icon="alert-triangle">
+      <M.Header @icon="alert-triangle" data-test-clients-config-modal="title">
         {{this.modalTitle}}
       </M.Header>
       <M.Body>
@@ -70,7 +70,7 @@
       <M.Footer as |F|>
         <Hds::ButtonSet>
           <Hds::Button @text="Continue" {{on "click" (perform this.save)}} data-test-clients-config-modal="continue" />
-          <Hds::Button @text="Cancel" @color="secondary" {{on "click" F.close}} />
+          <Hds::Button @text="Cancel" @color="secondary" {{on "click" F.close}} data-test-clients-config-modal="cancel" />
         </Hds::ButtonSet>
       </M.Footer>
     </Hds::Modal>

--- a/ui/app/templates/components/clients/config.hbs
+++ b/ui/app/templates/components/clients/config.hbs
@@ -47,47 +47,34 @@
     </div>
   </form>
 
-  <Modal
-    @title={{this.modalTitle}}
-    @onClose={{action (mut this.modalOpen) false}}
-    @isActive={{this.modalOpen}}
-    @type="warning"
-    @showCloseButton={{true}}
-  >
-    <section class="modal-card-body">
-      {{#if (eq @model.enabled "On")}}
-        <p class="has-bottom-margin-s" data-test-clients-config-modal="on">
-          Vault will start tracking data starting from today’s date,
-          {{date-format (now) "MMMM d, yyyy"}}. If you’ve previously enabled usage tracking, that historical data will still
-          be available to you.
-        </p>
-      {{else}}
-        <p class="has-bottom-margin-s" data-test-clients-config-modal="off">
-          Turning usage tracking off means that all data for the current month will be deleted. You will still be able to
-          query previous months.
-        </p>
-        <p>Are you sure?</p>
-      {{/if}}
-    </section>
-    <footer class="modal-card-foot modal-card-foot-outlined">
-      <button
-        type="button"
-        class="button is-primary"
-        data-test-clients-config-modal="continue"
-        {{on "click" (perform this.save)}}
-      >
-        Continue
-      </button>
-      <button
-        type="button"
-        class="button is-secondary"
-        {{on "click" (fn (mut this.modalOpen) false)}}
-        data-test-clients-config-modal="cancel"
-      >
-        Cancel
-      </button>
-    </footer>
-  </Modal>
+  {{#if this.modalOpen}}
+    <Hds::Modal id="clients-config-modal" @color="warning" @onClose={{fn (mut this.modalOpen) false}} as |M|>
+      <M.Header @icon="alert-triangle">
+        {{this.modalTitle}}
+      </M.Header>
+      <M.Body>
+        {{#if (eq @model.enabled "On")}}
+          <p class="has-bottom-margin-s" data-test-clients-config-modal="on">
+            Vault will start tracking data starting from today’s date,
+            {{date-format (now) "MMMM d, yyyy"}}. If you’ve previously enabled usage tracking, that historical data will
+            still be available to you.
+          </p>
+        {{else}}
+          <p class="has-bottom-margin-s" data-test-clients-config-modal="off">
+            Turning usage tracking off means that all data for the current month will be deleted. You will still be able to
+            query previous months.
+          </p>
+          <p>Are you sure?</p>
+        {{/if}}
+      </M.Body>
+      <M.Footer as |F|>
+        <Hds::ButtonSet>
+          <Hds::Button @text="Continue" {{on "click" (perform this.save)}} data-test-clients-config-modal="continue" />
+          <Hds::Button @text="Cancel" @color="secondary" {{on "click" F.close}} />
+        </Hds::ButtonSet>
+      </M.Footer>
+    </Hds::Modal>
+  {{/if}}
 {{else}}
   <div class="tabs-container box is-bottomless is-marginless is-fullwidth is-paddingless" data-test-clients-config-table>
     {{#each this.infoRows as |item|}}

--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -354,7 +354,7 @@
 
 {{#if this.showSaveModal}}
   <Hds::Modal id="rotate-credentials-modal" @onClose={{this.continueWithoutRotate}} as |M|>
-    <M.Header @icon="info">
+    <M.Header @icon="info" data-test-db-connection-modal-title>
       Rotate your root credentials?
     </M.Header>
     <M.Body>

--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -352,35 +352,32 @@
   {{/each}}
 {{/if}}
 
-<Modal
-  @title="Rotate your root credentials?"
-  @onClose={{this.continueWithoutRotate}}
-  @isActive={{this.showSaveModal}}
-  @type="info"
-  @showCloseButton={{false}}
->
-  <section class="modal-card-body">
-    <p class="has-bottom-margin-s">
-      It’s best practice to rotate the root credential immediately after the initial configuration of each database. Once
-      rotated,
-      <strong>only Vault knows the new root password</strong>.
-    </p>
-    <p>Would you like to rotate your new credentials? You can also do this later.</p>
-  </section>
-  <footer class="modal-card-foot modal-card-foot-outlined">
-    <button
-      type="button"
-      class="button is-primary"
-      {{on "click" this.continueWithRotate}}
-      data-test-enable-rotate-connection
-    >
-      Rotate and enable
-    </button>
-    <button type="button" class="button is-secondary" {{on "click" this.continueWithoutRotate}} data-test-enable-connection>
-      Enable without rotating
-    </button>
-  </footer>
-</Modal>
+{{#if this.showSaveModal}}
+  <Hds::Modal id="rotate-credentials-modal" @onClose={{this.continueWithoutRotate}} as |M|>
+    <M.Header @icon="info">
+      Rotate your root credentials?
+    </M.Header>
+    <M.Body>
+      <p class="has-bottom-margin-s">
+        It’s best practice to rotate the root credential immediately after the initial configuration of each database. Once
+        rotated,
+        <strong>only Vault knows the new root password</strong>.
+      </p>
+      <p>Would you like to rotate your new credentials? You can also do this later.</p>
+    </M.Body>
+    <M.Footer>
+      <Hds::ButtonSet>
+        <Hds::Button @text="Rotate and enable" {{on "click" this.continueWithRotate}} data-test-enable-rotate-connection />
+        <Hds::Button
+          @text="Enable without rotating"
+          @color="secondary"
+          {{on "click" this.continueWithoutRotate}}
+          data-test-enable-connection
+        />
+      </Hds::ButtonSet>
+    </M.Footer>
+  </Hds::Modal>
+{{/if}}
 
 <ConfirmationModal
   @title="Delete connection?"

--- a/ui/app/templates/components/link-status.hbs
+++ b/ui/app/templates/components/link-status.hbs
@@ -4,9 +4,8 @@
 ~}}
 
 {{#if (and this.state this.version.isEnterprise)}}
-  <div class="has-padding-s link-status {{if (eq this.state 'connected') 'connected' 'warning'}}">
-    <Icon @name="info" />
-    <p data-test-link-status>
+  <Hds::Alert @type="page" @color={{if (eq this.state "connected") "success" "warning"}} as |A|>
+    <A.Title data-test-link-status>
       {{#if (eq this.state "connected")}}
         This self-managed Vault is linked to
         <ExternalLink @href="https://portal.cloud.hashicorp.com/sign-in">
@@ -14,16 +13,18 @@
         </ExternalLink>
       {{else}}
         There was an error connecting to HCP. Click
-        <Hds::Button @text="here" class="hds-text-button" {{on "click" (fn (mut this.showModal))}} />
+        <button type="button" class="text-button is-underline" {{on "click" (fn (mut this.showModal))}}>
+          here
+        </button>
         for more information.
       {{/if}}
-    </p>
-  </div>
+    </A.Title>
+  </Hds::Alert>
 {{/if}}
 
 {{#if this.showModal}}
-  <Hds::Modal id="hcp-link-error-modal" @onClose={{fn (mut this.showModal) false}} as |M|>
-    <M.Header @icon="info">
+  <Hds::Modal id="hcp-link-error-modal" @color="warning" @size="small" @onClose={{fn (mut this.showModal) false}} as |M|>
+    <M.Header @icon="alert-triangle">
       HCP Link error
     </M.Header>
     <M.Body>

--- a/ui/app/templates/components/link-status.hbs
+++ b/ui/app/templates/components/link-status.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 {{#if (and this.state this.version.isEnterprise)}}
-  <Hds::Alert @type="page" @color={{if (eq this.state "connected") "success" "warning"}} as |A|>
+  <Hds::Alert @type="page" @color={{if (eq this.state "connected") "neutral" "warning"}} as |A|>
     <A.Title data-test-link-status>
       {{#if (eq this.state "connected")}}
         This self-managed Vault is linked to

--- a/ui/app/templates/components/link-status.hbs
+++ b/ui/app/templates/components/link-status.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 {{#if (and this.state this.version.isEnterprise)}}
-  <div class="link-status {{if (eq this.state 'connected') 'connected' 'warning'}}">
+  <div class="has-padding-s link-status {{if (eq this.state 'connected') 'connected' 'warning'}}">
     <Icon @name="info" />
     <p data-test-link-status>
       {{#if (eq this.state "connected")}}
@@ -14,54 +14,44 @@
         </ExternalLink>
       {{else}}
         There was an error connecting to HCP. Click
-        <button type="button" class="text-button is-underline" {{on "click" (fn (mut this.showModal))}}>
-          here
-        </button>
+        <Hds::Button @text="here" class="hds-text-button" {{on "click" (fn (mut this.showModal))}} />
         for more information.
       {{/if}}
     </p>
   </div>
 {{/if}}
 
-<Modal
-  @title="HCP Link error"
-  @onClose={{fn (mut this.showModal) false}}
-  @isActive={{this.showModal}}
-  @type="info"
-  @showCloseButton={{true}}
->
-  <section class="modal-card-body">
-    <div>
-      <p class="has-text-weight-bold">Timestamp</p>
-      <p data-test-link-status-timestamp>
-        {{or this.timestamp "Not available"}}
-      </p>
-    </div>
-    <div class="has-top-bottom-margin">
-      <p class="has-text-weight-bold">Error</p>
-      {{#if this.error}}
-        <code class="tag has-text-danger" data-test-link-status-error>
-          {{this.error}}
-        </code>
-      {{else}}
-        <p data-test-link-status-error>
-          Not available
+{{#if this.showModal}}
+  <Hds::Modal id="hcp-link-error-modal" @onClose={{fn (mut this.showModal) false}} as |M|>
+    <M.Header @icon="info">
+      HCP Link error
+    </M.Header>
+    <M.Body>
+      <div>
+        <p class="has-text-weight-bold">Timestamp</p>
+        <p data-test-link-status-timestamp>
+          {{or this.timestamp "Not available"}}
         </p>
-      {{/if}}
-    </div>
-    <div>
-      <p class="has-text-weight-bold">Additional information</p>
-      <p>Check the logs for more information</p>
-    </div>
-  </section>
-  <footer class="modal-card-foot modal-card-foot-outlined">
-    <button
-      type="button"
-      class="button is-primary"
-      {{on "click" (fn (mut this.showModal) false)}}
-      data-test-link-status-close
-    >
-      Close
-    </button>
-  </footer>
-</Modal>
+      </div>
+      <div class="has-top-bottom-margin">
+        <p class="has-text-weight-bold">Error</p>
+        {{#if this.error}}
+          <code class="tag has-text-danger" data-test-link-status-error>
+            {{this.error}}
+          </code>
+        {{else}}
+          <p data-test-link-status-error>
+            Not available
+          </p>
+        {{/if}}
+      </div>
+      <div>
+        <p class="has-text-weight-bold">Additional information</p>
+        <p>Check the logs for more information</p>
+      </div>
+    </M.Body>
+    <M.Footer as |F|>
+      <Hds::Button type="button" @text="Close" {{on "click" F.close}} data-test-link-status-close />
+    </M.Footer>
+  </Hds::Modal>
+{{/if}}

--- a/ui/app/templates/components/oidc/scope-form.hbs
+++ b/ui/app/templates/components/oidc/scope-form.hbs
@@ -81,7 +81,7 @@
 </form>
 
 {{#if this.showTemplateModal}}
-  <Hds::Modal id="scope-template-modal" @onClose={{fn (mut this.showTemplateModal) false}} as |M|>
+  <Hds::Modal id="scope-template-modal" @size="large" @onClose={{fn (mut this.showTemplateModal) false}} as |M|>
     <M.Header>
       Scope template
     </M.Header>
@@ -89,20 +89,7 @@
       <p data-test-modal-text>
         Example of a JSON template for scopes:
       </p>
-      <Hds::Copy::Button
-        @text="Copy"
-        @isIconOnly={{true}}
-        @textToCopy={{this.exampleTemplate}}
-        class="transparent"
-        data-test-copy-button
-      />
-      <JsonEditor
-        @value={{this.exampleTemplate}}
-        @mode="ruby"
-        @readOnly={{true}}
-        @showToolbar={{false}}
-        @container=".hds-modal"
-      />
+      <JsonEditor @value={{this.exampleTemplate}} @mode="ruby" @readOnly={{true}} @container=".hds-modal" />
       <p class="has-top-margin-m">
         The full list of template parameters can be found
         <DocLink @path="/vault/docs/concepts/oidc-provider#scopes">

--- a/ui/app/templates/components/oidc/scope-form.hbs
+++ b/ui/app/templates/components/oidc/scope-form.hbs
@@ -82,11 +82,11 @@
 
 {{#if this.showTemplateModal}}
   <Hds::Modal id="scope-template-modal" @size="large" @onClose={{fn (mut this.showTemplateModal) false}} as |M|>
-    <M.Header>
+    <M.Header data-test-scope-modal="title">
       Scope template
     </M.Header>
     <M.Body>
-      <p data-test-modal-text>
+      <p data-test-scope-modal="text">
         Example of a JSON template for scopes:
       </p>
       <JsonEditor @value={{this.exampleTemplate}} @mode="ruby" @readOnly={{true}} @container=".hds-modal" />

--- a/ui/app/templates/components/oidc/scope-form.hbs
+++ b/ui/app/templates/components/oidc/scope-form.hbs
@@ -111,7 +111,7 @@
       </p>
     </M.Body>
     <M.Footer as |F|>
-      <Hds::Button type="button" @text="Close" {{on "click" F.close}} data-test-close-modal />
+      <Hds::Button @text="Close" {{on "click" F.close}} data-test-close-modal />
     </M.Footer>
   </Hds::Modal>
 {{/if}}

--- a/ui/app/templates/components/oidc/scope-form.hbs
+++ b/ui/app/templates/components/oidc/scope-form.hbs
@@ -29,6 +29,15 @@
       Scope
     </h1>
   </p.levelLeft>
+  <p.levelRight>
+    <Hds::Button
+      @text="How to write JSON template for scopes"
+      @icon="bulb"
+      @color="tertiary"
+      {{on "click" (fn (mut this.showTemplateModal))}}
+      data-test-oidc-scope-example
+    />
+  </p.levelRight>
 </PageHeader>
 
 <form {{on "submit" (perform this.save)}}>
@@ -41,15 +50,8 @@
       <FormField @attr={{field}} @model={{@model}} @modelValidations={{this.modelValidations}} />
     {{/each}}
     <p class="is-size-9 has-text-grey has-bottom-margin-l">
-      You can use Alt+Tab (Option+Tab on MacOS) in the code editor to skip to the next field. See
-      <button
-        type="button"
-        class="text-button has-text-info"
-        {{on "click" (fn (mut this.showTemplateModal))}}
-        data-test-oidc-scope-example
-      >
-        example template
-      </button>.
+      You can use Alt+Tab (Option+Tab on MacOS) in the code editor to skip to the next field. Click 'How to write JSON
+      template for scopes' to view an example.
     </p>
   </div>
   <div class="has-top-margin-l has-bottom-margin-l">
@@ -78,14 +80,12 @@
   {{/if}}
 </form>
 
-<Modal
-  @title="Scope template"
-  @onClose={{fn (mut this.showTemplateModal) false}}
-  @isActive={{this.showTemplateModal}}
-  @showCloseButton={{true}}
->
-  <section class="modal-card-body">
-    <div class="is-flex-between is-flex-center has-bottom-margin-s">
+{{#if this.showTemplateModal}}
+  <Hds::Modal id="scope-template-modal" @onClose={{fn (mut this.showTemplateModal) false}} as |M|>
+    <M.Header>
+      Scope template
+    </M.Header>
+    <M.Body>
       <p data-test-modal-text>
         Example of a JSON template for scopes:
       </p>
@@ -96,22 +96,22 @@
         class="transparent"
         data-test-copy-button
       />
-    </div>
-    {{! code-mirror modifier does not render value initially in wormhole until focus event fires }}
-    {{! wait until the Modal is rendered and then show the JsonEditor }}
-    {{#if this.showTemplateModal}}
-      <JsonEditor @value={{this.exampleTemplate}} @mode="ruby" @readOnly={{true}} @showToolbar={{false}} />
-    {{/if}}
-    <p class="has-top-margin-m">
-      The full list of template parameters can be found
-      <DocLink @path="/vault/docs/concepts/oidc-provider#scopes">
-        here.
-      </DocLink>
-    </p>
-  </section>
-  <div class="modal-card-head has-border-top-light">
-    <button type="button" class="button" {{on "click" (fn (mut this.showTemplateModal) false)}} data-test-close-modal>
-      Close
-    </button>
-  </div>
-</Modal>
+      <JsonEditor
+        @value={{this.exampleTemplate}}
+        @mode="ruby"
+        @readOnly={{true}}
+        @showToolbar={{false}}
+        @container=".hds-modal"
+      />
+      <p class="has-top-margin-m">
+        The full list of template parameters can be found
+        <DocLink @path="/vault/docs/concepts/oidc-provider#scopes">
+          here.
+        </DocLink>
+      </p>
+    </M.Body>
+    <M.Footer as |F|>
+      <Hds::Button type="button" @text="Close" {{on "click" F.close}} data-test-close-modal />
+    </M.Footer>
+  </Hds::Modal>
+{{/if}}

--- a/ui/app/templates/components/transformation-edit.hbs
+++ b/ui/app/templates/components/transformation-edit.hbs
@@ -53,14 +53,12 @@
       {{/if}}
       {{#if this.capabilities.canUpdate}}
         {{#if (gt this.model.allowed_roles.length 0)}}
-          <button
-            class="toolbar-link"
-            onclick={{action (mut this.isEditModalActive) true}}
-            type="button"
-            data-test-edit-link
-          >
-            Edit transformation
-          </button>
+          <Hds::Button
+            @text="Edit transformation"
+            @color="secondary"
+            class="toolbar-button"
+            {{on "click" (fn (mut this.isEditModalActive) true)}}
+          />
         {{else}}
           <ToolbarSecretLink @secret={{this.model.id}} @mode="edit" data-test-edit-link={{true}} @replace={{true}}>
             Edit transformation
@@ -96,30 +94,27 @@
   <MessageError @model={{this.model}} @errorMessage={{this.error}} />
 </ConfirmationModal>
 
-<Modal
-  @title="Edit transformation"
-  @onClose={{action (mut this.isEditModalActive) false}}
-  @isActive={{this.isEditModalActive}}
-  @type="warning"
-  @showCloseButton={{true}}
->
-  <section class="modal-card-body">
-    <p>
-      You’re editing a transformation that is in use by at least one role. Editing it may mean that encode and decode
-      operations stop working. Are you sure?
-    </p>
-  </section>
-  <footer class="modal-card-foot modal-card-foot-outlined">
-    <LinkTo
-      @route="vault.cluster.secrets.backend.edit"
-      @model={{this.model.id}}
-      class="button is-primary"
-      data-test-edit-confirm-button={{true}}
-    >
-      Confirm
-    </LinkTo>
-    <button type="button" class="button is-secondary" onclick={{action (mut this.isEditModalActive) false}}>
-      Cancel
-    </button>
-  </footer>
-</Modal>
+{{#if this.isEditModalActive}}
+  <Hds::Modal id="transformation-edit-modal" @color="warning" @onClose={{fn (mut this.isEditModalActive) false}} as |M|>
+    <M.Header>
+      Edit transformation
+    </M.Header>
+    <M.Body>
+      <p>
+        You’re editing a transformation that is in use by at least one role. Editing it may mean that encode and decode
+        operations stop working. Are you sure?
+      </p>
+    </M.Body>
+    <M.Footer as |F|>
+      <Hds::ButtonSet>
+        <Hds::Button
+          type="button"
+          @text="Confirm"
+          {{on "click" (transition-to "vault.cluster.secrets.backend.edit" this.model.id)}}
+          data-test-edit-confirm-button
+        />
+        <Hds::Button type="button" @color="secondary" @text="Cancel" {{on "click" F.close}} />
+      </Hds::ButtonSet>
+    </M.Footer>
+  </Hds::Modal>
+{{/if}}

--- a/ui/app/templates/components/transformation-edit.hbs
+++ b/ui/app/templates/components/transformation-edit.hbs
@@ -58,6 +58,7 @@
             @color="secondary"
             class="toolbar-button"
             {{on "click" (fn (mut this.isEditModalActive) true)}}
+            data-test-edit-link
           />
         {{else}}
           <ToolbarSecretLink @secret={{this.model.id}} @mode="edit" data-test-edit-link={{true}} @replace={{true}}>

--- a/ui/app/templates/components/transformation-edit.hbs
+++ b/ui/app/templates/components/transformation-edit.hbs
@@ -97,7 +97,7 @@
 
 {{#if this.isEditModalActive}}
   <Hds::Modal id="transformation-edit-modal" @color="warning" @onClose={{fn (mut this.isEditModalActive) false}} as |M|>
-    <M.Header>
+    <M.Header @icon="alert-triangle">
       Edit transformation
     </M.Header>
     <M.Body>
@@ -109,12 +109,12 @@
     <M.Footer as |F|>
       <Hds::ButtonSet>
         <Hds::Button
-          type="button"
           @text="Confirm"
-          {{on "click" (transition-to "vault.cluster.secrets.backend.edit" this.model.id)}}
+          @route="vault.cluster.secrets.backend.edit"
+          @model={{this.model.id}}
           data-test-edit-confirm-button
         />
-        <Hds::Button type="button" @color="secondary" @text="Cancel" {{on "click" F.close}} />
+        <Hds::Button @color="secondary" @text="Cancel" {{on "click" F.close}} />
       </Hds::ButtonSet>
     </M.Footer>
   </Hds::Modal>

--- a/ui/lib/core/addon/components/policy-example.hbs
+++ b/ui/lib/core/addon/components/policy-example.hbs
@@ -42,7 +42,14 @@
     </p>
   {{/if}}
 </div>
-<JsonEditor @value={{get this.policyTemplates @policyType}} @mode="ruby" @readOnly={{true}} @showToolbar={{true}} />
+<JsonEditor
+  @value={{get this.policyTemplates @policyType}}
+  @mode="ruby"
+  @readOnly={{true}}
+  @showToolbar={{true}}
+  {{! Passed to copy button }}
+  @container=".hds-modal"
+/>
 <div class="has-bottom-margin-m has-top-padding-s">
   <p>
     More information about

--- a/ui/lib/core/addon/components/search-select-with-modal.hbs
+++ b/ui/lib/core/addon/components/search-select-with-modal.hbs
@@ -94,6 +94,8 @@
       @isActive={{this.showModal}}
       @type="info"
       @showCloseButton={{false}}
+      {{! temporary class until Hds::Modal is fully adopted so dynamic components with copy buttons work }}
+      class="hds-modal"
     >
       <section class="modal-card-body">
         {{#if @modalSubtext}}

--- a/ui/tests/acceptance/secrets/backend/database/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/database/secret-test.js
@@ -281,7 +281,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
       await connectionPage.save();
       await settled();
       assert
-        .dom('.modal.is-active .title')
+        .dom('[data-test-db-connection-modal-title]')
         .hasText('Rotate your root credentials?', 'Modal appears asking to rotate root credentials');
       assert.dom('[data-test-enable-connection]').exists('Enable button exists');
       await click('[data-test-enable-connection]');
@@ -397,7 +397,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
     await connectionPage.save();
     await settled();
     assert
-      .dom('.modal.is-active .title')
+      .dom('[data-test-db-connection-modal-title]')
       .hasText('Rotate your root credentials?', 'Modal appears asking to ');
     await connectionPage.enable();
     assert.strictEqual(

--- a/ui/tests/integration/components/clients/attribution-test.js
+++ b/ui/tests/integration/components/clients/attribution-test.js
@@ -46,7 +46,6 @@ module('Integration | Component | clients/attribution', function (hooks) {
 
   test('it renders empty state with no data', async function (assert) {
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <Clients::Attribution @chartLegend={{this.chartLegend}} />
     `);
 
@@ -59,7 +58,6 @@ module('Integration | Component | clients/attribution', function (hooks) {
 
   test('it renders with data for namespaces', async function (assert) {
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <Clients::Attribution
         @chartLegend={{this.chartLegend}}
         @totalClientAttribution={{this.totalClientAttribution}}
@@ -93,7 +91,6 @@ module('Integration | Component | clients/attribution', function (hooks) {
     this.start = formatRFC3339(subMonths(this.mockNow, 1));
     this.end = formatRFC3339(subMonths(endOfMonth(this.mockNow), 1));
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <Clients::Attribution
         @chartLegend={{this.chartLegend}}
         @totalClientAttribution={{this.totalClientAttribution}}
@@ -147,7 +144,6 @@ module('Integration | Component | clients/attribution', function (hooks) {
 
   test('it renders single chart for current month', async function (assert) {
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <Clients::Attribution
         @chartLegend={{this.chartLegend}}
         @totalClientAttribution={{this.totalClientAttribution}}
@@ -169,7 +165,6 @@ module('Integration | Component | clients/attribution', function (hooks) {
 
   test('it renders single chart and correct text for for date range', async function (assert) {
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <Clients::Attribution
         @chartLegend={{this.chartLegend}}
         @totalClientAttribution={{this.totalClientAttribution}}
@@ -193,7 +188,6 @@ module('Integration | Component | clients/attribution', function (hooks) {
   test('it renders with data for selected namespace auth methods for a date range', async function (assert) {
     this.set('selectedNamespace', 'second');
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <Clients::Attribution
         @chartLegend={{this.chartLegend}}
         @totalClientAttribution={{this.namespaceMountsData}}
@@ -225,7 +219,6 @@ module('Integration | Component | clients/attribution', function (hooks) {
 
   test('it renders modal', async function (assert) {
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <Clients::Attribution
         @chartLegend={{this.chartLegend}}
         @totalClientAttribution={{this.namespaceMountsData}}
@@ -235,7 +228,9 @@ module('Integration | Component | clients/attribution', function (hooks) {
         />
     `);
     await click('[data-test-attribution-export-button]');
-    assert.dom('.modal.is-active .title').hasText('Export attribution data', 'modal appears to export csv');
-    assert.dom('.modal.is-active').includesText('June 2022 - December 2022');
+    assert
+      .dom('[data-test-export-modal-title]')
+      .hasText('Export attribution data', 'modal appears to export csv');
+    assert.dom('[ data-test-export-date-range]').includesText('June 2022 - December 2022');
   });
 });

--- a/ui/tests/integration/components/clients/config-test.js
+++ b/ui/tests/integration/components/clients/config-test.js
@@ -52,7 +52,7 @@ module('Integration | Component | client count config', function (hooks) {
   });
 
   test('it should function in edit mode when reporting is disabled', async function (assert) {
-    assert.expect(13);
+    assert.expect(12);
 
     this.server.put('/sys/internal/counters/config', (schema, req) => {
       const { enabled, retention_months } = JSON.parse(req.requestBody);
@@ -64,7 +64,6 @@ module('Integration | Component | client count config', function (hooks) {
     this.createModel('disable');
 
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <Clients::Config @model={{this.model}} @mode="edit" />
     `);
 
@@ -86,9 +85,8 @@ module('Integration | Component | client count config', function (hooks) {
 
     await fillIn('[data-test-input="retentionMonths"]', 24);
     await click('[data-test-clients-config-save]');
-    assert.dom('.modal.is-active').exists('Modal renders');
     assert
-      .dom('[data-test-modal-title] span')
+      .dom('[data-test-clients-config-modal="title"]')
       .hasText('Turn usage tracking on?', 'Correct modal title renders');
     assert.dom('[data-test-clients-config-modal="on"]').exists('Correct modal description block renders');
 
@@ -100,14 +98,14 @@ module('Integration | Component | client count config', function (hooks) {
 
     await click('[data-test-input="enabled"]');
     await click('[data-test-clients-config-save]');
-    assert.dom('.modal.is-active').exists('Modal renders');
+    assert.dom('[data-test-clients-config-modal]').exists('Modal renders');
     assert
-      .dom('[data-test-modal-title] span')
+      .dom('[data-test-clients-config-modal="title"]')
       .hasText('Turn usage tracking off?', 'Correct modal title renders');
     assert.dom('[data-test-clients-config-modal="off"]').exists('Correct modal description block renders');
 
     await click('[data-test-clients-config-modal="cancel"]');
-    assert.dom('.modal.is-active').doesNotExist('Modal is hidden on cancel');
+    assert.dom('[data-test-clients-config-modal]').doesNotExist('Modal is hidden on cancel');
   });
 
   test('it should function in edit mode when reporting is enabled', async function (assert) {
@@ -123,7 +121,6 @@ module('Integration | Component | client count config', function (hooks) {
     this.createModel('enable', true, 24);
 
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <Clients::Config @model={{this.model}} @mode="edit" />
     `);
 
@@ -162,7 +159,6 @@ module('Integration | Component | client count config', function (hooks) {
     this.createModel();
 
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <Clients::Config @model={{this.model}} @mode="edit" />
     `);
     await fillIn('[data-test-input="retentionMonths"]', 24);

--- a/ui/tests/integration/components/link-status-test.js
+++ b/ui/tests/integration/components/link-status-test.js
@@ -13,6 +13,9 @@ import { statuses } from '../../../mirage/handlers/hcp-link';
 const SELECTORS = {
   modalOpen: '[data-test-link-status] button',
   modalClose: '[data-test-icon="x"]',
+  bannerSuccess: '.hds-alert [data-test-icon="check-circle"]',
+  bannerWarning: '.hds-alert [data-test-icon="alert-triangle"]',
+  banner: '[data-test-link-status]',
 };
 
 module('Integration | Component | link-status', function (hooks) {
@@ -27,31 +30,28 @@ module('Integration | Component | link-status', function (hooks) {
 
   test('it does not render banner when status is not present', async function (assert) {
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <LinkStatus @status={{undefined}} />
     `);
 
-    assert.dom('.link-status').doesNotExist('Banner is hidden for missing status message');
+    assert.dom(SELECTORS.banner).doesNotExist('Banner is hidden for missing status message');
   });
 
   test('it does not render banner in oss version', async function (assert) {
     this.owner.lookup('service:version').set('version', '1.13.0');
 
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <LinkStatus @status={{get this.statuses 0}} />
     `);
 
-    assert.dom('.link-status').doesNotExist('Banner is hidden in oss');
+    assert.dom(SELECTORS.banner).doesNotExist('Banner is hidden in oss');
   });
 
   test('it renders connected status', async function (assert) {
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <LinkStatus @status={{get this.statuses 0}} />
     `);
 
-    assert.dom('.link-status').hasClass('connected', 'Correct banner class renders for connected state');
+    assert.dom(SELECTORS.bannerSuccess).exists('Success banner renders for connected state');
     assert
       .dom('[data-test-link-status]')
       .hasText('This self-managed Vault is linked to HCP.', 'Banner copy renders for connected state');
@@ -63,11 +63,10 @@ module('Integration | Component | link-status', function (hooks) {
   test('it should render error states', async function (assert) {
     // disconnected error
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <LinkStatus @status={{get this.statuses 1}} />
     `);
 
-    assert.dom('.link-status').hasClass('warning', 'Correct banner class renders for error state');
+    assert.dom(SELECTORS.bannerWarning).exists('Warning banner renders for error state');
     assert
       .dom('[data-test-link-status]')
       .hasText(
@@ -86,7 +85,6 @@ module('Integration | Component | link-status', function (hooks) {
     await click(SELECTORS.modalClose);
     // connecting error
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <LinkStatus @status={{get this.statuses 3}} />
     `);
     await click(SELECTORS.modalOpen);
@@ -97,7 +95,6 @@ module('Integration | Component | link-status', function (hooks) {
 
     // this shouldn't happen but placeholders should render if disconnected/connecting status is returned without timestamp and/or error
     await render(hbs`
-      <div id="modal-wormhole"></div>
       <LinkStatus @status="connecting" />
     `);
     await click(SELECTORS.modalOpen);

--- a/ui/tests/integration/components/link-status-test.js
+++ b/ui/tests/integration/components/link-status-test.js
@@ -13,7 +13,7 @@ import { statuses } from '../../../mirage/handlers/hcp-link';
 const SELECTORS = {
   modalOpen: '[data-test-link-status] button',
   modalClose: '[data-test-icon="x"]',
-  bannerSuccess: '.hds-alert [data-test-icon="check-circle"]',
+  bannerConnected: '.hds-alert [data-test-icon="info"]',
   bannerWarning: '.hds-alert [data-test-icon="alert-triangle"]',
   banner: '[data-test-link-status]',
 };
@@ -51,7 +51,7 @@ module('Integration | Component | link-status', function (hooks) {
       <LinkStatus @status={{get this.statuses 0}} />
     `);
 
-    assert.dom(SELECTORS.bannerSuccess).exists('Success banner renders for connected state');
+    assert.dom(SELECTORS.bannerConnected).exists('Success banner renders for connected state');
     assert
       .dom('[data-test-link-status]')
       .hasText('This self-managed Vault is linked to HCP.', 'Banner copy renders for connected state');

--- a/ui/tests/integration/components/link-status-test.js
+++ b/ui/tests/integration/components/link-status-test.js
@@ -10,6 +10,11 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { statuses } from '../../../mirage/handlers/hcp-link';
 
+const SELECTORS = {
+  modalOpen: '[data-test-link-status] button',
+  modalClose: '[data-test-icon="x"]',
+};
+
 module('Integration | Component | link-status', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
@@ -70,7 +75,7 @@ module('Integration | Component | link-status', function (hooks) {
         'Banner copy renders for error state'
       );
 
-    await click('[data-test-link-status] button');
+    await click(SELECTORS.modalOpen);
     assert
       .dom('[data-test-link-status-timestamp]')
       .hasText('2022-09-21T11:25:02.196835-07:00', 'Timestamp renders');
@@ -78,20 +83,25 @@ module('Integration | Component | link-status', function (hooks) {
       .dom('[data-test-link-status-error]')
       .hasText('unable to establish a connection with HCP', 'Error renders');
 
+    await click(SELECTORS.modalClose);
     // connecting error
     await render(hbs`
       <div id="modal-wormhole"></div>
       <LinkStatus @status={{get this.statuses 3}} />
     `);
+    await click(SELECTORS.modalOpen);
     assert
       .dom('[data-test-link-status-error]')
       .hasText('principal does not have the permission to register as a provider', 'Error renders');
+    await click(SELECTORS.modalClose);
 
     // this shouldn't happen but placeholders should render if disconnected/connecting status is returned without timestamp and/or error
     await render(hbs`
       <div id="modal-wormhole"></div>
       <LinkStatus @status="connecting" />
     `);
+    await click(SELECTORS.modalOpen);
+
     assert.dom('[data-test-link-status-timestamp]').hasText('Not available', 'Timestamp placeholder renders');
     assert.dom('[data-test-link-status-error]').hasText('Not available', 'Error placeholder renders');
   });

--- a/ui/tests/integration/components/oidc/scope-form-test.js
+++ b/ui/tests/integration/components/oidc/scope-form-test.js
@@ -151,7 +151,7 @@ module('Integration | Component | oidc/scope-form', function (hooks) {
   });
 
   test('it should show example template modal', async function (assert) {
-    assert.expect(8);
+    assert.expect(5);
     const MODAL = (e) => `[data-test-scope-modal="${e}"]`;
     this.model = this.store.createRecord('oidc/scope');
 
@@ -174,15 +174,14 @@ module('Integration | Component | oidc/scope-form', function (hooks) {
     `);
 
     await click('[data-test-oidc-scope-example]');
-    assert.dom(MODAL.title).hasText('Scope template', 'Modal title renders');
-    assert.dom(MODAL.text).hasText('Example of a JSON template for scopes:', 'Modal text renders');
-    assert.dom('[data-test-copy-button]').exists('Modal copy button renders');
+    assert.dom(MODAL('title')).hasText('Scope template', 'Modal title renders');
+    assert.dom(MODAL('text')).hasText('Example of a JSON template for scopes:', 'Modal text renders');
     assert
-      .dom('.hds#scope-template-modal [data-test-copy-button]')
+      .dom('#scope-template-modal [data-test-copy-button]')
       .hasAttribute('data-clipboard-text', exampleTemplate, 'Modal copy button copies the example template');
     assert.dom('.cm-string').hasText('"username"', 'Example template json renders');
     await click('[data-test-close-modal]');
-    assert.dom('[data-test-modal-div]').doesNotHaveClass('is-active', 'Modal is hidden');
+    assert.dom('.hds#scope-template-modal').doesNotExist('Modal is hidden');
   });
 
   test('it should render error alerts when API returns an error', async function (assert) {

--- a/ui/tests/integration/components/oidc/scope-form-test.js
+++ b/ui/tests/integration/components/oidc/scope-form-test.js
@@ -35,7 +35,6 @@ module('Integration | Component | oidc/scope-form', function (hooks) {
         @onCancel={{this.onCancel}}
         @onSave={{this.onSave}}
       />
-      <div id="modal-wormhole"></div>
     `);
 
     assert.dom('[data-test-oidc-scope-title]').hasText('Create Scope', 'Form title renders');
@@ -87,7 +86,6 @@ module('Integration | Component | oidc/scope-form', function (hooks) {
         @onCancel={{this.onCancel}}
         @onSave={{this.onSave}}
       />
-      <div id="modal-wormhole"></div>
     `);
 
     assert.dom('[data-test-oidc-scope-title]').hasText('Edit Scope', 'Form title renders');
@@ -122,7 +120,6 @@ module('Integration | Component | oidc/scope-form', function (hooks) {
         @onCancel={{this.onCancel}}
         @onSave={{this.onSave}}
       />
-      <div id="modal-wormhole"></div>
     `);
 
     await click(SELECTORS.scopeCancelButton);
@@ -155,7 +152,7 @@ module('Integration | Component | oidc/scope-form', function (hooks) {
 
   test('it should show example template modal', async function (assert) {
     assert.expect(8);
-
+    const MODAL = (e) => `[data-test-scope-modal="${e}"]`;
     this.model = this.store.createRecord('oidc/scope');
 
     // formatting here is purposeful so that it matches formatting in the template modal
@@ -174,19 +171,14 @@ module('Integration | Component | oidc/scope-form', function (hooks) {
         @onCancel={{this.onCancel}}
         @onSave={{this.onSave}}
       />
-      <div id="modal-wormhole"></div>
     `);
 
-    assert.dom('[data-test-modal-div]').doesNotHaveClass('is-active', 'Modal is hidden');
     await click('[data-test-oidc-scope-example]');
-    assert.dom('[data-test-modal-div]').hasClass('is-active', 'Modal is shown');
-    assert.dom('[data-test-modal-title]').hasText('Scope template', 'Modal title renders');
-    assert
-      .dom('[data-test-modal-text]')
-      .hasText('Example of a JSON template for scopes:', 'Modal text renders');
+    assert.dom(MODAL.title).hasText('Scope template', 'Modal title renders');
+    assert.dom(MODAL.text).hasText('Example of a JSON template for scopes:', 'Modal text renders');
     assert.dom('[data-test-copy-button]').exists('Modal copy button renders');
     assert
-      .dom('[data-test-modal-div] [data-test-copy-button]')
+      .dom('.hds#scope-template-modal [data-test-copy-button]')
       .hasAttribute('data-clipboard-text', exampleTemplate, 'Modal copy button copies the example template');
     assert.dom('.cm-string').hasText('"username"', 'Example template json renders');
     await click('[data-test-close-modal]');
@@ -203,7 +195,6 @@ module('Integration | Component | oidc/scope-form', function (hooks) {
         @onCancel={{this.onCancel}}
         @onSave={{this.onSave}}
       />
-      <div id="modal-wormhole"></div>
     `);
     await fillIn('[data-test-input="name"]', 'test-scope');
     await click(SELECTORS.scopeSaveButton);

--- a/ui/tests/integration/components/search-select-with-modal-test.js
+++ b/ui/tests/integration/components/search-select-with-modal-test.js
@@ -146,7 +146,9 @@ module('Integration | Component | search select with modal', function (hooks) {
     );
     await component.selectOption();
 
-    assert.dom('[data-test-modal-div]').hasAttribute('class', 'modal is-info is-active', 'modal is active');
+    assert
+      .dom('[data-test-modal-div]')
+      .hasAttribute('class', 'modal is-info is-active hds-modal', 'modal is active');
     assert.dom('[data-test-empty-state-title]').hasText('No policy type selected');
     assert.ok(this.onChange.notCalled, 'onChange is not called');
   });

--- a/ui/tests/integration/components/sidebar/frame-test.js
+++ b/ui/tests/integration/components/sidebar/frame-test.js
@@ -37,7 +37,7 @@ module('Integration | Component | sidebar-frame', function (hooks) {
       </Sidebar::Frame>
     `);
 
-    assert.dom('.link-status').exists('Link status component renders');
+    assert.dom('[data-test-link-status]').exists('Link status component renders');
     assert.dom('[data-test-component="console/ui-panel"]').exists('Console UI panel renders');
     assert.dom('.page-container').exists('Block yields for app content');
   });


### PR DESCRIPTION
🔄  Replaces modal in

- `policy-form.hbs`
- `clients/attribution.hbs`
- `clients/config.hbs`
- `database-connection.hbs`
- `link-status.hbs` * pending design questions with this one
- `scope-form.hbs`
- `transformation-edit.hbs`