### PR TITLE
[DOCS] Update the Vault Github action URL

### DIFF
--- a/website/content/docs/platform/github-actions.mdx
+++ b/website/content/docs/platform/github-actions.mdx
@@ -8,7 +8,7 @@ description: >-
 # GitHub actions
 
 Workflows in GitHub Actions can make use of secrets stored in Vault by using a
-[`vault-action`](https://github.com/marketplace/actions/vault-secrets) step.
+[`vault-action`](https://github.com/marketplace/actions/hashicorp-vault) step.
 
 ## Example
 
@@ -42,5 +42,5 @@ This example will authenticate to Vault instance at `https://vault.example.com:8
 
 For more information on using the `vault-action` GitHub Action, visit:
 
-- [`vault-secrets` GitHub action documentation](https://github.com/marketplace/actions/vault-secrets)
-- [Vault GitHub actions tutorial](https://learn.hashicorp.com/tutorials/vault/github-actions)
+- [Vault GitHub action documentation](https://github.com/marketplace/actions/hashicorp-vault)
+- [Vault GitHub actions tutorial](/vault/tutorials/app-integration/github-actions)


### PR DESCRIPTION
Manually cherry picking the https://github.com/hashicorp/vault/pull/23993 and https://github.com/hashicorp/vault/pull/23290