### PR TITLE
UI: [VAULT-19693] Only make vault configuration call when in root namespace

### DIFF
--- a/ui/app/routes/vault/cluster/dashboard.js
+++ b/ui/app/routes/vault/cluster/dashboard.js
@@ -17,6 +17,8 @@ export default class VaultClusterDashboardRoute extends Route.extend(ClusterRout
 
   async getVaultConfiguration() {
     try {
+      if (!this.namespace.inRootNamespace) return null;
+
       const adapter = this.store.adapterFor('application');
       const configState = await adapter.ajax('/v1/sys/config/state/sanitized', 'GET');
       return configState.data;


### PR DESCRIPTION
Update the dashboard so it doesn't make a request to the vault configuration api endpoint unless it's in a root namespace. This endpoint is restricted to root namespace users.

https://developer.hashicorp.com/vault/api-docs/system/config-state