### PR TITLE
Fix remove endpoint doc

### DIFF
--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -524,9 +524,9 @@ operations delete the secret from the external system. The unsync operation
 reports success if the targeted association is removed, does not exist, or the
 secret was already removed from the external system.
 
-| Method | Path                                                  |
-|:-------|:------------------------------------------------------|
-| `POST` | `/sys/sync/destinations/:type/:name/associations/set` |
+| Method | Path                                                     |
+|:-------|:---------------------------------------------------------|
+| `POST` | `/sys/sync/destinations/:type/:name/associations/remove` |
 
 ### Parameters
 


### PR DESCRIPTION
Backport from PR against main didn't work so I cherry-picked the commit with the fix. Not needed for version <1.15.x since the feature launched with 1.15.
```
git cherry-pick b169526d69a1d7d57c046a2299e490942a135f28
```