### PR TITLE
docs: clarified the MS SQL EKM provider's authentication behavior, and the implications for AppRole configuration

### DIFF
--- a/website/content/docs/platform/mssql/installation.mdx
+++ b/website/content/docs/platform/mssql/installation.mdx
@@ -47,6 +47,12 @@ EKM provider to use it.
         token_policies=tde-policy
     ```
 
+-> **Note:** After authenticating to Vault with the AppRole, the EKM provider
+will re-use the token it receives until it expires, at which point it will
+authenticate using the AppRole credentials again; it will not attempt to renew
+its token. The example AppRole configuraiton here will work for this, but keep
+that in mind if you choose to use a different AppRole configuration.
+
 1. Retrieve the AppRole ID and secret ID for use later when configuring SQL Server:
 
     ```bash


### PR DESCRIPTION
Slack discussion with @tomhjp for context:
https://hashicorp.slack.com/archives/CPEPB6WRL/p1701966885637999?thread_ts=1701957028.186399&cid=CPEPB6WRL



The important part of the slack discussion, for transparency... I did some testing of the EKM provider to see how it behaved. My findings below:



EKM authenticates with Vault, gets a token with a specific TTL, then eventually that token expires.

After a few minutes of inactivity, looks like EKM did re-auth with Vault, and got itself a new token
```
Key                 Value
---                 -----
accessor            fBQVRIPK3td6ptYMNwNIIK9r
creation_time       1701956971
creation_ttl        2h
display_name        approle
entity_id           03ca3e9c-400a-1ab6-1580-58ea08f7437f
expire_time         2023-12-07T15:49:31.693948538Z
explicit_max_ttl    0s
id                  n/a
issue_time          2023-12-07T13:49:31.693958039Z
meta                map[role_name:tde-role]
num_uses            0
orphan              true
path                auth/approle/login
policies            [default tde-policy]
renewable           true
ttl                 1h57m54s
type                service
```
So I guess the behaviour is...
* EKM needs to read the key from Vault (the frequency of this, I'm not sure)
* If it has a valid token still, it uses that
* If the token is invalid (expired), then it'll attempt re-auth with the AppRole creds

At least... that's how it looks to me, without going for a deeper dive down this particular rabbit hole.

Feels like a detail missing from https://developer.hashicorp.com/vault/docs/platform/mssql which would be worth adding 🙂

(Especially as, by re-using the AppRole SecretID, you need to make sure your AppRole is configured to allow that) 