### PR TITLE
docs: link to the VSO+HVS quick-start tutorial

### DIFF
--- a/website/content/docs/platform/k8s/vso/sources/hvs.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/hvs.mdx
@@ -74,3 +74,9 @@ spec:
 ```
 
 @include 'vso/blurb-api-reference.mdx'
+
+## Tutorial
+
+Refer to the [HCP Vault Secrets with Vault Secrets Operator for
+Kubernetes](/vault/tutorials/hcp-vault-secrets-get-started/kubernetes-vso) tutorial to
+learn the end-to-end workflow using the Vault Secrets Operator.


### PR DESCRIPTION
PR adds a link to https://developer.hashicorp.com/vault/tutorials/hcp-vault-secrets-get-started/kubernetes-vso.