### PR TITLE
UI: a11y sidebranch - update tests

### DIFF
--- a/ui/tests/acceptance/sidebar-nav-test.js
+++ b/ui/tests/acceptance/sidebar-nav-test.js
@@ -9,6 +9,7 @@ import { click, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import authPage from 'vault/tests/pages/auth';
 import modifyPassthroughResponse from 'vault/mirage/helpers/modify-passthrough-response';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const link = (label) => `[data-test-sidebar-nav-link="${label}"]`;
 const panel = (label) => `[data-test-sidebar-nav-panel="${label}"]`;
@@ -23,7 +24,12 @@ module('Acceptance | sidebar navigation', function (hooks) {
       return modifyPassthroughResponse(req, { storage_type: 'raft' });
     });
     this.server.get('/sys/storage/raft/configuration', () => this.server.create('configuration', 'withRaft'));
-
+    setRunOptions({
+      rules: {
+        // TODO: fix use Dropdown on user-menu
+        'nested-interactive': { enabled: false },
+      },
+    });
     return authPage.login();
   });
 

--- a/ui/tests/integration/components/autocomplete-input-test.js
+++ b/ui/tests/integration/components/autocomplete-input-test.js
@@ -13,6 +13,12 @@ module('Integration | Component | autocomplete-input', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render label', async function (assert) {
+    // TODO: make the input accessible when no label provided
+    setRunOptions({
+      rules: {
+        label: { enabled: false },
+      },
+    });
     await render(
       hbs`
       <AutocompleteInput

--- a/ui/tests/integration/components/autocomplete-input-test.js
+++ b/ui/tests/integration/components/autocomplete-input-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn, triggerEvent, typeIn, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | autocomplete-input', function (hooks) {
   setupRenderingTest(hooks);
@@ -51,6 +52,12 @@ module('Integration | Component | autocomplete-input', function (hooks) {
   });
 
   test('it should trigger dropdown', async function (assert) {
+    setRunOptions({
+      rules: {
+        // TODO fix this component
+        label: { enabled: false },
+      },
+    });
     await render(
       hbs`
       <AutocompleteInput

--- a/ui/tests/integration/components/clients/running-total-test.js
+++ b/ui/tests/integration/components/clients/running-total-test.js
@@ -13,6 +13,7 @@ import { findAll } from '@ember/test-helpers';
 import { calculateAverage } from 'vault/utils/chart-helpers';
 import { formatNumber } from 'core/helpers/format-number';
 import timestamp from 'core/utils/timestamp';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | clients/running-total', function (hooks) {
   setupRenderingTest(hooks);
@@ -1430,6 +1431,12 @@ module('Integration | Component | clients/running-total', function (hooks) {
       { label: 'entity clients', key: 'entity_clients' },
       { label: 'non-entity clients', key: 'non_entity_clients' },
     ]);
+    // Fails on #ember-testing-container
+    setRunOptions({
+      rules: {
+        'scrollable-region-focusable': { enabled: false },
+      },
+    });
   });
   hooks.after(function () {
     timestamp.now.restore();

--- a/ui/tests/integration/components/confirm-action-test.js
+++ b/ui/tests/integration/components/confirm-action-test.js
@@ -8,6 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const SELECTORS = {
   modalToggle: '[data-test-confirm-action-trigger]',
@@ -57,6 +58,12 @@ module('Integration | Component | confirm-action', function (hooks) {
   });
 
   test('it renders isInDropdown defaults and calls onConfirmAction', async function (assert) {
+    setRunOptions({
+      rules: {
+        // this component breaks this rule because it expects to be rendered within <ul>
+        listitem: { enabled: false },
+      },
+    });
     await render(hbs`
       <ConfirmAction
         @buttonText="DELETE"

--- a/ui/tests/integration/components/console/log-json-test.js
+++ b/ui/tests/integration/components/console/log-json-test.js
@@ -7,12 +7,19 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | console/log json', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
     this.codeMirror = this.owner.lookup('service:code-mirror');
+    // TODO: Fix JSONEditor/CodeMirror
+    setRunOptions({
+      rules: {
+        label: { enabled: false },
+      },
+    });
   });
 
   test('it renders', async function (assert) {

--- a/ui/tests/integration/components/control-group-success-test.js
+++ b/ui/tests/integration/components/control-group-success-test.js
@@ -13,6 +13,7 @@ import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import { create } from 'ember-cli-page-object';
 import controlGroupSuccess from '../../pages/components/control-group-success';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const component = create(controlGroupSuccess);
 
@@ -44,6 +45,13 @@ module('Integration | Component | control group success', function (hooks) {
       this.router.reopen({
         transitionTo: sinon.stub().returns(resolve()),
       });
+      setRunOptions({
+        rules: {
+          // TODO: swap out JsonEditor with Hds::CodeBlock for display
+          'color-contrast': { enabled: false },
+          label: { enabled: false },
+        },
+      });
     });
   });
 
@@ -62,7 +70,7 @@ module('Integration | Component | control group success', function (hooks) {
     };
     this.set('model', MODEL);
     this.set('response', response);
-    await render(hbs`{{control-group-success model=this.model controlGroupResponse=this.response }}`);
+    await render(hbs`<ControlGroupSuccess @model={{this.model}} @controlGroupResponse={{this.response}} />`);
     assert.ok(component.showsNavigateMessage, 'shows unwrap message');
     await component.navigate();
     later(() => cancelTimers(), 50);
@@ -75,7 +83,7 @@ module('Integration | Component | control group success', function (hooks) {
   test('render without token', async function (assert) {
     assert.expect(2);
     this.set('model', MODEL);
-    await render(hbs`{{control-group-success model=this.model}}`);
+    await render(hbs`<ControlGroupSuccess @model={{this.model}} />`);
     assert.ok(component.showsUnwrapForm, 'shows unwrap form');
     await component.token('token');
     component.unwrap();

--- a/ui/tests/integration/components/dashboard/quick-actions-card-test.js
+++ b/ui/tests/integration/components/dashboard/quick-actions-card-test.js
@@ -11,6 +11,7 @@ import { fillIn } from '@ember/test-helpers';
 import { selectChoose } from 'ember-power-select/test-support/helpers';
 
 import { SELECTORS } from 'vault/tests/helpers/components/dashboard/dashboard-selectors';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | dashboard/quick-actions-card', function (hooks) {
   setupRenderingTest(hooks);
@@ -91,6 +92,14 @@ module('Integration | Component | dashboard/quick-actions-card', function (hooks
     this.renderComponent = () => {
       return render(hbs`<Dashboard::QuickActionsCard @secretsEngines={{this.secretsEngines}} />`);
     };
+
+    setRunOptions({
+      rules: {
+        // TODO: Fix SearchSelect component
+        'aria-required-attr': { enabled: false },
+        label: { enabled: false },
+      },
+    });
   });
 
   test('it should show quick action empty state if no engine is selected', async function (assert) {

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -11,6 +11,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { create } from 'ember-cli-page-object';
 import sinon from 'sinon';
 import formFields from '../../pages/components/form-field';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const component = create(formFields);
 
@@ -79,12 +80,24 @@ module('Integration | Component | form field', function (hooks) {
   });
 
   test('it renders: object', async function (assert) {
+    // TODO: Fix JSONEditor/CodeMirror
+    setRunOptions({
+      rules: {
+        label: { enabled: false },
+      },
+    });
     await setup.call(this, createAttr('foo', 'object'));
     assert.strictEqual(component.fields.objectAt(0).labelText[0], 'Foo', 'renders a label');
     assert.ok(component.hasJSONEditor, 'renders the json editor');
   });
 
   test('it renders: string as json with clear button', async function (assert) {
+    // TODO: Fix JSONEditor/CodeMirror
+    setRunOptions({
+      rules: {
+        label: { enabled: false },
+      },
+    });
     await setup.call(this, createAttr('foo', 'string', { editType: 'json', allowReset: true }));
     assert.strictEqual(component.fields.objectAt(0).labelText[0], 'Foo', 'renders a label');
     assert.ok(component.hasJSONEditor, 'renders the json editor');

--- a/ui/tests/integration/components/get-credentials-card-test.js
+++ b/ui/tests/integration/components/get-credentials-card-test.js
@@ -10,6 +10,7 @@ import { click, render } from '@ember/test-helpers';
 import { selectChoose, clickTrigger } from 'ember-power-select/test-support/helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const storeService = Service.extend({
   query(modelType) {
@@ -38,6 +39,13 @@ module('Integration | Component | get-credentials-card', function (hooks) {
     this.owner.register('service:store', storeService);
     this.set('title', 'Get Credentials');
     this.set('searchLabel', 'Role to use');
+    setRunOptions({
+      rules: {
+        // TODO: Fix SearchSelect component
+        'aria-required-attr': { enabled: false },
+        label: { enabled: false },
+      },
+    });
   });
 
   hooks.afterEach(function () {

--- a/ui/tests/integration/components/json-editor-test.js
+++ b/ui/tests/integration/components/json-editor-test.js
@@ -10,6 +10,7 @@ import { render, fillIn, find, waitUntil, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import jsonEditor from '../../pages/components/json-editor';
 import sinon from 'sinon';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const component = create(jsonEditor);
 
@@ -29,6 +30,12 @@ module('Integration | Component | json-editor', function (hooks) {
     this.set('json_blob', JSON_BLOB);
     this.set('bad_json_blob', BAD_JSON_BLOB);
     this.set('hashi-read-only-theme', 'hashi-read-only auto-height');
+    setRunOptions({
+      rules: {
+        // CodeMirror has a secret textarea without a label that causes this problem
+        label: { enabled: false },
+      },
+    });
   });
 
   test('it renders', async function (assert) {

--- a/ui/tests/integration/components/json-editor-test.js
+++ b/ui/tests/integration/components/json-editor-test.js
@@ -34,6 +34,8 @@ module('Integration | Component | json-editor', function (hooks) {
       rules: {
         // CodeMirror has a secret textarea without a label that causes this problem
         label: { enabled: false },
+        // TODO: investigate and fix Codemirror styling
+        'color-contrast': { enabled: false },
       },
     });
   });
@@ -80,7 +82,6 @@ module('Integration | Component | json-editor', function (hooks) {
       @theme={{this.hashi-read-only-theme}}
       @readOnly={{true}}
     />`);
-
     assert.dom('.cm-s-hashi-read-only').hasStyle({
       background: 'rgb(247, 248, 250) none repeat scroll 0% 0% / auto padding-box border-box',
     });

--- a/ui/tests/integration/components/keymgmt/distribute-test.js
+++ b/ui/tests/integration/components/keymgmt/distribute-test.js
@@ -11,6 +11,7 @@ import { create } from 'ember-cli-page-object';
 import { hbs } from 'ember-cli-htmlbars';
 import { typeInSearch, clickTrigger } from 'ember-power-select/test-support/helpers';
 import searchSelect from '../../../pages/components/search-select';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const SELECTORS = {
   form: '[data-test-keymgmt-distribution-form]',
@@ -94,6 +95,14 @@ module('Integration | Component | keymgmt/distribute', function (hooks) {
           }),
         ];
       });
+    });
+    setRunOptions({
+      rules: {
+        // TODO: Fix SearchSelect component
+        'aria-required-attr': { enabled: false },
+        label: { enabled: false },
+        'color-contrast': { enabled: false },
+      },
     });
   });
 

