### PR TITLE
Pin curl docker image to a specific version instead of latest

### DIFF
--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -192,7 +192,7 @@ func SubtestACMECaddy(configTemplate string, enableEAB bool) func(*testing.T, *V
 		// Start a cURL container.
 		curlRunner, err := hDocker.NewServiceRunner(hDocker.RunOptions{
 			ImageRepo:     "docker.mirror.hashicorp.services/curlimages/curl",
-			ImageTag:      "latest",
+			ImageTag:      "8.4.0",
 			ContainerName: fmt.Sprintf("curl_test_%s", runID),
 			NetworkName:   vaultNetwork,
 			Entrypoint:    []string{"sleep", sleepTimer},


### PR DESCRIPTION
 - Try to avoid these build failures as our proxy does seem to have issues around pulling images with the 'latest' tag at times.

```
acme_test.go:206:
	Error Trace:	/home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/builtin/logical/pkiext/pkiext_binary/acme_test.go:206
          	        /home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/builtin/logical/pkiext/pkiext_binary/acme_test.go:75
	Error:      	Received unexpected error:
				container create failed: Error response from daemon: No such image: docker.mirror.hashicorp.services/curlimages/curl:latest
	Test:       	Test_ACME/group/caddy_http_eab
	Messages:   	could not start cURL container
```