### PR TITLE
UI: Allow token configuration tune from namespace

### DIFF
--- a/changelog/24147.txt
+++ b/changelog/24147.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix error when tuning token auth configuration within namespace
+```

--- a/ui/app/components/auth-config-form/options.js
+++ b/ui/app/components/auth-config-form/options.js
@@ -32,7 +32,7 @@ export default AuthConfigComponent.extend({
       data.description = this.model.description;
 
       // token_type should not be tuneable for the token auth method.
-      if (this.model.type === 'token') {
+      if (this.model.methodType === 'token') {
         delete data.token_type;
       }
 

--- a/ui/tests/acceptance/auth-list-test.js
+++ b/ui/tests/acceptance/auth-list-test.js
@@ -151,4 +151,20 @@ module('Acceptance | auth backend list', function (hooks) {
       }
     }
   });
+
+  test('enterprise: token config within namespace', async function (assert) {
+    const ns = 'ns-wxyz';
+    await runCmd(`write sys/namespaces/${ns} -f`);
+    await authPage.loginNs(ns);
+    // go directly to token configure route
+    await visit('/vault/settings/auth/configure/token/options');
+    await fillIn('[data-test-input="description"]', 'My custom description');
+    await click('[data-test-save-config="true"]');
+    assert.strictEqual(currentURL(), '/vault/access', 'successfully saves and navigates away');
+    await click('[data-test-auth-backend-link="token"]');
+    assert
+      .dom('[data-test-row-value="Description"]')
+      .hasText('My custom description', 'description was saved');
+    await runCmd(`delete sys/namespaces/${ns}`);
+  });
 });


### PR DESCRIPTION
The previous [PR](https://github.com/hashicorp/vault/pull/12904) that fixed this issue only did so for non-namespace token mounts. We didn't realize `ns_token` was a token type, so this checks the correct model attribute with `ns_` stripped away