### PR TITLE
Use seal wrappers rather than config to determine autoSeal barrier type.

### DIFF
--- a/changelog/24165.txt
+++ b/changelog/24165.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+core: Fix an error that resulted in the wrong seal type being returned by sys/seal-status while
+Vault is in seal migration mode.
+```

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -5018,8 +5018,14 @@ func (core *Core) GetSealStatus(ctx context.Context, lock bool) (*SealStatusResp
 		return s, nil
 	}
 
+	var sealType string
 	var recoverySealType string
-	sealType := sealConfig.Type
+	if core.SealAccess().RecoveryKeySupported() {
+		recoverySealType = sealConfig.Type
+		sealType = core.seal.BarrierSealConfigType().String()
+	} else {
+		sealType = sealConfig.Type
+	}
 
 	// Fetch the local cluster name and identifier
 	var clusterName, clusterID string
@@ -5033,10 +5039,6 @@ func (core *Core) GetSealStatus(ctx context.Context, lock bool) (*SealStatusResp
 		}
 		clusterName = cluster.Name
 		clusterID = cluster.ID
-		if core.SealAccess().RecoveryKeySupported() {
-			recoverySealType = sealType
-		}
-		sealType = core.seal.BarrierSealConfigType().String()
 	}
 
 	progress, nonce := core.SecretProgress(lock)

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -53,12 +53,12 @@ func NewAutoSeal(lowLevel seal.Access) *autoSeal {
 	ret.barrierConfig.Store((*SealConfig)(nil))
 	ret.recoveryConfig.Store((*SealConfig)(nil))
 
-	// See SealConfigType for the rules about computing the type.
-	if len(lowLevel.GetSealGenerationInfo().Seals) > 1 {
-		ret.barrierSealConfigType = SealConfigTypeMultiseal
+	// See SealConfigType for the rules about computing the type. Note that NewAccess guarantees
+	// that there is at least one wrapper
+	if wrappers := lowLevel.GetAllSealWrappersByPriority(); len(wrappers) == 1 {
+		ret.barrierSealConfigType = SealConfigType(wrappers[0].SealConfigType)
 	} else {
-		// Note that the Access constructors guarantee that there is at least one KMS config
-		ret.barrierSealConfigType = SealConfigType(lowLevel.GetSealGenerationInfo().Seals[0].Type)
+		ret.barrierSealConfigType = SealConfigTypeMultiseal
 	}
 
 	return ret

--- a/vault/seal_autoseal_test.go
+++ b/vault/seal_autoseal_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
 	"time"
@@ -211,4 +212,15 @@ func TestAutoSeal_HealthCheck(t *testing.T) {
 	if !autoSeal.Healthy() {
 		t.Fatal("Expected seals to be healthy")
 	}
+}
+
+func TestAutoSeal_BarrierSealConfigType(t *testing.T) {
+	singleWrapperAccess, _ := seal.NewToggleableTestSeal(&seal.TestSealOpts{WrapperCount: 1})
+	multipleWrapperAccess, _ := seal.NewToggleableTestSeal(&seal.TestSealOpts{WrapperCount: 2})
+
+	require.Equalf(t, singleWrapperAccess.GetAllSealWrappersByPriority()[0].SealConfigType, NewAutoSeal(singleWrapperAccess).BarrierSealConfigType().String(),
+		"autoseals that have a single seal wrapper report that wrapper's as the barrier seal type")
+
+	require.Equalf(t, SealConfigTypeMultiseal, NewAutoSeal(multipleWrapperAccess).BarrierSealConfigType(),
+		"autoseals that have a multiple seal wrappers report the barrier seal type as Multiseal")
 }


### PR DESCRIPTION
A seal's Access object contains all seal configuration, which in the case of seal migration includes the "unwrap seal" as well as the barrier seal. Thus, to determine whether an autoSeal is of a specific type such as 'Transit' or whether it is a 'Multiseal', use the wrappers of the seal's Access.

In addition: Fix an error that resulted in the wrong seal type being reported while Vault is in seal migration mode.
