### PR TITLE
Step 3 of part 3 of removing ent init hooks: call stubs instead of var func hooks

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1741,7 +1741,7 @@ func (c *ServerCommand) Run(args []string) int {
 			}
 
 			// Reload license file
-			if err = vault.LicenseReload(core); err != nil {
+			if err = core.EntReloadLicense(); err != nil {
 				c.UI.Error(err.Error())
 			}
 

--- a/helper/builtinplugins/registry.go
+++ b/helper/builtinplugins/registry.go
@@ -200,7 +200,7 @@ func newRegistry() *registry {
 		},
 	}
 
-	addExternalPlugins(reg)
+	entAddExtPlugins(reg)
 
 	return reg
 }

--- a/http/handler.go
+++ b/http/handler.go
@@ -234,14 +234,14 @@ func handler(props *vault.HandlerProperties) http.Handler {
 		} else {
 			mux.Handle("/v1/sys/in-flight-req", handleLogicalNoForward(core))
 		}
-		additionalRoutes(mux, core)
+		entAdditionalRoutes(mux, core)
 	}
 
 	// Build up a chain of wrapping handlers.
 	wrappedHandler := wrapHelpHandler(mux, core)
 	wrappedHandler = wrapCORSHandler(wrappedHandler, core)
 	wrappedHandler = rateLimitQuotaWrapping(wrappedHandler, core)
-	wrappedHandler = genericWrapping(core, wrappedHandler, props)
+	wrappedHandler = entWrapGenericHandler(core, wrappedHandler, props)
 
 	// Add an extra wrapping handler if the DisablePrintableCheck listener
 	// setting isn't true that checks for non-printable characters in the
