### PR TITLE
Audit Broker: Log Response should always assign the multierror before returning from it.

### DIFF
--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -294,7 +294,8 @@ func (a *AuditBroker) LogResponse(ctx context.Context, in *logical.LogInput, hea
 		if len(a.backends) > 0 {
 			e, err := audit.NewEvent(audit.ResponseType)
 			if err != nil {
-				return multierror.Append(retErr, err)
+				retErr = multierror.Append(retErr, err)
+				return retErr.ErrorOrNil()
 			}
 
 			e.Data = in


### PR DESCRIPTION
As `retErr` is referenced by the defer, we should ensure that it always contains the most up to date set of errors.