### PR TITLE
VAULT-19869: Use Custom Types for Context Keys

### DIFF
--- a/helper/forwarding/util.go
+++ b/helper/forwarding/util.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -17,6 +17,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/vault/sdk/helper/compressutil"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 type bufCloser struct {
@@ -64,11 +65,11 @@ func GenerateForwardedHTTPRequest(req *http.Request, addr string) (*http.Request
 func GenerateForwardedRequest(req *http.Request) (*Request, error) {
 	var reader io.Reader = req.Body
 	ctx := req.Context()
-	maxRequestSize := ctx.Value("max_request_size")
+	maxRequestSize := ctx.Value(logical.CtxKeyMaxRequestSize{})
 	if maxRequestSize != nil {
 		max, ok := maxRequestSize.(int64)
 		if !ok {
-			return nil, errors.New("could not parse max_request_size from request context")
+			return nil, fmt.Errorf("could not parse %s from request context", logical.CtxKeyMaxRequestSize{})
 		}
 		if max > 0 {
 			reader = io.LimitReader(req.Body, max)

--- a/http/handler.go
+++ b/http/handler.go
@@ -381,7 +381,7 @@ func wrapGenericHandler(core *vault.Core, h http.Handler, props *vault.HandlerPr
 		// if maxRequestSize < 0, no need to set context value
 		// Add a size limiter if desired
 		if maxRequestSize > 0 {
-			ctx = context.WithValue(ctx, "max_request_size", maxRequestSize)
+			ctx = context.WithValue(ctx, logical.CtxKeyMaxRequestSize{}, maxRequestSize)
 		}
 		ctx = context.WithValue(ctx, "original_request_path", r.URL.Path)
 		r = r.WithContext(ctx)
@@ -710,11 +710,11 @@ func parseJSONRequest(perfStandby bool, r *http.Request, w http.ResponseWriter, 
 	// against an indefinite amount of data being read.
 	reader := r.Body
 	ctx := r.Context()
-	maxRequestSize := ctx.Value("max_request_size")
+	maxRequestSize := ctx.Value(logical.CtxKeyMaxRequestSize{})
 	if maxRequestSize != nil {
 		max, ok := maxRequestSize.(int64)
 		if !ok {
-			return nil, errors.New("could not parse max_request_size from request context")
+			return nil, fmt.Errorf("could not parse %s from request context", logical.CtxKeyMaxRequestSize{})
 		}
 		if max > 0 {
 			// MaxBytesReader won't do all the internal stuff it must unless it's
@@ -749,11 +749,11 @@ func parseJSONRequest(perfStandby bool, r *http.Request, w http.ResponseWriter, 
 //
 // A nil map will be returned if the format is empty or invalid.
 func parseFormRequest(r *http.Request) (map[string]interface{}, error) {
-	maxRequestSize := r.Context().Value("max_request_size")
+	maxRequestSize := r.Context().Value(logical.CtxKeyMaxRequestSize{})
 	if maxRequestSize != nil {
 		max, ok := maxRequestSize.(int64)
 		if !ok {
-			return nil, errors.New("could not parse max_request_size from request context")
+			return nil, fmt.Errorf("could not parse %s from request context", logical.CtxKeyMaxRequestSize{})
 		}
 		if max > 0 {
 			r.Body = ioutil.NopCloser(io.LimitReader(r.Body, max))

--- a/http/handler.go
+++ b/http/handler.go
@@ -559,21 +559,6 @@ func WrapForwardedForHandler(h http.Handler, l *configutil.Listener) http.Handle
 	})
 }
 
-// stripPrefix is a helper to strip a prefix from the path. It will
-// return false from the second return value if it the prefix doesn't exist.
-func stripPrefix(prefix, path string) (string, bool) {
-	if !strings.HasPrefix(path, prefix) {
-		return "", false
-	}
-
-	path = path[len(prefix):]
-	if path == "" {
-		return "", false
-	}
-
-	return path, true
-}
-
 func handleUIHeaders(core *vault.Core, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		header := w.Header()

--- a/http/handler.go
+++ b/http/handler.go
@@ -555,7 +555,6 @@ func WrapForwardedForHandler(h http.Handler, l *configutil.Listener) http.Handle
 
 		r.RemoteAddr = net.JoinHostPort(acc[indexToUse], port)
 		h.ServeHTTP(w, r)
-		return
 	})
 }
 
@@ -585,7 +584,6 @@ func handleUI(h http.Handler) http.Handler {
 		// here.
 		req.URL.Path = strings.TrimSuffix(req.URL.Path, "/")
 		h.ServeHTTP(w, req)
-		return
 	})
 }
 
@@ -664,7 +662,6 @@ func handleUIStub() http.Handler {
 func handleUIRedirect() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		http.Redirect(w, req, "/ui/", 307)
-		return
 	})
 }
 
@@ -869,7 +866,6 @@ func handleRequestForwarding(core *vault.Core, handler http.Handler) http.Handle
 		}
 
 		forwardRequest(core, w, r)
-		return
 	})
 }
 

