### PR TITLE
Upgrade upload and download artifact to v4

### DIFF
--- a/.github/workflows/build-vault-ce.yml
+++ b/.github/workflows/build-vault-ce.yml
@@ -73,7 +73,7 @@ jobs:
         env:
           BUNDLE_PATH: out/${{ env.ARTIFACT_BASENAME }}.zip
         run: make ci-bundle
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           name: ${{ env.ARTIFACT_BASENAME }}.zip
           path: out/${{ env.ARTIFACT_BASENAME }}.zip
@@ -101,13 +101,13 @@ jobs:
           echo "RPM_PACKAGE=$(basename out/*.rpm)" >> "$GITHUB_ENV"
           echo "DEB_PACKAGE=$(basename out/*.deb)" >> "$GITHUB_ENV"
       - if: ${{ inputs.create-packages }}
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           name: ${{ env.RPM_PACKAGE }}
           path: out/${{ env.RPM_PACKAGE }}
           if-no-files-found: error
       - if: ${{ inputs.create-packages }}
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           name: ${{ env.DEB_PACKAGE }}
           path: out/${{ env.DEB_PACKAGE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           version: ${{ steps.set-product-version.outputs.product-version }}
           product: ${{ steps.get-metadata.outputs.package-name }}
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,7 +447,8 @@ jobs:
       - name: Download failure summary
         uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
-          name: failure-summary
+          pattern: failure-summary-*
+          merge-multiple: true
       - name: Prepare failure summary
         run: |
           # Sort all of the summary table rows and push them to a temp file.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
           cd ui
           mkdir -p test-results/qunit
           yarn test:oss
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           name: test-results-ui
           path: ui/test-results
@@ -445,7 +445,7 @@ jobs:
       - test-go-race
     steps:
       - name: Download failure summary
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
           name: failure-summary
       - name: Prepare failure summary

--- a/.github/workflows/enos-run-k8s.yml
+++ b/.github/workflows/enos-run-k8s.yml
@@ -44,7 +44,7 @@ jobs:
           github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Download Docker Image
         id: download
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
           name: ${{ inputs.artifact-name }}
           path: ./enos/support/downloads

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -420,7 +420,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
-          name: test-results-${{ matrix.id }}
+          name: test-results-${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}-${{ matrix.id }}
           path: |
             test-results/go-test/*.json
             test-results/go-test/*.xml
@@ -493,7 +493,7 @@ jobs:
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         if: success() || failure()
         with:
-          name: failure-summary-${{ matrix.id }}
+          name: failure-summary-${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}-${{ matrix.id }}
           path: failure-summary-${{ matrix.id }}${{ inputs.name != '' && '-' || '' }}${{inputs.name}}.md
 
   test-collect-reports:

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -412,7 +412,7 @@ jobs:
       - name: Upload test logs archives
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
-          name: ${{ steps.archive-test-logs.outputs.log_prefix }}-${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}-${{ matrix.id }}-${{ github.job }}-${{ strategy.job-index }}
+          name: ${{ steps.archive-test-logs.outputs.log_prefix }}-${{ github.job }}-${{ strategy.job-index }}-${{ inputs.testonly && "testonly" || (inputs.name != '' && '-' || '') }}-${{ matrix.id }}
           path: ${{ steps.archive-test-logs.outputs.archive_name }}
           retention-days: 7
         if: success() || failure()
@@ -420,7 +420,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
-          name: test-results-${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}-${{ matrix.id }}-${{ github.job }}-${{ strategy.job-index }}
+          name: test-results-${{ github.job }}-${{ strategy.job-index }}-${{ inputs.testonly && "testonly" || (inputs.name != '' && '-' || '') }}-${{ matrix.id }}
           path: |
             test-results/go-test/*.json
             test-results/go-test/*.xml
@@ -493,7 +493,7 @@ jobs:
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         if: success() || failure()
         with:
-          name: failure-summary-${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}-${{ matrix.id }}-${{ github.job }}-${{ strategy.job-index }}
+          name: failure-summary-${{ github.job }}-${{ strategy.job-index }}-${{ inputs.testonly && "testonly" || (inputs.name != '' && '-' || '') }}-${{ matrix.id }}
           path: failure-summary-${{ matrix.id }}${{ inputs.name != '' && '-' || '' }}${{inputs.name}}.md
 
   test-collect-reports:

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -420,7 +420,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
-          name: test-results
+          name: test-results-${{ matrix.id }}
           path: |
             test-results/go-test/*.json
             test-results/go-test/*.xml
@@ -493,7 +493,7 @@ jobs:
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         if: success() || failure()
         with:
-          name: failure-summary
+          name: failure-summary-${{ matrix.id }}
           path: failure-summary-${{ matrix.id }}${{ inputs.name != '' && '-' || '' }}${{inputs.name}}.md
 
   test-collect-reports:
@@ -510,8 +510,9 @@ jobs:
             go-test-reports-
       - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
-          name: test-results
           path: test-results/go-test
+          pattern: test-results-*
+          merge-multiple: true
       - run: |
           ls -lhR test-results/go-test
           find test-results/go-test -mindepth 1 -type f -mtime +3 -delete

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -410,7 +410,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           tar -cvf "$archive_name" -C "${{ steps.run-go-tests.outputs.test-log-dir }}" .
       - name: Upload test logs archives
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           name: ${{ steps.archive-test-logs.outputs.log_prefix }}
           path: ${{ steps.archive-test-logs.outputs.archive_name }}
@@ -418,7 +418,7 @@ jobs:
         if: success() || failure()
       - name: Upload test results
         if: success() || failure()
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           name: test-results
           path: |
@@ -490,7 +490,7 @@ jobs:
           failure-summary-${{ matrix.id }}${{ inputs.name != '' && '-' || '' }}${{inputs.name}}.json \
           >> failure-summary-${{ matrix.id }}${{ inputs.name != '' && '-' || '' }}${{inputs.name}}.md
       - name: Upload failure summary
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         if: success() || failure()
         with:
           name: failure-summary
@@ -508,7 +508,7 @@ jobs:
           restore-keys: |
             ${{ inputs.test-timing-cache-key }}-
             go-test-reports-
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
           name: test-results
           path: test-results/go-test

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -412,7 +412,7 @@ jobs:
       - name: Upload test logs archives
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
-          name: ${{ steps.archive-test-logs.outputs.log_prefix }}
+          name: ${{ steps.archive-test-logs.outputs.log_prefix }}-${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}-${{ matrix.id }}
           path: ${{ steps.archive-test-logs.outputs.archive_name }}
           retention-days: 7
         if: success() || failure()

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -412,7 +412,7 @@ jobs:
       - name: Upload test logs archives
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
-          name: ${{ steps.archive-test-logs.outputs.log_prefix }}-${{ github.job }}-${{ strategy.job-index }}-${{ inputs.testonly && "testonly" || (inputs.name != '' && '-' || '') }}-${{ matrix.id }}
+          name: ${{ steps.archive-test-logs.outputs.log_prefix }}-${{ github.job }}-${{ strategy.job-index }}-${{ inputs.testonly && 'testonly' || (inputs.name != '' && '-' || '') }}-${{ matrix.id }}
           path: ${{ steps.archive-test-logs.outputs.archive_name }}
           retention-days: 7
         if: success() || failure()
@@ -420,7 +420,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
-          name: test-results-${{ github.job }}-${{ strategy.job-index }}-${{ inputs.testonly && "testonly" || (inputs.name != '' && '-' || '') }}-${{ matrix.id }}
+          name: test-results-${{ github.job }}-${{ strategy.job-index }}-${{ inputs.testonly && 'testonly' || (inputs.name != '' && '-' || '') }}-${{ matrix.id }}
           path: |
             test-results/go-test/*.json
             test-results/go-test/*.xml
@@ -493,7 +493,7 @@ jobs:
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         if: success() || failure()
         with:
-          name: failure-summary-${{ github.job }}-${{ strategy.job-index }}-${{ inputs.testonly && "testonly" || (inputs.name != '' && '-' || '') }}-${{ matrix.id }}
+          name: failure-summary-${{ github.job }}-${{ strategy.job-index }}-${{ inputs.testonly && 'testonly' || (inputs.name != '' && '-' || '') }}-${{ matrix.id }}
           path: failure-summary-${{ matrix.id }}${{ inputs.name != '' && '-' || '' }}${{inputs.name}}.md
 
   test-collect-reports:

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -412,7 +412,7 @@ jobs:
       - name: Upload test logs archives
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
-          name: ${{ steps.archive-test-logs.outputs.log_prefix }}-${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}-${{ matrix.id }}
+          name: ${{ steps.archive-test-logs.outputs.log_prefix }}-${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}-${{ matrix.id }}-${{ github.job }}-${{ strategy.job-index }}
           path: ${{ steps.archive-test-logs.outputs.archive_name }}
           retention-days: 7
         if: success() || failure()
@@ -420,7 +420,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
-          name: test-results-${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}-${{ matrix.id }}
+          name: test-results-${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}-${{ matrix.id }}-${{ github.job }}-${{ strategy.job-index }}
           path: |
             test-results/go-test/*.json
             test-results/go-test/*.xml
@@ -493,7 +493,7 @@ jobs:
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         if: success() || failure()
         with:
-          name: failure-summary-${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}-${{ matrix.id }}
+          name: failure-summary-${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}-${{ matrix.id }}-${{ github.job }}-${{ strategy.job-index }}
           path: failure-summary-${{ matrix.id }}${{ inputs.name != '' && '-' || '' }}${{inputs.name}}.md
 
   test-collect-reports:

--- a/.github/workflows/test-run-acc-tests-for-path.yml
+++ b/.github/workflows/test-run-acc-tests-for-path.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - run: go test -v ./${{ inputs.path }}/... 2>&1 | tee ${{ inputs.name }}.txt
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           name: ${{ inputs.name }}-output
           path: ${{ inputs.name }}.txt

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -123,7 +123,7 @@ jobs:
           chmod 600 "./enos/support/private_key.pem"
           echo "debug_data_artifact_name=enos-debug-data_$(echo "${{ matrix.scenario }}" | sed -e 's/ /_/g' | sed -e 's/:/=/g')" >> "$GITHUB_OUTPUT"
       - if: contains(inputs.sample-name, 'build')
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
           name: ${{ inputs.build-artifact-name }}
           path: ./enos/support/downloads
@@ -141,7 +141,7 @@ jobs:
         run: enos scenario launch --timeout 60m0s --chdir ./enos ${{ matrix.scenario.id.filter }}
       - name: Upload Debug Data
         if: failure()
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           # The name of the artifact is the same as the matrix scenario name with the spaces replaced with underscores and colons replaced by equals.
           name: ${{ steps.prepare_scenario.outputs.debug_data_artifact_name }}


### PR DESCRIPTION
As I learnt when looking at this (https://github.com/hashicorp/vault/pull/24874/files) dependabot PR, these need to be upgraded together.

I *think* we don't need to make any changes? But this PR is so that I can find out :)  

Migration here:
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md
https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md