### PR TITLE
Flaky Enterprise Control Group Test Fix

### DIFF
--- a/ui/tests/acceptance/enterprise-control-groups-test.js
+++ b/ui/tests/acceptance/enterprise-control-groups-test.js
@@ -130,6 +130,11 @@ module('Acceptance | Enterprise | control groups', function (hooks) {
       await waitUntil(() => currentRouteName() === 'vault.cluster.access.control-group-accessor'),
       'redirects to access control group route'
     );
+    // without waiting for a settled state before test teardown there was an occasional async request leak causing failures
+    // the queryRecord method in the capabilities adapter was seemingly resolving after the store was destroyed
+    // "Error: Async Request leaks detected. Add a breakpoint here and set store.generateStackTracesForTrackedRequests = true; to inspect traces for leak origins"
+    // this should allow the pending request to resolve before tear down
+    await settled();
   });
 
   const workflow = async (assert, context, shouldStoreToken) => {


### PR DESCRIPTION
There was an enterprise control group test failing pretty regularly with the following error:

![image](https://github.com/hashicorp/vault/assets/24611656/66dc270c-0c5a-4c1f-9056-923a43801c8e)

I was able to recreate locally by skipping the other tests in the module and running it in a loop where it failed at least once each time I ran it.

```js
let i = 0;
while (i < 50) {
  test('for v2 secrets it redirects you if you try to navigate to a Control Group restricted path', async function (assert) {
    // setup, actions and assertions
  });
  i++;
}
```

Since the test was being torn down (and by extension the store) before the capabilities request resolved, I added `settled` at the end of the test which seems to have fixed the problem. The test should now wait for pending request to finish before tearing down. I bumped the loop to 500 to verify the fix and all tests passed.