### PR TITLE
Common Selectors for Sync Tests

### DIFF
--- a/ui/tests/helpers/general-selectors.js
+++ b/ui/tests/helpers/general-selectors.js
@@ -11,6 +11,7 @@ export const SELECTORS = {
   headerContainer: 'header.page-header',
   icon: (name) => `[data-test-icon="${name}"]`,
   tab: (name) => `[data-test-tab="${name}"]`,
+  filter: (name) => `[data-test-filter="${name}"]`,
   confirmModalInput: '[data-test-confirmation-modal-input]',
   confirmButton: '[data-test-confirm-button]',
   emptyStateTitle: '[data-test-empty-state-title]',
@@ -26,6 +27,7 @@ export const SELECTORS = {
     option: (index = 0) => `.ember-power-select-option:nth-child(${index + 1})`,
     selectedOption: (index = 0) => `[data-test-selected-option="${index}"]`,
     noMatch: '.ember-power-select-option--no-matches-message',
+    removeSelected: '[data-test-selected-list-button="delete"]',
   },
   overviewCard: {
     title: (title) => `[data-test-overview-card="${title}"] h3`,

--- a/ui/tests/helpers/sync/sync-selectors.js
+++ b/ui/tests/helpers/sync/sync-selectors.js
@@ -34,6 +34,13 @@ export const PAGE = {
       submit: '[data-test-sync-submit]',
       cancel: '[data-test-sync-cancel]',
     },
+    list: {
+      icon: '[data-test-destination-icon]',
+      name: '[data-test-destination-name]',
+      type: '[data-test-destination-type]',
+      deleteAction: '[data-test-delete]',
+      create: '[data-test-create-destination]',
+    },
   },
   overview: {
     createDestination: '[data-test-create-destination]',

--- a/ui/tests/integration/components/sync/sync-header-test.js
+++ b/ui/tests/integration/components/sync/sync-header-test.js
@@ -8,6 +8,9 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupEngine } from 'ember-engines/test-support';
 import hbs from 'htmlbars-inline-precompile';
 import { render } from '@ember/test-helpers';
+import { PAGE } from 'vault/tests/helpers/sync/sync-selectors';
+
+const { breadcrumb, title } = PAGE;
 
 module('Integration | Component | sync | SyncHeader', function (hooks) {
   setupRenderingTest(hooks);
@@ -26,25 +29,25 @@ module('Integration | Component | sync | SyncHeader', function (hooks) {
 
   test('it should render default breadcrumb', async function (assert) {
     await this.renderComponent();
-    assert.dom('[data-test-breadcrumbs]').exists({ count: 1 }, 'Correct number of breadcrumbs render');
-    assert.dom('[data-test-crumb]').includesText('Secrets sync', 'renders default breadcrumb');
+    assert.dom(breadcrumb).exists({ count: 1 }, 'Correct number of breadcrumbs render');
+    assert.dom(breadcrumb).includesText('Secrets sync', 'renders default breadcrumb');
   });
 
   test('it should render breadcrumbs', async function (assert) {
     this.breadcrumbs = [{ label: 'Destinations', route: 'destinations' }];
     await this.renderComponent();
-    assert.dom('[data-test-crumb]').includesText('Destinations', 'renders breadcrumb');
+    assert.dom(breadcrumb).includesText('Destinations', 'renders breadcrumb');
   });
 
   test('it should just render title for enterprise version', async function (assert) {
     await this.renderComponent();
-    assert.dom('[data-test-page-title]').hasText('Secrets sync');
+    assert.dom(title).hasText('Secrets sync');
   });
 
   test('it should render title and promotional enterprise badge for community version', async function (assert) {
     this.version.type = null;
     await this.renderComponent();
-    assert.dom('[data-test-page-title]').hasText('Secrets sync Enterprise feature');
+    assert.dom(title).hasText('Secrets sync Enterprise feature');
   });
 
   test('it should yield actions block', async function (assert) {


### PR DESCRIPTION
Some of the early tests written in the sync engine were using selectors directly ([data-test-selector]) rather than importing from the common selector files. This PR removes all selectors from tests in favor of the new pattern.