### PR TITLE
Secrets Sync UI: Add purge delete progress and error banner to destination header

### DIFF
--- a/ui/app/models/sync/destination.js
+++ b/ui/app/models/sync/destination.js
@@ -17,6 +17,7 @@ const validations = {
 export default class SyncDestinationModel extends Model {
   @attr('string', { subText: 'Specifies the name for this destination.', editDisabled: true }) name;
   @attr type;
+  @attr('string') purgeInitiatedAt; // only present if delete action has been initiated
 
   // findDestination returns static attributes for each destination type
   get icon() {

--- a/ui/app/models/sync/destination.js
+++ b/ui/app/models/sync/destination.js
@@ -17,7 +17,9 @@ const validations = {
 export default class SyncDestinationModel extends Model {
   @attr('string', { subText: 'Specifies the name for this destination.', editDisabled: true }) name;
   @attr type;
-  @attr('string') purgeInitiatedAt; // only present if delete action has been initiated
+  // only present if delete action has been initiated
+  @attr('string') purgeInitiatedAt;
+  @attr('string') purgeError;
 
   // findDestination returns static attributes for each destination type
   get icon() {

--- a/ui/app/serializers/sync/destination.js
+++ b/ui/app/serializers/sync/destination.js
@@ -9,6 +9,8 @@ export default class SyncDestinationSerializer extends ApplicationSerializer {
   attrs = {
     name: { serialize: false },
     type: { serialize: false },
+    purgeInitiatedAt: { serialize: false },
+    purgeError: { serialize: false },
   };
 
   serialize(snapshot) {

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -6,7 +6,7 @@
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle={{@path}}>
   <:syncDetails>
     {{#if this.syncStatus}}
-      <Hds::Alert data-test-sync-alert @type="page" @color="neutral" as |A|>
+      <Hds::Alert data-test-sync-alert @type="inline" class="has-top-margin-s has-bottom-margin-m" @color="neutral" as |A|>
         <A.Title>
           This secret has been synced from Vault to
           {{pluralize this.syncStatus.length "destination"}}. Updates to this secret will automatically sync to its

--- a/ui/lib/sync/addon/components/secrets/destination-header.hbs
+++ b/ui/lib/sync/addon/components/secrets/destination-header.hbs
@@ -15,7 +15,7 @@
 
 {{#if @destination.purgeInitiatedAt}}
   <Hds::Alert
-    data-test-delete-progress
+    data-test-delete-status-banner
     @type="inline"
     class="has-bottom-margin-m"
     @color={{if @destination.purgeError "critical" "neutral"}}

--- a/ui/lib/sync/addon/components/secrets/destination-header.hbs
+++ b/ui/lib/sync/addon/components/secrets/destination-header.hbs
@@ -13,6 +13,24 @@
   }}
 />
 
+{{#if @destination.purgeInitiatedAt}}
+  <Hds::Alert
+    data-test-delete-progress
+    @type="inline"
+    class="has-bottom-margin-m"
+    @color="neutral"
+    @icon="loading-static"
+    as |A|
+  >
+    <A.Title>Deletion in progress</A.Title>
+    <A.Description>
+      Purge initiated on
+      {{date-format @destination.purgeInitiatedAt "MMM dd, yyyy 'at' hh:mm:ss aaa"}}. This process may take some time
+      depending on how many secrets must be un-synced from this destination.
+    </A.Description>
+  </Hds::Alert>
+{{/if}}
+
 <div class="tabs-container box is-bottomless is-marginless is-paddingless">
   <nav class="tabs" aria-label="destination tabs">
     <ul>

--- a/ui/lib/sync/addon/components/secrets/destination-header.hbs
+++ b/ui/lib/sync/addon/components/secrets/destination-header.hbs
@@ -18,16 +18,27 @@
     data-test-delete-progress
     @type="inline"
     class="has-bottom-margin-m"
-    @color="neutral"
-    @icon="loading-static"
+    @color={{if @destination.purgeError "critical" "neutral"}}
+    @icon={{unless @destination.purgeError "loading-static"}}
     as |A|
   >
-    <A.Title>Deletion in progress</A.Title>
-    <A.Description>
-      Purge initiated on
-      {{date-format @destination.purgeInitiatedAt "MMM dd, yyyy 'at' hh:mm:ss aaa"}}. This process may take some time
-      depending on how many secrets must be un-synced from this destination.
-    </A.Description>
+    {{#if @destination.purgeError}}
+      <A.Title>Deletion failed</A.Title>
+      <A.Description>
+        There was a problem with the delete purge initiated at
+        {{date-format @destination.purgeInitiatedAt "MMM dd, yyyy 'at' hh:mm:ss aaa"}}.
+      </A.Description>
+      <A.Description>
+        {{@destination.purgeError}}
+      </A.Description>
+    {{else}}
+      <A.Title>Deletion in progress</A.Title>
+      <A.Description>
+        Purge initiated on
+        {{date-format @destination.purgeInitiatedAt "MMM dd, yyyy 'at' hh:mm:ss aaa"}}. This process may take some time
+        depending on how many secrets must be un-synced from this destination.
+      </A.Description>
+    {{/if}}
   </Hds::Alert>
 {{/if}}
 

--- a/ui/lib/sync/addon/components/secrets/destination-header.ts
+++ b/ui/lib/sync/addon/components/secrets/destination-header.ts
@@ -26,11 +26,11 @@ export default class DestinationsTabsToolbar extends Component<Args> {
   async deleteDestination() {
     try {
       const { destination } = this.args;
-      const message = `Successfully deleted destination ${destination.name}.`;
+      const message = `Destination ${destination.name} has been queued for deletion.`;
       await destination.destroyRecord();
       this.store.clearDataset('sync/destination');
       this.router.transitionTo('vault.cluster.sync.secrets.destinations');
-      this.flashMessages.success(message);
+      this.flashMessages.info(message);
     } catch (error) {
       this.flashMessages.danger(`Error deleting destination \n ${errorMessage(error)}`);
     }

--- a/ui/lib/sync/addon/components/secrets/destination-header.ts
+++ b/ui/lib/sync/addon/components/secrets/destination-header.ts
@@ -29,8 +29,12 @@ export default class DestinationsTabsToolbar extends Component<Args> {
       const message = `Destination ${destination.name} has been queued for deletion.`;
       await destination.destroyRecord();
       this.store.clearDataset('sync/destination');
-      this.router.transitionTo('vault.cluster.sync.secrets.destinations');
-      this.flashMessages.info(message);
+      this.router.transitionTo(
+        'vault.cluster.sync.secrets.destinations.destination.secrets',
+        destination.type,
+        destination.name
+      );
+      this.flashMessages.success(message);
     } catch (error) {
       this.flashMessages.danger(`Error deleting destination \n ${errorMessage(error)}`);
     }

--- a/ui/lib/sync/addon/components/secrets/page/destinations.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations.ts
@@ -93,12 +93,12 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   @action
   async onDelete(destination: SyncDestinationModel) {
     try {
-      const { name } = destination;
+      const { name, type } = destination;
       const message = `Destination ${name} has been queued for deletion.`;
       await destination.destroyRecord();
       this.store.clearDataset('sync/destination');
-      this.router.transitionTo('vault.cluster.sync.secrets.destinations');
-      this.flashMessages.info(message);
+      this.router.transitionTo('vault.cluster.sync.secrets.destinations.destination.secrets', type, name);
+      this.flashMessages.success(message);
     } catch (error) {
       this.flashMessages.danger(`Error deleting destination \n ${errorMessage(error)}`);
     }

--- a/ui/lib/sync/addon/components/secrets/page/destinations.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations.ts
@@ -94,11 +94,11 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   async onDelete(destination: SyncDestinationModel) {
     try {
       const { name } = destination;
-      const message = `Successfully deleted destination ${name}.`;
+      const message = `Destination ${name} has been queued for deletion.`;
       await destination.destroyRecord();
       this.store.clearDataset('sync/destination');
       this.router.transitionTo('vault.cluster.sync.secrets.destinations');
-      this.flashMessages.success(message);
+      this.flashMessages.info(message);
     } catch (error) {
       this.flashMessages.danger(`Error deleting destination \n ${errorMessage(error)}`);
     }

--- a/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.ts
@@ -45,6 +45,7 @@ export default class DestinationsCreateForm extends Component<Args> {
           title: `Edit ${name}`,
           breadcrumbs: [
             { label: 'Secrets Sync', route: 'secrets.overview' },
+            { label: 'Destinations', route: 'secrets.destinations' },
             {
               label: 'Destination',
               route: 'secrets.destinations.destination.secrets',

--- a/ui/mirage/factories/sync-destination.js
+++ b/ui/mirage/factories/sync-destination.js
@@ -27,7 +27,6 @@ export default Factory.extend({
     type: 'gcp-sm',
     name: 'destination-gcp',
     credentials: '*****',
-    project_id: 'gcp-project-id', // TODO backend will add, doesn't exist yet
   }),
   gh: trait({
     type: 'gh',

--- a/ui/mirage/handlers/sync.js
+++ b/ui/mirage/handlers/sync.js
@@ -90,6 +90,14 @@ export default function (server) {
         connection_details,
         name,
         type,
+        /* 
+        these only exist if a delete has been initiated, including here for dev/testing purposes
+        if only `purge_initiated_at` present the delete progress banner renders
+        if `purge_error` also has a value then delete failed banner renders
+        */
+        // purge_initiated_at: '2024-01-09T16:54:28.463879-07:00',
+        // WIP (backend hasn't added yet) update when we have a realistic error message)
+        // purge_error: '1 error occurred: association could for some confusing reason not be un-synced!',
       },
     };
   };

--- a/ui/mirage/handlers/sync.js
+++ b/ui/mirage/handlers/sync.js
@@ -95,7 +95,7 @@ export default function (server) {
         if only `purge_initiated_at` present the delete progress banner renders
         if `purge_error` also has a value then delete failed banner renders
         */
-        // purge_initiated_at: '2024-01-09T16:54:28.463879-07:00',
+        purge_initiated_at: '2024-01-09T16:54:28.463879-07:00',
         // WIP (backend hasn't added yet) update when we have a realistic error message)
         // purge_error: '1 error occurred: association could for some confusing reason not be un-synced!',
       },

--- a/ui/mirage/handlers/sync.js
+++ b/ui/mirage/handlers/sync.js
@@ -90,14 +90,6 @@ export default function (server) {
         connection_details,
         name,
         type,
-        /* 
-        these only exist if a delete has been initiated, including here for dev/testing purposes
-        if only `purge_initiated_at` present the delete progress banner renders
-        if `purge_error` also has a value then delete failed banner renders
-        */
-        purge_initiated_at: '2024-01-09T16:54:28.463879-07:00',
-        // WIP (backend hasn't added yet) update when we have a realistic error message)
-        // purge_error: '1 error occurred: association could for some confusing reason not be un-synced!',
       },
     };
   };
@@ -141,8 +133,22 @@ export default function (server) {
   });
   server.delete(uri, (schema, req) => {
     const { type, name } = req.params;
-    schema.db.syncDestinations.remove({ type, name });
-    return new Response(204);
+    schema.db.syncDestinations.update(
+      { type, name },
+      // these parameters are added after a purge delete is initiated
+      // if only `purge_initiated_at` exists the delete progress banner renders
+      // if `purge_error` also has a value then delete failed banner renders
+      {
+        purge_initiated_at: '2024-01-09T16:54:28.463879-07:00',
+        // WIP (backend hasn't added yet) update when we have a realistic error message)
+        // purge_error: '1 error occurred: association could for some confusing reason not be un-synced!',
+      }
+    );
+    const record = schema.db.syncDestinations.findBy({ type, name });
+    return destinationResponse(record);
+    // return the following instead to test immediate deletion
+    // schema.db.syncDestinations.remove({ type, name });
+    // return new Response(204);
   });
   // associations
   server.get('/sys/sync/associations', (schema) => {

--- a/ui/tests/helpers/sync/sync-selectors.js
+++ b/ui/tests/helpers/sync/sync-selectors.js
@@ -26,6 +26,7 @@ export const PAGE = {
     },
   },
   destinations: {
+    deleteBanner: '[data-test-delete-status-banner]',
     sync: {
       mountSelect: '[data-test-sync-mount-select]',
       mountInput: '[data-test-sync-mount-input]',

--- a/ui/tests/integration/components/sync/secrets/destination-header-test.js
+++ b/ui/tests/integration/components/sync/secrets/destination-header-test.js
@@ -60,7 +60,7 @@ module('Integration | Component | sync | Secrets::DestinationHeader', function (
 
     assert.propEqual(
       transitionStub.lastCall.args,
-      ['vault.cluster.sync.secrets.destinations'],
+      ['vault.cluster.sync.secrets.destinations.destination.secrets', 'aws-sm', 'us-west-1'],
       'Transition is triggered on delete success'
     );
     assert.propEqual(

--- a/ui/tests/integration/components/sync/secrets/destination-header-test.js
+++ b/ui/tests/integration/components/sync/secrets/destination-header-test.js
@@ -9,7 +9,7 @@ import { setupEngine } from 'ember-engines/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupModels } from 'vault/tests/helpers/sync/setup-models';
 import hbs from 'htmlbars-inline-precompile';
-import { click, fillIn, render } from '@ember/test-helpers';
+import { click, fillIn, render, settled } from '@ember/test-helpers';
 import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
 import { PAGE } from 'vault/tests/helpers/sync/sync-selectors';
 import sinon from 'sinon';
@@ -68,5 +68,35 @@ module('Integration | Component | sync | Secrets::DestinationHeader', function (
       ['sync/destination'],
       'Store dataset is cleared on delete success'
     );
+  });
+
+  test('it should render delete progress banner', async function (assert) {
+    assert.expect(2);
+    this.destination.set('purgeInitiatedAt', '2024-01-09T16:54:28.463879');
+    await settled();
+    assert
+      .dom(PAGE.destinations.deleteBanner)
+      .hasText(
+        'Deletion in progress Purge initiated on Jan 09, 2024 at 04:54:28 pm. This process may take some time depending on how many secrets must be un-synced from this destination.'
+      );
+    assert
+      .dom(`${PAGE.destinations.deleteBanner} ${PAGE.icon('loading-static')}`)
+      .exists('banner renders loading icon');
+  });
+
+  test('it should render delete error banner', async function (assert) {
+    assert.expect(2);
+    this.destination.set('purgeInitiatedAt', '2024-01-09T16:54:28.463879');
+    this.destination.set('purgeError', 'oh no! a problem occurred!');
+    await settled();
+    assert
+      .dom(PAGE.destinations.deleteBanner)
+      .hasText(
+        'Deletion failed There was a problem with the delete purge initiated at Jan 09, 2024 at 04:54:28 pm. oh no! a problem occurred!',
+        'banner renders error message'
+      );
+    assert
+      .dom(`${PAGE.destinations.deleteBanner} ${PAGE.icon('alert-diamond')}`)
+      .exists('banner renders critical icon');
   });
 });

--- a/ui/tests/integration/components/sync/secrets/page/destinations-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations-test.js
@@ -154,7 +154,7 @@ module('Integration | Component | sync | Page::Destinations', function (hooks) {
 
     assert.propEqual(
       this.transitionStub.lastCall.args,
-      ['vault.cluster.sync.secrets.destinations'],
+      ['vault.cluster.sync.secrets.destinations.destination.secrets', 'aws-sm', 'destination-aws'],
       'Transition is triggered on delete success'
     );
     assert.propEqual(

--- a/ui/tests/integration/components/sync/secrets/page/destinations/create-and-edit-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations/create-and-edit-test.js
@@ -58,7 +58,7 @@ module('Integration | Component | sync | Secrets::Page::Destinations::CreateAndE
     this.model = this.store.peekRecord(`sync/destinations/${type}`, id);
 
     await this.renderFormComponent();
-    assert.dom(PAGE.breadcrumbs).hasText('Secrets Sync Destination Edit Destination');
+    assert.dom(PAGE.breadcrumbs).hasText('Secrets Sync Destinations Destination Edit Destination');
     assert.dom('h2').hasText('Credentials', 'renders credentials section on edit');
     assert
       .dom('p.hds-foreground-faint')


### PR DESCRIPTION
## Purge delete in progress banner
<img width="1082" alt="Screenshot 2024-01-09 at 5 50 13 PM" src="https://github.com/hashicorp/vault/assets/68122737/d638f1f7-556c-476a-9cb1-47004749a933">

## Delete failed banner
<img width="1069" alt="Screenshot 2024-01-09 at 6 11 22 PM" src="https://github.com/hashicorp/vault/assets/68122737/f97ad3a5-d05c-4990-9941-0c28cd3c6c90">

