### PR TITLE
Secrets sync UI: Round of bug fixes part 2

### DIFF
--- a/ui/lib/sync/addon/components/secrets/landing-cta.hbs
+++ b/ui/lib/sync/addon/components/secrets/landing-cta.hbs
@@ -18,15 +18,15 @@
     <p>
       This enterprise feature allows you to sync secrets to platforms and tools across your stack to get secrets when and
       where you need them.
+      <Hds::Link::Standalone
+        @text="Learn more about secrets sync"
+        @icon="docs-link"
+        @iconPosition="trailing"
+        @isHrefExternal={{true}}
+        @href={{doc-link "/vault/tutorials/enterprise/secrets-sync"}}
+        data-test-cta-doc-link
+      />
     </p>
-    <Hds::Link::Standalone
-      @text="Learn more about secrets sync"
-      @icon="docs-link"
-      @iconPosition="trailing"
-      @isHrefExternal={{true}}
-      @href={{doc-link "/vault/tutorials/enterprise/secrets-sync"}}
-      data-test-cta-doc-link
-    />
   {{/if}}
 </div>
 

--- a/ui/lib/sync/addon/components/secrets/landing-cta.hbs
+++ b/ui/lib/sync/addon/components/secrets/landing-cta.hbs
@@ -19,7 +19,7 @@
       This enterprise feature allows you to sync secrets to platforms and tools across your stack to get secrets when and
       where you need them.
     </p>
-    <Hds::Button
+    <Hds::Link::Standalone
       @text="Learn more about secrets sync"
       @icon="docs-link"
       @iconPosition="trailing"

--- a/ui/lib/sync/addon/components/secrets/page/destinations.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations.hbs
@@ -23,7 +23,7 @@
       @selectLimit={{1}}
       @disallowNewItems={{true}}
       @placeholder="Filter by type"
-      @inputValue={{if this.typeFilter (array this.typeFilter)}}
+      @inputValue={{if this.typeFilterName (array this.typeFilterName)}}
       @onChange={{fn this.onFilterChange "type"}}
       class="is-marginless"
       data-test-filter="type"

