### PR TITLE
New -kv-version argument to force version and avoid mounts call

### DIFF
--- a/command/agent_generate_config.go
+++ b/command/agent_generate_config.go
@@ -249,7 +249,7 @@ func constructTemplates(ctx context.Context, client *api.Client, paths []string)
 	for _, path := range paths {
 		path = sanitizePath(path)
 
-		mountPath, v2, err := isKVv2(path, client)
+		mountPath, v2, err := isKVv2(path, client, 0)
 		if err != nil {
 			return nil, fmt.Errorf("could not validate secret path %q: %w", path, err)
 		}

--- a/command/base.go
+++ b/command/base.go
@@ -69,6 +69,8 @@ type BaseCommand struct {
 
 	flagHeader map[string]string
 
+	flagKVVersion int
+
 	tokenHelper token.TokenHelper
 
 	client *api.Client
@@ -307,6 +309,7 @@ const (
 	FlagSetOutputField
 	FlagSetOutputFormat
 	FlagSetOutputDetailed
+	FlagSetKVCommon
 )
 
 // flagSet creates the flags for this command. The result is cached on the
@@ -548,6 +551,19 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 					Usage:   "Enables additional metadata during some operations",
 				})
 			}
+		}
+
+		// FlagSetKVCommon
+		if bit&FlagSetKVCommon != 0 {
+			kvCommonSet := set.NewFlagSet("KV Common Options")
+
+			kvCommonSet.IntVar(&IntVar{
+				Name:    "kv-version",
+				Target:  &c.flagKVVersion,
+				Default: 0,
+				Usage:   `Specifies the version of the KV backend to use. If not set it will be detected.`,
+			})
+
 		}
 
 		c.flags = set

--- a/command/kv_delete.go
+++ b/command/kv_delete.go
@@ -37,14 +37,14 @@ Usage: vault kv delete [options] PATH
   versioned data will not be fully removed, but marked as deleted and will no
   longer be returned in normal get requests.
 
-  To delete the latest version of the key "foo": 
+  To delete the latest version of the key "foo":
 
       $ vault kv delete -mount=secret foo
 
-  The deprecated path-like syntax can also be used, but this should be avoided 
-  for KV v2, as the fact that it is not actually the full API path to 
-  the secret (secret/data/foo) can cause confusion: 
-  
+  The deprecated path-like syntax can also be used, but this should be avoided
+  for KV v2, as the fact that it is not actually the full API path to
+  the secret (secret/data/foo) can cause confusion:
+
       $ vault kv delete secret/foo
 
   To delete version 3 of key foo:
@@ -76,10 +76,10 @@ func (c *KVDeleteCommand) Flags() *FlagSets {
 		Name:    "mount",
 		Target:  &c.flagMount,
 		Default: "", // no default, because the handling of the next arg is determined by whether this flag has a value
-		Usage: `Specifies the path where the KV backend is mounted. If specified, 
-		the next argument will be interpreted as the secret path. If this flag is 
-		not specified, the next argument will be interpreted as the combined mount 
-		path and secret path, with /data/ automatically appended between KV 
+		Usage: `Specifies the path where the KV backend is mounted. If specified,
+		the next argument will be interpreted as the secret path. If this flag is
+		not specified, the next argument will be interpreted as the combined mount
+		path and secret path, with /data/ automatically appended between KV
 		v2 secrets.`,
 	})
 
@@ -132,7 +132,7 @@ func (c *KVDeleteCommand) Run(args []string) int {
 	if mountFlagSyntax {
 		// In this case, this arg is the secret path (e.g. "foo").
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client)
+		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2
@@ -145,7 +145,7 @@ func (c *KVDeleteCommand) Run(args []string) int {
 		// In this case, this arg is a path-like combination of mountPath/secretPath.
 		// (e.g. "secret/foo")
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(partialPath, client)
+		mountPath, v2, err = isKVv2(partialPath, client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2

--- a/command/kv_destroy.go
+++ b/command/kv_destroy.go
@@ -39,10 +39,10 @@ Usage: vault kv destroy [options] KEY
 
       $ vault kv destroy -mount=secret -versions=3 foo
 
-  The deprecated path-like syntax can also be used, but this should be avoided 
-  for KV v2, as the fact that it is not actually the full API path to 
-  the secret (secret/data/foo) can cause confusion: 
-  
+  The deprecated path-like syntax can also be used, but this should be avoided
+  for KV v2, as the fact that it is not actually the full API path to
+  the secret (secret/data/foo) can cause confusion:
+
       $ vault kv destroy -versions=3 secret/foo
 
   Additional flags and more advanced use cases are detailed below.
@@ -68,10 +68,10 @@ func (c *KVDestroyCommand) Flags() *FlagSets {
 		Name:    "mount",
 		Target:  &c.flagMount,
 		Default: "", // no default, because the handling of the next arg is determined by whether this flag has a value
-		Usage: `Specifies the path where the KV backend is mounted. If specified, 
-		the next argument will be interpreted as the secret path. If this flag is 
-		not specified, the next argument will be interpreted as the combined mount 
-		path and secret path, with /data/ automatically appended between KV 
+		Usage: `Specifies the path where the KV backend is mounted. If specified,
+		the next argument will be interpreted as the secret path. If this flag is
+		not specified, the next argument will be interpreted as the combined mount
+		path and secret path, with /data/ automatically appended between KV
 		v2 secrets.`,
 	})
 
