### PR TITLE
UI: remove keyvauluri from credentials section

### DIFF
--- a/ui/app/models/sync/destinations/azure-kv.js
+++ b/ui/app/models/sync/destinations/azure-kv.js
@@ -8,8 +8,8 @@ import { attr } from '@ember-data/model';
 import { withFormFields } from 'vault/decorators/model-form-fields';
 const displayFields = ['name', 'keyVaultUri', 'tenantId', 'cloud', 'clientId', 'clientSecret'];
 const formFieldGroups = [
-  { default: ['name', 'tenantId', 'cloud', 'clientId'] },
-  { Credentials: ['keyVaultUri', 'clientSecret'] },
+  { default: ['name', 'keyVaultUri', 'tenantId', 'cloud', 'clientId'] },
+  { Credentials: ['clientSecret'] },
 ];
 @withFormFields(displayFields, formFieldGroups)
 export default class SyncDestinationsAzureKeyVaultModel extends SyncDestinationModel {

--- a/ui/tests/integration/components/sync/secrets/page/destinations/create-and-edit-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations/create-and-edit-test.js
@@ -257,10 +257,10 @@ module('Integration | Component | sync | Secrets::Page::Destinations::CreateAndE
 
         for (const attr of this.model.formFields) {
           // Enable inputs with sensitive values
-          if (maskedParams.includes(attr.name)) {
-            await click(PAGE.form.enableInput(attr.name));
-          }
           if (editable.includes(attr.name)) {
+            if (maskedParams.includes(attr.name)) {
+              await click(PAGE.form.enableInput(attr.name));
+            }
             await PAGE.form.fillInByAttr(attr.name, `new-${decamelize(attr.name)}-value`);
           } else {
             assert.dom(PAGE.inputByAttr(attr.name)).isDisabled(`${attr.name} is disabled`);

--- a/ui/tests/integration/components/sync/secrets/page/destinations/create-and-edit-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations/create-and-edit-test.js
@@ -256,9 +256,9 @@ module('Integration | Component | sync | Secrets::Page::Destinations::CreateAndE
         assert.dom(PAGE.title).hasTextContaining(`Edit ${this.model.name}`);
 
         for (const attr of this.model.formFields) {
-          // Enable inputs with sensitive values
           if (editable.includes(attr.name)) {
             if (maskedParams.includes(attr.name)) {
+              // Enable inputs with sensitive values
               await click(PAGE.form.enableInput(attr.name));
             }
             await PAGE.form.fillInByAttr(attr.name, `new-${decamelize(attr.name)}-value`);


### PR DESCRIPTION
In https://github.com/hashicorp/vault/pull/24644 I mistakingly added `key_vault_uri` to the credentials block because it is an obfuscated param - however it is not actually editable which is the intention of the credentials section. 
See below - there is an "enable" button to intentionally change the sensitive value. This doesn't make sense for a non-editable param.

<img width="833" alt="Screenshot 2024-01-04 at 4 52 16 PM" src="https://github.com/hashicorp/vault/assets/68122737/1216d0c3-0076-4687-b565-5f9a19a87375">

This PR moves the param back to the main section of the form
<img width="829" alt="Screenshot 2024-01-04 at 4 53 06 PM" src="https://github.com/hashicorp/vault/assets/68122737/80121b40-aabf-473b-b18d-4728737e6f27">
