### PR TITLE
command/server: fix bug with sigusr2 where pprof files were not closed

### DIFF
--- a/changelog/23636.txt
+++ b/changelog/23636.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+command/server: Fix bug with sigusr2 where pprof files were not closed correctly
+```

--- a/command/server.go
+++ b/command/server.go
@@ -1830,8 +1830,10 @@ func (c *ServerCommand) Run(args []string) int {
 					err = pprof.Lookup(dump).WriteTo(pFile, 0)
 					if err != nil {
 						c.logger.Error("error generating pprof data", "name", dump, "error", err)
+						pFile.Close()
 						break
 					}
+					pFile.Close()
 				}
 
 				c.logger.Info(fmt.Sprintf("Wrote pprof files to: %s", dir))


### PR DESCRIPTION
I forgot to close the file when generating pprof files using SIGUSR2.