### PR TITLE
List plugin runtimes API always includes a list even if empty

### DIFF
--- a/changelog/24864.txt
+++ b/changelog/24864.txt
@@ -1,0 +1,3 @@
+```release-note:change
+plugins: `/sys/plugins/runtimes/catalog` response will always include a list of "runtimes" in the response, even if empty.
+```

--- a/command/plugin_runtime_list_test.go
+++ b/command/plugin_runtime_list_test.go
@@ -46,14 +46,14 @@ func TestPluginRuntimeListCommand_Run(t *testing.T) {
 		{
 			"list container on empty plugin runtime catalog",
 			[]string{"-type=container"},
-			"Error listing available plugin runtimes:",
-			2,
+			"OCI Runtime",
+			0,
 		},
 		{
 			"list on empty plugin runtime catalog",
 			nil,
-			"Error listing available plugin runtimes:",
-			2,
+			"OCI Runtime",
+			0,
 		},
 	}
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -888,7 +888,7 @@ func (b *SystemBackend) handlePluginRuntimeCatalogRead(ctx context.Context, _ *l
 }
 
 func (b *SystemBackend) handlePluginRuntimeCatalogList(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	data := []map[string]any{}
+	runtimes := []map[string]any{}
 
 	var pluginRuntimeTypes []consts.PluginRuntimeType
 	runtimeTypeStr := d.Get("type").(string)
@@ -916,7 +916,7 @@ func (b *SystemBackend) handlePluginRuntimeCatalogList(ctx context.Context, _ *l
 				return strings.Compare(configs[i].Name, configs[j].Name) == -1
 			})
 			for _, conf := range configs {
-				data = append(data, map[string]any{
+				runtimes = append(runtimes, map[string]any{
 					"name":          conf.Name,
 					"type":          conf.Type.String(),
 					"oci_runtime":   conf.OCIRuntime,
@@ -929,13 +929,11 @@ func (b *SystemBackend) handlePluginRuntimeCatalogList(ctx context.Context, _ *l
 		}
 	}
 
-	resp := &logical.Response{
+	return &logical.Response{
 		Data: map[string]interface{}{
-			"runtimes": data,
+			"runtimes": runtimes,
 		},
-	}
-
-	return resp, nil
+	}, nil
 }
 
 // handleAuditedHeaderUpdate creates or overwrites a header entry

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -888,7 +888,7 @@ func (b *SystemBackend) handlePluginRuntimeCatalogRead(ctx context.Context, _ *l
 }
 
 func (b *SystemBackend) handlePluginRuntimeCatalogList(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	var data []map[string]any
+	data := []map[string]any{}
 
 	var pluginRuntimeTypes []consts.PluginRuntimeType
 	runtimeTypeStr := d.Get("type").(string)
@@ -930,11 +930,9 @@ func (b *SystemBackend) handlePluginRuntimeCatalogList(ctx context.Context, _ *l
 	}
 
 	resp := &logical.Response{
-		Data: map[string]interface{}{},
-	}
-
-	if len(data) > 0 {
-		resp.Data["runtimes"] = data
+		Data: map[string]interface{}{
+			"runtimes": data,
+		},
 	}
 
 	return resp, nil

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -6164,7 +6164,9 @@ func TestSystemBackend_pluginRuntimeCRUD(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	listExp := map[string]interface{}{}
+	listExp := map[string]any{
+		"runtimes": []map[string]any{},
+	}
 	if !reflect.DeepEqual(resp.Data, listExp) {
 		t.Fatalf("got: %#v expect: %#v", resp.Data, listExp)
 	}


### PR DESCRIPTION
The `api` package expects the `"runtimes"` key to always be there or it errors, but the API was omitting it when empty.

https://github.com/hashicorp/vault/blob/cd76e4fbc113a11d584b9359aa7e527e546af0c9/api/sys_plugins_runtimes.go#L162-L164