### PR TITLE
core: fix bug where deadlock detection was always on for expiration and quotas

### DIFF
--- a/changelog/23902.txt
+++ b/changelog/23902.txt
@@ -1,0 +1,5 @@
+```release-note:bug
+core: fix bug where deadlock detection was always on for expiration and quotas. 
+These can now be configured individually with `detect_deadlocks`.
+```
+

--- a/vault/core.go
+++ b/vault/core.go
@@ -959,6 +959,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 
 	var detectDeadlocks []string
 	if conf.DetectDeadlocks != "" {
+		conf.DetectDeadlocks = strings.Trim(conf.DetectDeadlocks, " ")
 		detectDeadlocks = strings.Split(conf.DetectDeadlocks, ",")
 	}
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -4202,3 +4202,10 @@ func (c *Core) GetRaftAutopilotState(ctx context.Context) (*raft.AutopilotState,
 func (c *Core) Events() *eventbus.EventBus {
 	return c.events
 }
+
+func (c *Core) DetectDeadlocks() bool {
+	if _, ok := c.stateLock.(*locking.DeadlockRWMutex); ok {
+		return true
+	}
+	return false
+}

--- a/vault/core.go
+++ b/vault/core.go
@@ -959,8 +959,10 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 
 	var detectDeadlocks []string
 	if conf.DetectDeadlocks != "" {
-		conf.DetectDeadlocks = strings.ToLower(strings.TrimSpace(conf.DetectDeadlocks))
 		detectDeadlocks = strings.Split(conf.DetectDeadlocks, ",")
+		for k, v := range detectDeadlocks {
+			detectDeadlocks[k] = strings.ToLower(strings.TrimSpace(v))
+		}
 	}
 
 	// Use imported logging deadlock if requested

--- a/vault/core.go
+++ b/vault/core.go
@@ -959,7 +959,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 
 	var detectDeadlocks []string
 	if conf.DetectDeadlocks != "" {
-		conf.DetectDeadlocks = strings.Trim(conf.DetectDeadlocks, " ")
+		conf.DetectDeadlocks = strings.ToLower(strings.TrimSpace(conf.DetectDeadlocks))
 		detectDeadlocks = strings.Split(conf.DetectDeadlocks, ",")
 	}
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -4203,7 +4203,7 @@ func (c *Core) Events() *eventbus.EventBus {
 	return c.events
 }
 
-func (c *Core) DetectDeadlocks() bool {
+func (c *Core) DetectStateLockDeadlocks() bool {
 	if _, ok := c.stateLock.(*locking.DeadlockRWMutex); ok {
 		return true
 	}

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -3398,14 +3398,14 @@ func TestStatelock_DeadlockDetection(t *testing.T) {
 	testCore := TestCore(t)
 	testCoreUnsealed(t, testCore)
 
-	if testCore.DetectDeadlocks() {
+	if testCore.DetectStateLockDeadlocks() {
 		t.Fatal("statelock has deadlock detection enabled, it shouldn't")
 	}
 
 	testCore = TestCoreWithDeadlockDetection(t, nil, false)
 	testCoreUnsealed(t, testCore)
 
-	if !testCore.DetectDeadlocks() {
+	if !testCore.DetectStateLockDeadlocks() {
 		t.Fatal("statelock doesn't have deadlock detection enabled, it should")
 	}
 }

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -3361,3 +3361,51 @@ func InduceDeadlock(t *testing.T, vaultcore *Core, expected uint32) {
 		t.Fatalf("expected 1 deadlock, detected %d", deadlocks)
 	}
 }
+
+func TestExpiration_DeadlockDetection(t *testing.T) {
+	testCore := TestCore(t)
+	testCoreUnsealed(t, testCore)
+
+	if testCore.expiration.DetectDeadlocks() {
+		t.Fatal("expiration has deadlock detection enabled, it shouldn't")
+	}
+
+	testCore = TestCoreWithDeadlockDetection(t, nil, false)
+	testCoreUnsealed(t, testCore)
+
+	if !testCore.expiration.DetectDeadlocks() {
+		t.Fatal("expiration doesn't have deadlock detection enabled, it should")
+	}
+}
+
+func TestQuotas_DeadlockDetection(t *testing.T) {
+	testCore := TestCore(t)
+	testCoreUnsealed(t, testCore)
+
+	if testCore.quotaManager.DetectDeadlocks() {
+		t.Fatal("quotas has deadlock detection enabled, it shouldn't")
+	}
+
+	testCore = TestCoreWithDeadlockDetection(t, nil, false)
+	testCoreUnsealed(t, testCore)
+
+	if !testCore.quotaManager.DetectDeadlocks() {
+		t.Fatal("quotas doesn't have deadlock detection enabled, it should")
+	}
+}
+
+func TestStatelock_DeadlockDetection(t *testing.T) {
+	testCore := TestCore(t)
+	testCoreUnsealed(t, testCore)
+
+	if testCore.DetectDeadlocks() {
+		t.Fatal("statelock has deadlock detection enabled, it shouldn't")
+	}
+
+	testCore = TestCoreWithDeadlockDetection(t, nil, false)
+	testCoreUnsealed(t, testCore)
+
+	if !testCore.DetectDeadlocks() {
+		t.Fatal("statelock doesn't have deadlock detection enabled, it should")
+	}
+}

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -2830,3 +2830,10 @@ func decodeLeaseEntry(buf []byte) (*leaseEntry, error) {
 	out := new(leaseEntry)
 	return out, jsonutil.DecodeJSON(buf, out)
 }
+
+func (e *ExpirationManager) DetectDeadlocks() bool {
+	if _, ok := e.pendingLock.(*locking.DeadlockRWMutex); ok {
+		return true
+	}
+	return false
+}

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -170,13 +170,13 @@ type Manager struct {
 	metricSink *metricsutil.ClusterMetricSink
 
 	// quotaLock is a lock for manipulating quotas and anything not covered by a more specific lock
-	quotaLock *locking.DeadlockRWMutex
+	quotaLock locking.RWMutex
 
 	// quotaConfigLock is a lock for accessing config items, such as RateLimitExemptPaths
-	quotaConfigLock *locking.DeadlockRWMutex
+	quotaConfigLock locking.RWMutex
 
 	// dbAndCacheLock is a lock for db and path caches that need to be reset during Reset()
-	dbAndCacheLock *locking.DeadlockRWMutex
+	dbAndCacheLock locking.RWMutex
 }
 
 // QuotaLeaseInformation contains all of the information lease-count quotas require
@@ -275,7 +275,7 @@ type Request struct {
 
 // NewManager creates and initializes a new quota manager to hold all the quota
 // rules and to process incoming requests.
-func NewManager(logger log.Logger, walkFunc leaseWalkFunc, ms *metricsutil.ClusterMetricSink) (*Manager, error) {
+func NewManager(logger log.Logger, walkFunc leaseWalkFunc, ms *metricsutil.ClusterMetricSink, detectDeadlocks bool) (*Manager, error) {
 	db, err := memdb.NewMemDB(dbSchema())
 	if err != nil {
 		return nil, err
@@ -287,9 +287,16 @@ func NewManager(logger log.Logger, walkFunc leaseWalkFunc, ms *metricsutil.Clust
 		metricSink:           ms,
 		rateLimitPathManager: pathmanager.New(),
 		config:               new(Config),
-		quotaLock:            new(locking.DeadlockRWMutex),
-		quotaConfigLock:      new(locking.DeadlockRWMutex),
-		dbAndCacheLock:       new(locking.DeadlockRWMutex),
+		quotaLock:            &locking.SyncRWMutex{},
+		quotaConfigLock:      &locking.SyncRWMutex{},
+		dbAndCacheLock:       &locking.SyncRWMutex{},
+	}
+
+	if detectDeadlocks {
+		logger.Debug("enabling deadlock detection")
+		manager.quotaLock = &locking.DeadlockRWMutex{}
+		manager.quotaConfigLock = &locking.DeadlockRWMutex{}
+		manager.dbAndCacheLock = &locking.DeadlockRWMutex{}
 	}
 
 	manager.init(walkFunc)

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -1326,3 +1326,10 @@ func (m *Manager) HandleBackendDisabling(ctx context.Context, nsPath, mountPath 
 
 	return nil
 }
+
+func (m *Manager) DetectDeadlocks() bool {
+	if _, ok := m.quotaLock.(*locking.DeadlockRWMutex); ok {
+		return true
+	}
+	return false
+}

--- a/vault/quotas/quotas_rate_limit_test.go
+++ b/vault/quotas/quotas_rate_limit_test.go
@@ -218,7 +218,7 @@ func TestRateLimitQuota_Allow_WithBlock(t *testing.T) {
 
 func TestRateLimitQuota_Update(t *testing.T) {
 	defer goleak.VerifyNone(t)
-	qm, err := NewManager(logging.NewVaultLogger(log.Trace), nil, metricsutil.BlackholeSink())
+	qm, err := NewManager(logging.NewVaultLogger(log.Trace), nil, metricsutil.BlackholeSink(), true)
 	require.NoError(t, err)
 
 	quota := NewRateLimitQuota("quota1", "", "", "", "", false, time.Second, 0, 10)

--- a/vault/quotas/quotas_test.go
+++ b/vault/quotas/quotas_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestQuotas_MountPathOverwrite(t *testing.T) {
-	qm, err := NewManager(logging.NewVaultLogger(log.Trace), nil, metricsutil.BlackholeSink())
+	qm, err := NewManager(logging.NewVaultLogger(log.Trace), nil, metricsutil.BlackholeSink(), true)
 	require.NoError(t, err)
 
 	quota := NewRateLimitQuota("tq", "", "kv1/", "", "", false, time.Second, 0, 10)
@@ -43,7 +43,7 @@ func TestQuotas_MountPathOverwrite(t *testing.T) {
 }
 
 func TestQuotas_Precedence(t *testing.T) {
-	qm, err := NewManager(logging.NewVaultLogger(log.Trace), nil, metricsutil.BlackholeSink())
+	qm, err := NewManager(logging.NewVaultLogger(log.Trace), nil, metricsutil.BlackholeSink(), true)
 	require.NoError(t, err)
 
 	setQuotaFunc := func(t *testing.T, name, nsPath, mountPath, pathSuffix, role string, inheritable bool) Quota {
@@ -142,7 +142,7 @@ func TestQuotas_QueryResolveRole_RateLimitQuotas(t *testing.T) {
 	leaseWalkFunc := func(context.Context, func(request *Request) bool) error {
 		return nil
 	}
-	qm, err := NewManager(logging.NewVaultLogger(log.Trace), leaseWalkFunc, metricsutil.BlackholeSink())
+	qm, err := NewManager(logging.NewVaultLogger(log.Trace), leaseWalkFunc, metricsutil.BlackholeSink(), true)
 	require.NoError(t, err)
 
 	rlqReq := &Request{

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -142,6 +142,20 @@ func TestCoreWithSeal(t testing.T, testSeal Seal, enableRaw bool) *Core {
 	return TestCoreWithSealAndUI(t, conf)
 }
 
+func TestCoreWithDeadlockDetection(t testing.T, testSeal Seal, enableRaw bool) *Core {
+	conf := &CoreConfig{
+		Seal:            testSeal,
+		EnableUI:        false,
+		EnableRaw:       enableRaw,
+		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
+		AuditBackends: map[string]audit.Factory{
+			"file": auditFile.Factory,
+		},
+		DetectDeadlocks: "expiration,quotas,statelock",
+	}
+	return TestCoreWithSealAndUI(t, conf)
+}
+
 func TestCoreWithCustomResponseHeaderAndUI(t testing.T, CustomResponseHeaders map[string]map[string]string, enableUI bool) (*Core, [][]byte, string) {
 	confRaw := &server.Config{
 		SharedConfig: &configutil.SharedConfig{

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -159,10 +159,11 @@ to specify where the configuration is.
   maximum request duration allowed before Vault cancels the request. This can
   be overridden per listener via the `max_request_duration` value.
 
-- `detect_deadlocks` `(string: "")` - Specifies the internal mutex locks that should be monitored for
-potential deadlocks. Currently supported value is `statelock`, which will cause "POTENTIAL DEADLOCK:"
-to be logged when an attempt at a core state lock appears to be deadlocked. Enabling this can have
-a negative effect on performance due to the tracking of each lock attempt.
+- `detect_deadlocks` `(string: "")` - A comma separated string that specifies the internal 
+mutex locks that should be monitored for potential deadlocks. Currently supported values 
+include `statelock`, `quotas` and `expiration` which will cause "POTENTIAL DEADLOCK:"
+to be logged when an attempt at a core state lock appears to be deadlocked. Enabling this 
+can have a negative effect on performance due to the tracking of each lock attempt.
 
 - `raw_storage_endpoint` `(bool: false)` – Enables the `sys/raw` endpoint which
   allows the decryption/encryption of raw data into and out of the security


### PR DESCRIPTION
PR #18604 introduced a bug where deadlock detection was always on for both expiration and quota subsystems. This can result in negative server performance as deadlock detection adds overhead to locks.

Deadlock detection can now be toggled on expiration and quotas via `detect_deadlocks="statelock,expiration,quotas"`.