### PR TITLE
[VAULT-21461] Do not error when token policy type lookup fails

### DIFF
--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -473,7 +473,7 @@ func (ps *PolicyStore) GetNonEGPPolicyType(nsID string, name string) (*PolicyTyp
 	pt, ok := ps.policyTypeMap.Load(index)
 	if !ok {
 		// Doesn't exist
-		return nil, fmt.Errorf("policy does not exist in type map: %v", index)
+		return nil, ErrPolicyNotExistInTypeMap
 	}
 
 	policyType, ok := pt.(PolicyType)

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -394,7 +394,7 @@ func TestPolicyStore_GetNonEGPPolicyType(t *testing.T) {
 			paramNamespace:       "1AbcD",
 			paramPolicyName:      "policy1",
 			isErrorExpected:      true,
-			expectedErrorMessage: "policy does not exist in type map: 1AbcD/policy1",
+			expectedErrorMessage: "policy does not exist in type map",
 		},
 		"not-in-map-rgp": {
 			policyStoreKey:       "2WxyZ/policy2",
@@ -402,7 +402,7 @@ func TestPolicyStore_GetNonEGPPolicyType(t *testing.T) {
 			paramNamespace:       "1AbcD",
 			paramPolicyName:      "policy1",
 			isErrorExpected:      true,
-			expectedErrorMessage: "policy does not exist in type map: 1AbcD/policy1",
+			expectedErrorMessage: "policy does not exist in type map",
 		},
 		"unknown-policy-type": {
 			policyStoreKey:       "1AbcD/policy1",

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -52,7 +52,8 @@ var (
 	// to complete, unless overridden on a per-handler basis
 	DefaultMaxRequestDuration = 90 * time.Second
 
-	ErrNoApplicablePolicies = errors.New("no applicable policies")
+	ErrNoApplicablePolicies    = errors.New("no applicable policies")
+	ErrPolicyNotExistInTypeMap = errors.New("policy does not exist in type map")
 
 	egpDebugLogging bool
 )
@@ -176,6 +177,13 @@ func (c *Core) getApplicableGroupPolicies(ctx context.Context, tokenNS *namespac
 
 	for _, policyName := range nsPolicies {
 		t, err := c.policyStore.GetNonEGPPolicyType(policyNS.ID, policyName)
+		if err != nil && errors.Is(err, ErrPolicyNotExistInTypeMap) {
+			// When we attempt to get a non-EGP policy type, and receive an
+			// explicit error that it doesn't exist (in the type map) we log the
+			// ns/policy and continue without error.
+			c.Logger().Debug(fmt.Errorf("%w: %v/%v", err, policyNS.ID, policyName).Error())
+			continue
+		}
 		if err != nil || t == nil {
 			return nil, fmt.Errorf("failed to look up type of policy: %w", err)
 		}


### PR DESCRIPTION
This PR fixes the issue where Vault returns  a 500/Internal Error when an internal lookup of policy type fails.

This PR is a CE companion for the changes in hashicorp/vault-enterprise#4919. The changelog will be filed on the ENT side, since CE is not affected by the bug.