### PR TITLE
Add additional Linux distros and Consul editions to Enos scenarios

### DIFF
--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -94,6 +94,11 @@ jobs:
       ENOS_VAR_vault_product_version: ${{ needs.metadata.outputs.vault-version }}
       ENOS_VAR_vault_revision: ${{ inputs.vault-revision }}
       ENOS_VAR_vault_license_path: ./support/vault.hclic
+      ENOS_VAR_distro_version_amazon_linux: ${{ matrix.attributes.distro_version_amazon_linux }}
+      ENOS_VAR_distro_version_leap: ${{ matrix.attributes.distro_version_leap }}
+      ENOS_VAR_distro_version_rhel: ${{ matrix.attributes.distro_version_rhel }}
+      ENOS_VAR_distro_version_sles: ${{ matrix.attributes.distro_version_sles }}
+      ENOS_VAR_distro_version_ubuntu: ${{ matrix.attributes.distro_version_ubuntu }}
       ENOS_DEBUG_DATA_ROOT_DIR: /tmp/enos-debug-data
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/enos/enos-globals.hcl
+++ b/enos/enos-globals.hcl
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 globals {
-  backend_tag_key = "VaultStorage"
+  backend_license_path = var.backend_license_path
+  backend_tag_key      = "VaultStorage"
   build_tags = {
     "ce"               = ["ui"]
     "ent"              = ["ui", "enterprise", "ent"]
@@ -10,28 +11,46 @@ globals {
     "ent.hsm"          = ["ui", "enterprise", "cgo", "hsm", "venthsm"]
     "ent.hsm.fips1402" = ["ui", "enterprise", "cgo", "hsm", "fips", "fips_140_2", "ent.hsm.fips1402"]
   }
+  distro_packages = {
+    amazon_linux = ["nc"]
+    leap         = ["netcat"]
+    rhel         = ["nc"]
+    sles         = ["netcat"]
+    ubuntu       = ["netcat"]
+  }
   distro_version = {
-    "rhel"   = var.rhel_distro_version
-    "ubuntu" = var.ubuntu_distro_version
+    "amazon_linux" = var.distro_version_amazon_linux
+    "leap"         = var.distro_version_leap
+    "rhel"         = var.distro_version_rhel
+    "sles"         = var.distro_version_sles
+    "ubuntu"       = var.distro_version_ubuntu
+  }
+  package_manager = {
+    "amazon_linux" = "yum"
+    "leap"         = "zypper"
+    "rhel"         = "yum"
+    "sles"         = "zypper"
+    "ubuntu"       = "apt"
   }
   packages = ["jq"]
-  distro_packages = {
-    ubuntu = ["netcat"]
-    rhel   = ["nc"]
-  }
   sample_attributes = {
     # NOTE(9/28/23): Temporarily use us-east-2 due to another networking in us-east-1
     # aws_region = ["us-east-1", "us-west-2"]
-    aws_region = ["us-east-2", "us-west-2"]
+    aws_region                  = ["us-east-2", "us-west-2"]
+    distro_version_amazon_linux = ["amzn2"]
+    distro_version_leap         = ["15.4", "15.5"]
+    distro_version_rhel         = ["8.8", "9.1"]
+    distro_version_sles         = ["v15_sp4_standard", "v15_sp5_standard"]
+    distro_version_ubuntu       = ["18.04", "20.04", "22.04"]
   }
   tags = merge({
     "Project Name" : var.project_name
     "Project" : "Enos",
     "Environment" : "ci"
   }, var.tags)
-  vault_install_dir_packages = {
-    rhel   = "/bin"
-    ubuntu = "/usr/bin"
+  vault_install_dir = {
+    bundle  = "/opt/vault/bin"
+    package = "/usr/bin"
   }
   vault_license_path = abspath(var.vault_license_path != null ? var.vault_license_path : joinpath(path.root, "./support/vault.hclic"))
   vault_tag_key      = "Type" // enos_vault_start expects Type as the tag key

--- a/enos/enos-providers.hcl
+++ b/enos/enos-providers.hcl
@@ -5,7 +5,8 @@ provider "aws" "default" {
   region = var.aws_region
 }
 
-provider "enos" "rhel" {
+# This default SSH user is used in RHEL, Amazon Linux, SUSE, and Leap distros
+provider "enos" "ec2_user" {
   transport = {
     ssh = {
       user             = "ec2-user"
@@ -14,6 +15,7 @@ provider "enos" "rhel" {
   }
 }
 
+# This default SSH user is used in the Ubuntu distro
 provider "enos" "ubuntu" {
   transport = {
     ssh = {

--- a/enos/enos-samples-ce-build.hcl
+++ b/enos/enos-samples-ce-build.hcl
@@ -9,6 +9,7 @@ sample "build_ce_linux_amd64_deb" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -19,6 +20,7 @@ sample "build_ce_linux_amd64_deb" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -29,6 +31,7 @@ sample "build_ce_linux_amd64_deb" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -39,6 +42,7 @@ sample "build_ce_linux_amd64_deb" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -53,6 +57,7 @@ sample "build_ce_linux_arm64_deb" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -63,6 +68,7 @@ sample "build_ce_linux_arm64_deb" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -73,6 +79,7 @@ sample "build_ce_linux_arm64_deb" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -83,6 +90,7 @@ sample "build_ce_linux_arm64_deb" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -97,6 +105,7 @@ sample "build_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["rhel"]
       edition         = ["ce"]
     }
@@ -107,7 +116,8 @@ sample "build_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      consul_edition  = ["ce"]
+      distro          = ["amazon_linux", "leap", "rhel"]
       edition         = ["ce"]
     }
   }
@@ -117,7 +127,8 @@ sample "build_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      consul_edition  = ["ce"]
+      distro          = ["amazon_linux", "leap", "rhel"]
       edition         = ["ce"]
     }
   }
@@ -127,7 +138,8 @@ sample "build_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      consul_edition  = ["ce"]
+      distro          = ["amazon_linux", "leap", "rhel"]
       edition         = ["ce"]
     }
   }
@@ -141,7 +153,8 @@ sample "build_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      consul_edition  = ["ce"]
+      distro          = ["amazon_linux", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -151,7 +164,8 @@ sample "build_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      consul_edition  = ["ce"]
+      distro          = ["amazon_linux", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -161,7 +175,8 @@ sample "build_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      consul_edition  = ["ce"]
+      distro          = ["amazon_linux", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -171,7 +186,8 @@ sample "build_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      consul_edition  = ["ce"]
+      distro          = ["amazon_linux", "leap", "rhel", "sles"]
       edition         = ["ce"]
 
       exclude {
@@ -191,6 +207,7 @@ sample "build_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["crt"]
+      consul_edition  = ["ce"]
       edition         = ["ce"]
     }
   }
@@ -200,6 +217,7 @@ sample "build_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["crt"]
+      consul_edition  = ["ce"]
       edition         = ["ce"]
     }
   }
@@ -209,6 +227,7 @@ sample "build_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["crt"]
+      consul_edition  = ["ce"]
       edition         = ["ce"]
     }
   }
@@ -218,6 +237,7 @@ sample "build_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["crt"]
+      consul_edition  = ["ce"]
       edition         = ["ce"]
     }
   }
@@ -231,6 +251,7 @@ sample "build_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["bundle"]
+      consul_edition  = ["ce"]
       edition         = ["ce"]
     }
   }
@@ -240,6 +261,7 @@ sample "build_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["bundle"]
+      consul_edition  = ["ce"]
       edition         = ["ce"]
     }
   }
@@ -249,6 +271,7 @@ sample "build_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["bundle"]
+      consul_edition  = ["ce"]
       edition         = ["ce"]
     }
   }
@@ -258,6 +281,7 @@ sample "build_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["bundle"]
+      consul_edition  = ["ce"]
       edition         = ["ce"]
     }
   }

--- a/enos/enos-samples-ce-release.hcl
+++ b/enos/enos-samples-ce-release.hcl
@@ -9,6 +9,7 @@ sample "release_ce_linux_amd64_deb" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -19,6 +20,7 @@ sample "release_ce_linux_amd64_deb" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -29,6 +31,7 @@ sample "release_ce_linux_amd64_deb" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -39,6 +42,7 @@ sample "release_ce_linux_amd64_deb" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -53,6 +57,7 @@ sample "release_ce_linux_arm64_deb" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -63,6 +68,7 @@ sample "release_ce_linux_arm64_deb" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -73,6 +79,7 @@ sample "release_ce_linux_arm64_deb" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -83,6 +90,7 @@ sample "release_ce_linux_arm64_deb" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
+      consul_edition  = ["ce"]
       distro          = ["ubuntu"]
       edition         = ["ce"]
     }
