### PR TITLE
Backport/1.15.x: update vault-helm docs for release 0.26.1

### DIFF
--- a/website/content/docs/configuration/service-registration/kubernetes.mdx
+++ b/website/content/docs/configuration/service-registration/kubernetes.mdx
@@ -71,7 +71,7 @@ metadata:
     vault-initialized: "true"
     vault-perf-standby: "false"
     vault-sealed: "false"
-    vault-version: 1.14.0
+    vault-version: 1.15.1
 ```
 
 After shutdowns, Vault pods will bear the following labels:
@@ -86,7 +86,7 @@ metadata:
     vault-initialized: "false"
     vault-perf-standby: "false"
     vault-sealed: "true"
-    vault-version: 1.14.0
+    vault-version: 1.15.1
 ```
 
 ## Label definitions
@@ -102,7 +102,7 @@ metadata:
 - `vault-sealed` `(string: "true"/"false")` – Vault sealed is updated dynamically each
   time Vault's sealed/unsealed status changes. True indicates that Vault is currently sealed. False indicates that Vault
   is currently unsealed.
-- `vault-version` `(string: "1.14.0")` – Vault version is a string that will not change during a pod's lifecycle.
+- `vault-version` `(string: "1.15.1")` – Vault version is a string that will not change during a pod's lifecycle.
 
 ## Working with vault's service discovery labels
 

--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -18,6 +18,8 @@ and consider if they're appropriate for your deployment.
 
   - `enabled` (`boolean: true`) - The master enabled/disabled configuration. If this is true, most components will be installed by default. If this is false, no components will be installed by default and manually opting-in is required, such as by setting `server.enabled` to true.
 
+  - `namespace` (`string: ""`) - The namespace to deploy to. Defaults to the `helm` installation namespace.
+
   - `imagePullSecrets` (`array: []`) - References secrets to be used when pulling images from private registries. See [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) for more details. May be specified as an array of name map entries or just as an array of names:
 
     ```yaml
@@ -77,7 +79,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault-k8s"`) - The name of the Docker image for Vault Agent Injector.
 
-    - `tag` (`string: "1.2.1"`) - The tag of the Docker image for the Vault Agent Injector. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
+    - `tag` (`string: "1.3.1"`) - The tag of the Docker image for the Vault Agent Injector. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
 
@@ -85,7 +87,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault"`) - The name of the Docker image for the Vault Agent sidecar. This should be set to the official Vault Docker image.
 
-    - `tag` (`string: "1.14.0"`) - The tag of the Vault Docker image to use for the Vault Agent Sidecar. **Vault 1.3.1+ is required by the admission controller**.
+    - `tag` (`string: "1.15.1"`) - The tag of the Vault Docker image to use for the Vault Agent Sidecar. **Vault 1.3.1+ is required by the admission controller**.
 
   - `agentDefaults` - Values that configure the injected Vault Agent containers default values.
 
@@ -349,7 +351,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault"`) - The name of the Docker image for the containers running Vault.
 
-    - `tag` (`string: "1.14.0"`) - The tag of the Docker image for the containers running Vault. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
+    - `tag` (`string: "1.15.1"`) - The tag of the Docker image for the containers running Vault. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
 
@@ -432,6 +434,8 @@ and consider if they're appropriate for your deployment.
         - /
         - /vault
       ```
+
+  - `hostAliases` (`array: []`) - A list of aliases to be added to `/etc/hosts`. Specified as a YAML list following the [hostAlias format](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/)
 
   - `route` - Values that configure Route services for Vault in OpenShift
 
@@ -706,9 +710,13 @@ and consider if they're appropriate for your deployment.
 
       - `enabled` (`boolean: true`) - When set to `true`, the vault-active Kubernetes service will be created for Vault, selecting pods which label themselves as the cluster leader with `vault-active: "true"`.
 
+      - `annotations` (`dictionary: {}`) -  Extra annotations for the active service definition. This can either be YAML or a YAML-formatted multi-line templated string.
+
     - `standby` - Values that apply only to the vault-standby service.
 
       - `enabled` (`boolean: true`) - When set to `true`, the vault-standby Kubernetes service will be created for Vault, selecting pods which label themselves as a cluster follower with `vault-active: "false"`.
+
+      - `annotations` (`dictionary: {}`) -  Extra annotations for the standby service definition. This can either be YAML or a YAML-formatted multi-line templated string.
 
     - `clusterIP` (`string`) - ClusterIP controls whether an IP address (cluster IP) is attached to the Vault service within Kubernetes. By default the Vault service will be given a Cluster IP address, set to `None` to disable. When disabled Kubernetes will create a "headless" service. Headless services can be used to communicate with pods directly through DNS instead of a round robin load balancer.
 
@@ -744,11 +752,17 @@ and consider if they're appropriate for your deployment.
       "sample/annotation2": "bar"
     ```
 
