### PR TITLE
Remove is-version Helper

### DIFF
--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -35,6 +35,7 @@ export default class KvSecretDetails extends Component {
 
   @tracked showJsonView = false;
   @tracked wrappedData = null;
+  @tracked syncStatus = null;
   secretDataIsAdvanced;
 
   constructor() {

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -35,7 +35,7 @@ export default class KvSecretDetails extends Component {
 
   @tracked showJsonView = false;
   @tracked wrappedData = null;
-  @tracked syncStatus = null;
+  @tracked syncStatus = null; // array of association sync status info by destination
   secretDataIsAdvanced;
 
   constructor() {

--- a/ui/lib/sync/addon/components/secrets/landing-cta.hbs
+++ b/ui/lib/sync/addon/components/secrets/landing-cta.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <div class="box is-fullwidth is-sideless is-flex-between is-shadowless" data-test-cta-container>
-  {{#if (is-version "Enterprise")}}
+  {{#if this.version.isCommunity}}
     <p>
       Sync secrets to platforms and tools across your stack to get secrets when and where you need them.
       <Hds::Link::Standalone

--- a/ui/lib/sync/addon/components/secrets/landing-cta.hbs
+++ b/ui/lib/sync/addon/components/secrets/landing-cta.hbs
@@ -4,13 +4,14 @@
 ~}}
 
 <div class="box is-fullwidth is-sideless is-flex-between is-shadowless" data-test-cta-container>
-  {{#if this.version.isCommunity}}
+  {{#if this.version.isEnterprise}}
     <p>
       Sync secrets to platforms and tools across your stack to get secrets when and where you need them.
       <Hds::Link::Standalone
         @icon="learn-link"
         @text="Secrets sync tutorial"
         @href={{doc-link "/vault/tutorials/enterprise/secrets-sync"}}
+        data-test-cta-doc-link
       />
     </p>
   {{else}}
@@ -24,7 +25,7 @@
       @iconPosition="trailing"
       @isHrefExternal={{true}}
       @href={{doc-link "/vault/tutorials/enterprise/secrets-sync"}}
-      data-test-cta-button
+      data-test-cta-doc-link
     />
   {{/if}}
 </div>

--- a/ui/lib/sync/addon/components/secrets/landing-cta.ts
+++ b/ui/lib/sync/addon/components/secrets/landing-cta.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+import type VersionService from 'vault/services/version';
+
+export default class SyncLandingCtaComponent extends Component {
+  @service declare readonly version: VersionService;
+}

--- a/ui/lib/sync/addon/components/sync-header.hbs
+++ b/ui/lib/sync/addon/components/sync-header.hbs
@@ -14,7 +14,7 @@
         <Icon @name={{@icon}} @size="24" />
       {{/if}}
       {{@title}}
-      {{#if (is-version "OSS")}}
+      {{#if this.version.isCommunity}}
         <Hds::Badge @text="Enterprise feature" @color="highlight" @size="large" />
       {{/if}}
     </h1>

--- a/ui/lib/sync/addon/components/sync-header.ts
+++ b/ui/lib/sync/addon/components/sync-header.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+import type VersionService from 'vault/services/version';
+import type { Breadcrumb } from 'vault/vault/app-types';
+
+interface Args {
+  title: string;
+  icon?: string;
+  breadcrumbs?: Breadcrumb[];
+}
+
+export default class SyncHeaderComponent extends Component<Args> {
+  @service declare readonly version: VersionService;
+}

--- a/ui/tests/helpers/sync/sync-selectors.js
+++ b/ui/tests/helpers/sync/sync-selectors.js
@@ -10,6 +10,7 @@ export const PAGE = {
   ...GENERAL,
   cta: {
     summary: '[data-test-cta-container] p',
+    link: '[data-test-cta-doc-link]',
     button: '[data-test-cta-button]',
   },
   associations: {

--- a/ui/tests/integration/components/sync/secrets/landing-cta-test.js
+++ b/ui/tests/integration/components/sync/secrets/landing-cta-test.js
@@ -18,7 +18,6 @@ module('Integration | Component | sync | Secrets::LandingCta', function (hooks) 
   });
 
   test('it should render promotional copy for community version', async function (assert) {
-    this.version.version = '1.16.0';
     await render(
       hbs`
      <Secrets::LandingCta />
@@ -31,11 +30,11 @@ module('Integration | Component | sync | Secrets::LandingCta', function (hooks) 
       .hasText(
         'This enterprise feature allows you to sync secrets to platforms and tools across your stack to get secrets when and where you need them.'
       );
-    assert.dom(PAGE.cta.button).hasText('Learn more about secrets sync');
+    assert.dom(PAGE.cta.link).hasText('Learn more about secrets sync');
   });
 
   test('it should render enterprise copy', async function (assert) {
-    this.version.version = '1.16.0+ent';
+    this.version.type = 'enterprise';
     await render(
       hbs`
      <Secrets::LandingCta />
@@ -48,6 +47,6 @@ module('Integration | Component | sync | Secrets::LandingCta', function (hooks) 
       .hasText(
         'Sync secrets to platforms and tools across your stack to get secrets when and where you need them. Secrets sync tutorial'
       );
-    assert.dom(PAGE.cta.button).hasText('Create first destination');
+    assert.dom(PAGE.cta.link).hasText('Secrets sync tutorial');
   });
 });

--- a/ui/tests/integration/components/sync/secrets/page/destinations-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations-test.js
@@ -18,7 +18,7 @@ module('Integration | Component | sync | Page::Destinations', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.owner.lookup('service:version').version = '1.16.0+ent';
+    this.owner.lookup('service:version').type = 'enterprise';
 
     this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub());
 

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -33,7 +33,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    this.owner.lookup('service:version').version = '1.16.0+ent';
+    this.owner.lookup('service:version').type = 'enterprise';
     syncScenario(this.server);
     syncHandlers(this.server);
 

--- a/ui/tests/integration/components/sync/sync-header-test.js
+++ b/ui/tests/integration/components/sync/sync-header-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | sync | SyncHeader', function (hooks) {
 
   hooks.beforeEach(function () {
     this.version = this.owner.lookup('service:version');
-    this.version.version = '1.16.0+ent';
+    this.version.type = 'enterprise';
     this.title = 'Secrets sync';
     this.renderComponent = () => {
       return render(hbs`<SyncHeader @title={{this.title}} @breadcrumbs={{this.breadcrumbs}} />`, {
@@ -42,7 +42,7 @@ module('Integration | Component | sync | SyncHeader', function (hooks) {
   });
 
   test('it should render title and promotional enterprise badge for community version', async function (assert) {
-    this.version.version = '1.16.0';
+    this.version.type = null;
     await this.renderComponent();
     assert.dom('[data-test-page-title]').hasText('Secrets sync Enterprise feature');
   });


### PR DESCRIPTION
This PR removes the `is-version` helper in the sync engine since it was removed from the core addon as part of another project.