### PR TITLE
Check that multi-seal wrappers provide unique key IDs

### DIFF
--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -514,7 +514,7 @@ func TestRaft_SnapshotAPI_MidstreamFailure(t *testing.T) {
 	// defer goleak.VerifyNone(t)
 	t.Parallel()
 
-	seal, setErr := vaultseal.NewToggleableTestSeal(nil)
+	seal, wrappers := vaultseal.NewTestSeal(nil)
 	autoSeal := vault.NewAutoSeal(seal)
 	cluster, _ := raftCluster(t, &RaftClusterOpts{
 		NumCores: 1,
@@ -547,7 +547,7 @@ func TestRaft_SnapshotAPI_MidstreamFailure(t *testing.T) {
 		wg.Done()
 	}()
 
-	setErr[0](errors.New("seal failure"))
+	wrappers[0].SetError(errors.New("seal failure"))
 	// Take a snapshot
 	err := leaderClient.Sys().RaftSnapshot(w)
 	w.Close()

--- a/vault/seal/seal.go
+++ b/vault/seal/seal.go
@@ -203,13 +203,13 @@ func haveCommonSeal(existingSealKmsConfigs, newSealKmsConfigs []*configutil.KMS)
 }
 
 func findRenamedDisabledSeals(configs []*configutil.KMS) []*configutil.KMS {
-	diabledSeals := []*configutil.KMS{}
+	disabledSeals := []*configutil.KMS{}
 	for _, seal := range configs {
 		if seal.Disabled && strings.HasSuffix(seal.Name, configutil.KmsRenameDisabledSuffix) {
-			diabledSeals = append(diabledSeals, seal)
+			disabledSeals = append(disabledSeals, seal)
 		}
 	}
-	return diabledSeals
+	return disabledSeals
 }
 
 func compareKMSConfigByNameAndType() cmp.Option {

--- a/vault/seal/seal.go
+++ b/vault/seal/seal.go
@@ -748,7 +748,7 @@ GATHER_RESULTS:
 	return nil, false, errors.New("context timeout exceeded")
 }
 
-// tryDecrypt returns the plaintext and a flad indicating whether the decryption was done by the "unwrapSeal" (see
+// tryDecrypt returns the plaintext and a flag indicating whether the decryption was done by the "unwrapSeal" (see
 // sealWrapMigration.Decrypt).
 func (a *access) tryDecrypt(ctx context.Context, sealWrapper *SealWrapper, ciphertextByKeyId map[string]*wrapping.BlobInfo, options []wrapping.Option) ([]byte, bool, error) {
 	now := time.Now()

--- a/vault/seal/seal_test.go
+++ b/vault/seal/seal_test.go
@@ -4,6 +4,9 @@
 package seal
 
 import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
@@ -94,4 +97,48 @@ func Test_keyIdSet(t *testing.T) {
 		runTest(tt.name+".set()", useSet)
 		runTest(tt.name+".setIDs", useSetIds)
 	}
+}
+
+// Test_Encrypt_duplicate_keyIds verifies that if two seal wrappers produce the same Key ID, an error
+// will be returned for both.
+func Test_Encrypt_duplicate_keyIds(t *testing.T) {
+	ctx := context.Background()
+
+	setId := func(w *SealWrapper, keyId string) {
+		testWrapper := w.Wrapper.(*ToggleableWrapper).Wrapper.(*wrapping.TestWrapper)
+		testWrapper.SetKeyId(keyId)
+	}
+
+	getId := func(w *SealWrapper) string {
+		id, err := w.Wrapper.KeyId(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return id
+	}
+
+	access, _ := NewTestSeal(&TestSealOpts{WrapperCount: 3})
+
+	// Set up - make the key IDs the same for the last two wrappers
+	wrappers := access.GetAllSealWrappersByPriority()
+	setId(wrappers[1], "this-key-is-duplicated")
+	setId(wrappers[2], "this-key-is-duplicated")
+
+	// Some sanity checks
+	require.NotEqual(t, wrappers[0].Name, wrappers[1].Name)
+	require.NotEqual(t, wrappers[1].Name, wrappers[2].Name)
+	require.NotEqual(t, getId(wrappers[0]), getId(wrappers[1]))
+	require.Equal(t, getId(wrappers[1]), getId(wrappers[2]))
+
+	// Encrypt a value
+	mwv, errorMap := access.Encrypt(ctx, []byte("Rinconete y Cortadillo"))
+
+	// Assertions
+	require.NotNilf(t, mwv, "seal 0 should have succeeded")
+
+	requireDuplicateErr := func(w *SealWrapper) {
+		require.ErrorContains(t, errorMap[w.Name], fmt.Sprintf("seal %v has returned duplicate key ID", w.Name))
+	}
+	requireDuplicateErr(wrappers[1])
+	requireDuplicateErr(wrappers[2])
 }

--- a/vault/seal/seal_testing.go
+++ b/vault/seal/seal_testing.go
@@ -75,43 +75,6 @@ type TestSealWrapperOpts struct {
 	WrapperCount int
 }
 
-func CreateTestSealWrapperOpts(opts *TestSealWrapperOpts) *TestSealWrapperOpts {
-	if opts == nil {
-		opts = new(TestSealWrapperOpts)
-	}
-	if opts.WrapperCount == 0 {
-		opts.WrapperCount = 1
-	}
-	if opts.Logger == nil {
-		opts.Logger = logging.NewVaultLogger(hclog.Debug)
-	}
-	return opts
-}
-
-func CreateTestSealWrappers(opts *TestSealWrapperOpts) []*SealWrapper {
-	opts = CreateTestSealWrapperOpts(opts)
-	wrappers := make([]*ToggleableWrapper, opts.WrapperCount)
-	sealWrappers := make([]*SealWrapper, opts.WrapperCount)
-	ctx := context.Background()
-	for i := 0; i < opts.WrapperCount; i++ {
-		wrappers[i] = &ToggleableWrapper{Wrapper: wrapping.NewTestWrapper(opts.Secret)}
-		wrapperType, err := wrappers[i].Type(ctx)
-		if err != nil {
-			panic(err)
-		}
-		sealWrappers[i] = NewSealWrapper(
-			wrappers[i],
-			i+1,
-			fmt.Sprintf("%s-%d", opts.Name, i+1),
-			wrapperType.String(),
-			false,
-			true,
-		)
-	}
-
-	return sealWrappers
-}
-
 type ToggleableWrapper struct {
 	wrapping.Wrapper
 	wrapperType  *wrapping.WrapperType

--- a/vault/seal/seal_testing.go
+++ b/vault/seal/seal_testing.go
@@ -70,7 +70,12 @@ func NewTestSeal(opts *TestSealOpts) (Access, []*ToggleableWrapper) {
 	sealWrappers := make([]*SealWrapper, opts.WrapperCount)
 	ctx := context.Background()
 	for i := 0; i < opts.WrapperCount; i++ {
+		wrapperName := fmt.Sprintf("%s-%d", opts.Name, i+1)
 		wrappers[i] = &ToggleableWrapper{Wrapper: wrapping.NewTestWrapper(opts.Secrets[i])}
+		_, err := wrappers[i].Wrapper.SetConfig(context.Background(), wrapping.WithKeyId(wrapperName))
+		if err != nil {
+			panic(err)
+		}
 		wrapperType, err := wrappers[i].Type(ctx)
 		if err != nil {
 			panic(err)
@@ -78,7 +83,7 @@ func NewTestSeal(opts *TestSealOpts) (Access, []*ToggleableWrapper) {
 		sealWrappers[i] = NewSealWrapper(
 			wrappers[i],
 			i+1,
-			fmt.Sprintf("%s-%d", opts.Name, i+1),
+			wrapperName,
 			wrapperType.String(),
 			false,
 			true,

--- a/vault/seal/seal_testing.go
+++ b/vault/seal/seal_testing.go
@@ -112,40 +112,6 @@ func CreateTestSealWrappers(opts *TestSealWrapperOpts) []*SealWrapper {
 	return sealWrappers
 }
 
-func NewToggleableTestSeal(opts *TestSealOpts) (Access, []func(error)) {
-	opts = NewTestSealOpts(opts)
-
-	wrappers := make([]*ToggleableWrapper, opts.WrapperCount)
-	sealWrappers := make([]*SealWrapper, opts.WrapperCount)
-	funcs := make([]func(error), opts.WrapperCount)
-	ctx := context.Background()
-	for i := 0; i < opts.WrapperCount; i++ {
-		w := &ToggleableWrapper{Wrapper: wrapping.NewTestWrapper(opts.Secret)}
-		wrapperType, err := w.Type(ctx)
-		if err != nil {
-			panic(err)
-		}
-
-		wrappers[i] = w
-		sealWrappers[i] = NewSealWrapper(
-			wrappers[i],
-			i+1,
-			fmt.Sprintf("%s-%d", opts.Name, i+1),
-			wrapperType.String(),
-			false,
-			true,
-		)
-		funcs[i] = w.SetError
-	}
-
-	sealAccess, err := NewAccessFromSealWrappers(nil, opts.Generation, true, sealWrappers)
-	if err != nil {
-		panic(err)
-	}
-
-	return sealAccess, funcs
-}
-
 type ToggleableWrapper struct {
 	wrapping.Wrapper
 	wrapperType  *wrapping.WrapperType

--- a/vault/seal_autoseal_test.go
+++ b/vault/seal_autoseal_test.go
@@ -183,7 +183,7 @@ func TestAutoSeal_HealthCheck(t *testing.T) {
 	metrics.NewGlobal(metricsConf, inmemSink)
 
 	pBackend := newTestBackend(t)
-	testSealAccess, setErrs := seal.NewToggleableTestSeal(&seal.TestSealOpts{Name: "health-test"})
+	testSealAccess, wrappers := seal.NewTestSeal(&seal.TestSealOpts{Name: "health-test"})
 	core, _, _ := TestCoreUnsealedWithConfig(t, &CoreConfig{
 		MetricSink: metricsutil.NewClusterMetricSink("", inmemSink),
 		Physical:   pBackend,
@@ -195,7 +195,7 @@ func TestAutoSeal_HealthCheck(t *testing.T) {
 	core.seal = autoSeal
 	autoSeal.StartHealthCheck()
 	defer autoSeal.StopHealthCheck()
-	setErrs[0](errors.New("disconnected"))
+	wrappers[0].SetError(errors.New("disconnected"))
 
 	tries := 10
 	for tries = 10; tries > 0; tries-- {
@@ -208,7 +208,7 @@ func TestAutoSeal_HealthCheck(t *testing.T) {
 		t.Fatalf("Expected to detect unhealthy seals")
 	}
 
-	setErrs[0](nil)
+	wrappers[0].SetError(nil)
 	time.Sleep(50 * time.Millisecond)
 	if !autoSeal.Healthy() {
 		t.Fatal("Expected seals to be healthy")
@@ -216,8 +216,8 @@ func TestAutoSeal_HealthCheck(t *testing.T) {
 }
 
 func TestAutoSeal_BarrierSealConfigType(t *testing.T) {
-	singleWrapperAccess, _ := seal.NewToggleableTestSeal(&seal.TestSealOpts{WrapperCount: 1})
-	multipleWrapperAccess, _ := seal.NewToggleableTestSeal(&seal.TestSealOpts{WrapperCount: 2})
+	singleWrapperAccess, _ := seal.NewTestSeal(&seal.TestSealOpts{WrapperCount: 1})
+	multipleWrapperAccess, _ := seal.NewTestSeal(&seal.TestSealOpts{WrapperCount: 2})
 
 	require.Equalf(t, singleWrapperAccess.GetAllSealWrappersByPriority()[0].SealConfigType, NewAutoSeal(singleWrapperAccess).BarrierSealConfigType().String(),
 		"autoseals that have a single seal wrapper report that wrapper's as the barrier seal type")

--- a/vault/seal_testing_util.go
+++ b/vault/seal_testing_util.go
@@ -10,6 +10,8 @@ import (
 	testing "github.com/mitchellh/go-testing-interface"
 )
 
+// NewTestSeal creates a new seal for testing. If you want to use the same seal multiple times, such as for
+// a cluster, use NewTestSealFunc instead.
 func NewTestSeal(t testing.T, opts *seal.TestSealOpts) Seal {
 	t.Helper()
 	opts = seal.NewTestSealOpts(opts)
@@ -49,4 +51,28 @@ func NewTestSeal(t testing.T, opts *seal.TestSealOpts) Seal {
 		access, _ := seal.NewTestSeal(opts)
 		return NewAutoSeal(access)
 	}
+}
+
+// NewTestSealFunc returns a function that creates seals. All such seals will have TestWrappers that
+// share the same secret, thus making them equivalent.
+func NewTestSealFunc(t testing.T, opts *seal.TestSealOpts) func() Seal {
+	testSeal := NewTestSeal(t, opts)
+
+	return func() Seal {
+		return cloneTestSeal(t, testSeal)
+	}
+}
+
+// CloneTestSeal creates a new test seal that shares the same seal wrappers as `testSeal`.
+func cloneTestSeal(t testing.T, testSeal Seal) Seal {
+	logger := corehelpers.NewTestLogger(t).Named("sealAccess")
+
+	access, err := seal.NewAccessFromSealWrappers(logger, testSeal.GetAccess().Generation(), testSeal.GetAccess().GetSealGenerationInfo().IsRewrapped(), testSeal.GetAccess().GetAllSealWrappersByPriority())
+	if err != nil {
+		t.Fatal("error cloning seal %v", err)
+	}
+	if testSeal.StoredKeysSupported() == seal.StoredKeysNotSupported {
+		return NewDefaultSeal(access)
+	}
+	return NewAutoSeal(access)
 }


### PR DESCRIPTION
The Access object which manages the KMS encryption wrappers relies on the wrappers providing unique key IDs.

This PR adds a guard to Access.Encrypt to verify that the key IDs are unique. If any wrappers produce duplicates, their BlobInfo is replaced by an error.

This PR also fixes various unit tests that were using test wrappers that were equivalent when they were meant not to be so.