### PR TITLE
[VAULT-22641] Include secret sync associations with hyperloglog estimations

### DIFF
--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -110,59 +110,61 @@ func (a *ActivityLog) computeCurrentMonthForBillingPeriodInternal(ctx context.Co
 		}
 		hllMonthlyTimestamp = timeutil.StartOfNextMonth(hllMonthlyTimestamp)
 	}
-
-	// Now we will add the clients for the current month to a copy of the billing period's hll to
-	// see how the cardinality grows.
-	billingPeriodHLLWithCurrentMonthEntityClients := billingPeriodHLL.Clone()
-	billingPeriodHLLWithCurrentMonthNonEntityClients := billingPeriodHLL.Clone()
-
 	// There's at most one month of data here. We should validate this assumption explicitly
 	if len(byMonth) > 1 {
 		return nil, errors.New(fmt.Sprintf("multiple months of data found in partial month's client count breakdowns: %+v\n", byMonth))
 	}
 
-	totalEntities := 0
-	totalNonEntities := 0
-	for _, month := range byMonth {
+	activityTypes := []string{entityActivityType, nonEntityTokenActivityType, secretSyncAssociationActivityType}
 
+	// Now we will add the clients for the current month to a copy of the billing period's hll to
+	// see how the cardinality grows.
+	hllByType := make(map[string]*hyperloglog.Sketch, len(activityTypes))
+	totalByType := make(map[string]int, len(activityTypes))
+	for _, typ := range activityTypes {
+		hllByType[typ] = billingPeriodHLL.Clone()
+	}
+
+	for _, month := range byMonth {
 		if month.NewClients == nil || month.NewClients.Counts == nil || month.Counts == nil {
 			return nil, errors.New("malformed current month used to calculate current month's activity")
 		}
 
-		// Note that the following calculations assume that all clients seen are currently in
-		// the NewClients section of byMonth. It is best to explicitly check this, just verify
-		// our assumptions about the passed in byMonth argument.
-		if month.Counts.countByType(entityActivityType) != month.NewClients.Counts.countByType(entityActivityType) ||
-			month.Counts.countByType(nonEntityTokenActivityType) != month.NewClients.Counts.countByType(nonEntityTokenActivityType) {
-			return nil, errors.New("current month clients cache assumes billing period")
-		}
-
-		// All the clients for the current month are in the newClients section, initially.
-		// We need to deduplicate these clients across the billing period by adding them
-		// into the billing period hyperloglogs.
-		entities := month.NewClients.Counts.clientsByType(entityActivityType)
-		nonEntities := month.NewClients.Counts.clientsByType(nonEntityTokenActivityType)
-		if entities != nil {
-			for entityID := range entities {
-				billingPeriodHLLWithCurrentMonthEntityClients.Insert([]byte(entityID))
-				totalEntities += 1
+		for _, typ := range activityTypes {
+			// Note that the following calculations assume that all clients seen are currently in
+			// the NewClients section of byMonth. It is best to explicitly check this, just verify
+			// our assumptions about the passed in byMonth argument.
+			if month.Counts.countByType(typ) != month.NewClients.Counts.countByType(typ) {
+				return nil, errors.New("current month clients cache assumes billing period")
 			}
-		}
-		if nonEntities != nil {
-			for nonEntityID := range nonEntities {
-				billingPeriodHLLWithCurrentMonthNonEntityClients.Insert([]byte(nonEntityID))
-				totalNonEntities += 1
+			for clientID := range month.NewClients.Counts.clientsByType(typ) {
+				// All the clients for the current month are in the newClients section, initially.
+				// We need to deduplicate these clients across the billing period by adding them
+				// into the billing period hyperloglogs.
+				hllByType[typ].Insert([]byte(clientID))
+				totalByType[typ] += 1
 			}
 		}
 	}
-	// The number of new entities for the current month is approximately the size of the hll with
-	// the current month's entities minus the size of the initial billing period hll.
-	currentMonthNewEntities := billingPeriodHLLWithCurrentMonthEntityClients.Estimate() - billingPeriodHLL.Estimate()
-	currentMonthNewNonEntities := billingPeriodHLLWithCurrentMonthNonEntityClients.Estimate() - billingPeriodHLL.Estimate()
+	currentMonthNewByType := make(map[string]int, len(activityTypes))
+	for _, typ := range activityTypes {
+		// The number of new entities for the current month is approximately the size of the hll with
+		// the current month's entities minus the size of the initial billing period hll.
+		currentMonthNewByType[typ] = int(hllByType[typ].Estimate() - billingPeriodHLL.Estimate())
+	}
+
 	return &activity.MonthRecord{
-		Timestamp:  timeutil.StartOfMonth(endTime).UTC().Unix(),
-		NewClients: &activity.NewClientRecord{Counts: &activity.CountsRecord{EntityClients: int(currentMonthNewEntities), NonEntityClients: int(currentMonthNewNonEntities)}},
-		Counts:     &activity.CountsRecord{EntityClients: totalEntities, NonEntityClients: totalNonEntities},
+		Timestamp: timeutil.StartOfMonth(endTime).UTC().Unix(),
+		NewClients: &activity.NewClientRecord{Counts: &activity.CountsRecord{
+			EntityClients:          currentMonthNewByType[entityActivityType],
+			NonEntityClients:       currentMonthNewByType[nonEntityTokenActivityType],
+			SecretSyncAssociations: currentMonthNewByType[secretSyncAssociationActivityType],
+		}},
+		Counts: &activity.CountsRecord{
+			EntityClients:          totalByType[entityActivityType],
+			NonEntityClients:       totalByType[nonEntityTokenActivityType],
+			SecretSyncAssociations: totalByType[secretSyncAssociationActivityType],
+		},
 	}, nil
 }
 

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -115,7 +115,7 @@ func (a *ActivityLog) computeCurrentMonthForBillingPeriodInternal(ctx context.Co
 		return nil, errors.New(fmt.Sprintf("multiple months of data found in partial month's client count breakdowns: %+v\n", byMonth))
 	}
 
-	activityTypes := []string{entityActivityType, nonEntityTokenActivityType, secretSyncAssociationActivityType}
+	activityTypes := []string{entityActivityType, nonEntityTokenActivityType, secretSyncActivityType}
 
 	// Now we will add the clients for the current month to a copy of the billing period's hll to
 	// see how the cardinality grows.
@@ -156,14 +156,14 @@ func (a *ActivityLog) computeCurrentMonthForBillingPeriodInternal(ctx context.Co
 	return &activity.MonthRecord{
 		Timestamp: timeutil.StartOfMonth(endTime).UTC().Unix(),
 		NewClients: &activity.NewClientRecord{Counts: &activity.CountsRecord{
-			EntityClients:          currentMonthNewByType[entityActivityType],
-			NonEntityClients:       currentMonthNewByType[nonEntityTokenActivityType],
-			SecretSyncAssociations: currentMonthNewByType[secretSyncAssociationActivityType],
+			EntityClients:    currentMonthNewByType[entityActivityType],
+			NonEntityClients: currentMonthNewByType[nonEntityTokenActivityType],
+			SecretSyncs:      currentMonthNewByType[secretSyncActivityType],
 		}},
 		Counts: &activity.CountsRecord{
-			EntityClients:          totalByType[entityActivityType],
-			NonEntityClients:       totalByType[nonEntityTokenActivityType],
-			SecretSyncAssociations: totalByType[secretSyncAssociationActivityType],
+			EntityClients:    totalByType[entityActivityType],
+			NonEntityClients: totalByType[nonEntityTokenActivityType],
+			SecretSyncs:      totalByType[secretSyncActivityType],
 		},
 	}, nil
 }

--- a/vault/activity_log_util_common_test.go
+++ b/vault/activity_log_util_common_test.go
@@ -18,28 +18,31 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// Test_ActivityLog_ComputeCurrentMonthForBillingPeriodInternal creates 3 months of hyperloglogs and fills them with
-// overlapping clients. The test calls computeCurrentMonthForBillingPeriodInternal with the current month map having
-// some overlap with the previous months. The test then verifies that the results have the correct number of entity and
-// non-entity clients. The test also calls computeCurrentMonthForBillingPeriodInternal with an empty current month map,
+// Test_ActivityLog_ComputeCurrentMonthForBillingPeriodInternal creates 3 months
+// of hyperloglogs and fills them with overlapping clients. The test calls
+// computeCurrentMonthForBillingPeriodInternal with the current month map having
+// some overlap with the previous months. The test then verifies that the
+// results have the correct number of entity, non-entity, and secret sync
+// association clients. The test also calls
+// computeCurrentMonthForBillingPeriodInternal with an empty current month map,
 // and verifies that the results are all 0.
 func Test_ActivityLog_ComputeCurrentMonthForBillingPeriodInternal(t *testing.T) {
-	// populate the first month with clients 1-10
+	// populate the first month with clients 1-20
 	monthOneHLL := hyperloglog.New()
-	// populate the second month with clients 5-15
+	// populate the second month with clients 10-30
 	monthTwoHLL := hyperloglog.New()
-	// populate the third month with clients 10-20
+	// populate the third month with clients 20-40
 	monthThreeHLL := hyperloglog.New()
 
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 40; i++ {
 		clientID := []byte(fmt.Sprintf("client_%d", i))
-		if i < 10 {
+		if i < 20 {
 			monthOneHLL.Insert(clientID)
 		}
-		if 5 <= i && i < 15 {
+		if 10 <= i && i < 20 {
 			monthTwoHLL.Insert(clientID)
 		}
-		if 10 <= i && i < 20 {
+		if 20 <= i && i < 40 {
 			monthThreeHLL.Insert(clientID)
 		}
 	}
@@ -58,50 +61,68 @@ func Test_ActivityLog_ComputeCurrentMonthForBillingPeriodInternal(t *testing.T) 
 	}
 
 	// Let's add 2 entities exclusive to month 1 (clients 0,1),
-	// 2 entities shared by month 1 and 2 (clients 5,6),
-	// 2 entities shared by month 2 and 3 (clients 10,11), and
-	// 2 entities exclusive to month 3 (15,16). Furthermore, we can add
-	// 3 new entities (clients 20,21, and 22).
-	entitiesStruct := make(map[string]struct{}, 0)
-	entitiesStruct["client_0"] = struct{}{}
-	entitiesStruct["client_1"] = struct{}{}
-	entitiesStruct["client_5"] = struct{}{}
-	entitiesStruct["client_6"] = struct{}{}
-	entitiesStruct["client_10"] = struct{}{}
-	entitiesStruct["client_11"] = struct{}{}
-	entitiesStruct["client_15"] = struct{}{}
-	entitiesStruct["client_16"] = struct{}{}
-	entitiesStruct["client_20"] = struct{}{}
-	entitiesStruct["client_21"] = struct{}{}
-	entitiesStruct["client_22"] = struct{}{}
+	// 2 entities shared by month 1 and 2 (clients 10,11),
+	// 2 entities shared by month 2 and 3 (clients 20,21), and
+	// 2 entities exclusive to month 3 (30,31). Furthermore, we can add
+	// 3 new entities (clients 40,41,42).
+	entitiesStruct := map[string]struct{}{
+		"client_0":  {},
+		"client_1":  {},
+		"client_10": {},
+		"client_11": {},
+		"client_20": {},
+		"client_21": {},
+		"client_30": {},
+		"client_31": {},
+		"client_40": {},
+		"client_41": {},
+		"client_42": {},
+	}
 
 	// We will add 3 nonentity clients from month 1 (clients 2,3,4),
-	// 3 shared by months 1 and 2 (7,8,9),
-	// 3 shared by months 2 and 3 (12,13,14), and
-	// 3 exclusive to month 3 (17,18,19). We will also
-	// add 4 new nonentity clients.
-	nonEntitiesStruct := make(map[string]struct{}, 0)
-	nonEntitiesStruct["client_2"] = struct{}{}
-	nonEntitiesStruct["client_3"] = struct{}{}
-	nonEntitiesStruct["client_4"] = struct{}{}
-	nonEntitiesStruct["client_7"] = struct{}{}
-	nonEntitiesStruct["client_8"] = struct{}{}
-	nonEntitiesStruct["client_9"] = struct{}{}
-	nonEntitiesStruct["client_12"] = struct{}{}
-	nonEntitiesStruct["client_13"] = struct{}{}
-	nonEntitiesStruct["client_14"] = struct{}{}
-	nonEntitiesStruct["client_17"] = struct{}{}
-	nonEntitiesStruct["client_18"] = struct{}{}
-	nonEntitiesStruct["client_19"] = struct{}{}
-	nonEntitiesStruct["client_23"] = struct{}{}
-	nonEntitiesStruct["client_24"] = struct{}{}
-	nonEntitiesStruct["client_25"] = struct{}{}
-	nonEntitiesStruct["client_26"] = struct{}{}
+	// 3 shared by months 1 and 2 (12,13,14),
+	// 3 shared by months 2 and 3 (22,23,24), and
+	// 3 exclusive to month 3 (32,33,34). We will also
+	// add 4 new nonentity clients (43,44,45,46)
+	nonEntitiesStruct := map[string]struct{}{
+		"client_2":  {},
+		"client_3":  {},
+		"client_4":  {},
+		"client_12": {},
+		"client_13": {},
+		"client_14": {},
+		"client_22": {},
+		"client_23": {},
+		"client_24": {},
+		"client_32": {},
+		"client_33": {},
+		"client_34": {},
+		"client_43": {},
+		"client_44": {},
+		"client_45": {},
+		"client_46": {},
+	}
+
+	// secret syncs have 1 client from month 1 (5)
+	// 1 shared by months 1 and 2 (15)
+	// 1 shared by months 2 and 3 (25)
+	// 2 exclusive to month 3 (35,36)
+	// and 2 new clients (47,48)
+	secretSyncAssociationStruct := map[string]struct{}{
+		"client_5":  {},
+		"client_15": {},
+		"client_25": {},
+		"client_35": {},
+		"client_36": {},
+		"client_47": {},
+		"client_48": {},
+	}
 
 	counts := &processCounts{
 		ClientsByType: map[string]clientIDSet{
-			entityActivityType:         entitiesStruct,
-			nonEntityTokenActivityType: nonEntitiesStruct,
+			entityActivityType:                entitiesStruct,
+			nonEntityTokenActivityType:        nonEntitiesStruct,
+			secretSyncAssociationActivityType: secretSyncAssociationStruct,
 		},
 	}
 
@@ -122,48 +143,29 @@ func Test_ActivityLog_ComputeCurrentMonthForBillingPeriodInternal(t *testing.T) 
 	startTime := timeutil.MonthsPreviousTo(3, endTime)
 
 	monthRecord, err := a.computeCurrentMonthForBillingPeriodInternal(context.Background(), currentMonthClientsMap, mockHLLGetFunc, startTime, endTime)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	// We should have 11 entity clients and 16 nonentity clients, and 3 new entity clients
-	// and 4 new nonentity clients
-	if monthRecord.Counts.EntityClients != 11 {
-		t.Fatalf("wrong number of entity clients. Expected 11, got %d", monthRecord.Counts.EntityClients)
-	}
-	if monthRecord.Counts.NonEntityClients != 16 {
-		t.Fatalf("wrong number of non entity clients. Expected 16, got %d", monthRecord.Counts.NonEntityClients)
-	}
-	if monthRecord.NewClients.Counts.EntityClients != 3 {
-		t.Fatalf("wrong number of new entity clients. Expected 3, got %d", monthRecord.NewClients.Counts.EntityClients)
-	}
-	if monthRecord.NewClients.Counts.NonEntityClients != 4 {
-		t.Fatalf("wrong number of new non entity clients. Expected 4, got %d", monthRecord.NewClients.Counts.NonEntityClients)
-	}
+	require.Equal(t, &activity.CountsRecord{
+		EntityClients:          11,
+		NonEntityClients:       16,
+		SecretSyncAssociations: 7,
+	}, monthRecord.Counts)
+
+	require.Equal(t, &activity.CountsRecord{
+		EntityClients:          3,
+		NonEntityClients:       4,
+		SecretSyncAssociations: 2,
+	}, monthRecord.NewClients.Counts)
 
 	// Attempt to compute current month when no records exist
 	endTime = time.Now().UTC()
 	startTime = timeutil.StartOfMonth(endTime)
 	emptyClientsMap := make(map[int64]*processMonth, 0)
 	monthRecord, err = a.computeCurrentMonthForBillingPeriodInternal(context.Background(), emptyClientsMap, mockHLLGetFunc, startTime, endTime)
-	if err != nil {
-		t.Fatalf("failed to compute empty current month, err: %v", err)
-	}
+	require.NoError(t, err)
 
-	// We should have 0 entity clients, nonentity clients,new entity clients
-	// and new nonentity clients
-	if monthRecord.Counts.EntityClients != 0 {
-		t.Fatalf("wrong number of entity clients. Expected 0, got %d", monthRecord.Counts.EntityClients)
-	}
-	if monthRecord.Counts.NonEntityClients != 0 {
-		t.Fatalf("wrong number of non entity clients. Expected 0, got %d", monthRecord.Counts.NonEntityClients)
-	}
-	if monthRecord.NewClients.Counts.EntityClients != 0 {
-		t.Fatalf("wrong number of new entity clients. Expected 0, got %d", monthRecord.NewClients.Counts.EntityClients)
-	}
-	if monthRecord.NewClients.Counts.NonEntityClients != 0 {
-		t.Fatalf("wrong number of new non entity clients. Expected 0, got %d", monthRecord.NewClients.Counts.NonEntityClients)
-	}
+	require.Equal(t, &activity.CountsRecord{}, monthRecord.Counts)
+	require.Equal(t, &activity.CountsRecord{}, monthRecord.NewClients.Counts)
 }
 
 // writeEntitySegment writes a single segment file with the given time and index for an entity

--- a/vault/activity_log_util_common_test.go
+++ b/vault/activity_log_util_common_test.go
@@ -111,7 +111,7 @@ func Test_ActivityLog_ComputeCurrentMonthForBillingPeriodInternal(t *testing.T) 
 	// 1 shared by months 2 and 3 (25)
 	// 2 exclusive to month 3 (35,36)
 	// and 2 new clients (47,48)
-	secretSyncAssociationStruct := map[string]struct{}{
+	secretSyncStruct := map[string]struct{}{
 		"client_5":  {},
 		"client_15": {},
 		"client_25": {},
@@ -123,9 +123,9 @@ func Test_ActivityLog_ComputeCurrentMonthForBillingPeriodInternal(t *testing.T) 
 
 	counts := &processCounts{
 		ClientsByType: map[string]clientIDSet{
-			entityActivityType:                entitiesStruct,
-			nonEntityTokenActivityType:        nonEntitiesStruct,
-			secretSyncAssociationActivityType: secretSyncAssociationStruct,
+			entityActivityType:         entitiesStruct,
+			nonEntityTokenActivityType: nonEntitiesStruct,
+			secretSyncActivityType:     secretSyncStruct,
 		},
 	}
 
@@ -149,15 +149,15 @@ func Test_ActivityLog_ComputeCurrentMonthForBillingPeriodInternal(t *testing.T) 
 	require.NoError(t, err)
 
 	require.Equal(t, &activity.CountsRecord{
-		EntityClients:          11,
-		NonEntityClients:       16,
-		SecretSyncAssociations: 7,
+		EntityClients:    11,
+		NonEntityClients: 16,
+		SecretSyncs:      7,
 	}, monthRecord.Counts)
 
 	require.Equal(t, &activity.CountsRecord{
-		EntityClients:          3,
-		NonEntityClients:       4,
-		SecretSyncAssociations: 2,
+		EntityClients:    3,
+		NonEntityClients: 4,
+		SecretSyncs:      2,
 	}, monthRecord.NewClients.Counts)
 
 	// Attempt to compute current month when no records exist

--- a/vault/activity_log_util_common_test.go
+++ b/vault/activity_log_util_common_test.go
@@ -60,6 +60,9 @@ func Test_ActivityLog_ComputeCurrentMonthForBillingPeriodInternal(t *testing.T) 
 		return nil, fmt.Errorf("bad start time")
 	}
 
+	// Below we register the entity, non-entity, and secret sync clients that
+	// are seen in the current month
+
 	// Let's add 2 entities exclusive to month 1 (clients 0,1),
 	// 2 entities shared by month 1 and 2 (clients 10,11),
 	// 2 entities shared by month 2 and 3 (clients 20,21), and


### PR DESCRIPTION
This PR adds secret sync association estimates to hyperloglog calculations for the current month count. 