### PR TITLE
VAULT-19869: Copy disable_replication_status_endpoints value to Active Context

### DIFF
--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -571,6 +571,10 @@ func (c *Core) switchedLockHandleRequest(httpCtx context.Context, req *logical.R
 	if ok {
 		ctx = context.WithValue(ctx, logical.CtxKeyRequestRole{}, requestRole)
 	}
+	disable_repl_status, ok := httpCtx.Value(logical.CtxKeyDisableReplicationStatusEndpoints{}).(string)
+	if ok {
+		ctx = context.WithValue(ctx, logical.CtxKeyDisableReplicationStatusEndpoints{}, disable_repl_status)
+	}
 	resp, err = c.handleCancelableRequest(ctx, req)
 	req.SetTokenEntry(nil)
 	cancel()


### PR DESCRIPTION
This PR makes a necessary change missed in a previous PR to copy the **logical.CtxKeyDisableReplicationStatusEndpoints** value from the **context.Context** of the **http.Request** to the active **context.Context** maintained by the instance of **vault.Core** at the point where we switch **context.Context**.

This is necessary because when the request handling chains are constructed, a middleware function that _adds_ the **logical.CtxKeyDisableReplicationStatusEndpoints** value to the context is used if the **disable_replication_status_endpoints** configuration parameter is set to `true` for the TCP listener in question. However, in order for this context value to make it all the way to the actual handler functions, which receive the **vault.Core**'s active context, not the **http.Request** context, the context value must be copied.