### PR TITLE
auth/saml: adds API docs for verbose_logging config

### DIFF
--- a/website/content/api-docs/auth/saml.mdx
+++ b/website/content/api-docs/auth/saml.mdx
@@ -46,6 +46,10 @@ Configures the auth method with a SAML identity provider.
   protection.
 - `default_role` `(string, <optional>)` - The role to use if no role is provided during login.
   If not set, a role is required during login.
+- `verbose_logging` `(bool, false)` - Log additional information during the SAML exchange.
+  The user attributes will be logged when debug-level logging is active. The full SAML response
+  will be logged when trace-level logging is active. **Not recommended** in production since
+  sensitive information may be present in SAML responses.
 
 ### Sample payload
 

--- a/website/content/api-docs/auth/saml.mdx
+++ b/website/content/api-docs/auth/saml.mdx
@@ -46,10 +46,11 @@ Configures the auth method with a SAML identity provider.
   protection.
 - `default_role` `(string, <optional>)` - The role to use if no role is provided during login.
   If not set, a role is required during login.
-- `verbose_logging` `(bool, false)` - Log additional information during the SAML exchange.
-  The user attributes will be logged when debug-level logging is active. The full SAML response
-  will be logged when trace-level logging is active. **Not recommended** in production since
-  sensitive information may be present in SAML responses.
+- `verbose_logging` `(bool, false)` - **Not recommended for production**. Log
+  additional, **potentially sensitive** information during the SAML exchange
+  according to the current logging level. When `verbose_logging` is `true`,
+  debug logs capture user attributes and trace logs capture the full SAML
+  response object.
 
 ### Sample payload
 

--- a/website/content/api-docs/auth/saml.mdx
+++ b/website/content/api-docs/auth/saml.mdx
@@ -49,8 +49,8 @@ Configures the auth method with a SAML identity provider.
 - `verbose_logging` `(bool, false)` - **Not recommended for production**. Log
   additional, **potentially sensitive** information during the SAML exchange
   according to the current logging level. When `verbose_logging` is `true`,
-  debug logs capture user attributes and trace logs capture the full SAML
-  response object.
+  debug-level logs provide user attributes and trace-level logs provide the full
+  SAML response.
 
 ### Sample payload
 


### PR DESCRIPTION
This PR adds API documentation for the `verbose_logging` option in the SAML auth method configuration.