### PR TITLE
[DOCS] Fix page heading

### DIFF
--- a/website/content/docs/auth/jwt/oidc-providers/auth0.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/auth0.mdx
@@ -4,7 +4,7 @@ page_title: OIDC Provider Setup - Auth Methods - Auth0
 description: OIDC provider configuration for Auth0
 ---
 
-## Auth0
+# Auth0
 
 1. Select Create Application (Regular Web App).
 1. Configure Allowed Callback URLs.

--- a/website/content/docs/auth/jwt/oidc-providers/azuread.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/azuread.mdx
@@ -4,7 +4,7 @@ page_title: OIDC Provider Setup - Auth Methods - Azure Active Directory
 description: OIDC provider configuration for Azure Active Directory
 ---
 
-## Azure active directory (AAD)
+# Azure active directory (AAD)
 
 ~> **Note:** Azure Active Directory Applications that have custom signing keys as a result of using
 the [claims-mapping](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-claims-mapping)

--- a/website/content/docs/auth/jwt/oidc-providers/forgerock.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/forgerock.mdx
@@ -4,7 +4,7 @@ page_title: OIDC Provider Setup - Auth Methods - ForgeRock
 description: OIDC provider configuration for ForgeRock
 ---
 
-## ForgeRock
+# ForgeRock
 
 1. Navigate to Applications -> OAuth 2.0 -> Clients in ForgeRock Access Management.
 1. Create new client.

--- a/website/content/docs/auth/jwt/oidc-providers/gitlab.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/gitlab.mdx
@@ -4,7 +4,7 @@ page_title: OIDC Provider Setup - Auth Methods - Gitlab
 description: OIDC provider configuration for Gitlab
 ---
 
-## Gitlab
+# Gitlab
 
 1. Visit Settings > Applications.
 1. Fill out Name and Redirect URIs.

--- a/website/content/docs/auth/jwt/oidc-providers/google.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/google.mdx
@@ -4,7 +4,7 @@ page_title: OIDC Provider Setup - Auth Methods - Google
 description: OIDC provider configuration for Google
 ---
 
-## Google
+# Google
 
 Main reference: [Using OAuth 2.0 to Access Google APIs](https://developers.google.com/identity/protocols/OAuth2)
 

--- a/website/content/docs/auth/jwt/oidc-providers/ibmisam.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/ibmisam.mdx
@@ -4,7 +4,7 @@ page_title: OIDC Provider Setup - Auth Methods - IBM Security Access Manager (IS
 description: OIDC provider configuration for IBM Security Access Manager (recently renamed to IBM Security Verify Access)
 ---
 
-## IBM ISAM
+# IBM ISAM
 
 The [IBM ISAM](https://www.ibm.com/de-de/products/verify-access) identity provider
 returns group membership claims as a space-separated list of strings (e.g.

--- a/website/content/docs/auth/jwt/oidc-providers/keycloak.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/keycloak.mdx
@@ -4,7 +4,7 @@ page_title: OIDC Provider Setup - Auth Methods - Keycloak
 description: OIDC provider configuration for Keycloak
 ---
 
-## Keycloak
+# Keycloak
 
 1. Select/create a Realm and Client. Select a Client and visit Settings.
 1. Client Protocol: openid-connect

--- a/website/content/docs/auth/jwt/oidc-providers/kubernetes.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/kubernetes.mdx
@@ -4,7 +4,7 @@ page_title: OIDC Provider Setup - Auth Methods - Kubernetes
 description: OIDC provider configuration for Kubernetes
 ---
 
-## Kubernetes
+# Kubernetes
 
 Kubernetes can function as an OIDC provider such that Vault can validate its
 service account tokens using JWT/OIDC auth.
@@ -16,7 +16,7 @@ still be considered valid by Vault until their expiry time. To mitigate this
 risk, use short TTLs for service account tokens or use
 [Kubernetes auth](/vault/docs/auth/kubernetes) which _does_ use the `TokenReview` API.
 
-### Using service account issuer discovery
+## Use service account issuer discovery
 
 When using service account issuer discovery, you only need to provide the JWT
 auth mount with an OIDC discovery URL, and sometimes a TLS certificate authority
@@ -75,7 +75,7 @@ Configuration steps:
 
 [k8s-sa-issuer-discovery]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery
 
-### Using JWT validation public keys
+## Use JWT validation public keys
 
 This method can be useful if Kubernetes' API is not reachable from Vault or if
 you would like a single JWT auth mount to service multiple Kubernetes clusters
@@ -124,7 +124,7 @@ Configuration steps:
 
 [jwk-to-pem]: https://8gwifi.org/jwkconvertfunctions.jsp
 
-### Creating a role and logging in
+## Create a role and logging in
 
 Once your JWT auth mount is configured, you're ready to configure a role and
 log in. The following assumes you use the projected service account token
@@ -178,7 +178,7 @@ below if you'd like to control the audience or TTL.
       "${VAULT_ADDR}/v1/auth/jwt/login"
    ```
 
-### Specifying TTL and audience
+## Specify TTL and audience
 
 If you would like to specify a custom TTL or audience for service account tokens,
 the following pod spec illustrates a volume mount that overrides the default

--- a/website/content/docs/auth/jwt/oidc-providers/okta.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/okta.mdx
@@ -4,7 +4,7 @@ page_title: OIDC Provider Setup - Auth Methods - Okta
 description: OIDC provider configuration for Okta
 ---
 
-## Okta
+# Okta
 
 1. Make sure an Authorization Server has been created. The "Issuer" field shown on the Setting page
    will be used as the `oidc_discovery_url`.

--- a/website/content/docs/auth/jwt/oidc-providers/secureauth.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/secureauth.mdx
@@ -4,7 +4,7 @@ page_title: OIDC Provider Setup - Auth Methods - SecureAuth
 description: OIDC provider configuration for SecureAuth
 ---
 
-## SecureAuth
+# SecureAuth
 
 The [SecureAuth](https://www.secureauth.com/) identity provider returns group membership
 claims as a comma-separated list of strings (e.g. `groups: "group-1,group-2"`) instead

--- a/website/content/docs/internals/architecture.mdx
+++ b/website/content/docs/internals/architecture.mdx
@@ -50,7 +50,7 @@ The configuration of the audit devices, auth methods, and secrets engines are se
 
 Requests may be processed from the HTTP API to the core once Vault is unsealed.
 The core manages the flow of requests through the system,
-enforce ACLs, and ensure audit logging is done.
+enforces ACLs, and ensures audit logging is done.
 
 When a client first connects to Vault, the client needs to authenticate. Vault provides
 configurable auth methods and offers flexibility within the authentication mechanism


### PR DESCRIPTION
 
🔍 [Deploy preview](https://vault-lds2uebl9-hashicorp.vercel.app/vault/docs/auth/jwt/oidc-providers/auth0)



This PR fixes: 

- Grammar error pointed out by https://github.com/hashicorp/vault/pull/19582 which couldn't be merged due to CLA.
- Page title had to use `#` instead of `##` --> all pages under **JWT/OIDC > OIDC Providers** menu

   ![image](https://github.com/hashicorp/vault/assets/7660718/9f3d39df-13b1-44bb-8314-b55069db01fa)

