### PR TITLE
Fix two potential channel hangs in access.tryDecrypt

### DIFF
--- a/vault/seal/seal.go
+++ b/vault/seal/seal.go
@@ -720,7 +720,7 @@ func (a *access) Decrypt(ctx context.Context, ciphertext *MultiWrapValue, option
 			for _, sealWrapper := range wrappersByPriority {
 				keyId, err := sealWrapper.Wrapper.KeyId(ctx)
 				if err != nil {
-					reportResult(sealWrapper.Name, nil, false, err)
+					go reportResult(sealWrapper.Name, nil, false, err)
 					continue
 				}
 				if keyId == k {
@@ -762,6 +762,7 @@ GATHER_RESULTS:
 				return result.pt, isUpToDate, nil
 			}
 		case <-ctx.Done():
+			close(resultCh)
 			break GATHER_RESULTS
 		}
 	}

--- a/vault/seal/seal.go
+++ b/vault/seal/seal.go
@@ -762,10 +762,10 @@ GATHER_RESULTS:
 				return result.pt, isUpToDate, nil
 			}
 		case <-ctx.Done():
-			close(resultCh)
 			break GATHER_RESULTS
 		}
 	}
+	close(resultCh)
 
 	// No wrapper was able to decrypt the value, return an error
 	if len(errs) > 0 {


### PR DESCRIPTION
The first could happen if an error is received and we call reportResult
synchronously.  But there is no one listening on the other side until later
in the function.  The second could occur if the context becomes done before
we receive the result.  The goroutine would be stuck trying to report the
result to the chan which is still open, but the for { select } loop is no
longer checking resultCh.