### PR TITLE
fix security-scanner: temporarily pin semgrep to 1.45.0

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -58,7 +58,7 @@ jobs:
         mv scan-plugin-codeql "$HOME/.bin"
 
         # Semgrep
-        python3 -m pip install semgrep
+        python3 -m pip install semgrep==1.45.0
 
         # CodeQL
         LATEST=$(gh release list --repo https://github.com/github/codeql-action | cut -f 3 | sort --version-sort | tail -n1)


### PR DESCRIPTION
Temporary fix due to incompatibility in new version of semgrep.