### PR TITLE
Kv directory fixes

### DIFF
--- a/ui/app/components/dashboard/quick-actions-card.js
+++ b/ui/app/components/dashboard/quick-actions-card.js
@@ -140,15 +140,17 @@ export default class DashboardQuickActionsCard extends Component {
   @action
   navigateToPage() {
     let route = this.searchSelectParams.route;
-    let param = this.paramValue.id;
+    // If search-select falls back to stringInput, paramVlue is a string not object
+    let param = this.paramValue.id || this.paramValue;
 
     // kv has a special use case where if the paramValue ends in a '/' you should
     // link to different route
     if (this.selectedEngine.type === 'kv') {
-      route = pathIsDirectory(this.paramValue?.path)
+      const path = this.paramValue.path || this.paramValue;
+      route = pathIsDirectory(path)
         ? 'vault.cluster.secrets.backend.kv.list-directory'
         : 'vault.cluster.secrets.backend.kv.secret.details';
-      param = this.paramValue?.path;
+      param = path;
     }
 
     this.router.transitionTo(route, this.selectedEngine.id, param);

--- a/ui/lib/kv/addon/components/page/list.hbs
+++ b/ui/lib/kv/addon/components/page/list.hbs
@@ -63,7 +63,7 @@
         <div class="level is-mobile">
           <div class="level-left">
             <div>
-              <Icon @name="file" class="has-text-grey-light" />
+              <Icon @name={{if metadata.pathIsDirectory "folder" "file"}} class="has-text-grey-light" />
               <span class="has-text-weight-semibold is-underline">
                 {{metadata.path}}
               </span>


### PR DESCRIPTION
Shows a folder if the item in a KV engine is a directory. Also includes a fix for the dashboard quick actions card if the user does not have list permissions and falls back to string input

<img width="303" alt="Folder vs file icon" src="https://github.com/hashicorp/vault/assets/82459713/0e8e1638-4d0d-47b8-ab3e-25967c9b2099">
