### PR TITLE
Run archive test logs always

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -397,6 +397,7 @@ jobs:
           datadog-ci junit upload --service "$GITHUB_REPOSITORY" test-results/go-test/results-${{ matrix.id }}.xml
         if: success() || failure()
       - name: Archive test logs
+        if: always()
         id: archive-test-logs
         # actions/upload-artifact will compress the artifact for us. We create a tarball to preserve
         # permissions and to support file names with special characters.


### PR DESCRIPTION
When it failed, we didn't run this, and then therefore get the outputs