+    - `ipFamilyPolicy` (`string: ""`) - The IP family and IP families options are to set the behaviour in a dual-stack environment. Omitting these values will let the service fall back to whatever the CNI dictates the defaults should be. These are only supported for kubernetes versions >=1.23. The service's [supported IP family policy](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services), can be either: `SingleStack`, `PreferDualStack`, or `RequireDualStack`.
+
+    - `serviceIPFamilies` (`array: []`) - Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6.
+
   - `serviceAccount` - Values that configure the Kubernetes service account created for Vault.
 
     - `create` (`boolean: true`): If set to true, creates a service account used by Vault.
 
     - `name` (`string: ""`): Name of the service account to use. If not set and create is true, a name is generated using the name of the installation (default is "vault").
+
+    - `createSecret` (`boolean: false`): Create a Kubernetes Secret object to store a non-expiring token for the service account. Prior to Kubernetes 1.24.0, Kubernetes used to generate this secret for each service account by default. Kubernetes recommends using short-lived tokens from the TokenRequest API or projected volumes instead if possible. For more details, see https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets. `server.serviceAccount.create` must be equal to 'true' in order to use this feature.
 
     - `annotations` (`dictionary: {}`) - This value defines additional annotations for the service account. This can either be YAML or a YAML-formatted multi-line templated string.
 
@@ -1000,6 +1014,10 @@ and consider if they're appropriate for your deployment.
 
   - `targetPort` (`int: 8200`) - Sets the target port value of the service.
 
