### PR TITLE
UI: HDS adoption update <AlertInline> component to use Hds::Alert

### DIFF
--- a/changelog/24299.txt
+++ b/changelog/24299.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Update AlertInline component to use Helios Design System Alert component
+```

--- a/ui/app/components/auth-saml.hbs
+++ b/ui/app/components/auth-saml.hbs
@@ -22,7 +22,6 @@
         />
       </div>
       <AlertInline
-        @sizeSmall={{true}}
         class="has-top-padding-s"
         @type="info"
         @message="Leave blank to sign in with the default role if one is configured."

--- a/ui/app/components/auth-saml.hbs
+++ b/ui/app/components/auth-saml.hbs
@@ -23,7 +23,7 @@
       </div>
       <AlertInline
         @sizeSmall={{true}}
-        @paddingTop={{true}}
+        class="has-top-padding-s"
         @type="info"
         @message="Leave blank to sign in with the default role if one is configured."
       />

--- a/ui/app/styles/components/doc-link.scss
+++ b/ui/app/styles/components/doc-link.scss
@@ -11,12 +11,3 @@
     text-decoration: underline !important;
   }
 }
-
-.doc-link-subtle {
-  color: inherit;
-  text-decoration: underline;
-  font-weight: inherit;
-  &:hover {
-    color: inherit;
-  }
-}

--- a/ui/app/templates/components/auth-form-options.hbs
+++ b/ui/app/templates/components/auth-form-options.hbs
@@ -23,7 +23,6 @@
           />
         </div>
         <AlertInline
-          @sizeSmall={{true}}
           class="has-top-padding-s"
           @type="info"
           @message="If this backend was mounted using a non-default path, enter it here."

--- a/ui/app/templates/components/auth-form-options.hbs
+++ b/ui/app/templates/components/auth-form-options.hbs
@@ -24,7 +24,7 @@
         </div>
         <AlertInline
           @sizeSmall={{true}}
-          @paddingTop={{true}}
+          class="has-top-padding-s"
           @type="info"
           @message="If this backend was mounted using a non-default path, enter it here."
         />

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -191,7 +191,7 @@
           />
           {{#if (and this.delayAuthMessageReminder.isIdle this.showLoading)}}
             <AlertInline
-              @paddingTop={{true}}
+              class="has-top-padding-s"
               @sizeSmall={{true}}
               @type="info"
               @message="If login takes longer than usual, you may need to check your device for an MFA notification, or contact your administrator if login times out."

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -192,7 +192,6 @@
           {{#if (and this.delayAuthMessageReminder.isIdle this.showLoading)}}
             <AlertInline
               class="has-top-padding-s"
-              @sizeSmall={{true}}
               @type="info"
               @message="If login takes longer than usual, you may need to check your device for an MFA notification, or contact your administrator if login times out."
               data-test-auth-message="push"

--- a/ui/app/templates/components/auth-jwt.hbs
+++ b/ui/app/templates/components/auth-jwt.hbs
@@ -22,7 +22,7 @@
     </div>
     <AlertInline
       @sizeSmall={{true}}
-      @paddingTop={{true}}
+      class="has-top-padding-s"
       @type="info"
       @message="Leave blank to sign in with the default role if one is configured"
     />

--- a/ui/app/templates/components/auth-jwt.hbs
+++ b/ui/app/templates/components/auth-jwt.hbs
@@ -21,7 +21,6 @@
       />
     </div>
     <AlertInline
-      @sizeSmall={{true}}
       class="has-top-padding-s"
       @type="info"
       @message="Leave blank to sign in with the default role if one is configured"

--- a/ui/app/templates/components/clients/attribution.hbs
+++ b/ui/app/templates/components/clients/attribution.hbs
@@ -112,17 +112,24 @@
         <Hds::Button @text="Cancel" @color="secondary" {{on "click" F.close}} />
       </Hds::ButtonSet>
       {{#if @upgradeExplanation}}
-        <div class="has-text-grey is-size-8 has-top-padding-m">
-          <AlertInline @type="warning">
-            Your data contains an upgrade.
-            <DocLink
-              @path="/vault/docs/concepts/client-count/faq#q-which-vault-version-reflects-the-most-accurate-client-counts"
+        <Hds::Alert class="has-top-padding-m" @type="compact" @color="warning" as |A|>
+          <A.Description>
+            <strong>Your data contains an upgrade.</strong>
+            {{@upgradeExplanation}}
+            Visit our
+            <Hds::Link::Inline
+              @icon="docs-link"
+              @iconPosition="trailing"
+              @isHrefExternal={{true}}
+              @href={{doc-link
+                "/vault/docs/concepts/client-count/faq#q-which-vault-version-reflects-the-most-accurate-client-counts"
+              }}
             >
-              Learn more here.
-            </DocLink>
-          </AlertInline>
-          <p class="has-left-padding-l">{{@upgradeExplanation}}</p>
-        </div>
+              Client count FAQ
+            </Hds::Link::Inline>
+            for more information.
+          </A.Description>
+        </Hds::Alert>
       {{/if}}
     </M.Footer>
   </Hds::Modal>

--- a/ui/app/templates/components/date-dropdown.hbs
+++ b/ui/app/templates/components/date-dropdown.hbs
@@ -34,5 +34,5 @@
   />
 </Hds::SegmentedGroup>
 {{#if this.invalidDate}}
-  <AlertInline @type="danger" @message={{this.invalidDate}} @paddingTop={{true}} @mimicRefresh={{true}} />
+  <AlertInline @type="danger" @message={{this.invalidDate}} class="has-top-padding-s" @mimicRefresh={{true}} />
 {{/if}}

--- a/ui/app/templates/components/date-dropdown.hbs
+++ b/ui/app/templates/components/date-dropdown.hbs
@@ -34,5 +34,5 @@
   />
 </Hds::SegmentedGroup>
 {{#if this.invalidDate}}
-  <AlertInline @type="danger" @message={{this.invalidDate}} class="has-top-padding-s" @mimicRefresh={{true}} />
+  <AlertInline @type="danger" @message={{this.invalidDate}} class="has-top-padding-s" />
 {{/if}}

--- a/ui/app/templates/components/keymgmt/distribute.hbs
+++ b/ui/app/templates/components/keymgmt/distribute.hbs
@@ -28,7 +28,7 @@
           @disallowNewItems={{false}}
         >
           {{#if (and this.validMatchError.key (not this.isNewKey))}}
-            <AlertInline @paddingTop={{true}} @sizeSmall={{true}} @type="danger" data-test-keymgmt-error="key">
+            <AlertInline class="has-top-padding-s" @sizeSmall={{true}} @type="danger" data-test-keymgmt-error="key">
               {{this.validMatchError.key}}
               To check compatibility,
               <DocLink class="doc-link-subtle" @path="/vault/docs/secrets/key-management#compatibility">refer to this table</DocLink>.
@@ -62,7 +62,7 @@
             </select>
           </div>
           {{#if this.validMatchError.key}}
-            <AlertInline @paddingTop={{true}} @sizeSmall={{true}} @type="danger" data-test-keymgmt-error="new-key">
+            <AlertInline class="has-top-padding-s" @sizeSmall={{true}} @type="danger" data-test-keymgmt-error="new-key">
               {{this.validMatchError.key}}
               To check compatibility,
               <DocLink class="doc-link-subtle" @path="/vault/docs/secrets/key-management#compatibility">refer to this table</DocLink>.
@@ -89,7 +89,7 @@
           data-test-keymgmt-dist-provider
         >
           {{#if this.validMatchError.provider}}
-            <AlertInline @paddingTop={{true}} @sizeSmall={{true}} @type="danger" data-test-keymgmt-error="provider">
+            <AlertInline class="has-top-padding-s" @sizeSmall={{true}} @type="danger" data-test-keymgmt-error="provider">
               {{this.validMatchError.provider}}
               To check compatibility,
               <DocLink class="doc-link-subtle" @path="/vault/docs/secrets/key-management#compatibility">refer to this table</DocLink>.

--- a/ui/app/templates/components/keymgmt/distribute.hbs
+++ b/ui/app/templates/components/keymgmt/distribute.hbs
@@ -28,7 +28,7 @@
           @disallowNewItems={{false}}
         >
           {{#if (and this.validMatchError.key (not this.isNewKey))}}
-            <AlertInline class="has-top-padding-s" @sizeSmall={{true}} @type="danger" data-test-keymgmt-error="key">
+            <AlertInline class="has-top-padding-s" @type="danger" data-test-keymgmt-error="key">
               {{this.validMatchError.key}}
               To check compatibility,
               <DocLink class="doc-link-subtle" @path="/vault/docs/secrets/key-management#compatibility">refer to this table</DocLink>.
@@ -62,7 +62,7 @@
             </select>
           </div>
           {{#if this.validMatchError.key}}
-            <AlertInline class="has-top-padding-s" @sizeSmall={{true}} @type="danger" data-test-keymgmt-error="new-key">
+            <AlertInline class="has-top-padding-s" @type="danger" data-test-keymgmt-error="new-key">
               {{this.validMatchError.key}}
               To check compatibility,
               <DocLink class="doc-link-subtle" @path="/vault/docs/secrets/key-management#compatibility">refer to this table</DocLink>.
@@ -89,7 +89,7 @@
           data-test-keymgmt-dist-provider
         >
           {{#if this.validMatchError.provider}}
-            <AlertInline class="has-top-padding-s" @sizeSmall={{true}} @type="danger" data-test-keymgmt-error="provider">
+            <AlertInline class="has-top-padding-s" @type="danger" data-test-keymgmt-error="provider">
               {{this.validMatchError.provider}}
               To check compatibility,
               <DocLink class="doc-link-subtle" @path="/vault/docs/secrets/key-management#compatibility">refer to this table</DocLink>.

--- a/ui/app/templates/components/keymgmt/distribute.hbs
+++ b/ui/app/templates/components/keymgmt/distribute.hbs
@@ -28,11 +28,20 @@
           @disallowNewItems={{false}}
         >
           {{#if (and this.validMatchError.key (not this.isNewKey))}}
-            <AlertInline class="has-top-padding-s" @type="danger" data-test-keymgmt-error="key">
-              {{this.validMatchError.key}}
-              To check compatibility,
-              <DocLink class="doc-link-subtle" @path="/vault/docs/secrets/key-management#compatibility">refer to this table</DocLink>.
-            </AlertInline>
+            <Hds::Alert class="has-top-margin-s" @type="inline" @color="warning" data-test-keymgmt-error="key" as |A|>
+              <A.Description>
+                {{this.validMatchError.key}}
+                To check compatibility,
+                <Hds::Link::Inline
+                  @icon="docs-link"
+                  @iconPosition="trailing"
+                  @isHrefExternal={{true}}
+                  @href={{doc-link "/vault/docs/secrets/key-management#compatibility"}}
+                >
+                  refer to this table
+                </Hds::Link::Inline>.
+              </A.Description>
+            </Hds::Alert>
           {{/if}}
         </SearchSelect>
       </div>
@@ -62,11 +71,20 @@
             </select>
           </div>
           {{#if this.validMatchError.key}}
-            <AlertInline class="has-top-padding-s" @type="danger" data-test-keymgmt-error="new-key">
-              {{this.validMatchError.key}}
-              To check compatibility,
-              <DocLink class="doc-link-subtle" @path="/vault/docs/secrets/key-management#compatibility">refer to this table</DocLink>.
-            </AlertInline>
+            <Hds::Alert class="has-top-margin-s" @type="inline" @color="warning" data-test-keymgmt-error="new-key" as |A|>
+              <A.Description>
+                {{this.validMatchError.key}}
+                To check compatibility,
+                <Hds::Link::Inline
+                  @icon="docs-link"
+                  @iconPosition="trailing"
+                  @isHrefExternal={{true}}
+                  @href={{doc-link "/vault/docs/secrets/key-management#compatibility"}}
+                >
+                  refer to this table
+                </Hds::Link::Inline>.
+              </A.Description>
+            </Hds::Alert>
           {{/if}}
         </div>
       </div>
@@ -89,11 +107,20 @@
           data-test-keymgmt-dist-provider
         >
           {{#if this.validMatchError.provider}}
-            <AlertInline class="has-top-padding-s" @type="danger" data-test-keymgmt-error="provider">
-              {{this.validMatchError.provider}}
-              To check compatibility,
-              <DocLink class="doc-link-subtle" @path="/vault/docs/secrets/key-management#compatibility">refer to this table</DocLink>.
-            </AlertInline>
+            <Hds::Alert class="has-top-margin-s" @type="inline" @color="warning" data-test-keymgmt-error="provider" as |A|>
+              <A.Description>
+                {{this.validMatchError.provider}}
+                To check compatibility,
+                <Hds::Link::Inline
+                  @icon="docs-link"
+                  @iconPosition="trailing"
+                  @isHrefExternal={{true}}
+                  @href={{doc-link "/vault/docs/secrets/key-management#compatibility"}}
+                >
+                  refer to this table
+                </Hds::Link::Inline>.
+              </A.Description>
+            </Hds::Alert>
           {{/if}}
         </SearchSelect>
       </div>

--- a/ui/app/templates/components/mfa/mfa-form.hbs
+++ b/ui/app/templates/components/mfa/mfa-form.hbs
@@ -58,7 +58,7 @@
       </div>
       {{#if this.newCodeDelay.isRunning}}
         <div>
-          <AlertInline @type="danger" @sizeSmall={{true}} @message={{this.codeDelayMessage}} />
+          <AlertInline @type="danger" @message={{this.codeDelayMessage}} />
         </div>
       {{/if}}
       <Hds::Button

--- a/ui/app/templates/components/mount-backend-form.hbs
+++ b/ui/app/templates/components/mount-backend-form.hbs
@@ -52,7 +52,12 @@
         </div>
         {{#if this.invalidFormAlert}}
           <div class="control">
-            <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+            <AlertInline
+              @type="danger"
+              class="has-top-padding-s"
+              @message={{this.invalidFormAlert}}
+              @mimicRefresh={{true}}
+            />
           </div>
         {{/if}}
       </div>

--- a/ui/app/templates/components/mount-backend-form.hbs
+++ b/ui/app/templates/components/mount-backend-form.hbs
@@ -52,12 +52,7 @@
         </div>
         {{#if this.invalidFormAlert}}
           <div class="control">
-            <AlertInline
-              @type="danger"
-              class="has-top-padding-s"
-              @message={{this.invalidFormAlert}}
-              @mimicRefresh={{true}}
-            />
+            <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} />
           </div>
         {{/if}}
       </div>

--- a/ui/app/templates/components/oidc/assignment-form.hbs
+++ b/ui/app/templates/components/oidc/assignment-form.hbs
@@ -63,7 +63,7 @@
       data-test-oidc-assignment-cancel
     />
     {{#if this.modelValidations.targets.errors}}
-      <AlertInline @type="danger" @message={{join ", " this.modelValidations.targets.errors}} @paddingTop={{true}} />
+      <AlertInline @type="danger" @message={{join ", " this.modelValidations.targets.errors}} class="has-top-padding-s" />
     {{/if}}
   </div>
 </form>

--- a/ui/app/templates/components/oidc/client-form.hbs
+++ b/ui/app/templates/components/oidc/client-form.hbs
@@ -97,7 +97,7 @@
     </div>
     {{#if this.invalidFormAlert}}
       <div class="control">
-        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} />
       </div>
     {{/if}}
   </div>

--- a/ui/app/templates/components/oidc/client-form.hbs
+++ b/ui/app/templates/components/oidc/client-form.hbs
@@ -97,7 +97,7 @@
     </div>
     {{#if this.invalidFormAlert}}
       <div class="control">
-        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
       </div>
     {{/if}}
   </div>

--- a/ui/app/templates/components/oidc/key-form.hbs
+++ b/ui/app/templates/components/oidc/key-form.hbs
@@ -98,7 +98,7 @@
     </div>
     {{#if this.invalidFormAlert}}
       <div class="control">
-        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
       </div>
     {{/if}}
   </div>

--- a/ui/app/templates/components/oidc/key-form.hbs
+++ b/ui/app/templates/components/oidc/key-form.hbs
@@ -98,7 +98,7 @@
     </div>
     {{#if this.invalidFormAlert}}
       <div class="control">
-        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} />
       </div>
     {{/if}}
   </div>

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -125,7 +125,7 @@
     </div>
     {{#if this.invalidFormAlert}}
       <div class="control">
-        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
       </div>
     {{/if}}
   </div>

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -125,7 +125,7 @@
     </div>
     {{#if this.invalidFormAlert}}
       <div class="control">
-        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} />
       </div>
     {{/if}}
   </div>

--- a/ui/app/templates/components/oidc/scope-form.hbs
+++ b/ui/app/templates/components/oidc/scope-form.hbs
@@ -73,7 +73,7 @@
   </div>
   {{#if this.invalidFormAlert}}
     <div class="control">
-      <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+      <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
     </div>
   {{/if}}
 </form>

--- a/ui/app/templates/components/oidc/scope-form.hbs
+++ b/ui/app/templates/components/oidc/scope-form.hbs
@@ -73,7 +73,7 @@
   </div>
   {{#if this.invalidFormAlert}}
     <div class="control">
-      <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+      <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} />
     </div>
   {{/if}}
 </form>

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -26,12 +26,7 @@
         />
       </p>
       {{#if (get this.validationMessages "path")}}
-        <AlertInline
-          @type="danger"
-          @message={{get this.validationMessages "path"}}
-          class="has-top-padding-s"
-          @isMarginless={{true}}
-        />
+        <AlertInline @type="danger" @message={{get this.validationMessages "path"}} class="has-top-padding-s" />
       {{/if}}
       {{#if @modelForData.isFolder}}
         <p class="help has-text-danger">
@@ -104,12 +99,7 @@
             </div>
           </div>
           {{#if this.validationMessages.key}}
-            <AlertInline
-              @type="danger"
-              @message={{this.validationMessages.key}}
-              class="has-top-padding-s"
-              @isMarginless={{true}}
-            />
+            <AlertInline @type="danger" @message={{this.validationMessages.key}} class="has-top-padding-s" />
           {{/if}}
         {{/each}}
       </div>

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -26,7 +26,7 @@
         />
       </p>
       {{#if (get this.validationMessages "path")}}
-        <AlertInline @type="danger" @message={{get this.validationMessages "path"}} class="has-top-padding-s" />
+        <AlertInline @type="danger" @message={{capitalize (get this.validationMessages "path")}} class="has-top-padding-s" />
       {{/if}}
       {{#if @modelForData.isFolder}}
         <p class="help has-text-danger">

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -29,7 +29,7 @@
         <AlertInline
           @type="danger"
           @message={{get this.validationMessages "path"}}
-          @paddingTop={{true}}
+          class="has-top-padding-s"
           @isMarginless={{true}}
         />
       {{/if}}
@@ -107,7 +107,7 @@
             <AlertInline
               @type="danger"
               @message={{this.validationMessages.key}}
-              @paddingTop={{true}}
+              class="has-top-padding-s"
               @isMarginless={{true}}
             />
           {{/if}}

--- a/ui/lib/core/addon/components/alert-inline.hbs
+++ b/ui/lib/core/addon/components/alert-inline.hbs
@@ -3,17 +3,16 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-{{! DEPRECATED use Hds::Alert directly }}
 <Hds::Alert
+  {{did-update this.refresh @message}}
   @type="compact"
   @color={{this.color}}
   @icon={{if this.isRefreshing "loading"}}
-  {{did-update this.refresh @message}}
   data-test-inline-alert
   ...attributes
   as |A|
 >
   {{#unless this.isRefreshing}}
-    <A.Description>{{@message}}</A.Description>
+    <A.Description data-test-inline-error-message>{{@message}}</A.Description>
   {{/unless}}
 </Hds::Alert>

--- a/ui/lib/core/addon/components/alert-inline.hbs
+++ b/ui/lib/core/addon/components/alert-inline.hbs
@@ -3,22 +3,17 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<div
+{{! DEPRECATED use Hds::Alert directly }}
+<Hds::Alert
+  @type="compact"
+  @color={{this.color}}
+  @icon={{if this.isRefreshing "loading"}}
   {{did-update this.refresh @message}}
-  class={{concat "is-flex-center" this.paddingTop this.isMarginless this.sizeSmall}}
   data-test-inline-alert
   ...attributes
+  as |A|
 >
-  {{#if this.isRefreshing}}
-    <Icon @name="loading" class="loading" />
-  {{else}}
-    <Icon @name={{this.alertType.glyph}} class={{this.alertType.glyphClass}} />
-    <p class={{this.textClass}} data-test-inline-error-message>
-      {{#if (has-block)}}
-        {{yield}}
-      {{else}}
-        {{@message}}
-      {{/if}}
-    </p>
-  {{/if}}
-</div>
+  {{#unless this.isRefreshing}}
+    <A.Description>{{@message}}</A.Description>
+  {{/unless}}
+</Hds::Alert>

--- a/ui/lib/core/addon/components/alert-inline.js
+++ b/ui/lib/core/addon/components/alert-inline.js
@@ -35,7 +35,7 @@ export default class AlertInlineComponent extends Component {
     if (this.args.color) {
       const possibleColors = ['critical', 'warning', 'success', 'highlight', 'neutral'];
       assert(
-        `${this.args.color} is not a valid color. @color arg must be one of: ${possibleColors.join(', ')}`,
+        `${this.args.color} is not a valid color. @color must be one of: ${possibleColors.join(', ')}`,
         possibleColors.includes(this.args.color)
       );
     }

--- a/ui/lib/core/addon/components/alert-inline.js
+++ b/ui/lib/core/addon/components/alert-inline.js
@@ -12,8 +12,8 @@ import { assert } from '@ember/debug';
 /**
  * @module AlertInline
  * * Use Hds::Alert @type="compact" for displaying alert messages.
- * This component is specifically for rendering messages that may update while a user is viewing the page
- * because it displays a loading icon when the @message arg changes before rendering the updated @message text.
+ * This component renders a compact Hds::Alert that displays a loading icon if the
+ * @message arg changes and then re-renders the updated @message text.
  * (Example: submitting a form and displaying the number of errors because on re-submit the number may change)
  *
  * @example

--- a/ui/lib/core/addon/components/alert-inline.js
+++ b/ui/lib/core/addon/components/alert-inline.js
@@ -7,9 +7,9 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { later } from '@ember/runloop';
 import { tracked } from '@glimmer/tracking';
-import { messageTypes } from 'core/helpers/message-types';
 
 /**
+ * DEPRECATED - use Hds::Alert @type="compact" instead https://helios.hashicorp.design/components/alert?tab=code#type
  * @module AlertInline
  * `AlertInline` components are used to inform users of important messages.
  *
@@ -18,47 +18,32 @@ import { messageTypes } from 'core/helpers/message-types';
  * <AlertInline @type="danger" @message="{{model.keyId}} is not a valid lease ID"/>
  * ```
  *
