### PR TITLE
Skip unnecessary deriving of policies from entity on Login MFA check

### DIFF
--- a/changelog/23894.txt
+++ b/changelog/23894.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Skip unnecessary deriving of policies during Login MFA Check.
+```

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1676,7 +1676,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 		source := c.router.MatchingMount(ctx, req.Path)
 
 		// Login MFA
-		entity, _, err := c.fetchEntityAndDerivedPolicies(ctx, ns, auth.EntityID, false)
+		entity, _, err := c.fetchEntityAndDerivedPolicies(ctx, ns, auth.EntityID, true)
 		if err != nil {
 			return nil, nil, ErrInternalError
 		}


### PR DESCRIPTION
This PR skips the unnecessary deriving of policies from a fetched entity. The returned policies are ignored so we can safely skip doing the work here.