### PR TITLE
UI: Update radio form field to have group styles and label/subtext

### DIFF
--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -42,10 +42,11 @@
               <label
                 for="{{or val.value val}}"
                 class="has-left-margin-xs {{if this.hasRadioSubTextAndLabel 'has-text-black is-size-7'}}"
+                data-test-radio-label={{or val.label val.value val}}
               >
-                {{or val.label val.value val}}
+                <span>{{or val.label val.value val}}</span>
                 {{#if this.hasRadioSubTextAndLabel}}
-                  <p class="has-left-margin-xs has-text-grey is-size-8">
+                  <p class="has-left-margin-xs has-text-grey is-size-8" data-test-radio-subText={{val.subText}}>
                     {{val.subText}}
                   </p>
                 {{/if}}

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -16,9 +16,17 @@
   {{/unless}}
   {{#if @attr.options.possibleValues}}
     {{#if (eq @attr.options.editType "radio")}}
-      <div class="control columns" data-test-radio-input>
+      <div class="control {{unless this.hasRadioSubTextAndLabel 'columns'}}" data-test-radio-input>
         {{#each (path-or-array @attr.options.possibleValues @model) as |val|}}
-          <div class="column is-narrow is-flex-center has-text-grey has-right-margin-s" data-test-input={{@attr.name}}>
+          <div
+            class="is-flex-center
+              {{if
+                this.hasRadioSubTextAndLabel
+                'has-top-padding-xs has-bottom-padding-s'
+                'column is-narrow has-text-grey has-right-margin-s'
+              }}"
+            data-test-input={{@attr.name}}
+          >
             <RadioButton
               class="radio"
               name={{@attr.name}}
@@ -26,12 +34,23 @@
               value={{or val.value val}}
               @value={{or val.value val}}
               @onChange={{this.setAndBroadcast}}
-              @groupValue={{(get @model this.valuePath)}}
+              @groupValue={{get @model this.valuePath}}
               @disabled={{and @attr.options.editDisabled (not @model.isNew)}}
+              data-test-radio={{or val.value val}}
             />
-            <label for={{or val.value val}} class="has-left-margin-xs">
-              {{or val.value val}}
-            </label>
+            <div class="has-left-margin-xs">
+              <label
+                for="{{or val.value val}}"
+                class="has-left-margin-xs {{if this.hasRadioSubTextAndLabel 'has-text-black is-size-7'}}"
+              >
+                {{or val.label val.value val}}
+                {{#if this.hasRadioSubTextAndLabel}}
+                  <p class="has-left-margin-xs has-text-grey is-size-8">
+                    {{val.subText}}
+                  </p>
+                {{/if}}
+              </label>
+            </div>
           </div>
         {{/each}}
       </div>
@@ -74,6 +93,15 @@
         </div>
       </div>
     {{/if}}
+  {{else if (eq @attr.options.editType "dateTimeLocal")}}
+    <Input
+      @type="datetime-local"
+      @value={{date-format (get @model this.valuePath) "yyyy-MM-dd'T'HH:mm"}}
+      class="input has-top-margin-xs is-auto-width is-block"
+      name={{@attr.name}}
+      data-test-input={{@attr.name}}
+      {{on "change" this.onChangeWithEvent}}
+    />
   {{else if (eq @attr.options.editType "searchSelect")}}
     <div class="form-section">
       <SearchSelect

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -16,15 +16,11 @@
   {{/unless}}
   {{#if @attr.options.possibleValues}}
     {{#if (eq @attr.options.editType "radio")}}
-      <div class="control {{unless this.hasRadioSubTextAndLabel 'columns'}}" data-test-radio-input>
+      <div class="control {{unless this.hasRadioSubText 'columns'}}" data-test-radio-input>
         {{#each (path-or-array @attr.options.possibleValues @model) as |val|}}
           <div
             class="is-flex-center
-              {{if
-                this.hasRadioSubTextAndLabel
-                'has-top-padding-xs has-bottom-padding-s'
-                'column is-narrow has-text-grey has-right-margin-s'
-              }}"
+              {{if this.hasRadioSubText 'has-top-padding-xs has-bottom-padding-s' 'column is-narrow has-right-margin-s'}}"
             data-test-input={{@attr.name}}
           >
             <RadioButton
@@ -41,11 +37,11 @@
             <div class="has-left-margin-xs">
               <label
                 for="{{or val.value val}}"
-                class="has-left-margin-xs {{if this.hasRadioSubTextAndLabel 'has-text-black is-size-7'}}"
+                class="has-left-margin-xs has-text-black is-size-7"
                 data-test-radio-label={{or val.label val.value val}}
               >
                 <span>{{or val.label val.value val}}</span>
-                {{#if this.hasRadioSubTextAndLabel}}
+                {{#if this.hasRadioSubText}}
                   <p class="has-left-margin-xs has-text-grey is-size-8" data-test-radio-subText={{val.subText}}>
                     {{val.subText}}
                   </p>

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -75,6 +75,11 @@ export default class FormFieldComponent extends Component {
     this.showInput = !!modelValue;
   }
 
+  get hasRadioSubTextAndLabel() {
+    // for 'radio' editType, check to see if every of the possibleValues has a subText and label
+    return this.args?.attr?.options?.possibleValues?.every((v) => v.subText && v.label);
+  }
+
   get hideLabel() {
     const { type, options } = this.args.attr;
     if (type === 'boolean' || type === 'object' || options?.isSectionHeader) {

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -75,9 +75,9 @@ export default class FormFieldComponent extends Component {
     this.showInput = !!modelValue;
   }
 
-  get hasRadioSubTextAndLabel() {
+  get hasRadioSubText() {
     // for 'radio' editType, check to see if every of the possibleValues has a subText and label
-    return this.args?.attr?.options?.possibleValues?.every((v) => v.subText && v.label);
+    return this.args?.attr?.options?.possibleValues?.any((v) => v.subText);
   }
 
   get hideLabel() {

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -11,6 +11,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { create } from 'ember-cli-page-object';
 import sinon from 'sinon';
 import formFields from '../../pages/components/form-field';
+import { format, startOfDay } from 'date-fns';
 
 const component = create(formFields);
 
@@ -167,6 +168,7 @@ module('Integration | Component | form field', function (hooks) {
         possibleValues: [
           { label: 'Label 1', subText: 'Some subtext 1', value: 'SHA1' },
           { label: 'Label 2', subText: 'Some subtext 2', value: 'SHA256' },
+          { subText: 'Some subtext 3', value: 'SHA256' },
         ],
       })
     );
@@ -175,10 +177,26 @@ module('Integration | Component | form field', function (hooks) {
     await component.selectRadioInput(selectedValue);
     assert.dom('[data-test-radio-label="Label 1"] span').hasText('Label 1');
     assert.dom('[data-test-radio-label="Label 2"] span').hasText('Label 2');
+    assert.dom('[data-test-radio-label="SHA256"] span').hasText('SHA256');
     assert.dom('[data-test-radio-subText="Some subtext 1"]').hasText('Some subtext 1');
     assert.dom('[data-test-radio-subText="Some subtext 2"]').hasText('Some subtext 2');
+    assert.dom('[data-test-radio-subText="Some subtext 3"]').hasText('Some subtext 3');
     assert.strictEqual(model.get('foo'), selectedValue);
     assert.ok(spy.calledWith('foo', selectedValue), 'onChange called with correct args');
+  });
+  test('it renders: datetimelocal', async function (assert) {
+    const [model] = await setup.call(
+      this,
+      createAttr('bar', null, {
+        editType: 'dateTimeLocal',
+      })
+    );
+    assert.dom("[data-test-input='bar']").exists();
+    await fillIn(
+      "[data-test-input='bar']",
+      format(startOfDay(new Date('2023-12-12'), 1), "yyyy-MM-dd'T'HH:mm")
+    );
+    assert.deepEqual(model.get('bar'), '2023-12-11T00:00', 'sets the value on the model');
   });
 
   test('it renders: editType stringArray', async function (assert) {

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -159,6 +159,27 @@ module('Integration | Component | form field', function (hooks) {
     assert.strictEqual(model.get('foo'), selectedValue);
     assert.ok(spy.calledWith('foo', selectedValue), 'onChange called with correct args');
   });
+  test('it renders: radio buttons for possible values, labels, and subtext', async function (assert) {
+    const [model, spy] = await setup.call(
+      this,
+      createAttr('foo', null, {
+        editType: 'radio',
+        possibleValues: [
+          { label: 'Label 1', subText: 'Some subtext 1', value: 'SHA1' },
+          { label: 'Label 2', subText: 'Some subtext 2', value: 'SHA256' },
+        ],
+      })
+    );
+    assert.ok(component.hasRadio, 'renders radio buttons');
+    const selectedValue = 'SHA256';
+    await component.selectRadioInput(selectedValue);
+    assert.dom('[data-test-radio-label="Label 1"] span').hasText('Label 1');
+    assert.dom('[data-test-radio-label="Label 2"] span').hasText('Label 2');
+    assert.dom('[data-test-radio-subText="Some subtext 1"]').hasText('Some subtext 1');
+    assert.dom('[data-test-radio-subText="Some subtext 2"]').hasText('Some subtext 2');
+    assert.strictEqual(model.get('foo'), selectedValue);
+    assert.ok(spy.calledWith('foo', selectedValue), 'onChange called with correct args');
+  });
 
   test('it renders: editType stringArray', async function (assert) {
     const [model, spy] = await setup.call(this, createAttr('foo', 'string', { editType: 'stringArray' }));

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -194,9 +194,9 @@ module('Integration | Component | form field', function (hooks) {
     assert.dom("[data-test-input='bar']").exists();
     await fillIn(
       "[data-test-input='bar']",
-      format(startOfDay(new Date('2023-12-12'), 1), "yyyy-MM-dd'T'HH:mm")
+      format(startOfDay(new Date('2023-12-17T03:24:00')), "yyyy-MM-dd'T'HH:mm")
     );
-    assert.deepEqual(model.get('bar'), '2023-12-11T00:00', 'sets the value on the model');
+    assert.deepEqual(model.get('bar'), '2023-12-17T00:00', 'sets the value on the model');
   });
 
   test('it renders: editType stringArray', async function (assert) {


### PR DESCRIPTION
This updates the radio form fields to have radio group styles. Radio groups include label and subtext!

<img width="537" alt="Screenshot 2023-12-14 at 8 43 22 AM" src="https://github.com/hashicorp/vault/assets/30884335/a1c4747b-b3cf-4ae2-9183-be06e7164893">
