### PR TITLE
Add configuration section to sync api

### DIFF
--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -11,6 +11,53 @@ The `/sys/sync` endpoints are used to configure destinations and associate secre
 Each destination type has its own endpoint for creation & update operations, but share the same endpoints for read &
 delete operations.
 
+## Configuration
+
+The `sys/sync/config` endpoint is used to set configuration parameters for the sync system as a whole.
+
+| Method  | Path              |
+|:--------|:------------------|
+| `PATCH` | `sys/sync/config` |
+
+### Parameters
+
+- `disabled` `(bool: false)` - Disables sync operations from sending secrets in Vault to external destinations when
+set to true. While disabled, actions performed in Vault which trigger a sync operation will instead queue them to be
+processed once the value is set back to false.
+
+### Sample payload
+```json
+{
+    "disabled": "true"
+}
+```
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request PATCH \
+    --data @payload.json
+    http://127.0.0.1:8200/v1/sys/sync/config
+```
+
+### Sample response
+
+```json
+{
+    "request_id": "uuid",
+    "lease_id": "",
+    "lease_duration": 0,
+    "renewable": false,
+    "data": {
+        "disabled": true
+    },
+    "warnings": null,
+    "mount_type": "system"
+}
+```
+
 ## List destinations
 
 This endpoint lists all configured sync destination names regrouped by destination type.

--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -22,8 +22,9 @@ The `sys/sync/config` endpoint is used to set configuration parameters for the s
 ### Parameters
 
 - `disabled` `(bool: false)` - Disables sync operations from sending secrets in Vault to external destinations when
-set to true. While disabled, actions performed in Vault which trigger a sync operation will instead queue them to be
-processed once the value is set back to false.
+set to true. While disabled, actions performed in Vault which trigger a sync operation will instead get queued to be
+processed once syncing is reactivated. Queued operations will have a status of `PENDING` until they are completed.
+This is provided as a safety mechanism for emergencies.
 
 ### Sample payload
 ```json

--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -6,8 +6,6 @@ description: The `/sys/sync` endpoints are used to configure destinations and as
 
 # `/sys/sync`
 
-@include 'alerts/restricted-root.mdx'
-
 The `/sys/sync` endpoints are used to configure destinations and associate secrets to sync with these destinations.
 
 Each destination type has its own endpoint for creation & update operations, but share the same endpoints for read &
@@ -16,6 +14,8 @@ delete operations.
 ## Configuration
 
 The `sys/sync/config` endpoint is used to set configuration parameters for the sync system as a whole.
+
+@include 'alerts/restricted-root.mdx'
 
 | Method  | Path              |
 |:--------|:------------------|

--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -6,6 +6,8 @@ description: The `/sys/sync` endpoints are used to configure destinations and as
 
 # `/sys/sync`
 
+@include 'alerts/restricted-root.mdx'
+
 The `/sys/sync` endpoints are used to configure destinations and associate secrets to sync with these destinations.
 
 Each destination type has its own endpoint for creation & update operations, but share the same endpoints for read &


### PR DESCRIPTION
Wasn't sure if/where we should include any section about configuration in the main docs.