### PR TITLE
Dashboard TLS Configuration Details Bug

### DIFF
--- a/changelog/23726.txt
+++ b/changelog/23726.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes issues displaying accurate TLS state in dashboard configuration details
+```

--- a/ui/app/components/dashboard/vault-configuration-details-card.js
+++ b/ui/app/components/dashboard/vault-configuration-details-card.js
@@ -22,7 +22,7 @@ export default class DashboardSecretsEnginesCard extends Component {
     // consider tls enabled if tls_disable is undefined or false AND both tls_cert_file and tls_key_file are defined
     const tlsListener = this.args.vaultConfiguration?.listeners.find((listener) => {
       const { tls_disable, tls_cert_file, tls_key_file } = listener.config || {};
-      return (tls_disable === undefined || tls_disable === false) && tls_cert_file && tls_key_file;
+      return !tls_disable && tls_cert_file && tls_key_file;
     });
 
     return tlsListener ? 'Enabled' : 'Disabled';

--- a/ui/app/components/dashboard/vault-configuration-details-card.js
+++ b/ui/app/components/dashboard/vault-configuration-details-card.js
@@ -17,11 +17,14 @@ import Component from '@glimmer/component';
  */
 
 export default class DashboardSecretsEnginesCard extends Component {
-  get tlsDisabled() {
-    const tlsDisableConfig = this.args.vaultConfiguration?.listeners.find((listener) => {
-      if (listener.config && listener.config.tls_disable) return listener.config.tls_disable;
+  get tls() {
+    // since the default for tls_disable is false it may not be in the config
+    // consider tls enabled if tls_disable is undefined or false AND both tls_cert_file and tls_key_file are defined
+    const tlsListener = this.args.vaultConfiguration?.listeners.find((listener) => {
+      const { tls_disable, tls_cert_file, tls_key_file } = listener.config || {};
+      return (tls_disable === undefined || tls_disable === false) && tls_cert_file && tls_key_file;
     });
 
-    return tlsDisableConfig?.config.tls_disable ? 'Enabled' : 'Disabled';
+    return tlsListener ? 'Enabled' : 'Disabled';
   }
 }

--- a/ui/app/templates/components/dashboard/vault-configuration-details-card.hbs
+++ b/ui/app/templates/components/dashboard/vault-configuration-details-card.hbs
@@ -19,7 +19,7 @@
       </B.Tr>
       <B.Tr>
         <B.Td>TLS</B.Td>
-        <B.Td data-test-vault-config-details="tls_disable">{{this.tlsDisabled}}</B.Td>
+        <B.Td data-test-vault-config-details="tls">{{this.tls}}</B.Td>
       </B.Tr>
       <B.Tr>
         <B.Td>Log format</B.Td>


### PR DESCRIPTION
The TLS field of the configuration details section on the dashboard was not displaying accurately based on the configuration settings. Since the `tls_disable` default value is `false`, it doesn't need to be defined and could be missing from the configuration. In addition, when using TLS the `tls_cert_file` and `tls_key_file` values are required. I updated to check that `tls_disable` is either `undefined` or `false` and both file properties have value to determine if TLS is enabled.

The screen shot below is after the changes with the following config:
```hcl
api_addr = "https://127.0.0.1:8200"
disable_mlock = true

listener "tcp" {
  address = "127.0.0.1:8200"
  tls_cert_file = "./certs/vault-cert.pem"
  tls_key_file = "./certs/vault-key.pem"
}

storage "inmem" {}
```

![image](https://github.com/hashicorp/vault/assets/24611656/2a963131-3315-4a58-be03-942d10bd430a)

I also noticed when running a dev server that it was incorrectly reporting that TLS was _Enabled_ which is now showing _Disabled_ as expected.

![image](https://github.com/hashicorp/vault/assets/24611656/80acb902-1580-4924-8d12-01b9842eac69)
