### PR TITLE
test: restart socket sink if it's not listening

### DIFF
--- a/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
+++ b/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
@@ -12,14 +12,17 @@ set -exo pipefail
 nohup nc -kl 9090 &> /dev/null < /dev/null &
 
 # Wait for nc to be listening before we attempt to enable the socket auditor.
-retries=3
+attempts=3
 count=0
 until nc -zv 127.0.0.1 9090 &> /dev/null < /dev/null; do
   wait=$((2 ** count))
   count=$((count + 1))
 
-  if [ "$count" -lt "$retries" ]; then
+  if [ "$count" -le "$attempts" ]; then
     sleep "$wait"
+    if ! pgrep -x nc; then
+      nohup nc -kl 9090 &> /dev/null < /dev/null &
+    fi
   else
 
     echo "Timed out waiting for nc to listen on 127.0.0.1:9090" 1>&2


### PR DESCRIPTION
We occasionally see initial failures when waiting for the netcat listener to start for the vault socket auditor sink. This usually happens on RHEL but I haven't been able to figure out why. On the retry it always seems to work, which I assume is due to attempting to start the listener again. This adds a checks for the process in the retry loop and starts it again if we can't find it.