- * @param {string} type=null - The alert type passed to the message-types helper.
+ * @param {string} type - The alert type maps to the alert @color
  * @param {string} [message=null] - The message to display within the alert.
- * @param {boolean} [paddingTop=false] - Whether or not to add padding above component.
- * @param {boolean} [isMarginless=false] - Whether or not to remove margin bottom below component.
- * @param {boolean} [sizeSmall=false] - Whether or not to display a small font with padding below of alert message.
  * @param {boolean} [mimicRefresh=false] - If true will display a loading icon when attributes change (e.g. when a form submits and the alert message changes).
  */
 
 export default class AlertInlineComponent extends Component {
   @tracked isRefreshing = false;
 
-  get mimicRefresh() {
-    return this.args.mimicRefresh || false;
-  }
-
-  get paddingTop() {
-    return this.args.paddingTop ? ' padding-top' : '';
-  }
-
-  get isMarginless() {
-    return this.args.isMarginless ? ' is-marginless' : '';
-  }
-
-  get sizeSmall() {
-    return this.args.sizeSmall ? ' size-small' : '';
-  }
-
-  get textClass() {
-    if (this.args.type === 'danger') {
-      return this.alertType.glyphClass;
+  get color() {
+    switch (this.args.type) {
+      case 'danger':
+        return 'critical';
+      case 'success':
+        return 'success';
+      case 'warning':
+        return 'warning';
+      case 'info':
+        return 'highlight';
+      default:
+        return 'neutral';
     }
-    return null;
-  }
-
-  get alertType() {
-    return messageTypes([this.args.type]);
   }
 
   @action
   refresh() {
-    if (this.mimicRefresh) {
+    if (this.args.mimicRefresh) {
       this.isRefreshing = true;
       later(() => {
         this.isRefreshing = false;

--- a/ui/lib/core/addon/components/kv-object-editor.hbs
+++ b/ui/lib/core/addon/components/kv-object-editor.hbs
@@ -13,7 +13,7 @@
   />
   {{#if @validationError}}
     <div>
-      <AlertInline @type="danger" @message={{@validationError}} @paddingTop={{true}} />
+      <AlertInline @type="danger" @message={{@validationError}} class="has-top-padding-s" />
     </div>
   {{/if}}
   {{#if this.kvData}}

--- a/ui/lib/core/addon/components/string-list.hbs
+++ b/ui/lib/core/addon/components/string-list.hbs
@@ -58,6 +58,10 @@
     </div>
   {{/each}}
   {{#if this.indicesWithComma}}
-    <AlertInline @type="warning" @message="Input contains a comma. Please separate values into individual rows." />
+    <Hds::Alert @type="inline" @color="warning" as |A|>
+      <A.Description>
+        Input contains a comma. Please separate values into individual rows.
+      </A.Description>
+    </Hds::Alert>
   {{/if}}
 </div>

--- a/ui/lib/core/addon/components/string-list.hbs
+++ b/ui/lib/core/addon/components/string-list.hbs
@@ -58,10 +58,6 @@
     </div>
   {{/each}}
   {{#if this.indicesWithComma}}
-    <AlertInline
-      @type="warning"
-      @message="Input contains a comma. Please separate values into individual rows."
-      @isMarginless={{true}}
-    />
+    <AlertInline @type="warning" @message="Input contains a comma. Please separate values into individual rows." />
   {{/if}}
 </div>

--- a/ui/lib/core/addon/components/string-list.hbs
+++ b/ui/lib/core/addon/components/string-list.hbs
@@ -53,7 +53,7 @@
         {{/if}}
       </div>
       {{#if (includes index this.indicesWithComma)}}
-        <Hds::Alert class="is-flex-v-centered" @type="compact" @color="warning" />
+        <FlightIcon @name="alert-triangle" @color="var(--token-color-foreground-warning)" @size="24" />
       {{/if}}
     </div>
   {{/each}}

--- a/ui/lib/core/addon/components/string-list.hbs
+++ b/ui/lib/core/addon/components/string-list.hbs
@@ -53,7 +53,7 @@
         {{/if}}
       </div>
       {{#if (includes index this.indicesWithComma)}}
-        <Icon class="is-flex-v-centered has-text-highlight" @name="alert-triangle-fill" />
+        <Hds::Alert class="is-flex-v-centered" @type="compact" @color="warning" />
       {{/if}}
     </div>
   {{/each}}

--- a/ui/lib/core/addon/components/text-file.hbs
+++ b/ui/lib/core/addon/components/text-file.hbs
@@ -57,7 +57,7 @@
       <AlertInline
         @type="danger"
         @message={{or @validationError this.uploadError}}
-        @paddingTop={{true}}
+        class="has-top-padding-s"
         data-test-field-validation="text-file"
       />
     {{/if}}

--- a/ui/lib/core/addon/templates/components/edit-form.hbs
+++ b/ui/lib/core/addon/templates/components/edit-form.hbs
@@ -30,7 +30,7 @@
   >
     <:error>
       {{#if this.invalidFormAlert}}
-        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
       {{/if}}
     </:error>
   </FormSaveButtons>

--- a/ui/lib/core/addon/templates/components/edit-form.hbs
+++ b/ui/lib/core/addon/templates/components/edit-form.hbs
@@ -30,7 +30,7 @@
   >
     <:error>
       {{#if this.invalidFormAlert}}
-        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} />
       {{/if}}
     </:error>
   </FormSaveButtons>

--- a/ui/lib/kubernetes/addon/components/page/configure.hbs
+++ b/ui/lib/kubernetes/addon/components/page/configure.hbs
@@ -89,7 +89,7 @@
     {{on "click" this.cancel}}
   />
   {{#if this.alert}}
-    <AlertInline @type="danger" class="has-top-padding-s" @message={{this.alert}} @mimicRefresh={{true}} data-test-alert />
+    <AlertInline @type="danger" class="has-top-padding-s" @message={{this.alert}} data-test-alert />
   {{/if}}
 </div>
 

--- a/ui/lib/kubernetes/addon/components/page/configure.hbs
+++ b/ui/lib/kubernetes/addon/components/page/configure.hbs
@@ -78,7 +78,8 @@
 
 <hr class="has-background-gray-200 has-top-margin-l" />
 
-<div class="has-top-margin-s has-bottom-margin-s is-flex">
+<Hds::ButtonSet class="has-top-margin-s has-bottom-margin-s">
+
   <Hds::Button @text="Save" data-test-config-save disabled={{this.isDisabled}} {{on "click" (perform this.save)}} />
   <Hds::Button
     @text="Back"
@@ -91,7 +92,7 @@
   {{#if this.alert}}
     <AlertInline @type="danger" class="has-top-padding-s" @message={{this.alert}} data-test-alert />
   {{/if}}
-</div>
+</Hds::ButtonSet>
 
 {{#if this.showConfirm}}
   <Hds::Modal id="kubernetes-edit-config-modal" @onClose={{fn (mut this.showConfirm) false}} @color="warning" as |M|>

--- a/ui/lib/kubernetes/addon/components/page/configure.hbs
+++ b/ui/lib/kubernetes/addon/components/page/configure.hbs
@@ -89,7 +89,7 @@
     {{on "click" this.cancel}}
   />
   {{#if this.alert}}
-    <AlertInline @type="danger" @paddingTop={{true}} @message={{this.alert}} @mimicRefresh={{true}} data-test-alert />
+    <AlertInline @type="danger" class="has-top-padding-s" @message={{this.alert}} @mimicRefresh={{true}} data-test-alert />
   {{/if}}
 </div>
 

--- a/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
+++ b/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
@@ -130,7 +130,7 @@
     {{/if}}
     {{#if this.invalidFormAlert}}
       <div class="control" data-test-invalid-form-alert>
-        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} />
       </div>
     {{/if}}
   </form>

--- a/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
+++ b/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
@@ -130,7 +130,7 @@
     {{/if}}
     {{#if this.invalidFormAlert}}
       <div class="control" data-test-invalid-form-alert>
-        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
       </div>
     {{/if}}
   </form>

--- a/ui/lib/kv/addon/components/kv-data-fields.hbs
+++ b/ui/lib/kv/addon/components/kv-data-fields.hbs
@@ -19,7 +19,7 @@
     @valueUpdated={{this.handleJson}}
   />
   {{#if (or @modelValidations.secretData.errors this.lintingErrors)}}
-    <AlertInline @type={{if this.lintingErrors "warning" "danger"}} @paddingTop={{true}}>
+    <AlertInline @type={{if this.lintingErrors "warning" "danger"}} class="has-top-padding-s">
       {{#if @modelValidations.secretData.errors}}
         {{@modelValidations.secretData.errors}}
       {{else}}

--- a/ui/lib/kv/addon/components/kv-data-fields.hbs
+++ b/ui/lib/kv/addon/components/kv-data-fields.hbs
@@ -19,13 +19,15 @@
     @valueUpdated={{this.handleJson}}
   />
   {{#if (or @modelValidations.secretData.errors this.lintingErrors)}}
-    <AlertInline @type={{if this.lintingErrors "warning" "danger"}} class="has-top-padding-s">
-      {{#if @modelValidations.secretData.errors}}
-        {{@modelValidations.secretData.errors}}
-      {{else}}
-        JSON is unparsable. Fix linting errors to avoid data discrepancies.
-      {{/if}}
-    </AlertInline>
+    <AlertInline
+      @color={{if this.lintingErrors "warning" "critical"}}
+      class="has-top-padding-s"
+      @message={{if
+        @modelValidations.secretData.errors
+        @modelValidations.secretData.errors
+        "JSON is unparsable. Fix linting errors to avoid data discrepancies."
+      }}
+    />
   {{/if}}
 {{else}}
   <KvObjectEditor

--- a/ui/lib/kv/addon/components/page/secret/edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/edit.hbs
@@ -94,7 +94,6 @@
         class="has-top-padding-s"
         @type="danger"
         @message={{this.invalidFormAlert}}
-        @mimicRefresh={{true}}
       />
     {{/if}}
   </div>

--- a/ui/lib/kv/addon/components/page/secret/metadata/edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/edit.hbs
@@ -38,7 +38,7 @@
             <AlertInline
               data-test-invalid-form-alert
               @type="danger"
-              @paddingTop={{true}}
+              class="has-top-padding-s"
               @message={{this.invalidFormAlert}}
               @mimicRefresh={{true}}
             />

--- a/ui/lib/kv/addon/components/page/secret/metadata/edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/edit.hbs
@@ -40,7 +40,6 @@
               @type="danger"
               class="has-top-padding-s"
               @message={{this.invalidFormAlert}}
-              @mimicRefresh={{true}}
             />
           </div>
         {{/if}}

--- a/ui/lib/kv/addon/components/page/secrets/create.hbs
+++ b/ui/lib/kv/addon/components/page/secrets/create.hbs
@@ -61,7 +61,6 @@
         class="has-top-padding-s"
         @type="danger"
         @message={{this.invalidFormAlert}}
-        @mimicRefresh={{true}}
       />
     {{/if}}
   </div>

--- a/ui/lib/ldap/addon/components/page/configure.hbs
+++ b/ui/lib/ldap/addon/components/page/configure.hbs
@@ -70,7 +70,7 @@
     {{#if this.invalidFormMessage}}
       <AlertInline
         @type="danger"
-        @paddingTop={{true}}
+        class="has-top-padding-s"
         @message={{this.invalidFormMessage}}
         @mimicRefresh={{true}}
         data-test-invalid-form-message

--- a/ui/lib/ldap/addon/components/page/configure.hbs
+++ b/ui/lib/ldap/addon/components/page/configure.hbs
@@ -72,7 +72,6 @@
         @type="danger"
         class="has-top-padding-s"
         @message={{this.invalidFormMessage}}
-        @mimicRefresh={{true}}
         data-test-invalid-form-message
       />
     {{/if}}

--- a/ui/lib/ldap/addon/components/page/library/create-and-edit.hbs
+++ b/ui/lib/ldap/addon/components/page/library/create-and-edit.hbs
@@ -43,7 +43,7 @@
     {{#if this.invalidFormMessage}}
       <AlertInline
         @type="danger"
-        @paddingTop={{true}}
+        class="has-top-padding-s"
         @message={{this.invalidFormMessage}}
         @mimicRefresh={{true}}
         data-test-invalid-form-message

--- a/ui/lib/ldap/addon/components/page/library/create-and-edit.hbs
+++ b/ui/lib/ldap/addon/components/page/library/create-and-edit.hbs
@@ -45,7 +45,6 @@
         @type="danger"
         class="has-top-padding-s"
         @message={{this.invalidFormMessage}}
-        @mimicRefresh={{true}}
         data-test-invalid-form-message
       />
     {{/if}}

--- a/ui/lib/ldap/addon/components/page/role/create-and-edit.hbs
+++ b/ui/lib/ldap/addon/components/page/role/create-and-edit.hbs
@@ -67,7 +67,7 @@
     {{#if this.invalidFormMessage}}
       <AlertInline
         @type="danger"
-        @paddingTop={{true}}
+        class="has-top-padding-s"
         @message={{this.invalidFormMessage}}
         @mimicRefresh={{true}}
         data-test-invalid-form-message

--- a/ui/lib/ldap/addon/components/page/role/create-and-edit.hbs
+++ b/ui/lib/ldap/addon/components/page/role/create-and-edit.hbs
@@ -69,7 +69,6 @@
         @type="danger"
         class="has-top-padding-s"
         @message={{this.invalidFormMessage}}
-        @mimicRefresh={{true}}
         data-test-invalid-form-message
       />
     {{/if}}

--- a/ui/lib/pki/addon/components/page/pki-configuration-edit.hbs
+++ b/ui/lib/pki/addon/components/page/pki-configuration-edit.hbs
@@ -148,7 +148,6 @@
           @type="danger"
           class="has-top-padding-s"
           @message={{this.invalidFormAlert}}
-          @mimicRefresh={{true}}
           data-test-configuration-edit-validation-alert
         />
       </div>

--- a/ui/lib/pki/addon/components/page/pki-configuration-edit.hbs
+++ b/ui/lib/pki/addon/components/page/pki-configuration-edit.hbs
@@ -146,7 +146,7 @@
       <div class="control">
         <AlertInline
           @type="danger"
-          @paddingTop={{true}}
+          class="has-top-padding-s"
           @message={{this.invalidFormAlert}}
           @mimicRefresh={{true}}
           data-test-configuration-edit-validation-alert

--- a/ui/lib/pki/addon/components/page/pki-issuer-edit.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-edit.hbs
@@ -68,12 +68,7 @@
   </Hds::ButtonSet>
   {{#if this.error}}
     <div class="control">
-      <AlertInline
-        @type="danger"
-        class="has-top-padding-s"
-        @message="There was an error submitting this form."
-        @mimicRefresh={{true}}
-      />
+      <AlertInline @type="danger" class="has-top-padding-s" @message="There was an error submitting this form." />
     </div>
   {{/if}}
 </form>

--- a/ui/lib/pki/addon/components/page/pki-issuer-edit.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-edit.hbs
@@ -70,7 +70,7 @@
     <div class="control">
       <AlertInline
         @type="danger"
-        @paddingTop={{true}}
+        class="has-top-padding-s"
         @message="There was an error submitting this form."
         @mimicRefresh={{true}}
       />

--- a/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
@@ -175,7 +175,6 @@
             @type="danger"
             class="has-top-padding-s"
             @message={{this.invalidFormAlert}}
-            @mimicRefresh={{true}}
             data-test-pki-rotate-root-validation-error
           />
         </div>

--- a/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
@@ -173,7 +173,7 @@
         <div class="control">
           <AlertInline
             @type="danger"
-            @paddingTop={{true}}
+            class="has-top-padding-s"
             @message={{this.invalidFormAlert}}
             @mimicRefresh={{true}}
             data-test-pki-rotate-root-validation-error

--- a/ui/lib/pki/addon/components/pki-generate-csr.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-csr.hbs
@@ -67,7 +67,13 @@
     </Hds::ButtonSet>
     {{#if this.alert}}
       <div class="control">
-        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.alert}} @mimicRefresh={{true}} data-test-alert />
+        <AlertInline
+          @type="danger"
+          class="has-top-padding-s"
+          @message={{this.alert}}
+          @mimicRefresh={{true}}
+          data-test-alert
+        />
       </div>
     {{/if}}
   </form>

--- a/ui/lib/pki/addon/components/pki-generate-csr.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-csr.hbs
@@ -67,13 +67,7 @@
     </Hds::ButtonSet>
     {{#if this.alert}}
       <div class="control">
-        <AlertInline
-          @type="danger"
-          class="has-top-padding-s"
-          @message={{this.alert}}
-          @mimicRefresh={{true}}
-          data-test-alert
-        />
+        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.alert}} data-test-alert />
       </div>
     {{/if}}
   </form>

--- a/ui/lib/pki/addon/components/pki-generate-root.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-root.hbs
@@ -104,7 +104,7 @@
       <div class="control">
         <AlertInline
           @type="danger"
-          @paddingTop={{true}}
+          class="has-top-padding-s"
           @message={{this.invalidFormAlert}}
           @mimicRefresh={{true}}
           data-test-pki-generate-root-validation-error

--- a/ui/lib/pki/addon/components/pki-generate-root.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-root.hbs
@@ -106,7 +106,6 @@
           @type="danger"
           class="has-top-padding-s"
           @message={{this.invalidFormAlert}}
-          @mimicRefresh={{true}}
           data-test-pki-generate-root-validation-error
         />
       </div>

--- a/ui/lib/pki/addon/components/pki-key-form.hbs
+++ b/ui/lib/pki/addon/components/pki-key-form.hbs
@@ -55,7 +55,7 @@
     <div class="control">
       <AlertInline
         @type="danger"
-        @paddingTop={{true}}
+        class="has-top-padding-s"
         @message={{this.invalidFormAlert}}
         @mimicRefresh={{true}}
         data-test-pki-key-validation-error

--- a/ui/lib/pki/addon/components/pki-key-form.hbs
+++ b/ui/lib/pki/addon/components/pki-key-form.hbs
@@ -57,7 +57,6 @@
         @type="danger"
         class="has-top-padding-s"
         @message={{this.invalidFormAlert}}
-        @mimicRefresh={{true}}
         data-test-pki-key-validation-error
       />
     </div>

--- a/ui/lib/pki/addon/components/pki-key-import.hbs
+++ b/ui/lib/pki/addon/components/pki-key-import.hbs
@@ -39,7 +39,6 @@
         @type="danger"
         class="has-top-padding-s"
         @message={{this.invalidFormAlert}}
-        @mimicRefresh={{true}}
         data-test-pki-key-validation-error
       />
     </div>

--- a/ui/lib/pki/addon/components/pki-key-import.hbs
+++ b/ui/lib/pki/addon/components/pki-key-import.hbs
@@ -37,7 +37,7 @@
     <div class="control">
       <AlertInline
         @type="danger"
-        @paddingTop={{true}}
+        class="has-top-padding-s"
         @message={{this.invalidFormAlert}}
         @mimicRefresh={{true}}
         data-test-pki-key-validation-error

--- a/ui/lib/pki/addon/components/pki-role-form.hbs
+++ b/ui/lib/pki/addon/components/pki-role-form.hbs
@@ -134,11 +134,11 @@
     />
   </Hds::ButtonSet>
   {{#if this.modelValidations.targets.errors}}
-    <AlertInline @type="danger" @message={{join ", " this.modelValidations.targets.errors}} @paddingTop={{true}} />
+    <AlertInline @type="danger" @message={{join ", " this.modelValidations.targets.errors}} class="has-top-padding-s" />
   {{/if}}
   {{#if this.invalidFormAlert}}
     <div class="control">
-      <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+      <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
     </div>
   {{/if}}
 </form>

--- a/ui/lib/pki/addon/components/pki-role-form.hbs
+++ b/ui/lib/pki/addon/components/pki-role-form.hbs
@@ -138,7 +138,7 @@
   {{/if}}
   {{#if this.invalidFormAlert}}
     <div class="control">
-      <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+      <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} />
     </div>
   {{/if}}
 </form>

--- a/ui/lib/pki/addon/components/pki-role-generate.hbs
+++ b/ui/lib/pki/addon/components/pki-role-generate.hbs
@@ -44,7 +44,7 @@
 
     {{#if this.invalidFormAlert}}
       <div class="control" data-test-alert>
-        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} />
       </div>
     {{/if}}
 

--- a/ui/lib/pki/addon/components/pki-role-generate.hbs
+++ b/ui/lib/pki/addon/components/pki-role-generate.hbs
@@ -44,7 +44,7 @@
 
     {{#if this.invalidFormAlert}}
       <div class="control" data-test-alert>
-        <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
       </div>
     {{/if}}
 

--- a/ui/lib/pki/addon/components/pki-sign-intermediate-form.hbs
+++ b/ui/lib/pki/addon/components/pki-sign-intermediate-form.hbs
@@ -75,7 +75,7 @@
       <div class="control">
         <AlertInline
           @type="danger"
-          @paddingTop={{true}}
+          class="has-top-padding-s"
           @message={{this.inlineFormAlert}}
           @mimicRefresh={{true}}
           data-test-form-error

--- a/ui/lib/pki/addon/components/pki-sign-intermediate-form.hbs
+++ b/ui/lib/pki/addon/components/pki-sign-intermediate-form.hbs
@@ -73,13 +73,7 @@
     </Hds::ButtonSet>
     {{#if this.inlineFormAlert}}
       <div class="control">
-        <AlertInline
-          @type="danger"
-          class="has-top-padding-s"
-          @message={{this.inlineFormAlert}}
-          @mimicRefresh={{true}}
-          data-test-form-error
-        />
+        <AlertInline @type="danger" class="has-top-padding-s" @message={{this.inlineFormAlert}} data-test-form-error />
       </div>
     {{/if}}
 

--- a/ui/lib/pki/addon/components/pki-tidy-form.hbs
+++ b/ui/lib/pki/addon/components/pki-tidy-form.hbs
@@ -75,7 +75,7 @@
   </Hds::ButtonSet>
   {{#if this.invalidFormAlert}}
     <div class="control">
-      <AlertInline @type="danger" @paddingTop={{true}} @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+      <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
     </div>
   {{/if}}
 </form>

--- a/ui/lib/pki/addon/components/pki-tidy-form.hbs
+++ b/ui/lib/pki/addon/components/pki-tidy-form.hbs
@@ -75,7 +75,7 @@
   </Hds::ButtonSet>
   {{#if this.invalidFormAlert}}
     <div class="control">
-      <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} @mimicRefresh={{true}} />
+      <AlertInline @type="danger" class="has-top-padding-s" @message={{this.invalidFormAlert}} />
     </div>
   {{/if}}
 </form>

--- a/ui/tests/integration/components/alert-inline-test.js
+++ b/ui/tests/integration/components/alert-inline-test.js
@@ -8,70 +8,84 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, settled, find, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
+const SHARED_STYLES = {
+  success: {
+    icon: 'check-circle-fill',
+    class: 'hds-alert--color-success',
+  },
+  warning: {
+    icon: 'alert-triangle-fill',
+    class: 'hds-alert--color-warning',
+  },
+};
 module('Integration | Component | alert-inline', function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
-    this.set('message', 'some very important alert');
-    this.set('type', 'warning');
-  });
+  test('it renders alert message for each @color arg', async function (assert) {
+    const COLORS = {
+      ...SHARED_STYLES,
+      neutral: {
+        icon: 'info-fill',
+        class: 'hds-alert--color-neutral',
+      },
+      highlight: {
+        icon: 'info-fill',
+        class: 'hds-alert--color-highlight',
+      },
+      critical: {
+        icon: 'alert-diamond-fill',
+        class: 'hds-alert--color-critical',
+      },
+    };
 
-  test('it renders alert message with correct class args', async function (assert) {
-    await render(hbs`
-    <AlertInline
-      class="has-top-padding-s"
-      @isMarginless={{true}}
-      @message={{this.message}}
-      @type={{this.type}}
-    />
-    `);
+    const { neutral } = COLORS; // default color
+    await render(hbs`<AlertInline @message="some very important alert" />`);
     assert.dom('[data-test-inline-error-message]').hasText('some very important alert');
-    assert
-      .dom('[data-test-inline-alert]')
-      .hasAttribute('class', 'is-flex-center has-padding-top-s is-marginless');
+    assert.dom(`[data-test-icon="${neutral.icon}"]`).exists('renders default icon');
+    assert.dom('[data-test-inline-alert]').hasClass(neutral.class, 'renders default class');
+
+    // assert deprecated @type arg values map to expected color
+    for (const type in COLORS) {
+      this.color = type;
+      const color = COLORS[type];
+      await render(hbs`<AlertInline @color={{this.color}}  @message="some very important alert" />`);
+      assert.dom(`[data-test-icon="${color.icon}"]`).exists(`@color="${type}" renders icon: ${color.icon}`);
+      assert
+        .dom('[data-test-inline-alert]')
+        .hasClass(color.class, `@color="${type}" renders class: ${color.class}`);
+    }
   });
 
-  test('it yields to block text', async function (assert) {
-    await render(hbs`
-    <AlertInline @message={{this.message}} @type={{this.type}}>
-      A much more important alert
-    </AlertInline>
-    `);
-    assert.dom('[data-test-inline-error-message]').hasText('A much more important alert');
-  });
-
-  test('it renders correctly for type=danger', async function (assert) {
-    this.set('type', 'danger');
-    await render(hbs`
-    <AlertInline
-      @type={{this.type}}
-      @message={{this.message}}
-    />
-    `);
-    assert
-      .dom('[data-test-inline-error-message]')
-      .hasAttribute('class', 'has-text-danger', 'has danger text');
-    assert.dom('[data-test-icon="x-square-fill"]').exists('danger icon exists');
-  });
-
-  test('it renders correctly for type=warning', async function (assert) {
-    await render(hbs`
-    <AlertInline
-      @type={{this.type}}
-      @message={{this.message}}
-    />
-    `);
-    assert.dom('[data-test-inline-error-message]').doesNotHaveAttribute('class', 'does not have styled text');
-    assert.dom('[data-test-icon="alert-triangle-fill"]').exists('warning icon exists');
+  test('it renders alert color for each deprecated @type arg', async function (assert) {
+    const OLD_TYPES = {
+      ...SHARED_STYLES,
+      info: {
+        icon: 'info-fill',
+        class: 'hds-alert--color-highlight',
+      },
+      danger: {
+        icon: 'alert-diamond-fill',
+        class: 'hds-alert--color-critical',
+      },
+    };
+    // assert deprecated @type arg values map to expected color
+    for (const type in OLD_TYPES) {
+      this.type = type;
+      const color = OLD_TYPES[type];
+      await render(hbs`<AlertInline @type={{this.type}}  @message="some very important alert" />`);
+      assert
+        .dom(`[data-test-icon="${color.icon}"]`)
+        .exists(`deprecated @type="${type}" renders icon: ${color.icon}`);
+      assert
+        .dom('[data-test-inline-alert]')
+        .hasClass(color.class, `deprecated @type="${type}" renders class: ${color.class}`);
+    }
   });
 
   test('it mimics loading when message changes', async function (assert) {
+    this.message = 'some very important alert';
     await render(hbs`
-    <AlertInline
-      @message={{this.message}}
-      @mimicRefresh={{true}}
-      @type={{this.type}}
-    />
+    <AlertInline @message={{this.message}}/>
     `);
     assert
       .dom('[data-test-inline-error-message]')

--- a/ui/tests/integration/components/alert-inline-test.js
+++ b/ui/tests/integration/components/alert-inline-test.js
@@ -29,7 +29,7 @@ module('Integration | Component | alert-inline', function (hooks) {
     assert.dom('[data-test-inline-error-message]').hasText('some very important alert');
     assert
       .dom('[data-test-inline-alert]')
-      .hasAttribute('class', 'is-flex-center padding-top is-marginless size-small');
+      .hasAttribute('class', 'is-flex-center has-padding-top-s is-marginless size-small');
   });
 
   test('it yields to block text', async function (assert) {

--- a/ui/tests/integration/components/alert-inline-test.js
+++ b/ui/tests/integration/components/alert-inline-test.js
@@ -21,7 +21,6 @@ module('Integration | Component | alert-inline', function (hooks) {
     <AlertInline
       class="has-top-padding-s"
       @isMarginless={{true}}
-      @sizeSmall={{true}}
       @message={{this.message}}
       @type={{this.type}}
     />
@@ -29,7 +28,7 @@ module('Integration | Component | alert-inline', function (hooks) {
     assert.dom('[data-test-inline-error-message]').hasText('some very important alert');
     assert
       .dom('[data-test-inline-alert]')
-      .hasAttribute('class', 'is-flex-center has-padding-top-s is-marginless size-small');
+      .hasAttribute('class', 'is-flex-center has-padding-top-s is-marginless');
   });
 
   test('it yields to block text', async function (assert) {

--- a/ui/tests/integration/components/alert-inline-test.js
+++ b/ui/tests/integration/components/alert-inline-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | alert-inline', function (hooks) {
   test('it renders alert message with correct class args', async function (assert) {
     await render(hbs`
     <AlertInline
-      @paddingTop={{true}}
+      class="has-top-padding-s"
       @isMarginless={{true}}
       @sizeSmall={{true}}
       @message={{this.message}}

--- a/ui/tests/integration/components/kubernetes/page/configure-test.js
+++ b/ui/tests/integration/components/kubernetes/page/configure-test.js
@@ -222,9 +222,9 @@ module('Integration | Component | kubernetes | Page::Configure', function (hooks
     await click('[data-test-config-save]');
 
     assert
-      .dom('[data-test-inline-error-message]')
+      .dom('[data-test-field-validation="kubernetesHost"] [data-test-inline-error-message]')
       .hasText('Kubernetes host is required', 'Error renders for required field');
-    assert.dom('[data-test-alert] p').hasText('There is an error with this form.', 'Alert renders');
+    assert.dom('[data-test-alert]').hasText('There is an error with this form.', 'Alert renders');
   });
 
   test('it should save inferred config', async function (assert) {

--- a/ui/tests/integration/components/ldap/page/configure-test.js
+++ b/ui/tests/integration/components/ldap/page/configure-test.js
@@ -85,7 +85,7 @@ module('Integration | Component | ldap | Page::Configure', function (hooks) {
       .dom('[data-test-field="bindpass"] [data-test-inline-error-message]')
       .hasText('Administrator password is required.', 'Validation message renders for bindpass');
     assert
-      .dom('[data-test-invalid-form-message] p')
+      .dom('[data-test-invalid-form-message]')
       .hasText('There are 2 errors with this form.', 'Invalid form message renders');
   });
 

--- a/ui/tests/integration/components/ldap/page/library/create-and-edit-test.js
+++ b/ui/tests/integration/components/ldap/page/library/create-and-edit-test.js
@@ -87,13 +87,13 @@ module('Integration | Component | ldap | Page::Library::CreateAndEdit', function
     await click('[data-test-save]');
 
     assert
-      .dom('[data-test-field-validation="name"] p')
+      .dom('[data-test-field-validation="name"]')
       .hasText('Library name is required.', 'Name validation error renders');
     assert
-      .dom('[data-test-field-validation="service_account_names"] p')
+      .dom('[data-test-field-validation="service_account_names"]')
       .hasText('At least one service account is required.', 'Service account name validation error renders');
     assert
-      .dom('[data-test-invalid-form-message] p')
+      .dom('[data-test-invalid-form-message]')
       .hasText('There are 2 errors with this form.', 'Invalid form message renders');
   });
 


### PR DESCRIPTION
Use `Hds::Alert @type="compact"` in the `AlertInline` component so styling is consistent throughout UI.

<img width="1135" alt="Screenshot 2023-11-30 at 11 22 50 AM" src="https://github.com/hashicorp/vault/assets/68122737/3bd89983-16a2-437c-8041-8ce2b809e0ab">
