### PR TITLE
Fix some GHAs not running on enterprise

### DIFF
--- a/.github/workflows/milestone-checker.yml
+++ b/.github/workflows/milestone-checker.yml
@@ -16,7 +16,8 @@ jobs:
   # checks that a milestone entry is present for a PR
   milestone-check:
     # If there is a `pr/no-milestone` label, or this comes from a fork (community contributor) we ignore this check
-    if: ${{ (github.repository == 'hashicorp/vault' && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name))
+    if: ${{ ((github.repository == 'hashicorp/vault' || github.repository == 'hashicorp/vault-enterprise')
+      && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name))
       && (!contains(github.event.pull_request.labels.*.name, 'pr/no-milestone')) }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -380,7 +380,7 @@ jobs:
               -parallel=${{ inputs.go-test-parallelism }} \
               ${{ inputs.extra-flags }} \
       - name: Prepare datadog-ci
-        if: github.repository == 'hashicorp/vault' && (success() || failure())
+        if: (github.repository == 'hashicorp/vault' || github.repository == 'hashicorp/vault-enterprise') && (success() || failure())
         continue-on-error: true
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"


### PR DESCRIPTION
`Prepare datadog-ci` has been failing on enterprise. My theory is that it still had binaries around on old runners from before we added the repo check, but it's failing on new/cleaned runners. This should fix that.

I also noticed milestone checker wasn't running on enterprise, so thought I'd do an easy fix of that too.