### PR TITLE
Cherry pick license updates from main

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,45 @@
 License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB Corporation Ab.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
 
 Parameters
 
 Licensor:             HashiCorp, Inc.
-Licensed Work:        Vault 1.15.2. The Licensed Work is (c) 2023 HashiCorp, Inc.
-Additional Use Grant: You may make production use of the Licensed Work,
-                      provided such use does not include offering the Licensed Work
-                      to third parties on a hosted or embedded basis which is
-                      competitive with HashiCorp's products.
+Licensed Work:        Vault Version 1.15.0 or later. The Licensed Work is (c) 2023
+                      HashiCorp, Inc.
+Additional Use Grant: You may make production use of the Licensed Work, provided
+                      Your use does not include offering the Licensed Work to third
+                      parties on a hosted or embedded basis in order to compete with 
+                      HashiCorp's paid version(s) of the Licensed Work. For purposes 
+                      of this license:
+
+                      A "competitive offering" is a Product that is offered to third
+                      parties on a paid basis, including through paid support 
+                      arrangements, that significantly overlaps with the capabilities 
+                      of HashiCorp's paid version(s) of the Licensed Work. If Your 
+                      Product is not a competitive offering when You first make it 
+                      generally available, it will not become a competitive offering
+                      later due to HashiCorp releasing a new version of the Licensed 
+                      Work with additional capabilities. In addition, Products that 
+                      are not provided on a paid basis are not competitive.
+
+                      "Product" means software that is offered to end users to manage 
+                      in their own environments or offered as a service on a hosted 
+                      basis.
+
+                      "Embedded" means including the source code or executable code 
+                      from the Licensed Work in a competitive offering. "Embedded" 
+                      also means packaging the competitive offering in such a way 
+                      that the Licensed Work must be accessed or downloaded for the 
+                      competitive offering to operate.
+
+                      Hosting or using the Licensed Work(s) for internal purposes 
+                      within an organization is not considered a competitive 
+                      offering. HashiCorp considers your organization to include all 
+                      of your affiliates under common control.
+
+                      For binding interpretive guidance on using HashiCorp products 
+                      under the Business Source License, please visit our FAQ. 
+                      (https://www.hashicorp.com/license-faq)
 Change Date:          Four years from the date the Licensed Work is published.
 Change License:       MPL 2.0
 
@@ -55,7 +86,7 @@ Licensor or its affiliates (provided that you may use a trademark or logo of
 Licensor as expressly required by this License).
 
 TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
-AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
 EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
 MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
 TITLE.


### PR DESCRIPTION
Should avoid the need to continually update these files on release.

The text is text I got from an appropriate source, not legal text I wrote. It now matches the file contents on `main`. This is a cherry-pick backport.