### PR TITLE
enos: fix licensing on backported files

### DIFF
--- a/enos/ci/aws-nuke.yml
+++ b/enos/ci/aws-nuke.yml
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 regions:
 - eu-north-1

--- a/enos/ci/bootstrap/main.tf
+++ b/enos/ci/bootstrap/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/ci/bootstrap/outputs.tf
+++ b/enos/ci/bootstrap/outputs.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 output "keys" {
   value = {

--- a/enos/ci/bootstrap/variables.tf
+++ b/enos/ci/bootstrap/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "aws_ssh_public_key" {
   description = "The public key to use for the ssh key"

--- a/enos/ci/service-user-iam/main.tf
+++ b/enos/ci/service-user-iam/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/ci/service-user-iam/outputs.tf
+++ b/enos/ci/service-user-iam/outputs.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 output "ci_role" {
   value = {

--- a/enos/ci/service-user-iam/providers.tf
+++ b/enos/ci/service-user-iam/providers.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 provider "aws" {
   region = "us-east-1"

--- a/enos/ci/service-user-iam/service-quotas.tf
+++ b/enos/ci/service-user-iam/service-quotas.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 locals {
   // This is the code of the service quota to request a change for. Each adjustable limit has a

--- a/enos/ci/service-user-iam/variables.tf
+++ b/enos/ci/service-user-iam/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "repository" {
   description = "The GitHub repository, either vault or vault-enterprise"

--- a/enos/enos-globals.hcl
+++ b/enos/enos-globals.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 globals {
   backend_tag_key = "VaultStorage"

--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 module "autopilot_upgrade_storageconfig" {
   source = "./modules/autopilot_upgrade_storageconfig"

--- a/enos/enos-providers.hcl
+++ b/enos/enos-providers.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 provider "aws" "default" {
   region = var.aws_region

--- a/enos/enos-samples-ce-build.hcl
+++ b/enos/enos-samples-ce-build.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 sample "build_ce_linux_amd64_deb" {
   attributes = global.sample_attributes

--- a/enos/enos-samples-ce-release.hcl
+++ b/enos/enos-samples-ce-release.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 sample "release_ce_linux_amd64_deb" {
   attributes = global.sample_attributes

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 scenario "agent" {
   matrix {

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 scenario "autopilot" {
   matrix {

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 scenario "proxy" {
   matrix {

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 // The replication scenario configures performance replication between two Vault clusters and verifies
 // known_primary_cluster_addrs are updated on secondary Vault cluster with the IP addresses of replaced

--- a/enos/enos-scenario-seal-ha.hcl
+++ b/enos/enos-scenario-seal-ha.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 scenario "seal_ha" {
   matrix {

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 scenario "smoke" {
   matrix {

--- a/enos/enos-scenario-ui.hcl
+++ b/enos/enos-scenario-ui.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 scenario "ui" {
   matrix {

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 scenario "upgrade" {
   matrix {

--- a/enos/enos-terraform.hcl
+++ b/enos/enos-terraform.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform_cli "default" {
   plugin_cache_dir = var.terraform_plugin_cache_dir != null ? abspath(var.terraform_plugin_cache_dir) : null

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "artifactory_username" {
   type        = string

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 # artifactory_username is the username to use when testing an artifact stored in artfactory.
 # artifactory_username = "yourname@hashicorp.com"

--- a/enos/k8s/enos-modules-k8s.hcl
+++ b/enos/k8s/enos-modules-k8s.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 module "create_kind_cluster" {
   source = "../modules/local_kind_cluster"

--- a/enos/k8s/enos-providers-k8s.hcl
+++ b/enos/k8s/enos-providers-k8s.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 provider "enos" "default" {}
 

--- a/enos/k8s/enos-scenario-k8s.hcl
+++ b/enos/k8s/enos-scenario-k8s.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 scenario "k8s" {
   matrix {

--- a/enos/k8s/enos-terraform-k8s.hcl
+++ b/enos/k8s/enos-terraform-k8s.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform "k8s" {
   required_version = ">= 1.2.0"

--- a/enos/k8s/enos-variables-k8s.hcl
+++ b/enos/k8s/enos-variables-k8s.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "vault_image_repository" {
   description = "The repository for the docker image to load, i.e. hashicorp/vault"

--- a/enos/modules/autopilot_upgrade_storageconfig/main.tf
+++ b/enos/modules/autopilot_upgrade_storageconfig/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "vault_product_version" {}
 

--- a/enos/modules/backend_consul/main.tf
+++ b/enos/modules/backend_consul/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_version = ">= 1.2.0"

--- a/enos/modules/backend_consul/outputs.tf
+++ b/enos/modules/backend_consul/outputs.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 output "private_ips" {
   description = "Consul cluster target host private_ips"

--- a/enos/modules/backend_consul/variables.tf
+++ b/enos/modules/backend_consul/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "cluster_name" {
   type        = string

--- a/enos/modules/backend_raft/main.tf
+++ b/enos/modules/backend_raft/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 // Shim module to handle the fact that Vault doesn't actually need a backend module when we use raft.
 terraform {

--- a/enos/modules/build_crt/main.tf
+++ b/enos/modules/build_crt/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 # Shim module since CRT provided things will use the crt_bundle_path variable
 variable "bundle_path" {

--- a/enos/modules/build_local/main.tf
+++ b/enos/modules/build_local/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/build_local/scripts/build.sh
+++ b/enos/modules/build_local/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 set -eux -o pipefail
 

--- a/enos/modules/create_vpc/main.tf
+++ b/enos/modules/create_vpc/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 data "aws_availability_zones" "available" {
   state = "available"

--- a/enos/modules/create_vpc/outputs.tf
+++ b/enos/modules/create_vpc/outputs.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 output "id" {
   description = "Created VPC ID"

--- a/enos/modules/create_vpc/variables.tf
+++ b/enos/modules/create_vpc/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "name" {
   type        = string

--- a/enos/modules/ec2_info/main.tf
+++ b/enos/modules/ec2_info/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 locals {
   architectures      = toset(["arm64", "x86_64"])

--- a/enos/modules/generate_secondary_token/main.tf
+++ b/enos/modules/generate_secondary_token/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/get_local_metadata/main.tf
+++ b/enos/modules/get_local_metadata/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/get_local_metadata/scripts/build_date.sh
+++ b/enos/modules/get_local_metadata/scripts/build_date.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 set -eu -o pipefail
 

--- a/enos/modules/get_local_metadata/scripts/version.sh
+++ b/enos/modules/get_local_metadata/scripts/version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 set -euo pipefail
 

--- a/enos/modules/k8s_deploy_vault/main.tf
+++ b/enos/modules/k8s_deploy_vault/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_version = ">= 1.0"

--- a/enos/modules/k8s_deploy_vault/variables.tf
+++ b/enos/modules/k8s_deploy_vault/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "context_name" {
   type        = string

--- a/enos/modules/k8s_vault_verify_build_date/main.tf
+++ b/enos/modules/k8s_vault_verify_build_date/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 terraform {

--- a/enos/modules/k8s_vault_verify_build_date/variables.tf
+++ b/enos/modules/k8s_vault_verify_build_date/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "vault_instance_count" {
   type        = number

--- a/enos/modules/k8s_vault_verify_replication/main.tf
+++ b/enos/modules/k8s_vault_verify_replication/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 terraform {

--- a/enos/modules/k8s_vault_verify_replication/scripts/smoke-verify-replication.sh
+++ b/enos/modules/k8s_vault_verify_replication/scripts/smoke-verify-replication.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 # The Vault replication smoke test, documented in

--- a/enos/modules/k8s_vault_verify_replication/variables.tf
+++ b/enos/modules/k8s_vault_verify_replication/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "vault_instance_count" {
   type        = number

--- a/enos/modules/k8s_vault_verify_ui/main.tf
+++ b/enos/modules/k8s_vault_verify_ui/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 terraform {

--- a/enos/modules/k8s_vault_verify_ui/scripts/smoke-verify-ui.sh
+++ b/enos/modules/k8s_vault_verify_ui/scripts/smoke-verify-ui.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/k8s_vault_verify_ui/variables.tf
+++ b/enos/modules/k8s_vault_verify_ui/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "vault_instance_count" {
   type        = number

--- a/enos/modules/k8s_vault_verify_version/main.tf
+++ b/enos/modules/k8s_vault_verify_version/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 terraform {

--- a/enos/modules/k8s_vault_verify_version/scripts/get-status.sh
+++ b/enos/modules/k8s_vault_verify_version/scripts/get-status.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/k8s_vault_verify_version/scripts/smoke-verify-version.sh
+++ b/enos/modules/k8s_vault_verify_version/scripts/smoke-verify-version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 # The Vault smoke test to verify the Vault version installed

--- a/enos/modules/k8s_vault_verify_version/variables.tf
+++ b/enos/modules/k8s_vault_verify_version/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "vault_instance_count" {
   type        = number

--- a/enos/modules/k8s_vault_verify_write_data/main.tf
+++ b/enos/modules/k8s_vault_verify_write_data/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 terraform {

--- a/enos/modules/k8s_vault_verify_write_data/variables.tf
+++ b/enos/modules/k8s_vault_verify_write_data/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "vault_instance_count" {
   type        = number

--- a/enos/modules/load_docker_image/main.tf
+++ b/enos/modules/load_docker_image/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/local_kind_cluster/main.tf
+++ b/enos/modules/local_kind_cluster/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/read_license/main.tf
+++ b/enos/modules/read_license/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "file_name" {}
 

--- a/enos/modules/replication_data/main.tf
+++ b/enos/modules/replication_data/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 // An arithmetic module for calculating inputs and outputs for various replication steps.
 

--- a/enos/modules/seal_key_awskms/main.tf
+++ b/enos/modules/seal_key_awskms/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "cluster_id" {
   type = string

--- a/enos/modules/seal_key_shamir/main.tf
+++ b/enos/modules/seal_key_shamir/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 # A shim unseal key module for shamir seal types
 

--- a/enos/modules/shutdown_multiple_nodes/main.tf
+++ b/enos/modules/shutdown_multiple_nodes/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/shutdown_node/main.tf
+++ b/enos/modules/shutdown_node/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/start_vault/main.tf
+++ b/enos/modules/start_vault/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/start_vault/outputs.tf
+++ b/enos/modules/start_vault/outputs.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 output "cluster_name" {
   description = "The Vault cluster name"

--- a/enos/modules/start_vault/variables.tf
+++ b/enos/modules/start_vault/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "cluster_name" {
   type        = string

--- a/enos/modules/stop_vault/main.tf
+++ b/enos/modules/stop_vault/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/target_ec2_fleet/main.tf
+++ b/enos/modules/target_ec2_fleet/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/target_ec2_fleet/outputs.tf
+++ b/enos/modules/target_ec2_fleet/outputs.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 output "cluster_name" {
   value = local.cluster_name

--- a/enos/modules/target_ec2_fleet/variables.tf
+++ b/enos/modules/target_ec2_fleet/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "ami_id" {
   description = "The machine image identifier"

--- a/enos/modules/target_ec2_instances/main.tf
+++ b/enos/modules/target_ec2_instances/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/target_ec2_instances/outputs.tf
+++ b/enos/modules/target_ec2_instances/outputs.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 output "cluster_name" {
   value = local.cluster_name

--- a/enos/modules/target_ec2_instances/variables.tf
+++ b/enos/modules/target_ec2_instances/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "ami_id" {
   description = "The machine image identifier"

--- a/enos/modules/target_ec2_shim/main.tf
+++ b/enos/modules/target_ec2_shim/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/target_ec2_spot_fleet/main.tf
+++ b/enos/modules/target_ec2_spot_fleet/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/target_ec2_spot_fleet/outputs.tf
+++ b/enos/modules/target_ec2_spot_fleet/outputs.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 output "cluster_name" {
   value = local.cluster_name

--- a/enos/modules/target_ec2_spot_fleet/variables.tf
+++ b/enos/modules/target_ec2_spot_fleet/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "ami_id" {
   description = "The machine image identifier"

--- a/enos/modules/vault_agent/main.tf
+++ b/enos/modules/vault_agent/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_agent/scripts/set-up-approle-and-agent.sh
+++ b/enos/modules/vault_agent/scripts/set-up-approle-and-agent.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_artifactory_artifact/locals.tf
+++ b/enos/modules/vault_artifactory_artifact/locals.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 locals {
 

--- a/enos/modules/vault_artifactory_artifact/main.tf
+++ b/enos/modules/vault_artifactory_artifact/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_artifactory_artifact/outputs.tf
+++ b/enos/modules/vault_artifactory_artifact/outputs.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 output "url" {

--- a/enos/modules/vault_artifactory_artifact/variables.tf
+++ b/enos/modules/vault_artifactory_artifact/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 variable "artifactory_username" {
   type        = string
   description = "The username to use when connecting to artifactory"

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_cluster/outputs.tf
+++ b/enos/modules/vault_cluster/outputs.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 output "audit_device_file_path" {
   description = "The file path for the audit device, if enabled"

--- a/enos/modules/vault_cluster/scripts/create_audit_log_dir.sh
+++ b/enos/modules/vault_cluster/scripts/create_audit_log_dir.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -eux

--- a/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
+++ b/enos/modules/vault_cluster/scripts/enable_audit_logging.sh
@@ -1,6 +1,6 @@
 #!/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 set -exo pipefail
 

--- a/enos/modules/vault_cluster/scripts/install-packages.sh
+++ b/enos/modules/vault_cluster/scripts/install-packages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -ex -o pipefail

--- a/enos/modules/vault_cluster/scripts/vault-write-license.sh
+++ b/enos/modules/vault_cluster/scripts/vault-write-license.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 if test "$LICENSE" = "none"; then

--- a/enos/modules/vault_cluster/variables.tf
+++ b/enos/modules/vault_cluster/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "artifactory_release" {
   type = object({

--- a/enos/modules/vault_get_cluster_ips/main.tf
+++ b/enos/modules/vault_get_cluster_ips/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_get_cluster_ips/scripts/get-follower-private-ips.sh
+++ b/enos/modules/vault_get_cluster_ips/scripts/get-follower-private-ips.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_get_cluster_ips/scripts/get-leader-private-ip.sh
+++ b/enos/modules/vault_get_cluster_ips/scripts/get-leader-private-ip.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_proxy/main.tf
+++ b/enos/modules/vault_proxy/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_proxy/scripts/set-up-approle-and-proxy.sh
+++ b/enos/modules/vault_proxy/scripts/set-up-approle-and-proxy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_proxy/scripts/use-proxy.sh
+++ b/enos/modules/vault_proxy/scripts/use-proxy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_raft_remove_peer/main.tf
+++ b/enos/modules/vault_raft_remove_peer/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_raft_remove_peer/scripts/raft-remove-peer.sh
+++ b/enos/modules/vault_raft_remove_peer/scripts/raft-remove-peer.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_setup_perf_primary/main.tf
+++ b/enos/modules/vault_setup_perf_primary/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_setup_perf_primary/scripts/configure-vault-pr-primary.sh
+++ b/enos/modules/vault_setup_perf_primary/scripts/configure-vault-pr-primary.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_setup_perf_secondary/main.tf
+++ b/enos/modules/vault_setup_perf_secondary/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_test_ui/main.tf
+++ b/enos/modules/vault_test_ui/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_test_ui/outputs.tf
+++ b/enos/modules/vault_test_ui/outputs.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 output "ui_test_stderr" {
   value = var.ui_run_tests ? enos_local_exec.test_ui[0].stderr : "No std out tests where not run"

--- a/enos/modules/vault_test_ui/scripts/test_ui.sh
+++ b/enos/modules/vault_test_ui/scripts/test_ui.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -eux -o pipefail

--- a/enos/modules/vault_test_ui/variables.tf
+++ b/enos/modules/vault_test_ui/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "vault_addr" {
   description = "The host address for the vault instance to test"

--- a/enos/modules/vault_unseal_nodes/main.tf
+++ b/enos/modules/vault_unseal_nodes/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 # This module unseals the replication secondary follower nodes
 terraform {

--- a/enos/modules/vault_unseal_nodes/scripts/unseal-node.sh
+++ b/enos/modules/vault_unseal_nodes/scripts/unseal-node.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 binpath=${VAULT_INSTALL_DIR}/vault

--- a/enos/modules/vault_unseal_nodes/scripts/wait-until-sealed.sh
+++ b/enos/modules/vault_unseal_nodes/scripts/wait-until-sealed.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 binpath=${VAULT_INSTALL_DIR}/vault

--- a/enos/modules/vault_upgrade/main.tf
+++ b/enos/modules/vault_upgrade/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_upgrade/scripts/get-follower-public-ips.sh
+++ b/enos/modules/vault_upgrade/scripts/get-follower-public-ips.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_upgrade/scripts/get-leader-public-ip.sh
+++ b/enos/modules/vault_upgrade/scripts/get-leader-public-ip.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_upgrade/scripts/restart-vault.sh
+++ b/enos/modules/vault_upgrade/scripts/restart-vault.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -eux

--- a/enos/modules/vault_verify_agent_output/main.tf
+++ b/enos/modules/vault_verify_agent_output/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_verify_agent_output/scripts/verify-vault-agent-output.sh
+++ b/enos/modules/vault_verify_agent_output/scripts/verify-vault-agent-output.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_verify_autopilot/main.tf
+++ b/enos/modules/vault_verify_autopilot/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_verify_autopilot/scripts/smoke-verify-autopilot.sh
+++ b/enos/modules/vault_verify_autopilot/scripts/smoke-verify-autopilot.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 fail() {
   echo "$1" 1>&2

--- a/enos/modules/vault_verify_performance_replication/main.tf
+++ b/enos/modules/vault_verify_performance_replication/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_verify_performance_replication/scripts/verify-replication-status.sh
+++ b/enos/modules/vault_verify_performance_replication/scripts/verify-replication-status.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 # This script waits for the replication status to be established

--- a/enos/modules/vault_verify_raft_auto_join_voter/main.tf
+++ b/enos/modules/vault_verify_raft_auto_join_voter/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_verify_raft_auto_join_voter/scripts/verify-raft-auto-join-voter.sh
+++ b/enos/modules/vault_verify_raft_auto_join_voter/scripts/verify-raft-auto-join-voter.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_verify_read_data/main.tf
+++ b/enos/modules/vault_verify_read_data/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_verify_read_data/scripts/verify-data.sh
+++ b/enos/modules/vault_verify_read_data/scripts/verify-data.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_verify_replication/main.tf
+++ b/enos/modules/vault_verify_replication/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 terraform {

--- a/enos/modules/vault_verify_replication/scripts/smoke-verify-replication.sh
+++ b/enos/modules/vault_verify_replication/scripts/smoke-verify-replication.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 # The Vault replication smoke test, documented in

--- a/enos/modules/vault_verify_replication/variables.tf
+++ b/enos/modules/vault_verify_replication/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 variable "vault_edition" {

--- a/enos/modules/vault_verify_ui/main.tf
+++ b/enos/modules/vault_verify_ui/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 terraform {

--- a/enos/modules/vault_verify_ui/scripts/smoke-verify-ui.sh
+++ b/enos/modules/vault_verify_ui/scripts/smoke-verify-ui.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_verify_ui/variables.tf
+++ b/enos/modules/vault_verify_ui/variables.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 variable "vault_addr" {
   type        = string

--- a/enos/modules/vault_verify_undo_logs/main.tf
+++ b/enos/modules/vault_verify_undo_logs/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_verify_undo_logs/scripts/smoke-verify-undo-logs.sh
+++ b/enos/modules/vault_verify_undo_logs/scripts/smoke-verify-undo-logs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 function fail() {
   echo "$1" 1>&2

--- a/enos/modules/vault_verify_unsealed/main.tf
+++ b/enos/modules/vault_verify_unsealed/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_verify_unsealed/scripts/verify-vault-node-unsealed.sh
+++ b/enos/modules/vault_verify_unsealed/scripts/verify-vault-node-unsealed.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 set -e
 

--- a/enos/modules/vault_verify_version/main.tf
+++ b/enos/modules/vault_verify_version/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_verify_version/scripts/verify-cluster-version.sh
+++ b/enos/modules/vault_verify_version/scripts/verify-cluster-version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 # Verify the Vault "version" includes the correct base version, build date,

--- a/enos/modules/vault_verify_write_data/main.tf
+++ b/enos/modules/vault_verify_write_data/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_verify_write_data/scripts/smoke-enable-secrets-kv.sh
+++ b/enos/modules/vault_verify_write_data/scripts/smoke-enable-secrets-kv.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_verify_write_data/scripts/smoke-write-test-data.sh
+++ b/enos/modules/vault_verify_write_data/scripts/smoke-write-test-data.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_wait_for_leader/main.tf
+++ b/enos/modules/vault_wait_for_leader/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_wait_for_leader/scripts/wait-for-leader.sh
+++ b/enos/modules/vault_wait_for_leader/scripts/wait-for-leader.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/vault_wait_for_seal_rewrap/main.tf
+++ b/enos/modules/vault_wait_for_seal_rewrap/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/vault_wait_for_seal_rewrap/scripts/wait-for-seal-rewrap.sh
+++ b/enos/modules/vault_wait_for_seal_rewrap/scripts/wait-for-seal-rewrap.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 
 set -e

--- a/enos/modules/verify_seal_type/main.tf
+++ b/enos/modules/verify_seal_type/main.tf
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 terraform {
   required_providers {

--- a/enos/modules/verify_seal_type/scripts/verify-seal-type.sh
+++ b/enos/modules/verify_seal_type/scripts/verify-seal-type.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: BUSL-1.1
+# SPDX-License-Identifier: MPL-2.0
 
 set -e
 


### PR DESCRIPTION
The enos backports accidentally included the BUSL-1.1 license header. Change it back to MPL 2.0 until 2024.