### PR TITLE
Remove asterixes in header

### DIFF
--- a/website/content/api-docs/system/config-state.mdx
+++ b/website/content/api-docs/system/config-state.mdx
@@ -11,7 +11,7 @@ description: The '/sys/config/state' endpoint is used to retrieve the configurat
 The endpoints under `sys/config/state` return Vault's configuration state.
 Currently, it only supports returning a sanitized version of the configuration.
 
-## `Get sanitized configuration state`
+## Get sanitized configuration state
 
 This endpoint returns a sanitized version of the configuration state. The
 configuration excludes certain fields and mappings in the configuration file


### PR DESCRIPTION
Remove asterixes in header to keep formatting uniform across the docs.