### PR TITLE
Specify within ACME client counting what are the certificate identifiers

### DIFF
--- a/website/content/docs/concepts/client-count/index.mdx
+++ b/website/content/docs/concepts/client-count/index.mdx
@@ -70,8 +70,8 @@ calculations.
 For example:
 
 - Authentication requests from two ACME clients living on different servers that
-  request the same set of certificate identifiers are assigned to the same
-  certificate entity.
+  request the same set of certificate identifiers (the combination of CN, DNS SANs,
+  and IP SANs) are assigned to the same certificate entity.
 - Multiple requests for the same certificate identifier from a single ACME
   client are assigned to the same certificate entity.
 - Two authentication requests from a single ACME client for different


### PR DESCRIPTION
Received feedback that it wasn't clear what we were considering as certificate identifiers within the ACME client counting section.