### PR TITLE
[QT-617] Add seal migration to `seal_ha` scenario

### DIFF
--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -279,3 +279,10 @@ module "vault_wait_for_seal_rewrap" {
   vault_install_dir    = var.vault_install_dir
   vault_instance_count = var.vault_instance_count
 }
+
+module "verify_seal_type" {
+  source = "./modules/verify_seal_type"
+
+  vault_install_dir    = var.vault_install_dir
+  vault_instance_count = var.vault_instance_count
+}

--- a/enos/modules/start_vault/main.tf
+++ b/enos/modules/start_vault/main.tf
@@ -51,7 +51,8 @@ locals {
     "awskms" = {
       type = "awskms"
       attributes = {
-        name       = "primary"
+        name       = var.seal_alias
+        priority   = var.seal_priority
         kms_key_id = var.seal_key_name
       }
     }
@@ -65,7 +66,8 @@ locals {
     "awskms" = {
       type = "awskms"
       attributes = {
-        name       = "secondary"
+        name       = var.seal_alias_secondary
+        priority   = var.seal_priority_secondary
         kms_key_id = var.seal_key_name_secondary
       }
     }

--- a/enos/modules/start_vault/variables.tf
+++ b/enos/modules/start_vault/variables.tf
@@ -53,9 +53,21 @@ variable "seal_ha_beta" {
   default     = true
 }
 
+variable "seal_alias" {
+  type        = string
+  description = "The primary seal alias name"
+  default     = "primary"
+}
+
+variable "seal_alias_secondary" {
+  type        = string
+  description = "The secondary seal alias name"
+  default     = "secondary"
+}
+
 variable "seal_key_name" {
   type        = string
-  description = "The auto-unseal key name"
+  description = "The primary auto-unseal key name"
   default     = null
 }
 
@@ -63,6 +75,18 @@ variable "seal_key_name_secondary" {
   type        = string
   description = "The secondary auto-unseal key name"
   default     = null
+}
+
+variable "seal_priority" {
+  type        = string
+  description = "The primary seal priority"
+  default     = "1"
+}
+
+variable "seal_priority_secondary" {
+  type        = string
+  description = "The secondary seal priority"
+  default     = "2"
 }
 
 variable "seal_type" {

--- a/enos/modules/verify_seal_type/main.tf
+++ b/enos/modules/verify_seal_type/main.tf
@@ -1,0 +1,52 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+terraform {
+  required_providers {
+    enos = {
+      source = "app.terraform.io/hashicorp-qti/enos"
+    }
+  }
+}
+
+variable "vault_install_dir" {
+  type        = string
+  description = "The directory where the Vault binary will be installed"
+}
+
+variable "vault_instance_count" {
+  type        = number
+  description = "How many vault instances are in the cluster"
+}
+
+variable "vault_hosts" {
+  type = map(object({
+    private_ip = string
+    public_ip  = string
+  }))
+  description = "The vault cluster instances that were created"
+}
+
+variable "seal_type" {
+  type        = string
+  description = "The expected seal type"
+  default     = "shamir"
+}
+
+resource "enos_remote_exec" "verify_seal_type" {
+  for_each = var.vault_hosts
+
+  scripts = [abspath("${path.module}/scripts/verify-seal-type.sh")]
+
+  environment = {
+    VAULT_ADDR         = "http://127.0.0.1:8200"
+    VAULT_INSTALL_DIR  = var.vault_install_dir
+    EXPECTED_SEAL_TYPE = var.seal_type
+  }
+
+  transport = {
+    ssh = {
+      host = each.value.public_ip
+    }
+  }
+}

--- a/enos/modules/verify_seal_type/scripts/verify-seal-type.sh
+++ b/enos/modules/verify_seal_type/scripts/verify-seal-type.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -e
+
+fail() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+[[ -z "$EXPECTED_SEAL_TYPE" ]] && fail "EXPECTED_SEAL_TYPE env variable has not been set"
+[[ -z "$VAULT_ADDR" ]] && fail "VAULT_ADDR env variable has not been set"
+[[ -z "$VAULT_INSTALL_DIR" ]] && fail "VAULT_INSTALL_DIR env variable has not been set"
+
+binpath=${VAULT_INSTALL_DIR}/vault
+test -x "$binpath" || fail "unable to locate vault binary at $binpath"
+
+count=0
+retries=2
+while :; do
+  if seal_status=$($binpath read sys/seal-status -format=json); then
+    if jq -Mer --arg expected "$EXPECTED_SEAL_TYPE" '.data.type == $expected' <<< "$seal_status" &> /dev/null; then
+      exit 0
+    fi
+  fi
+
+  wait=$((2 ** count))
+  count=$((count + 1))
+  if [ "$count" -lt "$retries" ]; then
+    sleep "$wait"
+  else
+    printf "Seal Status: %s\n" "$seal_status"
+    got=$(jq -Mer '.data.type' <<< "$seal_status")
+    fail "Expected seal type to be $EXPECTED_SEAL_TYPE, got: $got"
+  fi
+done


### PR DESCRIPTION
Test seal migration in the `seal_ha` scenario by removing the primary seal, waiting for seal rewrap to complete, and verifying data written only through the primary seal. We also add a verification for the seal type at various stages of the scenario.

* Allow configuring the seal alias and priority in the `start_vault` module.
* Add seal migration to `seal_ha` scenario.
* Verify the data written through the original primary seal after the seal migration.
* [QT-629] Verify the seal type at various stages in `seal_ha`.

[QT-629]: https://hashicorp.atlassian.net/browse/QT-629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