### PR TITLE
Backport 1.14.1x: Allow AWS secret engine to send empty policy document (#23470)

### DIFF
--- a/changelog/23470.txt
+++ b/changelog/23470.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix AWS secret engine to allow empty policy_document field.
+```

--- a/ui/app/helpers/jsonify.js
+++ b/ui/app/helpers/jsonify.js
@@ -6,6 +6,8 @@
 import { helper as buildHelper } from '@ember/component/helper';
 
 export function jsonify([target]) {
+  // aws secret engine needs to be able to send an empty json value on the field policy_document
+  if (!target) return;
   return JSON.parse(target);
 }
 

--- a/ui/app/models/role-aws.js
+++ b/ui/app/models/role-aws.js
@@ -54,7 +54,7 @@ export default Model.extend({
     editType: 'json',
     helpText:
       'A policy is an object in AWS that, when associated with an identity or resource, defines their permissions.',
-    defaultValue: '{\n}',
+    // Cannot have a default_value on policy_document because in some cases AWS expects this value to be empty.
   }),
   fields: computed('credentialType', function () {
     const credentialType = this.credentialType;


### PR DESCRIPTION
Manual Backport of [PR](https://github.com/hashicorp/vault/pull/23470)