### PR TITLE
typo corrections - spelling and grammar

### DIFF
--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -589,9 +589,9 @@ $ curl \
 ## Securely export key
 
 This endpoint returns a wrapped copy of the `source` key, protected by the
-`destination` key using BYOK method accepted by the
+`destination` key using the BYOK method accepted by the
 `/transit/keys/:name/import` API. This allows an operator using two separate
-Vault instances to secure established shared key material, withing exposing
+Vault instances to secure established shared key material, without exposing
 either key in plaintext and needing to run a manual BYOK import using the
 CLI helper utility.
 

--- a/website/content/api-docs/system/auth.mdx
+++ b/website/content/api-docs/system/auth.mdx
@@ -136,7 +136,7 @@ For example, enable the "foo" auth method will make it accessible at
   - `plugin_version` `(string: "")` – Specifies the semantic version of the plugin
     to use, e.g. "v1.0.0". If unspecified, the server will select any matching
     unversioned plugin that may have been registered, the latest versioned plugin
-    registered, or a built-in plugin in that order of precendence.
+    registered, or a built-in plugin in that order of precedence.
 
 Additionally, the following options are allowed in Vault open-source, but
 relevant functionality is only supported in Vault Enterprise:

--- a/website/content/api-docs/system/mounts.mdx
+++ b/website/content/api-docs/system/mounts.mdx
@@ -169,7 +169,7 @@ This endpoint enables a new secrets engine at the given path.
   - `plugin_version` `(string: "")` – Specifies the semantic version of the plugin
     to use, e.g. "v1.0.0". If unspecified, the server will select any matching
     unversioned plugin that may have been registered, the latest versioned plugin
-    registered, or a built-in plugin in that order of precendence.
+    registered, or a built-in plugin in that order of precedence.
 
   - `allowed_managed_keys` `(array: [])` - List of managed key registry entry names
     that the mount in question is allowed to access.

--- a/website/content/docs/concepts/user-lockout.mdx
+++ b/website/content/docs/concepts/user-lockout.mdx
@@ -11,7 +11,7 @@ description: >-
 
 @include 'user-lockout.mdx'
 
-## Precendence
+## Precedence
 
 The precedence for user lockout configuration is as follows: 
 

--- a/website/content/docs/platform/k8s/csi/configurations.mdx
+++ b/website/content/docs/platform/k8s/csi/configurations.mdx
@@ -48,7 +48,7 @@ If installing via the helm chart, they can be set using e.g.
   requests. Can also be specified via the `VAULT_NAMESPACE` environment variable.
 
 - `-vault-tls-ca-cert` `(string: "")` - (v1.1.0+) Path on disk to a single
-  PEM-encoded CA certificate to trust for Vault. Takes precendence over
+  PEM-encoded CA certificate to trust for Vault. Takes precedence over
   `-vault-tls-ca-directory`. Can also be specified via the `VAULT_CACERT`
   environment variable.
 


### PR DESCRIPTION
- corrected 4 misspellings of the word precedence in these locations
- corrected spelling and grammar in securely export key api doc description