### PR TITLE
UI: a11y sidebranch - labels

### DIFF
--- a/ui/app/components/policy-form.hbs
+++ b/ui/app/components/policy-form.hbs
@@ -23,11 +23,11 @@
       </div>
     {{/if}}
     <div class="field">
-      <Toolbar>
+      <Toolbar aria-label="toolbar for managing {{or @model.name 'new'}} policy">
         <label class="has-text-weight-bold has-right-margin-xxs">Policy</label>
         {{#if @renderPolicyExampleModal}}
           {{! only true in policy create and edit routes }}
-          <ToolbarFilters>
+          <ToolbarFilters aria-label="help tools for managing {{or @model.name 'new'}} policy">
             <Hds::Button
               @text="How to write a policy"
               @icon="bulb"
@@ -38,7 +38,7 @@
             />
           </ToolbarFilters>
         {{/if}}
-        <ToolbarActions>
+        <ToolbarActions aria-label="actions for managing {{or @model.name 'new'}} policy">
           <div class="toolbar-separator"></div>
           {{#if @model.isNew}}
             <div class="control is-flex">

--- a/ui/app/components/sidebar/frame.hbs
+++ b/ui/app/components/sidebar/frame.hbs
@@ -13,7 +13,7 @@
               @icon="vault"
               @route="vault.cluster.dashboard"
               @model={{this.currentCluster.cluster.name}}
-              @ariaLabel="home link"
+              @ariaLabel="Vault home"
               data-test-sidebar-logo
             />
           </:logo>

--- a/ui/app/components/sidebar/frame.hbs
+++ b/ui/app/components/sidebar/frame.hbs
@@ -31,7 +31,7 @@
 
       {{! this block is where the Hds::SideNav::Portal components render into }}
       <:body>
-        <Hds::SideNav::Portal::Target aria-label="sidebar navigation links" />
+        <Hds::SideNav::Portal::Target />
       </:body>
 
       <:footer>

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -140,6 +140,7 @@
                   autocomplete="off"
                   spellcheck="false"
                   data-test-token={{true}}
+                  id="token"
                 />
               </div>
             </div>

--- a/ui/app/templates/components/auth-jwt.hbs
+++ b/ui/app/templates/components/auth-jwt.hbs
@@ -28,16 +28,17 @@
   </div>
   {{#unless this.isOIDC}}
     <div class="field">
-      <label for="token" class="is-label">JWT Token</label>
+      <label for="jwt-token" class="is-label">JWT Token</label>
       <div class="control">
         <Input
           @type="password"
           @value={{this.jwt}}
+          id="jwt-token"
           name="jwt"
           class="input"
           autocomplete="off"
           spellcheck="false"
-          data-test-jwt={{true}}
+          data-test-jwt
         />
       </div>
     </div>

--- a/ui/app/templates/components/configure-aws-secret.hbs
+++ b/ui/app/templates/components/configure-aws-secret.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
-  <nav class="tabs">
+  <nav class="tabs" aria-label="navigation to configure AWS backend">
     <ul>
       <LinkTo
         @route="vault.cluster.settings.configure-secret-backend"

--- a/ui/app/templates/components/console/command-input.hbs
+++ b/ui/app/templates/components/console/command-input.hbs
@@ -19,6 +19,7 @@
   <Hds::Button
     class="hds-side-nav__icon-button"
     {{on "click" (action "fullscreen")}}
+    title={{if this.isFullscreen "minimize" "maximize"}}
     data-test-tool-tip-trigger
     @icon={{if this.isFullscreen "minimize" "maximize"}}
     @text={{if this.isFullscreen "Minimize" "Maximize"}}

--- a/ui/app/templates/components/console/command-input.hbs
+++ b/ui/app/templates/components/console/command-input.hbs
@@ -9,27 +9,20 @@
   {{else}}
     <Chevron />
   {{/if}}
-  <input onkeyup={{action "handleKeyUp"}} value={{this.value}} autocomplete="off" spellcheck="false" />
-  <ToolTip @horizontalPosition="auto-right" @verticalPosition="above" as |d|>
-    <d.Trigger>
-      <Hds::Button
-        class="hds-side-nav__icon-button"
-        {{on "click" (action "fullscreen")}}
-        data-test-tool-tip-trigger
-        @icon={{if this.isFullscreen "minimize" "maximize"}}
-        @text={{if this.isFullscreen "Minimize" "Maximize"}}
-        @isIconOnly={{true}}
-      />
-    </d.Trigger>
-    <d.Content @defaultClass="tool-tip">
-      <div class="box">
-        {{#if this.isFullscreen}}
-          Minimize
-        {{else}}
-          Maximize
-        {{/if}}
-      </div>
-    </d.Content>
-  </ToolTip>
+  <input
+    aria-label="command input"
+    onkeyup={{action "handleKeyUp"}}
+    value={{this.value}}
+    autocomplete="off"
+    spellcheck="false"
+  />
+  <Hds::Button
+    class="hds-side-nav__icon-button"
+    {{on "click" (action "fullscreen")}}
+    data-test-tool-tip-trigger
+    @icon={{if this.isFullscreen "minimize" "maximize"}}
+    @text={{if this.isFullscreen "Minimize" "Maximize"}}
+    @isIconOnly={{true}}
+  />
 </div>
 <NamespaceReminder @class="console-reminder" @mode="execute" @noun="command" />

--- a/ui/app/templates/components/control-group-success.hbs
+++ b/ui/app/templates/components/control-group-success.hbs
@@ -60,6 +60,7 @@
             autocomplete="off"
             spellcheck="false"
             name="token"
+            id="token"
             @value={{this.token}}
           />
         </div>

--- a/ui/app/templates/components/dashboard/quick-actions-card.hbs
+++ b/ui/app/templates/components/dashboard/quick-actions-card.hbs
@@ -28,7 +28,7 @@
     </div>
 
     {{#if this.selectedEngine}}
-      <h4 class="title is-6" data-test-card-subtitle="secrets-engines">Action</h4>
+      <h4 id="action-select-title" class="title is-6" data-test-card-subtitle="secrets-engines">Action</h4>
       <Select
         @name="action-select"
         @options={{this.actionOptions}}
@@ -36,6 +36,7 @@
         @selectedValue={{this.selectedAction}}
         @onChange={{this.setSelectedAction}}
         @noDefault={{true}}
+        aria-labelledby="action-select-title"
       />
 
       {{#if this.searchSelectParams.model}}

--- a/ui/app/templates/components/dashboard/quick-actions-card.hbs
+++ b/ui/app/templates/components/dashboard/quick-actions-card.hbs
@@ -36,7 +36,7 @@
         @selectedValue={{this.selectedAction}}
         @onChange={{this.setSelectedAction}}
         @noDefault={{true}}
-        aria-labelledby="action-select-title"
+        @ariaLabel="Action"
       />
 
       {{#if this.searchSelectParams.model}}

--- a/ui/app/templates/components/dashboard/secrets-engines-card.hbs
+++ b/ui/app/templates/components/dashboard/secrets-engines-card.hbs
@@ -29,7 +29,11 @@
                   {{#if backend.icon}}
                     <ToolTip @horizontalPosition="left" as |T|>
                       <T.Trigger>
-                        <Icon @name={{backend.icon}} class={{unless backend.isSupportedBackend "has-text-grey"}} />
+                        <Icon
+                          @name={{backend.icon}}
+                          @title="{{backend.icon}} icon"
+                          class={{unless backend.isSupportedBackend "has-text-grey"}}
+                        />
                       </T.Trigger>
                       <T.Content @defaultClass="tool-tip">
                         <div class="box">

--- a/ui/app/templates/components/generated-item-list.hbs
+++ b/ui/app/templates/components/generated-item-list.hbs
@@ -19,7 +19,7 @@
 {{#let (tabs-for-auth-section @methodModel "authConfig" @paths) as |tabs|}}
   {{#if tabs.length}}
     <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
-      <nav class="tabs">
+      <nav class="tabs" aria-label="navigation to manage {{@methodModel.id}}">
         <ul>
           {{#each tabs as |tab|}}
             <li>

--- a/ui/app/templates/components/identity/entity-nav.hbs
+++ b/ui/app/templates/components/identity/entity-nav.hbs
@@ -11,7 +11,7 @@
   </p.levelLeft>
 </PageHeader>
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
-  <nav class="tabs">
+  <nav class="tabs" aria-label="navigation for entities">
     <ul>
       <LinkTo @route="vault.cluster.access.identity.index" @model={{pluralize this.identityType}}>
         {{capitalize (pluralize this.identityType)}}

--- a/ui/app/templates/components/identity/popup-alias.hbs
+++ b/ui/app/templates/components/identity/popup-alias.hbs
@@ -5,7 +5,7 @@
 
 <PopupMenu @name="alias-menu">
   {{#let (get this.params "0") as |item|}}
-    <nav class="menu">
+    <nav class="menu" aria-label="navigation for managing aliases">
       <ul class="menu-list">
         <li class="action">
           <LinkTo

--- a/ui/app/templates/components/identity/popup-members.hbs
+++ b/ui/app/templates/components/identity/popup-members.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <PopupMenu @name="member-edit-menu">
-  <nav class="menu">
+  <nav class="menu" aria-label="navigation for managing identity members">
     <ul class="menu-list">
       <li class="action">
         <ConfirmAction

--- a/ui/app/templates/components/identity/popup-metadata.hbs
+++ b/ui/app/templates/components/identity/popup-metadata.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <PopupMenu @name="metadata-edit-menu">
-  <nav class="menu">
+  <nav class="menu" aria-label="navigation for managing identity metadata">
     <ul class="menu-list">
       <li class="action">
         <ConfirmAction

--- a/ui/app/templates/components/identity/popup-policy.hbs
+++ b/ui/app/templates/components/identity/popup-policy.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <PopupMenu @name="policy-menu">
-  <nav class="menu">
+  <nav class="menu" aria-label="navigation for managing identity policies">
     <ul class="menu-list">
       <li class="action">
         <LinkTo @route="vault.cluster.policy.show" @models={{array "acl" this.policyName}}>

--- a/ui/app/templates/components/keymgmt/key-edit.hbs
+++ b/ui/app/templates/components/keymgmt/key-edit.hbs
@@ -27,7 +27,7 @@
 {{else}}
   {{#if (eq this.mode "show")}}
     <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless" data-test-keymgmt-key-toolbar>
-      <nav class="tabs">
+      <nav class="tabs" aria-label="navigation for managing keys">
         <ul>
           <li class={{if (not-eq @tab "versions") "active"}}>
             <LinkTo

--- a/ui/app/templates/components/keymgmt/provider-edit.hbs
+++ b/ui/app/templates/components/keymgmt/provider-edit.hbs
@@ -26,7 +26,7 @@
 {{else}}
   {{#if this.isShowing}}
     <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
-      <nav class="tabs">
+      <nav class="tabs" aria-label="navigation for managing providers">
         <ul>
           <li class={{unless this.viewingKeys "active"}} data-test-kms-provider-tab="details">
             <LinkTo @route="vault.cluster.secrets.backend.show" @model={{@model.id}} @query={{hash tab=""}}>
@@ -44,7 +44,10 @@
       </nav>
     </div>
     {{#unless this.viewingKeys}}
-      <Toolbar data-test-kms-provider-details-actions>
+      <Toolbar
+        data-test-kms-provider-details-actions
+        aria-label="options for managing for key/management provider {{@model.id}}"
+      >
         <ToolbarActions>
           {{#if @model.canDelete}}
             <ConfirmAction

--- a/ui/app/templates/components/mfa/login-enforcement-list-item.hbs
+++ b/ui/app/templates/components/mfa/login-enforcement-list-item.hbs
@@ -20,7 +20,7 @@
     <div class="level-right is-flex is-paddingless is-marginless">
       <div class="level-item">
         <PopupMenu>
-          <nav class="menu">
+          <nav class="menu" aria-label="navigation for managing login enforcements">
             <ul class="menu-list">
               <li>
                 <LinkTo

--- a/ui/app/templates/components/mfa/method-list-item.hbs
+++ b/ui/app/templates/components/mfa/method-list-item.hbs
@@ -31,7 +31,7 @@
     <div class="level-right is-flex is-paddingless is-marginless">
       <div class="level-item">
         <PopupMenu>
-          <nav class="menu">
+          <nav class="menu" aria-label="navigation for managing MFA methods">
             <ul class="menu-list">
               <li>
                 <LinkTo

--- a/ui/app/templates/components/mfa/mfa-login-enforcement-form.hbs
+++ b/ui/app/templates/components/mfa/mfa-login-enforcement-form.hbs
@@ -17,6 +17,7 @@
     disabled={{not @model.isNew}}
     class="input field {{if this.errors.name.errors 'has-error-border'}}"
     data-test-mlef-input="name"
+    id="name"
     {{on "input" (pipe (pick "target.value") (fn (mut @model.name)))}}
   />
   {{#if this.errors.name.errors}}
@@ -85,6 +86,7 @@
         @selectedValue={{this.selectedTargetType}}
         @onChange={{this.onTargetSelect}}
         data-test-mlef-select="target-type"
+        aria-label="Target type"
       />
       <div class="has-left-margin-s is-flex-grow-1">
         {{#if (eq this.selectedTargetType "accessor")}}
@@ -106,6 +108,7 @@
             @selectedValue={{this.selectedTargetValue}}
             @onChange={{this.setTargetValue}}
             data-test-mlef-select="auth-method"
+            aria-label="Auth method"
           />
         {{else}}
           <SearchSelect

--- a/ui/app/templates/components/mfa/mfa-login-enforcement-form.hbs
+++ b/ui/app/templates/components/mfa/mfa-login-enforcement-form.hbs
@@ -85,6 +85,7 @@
         @valueAttribute="type"
         @selectedValue={{this.selectedTargetType}}
         @onChange={{this.onTargetSelect}}
+        @name="target-type"
         data-test-mlef-select="target-type"
         aria-label="Target type"
       />
@@ -107,6 +108,7 @@
             @noDefault={{true}}
             @selectedValue={{this.selectedTargetValue}}
             @onChange={{this.setTargetValue}}
+            @name="Auth method"
             data-test-mlef-select="auth-method"
             aria-label="Auth method"
           />

--- a/ui/app/templates/components/mfa/nav.hbs
+++ b/ui/app/templates/components/mfa/nav.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
-  <nav class="tabs">
+  <nav class="tabs" aria-label="navigation for managing MFA">
     <ul>
       <LinkTo @route="vault.cluster.access.mfa.methods" data-test-tab="methods">
         Methods

--- a/ui/app/templates/components/mount-accessor-select.hbs
+++ b/ui/app/templates/components/mount-accessor-select.hbs
@@ -21,7 +21,13 @@
   {{else if this.authMethods.last.value}}
     <div class="control is-expanded">
       <div class="select is-fullwidth">
-        <select name={{@name}} id={{@name}} {{on "change" this.change}} data-test-mount-accessor-select>
+        <select
+          aria-label={{or @label "Select a mount accessor"}}
+          name={{@name}}
+          id={{@name}}
+          {{on "change" this.change}}
+          data-test-mount-accessor-select
+        >
           {{#if this.noDefault}}
             <option value="">Select one</option>
           {{/if}}

--- a/ui/app/templates/components/oidc/assignment-form.hbs
+++ b/ui/app/templates/components/oidc/assignment-form.hbs
@@ -15,6 +15,7 @@
       class="input field {{if this.modelValidations.name.errors 'has-error-border'}}"
       {{on "input" this.handleOperation}}
       data-test-input="name"
+      id="name"
     />
     {{#if this.modelValidations.name.errors}}
       <AlertInline @type="danger" @message={{join ", " this.modelValidations.name.errors}} />

--- a/ui/app/templates/components/oidc/client-list.hbs
+++ b/ui/app/templates/components/oidc/client-list.hbs
@@ -25,7 +25,7 @@
       <div class="level-right is-flex is-paddingless is-marginless">
         <div class="level-item">
           <PopupMenu>
-            <nav class="menu">
+            <nav class="menu" aria-label="navigation for managing OIDC client {{client.name}}">
               <ul class="menu-list">
                 <li>
                   <LinkTo

--- a/ui/app/templates/components/oidc/provider-list.hbs
+++ b/ui/app/templates/components/oidc/provider-list.hbs
@@ -25,7 +25,7 @@
       <div class="level-right is-flex is-paddingless is-marginless">
         <div class="level-item">
           <PopupMenu>
-            <nav class="menu">
+            <nav class="menu" aria-label="navigation for managing provider {{provider.name}}">
               <ul class="menu-list">
                 <li>
                   <LinkTo

--- a/ui/app/templates/components/pgp-file.hbs
+++ b/ui/app/templates/components/pgp-file.hbs
@@ -38,9 +38,10 @@
         class="textarea"
         oninput={{action "updateData"}}
         data-test-pgp-file-textarea={{true}}
+        aria-labelledby={{concat "pgpFileTextarea-" this.elementId}}
       >{{this.key.value}}</textarea>
     </div>
-    <p class="help has-text-grey">
+    <p class="help has-text-grey" id={{concat "pgpFileTextarea-" this.elementId}}>
       {{#if this.textareaHelpText}}
         {{this.textareaHelpText}}
       {{else}}

--- a/ui/app/templates/components/secret-edit-toolbar.hbs
+++ b/ui/app/templates/components/secret-edit-toolbar.hbs
@@ -4,9 +4,9 @@
 ~}}
 
 {{! template-lint-configure simple-unless "warn" }}
-<Toolbar>
+<Toolbar aria-label="manage secret">
   {{#unless (and (eq @mode "show") @isWriteWithoutRead)}}
-    <ToolbarFilters>
+    <ToolbarFilters aria-label="manage view">
       <Toggle
         @name="json"
         @disabled={{and (eq @mode "show") @secretDataIsAdvanced}}
@@ -17,7 +17,7 @@
       </Toggle>
     </ToolbarFilters>
   {{/unless}}
-  <ToolbarActions>
+  <ToolbarActions aria-label="actions for {{@model.id}}">
     {{#if (and (eq @mode "show") @model.canDelete)}}
       <ConfirmAction
         @buttonText="Delete"

--- a/ui/app/templates/components/secret-edit.hbs
+++ b/ui/app/templates/components/secret-edit.hbs
@@ -29,7 +29,7 @@
   {{! tabs for show only }}
   {{#if (eq @mode "show")}}
     <div class="tabs-container box is-bottomless is-marginless is-fullwidth is-paddingless">
-      <nav class="tabs">
+      <nav class="tabs" aria-label="navigation for secret management">
         <ul>
           <LinkTo @route="vault.cluster.secrets.backend.show" @model={{@key.id}} data-test-secret-tab>
             Secret

--- a/ui/app/templates/components/secret-list/aws-role-item.hbs
+++ b/ui/app/templates/components/secret-list/aws-role-item.hbs
@@ -24,7 +24,7 @@
     </div>
     <div class="column has-text-right">
       <PopupMenu @name="role-aws-nav" @contentClass="is-wide">
-        <nav class="menu">
+        <nav class="menu" aria-label="navigation for managing AWS role {{@item.id}}">
           <ul class="menu-list">
             {{#if @item.generatePath.isPending}}
               <li class="action">

--- a/ui/app/templates/components/secret-list/database-list-item.hbs
+++ b/ui/app/templates/components/secret-list/database-list-item.hbs
@@ -27,7 +27,7 @@
     </div>
     <div class="column has-text-right">
       <PopupMenu name="secret-menu">
-        <nav class="menu">
+        <nav class="menu" aria-label="navigation for managing database {{@item.id}}">
           <ul class="menu-list">
             {{#if @item.canEdit}}
               <li class="action">

--- a/ui/app/templates/components/secret-list/item.hbs
+++ b/ui/app/templates/components/secret-list/item.hbs
@@ -31,7 +31,7 @@
     </div>
     <div class="column has-text-right">
       <PopupMenu name="secret-menu">
-        <nav class="menu">
+        <nav class="menu" aria-label="navigation for managing {{@item.id}}">
           <ul class="menu-list">
             {{#if @item.isFolder}}
               <SecretLink @mode="list" @secret={{@item.id}} class="has-text-black has-text-weight-semibold">

--- a/ui/app/templates/components/secret-list/ssh-role-item.hbs
+++ b/ui/app/templates/components/secret-list/ssh-role-item.hbs
@@ -37,7 +37,7 @@
     <div class="column has-text-right">
       {{#if (eq @backendType "ssh")}}
         <PopupMenu @name="role-ssh-nav">
-          <nav class="menu">
+          <nav class="menu" aria-label="navigation for managing SSH role {{@item.id}}">
             <ul class="menu-list">
               {{#if (eq @item.keyType "otp")}}
                 {{#if @item.generatePath.isPending}}

--- a/ui/app/templates/components/secret-list/transform-list-item.hbs
+++ b/ui/app/templates/components/secret-list/transform-list-item.hbs
@@ -26,7 +26,7 @@
       <div class="column has-text-right">
         {{#if (or @item.updatePath.canRead @item.updatePath.canUpdate)}}
           <PopupMenu name="secret-menu">
-            <nav class="menu">
+            <nav class="menu" aria-label="navigation for managing transformation item {{@itemPath}}">
               <ul class="menu-list">
                 {{#if @item.updatePath.canRead}}
                   <li class="action">

--- a/ui/app/templates/components/secret-list/transform-transformation-item.hbs
+++ b/ui/app/templates/components/secret-list/transform-transformation-item.hbs
@@ -26,7 +26,7 @@
       </div>
       <div class="column has-text-right">
         {{#if (or @item.updatePath.canRead @item.updatePath.canUpdate)}}
-          <PopupMenu name="secret-menu">
+          <PopupMenu name="secret-menu" aria-label={{concat "navigation for managing transformation " @item.id}}>
             <nav class="menu">
               <ul class="menu-list">
                 {{#if (or @item.versionPath.isLoading @item.secretPath.isLoading)}}

--- a/ui/app/templates/components/section-tabs.hbs
+++ b/ui/app/templates/components/section-tabs.hbs
@@ -6,7 +6,7 @@
 {{#let (tabs-for-auth-section this.model this.tabType this.paths) as |tabs|}}
   {{#if tabs.length}}
     <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
-      <nav class="tabs">
+      <nav class="tabs" aria-label="navigation to manage {{this.model.type}}">
         <ul>
           {{#each tabs as |tab|}}
             <li>

--- a/ui/app/templates/components/transit-form-show.hbs
+++ b/ui/app/templates/components/transit-form-show.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
-  <nav class="tabs" aria-label="tabs">
+  <nav class="tabs" aria-label="navigation to manage transit backend">
     <ul>
       <li class={{if (eq @tab "actions") "is-active"}}>
         <SecretLink

--- a/ui/app/templates/components/wizard-content.hbs
+++ b/ui/app/templates/components/wizard-content.hbs
@@ -6,7 +6,7 @@
 <div class="wizard-header">
   {{#unless this.hidePopup}}
     <PopupMenu @class="wizard-dismiss-menu">
-      <nav class="menu">
+      <nav class="menu" aria-label="navigation for wizard content">
         <ul class="menu-list">
           <li class="action">
             <Hds::Button @text="Dismiss" @color="secondary" class="link" {{on "click" (action "dismissWizard")}} />

--- a/ui/app/templates/vault/cluster/access/identity/aliases/show.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/show.hbs
@@ -20,7 +20,7 @@
   </p.levelLeft>
 </PageHeader>
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
-  <nav class="tabs sub-nav" aria-label="tabs">
+  <nav class="tabs sub-nav" aria-label="navigation for managing identity alias">
     <ul>
       {{#each (tabs-for-identity-show this.model.identityType) as |tab|}}
         <LinkTo @route="vault.cluster.access.identity.aliases.show" @models={{array this.model.id tab}}>

--- a/ui/app/templates/vault/cluster/access/identity/index.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/index.hbs
@@ -33,7 +33,7 @@
         </div>
         <div class="column has-text-right">
           <PopupMenu @name="identity-item" @onOpen={{action "reloadRecord" item}}>
-            <nav class="menu">
+            <nav class="menu" aria-label="navigation for managing identity">
               <ul class="menu-list">
                 <li class="action">
                   <LinkTo @route="vault.cluster.access.identity.show" @models={{array item.id "details"}}>

--- a/ui/app/templates/vault/cluster/access/identity/show.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/show.hbs
@@ -20,7 +20,7 @@
   </p.levelLeft>
 </PageHeader>
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
-  <nav class="tabs sub-nav" aria-label="tabs">
+  <nav class="tabs sub-nav" aria-label="navigation for managing {{this.model.identityType}}">
     <ul>
       {{#each (tabs-for-identity-show this.model.identityType this.model.type) as |tab|}}
         <LinkTo

--- a/ui/app/templates/vault/cluster/access/methods.hbs
+++ b/ui/app/templates/vault/cluster/access/methods.hbs
@@ -84,7 +84,7 @@
       <div class="level-right is-flex is-paddingless is-marginless">
         <div class="level-item">
           <PopupMenu @name="auth-backend-nav">
-            <nav class="menu">
+            <nav class="menu" aria-label="navigation for managing access method {{method.id}}">
               <ul class="menu-list">
                 <li>
                   <LinkTo @route="vault.cluster.access.method.section" @models={{array method.id "configuration"}}>

--- a/ui/app/templates/vault/cluster/access/oidc.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc.hbs
@@ -35,7 +35,7 @@
   {{#unless this.isCta}}
     {{! show tab links in list routes }}
     <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless" data-test-oidc-tabs>
-      <nav class="tabs">
+      <nav class="tabs" aria-label="navigation for managing OIDC">
         <ul>
           <LinkTo @route="vault.cluster.access.oidc.clients" data-test-tab="clients">
             Applications

--- a/ui/app/templates/vault/cluster/clients.hbs
+++ b/ui/app/templates/vault/cluster/clients.hbs
@@ -12,7 +12,7 @@
 </PageHeader>
 
 <div class="tabs-container box is-bottomless is-marginless is-fullwidth is-paddingless">
-  <nav class="tabs">
+  <nav class="tabs" aria-label="navigation for managing client counts">
     <ul>
       <LinkTo @route="vault.cluster.clients.dashboard" data-test-dashboard>
         Dashboard

--- a/ui/lib/core/addon/components/autocomplete-input.hbs
+++ b/ui/lib/core/addon/components/autocomplete-input.hbs
@@ -5,7 +5,7 @@
 
 <div {{did-insert this.setElement}} ...attributes>
   {{#if @label}}
-    <FormFieldLabel @label={{@label}} @subText={{@subText}} />
+    <FormFieldLabel @label={{@label}} @subText={{@subText}} for={{dasherize @label}} />
   {{/if}}
   <div class="control">
     <Input
@@ -15,6 +15,7 @@
       placeholder={{@placeholder}}
       class="input"
       {{on "input" this.onInput}}
+      id={{dasherize @label}}
     />
     <BasicDropdown @registerAPI={{this.setDropdownAPI}} @renderInPlace={{true}} as |D|>
       <D.Content @defaultClass="autocomplete-input">

--- a/ui/lib/core/addon/components/confirmation-modal.hbs
+++ b/ui/lib/core/addon/components/confirmation-modal.hbs
@@ -14,11 +14,11 @@
         <p class="has-text-weight-semibold is-size-6">
           Confirm
         </p>
-        <p class="sub-text has-top-bottom-margin-xxs">Type
+        <label class="sub-text has-top-bottom-margin-xxs" for={{concat "confirm-" (dasherize this.confirmText)}}>Type
           <strong>{{this.confirmText}}</strong>
           to confirm
           {{@toConfirmMsg}}
-        </p>
+        </label>
         <Input
           @type="text"
           @value={{this.confirmationInput}}
@@ -27,6 +27,7 @@
           autocomplete="off"
           spellcheck="false"
           data-test-confirmation-modal-input={{@title}}
+          id={{concat "confirm-" (dasherize this.confirmText)}}
         />
       </div>
     </M.Body>

--- a/ui/lib/core/addon/components/icon.hbs
+++ b/ui/lib/core/addon/components/icon.hbs
@@ -6,7 +6,7 @@
 {{#if this.isFlightIcon}}
   <FlightIcon @name={{this.name}} @size={{this.size}} @stretched={{@stretched}} ...attributes />
 {{else}}
-  <span class="hs-icon {{this.hsIconClass}}" ...attributes>
+  <span class="hs-icon {{this.hsIconClass}}" aria-hidden={{true}} ...attributes>
     {{svg-jar this.name}}
   </span>
 {{/if}}

--- a/ui/lib/core/addon/components/icon.hbs
+++ b/ui/lib/core/addon/components/icon.hbs
@@ -6,7 +6,7 @@
 {{#if this.isFlightIcon}}
   <FlightIcon @name={{this.name}} @size={{this.size}} @stretched={{@stretched}} ...attributes />
 {{else}}
-  <span class="hs-icon {{this.hsIconClass}}" aria-hidden={{true}} ...attributes>
+  <span class="hs-icon {{this.hsIconClass}}" aria-hidden="true" ...attributes>
     {{svg-jar this.name}}
   </span>
 {{/if}}

--- a/ui/lib/core/addon/components/info-tooltip.hbs
+++ b/ui/lib/core/addon/components/info-tooltip.hbs
@@ -17,8 +17,9 @@
       class="tool-tip-trigger button is-ghost is-compact"
       data-test-tool-tip-trigger={{true}}
       {{on "click" this.preventSubmit}}
+      aria-label="help"
     >
-      <Icon @name="info" class="auto-width" aria-label="help" />
+      <Icon @name="info" class="auto-width" />
     </d.Trigger>
     <d.Content @defaultClass="tool-tip">
       <div class="box" data-test-info-tooltip-content>

--- a/ui/lib/core/addon/components/json-editor.hbs
+++ b/ui/lib/core/addon/components/json-editor.hbs
@@ -6,14 +6,14 @@
 <div ...attributes>
   {{#if this.getShowToolbar}}
     <div data-test-component="json-editor-toolbar">
-      <Toolbar>
-        <label class="has-text-weight-bold" data-test-component="json-editor-title">
+      <Toolbar aria-label="items for managing JSON editor for {{@title}}">
+        <label id="json-editor-title" class="has-text-weight-bold" data-test-component="json-editor-title">
           {{@title}}
           {{#if @subTitle}}
             <span class="is-size-9 is-lowercase has-text-grey">({{@subTitle}})</span>
           {{/if}}
         </label>
-        <ToolbarActions>
+        <ToolbarActions aria-label="actions for {{@title}} JSON editor">
           {{yield}}
           {{#if @example}}
             <Hds::Button

--- a/ui/lib/core/addon/components/masked-input.hbs
+++ b/ui/lib/core/addon/components/masked-input.hbs
@@ -29,6 +29,7 @@
       rows={{1}}
       wrap="off"
       spellcheck="false"
+      aria-label={{or @name "masked input"}}
       {{on "change" this.onChange}}
       {{on "keyup" (fn this.handleKeyUp @name)}}
       data-test-textarea

--- a/ui/lib/core/addon/components/popup-menu.hbs
+++ b/ui/lib/core/addon/components/popup-menu.hbs
@@ -8,9 +8,10 @@
     <d.Trigger
       @htmlTag="button"
       class={{concat "popup-menu-trigger button is-ghost" (if d.isOpen " is-active")}}
+      aria-label="More options"
       data-test-popup-menu-trigger
     >
-      <Icon @name="more-horizontal" class="has-text-black auto-width" aria-label="More options" />
+      <Icon @name="more-horizontal" class="has-text-black auto-width" />
     </d.Trigger>
     <d.Content @defaultClass={{concat "popup-menu-content " @contentClass}}>
       <div class="box">

--- a/ui/lib/core/addon/components/select.js
+++ b/ui/lib/core/addon/components/select.js
@@ -25,6 +25,7 @@ import layout from '../templates/components/select';
  * @param {boolean} [isFullwidth = false] - Whether or not the select should take up the full width of the parent element.
  * @param {boolean} [noDefault = false] - shows Select One with empty value as first option
  * @param {Func} [onChange] - The action to take once the user has selected an item. This method will be passed the `value` of the select.
+ * @param {string} [ariaLabel] - pass when label is defined elsewhere to ensure the select input has a valid label
  */
 
 export default Component.extend({
@@ -40,4 +41,5 @@ export default Component.extend({
   isFullwidth: false,
   noDefault: false,
   onChange() {},
+  ariaLabel: null,
 });

--- a/ui/lib/core/addon/components/shamir/form.hbs
+++ b/ui/lib/core/addon/components/shamir/form.hbs
@@ -34,7 +34,15 @@
       {{this.inputLabel}}
     </label>
     <div class="control">
-      <Input class="input" @type="password" name="key" @value={{this.key}} autocomplete="off" data-test-shamir-key-input />
+      <Input
+        class="input"
+        @type="password"
+        id="key"
+        name="key"
+        @value={{this.key}}
+        autocomplete="off"
+        data-test-shamir-key-input
+      />
     </div>
   </div>
   <div class="columns is-mobile">

--- a/ui/lib/core/addon/components/string-list.hbs
+++ b/ui/lib/core/addon/components/string-list.hbs
@@ -32,8 +32,7 @@
           class="input {{if (includes index this.indicesWithComma) 'has-warning-border'}}"
           @value={{data.value}}
           name={{concat this.elementId "-" index}}
-          id={{concat this.elementId "-" index}}
-          aria-label="List item {{index}}"
+          aria-label="{{@label}} list item {{index}}"
           {{on "keyup" (action "inputChanged" index)}}
           {{on "change" (action "inputChanged" index)}}
         />

--- a/ui/lib/core/addon/components/string-list.hbs
+++ b/ui/lib/core/addon/components/string-list.hbs
@@ -33,6 +33,7 @@
           @value={{data.value}}
           name={{concat this.elementId "-" index}}
           id={{concat this.elementId "-" index}}
+          aria-label="List item {{index}}"
           {{on "keyup" (action "inputChanged" index)}}
           {{on "change" (action "inputChanged" index)}}
         />

--- a/ui/lib/core/addon/components/text-file.hbs
+++ b/ui/lib/core/addon/components/text-file.hbs
@@ -6,7 +6,7 @@
 {{#unless @uploadOnly}}
   <div class="level is-mobile">
     <div class="level-left">
-      <label for="input-{{this.elementId}}" class="has-text-weight-semibold" data-test-text-file-label>
+      <label id="text-file-input-label" class="has-text-weight-semibold" data-test-text-file-label>
         {{or @label "File"}}
         {{#if @helpText}}
           <InfoTooltip>
@@ -35,10 +35,10 @@
 <div class="field text-file box is-fullwidth is-marginless is-shadowless is-paddingless" data-test-component="text-file">
   {{#if this.showTextArea}}
     <Hds::Form::MaskedInput::Field
-      id="input-{{this.elementId}}"
       @value={{this.content}}
       @isMultiline={{true}}
       {{on "input" this.handleTextInput}}
+      aria-labelledby="text-file-input-label"
       data-test-text-file-textarea
       as |F|
     >
@@ -46,8 +46,8 @@
     </Hds::Form::MaskedInput::Field>
   {{else}}
     <Hds::Form::FileInput::Field
-      id="file-input-{{this.elementId}}"
       {{on "change" this.handleFileUpload}}
+      aria-labelledby="text-file-input-label"
       data-test-text-file-input
       as |F|
     >

--- a/ui/lib/core/addon/components/text-file.hbs
+++ b/ui/lib/core/addon/components/text-file.hbs
@@ -3,10 +3,12 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-{{#unless @uploadOnly}}
+{{#if @uploadOnly}}
+  <label id="text-file-input-{{this.elementId}}" class="sr-only">{{or @label "File"}}</label>
+{{else}}
   <div class="level is-mobile">
     <div class="level-left">
-      <label id="text-file-input-label" class="has-text-weight-semibold" data-test-text-file-label>
+      <label id="text-file-input-{{this.elementId}}" class="has-text-weight-semibold" data-test-text-file-label>
         {{or @label "File"}}
         {{#if @helpText}}
           <InfoTooltip>
@@ -31,14 +33,14 @@
       </label>
     </div>
   </div>
-{{/unless}}
+{{/if}}
 <div class="field text-file box is-fullwidth is-marginless is-shadowless is-paddingless" data-test-component="text-file">
   {{#if this.showTextArea}}
     <Hds::Form::MaskedInput::Field
       @value={{this.content}}
       @isMultiline={{true}}
       {{on "input" this.handleTextInput}}
-      aria-labelledby="text-file-input-label"
+      aria-labelledby="text-file-input-{{this.elementId}}"
       data-test-text-file-textarea
       as |F|
     >
@@ -47,7 +49,7 @@
   {{else}}
     <Hds::Form::FileInput::Field
       {{on "change" this.handleFileUpload}}
-      aria-labelledby="text-file-input-label"
+      aria-labelledby="text-file-input-{{this.elementId}}"
       data-test-text-file-input
       as |F|
     >

--- a/ui/lib/core/addon/components/toolbar-actions.hbs
+++ b/ui/lib/core/addon/components/toolbar-actions.hbs
@@ -3,6 +3,6 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<nav class="toolbar-actions">
+<nav class="toolbar-actions" ...attributes>
   {{yield}}
 </nav>

--- a/ui/lib/core/addon/components/toolbar-filters.hbs
+++ b/ui/lib/core/addon/components/toolbar-filters.hbs
@@ -3,6 +3,6 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<nav class="toolbar-filters">
+<nav class="toolbar-filters" ...attributes>
   {{yield}}
 </nav>

--- a/ui/lib/core/addon/components/ttl-picker.hbs
+++ b/ui/lib/core/addon/components/ttl-picker.hbs
@@ -45,9 +45,9 @@
         />
       </div>
       <div class="control">
-        <label for="unit-{{this.elementId}}" class="sr-only">Unit for TTL</label>
+        <label for="select-ttl-unit" class="sr-only">Unit for TTL</label>
+        {{! Select automatically gets id based on name }}
         <Select
-          id="unit-{{this.elementId}}"
           @name="ttl-unit"
           @options={{this.unitOptions}}
           @onChange={{this.updateUnit}}

--- a/ui/lib/core/addon/templates/components/select.hbs
+++ b/ui/lib/core/addon/templates/components/select.hbs
@@ -15,7 +15,7 @@
       id="select-{{this.name}}"
       onchange={{action this.onChange value="target.value"}}
       data-test-select={{this.name}}
-      ...attributes
+      aria-label={{this.ariaLabel}}
     >
       {{#if this.noDefault}}
         <option value="">

--- a/ui/lib/core/addon/templates/components/select.hbs
+++ b/ui/lib/core/addon/templates/components/select.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 {{#if this.label}}
-  <label for="select-{{this.elementId}}" class="is-label" data-test-select-label>
+  <label for="select-{{this.name}}" class="is-label" data-test-select-label>
     {{this.label}}
   </label>
 {{/if}}
@@ -12,9 +12,10 @@
   <div class="select {{if this.isFullwidth 'is-fullwidth'}}">
     <select
       class="select"
-      id="select-{{this.elementId}}"
+      id="select-{{this.name}}"
       onchange={{action this.onChange value="target.value"}}
       data-test-select={{this.name}}
+      ...attributes
     >
       {{#if this.noDefault}}
         <option value="">

--- a/ui/lib/kubernetes/addon/components/page/credentials.hbs
+++ b/ui/lib/kubernetes/addon/components/page/credentials.hbs
@@ -58,7 +58,7 @@
           <MessageError class="has-top-margin-l" @errorMessage={{this.error}} />
         {{/if}}
 
-        <label for="token" class="is-label has-top-margin-l">Kubernetes namespace</label>
+        <label for="k8s-namespace" class="is-label has-top-margin-l">Kubernetes namespace</label>
         <div class="has-text-grey is-size-8 has-bottom-margin-xs">
           The namespace in which to generate the credentials.
         </div>
@@ -66,6 +66,7 @@
           @type="text"
           @value={{this.kubernetesNamespace}}
           class="input"
+          id="k8s-namespace"
           {{on "input" this.setKubernetesNamespace}}
           data-test-kubernetes-namespace
         />

--- a/ui/lib/kubernetes/addon/components/page/role/details.hbs
+++ b/ui/lib/kubernetes/addon/components/page/role/details.hbs
@@ -14,7 +14,7 @@
   </p.levelLeft>
 </PageHeader>
 
-<Toolbar>
+<Toolbar aria-label="menu items for managing role {{@model.id}}">
   <ToolbarActions>
     {{#if @model.canDelete}}
       <ConfirmAction

--- a/ui/lib/kubernetes/addon/components/tab-page-header.hbs
+++ b/ui/lib/kubernetes/addon/components/tab-page-header.hbs
@@ -25,7 +25,7 @@
   </nav>
 </div>
 
-<Toolbar>
+<Toolbar aria-label="items for managing kubernetes items">
   {{#if @filterRoles}}
     <ToolbarFilters>
       <NavigateInput

--- a/ui/lib/kv/addon/components/kv-list-filter.hbs
+++ b/ui/lib/kv/addon/components/kv-list-filter.hbs
@@ -6,10 +6,9 @@
 <form {{on "submit" (perform this.handleSearch)}}>
   <Hds::SegmentedGroup as |S|>
     <S.TextInput
-      id="secret-id"
       @value={{this.query}}
       placeholder="Search secret path"
-      aria-describedby="Search by secret path"
+      aria-label="Search by secret path"
       size="32"
       {{on "input" this.handleInput}}
       {{on "keydown" this.handleKeyDown}}

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -31,11 +31,11 @@
 {{/if}}
 
 {{#if (or (has-block "toolbarFilters") (has-block "toolbarActions"))}}
-  <Toolbar>
-    <ToolbarFilters>
+  <Toolbar aria-label="menu items for managing {{or @mountName @pageTitle}}">
+    <ToolbarFilters aria-label="filters for secrets list">
       {{yield to="toolbarFilters"}}
     </ToolbarFilters>
-    <ToolbarActions>
+    <ToolbarActions aria-label="actions for secrets">
       {{yield to="toolbarActions"}}
     </ToolbarActions>
   </Toolbar>

--- a/ui/lib/ldap/addon/components/page/library/details.hbs
+++ b/ui/lib/ldap/addon/components/page/library/details.hbs
@@ -24,7 +24,7 @@
 </div>
 
 <Toolbar>
-  <ToolbarActions>
+  <ToolbarActions aria-label="actions for library {{@model.id}}">
     {{#if @model.canDelete}}
       <ConfirmAction
         @buttonText="Delete library"

--- a/ui/lib/ldap/addon/components/page/role/details.hbs
+++ b/ui/lib/ldap/addon/components/page/role/details.hbs
@@ -15,7 +15,7 @@
 </PageHeader>
 
 <Toolbar>
-  <ToolbarActions>
+  <ToolbarActions aria-label="actions for role {{@role.id}}">
     {{#if @model.canDelete}}
       <ConfirmAction
         @buttonText="Delete role"

--- a/ui/lib/ldap/addon/components/tab-page-header.hbs
+++ b/ui/lib/ldap/addon/components/tab-page-header.hbs
@@ -26,11 +26,11 @@
   </nav>
 </div>
 
-<Toolbar>
-  <ToolbarFilters>
+<Toolbar aria-label="nav for managing LDAP">
+  <ToolbarFilters aria-label="filter for LDAP items">
     {{yield to="toolbarFilters"}}
   </ToolbarFilters>
-  <ToolbarActions>
+  <ToolbarActions aria-label="actions for LDAP items">
     {{yield to="toolbarActions"}}
   </ToolbarActions>
 </Toolbar>

--- a/ui/lib/pki/addon/components/page/pki-configuration-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-configuration-details.hbs
@@ -4,8 +4,8 @@
 ~}}
 
 {{#if @hasConfig}}
-  <Toolbar>
-    <ToolbarActions>
+  <Toolbar aria-label="PKI configuration">
+    <ToolbarActions aria-label="actions for PKI configuration">
       {{#if @canDeleteAllIssuers}}
         <Hds::Button
           @text="Delete all issuers"

--- a/ui/lib/pki/addon/components/page/pki-issuer-edit.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-edit.hbs
@@ -32,8 +32,8 @@
           <div class="control is-expanded">
             <div class="select is-fullwidth">
               <select
-                name={{@attr.name}}
-                id={{@attr.name}}
+                name={{field.name}}
+                id={{field.name}}
                 {{on "change" (pipe (pick "target.value") (fn (mut @model.leafNotAfterBehavior)))}}
                 onchange={{this.onChangeWithEvent}}
               >

--- a/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
@@ -15,8 +15,8 @@
 </PageHeader>
 
 {{#if @newRootModel.id}}
-  <Toolbar>
-    <ToolbarActions>
+  <Toolbar aria-label="manu for managing PKI certificate">
+    <ToolbarActions aria-label="actions for managing PKI certificate">
       <ToolbarLink
         @route="issuers.issuer.cross-sign"
         @type="pen-tool"

--- a/ui/lib/pki/addon/components/pki-role-form.hbs
+++ b/ui/lib/pki/addon/components/pki-role-form.hbs
@@ -15,7 +15,7 @@
             {{#if (and (eq attr.name "issuerRef") @issuers)}}
               <div class="has-top-margin-m {{unless this.showDefaultIssuer 'has-bottom-margin-xs' 'has-bottom-margin-m'}}">
                 <FormFieldLabel
-                  for={{attr.name}}
+                  for="select-{{attr.name}}"
                   @label="Issuer ref"
                   @helpText={{(if this.showHelpText attr.options.helpText)}}
                   @subText={{attr.options.subText}}
@@ -39,6 +39,7 @@
                       @isFullwidth={{true}}
                       @selectedValue={{@role.issuerRef}}
                       @onChange={{action (mut @role.issuerRef)}}
+                      aria-labelledby={{attr.name}}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
This PR adds [labels](https://dequeuniversity.com/rules/axe/4.8/label) to tags that require them (`<nav>`, `<input>`, etc). The changes in this PR are based on failures from the Integration tests only.

Unfortunately, a couple 3rd party components that we use (CodeMirror and ember power select to be specific) have violations that are causing widespread failures. But, I tried to address all the instances that we can control. 