### PR TITLE
docs: adds more targeted guidance for GCP workload identity

### DIFF
--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -77,11 +77,11 @@ For more information on the differences between rolesets and static accounts, se
 
 ### Roleset policy considerations
 
-Starting with Vault 1.8.0, existing permissive policies containing globs 
-for the GCP Secrets Engine may grant additional privileges due to the introduction 
+Starting with Vault 1.8.0, existing permissive policies containing globs
+for the GCP Secrets Engine may grant additional privileges due to the introduction
 of `/gcp/roleset/:roleset/token` and `/gcp/roleset/:roleset/key` endpoints.
 
-The following policy grants a user the ability to read all rolesets, but would 
+The following policy grants a user the ability to read all rolesets, but would
 also allow them to generate tokens and keys. This type of policy is not recommended:
 
 ```hcl
@@ -91,7 +91,7 @@ path "/gcp/roleset/*" {
 }
 ```
 
-The following example demonstrates how a wildcard can instead be used in a roleset policy to 
+The following example demonstrates how a wildcard can instead be used in a roleset policy to
 adhere to the principle of least privilege:
 
 ```hcl
@@ -100,7 +100,7 @@ path "/gcp/roleset/+" {
 }
 ```
 
-For more more information on policy syntax, see the 
+For more more information on policy syntax, see the
 [policy documentation](/vault/docs/concepts/policies#policy-syntax).
 
 ### Examples
@@ -217,7 +217,7 @@ Impersonated accounts are a way to generate an OAuth2 [access token](/vault/docs
 the permissions and accesses of another given service account. These access
 tokens do not have the same 10-key limit as service account keys do, yet they
 retain their short-lived nature. By default, their TTL in GCP is 1 hour, but
-this may be configured to be up to 12 hours as explained in Google's 
+this may be configured to be up to 12 hours as explained in Google's
 [short-lived credentials documentation](https://cloud.google.com/iam/docs/create-short-lived-credentials-delegated#sa-credentials-oauth).
 
 For more information regarding service account impersonation in GCP, consider starting
@@ -453,14 +453,16 @@ Cloud][cloud-creds]. In addition to specifying `credentials` directly via Vault
 configuration, you can also get configuration from the following values **on the
 Vault server**:
 
-1. The environment variables `GOOGLE_APPLICATION_CREDENTIALS`. This is specified
+1. The `GOOGLE_APPLICATION_CREDENTIALS` environment variable. This is specified
    as the **path** to a Google Cloud credentials file, typically for a service
    account. If this environment variable is present, the resulting credentials are
    used. If the credentials are invalid, an error is returned.
 
-1. Default instance credentials. When no environment variable is present, the
-   default service account credentials are used. This is useful when running Vault
-   on [Google Compute Engine][gce] or [Google Kubernetes Engine][gke]
+1. The identity of a Google Cloud [workload][workloads-ids]. When Vault server is running
+   on a Google workload like [Google Compute Engine][gce] or [Google Kubernetes Engine][gke],
+   identity associated with the workload is automatically used. To configure Google Compute
+   Engine with an identity, see [attached service accounts][attached-service-accounts]. To
+   configure Google Kubernetes Engine with an identity, see [GKE workload identity][gke-workload-ids].
 
 For more information on service accounts, please see the [Google Cloud Service
 Accounts documentation][service-accounts].
@@ -692,6 +694,9 @@ for more details.
 [resource-name-relative]: https://cloud.google.com/apis/design/resource_names#relative_resource_name
 [quotas]: https://cloud.google.com/compute/quotas
 [service-accounts]: https://cloud.google.com/compute/docs/access/service-accounts
+[workloads-ids]: https://cloud.google.com/iam/docs/workload-identities
+[attached-service-accounts]: https://cloud.google.com/iam/docs/workload-identities#attached-service-accounts
+[gke-workload-ids]: https://cloud.google.com/iam/docs/workload-identities#kubernetes-workload-identity
 
 ## Upgrade guides
 

--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -77,11 +77,11 @@ For more information on the differences between rolesets and static accounts, se
 
 ### Roleset policy considerations
 
-Starting with Vault 1.8.0, existing permissive policies containing globs
-for the GCP Secrets Engine may grant additional privileges due to the introduction
+Starting with Vault 1.8.0, existing permissive policies containing globs 
+for the GCP Secrets Engine may grant additional privileges due to the introduction 
 of `/gcp/roleset/:roleset/token` and `/gcp/roleset/:roleset/key` endpoints.
 
-The following policy grants a user the ability to read all rolesets, but would
+The following policy grants a user the ability to read all rolesets, but would 
 also allow them to generate tokens and keys. This type of policy is not recommended:
 
 ```hcl
@@ -91,7 +91,7 @@ path "/gcp/roleset/*" {
 }
 ```
 
-The following example demonstrates how a wildcard can instead be used in a roleset policy to
+The following example demonstrates how a wildcard can instead be used in a roleset policy to 
 adhere to the principle of least privilege:
 
 ```hcl
@@ -100,7 +100,7 @@ path "/gcp/roleset/+" {
 }
 ```
 
-For more more information on policy syntax, see the
+For more more information on policy syntax, see the 
 [policy documentation](/vault/docs/concepts/policies#policy-syntax).
 
 ### Examples
@@ -217,7 +217,7 @@ Impersonated accounts are a way to generate an OAuth2 [access token](/vault/docs
 the permissions and accesses of another given service account. These access
 tokens do not have the same 10-key limit as service account keys do, yet they
 retain their short-lived nature. By default, their TTL in GCP is 1 hour, but
-this may be configured to be up to 12 hours as explained in Google's
+this may be configured to be up to 12 hours as explained in Google's 
 [short-lived credentials documentation](https://cloud.google.com/iam/docs/create-short-lived-credentials-delegated#sa-credentials-oauth).
 
 For more information regarding service account impersonation in GCP, consider starting


### PR DESCRIPTION
This PR improves the guidance given for authenticating GCP integrations using workload identities by providing more targeted links.