### PR TITLE
Fix UI when editing database roles

### DIFF
--- a/ui/app/adapters/database/role.js
+++ b/ui/app/adapters/database/role.js
@@ -164,7 +164,7 @@ export default ApplicationAdapter.extend({
         db: db[0],
       });
     } catch (e) {
-      throw new Error('Could not update allowed roles for selected database. Check Vault logs for details');
+      this.checkError(e)
     }
 
     return this.ajax(this.urlFor(backend, id, roleType), 'POST', { data }).then(() => {
@@ -199,4 +199,14 @@ export default ApplicationAdapter.extend({
 
     return this.ajax(this.urlFor(backend, id, roleType), 'POST', { data }).then(() => data);
   },
+
+  checkError(e) {
+    if (e.httpStatus === 403) {
+      // The user does not have the permission to update the connection. This
+      // can happen if there permissions are limited to the role. In that case
+      // we ignore the error and continue updating the role.
+      return
+    }
+    throw new Error(`Could not update allowed roles for selected database: ${e.errors.join(' ')}`);
+  }
 });

--- a/ui/app/components/database-role-edit.js
+++ b/ui/app/components/database-role-edit.js
@@ -27,9 +27,6 @@ export default class DatabaseRoleEdit extends Component {
 
   get warningMessages() {
     const warnings = {};
-    if (this.args.model.canUpdateDb === false) {
-      warnings.database = `You don’t have permissions to update this database connection, so this role cannot be created.`;
-    }
     if (
       (this.args.model.type === 'dynamic' && this.args.model.canCreateDynamic === false) ||
       (this.args.model.type === 'static' && this.args.model.canCreateStatic === false)


### PR DESCRIPTION
When using a database role the UI will try to update the database connection associated to the role. This is to make sure that the role is allowed to use this connection:

    async _updateAllowedRoles(store, { role, backend, db, type = 'add' }) {
      const connection = await store.queryRecord('database/connection', { backend, id: db });
      const roles = [...connection.allowed_roles];
      const allowedRoles = type === 'add' ? addToArray([roles, role]) : removeFromArray([roles, role]);
      connection.allowed_roles = allowedRoles;
      return connection.save();
    },

    async createRecord(store, type, snapshot) {
      const serializer = store.serializerFor(type.modelName);
      const data = serializer.serialize(snapshot);
      const roleType = snapshot.attr('type');
      const backend = snapshot.attr('backend');
      const id = snapshot.attr('name');
      const db = snapshot.attr('database');
      try {
        await this._updateAllowedRoles(store, {
          role: id,
          backend,
          db: db[0],
        });
      } catch (e) {
        throw new Error('Could not update allowed roles for selected database. Check Vault logs for details');
      }

      return this.ajax(this.urlFor(backend, id, roleType), 'POST', { data }).then(() => {
        // ember data doesn't like 204s if it's not a DELETE
        return {
          data: assign({}, data, { id }),
        };
      });
    },

This is intended to help the administrator as the role will only work if it is allowed by the database connection.

This is however an issue if the person doing the update does not have the permission to update the connection: they will not be able to use the UI to update the role even though they have the appropriate permissions to do so (using the CLI or the API will work for example).

This is often the case when the database connections are created by a centralized system but a human operator needs to create the roles.

You can try this with the following test case:

    $ cat main.tf
    resource "vault_auth_backend" "userpass" {
      type = "userpass"
    }

    resource "vault_generic_endpoint" "alice" {
      depends_on           = [vault_auth_backend.userpass]
      path                 = "auth/userpass/users/alice"
      ignore_absent_fields = true

      data_json = jsonencode({
        "policies" : ["root"],
        "password" : "alice"
      })
    }

    data "vault_policy_document" "db_admin" {
      rule {
        path         = "database/roles/*"
        capabilities = ["create", "read", "update", "delete", "list"]
      }
    }

    resource "vault_policy" "db_admin" {
      name   = "db-admin"
      policy = data.vault_policy_document.db_admin.hcl
    }

    resource "vault_generic_endpoint" "bob" {
      depends_on           = [vault_auth_backend.userpass]
      path                 = "auth/userpass/users/bob"
      ignore_absent_fields = true

      data_json = jsonencode({
        "policies" : [vault_policy.db_admin.name],
        "password" : "bob"
      })
    }

    resource "vault_mount" "db" {
      path = "database"
      type = "database"
    }

    resource "vault_database_secret_backend_connection" "postgres" {
      backend           = vault_mount.db.path
      name              = "postgres"
      allowed_roles     = ["*"]
      verify_connection = false

      postgresql {
        connection_url = "postgres://username:password@localhost/database"
      }
    }
    $ terraform apply --auto-approve

then using bob to create a role associated to the `postgres` connection.

This patch changes the way the UI does the update: it still tries to update the database connection but if it fails to do so because it does not have the permission it just silently skip this part and updates the role.

This also update the error message returned to the user in case of issues to include the actual errors.


### Before the change

https://github.com/hashicorp/vault/assets/35201360/006b5271-609c-4152-b130-bb2a7002db7c


### After the change

https://github.com/hashicorp/vault/assets/35201360/f9d37296-a515-451c-a73d-50428da8e551

