### PR TITLE
docs(web repl): add initial docs about the UI REPL

### DIFF
--- a/ui/app/templates/components/console/log-help.hbs
+++ b/ui/app/templates/components/console/log-help.hbs
@@ -22,5 +22,9 @@ Web CLI Commands:
   clearall    Clear output and command history
   fullscreen  Toggle fullscreen display
   refresh     Refresh the data on the current screen under the CLI window
+
 </pre>
+  <p class="console-ui-panel-intro is-font-mono has-bottom-margin-s">
+    For more detailed documentation, see the <DocLink @path="/vault/docs/command/web">HashiCorp Developer site</DocLink>.
+  </p>
 </div>

--- a/ui/app/templates/components/console/log-help.hbs
+++ b/ui/app/templates/components/console/log-help.hbs
@@ -25,6 +25,6 @@ Web REPL Commands:
 
 </pre>
   <p class="console-ui-panel-intro is-font-mono has-bottom-margin-s">
-    For more detailed documentation, see the <DocLink @path="/vault/docs/command/web">HashiCorp Developer site</DocLink>.
+    For more detailed documentation, see the <Hds::Link::Inline @href={{doc-link "/vault/docs/command/web"}}>HashiCorp Developer site</Hds::Link::Inline>.
   </p>
 </div>

--- a/ui/app/templates/components/console/log-help.hbs
+++ b/ui/app/templates/components/console/log-help.hbs
@@ -16,7 +16,7 @@ Commands:
   delete      Delete secrets and configuration
   list        List data or secrets
 
-Web CLI Commands:
+Web REPL Commands:
   api         Navigate to the Vault API explorer. Use 'api [filter]' to prefilter the list.
   clear       Clear output from the log
   clearall    Clear output and command history

--- a/ui/app/templates/components/console/ui-panel.hbs
+++ b/ui/app/templates/components/console/ui-panel.hbs
@@ -16,7 +16,7 @@
 <div class="console-ui-panel-content">
   <div class="content has-bottom-margin-l">
     <p class="console-ui-panel-intro is-font-mono has-bottom-margin-s">
-      The Vault Browser CLI provides an easy way to execute common Vault CLI commands, such as write, read, delete, and list.
+      The Vault Web REPL provides an easy way to execute common Vault CLI commands, such as write, read, delete, and list.
       It does not include kv v2 write or put commands. For guidance, type `help`. For more detailed documentation, see the
       <DocLink @path="/vault/docs/command/web">HashiCorp Developer site</DocLink>.
     </p>

--- a/ui/app/templates/components/console/ui-panel.hbs
+++ b/ui/app/templates/components/console/ui-panel.hbs
@@ -17,7 +17,7 @@
   <div class="content has-bottom-margin-l">
     <p class="console-ui-panel-intro is-font-mono has-bottom-margin-s">
       The Vault Web REPL provides an easy way to execute common Vault CLI commands, such as write, read, delete, and list.
-      It does not include kv v2 write or put commands. For guidance, type `help`. For more detailed documentation, see the
+      It does not include KV version 2 write or put commands. For guidance, type `help`. For more detailed documentation, see the
       <Hds::Link::Inline @href={{doc-link "/vault/docs/command/web"}}>HashiCorp Developer site</Hds::Link::Inline>.
     </p>
     <p class="console-ui-panel-intro is-font-mono has-bottom-margin-s">Examples:</p>

--- a/ui/app/templates/components/console/ui-panel.hbs
+++ b/ui/app/templates/components/console/ui-panel.hbs
@@ -18,7 +18,7 @@
     <p class="console-ui-panel-intro is-font-mono has-bottom-margin-s">
       The Vault Web REPL provides an easy way to execute common Vault CLI commands, such as write, read, delete, and list.
       It does not include kv v2 write or put commands. For guidance, type `help`. For more detailed documentation, see the
-      <DocLink @path="/vault/docs/command/web">HashiCorp Developer site</DocLink>.
+      <Hds::Link::Inline @href={{doc-link "/vault/docs/command/web"}}>HashiCorp Developer site</Hds::Link::Inline>.
     </p>
     <p class="console-ui-panel-intro is-font-mono has-bottom-margin-s">Examples:</p>
     <p class="console-ui-panel-intro is-font-mono">→ Write secrets to kv v1: write &lt;mount&gt;/my-secret foo=bar</p>

