### PR TITLE
Kubernetes reference architecture link removal

### DIFF
--- a/website/content/docs/platform/k8s/index.mdx
+++ b/website/content/docs/platform/k8s/index.mdx
@@ -52,7 +52,7 @@ There are several ways to try Vault with Kubernetes in different environments.
 
 - [Integrate a Kubernetes Cluster with an External Vault](/vault/tutorials/kubernetes/kubernetes-external-vault) provides an example of making Vault accessible via a Kubernetes service and endpoint.
 
-- [Vault on Kubernetes Deployment Guide](/vault/tutorials/kubernetes/kubernetes-raft-deployment-guide) covers the steps required to install and configure a single HashiCorp Vault cluster as defined in the [Vault on Kubernetes Reference Architecture](/vault/tutorials/kubernetes/kubernetes-reference-architecture).
+- [Vault on Kubernetes Deployment Guide](/vault/tutorials/kubernetes/kubernetes-raft-deployment-guide) covers the steps required to install and configure a single HashiCorp Vault cluster.
 
 ### High level comparison of integrations
 
@@ -77,7 +77,5 @@ There are currently 3 different integrations to help Kubernetes workloads seamle
 - No durable secret storage outside Vault if the secret sync feature isn't used. All secrets written to disk are in ephemeral in-memory volumes.
 
 ### Documentation
-
-- [Vault on Kubernetes Reference Architecture](/vault/tutorials/kubernetes/kubernetes-reference-architecture) provides recommended practices for running Vault on Kubernetes in production.
 
 - [Vault on Kubernetes Security Considerations](/vault/tutorials/kubernetes/kubernetes-security-concerns) provides recommendations specific to securely running Vault in a production Kubernetes environment.


### PR DESCRIPTION
https://developer.hashicorp.com/vault/docs/platform/k8s contained references to the Vault reference architecture for Kubernetes, however it looks like this has been [removed from tutorials](https://github.com/hashicorp/tutorials/pull/1617).

This PR removes the references to clear things up.

Vercel deployed page: https://vault-c150g3d53-hashicorp.vercel.app/vault/docs/platform/k8s