@@ -97,7 +105,8 @@ sample "release_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      consul_edition  = ["ce"]
+      distro          = ["amazon_linux", "leap", "rhel"]
       edition         = ["ce"]
     }
   }
@@ -107,7 +116,8 @@ sample "release_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      consul_edition  = ["ce"]
+      distro          = ["amazon_linux", "leap", "rhel"]
       edition         = ["ce"]
     }
   }
@@ -117,7 +127,8 @@ sample "release_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      consul_edition  = ["ce"]
+      distro          = ["amazon_linux", "leap", "rhel"]
       edition         = ["ce"]
     }
   }
@@ -127,7 +138,8 @@ sample "release_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      consul_edition  = ["ce"]
+      distro          = ["amazon_linux", "leap", "rhel"]
       edition         = ["ce"]
     }
   }
@@ -141,7 +153,8 @@ sample "release_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      consul_edition  = ["ce"]
+      distro          = ["amazon_linux", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -151,7 +164,8 @@ sample "release_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      consul_edition  = ["ce"]
+      distro          = ["amazon_linux", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -161,7 +175,8 @@ sample "release_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      consul_edition  = ["ce"]
+      distro          = ["amazon_linux", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -171,7 +186,8 @@ sample "release_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      consul_edition  = ["ce"]
+      distro          = ["amazon_linux", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -185,6 +201,7 @@ sample "release_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["artifactory"]
+      consul_edition  = ["ce"]
       edition         = ["ce"]
     }
   }
@@ -194,6 +211,7 @@ sample "release_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["artifactory"]
+      consul_edition  = ["ce"]
       edition         = ["ce"]
     }
   }
@@ -203,6 +221,7 @@ sample "release_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["artifactory"]
+      consul_edition  = ["ce"]
       edition         = ["ce"]
     }
   }
@@ -212,6 +231,7 @@ sample "release_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["artifactory"]
+      consul_edition  = ["ce"]
       edition         = ["ce"]
     }
   }
@@ -225,6 +245,7 @@ sample "release_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["bundle"]
+      consul_edition  = ["ce"]
       edition         = ["ce"]
     }
   }
@@ -243,6 +264,7 @@ sample "release_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["bundle"]
+      consul_edition  = ["ce"]
       edition         = ["ce"]
     }
   }
