### PR TITLE
VAULT-22481: Create audit filter node

### DIFF
--- a/audit/entry_filter.go
+++ b/audit/entry_filter.go
@@ -71,10 +71,7 @@ func (f *EntryFilter) Process(ctx context.Context, e *eventlogger.Event) (*event
 		return nil, fmt.Errorf("%s: cannot obtain namespace: %w", op, err)
 	}
 
-	datum, err := a.Data.BexprDatum(ns.ID)
-	if err != nil {
-		return nil, fmt.Errorf("%s: cannot convert audit entry in order to evaluate filter: %w", op, err)
-	}
+	datum := a.Data.BexprDatum(ns.Path)
 
 	result, err := f.evaluator.Evaluate(datum)
 	if err != nil {

--- a/audit/entry_filter.go
+++ b/audit/entry_filter.go
@@ -1,0 +1,91 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/go-bexpr"
+	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/internal/observability/event"
+)
+
+var _ eventlogger.Node = (*EntryFormatter)(nil)
+
+// NewEntryFilter should be used to create an EntryFilter node.
+// The filter supplied should be in bexpr format and reference fields from logical.LogInputBexpr.
+func NewEntryFilter(filter string) (*EntryFilter, error) {
+	const op = "audit.NewEntryFilter"
+
+	filter = strings.TrimSpace(filter)
+	if filter == "" {
+		return nil, fmt.Errorf("%s: cannot create new audit filter with empty filter expression: %w", op, event.ErrInvalidParameter)
+	}
+
+	eval, err := bexpr.CreateEvaluator(filter)
+	if err != nil {
+		return nil, fmt.Errorf("%s: cannot create new audit filter: %w", op, err)
+	}
+
+	return &EntryFilter{evaluator: eval}, nil
+}
+
+// Reopen is a no-op for the filter node.
+func (*EntryFilter) Reopen() error {
+	return nil
+}
+
+// Type describes the type of this node (filter).
+func (*EntryFilter) Type() eventlogger.NodeType {
+	return eventlogger.NodeTypeFilter
+}
+
+// Process will attempt to parse the incoming event data and decide whether it
+// should be filtered or remain in the pipeline and passed to the next node.
+func (f *EntryFilter) Process(ctx context.Context, e *eventlogger.Event) (*eventlogger.Event, error) {
+	const op = "audit.(EntryFilter).Process"
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	if e == nil {
+		return nil, fmt.Errorf("%s: event is nil: %w", op, event.ErrInvalidParameter)
+	}
+
+	a, ok := e.Payload.(*auditEvent)
+	if !ok {
+		return nil, fmt.Errorf("%s: cannot parse event payload: %w", op, event.ErrInvalidParameter)
+	}
+
+	// If we don't have data to process, then we're done.
+	if a.Data == nil {
+		return nil, nil
+	}
+
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%s: cannot obtain namespace: %w", op, err)
+	}
+
+	datum, err := a.Data.BexprDatum(ns.ID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: cannot convert audit entry in order to evaluate filter: %w", op, err)
+	}
+
+	result, err := f.evaluator.Evaluate(datum)
+	if err != nil {
+		return nil, fmt.Errorf("%s: unable to evaluate filter: %w", op, err)
+	}
+
+	if result {
+		// Allow this event to carry on through the pipeline.
+		return e, nil
+	}
+
+	// End process of this pipeline.
+	return nil, nil
+}

