### PR TITLE
UI: add ember-a11y-testing

### DIFF
--- a/ui/app/components/calendar-widget.js
+++ b/ui/app/components/calendar-widget.js
@@ -28,8 +28,6 @@ export default class CalendarWidget extends Component {
   currentDate = timestamp.now();
   @tracked calendarDisplayDate = this.currentDate; // init to current date, updates when user clicks on calendar chevrons
   @tracked showCalendar = false;
-  @tracked tooltipTarget = null;
-  @tracked tooltipText = null;
 
   // both date getters return a date object
   get startDate() {
@@ -70,20 +68,6 @@ export default class CalendarWidget extends Component {
         readonly,
       };
     });
-  }
-
-  @action
-  addTooltip() {
-    if (this.disablePastYear) {
-      const previousYear = this.displayYear - 1;
-      this.tooltipText = `${previousYear} is unavailable because it is before your start date. Change your start month to a date in ${previousYear} to see data for this year.`;
-      this.tooltipTarget = '#previous-year';
-    }
-  }
-
-  @action
-  removeTooltip() {
-    this.tooltipTarget = null;
   }
 
   @action

--- a/ui/app/styles/components/calendar-widget.scss
+++ b/ui/app/styles/components/calendar-widget.scss
@@ -32,30 +32,6 @@ $dark-gray: #535f73;
 
 .calendar-widget {
   grid-area: calendar-widget;
-
-  > button {
-    &.is-month-list {
-      background-color: $white;
-      color: black;
-      text-align: center;
-      border: $light-border;
-      border-radius: $radius;
-    }
-    &.is-current-month {
-      border: 1px solid $ui-gray-900;
-    }
-    &:hover {
-      background-color: lighten($dark-gray, 30%);
-      color: $white;
-      text-align: center;
-      cursor: pointer;
-    }
-    &.is-readOnly {
-      background-color: $ui-gray-100;
-      color: lighten($dark-gray, 30%);
-      pointer-events: none;
-    }
-  }
 }
 
 .border-col {
@@ -81,18 +57,4 @@ $dark-gray: #535f73;
   grid-template-rows: repeat(2, 1fr);
   grid-gap: 0.7rem;
   padding: 7px 28px 28px 28px;
-}
-
-// for modal-dialog tooltips
-.calendar-tooltip {
-  background-color: $ui-gray-700;
-  color: $white;
-  font-size: $size-8;
-  padding: $spacing-10;
-  border-radius: $radius-large;
-  width: 141px;
-}
-
-.ember-modal-dialog {
-  z-index: 1000;
 }

--- a/ui/app/templates/components/calendar-widget.hbs
+++ b/ui/app/templates/components/calendar-widget.hbs
@@ -12,9 +12,7 @@
   </D.Trigger>
   <D.Content @defaultClass={{concat "popup-menu-content calendar-content" (if this.showCalendar " calendar-open")}}>
     <nav class="box menu">
-      <div class="calendar-title is-subtitle-gray">
-        DATE OPTIONS
-      </div>
+      <Hds::Text::Body class="calendar-title" @color="faint">DATE OPTIONS</Hds::Text::Body>
       {{! TODO Hds::Dropdown swapout }}
       <ul class="menu-list">
         <li class="action">
