### PR TITLE
Forbid setting auto_rotate_period on transit managed keys

### DIFF
--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -275,6 +275,11 @@ func (b *backend) rotateIfRequired(ctx context.Context, req *logical.Request, ke
 		return nil
 	}
 
+	// We can't auto-rotate managed keys
+	if p.Type == keysutil.KeyType_MANAGED_KEY {
+		return nil
+	}
+
 	// Retrieve the latest version of the policy and determine if it is time to rotate.
 	latestKey := p.Keys[strconv.Itoa(p.LatestVersion)]
 	if time.Now().After(latestKey.CreationTime.Add(p.AutoRotatePeriod)) {

--- a/builtin/logical/transit/path_datakey.go
+++ b/builtin/logical/transit/path_datakey.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/vault/helper/constants"
@@ -141,7 +142,23 @@ func (b *backend) pathDatakeyWrite(ctx context.Context, req *logical.Request, d 
 		return nil, err
 	}
 
-	ciphertext, err := p.Encrypt(ver, context, nonce, base64.StdEncoding.EncodeToString(newKey))
+	var managedKeyFactory ManagedKeyFactory
+	if p.Type == keysutil.KeyType_MANAGED_KEY {
+		managedKeySystemView, ok := b.System().(logical.ManagedKeySystemView)
+		if !ok {
+			return nil, errors.New("unsupported system view")
+		}
+
+		managedKeyFactory = ManagedKeyFactory{
+			managedKeyParams: keysutil.ManagedKeyParameters{
+				ManagedKeySystemView: managedKeySystemView,
+				BackendUUID:          b.backendUUID,
+				Context:              ctx,
+			},
+		}
+	}
+
+	ciphertext, err := p.EncryptWithFactory(ver, context, nonce, base64.StdEncoding.EncodeToString(newKey), nil, managedKeyFactory)
 	if err != nil {
 		switch err.(type) {
 		case errutil.UserError:

--- a/builtin/logical/transit/path_keys_config.go
+++ b/builtin/logical/transit/path_keys_config.go
@@ -218,6 +218,10 @@ func (b *backend) pathKeysConfigWrite(ctx context.Context, req *logical.Request,
 			p.AutoRotatePeriod = autoRotatePeriod
 			persistNeeded = true
 		}
+
+		if p.Type == keysutil.KeyType_MANAGED_KEY && autoRotatePeriod != 0 {
+			return logical.ErrorResponse("Auto rotation can not be set for managed keys"), nil
+		}
 	}
 
 	if !persistNeeded {

--- a/changelog/23723.txt
+++ b/changelog/23723.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/transit: Do not allow auto rotation on managed_key key types
+```


### PR DESCRIPTION
 - Prevent and guard against auto-rotating managed keys as we generate an invalid key version without the UUID field set.
 - Hook in the datakey generation api into managed key encryption.

 - Tests will come within a seperate enterprise PR