--- a/http/handler.go
+++ b/http/handler.go
@@ -383,7 +383,7 @@ func wrapGenericHandler(core *vault.Core, h http.Handler, props *vault.HandlerPr
 		if maxRequestSize > 0 {
 			ctx = context.WithValue(ctx, logical.CtxKeyMaxRequestSize{}, maxRequestSize)
 		}
-		ctx = context.WithValue(ctx, "original_request_path", r.URL.Path)
+		ctx = context.WithValue(ctx, logical.CtxKeyOriginalRequestPath{}, r.URL.Path)
 		r = r.WithContext(ctx)
 		r = r.WithContext(namespace.ContextWithNamespace(r.Context(), namespace.RootNamespace))
 

--- a/http/handler.go
+++ b/http/handler.go
@@ -661,7 +661,7 @@ func handleUIStub() http.Handler {
 
 func handleUIRedirect() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		http.Redirect(w, req, "/ui/", 307)
+		http.Redirect(w, req, "/ui/", http.StatusTemporaryRedirect)
 	})
 }
 

--- a/http/handler.go
+++ b/http/handler.go
@@ -568,12 +568,12 @@ func handleUIHeaders(core *vault.Core, h http.Handler) http.Handler {
 			respondError(w, http.StatusInternalServerError, err)
 			return
 		}
-		if userHeaders != nil {
-			for k := range userHeaders {
-				v := userHeaders.Get(k)
-				header.Set(k, v)
-			}
+
+		for k := range userHeaders {
+			v := userHeaders.Get(k)
+			header.Set(k, v)
 		}
+
 		h.ServeHTTP(w, req)
 	})
 }
