### PR TITLE
Audit: `LogInput.Request` Cloning update

### DIFF
--- a/sdk/logical/audit.go
+++ b/sdk/logical/audit.go
@@ -78,7 +78,7 @@ func (l *LogInput) Clone() (*LogInput, error) {
 	}
 
 	// Clone Request
-	req, err := cloneRequest(l.Request)
+	req, err := l.Request.Clone()
 	if err != nil {
 		return nil, err
 	}
@@ -140,32 +140,6 @@ func cloneAuth(auth *Auth) (*Auth, error) {
 	}
 
 	return auth, nil
-}
-
-// cloneRequest deep copies a Request struct.
-// It will set unexported fields which were only previously accessible outside
-// the package via receiver methods.
-func cloneRequest(request *Request) (*Request, error) {
-	// If request is nil, there's nothing to clone.
-	if request == nil {
-		return nil, nil
-	}
-
-	req, err := clone[*Request](request)
-	if err != nil {
-		return nil, fmt.Errorf("unable to clone request: %w", err)
-	}
-
-	// Add the unexported values that were only retrievable via receivers.
-	req.mountClass = request.MountClass()
-	req.mountRunningVersion = request.MountRunningVersion()
-	req.mountRunningSha256 = request.MountRunningSha256()
-	req.mountIsExternalPlugin = request.MountIsExternalPlugin()
-	// This needs to be overwritten as the internal connection state is not cloned properly
-	// mainly the big.Int serial numbers within the x509.Certificate objects get mangled.
-	req.Connection = request.Connection
-
-	return req, nil
 }
 
 // cloneResponse deep copies a Response struct.

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -253,9 +253,11 @@ type Request struct {
 	ChrootNamespace string `json:"chroot_namespace,omitempty"`
 }
 
-// Clone returns a deep copy of the request by using copystructure.
+// Clone returns a deep copy (almost) of the request.
 // It will set unexported fields which were only previously accessible outside
 // the package via receiver methods.
+// NOTE: Request.Connection is NOT deep-copied, due to issues with the results
+// of copystructure on serial numbers within the x509.Certificate objects.
 func (r *Request) Clone() (*Request, error) {
 	cpy, err := copystructure.Copy(r)
 	if err != nil {

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -253,13 +253,28 @@ type Request struct {
 	ChrootNamespace string `json:"chroot_namespace,omitempty"`
 }
 
-// Clone returns a deep copy of the request by using copystructure
+// Clone returns a deep copy of the request by using copystructure.
+// It will set unexported fields which were only previously accessible outside
+// the package via receiver methods.
 func (r *Request) Clone() (*Request, error) {
 	cpy, err := copystructure.Copy(r)
 	if err != nil {
 		return nil, err
 	}
-	return cpy.(*Request), nil
+
+	req := cpy.(*Request)
+
+	// Add the unexported values that were only retrievable via receivers.
+	// copystructure isn't able to do this, which is why we're doing it manually.
+	req.mountClass = r.MountClass()
+	req.mountRunningVersion = r.MountRunningVersion()
+	req.mountRunningSha256 = r.MountRunningSha256()
+	req.mountIsExternalPlugin = r.MountIsExternalPlugin()
+	// This needs to be overwritten as the internal connection state is not cloned properly
+	// mainly the big.Int serial numbers within the x509.Certificate objects get mangled.
+	req.Connection = r.Connection
+
+	return req, nil
 }
 
 // Get returns a data field and guards for nil Data


### PR DESCRIPTION
Use the existing `Request.Clone()` method (thanks to @stevendpclark for pointing that out), and update said method with missing fields that `copystructure` couldn't sort out for us. 