### PR TITLE
cli: Improve error handling for plugin commands

### DIFF
--- a/changelog/24250.txt
+++ b/changelog/24250.txt
@@ -1,0 +1,6 @@
+```release-note:change
+cli: `vault plugin info` and `vault plugin deregister` now require 2 positional arguments instead of accepting either 1 or 2.
+```
+```release-note:improvement
+cli: Improved error messages for `vault plugin` sub-commands.
+```

--- a/command/plugin_deregister.go
+++ b/command/plugin_deregister.go
@@ -85,15 +85,16 @@ func (c *PluginDeregisterCommand) Run(args []string) int {
 
 	var pluginNameRaw, pluginTypeRaw string
 	args = f.Args()
-	switch len(args) {
+	positionalArgsCount := len(args)
+	switch positionalArgsCount {
 	case 0, 1:
-		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 2, got %d)", len(args)))
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 2, got %d)", positionalArgsCount))
 		return 1
 	case 2:
 		pluginTypeRaw = args[0]
 		pluginNameRaw = args[1]
 	default:
-		c.UI.Error(fmt.Sprintf("Too many arguments (expected 2, got %d)", len(args)))
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 2, got %d)", positionalArgsCount))
 		return 1
 	}
 
@@ -119,11 +120,11 @@ func (c *PluginDeregisterCommand) Run(args []string) int {
 
 	// The deregister endpoint returns 200 if the plugin doesn't exist, so first
 	// try fetching the plugin to help improve info printed to the user.
-	// 404 => Return early with a descriptive message
-	// Other error => Continue attempting to deregister the plugin anyway
-	// Plugin exists but is builtin => Error early
+	// 404 => Return early with a descriptive message.
+	// Other error => Continue attempting to deregister the plugin anyway.
+	// Plugin exists but is builtin => Error early.
 	// Otherwise => If deregister succeeds, we can report that the plugin really
-	// 				was deregistered (and not just already absent)
+	//              was deregistered (and not just already absent).
 	var pluginExists bool
 	if info, err := client.Sys().GetPluginWithContext(context.Background(), &api.GetPluginInput{
 		Name:    pluginName,
@@ -137,7 +138,7 @@ func (c *PluginDeregisterCommand) Run(args []string) int {
 		// Best-effort check, continue trying to deregister.
 	} else if info != nil {
 		if info.Builtin {
-			c.UI.Error(fmt.Sprintf("Plugin %q (type: %q) is a builtin plugin", pluginName, pluginType))
+			c.UI.Error(fmt.Sprintf("Plugin %q (type: %q) is a builtin plugin and cannot be deregistered", pluginName, pluginType))
 			return 2
 		}
 		pluginExists = true

--- a/command/plugin_deregister.go
+++ b/command/plugin_deregister.go
@@ -4,7 +4,9 @@
 package command
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	semver "github.com/hashicorp/go-version"
@@ -84,17 +86,14 @@ func (c *PluginDeregisterCommand) Run(args []string) int {
 	var pluginNameRaw, pluginTypeRaw string
 	args = f.Args()
 	switch len(args) {
-	case 0:
-		c.UI.Error("Not enough arguments (expected 1, or 2, got 0)")
+	case 0, 1:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 2, got %d)", len(args)))
 		return 1
-	case 1:
-		pluginTypeRaw = "unknown"
-		pluginNameRaw = args[0]
 	case 2:
 		pluginTypeRaw = args[0]
 		pluginNameRaw = args[1]
 	default:
-		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, or 2, got %d)", len(args)))
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 2, got %d)", len(args)))
 		return 1
 	}
 
@@ -118,7 +117,33 @@ func (c *PluginDeregisterCommand) Run(args []string) int {
 		}
 	}
 
-	if err := client.Sys().DeregisterPlugin(&api.DeregisterPluginInput{
+	// The deregister endpoint returns 200 if the plugin doesn't exist, so first
+	// try fetching the plugin to help improve info printed to the user.
+	// 404 => Return early with a descriptive message
+	// Other error => Continue attempting to deregister the plugin anyway
+	// Plugin exists but is builtin => Error early
+	// Otherwise => If deregister succeeds, we can report that the plugin really
+	// 				was deregistered (and not just already absent)
+	var pluginExists bool
+	if info, err := client.Sys().GetPluginWithContext(context.Background(), &api.GetPluginInput{
+		Name:    pluginName,
+		Type:    pluginType,
+		Version: c.flagPluginVersion,
+	}); err != nil {
+		if respErr, ok := err.(*api.ResponseError); ok && respErr.StatusCode == http.StatusNotFound {
+			c.UI.Output(fmt.Sprintf("Plugin %q (type: %q, version %q) does not exist in the catalog", pluginName, pluginType, c.flagPluginVersion))
+			return 0
+		}
+		// Best-effort check, continue trying to deregister.
+	} else if info != nil {
+		if info.Builtin {
+			c.UI.Error(fmt.Sprintf("Plugin %q (type: %q) is a builtin plugin", pluginName, pluginType))
+			return 2
+		}
+		pluginExists = true
+	}
+
+	if err := client.Sys().DeregisterPluginWithContext(context.Background(), &api.DeregisterPluginInput{
 		Name:    pluginName,
 		Type:    pluginType,
 		Version: c.flagPluginVersion,
@@ -127,6 +152,10 @@ func (c *PluginDeregisterCommand) Run(args []string) int {
 		return 2
 	}
 
-	c.UI.Output(fmt.Sprintf("Success! Deregistered plugin (if it was registered): %s", pluginName))
+	if pluginExists {
+		c.UI.Output(fmt.Sprintf("Success! Deregistered %s plugin: %s", pluginType, pluginName))
+	} else {
+		c.UI.Output(fmt.Sprintf("Success! Deregistered %s plugin (if it was registered): %s", pluginType, pluginName))
+	}
 	return 0
 }

--- a/command/plugin_info.go
+++ b/command/plugin_info.go
@@ -78,21 +78,16 @@ func (c *PluginInfoCommand) Run(args []string) int {
 	var pluginNameRaw, pluginTypeRaw string
 	args = f.Args()
 	switch {
-	case len(args) < 1:
-		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 1 or 2, got %d)", len(args)))
+	case len(args) < 2:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 2, got %d)", len(args)))
 		return 1
 	case len(args) > 2:
-		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1 or 2, got %d)", len(args)))
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 2, got %d)", len(args)))
 		return 1
-
-	// These cases should come after invalid cases have been checked
-	case len(args) == 1:
-		pluginTypeRaw = "unknown"
-		pluginNameRaw = args[0]
-	case len(args) == 2:
-		pluginTypeRaw = args[0]
-		pluginNameRaw = args[1]
 	}
+
+	pluginTypeRaw = args[0]
+	pluginNameRaw = args[1]
 
 	client, err := c.Client()
 	if err != nil {

--- a/command/plugin_info.go
+++ b/command/plugin_info.go
@@ -77,12 +77,13 @@ func (c *PluginInfoCommand) Run(args []string) int {
 
 	var pluginNameRaw, pluginTypeRaw string
 	args = f.Args()
+	positionalArgsCount := len(args)
 	switch {
-	case len(args) < 2:
-		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 2, got %d)", len(args)))
+	case positionalArgsCount < 2:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 2, got %d)", positionalArgsCount))
 		return 1
-	case len(args) > 2:
-		c.UI.Error(fmt.Sprintf("Too many arguments (expected 2, got %d)", len(args)))
+	case positionalArgsCount > 2:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 2, got %d)", positionalArgsCount))
 		return 1
 	}
 

