### PR TITLE
Use the same approach for copywrite checks as we do in our other workflows

### DIFF
--- a/.github/workflows/copywrite.yml
+++ b/.github/workflows/copywrite.yml
@@ -1,7 +1,12 @@
 name: Check Copywrite Headers
 
 on:
-  push: {}
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - main
+      - release/**
 
 jobs:
   copywrite:


### PR DESCRIPTION
Apply only to PRs, and to pushes to our main and release branches.