### PR TITLE
Proof of concept Pre-Authentication flow

### DIFF
--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -271,6 +271,7 @@ type MountConfigInput struct {
 	AllowedManagedKeys        []string                `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
 	PluginVersion             string                  `json:"plugin_version,omitempty"`
 	UserLockoutConfig         *UserLockoutConfigInput `json:"user_lockout_config,omitempty"`
+	DelegatedAuthAccessors    []string                `json:"delegated_auth_accessors,omitempty" mapstructure:"delegated_auth_accessors"`
 	// Deprecated: This field will always be blank for newer server responses.
 	PluginName string `json:"plugin_name,omitempty" mapstructure:"plugin_name"`
 }
@@ -303,6 +304,8 @@ type MountConfigOutput struct {
 	TokenType                 string                   `json:"token_type,omitempty" mapstructure:"token_type"`
 	AllowedManagedKeys        []string                 `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
 	UserLockoutConfig         *UserLockoutConfigOutput `json:"user_lockout_config,omitempty"`
+	DelegatedAuthAccessors    []string                 `json:"delegated_auth_accessors,omitempty" mapstructure:"delegated_auth_accessors"`
+
 	// Deprecated: This field will always be blank for newer server responses.
 	PluginName string `json:"plugin_name,omitempty" mapstructure:"plugin_name"`
 }

--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -45,6 +45,9 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*backend, error)
 				"archive/",
 				"policy/",
 			},
+			Unauthenticated: []string{
+				"preauth-test",
+			},
 		},
 
 		Paths: []*framework.Path{
@@ -75,6 +78,7 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*backend, error)
 			b.pathConfigKeys(),
 			b.pathCreateCsr(),
 			b.pathImportCertChain(),
+			b.pathPreauthTest(),
 		},
 
 		Secrets:      []*framework.Secret{},

