### PR TITLE
Add -type -f to the -find delete call as part of test collect reports

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -510,7 +510,7 @@ jobs:
       - run: |
           rm -rf test-results/go-test/logs
           ls -lhR test-results/go-test
-          find test-results/go-test -mindepth 1 -mtime +3 -delete
+          find test-results/go-test -mindepth 1 -type f -mtime +3 -delete
 
           # Prune invalid timing files
           find test-results/go-test -mindepth 1 -type f -name "*.json" -exec sh -c '


### PR DESCRIPTION
We had a recent failure with `find: cannot delete ‘test-results/go-test/logs-13’: Directory not empty`, a failure to delete a non-empty directory. Limiting this to just the files seems to be an easy win.