### PR TITLE
Start process of replacing init-style ent hooks with stubmaker

### DIFF
--- a/command/command_stubs_oss.go
+++ b/command/command_stubs_oss.go
@@ -1,0 +1,30 @@
+//go:build !enterprise
+
+package command
+
+//go:generate go run github.com/hashicorp/vault/tools/stubmaker
+
+import (
+	"github.com/hashicorp/vault/command/server"
+	"github.com/hashicorp/vault/vault"
+	"github.com/mitchellh/cli"
+)
+
+func entInitCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions, commands map[string]cli.CommandFactory) {
+}
+
+func entEnableFourClusterDev(c *ServerCommand, base *vault.CoreConfig, info map[string]string, infoKeys []string, devListenAddress, tempDir string) int {
+	c.logger.Error("-dev-four-cluster only supported in enterprise Vault")
+	return 1
+}
+
+func entAdjustCoreConfig(config *server.Config, coreConfig *vault.CoreConfig) {
+}
+
+func entCheckStorageType(coreConfig *vault.CoreConfig) bool {
+	return true
+}
+
+func entGetFIPSInfoKey() string {
+	return ""
+}

--- a/command/commands.go
+++ b/command/commands.go
@@ -241,6 +241,7 @@ var (
 		},
 	}
 
+	// TODO remove this once entInitCommands has replaced it
 	initCommandsEnt = func(ui, serverCmdUi cli.Ui, runOpts *RunOptions, commands map[string]cli.CommandFactory) {}
 )
 

--- a/command/server.go
+++ b/command/server.go
@@ -80,6 +80,7 @@ var (
 
 var memProfilerEnabled = false
 
+// TODO remove this once entEnableFourClusterDev has replaced it
 var enableFourClusterDev = func(c *ServerCommand, base *vault.CoreConfig, info map[string]string, infoKeys []string, devListenAddress, tempDir string) int {
 	c.logger.Error("-dev-four-cluster only supported in enterprise Vault")
 	return 1

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -35,6 +35,7 @@ const (
 )
 
 var (
+	// TODO remove once entValidateConfig has replaced it
 	entConfigValidate = func(_ *Config, _ string) []configutil.ConfigError {
 		return nil
 	}
@@ -141,6 +142,7 @@ func (c *Config) Validate(sourceFilePath string) []configutil.ConfigError {
 	return results
 }
 
+// TODO remove once entValidateConfig is present in both repos
 func (c *Config) validateEnt(sourceFilePath string) []configutil.ConfigError {
 	return entConfigValidate(c, sourceFilePath)
 }

--- a/command/server/server_stubs_oss.go
+++ b/command/server/server_stubs_oss.go
@@ -1,0 +1,11 @@
+//go:build !enterprise
+
+package server
+
+import "github.com/hashicorp/vault/internalshared/configutil"
+
+//go:generate go run github.com/hashicorp/vault/tools/stubmaker
+
+func entValidateConfig(_ *Config, _ string) []configutil.ConfigError {
+	return nil
+}

--- a/command/server_util.go
+++ b/command/server_util.go
@@ -9,13 +9,16 @@ import (
 )
 
 var (
+	// TODO remove once entAdjustCoreConfig has replaced it
 	adjustCoreConfigForEnt = adjustCoreConfigForEntNoop
+	// TODO remove once entCheckStorageType has replaced it
 	storageSupportedForEnt = checkStorageTypeForEntNoop
 )
 
 func adjustCoreConfigForEntNoop(config *server.Config, coreConfig *vault.CoreConfig) {
 }
 
+// TODO remove once entGetFIPSInfoKey has replaced it
 var getFIPSInfoKey = getFIPSInfoKeyNoop
 
 func getFIPSInfoKeyNoop() string {


### PR DESCRIPTION
After this change lands on ent, I will create an ent PR that renames the ent funcs currently being assigned in init blocks.   For example instead of doing `initCommandsEnt = initCommandsEntImpl` in an init func, I'll rename initCommandsEntImpl to be entInitCommands.  This will break ent, unfortunately, because the CE files will still be invoking initCommandsEnt - things will still compile, but tests are likely to break and the binary won't behave correctly.

Finally, once that ent PR merges, the last step will be to create another CE PR that gets rid of the current var hooks and replaces references to them with the new stubmaker funcs.

To minimize the ent breakage, ideally I'd do all of the stubs at once, but I want to validate the process at a smaller scale before I invest too much time.