### PR TITLE
Always forward entity merge requests from perfStandby (#24325)

### DIFF
--- a/changelog/24325.txt
+++ b/changelog/24325.txt
@@ -1,0 +1,4 @@
+```release-note:change
+identity (enterprise): POST requests to the `/identity/entity/merge` endpoint
+are now always forwarded from standbys to the active node.
+```

--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -143,8 +143,11 @@ func entityPaths(i *IdentityStore) []*framework.Path {
 					Description: "Setting this will follow the 'mine' strategy for merging MFA secrets. If there are secrets of the same type both in entities that are merged from and in entity into which all others are getting merged, secrets in the destination will be unaltered. If not set, this API will throw an error containing all the conflicts.",
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: i.pathEntityMergeID(),
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:                  i.pathEntityMergeID(),
+					ForwardPerformanceStandby: true,
+				},
 			},
 
 			HelpSynopsis:    strings.TrimSpace(entityHelp["entity-merge-id"][0]),


### PR DESCRIPTION
Update requests to /sys/identity/entity/merge perform merges on perfStandby nodes in memory and skip the persist call.

This commit changes the behavior for the merge endpoint, forcing it to be forwarded from the standby to the active node. This change is specifically scoped to manual merges, as automatic merges are not isolated to a specific endpoint and require careful consideration for all callers.