### PR TITLE
fix `log_requests_level` misconfiguration

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1285,7 +1285,7 @@ func (c *Core) configureListeners(conf *CoreConfig) error {
 	return nil
 }
 
-// configureLogRequestsLevel configures the Core with the supplied log level.
+// configureLogRequestsLevel configures the Core with the supplied log requests level.
 func (c *Core) configureLogRequestsLevel(level string) {
 	c.logRequestsLevel = uberAtomic.NewInt32(0)
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -1229,7 +1229,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	}
 
 	// Log level
-	c.configureLogRequestLevel(conf.RawConfig.LogLevel)
+	c.configureLogRequestLevel(conf.RawConfig.LogRequestsLevel)
 
 	// Quotas
 	quotasLogger := conf.Logger.Named("quotas")

--- a/vault/core.go
+++ b/vault/core.go
@@ -1228,8 +1228,8 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		return nil, err
 	}
 
-	// Log level
-	c.configureLogRequestLevel(conf.RawConfig.LogRequestsLevel)
+	// Log requests level
+	c.configureLogRequestsLevel(conf.RawConfig.LogRequestsLevel)
 
 	// Quotas
 	quotasLogger := conf.Logger.Named("quotas")
@@ -1285,8 +1285,8 @@ func (c *Core) configureListeners(conf *CoreConfig) error {
 	return nil
 }
 
-// configureLogRequestLevel configures the Core with the supplied log level.
-func (c *Core) configureLogRequestLevel(level string) {
+// configureLogRequestsLevel configures the Core with the supplied log level.
+func (c *Core) configureLogRequestsLevel(level string) {
 	c.logRequestsLevel = uberAtomic.NewInt32(0)
 
 	lvl := log.LevelFromString(level)

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -254,12 +254,12 @@ func TestNewCore_configureLogRequestLevel(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// We need to supply a logger, as configureLogRequestLevel emits
+			// We need to supply a logger, as configureLogRequestsLevel emits
 			// warnings to the logs in certain circumstances.
 			core := &Core{
 				logger: corehelpers.NewTestLogger(t),
 			}
-			core.configureLogRequestLevel(tc.level)
+			core.configureLogRequestsLevel(tc.level)
 			require.Equal(t, tc.expectedLevel, log.Level(core.logRequestsLevel.Load()))
 		})
 	}


### PR DESCRIPTION
A refactoring change introduced a bug where the incorrect value (log level rather than log requests level) is suppled to the receiver which configures the log requests level on a Core.

Fixes: https://github.com/hashicorp/vault/issues/24045