### PR TITLE
[VAULT-20630] CI: Use 'ref' (not 'base_ref') as a default git reference to check out code in the test-go GHA workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
         with:
           github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
           no-restore: true # don't download them on a cache hit
-      # control checking out head instead of base ref by a GH label
-      # if checkout-head label is added to a PR, checkout HEAD otherwise checkout base_ref
+      # control checking out head instead of default ref by a GH label
+      # if checkout-head label is added to a PR, checkout HEAD otherwise checkout ref
       - if: ${{ !contains(github.event.pull_request.labels.*.name, 'checkout-head') }}
         run: echo "CHECKOUT_REF=${{ github.ref }}" >> "$GITHUB_ENV"
       - if: ${{ contains(github.event.pull_request.labels.*.name, 'checkout-head') }}

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -70,7 +70,7 @@ on:
       checkout-ref:
         description: The ref to use for checkout.
         required: false
-        default: ${{ github.base_ref }}
+        default: ${{ github.ref }}
         type: string
 
 env: ${{ fromJSON(inputs.env-vars) }}


### PR DESCRIPTION
A companion PR to #23453. 

This one changes the default value of the `checkout-ref` input in the test-go.yml workflow (from `github.base_ref` to `github.ref`). Currently, nothing (that I am aware of) uses that default, but it could bite us in the future.