### PR TITLE
Bug fix for double slash in LIST endpoint

### DIFF
--- a/changelog/23446.txt
+++ b/changelog/23446.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix bug where a change on OpenAPI added a double forward slash on some LIST endpoints.
+```

--- a/ui/app/services/path-help.js
+++ b/ui/app/services/path-help.js
@@ -244,7 +244,7 @@ export default Service.extend({
 
     return generatedItemAdapter.extend({
       urlForItem(id, isList, dynamicApiPath) {
-        const itemType = getPath.path.slice(1);
+        const itemType = sanitizePath(getPath.path);
         let url;
         id = encodePath(id);
         // the apiPath changes when you switch between routes but the apiPath variable does not unless the model is reloaded


### PR DESCRIPTION
This UI only regression bug was potentially introduced by this [PR](https://github.com/hashicorp/vault/pull/21723). 

The reproduction steps of how the bug was reported:
1. on a binary
2. Create a namespace
3. Within the namespace mount the auth method userpass.
4. Create a user userpass and navigate to the list view. No users would show and there was a 301 followed by a 404 error on the network request on this LIST endpoint. if you look closely, you'll see a double forward slash. 
`http://localhost:4200/v1/auth/userpass/users//?list=true`

This fix cleans out the double forward slash and resolves the issue. The `sanitizePath` method removes any whitespace and trailing and leading slashes.

TODO:
- test to make sure doesn't break anything ✅
- run enterprise tests locally. ✅