### PR TITLE
fix a bug reading auth mount using sys/internal/ui/mount endpoint when filter paths are enforced

### DIFF
--- a/changelog/23802.txt
+++ b/changelog/23802.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-core/mounts: Reading an "auth" mount using "sys/internal/ui/mounts/" when filter paths are enforced returns 500 error code from the secondary
+core/mounts: Fix reading an "auth" mount using "sys/internal/ui/mounts/" when filter paths are enforced returns 500 error code from the secondary
 ```

--- a/changelog/23802.txt
+++ b/changelog/23802.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/mounts: Reading an "auth" mount using "sys/internal/ui/mounts/" when filter paths are enforced returns 500 error code from the secondary
+```

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4551,7 +4551,12 @@ func (b *SystemBackend) pathInternalUIMountRead(ctx context.Context, req *logica
 		return errResp, logical.ErrPermissionDenied
 	}
 
-	filtered, err := b.Core.checkReplicatedFiltering(ctx, me, "")
+	var routerPrefix string
+	if strings.HasPrefix(me.APIPathNoNamespace(), credentialRoutePrefix) {
+		routerPrefix = credentialRoutePrefix
+	}
+
+	filtered, err := b.Core.checkReplicatedFiltering(ctx, me, routerPrefix)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Addresses https://hashicorp.atlassian.net/browse/VAULT-21207

Reading an "auth" mount using "sys/internal/ui/mounts/" when filter paths are enforced returns 500 error code from the secondary:
```
failed to read a mount point in allow mode, Error making API request.
        
        URL: GET https://127.0.0.1:49227/v1/sys/internal/ui/mounts/auth/d0681fa6-a5be-4d7e-8c38-c443325bb3ee
        Code: 500. Errors:
        
        * unable to retrieve route entry for mount path
```