### PR TITLE
Make leaderCheckInterval configurable.

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -699,8 +699,9 @@ type Core struct {
 	// Config value for "detect_deadlocks".
 	detectDeadlocks []string
 
-	echoDuration              *uberAtomic.Duration
-	activeNodeClockSkewMillis *uberAtomic.Int64
+	echoDuration                  *uberAtomic.Duration
+	activeNodeClockSkewMillis     *uberAtomic.Int64
+	periodicLeaderRefreshInterval time.Duration
 }
 
 func (c *Core) ActiveNodeClockSkewMillis() int64 {
@@ -875,6 +876,8 @@ type CoreConfig struct {
 	AdministrativeNamespacePath string
 
 	NumRollbackWorkers int
+
+	PeriodicLeaderRefreshInterval time.Duration
 }
 
 // GetServiceRegistration returns the config's ServiceRegistration, or nil if it does
@@ -958,6 +961,10 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 
 	if conf.NumRollbackWorkers == 0 {
 		conf.NumRollbackWorkers = RollbackDefaultNumWorkers
+	}
+
+	if conf.PeriodicLeaderRefreshInterval == 0 {
+		conf.PeriodicLeaderRefreshInterval = leaderCheckInterval
 	}
 
 	effectiveSDKVersion := conf.EffectiveSDKVersion
@@ -1058,6 +1065,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		detectDeadlocks:                detectDeadlocks,
 		echoDuration:                   uberAtomic.NewDuration(0),
 		activeNodeClockSkewMillis:      uberAtomic.NewInt64(0),
+		periodicLeaderRefreshInterval:  conf.PeriodicLeaderRefreshInterval,
 	}
 
 	c.standbyStopCh.Store(make(chan struct{}))

--- a/vault/external_tests/raft/raft_autopilot_test.go
+++ b/vault/external_tests/raft/raft_autopilot_test.go
@@ -438,8 +438,8 @@ func TestRaft_Autopilot_DeadServerCleanup(t *testing.T) {
 	}
 
 	cluster := vault.NewTestCluster(t, conf, opts)
-	cluster.Start()
 	defer cluster.Cleanup()
+	testhelpers.WaitForActiveNode(t, cluster)
 	leader, addressProvider := setupLeaderAndUnseal(t, cluster)
 
 	// Join 2 extra nodes manually, store the 3rd for later

--- a/vault/external_tests/raft/raft_autopilot_test.go
+++ b/vault/external_tests/raft/raft_autopilot_test.go
@@ -226,8 +226,8 @@ func TestRaft_Autopilot_Stabilization_Delay(t *testing.T) {
 		config := map[string]interface{}{
 			"snapshot_threshold":           "50",
 			"trailing_logs":                "100",
-			"autopilot_reconcile_interval": "1s",
-			"autopilot_update_interval":    "500ms",
+			"autopilot_reconcile_interval": "300ms",
+			"autopilot_update_interval":    "100ms",
 			"snapshot_interval":            "1s",
 		}
 		if coreIdx == 2 {

--- a/vault/external_tests/raft/raft_autopilot_test.go
+++ b/vault/external_tests/raft/raft_autopilot_test.go
@@ -44,6 +44,9 @@ func TestRaft_Autopilot_Disable(t *testing.T) {
 	require.Nil(t, nil, state)
 }
 
+// TestRaft_Autopilot_Stabilization_And_State verifies that nodes get promoted
+// to be voters after the stabilization time has elapsed.  Also checks that
+// the autopilot state is Healthy once all nodes are available.
 func TestRaft_Autopilot_Stabilization_And_State(t *testing.T) {
 	t.Parallel()
 	cluster, _ := raftCluster(t, &RaftClusterOpts{

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -835,7 +835,7 @@ func (c *Core) periodicLeaderRefresh(newLeaderCh chan func(), stopCh chan struct
 
 	clusterAddr := ""
 	for {
-		timer := time.NewTimer(leaderCheckInterval)
+		timer := time.NewTimer(c.periodicLeaderRefreshInterval)
 		select {
 		case <-timer.C:
 			count := atomic.AddInt32(opCount, 1)

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1640,6 +1640,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		coreConfig.RollbackPeriod = base.RollbackPeriod
 		coreConfig.PendingRemovalMountsAllowed = base.PendingRemovalMountsAllowed
 		coreConfig.ExpirationRevokeRetryBase = base.ExpirationRevokeRetryBase
+		coreConfig.PeriodicLeaderRefreshInterval = base.PeriodicLeaderRefreshInterval
 		testApplyEntBaseConfig(coreConfig, base)
 	}
 	if coreConfig.ClusterName == "" {
@@ -1653,6 +1654,11 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 	if coreConfig.ClusterHeartbeatInterval == 0 {
 		// Set this lower so that state populates quickly to standby nodes
 		coreConfig.ClusterHeartbeatInterval = 2 * time.Second
+	}
+
+	if coreConfig.PeriodicLeaderRefreshInterval == 0 {
+		// Set this lower so that perf standby nodes become stable more quickly
+		coreConfig.PeriodicLeaderRefreshInterval = 250 * time.Millisecond
 	}
 
 	if coreConfig.RawConfig == nil {

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1824,6 +1824,8 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 	testCluster.start(t)
 
 	if !coreConfig.DisablePerformanceStandby && numCores > 1 && constants.IsEnterprise {
+		// Sleep so that perf standbys have the opportunity to run periodicLeaderRefresh
+		// once, otherwise when they re-initialize themselves they can yield 500s.
 		time.Sleep(coreConfig.PeriodicLeaderRefreshInterval)
 	}
 	return &testCluster

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1822,6 +1822,10 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 
 	testCluster.opts = opts
 	testCluster.start(t)
+
+	if !coreConfig.DisablePerformanceStandby && numCores > 1 && constants.IsEnterprise {
+		time.Sleep(coreConfig.PeriodicLeaderRefreshInterval)
+	}
 	return &testCluster
 }
 


### PR DESCRIPTION
Currently periodicLeaderRefresh polls the leader status every 2.5s.  When a test makes use of a perf standby node, it could get unlucky and issue a request right when that refresh is firing and discovering the leader for the first time, resulting in a 500 error while the perf standby re-initializes itself as a result of periodicLeaderRefresh having closed newLeaderCh.

We could just sleep for 3s after creating a cluster when we want to talk to perf standbys, but that seems an excessive delay, hence this PR to make the polling interval of periodicLeaderRefresh configurable.

After pushing this change I found that some Autopilot tests were failing, I think because of the sleep I added to NewTestCluster.  I want to keep that sleep, because it allows tests to avoid having to worry about periodicLeaderRefresh making them flaky, so I reworked the failing tests.  Then I ran the tests with untilfail and found some more flakiness, so I went a little further to address those.