### PR TITLE
Add saml to gen_openapi script.  Fix some plugin registry tests

### DIFF
--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -94,6 +94,7 @@ if [[ -n "${VAULT_LICENSE:-}" ]]; then
     vault secrets enable "keymgmt"
     vault secrets enable "kmip"
     vault secrets enable "transform"
+    vault auth enable "saml"
 fi
 
 # Output OpenAPI, optionally formatted


### PR DESCRIPTION
It seems that they never had to cope with ent-specific plugins.  My theory is that this is because the Registry global var was previously being initialized *after* the addExternalPlugins hook got populated.  Now that we're no longer relying on that hook but rather calling a stub function, we fixed a bug and have to deal with these broken tests. Presumably that only happened in tests and not in prod or those plugins wouldn't be usable.