### PR TITLE
Discovery - increase base font size 

### DIFF
--- a/ui/app/components/mount-backend/type-form.hbs
+++ b/ui/app/components/mount-backend/type-form.hbs
@@ -11,7 +11,7 @@
     {{#each (filter-by "category" category this.mountTypes) as |type|}}
       <SelectableCard
         id={{type.type}}
-        class="has-top-padding-m has-text-centered small-card"
+        class="has-top-padding-l has-text-centered small-card"
         @onClick={{fn @setMountType type.type}}
         @disabled={{if type.requiredFeature (not (has-feature type.requiredFeature)) false}}
         data-test-mount-type={{type.type}}

--- a/ui/app/styles/components/action-block.scss
+++ b/ui/app/styles/components/action-block.scss
@@ -8,16 +8,16 @@
   grid-row: 1/1;
 }
 @mixin stacked-content {
-  margin-bottom: $spacing-l;
+  margin-bottom: $spacing-24;
 }
 
 .action-block {
   box-shadow: 0 0 0 1px rgba($grey-dark, 0.3);
   grid-template-columns: 2fr 1fr;
   display: grid;
-  padding: $spacing-m $spacing-l;
+  padding: $spacing-16 $spacing-24;
   line-height: inherit;
-  grid-gap: $spacing-m;
+  grid-gap: $spacing-16;
 
   @include until($mobile) {
     @include stacked-grid();
@@ -52,7 +52,7 @@
 .replication-actions-grid-layout {
   display: flex;
   flex-wrap: wrap;
-  margin: $spacing-m 0;
+  margin: $spacing-16 0;
   @include until($mobile) {
     display: block;
   }
@@ -60,7 +60,7 @@
 
 .replication-actions-grid-item {
   flex-basis: 50%;
-  padding: $spacing-s;
+  padding: $spacing-12;
   display: flex;
   width: 100%;
 }

--- a/ui/app/styles/components/auth-form.scss
+++ b/ui/app/styles/components/auth-form.scss
@@ -25,14 +25,14 @@
 }
 
 .toolbar-namespace-picker {
-  padding: 0 $spacing-s;
+  padding: 0 $spacing-12;
 
   .field {
     width: 100%;
   }
 
   .field-label {
-    margin-right: $spacing-s;
+    margin-right: $spacing-12;
     align-self: center;
   }
 

--- a/ui/app/styles/components/calendar-widget.scss
+++ b/ui/app/styles/components/calendar-widget.scss
@@ -18,7 +18,7 @@ $dark-gray: #535f73;
   }
 }
 .calendar-title {
-  padding: $spacing-10 $spacing-8;
+  padding: $spacing-10 $spacing-12;
 }
 
 .select-year {

--- a/ui/app/styles/components/calendar-widget.scss
+++ b/ui/app/styles/components/calendar-widget.scss
@@ -18,7 +18,7 @@ $dark-gray: #535f73;
   }
 }
 .calendar-title {
-  padding: $size-10 $size-8;
+  padding: $spacing-10 $spacing-8;
 }
 
 .select-year {
@@ -88,7 +88,7 @@ $dark-gray: #535f73;
   background-color: $ui-gray-700;
   color: $white;
   font-size: $size-8;
-  padding: $size-9;
+  padding: $spacing-10;
   border-radius: $radius-large;
   width: 141px;
 }

--- a/ui/app/styles/components/cluster-banners.scss
+++ b/ui/app/styles/components/cluster-banners.scss
@@ -10,9 +10,9 @@
   padding: 0 1.5rem;
 
   > div {
-    margin-top: $spacing-l;
+    margin-top: $spacing-24;
     &:last-of-type {
-      margin-bottom: $spacing-l;
+      margin-bottom: $spacing-24;
     }
   }
 }

--- a/ui/app/styles/components/confirm.scss
+++ b/ui/app/styles/components/confirm.scss
@@ -110,7 +110,7 @@
   }
 
   .message-title {
-    font-size: 1rem;
+    font-size: $size-6;
   }
 
   .hs-icon {

--- a/ui/app/styles/components/confirm.scss
+++ b/ui/app/styles/components/confirm.scss
@@ -119,21 +119,21 @@
 
   p {
     font-weight: $font-weight-semibold;
-    margin-left: $spacing-l;
-    padding-left: $spacing-xxs;
+    margin-left: $spacing-24;
+    padding-left: $spacing-4;
     padding-top: 0;
   }
 
   .confirm-action-options {
     border-top: $light-border;
     display: flex;
-    padding: $spacing-xxs;
+    padding: $spacing-4;
 
     .link {
       flex: 1;
       text-align: center;
       width: auto;
-      padding: $spacing-xs;
+      padding: $spacing-8;
     }
   }
 }

--- a/ui/app/styles/components/confirm.scss
+++ b/ui/app/styles/components/confirm.scss
@@ -82,7 +82,7 @@
   }
 
   * {
-    margin-left: $size-8;
+    margin-left: $spacing-12;
   }
 
   .confirm-action-text:not(.is-block) {
@@ -90,7 +90,7 @@
 
     @include until($mobile) {
       display: block;
-      margin-bottom: $size-8;
+      margin-bottom: $spacing-12;
       text-align: left;
     }
   }

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -64,7 +64,7 @@ $console-close-height: 35px;
     color: $white;
     flex: 1 1 auto;
     font-family: $family-monospace;
-    font-size: 16px;
+    font-size: $size-6;
     font-weight: $font-weight-bold;
     outline: none;
     padding: $spacing-8;

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -28,7 +28,7 @@ $console-close-height: 35px;
   font-weight: $font-weight-semibold;
   justify-content: flex-end;
   min-height: calc(100% - $console-close-height); // account for close button that is sticky positioned
-  padding: $spacing-12 $spacing-12 $spacing-16;
+  padding: $spacing-12 $spacing-12 $spacing-18;
   transition: justify-content $speed ease-in;
 
   pre,

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -68,7 +68,7 @@ $console-close-height: 35px;
     font-weight: $font-weight-bold;
     outline: none;
     padding: $size-10;
-    margin-right: $spacing-xs;
+    margin-right: $spacing-8;
     transition: background-color $speed;
   }
 }
@@ -132,13 +132,13 @@ $console-close-height: 35px;
 
 .console-close-button {
   position: sticky;
-  top: $spacing-xs;
+  top: $spacing-8;
   height: $console-close-height;
   display: flex;
   justify-content: flex-end;
   z-index: 210;
 
   button {
-    margin-right: $spacing-xs;
+    margin-right: $spacing-8;
   }
 }

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -24,7 +24,7 @@ $console-close-height: 35px;
   color: $white;
   display: flex;
   flex-direction: column;
-  font-size: 14px;
+  font-size: $size-8;
   font-weight: $font-weight-semibold;
   justify-content: flex-end;
   min-height: calc(100% - $console-close-height); // account for close button that is sticky positioned
@@ -35,7 +35,7 @@ $console-close-height: 35px;
   p {
     background: none;
     color: inherit;
-    font-size: 14px;
+    font-size: $size-8;
     min-height: 2rem;
     padding: 0;
 

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -28,7 +28,7 @@ $console-close-height: 35px;
   font-weight: $font-weight-semibold;
   justify-content: flex-end;
   min-height: calc(100% - $console-close-height); // account for close button that is sticky positioned
-  padding: $size-8 $size-8 $size-5;
+  padding: $spacing-12 $spacing-12 $spacing-16;
   transition: justify-content $speed ease-in;
 
   pre,
@@ -40,15 +40,15 @@ $console-close-height: 35px;
     padding: 0;
 
     &:not(.console-ui-command):not(.CodeMirror-line) {
-      padding-left: $size-4;
+      padding-left: $spacing-20;
     }
   }
 
   .cm-s-hashi.CodeMirror {
     background-color: rgba($black, 0.5) !important;
     font-weight: $font-weight-normal;
-    margin-left: $size-4;
-    padding: $size-8 $size-4;
+    margin-left: $spacing-20;
+    padding: $spacing-12 $spacing-20;
   }
 }
 
@@ -67,7 +67,7 @@ $console-close-height: 35px;
     font-size: 16px;
     font-weight: $font-weight-bold;
     outline: none;
-    padding: $size-10;
+    padding: $spacing-8;
     margin-right: $spacing-8;
     transition: background-color $speed;
   }
@@ -80,7 +80,7 @@ $console-close-height: 35px;
 .console-ui-output {
   transition: background-color $speed ease-in-out;
   will-change: background-color;
-  padding-right: $size-2;
+  padding-right: $spacing-36;
   position: relative;
   background-color: rgba(#000, 0);
   &:hover {
@@ -89,7 +89,7 @@ $console-close-height: 35px;
 }
 
 .console-ui-alert {
-  margin-left: calc(#{$size-4} - 0.33rem);
+  margin-left: calc(#{$spacing-20} - 0.33rem);
   position: relative;
 
   svg {

--- a/ui/app/styles/components/control-group.scss
+++ b/ui/app/styles/components/control-group.scss
@@ -17,7 +17,7 @@
 }
 .control-group-header {
   box-shadow: 0 0 1px currentColor;
-  padding: $size-9 $size-6;
+  padding: $spacing-10 $spacing-14;
   background: $grey-lightest;
   color: $grey-dark;
   position: relative;
@@ -32,5 +32,5 @@
 }
 
 .control-group .authorizations {
-  margin-top: $size-9;
+  margin-top: $spacing-10;
 }

--- a/ui/app/styles/components/empty-state-component.scss
+++ b/ui/app/styles/components/empty-state-component.scss
@@ -9,7 +9,7 @@
   background: $ui-gray-010;
   display: flex;
   justify-content: center;
-  padding: $spacing-xxl $spacing-s;
+  padding: $spacing-48 $spacing-12;
   box-shadow: 0 -2px 0 -1px $ui-gray-300;
 }
 
@@ -19,7 +19,7 @@
   background: transparent;
   display: flex;
   justify-content: center;
-  padding: $spacing-xxl 0;
+  padding: $spacing-48 0;
   box-shadow: none;
 }
 
@@ -32,21 +32,21 @@
   font-size: $size-4;
   font-weight: $font-weight-semibold;
   line-height: 1.2;
-  margin-bottom: $spacing-xs;
+  margin-bottom: $spacing-8;
 }
 
 .empty-state-subTitle {
   font-size: $size-7;
   margin-top: -10px;
-  padding-bottom: $spacing-s;
+  padding-bottom: $spacing-12;
 }
 
 .empty-state-message.has-border-bottom-light {
-  padding-bottom: $spacing-s;
+  padding-bottom: $spacing-12;
 }
 
 .empty-state-actions {
-  margin-top: $spacing-xs;
+  margin-top: $spacing-8;
   display: flex;
   justify-content: space-between;
 
@@ -60,13 +60,13 @@
   }
 
   > * + * {
-    margin-left: $spacing-s;
-    margin-right: $spacing-s;
+    margin-left: $spacing-12;
+    margin-right: $spacing-12;
   }
 }
 
 .empty-state-icon > .hs-icon,
 .empty-state-icon > .flight-icon {
   float: left;
-  margin-right: $spacing-xs;
+  margin-right: $spacing-8;
 }

--- a/ui/app/styles/components/empty-state-component.scss
+++ b/ui/app/styles/components/empty-state-component.scss
@@ -36,7 +36,7 @@
 }
 
 .empty-state-subTitle {
-  font-size: $size-7;
+  font-size: $size-6;
   margin-top: -10px;
   padding-bottom: $spacing-12;
 }

