### PR TITLE
UI: unseal tests used mocked endpoints

### DIFF
--- a/ui/app/templates/vault/cluster/unseal.hbs
+++ b/ui/app/templates/vault/cluster/unseal.hbs
@@ -39,6 +39,12 @@
         </p>
         {{#if this.model.unsealed}}
           <p>Please wait while we redirect you.</p>
+          <Hds::Link::Standalone
+            @route="vault.cluster.auth"
+            @model={{this.model.id}}
+            @text="Continue to log in"
+            @icon="sign-in"
+          />
         {{else}}
           <p>
             Unseal Vault by entering portions of the unseal key. This can be done via multiple mechanisms on multiple

--- a/ui/tests/acceptance/unseal-test.js
+++ b/ui/tests/acceptance/unseal-test.js
@@ -6,27 +6,57 @@
 import { click, currentRouteName, currentURL, fillIn, settled, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
 import VAULT_KEYS from 'vault/tests/helpers/vault-keys';
 import authPage from 'vault/tests/pages/auth';
 import { pollCluster } from 'vault/tests/helpers/poll-cluster';
+import { overrideResponse } from 'vault/tests/helpers/clients';
 
 const { unsealKeys } = VAULT_KEYS;
 
-module.skip('Acceptance | unseal', function (hooks) {
+module('Acceptance | unseal', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
+    this.unsealCount = 0;
+    this.sealed = false;
     return authPage.login();
   });
 
   test('seal then unseal', async function (assert) {
+    this.server.get(`/sys/seal-status`, () => {
+      return {
+        type: 'shamir',
+        initialized: true,
+        sealed: this.sealed,
+      };
+    });
+    this.server.put(`/sys/seal`, () => {
+      this.sealed = true;
+      return overrideResponse(204);
+    });
+    this.server.put(`/sys/unseal`, () => {
+      const threshold = unsealKeys.length;
+      const attemptCount = this.unsealCount + 1;
+      if (attemptCount >= threshold) {
+        this.sealed = false;
+      }
+      this.unsealCount = attemptCount;
+      return {
+        sealed: attemptCount < threshold,
+        t: threshold,
+        n: threshold,
+        progress: attemptCount,
+      };
+    });
     await visit('/vault/settings/seal');
 
     assert.strictEqual(currentURL(), '/vault/settings/seal');
 
     // seal
     await click('[data-test-seal]');
-
     await click('[data-test-confirm-button]');
 
     await pollCluster(this.owner);


### PR DESCRIPTION
When we adopted ember-exam we had to skip the tests for seal/unseal flow because it seals the vault used on the concurrent tests and causes them to fail. This PR uses mocked endpoints to approximate the seal flow without jeopardizing the other tests. 