### PR TITLE
VAULT-18307 Vault correctly requeues credentials when the rotation period is updated

### DIFF
--- a/builtin/logical/aws/path_static_roles.go
+++ b/builtin/logical/aws/path_static_roles.go
@@ -212,6 +212,21 @@ func (b *backend) pathStaticRolesWrite(ctx context.Context, req *logical.Request
 		if err != nil {
 			return nil, fmt.Errorf("failed to add item into the rotation queue for role %q: %w", config.Name, err)
 		}
+	} else {
+		// creds already exist, so all we need to do is update the rotation
+		// what here stays the same and what changes? Can we change the name?
+		i, err := b.credRotationQueue.PopByKey(config.Name)
+		if err != nil {
+			return nil, fmt.Errorf("expected an item with name %q, but got an error: %w", config.Name, err)
+		}
+		i.Value = config
+		// a few options for updating the priority - the most straightforward is to just say it's rotation period + now.
+		// this might not be ideal since it would allow infinite postponing of the deadline.
+		i.Priority = time.Now().Add(config.RotationPeriod).Unix()
+		err = b.credRotationQueue.Push(i)
+		if err != nil {
+			return nil, fmt.Errorf("failed to add updated item into the rotation queue for role %q: %w", config.Name, err)
+		}
 	}
 
 	return &logical.Response{


### PR DESCRIPTION
This PR implements a hopefully simple fix where Vault wouldn't reprioritize credentials when the rotation period was changed. Tests are incoming, but I wanted to get some thoughts on a question below:

The question that invites some bikeshedding is how to update the 'next rotation time' period - 

Right now, I am doing the simplest case - take the current time, add the rotation period. This is easy to understand, but if, say someone updates a 30 day rotation to a 45 day rotation, could result in a rotation period (just this once) that is much longer than expected.

Another way would be to update the next rotation time to be "as though" it was with the new rotation period, e.g., if you update a 30d period to 45d, we would add only 15 days. If you lowered the rotation period to 20d, we would subtract 10 days. This could result in a priority in the past, which might be unexpected, but would be programmatically fine - the credential would simply rotate the next time the queue is checked.

There are also hybrid approaches possible, of course, trading off complexity with trying to do "what people would want".