### PR TITLE
Secrets Sync UI: Small bug fixes from more QA 

### DIFF
--- a/ui/app/models/sync/destination.js
+++ b/ui/app/models/sync/destination.js
@@ -10,7 +10,10 @@ import { withModelValidations } from 'vault/decorators/model-validations';
 
 // Base model for all secret sync destination types
 const validations = {
-  name: [{ type: 'presence', message: 'Name is required.' }],
+  name: [
+    { type: 'presence', message: 'Name is required.' },
+    { type: 'containsWhiteSpace', message: 'Name cannot contain whitespace.' },
+  ],
 };
 
 @withModelValidations(validations)

--- a/ui/app/models/sync/destinations/azure-kv.js
+++ b/ui/app/models/sync/destinations/azure-kv.js
@@ -19,7 +19,7 @@ export default class SyncDestinationsAzureKeyVaultModel extends SyncDestinationM
       'URI of an existing Azure Key Vault instance. If empty, Vault will use the KEY_VAULT_URI environment variable if configured.',
     editDisabled: true,
   })
-  keyVaultUri; // obfuscated, never returned by API
+  keyVaultUri;
 
   @attr('string', {
     label: 'Client ID',

--- a/ui/lib/core/addon/components/text-file.hbs
+++ b/ui/lib/core/addon/components/text-file.hbs
@@ -51,9 +51,7 @@
         {{/if}}
         {{#if @docLink}}
           See our
-          <Hds::Link::Inline @href={{doc-link @docLink}} @icon="docs-link" @iconPosition="trailing">
-            documentation
-          </Hds::Link::Inline>
+          <Hds::Link::Inline @href={{doc-link @docLink}}>documentation</Hds::Link::Inline>
           for help.
         {{/if}}
       </F.HelperText>
@@ -72,9 +70,7 @@
         {{/if}}
         {{#if @docLink}}
           See our
-          <Hds::Link::Inline @href={{doc-link @docLink}} @icon="docs-link" @iconPosition="trailing">
-            documentation
-          </Hds::Link::Inline>
+          <Hds::Link::Inline @href={{doc-link @docLink}}>documentation</Hds::Link::Inline>
           for help.
         {{/if}}
       </F.HelperText>

--- a/ui/lib/core/addon/helpers/sync-destinations.ts
+++ b/ui/lib/core/addon/helpers/sync-destinations.ts
@@ -26,7 +26,7 @@ const SYNC_DESTINATIONS: Array<SyncDestination> = [
     type: 'azure-kv',
     icon: 'azure-color',
     category: 'cloud',
-    maskedParams: ['clientSecret', 'keyVaultUri'],
+    maskedParams: ['clientSecret'],
   },
   {
     name: 'Google Secret Manager',

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -21,9 +21,7 @@
               @color="secondary"
               @isRouteExternal={{true}}
               @models={{array status.destinationType status.destinationName}}
-            >
-              {{status.destinationName}}
-            </Hds::Link::Inline>
+            >{{status.destinationName}}</Hds::Link::Inline>
             - last updated
             {{date-format status.updatedAt "MMMM do yyyy, h:mm:ss a"}}
           </A.Description>

--- a/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.hbs
@@ -38,7 +38,7 @@
   {{/each}}
 
   <hr class="has-background-gray-200 has-top-margin-l" />
-  <Hds::ButtonSet>
+  <Hds::ButtonSet class="has-bottom-margin-m">
     <Hds::Button
       @text={{if @model.isNew "Create destination" "Save"}}
       @icon={{if this.save.isRunning "loading"}}

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
@@ -17,7 +17,7 @@
 <form {{on "submit" (perform this.setAssociation)}}>
   <MessageError @errorMessage={{this.error}} />
 
-  {{#if this.syncedSecret}}
+  {{#if (and this.syncedSecret this.mountPath)}}
     <Hds::Alert @type="inline" @color="success" @icon="sync" as |A|>
       <A.Title>Sync initiated</A.Title>
       <A.Description data-test-sync-success-message>

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
@@ -17,7 +17,7 @@
 <form {{on "submit" (perform this.setAssociation)}}>
   <MessageError @errorMessage={{this.error}} />
 
-  {{#if (and this.syncedSecret this.mountPath)}}
+  {{#if this.syncedSecret}}
     <Hds::Alert @type="inline" @color="success" @icon="sync" as |A|>
       <A.Title>Sync initiated</A.Title>
       <A.Description data-test-sync-success-message>

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
@@ -70,8 +70,9 @@ export default class DestinationSyncPageComponent extends Component<Args> {
   setMount(selected: Array<string>) {
     this.mountPath = selected[0] || '';
     if (this.mountPath === '') {
-      // clear secret path when mount is cleared
+      // reset form path when mount is cleared
       this.secretPath = '';
+      this.syncedSecret = '';
     }
   }
 

--- a/ui/tests/integration/components/sync/secrets/page/destinations/destination/sync-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations/destination/sync-test.js
@@ -70,7 +70,7 @@ module('Integration | Component | sync | Secrets::Page::Destinations::Destinatio
   });
 
   test('it should sync secret', async function (assert) {
-    assert.expect(6);
+    assert.expect(7);
 
     const { type, name } = this.destination;
     this.server.post(`/sys/sync/destinations/${type}/${name}/associations/set`, (schema, req) => {
@@ -91,6 +91,8 @@ module('Integration | Component | sync | Secrets::Page::Destinations::Destinatio
     assert
       .dom(successMessage)
       .includesText('Sync operation successfully initiated for my-secret.', 'Success banner renders');
+    await click(searchSelect.removeSelected);
+    assert.dom(successMessage).doesNotExist('clearing kv v2 mount path clears success banner');
   });
 
   test('it should allow manual mount path input if kv mounts are not returned', async function (assert) {


### PR DESCRIPTION
- Only render success banner in sync form if `mountPath` is set
- Remove trailing space from kv details banner
- Un-obfuscate `key_vault_uri` following backend bug fix
- Add validation for space in destination name

<img width="836" alt="Screenshot 2024-01-08 at 5 55 28 PM" src="https://github.com/hashicorp/vault/assets/68122737/52c77929-b684-43a6-b9c1-f208aa1a3f29">