@@ -131,7 +131,7 @@ func (c *KVDestroyCommand) Run(args []string) int {
 	if mountFlagSyntax {
 		// In this case, this arg is the secret path (e.g. "foo").
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client)
+		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2
@@ -144,7 +144,7 @@ func (c *KVDestroyCommand) Run(args []string) int {
 		// In this case, this arg is a path-like combination of mountPath/secretPath.
 		// (e.g. "secret/foo")
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(partialPath, client)
+		mountPath, v2, err = isKVv2(partialPath, client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2

--- a/command/kv_helpers.go
+++ b/command/kv_helpers.go
@@ -78,10 +78,10 @@ func kvPreflightVersionRequest(client *api.Client, path string) (string, int, er
 				// we provide a more helpful error for the user,
 				// who may not understand why the flag isn't working.
 				err = fmt.Errorf(
-					`This output flag requires the success of a preflight request 
-to determine the version of a KV secrets engine. Please 
-re-run this command with a token with read access to %s. 
-Note that if the path you are trying to reach is a KV v2 path, your token's policy must 
+					`This output flag requires the success of a preflight request
+to determine the version of a KV secrets engine. Please
+re-run this command with a token with read access to %s.
+Note that if the path you are trying to reach is a KV v2 path, your token's policy must
 allow read access to that path in the format 'mount-path/data/foo', not just 'mount-path/foo'.`, path)
 			}
 		}
@@ -119,7 +119,11 @@ allow read access to that path in the format 'mount-path/data/foo', not just 'mo
 	return mountPath, 1, nil
 }
 
-func isKVv2(path string, client *api.Client) (string, bool, error) {
+func isKVv2(path string, client *api.Client, kvVersion int) (string, bool, error) {
+	if kvVersion != 0 {
+		return strings.SplitN(path, "/", 2)[0], kvVersion == 2, nil
+	}
+
 	mountPath, version, err := kvPreflightVersionRequest(client, path)
 	if err != nil {
 		return "", false, err

--- a/command/kv_list.go
+++ b/command/kv_list.go
@@ -54,10 +54,10 @@ func (c *KVListCommand) Flags() *FlagSets {
 		Name:    "mount",
 		Target:  &c.flagMount,
 		Default: "", // no default, because the handling of the next arg is determined by whether this flag has a value
-		Usage: `Specifies the path where the KV backend is mounted. If specified, 
-		the next argument will be interpreted as the secret path. If this flag is 
-		not specified, the next argument will be interpreted as the combined mount 
-		path and secret path, with /data/ automatically appended between KV 
+		Usage: `Specifies the path where the KV backend is mounted. If specified,
+		the next argument will be interpreted as the secret path. If this flag is
+		not specified, the next argument will be interpreted as the combined mount
+		path and secret path, with /data/ automatically appended between KV
 		v2 secrets.`,
 	})
 
@@ -113,7 +113,7 @@ func (c *KVListCommand) Run(args []string) int {
 	if mountFlagSyntax {
 		// In this case, this arg is the secret path (e.g. "foo").
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client)
+		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2
@@ -126,7 +126,7 @@ func (c *KVListCommand) Run(args []string) int {
 		// In this case, this arg is a path-like combination of mountPath/secretPath.
 		// (e.g. "secret/foo")
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(partialPath, client)
+		mountPath, v2, err = isKVv2(partialPath, client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2

--- a/command/kv_metadata_delete.go
+++ b/command/kv_metadata_delete.go
@@ -30,14 +30,14 @@ func (c *KVMetadataDeleteCommand) Help() string {
 	helpText := `
 Usage: vault kv metadata delete [options] PATH
 
-  Deletes all versions and metadata for the provided key. 
+  Deletes all versions and metadata for the provided key.
 
       $ vault kv metadata delete -mount=secret foo
 
-  The deprecated path-like syntax can also be used, but this should be avoided 
-  for KV v2, as the fact that it is not actually the full API path to 
-  the secret (secret/metadata/foo) can cause confusion: 
-  
+  The deprecated path-like syntax can also be used, but this should be avoided
+  for KV v2, as the fact that it is not actually the full API path to
+  the secret (secret/metadata/foo) can cause confusion:
+
       $ vault kv metadata delete secret/foo
 
   Additional flags and more advanced use cases are detailed below.
@@ -57,10 +57,10 @@ func (c *KVMetadataDeleteCommand) Flags() *FlagSets {
 		Name:    "mount",
 		Target:  &c.flagMount,
 		Default: "", // no default, because the handling of the next arg is determined by whether this flag has a value
-		Usage: `Specifies the path where the KV backend is mounted. If specified, 
-		the next argument will be interpreted as the secret path. If this flag is 
-		not specified, the next argument will be interpreted as the combined mount 
-		path and secret path, with /metadata/ automatically appended between KV 
+		Usage: `Specifies the path where the KV backend is mounted. If specified,
+		the next argument will be interpreted as the secret path. If this flag is
+		not specified, the next argument will be interpreted as the combined mount
+		path and secret path, with /metadata/ automatically appended between KV
 		v2 secrets.`,
 	})
 
@@ -113,7 +113,7 @@ func (c *KVMetadataDeleteCommand) Run(args []string) int {
 	if mountFlagSyntax {
 		// In this case, this arg is the secret path (e.g. "foo").
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client)
+		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2
@@ -126,7 +126,7 @@ func (c *KVMetadataDeleteCommand) Run(args []string) int {
 		// In this case, this arg is a path-like combination of mountPath/secretPath.
 		// (e.g. "secret/foo")
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(partialPath, client)
+		mountPath, v2, err = isKVv2(partialPath, client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2

--- a/command/kv_metadata_get.go
+++ b/command/kv_metadata_get.go
@@ -37,10 +37,10 @@ Usage: vault kv metadata get [options] KEY
 
       $ vault kv metadata get -mount=secret foo
 
-  The deprecated path-like syntax can also be used, but this should be avoided 
-  for KV v2, as the fact that it is not actually the full API path to 
-  the secret (secret/metadata/foo) can cause confusion: 
-  
+  The deprecated path-like syntax can also be used, but this should be avoided
+  for KV v2, as the fact that it is not actually the full API path to
+  the secret (secret/metadata/foo) can cause confusion:
+
       $ vault kv metadata get secret/foo
 
   Additional flags and more advanced use cases are detailed below.
@@ -59,10 +59,10 @@ func (c *KVMetadataGetCommand) Flags() *FlagSets {
 		Name:    "mount",
 		Target:  &c.flagMount,
 		Default: "", // no default, because the handling of the next arg is determined by whether this flag has a value
-		Usage: `Specifies the path where the KV backend is mounted. If specified, 
-		the next argument will be interpreted as the secret path. If this flag is 
-		not specified, the next argument will be interpreted as the combined mount 
-		path and secret path, with /metadata/ automatically appended between KV 
+		Usage: `Specifies the path where the KV backend is mounted. If specified,
+		the next argument will be interpreted as the secret path. If this flag is
+		not specified, the next argument will be interpreted as the combined mount
+		path and secret path, with /metadata/ automatically appended between KV
 		v2 secrets.`,
 	})
 
@@ -115,7 +115,7 @@ func (c *KVMetadataGetCommand) Run(args []string) int {
 	if mountFlagSyntax {
 		// In this case, this arg is the secret path (e.g. "foo").
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client)
+		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2
@@ -128,7 +128,7 @@ func (c *KVMetadataGetCommand) Run(args []string) int {
 		// In this case, this arg is a path-like combination of mountPath/secretPath.
 		// (e.g. "secret/foo")
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(partialPath, client)
+		mountPath, v2, err = isKVv2(partialPath, client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2

--- a/command/kv_metadata_patch.go
+++ b/command/kv_metadata_patch.go
@@ -47,10 +47,10 @@ Usage: vault kv metadata patch [options] KEY
 
       $ vault kv metadata patch -mount=secret foo
 
-  The deprecated path-like syntax can also be used, but this should be avoided 
-  for KV v2, as the fact that it is not actually the full API path to 
-  the secret (secret/metadata/foo) can cause confusion: 
-  
+  The deprecated path-like syntax can also be used, but this should be avoided
+  for KV v2, as the fact that it is not actually the full API path to
+  the secret (secret/metadata/foo) can cause confusion:
+
       $ vault kv metadata patch secret/foo
 
   Set a max versions setting on the key:
@@ -130,10 +130,10 @@ func (c *KVMetadataPatchCommand) Flags() *FlagSets {
 		Name:    "mount",
 		Target:  &c.flagMount,
 		Default: "", // no default, because the handling of the next arg is determined by whether this flag has a value
-		Usage: `Specifies the path where the KV backend is mounted. If specified, 
-		the next argument will be interpreted as the secret path. If this flag is 
-		not specified, the next argument will be interpreted as the combined mount 
-		path and secret path, with /metadata/ automatically appended between KV 
+		Usage: `Specifies the path where the KV backend is mounted. If specified,
+		the next argument will be interpreted as the secret path. If this flag is
+		not specified, the next argument will be interpreted as the combined mount
+		path and secret path, with /metadata/ automatically appended between KV
 		v2 secrets.`,
 	})
 
@@ -187,7 +187,7 @@ func (c *KVMetadataPatchCommand) Run(args []string) int {
 	if mountFlagSyntax {
 		// In this case, this arg is the secret path (e.g. "foo").
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client)
+		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2
@@ -200,7 +200,7 @@ func (c *KVMetadataPatchCommand) Run(args []string) int {
 		// In this case, this arg is a path-like combination of mountPath/secretPath.
 		// (e.g. "secret/foo")
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(partialPath, client)
+		mountPath, v2, err = isKVv2(partialPath, client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2

--- a/command/kv_metadata_put.go
+++ b/command/kv_metadata_put.go
@@ -45,10 +45,10 @@ Usage: vault kv metadata put [options] KEY
 
       $ vault kv metadata put -mount=secret foo
 
-  The deprecated path-like syntax can also be used, but this should be avoided 
-  for KV v2, as the fact that it is not actually the full API path to 
-  the secret (secret/metadata/foo) can cause confusion: 
-  
+  The deprecated path-like syntax can also be used, but this should be avoided
+  for KV v2, as the fact that it is not actually the full API path to
+  the secret (secret/metadata/foo) can cause confusion:
+
       $ vault kv metadata put secret/foo
 
   Set a max versions setting on the key:
@@ -117,10 +117,10 @@ func (c *KVMetadataPutCommand) Flags() *FlagSets {
 		Name:    "mount",
 		Target:  &c.flagMount,
 		Default: "", // no default, because the handling of the next arg is determined by whether this flag has a value
-		Usage: `Specifies the path where the KV backend is mounted. If specified, 
-		the next argument will be interpreted as the secret path. If this flag is 
-		not specified, the next argument will be interpreted as the combined mount 
-		path and secret path, with /metadata/ automatically appended between KV 
+		Usage: `Specifies the path where the KV backend is mounted. If specified,
+		the next argument will be interpreted as the secret path. If this flag is
+		not specified, the next argument will be interpreted as the combined mount
+		path and secret path, with /metadata/ automatically appended between KV
 		v2 secrets.`,
 	})
 
@@ -174,7 +174,7 @@ func (c *KVMetadataPutCommand) Run(args []string) int {
 	if mountFlagSyntax {
 		// In this case, this arg is the secret path (e.g. "foo").
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client)
+		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2
@@ -187,7 +187,7 @@ func (c *KVMetadataPutCommand) Run(args []string) int {
 		// In this case, this arg is a path-like combination of mountPath/secretPath.
 		// (e.g. "secret/foo")
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(partialPath, client)
+		mountPath, v2, err = isKVv2(partialPath, client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2

--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -46,10 +46,10 @@ Usage: vault kv patch [options] KEY [DATA]
 
       $ vault kv patch -mount=secret foo bar=baz
 
-  The deprecated path-like syntax can also be used, but this should be avoided, 
-  as the fact that it is not actually the full API path to 
-  the secret (secret/data/foo) can cause confusion: 
-  
+  The deprecated path-like syntax can also be used, but this should be avoided,
+  as the fact that it is not actually the full API path to
+  the secret (secret/data/foo) can cause confusion:
+
       $ vault kv patch secret/foo bar=baz
 
   The data can also be consumed from a file on disk by prefixing with the "@"
@@ -118,10 +118,10 @@ func (c *KVPatchCommand) Flags() *FlagSets {
 		Name:    "mount",
 		Target:  &c.flagMount,
 		Default: "", // no default, because the handling of the next arg is determined by whether this flag has a value
-		Usage: `Specifies the path where the KV backend is mounted. If specified, 
-		the next argument will be interpreted as the secret path. If this flag is 
-		not specified, the next argument will be interpreted as the combined mount 
-		path and secret path, with /data/ automatically appended between KV 
+		Usage: `Specifies the path where the KV backend is mounted. If specified,
+		the next argument will be interpreted as the secret path. If this flag is
+		not specified, the next argument will be interpreted as the combined mount
+		path and secret path, with /data/ automatically appended between KV
 		v2 secrets.`,
 	})
 
@@ -195,7 +195,7 @@ func (c *KVPatchCommand) Run(args []string) int {
 	if mountFlagSyntax {
 		// In this case, this arg is the secret path (e.g. "foo").
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client)
+		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2
@@ -208,7 +208,7 @@ func (c *KVPatchCommand) Run(args []string) int {
 		// In this case, this arg is a path-like combination of mountPath/secretPath.
 		// (e.g. "secret/foo")
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(partialPath, client)
+		mountPath, v2, err = isKVv2(partialPath, client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2

--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -40,10 +40,10 @@ Usage: vault kv put [options] KEY [DATA]
 
       $ vault kv put -mount=secret foo bar=baz
 
-  The deprecated path-like syntax can also be used, but this should be avoided 
-  for KV v2, as the fact that it is not actually the full API path to 
-  the secret (secret/data/foo) can cause confusion: 
-  
+  The deprecated path-like syntax can also be used, but this should be avoided
+  for KV v2, as the fact that it is not actually the full API path to
+  the secret (secret/data/foo) can cause confusion:
+
       $ vault kv put secret/foo bar=baz
 
   The data can also be consumed from a file on disk by prefixing with the "@"
@@ -88,10 +88,10 @@ func (c *KVPutCommand) Flags() *FlagSets {
 		Name:    "mount",
 		Target:  &c.flagMount,
 		Default: "", // no default, because the handling of the next arg is determined by whether this flag has a value
-		Usage: `Specifies the path where the KV backend is mounted. If specified, 
-		the next argument will be interpreted as the secret path. If this flag is 
-		not specified, the next argument will be interpreted as the combined mount 
-		path and secret path, with /data/ automatically appended between KV 
+		Usage: `Specifies the path where the KV backend is mounted. If specified,
+		the next argument will be interpreted as the secret path. If this flag is
+		not specified, the next argument will be interpreted as the combined mount
+		path and secret path, with /data/ automatically appended between KV
 		v2 secrets.`,
 	})
 
@@ -158,7 +158,7 @@ func (c *KVPutCommand) Run(args []string) int {
 	if mountFlagSyntax {
 		// In this case, this arg is the secret path (e.g. "foo").
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client)
+		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2
@@ -171,7 +171,7 @@ func (c *KVPutCommand) Run(args []string) int {
 		// In this case, this arg is a path-like combination of mountPath/secretPath.
 		// (e.g. "secret/foo")
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(partialPath, client)
+		mountPath, v2, err = isKVv2(partialPath, client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2

--- a/command/kv_rollback.go
+++ b/command/kv_rollback.go
@@ -42,10 +42,10 @@ Usage: vault kv rollback [options] KEY
 
       $ vault kv rollback -mount=secret -version=2 foo
 
-  The deprecated path-like syntax can also be used, but this should be avoided, 
-  as the fact that it is not actually the full API path to 
-  the secret (secret/data/foo) can cause confusion: 
-  
+  The deprecated path-like syntax can also be used, but this should be avoided,
+  as the fact that it is not actually the full API path to
+  the secret (secret/data/foo) can cause confusion:
+
       $ vault kv rollback -version=2 secret/foo
 
   Additional flags and more advanced use cases are detailed below.
@@ -70,10 +70,10 @@ func (c *KVRollbackCommand) Flags() *FlagSets {
 		Name:    "mount",
 		Target:  &c.flagMount,
 		Default: "", // no default, because the handling of the next arg is determined by whether this flag has a value
-		Usage: `Specifies the path where the KV backend is mounted. If specified, 
-		the next argument will be interpreted as the secret path. If this flag is 
-		not specified, the next argument will be interpreted as the combined mount 
-		path and secret path, with /data/ automatically appended between KV 
+		Usage: `Specifies the path where the KV backend is mounted. If specified,
+		the next argument will be interpreted as the secret path. If this flag is
+		not specified, the next argument will be interpreted as the combined mount
+		path and secret path, with /data/ automatically appended between KV
 		v2 secrets.`,
 	})
 
@@ -139,7 +139,7 @@ func (c *KVRollbackCommand) Run(args []string) int {
 	if mountFlagSyntax {
 		// In this case, this arg is the secret path (e.g. "foo").
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client)
+		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2
@@ -152,7 +152,7 @@ func (c *KVRollbackCommand) Run(args []string) int {
 		// In this case, this arg is a path-like combination of mountPath/secretPath.
 		// (e.g. "secret/foo")
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(partialPath, client)
+		mountPath, v2, err = isKVv2(partialPath, client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2

--- a/command/kv_undelete.go
+++ b/command/kv_undelete.go
@@ -130,7 +130,7 @@ func (c *KVUndeleteCommand) Run(args []string) int {
 		// In this case, this arg is the secret path (e.g. "foo").
 		partialPath = sanitizePath(args[0])
 		mountPath = sanitizePath(c.flagMount)
-		_, v2, err = isKVv2(mountPath, client)
+		_, v2, err = isKVv2(mountPath, client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2
@@ -147,7 +147,7 @@ func (c *KVUndeleteCommand) Run(args []string) int {
 		// In this case, this arg is a path-like combination of mountPath/secretPath.
 		// (e.g. "secret/foo")
 		partialPath = sanitizePath(args[0])
-		mountPath, v2, err = isKVv2(partialPath, client)
+		mountPath, v2, err = isKVv2(partialPath, client, c.flagKVVersion)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2


### PR DESCRIPTION
Added a new argument "-kv-version" that could be used with the "kv" subcommands to force the KV engine version to be used.

Forcing the version allows the CLI to skip the call to /v1/sys/internal/ui/mounts/kv.
This allow the CLI to get cached vaules from a proxy without intervention of the server.

Related to #19879