### PR TITLE
VAULT-19232 Add static secret capability manager to Vault Proxy

### DIFF
--- a/command/agentproxyshared/cache/cacheboltdb/bolt.go
+++ b/command/agentproxyshared/cache/cacheboltdb/bolt.go
@@ -165,7 +165,7 @@ func createV1BoltSchema(tx *bolt.Tx) error {
 
 func createV2BoltSchema(tx *bolt.Tx) error {
 	// Create the buckets for tokens and leases.
-	for _, bucket := range []string{TokenType, LeaseType, lookupType} {
+	for _, bucket := range []string{TokenType, LeaseType, lookupType, StaticSecretType, TokenCapabilitiesType} {
 		if _, err := tx.CreateBucketIfNotExists([]byte(bucket)); err != nil {
 			return fmt.Errorf("failed to create %s bucket: %w", bucket, err)
 		}
@@ -267,6 +267,10 @@ func (b *BoltStorage) Set(ctx context.Context, id string, plaintext []byte, inde
 			if err := meta.Put([]byte(AutoAuthToken), protoBlob); err != nil {
 				return fmt.Errorf("failed to set latest auto-auth token: %w", err)
 			}
+		case StaticSecretType:
+			key = []byte(id)
+		case TokenCapabilitiesType:
+			key = []byte(id)
 		default:
 			return fmt.Errorf("called Set for unsupported type %q", indexType)
 		}
@@ -419,7 +423,7 @@ func (b *BoltStorage) Close() error {
 // the schema/layout
 func (b *BoltStorage) Clear() error {
 	return b.db.Update(func(tx *bolt.Tx) error {
-		for _, name := range []string{TokenType, LeaseType, lookupType} {
+		for _, name := range []string{TokenType, LeaseType, lookupType, StaticSecretType, TokenCapabilitiesType} {
 			b.logger.Trace("deleting bolt bucket", "name", name)
 			if err := tx.DeleteBucket([]byte(name)); err != nil {
 				return err

--- a/command/agentproxyshared/cache/cacheboltdb/bolt_test.go
+++ b/command/agentproxyshared/cache/cacheboltdb/bolt_test.go
@@ -6,7 +6,6 @@ package cacheboltdb
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -34,7 +33,7 @@ func getTestKeyManager(t *testing.T) keymanager.KeyManager {
 func TestBolt_SetGet(t *testing.T) {
 	ctx := context.Background()
 
-	path, err := ioutil.TempDir("", "bolt-test")
+	path, err := os.MkdirTemp("", "bolt-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 
@@ -60,7 +59,7 @@ func TestBolt_SetGet(t *testing.T) {
 func TestBoltDelete(t *testing.T) {
 	ctx := context.Background()
 
-	path, err := ioutil.TempDir("", "bolt-test")
+	path, err := os.MkdirTemp("", "bolt-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 
@@ -92,7 +91,7 @@ func TestBoltDelete(t *testing.T) {
 func TestBoltClear(t *testing.T) {
 	ctx := context.Background()
 
-	path, err := ioutil.TempDir("", "bolt-test")
+	path, err := os.MkdirTemp("", "bolt-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 
@@ -126,6 +125,20 @@ func TestBoltClear(t *testing.T) {
 	require.Len(t, tokens, 1)
 	assert.Equal(t, []byte("hello"), tokens[0])
 
+	err = b.Set(ctx, "static-secret", []byte("hello"), StaticSecretType)
+	require.NoError(t, err)
+	staticSecrets, err := b.GetByType(ctx, StaticSecretType)
+	require.NoError(t, err)
+	require.Len(t, staticSecrets, 1)
+	assert.Equal(t, []byte("hello"), staticSecrets[0])
+
+	err = b.Set(ctx, "capabilities-index", []byte("hello"), TokenCapabilitiesType)
+	require.NoError(t, err)
+	capabilities, err := b.GetByType(ctx, TokenCapabilitiesType)
+	require.NoError(t, err)
+	require.Len(t, capabilities, 1)
+	assert.Equal(t, []byte("hello"), capabilities[0])
+
 	// Clear the bolt db, and check that it's indeed clear
 	err = b.Clear()
 	require.NoError(t, err)
@@ -135,12 +148,18 @@ func TestBoltClear(t *testing.T) {
 	tokens, err = b.GetByType(ctx, TokenType)
 	require.NoError(t, err)
 	assert.Len(t, tokens, 0)
+	staticSecrets, err = b.GetByType(ctx, StaticSecretType)
+	require.NoError(t, err)
+	require.Len(t, staticSecrets, 0)
+	capabilities, err = b.GetByType(ctx, TokenCapabilitiesType)
+	require.NoError(t, err)
+	require.Len(t, capabilities, 0)
 }
 
 func TestBoltSetAutoAuthToken(t *testing.T) {
 	ctx := context.Background()
 
-	path, err := ioutil.TempDir("", "bolt-test")
+	path, err := os.MkdirTemp("", "bolt-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 
@@ -210,11 +229,11 @@ func TestDBFileExists(t *testing.T) {
 			var tmpPath string
 			var err error
 			if tc.mkDir {
-				tmpPath, err = ioutil.TempDir("", "test-db-path")
+				tmpPath, err = os.MkdirTemp("", "test-db-path")
 				require.NoError(t, err)
 			}
 			if tc.createFile {
-				err = ioutil.WriteFile(path.Join(tmpPath, DatabaseFileName), []byte("test-db-path"), 0o600)
+				err = os.WriteFile(path.Join(tmpPath, DatabaseFileName), []byte("test-db-path"), 0o600)
 				require.NoError(t, err)
 			}
 			exists, err := DBFileExists(tmpPath)
@@ -244,7 +263,7 @@ func Test_SetGetRetrievalToken(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			path, err := ioutil.TempDir("", "bolt-test")
+			path, err := os.MkdirTemp("", "bolt-test")
 			require.NoError(t, err)
 			defer os.RemoveAll(path)
 
@@ -270,7 +289,7 @@ func Test_SetGetRetrievalToken(t *testing.T) {
 func TestBolt_MigrateFromV1ToV2Schema(t *testing.T) {
 	ctx := context.Background()
 
-	path, err := ioutil.TempDir("", "bolt-test")
+	path, err := os.MkdirTemp("", "bolt-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 
@@ -342,7 +361,7 @@ func TestBolt_MigrateFromV1ToV2Schema(t *testing.T) {
 func TestBolt_MigrateFromInvalidToV2Schema(t *testing.T) {
 	ctx := context.Background()
 
-	path, err := ioutil.TempDir("", "bolt-test")
+	path, err := os.MkdirTemp("", "bolt-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 

--- a/command/agentproxyshared/cache/cachememdb/cache_memdb.go
+++ b/command/agentproxyshared/cache/cachememdb/cache_memdb.go
@@ -237,6 +237,28 @@ func (c *CacheMemDB) SetCapabilitiesIndex(index *CapabilitiesIndex) error {
 	return nil
 }
 
+// EvictCapabilitiesIndex removes a capabilities index from the cache based on index name and value.
+func (c *CacheMemDB) EvictCapabilitiesIndex(indexName string, indexValues ...interface{}) error {
+	index, err := c.GetCapabilitiesIndex(indexName, indexValues...)
+	if err == ErrCacheItemNotFound {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("unable to fetch index on cache deletion: %v", err)
+	}
+
+	txn := c.db.Load().(*memdb.MemDB).Txn(true)
+	defer txn.Abort()
+
+	if err := txn.Delete(tableNameCapabilitiesIndexer, index); err != nil {
+		return fmt.Errorf("unable to delete index from cache: %v", err)
+	}
+
+	txn.Commit()
+
+	return nil
+}
+
 // GetByPrefix returns all the cached indexes based on the index name and the
 // value prefix.
 func (c *CacheMemDB) GetByPrefix(indexName string, indexValues ...interface{}) ([]*Index, error) {

--- a/command/agentproxyshared/cache/cachememdb/index.go
+++ b/command/agentproxyshared/cache/cachememdb/index.go
@@ -198,3 +198,22 @@ func Deserialize(indexBytes []byte) (*Index, error) {
 	}
 	return index, nil
 }
+
+// SerializeCapabilitiesIndex returns a json marshal'ed CapabilitiesIndex object
+func (i CapabilitiesIndex) SerializeCapabilitiesIndex() ([]byte, error) {
+	indexBytes, err := json.Marshal(i)
+	if err != nil {
+		return nil, err
+	}
+
+	return indexBytes, nil
+}
+
+// DeserializeCapabilitiesIndex converts json bytes to an CapabilitiesIndex object
+func DeserializeCapabilitiesIndex(indexBytes []byte) (*CapabilitiesIndex, error) {
+	index := new(CapabilitiesIndex)
+	if err := json.Unmarshal(indexBytes, index); err != nil {
+		return nil, err
+	}
+	return index, nil
+}

--- a/command/agentproxyshared/cache/lease_cache.go
+++ b/command/agentproxyshared/cache/lease_cache.go
@@ -172,7 +172,8 @@ func NewLeaseCache(conf *LeaseCacheConfig) (*LeaseCache, error) {
 	}, nil
 }
 
-// SetCapabilityManager is a setter for the shuttingDown field
+// SetCapabilityManager is a setter for CapabilityManager. If set, will manage capabilities
+// for capability indexes.
 func (c *LeaseCache) SetCapabilityManager(capabilityManager *StaticSecretCapabilityManager) {
 	c.capabilityManager = capabilityManager
 }

--- a/command/agentproxyshared/cache/static_secret_capability_manager.go
+++ b/command/agentproxyshared/cache/static_secret_capability_manager.go
@@ -4,6 +4,7 @@
 package cache
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -169,7 +170,7 @@ func (sscm *StaticSecretCapabilityManager) StartRenewingCapabilities(indexToRene
 				sscm.logger.Trace("updating tokens for index, as capability has been lost", "index.ID", index.ID, "request_path", index.RequestPath)
 				index.IndexLock.Lock()
 				delete(index.Tokens, capabilitiesIndex.Token)
-				err = sscm.leaseCache.db.Set(index)
+				err = sscm.leaseCache.Set(context.Background(), index)
 				if err != nil {
 					sscm.logger.Error("error when attempting to update index in cache", "index.ID", index.ID, "err", err)
 				}
@@ -193,7 +194,7 @@ func (sscm *StaticSecretCapabilityManager) StartRenewingCapabilities(indexToRene
 
 		// The token still has some capabilities, so, update the capabilities index:
 		capabilitiesIndex.ReadablePaths = newReadablePaths
-		err = sscm.leaseCache.db.SetCapabilitiesIndex(capabilitiesIndex)
+		err = sscm.leaseCache.SetCapabilitiesIndex(context.Background(), capabilitiesIndex)
 		if err != nil {
 			sscm.logger.Error("error when attempting to update capabilities from cache", "index.ID", indexToRenew.ID, "err", err)
 		}

--- a/command/agentproxyshared/cache/static_secret_capability_manager.go
+++ b/command/agentproxyshared/cache/static_secret_capability_manager.go
@@ -98,7 +98,7 @@ func (sscm *StaticSecretCapabilityManager) Stop() {
 }
 
 // StartRenewingCapabilities takes a polling job and submits a constant renewal of capabilities to the worker pool.
-// the indexToRenew is the capabilities index we'll renew the capabilities for.
+// indexToRenew is the capabilities index we'll renew the capabilities for.
 func (sscm *StaticSecretCapabilityManager) StartRenewingCapabilities(indexToRenew *cachememdb.CapabilitiesIndex) {
 	var work func()
 	work = func() {

--- a/command/agentproxyshared/cache/static_secret_capability_manager.go
+++ b/command/agentproxyshared/cache/static_secret_capability_manager.go
@@ -1,0 +1,167 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"golang.org/x/exp/maps"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/gammazero/workerpool"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/command/agentproxyshared/cache/cachememdb"
+	"github.com/hashicorp/vault/command/agentproxyshared/sink"
+)
+
+const (
+	// DefaultWorkers is the default number of workers for the worker pool.
+	DefaultWorkers = 5
+
+	// DefaultStaticSecretTokenCapabilityRefreshInterval is the default time
+	// between each capability poll. This is configured with the following config value:
+	// static_secret_token_capability_refresh_interval
+	DefaultStaticSecretTokenCapabilityRefreshInterval = 5 * time.Minute
+)
+
+// StaticSecretCapabilityManager is a struct that utilizes
+// a worker pool to keep capabilities up to date.
+type StaticSecretCapabilityManager struct {
+	client     *api.Client
+	leaseCache *LeaseCache
+	logger     hclog.Logger
+	tokenSink  sink.Sink
+	workerPool *workerpool.WorkerPool
+}
+
+// StaticSecretCapabilityManagerConfig is the configuration for initializing a new
+// StaticSecretCapabilityManager.
+type StaticSecretCapabilityManagerConfig struct {
+	LeaseCache *LeaseCache
+	Logger     hclog.Logger
+	// TokenSink is a token sync that will have the latest
+	// token from auto-auth in it, to be used in event system
+	// connections.
+	TokenSink sink.Sink
+}
+
+// NewStaticSecretCapabilityManager creates a new instance of a StaticSecretCapabilityManager.
+func NewStaticSecretCapabilityManager(conf *StaticSecretCapabilityManagerConfig) (*StaticSecretCapabilityManager, error) {
+	if conf == nil {
+		return nil, errors.New("nil configuration provided")
+	}
+
+	if conf.LeaseCache == nil {
+		return nil, fmt.Errorf("nil Lease Cache (a required parameter): %v", conf)
+	}
+
+	if conf.Logger == nil {
+		return nil, fmt.Errorf("nil Logger (a required parameter): %v", conf)
+	}
+
+	if conf.TokenSink == nil {
+		return nil, fmt.Errorf("nil token sink (a required parameter): %v", conf)
+	}
+
+	client, err := api.NewClient(api.DefaultConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	workerPool := workerpool.New(DefaultWorkers)
+
+	return &StaticSecretCapabilityManager{
+		client:     client,
+		leaseCache: conf.LeaseCache,
+		logger:     conf.Logger,
+		tokenSink:  conf.TokenSink,
+		workerPool: workerPool,
+	}, nil
+}
+
+type PollingJob struct {
+	ctx    context.Context
+	client *api.Client
+	// index is the index of the cache entry of the permissions we want
+	// to check and keep up to date
+	index *cachememdb.Index
+}
+
+// StartRenewing takes a polling job and submits a constant renewal to the worker pool.
+func (sscm *StaticSecretCapabilityManager) StartRenewing(pj *PollingJob) error {
+	work := func() {
+		index, err := sscm.leaseCache.db.GetCapabilitiesIndex(cachememdb.IndexNameID, pj.index.ID)
+		if errors.Is(err, cachememdb.ErrCacheItemNotFound) {
+			// This cache entry no longer exists, so there is no more work to do.
+			return
+		}
+		if err != nil {
+			sscm.logger.Error("error when attempting to refresh token capabilities", "index.ID", pj.index.ID)
+			// TODO what do we do here?
+			return
+		}
+
+		token := index.Token
+		client, err := sscm.client.Clone()
+		if err != nil {
+			sscm.logger.Error("error when attempting to refresh token capabilities", "index.ID", pj.index.ID)
+			// TODO what do we do here?
+			return
+		}
+
+		client.SetToken(token)
+
+		capabilities, err := getCapabilities(maps.Keys(index.ReadablePaths), client)
+		if err != nil {
+			sscm.logger.Error("error when attempting to refresh token capabilities", "index.ID", pj.index.ID)
+			// TODO what do we do here?
+			return
+		}
+		for _, capabilities := range capabilities {
+			if len(capabilities) > 0 {
+				// TODO
+			}
+		}
+	}
+
+	time.AfterFunc(DefaultStaticSecretTokenCapabilityRefreshInterval, func() {
+		sscm.workerPool.Submit(work)
+	})
+
+	return nil
+}
+
+// getCapabilities is a wrapper around a /sys/capabilities-self call that returns
+// capabilities as a map with paths as keys, and capabilities as values.
+func getCapabilities(paths []string, client *api.Client) (map[string][]string, error) {
+	body := make(map[string]interface{})
+	body["paths"] = paths
+	secret, err := client.Logical().Write("/sys/capabilities-self", body)
+	if err != nil {
+		return nil, err
+	}
+
+	if secret == nil || secret.Data == nil {
+		return nil, errors.New("data from server response is empty")
+	}
+
+	capabilities := make(map[string][]string)
+
+	for _, path := range paths {
+		var res []string
+		err = mapstructure.Decode(secret.Data[path], &res)
+		if err != nil {
+			return nil, err
+		}
+
+		capabilities[path] = res
+	}
+
+	return capabilities, nil
+}

--- a/command/agentproxyshared/cache/static_secret_capability_manager_test.go
+++ b/command/agentproxyshared/cache/static_secret_capability_manager_test.go
@@ -4,28 +4,125 @@
 package cache
 
 import (
+	"context"
+	"encoding/hex"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
-
-	"github.com/stretchr/testify/require"
-
+	"github.com/hashicorp/vault/command/agentproxyshared/cache/cachememdb"
 	"github.com/hashicorp/vault/helper/testhelpers/minimal"
+	"github.com/hashicorp/vault/sdk/helper/cryptoutil"
+	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/stretchr/testify/require"
 )
+
+// testNewStaticSecretCapabilityManager returns a new StaticSecretCapabilityManager
+// for use in tests.
+func testNewStaticSecretCapabilityManager(t *testing.T, client *api.Client) *StaticSecretCapabilityManager {
+	t.Helper()
+
+	lc := testNewLeaseCache(t, []*SendResponse{})
+
+	updater, err := NewStaticSecretCapabilityManager(&StaticSecretCapabilityManagerConfig{
+		LeaseCache: lc,
+		Logger:     logging.NewVaultLogger(hclog.Trace).Named("cache.capabilitiesmanager"),
+		Client:     client,
+		StaticSecretTokenCapabilityRefreshInterval: 250 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return updater
+}
+
+// TestNewStaticSecretCapabilityManager tests the NewStaticSecretCapabilityManager method,
+// to ensure it errors out when appropriate.
+func TestNewStaticSecretCapabilityManager(t *testing.T) {
+	t.Parallel()
+
+	lc := testNewLeaseCache(t, []*SendResponse{})
+	logger := logging.NewVaultLogger(hclog.Trace).Named("cache.capabilitiesmanager")
+	client, err := api.NewClient(api.DefaultConfig())
+	require.Nil(t, err)
+
+	// Expect an error if any of the arguments are nil:
+	updater, err := NewStaticSecretCapabilityManager(&StaticSecretCapabilityManagerConfig{
+		LeaseCache: nil,
+		Logger:     logger,
+		Client:     client,
+	})
+	require.Error(t, err)
+	require.Nil(t, updater)
+
+	updater, err = NewStaticSecretCapabilityManager(&StaticSecretCapabilityManagerConfig{
+		LeaseCache: lc,
+		Logger:     nil,
+		Client:     client,
+	})
+	require.Error(t, err)
+	require.Nil(t, updater)
+
+	updater, err = NewStaticSecretCapabilityManager(&StaticSecretCapabilityManagerConfig{
+		LeaseCache: lc,
+		Logger:     logger,
+		Client:     nil,
+	})
+	require.Error(t, err)
+	require.Nil(t, updater)
+
+	// Don't expect an error if the arguments are as expected
+	updater, err = NewStaticSecretCapabilityManager(&StaticSecretCapabilityManagerConfig{
+		LeaseCache: lc,
+		Logger:     logging.NewVaultLogger(hclog.Trace).Named("cache.capabilitiesmanager"),
+		Client:     client,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.NotNil(t, updater)
+	require.NotNil(t, updater.workerPool)
+	require.NotNil(t, updater.staticSecretTokenCapabilityRefreshInterval)
+	require.NotNil(t, updater.client)
+	require.NotNil(t, updater.leaseCache)
+	require.NotNil(t, updater.logger)
+	require.Equal(t, DefaultStaticSecretTokenCapabilityRefreshInterval, updater.staticSecretTokenCapabilityRefreshInterval)
+
+	// Lastly, double check that the refresh interval can be properly set
+	updater, err = NewStaticSecretCapabilityManager(&StaticSecretCapabilityManagerConfig{
+		LeaseCache: lc,
+		Logger:     logging.NewVaultLogger(hclog.Trace).Named("cache.capabilitiesmanager"),
+		Client:     client,
+		StaticSecretTokenCapabilityRefreshInterval: time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.NotNil(t, updater)
+	require.NotNil(t, updater.workerPool)
+	require.NotNil(t, updater.staticSecretTokenCapabilityRefreshInterval)
+	require.NotNil(t, updater.client)
+	require.NotNil(t, updater.leaseCache)
+	require.NotNil(t, updater.logger)
+	require.Equal(t, time.Hour, updater.staticSecretTokenCapabilityRefreshInterval)
+}
 
 // TestGetCapabilitiesRootToken tests the getCapabilities method with the root
 // token, expecting to get "root" capabilities on valid paths
 func TestGetCapabilitiesRootToken(t *testing.T) {
+	t.Parallel()
 	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
-	capabilitiesToCheck := []string{"/auth/token/create", "/sys/health"}
+	capabilitiesToCheck := []string{"auth/token/create", "sys/health"}
 	capabilities, err := getCapabilities(capabilitiesToCheck, client)
 	require.NoError(t, err)
 
 	expectedCapabilities := map[string][]string{
-		"/auth/token/create": {"root"},
-		"/sys/health":        {"root"},
+		"auth/token/create": {"root"},
+		"sys/health":        {"root"},
 	}
 	require.Equal(t, expectedCapabilities, capabilities)
 }
@@ -33,6 +130,7 @@ func TestGetCapabilitiesRootToken(t *testing.T) {
 // TestGetCapabilitiesLowPrivilegeToken tests the getCapabilities method with
 // a low privilege token, expecting to get deny or non-root capabilities
 func TestGetCapabilitiesLowPrivilegeToken(t *testing.T) {
+	t.Parallel()
 	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
@@ -50,33 +148,36 @@ func TestGetCapabilitiesLowPrivilegeToken(t *testing.T) {
 
 	client.SetToken(token)
 
-	capabilitiesToCheck := []string{"/auth/token/create", "/sys/capabilities-self", "/auth/token/lookup-self"}
+	capabilitiesToCheck := []string{"auth/token/create", "sys/capabilities-self", "auth/token/lookup-self"}
 	capabilities, err := getCapabilities(capabilitiesToCheck, client)
 	require.NoError(t, err)
 
 	expectedCapabilities := map[string][]string{
-		"/auth/token/create":      {"deny"},
-		"/sys/capabilities-self":  {"update"},
-		"/auth/token/lookup-self": {"read"},
+		"auth/token/create":      {"deny"},
+		"sys/capabilities-self":  {"update"},
+		"auth/token/lookup-self": {"read"},
 	}
 	require.Equal(t, expectedCapabilities, capabilities)
 }
 
 // TestGetCapabilitiesBadClientToken tests that getCapabilities
-// returns an error if the client token is bad.
+// returns an empty set of capabilities if the token is bad (and it gets a 403)
 func TestGetCapabilitiesBadClientToken(t *testing.T) {
+	t.Parallel()
 	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 	client.SetToken("")
 
-	capabilitiesToCheck := []string{"/auth/token/create", "/sys/capabilities-self", "/auth/token/lookup-self"}
-	_, err := getCapabilities(capabilitiesToCheck, client)
-	require.Error(t, err)
+	capabilitiesToCheck := []string{"auth/token/create", "sys/capabilities-self", "auth/token/lookup-self"}
+	capabilities, err := getCapabilities(capabilitiesToCheck, client)
+	require.Nil(t, err)
+	require.Equal(t, map[string][]string{}, capabilities)
 }
 
 // TestGetCapabilitiesEmptyPaths tests the getCapabilities will error on an empty
 // set of paths to check
 func TestGetCapabilitiesEmptyPaths(t *testing.T) {
+	t.Parallel()
 	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
@@ -88,16 +189,17 @@ func TestGetCapabilitiesEmptyPaths(t *testing.T) {
 // TestReconcileCapabilities tests that reconcileCapabilities will
 // correctly previously remove readable paths that we don't have read access to.
 func TestReconcileCapabilities(t *testing.T) {
-	paths := []string{"/auth/token/create", "/sys/capabilities-self", "/auth/token/lookup-self"}
+	t.Parallel()
+	paths := []string{"auth/token/create", "sys/capabilities-self", "auth/token/lookup-self"}
 	capabilities := map[string][]string{
-		"/auth/token/create":      {"deny"},
-		"/sys/capabilities-self":  {"update"},
-		"/auth/token/lookup-self": {"read"},
+		"auth/token/create":      {"deny"},
+		"sys/capabilities-self":  {"update"},
+		"auth/token/lookup-self": {"read"},
 	}
 
 	updatedCapabilities := reconcileCapabilities(paths, capabilities)
 	expectedUpdatedCapabilities := map[string]struct{}{
-		"/auth/token/lookup-self": {},
+		"auth/token/lookup-self": {},
 	}
 	require.Equal(t, expectedUpdatedCapabilities, updatedCapabilities)
 }
@@ -105,18 +207,245 @@ func TestReconcileCapabilities(t *testing.T) {
 // TestReconcileCapabilitiesNoOp tests that reconcileCapabilities will
 // correctly not remove capabilities when they all remain readable.
 func TestReconcileCapabilitiesNoOp(t *testing.T) {
-	paths := []string{"/foo/bar", "/bar/baz", "/baz/foo"}
+	t.Parallel()
+	paths := []string{"foo/bar", "bar/baz", "baz/foo"}
 	capabilities := map[string][]string{
-		"/foo/bar": {"read"},
-		"/bar/baz": {"root"},
-		"/baz/foo": {"read"},
+		"foo/bar": {"read"},
+		"bar/baz": {"root"},
+		"baz/foo": {"read"},
 	}
 
 	updatedCapabilities := reconcileCapabilities(paths, capabilities)
 	expectedUpdatedCapabilities := map[string]struct{}{
-		"/foo/bar": {},
-		"/bar/baz": {},
-		"/baz/foo": {},
+		"foo/bar": {},
+		"bar/baz": {},
+		"baz/foo": {},
 	}
 	require.Equal(t, expectedUpdatedCapabilities, updatedCapabilities)
+}
+
+// TestReconcileCapabilitiesNoAdding tests that reconcileCapabilities will
+// not add any capabilities that weren't present in the first argument to the function
+func TestReconcileCapabilitiesNoAdding(t *testing.T) {
+	t.Parallel()
+	paths := []string{"auth/token/create", "sys/capabilities-self", "auth/token/lookup-self"}
+	capabilities := map[string][]string{
+		"auth/token/create":      {"deny"},
+		"sys/capabilities-self":  {"update"},
+		"auth/token/lookup-self": {"read"},
+		"some/new/path":          {"read"},
+	}
+
+	updatedCapabilities := reconcileCapabilities(paths, capabilities)
+	expectedUpdatedCapabilities := map[string]struct{}{
+		"auth/token/lookup-self": {},
+	}
+	require.Equal(t, expectedUpdatedCapabilities, updatedCapabilities)
+}
+
+// TestSubmitWorkNoOp tests that we will gracefully end if the capabilities index
+// does not exist in the cache
+func TestSubmitWorkNoOp(t *testing.T) {
+	t.Parallel()
+	client, err := api.NewClient(api.DefaultConfig())
+	require.Nil(t, err)
+	sscm := testNewStaticSecretCapabilityManager(t, client)
+	// This index will be a no-op, as this does not exist in the cache
+	index := &cachememdb.CapabilitiesIndex{
+		ID: "test",
+	}
+	pj := &PollingJob{
+		index: index,
+		ctx:   context.Background(),
+	}
+	sscm.StartRenewing(pj)
+
+	// Wait for the job to complete...
+	time.Sleep(1 * time.Second)
+	require.Equal(t, 0, sscm.workerPool.WaitingQueueSize())
+}
+
+// TestSubmitWorkUpdatesIndex tests that an index will be correctly updated if the capabilities differ.
+func TestSubmitWorkUpdatesIndex(t *testing.T) {
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
+
+	// Create a low permission token
+	renewable := true
+	// Set the token's policies to 'default' and nothing else
+	tokenCreateRequest := &api.TokenCreateRequest{
+		Policies:  []string{"default"},
+		TTL:       "30m",
+		Renewable: &renewable,
+	}
+
+	secret, err := client.Auth().Token().CreateOrphan(tokenCreateRequest)
+	require.NoError(t, err)
+	token := secret.Auth.ClientToken
+	indexId := hex.EncodeToString(cryptoutil.Blake2b256Hash(token))
+
+	sscm := testNewStaticSecretCapabilityManager(t, client)
+	index := &cachememdb.CapabilitiesIndex{
+		ID:    indexId,
+		Token: token,
+		// The token will (perhaps obviously) not have
+		// read access to /foo/bar, but will to /auth/token/lookup-self
+		ReadablePaths: map[string]struct{}{
+			"foo/bar":                {},
+			"auth/token/lookup-self": {},
+		},
+	}
+	err = sscm.leaseCache.db.SetCapabilitiesIndex(index)
+	require.Nil(t, err)
+
+	pj := &PollingJob{
+		index: index,
+		ctx:   context.Background(),
+	}
+	sscm.StartRenewing(pj)
+
+	// Wait for the job to complete at least once...
+	time.Sleep(3 * time.Second)
+
+	newIndex, err := sscm.leaseCache.db.GetCapabilitiesIndex(cachememdb.IndexNameID, indexId)
+	require.Nil(t, err)
+	require.Equal(t, map[string]struct{}{
+		"auth/token/lookup-self": {},
+	}, newIndex.ReadablePaths)
+
+	// Forcefully stop any remaining workers
+	sscm.workerPool.Stop()
+}
+
+// TestSubmitWorkUpdatesIndexWithBadToken tests that an index will be correctly updated if the token
+// has expired and we cannot access the sys capabilities endpoint.
+func TestSubmitWorkUpdatesIndexWithBadToken(t *testing.T) {
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
+
+	token := "not real token"
+	indexId := hex.EncodeToString(cryptoutil.Blake2b256Hash(token))
+
+	sscm := testNewStaticSecretCapabilityManager(t, client)
+	index := &cachememdb.CapabilitiesIndex{
+		ID:    indexId,
+		Token: token,
+		ReadablePaths: map[string]struct{}{
+			"foo/bar":                {},
+			"auth/token/lookup-self": {},
+		},
+	}
+	err := sscm.leaseCache.db.SetCapabilitiesIndex(index)
+	require.Nil(t, err)
+
+	pj := &PollingJob{
+		index: index,
+		ctx:   context.Background(),
+	}
+	sscm.StartRenewing(pj)
+
+	// Wait for the job to complete at least once...
+	time.Sleep(3 * time.Second)
+
+	// This entry should be evicted.
+	newIndex, err := sscm.leaseCache.db.GetCapabilitiesIndex(cachememdb.IndexNameID, indexId)
+	require.Equal(t, err, cachememdb.ErrCacheItemNotFound)
+	require.Nil(t, newIndex)
+
+	// Forcefully stop any remaining workers
+	sscm.workerPool.Stop()
+}
+
+// TestSubmitWorkUpdatesAllIndexes tests that an index will be correctly updated if the capabilities differ, as
+// well as the indexes related to the paths that are being checked for.
+func TestSubmitWorkUpdatesAllIndexes(t *testing.T) {
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
+
+	// Create a low permission token
+	renewable := true
+	// Set the token's policies to 'default' and nothing else
+	tokenCreateRequest := &api.TokenCreateRequest{
+		Policies:  []string{"default"},
+		TTL:       "30m",
+		Renewable: &renewable,
+	}
+
+	secret, err := client.Auth().Token().CreateOrphan(tokenCreateRequest)
+	require.NoError(t, err)
+	token := secret.Auth.ClientToken
+	indexId := hex.EncodeToString(cryptoutil.Blake2b256Hash(token))
+
+	sscm := testNewStaticSecretCapabilityManager(t, client)
+	index := &cachememdb.CapabilitiesIndex{
+		ID:    indexId,
+		Token: token,
+		// The token will (perhaps obviously) not have
+		// read access to /foo/bar, but will to /auth/token/lookup-self
+		ReadablePaths: map[string]struct{}{
+			"foo/bar":                {},
+			"auth/token/lookup-self": {},
+		},
+	}
+	err = sscm.leaseCache.db.SetCapabilitiesIndex(index)
+	require.Nil(t, err)
+
+	pathIndexId1 := hex.EncodeToString(cryptoutil.Blake2b256Hash("foo/bar"))
+	pathIndex1 := &cachememdb.Index{
+		ID:        pathIndexId1,
+		Namespace: "root/",
+		Tokens: map[string]struct{}{
+			token: {},
+		},
+		RequestPath: "foo/bar",
+		Response:    []byte{},
+	}
+
+	pathIndexId2 := hex.EncodeToString(cryptoutil.Blake2b256Hash("auth/token/lookup-self"))
+	pathIndex2 := &cachememdb.Index{
+		ID:        pathIndexId2,
+		Namespace: "root/",
+		Tokens: map[string]struct{}{
+			token: {},
+		},
+		RequestPath: "auth/token/lookup-self",
+		Response:    []byte{},
+	}
+
+	err = sscm.leaseCache.db.Set(pathIndex1)
+	require.Nil(t, err)
+
+	err = sscm.leaseCache.db.Set(pathIndex2)
+	require.Nil(t, err)
+
+	pj := &PollingJob{
+		index: index,
+		ctx:   context.Background(),
+	}
+	sscm.StartRenewing(pj)
+
+	// Wait for the job to complete at least once...
+	time.Sleep(1 * time.Second)
+
+	newIndex, err := sscm.leaseCache.db.GetCapabilitiesIndex(cachememdb.IndexNameID, indexId)
+	require.Nil(t, err)
+	require.Equal(t, map[string]struct{}{
+		"auth/token/lookup-self": {},
+	}, newIndex.ReadablePaths)
+
+	// For this, we expect the token to have been deleted
+	newPathIndex1, err := sscm.leaseCache.db.Get(cachememdb.IndexNameID, pathIndexId1)
+	require.Nil(t, err)
+	require.Equal(t, map[string]struct{}{}, newPathIndex1.Tokens)
+
+	// For this, we expect no change
+	newPathIndex2, err := sscm.leaseCache.db.Get(cachememdb.IndexNameID, pathIndexId2)
+	require.Nil(t, err)
+	require.Equal(t, newPathIndex2, newPathIndex2)
+
+	// Forcefully stop any remaining workers
+	sscm.workerPool.Stop()
 }

--- a/command/agentproxyshared/cache/static_secret_capability_manager_test.go
+++ b/command/agentproxyshared/cache/static_secret_capability_manager_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/vault/helper/testhelpers/minimal"
+)
+
+// TestGetCapabilitiesRootToken tests the getCapabilities method with the root
+// token, expecting to get "root" capabilities on valid paths
+func TestGetCapabilitiesRootToken(t *testing.T) {
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
+
+	capabilitiesToCheck := []string{"/auth/token/create", "/sys/health"}
+	capabilities, err := getCapabilities(capabilitiesToCheck, client)
+	require.NoError(t, err)
+
+	expectedCapabilities := map[string][]string{
+		"/auth/token/create": {"root"},
+		"/sys/health":        {"root"},
+	}
+	require.Equal(t, expectedCapabilities, capabilities)
+}
+
+// TestGetCapabilitiesLowPrivilegeToken tests the getCapabilities method with
+// a low privilege token, expecting to get deny or non-root capabilities
+func TestGetCapabilitiesLowPrivilegeToken(t *testing.T) {
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
+
+	renewable := true
+	// Set the token's policies to 'default' and nothing else
+	tokenCreateRequest := &api.TokenCreateRequest{
+		Policies:  []string{"default"},
+		TTL:       "30m",
+		Renewable: &renewable,
+	}
+
+	secret, err := client.Auth().Token().CreateOrphan(tokenCreateRequest)
+	require.NoError(t, err)
+	token := secret.Auth.ClientToken
+
+	client.SetToken(token)
+
+	capabilitiesToCheck := []string{"/auth/token/create", "/sys/capabilities-self", "/auth/token/lookup-self"}
+	capabilities, err := getCapabilities(capabilitiesToCheck, client)
+	require.NoError(t, err)
+
+	expectedCapabilities := map[string][]string{
+		"/auth/token/create":      {"deny"},
+		"/sys/capabilities-self":  {"update"},
+		"/auth/token/lookup-self": {"read"},
+	}
+	require.Equal(t, expectedCapabilities, capabilities)
+}
+
+// TestGetCapabilitiesBadClientToken tests that getCapabilities
+// returns an error if the client token is bad.
+func TestGetCapabilitiesBadClientToken(t *testing.T) {
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
+	client.SetToken("")
+
+	capabilitiesToCheck := []string{"/auth/token/create", "/sys/capabilities-self", "/auth/token/lookup-self"}
+	_, err := getCapabilities(capabilitiesToCheck, client)
+	require.Error(t, err)
+}
+
+// TestGetCapabilitiesEmptyPaths tests the getCapabilities will error on an empty
+// set of paths to check
+func TestGetCapabilitiesEmptyPaths(t *testing.T) {
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
+
+	var capabilitiesToCheck []string
+	_, err := getCapabilities(capabilitiesToCheck, client)
+	require.Error(t, err)
+}

--- a/command/proxy.go
+++ b/command/proxy.go
@@ -491,6 +491,18 @@ func (c *ProxyCommand) Run(args []string) int {
 				c.UI.Error(fmt.Sprintf("Error creating static secret cache updater: %v", err))
 				return 1
 			}
+
+			capabilityManager, err := cache.NewStaticSecretCapabilityManager(&cache.StaticSecretCapabilityManagerConfig{
+				LeaseCache: leaseCache,
+				Logger:     c.logger.Named("cache.staticsecretcapabilitymanager"),
+				Client:     client,
+				StaticSecretTokenCapabilityRefreshInterval: config.Cache.StaticSecretTokenCapabilityRefreshInterval,
+			})
+			if err != nil {
+				c.UI.Error(fmt.Sprintf("Error creating static secret capability manager: %v", err))
+				return 1
+			}
+			leaseCache.SetCapabilityManager(capabilityManager)
 		}
 	}
 

--- a/command/proxy/config/config.go
+++ b/command/proxy/config/config.go
@@ -101,9 +101,11 @@ type APIProxy struct {
 
 // Cache contains any configuration needed for Cache mode
 type Cache struct {
-	Persist            *agentproxyshared.PersistConfig `hcl:"persist"`
-	InProcDialer       transportDialer                 `hcl:"-"`
-	CacheStaticSecrets bool                            `hcl:"cache_static_secrets"`
+	Persist                                       *agentproxyshared.PersistConfig `hcl:"persist"`
+	InProcDialer                                  transportDialer                 `hcl:"-"`
+	CacheStaticSecrets                            bool                            `hcl:"cache_static_secrets"`
+	StaticSecretTokenCapabilityRefreshIntervalRaw interface{}                     `hcl:"static_secret_token_capability_refresh_interval"`
+	StaticSecretTokenCapabilityRefreshInterval    time.Duration                   `hcl:"-"`
 }
 
 // AutoAuth is the configured authentication method and sinks
@@ -619,6 +621,14 @@ func parseCache(result *Config, list *ast.ObjectList) error {
 	subList := subs.List
 	if err := parsePersist(result, subList); err != nil {
 		return fmt.Errorf("error parsing persist: %w", err)
+	}
+
+	if result.Cache.StaticSecretTokenCapabilityRefreshIntervalRaw != nil {
+		var err error
+		if result.Cache.StaticSecretTokenCapabilityRefreshInterval, err = parseutil.ParseDurationSecond(result.Cache.StaticSecretTokenCapabilityRefreshIntervalRaw); err != nil {
+			return fmt.Errorf("error parsing static_secret_token_capability_refresh_interval, must be provided as a duration string: %w", err)
+		}
+		result.Cache.StaticSecretTokenCapabilityRefreshIntervalRaw = nil
 	}
 
 	return nil

--- a/command/proxy/config/config_test.go
+++ b/command/proxy/config/config_test.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/vault/command/agentproxyshared"
@@ -128,5 +129,64 @@ func TestLoadConfigFile_StaticSecretCachingWithoutAutoAuth(t *testing.T) {
 
 	if err := cfg.ValidateConfig(); err == nil {
 		t.Fatalf("expected error, as static secret caching requires auto-auth")
+	}
+}
+
+// TestLoadConfigFile_ProxyCacheStaticSecrets tests loading a config file containing a cache
+// as well as a valid proxy config with static secret caching enabled
+func TestLoadConfigFile_ProxyCacheStaticSecrets(t *testing.T) {
+	config, err := LoadConfigFile("./test-fixtures/config-cache-static-secret-cache.hcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &Config{
+		SharedConfig: &configutil.SharedConfig{
+			PidFile: "./pidfile",
+			Listeners: []*configutil.Listener{
+				{
+					Type:       "tcp",
+					Address:    "127.0.0.1:8300",
+					TLSDisable: true,
+				},
+			},
+		},
+		AutoAuth: &AutoAuth{
+			Method: &Method{
+				Type:      "aws",
+				MountPath: "auth/aws",
+				Config: map[string]interface{}{
+					"role": "foobar",
+				},
+			},
+			Sinks: []*Sink{
+				{
+					Type:   "file",
+					DHType: "curve25519",
+					DHPath: "/tmp/file-foo-dhpath",
+					AAD:    "foobar",
+					Config: map[string]interface{}{
+						"path": "/tmp/file-foo",
+					},
+				},
+			},
+		},
+		Cache: &Cache{
+			CacheStaticSecrets:                         true,
+			StaticSecretTokenCapabilityRefreshInterval: 1 * time.Hour,
+		},
+		Vault: &Vault{
+			Address:          "http://127.0.0.1:1111",
+			TLSSkipVerify:    true,
+			TLSSkipVerifyRaw: interface{}("true"),
+			Retry: &Retry{
+				NumRetries: 12,
+			},
+		},
+	}
+
+	config.Prune()
+	if diff := deep.Equal(config, expected); diff != nil {
+		t.Fatal(diff)
 	}
 }

--- a/command/proxy/config/test-fixtures/config-cache-static-secret-cache.hcl
+++ b/command/proxy/config/test-fixtures/config-cache-static-secret-cache.hcl
@@ -1,0 +1,38 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+pid_file = "./pidfile"
+
+auto_auth {
+	method {
+		type = "aws"
+		config = {
+			role = "foobar"
+		}
+	}
+
+	sink {
+		type = "file"
+		config = {
+			path = "/tmp/file-foo"
+		}
+		aad = "foobar"
+		dh_type = "curve25519"
+		dh_path = "/tmp/file-foo-dhpath"
+	}
+}
+
+cache {
+    cache_static_secrets = true
+    static_secret_token_capability_refresh_interval = "1h"
+}
+
+listener "tcp" {
+    address = "127.0.0.1:8300"
+    tls_disable = true
+}
+
+vault {
+	address = "http://127.0.0.1:1111"
+	tls_skip_verify = "true"
+}

--- a/command/proxy_test.go
+++ b/command/proxy_test.go
@@ -1156,6 +1156,178 @@ log_level = "trace"
 	wg.Wait()
 }
 
+// TestProxy_Cache_StaticSecretPermissionsLost Tests that the cache successfully caches a static secret
+// going through the Proxy for a KVV2 secret, and then the calling client loses permissions to the secret,
+// so it can no longer access the cache.
+func TestProxy_Cache_StaticSecretPermissionsLost(t *testing.T) {
+	logger := logging.NewVaultLogger(hclog.Trace)
+	cluster := vault.NewTestCluster(t, &vault.CoreConfig{
+		LogicalBackends: map[string]logical.Factory{
+			"kv": logicalKv.VersionedKVFactory,
+		},
+	}, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+
+	serverClient := cluster.Cores[0].Client
+
+	// Unset the environment variable so that proxy picks up the right test
+	// cluster address
+	defer os.Setenv(api.EnvVaultAddress, os.Getenv(api.EnvVaultAddress))
+	os.Unsetenv(api.EnvVaultAddress)
+
+	tokenFileName := makeTempFile(t, "token-file", serverClient.Token())
+	defer os.Remove(tokenFileName)
+	// We need auto-auth so that the event system can run.
+	// For ease, we use the token file path with the root token.
+	autoAuthConfig := fmt.Sprintf(`
+auto_auth {
+    method {
+		type = "token_file"
+        config = {
+            token_file_path = "%s"
+        }
+    }
+}`, tokenFileName)
+
+	// We make the token capability refresh interval one second, for ease of testing
+	cacheConfig := `
+cache {
+	cache_static_secrets = true
+	static_secret_token_capability_refresh_interval = "1s"
+}
+`
+	listenAddr := generateListenerAddress(t)
+	listenConfig := fmt.Sprintf(`
+listener "tcp" {
+  address = "%s"
+  tls_disable = true
+}
+`, listenAddr)
+
+	config := fmt.Sprintf(`
+vault {
+  address = "%s"
+  tls_skip_verify = true
+}
+%s
+%s
+%s
+log_level = "trace"
+`, serverClient.Address(), cacheConfig, listenConfig, autoAuthConfig)
+	configPath := makeTempFile(t, "config.hcl", config)
+	defer os.Remove(configPath)
+
+	// Start proxy
+	ui, cmd := testProxyCommand(t, logger)
+	cmd.startedCh = make(chan struct{})
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		cmd.Run([]string{"-config", configPath})
+		wg.Done()
+	}()
+
+	select {
+	case <-cmd.startedCh:
+	case <-time.After(5 * time.Second):
+		t.Errorf("timeout")
+		t.Errorf("stdout: %s", ui.OutputWriter.String())
+		t.Errorf("stderr: %s", ui.ErrorWriter.String())
+	}
+
+	proxyClient, err := api.NewClient(api.DefaultConfig())
+	require.Nil(t, err)
+	proxyClient.SetMaxRetries(0)
+	err = proxyClient.SetAddress("http://" + listenAddr)
+	require.Nil(t, err)
+
+	secretData := map[string]interface{}{
+		"foo": "bar",
+	}
+
+	// Mount the KVV2 engine
+	err = serverClient.Sys().Mount("secret-v2", &api.MountInput{
+		Type: "kv-v2",
+	})
+	require.Nil(t, err)
+
+	err = serverClient.Sys().PutPolicy("kv-policy", `
+   path "secret-v2/*" {
+     capabilities = ["update", "read"]
+   }`)
+	require.Nil(t, err)
+
+	// Setup a token that we can later revoke:
+	renewable := true
+	// Set the token's policies to 'default' and nothing else
+	tokenCreateRequest := &api.TokenCreateRequest{
+		Policies:  []string{"default", "kv-policy"},
+		TTL:       "2s",
+		Renewable: &renewable,
+	}
+
+	secret, err := serverClient.Auth().Token().CreateOrphan(tokenCreateRequest)
+	require.Nil(t, err)
+	token := secret.Auth.ClientToken
+	proxyClient.SetToken(token)
+
+	// Create kvv2 secret
+	_, err = serverClient.KVv2("secret-v2").Put(context.Background(), "my-secret", secretData)
+	require.Nil(t, err)
+
+	// We use raw requests so we can check the headers for cache hit/miss.
+	req := proxyClient.NewRequest(http.MethodGet, "/v1/secret-v2/data/my-secret")
+	resp1, err := proxyClient.RawRequest(req)
+	require.Nil(t, err)
+
+	cacheValue := resp1.Header.Get("X-Cache")
+	require.Equal(t, "MISS", cacheValue)
+
+	// We expect this to be a cache hit, with the new value
+	resp2, err := proxyClient.RawRequest(req)
+	require.Nil(t, err)
+
+	cacheValue = resp2.Header.Get("X-Cache")
+	require.Equal(t, "HIT", cacheValue)
+
+	// Lastly, we check to make sure the actual data we received is
+	// as we expect. We must use ParseSecret due to the raw requests.
+	secret1, err := api.ParseSecret(resp1.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, ok := secret1.Data["data"]
+	require.True(t, ok)
+	require.Equal(t, secretData, data)
+
+	secret2, err := api.ParseSecret(resp2.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data2, ok := secret2.Data["data"]
+	require.True(t, ok)
+	// We expect that the cached value got updated by the event system.
+	require.Equal(t, secretData, data2)
+
+	// Wait for the token to expire, and for the permissions to be revoked
+	// The TTL on the token was 2s, and the capability refresh is every 1s,
+	// so this should give us more than enough time!
+	time.Sleep(5 * time.Second)
+	kvSecret, err := proxyClient.KVv2("secret-v2").Get(context.Background(), "my-secret")
+	if err == nil {
+		t.Fatalf("expected error, but none found, secret:%v, err:%v", kvSecret, err)
+	}
+	// Make sure it's a permission denied error
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("expected error on GET to secret after token revocation, secret:%v, err:%v", kvSecret, err)
+	}
+
+	close(cmd.ShutdownCh)
+	wg.Wait()
+}
+
 // TestProxy_ApiProxy_Retry Tests the retry functionalities of Vault Proxy's API Proxy
 func TestProxy_ApiProxy_Retry(t *testing.T) {
 	//----------------------------------------------------


### PR DESCRIPTION
This subsystem manages the capabilities of tokens that have been used in static secret caching by sending a job to the queue every duration `d` that will check if the capabilities are the same, and if not, update. I tried to leave good godocs where I could.

This docs page might be useful pre-reading if you're unfamiliar with the capabilities API: https://developer.hashicorp.com/vault/api-docs/system/capabilities-self

The most likely happy path through this subsystem will be during token expiry, in which situation we evict the capabilities index and update all related path indexes. However, it fully supports updated permissions, too.

We use `gammazero/workerpool` as it's a good fit for the problem, as well as having usage elsewhere in Vault.

There were some bugs related to restoring from persistent storage, and I fixed them as part of this PR, too, as I needed to work in that area.

All that's left to make this feature complete is the pre-event stream update for static secrets, and then, the option to turn off dynamic secret caching.