### PR TITLE
VAULT-20476: vault.NewCore refactor.

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -893,7 +893,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 			// this is loaded *after* the normal mounts, including cubbyhole
 			c.router.tokenStoreSaltFunc = c.tokenStore.Salt
 			if !c.IsDRSecondary() {
-				c.tokenStore.cubbyholeBackend = c.router.MatchingBackend(ctx, cubbyholeMountPath).(*CubbyholeBackend)
+				c.tokenStore.cubbyholeBackend = c.router.MatchingBackend(ctx, mountPathCubbyhole).(*CubbyholeBackend)
 			}
 		}
 

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -115,7 +115,7 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 	}
 
 	// Ensure the token backend is a singleton
-	if entry.Type == "token" {
+	if entry.Type == mountTypeToken {
 		return fmt.Errorf("token credential backend cannot be instantiated")
 	}
 
@@ -883,7 +883,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 		}
 
 		// Check if this is the token store
-		if entry.Type == "token" {
+		if entry.Type == mountTypeToken {
 			c.tokenStore = backend.(*TokenStore)
 
 			// At some point when this isn't beta we may persist this but for
@@ -1046,7 +1046,7 @@ func (c *Core) defaultAuthTable() *MountTable {
 	tokenAuth := &MountEntry{
 		Table:            credentialTableType,
 		Path:             "token/",
-		Type:             "token",
+		Type:             mountTypeToken,
 		Description:      "token based credentials",
 		UUID:             tokenUUID,
 		Accessor:         tokenAccessor,

--- a/vault/core.go
+++ b/vault/core.go
@@ -1357,11 +1357,13 @@ func (c *Core) configureCredentialsBackends(backends map[string]logical.Factory,
 		credentialBackends[k] = f
 	}
 
-	credentialBackends["token"] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
+	credentialBackends[mountTypeToken] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
 		return NewTokenStore(ctx, logger.Named("token"), c, config)
 	}
 
 	c.credentialBackends = credentialBackends
+
+	c.addExtraCredentialBackends()
 }
 
 // configureLogicalBackends configures the Core with the ability to create

--- a/vault/core.go
+++ b/vault/core.go
@@ -1261,7 +1261,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	c.loginMFABackend = NewLoginMFABackend(c, conf.Logger)
 
 	// UI
-	uiStoragePrefix := fmt.Sprintf("%sui", systemBarrierPrefix)
+	uiStoragePrefix := systemBarrierPrefix + "ui"
 	c.uiConfig = NewUIConfig(conf.EnableUI, physical.NewView(c.physical, uiStoragePrefix), NewBarrierView(c.barrier, uiStoragePrefix))
 
 	// Listeners
@@ -1308,7 +1308,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 
 // configureListeners configures the Core with the listeners from the CoreConfig.
 func (c *Core) configureListeners(conf *CoreConfig) error {
-	if conf == nil || conf.RawConfig == nil || conf.RawConfig.SharedConfig.Listeners == nil {
+	if conf == nil || conf.RawConfig == nil || conf.RawConfig.Listeners == nil {
 		c.customListenerHeader.Store(([]*ListenerCustomHeaders)(nil))
 		return nil
 	}

--- a/vault/core.go
+++ b/vault/core.go
@@ -1308,6 +1308,8 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 
 // configureListeners configures the Core with the listeners from the CoreConfig.
 func (c *Core) configureListeners(conf *CoreConfig) error {
+	c.clusterListener.Store((*cluster.Listener)(nil))
+
 	if conf == nil || conf.RawConfig == nil || conf.RawConfig.Listeners == nil {
 		c.customListenerHeader.Store(([]*ListenerCustomHeaders)(nil))
 		return nil
@@ -1317,6 +1319,7 @@ func (c *Core) configureListeners(conf *CoreConfig) error {
 	if err != nil {
 		return err
 	}
+
 	c.customListenerHeader.Store(NewListenerCustomHeader(conf.RawConfig.Listeners, c.logger, uiHeaders))
 
 	return nil

--- a/vault/core.go
+++ b/vault/core.go
@@ -1292,10 +1292,11 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	}
 
 	// Events
-	c.events, err = eventbus.NewEventBus(conf.Logger.Named("events"))
+	events, err := eventbus.NewEventBus(conf.Logger.Named("events"))
 	if err != nil {
 		return nil, err
 	}
+	c.events = events
 	c.events.Start()
 
 	// Make sure we're keeping track of the subloggers added above. We haven't

--- a/vault/core.go
+++ b/vault/core.go
@@ -126,6 +126,15 @@ const (
 	// undoLogsAreSafeStoragePath is a storage path that we write once we know undo logs are
 	// safe, so we don't have to keep checking all the time.
 	undoLogsAreSafeStoragePath = "core/raft/undo_logs_are_safe"
+
+	ErrMlockFailedTemplate = "Failed to lock memory: %v\n\n" +
+		"This usually means that the mlock syscall is not available.\n" +
+		"Vault uses mlock to prevent memory from being swapped to\n" +
+		"disk. This requires root privileges as well as a machine\n" +
+		"that supports mlock. Please enable mlock on your system or\n" +
+		"disable Vault from using it. To disable Vault from using it,\n" +
+		"set the `disable_mlock` configuration option in your configuration\n" +
+		"file."
 )
 
 var (
@@ -1164,30 +1173,27 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 	return c, nil
 }
 
-// NewCore is used to construct a new core
+// NewCore creates, initializes and configures a Vault node (core).
 func NewCore(conf *CoreConfig) (*Core, error) {
-	var err error
+	// NOTE: The order of configuration of the core has some importance, as we can
+	// make use of an early return if we are running this new core in recovery mode.
 	c, err := CreateCore(conf)
 	if err != nil {
 		return nil, err
 	}
-	if err = coreInit(c, conf); err != nil {
+
+	err = coreInit(c, conf)
+	if err != nil {
 		return nil, err
 	}
 
-	if !conf.DisableMlock {
-		// Ensure our memory usage is locked into physical RAM
-		if err := mlock.LockMemory(); err != nil {
-			return nil, fmt.Errorf(
-				"Failed to lock memory: %v\n\n"+
-					"This usually means that the mlock syscall is not available.\n"+
-					"Vault uses mlock to prevent memory from being swapped to\n"+
-					"disk. This requires root privileges as well as a machine\n"+
-					"that supports mlock. Please enable mlock on your system or\n"+
-					"disable Vault from using it. To disable Vault from using it,\n"+
-					"set the `disable_mlock` configuration option in your configuration\n"+
-					"file.",
-				err)
+	switch {
+	case conf.DisableMlock:
+		// User configured that memory lock should be disabled on unix systems.
+	default:
+		err = mlock.LockMemory()
+		if err != nil {
+			return nil, fmt.Errorf(ErrMlockFailedTemplate, err)
 		}
 	}
 
@@ -1197,9 +1203,11 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		return nil, fmt.Errorf("barrier setup failed: %w", err)
 	}
 
-	if err := storedLicenseCheck(c, conf); err != nil {
+	err = storedLicenseCheck(c, conf)
+	if err != nil {
 		return nil, err
 	}
+
 	// We create the funcs here, then populate the given config with it so that
 	// the caller can share state
 	conf.ReloadFuncsLock = &c.reloadFuncsLock
@@ -1209,12 +1217,12 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	conf.ReloadFuncs = &c.reloadFuncs
 
 	c.rollbackPeriod = conf.RollbackPeriod
-	if conf.RollbackPeriod == 0 {
-		c.rollbackPeriod = time.Minute
+	if c.rollbackPeriod == 0 {
+		// Default to 1 minute
+		c.rollbackPeriod = 1 * time.Minute
 	}
 
-	// All the things happening below this are not required in
-	// recovery mode
+	// For recovery mode we've now configured enough to return early.
 	if c.recoveryMode {
 		return c, nil
 	}
@@ -1233,81 +1241,39 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		c.pluginFilePermissions = conf.PluginFilePermissions
 	}
 
-	createSecondaries(c, conf)
+	// Create secondaries (this will only impact Enterprise versions of Vault)
+	c.createSecondaries(conf.Logger)
 
 	if conf.HAPhysical != nil && conf.HAPhysical.HAEnabled() {
 		c.ha = conf.HAPhysical
 	}
 
+	// Audit backends
+	c.configureAuditBackends(conf.AuditBackends)
+
+	// Credentials backends
+	c.configureCredentialsBackends(conf.CredentialBackends, conf.Logger)
+
+	// Logical backends
+	c.configureLogicalBackends(conf.LogicalBackends, conf.Logger, conf.AdministrativeNamespacePath)
+
+	// MFA method
 	c.loginMFABackend = NewLoginMFABackend(c, conf.Logger)
 
-	logicalBackends := make(map[string]logical.Factory)
-	for k, f := range conf.LogicalBackends {
-		logicalBackends[k] = f
-	}
-	_, ok := logicalBackends["kv"]
-	if !ok {
-		logicalBackends["kv"] = PassthroughBackendFactory
-	}
-
-	logicalBackends["cubbyhole"] = CubbyholeBackendFactory
-	logicalBackends[systemMountType] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
-		sysBackendLogger := conf.Logger.Named("system")
-		b := NewSystemBackend(c, sysBackendLogger)
-		if err := b.Setup(ctx, config); err != nil {
-			return nil, err
-		}
-		return b, nil
-	}
-	logicalBackends["identity"] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
-		identityLogger := conf.Logger.Named("identity")
-		return NewIdentityStore(ctx, c, config, identityLogger)
-	}
-	addExtraLogicalBackends(c, logicalBackends, conf.AdministrativeNamespacePath)
-	c.logicalBackends = logicalBackends
-
-	credentialBackends := make(map[string]logical.Factory)
-	for k, f := range conf.CredentialBackends {
-		credentialBackends[k] = f
-	}
-	credentialBackends["token"] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
-		tsLogger := conf.Logger.Named("token")
-		return NewTokenStore(ctx, tsLogger, c, config)
-	}
-	addExtraCredentialBackends(c, credentialBackends)
-	c.credentialBackends = credentialBackends
-
-	auditBackends := make(map[string]audit.Factory)
-	for k, f := range conf.AuditBackends {
-		auditBackends[k] = f
-	}
-	c.auditBackends = auditBackends
-
-	uiStoragePrefix := systemBarrierPrefix + "ui"
+	// UI
+	uiStoragePrefix := fmt.Sprintf("%sui", systemBarrierPrefix)
 	c.uiConfig = NewUIConfig(conf.EnableUI, physical.NewView(c.physical, uiStoragePrefix), NewBarrierView(c.barrier, uiStoragePrefix))
 
-	c.clusterListener.Store((*cluster.Listener)(nil))
-
-	// for listeners with custom response headers, configuring customListenerHeader
-	if conf.RawConfig.Listeners != nil {
-		uiHeaders, err := c.UIHeaders()
-		if err != nil {
-			return nil, err
-		}
-		c.customListenerHeader.Store(NewListenerCustomHeader(conf.RawConfig.Listeners, c.logger, uiHeaders))
-	} else {
-		c.customListenerHeader.Store(([]*ListenerCustomHeaders)(nil))
+	// Listeners
+	err = c.configureListeners(conf)
+	if err != nil {
+		return nil, err
 	}
 
-	logRequestsLevel := conf.RawConfig.LogRequestsLevel
-	c.logRequestsLevel = uberAtomic.NewInt32(0)
-	switch {
-	case log.LevelFromString(logRequestsLevel) > log.NoLevel && log.LevelFromString(logRequestsLevel) < log.Off:
-		c.logRequestsLevel.Store(int32(log.LevelFromString(logRequestsLevel)))
-	case logRequestsLevel != "":
-		c.logger.Warn("invalid log_requests_level", "level", conf.RawConfig.LogRequestsLevel)
-	}
+	// Log level
+	c.configureLogRequestLevel(conf.RawConfig.LogLevel)
 
+	// Quotas
 	quotasLogger := conf.Logger.Named("quotas")
 	c.quotaManager, err = quotas.NewManager(quotasLogger, c.quotaLeaseWalker, c.metricSink)
 	if err != nil {
@@ -1319,25 +1285,120 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		return nil, err
 	}
 
+	// Version history
 	if c.versionHistory == nil {
 		c.logger.Info("Initializing version history cache for core")
 		c.versionHistory = make(map[string]VaultVersion)
 	}
 
-	// start the event system
-	eventsLogger := conf.Logger.Named("events")
-	events, err := eventbus.NewEventBus(eventsLogger)
+	// Events
+	c.events, err = eventbus.NewEventBus(conf.Logger.Named("events"))
 	if err != nil {
 		return nil, err
 	}
-	c.events = events
 	c.events.Start()
 
 	// Make sure we're keeping track of the subloggers added above. We haven't
 	// yet registered core to the server command's SubloggerAdder, so any new
 	// subloggers will be in conf.AllLoggers.
 	c.allLoggers = conf.AllLoggers
+
 	return c, nil
+}
+
+// configureListeners configures the Core with the listeners from the CoreConfig.
+func (c *Core) configureListeners(conf *CoreConfig) error {
+	if conf == nil || conf.RawConfig == nil || conf.RawConfig.SharedConfig.Listeners == nil {
+		c.customListenerHeader.Store(([]*ListenerCustomHeaders)(nil))
+		return nil
+	}
+
+	uiHeaders, err := c.UIHeaders()
+	if err != nil {
+		return err
+	}
+	c.customListenerHeader.Store(NewListenerCustomHeader(conf.RawConfig.Listeners, c.logger, uiHeaders))
+
+	return nil
+}
+
+// configureLogRequestLevel configures the Core with the supplied log level.
+func (c *Core) configureLogRequestLevel(level string) {
+	c.logRequestsLevel = uberAtomic.NewInt32(0)
+
+	lvl := log.LevelFromString(level)
+
+	switch {
+	case lvl > log.NoLevel && lvl < log.Off:
+		c.logRequestsLevel.Store(int32(lvl))
+	case level != "":
+		c.logger.Warn("invalid log_requests_level", "level", level)
+	}
+}
+
+// configureAuditBackends configures the Core with the ability to create audit
+// backends for various types.
+func (c *Core) configureAuditBackends(backends map[string]audit.Factory) {
+	auditBackends := make(map[string]audit.Factory, len(backends))
+
+	for k, f := range backends {
+		auditBackends[k] = f
+	}
+
+	c.auditBackends = auditBackends
+}
+
+// configureCredentialsBackends configures the Core with the ability to create
+// credential backends for various types.
+func (c *Core) configureCredentialsBackends(backends map[string]logical.Factory, logger log.Logger) {
+	credentialBackends := make(map[string]logical.Factory, len(backends))
+
+	for k, f := range backends {
+		credentialBackends[k] = f
+	}
+
+	credentialBackends["token"] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
+		return NewTokenStore(ctx, logger.Named("token"), c, config)
+	}
+
+	c.credentialBackends = credentialBackends
+}
+
+// configureLogicalBackends configures the Core with the ability to create
+// logical backends for various types.
+func (c *Core) configureLogicalBackends(backends map[string]logical.Factory, logger log.Logger, adminNamespacePath string) {
+	logicalBackends := make(map[string]logical.Factory, len(backends))
+
+	for k, f := range backends {
+		logicalBackends[k] = f
+	}
+
+	// KV
+	_, ok := logicalBackends[mountTypeKV]
+	if !ok {
+		logicalBackends[mountTypeKV] = PassthroughBackendFactory
+	}
+
+	// Cubbyhole
+	logicalBackends[mountTypeCubbyhole] = CubbyholeBackendFactory
+
+	// System
+	logicalBackends[mountTypeSystem] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
+		b := NewSystemBackend(c, logger.Named("system"))
+		if err := b.Setup(ctx, config); err != nil {
+			return nil, err
+		}
+		return b, nil
+	}
+
+	// Identity
+	logicalBackends[mountTypeIdentity] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
+		return NewIdentityStore(ctx, c, config, logger.Named("identity"))
+	}
+
+	c.logicalBackends = logicalBackends
+
+	c.addExtraLogicalBackends(adminNamespacePath)
 }
 
 // handleVersionTimeStamps stores the current version at the current time to

--- a/vault/core.go
+++ b/vault/core.go
@@ -1311,7 +1311,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 func (c *Core) configureListeners(conf *CoreConfig) error {
 	c.clusterListener.Store((*cluster.Listener)(nil))
 
-	if conf == nil || conf.RawConfig == nil || conf.RawConfig.Listeners == nil {
+	if conf.RawConfig.Listeners == nil {
 		c.customListenerHeader.Store(([]*ListenerCustomHeaders)(nil))
 		return nil
 	}

--- a/vault/core.go
+++ b/vault/core.go
@@ -1203,7 +1203,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		return nil, fmt.Errorf("barrier setup failed: %w", err)
 	}
 
-	err = entCheckStoredLicense(c, conf)
+	err = c.entCheckStoredLicense(conf)
 	if err != nil {
 		return nil, err
 	}

--- a/vault/core.go
+++ b/vault/core.go
@@ -1248,17 +1248,17 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		c.ha = conf.HAPhysical
 	}
 
-	// Audit backends
-	c.configureAuditBackends(conf.AuditBackends)
-
-	// Credentials backends
-	c.configureCredentialsBackends(conf.CredentialBackends, conf.Logger)
+	// MFA method
+	c.loginMFABackend = NewLoginMFABackend(c, conf.Logger)
 
 	// Logical backends
 	c.configureLogicalBackends(conf.LogicalBackends, conf.Logger, conf.AdministrativeNamespacePath)
 
-	// MFA method
-	c.loginMFABackend = NewLoginMFABackend(c, conf.Logger)
+	// Credentials backends
+	c.configureCredentialsBackends(conf.CredentialBackends, conf.Logger)
+
+	// Audit backends
+	c.configureAuditBackends(conf.AuditBackends)
 
 	// UI
 	uiStoragePrefix := systemBarrierPrefix + "ui"

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -13,6 +13,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/vault/command/server"
+
+	logicalKv "github.com/hashicorp/vault-plugin-secrets-kv"
+	logicalDb "github.com/hashicorp/vault/builtin/logical/database"
+
+	"github.com/hashicorp/vault/builtin/plugin"
+
+	"github.com/hashicorp/vault/builtin/audit/syslog"
+
+	"github.com/hashicorp/vault/builtin/audit/file"
+	"github.com/hashicorp/vault/builtin/audit/socket"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-test/deep"
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
@@ -34,6 +47,291 @@ import (
 
 // invalidKey is used to test Unseal
 var invalidKey = []byte("abcdefghijklmnopqrstuvwxyz")[:17]
+
+// TestNewCore_configureAuditBackends ensures that we are able to configure the
+// supplied audit backends when getting a NewCore.
+func TestNewCore_configureAuditBackends(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		backends map[string]audit.Factory
+	}{
+		"none": {
+			backends: nil,
+		},
+		"file": {
+			backends: map[string]audit.Factory{
+				"file": file.Factory,
+			},
+		},
+		"socket": {
+			backends: map[string]audit.Factory{
+				"socket": socket.Factory,
+			},
+		},
+		"syslog": {
+			backends: map[string]audit.Factory{
+				"syslog": syslog.Factory,
+			},
+		},
+		"all": {
+			backends: map[string]audit.Factory{
+				"file":   file.Factory,
+				"socket": socket.Factory,
+				"syslog": syslog.Factory,
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			core := &Core{}
+			require.Len(t, core.auditBackends, 0)
+			core.configureAuditBackends(tc.backends)
+			require.Len(t, core.auditBackends, len(tc.backends))
+			for k := range tc.backends {
+				require.Contains(t, core.auditBackends, k)
+			}
+		})
+	}
+}
+
+// TestNewCore_configureCredentialsBackends ensures that we are able to configure the
+// supplied credential backends, in addition to defaults, when getting a NewCore.
+func TestNewCore_configureCredentialsBackends(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		backends map[string]logical.Factory
+	}{
+		"none": {
+			backends: nil,
+		},
+		"plugin": {
+			backends: map[string]logical.Factory{
+				"plugin": plugin.Factory,
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			core := &Core{}
+			require.Len(t, core.credentialBackends, 0)
+			core.configureCredentialsBackends(tc.backends, corehelpers.NewTestLogger(t))
+			require.Len(t, core.credentialBackends, len(tc.backends)+1) // + token
+			for k := range tc.backends {
+				require.Contains(t, core.credentialBackends, k)
+			}
+		})
+	}
+}
+
+// TestNewCore_configureLogicalBackends ensures that we are able to configure the
+// supplied logical backends, in addition to defaults, when getting a NewCore.
+func TestNewCore_configureLogicalBackends(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		backends           map[string]logical.Factory
+		adminNamespacePath string
+	}{
+		"none": {
+			backends: nil,
+		},
+		"database": {
+			backends: map[string]logical.Factory{
+				"database": logicalDb.Factory,
+			},
+			adminNamespacePath: "foo",
+		},
+		"kv": {
+			backends: map[string]logical.Factory{
+				"kv": logicalKv.Factory,
+			},
+			adminNamespacePath: "foo",
+		},
+		"plugin": {
+			backends: map[string]logical.Factory{
+				"plugin": plugin.Factory,
+			},
+			adminNamespacePath: "foo",
+		},
+		"all": {
+			backends: map[string]logical.Factory{
+				"database": logicalDb.Factory,
+				"kv":       logicalKv.Factory,
+				"plugin":   plugin.Factory,
+			},
+			adminNamespacePath: "foo",
+		},
+	}
+
+	for name, tc := range tests {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			core := &Core{}
+			require.Len(t, core.logicalBackends, 0)
+			core.configureLogicalBackends(tc.backends, corehelpers.NewTestLogger(t), tc.adminNamespacePath)
+			require.GreaterOrEqual(t, len(core.logicalBackends), len(tc.backends))
+			require.Contains(t, core.logicalBackends, mountTypeKV)
+			require.Contains(t, core.logicalBackends, mountTypeCubbyhole)
+			require.Contains(t, core.logicalBackends, mountTypeSystem)
+			require.Contains(t, core.logicalBackends, mountTypeIdentity)
+			for k := range tc.backends {
+				require.Contains(t, core.logicalBackends, k)
+			}
+		})
+	}
+}
+
+// TestNewCore_configureLogRequestLevel ensures that we are able to configure the
+// supplied logging level when getting a NewCore.
+func TestNewCore_configureLogRequestLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		level         string
+		expectedLevel log.Level
+	}{
+		"none": {
+			level:         "",
+			expectedLevel: log.NoLevel,
+		},
+		"trace": {
+			level:         "trace",
+			expectedLevel: log.Trace,
+		},
+		"debug": {
+			level:         "debug",
+			expectedLevel: log.Debug,
+		},
+		"info": {
+			level:         "info",
+			expectedLevel: log.Info,
+		},
+		"warn": {
+			level:         "warn",
+			expectedLevel: log.Warn,
+		},
+		"error": {
+			level:         "error",
+			expectedLevel: log.Error,
+		},
+		"bad": {
+			level:         "foo",
+			expectedLevel: log.NoLevel,
+		},
+	}
+
+	for name, tc := range tests {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// We need to supply a logger, as configureLogRequestLevel emits
+			// warnings to the logs in certain circumstances.
+			core := &Core{
+				logger: corehelpers.NewTestLogger(t),
+			}
+			core.configureLogRequestLevel(tc.level)
+			require.Equal(t, tc.expectedLevel, log.Level(core.logRequestsLevel.Load()))
+		})
+	}
+}
+
+// TestNewCore_configureListeners tests that we are able to configure listeners
+// on a NewCore via config.
+func TestNewCore_configureListeners(t *testing.T) {
+	// We would usually expect CoreConfig to come from server.NewConfig().
+	// However, we want to fiddle to give us some granular control over the config.
+	tests := map[string]struct {
+		config            *CoreConfig
+		expectedListeners []*ListenerCustomHeaders
+	}{
+		"nil-config": {
+			config:            nil,
+			expectedListeners: nil,
+		},
+		"nil-rawconfig": {
+			config:            &CoreConfig{},
+			expectedListeners: nil,
+		},
+		"nil-listeners": {
+			config: &CoreConfig{
+				RawConfig: &server.Config{
+					SharedConfig: &configutil.SharedConfig{},
+				},
+			},
+			expectedListeners: nil,
+		},
+		"listeners-empty": {
+			config: &CoreConfig{
+				RawConfig: &server.Config{
+					SharedConfig: &configutil.SharedConfig{
+						Listeners: []*configutil.Listener{},
+					},
+				},
+			},
+			expectedListeners: nil,
+		},
+		"listeners-some": {
+			config: &CoreConfig{
+				RawConfig: &server.Config{
+					SharedConfig: &configutil.SharedConfig{
+						Listeners: []*configutil.Listener{
+							{Address: "foo"},
+						},
+					},
+				},
+			},
+			expectedListeners: []*ListenerCustomHeaders{
+				{Address: "foo"},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// We need to init some values ourselves, usually CreateCore does this for us.
+			logger := corehelpers.NewTestLogger(t)
+			backend, err := inmem.NewInmem(nil, logger)
+			require.NoError(t, err)
+			storage := &logical.InmemStorage{}
+			core := &Core{
+				customListenerHeader: new(atomic.Value),
+				uiConfig:             NewUIConfig(false, backend, storage),
+			}
+
+			err = core.configureListeners(tc.config)
+			require.NoError(t, err)
+			switch tc.expectedListeners {
+			case nil:
+				require.Nil(t, core.customListenerHeader.Load())
+			default:
+				for i, v := range core.customListenerHeader.Load().([]*ListenerCustomHeaders) {
+					require.Equal(t, v.Address, tc.config.RawConfig.Listeners[i].Address)
+				}
+			}
+		})
+	}
+}
 
 func TestNewCore_badRedirectAddr(t *testing.T) {
 	logger = logging.NewVaultLogger(log.Trace)

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -127,7 +127,7 @@ func TestNewCore_configureCredentialsBackends(t *testing.T) {
 			core := &Core{}
 			require.Len(t, core.credentialBackends, 0)
 			core.configureCredentialsBackends(tc.backends, corehelpers.NewTestLogger(t))
-			require.Len(t, core.credentialBackends, len(tc.backends)+1) // + token
+			require.GreaterOrEqual(t, len(core.credentialBackends), len(tc.backends)+1) // token + ent
 			for k := range tc.backends {
 				require.Contains(t, core.credentialBackends, k)
 			}

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -274,14 +274,6 @@ func TestNewCore_configureListeners(t *testing.T) {
 		config            *CoreConfig
 		expectedListeners []*ListenerCustomHeaders
 	}{
-		"nil-config": {
-			config:            nil,
-			expectedListeners: nil,
-		},
-		"nil-rawconfig": {
-			config:            &CoreConfig{},
-			expectedListeners: nil,
-		},
 		"nil-listeners": {
 			config: &CoreConfig{
 				RawConfig: &server.Config{
@@ -328,6 +320,7 @@ func TestNewCore_configureListeners(t *testing.T) {
 			require.NoError(t, err)
 			storage := &logical.InmemStorage{}
 			core := &Core{
+				clusterListener:      new(atomic.Value),
 				customListenerHeader: new(atomic.Value),
 				uiConfig:             NewUIConfig(false, backend, storage),
 			}

--- a/vault/core_util.go
+++ b/vault/core_util.go
@@ -82,11 +82,11 @@ func (c *Core) BuildProgress() *uint32 { return nil }
 func (c *Core) BuildTotal() *uint32    { return nil }
 
 func (c *Core) teardownReplicationResolverHandler() {}
-func createSecondaries(*Core, *CoreConfig)          {}
+func (c *Core) createSecondaries(_ hclog.Logger)    {}
 
-func addExtraLogicalBackends(*Core, map[string]logical.Factory, string) {}
+func (c *Core) addExtraLogicalBackends(_ string) {}
 
-func addExtraCredentialBackends(*Core, map[string]logical.Factory) {}
+func (c *Core) addExtraCredentialBackends() {}
 
 func preUnsealInternal(context.Context, *Core) error { return nil }
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2253,7 +2253,7 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		if !strings.HasPrefix(path, "auth/") {
 			return logical.ErrorResponse(fmt.Sprintf("'token_type' can only be modified on auth mounts")), logical.ErrInvalidRequest
 		}
-		if mountEntry.Type == "token" || mountEntry.Type == "ns_token" {
+		if mountEntry.Type == mountTypeToken || mountEntry.Type == mountTypeNSToken {
 			return logical.ErrorResponse(fmt.Sprintf("'token_type' cannot be set for 'token' or 'ns_token' auth mounts")), logical.ErrInvalidRequest
 		}
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -66,11 +66,14 @@ const (
 	cubbyholeMountPath = "cubbyhole/"
 
 	mountTypeSystem      = "system"
+	mountTypeNSSystem    = "ns_system"
 	mountTypeIdentity    = "identity"
 	mountTypeCubbyhole   = "cubbyhole"
 	mountTypePlugin      = "plugin"
 	mountTypeKV          = "kv"
 	mountTypeNSCubbyhole = "ns_cubbyhole"
+	mountTypeToken       = "token"
+	mountTypeNSToken     = "ns_token"
 
 	MountTableUpdateStorage   = true
 	MountTableNoUpdateStorage = false

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -61,9 +61,9 @@ const (
 	// ListingVisibilityUnauth is the unauth type for listing visibility
 	ListingVisibilityUnauth ListingVisibilityType = "unauth"
 
-	systemMountPath    = "sys/"
-	identityMountPath  = "identity/"
-	cubbyholeMountPath = "cubbyhole/"
+	mountPathSystem    = "sys/"
+	mountPathIdentity  = "identity/"
+	mountPathCubbyhole = "cubbyhole/"
 
 	mountTypeSystem      = "system"
 	mountTypeNSSystem    = "ns_system"
@@ -94,16 +94,16 @@ var (
 	protectedMounts = []string{
 		"audit/",
 		"auth/",
-		systemMountPath,
-		cubbyholeMountPath,
-		identityMountPath,
+		mountPathSystem,
+		mountPathCubbyhole,
+		mountPathIdentity,
 	}
 
 	untunableMounts = []string{
-		cubbyholeMountPath,
-		systemMountPath,
+		mountPathCubbyhole,
+		mountPathSystem,
 		"audit/",
-		identityMountPath,
+		mountPathIdentity,
 	}
 
 	// singletonMounts can only exist in one location and are
@@ -433,7 +433,7 @@ func (e *MountEntry) IsExternalPlugin() bool {
 
 // MountClass returns the mount class based on Accessor and Path
 func (e *MountEntry) MountClass() string {
-	if e.Accessor == "" || strings.HasPrefix(e.Path, fmt.Sprintf("%s/", systemMountPath)) {
+	if e.Accessor == "" || strings.HasPrefix(e.Path, fmt.Sprintf("%s/", mountPathSystem)) {
 		return ""
 	}
 
@@ -1802,7 +1802,7 @@ func (c *Core) requiredMountTable() *MountTable {
 	}
 	cubbyholeMount := &MountEntry{
 		Table:            mountTableType,
-		Path:             cubbyholeMountPath,
+		Path:             mountPathCubbyhole,
 		Type:             mountTypeCubbyhole,
 		Description:      "per-token private secret storage",
 		UUID:             cubbyholeUUID,

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -111,7 +111,7 @@ var (
 	singletonMounts = []string{
 		mountTypeCubbyhole,
 		mountTypeSystem,
-		"token",
+		mountTypeToken,
 		mountTypeIdentity,
 	}
 

--- a/vault/mount_util.go
+++ b/vault/mount_util.go
@@ -33,7 +33,7 @@ func runFilteredPathsEvaluation(context.Context, *Core, bool) error           { 
 // ViewPath returns storage prefix for the view
 func (e *MountEntry) ViewPath() string {
 	switch e.Type {
-	case systemMountType:
+	case mountTypeSystem:
 		return systemBarrierPrefix
 	case "token":
 		return path.Join(systemBarrierPrefix, tokenSubPath) + "/"

--- a/vault/plugin_reload.go
+++ b/vault/plugin_reload.go
@@ -41,9 +41,9 @@ func (c *Core) reloadMatchingPluginMounts(ctx context.Context, mounts []string) 
 		//   - auth/foo
 		if strings.HasPrefix(mount, credentialRoutePrefix) {
 			isAuth = true
-		} else if strings.HasPrefix(mount, systemMountPath+credentialRoutePrefix) {
+		} else if strings.HasPrefix(mount, mountPathSystem+credentialRoutePrefix) {
 			isAuth = true
-			mount = strings.TrimPrefix(mount, systemMountPath)
+			mount = strings.TrimPrefix(mount, mountPathSystem)
 		}
 		if !strings.HasSuffix(mount, "/") {
 			mount += "/"

--- a/vault/router.go
+++ b/vault/router.go
@@ -811,7 +811,7 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 				}
 
 				switch re.mountEntry.Type {
-				case "token", "ns_token":
+				case mountTypeToken, mountTypeNSToken:
 					// Nothing; we respect what the token store is telling us and
 					// we don't allow tuning
 				default:

--- a/vault/router.go
+++ b/vault/router.go
@@ -639,9 +639,9 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 	clientToken := req.ClientToken
 	switch {
 	case strings.HasPrefix(originalPath, "auth/token/"):
-	case strings.HasPrefix(originalPath, "sys/"):
-	case strings.HasPrefix(originalPath, "identity/"):
-	case strings.HasPrefix(originalPath, cubbyholeMountPath):
+	case strings.HasPrefix(originalPath, mountPathSystem):
+	case strings.HasPrefix(originalPath, mountPathIdentity):
+	case strings.HasPrefix(originalPath, mountPathCubbyhole):
 		if req.Operation == logical.RollbackOperation {
 			// Backend doesn't support this and it can't properly look up a
 			// cubbyhole ID so just return here

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -113,7 +113,7 @@ var (
 			return errors.New("nil token entry")
 		}
 
-		storage := ts.core.router.MatchingStorageByAPIPath(ctx, cubbyholeMountPath)
+		storage := ts.core.router.MatchingStorageByAPIPath(ctx, mountPathCubbyhole)
 		if storage == nil {
 			return fmt.Errorf("no cubby mount entry")
 		}
@@ -2202,7 +2202,7 @@ func (ts *TokenStore) handleTidy(ctx context.Context, req *logical.Request, data
 			}
 
 			// List all the cubbyhole storage keys
-			view := ts.core.router.MatchingStorageByAPIPath(ctx, cubbyholeMountPath)
+			view := ts.core.router.MatchingStorageByAPIPath(ctx, mountPathCubbyhole)
 			if view == nil {
 				return fmt.Errorf("no cubby mount entry")
 			}

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -136,8 +136,8 @@ func TestTokenStore_CubbyholeTidy(t *testing.T) {
 func testTokenStore_CubbyholeTidy(t *testing.T, c *Core, root string, nsCtx context.Context) {
 	ts := c.tokenStore
 
-	backend := c.router.MatchingBackend(nsCtx, cubbyholeMountPath)
-	view := c.router.MatchingStorageByAPIPath(nsCtx, cubbyholeMountPath)
+	backend := c.router.MatchingBackend(nsCtx, mountPathCubbyhole)
+	view := c.router.MatchingStorageByAPIPath(nsCtx, mountPathCubbyhole)
 
 	for i := 1; i <= 20; i++ {
 		// Create 20 tokens


### PR DESCRIPTION
Tech debt ticket.

 Cyclomatic complexity: `gocyclo vault/core.go | grep NewCore`

Before:`29`
After: `20`

Split out `NewCore` into more testable receivers, some other refactoring work for naming and moving from funcs to receivers.

`gocyclo vault/core.go | grep configure`:

```
(*Core).configureLogicalBackends: 4
(*Core).configureLogRequestLevel: 4
(*Core).configureListeners: 3
(*Core).configureCredentialsBackends: 2
(*Core).configureAuditBackends: 2
```

Ent PR: https://github.com/hashicorp/vault-enterprise/pull/4824

One for later (TODO): Review the way we handle this shared state on reload funcs for config + core.