### PR TITLE
Always forward entity merge requests from perfStandby

### DIFF
--- a/changelog/24325.txt
+++ b/changelog/24325.txt
@@ -1,4 +1,4 @@
 ```release-note:change
-identity (enterprise) : POST requests to the `/identity/entity/merge` endpoint
+identity (enterprise): POST requests to the `/identity/entity/merge` endpoint
 are now always forwarded from standbys to the active node.
 ```

--- a/changelog/24325.txt
+++ b/changelog/24325.txt
@@ -1,0 +1,4 @@
+```release-note:change
+identity: POST requests to the `/identity/entity/merge` endpoint are now always
+forwarded from standbys to the active node.
+```

--- a/changelog/24325.txt
+++ b/changelog/24325.txt
@@ -1,4 +1,4 @@
 ```release-note:change
-identity: POST requests to the `/identity/entity/merge` endpoint are now always
-forwarded from standbys to the active node.
+identity (enterprise) : POST requests to the `/identity/entity/merge` endpoint
+are now always forwarded from standbys to the active node.
 ```

--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -231,7 +231,8 @@ func entityPaths(i *IdentityStore) []*framework.Path {
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.UpdateOperation: &framework.PathOperation{
-					Callback: i.pathEntityMergeID(),
+					Callback:                  i.pathEntityMergeID(),
+					ForwardPerformanceStandby: true,
 				},
 			},
 


### PR DESCRIPTION
Update requests to `/sys/identity/entity/merge` perform merges on perfStandby nodes in memory and skip the persist call. 

This PR changes the behavior for the merge endpoint, forcing it to be forwarded from the standby to the active node. This change is specifically scoped to manual merges, as automatic merges are not isolated to a specific endpoint and require careful consideration for all callers.

Tests are on Enterprise: https://github.com/hashicorp/vault-enterprise/pull/5008/files