### PR TITLE
Correct required policy in static secret caching docs

### DIFF
--- a/website/content/docs/agent-and-proxy/proxy/caching/static-secret-caching.mdx
+++ b/website/content/docs/agent-and-proxy/proxy/caching/static-secret-caching.mdx
@@ -18,18 +18,25 @@ appropriate cache updates.
 1. Enable [auto-auth](/vault/docs/agent-and-proxy/autoauth).
 1. Create an auto-auth token with permission to subscribe to KV event updates
 with the [Vault event system](/vault/docs/concepts/events). For example, to
-create a policy that grants access to static secret (KVv1 and KVv2) events:
+create a policy that grants access to static secret (KVv1 and KVv2) events,
+we need permission to subscribe to the `events` endpoint, as well as the
+`list` and `subscribe` permissions on KV secrets we want to get secrets
+from:
  ```hcl
- path "sys/events/subscribe/kv*" {
-   capabilities = ["read"]
- }
+  path "sys/events/subscribe/kv*" {
+    capabilities = ["read"]
+  }
+
+  path "*" {
+    capabilities = ["list", "subscribe"]
+    subscribe_event_types = ["kv*"]
+  }
    ```
 
 Subscribing to KV events means that Proxy receives updates as soon as a secret
 changes, which reduces staleness in the cache. Vault Proxy only checks for a
 secret update if an event notification indicates that the related secret was
 updated.
-
 
 ## Step 2: Ensure tokens have `capabilities-self` access
 
@@ -76,7 +83,7 @@ same token can then access this secret from the cache instead of Vault.
 Vault Proxy uses the [event system](/vault/docs/concepts/events) to keep the
 cache up to date. It monitors the KV event feed for events related to any secret
 currently stored in the cache, including modification events like updates and
-deletes. When Proxy detects a change in a cached secrete, it will update or
+deletes. When Proxy detects a change in a cached secret, it will update or
 evict the cache entry as appropriate.
 
 Vault Proxy also checks and refreshes the access permissions of known tokens


### PR DESCRIPTION
Spotted by @ccapurso during testing of the feature. It seems to have been a new add to the event system that I missed when writing the docs.