### PR TITLE
[Backport] Add some clarity to `retry_join` docs (#24605)

### DIFF
--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -89,16 +89,25 @@ delay) mode. The maximum allowed value is 10.
   snapshot. Servers may take longer to recover from crashes or failover if this
   is increased significantly as more logs will need to be replayed.
 
-- `retry_join` `(list: [])` - There can be one or more
-  [`retry_join`](#retry_join-stanza) stanzas. When the Raft cluster is getting
-  bootstrapped, if the connection details of all the nodes are known beforehand,
-  then specifying this config stanzas enables the nodes to automatically join a
-  Raft cluster. All the nodes would mention all other nodes that they could join
-  using this config. When one of the nodes is initialized, it becomes the leader
-  and all the other nodes will join the leader node to form the cluster. When
-  using Shamir seal, the joined nodes will still need to be unsealed manually.
-  See [the section below](#retry_join-stanza) that describes the parameters
-  accepted by the [`retry_join`](#retry_join-stanza) stanza.
+- `snapshot_interval` `(integer: 120 seconds)` - The snapshot interval
+   controls how often Raft checks whether a snapshot operation is
+   required. Raft randomly staggers snapshots between the configured
+   interval and twice the configured interval to keep the entire cluster
+   from performing a snapshot at once. The default snapshot interval is
+   120 seconds.
+
+- `retry_join` `(list: [])` - A set of connection details for another node in the
+  cluster, which is used to help nodes locate a leader in order to join a cluster.
+  There can be one or more [`retry_join`](#retry_join-stanza) stanzas.
+
+  If the connection details for all nodes in the cluster are known in advance, you
+  can include these stanzas to enable nodes to automatically join the Raft cluster.
+  Once one of the nodes is initialized as the leader, the remaining nodes will use
+  their [`retry_join`](#retry_join-stanza) configuration to locate the leader and
+  join the cluster. Note that when using Shamir seal, the joined nodes will still
+  need to be unsealed manually.
+  See [the section below](#retry_join-stanza) for the parameters accepted by the
+  [`retry_join`](#retry_join-stanza) stanza.
 
 - `retry_join_as_non_voter` `(boolean: false)` - If set, causes any `retry_join`
   config to join the Raft cluster as a non-voter. The node will not participate


### PR DESCRIPTION
Due to merge conflict, manually cherry-pick a commit made by https://github.com/hashicorp/vault/pull/24605