--- a/ui/lib/sync/addon/components/secrets/page/destinations.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations.ts
@@ -51,15 +51,15 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   }
 
   get noResultsMessage() {
-    const { nameFilter, typeFilter } = this.args;
-    if (nameFilter && typeFilter) {
-      return `There are no ${typeFilter} destinations matching "${nameFilter}".`;
+    const { nameFilter } = this.args;
+    if (nameFilter && this.typeFilter) {
+      return `There are no ${this.typeFilter} destinations matching "${nameFilter}".`;
     }
     if (nameFilter) {
       return `There are no destinations matching "${nameFilter}".`;
     }
-    if (typeFilter) {
-      return `There are no ${typeFilter} destinations.`;
+    if (this.typeFilter) {
+      return `There are no ${this.typeFilter} destinations.`;
     }
     return '';
   }

--- a/ui/lib/sync/addon/components/secrets/page/destinations.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations.ts
@@ -28,8 +28,8 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   @service declare readonly store: StoreService;
   @service declare readonly flashMessages: FlashMessageService;
 
-  // typeFilter arg comes in as destination type but we need to pass the name of the type into the SearchSelect
-  get typeFilter() {
+  // typeFilter arg comes in as destination type but we need to pass the destination display name into the SearchSelect
+  get typeFilterName() {
     return findDestination(this.args.typeFilter)?.name;
   }
 
@@ -51,15 +51,15 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   }
 
   get noResultsMessage() {
-    const { nameFilter } = this.args;
-    if (nameFilter && this.typeFilter) {
-      return `There are no ${this.typeFilter} destinations matching "${nameFilter}".`;
+    const { nameFilter, typeFilter } = this.args;
+    if (nameFilter && typeFilter) {
+      return `There are no ${this.typeFilterName || typeFilter} destinations matching "${nameFilter}".`;
     }
     if (nameFilter) {
       return `There are no destinations matching "${nameFilter}".`;
     }
-    if (this.typeFilter) {
-      return `There are no ${this.typeFilter} destinations.`;
+    if (typeFilter) {
+      return `There are no ${this.typeFilterName || typeFilter} destinations.`;
     }
     return '';
   }

--- a/ui/lib/sync/addon/components/secrets/page/destinations.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations.ts
@@ -8,7 +8,7 @@ import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { getOwner } from '@ember/application';
 import errorMessage from 'vault/utils/error-message';
-import { findDestination } from 'core/helpers/sync-destinations';
+import { findDestination, syncDestinations } from 'core/helpers/sync-destinations';
 
 import type SyncDestinationModel from 'vault/vault/models/sync/destination';
 import type RouterService from '@ember/routing/router-service';
@@ -38,14 +38,7 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   }
 
   get destinationTypes() {
-    return this.args.destinations.reduce((types: Array<{ id: string; name: string }>, destination) => {
-      const { typeDisplayName } = destination;
-      const isUnique = !types.find((type) => type.id === typeDisplayName);
-      if (isUnique) {
-        types.push({ id: typeDisplayName, name: destination.type });
-      }
-      return types;
-    }, []);
+    return syncDestinations().map((d) => ({ id: d.name, name: d.type }));
   }
 
   get mountPoint(): string {

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.hbs
@@ -84,8 +84,12 @@
     @title="No synced secrets yet"
     @message="Select secrets from existing KV version 2 engines and sync them to the destination."
   >
-    <LinkTo class="has-top-margin-xs" @route="secrets.destinations.destination.sync">
-      Sync secrets
-    </LinkTo>
+    <Hds::Link::Standalone
+      @text="Sync secrets"
+      @icon="chevron-right"
+      @iconPosition="trailing"
+      class="has-top-margin-xs"
+      @route="secrets.destinations.destination.sync"
+    />
   </EmptyState>
 {{/if}}

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.ts
@@ -41,6 +41,9 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
       await association.save({ adapterOptions: { action: operation } });
       const action: string = operation === 'set' ? 'Sync' : 'Unsync';
       this.flashMessages.success(`${action} operation initiated.`);
+    } catch (error) {
+      this.flashMessages.danger(`Sync operation error: \n ${errorMessage(error)}`);
+    } finally {
       // refresh route to update displayed secrets
       this.store.clearDataset('sync/association');
       this.router.transitionTo(
@@ -48,8 +51,6 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
         this.args.destination.type,
         this.args.destination.name
       );
-    } catch (error) {
-      this.flashMessages.danger(`Sync operation error: \n ${errorMessage(error)}`);
     }
   }
 }

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -5,9 +5,9 @@
 
 <SyncHeader @title="Secrets Sync">
   <:actions>
-    {{#unless @destinations}}
+    {{#if (and this.version.isEnterprise (not @destinations))}}
       <Hds::Button @text="Create first destination" @route="secrets.destinations.create" data-test-cta-button />
-    {{/unless}}
+    {{/if}}
   </:actions>
 </SyncHeader>
 

--- a/ui/lib/sync/addon/components/secrets/page/overview.ts
+++ b/ui/lib/sync/addon/components/secrets/page/overview.ts
@@ -9,9 +9,10 @@ import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import Ember from 'ember';
 
+import type FlashMessageService from 'vault/services/flash-messages';
 import type RouterService from '@ember/routing/router-service';
 import type StoreService from 'vault/services/store';
-import type FlashMessageService from 'vault/services/flash-messages';
+import type VersionService from 'vault/services/version';
 import type { SyncDestinationAssociationMetrics } from 'vault/vault/adapters/sync/association';
 import type SyncDestinationModel from 'vault/vault/models/sync/destination';
 
@@ -21,9 +22,10 @@ interface Args {
 }
 
 export default class SyncSecretsDestinationsPageComponent extends Component<Args> {
+  @service declare readonly flashMessages: FlashMessageService;
   @service declare readonly router: RouterService;
   @service declare readonly store: StoreService;
-  @service declare readonly flashMessages: FlashMessageService;
+  @service declare readonly version: VersionService;
 
   @tracked destinationMetrics: SyncDestinationAssociationMetrics[] = [];
   @tracked page = 1;

--- a/ui/tests/helpers/general-selectors.js
+++ b/ui/tests/helpers/general-selectors.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+import { findAll } from '@ember/test-helpers';
+
 export const SELECTORS = {
   breadcrumb: '[data-test-breadcrumbs] li',
   breadcrumbAtIdx: (idx) => `[data-test-breadcrumbs] li:nth-child(${idx + 1}) a`,
@@ -27,6 +29,7 @@ export const SELECTORS = {
   messageError: '[data-test-message-error]',
   searchSelect: {
     options: '.ember-power-select-option',
+    optionIndex: (text) => findAll('.ember-power-select-options li').findIndex((e) => e.innerText === text),
     option: (index = 0) => `.ember-power-select-option:nth-child(${index + 1})`,
     selectedOption: (index = 0) => `[data-test-selected-option="${index}"]`,
     noMatch: '.ember-power-select-option--no-matches-message',

--- a/ui/tests/integration/components/sync/secrets/landing-cta-test.js
+++ b/ui/tests/integration/components/sync/secrets/landing-cta-test.js
@@ -28,7 +28,7 @@ module('Integration | Component | sync | Secrets::LandingCta', function (hooks) 
     assert
       .dom(PAGE.cta.summary)
       .hasText(
-        'This enterprise feature allows you to sync secrets to platforms and tools across your stack to get secrets when and where you need them.'
+        'This enterprise feature allows you to sync secrets to platforms and tools across your stack to get secrets when and where you need them. Learn more about secrets sync'
       );
     assert.dom(PAGE.cta.link).hasText('Learn more about secrets sync');
   });

--- a/ui/tests/integration/components/sync/secrets/page/destinations-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations-test.js
@@ -87,17 +87,23 @@ module('Integration | Component | sync | Page::Destinations', function (hooks) {
       .includesText('AWS Secrets Manager', 'Filter is populated for correct initial value');
     await click(searchSelect.removeSelected);
 
-    for (const filterType of ['type', 'name']) {
-      await click(`${filter(filterType)} .ember-basic-dropdown-trigger`);
-      await click(searchSelect.option(0));
+    // TYPE FILTER
+    await click(`${filter('type')} .ember-basic-dropdown-trigger`);
+    await click(searchSelect.option(searchSelect.optionIndex('AWS Secrets Manager')));
+    assert.deepEqual(
+      this.transitionStub.lastCall.args,
+      ['vault.cluster.sync.secrets.destinations', { queryParams: { type: 'aws-sm' } }],
+      'type filter triggered transition with correct query params'
+    );
 
-      const value = filterType === 'type' ? 'aws-sm' : 'destination-aws';
-      assert.deepEqual(
-        this.transitionStub.lastCall.args,
-        ['vault.cluster.sync.secrets.destinations', { queryParams: { [filterType]: value } }],
-        `${filterType} filter triggered transition with correct query params`
-      );
-    }
+    // NAME FILTER
+    await click(`${filter('name')} .ember-basic-dropdown-trigger`);
+    await click(searchSelect.option(searchSelect.optionIndex('destination-aws')));
+    assert.deepEqual(
+      this.transitionStub.lastCall.args,
+      ['vault.cluster.sync.secrets.destinations', { queryParams: { name: 'destination-aws' } }],
+      'name filter triggered transition with correct query params'
+    );
   });
 
   test('it should render empty state when there are no filtered results', async function (assert) {

--- a/ui/tests/integration/components/sync/secrets/page/destinations/destination/secrets-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations/destination/secrets-test.js
@@ -10,6 +10,8 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupModels } from 'vault/tests/helpers/sync/setup-models';
 import hbs from 'htmlbars-inline-precompile';
 import { click, render } from '@ember/test-helpers';
+import sinon from 'sinon';
+
 import { PAGE } from 'vault/tests/helpers/sync/sync-selectors';
 import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
 
@@ -23,6 +25,7 @@ module(
 
     hooks.beforeEach(async function () {
       this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub());
+      sinon.stub(this.owner.lookup('service:router'), 'transitionTo');
 
       await render(
         hbs`

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -33,7 +33,8 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    this.owner.lookup('service:version').type = 'enterprise';
+    this.version = this.owner.lookup('service:version');
+    this.version.type = 'enterprise';
     syncScenario(this.server);
     syncHandlers(this.server);
 
@@ -48,7 +49,15 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     );
   });
 
-  test('it should render landing cta component', async function (assert) {
+  test('it should render landing cta component for community', async function (assert) {
+    this.version.type = 'community';
+    this.set('destinations', []);
+    await settled();
+    assert.dom(title).hasText('Secrets Sync Enterprise feature', 'Page title renders');
+    assert.dom(cta.button).doesNotExist('Create first destination button does not render');
+  });
+
+  test('it should render landing cta component for enterprise', async function (assert) {
     this.set('destinations', []);
     await settled();
     assert.dom(title).hasText('Secrets Sync', 'Page title renders');


### PR DESCRIPTION
- Fixes the secrets status in the list view so it updates if the `sync now` popup menu action returns an error. 
- Previously, the type filter only included types that were on the current page (because of pagination). Refactoring so all destination types are filter-able and rely on the empty state to let the user know none exist
- Only displays `Create first destination` CTA for enterprise versions

<hr> 


<img width="1126" alt="Screenshot 2023-12-21 at 2 54 16 PM" src="https://github.com/hashicorp/vault/assets/68122737/6cd78574-138c-40dd-9a6f-a17b8b28b09c">

<hr>

_CTA button is hidden, just learn more link displays_

![Screenshot 2023-12-22 at 11 37 28 AM](https://github.com/hashicorp/vault/assets/68122737/f723975b-c6e1-4806-b673-794ac223f24c)

