### PR TITLE
Handle expired OCSP responses from server

### DIFF
--- a/changelog/24193.txt
+++ b/changelog/24193.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/cert: Handle errors related to expired OCSP server responses
+```


### PR DESCRIPTION
 - If a server replies with what we considered an expired OCSP response, NextUpdate is now or in the past, and it was our only response we would panic due to missing error handling logic.