### PR TITLE
api/plugins: add tls-server-name arg for plugin registration

### DIFF
--- a/api/plugin_helpers.go
+++ b/api/plugin_helpers.go
@@ -51,6 +51,7 @@ type PluginAPIClientMeta struct {
 	flagCAPath     string
 	flagClientCert string
 	flagClientKey  string
+	flagServerName string
 	flagInsecure   bool
 }
 
@@ -62,6 +63,7 @@ func (f *PluginAPIClientMeta) FlagSet() *flag.FlagSet {
 	fs.StringVar(&f.flagCAPath, "ca-path", "", "")
 	fs.StringVar(&f.flagClientCert, "client-cert", "", "")
 	fs.StringVar(&f.flagClientKey, "client-key", "", "")
+	fs.StringVar(&f.flagServerName, "tls-server-name", "", "")
 	fs.BoolVar(&f.flagInsecure, "tls-skip-verify", false, "")
 
 	return fs
@@ -70,13 +72,13 @@ func (f *PluginAPIClientMeta) FlagSet() *flag.FlagSet {
 // GetTLSConfig will return a TLSConfig based off the values from the flags
 func (f *PluginAPIClientMeta) GetTLSConfig() *TLSConfig {
 	// If we need custom TLS configuration, then set it
-	if f.flagCACert != "" || f.flagCAPath != "" || f.flagClientCert != "" || f.flagClientKey != "" || f.flagInsecure {
+	if f.flagCACert != "" || f.flagCAPath != "" || f.flagClientCert != "" || f.flagClientKey != "" || f.flagInsecure || f.flagServerName != "" {
 		t := &TLSConfig{
 			CACert:        f.flagCACert,
 			CAPath:        f.flagCAPath,
 			ClientCert:    f.flagClientCert,
 			ClientKey:     f.flagClientKey,
-			TLSServerName: "",
+			TLSServerName: f.flagServerName,
 			Insecure:      f.flagInsecure,
 		}
 

--- a/changelog/23549.txt
+++ b/changelog/23549.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api/plugins: add `tls-server-name` arg for plugin registration
+```


### PR DESCRIPTION
If Vault is running in an ephemeral environment where nodes are often replaced and are randomly assigned IP addresses, it can be difficult to have IP SANs in server certs. By adding a TLS server name configurable we allow operators to register a plugin and specify the acceptable SAN for TLS verification.