### PR TITLE
docs: fix code snippet copy for SAML auth method

### DIFF
--- a/website/content/docs/auth/saml.mdx
+++ b/website/content/docs/auth/saml.mdx
@@ -75,8 +75,8 @@ management tool.
 
    ```shell-session
    $ vault write auth/saml/config \
-      default_role=admin \
-      idp_metadata_url=https://company.okta.com/app/abc123eb9xnIfzlaf697/sso/saml/metadata \
+      default_role="admin" \
+      idp_metadata_url="https://company.okta.com/app/abc123eb9xnIfzlaf697/sso/saml/metadata" \
       entity_id="https://my.vault/v1/auth/saml" \
       acs_urls="https://my.vault/v1/auth/saml/callback"
    ```
@@ -85,10 +85,10 @@ management tool.
 
    ```shell-session
    $ vault write auth/saml/config \
-      default_role=admin \
-      idp_sso_url=https://company.okta.com/app/abc123eb9xnIfzlaf697/sso/saml \
-      idp_entity_id=https://www.okta.com/abc123eb9xnIfzlaf697 \
-      idp_cert=@path/to/cert.pem \
+      default_role="admin" \
+      idp_sso_url="https://company.okta.com/app/abc123eb9xnIfzlaf697/sso/saml" \
+      idp_entity_id="https://www.okta.com/abc123eb9xnIfzlaf697" \
+      idp_cert="@path/to/cert.pem" \
       entity_id="https://my.vault/v1/auth/saml" \
       acs_urls="https://my.vault/v1/auth/saml/callback"
    ```
@@ -96,12 +96,12 @@ management tool.
 1. Create a named role:
 
    ```shell-session
-    $ vault write auth/saml/role/admin \
+   $ vault write auth/saml/role/admin \
        bound_subjects="*@hashicorp.com" \
        bound_subjects_type="glob" \
        token_policies="writer" \
        bound_attributes=group="admin" \
-       ttl=1h
+       ttl="1h"
    ```
 
    This role authorizes users that have a subject with an `@hashicorp.com` suffix and


### PR DESCRIPTION
This PR fixes the code snippet copy function in the SAML auth method docs. It also fixes quoting inconsistency of arguments in the CLI examples.