### PR TITLE
Define a bunch of stubs that will replace existing init hooks.

### DIFF
--- a/helper/builtinplugins/registry.go
+++ b/helper/builtinplugins/registry.go
@@ -64,6 +64,7 @@ import (
 // Thus, rather than creating multiple instances of it, we only need one.
 var Registry = newRegistry()
 
+// TODO remove once entAddExtPlugins is implemented in ENT
 var addExternalPlugins = addExtPluginsImpl
 
 // BuiltinFactory is the func signature that should be returned by

--- a/helper/builtinplugins/registry_stubs_oss.go
+++ b/helper/builtinplugins/registry_stubs_oss.go
@@ -1,0 +1,8 @@
+//go:build !enterprise
+
+package builtinplugins
+
+//go:generate go run github.com/hashicorp/vault/tools/stubmaker
+
+func entAddExtPlugins(r *registry) {
+}

--- a/http/util.go
+++ b/http/util.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	// TODO remove once entGenericWrapping is implemented in ENT
+	// TODO remove once entWrapGenericHandler is implemented in ENT
 	genericWrapping = func(core *vault.Core, in http.Handler, props *vault.HandlerProperties) http.Handler {
 		// Wrap the help wrapped handler with another layer with a generic
 		// handler

--- a/http/util.go
+++ b/http/util.go
@@ -21,16 +21,19 @@ import (
 )
 
 var (
+	// TODO remove once entGenericWrapping is implemented in ENT
 	genericWrapping = func(core *vault.Core, in http.Handler, props *vault.HandlerProperties) http.Handler {
 		// Wrap the help wrapped handler with another layer with a generic
 		// handler
 		return wrapGenericHandler(core, in, props)
 	}
 
+	// TODO remove once entAdditionalRoutes is implemented in ENT
 	additionalRoutes = func(mux *http.ServeMux, core *vault.Core) {}
 
 	nonVotersAllowed = false
 
+	// TODO remove once entAdjustResponse is implemented in ENT
 	adjustResponse = func(core *vault.Core, w http.ResponseWriter, req *logical.Request) {}
 )
 

--- a/http/util_stubs_oss.go
+++ b/http/util_stubs_oss.go
@@ -1,0 +1,21 @@
+//go:build !enterprise
+
+package http
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/vault/vault"
+)
+
+//go:generate go run github.com/hashicorp/vault/tools/stubmaker
+
+func entGenericWrapping(core *vault.Core, in http.Handler, props *vault.HandlerProperties) http.Handler {
+	// Wrap the help wrapped handler with another layer with a generic
+	// handler
+	return wrapGenericHandler(core, in, props)
+}
+
+func entAdditionalRoutes(mux *http.ServeMux, core *vault.Core) {}
+
+func entAdjustResponse() {}

--- a/http/util_stubs_oss.go
+++ b/http/util_stubs_oss.go
@@ -10,7 +10,7 @@ import (
 
 //go:generate go run github.com/hashicorp/vault/tools/stubmaker
 
-func entGenericWrapping(core *vault.Core, in http.Handler, props *vault.HandlerProperties) http.Handler {
+func entWrapGenericHandler(core *vault.Core, in http.Handler, props *vault.HandlerProperties) http.Handler {
 	// Wrap the help wrapped handler with another layer with a generic
 	// handler
 	return wrapGenericHandler(core, in, props)

--- a/vault/core.go
+++ b/vault/core.go
@@ -150,26 +150,46 @@ var (
 	manualStepDownSleepPeriod = 10 * time.Second
 
 	// Functions only in the Enterprise version
-	enterprisePostUnseal         = enterprisePostUnsealImpl
-	enterprisePreSeal            = enterprisePreSealImpl
+	// TODO remove once entPostUnseal is implemented in ENT
+	enterprisePostUnseal = enterprisePostUnsealImpl
+	// TODO remove once entPreSeal is implemented in ENT
+	enterprisePreSeal = enterprisePreSealImpl
+	// TODO remove once entSetupFilteredPaths is implemented in ENT
 	enterpriseSetupFilteredPaths = enterpriseSetupFilteredPathsImpl
-	enterpriseSetupQuotas        = enterpriseSetupQuotasImpl
-	enterpriseSetupAPILock       = setupAPILockImpl
-	startReplication             = startReplicationImpl
-	stopReplication              = stopReplicationImpl
-	LastWAL                      = lastWALImpl
-	LastPerformanceWAL           = lastPerformanceWALImpl
-	LastDRWAL                    = lastDRWALImpl
-	PerformanceMerkleRoot        = merkleRootImpl
-	DRMerkleRoot                 = merkleRootImpl
-	LastRemoteWAL                = lastRemoteWALImpl
-	LastRemoteUpstreamWAL        = lastRemoteUpstreamWALImpl
-	WaitUntilWALShipped          = waitUntilWALShippedImpl
-	storedLicenseCheck           = func(c *Core, conf *CoreConfig) error { return nil }
-	LicenseAutoloaded            = func(*Core) bool { return false }
-	LicenseInitCheck             = func(*Core) error { return nil }
-	LicenseSummary               = func(*Core) (*LicenseState, error) { return nil, nil }
-	LicenseReload                = func(*Core) error { return nil }
+	// TODO remove once entSetupQuotas is implemented in ENT
+	enterpriseSetupQuotas = enterpriseSetupQuotasImpl
+	// TODO remove once entSetupAPILock is implemented in ENT
+	enterpriseSetupAPILock = setupAPILockImpl
+	// TODO remove once entStartReplication is implemented in ENT
+	startReplication = startReplicationImpl
+	// TODO remove once entStopReplication is implemented in ENT
+	stopReplication = stopReplicationImpl
+	// TODO remove once EntLastWAL is implemented in ENT
+	LastWAL = lastWALImpl
+	// TODO remove once EntLastPerformanceWAL is implemented in ENT
+	LastPerformanceWAL = lastPerformanceWALImpl
+	// TODO remove once EntLastDRWAL is implemented in ENT
+	LastDRWAL = lastDRWALImpl
+	// TODO remove once EntPerformanceMerkleRoot is implemented in ENT
+	PerformanceMerkleRoot = merkleRootImpl
+	// TODO remove once EntDRMerkleRoot is implemented in ENT
+	DRMerkleRoot = merkleRootImpl
+	// TODO remove once EntLastRemoteWAL is implemented in ENT
+	LastRemoteWAL = lastRemoteWALImpl
+	// TODO remove once entLastRemoteUpstreamWAL is implemented in ENT
+	LastRemoteUpstreamWAL = lastRemoteUpstreamWALImpl
+	// TODO remove once EntWaitUntilWALShipped is implemented in ENT
+	WaitUntilWALShipped = waitUntilWALShippedImpl
+	// TODO remove once entCheckStoredLicense is implemented in ENT
+	storedLicenseCheck = func(c *Core, conf *CoreConfig) error { return nil }
+	// TODO remove once entIsLicenseAutoloaded is implemented in ENT
+	LicenseAutoloaded = func(*Core) bool { return false }
+	// TODO remove once entCheckLicenseInit is implemented in ENT
+	LicenseInitCheck = func(*Core) error { return nil }
+	// TODO remove once entGetLicenseState is implemented in ENT
+	LicenseSummary = func(*Core) (*LicenseState, error) { return nil, nil }
+	// TODO remove once entReloadLicense is implemented in ENT
+	LicenseReload = func(*Core) error { return nil }
 )
 
 // NonFatalError is an error that can be returned during NewCore that should be

--- a/vault/core_stubs_oss.go
+++ b/vault/core_stubs_oss.go
@@ -1,0 +1,95 @@
+//go:build !enterprise
+
+package vault
+
+import "context"
+
+//go:generate go run github.com/hashicorp/vault/tools/stubmaker
+
+func (c *Core) entInitWALPassThrough() func() {
+	return nil
+}
+
+func (c *Core) entCheckStoredLicense(conf *CoreConfig) error {
+	return nil
+}
+
+func (c *Core) entIsLicenseAutoloaded() bool {
+	return false
+}
+
+func (c *Core) entCheckLicenseInit() error {
+	return nil
+}
+
+func (c *Core) entGetLicenseState() (*LicenseState, error) {
+	return nil, nil
+}
+
+func (c *Core) entReloadLicense() error {
+	return nil
+}
+
+func (c *Core) entPostUnseal(isStandby bool) error {
+	return nil
+}
+
+func (c *Core) entPreSeal() error {
+	return nil
+}
+
+func (c *Core) entSetupFilteredPaths() error {
+	return nil
+}
+
+func (c *Core) entSetupQuotas(ctx context.Context) error {
+	return nil
+}
+
+func (c *Core) entSetupAPILock(ctx context.Context) error {
+	return nil
+}
+
+func (c *Core) entBlockRequestIfError(nsPath, requestPath string) error {
+	return nil
+}
+
+func (c *Core) entStartReplication() error {
+	return nil
+}
+
+func (c *Core) entStopReplication() error {
+	return nil
+}
+
+func (c *Core) EntLastWAL() uint64 {
+	return 0
+}
+
+func (c *Core) EntLastPerformanceWAL() uint64 {
+	return 0
+}
+
+func (c *Core) EntLastDRWAL() uint64 {
+	return 0
+}
+
+func (c *Core) EntDRMerkleRoot() string {
+	return ""
+}
+
+func (c *Core) EntPerformanceMerkleRoot() string {
+	return ""
+}
+
+func (c *Core) EntLastRemoteWAL() uint64 {
+	return 0
+}
+
+func (c *Core) entLastRemoteUpstreamWAL() uint64 {
+	return 0
+}
+
+func (c *Core) EntWaitUntilWALShipped(ctx context.Context, index uint64) bool {
+	return true
+}

--- a/vault/init.go
+++ b/vault/init.go
@@ -40,6 +40,7 @@ type InitResult struct {
 }
 
 var (
+	// TODO remove once entInitWALPassThrough is implemented in ENT
 	initPTFunc                = func(c *Core) func() { return nil }
 	initInProgress            uint32
 	ErrInitWithoutAutoloading = errors.New("cannot initialize storage without an autoloaded license")

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -58,6 +58,7 @@ var (
 
 	// if this returns an error, the request should be blocked and the error
 	// should be returned to the client
+	// TODO remove once entBlockRequestIfError is implemented in ENT
 	enterpriseBlockRequestIfError = blockRequestIfErrorImpl
 )
 


### PR DESCRIPTION
See https://github.com/hashicorp/vault/pull/23545 for background on strategy.  I was a little more ambitious this time: funcs which took Core as a first argument are now Core methods instead.  In some cases I renamed funcs to ensure that I didn't collide with existing ent func names, or for consistency.  I've decided that it's desirable to use `ent` or `Ent` as a prefix to these methods that are called (as stubs) from CE code but do something more in the Ent repo.  It helps to draw attention to the fact that these funcs are special, and that if you're modifying code using them in CE, you should probably be testing in Ent.