### PR TITLE
Docs: known issue - audit file reload on SIGHUP

### DIFF
--- a/website/content/docs/release-notes/1.15.0.mdx
+++ b/website/content/docs/release-notes/1.15.0.mdx
@@ -17,7 +17,7 @@ Version | Issue
 ------- | -----
 1.15.0+ | [Vault no longer reports rollback metrics by mountpoint](/vault/docs/upgrading/upgrade-to-1.15.x#rollback-metrics)
 1.15.0  | [Panic in AWS auth method during IAM-based login](/vault/docs/upgrading/upgrade-to-1.15.x#panic-in-aws-auth-method-during-iam-based-login)
-1.15    | [Vault file audit devices do not honor SIGHUP signal to reload](/vault/docs/upgrading/upgrade-to-1.15.x#file-audit-devices-do-not-honor-SIGHUP-signal-to-reload)
+1.15    | [Vault file audit devices do not honor SIGHUP signal to reload](/vault/docs/upgrading/upgrade-to-1.15.x#file-audit-devices-do-not-honor-sighup-signal-to-reload)
 
 ## Vault companion updates
 

--- a/website/content/docs/release-notes/1.15.0.mdx
+++ b/website/content/docs/release-notes/1.15.0.mdx
@@ -17,6 +17,7 @@ Version | Issue
 ------- | -----
 1.15.0+ | [Vault no longer reports rollback metrics by mountpoint](/vault/docs/upgrading/upgrade-to-1.15.x#rollback-metrics)
 1.15.0  | [Panic in AWS auth method during IAM-based login](/vault/docs/upgrading/upgrade-to-1.15.x#panic-in-aws-auth-method-during-iam-based-login)
+1.15    | [Vault file audit devices do not honor SIGHUP signal to reload](/vault/docs/upgrading/upgrade-to-1.15.x#file-audit-devices-do-not-honor-SIGHUP-signal-to-reload)
 
 ## Vault companion updates
 

--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -52,3 +52,5 @@ option.
 @include 'known-issues/transit-managed-keys-sign-fails.mdx'
 
 @include 'known-issues/aws-auth-panics.mdx'
+
+@include 'known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx'

--- a/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
+++ b/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
@@ -6,37 +6,42 @@
 
 #### Issue
 
-Vault clusters with `file` audit devices enabled can be impacted by the issue.
-
-Vault's new underlying event framework for audit causes Vault to continue using
+The new underlying event framework for auditing causes Vault to continue using
 audit log files instead of reopening the file paths even when you send
-[`SIGHUP`](/vault/docs/audit/file#log-file-rotation) after log rotation.
+[`SIGHUP`](/vault/docs/audit/file#log-file-rotation) after log rotation. The
+issue impacts any Vault cluster with `file` audit devices enabled.
 
-If you move or rename your audit log file locally, Vault continues to log data to the original file.
+Not honoring the `SIGHUP` signal has two key consequences when moving or
+deleting audit files.
 
-For example, when archiving a file locally:
+If you **move or rename your audit log file** locally, Vault continues to log
+data to the original file. For example, if you archive a file locally:
 
 ```shell-session
 $ mv /var/log/vault/audit.log /var/log/vault/archive/audit.log.bak
 ```
 
-Instead of logging audit entries to a newly created file at `/var/log/vault/audit.log`,
-Vault continues to write data to `/var/log/vault/archive/audit.log.bak`.
+Vault continues to write data to `/var/log/vault/archive/audit.log.bak`
+instead of logging audit entries to a newly created file at
+`/var/log/vault/audit.log`.
 
-If you delete your audit log file, the OS unlinks the file from the directory
-structure. As Vault still has the file open, it continues to write data to the
-deleted file, which continues to consume disk space as it grows. When
-Vault is sealed or restarted, the OS deletes the previously unlinked file, and you
-will lose all data logged to the audit file after it was tagged for deletion.
+If you **delete your audit log file**, the OS unlinks the file from the
+directory structure, but Vault still has the file open. Vault continues to write
+data to the deleted file, which continues to consume disk space as it grows.
+When Vault is sealed or restarted, the OS deletes the previously unlinked file,
+and you will lose all data logged to the audit file after it was tagged for
+deletion.
 
-The issue with file audit devices not honoring SIGHUP signals is fixed as a patch release in Vault `1.15.1`.
+The issue with `file` audit devices not honoring `SIGHUP` signals is fixed as a
+patch release in Vault `1.15.1`.
 
 #### Workaround
 
-Set the `VAULT_AUDIT_DISABLE_EVENTLOGGER` environment variable to `true` in order
-to disable the new underlying event framework Vault uses to process audit events.
-Upon startup Vault's audit framework reverts to mirror versions before `1.15`.
+Set the `VAULT_AUDIT_DISABLE_EVENTLOGGER` environment variable to `true` to
+disable the new underlying event framework and restart Vault:
 
 ```shell-session
 $ export VAULT_AUDIT_DISABLE_EVENTLOGGER=true
 ```
+
+On startup, Vault reverts to the audit behavior used in `1.14.x`.

--- a/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
+++ b/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
@@ -6,38 +6,37 @@
 
 #### Issue
 
-The new underlying event framework for Vault causes Vault to continue using 
-audit logs instead of reopening the file paths even when you send 
-[`SIGHUP`](/vault/docs/audit/file#log-file-rotation) after log rotation:
+Vault clusters with `file` audit devices enabled can be impacted by the issue.
 
-- If you move or rename your audit log file, Vault continues to log data to the
-  moved file. For example, if you archive the log file
-  `audit/log/path/vault-audit.log` by moving it to
-  `audit/log/archive/path/vault-audit.log.bak`, Vault continues to write data to
-  `audit/log/archive/path/vault-audit.log.bak` instead of starting a fresh log
-  at `audit/log/path/vault-audit.log`.
-- If you delete your audit log file, Vault continues to write data to the
-  deleted file, which will continue to consume disk space as it grows. When
-  Vault is sealed or restarted, the OS will perform junk collection on the
-  deleted file and you will lose all data logged the audit file after it was
-  tagged for deletion.
+Vault's new underlying event framework for audit causes Vault to continue using
+audit log files instead of reopening the file paths even when you send
+[`SIGHUP`](/vault/docs/audit/file#log-file-rotation) after log rotation.
 
-<Warning title="You may lose audit entries">
-  If you delete the audit file on rotation, rather than moving it, you
-  will lose any entries written by Vault after rotation when the OS
-  permanently deletes the file.
-</Warning>
+If you move or rename your audit log file locally, Vault continues to log data to the original file.
+
+For example, when archiving a file locally:
+
+```shell-session
+$ mv /var/log/vault/audit.log /var/log/vault/archive/audit.log.bak
+```
+
+Instead of logging audit entries to a newly created file at `/var/log/vault/audit.log`,
+Vault continues to write data to `/var/log/vault/archive/audit.log.bak`.
+
+If you delete your audit log file, the OS unlinks the file from the directory
+structure. As Vault still has the file open, it continues to write data to the
+deleted file, which continues to consume disk space as it grows. When
+Vault is sealed or restarted, the OS deletes the previously unlinked file, and you
+will lose all data logged to the audit file after it was tagged for deletion.
 
 The issue with file audit devices not honoring SIGHUP signals is fixed as a patch release in Vault `1.15.1`.
 
 #### Workaround
 
-If your Vault cluster uses any `file` audit devices, you can use the following
-environment variable set to `true` in order to disable the new underlying event
-framework Vault uses to process audit events.
+Set the `VAULT_AUDIT_DISABLE_EVENTLOGGER` environment variable to `true` in order
+to disable the new underlying event framework Vault uses to process audit events.
+Upon startup Vault's audit framework reverts to mirror versions before `1.15`.
 
-
-<Note title="Temporary workaround">
-  The `VAULT_AUDIT_DISABLE_EVENTLOGGER` environment variable
-  is a temporary solution and will be removed in a future release of Vault.
-<Note>
+```shell-session
+$ export VAULT_AUDIT_DISABLE_EVENTLOGGER=true
+```

--- a/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
+++ b/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
@@ -28,4 +28,4 @@ event framework Vault uses to process audit events.
 |-----------------------------------|--------|
 | `VAULT_AUDIT_DISABLE_EVENTLOGGER` | `true` |
 
-Please note that is environment variable will be removed in a future release of Vault.
+Please note that this environment variable will be removed in a future release of Vault.

--- a/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
+++ b/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
@@ -29,9 +29,6 @@ If your Vault cluster uses any `file` audit devices, you can use the following
 environment variable set to `true` in order to disable the new underlying event
 framework Vault uses to process audit events.
 
-| Environment variable name         | Value  |
-|-----------------------------------|--------|
-| `VAULT_AUDIT_DISABLE_EVENTLOGGER` | `true` |
 
 <Note title="Temporary workaround">
   The `VAULT_AUDIT_DISABLE_EVENTLOGGER` environment variable

--- a/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
+++ b/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
@@ -1,0 +1,31 @@
+### File audit devices do not honor SIGHUP signal to reload
+
+#### Affected versions
+
+- 1.15.0
+
+#### Issue
+
+Sending [`SIGHUP`](/vault/docs/audit/file#log-file-rotation) to Vault after rotating
+an audit log file doesn't reopen the file path as expected.
+
+If the file was moved (renamed), then Vault will continue to write data to the location
+of the moved file.
+
+If the file was deleted, then Vault will continue to write data to the deleted file.
+The file will be deleted by the OS once Vault is sealed or restarted, but
+until then will continue to consume disk space due to audit entries being written.
+
+The issue has been fixed for a patch release in Vault `1.15.1`.
+
+#### Workaround
+
+If audit log rotation is a requirement for your Vault deployment, you can use the
+following environment variable set to `true` in order to disable the new underlying
+event framework Vault uses to process audit events.
+
+| Environment variable name         | Value  |
+|-----------------------------------|--------|
+| `VAULT_AUDIT_DISABLE_EVENTLOGGER` | `true` |
+
+Please note that is environment variable will be removed in a future release of Vault.

--- a/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
+++ b/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
@@ -6,8 +6,9 @@
 
 #### Issue
 
-Sending [`SIGHUP`](/vault/docs/audit/file#log-file-rotation) to Vault after rotating
-an audit log file doesn't reopen the file path as expected.
+The new underlying event framework for Vault causes Vault to continue using 
+audit logs instead of reopening the file paths even when you send 
+[`SIGHUP`](/vault/docs/audit/file#log-file-rotation) after log rotation:
 
 If the file was moved (renamed), then Vault will continue to write data to the location
 of the moved file.

--- a/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
+++ b/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
@@ -33,4 +33,7 @@ framework Vault uses to process audit events.
 |-----------------------------------|--------|
 | `VAULT_AUDIT_DISABLE_EVENTLOGGER` | `true` |
 
-Please note that this environment variable will be removed in a future release of Vault.
+<Note title="Temporary workaround">
+  The `VAULT_AUDIT_DISABLE_EVENTLOGGER` environment variable
+  is a temporary solution and will be removed in a future release of Vault.
+  <Note>

--- a/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
+++ b/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
@@ -21,7 +21,7 @@ until then will continue to consume disk space due to audit entries being writte
   by Vault will be lost.
 </Warning>
 
-The issue has been fixed for a patch release in Vault `1.15.1`.
+The issue with file audit devices not honoring SIGHUP signals is fixed as a patch release in Vault `1.15.1`.
 
 #### Workaround
 

--- a/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
+++ b/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
@@ -16,13 +16,18 @@ If the file was deleted, then Vault will continue to write data to the deleted f
 The file will be deleted by the OS once Vault is sealed or restarted, but
 until then will continue to consume disk space due to audit entries being written.
 
+<Important title="Missing Audit Entries">
+  If the file was deleted (rather than moved locally) then audit entries written
+  by Vault will be lost.
+</Important>
+
 The issue has been fixed for a patch release in Vault `1.15.1`.
 
 #### Workaround
 
-If audit log rotation is a requirement for your Vault deployment, you can use the
-following environment variable set to `true` in order to disable the new underlying
-event framework Vault uses to process audit events.
+If your Vault cluster uses any `file` audit devices, you can use the following
+environment variable set to `true` in order to disable the new underlying event
+framework Vault uses to process audit events.
 
 | Environment variable name         | Value  |
 |-----------------------------------|--------|

--- a/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
+++ b/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
@@ -22,9 +22,10 @@ audit logs instead of reopening the file paths even when you send
   deleted file and you will lose all data logged the audit file after it was
   tagged for deletion.
 
-<Warning title="Missing Audit Entries">
-  If the file was deleted (rather than moved locally) then audit entries written
-  by Vault will be lost.
+<Warning title="You may lose audit entries">
+  If you delete the audit file on rotation, rather than moving it, you
+  will lose any entries written by Vault after rotation when the OS
+  permanently deletes the file.
 </Warning>
 
 The issue with file audit devices not honoring SIGHUP signals is fixed as a patch release in Vault `1.15.1`.

--- a/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
+++ b/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
@@ -16,10 +16,10 @@ If the file was deleted, then Vault will continue to write data to the deleted f
 The file will be deleted by the OS once Vault is sealed or restarted, but
 until then will continue to consume disk space due to audit entries being written.
 
-<Important title="Missing Audit Entries">
+<Warning title="Missing Audit Entries">
   If the file was deleted (rather than moved locally) then audit entries written
   by Vault will be lost.
-</Important>
+</Warning>
 
 The issue has been fixed for a patch release in Vault `1.15.1`.
 

--- a/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
+++ b/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
@@ -40,4 +40,4 @@ framework Vault uses to process audit events.
 <Note title="Temporary workaround">
   The `VAULT_AUDIT_DISABLE_EVENTLOGGER` environment variable
   is a temporary solution and will be removed in a future release of Vault.
-  <Note>
+<Note>

--- a/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
+++ b/website/content/partials/known-issues/1_15-audit-file-sighup-does-not-trigger-reload.mdx
@@ -10,12 +10,17 @@ The new underlying event framework for Vault causes Vault to continue using
 audit logs instead of reopening the file paths even when you send 
 [`SIGHUP`](/vault/docs/audit/file#log-file-rotation) after log rotation:
 
-If the file was moved (renamed), then Vault will continue to write data to the location
-of the moved file.
-
-If the file was deleted, then Vault will continue to write data to the deleted file.
-The file will be deleted by the OS once Vault is sealed or restarted, but
-until then will continue to consume disk space due to audit entries being written.
+- If you move or rename your audit log file, Vault continues to log data to the
+  moved file. For example, if you archive the log file
+  `audit/log/path/vault-audit.log` by moving it to
+  `audit/log/archive/path/vault-audit.log.bak`, Vault continues to write data to
+  `audit/log/archive/path/vault-audit.log.bak` instead of starting a fresh log
+  at `audit/log/path/vault-audit.log`.
+- If you delete your audit log file, Vault continues to write data to the
+  deleted file, which will continue to consume disk space as it grows. When
+  Vault is sealed or restarted, the OS will perform junk collection on the
+  deleted file and you will lose all data logged the audit file after it was
+  tagged for deletion.
 
 <Warning title="Missing Audit Entries">
   If the file was deleted (rather than moved locally) then audit entries written


### PR DESCRIPTION
Documentation to describe a known issue which has been reported where Vault file audit devices do no honor reopening after Vault processes a `SIGHUP` command. 

PR: https://github.com/hashicorp/vault/pull/23598
Issue: https://github.com/hashicorp/vault/issues/23596

Release notes: https://vault-git-docs-peteski22audit-file-sighup-issue-hashicorp.vercel.app/vault/docs/release-notes/1.15.0
Upgrade guide: https://vault-git-docs-peteski22audit-file-sighup-issue-hashicorp.vercel.app/vault/docs/upgrading/upgrade-to-1.15.x#file-audit-devices-do-not-honor-sighup-signal-to-reload