### PR TITLE
Added clean function stub so it can be used in Vault ENT

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -231,6 +231,7 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 
 	b.Backend.Invalidate = sysInvalidate(b)
 	b.Backend.InitializeFunc = sysInitialize(b)
+	b.Backend.Clean = sysClean(b)
 	return b
 }
 

--- a/vault/logical_system_helpers.go
+++ b/vault/logical_system_helpers.go
@@ -34,6 +34,10 @@ var (
 		return nil
 	}
 
+	sysClean = func(b *SystemBackend) func(context.Context) {
+		return nil
+	}
+
 	getSystemSchemas = func() []func() *memdb.TableSchema { return nil }
 
 	getEGPListResponseKeyInfo = func(*SystemBackend, *namespace.Namespace) map[string]interface{} { return nil }


### PR DESCRIPTION
Vault Enterprise needs to execute some clean-up code to close some metrics-gathering background jobs that do not exist on the community version. This PR adds a stub similar to `InitializeFunc` or `Invalidate` so it can overridden by the ENT codebase.

We plan to backport this change so it is available on the 1.15.1 release.