@@ -59,46 +57,72 @@
     {{#if this.showCalendar}}
       <div class="calendar-widget-container" data-test-calendar-widget-container>
         <div class="select-year">
-          <Hds::Button
-            data-test-previous-year
-            id="previous-year"
-            disabled={{this.disablePastYear}}
-            {{on "click" this.subYear}}
-            @color="secondary"
-            @text="previous year"
-            @icon="chevron-left"
-            @isIconOnly={{true}}
-          />
-          <p data-test-display-year>
+          {{#if this.disablePastYear}}
+            <Hds::TooltipButton
+              @text={{concat
+                (sub this.displayYear 1)
+                " is unavailable because it is before your start date. Change your start month to a date in "
+                (sub this.displayYear 1)
+                " to see data for this year."
+              }}
+              aria-label="More information about why previous year is disabled"
+            >
+              <Hds::Button
+                data-test-previous-year
+                id="previous-year"
+                disabled={{true}}
+                {{on "click" this.subYear}}
+                @color="secondary"
+                @text="previous year"
+                @icon="chevron-left"
+                @isIconOnly={{true}}
+              />
+            </Hds::TooltipButton>
+          {{else}}
+            <Hds::Button
+              data-test-previous-year
+              id="previous-year"
+              {{on "click" this.subYear}}
+              @color="secondary"
+              @text="previous year"
+              @icon="chevron-left"
+              @isIconOnly={{true}}
+            />
+          {{/if}}
+
+          <Hds::Text::Display data-test-display-year>
             {{this.displayYear}}
-          </p>
-          <Hds::Button
-            data-test-next-year
-            id="next-year"
-            disabled={{this.disableFutureYear}}
-            {{on "click" this.addYear}}
-            @color="secondary"
-            @text="next year"
-            @icon="chevron-right"
-            @isIconOnly={{true}}
-          />
-          {{#if this.tooltipTarget}}
-            {{! Component must be in curly bracket notation }}
-            {{! template-lint-disable no-curly-component-invocation }}
-            {{#modal-dialog
-              tagName="div"
-              tetherTarget=this.tooltipTarget
-              targetAttachment="top right"
-              attachment="top middle"
-              offset="150px 0"
-            }}
-              <div class={{"calendar-tooltip"}}>
-                <p>
-                  {{this.tooltipText}}
-                </p>
-              </div>
-              <div class="chart-tooltip-arrow"></div>
-            {{/modal-dialog}}
+          </Hds::Text::Display>
+
+          {{#if this.disableFutureYear}}
+            <Hds::TooltipButton
+              @text={{concat
+                (add this.displayYear 1)
+                " is unavailable because data is only available up to the current month."
+              }}
+              aria-label="More information about why next year is disabled"
+            >
+              <Hds::Button
+                data-test-next-year
+                id="next-year"
+                disabled={{true}}
+                {{on "click" this.addYear}}
+                @color="secondary"
+                @text="next year"
+                @icon="chevron-right"
+                @isIconOnly={{true}}
+              />
+            </Hds::TooltipButton>
+          {{else}}
+            <Hds::Button
+              data-test-next-year
+              id="next-year"
+              {{on "click" this.addYear}}
+              @color="secondary"
+              @text="next year"
+              @icon="chevron-right"
+              @isIconOnly={{true}}
+            />
           {{/if}}
         </div>
         <div class="calendar-widget-grid calendar-widget">
@@ -107,7 +131,7 @@
               @text={{month.name}}
               @color="secondary"
               @size="small"
-              class="is-month-list {{if month.readonly 'is-readOnly'}}"
+              disabled={{month.readonly}}
               data-test-calendar-month={{month.name}}
               id={{month.index}}
               {{on "click" (fn this.selectMonth month D.actions)}}

--- a/ui/package.json
+++ b/ui/package.json
@@ -153,7 +153,7 @@
     "ember-page-title": "^7.0.0",
     "ember-power-select": "6.0.1",
     "ember-qrcode-shim": "^0.4.0",
-    "ember-qunit": "6.0.0",
+    "ember-qunit": "^6.0.2",
     "ember-resolver": "^10.0.0",
     "ember-responsive": "5.0.0",
     "ember-router-helpers": "^0.4.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -120,6 +120,7 @@
     "deepmerge": "^4.0.0",
     "doctoc": "^2.2.0",
     "dompurify": "^3.0.2",
+    "ember-a11y-testing": "^5.2.1",
     "ember-auto-import": "2.6.3",
     "ember-basic-dropdown": "6.0.1",
     "ember-cli": "~4.12.1",

--- a/ui/testem.js
+++ b/ui/testem.js
@@ -6,7 +6,7 @@
 'use strict';
 
 module.exports = {
-  test_page: 'tests/index.html?hidepassed',
+  test_page: 'tests/index.html?hidepassed&enableA11yAudit=true',
   tap_quiet_logs: true,
   tap_failed_tests_only: true,
   disable_watching: true,

--- a/ui/tests/integration/components/calendar-widget-test.js
+++ b/ui/tests/integration/components/calendar-widget-test.js
@@ -50,11 +50,9 @@ module('Integration | Component | calendar-widget', function (hooks) {
     const enabledMonths = ['January', 'February', 'March', 'April'];
     ARRAY_OF_MONTHS.forEach(function (month) {
       if (enabledMonths.includes(month)) {
-        assert
-          .dom(`[data-test-calendar-month="${month}"]`)
-          .doesNotHaveClass('is-readOnly', `${month} is enabled`);
+        assert.dom(`[data-test-calendar-month="${month}"]`).isNotDisabled(`${month} is enabled`);
       } else {
-        assert.dom(`[data-test-calendar-month="${month}"]`).hasClass('is-readOnly', `${month} is read only`);
+        assert.dom(`[data-test-calendar-month="${month}"]`).isDisabled(`${month} is disabled`);
       }
     });
   });
@@ -80,11 +78,9 @@ module('Integration | Component | calendar-widget', function (hooks) {
     const disabledMonths = ['January', 'February', 'March'];
     ARRAY_OF_MONTHS.forEach(function (month) {
       if (disabledMonths.includes(month)) {
-        assert.dom(`[data-test-calendar-month="${month}"]`).hasClass('is-readOnly', `${month} is read only`);
+        assert.dom(`[data-test-calendar-month="${month}"]`).isDisabled(`${month} is disabled`);
       } else {
-        assert
-          .dom(`[data-test-calendar-month="${month}"]`)
-          .doesNotHaveClass('is-readOnly', `${month} is enabled`);
+        assert.dom(`[data-test-calendar-month="${month}"]`).isNotDisabled(`${month} is enabled`);
       }
     });
   });
@@ -146,13 +142,13 @@ module('Integration | Component | calendar-widget', function (hooks) {
 
     await calendarDropdown.openCalendar();
     await calendarDropdown.clickPreviousYear();
-    await click(`[data-test-calendar-month="March"]`);
+    await click(`[data-test-calendar-month="May"]`);
     assert.propEqual(
       this.handleClientActivityQuery.lastCall.lastArg,
       {
         dateType: 'endDate',
-        monthIdx: 2,
-        monthName: 'March',
+        monthIdx: 4,
+        monthName: 'May',
         year: 2017,
       },
       'it calls parent function with selected start date month/year'
@@ -179,11 +175,9 @@ module('Integration | Component | calendar-widget', function (hooks) {
     const prevYearEnabled = ['October', 'November', 'December'];
     ARRAY_OF_MONTHS.forEach(function (month) {
       if (prevYearEnabled.includes(month)) {
-        assert
-          .dom(`[data-test-calendar-month="${month}"]`)
-          .doesNotHaveClass('is-readOnly', `${month} is enabled`);
+        assert.dom(`[data-test-calendar-month="${month}"]`).isNotDisabled(`${month} is enabled`);
       } else {
-        assert.dom(`[data-test-calendar-month="${month}"]`).hasClass('is-readOnly', `${month} is read only`);
+        assert.dom(`[data-test-calendar-month="${month}"]`).isDisabled(`${month} is read only`);
       }
     });
 
@@ -192,11 +186,9 @@ module('Integration | Component | calendar-widget', function (hooks) {
     const currYearEnabled = ['January', 'February', 'March', 'April'];
     ARRAY_OF_MONTHS.forEach(function (month) {
       if (currYearEnabled.includes(month)) {
-        assert
-          .dom(`[data-test-calendar-month="${month}"]`)
-          .doesNotHaveClass('is-readOnly', `${month} is enabled`);
+        assert.dom(`[data-test-calendar-month="${month}"]`).isNotDisabled(`${month} is enabled`);
       } else {
-        assert.dom(`[data-test-calendar-month="${month}"]`).hasClass('is-readOnly', `${month} is read only`);
+        assert.dom(`[data-test-calendar-month="${month}"]`).isDisabled(`${month} is disabled`);
       }
     });
   });
@@ -214,7 +206,6 @@ module('Integration | Component | calendar-widget', function (hooks) {
 
     await calendarDropdown.openCalendar();
     assert.dom('[data-test-next-year]').isDisabled('Future year is disabled');
-
     for (const year of [2017, 2016, 2015]) {
       await calendarDropdown.clickPreviousYear();
       assert.dom('[data-test-display-year]').hasText(year.toString());
@@ -223,34 +214,31 @@ module('Integration | Component | calendar-widget', function (hooks) {
     assert.dom('[data-test-previous-year]').isDisabled('previous year is disabled');
     assert.dom('[data-test-next-year]').isEnabled('next year is enabled');
 
-    assert.dom('.calendar-widget .is-readOnly').exists('Some months disabled');
-
     const disabledMonths = ['January', 'February', 'March'];
     ARRAY_OF_MONTHS.forEach(function (month) {
       if (disabledMonths.includes(month)) {
-        assert.dom(`[data-test-calendar-month="${month}"]`).hasClass('is-readOnly', `${month} is read only`);
+        assert.dom(`[data-test-calendar-month="${month}"]`).isDisabled(`${month} is disabled`);
       } else {
-        assert
-          .dom(`[data-test-calendar-month="${month}"]`)
-          .doesNotHaveClass('is-readOnly', `${month} is enabled`);
+        assert.dom(`[data-test-calendar-month="${month}"]`).isNotDisabled(`${month} is enabled`);
       }
     });
 
     await click('[data-test-next-year]');
-    assert.dom('.calendar-widget .is-readOnly').doesNotExist('All months enabled for 2016');
+    ARRAY_OF_MONTHS.forEach(function (month) {
+      assert.dom(`[data-test-calendar-month="${month}"]`).isNotDisabled(`${month} is enabled for 2016`);
+    });
     await click('[data-test-next-year]');
-    assert.dom('.calendar-widget .is-readOnly').doesNotExist('All months enabled for 2017');
+    ARRAY_OF_MONTHS.forEach(function (month) {
+      assert.dom(`[data-test-calendar-month="${month}"]`).isNotDisabled(`${month} is enabled for 2017`);
+    });
     await click('[data-test-next-year]');
-    assert.dom('.calendar-widget .is-readOnly').exists('Some months disabled for 2018');
 
     const enabledMonths = ['January', 'February', 'March', 'April'];
     ARRAY_OF_MONTHS.forEach(function (month) {
       if (enabledMonths.includes(month)) {
-        assert
-          .dom(`[data-test-calendar-month="${month}"]`)
-          .doesNotHaveClass('is-readOnly', `${month} is enabled`);
+        assert.dom(`[data-test-calendar-month="${month}"]`).isNotDisabled(`${month} is enabled`);
       } else {
-        assert.dom(`[data-test-calendar-month="${month}"]`).hasClass('is-readOnly', `${month} is read only`);
+        assert.dom(`[data-test-calendar-month="${month}"]`).isDisabled(`${month} is disabled`);
       }
     });
   });

--- a/ui/tests/test-helper.js
+++ b/ui/tests/test-helper.js
@@ -11,20 +11,22 @@ import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
 import './helpers/flash-message';
 import preloadAssets from 'ember-asset-loader/test-support/preload-assets';
-import {
-  setupGlobalA11yHooks,
-  setupConsoleLogger,
-  DEFAULT_A11Y_TEST_HELPER_NAMES,
-} from 'ember-a11y-testing/test-support';
+import { setupGlobalA11yHooks, setRunOptions } from 'ember-a11y-testing/test-support';
 import manifest from 'vault/config/asset-manifest';
 
 preloadAssets(manifest).then(() => {
   setup(QUnit.assert);
   setApplication(Application.create(config.APP));
   setupGlobalA11yHooks(() => true, {
-    helpers: [...DEFAULT_A11Y_TEST_HELPER_NAMES, 'render'],
+    helpers: ['click'],
   });
-  setupConsoleLogger();
+  setRunOptions({
+    runOnly: {
+      type: 'tag',
+      values: ['wcag2a'],
+    },
+  });
+
   start({
     setupTestIsolationValidation: true,
   });

--- a/ui/tests/test-helper.js
+++ b/ui/tests/test-helper.js
@@ -11,11 +11,20 @@ import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
 import './helpers/flash-message';
 import preloadAssets from 'ember-asset-loader/test-support/preload-assets';
+import {
+  setupGlobalA11yHooks,
+  setupConsoleLogger,
+  DEFAULT_A11Y_TEST_HELPER_NAMES,
+} from 'ember-a11y-testing/test-support';
 import manifest from 'vault/config/asset-manifest';
 
 preloadAssets(manifest).then(() => {
   setup(QUnit.assert);
   setApplication(Application.create(config.APP));
+  setupGlobalA11yHooks(() => true, {
+    helpers: [...DEFAULT_A11Y_TEST_HELPER_NAMES, 'render'],
+  });
+  setupConsoleLogger();
   start({
     setupTestIsolationValidation: true,
   });

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -5542,6 +5542,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ember/test-waiters@npm:^2.4.3 || ^3.0.0, @ember/test-waiters@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@ember/test-waiters@npm:3.1.0"
+  dependencies:
+    calculate-cache-key-for-tree: ^2.0.0
+    ember-cli-babel: ^7.26.6
+    ember-cli-version-checker: ^5.1.2
+    semver: ^7.3.5
+  checksum: f5d8c75ec060f01d038c4f8f419f844e50928b9d7af518b00318844238b43a7b740fc2ec941f45c61fdf698977f2f8a47b34898faa7da2d09e3a38a8137ac8cf
+  languageName: node
+  linkType: hard
+
 "@ember/test-waiters@npm:^3.0.0":
   version: 3.0.0
   resolution: "@ember/test-waiters@npm:3.0.0"
@@ -5551,18 +5563,6 @@ __metadata:
     ember-cli-version-checker: ^5.1.2
     semver: ^7.3.5
   checksum: 4998a8213b8800633485eaca342bd6e9b388d974def70ab794612d0c691b68599b2377b9a5467bdddea699099fec2897821c9127443ddac3c69c82d73ea21fa5
-  languageName: node
-  linkType: hard
-
-"@ember/test-waiters@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@ember/test-waiters@npm:3.1.0"
-  dependencies:
-    calculate-cache-key-for-tree: ^2.0.0
-    ember-cli-babel: ^7.26.6
-    ember-cli-version-checker: ^5.1.2
-    semver: ^7.3.5
-  checksum: f5d8c75ec060f01d038c4f8f419f844e50928b9d7af518b00318844238b43a7b740fc2ec941f45c61fdf698977f2f8a47b34898faa7da2d09e3a38a8137ac8cf
   languageName: node
   linkType: hard
 
@@ -6524,6 +6524,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@scalvert/ember-setup-middleware-reporter@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@scalvert/ember-setup-middleware-reporter@npm:0.1.1"
+  dependencies:
+    "@types/fs-extra": ^9.0.12
+    body-parser: ^1.19.0
+    errorhandler: ^1.5.1
+    fs-extra: ^10.0.0
+  checksum: 4015fc0ede7d72a2a8a5e334c63fb7f570c89d2f53d45cdb453dd85e3de48734a5d083b4cf0cadf70a3b5e71ee7aca020b45d5798e8a6334db1f72aa7ab72cb4
+  languageName: node
+  linkType: hard
+
 "@simple-dom/interface@npm:^1.4.0":
   version: 1.4.0
   resolution: "@simple-dom/interface@npm:1.4.0"
@@ -7051,6 +7063,15 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: d7d564b84b86e51241984c9bec16f683056d45510e2c63e1bfe9282026685bd14e5ca406ee809453f1e2fd8c9aa76c5712a3019492eb946dd46de327ccb0e1b1
+  languageName: node
+  linkType: hard
+
+"@types/fs-extra@npm:^9.0.12":
+  version: 9.0.13
+  resolution: "@types/fs-extra@npm:9.0.13"
+  dependencies:
+    "@types/node": "*"
+  checksum: add79e212acd5ac76b97b9045834e03a7996aef60a814185e0459088fd290519a3c1620865d588fa36c4498bf614210d2a703af5cf80aa1dbc125db78f6edac3
   languageName: node
   linkType: hard
 
@@ -8643,6 +8664,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axe-core@npm:^4.6.3":
+  version: 4.8.2
+  resolution: "axe-core@npm:4.8.2"
+  checksum: 8c19f507dabfcb8514e4280c7fc66e85143be303ddb57ec9f119338021228dc9b80560993938003837bda415fde7c07bba3a96560008ffa5f4145a248ed8f5fe
+  languageName: node
+  linkType: hard
+
 "babel-code-frame@npm:^6.26.0":
   version: 6.26.0
   resolution: "babel-code-frame@npm:6.26.0"
@@ -9819,6 +9847,26 @@ __metadata:
     type-is: ~1.6.18
     unpipe: 1.0.0
   checksum: f1050dbac3bede6a78f0b87947a8d548ce43f91ccc718a50dd774f3c81f2d8b04693e52acf62659fad23101827dd318da1fb1363444ff9a8482b886a3e4a5266
+  languageName: node
+  linkType: hard
+
+"body-parser@npm:^1.19.0, body-parser@npm:^1.19.1":
+  version: 1.20.2
+  resolution: "body-parser@npm:1.20.2"
+  dependencies:
+    bytes: 3.1.2
+    content-type: ~1.0.5
+    debug: 2.6.9
+    depd: 2.0.0
+    destroy: 1.2.0
+    http-errors: 2.0.0
+    iconv-lite: 0.4.24
+    on-finished: 2.4.1
+    qs: 6.11.0
+    raw-body: 2.5.2
+    type-is: ~1.6.18
+    unpipe: 1.0.0
+  checksum: 14d37ec638ab5c93f6099ecaed7f28f890d222c650c69306872e00b9efa081ff6c596cd9afb9930656aae4d6c4e1c17537bea12bb73c87a217cb3cfea8896737
   languageName: node
   linkType: hard
 
@@ -11291,14 +11339,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000792, caniuse-lite@npm:^1.0.30000805, caniuse-lite@npm:^1.0.30000844, caniuse-lite@npm:^1.0.30001219, caniuse-lite@npm:^1.0.30001264, caniuse-lite@npm:^1.0.30001280, caniuse-lite@npm:^1.0.30001304, caniuse-lite@npm:^1.0.30001317, caniuse-lite@npm:^1.0.30001349, caniuse-lite@npm:^1.0.30001503":
-  version: 1.0.30001566
-  resolution: "caniuse-lite@npm:1.0.30001566"
-  checksum: 0f9084bf9f7d5c0a9ddb200c2baddb25dd2ad5a2f205f01e7b971f3e98e9a7bb23c2d86bae48237e9bc9782b682cffaaf3406d936937ab9844987dbe2a6401f2
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001565":
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000792, caniuse-lite@npm:^1.0.30000805, caniuse-lite@npm:^1.0.30000844, caniuse-lite@npm:^1.0.30001219, caniuse-lite@npm:^1.0.30001264, caniuse-lite@npm:^1.0.30001280, caniuse-lite@npm:^1.0.30001304, caniuse-lite@npm:^1.0.30001317, caniuse-lite@npm:^1.0.30001349, caniuse-lite@npm:^1.0.30001503, caniuse-lite@npm:^1.0.30001565":
   version: 1.0.30001566
   resolution: "caniuse-lite@npm:1.0.30001566"
   checksum: 0f9084bf9f7d5c0a9ddb200c2baddb25dd2ad5a2f205f01e7b971f3e98e9a7bb23c2d86bae48237e9bc9782b682cffaaf3406d936937ab9844987dbe2a6401f2
@@ -12053,6 +12094,13 @@ __metadata:
   version: 1.0.4
   resolution: "content-type@npm:1.0.4"
   checksum: 3d93585fda985d1554eca5ebd251994327608d2e200978fdbfba21c0c679914d5faf266d17027de44b34a72c7b0745b18584ecccaa7e1fdfb6a68ac7114f12e0
+  languageName: node
+  linkType: hard
+
+"content-type@npm:~1.0.5":
+  version: 1.0.5
+  resolution: "content-type@npm:1.0.5"
+  checksum: 566271e0a251642254cde0f845f9dd4f9856e52d988f4eb0d0dcffbb7a1f8ec98de7a5215fc628f3bce30fe2fb6fd2bc064b562d721658c59b544e2d34ea2766
   languageName: node
   linkType: hard
 
@@ -13570,6 +13618,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ember-a11y-testing@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "ember-a11y-testing@npm:5.2.1"
+  dependencies:
+    "@ember/test-waiters": ^2.4.3 || ^3.0.0
+    "@scalvert/ember-setup-middleware-reporter": ^0.1.1
+    axe-core: ^4.6.3
+    body-parser: ^1.19.1
+    broccoli-persistent-filter: ^3.1.2
+    ember-auto-import: ^2.2.4
+    ember-cli-babel: ^7.26.11
+    ember-cli-typescript: ^4.2.1
+    ember-cli-version-checker: ^5.1.2
+    ember-destroyable-polyfill: ^2.0.1
+    fs-extra: ^10.0.0
+    validate-peer-dependencies: ^2.0.0
+  peerDependencies:
+    "@ember/test-helpers": ^2.0.0
+    qunit: ">= 2"
+  peerDependenciesMeta:
+    qunit:
+      optional: true
+  checksum: 4c8a2c1a04751c995679f537af3c93036c648dc7e289a2bfa044b8cab189662a8c451507ae6a7777d1b77e0589c0e2304f0c5c76e2ee53e75cf2c3c0845d23da
+  languageName: node
+  linkType: hard
+
 "ember-asset-loader@npm:^0.6.1":
   version: 0.6.1
   resolution: "ember-asset-loader@npm:0.6.1"
@@ -13708,45 +13782,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-auto-import@npm:^2.4.1":
-  version: 2.4.2
-  resolution: "ember-auto-import@npm:2.4.2"
-  dependencies:
-    "@babel/core": ^7.16.7
-    "@babel/plugin-proposal-class-properties": ^7.16.7
-    "@babel/plugin-proposal-decorators": ^7.16.7
-    "@babel/preset-env": ^7.16.7
-    "@embroider/macros": ^1.0.0
-    "@embroider/shared-internals": ^1.0.0
-    babel-loader: ^8.0.6
-    babel-plugin-ember-modules-api-polyfill: ^3.5.0
-    babel-plugin-htmlbars-inline-precompile: ^5.2.1
-    babel-plugin-syntax-dynamic-import: ^6.18.0
-    broccoli-debug: ^0.6.4
-    broccoli-funnel: ^3.0.8
-    broccoli-merge-trees: ^4.2.0
-    broccoli-plugin: ^4.0.0
-    broccoli-source: ^3.0.0
-    css-loader: ^5.2.0
-    debug: ^4.3.1
-    fs-extra: ^10.0.0
-    fs-tree-diff: ^2.0.0
-    handlebars: ^4.3.1
-    js-string-escape: ^1.0.1
-    lodash: ^4.17.19
-    mini-css-extract-plugin: ^2.5.2
-    parse5: ^6.0.1
-    resolve: ^1.20.0
-    resolve-package-path: ^4.0.3
-    semver: ^7.3.4
-    style-loader: ^2.0.0
-    typescript-memoize: ^1.0.0-alpha.3
-    walk-sync: ^3.0.0
-  checksum: f7c4e4bab62b124c03955b8b382d6bf9c170c1ad5605bb019cbb1baf63065b482b8767a2e4922682fbc54c701f0296601e7ed50965bd4c741dab6cfff43c6de5
-  languageName: node
-  linkType: hard
-
-"ember-auto-import@npm:^2.6.0":
+"ember-auto-import@npm:^2.2.4, ember-auto-import@npm:^2.6.0":
   version: 2.7.0
   resolution: "ember-auto-import@npm:2.7.0"
   dependencies:
@@ -13785,6 +13821,44 @@ __metadata:
     typescript-memoize: ^1.0.0-alpha.3
     walk-sync: ^3.0.0
   checksum: abf483c7c2cd61d35fd26f779dd6b818bb83775bbab1834ab80cfbe396d9b753dfab5fdc0882b91467321dd23575419522e9e8b53e37e7149d4561dd753fd2d6
+  languageName: node
+  linkType: hard
+
+"ember-auto-import@npm:^2.4.1":
+  version: 2.4.2
+  resolution: "ember-auto-import@npm:2.4.2"
+  dependencies:
+    "@babel/core": ^7.16.7
+    "@babel/plugin-proposal-class-properties": ^7.16.7
+    "@babel/plugin-proposal-decorators": ^7.16.7
+    "@babel/preset-env": ^7.16.7
+    "@embroider/macros": ^1.0.0
+    "@embroider/shared-internals": ^1.0.0
+    babel-loader: ^8.0.6
+    babel-plugin-ember-modules-api-polyfill: ^3.5.0
+    babel-plugin-htmlbars-inline-precompile: ^5.2.1
+    babel-plugin-syntax-dynamic-import: ^6.18.0
+    broccoli-debug: ^0.6.4
+    broccoli-funnel: ^3.0.8
+    broccoli-merge-trees: ^4.2.0
+    broccoli-plugin: ^4.0.0
+    broccoli-source: ^3.0.0
+    css-loader: ^5.2.0
+    debug: ^4.3.1
+    fs-extra: ^10.0.0
+    fs-tree-diff: ^2.0.0
+    handlebars: ^4.3.1
+    js-string-escape: ^1.0.1
+    lodash: ^4.17.19
+    mini-css-extract-plugin: ^2.5.2
+    parse5: ^6.0.1
+    resolve: ^1.20.0
+    resolve-package-path: ^4.0.3
+    semver: ^7.3.4
+    style-loader: ^2.0.0
+    typescript-memoize: ^1.0.0-alpha.3
+    walk-sync: ^3.0.0
+  checksum: f7c4e4bab62b124c03955b8b382d6bf9c170c1ad5605bb019cbb1baf63065b482b8767a2e4922682fbc54c701f0296601e7ed50965bd4c741dab6cfff43c6de5
   languageName: node
   linkType: hard
 
@@ -14784,7 +14858,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-destroyable-polyfill@npm:^2.0.2, ember-destroyable-polyfill@npm:^2.0.3":
+"ember-destroyable-polyfill@npm:^2.0.1, ember-destroyable-polyfill@npm:^2.0.2, ember-destroyable-polyfill@npm:^2.0.3":
   version: 2.0.3
   resolution: "ember-destroyable-polyfill@npm:2.0.3"
   dependencies:
@@ -15633,6 +15707,16 @@ __metadata:
   dependencies:
     string-template: ~0.2.1
   checksum: 9c790d20a386947acfeabb0d1c39173efe8e5a38cb732b5f06c11a25c23ce8ac4dafbb7aa240565e034580a49aba0703e743d0274c6228500ddf947a1b998568
+  languageName: node
+  linkType: hard
+
+"errorhandler@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "errorhandler@npm:1.5.1"
+  dependencies:
+    accepts: ~1.3.7
+    escape-html: ~1.0.3
+  checksum: 73b7abb08fb751107e9bebecc33c40c0641a54be8bda8e4a045f3f5cb7b805041927fef5629ea39b1737799eb52fe2499ca531f11ac51b0294ccc4667d72cb91
   languageName: node
   linkType: hard
 
@@ -23496,6 +23580,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"raw-body@npm:2.5.2":
+  version: 2.5.2
+  resolution: "raw-body@npm:2.5.2"
+  dependencies:
+    bytes: 3.1.2
+    http-errors: 2.0.0
+    iconv-lite: 0.4.24
+    unpipe: 1.0.0
+  checksum: ba1583c8d8a48e8fbb7a873fdbb2df66ea4ff83775421bfe21ee120140949ab048200668c47d9ae3880012f6e217052690628cf679ddfbd82c9fc9358d574676
+  languageName: node
+  linkType: hard
+
 "raw-body@npm:~1.1.0":
   version: 1.1.7
   resolution: "raw-body@npm:1.1.7"
@@ -27215,7 +27311,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validate-peer-dependencies@npm:^2.2.0":
+"validate-peer-dependencies@npm:^2.0.0, validate-peer-dependencies@npm:^2.2.0":
   version: 2.2.0
   resolution: "validate-peer-dependencies@npm:2.2.0"
   dependencies:
@@ -27304,6 +27400,7 @@ __metadata:
     deepmerge: ^4.0.0
     doctoc: ^2.2.0
     dompurify: ^3.0.2
+    ember-a11y-testing: ^5.2.1
     ember-auto-import: 2.6.3
     ember-basic-dropdown: 6.0.1
     ember-cli: ~4.12.1

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -11291,17 +11291,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000792, caniuse-lite@npm:^1.0.30000805, caniuse-lite@npm:^1.0.30001219, caniuse-lite@npm:^1.0.30001264, caniuse-lite@npm:^1.0.30001280, caniuse-lite@npm:^1.0.30001304, caniuse-lite@npm:^1.0.30001317, caniuse-lite@npm:^1.0.30001349":
-  version: 1.0.30001487
-  resolution: "caniuse-lite@npm:1.0.30001487"
-  checksum: b5a9e72ec165765fb3e07913cc389685ce8a30ac48967f99baec773a4353d2037fb534241e87b3c95d40a5081079be2263710b784883183bb2998b73f7202233
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30000844, caniuse-lite@npm:^1.0.30001503":
-  version: 1.0.30001516
-  resolution: "caniuse-lite@npm:1.0.30001516"
-  checksum: 044adf3493b734a356a2922445a30095a0f6de6b9194695cdf74deafe7bef658e85858a31177762c2813f6e1ed2722d832d59eee0ecb2151e93a611ee18cb21f
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000792, caniuse-lite@npm:^1.0.30000805, caniuse-lite@npm:^1.0.30000844, caniuse-lite@npm:^1.0.30001219, caniuse-lite@npm:^1.0.30001264, caniuse-lite@npm:^1.0.30001280, caniuse-lite@npm:^1.0.30001304, caniuse-lite@npm:^1.0.30001317, caniuse-lite@npm:^1.0.30001349, caniuse-lite@npm:^1.0.30001503":
+  version: 1.0.30001566
+  resolution: "caniuse-lite@npm:1.0.30001566"
+  checksum: 0f9084bf9f7d5c0a9ddb200c2baddb25dd2ad5a2f205f01e7b971f3e98e9a7bb23c2d86bae48237e9bc9782b682cffaaf3406d936937ab9844987dbe2a6401f2
   languageName: node
   linkType: hard
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -535,24 +535,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-create-class-features-plugin@npm:^7.19.0":
-  version: 7.19.0
-  resolution: "@babel/helper-create-class-features-plugin@npm:7.19.0"
-  dependencies:
-    "@babel/helper-annotate-as-pure": ^7.18.6
-    "@babel/helper-environment-visitor": ^7.18.9
-    "@babel/helper-function-name": ^7.19.0
-    "@babel/helper-member-expression-to-functions": ^7.18.9
-    "@babel/helper-optimise-call-expression": ^7.18.6
-    "@babel/helper-replace-supers": ^7.18.9
-    "@babel/helper-split-export-declaration": ^7.18.6
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: f0c6fb77b6f113d70f308e7093f60dd465b697818badf5df0519d8dd12b6bfb1f4ad300b923207ce9f9c1c940ef58bff12ac4270c0863eadf9e303b7dd6d01b6
-  languageName: node
-  linkType: hard
-
-"@babel/helper-create-class-features-plugin@npm:^7.21.0, @babel/helper-create-class-features-plugin@npm:^7.22.15, @babel/helper-create-class-features-plugin@npm:^7.23.5":
+"@babel/helper-create-class-features-plugin@npm:^7.18.6, @babel/helper-create-class-features-plugin@npm:^7.21.0, @babel/helper-create-class-features-plugin@npm:^7.22.15, @babel/helper-create-class-features-plugin@npm:^7.23.5":
   version: 7.23.5
   resolution: "@babel/helper-create-class-features-plugin@npm:7.23.5"
   dependencies:
@@ -568,6 +551,23 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: fe7c6c0baca1838bba76ac1330df47b661d932354115ea9e2ea65b179f80b717987d3c3da7e1525fd648e5f2d86c620efc959cabda4d7562b125a27c3ac780d0
+  languageName: node
+  linkType: hard
+
+"@babel/helper-create-class-features-plugin@npm:^7.19.0":
+  version: 7.19.0
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.19.0"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.18.6
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-function-name": ^7.19.0
+    "@babel/helper-member-expression-to-functions": ^7.18.9
+    "@babel/helper-optimise-call-expression": ^7.18.6
+    "@babel/helper-replace-supers": ^7.18.9
+    "@babel/helper-split-export-declaration": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: f0c6fb77b6f113d70f308e7093f60dd465b697818badf5df0519d8dd12b6bfb1f4ad300b923207ce9f9c1c940ef58bff12ac4270c0863eadf9e303b7dd6d01b6
   languageName: node
   linkType: hard
 
@@ -2313,6 +2313,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-proposal-private-methods@npm:^7.16.7":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-private-methods@npm:7.18.6"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 22d8502ee96bca99ad2c8393e8493e2b8d4507576dd054490fd8201a36824373440106f5b098b6d821b026c7e72b0424ff4aeca69ed5f42e48f029d3a156d5ad
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-private-methods@npm:^7.17.12":
   version: 7.17.12
   resolution: "@babel/plugin-proposal-private-methods@npm:7.17.12"
@@ -2956,7 +2968,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-class-static-block@npm:^7.22.11, @babel/plugin-transform-class-static-block@npm:^7.23.4":
+"@babel/plugin-transform-class-static-block@npm:^7.16.7, @babel/plugin-transform-class-static-block@npm:^7.22.11, @babel/plugin-transform-class-static-block@npm:^7.23.4":
   version: 7.23.4
   resolution: "@babel/plugin-transform-class-static-block@npm:7.23.4"
   dependencies:
@@ -13590,7 +13602,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-auto-import@npm:2.6.3, ember-auto-import@npm:^2.4.2, ember-auto-import@npm:^2.4.3, ember-auto-import@npm:^2.5.0, ember-auto-import@npm:^2.6.3":
+"ember-auto-import@npm:2.6.3, ember-auto-import@npm:^2.4.3, ember-auto-import@npm:^2.5.0, ember-auto-import@npm:^2.6.3":
   version: 2.6.3
   resolution: "ember-auto-import@npm:2.6.3"
   dependencies:
@@ -13738,6 +13750,48 @@ __metadata:
     typescript-memoize: ^1.0.0-alpha.3
     walk-sync: ^3.0.0
   checksum: f7c4e4bab62b124c03955b8b382d6bf9c170c1ad5605bb019cbb1baf63065b482b8767a2e4922682fbc54c701f0296601e7ed50965bd4c741dab6cfff43c6de5
+  languageName: node
+  linkType: hard
+
+"ember-auto-import@npm:^2.6.0":
+  version: 2.7.0
+  resolution: "ember-auto-import@npm:2.7.0"
+  dependencies:
+    "@babel/core": ^7.16.7
+    "@babel/plugin-proposal-class-properties": ^7.16.7
+    "@babel/plugin-proposal-decorators": ^7.16.7
+    "@babel/plugin-proposal-private-methods": ^7.16.7
+    "@babel/plugin-transform-class-static-block": ^7.16.7
+    "@babel/preset-env": ^7.16.7
+    "@embroider/macros": ^1.0.0
+    "@embroider/shared-internals": ^2.0.0
+    babel-loader: ^8.0.6
+    babel-plugin-ember-modules-api-polyfill: ^3.5.0
+    babel-plugin-ember-template-compilation: ^2.0.1
+    babel-plugin-htmlbars-inline-precompile: ^5.2.1
+    babel-plugin-syntax-dynamic-import: ^6.18.0
+    broccoli-debug: ^0.6.4
+    broccoli-funnel: ^3.0.8
+    broccoli-merge-trees: ^4.2.0
+    broccoli-plugin: ^4.0.0
+    broccoli-source: ^3.0.0
+    css-loader: ^5.2.0
+    debug: ^4.3.1
+    fs-extra: ^10.0.0
+    fs-tree-diff: ^2.0.0
+    handlebars: ^4.3.1
+    js-string-escape: ^1.0.1
+    lodash: ^4.17.19
+    mini-css-extract-plugin: ^2.5.2
+    minimatch: ^3.0.0
+    parse5: ^6.0.1
+    resolve: ^1.20.0
+    resolve-package-path: ^4.0.3
+    semver: ^7.3.4
+    style-loader: ^2.0.0
+    typescript-memoize: ^1.0.0-alpha.3
+    walk-sync: ^3.0.0
+  checksum: abf483c7c2cd61d35fd26f779dd6b818bb83775bbab1834ab80cfbe396d9b753dfab5fdc0882b91467321dd23575419522e9e8b53e37e7149d4561dd753fd2d6
   languageName: node
   linkType: hard
 
@@ -15025,23 +15079,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-qunit@npm:6.0.0":
-  version: 6.0.0
-  resolution: "ember-qunit@npm:6.0.0"
+"ember-qunit@npm:^6.0.2":
+  version: 6.2.0
+  resolution: "ember-qunit@npm:6.2.0"
   dependencies:
     broccoli-funnel: ^3.0.8
     broccoli-merge-trees: ^3.0.2
     common-tags: ^1.8.0
-    ember-auto-import: ^2.4.2
-    ember-cli-babel: ^7.26.6
+    ember-auto-import: ^2.6.0
+    ember-cli-babel: ^7.26.11
     ember-cli-test-loader: ^3.0.0
     resolve-package-path: ^4.0.3
     silent-error: ^1.1.1
-    validate-peer-dependencies: ^2.1.0
+    validate-peer-dependencies: ^2.2.0
   peerDependencies:
-    "@ember/test-helpers": ^2.4.0
+    "@ember/test-helpers": ^2.9.3
+    ember-source: ">=3.28"
     qunit: ^2.13.0
-  checksum: 74c4c9316ff509a195e7961bae9aa1da6e6260d1a5e0ce153dff76302d23f974fa652dfc9d484fbe78d64623ba0d837b68d437d56745531118b88b950c6a5608
+  checksum: c9058d02d78efe06887ee6993908d8f45592c4369e0f72a57045f5ae27df94ea7497866bdf484f12eaddfac23ae4051a259bae0280a70c0dd50a8260eae3126c
   languageName: node
   linkType: hard
 
@@ -27167,7 +27222,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validate-peer-dependencies@npm:^2.1.0":
+"validate-peer-dependencies@npm:^2.2.0":
   version: 2.2.0
   resolution: "validate-peer-dependencies@npm:2.2.0"
   dependencies:
@@ -27289,7 +27344,7 @@ __metadata:
     ember-page-title: ^7.0.0
     ember-power-select: 6.0.1
     ember-qrcode-shim: ^0.4.0
-    ember-qunit: 6.0.0
+    ember-qunit: ^6.0.2
     ember-resolver: ^10.0.0
     ember-responsive: 5.0.0
     ember-router-helpers: ^0.4.0


### PR DESCRIPTION
Adds and enables the ember a11y tests on all of our tests.

Note: had to pin to an older version of [ember-ally-testing](https://github.com/ember-a11y/ember-a11y-testing) because the peer dependencies on v6.x does not match what we can use on our current ember version, 4.12. Once we upgrade to ember 5.x we can also update this dependency to the latest version. 