### PR TITLE
UI: handle reduced disclosure on replication endpoints

### DIFF
--- a/ui/app/adapters/cluster.js
+++ b/ui/app/adapters/cluster.js
@@ -61,6 +61,12 @@ export default ApplicationAdapter.extend({
       }
       if (replicationStatus && replicationStatus instanceof AdapterError === false) {
         ret = Object.assign(ret, replicationStatus.data);
+      } else if (
+        replicationStatus instanceof AdapterError &&
+        replicationStatus?.errors.find((err) => err === 'disabled path')
+      ) {
+        // set redacted if result is an error which only happens when redacted
+        ret = Object.assign(ret, { replication_redacted: true });
       }
       return resolve(ret);
     });

--- a/ui/app/components/sidebar/nav/cluster.hbs
+++ b/ui/app/components/sidebar/nav/cluster.hbs
@@ -52,7 +52,14 @@
   }}
     <Nav.Title data-test-sidebar-nav-heading="Monitoring">Monitoring</Nav.Title>
   {{/if}}
-  {{#if (and this.version.isEnterprise this.namespace.inRootNamespace (has-permission "status" routeParams="replication"))}}
+  {{#if
+    (and
+      this.version.isEnterprise
+      this.namespace.inRootNamespace
+      (not this.cluster.replicationRedacted)
+      (has-permission "status" routeParams="replication")
+    )
+  }}
     <Nav.Link
       @route="vault.cluster.replication.index"
       @text="Replication"

--- a/ui/app/models/cluster.js
+++ b/ui/app/models/cluster.js
@@ -16,8 +16,10 @@ export default class ClusterModel extends Model {
   @attr('boolean') standby;
   @attr('string') type;
   @attr('object') license;
-  // manually set on response when sys/health failure
+
+  // manually set on response in cluster adapter
   @attr('boolean') hasChrootNamespace;
+  @attr('boolean') replicationRedacted;
 
   /* Licensing concerns */
   get licenseExpiry() {

--- a/ui/app/routes/vault/cluster/dashboard.js
+++ b/ui/app/routes/vault/cluster/dashboard.js
@@ -30,12 +30,13 @@ export default class VaultClusterDashboardRoute extends Route.extend(ClusterRout
   model() {
     const clusterModel = this.modelFor('vault.cluster');
     const hasChroot = clusterModel?.hasChrootNamespace;
-    const replication = hasChroot
-      ? null
-      : {
-          dr: clusterModel.dr,
-          performance: clusterModel.performance,
-        };
+    const replication =
+      hasChroot || clusterModel.replicationRedacted
+        ? null
+        : {
+            dr: clusterModel.dr,
+            performance: clusterModel.performance,
+          };
     return hash({
       replication,
       secretsEngines: this.store.query('secret-engine', {}),

--- a/ui/app/templates/components/dashboard/overview.hbs
+++ b/ui/app/templates/components/dashboard/overview.hbs
@@ -12,7 +12,9 @@
         {{#if @license}}
           <Dashboard::ClientCountCard @license={{@license}} />
         {{/if}}
-        {{#if (and @isRootNamespace (has-permission "status" routeParams="replication"))}}
+        {{#if
+          (and @isRootNamespace (has-permission "status" routeParams="replication") (not (is-empty-value @replication)))
+        }}
           <Dashboard::ReplicationCard
             @replication={{@replication}}
             @version={{@version}}

--- a/ui/lib/replication/addon/routes/application.js
+++ b/ui/lib/replication/addon/routes/application.js
@@ -13,8 +13,13 @@ export default Route.extend(ClusterRoute, {
   version: service(),
   store: service(),
   auth: service(),
+  router: service(),
 
   beforeModel() {
+    if (this.auth.activeCluster.replicationRedacted) {
+      // disallow replication access if endpoints are redacted
+      return this.router.transitionTo('vault.cluster');
+    }
     return this.version.fetchFeatures().then(() => {
       return this._super(...arguments);
     });

--- a/ui/mirage/handlers/reduced-disclosure.js
+++ b/ui/mirage/handlers/reduced-disclosure.js
@@ -4,6 +4,7 @@
  */
 
 import modifyPassthroughResponse from '../helpers/modify-passthrough-response';
+import { Response } from 'miragejs';
 
 export default function (server) {
   server.get('/sys/health', (schema, req) =>
@@ -12,7 +13,10 @@ export default function (server) {
   server.get('/sys/seal-status', (schema, req) =>
     modifyPassthroughResponse(req, { version: '', cluster_name: '', build_date: '' })
   );
-  server.get('sys/replication/status', () => new Response(404));
-  server.get('sys/replication/dr/status', () => new Response(404));
-  server.get('sys/replication/performance/status', () => new Response(404));
+  server.get('sys/replication/status', () => new Response(404, {}, { errors: ['disabled path'] }));
+  server.get('sys/replication/dr/status', () => new Response(404, {}, { errors: ['disabled path'] }));
+  server.get(
+    'sys/replication/performance/status',
+    () => new Response(404, {}, { errors: ['disabled path'] })
+  );
 }

--- a/ui/tests/acceptance/enterprise-reduced-disclosure-test.js
+++ b/ui/tests/acceptance/enterprise-reduced-disclosure-test.js
@@ -134,4 +134,15 @@ module('Acceptance | Enterprise | reduced disclosure test', function (hooks) {
       .dom('[data-test-footer-version]')
       .hasText(`Vault ${versionSvc.version}`, 'Version is shown after login');
   });
+
+  test('does not allow access to replication pages', async function (assert) {
+    await authPage.login();
+    await visit(`/vault/replication/dr`);
+
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.dashboard',
+      'redirects to dashboard if replication access attempted'
+    );
+  });
 });

--- a/ui/tests/acceptance/enterprise-reduced-disclosure-test.js
+++ b/ui/tests/acceptance/enterprise-reduced-disclosure-test.js
@@ -140,11 +140,11 @@ module('Acceptance | Enterprise | reduced disclosure test', function (hooks) {
     assert.dom('[data-test-sidebar-nav-link="Replication"]').doesNotExist('hides replication nav item');
 
     await visit(`/vault/replication/dr`);
-
     assert.strictEqual(
       currentRouteName(),
       'vault.cluster.dashboard',
       'redirects to dashboard if replication access attempted'
     );
+    assert.dom('[data-test-card="replication"]').doesNotExist('hides replication card on dashboard');
   });
 });

--- a/ui/tests/acceptance/enterprise-reduced-disclosure-test.js
+++ b/ui/tests/acceptance/enterprise-reduced-disclosure-test.js
@@ -137,6 +137,8 @@ module('Acceptance | Enterprise | reduced disclosure test', function (hooks) {
 
   test('does not allow access to replication pages', async function (assert) {
     await authPage.login();
+    assert.dom('[data-test-sidebar-nav-link="Replication"]').doesNotExist('hides replication nav item');
+
     await visit(`/vault/replication/dr`);
 
     assert.strictEqual(


### PR DESCRIPTION
This PR hides replication-related features when `disable_replication_status_endpoints` is true on the vault configuration. Specifically, when replication endpoints are disabled the UI should:

- hide the replication nav item in the sidebar
- hide the replication card on the dashboard
- disallow access to replication pages (eg. `/ui/vault/replication`) 
- redirect to login page when attempting to access `/ui/vault/replication-dr-promote` when vault is set up as DR secondary

To test, first make sure you are on a 1.16.0-beta+ent or above build of vault. Add `disable_replication_status_endpoints = true` to your listener config like so:
```
listener "tcp" {
  address               = "0.0.0.0:8200"
  cluster_address       = "0.0.0.0:8201"
  disable_replication_status_endpoints = true
  tls_disable = 1
}
```
Then run `yarn start` on this branch to see the changes. 

**Dashboard with root token when disable_replication_status_endpoints is true**
<img width="1395" alt="Dashboard with root token when disable_replication_status_endpoints is true" src="https://github.com/hashicorp/vault/assets/82459713/56cbd243-df06-4e6e-8cd9-fcc9103515f1">


