### PR TITLE
[VAULT-20630] CI: Fix the CI workflow issue where we check out base ref instead of the ref that triggered the workflow run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       # control checking out head instead of base ref by a GH label
       # if checkout-head label is added to a PR, checkout HEAD otherwise checkout base_ref
       - if: ${{ !contains(github.event.pull_request.labels.*.name, 'checkout-head') }}
-        run: echo "CHECKOUT_REF=${{ github.base_ref }}" >> "$GITHUB_ENV"
+        run: echo "CHECKOUT_REF=${{ github.ref }}" >> "$GITHUB_ENV"
       - if: ${{ contains(github.event.pull_request.labels.*.name, 'checkout-head') }}
         run: echo "CHECKOUT_REF=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_ENV"
       - id: checkout-ref-output


### PR DESCRIPTION
In #22817, we've introduced a CI bug where we started checking out the `github.base_ref` instead of the `github.ref`, which meant the tests were running against the target branch of the pull request, so not testing the changes.

From the docs: https://docs.github.com/en/actions/learn-github-actions/contexts

`github.base_ref`  
The base_ref or target branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either pull_request or pull_request_target.

`github.ref`
The fully-formed ref of the branch or tag that triggered the workflow run. For workflows triggered by push, this is the branch or tag ref that was pushed. For workflows triggered by pull_request, this is the pull request merge branch.