### PR TITLE
Consistently refer to Key Value secrets engine as KV

### DIFF
--- a/changelog/24529.txt
+++ b/changelog/24529.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+website/docs: Update references to Key Value secrets engine from 'K/V' to 'KV'
+```

--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -216,7 +216,7 @@ func (c *KVPatchCommand) Run(args []string) int {
 	}
 
 	if !v2 {
-		c.UI.Error("K/V engine mount must be version 2 for patch support")
+		c.UI.Error("KV engine mount must be version 2 for patch support")
 		return 2
 	}
 

--- a/command/kv_rollback.go
+++ b/command/kv_rollback.go
@@ -160,7 +160,7 @@ func (c *KVRollbackCommand) Run(args []string) int {
 	}
 
 	if !v2 {
-		c.UI.Error("K/V engine mount must be version 2 for rollback support")
+		c.UI.Error("KV engine mount must be version 2 for rollback support")
 		return 2
 	}
 

--- a/command/server.go
+++ b/command/server.go
@@ -2066,10 +2066,10 @@ func (c *ServerCommand) enableDev(core *vault.Core, coreConfig *vault.CoreConfig
 	}
 	resp, err := core.HandleRequest(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("error creating default K/V store: %w", err)
+		return nil, fmt.Errorf("error creating default KV store: %w", err)
 	}
 	if resp.IsError() {
-		return nil, fmt.Errorf("failed to create default K/V store: %w", resp.Error())
+		return nil, fmt.Errorf("failed to create default KV store: %w", resp.Error())
 	}
 
 	return init, nil

--- a/ui/app/models/auth-method.js
+++ b/ui/app/models/auth-method.js
@@ -51,7 +51,7 @@ const ModelExport = AuthMethodModel.extend({
   }),
   sealWrap: attr('boolean', {
     helpText:
-      'When enabled - if a seal supporting seal wrapping is specified in the configuration, all critical security parameters (CSPs) in this backend will be seal wrapped. (For K/V mounts, all values will be seal wrapped.) This can only be specified at mount time.',
+      'When enabled - if a seal supporting seal wrapping is specified in the configuration, all critical security parameters (CSPs) in this backend will be seal wrapped. (For KV mounts, all values will be seal wrapped.) This can only be specified at mount time.',
   }),
 
   // used when the `auth` prefix is important,

--- a/ui/app/models/secret-engine.js
+++ b/ui/app/models/secret-engine.js
@@ -52,7 +52,7 @@ export default class SecretEngineModel extends Model {
   local;
   @attr('boolean', {
     helpText:
-      'When enabled - if a seal supporting seal wrapping is specified in the configuration, all critical security parameters (CSPs) in this backend will be seal wrapped. (For K/V mounts, all values will be seal wrapped.) This can only be specified at mount time.',
+      'When enabled - if a seal supporting seal wrapping is specified in the configuration, all critical security parameters (CSPs) in this backend will be seal wrapped. (For KV mounts, all values will be seal wrapped.) This can only be specified at mount time.',
   })
   sealWrap;
   @attr('boolean') externalEntropyAccess;

--- a/ui/app/templates/components/wizard/kv-engine.hbs
+++ b/ui/app/templates/components/wizard/kv-engine.hbs
@@ -4,9 +4,9 @@
 ~}}
 
 <WizardSection
-  @headerText="Key/Value"
+  @headerText="Key Value"
   @headerIcon="list"
-  @docText="Docs: Key/Value Secrets"
+  @docText="Docs: Key Value Secrets"
   @docPath="/docs/secrets/kv/index.html"
 >
   <p>

--- a/ui/lib/core/addon/components/secret-list-header.hbs
+++ b/ui/lib/core/addon/components/secret-list-header.hbs
@@ -25,7 +25,7 @@
         {{@model.id}}
         {{#if this.isKV}}
           <span class="tag" data-test-kv-version-badge>
-            Version
+            version
             {{or @model.version "1"}}
           </span>
         {{/if}}

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -12,7 +12,7 @@
       {{#if @mountName}}
         <Icon @name="kv" @size="24" class="has-text-grey-light" />
         {{@mountName}}
-        <span class="tag">Version 2</span>
+        <span class="tag">version 2</span>
       {{else}}
         {{@pageTitle}}
       {{/if}}

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -95,7 +95,7 @@ module('Acceptance | kv-v2 workflow | edge cases', function (hooks) {
       );
 
       // Title correct
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`);
+      assert.dom(PAGE.title).hasText(`${backend} version 2`);
       // Tabs correct
       assert.dom(PAGE.secretTab('Secrets')).hasText('Secrets');
       assert.dom(PAGE.secretTab('Secrets')).hasClass('active');

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
@@ -117,7 +117,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       // Breadcrumbs correct
       assertCorrectBreadcrumbs(assert, ['secrets', backend]);
       // Title correct
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`);
+      assert.dom(PAGE.title).hasText(`${backend} version 2`);
       // Tabs correct
       assert.dom(PAGE.secretTab('Secrets')).hasText('Secrets');
       assert.dom(PAGE.secretTab('Secrets')).hasClass('active');
@@ -163,7 +163,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.expect(40);
       const backend = this.backend;
       await navToBackend(backend);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'title text correct');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title text correct');
       assert.dom(PAGE.emptyStateTitle).doesNotExist('No empty state');
       assertCorrectBreadcrumbs(assert, ['secret', backend]);
       assert.dom(PAGE.list.filter).hasNoValue('List filter input is empty');
@@ -172,14 +172,14 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       await click(PAGE.list.item('app/'));
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list/app/`);
       assertCorrectBreadcrumbs(assert, ['secret', backend, 'app']);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`);
+      assert.dom(PAGE.title).hasText(`${backend} version 2`);
       assert.dom(PAGE.list.filter).hasValue('app/', 'List filter input is prefilled');
       assert.dom(PAGE.list.item('nested/')).exists('Shows nested secret');
 
       await click(PAGE.list.item('nested/'));
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list/app/nested/`);
       assertCorrectBreadcrumbs(assert, ['secret', backend, 'app', 'nested']);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`);
+      assert.dom(PAGE.title).hasText(`${backend} version 2`);
       assert.dom(PAGE.list.filter).hasValue('app/nested/', 'List filter input is prefilled');
       assert.dom(PAGE.list.item('secret')).exists('Shows deeply nested secret');
 
@@ -322,11 +322,11 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
       assertCorrectBreadcrumbs(assert, ['secrets', backend, 'configuration']);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'correct page title for configuration');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for configuration');
 
       await click(PAGE.secretTab('Secrets'));
       assertCorrectBreadcrumbs(assert, ['secrets', backend]);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'correct page title for secret list');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for secret list');
 
       await click(PAGE.list.item(secretPath));
       assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath]);
@@ -379,7 +379,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       // Breadcrumbs correct
       assertCorrectBreadcrumbs(assert, ['secrets', backend]);
       // Title correct
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`);
+      assert.dom(PAGE.title).hasText(`${backend} version 2`);
       // Tabs correct
       assert.dom(PAGE.secretTab('Secrets')).hasText('Secrets');
       assert.dom(PAGE.secretTab('Secrets')).hasClass('active');
