### PR TITLE
Sync Destination List Refresh Bug

### DIFF
--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
@@ -45,6 +45,11 @@ export default class DestinationSyncPageComponent extends Component<Args> {
   powerSelectAPI: PowerSelectAPI | undefined;
   _lastFetch: KvSecretMetadataModel[] | undefined; // cache the response for filtering purposes
 
+  willDestroy(): void {
+    this.store.clearDataset('sync/association');
+    super.willDestroy();
+  }
+
   // strip trailing slash from mount path
   get mountName() {
     return keyIsFolder(this.mountPath) ? this.mountPath.slice(0, -1) : this.mountPath;

--- a/ui/tests/integration/components/sync/secrets/page/destinations/destination/sync-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations/destination/sync-test.js
@@ -9,7 +9,7 @@ import { setupEngine } from 'ember-engines/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupModels } from 'vault/tests/helpers/sync/setup-models';
 import hbs from 'htmlbars-inline-precompile';
-import { render, click, fillIn } from '@ember/test-helpers';
+import { render, click, fillIn, settled } from '@ember/test-helpers';
 import { PAGE } from 'vault/tests/helpers/sync/sync-selectors';
 import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
 import { selectChoose } from 'ember-power-select/test-support/helpers';
@@ -140,5 +140,26 @@ module('Integration | Component | sync | Secrets::Page::Destinations::Destinatio
     await click(submit);
 
     assert.dom(messageError).hasTextContaining(error, 'Error renders in alert banner');
+  });
+
+  test('it should clear sync associations from store in willDestroy hook', async function (assert) {
+    const clearDatasetStub = sinon.stub(this.store, 'clearDataset');
+
+    this.renderComponent = true;
+    await render(
+      hbs`
+      {{#if this.renderComponent}}
+        <Secrets::Page::Destinations::Destination::Sync @destination={{this.destination}} />
+      {{/if}}
+    `,
+      { owner: this.engine }
+    );
+    this.set('renderComponent', false);
+    await settled();
+
+    assert.true(
+      clearDatasetStub.calledWith('sync/association'),
+      'Sync associations are cleared from store on component teardown'
+    );
   });
 });


### PR DESCRIPTION
This PR fixes an issue where newly synced associations were not appearing in the list on the destination secrets page. Sync associations needed to be cleared from the store so that `lazyPaginatedQuery` would fetch results from the server.