### PR TITLE
Update specifics around managed keys support in Transit

### DIFF
--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -1932,15 +1932,15 @@ $ curl \
   },
 ```
 
-## Managed keys
+## Managed keys <EnterpriseAlert inline="true" />
 
-~> **Note**: Managed keys are an Enterprise only feature.
+Managed Keys can be used with the Transit Secrets Engine to perform cryptographic operations. Currently,
+[Sign Data](#sign-data) and [Verify Signed Data](#verify-signed-data) are well-supported across all the managed key types.
 
-Managed Keys can be used with the Transit Secrets Engine to perform cryptographic operations. Currently
-[Sign Data](#sign-data) and [Verify Signed Data](#verify-signed-data) are well supported, and in certain
-configurations, [Encrypt Data](#encrypt-data) and [Decrypt Data](#decrypt-data) are supported.
+Only PKCS#11 managed keys support [Encrypt Data](#encrypt-data) and [Decrypt Data](#decrypt-data) operations at this time. We
+are planning on adding support for AWS, GCP and Azure managed keys at a later time.
 
-When a Transit key is created of type `managed_key`, Transit will lookup the key by name or ID, and will
+When a Transit key is created of type `managed_key`, Transit will look up the key by name or ID, and will
 attempt to generate the key when key generation is allowed (as specified when the [Create/Update Managed Key](/vault/api-docs/system/managed-keys#create-update-managed-key)
 endpoint is called). Key generation is currently supported for cloud KMSes and for certain PKCS#11 mechanisms
 on HSMs. This is a best effort operation, so certain KMS/HSM/key configurations will require the key to exist
@@ -1953,4 +1953,3 @@ Signing and verifying data with a Managed Key through Transit may require pre-ha
 can be informed that data is pre-hashed with the `prehashed` parameter of the [Sign Data](#sign-data) and
 [Verify Signed Data](#verify-signed-data) endpoints.
 
-[sys-plugin-reload-backend]: /vault/api-docs/system/plugins-reload-backend#reload-plugins


### PR DESCRIPTION
Document that sign/verify work across all managed key types and encryption/decryption only for PKCS#11 at this time.