### PR TITLE
Fix path for Delete metadata and all versions

### DIFF
--- a/website/content/api-docs/secret/kv/kv-v2.mdx
+++ b/website/content/api-docs/secret/kv/kv-v2.mdx
@@ -738,7 +738,7 @@ specified key. All version history will be removed.
 
 | Method   | Path                     |
 |:---------|:-------------------------|
-| `DELETE` | `/:secret-mount-path:/metadata/:path` |
+| `DELETE` | `/:secret-mount-path/metadata/:path` |
 
 ### Parameters
 

--- a/website/content/api-docs/secret/kv/kv-v2.mdx
+++ b/website/content/api-docs/secret/kv/kv-v2.mdx
@@ -738,7 +738,7 @@ specified key. All version history will be removed.
 
 | Method   | Path                     |
 |:---------|:-------------------------|
-| `DELETE` | `/secret/metadata/:path` |
+| `DELETE` | `/:secret-mount-path:/metadata/:path` |
 
 ### Parameters
 


### PR DESCRIPTION
Fix `Path` value for `Delete metadata and all versions` - use template `:secret-mount-path` instead of `secret`.