### PR TITLE
Fix copy button in collapsed sidebar nav in CopyButton component

### DIFF
--- a/ui/app/components/sidebar/user-menu.hbs
+++ b/ui/app/components/sidebar/user-menu.hbs
@@ -39,12 +39,13 @@
                   </LinkTo>
                 </li>
               {{/if}}
-              <li class="action">
+              <li class="action" id="container">
                 <CopyButton
                   @clipboardText={{this.auth.currentToken}}
                   class="link"
                   @buttonType="button"
                   @success={{action (set-flash-message "Token copied!")}}
+                  @container="#container"
                 >
                   Copy token
                 </CopyButton>


### PR DESCRIPTION
This is more or less a manual backport but with changes because we don't have the HDS copy button in 1.15. See original PR [here](https://github.com/hashicorp/vault/pull/23331). 