### PR TITLE
Sync Destinations List Filter Bug

### DIFF
--- a/ui/app/serializers/sync/destination.js
+++ b/ui/app/serializers/sync/destination.js
@@ -48,10 +48,11 @@ export default class SyncDestinationSerializer extends ApplicationSerializer {
   }
 
   _normalizePayload(payload, requestType) {
-    if (payload?.data) {
-      if (requestType === 'query') {
-        return this.extractLazyPaginatedData(payload);
-      }
+    // if request is from lazyPaginatedQuery it will already have been extracted and meta will be set on object
+    // for store.query it will be the raw response which will need to be extracted
+    if (requestType === 'query') {
+      return payload.meta ? payload : this.extractLazyPaginatedData(payload);
+    } else if (payload?.data) {
       // uses name for id and spreads connection_details object into data
       const { data } = payload;
       const connection_details = payload.data.connection_details || {};

--- a/ui/lib/sync/addon/components/secrets/page/destinations.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations.ts
@@ -40,7 +40,7 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   get destinationTypes() {
     return this.args.destinations.reduce((types: Array<{ id: string; name: string }>, destination) => {
       const { typeDisplayName } = destination;
-      const isUnique = !types.find((type) => type.name === typeDisplayName);
+      const isUnique = !types.find((type) => type.id === typeDisplayName);
       if (isUnique) {
         types.push({ id: typeDisplayName, name: destination.type });
       }

--- a/ui/tests/acceptance/sync/secrets/destinations-test.js
+++ b/ui/tests/acceptance/sync/secrets/destinations-test.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import syncScenario from 'vault/mirage/scenarios/sync';
+import syncHandlers from 'vault/mirage/handlers/sync';
+import authPage from 'vault/tests/pages/auth';
+import { click, visit } from '@ember/test-helpers';
+import { PAGE } from 'vault/tests/helpers/sync/sync-selectors';
+
+const { searchSelect, filter, listItem } = PAGE;
+
+module('Acceptance | sync | destinations', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    syncScenario(this.server);
+    syncHandlers(this.server);
+    return authPage.login();
+  });
+
+  test('it should filter destinations list', async function (assert) {
+    await visit('vault/sync/secrets/destinations');
+    assert.dom(listItem).exists({ count: 6 }, 'All destinations render');
+    await click(`${filter('type')} .ember-basic-dropdown-trigger`);
+    await click(searchSelect.option());
+    assert.dom(listItem).exists({ count: 2 }, 'Filtered destinations render');
+  });
+});

--- a/ui/tests/helpers/general-selectors.js
+++ b/ui/tests/helpers/general-selectors.js
@@ -18,6 +18,7 @@ export const SELECTORS = {
   emptyStateMessage: '[data-test-empty-state-message]',
   emptyStateActions: '[data-test-empty-state-actions]',
   menuTrigger: '[data-test-popup-menu-trigger]',
+  listItem: '[data-test-list-item-link]',
   // FORMS
   infoRowValue: (label) => `[data-test-value-div="${label}"]`,
   inputByAttr: (attr) => `[data-test-input="${attr}"]`,


### PR DESCRIPTION
This PR fixes 2 bugs surrounding filtering of the destinations list view. The first where duplicate destination types were appearing in the type filter dropdown, and the second where destinations were not filtering properly based on the selections.

_Before. Notice the pagination totals are correct but all types are returned. The same would be true if we filtered by name._

![image](https://github.com/hashicorp/vault/assets/24611656/e4e1308e-f197-4ded-b898-a3d2611f5574)
_After_

![image](https://github.com/hashicorp/vault/assets/24611656/7484069a-b11e-4c92-a0ff-9c5c23acbb9a)
