### PR TITLE
Update link for MongoDB Atlas database secrets engine

### DIFF
--- a/website/content/docs/secrets/mongodbatlas.mdx
+++ b/website/content/docs/secrets/mongodbatlas.mdx
@@ -16,12 +16,14 @@ project or organization with appropriate role(s). The MongoDB Atlas Programmatic
 Private Keys are returned to the caller. To learn more about Programmatic API Keys visit the
 [Programmatic API Keys Doc](https://docs.atlas.mongodb.com/reference/api-docs/apiKeys/).
 
-<Note>
+  <Note>
+
   The information below relates to the **MongoDB Altas secrets engine**. Refer to the
   [MongoDB Atlas **database** secrets engine](/vault/docs/secrets/databases/mongodbatlas)
   for information about using the MongoDB Atlas database plugin for the Vault
   database secrets engine.
-</Note>
+
+  </Note>
 
 ## Setup
 

--- a/website/content/docs/secrets/mongodbatlas.mdx
+++ b/website/content/docs/secrets/mongodbatlas.mdx
@@ -17,8 +17,8 @@ Private Keys are returned to the caller. To learn more about Programmatic API Ke
 [Programmatic API Keys Doc](https://docs.atlas.mongodb.com/reference/api-docs/apiKeys/).
 
 <Note>
-  The information below relates to the MongoDB Altas <b>secrets engine</b>. Refer to the
-  <a href="vault/docs/secrets/databases/mongodbatlas">MongoDB Atlas database secrets engine</a>
+  The information below relates to the **MongoDB Altas secrets engine**. Refer to the
+  [MongoDB Atlas **database** secrets engine](/vault/docs/secrets/databases/mongodbatlas)
   for information about using the MongoDB Atlas database plugin for the Vault
   database secrets engine.
 </Note>


### PR DESCRIPTION
Update link format to MongoDB Atlas database secrets engine
Backport to 1.15 and 1.14 only as the note does not exist in 1.13 or earlier