### PR TITLE
Set VAULT_TEST_LOG_DIR, logs from NewTestLogger will be written there

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -350,6 +350,9 @@ jobs:
             fi
           fi
 
+          export VAULT_TEST_LOG_DIR=test-results/go-test/logs
+          mkdir -p $VAULT_TEST_LOG_DIR
+          
           # shellcheck disable=SC2086 # can't quote RERUN_FAILS
           GOARCH=${{ inputs.go-arch }} \
             gotestsum --format=short-verbose \


### PR DESCRIPTION
The goal is to avoid overwhelming the GHA UI with excessive log lines, so we can see failures without having to download logs.