### PR TITLE
Bug: handle error on updating rotation config (/sys/rotate/config)

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3698,7 +3698,7 @@ func (b *SystemBackend) handleKeyRotationConfigUpdate(ctx context.Context, req *
 	}
 
 	// Store the rotation config
-	b.Core.barrier.SetRotationConfig(ctx, rotConfig)
+	err = b.Core.barrier.SetRotationConfig(ctx, rotConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Quick bug fix, ensure we handle any errors returned by `SetRotationConfig` when attempting to update the key rotation configuration.

https://developer.hashicorp.com/vault/api-docs/system/rotate-config#create-or-update-the-auto-rotation-configuration