### PR TITLE
Attempt to move control of registration for nodes and pipelines to the audit broker

### DIFF
--- a/audit/types.go
+++ b/audit/types.go
@@ -8,8 +8,8 @@ import (
 	"io"
 	"time"
 
-	"github.com/hashicorp/eventlogger"
 	"github.com/hashicorp/go-bexpr"
+	"github.com/hashicorp/vault/internal/observability/event"
 	"github.com/hashicorp/vault/sdk/helper/salt"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -275,6 +275,10 @@ type Backend interface {
 	// Salter interface must be implemented by anything implementing Backend.
 	Salter
 
+	// The Pipeliner interface allows backends to surface information about their
+	// nodes for node and pipeline registration.
+	event.Pipeliner
+
 	// LogRequest is used to synchronously log a request. This is done after the
 	// request is authorized but before the request is executed. The arguments
 	// MUST not be modified in any way. They should be deep copied if this is
@@ -298,12 +302,6 @@ type Backend interface {
 
 	// Invalidate is called for path invalidation
 	Invalidate(context.Context)
-
-	// RegisterNodesAndPipeline provides an eventlogger.Broker pointer so that
-	// the Backend can call its RegisterNode and RegisterPipeline methods with
-	// the nodes and the pipeline that were created in the corresponding
-	// Factory function.
-	RegisterNodesAndPipeline(*eventlogger.Broker, string) error
 }
 
 // BackendConfig contains configuration parameters used in the factory func to

--- a/builtin/audit/syslog/backend.go
+++ b/builtin/audit/syslog/backend.go
@@ -26,11 +26,12 @@ type Backend struct {
 	formatter    *audit.EntryFormatterWriter
 	formatConfig audit.FormatterConfig
 	logger       gsyslog.Syslogger
-	saltMutex    sync.RWMutex
+	name         string
 	nodeIDList   []eventlogger.NodeID
 	nodeMap      map[eventlogger.NodeID]eventlogger.Node
 	salt         *salt.Salt
 	saltConfig   *salt.Config
+	saltMutex    sync.RWMutex
 	saltView     logical.Storage
 }
 
@@ -69,10 +70,11 @@ func Factory(_ context.Context, conf *audit.BackendConfig, useEventLogger bool, 
 	}
 
 	b := &Backend{
+		formatConfig: cfg,
 		logger:       logger,
+		name:         conf.MountPath,
 		saltConfig:   conf.SaltConfig,
 		saltView:     conf.SaltView,
-		formatConfig: cfg,
 	}
 
 	// Configure the formatter for either case.
@@ -206,24 +208,6 @@ func (b *Backend) Invalidate(_ context.Context) {
 	b.salt = nil
 }
 
-// RegisterNodesAndPipeline registers the nodes and a pipeline as required by
-// the audit.Backend interface.
-func (b *Backend) RegisterNodesAndPipeline(broker *eventlogger.Broker, name string) error {
-	for id, node := range b.nodeMap {
-		if err := broker.RegisterNode(id, node, eventlogger.WithNodeRegistrationPolicy(eventlogger.DenyOverwrite)); err != nil {
-			return err
-		}
-	}
-
-	pipeline := eventlogger.Pipeline{
-		PipelineID: eventlogger.PipelineID(name),
-		EventType:  eventlogger.EventType(event.AuditType.String()),
-		NodeIDs:    b.nodeIDList,
-	}
-
-	return broker.RegisterPipeline(pipeline, eventlogger.WithPipelineRegistrationPolicy(eventlogger.DenyOverwrite))
-}
-
 // formatterConfig creates the configuration required by a formatter node using
 // the config map supplied to the factory.
 func formatterConfig(config map[string]string) (audit.FormatterConfig, error) {
@@ -337,4 +321,29 @@ func (b *Backend) configureSinkNode(name string, format string, opts ...event.Op
 	b.nodeIDList = append(b.nodeIDList, sinkNodeID)
 	b.nodeMap[sinkNodeID] = sinkNode
 	return nil
+}
+
+// Name for this backend, this would ideally correspond to the mount path for the audit device.
+func (b *Backend) Name() string {
+	return b.name
+}
+
+// Nodes returns the nodes which should be used by the event framework to process audit entries.
+func (b *Backend) Nodes() map[eventlogger.NodeID]eventlogger.Node {
+	return b.nodeMap
+}
+
+// NodeIDs returns the IDs of the nodes, in the order they are required.
+func (b *Backend) NodeIDs() []eventlogger.NodeID {
+	return b.nodeIDList
+}
+
+// EventType returns the event type for the backend.
+func (b *Backend) EventType() eventlogger.EventType {
+	return eventlogger.EventType(event.AuditType.String())
+}
+
+// IsFilteringPipeline determines if the first node for the pipeline is an eventlogger.NodeTypeFilter.
+func (b *Backend) IsFilteringPipeline() bool {
+	return len(b.nodeIDList) > 0 && b.nodeMap[b.nodeIDList[0]].Type() == eventlogger.NodeTypeFilter
 }

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -331,7 +331,7 @@ func (n *NoopAudit) IsFilteringPipeline() bool {
 }
 
 func (n *NoopAudit) Name() string {
-	return "noop"
+	return "noop/"
 }
 
 func (n *NoopAudit) Nodes() map[eventlogger.NodeID]eventlogger.Node {

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -293,6 +293,8 @@ func NoopAuditFactory(records **[][]byte) audit.Factory {
 	}
 }
 
+var _ audit.Backend = (*NoopAudit)(nil)
+
 type NoopAudit struct {
 	Config         *audit.BackendConfig
 	ReqErr         error
@@ -318,6 +320,26 @@ type NoopAudit struct {
 
 	nodeIDList []eventlogger.NodeID
 	nodeMap    map[eventlogger.NodeID]eventlogger.Node
+}
+
+func (n *NoopAudit) EventType() eventlogger.EventType {
+	return eventlogger.EventType(event.AuditType.String())
+}
+
+func (n *NoopAudit) IsFilteringPipeline() bool {
+	return false
+}
+
+func (n *NoopAudit) Name() string {
+	return "noop"
+}
+
+func (n *NoopAudit) Nodes() map[eventlogger.NodeID]eventlogger.Node {
+	return n.nodeMap
+}
+
+func (n *NoopAudit) NodeIDs() []eventlogger.NodeID {
+	return n.nodeIDList
 }
 
 func (n *NoopAudit) LogRequest(ctx context.Context, in *logical.LogInput) error {

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -226,6 +226,8 @@ func TestNoopAudit(t testing.T, config map[string]string) *NoopAudit {
 
 func NewNoopAudit(config *audit.BackendConfig) (*NoopAudit, error) {
 	view := &logical.InmemStorage{}
+
+	// Set the salt to be a known key and value for comparing hash values in tests.
 	err := view.Put(context.Background(), &logical.StorageEntry{
 		Key:   "salt",
 		Value: []byte("foo"),
@@ -234,15 +236,11 @@ func NewNoopAudit(config *audit.BackendConfig) (*NoopAudit, error) {
 		return nil, err
 	}
 
-	if config.SaltView == nil {
-		config.SaltView = view
-	}
-
-	if config.SaltConfig == nil {
-		config.SaltConfig = &salt.Config{
-			HMAC:     sha256.New,
-			HMACType: "hmac-sha256",
-		}
+	// Override parts of config for testing purposes.
+	config.SaltView = view
+	config.SaltConfig = &salt.Config{
+		HMAC:     sha256.New,
+		HMACType: "hmac-sha256",
 	}
 
 	n := &NoopAudit{Config: config}

--- a/internal/observability/event/pipeliner.go
+++ b/internal/observability/event/pipeliner.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package event
+
+import "github.com/hashicorp/eventlogger"
+
+// The Pipeliner interface surfaces information required for pipeline registration.
+type Pipeliner interface {
+	// EventType returns the event type to be used for registration.
+	EventType() eventlogger.EventType
+
+	// IsFilteringPipeline determines whether the pipeline uses filtering.
+	IsFilteringPipeline() bool
+
+	// Name for the pipeline which should be used for the eventlogger.PipelineID.
+	Name() string
+
+	// Nodes returns the nodes which should be used by the framework to process events.
+	Nodes() map[eventlogger.NodeID]eventlogger.Node
+
+	// NodeIDs returns the IDs of the nodes, in the order they are required.
+	NodeIDs() []eventlogger.NodeID
+}

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -538,7 +538,6 @@ func (c *Core) newAuditBackend(ctx context.Context, entry *MountEntry, view logi
 	}
 
 	auditLogger := c.baseLogger.Named("audit")
-	c.AddLogger(auditLogger)
 
 	switch entry.Type {
 	case "file":
@@ -569,6 +568,7 @@ func (c *Core) newAuditBackend(ctx context.Context, entry *MountEntry, view logi
 		}
 	}
 
+	c.AddLogger(auditLogger)
 	return be, err
 }
 

--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -57,6 +57,8 @@ func NewAuditBroker(log log.Logger, useEventLogger bool) (*AuditBroker, error) {
 
 // Register is used to add new audit backend to the broker
 func (a *AuditBroker) Register(name string, b audit.Backend, local bool) error {
+	const op = "vault.(AuditBroker).Register"
+
 	a.Lock()
 	defer a.Unlock()
 
@@ -66,16 +68,36 @@ func (a *AuditBroker) Register(name string, b audit.Backend, local bool) error {
 	}
 
 	if a.broker != nil {
-		// Attempt to register the pipeline before enabling 'broker level' enforcement
-		// of how many successful sinks we expect.
-		err := b.RegisterNodesAndPipeline(a.broker, name)
-		if err != nil {
-			return err
+		if name != b.Name() {
+			return fmt.Errorf("%s: audit registration failed due to device name mismatch: %q, %q", op, name, b.Name())
 		}
-		// Update the success threshold now that the pipeline is registered.
-		err = a.broker.SetSuccessThresholdSinks(eventlogger.EventType(event.AuditType.String()), 1)
+
+		for id, node := range b.Nodes() {
+			err := a.broker.RegisterNode(id, node, eventlogger.WithNodeRegistrationPolicy(eventlogger.DenyOverwrite))
+			if err != nil {
+				return fmt.Errorf("%s: unable to register nodes for %q: %w", op, name, err)
+			}
+		}
+
+		pipeline := eventlogger.Pipeline{
+			PipelineID: eventlogger.PipelineID(b.Name()),
+			EventType:  b.EventType(),
+			NodeIDs:    b.NodeIDs(),
+		}
+
+		err := a.broker.RegisterPipeline(pipeline, eventlogger.WithPipelineRegistrationPolicy(eventlogger.DenyOverwrite))
 		if err != nil {
-			return err
+			return fmt.Errorf("%s: unable to register pipeline for %q: %w", op, name, err)
+		}
+
+		// Establish if we ONLY have pipelines that include filter nodes.
+		// Otherwise, we can rely on the eventlogger broker guarantee.
+		threshold := a.requiredSuccessThresholdSinks()
+
+		// Update the success threshold now that the pipeline is registered.
+		err = a.broker.SetSuccessThresholdSinks(eventlogger.EventType(event.AuditType.String()), threshold)
+		if err != nil {
+			return fmt.Errorf("%s: unable to configure sink success threshold (%d) for %q: %w", op, threshold, name, err)
 		}
 	}
 
@@ -84,6 +106,8 @@ func (a *AuditBroker) Register(name string, b audit.Backend, local bool) error {
 
 // Deregister is used to remove an audit backend from the broker
 func (a *AuditBroker) Deregister(ctx context.Context, name string) error {
+	const op = "vault.(AuditBroker).Deregister"
+
 	a.Lock()
 	defer a.Unlock()
 
@@ -93,20 +117,22 @@ func (a *AuditBroker) Deregister(ctx context.Context, name string) error {
 	delete(a.backends, name)
 
 	if a.broker != nil {
-		if len(a.backends) == 0 {
-			err := a.broker.SetSuccessThresholdSinks(eventlogger.EventType(event.AuditType.String()), 0)
-			if err != nil {
-				return err
-			}
+		// Establish if we ONLY have pipelines that include filter nodes.
+		// Otherwise, we can rely on the eventlogger broker guarantee.
+		threshold := a.requiredSuccessThresholdSinks()
+
+		err := a.broker.SetSuccessThresholdSinks(eventlogger.EventType(event.AuditType.String()), threshold)
+		if err != nil {
+			return fmt.Errorf("%s: unable to configure sink success threshold (%d) for %q: %w", op, threshold, name, err)
 		}
 
 		// The first return value, a bool, indicates whether
 		// RemovePipelineAndNodes encountered the error while evaluating
 		// pre-conditions (false) or once it started removing the pipeline and
 		// the nodes (true). This code doesn't care either way.
-		_, err := a.broker.RemovePipelineAndNodes(ctx, eventlogger.EventType(event.AuditType.String()), eventlogger.PipelineID(name))
+		_, err = a.broker.RemovePipelineAndNodes(ctx, eventlogger.EventType(event.AuditType.String()), eventlogger.PipelineID(name))
 		if err != nil {
-			return err
+			return fmt.Errorf("%s: unable to remove pipeline and nodes for %q: %w", op, name, err)
 		}
 	}
 
@@ -332,4 +358,20 @@ func (a *AuditBroker) Invalidate(ctx context.Context, key string) {
 	for _, be := range a.backends {
 		be.backend.Invalidate(ctx)
 	}
+}
+
+// requiredSuccessThresholdSinks returns the value that should be used for configuring
+// success threshold sinks on the eventlogger broker.
+// If all backends have nodes which provide filtering, then we cannot rely on the
+// guarantee provided by setting the threshold to 1, and must set it to 0.
+func (a *AuditBroker) requiredSuccessThresholdSinks() int {
+	threshold := 0
+	for _, be := range a.backends {
+		if !be.backend.IsFilteringPipeline() {
+			threshold = 1
+			break
+		}
+	}
+
+	return threshold
 }


### PR DESCRIPTION
This PR tries to provide `AuditBroker` with more information to let it manage pipelines and set the success threshold (for sinks) based on whether we have:

* Only non-filtering pipelines
* Mixed filtering and non-filtering pipelines
* Only filtering pipelines