### PR TITLE
Simplify raft tests, use inmem networking instead of address providers

### DIFF
--- a/helper/testhelpers/teststorage/teststorage.go
+++ b/helper/testhelpers/teststorage/teststorage.go
@@ -119,9 +119,11 @@ func MakeRaftBackend(t testing.T, coreIdx int, logger hclog.Logger, extraConf ma
 	logger.Info("raft dir", "dir", raftDir)
 
 	conf := map[string]string{
-		"path":                   raftDir,
-		"node_id":                nodeID,
-		"performance_multiplier": "8",
+		"path":                         raftDir,
+		"node_id":                      nodeID,
+		"performance_multiplier":       "8",
+		"autopilot_reconcile_interval": "300ms",
+		"autopilot_update_interval":    "100ms",
 	}
 	for k, v := range extraConf {
 		val, ok := v.(string)

--- a/vault/external_tests/raft/raft_autopilot_test.go
+++ b/vault/external_tests/raft/raft_autopilot_test.go
@@ -9,23 +9,19 @@ import (
 	"fmt"
 	"math"
 	"reflect"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/go-hclog"
 	autopilot "github.com/hashicorp/raft-autopilot"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/constants"
 	"github.com/hashicorp/vault/helper/testhelpers"
-	"github.com/hashicorp/vault/helper/testhelpers/teststorage"
 	"github.com/hashicorp/vault/physical/raft"
 	"github.com/hashicorp/vault/sdk/helper/testcluster"
 	"github.com/hashicorp/vault/vault"
 	"github.com/hashicorp/vault/version"
 	"github.com/kr/pretty"
-	testingintf "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
 )
 
@@ -218,29 +214,25 @@ func TestRaft_Autopilot_Configuration(t *testing.T) {
 // TestRaft_Autopilot_Stabilization_Delay verifies that if a node takes a long
 // time to become ready, it doesn't get promoted to voter until then.
 func TestRaft_Autopilot_Stabilization_Delay(t *testing.T) {
-	t.Skip()
 	t.Parallel()
-	conf, opts := teststorage.ClusterSetup(nil, nil, teststorage.RaftBackendSetup)
-	conf.DisableAutopilot = false
-	opts.InmemClusterLayers = true
-	opts.KeepStandbysSealed = true
-	opts.SetupFunc = nil
 	core2SnapshotDelay := 5 * time.Second
-	opts.PhysicalFactory = func(t testingintf.T, coreIdx int, logger hclog.Logger, conf map[string]interface{}) *vault.PhysicalBackendBundle {
-		config := map[string]interface{}{
-			"snapshot_threshold":           "50",
-			"trailing_logs":                "100",
-			"autopilot_reconcile_interval": "300ms",
-			"autopilot_update_interval":    "100ms",
-			"snapshot_interval":            "1s",
-		}
-		if coreIdx == 2 {
-			config["snapshot_delay"] = core2SnapshotDelay.String()
-		}
-		return teststorage.MakeRaftBackend(t, coreIdx, logger, config)
-	}
+	conf, opts := raftClusterBuilder(t, &RaftClusterOpts{
+		DisableFollowerJoins: true,
+		InmemCluster:         true,
+		EnableAutopilot:      true,
+		PhysicalFactoryConfig: map[string]interface{}{
+			"snapshot_threshold": "50",
+			"trailing_logs":      "100",
+			"snapshot_interval":  "1s",
+		},
+		PerNodePhysicalFactoryConfig: map[int]map[string]interface{}{
+			2: {
+				"snapshot_delay": core2SnapshotDelay.String(),
+			},
+		},
+	})
 
-	cluster := vault.NewTestCluster(t, conf, opts)
+	cluster := vault.NewTestCluster(t, conf, &opts)
 	defer cluster.Cleanup()
 	testhelpers.WaitForActiveNode(t, cluster)
 
@@ -432,27 +424,20 @@ func TestRaft_VotersStayVoters(t *testing.T) {
 // remove it from Raft until a replacement voter had joined and stabilized/been promoted.
 func TestRaft_Autopilot_DeadServerCleanup(t *testing.T) {
 	t.Parallel()
-	conf, opts := teststorage.ClusterSetup(nil, nil, teststorage.RaftBackendSetup)
-	conf.DisableAutopilot = false
-	opts.NumCores = 4
-	opts.SetupFunc = nil
-	opts.PhysicalFactoryConfig = map[string]interface{}{
-		"autopilot_reconcile_interval": "300ms",
-		"autopilot_update_interval":    "100ms",
-	}
-
-	cluster := vault.NewTestCluster(t, conf, opts)
+	cluster, _ := raftCluster(t, &RaftClusterOpts{
+		DisableFollowerJoins: true,
+		InmemCluster:         true,
+		EnableAutopilot:      true,
+		NumCores:             4,
+	})
 	defer cluster.Cleanup()
 	testhelpers.WaitForActiveNode(t, cluster)
-	leader, addressProvider := setupLeaderAndUnseal(t, cluster)
 
 	// Join 2 extra nodes manually, store the 3rd for later
+	leader := cluster.Cores[0]
 	core1 := cluster.Cores[1]
 	core2 := cluster.Cores[2]
 	core3 := cluster.Cores[3]
-	core1.UnderlyingRawStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
-	core2.UnderlyingRawStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
-	core3.UnderlyingRawStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
 	joinAsVoterAndUnseal(t, core1, cluster)
 	joinAsVoterAndUnseal(t, core2, cluster)
 	// Do not join node 3
@@ -604,26 +589,6 @@ func joinAndUnseal(t *testing.T, core *vault.TestClusterCore, cluster *vault.Tes
 	if waitForUnseal {
 		waitForCoreUnseal(t, core)
 	}
-}
-
-// setupLeaderAndUnseal configures and unseals the leader node.
-// It will wait until the node is active before returning the core and the address of the leader.
-func setupLeaderAndUnseal(t *testing.T, cluster *vault.TestCluster) (*vault.TestClusterCore, *testhelpers.TestRaftServerAddressProvider) {
-	t.Helper()
-	leaderIdx, err := testcluster.LeaderNode(context.Background(), cluster)
-	require.NoError(t, err)
-	leader := cluster.Cores[leaderIdx]
-
-	// Lots of tests seem to do this when they deal with a TestRaftServerAddressProvider, it makes the test work rather than error out.
-	atomic.StoreUint32(&vault.TestingUpdateClusterAddr, 1)
-
-	addressProvider := &testhelpers.TestRaftServerAddressProvider{Cluster: cluster}
-	testhelpers.EnsureCoreSealed(t, leader)
-	leader.UnderlyingRawStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
-	cluster.UnsealCore(t, leader)
-	vault.TestWaitActive(t, leader.Core)
-
-	return leader, addressProvider
 }
 
 // waitForCoreUnseal waits until the specified core is unsealed.

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -50,11 +50,17 @@ type RaftClusterOpts struct {
 	VersionMap                     map[int]string
 	RedundancyZoneMap              map[int]string
 	EffectiveSDKVersionMap         map[int]string
+	PerNodePhysicalFactoryConfig   map[int]map[string]interface{}
 }
 
-func raftCluster(t testing.TB, ropts *RaftClusterOpts) (*vault.TestCluster, *vault.TestClusterOptions) {
+func raftClusterBuilder(t testing.TB, ropts *RaftClusterOpts) (*vault.CoreConfig, vault.TestClusterOptions) {
+	// TODO remove global
+	atomic.StoreUint32(&vault.TestingUpdateClusterAddr, 1)
+
 	if ropts == nil {
-		ropts = &RaftClusterOpts{}
+		ropts = &RaftClusterOpts{
+			InmemCluster: true,
+		}
 	}
 
 	conf := &vault.CoreConfig{
@@ -73,41 +79,56 @@ func raftCluster(t testing.TB, ropts *RaftClusterOpts) (*vault.TestCluster, *vau
 	opts.PhysicalFactoryConfig = ropts.PhysicalFactoryConfig
 	conf.DisablePerformanceStandby = ropts.DisablePerfStandby
 	opts.NumCores = ropts.NumCores
-	opts.VersionMap = ropts.VersionMap
-	opts.RedundancyZoneMap = ropts.RedundancyZoneMap
 	opts.EffectiveSDKVersionMap = ropts.EffectiveSDKVersionMap
+	opts.PerNodePhysicalFactoryConfig = ropts.PerNodePhysicalFactoryConfig
+	if len(ropts.VersionMap) > 0 || len(ropts.RedundancyZoneMap) > 0 {
+		if opts.PerNodePhysicalFactoryConfig == nil {
+			opts.PerNodePhysicalFactoryConfig = map[int]map[string]interface{}{}
+		}
+		for idx, ver := range ropts.VersionMap {
+			if opts.PerNodePhysicalFactoryConfig[idx] == nil {
+				opts.PerNodePhysicalFactoryConfig[idx] = map[string]interface{}{}
+			}
+			opts.PerNodePhysicalFactoryConfig[idx]["autopilot_upgrade_version"] = ver
+		}
+		for idx, zone := range ropts.RedundancyZoneMap {
+			if opts.PerNodePhysicalFactoryConfig[idx] == nil {
+				opts.PerNodePhysicalFactoryConfig[idx] = map[string]interface{}{}
+			}
+			opts.PerNodePhysicalFactoryConfig[idx]["autopilot_redundancy_zone"] = zone
+		}
+	}
 
 	teststorage.RaftBackendSetup(conf, &opts)
 
 	if ropts.DisableFollowerJoins {
 		opts.SetupFunc = nil
 	}
+	return conf, opts
+}
 
+func raftCluster(t testing.TB, ropts *RaftClusterOpts) (*vault.TestCluster, *vault.TestClusterOptions) {
+	conf, opts := raftClusterBuilder(t, ropts)
 	cluster := vault.NewTestCluster(benchhelpers.TBtoT(t), conf, &opts)
-	cluster.Start()
 	vault.TestWaitActive(benchhelpers.TBtoT(t), cluster.Cores[0].Core)
 	return cluster, &opts
 }
 
 func TestRaft_BoltDBMetrics(t *testing.T) {
 	t.Parallel()
-	conf := vault.CoreConfig{}
-	opts := vault.TestClusterOptions{
-		HandlerFunc:            vaulthttp.Handler,
-		NumCores:               1,
-		CoreMetricSinkProvider: testhelpers.TestMetricSinkProvider(time.Minute),
-		DefaultHandlerProperties: vault.HandlerProperties{
-			ListenerConfig: &configutil.Listener{
-				Telemetry: configutil.ListenerTelemetry{
-					UnauthenticatedMetricsAccess: true,
-				},
+	conf, opts := raftClusterBuilder(t, &RaftClusterOpts{
+		InmemCluster: true,
+		NumCores:     1,
+	})
+	opts.CoreMetricSinkProvider = testhelpers.TestMetricSinkProvider(time.Minute)
+	opts.DefaultHandlerProperties = vault.HandlerProperties{
+		ListenerConfig: &configutil.Listener{
+			Telemetry: configutil.ListenerTelemetry{
+				UnauthenticatedMetricsAccess: true,
 			},
 		},
 	}
-
-	teststorage.RaftBackendSetup(&conf, &opts)
-	cluster := vault.NewTestCluster(t, &conf, &opts)
-	cluster.Start()
+	cluster := vault.NewTestCluster(t, conf, &opts)
 	defer cluster.Cleanup()
 
 	vault.TestWaitActive(t, cluster.Cores[0].Core)
@@ -148,30 +169,13 @@ func TestRaft_BoltDBMetrics(t *testing.T) {
 func TestRaft_RetryAutoJoin(t *testing.T) {
 	t.Parallel()
 
-	var (
-		conf vault.CoreConfig
-
-		opts = vault.TestClusterOptions{HandlerFunc: vaulthttp.Handler}
-	)
-
-	teststorage.RaftBackendSetup(&conf, &opts)
-
-	opts.SetupFunc = nil
-	cluster := vault.NewTestCluster(t, &conf, &opts)
-
-	cluster.Start()
+	cluster, _ := raftCluster(t, &RaftClusterOpts{
+		InmemCluster:         true,
+		DisableFollowerJoins: true,
+	})
 	defer cluster.Cleanup()
 
-	addressProvider := &testhelpers.TestRaftServerAddressProvider{Cluster: cluster}
 	leaderCore := cluster.Cores[0]
-	atomic.StoreUint32(&vault.TestingUpdateClusterAddr, 1)
-
-	{
-		testhelpers.EnsureCoreSealed(t, leaderCore)
-		leaderCore.UnderlyingRawStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
-		cluster.UnsealCore(t, leaderCore)
-		vault.TestWaitActive(t, leaderCore.Core)
-	}
 
 	leaderInfos := []*raft.LeaderJoinInfo{
 		{
@@ -184,7 +188,6 @@ func TestRaft_RetryAutoJoin(t *testing.T) {
 	{
 		// expected to pass but not join as we're not actually discovering leader addresses
 		core := cluster.Cores[1]
-		core.UnderlyingRawStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
 
 		_, err := core.JoinRaftCluster(namespace.RootContext(context.Background()), leaderInfos, false)
 		require.NoError(t, err)
@@ -200,24 +203,14 @@ func TestRaft_RetryAutoJoin(t *testing.T) {
 
 func TestRaft_Retry_Join(t *testing.T) {
 	t.Parallel()
-	var conf vault.CoreConfig
-	opts := vault.TestClusterOptions{HandlerFunc: vaulthttp.Handler}
-	teststorage.RaftBackendSetup(&conf, &opts)
-	opts.SetupFunc = nil
-	cluster := vault.NewTestCluster(t, &conf, &opts)
-	cluster.Start()
+	cluster, _ := raftCluster(t, &RaftClusterOpts{
+		InmemCluster:         true,
+		DisableFollowerJoins: true,
+	})
 	defer cluster.Cleanup()
-
-	addressProvider := &testhelpers.TestRaftServerAddressProvider{Cluster: cluster}
 
 	leaderCore := cluster.Cores[0]
 	leaderAPI := leaderCore.Client.Address()
-	atomic.StoreUint32(&vault.TestingUpdateClusterAddr, 1)
-
-	{
-		testhelpers.EnsureCoreSealed(t, leaderCore)
-		leaderCore.UnderlyingRawStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
-	}
 
 	leaderInfos := []*raft.LeaderJoinInfo{
 		{
@@ -233,7 +226,6 @@ func TestRaft_Retry_Join(t *testing.T) {
 		go func(t *testing.T, core *vault.TestClusterCore) {
 			t.Helper()
 			defer wg.Done()
-			core.UnderlyingRawStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
 			_, err := core.JoinRaftCluster(namespace.RootContext(context.Background()), leaderInfos, false)
 			if err != nil {
 				t.Error(err)
@@ -263,27 +255,13 @@ func TestRaft_Retry_Join(t *testing.T) {
 
 func TestRaft_Join(t *testing.T) {
 	t.Parallel()
-	var conf vault.CoreConfig
-	opts := vault.TestClusterOptions{HandlerFunc: vaulthttp.Handler}
-	teststorage.RaftBackendSetup(&conf, &opts)
-	opts.SetupFunc = nil
-	cluster := vault.NewTestCluster(t, &conf, &opts)
-	cluster.Start()
+	cluster, _ := raftCluster(t, &RaftClusterOpts{
+		DisableFollowerJoins: true,
+	})
 	defer cluster.Cleanup()
-
-	addressProvider := &testhelpers.TestRaftServerAddressProvider{Cluster: cluster}
 
 	leaderCore := cluster.Cores[0]
 	leaderAPI := leaderCore.Client.Address()
-	atomic.StoreUint32(&vault.TestingUpdateClusterAddr, 1)
-
-	// Seal the leader so we can install an address provider
-	{
-		testhelpers.EnsureCoreSealed(t, leaderCore)
-		leaderCore.UnderlyingRawStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
-		cluster.UnsealCore(t, leaderCore)
-		vault.TestWaitActive(t, leaderCore.Core)
-	}
 
 	joinFunc := func(client *api.Client, addClientCerts bool) {
 		req := &api.RaftJoinRequest{
@@ -392,6 +370,7 @@ func TestRaft_NodeIDHeader(t *testing.T) {
 			description: "with header configured",
 			ropts: &RaftClusterOpts{
 				EnableResponseHeaderRaftNodeID: true,
+				InmemCluster:                   true,
 			},
 			headerPresent: true,
 		},
@@ -622,7 +601,10 @@ func TestRaft_SnapshotAPI_RekeyRotate_Backward(t *testing.T) {
 			tCaseLocal := tCase
 			t.Parallel()
 
-			cluster, _ := raftCluster(t, &RaftClusterOpts{DisablePerfStandby: tCaseLocal.DisablePerfStandby})
+			cluster, _ := raftCluster(t, &RaftClusterOpts{
+				DisablePerfStandby: tCaseLocal.DisablePerfStandby,
+				InmemCluster:       true,
+			})
 			defer cluster.Cleanup()
 
 			leaderClient := cluster.Cores[0].Client
@@ -824,7 +806,10 @@ func TestRaft_SnapshotAPI_RekeyRotate_Forward(t *testing.T) {
 			tCaseLocal := tCase
 			t.Parallel()
 
-			cluster, _ := raftCluster(t, &RaftClusterOpts{DisablePerfStandby: tCaseLocal.DisablePerfStandby})
+			cluster, _ := raftCluster(t, &RaftClusterOpts{
+				DisablePerfStandby: tCaseLocal.DisablePerfStandby,
+				InmemCluster:       true,
+			})
 			defer cluster.Cleanup()
 
 			leaderClient := cluster.Cores[0].Client
@@ -1134,27 +1119,15 @@ func BenchmarkRaft_SingleNode(b *testing.B) {
 
 func TestRaft_Join_InitStatus(t *testing.T) {
 	t.Parallel()
-	var conf vault.CoreConfig
-	opts := vault.TestClusterOptions{HandlerFunc: vaulthttp.Handler}
-	teststorage.RaftBackendSetup(&conf, &opts)
-	opts.SetupFunc = nil
-	cluster := vault.NewTestCluster(t, &conf, &opts)
-	cluster.Start()
-	defer cluster.Cleanup()
 
-	addressProvider := &testhelpers.TestRaftServerAddressProvider{Cluster: cluster}
+	cluster, _ := raftCluster(t, &RaftClusterOpts{
+		InmemCluster:         true,
+		DisableFollowerJoins: true,
+	})
+	defer cluster.Cleanup()
 
 	leaderCore := cluster.Cores[0]
 	leaderAPI := leaderCore.Client.Address()
-	atomic.StoreUint32(&vault.TestingUpdateClusterAddr, 1)
-
-	// Seal the leader so we can install an address provider
-	{
-		testhelpers.EnsureCoreSealed(t, leaderCore)
-		leaderCore.UnderlyingRawStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
-		cluster.UnsealCore(t, leaderCore)
-		vault.TestWaitActive(t, leaderCore.Core)
-	}
 
 	joinFunc := func(client *api.Client) {
 		req := &api.RaftJoinRequest{

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1114,13 +1114,12 @@ type TestClusterOptions struct {
 
 	CoreMetricSinkProvider func(clusterName string) (*metricsutil.ClusterMetricSink, *metricsutil.MetricsHelper)
 
-	PhysicalFactoryConfig map[string]interface{}
-	LicensePublicKey      ed25519.PublicKey
-	LicensePrivateKey     ed25519.PrivateKey
+	PhysicalFactoryConfig        map[string]interface{}
+	PerNodePhysicalFactoryConfig map[int]map[string]interface{}
 
-	// this stores the vault version that should be used for each core config
-	VersionMap             map[int]string
-	RedundancyZoneMap      map[int]string
+	LicensePublicKey  ed25519.PublicKey
+	LicensePrivateKey ed25519.PrivateKey
+
 	KVVersion              string
 	EffectiveSDKVersionMap map[int]string
 
@@ -1831,11 +1830,10 @@ func (testCluster *TestCluster) newCore(t testing.T, idx int, coreConfig *CoreCo
 		if pfc == nil {
 			pfc = make(map[string]interface{})
 		}
-		if len(opts.VersionMap) > 0 {
-			pfc["autopilot_upgrade_version"] = opts.VersionMap[idx]
-		}
-		if len(opts.RedundancyZoneMap) > 0 {
-			pfc["autopilot_redundancy_zone"] = opts.RedundancyZoneMap[idx]
+		if opts.PerNodePhysicalFactoryConfig != nil {
+			for k, v := range opts.PerNodePhysicalFactoryConfig[idx] {
+				pfc[k] = v
+			}
 		}
 		physBundle := opts.PhysicalFactory(t, idx, localConfig.Logger, pfc)
 		switch {


### PR DESCRIPTION
Also replace VersionMap and RedundancyZoneMap with PerNodePhysicalFactoryConfig.  