### PR TITLE
docs: add workaround to known issue loading missing policies from other namespaces

### DIFF
--- a/website/content/docs/release-notes/1.14.0.mdx
+++ b/website/content/docs/release-notes/1.14.0.mdx
@@ -20,6 +20,7 @@ All     | [API calls to update-primary may lead to data loss](/vault/docs/upgrad
 1.14.0+ | [AWS static roles ignore changes to rotation period](/vault/docs/upgrading/upgrade-to-1.14.x#aws-static-role-rotation)
 1.14.0+ | [UI Collapsed navbar does not allow certain click events](/vault/docs/upgrading/upgrade-to-1.14.x#ui-collapsed-navbar)
 1.14.3+ | [Vault storing references to ephemeral sub-loggers causing memory leak](/vault/docs/upgrading/upgrade-to-1.14.x#ephemeral-loggers-memory-leak)
+1.14.4+ | [Missing namespace policy causing vault internal error](/vault/docs/upgrading/upgrade-to-1.14.x#internal-error-namespace-missing-policy)
 
 ## Vault companion updates
 

--- a/website/content/docs/release-notes/1.14.0.mdx
+++ b/website/content/docs/release-notes/1.14.0.mdx
@@ -20,7 +20,7 @@ All     | [API calls to update-primary may lead to data loss](/vault/docs/upgrad
 1.14.0+ | [AWS static roles ignore changes to rotation period](/vault/docs/upgrading/upgrade-to-1.14.x#aws-static-role-rotation)
 1.14.0+ | [UI Collapsed navbar does not allow certain click events](/vault/docs/upgrading/upgrade-to-1.14.x#ui-collapsed-navbar)
 1.14.3+ | [Vault storing references to ephemeral sub-loggers causing memory leak](/vault/docs/upgrading/upgrade-to-1.14.x#ephemeral-loggers-memory-leak)
-1.14.4+ | [Missing namespace policy causing vault internal error](/vault/docs/upgrading/upgrade-to-1.14.x#internal-error-namespace-missing-policy)
+1.14.4+ | [Internal error when vault policy in namespace does not exist](/vault/docs/upgrading/upgrade-to-1.14.x#internal-error-namespace-missing-policy)
 
 ## Vault companion updates
 

--- a/website/content/docs/release-notes/1.14.0.mdx
+++ b/website/content/docs/release-notes/1.14.0.mdx
@@ -20,7 +20,7 @@ All     | [API calls to update-primary may lead to data loss](/vault/docs/upgrad
 1.14.0+ | [AWS static roles ignore changes to rotation period](/vault/docs/upgrading/upgrade-to-1.14.x#aws-static-role-rotation)
 1.14.0+ | [UI Collapsed navbar does not allow certain click events](/vault/docs/upgrading/upgrade-to-1.14.x#ui-collapsed-navbar)
 1.14.3+ | [Vault storing references to ephemeral sub-loggers causing memory leak](/vault/docs/upgrading/upgrade-to-1.14.x#ephemeral-loggers-memory-leak)
-1.14.4+ | [Internal error when vault policy in namespace does not exist](/vault/docs/upgrading/upgrade-to-1.14.x#internal-error-namespace-missing-policy)
+1.14.4+ | [Internal error when vault policy in namespace does not exist](/vault/docs/upgrading/upgrade-to-1.14.x#internal-error-when-vault-policy-in-namespace-does-not-exist)
 
 ## Vault companion updates
 

--- a/website/content/docs/release-notes/1.15.0.mdx
+++ b/website/content/docs/release-notes/1.15.0.mdx
@@ -20,7 +20,7 @@ Version | Issue
 1.15.0+ | [UI Collapsed navbar does not allow certain click events](/vault/docs/upgrading/upgrade-to-1.15.x#ui-collapsed-navbar)
 1.15    | [Vault file audit devices do not honor SIGHUP signal to reload](/vault/docs/upgrading/upgrade-to-1.15.x#file-audit-devices-do-not-honor-sighup-signal-to-reload)
 1.15.0+ | [Vault storing references to ephemeral sub-loggers causing memory leak](/vault/docs/upgrading/upgrade-to-1.15.x#ephemeral-loggers-memory-leak)
-1.15.0+ | [Missing namespace policy causing vault internal error](/vault/docs/upgrading/upgrade-to-1.15.x#internal-error-namespace-missing-policy)
+1.15.0+ | [Internal error when vault policy in namespace does not exist](/vault/docs/upgrading/upgrade-to-1.15.x#internal-error-namespace-missing-policy)
 
 
 ## Vault companion updates

--- a/website/content/docs/release-notes/1.15.0.mdx
+++ b/website/content/docs/release-notes/1.15.0.mdx
@@ -20,7 +20,7 @@ Version | Issue
 1.15.0+ | [UI Collapsed navbar does not allow certain click events](/vault/docs/upgrading/upgrade-to-1.15.x#ui-collapsed-navbar)
 1.15    | [Vault file audit devices do not honor SIGHUP signal to reload](/vault/docs/upgrading/upgrade-to-1.15.x#file-audit-devices-do-not-honor-sighup-signal-to-reload)
 1.15.0+ | [Vault storing references to ephemeral sub-loggers causing memory leak](/vault/docs/upgrading/upgrade-to-1.15.x#ephemeral-loggers-memory-leak)
-1.15.0+ | [Internal error when vault policy in namespace does not exist](/vault/docs/upgrading/upgrade-to-1.15.x#internal-error-namespace-missing-policy)
+1.15.0+ | [Internal error when vault policy in namespace does not exist](/vault/docs/upgrading/upgrade-to-1.15.x#internal-error-when-vault-policy-in-namespace-does-not-exist)
 
 
 ## Vault companion updates

--- a/website/content/docs/release-notes/1.15.0.mdx
+++ b/website/content/docs/release-notes/1.15.0.mdx
@@ -20,6 +20,8 @@ Version | Issue
 1.15.0+ | [UI Collapsed navbar does not allow certain click events](/vault/docs/upgrading/upgrade-to-1.15.x#ui-collapsed-navbar)
 1.15    | [Vault file audit devices do not honor SIGHUP signal to reload](/vault/docs/upgrading/upgrade-to-1.15.x#file-audit-devices-do-not-honor-sighup-signal-to-reload)
 1.15.0+ | [Vault storing references to ephemeral sub-loggers causing memory leak](/vault/docs/upgrading/upgrade-to-1.15.x#ephemeral-loggers-memory-leak)
+1.15.0+ | [Missing namespace policy causing vault internal error](/vault/docs/upgrading/upgrade-to-1.15.x#internal-error-namespace-missing-policy)
+
 
 ## Vault companion updates
 

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -39,6 +39,9 @@ URL: PUT http://127.0.0.1:8200/v1/auth/userpass/login/user1
 Code: 500. Errors:
 
 * internal error
+```
+
+</CodeBlockConfig>
 
 To confirm the problem is a missing policy, start by identifying the relevant
 entity and group IDs:

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -77,6 +77,7 @@ $ vault read -format=json -namespace=ns1 \
 ```
 
 </CodeBlockConfig>
+
 Now that we know Vault is looking for a policy called `group_policy`, we can
 check whether that policy exists under the `ns1` namespace:
 

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -12,6 +12,7 @@ This impacts all auth methods.
 A fix will be released in Vault 1.15.2, 1.14.6, and 1.13.10.
 
 ### Workaround
+
 During authentication, Vault derives inherited policies based on the groups an
 entity belongs to. Vault returns an internal error when attaching the derived
 policy to a token when:

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -40,14 +40,23 @@ Code: 500. Errors:
 
 * internal error
 
-# Identify the entity and group IDs
-$ vault read -format=json identity/entity/name/user1 | jq '{"entity_id": .data.id, "group_ids": .data.group_ids} '
+To confirm the problem is a missing policy, start by identifying the relevant
+entity and group IDs:
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ vault read -format=json identity/entity/name/user1 | \
+  jq '{"entity_id": .data.id, "group_ids": .data.group_ids} '
 {
   "entity_id": "420c82de-57c3-df2e-2ef6-0690073b1636",
   "group_ids": [
     "6cb152b7-955d-272b-4dcf-a2ed668ca1ea"
   ]
 }
+```
+
+</CodeBlockConfig>
 
 # Fetch the group from the other namespace
 $ vault read -format=json -namespace=ns1 identity/group/id/6cb152b7-955d-272b-4dcf-a2ed668ca1ea | jq '.data.policies'

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -12,7 +12,17 @@ This impacts all auth methods.
 A fix will be released in Vault 1.15.2, 1.14.6, and 1.13.10.
 
 ### Workaround
-During authentication, Vault will derive any additional policies that should be inherited based on any groups an entity is a member of. If Vault attempts to attach a policy to a token from a different namespace than the one handling the authentication, _and_ that policy does not exist, Vault will return an internal error. The way to resolve this issue is to either add the policy, or to delete the group policy mapping referring to the non-existent policy.
+During authentication, Vault derives inherited policies based on the groups an
+entity belongs to. Vault returns an internal error when attaching the derived
+policy to a token when:
+
+1. the token belongs to a different namespace than the one handling
+   authentication, and
+1. the derived policy does not exist under the namespace.
+
+
+You can resolve the error by adding the policy to the relevant namespace or
+deleting the group policy mapping that uses the derived policy.
 
 Below is an example of a userpass auth method that is failing because of a
 missing group policy from another namespace.

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -10,3 +10,58 @@ This impacts all auth methods.
 - 1.15.0 and 1.15.1
 
 A fix will be released in Vault 1.15.2, 1.14.6, and 1.13.10.
+
+### Workaround
+During authentication, vault adds all policies that can be applied to an entity.
+This includes policies in separate namespaces. If vault attempts to add a policy
+from another namespace _and_ this policy does not exist, vault will return an
+internal error. The way to resolve this issue is to either add the policy, or to
+delete the policy.
+
+Below is an example of a userpass auth method that is failing because of a
+missing group policy from another namespace.
+
+```
+`# Failed login
+$ vault login -method=userpass username=user1 password=123
+Error authenticating: Error making API request.
+
+URL: PUT http://127.0.0.1:8200/v1/auth/userpass/login/user1
+Code: 500. Errors:
+
+* internal error
+
+# Identify the entity and group IDs
+$ vault read -format=json identity/entity/name/user1 | jq '{"entity_id": .data.id, "group_ids": .data.group_ids} '
+{
+  "entity_id": "420c82de-57c3-df2e-2ef6-0690073b1636",
+  "group_ids": [
+    "6cb152b7-955d-272b-4dcf-a2ed668ca1ea"
+  ]
+}
+
+# Fetch the group from the other namespace
+$ vault read -format=json -namespace=ns1 identity/group/id/6cb152b7-955d-272b-4dcf-a2ed668ca1ea | jq '.data
+.policies'
+[
+  "group_policy"
+]
+
+# The only policy in this namespace is default (group_policy is missing)
+$ vault policy list -namespace=ns1
+default
+
+# Option 1: Remove the missing policy from the group
+vault write -namespace=ns1 identity/group/id/6cb152b7-955d-272b-4dcf-a2ed668ca1ea name="test" policies="d
+efault"
+
+# OR Option 2: Create the missing policy
+$ vault policy write -namespace=ns1 group_policy - << EOF
+    path "secret/data/*" {
+	    capabilities = ["create", "update"]
+    }
+EOF
+
+# Login should succeed now
+$ vault login -method=userpass username=user1 password=123`
+```

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -91,16 +91,51 @@ default
 The only policy in the `ns1` namespace is `default`, which confirms that the
 missing policy (`group_policy`) is causing the error.
 
-# Option 1: Remove the missing policy from the group
-$ vault write -namespace=ns1 identity/group/id/6cb152b7-955d-272b-4dcf-a2ed668ca1ea name="test" policies="default"
 
-# OR Option 2: Create the missing policy
+To fix the problem, we can either remove the missing policy from the
+`6cb152b7-955d-272b-4dcf-a2ed668ca1ea` group or create the missing policy under
+the `ns1` namespace.
+
+<Tabs>
+
+<Tab heading="Remove the group policy">
+
+To remove `group_policy` from group ID `6cb152b7-955d-272b-4dcf-a2ed668ca1ea`,
+use the `vault write` command to set the applicable policies to just include
+`default`:
+
+```shell-session
+$ vault write                                             \
+  -namespace=ns1                                          \
+  identity/group/id/6cb152b7-955d-272b-4dcf-a2ed668ca1ea  \
+  name="test"                                             \
+  policies="default"
+```
+
+</Tab>
+
+<Tab heading="Add the policy to ns1">
+
+To create the missing policy, use `vault policy write` and define the
+appropriate capabilities:
+
+```shell-session
 $ vault policy write -namespace=ns1 group_policy - << EOF
     path "secret/data/*" {
 	    capabilities = ["create", "update"]
     }
 EOF
+```
 
-# Login should succeed now
+</Tab>
+</Tabs>
+
+Verify the fix by re-running the login command:
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
 $ vault login -method=userpass username=user1 password=123`
 ```
+
+</CodeBlockConfig>

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -18,15 +18,15 @@ policy to a token when:
 
 1. the token belongs to a different namespace than the one handling
    authentication, and
-1. the derived policy does not exist under the namespace.
+2. the derived policy does not exist under the namespace.
 
 
 You can resolve the error by adding the policy to the relevant namespace or
 deleting the group policy mapping that uses the derived policy.
 
 As an example, consider the following userpass auth method failure. The error is
-likely due to the fact that Vault expects a group policy under the namespace for
-`user1` that does not exist.
+due to the fact that Vault expects a group policy under the namespace that does 
+not exist.
 
 <CodeBlockConfig hideClipboard>
 
@@ -61,7 +61,7 @@ $ vault read -format=json identity/entity/name/user1 | \
 
 </CodeBlockConfig>
 
-Use the group ID to fetch the relevant policies for `user1` under the `ns1`
+Use the group ID to fetch the relevant policies for the group under the `ns1`
 namespace:
 
 <CodeBlockConfig hideClipboard>

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -37,8 +37,7 @@ $ vault read -format=json identity/entity/name/user1 | jq '{"entity_id": .data.i
 }
 
 # Fetch the group from the other namespace
-$ vault read -format=json -namespace=ns1 identity/group/id/6cb152b7-955d-272b-4dcf-a2ed668ca1ea | jq '.data
-.policies'
+$ vault read -format=json -namespace=ns1 identity/group/id/6cb152b7-955d-272b-4dcf-a2ed668ca1ea | jq '.data.policies'
 [
   "group_policy"
 ]
@@ -48,8 +47,7 @@ $ vault policy list -namespace=ns1
 default
 
 # Option 1: Remove the missing policy from the group
-vault write -namespace=ns1 identity/group/id/6cb152b7-955d-272b-4dcf-a2ed668ca1ea name="test" policies="d
-efault"
+$ vault write -namespace=ns1 identity/group/id/6cb152b7-955d-272b-4dcf-a2ed668ca1ea name="test" policies="default"
 
 # OR Option 2: Create the missing policy
 $ vault policy write -namespace=ns1 group_policy - << EOF

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -24,8 +24,9 @@ policy to a token when:
 You can resolve the error by adding the policy to the relevant namespace or
 deleting the group policy mapping that uses the derived policy.
 
-Below is an example of a userpass auth method that is failing because of a
-missing group policy from another namespace.
+As an example, consider the following userpass auth method failure. The error is
+likely due to the fact that Vault expects a group policy under the namespace for
+`user1` that does not exist.
 
 ```
 # Failed login

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -12,11 +12,7 @@ This impacts all auth methods.
 A fix will be released in Vault 1.15.2, 1.14.6, and 1.13.10.
 
 ### Workaround
-During authentication, vault adds all policies that can be applied to an entity.
-This includes policies in separate namespaces. If vault attempts to add a policy
-from another namespace _and_ this policy does not exist, vault will return an
-internal error. The way to resolve this issue is to either add the policy, or to
-delete the policy.
+During authentication, Vault will derive any additional policies that should be inherited based on any groups an entity is a member of. If Vault attempts to attach a policy to a token from a different namespace than the one handling the authentication, _and_ that policy does not exist, Vault will return an internal error. The way to resolve this issue is to either add the policy, or to delete the group policy mapping referring to the non-existent policy.
 
 Below is an example of a userpass auth method that is failing because of a
 missing group policy from another namespace.

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -137,7 +137,7 @@ Verify the fix by re-running the login command:
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ vault login -method=userpass username=user1 password=123`
+$ vault login -method=userpass username=user1 password=123
 ```
 
 </CodeBlockConfig>

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -61,12 +61,21 @@ $ vault read -format=json identity/entity/name/user1 | \
 
 </CodeBlockConfig>
 
-# Fetch the group from the other namespace
-$ vault read -format=json -namespace=ns1 identity/group/id/6cb152b7-955d-272b-4dcf-a2ed668ca1ea | jq '.data.policies'
+Use the group ID to fetch the relevant policies for `user1` under the `ns1`
+namespace:
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ vault read -format=json -namespace=ns1 \
+  identity/group/id/6cb152b7-955d-272b-4dcf-a2ed668ca1ea | \
+  jq '.data.policies'
 [
   "group_policy"
 ]
+```
 
+</CodeBlockConfig>
 # The only policy in this namespace is default (group_policy is missing)
 $ vault policy list -namespace=ns1
 default

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -76,9 +76,20 @@ $ vault read -format=json -namespace=ns1 \
 ```
 
 </CodeBlockConfig>
-# The only policy in this namespace is default (group_policy is missing)
+Now that we know Vault is looking for a policy called `group_policy`, we can
+check whether that policy exists under the `ns1` namespace:
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
 $ vault policy list -namespace=ns1
 default
+```
+
+</CodeBlockConfig>
+
+The only policy in the `ns1` namespace is `default`, which confirms that the
+missing policy (`group_policy`) is causing the error.
 
 # Option 1: Remove the missing policy from the group
 $ vault write -namespace=ns1 identity/group/id/6cb152b7-955d-272b-4dcf-a2ed668ca1ea name="test" policies="default"

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -22,7 +22,7 @@ Below is an example of a userpass auth method that is failing because of a
 missing group policy from another namespace.
 
 ```
-`# Failed login
+# Failed login
 $ vault login -method=userpass username=user1 password=123
 Error authenticating: Error making API request.
 

--- a/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
+++ b/website/content/partials/known-issues/internal-error-namespace-missing-policy.mdx
@@ -28,7 +28,9 @@ As an example, consider the following userpass auth method failure. The error is
 likely due to the fact that Vault expects a group policy under the namespace for
 `user1` that does not exist.
 
-```
+<CodeBlockConfig hideClipboard>
+
+```shell-session
 # Failed login
 $ vault login -method=userpass username=user1 password=123
 Error authenticating: Error making API request.


### PR DESCRIPTION
Add workaround to known issue loading missing policies from other namespaces