### PR TITLE
Fix copy button in collapsed sidebar nav in CopyButton component

### DIFF
--- a/changelog/23331.txt
+++ b/changelog/23331.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix the copy token button in the sidebar navigation window when in a collapsed state.
+```

--- a/ui/app/components/sidebar/user-menu.hbs
+++ b/ui/app/components/sidebar/user-menu.hbs
@@ -34,12 +34,13 @@
                   </LinkTo>
                 </li>
               {{/if}}
-              <li class="action">
+              <li class="action" id="container">
                 <CopyButton
                   @clipboardText={{this.auth.currentToken}}
                   class="link"
                   @buttonType="button"
                   @success={{action (set-flash-message "Token copied!")}}
+                  @container="#container"
                 >
                   Copy token
                 </CopyButton>


### PR DESCRIPTION
This is more or less a manual backport but with changes because we don't have the HDS copy button in 1.15. See original PR https://github.com/hashicorp/vault/pull/23331.