--- a/audit/entry_filter_test.go
+++ b/audit/entry_filter_test.go
@@ -1,0 +1,247 @@
+package audit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/internal/observability/event"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEntryFilter_NewEntryFilter tests that we can create EntryFilter types correctly.
+func TestEntryFilter_NewEntryFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		Filter               string
+		IsErrorExpected      bool
+		ExpectedErrorMessage string
+	}{
+		"empty-filter": {
+			Filter:               "",
+			IsErrorExpected:      true,
+			ExpectedErrorMessage: "audit.NewEntryFilter: cannot create new audit filter with empty filter expression: invalid parameter",
+		},
+		"spacey-filter": {
+			Filter:               "    ",
+			IsErrorExpected:      true,
+			ExpectedErrorMessage: "audit.NewEntryFilter: cannot create new audit filter with empty filter expression: invalid parameter",
+		},
+		"bad-filter": {
+			Filter:               "____",
+			IsErrorExpected:      true,
+			ExpectedErrorMessage: "audit.NewEntryFilter: cannot create new audit filter",
+		},
+		"good-filter": {
+			Filter:          "foo == bar",
+			IsErrorExpected: false,
+		},
+	}
+
+	for name, tc := range tests {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			f, err := NewEntryFilter(tc.Filter)
+			switch {
+			case tc.IsErrorExpected:
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.ExpectedErrorMessage)
+				require.Nil(t, f)
+			default:
+				require.NoError(t, err)
+				require.NotNil(t, f)
+			}
+		})
+	}
+}
+
+// TestEntryFilter_Reopen ensures we can reopen the filter node.
+func TestEntryFilter_Reopen(t *testing.T) {
+	t.Parallel()
+
+	f := &EntryFilter{}
+	res := f.Reopen()
+	require.Nil(t, res)
+}
+
+// TestEntryFilter_Type ensures we always return the right type for this node.
+func TestEntryFilter_Type(t *testing.T) {
+	t.Parallel()
+
+	f := &EntryFilter{}
+	require.Equal(t, eventlogger.NodeTypeFilter, f.Type())
+}
+
+// TestEntryFilter_Process_ContextDone ensures that we stop processing the event
+// if the context was cancelled.
+func TestEntryFilter_Process_ContextDone(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Explicitly cancel the context
+	cancel()
+
+	l, err := NewEntryFilter("foo == bar")
+	require.NoError(t, err)
+
+	// Fake audit event
+	a, err := NewEvent(RequestType)
+	require.NoError(t, err)
+
+	// Fake event logger event
+	e := &eventlogger.Event{
+		Type:      eventlogger.EventType(event.AuditType.String()),
+		CreatedAt: time.Now(),
+		Formatted: make(map[string][]byte),
+		Payload:   a,
+	}
+
+	e2, err := l.Process(ctx, e)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "context canceled")
+
+	// Ensure that the pipeline won't continue.
+	require.Nil(t, e2)
+}
+
+// TestEntryFilter_Process_NilEvent ensures we receive the right error when the
+// event we are trying to process is nil.
+func TestEntryFilter_Process_NilEvent(t *testing.T) {
+	t.Parallel()
+
+	l, err := NewEntryFilter("foo == bar")
+	require.NoError(t, err)
+	e, err := l.Process(context.Background(), nil)
+	require.Error(t, err)
+	require.EqualError(t, err, "audit.(EntryFilter).Process: event is nil: invalid parameter")
+
+	// Ensure that the pipeline won't continue.
+	require.Nil(t, e)
+}
+
+// TestEntryFilter_Process_BadPayload ensures we receive the correct error when
+// attempting to process an event with a payload that cannot be parsed back to
+// an audit event.
+func TestEntryFilter_Process_BadPayload(t *testing.T) {
+	t.Parallel()
+
+	l, err := NewEntryFilter("foo == bar")
+	require.NoError(t, err)
+
+	e := &eventlogger.Event{
+		Type:      eventlogger.EventType(event.AuditType.String()),
+		CreatedAt: time.Now(),
+		Formatted: make(map[string][]byte),
+		Payload:   nil,
+	}
+
+	e2, err := l.Process(context.Background(), e)
+	require.Error(t, err)
+	require.EqualError(t, err, "audit.(EntryFilter).Process: cannot parse event payload: invalid parameter")
+
+	// Ensure that the pipeline won't continue.
+	require.Nil(t, e2)
+}
+
+// TestEntryFilter_Process_NoAuditDataInPayload ensure we stop processing a pipeline
+// when the data in the audit event is nil.
+func TestEntryFilter_Process_NoAuditDataInPayload(t *testing.T) {
+	t.Parallel()
+
+	l, err := NewEntryFilter("foo == bar")
+	require.NoError(t, err)
+
+	a, err := NewEvent(RequestType)
+	require.NoError(t, err)
+
+	// Ensure audit data is nil
+	a.Data = nil
+
+	e := &eventlogger.Event{
+		Type:      eventlogger.EventType(event.AuditType.String()),
+		CreatedAt: time.Now(),
+		Formatted: make(map[string][]byte),
+		Payload:   a,
+	}
+
+	e2, err := l.Process(context.Background(), e)
+
+	// Make sure we get the 'nil, nil' response to stop processing this pipeline.
+	require.NoError(t, err)
+	require.Nil(t, e2)
+}
+
+// TestEntryFilter_Process_FilterSuccess tests that when a filter matches we
+// receive no error and the event is not nil so it continues in the pipeline.
+func TestEntryFilter_Process_FilterSuccess(t *testing.T) {
+	t.Parallel()
+
+	l, err := NewEntryFilter("mount_type == juan")
+	require.NoError(t, err)
+
+	a, err := NewEvent(RequestType)
+	require.NoError(t, err)
+
+	a.Data = &logical.LogInput{
+		Request: &logical.Request{
+			Operation: logical.CreateOperation,
+			MountType: "juan",
+		},
+	}
+
+	e := &eventlogger.Event{
+		Type:      eventlogger.EventType(event.AuditType.String()),
+		CreatedAt: time.Now(),
+		Formatted: make(map[string][]byte),
+		Payload:   a,
+	}
+
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	e2, err := l.Process(ctx, e)
+
+	require.NoError(t, err)
+	require.NotNil(t, e2)
+}
+
+// TestEntryFilter_Process_FilterFail tests that when a filter fails to match we
+// receive no error, but also the event is nil so that the pipeline completes.
+func TestEntryFilter_Process_FilterFail(t *testing.T) {
+	t.Parallel()
+
+	l, err := NewEntryFilter("mount_type == john")
+	require.NoError(t, err)
+
+	a, err := NewEvent(RequestType)
+	require.NoError(t, err)
+
+	a.Data = &logical.LogInput{
+		Request: &logical.Request{
+			Operation: logical.CreateOperation,
+			MountType: "juan",
+		},
+	}
+
+	e := &eventlogger.Event{
+		Type:      eventlogger.EventType(event.AuditType.String()),
+		CreatedAt: time.Now(),
+		Formatted: make(map[string][]byte),
+		Payload:   a,
+	}
+
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	e2, err := l.Process(ctx, e)
+
+	require.NoError(t, err)
+	require.Nil(t, e2)
+}

