### PR TITLE
PKI: Address some errors that were not wrapped properly

### DIFF
--- a/builtin/logical/pki/acme_challenges.go
+++ b/builtin/logical/pki/acme_challenges.go
@@ -311,7 +311,7 @@ func ValidateTLSALPN01Challenge(domain string, token string, thumbprint string, 
 			//       checks for the parent certificate having the IsCA basic constraint set.
 			err := cert.CheckSignature(cert.SignatureAlgorithm, cert.RawTBSCertificate, cert.Signature)
 			if err != nil {
-				return fmt.Errorf("server under test returned a non-self-signed certificate: %v", err)
+				return fmt.Errorf("server under test returned a non-self-signed certificate: %w", err)
 			}
 
 			if !bytes.Equal(cert.RawSubject, cert.RawIssuer) {

--- a/builtin/logical/pki/path_resign_crls.go
+++ b/builtin/logical/pki/path_resign_crls.go
@@ -252,7 +252,7 @@ func (b *backend) pathUpdateResignCrlsHandler(ctx context.Context, request *logi
 	if deltaCrlBaseNumber > -1 {
 		ext, err := certutil.CreateDeltaCRLIndicatorExt(int64(deltaCrlBaseNumber))
 		if err != nil {
-			return nil, fmt.Errorf("could not create crl delta indicator extension: %v", err)
+			return nil, fmt.Errorf("could not create crl delta indicator extension: %w", err)
 		}
 		template.ExtraExtensions = []pkix.Extension{ext}
 	}
@@ -325,7 +325,7 @@ func (b *backend) pathUpdateSignRevocationListHandler(ctx context.Context, reque
 	if deltaCrlBaseNumber > -1 {
 		ext, err := certutil.CreateDeltaCRLIndicatorExt(int64(deltaCrlBaseNumber))
 		if err != nil {
-			return nil, fmt.Errorf("could not create crl delta indicator extension: %v", err)
+			return nil, fmt.Errorf("could not create crl delta indicator extension: %w", err)
 		}
 		crlExtensions = append(crlExtensions, ext)
 	}

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -436,3 +436,27 @@ func performOcspPost(t *testing.T, cert *x509.Certificate, issuerCert *x509.Cert
 	require.NoError(t, err, "parsing ocsp get response")
 	return ocspResp
 }
+
+func requireCertMissingFromStorage(t *testing.T, client *api.Client, cert *x509.Certificate) {
+	serial := serialFromCert(cert)
+	requireSerialMissingFromStorage(t, client, serial)
+}
+
+func requireSerialMissingFromStorage(t *testing.T, client *api.Client, serial string) {
+	resp, err := client.Logical().ReadWithContext(context.Background(), "pki/cert/"+serial)
+	require.NoErrorf(t, err, "failed reading certificate with serial %s", serial)
+	require.Nilf(t, resp, "expected a nil response looking up serial %s got: %v", serial, resp)
+}
+
+func requireCertInStorage(t *testing.T, client *api.Client, cert *x509.Certificate) {
+	serial := serialFromCert(cert)
+	requireSerialInStorage(t, client, serial)
+}
+
+func requireSerialInStorage(t *testing.T, client *api.Client, serial string) {
+	resp, err := client.Logical().ReadWithContext(context.Background(), "pki/cert/"+serial)
+	require.NoErrorf(t, err, "failed reading certificate with serial %s", serial)
+	require.NotNilf(t, resp, "reading certificate returned a nil response for serial: %s", serial)
+	require.NotNilf(t, resp.Data, "reading certificate returned a nil data response for serial: %s", serial)
+	require.NotEmpty(t, resp.Data["certificate"], "certificate field was empty for serial: %s", serial)
+}


### PR DESCRIPTION
Fix up some error wrapping issues. I don't believe these actually cause/fix real issues, as we only really care about the ErrReadOnly case and the forwarding handler looks for both the error type or the special error string "cannot write to readonly storage", which the %v would have included.

Also add some testhelper methods mainly for enterprise tests to help lookup if a particular cluster has a certificate stored or not.