### PR TITLE
core/link: fix bug where lock was unlocked before getting ha state

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -718,7 +718,7 @@ func (c *Core) HAState() consts.HAState {
 
 func (c *Core) HAStateWithLock() consts.HAState {
 	c.stateLock.RLock()
-	c.stateLock.RUnlock()
+	defer c.stateLock.RUnlock()
 
 	return c.HAState()
 }


### PR DESCRIPTION
Missing a defer causing the a lock to be unlocked too early.