### PR TITLE
Copy the Connection reference within LogInput Clone()

### DIFF
--- a/sdk/logical/audit.go
+++ b/sdk/logical/audit.go
@@ -161,6 +161,9 @@ func cloneRequest(request *Request) (*Request, error) {
 	req.mountRunningVersion = request.MountRunningVersion()
 	req.mountRunningSha256 = request.MountRunningSha256()
 	req.mountIsExternalPlugin = request.MountIsExternalPlugin()
+	// This needs to be overwritten as the internal connection state is not cloned properly
+	// mainly the big.Int serial numbers within the x509.Certificate objects get mangled.
+	req.Connection = request.Connection
 
 	return req, nil
 }


### PR DESCRIPTION
 - As TestInteg_KMIP_Audit showed, the x509.Certificate's big.Int SerialNumber is mangled when we do a deep clone of the LogInput's Request TLSConnection object.
 - As the tls.ConnectionState does not have a Clone itself and we don't modify this field, it should be safe to just grab the existing reference into the cloned version.

This addresses a test failure that was introduced by https://github.com/hashicorp/vault/pull/24811 within ENT.