+  - `serviceIPFamilyPolicy` (`string: ""`) - The IP family and IP families options are to set the behaviour in a dual-stack environment. Omitting these values will let the service fall back to whatever the CNI dictates the defaults should be. These are only supported for kubernetes versions >=1.23. The service's [supported IP family policy](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services), can be either: `SingleStack`, `PreferDualStack`, or `RequireDualStack`.
+
+  - `serviceIPFamilies` (`array: []`) - Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6.
+
   - `externalTrafficPolicy` (`string: "Cluster"`) - The [externalTrafficPolicy](https://kubernetes.io/docs/concepts/services-networking/service/#external-traffic-policy) can be set to either Cluster or Local and is only valid for LoadBalancer and NodePort service types.
 
   - `loadBalancerSourceRanges` (`array`) - This value defines additional source CIDRs when using `serviceType: LoadBalancer`.
@@ -1032,7 +1050,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault-csi-provider"`) - The name of the Docker image for the Vault CSI Provider.
 
-    - `tag` (`string: "1.4.0"`) - The tag of the Docker image for the Vault CSI Provider.. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your CSI provider.
+    - `tag` (`string: "1.4.1"`) - The tag of the Docker image for the Vault CSI Provider.. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your CSI provider.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists locally.
 
@@ -1181,7 +1199,7 @@ and consider if they're appropriate for your deployment.
 
       - `repository` (`string: "hashicorp/vault"`) - The name of the Docker image for the Vault Agent sidecar. This should be set to the official Vault Docker image.
 
-      - `tag` (`string: "1.14.0"`) - The tag of the Vault Docker image to use for the Vault Agent Sidecar.
+      - `tag` (`string: "1.15.1"`) - The tag of the Vault Docker image to use for the Vault Agent Sidecar.
 
     - `logFormat` (`string: "standard"`) -
     - `logLevel` (`string: "info"`) -

--- a/website/content/docs/platform/k8s/helm/enterprise.mdx
+++ b/website/content/docs/platform/k8s/helm/enterprise.mdx
@@ -33,7 +33,7 @@ In your chart overrides, set the values of [`server.image`](/vault/docs/platform
 server:
   image:
     repository: hashicorp/vault-enterprise
-    tag: 1.14.0-ent
+    tag: 1.15.1-ent
   enterpriseLicense:
     secretName: vault-ent-license
 ```

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
@@ -23,7 +23,7 @@ First, create the primary cluster:
 ```shell
 helm install vault-primary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.14.0-ent' \
+  --set='server.image.tag=1.15.1-ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```
@@ -75,7 +75,7 @@ disaster recovery replication.
 ```shell
 helm install vault-secondary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.14.0-ent' \
+  --set='server.image.tag=1.15.1-ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
@@ -23,7 +23,7 @@ First, create the primary cluster:
 ```shell
 helm install vault-primary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.14.0-ent' \
+  --set='server.image.tag=1.15.1-ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```
@@ -74,7 +74,7 @@ With the primary cluster created, next create a secondary cluster.
 ```shell
 helm install vault-secondary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.14.0-ent' \
+  --set='server.image.tag=1.15.1-ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
@@ -15,7 +15,7 @@ Integrated Storage (raft) can be enabled using the `server.ha.raft.enabled` valu
 ```shell
 helm install vault hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.14.0-ent' \
+  --set='server.image.tag=1.15.1-ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -409,14 +409,14 @@ Next, list the Helm versions and choose the desired version to install.
 ```bash
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.25.0       	1.14.0     	Official HashiCorp Vault Chart
+hashicorp/vault	0.26.1       	1.15.1     	Official HashiCorp Vault Chart
 ```
 
 Next, test the upgrade with `--dry-run` first to verify the changes sent to the
 Kubernetes cluster.
 
 ```shell-session
-$ helm upgrade vault hashicorp/vault --version=0.25.0 \
+$ helm upgrade vault hashicorp/vault --version=0.26.1 \
     --set='server.image.repository=vault' \
     --set='server.image.tag=123.456' \
     --dry-run

--- a/website/content/partials/helm/install.mdx
+++ b/website/content/partials/helm/install.mdx
@@ -2,15 +2,16 @@
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
+hashicorp/vault	0.26.1       	1.15.1     	Official HashiCorp Vault Chart
+hashicorp/vault	0.26.0       	1.15.1     	Official HashiCorp Vault Chart
 hashicorp/vault	0.25.0       	1.14.0     	Official HashiCorp Vault Chart
 hashicorp/vault	0.24.0       	1.13.1     	Official HashiCorp Vault Chart
 hashicorp/vault	0.23.0       	1.12.1     	Official HashiCorp Vault Chart
 hashicorp/vault	0.22.1       	1.12.0     	Official HashiCorp Vault Chart
 hashicorp/vault	0.22.0       	1.11.3     	Official HashiCorp Vault Chart
 hashicorp/vault	0.21.0       	1.11.2     	Official HashiCorp Vault Chart
-hashicorp/vault	0.20.1       	1.10.3     	Official HashiCorp Vault Chart
 ...
 
-# Install version 0.25.0
-$ helm install vault hashicorp/vault --version 0.25.0
+# Install version 0.26.1
+$ helm install vault hashicorp/vault --version 0.26.1
 ```

--- a/website/content/partials/helm/repo.mdx
+++ b/website/content/partials/helm/repo.mdx
@@ -4,5 +4,5 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.25.0       	1.14.0     	Official HashiCorp Vault Chart
+hashicorp/vault	0.26.1       	1.15.1     	Official HashiCorp Vault Chart
 ```


### PR DESCRIPTION
Backporting the [docs update for vault-helm 0.26.0 and 0.26.1](https://github.com/hashicorp/vault/pull/23890), since backport-assistant got hung up on the command/kv_test.go fix: https://github.com/hashicorp/vault/pull/23920