### PR TITLE
Copywrite pre-commit

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -115,9 +115,6 @@ ui_copywrite() {
   # run the copywrite tool
   # if a --path option is added we could apply the headers to only the staged files much easier
   # as of the latest version 0.16.6 there is only support for --dirPath
-  # since we want to block the commit if headers are added run --plan first to identify if files have missing headers
-
-  # ---- EXPERIMENTAL workaround to only run tool on staged files
   STAGED_FILES=($(git diff --name-only --cached))
 
   rm -rf $BINARY_DIR/.staged
@@ -145,19 +142,6 @@ ui_copywrite() {
       git add "${STAGED_FILES[$i]}"
       i=$(( i + 1 ))
     done
-  fi
-  return 0;
-  # ----
-  
-
-  # ---- Original attempt which is working but runs the tool against the full ui directory
-  cd $BINARY_DIR
-  COPYWRITE_LOG_LEVEL=info
-  COPY_CMD="./copywrite headers -d ../ --config ../.copywrite.hcl"
-  eval $COPY_CMD --plan
-  if [ $(echo $?) == 1 ]; then
-    eval $COPY_CMD || { echo "==> Copyright check failed. Please review and add headers manually."; return 0; };
-    block "Copyright headers automatically added to files. Please review and commit again."
   fi
 }
 

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -35,7 +35,7 @@ block() {
 
 # Add all check functions to this space separated list.
 # They are executed in this order (see end of file).
-CHECKS="ui_lint backend_lint"
+CHECKS="ui_lint ui_copywrite backend_lint"
 
 # Run ui linter if changes in that dir detected.
 ui_lint() {
@@ -70,6 +70,98 @@ backend_lint() {
 
   # Only run fmtcheck on staged files
   ./scripts/gofmtcheck.sh "${staged}" || block "Backend linting failed; run 'make fmt' to fix."
+}
+
+ui_copywrite() {
+  DIR=ui
+  BINARY_DIR=$DIR/.copywrite
+  DOWNLOAD_ERR="==> Copywrite tool not found and failed to downloaded. Please download manually and extract to ui/.copywrite directory to utilize in pre-commit hook."
+
+  # silently succeed if no changes staged for $DIR
+  if git diff --name-only --cached --exit-code -- $DIR/; then
+    return 0
+  fi
+
+  echo "==> Changes detected in $DIR/: Checking copyright headers..."
+
+  # download latest version of hashicorp/copywrite if necessary 
+  if [ ! -x $BINARY_DIR/copywrite ]; then
+    local REPO_URL=https://github.com/hashicorp/copywrite
+    # get the latest version tag
+    local LATEST_RELEASE_JSON=$(curl -L -s -H 'Accept: application/json' $REPO_URL/releases/latest);
+    local LATEST_TAG=$(echo $LATEST_RELEASE_JSON | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+
+    if [ ! $LATEST_TAG ]; then
+      echo $DOWNLOAD_ERR
+      return 0;
+    fi
+
+    # get the OS/Architecture specifics to build the filename
+    case "$OSTYPE" in
+      linux*) OS='linux' ;;
+      darwin*) OS='darwin' ;;
+      msys*) OS='windows';;
+    esac
+    local ARCH=$([ $(uname -m) == arm* ] && echo 'arm64' || echo 'x86_64')
+    local EXT=$([ $OSTYPE == "msys" ] && echo '.zip' || echo '.tar.gz')
+    local FILENAME=copywrite_"${LATEST_TAG:1}"_"$OS"_"$ARCH""$EXT"
+
+    mkdir -p $BINARY_DIR
+    echo "==> Copywrite tool not found, downloading version $LATEST_TAG from $REPO_URL..."
+    curl -L -s $REPO_URL/releases/download/$LATEST_TAG/$FILENAME | tar -xz - -C $BINARY_DIR || { echo $DOWNLOAD_ERR;  return 0; };
+  fi
+  
+  # run the copywrite tool
+  # if a --path option is added we could apply the headers to only the staged files much easier
+  # as of the latest version 0.16.6 there is only support for --dirPath
+  # since we want to block the commit if headers are added run --plan first to identify if files have missing headers
+
+  # ---- EXPERIMENTAL workaround to only run tool on staged files
+  STAGED_FILES=$(git diff --name-only --cached)
+
+  rm -rf $BINARY_DIR/.staged
+  mkdir $BINARY_DIR/.staged
+  
+  # copy staged files to temp directory
+  for FILE_PATH in $STAGED_FILES; do
+    cp $FILE_PATH $BINARY_DIR/.staged
+  done
+
+  COPYWRITE_LOG_LEVEL=off
+  COPY_CMD="$BINARY_DIR/copywrite headers -d $BINARY_DIR/.staged --config $DIR/.copywrite.hcl"
+
+  # if staged files are missing header run the tool against temp directory
+  eval $COPY_CMD --plan
+  if [ $(echo $?) == 1 ]; then
+    COPYWRITE_LOG_LEVEL=info
+    eval $COPY_CMD || { echo "==> Copyright check failed. Please review and add headers manually."; return 0; };
+
+    # copy files back to original locations
+    local TMP_FILES=$(ls $BINARY_DIR/.staged)
+    i=0
+    for FILE in $TMP_FILES; do
+      cp $BINARY_DIR/.staged/$FILE "${STAGED_FILES[$i]}"
+      i=$(( i + 1 ))
+    done
+    
+    # this will result in unstaged changes
+    # block so they can be added to existing commit
+    block "Copyright headers automatically added to files. Please review and commit again."
+  fi
+  return 0;
+  # ----
+  
+
+  # ---- Original attempt which is working but runs the tool against the full ui directory
+  cd $BINARY_DIR
+  COPYWRITE_LOG_LEVEL=off
+  COPY_CMD="./copywrite headers -d ../ --config ../.copywrite.hcl"
+  eval $COPY_CMD --plan
+  if [ $(echo $?) == 1 ]; then
+    COPYWRITE_LOG_LEVEL=info
+    eval $COPY_CMD || { echo "==> Copyright check failed. Please review and add headers manually."; return 0; };
+    block "Copyright headers automatically added to files. Please review and commit again."
+  fi
 }
 
 for CHECK in $CHECKS; do

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -97,6 +97,7 @@ ui_copywrite() {
     fi
 
     # get the OS/Architecture specifics to build the filename
+    # eg. copywrite_0.16.6_darwin_x86_64.tar.gz
     case "$OSTYPE" in
       linux*) OS='linux' ;;
       darwin*) OS='darwin' ;;

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -117,21 +117,22 @@ ui_copywrite() {
   # since we want to block the commit if headers are added run --plan first to identify if files have missing headers
 
   # ---- EXPERIMENTAL workaround to only run tool on staged files
-  STAGED_FILES=$(git diff --name-only --cached)
+  STAGED_FILES=($(git diff --name-only --cached))
 
   rm -rf $BINARY_DIR/.staged
   mkdir $BINARY_DIR/.staged
   
-  # copy staged files to temp directory
-  for FILE_PATH in $STAGED_FILES; do
+  # copy staged files to .staged directory
+  echo $STAGED_FILES;
+  for FILE_PATH in "${STAGED_FILES[@]}"; do
     cp $FILE_PATH $BINARY_DIR/.staged
   done
 
   COPYWRITE_LOG_LEVEL=info
   COPY_CMD="$BINARY_DIR/copywrite headers -d $BINARY_DIR/.staged --config $DIR/.copywrite.hcl"
 
-  # if staged files are missing header run the tool against temp directory
-  eval $COPY_CMD --plan
+  # if staged files are missing header run the tool on .staged directory
+  VALIDATE=$(eval $COPY_CMD --plan) # assigning to var so output is suppressed since it is repeated during second run
   if [ $(echo $?) == 1 ]; then
     eval $COPY_CMD || { echo "==> Copyright check failed. Please review and add headers manually."; return 0; };
 
@@ -145,7 +146,7 @@ ui_copywrite() {
     
     # this will result in unstaged changes
     # block so they can be added to existing commit
-    block "Copyright headers automatically added to files. Please review and commit again."
+    block "Copyright headers automatically added to files. Please review and stage the changes."
   fi
   return 0;
   # ----

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -137,17 +137,14 @@ ui_copywrite() {
   if [ $(echo $?) == 1 ]; then
     eval $COPY_CMD || { echo "==> Copyright check failed. Please review and add headers manually."; return 0; };
 
-    # copy files back to original locations
+    # copy files back to original locations and stage changes
     local TMP_FILES=$(ls $BINARY_DIR/.staged)
     i=0
     for FILE in $TMP_FILES; do
       cp $BINARY_DIR/.staged/$FILE "${STAGED_FILES[$i]}"
+      git add "${STAGED_FILES[$i]}"
       i=$(( i + 1 ))
     done
-    
-    # this will result in unstaged changes
-    # block so they can be added to existing commit
-    block "Copyright headers automatically added to files. Please review and stage the changes."
   fi
   return 0;
   # ----

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -127,13 +127,12 @@ ui_copywrite() {
     cp $FILE_PATH $BINARY_DIR/.staged
   done
 
-  COPYWRITE_LOG_LEVEL=off
+  COPYWRITE_LOG_LEVEL=info
   COPY_CMD="$BINARY_DIR/copywrite headers -d $BINARY_DIR/.staged --config $DIR/.copywrite.hcl"
 
   # if staged files are missing header run the tool against temp directory
   eval $COPY_CMD --plan
   if [ $(echo $?) == 1 ]; then
-    COPYWRITE_LOG_LEVEL=info
     eval $COPY_CMD || { echo "==> Copyright check failed. Please review and add headers manually."; return 0; };
 
     # copy files back to original locations
@@ -154,11 +153,10 @@ ui_copywrite() {
 
   # ---- Original attempt which is working but runs the tool against the full ui directory
   cd $BINARY_DIR
-  COPYWRITE_LOG_LEVEL=off
+  COPYWRITE_LOG_LEVEL=info
   COPY_CMD="./copywrite headers -d ../ --config ../.copywrite.hcl"
   eval $COPY_CMD --plan
   if [ $(echo $?) == 1 ]; then
-    COPYWRITE_LOG_LEVEL=info
     eval $COPY_CMD || { echo "==> Copyright check failed. Please review and add headers manually."; return 0; };
     block "Copyright headers automatically added to files. Please review and commit again."
   fi

--- a/ui/.copywrite.hcl
+++ b/ui/.copywrite.hcl
@@ -1,0 +1,33 @@
+# (OPTIONAL) Overrides the copywrite config schema version
+# Default: 1
+schema_version = 1
+
+project {
+  # (OPTIONAL) SPDX-compatible license identifier
+  # Leave blank if you don't wish to license the project
+  # Default: "MPL-2.0"
+  license = "BUSL-1.1"
+
+  # (OPTIONAL) Represents the copyright holder used in all statements
+  # Default: HashiCorp, Inc.
+  # copyright_holder = ""
+
+  # (OPTIONAL) Represents the year that the project initially began
+  # Default: <the year the repo was first created>
+  # copyright_year = 0
+
+  # (OPTIONAL) A list of globs that should not have copyright or license headers .
+  # Supports doublestar glob patterns for more flexibility in defining which
+  # files or folders should be ignored
+  # Default: []
+  header_ignore = [
+    "node_modules/**"
+  ]
+
+  # (OPTIONAL) Links to an upstream repo for determining repo relationships
+  # This is for special cases and should not normally be set.
+  # Default: ""
+  # upstream = "hashicorp/<REPONAME>"
+}
+
+

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -38,3 +38,7 @@ package-lock.json
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# copywrite tool used in pre-commit hook
+.copywrite
+


### PR DESCRIPTION
This PR adds a bash function to be executed in the pre-commit hook for automatically adding copyright headers to staged files using the [Copywrite](https://github.com/hashicorp/copywrite) tool. 