### PR TITLE
VAULT-22030 update error message when from entity isn't found as part of automated entity merge

### DIFF
--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -883,6 +883,15 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 		}
 
 		if fromEntity == nil {
+			// If forceMergeAliases is true, and we didn't find a fromEntity, then something
+			// is wrong with storage. This function was called as part of an automated
+			// merge from CreateOrFetchEntity or Invalidate to repatriate an alias with its 'true'
+			// entity. As a result, the entity _should_ exist, but we can't find it.
+			// MemDb may be in a bad state, because fromEntity should be non-nil in the
+			// automated merge case.
+			if forceMergeAliases {
+				return errors.New("fromEntity was not found in memdb as part of an automated entity merge; storage/memdb may be in a bad state"), nil, nil
+			}
 			return errors.New("entity id to merge from is invalid"), nil, nil
 		}
 
@@ -995,6 +1004,15 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 		}
 
 		if fromEntity == nil {
+			// If forceMergeAliases is true, and we didn't find a fromEntity, then something
+			// is wrong with storage. This function was called as part of an automated
+			// merge from CreateOrFetchEntity or Invalidate to repatriate an alias with its 'true'
+			// entity. As a result, the entity _should_ exist, but we can't find it.
+			// MemDb may be in a bad state, because fromEntity should be non-nil in the
+			// automated merge case.
+			if forceMergeAliases {
+				return errors.New("fromEntity was not found in memdb as part of an automated entity merge; storage/memdb may be in a bad state"), nil, nil
+			}
 			return errors.New("entity id to merge from is invalid"), nil, nil
 		}
 

--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -890,7 +890,7 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 			// MemDb may be in a bad state, because fromEntity should be non-nil in the
 			// automated merge case.
 			if forceMergeAliases {
-				return errors.New("fromEntity was not found in memdb as part of an automated entity merge; storage/memdb may be in a bad state"), nil, nil
+				return fmt.Errorf("fromEntity %s was not found in memdb as part of an automated entity merge into %s; storage/memdb may be in a bad state", fromEntityID, toEntity.ID), nil, nil
 			}
 			return errors.New("entity id to merge from is invalid"), nil, nil
 		}
@@ -1011,7 +1011,7 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 			// MemDb may be in a bad state, because fromEntity should be non-nil in the
 			// automated merge case.
 			if forceMergeAliases {
-				return errors.New("fromEntity was not found in memdb as part of an automated entity merge; storage/memdb may be in a bad state"), nil, nil
+				return fmt.Errorf("fromEntity %s was not found in memdb as part of an automated entity merge into %s; storage/memdb may be in a bad state", fromEntityID, toEntity.ID), nil, nil
 			}
 			return errors.New("entity id to merge from is invalid"), nil, nil
 		}


### PR DESCRIPTION
Related to the escalation we've been looking into, this should hopefully signpost better if this issue recurs.

Jason, I know you're OOO, but adding you for visibility.