### PR TITLE
plugins: allow all log levels for external plugins

### DIFF
--- a/changelog/23771.txt
+++ b/changelog/23771.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+sdk/plugin: Fix an issue where external plugins were not reporting logs below INFO level
+```

--- a/sdk/plugin/serve.go
+++ b/sdk/plugin/serve.go
@@ -97,7 +97,7 @@ func ServeMultiplex(opts *ServeOpts) error {
 	logger := opts.Logger
 	if logger == nil {
 		logger = log.New(&log.LoggerOptions{
-			Level:      log.Info,
+			Level:      log.Trace,
 			Output:     os.Stderr,
 			JSONFormat: true,
 		})


### PR DESCRIPTION
This fixes an issue where external plugins were not reporting logs below INFO level.