### PR TITLE
configurable log level for tests via VAULT_TEST_LOG_LEVEL

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -387,7 +387,7 @@ jobs:
           
           # shellcheck disable=SC2086 # can't quote RERUN_FAILS
           GOARCH=${{ inputs.go-arch }} \
-            gotestsum --format=short-verbose \
+            VAULT_TEST_LOG_LEVEL=off gotestsum --format=short-verbose \
               --junitfile test-results/go-test/results-${{ matrix.id }}.xml \
               --jsonfile test-results/go-test/results-${{ matrix.id }}.json \
               --jsonfile-timing-events failure-summary-${{ matrix.id }}${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}.json \

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -387,7 +387,7 @@ jobs:
           
           # shellcheck disable=SC2086 # can't quote RERUN_FAILS
           GOARCH=${{ inputs.go-arch }} \
-            VAULT_TEST_LOG_LEVEL=off gotestsum --format=short-verbose \
+            gotestsum --format=short-verbose \
               --junitfile test-results/go-test/results-${{ matrix.id }}.xml \
               --jsonfile test-results/go-test/results-${{ matrix.id }}.json \
               --jsonfile-timing-events failure-summary-${{ matrix.id }}${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}.json \

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -382,7 +382,7 @@ jobs:
           VAULT_TEST_LOG_DIR="$(pwd)/test-results/go-test/logs-${{ matrix.id }}"
           export VAULT_TEST_LOG_DIR
           mkdir -p "$VAULT_TEST_LOG_DIR"
-          export VAULT_TEST_LOG_LEVEL=info
+          export VAULT_TEST_LOG_LEVEL=off
           
           
           # shellcheck disable=SC2086 # can't quote RERUN_FAILS

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -382,6 +382,7 @@ jobs:
           VAULT_TEST_LOG_DIR="$(pwd)/test-results/go-test/logs-${{ matrix.id }}"
           export VAULT_TEST_LOG_DIR
           mkdir -p "$VAULT_TEST_LOG_DIR"
+          export VAULT_TEST_LOG_LEVEL=info
           
           
           # shellcheck disable=SC2086 # can't quote RERUN_FAILS

--- a/builtin/credential/aws/path_role_test.go
+++ b/builtin/credential/aws/path_role_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/awsutil"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
+
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	vlttesting "github.com/hashicorp/vault/helper/testhelpers/logical"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/helper/policyutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -1011,7 +1011,7 @@ func TestRoleResolutionWithSTSEndpointConfigured(t *testing.T) {
 	}
 
 	// Ensure aws credentials are available locally for testing.
-	logger := logging.NewVaultLogger(hclog.Debug)
+	logger := corehelpers.Logger
 	credsConfig := &awsutil.CredentialsConfig{Logger: logger}
 	credsChain, err := credsConfig.GenerateCredentialChain()
 	if err != nil {

--- a/builtin/credential/aws/pkcs7/pkcs7_test.go
+++ b/builtin/credential/aws/pkcs7/pkcs7_test.go
@@ -11,9 +11,8 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"log"
+	"io"
 	"math/big"
-	"os"
 	"time"
 )
 
@@ -206,7 +205,6 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 		issuerKey = priv
 	}
 
