### PR TITLE
update /sys/leader api docs

### DIFF
--- a/website/content/api-docs/system/leader.mdx
+++ b/website/content/api-docs/system/leader.mdx
@@ -33,9 +33,13 @@ $ curl \
 {
   "ha_enabled": true,
   "is_self": false,
+  "active_time": "2024-01-09T00:11:46.439409062Z",
   "leader_address": "https://127.0.0.1:8200/",
   "leader_cluster_address": "https://127.0.0.1:8201/",
   "performance_standby": false,
-  "performance_standby_last_remote_wal": 0
+  "performance_standby_last_remote_wal": 0,
+  "last_wal": 0,
+  "raft_committed_index": 0,
+  "raft_applied_index": 0
 }
 ```


### PR DESCRIPTION
The `/sys/leader` endpoint returns additional fields that are not in the current sample response. This PR updates the API docs at https://developer.hashicorp.com/vault/api-docs/system/leader to include the `active_time`, `last_wal`, `raft_committed_index`, and `raft_applied_index` fields.

<details><summary>Real response I received today for reference</summary>

```json
{
  "ha_enabled": true,
  "is_self": true,
  "active_time": "2024-01-09T00:11:46.439409062Z",
  "leader_address": "https://node-13-1.helen-test-p-private-vault-22e7cae2.274d6236.z1.hashicorp.cloud:8202",
  "leader_cluster_address": "https://172.25.21.40:8201",
  "performance_standby": false,
  "performance_standby_last_remote_wal": 0,
  "last_wal": 643892,
  "raft_committed_index": 2507946,
  "raft_applied_index": 2507946
}
```

</details>