### PR TITLE
Read seal configuration info from storage during unseal process.

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -2471,19 +2471,43 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 			return err
 		}
 
-		// store the sealGenInfo
-		sealGenerationInfo := c.seal.GetAccess().GetSealGenerationInfo()
-		err := c.SetPhysicalSealGenInfo(context.Background(), sealGenerationInfo)
+		// Retrieve the seal generation information from storage
+		existingGenerationInfo, err := PhysicalSealGenInfo(ctx, c.physical)
 		if err != nil {
-			c.logger.Error("failed to store seal generation info", "error", err)
+			c.logger.Error("cannot read existing seal generation info from storage", "error", err)
 			return err
+		}
+
+		sealGenerationInfo := c.seal.GetAccess().GetSealGenerationInfo()
+
+		switch {
+		case existingGenerationInfo == nil:
+			// This is the first time we store seal generation information
+			fallthrough
+		case existingGenerationInfo.Generation < sealGenerationInfo.Generation:
+			// We have incremented the seal generation
+			if err := c.SetPhysicalSealGenInfo(ctx, sealGenerationInfo); err != nil {
+				c.logger.Error("failed to store seal generation info", "error", err)
+				return err
+			}
+
+		case existingGenerationInfo.Generation == sealGenerationInfo.Generation:
+			// Same generation, update the rewrapped flag in case the previous active node
+			// changed its value. In other words, a rewrap may have happened, or a rewrap may have been
+			// started but not completed.
+			c.seal.GetAccess().GetSealGenerationInfo().SetRewrapped(existingGenerationInfo.IsRewrapped())
+
+		case existingGenerationInfo.Generation > sealGenerationInfo.Generation:
+			// Our seal information is out of date. The previous active node used a newer generation.
+			c.logger.Error("A newer seal generation was found in storage. The seal configuration in this node should be updated to match that of the previous active node, and this node should be restarted.")
+			return errors.New("newer seal generation found in storage, in memory seal configuration is out of date")
 		}
 
 		if server.IsMultisealSupported() && !sealGenerationInfo.IsRewrapped() {
 			// Set the migration done flag so that a seal-rewrap gets triggered later.
 			// Note that in the case where multi seal is not supported, Core.migrateSeal() takes care of
 			// triggering the rewrap when necessary.
-			c.logger.Trace("seal generation information indicates that a seal-rewrap is needed", "generation", sealGenerationInfo.Generation, "rewrapped", sealGenerationInfo.IsRewrapped())
+			c.logger.Trace("seal generation information indicates that a seal-rewrap is needed", "generation", sealGenerationInfo.Generation)
 			atomic.StoreUint32(c.sealMigrationDone, 1)
 		}
 


### PR DESCRIPTION
Do not blindly store computed seal configuration information during unsealing. Instead, read any configuration already stored and determine whether the computed configuration during startup is newer (has a newer generation number), whether the in-memory re-wrapped status needs to be updated (if the generation numbers match), or whether the in-memory seal configuration is outdated (the stored seal generation is newer).