@@ -944,7 +944,7 @@ func forwardRequest(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 // case of an error.
 func request(core *vault.Core, w http.ResponseWriter, rawReq *http.Request, r *logical.Request) (*logical.Response, bool, bool) {
 	resp, err := core.HandleRequest(rawReq.Context(), r)
-	if r.LastRemoteWAL() > 0 && !vault.WaitUntilWALShipped(rawReq.Context(), core, r.LastRemoteWAL()) {
+	if r.LastRemoteWAL() > 0 && !core.EntWaitUntilWALShipped(rawReq.Context(), r.LastRemoteWAL()) {
 		if resp == nil {
 			resp = &logical.Response{}
 		}

--- a/http/logical.go
+++ b/http/logical.go
@@ -446,7 +446,7 @@ func respondLogical(core *vault.Core, w http.ResponseWriter, r *http.Request, re
 		}
 	}
 
-	adjustResponse(core, w, req)
+	entAdjustResponse(core, w, req)
 
 	// Respond
 	respondOk(w, ret)

--- a/http/sys_health.go
+++ b/http/sys_health.go
@@ -208,7 +208,7 @@ func getSysHealth(core *vault.Core, r *http.Request) (int, *HealthResponse, erro
 		ClusterID:                  clusterID,
 	}
 
-	licenseState, err := vault.LicenseSummary(core)
+	licenseState, err := core.EntGetLicenseState()
 	if err != nil {
 		return http.StatusInternalServerError, nil, err
 	}
@@ -224,7 +224,7 @@ func getSysHealth(core *vault.Core, r *http.Request) (int, *HealthResponse, erro
 	}
 
 	if init && !sealed && !standby {
-		body.LastWAL = vault.LastWAL(core)
+		body.LastWAL = core.EntLastWAL()
 	}
 
 	return code, body, nil

--- a/vault/core.go
+++ b/vault/core.go
@@ -1197,7 +1197,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		return nil, fmt.Errorf("barrier setup failed: %w", err)
 	}
 
-	if err := storedLicenseCheck(c, conf); err != nil {
+	if err := c.entCheckStoredLicense(conf); err != nil {
 		return nil, err
 	}
 	// We create the funcs here, then populate the given config with it so that
@@ -2313,7 +2313,7 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 		return err
 	}
 
-	if err := enterprisePostUnseal(c, false); err != nil {
+	if err := c.entPostUnseal(false); err != nil {
 		return err
 	}
 	if !c.ReplicationState().HasState(consts.ReplicationPerformanceSecondary | consts.ReplicationDRSecondary) {
@@ -2345,13 +2345,13 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 	if err := c.loadMounts(ctx); err != nil {
 		return err
 	}
-	if err := enterpriseSetupFilteredPaths(c); err != nil {
+	if err := c.entSetupFilteredPaths(); err != nil {
 		return err
 	}
 	if err := c.setupMounts(ctx); err != nil {
 		return err
 	}
-	if err := enterpriseSetupAPILock(c, ctx); err != nil {
+	if err := c.entSetupAPILock(ctx); err != nil {
 		return err
 	}
 	if err := c.setupPolicyStore(ctx); err != nil {
@@ -2366,7 +2366,7 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 	if err := c.loadCredentials(ctx); err != nil {
 		return err
 	}
-	if err := enterpriseSetupFilteredPaths(c); err != nil {
+	if err := c.entSetupFilteredPaths(); err != nil {
 		return err
 	}
 	if err := c.setupCredentials(ctx); err != nil {
@@ -2471,7 +2471,7 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 
 	c.clusterParamsLock.Lock()
 	defer c.clusterParamsLock.Unlock()
-	if err := startReplication(c); err != nil {
+	if err := c.entStartReplication(); err != nil {
 		return err
 	}
 
@@ -2630,7 +2630,7 @@ func (c *Core) preSeal() error {
 	c.stopRaftActiveNode()
 
 	c.clusterParamsLock.Lock()
-	if err := stopReplication(c); err != nil {
+	if err := c.entStopReplication(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error stopping replication: %w", err))
 	}
 	c.clusterParamsLock.Unlock()
@@ -2660,7 +2660,7 @@ func (c *Core) preSeal() error {
 		result = multierror.Append(result, fmt.Errorf("error unloading mounts: %w", err))
 	}
 
-	if err := enterprisePreSeal(c); err != nil {
+	if err := c.entPreSeal(); err != nil {
 		result = multierror.Append(result, err)
 	}
 

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -143,7 +143,7 @@ func (e extendedSystemViewImpl) APILockShouldBlockRequest() (bool, error) {
 	}
 	ns := mountEntry.Namespace()
 
-	if err := enterpriseBlockRequestIfError(e.core, ns.Path, mountEntry.Path); err != nil {
+	if err := e.core.entBlockRequestIfError(ns.Path, mountEntry.Path); err != nil {
 		return true, nil
 	}
 

--- a/vault/init.go
+++ b/vault/init.go
@@ -162,7 +162,7 @@ func (c *Core) generateShares(sc *SealConfig) ([]byte, [][]byte, error) {
 // Initialize is used to initialize the Vault with the given
 // configurations.
 func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitResult, error) {
-	if err := LicenseInitCheck(c); err != nil {
+	if err := c.entCheckLicenseInit(); err != nil {
 		return nil, err
 	}
 
@@ -265,7 +265,7 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 		return nil, fmt.Errorf("error initializing seal: %w", err)
 	}
 
-	initPTCleanup := initPTFunc(c)
+	initPTCleanup := c.entInitWALPassThrough()
 	if initPTCleanup != nil {
 		defer initPTCleanup()
 	}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -5117,9 +5117,9 @@ func (core *Core) GetLeaderStatus() (*LeaderResponse, error) {
 		resp.ActiveTime = core.ActiveTime()
 	}
 	if resp.PerfStandby {
-		resp.PerfStandbyLastRemoteWAL = LastRemoteWAL(core)
+		resp.PerfStandbyLastRemoteWAL = core.EntLastRemoteWAL()
 	} else if isLeader || !haEnabled {
-		resp.LastWAL = LastWAL(core)
+		resp.LastWAL = core.EntLastWAL()
 	}
 
 	resp.RaftCommittedIndex, resp.RaftAppliedIndex = core.GetRaftIndexes()

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -396,7 +396,7 @@ func (b *SystemBackend) handleRaftBootstrapAnswerWrite() framework.OperationFunc
 			Data: map[string]interface{}{
 				"peers":              peers,
 				"tls_keyring":        &keyring,
-				"autoloaded_license": LicenseAutoloaded(b.Core),
+				"autoloaded_license": b.Core.entIsLicenseAutoloaded(),
 			},
 		}, nil
 	}

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -1329,7 +1329,7 @@ func (c *Core) joinRaftSendAnswer(ctx context.Context, sealAccess seal.Access, r
 		return err
 	}
 
-	if answerResp.Data.AutoloadedLicense && !LicenseAutoloaded(c) {
+	if answerResp.Data.AutoloadedLicense && !c.entIsLicenseAutoloaded() {
 		return ErrJoinWithoutAutoloading
 	}
 	if err := raftBackend.Bootstrap(answerResp.Data.Peers); err != nil {

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -379,7 +379,7 @@ func (c *Core) ForwardRequest(req *http.Request) (int, http.Header, []byte, erro
 	// we should attempt to wait for the WAL to ship to offer best effort read after
 	// write guarantees
 	if isPerfStandby && resp.LastRemoteWal > 0 {
-		WaitUntilWALShipped(req.Context(), c, resp.LastRemoteWal)
+		c.EntWaitUntilWALShipped(req.Context(), resp.LastRemoteWal)
 	}
 
 	return int(resp.StatusCode), header, resp.Body, nil

--- a/vault/request_forwarding_rpc.go
+++ b/vault/request_forwarding_rpc.go
@@ -66,7 +66,7 @@ func (s *forwardedRequestRPCServer) ForwardRequest(ctx context.Context, freq *fo
 
 	// Performance standby nodes will use this value to do wait for WALs to ship
 	// in order to do a best-effort read after write guarantee
-	resp.LastRemoteWal = LastWAL(s.core)
+	resp.LastRemoteWal = s.core.EntLastWAL()
 
 	return resp, nil
 }

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -895,16 +895,16 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 		walState.ClusterID = c.ClusterID()
 		if walState.LocalIndex == 0 {
 			if c.perfStandby {
-				walState.LocalIndex = LastRemoteWAL(c)
+				walState.LocalIndex = c.EntLastRemoteWAL()
 			} else {
-				walState.LocalIndex = LastWAL(c)
+				walState.LocalIndex = c.EntLastWAL()
 			}
 		}
 		if walState.ReplicatedIndex == 0 {
 			if c.perfStandby {
-				walState.ReplicatedIndex = LastRemoteUpstreamWAL(c)
+				walState.ReplicatedIndex = c.entLastRemoteUpstreamWAL()
 			} else {
-				walState.ReplicatedIndex = LastRemoteWAL(c)
+				walState.ReplicatedIndex = c.EntLastRemoteWAL()
 			}
 		}
 
@@ -1102,7 +1102,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 		}
 	}
 
-	if err := enterpriseBlockRequestIfError(c, ns.Path, req.Path); err != nil {
+	if err := c.entBlockRequestIfError(ns.Path, req.Path); err != nil {
 		return nil, nil, multierror.Append(retErr, err)
 	}
 
@@ -1561,7 +1561,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 
 		// by placing this after the authorization check, we don't leak
 		// information about locked namespaces to unauthenticated clients.
-		if err := enterpriseBlockRequestIfError(c, ns.Path, req.Path); err != nil {
+		if err := c.entBlockRequestIfError(ns.Path, req.Path); err != nil {
 			retErr = multierror.Append(retErr, err)
 			return
 		}
@@ -1825,7 +1825,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 	}
 
 	// this check handles the bad login credential case
-	if err := enterpriseBlockRequestIfError(c, ns.Path, req.Path); err != nil {
+	if err := c.entBlockRequestIfError(ns.Path, req.Path); err != nil {
 		return nil, nil, multierror.Append(retErr, err)
 	}
 


### PR DESCRIPTION
This continues on the work from https://github.com/hashicorp/vault-enterprise/pull/4825.  After this lands in Ent, we can start getting rid of the hooks.