### PR TITLE
Vault-14651: add function for restarting cluster nodes

### DIFF
--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -16,7 +16,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
+	"github.com/docker/docker/api/types/container"
 	"io"
 	"io/ioutil"
 	"math/big"
@@ -25,6 +27,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -862,6 +865,52 @@ func (n *DockerClusterNode) Start(ctx context.Context, opts *DockerClusterOption
 
 func (n *DockerClusterNode) Pause(ctx context.Context) error {
 	return n.DockerAPI.ContainerPause(ctx, n.Container.ID)
+}
+
+func (n *DockerClusterNode) Restart(ctx context.Context) error {
+	timeout := 5
+	err := n.DockerAPI.ContainerRestart(ctx, n.Container.ID, container.StopOptions{Timeout: &timeout})
+	if err != nil {
+		return err
+	}
+
+	resp, err := n.DockerAPI.ContainerInspect(ctx, n.Container.ID)
+	if err != nil {
+		return fmt.Errorf("error inspecting container after restart: %s", err)
+	}
+
+	var port int
+	if len(resp.NetworkSettings.Ports) > 0 {
+		for key, binding := range resp.NetworkSettings.Ports {
+			if len(binding) < 1 {
+				continue
+			}
+
+			if key == "8200/tcp" {
+				port, err = strconv.Atoi(binding[0].HostPort)
+			}
+		}
+	}
+
+	if port == 0 {
+		return fmt.Errorf("failed to find container port after restart")
+	}
+
+	hostPieces := strings.Split(n.HostPort, ":")
+	if len(hostPieces) < 2 {
+		return errors.New("could not parse node hostname")
+	}
+
+	n.HostPort = fmt.Sprintf("%s:%d", hostPieces[0], port)
+
+	client, err := n.newAPIClient()
+	if err != nil {
+		return err
+	}
+	client.SetToken(n.Cluster.rootToken)
+	n.client = client
+
+	return nil
 }
 
 func (n *DockerClusterNode) AddNetworkDelay(ctx context.Context, delay time.Duration, targetIP string) error {


### PR DESCRIPTION
This adds a `Restart` function for use in testing with docker clusters