### PR TITLE
UI: Changes jwks_ca_pem param to a 'file' edit type

### DIFF
--- a/changelog/24697.txt
+++ b/changelog/24697.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes input for jwks_ca_pem when configuring a JWT auth method
+```

--- a/ui/app/models/auth-config/jwt.js
+++ b/ui/app/models/auth-config/jwt.js
@@ -24,12 +24,31 @@ export default AuthConfig.extend({
   oidcClientSecret: attr('string', {
     label: 'OIDC client secret',
   }),
+
   oidcDiscoveryCaPem: attr('string', {
     label: 'OIDC discovery CA PEM',
     editType: 'file',
     helpText:
       'The CA certificate or chain of certificates, in PEM format, to use to validate connections to the OIDC Discovery URL. If not set, system certificates are used',
   }),
+
+  jwksCaPem: attr('string', {
+    label: 'JWKS CA PEM',
+    editType: 'file',
+  }),
+
+  jwksUrl: attr('string', {
+    label: 'JWKS URL',
+  }),
+
+  oidcResponseMode: attr('string', {
+    label: 'OIDC response mode',
+  }),
+
+  oidcResponseTypes: attr('string', {
+    label: 'OIDC response types',
+  }),
+
   jwtValidationPubkeys: attr({
     label: 'JWT validation public keys',
     editType: 'stringArray',
@@ -38,14 +57,23 @@ export default AuthConfig.extend({
   jwtSupportedAlgs: attr({
     label: 'JWT supported algorithms',
   }),
+
   boundIssuer: attr('string', {
     helpText: 'The value against which to match the iss claim in a JWT',
   }),
+
   fieldGroups: computed('constructor.modelName', 'newFields', function () {
     const type = this.constructor.modelName.split('/')[1].toUpperCase();
     let groups = [
       {
-        default: ['oidcDiscoveryUrl', 'defaultRole'],
+        default: [
+          'oidcDiscoveryUrl',
+          'defaultRole',
+          'jwksCaPem',
+          'jwksUrl',
+          'oidcResponseMode',
+          'oidcResponseTypes',
+        ],
       },
       {
         [`${type} Options`]: [


### PR DESCRIPTION
Fixes https://github.com/hashicorp/vault-plugin-auth-jwt/issues/248 by adding upload capabilities for the `jwks_ca_pem` param. Previously the input was a basic (single line) text input, now a user can upload a PEM certificate or paste it in a multi-line text area.  The CA is submitted in the correct format now, see the screenshot below includes line breaks where expected: 
<img width="951" alt="Screenshot 2024-01-05 at 4 08 11 PM" src="https://github.com/hashicorp/vault/assets/68122737/141880eb-7d6c-4d3e-96da-5216c417d72b">

<img width="1112" alt="Screenshot 2024-01-05 at 3 56 22 PM" src="https://github.com/hashicorp/vault/assets/68122737/2db836f6-c39a-403f-818e-16769bb30e38">
