### PR TITLE
Reset the Connection object within Request.Clone

### DIFF
--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -253,13 +253,20 @@ type Request struct {
 	ChrootNamespace string `json:"chroot_namespace,omitempty"`
 }
 
-// Clone returns a deep copy of the request by using copystructure
+// Clone returns a deep copy of the request by using copystructure,
+// Note that the Connection property will keep the same reference
+// from the original value as to not corrupt some of its internal state
 func (r *Request) Clone() (*Request, error) {
 	cpy, err := copystructure.Copy(r)
 	if err != nil {
 		return nil, err
 	}
-	return cpy.(*Request), nil
+	clonedReq := cpy.(*Request)
+	// We can't properly clone the connection from the request, big.Int values
+	// within the x509 certificates such as the SerialNumber and or PublicKey
+	// do not get copied properly
+	clonedReq.Connection = r.Connection
+	return clonedReq, nil
 }
 
 // Get returns a data field and guards for nil Data


### PR DESCRIPTION
 - The Clone() method within the Request object used copystructure to clone values within the Connection property it has. The various big.Int values within x509 certificates though would not be cloned properly having their values set to 0.
 - This would affect values such as the certificate's SerialNumber field, the public key values...
 - Since Connection doesn't have a proper Clone method of its own just use the same reference across cloned Request objects.