### PR TITLE
Sample payload is empty for AWS auth login request in API docs

### DIFF
--- a/website/content/api-docs/auth/aws.mdx
+++ b/website/content/api-docs/auth/aws.mdx
@@ -1103,7 +1103,11 @@ for more information on the signature types.
 ### Sample payload
 
 ```json
-{}
+{
+  "iam_request_body": "eyJBdXRob3JpemF0aW9uIj...",
+  "iam_request_url": "aHR0cHM6L...",
+  "role": "dev-role"
+}
 ```
 
 ### Sample request

--- a/website/content/api-docs/auth/aws.mdx
+++ b/website/content/api-docs/auth/aws.mdx
@@ -1104,7 +1104,9 @@ for more information on the signature types.
 
 ```json
 {
-  "iam_request_body": "eyJBdXRob3JpemF0aW9uIj...",
+  "iam_http_request_method": "POST",
+  "iam_request_body": "QWN0aW9uPUdldENhbG...",
+  "iam_request_headers": "eyJBdXRob3JpemF0aW9uIj...",
   "iam_request_url": "aHR0cHM6L...",
   "role": "dev-role"
 }


### PR DESCRIPTION
Current docs for the AWS auth method login request have an empty object as the sample payload for the request.
https://developer.hashicorp.com/vault/api-docs/auth/aws#login. This is inaccurate as the request requires values in the data payload.