### PR TITLE
Add Ability to Disable Replication Status Endpoints in Listener Configuration

### DIFF
--- a/.github/scripts/verify_changes.sh
+++ b/.github/scripts/verify_changes.sh
@@ -29,8 +29,9 @@ else
 fi
 
 # git diff with ... shows the differences between base_commit and head_commit starting at the last common commit
-changed_dir=$(git diff $base_commit...$head_commit --name-only | awk -F"/" '{ print $1}' | uniq)
-change_count=$(git diff $base_commit...$head_commit --name-only | awk -F"/" '{ print $1}' | uniq | wc -l)
+# excluding the changelog directory
+changed_dir=$(git diff $base_commit...$head_commit --name-only | awk -F"/" '{ print $1}' | uniq | sed '/changelog/d')
+change_count=$(git diff $base_commit...$head_commit --name-only | awk -F"/" '{ print $1}' | uniq | sed '/changelog/d' | wc -l)
 
 # There are 4 main conditions to check:
 #

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -41,7 +41,7 @@ jobs:
         repository: hashicorp/security-scanner
         token: ${{ secrets.HASHIBOT_PRODSEC_GITHUB_TOKEN }}
         path: security-scanner
-        ref: 52d94588851f38a416f11c1e727131b3c8b0dd4d
+        ref: 6c530f211c0a1b1da078a9c80341ebe2dca4200c
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -476,6 +476,7 @@ jobs:
           name: test-results
           path: test-results/go-test
       - run: |
+          rm -rf test-results/go-test/logs
           ls -lhR test-results/go-test
           find test-results/go-test -mindepth 1 -mtime +3 -delete
 

