### PR TITLE
PKI: Refactor storage of certificates into a common method

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -294,6 +294,8 @@ func Backend(conf *logical.BackendConfig) *backend {
 	b.acmeState = NewACMEState()
 	b.certificateCounter = NewCertificateCounter(b.backendUUID)
 
+	// It is important that we call SetupEnt at the very end as
+	// some ENT backends need access to the member vars initialized above.
 	b.SetupEnt()
 	return &b
 }

--- a/builtin/logical/pki/parsing/certificate.go
+++ b/builtin/logical/pki/parsing/certificate.go
@@ -6,8 +6,23 @@ package parsing
 import (
 	"crypto/x509"
 	"fmt"
+	"math/big"
 	"strings"
+
+	"github.com/hashicorp/vault/sdk/helper/certutil"
 )
+
+// NormalizeSerialForStorageFromBigInt given a serial number, format it as a string
+// that is safe to store within a filesystem
+func NormalizeSerialForStorageFromBigInt(serial *big.Int) string {
+	return strings.TrimSpace(certutil.GetHexFormatted(serial.Bytes(), "-"))
+}
+
+// NormalizeSerialForStorage given a serial number with ':' characters, convert
+// them to '-' which is safe to store within filesystems
+func NormalizeSerialForStorage(serial string) string {
+	return strings.ReplaceAll(strings.ToLower(serial), ":", "-")
+}
 
 func ParseCertificateFromString(pemCert string) (*x509.Certificate, error) {
 	return ParseCertificateFromBytes([]byte(pemCert))

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -288,17 +288,10 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 
 	// Also store it as just the certificate identified by serial number, so it
 	// can be revoked
-	key := "certs/" + normalizeSerial(cb.SerialNumber)
-	certCounter := b.GetCertificateCounter()
-	certsCounted := certCounter.IsInitialized()
-	err = req.Storage.Put(ctx, &logical.StorageEntry{
-		Key:   key,
-		Value: parsedBundle.CertificateBytes,
-	})
+	err = issuing.StoreCertificate(ctx, req.Storage, b.GetCertificateCounter(), parsedBundle)
 	if err != nil {
-		return nil, fmt.Errorf("unable to store certificate locally: %w", err)
+		return nil, err
 	}
-	certCounter.IncrementTotalCertificatesCount(certsCounted, key)
 
 	// Build a fresh CRL
 	warnings, err = b.CrlBuilder().rebuild(sc, true)
@@ -423,17 +416,10 @@ func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.R
 		return nil, err
 	}
 
-	key := "certs/" + normalizeSerialFromBigInt(parsedBundle.Certificate.SerialNumber)
-	certCounter := b.GetCertificateCounter()
-	certsCounted := certCounter.IsInitialized()
-	err = req.Storage.Put(ctx, &logical.StorageEntry{
-		Key:   key,
-		Value: parsedBundle.CertificateBytes,
-	})
+	err = issuing.StoreCertificate(ctx, req.Storage, b.GetCertificateCounter(), parsedBundle)
 	if err != nil {
-		return nil, fmt.Errorf("unable to store certificate locally: %w", err)
+		return nil, err
 	}
-	certCounter.IncrementTotalCertificatesCount(certsCounted, key)
 
 	return resp, nil
 }

--- a/builtin/logical/pki/pki_backend/common.go
+++ b/builtin/logical/pki/pki_backend/common.go
@@ -19,3 +19,8 @@ type MountInfo interface {
 type Logger interface {
 	Logger() log.Logger
 }
+
+type CertificateCounter interface {
+	IsInitialized() bool
+	IncrementTotalCertificatesCount(certsCounted bool, newSerial string)
+}

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hashicorp/vault/builtin/logical/pki/issuing"
 	"github.com/hashicorp/vault/builtin/logical/pki/managed_key"
+	"github.com/hashicorp/vault/builtin/logical/pki/parsing"
 	"github.com/hashicorp/vault/sdk/framework"
 
 	"github.com/hashicorp/vault/sdk/helper/certutil"
@@ -48,11 +49,11 @@ func serialFromBigInt(serial *big.Int) string {
 }
 
 func normalizeSerialFromBigInt(serial *big.Int) string {
-	return strings.TrimSpace(certutil.GetHexFormatted(serial.Bytes(), "-"))
+	return parsing.NormalizeSerialForStorageFromBigInt(serial)
 }
 
 func normalizeSerial(serial string) string {
-	return strings.ReplaceAll(strings.ToLower(serial), ":", "-")
+	return parsing.NormalizeSerialForStorage(serial)
 }
 
 func denormalizeSerial(serial string) string {


### PR DESCRIPTION
 - Move the copy/pasted code to store certificates into a common method within the PKI plugin