--- a/ui/app/templates/components/console/ui-panel.hbs
+++ b/ui/app/templates/components/console/ui-panel.hbs
@@ -17,7 +17,8 @@
   <div class="content has-bottom-margin-l">
     <p class="console-ui-panel-intro is-font-mono has-bottom-margin-s">
       The Vault Browser CLI provides an easy way to execute common Vault CLI commands, such as write, read, delete, and list.
-      It does not include kv v2 write or put commands. For guidance, type `help`.
+      It does not include kv v2 write or put commands. For guidance, type `help`. For more detailed documentation, see the
+      <DocLink @path="/vault/docs/command/web">HashiCorp Developer site</DocLink>.
     </p>
     <p class="console-ui-panel-intro is-font-mono has-bottom-margin-s">Examples:</p>
     <p class="console-ui-panel-intro is-font-mono">→ Write secrets to kv v1: write &lt;mount&gt;/my-secret foo=bar</p>

--- a/ui/app/templates/components/console/ui-panel.hbs
+++ b/ui/app/templates/components/console/ui-panel.hbs
@@ -16,8 +16,9 @@
 <div class="console-ui-panel-content">
   <div class="content has-bottom-margin-l">
     <p class="console-ui-panel-intro is-font-mono has-bottom-margin-s">
-      The Vault Web REPL provides an easy way to execute common Vault CLI commands, such as write, read, delete, and list.
-      It does not include KV version 2 write or put commands. For guidance, type `help`. For more detailed documentation, see the
+      The Vault Web REPL provides an easy way to execute common Vault CLI commands, such as write, read, delete, and list. It
+      does not include KV version 2 write or put commands. For guidance, type `help`. For more detailed documentation, see
+      the
       <Hds::Link::Inline @href={{doc-link "/vault/docs/command/web"}}>HashiCorp Developer site</Hds::Link::Inline>.
     </p>
     <p class="console-ui-panel-intro is-font-mono has-bottom-margin-s">Examples:</p>

--- a/ui/app/templates/components/wizard/secrets-list.hbs
+++ b/ui/app/templates/components/wizard/secrets-list.hbs
@@ -10,6 +10,6 @@
 >
   <p>
     This engine isn't fully supported in the Vault UI yet, but you can view and edit the configuration and use the Vault
-    Browser CLI to interact with the engine just like you would on the command-line.
+    Web REPL to interact with the engine just like you would on the command-line.
   </p>
 </WizardSection>

--- a/ui/app/templates/components/wizard/secrets-list.hbs
+++ b/ui/app/templates/components/wizard/secrets-list.hbs
@@ -9,7 +9,7 @@
   @instructions='Find the engine in the list and click on "View configuration" in the menu on the right.'
 >
   <p>
-    This engine isn't fully supported in the Vault UI yet, but you can view and edit the configuration and use the Vault
-    Web REPL to interact with the engine just like you would on the command-line.
+    This engine isn't fully supported in the Vault UI yet, but you can view and edit the configuration and use the Vault Web
+    REPL to interact with the engine just like you would on the command-line.
   </p>
 </WizardSection>

--- a/ui/tests/integration/components/secret-edit-test.js
+++ b/ui/tests/integration/components/secret-edit-test.js
@@ -91,7 +91,7 @@ module('Integration | Component | secret edit', function (hooks) {
         float: '1.234',
       },
     });
-    await render(hbs`<SecretEdit @mode={{this.mode}} @model={{this.model}} key=this.key />`);
+    await render(hbs`<SecretEdit @mode={{this.mode}} @model={{this.model}} key="this.key" />`);
     assert.dom('[data-test-secret-save]').isNotDisabled();
   });
 

--- a/website/content/docs/commands/web.mdx
+++ b/website/content/docs/commands/web.mdx
@@ -16,7 +16,7 @@ The Vault web user interface (UI) includes an advanced mode that mimics some bas
 ## Command history
 The Web REPL will keep a history of all of the commands you've entered in your current session. If you refresh the browser or use the `clearall` command, this history will be reset.
 
-To cycle through the command history, you can use the up and down arrows when the REPL input has focus. If you reach either end of the history, it will cycle back to the the other side and continue looping through them.
+To cycle through the command history, you can use the up and down arrows when the REPL input has focus. If you reach either beginning of the history by pressing up, it will cycle back to the most recent command. Pressing the down arrow will stop at an empty prompt after the most recent command.
 
 ## Commands
 The Vault Web REPL implements the Create/Read/Update/Delete/List (CRUDL) commands from the Vault CLI. With these basic commands, a user can interact with most of the Vault API even if there aren't explicit screens for it in Vault's Web UI.