@@ -423,7 +423,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.expect(23);
       const backend = this.backend;
       await navToBackend(backend);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'title text correct');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title text correct');
       assert.dom(PAGE.emptyStateTitle).doesNotExist('No empty state');
       assertCorrectBreadcrumbs(assert, ['secret', backend]);
       assert
@@ -509,11 +509,11 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
       assertCorrectBreadcrumbs(assert, ['secrets', backend, 'configuration']);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'title correct on config page');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title correct on config page');
 
       await click(PAGE.secretTab('Secrets'));
       assertCorrectBreadcrumbs(assert, ['secrets', backend]);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'title correct on secrets list');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title correct on secrets list');
 
       await typeIn(PAGE.list.overviewInput, 'app/nested/secret');
       await click(PAGE.list.overviewButton);
@@ -560,7 +560,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       // Breadcrumbs correct
       assertCorrectBreadcrumbs(assert, ['secrets', backend]);
       // Title correct
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`);
+      assert.dom(PAGE.title).hasText(`${backend} version 2`);
       // Tabs correct
       assert.dom(PAGE.secretTab('Secrets')).hasText('Secrets');
       assert.dom(PAGE.secretTab('Secrets')).hasClass('active');
@@ -606,7 +606,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.expect(31);
       const backend = this.backend;
       await navToBackend(backend);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'title text correct');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title text correct');
       assert.dom(PAGE.emptyStateTitle).doesNotExist('No empty state');
       assertCorrectBreadcrumbs(assert, ['secret', backend]);
       assert.dom(PAGE.list.filter).hasNoValue('List filter input is empty');
@@ -615,7 +615,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       await click(PAGE.list.item('app/'));
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list/app/`);
       assertCorrectBreadcrumbs(assert, ['secret', backend, 'app']);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`);
+      assert.dom(PAGE.title).hasText(`${backend} version 2`);
       assert.dom(PAGE.list.filter).doesNotExist('List filter hidden since no nested list access');
 
       assert
@@ -697,11 +697,11 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
 
       await click(PAGE.secretTab('Configuration'));
       assertCorrectBreadcrumbs(assert, ['secrets', backend, 'configuration']);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'correct page title for configuration');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for configuration');
 
       await click(PAGE.secretTab('Secrets'));
       assertCorrectBreadcrumbs(assert, ['secrets', backend]);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'correct page title for secret list');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for secret list');
 
       await click(PAGE.list.item(secretPath));
       assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath]);
@@ -746,7 +746,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       // Breadcrumbs correct
       assertCorrectBreadcrumbs(assert, ['secrets', backend]);
       // Title correct
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`);
+      assert.dom(PAGE.title).hasText(`${backend} version 2`);
       // Tabs correct
       assert.dom(PAGE.secretTab('Secrets')).hasText('Secrets');
       assert.dom(PAGE.secretTab('Secrets')).hasClass('active');
@@ -792,7 +792,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.expect(41);
       const backend = this.backend;
       await navToBackend(backend);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'title text correct');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title text correct');
       assert.dom(PAGE.emptyStateTitle).doesNotExist('No empty state');
       assertCorrectBreadcrumbs(assert, ['secret', backend]);
       assert.dom(PAGE.list.filter).hasNoValue('List filter input is empty');
@@ -801,14 +801,14 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       await click(PAGE.list.item('app/'));
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list/app/`);
       assertCorrectBreadcrumbs(assert, ['secret', backend, 'app']);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`);
