### PR TITLE
Add documentation for new ldap param

### DIFF
--- a/website/content/api-docs/secret/ldap.mdx
+++ b/website/content/api-docs/secret/ldap.mdx
@@ -64,7 +64,8 @@ to search and change entry passwords in LDAP.
   PEM encoded.
 - `client_tls_key` `(string: <optional>)` - Client key to provide to the LDAP server, must be x509 PEM encoded.
 - `skip_static_role_import_rotation` `(string: <boolean>)` - The default value to use for `skip_import_rotation` when
-  creating static roles. See the [static roles section](#static-roles) for more detailed information and caveats.
+  creating static roles. This value defaults to false. This field can be overridden on an individual role level during
+  [role creation](#static-roles). See the [static roles section](#static-roles) for more detailed information and caveats.
 
 **Deprecated Parameters**:
 
@@ -185,7 +186,8 @@ The `static-role` endpoint configures Vault to manage the passwords of existing 
   **Example:** `"3600", "5s", "1h"`
 - `skip_import_rotation` `(boolean: <optional>)` - When set on a role creation request, Vault will not rotate the
   pre-existing password of the associated LDAP entry. Note: This means that Vault will not be able to supply the
-  password to `GET` requests until the password is rotated (either automatically or manually by `rotate-role`)
+  password to `GET` requests until the password is rotated (either automatically or manually by `rotate-role`). This
+  field overrides `skip_static_role_import_rotation` from the ldap config if both are set.
 
 ### Sample payload
 

--- a/website/content/api-docs/secret/ldap.mdx
+++ b/website/content/api-docs/secret/ldap.mdx
@@ -63,9 +63,9 @@ to search and change entry passwords in LDAP.
 - `client_tls_cert` `(string: <optional>)` - Client certificate to provide to the LDAP server, must be x509
   PEM encoded.
 - `client_tls_key` `(string: <optional>)` - Client key to provide to the LDAP server, must be x509 PEM encoded.
-- `skip_static_role_import_rotation` `(bool: <optional>)` - The default value to use for `skip_import_rotation` when
-  creating static roles. This value defaults to false. This field can be overridden on an individual role level during
-  [role creation](#static-roles). See the [static roles section](#static-roles) for more detailed information and caveats.
+- `skip_static_role_import_rotation` `(bool: false)` - The default value to use for `skip_import_rotation` when
+  creating static roles. This field can be overridden on an individual role level during [role creation](#static-roles).
+  See the [static roles section](#static-roles) for more detailed information and caveats.
 
 **Deprecated Parameters**:
 
@@ -184,7 +184,7 @@ The `static-role` endpoint configures Vault to manage the passwords of existing 
 - `rotation_period` `(string: <required>)` - How often Vault should rotate the password of the user entry. Accepts
   [duration format strings](/vault/docs/concepts/duration-format). The minimum rotation period is 5 seconds.<br />
   **Example:** `"3600", "5s", "1h"`
-- `skip_import_rotation` `(boolean: <optional>)` - When set on a role creation request, Vault will not rotate the
+- `skip_import_rotation` `(boolean: false)` - When set on a role creation request, Vault will not rotate the
   pre-existing password of the associated LDAP entry. Note: This means that Vault will not be able to supply the
   password to `GET` requests until the password is rotated (either automatically or manually by `rotate-role`). This
   field overrides `skip_static_role_import_rotation` from the ldap config if both are set.

--- a/website/content/api-docs/secret/ldap.mdx
+++ b/website/content/api-docs/secret/ldap.mdx
@@ -63,7 +63,7 @@ to search and change entry passwords in LDAP.
 - `client_tls_cert` `(string: <optional>)` - Client certificate to provide to the LDAP server, must be x509
   PEM encoded.
 - `client_tls_key` `(string: <optional>)` - Client key to provide to the LDAP server, must be x509 PEM encoded.
-- `skip_static_role_import_rotation` `(string: <boolean>)` - The default value to use for `skip_import_rotation` when
+- `skip_static_role_import_rotation` `(bool: <optional>)` - The default value to use for `skip_import_rotation` when
   creating static roles. This value defaults to false. This field can be overridden on an individual role level during
   [role creation](#static-roles). See the [static roles section](#static-roles) for more detailed information and caveats.
 

--- a/website/content/api-docs/secret/ldap.mdx
+++ b/website/content/api-docs/secret/ldap.mdx
@@ -63,6 +63,8 @@ to search and change entry passwords in LDAP.
 - `client_tls_cert` `(string: <optional>)` - Client certificate to provide to the LDAP server, must be x509
   PEM encoded.
 - `client_tls_key` `(string: <optional>)` - Client key to provide to the LDAP server, must be x509 PEM encoded.
+- `skip_static_role_import_rotation` `(string: <boolean>)` - The default value to use for `skip_import_rotation` when
+  creating static roles. See the [static roles section](#static-roles) for more detailed information and caveats.
 
 **Deprecated Parameters**:
 
@@ -181,6 +183,9 @@ The `static-role` endpoint configures Vault to manage the passwords of existing 
 - `rotation_period` `(string: <required>)` - How often Vault should rotate the password of the user entry. Accepts
   [duration format strings](/vault/docs/concepts/duration-format). The minimum rotation period is 5 seconds.<br />
   **Example:** `"3600", "5s", "1h"`
+- `skip_import_rotation` `(boolean: <optional>)` - When set on a role creation request, Vault will not rotate the
+  pre-existing password of the associated LDAP entry. Note: This means that Vault will not be able to supply the
+  password to `GET` requests until the password is rotated (either automatically or manually by `rotate-role`)
 
 ### Sample payload
 


### PR DESCRIPTION
This is the doc-side update for the addition of a new parameter to the LDAP secrets engine. The new parameter will allow users to skip the initial rotation that Vault does when adding a new static role. See [the feature PR](https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/83) for more information.

This PR should be merged after that PR, or I suppose at the same time.