### PR TITLE
Fix templating mention in Proxy docs

### DIFF
--- a/website/content/docs/agent-and-proxy/proxy/index.mdx
+++ b/website/content/docs/agent-and-proxy/proxy/index.mdx
@@ -131,10 +131,6 @@ environment variable as a comma separated string. This environment variable will
 Valid values include: `auto-auth`, and `proxying`. Can also be configured by setting the `VAULT_PROXY_DISABLE_KEEP_ALIVES`
 environment variable as a comma separated string. This environment variable will override any values found in a configuration file.
 
-- `template` <code>([template][template]: <optional\>)</code> - Specifies options used for templating Vault secrets to files.
-
-- `template_config` <code>([template_config][template-config]: <optional\>)</code> - Specifies templating engine behavior.
-
 - `telemetry` <code>([telemetry][telemetry]: <optional\>)</code> – Specifies the telemetry
 reporting system. See the [telemetry Stanza](/vault/docs/agent-and-proxy/proxy#telemetry-stanza) section below
 for a list of metrics specific to Proxy.
@@ -349,8 +345,6 @@ listener "tcp" {
 [caching]: /vault/docs/agent-and-proxy/proxy/caching
 [apiproxy]: /vault/docs/agent-and-proxy/proxy/apiproxy
 [persistent-cache]: /vault/docs/agent-and-proxy/proxy/caching/persistent-caches
-[template]: /vault/docs/agent-and-proxy/proxy/template
-[template-config]: /vault/docs/agent-and-proxy/proxy/template#template-configurations
 [proxy-api]: /vault/docs/agent-and-proxy/proxy/#proxy_api-stanza
 [listener]: /vault/docs/agent-and-proxy/proxy#listener-stanza
 [listener_main]: /vault/docs/configuration/listener/tcp


### PR DESCRIPTION
Looks like a copy/paste error, but yeah, this shouldn't be here (the links do not work, and this functionality is not supported for Vault Proxy).