--- a/ui/app/styles/components/env-banner.scss
+++ b/ui/app/styles/components/env-banner.scss
@@ -5,7 +5,7 @@
 
 .env-banner {
   align-self: center;
-  border-radius: $size-1;
+  border-radius: $spacing-42;
   background: linear-gradient(
     135deg,
     $blue,

--- a/ui/app/styles/components/env-banner.scss
+++ b/ui/app/styles/components/env-banner.scss
@@ -23,7 +23,7 @@
   .notification {
     background-color: transparent;
     line-height: 1.66;
-    padding: 0 $spacing-s;
+    padding: 0 $spacing-12;
   }
 }
 

--- a/ui/app/styles/components/features-selection.scss
+++ b/ui/app/styles/components/features-selection.scss
@@ -11,15 +11,15 @@
 
 .access-information {
   display: flex;
-  padding: $size-8 0px;
+  padding: $spacing-12 0px;
   font-size: $size-8;
 }
 
 .feature-box {
   box-shadow: $box-shadow;
   border-radius: $radius;
-  padding: $size-8;
-  margin: $size-8 0;
+  padding: $spacing-12;
+  margin: $spacing-12 0;
 
   &.is-active {
     box-shadow: 0 0 0 1px $grey-light;
@@ -33,7 +33,7 @@
 
 .feature-box label {
   font-weight: $font-weight-semibold;
-  padding-left: $size-10;
+  padding-left: $spacing-8;
 
   &::before {
     top: 3px;
@@ -48,13 +48,13 @@
   font-size: $size-8;
   color: $grey;
   line-height: 1.5;
-  margin-left: $size-3;
-  margin-top: $size-10;
+  margin-left: $spacing-24;
+  margin-top: $spacing-8;
 
   li::before {
     // bullet
     content: '\2022';
     position: relative;
-    right: $size-11;
+    right: $spacing-4;
   }
 }

--- a/ui/app/styles/components/global-flash.scss
+++ b/ui/app/styles/components/global-flash.scss
@@ -5,7 +5,7 @@
 
 .global-flash {
   bottom: 0;
-  left: $spacing-s;
+  left: $spacing-12;
   margin: 10px;
   max-width: $drawer-width;
   position: fixed;

--- a/ui/app/styles/components/icon.scss
+++ b/ui/app/styles/components/icon.scss
@@ -6,10 +6,10 @@
 .icon {
   align-items: center;
   display: inline-flex;
-  height: $size-4;
+  height: $spacing-16;
   justify-content: center;
   vertical-align: middle;
-  width: $size-4;
+  width: $spacing-16;
   // override the display if .button.icon to .button's default display: inline-block. See manage namespaces icon button in the namespace picker
   &.button {
     display: inline-block;
@@ -34,8 +34,8 @@
   justify-content: center;
   align-items: flex-start;
   vertical-align: middle;
-  width: 16px;
-  height: 16px;
+  width: $spacing-16;
+  height: $spacing-16;
   margin: 2px 4px;
 }
 
@@ -50,6 +50,7 @@
   align-items: center;
 }
 
+// TODO used??
 .hs-icon-s {
   width: 12px;
   height: 12px;

--- a/ui/app/styles/components/icon.scss
+++ b/ui/app/styles/components/icon.scss
@@ -23,8 +23,8 @@
 .flight-icon {
   &.flight-icon-display-inline {
     vertical-align: middle;
-    margin-left: $spacing-xxs;
-    margin-right: $spacing-xxs;
+    margin-left: $spacing-4;
+    margin-right: $spacing-4;
   }
 }
 

--- a/ui/app/styles/components/info-table-row.scss
+++ b/ui/app/styles/components/info-table-row.scss
@@ -27,7 +27,7 @@
 
   .column {
     align-self: center;
-    padding: $spacing-m;
+    padding: $spacing-16;
 
     &.info-table-row-edit {
       padding-bottom: 0.3rem;

--- a/ui/app/styles/components/info-table-row.scss
+++ b/ui/app/styles/components/info-table-row.scss
@@ -18,7 +18,7 @@
   &.thead {
     box-shadow: 0 1px 0 $grey-light, 0 -1px 0 $grey-light;
     margin: 0;
-    padding: 0 $size-6 0 0;
+    padding: 0 $spacing-14 0 0;
 
     .column {
       padding: 0.5rem 0.75rem;
@@ -48,7 +48,7 @@
   }
 
   .hs-icon {
-    margin-right: $size-11;
+    margin-right: $spacing-4;
   }
 
   .icon-true {
@@ -73,7 +73,7 @@
     padding-left: 0;
 
     @include until($mobile) {
-      padding: $size-8 0 0;
+      padding: $spacing-12 0 0;
     }
   }
 
@@ -81,7 +81,7 @@
     padding-right: 0;
 
     @include until($mobile) {
-      padding: 0 0 $size-8;
+      padding: 0 0 $spacing-12;
     }
   }
 }

--- a/ui/app/styles/components/kmip-role-edit.scss
+++ b/ui/app/styles/components/kmip-role-edit.scss
@@ -10,5 +10,5 @@
   padding: 0;
 }
 .kmip-role-allowed-operations .field {
-  margin-bottom: $spacing-xxs;
+  margin-bottom: $spacing-4;
 }

--- a/ui/app/styles/components/known-secondaries-card.scss
+++ b/ui/app/styles/components/known-secondaries-card.scss
@@ -13,7 +13,7 @@
   }
 
   .secondaries-table {
-    margin-bottom: $spacing-s;
+    margin-bottom: $spacing-12;
   }
 
   .link {

--- a/ui/app/styles/components/known-secondaries-card.scss
+++ b/ui/app/styles/components/known-secondaries-card.scss
@@ -17,7 +17,7 @@
   }
 
   .link {
-    font-size: $size-7;
+    font-size: $size-6;
     text-decoration: none;
   }
 }

--- a/ui/app/styles/components/list-item-row.scss
+++ b/ui/app/styles/components/list-item-row.scss
@@ -41,10 +41,10 @@ a.list-item-row,
   &:hover,
   &:focus,
   &:active {
-    margin-left: #{-$size-9} !important;
-    margin-right: #{-$size-9} !important;
-    padding-left: $size-9;
-    padding-right: $size-9;
+    margin-left: #{-$spacing-10} !important;
+    margin-right: #{-$spacing-10} !important;
+    padding-left: $spacing-10;
+    padding-right: $spacing-10;
     position: relative;
     box-shadow: 0 2px 0 -1px $grey-light, 0 -2px 0 -1px $grey-light, $box-link-hover-shadow,
       $box-shadow-middle;

--- a/ui/app/styles/components/masked-input.scss
+++ b/ui/app/styles/components/masked-input.scss
@@ -13,7 +13,7 @@
 }
 
 .has-label .masked-input {
-  padding-top: $spacing-s;
+  padding-top: $spacing-12;
 }
 
 .has-padding {
@@ -44,12 +44,12 @@
   font-size: 1rem;
   padding-top: 0;
   padding-bottom: 0;
-  padding-left: $spacing-s;
+  padding-left: $spacing-12;
   background-color: transparent;
 }
 
 .button.masked-input-toggle {
-  min-width: $spacing-xl;
+  min-width: $spacing-36;
   border-left: 0;
   color: $grey;
   box-shadow: 0 3px 1px 0px rgba(10, 10, 10, 0.12);
@@ -64,7 +64,7 @@
     background: transparent;
     height: auto;
     line-height: 1rem;
-    min-width: $spacing-l;
+    min-width: $spacing-24;
     border: 0;
     box-shadow: none;
     color: $grey-light;

--- a/ui/app/styles/components/masked-input.scss
+++ b/ui/app/styles/components/masked-input.scss
@@ -17,7 +17,7 @@
 }
 
 .has-padding {
-  padding: $size-10 $size-8;
+  padding: $spacing-8 $spacing-12;
 }
 
 // we want to style the boxes the same everywhere so they

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -7,7 +7,7 @@
   position: relative;
   color: var(--token-color-palette-neutral-300);
   display: flex;
-  padding: $spacing-xxs $spacing-xs;
+  padding: $spacing-4 $spacing-8;
   width: 100%;
 }
 
@@ -22,7 +22,7 @@
   flex: 1 1 auto;
   height: 2rem;
   justify-content: space-between;
-  margin-right: $spacing-xxs;
+  margin-right: $spacing-4;
 }
 
 .namespace-picker-content {

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -45,7 +45,7 @@
 }
 
 .namespace-header-bar {
-  padding: $size-11 $size-9;
+  padding: $spacing-4 $spacing-10;
   border-bottom: 1px solid rgba($black, 0.1);
   font-weight: $font-weight-semibold;
   min-height: 32px;
@@ -72,12 +72,12 @@
   color: $black;
   text-decoration: none;
   font-weight: $font-weight-semibold;
-  padding: $size-10 $size-9 $size-10 0;
+  padding: $spacing-8 $spacing-10 $spacing-8 0;
 }
 
 .namespace-link.is-current {
-  margin-top: $size-8;
-  margin-right: -$size-10;
+  margin-top: $spacing-12;
+  margin-right: -$spacing-8;
 
   svg {
     margin-top: 2px;
@@ -86,7 +86,7 @@
 }
 
 .leaf-panel {
-  padding: $size-11 $size-9;
+  padding: $spacing-4 $spacing-10;
   transition: transform ease-in-out 250ms;
   will-change: transform;
   transform: translateX(0);

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -56,7 +56,7 @@
 
   .level-left {
     font-weight: $font-weight-bold;
-    font-size: 14px;
+    font-size: $size-8;
   }
   .level-right {
     margin-right: 10px;

--- a/ui/app/styles/components/namespace-reminder.scss
+++ b/ui/app/styles/components/namespace-reminder.scss
@@ -5,7 +5,7 @@
 
 .namespace-reminder {
   color: $grey;
-  margin: 0 0 $size-6 0;
+  margin: 0 0 $spacing-14 0;
 }
 
 .console-reminder p.namespace-reminder {

--- a/ui/app/styles/components/namespace-reminder.scss
+++ b/ui/app/styles/components/namespace-reminder.scss
@@ -12,7 +12,7 @@
   color: $grey;
   font-family: $family-monospace;
   font-size: $size-8;
-  margin: $spacing-xxs 0 0;
+  margin: $spacing-4 0 0;
   opacity: 0.7;
   position: absolute;
 

--- a/ui/app/styles/components/overview-card.scss
+++ b/ui/app/styles/components/overview-card.scss
@@ -4,6 +4,6 @@
  */
 
 .overview-card {
-  padding: $spacing-l;
+  padding: $spacing-24;
   line-height: initial;
 }

--- a/ui/app/styles/components/page-header-old.scss
+++ b/ui/app/styles/components/page-header-old.scss
@@ -4,8 +4,8 @@
  */
 
 .page-header {
-  padding-bottom: $size-10;
-  padding-top: $size-4;
+  padding-bottom: $spacing-8;
+  padding-top: $spacing-20;
 
   .level {
     align-items: flex-end;
@@ -26,7 +26,7 @@
   }
 
   .title {
-    margin-top: $size-2;
+    margin-top: $spacing-36;
   }
 
   .title-with-icon {
@@ -34,7 +34,7 @@
   }
 
   .breadcrumb + .level .title {
-    margin-top: $size-4;
+    margin-top: $spacing-20;
   }
   .title .icon {
     height: auto;

--- a/ui/app/styles/components/popup-menu.scss
+++ b/ui/app/styles/components/popup-menu.scss
@@ -40,7 +40,7 @@
     border: none;
     display: block;
     height: auto;
-    font-size: $size-7;
+    font-size: $size-6;
     font-weight: $font-weight-semibold;
     padding: $spacing-10 $spacing-8;
     text-align: left;

--- a/ui/app/styles/components/popup-menu.scss
+++ b/ui/app/styles/components/popup-menu.scss
@@ -27,7 +27,7 @@
   }
 
   .menu {
-    padding: $size-11 0;
+    padding: spacing-4 0;
   }
 
   button.link,
@@ -42,7 +42,7 @@
     height: auto;
     font-size: $size-7;
     font-weight: $font-weight-semibold;
-    padding: $size-9 $size-8;
+    padding: $spacing-10 $spacing-8;
     text-align: left;
     text-decoration: none;
     width: 100%;
@@ -95,12 +95,12 @@
     font-weight: $font-weight-normal;
     letter-spacing: 0;
     margin: 0;
-    padding: $size-10 $size-8 0;
+    padding: $spacing-8 $spacing-12 0;
     text-transform: uppercase;
   }
 
   .menu-content {
-    padding: $size-10 $size-8;
+    padding: $spacing-8 $spacing-12;
   }
 
   hr {
@@ -111,7 +111,7 @@
 
 .popup-menu-content p {
   box-shadow: none;
-  padding-top: $size-10;
+  padding-top: $spacing-8;
   font-weight: $font-weight-semibold;
 }
 

--- a/ui/app/styles/components/popup-menu.scss
+++ b/ui/app/styles/components/popup-menu.scss
@@ -27,7 +27,7 @@
   }
 
   .menu {
-    padding: spacing-4 0;
+    padding: $spacing-4 0;
   }
 
   button.link,
@@ -42,7 +42,7 @@
     height: auto;
     font-size: $size-6;
     font-weight: $font-weight-semibold;
-    padding: $spacing-10 $spacing-8;
+    padding: $spacing-10 $spacing-12;
     text-align: left;
     text-decoration: none;
     width: 100%;

--- a/ui/app/styles/components/radio-card.scss
+++ b/ui/app/styles/components/radio-card.scss
@@ -78,7 +78,7 @@
 
 .radio-card-message-title {
   font-weight: $font-weight-semibold;
-  font-size: $size-7;
+  font-size: $size-6;
   margin-bottom: $spacing-4;
 }
 .radio-card-message-body {

--- a/ui/app/styles/components/radio-card.scss
+++ b/ui/app/styles/components/radio-card.scss
@@ -5,14 +5,14 @@
 
 .radio-card-selector {
   display: flex;
-  margin-bottom: $spacing-xs;
+  margin-bottom: $spacing-8;
 }
 .radio-card {
   box-shadow: $box-shadow-low;
   flex: 1 1 25%;
   flex-direction: column;
   justify-content: space-between;
-  margin: $spacing-xs $spacing-m;
+  margin: $spacing-8 $spacing-16;
   border: $base-border;
   border-radius: $radius;
   transition: all ease-in-out $speed;
@@ -67,19 +67,19 @@
 .radio-card-row {
   display: flex;
   flex: 1;
-  padding: $spacing-m;
+  padding: $spacing-16;
 }
 .radio-card-icon {
   color: $ui-gray-300;
 }
 .radio-card-message {
-  margin: $spacing-xxs;
+  margin: $spacing-4;
 }
 
 .radio-card-message-title {
   font-weight: $font-weight-semibold;
   font-size: $size-7;
-  margin-bottom: $spacing-xxs;
+  margin-bottom: $spacing-4;
 }
 .radio-card-message-body {
   line-height: 1.2;
@@ -91,7 +91,7 @@
   display: flex;
   justify-content: center;
   background: $ui-gray-050;
-  padding: $spacing-xs;
+  padding: $spacing-8;
 }
 
 .is-selected {

--- a/ui/app/styles/components/raft-join.scss
+++ b/ui/app/styles/components/raft-join.scss
@@ -7,8 +7,8 @@
   margin-bottom: 0;
 }
 .raft-join .box.is-fullwidth {
-  padding-top: $spacing-s;
-  padding-bottom: $spacing-s;
+  padding-top: $spacing-12;
+  padding-bottom: $spacing-12;
 }
 .raft-join-unseal {
   color: $orange;

--- a/ui/app/styles/components/regex-validator.scss
+++ b/ui/app/styles/components/regex-validator.scss
@@ -29,5 +29,5 @@
   }
 }
 .regex-group-value {
-  margin-right: $spacing-m;
+  margin-right: $spacing-16;
 }

--- a/ui/app/styles/components/replication-dashboard.scss
+++ b/ui/app/styles/components/replication-dashboard.scss
@@ -23,16 +23,16 @@
   }
 
   .title.is-6 {
-    margin-bottom: $spacing-xs;
+    margin-bottom: $spacing-8;
   }
 
   .reindexing-alert,
   .syncing-alert {
-    margin-top: $spacing-xl;
+    margin-top: $spacing-36;
   }
 
   .selectable-card-container {
-    margin-top: $spacing-xl;
+    margin-top: $spacing-36;
     display: grid;
 
     &.primary,
@@ -47,15 +47,15 @@
 
     &.secondary {
       grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-      grid-gap: $spacing-xl;
+      grid-gap: $spacing-36;
     }
 
     .card-container {
       display: grid;
-      grid-gap: $spacing-s;
+      grid-gap: $spacing-12;
       grid-template-columns: 1fr 1fr;
       grid-template-rows: 0.2fr 0.2fr 0.2fr;
-      padding: $spacing-l;
+      padding: $spacing-24;
       line-height: 1.5;
 
       &.summary {
@@ -120,11 +120,11 @@
     }
 
     &.summary {
-      margin-bottom: $spacing-xl;
+      margin-bottom: $spacing-36;
     }
   }
   .summary-state {
-    padding-bottom: $spacing-xl;
+    padding-bottom: $spacing-36;
     border-bottom: 1px solid rgba($grey-dark, 0.3);
   }
 

--- a/ui/app/styles/components/replication-mode-summary.scss
+++ b/ui/app/styles/components/replication-mode-summary.scss
@@ -7,10 +7,10 @@
   flex-shrink: 1;
 
   .title {
-    margin-bottom: $spacing-xs;
+    margin-bottom: $spacing-8;
   }
 
   .detail-tags {
-    margin-bottom: $spacing-m;
+    margin-bottom: $spacing-16;
   }
 }

--- a/ui/app/styles/components/replication-summary.scss
+++ b/ui/app/styles/components/replication-summary.scss
@@ -13,7 +13,7 @@
   }
 
   .float-right {
-    margin: $spacing-s 0 $spacing-l 0;
+    margin: $spacing-12 0 $spacing-24 0;
     float: right;
   }
 }

--- a/ui/app/styles/components/search-select.scss
+++ b/ui/app/styles/components/search-select.scss
@@ -44,12 +44,12 @@
 
   &::after {
     background: $white;
-    bottom: $spacing-xxs;
+    bottom: $spacing-4;
     content: '';
-    left: $spacing-xxs + $spacing-l;
+    left: $spacing-4 + $spacing-24;
     position: absolute;
-    right: $spacing-xxs;
-    top: $spacing-xxs;
+    right: $spacing-4;
+    top: $spacing-4;
     z-index: -1;
   }
 }
@@ -57,16 +57,16 @@
 .ember-power-select-search-input {
   background: transparent;
   border: 0;
-  padding: $spacing-xxs $spacing-s;
-  padding-left: $spacing-xxs + $spacing-l;
+  padding: $spacing-4 $spacing-12;
+  padding-left: $spacing-4 + $spacing-24;
 }
 
 div > .ember-power-select-options {
   background: $white;
   border: $base-border;
   box-shadow: $box-shadow-middle;
-  margin: -4px $spacing-xs 0;
-  padding: $spacing-xxs 0;
+  margin: -4px $spacing-8 0;
+  padding: $spacing-4 0;
 
   .ember-power-select-option,
   .ember-power-select-option[aria-current='true'] {
@@ -97,7 +97,7 @@ div > .ember-power-select-options {
 .search-select-list-item {
   align-items: center;
   display: flex;
-  padding: $spacing-xxs;
+  padding: $spacing-4;
   justify-content: space-between;
   border-bottom: $light-border;
 

--- a/ui/app/styles/components/selectable-card.scss
+++ b/ui/app/styles/components/selectable-card.scss
@@ -17,7 +17,7 @@
   }
 
   &.small-card {
-    width: 7rem;
+    width: 6.5rem;
     min-height: 8rem;
   }
 }

--- a/ui/app/styles/components/shamir-progress.scss
+++ b/ui/app/styles/components/shamir-progress.scss
@@ -6,12 +6,12 @@
 .shamir-progress {
   .shamir-progress-progress {
     display: inline-block;
-    margin-top: $size-10;
-    margin-right: $size-8;
+    margin-top: $spacing-8;
+    margin-right: $spacing-12;
   }
   .progress {
     box-shadow: 0 0 0 4px $ui-gray-050;
-    margin-top: $size-10;
+    margin-top: $spacing-8;
     min-width: 90px;
   }
 }

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -19,7 +19,7 @@
   }
 
   .confirm-action-message p {
-    padding-top: $size-10;
+    padding-top: $spacing-8;
     font-weight: $font-weight-semibold;
     color: $black;
   }

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -9,7 +9,7 @@
   .popup-menu-content {
     .menu-label {
       color: $black;
-      font-size: 14px;
+      font-size: $size-8;
       font-weight: $font-weight-bold;
       text-transform: unset;
     }

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -14,7 +14,7 @@
       text-transform: unset;
     }
     .token-alert {
-      padding: $spacing-xs;
+      padding: $spacing-8;
     }
   }
 

--- a/ui/app/styles/components/splash-page.scss
+++ b/ui/app/styles/components/splash-page.scss
@@ -4,10 +4,10 @@
  */
 
 .splash-page-logo {
-  padding: $spacing-xs $spacing-s $spacing-xs $spacing-l;
+  padding: $spacing-8 $spacing-12 $spacing-8 $spacing-24;
 
   @include from($mobile) {
-    padding-left: $spacing-xs;
+    padding-left: $spacing-8;
   }
 
   svg {
@@ -16,7 +16,7 @@
     width: 72px;
 
     @include from($mobile) {
-      margin-left: $spacing-xs;
+      margin-left: $spacing-8;
     }
   }
 }

--- a/ui/app/styles/components/splash-page.scss
+++ b/ui/app/styles/components/splash-page.scss
@@ -22,9 +22,9 @@
 }
 
 .splash-page-container {
-  margin: $size-2 0;
+  margin: $spacing-36 0;
 }
 
 .splash-page-header {
-  padding: $size-6 0;
+  padding: $spacing-14 0;
 }

--- a/ui/app/styles/components/stat-text.scss
+++ b/ui/app/styles/components/stat-text.scss
@@ -14,7 +14,7 @@
     .stat-label {
       font-size: $size-5;
       font-weight: $font-weight-semibold;
-      margin-bottom: $spacing-xxs;
+      margin-bottom: $spacing-4;
       line-height: inherit;
     }
     .stat-text {
@@ -26,7 +26,7 @@
     .stat-value {
       font-size: $size-3;
       font-weight: $font-weight-normal;
-      margin-top: $spacing-s;
+      margin-top: $spacing-12;
     }
   }
 
@@ -45,7 +45,7 @@
     .stat-value {
       font-size: $size-5;
       font-weight: $font-weight-normal;
-      margin-top: $spacing-s;
+      margin-top: $spacing-12;
     }
   }
 
@@ -64,7 +64,7 @@
     .stat-value {
       font-size: $size-3;
       font-weight: $font-weight-normal;
-      margin-top: $spacing-xxs;
+      margin-top: $spacing-4;
     }
   }
 
