### PR TITLE
Correcting Sample Request to use token and POST

### DIFF
--- a/website/content/api-docs/system/replication/index.mdx
+++ b/website/content/api-docs/system/replication/index.mdx
@@ -221,6 +221,8 @@ You must provide an authentication token when calling `replication/merkle-check`
 
 ```shell-session
 $ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
     http://127.0.0.1:8200/v1/sys/replication/merkle-check
 ```
 


### PR DESCRIPTION
Example missing needed `curl` parameters