### PR TITLE
UI: Replace buttons for HDS in component templates part 2

### DIFF
--- a/ui/app/templates/components/clients/config.hbs
+++ b/ui/app/templates/components/clients/config.hbs
@@ -36,12 +36,10 @@
       {{/each}}
     </div>
     <div class="field is-grouped-split box is-fullwidth is-bottomless">
-      <div class="control">
+      <Hds::ButtonSet>
         <Hds::Button @text="Save" type="submit" disabled={{this.buttonDisabled}} data-test-clients-config-save />
-        <LinkTo @route="vault.cluster.clients.config" class="button">
-          Cancel
-        </LinkTo>
-      </div>
+        <Hds::Button @text="Cancel" @color="secondary" @route="vault.cluster.clients.config" />
+      </Hds::ButtonSet>
     </div>
   </form>
 

--- a/ui/app/templates/components/control-group-success.hbs
+++ b/ui/app/templates/components/control-group-success.hbs
@@ -34,7 +34,7 @@
       </div>
     </div>
     <div class="field is-grouped box is-fullwidth is-bottomless">
-      <Hds::button
+      <Hds::Button
         @text="Back"
         @color="secondary"
         @route="vault.cluster.access.control-groups"

--- a/ui/app/templates/components/control-group-success.hbs
+++ b/ui/app/templates/components/control-group-success.hbs
@@ -34,10 +34,13 @@
       </div>
     </div>
     <div class="field is-grouped box is-fullwidth is-bottomless">
-      <LinkTo @route="vault.cluster.access.control-groups" class="button">
-        <Chevron @direction="left" />
-        Back
-      </LinkTo>
+      <Hds::button
+        @text="Back"
+        @color="secondary"
+        @route="vault.cluster.access.control-groups"
+        @icon="chevron-left"
+        @iconPosition="leading"
+      />
     </div>
   {{else}}
     <div class="control-group-success" data-test-unwrap-form>