@@ -83,7 +83,7 @@
     .stat-value {
       font-size: $size-5;
       font-weight: $font-weight-normal;
-      margin-top: $spacing-xxs;
+      margin-top: $spacing-4;
     }
   }
 

--- a/ui/app/styles/components/tabs-component.scss
+++ b/ui/app/styles/components/tabs-component.scss
@@ -70,7 +70,7 @@
     border-bottom: 2px solid transparent;
     color: $grey;
     font-weight: $font-weight-semibold;
-    padding: $size-6 $size-8 $size-8;
+    padding: $spacing-14 $spacing-12 $spacing-12;
     text-decoration: none;
     transition: background-color $speed, border-color $speed;
 

--- a/ui/app/styles/components/tool-tip.scss
+++ b/ui/app/styles/components/tool-tip.scss
@@ -4,7 +4,7 @@
  */
 
 .tool-tip {
-  font-size: $size-7;
+  font-size: $size-6;
   text-transform: none;
   margin: 8px 0px 0 -4px;
 

--- a/ui/app/styles/components/tool-tip.scss
+++ b/ui/app/styles/components/tool-tip.scss
@@ -45,7 +45,7 @@
   &::before,
   &::after {
     right: auto;
-    left: $spacing-s;
+    left: $spacing-12;
   }
 }
 .ember-basic-dropdown-content--right.tool-tip {

--- a/ui/app/styles/components/toolbar.scss
+++ b/ui/app/styles/components/toolbar.scss
@@ -105,7 +105,7 @@
 
   &.popup-menu-trigger {
     height: 2.5rem;
-    padding: $size-10 $size-8;
+    padding: $spacing-8 $spacing-12;
   }
 
   &.disabled {

--- a/ui/app/styles/components/toolbar.scss
+++ b/ui/app/styles/components/toolbar.scss
@@ -21,7 +21,7 @@
     position: absolute;
     right: 0;
     top: 0;
-    width: $spacing-xxs;
+    width: $spacing-4;
     z-index: 2;
   }
 
@@ -32,7 +32,7 @@
 }
 
 .toolbar-label {
-  padding: $spacing-xs;
+  padding: $spacing-8;
   color: $grey;
 }
 
@@ -45,17 +45,17 @@
   width: 100%;
 
   @include from($mobile) {
-    padding: 0 $spacing-xxs;
+    padding: 0 $spacing-4;
   }
 
   &::-webkit-scrollbar {
     border-bottom: $base-border;
-    height: $spacing-xxs;
+    height: $spacing-4;
   }
 
   &::-webkit-scrollbar-thumb {
     background: $ui-gray-300;
-    border-radius: $spacing-xxs;
+    border-radius: $spacing-4;
   }
 }
 
@@ -74,8 +74,8 @@
 .toolbar-filters + .toolbar-actions {
   @include until($mobile) {
     border-left: $base-border;
-    margin-left: $spacing-xs;
-    padding-left: $spacing-xs;
+    margin-left: $spacing-8;
+    padding-left: $spacing-8;
   }
 }
 
@@ -133,6 +133,6 @@ a.disabled.toolbar-link {
 .toolbar-separator {
   border-right: $light-border;
   height: 32px;
-  margin: 0 $spacing-xs;
+  margin: 0 $spacing-8;
   width: 0;
 }

--- a/ui/app/styles/components/transform-edit.scss
+++ b/ui/app/styles/components/transform-edit.scss
@@ -15,5 +15,5 @@
   font-family: $family-monospace;
 }
 .transform-decode-formats:not(:last-child) {
-  margin-bottom: $spacing-s;
+  margin-bottom: $spacing-12;
 }

