### PR TITLE
actions: upload go test logs as a tarball

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -362,8 +362,9 @@ jobs:
             fi
           fi
 
-          VAULT_TEST_LOG_DIR="$(pwd)/test-results/go-test/logs-${{ matrix.id }}"
+          VAULT_TEST_LOG_DIR="$(pwd)/test-results/go-test/logs"
           export VAULT_TEST_LOG_DIR
+          echo "test-log-dir=$VAULT_TEST_LOG_DIR" >> "$GITHUB_OUTPUT"
           mkdir -p "$VAULT_TEST_LOG_DIR"
           # shellcheck disable=SC2086 # can't quote RERUN_FAILS
           GOARCH=${{ inputs.go-arch }} VAULT_ADDR='' \
@@ -395,12 +396,34 @@ jobs:
           fi
           datadog-ci junit upload --service "$GITHUB_REPOSITORY" test-results/go-test/results-${{ matrix.id }}.xml
         if: success() || failure()
-      - name: Archive test results
+      - name: Archive test logs
+        id: archive-test-logs
+        # actions/upload-artifact will compress the artifact for us. We create a tarball to preserve
+        # permissions and to support file names with special characters.
+        run: |
+          log_prefix="test-logs-${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}-${{ matrix.id }}"
+          archive_name="${log_prefix}.tar"
+          {
+            echo "log_prefix=$log_prefix"
+            echo "archive_name=$archive_name"
+          } >> "$GITHUB_OUTPUT"
+          tar -cvf "$archive_name" -C "${{ steps.run-go-tests.outputs.test-log-dir }}" .
+      - name: Upload test logs archives
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: test-results${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}
-          path: test-results/go-test
+          name: ${{ steps.archive-test-logs.outputs.log_prefix }}
+          path: ${{ steps.archive-test-logs.outputs.archive_name }}
+          retention-days: 7
         if: success() || failure()
+      - name: Upload test results
+        if: success() || failure()
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: test-results
+          path: |
+            test-results/go-test/*.json
+            test-results/go-test/*.xml
+          retention-days: 1
       # GitHub Actions doesn't expose the job ID or the URL to the job execution,
       # so we have to fetch it from the API
       - name: Fetch job logs URL
@@ -489,7 +512,6 @@ jobs:
           name: test-results
           path: test-results/go-test
       - run: |
-          rm -rf test-results/go-test/logs
           ls -lhR test-results/go-test
           find test-results/go-test -mindepth 1 -type f -mtime +3 -delete
 


### PR DESCRIPTION
The `actions/upload-artifact` action does not support filenames with special characters as it needs to maintain restore compatibility with NTFS filesystems. Instead of uploading raw log files, which can inherit names with special characters and break the upload, we tar them all together to preserve their names and upload the resulting tarball.