### PR TITLE
Backport 1.15.x: Fix failing dashboard tests

### DIFF
--- a/ui/tests/integration/components/dashboard/overview-test.js
+++ b/ui/tests/integration/components/dashboard/overview-test.js
@@ -111,7 +111,7 @@ module('Integration | Component | dashboard/overview', function (hooks) {
     assert.dom(SELECTORS.cardName('client-count')).doesNotExist();
   });
 
-  test('it should show client count and replication card on enterprise w/ license + namespace enabled', async function (assert) {
+  test('it should show client count on enterprise w/ license', async function (assert) {
     this.version = this.owner.lookup('service:version');
     this.version.version = '1.13.1+ent';
     this.license = {
@@ -137,7 +137,7 @@ module('Integration | Component | dashboard/overview', function (hooks) {
     assert.dom(SELECTORS.cardName('learn-more')).exists();
     assert.dom(SELECTORS.cardName('quick-actions')).exists();
     assert.dom(SELECTORS.cardName('configuration-details')).exists();
-    assert.dom(SELECTORS.cardName('replication')).exists();
+    assert.dom(SELECTORS.cardName('replication')).doesNotExist();
     assert.dom(SELECTORS.cardName('client-count')).exists();
   });
 
@@ -164,7 +164,7 @@ module('Integration | Component | dashboard/overview', function (hooks) {
     assert.dom(SELECTORS.cardName('learn-more')).exists();
     assert.dom(SELECTORS.cardName('quick-actions')).exists();
     assert.dom(SELECTORS.cardName('configuration-details')).exists();
-    assert.dom(SELECTORS.cardName('replication')).exists();
+    assert.dom(SELECTORS.cardName('replication')).doesNotExist();
     assert.dom(SELECTORS.cardName('client-count')).doesNotExist();
   });
 

--- a/ui/tests/integration/components/dashboard/overview-test.js
+++ b/ui/tests/integration/components/dashboard/overview-test.js
@@ -137,7 +137,6 @@ module('Integration | Component | dashboard/overview', function (hooks) {
     assert.dom(SELECTORS.cardName('learn-more')).exists();
     assert.dom(SELECTORS.cardName('quick-actions')).exists();
     assert.dom(SELECTORS.cardName('configuration-details')).exists();
-    assert.dom(SELECTORS.cardName('replication')).doesNotExist();
     assert.dom(SELECTORS.cardName('client-count')).exists();
   });
 
@@ -164,7 +163,6 @@ module('Integration | Component | dashboard/overview', function (hooks) {
     assert.dom(SELECTORS.cardName('learn-more')).exists();
     assert.dom(SELECTORS.cardName('quick-actions')).exists();
     assert.dom(SELECTORS.cardName('configuration-details')).exists();
-    assert.dom(SELECTORS.cardName('replication')).doesNotExist();
     assert.dom(SELECTORS.cardName('client-count')).doesNotExist();
   });
 


### PR DESCRIPTION
**Description**

Fixes failing dashboard tests. Remove replication tests since we have acceptance tests for these in https://github.com/hashicorp/vault/pull/23452. 

This backport is for https://github.com/hashicorp/vault/pull/23452