### PR TITLE
Bump versions within transit managed key known issues

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -44,3 +44,9 @@ option.
 ## Application of Sentinel Role Governing Policies (RGPs) via identity groups
 
 @include 'application-of-sentinel-rgps-via-identity-groups.mdx'
+
+## Known issues and workarounds
+
+@include 'known-issues/transit-managed-keys-panics.mdx'
+
+@include 'known-issues/transit-managed-keys-sign-fails.mdx'

--- a/website/content/partials/known-issues/transit-managed-keys-panics.mdx
+++ b/website/content/partials/known-issues/transit-managed-keys-panics.mdx
@@ -2,8 +2,9 @@
 
 #### Affected versions
 
-- 1.13.1+ up to 1.13.7 inclusively
-- 1.14.0+ up to 1.14.3 inclusively
+- 1.13.1+ up to 1.13.8 inclusively
+- 1.14.0+ up to 1.14.4 inclusively
+- 1.15.0
 
 #### Issue
 

--- a/website/content/partials/known-issues/transit-managed-keys-sign-fails.mdx
+++ b/website/content/partials/known-issues/transit-managed-keys-sign-fails.mdx
@@ -2,7 +2,8 @@
 
 #### Affected versions
 
-- 1.14.0+ up to 1.14.3 inclusively
+- 1.14.0+ up to 1.14.4 inclusively
+- 1.15.0
 
 #### Issue
 


### PR DESCRIPTION
We missed the window for the next releases for the transit managed key fixes so update the affected versions within the existing known issues.