-	log.Println("creating cert", name, "issued by", issuerCert.Subject.CommonName, "with sigalg", sigAlg)
 	switch priv.(type) {
 	case *rsa.PrivateKey:
 		switch issuerKey.(type) {
@@ -247,7 +245,7 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 	if err != nil {
 		return nil, err
 	}
-	pem.Encode(os.Stdout, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	pem.Encode(io.Discard, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
 	return &certKeyPair{
 		Certificate: cert,
 		PrivateKey:  &priv,

--- a/builtin/credential/aws/pkcs7/sign_test.go
+++ b/builtin/credential/aws/pkcs7/sign_test.go
@@ -7,8 +7,8 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"io/ioutil"
-	"log"
 	"math/big"
 	"os"
 	"os/exec"
@@ -44,7 +44,6 @@ func TestSign(t *testing.T) {
 					t.Fatalf("test %s/%s/%s: cannot generate signer cert: %s", sigalgroot, sigalginter, sigalgsigner, err)
 				}
 				for _, testDetach := range []bool{false, true} {
-					log.Printf("test %s/%s/%s detached %t\n", sigalgroot, sigalginter, sigalgsigner, testDetach)
 					toBeSigned, err := NewSignedData(content)
 					if err != nil {
 						t.Fatalf("test %s/%s/%s: cannot initialize signed data: %s", sigalgroot, sigalginter, sigalgsigner, err)
@@ -64,7 +63,7 @@ func TestSign(t *testing.T) {
 					if err != nil {
 						t.Fatalf("test %s/%s/%s: cannot finish signing data: %s", sigalgroot, sigalginter, sigalgsigner, err)
 					}
-					pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: signed})
+					pem.Encode(io.Discard, &pem.Block{Type: "PKCS7", Bytes: signed})
 					p7, err := Parse(signed)
 					if err != nil {
 						t.Fatalf("test %s/%s/%s: cannot parse signed data: %s", sigalgroot, sigalginter, sigalgsigner, err)
@@ -207,7 +206,7 @@ func ExampleSignedData() {
 	if err != nil {
 		fmt.Printf("Cannot finish signing data: %s", err)
 	}
-	pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: detachedSignature})
+	pem.Encode(io.Discard, &pem.Block{Type: "PKCS7", Bytes: detachedSignature})
 }
 
 func TestUnmarshalSignedAttribute(t *testing.T) {
@@ -255,7 +254,7 @@ func TestDegenerateCertificate(t *testing.T) {
 		t.Fatal(err)
 	}
 	testOpenSSLParse(t, deg)
-	pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: deg})
+	pem.Encode(io.Discard, &pem.Block{Type: "PKCS7", Bytes: deg})
 }
 
 // writes the cert to a temporary file and tests that openssl can read it.

--- a/builtin/credential/okta/backend_test.go
+++ b/builtin/credential/okta/backend_test.go
@@ -11,15 +11,15 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/helper/testhelpers"
-	logicaltest "github.com/hashicorp/vault/helper/testhelpers/logical"
-	"github.com/hashicorp/vault/sdk/helper/logging"
-	"github.com/hashicorp/vault/sdk/helper/policyutil"
-	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/okta/okta-sdk-golang/v2/okta"
 	"github.com/okta/okta-sdk-golang/v2/okta/query"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/vault/helper/testhelpers"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
+	logicaltest "github.com/hashicorp/vault/helper/testhelpers/logical"
+	"github.com/hashicorp/vault/sdk/helper/policyutil"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 // To run this test, set the following env variables:
@@ -51,7 +51,7 @@ func TestBackend_Config(t *testing.T) {
 	defaultLeaseTTLVal := time.Hour * 12
 	maxLeaseTTLVal := time.Hour * 24
 	b, err := Factory(context.Background(), &logical.BackendConfig{
-		Logger: logging.NewVaultLogger(log.Trace),
+		Logger: corehelpers.Logger,
 		System: &logical.StaticSystemView{
 			DefaultLeaseTTLVal: defaultLeaseTTLVal,
 			MaxLeaseTTLVal:     maxLeaseTTLVal,

--- a/builtin/credential/okta/path_groups_test.go
+++ b/builtin/credential/okta/path_groups_test.go
@@ -11,8 +11,7 @@ import (
 
 	"github.com/go-test/deep"
 
-	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -94,7 +93,7 @@ func getBackend(t *testing.T) (logical.Backend, logical.Storage) {
 	maxLeaseTTLVal := time.Hour * 24
 
 	config := &logical.BackendConfig{
-		Logger: logging.NewVaultLogger(log.Trace),
+		Logger: corehelpers.Logger,
 
 		System: &logical.StaticSystemView{
 			DefaultLeaseTTLVal: defaultLeaseTTLVal,

--- a/builtin/logical/transit/path_certificates_test.go
+++ b/builtin/logical/transit/path_certificates_test.go
@@ -14,12 +14,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/builtin/logical/pki"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTransit_Certs_CreateCsr(t *testing.T) {
@@ -179,7 +180,6 @@ func testTransit_ImportCertChain(t *testing.T, apiClient *api.Client, keyType st
 		Type:  "CERTIFICATE REQUEST",
 		Bytes: reqCsrBytes,
 	})
-	t.Logf("csr: %v", string(pemTemplateCsr))
 
 	// Create CSR from template CSR fields and key in transit
 	resp, err := apiClient.Logical().Write(fmt.Sprintf("transit/keys/%s/csr", keyName), map[string]interface{}{
@@ -231,8 +231,6 @@ func testTransit_ImportCertChain(t *testing.T, apiClient *api.Client, keyType st
 	require.NoError(t, err)
 
 	require.NoError(t, leafCert.CheckSignatureFrom(rootCert))
-	t.Logf("root: %v", rootCertPEM)
-	t.Logf("leaf: %v", leafCertPEM)
 
 	certificateChain := strings.Join([]string{leafCertPEM, rootCertPEM}, "\n")
 	// Import certificate chain to transit key version

--- a/builtin/plugin/backend_lazyLoad_test.go
+++ b/builtin/plugin/backend_lazyLoad_test.go
@@ -8,11 +8,11 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hashicorp/vault/sdk/helper/logging"
-
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/sdk/helper/pluginutil"
 
 	"github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/plugin"
@@ -54,7 +54,7 @@ func testLazyLoad(t *testing.T, methodWrapper func() error) *PluginBackend {
 
 	ctx := context.Background()
 	config := &logical.BackendConfig{
-		Logger: logging.NewVaultLogger(hclog.Trace),
+		Logger: corehelpers.Logger,
 		System: sysView,
 		Config: map[string]string{
 			"plugin_name": "test-plugin",
@@ -144,7 +144,7 @@ func (b *testBackend) SpecialPaths() *logical.Paths {
 }
 
 func (b *testBackend) Logger() hclog.Logger {
-	return logging.NewVaultLogger(hclog.Trace)
+	return corehelpers.Logger
 }
 
 func (b *testBackend) HandleRequest(context.Context, *logical.Request) (*logical.Response, error) {

--- a/command/agent/approle_end_to_end_test.go
+++ b/command/agent/approle_end_to_end_test.go
@@ -13,15 +13,14 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
 	"github.com/hashicorp/vault/command/agentproxyshared/auth"
 	agentapprole "github.com/hashicorp/vault/command/agentproxyshared/auth/approle"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink/file"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
@@ -68,7 +67,7 @@ func TestAppRoleEndToEnd(t *testing.T) {
 
 func testAppRoleEndToEnd(t *testing.T, removeSecretIDFile bool, bindSecretID bool, secretIDLess bool, expectToken bool) {
 	var err error
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	coreConfig := &vault.CoreConfig{
 		DisableMlock: true,
 		DisableCache: true,
@@ -471,7 +470,7 @@ func TestAppRoleWithWrapping(t *testing.T) {
 
 func testAppRoleWithWrapping(t *testing.T, bindSecretID bool, secretIDLess bool, expectToken bool) {
 	var err error
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	coreConfig := &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
 			"approle": credAppRole.Factory,

--- a/command/agent/auto_auth_preload_token_end_to_end_test.go
+++ b/command/agent/auto_auth_preload_token_end_to_end_test.go
@@ -10,21 +10,20 @@ import (
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
 	"github.com/hashicorp/vault/command/agentproxyshared/auth"
 	agentAppRole "github.com/hashicorp/vault/command/agentproxyshared/auth/approle"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink/file"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
 
 func TestTokenPreload_UsingAutoAuth(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	coreConfig := &vault.CoreConfig{
 		LogicalBackends: map[string]logical.Factory{
 			"kv": vault.LeasedPassthroughBackendFactory,

--- a/command/agent/aws_end_to_end_test.go
+++ b/command/agent/aws_end_to_end_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
-	hclog "github.com/hashicorp/go-hclog"
 	uuid "github.com/hashicorp/go-uuid"
+
 	"github.com/hashicorp/vault/api"
 	vaultaws "github.com/hashicorp/vault/builtin/credential/aws"
 	"github.com/hashicorp/vault/command/agentproxyshared/auth"
@@ -23,8 +23,8 @@ import (
 	"github.com/hashicorp/vault/command/agentproxyshared/sink"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink/file"
 	"github.com/hashicorp/vault/helper/testhelpers"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
@@ -59,7 +59,7 @@ func TestAWSEndToEnd(t *testing.T) {
 	}
 	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	coreConfig := &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
 			"aws": vaultaws.Factory,

--- a/command/agent/cache_end_to_end_test.go
+++ b/command/agent/cache_end_to_end_test.go
@@ -12,8 +12,6 @@ import (
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
-	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
 	"github.com/hashicorp/vault/command/agentproxyshared/auth"
@@ -22,10 +20,10 @@ import (
 	"github.com/hashicorp/vault/command/agentproxyshared/sink"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink/file"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink/inmem"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/helper/useragent"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/consts"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
@@ -42,7 +40,7 @@ path "/auth/token/create" {
 
 func TestCache_UsingAutoAuthToken(t *testing.T) {
 	var err error
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	coreConfig := &vault.CoreConfig{
 		LogicalBackends: map[string]logical.Factory{
 			"kv": vault.LeasedPassthroughBackendFactory,
@@ -159,7 +157,7 @@ func TestCache_UsingAutoAuthToken(t *testing.T) {
 		"remove_secret_id_file_after_reading": true,
 	}
 
-	cacheLogger := logging.NewVaultLogger(hclog.Trace).Named("cache")
+	cacheLogger := corehelpers.Logger.Named("cache")
 
 	// Create the API proxier
 	apiProxy, err := cache.NewAPIProxy(&cache.APIProxyConfig{

--- a/command/agent/cert_end_to_end_test.go
+++ b/command/agent/cert_end_to_end_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	vaultcert "github.com/hashicorp/vault/builtin/credential/cert"
 	"github.com/hashicorp/vault/builtin/logical/pki"
@@ -21,9 +20,9 @@ import (
 	"github.com/hashicorp/vault/command/agentproxyshared/sink"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink/file"
 	"github.com/hashicorp/vault/helper/dhutil"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
@@ -64,7 +63,7 @@ func TestCertEndToEnd(t *testing.T) {
 }
 
 func testCertEndToEnd(t *testing.T, withCertRoleName, ahWrapping bool) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	coreConfig := &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
 			"cert": vaultcert.Factory,
@@ -303,7 +302,7 @@ func testCertEndToEnd(t *testing.T, withCertRoleName, ahWrapping bool) {
 }
 
 func TestCertEndToEnd_CertsInConfig(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	coreConfig := &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
 			"cert": vaultcert.Factory,

--- a/command/agent/cf_end_to_end_test.go
+++ b/command/agent/cf_end_to_end_test.go
@@ -10,23 +10,23 @@ import (
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
 	credCF "github.com/hashicorp/vault-plugin-auth-cf"
 	"github.com/hashicorp/vault-plugin-auth-cf/testing/certificates"
 	cfAPI "github.com/hashicorp/vault-plugin-auth-cf/testing/cf"
+
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agentproxyshared/auth"
 	agentcf "github.com/hashicorp/vault/command/agentproxyshared/auth/cf"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink/file"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
 
 func TestCFEndToEnd(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 
 	coreConfig := &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{

--- a/command/agent/exec/exec_test.go
+++ b/command/agent/exec/exec_test.go
@@ -22,8 +22,9 @@ import (
 	ctconfig "github.com/hashicorp/consul-template/config"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-retryablehttp"
+
 	"github.com/hashicorp/vault/command/agent/config"
-	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/sdk/helper/pointerutil"
 )
 
@@ -252,7 +253,7 @@ func TestExecServer_Run(t *testing.T) {
 			}
 
 			execServer, err := NewServer(&ServerConfig{
-				Logger: logging.NewVaultLogger(hclog.Trace),
+				Logger: corehelpers.Logger,
 				AgentConfig: &config.Config{
 					Vault: &config.Vault{
 						Address: fakeVault.URL,
@@ -271,7 +272,7 @@ func TestExecServer_Run(t *testing.T) {
 						StaticSecretRenderInt: testCase.staticSecretRenderInterval,
 					},
 				},
-				LogLevel:  hclog.Trace,
+				LogLevel:  corehelpers.TestLogLevel,
 				LogWriter: hclog.DefaultOutput,
 			})
 			if err != nil {
@@ -449,7 +450,7 @@ func TestExecServer_LogFiles(t *testing.T) {
 			}
 
 			execServer, err := NewServer(&ServerConfig{
-				Logger: logging.NewVaultLogger(hclog.Trace),
+				Logger: corehelpers.Logger,
 				AgentConfig: &config.Config{
 					Vault: &config.Vault{
 						Address: fakeVault.URL,
@@ -467,7 +468,7 @@ func TestExecServer_LogFiles(t *testing.T) {
 						StaticSecretRenderInt: 5 * time.Second,
 					},
 				},
-				LogLevel:  hclog.Trace,
+				LogLevel:  corehelpers.TestLogLevel,
 				LogWriter: hclog.DefaultOutput,
 			})
 			if err != nil {

--- a/command/agent/jwt_end_to_end_test.go
+++ b/command/agent/jwt_end_to_end_test.go
@@ -11,17 +11,17 @@ import (
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
 	vaultjwt "github.com/hashicorp/vault-plugin-auth-jwt"
+
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agentproxyshared/auth"
 	agentjwt "github.com/hashicorp/vault/command/agentproxyshared/auth/jwt"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink/file"
 	"github.com/hashicorp/vault/helper/dhutil"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
@@ -53,7 +53,7 @@ func TestJWTEndToEnd(t *testing.T) {
 }
 
 func testJWTEndToEnd(t *testing.T, ahWrapping, useSymlink, removeJWTAfterReading bool) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	coreConfig := &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
 			"jwt": vaultjwt.Factory,

--- a/command/agent/oci_end_to_end_test.go
+++ b/command/agent/oci_end_to_end_test.go
@@ -10,16 +10,16 @@ import (
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
 	vaultoci "github.com/hashicorp/vault-plugin-auth-oci"
+
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agentproxyshared/auth"
 	agentoci "github.com/hashicorp/vault/command/agentproxyshared/auth/oci"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink/file"
 	"github.com/hashicorp/vault/helper/testhelpers"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
@@ -57,7 +57,7 @@ func TestOCIEndToEnd(t *testing.T) {
 	}
 	testhelpers.SkipUnlessEnvVarsSet(t, credNames)
 
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	coreConfig := &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
 			"oci": vaultoci.Factory,

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -16,16 +16,18 @@ import (
 
 	ctconfig "github.com/hashicorp/consul-template/config"
 	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/test/bufconn"
+
 	"github.com/hashicorp/vault/command/agent/config"
 	"github.com/hashicorp/vault/command/agent/internal/ctmanager"
 	"github.com/hashicorp/vault/command/agentproxyshared"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/internalshared/configutil"
 	"github.com/hashicorp/vault/internalshared/listenerutil"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/helper/pointerutil"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/test/bufconn"
 )
 
 func newRunnerConfig(s *ServerConfig, configs ctconfig.TemplateConfigs) (*ctconfig.Config, error) {
@@ -363,7 +365,7 @@ func TestServerRun(t *testing.T) {
 
 			ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
 			sc := ServerConfig{
-				Logger: logging.NewVaultLogger(hclog.Trace),
+				Logger: corehelpers.Logger,
 				AgentConfig: &config.Config{
 					Vault: &config.Vault{
 						Address: ts.URL,
@@ -375,7 +377,7 @@ func TestServerRun(t *testing.T) {
 						ExitOnRetryFailure: tc.exitOnRetryFailure,
 					},
 				},
-				LogLevel:      hclog.Trace,
+				LogLevel:      corehelpers.TestLogLevel,
 				LogWriter:     hclog.DefaultOutput,
 				ExitAfterAuth: true,
 			}

--- a/command/agent/token_file_end_to_end_test.go
+++ b/command/agent/token_file_end_to_end_test.go
@@ -10,18 +10,17 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/command/agentproxyshared/auth"
 	token_file "github.com/hashicorp/vault/command/agentproxyshared/auth/token-file"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink/file"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/vault"
 )
 
 func TestTokenFileEndToEnd(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
 		HandlerFunc: vaulthttp.Handler,
 	})

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -2510,7 +2510,7 @@ vault {
 			wg.Add(1)
 			var code int
 			go func() {
-				code = cmd.Run([]string{"-config", configPath})
+				code = cmd.Run([]string{"-config", configPath, "-log-level", "error"})
 				close(cmdRunDoneCh)
 				wg.Done()
 			}()

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -24,20 +24,21 @@ import (
 	"github.com/hashicorp/go-hclog"
 	vaultjwt "github.com/hashicorp/vault-plugin-auth-jwt"
 	logicalKv "github.com/hashicorp/vault-plugin-secrets-kv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/vault/api"
 	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
 	"github.com/hashicorp/vault/command/agent"
 	agentConfig "github.com/hashicorp/vault/command/agent/config"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	"github.com/hashicorp/vault/helper/useragent"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/consts"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/helper/pointerutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -106,7 +107,7 @@ func TestAgent_ExitAfterAuth(t *testing.T) {
 }
 
 func testAgentExitAfterAuth(t *testing.T, viaFlag bool) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	coreConfig := &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
 			"jwt": vaultjwt.Factory,
@@ -308,7 +309,7 @@ func TestAgent_RequireRequestHeader(t *testing.T) {
 	//----------------------------------------------------
 
 	// Start a vault server
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t,
 		&vault.CoreConfig{
 			CredentialBackends: map[string]logical.Factory{
@@ -457,7 +458,7 @@ listener "tcp" {
 // non-zero code if configured to force the use of an auto-auth token without
 // configuring the auto_auth block
 func TestAgent_RequireAutoAuthWithForce(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	// Create a config file
 	config := fmt.Sprintf(`
 cache {
@@ -493,7 +494,7 @@ func TestAgent_Template_UserAgent(t *testing.T) {
 	//----------------------------------------------------
 	// Start the server and agent
 	//----------------------------------------------------
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	var h userAgentHandler
 	cluster := vault.NewTestCluster(t,
 		&vault.CoreConfig{
@@ -674,7 +675,7 @@ func TestAgent_Template_Basic(t *testing.T) {
 	//----------------------------------------------------
 	// Start the server and agent
 	//----------------------------------------------------
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t,
 		&vault.CoreConfig{
 			CredentialBackends: map[string]logical.Factory{
@@ -980,7 +981,7 @@ func TestAgent_Template_VaultClientFromEnv(t *testing.T) {
 	//----------------------------------------------------
 	// Start the server and agent
 	//----------------------------------------------------
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t,
 		&vault.CoreConfig{
 			CredentialBackends: map[string]logical.Factory{
@@ -1158,7 +1159,7 @@ func TestAgent_Template_ExitCounter(t *testing.T) {
 	//----------------------------------------------------
 	// Start the server and agent
 	//----------------------------------------------------
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t,
 		&vault.CoreConfig{
 			CredentialBackends: map[string]logical.Factory{
@@ -1436,7 +1437,7 @@ func TestAgent_Template_Retry(t *testing.T) {
 	//----------------------------------------------------
 	// Start the server and agent
 	//----------------------------------------------------
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	var h handler
 	cluster := vault.NewTestCluster(t,
 		&vault.CoreConfig{
@@ -1724,7 +1725,7 @@ auto_auth {
 // Uses the custom handler userAgentHandler (defined above) so
 // that Vault validates the User-Agent on requests sent by Agent.
 func TestAgent_AutoAuth_UserAgent(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	var h userAgentHandler
 	cluster := vault.NewTestCluster(t, &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
@@ -1850,7 +1851,7 @@ api_proxy {
 // userAgentHandler struct defined in this test package, so that Vault validates the
 // User-Agent on requests sent by Agent.
 func TestAgent_APIProxyWithoutCache_UserAgent(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	userAgentForProxiedClient := "proxied-client"
 	var h userAgentHandler
 	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
@@ -1937,7 +1938,7 @@ vault {
 // userAgentHandler struct defined in this test package, so that Vault validates the
 // User-Agent on requests sent by Agent.
 func TestAgent_APIProxyWithCache_UserAgent(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	userAgentForProxiedClient := "proxied-client"
 	var h userAgentHandler
 	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
@@ -2024,7 +2025,7 @@ vault {
 }
 
 func TestAgent_Cache_DynamicSecret(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
 		HandlerFunc: vaulthttp.Handler,
 	})
@@ -2132,7 +2133,7 @@ func TestAgent_ApiProxy_Retry(t *testing.T) {
 	//----------------------------------------------------
 	// Start the server and agent
 	//----------------------------------------------------
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	var h handler
 	cluster := vault.NewTestCluster(t,
 		&vault.CoreConfig{
@@ -2284,7 +2285,7 @@ func TestAgent_TemplateConfig_ExitOnRetryFailure(t *testing.T) {
 	//----------------------------------------------------
 	// Start the server and agent
 	//----------------------------------------------------
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t,
 		&vault.CoreConfig{
 			CredentialBackends: map[string]logical.Factory{
@@ -2612,7 +2613,7 @@ listener "tcp" {
 	defer os.Remove(configPath)
 
 	// Start the agent
-	ui, cmd := testAgentCommand(t, logging.NewVaultLogger(hclog.Trace))
+	ui, cmd := testAgentCommand(t, corehelpers.Logger)
 	cmd.client = serverClient
 	cmd.startedCh = make(chan struct{})
 
@@ -2914,7 +2915,7 @@ func TestAgent_Config_ReloadTls(t *testing.T) {
 	configFile := populateTempFile(t, "agent-config.hcl", replacedHcl)
 
 	// Set up Agent/cmd
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	ui, cmd := testAgentCommand(t, logger)
 
 	var output string
@@ -3001,7 +3002,7 @@ func TestAgent_Config_ReloadTls(t *testing.T) {
 // without a TLS configuration. Prior to fixing GitHub issue #19480, this
 // would cause a panic.
 func TestAgent_NonTLSListener_SIGHUP(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
 		HandlerFunc: vaulthttp.Handler,
 	})

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -91,6 +91,7 @@ func testAgentCommand(tb testing.TB, logger hclog.Logger) (*cli.MockUi, *AgentCo
 		ShutdownCh: MakeShutdownCh(),
 		SighupCh:   MakeSighupCh(),
 		logger:     logger,
+		logWriter:  io.Discard,
 		startedCh:  make(chan struct{}, 5),
 		reloadedCh: make(chan struct{}, 5),
 	}

--- a/command/agentproxyshared/auth/auth_test.go
+++ b/command/agentproxyshared/auth/auth_test.go
@@ -9,11 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/builtin/credential/userpass"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
@@ -75,7 +74,7 @@ func TestAuthHandler(t *testing.T) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
 	ah := NewAuthHandler(&AuthHandlerConfig{
-		Logger: logging.NewVaultLogger(hclog.Trace).Named("auth.handler"),
+		Logger: corehelpers.Logger.Named("auth.handler"),
 		Client: client,
 	})
 

--- a/command/agentproxyshared/auth/kubernetes/kubernetes_test.go
+++ b/command/agentproxyshared/auth/kubernetes/kubernetes_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/errwrap"
-	hclog "github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/vault/command/agentproxyshared/auth"
-	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 )
 
 func TestKubernetesAuth_basic(t *testing.T) {
@@ -41,7 +41,7 @@ func TestKubernetesAuth_basic(t *testing.T) {
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
 			authCfg := auth.AuthConfig{
-				Logger:    logging.NewVaultLogger(hclog.Trace),
+				Logger:    corehelpers.Logger,
 				MountPath: "kubernetes",
 				Config: map[string]interface{}{
 					"role": "plugin-test",

--- a/command/agentproxyshared/auth/token-file/token_file_test.go
+++ b/command/agentproxyshared/auth/token-file/token_file_test.go
@@ -8,13 +8,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/command/agentproxyshared/auth"
-	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 )
 
 func TestNewTokenFileAuthMethodEmptyConfig(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	_, err := NewTokenFileAuthMethod(&auth.AuthConfig{
 		Logger: logger.Named("auth.method"),
 		Config: map[string]interface{}{},
@@ -25,7 +24,7 @@ func TestNewTokenFileAuthMethodEmptyConfig(t *testing.T) {
 }
 
 func TestNewTokenFileEmptyFilePath(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	_, err := NewTokenFileAuthMethod(&auth.AuthConfig{
 		Logger: logger.Named("auth.method"),
 		Config: map[string]interface{}{
@@ -48,7 +47,7 @@ func TestNewTokenFileAuthenticate(t *testing.T) {
 	os.WriteFile(tokenFileName, []byte(tokenFileContents), 0o666)
 	defer os.Remove(tokenFileName)
 
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	am, err := NewTokenFileAuthMethod(&auth.AuthConfig{
 		Logger: logger.Named("auth.method"),
 		Config: map[string]interface{}{

--- a/command/agentproxyshared/cache/api_proxy_test.go
+++ b/command/agentproxyshared/cache/api_proxy_test.go
@@ -12,14 +12,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/helper/useragent"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
@@ -36,7 +35,7 @@ func TestAPIProxy(t *testing.T) {
 
 	proxier, err := NewAPIProxy(&APIProxyConfig{
 		Client:                  client,
-		Logger:                  logging.NewVaultLogger(hclog.Trace),
+		Logger:                  corehelpers.Logger,
 		UserAgentStringFunction: useragent.ProxyStringWithProxiedUserAgent,
 		UserAgentString:         useragent.ProxyAPIProxyString(),
 	})
@@ -74,7 +73,7 @@ func TestAPIProxyNoCache(t *testing.T) {
 
 	proxier, err := NewAPIProxy(&APIProxyConfig{
 		Client:                  client,
-		Logger:                  logging.NewVaultLogger(hclog.Trace),
+		Logger:                  corehelpers.Logger,
 		UserAgentStringFunction: useragent.ProxyStringWithProxiedUserAgent,
 		UserAgentString:         useragent.ProxyAPIProxyString(),
 	})
@@ -114,7 +113,7 @@ func TestAPIProxy_queryParams(t *testing.T) {
 
 	proxier, err := NewAPIProxy(&APIProxyConfig{
 		Client:                  client,
-		Logger:                  logging.NewVaultLogger(hclog.Trace),
+		Logger:                  corehelpers.Logger,
 		UserAgentStringFunction: useragent.ProxyStringWithProxiedUserAgent,
 		UserAgentString:         useragent.ProxyAPIProxyString(),
 	})

--- a/command/agentproxyshared/cache/cache_test.go
+++ b/command/agentproxyshared/cache/cache_test.go
@@ -16,15 +16,15 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	"github.com/hashicorp/go-hclog"
 	kv "github.com/hashicorp/vault-plugin-secrets-kv"
+
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agentproxyshared/cache/cachememdb"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink/mock"
 	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/consts"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
@@ -69,7 +69,7 @@ func TestCache_AutoAuthTokenStripping(t *testing.T) {
 	vault.TestWaitActive(t, cores[0].Core)
 	client := cores[0].Client
 
-	cacheLogger := logging.NewVaultLogger(hclog.Trace).Named("cache")
+	cacheLogger := corehelpers.Logger.Named("cache")
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -158,7 +158,7 @@ func TestCache_AutoAuthClientTokenProxyStripping(t *testing.T) {
 	vault.TestWaitActive(t, cores[0].Core)
 	client := cores[0].Client
 
-	cacheLogger := logging.NewVaultLogger(hclog.Trace).Named("cache")
+	cacheLogger := corehelpers.Logger.Named("cache")
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)

--- a/command/agentproxyshared/cache/lease_cache_test.go
+++ b/command/agentproxyshared/cache/lease_cache_test.go
@@ -21,18 +21,19 @@ import (
 	"github.com/go-test/deep"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agentproxyshared/cache/cacheboltdb"
 	"github.com/hashicorp/vault/command/agentproxyshared/cache/cachememdb"
 	"github.com/hashicorp/vault/command/agentproxyshared/cache/keymanager"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/helper/useragent"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/cryptoutil"
-	"github.com/hashicorp/vault/sdk/helper/logging"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
 
 func testNewLeaseCache(t *testing.T, responses []*SendResponse) *LeaseCache {
@@ -46,7 +47,7 @@ func testNewLeaseCache(t *testing.T, responses []*SendResponse) *LeaseCache {
 		Client:              client,
 		BaseContext:         context.Background(),
 		Proxier:             NewMockProxier(responses),
-		Logger:              logging.NewVaultLogger(hclog.Trace).Named("cache.leasecache"),
+		Logger:              corehelpers.Logger.Named("cache.leasecache"),
 		CacheStaticSecrets:  true,
 		CacheDynamicSecrets: true,
 		UserAgentToUse:      "test",
@@ -69,7 +70,7 @@ func testNewLeaseCacheWithDelay(t *testing.T, cacheable bool, delay int) *LeaseC
 		Client:              client,
 		BaseContext:         context.Background(),
 		Proxier:             &mockDelayProxier{cacheable, delay},
-		Logger:              logging.NewVaultLogger(hclog.Trace).Named("cache.leasecache"),
+		Logger:              corehelpers.Logger.Named("cache.leasecache"),
 		CacheStaticSecrets:  true,
 		CacheDynamicSecrets: true,
 		UserAgentToUse:      "test",
@@ -91,7 +92,7 @@ func testNewLeaseCacheWithPersistence(t *testing.T, responses []*SendResponse, s
 		Client:              client,
 		BaseContext:         context.Background(),
 		Proxier:             NewMockProxier(responses),
-		Logger:              logging.NewVaultLogger(hclog.Trace).Named("cache.leasecache"),
+		Logger:              corehelpers.Logger.Named("cache.leasecache"),
 		Storage:             storage,
 		CacheStaticSecrets:  true,
 		CacheDynamicSecrets: true,

--- a/command/agentproxyshared/cache/static_secret_cache_updater_test.go
+++ b/command/agentproxyshared/cache/static_secret_cache_updater_test.go
@@ -10,20 +10,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
 	kv "github.com/hashicorp/vault-plugin-secrets-kv"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"nhooyr.io/websocket"
+
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agentproxyshared/cache/cacheboltdb"
 	"github.com/hashicorp/vault/command/agentproxyshared/cache/cachememdb"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
-	"nhooyr.io/websocket"
 )
 
 // Avoiding a circular dependency in the test.
@@ -60,7 +60,7 @@ func testNewStaticSecretCacheUpdater(t *testing.T, client *api.Client) *StaticSe
 	updater, err := NewStaticSecretCacheUpdater(&StaticSecretCacheUpdaterConfig{
 		Client:     client,
 		LeaseCache: lc,
-		Logger:     logging.NewVaultLogger(hclog.Trace).Named("cache.updater"),
+		Logger:     corehelpers.Logger.Named("cache.updater"),
 		TokenSink:  tokenSink,
 	})
 	if err != nil {
@@ -76,7 +76,7 @@ func TestNewStaticSecretCacheUpdater(t *testing.T) {
 
 	lc := testNewLeaseCache(t, []*SendResponse{})
 	config := api.DefaultConfig()
-	logger := logging.NewVaultLogger(hclog.Trace).Named("cache.updater")
+	logger := corehelpers.Logger.Named("cache.updater")
 	client, err := api.NewClient(config)
 	if err != nil {
 		t.Fatal(err)
@@ -114,7 +114,7 @@ func TestNewStaticSecretCacheUpdater(t *testing.T) {
 	updater, err = NewStaticSecretCacheUpdater(&StaticSecretCacheUpdaterConfig{
 		Client:     client,
 		LeaseCache: lc,
-		Logger:     logging.NewVaultLogger(hclog.Trace).Named("cache.updater"),
+		Logger:     corehelpers.Logger.Named("cache.updater"),
 		TokenSink:  nil,
 	})
 	require.Error(t, err)
@@ -124,7 +124,7 @@ func TestNewStaticSecretCacheUpdater(t *testing.T) {
 	updater, err = NewStaticSecretCacheUpdater(&StaticSecretCacheUpdaterConfig{
 		Client:     client,
 		LeaseCache: lc,
-		Logger:     logging.NewVaultLogger(hclog.Trace).Named("cache.updater"),
+		Logger:     corehelpers.Logger.Named("cache.updater"),
 		TokenSink:  tokenSink,
 	})
 	if err != nil {

--- a/command/agentproxyshared/cache/static_secret_capability_manager_test.go
+++ b/command/agentproxyshared/cache/static_secret_capability_manager_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agentproxyshared/cache/cachememdb"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/helper/testhelpers/minimal"
-	"github.com/hashicorp/vault/sdk/helper/logging"
-	"github.com/stretchr/testify/require"
 )
 
 // testNewStaticSecretCapabilityManager returns a new StaticSecretCapabilityManager
@@ -24,7 +24,7 @@ func testNewStaticSecretCapabilityManager(t *testing.T, client *api.Client) *Sta
 
 	updater, err := NewStaticSecretCapabilityManager(&StaticSecretCapabilityManagerConfig{
 		LeaseCache: lc,
-		Logger:     logging.NewVaultLogger(hclog.Trace).Named("cache.capabilitiesmanager"),
+		Logger:     corehelpers.Logger.Named("cache.capabilitiesmanager"),
 		Client:     client,
 		StaticSecretTokenCapabilityRefreshInterval: 250 * time.Millisecond,
 	})
@@ -41,7 +41,7 @@ func TestNewStaticSecretCapabilityManager(t *testing.T) {
 	t.Parallel()
 
 	lc := testNewLeaseCache(t, []*SendResponse{})
-	logger := logging.NewVaultLogger(hclog.Trace).Named("cache.capabilitiesmanager")
+	logger := corehelpers.Logger.Named("cache.capabilitiesmanager")
 	client, err := api.NewClient(api.DefaultConfig())
 	require.Nil(t, err)
 
@@ -73,7 +73,7 @@ func TestNewStaticSecretCapabilityManager(t *testing.T) {
 	// Don't expect an error if the arguments are as expected
 	updater, err = NewStaticSecretCapabilityManager(&StaticSecretCapabilityManagerConfig{
 		LeaseCache: lc,
-		Logger:     logging.NewVaultLogger(hclog.Trace).Named("cache.capabilitiesmanager"),
+		Logger:     corehelpers.Logger.Named("cache.capabilitiesmanager"),
 		Client:     client,
 	})
 	if err != nil {
@@ -90,7 +90,7 @@ func TestNewStaticSecretCapabilityManager(t *testing.T) {
 	// Lastly, double check that the refresh interval can be properly set
 	updater, err = NewStaticSecretCapabilityManager(&StaticSecretCapabilityManagerConfig{
 		LeaseCache: lc,
-		Logger:     logging.NewVaultLogger(hclog.Trace).Named("cache.capabilitiesmanager"),
+		Logger:     corehelpers.Logger.Named("cache.capabilitiesmanager"),
 		Client:     client,
 		StaticSecretTokenCapabilityRefreshInterval: time.Hour,
 	})

--- a/command/agentproxyshared/helpers_test.go
+++ b/command/agentproxyshared/helpers_test.go
@@ -8,10 +8,9 @@ import (
 	"os"
 	"testing"
 
-	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agentproxyshared/cache"
-	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 )
 
 func testNewLeaseCache(t *testing.T, responses []*cache.SendResponse) *cache.LeaseCache {
@@ -25,7 +24,7 @@ func testNewLeaseCache(t *testing.T, responses []*cache.SendResponse) *cache.Lea
 		Client:              client,
 		BaseContext:         context.Background(),
 		Proxier:             cache.NewMockProxier(responses),
-		Logger:              logging.NewVaultLogger(hclog.Trace).Named("cache.leasecache"),
+		Logger:              corehelpers.Logger.Named("cache.leasecache"),
 		CacheDynamicSecrets: true,
 		UserAgentToUse:      "test",
 	})
@@ -75,7 +74,7 @@ func Test_AddPersistentStorageToLeaseCache(t *testing.T) {
 		t.Fatal("persistent storage was available before ours was added")
 	}
 
-	deferFunc, token, err := AddPersistentStorageToLeaseCache(context.Background(), leaseCache, persistConfig, logging.NewVaultLogger(hclog.Info))
+	deferFunc, token, err := AddPersistentStorageToLeaseCache(context.Background(), leaseCache, persistConfig, corehelpers.Logger)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/command/agentproxyshared/sink/file/file_sink_test.go
+++ b/command/agentproxyshared/sink/file/file_sink_test.go
@@ -12,8 +12,9 @@ import (
 
 	hclog "github.com/hashicorp/go-hclog"
 	uuid "github.com/hashicorp/go-uuid"
+
 	"github.com/hashicorp/vault/command/agentproxyshared/sink"
-	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 )
 
 const (
@@ -45,7 +46,7 @@ func testFileSink(t *testing.T, log hclog.Logger) (*sink.SinkConfig, string) {
 }
 
 func TestFileSink(t *testing.T) {
-	log := logging.NewVaultLogger(hclog.Trace)
+	log := corehelpers.Logger
 
 	fs, tmpDir := testFileSink(t, log)
 	defer os.RemoveAll(tmpDir)
@@ -110,7 +111,7 @@ func testFileSinkMode(t *testing.T, log hclog.Logger) (*sink.SinkConfig, string)
 }
 
 func TestFileSinkMode(t *testing.T) {
-	log := logging.NewVaultLogger(hclog.Trace)
+	log := corehelpers.Logger
 
 	fs, tmpDir := testFileSinkMode(t, log)
 	defer os.RemoveAll(tmpDir)

--- a/command/agentproxyshared/sink/file/sink_test.go
+++ b/command/agentproxyshared/sink/file/sink_test.go
@@ -15,12 +15,13 @@ import (
 
 	hclog "github.com/hashicorp/go-hclog"
 	uuid "github.com/hashicorp/go-uuid"
+
 	"github.com/hashicorp/vault/command/agentproxyshared/sink"
-	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 )
 
 func TestSinkServer(t *testing.T) {
-	log := logging.NewVaultLogger(hclog.Trace)
+	log := corehelpers.Logger
 
 	fs1, path1 := testFileSink(t, log)
 	defer os.RemoveAll(path1)
@@ -90,7 +91,7 @@ func (b *badSink) WriteToken(token string) error {
 }
 
 func TestSinkServerRetry(t *testing.T) {
-	log := logging.NewVaultLogger(hclog.Trace)
+	log := corehelpers.Logger
 
 	b1 := &badSink{logger: log.Named("b1")}
 	b2 := &badSink{logger: log.Named("b2")}

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -156,7 +156,6 @@ func testVaultServerUnsealWithKVVersionWithSeal(tb testing.TB, kvVersion string,
 		AuditBackends:      defaultVaultAuditBackends,
 		LogicalBackends:    defaultVaultLogicalBackends,
 		BuiltinRegistry:    builtinplugins.Registry,
-		Logger:             defaultVaultLogger,
 		Seal:               seal,
 	}, &vault.TestClusterOptions{
 		HandlerFunc: vaulthttp.Handler,

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/cli"
 	log "github.com/hashicorp/go-hclog"
 	kv "github.com/hashicorp/vault-plugin-secrets-kv"
+
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/builtin/logical/pki"
@@ -155,6 +156,7 @@ func testVaultServerUnsealWithKVVersionWithSeal(tb testing.TB, kvVersion string,
 		AuditBackends:      defaultVaultAuditBackends,
 		LogicalBackends:    defaultVaultLogicalBackends,
 		BuiltinRegistry:    builtinplugins.Registry,
+		Logger:             defaultVaultLogger,
 		Seal:               seal,
 	}, &vault.TestClusterOptions{
 		HandlerFunc: vaulthttp.Handler,
@@ -234,6 +236,7 @@ func testVaultServerUninit(tb testing.TB) (*api.Client, func()) {
 	core, err := vault.NewCore(&vault.CoreConfig{
 		DisableMlock:       true,
 		Physical:           inm,
+		Logger:             defaultVaultLogger,
 		CredentialBackends: defaultVaultCredentialBackends,
 		AuditBackends:      defaultVaultAuditBackends,
 		LogicalBackends:    defaultVaultLogicalBackends,
@@ -246,6 +249,7 @@ func testVaultServerUninit(tb testing.TB) (*api.Client, func()) {
 	ln, addr := vaulthttp.TestServer(tb, core)
 
 	client, err := api.NewClient(&api.Config{
+		Logger:  defaultVaultLogger,
 		Address: addr,
 	})
 	if err != nil {

--- a/command/debug.go
+++ b/command/debug.go
@@ -21,14 +21,16 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/gatedwriter"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
-	"github.com/hashicorp/vault/api"
-	"github.com/hashicorp/vault/helper/osutil"
-	"github.com/hashicorp/vault/sdk/helper/jsonutil"
-	"github.com/hashicorp/vault/sdk/helper/logging"
-	"github.com/hashicorp/vault/version"
 	"github.com/mholt/archiver/v3"
 	"github.com/oklog/run"
 	"github.com/posener/complete"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/helper/osutil"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
+	"github.com/hashicorp/vault/sdk/helper/jsonutil"
+	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/version"
 )
 
 const (
@@ -247,7 +249,7 @@ func (c *DebugCommand) Run(args []string) int {
 	// Initialize the logger for debug output
 	gatedWriter := gatedwriter.NewWriter(os.Stderr)
 	if c.logger == nil {
-		c.logger = logging.NewVaultLoggerWithWriter(gatedWriter, hclog.Trace)
+		c.logger = logging.NewVaultLoggerWithWriter(gatedWriter, corehelpers.TestLogLevel)
 	}
 
 	dstOutputFile, err := c.preflight(args)

--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -17,8 +17,10 @@ import (
 	"time"
 
 	"github.com/hashicorp/cli"
-	"github.com/hashicorp/vault/api"
 	"github.com/mholt/archiver/v3"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 )
 
 func testDebugCommand(tb testing.TB) (*cli.MockUi, *DebugCommand) {
@@ -29,6 +31,7 @@ func testDebugCommand(tb testing.TB) (*cli.MockUi, *DebugCommand) {
 		BaseCommand: &BaseCommand{
 			UI: ui,
 		},
+		logger: corehelpers.Logger,
 	}
 }
 

--- a/command/pki_health_check_test.go
+++ b/command/pki_health_check_test.go
@@ -310,8 +310,6 @@ func execPKIHC(t *testing.T, client *api.Client, ok bool) (int, string, map[stri
 		}
 	}
 
-	t.Log(combined)
-
 	return code, combined, results
 }
 

--- a/command/pki_verify_sign_test.go
+++ b/command/pki_verify_sign_test.go
@@ -152,8 +152,6 @@ func execPKIVerifyNonJson(t *testing.T, client *api.Client, expectErrorOut bool,
 		t.Fatalf("running command `%v` unsuccessful (ret %v)\nerr: %v", strings.Join(callArgs, " "), code, stderr.String())
 	}
 
-	t.Log(stdout.String() + stderr.String())
-
 	return stdout.String(), stderr.String()
 }
 

--- a/command/proxy.go
+++ b/command/proxy.go
@@ -25,6 +25,13 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/gatedwriter"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/reloadutil"
+	"github.com/kr/pretty"
+	"github.com/oklog/run"
+	"github.com/posener/complete"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"google.golang.org/grpc/test/bufconn"
+
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agentproxyshared"
 	"github.com/hashicorp/vault/command/agentproxyshared/auth"
@@ -42,12 +49,6 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/version"
-	"github.com/kr/pretty"
-	"github.com/oklog/run"
-	"github.com/posener/complete"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-	"google.golang.org/grpc/test/bufconn"
 )
 
 var (
@@ -178,7 +179,9 @@ func (c *ProxyCommand) Run(args []string) int {
 	// Create a logger. We wrap it in a gated writer so that it doesn't
 	// start logging too early.
 	c.logGate = gatedwriter.NewWriter(os.Stderr)
-	c.logWriter = c.logGate
+	if c.logWriter == nil {
+		c.logWriter = c.logGate
+	}
 
 	if c.logFlags.flagCombineLogs {
 		c.logWriter = os.Stdout
@@ -203,12 +206,14 @@ func (c *ProxyCommand) Run(args []string) int {
 	c.applyConfigOverrides(f, config) // This only needs to happen on start-up to aggregate config from flags and env vars
 	c.config = config
 
-	l, err := c.newLogger()
-	if err != nil {
-		c.outputErrors(err)
-		return 1
+	if c.logger == nil {
+		l, err := c.newLogger()
+		if err != nil {
+			c.outputErrors(err)
+			return 1
+		}
+		c.logger = l
 	}
-	c.logger = l
 
 	// release log gate if the disable-gated-logs flag is set
 	if c.logFlags.flagDisableGatedLogs {

--- a/command/proxy_test.go
+++ b/command/proxy_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -44,6 +45,7 @@ func testProxyCommand(tb testing.TB, logger hclog.Logger) (*cli.MockUi, *ProxyCo
 		BaseCommand: &BaseCommand{
 			UI: ui,
 		},
+		logWriter:  io.Discard,
 		ShutdownCh: MakeShutdownCh(),
 		SighupCh:   MakeSighupCh(),
 		logger:     logger,
@@ -693,6 +695,7 @@ func TestProxy_Cache_DisableDynamicSecretCaching(t *testing.T) {
 	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
 		HandlerFunc: vaulthttp.Handler,
+		Logger:      logger,
 	})
 	cluster.Start()
 	defer cluster.Cleanup()

--- a/command/proxy_test.go
+++ b/command/proxy_test.go
@@ -21,18 +21,19 @@ import (
 	"github.com/hashicorp/go-hclog"
 	vaultjwt "github.com/hashicorp/vault-plugin-auth-jwt"
 	logicalKv "github.com/hashicorp/vault-plugin-secrets-kv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/vault/api"
 	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
 	"github.com/hashicorp/vault/command/agent"
 	proxyConfig "github.com/hashicorp/vault/command/proxy/config"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	"github.com/hashicorp/vault/helper/useragent"
 	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func testProxyCommand(tb testing.TB, logger hclog.Logger) (*cli.MockUi, *ProxyCommand) {
@@ -64,7 +65,7 @@ func TestProxy_ExitAfterAuth(t *testing.T) {
 }
 
 func testProxyExitAfterAuth(t *testing.T, viaFlag bool) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	coreConfig := &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
 			"jwt": vaultjwt.Factory,
@@ -246,7 +247,7 @@ auto_auth {
 // Uses the custom handler userAgentHandler (defined above) so
 // that Vault validates the User-Agent on requests sent by Proxy.
 func TestProxy_AutoAuth_UserAgent(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	var h userAgentHandler
 	cluster := vault.NewTestCluster(t, &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
@@ -406,7 +407,7 @@ api_proxy {
 // userAgentHandler struct defined in this test package, so that Vault validates the
 // User-Agent on requests sent by Proxy.
 func TestProxy_APIProxyWithoutCache_UserAgent(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	userAgentForProxiedClient := "proxied-client"
 	var h userAgentHandler
 	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
@@ -493,7 +494,7 @@ vault {
 // userAgentHandler struct defined in this test package, so that Vault validates the
 // User-Agent on requests sent by Proxy.
 func TestProxy_APIProxyWithCache_UserAgent(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	userAgentForProxiedClient := "proxied-client"
 	var h userAgentHandler
 	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
@@ -582,7 +583,7 @@ vault {
 // TestProxy_Cache_DynamicSecret tests that the cache successfully caches a dynamic secret
 // going through the Proxy, and that a subsequent request will be served from the cache.
 func TestProxy_Cache_DynamicSecret(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
 		HandlerFunc: vaulthttp.Handler,
 	})
@@ -689,7 +690,7 @@ vault {
 // TestProxy_Cache_DisableDynamicSecretCaching tests that the cache will not cache a dynamic secret
 // if disabled in the options.
 func TestProxy_Cache_DisableDynamicSecretCaching(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
 		HandlerFunc: vaulthttp.Handler,
 	})
@@ -813,7 +814,7 @@ vault {
 // TestProxy_Cache_StaticSecret Tests that the cache successfully caches a static secret
 // going through the Proxy,
 func TestProxy_Cache_StaticSecret(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
 		HandlerFunc: vaulthttp.Handler,
 	})
@@ -949,7 +950,7 @@ log_level = "trace"
 // going through the Proxy, and then the cache gets updated on a POST to the KVV1 secret due to an
 // event.
 func TestProxy_Cache_EventSystemUpdatesCacheKVV1(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t, &vault.CoreConfig{
 		LogicalBackends: map[string]logical.Factory{
 			"kv": logicalKv.Factory,
@@ -1116,7 +1117,7 @@ log_level = "trace"
 // going through the Proxy for a KVV2 secret, and then the cache gets updated on a POST to the secret due to an
 // event.
 func TestProxy_Cache_EventSystemUpdatesCacheKVV2(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t, &vault.CoreConfig{
 		LogicalBackends: map[string]logical.Factory{
 			"kv": logicalKv.VersionedKVFactory,
@@ -1295,7 +1296,7 @@ log_level = "trace"
 // going through the Proxy for a KVV2 secret, and that the cache works as expected with the
 // use_auto_auth_token=force option.
 func TestProxy_Cache_EventSystemUpdatesCacheUseAutoAuthToken(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t, &vault.CoreConfig{
 		LogicalBackends: map[string]logical.Factory{
 			"kv": logicalKv.VersionedKVFactory,
@@ -1485,7 +1486,7 @@ log_level = "trace"
 // before it updates the secret, meaning that the event system should update it from the pre-event stream
 // update as opposed to receiving the event.
 func TestProxy_Cache_EventSystemPreEventStreamUpdateWorks(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := minimal.NewTestSoloCluster(t, &vault.CoreConfig{
 		LogicalBackends: map[string]logical.Factory{
 			"kv": logicalKv.VersionedKVFactory,
@@ -1633,7 +1634,7 @@ log_level = "trace"
 // going through the Proxy for a KVV2 secret, and then the calling client loses permissions to the secret,
 // so it can no longer access the cache.
 func TestProxy_Cache_StaticSecretPermissionsLost(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t, &vault.CoreConfig{
 		LogicalBackends: map[string]logical.Factory{
 			"kv": logicalKv.VersionedKVFactory,
@@ -1806,7 +1807,7 @@ func TestProxy_ApiProxy_Retry(t *testing.T) {
 	//----------------------------------------------------
 	// Start the server and proxy
 	//----------------------------------------------------
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	var h handler
 	cluster := vault.NewTestCluster(t,
 		&vault.CoreConfig{
@@ -1956,7 +1957,7 @@ vault {
 // TestProxy_Metrics tests that metrics are being properly reported.
 func TestProxy_Metrics(t *testing.T) {
 	// Start a vault server
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	cluster := vault.NewTestCluster(t, nil,
 		&vault.TestClusterOptions{
 			HandlerFunc: vaulthttp.Handler,
@@ -2284,7 +2285,7 @@ func TestProxy_Config_ReloadTls(t *testing.T) {
 	configFile := populateTempFile(t, "proxy-config.hcl", replacedHcl)
 
 	// Set up Proxy
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	ui, cmd := testProxyCommand(t, logger)
 
 	var output string

--- a/command/transit_import_key_test.go
+++ b/command/transit_import_key_test.go
@@ -129,8 +129,7 @@ func TestTransitImport(t *testing.T) {
 		},
 	}
 
-	for index, tc := range tests {
-		t.Logf("Running test case %d: %v", index, tc)
+	for _, tc := range tests {
 		execTransitImport(t, client, tc.variant, tc.path, tc.key, tc.args, tc.shouldFail)
 	}
 }

--- a/helper/fairshare/fairshare_testing_util.go
+++ b/helper/fairshare/fairshare_testing_util.go
@@ -9,6 +9,8 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 	uuid "github.com/hashicorp/go-uuid"
+
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 )
 
 type testJob struct {
@@ -52,10 +54,8 @@ func newTestLogger(name string) log.Logger {
 	if err != nil {
 		guid = "no-guid"
 	}
-	return log.New(&log.LoggerOptions{
-		Name:  fmt.Sprintf("%s-%s", name, guid),
-		Level: log.LevelFromString("TRACE"),
-	})
+	logName := fmt.Sprintf("%s-%s", name, guid)
+	return corehelpers.Logger.Named(logName)
 }
 
 func GetNumWorkers(j *JobManager) int {

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/hashicorp/eventlogger"
 	"github.com/hashicorp/go-hclog"
+	"github.com/mitchellh/go-testing-interface"
+
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/builtin/credential/approle"
 	"github.com/hashicorp/vault/internal/observability/event"
@@ -27,7 +29,6 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/salt"
 	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/mitchellh/go-testing-interface"
 )
 
 var (
@@ -561,6 +562,11 @@ func NewTestLogger(t testing.T) *TestLogger {
 	var logPath string
 	output := os.Stderr
 
+	logLevel := hclog.Trace
+	logLevelRaw := os.Getenv("VAULT_TEST_LOG_LEVEL")
+	if logLevelRaw != "" {
+		logLevel = hclog.LevelFromString(logLevelRaw)
+	}
 	logDir := os.Getenv("VAULT_TEST_LOG_DIR")
 	if logDir != "" {
 		logPath = filepath.Join(logDir, t.Name()+".log")
@@ -586,7 +592,7 @@ func NewTestLogger(t testing.T) *TestLogger {
 	})
 	sink := hclog.NewSinkAdapter(&hclog.LoggerOptions{
 		Output:            output,
-		Level:             hclog.Trace,
+		Level:             logLevel,
 		IndependentLevels: true,
 	})
 	logger.RegisterSink(sink)

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -571,7 +571,6 @@ func NewTestLogger(t testing.T) *TestLogger {
 	logLevelRaw := os.Getenv("VAULT_TEST_LOG_LEVEL")
 	if logLevelRaw != "" {
 		logLevel = hclog.LevelFromString(logLevelRaw)
-		t.Logf("RAYMOND TESTING: logLevelRaw: %v\n", logLevel.String())
 	}
 	logDir := os.Getenv("VAULT_TEST_LOG_DIR")
 	if logDir != "" {

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -571,6 +571,7 @@ func NewTestLogger(t testing.T) *TestLogger {
 	logLevelRaw := os.Getenv("VAULT_TEST_LOG_LEVEL")
 	if logLevelRaw != "" {
 		logLevel = hclog.LevelFromString(logLevelRaw)
+		t.Logf("RAYMOND TESTING: logLevelRaw: %v\n", logLevel.String())
 	}
 	logDir := os.Getenv("VAULT_TEST_LOG_DIR")
 	if logDir != "" {

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/vault/plugins/database/mysql"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/consts"
+	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/helper/salt"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -36,7 +37,11 @@ var (
 	_ eventlogger.Node = (*noopWrapper)(nil)
 )
 
-var externalPlugins = []string{"transform", "kmip", "keymgmt"}
+var (
+	TestLogLevel    = hclog.LevelFromString(os.Getenv("VAULT_TEST_LOG_LEVEL"))
+	Logger          = logging.NewVaultLogger(TestLogLevel)
+	externalPlugins = []string{"transform", "kmip", "keymgmt"}
+)
 
 // RetryUntil runs f until it returns a nil result or the timeout is reached.
 // If a nil result hasn't been obtained by timeout, calls t.Fatal.

--- a/helper/testhelpers/logical/testing.go
+++ b/helper/testhelpers/logical/testing.go
@@ -13,12 +13,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/errwrap"
-	log "github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
 	"github.com/hashicorp/vault/vault"
@@ -158,7 +157,7 @@ func Test(tt TestT, c TestCase) {
 	}
 
 	// Create an in-memory Vault core
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 
 	phys, err := inmem.NewInmem(nil, logger)
 	if err != nil {

--- a/helper/testhelpers/logical/testing.go
+++ b/helper/testhelpers/logical/testing.go
@@ -166,6 +166,7 @@ func Test(tt TestT, c TestCase) {
 	}
 
 	config := &vault.CoreConfig{
+		Logger:          logger,
 		Physical:        phys,
 		DisableMlock:    true,
 		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),

--- a/http/events_test.go
+++ b/http/events_test.go
@@ -17,6 +17,9 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
+	"github.com/stretchr/testify/assert"
+	"nhooyr.io/websocket"
+
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/helper/namespace"
@@ -25,8 +28,6 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 	"github.com/hashicorp/vault/vault/cluster"
-	"github.com/stretchr/testify/assert"
-	"nhooyr.io/websocket"
 )
 
 // TestEventsSubscribe tests the websocket endpoint for subscribing to events
@@ -320,7 +321,7 @@ func TestCanForwardEventConnections(t *testing.T) {
 	// Run again with in-memory network
 	inmemCluster, err := cluster.NewInmemLayerCluster("inmem-cluster", 3, hclog.New(&hclog.LoggerOptions{
 		Mutex: &sync.Mutex{},
-		Level: hclog.Trace,
+		Level: corehelpers.TestLogLevel,
 		Name:  "inmem-cluster",
 	}))
 	if err != nil {

--- a/physical/gcs/gcs_ha_test.go
+++ b/physical/gcs/gcs_ha_test.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/sdk/helper/logging"
+
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/sdk/physical"
 )
 
@@ -40,7 +40,7 @@ func TestHABackend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.NewTestLogger(t)
 	config := map[string]string{
 		"bucket":     bucket,
 		"ha_enabled": "true",

--- a/physical/gcs/gcs_test.go
+++ b/physical/gcs/gcs_test.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/sdk/helper/logging"
-	"github.com/hashicorp/vault/sdk/physical"
 	"google.golang.org/api/googleapi"
+
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
+	"github.com/hashicorp/vault/sdk/physical"
 )
 
 func testCleanup(t testing.TB, client *storage.Client, bucket string) {
@@ -56,7 +56,7 @@ func TestBackend(t *testing.T) {
 	backend, err := NewBackend(map[string]string{
 		"bucket":     bucket,
 		"ha_enabled": "false",
-	}, logging.NewVaultLogger(log.Trace))
+	}, corehelpers.Logger)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/physical/oci/oci_test.go
+++ b/physical/oci/oci_test.go
@@ -5,13 +5,13 @@ import (
 	"os"
 	"testing"
 
-	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/vault/sdk/helper/logging"
-	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/oracle/oci-go-sdk/common"
 	"github.com/oracle/oci-go-sdk/objectstorage"
 	"golang.org/x/net/context"
+
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
+	"github.com/hashicorp/vault/sdk/physical"
 )
 
 func TestOCIBackend(t *testing.T) {
@@ -77,7 +77,7 @@ func createBackend(bucketName string, namespaceName string, haEnabledStr string,
 		"namespace_name":    namespaceName,
 		"ha_enabled":        haEnabledStr,
 		"lock_bucket_name":  lockBucketName,
-	}, logging.NewVaultLogger(log.Trace))
+	}, corehelpers.Logger)
 	if err != nil {
 		t.Fatalf("Failed to create new backend: %v", err)
 	}

--- a/physical/raft/fsm_test.go
+++ b/physical/raft/fsm_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/golang/protobuf/proto"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/raft"
+
 	"github.com/hashicorp/vault/sdk/physical"
 )
 
@@ -25,11 +25,6 @@ func getFSM(t testing.TB) (*FSM, string) {
 		t.Fatal(err)
 	}
 	t.Logf("raft dir: %s", raftDir)
-
-	logger := hclog.New(&hclog.LoggerOptions{
-		Name:  "raft",
-		Level: hclog.Trace,
-	})
 
 	fsm, err := NewFSM(raftDir, "", logger)
 	if err != nil {

--- a/physical/raft/snapshot_test.go
+++ b/physical/raft/snapshot_test.go
@@ -20,10 +20,16 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/raft"
+
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/sdk/plugin/pb"
 )
+
+var logger = hclog.New(&hclog.LoggerOptions{
+	Name:  "raft",
+	Level: hclog.LevelFromString(os.Getenv("VAULT_TEST_LOG_LEVEL")),
+})
 
 type idAddr struct {
 	id string
@@ -544,11 +550,6 @@ func TestBoltSnapshotStore_CreateSnapshotMissingParentDir(t *testing.T) {
 		t.Fatalf("err: %v ", err)
 	}
 
-	logger := hclog.New(&hclog.LoggerOptions{
-		Name:  "raft",
-		Level: hclog.Trace,
-	})
-
 	snap, err := NewBoltSnapshotStore(dir, logger, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -586,11 +587,6 @@ func TestBoltSnapshotStore_Listing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v ", err)
 	}
-
-	logger := hclog.New(&hclog.LoggerOptions{
-		Name:  "raft",
-		Level: hclog.Trace,
-	})
 
 	fsm, err := NewFSM(parent, "", logger)
 	if err != nil {
@@ -651,11 +647,6 @@ func TestBoltSnapshotStore_CreateInstallSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v ", err)
 	}
-
-	logger := hclog.New(&hclog.LoggerOptions{
-		Name:  "raft",
-		Level: hclog.Trace,
-	})
 
 	fsm, err := NewFSM(parent, "", logger)
 	if err != nil {
@@ -829,11 +820,6 @@ func TestBoltSnapshotStore_CancelSnapshot(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	logger := hclog.New(&hclog.LoggerOptions{
-		Name:  "raft",
-		Level: hclog.Trace,
-	})
-
 	snap, err := NewBoltSnapshotStore(dir, logger, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -899,11 +885,6 @@ func TestBoltSnapshotStore_BadPerm(t *testing.T) {
 	}
 	defer os.Chmod(dir2, 777) // Set perms back for delete
 
-	logger := hclog.New(&hclog.LoggerOptions{
-		Name:  "raft",
-		Level: hclog.Trace,
-	})
-
 	_, err = NewBoltSnapshotStore(dir2, logger, nil)
 	if err == nil {
 		t.Fatalf("should fail to use dir with bad perms")
@@ -917,11 +898,6 @@ func TestBoltSnapshotStore_CloseFailure(t *testing.T) {
 		t.Fatalf("err: %v ", err)
 	}
 	defer os.RemoveAll(dir)
-
-	logger := hclog.New(&hclog.LoggerOptions{
-		Name:  "raft",
-		Level: hclog.Trace,
-	})
 
 	snap, err := NewBoltSnapshotStore(dir, logger, nil)
 	if err != nil {

--- a/sdk/logical/testing.go
+++ b/sdk/logical/testing.go
@@ -5,12 +5,14 @@ package logical
 
 import (
 	"context"
+	"os"
 	"reflect"
 	"time"
 
 	testing "github.com/mitchellh/go-testing-interface"
 
 	log "github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/vault/sdk/helper/logging"
 )
 
@@ -81,8 +83,9 @@ func TestSystemView() *StaticSystemView {
 }
 
 func TestBackendConfig() *BackendConfig {
+	level := log.LevelFromString(os.Getenv("VAULT_TEST_LOG_LEVEL"))
 	bc := &BackendConfig{
-		Logger: logging.NewVaultLogger(log.Trace),
+		Logger: logging.NewVaultLogger(level),
 		System: TestSystemView(),
 		Config: make(map[string]string),
 	}

--- a/serviceregistration/consul/consul_service_registration_test.go
+++ b/serviceregistration/consul/consul_service_registration_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/go-test/deep"
 	"github.com/hashicorp/consul/api"
 	log "github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/vault/helper/testhelpers/consul"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
@@ -92,7 +94,7 @@ func TestConsul_ServiceRegistration(t *testing.T) {
 	const redirectAddr = "http://127.0.0.1:8200"
 
 	// Create a ServiceRegistration that points to our consul instance
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	sd, err := NewServiceRegistration(map[string]string{
 		"address": config.Address(),
 		"token":   config.Token,
@@ -595,7 +597,7 @@ func TestConsul_NewServiceRegistration_serviceTags(t *testing.T) {
 			t.Parallel()
 
 			cfg := map[string]string{"service_tags": tc.Tags}
-			logger := logging.NewVaultLogger(log.Trace)
+			logger := corehelpers.Logger
 			be, err := NewServiceRegistration(cfg, logger, sr.State{})
 			require.NoError(t, err)
 			require.NotNil(t, be)

--- a/vault/activity/query_test.go
+++ b/vault/activity/query_test.go
@@ -10,16 +10,15 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/helper/timeutil"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func NewTestQueryStore(t *testing.T) *PrecomputedQueryStore {
 	t.Helper()
 
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	view := &logical.InmemStorage{}
 	return NewPrecomputedQueryStore(logger, view, 12)
 }

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -17,14 +17,13 @@ import (
 	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 
 	"github.com/hashicorp/errwrap"
-	log "github.com/hashicorp/go-hclog"
 	uuid "github.com/hashicorp/go-uuid"
+	"github.com/mitchellh/copystructure"
+
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/mitchellh/copystructure"
 )
 
 func TestAudit_ReadOnlyViewDuringMount(t *testing.T) {
@@ -341,7 +340,7 @@ func verifyDefaultAuditTable(t *testing.T, table *MountTable) {
 }
 
 func TestAuditBroker_LogRequest(t *testing.T) {
-	l := logging.NewVaultLogger(log.Trace)
+	l := corehelpers.Logger
 	b, err := NewAuditBroker(l, true)
 	if err != nil {
 		t.Fatal(err)
@@ -433,7 +432,7 @@ func TestAuditBroker_LogRequest(t *testing.T) {
 }
 
 func TestAuditBroker_LogResponse(t *testing.T) {
-	l := logging.NewVaultLogger(log.Trace)
+	l := corehelpers.Logger
 	b, err := NewAuditBroker(l, true)
 	if err != nil {
 		t.Fatal(err)
@@ -540,7 +539,7 @@ func TestAuditBroker_LogResponse(t *testing.T) {
 }
 
 func TestAuditBroker_AuditHeaders(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 
 	b, err := NewAuditBroker(logger, true)
 	if err != nil {

--- a/vault/barrier_aes_gcm_test.go
+++ b/vault/barrier_aes_gcm_test.go
@@ -11,16 +11,15 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
-	"github.com/stretchr/testify/require"
 )
 
-var logger = logging.NewVaultLogger(log.Trace)
+var logger = corehelpers.Logger
 
 // mockBarrier returns a physical backend, security barrier, and master key
 func mockBarrier(t testing.TB) (physical.Backend, SecurityBarrier, []byte) {

--- a/vault/cluster_test.go
+++ b/vault/cluster_test.go
@@ -14,9 +14,9 @@ import (
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/sdk/helper/consts"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
@@ -44,8 +44,6 @@ func TestClusterFetching(t *testing.T) {
 }
 
 func TestClusterHAFetching(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Trace)
-
 	redirect := "http://127.0.0.1:8200"
 
 	inm, err := inmem.NewInmemHA(nil, logger)

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -17,35 +17,37 @@ import (
 	"github.com/hashicorp/vault/command/server"
 
 	logicalKv "github.com/hashicorp/vault-plugin-secrets-kv"
+
 	logicalDb "github.com/hashicorp/vault/builtin/logical/database"
 
 	"github.com/hashicorp/vault/builtin/plugin"
 
 	"github.com/hashicorp/vault/builtin/audit/syslog"
 
-	"github.com/hashicorp/vault/builtin/audit/file"
-	"github.com/hashicorp/vault/builtin/audit/socket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/vault/builtin/audit/file"
+	"github.com/hashicorp/vault/builtin/audit/socket"
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/go-uuid"
+	"github.com/sasha-s/go-deadlock"
+
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/internalshared/configutil"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
 	"github.com/hashicorp/vault/vault/seal"
 	"github.com/hashicorp/vault/version"
-	"github.com/sasha-s/go-deadlock"
 )
 
 // invalidKey is used to test Unseal
@@ -343,7 +345,7 @@ func TestNewCore_configureListeners(t *testing.T) {
 }
 
 func TestNewCore_badRedirectAddr(t *testing.T) {
-	logger = logging.NewVaultLogger(log.Trace)
+	logger = corehelpers.Logger
 
 	inm, err := inmem.NewInmem(nil, logger)
 	if err != nil {
@@ -1852,7 +1854,7 @@ func TestCore_LimitedUseToken(t *testing.T) {
 
 func TestCore_Standby_Seal(t *testing.T) {
 	// Create the first core and initialize it
-	logger = logging.NewVaultLogger(log.Trace)
+	logger = corehelpers.Logger
 
 	inm, err := inmem.NewInmemHA(nil, logger)
 	if err != nil {
@@ -1964,7 +1966,7 @@ func TestCore_Standby_Seal(t *testing.T) {
 
 func TestCore_StepDown(t *testing.T) {
 	// Create the first core and initialize it
-	logger = logging.NewVaultLogger(log.Trace).Named(t.Name())
+	logger = corehelpers.Logger.Named(t.Name())
 
 	inm, err := inmem.NewInmemHA(nil, logger)
 	if err != nil {
@@ -2158,7 +2160,7 @@ func TestCore_StepDown(t *testing.T) {
 
 func TestCore_CleanLeaderPrefix(t *testing.T) {
 	// Create the first core and initialize it
-	logger = logging.NewVaultLogger(log.Trace)
+	logger = corehelpers.Logger
 
 	inm, err := inmem.NewInmemHA(nil, logger)
 	if err != nil {
@@ -2321,7 +2323,7 @@ func TestCore_CleanLeaderPrefix(t *testing.T) {
 }
 
 func TestCore_Standby(t *testing.T) {
-	logger = logging.NewVaultLogger(log.Trace)
+	logger = corehelpers.Logger
 
 	inmha, err := inmem.NewInmemHA(nil, logger)
 	if err != nil {
@@ -2332,7 +2334,7 @@ func TestCore_Standby(t *testing.T) {
 }
 
 func TestCore_Standby_SeparateHA(t *testing.T) {
-	logger = logging.NewVaultLogger(log.Trace)
+	logger = corehelpers.Logger
 
 	inmha, err := inmem.NewInmemHA(nil, logger)
 	if err != nil {
@@ -2931,7 +2933,7 @@ func TestCore_HandleRequest_MountPointType(t *testing.T) {
 
 func TestCore_Standby_Rotate(t *testing.T) {
 	// Create the first core and initialize it
-	logger = logging.NewVaultLogger(log.Trace)
+	logger = corehelpers.Logger
 
 	inm, err := inmem.NewInmemHA(nil, logger)
 	if err != nil {
@@ -3249,7 +3251,7 @@ func TestCore_ServiceRegistration(t *testing.T) {
 	sr := &mockServiceRegistration{}
 
 	// Create the core
-	logger = logging.NewVaultLogger(log.Trace)
+	logger = corehelpers.Logger
 	inm, err := inmem.NewInmemHA(nil, logger)
 	if err != nil {
 		t.Fatal(err)

--- a/vault/custom_response_headers_test.go
+++ b/vault/custom_response_headers_test.go
@@ -10,10 +10,9 @@ import (
 	"strings"
 	"testing"
 
-	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/internalshared/configutil"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
@@ -53,7 +52,7 @@ var customHeader400 = map[string]string{
 }
 
 func TestConfigCustomHeaders(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	phys, err := inmem.NewTransactionalInmem(nil, logger)
 	if err != nil {
 		t.Fatal(err)
@@ -107,7 +106,7 @@ func TestCustomResponseHeadersConfigInteractUiConfig(t *testing.T) {
 	view := NewBarrierView(barrier, "")
 	b.(*SystemBackend).Core.systemBarrierView = view
 
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	rawListenerConfig := []*configutil.Listener{
 		{
 			Type:    "tcp",

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -20,12 +20,13 @@ import (
 	"github.com/armon/go-metrics"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
+
 	"github.com/hashicorp/vault/helper/benchhelpers"
 	"github.com/hashicorp/vault/helper/fairshare"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/sdk/framework"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
@@ -690,7 +691,7 @@ func BenchmarkExpiration_Restore_Consul(b *testing.B) {
 */
 
 func BenchmarkExpiration_Restore_InMem(b *testing.B) {
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	inm, err := inmem.NewInmem(nil, logger)
 	if err != nil {
 		b.Fatal(err)
@@ -762,7 +763,7 @@ func benchmarkExpirationBackend(b *testing.B, physicalBackend physical.Backend, 
 }
 
 func BenchmarkExpiration_Create_Leases(b *testing.B) {
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	inm, err := inmem.NewInmem(nil, logger)
 	if err != nil {
 		b.Fatal(err)

--- a/vault/external_tests/api/sys_rekey_ext_test.go
+++ b/vault/external_tests/api/sys_rekey_ext_test.go
@@ -8,12 +8,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/go-hclog"
-
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/testhelpers"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
 	"github.com/hashicorp/vault/vault"
 	"github.com/hashicorp/vault/vault/seal"
@@ -59,7 +57,7 @@ func testSysRekey_Verification(t *testing.T, recovery bool, legacyShamir bool) {
 			})
 		}
 	}
-	inm, err := inmem.NewInmemHA(nil, logging.NewVaultLogger(hclog.Debug))
+	inm, err := inmem.NewInmemHA(nil, corehelpers.Logger)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/external_tests/raftha/raft_ha_test.go
+++ b/vault/external_tests/raftha/raft_ha_test.go
@@ -6,13 +6,12 @@ package raftha
 import (
 	"testing"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/testhelpers"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/helper/testhelpers/teststorage"
 	consulstorage "github.com/hashicorp/vault/helper/testhelpers/teststorage/consul"
 	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/vault"
 )
 
@@ -127,7 +126,7 @@ func TestRaft_HA_ExistingCluster(t *testing.T) {
 		NumCores:           vault.DefaultNumCores,
 		KeepStandbysSealed: true,
 	}
-	logger := logging.NewVaultLogger(hclog.Debug).Named(t.Name())
+	logger := corehelpers.Logger
 
 	physBundle := teststorage.MakeInmemBackend(t, logger)
 	physBundle.HABackend = nil

--- a/vault/external_tests/sealmigrationext/seal_migration_pre14_test.go
+++ b/vault/external_tests/sealmigrationext/seal_migration_pre14_test.go
@@ -6,16 +6,15 @@ package sealmigrationext
 import (
 	"testing"
 
-	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/helper/testhelpers/teststorage"
 	"github.com/hashicorp/vault/helper/testhelpers/teststorage/consul"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/vault/external_tests/sealmigration"
 )
 
 func TestSealMigration_ShamirToTransit_Pre14(t *testing.T) {
 	t.Parallel()
-	logger := logging.NewVaultLogger(hclog.Debug).Named(t.Name())
+	logger := corehelpers.Logger
 	storage, cleanup := teststorage.MakeReusableStorage(t, logger,
 		consul.MakeConsulBackend(t, logger))
 	defer cleanup()
@@ -25,7 +24,7 @@ func TestSealMigration_ShamirToTransit_Pre14(t *testing.T) {
 
 func TestSealMigration_TransitToShamir_Pre14(t *testing.T) {
 	t.Parallel()
-	logger := logging.NewVaultLogger(hclog.Debug).Named(t.Name())
+	logger := corehelpers.Logger
 	storage, cleanup := teststorage.MakeReusableStorage(t, logger,
 		consul.MakeConsulBackend(t, logger))
 	defer cleanup()
@@ -35,7 +34,7 @@ func TestSealMigration_TransitToShamir_Pre14(t *testing.T) {
 
 func TestSealMigration_ShamirToTransit_Post14(t *testing.T) {
 	t.Parallel()
-	logger := logging.NewVaultLogger(hclog.Debug).Named(t.Name())
+	logger := corehelpers.Logger
 	storage, cleanup := teststorage.MakeReusableStorage(t, logger,
 		consul.MakeConsulBackend(t, logger))
 	defer cleanup()
@@ -45,7 +44,7 @@ func TestSealMigration_ShamirToTransit_Post14(t *testing.T) {
 
 func TestSealMigration_TransitToShamir_Post14(t *testing.T) {
 	t.Parallel()
-	logger := logging.NewVaultLogger(hclog.Debug).Named(t.Name())
+	logger := corehelpers.Logger
 	storage, cleanup := teststorage.MakeReusableStorage(t, logger,
 		consul.MakeConsulBackend(t, logger))
 	defer cleanup()
@@ -55,7 +54,7 @@ func TestSealMigration_TransitToShamir_Post14(t *testing.T) {
 
 func TestSealMigration_TransitToTransit_Post14(t *testing.T) {
 	t.Parallel()
-	logger := logging.NewVaultLogger(hclog.Debug).Named(t.Name())
+	logger := corehelpers.Logger
 	storage, cleanup := teststorage.MakeReusableStorage(t, logger,
 		consul.MakeConsulBackend(t, logger))
 	defer cleanup()

--- a/vault/init_test.go
+++ b/vault/init_test.go
@@ -8,8 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
 )
@@ -24,7 +23,7 @@ func testCore_NewTestCore(t *testing.T, seal Seal) (*Core, *CoreConfig) {
 }
 
 func testCore_NewTestCoreLicensing(t *testing.T, seal Seal, licensingConfig *LicensingConfig) (*Core, *CoreConfig) {
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 
 	inm, err := inmem.NewInmem(nil, logger)
 	if err != nil {

--- a/vault/logical_system_integ_test.go
+++ b/vault/logical_system_integ_test.go
@@ -9,12 +9,11 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	"github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	vaulthttp "github.com/hashicorp/vault/http"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
 	"github.com/hashicorp/vault/vault"
@@ -154,7 +153,7 @@ func TestSystemBackend_InternalUIResultantACL(t *testing.T) {
 }
 
 func TestSystemBackend_HAStatus(t *testing.T) {
-	logger := logging.NewVaultLogger(hclog.Trace)
+	logger := corehelpers.Logger
 	inm, err := inmem.NewTransactionalInmem(nil, logger)
 	if err != nil {
 		t.Fatal(err)

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -24,6 +24,9 @@ import (
 	"github.com/hashicorp/go-hclog"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	aeadwrapper "github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2"
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/require"
+
 	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/helper/builtinplugins"
 	"github.com/hashicorp/vault/helper/experiments"
@@ -37,7 +40,6 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/compressutil"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/helper/pluginruntimeutil"
 	"github.com/hashicorp/vault/sdk/helper/pluginutil"
 	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
@@ -45,8 +47,6 @@ import (
 	"github.com/hashicorp/vault/vault/plugincatalog"
 	"github.com/hashicorp/vault/vault/seal"
 	"github.com/hashicorp/vault/version"
-	"github.com/mitchellh/mapstructure"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSystemConfigCORS(t *testing.T) {
@@ -5694,7 +5694,7 @@ func TestSystemBackend_LoggersByName(t *testing.T) {
 			t.Parallel()
 
 			core, _, _ := TestCoreUnsealedWithConfig(t, &CoreConfig{
-				Logger: logging.NewVaultLogger(hclog.Trace),
+				Logger: corehelpers.Logger,
 			})
 			b := core.systemBackend
 

--- a/vault/plugincatalog/plugin_catalog_test.go
+++ b/vault/plugincatalog/plugin_catalog_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-version"
+
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
@@ -40,7 +41,7 @@ import (
 
 func testPluginCatalog(t *testing.T) *PluginCatalog {
 	logger := hclog.New(&hclog.LoggerOptions{
-		Level: hclog.Trace,
+		Level: corehelpers.TestLogLevel,
 	})
 	storage, err := inmem.NewInmem(nil, logger)
 	if err != nil {

--- a/vault/quotas/quotas_rate_limit_test.go
+++ b/vault/quotas/quotas_rate_limit_test.go
@@ -11,13 +11,13 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/helper/metricsutil"
-	"github.com/hashicorp/vault/sdk/helper/logging"
-	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"go.uber.org/goleak"
+
+	"github.com/hashicorp/vault/helper/metricsutil"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 type clientResult struct {
@@ -38,7 +38,7 @@ func TestNewRateLimitQuota(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.rlq.initialize(logging.NewVaultLogger(log.Trace), metricsutil.BlackholeSink())
+			err := tc.rlq.initialize(corehelpers.Logger, metricsutil.BlackholeSink())
 			require.Equal(t, tc.expectErr, err != nil, err)
 			if err == nil {
 				require.Nil(t, tc.rlq.close(context.Background()))
@@ -49,7 +49,7 @@ func TestNewRateLimitQuota(t *testing.T) {
 
 func TestRateLimitQuota_Close(t *testing.T) {
 	rlq := NewRateLimitQuota("test-rate-limiter", "qa", "/foo/bar", "", "", false, time.Second, time.Minute, 16.7)
-	require.NoError(t, rlq.initialize(logging.NewVaultLogger(log.Trace), metricsutil.BlackholeSink()))
+	require.NoError(t, rlq.initialize(corehelpers.Logger, metricsutil.BlackholeSink()))
 	require.NoError(t, rlq.close(context.Background()))
 
 	time.Sleep(time.Second) // allow enough time for purgeClientsLoop to receive on closeCh
@@ -69,7 +69,7 @@ func TestRateLimitQuota_Allow(t *testing.T) {
 		staleAge:      10 * time.Second,
 	}
 
-	require.NoError(t, rlq.initialize(logging.NewVaultLogger(log.Trace), metricsutil.BlackholeSink()))
+	require.NoError(t, rlq.initialize(corehelpers.Logger, metricsutil.BlackholeSink()))
 	defer rlq.close(context.Background())
 
 	var wg sync.WaitGroup
@@ -146,7 +146,7 @@ func TestRateLimitQuota_Allow_WithBlock(t *testing.T) {
 		staleAge:      10 * time.Second,
 	}
 
-	require.NoError(t, rlq.initialize(logging.NewVaultLogger(log.Trace), metricsutil.BlackholeSink()))
+	require.NoError(t, rlq.initialize(corehelpers.Logger, metricsutil.BlackholeSink()))
 	defer rlq.close(context.Background())
 	require.True(t, rlq.getPurgeBlocked())
 
@@ -219,7 +219,7 @@ func TestRateLimitQuota_Allow_WithBlock(t *testing.T) {
 
 func TestRateLimitQuota_Update(t *testing.T) {
 	defer goleak.VerifyNone(t)
-	qm, err := NewManager(logging.NewVaultLogger(log.Trace), nil, metricsutil.BlackholeSink(), true)
+	qm, err := NewManager(corehelpers.Logger, nil, metricsutil.BlackholeSink(), true)
 	require.NoError(t, err)
 
 	view := &logical.InmemStorage{}

--- a/vault/quotas/quotas_test.go
+++ b/vault/quotas/quotas_test.go
@@ -9,15 +9,15 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	"github.com/stretchr/testify/require"
-
+	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/helper/metricsutil"
-	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
+	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
 )
 
 func TestQuotas_MountPathOverwrite(t *testing.T) {
-	qm, err := NewManager(corehelpers.Logger, nil, metricsutil.BlackholeSink(), true)
+	qm, err := NewManager(logging.NewVaultLogger(log.Trace), nil, metricsutil.BlackholeSink(), true)
 	require.NoError(t, err)
 
 	view := &logical.InmemStorage{}
@@ -47,7 +47,7 @@ func TestQuotas_MountPathOverwrite(t *testing.T) {
 }
 
 func TestQuotas_Precedence(t *testing.T) {
-	qm, err := NewManager(corehelpers.Logger, nil, metricsutil.BlackholeSink(), true)
+	qm, err := NewManager(logging.NewVaultLogger(log.Trace), nil, metricsutil.BlackholeSink(), true)
 	require.NoError(t, err)
 
 	setQuotaFunc := func(t *testing.T, name, nsPath, mountPath, pathSuffix, role string, inheritable bool) Quota {
@@ -149,7 +149,7 @@ func TestQuotas_QueryResolveRole_RateLimitQuotas(t *testing.T) {
 	leaseWalkFunc := func(context.Context, func(request *Request) bool) error {
 		return nil
 	}
-	qm, err := NewManager(corehelpers.Logger, leaseWalkFunc, metricsutil.BlackholeSink(), true)
+	qm, err := NewManager(logging.NewVaultLogger(log.Trace), leaseWalkFunc, metricsutil.BlackholeSink(), true)
 	require.NoError(t, err)
 
 	view := &logical.InmemStorage{}

--- a/vault/quotas/quotas_test.go
+++ b/vault/quotas/quotas_test.go
@@ -9,15 +9,15 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/helper/metricsutil"
-	"github.com/hashicorp/vault/sdk/helper/logging"
-	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/vault/helper/metricsutil"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func TestQuotas_MountPathOverwrite(t *testing.T) {
-	qm, err := NewManager(logging.NewVaultLogger(log.Trace), nil, metricsutil.BlackholeSink(), true)
+	qm, err := NewManager(corehelpers.Logger, nil, metricsutil.BlackholeSink(), true)
 	require.NoError(t, err)
 
 	view := &logical.InmemStorage{}
@@ -47,7 +47,7 @@ func TestQuotas_MountPathOverwrite(t *testing.T) {
 }
 
 func TestQuotas_Precedence(t *testing.T) {
-	qm, err := NewManager(logging.NewVaultLogger(log.Trace), nil, metricsutil.BlackholeSink(), true)
+	qm, err := NewManager(corehelpers.Logger, nil, metricsutil.BlackholeSink(), true)
 	require.NoError(t, err)
 
 	setQuotaFunc := func(t *testing.T, name, nsPath, mountPath, pathSuffix, role string, inheritable bool) Quota {
@@ -149,7 +149,7 @@ func TestQuotas_QueryResolveRole_RateLimitQuotas(t *testing.T) {
 	leaseWalkFunc := func(context.Context, func(request *Request) bool) error {
 		return nil
 	}
-	qm, err := NewManager(logging.NewVaultLogger(log.Trace), leaseWalkFunc, metricsutil.BlackholeSink(), true)
+	qm, err := NewManager(corehelpers.Logger, leaseWalkFunc, metricsutil.BlackholeSink(), true)
 	require.NoError(t, err)
 
 	view := &logical.InmemStorage{}

--- a/vault/rekey_test.go
+++ b/vault/rekey_test.go
@@ -10,9 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	log "github.com/hashicorp/go-hclog"
-
-	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
 	"github.com/hashicorp/vault/vault/seal"
@@ -407,7 +405,7 @@ func testCore_Rekey_Invalid_Common(t *testing.T, c *Core, keys [][]byte, recover
 
 func TestCore_Rekey_Standby(t *testing.T) {
 	// Create the first core and initialize it
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 
 	inm, err := inmem.NewInmemHA(nil, logger)
 	if err != nil {

--- a/vault/rollback_test.go
+++ b/vault/rollback_test.go
@@ -12,13 +12,13 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
-	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
-	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/stretchr/testify/require"
 )
 
 // mockRollback returns a mock rollback manager
@@ -51,7 +51,7 @@ func mockRollback(t *testing.T) (*RollbackManager, *NoopBackend) {
 		return mounts.Entries
 	}
 
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 
 	rb := NewRollbackManager(context.Background(), logger, mountsFunc, router, core)
 	rb.period = 10 * time.Millisecond

--- a/vault/seal/seal_testing.go
+++ b/vault/seal/seal_testing.go
@@ -10,10 +10,10 @@ import (
 
 	UUID "github.com/hashicorp/go-uuid"
 
-	"github.com/hashicorp/vault/sdk/helper/logging"
-
 	"github.com/hashicorp/go-hclog"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 )
 
 type TestSealOpts struct {
@@ -33,7 +33,7 @@ func NewTestSealOpts(opts *TestSealOpts) *TestSealOpts {
 		opts.WrapperCount = 1
 	}
 	if opts.Logger == nil {
-		opts.Logger = logging.NewVaultLogger(hclog.Debug)
+		opts.Logger = corehelpers.Logger
 	}
 	if opts.Generation == 0 {
 		// we might at some point need to allow Generation == 0

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -21,19 +21,20 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-sockaddr"
 	"github.com/hashicorp/go-uuid"
+	"github.com/mitchellh/mapstructure"
+
 	"github.com/hashicorp/vault/helper/benchhelpers"
 	"github.com/hashicorp/vault/helper/identity"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"github.com/hashicorp/vault/sdk/helper/tokenutil"
 	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/mitchellh/mapstructure"
 )
 
 func TestTokenStore_CreateOrphanResponse(t *testing.T) {
@@ -1069,7 +1070,7 @@ func TestTokenStore_CreateLookup(t *testing.T) {
 	deepEqualTokenEntries(t, out, ent)
 
 	// New store should share the salt
-	ts2, err := NewTokenStore(namespace.RootContext(nil), hclog.New(&hclog.LoggerOptions{}), c, getBackendConfig(c))
+	ts2, err := NewTokenStore(namespace.RootContext(nil), corehelpers.Logger, c, getBackendConfig(c))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1109,7 +1110,7 @@ func TestTokenStore_CreateLookup_ProvidedID(t *testing.T) {
 	deepEqualTokenEntries(t, out, ent)
 
 	// New store should share the salt
-	ts2, err := NewTokenStore(namespace.RootContext(nil), hclog.New(&hclog.LoggerOptions{}), c, getBackendConfig(c))
+	ts2, err := NewTokenStore(namespace.RootContext(nil), corehelpers.Logger, c, getBackendConfig(c))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/ui_test.go
+++ b/vault/ui_test.go
@@ -7,15 +7,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/sdk/logical"
 
-	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
 )
 
 func TestConfig_Enabled(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	phys, err := inmem.NewTransactionalInmem(nil, logger)
 	if err != nil {
 		t.Fatal(err)
@@ -34,7 +33,7 @@ func TestConfig_Enabled(t *testing.T) {
 }
 
 func TestConfig_Headers(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	phys, err := inmem.NewTransactionalInmem(nil, logger)
 	if err != nil {
 		t.Fatal(err)
@@ -134,7 +133,7 @@ func TestConfig_Headers(t *testing.T) {
 }
 
 func TestConfig_DefaultHeaders(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Trace)
+	logger := corehelpers.Logger
 	phys, err := inmem.NewTransactionalInmem(nil, logger)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Modifies a good portion of Vault tests to use the `Logger` from the corehelpers package. Also introduces an environment variable `VAULT_TEST_LOG_LEVEL` that can configure the log level when running tests.

Setting the log level to `off` in CI results a much smaller artifact size for the test-results (28MB -> 11MB). Unfortunately it didn't have much of an impact on the CI test times.