### PR TITLE
Flaky Tests from lastLogOutput Error

### DIFF
--- a/ui/tests/pages/components/console/ui-panel.js
+++ b/ui/tests/pages/components/console/ui-panel.js
@@ -19,7 +19,11 @@ export default {
   }),
   lastLogOutput: getter(function () {
     const count = this.logOutputItems.length;
-    const outputItemText = this.logOutputItems.objectAt(count - 1).text;
+    if (count === 0) {
+      // If no logOutput items are found, we can assume the response is empty
+      return '';
+    }
+    const outputItemText = this.logOutputItems[count - 1].text;
     return outputItemText;
   }),
   logTextItems: collection('[data-test-component="console/log-text"]', {


### PR DESCRIPTION
There was an uptick in flaky tests [due to an error](https://github.com/hashicorp/vault/actions/runs/7466007078/attempts/1#summary-20316427775) accessing the `lastLogOuput` from the console ui-panel. A check was added to verify that there are output items returned before attempting to access the last item in the array. 