+      assert.dom(PAGE.title).hasText(`${backend} version 2`);
       assert.dom(PAGE.list.filter).hasValue('app/', 'List filter input is prefilled');
       assert.dom(PAGE.list.item('nested/')).exists('Shows nested secret');
 
       await click(PAGE.list.item('nested/'));
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list/app/nested/`);
       assertCorrectBreadcrumbs(assert, ['secret', backend, 'app', 'nested']);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`);
+      assert.dom(PAGE.title).hasText(`${backend} version 2`);
       assert.dom(PAGE.list.filter).hasValue('app/nested/', 'List filter input is prefilled');
       assert.dom(PAGE.list.item('secret')).exists('Shows deeply nested secret');
 
@@ -912,11 +912,11 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
       assertCorrectBreadcrumbs(assert, ['secrets', backend, 'configuration']);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'correct page title for configuration');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for configuration');
 
       await click(PAGE.secretTab('Secrets'));
       assertCorrectBreadcrumbs(assert, ['secrets', backend]);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'correct page title for secret list');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for secret list');
 
       await click(PAGE.list.item(secretPath));
       assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath]);
@@ -964,7 +964,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       // Breadcrumbs correct
       assertCorrectBreadcrumbs(assert, ['secrets', backend]);
       // Title correct
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`);
+      assert.dom(PAGE.title).hasText(`${backend} version 2`);
       // Tabs correct
       assert.dom(PAGE.secretTab('Secrets')).hasText('Secrets');
       assert.dom(PAGE.secretTab('Secrets')).hasClass('active');
@@ -997,7 +997,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.expect(23);
       const backend = this.backend;
       await navToBackend(backend);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'title text correct');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title text correct');
       assert.dom(PAGE.emptyStateTitle).doesNotExist('No empty state');
       assertCorrectBreadcrumbs(assert, ['secret', backend]);
       assert.dom(PAGE.list.filter).doesNotExist('List filter input is not rendered');
@@ -1110,11 +1110,11 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
       assertCorrectBreadcrumbs(assert, ['secrets', backend, 'configuration']);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'correct page title for configuration');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for configuration');
 
       await click(PAGE.secretTab('Secrets'));
       assertCorrectBreadcrumbs(assert, ['secrets', backend]);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'correct page title for secret list');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for secret list');
 
       await typeIn(PAGE.list.overviewInput, secretPath);
       await click(PAGE.list.overviewButton);
@@ -1173,7 +1173,7 @@ path "${this.backend}/*" {
       assert.expect(42);
       const backend = this.backend;
       await navToBackend(backend);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'title text correct');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title text correct');
       assert.dom(PAGE.emptyStateTitle).doesNotExist('No empty state');
       assertCorrectBreadcrumbs(assert, ['secret', backend]);
       assert.dom(PAGE.list.filter).hasNoValue('List filter input is empty');
@@ -1182,14 +1182,14 @@ path "${this.backend}/*" {
       await click(PAGE.list.item('app/'));
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list/app/`);
       assertCorrectBreadcrumbs(assert, ['secret', backend, 'app']);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`);
+      assert.dom(PAGE.title).hasText(`${backend} version 2`);
       assert.dom(PAGE.list.filter).hasValue('app/', 'List filter input is prefilled');
       assert.dom(PAGE.list.item('nested/')).exists('Shows nested secret');
 
       await click(PAGE.list.item('nested/'));
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list/app/nested/`);
       assertCorrectBreadcrumbs(assert, ['secret', backend, 'app', 'nested']);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`);
+      assert.dom(PAGE.title).hasText(`${backend} version 2`);
       assert.dom(PAGE.list.filter).hasValue('app/nested/', 'List filter input is prefilled');
       assert.dom(PAGE.list.item('secret')).exists('Shows deeply nested secret');
 
@@ -1242,11 +1242,11 @@ path "${this.backend}/*" {
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
       assertCorrectBreadcrumbs(assert, ['secrets', backend, 'configuration']);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'correct page title for configuration');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for configuration');
 
       await click(PAGE.secretTab('Secrets'));
       assertCorrectBreadcrumbs(assert, ['secrets', backend]);
-      assert.dom(PAGE.title).hasText(`${backend} Version 2`, 'correct page title for secret list');
+      assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for secret list');
 
       await visit(`/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/details`);
 

--- a/ui/tests/integration/components/kv/kv-page-header-test.js
+++ b/ui/tests/integration/components/kv/kv-page-header-test.js
@@ -70,7 +70,7 @@ module('Integration | Component | kv | kv-page-header', function (hooks) {
     });
     assert
       .dom('[data-test-header-title]')
-      .hasText(`${this.backend} Version 2`, 'Mount path and Version tag render for title.');
+      .hasText(`${this.backend} version 2`, 'Mount path and version tag render for title.');
     assert.dom('[data-test-header-title] span').hasClass('hs-icon', 'An icon renders next to title.');
   });
 

--- a/ui/tests/integration/components/secret-list-header-test.js
+++ b/ui/tests/integration/components/secret-list-header-test.js
@@ -35,7 +35,7 @@ module('Integration | Component | secret-list-header', function (hooks) {
         assert
           .dom(selector)
           .hasText(
-            `Version ${this.model.version || 1}`,
+            `version ${this.model.version || 1}`,
             `Badge renders with correct version for ${type} engine type`
           );
       } else {

--- a/website/content/api-docs/index.mdx
+++ b/website/content/api-docs/index.mdx
@@ -90,7 +90,7 @@ Vault sets the `Content-Type` header appropriately with its response and does
 not require it from the clients request.
 
 The demonstration below uses the [`KVv1` secrets engine](/vault/api-docs/secret/kv/kv-v1), which is a
-simple Key/Value store. Please read [the API documentation of KV secret engines](/vault/api-docs/secret/kv)
+simple Key Value store. Please read [the API documentation of KV secret engines](/vault/api-docs/secret/kv)
 for details of `KVv1` compared to `KVv2` and how they differ in their URI paths
 as well as the features available in version 2 of the KV secrets engine.
 

--- a/website/content/api-docs/system/lease-count-quotas.mdx
+++ b/website/content/api-docs/system/lease-count-quotas.mdx
@@ -38,7 +38,7 @@ millions of leases in an automated way, it is recommended to space out the creat
   A blank path configures a global lease count quota. For example `namespace1/`
   adds a quota to a full namespace, `namespace1/auth/userpass` adds a quota to
   `userpass` in `namespace1`, and `namespace1/kv-v2/data/foo/bar` adds a quota to
-  a specific secret on a K/V v2 mount in `namespace1`. A trailing glob (`*`) can also
+  a specific secret on a KV v2 mount in `namespace1`. A trailing glob (`*`) can also
   be added as part of the path after the mount to match paths that share the same prefix
   prior to the glob. `namespace1/kv-v2/data/foo/*` would match both `namespace1/kv-v2/data/foo/bar`
   and `namespace1/kv-v2/data/foo/baz`. Updating this field on an existing

--- a/website/content/api-docs/system/rate-limit-quotas.mdx
+++ b/website/content/api-docs/system/rate-limit-quotas.mdx
@@ -28,7 +28,7 @@ the mount to restrict more specific API paths.
   A blank path configures a global rate limit quota. For example `namespace1/`
   adds a quota to a full namespace, `namespace1/auth/userpass` adds a quota to
   `userpass` in `namespace1`, and `namespace1/kv-v2/data/foo/bar` adds a quota to
-  a specific secret on a K/V v2 mount in `namespace1`. A trailing glob (`*`) can also
+  a specific secret on a KV v2 mount in `namespace1`. A trailing glob (`*`) can also
   be added as part of the path after the mount to match paths that share the same prefix
   prior to the glob. `namespace1/kv-v2/data/foo/*` would match both
   `namespace1/kv-v2/data/foo/bar` and `namespace1/kv-v2/data/foo/baz`. Updating this field on

--- a/website/content/docs/commands/kv/delete.mdx
+++ b/website/content/docs/commands/kv/delete.mdx
@@ -8,7 +8,7 @@ description: |-
 # kv delete
 
 The `kv delete` command deletes the data for the provided path in
-the key/value secrets engine. If using K/V Version 2, its versioned data will
+the key/value secrets engine. If using KV version 2, its versioned data will
 not be fully removed, but marked as deleted and will no longer be returned in
 normal get requests.
 
@@ -21,7 +21,7 @@ $ vault kv delete -mount=secret creds
 Success! Data deleted (if it existed) at: secret/creds
 ```
 
-**[K/V Version 2]** Delete version 11 of key "creds":
+**[KV version 2]** Delete version 11 of key "creds":
 
 ```shell-session
 $ vault kv delete -mount=secret -versions=11 creds
@@ -45,4 +45,4 @@ included on all commands.
   data will not be deleted, but it will no longer be returned in normal get
   requests.
 
-~> **NOTE:** The `-versions` command option is only for K/V v2.
+~> **NOTE:** The `-versions` command option is only for KV v2.

--- a/website/content/docs/commands/kv/destroy.mdx
+++ b/website/content/docs/commands/kv/destroy.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # kv destroy
 
-~> **NOTE:** This is a [K/V Version 2](/vault/docs/secrets/kv/kv-v2) secrets
+~> **NOTE:** This is a [KV version 2](/vault/docs/secrets/kv/kv-v2) secrets
 engine command, and not available for Version 1.
 
 The `kv destroy` command permanently removes the specified versions' data

--- a/website/content/docs/commands/kv/enable-versioning.mdx
+++ b/website/content/docs/commands/kv/enable-versioning.mdx
@@ -9,11 +9,11 @@ description: |-
 # kv enable-versioning
 
 The `kv enable-versioning` command turns on versioning for an existing
-non-versioned key/value secrets engine (K/V Version 1) at its path.
+non-versioned key/value secrets engine (KV version 1) at its path.
 
 ## Examples
 
-This command turns on versioning for the K/V Version 1 secrets engine enabled at
+This command turns on versioning for the KV version 1 secrets engine enabled at
 "secret".
 
 ```shell-session

--- a/website/content/docs/commands/kv/get.mdx
+++ b/website/content/docs/commands/kv/get.mdx
@@ -9,7 +9,7 @@ description: |-
 
 # kv get
 
-The `kv get` command retrieves the value from K/V secrets engine at the given
+The `kv get` command retrieves the value from KV secrets engine at the given
 key name. If no key exists with that name, an error is returned. If a key exists
 with the name but has no data, nothing is returned.
 
@@ -37,7 +37,7 @@ Key         Value
 passcode    my-long-passcode
 ```
 
-If K/V Version 1 secrets engine is enabled at "secret", the output has no
+If KV version 1 secrets engine is enabled at "secret", the output has no
 metadata since there is no versioning information associated with the data:
 
 ```shell-session

--- a/website/content/docs/commands/kv/index.mdx
+++ b/website/content/docs/commands/kv/index.mdx
@@ -9,7 +9,7 @@ description: |-
 # kv
 
 The `kv` command groups subcommands for interacting with Vault's key/value
-secrets engine (both [K/V Version 1](/vault/docs/secrets/kv/kv-v1) and [K/V
+secrets engine (both [KV version 1](/vault/docs/secrets/kv/kv-v1) and [KV
 Version 2](/vault/docs/secrets/kv/kv-v2).
 
 ## Syntax
@@ -28,7 +28,7 @@ which only use the old syntax to refer to the mount path.
 
 ## Examples
 
-Create or update the key named "creds" in the K/V Version 2 enabled at "secret"
+Create or update the key named "creds" in the KV version 2 enabled at "secret"
 with the value "passcode=my-long-passcode":
 
 ```shell-session

--- a/website/content/docs/commands/kv/list.mdx
+++ b/website/content/docs/commands/kv/list.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: kv list - Command
 description: |-
-  The "kv list" command lists data from Vault's K/V secrets engine at the given
+  The "kv list" command lists data from Vault's KV secrets engine at the given
   path.
 ---
 

--- a/website/content/docs/commands/kv/metadata.mdx
+++ b/website/content/docs/commands/kv/metadata.mdx
@@ -8,11 +8,11 @@ description: |-
 
 # kv metadata
 
-~> **NOTE:** This is a [K/V Version 2](/vault/docs/secrets/kv/kv-v2) secrets
+~> **NOTE:** This is a [KV version 2](/vault/docs/secrets/kv/kv-v2) secrets
 engine command, and not available for Version 1.
 
 The `kv metadata` command has subcommands for interacting with the metadata and
-versions for the versioned secrets (K/V Version 2 secrets engine) at the
+versions for the versioned secrets (KV version 2 secrets engine) at the
 specified path.
 
 ## Usage
@@ -86,12 +86,12 @@ destroyed        false
 
 ### kv metadata put
 
-The `kv metadata put` command can be used to create a blank key in the K/V v2
+The `kv metadata put` command can be used to create a blank key in the KV v2
 secrets engine or to update key configuration for a specified key.
 
 #### Examples
 
-Create a key in the K/V v2 with no data at the key "creds":
+Create a key in the KV v2 with no data at the key "creds":
 
 ```shell-session
 $ vault kv metadata put -mount=secret creds

--- a/website/content/docs/commands/kv/patch.mdx
+++ b/website/content/docs/commands/kv/patch.mdx
@@ -8,10 +8,10 @@ description: |-
 
 # kv patch
 
-~> **NOTE:** This is a [K/V Version 2](/vault/docs/secrets/kv/kv-v2) secrets
+~> **NOTE:** This is a [KV version 2](/vault/docs/secrets/kv/kv-v2) secrets
 engine command, and not available for Version 1.
 
-The `kv patch` command writes the data to the given path in the K/V v2 secrets
+The `kv patch` command writes the data to the given path in the KV v2 secrets
 engine. The data can be of any type. Unlike the `kv put` command, the `patch`
 command combines the change with existing data instead of replacing them.
 Therefore, this command makes it easy to make a partial updates to an existing

--- a/website/content/docs/commands/kv/put.mdx
+++ b/website/content/docs/commands/kv/put.mdx
@@ -2,20 +2,20 @@
 layout: docs
 page_title: kv put - Command
 description: |-
-  The "kv put" command writes the data to the given path in the K/V secrets
+  The "kv put" command writes the data to the given path in the KV secrets
   engine. The data can be of any type.
 ---
 
 # kv put
 
-The `kv put` command writes the data to the given path in the K/V secrets
+The `kv put` command writes the data to the given path in the KV secrets
 engine.
 
-If working with K/V v2, this command creates a new version of a secret at the
-specified location. If working with K/V v1, this command stores the given secret
+If working with KV v2, this command creates a new version of a secret at the
+specified location. If working with KV v1, this command stores the given secret
 at the specified location.
 
-Regardless of the K/V version, if the value does not yet exist at the specified
+Regardless of the KV version, if the value does not yet exist at the specified
 path, the calling token must have an ACL policy granting the "create"
 capability. If the value already exists, the calling token must have an ACL
 policy granting the "update" capability.

--- a/website/content/docs/commands/kv/rollback.mdx
+++ b/website/content/docs/commands/kv/rollback.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # kv rollback
 
-~> **NOTE:** This is a [K/V Version 2](/vault/docs/secrets/kv/kv-v2) secrets
+~> **NOTE:** This is a [KV version 2](/vault/docs/secrets/kv/kv-v2) secrets
 engine command, and not available for Version 1.
 
 The `kv rollback` command restores a given previous version to the current

--- a/website/content/docs/commands/kv/undelete.mdx
+++ b/website/content/docs/commands/kv/undelete.mdx
@@ -9,7 +9,7 @@ description: |-
 
 # kv undelete
 
-~> **NOTE:** This is a [K/V Version 2](/vault/docs/secrets/kv/kv-v2) secrets
+~> **NOTE:** This is a [KV version 2](/vault/docs/secrets/kv/kv-v2) secrets
 engine command, and not available for Version 1.
 
 The `kv undelete` command undoes the deletes of the data for the provided version

--- a/website/content/docs/commands/read.mdx
+++ b/website/content/docs/commands/read.mdx
@@ -29,7 +29,7 @@ $ vault read aws/creds/my-role
 
 ### API versus CLI
 
-Assuming that you have K/V version 2 (`kv-v2`) secrets engine enabled at
+Assuming that you have KV version 2 (`kv-v2`) secrets engine enabled at
 `secret/`, the following command reads secrets at the `secret/data/customers`
 API path:
 
@@ -44,7 +44,7 @@ $ curl --request GET --header "X-Vault-Token: $VAULT_TOKEN" \
     $VAULT_ADDR/v1/secret/data/customers
 ```
 
-Since K/V secrets engine is a commonly used feature, Vault CLI provides the
+Since KV secrets engine is a commonly used feature, Vault CLI provides the
 [`kv`](/vault/docs/commands/kv) command. Read secrets from the `secret/data/customers`
 path using the `kv` CLI command:
 
@@ -55,7 +55,7 @@ $ vault kv get -mount=secret customers
 -> **Comparison:** All three commands retrieve the same data, but display the
 output in a different format. By default, `vault read` prints output in
 key-value format. The `curl` command prints the response in JSON. Since the
-`kv` command is designed to handle operations associated with K/V secrets
+`kv` command is designed to handle operations associated with KV secrets
 engine, it prints the output in more structured format that is easy to read.
 
 ## Usage

--- a/website/content/docs/concepts/lease.mdx
+++ b/website/content/docs/concepts/lease.mdx
@@ -35,7 +35,7 @@ the user interface (UI) under the Access tab, or automatically by Vault. When a 
 is expired, Vault will automatically revoke that lease. When a token is revoked,
 Vault will revoke all leases that were created using that token.
 
-**Note**: The [Key/Value Backend](/vault/docs/secrets/kv) which stores
+**Note**: The [Key Value Backend](/vault/docs/secrets/kv) which stores
 arbitrary secrets does not issue leases although it will sometimes return a
 lease duration; see the documentation for more information.
 

--- a/website/content/docs/enterprise/replication.mdx
+++ b/website/content/docs/enterprise/replication.mdx
@@ -88,7 +88,7 @@ secondaries to have a different configuration than their primary.  Tokens and le
 @include 'alerts/enterprise-and-hcp.mdx'
 
 In Performance Replication, secondaries keep track of their own tokens and leases
-but share the underlying configuration, policies, and supporting secrets (K/V values,
+but share the underlying configuration, policies, and supporting secrets (KV values,
 encryption keys for `transit`, etc).
 
 If a user action would modify underlying shared state, the secondary forwards the request
@@ -151,7 +151,7 @@ step-by-step instructions.
 ## Disaster recovery (DR) replication
 
 In disaster recovery (or DR) replication, secondaries share the same underlying configuration,
-policy, and supporting secrets (K/V values, encryption keys for `transit`, etc) infrastructure
+policy, and supporting secrets (KV values, encryption keys for `transit`, etc) infrastructure
 as the primary. They also share the same token and lease infrastructure as the primary, as
 they are designed to allow for continuous operations with applications connecting to the
 original primary on the election of the DR secondary.

--- a/website/content/docs/internals/high-availability.mdx
+++ b/website/content/docs/internals/high-availability.mdx
@@ -39,7 +39,7 @@ If a server is in a sealed state, it cannot act as a standby. Servers in a seale
 
 Performance Standby Nodes service read-only requests from users or applications.
 Read-only requests are requests that do not modify Vault's storage. Vault quickly scales its ability to service these operations,
-providing a near-linear request-per-second scaling for most scenarios and secrets engines like K/V and Transit. Traffic is distributed across performance standby nodes, allowing clients to scale these IOPS horizontally, and control high traffic workloads.
+providing a near-linear request-per-second scaling for most scenarios and secrets engines like KV and Transit. Traffic is distributed across performance standby nodes, allowing clients to scale these IOPS horizontally, and control high traffic workloads.
 
 If a request comes into a Performance Standby Node that causes a storage to write
 the request, the request is forwarded to the active server. Read-only requests are serviced locally on the Performance Standby.

--- a/website/content/docs/interoperability-matrix.mdx
+++ b/website/content/docs/interoperability-matrix.mdx
@@ -48,19 +48,19 @@ Partners who integrate with Vault to have Vault store and/or manage encryption k
 ~> Note: HCP Vault Verified means that the integration has been verified to work with HCP Vault. All integrations have been verified with Vault self-managed.
 
 <span style={{fontSize:'12px'}}>
-Vault Secrets Engine Key: EKM Provider = <a href="/docs/platform/mssql">Vault EKM provider for SQL server</a>; K/V = <a href="/docs/secrets/kv">K/V secrets engine</a>; KMSE = <a href="/docs/secrets/key-management">Key Management Secrets Engine</a>; KMIP = <a href="/docs/secrets/kmip">KMIP Secrets Engine</a>; PKCS#11 = <a href="/docs/enterprise/pkcs11-provider">PKCS#11 Provider</a>; Transit = <a href="/docs/secrets/transit">Transit Secrets Engine</a>
+Vault Secrets Engine Key: EKM Provider = <a href="/docs/platform/mssql">Vault EKM provider for SQL server</a>; KV = <a href="/docs/secrets/kv">KV secrets engine</a>; KMSE = <a href="/docs/secrets/key-management">Key Management Secrets Engine</a>; KMIP = <a href="/docs/secrets/kmip">KMIP Secrets Engine</a>; PKCS#11 = <a href="/docs/enterprise/pkcs11-provider">PKCS#11 Provider</a>; Transit = <a href="/docs/secrets/transit">Transit Secrets Engine</a>
 </span>
 
 | Partner           | Product                  | Vault Secrets Engine | Min. Vault Version Verified | HCP Vault Verified |
 | ----------------- | ------------------------ | -------------------- | --------------------------- | ------------------- |
 | AWS               | AWS KMS                  | KMSE                 | 1.8                         | Yes                 |
-| Baffle            | Shield                   | K/V                  | 1.3                         | No                  |
+| Baffle            | Shield                   | KV                  | 1.3                         | No                  |
 | Bloombase         | StoreSafe                | KMIP                 | 1.9                         | N/A                 |
 | Cloudian          | HyperStore 7.5.1         | KMIP                 | 1.12                        | N/A                 |
 | Cockroach Labs    | Cockroach Cloud DB       | KMSE                 | 1.10                        | N/A                 |
 | Cockroach Labs    | Cockroach DB             | Transit              | 1.10                        | Yes                 |
 | Commvault Systems | CommVault                | KMIP                 | 1.9                         | N/A                 |
-| Cribl             | Cribl Stream             | K/V                  | 1.8                         | Yes                 |
+| Cribl             | Cribl Stream             | KV                  | 1.8                         | Yes                 |
 | DataStax          | DataStax Enterprise      | KMIP                 | 1.11                        | Yes                 |
 | Dell              | PowerMax                 | KMIP                 | 1.12.1                      | N/A                 |
 | EnterpriseDB      | Postgres Advanced Server | KMIP                 | 1.12.6                      | N/A                 |
@@ -68,11 +68,11 @@ Vault Secrets Engine Key: EKM Provider = <a href="/docs/platform/mssql">Vault EK
 | Google            | Google KMS               | KMSE                 | 1.9                         | N/A                 |
 | HPE               | Exmeral Data Fabric      | KMIP                 | 1.2                         | N/A                 |
 | Intel             | Key Broker Service       | KMIP                 | 1.11                        | N/A                 |
-| JumpWire          | JumpWire                 | K/V                  | 1.12                        | Yes                 |
+| JumpWire          | JumpWire                 | KV                  | 1.12                        | Yes                 |
 | Micro Focus       | Connected Mx             | Transit              | 1.7                         | No                  |
 | Microsoft         | Azure Key Vault          | KMSE                 | 1.6                         | N/A                 |
 | Microsoft         | MSSSQL                   | EKM Provider         | 1.9                         | No                  |
-| MinIO             | Key Encryption Service   | K/V                  | 1.11                        | No                  |
+| MinIO             | Key Encryption Service   | KV                  | 1.11                        | No                  |
 | MongoDB           | Atlas                    | KMSE                 | 1.6                         | N/A                 |
 | MongoDB           | MongoDB Enterprise       | KMIP                 | 1.2                         | N/A                 |
 | MongoDB           | Client Libraries         | KMIP                 | 1.9                         | N/A                 |

--- a/website/content/docs/platform/servicenow/configuration.mdx
+++ b/website/content/docs/platform/servicenow/configuration.mdx
@@ -34,10 +34,10 @@ The credential resolver supports reading credentials from the following secret e
 
 * [Active Directory](/vault/docs/secrets/ad)
 * [AWS](/vault/docs/secrets/aws)
-* [K/V v1](/vault/docs/secrets/kv/kv-v1)
-* [K/V v2](/vault/docs/secrets/kv/kv-v2)
+* [KV v1](/vault/docs/secrets/kv/kv-v1)
+* [KV v2](/vault/docs/secrets/kv/kv-v2)
 
-When creating K/V secrets, you must use the following keys for each component
+When creating KV secrets, you must use the following keys for each component
 to ensure it is correctly mapped to ServiceNow's credential fields:
 
 Key         | Description                            | Supported aliases

--- a/website/content/docs/release-notes/1.11.0.mdx
+++ b/website/content/docs/release-notes/1.11.0.mdx
@@ -51,7 +51,7 @@ The KV version 2 secrets engine now includes a set of utilities and enhancements
 * New flag to output a sample policy in HCL (`-output-policy`) for any Vault CLI command.
 * New KV convenience/helper methods (GET and PUT) added to the Go client library.
 
-For more details, refer to the [Version Key/Value Secrets Engine](/vault/tutorials/secrets-management/versioned-kv) tutorial.
+For more details, refer to the [Version Key Value Secrets Engine](/vault/tutorials/secrets-management/versioned-kv) tutorial.
 
 ### Support for node identity and service identity for Vault consul secrets engine
 

--- a/website/content/docs/release-notes/1.15.0.mdx
+++ b/website/content/docs/release-notes/1.15.0.mdx
@@ -183,7 +183,7 @@ Follow the learn more links for more information, or browse the list of
     </td>
     <td style={{verticalAlign: 'middle', textAlign: 'center'}}>BETA</td>
     <td style={{verticalAlign: 'middle'}}>
-      Sync Key/Value (KV) v2 data between Vault and secrets managers from AWS,
+      Sync Key Value (KV) v2 data between Vault and secrets managers from AWS,
       Azure, Google Cloud Platform (GCP), GitHub, and Vercel.
       <br /><br />
       Learn more: <a href="/vault/docs/sync">Secrets Sync</a>

--- a/website/content/docs/secrets/kv/index.mdx
+++ b/website/content/docs/secrets/kv/index.mdx
@@ -21,7 +21,7 @@ is stored. Additionally, requests going to a backend configured this way will be
 more performant because for any given request there will be fewer storage calls
 and no locking.
 
-More information about running in this mode can be found in the [K/V Version 1
+More information about running in this mode can be found in the [KV version 1
 Docs](/vault/docs/secrets/kv/kv-v1)
 
 ## KV version 2
@@ -38,5 +38,5 @@ versions and metadata for a key can be deleted by deleting on the metadata
 command or API endpoint. Each of these operations can be ACL'ed differently,
 restricting who has permissions to soft delete, undelete, or fully remove data.
 
-More information about running in this mode can be found in the [K/V Version 2
+More information about running in this mode can be found in the [KV version 2
 Docs](/vault/docs/secrets/kv/kv-v2)

--- a/website/content/docs/secrets/kv/kv-v1.mdx
+++ b/website/content/docs/secrets/kv/kv-v1.mdx
@@ -139,7 +139,7 @@ ttl                 30m
 
 ## Tutorial
 
-Refer to the [Static Secrets: Key/Value Secrets
+Refer to the [Static Secrets: Key Value Secrets
 Engine](/vault/tutorials/secrets-management/static-secrets)
 tutorial to learn how to set up a uniform workflow to securely store sensitive information.
 

--- a/website/content/docs/secrets/kv/kv-v2.mdx
+++ b/website/content/docs/secrets/kv/kv-v2.mdx
@@ -619,7 +619,7 @@ See the commands below for more information:
 
 ## Tutorial
 
-Refer to the [Versioned Key/Value Secrets
+Refer to the [Versioned Key Value Secrets
 Engine](/vault/tutorials/secrets-management/versioned-kv)
 tutorial to learn how to use KV secrets engine v2 to version or roll back secrets.
 

--- a/website/content/docs/upgrading/upgrade-to-1.5.0.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.5.0.mdx
@@ -21,7 +21,7 @@ for details on supported options.
 ## Raft configuration
 
 A new Raft configuration value, `max_entry_size`, has been introduced. This value
-limits the size in bytes for a Raft K/V entry. It applies to both put operations and
+limits the size in bytes for a Raft KV entry. It applies to both put operations and
 transactions. Any put or transaction operation exceeding this configuration value
 will cause the respective operation to fail. The default value for this
 configuration is 1MiB.

--- a/website/data/api-docs-nav-data.json
+++ b/website/data/api-docs-nav-data.json
@@ -216,7 +216,7 @@
         ]
       },
       {
-        "title": "Key/Value",
+        "title": "Key Value",
         "routes": [
           {
             "title": "Overview",

--- a/website/data/api-docs-nav-data.json
+++ b/website/data/api-docs-nav-data.json
@@ -223,11 +223,11 @@
             "path": "secret/kv"
           },
           {
-            "title": "K/V Version 1",
+            "title": "KV version 1",
             "path": "secret/kv/kv-v1"
           },
           {
-            "title": "K/V Version 2",
+            "title": "KV version 2",
             "path": "secret/kv/kv-v2"
           }
         ]

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1361,11 +1361,11 @@
             "path": "secrets/kv"
           },
           {
-            "title": "K/V Version 1",
+            "title": "KV version  1",
             "path": "secrets/kv/kv-v1"
           },
           {
-            "title": "K/V Version 2",
+            "title": "KV version  2",
             "path": "secrets/kv/kv-v2"
           }
         ]

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1354,7 +1354,7 @@
         ]
       },
       {
-        "title": "Key/Value",
+        "title": "Key Value",
         "routes": [
           {
             "title": "Overview",


### PR DESCRIPTION
Historically we've been inconsistent across Vault products referring to the Key Value secrets engine. See one example in the docs below where there are three different styles of key value: 
<img width="1000" alt="Screenshot 2023-12-13 at 2 20 44 PM" src="https://github.com/hashicorp/vault/assets/68122737/946bc26f-2872-4a88-88bf-1525a7972f95">

In a Vault UI sync meeting last week we discussed with design and the core PM to come to a consensus on how to refer to the Key Value secrets engine. We settled on `Key Value` as the complete term and `KV version 1` (`KV v1`) or `KV version 2` (`KV v2`), without the slash (`K/V`) because it's an acronym for the secrets engine. This PR updates references to `K/V` and `Key/Value`



