### PR TITLE
fix race condition on GetWorkerCounts by cloning map

### DIFF
--- a/changelog/24616.txt
+++ b/changelog/24616.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+fairshare: fix a race condition in JobManager.GetWorkerCounts
+```

--- a/helper/fairshare/jobmanager.go
+++ b/helper/fairshare/jobmanager.go
@@ -143,7 +143,12 @@ func (j *JobManager) GetPendingJobCount() int {
 func (j *JobManager) GetWorkerCounts() map[string]int {
 	j.l.RLock()
 	defer j.l.RUnlock()
-	return j.workerCount
+	workerCounts := make(map[string]int, len(j.workerCount))
+	for k, v := range j.workerCount {
+		workerCounts[k] = v
+	}
+
+	return workerCounts
 }
 
 // GetWorkQueueLengths() returns a map of queue ID to number of jobs in the queue

--- a/helper/fairshare/jobmanager_test.go
+++ b/helper/fairshare/jobmanager_test.go
@@ -747,3 +747,23 @@ func TestFairshare_queueWorkersSaturated(t *testing.T) {
 		j.l.RUnlock()
 	}
 }
+
+func TestJobManager_GetWorkerCounts_RaceCondition(t *testing.T) {
+	j := NewJobManager("test-job-mgr", 20, nil, nil)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10; i++ {
+			j.incrementWorkerCount("a")
+		}
+	}()
+	wcs := j.GetWorkerCounts()
+	wcs["foo"] = 10
+	for worker, count := range wcs {
+		_ = worker
+		_ = count
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
Our race detector is giving us a warning when we iterate the map as a job finishes (which decrements the worker count).

Instead of returning the map, we should instead clone it so that readers can access it safely.

Tested via
```
go test ./helper/fairshare/... -run TestJobManager_GetWorkerCounts_RaceCondition -race
```

