### PR TITLE
Quote example domains within ACME entity docs

### DIFF
--- a/website/content/docs/concepts/client-count/index.mdx
+++ b/website/content/docs/concepts/client-count/index.mdx
@@ -72,12 +72,12 @@ For example:
 - ACME client requests (from the same server or separate servers) for the same
   certificate identifier (a unique combination of CN,DNS, SANS and IP SANS)
   are treated as the same entities.
-- If an ACME client makes a request for a.test.com, and subsequently makes a new
-  request for b.test.com and *.test.com then two distinct entities will be created,
-  one for a.test.com and another for the combination of b.test.com and *.test.com.
+- If an ACME client makes a request for `a.test.com`, and subsequently makes a new
+  request for `b.test.com` and `*.test.com` then two distinct entities will be created,
+  one for `a.test.com` and another for the combination of `b.test.com` and `*.test.com`.
 - Overlap of certificate identifiers from different ACME clients will be treated
-  as the same entity e.g. if client 1 request a.test.com and client 2 requests
-  a.test.com a single entity is created for both requests.
+  as the same entity e.g. if client 1 requests `a.test.com` and client 2 requests
+  `a.test.com` a single entity is created for both requests.
 
 ## Entity assignment with namespaces
 


### PR DESCRIPTION
 - The existing bare *.test.com triggered italics and stripped the * from the output 🤕 

<img width="695" alt="rendered" src="https://github.com/hashicorp/vault/assets/3989899/798ef95e-2adc-4770-b006-96ff73131e0f">
