### PR TITLE
Fix backticks for cluster_aia_path

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -2923,7 +2923,7 @@ do so, import a new issuer and a new `issuer_id` will be assigned.
   `{{issuer_id}}` with the ID of the issuer doing the issuance, the
   literal value `{{cluster_path}}` with the value of `path` from the
   cluster-local configuration endpoint `/config/cluster`, and the
-  literal value '{{cluster_aia_path}}' with the value of `aia_path` from
+  literal value `{{cluster_aia_path}}` with the value of `aia_path` from
   the cluster-local configuration endpoint `/config/cluster`.
 
 ~> **Note**: If no cluster-local address is present and templating is used,
@@ -3823,7 +3823,7 @@ parameter.
   `{{issuer_id}}` with the ID of the issuer doing the issuance, the
   literal value `{{cluster_path}}` with the value of `path` from the
   cluster-local configuration endpoint `/config/cluster`, and the
-  literal value '{{cluster_aia_path}}' with the value of `aia_path` from
+  literal value `{{cluster_aia_path}}` with the value of `aia_path` from
   the cluster-local configuration endpoint `/config/cluster`.
 
   For example, the following values can be used globally to ensure all AIA


### PR DESCRIPTION
This replaces quotes with backticks in the documentation.