### PR TITLE
docs/k8s-versions: updating supported k8s versions

### DIFF
--- a/website/content/partials/kubernetes-supported-versions.mdx
+++ b/website/content/partials/kubernetes-supported-versions.mdx
@@ -4,10 +4,10 @@ The following [Kubernetes minor releases][k8s-releases] are currently supported.
 The latest version is tested against each Kubernetes version. It may work with
 other versions of Kubernetes, but those are not supported.
 
+* 1.28
 * 1.27
 * 1.26
 * 1.25
 * 1.24
-* 1.23
 
 [k8s-releases]: https://kubernetes.io/releases/


### PR DESCRIPTION
Dropping 1.23 since 1.24 is the oldest supported by the cloud providers ([EKS](https://endoflife.date/amazon-eks), [GKE](https://endoflife.date/google-kubernetes-engine), [AKS](https://endoflife.date/azure-kubernetes-service)), and 1.28 is the latest release.

Related to https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/212