### PR TITLE
Fix panic when unlocking unlocked user

### DIFF
--- a/vault/logical_system_user_lockout.go
+++ b/vault/logical_system_user_lockout.go
@@ -51,14 +51,16 @@ func unlockUser(ctx context.Context, core *Core, mountAccessor string, aliasName
 		return err
 	}
 
-	// Check if we have no more locked users and cancel any running lockout logger
-	core.userFailedLoginInfoLock.RLock()
-	numLockedUsers := len(core.userFailedLoginInfo)
-	core.userFailedLoginInfoLock.RUnlock()
+	if core.lockoutLoggerCancel != nil {
+		// Check if we have no more locked users and cancel any running lockout logger
+		core.userFailedLoginInfoLock.RLock()
+		numLockedUsers := len(core.userFailedLoginInfo)
+		core.userFailedLoginInfoLock.RUnlock()
 
-	if numLockedUsers == 0 {
-		core.Logger().Info("user lockout(s) cleared")
-		core.lockoutLoggerCancel()
+		if numLockedUsers == 0 {
+			core.Logger().Info("user lockout(s) cleared")
+			core.lockoutLoggerCancel()
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR fixes a panic when attempting to unlock an already unlocked user.

Example Panic: 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x380c80a]

goroutine 147274 [running]:
github.com/hashicorp/vault/vault.unlockUser({0xa434c80, 0xc00fa6aeb0}, 0xc00ef26900, {0xc00e8cfb11, 0x16}, {0xc00e8cfb2f, 0x6})
	/home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/vault/logical_system_user_lockout.go:61 +0x28a
github.com/hashicorp/vault/vault.(*SystemBackend).handleUnlockUser(0xc005b7e740, {0xa434c80, 0xc00fa6aeb0}, 0x0?, 0xffffffffffffffff?)
	/home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/vault/logical_system.go:2492 +0x27b
github.com/hashicorp/vault/sdk/framework.(*Backend).HandleRequest(0xc011fbd770, {0xa434c80, 0xc00fa6aeb0}, 0xc023034fc0)
	/home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/sdk/framework/backend.go:310 +0xa88
```