### PR TITLE
OIDC/JWT Role Fetch Error Handling Updates

### DIFF
--- a/changelog/23908.txt
+++ b/changelog/23908.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Updates OIDC/JWT login error handling to surface all role related errors
+```

--- a/ui/app/templates/components/auth-jwt.hbs
+++ b/ui/app/templates/components/auth-jwt.hbs
@@ -3,20 +3,20 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<form id="auth-form" onsubmit={{action (if this.isOIDC "startOIDCAuth" @onSubmit) (hash role=this.roleName jwt=this.jwt)}}>
+<form id="auth-form" {{on "submit" (action "signIn")}}>
   <div class="field">
     <label for="role" class="is-label">Role</label>
     <div class="control">
       <input
-        value={{@roleName}}
+        value={{this.roleName}}
         placeholder="Default"
-        oninput={{perform this.fetchRole value="target.value"}}
         autocomplete="off"
         spellcheck="false"
         name="role"
         id="role"
         class="input"
         type="text"
+        {{on "input" (action "onRoleChange")}}
         data-test-role
       />
     </div>

--- a/ui/tests/integration/components/auth-jwt-test.js
+++ b/ui/tests/integration/components/auth-jwt-test.js
@@ -138,7 +138,7 @@ module('Integration | Component | auth jwt', function (hooks) {
 
     await component.role('okta');
     // 1 for initial render, 1 for each time role changed = 3
-    assert.strictEqual(this.server.handledRequests.length, 4, 'fetches the auth_url when the path changes');
+    assert.strictEqual(this.server.handledRequests.length, 3, 'fetches the auth_url when the path changes');
     assert.strictEqual(
       component.loginButtonText,
       'Sign in with Okta',


### PR DESCRIPTION
There is an issue with error handling in the `AuthJwt` component where errors when attempting to fetch the role were being thrown with no catch. This gave the user the impression that nothing was happening when they would try to login via OIDC/JWT. This PR updates the workflow to surface all role related fetch errors so the user can better troubleshoot setup issues.

The attached video illustrates a 403 error that would have previously been unhandled and is now displayed as an alert. The network inspector is also visible to illustrate that when changing mount path or type that a request is made to fetch the role which is necessary to determine whether or not the mount is configured for JWT authentication. This is only provided as verification that regressions were not introduced in the workflow and is existing functionality.

https://github.com/hashicorp/vault/assets/24611656/22a3d796-d5dd-4103-a9b0-a5916ef26f34

Example of unhandled error before updates

![image](https://github.com/hashicorp/vault/assets/24611656/7e923165-a5ec-4682-b793-dfaff7da3810)
