### PR TITLE
sync: setup backend with system backend config

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1353,7 +1353,7 @@ func (c *Core) configureLogicalBackends(backends map[string]logical.Factory, log
 	logicalBackends[mountTypeSystem] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
 		sysBackendLogger := logger.Named("system")
 		c.AddLogger(sysBackendLogger)
-		b := NewSystemBackend(c, sysBackendLogger)
+		b := NewSystemBackend(c, sysBackendLogger, config)
 		if err := b.Setup(ctx, config); err != nil {
 			return nil, err
 		}

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -1868,7 +1868,7 @@ func TestSystemBackend_revokePrefixAuth_newUrl(t *testing.T) {
 			MaxLeaseTTLVal:     time.Hour * 24 * 32,
 		},
 	}
-	b := NewSystemBackend(core, hclog.New(&hclog.LoggerOptions{}))
+	b := NewSystemBackend(core, hclog.New(&hclog.LoggerOptions{}), bc)
 	err := b.Backend.Setup(namespace.RootContext(nil), bc)
 	if err != nil {
 		t.Fatal(err)
@@ -1932,7 +1932,7 @@ func TestSystemBackend_revokePrefixAuth_origUrl(t *testing.T) {
 			MaxLeaseTTLVal:     time.Hour * 24 * 32,
 		},
 	}
-	b := NewSystemBackend(core, hclog.New(&hclog.LoggerOptions{}))
+	b := NewSystemBackend(core, hclog.New(&hclog.LoggerOptions{}), bc)
 	err := b.Backend.Setup(namespace.RootContext(nil), bc)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR passes the `logical.BackendConfig` to `NewSystemBackend()` so that it can be used to properly setup the secrets sync backend with a system view.