### PR TITLE
[DOCS] Confirm restricted endpoint alerts (main)

### DIFF
--- a/website/content/api-docs/system/audit-hash.mdx
+++ b/website/content/api-docs/system/audit-hash.mdx
@@ -8,13 +8,13 @@ description: |-
 
 # `/sys/audit-hash`
 
+@include 'alerts/restricted-admin.mdx'
+
 The `/sys/audit-hash` endpoint is used to calculate the hash of the data used by
 an audit device's hash function and salt. This can be used to search audit logs
 for a hashed value when the original value is known.
 
 ## Calculate hash
-
-@include 'alerts/restricted-admin.mdx'
 
 This endpoint hashes the given input data with the specified audit device's
 hash function and salt. This endpoint can be used to discover whether a given

--- a/website/content/api-docs/system/mfa/index.mdx
+++ b/website/content/api-docs/system/mfa/index.mdx
@@ -8,6 +8,8 @@ description: >-
 
 # `/sys/mfa`
 
+@include 'alerts/restricted-root.mdx'
+
 The `/sys/mfa` endpoint focuses on managing Multi-factor Authentication (MFA)
 behaviors in Vault Enterprise MFA.
 

--- a/website/content/api-docs/system/monitor.mdx
+++ b/website/content/api-docs/system/monitor.mdx
@@ -6,14 +6,14 @@ description: The `/sys/monitor` endpoint is used to receive streaming logs from 
 
 # `/sys/monitor`
 
+@include 'alerts/restricted-admin.mdx'
+
 The `/sys/monitor` endpoint is used to receive streaming logs from the Vault server.
 
 If Vault is emitting log messages faster than a receiver can process them, then
 some log lines will be dropped.
 
 ## Monitor system logs
-
-- @include 'alerts/restricted-admin.mdx'
 
 This endpoint streams logs back to the client from Vault. Note that unlike most API endpoints in Vault, this one
 does not return JSON by default. This will send back data in whatever log format Vault has been configured with. By

--- a/website/content/partials/api/restricted-endpoints.mdx
+++ b/website/content/partials/api/restricted-endpoints.mdx
@@ -7,7 +7,7 @@
 API path                                  | Root | Admin
 ----------------------------------------- | ---- | -----
 `sys/audit`                               | YES  | NO
-`sys/audit-hash/`                         | YES  | YES
+`sys/audit-hash`                          | YES  | YES
 `sys/config/auditing/*`                   | YES  | NO
 `sys/config/cors`                         | YES  | NO
 `sys/config/group-policy-application`     | YES  | NO
@@ -22,43 +22,35 @@ API path                                  | Root | Admin
 `sys/host-info`                           | YES  | NO
 `sys/in-flight-req`                       | YES  | NO
 `sys/init`                                | YES  | NO
-`sys/internal/inspect/router`             | YES  | NO
+`sys/internal/counters/activity`          | YES  | NO
+`sys/internal/counters/activity/export`   | YES  | NO
+`sys/internal/counters/activity/monthly`  | YES  | NO
+`sys/internal/counters/config`            | YES  | NO
+`sys/internal/inspect/router/*`           | YES  | NO
 `sys/key-status`                          | YES  | NO
 `sys/loggers`                             | YES  | NO
+`sys/managed-keys/*`                      | YES  | NO
 `sys/metrics`                             | YES  | NO
+`sys/mfa/method/*`                        | YES  | NO
 `sys/monitor`                             | YES  | YES
-`sys/pprof`                               | YES  | NO
-`sys/pprof/allocs`                        | YES  | NO
-`sys/pprof/block`                         | YES  | NO
-`sys/pprof/cmdline`                       | YES  | NO
-`sys/pprof/goroutine`                     | YES  | NO
-`sys/pprof/heap`                          | YES  | NO
-`sys/pprof/mutex`                         | YES  | NO
-`sys/pprof/profile`                       | YES  | NO
-`sys/pprof/symbol`                        | YES  | NO
-`sys/pprof/threadcreate`                  | YES  | NO
-`sys/pprof/trace`                         | YES  | NO
+`sys/pprof/*`                             | YES  | NO
 `sys/quotas/config`                       | YES  | NO
 `sys/quotas/lease-count`                  | YES  | NO
 `sys/quotas/rate-limit`                   | YES  | NO
 `sys/raw`                                 | YES  | NO
 `sys/rekey/*`                             | YES  | NO
 `sys/rekey-recovery-key`                  | YES  | NO
-`sys/replication`                         | YES  | NO
-`sys/rotate`                              | YES  | NO
+`sys/replication/recover                  | YES  | NO
+`sys/replication/reindex                  | YES  | NO
+`sys/replication/status                   | YES  | NO
+`sys/replication/merkle-check             | YES  | NO
 `sys/rotate/config`                       | YES  | NO
+`sys/rotate`                              | YES  | NO
 `sys/seal`                                | YES  | NO
 `sys/sealwrap/rewrap`                     | YES  | NO
-`sys/managed-keys/*`                      | YES  | NO
 `sys/step-down`                           | YES  | NO
 `sys/storage`                             | YES  | NO
 `sys/unseal`                              | YES  | NO
-`sys/internal/counters/activity`          | YES  | NO
-`sys/internal/counters/activity/monthly`  | YES  | NO
-`sys/internal/counters/config`            | YES  | NO
-`sys/internal/counters/activity/export`   | YES  | NO
-`sys/internal/inspect/router/*`           | YES  | NO
-`sys/mfa/method/*`                        | YES  | NO
 
 Privileged CLI commands without public API endpoints:
 


### PR DESCRIPTION
Confirm correct alerts on restricted endpoints and clean up the restricted endpoint table to remove duplicates and simplify entries when all endpoints under the path are restricted.