### PR TITLE
pause and unpause for jobmanager

### DIFF
--- a/changelog/24511.txt
+++ b/changelog/24511.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+fairshare/jobmanager: Add pause/unpause method to JobManager. Remove Stopped method.
+```


### PR DESCRIPTION
Adds two methods, `Pause` and `Unpause` for the JobManager. I reached for adding new methods instead of modifying `Start` and `Stop` to be invoked more than once, in case there was a reason why it was implemented that way.

Also ended up removing the `Stopped` method, which we added a few weeks ago. It ended up not being needed for our use case.

