### PR TITLE
Secrets sync: Update Azure KV destination

### DIFF
--- a/ui/app/models/sync/destinations/azure-kv.js
+++ b/ui/app/models/sync/destinations/azure-kv.js
@@ -19,7 +19,7 @@ export default class SyncDestinationsAzureKeyVaultModel extends SyncDestinationM
       'URI of an existing Azure Key Vault instance. If empty, Vault will use the KEY_VAULT_URI environment variable if configured.',
     editDisabled: true,
   })
-  keyVaultUri;
+  keyVaultUri; // obfuscated, never returned by API
 
   @attr('string', {
     label: 'Client ID',
@@ -44,7 +44,6 @@ export default class SyncDestinationsAzureKeyVaultModel extends SyncDestinationM
 
   @attr('string', {
     subText: 'Specifies a cloud for the client. The default is Azure Public Cloud.',
-    defaultValue: 'cloud',
     editDisabled: true,
   })
   cloud;

--- a/ui/lib/core/addon/helpers/sync-destinations.ts
+++ b/ui/lib/core/addon/helpers/sync-destinations.ts
@@ -26,7 +26,7 @@ const SYNC_DESTINATIONS: Array<SyncDestination> = [
     type: 'azure-kv',
     icon: 'azure-color',
     category: 'cloud',
-    maskedParams: ['clientSecret'],
+    maskedParams: ['clientSecret', 'keyVaultUri'],
   },
   {
     name: 'Google Secret Manager',


### PR DESCRIPTION
- add `keyVaultUri` to obfuscated values
- ❓ Should we remove cloud default for cloud param? (docs mention cloud as the default value, but destination failed to create with that value - failure could have been because of a separate backend bug that is causing the destination GET requests to return a 500 until secrets have been synced