--- a/command/plugin_info_test.go
+++ b/command/plugin_info_test.go
@@ -35,6 +35,12 @@ func TestPluginInfoCommand_Run(t *testing.T) {
 		code int
 	}{
 		{
+			"not_enough_args",
+			[]string{"foo"},
+			"Not enough arguments",
+			1,
+		},
+		{
 			"too_many_args",
 			[]string{"foo", "bar", "fizz"},
 			"Too many arguments",

--- a/command/plugin_reload.go
+++ b/command/plugin_reload.go
@@ -90,12 +90,16 @@ func (c *PluginReloadCommand) Run(args []string) int {
 		return 1
 	}
 
+	positionalArgs := len(f.Args())
 	switch {
+	case positionalArgs != 0:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 0, got %d)", positionalArgs))
+		return 1
 	case c.plugin == "" && len(c.mounts) == 0:
-		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 1, got %d)", len(args)))
+		c.UI.Error("No plugins specified, must specify exactly one of -plugin or -mounts")
 		return 1
 	case c.plugin != "" && len(c.mounts) > 0:
-		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
+		c.UI.Error("Must specify exactly one of -plugin or -mounts")
 		return 1
 	case c.scope != "" && c.scope != "global":
 		c.UI.Error(fmt.Sprintf("Invalid reload scope: %s", c.scope))

--- a/command/plugin_reload_test.go
+++ b/command/plugin_reload_test.go
@@ -46,13 +46,13 @@ func TestPluginReloadCommand_Run(t *testing.T) {
 		{
 			"not_enough_args",
 			nil,
-			"Not enough arguments",
+			"No plugins specified, must specify exactly one of -plugin or -mounts",
 			1,
 		},
 		{
 			"too_many_args",
 			[]string{"-plugin", "foo", "-mounts", "bar"},
-			"Too many arguments",
+			"Must specify exactly one of -plugin or -mounts",
 			1,
 		},
 	}
@@ -147,7 +147,7 @@ func TestPluginReloadStatusCommand_Run(t *testing.T) {
 			client, closer := testVaultServer(t)
 			defer closer()
 
-			ui, cmd := testPluginReloadCommand(t)
+			ui, cmd := testPluginReloadStatusCommand(t)
 			cmd.client = client
 
 			args := append([]string{}, tc.args...)


### PR DESCRIPTION
`vault plugin info` and `vault plugin deregister` have accepted either 1 or 2 positional args since we introduced types for plugins way back in v1.0.0 (#5536). This PR drops CLI support for type-less plugins on those commands, but the API can still be used to query any extremely old legacy plugins (although based on the plugin catalog's [UpgradePlugins](https://github.com/hashicorp/vault/blob/511ce92852eea274f0a72a8b718c3217de47dbcb/vault/plugin_catalog.go#L753) function, run during unseal, I don't think it should be possible for v1.0.0+ versions of Vault to have functioning type-less plugins). In return, we can get a much nicer UX on the CLI. It also improves the error reporting for `vault plugin reload`, which was simply buggy.

Examples of previous bad behaviour:

```shell-session
# The type is missing, but it's hard to give a good error message when it's valid to not include it.
$ vault plugin info github
No value found for plugin "github"

# Plugin not actually deleted because a type-less artifactory plugin does not exist
$ vault plugin deregister artifactory
Success! Deregistered plugin (if it was registered): artifactory
$ vault plugin list | grep artifactory
artifactory

# reload takes flags instead of positional arguments
$ vault plugin reload artifactory
Not enough arguments (expected 1, got 1)
```

To exercise all the possible `vault plugin deregister` outcomes and get a feel for the UX:

```bash
# Setup Vault dev server with plugin_directory config
tee local/config.hcl <<EOF
plugin_directory = "$(pwd)/local/config.hcl
EOF
VAULT_DEV_ROOT_TOKEN_ID=root vault server -dev -config=local/config.hcl
export VAULT_ADDR=http://127.0.0.1:8200
export VAULT_TOKEN=root
vault policy write deregister-only -<<EOF
$(vault plugin deregister -output-policy auth github)
EOF

# Build a plugin
go build -o local/plugins/github builtin/credential/github/cmd/github/main.go
SHA256="(shasum -a 256 local/plugins/github | cut -f1 -d' ')"
vault plugin register -sha256=$SHA256 auth github
```

```shell-session
$ vault plugin deregister auth github
Success! Deregistered auth plugin: github

$ vault plugin deregister auth github
Plugin "github" (type: "auth") is a builtin plugin
# Exit code 2

$ vault plugin deregister auth github2
Plugin "github2" (type: "auth", version "") does not exist in the catalog
# Exit code 0

$ VAULT_TOKEN="$(vault token create -policy=deregister-only -field=token)" vault plugin deregister auth github
Success! Deregistered auth plugin (if it was registered): github
```