### PR TITLE
Remove duplicate partial reference from release-notes

### DIFF
--- a/website/content/docs/release-notes/1.14.0.mdx
+++ b/website/content/docs/release-notes/1.14.0.mdx
@@ -20,7 +20,7 @@ All     | [API calls to update-primary may lead to data loss](/vault/docs/upgrad
 1.14.0+ | [AWS static roles ignore changes to rotation period](/vault/docs/upgrading/upgrade-to-1.14.x#aws-static-role-rotation)
 1.14.0+ | [UI Collapsed navbar does not allow certain click events](/vault/docs/upgrading/upgrade-to-1.14.x#ui-collapsed-navbar)
 1.14.3 - 1.14.5 | [Vault storing references to ephemeral sub-loggers leading to unbounded memory consumption](/vault/docs/upgrading/upgrade-to-1.14.x#vault-is-storing-references-to-ephemeral-sub-loggers-leading-to-unbounded-memory-consumption)
-1.14.4+ | [Internal error when vault policy in namespace does not exist](/vault/docs/upgrading/upgrade-to-1.14.x#internal-error-when-vault-policy-in-namespace-does-not-exist)
+1.14.4 - 1.14.5 | [Internal error when vault policy in namespace does not exist](/vault/docs/upgrading/upgrade-to-1.14.x#internal-error-when-vault-policy-in-namespace-does-not-exist)
 1.14.0+ | [Sublogger levels not adjusted on reload](/vault/docs/upgrading/upgrade-to-1.14.x#sublogger-levels-unchanged-on-reload)
 1.14.5  | [Fatal error during expiration metrics gathering causing Vault crash](/vault/docs/upgrading/upgrade-to-1.15.x#fatal-error-during-expiration-metrics-gathering-causing-vault-crash)
 

--- a/website/content/docs/release-notes/1.14.0.mdx
+++ b/website/content/docs/release-notes/1.14.0.mdx
@@ -19,7 +19,7 @@ Version | Issue
 All     | [API calls to update-primary may lead to data loss](/vault/docs/upgrading/upgrade-to-1.14.x#update-primary-data-loss)
 1.14.0+ | [AWS static roles ignore changes to rotation period](/vault/docs/upgrading/upgrade-to-1.14.x#aws-static-role-rotation)
 1.14.0+ | [UI Collapsed navbar does not allow certain click events](/vault/docs/upgrading/upgrade-to-1.14.x#ui-collapsed-navbar)
-1.14.3+ | [Vault storing references to ephemeral sub-loggers causing memory leak](/vault/docs/upgrading/upgrade-to-1.14.x#vault-is-storing-references-to-ephemeral-sub-loggers-leading-to-a-memory-leak)
+1.14.3 - 1.14.5 | [Vault storing references to ephemeral sub-loggers leading to unbounded memory consumption](/vault/docs/upgrading/upgrade-to-1.14.x#vault-is-storing-references-to-ephemeral-sub-loggers-leading-to-unbounded-memory-consumption)
 1.14.4+ | [Internal error when vault policy in namespace does not exist](/vault/docs/upgrading/upgrade-to-1.14.x#internal-error-when-vault-policy-in-namespace-does-not-exist)
 1.14.0+ | [Sublogger levels not adjusted on reload](/vault/docs/upgrading/upgrade-to-1.14.x#sublogger-levels-unchanged-on-reload)
 1.14.5  | [Fatal error during expiration metrics gathering causing Vault crash](/vault/docs/upgrading/upgrade-to-1.15.x#fatal-error-during-expiration-metrics-gathering-causing-vault-crash)

--- a/website/content/docs/release-notes/1.14.0.mdx
+++ b/website/content/docs/release-notes/1.14.0.mdx
@@ -281,12 +281,6 @@ Follow the learn more links for more information, or browse the list of
   </tbody>
 </table>
 
-@include 'known-issues/internal-error-namespace-missing-policy.mdx'
-
-@include 'known-issues/ephemeral-loggers-memory-leak.mdx'
-
-@include 'known-issues/expiration-metrics-fatal-error.mdx'
-
 ## Feature deprecations and EOL
 
 Deprecated in 1.14 | Retired in 1.14

--- a/website/content/docs/release-notes/1.15.0.mdx
+++ b/website/content/docs/release-notes/1.15.0.mdx
@@ -20,7 +20,7 @@ Version | Issue
 1.15.0+ | [UI Collapsed navbar does not allow certain click events](/vault/docs/upgrading/upgrade-to-1.15.x#ui-collapsed-navbar)
 1.15    | [Vault file audit devices do not honor SIGHUP signal to reload](/vault/docs/upgrading/upgrade-to-1.15.x#file-audit-devices-do-not-honor-sighup-signal-to-reload)
 1.15.0 - 1.15.1 | [Vault storing references to ephemeral sub-loggers leading to unbounded memory consumption](/vault/docs/upgrading/upgrade-to-1.15.x#vault-is-storing-references-to-ephemeral-sub-loggers-leading-to-unbounded-memory-consumption)
-1.15.0+ | [Internal error when vault policy in namespace does not exist](/vault/docs/upgrading/upgrade-to-1.15.x#internal-error-when-vault-policy-in-namespace-does-not-exist)
+1.15.0 - 1.15.1 | [Internal error when vault policy in namespace does not exist](/vault/docs/upgrading/upgrade-to-1.15.x#internal-error-when-vault-policy-in-namespace-does-not-exist)
 1.15.0+ | [Sublogger levels not adjusted on reload](/vault/docs/upgrading/upgrade-to-1.15.x#sublogger-levels-unchanged-on-reload)
 1.15.1  | [Fatal error during expiration metrics gathering causing Vault crash](/vault/docs/upgrading/upgrade-to-1.15.x#fatal-error-during-expiration-metrics-gathering-causing-vault-crash)
 

--- a/website/content/docs/release-notes/1.15.0.mdx
+++ b/website/content/docs/release-notes/1.15.0.mdx
@@ -19,7 +19,7 @@ Version | Issue
 1.15.0  | [Panic in AWS auth method during IAM-based login](/vault/docs/upgrading/upgrade-to-1.15.x#panic-in-aws-auth-method-during-iam-based-login)
 1.15.0+ | [UI Collapsed navbar does not allow certain click events](/vault/docs/upgrading/upgrade-to-1.15.x#ui-collapsed-navbar)
 1.15    | [Vault file audit devices do not honor SIGHUP signal to reload](/vault/docs/upgrading/upgrade-to-1.15.x#file-audit-devices-do-not-honor-sighup-signal-to-reload)
-1.15.0+ | [Vault storing references to ephemeral sub-loggers causing memory leak](/vault/docs/upgrading/upgrade-to-1.15.x#vault-is-storing-references-to-ephemeral-sub-loggers-leading-to-a-memory-leak)
+1.15.0 - 1.15.1 | [Vault storing references to ephemeral sub-loggers leading to unbounded memory consumption](/vault/docs/upgrading/upgrade-to-1.15.x#vault-is-storing-references-to-ephemeral-sub-loggers-leading-to-unbounded-memory-consumption)
 1.15.0+ | [Internal error when vault policy in namespace does not exist](/vault/docs/upgrading/upgrade-to-1.15.x#internal-error-when-vault-policy-in-namespace-does-not-exist)
 1.15.0+ | [Sublogger levels not adjusted on reload](/vault/docs/upgrading/upgrade-to-1.15.x#sublogger-levels-unchanged-on-reload)
 1.15.1  | [Fatal error during expiration metrics gathering causing Vault crash](/vault/docs/upgrading/upgrade-to-1.15.x#fatal-error-during-expiration-metrics-gathering-causing-vault-crash)

--- a/website/content/docs/release-notes/1.15.0.mdx
+++ b/website/content/docs/release-notes/1.15.0.mdx
@@ -245,12 +245,6 @@ Follow the learn more links for more information, or browse the list of
   </tbody>
 </table>
 
-@include 'known-issues/internal-error-namespace-missing-policy.mdx'
-
-@include 'known-issues/ephemeral-loggers-memory-leak.mdx'
-
-@include 'known-issues/expiration-metrics-fatal-error.mdx'
-
 ## Feature deprecations and EOL
 
 Deprecated in 1.15 | Retired in 1.15

--- a/website/content/partials/known-issues/ephemeral-loggers-memory-leak.mdx
+++ b/website/content/partials/known-issues/ephemeral-loggers-memory-leak.mdx
@@ -13,7 +13,7 @@ This change that introduced this leak has been reverted as of 1.13.10, 1.14.6, a
 #### Issue
 Vault is unexpectedly storing references to ephemeral sub-loggers which prevents them from being cleaned up, leading to
 a memory leak. This came about from a change to address a previously known issue around [sub-logger levels not being adjusted
-on reload](/vault/docs/upgrading/upgrade-to-1.15.x#sublogger-levels-unchanged-on-reload).
+on reload](#sublogger-levels-unchanged-on-reload).
 This impacts many areas of Vault, but primarily logins in Enterprise.
 
 #### Workaround

--- a/website/content/partials/known-issues/ephemeral-loggers-memory-leak.mdx
+++ b/website/content/partials/known-issues/ephemeral-loggers-memory-leak.mdx
@@ -1,19 +1,19 @@
-### Vault is storing references to ephemeral sub-loggers leading to a memory leak
+### Vault is storing references to ephemeral sub-loggers leading to unbound memory consumption
 
 #### Affected versions
 
-This memory leak affects Vault Community and Enterprise versions:
+This memory consumption bug affects Vault Community and Enterprise versions:
 
 - 1.13.7 - 1.13.9
 - 1.14.3 - 1.14.5
 - 1.15.0 - 1.15.1
 
-This change that introduced this leak has been reverted as of 1.13.10, 1.14.6, and 1.15.2
+This change that introduced this bug has been reverted as of 1.13.10, 1.14.6, and 1.15.2
 
 #### Issue
 Vault is unexpectedly storing references to ephemeral sub-loggers which prevents them from being cleaned up, leading to
-a memory leak. This came about from a change to address a previously known issue around [sub-logger levels not being adjusted
-on reload](#sublogger-levels-unchanged-on-reload).
+unbound memory consumption for loggers. This came about from a change to address a previously known issue around
+[sub-logger levels not being adjusted on reload](#sublogger-levels-unchanged-on-reload).
 This impacts many areas of Vault, but primarily logins in Enterprise.
 
 #### Workaround

--- a/website/content/partials/known-issues/ephemeral-loggers-memory-leak.mdx
+++ b/website/content/partials/known-issues/ephemeral-loggers-memory-leak.mdx
@@ -1,4 +1,4 @@
-### Vault is storing references to ephemeral sub-loggers leading to unbound memory consumption
+### Vault is storing references to ephemeral sub-loggers leading to unbounded memory consumption
 
 #### Affected versions
 


### PR DESCRIPTION
Remove partial references from release-notes that link to upgrade guides, and change link in partial to anchor.