@@ -252,6 +274,7 @@ sample "release_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["bundle"]
+      consul_edition  = ["ce"]
       edition         = ["ce"]
     }
   }

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -7,8 +7,9 @@ scenario "agent" {
     artifact_source = ["local", "crt", "artifactory"]
     artifact_type   = ["bundle", "package"]
     backend         = ["consul", "raft"]
+    consul_edition  = ["ce", "ent"]
     consul_version  = ["1.12.9", "1.13.9", "1.14.9", "1.15.5", "1.16.1"]
-    distro          = ["ubuntu", "rhel"]
+    distro          = ["amazon_linux", "leap", "rhel", "sles", "ubuntu"]
     edition         = ["ce", "ent", "ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     seal            = ["awskms", "shamir"]
     seal_ha_beta    = ["true", "false"]
@@ -24,24 +25,33 @@ scenario "agent" {
       arch    = ["arm64"]
       edition = ["ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     }
+
+    # non-SAP, non-BYOS SLES AMIs in the versions we use are only offered for amd64
+    # (see distro_version_* variables in enos-variables.hcl for currently supported versions)
+    exclude {
+      distro = ["sles"]
+      arch   = ["arm64"]
+    }
   }
 
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.ubuntu,
-    provider.enos.rhel
+    provider.enos.ec2_user,
+    provider.enos.ubuntu
   ]
 
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      rhel   = provider.enos.rhel
-      ubuntu = provider.enos.ubuntu
+      amazon_linux = provider.enos.ec2_user
+      leap         = provider.enos.ec2_user
+      rhel         = provider.enos.ec2_user
+      sles         = provider.enos.ec2_user
+      ubuntu       = provider.enos.ubuntu
     }
-    manage_service    = matrix.artifact_type == "bundle"
-    vault_install_dir = matrix.artifact_type == "bundle" ? var.vault_install_dir : global.vault_install_dir_packages[matrix.distro]
+    manage_service = matrix.artifact_type == "bundle"
   }
 
   step "get_local_metadata" {
@@ -94,7 +104,7 @@ scenario "agent" {
   // This step reads the contents of the backend license if we're using a Consul backend and
   // the edition is "ent".
   step "read_backend_license" {
-    skip_step = matrix.backend == "raft" || var.backend_edition == "ce"
+    skip_step = matrix.backend == "raft" || matrix.consul_edition == "ce"
     module    = module.read_license
 
     variables {
@@ -158,9 +168,9 @@ scenario "agent" {
     variables {
       cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       cluster_tag_key = global.backend_tag_key
-      license         = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      license         = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       release = {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       }
       target_hosts = step.create_vault_cluster_backend_targets.hosts
@@ -180,20 +190,23 @@ scenario "agent" {
     }
 
     variables {
+      arch                    = matrix.arch
       artifactory_release     = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
       backend_cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       backend_cluster_tag_key = global.backend_tag_key
       cluster_name            = step.create_vault_cluster_targets.cluster_name
-      consul_license          = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      consul_license          = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       consul_release = matrix.backend == "consul" ? {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       } : null
+      distro_version_sles  = var.distro_version_sles
       enable_audit_devices = var.vault_enable_audit_devices
-      install_dir          = local.vault_install_dir
+      install_dir          = global.vault_install_dir[matrix.artifact_type]
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = local.artifact_path
       manage_service       = local.manage_service
+      package_manager      = global.package_manager[matrix.distro]
       packages             = concat(global.packages, global.distro_packages[matrix.distro])
       seal_ha_beta         = matrix.seal_ha_beta
       seal_key_name        = step.create_seal_key.resource_name
@@ -215,7 +228,7 @@ scenario "agent" {
     variables {
       timeout           = 120 # seconds
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -233,7 +246,7 @@ scenario "agent" {
     }
 
     variables {
-      vault_install_dir                = local.vault_install_dir
+      vault_install_dir                = global.vault_install_dir[matrix.artifact_type]
       vault_instances                  = step.create_vault_cluster_targets.hosts
       vault_root_token                 = step.create_vault_cluster.root_token
       vault_agent_template_destination = "/tmp/agent_output.txt"
@@ -270,7 +283,7 @@ scenario "agent" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -286,7 +299,7 @@ scenario "agent" {
     variables {
       vault_instances       = step.create_vault_cluster_targets.hosts
       vault_edition         = matrix.edition
-      vault_install_dir     = local.vault_install_dir
+      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
       vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
       vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
@@ -303,7 +316,7 @@ scenario "agent" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -323,7 +336,7 @@ scenario "agent" {
       leader_public_ip  = step.get_vault_cluster_ips.leader_public_ip
       leader_private_ip = step.get_vault_cluster_ips.leader_private_ip
       vault_instances   = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -341,7 +354,7 @@ scenario "agent" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
       vault_root_token  = step.create_vault_cluster.root_token
     }
@@ -360,7 +373,7 @@ scenario "agent" {
 
     variables {
       vault_edition     = matrix.edition
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -378,7 +391,7 @@ scenario "agent" {
 
     variables {
       node_public_ips   = step.get_vault_cluster_ips.follower_public_ips
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
     }
   }
 

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -6,7 +6,7 @@ scenario "autopilot" {
     arch            = ["amd64", "arm64"]
     artifact_source = ["local", "crt", "artifactory"]
     artifact_type   = ["bundle", "package"]
-    distro          = ["ubuntu", "rhel"]
+    distro          = ["amazon_linux", "leap", "rhel", "sles", "ubuntu"]
     edition         = ["ce", "ent", "ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     // NOTE: when backporting, make sure that our initial versions are less than that
     // release branch's version.
@@ -25,24 +25,33 @@ scenario "autopilot" {
       arch    = ["arm64"]
       edition = ["ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     }
+
+    # non-SAP, non-BYOS SLES AMIs in the versions we use are only offered for amd64
+    # (see distro_version_* variables in enos-variables.hcl for currently supported versions)
+    exclude {
+      distro = ["sles"]
+      arch   = ["arm64"]
+    }
   }
 
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.ubuntu,
-    provider.enos.rhel
+    provider.enos.ec2_user,
+    provider.enos.ubuntu
   ]
 
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      rhel   = provider.enos.rhel
-      ubuntu = provider.enos.ubuntu
+      amazon_linux = provider.enos.ec2_user
+      leap         = provider.enos.ec2_user
+      rhel         = provider.enos.ec2_user
+      sles         = provider.enos.ec2_user
+      ubuntu       = provider.enos.ubuntu
     }
-    manage_service    = matrix.artifact_type == "bundle"
-    vault_install_dir = matrix.artifact_type == "bundle" ? var.vault_install_dir : global.vault_install_dir_packages[matrix.distro]
+    manage_service = matrix.artifact_type == "bundle"
   }
 
   step "build_vault" {
@@ -124,10 +133,13 @@ scenario "autopilot" {
     }
 
     variables {
+      arch                 = matrix.arch
       cluster_name         = step.create_vault_cluster_targets.cluster_name
+      distro_version_sles  = var.distro_version_sles
       enable_audit_devices = var.vault_enable_audit_devices
-      install_dir          = local.vault_install_dir
+      install_dir          = global.vault_install_dir[matrix.artifact_type]
       license              = matrix.edition != "ce" ? step.read_license.license : null
+      package_manager      = global.package_manager[matrix.distro]
       packages             = concat(global.packages, global.distro_packages[matrix.distro])
       release = {
         edition = matrix.edition
@@ -159,7 +171,7 @@ scenario "autopilot" {
 
     variables {
       vault_hosts       = step.create_vault_cluster.target_hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -179,7 +191,7 @@ scenario "autopilot" {
       leader_public_ip  = step.get_vault_cluster_ips.leader_public_ip
       leader_private_ip = step.get_vault_cluster_ips.leader_private_ip
       vault_instances   = step.create_vault_cluster.target_hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -223,17 +235,20 @@ scenario "autopilot" {
     }
 
     variables {
+      arch                        = matrix.arch
       artifactory_release         = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
       enable_audit_devices        = var.vault_enable_audit_devices
       cluster_name                = step.create_vault_cluster_targets.cluster_name
+      distro_version_sles         = var.distro_version_sles
       log_level                   = var.vault_log_level
       force_unseal                = matrix.seal == "shamir"
       initialize_cluster          = false
-      install_dir                 = local.vault_install_dir
+      install_dir                 = global.vault_install_dir[matrix.artifact_type]
       license                     = matrix.edition != "ce" ? step.read_license.license : null
       local_artifact_path         = local.artifact_path
       manage_service              = local.manage_service
-      packages                    = concat(global.packages, global.distro_packages[matrix.distro])
+      package_manager             = global.package_manager[matrix.distro]
+      packages                    = global.packages
       root_token                  = step.create_vault_cluster.root_token
       seal_ha_beta                = matrix.seal_ha_beta
       seal_key_name               = step.create_seal_key.resource_name
@@ -259,7 +274,7 @@ scenario "autopilot" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.upgrade_vault_cluster_with_autopilot.target_hosts
     }
   }
@@ -276,7 +291,7 @@ scenario "autopilot" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.upgrade_vault_cluster_with_autopilot.target_hosts
       vault_root_token  = step.upgrade_vault_cluster_with_autopilot.root_token
     }
@@ -297,7 +312,7 @@ scenario "autopilot" {
     variables {
       vault_autopilot_upgrade_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_autopilot_upgrade_status  = "await-server-removal"
-      vault_install_dir               = local.vault_install_dir
+      vault_install_dir               = global.vault_install_dir[matrix.artifact_type]
       vault_instances                 = step.create_vault_cluster.target_hosts
       vault_root_token                = step.upgrade_vault_cluster_with_autopilot.root_token
     }
@@ -317,7 +332,7 @@ scenario "autopilot" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
       vault_hosts       = step.upgrade_vault_cluster_with_autopilot.target_hosts
     }
@@ -339,7 +354,7 @@ scenario "autopilot" {
 
     variables {
       vault_hosts       = step.upgrade_vault_cluster_with_autopilot.target_hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -360,7 +375,7 @@ scenario "autopilot" {
     variables {
       node_public_ips      = step.get_updated_vault_cluster_ips.follower_public_ips
       vault_instance_count = 6
-      vault_install_dir    = local.vault_install_dir
+      vault_install_dir    = global.vault_install_dir[matrix.artifact_type]
     }
   }
 
@@ -380,7 +395,7 @@ scenario "autopilot" {
     variables {
       operator_instance      = step.get_updated_vault_cluster_ips.leader_public_ip
       remove_vault_instances = step.create_vault_cluster.target_hosts
-      vault_install_dir      = local.vault_install_dir
+      vault_install_dir      = global.vault_install_dir[matrix.artifact_type]
       vault_instance_count   = 3
       vault_root_token       = step.create_vault_cluster.root_token
     }
@@ -419,7 +434,7 @@ scenario "autopilot" {
     variables {
       vault_autopilot_upgrade_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_autopilot_upgrade_status  = "idle"
-      vault_install_dir               = local.vault_install_dir
+      vault_install_dir               = global.vault_install_dir[matrix.artifact_type]
       vault_instances                 = step.upgrade_vault_cluster_with_autopilot.target_hosts
       vault_root_token                = step.create_vault_cluster.root_token
     }
@@ -440,7 +455,7 @@ scenario "autopilot" {
 
     variables {
       vault_edition     = matrix.edition
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.upgrade_vault_cluster_with_autopilot.target_hosts
     }
   }
@@ -461,7 +476,7 @@ scenario "autopilot" {
     variables {
       vault_instances       = step.upgrade_vault_cluster_with_autopilot.target_hosts
       vault_edition         = matrix.edition
-      vault_install_dir     = local.vault_install_dir
+      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
       vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
       vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
@@ -504,7 +519,7 @@ scenario "autopilot" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.upgrade_vault_cluster_with_autopilot.target_hosts
       vault_root_token  = step.create_vault_cluster.root_token
     }

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -7,8 +7,9 @@ scenario "proxy" {
     artifact_source = ["local", "crt", "artifactory"]
     artifact_type   = ["bundle", "package"]
     backend         = ["consul", "raft"]
+    consul_edition  = ["ce", "ent"]
     consul_version  = ["1.12.9", "1.13.9", "1.14.9", "1.15.5", "1.16.1"]
-    distro          = ["ubuntu", "rhel"]
+    distro          = ["amazon_linux", "leap", "rhel", "sles", "ubuntu"]
     edition         = ["ce", "ent", "ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     seal            = ["awskms", "shamir"]
     seal_ha_beta    = ["true", "false"]
@@ -24,24 +25,34 @@ scenario "proxy" {
       arch    = ["arm64"]
       edition = ["ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     }
+
+    # non-SAP, non-BYOS SLES AMIs in the versions we use are only offered for amd64
+    # (see distro_version_* variables in enos-variables.hcl for currently supported versions)
+    exclude {
+      distro = ["sles"]
+      arch   = ["arm64"]
+    }
   }
 
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.ubuntu,
-    provider.enos.rhel
+    provider.enos.ec2_user,
+    provider.enos.ubuntu
   ]
 
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      rhel   = provider.enos.rhel
-      ubuntu = provider.enos.ubuntu
+      amazon_linux = provider.enos.ec2_user
+      leap         = provider.enos.ec2_user
+      rhel         = provider.enos.ec2_user
+      sles         = provider.enos.ec2_user
+      ubuntu       = provider.enos.ubuntu
     }
     manage_service    = matrix.artifact_type == "bundle"
-    vault_install_dir = matrix.artifact_type == "bundle" ? var.vault_install_dir : global.vault_install_dir_packages[matrix.distro]
+    vault_install_dir = global.vault_install_dir[matrix.artifact_type]
   }
 
   step "get_local_metadata" {
@@ -94,7 +105,7 @@ scenario "proxy" {
   // This step reads the contents of the backend license if we're using a Consul backend and
   // the edition is "ent".
   step "read_backend_license" {
-    skip_step = matrix.backend == "raft" || var.backend_edition == "ce"
+    skip_step = matrix.backend == "raft" || matrix.consul_edition == "ce"
     module    = module.read_license
 
     variables {
@@ -158,9 +169,9 @@ scenario "proxy" {
     variables {
       cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       cluster_tag_key = global.backend_tag_key
-      license         = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      license         = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       release = {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       }
       target_hosts = step.create_vault_cluster_backend_targets.hosts
@@ -180,20 +191,23 @@ scenario "proxy" {
     }
 
     variables {
+      arch                    = matrix.arch
       artifactory_release     = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
       backend_cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       backend_cluster_tag_key = global.backend_tag_key
       cluster_name            = step.create_vault_cluster_targets.cluster_name
-      consul_license          = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      consul_license          = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       consul_release = matrix.backend == "consul" ? {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       } : null
+      distro_version_sles  = var.distro_version_sles
       enable_audit_devices = var.vault_enable_audit_devices
-      install_dir          = local.vault_install_dir
+      install_dir          = global.vault_install_dir[matrix.artifact_type]
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = local.artifact_path
       manage_service       = local.manage_service
+      package_manager      = global.package_manager[matrix.distro]
       packages             = concat(global.packages, global.distro_packages[matrix.distro])
       seal_ha_beta         = matrix.seal_ha_beta
       seal_key_name        = step.create_seal_key.resource_name
@@ -215,7 +229,7 @@ scenario "proxy" {
     variables {
       timeout           = 120 # seconds
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -232,7 +246,7 @@ scenario "proxy" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
       vault_root_token  = step.create_vault_cluster.root_token
     }
@@ -248,7 +262,7 @@ scenario "proxy" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -264,7 +278,7 @@ scenario "proxy" {
     variables {
       vault_instances       = step.create_vault_cluster_targets.hosts
       vault_edition         = matrix.edition
-      vault_install_dir     = local.vault_install_dir
+      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
       vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
       vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
@@ -281,7 +295,7 @@ scenario "proxy" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -301,7 +315,7 @@ scenario "proxy" {
       leader_public_ip  = step.get_vault_cluster_ips.leader_public_ip
       leader_private_ip = step.get_vault_cluster_ips.leader_private_ip
       vault_instances   = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -316,7 +330,7 @@ scenario "proxy" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
       vault_root_token  = step.create_vault_cluster.root_token
     }
@@ -332,7 +346,7 @@ scenario "proxy" {
 
     variables {
       vault_edition     = matrix.edition
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -350,7 +364,7 @@ scenario "proxy" {
 
     variables {
       node_public_ips   = step.get_vault_cluster_ips.follower_public_ips
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
     }
   }
 

--- a/enos/enos-scenario-seal-ha.hcl
+++ b/enos/enos-scenario-seal-ha.hcl
@@ -7,8 +7,9 @@ scenario "seal_ha" {
     artifact_source = ["local", "crt", "artifactory"]
     artifact_type   = ["bundle", "package"]
     backend         = ["consul", "raft"]
+    consul_edition  = ["ce", "ent"]
     consul_version  = ["1.12.9", "1.13.9", "1.14.9", "1.15.5", "1.16.1"]
-    distro          = ["ubuntu", "rhel"]
+    distro          = ["amazon_linux", "leap", "rhel", "sles", "ubuntu"]
     edition         = ["ent", "ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     primary_seal    = ["awskms"]
     secondary_seal  = ["awskms"]
@@ -24,24 +25,33 @@ scenario "seal_ha" {
       arch    = ["arm64"]
       edition = ["ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     }
+
+    # non-SAP, non-BYOS SLES AMIs in the versions we use are only offered for amd64
+    # (see distro_version_* variables in enos-variables.hcl for currently supported versions)
+    exclude {
+      distro = ["sles"]
+      arch   = ["arm64"]
+    }
   }
 
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.ubuntu,
-    provider.enos.rhel
+    provider.enos.ec2_user,
+    provider.enos.ubuntu
   ]
 
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      rhel   = provider.enos.rhel
-      ubuntu = provider.enos.ubuntu
+      amazon_linux = provider.enos.ec2_user
+      leap         = provider.enos.ec2_user
+      rhel         = provider.enos.ec2_user
+      sles         = provider.enos.ec2_user
+      ubuntu       = provider.enos.ubuntu
     }
-    manage_service    = matrix.artifact_type == "bundle"
-    vault_install_dir = matrix.artifact_type == "bundle" ? var.vault_install_dir : global.vault_install_dir_packages[matrix.distro]
+    manage_service = matrix.artifact_type == "bundle"
   }
 
   step "get_local_metadata" {
@@ -106,7 +116,7 @@ scenario "seal_ha" {
   // This step reads the contents of the backend license if we're using a Consul backend and
   // the edition is "ent".
   step "read_backend_license" {
-    skip_step = matrix.backend == "raft" || var.backend_edition == "ce"
+    skip_step = matrix.backend == "raft" || matrix.consul_edition == "ce"
     module    = module.read_license
 
     variables {
@@ -170,9 +180,9 @@ scenario "seal_ha" {
     variables {
       cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       cluster_tag_key = global.backend_tag_key
-      license         = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      license         = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       release = {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       }
       target_hosts = step.create_vault_cluster_backend_targets.hosts
@@ -192,20 +202,23 @@ scenario "seal_ha" {
     }
 
     variables {
+      arch                    = matrix.arch
       artifactory_release     = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
       backend_cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       backend_cluster_tag_key = global.backend_tag_key
       cluster_name            = step.create_vault_cluster_targets.cluster_name
-      consul_license          = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      consul_license          = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       consul_release = matrix.backend == "consul" ? {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       } : null
+      distro_version_sles  = var.distro_version_sles
       enable_audit_devices = var.vault_enable_audit_devices
-      install_dir          = local.vault_install_dir
+      install_dir          = global.vault_install_dir[matrix.artifact_type]
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = local.artifact_path
       manage_service       = local.manage_service
+      package_manager      = global.package_manager[matrix.distro]
       packages             = concat(global.packages, global.distro_packages[matrix.distro])
       // Only configure our primary seal during our initial cluster setup
       seal_type       = matrix.primary_seal
@@ -227,7 +240,7 @@ scenario "seal_ha" {
     variables {
       timeout           = 120 # seconds
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -242,7 +255,7 @@ scenario "seal_ha" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -256,7 +269,7 @@ scenario "seal_ha" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -278,7 +291,7 @@ scenario "seal_ha" {
       leader_public_ip  = step.get_vault_cluster_ips.leader_public_ip
       leader_private_ip = step.get_vault_cluster_ips.leader_private_ip
       vault_instances   = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -296,7 +309,7 @@ scenario "seal_ha" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -330,7 +343,7 @@ scenario "seal_ha" {
 
     variables {
       cluster_name            = step.create_vault_cluster_targets.cluster_name
-      install_dir             = local.vault_install_dir
+      install_dir             = global.vault_install_dir[matrix.artifact_type]
       license                 = matrix.edition != "ce" ? step.read_vault_license.license : null
       manage_service          = local.manage_service
       seal_type               = matrix.primary_seal
@@ -354,7 +367,7 @@ scenario "seal_ha" {
     variables {
       timeout           = 120 # seconds
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -369,7 +382,7 @@ scenario "seal_ha" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -383,7 +396,7 @@ scenario "seal_ha" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -402,7 +415,7 @@ scenario "seal_ha" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -419,7 +432,7 @@ scenario "seal_ha" {
     variables {
       vault_instances       = step.create_vault_cluster_targets.hosts
       vault_edition         = matrix.edition
-      vault_install_dir     = local.vault_install_dir
+      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
       vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
       vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
@@ -437,7 +450,7 @@ scenario "seal_ha" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
       vault_root_token  = step.create_vault_cluster.root_token
     }
@@ -453,7 +466,7 @@ scenario "seal_ha" {
 
     variables {
       vault_edition     = matrix.edition
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -469,7 +482,7 @@ scenario "seal_ha" {
 
     variables {
       node_public_ips   = step.get_updated_cluster_ips.follower_public_ips
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
     }
   }
 
@@ -498,7 +511,7 @@ scenario "seal_ha" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_hosts       = step.create_vault_cluster_targets.hosts
       seal_type         = "multiseal"
     }
@@ -535,7 +548,7 @@ scenario "seal_ha" {
 
     variables {
       cluster_name    = step.create_vault_cluster_targets.cluster_name
-      install_dir     = local.vault_install_dir
+      install_dir     = global.vault_install_dir[matrix.artifact_type]
       license         = matrix.edition != "ce" ? step.read_vault_license.license : null
       manage_service  = local.manage_service
       seal_alias      = "secondary"
@@ -558,7 +571,7 @@ scenario "seal_ha" {
     variables {
       timeout           = 120 # seconds
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -574,7 +587,7 @@ scenario "seal_ha" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -589,7 +602,7 @@ scenario "seal_ha" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -608,7 +621,7 @@ scenario "seal_ha" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -624,7 +637,7 @@ scenario "seal_ha" {
 
     variables {
       node_public_ips   = step.get_cluster_ips_after_migration.follower_public_ips
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
     }
   }
 
@@ -640,7 +653,7 @@ scenario "seal_ha" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_hosts       = step.create_vault_cluster_targets.hosts
       seal_type         = matrix.secondary_seal
     }

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -7,8 +7,9 @@ scenario "smoke" {
     artifact_source = ["local", "crt", "artifactory"]
     artifact_type   = ["bundle", "package"]
     backend         = ["consul", "raft"]
+    consul_edition  = ["ce", "ent"]
     consul_version  = ["1.12.9", "1.13.9", "1.14.9", "1.15.5", "1.16.1"]
-    distro          = ["ubuntu", "rhel"]
+    distro          = ["amazon_linux", "leap", "rhel", "sles", "ubuntu"]
     edition         = ["ce", "ent", "ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     seal            = ["awskms", "shamir"]
     seal_ha_beta    = ["true", "false"]
@@ -24,24 +25,33 @@ scenario "smoke" {
       arch    = ["arm64"]
       edition = ["ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     }
+
+    # non-SAP, non-BYOS SLES AMIs in the versions we use are only offered for amd64
+    # (see distro_version_* variables in enos-variables.hcl for currently supported versions)
+    exclude {
+      distro = ["sles"]
+      arch   = ["arm64"]
+    }
   }
 
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.ubuntu,
-    provider.enos.rhel
+    provider.enos.ec2_user,
+    provider.enos.ubuntu
   ]
 
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      rhel   = provider.enos.rhel
-      ubuntu = provider.enos.ubuntu
+      amazon_linux = provider.enos.ec2_user
+      leap         = provider.enos.ec2_user
+      rhel         = provider.enos.ec2_user
+      sles         = provider.enos.ec2_user
+      ubuntu       = provider.enos.ubuntu
     }
-    manage_service    = matrix.artifact_type == "bundle"
-    vault_install_dir = matrix.artifact_type == "bundle" ? var.vault_install_dir : global.vault_install_dir_packages[matrix.distro]
+    manage_service = matrix.artifact_type == "bundle"
   }
 
   step "get_local_metadata" {
@@ -94,7 +104,7 @@ scenario "smoke" {
   // This step reads the contents of the backend license if we're using a Consul backend and
   // the edition is "ent".
   step "read_backend_license" {
-    skip_step = matrix.backend == "raft" || var.backend_edition == "ce"
+    skip_step = matrix.backend == "raft" || matrix.consul_edition == "ce"
     module    = module.read_license
 
     variables {
@@ -158,9 +168,9 @@ scenario "smoke" {
     variables {
       cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       cluster_tag_key = global.backend_tag_key
-      license         = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      license         = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       release = {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       }
       target_hosts = step.create_vault_cluster_backend_targets.hosts
@@ -180,20 +190,23 @@ scenario "smoke" {
     }
 
     variables {
+      arch                    = matrix.arch
       artifactory_release     = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
       backend_cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       backend_cluster_tag_key = global.backend_tag_key
       cluster_name            = step.create_vault_cluster_targets.cluster_name
-      consul_license          = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      consul_license          = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       consul_release = matrix.backend == "consul" ? {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       } : null
+      distro_version_sles  = var.distro_version_sles
       enable_audit_devices = var.vault_enable_audit_devices
-      install_dir          = local.vault_install_dir
+      install_dir          = global.vault_install_dir[matrix.artifact_type]
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = local.artifact_path
       manage_service       = local.manage_service
+      package_manager      = global.package_manager[matrix.distro]
       packages             = concat(global.packages, global.distro_packages[matrix.distro])
       seal_ha_beta         = matrix.seal_ha_beta
       seal_key_name        = step.create_seal_key.resource_name
@@ -215,7 +228,7 @@ scenario "smoke" {
     variables {
       timeout           = 120 # seconds
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -230,7 +243,7 @@ scenario "smoke" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -246,7 +259,7 @@ scenario "smoke" {
     variables {
       vault_instances       = step.create_vault_cluster_targets.hosts
       vault_edition         = matrix.edition
-      vault_install_dir     = local.vault_install_dir
+      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
       vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
       vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
@@ -263,7 +276,7 @@ scenario "smoke" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -283,7 +296,7 @@ scenario "smoke" {
       leader_public_ip  = step.get_vault_cluster_ips.leader_public_ip
       leader_private_ip = step.get_vault_cluster_ips.leader_private_ip
       vault_instances   = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -301,7 +314,7 @@ scenario "smoke" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
       vault_root_token  = step.create_vault_cluster.root_token
     }
@@ -320,7 +333,7 @@ scenario "smoke" {
 
     variables {
       vault_edition     = matrix.edition
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -338,7 +351,7 @@ scenario "smoke" {
 
     variables {
       node_public_ips   = step.get_vault_cluster_ips.follower_public_ips
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
     }
   }
 

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -200,6 +200,7 @@ scenario "smoke" {
         edition = matrix.consul_edition
         version = matrix.consul_version
       } : null
+      # TO DO: can we get rid of this?
       distro_version_sles  = var.distro_version_sles
       enable_audit_devices = var.vault_enable_audit_devices
       install_dir          = global.vault_install_dir[matrix.artifact_type]

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -7,8 +7,9 @@ scenario "upgrade" {
     artifact_source = ["local", "crt", "artifactory"]
     artifact_type   = ["bundle", "package"]
     backend         = ["consul", "raft"]
+    consul_edition  = ["ce", "ent"]
     consul_version  = ["1.14.9", "1.15.5", "1.16.1"]
-    distro          = ["ubuntu", "rhel"]
+    distro          = ["amazon_linux", "leap", "rhel", "sles", "ubuntu"]
     edition         = ["ce", "ent", "ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     // NOTE: when backporting the initial version make sure we don't include initial versions that
     // are a higher minor version that our release candidate. Also, prior to 1.11.x the
@@ -35,24 +36,33 @@ scenario "upgrade" {
       edition         = ["ent.fips1402", "ent.hsm.fips1402"]
       initial_version = ["1.8.12", "1.9.10"]
     }
+
+    # non-SAP, non-BYOS SLES AMIs in the versions we use are only offered for amd64
+    # (see distro_version_* variables in enos-variables.hcl for currently supported versions)
+    exclude {
+      distro = ["sles"]
+      arch   = ["arm64"]
+    }
   }
 
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.ubuntu,
-    provider.enos.rhel
+    provider.enos.ec2_user,
+    provider.enos.ubuntu
   ]
 
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      rhel   = provider.enos.rhel
-      ubuntu = provider.enos.ubuntu
+      amazon_linux = provider.enos.ec2_user
+      leap         = provider.enos.ec2_user
+      rhel         = provider.enos.ec2_user
+      sles         = provider.enos.ec2_user
+      ubuntu       = provider.enos.ubuntu
     }
-    manage_service    = matrix.artifact_type == "bundle"
-    vault_install_dir = matrix.artifact_type == "bundle" ? var.vault_install_dir : global.vault_install_dir_packages[matrix.distro]
+    manage_service = matrix.artifact_type == "bundle"
   }
 
   step "get_local_metadata" {
@@ -106,7 +116,7 @@ scenario "upgrade" {
   // This step reads the contents of the backend license if we're using a Consul backend and
   // the edition is "ent".
   step "read_backend_license" {
-    skip_step = matrix.backend == "raft" || var.backend_edition == "ce"
+    skip_step = matrix.backend == "raft" || matrix.consul_edition == "ce"
     module    = module.read_license
 
     variables {
@@ -170,9 +180,9 @@ scenario "upgrade" {
     variables {
       cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       cluster_tag_key = global.backend_tag_key
-      license         = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      license         = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       release = {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       }
       target_hosts = step.create_vault_cluster_backend_targets.hosts
@@ -192,17 +202,21 @@ scenario "upgrade" {
     }
 
     variables {
+      arch = matrix.arch
+      # awskms_unseal_key_arn   = step.create_vpc.kms_key_arn
       backend_cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       backend_cluster_tag_key = global.backend_tag_key
-      consul_license          = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
       cluster_name            = step.create_vault_cluster_targets.cluster_name
+      consul_license          = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       consul_release = matrix.backend == "consul" ? {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       } : null
+      distro_version_sles  = var.distro_version_sles
       enable_audit_devices = var.vault_enable_audit_devices
-      install_dir          = local.vault_install_dir
+      install_dir          = global.vault_install_dir[matrix.artifact_type]
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
+      package_manager      = global.package_manager[matrix.distro]
       packages             = concat(global.packages, global.distro_packages[matrix.distro])
       release = {
         edition = matrix.edition
@@ -226,7 +240,7 @@ scenario "upgrade" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -246,7 +260,7 @@ scenario "upgrade" {
       leader_public_ip  = step.get_vault_cluster_ips.leader_public_ip
       leader_private_ip = step.get_vault_cluster_ips.leader_private_ip
       vault_instances   = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -269,7 +283,7 @@ scenario "upgrade" {
       vault_instances           = step.create_vault_cluster_targets.hosts
       vault_local_artifact_path = local.artifact_path
       vault_artifactory_release = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
-      vault_install_dir         = local.vault_install_dir
+      vault_install_dir         = global.vault_install_dir[matrix.artifact_type]
       vault_unseal_keys         = matrix.seal == "shamir" ? step.create_vault_cluster.unseal_keys_hex : null
       vault_seal_type           = matrix.seal
     }
@@ -290,7 +304,7 @@ scenario "upgrade" {
     variables {
       timeout           = 120 # seconds
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -309,7 +323,7 @@ scenario "upgrade" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -327,7 +341,7 @@ scenario "upgrade" {
     variables {
       vault_instances       = step.create_vault_cluster_targets.hosts
       vault_edition         = matrix.edition
-      vault_install_dir     = local.vault_install_dir
+      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
       vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
       vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
@@ -347,7 +361,7 @@ scenario "upgrade" {
 
     variables {
       vault_instances   = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
     }
   }
 
@@ -365,7 +379,7 @@ scenario "upgrade" {
 
     variables {
       node_public_ips   = step.get_updated_vault_cluster_ips.follower_public_ips
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
     }
   }
 
@@ -381,7 +395,7 @@ scenario "upgrade" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
       vault_root_token  = step.create_vault_cluster.root_token
     }
@@ -399,7 +413,7 @@ scenario "upgrade" {
 
     variables {
       vault_edition     = matrix.edition
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -45,12 +45,6 @@ variable "aws_ssh_private_key_path" {
   default     = "./support/private_key.pem"
 }
 
-variable "backend_edition" {
-  description = "The backend release edition if applicable"
-  type        = string
-  default     = "ce" // or "ent"
-}
-
 variable "backend_instance_type" {
   description = "The instance type to use for the Vault backend. Must be arm64/nitro compatible"
   type        = string
@@ -75,10 +69,34 @@ variable "project_name" {
   default     = "vault-enos-integration"
 }
 
-variable "rhel_distro_version" {
+variable "distro_version_amazon_linux" {
+  description = "The version of Amazon Linux to use"
+  type        = string
+  default     = "amzn2" // currently this is the only version we support
+}
+
+variable "distro_version_leap" {
+  description = "The version of openSUSE leap to use"
+  type        = string
+  default     = "15.5" // or "15.4"
+}
+
+variable "distro_version_rhel" {
   description = "The version of RHEL to use"
   type        = string
   default     = "9.1" // or "8.8"
+}
+
+variable "distro_version_sles" {
+  description = "The version of SUSE SLES to use"
+  type        = string
+  default     = "v15_sp5_standard" // or "v15_sp4_standard"
+}
+
+variable "distro_version_ubuntu" {
+  description = "The version of ubuntu to use"
+  type        = string
+  default     = "22.04" // or "20.04", "18.04"
 }
 
 variable "tags" {
@@ -97,12 +115,6 @@ variable "tfc_api_token" {
   description = "The Terraform Cloud QTI Organization API token. This is used to download the enos Terraform provider."
   type        = string
   sensitive   = true
-}
-
-variable "ubuntu_distro_version" {
-  description = "The version of ubuntu to use"
-  type        = string
-  default     = "22.04" // or "20.04", "18.04"
 }
 
 variable "ui_test_filter" {

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -23,9 +23,6 @@
 # aws_ssh_private_key_path is the path to the AWS keypair private key
 # aws_ssh_private_key_path = "./support/private_key.pem"
 
-# backend_edition is the backend (consul) release edition if applicable to the scenario.
-# backend_edition = "ce"
-
 # backend_license_path is the license for the backend if applicable (Consul Enterprise)".
 # backend_license_path = "./support/consul.hclic"
 
@@ -40,8 +37,17 @@
 # resources.
 # project_name = "vault-enos-integration"
 
-# rhel_distro_version is the version of RHEL to use for "distro:rhel" variants.
-# rhel_distro_version = "9.1" // or "8.8"
+# distro_version_leap is the version of openSUSE Leap to use for "distro:leap" variants
+# distro_version_leap = "15.5" // or "15.4"
+
+# distro_version_rhel is the version of RHEL to use for "distro:rhel" variants.
+# distro_version_rhel = "9.1" // or "8.8"
+
+# distro_version_sles is the version of SUSE SLES to use for "distro:sles" variants.
+# distro_version_sles = "v15_sp5_standard" // or "v15_sp4_standard"
+
+# distro_version_ubuntu is the version of ubuntu to use for "distro:ubuntu" variants
+# distro_version_ubuntu = "22.04" // or "20.04", "18.04"
 
 # tags are a map of tags that will be applied to infrastructure resources that
 # support tagging.
@@ -62,9 +68,6 @@
 # ui_run_tests sets whether to run the UI tests or not for the ui scenario. If set to false a
 # cluster will be created but no tests will be run.
 # ui_run_tests = true
-
-# ubuntu_distro_version is the version of ubuntu to use for "distro:ubuntu" variants
-# ubuntu_distro_version = "22.04" // or "20.04", "18.04"
 
 # vault_artifact_path is the path to CRT generated or local vault.zip bundle. When
 # using the "builder:local" variant a bundle will be built from the current branch.

--- a/enos/modules/ec2_info/main.tf
+++ b/enos/modules/ec2_info/main.tf
@@ -1,9 +1,18 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
+# Note: in order to use the openSUSE Leap AMIs, the AWS account in use must "subscribe"
+# and accept SUSE's terms of use. You can do this at the links below. If the AWS account
+# you are using is already subscribed, this confirmation will be displayed on each page.
+# openSUSE Leap arm64 subscription: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
+# openSUSE leap amd64 subscription: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+
 locals {
   architectures      = toset(["arm64", "x86_64"])
+  amazon_owner_id    = "591542846629"
   canonical_owner_id = "099720109477"
+  sles_owner_id      = "013907871322"
+  suse_owner_id      = "679593333241"
   rhel_owner_id      = "309956199498"
   ids = {
     "arm64" = {
@@ -16,6 +25,13 @@ locals {
         "20.04" = data.aws_ami.ubuntu_2004["arm64"].id
         "22.04" = data.aws_ami.ubuntu_2204["arm64"].id
       }
+      "amazon_linux" = {
+        "amzn2" = data.aws_ami.amazon_linux_2["arm64"].id
+      }
+      "leap" = {
+        "15.4" = data.aws_ami.leap_154["arm64"].id
+        "15.5" = data.aws_ami.leap_155["arm64"].id
+      }
     }
     "amd64" = {
       "rhel" = {
@@ -27,6 +43,17 @@ locals {
         "18.04" = data.aws_ami.ubuntu_1804["x86_64"].id
         "20.04" = data.aws_ami.ubuntu_2004["x86_64"].id
         "22.04" = data.aws_ami.ubuntu_2204["x86_64"].id
+      }
+      "amazon_linux" = {
+        "amzn2" = data.aws_ami.amazon_linux_2["x86_64"].id
+      }
+      "leap" = {
+        "15.4" = data.aws_ami.leap_154["x86_64"].id
+        "15.5" = data.aws_ami.leap_155["x86_64"].id
+      }
+      "sles" = {
+        "v15_sp4_standard" = data.aws_ami.sles_15_sp4_standard["x86_64"].id
+        "v15_sp5_standard" = data.aws_ami.sles_15_sp5_standard["x86_64"].id
       }
     }
   }
@@ -164,6 +191,91 @@ data "aws_ami" "rhel_91" {
   }
 
   owners = [local.rhel_owner_id]
+}
+
+data "aws_ami" "amazon_linux_2" {
+  most_recent = true
+  for_each    = local.architectures
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-ecs-hvm-2.0*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [each.value]
+  }
+
+  owners = [local.amazon_owner_id]
+}
+
+data "aws_ami" "sles_15_sp4_standard" {
+  most_recent = true
+  for_each    = local.architectures
+
+  filter {
+    name   = "description"
+    values = ["SUSE Linux Enterprise Server 15 SP4 (HVM*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [each.value]
+  }
+
+  owners = [local.sles_owner_id]
+}
+
+data "aws_ami" "sles_15_sp5_standard" {
+  most_recent = true
+  for_each    = local.architectures
+
+  filter {
+    name   = "description"
+    values = ["SUSE Linux Enterprise Server 15 SP5 (HVM*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [each.value]
+  }
+
+  owners = [local.sles_owner_id]
+}
+
+data "aws_ami" "leap_154" {
+  most_recent = true
+  for_each    = local.architectures
+
+  filter {
+    name   = "name"
+    values = ["openSUSE-Leap-15-4*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [each.value]
+  }
+
+  owners = [local.suse_owner_id]
+}
+
+data "aws_ami" "leap_155" {
+  most_recent = true
+  for_each    = local.architectures
+
+  filter {
+    name   = "name"
+    values = ["openSUSE-Leap-15-5*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [each.value]
+  }
+
+  owners = [local.suse_owner_id]
 }
 
 data "aws_region" "current" {}

--- a/enos/modules/vault_artifactory_artifact/locals.tf
+++ b/enos/modules/vault_artifactory_artifact/locals.tf
@@ -6,12 +6,19 @@ locals {
   // file name extensions for the install packages of vault for the various architectures, distributions and editions
   package_extensions = {
     amd64 = {
-      ubuntu = "-1_amd64.deb"
-      rhel   = "-1.x86_64.rpm"
+      amazon_linux = "-1.x86_64.rpm"
+      leap         = "-1.x86_64.rpm"
+      rhel         = "-1.x86_64.rpm"
+      sles         = "-1.x86_64.rpm"
+      ubuntu       = "-1_amd64.deb"
     }
     arm64 = {
-      ubuntu = "-1_arm64.deb"
-      rhel   = "-1.aarch64.rpm"
+      amazon_linux = "-1.aarch64.rpm"
+      leap         = "-1.aarch64.rpm"
+      rhel         = "-1.aarch64.rpm"
+      ubuntu       = "-1_arm64.deb"
+      # Note: SLES not included here because the versions/editions of SLES we use
+      # are only offered for amd64
     }
   }
 
@@ -20,12 +27,19 @@ locals {
 
   // file name prefixes for the install packages of vault for the various distributions and artifact types (package or bundle)
   artifact_package_release_names = {
-    ubuntu = {
-      "ce"               = "vault_"
-      "ent"              = "vault-enterprise_",
-      "ent.fips1402"     = "vault-enterprise-fips1402_",
-      "ent.hsm"          = "vault-enterprise-hsm_",
-      "ent.hsm.fips1402" = "vault-enterprise-hsm-fips1402_",
+    amazon_linux = {
+      "ce"               = "vault-"
+      "ent"              = "vault-enterprise-",
+      "ent.fips1402"     = "vault-enterprise-fips1402-",
+      "ent.hsm"          = "vault-enterprise-hsm-",
+      "ent.hsm.fips1402" = "vault-enterprise-hsm-fips1402-",
+    },
+    leap = {
+      "ce"               = "vault-"
+      "ent"              = "vault-enterprise-",
+      "ent.fips1402"     = "vault-enterprise-fips1402-",
+      "ent.hsm"          = "vault-enterprise-hsm-",
+      "ent.hsm.fips1402" = "vault-enterprise-hsm-fips1402-",
     },
     rhel = {
       "ce"               = "vault-"
@@ -33,19 +47,27 @@ locals {
       "ent.fips1402"     = "vault-enterprise-fips1402-",
       "ent.hsm"          = "vault-enterprise-hsm-",
       "ent.hsm.fips1402" = "vault-enterprise-hsm-fips1402-",
+    },
+    sles = {
+      "ce"               = "vault-"
+      "ent"              = "vault-enterprise-",
+      "ent.fips1402"     = "vault-enterprise-fips1402-",
+      "ent.hsm"          = "vault-enterprise-hsm-",
+      "ent.hsm.fips1402" = "vault-enterprise-hsm-fips1402-",
+    }
+    ubuntu = {
+      "ce"               = "vault_"
+      "ent"              = "vault-enterprise_",
+      "ent.fips1402"     = "vault-enterprise-fips1402_",
+      "ent.hsm"          = "vault-enterprise-hsm_",
+      "ent.hsm.fips1402" = "vault-enterprise-hsm-fips1402_",
     }
   }
 
-  // edition --> artifact name edition
-  artifact_name_edition = {
-    "ce"               = ""
-    "ent"              = ""
-    "ent.hsm"          = ".hsm"
-    "ent.fips1402"     = ".fips1402"
-    "ent.hsm.fips1402" = ".hsm.fips1402"
-  }
-
-  artifact_name_prefix    = var.artifact_type == "package" ? local.artifact_package_release_names[var.distro][var.edition] : "vault_"
+  # Prefix for the artifact name. Ex: vault_, vault-, vault-enterprise_, vault-enterprise-hsm-fips1402-, etc
+  artifact_name_prefix = var.artifact_type == "package" ? local.artifact_package_release_names[var.distro][var.edition] : "vault_"
+  # Suffix and extension for the artifact name. Ex: _linux_<arch>.zip, 
   artifact_name_extension = var.artifact_type == "package" ? local.package_extensions[var.arch][var.distro] : "_linux_${var.arch}.zip"
-  artifact_name           = var.artifact_type == "package" ? "${local.artifact_name_prefix}${replace(local.artifact_version, "-", "~")}${local.artifact_name_extension}" : "${local.artifact_name_prefix}${var.product_version}${local.artifact_name_extension}"
+  # Combine prefix/suffix/extension together to form the artifact name
+  artifact_name = var.artifact_type == "package" ? "${local.artifact_name_prefix}${replace(local.artifact_version, "-", "~")}${local.artifact_name_extension}" : "${local.artifact_name_prefix}${var.product_version}${local.artifact_name_extension}"
 }

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -7,7 +7,7 @@ terraform {
     # to the public registry
     enos = {
       source  = "app.terraform.io/hashicorp-qti/enos"
-      version = ">= 0.4.0"
+      version = ">= 0.4.8"
     }
   }
 }

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -30,6 +30,9 @@ locals {
   audit_device_file_path = "/var/log/vault/vault_audit.log"
   bin_path               = "${var.install_dir}/vault"
   consul_bin_path        = "${var.consul_install_dir}/consul"
+  # consul_bind_addr       = {
+  #   amazon_linux = "{{ GetInterfaceIP \"eth0\" }}"
+  # }
   enable_audit_devices   = var.enable_audit_devices && var.initialize_cluster
   // In order to get Terraform to plan we have to use collections with keys
   // that are known at plan time. In order for our module to work our var.target_hosts
@@ -144,6 +147,7 @@ resource "enos_consul_start" "consul" {
   bin_path = local.consul_bin_path
   data_dir = var.consul_data_dir
   config = {
+    bind_addr        = "{{ GetPrivateInterfaces | include \"type\" \"IP\" | sort \"default\" |  limit 1 | attr \"address\"}}"
     data_dir         = var.consul_data_dir
     datacenter       = "dc1"
     retry_join       = ["provider=aws tag_key=${var.backend_cluster_tag_key} tag_value=${var.backend_cluster_name}"]

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -33,7 +33,7 @@ locals {
   # consul_bind_addr       = {
   #   amazon_linux = "{{ GetInterfaceIP \"eth0\" }}"
   # }
-  enable_audit_devices   = var.enable_audit_devices && var.initialize_cluster
+  enable_audit_devices = var.enable_audit_devices && var.initialize_cluster
   // In order to get Terraform to plan we have to use collections with keys
   // that are known at plan time. In order for our module to work our var.target_hosts
   // must be a map with known keys at plan time. Here we're creating locals

--- a/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
+++ b/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 

--- a/enos/modules/vault_cluster/scripts/install-packages.sh
+++ b/enos/modules/vault_cluster/scripts/install-packages.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -ex -o pipefail
 
 if [ "$PACKAGES" == "" ]
@@ -11,38 +10,41 @@ then
   exit 0
 fi
 
-function retry {
-  local retries=$1
-  shift
-  local count=0
-
-  until "$@"; do
-    exit=$?
-    wait=$((2 ** count))
-    count=$((count + 1))
-    if [ "$count" -lt "$retries" ]; then
-      sleep "$wait"
-    else
-      exit "$exit"
-    fi
-  done
-
-  return 0
-}
+# Wait for cloud-init to finish so it doesn't race with any of our package installations.
+# Note: Amazon Linux 2 throws Python 2.7 errors when running `cloud-init status` as
+# non-root user (known bug).
+sudo cloud-init status --wait
 
 echo "Installing Dependencies: $PACKAGES"
-if [ -f /etc/debian_version ]; then
-  # Do our best to make sure that we don't race with cloud-init. Wait a reasonable time until we
-  # see ec2 in the sources list. Very rarely cloud-init will take longer than we wait. In that case
-  # we'll just install our packages.
-  retry 7 grep ec2 /etc/apt/sources.list || true
 
+# Use the default package manager of the current Linux distro to install packages
+if [ "$PACKAGE_MANAGER" = "apt" ]; then
   cd /tmp
-  retry 5 sudo apt update
-  # shellcheck disable=2068
-  retry 5 sudo apt install -y ${PACKAGES[@]}
+  sudo apt update
+  # Disable this shellcheck rule about double-quoting array expansions; if we use
+  # double quotes on ${PACKAGES[@]}, it does not take the packages as separate
+  # arguments.
+  # shellcheck disable=SC2068,SC2086
+  sudo apt install -y ${PACKAGES[@]}
+elif [ "$PACKAGE_MANAGER" = "yum" ]; then
+  cd /tmp
+   # shellcheck disable=SC2068,SC2086
+  sudo yum -y install ${PACKAGES[@]}
+elif [ "$PACKAGE_MANAGER" = "zypper" ]; then
+  # Note: For some SUSE distro versions, and/or some packages, the
+  # packages may not be offered in an official repo. If the first install step
+  # fails, we instead attempt to register with PackageHub,SUSE's third party
+  # package marketplace, and then find and install the package from there.
+
+  # shellcheck disable=SC2068,SC2086
+  sudo zypper install --no-confirm ${PACKAGES[@]} || ( sudo SUSEConnect -p PackageHub/$SLES_VERSION/$ARCH && sudo zypper install --no-confirm ${PACKAGES[@]})
+  # For SUSE distros on arm64 architecture, we need to manually install these two
+  # packages in order to install Vault RPM packages later.
+  if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+    sudo zypper install --no-confirm libcap-progs
+    sudo zypper install --no-confirm openssl
+  fi
 else
-  cd /tmp
-  # shellcheck disable=2068
-  retry 7 sudo yum -y install ${PACKAGES[@]}
+  echo "No matching package manager provided."
+  exit 1
 fi

--- a/enos/modules/vault_cluster/scripts/install-rpm-dependencies.sh
+++ b/enos/modules/vault_cluster/scripts/install-rpm-dependencies.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -ex -o pipefail
+
+# Wait for cloud-init to finish so it doesn't race with any of our package installations.
+# Note: Amazon Linux 2 throws Python 2.7 errors when running `cloud-init status` as
+# non-root user (known bug).
+sudo cloud-init status --wait
+
+if [ "$PACKAGE_MANAGER" == "zypper" ]; then
+  echo "Installing dependencies libcap-progs and openssl"
+  sudo zypper install --no-confirm libcap-progs
+  sudo zypper install --no-confirm openssl
+else
+  exit 0
+fi

--- a/enos/modules/vault_cluster/variables.tf
+++ b/enos/modules/vault_cluster/variables.tf
@@ -49,9 +49,9 @@ variable "config_env_vars" {
 }
 
 variable "consul_bind_addr" {
-  type = string
+  type        = string
   description = "The IP that Consul should bind to"
-  default = null
+  default     = null
 }
 
 variable "consul_data_dir" {

--- a/enos/modules/vault_cluster/variables.tf
+++ b/enos/modules/vault_cluster/variables.tf
@@ -48,6 +48,13 @@ variable "config_env_vars" {
   default     = null
 }
 
+variable "consul_bind_addr" {
+  type        = string
+  # TO DO: Fill in
+  # description = ""
+  default     = null
+}
+
 variable "consul_data_dir" {
   type        = string
   description = "The directory where the consul will store data"

--- a/enos/modules/vault_cluster/variables.tf
+++ b/enos/modules/vault_cluster/variables.tf
@@ -49,10 +49,9 @@ variable "config_env_vars" {
 }
 
 variable "consul_bind_addr" {
-  type        = string
-  # TO DO: Fill in
-  # description = ""
-  default     = null
+  type = string
+  description = "The IP that Consul should bind to"
+  default = null
 }
 
 variable "consul_data_dir" {

--- a/enos/modules/vault_cluster/variables.tf
+++ b/enos/modules/vault_cluster/variables.tf
@@ -1,6 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
+variable "arch" {
+  type        = string
+  description = "The architecture being used"
+  default     = null
+}
+
 variable "artifactory_release" {
   type = object({
     username = string
@@ -110,7 +116,7 @@ variable "initialize_cluster" {
 
 variable "install_dir" {
   type        = string
-  description = "The directory where the vault binary will be installed"
+  description = "The directory where the Vault binary will be installed"
   default     = "/opt/vault/bin"
 }
 
@@ -142,6 +148,11 @@ variable "manage_service" {
   type        = bool
   description = "Manage the Vault service users and systemd unit. Disable this to use configuration in RPM and Debian packages"
   default     = true
+}
+
+variable "package_manager" {
+  type        = string
+  description = "The package manager that comes with each Linux distro"
 }
 
 variable "packages" {
@@ -208,6 +219,12 @@ variable "shamir_unseal_keys" {
   type        = list(string)
   description = "Shamir unseal keys. Often only used adding additional nodes to an already initialized cluster."
   default     = null
+}
+
+variable "distro_version_sles" {
+  type        = string
+  description = "The SLES distro version; sometimes required to install packages on certain SLES versions"
+  default     = "15.5" // or 15.4
 }
 
 variable "storage_backend" {

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
 	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.2
-	github.com/hashicorp/go-sockaddr v1.0.4
+	github.com/hashicorp/go-sockaddr v1.0.6
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -2257,6 +2257,8 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
 github.com/hashicorp/go-sockaddr v1.0.4 h1:NJY/hSAoWy0EhQQdDxxoBlwyJex/xC2qNWXD0up6D48=
 github.com/hashicorp/go-sockaddr v1.0.4/go.mod h1:LPGW7TbF+cTE2o/bBlBWD4XG8rgRJeIurURxH5kEHr8=
+github.com/hashicorp/go-sockaddr v1.0.6 h1:RSG8rKU28VTUTvEKghe5gIhIQpv8evvNpnDEyqO4u9I=
+github.com/hashicorp/go-sockaddr v1.0.6/go.mod h1:uoUUmtwU7n9Dv3O4SNLeFvg0SxQ3lyjsj6+CCykpaxI=
 github.com/hashicorp/go-syslog v1.0.0 h1:KaodqZuhUoZereWVIYmpUgZysurB1kBLX2j0MwMrUAE=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-tfe v1.33.0 h1:UQ04F/Dd+IgjQDciBZz/BKHTFwc7zXbJTI1+zNN355U=


### PR DESCRIPTION
This PR:
* Adds module support for additional Linux distros in multiple versions: Amazon Linux (amzn2), OpenSUSE Leap (15.4, 15.4), SUSE SLES (v15 SP5, v15 SP4)
* Adds additional Linux distros into all scenarios that include distros in the matrix
* Adds support for Consul `ent` edition
* Adds `consul_edition` into all scenarios
* Updates CI scenario sampling to include new matrix items

This more than doubles the number of Linux distros/versions we test Vault on, and allows us to test integrations of Vault with Consul `ent` in addition to Consul `ce`.