### PR TITLE
UI: fix PKI issuer capabilities

### DIFF
--- a/changelog/24686.txt
+++ b/changelog/24686.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fix incorrectly calculated capabilities on PKI issuer endpoints
+```

--- a/ui/app/models/pki/issuer.js
+++ b/ui/app/models/pki/issuer.js
@@ -135,13 +135,14 @@ export default class PkiIssuerModel extends Model {
   @attr importedKeys;
   @attr mapping;
 
-  @lazyCapabilities(apiPath`${'backend'}/issuer/${'issuerId'}`, 'backend') issuerPath;
+  @lazyCapabilities(apiPath`${'backend'}/issuer/${'issuerId'}`, 'backend', 'issuerId') issuerPath;
   @lazyCapabilities(apiPath`${'backend'}/root/rotate/exported`, 'backend') rotateExported;
   @lazyCapabilities(apiPath`${'backend'}/root/rotate/internal`, 'backend') rotateInternal;
   @lazyCapabilities(apiPath`${'backend'}/root/rotate/existing`, 'backend') rotateExisting;
   @lazyCapabilities(apiPath`${'backend'}/root`, 'backend') deletePath;
   @lazyCapabilities(apiPath`${'backend'}/intermediate/cross-sign`, 'backend') crossSignPath;
-  @lazyCapabilities(apiPath`${'backend'}/issuer/${'issuerId'}/sign-intermediate`, 'backend') signIntermediate;
+  @lazyCapabilities(apiPath`${'backend'}/issuer/${'issuerId'}/sign-intermediate`, 'backend', 'issuerId')
+  signIntermediate;
   get canRotateIssuer() {
     return (
       this.rotateExported.get('canUpdate') !== false ||

--- a/ui/app/models/pki/issuer.js
+++ b/ui/app/models/pki/issuer.js
@@ -135,13 +135,13 @@ export default class PkiIssuerModel extends Model {
   @attr importedKeys;
   @attr mapping;
 
-  @lazyCapabilities(apiPath`${'backend'}/issuer/${'issuerId'}`) issuerPath;
-  @lazyCapabilities(apiPath`${'backend'}/root/rotate/exported`) rotateExported;
-  @lazyCapabilities(apiPath`${'backend'}/root/rotate/internal`) rotateInternal;
-  @lazyCapabilities(apiPath`${'backend'}/root/rotate/existing`) rotateExisting;
+  @lazyCapabilities(apiPath`${'backend'}/issuer/${'issuerId'}`, 'backend') issuerPath;
+  @lazyCapabilities(apiPath`${'backend'}/root/rotate/exported`, 'backend') rotateExported;
+  @lazyCapabilities(apiPath`${'backend'}/root/rotate/internal`, 'backend') rotateInternal;
+  @lazyCapabilities(apiPath`${'backend'}/root/rotate/existing`, 'backend') rotateExisting;
   @lazyCapabilities(apiPath`${'backend'}/root`, 'backend') deletePath;
-  @lazyCapabilities(apiPath`${'backend'}/intermediate/cross-sign`) crossSignPath;
-  @lazyCapabilities(apiPath`${'backend'}/issuer/${'issuerId'}/sign-intermediate`) signIntermediate;
+  @lazyCapabilities(apiPath`${'backend'}/intermediate/cross-sign`, 'backend') crossSignPath;
+  @lazyCapabilities(apiPath`${'backend'}/issuer/${'issuerId'}/sign-intermediate`, 'backend') signIntermediate;
   get canRotateIssuer() {
     return (
       this.rotateExported.get('canUpdate') !== false ||

--- a/ui/tests/acceptance/pki/pki-engine-workflow-test.js
+++ b/ui/tests/acceptance/pki/pki-engine-workflow-test.js
@@ -93,9 +93,9 @@ module('Acceptance | pki workflow', function (hooks) {
       const pki_admin_policy = adminPolicy(this.mountPath, 'roles');
       const pki_reader_policy = readerPolicy(this.mountPath, 'roles');
       const pki_editor_policy = updatePolicy(this.mountPath, 'roles');
-      this.pkiRoleReader = await tokenWithPolicy('pki-reader', pki_reader_policy);
-      this.pkiRoleEditor = await tokenWithPolicy('pki-editor', pki_editor_policy);
-      this.pkiAdminToken = await tokenWithPolicy('pki-admin', pki_admin_policy);
+      this.pkiRoleReader = await tokenWithPolicy(`pki-reader-${this.mountPath}`, pki_reader_policy);
+      this.pkiRoleEditor = await tokenWithPolicy(`pki-editor-${this.mountPath}`, pki_editor_policy);
+      this.pkiAdminToken = await tokenWithPolicy(`pki-admin-${this.mountPath}`, pki_admin_policy);
       await logout.visit();
       clearRecords(this.store);
     });
@@ -225,9 +225,9 @@ module('Acceptance | pki workflow', function (hooks) {
       const pki_admin_policy = adminPolicy(this.mountPath);
       const pki_reader_policy = readerPolicy(this.mountPath, 'keys', true);
       const pki_editor_policy = updatePolicy(this.mountPath, 'keys');
-      this.pkiKeyReader = await tokenWithPolicy('pki-reader', pki_reader_policy);
-      this.pkiKeyEditor = await tokenWithPolicy('pki-editor', pki_editor_policy);
-      this.pkiAdminToken = await tokenWithPolicy('pki-admin', pki_admin_policy);
+      this.pkiKeyReader = await tokenWithPolicy(`pki-reader-${this.mountPath}`, pki_reader_policy);
+      this.pkiKeyEditor = await tokenWithPolicy(`pki-editor-${this.mountPath}`, pki_editor_policy);
+      this.pkiAdminToken = await tokenWithPolicy(`pki-admin-${this.mountPath}`, pki_admin_policy);
       await logout.visit();
       clearRecords(this.store);
     });
@@ -344,7 +344,7 @@ module('Acceptance | pki workflow', function (hooks) {
     hooks.beforeEach(async function () {
       await authPage.login();
       const pki_admin_policy = adminPolicy(this.mountPath);
-      this.pkiAdminToken = await tokenWithPolicy('pki-admin', pki_admin_policy);
+      this.pkiAdminToken = await tokenWithPolicy(`pki-admin-${this.mountPath}`, pki_admin_policy);
       // Configure engine with a default issuer
       await runCommands([
         `write ${this.mountPath}/root/generate/internal common_name="Hashicorp Test" name="Hashicorp Test"`,
@@ -380,7 +380,10 @@ module('Acceptance | pki workflow', function (hooks) {
         capabilities = ["deny"]
       }
       `;
