### PR TITLE
Make the TestRaft_Snapshot_API "rotate" tests use TCP networking again

### DIFF
--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -599,7 +599,6 @@ func TestRaft_SnapshotAPI_RekeyRotate_Backward(t *testing.T) {
 
 			cluster, _ := raftCluster(t, &RaftClusterOpts{
 				DisablePerfStandby: tCaseLocal.DisablePerfStandby,
-				InmemCluster:       true,
 			})
 			defer cluster.Cleanup()
 
@@ -804,7 +803,6 @@ func TestRaft_SnapshotAPI_RekeyRotate_Forward(t *testing.T) {
 
 			cluster, _ := raftCluster(t, &RaftClusterOpts{
 				DisablePerfStandby: tCaseLocal.DisablePerfStandby,
-				InmemCluster:       true,
 			})
 			defer cluster.Cleanup()
 


### PR DESCRIPTION
They've been flakier since #24557 so we hypothesize that change had a negative impact.