### PR TITLE
UI: Update secrets engines sidenav to title-casing

### DIFF
--- a/changelog/23964.txt
+++ b/changelog/23964.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Update sidebar Secrets engine to title case.
+```

--- a/ui/app/components/sidebar/nav/cluster.hbs
+++ b/ui/app/components/sidebar/nav/cluster.hbs
@@ -10,8 +10,8 @@
   <Nav.Link
     @route="vault.cluster.secrets"
     @current-when="vault.cluster.secrets vault.cluster.settings.mount-secret-backend vault.cluster.settings.configure-secret-backend"
-    @text="Secrets engines"
-    data-test-sidebar-nav-link="Secrets engines"
+    @text="Secrets Engines"
+    data-test-sidebar-nav-link="Secrets Engines"
   />
   {{#if (has-permission "access")}}
     <Nav.Link

--- a/ui/tests/acceptance/secrets/backend/database/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/database/secret-test.js
@@ -461,7 +461,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
     await authPage.logout();
     // Check with restricted permissions
     await authPage.login(token);
-    await click('[data-test-sidebar-nav-link="Secrets engines"]');
+    await click('[data-test-sidebar-nav-link="Secrets Engines"]');
     assert.dom(`[data-test-secrets-backend-link="${backend}"]`).exists('Shows backend on secret list page');
     await navToConnection(backend, connection);
     assert.strictEqual(

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -276,7 +276,7 @@ module('Acceptance | Enterprise | kv-v2 workflow | edge cases', function (hooks)
   setupApplicationTest(hooks);
 
   const navToEngine = async (backend) => {
-    await click('[data-test-sidebar-nav-link="Secrets engines"]');
+    await click('[data-test-sidebar-nav-link="Secrets Engines"]');
     return await click(PAGE.backends.link(backend));
   };
 

--- a/ui/tests/acceptance/sidebar-nav-test.js
+++ b/ui/tests/acceptance/sidebar-nav-test.js
@@ -54,7 +54,7 @@ module('Acceptance | sidebar navigation', function (hooks) {
     const links = [
       { label: 'Raft Storage', route: '/vault/storage/raft' },
       { label: 'Seal Vault', route: '/vault/settings/seal' },
-      { label: 'Secrets engines', route: '/vault/secrets' },
+      { label: 'Secrets Engines', route: '/vault/secrets' },
       { label: 'Dashboard', route: '/vault/dashboard' },
     ];
 

--- a/ui/tests/integration/components/sidebar/nav/cluster-test.js
+++ b/ui/tests/integration/components/sidebar/nav/cluster-test.js
@@ -48,7 +48,7 @@ module('Integration | Component | sidebar-nav-cluster', function (hooks) {
   test('it should render nav links', async function (assert) {
     const links = [
       'Dashboard',
-      'Secrets engines',
+      'Secrets Engines',
       'Access',
       'Policies',
       'Tools',

--- a/ui/tests/pages/settings/mount-secret-backend.js
+++ b/ui/tests/pages/settings/mount-secret-backend.js
@@ -17,7 +17,7 @@ export default create({
   maxTTLUnit: fillable('[data-test-ttl-unit="Max Lease TTL"] [data-test-select="ttl-unit"]'),
   enableDefaultTtl: clickable('[data-test-toggle-input="Default Lease TTL"]'),
   enableEngine: clickable('[data-test-enable-engine]'),
-  secretList: clickable('[data-test-sidebar-nav-link="Secrets engines"]'),
+  secretList: clickable('[data-test-sidebar-nav-link="Secrets Engines"]'),
   defaultTTLVal: fillable('input[data-test-ttl-value="Default Lease TTL"]'),
   defaultTTLUnit: fillable('[data-test-ttl-unit="Default Lease TTL"] [data-test-select="ttl-unit"]'),
   enable: async function (type, path) {


### PR DESCRIPTION
Updated sidebar/nav "Secrets engines" to "Secret Engines"

<img width="345" alt="Screenshot 2023-11-02 at 10 07 29 AM" src="https://github.com/hashicorp/vault/assets/30884335/ecff0367-75e3-46b0-b814-2151c9466f34">
