### PR TITLE
For now, go back to the hook approach for addExternalPlugins. 

### DIFF
--- a/helper/builtinplugins/registry.go
+++ b/helper/builtinplugins/registry.go
@@ -200,7 +200,7 @@ func newRegistry() *registry {
 		},
 	}
 
-	entAddExtPlugins(reg)
+	addExternalPlugins(reg)
 
 	return reg
 }


### PR DESCRIPTION
I've broken many tests on ent that relied on a broken behaviour.  I'll fix them properly later, for now I want to unbreak the build.