### PR TITLE
New database plugin API to reload by plugin name

### DIFF
--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -107,6 +107,7 @@ func Backend(conf *logical.BackendConfig) *databaseBackend {
 				pathListPluginConnection(&b),
 				pathConfigurePluginConnection(&b),
 				pathResetConnection(&b),
+				pathReloadPlugin(&b),
 			},
 			pathListRoles(&b),
 			pathRoles(&b),

--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -769,6 +769,11 @@ func TestBackend_connectionCrud(t *testing.T) {
 		if hanaID != getConnectionID("plugin-test-hana") {
 			t.Fatal("hana plugin got restarted but shouldn't have been")
 		}
+		if strings.HasPrefix(reloadPath, "reload/") {
+			if resp.Data["reloaded"] != 1 {
+				t.Fatal("expected 1 reload to be reported but got: ", resp.Data)
+			}
+		}
 	}
 
 	// Get creds

--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -770,8 +770,11 @@ func TestBackend_connectionCrud(t *testing.T) {
 			t.Fatal("hana plugin got restarted but shouldn't have been")
 		}
 		if strings.HasPrefix(reloadPath, "reload/") {
-			if resp.Data["reloaded"] != 1 {
-				t.Fatal("expected 1 reload to be reported but got: ", resp.Data)
+			if expected := 1; expected != resp.Data["count"] {
+				t.Fatalf("expected %d but got %d", expected, resp.Data["count"])
+			}
+			if expected := []string{"plugin-test"}; !reflect.DeepEqual(expected, resp.Data["connections"]) {
+				t.Fatalf("expected %v but got %v", expected, resp.Data["connections"])
 			}
 		}
 	}

--- a/builtin/logical/database/path_config_connection.go
+++ b/builtin/logical/database/path_config_connection.go
@@ -94,7 +94,7 @@ func (b *databaseBackend) pathConnectionReset() framework.OperationFunc {
 			return logical.ErrorResponse(respErrEmptyName), nil
 		}
 
-		if err := b.reloadConnection(ctx, name, req.Storage); err != nil {
+		if err := b.reloadConnection(ctx, req.Storage, name); err != nil {
 			return nil, err
 		}
 
@@ -102,7 +102,7 @@ func (b *databaseBackend) pathConnectionReset() framework.OperationFunc {
 	}
 }
 
-func (b *databaseBackend) reloadConnection(ctx context.Context, name string, storage logical.Storage) error {
+func (b *databaseBackend) reloadConnection(ctx context.Context, storage logical.Storage, name string) error {
 	// Close plugin and delete the entry in the connections cache.
 	if err := b.ClearConnection(name); err != nil {
 		return err
@@ -138,8 +138,8 @@ func pathReloadPlugin(b *databaseBackend) *framework.Path {
 			logical.UpdateOperation: b.reloadPlugin(),
 		},
 
-		HelpSynopsis:    pathResetConnectionHelpSyn,
-		HelpDescription: pathResetConnectionHelpDesc,
+		HelpSynopsis:    pathReloadPluginHelpSyn,
+		HelpDescription: pathReloadPluginHelpDesc,
 	}
 }
 
@@ -170,7 +170,7 @@ func (b *databaseBackend) reloadPlugin() framework.OperationFunc {
 				return nil, err
 			}
 			if config.PluginName == pluginName {
-				if err := b.reloadConnection(ctx, connName, req.Storage); err != nil {
+				if err := b.reloadConnection(ctx, req.Storage, connName); err != nil {
 					return nil, err
 				}
 			}

--- a/builtin/logical/database/path_config_connection.go
+++ b/builtin/logical/database/path_config_connection.go
@@ -156,6 +156,7 @@ func (b *databaseBackend) reloadPlugin() framework.OperationFunc {
 		if err != nil {
 			return nil, err
 		}
+		var reloaded int
 		for _, connName := range connNames {
 			entry, err := req.Storage.Get(ctx, fmt.Sprintf("config/%s", connName))
 			if err != nil {
@@ -170,13 +171,18 @@ func (b *databaseBackend) reloadPlugin() framework.OperationFunc {
 				return nil, err
 			}
 			if config.PluginName == pluginName {
+				reloaded++
 				if err := b.reloadConnection(ctx, req.Storage, connName); err != nil {
-					return nil, err
+					return nil, fmt.Errorf("failed to reload connection %q: %w", connName, err)
 				}
 			}
 		}
 
-		return nil, nil
+		return &logical.Response{
+			Data: map[string]interface{}{
+				"reloaded": reloaded,
+			},
+		}, nil
 	}
 }
 

--- a/changelog/24472.txt
+++ b/changelog/24472.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/database: Add new reload/:plugin_name API to reload database plugins by name for a specific mount.
+```

--- a/website/content/api-docs/secret/databases/index.mdx
+++ b/website/content/api-docs/secret/databases/index.mdx
@@ -250,6 +250,42 @@ $ curl \
     http://127.0.0.1:8200/v1/database/reset/mysql
 ```
 
+## Reload plugin
+
+This endpoint performs the same operation as
+[reset connection](/vault/api-docs/secret/databases#reset-connection) but for
+all connections that reference a specific plugin name. This can be useful to
+restart a specific plugin after it's been upgraded in the plugin catalog.
+
+| Method | Path                            |
+| :----- | :------------------------------ |
+| `POST` | `/database/reload/:plugin_name` |
+
+### Parameters
+
+- `plugin_name` `(string: <required>)` – Specifies the name of the plugin for
+  which all connections should be reset. This is specified as part of the URL.
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    http://127.0.0.1:8200/v1/database/reload/postgresql-database-plugin
+```
+
+### Sample response
+
+```json
+{
+  "data": {
+    "connections": ["pg1", "pg2"],
+    "count": 2
+  }
+}
+```
+
 ## Rotate root credentials
 
 This endpoint is used to rotate the "root" user credentials stored for


### PR DESCRIPTION
This complements the [reset connection](https://developer.hashicorp.com/vault/api-docs/secret/databases#reset-connection) API, to also be able to restart by plugin instead of just by connection. This is especially helpful for completing plugin upgrades. In a future PR, I plan to support making an internal call to this endpoint from a more generic plugin reload endpoint to support database plugin reloads across multiple database mounts.

I had originally planned to implement cross-mount plugin reloads by killing plugins directly from the plugin catalog. However, that wouldn't give the best possible UX because the plugin catalog only knows what's currently running, not what the next config should be, so it would only be able to kill the existing plugins and not restart them. Then if the new plugin fails to come up, users won't get the error message as soon as they could have if it got started again immediately. By adding the API to the database plugin directly, we can kill _and_ restart the plugin in the same context and return errors immediately.