### PR TITLE
Allow AWS secret engine to send empty policy document

### DIFF
--- a/changelog/23470.txt
+++ b/changelog/23470.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix AWS secret engine to allow empty policy_document field.
+```

--- a/ui/app/models/role-aws.js
+++ b/ui/app/models/role-aws.js
@@ -54,7 +54,7 @@ export default Model.extend({
     editType: 'json',
     helpText:
       'A policy is an object in AWS that, when associated with an identity or resource, defines their permissions.',
-    defaultValue: '{\n}',
+    // Cannot have a default_value on policy_document because in some cases AWS expects this value to be empty.
   }),
   fields: computed('credentialType', function () {
     const credentialType = this.credentialType;

--- a/ui/lib/core/addon/helpers/jsonify.js
+++ b/ui/lib/core/addon/helpers/jsonify.js
@@ -6,6 +6,8 @@
 import { helper as buildHelper } from '@ember/component/helper';
 
 export function jsonify([target]) {
+  // aws secret engine needs to be able to send an empty json value on the field policy_document
+  if (!target) return;
   return JSON.parse(target);
 }
 


### PR DESCRIPTION
This fixes a regression caused by a PR [here](https://github.com/hashicorp/vault/pull/19117/files#diff-21e5ef7b872398bce34be2638fe826222f894d722d838292c289ca95a9a10508R52) that fixed a larger issue.

AWS is a unique case where we can't default the json form field to an empty object. A user needs to return nothing if no `policy_document` is added.

**With the fix:**

https://github.com/hashicorp/vault/assets/6618863/b0ef6e6d-9cf5-43a8-882b-6d503627d34d