@@ -913,10 +913,8 @@ func forwardRequest(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if header != nil {
-		for k, v := range header {
-			w.Header()[k] = v
-		}
+	for k, v := range header {
+		w.Header()[k] = v
 	}
 
 	w.WriteHeader(statusCode)

--- a/http/util.go
+++ b/http/util.go
@@ -135,7 +135,7 @@ func rateLimitQuotaWrapping(handler http.Handler, core *vault.Core) http.Handler
 
 func disableReplicationStatusEndpointWrapping(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		request := r.WithContext(context.WithValue(r.Context(), "disable_replication_status_endpoints", true))
+		request := r.WithContext(context.WithValue(r.Context(), logical.CtxKeyDisableReplicationStatusEndpoints{}, true))
 
 		h.ServeHTTP(w, request)
 	})

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -453,3 +453,14 @@ type CtxKeyRequestRole struct{}
 func (c CtxKeyRequestRole) String() string {
 	return "request-role"
 }
+
+// CtxKeyDisableReplicationStatusEndpoints is a custom type used as a key in
+// context.Context to store the value `true` when the
+// disable_replication_status_endpoints configuration parameter is set to true
+// for the listener through which a request was received.
+type CtxKeyDisableReplicationStatusEndpoints struct{}
+
+// String returns a string representation of the receiver type.
+func (c CtxKeyDisableReplicationStatusEndpoints) String() string {
+	return "disable-replication-status-endpoints"
+}

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -464,3 +464,13 @@ type CtxKeyDisableReplicationStatusEndpoints struct{}
 func (c CtxKeyDisableReplicationStatusEndpoints) String() string {
 	return "disable-replication-status-endpoints"
 }
+
+// CtxKeyMaxRequestSize is a custom type used as a key in context.Context to
+// store the value of the max_request_size set for the listener through which
+// a request was received.
+type CtxKeyMaxRequestSize struct{}
+
+// String returns a string representation of the receiver type.
+func (c CtxKeyMaxRequestSize) String() string {
+	return "max_request_size"
+}

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -474,3 +474,12 @@ type CtxKeyMaxRequestSize struct{}
 func (c CtxKeyMaxRequestSize) String() string {
 	return "max_request_size"
 }
+
+// CtxKeyOriginalRequestPath is a custom type used as a key in context.Context
+// to store the original request path.
+type CtxKeyOriginalRequestPath struct{}
+
+// String returns a string representation of the receiver type.
+func (c CtxKeyOriginalRequestPath) String() string {
+	return "original_request_path"
+}

--- a/vault/cluster_test.go
+++ b/vault/cluster_test.go
@@ -338,7 +338,7 @@ func testCluster_ForwardRequests(t *testing.T, c *TestClusterCore, rootToken, re
 		t.Fatal(err)
 	}
 	req.Header.Add(consts.AuthHeaderName, rootToken)
-	req = req.WithContext(context.WithValue(req.Context(), "original_request_path", req.URL.Path))
+	req = req.WithContext(context.WithValue(req.Context(), logical.CtxKeyOriginalRequestPath{}, req.URL.Path))
 
 	statusCode, header, respBytes, err := c.ForwardRequest(req)
 	if err != nil {

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -21,6 +21,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/helper/forwarding"
 	"github.com/hashicorp/vault/sdk/helper/consts"
+	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault/cluster"
 	"github.com/hashicorp/vault/vault/replication"
 	"golang.org/x/net/http2"
@@ -349,7 +350,7 @@ func (c *Core) ForwardRequest(req *http.Request) (int, http.Header, []byte, erro
 		req.URL.Path = origPath
 	}()
 
-	req.URL.Path = req.Context().Value("original_request_path").(string)
+	req.URL.Path = req.Context().Value(logical.CtxKeyOriginalRequestPath{}).(string)
 
 	freq, err := forwarding.GenerateForwardedRequest(req)
 	if err != nil {


### PR DESCRIPTION
This PR introduces a required change and some code clean up changes. The changes have been isolated into specific commits and the description below references the specific commits along with explaining the changes. Each commit can be reviewed independently by clicking the commit hash in this description.

The primary change consists of introducing a custom type to be used as the key when setting a value in the context to propagate the **disable_replication_status_endpoints** throughout the request handling chain and making use of that custom type instead of the hard coded string that the custom type replaces - f07b711

In addition to the primary change, some code clean up changes were also made.

This change removes an unnecessary if condition to check if `origBody` is nil because it is initialize with the `new(bytes.Buffer)` which will never return `nil`. The change also replaces the use of the deprecated type **ioutil.NopCloser** with **io.NopCloser**. A few redundant return statements (return statements that do not have any arguments and that appear at the end of the function's body). Finally, the **error** value returned by **jsonutil.DecodeJSON** function was only read in an if condition, to check if it wasn't nil, but the if condition block was empty with a comment saying that the error was being ignored - b0f96a7

An unexported function that's never used in this repository or the enterprise repository has been removed - dd70e53

Two instances of an unncessary if block to check if the variable used in a range expression is nil have been removed. In other words, if a range expression is nil, the for loop is simply skipped without causing a panic - 237a75f

Removed more instances of redundant return statements - 42fcdc6

Replaced the literal integer number 307 with the appropriate constant for that HTTP status code - 80476d2

Finally, two other context values were being set and retrieved using a hard coded string. These changes replaces those hard coded strings with custom types:
1. **max_request_size** - 16317be
2. **original_request_path** - 0fd294d
