### PR TITLE
updated setup/teardown audit code and ordering within broker registration

### DIFF
--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -66,12 +66,14 @@ func (a *AuditBroker) Register(name string, b audit.Backend, local bool) error {
 	}
 
 	if a.broker != nil {
-		err := a.broker.SetSuccessThresholdSinks(eventlogger.EventType(event.AuditType.String()), 1)
+		// Attempt to register the pipeline before enabling 'broker level' enforcement
+		// of how many successful sinks we expect.
+		err := b.RegisterNodesAndPipeline(a.broker, name)
 		if err != nil {
 			return err
 		}
-
-		err = b.RegisterNodesAndPipeline(a.broker, name)
+		// Update the success threshold now that the pipeline is registered.
+		err = a.broker.SetSuccessThresholdSinks(eventlogger.EventType(event.AuditType.String()), 1)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR updates setup and teardown logic for audit, including error handling for failed registration/deregistration. 

During registration of an eventlogger pipeline we now set the threshold *after* the pipeline is successfully registered, this reduces risk that if the first audit device enabled fails, subsequent requests to Vault could fail as the threshold will be configured to `1` when it should not be.