### PR TITLE
VAULT-21608: Endpoints to Retrieve Active Pre- and Post- Login Messages

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -526,7 +526,7 @@ type Core struct {
 
 	// uiConfig contains UI configuration
 	uiConfig             *UIConfig
-	customMessageManager *uicustommessages.Manager
+	customMessageManager CustomMessagesManager
 
 	// rawEnabled indicates whether the Raw endpoint is enabled
 	rawEnabled bool

--- a/vault/custom_messages_manager.go
+++ b/vault/custom_messages_manager.go
@@ -1,0 +1,20 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package vault
+
+import (
+	"context"
+
+	uicustommessages "github.com/hashicorp/vault/vault/ui_custom_messages"
+)
+
+// CustomMessagesManager is the interface used by the vault package when
+// interacting with a uicustommessages.Manager instance.
+type CustomMessagesManager interface {
+	FindMessages(context.Context, uicustommessages.FindFilter) ([]uicustommessages.Message, error)
+	AddMessage(context.Context, uicustommessages.Message) (*uicustommessages.Message, error)
+	ReadMessage(context.Context, string) (*uicustommessages.Message, error)
+	UpdateMessage(context.Context, uicustommessages.Message) (*uicustommessages.Message, error)
+	DeleteMessage(context.Context, string) error
+}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4487,11 +4487,12 @@ func (b *SystemBackend) pathInternalUICustomMessagesCommon(ctx context.Context, 
 			endTimeFormatted = message.EndTime.Format(time.RFC3339Nano)
 		}
 
-		linkFormatted := map[string]any{}
+		var linkFormatted map[string]string = nil
 
 		if message.Link != nil {
-			linkFormatted["title"] = message.Link.Title
-			linkFormatted["href"] = message.Link.Href
+			linkFormatted = make(map[string]string)
+
+			linkFormatted[message.Link.Title] = message.Link.Href
 		}
 
 		keyInfo[message.ID] = map[string]any{

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -50,6 +50,7 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/wrapping"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault/plugincatalog"
+	uicustommessages "github.com/hashicorp/vault/vault/ui_custom_messages"
 	"github.com/hashicorp/vault/version"
 	"github.com/mitchellh/mapstructure"
 	"golang.org/x/crypto/sha3"
@@ -142,8 +143,8 @@ func NewSystemBackend(core *Core, logger log.Logger, config *logical.BackendConf
 				"wrapping/pubkey",
 				"replication/status",
 				"internal/specs/openapi",
-				"internal/ui/custom-messages",
-				"internal/ui/custom-messages/*",
+				"internal/ui/authenticated-messages",
+				"internal/ui/unauthenticated-messages",
 				"internal/ui/mounts",
 				"internal/ui/mounts/*",
 				"internal/ui/namespaces",
@@ -4426,6 +4427,86 @@ func hasMountAccess(ctx context.Context, acl *ACL, path string) bool {
 	}
 
 	return aclCapabilitiesGiven
+}
+
+// pathInternalUIAuthenticatedMessages finds all of the active messages whose
+// Authenticated property is set to true in the current namespace (based on the
+// provided context.Context) or in any ancestor namespace all the way up to the
+// root namespace.
+func (b *SystemBackend) pathInternalUIAuthenticatedMessages(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	// Make sure that the request includes a Vault token.
+	var tokenEntry *logical.TokenEntry
+	if token := req.ClientToken; token != "" {
+		tokenEntry, _ = b.Core.LookupToken(ctx, token)
+	}
+
+	if tokenEntry == nil {
+		return logical.ListResponseWithInfo([]string{}, map[string]any{}), nil
+	}
+
+	filter := uicustommessages.FindFilter{
+		IncludeAncestors: true,
+	}
+	filter.Active(true)
+	filter.Authenticated(true)
+
+	return b.pathInternalUICustomMessagesCommon(ctx, filter)
+}
+
+// pathInternalUIUnauthenticatedMessages finds all of the active messages whose
+// Authenticated property is set to false in the current namespace (based on the
+// provided context.Context) or in any ancestor namespace all the way up to the
+// root namespace.
+func (b *SystemBackend) pathInternalUIUnauthenticatedMessages(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	filter := uicustommessages.FindFilter{
+		IncludeAncestors: true,
+	}
+	filter.Active(true)
+	filter.Authenticated(false)
+
+	return b.pathInternalUICustomMessagesCommon(ctx, filter)
+}
+
+// pathInternalUICustomMessagesCommon takes care of finding the custom messages
+// that meet the criteria set in the provided uicustommessages.FindFilter.
+func (b *SystemBackend) pathInternalUICustomMessagesCommon(ctx context.Context, filter uicustommessages.FindFilter) (*logical.Response, error) {
+	messages, err := b.Core.customMessageManager.FindMessages(ctx, filter)
+	if err != nil {
+		return logical.ErrorResponse("failed to retrieve custom messages: %w", err), nil
+	}
+
+	keys := []string{}
+	keyInfo := map[string]any{}
+
+	for _, message := range messages {
+		keys = append(keys, message.ID)
+
+		var endTimeFormatted any
+
+		if message.EndTime != nil {
+			endTimeFormatted = message.EndTime.Format(time.RFC3339Nano)
+		}
+
+		linkFormatted := map[string]any{}
+
+		if message.Link != nil {
+			linkFormatted["title"] = message.Link.Title
+			linkFormatted["href"] = message.Link.Href
+		}
+
+		keyInfo[message.ID] = map[string]any{
+			"title":         message.Title,
+			"message":       message.Message,
+			"authenticated": message.Authenticated,
+			"type":          message.Type,
+			"start_time":    message.StartTime.Format(time.RFC3339Nano),
+			"end_time":      endTimeFormatted,
+			"link":          linkFormatted,
+			"options":       message.Options,
+		}
+	}
+
+	return logical.ListResponseWithInfo(keys, keyInfo), nil
 }
 
 func (b *SystemBackend) pathInternalUIMountsRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {

--- a/vault/logical_system_custom_messages.go
+++ b/vault/logical_system_custom_messages.go
@@ -422,6 +422,10 @@ func (b *SystemBackend) handleCreateCustomMessages(ctx context.Context, req *log
 		return logical.ErrorResponse(err.Error()), nil
 	}
 
+	if len(linkMap) > 1 {
+		return logical.ErrorResponse("invalid number of elements in link parameter value; only a single element can be provided"), nil
+	}
+
 	var link *uicustommessages.MessageLink
 	if linkMap != nil {
 		link = &uicustommessages.MessageLink{}
@@ -555,6 +559,10 @@ func (b *SystemBackend) handleUpdateCustomMessage(ctx context.Context, req *logi
 	linkMap, err := parameterValidateMap("link", d)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
+	}
+
+	if len(linkMap) > 1 {
+		return logical.ErrorResponse("invalid number of elements in link parameter value; only a single element can be provided"), nil
 	}
 
 	var link *uicustommessages.MessageLink

--- a/vault/logical_system_custom_messages.go
+++ b/vault/logical_system_custom_messages.go
@@ -426,24 +426,16 @@ func (b *SystemBackend) handleCreateCustomMessages(ctx context.Context, req *log
 	if linkMap != nil {
 		link = &uicustommessages.MessageLink{}
 
-		linkTitle, ok := linkMap["title"]
-		if !ok {
-			return logical.ErrorResponse("missing title in link parameter value"), nil
-		}
+		for k, v := range linkMap {
+			href, ok := v.(string)
+			if !ok {
+				return logical.ErrorResponse(fmt.Sprintf("invalid url for %q key in link parameter value", k)), nil
+			}
 
-		link.Title, ok = linkTitle.(string)
-		if !ok {
-			return logical.ErrorResponse("invalid title value in link parameter value"), nil
-		}
+			link.Title = k
+			link.Href = href
 
-		linkHref, ok := linkMap["href"]
-		if !ok {
-			return logical.ErrorResponse("missing href in link parameter value"), nil
-		}
-
-		link.Href, ok = linkHref.(string)
-		if !ok {
-			return logical.ErrorResponse("invalid href value in link parameter value"), nil
+			break
 		}
 	}
 
@@ -509,6 +501,13 @@ func (b *SystemBackend) handleReadCustomMessage(ctx context.Context, req *logica
 		endTimeResponse = message.EndTime.Format(time.RFC3339Nano)
 	}
 
+	var linkResponse map[string]string = nil
+	if message.Link != nil {
+		linkResponse = make(map[string]string)
+
+		linkResponse[message.Link.Title] = message.Link.Href
+	}
+
 	return &logical.Response{
 		Data: map[string]any{
 			"id":            id,
@@ -517,7 +516,7 @@ func (b *SystemBackend) handleReadCustomMessage(ctx context.Context, req *logica
 			"message":       message.Message,
 			"start_time":    message.StartTime.Format(time.RFC3339Nano),
 			"end_time":      endTimeResponse,
-			"link":          message.Link,
+			"link":          linkResponse,
 			"options":       message.Options,
 			"active":        message.Active(),
 			"title":         message.Title,
@@ -562,24 +561,16 @@ func (b *SystemBackend) handleUpdateCustomMessage(ctx context.Context, req *logi
 	if linkMap != nil {
 		link = &uicustommessages.MessageLink{}
 
-		linkTitle, ok := linkMap["title"]
-		if !ok {
-			return logical.ErrorResponse("missing title in link parameter value"), nil
-		}
+		for k, v := range linkMap {
+			href, ok := v.(string)
+			if !ok {
+				return logical.ErrorResponse("invalid url for %q key link parameter value", k), nil
+			}
 
-		link.Title, ok = linkTitle.(string)
-		if !ok {
-			return logical.ErrorResponse("invalid title value in link parameter value"), nil
-		}
+			link.Title = k
+			link.Href = href
 
-		linkHref, ok := linkMap["href"]
-		if !ok {
-			return logical.ErrorResponse("missing href in link parameter value"), nil
-		}
-
-		link.Href, ok = linkHref.(string)
-		if !ok {
-			return logical.ErrorResponse("invalid href value in link parameter value"), nil
+			break
 		}
 	}
 

--- a/vault/logical_system_custom_messages_test.go
+++ b/vault/logical_system_custom_messages_test.go
@@ -303,6 +303,15 @@ func TestHandleCreateCustomMessage(t *testing.T) {
 			errorExpected: true,
 		},
 		{
+			name: "link-parameter-href-invalid",
+			fieldRawUpdate: map[string]any{
+				"link": map[string]any{
+					"click here": []int{},
+				},
+			},
+			errorExpected: true,
+		},
+		{
 			name: "options-parameter-invalid",
 			fieldRawUpdate: map[string]any{
 				"options": "not-a-map",
@@ -321,9 +330,8 @@ func TestHandleCreateCustomMessage(t *testing.T) {
 				"options": map[string]any{
 					"color": "red",
 				},
-				"link": map[string]any{
-					"title": "Details",
-					"href":  "https://server.com/details",
+				"link": map[string]string{
+					"Details": "https://server.com/details",
 				},
 			},
 		},
@@ -373,14 +381,24 @@ func TestHandleCreateCustomMessage(t *testing.T) {
 			assert.Contains(t, resp.Data, "start_time", testcase.name)
 			assert.Contains(t, resp.Data, "end_time", testcase.name)
 			assert.Contains(t, resp.Data, "id", testcase.name)
-			if _, ok := testcase.fieldRawUpdate["authenticated"]; !ok {
-				assert.True(t, resp.Data["authenticated"].(bool), testcase.name)
-			}
+			assert.Contains(t, resp.Data, "options", testcase.name)
+			assert.Contains(t, resp.Data, "link", testcase.name)
+			_, ok := testcase.fieldRawUpdate["authenticated"]
+			assert.Equal(t, !ok, resp.Data["authenticated"].(bool), testcase.name)
 			if _, ok := testcase.fieldRawUpdate["type"]; !ok {
 				assert.Equal(t, resp.Data["type"], uicustommessages.BannerMessageType, testcase.name)
+			} else {
+				assert.Equal(t, resp.Data["type"], uicustommessages.ModalMessageType, testcase.name)
 			}
 			if _, ok := testcase.fieldRawUpdate["end_time"]; !ok {
 				assert.Nil(t, resp.Data["end_time"], testcase.name)
+			} else {
+				assert.NotNil(t, resp.Data["end_time"], testcase.name)
+			}
+			if _, ok := testcase.fieldRawUpdate["link"]; !ok {
+				assert.Nil(t, resp.Data["link"], testcase.name)
+			} else {
+				assert.NotNil(t, resp.Data["link"], testcase.name)
 			}
 		}
 	}
@@ -428,7 +446,10 @@ func TestHandleReadCustomMessage(t *testing.T) {
 		StartTime:     earlier,
 		EndTime:       &later,
 		Options:       make(map[string]any),
-		Link:          nil,
+		Link: &uicustommessages.MessageLink{
+			Title: "Click Here",
+			Href:  "www.example.com",
+		},
 	}
 
 	message, err := backend.Core.customMessageManager.AddMessage(nsCtx, *message)
@@ -457,9 +478,12 @@ func TestHandleReadCustomMessage(t *testing.T) {
 	assert.Equal(t, resp.Data["active"], true)
 	assert.Contains(t, resp.Data, "end_time")
 	assert.NotNil(t, resp.Data["end_time"])
+	assert.Contains(t, resp.Data, "link")
+	assert.Equal(t, 1, len(resp.Data["link"].(map[string]string)))
 
 	// Change the message so that it doesn't have an end time.
 	message.EndTime = nil
+	message.Link = nil
 	message, err = backend.Core.customMessageManager.UpdateMessage(nsCtx, *message)
 	require.NoError(t, err)
 	require.NotNil(t, message)
@@ -474,6 +498,8 @@ func TestHandleReadCustomMessage(t *testing.T) {
 	assert.Equal(t, resp.Data["active"], true)
 	assert.Contains(t, resp.Data, "end_time")
 	assert.Nil(t, resp.Data["end_time"])
+	assert.Contains(t, resp.Data, "link")
+	assert.Nil(t, resp.Data["link"])
 
 	// Check that there's an error when trying to read a non-existant custom
 	// message.
@@ -538,7 +564,7 @@ func TestHandleUpdateCustomMessage(t *testing.T) {
 	endTime := now.Add(time.Hour).Format(time.RFC3339Nano)
 	startTime2 := now.UTC().Add(-2 * time.Hour).Format(time.RFC3339Nano)
 
-	storageEntryValue := fmt.Sprintf(`{"messages":{"xyz":{"id":"xyz","title":"title","message":"message","authenticated":true,"type":"%s","start_time":"%s","end_time":"%s","link":{},"options":{}}}}`, uicustommessages.ModalMessageType, startTime, endTime)
+	storageEntryValue := fmt.Sprintf(`{"messages":{"xyz":{"id":"xyz","title":"title","message":"message","authenticated":true,"type":"%s","start_time":"%s","end_time":"%s","link":null,"options":null}}}`, uicustommessages.ModalMessageType, startTime, endTime)
 
 	storageEntry := &logical.StorageEntry{
 		Key:   "sys/config/ui/custom-messages",
@@ -595,8 +621,7 @@ func TestHandleUpdateCustomMessage(t *testing.T) {
 			"start_time":    startTime,
 			"end_time":      endTime,
 			"link": map[string]any{
-				"title": "link-title",
-				"href":  "http://link.url.com",
+				"link-title": "http://link.url.com",
 			},
 			"options": map[string]any{},
 		},
@@ -702,6 +727,14 @@ func TestHandleUpdateCustomMessage(t *testing.T) {
 			name: "link-parameter-invalid",
 			fieldRawUpdate: map[string]any{
 				"link": "link",
+			},
+		},
+		{
+			name: "link-parameter-url-invalid",
+			fieldRawUpdate: map[string]any{
+				"link": map[string]any{
+					"my-link": []int{},
+				},
 			},
 		},
 		{

--- a/vault/logical_system_custom_messages_test.go
+++ b/vault/logical_system_custom_messages_test.go
@@ -312,6 +312,16 @@ func TestHandleCreateCustomMessage(t *testing.T) {
 			errorExpected: true,
 		},
 		{
+			name: "link-parameter-multiple-links",
+			fieldRawUpdate: map[string]any{
+				"link": map[string]any{
+					"click here":   "http://example.org",
+					"click here 2": "http://ping.net",
+				},
+			},
+			errorExpected: true,
+		},
+		{
 			name: "options-parameter-invalid",
 			fieldRawUpdate: map[string]any{
 				"options": "not-a-map",
@@ -734,6 +744,15 @@ func TestHandleUpdateCustomMessage(t *testing.T) {
 			fieldRawUpdate: map[string]any{
 				"link": map[string]any{
 					"my-link": []int{},
+				},
+			},
+		},
+		{
+			name: "link-parameter-multiple-links",
+			fieldRawUpdate: map[string]any{
+				"link": map[string]any{
+					"click here":   "http://example.org",
+					"click here 2": "http://ping.net",
 				},
 			},
 		},

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -2436,6 +2436,37 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 			HelpSynopsis: "Generate an OpenAPI 3 document of all mounted paths.",
 		},
 		{
+			Pattern: "internal/ui/authenticated-messages",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "internal-ui",
+				OperationVerb:   "read",
+				OperationSuffix: "authenticated-active-custom-messages",
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathInternalUIAuthenticatedMessages,
+					Summary:  "Retrieves Active post-login Custom Messages",
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"keys": {
+									Type:     framework.TypeStringSlice,
+									Required: true,
+								},
+								"key_info": {
+									Type:     framework.TypeMap,
+									Required: true,
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
+		{
 			Pattern: "internal/ui/feature-flags",
 
 			DisplayAttrs: &framework.DisplayAttributes{
@@ -2652,6 +2683,37 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 			},
 			HelpSynopsis:    strings.TrimSpace(sysHelp["internal-ui-resultant-acl"][0]),
 			HelpDescription: strings.TrimSpace(sysHelp["internal-ui-resultant-acl"][1]),
+		},
+		{
+			Pattern: "internal/ui/unauthenticated-messages",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "internal-ui",
+				OperationVerb:   "read",
+				OperationSuffix: "unauthenticated-active-custom-messages",
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathInternalUIUnauthenticatedMessages,
+					Summary:  "Retrieves Active pre-login Custom Messages",
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"keys": {
+									Type:     framework.TypeStringSlice,
+									Required: true,
+								},
+								"key_info": {
+									Type:     framework.TypeMap,
+									Required: true,
+								},
+							},
+						}},
+					},
+				},
+			},
 		},
 		{
 			Pattern: "internal/ui/version",

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -6491,3 +6491,60 @@ func TestPathInternalUIAuthenticatedMessages(t *testing.T) {
 
 	assert.ElementsMatch(t, testingCMM.findFilters, []uicustommessages.FindFilter{expectedFilter})
 }
+
+// TestPathInternalUICustomMessagesCommon verifies the correct behaviour of the
+// (*SystemBackend).pathInternalUICustomMessagesCommon method.
+func TestPathInternalUICustomMessagesCommon(t *testing.T) {
+	var storage logical.Storage = &testingStorage{getFails: true}
+	testingCMM := uicustommessages.NewManager(storage)
+	backend := &SystemBackend{
+		Core: &Core{
+			customMessageManager: testingCMM,
+		},
+	}
+
+	// First, check that when an error occurs in the FindMessages method, it's
+	// handled correctly.
+	filter := uicustommessages.FindFilter{
+		IncludeAncestors: true,
+	}
+	filter.Active(true)
+	filter.Authenticated(false)
+
+	resp, err := backend.pathInternalUICustomMessagesCommon(context.Background(), filter)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Contains(t, resp.Data, "error")
+	assert.Contains(t, resp.Data["error"], "failed to retrieve custom messages")
+
+	// Next, check that when no error occur and messages are returned by
+	// FindMessages that they are correctly translated.
+	storage = &logical.InmemStorage{}
+	backend.Core.customMessageManager = uicustommessages.NewManager(storage)
+
+	// Load some messages for the root namespace and a testNS namespace.
+	startTime := time.Now().Add(-1 * time.Hour).Format(time.RFC3339Nano)
+	endTime := time.Now().Add(time.Hour).Format(time.RFC3339Nano)
+
+	messagesTemplate := `{"messages":{"%[1]d01":{"id":"%[1]d01","title":"Title-%[1]d01","message":"Message of Title-%[1]d01","authenticated":false,"type":"banner","start_time":"%[2]s"},"%[1]d02":{"id":"%[1]d02","title":"Title-%[1]d02","message":"Message of Title-%[1]d02","authenticated":false,"type":"modal","start_time":"%[2]s","end_time":"%[3]s"},"%[1]d03":{"id":"%[1]d03","title":"Title-%[1]d03","message":"Message of Title-%[1]d03","authenticated":false,"type":"banner","start_time":"%[2]s","link":{"Link":"www.example.com"}}}}`
+
+	cmStorageEntry := &logical.StorageEntry{
+		Key:   "sys/config/ui/custom-messages",
+		Value: []byte(fmt.Sprintf(messagesTemplate, 0, startTime, endTime)),
+	}
+	storage.Put(context.Background(), cmStorageEntry)
+
+	cmStorageEntry = &logical.StorageEntry{
+		Key:   "namespaces/testNS/sys/config/ui/custom-messages",
+		Value: []byte(fmt.Sprintf(messagesTemplate, 1, startTime, endTime)),
+	}
+	storage.Put(context.Background(), cmStorageEntry)
+
+	resp, err = backend.pathInternalUICustomMessagesCommon(namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace), filter)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Contains(t, resp.Data, "keys")
+	assert.Equal(t, 3, len(resp.Data["keys"].([]string)))
+	assert.Contains(t, resp.Data, "key_info")
+	assert.Equal(t, 3, len(resp.Data["key_info"].(map[string]any)))
+}

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -44,8 +44,10 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault/plugincatalog"
 	"github.com/hashicorp/vault/vault/seal"
+	uicustommessages "github.com/hashicorp/vault/vault/ui_custom_messages"
 	"github.com/hashicorp/vault/version"
 	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -6382,4 +6384,110 @@ func TestSystemBackend_pluginRuntime_CannotDeleteRuntimeWithReferencingPlugins(t
 	if err != nil || resp.Error() != nil {
 		t.Fatalf("err: %v %v", err, resp.Error())
 	}
+}
+
+type testingCustomMessageManager struct {
+	findFilters []uicustommessages.FindFilter
+}
+
+func (m *testingCustomMessageManager) FindMessages(_ context.Context, filter uicustommessages.FindFilter) ([]uicustommessages.Message, error) {
+	m.findFilters = append(m.findFilters, filter)
+
+	return []uicustommessages.Message{}, nil
+}
+
+func (m *testingCustomMessageManager) AddMessage(_ context.Context, _ uicustommessages.Message) (*uicustommessages.Message, error) {
+	return nil, nil
+}
+
+func (m *testingCustomMessageManager) ReadMessage(_ context.Context, _ string) (*uicustommessages.Message, error) {
+	return nil, nil
+}
+
+func (m *testingCustomMessageManager) UpdateMessage(_ context.Context, _ uicustommessages.Message) (*uicustommessages.Message, error) {
+	return nil, nil
+}
+
+func (m *testingCustomMessageManager) DeleteMessage(_ context.Context, _ string) error {
+	return nil
+}
+
+// TestPathInternalUIUnauthenticatedMessages verifies the correct behaviour of
+// the pathInternalUIUnauthenticatedMessages method, which is to call the
+// FindMessages method of the Core.customMessagesManager field with a FindFilter
+// that has the IncludeAncestors field set to true, the active field pointing to
+// a true value, and the authenticated field pointing to a false value.
+func TestPathInternalUIUnauthenticatedMessages(t *testing.T) {
+	testingCMM := &testingCustomMessageManager{}
+	backend := &SystemBackend{
+		Core: &Core{
+			customMessageManager: testingCMM,
+		},
+	}
+
+	resp, err := backend.pathInternalUIUnauthenticatedMessages(context.Background(), &logical.Request{}, &framework.FieldData{})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	expectedFilter := uicustommessages.FindFilter{IncludeAncestors: true}
+	expectedFilter.Active(true)
+	expectedFilter.Authenticated(false)
+
+	assert.ElementsMatch(t, testingCMM.findFilters, []uicustommessages.FindFilter{expectedFilter})
+}
+
+// TestPathInternalUIAuthenticatedMessages verifies the correct behaviour of the
+// pathInternalUIAuthenticatedMessages method, which is to first check if the
+// request has a valid token included, then call the FindMessages method of the
+// Core.customMessagesManager field with a FindFilter that has the
+// IncludeAncestors field set to true, the active field pointing to a true
+// value, and the authenticated field pointing to a true value. If the request
+// does not have a valid token, the method behaves as if no messages meet the
+// criteria.
+func TestPathInternalUIAuthenticatedMessages(t *testing.T) {
+	testingCMM := &testingCustomMessageManager{}
+	testCore := TestCoreRaw(t)
+	_, _, token := testCoreUnsealed(t, testCore)
+	testCore.customMessageManager = testingCMM
+
+	backend := &SystemBackend{
+		Core: testCore,
+	}
+
+	nsCtx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	// Check with a request that includes a valid token
+	resp, err := backend.pathInternalUIAuthenticatedMessages(nsCtx, &logical.Request{
+		ClientToken: token,
+	}, &framework.FieldData{})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	expectedFilter := uicustommessages.FindFilter{
+		IncludeAncestors: true,
+	}
+	expectedFilter.Active(true)
+	expectedFilter.Authenticated(true)
+
+	assert.ElementsMatch(t, testingCMM.findFilters, []uicustommessages.FindFilter{expectedFilter})
+
+	// Now, check with a request that has no token: expecting no new filter
+	// in the testingCMM.
+	resp, err = backend.pathInternalUIAuthenticatedMessages(nsCtx, &logical.Request{}, &framework.FieldData{})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.NotContains(t, resp.Data, "keys")
+	assert.NotContains(t, resp.Data, "key_info")
+
+	assert.ElementsMatch(t, testingCMM.findFilters, []uicustommessages.FindFilter{expectedFilter})
+
+	// Finally, check with an invalid token in the request: again, expecting no
+	// new filter in the testingCMM.
+	resp, err = backend.pathInternalUIAuthenticatedMessages(nsCtx, &logical.Request{ClientToken: "invalid"}, &framework.FieldData{})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.NotContains(t, resp.Data, "keys")
+	assert.NotContains(t, resp.Data, "key_info")
+
+	assert.ElementsMatch(t, testingCMM.findFilters, []uicustommessages.FindFilter{expectedFilter})
 }

--- a/vault/ui_custom_messages/manager_test.go
+++ b/vault/ui_custom_messages/manager_test.go
@@ -220,9 +220,41 @@ func TestGetNamespacesToSearch(t *testing.T) {
 
 	list, err = getNamespacesToSearch(namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace), FindFilter{})
 	assert.NoError(t, err)
-	assert.NotNil(t, list)
-	assert.Equal(t, 1, len(list))
+	assert.Len(t, list, 1)
 	assert.Equal(t, namespace.RootNamespace, list[0])
+
+	// Verify with nsManager set to an instance of testNamespaceManager to
+	// ensure that it is used to calculate the list of namespaces.
+	currentNsManager := nsManager
+	defer func() {
+		nsManager = currentNsManager
+	}()
+
+	nsManager = &testNamespaceManager{
+		results: []namespace.Namespace{
+			{
+				ID:   "ccc",
+				Path: "c/",
+			},
+			{
+				ID:   "bbb",
+				Path: "b/",
+			},
+			{
+				ID:   "aaa",
+				Path: "a/",
+			},
+		},
+	}
+
+	list, err = getNamespacesToSearch(namespace.ContextWithNamespace(context.Background(), &namespace.Namespace{ID: "ddd", Path: "d/"}), FindFilter{IncludeAncestors: true})
+	assert.NoError(t, err)
+	assert.Len(t, list, 5)
+	assert.Equal(t, list[0].Path, "d/")
+	assert.Equal(t, list[1].Path, "c/")
+	assert.Equal(t, list[2].Path, "b/")
+	assert.Equal(t, list[3].Path, "a/")
+	assert.Equal(t, list[4].Path, "")
 }
 
 // TestStorageKeyForNamespace verifies that the storageKeyForNamespace function
@@ -632,4 +664,25 @@ func (s *testingStorage) Put(_ context.Context, _ *logical.StorageEntry) error {
 	}
 
 	return nil
+}
+
+// testNamespaceManager is a perculiar type of NamespaceManager where it can be
+// instantiated with the results that successive calls to its GetParentNamespace
+// method will return.
+type testNamespaceManager struct {
+	results []namespace.Namespace
+}
+
+// GetParentNamespace effectively pops namespaces from the results field in the
+// receiver testNamespaceManager struct and returns them. Once all namespaces
+// have been returns, it returns namespace.RootNamespace.
+func (n *testNamespaceManager) GetParentNamespace(_ string) *namespace.Namespace {
+	if len(n.results) == 0 {
+		return namespace.RootNamespace
+	}
+
+	ns := n.results[0]
+	n.results = n.results[1:]
+
+	return &ns
 }

--- a/vault/ui_custom_messages/namespace.go
+++ b/vault/ui_custom_messages/namespace.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package uicustommessages
+
+import "github.com/hashicorp/vault/helper/namespace"
+
+// NamespaceManager is the interface needed of a NamespaceManager by this
+// package. This interface allows setting a dummy NamespaceManager in the
+// community edition that can be replaced with the real
+// namespace.NamespaceManager in the enterprise edition.
+type NamespaceManager interface {
+	GetParentNamespace(string) *namespace.Namespace
+}
+
+// CommunityEditionNamespaceManager is a struct that implements the
+// NamespaceManager interface. This struct is used as a placeholder in the
+// community edition.
+type CommunityEditionNamespaceManager struct{}
+
+// GetParentNamespace always returns namespace.RootNamespace.
+func (n *CommunityEditionNamespaceManager) GetParentNamespace(_ string) *namespace.Namespace {
+	return namespace.RootNamespace
+}

--- a/vault/ui_custom_messages/namespace_test.go
+++ b/vault/ui_custom_messages/namespace_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package uicustommessages
+
+import (
+	"testing"
+
+	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCommunityEditionNamespaceManagerGetParentNamespace verifies that the
+// (*CommunityEditionNamespaceManager).GetParentNamespace behaves as intended,
+// which is to always return namespace.RootNamespace, regardless of the input.
+func TestCommunityEditionNamespaceManagerGetParentNamespace(t *testing.T) {
+	testNsManager := &CommunityEditionNamespaceManager{}
+
+	// Verify root namespace
+	assert.Equal(t, namespace.RootNamespace, testNsManager.GetParentNamespace(namespace.RootNamespace.Path))
+
+	// Verify a different namespace
+	testNamespace := namespace.Namespace{
+		ID:   "abc123",
+		Path: "test/",
+	}
+	assert.Equal(t, namespace.RootNamespace, testNsManager.GetParentNamespace(testNamespace.Path))
+
+	// Verify that even a random string results in the root namespace
+	assert.Equal(t, namespace.RootNamespace, testNsManager.GetParentNamespace("blah"))
+}


### PR DESCRIPTION
This PR completes the changes in this repository for the UI Custom Messages feature. It introduces two more endpoints:
1. `sys/internal/ui/unauthenticated-messages`
2. `sys/internal/ui/authenticated-messages`
This PR introduces the handler for these endpoints and tests to cover them.

This PR also includes a change in the structure of the link parameter in the request body or in the response body. The previous structure was:
```json
{
  "link": {
    "title": "Click Here",
    "href": "https://www.example.com"
  }
}
```

The new structure is changing to:
```json
{
  "link": {
    "Click Here": "https://www.example.com"
  }
}
```
The tests that cover functions impacted by this change weren't doing much in verifying the previous structure, but have been improved to properly check that this structure is properly handled. 