### PR TITLE
only update license changes in ui related files in ui precommit hook

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -115,7 +115,7 @@ ui_copywrite() {
   # run the copywrite tool
   # if a --path option is added we could apply the headers to only the staged files much easier
   # as of the latest version 0.16.6 there is only support for --dirPath
-  STAGED_FILES=($(git diff --name-only --cached))
+  STAGED_FILES=($(git diff --name-only --cached -- $DIR/))
 
   rm -rf $BINARY_DIR/.staged
   mkdir $BINARY_DIR/.staged


### PR DESCRIPTION
I am facing a bug in the pre commit hook where if the staged files include non-ui changes, they are being modified as well. This has happened to me when trying to merge main into a branch and there are ui changes, and then the precommit hook will modify go.mod, some go files, etc. 