### PR TITLE
Allow multiseal to mismatch stored conf type

### DIFF
--- a/changelog/23573.txt
+++ b/changelog/23573.txt
@@ -1,0 +1,5 @@
+```release-note:bug
+* Seal HA (enterprise/beta): Fix rejection of a seal configuration change
+from two to one auto seal due to persistence of the previous seal type being
+"multiseal". 
+```

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -194,7 +194,7 @@ func (d *autoSeal) BarrierConfig(ctx context.Context) (*SealConfig, error) {
 
 	barrierTypeUpgradeCheck(d.BarrierSealConfigType(), conf)
 
-	if conf.Type != d.BarrierSealConfigType().String() && conf.Type != "multiseal" {
+	if conf.Type != d.BarrierSealConfigType().String() && conf.Type != SealConfigTypeMultiseal.String() && d.BarrierSealConfigType() != SealConfigTypeMultiseal {
 		d.logger.Error("barrier seal type does not match loaded type", "seal_type", conf.Type, "loaded_type", d.BarrierSealConfigType())
 		return nil, fmt.Errorf("barrier seal type of %q does not match loaded type of %q", conf.Type, d.BarrierSealConfigType())
 	}


### PR DESCRIPTION
Fixes an error when going from single to multiple auto seals of the same
type