### PR TITLE
Add replace directive to work around an issue in ent with github.com/ma314smith/signedxml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -537,3 +537,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/ma314smith/signedxml v1.1.1 => github.com/moov-io/signedxml v1.1.1


### PR DESCRIPTION
Error we're trying to fix: module declares its path as: github.com/moov-io/signedxml but was required as: github.com/ma314smith/signedxml.