### PR TITLE
Fix pluralization error in ACME entity assignment doc

### DIFF
--- a/website/content/docs/concepts/client-count/index.mdx
+++ b/website/content/docs/concepts/client-count/index.mdx
@@ -71,7 +71,7 @@ For example:
 
 - ACME client requests (from the same server or separate servers) for the same
   certificate identifier (a unique combination of CN,DNS, SANS and IP SANS)
-  are treated as the same entities.
+  are treated as the same entity.
 - If an ACME client makes a request for `a.test.com`, and subsequently makes a new
   request for `b.test.com` and `*.test.com` then two distinct entities will be created,
   one for `a.test.com` and another for the combination of `b.test.com` and `*.test.com`.


### PR DESCRIPTION
I introduced a pluralization error within #24501 when updating the ACME entity assignment docs. 