### PR TITLE
Only use the short persistKeyring timeout for encryption count tracking

### DIFF
--- a/changelog/24336.txt
+++ b/changelog/24336.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix a timeout initializing Vault by only using a short timeout persisting barrier keyring encryption counts.
+```

--- a/vault/core.go
+++ b/vault/core.go
@@ -3528,7 +3528,8 @@ func (c *Core) autoRotateBarrierLoop(ctx context.Context) {
 	t := time.NewTicker(autoRotateCheckInterval)
 	for {
 		select {
-		case <-t.C:
+		case <-t.C: // persistKeyring is used to write out the keyring using the
+
 			c.checkBarrierAutoRotate(ctx)
 		case <-ctx.Done():
 			t.Stop()

--- a/vault/core.go
+++ b/vault/core.go
@@ -3528,8 +3528,7 @@ func (c *Core) autoRotateBarrierLoop(ctx context.Context) {
 	t := time.NewTicker(autoRotateCheckInterval)
 	for {
 		select {
-		case <-t.C: // persistKeyring is used to write out the keyring using the
-
+		case <-t.C:
 			c.checkBarrierAutoRotate(ctx)
 		case <-ctx.Done():
 			t.Stop()


### PR DESCRIPTION
The recently introduced short timeout to prevent slow HSMs causing trouble while persisting barrier encryptions was also affecting more important code paths.  This changes that timeout to only be applied on encryption count persists.