### PR TITLE
Document and augment tests that PKI accepts 8192 bit RSA keys

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1220,7 +1220,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 	}
 
 	getRandCsr := func(keyType string, errorOk bool, csrTemplate *x509.CertificateRequest) csrPlan {
-		rsaKeyBits := []int{2048, 3072, 4096}
+		rsaKeyBits := []int{2048, 3072, 4096, 8192}
 		ecKeyBits := []int{224, 256, 384, 521}
 		plan := csrPlan{errorOk: errorOk}
 

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -324,9 +324,8 @@ is required. Ignored for other types.`,
 		Type:    framework.TypeInt,
 		Default: 0,
 		Description: `The number of bits to use. Allowed values are
-0 (universal default); with rsa key_type: 2048 (default), 3072, or
-4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
-ed25519.`,
+0 (universal default); with rsa key_type: 2048 (default), 3072, 4096 or 8192;
+with ec key_type: 224, 256 (default), 384, or 521; ignored with ed25519.`,
 		DisplayAttrs: &framework.DisplayAttributes{
 			Value: 0,
 		},

--- a/builtin/logical/pki/path_manage_keys.go
+++ b/builtin/logical/pki/path_manage_keys.go
@@ -44,9 +44,8 @@ func pathGenerateKey(b *backend) *framework.Path {
 				Type:    framework.TypeInt,
 				Default: 0,
 				Description: `The number of bits to use. Allowed values are
-0 (universal default); with rsa key_type: 2048 (default), 3072, or
-4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
-ed25519.`,
+0 (universal default); with rsa key_type: 2048 (default), 3072, 4096 or 8192;
+with ec key_type: 224, 256 (default), 384, or 521; ignored with ed25519.`,
 			},
 			"managed_key_name": {
 				Type: framework.TypeString,

--- a/builtin/logical/pki/path_manage_keys_test.go
+++ b/builtin/logical/pki/path_manage_keys_test.go
@@ -31,7 +31,7 @@ func TestPKI_PathManageKeys_GenerateInternalKeys(t *testing.T) {
 		wantLogicalErr bool
 	}{
 		{"all-defaults", "", []int{0}, false},
-		{"rsa", "rsa", []int{0, 2048, 3072, 4096}, false},
+		{"rsa", "rsa", []int{0, 2048, 3072, 4096, 8192}, false},
 		{"ec", "ec", []int{0, 224, 256, 384, 521}, false},
 		{"ed25519", "ed25519", []int{0}, false},
 		{"error-rsa", "rsa", []int{-1, 343444}, true},

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -751,8 +751,8 @@ engine override the issuer as necessary.
 
 - `key_bits` `(int: 0)` - Specifies the number of bits to use for the
   generated keys. Allowed values are 0 (universal default); with
-  `key_type=rsa`, allowed values are: 2048 (default), 3072, or
-  4096; with `key_type=ec`, allowed values are: 224, 256 (default),
+  `key_type=rsa`, allowed values are: 2048 (default), 3072, 4096 or 8192;
+  with `key_type=ec`, allowed values are: 224, 256 (default),
   384, or 521; ignored with `key_type=ed25519`.
 
 - `private_key_format` `(string: "der")` - Specifies the format for marshaling
@@ -2194,8 +2194,8 @@ used.
 
 - `key_bits` `(int: 0)` - Specifies the number of bits to use for the
   generated keys. Allowed values are 0 (universal default); with
-  `key_type=rsa`, allowed values are: 2048 (default), 3072, or
-  4096; with `key_type=ec`, allowed values are: 224, 256 (default),
+  `key_type=rsa`, allowed values are: 2048 (default), 3072, 4096 or 8192;
+  with `key_type=ec`, allowed values are: 224, 256 (default),
   384, or 521; ignored with `key_type=ed25519`.
 
 #### Managed keys parameters
@@ -2341,8 +2341,8 @@ use the values set via `config/urls`.
 
 - `key_bits` `(int: 0)` - Specifies the number of bits to use for the
   generated keys. Allowed values are 0 (universal default); with
-  `key_type=rsa`, allowed values are: 2048 (default), 3072, or
-  4096; with `key_type=ec`, allowed values are: 224, 256 (default),
+  `key_type=rsa`, allowed values are: 2048 (default), 3072, 4096 or 8192;
+  with `key_type=ec`, allowed values are: 224, 256 (default),
   384, or 521; ignored with `key_type=ed25519`.
 
 - `max_path_length` `(int: -1)` - Specifies the maximum path length to encode in
@@ -2541,8 +2541,8 @@ generated depending on the `type` request parameter.
 
 - `key_bits` `(int: 0)` - Specifies the number of bits to use for the
   generated keys. Allowed values are 0 (universal default); with
-  `key_type=rsa`, allowed values are: 2048 (default), 3072, or
-  4096; with `key_type=ec`, allowed values are: 224, 256 (default),
+  `key_type=rsa`, allowed values are: 2048 (default), 3072, 4096, or 8192;
+  with `key_type=ec`, allowed values are: 224, 256 (default),
   384, or 521; ignored with `key_type=ed25519`. Not suitable for
   `type=existing` requests.
 
@@ -3449,8 +3449,8 @@ request is denied.
 
 - `key_bits` `(int: 0)` - Specifies the number of bits to use for the
   generated keys. Allowed values are 0 (universal default); with
-  `key_type=rsa`, allowed values are: 2048 (default), 3072, or
-  4096; with `key_type=ec`, allowed values are: 224, 256 (default),
+  `key_type=rsa`, allowed values are: 2048 (default), 3072, 4096 or 8192;
+  with `key_type=ec`, allowed values are: 224, 256 (default),
   384, or 521; ignored with `key_type=ed25519` or in signing operations
   when `key_type=any`.
 


### PR DESCRIPTION
 - Noticed that our documentation was out of date, we allow 8192 bit RSA keys to be used as an argument to the various PKI issuer/key creation APIs.
 - Augument some unit tests to verify this continues to work