### PR TITLE
Revert Namespace Test Fix Attempt 

### DIFF
--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { click, visit, fillIn, currentURL } from '@ember/test-helpers';
+import { click, settled, visit, fillIn, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { create } from 'ember-cli-page-object';
@@ -13,7 +13,7 @@ import logout from 'vault/tests/pages/logout';
 
 const shell = create(consoleClass);
 
-const createNS = (name) => shell.runCommands(`write sys/namespaces/${name} -force`);
+const createNS = async (name) => shell.runCommands(`write sys/namespaces/${name} -force`);
 
 module('Acceptance | Enterprise | namespaces', function (hooks) {
   setupApplicationTest(hooks);
@@ -42,6 +42,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
     const nses = ['beep', 'boop', 'bop'];
     for (const [i, ns] of nses.entries()) {
       await createNS(ns);
+      await settled();
       // the namespace path will include all of the namespaces up to this point
       const targetNamespace = nses.slice(0, i + 1).join('/');
       const url = `/vault/secrets?namespace=${targetNamespace}`;
@@ -51,13 +52,16 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
       assert
         .dom(`[data-test-namespace-link="${targetNamespace}"]`)
         .hasText(ns, `shows the namespace ${ns} in the toggle component`);
-      // because quint does not like page reloads, visiting url directly instead of clicking on namespace in toggle
+      // because quint does not like page reloads, visiting url directing instead of clicking on namespace in toggle
       await visit(url);
     }
 
     await logout.visit();
+    await settled();
     await authPage.visit({ namespace: '/beep/boop' });
+    await settled();
     await authPage.tokenInput('root').submit();
+    await settled();
     await click('[data-test-namespace-toggle]');
 
     assert.dom('[data-test-current-namespace]').hasText('/beep/boop/', 'current namespace begins with a /');

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -4,7 +4,7 @@
  */
 
 import { click, settled, visit, fillIn, currentURL } from '@ember/test-helpers';
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { create } from 'ember-cli-page-object';
 import consoleClass from 'vault/tests/pages/components/console/ui-panel';
@@ -34,7 +34,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
     assert.dom('[data-test-namespace-link]').doesNotExist('Additional namespace have been cleared');
   });
 
-  test('it shows nested namespaces if you log in with a namespace starting with a /', async function (assert) {
+  skip('it shows nested namespaces if you log in with a namespace starting with a /', async function (assert) {
     assert.expect(5);
 
     await click('[data-test-namespace-toggle]');

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -34,6 +34,10 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
     assert.dom('[data-test-namespace-link]').doesNotExist('Additional namespace have been cleared');
   });
 
+  // this test is flaky and is intentionally being skipped for now
+  // after seeing it fail both in CI and locally, an attempt at stabilizing it was made in https://github.com/hashicorp/vault/pull/23867
+  // this seemed to make it consistently pass locally while continuing to fail sporadically in CI
+  // that fix attempt was reverted in favor of skipping until it can be reworked to reliably pass
   skip('it shows nested namespaces if you log in with a namespace starting with a /', async function (assert) {
     assert.expect(5);
 

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -52,7 +52,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
       assert
         .dom(`[data-test-namespace-link="${targetNamespace}"]`)
         .hasText(ns, `shows the namespace ${ns} in the toggle component`);
-      // because quint does not like page reloads, visiting url directing instead of clicking on namespace in toggle
+      // because quint does not like page reloads, visiting url directly instead of clicking on namespace in toggle
       await visit(url);
     }
 

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -13,7 +13,7 @@ import logout from 'vault/tests/pages/logout';
 
 const shell = create(consoleClass);
 
-const createNS = async (name) => shell.runCommands(`write sys/namespaces/${name} -force`);
+const createNS = (name) => shell.runCommands(`write sys/namespaces/${name} -force`);
 
 module('Acceptance | Enterprise | namespaces', function (hooks) {
   setupApplicationTest(hooks);


### PR DESCRIPTION
This reverts commit 0e3697382589aa89392f6cc225595ca846bfa9b2 and skips the test for now since it is not reliably passing. See #23867 for original fix attempt but the tests are still failing in CI.