### PR TITLE
Add log_rotate_enabled option

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -1125,6 +1125,7 @@ func (c *AgentCommand) newLogger() (log.InterceptLogger, error) {
 		LogLevel:          logLevel,
 		LogFormat:         logFormat,
 		LogFilePath:       c.config.LogFile,
+		LogRotateEnabled:  c.config.LogRotateEnabled,
 		LogRotateDuration: logRotateDuration,
 		LogRotateBytes:    c.config.LogRotateBytes,
 		LogRotateMaxFiles: c.config.LogRotateMaxFiles,

--- a/command/commands.go
+++ b/command/commands.go
@@ -150,6 +150,8 @@ const (
 	flagNameCombineLogs = "combine-logs"
 	// flagNameLogFile is used to specify the path to the log file that Vault should use for logging
 	flagNameLogFile = "log-file"
+	// flagNameLogRotateEnabled is used to enable vault's log rotation behavior
+	flagNameLogRotateEnabled = "log-rotate-enabled"
 	// flagNameLogRotateBytes is the flag used to specify the number of bytes a log file should be before it is rotated.
 	flagNameLogRotateBytes = "log-rotate-bytes"
 	// flagNameLogRotateDuration is the flag used to specify the duration after which a log file should be rotated.

--- a/command/log_flags.go
+++ b/command/log_flags.go
@@ -18,6 +18,7 @@ type logFlags struct {
 	flagLogLevel          string
 	flagLogFormat         string
 	flagLogFile           string
+	flagLogRotateEnabled  bool
 	flagLogRotateBytes    int
 	flagLogRotateDuration string
 	flagLogRotateMaxFiles int
@@ -64,6 +65,13 @@ func (f *FlagSet) addLogFlags(l *logFlags) {
 		Name:   flagNameLogFile,
 		Target: &l.flagLogFile,
 		Usage:  "Path to the log file that Vault should use for logging",
+	})
+
+	f.BoolVar(&BoolVar{
+		Name:    flagNameLogRotateEnabled,
+		Target:  &l.flagLogRotateEnabled,
+		Default: true,
+		Usage:   "Enable automatic log rotation. Defaults to true",
 	})
 
 	f.IntVar(&IntVar{
@@ -159,6 +167,11 @@ func (f *FlagSets) applyLogConfigOverrides(config *configutil.SharedConfig) {
 	// Update log file name
 	if val, found := p.overrideValue(flagNameLogFile, ""); found {
 		config.LogFile = val
+	}
+
+	// Update log rotate enabled flag
+	if val, found := p.overrideValue(flagNameLogRotateEnabled, ""); found {
+		config.LogRotateEnabled, _ = strconv.ParseBool(val)
 	}
 
 	// Update log rotation duration

--- a/command/proxy.go
+++ b/command/proxy.go
@@ -1045,6 +1045,7 @@ func (c *ProxyCommand) newLogger() (log.InterceptLogger, error) {
 		LogLevel:          logLevel,
 		LogFormat:         logFormat,
 		LogFilePath:       c.config.LogFile,
+		LogRotateEnabled:  c.config.LogRotateEnabled,
 		LogRotateDuration: logRotateDuration,
 		LogRotateBytes:    c.config.LogRotateBytes,
 		LogRotateMaxFiles: c.config.LogRotateMaxFiles,

--- a/command/server.go
+++ b/command/server.go
@@ -1859,6 +1859,7 @@ func (c *ServerCommand) configureLogging(config *server.Config) (hclog.Intercept
 		LogLevel:          logLevel,
 		LogFormat:         logFormat,
 		LogFilePath:       config.LogFile,
+		LogRotateEnabled:  config.LogRotateEnabled,
 		LogRotateDuration: logRotateDuration,
 		LogRotateBytes:    config.LogRotateBytes,
 		LogRotateMaxFiles: config.LogRotateMaxFiles,

--- a/helper/logging/logfile_test.go
+++ b/helper/logging/logfile_test.go
@@ -21,7 +21,7 @@ func TestLogFile_openNew(t *testing.T) {
 		duration: defaultRotateDuration,
 	}
 
-	err := logFile.openNew()
+	err := logFile.open()
 	require.NoError(t, err)
 
 	msg := "[INFO] Something"

--- a/helper/logging/logger.go
+++ b/helper/logging/logger.go
@@ -40,6 +40,9 @@ type LogConfig struct {
 	// LogFilePath is the path to write the logs to the user specified file.
 	LogFilePath string
 
+	// LogRotateEnabled is used to enable vault's log rotation behavior
+	LogRotateEnabled bool
+
 	// LogRotateDuration is the user specified time to rotate logs
 	LogRotateDuration time.Duration
 
@@ -129,6 +132,7 @@ func Setup(config *LogConfig, w io.Writer) (log.InterceptLogger, error) {
 		logFile := &LogFile{
 			fileName:         fileName,
 			logPath:          dir,
+			rotateEnabled:    config.LogRotateEnabled,
 			duration:         config.LogRotateDuration,
 			maxBytes:         config.LogRotateBytes,
 			maxArchivedFiles: config.LogRotateMaxFiles,
@@ -136,7 +140,7 @@ func Setup(config *LogConfig, w io.Writer) (log.InterceptLogger, error) {
 		if err := logFile.pruneFiles(); err != nil {
 			return nil, fmt.Errorf("failed to prune log files: %w", err)
 		}
-		if err := logFile.openNew(); err != nil {
+		if err := logFile.open(); err != nil {
 			return nil, fmt.Errorf("failed to setup logging: %w", err)
 		}
 		writers = append(writers, logFile)

--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -44,6 +44,7 @@ type SharedConfig struct {
 	LogFile              string      `hcl:"log_file"`
 	LogFormat            string      `hcl:"log_format"`
 	LogLevel             string      `hcl:"log_level"`
+	LogRotateEnabled     bool        `hcl:"log_rotate_enabled"`
 	LogRotateBytes       int         `hcl:"log_rotate_bytes"`
 	LogRotateBytesRaw    interface{} `hcl:"log_rotate_bytes"`
 	LogRotateDuration    string      `hcl:"log_rotate_duration"`

--- a/website/content/docs/commands/server.mdx
+++ b/website/content/docs/commands/server.mdx
@@ -67,8 +67,11 @@ flags](/vault/docs/commands) included on all commands.
   is appended. For example, setting `log-file` to `/var/log/` would result in a log
   file path of `/var/log/vault-{timestamp}.log`. `log-file` can be combined with
   [`-log-rotate-bytes`](#_log_rotate_bytes) and [`-log-rotate-duration`](#_log_rotate_duration)
-  for a fine-grained log rotation experience. This output operates in addition to existing 
+  for a fine-grained log rotation experience. This output operates in addition to existing
   outputs, meaning logs will continue to be written to journald / stdout (where appropriate).
+
+- `-log-rotate-enabled` ((#\_log_rotate_enabled)) - If set to false, disables all automatic
+  log rotation behavior, including disabling appending log filename timestamp. Defaults to `true`.
 
 - `-log-rotate-bytes` ((#\_log_rotate_bytes)) - to specify the number of
   bytes that should be written to a log before it needs to be rotated. Unless specified,


### PR DESCRIPTION
Add configuration setting/flag `-log-rotate-enabled`. Defaults to `true`, maintaining current behavior.

When set to `false`, disables vault's internal log rotation _and_ does not alter the log filename with an appended timestamp.

Closes [VAULT-24265](https://github.com/hashicorp/vault/issues/24265)