### PR TITLE
quotas: Move storage updates into quotas package

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -3483,7 +3483,12 @@ func (c *Core) setupQuotas(ctx context.Context, isPerfStandby bool) error {
 		return nil
 	}
 
-	return c.quotaManager.Setup(ctx, c.systemBarrierView, isPerfStandby, c.IsDRSecondary())
+	qmFlags := &quotas.ManagerFlags{
+		IsPerfStandby: isPerfStandby,
+		IsDRSecondary: c.IsDRSecondary(),
+	}
+
+	return c.quotaManager.Setup(ctx, c.systemBarrierView, qmFlags)
 }
 
 // ApplyRateLimitQuota checks the request against all the applicable quota rules.

--- a/vault/logical_system_quotas.go
+++ b/vault/logical_system_quotas.go
@@ -477,15 +477,6 @@ func (b *SystemBackend) handleRateLimitQuotasUpdate() framework.OperationFunc {
 			rlq.BlockInterval = blockInterval
 			quota = rlq
 		}
-		entry, err := logical.StorageEntryJSON(quotas.QuotaStoragePath(qType, name), quota)
-		if err != nil {
-			return nil, err
-		}
-
-		if err := b.Core.systemBarrierView.storage.Put(ctx, entry); err != nil {
-			return nil, err
-		}
-
 		if err := b.Core.quotaManager.SetQuota(ctx, qType, quota, false); err != nil {
 			return nil, err
 		}
@@ -548,10 +539,6 @@ func (b *SystemBackend) handleRateLimitQuotasDelete() framework.OperationFunc {
 			if quota != nil && !strings.HasPrefix(quota.GetNamespacePath(), ns.Path) {
 				return logical.ErrorResponse(ErrInvalidQuotaDeletion), nil
 			}
-		}
-
-		if err := b.Core.systemBarrierView.Delete(ctx, quotas.QuotaStoragePath(qType, name)); err != nil {
-			return nil, err
 		}
 
 		if err := b.Core.quotaManager.DeleteQuota(ctx, qType, name); err != nil {

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -316,8 +316,23 @@ func NewManager(logger log.Logger, walkFunc leaseWalkFunc, ms *metricsutil.Clust
 	return manager, nil
 }
 
-// SetQuota adds or updates a quota rule.
+// SetQuota adds or updates a quota rule in the Quota Manager's storage view and
+// the associated index in memdb.
 func (m *Manager) SetQuota(ctx context.Context, qType string, quota Quota, loading bool) error {
+	entry, err := logical.StorageEntryJSON(QuotaStoragePath(qType, quota.QuotaName()), quota)
+	if err != nil {
+		return err
+	}
+
+	if err := m.storage.Put(ctx, entry); err != nil {
+		return err
+	}
+
+	return m.setQuotaIndex(ctx, qType, quota, loading)
+}
+
+// setQuotaIndex adds or updates a quota rule in memdb.
+func (m *Manager) setQuotaIndex(ctx context.Context, qType string, quota Quota, loading bool) error {
 	m.quotaLock.Lock()
 	m.dbAndCacheLock.RLock()
 	defer m.quotaLock.Unlock()
@@ -667,8 +682,18 @@ func (m *Manager) QueryResolveRoleQuotas(req *Request) (bool, error) {
 	return false, nil
 }
 
-// DeleteQuota removes a quota rule from the db for a given name
+// DeleteQuota removes a quota rule the QuotaManager's storage view and then
+// updates the associated index in memdb.
 func (m *Manager) DeleteQuota(ctx context.Context, qType string, name string) error {
+	if err := m.storage.Delete(ctx, QuotaStoragePath(qType, name)); err != nil {
+		return err
+	}
+
+	return m.deleteQuotaIndex(ctx, qType, name)
+}
+
+// deleteQuotaIndex removes a quota rule memdb for a given quota type and name.
+func (m *Manager) deleteQuotaIndex(ctx context.Context, qType string, name string) error {
 	m.quotaLock.Lock()
 	m.dbAndCacheLock.RLock()
 	defer m.quotaLock.Unlock()
@@ -1058,13 +1083,13 @@ func (m *Manager) Invalidate(key string) {
 		switch {
 		case quota == nil:
 			// Handle quota deletion
-			if err := m.DeleteQuota(m.ctx, qType, name); err != nil {
+			if err := m.deleteQuotaIndex(m.ctx, qType, name); err != nil {
 				m.logger.Error("failed to delete invalidated quota rule", "error", err)
 				return
 			}
 		default:
 			// Handle quota update
-			if err := m.SetQuota(m.ctx, qType, quota, false); err != nil {
+			if err := m.setQuotaIndex(m.ctx, qType, quota, false); err != nil {
 				m.logger.Error("failed to update invalidated quota rule", "error", err)
 				return
 			}
@@ -1119,9 +1144,14 @@ func Load(ctx context.Context, storage logical.Storage, qType, name string) (Quo
 	return quota, nil
 }
 
+type ManagerFlags struct {
+	IsPerfStandby bool
+	IsDRSecondary bool
+}
+
 // Setup loads the quota configuration and all the quota rules into the
 // quota manager.
-func (m *Manager) Setup(ctx context.Context, storage logical.Storage, isPerfStandby, isDRSecondary bool) error {
+func (m *Manager) Setup(ctx context.Context, storage logical.Storage, flags *ManagerFlags) error {
 	m.quotaLock.Lock()
 	m.quotaConfigLock.Lock()
 	m.dbAndCacheLock.Lock()
@@ -1131,8 +1161,12 @@ func (m *Manager) Setup(ctx context.Context, storage logical.Storage, isPerfStan
 
 	m.storage = storage
 	m.ctx = ctx
-	m.isPerfStandby = isPerfStandby
-	m.isDRSecondary = isDRSecondary
+
+	if flags == nil {
+		flags = &ManagerFlags{}
+	}
+	m.isPerfStandby = flags.IsPerfStandby
+	m.isDRSecondary = flags.IsDRSecondary
 
 	// Load the quota configuration from storage and load it into the quota
 	// manager.

--- a/vault/quotas/quotas_rate_limit_test.go
+++ b/vault/quotas/quotas_rate_limit_test.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"go.uber.org/goleak"
@@ -220,6 +221,9 @@ func TestRateLimitQuota_Update(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	qm, err := NewManager(logging.NewVaultLogger(log.Trace), nil, metricsutil.BlackholeSink(), true)
 	require.NoError(t, err)
+
+	view := &logical.InmemStorage{}
+	require.NoError(t, qm.Setup(context.Background(), view, nil))
 
 	quota := NewRateLimitQuota("quota1", "", "", "", "", false, time.Second, 0, 10)
 	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), quota, true))


### PR DESCRIPTION
This commit moves quota storage updates into the storage package to facilitate testing. As a part of the change, we create a new `ManagerFlags` struct to make Setup invocations a bit more ergnomic.