### PR TITLE
Don't touch ActiveTime in preSeal/postUnseal

### DIFF
--- a/changelog/24549.txt
+++ b/changelog/24549.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: sys/leader ActiveTime field no longer gets reset when we do an internal state change that doesn't change our active status.
+```

--- a/vault/core.go
+++ b/vault/core.go
@@ -2390,7 +2390,6 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 
 	// Mark the active time. We do this first so it can be correlated to the logs
 	// for the active startup.
-	c.activeTime = time.Now().UTC()
 
 	if err := postUnsealPhysical(c); err != nil {
 		return err
@@ -2766,7 +2765,6 @@ func (c *Core) preSeal() error {
 	}
 	// Clear any pending funcs
 	c.postUnsealFuncs = nil
-	c.activeTime = time.Time{}
 
 	// Clear any rekey progress
 	c.barrierRekeyConfig = nil

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -663,6 +663,7 @@ func (c *Core) waitForLeadership(newLeaderCh chan func(), manualStepDownCh, stop
 		err = c.postUnseal(activeCtx, activeCtxCancel, standardUnsealStrategy{})
 		if err == nil {
 			c.standby = false
+			c.activeTime = time.Now()
 			c.leaderUUID = uuid
 			c.metricSink.SetGaugeWithLabels([]string{"core", "active"}, 1, nil)
 		}
@@ -715,6 +716,7 @@ func (c *Core) waitForLeadership(newLeaderCh chan func(), manualStepDownCh, stop
 
 			// Mark as standby
 			c.standby = true
+			c.activeTime = time.Time{}
 			c.leaderUUID = ""
 			c.metricSink.SetGaugeWithLabels([]string{"core", "active"}, 0, nil)
 


### PR DESCRIPTION
If a consumer of the sys/leader api relies on ActiveTime, they can be misled by our current behaviour, whereby ActiveTime gets set to "now" during postUnseal and to the zero time during preSeal.  We sometimes preSeal/postUnseal while remaining the active node.  Instead, only set these when we actually change active role.