### PR TITLE
[DOCS] Update 'vault-secrets' to 'Vault' for clarify

### DIFF
--- a/website/content/docs/platform/github-actions.mdx
+++ b/website/content/docs/platform/github-actions.mdx
@@ -42,5 +42,5 @@ This example will authenticate to Vault instance at `https://vault.example.com:8
 
 For more information on using the `vault-action` GitHub Action, visit:
 
-- [`vault-secrets` GitHub action documentation](https://github.com/marketplace/actions/hashicorp-vault)
+- [Vault GitHub action documentation](https://github.com/marketplace/actions/hashicorp-vault)
 - [Vault GitHub actions tutorial](/vault/tutorials/app-integration/github-actions)


### PR DESCRIPTION
Minor updates due to URL change:  `vault-secrets` is no longer accurate and should simply say, "Vault Github action"

🔍 [Deploy preview](https://vault-d3jewxrmy-hashicorp.vercel.app/vault/docs/platform/github-actions)

