### PR TITLE
UI Secrets sync: Add purge query param to delete endpoint

### DIFF
--- a/ui/app/adapters/sync/destination.js
+++ b/ui/app/adapters/sync/destination.js
@@ -25,12 +25,8 @@ export default class SyncDestinationAdapter extends ApplicationAdapter {
 
   urlForDeleteRecord(id, modelName, snapshot) {
     const { name, type } = snapshot.attributes();
-    // the modelName may be sync/destination or a child depending if it was initiated from the list or details view
-    // since the id for sync/destinations is type/name it will actually generate the correct url but the slash will be encoded
-    // if we normalize to use the child model name for url generation instead things will be consistent
-    const normalizedModelName =
-      modelName === 'sync/destination' ? `${pluralize(modelName)}/${type}` : modelName;
-    return `${super.urlForDeleteRecord(name, normalizedModelName, snapshot)}`;
+    // the only delete option in the UI is to purge which unsyncs all secrets prior to deleting
+    return `${this.buildURL('sync/destinations')}/${type}/${name}?purge=true`;
   }
 
   query(store, { modelName }) {

--- a/ui/tests/unit/adapters/sync/destinations-test.js
+++ b/ui/tests/unit/adapters/sync/destinations-test.js
@@ -125,10 +125,11 @@ module('Unit | Adapter | sync | destination', function (hooks) {
   });
 
   test('it should make request to correct endpoint for deleteRecord with base model', async function (assert) {
-    assert.expect(1);
+    assert.expect(2);
 
-    this.server.delete('/sys/sync/destinations/aws-sm/us-west-1?purge=true', () => {
+    this.server.delete('/sys/sync/destinations/aws-sm/us-west-1', (schema, req) => {
       assert.ok(true, 'DELETE request made to correct endpoint');
+      assert.propEqual(req.queryParams, { purge: 'true' }, 'Purge query param is passed in request');
       return {};
     });
 
@@ -144,12 +145,13 @@ module('Unit | Adapter | sync | destination', function (hooks) {
   });
 
   test('it should make request to correct endpoint for deleteRecord', async function (assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     const destination = this.server.create('sync-destination', 'aws-sm');
 
-    this.server.delete(`/sys/sync/destinations/${destination.type}/${destination.name}?purge=true`, () => {
+    this.server.delete(`/sys/sync/destinations/${destination.type}/${destination.name}`, (schema, req) => {
       assert.ok(true, 'DELETE request made to correct endpoint');
+      assert.propEqual(req.queryParams, { purge: 'true' }, 'Purge query param is passed in request');
       return {};
     });
 

--- a/ui/tests/unit/adapters/sync/destinations-test.js
+++ b/ui/tests/unit/adapters/sync/destinations-test.js
@@ -147,6 +147,7 @@ module('Unit | Adapter | sync | destination', function (hooks) {
     assert.expect(1);
 
     const destination = this.server.create('sync-destination', 'aws-sm');
+
     this.server.delete(`/sys/sync/destinations/${destination.type}/${destination.name}?purge=true`, () => {
       assert.ok(true, 'DELETE request made to correct endpoint');
       return {};

--- a/ui/tests/unit/adapters/sync/destinations-test.js
+++ b/ui/tests/unit/adapters/sync/destinations-test.js
@@ -127,7 +127,7 @@ module('Unit | Adapter | sync | destination', function (hooks) {
   test('it should make request to correct endpoint for deleteRecord with base model', async function (assert) {
     assert.expect(1);
 
-    this.server.delete('/sys/sync/destinations/aws-sm/us-west-1', () => {
+    this.server.delete('/sys/sync/destinations/aws-sm/us-west-1?purge=true', () => {
       assert.ok(true, 'DELETE request made to correct endpoint');
       return {};
     });
@@ -147,8 +147,7 @@ module('Unit | Adapter | sync | destination', function (hooks) {
     assert.expect(1);
 
     const destination = this.server.create('sync-destination', 'aws-sm');
-
-    this.server.delete(`/sys/sync/destinations/${destination.type}/${destination.name}`, () => {
+    this.server.delete(`/sys/sync/destinations/${destination.type}/${destination.name}?purge=true`, () => {
       assert.ok(true, 'DELETE request made to correct endpoint');
       return {};
     });


### PR DESCRIPTION
This PR adds the `?purge=true` query param which is working under the assumption that this PR is merged https://github.com/hashicorp/vault-enterprise/pull/5056