### PR TITLE
VAULT-21608: Make Namespace Manager a Field in the Manager Structure

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -64,7 +64,6 @@ import (
 	"github.com/hashicorp/vault/vault/plugincatalog"
 	"github.com/hashicorp/vault/vault/quotas"
 	vaultseal "github.com/hashicorp/vault/vault/seal"
-	uicustommessages "github.com/hashicorp/vault/vault/ui_custom_messages"
 	"github.com/hashicorp/vault/version"
 	"github.com/patrickmn/go-cache"
 	uberAtomic "go.uber.org/atomic"
@@ -1264,7 +1263,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	// UI
 	uiStoragePrefix := systemBarrierPrefix + "ui"
 	c.uiConfig = NewUIConfig(conf.EnableUI, physical.NewView(c.physical, uiStoragePrefix), NewBarrierView(c.barrier, uiStoragePrefix))
-	c.customMessageManager = uicustommessages.NewManager(c.barrier)
+	c.customMessageManager = createCustomMessageManager(c.barrier, c)
 
 	// Listeners
 	err = c.configureListeners(conf)

--- a/vault/core_util.go
+++ b/vault/core_util.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/vault/quotas"
 	"github.com/hashicorp/vault/vault/replication"
+	uicustommessages "github.com/hashicorp/vault/vault/ui_custom_messages"
 )
 
 const (
@@ -201,4 +202,12 @@ func (c *Core) MissingRequiredState(raw []string, perfStandby bool) bool {
 
 func DiagnoseCheckLicense(ctx context.Context, vaultCore *Core, coreConfig CoreConfig, generate bool) (bool, []string) {
 	return false, nil
+}
+
+// createCustomMessageManager is a function implemented differently for the
+// community edition and the enterprise edition. This is the community
+// edition implementation. It simply constructs a uicustommessages.Manager
+// instance and returns a pointer to it.
+func createCustomMessageManager(storage logical.Storage, _ *Core) CustomMessagesManager {
+	return uicustommessages.NewManager(storage)
 }

--- a/vault/ui_custom_messages/manager_test.go
+++ b/vault/ui_custom_messages/manager_test.go
@@ -214,23 +214,18 @@ func TestManagerPutEntry(t *testing.T) {
 // context (e.g. checking that the list contains 1 element and that it's equal
 // to namespace.RootNamespace).
 func TestGetNamespacesToSearch(t *testing.T) {
-	list, err := getNamespacesToSearch(context.Background(), FindFilter{})
+	testManager := &Manager{nsManager: &CommunityEditionNamespaceManager{}}
+
+	list, err := testManager.getNamespacesToSearch(context.Background(), FindFilter{})
 	assert.Error(t, err)
 	assert.Nil(t, list)
 
-	list, err = getNamespacesToSearch(namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace), FindFilter{})
+	list, err = testManager.getNamespacesToSearch(namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace), FindFilter{})
 	assert.NoError(t, err)
 	assert.Len(t, list, 1)
 	assert.Equal(t, namespace.RootNamespace, list[0])
 
-	// Verify with nsManager set to an instance of testNamespaceManager to
-	// ensure that it is used to calculate the list of namespaces.
-	currentNsManager := nsManager
-	defer func() {
-		nsManager = currentNsManager
-	}()
-
-	nsManager = &testNamespaceManager{
+	testManager.nsManager = &testNamespaceManager{
 		results: []namespace.Namespace{
 			{
 				ID:   "ccc",
@@ -247,7 +242,7 @@ func TestGetNamespacesToSearch(t *testing.T) {
 		},
 	}
 
-	list, err = getNamespacesToSearch(namespace.ContextWithNamespace(context.Background(), &namespace.Namespace{ID: "ddd", Path: "d/"}), FindFilter{IncludeAncestors: true})
+	list, err = testManager.getNamespacesToSearch(namespace.ContextWithNamespace(context.Background(), &namespace.Namespace{ID: "ddd", Path: "d/"}), FindFilter{IncludeAncestors: true})
 	assert.NoError(t, err)
 	assert.Len(t, list, 5)
 	assert.Equal(t, list[0].Path, "d/")


### PR DESCRIPTION
This PR makes changes that allow replacing the **nsManager** global variable with a field bearing the same name in the **uicustommessages.Manager** struct. The refactoring will avoid a potential data race due to the updating of the **nsManager** global variable, which happens when running the enterprise edition. Instead, by making **nsManager** a field of the **Manager** struct, it can be initialized appropriately, based on the edition.