### PR TITLE
Stop running fips tests on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,12 +147,13 @@ jobs:
 
   test-go-fips:
     name: Run Go tests with FIPS configuration
-    # Only run fips on the enterprise repo, and only if it's main or a release branch (i.e. not a PR)
-    # TODO: add back `needs.setup.outputs.enterprise == 1 &&`
+    # Only run fips on the enterprise repo, and only if it's main or a release branch
+    # (i.e. not a PR), or is a PR with the label "fips"
     if: |
+      needs.setup.outputs.enterprise == 1 &&
       needs.verify-changes.outputs.is_docs_change == 'false' &&
       needs.verify-changes.outputs.is_ui_change == 'false' && 
-      (github.ref_name == 'main' || startsWith(github.ref_name, 'release/'))
+      (contains(github.event.pull_request.labels.*.name, 'fips') || github.ref_name == 'main' || startsWith(github.ref_name, 'release/'))
     needs:
       - setup
       - verify-changes


### PR DESCRIPTION
We expect fips-specific failures to be rare enough that it's not worth the cost.