### PR TITLE
Audit related foibles

### DIFF
--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -436,16 +436,16 @@ func (b *Backend) Invalidate(_ context.Context) {
 // the audit.Backend interface.
 func (b *Backend) RegisterNodesAndPipeline(broker *eventlogger.Broker, name string) error {
 	for id, node := range b.nodeMap {
-		if err := broker.RegisterNode(id, node); err != nil {
+		if err := broker.RegisterNode(id, node, eventlogger.WithNodeRegistrationPolicy(eventlogger.DenyOverwrite)); err != nil {
 			return err
 		}
 	}
 
 	pipeline := eventlogger.Pipeline{
 		PipelineID: eventlogger.PipelineID(name),
-		EventType:  eventlogger.EventType("audit"),
+		EventType:  eventlogger.EventType(event.AuditType.String()),
 		NodeIDs:    b.nodeIDList,
 	}
 
-	return broker.RegisterPipeline(pipeline)
+	return broker.RegisterPipeline(pipeline, eventlogger.WithPipelineRegistrationPolicy(eventlogger.DenyOverwrite))
 }

--- a/builtin/audit/socket/backend.go
+++ b/builtin/audit/socket/backend.go
@@ -12,10 +12,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go-secure-stdlib/parseutil"
-
 	"github.com/hashicorp/eventlogger"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/internal/observability/event"
 	"github.com/hashicorp/vault/sdk/helper/salt"

--- a/builtin/audit/socket/backend.go
+++ b/builtin/audit/socket/backend.go
@@ -336,16 +336,16 @@ func (b *Backend) Invalidate(_ context.Context) {
 // the audit.Backend interface.
 func (b *Backend) RegisterNodesAndPipeline(broker *eventlogger.Broker, name string) error {
 	for id, node := range b.nodeMap {
-		if err := broker.RegisterNode(id, node); err != nil {
+		if err := broker.RegisterNode(id, node, eventlogger.WithNodeRegistrationPolicy(eventlogger.DenyOverwrite)); err != nil {
 			return err
 		}
 	}
 
 	pipeline := eventlogger.Pipeline{
 		PipelineID: eventlogger.PipelineID(name),
-		EventType:  eventlogger.EventType("audit"),
+		EventType:  eventlogger.EventType(event.AuditType.String()),
 		NodeIDs:    b.nodeIDList,
 	}
 
-	return broker.RegisterPipeline(pipeline)
+	return broker.RegisterPipeline(pipeline, eventlogger.WithPipelineRegistrationPolicy(eventlogger.DenyOverwrite))
 }

--- a/builtin/audit/syslog/backend.go
+++ b/builtin/audit/syslog/backend.go
@@ -245,16 +245,16 @@ func (b *Backend) Invalidate(_ context.Context) {
 // the audit.Backend interface.
 func (b *Backend) RegisterNodesAndPipeline(broker *eventlogger.Broker, name string) error {
 	for id, node := range b.nodeMap {
-		if err := broker.RegisterNode(id, node); err != nil {
+		if err := broker.RegisterNode(id, node, eventlogger.WithNodeRegistrationPolicy(eventlogger.DenyOverwrite)); err != nil {
 			return err
 		}
 	}
 
 	pipeline := eventlogger.Pipeline{
 		PipelineID: eventlogger.PipelineID(name),
-		EventType:  eventlogger.EventType("audit"),
+		EventType:  eventlogger.EventType(event.AuditType.String()),
 		NodeIDs:    b.nodeIDList,
 	}
 
-	return broker.RegisterPipeline(pipeline)
+	return broker.RegisterPipeline(pipeline, eventlogger.WithPipelineRegistrationPolicy(eventlogger.DenyOverwrite))
 }

--- a/helper/builtinplugins/builtinplugins_test.go
+++ b/helper/builtinplugins/builtinplugins_test.go
@@ -6,12 +6,11 @@ package builtinplugins
 import (
 	"testing"
 
-	"github.com/hashicorp/vault/audit"
-	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
-
 	logicalKv "github.com/hashicorp/vault-plugin-secrets-kv"
 	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/audit"
 	logicalDb "github.com/hashicorp/vault/builtin/logical/database"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"

--- a/helper/builtinplugins/builtinplugins_test.go
+++ b/helper/builtinplugins/builtinplugins_test.go
@@ -6,6 +6,9 @@ package builtinplugins
 import (
 	"testing"
 
+	"github.com/hashicorp/vault/audit"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
+
 	logicalKv "github.com/hashicorp/vault-plugin-secrets-kv"
 	"github.com/hashicorp/vault/api"
 	logicalDb "github.com/hashicorp/vault/builtin/logical/database"
@@ -43,6 +46,11 @@ func TestBuiltinPluginsWork(t *testing.T) {
 				"database": logicalDb.Factory,
 			},
 			PendingRemovalMountsAllowed: true,
+			// Specifying at least one audit backend factory will prevent NewTestCluster
+			// from attempting to enable a noop audit, and audit isn't required for this test.
+			AuditBackends: map[string]audit.Factory{
+				"noop": corehelpers.NoopAuditFactory(nil),
+			},
 		},
 		&vault.TestClusterOptions{
 			HandlerFunc: vaulthttp.Handler,

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -429,20 +429,20 @@ func (n *NoopAudit) Invalidate(_ context.Context) {
 
 // RegisterNodesAndPipeline registers the nodes and a pipeline as required by
 // the audit.Backend interface.
-func (b *NoopAudit) RegisterNodesAndPipeline(broker *eventlogger.Broker, name string) error {
-	for id, node := range b.nodeMap {
-		if err := broker.RegisterNode(id, node); err != nil {
+func (n *NoopAudit) RegisterNodesAndPipeline(broker *eventlogger.Broker, name string) error {
+	for id, node := range n.nodeMap {
+		if err := broker.RegisterNode(id, node, eventlogger.WithNodeRegistrationPolicy(eventlogger.DenyOverwrite)); err != nil {
 			return err
 		}
 	}
 
 	pipeline := eventlogger.Pipeline{
 		PipelineID: eventlogger.PipelineID(name),
-		EventType:  eventlogger.EventType("audit"),
-		NodeIDs:    b.nodeIDList,
+		EventType:  eventlogger.EventType(event.AuditType.String()),
+		NodeIDs:    n.nodeIDList,
 	}
 
-	return broker.RegisterPipeline(pipeline)
+	return broker.RegisterPipeline(pipeline, eventlogger.WithPipelineRegistrationPolicy(eventlogger.DenyOverwrite))
 }
 
 type TestLogger struct {

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -16,12 +16,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/vault/internal/observability/event"
-
 	"github.com/hashicorp/eventlogger"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/builtin/credential/approle"
+	"github.com/hashicorp/vault/internal/observability/event"
 	"github.com/hashicorp/vault/plugins/database/mysql"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/consts"

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -709,7 +709,6 @@ type TestCluster struct {
 	SetupFunc          func()
 
 	cleanupFuncs      []func()
-	base              *CoreConfig
 	LicensePublicKey  ed25519.PublicKey
 	LicensePrivateKey ed25519.PrivateKey
 	opts              *TestClusterOptions
@@ -1189,7 +1188,6 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 
 	baseAddr, certIPs := GenerateListenerAddr(t, opts, certIPs)
 	var testCluster TestCluster
-	testCluster.base = base
 
 	switch {
 	case opts != nil && opts.Logger != nil && !reflect.ValueOf(opts.Logger).IsNil():


### PR DESCRIPTION
* Prevent overwriting pipelines and nodes
* Remove unused bits of test cluster
* Test flaking didn't need audit, so supply a factory to prevent auto-enabling audit