--- a/website/content/docs/commands/web.mdx
+++ b/website/content/docs/commands/web.mdx
@@ -11,7 +11,7 @@ description: |-
 
 The Vault web user interface (UI) includes an advanced mode that mimics some basic commands from the Vault CLI. It can be useful for users more familiar with the CLI or API as it lets a user directly input the paths they wish to manipulate.
 
-~> **Note:** The Vault Web REPL is _not_ a full terminal emulator. Features like environment varialbes, HEREDOC, or piping of data or files will not work unless explicitly documented.
+~> **Note:** The Vault Web REPL is _not_ a full terminal emulator. Features like environment variables, HEREDOC, or piping of data or files will not work unless explicitly documented.
 
 ## Command history
 The Web REPL will keep a history of all of the commands you've entered in your current session. If you refresh the browser or use the `clearall` command, this history will be reset.

--- a/website/content/docs/commands/web.mdx
+++ b/website/content/docs/commands/web.mdx
@@ -9,7 +9,7 @@ description: |-
 
 # Web REPL
 
-The Vault web user interface (UI) includes an advanced mode that mimics some basic commands from the Vault CLI. It can be useful a user is more familiar with the CLI or API as it lets a user directly input the paths they wish to manipulate.
+The Vault web user interface (UI) includes an advanced mode that mimics some basic commands from the Vault CLI. It can be useful for users more familiar with the CLI or API as it lets a user directly input the paths they wish to manipulate.
 
 ~> **Note:** The Vault Web REPL is _not_ a full terminal emulator. Features like environment varialbes, HEREDOC, or piping of data or files will not work unless explicitly documented.
 

--- a/website/content/docs/commands/web.mdx
+++ b/website/content/docs/commands/web.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Web REPL - Command
 description: |-
-  The Vault web user interface (UI) includes an advanced mode that mimics some basic commands from the Vault CLI. It can be useful a user is more familiar with the CLI or API as it lets a user directly input the paths they wish to manipulate.
+  The Vault web user interface (UI) includes an advanced mode that mimics some basic commands from the Vault CLI. It can be useful for users more familiar with the CLI or API as it lets a user directly input the paths they wish to manipulate.
 
 ---
 
@@ -27,12 +27,12 @@ All commands can optionally be prefixed with `vault` as if you were using the CL
 `delete` in the Web REPL is the same as using the [`delete`](/vault/docs/commands/delete) command in the CLI. It can be used to delete secrets and configuration from Vault at the given path via an HTTP DELETE.
 
 ### kv-get
-The Web REPL is a convenience method much like [`kv read`](/vault/docs/commands/kv/read) to read KV secrets from a version 2 KV secrets engine. The command `kv-get secret/foo` is functionally equivalent to running the REPL `read` command with the full API path: `read secret/data/foo`.
+The Web REPL is a convenience method exclusively for reading secrets from a KV version 2 secrets engine, much like [`kv read`](/vault/docs/commands/kv/read). The command `kv-get secret/foo` is functionally equivalent to running the REPL `read` command with the full API path: `read secret/data/foo`.
 
 There is also a `-metadata` flag that is shorthand for `-field=metadata`.
 
 ### list
