### PR TITLE
Sync Success Banner

### DIFF
--- a/ui/lib/core/addon/components/kv-suggestion-input.hbs
+++ b/ui/lib/core/addon/components/kv-suggestion-input.hbs
@@ -4,7 +4,7 @@
 ~}}
 <div ...attributes {{did-update this.updateSuggestions @mountPath}}>
   {{#if @label}}
-    <FormFieldLabel @label={{@label}} @subText={{@subText}} />
+    <FormFieldLabel for={{this.inputId}} @label={{@label}} @subText={{@subText}} />
   {{/if}}
   <FilterInput
     id={{this.inputId}}

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
@@ -13,61 +13,75 @@
   }}
 />
 
-<form {{on "submit" (perform this.setAssociation)}} class="has-top-margin-xl">
-  <p class="is-label">Which secrets would you like us to sync?</p>
-  <p class="sub-text">
-    Select a KV engine mount and path to sync a secret to the destination.
-  </p>
-
+<form {{on "submit" (perform this.setAssociation)}} class={{unless (or this.error this.syncedSecret) "has-top-margin-m"}}>
   <MessageError @errorMessage={{this.error}} />
 
+  {{#if this.syncedSecret}}
+    <Hds::Alert @type="inline" @color="success" as |A|>
+      <A.Title>Successfully synced a secret</A.Title>
+      <A.Description data-test-sync-success-message>
+        Sync operation successfully initiated for "{{this.syncedSecret}}". You can continue on this page to sync more
+        secrets.
+      </A.Description>
+    </Hds::Alert>
+  {{/if}}
+
   <div class="has-top-margin-l">
-    {{#if this.mounts}}
-      <SearchSelect
-        @label="Select a mount for the KV engine"
-        @options={{this.mounts}}
-        @selectLimit={{1}}
-        @disallowNewItems={{true}}
-        @onChange={{this.setMount}}
-        data-test-sync-mount-select
-      />
-    {{else}}
-      <FormFieldLabel @label="Enter an existing KV engine mount" />
-      <FilterInput
-        placeholder="KV engine mount path"
-        value={{this.mountPath}}
-        @onInput={{fn (mut this.mountPath)}}
-        data-test-sync-mount-input
-      />
-    {{/if}}
 
-    <KvSuggestionInput
-      @label="Select a secret to sync"
-      @subText="Enter the full path to the secret. Suggestions will display below if permitted by policy."
-      @value={{this.secretPath}}
-      @mountPath={{this.mountPath}}
-      @onChange={{fn (mut this.secretPath)}}
-    />
+    <p class="is-label">Which secrets would you like us to sync?</p>
+    <p class="sub-text">
+      Select a KV engine mount and path to sync a secret to the destination.
+    </p>
 
-    <div class="field box is-fullwidth is-bottomless has-top-margin-xxxl">
-      <Hds::ButtonSet>
-        <Hds::Button
-          @text="Sync to destination"
-          @color="primary"
-          @icon={{if this.setAssociation.isRunning "loading"}}
-          type="submit"
-          disabled={{or (not (and this.mountPath this.secretPath)) this.isSecretDirectory this.setAssociation.isRunning}}
-          data-test-sync-submit
+    <div class="has-top-margin-l">
+      {{#if this.mounts}}
+        <SearchSelect
+          @label="Select a mount for the KV engine"
+          @options={{this.mounts}}
+          @selectLimit={{1}}
+          @disallowNewItems={{true}}
+          @onChange={{this.setMount}}
+          data-test-sync-mount-select
         />
-        <Hds::Button @text="Back" @color="secondary" {{on "click" this.back}} data-test-sync-cancel />
-      </Hds::ButtonSet>
-      {{#if this.isSecretDirectory}}
-        <AlertInline
-          @type="warning"
-          @message="Syncing secret directories is not available at this time, please type a path to a single secret"
-          class="has-top-margin-s"
+      {{else}}
+        <FormFieldLabel @label="Enter an existing KV engine mount" />
+        <FilterInput
+          placeholder="KV engine mount path"
+          value={{this.mountPath}}
+          @onInput={{fn (mut this.mountPath)}}
+          data-test-sync-mount-input
         />
       {{/if}}
+
+      <KvSuggestionInput
+        @label="Select a secret to sync"
+        @subText="Enter the full path to the secret. Suggestions will display below if permitted by policy."
+        @value={{this.secretPath}}
+        @mountPath={{this.mountPath}}
+        @onChange={{fn (mut this.secretPath)}}
+      />
+
+      <div class="field box is-fullwidth is-bottomless has-top-margin-xxxl">
+        <Hds::ButtonSet>
+          <Hds::Button
+            @text="Sync to destination"
+            @color="primary"
+            @icon={{if this.setAssociation.isRunning "loading"}}
+            type="submit"
+            disabled={{or (not (and this.mountPath this.secretPath)) this.isSecretDirectory this.setAssociation.isRunning}}
+            data-test-sync-submit
+          />
+          <Hds::Button @text="Back" @color="secondary" {{on "click" this.back}} data-test-sync-cancel />
+        </Hds::ButtonSet>
+        {{#if this.isSecretDirectory}}
+          <AlertInline
+            @type="warning"
+            @message="Syncing secret directories is not available at this time, please type a path to a single secret"
+            class="has-top-margin-s"
+          />
+        {{/if}}
+      </div>
+
     </div>
   </div>
 </form>

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
@@ -68,7 +68,7 @@
             @color="primary"
             @icon={{if this.setAssociation.isRunning "loading"}}
             type="submit"
-            disabled={{or (not (and this.mountPath this.secretPath)) this.isSecretDirectory this.setAssociation.isRunning}}
+            disabled={{this.isSubmitDisabled}}
             data-test-sync-submit
           />
           <Hds::Button @text="Back" @color="secondary" {{on "click" this.back}} data-test-sync-cancel />

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
@@ -44,8 +44,9 @@
           data-test-sync-mount-select
         />
       {{else}}
-        <FormFieldLabel @label="Enter an existing KV engine mount" />
+        <FormFieldLabel for="kv-mount-input" @label="Enter an existing KV engine mount" />
         <FilterInput
+          id="kv-mount-input"
           placeholder="KV engine mount path"
           value={{this.mountPath}}
           @onInput={{fn (mut this.mountPath)}}

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
@@ -79,6 +79,7 @@ export default class DestinationSyncPageComponent extends Component<Args> {
   setAssociation = task({}, async (event: Event) => {
     event.preventDefault();
     try {
+      this.syncedSecret = '';
       const { name: destinationName, type: destinationType } = this.args.destination;
       const mount = keyIsFolder(this.mountPath) ? this.mountPath.slice(0, -1) : this.mountPath; // strip trailing slash from mount path
       const association = this.store.createRecord('sync/association', {

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
@@ -41,6 +41,10 @@ export default class DestinationSyncPageComponent extends Component<Args> {
     return this.secretPath && keyIsFolder(this.secretPath);
   }
 
+  get isSubmitDisabled() {
+    return !this.mountPath || !this.secretPath || this.isSecretDirectory || this.setAssociation.isRunning;
+  }
+
   willDestroy(): void {
     this.store.clearDataset('sync/association');
     super.willDestroy();
@@ -72,8 +76,7 @@ export default class DestinationSyncPageComponent extends Component<Args> {
     this.mountPath = selected[0] || '';
   }
 
-  @task
-  *setAssociation(event: Event) {
+  setAssociation = task({}, async (event: Event) => {
     event.preventDefault();
     try {
       const { name: destinationName, type: destinationType } = this.args.destination;
@@ -84,10 +87,10 @@ export default class DestinationSyncPageComponent extends Component<Args> {
         mount,
         secretName: this.secretPath,
       });
-      yield association.save({ adapterOptions: { action: 'set' } });
+      await association.save({ adapterOptions: { action: 'set' } });
       this.syncedSecret = this.secretPath;
     } catch (error) {
       this.error = `Sync operation error: \n ${errorMessage(error)}`;
     }
-  }
+  });
 }

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
@@ -35,6 +35,7 @@ export default class DestinationSyncPageComponent extends Component<Args> {
   @tracked mountPath = '';
   @tracked secretPath = '';
   @tracked error = '';
+  @tracked syncedSecret = '';
 
   get isSecretDirectory() {
     return this.secretPath && keyIsFolder(this.secretPath);
@@ -84,10 +85,7 @@ export default class DestinationSyncPageComponent extends Component<Args> {
         secretName: this.secretPath,
       });
       yield association.save({ adapterOptions: { action: 'set' } });
-      // this message can be expanded after testing -- deliberately generic for now
-      this.flashMessages.success(
-        'Sync operation successfully initiated. Status will be updated on secret when complete.'
-      );
+      this.syncedSecret = this.secretPath;
     } catch (error) {
       this.error = `Sync operation error: \n ${errorMessage(error)}`;
     }

--- a/ui/tests/helpers/sync/sync-selectors.js
+++ b/ui/tests/helpers/sync/sync-selectors.js
@@ -31,6 +31,7 @@ export const PAGE = {
       mountInput: '[data-test-sync-mount-input]',
       submit: '[data-test-sync-submit]',
       cancel: '[data-test-sync-cancel]',
+      successMessage: '[data-test-sync-success-message]',
     },
     list: {
       icon: '[data-test-destination-icon]',

--- a/ui/tests/integration/components/sync/secrets/page/destinations/destination/sync-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations/destination/sync-test.js
@@ -17,7 +17,7 @@ import sinon from 'sinon';
 import { Response } from 'miragejs';
 
 const { destinations, searchSelect, messageError, kvSuggestion } = PAGE;
-const { mountSelect, mountInput, submit, cancel } = destinations.sync;
+const { mountSelect, mountInput, submit, cancel, successMessage } = destinations.sync;
 
 module('Integration | Component | sync | Secrets::Page::Destinations::Destination::Sync', function (hooks) {
   setupRenderingTest(hooks);
@@ -68,14 +68,14 @@ module('Integration | Component | sync | Secrets::Page::Destinations::Destinatio
   });
 
   test('it should sync secret', async function (assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     const { type, name } = this.destination;
     this.server.post(`/sys/sync/destinations/${type}/${name}/associations/set`, (schema, req) => {
       const data = JSON.parse(req.requestBody);
       const expected = { mount: 'my-kv', secret_name: 'my-secret' };
       assert.deepEqual(data, expected, 'Sync request made with mount and secret name');
-      return {};
+      return { data: { associated_secrets: {} } };
     });
 
     assert.dom(submit).isDisabled('Submit button is disabled when mount is not selected');
@@ -84,6 +84,9 @@ module('Integration | Component | sync | Secrets::Page::Destinations::Destinatio
     await click(kvSuggestion.input);
     await click(searchSelect.option(1));
     await click(submit);
+    assert
+      .dom(successMessage)
+      .includesText('Sync operation successfully initiated for "my-secret".', 'Success banner renders');
   });
 
   test('it should allow manual mount path input if kv mounts are not returned', async function (assert) {


### PR DESCRIPTION
This PR adds a success banner to the destination sync page since the user remains on the page and is able to sync more secrets.

![image](https://github.com/hashicorp/vault/assets/24611656/7f0cfa67-208e-4dc0-88dc-1fc75b167545)
