### PR TITLE
Secrets Sync: Bug fixes part 1

### DIFF
--- a/ui/app/adapters/sync/association.js
+++ b/ui/app/adapters/sync/association.js
@@ -50,8 +50,8 @@ export default class SyncAssociationAdapter extends ApplicationAdapter {
 
   // array of association data for each destination a secret is synced to
   fetchSyncStatus({ mount, secretName }) {
-    const url = `${this.buildURL()}/destinations?mount=${mount}&secret_name=${secretName}`;
-    return this.ajax(url, 'GET').then((resp) => {
+    const url = `${this.buildURL()}/destinations`;
+    return this.ajax(url, 'GET', { data: { mount, secret_name: secretName } }).then((resp) => {
       const { associated_destinations } = resp.data;
       const syncData = [];
       for (const key in associated_destinations) {

--- a/ui/app/adapters/sync/association.js
+++ b/ui/app/adapters/sync/association.js
@@ -20,20 +20,19 @@ export default class SyncAssociationAdapter extends ApplicationAdapter {
     return `${super.buildURL()}/destinations/${destinationType}/${destinationName}/associations${uri}`;
   }
 
-  query(store, { modelName }, query = {}) {
+  query(store, { modelName }, query) {
+    // endpoint doesn't accept the typical list query param and we don't want to pass options from lazyPaginatedQuery
     const url = this.buildURL(modelName, null, null, 'query', query);
-    return this.ajax(url, 'GET', query);
+    return this.ajax(url, 'GET');
   }
 
   // typically associations are queried for a specific destination which is what the standard query method does
   // in specific cases we can query all associations to access total_associations and total_secrets values
   queryAll() {
-    return this.query(this.store, { modelName: 'sync/association' }, { data: { list: true } }).then(
-      (response) => {
-        const { total_associations, total_secrets } = response.data;
-        return { total_associations, total_secrets };
-      }
-    );
+    return this.query(this.store, { modelName: 'sync/association' }).then((response) => {
+      const { total_associations, total_secrets } = response.data;
+      return { total_associations, total_secrets };
+    });
   }
 
   // fetch associations for many destinations
@@ -50,7 +49,7 @@ export default class SyncAssociationAdapter extends ApplicationAdapter {
 
   // array of association data for each destination a secret is synced to
   fetchSyncStatus({ mount, secretName }) {
-    const url = `${this.buildURL()}/destinations?mount=${mount}&secret_name=${secretName}`;
+    const url = `${this.buildURL()}/${mount}/${secretName}`;
     return this.ajax(url, 'GET').then((resp) => {
       const { associated_destinations } = resp.data;
       const syncData = [];

--- a/ui/app/adapters/sync/association.js
+++ b/ui/app/adapters/sync/association.js
@@ -20,19 +20,20 @@ export default class SyncAssociationAdapter extends ApplicationAdapter {
     return `${super.buildURL()}/destinations/${destinationType}/${destinationName}/associations${uri}`;
   }
 
-  query(store, { modelName }, query) {
-    // endpoint doesn't accept the typical list query param and we don't want to pass options from lazyPaginatedQuery
+  query(store, { modelName }, query = {}) {
     const url = this.buildURL(modelName, null, null, 'query', query);
-    return this.ajax(url, 'GET');
+    return this.ajax(url, 'GET', query);
   }
 
   // typically associations are queried for a specific destination which is what the standard query method does
   // in specific cases we can query all associations to access total_associations and total_secrets values
   queryAll() {
-    return this.query(this.store, { modelName: 'sync/association' }).then((response) => {
-      const { total_associations, total_secrets } = response.data;
-      return { total_associations, total_secrets };
-    });
+    return this.query(this.store, { modelName: 'sync/association' }, { data: { list: true } }).then(
+      (response) => {
+        const { total_associations, total_secrets } = response.data;
+        return { total_associations, total_secrets };
+      }
+    );
   }
 
   // fetch associations for many destinations
@@ -49,7 +50,7 @@ export default class SyncAssociationAdapter extends ApplicationAdapter {
 
   // array of association data for each destination a secret is synced to
   fetchSyncStatus({ mount, secretName }) {
-    const url = `${this.buildURL()}/${mount}/${secretName}`;
+    const url = `${this.buildURL()}/destinations?mount=${mount}&secret_name=${secretName}`;
     return this.ajax(url, 'GET').then((resp) => {
       const { associated_destinations } = resp.data;
       const syncData = [];

--- a/ui/app/adapters/sync/association.js
+++ b/ui/app/adapters/sync/association.js
@@ -20,20 +20,20 @@ export default class SyncAssociationAdapter extends ApplicationAdapter {
     return `${super.buildURL()}/destinations/${destinationType}/${destinationName}/associations${uri}`;
   }
 
-  query(store, { modelName }, query = {}) {
+  query(store, { modelName }, query) {
+    // endpoint doesn't accept the typical list query param and we don't want to pass options from lazyPaginatedQuery
     const url = this.buildURL(modelName, null, null, 'query', query);
-    return this.ajax(url, 'GET', query);
+    return this.ajax(url, 'GET');
   }
 
   // typically associations are queried for a specific destination which is what the standard query method does
   // in specific cases we can query all associations to access total_associations and total_secrets values
   queryAll() {
-    return this.query(this.store, { modelName: 'sync/association' }, { data: { list: true } }).then(
-      (response) => {
-        const { total_associations, total_secrets } = response.data;
-        return { total_associations, total_secrets };
-      }
-    );
+    const url = `${this.buildURL('sync/association')}`;
+    return this.ajax(url, 'GET', { data: { list: true } }).then((response) => {
+      const { total_associations, total_secrets } = response.data;
+      return { total_associations, total_secrets };
+    });
   }
 
   // fetch associations for many destinations

--- a/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.ts
@@ -55,6 +55,12 @@ export default class DestinationsCreateForm extends Component<Args> {
         };
   }
 
+  willDestroy() {
+    const method = this.args.destination.isNew ? 'unloadRecord' : 'rollbackAttributes';
+    this.args.destination[method]();
+    super.willDestroy();
+  }
+
   @task
   @waitFor
   *save(event: Event) {
@@ -96,8 +102,6 @@ export default class DestinationsCreateForm extends Component<Args> {
   @action
   cancel() {
     const { isNew } = this.args.destination;
-    const method = isNew ? 'unloadRecord' : 'rollbackAttributes';
-    this.args.destination[method]();
     this.router.transitionTo(`vault.cluster.sync.secrets.destinations.${isNew ? 'create' : 'destination'}`);
   }
 }

--- a/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.ts
@@ -55,12 +55,6 @@ export default class DestinationsCreateForm extends Component<Args> {
         };
   }
 
-  willDestroy() {
-    const method = this.args.destination.isNew ? 'unloadRecord' : 'rollbackAttributes';
-    this.args.destination[method]();
-    super.willDestroy();
-  }
-
   @task
   @waitFor
   *save(event: Event) {
@@ -102,6 +96,8 @@ export default class DestinationsCreateForm extends Component<Args> {
   @action
   cancel() {
     const { isNew } = this.args.destination;
+    const method = isNew ? 'unloadRecord' : 'rollbackAttributes';
+    this.args.destination[method]();
     this.router.transitionTo(`vault.cluster.sync.secrets.destinations.${isNew ? 'create' : 'destination'}`);
   }
 }

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.hbs
@@ -36,10 +36,11 @@
               <LoadingDropdownOption />
             </li>
           {{else}}
-            <li class="is-inline-block">
+            <li class="action">
               <Hds::Button
                 @text="Sync now"
-                class="link"
+                class="link is-flex-start"
+                @isFullWidth={{true}}
                 disabled={{not association.canSync}}
                 data-test-association-action="sync"
                 {{on "click" (fn this.update association "set")}}
@@ -60,7 +61,7 @@
                 data-test-association-action="unsync"
                 @isInDropdown={{true}}
                 @buttonText="Unsync"
-                @confirmMessage="This secret will be unsynced from all destinations."
+                @confirmMessage="This secret will be unsynced from this destination."
                 @onConfirmAction={{fn this.update association "remove"}}
               />
             {{/if}}

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.ts
@@ -39,9 +39,13 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   async update(association: SyncAssociationModel, operation: string) {
     try {
       await association.save({ adapterOptions: { action: operation } });
-      // this message can be expanded after testing -- deliberately generic for now
-      this.flashMessages.success(
-        'Sync operation successfully initiated. Status will be updated on secret when complete.'
+      const action: string = operation === 'set' ? 'Sync' : 'Unsync';
+      this.flashMessages.success(`${action} operation initiated.`);
+      // refresh route to update list of secrets, clearing dataset does not reload UI
+      this.router.transitionTo(
+        'vault.cluster.sync.secrets.destinations.destination.secrets',
+        this.args.destination.type,
+        this.args.destination.name
       );
     } catch (error) {
       this.flashMessages.danger(`Sync operation error: \n ${errorMessage(error)}`);

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.ts
@@ -42,6 +42,7 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
       const action: string = operation === 'set' ? 'Sync' : 'Unsync';
       this.flashMessages.success(`${action} operation initiated.`);
       // refresh route to update list of secrets, clearing dataset does not reload UI
+      this.store.clearDataset('sync/association');
       this.router.transitionTo(
         'vault.cluster.sync.secrets.destinations.destination.secrets',
         this.args.destination.type,

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.ts
@@ -41,7 +41,7 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
       await association.save({ adapterOptions: { action: operation } });
       const action: string = operation === 'set' ? 'Sync' : 'Unsync';
       this.flashMessages.success(`${action} operation initiated.`);
-      // refresh route to update list of secrets, clearing dataset does not reload UI
+      // refresh route to update displayed secrets
       this.store.clearDataset('sync/association');
       this.router.transitionTo(
         'vault.cluster.sync.secrets.destinations.destination.secrets',

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
@@ -82,6 +82,7 @@ export default class DestinationSyncPageComponent extends Component<Args> {
 
   setAssociation = task({}, async (event: Event) => {
     event.preventDefault();
+    this.error = ''; // reset error
     try {
       this.syncedSecret = '';
       const { name: destinationName, type: destinationType } = this.args.destination;

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
@@ -74,6 +74,10 @@ export default class DestinationSyncPageComponent extends Component<Args> {
   @action
   setMount(selected: Array<string>) {
     this.mountPath = selected[0] || '';
+    if (this.mountPath === '') {
+      // clear secret path when mount is cleared
+      this.secretPath = '';
+    }
   }
 
   setAssociation = task({}, async (event: Event) => {

--- a/ui/lib/sync/addon/routes/secrets/destinations/destination/secrets.ts
+++ b/ui/lib/sync/addon/routes/secrets/destinations/destination/secrets.ts
@@ -17,6 +17,12 @@ interface SyncDestinationSecretsRouteParams {
 export default class SyncDestinationSecretsRoute extends Route {
   @service declare readonly store: StoreService;
 
+  queryParams = {
+    page: {
+      refreshModel: true,
+    },
+  };
+
   model(params: SyncDestinationSecretsRouteParams) {
     const destination = this.modelFor('secrets.destinations.destination') as SyncDestinationModel;
     return hash({

--- a/ui/lib/sync/addon/routes/secrets/destinations/index.ts
+++ b/ui/lib/sync/addon/routes/secrets/destinations/index.ts
@@ -19,6 +19,18 @@ interface SyncSecretsDestinationsIndexRouteParams {
 export default class SyncSecretsDestinationsIndexRoute extends Route {
   @service declare readonly store: StoreService;
 
+  queryParams = {
+    page: {
+      refreshModel: true,
+    },
+    name: {
+      refreshModel: true,
+    },
+    type: {
+      refreshModel: true,
+    },
+  };
+
   filterData(dataset: Array<SyncDestinationModel>, name: string, type: string): Array<SyncDestinationModel> {
     let filteredDataset = dataset;
     const filter = (key: keyof SyncDestinationModel, value: string) => {

--- a/ui/mirage/handlers/sync.js
+++ b/ui/mirage/handlers/sync.js
@@ -29,7 +29,7 @@ export const associationsResponse = (schema, req) => {
 };
 
 export const syncStatusResponse = (schema, req) => {
-  const { mount, name: secret_name } = req.params;
+  const { mount, secret_name } = req.queryParams;
   const records = schema.db.syncAssociations.where({ mount, secret_name });
   if (!records.length) {
     return new Response(404, {}, { errors: [] });

--- a/ui/tests/integration/components/kv/page/kv-page-secret-details-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-details-test.js
@@ -99,9 +99,17 @@ module('Integration | Component | kv-v2 | Page::Secret::Details', function (hook
   });
 
   test('it renders secret details and toggles json view', async function (assert) {
-    assert.expect(8);
-    this.server.get(`sys/sync/associations/:mount/*name`, (schema, req) => {
+    assert.expect(9);
+    this.server.get(`sys/sync/associations/destinations`, (schema, req) => {
       assert.ok(true, 'request made to fetch sync status');
+      assert.propEqual(
+        req.queryParams,
+        {
+          mount: this.backend,
+          secret_name: this.secret,
+        },
+        'query params include mount and secret name'
+      );
       // no records so response returns 404
       return syncStatusResponse(schema, req);
     });

--- a/ui/tests/integration/components/kv/page/kv-page-secret-details-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-details-test.js
@@ -106,7 +106,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Details', function (hook
         req.queryParams,
         {
           mount: this.backend,
-          secret_name: this.secret,
+          secret_name: this.path,
         },
         'query params include mount and secret name'
       );
@@ -241,7 +241,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Details', function (hook
   });
 
   test('it renders sync status page alert', async function (assert) {
-    assert.expect(3); // assert count important because confirms request made to fetch sync status twice
+    assert.expect(5); // assert count important because confirms request made to fetch sync status twice
     const destinationName = 'my-destination';
     this.server.create('sync-association', {
       type: 'aws-sm',
@@ -249,9 +249,17 @@ module('Integration | Component | kv-v2 | Page::Secret::Details', function (hook
       mount: this.backend,
       secret_name: this.path,
     });
-    this.server.get('sys/sync/associations/:mount/*name', (schema, req) => {
+    this.server.get(`sys/sync/associations/destinations`, (schema, req) => {
       // this assertion should be hit twice, once on init and again when the 'Refresh' button is clicked
       assert.ok(true, 'request made to fetch sync status');
+      assert.propEqual(
+        req.queryParams,
+        {
+          mount: this.backend,
+          secret_name: this.path,
+        },
+        'query params include mount and secret name'
+      );
       return syncStatusResponse(schema, req);
     });
 

--- a/ui/tests/integration/components/sync/secrets/page/destinations/destination/sync-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations/destination/sync-test.js
@@ -56,6 +56,8 @@ module('Integration | Component | sync | Secrets::Page::Destinations::Destinatio
     await click(kvSuggestion.input);
     assert.dom(searchSelect.option()).hasText('my-path/', 'Nested secret path renders');
     assert.dom(searchSelect.option(1)).hasText('my-secret', 'Secret renders');
+    await click(searchSelect.removeSelected);
+    assert.dom(kvSuggestion.input).hasValue('', 'secret path value is cleared when mount is unset');
   });
 
   test('it should render secret suggestions for nested paths', async function (assert) {

--- a/ui/tests/unit/adapters/sync/associations-test.js
+++ b/ui/tests/unit/adapters/sync/associations-test.js
@@ -59,10 +59,11 @@ module('Unit | Adapter | sync | association', function (hooks) {
   });
 
   test('it should make request to correct endpoint for queryAll associations', async function (assert) {
-    assert.expect(2);
+    assert.expect(3);
 
-    this.server.get('/sys/sync/associations', () => {
+    this.server.get('/sys/sync/associations', (schema, req) => {
       assert.ok(true, 'request is made to correct endpoint for queryAll');
+      assert.propEqual(req.queryParams, { list: 'true' }, 'query params include list: true');
       return {
         data: {
           key_info: {},


### PR DESCRIPTION
 - Fix `404` error for `/sys/sync/associations/:mount/:secret` endpoint which does not work with nested secret paths because the endpoint URL has no way of differentiating between the mount and secret path. Update UI to use query params:  `/sys/sync/associations/destinations?mount=:mount&secret_name=:secret`
- Add `{ list: true }` to `GET sys/sync/associations`
- Reset sync error when form re-submits
- ~Add `willDestroy` hook to cleanup destination model in create-and-edit form~ (introduced too many regressions, caused lots of test failures. Separate ticket created to investigate.)
- Fixes pagination by adding `refreshModel` in route for params
- Fix styling for `Sync now` action (previously the grey hover only happened
## before 
<img width="239" alt="Screenshot 2023-12-18 at 6 09 05 PM" src="https://github.com/hashicorp/vault/assets/68122737/fede7945-7013-4e18-a9d1-9feec188419d">


## after
<img width="239" alt="Screenshot 2023-12-18 at 5 41 54 PM" src="https://github.com/hashicorp/vault/assets/68122737/2cd235ce-2b58-4bea-a573-17ba3ab2c181">