-The Web REPL `list` command is functionally identical to the CLI [`list`](/vault/docs/commands/list) command. It is used to list keys at a given path such as roles in an auth method, or keys for a given secrets engine. The Web REPL version issues an GET with the `?list=true` query parameter as described in the [API overview](/vault/api-docs#api-operations) since web browsers do not support custom HTTP verbs.
+The Web REPL `list` command is functionally identical to the CLI [`list`](/vault/docs/commands/list) command. It is used to list keys at a given path such as roles in an auth method, or keys for a given secrets engine. The Web REPL version issues a GET with the `?list=true` query parameter as described in the [API overview](/vault/api-docs#api-operations) since web browsers do not support custom HTTP verbs.
 
 ### read
 Like the CLI [`read`](/vault/docs/commands/read) command, the Web REPL `read` performs an HTTP GET on a given path.
@@ -47,7 +47,7 @@ This is the major shortcoming of the Vault Web REPL.
 ## Command options
 
 ### field
-If you are only interested in a single field in the response, you can use the `-field` flag which will specify that the REPL should only print that field in the response. Using this in conjucntion with `-wrap-ttl` is nice because you can return just the wrapped token by doing something like this:
+If you are only interested in a single field in the response, you can use the `-field` flag which will specify that the REPL should only print that field in the response. Using this in conjunction with `-wrap-ttl` is nice because you can return just the wrapped token by doing something like this:
 ```
 kv-get secret/one -wrap-ttl=10m -field=token
 ```
@@ -72,7 +72,7 @@ This will navigate you to an interactive OpenAPI explorer in the Vault UI. This 
 This will clear all of the output currently in the Web REPL log.
 
 ### clearall
-This clears the output _and_ the command history in the Web REPL. After running `clearall`,  arrowing up won't show previsouly executed commands.
+This clears the output _and_ the command history in the Web REPL. After running `clearall`, arrowing up won't show previously executed commands.
 
 ### fullscreen
 `fullscreen` will toggle the Web REPL into a view that expands to cover the whole browser window.
@@ -81,4 +81,4 @@ This clears the output _and_ the command history in the Web REPL. After running 
 Submitting the form with no input or typing `help` in the Web REPL will print out a list of available commands with short descriptions.
 
 ### refresh
-If you've run a command in the Web REPL that affects the data on a page you're currently on in the Vault UI, the UI does not automatically refresh. The `refresh` command is a convenient way to refresh the current route withouth having to navigate away or fully refresh the browser application.
+If you've run a command in the Web REPL that affects the data on a page you're currently on in the Vault UI, the UI does not automatically refresh. The `refresh` command is a convenient way to refresh the current route without having to navigate away or fully refresh the browser application.

--- a/website/content/docs/commands/web.mdx
+++ b/website/content/docs/commands/web.mdx
@@ -1,0 +1,84 @@
+---
+layout: docs
+page_title: Web REPL - Command
+description: |-
+  The Vault web user interface (UI) includes an advanced mode that mimics some basic commands from the Vault CLI. It can be useful a user is more familiar with the CLI or API as it lets a user directly input the paths they wish to manipulate.
+
+---
+
+
+# Web REPL
+
+The Vault web user interface (UI) includes an advanced mode that mimics some basic commands from the Vault CLI. It can be useful a user is more familiar with the CLI or API as it lets a user directly input the paths they wish to manipulate.
+
+~> **Note:** The Vault Web REPL is _not_ a full terminal emulator. Features like environment varialbes, HEREDOC, or piping of data or files will not work unless explicitly documented.
+
+## Command history
+The Web REPL will keep a history of all of the commands you've entered in your current session. If you refresh the browser or use the `clearall` command, this history will be reset.
+
+To cycle through the command history, you can use the up and down arrows when the REPL input has focus. If you reach either end of the history, it will cycle back to the the other side and continue looping through them.
+
+## Commands
+The Vault Web REPL implements the Create/Read/Update/Delete/List (CRUDL) commands from the Vault CLI. With these basic commands, a user can interact with most of the Vault API even if there aren't explicit screens for it in Vault's Web UI.
+
+All commands can optionally be prefixed with `vault` as if you were using the CLI - the intent being that a large number of example commands from the documentation should work via simply copy and pasting them from the documentation site into the web REPL.
+
+### delete
+`delete` in the Web REPL is the same as using the [`delete`](/vault/docs/commands/delete) command in the CLI. It can be used to delete secrets and configuration from Vault at the given path via an HTTP DELETE.
+
+### kv-get
+The Web REPL is a convenience method much like [`kv read`](/vault/docs/commands/kv/read) to read KV secrets from a version 2 KV secrets engine. The command `kv-get secret/foo` is functionally equivalent to running the REPL `read` command with the full API path: `read secret/data/foo`.
+
+There is also a `-metadata` flag that is shorthand for `-field=metadata`.
+
+### list
+The Web REPL `list` command is functionally identical to the CLI [`list`](/vault/docs/commands/list) command. It is used to list keys at a given path such as roles in an auth method, or keys for a given secrets engine. The Web REPL version issues an GET with the `?list=true` query parameter as described in the [API overview](/vault/api-docs#api-operations) since web browsers do not support custom HTTP verbs.
+
+### read
+Like the CLI [`read`](/vault/docs/commands/read) command, the Web REPL `read` performs an HTTP GET on a given path.
+
+Also like the CLI `read`, the REPL implements `-field` and `-format` flags. The output defaults to "table" format, but also supports "json" output.
+
+### write
+This is a Web REPL implementation of the CLI [`write`](/vault/docs/commands/write) command - it will perform an HTTP POST to the given path with the given data. Notably the special "**@**" syntax from the CLI is not implemented - data must be specified as arguments to the command. Because of this, any API fields that require data structures not expressible as arguments are not supported.
+This is the major shortcoming of the Vault Web REPL.
+
+
+## Command options
+
+### field
+If you are only interested in a single field in the response, you can use the `-field` flag which will specify that the REPL should only print that field in the response. Using this in conjucntion with `-wrap-ttl` is nice because you can return just the wrapped token by doing something like this:
+```
+kv-get secret/one -wrap-ttl=10m -field=token
+```
+### force
+Some delete paths require using `-force` as a confirmation that the delete is intentional. Using `delete` without this flag on a path that needs it will result in an error that tells you `-force` is required.
+
+### format
+`read` commands default to the "table" format, if you would like to see the JSON format of a response, you can pass `-format=json`. This is most often useful for responses that have deeply nested objects that don't fit well in the table format.
+
+### metadata
+As mentioned above in the `kv-get` section - this flag is shorthand for `-field=metadata` which is useful when reading secrets from the KVv2 secrets engine.
+
+### wrap-ttl
+Like the `vault` CLI, the Web REPL supports creating [response-wrapping tokens](/vault/docs/concepts/response-wrapping#response-wrapping-token-creation).The format is also the same: it can be an integer that sets the wrapping TTL for a number of seconds, or it can be a string that specifys the length of the duration in seconds (`15s`), miniutes (`20m`), or hours (`25h`).
+
+## REPL-specific commands
+
+### api
+This will navigate you to an interactive OpenAPI explorer in the Vault UI. This explorer will only contain the paths your current `VAULT_TOKEN` has permissions to operate on.
+
+### clear
+This will clear all of the output currently in the Web REPL log.
+
+### clearall
+This clears the output _and_ the command history in the Web REPL. After running `clearall`,  arrowing up won't show previsouly executed commands.
+
+### fullscreen
+`fullscreen` will toggle the Web REPL into a view that expands to cover the whole browser window.
+
+### help
+Submitting the form with no input or typing `help` in the Web REPL will print out a list of available commands with short descriptions.
+
+### refresh
+If you've run a command in the Web REPL that affects the data on a page you're currently on in the Vault UI, the UI does not automatically refresh. The `refresh` command is a convenient way to refresh the current route withouth having to navigate away or fully refresh the browser application.

--- a/website/content/docs/configuration/ui.mdx
+++ b/website/content/docs/configuration/ui.mdx
@@ -70,3 +70,10 @@ Vault UI will need to have the root CA installed. Failure to do so may result in
 the browser displaying a warning that the site is "untrusted". It is highly
 recommended that client browsers accessing the Vault UI install the proper CA
 root for validation to reduce the chance of a MITM attack.
+
+
+## Vault UI Web REPL
+
+The Vault UI includes an interactive Web REPL to interact with Vault's API much
+like the Vault CLI. For more on that, see the
+[Web REPL documentation](/vault/docs/commands/web).

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -522,6 +522,10 @@
         "path": "commands"
       },
       {
+        "title": "Web REPL",
+        "path": "commands/web"
+      },
+      {
         "title": "<code>agent</code>",
         "path": "commands/agent"
       },


### PR DESCRIPTION
So this is loooooong overdue, and I think I've promised it at least a couple of times over the years. But! This is a first pass at adding a page about the Web CLI / Web [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop) to the docs. I think we should explicitly call it the Web REPL everywhere so that it's clear it's not a fully-functioning CLI and so users don't expect it to have every feature the `vault` CLI does.

Open questions: 

1. **Is this the right place for this to live in the docs?** There aren't a lot of other UI-specific docs, so I nested it in at the top of the CLI docs.
2. **Is this complete?** It's been a while since I did anything related to the REPL, so there could be new functionality. I looked through the code a bit and I think I got everything, but please comment if you'd like me to expand on anything or if there's anything I missed.
3. **Should I also update references in the UI to change `CLI` -> `REPL`?** I'm happy to go through and update these as part of this PR, but I think renaming things from CLI to REPL is worthwhile to set expectations.


![CleanShot 2023-12-27 at 13 48 16](https://github.com/hashicorp/vault/assets/39469/f41e1ae2-7b9d-4406-9961-c5ad9c1da6f4)


Added links to the new docs page in the REPL itself, both in the initial output, but also in the `help` command:

![CleanShot 2023-12-27 at 14 32 33](https://github.com/hashicorp/vault/assets/39469/82fbf0e2-9bc8-43ee-afdb-7a105d1c9d30)

Thanks @hellobontempo for the suggestion.


For number 3 above, I went ahead and did the replacement, but it's easy enough to drop that commit if y'all decide you don't want it.
