### PR TITLE
docs: adds domain to OIDC Google Workspace integration

### DIFF
--- a/website/content/docs/auth/jwt/oidc-providers/google.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/google.mdx
@@ -71,7 +71,8 @@ that enable the feature.
 - `impersonate_principal` `(string: <optional>)` - Service account email that has been granted domain-wide delegation of authority in Google Workspace.
   Required if accessing the Google Workspace Directory API through domain-wide delegation of authority, without using a service account key.
   The service account vault is running under must be granted the `iam.serviceAccounts.signJwt` permission on this service account.
-  If `gsuite_admin_impersonate` is specifed, that	Workspace user will be impersonated.
+  If `gsuite_admin_impersonate` is specified, that	Workspace user will be impersonated.
+- `domain` `(string: <optional>)` - The domain to get groups from. Set this if your workspace is configured with more than one domain.
 
 Example configuration:
 


### PR DESCRIPTION
This PR adds the [`domain`](https://github.com/hashicorp/vault-plugin-auth-jwt/blob/main/provider_gsuite.go#L68) field to the documentation for the OIDC / Google Workspace integration.