### PR TITLE
[docs] add a link to the VSO threat model to the vso docs

### DIFF
--- a/website/content/docs/platform/k8s/vso/index.mdx
+++ b/website/content/docs/platform/k8s/vso/index.mdx
@@ -46,8 +46,13 @@ The Vault Secrets Operator has been tested successfully in the following hosted 
 Basic integration tests are available in the project repository.
 Please report any issues [here](https://github.com/hashicorp/vault-secrets-operator/issues).
 
+## Threat model and security considerations
+HahsiCorp takes security seriously and strives to enable users to configure their systems
+with security and safety in mind. Please see the Vault Secrets Operator's
+[Threat Model](https://github.com/hashicorp/vault-secrets-operator/blob/main/docs/threat-model/README.md)
+for highlights on how using the Vault Secrets Operator affects users' security posture and recommendations for running securely.
+
 ## Tutorial
 
-Refer to the [Vault Secrets Operator on
-Kubernetes](/vault/tutorials/kubernetes/vault-secrets-operator) tutorial to
-learn the end-to-end workflow using the Vault Secrets Operator.
+Refer to the [Vault Secrets Operator on Kubernetes](/vault/tutorials/kubernetes/vault-secrets-operator)
+tutorial to learn the end-to-end workflow using the Vault Secrets Operator.


### PR DESCRIPTION
Adds a link to the VSO threat model in the top level page for VSO