### PR TITLE
Add method and path for Read the client count configuration

### DIFF
--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -907,6 +907,10 @@ $ curl \
 
 Reading the configuration shows the current settings, as well as a flag as to whether any data can be queried.
 
+| Method | Path                            |
+| :----- | :------------------------------ |
+| `GET` | `/sys/internal/counters/config` |
+
 - `enabled` `(string)` - returns `default-enabled` or `default-disabled` if the configuration is `default`.
 - `queries_available` `(bool)` - indicates whether any usage report is available. This will initially be
   false until the end of the first calendar month after the feature is enabled.


### PR DESCRIPTION
`Read the client count configuration` misses HTTP verb and endpoint path.
This PR fixes this.