--- a/ui/tests/integration/components/keymgmt/provider-edit-test.js
+++ b/ui/tests/integration/components/keymgmt/provider-edit-test.js
@@ -9,6 +9,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { click, settled, fillIn } from '@ember/test-helpers';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const ts = 'data-test-kms-provider';
 const root = {
@@ -43,6 +44,14 @@ module('Integration | Component | keymgmt/provider-edit', function (hooks) {
       currentRouteName: 'secrets.keymgmt.provider.show',
       urlFor() {
         return '';
+      },
+    });
+
+    setRunOptions({
+      rules: {
+        // TODO: fix KMS provider-edit [data-test-kms-provider-delete] violates this rule
+        // see https://dequeuniversity.com/rules/axe/4.8/scrollable-region-focusable
+        'scrollable-region-focusable': { enabled: false },
       },
     });
   });

--- a/ui/tests/integration/components/kubernetes/page/configure-test.js
+++ b/ui/tests/integration/components/kubernetes/page/configure-test.js
@@ -11,6 +11,7 @@ import { render, click, waitUntil, find, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { Response } from 'miragejs';
 import sinon from 'sinon';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | kubernetes | Page::Configure', function (hooks) {
   setupRenderingTest(hooks);
@@ -43,6 +44,13 @@ module('Integration | Component | kubernetes | Page::Configure', function (hooks
       kubernetes_host: null,
       service_account_jwt: null,
     };
+    setRunOptions({
+      rules: {
+        // TODO: fix RadioCard component (replace with HDS)
+        'aria-valid-attr-value': { enabled: false },
+        'nested-interactive': { enabled: false },
+      },
+    });
   });
 
   test('it should display proper options when toggling radio cards', async function (assert) {

--- a/ui/tests/integration/components/kubernetes/page/overview-test.js
+++ b/ui/tests/integration/components/kubernetes/page/overview-test.js
@@ -11,6 +11,7 @@ import { render } from '@ember/test-helpers';
 import { typeInSearch, clickTrigger, selectChoose } from 'ember-power-select/test-support/helpers';
 import { SELECTORS } from 'vault/tests/helpers/kubernetes/overview';
 import hbs from 'htmlbars-inline-precompile';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | kubernetes | Page::Overview', function (hooks) {
   setupRenderingTest(hooks);
@@ -50,6 +51,13 @@ module('Integration | Component | kubernetes | Page::Overview', function (hooks)
         { owner: this.engine }
       );
     };
+    setRunOptions({
+      rules: {
+        // TODO: Fix SearchSelect component
+        'aria-required-attr': { enabled: false },
+        label: { enabled: false },
+      },
+    });
   });
 
   test('it should display role card', async function (assert) {

--- a/ui/tests/integration/components/kubernetes/page/role/create-and-edit-test.js
+++ b/ui/tests/integration/components/kubernetes/page/role/create-and-edit-test.js
@@ -10,6 +10,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render, click, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | kubernetes | Page::Role::CreateAndEdit', function (hooks) {
   setupRenderingTest(hooks);
@@ -42,6 +43,15 @@ module('Integration | Component | kubernetes | Page::Role::CreateAndEdit', funct
       { label: 'roles', route: 'roles' },
       { label: 'create' },
     ];
+    setRunOptions({
+      rules: {
+        // TODO: fix RadioCard component (replace with HDS)
+        'aria-valid-attr-value': { enabled: false },
+        'nested-interactive': { enabled: false },
+        // TODO: fix JSONEditor/CodeMirror
+        label: { enabled: false },
+      },
+    });
   });
 
   test('it should display placeholder when generation preference is not selected', async function (assert) {

--- a/ui/tests/integration/components/kubernetes/page/role/details-test.js
+++ b/ui/tests/integration/components/kubernetes/page/role/details-test.js
@@ -11,6 +11,7 @@ import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import { duration } from 'core/helpers/format-duration';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const allFields = [
   { label: 'Role name', key: 'name' },
@@ -78,6 +79,12 @@ module('Integration | Component | kubernetes | Page::Role::Details', function (h
         }
       });
     };
+    setRunOptions({
+      rules: {
+        // TODO: Fix JSONEditor component
+        label: { enabled: false },
+      },
+    });
   });
 
   test('it should render header with role name and breadcrumbs', async function (assert) {

--- a/ui/tests/integration/components/kv/kv-data-fields-test.js
+++ b/ui/tests/integration/components/kv/kv-data-fields-test.js
@@ -11,6 +11,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { fillIn, render, click } from '@ember/test-helpers';
 import codemirror from 'vault/tests/helpers/codemirror';
 import { PAGE, FORM } from 'vault/tests/helpers/kv/kv-selectors';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | kv-v2 | KvDataFields', function (hooks) {
   setupRenderingTest(hooks);
@@ -22,6 +23,12 @@ module('Integration | Component | kv-v2 | KvDataFields', function (hooks) {
     this.backend = 'my-kv-engine';
     this.path = 'my-secret';
     this.secret = this.store.createRecord('kv/data', { backend: this.backend });
+    // TODO: Fix JSONEditor/CodeMirror
+    setRunOptions({
+      rules: {
+        label: { enabled: false },
+      },
+    });
   });
 
   test('it updates the secret model', async function (assert) {

--- a/ui/tests/integration/components/kv/kv-page-header-test.js
+++ b/ui/tests/integration/components/kv/kv-page-header-test.js
@@ -79,8 +79,8 @@ module('Integration | Component | kv | kv-page-header', function (hooks) {
     await render(
       hbs`<KvPageHeader @breadcrumbs={{this.breadcrumbs}} @mountName="my-engine">
   <:tabLinks>
-    <LinkTo @route="list" data-test-secrets-tab="Secrets">Secrets</LinkTo>
-    <LinkTo @route="configuration" data-test-secrets-tab="Configuration">Configuration</LinkTo>
+    <li><LinkTo @route="list" data-test-secrets-tab="Secrets">Secrets</LinkTo></li>
+    <li><LinkTo @route="configuration" data-test-secrets-tab="Configuration">Configuration</LinkTo></li>
   </:tabLinks>
   </KvPageHeader>
     `,

--- a/ui/tests/integration/components/kv/page/kv-page-list-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-list-test.js
@@ -12,6 +12,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { kvMetadataPath } from 'vault/utils/kv-path';
 import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
 import { PAGE } from 'vault/tests/helpers/kv/kv-selectors';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const CREATE_RECORDS = (number, store, server) => {
   const mirageList = server.createList('kv-metadatum', number, 'withCustomPath');
@@ -43,32 +44,41 @@ module('Integration | Component | kv | Page::List', function (hooks) {
   hooks.beforeEach(async function () {
     this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub());
     this.store = this.owner.lookup('service:store');
+    setRunOptions({
+      rules: {
+        // TODO: ConfirmAction renders modal within list when @isInDropdown
+        list: { enabled: false },
+      },
+    });
   });
 
   test('it renders Pagination and allows you to delete a kv/metadata record', async function (assert) {
-    assert.expect(19);
+    assert.expect(20);
     CREATE_RECORDS(15, this.store, this.server);
     this.model = await this.store.peekAll('kv/metadata');
     this.model.meta = META;
+    this.backend = 'kv-engine';
     this.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.model.backend, route: 'list' },
+      { label: this.backend, route: 'list' },
     ];
     this.failedDirectoryQuery = false;
     await render(
       hbs`<Page::List
-      @secrets={{this.model}} 
-      @backend={{this.model.backend}}
+      @secrets={{this.model}}
+      @backend={{this.backend}}
       @failedDirectoryQuery={{this.failedDirectoryQuery}}
-      @breadcrumbs={{this.breadcrumbs}} 
+      @breadcrumbs={{this.breadcrumbs}}
       @meta={{this.model.meta}}
     />`,
       {
         owner: this.engine,
       }
     );
+
     assert.dom(PAGE.list.pagination).exists('shows hds pagination component');
     assert.dom(PAGE.list.paginationInfo).hasText('1–15 of 16', 'shows correct page of pages');
+    assert.dom(PAGE.title).includesText(this.backend, 'shows backend as title');
 
     this.model.forEach((record) => {
       assert.dom(PAGE.list.item(record.path)).exists('lists all records from 0-14 on the first page');

--- a/ui/tests/integration/components/kv/page/kv-page-secret-details-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-details-test.js
@@ -12,6 +12,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { kvDataPath, kvMetadataPath } from 'vault/utils/kv-path';
 import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
 import { FORM, PAGE, parseJsonEditor } from 'vault/tests/helpers/kv/kv-selectors';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | kv-v2 | Page::Secret::Details', function (hooks) {
   setupRenderingTest(hooks);
@@ -86,6 +87,12 @@ module('Integration | Component | kv-v2 | Page::Secret::Details', function (hook
       secret: this.secretComplex,
       metadata: this.metadata,
     };
+    setRunOptions({
+      rules: {
+        // TODO: Fix JSONEditor component
+        label: { enabled: false },
+      },
+    });
   });
 
   test('it renders secret details and toggles json view', async function (assert) {

--- a/ui/tests/integration/components/kv/page/kv-page-secret-edit-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-edit-test.js
@@ -13,6 +13,7 @@ import { click, fillIn, render } from '@ember/test-helpers';
 import codemirror from 'vault/tests/helpers/codemirror';
 import { FORM, PAGE } from 'vault/tests/helpers/kv/kv-selectors';
 import sinon from 'sinon';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | kv-v2 | Page::Secret::Edit', function (hooks) {
   setupRenderingTest(hooks);
@@ -36,6 +37,13 @@ module('Integration | Component | kv-v2 | Page::Secret::Edit', function (hooks) 
       { label: this.backend, route: 'list' },
       { label: 'edit' },
     ];
+    setRunOptions({
+      rules: {
+        // TODO fix JSONEditor, KVObjectEditor, MaskedInput
+        label: { enabled: false },
+        'color-contrast': { enabled: false }, // JSONEditor only
+      },
+    });
   });
 
   hooks.afterEach(function () {

--- a/ui/tests/integration/components/kv/page/kv-page-secrets-create-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secrets-create-test.js
@@ -13,6 +13,7 @@ import { click, fillIn, findAll, render, typeIn } from '@ember/test-helpers';
 import codemirror from 'vault/tests/helpers/codemirror';
 import { FORM } from 'vault/tests/helpers/kv/kv-selectors';
 import sinon from 'sinon';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | kv-v2 | Page::Secrets::Create', function (hooks) {
   setupRenderingTest(hooks);
@@ -33,6 +34,13 @@ module('Integration | Component | kv-v2 | Page::Secrets::Create', function (hook
       { label: this.backend, route: 'list' },
       { label: 'create' },
     ];
+    setRunOptions({
+      rules: {
+        // TODO fix JSONEditor, KVObjectEditor, MaskedInput
+        label: { enabled: false },
+        'color-contrast': { enabled: false }, // JSONEditor only
+      },
+    });
   });
 
   hooks.afterEach(function () {

--- a/ui/tests/integration/components/ldap/page/configuration-test.js
+++ b/ui/tests/integration/components/ldap/page/configuration-test.js
@@ -11,6 +11,7 @@ import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { duration } from 'core/helpers/format-duration';
 import { createSecretsEngine, generateBreadcrumbs } from 'vault/tests/helpers/ldap';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const selectors = {
   rotateAction: '[data-test-toolbar-rotate-action]',
@@ -53,6 +54,13 @@ module('Integration | Component | ldap | Page::Configuration', function (hooks) 
         }
       );
     };
+    setRunOptions({
+      rules: {
+        // TODO: fix ConfirmAction rendered in toolbar not a list item
+        list: { enabled: false },
+        'scrollable-region-focusable': { enabled: false },
+      },
+    });
   });
 
   test('it should render tab page header, config cta and mount config', async function (assert) {

--- a/ui/tests/integration/components/ldap/page/libraries-test.js
+++ b/ui/tests/integration/components/ldap/page/libraries-test.js
@@ -11,6 +11,7 @@ import { render, click, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
 import { createSecretsEngine, generateBreadcrumbs } from 'vault/tests/helpers/ldap';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | ldap | Page::Libraries', function (hooks) {
   setupRenderingTest(hooks);
@@ -45,6 +46,11 @@ module('Integration | Component | ldap | Page::Libraries', function (hooks) {
         { owner: this.engine }
       );
     };
+    setRunOptions({
+      rules: {
+        list: { enabled: false },
+      },
+    });
   });
 
   test('it should render tab page header and config cta', async function (assert) {

--- a/ui/tests/integration/components/ldap/page/overview-test.js
+++ b/ui/tests/integration/components/ldap/page/overview-test.js
@@ -11,6 +11,7 @@ import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { createSecretsEngine, generateBreadcrumbs } from 'vault/tests/helpers/ldap';
 import sinon from 'sinon';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | ldap | Page::Overview', function (hooks) {
   setupRenderingTest(hooks);
@@ -55,6 +56,13 @@ module('Integration | Component | ldap | Page::Overview', function (hooks) {
         }
       );
     };
+    setRunOptions({
+      rules: {
+        // TODO: Fix SearchSelect component
+        'aria-required-attr': { enabled: false },
+        label: { enabled: false },
+      },
+    });
   });
 
   test('it should render tab page header and config cta', async function (assert) {

--- a/ui/tests/integration/components/ldap/page/role/create-and-edit-test.js
+++ b/ui/tests/integration/components/ldap/page/role/create-and-edit-test.js
@@ -10,6 +10,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render, click, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | ldap | Page::Role::CreateAndEdit', function (hooks) {
   setupRenderingTest(hooks);
@@ -50,6 +51,12 @@ module('Integration | Component | ldap | Page::Role::CreateAndEdit', function (h
         { owner: this.engine }
       );
     };
+    setRunOptions({
+      rules: {
+        // TODO: Fix JsonEditor component
+        label: { enabled: false },
+      },
+    });
   });
 
   test('it should display different form fields based on type', async function (assert) {

--- a/ui/tests/integration/components/license-info-test.js
+++ b/ui/tests/integration/components/license-info-test.js
@@ -11,6 +11,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { create } from 'ember-cli-page-object';
 import license from '../../pages/components/license-info';
 import { allFeatures } from 'vault/helpers/all-features';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const FEATURES = allFeatures();
 
@@ -18,6 +19,15 @@ const component = create(license);
 
 module('Integration | Component | license info', function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    // Fails on #ember-testing-container
+    setRunOptions({
+      rules: {
+        'scrollable-region-focusable': { enabled: false },
+      },
+    });
+  });
 
   test('it renders feature status properly for features associated with license', async function (assert) {
     const now = Date.now();

--- a/ui/tests/integration/components/mfa-login-enforcement-form-test.js
+++ b/ui/tests/integration/components/mfa-login-enforcement-form-test.js
@@ -8,6 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | mfa-login-enforcement-form', function (hooks) {
   setupRenderingTest(hooks);
@@ -27,6 +28,14 @@ module('Integration | Component | mfa-login-enforcement-form', function (hooks) 
         keys: ['123456'],
       },
     }));
+    setRunOptions({
+      rules: {
+        // TODO: Fix SearchSelect component
+        'aria-required-attr': { enabled: false },
+        label: { enabled: false },
+        'color-contrast': { enabled: false },
+      },
+    });
   });
 
   test('it should render correct fields', async function (assert) {

--- a/ui/tests/integration/components/mfa-login-enforcement-form-test.js
+++ b/ui/tests/integration/components/mfa-login-enforcement-form-test.js
@@ -33,7 +33,8 @@ module('Integration | Component | mfa-login-enforcement-form', function (hooks) 
         // TODO: Fix SearchSelect component
         'aria-required-attr': { enabled: false },
         label: { enabled: false },
-        'color-contrast': { enabled: false },
+        // TODO: add labels to enforcement targets key/value style inputs
+        'select-name': { enabled: false },
       },
     });
   });

--- a/ui/tests/integration/components/mfa-login-enforcement-header-test.js
+++ b/ui/tests/integration/components/mfa-login-enforcement-header-test.js
@@ -9,10 +9,24 @@ import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { clickTrigger } from 'ember-power-select/test-support/helpers';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | mfa-login-enforcement-header', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    setRunOptions({
+      rules: {
+        // TODO: fix RadioCard component (replace with HDS)
+        'aria-valid-attr-value': { enabled: false },
+        'nested-interactive': { enabled: false },
+        // TODO: Fix SearchSelect component
+        'aria-required-attr': { enabled: false },
+        label: { enabled: false },
+      },
+    });
+  });
 
   test('it renders heading', async function (assert) {
     await render(hbs`<Mfa::MfaLoginEnforcementHeader @heading="New enforcement" />`);

--- a/ui/tests/integration/components/oidc/assignment-form-test.js
+++ b/ui/tests/integration/components/oidc/assignment-form-test.js
@@ -10,6 +10,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import ENV from 'vault/config/environment';
 import { overrideMirageResponse } from 'vault/tests/helpers/oidc-config';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | oidc/assignment-form', function (hooks) {
   setupRenderingTest(hooks);
@@ -26,6 +27,13 @@ module('Integration | Component | oidc/assignment-form', function (hooks) {
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');
     this.server.post('/sys/capabilities-self', () => {});
+    setRunOptions({
+      rules: {
+        // TODO: Fix SearchSelect component
+        'aria-required-attr': { enabled: false },
+        label: { enabled: false },
+      },
+    });
   });
 
   test('it should save new assignment', async function (assert) {

--- a/ui/tests/integration/components/oidc/client-form-test.js
+++ b/ui/tests/integration/components/oidc/client-form-test.js
@@ -18,6 +18,7 @@ import {
   overrideMirageResponse,
   overrideCapabilities,
 } from 'vault/tests/helpers/oidc-config';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const searchSelect = create(ss);
 
@@ -60,6 +61,17 @@ module('Integration | Component | oidc/client-form', function (hooks) {
           group_ids: ['abcdef-123'],
         },
       };
+    });
+    setRunOptions({
+      rules: {
+        // TODO: fix RadioCard component (replace with HDS)
+        'aria-valid-attr-value': { enabled: false },
+        'nested-interactive': { enabled: false },
+        // TODO: Fix SearchSelect component
+        'aria-required-attr': { enabled: false },
+        label: { enabled: false },
+        'color-contrast': { enabled: false },
+      },
     });
   });
 

--- a/ui/tests/integration/components/oidc/key-form-test.js
+++ b/ui/tests/integration/components/oidc/key-form-test.js
@@ -16,6 +16,7 @@ import {
   overrideMirageResponse,
   overrideCapabilities,
 } from 'vault/tests/helpers/oidc-config';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | oidc/key-form', function (hooks) {
   setupRenderingTest(hooks);
@@ -32,6 +33,16 @@ module('Integration | Component | oidc/key-form', function (hooks) {
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');
     this.server.get('/identity/oidc/client', () => overrideMirageResponse(null, CLIENT_LIST_RESPONSE));
+    setRunOptions({
+      rules: {
+        // TODO: fix RadioCard component (replace with HDS)
+        'aria-valid-attr-value': { enabled: false },
+        'nested-interactive': { enabled: false },
+        // TODO: Fix SearchSelect component
+        'aria-required-attr': { enabled: false },
+        label: { enabled: false },
+      },
+    });
   });
 
   test('it should save new key', async function (assert) {

--- a/ui/tests/integration/components/oidc/provider-form-test.js
+++ b/ui/tests/integration/components/oidc/provider-form-test.js
@@ -17,6 +17,7 @@ import {
   overrideCapabilities,
 } from 'vault/tests/helpers/oidc-config';
 import parseURL from 'core/utils/parse-url';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const ISSUER_URL = 'http://127.0.0.1:8200/v1/identity/oidc/provider/test-provider';
 
@@ -49,6 +50,16 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
       };
     });
     this.server.get('/identity/oidc/client', () => overrideMirageResponse(null, CLIENT_LIST_RESPONSE));
+    setRunOptions({
+      rules: {
+        // TODO: Fix SearchSelect component
+        'aria-required-attr': { enabled: false },
+        label: { enabled: false },
+        // TODO: fix RadioCard component (replace with HDS)
+        'aria-valid-attr-value': { enabled: false },
+        'nested-interactive': { enabled: false },
+      },
+    });
   });
 
   test('it should save new provider', async function (assert) {

--- a/ui/tests/integration/components/oidc/scope-form-test.js
+++ b/ui/tests/integration/components/oidc/scope-form-test.js
@@ -9,6 +9,7 @@ import { render, fillIn, click, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { SELECTORS, OIDC_BASE_URL, overrideCapabilities } from 'vault/tests/helpers/oidc-config';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | oidc/scope-form', function (hooks) {
   setupRenderingTest(hooks);
@@ -16,6 +17,12 @@ module('Integration | Component | oidc/scope-form', function (hooks) {
 
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');
+    setRunOptions({
+      rules: {
+        // TODO: fix JSONEditor/CodeMirror
+        label: { enabled: false },
+      },
+    });
   });
 
   test('it should save new scope', async function (assert) {

--- a/ui/tests/integration/components/path-filter-config-list-test.js
+++ b/ui/tests/integration/components/path-filter-config-list-test.js
@@ -14,6 +14,7 @@ import sinon from 'sinon';
 import { Promise } from 'rsvp';
 import { create } from 'ember-cli-page-object';
 import ss from 'vault/tests/pages/components/search-select';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const searchSelect = create(ss);
 
@@ -62,6 +63,15 @@ module('Integration | Component | path filter config list', function (hooks) {
     });
     this.engine.register('service:namespace', namespaceServiceStub);
     this.engine.register('service:store', storeServiceStub);
+    setRunOptions({
+      rules: {
+        // TODO: Fix SearchSelect component
+        'aria-required-attr': { enabled: false },
+        label: { enabled: false },
+        // TODO: Fix groupname rendering on SearchSelect component
+        'aria-required-parent': { enabled: false },
+      },
+    });
   });
 
   test('it renders', async function (assert) {

--- a/ui/tests/integration/components/pki/page/pki-configuration-details-test.js
+++ b/ui/tests/integration/components/pki/page/pki-configuration-details-test.js
@@ -8,6 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupEngine } from 'ember-engines/test-support';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const SELECTORS = {
   rowLabel: (attr) => `[data-test-row-label="${attr}"]`,
@@ -45,6 +46,12 @@ module('Integration | Component | Page::PkiConfigurationDetails', function (hook
       crossClusterRevocation: true,
       unifiedCrl: true,
       unifiedCrlOnExistingPaths: true,
+    });
+    // Fails on #ember-testing-container
+    setRunOptions({
+      rules: {
+        'scrollable-region-focusable': { enabled: false },
+      },
     });
   });
 

--- a/ui/tests/integration/components/pki/page/pki-issuer-generate-root-test.js
+++ b/ui/tests/integration/components/pki/page/pki-issuer-generate-root-test.js
@@ -14,6 +14,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { setupRenderingTest } from 'vault/tests/helpers';
 import { SELECTORS } from 'vault/tests/helpers/pki/pki-configure-create';
 import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 /**
  * this test is for the page component only. A separate test is written for the form rendered
@@ -32,6 +33,15 @@ module('Integration | Component | page/pki-issuer-generate-root', function (hook
     this.secretMountPath = this.owner.lookup('service:secret-mount-path');
     this.secretMountPath.currentPath = 'pki-component';
     this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub());
+    setRunOptions({
+      rules: {
+        // something strange happening here
+        'link-name': { enabled: false },
+        // TODO: fix RadioCard component (replace with HDS)
+        'aria-valid-attr-value': { enabled: false },
+        'nested-interactive': { enabled: false },
+      },
+    });
   });
 
   test('it renders correct title before and after submit', async function (assert) {

--- a/ui/tests/integration/components/pki/page/pki-issuer-rotate-root-test.js
+++ b/ui/tests/integration/components/pki/page/pki-issuer-rotate-root-test.js
@@ -13,6 +13,7 @@ import { loadedCert } from 'vault/tests/helpers/pki/values';
 import camelizeKeys from 'vault/utils/camelize-object-keys';
 import { parseCertificate } from 'vault/utils/parse-pki-cert';
 import { SELECTORS as S } from 'vault/tests/helpers/pki/pki-generate-root';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const SELECTORS = {
   pageTitle: '[data-test-pki-page-title]',
@@ -72,6 +73,13 @@ module('Integration | Component | page/pki-issuer-rotate-root', function (hooks)
       key_name: 'my-key',
       serial_number: '3a:3c:17:..',
     };
+    setRunOptions({
+      rules: {
+        // TODO: fix RadioCard component (replace with HDS)
+        'aria-valid-attr-value': { enabled: false },
+        'nested-interactive': { enabled: false },
+      },
+    });
   });
 
   test('it renders', async function (assert) {

--- a/ui/tests/integration/components/pki/pki-generate-csr-test.js
+++ b/ui/tests/integration/components/pki/pki-generate-csr-test.js
@@ -9,6 +9,7 @@ import { click, fillIn, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupEngine } from 'ember-engines/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | pki-generate-csr', function (hooks) {
   setupRenderingTest(hooks);
@@ -29,6 +30,12 @@ module('Integration | Component | pki-generate-csr', function (hooks) {
         'pki-test/issuers/generate/intermediate/exported': ['root'],
       },
     }));
+    setRunOptions({
+      rules: {
+        // something strange happening here
+        'link-name': { enabled: false },
+      },
+    });
   });
 
   test('it should render fields and save', async function (assert) {

--- a/ui/tests/integration/components/pki/pki-key-parameters-test.js
+++ b/ui/tests/integration/components/pki/pki-key-parameters-test.js
@@ -9,6 +9,7 @@ import { render, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupEngine } from 'ember-engines/test-support';
 import { SELECTORS } from 'vault/tests/helpers/pki/pki-role-form';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | pki key parameters', function (hooks) {
   setupRenderingTest(hooks);
@@ -18,6 +19,12 @@ module('Integration | Component | pki key parameters', function (hooks) {
     this.store = this.owner.lookup('service:store');
     this.model = this.store.createRecord('pki/role', { backend: 'pki' });
     [this.fields] = Object.values(this.model.formFieldGroups.find((g) => g['Key parameters']));
+    // TODO: remove Tooltip/ember-basic-dropdown
+    setRunOptions({
+      rules: {
+        'nested-interactive': { enabled: false },
+      },
+    });
   });
 
   test('it should render the component and display the correct defaults', async function (assert) {

--- a/ui/tests/integration/components/pki/pki-role-form-test.js
+++ b/ui/tests/integration/components/pki/pki-role-form-test.js
@@ -11,6 +11,7 @@ import { setupEngine } from 'ember-engines/test-support';
 import { SELECTORS } from 'vault/tests/helpers/pki/pki-role-form';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import sinon from 'sinon';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | pki-role-form', function (hooks) {
   setupRenderingTest(hooks);
@@ -25,6 +26,13 @@ module('Integration | Component | pki-role-form', function (hooks) {
     this.issuers = this.store.peekAll('pki/issuer');
     this.role.backend = 'pki';
     this.onCancel = sinon.spy();
+    setRunOptions({
+      rules: {
+        // TODO: fix RadioCard component (replace with HDS)
+        'aria-valid-attr-value': { enabled: false },
+        'nested-interactive': { enabled: false },
+      },
+    });
   });
 
   test('it should render default fields and toggle groups', async function (assert) {

--- a/ui/tests/integration/components/policy-example-test.js
+++ b/ui/tests/integration/components/policy-example-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'vault/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const SELECTORS = {
   policyText: '[data-test-modal-title]',
@@ -17,6 +18,17 @@ const SELECTORS = {
 
 module('Integration | Component | policy-example', function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    setRunOptions({
+      rules: {
+        // TODO: Fix JSONEditor/CodeMirror
+        label: { enabled: false },
+        // failing on .CodeMirror-scroll
+        'scrollable-region-focusable': { enabled: false },
+      },
+    });
+  });
 
   test('it renders the correct paragraph for ACL policy', async function (assert) {
     await render(hbs`

--- a/ui/tests/integration/components/policy-form-test.js
+++ b/ui/tests/integration/components/policy-form-test.js
@@ -9,6 +9,7 @@ import { click, fillIn, render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import Pretender from 'pretender';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const SELECTORS = {
   nameInput: '[data-test-policy-input="name"]',
@@ -53,6 +54,13 @@ module('Integration | Component | policy-form', function (hooks) {
       this.put('/v1/sys/policies/egp/**', () => {
         return [204, { 'Content-Type': 'application/json' }];
       });
+    });
+    setRunOptions({
+      rules: {
+        // TODO: fix JSONEditor/CodeMirror
+        label: { enabled: false },
+        'label-title-only': { enabled: false },
+      },
     });
   });
   hooks.afterEach(function () {

--- a/ui/tests/integration/components/radio-button-test.js
+++ b/ui/tests/integration/components/radio-button-test.js
@@ -14,6 +14,7 @@ module('Integration | Component | radio-button', function (hooks) {
   test('it should spread attributes on input element', async function (assert) {
     await render(
       hbs(`
+      <label for="foo">No A11y violations</label>
       <RadioButton
         id="foo"
         name="bar"
@@ -30,7 +31,9 @@ module('Integration | Component | radio-button', function (hooks) {
   test('it should be checked when value and groupValue are equal', async function (assert) {
     await render(
       hbs(`
+      <label for="foo">Must pass ID on RadioButton</label>
       <RadioButton
+        id="foo"
         @value="foo"
         @groupValue="foo"
         @onChange={{fn (mut this.groupValue)}}
@@ -51,13 +54,15 @@ module('Integration | Component | radio-button', function (hooks) {
         @groupValue={{this.groupValue}}
         @onChange={{fn (mut this.groupValue)}}
         data-test-radio-1
-      />
+        id="opt1"
+      /><label for="opt1">Option 1</label>
       <RadioButton
         @value="bar"
         @groupValue={{this.groupValue}}
         @onChange={{fn (mut this.groupValue)}}
         data-test-radio-2
-      />
+        id="opt2"
+      /><label for="opt2">Option 2</label>
     `)
     );
     const radio1 = this.element.querySelector('[data-test-radio-1]');

--- a/ui/tests/integration/components/replication-secondary-card-test.js
+++ b/ui/tests/integration/components/replication-secondary-card-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const TITLE = 'Status';
 
@@ -28,6 +29,13 @@ module('Integration | Component | replication-secondary-card', function (hooks) 
   hooks.beforeEach(function () {
     this.set('replicationDetails', REPLICATION_DETAILS);
     this.set('title', TITLE);
+    // TODO: remove Tooltip/ember-basic-dropdown
+    setRunOptions({
+      rules: {
+        'aria-command-name': { enabled: false },
+        'nested-interactive': { enabled: false },
+      },
+    });
   });
 
   test('it renders', async function (assert) {

--- a/ui/tests/integration/components/search-select-test.js
+++ b/ui/tests/integration/components/search-select-test.js
@@ -15,6 +15,7 @@ import sinon from 'sinon';
 import waitForError from 'vault/tests/helpers/wait-for-error';
 import searchSelect from '../../pages/components/search-select';
 import { isWildcardString } from 'vault/helpers/is-wildcard-string';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const component = create(searchSelect);
 
@@ -89,6 +90,16 @@ module('Integration | Component | search select', function (hooks) {
     run(() => {
       this.owner.unregister('service:store');
       this.owner.register('service:store', storeService);
+    });
+    setRunOptions({
+      rules: {
+        // TODO: Fix this component
+        'color-contrast': { enabled: false },
+        label: { enabled: false },
+        'aria-input-field-name': { enabled: false },
+        'aria-required-attr': { enabled: false },
+        'aria-valid-attr-value': { enabled: false },
+      },
     });
   });
 

--- a/ui/tests/integration/components/search-select-with-modal-test.js
+++ b/ui/tests/integration/components/search-select-with-modal-test.js
@@ -13,6 +13,7 @@ import { render, fillIn, click, findAll } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import ss from 'vault/tests/pages/components/search-select';
 import sinon from 'sinon';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const component = create(ss);
 
@@ -57,6 +58,16 @@ module('Integration | Component | search select with modal', function (hooks) {
             '\n# Import strings library that exposes common string operations\nimport "strings"\n\n# Conditional rule (precond) checks the incoming request endpoint\n# targeted to sys/policies/acl/admin\nprecond = rule {\n    strings.has_prefix(request.path, "sys/policies/admin")\n}\n\n# Vault checks to see if the request was made by an entity\n# named James Thomas or Team Lead role defined as its metadata\nmain = rule when precond {\n    identity.entity.metadata.role is "Team Lead" or\n      identity.entity.name is "James Thomas"\n}\n',
         },
       };
+    });
+    setRunOptions({
+      rules: {
+        // TODO: Fix this component
+        'color-contrast': { enabled: false },
+        label: { enabled: false },
+        'aria-input-field-name': { enabled: false },
+        'aria-required-attr': { enabled: false },
+        'aria-valid-attr-value': { enabled: false },
+      },
     });
   });
 

--- a/ui/tests/integration/components/secret-edit-test.js
+++ b/ui/tests/integration/components/secret-edit-test.js
@@ -10,6 +10,7 @@ import { resolve } from 'rsvp';
 import { run } from '@ember/runloop';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 let capabilities;
 const storeService = Service.extend({
@@ -23,9 +24,16 @@ module('Integration | Component | secret edit', function (hooks) {
   hooks.beforeEach(function () {
     capabilities = null;
     this.codeMirror = this.owner.lookup('service:code-mirror');
+    this.set('key', { id: 'Foobar' });
     run(() => {
       this.owner.unregister('service:store');
       this.owner.register('service:store', storeService);
+    });
+    setRunOptions({
+      rules: {
+        // TODO: Fix JSONEditor/CodeMirror
+        label: { enabled: false },
+      },
     });
   });
 
@@ -39,7 +47,7 @@ module('Integration | Component | secret edit', function (hooks) {
       },
     });
 
-    await render(hbs`{{secret-edit mode=this.mode model=this.model }}`);
+    await render(hbs`{{secret-edit mode=this.mode model=this.model key=this.key }}`);
     assert.dom('[data-test-toggle-input="json"]').isDisabled();
   });
 
@@ -53,7 +61,7 @@ module('Integration | Component | secret edit', function (hooks) {
       },
     });
 
-    await render(hbs`{{secret-edit mode=this.mode model=this.model }}`);
+    await render(hbs`{{secret-edit mode=this.mode model=this.model key=this.key }}`);
     assert.dom('[data-test-toggle-input="json"]').isNotDisabled();
   });
 
@@ -63,7 +71,7 @@ module('Integration | Component | secret edit', function (hooks) {
       secretData: null,
     });
 
-    await render(hbs`{{secret-edit mode=this.mode model=this.model preferAdvancedEdit=true }}`);
+    await render(hbs`{{secret-edit mode=this.mode model=this.model preferAdvancedEdit=true key=this.key }}`);
 
     const instance = document.querySelector('.CodeMirror').CodeMirror;
     instance.setValue(JSON.stringify([{ foo: 'bar' }]));
@@ -83,7 +91,7 @@ module('Integration | Component | secret edit', function (hooks) {
         float: '1.234',
       },
     });
-    await render(hbs`<SecretEdit @mode={{this.mode}} @model={{this.model}} />`);
+    await render(hbs`<SecretEdit @mode={{this.mode}} @model={{this.model}} key=this.key />`);
     assert.dom('[data-test-secret-save]').isNotDisabled();
   });
 
@@ -101,7 +109,7 @@ module('Integration | Component | secret edit', function (hooks) {
       canReadSecretData: true,
     });
 
-    await render(hbs`{{secret-edit mode=this.mode model=this.model preferAdvancedEdit=true }}`);
+    await render(hbs`{{secret-edit mode=this.mode model=this.model preferAdvancedEdit=true key=this.key }}`);
 
     const instance = document.querySelector('.CodeMirror').CodeMirror;
     instance.setValue(JSON.stringify([{ foo: 'bar' }]));

--- a/ui/tests/integration/components/select-test.js
+++ b/ui/tests/integration/components/select-test.js
@@ -78,7 +78,9 @@ module('Integration | Component | Select', function (hooks) {
 
   test('it calls onChange when an item is selected', async function (assert) {
     this.set('onChange', sinon.spy());
-    await render(hbs`<Select @options={{this.options}} @name={{this.name}} @onChange={{this.onChange}}/>`);
+    await render(
+      hbs`<Select @label={{this.label}} @options={{this.options}} @name={{this.name}} @onChange={{this.onChange}}/>`
+    );
     await fillIn('[data-test-select="foo"]', 'bar');
 
     assert.ok(this.onChange.calledOnce);

--- a/ui/tests/integration/components/sidebar/frame-test.js
+++ b/ui/tests/integration/components/sidebar/frame-test.js
@@ -13,6 +13,17 @@ import { setRunOptions } from 'ember-a11y-testing/test-support';
 module('Integration | Component | sidebar-frame', function (hooks) {
   setupRenderingTest(hooks);
 
+  hooks.beforeEach(function () {
+    setRunOptions({
+      rules: {
+        // This is an issue with Hds::SideNav::Header::HomeLink
+        'aria-prohibited-attr': { enabled: false },
+        // TODO: fix use Dropdown on user-menu
+        'nested-interactive': { enabled: false },
+      },
+    });
+  });
+
   test('it should hide and show sidebar', async function (assert) {
     this.set('showSidebar', true);
     await render(hbs`

--- a/ui/tests/integration/components/sidebar/frame-test.js
+++ b/ui/tests/integration/components/sidebar/frame-test.js
@@ -8,6 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | sidebar-frame', function (hooks) {
   setupRenderingTest(hooks);
@@ -43,6 +44,13 @@ module('Integration | Component | sidebar-frame', function (hooks) {
   });
 
   test('it should render logo and actions in sidebar header', async function (assert) {
+    setRunOptions({
+      rules: {
+        'aria-prohibited-attr': { enabled: false },
+        'nested-interactive': { enabled: false },
+        label: { enabled: false },
+      },
+    });
     this.owner.lookup('service:currentCluster').setCluster({ name: 'vault' });
 
     await render(hbs`
@@ -53,6 +61,7 @@ module('Integration | Component | sidebar-frame', function (hooks) {
     assert.dom('[data-test-console-toggle]').exists('Console toggle button renders in sidebar header');
     await click('[data-test-console-toggle]');
     assert.dom('.panel-open').exists('Console ui panel opens');
+
     await click('[data-test-console-toggle]');
     assert.dom('.panel-open').doesNotExist('Console ui panel closes');
     assert.dom('[data-test-user-menu]').exists('User menu renders');

--- a/ui/tests/integration/components/sidebar/nav/access-test.js
+++ b/ui/tests/integration/components/sidebar/nav/access-test.js
@@ -8,6 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { stubFeaturesAndPermissions } from 'vault/tests/helpers/components/sidebar-nav';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const renderComponent = () => {
   return render(hbs`
@@ -19,6 +20,17 @@ const renderComponent = () => {
 
 module('Integration | Component | sidebar-nav-access', function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    setRunOptions({
+      rules: {
+        // This is an issue with Hds::SideNav::Header::HomeLink
+        'aria-prohibited-attr': { enabled: false },
+        // TODO: fix use Dropdown on user-menu
+        'nested-interactive': { enabled: false },
+      },
+    });
+  });
 
   test('it should render nav headings', async function (assert) {
     const headings = ['Authentication', 'Access Control', 'Organization', 'Administration'];

--- a/ui/tests/integration/components/sidebar/nav/cluster-test.js
+++ b/ui/tests/integration/components/sidebar/nav/cluster-test.js
@@ -8,6 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { stubFeaturesAndPermissions } from 'vault/tests/helpers/components/sidebar-nav';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const renderComponent = () => {
   return render(hbs`
@@ -19,6 +20,17 @@ const renderComponent = () => {
 
 module('Integration | Component | sidebar-nav-cluster', function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    setRunOptions({
+      rules: {
+        // This is an issue with Hds::SideNav::Header::HomeLink
+        'aria-prohibited-attr': { enabled: false },
+        // TODO: fix use Dropdown on user-menu
+        'nested-interactive': { enabled: false },
+      },
+    });
+  });
 
   test('it should render nav headings', async function (assert) {
     const headings = ['Vault', 'Monitoring'];

--- a/ui/tests/integration/components/sidebar/nav/policies-test.js
+++ b/ui/tests/integration/components/sidebar/nav/policies-test.js
@@ -8,6 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { stubFeaturesAndPermissions } from 'vault/tests/helpers/components/sidebar-nav';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const renderComponent = () => {
   return render(hbs`
@@ -19,6 +20,17 @@ const renderComponent = () => {
 
 module('Integration | Component | sidebar-nav-policies', function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    setRunOptions({
+      rules: {
+        // This is an issue with Hds::SideNav::Header::HomeLink
+        'aria-prohibited-attr': { enabled: false },
+        // TODO: fix use Dropdown on user-menu
+        'nested-interactive': { enabled: false },
+      },
+    });
+  });
 
   test('it should hide links user does not have access too', async function (assert) {
     await renderComponent();

--- a/ui/tests/integration/components/sidebar/nav/tools-test.js
+++ b/ui/tests/integration/components/sidebar/nav/tools-test.js
@@ -10,6 +10,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { stubFeaturesAndPermissions } from 'vault/tests/helpers/components/sidebar-nav';
 import { toolsActions } from 'vault/helpers/tools-actions';
 import { capitalize } from '@ember/string';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const renderComponent = () => {
   return render(hbs`
@@ -21,6 +22,17 @@ const renderComponent = () => {
 
 module('Integration | Component | sidebar-nav-tools', function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    setRunOptions({
+      rules: {
+        // This is an issue with Hds::SideNav::Header::HomeLink
+        'aria-prohibited-attr': { enabled: false },
+        // TODO: fix use Dropdown on user-menu
+        'nested-interactive': { enabled: false },
+      },
+    });
+  });
 
   test('it should hide links user does not have access too', async function (assert) {
     await renderComponent();

--- a/ui/tests/integration/components/sidebar/user-menu-test.js
+++ b/ui/tests/integration/components/sidebar/user-menu-test.js
@@ -8,12 +8,21 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | sidebar-user-menu', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
     this.auth = this.owner.lookup('service:auth');
+    setRunOptions({
+      // TODO: fix this component
+      rules: {
+        'nested-interactive': { enabled: false },
+        // TODO: fix ConfirmAction rendered in toolbar not a list item
+        list: { enabled: false },
+      },
+    });
   });
 
   test('it should render trigger and open menu', async function (assert) {

--- a/ui/tests/integration/components/text-file-test.js
+++ b/ui/tests/integration/components/text-file-test.js
@@ -9,6 +9,7 @@ import { click, fillIn, render, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import { componentPemBundle } from 'vault/tests/helpers/pki/values';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const SELECTORS = {
   label: '[data-test-text-file-label]',
@@ -34,6 +35,14 @@ module('Integration | Component | text-file', function (hooks) {
   });
 
   test('it renders without toggle and option for text input when uploadOnly=true', async function (assert) {
+    setRunOptions({
+      rules: {
+        // TODO: fix textFile / replace with HDS
+        label: { enabled: false },
+        'label-title-only': { enabled: false },
+      },
+    });
+
     await render(hbs`<TextFile @onChange={{this.onChange}} @uploadOnly={{true}} />`);
 
     assert.dom(SELECTORS.label).doesNotExist('Label no longer rendered');

--- a/ui/tests/integration/components/transform-advanced-templating-test.js
+++ b/ui/tests/integration/components/transform-advanced-templating-test.js
@@ -7,11 +7,18 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn, render, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | transform-advanced-templating', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should render', async function (assert) {
+    setRunOptions({
+      rules: {
+        // TODO: fix JSONEditor/CodeMirror
+        label: { enabled: false },
+      },
+    });
     this.model = {
       pattern: '(\\d{3})-(\\d{2})-(?<last>\\d{5})',
       encodeFormat: null,

--- a/ui/tests/integration/components/transit-key-actions-test.js
+++ b/ui/tests/integration/components/transit-key-actions-test.js
@@ -13,6 +13,7 @@ import { render, click, find, findAll, fillIn, blur, triggerEvent } from '@ember
 import hbs from 'htmlbars-inline-precompile';
 import { encodeString } from 'vault/utils/b64';
 import waitForError from 'vault/tests/helpers/wait-for-error';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 const storeStub = Service.extend({
   callArgs: null,
@@ -46,25 +47,29 @@ module('Integration | Component | transit key actions', function (hooks) {
       this.owner.register('service:store', storeStub);
       this.storeService = this.owner.lookup('service:store');
     });
+    setRunOptions({
+      rules: {
+        // TODO: fix JSONEditor/CodeMirror
+        label: { enabled: false },
+      },
+    });
   });
 
   test('it requires `key`', async function (assert) {
     const promise = waitForError();
     render(hbs`
-      {{transit-key-actions}}`);
+      <TransitKeyActions />`);
     const err = await promise;
     assert.ok(err.message.includes('`key` is required for'), 'asserts without key');
   });
 
   test('it renders', async function (assert) {
     this.set('key', { backend: 'transit', supportedActions: ['encrypt'] });
-    await render(hbs`
-      {{transit-key-actions selectedAction="encrypt" key=this.key}}`);
+    await render(hbs`<TransitKeyActions @selectedAction="encrypt" @key={{this.key}} />`);
     assert.dom('[data-test-transit-action="encrypt"]').exists({ count: 1 }, 'renders encrypt');
 
     this.set('key', { backend: 'transit', supportedActions: ['sign'] });
-    await render(hbs`
-      {{transit-key-actions selectedAction="sign" key=this.key}}`);
+    await render(hbs`<TransitKeyActions @selectedAction="sign" @key={{this.key}} />`);
     assert.dom('[data-test-transit-action="sign"]').exists({ count: 1 }, 'renders sign');
   });
 
@@ -72,7 +77,7 @@ module('Integration | Component | transit key actions', function (hooks) {
     this.set('key', { backend: 'transit', supportsSigning: true, supportedActions: ['sign', 'verify'] });
     this.set('selectedAction', 'sign');
     await render(hbs`
-      {{transit-key-actions selectedAction=this.selectedAction key=this.key}}`);
+    <TransitKeyActions @selectedAction={{this.selectedAction}} @key={{this.key}} />`);
     assert
       .dom('[data-test-signature-algorithm]')
       .doesNotExist('does not render signature_algorithm field on sign');
@@ -100,7 +105,7 @@ module('Integration | Component | transit key actions', function (hooks) {
   test('it renders: rotate', async function (assert) {
     this.set('key', { backend: 'transit', id: 'akey', supportedActions: ['rotate'] });
     await render(hbs`
-      {{transit-key-actions selectedAction="rotate" key=this.key}}`);
+    <TransitKeyActions @selectedAction="rotate" @key={{this.key}} />`);
 
     assert.dom('*').hasText('', 'renders an empty div');
 
@@ -118,7 +123,7 @@ module('Integration | Component | transit key actions', function (hooks) {
     this.set('selectedAction', 'encrypt');
     this.set('storeService.keyActionReturnVal', { ciphertext: 'secret' });
     await render(hbs`
-      {{transit-key-actions selectedAction=this.selectedAction key=this.key}}`);
+    <TransitKeyActions @selectedAction={{this.selectedAction}} @key={{this.key}} />`);
 
     find('#plaintext-control .CodeMirror').CodeMirror.setValue('plaintext');
     await click('button[type="submit"]');
@@ -168,7 +173,7 @@ module('Integration | Component | transit key actions', function (hooks) {
     this.set('key', key);
     this.set('storeService.keyActionReturnVal', { ciphertext: 'secret' });
     await render(hbs`
-      {{transit-key-actions selectedAction="encrypt" key=this.key}}`);
+    <TransitKeyActions @selectedAction="encrypt" @key={{this.key}} />`);
 
     findAll('.CodeMirror')[0].CodeMirror.setValue('plaintext');
     assert.dom('#key_version').exists({ count: 1 }, 'it renders the key version selector');
@@ -197,7 +202,7 @@ module('Integration | Component | transit key actions', function (hooks) {
     this.set('key', key);
     this.set('storeService.keyActionReturnVal', { ciphertext: 'secret' });
     await render(hbs`
-      {{transit-key-actions selectedAction="encrypt" key=this.key}}`);
+    <TransitKeyActions @selectedAction="encrypt" @key={{this.key}} />`);
 
     // await fillIn('#plaintext', 'plaintext');
     find('#plaintext-control .CodeMirror').CodeMirror.setValue('plaintext');
@@ -227,7 +232,7 @@ module('Integration | Component | transit key actions', function (hooks) {
       validKeyVersions: [1],
     });
     await render(hbs`
-      {{transit-key-actions key=this.key}}`);
+    <TransitKeyActions @key={{this.key}} />`);
   };
 
   test('it can export a key:default behavior', async function (assert) {
@@ -298,6 +303,8 @@ module('Integration | Component | transit key actions', function (hooks) {
   });
 
   test('it includes algorithm param for HMAC', async function (assert) {
+    // Return mocked data so a11y-testing doesn't get mad about empty copy button contents
+    this.set('storeService.rootKeyActionReturnVal', { data: { hmac: 'vault:v1:hmac-token' } });
     this.set('key', {
       backend: 'transit',
       id: 'akey',
@@ -305,7 +312,7 @@ module('Integration | Component | transit key actions', function (hooks) {
       validKeyVersions: [1],
     });
     await render(hbs`
-      {{transit-key-actions key=this.key}}`);
+    <TransitKeyActions @key={{this.key}} />`);
     await fillIn('#algorithm', 'sha2-384');
     await blur('#algorithm');
     await fillIn('[data-test-component="code-mirror-modifier"] textarea', 'plaintext');

--- a/ui/tests/integration/components/ttl-picker-test.js
+++ b/ui/tests/integration/components/ttl-picker-test.js
@@ -9,6 +9,7 @@ import { render, click, fillIn } from '@ember/test-helpers';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 import selectors from 'vault/tests/helpers/components/ttl-picker';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | ttl-picker', function (hooks) {
   setupRenderingTest(hooks);
@@ -186,6 +187,12 @@ module('Integration | Component | ttl-picker', function (hooks) {
     });
 
     test('it shows subtext and description when passed', async function (assert) {
+      setRunOptions({
+        rules: {
+          // TODO: remove Tooltip
+          'aria-command-name': { enabled: false },
+        },
+      });
       this.set('label', 'My Label');
       await render(hbs`
         <TtlPicker


### PR DESCRIPTION
Skip component tests with a11y violations that cannot be easily addressed at this time. 