### PR TITLE
Fix failing LDAP test with new attribute

### DIFF
--- a/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
+++ b/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
@@ -18,7 +18,10 @@
       <KnownSecondariesTable @secondaries={{this.replicationAttrs.secondaries}} />
     {{else}}
       <Hds::ApplicationState as |A|>
-        <A.Header @title="No known {{this.cluster.replicationMode}} secondary clusters associated with this cluster" />
+        <A.Header
+          @title="No known {{this.cluster.replicationMode}} secondary clusters associated with this cluster"
+          data-test-empty-state-title
+        />
         <A.Body
           @text="Associated secondary clusters will be listed here. Add your first secondary cluster to get started."
         />

--- a/ui/tests/acceptance/enterprise-replication-test.js
+++ b/ui/tests/acceptance/enterprise-replication-test.js
@@ -123,7 +123,7 @@ module('Acceptance | Enterprise | replication', function (hooks) {
     await click('[data-test-replication-link="details"]');
 
     assert
-      .dom(`[data-test-secondaries=row-for-${secondaryName}]`)
+      .dom(`[data-test-secondaries-node=${secondaryName}]`)
       .exists('shows a table row the recently added secondary');
 
     // nav to DR

--- a/ui/tests/helpers/openapi/auth-model-attributes.js
+++ b/ui/tests/helpers/openapi/auth-model-attributes.js
@@ -822,6 +822,12 @@ const ldap = {
       fieldGroup: 'default',
       type: 'number',
     },
+    passwordPolicy: {
+      editType: 'string',
+      fieldGroup: 'default',
+      helpText: 'Password policy to use to rotate the root password',
+      type: 'string',
+    },
     requestTimeout: {
       editType: 'ttl',
       helpText:


### PR DESCRIPTION
This PR address two sets of Failures for enterprise test:

1. LDAP failure. I believe this failure started because of this [PR](https://github.com/hashicorp/vault/pull/24099/files#diff-488a96fb64f816186eb8d54271a15655a0758c77c0d7375d4c5396020d11e211R54) which appears to add Password Policy to the LDAP configuration Open API.

2. Replication. Due to this [PR](https://github.com/hashicorp/vault/issues/24257). 

Locally, now all enterprise tests are passing.
