### PR TITLE
Fix Read config header level

### DIFF
--- a/website/content/api-docs/auth/jwt.mdx
+++ b/website/content/api-docs/auth/jwt.mdx
@@ -65,7 +65,7 @@ $ curl \
     https://127.0.0.1:8200/v1/auth/jwt/config
 ```
 
-# Read config
+## Read config
 
 Returns the previously configured config.
 


### PR DESCRIPTION
Read config is the 1st level header (single `#`). This does not generate an in-page link for the header.
The PR moves the header to the second level, so link is generated and header is the same level as other headers.