### PR TITLE
VAULT-3825: Wildcard ACL policies without a trailing slash should match LIST operations

### DIFF
--- a/vault/acl.go
+++ b/vault/acl.go
@@ -409,6 +409,16 @@ func (a *ACL) AllowOperation(ctx context.Context, req *logical.Request, capCheck
 		}
 	}
 
+	// List operations need to check without the trailing slash first, because
+	// there could be other rules with trailing wildcards that will match the
+	// path
+	if op == logical.ListOperation && strings.HasSuffix(path, "/") {
+		permissions = a.CheckAllowedFromNonExactPaths(strings.TrimSuffix(path, "/"), false)
+		if permissions != nil {
+			capabilities = permissions.CapabilitiesBitmap
+			goto CHECK
+		}
+	}
 	permissions = a.CheckAllowedFromNonExactPaths(path, false)
 	if permissions != nil {
 		capabilities = permissions.CapabilitiesBitmap


### PR DESCRIPTION
I'll split this into an OSS PR and add a changelog there once it's approved.

When a LIST operation is executed on namespace foo, both of the following policies will independently allow the operation:

path "foo/sys/policies/acl" {
	capabilities = ["list"]
}
and

path "foo/sys/policies/acl/" {
	capabilities = ["list"]
}
both work 👍

However, when we use a wildcard in the policy path, we get different behavior:

path "+/sys/policies/acl" {
	capabilities = ["list"]
}
^ this fails

path "+/sys/policies/acl/" {
	capabilities = ["list"]
}
but ^ this succeeds.

This PR fixes the behavior so that it's the same for a wildcard versus no wildcard.

I considered stripping the trailing slash earlier in the request flow, but that would mean that any users that had written rules assuming that there was a trailing slash would need to update their policies after this change.

Tests for this are in enterprise.