--- a/ui/app/styles/components/transform-edit.scss
+++ b/ui/app/styles/components/transform-edit.scss
@@ -8,7 +8,7 @@
 
   & > code {
     color: $ui-gray-800;
-    padding: 14px;
+    padding: $spacing-14;
   }
 }
 .transform-pattern-text div:not(:first-child) {

--- a/ui/app/styles/components/transit-card.scss
+++ b/ui/app/styles/components/transit-card.scss
@@ -9,7 +9,7 @@
   grid-template-rows: 1fr;
   align-content: start;
   grid-gap: 2rem;
-  margin-top: $spacing-l;
+  margin-top: $spacing-24;
 }
 
 .transit-card {
@@ -17,7 +17,7 @@
   box-shadow: 0 0 0 1px rgba($grey-light, 0.4);
   display: grid;
   grid-template-columns: 0.45fr 2fr;
-  padding: $spacing-m;
+  padding: $spacing-16;
   border: none;
 
   .transit-icon {
@@ -33,7 +33,7 @@
   .title {
     color: $grey;
     font-size: $size-7;
-    margin-bottom: $spacing-xxs;
+    margin-bottom: $spacing-4;
   }
 
   &:hover {

--- a/ui/app/styles/components/transit-card.scss
+++ b/ui/app/styles/components/transit-card.scss
@@ -32,7 +32,7 @@
 
   .title {
     color: $grey;
-    font-size: $size-7;
+    font-size: $size-6;
     margin-bottom: $spacing-4;
   }
 

--- a/ui/app/styles/components/ui-wizard.scss
+++ b/ui/app/styles/components/ui-wizard.scss
@@ -32,14 +32,14 @@
 
 .ui-wizard {
   z-index: 300;
-  padding: $size-5;
+  padding: $spacing-16;
   width: $drawer-width;
   background: $white;
   box-shadow: $box-shadow, $box-shadow-highest;
   position: fixed;
-  right: $size-8;
-  bottom: $size-8;
-  top: calc(#{4rem} + #{$size-8});
+  right: $spacing-12;
+  bottom: $spacing-12;
+  top: calc(#{4rem} + #{$spacing-12});
   overflow: auto;
 
   p {
@@ -56,20 +56,20 @@
   }
 
   .doc-link {
-    margin-top: $size-5;
+    margin-top: $spacing-16;
     display: block;
   }
 
   pre code {
     background: $ui-gray-050;
-    margin: $size-8 0;
+    margin: $spacing-12 0;
   }
 }
 
 .wizard-header {
   border-bottom: $light-border;
-  padding: 0 $size-4 $size-8 0;
-  margin: $size-4 0;
+  padding: 0 $spacing-20 $spacing-12 0;
+  margin: $spacing-20 0;
   position: relative;
 
   @include until($mobile) {
@@ -81,7 +81,7 @@
 .wizard-dismiss-menu {
   position: absolute;
   right: 0;
-  top: -$size-11;
+  top: -$spacing-8;
   z-index: 10;
 }
 
@@ -93,10 +93,10 @@
   box-shadow: $box-shadow-middle;
   height: auto;
   min-height: 0;
-  padding-bottom: $size-11;
+  padding-bottom: $spacing-8;
   position: fixed;
-  right: $size-8;
-  top: calc(#{4rem} + #{$size-8});
+  right: $spacing-12;
+  top: calc(#{4rem} + #{$spacing-12});
 
   @include until($mobile) {
     box-shadow: $box-shadow, 0 0 20px rgba($black, 0.24);
@@ -113,7 +113,7 @@
 
   .wizard-header {
     border-bottom: 0;
-    margin: 0 0 $size-10;
+    margin: 0 0 $spacing-8;
     padding-top: 0;
   }
 
@@ -131,8 +131,8 @@
 .wizard-divider-box {
   background: none;
   box-shadow: none;
-  margin: $size-8 0 0;
-  padding: 0 $size-8;
+  margin: $spacing-12 0 0;
+  padding: 0 $spacing-12;
   border-top: solid 1px $white;
   border-image: linear-gradient(to right, $grey-dark, $grey) 1;
   border-width: 1px 0 0;
@@ -143,21 +143,21 @@
 }
 
 .wizard-section:last-of-type {
-  margin-bottom: $size-5;
+  margin-bottom: $spacing-16;
 }
 
 .wizard-section button:not(:last-of-type) {
-  margin-bottom: $size-10;
+  margin-bottom: $spacing-8;
 }
 
 .wizard-details {
-  padding-top: $size-4;
-  margin-top: $size-4;
+  padding-top: $spacing-20;
+  margin-top: $spacing-20;
   border-top: 1px solid $grey-light;
 }
 
 .wizard-instructions {
-  margin: $size-4 0;
+  margin: $spacing-20 0;
 }
 
 .selection-summary {

--- a/ui/app/styles/components/ui-wizard.scss
+++ b/ui/app/styles/components/ui-wizard.scss
@@ -137,7 +137,7 @@
   border-image: linear-gradient(to right, $grey-dark, $grey) 1;
   border-width: 1px 0 0;
   button {
-    font-size: $size-7;
+    font-size: $size-6;
     font-weight: $font-weight-semibold;
   }
 }

--- a/ui/app/styles/components/ui-wizard.scss
+++ b/ui/app/styles/components/ui-wizard.scss
@@ -32,7 +32,7 @@
 
 .ui-wizard {
   z-index: 300;
-  padding: $spacing-16;
+  padding: $spacing-18;
   width: $drawer-width;
   background: $white;
   box-shadow: $box-shadow, $box-shadow-highest;
@@ -56,7 +56,7 @@
   }
 
   .doc-link {
-    margin-top: $spacing-16;
+    margin-top: $spacing-18;
     display: block;
   }
 
@@ -143,7 +143,7 @@
 }
 
 .wizard-section:last-of-type {
-  margin-bottom: $spacing-16;
+  margin-bottom: $spacing-18;
 }
 
 .wizard-section button:not(:last-of-type) {

--- a/ui/app/styles/components/vlt-table.scss
+++ b/ui/app/styles/components/vlt-table.scss
@@ -37,7 +37,7 @@
   }
 
   tbody th {
-    font-size: $size-7;
+    font-size: $size-6;
   }
 
   tr {
@@ -57,7 +57,7 @@
   }
 
   code {
-    font-size: $size-7;
+    font-size: $size-6;
     color: $black;
   }
 }

--- a/ui/app/styles/components/vlt-table.scss
+++ b/ui/app/styles/components/vlt-table.scss
@@ -25,7 +25,7 @@
 
   th,
   td {
-    padding: $spacing-s;
+    padding: $spacing-12;
   }
 
   th {

--- a/ui/app/styles/core/box.scss
+++ b/ui/app/styles/core/box.scss
@@ -9,7 +9,7 @@
   box-shadow: 0 0 0 1px rgba($grey-dark, 0.3);
   color: $ui-gray-900;
   display: block;
-  padding: $size-5;
+  padding: $spacing-16;
 
   &:not(:last-child) {
     margin-bottom: 1.5rem;

--- a/ui/app/styles/core/box.scss
+++ b/ui/app/styles/core/box.scss
@@ -9,7 +9,7 @@
   box-shadow: 0 0 0 1px rgba($grey-dark, 0.3);
   color: $ui-gray-900;
   display: block;
-  padding: $spacing-16;
+  padding: $spacing-18;
 
   &:not(:last-child) {
     margin-bottom: 1.5rem;

--- a/ui/app/styles/core/box.scss
+++ b/ui/app/styles/core/box.scss
@@ -35,6 +35,6 @@
   &.has-container {
     box-shadow: 0 4px 4px rgba($black, 0.25);
     border: $base-border;
-    padding: $spacing-l;
+    padding: $spacing-24;
   }
 }

--- a/ui/app/styles/core/breadcrumb.scss
+++ b/ui/app/styles/core/breadcrumb.scss
@@ -67,7 +67,7 @@
     &::before {
       color: $blue;
       content: '❮';
-      font-size: 1rem;
+      font-size: $size-6;
       line-height: 1;
       opacity: 0.33;
     }

--- a/ui/app/styles/core/breadcrumb.scss
+++ b/ui/app/styles/core/breadcrumb.scss
@@ -49,7 +49,7 @@
     display: flex;
     justify-content: center;
     line-height: 1;
-    padding: 0 $size-11 0 0;
+    padding: 0 $spacing-4 0 0;
     text-decoration: none;
 
     &:hover {

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -58,7 +58,7 @@
 
   &.is-compact {
     height: 2rem;
-    padding: $size-11 $size-8;
+    padding: $spacing-4 $spacing-12;
   }
 
   &.is-danger {
@@ -111,7 +111,7 @@
   }
 
   &.is-icon {
-    padding: 0.25rem $size-3;
+    padding: 0.25rem $spacing-24;
   }
 
   &.is-loading {
@@ -246,7 +246,7 @@
       &,
       &:first-child:last-child {
         position: relative;
-        left: -$size-10;
+        left: -$spacing-8;
       }
     }
   }
@@ -264,7 +264,7 @@
 
 .button.icon {
   box-sizing: border-box;
-  padding: 0 $size-11;
+  padding: 0 $spacing-4;
   height: 24px;
   width: 24px;
   &,

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -356,7 +356,7 @@ a.button.disabled {
 
   &.in-dropdown {
     div {
-      font-size: $size-7;
+      font-size: $size-6;
     }
     svg {
       color: transparent;

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -255,8 +255,8 @@
     .hs-icon {
       &,
       &:first-child:last-child {
-        margin-left: $spacing-xxs;
-        margin-right: -$spacing-xxs;
+        margin-left: $spacing-4;
+        margin-right: -$spacing-4;
       }
     }
   }

--- a/ui/app/styles/core/charts.scss
+++ b/ui/app/styles/core/charts.scss
@@ -6,8 +6,8 @@
 .chart-wrapper {
   border: $light-border;
   border-radius: $radius-large;
-  padding: $spacing-s $spacing-l;
-  margin-bottom: $spacing-m;
+  padding: $spacing-12 $spacing-24;
+  margin-bottom: $spacing-16;
 }
 
 // GRID LAYOUT //
@@ -97,8 +97,8 @@
   grid-column-end: 4;
   grid-row-start: 2;
   grid-row-end: 5;
-  padding-bottom: $spacing-xl;
-  margin-bottom: $spacing-s;
+  padding-bottom: $spacing-36;
+  margin-bottom: $spacing-12;
   box-shadow: inset 0 -1px 0 $ui-gray-200;
 
   > h2 {
@@ -114,8 +114,8 @@
   grid-column-end: 8;
   grid-row-start: 2;
   grid-row-end: 5;
-  padding-bottom: $spacing-xl;
-  margin-bottom: $spacing-s;
+  padding-bottom: $spacing-36;
+  margin-bottom: $spacing-12;
   box-shadow: inset 0 -1px 0 $ui-gray-200;
 
   > h2 {
@@ -196,29 +196,29 @@
 h2.chart-title {
   font-weight: $font-weight-bold;
   font-size: $size-5;
-  line-height: $spacing-l;
-  margin-bottom: $spacing-xxs;
+  line-height: $spacing-24;
+  margin-bottom: $spacing-4;
 }
 
 p.chart-description {
   color: $ui-gray-700;
   font-size: 14px;
   line-height: 18px;
-  margin-bottom: $spacing-xs;
+  margin-bottom: $spacing-8;
 }
 
 p.chart-subtext {
   color: $ui-gray-500;
   font-size: $size-8;
   line-height: 16px;
-  margin-top: $spacing-xs;
+  margin-top: $spacing-8;
 }
 
 h3.data-details {
   font-weight: $font-weight-bold;
   font-size: $size-8;
   line-height: 14px;
-  margin-bottom: $spacing-xs;
+  margin-bottom: $spacing-8;
 }
 
 p.data-details {
@@ -245,8 +245,8 @@ p.data-details {
 }
 
 .legend-label {
-  padding-left: $spacing-xs;
-  padding-right: $spacing-xl;
+  padding-left: $spacing-8;
+  padding-right: $spacing-36;
 }
 
 .chart-tooltip {
@@ -269,7 +269,7 @@ p.data-details {
     width: fit-content;
   }
   .horizontal-chart {
-    padding: $spacing-s;
+    padding: $spacing-12;
   }
 }
 
@@ -324,16 +324,16 @@ p.data-details {
     grid-column-end: 4;
     grid-row-start: 2;
     grid-row-end: 3;
-    margin-left: $spacing-xxl;
-    margin-right: $spacing-xxl;
+    margin-left: $spacing-48;
+    margin-right: $spacing-48;
   }
   .chart-container-right {
     grid-column-start: 1;
     grid-column-end: 4;
     grid-row-start: 3;
     grid-row-end: 4;
-    margin-left: $spacing-xxl;
-    margin-right: $spacing-xxl;
+    margin-left: $spacing-48;
+    margin-right: $spacing-48;
   }
 
   .legend-center {

--- a/ui/app/styles/core/charts.scss
+++ b/ui/app/styles/core/charts.scss
@@ -202,7 +202,7 @@ h2.chart-title {
 
 p.chart-description {
   color: $ui-gray-700;
-  font-size: 14px;
+  font-size: $size-8;
   line-height: 18px;
   margin-bottom: $spacing-8;
 }
@@ -217,7 +217,7 @@ p.chart-subtext {
 h3.data-details {
   font-weight: $font-weight-bold;
   font-size: $size-8;
-  line-height: 14px;
+  line-height: $spacing-14;
   margin-bottom: $spacing-8;
 }
 

--- a/ui/app/styles/core/checkbox-and-radio.scss
+++ b/ui/app/styles/core/checkbox-and-radio.scss
@@ -42,7 +42,7 @@
 // one-off checkbox class
 .checkbox-help-text {
   color: $ui-gray-700;
-  font-size: $size-7;
+  font-size: $size-6;
   padding-left: 28px;
 }
 

--- a/ui/app/styles/core/columns.scss
+++ b/ui/app/styles/core/columns.scss
@@ -7,12 +7,12 @@
 
 // Columns (plural)
 .columns {
-  margin-left: -$size-9;
-  margin-right: -$size-9;
-  margin-top: -$size-9;
+  margin-left: -$spacing-10;
+  margin-right: -$spacing-10;
+  margin-top: -$spacing-10;
 
   &:last-child {
-    margin-bottom: -$size-9;
+    margin-bottom: -$spacing-10;
   }
 
   &.is-centered {
@@ -31,7 +31,7 @@
   }
 
   &.is-gapless:not(:last-child) {
-    margin-bottom: $size-4;
+    margin-bottom: $spacing-20;
   }
 
   &.is-gapless:last-child {

--- a/ui/app/styles/core/containers.scss
+++ b/ui/app/styles/core/containers.scss
@@ -21,7 +21,7 @@
   display: flex;
   flex-grow: 1;
   flex-direction: column;
-  padding: 0 $size-4;
+  padding: 0 $spacing-20;
 
   > .container {
     display: flex;

--- a/ui/app/styles/core/element-styling.scss
+++ b/ui/app/styles/core/element-styling.scss
@@ -80,7 +80,7 @@ object {
 
 html {
   background-color: $white;
-  font-size: 14px;
+  font-size: $base-font-size;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   min-width: 300px;

--- a/ui/app/styles/core/field.scss
+++ b/ui/app/styles/core/field.scss
@@ -13,7 +13,7 @@
   }
 
   &:not(:last-child) {
-    margin-bottom: $size-4;
+    margin-bottom: $spacing-20;
   }
 }
 // must come after field due to overriding the margin-bottom of not last-child
@@ -110,7 +110,7 @@ fieldset.form-fieldset {
     flex-shrink: 1;
 
     > .field:not(:last-child) {
-      margin-right: $size-9;
+      margin-right: $spacing-10;
     }
     .field:not(.is-narrow) {
       flex-grow: 1;

--- a/ui/app/styles/core/file.scss
+++ b/ui/app/styles/core/file.scss
@@ -45,7 +45,7 @@
   @extend .is-transparent;
   color: $grey;
   position: absolute;
-  right: $spacing-xs;
+  right: $spacing-8;
 }
 
 .file-icon {

--- a/ui/app/styles/core/file.scss
+++ b/ui/app/styles/core/file.scss
@@ -25,8 +25,13 @@
   vertical-align: top;
   white-space: nowrap;
 
+  // TODO is this still a thing?
+  // hds-button--size-medium {
+  //   min-height: 2.25rem;
+  //   padding: 0.5625rem 0.9375rem;
+  // }
   &.button {
-    height: $size-2; // in older parts of the code (Ex: shamir-modal-flow) this class is not a button. In newer parts of the code it is, and height needs to match the height of a button (2.5rem).
+    height: $spacing-36; // in older parts of the code (Ex: shamir-modal-flow) this class is not a button. In newer parts of the code it is, and height needs to match the height of a button (2.5rem).
   }
 
   &:disabled {

--- a/ui/app/styles/core/footer.scss
+++ b/ui/app/styles/core/footer.scss
@@ -6,7 +6,7 @@
 .footer {
   background-color: transparent;
   border-top: $base-border;
-  padding: $size-3 1.5rem;
+  padding: $spacing-24 1.5rem;
   margin-top: auto;
 
   span:not(:first-child) {

--- a/ui/app/styles/core/inputs.scss
+++ b/ui/app/styles/core/inputs.scss
@@ -14,12 +14,12 @@
   color: $grey-dark;
   display: inline-flex;
   font-size: $size-6;
-  height: $size-2;
+  height: $spacing-36;
   line-height: 1.5;
   max-width: 100%;
   padding-bottom: calc(0.375em - 1px);
-  padding-left: $size-8;
-  padding-right: $size-8;
+  padding-left: $spacing-12;
+  padding-right: $spacing-12;
   padding-top: calc(0.375em - 1px);
   width: 100%;
 
@@ -79,7 +79,7 @@
 
 // custom input
 .input-hint {
-  padding: 0 $size-9;
+  padding: 0 $spacing-10;
   font-size: $size-8;
   color: $grey;
 }

--- a/ui/app/styles/core/label.scss
+++ b/ui/app/styles/core/label.scss
@@ -7,7 +7,7 @@
 
 .is-label {
   color: $grey-darkest;
-  font-size: 14px;
+  font-size: $size-8;
   font-weight: $font-weight-bold;
   display: flex;
   align-items: center;

--- a/ui/app/styles/core/label.scss
+++ b/ui/app/styles/core/label.scss
@@ -11,7 +11,7 @@
   font-weight: $font-weight-bold;
   display: flex;
   align-items: center;
-  gap: $spacing-xxs;
+  gap: $spacing-4;
   width: min-content;
   min-width: 100%;
 

--- a/ui/app/styles/core/level.scss
+++ b/ui/app/styles/core/level.scss
@@ -45,7 +45,7 @@
 
 .level.is-mobile .level-item:not(:last-child) {
   margin-bottom: 0;
-  margin-right: $size-9;
+  margin-right: $spacing-10;
 }
 
 .level.is-mobile .level-item:not(.is-narrow) {
@@ -92,6 +92,6 @@
 
 @media screen and (max-width: 768px) {
   .level-item:not(:last-child) {
-    margin-bottom: $size-9;
+    margin-bottom: $spacing-10;
   }
 }

--- a/ui/app/styles/core/lists.scss
+++ b/ui/app/styles/core/lists.scss
@@ -17,7 +17,7 @@
 }
 
 .list-header {
-  margin: $size-9 $size-9 0;
+  margin: $spacing-10 $spacing-10 0;
   color: $grey;
   font-size: $size-8;
   font-weight: $font-weight-semibold;

--- a/ui/app/styles/core/lists.scss
+++ b/ui/app/styles/core/lists.scss
@@ -26,5 +26,5 @@
 
 ul.bullet {
   list-style: disc;
-  padding-left: $spacing-m;
+  padding-left: $spacing-16;
 }

--- a/ui/app/styles/core/menu.scss
+++ b/ui/app/styles/core/menu.scss
@@ -9,7 +9,7 @@
 
 .menu a {
   display: block;
-  padding: $size-10 $size-9;
+  padding: $spacing-8 $spacing-10;
   text-decoration: none;
 }
 

--- a/ui/app/styles/core/message.scss
+++ b/ui/app/styles/core/message.scss
@@ -26,7 +26,7 @@
 
   .message-title {
     color: $blue-500;
-    font-size: 16px;
+    font-size: $size-6;
     font-weight: $font-weight-bold;
     line-height: 1.25;
   }

--- a/ui/app/styles/core/message.scss
+++ b/ui/app/styles/core/message.scss
@@ -11,8 +11,8 @@
 .message {
   background: $blue-010;
   border: 1px solid $blue-100;
-  margin-bottom: $spacing-s;
-  padding: $spacing-s $spacing-m $spacing-m $spacing-s;
+  margin-bottom: $spacing-12;
+  padding: $spacing-12 $spacing-16 $spacing-16 $spacing-12;
   position: relative;
 
   &:not(:last-child) {
@@ -21,7 +21,7 @@
 
   .message-icon {
     color: $blue;
-    margin-right: $spacing-xs;
+    margin-right: $spacing-8;
   }
 
   .message-title {
@@ -34,7 +34,7 @@
   .message-body {
     border: 0;
     padding: 1em 1.25em;
-    margin-top: $spacing-xxs;
+    margin-top: $spacing-4;
   }
 
   // message types, see message-types.js

--- a/ui/app/styles/core/message.scss
+++ b/ui/app/styles/core/message.scss
@@ -16,7 +16,7 @@
   position: relative;
 
   &:not(:last-child) {
-    margin-bottom: $size-4;
+    margin-bottom: $spacing-20;
   }
 
   .message-icon {

--- a/ui/app/styles/core/progress.scss
+++ b/ui/app/styles/core/progress.scss
@@ -23,7 +23,7 @@
     width: 30px;
   }
   &.is-medium {
-    height: $spacing-16;
+    height: $spacing-18;
     width: 120px;
   }
 }

--- a/ui/app/styles/core/progress.scss
+++ b/ui/app/styles/core/progress.scss
@@ -10,7 +10,7 @@
   box-shadow: inset $box-link-shadow;
   border-radius: $radius;
   display: block;
-  height: $size-6;
+  height: $spacing-14;
   overflow: hidden;
   padding: 0;
   margin-bottom: 0;
@@ -23,7 +23,7 @@
     width: 30px;
   }
   &.is-medium {
-    height: $size-5;
+    height: $spacing-16;
     width: 120px;
   }
 }

--- a/ui/app/styles/core/select.scss
+++ b/ui/app/styles/core/select.scss
@@ -21,8 +21,8 @@ select {
   max-width: 100%;
   outline: none;
   padding-bottom: calc(0.375em - 1px);
-  padding-left: $size-8;
-  padding-right: $size-8;
+  padding-left: $spacing-12;
+  padding-right: $spacing-12;
   padding-top: calc(0.375em - 1px);
   text-rendering: auto !important;
 
@@ -44,7 +44,7 @@ select {
 }
 
 .select select:not([multiple]) {
-  padding-right: $size-2;
+  padding-right: $spacing-36;
 }
 
 .select select[disabled] {

--- a/ui/app/styles/core/select.scss
+++ b/ui/app/styles/core/select.scss
@@ -76,7 +76,7 @@ select {
   margin: 0;
   pointer-events: none;
   position: absolute;
-  right: $spacing-xs;
+  right: $spacing-8;
   top: 50%;
   transform: translateY(-50%);
   width: 24px;

--- a/ui/app/styles/core/switch.scss
+++ b/ui/app/styles/core/switch.scss
@@ -114,7 +114,7 @@
       will-change: left;
 
       &:checked {
-        left: $spacing-16;
+        left: $spacing-18;
       }
     }
   }

--- a/ui/app/styles/core/switch.scss
+++ b/ui/app/styles/core/switch.scss
@@ -27,8 +27,8 @@
       display: block;
       top: calc(50% - 1.5rem * 0.5);
       left: 0;
-      width: $size-1;
-      height: $size-4;
+      width: $spacing-42;
+      height: $spacing-20;
       border: 0.1rem solid transparent;
       border-radius: $radius-large;
       background: $ui-gray-300;
@@ -40,13 +40,13 @@
       border-radius: $radius-large;
       content: '';
       display: block;
-      height: $size-6;
-      left: $size-11;
+      height: $spacing-14;
+      left: $spacing-4;
       position: absolute;
       top: calc(50% - 1rem * 0.5);
       transform: translate3d(0, 0, 0);
       transition: all 0.25s ease-out;
-      width: $size-6;
+      width: $spacing-14;
     }
 
     &:checked::after {
@@ -55,6 +55,7 @@
   }
 }
 
+// TODO is this why the toggles are off???
 // is-rounded
 .switch[type='checkbox'].is-rounded {
   + label {
@@ -84,36 +85,36 @@
     font-size: $size-8;
     font-weight: bold;
     height: 18px;
-    padding-left: $size-8 * 2.5;
+    padding-left: $spacing-12 * 2.5;
     position: relative;
-    margin: 0 $size-11;
+    margin: 0 $spacing-4;
     &::before {
       border: 0.1rem solid transparent;
       border-radius: $radius-large;
       background: $ui-gray-300;
       display: block;
       content: '';
-      height: $size-8;
+      height: $spacing-12;
       position: absolute;
-      top: calc($size-8 / 5);
-      width: $size-8 * 2;
+      top: calc($spacing-12 / 5);
+      width: $spacing-12 * 2;
     }
     &::after {
       background: $white;
       border-radius: $radius-large;
       content: '';
       display: block;
-      height: $size-8 * 0.8;
+      height: $spacing-12 * 0.8;
       left: 0;
       position: absolute;
-      top: calc($size-8 / 4);
+      top: calc($spacing-12 / 4);
       transform: translateX(0.15rem);
       transition: all 0.25s ease-out;
-      width: $size-8 * 0.8;
+      width: $spacing-12 * 0.8;
       will-change: left;
 
       &:checked {
-        left: $size-5;
+        left: $spacing-16;
       }
     }
   }

--- a/ui/app/styles/core/tag.scss
+++ b/ui/app/styles/core/tag.scss
@@ -34,7 +34,7 @@
   }
 
   &.has-extra-padding {
-    padding: $size-11 $spacing-xxs;
+    padding: $size-11 $spacing-4;
   }
 }
 

--- a/ui/app/styles/core/tag.scss
+++ b/ui/app/styles/core/tag.scss
@@ -16,8 +16,8 @@
   height: auto;
   justify-content: center;
   line-height: 1.5;
-  margin-right: $size-10;
-  padding: 0 $size-10;
+  margin-right: $spacing-8;
+  padding: 0 $spacing-8;
   white-space: nowrap;
   vertical-align: middle;
 
@@ -34,7 +34,7 @@
   }
 
   &.has-extra-padding {
-    padding: $size-11 $spacing-4;
+    padding: $spacing-4 $spacing-4;
   }
 }
 

--- a/ui/app/styles/core/title.scss
+++ b/ui/app/styles/core/title.scss
@@ -45,7 +45,7 @@
   }
 
   &.is-7 {
-    font-size: $size-7;
+    font-size: $size-6;
   }
 
   &.is-8 {
@@ -59,6 +59,6 @@
 
 .is-subtitle-gray {
   text-transform: uppercase;
-  font-size: $size-7;
+  font-size: $size-6;
   color: $ui-gray-500;
 }

--- a/ui/app/styles/core/title.scss
+++ b/ui/app/styles/core/title.scss
@@ -24,9 +24,6 @@
   }
 
   // title sizes
-  &.is-2 {
-    font-size: $size-2;
-  }
 
   &.is-3 {
     font-size: $size-3;

--- a/ui/app/styles/core/title.scss
+++ b/ui/app/styles/core/title.scss
@@ -54,7 +54,7 @@
 }
 
 .form-section .title {
-  margin-bottom: $spacing-s;
+  margin-bottom: $spacing-12;
 }
 
 .is-subtitle-gray {

--- a/ui/app/styles/core/toggle.scss
+++ b/ui/app/styles/core/toggle.scss
@@ -67,28 +67,29 @@
 }
 
 /* CUSTOM */
+// TODO or is this why the toggles are off??
 .toggle[type='checkbox'] {
   &.is-small {
     + label {
       font-size: $size-7;
-      padding-left: $size-8 * 2.5;
+      padding-left: $spacing-12 * 2.5;
       margin: 0 0.25rem;
       &::before {
-        top: calc($size-8 / 5);
-        height: $size-8;
-        width: $size-8 * 2;
+        top: calc($spacing-12 / 5);
+        height: $spacing-12;
+        width: $spacing-12 * 2;
       }
       &::after {
-        width: $size-8 * 0.8;
-        height: $size-8 * 0.8;
+        width: $spacing-12 * 0.8;
+        height: $spacing-12 * 0.8;
         transform: translateX(0.15rem);
         left: 0;
-        top: calc($size-8 / 4);
+        top: calc($spacing-12 / 4);
       }
     }
     &:checked + label::after {
       left: 0;
-      transform: translateX(($size-8 * 2) - ($size-8 * 0.94));
+      transform: translateX(($spacing-12 * 2) - ($spacing-12 * 0.94));
     }
   }
 

--- a/ui/app/styles/core/toggle.scss
+++ b/ui/app/styles/core/toggle.scss
@@ -71,7 +71,7 @@
 .toggle[type='checkbox'] {
   &.is-small {
     + label {
-      font-size: $size-7;
+      font-size: $size-6;
       padding-left: $spacing-12 * 2.5;
       margin: 0 0.25rem;
       &::before {

--- a/ui/app/styles/helper-classes/flexbox-and-grid.scss
+++ b/ui/app/styles/helper-classes/flexbox-and-grid.scss
@@ -21,11 +21,11 @@
 }
 
 .has-gap-m {
-  gap: $spacing-m;
+  gap: $spacing-16;
 }
 
 .has-gap-l {
-  gap: $spacing-l;
+  gap: $spacing-24;
 }
 
 // Alignment of the items
@@ -66,7 +66,7 @@
   justify-content: flex-start;
 
   &.has-gap {
-    gap: $spacing-m;
+    gap: $spacing-16;
   }
 }
 
@@ -118,11 +118,11 @@
   }
 
   &.row-gap-8 {
-    row-gap: $spacing-xs;
+    row-gap: $spacing-8;
   }
 
   &.column-gap-16 {
-    column-gap: $spacing-m;
+    column-gap: $spacing-16;
   }
 }
 

--- a/ui/app/styles/helper-classes/general.scss
+++ b/ui/app/styles/helper-classes/general.scss
@@ -61,7 +61,7 @@
 .is-hint {
   color: $grey;
   font-size: $size-8;
-  padding: $size-8 0;
+  padding: $spacing-12 0;
 }
 
 .is-optional {

--- a/ui/app/styles/helper-classes/layout.scss
+++ b/ui/app/styles/helper-classes/layout.scss
@@ -42,7 +42,7 @@
 }
 
 .top-xxs {
-  top: $spacing-xxs;
+  top: $spacing-4;
 }
 
 // visibility

--- a/ui/app/styles/helper-classes/spacing.scss
+++ b/ui/app/styles/helper-classes/spacing.scss
@@ -31,7 +31,7 @@
 }
 
 .has-padding-m {
-  padding: $spacing-16;
+  padding: $spacing-18;
 }
 .has-padding-l {
   padding: $spacing-24;
@@ -46,7 +46,7 @@
 }
 
 .has-bottom-padding-m {
-  padding-bottom: $spacing-16;
+  padding-bottom: $spacing-18;
 }
 
 .has-bottom-padding-l {
@@ -58,7 +58,7 @@
 }
 
 .has-top-padding-m {
-  padding-top: $spacing-16;
+  padding-top: $spacing-18;
 }
 
 .has-top-padding-l {
@@ -95,8 +95,8 @@
 }
 
 .has-top-bottom-margin-negative-m {
-  margin-top: -$spacing-16;
-  margin-bottom: -$spacing-16;
+  margin-top: -$spacing-18;
+  margin-bottom: -$spacing-18;
 }
 
 .has-top-margin-negative-xxl {
@@ -124,7 +124,7 @@
 }
 
 .has-bottom-margin-m {
-  margin-bottom: $spacing-16;
+  margin-bottom: $spacing-18;
 }
 
 .has-bottom-margin-l {
@@ -152,7 +152,7 @@
 }
 
 .has-top-margin-m {
-  margin-top: $spacing-16;
+  margin-top: $spacing-18;
 }
 
 .has-top-margin-l {
@@ -184,7 +184,7 @@
 }
 
 .has-left-margin-m {
-  margin-left: $spacing-16;
+  margin-left: $spacing-18;
 }
 
 .has-left-margin-l {
@@ -196,7 +196,7 @@
 }
 
 .has-right-margin-m {
-  margin-right: $spacing-16;
+  margin-right: $spacing-18;
 }
 
 .has-right-margin-l {

--- a/ui/app/styles/helper-classes/spacing.scss
+++ b/ui/app/styles/helper-classes/spacing.scss
@@ -10,7 +10,7 @@
 }
 
 .has-short-padding {
-  padding: $spacing-4 $spacing-17;
+  padding: $spacing-4 $spacing-18;
 }
 
 .has-tall-padding {
@@ -87,7 +87,7 @@
 }
 
 .has-top-bottom-margin {
-  margin: $spacing-17 0rem;
+  margin: $spacing-18 0rem;
 }
 
 .has-top-bottom-margin-xxs {

--- a/ui/app/styles/helper-classes/spacing.scss
+++ b/ui/app/styles/helper-classes/spacing.scss
@@ -22,67 +22,67 @@
 }
 
 .has-side-padding-s {
-  padding-left: $spacing-s;
-  padding-right: $spacing-s;
+  padding-left: $spacing-12;
+  padding-right: $spacing-12;
 }
 
 .has-padding-s {
-  padding: $spacing-s;
+  padding: $spacing-12;
 }
 
 .has-padding-xxs {
-  padding: $spacing-xxs;
+  padding: $spacing-4;
 }
 
 .has-padding-m {
-  padding: $spacing-m;
+  padding: $spacing-16;
 }
 .has-padding-l {
-  padding: $spacing-l;
+  padding: $spacing-24;
 }
 
 .has-padding-l {
-  padding: $spacing-l;
+  padding: $spacing-24;
 }
 
 .has-bottom-padding-s {
-  padding-bottom: $spacing-s;
+  padding-bottom: $spacing-12;
 }
 
 .has-bottom-padding-m {
-  padding-bottom: $spacing-m;
+  padding-bottom: $spacing-16;
 }
 
 .has-bottom-padding-l {
-  padding-bottom: $spacing-l;
+  padding-bottom: $spacing-24;
 }
 
 .has-top-padding-s {
-  padding-top: $spacing-s;
+  padding-top: $spacing-12;
 }
 
 .has-top-padding-m {
-  padding-top: $spacing-m;
+  padding-top: $spacing-16;
 }
 
 .has-top-padding-l {
-  padding-top: $spacing-l;
+  padding-top: $spacing-24;
 }
 
 .has-left-padding-xs {
-  padding-left: $spacing-xs;
+  padding-left: $spacing-8;
 }
 
 .has-left-padding-s {
-  padding-left: $spacing-s;
+  padding-left: $spacing-12;
 }
 
 .has-left-padding-l {
-  padding-left: $spacing-l;
+  padding-left: $spacing-24;
 }
 
 .has-top-padding-xxl {
-  padding-top: $spacing-xxl;
+  padding-top: $spacing-48;
 }
 
 // All Margin helpers
@@ -95,114 +95,114 @@
 }
 
 .has-top-bottom-margin-xxs {
-  margin: $spacing-xxs 0;
+  margin: $spacing-4 0;
 }
 
 .has-top-bottom-margin-negative-m {
-  margin-top: -$spacing-m;
-  margin-bottom: -$spacing-m;
+  margin-top: -$spacing-16;
+  margin-bottom: -$spacing-16;
 }
 
 .has-top-margin-negative-xxl {
-  margin-top: -$spacing-xxl;
+  margin-top: -$spacing-48;
 }
 
 .has-right-margin-xxs {
-  margin-right: $spacing-xxs;
+  margin-right: $spacing-4;
 }
 
 .has-left-margin-xxs {
-  margin-left: $spacing-xxs;
+  margin-left: $spacing-4;
 }
 
 .has-bottom-margin-xxs {
-  margin-bottom: $spacing-xxs !important;
+  margin-bottom: $spacing-4 !important;
 }
 
 .has-bottom-margin-xs {
-  margin-bottom: $spacing-xs !important;
+  margin-bottom: $spacing-8 !important;
 }
 
 .has-bottom-margin-s {
-  margin-bottom: $spacing-s;
+  margin-bottom: $spacing-12;
 }
 
 .has-bottom-margin-m {
-  margin-bottom: $spacing-m;
+  margin-bottom: $spacing-16;
 }
 
 .has-bottom-margin-l {
-  margin-bottom: $spacing-l;
+  margin-bottom: $spacing-24;
 }
 
 .has-bottom-margin-xl {
-  margin-bottom: $spacing-xl;
+  margin-bottom: $spacing-36;
 }
 
 .has-bottom-margin-xxl {
-  margin-bottom: $spacing-xxl;
+  margin-bottom: $spacing-48;
 }
 
 .has-top-margin-xxs {
-  margin-top: $spacing-xxs;
+  margin-top: $spacing-4;
 }
 
 .has-top-margin-s {
-  margin-top: $spacing-s;
+  margin-top: $spacing-12;
 }
 
 .has-top-margin-xs {
-  margin-top: $spacing-xs;
+  margin-top: $spacing-8;
 }
 
 .has-top-margin-m {
-  margin-top: $spacing-m;
+  margin-top: $spacing-16;
 }
 
 .has-top-margin-l {
-  margin-top: $spacing-l;
+  margin-top: $spacing-24;
 }
 
 .has-top-margin-xl {
-  margin-top: $spacing-xl;
+  margin-top: $spacing-36;
 }
 
 .has-top-margin-xxl {
-  margin-top: $spacing-xxl;
+  margin-top: $spacing-48;
 }
 
 .has-top-margin-negative-s {
-  margin-top: (-1 * $spacing-s);
+  margin-top: (-1 * $spacing-12);
 }
 
 .has-left-margin-xxs {
-  margin-left: $spacing-xxs;
+  margin-left: $spacing-4;
 }
 
 .has-left-margin-xs {
-  margin-left: $spacing-xs;
+  margin-left: $spacing-8;
 }
 
 .has-left-margin-s {
-  margin-left: $spacing-s;
+  margin-left: $spacing-12;
 }
 
 .has-left-margin-m {
-  margin-left: $spacing-m;
+  margin-left: $spacing-16;
 }
 
 .has-left-margin-l {
-  margin-left: $spacing-l;
+  margin-left: $spacing-24;
 }
 
 .has-left-margin-xl {
-  margin-left: $spacing-xl;
+  margin-left: $spacing-36;
 }
 
 .has-right-margin-m {
-  margin-right: $spacing-m;
+  margin-right: $spacing-16;
 }
 
 .has-right-margin-l {
-  margin-right: $spacing-l;
+  margin-right: $spacing-24;
 }

--- a/ui/app/styles/helper-classes/spacing.scss
+++ b/ui/app/styles/helper-classes/spacing.scss
@@ -5,20 +5,16 @@
 
 /* Helpers that define anything with the margin or padding. */
 
-/* Notes
-- these helpers are generally defined in px but some (if they use $size-xx) are using rems.
-*/
-
 .is-paddingless {
   padding: 0 !important;
 }
 
 .has-short-padding {
-  padding: $size-11 $size-5;
+  padding: $spacing-4 $spacing-17;
 }
 
 .has-tall-padding {
-  padding: $size-2;
+  padding: $spacing-36;
 }
 
 .has-side-padding-s {
@@ -91,7 +87,7 @@
 }
 
 .has-top-bottom-margin {
-  margin: $size-5 0rem;
+  margin: $spacing-17 0rem;
 }
 
 .has-top-bottom-margin-xxs {

--- a/ui/app/styles/helper-classes/spacing.scss
+++ b/ui/app/styles/helper-classes/spacing.scss
@@ -33,9 +33,6 @@
 .has-padding-m {
   padding: $spacing-18;
 }
-.has-padding-l {
-  padding: $spacing-24;
-}
 
 .has-padding-l {
   padding: $spacing-24;

--- a/ui/app/styles/helper-classes/typography.scss
+++ b/ui/app/styles/helper-classes/typography.scss
@@ -90,18 +90,18 @@
 // Text color or styling
 .is-help {
   font-size: $size-8;
-  margin-top: $size-11;
+  margin-top: $spacing-4;
 }
 
 .help {
   display: block;
   font-size: 0.85714rem;
-  margin-top: $size-11;
+  margin-top: $spacing-4;
 }
 
 .sub-text {
   color: $grey;
-  margin-bottom: $size-11;
+  margin-bottom: $spacing-4;
   font-size: $size-8;
 
   strong {

--- a/ui/app/styles/helper-classes/typography.scss
+++ b/ui/app/styles/helper-classes/typography.scss
@@ -6,10 +6,6 @@
 /* This helper includes styles relating to: font-size, font-family, font-alignment, text-transform, text-weight, font-style, text-decoration. */
 
 // font size helpers
-.is-size-4 {
-  font-size: $size-4 !important;
-}
-
 .is-size-5 {
   font-size: $size-5 !important;
 }

--- a/ui/app/styles/helper-classes/typography.scss
+++ b/ui/app/styles/helper-classes/typography.scss
@@ -6,10 +6,6 @@
 /* This helper includes styles relating to: font-size, font-family, font-alignment, text-transform, text-weight, font-style, text-decoration. */
 
 // font size helpers
-.is-size-5 {
-  font-size: $size-5 !important;
-}
-
 .is-size-6 {
   font-size: $size-6 !important;
 }

--- a/ui/app/styles/helper-classes/typography.scss
+++ b/ui/app/styles/helper-classes/typography.scss
@@ -19,7 +19,7 @@
 }
 
 .is-size-7 {
-  font-size: $size-7 !important;
+  font-size: $size-6 !important;
 }
 
 .is-size-8 {

--- a/ui/app/styles/helper-classes/typography.scss
+++ b/ui/app/styles/helper-classes/typography.scss
@@ -95,7 +95,7 @@
 
 .help {
   display: block;
-  font-size: 0.85714rem;
+  font-size: $size-9;
   margin-top: $spacing-4;
 }
 

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -3,26 +3,30 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* General sizing in rem values used largely for text sizing.*/
-$size-1: 3rem; // 48px, same as $spacing-48
-$size-2: 2.5rem; // 40px
-$size-3: calc(24 / 14) + 0rem; // ~1.714rem ~27px
-$size-4: 1.5rem; // 24px same as $spacing-24
-$size-5: 1.25rem; // 20px
-$size-6: 1rem; // 16px same as $spacing-16
-$size-7: calc(13 / 14) + 0rem; // ~.929rem ~15px
-$size-8: calc(12 / 14) + 0rem; // ~.857rem  ~13.7px
-$size-9: 0.75rem; // 12px same as $spacing-12
-$size-10: 0.5rem; // 8px same as $spacing-8
-$size-11: 0.25rem; // 4px same as spacing-4
+/* Size variables (rem only) */
+$size-1: 3rem; // 42px,
+$size-2: 2.5rem; // 35px
+$size-3: calc(24 / 14) + 0rem; // ~1.714rem ~24px
+$size-4: 1.5rem; // 21px
+$size-5: 1.25rem; // 17.5px
+$size-6: 1rem; // 14px
+$size-7: calc(13 / 14) + 0rem; // ~.929rem ~13px
+$size-8: calc(12 / 14) + 0rem; // ~.857rem  ~12px
+$size-9: 0.75rem; // 10.5px
+$size-10: 0.5rem; // 7px
+$size-11: 0.25rem; // 3.5px
 
-/* Spacing vars in px */
+/* Spacing variables (px only) */
 $spacing-4: 4px;
 $spacing-8: 8px;
+$spacing-10: 10px;
 $spacing-12: 12px;
+$spacing-14: 14px;
 $spacing-16: 16px;
+$spacing-20: 20px;
 $spacing-24: 24px;
 $spacing-36: 36px;
+$spacing-42: 42px;
 $spacing-48: 48px;
 
 /* Border radius */

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -23,6 +23,7 @@ $spacing-10: 10px;
 $spacing-12: 12px;
 $spacing-14: 14px;
 $spacing-16: 16px;
+$spacing-18: 18px;
 $spacing-20: 20px;
 $spacing-24: 24px;
 $spacing-36: 36px;

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -3,19 +3,22 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* Size variables (rem only) */
-$size-1: 3rem; // 42px,
-$size-2: 2.5rem; // 35px
-$size-3: calc(24 / 14) + 0rem; // ~1.714rem ~24px
-$size-4: 1.5rem; // 21px
-$size-5: 1.25rem; // 17.5px
-$size-6: 1rem; // 14px
-$size-8: calc(12 / 14) + 0rem; // ~.857rem  ~12px
-$size-9: 0.75rem; // 10.5px
-$size-10: 0.5rem; // 7px
-$size-11: 0.25rem; // 3.5px
+$base-font-size: 16px;
 
-/* Spacing variables (px only) */
+@function rem($pixels, $base: 16) {
+  @return calc($pixels / $base) + 0rem;
+}
+
+/* General sizing in rem values used largely for text sizing */
+$size-2: rem(40);
+$size-3: rem(26);
+$size-4: rem(24);
+$size-5: rem(20);
+$size-6: rem(16);
+$size-8: rem(14);
+$size-9: rem(12);
+
+/* Spacing vars in px */
 $spacing-4: 4px;
 $spacing-8: 8px;
 $spacing-10: 10px;

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -4,26 +4,26 @@
  */
 
 /* General sizing in rem values used largely for text sizing.*/
-$size-1: 3rem; // 48px, same as $spacing-xxl
+$size-1: 3rem; // 48px, same as $spacing-48
 $size-2: 2.5rem; // 40px
 $size-3: calc(24 / 14) + 0rem; // ~1.714rem ~27px
-$size-4: 1.5rem; // 24px same as $spacing-l
+$size-4: 1.5rem; // 24px same as $spacing-24
 $size-5: 1.25rem; // 20px
-$size-6: 1rem; // 16px same as $spacing-m
+$size-6: 1rem; // 16px same as $spacing-16
 $size-7: calc(13 / 14) + 0rem; // ~.929rem ~15px
 $size-8: calc(12 / 14) + 0rem; // ~.857rem  ~13.7px
-$size-9: 0.75rem; // 12px same as $spacing-s
-$size-10: 0.5rem; // 8px same as $spacing-xs
-$size-11: 0.25rem; // 4px same as spacing-xxs
+$size-9: 0.75rem; // 12px same as $spacing-12
+$size-10: 0.5rem; // 8px same as $spacing-8
+$size-11: 0.25rem; // 4px same as spacing-4
 
 /* Spacing vars in px */
-$spacing-xxs: 4px;
-$spacing-xs: 8px;
-$spacing-s: 12px;
-$spacing-m: 16px;
-$spacing-l: 24px;
-$spacing-xl: 36px;
-$spacing-xxl: 48px;
+$spacing-4: 4px;
+$spacing-8: 8px;
+$spacing-12: 12px;
+$spacing-16: 16px;
+$spacing-24: 24px;
+$spacing-36: 36px;
+$spacing-48: 48px;
 
 /* Border radius */
 $radius: 2px;

--- a/ui/app/styles/utils/_size_variables.scss
+++ b/ui/app/styles/utils/_size_variables.scss
@@ -10,7 +10,6 @@ $size-3: calc(24 / 14) + 0rem; // ~1.714rem ~24px
 $size-4: 1.5rem; // 21px
 $size-5: 1.25rem; // 17.5px
 $size-6: 1rem; // 14px
-$size-7: calc(13 / 14) + 0rem; // ~.929rem ~13px
 $size-8: calc(12 / 14) + 0rem; // ~.857rem  ~12px
 $size-9: 0.75rem; // 10.5px
 $size-10: 0.5rem; // 7px

--- a/ui/app/templates/components/clients/dashboard.hbs
+++ b/ui/app/templates/components/clients/dashboard.hbs
@@ -17,6 +17,7 @@
     {{#if this.formattedStartDate}}
       <p class="is-size-6" data-test-date-display>{{this.formattedStartDate}}</p>
       <Hds::Button
+        class="has-left-margin-xs"
         @text="Edit"
         @color="tertiary"
         @icon="edit"

--- a/ui/app/templates/components/clients/dashboard.hbs
+++ b/ui/app/templates/components/clients/dashboard.hbs
@@ -28,7 +28,7 @@
       <DateDropdown @handleSubmit={{this.handleClientActivityQuery}} @dateType="startDate" @submitText="Save" />
     {{/if}}
   </div>
-  <p class="is-8 has-text-grey has-bottom-margin-l">
+  <p class="has-text-grey has-bottom-margin-l">
     {{this.versionText.description}}
   </p>
   {{#if this.noActivityData}}

--- a/ui/app/templates/components/dashboard/replication-state-text.hbs
+++ b/ui/app/templates/components/dashboard/replication-state-text.hbs
@@ -4,9 +4,9 @@
 ~}}
 
 <div>
-  <h2 class="is-size-5 has-text-weight-semibold has-bottom-margin-xs" data-test-title={{@title}}>
+  <Hds::Text::Display @tag="h2" @size="300" @weight="semibold" class="has-bottom-margin-xs" data-test-title={{@title}}>
     {{@title}}
-  </h2>
+  </Hds::Text::Display>
 
   {{#if @subText}}
     <div class="title is-8 has-font-weight-normal has-text-grey-dark" data-test-subtext={{@title}}>

--- a/ui/app/templates/components/dashboard/survey-link-text.hbs
+++ b/ui/app/templates/components/dashboard/survey-link-text.hbs
@@ -4,11 +4,10 @@
 ~}}
 
 <div class="has-top-padding-xs has-bottom-padding-xs has-top-margin-m" data-test-feedback-form>
-  <small>
-    Don't see what you're looking for on this page? Let us know via our
+  <Hds::Text::Body @tag="p" @size="100">Paragraph text Don't see what you're looking for on this page? Let us know via our
     <Hds::Link::Inline @icon="external-link" @href="https://hashicorp.sjc1.qualtrics.com/jfe/form/SV_1SNUsZLdWHpfw0e">
       feedback form
     </Hds::Link::Inline>
     .
-  </small>
+  </Hds::Text::Body>
 </div>

--- a/ui/app/templates/components/transit-form-show.hbs
+++ b/ui/app/templates/components/transit-form-show.hbs
@@ -100,7 +100,7 @@
           <div class="column is-3">
             <div class="level level-left">
               <Icon @name="history" class="has-text-grey-light is-padded" />
-              <strong class="has-padding is-size-5">Version {{version}}</strong>
+              <Hds::Text::Display @tag="p" @size="300" @weight="bold">Version {{version}}</Hds::Text::Display>
             </div>
           </div>
           <div class="column is-4">
@@ -130,7 +130,7 @@
           <div class="column is-3">
             <div class="level level-left">
               <Icon @name="history" class="has-text-grey-light is-padded" />
-              <strong class="has-padding is-size-5">Version {{version}}</strong>
+              <Hds::Text::Display @tag="p" @size="300" @weight="bold">Version {{version}}</Hds::Text::Display>
             </div>
           </div>
           <div class="column is-4">

--- a/ui/app/templates/vault/cluster/access/mfa/methods/create.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/create.hbs
@@ -30,7 +30,9 @@
 </PageHeader>
 <div class="has-border-top-light has-top-padding-l">
   {{#if this.showForms}}
-    <h3 class="is-size-4 has-text-weight-semibold">Settings</h3>
+    <Hds::Text::Display @tag="h3" @size="400" @weight="semibold">
+      Settings
+    </Hds::Text::Display>
     <p class="has-border-top-light has-top-padding-l">
       {{this.description}}
       <DocLink @path={{concat "/vault/api-docs/secret/identity/mfa/" this.type}}>Learn more.</DocLink>

--- a/ui/app/templates/vault/error.hbs
+++ b/ui/app/templates/vault/error.hbs
@@ -15,7 +15,7 @@
         <Icon @name="help" @size="24" class="has-text-grey" @stretched={{true}} />
       </div>
       <div class="has-left-margin-s">
-        <h1 class="is-size-4 has-text-semibold has-text-grey has-line-height-1">
+        <Hds::Text::Display @tag="h1" @size="400" @weight="medium" class="has-text-grey">
           {{#if (eq this.model.httpStatus 403)}}
             Not authorized
           {{else if (eq this.model.httpStatus 404)}}
@@ -23,7 +23,7 @@
           {{else}}
             Error
           {{/if}}
-        </h1>
+        </Hds::Text::Display>
         <p class="has-text-grey is-size-8">Error {{this.model.httpStatus}}</p>
       </div>
     </div>

--- a/ui/lib/core/addon/components/overview-card.hbs
+++ b/ui/lib/core/addon/components/overview-card.hbs
@@ -11,7 +11,7 @@
   ...attributes
 >
   <div class="flex row-wrap space-between has-bottom-margin-m" data-test-overview-card={{@cardTitle}}>
-    <h3 class="has-text-weight-bold is-size-5">{{@cardTitle}}</h3>
+    <Hds::Text::Display @tag="h3" @size="300" @weight="bold">{{@cardTitle}}</Hds::Text::Display>
     {{#if @actionText}}
       <Hds::Link::Standalone
         @icon={{or @actionIcon "chevron-right"}}

--- a/ui/lib/kubernetes/addon/components/page/overview.hbs
+++ b/ui/lib/kubernetes/addon/components/page/overview.hbs
@@ -17,10 +17,9 @@
       @actionText={{if @roles.length "View Roles" "Create Role"}}
       @actionTo={{if @roles.length "roles" "roles.create"}}
     >
-      <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-roles-card-overview-num>{{or
-          @roles.length
-          "None"
-        }}</h2>
+      <Hds::Text::Display @tag="h2" @size="400" @weight="medium" class="has-top-margin-m" data-test-roles-card-overview-num>
+        {{or @roles.length "None"}}
+      </Hds::Text::Display>
     </OverviewCard>
     <OverviewCard @cardTitle="Generate credentials" @subText="Quickly generate credentials by typing the role name.">
       <div class="has-top-margin-m is-flex">

--- a/ui/lib/ldap/addon/components/page/library/details/accounts.hbs
+++ b/ui/lib/ldap/addon/components/page/library/details/accounts.hbs
@@ -7,7 +7,7 @@
   <div>
     <Hds::Card::Container @level="mid" @hasBorder={{true}} class="has-padding-l is-flex-half">
       <div class="is-flex-between">
-        <h3 class="is-size-5 has-text-weight-semibold">All accounts</h3>
+        <Hds::Text::Display @tag="h3" @size="300" @weight="semibold">All accounts</Hds::Text::Display>
         {{#if @library.canCheckOut}}
           <Hds::Button
             @text="Check-out"

--- a/ui/lib/ldap/addon/components/page/overview.hbs
+++ b/ui/lib/ldap/addon/components/page/overview.hbs
@@ -23,9 +23,9 @@
       @actionText="Create new"
       @actionTo="roles.create"
     >
-      <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-roles-count>
+      <Hds::Text::Display @tag="h2" @size="400" @weight="medium" class="has-top-margin-m" data-test-roles-count>
         {{or @roles.length "None"}}
-      </h2>
+      </Hds::Text::Display>
     </OverviewCard>
     <OverviewCard
       @cardTitle="Libraries"
@@ -33,9 +33,9 @@
       @actionText="Create new"
       @actionTo="libraries.create"
     >
-      <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-libraries-count>
+      <Hds::Text::Display @tag="h2" @size="400" @weight="medium" class="has-top-margin-m" data-test-libraries-count>
         {{or @libraries.length "None"}}
-      </h2>
+      </Hds::Text::Display>
     </OverviewCard>
   </div>
   <div class="is-grid has-top-margin-l grid-2-columns grid-gap-2">

--- a/ui/lib/pki/addon/components/page/pki-configuration-edit.hbs
+++ b/ui/lib/pki/addon/components/page/pki-configuration-edit.hbs
@@ -21,7 +21,7 @@
   {{/if}}
   <form {{on "submit" (perform this.save)}}>
     <fieldset class="is-shadowless is-marginless is-borderless is-fullwidth" data-test-cluster-config-edit-section>
-      <h2 class="title is-size-5 has-border-bottom-light page-header">
+      <h2 class="title is-5 has-border-bottom-light page-header">
         Cluster Config
       </h2>
       {{#if @cluster.canSet}}
@@ -40,7 +40,7 @@
     </fieldset>
 
     <fieldset class="box is-shadowless is-marginless is-borderless is-fullwidth" data-test-acme-edit-section>
-      <h2 class="title is-size-5 has-border-bottom-light page-header">
+      <h2 class="title is-5 has-border-bottom-light page-header">
         ACME Config
       </h2>
       {{#if @acme.canSet}}
@@ -59,7 +59,7 @@
     </fieldset>
 
     <fieldset class="box is-shadowless is-marginless is-borderless is-fullwidth" data-test-urls-edit-section>
-      <h2 class="title is-size-5 has-border-bottom-light page-header">
+      <h2 class="title is-5 has-border-bottom-light page-header">
         Global URLs
       </h2>
       {{#if @urls.canSet}}
@@ -82,7 +82,7 @@
         {{#each @crl.formFieldGroups as |fieldGroup|}}
           {{#each-in fieldGroup as |group fields|}}
             {{#if (or (not-eq group "Unified Revocation") this.isEnterprise)}}
-              <h2 class="title is-size-5 has-border-bottom-light page-header" data-test-crl-header={{group}}>
+              <h2 class="title is-5 has-border-bottom-light page-header" data-test-crl-header={{group}}>
                 {{group}}
               </h2>
             {{/if}}

--- a/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
@@ -132,7 +132,7 @@
     </div>
   {{else}}
     {{!  USE OLD SETTINGS FORM INPUTS  }}
-    <h2 class="title is-size-5 has-border-bottom-light page-header">
+    <h2 class="title is-5 has-border-bottom-light page-header">
       Root parameters
     </h2>
     <form {{on "submit" (perform this.save)}} data-test-pki-rotate-old-settings-form>

--- a/ui/lib/pki/addon/components/page/pki-overview.hbs
+++ b/ui/lib/pki/addon/components/page/pki-overview.hbs
@@ -10,7 +10,7 @@
     @actionText="View issuers"
     @actionTo="issuers"
   >
-    <Hds::Text::Display @tag="h2" @size="500">
+    <Hds::Text::Display @tag="h2" @size="400" @weight="medium" class="has-top-margin-m">
       {{format-number (if (eq @issuers 404) 0 @issuers.length)}}
     </Hds::Text::Display>
   </OverviewCard>
@@ -21,7 +21,7 @@
       @actionText="View roles"
       @actionTo="roles"
     >
-      <Hds::Text::Display @tag="h2" @size="500">
+      <Hds::Text::Display @tag="h2" @size="400" @weight="medium" class="has-top-margin-m">
         {{format-number (if (eq @roles 404) 0 @roles.length)}}
       </Hds::Text::Display>
     </OverviewCard>

--- a/ui/lib/pki/addon/components/page/pki-role-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-role-details.hbs
@@ -40,7 +40,9 @@
 {{#each @role.formFieldGroups as |fg|}}
   {{#each-in fg as |group fields|}}
     {{#if (not-eq group "default")}}
-      <h3 class="is-size-4 has-text-weight-semibold has-top-margin-m">{{group}}</h3>
+      <Hds::Text::Display @tag="h3" @size="400" @weight="semibold" class="has-top-margin-m">
+        {{group}}
+      </Hds::Text::Display>
     {{/if}}
     {{#each fields as |attr|}}
       {{#let (get @role attr.name) as |val|}}

--- a/ui/lib/pki/addon/components/pki-generate-csr.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-csr.hbs
@@ -54,7 +54,7 @@
 {{else}}
   <form {{on "submit" (perform this.save)}}>
     <MessageError @errorMessage={{this.error}} class="has-top-margin-s" />
-    <h2 class="title is-size-5 has-border-bottom-light page-header">
+    <h2 class="title is-5 has-border-bottom-light page-header">
       CSR parameters
     </h2>
 

--- a/ui/lib/pki/addon/components/pki-generate-root.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-root.hbs
@@ -54,7 +54,7 @@
 {{else}}
   <form {{on "submit" (perform this.save)}} data-test-pki-config-generate-root-form>
     <MessageError @errorMessage={{this.errorBanner}} class="has-top-margin-s" />
-    <h2 class="title is-size-5 has-border-bottom-light page-header" data-test-generate-root-title="Root parameters">
+    <h2 class="title is-5 has-border-bottom-light page-header" data-test-generate-root-title="Root parameters">
       Root parameters
     </h2>
     {{#each this.defaultFields as |field|}}
@@ -73,7 +73,7 @@
     {{#if @urls}}
       <fieldset class="box is-shadowless is-marginless is-borderless is-fullwidth" data-test-urls-section>
         <h2
-          class="title is-size-5 page-header {{if @urls.canCreate 'has-border-bottom-light' 'is-borderless'}}"
+          class="title is-5 page-header {{if @urls.canCreate 'has-border-bottom-light' 'is-borderless'}}"
           data-test-generate-root-title="Issuer URLs"
         >
           Issuer URLs

--- a/ui/lib/pki/addon/components/pki-tidy-form.hbs
+++ b/ui/lib/pki/addon/components/pki-tidy-form.hbs
@@ -30,7 +30,7 @@
   {{#each @tidy.formFieldGroups as |fieldGroup|}}
     {{#each-in fieldGroup as |group fields|}}
       {{#if (or (eq @tidyType "manual") @tidy.enabled)}}
-        <h2 class="title is-size-5 has-border-bottom-light page-header" data-test-tidy-header={{group}}>
+        <h2 class="title is-5 has-border-bottom-light page-header" data-test-tidy-header={{group}}>
           {{group}}
         </h2>
         {{#each fields as |attr|}}


### PR DESCRIPTION
This PR increases the on-prem UI base font size from 14px to 16px. 

In addition, this PR addresses some minor cleanup intended to make Helios practices easier to iteratively address in the future, these include: 

1. renaming sizing variables to correspond to their numerical value, ex: `$spacing-xxs` (which is 4 pixels) is now `$spacing-4`

2. updates usage of pixels vs rem to be consistent. Using `rem` for fonts and elements that need to be scalable (like animations) and `pixels` for spacing (i..e margin and padding). 

For review reference, this table maps rem to pixel values (these values were calculated with a base font of 14p so padding remains the same when post base font size increase)

| size var | rem value            | pixel value |  spacing var replacement (always rounded up)
| -------- | -------------------- | ----------- | ------- |
| $size-1  | 3rem                 | 42px,       | $spacing-42
| $size-2  | 2.5rem               | 35px        | $spacing-36
| $size-3  | calc(24 / 14) + 0rem | 24px       | $spacing-24
| $size-4  | 1.5rem               | 21px        |  $spacing-20
| $size-5  | 1.25rem              | 17.5px      | $spacing-18
| $size-6  | 1rem                 | 14px        | $spacing-14
| $size-7 (**deleted**, replaced all with $size-6)  | calc(13 / 14) + 0rem | 13px        |   $spacing-14
| $size-8  | calc(12 / 14) + 0rem | 12px        | $spacing-12
| $size-9  | 0.75rem              | 10.5px      | $spacing-10 (only instance of rounding down)
| $size-10 | 0.5rem               | 7px         | $spacing-8
| $size-11 | 0.25rem              | 3.5px       | $spacing-4

