### PR TITLE
[QT-616] Add `seal_ha` enos scenario

### DIFF
--- a/.github/workflows/enos-lint.yml
+++ b/.github/workflows/enos-lint.yml
@@ -41,7 +41,6 @@ jobs:
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
-          terraform_version: 1.5.7 # QT-623: pin to terraform 1.5.x until a tfjson bug is resolved
       - uses: hashicorp/action-setup-enos@v1
         with:
           github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}

--- a/.github/workflows/enos-run-k8s.yml
+++ b/.github/workflows/enos-run-k8s.yml
@@ -38,7 +38,6 @@ jobs:
           # the Terraform wrapper will break Terraform execution in Enos because
           # it changes the output to text when we expect it to be JSON.
           terraform_wrapper: false
-          terraform_version: 1.5.7 # QT-623: pin to terraform 1.5.x until a tfjson bug is resolved
       - name: Set up Enos
         uses: hashicorp/action-setup-enos@v1
         with:

--- a/.github/workflows/test-enos-scenario-ui.yml
+++ b/.github/workflows/test-enos-scenario-ui.yml
@@ -90,7 +90,6 @@ jobs:
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_wrapper: false
-          terraform_version: 1.5.7 # QT-623: pin to terraform 1.5.x until a tfjson bug is resolved
       - name: Prepare scenario dependencies
         run: |
           mkdir -p ./enos/support/terraform-plugin-cache

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -102,7 +102,6 @@ jobs:
           # the Terraform wrapper will break Terraform execution in Enos because
           # it changes the output to text when we expect it to be JSON.
           terraform_wrapper: false
-          terraform_version: 1.5.7 # QT-623: pin to terraform 1.5.x until a tfjson bug is resolved
       - uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}

--- a/enos/ci/service-user-iam/main.tf
+++ b/enos/ci/service-user-iam/main.tf
@@ -216,6 +216,7 @@ data "aws_iam_policy_document" "enos_scenario" {
       "kms:ListKeys",
       "kms:ListResourceTags",
       "kms:ScheduleKeyDeletion",
+      "kms:TagResource",
       "servicequotas:ListServiceQuotas"
     ]
 

--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -57,12 +57,35 @@ module "replication_data" {
   source = "./modules/replication_data"
 }
 
+module "seal_key_awskms" {
+  source = "./modules/seal_key_awskms"
+
+  common_tags = var.tags
+}
+
+module "seal_key_shamir" {
+  source = "./modules/seal_key_shamir"
+
+  common_tags = var.tags
+}
+
 module "shutdown_node" {
   source = "./modules/shutdown_node"
 }
 
 module "shutdown_multiple_nodes" {
   source = "./modules/shutdown_multiple_nodes"
+}
+
+module "start_vault" {
+  source = "./modules/start_vault"
+
+  install_dir = var.vault_install_dir
+  log_level   = var.vault_log_level
+}
+
+module "stop_vault" {
+  source = "./modules/stop_vault"
 }
 
 # create target instances using ec2:CreateFleet
