### PR TITLE
events: Add filters to keep track of local and other subscriptions

### DIFF
--- a/changelog/24201.txt
+++ b/changelog/24201.txt
@@ -1,0 +1,3 @@
+```release-note:change
+events: Source URL is now `vault://{vault node}`
+```

--- a/vault/core.go
+++ b/vault/core.go
@@ -1265,7 +1265,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	if err != nil {
 		return nil, err
 	}
-	events, err := eventbus.NewEventBus(c.clusterID.Load, nodeID, eventsLogger)
+	events, err := eventbus.NewEventBus(nodeID, eventsLogger)
 	if err != nil {
 		return nil, err
 	}

--- a/vault/core.go
+++ b/vault/core.go
@@ -1261,7 +1261,11 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	eventsLogger := conf.Logger.Named("events")
 	c.allLoggers = append(c.allLoggers, eventsLogger)
 	// start the event system
-	events, err := eventbus.NewEventBus(eventsLogger)
+	nodeID, err := c.LoadNodeID()
+	if err != nil {
+		return nil, err
+	}
+	events, err := eventbus.NewEventBus(c.clusterID.Load, nodeID, eventsLogger)
 	if err != nil {
 		return nil, err
 	}

--- a/vault/eventbus/bus.go
+++ b/vault/eventbus/bus.go
@@ -43,7 +43,6 @@ var (
 		"path",
 		logical.EventMetadataDataPath,
 	}
-	initCloudEventsFormatterFilterOnce sync.Once
 )
 
 // EventBus contains the main logic of running an event broker for Vault.

--- a/vault/eventbus/bus_test.go
+++ b/vault/eventbus/bus_test.go
@@ -23,7 +23,7 @@ import (
 
 // TestBusBasics tests that basic event sending and subscribing function.
 func TestBusBasics(t *testing.T) {
-	bus, err := NewEventBus(nil)
+	bus, err := NewEventBus("", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestBusBasics(t *testing.T) {
 // TestBusIgnoresSendContext tests that the context is ignored when sending to an event,
 // so that we do not give up too quickly.
 func TestBusIgnoresSendContext(t *testing.T) {
-	bus, err := NewEventBus(nil)
+	bus, err := NewEventBus("", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestBusIgnoresSendContext(t *testing.T) {
 // TestSubscribeNonRootNamespace verifies that events for non-root namespaces
 // aren't filtered out by the bus.
 func TestSubscribeNonRootNamespace(t *testing.T) {
-	bus, err := NewEventBus(nil)
+	bus, err := NewEventBus("", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func TestSubscribeNonRootNamespace(t *testing.T) {
 
 // TestNamespaceFiltering verifies that events for other namespaces are filtered out by the bus.
 func TestNamespaceFiltering(t *testing.T) {
-	bus, err := NewEventBus(nil)
+	bus, err := NewEventBus("", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +222,7 @@ func TestNamespaceFiltering(t *testing.T) {
 
 // TestBus2Subscriptions verifies that events of different types are successfully routed to the correct subscribers.
 func TestBus2Subscriptions(t *testing.T) {
-	bus, err := NewEventBus(nil)
+	bus, err := NewEventBus("", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,7 +293,7 @@ func TestBusSubscriptionsCancel(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("cancel=%v", tc.cancel), func(t *testing.T) {
 			subscriptions.Store(0)
-			bus, err := NewEventBus(nil)
+			bus, err := NewEventBus("", "", nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -396,7 +396,7 @@ func waitFor(t *testing.T, maxWait time.Duration, f func() bool) {
 // TestBusWildcardSubscriptions tests that a single subscription can receive
 // multiple event types using * for glob patterns.
 func TestBusWildcardSubscriptions(t *testing.T) {
-	bus, err := NewEventBus(nil)
+	bus, err := NewEventBus("", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -471,7 +471,7 @@ func TestBusWildcardSubscriptions(t *testing.T) {
 // TestDataPathIsPrependedWithMount tests that "data_path", if present in the
 // metadata, is prepended with the plugin's mount.
 func TestDataPathIsPrependedWithMount(t *testing.T) {
-	bus, err := NewEventBus(nil)
+	bus, err := NewEventBus("", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -591,7 +591,7 @@ func TestDataPathIsPrependedWithMount(t *testing.T) {
 
 // TestBexpr tests go-bexpr filters are evaluated on an event.
 func TestBexpr(t *testing.T) {
-	bus, err := NewEventBus(nil)
+	bus, err := NewEventBus("", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -671,7 +671,7 @@ func TestBexpr(t *testing.T) {
 // TestPipelineCleanedUp ensures pipelines are properly cleaned up after
 // subscriptions are closed.
 func TestPipelineCleanedUp(t *testing.T) {
-	bus, err := NewEventBus(nil)
+	bus, err := NewEventBus("", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -683,6 +683,10 @@ func TestPipelineCleanedUp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// check that the filters are set
+	if !bus.filters.anyMatch(namespace.RootNamespace.Path, eventType) {
+		t.Fatal()
+	}
 	if !bus.broker.IsAnyPipelineRegistered(eventTypeAll) {
 		cancel()
 		t.Fatal()
@@ -691,6 +695,11 @@ func TestPipelineCleanedUp(t *testing.T) {
 	cancel()
 
 	if bus.broker.IsAnyPipelineRegistered(eventTypeAll) {
+		t.Fatal()
+	}
+
+	// and that the filters are cleaned up
+	if bus.filters.anyMatch(namespace.RootNamespace.Path, eventType) {
 		t.Fatal()
 	}
 }

--- a/vault/eventbus/bus_test.go
+++ b/vault/eventbus/bus_test.go
@@ -23,7 +23,7 @@ import (
 
 // TestBusBasics tests that basic event sending and subscribing function.
 func TestBusBasics(t *testing.T) {
-	bus, err := NewEventBus("", "", nil)
+	bus, err := NewEventBus("", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestBusBasics(t *testing.T) {
 // TestBusIgnoresSendContext tests that the context is ignored when sending to an event,
 // so that we do not give up too quickly.
 func TestBusIgnoresSendContext(t *testing.T) {
-	bus, err := NewEventBus("", "", nil)
+	bus, err := NewEventBus("", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestBusIgnoresSendContext(t *testing.T) {
 // TestSubscribeNonRootNamespace verifies that events for non-root namespaces
 // aren't filtered out by the bus.
 func TestSubscribeNonRootNamespace(t *testing.T) {
-	bus, err := NewEventBus("", "", nil)
+	bus, err := NewEventBus("", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func TestSubscribeNonRootNamespace(t *testing.T) {
 
 // TestNamespaceFiltering verifies that events for other namespaces are filtered out by the bus.
 func TestNamespaceFiltering(t *testing.T) {
-	bus, err := NewEventBus("", "", nil)
+	bus, err := NewEventBus("", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +222,7 @@ func TestNamespaceFiltering(t *testing.T) {
 
 // TestBus2Subscriptions verifies that events of different types are successfully routed to the correct subscribers.
 func TestBus2Subscriptions(t *testing.T) {
-	bus, err := NewEventBus("", "", nil)
+	bus, err := NewEventBus("", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,7 +293,7 @@ func TestBusSubscriptionsCancel(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("cancel=%v", tc.cancel), func(t *testing.T) {
 			subscriptions.Store(0)
-			bus, err := NewEventBus("", "", nil)
+			bus, err := NewEventBus("", nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -396,7 +396,7 @@ func waitFor(t *testing.T, maxWait time.Duration, f func() bool) {
 // TestBusWildcardSubscriptions tests that a single subscription can receive
 // multiple event types using * for glob patterns.
 func TestBusWildcardSubscriptions(t *testing.T) {
-	bus, err := NewEventBus("", "", nil)
+	bus, err := NewEventBus("", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -471,7 +471,7 @@ func TestBusWildcardSubscriptions(t *testing.T) {
 // TestDataPathIsPrependedWithMount tests that "data_path", if present in the
 // metadata, is prepended with the plugin's mount.
 func TestDataPathIsPrependedWithMount(t *testing.T) {
-	bus, err := NewEventBus("", "", nil)
+	bus, err := NewEventBus("", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -591,7 +591,7 @@ func TestDataPathIsPrependedWithMount(t *testing.T) {
 
 // TestBexpr tests go-bexpr filters are evaluated on an event.
 func TestBexpr(t *testing.T) {
-	bus, err := NewEventBus("", "", nil)
+	bus, err := NewEventBus("", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -671,7 +671,7 @@ func TestBexpr(t *testing.T) {
 // TestPipelineCleanedUp ensures pipelines are properly cleaned up after
 // subscriptions are closed.
 func TestPipelineCleanedUp(t *testing.T) {
-	bus, err := NewEventBus("", "", nil)
+	bus, err := NewEventBus("", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/eventbus/bus_test.go
+++ b/vault/eventbus/bus_test.go
@@ -684,7 +684,7 @@ func TestPipelineCleanedUp(t *testing.T) {
 		t.Fatal(err)
 	}
 	// check that the filters are set
-	if !bus.filters.anyMatch(namespace.RootNamespace.Path, eventType) {
+	if !bus.filters.anyMatch(namespace.RootNamespace, eventType) {
 		t.Fatal()
 	}
 	if !bus.broker.IsAnyPipelineRegistered(eventTypeAll) {
@@ -699,7 +699,7 @@ func TestPipelineCleanedUp(t *testing.T) {
 	}
 
 	// and that the filters are cleaned up
-	if bus.filters.anyMatch(namespace.RootNamespace.Path, eventType) {
+	if bus.filters.anyMatch(namespace.RootNamespace, eventType) {
 		t.Fatal()
 	}
 }

--- a/vault/eventbus/filter.go
+++ b/vault/eventbus/filter.go
@@ -1,0 +1,124 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package eventbus
+
+import (
+	"slices"
+	"sync"
+	"sync/atomic"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/ryanuber/go-glob"
+)
+
+// Filters keeps track of all the event patterns that each node is interested in.
+type Filters struct {
+	lock     sync.RWMutex
+	parallel bool
+	self     nodeID
+	filters  map[nodeID]*NodeFilter
+}
+
+// nodeID is used to syntactically indicate that the string is a node's name identifier.
+type nodeID string
+
+// pattern is used to represent one or more combinations of patterns
+type pattern struct {
+	eventTypePattern  string
+	namespacePatterns []string
+}
+
+// NodeFilter keeps track of all patterns that a particular node is interested in.
+type NodeFilter struct {
+	patterns []pattern
+}
+
+func (nf *NodeFilter) match(nsPath string, eventType logical.EventType) bool {
+	if nf == nil {
+		return false
+	}
+	for _, p := range nf.patterns {
+		if glob.Glob(p.eventTypePattern, string(eventType)) {
+			for _, nsp := range p.namespacePatterns {
+				if glob.Glob(nsp, nsPath) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// NewFilters creates an empty set of filters to keep track of each node's pattern interests.
+func NewFilters(self string) *Filters {
+	return &Filters{
+		self:    nodeID(self),
+		filters: map[nodeID]*NodeFilter{},
+	}
+}
+
+// addPattern adds a pattern to a node's list.
+func (f *Filters) addPattern(node nodeID, namespacePatterns []string, eventTypePattern string) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	if _, ok := f.filters[node]; !ok {
+		f.filters[node] = &NodeFilter{}
+	}
+	f.filters[node].patterns = append(f.filters[node].patterns, pattern{eventTypePattern: eventTypePattern, namespacePatterns: namespacePatterns})
+}
+
+// removePattern removes a pattern from a node's list.
+func (f *Filters) removePattern(node nodeID, namespacePatterns []string, eventTypePattern string) {
+	check := pattern{eventTypePattern: eventTypePattern, namespacePatterns: namespacePatterns}
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	filters, ok := f.filters[node]
+	if !ok {
+		return
+	}
+	filters.patterns = slices.DeleteFunc(filters.patterns, func(m pattern) bool {
+		return m.eventTypePattern == check.eventTypePattern &&
+			slices.Equal(m.namespacePatterns, check.namespacePatterns)
+	})
+}
+
+// anyMatch returns true if any node's pattern list matches the arguments.
+func (f *Filters) anyMatch(nsPath string, eventType logical.EventType) bool {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	if f.parallel {
+		wg := sync.WaitGroup{}
+		anyMatched := atomic.Bool{}
+		for _, nf := range f.filters {
+			wg.Add(1)
+			go func(nf *NodeFilter) {
+				if nf.match(nsPath, eventType) {
+					anyMatched.Store(true)
+				}
+				wg.Done()
+			}(nf)
+		}
+		wg.Wait()
+		return anyMatched.Load()
+	} else {
+		for _, nf := range f.filters {
+			if nf.match(nsPath, eventType) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// nodeMatch returns true if the given node's pattern list matches the arguments.
+func (f *Filters) nodeMatch(node nodeID, nsPath string, eventType logical.EventType) bool {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return f.filters[node].match(nsPath, eventType)
+}
+
+// localMatch returns true if the local node's pattern list matches the arguments.
+func (f *Filters) localMatch(nsPath string, eventType logical.EventType) bool {
+	return f.nodeMatch(f.self, nsPath, eventType)
+}

--- a/vault/eventbus/filter_test.go
+++ b/vault/eventbus/filter_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestFilters_AddRemoveMatchLocal checks that basic matching, adding, and removing of patterns all work.
 func TestFilters_AddRemoveMatchLocal(t *testing.T) {
 	f := NewFilters("self")
 
@@ -24,6 +25,7 @@ func TestFilters_AddRemoveMatchLocal(t *testing.T) {
 	assert.False(t, f.anyMatch("ns1", "abc"))
 }
 
+// TestFilters_ParallelAnyMatch checks that anyMatch works with parallel set to true.
 func TestFilters_ParallelAnyMatch(t *testing.T) {
 	f := NewFilters("self")
 	f.parallel = true

--- a/vault/eventbus/filter_test.go
+++ b/vault/eventbus/filter_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package eventbus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilters_AddRemoveMatchLocal(t *testing.T) {
+	f := NewFilters("self")
+
+	assert.False(t, f.localMatch("ns1", "abc"))
+	assert.False(t, f.anyMatch("ns1", "abc"))
+	f.addPattern("self", []string{"ns1"}, "abc")
+	assert.True(t, f.localMatch("ns1", "abc"))
+	assert.False(t, f.localMatch("ns1", "abcd"))
+	assert.True(t, f.anyMatch("ns1", "abc"))
+	assert.False(t, f.anyMatch("ns1", "abcd"))
+	f.removePattern("self", []string{"ns1"}, "abc")
+	assert.False(t, f.localMatch("ns1", "abc"))
+	assert.False(t, f.anyMatch("ns1", "abc"))
+}
+
+func TestFilters_ParallelAnyMatch(t *testing.T) {
+	f := NewFilters("self")
+	f.parallel = true
+
+	f.addPattern("self", []string{"ns1"}, "abc")
+	assert.True(t, f.anyMatch("ns1", "abc"))
+	assert.False(t, f.anyMatch("ns1", "abcd"))
+}

--- a/vault/eventbus/filter_test.go
+++ b/vault/eventbus/filter_test.go
@@ -6,31 +6,26 @@ package eventbus
 import (
 	"testing"
 
+	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/stretchr/testify/assert"
 )
 
 // TestFilters_AddRemoveMatchLocal checks that basic matching, adding, and removing of patterns all work.
 func TestFilters_AddRemoveMatchLocal(t *testing.T) {
 	f := NewFilters("self")
+	ns := &namespace.Namespace{
+		ID:   "ns1",
+		Path: "ns1",
+	}
 
-	assert.False(t, f.localMatch("ns1", "abc"))
-	assert.False(t, f.anyMatch("ns1", "abc"))
-	f.addPattern("self", []string{"ns1"}, "abc")
-	assert.True(t, f.localMatch("ns1", "abc"))
-	assert.False(t, f.localMatch("ns1", "abcd"))
-	assert.True(t, f.anyMatch("ns1", "abc"))
-	assert.False(t, f.anyMatch("ns1", "abcd"))
-	f.removePattern("self", []string{"ns1"}, "abc")
-	assert.False(t, f.localMatch("ns1", "abc"))
-	assert.False(t, f.anyMatch("ns1", "abc"))
-}
-
-// TestFilters_ParallelAnyMatch checks that anyMatch works with parallel set to true.
-func TestFilters_ParallelAnyMatch(t *testing.T) {
-	f := NewFilters("self")
-	f.parallel = true
-
-	f.addPattern("self", []string{"ns1"}, "abc")
-	assert.True(t, f.anyMatch("ns1", "abc"))
-	assert.False(t, f.anyMatch("ns1", "abcd"))
+	assert.False(t, f.localMatch(ns, "abc"))
+	assert.False(t, f.anyMatch(ns, "abc"))
+	f.addNsPattern("self", ns, "abc")
+	assert.True(t, f.localMatch(ns, "abc"))
+	assert.False(t, f.localMatch(ns, "abcd"))
+	assert.True(t, f.anyMatch(ns, "abc"))
+	assert.False(t, f.anyMatch(ns, "abcd"))
+	f.removeNsPattern("self", ns, "abc")
+	assert.False(t, f.localMatch(ns, "abc"))
+	assert.False(t, f.anyMatch(ns, "abc"))
 }


### PR DESCRIPTION
This adds a very basic implementation of a list of namespace+eventType combinations that each node is interested in by just running the glob operations in for-loops. Some parallelization is possible, but not enabled by default.

It only wires up keeping track of what the local event bus is interested in for now (but doesn't use it yet to filter messages).