### PR TITLE
Simplify raft cluster address management in tests

### DIFF
--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -11,10 +11,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
-	"net/url"
 	"os"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/armon/go-metrics"
@@ -435,45 +433,8 @@ func RekeyCluster(t testing.T, cluster *vault.TestCluster, recovery bool) [][]by
 	return newKeys
 }
 
-// TestRaftServerAddressProvider is a ServerAddressProvider that uses the
-// ClusterAddr() of each node to provide raft addresses.
-//
-// Note that TestRaftServerAddressProvider should only be used in cases where
-// cores that are part of a raft configuration have already had
-// startClusterListener() called (via either unsealing or raft joining).
-type TestRaftServerAddressProvider struct {
-	Cluster *vault.TestCluster
-}
-
-func (p *TestRaftServerAddressProvider) ServerAddr(id raftlib.ServerID) (raftlib.ServerAddress, error) {
-	for _, core := range p.Cluster.Cores {
-		if core.NodeID == string(id) {
-			parsed, err := url.Parse(core.ClusterAddr())
-			if err != nil {
-				return "", err
-			}
-
-			return raftlib.ServerAddress(parsed.Host), nil
-		}
-	}
-
-	return "", errors.New("could not find cluster addr")
-}
-
 func RaftClusterJoinNodes(t testing.T, cluster *vault.TestCluster) {
-	addressProvider := &TestRaftServerAddressProvider{Cluster: cluster}
-
-	atomic.StoreUint32(&vault.TestingUpdateClusterAddr, 1)
-
 	leader := cluster.Cores[0]
-
-	// Seal the leader so we can install an address provider
-	{
-		EnsureCoreSealed(t, leader)
-		leader.UnderlyingRawStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
-		cluster.UnsealCore(t, leader)
-		vault.TestWaitActive(t, leader.Core)
-	}
 
 	leaderInfos := []*raft.LeaderJoinInfo{
 		{
@@ -485,7 +446,6 @@ func RaftClusterJoinNodes(t testing.T, cluster *vault.TestCluster) {
 	// Join followers
 	for i := 1; i < len(cluster.Cores); i++ {
 		core := cluster.Cores[i]
-		core.UnderlyingRawStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
 		_, err := core.JoinRaftCluster(namespace.RootContext(context.Background()), leaderInfos, false)
 		if err != nil {
 			t.Fatal(err)

--- a/sdk/helper/testcluster/util.go
+++ b/sdk/helper/testcluster/util.go
@@ -174,7 +174,7 @@ func LeaderNode(ctx context.Context, cluster VaultCluster) (int, error) {
 	leaderActiveTimes := make(map[int]time.Time)
 	for i, node := range cluster.Nodes() {
 		client := node.APIClient()
-		ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+		ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 		resp, err := client.Sys().LeaderWithContext(ctx)
 		cancel()
 		if err != nil || resp == nil || !resp.IsSelf {

--- a/vault/cluster.go
+++ b/vault/cluster.go
@@ -340,7 +340,7 @@ func (c *Core) startClusterListener(ctx context.Context) error {
 	}
 	if strings.HasSuffix(c.ClusterAddr(), ":0") {
 		// If we listened on port 0, record the port the OS gave us.
-		c.clusterAddr.Store(fmt.Sprintf("https://%s", c.getClusterListener().Addr()))
+		c.SetClusterAddr(fmt.Sprintf("https://%s", c.getClusterListener().Addr()))
 	}
 
 	if len(c.ClusterAddr()) != 0 {
@@ -354,6 +354,15 @@ func (c *Core) startClusterListener(ctx context.Context) error {
 
 func (c *Core) ClusterAddr() string {
 	return c.clusterAddr.Load().(string)
+}
+
+func (c *Core) SetClusterAddr(s string) {
+	c.clusterAddr.Store(s)
+	rb := c.getRaftBackend()
+
+	if rb != nil && c.clusterAddrBridge != nil {
+		c.clusterAddrBridge.UpdateClusterAddr(c.GetRaftNodeID(), s)
+	}
 }
 
 func (c *Core) getClusterListener() *cluster.Listener {

--- a/vault/core.go
+++ b/vault/core.go
@@ -710,6 +710,8 @@ type Core struct {
 	echoDuration                  *uberAtomic.Duration
 	activeNodeClockSkewMillis     *uberAtomic.Int64
 	periodicLeaderRefreshInterval time.Duration
+
+	clusterAddrBridge *raft.ClusterAddrBridge
 }
 
 func (c *Core) ActiveNodeClockSkewMillis() int64 {
@@ -886,6 +888,8 @@ type CoreConfig struct {
 	NumRollbackWorkers int
 
 	PeriodicLeaderRefreshInterval time.Duration
+
+	ClusterAddrBridge *raft.ClusterAddrBridge
 }
 
 // GetServiceRegistration returns the config's ServiceRegistration, or nil if it does
@@ -1308,6 +1312,8 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	}
 	c.events = events
 	c.events.Start()
+
+	c.clusterAddrBridge = conf.ClusterAddrBridge
 
 	return c, nil
 }

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -54,9 +53,6 @@ type RaftClusterOpts struct {
 }
 
 func raftClusterBuilder(t testing.TB, ropts *RaftClusterOpts) (*vault.CoreConfig, vault.TestClusterOptions) {
-	// TODO remove global
-	atomic.StoreUint32(&vault.TestingUpdateClusterAddr, 1)
-
 	if ropts == nil {
 		ropts = &RaftClusterOpts{
 			InmemCluster: true,

--- a/vault/external_tests/raftha/raft_ha_test.go
+++ b/vault/external_tests/raftha/raft_ha_test.go
@@ -4,7 +4,6 @@
 package raftha
 
 import (
-	"sync/atomic"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
@@ -13,7 +12,6 @@ import (
 	"github.com/hashicorp/vault/helper/testhelpers/teststorage"
 	consulstorage "github.com/hashicorp/vault/helper/testhelpers/teststorage/consul"
 	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/physical/raft"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/vault"
 )
@@ -62,24 +60,7 @@ func testRaftHANewCluster(t *testing.T, bundler teststorage.PhysicalBackendBundl
 
 	teststorage.RaftHASetup(&conf, &opts, bundler)
 	cluster := vault.NewTestCluster(t, &conf, &opts)
-	cluster.Start()
 	defer cluster.Cleanup()
-
-	addressProvider := &testhelpers.TestRaftServerAddressProvider{Cluster: cluster}
-
-	leaderCore := cluster.Cores[0]
-	atomic.StoreUint32(&vault.TestingUpdateClusterAddr, 1)
-
-	// Seal the leader so we can install an address provider
-	{
-		testhelpers.EnsureCoreSealed(t, leaderCore)
-		leaderCore.UnderlyingHAStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
-		cluster.UnsealCore(t, leaderCore)
-		vault.TestWaitActive(t, leaderCore.Core)
-	}
-
-	// Now unseal core for join commands to work
-	testhelpers.EnsureCoresUnsealed(t, cluster)
 
 	joinFunc := func(client *api.Client, addClientCerts bool) {
 		req := &api.RaftJoinRequest{
@@ -164,7 +145,6 @@ func TestRaft_HA_ExistingCluster(t *testing.T) {
 		storage.Setup(&conf, &opts)
 
 		cluster := vault.NewTestCluster(t, &conf, &opts)
-		cluster.Start()
 		defer func() {
 			cluster.Cleanup()
 			storage.Cleanup(t, cluster)
@@ -186,7 +166,6 @@ func TestRaft_HA_ExistingCluster(t *testing.T) {
 		haStorage.Setup(&conf, &opts)
 
 		cluster := vault.NewTestCluster(t, &conf, &opts)
-		cluster.Start()
 		defer func() {
 			cluster.Cleanup()
 			haStorage.Cleanup(t, cluster)
@@ -196,16 +175,8 @@ func TestRaft_HA_ExistingCluster(t *testing.T) {
 		cluster.BarrierKeys = clusterBarrierKeys
 		cluster.RootToken = clusterRootToken
 
-		addressProvider := &testhelpers.TestRaftServerAddressProvider{Cluster: cluster}
-		atomic.StoreUint32(&vault.TestingUpdateClusterAddr, 1)
-
-		// Seal the leader so we can install an address provider
 		leaderCore := cluster.Cores[0]
-		{
-			testhelpers.EnsureCoreSealed(t, leaderCore)
-			leaderCore.UnderlyingHAStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
-			testhelpers.EnsureCoreUnsealed(t, cluster, leaderCore)
-		}
+		testhelpers.EnsureCoreUnsealed(t, cluster, leaderCore)
 
 		// Call the bootstrap on the leader and then ensure that it becomes active
 		leaderClient := cluster.Cores[0].Client
@@ -217,10 +188,6 @@ func TestRaft_HA_ExistingCluster(t *testing.T) {
 			}
 			vault.TestWaitActive(t, leaderCore.Core)
 		}
-
-		// Set address provider
-		cluster.Cores[1].UnderlyingHAStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
-		cluster.Cores[2].UnderlyingHAStorage.(*raft.RaftBackend).SetServerAddressProvider(addressProvider)
 
 		// Now unseal core for join commands to work
 		testhelpers.EnsureCoresUnsealed(t, cluster)

--- a/vault/external_tests/sealmigration/seal_migration_test.go
+++ b/vault/external_tests/sealmigration/seal_migration_test.go
@@ -4,14 +4,11 @@
 package sealmigration
 
 import (
-	"sync/atomic"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/helper/testhelpers"
 	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/helper/testhelpers/teststorage"
-	"github.com/hashicorp/vault/vault"
 )
 
 type testFunc func(t *testing.T, logger hclog.Logger, storage teststorage.ReusableStorage, basePort int)
@@ -36,10 +33,7 @@ func testVariousBackends(t *testing.T, tf testFunc, basePort int, includeRaft bo
 			logger := logger.Named("raft")
 			raftBasePort := basePort + 400
 
-			atomic.StoreUint32(&vault.TestingUpdateClusterAddr, 1)
-			addressProvider := testhelpers.NewHardcodedServerAddressProvider(numTestCores, raftBasePort+10)
-
-			storage, cleanup := teststorage.MakeReusableRaftStorage(t, logger, numTestCores, addressProvider)
+			storage, cleanup := teststorage.MakeReusableRaftStorage(t, logger, numTestCores)
 			defer cleanup()
 			tf(t, logger, storage, raftBasePort)
 		})

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -50,9 +50,6 @@ var (
 
 	raftAutopilotConfigurationStoragePath = "core/raft/autopilot/configuration"
 
-	// TestingUpdateClusterAddr is used in tests to override the cluster address
-	TestingUpdateClusterAddr uint32
-
 	ErrJoinWithoutAutoloading = errors.New("attempt to join a cluster using autoloaded licenses while not using autoloading ourself")
 )
 
@@ -1303,7 +1300,7 @@ func (c *Core) joinRaftSendAnswer(ctx context.Context, sealAccess seal.Access, r
 		return fmt.Errorf("error parsing cluster address: %w", err)
 	}
 	clusterAddr := parsedClusterAddr.Host
-	if atomic.LoadUint32(&TestingUpdateClusterAddr) == 1 && strings.HasSuffix(clusterAddr, ":0") {
+	if c.clusterAddrBridge != nil && strings.HasSuffix(clusterAddr, ":0") {
 		// We are testing and have an address provider, so just create a random
 		// addr, it will be overwritten later.
 		var err error

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1508,6 +1508,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		coreConfig.PendingRemovalMountsAllowed = base.PendingRemovalMountsAllowed
 		coreConfig.ExpirationRevokeRetryBase = base.ExpirationRevokeRetryBase
 		coreConfig.PeriodicLeaderRefreshInterval = base.PeriodicLeaderRefreshInterval
+		coreConfig.ClusterAddrBridge = base.ClusterAddrBridge
 		testApplyEntBaseConfig(coreConfig, base)
 	}
 	if coreConfig.ClusterName == "" {
@@ -1868,6 +1869,9 @@ func (testCluster *TestCluster) newCore(t testing.T, idx int, coreConfig *CoreCo
 	if opts != nil && opts.ClusterLayers != nil {
 		localConfig.ClusterNetworkLayer = opts.ClusterLayers.Layers()[idx]
 		localConfig.ClusterAddr = "https://" + localConfig.ClusterNetworkLayer.Listeners()[0].Addr().String()
+	}
+	if opts != nil && opts.BaseClusterListenPort != 0 {
+		localConfig.ClusterAddr = fmt.Sprintf("https://127.0.0.1:%d", opts.BaseClusterListenPort+idx)
 	}
 
 	switch {


### PR DESCRIPTION
To accommodate our use of ephemeral cluster ports (":0"), we have been using a ServerAddressProvider that we pass to Raft. This is because when we create the raft backend and the raft library instance, we don't know what the actual port/address each node will have, and this was a mechanism to provide that information late, after each listener has started and we do know the port. However, this required sealing a node to install the address provider, which adds some non-determinism to our tests and complicates them.

Instead, most tests are now using the inmem network layer, which has no need for a server address provider. For a handful of tests this is inconvenient, and we'd also still like to be able to run raft tests using TCP networking, so for those we use a new address provider, which doesn't need sealing or any awareness in the tests themselves.

There also some tests that don't use inmem networking or ephemeral ports: they use hardcoded ports that are chosen not to interfere with other ports/tests. For these, there's also no need for an address provider, except that we weren't properly setting the ClusterAddr based on opts.BaseClusterListenPort; now that we are, they can dispense with using an address provider.

Finally, there are also a couple of small flaky text fixes in this PR, mostly timing related.