-      this.token = await tokenWithPolicy('pki-issuer-denied-policy', pki_issuer_denied_policy);
+      this.token = await tokenWithPolicy(
+        `pki-issuer-denied-policy-${this.mountPath}`,
+        pki_issuer_denied_policy
+      );
       await logout.visit();
       await authPage.login(this.token);
       await visit(`/vault/secrets/${this.mountPath}/pki/overview`);
@@ -494,7 +497,10 @@ module('Acceptance | pki workflow', function (hooks) {
       ${adminPolicy(this.mountPath)}
       ${readerPolicy(this.mountPath, 'config/cluster')}
       `;
-      this.mixedConfigCapabilities = await tokenWithPolicy('pki-reader', mixed_config_policy);
+      this.mixedConfigCapabilities = await tokenWithPolicy(
+        `pki-reader-${this.mountPath}`,
+        mixed_config_policy
+      );
       await logout.visit();
     });
 

--- a/ui/tests/acceptance/pki/pki-engine-workflow-test.js
+++ b/ui/tests/acceptance/pki/pki-engine-workflow-test.js
@@ -42,40 +42,50 @@ module('Acceptance | pki workflow', function (hooks) {
     await runCommands([`delete sys/mounts/${this.mountPath}`]);
   });
 
-  test('empty state messages are correct when PKI not configured', async function (assert) {
-    assert.expect(21);
-    const assertEmptyState = (assert, resource) => {
-      assert.strictEqual(currentURL(), `/vault/secrets/${this.mountPath}/pki/${resource}`);
-      assert
-        .dom(SELECTORS.emptyStateTitle)
-        .hasText(
-          'PKI not configured',
-          `${resource} index renders correct empty state title when PKI not configured`
-        );
-      assert.dom(SELECTORS.emptyStateLink).hasText('Configure PKI');
-      assert
-        .dom(SELECTORS.emptyStateMessage)
-        .hasText(
-          `This PKI mount hasn't yet been configured with a certificate issuer.`,
-          `${resource} index empty state message correct when PKI not configured`
-        );
-    };
-    await authPage.login(this.pkiAdminToken);
-    await visit(`/vault/secrets/${this.mountPath}/pki/overview`);
-    assert.strictEqual(currentURL(), `/vault/secrets/${this.mountPath}/pki/overview`);
+  module('not configured', function (hooks) {
+    hooks.beforeEach(async function () {
+      await authPage.login();
+      const pki_admin_policy = adminPolicy(this.mountPath, 'roles');
+      this.pkiAdminToken = await tokenWithPolicy(`pki-admin-${this.mountPath}`, pki_admin_policy);
+      await logout.visit();
+      clearRecords(this.store);
+    });
 
-    await click(SELECTORS.rolesTab);
-    assertEmptyState(assert, 'roles');
+    test('empty state messages are correct when PKI not configured', async function (assert) {
+      assert.expect(21);
+      const assertEmptyState = (assert, resource) => {
+        assert.strictEqual(currentURL(), `/vault/secrets/${this.mountPath}/pki/${resource}`);
+        assert
+          .dom(SELECTORS.emptyStateTitle)
+          .hasText(
+            'PKI not configured',
+            `${resource} index renders correct empty state title when PKI not configured`
+          );
+        assert.dom(SELECTORS.emptyStateLink).hasText('Configure PKI');
+        assert
+          .dom(SELECTORS.emptyStateMessage)
+          .hasText(
+            `This PKI mount hasn't yet been configured with a certificate issuer.`,
+            `${resource} index empty state message correct when PKI not configured`
+          );
+      };
+      await authPage.login(this.pkiAdminToken);
+      await visit(`/vault/secrets/${this.mountPath}/pki/overview`);
+      assert.strictEqual(currentURL(), `/vault/secrets/${this.mountPath}/pki/overview`);
 
-    await click(SELECTORS.issuersTab);
-    assertEmptyState(assert, 'issuers');
+      await click(SELECTORS.rolesTab);
+      assertEmptyState(assert, 'roles');
 
-    await click(SELECTORS.certsTab);
-    assertEmptyState(assert, 'certificates');
-    await click(SELECTORS.keysTab);
-    assertEmptyState(assert, 'keys');
-    await click(SELECTORS.tidyTab);
-    assertEmptyState(assert, 'tidy');
+      await click(SELECTORS.issuersTab);
+      assertEmptyState(assert, 'issuers');
+
+      await click(SELECTORS.certsTab);
+      assertEmptyState(assert, 'certificates');
+      await click(SELECTORS.keysTab);
+      assertEmptyState(assert, 'keys');
+      await click(SELECTORS.tidyTab);
+      assertEmptyState(assert, 'tidy');
+    });
   });
 
   module('roles', function (hooks) {

--- a/ui/tests/acceptance/pki/pki-overview-test.js
+++ b/ui/tests/acceptance/pki/pki-overview-test.js
@@ -10,12 +10,13 @@ import logout from 'vault/tests/pages/logout';
 import enablePage from 'vault/tests/pages/settings/mount-secret-backend';
 import { click, currentURL, currentRouteName, visit } from '@ember/test-helpers';
 import { SELECTORS } from 'vault/tests/helpers/pki/overview';
-import { tokenWithPolicy, runCommands } from 'vault/tests/helpers/pki/pki-run-commands';
+import { tokenWithPolicy, runCommands, clearRecords } from 'vault/tests/helpers/pki/pki-run-commands';
 
 module('Acceptance | pki overview', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
+    this.store = this.owner.lookup('service:store');
     await authPage.login();
     // Setup PKI engine
     const mountPath = `pki`;
@@ -42,6 +43,7 @@ module('Acceptance | pki overview', function (hooks) {
     this.pkiIssuersList = await tokenWithPolicy('pki-issuers-list', pki_issuers_list_policy);
     this.pkiAdminToken = await tokenWithPolicy('pki-admin', pki_admin_policy);
     await logout.visit();
+    clearRecords(this.store);
   });
 
   hooks.afterEach(async function () {

--- a/ui/tests/acceptance/policies-acl-old-test.js
+++ b/ui/tests/acceptance/policies-acl-old-test.js
@@ -42,10 +42,10 @@ module('Acceptance | policies (old)', function (hooks) {
       `/vault/policy/acl/${encodeURIComponent(policyLower)}`,
       'navigates to policy show on successful save'
     );
-    await fillIn('[data-test-component="navigate-input"]', policyLower);
     assert.dom('[data-test-policy-name]').hasText(policyLower, 'displays the policy name on the show page');
     assert.dom('[data-test-flash-message].is-info').doesNotExist('no flash message is displayed on save');
     await click('[data-test-policy-list-link] a');
+    await fillIn('[data-test-component="navigate-input"]', policyLower);
     assert
       .dom(`[data-test-policy-link="${policyLower}"]`)
       .exists({ count: 1 }, 'new policy shown in the list');

--- a/ui/tests/acceptance/policies-acl-old-test.js
+++ b/ui/tests/acceptance/policies-acl-old-test.js
@@ -42,6 +42,7 @@ module('Acceptance | policies (old)', function (hooks) {
       `/vault/policy/acl/${encodeURIComponent(policyLower)}`,
       'navigates to policy show on successful save'
     );
+    await fillIn('[data-test-component="navigate-input"]', policyLower);
     assert.dom('[data-test-policy-name]').hasText(policyLower, 'displays the policy name on the show page');
     assert.dom('[data-test-flash-message].is-info').doesNotExist('no flash message is displayed on save');
     await click('[data-test-policy-list-link] a');
@@ -63,6 +64,7 @@ module('Acceptance | policies (old)', function (hooks) {
       `/vault/policies/acl`,
       'navigates to policy list on successful deletion'
     );
+    await fillIn('[data-test-component="navigate-input"]', policyLower);
     assert
       .dom(`[data-test-policy-item="${policyLower}"]`)
       .doesNotExist('deleted policy is not shown in the list');

--- a/ui/tests/helpers/pki/pki-run-commands.js
+++ b/ui/tests/helpers/pki/pki-run-commands.js
@@ -34,3 +34,21 @@ export const runCommands = async function (commands) {
     throw error;
   }
 };
+
+// Clears pki-related data and capabilities so that admin
+// capabilities from setup don't rollover
+export function clearRecords(store) {
+  store.unloadAll('pki/action');
+  store.unloadAll('pki/issuer');
+  store.unloadAll('pki/key');
+  store.unloadAll('pki/role');
+  store.unloadAll('pki/sign-intermediate');
+  store.unloadAll('pki/tidy');
+  store.unloadAll('pki/config/urls');
+  store.unloadAll('pki/config/crl');
+  store.unloadAll('pki/config/cluster');
+  store.unloadAll('pki/config/acme');
+  store.unloadAll('pki/certificate/generate');
+  store.unloadAll('pki/certificate/sign');
+  store.unloadAll('capabilities');
+}


### PR DESCRIPTION
There was a bug where capabilities on PKI issuers were incorrectly calculated. The workflow tests did not catch this because we weren't clearing the store of `capabilities` entries after setup, which means the UI was using the old capabilities in memory from the root setup. 