### PR TITLE
Add Validation for message Parameter in Create/Update Custom Message Operation

### DIFF
--- a/vault/logical_system_custom_messages.go
+++ b/vault/logical_system_custom_messages.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -402,6 +403,11 @@ func (b *SystemBackend) handleCreateCustomMessages(ctx context.Context, req *log
 		return logical.ErrorResponse(err.Error()), nil
 	}
 
+	_, err = base64.StdEncoding.DecodeString(messageValue)
+	if err != nil {
+		return logical.ErrorResponse("invalid message parameter value, must be base64 encoded"), nil
+	}
+
 	startTime, err := parameterValidateOrReportMissing[time.Time]("start_time", d)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
@@ -554,6 +560,11 @@ func (b *SystemBackend) handleUpdateCustomMessage(ctx context.Context, req *logi
 	messageValue, err := parameterValidateOrReportMissing[string]("message", d)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
+	}
+
+	_, err = base64.StdEncoding.DecodeString(messageValue)
+	if err != nil {
+		return logical.ErrorResponse("invalid message parameter value, must be base64 encoded"), nil
 	}
 
 	linkMap, err := parameterValidateMap("link", d)

--- a/vault/logical_system_custom_messages_test.go
+++ b/vault/logical_system_custom_messages_test.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"testing"
@@ -228,7 +229,7 @@ func TestHandleCreateCustomMessage(t *testing.T) {
 	// it to test different conditions.
 	fieldRaw := map[string]any{
 		"title":      "title",
-		"message":    "message",
+		"message":    base64.StdEncoding.EncodeToString([]byte("message")),
 		"start_time": "2023-01-01T00:00:00Z",
 	}
 
@@ -273,6 +274,13 @@ func TestHandleCreateCustomMessage(t *testing.T) {
 			name: "message-parameter-invalid",
 			fieldRawUpdate: map[string]any{
 				"message": map[int]string{},
+			},
+			errorExpected: true,
+		},
+		{
+			name: "message-parameter-invalid-not-base64",
+			fieldRawUpdate: map[string]any{
+				"message": "The message not base64 encoded.",
 			},
 			errorExpected: true,
 		},
@@ -625,7 +633,7 @@ func TestHandleUpdateCustomMessage(t *testing.T) {
 		Raw: map[string]any{
 			"id":            "abc",
 			"title":         "title",
-			"message":       "message",
+			"message":       base64.StdEncoding.EncodeToString([]byte("message")),
 			"authenticated": "true",
 			"type":          uicustommessages.ModalMessageType,
 			"start_time":    startTime,
@@ -703,6 +711,12 @@ func TestHandleUpdateCustomMessage(t *testing.T) {
 			name: "message-parameter-invalid",
 			fieldRawUpdate: map[string]any{
 				"message": []bool{},
+			},
+		},
+		{
+			name: "message-parameter-invalid-not-base64",
+			fieldRawUpdate: map[string]any{
+				"message": "The message not base64 encoded.",
 			},
 		},
 		{


### PR DESCRIPTION
This PR adds an additional validation step that ensures that the message parameter provided is indeed base64 encoded as described in the API documentation (see https://github.com/hashicorp/vault/pull/24845)