--- a/ui/app/templates/components/control-group.hbs
+++ b/ui/app/templates/components/control-group.hbs
@@ -104,7 +104,7 @@
     <div class="field is-grouped box is-fullwidth is-bottomless">
       {{#if this.model.canAuthorize}}
         {{#if (or this.model.approved this.currentUserHasAuthorized)}}
-          <Hds::button
+          <Hds::Button
             @text="Back"
             @color="secondary"
             @route="vault.cluster.access.control-groups"

--- a/ui/app/templates/components/control-group.hbs
+++ b/ui/app/templates/components/control-group.hbs
@@ -110,6 +110,7 @@
             @route="vault.cluster.access.control-groups"
             @icon="chevron-left"
             @iconPosition="leading"
+            data-test-back-link
           />
         {{else}}
           <Hds::Button

--- a/ui/app/templates/components/control-group.hbs
+++ b/ui/app/templates/components/control-group.hbs
@@ -104,10 +104,13 @@
     <div class="field is-grouped box is-fullwidth is-bottomless">
       {{#if this.model.canAuthorize}}
         {{#if (or this.model.approved this.currentUserHasAuthorized)}}
-          <LinkTo @route="vault.cluster.access.control-groups" class="button" data-test-back-link={{true}}>
-            <Chevron @direction="left" />
-            Back
-          </LinkTo>
+          <Hds::button
+            @text="Back"
+            @color="secondary"
+            @route="vault.cluster.access.control-groups"
+            @icon="chevron-left"
+            @iconPosition="leading"
+          />
         {{else}}
           <Hds::Button
             @text="Authorize"

--- a/ui/app/templates/components/generate-credentials.hbs
+++ b/ui/app/templates/components/generate-credentials.hbs
@@ -101,7 +101,7 @@
     {{/if}}
     <div class="control">
       {{#if this.options.backIsListLink}}
-        <Hds::button
+        <Hds::Button
           @text="Back"
           @color="secondary"
           @route="vault.cluster.secrets.backend.list-root"

--- a/ui/app/templates/components/generate-credentials.hbs
+++ b/ui/app/templates/components/generate-credentials.hbs
@@ -101,14 +101,13 @@
     {{/if}}
     <div class="control">
       {{#if this.options.backIsListLink}}
-        <LinkTo
+        <Hds::button
+          @text="Back"
+          @color="secondary"
           @route="vault.cluster.secrets.backend.list-root"
           @model={{this.backendPath}}
           data-test-secret-generate-back={{true}}
-          class="button"
-        >
-          Back
-        </LinkTo>
+        />
       {{else}}
         <Hds::Button
           @text="Back"
@@ -136,7 +135,7 @@
       {{/if}}
     </div>
     <div class="field is-grouped box is-fullwidth is-bottomless">
-      <div class="control">
+      <Hds::ButtonSet>
         <Hds::Button
           @text="Generate"
           @icon={{if this.loading "loading"}}
@@ -144,17 +143,13 @@
           disabled={{this.loading}}
           data-test-secret-generate={{true}}
         />
-      </div>
-      <div class="control">
-        <LinkTo
+        <Hds::Button
+          @text="Cancel"
           @route="vault.cluster.secrets.backend.list-root"
           @model={{this.backendPath}}
-          class="button"
           data-test-secret-generate-cancel={{true}}
-        >
-          Cancel
-        </LinkTo>
-      </div>
+        />
+      </Hds::ButtonSet>
     </div>
   </form>
 {{/if}}

--- a/ui/app/templates/components/generated-item.hbs
+++ b/ui/app/templates/components/generated-item.hbs
@@ -74,7 +74,7 @@
       />
     </div>
     <div class="field is-grouped-split box is-fullwidth is-bottomless">
-      <div class="control">
+      <Hds::ButtonSet>
         <Hds::Button
           @text="Save"
           @icon={{if this.saveModel.isRunning "loading"}}
@@ -83,20 +83,22 @@
           disabled={{this.saveModel.isRunning}}
         />
         {{#if (eq this.mode "create")}}
-          <LinkTo @route="vault.cluster.access.method.item.list" class="button" data-test-cancel-link={{true}}>
-            Cancel
-          </LinkTo>
+          <Hds::Button
+            @text="Cancel"
+            @color="secondary"
+            @route="vault.cluster.access.method.item.list"
+            data-test-cancel-link={{true}}
+          />
         {{else}}
-          <LinkTo
+          <Hds::Button
+            @text="Cancel"
+            @color="secondary"
             @route="vault.cluster.access.method.item.show"
             @model={{this.model.id}}
-            class="button"
             data-test-cancel-link={{true}}
-          >
-            Cancel
-          </LinkTo>
+          />
         {{/if}}
-      </div>
+      </Hds::ButtonSet>
     </div>
   </form>
 {{/if}}

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -116,14 +116,19 @@
     {{/if}}
 
     <div class="field is-grouped box is-fullwidth is-bottomless">
-      <div class="control">
+      <Hds::ButtonSet>
         <Hds::Button @text="Save" type="submit" disabled={{@buttonDisabled}} data-test-secret-save={{true}} />
-      </div>
-      <div class="control">
-        <SecretLink @mode="list" @secret={{@model.parentKey}} class="button">
-          Cancel
-        </SecretLink>
-      </div>
+        {{#if @model.path}}
+          <Hds::Button
+            @text="Cancel"
+            @color="secondary"
+            @route="vault.cluster.secrets.backend.list"
+            @model={{@model.path}}
+          />
+        {{else}}
+          <Hds::Button @text="Cancel" @color="secondary" @route="vault.cluster.secrets.backend.list-root" />
+        {{/if}}
+      </Hds::ButtonSet>
     </div>
   </form>
 {{/if}}
@@ -206,19 +211,21 @@
     </div>
     <div class="field is-grouped is-grouped-split is-fullwidth box is-bottomless">
       <div class="field is-grouped">
-        <div class="control">
+        <Hds::ButtonSet>
           <Hds::Button
             @text="Save"
             data-test-secret-save
             type="submit"
             disabled={{or @buttonDisabled this.validationErrorCount}}
           />
-        </div>
-        <div class="control">
-          <SecretLink @mode="show" @secret={{@model.id}} @queryParams={{hash version=@modelForData.version}} class="button">
-            Cancel
-          </SecretLink>
-        </div>
+          <Hds::Button
+            @text="Cancel"
+            @color="secondary"
+            @route="vault.cluster.secrets.backend.show"
+            @model={{@model.id}}
+            @query={{hash version=@modelForData.version}}
+          />
+        </Hds::ButtonSet>
       </div>
     </div>
   </form>

--- a/ui/app/templates/components/transit-form-create.hbs
+++ b/ui/app/templates/components/transit-form-create.hbs
@@ -124,7 +124,7 @@
     {{/if}}
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">
-    <div class="control">
+    <Hds::ButtonSet>
       <Hds::Button
         @text="Create encryption key"
         @icon={{if @requestInFlight "loading"}}
@@ -132,11 +132,7 @@
         type="submit"
         disabled={{@requestInFlight}}
       />
-    </div>
-    <div class="control">
-      <SecretLink @mode="list" class="button">
-        Cancel
-      </SecretLink>
-    </div>
+      <Hds::Button @text="Cancel" @color="secondary" @route="vault.cluster.secrets.backend.list-root" />
+    </Hds::ButtonSet>
   </div>
 </form>

--- a/ui/app/templates/components/transit-form-edit.hbs
+++ b/ui/app/templates/components/transit-form-edit.hbs
@@ -100,9 +100,7 @@
         </div>
       {{/if}}
       <div class="control">
-        <SecretLink @mode="show" @secret={{@key.id}} class="button">
-          Cancel
-        </SecretLink>
+        <Hds::Button @text="Cancel" @color="secondary" @route="vault.cluster.secrets.backend.show" @model={{@key.id}} />
       </div>
     </div>
     {{#if (and @key.canDelete @capabilities.canDelete)}}


### PR DESCRIPTION
Some of the `<LinkTo>` components have `class="button"` and therefore look like buttons but are technically not. These also need to be swapped for `<Hds::Button>` when used in places like forms, so this PR tackles those missed during the initial button replacement sweep through these files.


Follow on to https://github.com/hashicorp/vault/pull/23698