--- a/audit/entry_filter_test.go
+++ b/audit/entry_filter_test.go
@@ -218,7 +218,7 @@ func TestEntryFilter_Process_FilterSuccess(t *testing.T) {
 func TestEntryFilter_Process_FilterFail(t *testing.T) {
 	t.Parallel()
 
-	l, err := NewEntryFilter("mount_type == john")
+	l, err := NewEntryFilter("mount_type == john and operation == create and namespace == root")
 	require.NoError(t, err)
 
 	a, err := NewEvent(RequestType)

--- a/audit/types.go
+++ b/audit/types.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/go-bexpr"
 	"github.com/hashicorp/vault/sdk/helper/salt"
-
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -142,6 +142,13 @@ type FormatterConfig struct {
 
 	// The required/target format for the event (supported: JSONFormat and JSONxFormat).
 	RequiredFormat format
+}
+
+// EntryFilter should be used to filter audit requests and responses which should
+// make it to a sink.
+type EntryFilter struct {
+	// the evaluator for the bexpr expression that should be applied by the node.
+	evaluator *bexpr.Evaluator
 }
 
 // RequestEntry is the structure of a request audit log entry.

--- a/sdk/logical/audit.go
+++ b/sdk/logical/audit.go
@@ -20,3 +20,36 @@ type MarshalOptions struct {
 type OptMarshaler interface {
 	MarshalJSONWithOptions(*MarshalOptions) ([]byte, error)
 }
+
+// LogInputBexpr is used for evaluating boolean expressions with go-bexpr.
+type LogInputBexpr struct {
+	MountPoint string `bexpr:"mount_point"`
+	MountType  string `bexpr:"mount_type"`
+	Namespace  string `bexpr:"namespace"` // TODO: PW: ns.ID, ns.Path? what should bexpr look like?
+	Operation  string `bexpr:"operation"`
+	Path       string `bexpr:"path"`
+}
+
+// BexprDatum returns values from a LogInput formatted for use in evaluating go-bexpr boolean expressions.
+// The namespace should be supplied from the current request's context.
+func (l *LogInput) BexprDatum(namespace string) (any, error) {
+	var mountPoint string
+	var mountType string
+	var operation string
+	var path string
+
+	if l.Request != nil {
+		mountPoint = l.Request.MountPoint
+		mountType = l.Request.MountType
+		operation = string(l.Request.Operation)
+		path = l.Request.Path
+	}
+
+	return &LogInputBexpr{
+		MountPoint: mountPoint,
+		MountType:  mountType,
+		Namespace:  namespace,
+		Operation:  operation,
+		Path:       path,
+	}, nil
+}

--- a/sdk/logical/audit.go
+++ b/sdk/logical/audit.go
@@ -25,14 +25,14 @@ type OptMarshaler interface {
 type LogInputBexpr struct {
 	MountPoint string `bexpr:"mount_point"`
 	MountType  string `bexpr:"mount_type"`
-	Namespace  string `bexpr:"namespace"` // TODO: PW: ns.ID, ns.Path? what should bexpr look like?
+	Namespace  string `bexpr:"namespace"`
 	Operation  string `bexpr:"operation"`
 	Path       string `bexpr:"path"`
 }
 
 // BexprDatum returns values from a LogInput formatted for use in evaluating go-bexpr boolean expressions.
 // The namespace should be supplied from the current request's context.
-func (l *LogInput) BexprDatum(namespace string) (any, error) {
+func (l *LogInput) BexprDatum(namespace string) any {
 	var mountPoint string
 	var mountType string
 	var operation string
@@ -51,5 +51,5 @@ func (l *LogInput) BexprDatum(namespace string) (any, error) {
 		Namespace:  namespace,
 		Operation:  operation,
 		Path:       path,
-	}, nil
+	}
 }

--- a/sdk/logical/audit_test.go
+++ b/sdk/logical/audit_test.go
@@ -1,0 +1,72 @@
+package logical
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogInput_BexprDatum ensures that we can transform a LogInput
+// into a LogInputBexpr to be used in audit filtering.
+func TestLogInput_BexprDatum(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		Request            *Request
+		Namespace          string
+		ExpectedMountPoint string
+		ExpectedMountType  string
+		ExpectedNamespace  string
+		ExpectedOperation  string
+	}{
+		"nil-no-namespace": {
+			Request:            nil,
+			Namespace:          "",
+			ExpectedMountPoint: "",
+			ExpectedMountType:  "",
+			ExpectedNamespace:  "",
+			ExpectedOperation:  "",
+		},
+		"nil-namespace": {
+			Request:            nil,
+			Namespace:          "juan",
+			ExpectedMountPoint: "",
+			ExpectedMountType:  "",
+			ExpectedNamespace:  "juan",
+			ExpectedOperation:  "",
+		},
+		"happy-path": {
+			Request: &Request{
+				MountPoint: "IAmAMountPoint",
+				MountType:  "IAmAMountType",
+				Operation:  CreateOperation,
+				Path:       "IAmAPath",
+			},
+			Namespace:          "juan",
+			ExpectedMountPoint: "IAmAMountPoint",
+			ExpectedMountType:  "IAmAMountType",
+			ExpectedNamespace:  "juan",
+			ExpectedOperation:  "create",
+		},
+	}
+
+	for name, tc := range tests {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			l := &LogInput{Request: tc.Request}
+
+			d := l.BexprDatum(tc.Namespace)
+
+			res, ok := d.(*LogInputBexpr)
+			require.True(t, ok)
+			require.NotNil(t, res)
+			require.Equal(t, tc.ExpectedMountPoint, res.MountPoint)
+			require.Equal(t, tc.ExpectedMountType, res.MountType)
+			require.Equal(t, tc.ExpectedNamespace, res.Namespace)
+			require.Equal(t, tc.ExpectedOperation, res.Operation)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the `EntryFilter` node for audit pipelines. 

The node supports a bexpr filter that users can configure, the following fields are available to filter on:

* `mount_point`
* `mount_type`
* `namespace`
* `operation`
* `path`

Example filters:

`mount_type == kv`
`mount_type == kv and operation == create`
`mount_type == kv and operation == create and namespace == root`