### PR TITLE
Policies Error Route

### DIFF
--- a/changelog/23516.txt
+++ b/changelog/23516.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes issue with sidebar navigation links disappearing when navigating to policies when a user is not authorized
+```

--- a/ui/app/templates/vault/cluster/policies/error.hbs
+++ b/ui/app/templates/vault/cluster/policies/error.hbs
@@ -1,0 +1,28 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+~}}
+
+{{#if (eq this.model.httpStatus 404)}}
+  <NotFound @model={{this.model}} />
+{{else}}
+  <PageHeader as |p|>
+    <p.levelLeft>
+      <h1 class="title is-3 has-text-grey">
+        {{#if (eq this.model.httpStatus 403)}}
+          Not authorized
+        {{else}}
+          Error
+        {{/if}}
+      </h1>
+    </p.levelLeft>
+  </PageHeader>
+  <div class="box is-sideless has-background-white-bis has-text-grey has-text-centered">
+    {{#if this.model.message}}
+      <p>{{this.model.message}}</p>
+    {{/if}}
+    {{#each this.model.errors as |error|}}
+      <p>{{error}}</p>
+    {{/each}}
+  </div>
+{{/if}}


### PR DESCRIPTION
This PR adds an error route for policies to allow for the policy navigation links to show if the route transition errors. Interestingly enough the error was bubbling up to the `cluster.error` route which I would expect that the cluster navigation links would display but for some reason no links were rendering.

![image](https://github.com/hashicorp/vault/assets/24611656/b17340c9-e6b2-40b1-9d94-ce0f993736aa)

In any case we want the policy links to render in the case of an error so adding the error route template was necessary.

![image](https://github.com/hashicorp/vault/assets/24611656/2ef6f209-97f7-47be-9c44-6caa7fecb301)

 