### PR TITLE
Address a panic when exporting RSA public keys in transit

### DIFF
--- a/builtin/logical/transit/path_export.go
+++ b/builtin/logical/transit/path_export.go
@@ -5,6 +5,7 @@ package transit
 
 import (
 	"context"
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/x509"
@@ -296,18 +297,31 @@ func encodeRSAPublicKey(key *keysutil.KeyEntry) (string, error) {
 		return "", errors.New("nil KeyEntry provided")
 	}
 
-	blockType := "RSA PUBLIC KEY"
-	derBytes, err := x509.MarshalPKIXPublicKey(key.RSAPublicKey)
-	if err != nil {
-		return "", err
+	var publicKey crypto.PublicKey
+	publicKey = key.RSAPublicKey
+	if key.RSAKey != nil {
+		// Prefer the private key if it exists
+		publicKey = key.RSAKey.Public()
 	}
 
-	pemBlock := pem.Block{
-		Type:  blockType,
+	if publicKey == nil {
+		return "", errors.New("requested to encode an RSA public key with no RSA key present")
+	}
+
+	// Encode the RSA public key in PEM format to return over the API
+	derBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling RSA public key: %w", err)
+	}
+	pemBlock := &pem.Block{
+		Type:  "PUBLIC KEY",
 		Bytes: derBytes,
 	}
+	pemBytes := pem.EncodeToMemory(pemBlock)
+	if pemBytes == nil || len(pemBytes) == 0 {
+		return "", fmt.Errorf("failed to PEM-encode RSA public key")
+	}
 
-	pemBytes := pem.EncodeToMemory(&pemBlock)
 	return string(pemBytes), nil
 }
 

--- a/changelog/24054.txt
+++ b/changelog/24054.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/transit: Fix a panic when attempting to export a public RSA key
+```


### PR DESCRIPTION
 - When attempting to export the public key for an RSA key that we only have a private key for, the export panics with a nil deference.
 - Add additional tests around Transit key exporting
 - Fixes #23980