### PR TITLE
UI: Prevent replication disable action from sending data payload

### DIFF
--- a/changelog/24292.txt
+++ b/changelog/24292.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix payload sent when disabling replication
+```

--- a/ui/lib/core/addon/components/replication-action-disable.js
+++ b/ui/lib/core/addon/components/replication-action-disable.js
@@ -9,4 +9,11 @@ import layout from '../templates/components/replication-action-disable';
 export default Actions.extend({
   layout,
   tagName: '',
+
+  actions: {
+    onSubmit(replicationMode, clusterMode, evt) {
+      // No data is submitted for disable request
+      return this.onSubmit(replicationMode, clusterMode, null, evt);
+    },
+  },
 });

--- a/ui/lib/core/addon/templates/components/replication-action-disable.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-disable.hbs
@@ -31,8 +31,8 @@
   @isActive={{this.isModalActive}}
   @confirmText={{this.model.replicationModeForDisplay}}
   @toConfirmMsg="disabling {{this.model.replicationModeForDisplay}} Replication on this cluster"
-  @onConfirm={{action
-    "onSubmit"
+  @onConfirm={{fn
+    (action "onSubmit")
     "disable"
     (if (eq this.model.replicationAttrs.modeForUrl "bootstrapping") this.mode this.model.replicationAttrs.modeForUrl)
   }}


### PR DESCRIPTION
Previously we were incorrectly sending a payload on the `replication/disable` endpoint, which returned a warning. This PR fixes the disable callback so that no payload is sent. 

Before:
<img width="1512" alt="Warning shown after disable" src="https://github.com/hashicorp/vault/assets/82459713/c218a4dd-808e-4dc1-b519-e35525f47d0c">
