### PR TITLE
Sync sublogger level with parent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-discover v0.0.0-20210818145131-c573d69da192
 	github.com/hashicorp/go-gcp-common v0.8.0
-	github.com/hashicorp/go-hclog v1.5.0
+	github.com/hashicorp/go-hclog v1.6.2
 	github.com/hashicorp/go-kms-wrapping/entropy/v2 v2.0.0
 	github.com/hashicorp/go-kms-wrapping/v2 v2.0.13
 	github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2 v2.0.7-1

--- a/go.sum
+++ b/go.sum
@@ -2166,8 +2166,11 @@ github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39
 github.com/hashicorp/go-hclog v0.16.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v1.4.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
-github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+13c=
 github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-hclog v1.6.1 h1:pa92nu9bPoAqI7p+uPDCIWGAibUdlCi6TYWJEQQkLf8=
+github.com/hashicorp/go-hclog v1.6.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-hclog v1.6.2 h1:NOtoftovWkDheyUM/8JW3QMiXyxJK3uHRK7wV04nD2I=
+github.com/hashicorp/go-hclog v1.6.2/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=

--- a/helper/logging/logger.go
+++ b/helper/logging/logger.go
@@ -162,11 +162,11 @@ func Setup(config *LogConfig, w io.Writer) (hclog.InterceptLogger, error) {
 	}
 
 	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
-		Name:              config.Name,
-		Level:             config.LogLevel,
-		IndependentLevels: true,
-		Output:            io.MultiWriter(writers...),
-		JSONFormat:        config.isFormatJson(),
+		Name:            config.Name,
+		Level:           config.LogLevel,
+		SyncParentLevel: true,
+		Output:          io.MultiWriter(writers...),
+		JSONFormat:      config.isFormatJson(),
 	})
 
 	return logger, nil

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -475,14 +475,14 @@ func NewTestLogger(t testing.T) *TestLogger {
 	// We send nothing on the regular logger, that way we can later deregister
 	// the sink to stop logging during cluster cleanup.
 	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
-		Output:            io.Discard,
-		IndependentLevels: true,
-		Name:              t.Name(),
+		Output:          io.Discard,
+		SyncParentLevel: true,
+		Name:            t.Name(),
 	})
 	sink := hclog.NewSinkAdapter(&hclog.LoggerOptions{
-		Output:            output,
-		Level:             hclog.Trace,
-		IndependentLevels: true,
+		Output:          output,
+		Level:           hclog.Trace,
+		SyncParentLevel: true,
 	})
 	logger.RegisterSink(sink)
 

--- a/sdk/helper/logging/logging.go
+++ b/sdk/helper/logging/logging.go
@@ -45,10 +45,10 @@ func NewVaultLogger(level log.Level) log.Logger {
 // writer and a Vault formatter
 func NewVaultLoggerWithWriter(w io.Writer, level log.Level) log.Logger {
 	opts := &log.LoggerOptions{
-		Level:             level,
-		IndependentLevels: true,
-		Output:            w,
-		JSONFormat:        ParseEnvLogFormat() == JSONFormat,
+		Level:           level,
+		SyncParentLevel: true,
+		Output:          w,
+		JSONFormat:      ParseEnvLogFormat() == JSONFormat,
 	}
 	return log.New(opts)
 }


### PR DESCRIPTION
With the following commits, subloggers are now able to set their own levels while maintaining a hierarchical relationship to their parent/children.

https://github.com/hashicorp/go-hclog/pull/134
https://github.com/hashicorp/go-hclog/pull/137

This allows us to keep leaf sublogger levels in sync with their parent, unless specifically set otherwise.

As a result, we no longer have to track every leaf logger in the `(Core).allLoggers` slice. Instead, we can track main subsystem subloggers in `allLoggers` (e.g. `core.replication`), without having to manage every child (e.g. `core.replication.index`).