--- a/builtin/logical/aws/path_static_roles.go
+++ b/builtin/logical/aws/path_static_roles.go
@@ -212,6 +212,20 @@ func (b *backend) pathStaticRolesWrite(ctx context.Context, req *logical.Request
 		if err != nil {
 			return nil, fmt.Errorf("failed to add item into the rotation queue for role %q: %w", config.Name, err)
 		}
+	} else {
+		// creds already exist, so all we need to do is update the rotation
+		// what here stays the same and what changes? Can we change the name?
+		i, err := b.credRotationQueue.PopByKey(config.Name)
+		if err != nil {
+			return nil, fmt.Errorf("expected an item with name %q, but got an error: %w", config.Name, err)
+		}
+		i.Value = config
+		// update the next rotation to occur at now + the new rotation period
+		i.Priority = time.Now().Add(config.RotationPeriod).Unix()
+		err = b.credRotationQueue.Push(i)
+		if err != nil {
+			return nil, fmt.Errorf("failed to add updated item into the rotation queue for role %q: %w", config.Name, err)
+		}
 	}
 
 	return &logical.Response{

--- a/builtin/logical/aws/path_static_roles_test.go
+++ b/builtin/logical/aws/path_static_roles_test.go
@@ -124,12 +124,21 @@ func TestStaticRolesWrite(t *testing.T) {
 	bgCTX := context.Background()
 
 	cases := []struct {
-		name          string
-		opts          []awsutil.MockIAMOption
+		name string
+		// objects to return from mock IAM.
+		// You'll need a GetUserOutput (to validate the existence of the user being written,
+		// the keys the user has already been assigned,
+		// and the new key vault requests.
+		opts []awsutil.MockIAMOption // objects to return from the mock IAM
+		// the name, username if updating, and rotation_period of the user. This is the inbound request the cod would get.
 		data          map[string]interface{}
 		expectedError bool
 		findUser      bool
-		isUpdate      bool
+		// if data is sent the name "johnny", then we'll match an existing user with rotation period 24 hours.
+		isUpdate    bool
+		newPriority int64 // update time of new item in queue, skip if isUpdate false. There is a wiggle room of 5 seconds
+		// so the deltas between the old and the new update time should be larger than that to ensure the difference
+		// can be detected.
 	}{
 		{
 			name: "happy path",
@@ -168,7 +177,7 @@ func TestStaticRolesWrite(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "update existing user",
+			name: "update existing user, decreased rotation duration",
 			opts: []awsutil.MockIAMOption{
 				awsutil.WithGetUserOutput(&iam.GetUserOutput{User: &iam.User{UserName: aws.String("john-doe"), UserId: aws.String("unique-id")}}),
 				awsutil.WithListAccessKeysOutput(&iam.ListAccessKeysOutput{
@@ -187,8 +196,33 @@ func TestStaticRolesWrite(t *testing.T) {
 				"name":            "johnny",
 				"rotation_period": "19m",
 			},
-			findUser: true,
-			isUpdate: true,
+			findUser:    true,
+			isUpdate:    true,
+			newPriority: time.Now().Add(19 * time.Minute).Unix(),
+		},
+		{
+			name: "update existing user, increased rotation duration",
+			opts: []awsutil.MockIAMOption{
+				awsutil.WithGetUserOutput(&iam.GetUserOutput{User: &iam.User{UserName: aws.String("john-doe"), UserId: aws.String("unique-id")}}),
+				awsutil.WithListAccessKeysOutput(&iam.ListAccessKeysOutput{
+					AccessKeyMetadata: []*iam.AccessKeyMetadata{},
+					IsTruncated:       aws.Bool(false),
+				}),
+				awsutil.WithCreateAccessKeyOutput(&iam.CreateAccessKeyOutput{
+					AccessKey: &iam.AccessKey{
+						AccessKeyId:     aws.String("abcdefghijklmnopqrstuvwxyz"),
+						SecretAccessKey: aws.String("zyxwvutsrqponmlkjihgfedcba"),
+						UserName:        aws.String("john-doe"),
+					},
+				}),
+			},
+			data: map[string]interface{}{
+				"name":            "johnny",
+				"rotation_period": "40h",
+			},
+			findUser:    true,
+			isUpdate:    true,
+			newPriority: time.Now().Add(40 * time.Hour).Unix(),
 		},
 	}
 
@@ -269,6 +303,11 @@ func TestStaticRolesWrite(t *testing.T) {
 				expectedData = staticRole
 			}
 
+			var actualItem *queue.Item
+			if c.isUpdate {
+				actualItem, _ = b.credRotationQueue.PopByKey(expectedData.Name)
+			}
+
 			if u, ok := fieldData.GetOk("username"); ok {
 				expectedData.Username = u.(string)
 			}
@@ -288,6 +327,20 @@ func TestStaticRolesWrite(t *testing.T) {
 			}
 			if en, an := expectedData.Name, actualData.Name; en != an {
 				t.Fatalf("mismatched role name, expected %q, but got %q", en, an)
+			}
+
+			// one-off to avoid importing/casting
+			abs := func(x int64) int64 {
+				if x < 0 {
+					return -x
+				}
+				return x
+			}
+
+			if c.isUpdate {
+				if ep, ap := c.newPriority, actualItem.Priority; abs(ep-ap) > 5 { // 5 second wiggle room for how long the test takes
+					t.Fatalf("mismatched updated priority, expected %d but got %d", ep, ap)
+				}
 			}
 		})
 	}

--- a/changelog/23528.txt
+++ b/changelog/23528.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/aws: update credential rotation deadline when static role rotation period is updated
+```

--- a/changelog/23547.txt
+++ b/changelog/23547.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+config/listener: allow per-listener configuration setting to disable replication status endpoints.
+```

--- a/changelog/23565.txt
+++ b/changelog/23565.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix regression that broke the oktaNumberChallenge on the ui.
+```

--- a/changelog/23598.txt
+++ b/changelog/23598.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+audit: Fix bug reopening 'file' audit devices on SIGHUP.
+```

--- a/command/server.go
+++ b/command/server.go
@@ -886,9 +886,9 @@ func (c *ServerCommand) InitListeners(config *server.Config, disableClustering b
 		}
 
 		if reloadFunc != nil {
-			relSlice := (*c.reloadFuncs)["listener|"+lnConfig.Type]
+			relSlice := (*c.reloadFuncs)[fmt.Sprintf("listener|%s", lnConfig.Type)]
 			relSlice = append(relSlice, reloadFunc)
-			(*c.reloadFuncs)["listener|"+lnConfig.Type] = relSlice
+			(*c.reloadFuncs)[fmt.Sprintf("listener|%s", lnConfig.Type)] = relSlice
 		}
 
 		if !disableClustering && lnConfig.Type == "tcp" {

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -793,7 +793,7 @@ func testConfig_Sanitized(t *testing.T) {
 					"address":          "127.0.0.1:443",
 					"chroot_namespace": "admin/",
 				},
-				"type": "tcp",
+				"type": configutil.TCP,
 			},
 		},
 		"log_format":       "",
@@ -890,6 +890,15 @@ listener "tcp" {
   redact_addresses = true
   redact_cluster_name = true
   redact_version = true
+}
+listener "unix" {
+  address = "/var/run/vault.sock"
+  socket_mode = "644"
+  socket_user = "1000"
+  socket_group = "1000"
+  redact_addresses = true
+  redact_cluster_name = true
+  redact_version = true
 }`))
 
 	config := Config{
@@ -903,16 +912,14 @@ listener "tcp" {
 	config.Listeners = listeners
 	// Track which types of listener were found.
 	for _, l := range config.Listeners {
-		config.found(l.Type, l.Type)
+		config.found(l.Type.String(), l.Type.String())
 	}
 
-	if len(config.Listeners) == 0 {
-		t.Fatalf("expected at least one listener in the config")
-	}
-	listener := config.Listeners[0]
-	if listener.Type != "tcp" {
-		t.Fatalf("expected tcp listener in the config")
-	}
+	require.Len(t, config.Listeners, 2)
+	tcpListener := config.Listeners[0]
+	require.Equal(t, configutil.TCP, tcpListener.Type)
+	unixListner := config.Listeners[1]
+	require.Equal(t, configutil.Unix, unixListner.Type)
 
 	expected := &Config{
 		SharedConfig: &configutil.SharedConfig{
@@ -945,6 +952,16 @@ listener "tcp" {
 					RedactAddresses:       true,
 					RedactClusterName:     true,
 					RedactVersion:         true,
+				},
+				{
+					Type:              "unix",
+					Address:           "/var/run/vault.sock",
+					SocketMode:        "644",
+					SocketUser:        "1000",
+					SocketGroup:       "1000",
+					RedactAddresses:   false,
+					RedactClusterName: false,
+					RedactVersion:     false,
 				},
 			},
 		},

--- a/command/server/listener.go
+++ b/command/server/listener.go
@@ -22,7 +22,7 @@ import (
 type ListenerFactory func(*configutil.Listener, io.Writer, cli.Ui) (net.Listener, map[string]string, reloadutil.ReloadFunc, error)
 
 // BuiltinListeners is the list of built-in listener types.
-var BuiltinListeners = map[string]ListenerFactory{
+var BuiltinListeners = map[configutil.ListenerType]ListenerFactory{
 	"tcp":  tcpListenerFactory,
 	"unix": unixListenerFactory,
 }

--- a/http/handler.go
+++ b/http/handler.go
@@ -237,20 +237,27 @@ func handler(props *vault.HandlerProperties) http.Handler {
 		additionalRoutes(mux, core)
 	}
 
-	// Wrap the handler in another handler to trigger all help paths.
-	helpWrappedHandler := wrapHelpHandler(mux, core)
-	corsWrappedHandler := wrapCORSHandler(helpWrappedHandler, core)
-	quotaWrappedHandler := rateLimitQuotaWrapping(corsWrappedHandler, core)
-	genericWrappedHandler := genericWrapping(core, quotaWrappedHandler, props)
+	// Build up a chain of wrapping handlers.
+	wrappedHandler := wrapHelpHandler(mux, core)
+	wrappedHandler = wrapCORSHandler(wrappedHandler, core)
+	wrappedHandler = rateLimitQuotaWrapping(wrappedHandler, core)
+	wrappedHandler = genericWrapping(core, wrappedHandler, props)
 
-	// Wrap the handler with PrintablePathCheckHandler to check for non-printable
-	// characters in the request path.
-	printablePathCheckHandler := genericWrappedHandler
+	// Add an extra wrapping handler if the DisablePrintableCheck listener
+	// setting isn't true that checks for non-printable characters in the
+	// request path.
 	if !props.DisablePrintableCheck {
-		printablePathCheckHandler = cleanhttp.PrintablePathCheckHandler(genericWrappedHandler, nil)
+		wrappedHandler = cleanhttp.PrintablePathCheckHandler(wrappedHandler, nil)
 	}
 
-	return printablePathCheckHandler
+	// Add an extra wrapping handler if the DisableReplicationStatusEndpoints
+	// setting is true that will create a new request with a context that has
+	// a value indicating that the replication status endpoints are disabled.
+	if props.ListenerConfig.DisableReplicationStatusEndpoints {
+		wrappedHandler = disableReplicationStatusEndpointWrapping(wrappedHandler)
+	}
+
+	return wrappedHandler
 }
 
 type copyResponseWriter struct {

--- a/http/handler.go
+++ b/http/handler.go
@@ -253,7 +253,7 @@ func handler(props *vault.HandlerProperties) http.Handler {
 	// Add an extra wrapping handler if the DisableReplicationStatusEndpoints
 	// setting is true that will create a new request with a context that has
 	// a value indicating that the replication status endpoints are disabled.
-	if props.ListenerConfig.DisableReplicationStatusEndpoints {
+	if props.ListenerConfig != nil && props.ListenerConfig.DisableReplicationStatusEndpoints {
 		wrappedHandler = disableReplicationStatusEndpointWrapping(wrappedHandler)
 	}
 

--- a/http/util.go
+++ b/http/util.go
@@ -133,6 +133,14 @@ func rateLimitQuotaWrapping(handler http.Handler, core *vault.Core) http.Handler
 	})
 }
 
+func disableReplicationStatusEndpointWrapping(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := r.WithContext(context.WithValue(r.Context(), "disable_replication_status_endpoints", true))
+
+		h.ServeHTTP(w, request)
+	})
+}
+
 func parseRemoteIPAddress(r *http.Request) string {
 	ip, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {

--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -141,7 +141,7 @@ func ParseConfig(d string) (*SharedConfig, error) {
 
 		// Track which types of listener were found.
 		for _, l := range result.Listeners {
-			result.found(l.Type, l.Type)
+			result.found(l.Type.String(), l.Type.String())
 		}
 	}
 

--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -357,6 +357,10 @@ func parseAndClearDurationSecond(rawSetting *interface{}, parsedSetting *time.Du
 // DisableReplicationStatusEndpoints field will be set with the successfully
 // parsed value.
 func (l *Listener) parseDisableReplicationStatusEndpointSettings() error {
+	if l.Type != "tcp" {
+		return nil
+	}
+
 	if err := parseAndClearBool(&l.DisableReplicationStatusEndpointsRaw, &l.DisableReplicationStatusEndpoints); err != nil {
 		return fmt.Errorf("invalid value for disable_replication_status_endpoints: %w", err)
 	}

--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -22,6 +22,14 @@ import (
 	"github.com/hashicorp/vault/helper/namespace"
 )
 
+const (
+	TCP  ListenerType = "tcp"
+	Unix ListenerType = "unix"
+)
+
+// ListenerType represents the supported types of listener.
+type ListenerType string
+
 type ListenerTelemetry struct {
 	UnusedKeys                      UnusedKeyMap `hcl:",unusedKeyPositions"`
 	UnauthenticatedMetricsAccess    bool         `hcl:"-"`
@@ -45,7 +53,7 @@ type Listener struct {
 	UnusedKeys UnusedKeyMap `hcl:",unusedKeyPositions"`
 	RawConfig  map[string]interface{}
 
-	Type       string
+	Type       ListenerType
 	Purpose    []string    `hcl:"-"`
 	PurposeRaw interface{} `hcl:"purpose"`
 	Role       string      `hcl:"role"`
@@ -254,6 +262,16 @@ func parseListener(item *ast.ObjectItem) (*Listener, error) {
 	return l, nil
 }
 
+// Normalize returns the lower case string version of a listener type.
+func (t ListenerType) Normalize() ListenerType {
+	return ListenerType(strings.ToLower(string(t)))
+}
+
+// String returns the string version of a listener type.
+func (t ListenerType) String() string {
+	return string(t.Normalize())
+}
+
 // parseChrootNamespace attempts to parse the raw listener chroot namespace settings.
 // The state of the listener will be modified, raw data will be cleared upon
 // successful parsing.
@@ -286,20 +304,21 @@ func (l *Listener) parseType(fallback string) error {
 	}
 
 	// Use type if available, otherwise fall back.
-	result := l.Type
-	if result == "" {
-		result = fallback
+	rawType := l.Type
+	if rawType == "" {
+		rawType = ListenerType(fallback)
 	}
-	result = strings.ToLower(result)
+
+	parsedType := rawType.Normalize()
 
 	// Sanity check the values
-	switch result {
-	case "tcp", "unix":
+	switch parsedType {
+	case TCP, Unix:
 	default:
-		return fmt.Errorf("unsupported listener type %q", result)
+		return fmt.Errorf("unsupported listener type %q", parsedType)
 	}
 
-	l.Type = result
+	l.Type = parsedType
 
 	return nil
 }
@@ -396,6 +415,13 @@ func (l *Listener) parseTLSSettings() error {
 // The state of the listener will be modified, raw data will be cleared upon
 // successful parsing.
 func (l *Listener) parseHTTPHeaderSettings() error {
+	// Custom response headers are only supported by TCP listeners.
+	// Clear raw data and return early if it was something else.
+	if l.Type != TCP {
+		l.CustomResponseHeadersRaw = nil
+		return nil
+	}
+
 	// if CustomResponseHeadersRaw is nil, we still need to set the default headers
 	customHeadersMap, err := ParseCustomResponseHeaders(l.CustomResponseHeadersRaw)
 	if err != nil {
@@ -604,6 +630,16 @@ func (l *Listener) parseCORSSettings() error {
 // The state of the listener will be modified, raw data will be cleared upon
 // successful parsing.
 func (l *Listener) parseRedactionSettings() error {
+	// Redaction is only supported on TCP listeners.
+	// Clear raw data and return early if it was something else.
+	if l.Type != TCP {
+		l.RedactAddressesRaw = nil
+		l.RedactClusterNameRaw = nil
+		l.RedactVersionRaw = nil
+
+		return nil
+	}
+
 	var err error
 
 	if l.RedactAddressesRaw != nil {

--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -139,6 +139,10 @@ type Listener struct {
 	RedactClusterName    bool `hcl:"-"`
 	RedactVersionRaw     any  `hcl:"redact_version"`
 	RedactVersion        bool `hcl:"-"`
+
+	// DisableReplicationStatusEndpoint disables the unauthenticated replication status endpoints
+	DisableReplicationStatusEndpointsRaw interface{} `hcl:"disable_replication_status_endpoints"`
+	DisableReplicationStatusEndpoints    bool        `hcl:"-"`
 }
 
 // AgentAPI allows users to select which parts of the Agent API they want enabled.
@@ -256,6 +260,18 @@ func parseListener(item *ast.ObjectItem) (*Listener, error) {
 		err := parser()
 		if err != nil {
 			return nil, err
+		}
+
+		// Disable Replication Status Endpoint
+		{
+			// If a valid DisableReplicationStatusEndpoints value exists, then canonicalize the value
+			if l.DisableReplicationStatusEndpointsRaw != nil {
+				if l.DisableReplicationStatusEndpoints, err = parseutil.ParseBool(l.DisableReplicationStatusEndpointsRaw); err != nil {
+					return multierror.Prefix(fmt.Errorf("invalid value for disable_replication_status_endpoints: %w", err), fmt.Sprintf("listeners.%d", i))
+				}
+
+				l.DisableReplicationStatusEndpointsRaw = nil
+			}
 		}
 	}
 

--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -275,6 +275,8 @@ func (t ListenerType) Normalize() ListenerType {
 // String returns the string version of a listener type.
 func (t ListenerType) String() string {
 	return string(t.Normalize())
+}
+
 // parseAndClearBool parses a raw setting as a bool configuration parameter. If
 // the raw value is successfully parsed, the parsedSetting argument is set to it
 // and the rawSetting argument is cleared. Otherwise, the rawSetting argument is
@@ -357,7 +359,7 @@ func parseAndClearDurationSecond(rawSetting *interface{}, parsedSetting *time.Du
 // DisableReplicationStatusEndpoints field will be set with the successfully
 // parsed value.
 func (l *Listener) parseDisableReplicationStatusEndpointSettings() error {
-	if l.Type != "tcp" {
+	if l.Type != TCP {
 		return nil
 	}
 

--- a/internalshared/configutil/listener_test.go
+++ b/internalshared/configutil/listener_test.go
@@ -1254,3 +1254,108 @@ func TestParseAndClearString(t *testing.T) {
 		testcase.rawAssertion(t, testcase.raw, testcase.name)
 	}
 }
+
+func TestParseAndClearInt(t *testing.T) {
+	testcases := []struct {
+		name           string
+		raw            any
+		rawAssertion   func(assert.TestingT, any, ...any) bool
+		expectedParsed int64
+		errorAssertion func(assert.TestingT, error, ...any) bool
+	}{
+		{
+			name:           "valid-as-int",
+			raw:            200,
+			rawAssertion:   assert.Nil,
+			expectedParsed: int64(200),
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "valid-as-string",
+			raw:            "53",
+			rawAssertion:   assert.Nil,
+			expectedParsed: int64(53),
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "invalid-as-hex-string",
+			raw:            "0xa",
+			rawAssertion:   assert.NotNil,
+			errorAssertion: assert.Error,
+		},
+		{
+			name:           "not-set",
+			raw:            nil,
+			rawAssertion:   assert.Nil,
+			errorAssertion: assert.NoError,
+		},
+	}
+
+	for _, testcase := range testcases {
+		var parsed int64
+		err := parseAndClearInt(&testcase.raw, &parsed)
+
+		testcase.errorAssertion(t, err, testcase.name)
+		assert.Equal(t, testcase.expectedParsed, parsed, testcase.name)
+		testcase.rawAssertion(t, testcase.raw, testcase.name)
+	}
+}
+
+func TestParseAndClearDurationSecond(t *testing.T) {
+	testcases := []struct {
+		name           string
+		raw            any
+		rawAssertion   func(assert.TestingT, any, ...any) bool
+		expectedParsed time.Duration
+		errorAssertion func(assert.TestingT, error, ...any) bool
+	}{
+		{
+			name:           "valid-as-string",
+			raw:            "30s",
+			rawAssertion:   assert.Nil,
+			expectedParsed: time.Duration(30 * time.Second),
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "valid-as-string-more-complex",
+			raw:            "29h24m49s",
+			rawAssertion:   assert.Nil,
+			expectedParsed: time.Duration((29 * time.Hour) + (24 * time.Minute) + (49 * time.Second)),
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "invalid-as-string-using-days",
+			raw:            "1d3s",
+			rawAssertion:   assert.NotNil,
+			errorAssertion: assert.Error,
+		},
+		{
+			name:           "valid-as-integer",
+			raw:            87,
+			rawAssertion:   assert.Nil,
+			expectedParsed: time.Duration(87 * time.Second),
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "not-set",
+			raw:            nil,
+			rawAssertion:   assert.Nil,
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "invalid-as-struct",
+			raw:            struct{}{},
+			rawAssertion:   assert.NotNil,
+			errorAssertion: assert.Error,
+		},
+	}
+
+	for _, testcase := range testcases {
+		var parsed time.Duration
+
+		err := parseAndClearDurationSecond(&testcase.raw, &parsed)
+		testcase.errorAssertion(t, err, testcase.name)
+		assert.Equal(t, testcase.expectedParsed, parsed)
+		testcase.rawAssertion(t, testcase.raw, testcase.name)
+	}
+}

--- a/internalshared/configutil/listener_test.go
+++ b/internalshared/configutil/listener_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1093,5 +1094,163 @@ func TestListener_parseRedactionSettings(t *testing.T) {
 				require.Nil(t, l.RedactVersionRaw)
 			}
 		})
+func TestParseAndClearBool(t *testing.T) {
+	testcases := []struct {
+		name           string
+		raw            interface{}
+		rawAssertion   func(assert.TestingT, any, ...any) bool
+		expectedParsed bool
+		errorAssertion func(assert.TestingT, error, ...any) bool
+	}{
+		{
+			name:           "valid-true-as-string",
+			raw:            "true",
+			rawAssertion:   assert.Nil,
+			expectedParsed: true,
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "valid-false-as-string",
+			raw:            "false",
+			rawAssertion:   assert.Nil,
+			expectedParsed: false,
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "valid-true-as-bool",
+			raw:            true,
+			rawAssertion:   assert.Nil,
+			expectedParsed: true,
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "valid-false-as-bool",
+			raw:            false,
+			rawAssertion:   assert.Nil,
+			expectedParsed: false,
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "valid-true-as-string-mix-case",
+			raw:            "True",
+			rawAssertion:   assert.Nil,
+			expectedParsed: true,
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "valid-false-as-integer",
+			raw:            0,
+			rawAssertion:   assert.Nil,
+			expectedParsed: false,
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "valid-true-as-integer",
+			raw:            2,
+			rawAssertion:   assert.Nil,
+			expectedParsed: true,
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "valid-true-as-float",
+			raw:            3.14,
+			rawAssertion:   assert.Nil,
+			expectedParsed: true,
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "valid-false-as-float",
+			raw:            0.0,
+			rawAssertion:   assert.Nil,
+			expectedParsed: false,
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "invalid-as-string",
+			raw:            "0.0.0.0:8200",
+			rawAssertion:   assert.NotNil,
+			errorAssertion: assert.Error,
+		},
+		{
+			name:           "invalid-as-struct",
+			raw:            struct{}{},
+			rawAssertion:   assert.NotNil,
+			errorAssertion: assert.Error,
+		},
+		{
+			name:           "not-set",
+			raw:            nil,
+			rawAssertion:   assert.Nil,
+			errorAssertion: assert.NoError,
+		},
+	}
+
+	for _, testcase := range testcases {
+		var parsed bool
+		err := parseAndClearBool(&testcase.raw, &parsed)
+
+		testcase.errorAssertion(t, err, testcase.name)
+		assert.Equal(t, testcase.expectedParsed, parsed, testcase.name)
+		testcase.rawAssertion(t, testcase.raw, testcase.name)
+	}
+}
+
+func TestParseAndClearString(t *testing.T) {
+	testcases := []struct {
+		name           string
+		raw            any
+		rawAssertion   func(assert.TestingT, any, ...any) bool
+		expectedParsed string
+		errorAssertion func(assert.TestingT, error, ...any) bool
+	}{
+		{
+			name:           "valid-empty-string",
+			raw:            "",
+			rawAssertion:   assert.Nil,
+			expectedParsed: "",
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "valid-some-string",
+			raw:            "blah blah",
+			rawAssertion:   assert.Nil,
+			expectedParsed: "blah blah",
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "valid-as-integer",
+			raw:            8,
+			rawAssertion:   assert.Nil,
+			expectedParsed: "8",
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "valid-as-bool",
+			raw:            true,
+			rawAssertion:   assert.Nil,
+			expectedParsed: "1",
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "not-set",
+			raw:            nil,
+			rawAssertion:   assert.Nil,
+			expectedParsed: "",
+			errorAssertion: assert.NoError,
+		},
+		{
+			name:           "invalid-as-struct",
+			raw:            struct{}{},
+			rawAssertion:   assert.NotNil,
+			errorAssertion: assert.Error,
+		},
+	}
+	for _, testcase := range testcases {
+		var parsed string
+		err := parseAndClearString(&testcase.raw, &parsed)
+
+		testcase.errorAssertion(t, err, testcase.name)
+		assert.Equal(t, testcase.expectedParsed, parsed, testcase.name)
+		testcase.rawAssertion(t, testcase.raw, testcase.name)
 	}
 }

--- a/internalshared/configutil/listener_test.go
+++ b/internalshared/configutil/listener_test.go
@@ -1094,6 +1094,9 @@ func TestListener_parseRedactionSettings(t *testing.T) {
 				require.Nil(t, l.RedactVersionRaw)
 			}
 		})
+	}
+}
+
 func TestParseAndClearBool(t *testing.T) {
 	testcases := []struct {
 		name           string

--- a/internalshared/configutil/listener_test.go
+++ b/internalshared/configutil/listener_test.go
@@ -159,7 +159,7 @@ func TestListener_parseType(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			l := &Listener{Type: tc.inputType}
+			l := &Listener{Type: ListenerType(tc.inputType)}
 			err := l.parseType(tc.inputFallback)
 			switch {
 			case tc.isErrorExpected:
@@ -167,7 +167,7 @@ func TestListener_parseType(t *testing.T) {
 				require.ErrorContains(t, err, tc.errorMessage)
 			default:
 				require.NoError(t, err)
-				require.Equal(t, tc.expectedValue, l.Type)
+				require.Equal(t, tc.expectedValue, l.Type.String())
 			}
 		})
 	}
@@ -861,16 +861,19 @@ func TestListener_parseCORSSettings(t *testing.T) {
 // assign the relevant value on the SharedConfig struct.
 func TestListener_parseHTTPHeaderSettings(t *testing.T) {
 	tests := map[string]struct {
+		listenerType                     ListenerType
 		rawCustomResponseHeaders         []map[string]any
 		expectedNumCustomResponseHeaders int
 		isErrorExpected                  bool
 		errorMessage                     string
 	}{
 		"nil": {
+			listenerType:                     TCP,
 			isErrorExpected:                  false,
 			expectedNumCustomResponseHeaders: 1, // default: Strict-Transport-Security
 		},
 		"custom-headers-bad": {
+			listenerType: TCP,
 			rawCustomResponseHeaders: []map[string]any{
 				{"juan": false},
 			},
@@ -878,6 +881,7 @@ func TestListener_parseHTTPHeaderSettings(t *testing.T) {
 			errorMessage:    "failed to parse custom_response_headers",
 		},
 		"custom-headers-good": {
+			listenerType: TCP,
 			rawCustomResponseHeaders: []map[string]any{
 				{
 					"2xx": []map[string]any{
@@ -886,6 +890,18 @@ func TestListener_parseHTTPHeaderSettings(t *testing.T) {
 				},
 			},
 			expectedNumCustomResponseHeaders: 2,
+			isErrorExpected:                  false,
+		},
+		"unix-no-headers": {
+			listenerType: Unix,
+			rawCustomResponseHeaders: []map[string]any{
+				{
+					"2xx": []map[string]any{
+						{"X-Custom-Header": []any{"Custom Header Value 1", "Custom Header Value 2"}},
+					},
+				},
+			},
+			expectedNumCustomResponseHeaders: 0,
 			isErrorExpected:                  false,
 		},
 	}
@@ -898,6 +914,7 @@ func TestListener_parseHTTPHeaderSettings(t *testing.T) {
 
 			// Configure listener with raw values
 			l := &Listener{
+				Type:                     tc.listenerType,
 				CustomResponseHeadersRaw: tc.rawCustomResponseHeaders,
 			}
 
@@ -978,6 +995,7 @@ func TestListener_parseChrootNamespaceSettings(t *testing.T) {
 // assign the relevant value on the SharedConfig struct.
 func TestListener_parseRedactionSettings(t *testing.T) {
 	tests := map[string]struct {
+		listenerType              ListenerType
 		rawRedactAddresses        any
 		expectedRedactAddresses   bool
 		rawRedactClusterName      any
@@ -988,40 +1006,57 @@ func TestListener_parseRedactionSettings(t *testing.T) {
 		errorMessage              string
 	}{
 		"missing": {
+			listenerType:              TCP,
 			isErrorExpected:           false,
 			expectedRedactAddresses:   false,
 			expectedRedactClusterName: false,
 			expectedRedactVersion:     false,
 		},
 		"redact-addresses-bad": {
+			listenerType:       TCP,
 			rawRedactAddresses: "juan",
 			isErrorExpected:    true,
 			errorMessage:       "invalid value for redact_addresses",
 		},
 		"redact-addresses-good": {
+			listenerType:            TCP,
 			rawRedactAddresses:      "true",
 			expectedRedactAddresses: true,
 			isErrorExpected:         false,
 		},
 		"redact-cluster-name-bad": {
+			listenerType:         TCP,
 			rawRedactClusterName: "juan",
 			isErrorExpected:      true,
 			errorMessage:         "invalid value for redact_cluster_name",
 		},
 		"redact-cluster-name-good": {
+			listenerType:              TCP,
 			rawRedactClusterName:      "true",
 			expectedRedactClusterName: true,
 			isErrorExpected:           false,
 		},
 		"redact-version-bad": {
+			listenerType:     TCP,
 			rawRedactVersion: "juan",
 			isErrorExpected:  true,
 			errorMessage:     "invalid value for redact_version",
 		},
 		"redact-version-good": {
+			listenerType:          TCP,
 			rawRedactVersion:      "true",
 			expectedRedactVersion: true,
 			isErrorExpected:       false,
+		},
+		"redact-unix-na": {
+			listenerType:              Unix,
+			rawRedactAddresses:        "true",
+			expectedRedactAddresses:   false,
+			rawRedactClusterName:      "true",
+			expectedRedactClusterName: false,
+			rawRedactVersion:          "true",
+			expectedRedactVersion:     false,
+			isErrorExpected:           false,
 		},
 	}
 
@@ -1033,6 +1068,7 @@ func TestListener_parseRedactionSettings(t *testing.T) {
 
 			// Configure listener with raw values
 			l := &Listener{
+				Type:                 tc.listenerType,
 				RedactAddressesRaw:   tc.rawRedactAddresses,
 				RedactClusterNameRaw: tc.rawRedactClusterName,
 				RedactVersionRaw:     tc.rawRedactVersion,

--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -269,7 +269,7 @@ export default Component.extend(DEFAULTS, {
       return;
     }
     let response = null;
-    this.args.setOktaNumberChallenge(true);
+    this.setOktaNumberChallenge(true);
     this.setCancellingAuth(false);
     // keep polling /auth/okta/verify/:nonce API every 1s until a response is given with the correct number for the Okta Number Challenge
     while (response === null) {
@@ -332,7 +332,7 @@ export default Component.extend(DEFAULTS, {
       });
     },
     returnToLoginFromOktaNumberChallenge() {
-      this.args.setOktaNumberChallenge(false);
+      this.setOktaNumberChallenge(false);
       this.set('oktaNumberChallengeAnswer', null);
     },
   },

--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -216,9 +216,9 @@ func (a *AuditBroker) LogRequest(ctx context.Context, in *logical.LogInput, head
 
 			e.Data = in
 
-			_, err = a.broker.Send(ctx, eventlogger.EventType(event.AuditType.String()), e)
+			status, err := a.broker.Send(ctx, eventlogger.EventType(event.AuditType.String()), e)
 			if err != nil {
-				retErr = multierror.Append(retErr, err)
+				retErr = multierror.Append(retErr, multierror.Append(err, status.Warnings...))
 			}
 		}
 	}
@@ -297,9 +297,9 @@ func (a *AuditBroker) LogResponse(ctx context.Context, in *logical.LogInput, hea
 
 			e.Data = in
 
-			_, err = a.broker.Send(ctx, eventlogger.EventType(event.AuditType.String()), e)
+			status, err := a.broker.Send(ctx, eventlogger.EventType(event.AuditType.String()), e)
 			if err != nil {
-				retErr = multierror.Append(retErr, err)
+				retErr = multierror.Append(retErr, multierror.Append(err, status.Warnings...))
 			}
 		}
 	}

--- a/vault/logical_system_user_lockout.go
+++ b/vault/logical_system_user_lockout.go
@@ -51,14 +51,16 @@ func unlockUser(ctx context.Context, core *Core, mountAccessor string, aliasName
 		return err
 	}
 
-	// Check if we have no more locked users and cancel any running lockout logger
-	core.userFailedLoginInfoLock.RLock()
-	numLockedUsers := len(core.userFailedLoginInfo)
-	core.userFailedLoginInfoLock.RUnlock()
+	if core.lockoutLoggerCancel != nil {
+		// Check if we have no more locked users and cancel any running lockout logger
+		core.userFailedLoginInfoLock.RLock()
+		numLockedUsers := len(core.userFailedLoginInfo)
+		core.userFailedLoginInfoLock.RUnlock()
 
-	if numLockedUsers == 0 {
-		core.Logger().Info("user lockout(s) cleared")
-		core.lockoutLoggerCancel()
+		if numLockedUsers == 0 {
+			core.Logger().Info("user lockout(s) cleared")
+			core.lockoutLoggerCancel()
+		}
 	}
 
 	return nil

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -586,7 +586,7 @@ $ curl \
 }
 ```
 
-## Create static role
+## Create/Update static role
 This endpoint creates or updates static role definitions. A static role is a 1-to-1 mapping
 with an AWS IAM User, which will be adopted and managed by Vault, including rotating it according
 to the configured `rotation_period`.
@@ -613,6 +613,7 @@ is specified as part of the URL.
 - `rotation_period` `(string/int: <required>)` – Specifies the amount of time
 Vault should wait before rotating the password. The minimum is 1 minute. Can be
 specified in either `24h` or `86400` format (see [duration format strings](/vault/docs/concepts/duration-format)).
+Updating the rotation period will 'reset' the next rotation to occur at `now` + `rotation_period`.
 
 ### Sample payload
 

--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -202,6 +202,10 @@ default value in the `"/sys/config/ui"` [API endpoint](/vault/api-docs/system/co
   there is no X-Forwarded-For header or it is empty, the client address will be
   used as-is, rather than the client connection rejected.
 
+- `disable_replication_status_endpoints` `(bool: false)` - If set true, the
+  replication status endpoints will be disabled for requests sent to this
+  listener.
+
 ### `telemetry` parameters
 
 - `unauthenticated_metrics_access` `(bool: false)` - If set to true, allows

--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -202,9 +202,8 @@ default value in the `"/sys/config/ui"` [API endpoint](/vault/api-docs/system/co
   there is no X-Forwarded-For header or it is empty, the client address will be
   used as-is, rather than the client connection rejected.
 
-- `disable_replication_status_endpoints` `(bool: false)` - If set true, the
-  replication status endpoints will be disabled for requests sent to this
-  listener.
+- `disable_replication_status_endpoints` `(bool: false)` - Disables replication
+  status endpoints for the configured listener when set to `true`.
 
 ### `telemetry` parameters
 


### PR DESCRIPTION
This PR adds the ability to parse a configuration setting in the TCP listener configuration section so that the value can be stored in the http.Request context. This will allow the enterprise version implementation of the replication status endpoints:
- `sys/replication/status`
- `sys/replication/dr/status`
- `sys/replication/performance/status`
to react accordingly.