### PR TITLE
Update VSO docs for v0.4.1

### DIFF
--- a/website/content/docs/platform/k8s/vso/helm.mdx
+++ b/website/content/docs/platform/k8s/vso/helm.mdx
@@ -119,7 +119,7 @@ Use these links to navigate to a particular top-level stanza.
 
       - `repository` ((#v-controller-manager-image-repository)) (`string: hashicorp/vault-secrets-operator`)
 
-      - `tag` ((#v-controller-manager-image-tag)) (`string: 0.4.0`)
+      - `tag` ((#v-controller-manager-image-tag)) (`string: 0.4.1`)
 
     - `clientCache` ((#v-controller-manager-clientcache)) - Configures the client cache which is used by the controller to cache (and potentially persist) vault tokens that
       are the result of using the VaultAuthMethod. This enables re-use of Vault Tokens
@@ -262,8 +262,7 @@ Use these links to navigate to a particular top-level stanza.
           headers:
             X-vault-something1: "foo"
 
-    - `maxConcurrentReconciles` ((#v-controller-manager-maxconcurrentreconciles)) (`integer: ""`) - Defines the maximum number of concurrent reconciles by the controller.
-      NOTE: Currently this is only used by the reconciliation logic of dynamic secrets.
+    - `maxConcurrentReconciles` ((#v-controller-manager-maxconcurrentreconciles)) (`integer: ""`) - Defines the maximum number of concurrent reconciles for each controller.
 
       default: 100
 

--- a/website/content/docs/platform/k8s/vso/installation.mdx
+++ b/website/content/docs/platform/k8s/vso/installation.mdx
@@ -30,13 +30,13 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 ```shell-session
 $ helm search repo hashicorp/vault-secrets-operator
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault-secrets-operator	0.4.0       	0.4.0     	Official HashiCorp Vault Secrets Operator Chart
+hashicorp/vault-secrets-operator	0.4.1       	0.4.1     	Official HashiCorp Vault Secrets Operator Chart
 ```
 
 Then install the Operator:
 
 ```shell-session
-$ helm install --version 0.4.0 --create-namespace --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
+$ helm install --version 0.4.1 --create-namespace --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
 ```
 
 
@@ -65,10 +65,10 @@ $ helm show crds --version <TARGET_VSO_VERSION> hashicorp/vault-secrets-operator
 $ helm upgrade --version <TARGET_VSO_VERSION> --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
 ```
 
-For example, if you are upgrading to VSO 0.4.0:
+For example, if you are upgrading to VSO 0.4.1:
 ```shell-session
-$ helm show crds --version 0.4.0 hashicorp/vault-secrets-operator | kubectl apply -f -
-$ helm upgrade --version 0.4.0 --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
+$ helm show crds --version 0.4.1 hashicorp/vault-secrets-operator | kubectl apply -f -
+$ helm upgrade --version 0.4.1 --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
 ```
 
 ## Updating CRDs
@@ -83,9 +83,9 @@ To update the VSO CRDs, replace `<TARGET_VSO_VERSION>` with the VSO version you 
 $ helm show crds --version <TARGET_VSO_VERSION> hashicorp/vault-secrets-operator | kubectl apply -f -
 ```
 
-For example, if you are upgrading to VSO 0.4.0:
+For example, if you are upgrading to VSO 0.4.1:
 ```shell-session
-$ helm show crds --version 0.4.0 hashicorp/vault-secrets-operator | kubectl apply -f -
+$ helm show crds --version 0.4.1 hashicorp/vault-secrets-operator | kubectl apply -f -
 
 customresourcedefinition.apiextensions.k8s.io/hcpauths.secrets.hashicorp.com created
 customresourcedefinition.apiextensions.k8s.io/hcpvaultsecretsapps.secrets.hashicorp.com created

--- a/website/content/docs/platform/k8s/vso/openshift.mdx
+++ b/website/content/docs/platform/k8s/vso/openshift.mdx
@@ -23,7 +23,7 @@ The Vault Secrets Operator may also be installed in OpenShift using the Helm cha
 $ helm install vault-secrets-operator hashicorp/vault-secrets-operator \
   --create-namespace \
   --namespace vault-secrets-operator \
-  --version 0.4.0 \
+  --version 0.4.1 \
   --values values.yaml
 ```
 
@@ -56,7 +56,7 @@ controller:
   manager:
     image:
       repository: registry.connect.redhat.com/hashicorp/vault-secrets-operator
-      tag: 0.4.0-ubi
+      tag: 0.4.1-ubi
     resources:
       limits:
         memory: 256Mi


### PR DESCRIPTION
Update platform docs for the v0.4.1 VSO release.

Milestone: https://github.com/hashicorp/vault-secrets-operator/milestone/16