### PR TITLE
ui: doc-link helper

### DIFF
--- a/ui/lib/core/addon/helpers/doc-link.js
+++ b/ui/lib/core/addon/helpers/doc-link.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { helper } from '@ember/component/helper';
+
+export function docLink([path]) {
+  const host = 'https://developer.hashicorp.com';
+  return `${host}${path}`;
+}
+
+export default helper(docLink);

--- a/ui/lib/core/addon/helpers/doc-link.js
+++ b/ui/lib/core/addon/helpers/doc-link.js
@@ -4,8 +4,10 @@
  */
 
 import { helper } from '@ember/component/helper';
+import { assert } from '@ember/debug';
 
 export function docLink([path]) {
+  assert(`doc-link path: "${path}" must begin with a forward slash`, path.startsWith('/'));
   const host = 'https://developer.hashicorp.com';
   return `${host}${path}`;
 }

--- a/ui/lib/core/app/helpers/doc-link.js
+++ b/ui/lib/core/app/helpers/doc-link.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+export { default } from 'core/helpers/doc-link';


### PR DESCRIPTION
Template helper to assist migration to using HDS components with a `@href` arg

Example use: 
```js
    <Hds::Button
      @text="Learn more"
      @icon="docs-link"
      @isHrefExternal={{true}}
      @href={{doc-link "/vault/tutorials/getting-started-ui)"}}
    />
```

```js
<Hds::Link::Standalone @icon="film" @text="Watch tutorial video" @href={{doc-link "/some-path"}} />
```

It also throws an error if the path arg does not begin with a forward slash `/`
<img width="990" alt="Screenshot 2023-10-16 at 5 45 21 PM" src="https://github.com/hashicorp/vault/assets/68122737/5dd1e9ec-3465-421c-9882-79b8cae09eba">
