### PR TITLE
Update ldap.mdx

### DIFF
--- a/website/content/api-docs/auth/ldap.mdx
+++ b/website/content/api-docs/auth/ldap.mdx
@@ -103,6 +103,8 @@ This endpoint configures the LDAP auth method.
   up to the given size. This can be used to avoid hitting the LDAP server's
   maximum result size limit. Otherwise, the LDAP backend will not use the
   paged search control.
+- `use_token_groups` `(bool: true)` - (Optional) Use the Active Directory tokenGroups
+  constructed attribute of the user to find the group memberships.
 
 @include 'tokenfields.mdx'
 


### PR DESCRIPTION
add missing use_token_groups parameter

* use_token_groups - (Optional) Use the Active Directory tokenGroups constructed attribute of the user to find the group memberships https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/ldap_auth_backend#use_token_groups