### PR TITLE
enos: don't include consul_version in autopilot

### DIFF
--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -6,7 +6,6 @@ scenario "autopilot" {
     arch            = global.archs
     artifact_source = global.artifact_sources
     artifact_type   = global.artifact_types
-    consul_version  = global.consul_versions
     distro          = global.distros
     edition         = global.editions
     initial_version = global.upgrade_initial_versions


### PR DESCRIPTION
Autopilot requires using integrated storage, therefore there's no reason to include this variant for this scenario.