@@ -245,6 +268,13 @@ module "vault_verify_write_data" {
 
 module "vault_wait_for_leader" {
   source = "./modules/vault_wait_for_leader"
+
+  vault_install_dir    = var.vault_install_dir
+  vault_instance_count = var.vault_instance_count
+}
+
+module "vault_wait_for_seal_rewrap" {
+  source = "./modules/vault_wait_for_seal_rewrap"
 
   vault_install_dir    = var.vault_install_dir
   vault_instance_count = var.vault_instance_count

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -11,6 +11,7 @@ scenario "agent" {
     distro          = ["ubuntu", "rhel"]
     edition         = ["ce", "ent", "ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     seal            = ["awskms", "shamir"]
+    seal_ha_beta    = ["true", "false"]
 
     # Our local builder always creates bundles
     exclude {
@@ -81,6 +82,15 @@ scenario "agent" {
     }
   }
 
+  step "create_seal_key" {
+    module = "seal_key_${matrix.seal}"
+
+    variables {
+      cluster_id  = step.create_vpc.cluster_id
+      common_tags = global.tags
+    }
+  }
+
   // This step reads the contents of the backend license if we're using a Consul backend and
   // the edition is "ent".
   step "read_backend_license" {
@@ -110,11 +120,11 @@ scenario "agent" {
     }
 
     variables {
-      ami_id                = step.ec2_info.ami_ids[matrix.arch][matrix.distro][global.distro_version[matrix.distro]]
-      awskms_unseal_key_arn = step.create_vpc.kms_key_arn
-      cluster_tag_key       = global.vault_tag_key
-      common_tags           = global.tags
-      vpc_id                = step.create_vpc.vpc_id
+      ami_id          = step.ec2_info.ami_ids[matrix.arch][matrix.distro][global.distro_version[matrix.distro]]
+      cluster_tag_key = global.vault_tag_key
+      common_tags     = global.tags
+      seal_key_names  = step.create_seal_key.resource_names
+      vpc_id          = step.create_vpc.id
     }
   }
 
@@ -127,11 +137,11 @@ scenario "agent" {
     }
 
     variables {
-      ami_id                = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
-      awskms_unseal_key_arn = step.create_vpc.kms_key_arn
-      cluster_tag_key       = global.backend_tag_key
-      common_tags           = global.tags
-      vpc_id                = step.create_vpc.vpc_id
+      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      cluster_tag_key = global.backend_tag_key
+      common_tags     = global.tags
+      seal_key_names  = step.create_seal_key.resource_names
+      vpc_id          = step.create_vpc.id
     }
   }
 
@@ -171,7 +181,6 @@ scenario "agent" {
 
     variables {
       artifactory_release     = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
-      awskms_unseal_key_arn   = step.create_vpc.kms_key_arn
       backend_cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       backend_cluster_tag_key = global.backend_tag_key
       cluster_name            = step.create_vault_cluster_targets.cluster_name
@@ -186,9 +195,11 @@ scenario "agent" {
       local_artifact_path  = local.artifact_path
       manage_service       = local.manage_service
       packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      seal_ha_beta         = matrix.seal_ha_beta
+      seal_key_name        = step.create_seal_key.resource_name
+      seal_type            = matrix.seal
       storage_backend      = matrix.backend
       target_hosts         = step.create_vault_cluster_targets.hosts
-      unseal_method        = matrix.seal
     }
   }
 
@@ -389,11 +400,6 @@ scenario "agent" {
     value       = step.create_vault_cluster.audit_device_file_path
   }
 
-  output "awskms_unseal_key_arn" {
-    description = "The Vault cluster KMS key arn"
-    value       = step.create_vpc.kms_key_arn
-  }
-
   output "cluster_name" {
     description = "The Vault cluster name"
     value       = step.create_vault_cluster.cluster_name
@@ -432,6 +438,11 @@ scenario "agent" {
   output "recovery_keys_hex" {
     description = "The Vault cluster recovery keys hex"
     value       = step.create_vault_cluster.recovery_keys_hex
+  }
+
+  output "seal_key_name" {
+    description = "The name of the cluster seal key"
+    value       = step.create_seal_key.resource_name
   }
 
   output "unseal_keys_b64" {

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -12,6 +12,7 @@ scenario "autopilot" {
     // release branch's version.
     initial_version = ["1.11.12", "1.12.11", "1.13.6", "1.14.2"]
     seal            = ["awskms", "shamir"]
+    seal_ha_beta    = ["true", "false"]
 
     # Our local builder always creates bundles
     exclude {
@@ -77,6 +78,15 @@ scenario "autopilot" {
     }
   }
 
+  step "create_seal_key" {
+    module = "seal_key_${matrix.seal}"
+
+    variables {
+      cluster_id  = step.create_vpc.cluster_id
+      common_tags = global.tags
+    }
+  }
+
   step "read_license" {
     module = module.read_license
 
@@ -94,11 +104,11 @@ scenario "autopilot" {
     }
 
     variables {
-      ami_id                = step.ec2_info.ami_ids[matrix.arch][matrix.distro][global.distro_version[matrix.distro]]
-      awskms_unseal_key_arn = step.create_vpc.kms_key_arn
-      cluster_tag_key       = global.vault_tag_key
-      common_tags           = global.tags
-      vpc_id                = step.create_vpc.vpc_id
+      ami_id          = step.ec2_info.ami_ids[matrix.arch][matrix.distro][global.distro_version[matrix.distro]]
+      cluster_tag_key = global.vault_tag_key
+      common_tags     = global.tags
+      seal_key_names  = step.create_seal_key.resource_names
+      vpc_id          = step.create_vpc.id
     }
   }
 
@@ -114,22 +124,23 @@ scenario "autopilot" {
     }
 
     variables {
-      awskms_unseal_key_arn = step.create_vpc.kms_key_arn
-      cluster_name          = step.create_vault_cluster_targets.cluster_name
-      install_dir           = local.vault_install_dir
-      license               = matrix.edition != "ce" ? step.read_license.license : null
-      packages              = concat(global.packages, global.distro_packages[matrix.distro])
+      cluster_name         = step.create_vault_cluster_targets.cluster_name
+      enable_audit_devices = var.vault_enable_audit_devices
+      install_dir          = local.vault_install_dir
+      license              = matrix.edition != "ce" ? step.read_license.license : null
+      packages             = concat(global.packages, global.distro_packages[matrix.distro])
       release = {
         edition = matrix.edition
         version = matrix.initial_version
       }
+      seal_ha_beta    = matrix.seal_ha_beta
+      seal_key_name   = step.create_seal_key.resource_name
+      seal_type       = matrix.seal
       storage_backend = "raft"
       storage_backend_addl_config = {
         autopilot_upgrade_version = matrix.initial_version
       }
-      target_hosts         = step.create_vault_cluster_targets.hosts
-      unseal_method        = matrix.seal
-      enable_audit_devices = var.vault_enable_audit_devices
+      target_hosts = step.create_vault_cluster_targets.hosts
     }
   }
 
@@ -190,11 +201,11 @@ scenario "autopilot" {
     }
 
     variables {
-      ami_id                = step.ec2_info.ami_ids[matrix.arch][matrix.distro][global.distro_version[matrix.distro]]
-      awskms_unseal_key_arn = step.create_vpc.kms_key_arn
-      common_tags           = global.tags
-      cluster_name          = step.create_vault_cluster_targets.cluster_name
-      vpc_id                = step.create_vpc.vpc_id
+      ami_id         = step.ec2_info.ami_ids[matrix.arch][matrix.distro][global.distro_version[matrix.distro]]
+      common_tags    = global.tags
+      cluster_name   = step.create_vault_cluster_targets.cluster_name
+      seal_key_names = step.create_seal_key.resource_names
+      vpc_id         = step.create_vpc.id
     }
   }
 
@@ -213,7 +224,7 @@ scenario "autopilot" {
 
     variables {
       artifactory_release         = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
-      awskms_unseal_key_arn       = step.create_vpc.kms_key_arn
+      enable_audit_devices        = var.vault_enable_audit_devices
       cluster_name                = step.create_vault_cluster_targets.cluster_name
       log_level                   = var.vault_log_level
       force_unseal                = matrix.seal == "shamir"
@@ -224,13 +235,14 @@ scenario "autopilot" {
       manage_service              = local.manage_service
       packages                    = concat(global.packages, global.distro_packages[matrix.distro])
       root_token                  = step.create_vault_cluster.root_token
+      seal_ha_beta                = matrix.seal_ha_beta
+      seal_key_name               = step.create_seal_key.resource_name
+      seal_type                   = matrix.seal
       shamir_unseal_keys          = matrix.seal == "shamir" ? step.create_vault_cluster.unseal_keys_hex : null
       storage_backend             = "raft"
       storage_backend_addl_config = step.create_autopilot_upgrade_storageconfig.storage_addl_config
       storage_node_prefix         = "upgrade_node"
       target_hosts                = step.create_vault_cluster_upgrade_targets.hosts
-      unseal_method               = matrix.seal
-      enable_audit_devices        = var.vault_enable_audit_devices
     }
   }
 
@@ -498,9 +510,9 @@ scenario "autopilot" {
     }
   }
 
-  output "awskms_unseal_key_arn" {
-    description = "The Vault cluster KMS key arn"
-    value       = step.create_vpc.kms_key_arn
+  output "audit_device_file_path" {
+    description = "The file path for the file audit device, if enabled"
+    value       = step.create_vault_cluster.audit_device_file_path
   }
 
   output "cluster_name" {
@@ -543,6 +555,11 @@ scenario "autopilot" {
     value       = step.create_vault_cluster.recovery_keys_hex
   }
 
+  output "seal_key_name" {
+    description = "The Vault cluster seal key name"
+    value       = step.create_seal_key.resource_name
+  }
+
   output "unseal_keys_b64" {
     description = "The Vault cluster unseal keys"
     value       = step.create_vault_cluster.unseal_keys_b64
@@ -566,10 +583,5 @@ scenario "autopilot" {
   output "upgrade_public_ips" {
     description = "The Vault cluster public IPs"
     value       = step.upgrade_vault_cluster_with_autopilot.public_ips
-  }
-
-  output "vault_audit_device_file_path" {
-    description = "The file path for the file audit device, if enabled"
-    value       = step.create_vault_cluster.audit_device_file_path
   }
 }

--- a/enos/enos-scenario-ui.hcl
+++ b/enos/enos-scenario-ui.hcl
@@ -3,8 +3,9 @@
 
 scenario "ui" {
   matrix {
-    edition = ["ce", "ent"]
-    backend = ["consul", "raft"]
+    edition      = ["ce", "ent"]
+    backend      = ["consul", "raft"]
+    seal_ha_beta = ["true", "false"]
   }
 
   terraform_cli = terraform_cli.default
@@ -68,6 +69,15 @@ scenario "ui" {
     }
   }
 
+  step "create_seal_key" {
+    module = "seal_key_${local.seal}"
+
+    variables {
+      cluster_id  = step.create_vpc.cluster_id
+      common_tags = global.tags
+    }
+  }
+
   // This step reads the contents of the backend license if we're using a Consul backend and
   // the edition is "ent".
   step "read_backend_license" {
@@ -97,11 +107,11 @@ scenario "ui" {
     }
 
     variables {
-      ami_id                = step.ec2_info.ami_ids[local.arch][local.distro][var.ubuntu_distro_version]
-      awskms_unseal_key_arn = step.create_vpc.kms_key_arn
-      cluster_tag_key       = local.vault_tag_key
-      common_tags           = local.tags
-      vpc_id                = step.create_vpc.vpc_id
+      ami_id          = step.ec2_info.ami_ids[local.arch][local.distro][var.ubuntu_distro_version]
+      cluster_tag_key = local.vault_tag_key
+      common_tags     = local.tags
+      seal_key_names  = step.create_seal_key.resource_names
+      vpc_id          = step.create_vpc.id
     }
   }
 
@@ -114,11 +124,11 @@ scenario "ui" {
     }
 
     variables {
-      ami_id                = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
-      awskms_unseal_key_arn = step.create_vpc.kms_key_arn
-      cluster_tag_key       = local.backend_tag_key
-      common_tags           = local.tags
-      vpc_id                = step.create_vpc.vpc_id
+      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      cluster_tag_key = local.backend_tag_key
+      common_tags     = local.tags
+      seal_key_names  = step.create_seal_key.resource_names
+      vpc_id          = step.create_vpc.id
     }
   }
 
@@ -157,7 +167,6 @@ scenario "ui" {
     }
 
     variables {
-      awskms_unseal_key_arn   = step.create_vpc.kms_key_arn
       backend_cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       backend_cluster_tag_key = local.backend_tag_key
       cluster_name            = step.create_vault_cluster_targets.cluster_name
@@ -171,9 +180,11 @@ scenario "ui" {
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = local.bundle_path
       packages             = global.distro_packages["ubuntu"]
+      seal_ha_beta         = matrix.seal_ha_beta
+      seal_key_name        = step.create_seal_key.resource_name
+      seal_type            = local.seal
       storage_backend      = matrix.backend
       target_hosts         = step.create_vault_cluster_targets.hosts
-      unseal_method        = local.seal
     }
   }
 
@@ -210,11 +221,6 @@ scenario "ui" {
   output "audit_device_file_path" {
     description = "The file path for the file audit device, if enabled"
     value       = step.create_vault_cluster.audit_device_file_path
-  }
-
-  output "awskms_unseal_key_arn" {
-    description = "The Vault cluster KMS key arn"
-    value       = step.create_vpc.kms_key_arn
   }
 
   output "cluster_name" {
@@ -255,6 +261,11 @@ scenario "ui" {
   output "root_token" {
     description = "The Vault cluster root token"
     value       = step.create_vault_cluster.root_token
+  }
+
+  output "seal_key_name" {
+    description = "The Vault cluster seal key name"
+    value       = step.create_seal_key.resource_name
   }
 
   output "ui_test_environment" {

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -16,6 +16,7 @@ scenario "upgrade" {
     // those earlier versions.
     initial_version = ["1.11.12", "1.12.11", "1.13.6", "1.14.2"]
     seal            = ["awskms", "shamir"]
+    seal_ha_beta    = ["true", "false"]
 
     # Our local builder always creates bundles
     exclude {
@@ -93,6 +94,15 @@ scenario "upgrade" {
     }
   }
 
+  step "create_seal_key" {
+    module = "seal_key_${matrix.seal}"
+
+    variables {
+      cluster_id  = step.create_vpc.cluster_id
+      common_tags = global.tags
+    }
+  }
+
   // This step reads the contents of the backend license if we're using a Consul backend and
   // the edition is "ent".
   step "read_backend_license" {
@@ -122,11 +132,11 @@ scenario "upgrade" {
     }
 
     variables {
-      ami_id                = step.ec2_info.ami_ids[matrix.arch][matrix.distro][global.distro_version[matrix.distro]]
-      awskms_unseal_key_arn = step.create_vpc.kms_key_arn
-      cluster_tag_key       = global.vault_tag_key
-      common_tags           = global.tags
-      vpc_id                = step.create_vpc.vpc_id
+      ami_id          = step.ec2_info.ami_ids[matrix.arch][matrix.distro][global.distro_version[matrix.distro]]
+      cluster_tag_key = global.vault_tag_key
+      common_tags     = global.tags
+      seal_key_names  = step.create_seal_key.resource_names
+      vpc_id          = step.create_vpc.id
     }
   }
 
@@ -139,11 +149,11 @@ scenario "upgrade" {
     }
 
     variables {
-      ami_id                = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
-      awskms_unseal_key_arn = step.create_vpc.kms_key_arn
-      cluster_tag_key       = global.backend_tag_key
-      common_tags           = global.tags
-      vpc_id                = step.create_vpc.vpc_id
+      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      cluster_tag_key = global.backend_tag_key
+      common_tags     = global.tags
+      seal_key_names  = step.create_seal_key.resource_names
+      vpc_id          = step.create_vpc.id
     }
   }
 
@@ -182,7 +192,6 @@ scenario "upgrade" {
     }
 
     variables {
-      awskms_unseal_key_arn   = step.create_vpc.kms_key_arn
       backend_cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       backend_cluster_tag_key = global.backend_tag_key
       consul_license          = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
@@ -199,9 +208,11 @@ scenario "upgrade" {
         edition = matrix.edition
         version = matrix.initial_version
       }
+      seal_ha_beta    = matrix.seal_ha_beta
+      seal_key_name   = step.create_seal_key.resource_name
+      seal_type       = matrix.seal
       storage_backend = matrix.backend
       target_hosts    = step.create_vault_cluster_targets.hosts
-      unseal_method   = matrix.seal
     }
   }
 
@@ -413,11 +424,6 @@ scenario "upgrade" {
     value       = step.create_vault_cluster.audit_device_file_path
   }
 
-  output "awskms_unseal_key_arn" {
-    description = "The Vault cluster KMS key arn"
-    value       = step.create_vpc.kms_key_arn
-  }
-
   output "cluster_name" {
     description = "The Vault cluster name"
     value       = step.create_vault_cluster.cluster_name
@@ -456,6 +462,11 @@ scenario "upgrade" {
   output "recovery_keys_hex" {
     description = "The Vault cluster recovery keys hex"
     value       = step.create_vault_cluster.recovery_keys_hex
+  }
+
+  output "seal_key_name" {
+    description = "The Vault cluster seal key name"
+    value       = step.create_seal_key.resource_name
   }
 
   output "unseal_keys_b64" {

--- a/enos/modules/create_vpc/main.tf
+++ b/enos/modules/create_vpc/main.tf
@@ -18,18 +18,6 @@ resource "random_string" "cluster_id" {
   special = false
 }
 
-resource "aws_kms_key" "key" {
-  count                   = var.create_kms_key ? 1 : 0
-  description             = "vault-ci-kms-key"
-  deletion_window_in_days = 7 // 7 is the shortest allowed window
-}
-
-resource "aws_kms_alias" "alias" {
-  count         = var.create_kms_key ? 1 : 0
-  name          = "alias/enos_key-${random_string.cluster_id.result}"
-  target_key_id = aws_kms_key.key[0].key_id
-}
-
 resource "aws_vpc" "vpc" {
   cidr_block           = var.cidr
   enable_dns_hostnames = true

--- a/enos/modules/create_vpc/outputs.tf
+++ b/enos/modules/create_vpc/outputs.tf
@@ -1,22 +1,17 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-output "vpc_id" {
+output "id" {
   description = "Created VPC ID"
   value       = aws_vpc.vpc.id
 }
 
-output "vpc_cidr" {
+output "cidr" {
   description = "CIDR for whole VPC"
   value       = var.cidr
 }
 
-output "kms_key_arn" {
-  description = "ARN of the generated KMS key"
-  value       = try(aws_kms_key.key[0].arn, null)
-}
-
-output "kms_key_alias" {
-  description = "Alias of the generated KMS key"
-  value       = try(aws_kms_alias.alias[0].name, null)
+output "cluster_id" {
+  description = "A unique string associated with the VPC"
+  value       = random_string.cluster_id.result
 }

--- a/enos/modules/create_vpc/variables.tf
+++ b/enos/modules/create_vpc/variables.tf
@@ -24,9 +24,3 @@ variable "common_tags" {
   type        = map(string)
   default     = { "Project" : "vault-ci" }
 }
-
-variable "create_kms_key" {
-  description = "Whether or not to create an key management service key"
-  type        = bool
-  default     = true
-}

--- a/enos/modules/seal_key_awskms/main.tf
+++ b/enos/modules/seal_key_awskms/main.tf
@@ -1,0 +1,56 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+variable "cluster_id" {
+  type = string
+}
+
+variable "cluster_meta" {
+  type    = string
+  default = null
+}
+
+variable "common_tags" {
+  type    = map(string)
+  default = null
+}
+
+variable "other_resources" {
+  type    = list(string)
+  default = []
+}
+
+locals {
+  cluster_name = var.cluster_meta == null ? var.cluster_id : "${var.cluster_id}-${var.cluster_meta}"
+}
+
+resource "aws_kms_key" "key" {
+  description             = "auto-unseal-key-${local.cluster_name}"
+  deletion_window_in_days = 7 // 7 is the shortest allowed window
+  tags                    = var.common_tags
+}
+
+resource "aws_kms_alias" "alias" {
+  name          = "alias/auto-unseal-key-${local.cluster_name}"
+  target_key_id = aws_kms_key.key.key_id
+}
+
+output "alias" {
+  description = "The key alias name"
+  value       = aws_kms_alias.alias.name
+}
+
+output "id" {
+  description = "The key ID"
+  value       = aws_kms_key.key.key_id
+}
+
+output "resource_name" {
+  description = "The ARN"
+  value       = aws_kms_key.key.arn
+}
+
+output "resource_names" {
+  description = "The list of names"
+  value       = compact(concat([aws_kms_key.key.arn], var.other_resources))
+}

--- a/enos/modules/seal_key_shamir/main.tf
+++ b/enos/modules/seal_key_shamir/main.tf
@@ -1,0 +1,17 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+# A shim unseal key module for shamir seal types
+
+variable "cluster_id" { default = null }
+variable "cluster_meta" { default = null }
+variable "common_tags" { default = null }
+variable "names" {
+  type    = list(string)
+  default = []
+}
+
+output "alias" { value = null }
+output "id" { value = null }
+output "resource_name" { value = null }
+output "resource_names" { value = var.names }

--- a/enos/modules/start_vault/main.tf
+++ b/enos/modules/start_vault/main.tf
@@ -1,0 +1,167 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+terraform {
+  required_providers {
+    # We need to specify the provider source in each module until we publish it
+    # to the public registry
+    enos = {
+      source  = "app.terraform.io/hashicorp-qti/enos"
+      version = ">= 0.4.7"
+    }
+  }
+}
+
+data "enos_environment" "localhost" {}
+
+locals {
+  bin_path = "${var.install_dir}/vault"
+  environment = local.seal_secondary == null ? var.environment : merge(
+    var.environment,
+    { VAULT_ENABLE_SEAL_HA_BETA : tobool(var.seal_ha_beta) },
+  )
+  // In order to get Terraform to plan we have to use collections with keys
+  // that are known at plan time. In order for our module to work our var.target_hosts
+  // must be a map with known keys at plan time. Here we're creating locals
+  // that keep track of index values that point to our target hosts.
+  followers = toset(slice(local.instances, 1, length(local.instances)))
+  instances = [for idx in range(length(var.target_hosts)) : tostring(idx)]
+  key_shares = {
+    "awskms" = null
+    "shamir" = 5
+  }
+  key_threshold = {
+    "awskms" = null
+    "shamir" = 3
+  }
+  leader = toset(slice(local.instances, 0, 1))
+  recovery_shares = {
+    "awskms" = 5
+    "shamir" = null
+  }
+  recovery_threshold = {
+    "awskms" = 3
+    "shamir" = null
+  }
+  seals = local.seal_secondary.type == "none" ? { primary = local.seal_primary } : {
+    primary   = local.seal_primary
+    secondary = local.seal_secondary
+  }
+  seals_primary = {
+    "awskms" = {
+      type = "awskms"
+      attributes = {
+        name       = "primary"
+        kms_key_id = var.seal_key_name
+      }
+    }
+    "shamir" = {
+      type       = "shamir"
+      attributes = null
+    }
+  }
+  seal_primary = local.seals_primary[var.seal_type]
+  seals_secondary = {
+    "awskms" = {
+      type = "awskms"
+      attributes = {
+        name       = "secondary"
+        kms_key_id = var.seal_key_name_secondary
+      }
+    }
+    "none" = {
+      type       = "none"
+      attributes = null
+    }
+  }
+  seal_secondary = local.seals_secondary[var.seal_type_secondary]
+  storage_config = [for idx, host in var.target_hosts : (var.storage_backend == "raft" ?
+    merge(
+      {
+        node_id = "${var.storage_node_prefix}_${idx}"
+      },
+      var.storage_backend_attrs
+    ) :
+    {
+      address = "127.0.0.1:8500"
+      path    = "vault"
+    })
+  ]
+}
+
+resource "enos_vault_start" "leader" {
+  for_each = local.leader
+
+  bin_path    = local.bin_path
+  config_dir  = var.config_dir
+  environment = local.environment
+  config = {
+    api_addr     = "http://${var.target_hosts[each.value].private_ip}:8200"
+    cluster_addr = "http://${var.target_hosts[each.value].private_ip}:8201"
+    cluster_name = var.cluster_name
+    listener = {
+      type = "tcp"
+      attributes = {
+        address     = "0.0.0.0:8200"
+        tls_disable = "true"
+      }
+    }
+    log_level = var.log_level
+    storage = {
+      type       = var.storage_backend
+      attributes = ({ for key, value in local.storage_config[each.key] : key => value })
+    }
+    seals = local.seals
+    ui    = true
+  }
+  license        = var.license
+  manage_service = var.manage_service
+  username       = var.service_username
+  unit_name      = "vault"
+
+  transport = {
+    ssh = {
+      host = var.target_hosts[each.value].public_ip
+    }
+  }
+}
+
+resource "enos_vault_start" "followers" {
+  depends_on = [
+    enos_vault_start.leader,
+  ]
+  for_each = local.followers
+
+  bin_path    = local.bin_path
+  config_dir  = var.config_dir
+  environment = local.environment
+  config = {
+    api_addr     = "http://${var.target_hosts[each.value].private_ip}:8200"
+    cluster_addr = "http://${var.target_hosts[each.value].private_ip}:8201"
+    cluster_name = var.cluster_name
+    listener = {
+      type = "tcp"
+      attributes = {
+        address     = "0.0.0.0:8200"
+        tls_disable = "true"
+      }
+    }
+    log_level = var.log_level
+    storage = {
+      type       = var.storage_backend
+      attributes = { for key, value in local.storage_config[each.key] : key => value }
+    }
+    seals = local.seals
+    ui    = true
+  }
+  license        = var.license
+  manage_service = var.manage_service
+  username       = var.service_username
+  unit_name      = "vault"
+
+  transport = {
+    ssh = {
+      host = var.target_hosts[each.value].public_ip
+    }
+  }
+}

--- a/enos/modules/start_vault/outputs.tf
+++ b/enos/modules/start_vault/outputs.tf
@@ -1,0 +1,33 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+output "cluster_name" {
+  description = "The Vault cluster name"
+  value       = var.cluster_name
+}
+
+output "followers" {
+  description = "The follower enos_vault_start resources"
+  value       = enos_vault_start.followers
+}
+
+output "leader" {
+  description = "The leader enos_vault_start resource"
+  value       = enos_vault_start.leader
+}
+
+output "private_ips" {
+  description = "Vault cluster target host private_ips"
+  value       = [for host in var.target_hosts : host.private_ip]
+}
+
+output "public_ips" {
+  description = "Vault cluster target host public_ips"
+  value       = [for host in var.target_hosts : host.public_ip]
+}
+
+output "target_hosts" {
+  description = "The vault cluster instances that were created"
+
+  value = var.target_hosts
+}

--- a/enos/modules/start_vault/variables.tf
+++ b/enos/modules/start_vault/variables.tf
@@ -1,33 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-variable "artifactory_release" {
-  type = object({
-    username = string
-    token    = string
-    url      = string
-    sha256   = string
-  })
-  description = "The Artifactory release information to install Vault artifacts from Artifactory"
-  default     = null
-}
-
-variable "backend_cluster_name" {
-  type        = string
-  description = "The name of the backend cluster"
-  default     = null
-}
-
-variable "backend_cluster_tag_key" {
-  type        = string
-  description = "The tag key for searching for backend nodes"
-  default     = null
-}
-
 variable "cluster_name" {
   type        = string
   description = "The Vault cluster name"
-  default     = null
 }
 
 variable "config_dir" {
@@ -36,76 +12,10 @@ variable "config_dir" {
   default     = "/etc/vault.d"
 }
 
-variable "config_env_vars" {
+variable "environment" {
   description = "Optional Vault configuration environment variables to set starting Vault"
   type        = map(string)
   default     = null
-}
-
-variable "consul_data_dir" {
-  type        = string
-  description = "The directory where the consul will store data"
-  default     = "/opt/consul/data"
-}
-
-variable "consul_install_dir" {
-  type        = string
-  description = "The directory where the consul binary will be installed"
-  default     = "/opt/consul/bin"
-}
-
-variable "consul_license" {
-  type        = string
-  sensitive   = true
-  description = "The consul enterprise license"
-  default     = null
-}
-
-variable "consul_log_file" {
-  type        = string
-  description = "The file where the consul will write log output"
-  default     = "/var/log/consul.log"
-}
-
-variable "consul_log_level" {
-  type        = string
-  description = "The consul service log level"
-  default     = "info"
-
-  validation {
-    condition     = contains(["trace", "debug", "info", "warn", "error"], var.consul_log_level)
-    error_message = "The consul_log_level must be one of 'trace', 'debug', 'info', 'warn', or 'error'."
-  }
-}
-
-variable "consul_release" {
-  type = object({
-    version = string
-    edition = string
-  })
-  description = "Consul release version and edition to install from releases.hashicorp.com"
-  default = {
-    version = "1.15.1"
-    edition = "ce"
-  }
-}
-
-variable "enable_audit_devices" {
-  description = "If true every audit device will be enabled"
-  type        = bool
-  default     = true
-}
-
-variable "force_unseal" {
-  type        = bool
-  description = "Always unseal the Vault cluster even if we're not initializing it"
-  default     = false
-}
-
-variable "initialize_cluster" {
-  type        = bool
-  description = "Initialize the Vault cluster"
-  default     = true
 }
 
 variable "install_dir" {
@@ -118,12 +28,6 @@ variable "license" {
   type        = string
   sensitive   = true
   description = "The value of the Vault license"
-  default     = null
-}
-
-variable "local_artifact_path" {
-  type        = string
-  description = "The path to a locally built vault artifact to install. It can be a zip archive, RPM, or Debian package"
   default     = null
 }
 
@@ -142,27 +46,6 @@ variable "manage_service" {
   type        = bool
   description = "Manage the Vault service users and systemd unit. Disable this to use configuration in RPM and Debian packages"
   default     = true
-}
-
-variable "packages" {
-  type        = list(string)
-  description = "A list of packages to install via the target host package manager"
-  default     = []
-}
-
-variable "release" {
-  type = object({
-    version = string
-    edition = string
-  })
-  description = "Vault release version and edition to install from releases.hashicorp.com"
-  default     = null
-}
-
-variable "root_token" {
-  type        = string
-  description = "The Vault root token that we can use to intialize and configure the cluster"
-  default     = null
 }
 
 variable "seal_ha_beta" {
@@ -204,10 +87,10 @@ variable "seal_type_secondary" {
   }
 }
 
-variable "shamir_unseal_keys" {
-  type        = list(string)
-  description = "Shamir unseal keys. Often only used adding additional nodes to an already initialized cluster."
-  default     = null
+variable "service_username" {
+  type        = string
+  description = "The host username to own the vault service"
+  default     = "vault"
 }
 
 variable "storage_backend" {
@@ -221,7 +104,7 @@ variable "storage_backend" {
   }
 }
 
-variable "storage_backend_addl_config" {
+variable "storage_backend_attrs" {
   type        = map(any)
   description = "An optional set of key value pairs to inject into the storage block"
   default     = {}

--- a/enos/modules/stop_vault/main.tf
+++ b/enos/modules/stop_vault/main.tf
@@ -1,0 +1,38 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+terraform {
+  required_providers {
+    # We need to specify the provider source in each module until we publish it
+    # to the public registry
+    enos = {
+      source  = "app.terraform.io/hashicorp-qti/enos"
+      version = ">= 0.4.0"
+    }
+  }
+}
+
+variable "service_name" {
+  type        = string
+  description = "The Vault systemd service name"
+  default     = "vault"
+}
+
+variable "target_hosts" {
+  description = "The target machines host addresses to use for the Vault cluster"
+  type = map(object({
+    private_ip = string
+    public_ip  = string
+  }))
+}
+
+resource "enos_remote_exec" "shutdown_multiple_nodes" {
+  for_each = var.target_hosts
+  inline   = ["sudo systemctl stop ${var.service_name}.service; sleep 5"]
+
+  transport = {
+    ssh = {
+      host = each.value.public_ip
+    }
+  }
+}

--- a/enos/modules/target_ec2_fleet/main.tf
+++ b/enos/modules/target_ec2_fleet/main.tf
@@ -23,10 +23,6 @@ data "aws_subnets" "vpc" {
   }
 }
 
-data "aws_kms_key" "kms_key" {
-  key_id = var.awskms_unseal_key_arn
-}
-
 data "aws_iam_policy_document" "target" {
   statement {
     resources = ["*"]
@@ -37,16 +33,20 @@ data "aws_iam_policy_document" "target" {
     ]
   }
 
-  statement {
-    resources = [var.awskms_unseal_key_arn]
+  dynamic "statement" {
+    for_each = var.seal_key_names
 
-    actions = [
-      "kms:DescribeKey",
-      "kms:ListKeys",
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:GenerateDataKey"
-    ]
+    content {
+      resources = [statement.value]
+
+      actions = [
+        "kms:DescribeKey",
+        "kms:ListKeys",
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:GenerateDataKey"
+      ]
+    }
   }
 }
 

--- a/enos/modules/target_ec2_fleet/variables.tf
+++ b/enos/modules/target_ec2_fleet/variables.tf
@@ -6,12 +6,6 @@ variable "ami_id" {
   type        = string
 }
 
-variable "awskms_unseal_key_arn" {
-  type        = string
-  description = "The AWSKMS key ARN if using the awskms unseal method. If specified the instances will be granted kms permissions to the key"
-  default     = null
-}
-
 variable "cluster_name" {
   type        = string
   description = "A unique cluster identifier"
@@ -71,6 +65,12 @@ variable "max_price" {
 variable "project_name" {
   description = "A unique project name"
   type        = string
+}
+
+variable "seal_key_names" {
+  type        = list(string)
+  description = "The key management seal key names"
+  default     = null
 }
 
 variable "ssh_allow_ips" {

--- a/enos/modules/target_ec2_instances/main.tf
+++ b/enos/modules/target_ec2_instances/main.tf
@@ -53,10 +53,6 @@ data "aws_subnets" "vpc" {
   }
 }
 
-data "aws_kms_key" "kms_key" {
-  key_id = var.awskms_unseal_key_arn
-}
-
 data "aws_iam_policy_document" "target" {
   statement {
     resources = ["*"]
@@ -67,16 +63,20 @@ data "aws_iam_policy_document" "target" {
     ]
   }
 
-  statement {
-    resources = [var.awskms_unseal_key_arn]
+  dynamic "statement" {
+    for_each = var.seal_key_names
 
-    actions = [
-      "kms:DescribeKey",
-      "kms:ListKeys",
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:GenerateDataKey"
-    ]
+    content {
+      resources = [statement.value]
+
+      actions = [
+        "kms:DescribeKey",
+        "kms:ListKeys",
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:GenerateDataKey"
+      ]
+    }
   }
 }
 

--- a/enos/modules/target_ec2_instances/variables.tf
+++ b/enos/modules/target_ec2_instances/variables.tf
@@ -6,12 +6,6 @@ variable "ami_id" {
   type        = string
 }
 
-variable "awskms_unseal_key_arn" {
-  type        = string
-  description = "The AWSKMS key ARN if using the awskms unseal method. If specified the instances will be granted kms permissions to the key"
-  default     = null
-}
-
 variable "cluster_name" {
   type        = string
   description = "A unique cluster identifier"
@@ -51,6 +45,12 @@ variable "instance_types" {
 variable "project_name" {
   description = "A unique project name"
   type        = string
+}
+
+variable "seal_key_names" {
+  type        = list(string)
+  description = "The key management seal key names"
+  default     = null
 }
 
 variable "ssh_allow_ips" {

--- a/enos/modules/target_ec2_shim/main.tf
+++ b/enos/modules/target_ec2_shim/main.tf
@@ -13,7 +13,6 @@ terraform {
 }
 
 variable "ami_id" { default = null }
-variable "awskms_unseal_key_arn" { default = null }
 variable "cluster_name" { default = null }
 variable "cluster_tag_key" { default = null }
 variable "common_tags" { default = null }
@@ -25,6 +24,7 @@ variable "instance_mem_min" { default = null }
 variable "instance_types" { default = null }
 variable "max_price" { default = null }
 variable "project_name" { default = null }
+variable "seal_key_names" { default = null }
 variable "ssh_allow_ips" { default = null }
 variable "ssh_keypair" { default = null }
 variable "vpc_id" { default = null }

--- a/enos/modules/target_ec2_spot_fleet/main.tf
+++ b/enos/modules/target_ec2_spot_fleet/main.tf
@@ -23,10 +23,6 @@ data "aws_subnets" "vpc" {
   }
 }
 
-data "aws_kms_key" "kms_key" {
-  key_id = var.awskms_unseal_key_arn
-}
-
 data "aws_iam_policy_document" "target" {
   statement {
     resources = ["*"]
@@ -37,16 +33,20 @@ data "aws_iam_policy_document" "target" {
     ]
   }
 
-  statement {
-    resources = [var.awskms_unseal_key_arn]
+  dynamic "statement" {
+    for_each = var.seal_key_names
 
-    actions = [
-      "kms:DescribeKey",
-      "kms:ListKeys",
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:GenerateDataKey"
-    ]
+    content {
+      resources = [statement.value]
+
+      actions = [
+        "kms:DescribeKey",
+        "kms:ListKeys",
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:GenerateDataKey"
+      ]
+    }
   }
 }
 

--- a/enos/modules/target_ec2_spot_fleet/variables.tf
+++ b/enos/modules/target_ec2_spot_fleet/variables.tf
@@ -6,12 +6,6 @@ variable "ami_id" {
   type        = string
 }
 
-variable "awskms_unseal_key_arn" {
-  type        = string
-  description = "The AWSKMS key ARN if using the awskms unseal method. If specified the instances will be granted kms permissions to the key"
-  default     = null
-}
-
 variable "cluster_name" {
   type        = string
   description = "A unique cluster identifier"
@@ -71,6 +65,12 @@ variable "max_price" {
   description = "The maximum hourly price to pay for each target instance"
   type        = string
   default     = "0.0416"
+}
+
+variable "seal_key_names" {
+  type        = list(string)
+  description = "The key management seal key names"
+  default     = null
 }
 
 variable "ssh_allow_ips" {

--- a/enos/modules/vault_wait_for_leader/scripts/wait-for-leader.sh
+++ b/enos/modules/vault_wait_for_leader/scripts/wait-for-leader.sh
@@ -23,14 +23,14 @@ test -x "$binpath" || fail "unable to locate vault binary at $binpath"
 findLeaderInPrivateIPs() {
   # Find the leader private IP address
   local leader_private_ip
-  if ! leader_private_ip=$($binpath read sys/leader -format=json | jq -r '.data.leader_address | scan("[0-9]+.[0-9]+.[0-9]+.[0-9]+")') ; then
+  if ! leader_private_ip=$($binpath read sys/leader -format=json | jq -er '.data.leader_address | scan("[0-9]+.[0-9]+.[0-9]+.[0-9]+")') ; then
     # Some older versions of vault don't support reading sys/leader. Fallback to the cli status.
-    if leader_private_ip=$($binpath status -format json | jq '.leader_address | scan("[0-9]+.[0-9]+.[0-9]+.[0-9]+")'); then
+    if ! leader_private_ip=$($binpath status -format json | jq -er '.leader_address | scan("[0-9]+.[0-9]+.[0-9]+.[0-9]+")'); then
       return 1
     fi
   fi
 
-  if isIn=$(jq -r --arg ip "$leader_private_ip" 'map(select(. == $ip)) | length == 1' <<< "$VAULT_INSTANCE_PRIVATE_IPS"); then
+  if isIn=$(jq -er --arg ip "$leader_private_ip" 'map(select(. == $ip)) | length == 1' <<< "$VAULT_INSTANCE_PRIVATE_IPS"); then
     if [[ "$isIn" == "true" ]]; then
       echo "$leader_private_ip"
       return 0

--- a/enos/modules/vault_wait_for_seal_rewrap/main.tf
+++ b/enos/modules/vault_wait_for_seal_rewrap/main.tf
@@ -1,0 +1,67 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+terraform {
+  required_providers {
+    enos = {
+      source = "app.terraform.io/hashicorp-qti/enos"
+    }
+  }
+}
+
+variable "vault_install_dir" {
+  type        = string
+  description = "The directory where the Vault binary will be installed"
+}
+
+variable "vault_root_token" {
+  type        = string
+  description = "The vault root token"
+}
+
+variable "vault_instance_count" {
+  type        = number
+  description = "The number of instances in the vault cluster"
+}
+
+variable "vault_hosts" {
+  type = map(object({
+    private_ip = string
+    public_ip  = string
+  }))
+  description = "The vault cluster hosts that can be expected as a leader"
+}
+
+variable "timeout" {
+  type        = number
+  description = "The max number of seconds to wait before timing out"
+  default     = 60
+}
+
+variable "retry_interval" {
+  type        = number
+  description = "How many seconds to wait between each retry"
+  default     = 2
+}
+
+locals {
+  private_ips = [for k, v in values(tomap(var.vault_hosts)) : tostring(v["private_ip"])]
+}
+
+resource "enos_remote_exec" "wait_for_seal_rewrap_to_be_completed" {
+  environment = {
+    RETRY_INTERVAL    = var.retry_interval
+    TIMEOUT_SECONDS   = var.timeout
+    VAULT_ADDR        = "http://127.0.0.1:8200"
+    VAULT_TOKEN       = var.vault_root_token
+    VAULT_INSTALL_DIR = var.vault_install_dir
+  }
+
+  scripts = [abspath("${path.module}/scripts/wait-for-seal-rewrap.sh")]
+
+  transport = {
+    ssh = {
+      host = var.vault_hosts[0].public_ip
+    }
+  }
+}

--- a/enos/modules/vault_wait_for_seal_rewrap/scripts/wait-for-seal-rewrap.sh
+++ b/enos/modules/vault_wait_for_seal_rewrap/scripts/wait-for-seal-rewrap.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+
+set -e
+
+fail() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+[[ -z "$RETRY_INTERVAL" ]] && fail "RETRY_INTERVAL env variable has not been set"
+[[ -z "$TIMEOUT_SECONDS" ]] && fail "TIMEOUT_SECONDS env variable has not been set"
+[[ -z "$VAULT_ADDR" ]] && fail "VAULT_ADDR env variable has not been set"
+[[ -z "$VAULT_INSTALL_DIR" ]] && fail "VAULT_INSTALL_DIR env variable has not been set"
+[[ -z "$VAULT_TOKEN" ]] && fail "VAULT_TOKEN env variable has not been set"
+
+binpath=${VAULT_INSTALL_DIR}/vault
+test -x "$binpath" || fail "unable to locate vault binary at $binpath"
+
+getRewrapData() {
+  $binpath read sys/sealwrap/rewrap -format=json | jq -eMc '.data'
+}
+
+waitForRewrap() {
+  local data
+  if ! data=$(getRewrapData); then
+    echo "failed getting /v1/sys/sealwrap/rewrap data" 1>&2
+    return 1
+  fi
+
+  if ! jq -e '.is_running == false' <<< "$data" &> /dev/null; then
+    echo "rewrap is running" 1>&2
+    return 1
+  fi
+
+  if ! jq -e '.entries.failed == 0' <<< "$data" &> /dev/null; then
+    local entries
+    entries=$(jq -Mc '.entries.failed' <<< "$data")
+    echo "rewrap has $entries failed entries" 1>&2
+    return 1
+  fi
+
+  if ! jq -e '.entries.processed == .entries.succeeded' <<< "$data" &> /dev/null; then
+    local processed
+    local succeeded
+    processed=$(jq -Mc '.entries.processed' <<< "$data")
+    succeeded=$(jq -Mc '.entries.succeeded' <<< "$data")
+    echo "the number of processed entries ($processed) does not equal then number of succeeded ($succeeded)" 1>&2
+    return 1
+  fi
+
+  return 0
+}
+
+begin_time=$(date +%s)
+end_time=$((begin_time + TIMEOUT_SECONDS))
+while [ "$(date +%s)" -lt "$end_time" ]; do
+  if waitForRewrap; then
+    exit 0
+  fi
+
+  sleep "$RETRY_INTERVAL"
+done
+
+fail "Timed out waiting for seal rewrap to be completed. Data:\n\t$(getRewrapData)"


### PR DESCRIPTION
Add support for testing Vault Enterprise with HA seal support by adding a new `seal_ha` scenario that configures more than one seal type for a Vault cluster. We also extend existing scenarios to support testing with or without the Seal HA code path enabled.

* Extract starting vault into a separate enos module to allow for better handling of complex clusters that need to be started more than once.
* Extract seal key creation into a separate module and provide it to target modules. This allows us to create more than one seal key and associate it with instances. This also allows us to forego creating keys when using shamir seals.
* [QT-615] Add support for configuring more that one seal type to `vault_cluster` module.
* [QT-616] Add `seal_ha` scenario
* [QT-625] Add `seal_ha_beta` variant to existing scenarios to test with both code paths.
* Unpin action-setup-terraform

[QT-615]: https://hashicorp.atlassian.net/browse/QT-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QT-616]: https://hashicorp.atlassian.net/browse/QT-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QT-625]: https://hashicorp.atlassian.net/browse/QT-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