--- a/builtin/logical/transit/path_preauth.go
+++ b/builtin/logical/transit/path_preauth.go
@@ -20,12 +20,16 @@ func (b *backend) pathPreauthTest() *framework.Path {
 		},
 		Fields: map[string]*framework.FieldSchema{
 			"accessor": {
-				Type:     framework.TypeString,
-				Required: false,
+				Type: framework.TypeString,
 			},
 			"path": {
-				Type:     framework.TypeString,
-				Required: false,
+				Type: framework.TypeString,
+			},
+			"username": {
+				Type: framework.TypeString,
+			},
+			"password": {
+				Type: framework.TypeString,
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -42,11 +46,19 @@ func (b *backend) pathPreauthTest() *framework.Path {
 
 func (b *backend) handlePreauthTest(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	if req.ClientTokenSource != logical.ClientTokenFromInternalAuth {
-		da := logical.NewDelegatedAuthenticationRequest(d.Get("accessor").(string), paths.Join(d.Get("path").(string), req.Data["username"].(string)), nil)
+		da := logical.NewDelegatedAuthenticationRequest(d.Get("accessor").(string), paths.Join(d.Get("path").(string), d.Get("username").(string)),
+			map[string]interface{}{
+				"password": d.Get("password").(string),
+			},
+			nil)
 		delete(req.Data, "username")
 		return nil, da
 	} else {
 		delete(req.Data, "password")
 	}
-	return &logical.Response{}, nil
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"success": true,
+		},
+	}, nil
 }

--- a/builtin/logical/transit/path_preauth.go
+++ b/builtin/logical/transit/path_preauth.go
@@ -31,6 +31,10 @@ func (b *backend) pathPreauthTest() *framework.Path {
 			"password": {
 				Type: framework.TypeString,
 			},
+			"loop": {
+				Type:    framework.TypeBool,
+				Default: false,
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
@@ -45,6 +49,14 @@ func (b *backend) pathPreauthTest() *framework.Path {
 }
 
 func (b *backend) handlePreauthTest(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if d.Get("loop").(bool) {
+		da := logical.NewDelegatedAuthenticationRequest(d.Get("accessor").(string), paths.Join(d.Get("path").(string), d.Get("username").(string)),
+			map[string]interface{}{
+				"password": d.Get("password").(string),
+			},
+			nil)
+		return nil, da
+	}
 	if req.ClientTokenSource != logical.ClientTokenFromInternalAuth {
 		da := logical.NewDelegatedAuthenticationRequest(d.Get("accessor").(string), paths.Join(d.Get("path").(string), d.Get("username").(string)),
 			map[string]interface{}{

--- a/builtin/logical/transit/path_preauth.go
+++ b/builtin/logical/transit/path_preauth.go
@@ -51,10 +51,7 @@ func (b *backend) handlePreauthTest(ctx context.Context, req *logical.Request, d
 				"password": d.Get("password").(string),
 			},
 			nil)
-		delete(req.Data, "username")
 		return nil, da
-	} else {
-		delete(req.Data, "password")
 	}
 	return &logical.Response{
 		Data: map[string]interface{}{

--- a/builtin/logical/transit/path_preauth.go
+++ b/builtin/logical/transit/path_preauth.go
@@ -42,7 +42,7 @@ func (b *backend) pathPreauthTest() *framework.Path {
 
 func (b *backend) handlePreauthTest(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	if req.ClientTokenSource != logical.ClientTokenFromInternalAuth {
-		da := logical.NewDelegatedAuthenticationError(d.Get("accessor").(string), paths.Join(d.Get("path").(string), req.Data["username"].(string)), nil)
+		da := logical.NewDelegatedAuthenticationRequest(d.Get("accessor").(string), paths.Join(d.Get("path").(string), req.Data["username"].(string)), nil)
 		delete(req.Data, "username")
 		return nil, da
 	} else {

--- a/builtin/logical/transit/path_preauth.go
+++ b/builtin/logical/transit/path_preauth.go
@@ -45,6 +45,8 @@ func (b *backend) handlePreauthTest(ctx context.Context, req *logical.Request, d
 		da := logical.NewDelegatedAuthenticationError(d.Get("accessor").(string), paths.Join(d.Get("path").(string), req.Data["username"].(string)), nil)
 		delete(req.Data, "username")
 		return nil, da
+	} else {
+		delete(req.Data, "password")
 	}
 	return &logical.Response{}, nil
 }

--- a/builtin/logical/transit/path_preauth.go
+++ b/builtin/logical/transit/path_preauth.go
@@ -5,6 +5,7 @@ package transit
 
 import (
 	"context"
+	paths "path"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -40,8 +41,10 @@ func (b *backend) pathPreauthTest() *framework.Path {
 }
 
 func (b *backend) handlePreauthTest(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	if req.ClientTokenSource == logical.NoClientToken {
-		return nil, logical.NewDelegatedAuthenticationError(d.Get("accessor").(string), d.Get("path").(string))
+	if req.ClientTokenSource != logical.ClientTokenFromInternalAuth {
+		da := logical.NewDelegatedAuthenticationError(d.Get("accessor").(string), paths.Join(d.Get("path").(string), req.Data["username"].(string)), nil)
+		delete(req.Data, "username")
+		return nil, da
 	}
 	return &logical.Response{}, nil
 }

--- a/builtin/logical/transit/path_preauth.go
+++ b/builtin/logical/transit/path_preauth.go
@@ -1,0 +1,47 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package transit
+
+import (
+	"context"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func (b *backend) pathPreauthTest() *framework.Path {
+	return &framework.Path{
+		Pattern: "preauth-test",
+
+		DisplayAttrs: &framework.DisplayAttributes{
+			OperationPrefix: operationPrefixTransit,
+		},
+		Fields: map[string]*framework.FieldSchema{
+			"accessor": {
+				Type:     framework.TypeString,
+				Required: false,
+			},
+			"path": {
+				Type:     framework.TypeString,
+				Required: false,
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.handlePreauthTest,
+				Summary:  "Returns the size of the active cache",
+				DisplayAttrs: &framework.DisplayAttributes{
+					OperationSuffix: "cache-configuration",
+				},
+			},
+		},
+	}
+}
+
+func (b *backend) handlePreauthTest(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if req.ClientTokenSource == logical.NoClientToken {
+		return nil, logical.NewDelegatedAuthenticationError(d.Get("accessor").(string), d.Get("path").(string))
+	}
+	return &logical.Response{}, nil
+}

--- a/command/commands.go
+++ b/command/commands.go
@@ -161,6 +161,9 @@ const (
 	// flagNameLogLevel is used to specify the log level applied to logging
 	// Supported log levels: Trace, Debug, Error, Warn, Info
 	flagNameLogLevel = "log-level"
+	// flagNameDelegatedAuthAccessors allows operators to specify the allowed mount accessors a backend can delegate
+	// authentication
+	flagNameDelegatedAuthAccessors = "delegated-auth-accessors"
 )
 
 var (

--- a/command/secrets_tune.go
+++ b/command/secrets_tune.go
@@ -35,6 +35,7 @@ type SecretsTuneCommand struct {
 	flagVersion                   int
 	flagPluginVersion             string
 	flagAllowedManagedKeys        []string
+	flagDelegatedAuthAccessors    []string
 }
 
 func (c *SecretsTuneCommand) Synopsis() string {
@@ -158,6 +159,14 @@ func (c *SecretsTuneCommand) Flags() *FlagSets {
 			"the plugin catalog, and will not start running until the plugin is reloaded.",
 	})
 
+	f.StringSliceVar(&StringSliceVar{
+		Name:   flagNameDelegatedAuthAccessors,
+		Target: &c.flagDelegatedAuthAccessors,
+		Usage: "A list of permitted authentication accessors this backend can delegate authentication too. " +
+			"Note that multiple values may be specified by providing this option multiple times, " +
+			"each time with 1 accessor.",
+	})
+
 	return set
 }
 
@@ -241,6 +250,10 @@ func (c *SecretsTuneCommand) Run(args []string) int {
 
 		if fl.Name == flagNamePluginVersion {
 			mountConfigInput.PluginVersion = c.flagPluginVersion
+		}
+
+		if fl.Name == flagNameDelegatedAuthAccessors {
+			mountConfigInput.DelegatedAuthAccessors = c.flagDelegatedAuthAccessors
 		}
 	})
 

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -50,7 +50,8 @@ type Backend struct {
 	//
 	// PathsSpecial is the list of path patterns that denote the paths above
 	// that require special privileges.
-	Paths        []*Path
+	Paths []*Path
+
 	PathsSpecial *logical.Paths
 
 	// Secrets is the list of secret types that this backend can

--- a/sdk/logical/error.go
+++ b/sdk/logical/error.go
@@ -65,12 +65,14 @@ var (
 type DelegatedAuthenticationError struct {
 	mountAccessor string
 	path          string
+	extraData     map[string]interface{}
 }
 
-func NewDelegatedAuthenticationError(mountAccessor, path string) *DelegatedAuthenticationError {
+func NewDelegatedAuthenticationError(mountAccessor, path string, extraData map[string]interface{}) *DelegatedAuthenticationError {
 	return &DelegatedAuthenticationError{
 		mountAccessor: mountAccessor,
 		path:          path,
+		extraData:     extraData,
 	}
 }
 
@@ -84,6 +86,10 @@ func (d *DelegatedAuthenticationError) MountAccessor() string {
 
 func (d *DelegatedAuthenticationError) Path() string {
 	return d.path
+}
+
+func (d *DelegatedAuthenticationError) ExtraData() map[string]interface{} {
+	return d.extraData
 }
 
 type HTTPCodedError interface {

--- a/sdk/logical/error.go
+++ b/sdk/logical/error.go
@@ -61,6 +61,31 @@ var (
 	ErrPathFunctionalityRemoved = errors.New("functionality on this path has been removed")
 )
 
+// Special error indicating the backend wants to delegate authentication elsewhere
+type DelegatedAuthenticationError struct {
+	mountAccessor string
+	path          string
+}
+
+func NewDelegatedAuthenticationError(mountAccessor, path string) *DelegatedAuthenticationError {
+	return &DelegatedAuthenticationError{
+		mountAccessor: mountAccessor,
+		path:          path,
+	}
+}
+
+func (d *DelegatedAuthenticationError) Error() string {
+	return "authentication delegation requested"
+}
+
+func (d *DelegatedAuthenticationError) MountAccessor() string {
+	return d.mountAccessor
+}
+
+func (d *DelegatedAuthenticationError) Path() string {
+	return d.path
+}
+
 type HTTPCodedError interface {
 	Error() string
 	Code() int

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -56,6 +56,7 @@ const (
 	NoClientToken ClientTokenSource = iota
 	ClientTokenFromVaultHeader
 	ClientTokenFromAuthzHeader
+	ClientTokenFromInternalAuth
 )
 
 type WALState struct {

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -411,16 +411,17 @@ type Operation string
 
 const (
 	// The operations below are called per path
-	CreateOperation         Operation = "create"
-	ReadOperation                     = "read"
-	UpdateOperation                   = "update"
-	PatchOperation                    = "patch"
-	DeleteOperation                   = "delete"
-	ListOperation                     = "list"
-	HelpOperation                     = "help"
-	AliasLookaheadOperation           = "alias-lookahead"
-	ResolveRoleOperation              = "resolve-role"
-	HeaderOperation                   = "header"
+	CreateOperation          Operation = "create"
+	ReadOperation                      = "read"
+	UpdateOperation                    = "update"
+	PatchOperation                     = "patch"
+	DeleteOperation                    = "delete"
+	ListOperation                      = "list"
+	HelpOperation                      = "help"
+	AliasLookaheadOperation            = "alias-lookahead"
+	ResolveRoleOperation               = "resolve-role"
+	HeaderOperation                    = "header"
+	PreAuthenticateOperation           = "pre-authenticate"
 
 	// The operations below are called globally, the path is less relevant.
 	RevokeOperation   Operation = "revoke"

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -412,17 +412,16 @@ type Operation string
 
 const (
 	// The operations below are called per path
-	CreateOperation          Operation = "create"
-	ReadOperation                      = "read"
-	UpdateOperation                    = "update"
-	PatchOperation                     = "patch"
-	DeleteOperation                    = "delete"
-	ListOperation                      = "list"
-	HelpOperation                      = "help"
-	AliasLookaheadOperation            = "alias-lookahead"
-	ResolveRoleOperation               = "resolve-role"
-	HeaderOperation                    = "header"
-	PreAuthenticateOperation           = "pre-authenticate"
+	CreateOperation         Operation = "create"
+	ReadOperation                     = "read"
+	UpdateOperation                   = "update"
+	PatchOperation                    = "patch"
+	DeleteOperation                   = "delete"
+	ListOperation                     = "list"
+	HelpOperation                     = "help"
+	AliasLookaheadOperation           = "alias-lookahead"
+	ResolveRoleOperation              = "resolve-role"
+	HeaderOperation                   = "header"
 
 	// The operations below are called globally, the path is less relevant.
 	RevokeOperation   Operation = "revoke"

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -6388,4 +6388,8 @@ This path responds to the following HTTP methods.
 			Returns the available and enabled experiments.
 		`,
 	},
+	"delegated_auth_accessors": {
+		"A list of auth accessors that the mount is allowed to delegate authentication too",
+		"",
+	},
 }

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -4395,6 +4395,10 @@ func (b *SystemBackend) mountPaths() []*framework.Path {
 					Type:        framework.TypeCommaStringSlice,
 					Description: strings.TrimSpace(sysHelp["tune_allowed_managed_keys"][0]),
 				},
+				"delegated_auth_accessors": {
+					Type: framework.TypeCommaStringSlice,
+					// Description: strings.TrimSpace(sysHelp["tune_allowed_managed_keys"][0]),
+				},
 				"plugin_version": {
 					Type:        framework.TypeString,
 					Description: strings.TrimSpace(sysHelp["plugin-catalog_version"][0]),
@@ -4444,6 +4448,11 @@ func (b *SystemBackend) mountPaths() []*framework.Path {
 									Type:        framework.TypeCommaStringSlice,
 									Description: strings.TrimSpace(sysHelp["tune_allowed_managed_keys"][0]),
 									Required:    false,
+								},
+								"delegated_auth_accessors": {
+									Type: framework.TypeCommaStringSlice,
+									// Description: strings.TrimSpace(sysHelp["tune_allowed_managed_keys"][0]),
+									Required: false,
 								},
 								"allowed_response_headers": {
 									Type:        framework.TypeCommaStringSlice,

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -4396,8 +4396,8 @@ func (b *SystemBackend) mountPaths() []*framework.Path {
 					Description: strings.TrimSpace(sysHelp["tune_allowed_managed_keys"][0]),
 				},
 				"delegated_auth_accessors": {
-					Type: framework.TypeCommaStringSlice,
-					// Description: strings.TrimSpace(sysHelp["tune_allowed_managed_keys"][0]),
+					Type:        framework.TypeCommaStringSlice,
+					Description: strings.TrimSpace(sysHelp["allowed_delegated_auth_accessors"][0]),
 				},
 				"plugin_version": {
 					Type:        framework.TypeString,
@@ -4450,9 +4450,9 @@ func (b *SystemBackend) mountPaths() []*framework.Path {
 									Required:    false,
 								},
 								"delegated_auth_accessors": {
-									Type: framework.TypeCommaStringSlice,
-									// Description: strings.TrimSpace(sysHelp["tune_allowed_managed_keys"][0]),
-									Required: false,
+									Type:        framework.TypeCommaStringSlice,
+									Description: strings.TrimSpace(sysHelp["delegated_auth_accessors"][0]),
+									Required:    false,
 								},
 								"allowed_response_headers": {
 									Type:        framework.TypeCommaStringSlice,

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -376,6 +376,7 @@ type MountConfig struct {
 	TokenType                 logical.TokenType     `json:"token_type,omitempty" structs:"token_type" mapstructure:"token_type"`
 	AllowedManagedKeys        []string              `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
 	UserLockoutConfig         *UserLockoutConfig    `json:"user_lockout_config,omitempty" mapstructure:"user_lockout_config"`
+	DelegatedAuthAccessors    []string              `json:"delegated_auth_accessors,omitempty" mapstructure:"delegated_auth_accessors"`
 
 	// PluginName is the name of the plugin registered in the catalog.
 	//

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -134,8 +134,9 @@ func (c *Core) generateMountAccessor(entryType string) (string, error) {
 
 // MountTable is used to represent the internal mount table
 type MountTable struct {
-	Type    string        `json:"type"`
-	Entries []*MountEntry `json:"entries"`
+	Type              string        `json:"type"`
+	Entries           []*MountEntry `json:"entries"`
+	entriesByAccessor map[string]*MountEntry
 }
 
 type MountMigrationStatus int
@@ -288,6 +289,21 @@ func (t *MountTable) findByBackendUUID(ctx context.Context, backendUUID string) 
 
 	for i := 0; i < n; i++ {
 		if entry := t.Entries[i]; entry.BackendAwareUUID == backendUUID && entry.Namespace().ID == ns.ID {
+			return entry, nil
+		}
+	}
+	return nil, nil
+}
+
+func (t *MountTable) findByAccessor(ctx context.Context, accessor string) (*MountEntry, error) {
+	n := len(t.Entries)
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < n; i++ {
+		if entry := t.Entries[i]; entry.Accessor == accessor && entry.Namespace().ID == ns.ID {
 			return entry, nil
 		}
 	}

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1528,6 +1528,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 			}
 
 			// Found it, now form the login path and issue the request
+			// TODO: Prevent recursive loops
 			path := paths.Join("auth", mount.Path, da.Path())
 			req2, err := req.Clone()
 			if err != nil {
@@ -1542,7 +1543,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 				}
 			}
 
-			resp, auth, err = c.handleLoginRequest(ctx, req2)
+			resp, err = c.handleCancelableRequest(ctx, req2)
 			if err == logical.ErrInvalidCredentials {
 				return handleInvalidCreds()
 			} else if err != nil {

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -762,7 +762,7 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 	walState := &logical.WALState{}
 	ctx = logical.IndexStateContext(ctx, walState)
 	var auth *logical.Auth
-	if c.isLoginRequest(ctx, req) {
+	if c.isLoginRequest(ctx, req) && req.ClientTokenSource != logical.ClientTokenFromInternalAuth {
 		resp, auth, err = c.handleLoginRequest(ctx, req)
 	} else {
 		resp, auth, err = c.handleRequest(ctx, req)
@@ -1563,13 +1563,13 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 			}
 
 			// Authentication successful, use the resulting ClientToken to reissue the original request
-			authReq, err = req.Clone()
+			secondReq, err := req.Clone()
 			if err != nil {
 				return nil, nil, err
 			}
-			authReq.ClientToken = authResp.Auth.ClientToken
-			authReq.ClientTokenSource = logical.ClientTokenFromInternalAuth
-			resp2, err := c.handleCancelableRequest(ctx, authReq)
+			secondReq.ClientToken = authResp.Auth.ClientToken
+			secondReq.ClientTokenSource = logical.ClientTokenFromInternalAuth
+			resp2, err := c.handleCancelableRequest(ctx, secondReq)
 			return resp2, nil, err
 		}
 	}

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1530,46 +1530,46 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 			// Found it, now form the login path and issue the request
 			// TODO: Prevent recursive loops
 			path := paths.Join("auth", mount.Path, da.Path())
-			req2, err := req.Clone()
+			authReq, err := req.Clone()
 			if err != nil {
 				return nil, nil, err
 			}
-			req2.MountAccessor = requestedAccessor
-			req2.Path = path
+			authReq.MountAccessor = requestedAccessor
+			authReq.Path = path
 			// Clear the data fields for the new request
-			req2.Data = make(map[string]interface{})
+			authReq.Data = make(map[string]interface{})
 			if da.Data() != nil {
 				// Add any other data fields the auth method might need, provided dynamically by the source mount
 				for k, v := range da.Data() {
-					req2.Data[k] = v
+					authReq.Data[k] = v
 				}
 			}
 
-			resp, err = c.handleCancelableRequest(ctx, req2)
+			authResp, err := c.handleCancelableRequest(ctx, authReq)
 			if err != nil || resp.IsError() {
 				// see if the backend wishes to handle the failed auth
 				if da.AuthErrorHandler() != nil {
-					resp, err = da.AuthErrorHandler()(ctx, req, req2, resp, err)
+					resp, err := da.AuthErrorHandler()(ctx, req, authReq, authResp, err)
 					return resp, nil, err
 				}
 				switch err {
 				case nil:
-					return resp, nil, nil
+					return authResp, nil, nil
 				case logical.ErrInvalidCredentials:
 					return handleInvalidCreds(err)
 				default:
-					return resp, nil, err
+					return authResp, nil, err
 				}
 			}
 
 			// Authentication successful, use the resulting ClientToken to reissue the original request
-			req2, err = req.Clone()
+			authReq, err = req.Clone()
 			if err != nil {
 				return nil, nil, err
 			}
-			req2.ClientToken = resp.Auth.ClientToken
-			req2.ClientTokenSource = logical.ClientTokenFromInternalAuth
-			resp2, err := c.handleCancelableRequest(ctx, req2)
+			authReq.ClientToken = authResp.Auth.ClientToken
+			authReq.ClientTokenSource = logical.ClientTokenFromInternalAuth
+			resp2, err := c.handleCancelableRequest(ctx, authReq)
 			return resp2, nil, err
 		}
 	}

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -952,7 +952,7 @@ func (c *Core) doRouting(ctx context.Context, req *logical.Request) (*logical.Re
 }
 
 func (c *Core) isLoginRequest(ctx context.Context, req *logical.Request) bool {
-	return c.router.LoginPath(ctx, req.Path) && req.ClientToken == ""
+	return c.router.LoginPath(ctx, req.Path)
 }
 
 func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp *logical.Response, retAuth *logical.Auth, retErr error) {

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	paths "path"
 	"strconv"
 	"strings"
 	"time"
@@ -950,7 +951,7 @@ func (c *Core) doRouting(ctx context.Context, req *logical.Request) (*logical.Re
 }
 
 func (c *Core) isLoginRequest(ctx context.Context, req *logical.Request) bool {
-	return c.router.LoginPath(ctx, req.Path)
+	return c.router.LoginPath(ctx, req.Path) && req.ClientToken == ""
 }
 
 func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp *logical.Response, retAuth *logical.Auth, retErr error) {
@@ -1489,8 +1490,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 	// Route the request
 	resp, routeErr := c.doRouting(ctx, req)
 
-	// if routeErr has invalid credentials error, update the userFailedLoginMap
-	if routeErr != nil && routeErr == logical.ErrInvalidCredentials {
+	handleInvalidCreds := func() (*logical.Response, *logical.Auth, error) {
 		if !isUserLockoutDisabled {
 			err := c.failedUserLoginProcess(ctx, entry, req)
 			if err != nil {
@@ -1498,6 +1498,43 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 			}
 		}
 		return resp, nil, routeErr
+	}
+
+	if routeErr != nil {
+		// if routeErr has invalid credentials error, update the userFailedLoginMap
+		if routeErr == logical.ErrInvalidCredentials {
+			return handleInvalidCreds()
+		} else if da, ok := routeErr.(*logical.DelegatedAuthenticationError); ok {
+			// If the route is requesting delegated authentication...
+			mount, err := c.auth.findByAccessor(ctx, da.MountAccessor())
+			if err != nil {
+				return nil, nil, err
+			}
+			if mount == nil {
+				return nil, nil, fmt.Errorf("backend requested delegate authentication but mount with accessor '%s' not found", da.MountAccessor())
+			}
+			path := paths.Join("auth", mount.Path, da.Path())
+			req2, err := req.Clone()
+			if err != nil {
+				return nil, nil, err
+			}
+			req2.MountAccessor = da.MountAccessor()
+			req2.Path = path
+			resp, auth, err = c.handleLoginRequest(ctx, req2)
+			if err == logical.ErrInvalidCredentials {
+				return handleInvalidCreds()
+			} else if err != nil {
+				return nil, nil, err
+			}
+			req2, err = req.Clone()
+			if err != nil {
+				return nil, nil, err
+			}
+			req2.ClientToken = resp.Auth.ClientToken
+			req2.ClientTokenSource = logical.ClientTokenFromVaultHeader // TODO: From internal
+			resp2, err := c.handleCancelableRequest(ctx, req2)
+			return resp2, nil, err
+		}
 	}
 
 	if resp != nil {

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1374,7 +1374,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 
 	// Return the response and error
 	if routeErr != nil {
-		if _, ok := routeErr.(*logical.DelegatedAuthenticationError); ok {
+		if _, ok := routeErr.(*logical.RequestDelegatedAuth); ok {
 			routeErr = fmt.Errorf("delegated authentication requested but authentication token present")
 		}
 
@@ -1495,21 +1495,21 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 	// Route the request
 	resp, routeErr := c.doRouting(ctx, req)
 
-	handleInvalidCreds := func() (*logical.Response, *logical.Auth, error) {
+	handleInvalidCreds := func(err error) (*logical.Response, *logical.Auth, error) {
 		if !isUserLockoutDisabled {
 			err := c.failedUserLoginProcess(ctx, entry, req)
 			if err != nil {
 				return nil, nil, err
 			}
 		}
-		return resp, nil, routeErr
+		return resp, nil, err
 	}
 
 	if routeErr != nil {
 		// if routeErr has invalid credentials error, update the userFailedLoginMap
 		if routeErr == logical.ErrInvalidCredentials {
-			return handleInvalidCreds()
-		} else if da, ok := routeErr.(*logical.DelegatedAuthenticationError); ok {
+			return handleInvalidCreds(routeErr)
+		} else if da, ok := routeErr.(*logical.RequestDelegatedAuth); ok {
 			// Backend has requested internally delegated authentication
 
 			requestedAccessor := da.MountAccessor()
@@ -1536,18 +1536,30 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 			}
 			req2.MountAccessor = requestedAccessor
 			req2.Path = path
-			if da.ExtraData() != nil {
+			// Clear the data fields for the new request
+			req2.Data = make(map[string]interface{})
+			if da.Data() != nil {
 				// Add any other data fields the auth method might need, provided dynamically by the source mount
-				for k, v := range da.ExtraData() {
+				for k, v := range da.Data() {
 					req2.Data[k] = v
 				}
 			}
 
 			resp, err = c.handleCancelableRequest(ctx, req2)
-			if err == logical.ErrInvalidCredentials {
-				return handleInvalidCreds()
-			} else if err != nil {
-				return nil, nil, err
+			if err != nil || resp.IsError() {
+				// see if the backend wishes to handle the failed auth
+				if da.AuthErrorHandler() != nil {
+					resp, err = da.AuthErrorHandler()(ctx, req, req2, resp, err)
+					return resp, nil, err
+				}
+				switch err {
+				case nil:
+					return resp, nil, nil
+				case logical.ErrInvalidCredentials:
+					return handleInvalidCreds(err)
+				default:
+					return resp, nil, err
+				}
 			}
 
 			// Authentication successful, use the resulting ClientToken to reissue the original request

--- a/website/content/api-docs/system/mounts.mdx
+++ b/website/content/api-docs/system/mounts.mdx
@@ -379,6 +379,9 @@ This endpoint tunes configuration parameters for a given mount point.
 - `plugin_version` `(string: "")` – Specifies the semantic version of the plugin
   to use, e.g. "v1.0.0". Changes will not take effect until the mount is reloaded.
 
+- `delegated_auth_accessors` `(array: [])` - List of allowed authentication mount
+  accessors the backend can request delegated authentication for.
+
 ### Sample payload
 
 ```json


### PR DESCRIPTION
Adds a special error return, DelegatedAuthenticationError, which can be used to signal to the request processing system that an internal call to an auth mount is needed before re-processing this request.  In this spike the mount accessor is provided by the backend, and so would have to be a configuration element. 

In addition, I added a mount tuneable to allow access to mounts for pre-auth purposes.  This may or may not be overkill.

When encountering the error, the pre-auth mount is resolved, and any extra data the backend likes is tacked onto the auth request.  The auth method is called, and if successful, the client token is re-set on the initial request and the initial request is re-handled. 

API endpoints that need pre-auth have to be declared Unauthenticated, and detect that they need pre-auth, returning the above error, and then subsequently detecting that auth occurred (and occurred internally), to finish processing the call.