### PR TITLE
Sync Destination Transition Bug

### DIFF
--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.hbs
@@ -73,6 +73,7 @@
       @currentPage={{@associations.meta.currentPage}}
       @currentPageSize={{@associations.meta.pageSize}}
       @route="secrets.destinations.destination.secrets"
+      @model={{@destination}}
       @showSizeSelector={{false}}
       @totalItems={{@associations.meta.filteredTotal}}
       @queryFunction={{this.paginationQueryParams}}

--- a/ui/tests/acceptance/sync/secrets/destination-test.js
+++ b/ui/tests/acceptance/sync/secrets/destination-test.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import syncScenario from 'vault/mirage/scenarios/sync';
+import syncHandlers from 'vault/mirage/handlers/sync';
+import authPage from 'vault/tests/pages/auth';
+import { click, visit, currentURL } from '@ember/test-helpers';
+import { PAGE } from 'vault/tests/helpers/sync/sync-selectors';
+
+const { breadcrumbAtIdx } = PAGE;
+
+module('Acceptance | sync | destination', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    syncScenario(this.server);
+    syncHandlers(this.server);
+    return authPage.login();
+  });
+
+  test('it should transition to overview route via breadcrumb', async function (assert) {
+    await visit('vault/sync/secrets/destinations/aws-sm/destination-aws/secrets');
+    await click(breadcrumbAtIdx(0));
+    assert.strictEqual(
+      currentURL(),
+      '/vault/sync/secrets/overview',
+      'Transitions to overview on breadcrumb click'
+    );
+  });
+});


### PR DESCRIPTION
Transitioning to the sync overview route from the destination secrets or details route via the breadcrumb was resulting in the following error:

![image](https://github.com/hashicorp/vault/assets/24611656/119daeba-029f-4c7e-beb5-5a80b15d46c2)

Since `@model` was not provided to the `Hds::Pagination::Numbered` component, a transition away from the parent destination route (where the necessary model was loaded) was resulting in an error from a `LinkTo` component. 