### PR TITLE
Fix lifetime watcher user-agent reporting Vault Agent for Vault Proxy requests

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -25,14 +25,6 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/gatedwriter"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/reloadutil"
-	"github.com/kr/pretty"
-	"github.com/mitchellh/cli"
-	"github.com/oklog/run"
-	"github.com/posener/complete"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-	"google.golang.org/grpc/test/bufconn"
-
 	"github.com/hashicorp/vault/api"
 	agentConfig "github.com/hashicorp/vault/command/agent/config"
 	"github.com/hashicorp/vault/command/agent/exec"
@@ -52,6 +44,13 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/version"
+	"github.com/kr/pretty"
+	"github.com/mitchellh/cli"
+	"github.com/oklog/run"
+	"github.com/posener/complete"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"google.golang.org/grpc/test/bufconn"
 )
 
 var (
@@ -490,10 +489,11 @@ func (c *AgentCommand) Run(args []string) int {
 		// Create the lease cache proxier and set its underlying proxier to
 		// the API proxier.
 		leaseCache, err = cache.NewLeaseCache(&cache.LeaseCacheConfig{
-			Client:      proxyClient,
-			BaseContext: ctx,
-			Proxier:     apiProxy,
-			Logger:      cacheLogger.Named("leasecache"),
+			Client:         proxyClient,
+			BaseContext:    ctx,
+			Proxier:        apiProxy,
+			Logger:         cacheLogger.Named("leasecache"),
+			UserAgentToUse: useragent.ProxyAPIProxyString(),
 		})
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error creating lease cache: %v", err))

--- a/command/agent/cache_end_to_end_test.go
+++ b/command/agent/cache_end_to_end_test.go
@@ -176,10 +176,11 @@ func TestCache_UsingAutoAuthToken(t *testing.T) {
 	// Create the lease cache proxier and set its underlying proxier to
 	// the API proxier.
 	leaseCache, err := cache.NewLeaseCache(&cache.LeaseCacheConfig{
-		Client:      client,
-		BaseContext: ctx,
-		Proxier:     apiProxy,
-		Logger:      cacheLogger.Named("leasecache"),
+		Client:         client,
+		BaseContext:    ctx,
+		Proxier:        apiProxy,
+		Logger:         cacheLogger.Named("leasecache"),
+		UserAgentToUse: "test",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/command/agentproxyshared/cache/api_proxy_test.go
+++ b/command/agentproxyshared/cache/api_proxy_test.go
@@ -272,10 +272,11 @@ func setupClusterAndAgentCommon(ctx context.Context, t *testing.T, coreConfig *v
 		// Create the lease cache proxier and set its underlying proxier to
 		// the API proxier.
 		leaseCache, err = NewLeaseCache(&LeaseCacheConfig{
-			Client:      clienToUse,
-			BaseContext: ctx,
-			Proxier:     apiProxy,
-			Logger:      cacheLogger.Named("leasecache"),
+			Client:         clienToUse,
+			BaseContext:    ctx,
+			Proxier:        apiProxy,
+			Logger:         cacheLogger.Named("leasecache"),
+			UserAgentToUse: "test",
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/command/agentproxyshared/cache/lease_cache.go
+++ b/command/agentproxyshared/cache/lease_cache.go
@@ -26,7 +26,6 @@ import (
 	"github.com/hashicorp/vault/command/agentproxyshared/cache/cachememdb"
 	"github.com/hashicorp/vault/helper/namespace"
 	nshelper "github.com/hashicorp/vault/helper/namespace"
-	"github.com/hashicorp/vault/helper/useragent"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/cryptoutil"
@@ -85,6 +84,10 @@ type LeaseCache struct {
 	baseCtxInfo *cachememdb.ContextInfo
 	l           *sync.RWMutex
 
+	// userAgentToUse is the user agent to use when making independent requests
+	// to Vault.
+	userAgentToUse string
+
 	// idLocks is used during cache lookup to ensure that identical requests made
 	// in parallel won't trigger multiple renewal goroutines.
 	idLocks []*locksutil.LockEntry
@@ -115,6 +118,7 @@ type LeaseCacheConfig struct {
 	BaseContext        context.Context
 	Proxier            Proxier
 	Logger             hclog.Logger
+	UserAgentToUse     string
 	Storage            *cacheboltdb.BoltStorage
 	CacheStaticSecrets bool
 }
@@ -150,6 +154,10 @@ func NewLeaseCache(conf *LeaseCacheConfig) (*LeaseCache, error) {
 		return nil, fmt.Errorf("nil API client")
 	}
 
+	if conf.UserAgentToUse == "" {
+		return nil, fmt.Errorf("no user agent specified -- see useragent.go")
+	}
+
 	db, err := cachememdb.New()
 	if err != nil {
 		return nil, err
@@ -162,6 +170,7 @@ func NewLeaseCache(conf *LeaseCacheConfig) (*LeaseCache, error) {
 		client:             conf.Client,
 		proxier:            conf.Proxier,
 		logger:             conf.Logger,
+		userAgentToUse:     conf.UserAgentToUse,
 		db:                 db,
 		baseCtxInfo:        baseCtxInfo,
 		l:                  &sync.RWMutex{},
@@ -738,11 +747,10 @@ func (c *LeaseCache) startRenewing(ctx context.Context, index *cachememdb.Index,
 		headers = make(http.Header)
 	}
 
-	// We do not preserve the initial User-Agent here (i.e. use
-	// AgentProxyStringWithProxiedUserAgent) since these requests are from
-	// the proxy subsystem, but are made by Agent's lifetime watcher,
+	// We do not preserve any initial User-Agent here since these requests are from
+	// the proxy subsystem, but are made by the lease cache's lifetime watcher,
 	// not triggered by a specific request.
-	headers.Set("User-Agent", useragent.AgentProxyString())
+	headers.Set("User-Agent", c.userAgentToUse)
 	client.SetHeaders(headers)
 
 	watcher, err := client.NewLifetimeWatcher(&api.LifetimeWatcherInput{

--- a/command/agentproxyshared/cache/lease_cache_test.go
+++ b/command/agentproxyshared/cache/lease_cache_test.go
@@ -48,6 +48,7 @@ func testNewLeaseCache(t *testing.T, responses []*SendResponse) *LeaseCache {
 		Proxier:            NewMockProxier(responses),
 		Logger:             logging.NewVaultLogger(hclog.Trace).Named("cache.leasecache"),
 		CacheStaticSecrets: true,
+		UserAgentToUse:     "test",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -69,6 +70,7 @@ func testNewLeaseCacheWithDelay(t *testing.T, cacheable bool, delay int) *LeaseC
 		Proxier:            &mockDelayProxier{cacheable, delay},
 		Logger:             logging.NewVaultLogger(hclog.Trace).Named("cache.leasecache"),
 		CacheStaticSecrets: true,
+		UserAgentToUse:     "test",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -90,6 +92,7 @@ func testNewLeaseCacheWithPersistence(t *testing.T, responses []*SendResponse, s
 		Logger:             logging.NewVaultLogger(hclog.Trace).Named("cache.leasecache"),
 		Storage:            storage,
 		CacheStaticSecrets: true,
+		UserAgentToUse:     "test",
 	})
 	require.NoError(t, err)
 

--- a/command/agentproxyshared/helpers_test.go
+++ b/command/agentproxyshared/helpers_test.go
@@ -22,10 +22,11 @@ func testNewLeaseCache(t *testing.T, responses []*cache.SendResponse) *cache.Lea
 		t.Fatal(err)
 	}
 	lc, err := cache.NewLeaseCache(&cache.LeaseCacheConfig{
-		Client:      client,
-		BaseContext: context.Background(),
-		Proxier:     cache.NewMockProxier(responses),
-		Logger:      logging.NewVaultLogger(hclog.Trace).Named("cache.leasecache"),
+		Client:         client,
+		BaseContext:    context.Background(),
+		Proxier:        cache.NewMockProxier(responses),
+		Logger:         logging.NewVaultLogger(hclog.Trace).Named("cache.leasecache"),
+		UserAgentToUse: "test",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/command/proxy.go
+++ b/command/proxy.go
@@ -447,6 +447,7 @@ func (c *ProxyCommand) Run(args []string) int {
 			Proxier:            apiProxy,
 			Logger:             cacheLogger.Named("leasecache"),
 			CacheStaticSecrets: config.Cache.CacheStaticSecrets,
+			UserAgentToUse:     useragent.AgentProxyString(),
 		})
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error creating lease cache: %v", err))


### PR DESCRIPTION
I think this was a miss when I split Agent and Proxy. The LifetimeWatcher subsystem uses the Agent user agent even if it's Proxy's lifetime watcher.

I think this will cause merge conflicts with #23801 when I merge it, but they should be easy enough to resolve, and I'm happy to fix them.

I don't think this will have any user-facing impact yet, since this doesn't yet show up in audit logs, so I don't know that a changelog is necessary. Still, it seems good to do since we're planning on doing that eventually. I noticed this when doing work in the area and it's an easy fix.