### PR TITLE
VAULT-8790 Ensure time.NewTicker never gets called with a negative value

### DIFF
--- a/builtin/logical/database/rotation.go
+++ b/builtin/logical/database/rotation.go
@@ -586,10 +586,10 @@ func (b *databaseBackend) initQueue(ctx context.Context, conf *logical.BackendCo
 		queueTickerInterval := defaultQueueTickSeconds * time.Second
 		if strVal, ok := conf.Config[queueTickIntervalKey]; ok {
 			newVal, err := strconv.Atoi(strVal)
-			if err == nil {
+			if err == nil && newVal > 0 {
 				queueTickerInterval = time.Duration(newVal) * time.Second
 			} else {
-				b.Logger().Error("bad value for %q option: %q", queueTickIntervalKey, strVal)
+				b.Logger().Error("bad value for %q option: %q, default value of %d being used instead", queueTickIntervalKey, strVal, defaultQueueTickSeconds)
 			}
 		}
 		go b.runTicker(ctx, queueTickerInterval, conf.StorageView)

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -1000,7 +1000,7 @@ func TestBackend_StaticRole_Rotation_MongoDBAtlas(t *testing.T) {
 }
 
 // TestQueueTickIntervalKeyConfig tests the configuration of queueTickIntervalKey
-// Previous to a fix, this test panicked.
+// does not break on invalid values.
 func TestQueueTickIntervalKeyConfig(t *testing.T) {
 	t.Parallel()
 	cluster, sys := getClusterPostgresDB(t)

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -14,8 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/Sectorbob/mlab-ns2/gae/ns/digest"
 	"github.com/hashicorp/vault/builtin/logical/database/schedule"
 	"github.com/hashicorp/vault/helper/namespace"
@@ -30,6 +28,7 @@ import (
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/robfig/cron/v3"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	mongodbatlasapi "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"

--- a/command/agentproxyshared/auth/alicloud/alicloud.go
+++ b/command/agentproxyshared/auth/alicloud/alicloud.go
@@ -63,10 +63,10 @@ func NewAliCloudAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 	// Check for an optional custom frequency at which we should poll for creds.
 	credCheckFreqSec := defaultCredCheckFreqSeconds
 	if checkFreqRaw, ok := conf.Config["credential_poll_interval"]; ok {
-		if credFreq, ok := checkFreqRaw.(int); ok {
+		if credFreq, ok := checkFreqRaw.(int); ok && credFreq > 0 {
 			credCheckFreqSec = credFreq
 		} else {
-			return nil, errors.New("could not convert 'credential_poll_interval' config value to int")
+			return nil, errors.New("could not convert 'credential_poll_interval' config value to positive int")
 		}
 	}
 

--- a/command/agentproxyshared/auth/aws/aws.go
+++ b/command/agentproxyshared/auth/aws/aws.go
@@ -158,10 +158,10 @@ func NewAWSAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 		// Check for an optional custom frequency at which we should poll for creds.
 		credentialPollIntervalSec := defaultCredentialPollInterval
 		if credentialPollIntervalRaw, ok := conf.Config["credential_poll_interval"]; ok {
-			if credentialPollInterval, ok := credentialPollIntervalRaw.(int); ok {
+			if credentialPollInterval, ok := credentialPollIntervalRaw.(int); ok && credentialPollInterval > 0 {
 				credentialPollIntervalSec = credentialPollInterval
 			} else {
-				return nil, errors.New("could not convert 'credential_poll_interval' into int")
+				return nil, errors.New("could not convert 'credential_poll_interval' into positive int")
 			}
 		}
 

--- a/command/agentproxyshared/auth/ldap/ldap.go
+++ b/command/agentproxyshared/auth/ldap/ldap.go
@@ -108,7 +108,7 @@ func NewLdapAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 	if passReadPeriodRaw, ok := conf.Config["password_read_period"]; ok {
 		passReadPeriod, err := parseutil.ParseDurationSecond(passReadPeriodRaw)
 		if err != nil || passReadPeriod <= 0 {
-			return nil, fmt.Errorf("error parsing 'pass_read_period' value into a positive value: %w", err)
+			return nil, fmt.Errorf("error parsing 'password_read_period' value into a positive value: %w", err)
 		}
 		readPeriod = passReadPeriod
 	} else {

--- a/command/agentproxyshared/auth/ldap/ldap.go
+++ b/command/agentproxyshared/auth/ldap/ldap.go
@@ -107,8 +107,8 @@ func NewLdapAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 
 	if passReadPeriodRaw, ok := conf.Config["password_read_period"]; ok {
 		passReadPeriod, err := parseutil.ParseDurationSecond(passReadPeriodRaw)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing 'pass_read_period' value: %w", err)
+		if err != nil || passReadPeriod <= 0 {
+			return nil, fmt.Errorf("error parsing 'pass_read_period' value into a positive value: %w", err)
 		}
 		readPeriod = passReadPeriod
 	} else {

--- a/vault/core.go
+++ b/vault/core.go
@@ -937,7 +937,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 	}
 
 	clusterHeartbeatInterval := conf.ClusterHeartbeatInterval
-	if clusterHeartbeatInterval == 0 {
+	if clusterHeartbeatInterval <= 0 {
 		clusterHeartbeatInterval = 5 * time.Second
 	}
 
@@ -1177,7 +1177,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	conf.ReloadFuncs = &c.reloadFuncs
 
 	c.rollbackPeriod = conf.RollbackPeriod
-	if c.rollbackPeriod == 0 {
+	if c.rollbackPeriod <= 0 {
 		// Default to 1 minute
 		c.rollbackPeriod = 1 * time.Minute
 	}

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -296,10 +296,14 @@ func (c *Core) refreshRequestForwardingConnection(ctx context.Context, clusterAd
 	}
 	c.rpcClientConnContext = dctx
 	c.rpcClientConnCancelFunc = cancelFunc
+	duration := c.clusterHeartbeatInterval
+	if duration <= 0 {
+		duration = time.Second * 5
+	}
 	c.rpcForwardingClient = &forwardingClient{
 		RequestForwardingClient: NewRequestForwardingClient(c.rpcClientConn),
 		core:                    c,
-		echoTicker:              time.NewTicker(c.clusterHeartbeatInterval),
+		echoTicker:              time.NewTicker(duration),
 		echoContext:             dctx,
 	}
 	c.rpcForwardingClient.startHeartbeat()


### PR DESCRIPTION
`time.NewTicker` panics if given a value `<= 0`. As a result, it needs to be given a positive number (above 0). These were all of the cases I found where this could happen, and I added a test for the main one called out in the bug report.