### PR TITLE
UI: Add version 1 if KV engine has no version data

### DIFF
--- a/ui/app/serializers/secret-engine.js
+++ b/ui/app/serializers/secret-engine.js
@@ -40,6 +40,9 @@ export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
     // strip the trailing slash off of the path so we
     // can navigate to it without getting `//` in the url
     struct.id = struct.path.slice(0, -1);
+    if (backend.type === 'kv' && !backend.options) {
+      backend.options = { version: 1 };
+    }
     return struct;
   },
 

--- a/ui/app/serializers/secret-engine.js
+++ b/ui/app/serializers/secret-engine.js
@@ -40,6 +40,9 @@ export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
     // strip the trailing slash off of the path so we
     // can navigate to it without getting `//` in the url
     struct.id = struct.path.slice(0, -1);
+
+    // enabling kv in the CLI without a version flag mounts a v1 engine
+    // however, the options object is null so setting version number manually
     if (backend.type === 'kv' && !backend.options) {
       backend.options = { version: 1 };
     }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/vault/issues/23463

When a user enables KV in the UI we default to version 2 by passing the version in the `options` object.

In the CLI if no version flag is used, a kv v1 engine is mounted but there are no options containing any version information. If no version information exists, the UI should assume it is version 1. 