### PR TITLE
removed references to Vault reference architecture on Kubernetes

### DIFF
--- a/website/content/docs/platform/k8s/index.mdx
+++ b/website/content/docs/platform/k8s/index.mdx
@@ -52,10 +52,8 @@ There are several ways to try Vault with Kubernetes in different environments.
 
 - [Integrate a Kubernetes Cluster with an External Vault](https://learn.hashicorp.com/tutorials/vault/kubernetes-external-vault) provides an example of making Vault accessible via a Kubernetes service and endpoint.
 
-- [Vault on Kubernetes Deployment Guide](https://learn.hashicorp.com/tutorials/vault/kubernetes-raft-deployment-guide) covers the steps required to install and configure a single HashiCorp Vault cluster as defined in the [Vault on Kubernetes Reference Architecture](https://learn.hashicorp.com/tutorials/vault/kubernetes-reference-architecture).
+- [Vault on Kubernetes Deployment Guide](https://learn.hashicorp.com/tutorials/vault/kubernetes-raft-deployment-guide) covers the steps required to install and configure a single HashiCorp Vault cluster.
 
 ### Documentation
-
-- [Vault on Kubernetes Reference Architecture](https://learn.hashicorp.com/tutorials/vault/kubernetes-reference-architecture) provides recommended practices for running Vault on Kubernetes in production.
 
 - [Vault on Kubernetes Security Considerations](https://learn.hashicorp.com/tutorials/vault/kubernetes-security-concerns) provides recommendations specific to securely running Vault in a production Kubernetes environment.


### PR DESCRIPTION
https://developer.hashicorp.com/vault/docs/platform/k8s contained references to the Vault reference architecture for Kubernetes, however it looks like this has been https://github.com/hashicorp/tutorials/pull/1617.

This PR removes the references to clear things up.

Manually backported to `1.12.x` based on PR: https://github.com/hashicorp/vault/pull/23381