### PR TITLE
Audit:  logging a request uses a separate 5 second timeout

### DIFF
--- a/changelog/24377.txt
+++ b/changelog/24377.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/audit: Audit logging a Vault request will now use a 5 second context timeout, separate from the original request.
+```


### PR DESCRIPTION
fixes #24376