### PR TITLE
identity/tokens: adds plugin issuer with openid-configuration and keys

### DIFF
--- a/changelog/24898.txt
+++ b/changelog/24898.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+identity/tokens: adds plugin issuer with openid-configuration and keys APIs
+```

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -104,6 +104,7 @@ func NewIdentityStore(ctx context.Context, core *Core, config *logical.BackendCo
 		PathsSpecial: &logical.Paths{
 			Unauthenticated: []string{
 				"oidc/.well-known/*",
+				"oidc/+/.well-known/*",
 				"oidc/provider/+/.well-known/*",
 				"oidc/provider/+/token",
 			},

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -37,11 +37,34 @@ import (
 )
 
 type oidcConfig struct {
+	// Issuer is the scheme://host:port component of the issuer set as
+	// configuration in the Vault API. It is the URL base.
 	Issuer string `json:"issuer"`
 
 	// effectiveIssuer is a calculated field and will be either Issuer (if
-	// that's set) or the Vault instance's api_addr.
+	// that's set) or the Vault instance's api_addr, followed by the path
+	// /v1/<namespace_path>/identity/oidc.
 	effectiveIssuer string
+}
+
+// fullIssuer returns the full issuer for the config, suitable for OpenID metadata and
+// token claims. It takes an optional child, which much be of the value "" or "plugins".
+// The child will be appended as the last path segment on the returned issuer URL.
+func (c *oidcConfig) fullIssuer(child string) (string, error) {
+	if !validChildIssuer(child) {
+		return "", fmt.Errorf("invalid child issuer %q", child)
+	}
+
+	issuer, err := url.JoinPath(c.effectiveIssuer, child)
+	if err != nil {
+		return "", fmt.Errorf("failed to join issuer: %w", err)
+	}
+
+	return issuer, nil
+}
+
+func validChildIssuer(child string) bool {
+	return child == baseIdentityTokenIssuer || child == pluginIdentityTokenIssuer
 }
 
 type expireableKey struct {
@@ -113,6 +136,10 @@ const (
 	namedKeyConfigPath   = oidcTokensPrefix + "named_keys/"
 	publicKeysConfigPath = oidcTokensPrefix + "public_keys/"
 	roleConfigPath       = oidcTokensPrefix + "roles/"
+
+	// Identity tokens have a base issuer and plugin issuer
+	baseIdentityTokenIssuer   = ""
+	pluginIdentityTokenIssuer = "plugins"
 )
 
 var (
@@ -134,6 +161,13 @@ var (
 
 // pseudo-namespace for cache items that don't belong to any real namespace.
 var noNamespace = &namespace.Namespace{ID: "__NO_NAMESPACE"}
+
+// optionalChildIssuerRegex is a regex for optionally accepting a field in an
+// API request as a single path segment. Adapted from framework.OptionalParamRegex
+// to not include additional forward slashes.
+func optionalChildIssuerRegex(name string) string {
+	return fmt.Sprintf(`(/(?P<%s>[^/]+))?`, name)
+}
 
 func oidcPaths(i *IdentityStore) []*framework.Path {
 	return []*framework.Path{
@@ -252,10 +286,16 @@ func oidcPaths(i *IdentityStore) []*framework.Path {
 			HelpDescription: "List all named OIDC keys",
 		},
 		{
-			Pattern: "oidc/\\.well-known/openid-configuration/?$",
+			Pattern: "oidc" + optionalChildIssuerRegex("child") + "/\\.well-known/openid-configuration/?$",
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: "oidc",
 				OperationSuffix: "open-id-configuration",
+			},
+			Fields: map[string]*framework.FieldSchema{
+				"child": {
+					Type:        framework.TypeString,
+					Description: "Name of the child issuer",
+				},
 			},
 			Callbacks: map[logical.Operation]framework.OperationFunc{
 				logical.ReadOperation: i.pathOIDCDiscovery,
@@ -264,10 +304,16 @@ func oidcPaths(i *IdentityStore) []*framework.Path {
 			HelpDescription: "Query this path to retrieve the configured OIDC Issuer and Keys endpoints, response types, subject types, and signing algorithms used by the OIDC backend.",
 		},
 		{
-			Pattern: "oidc/\\.well-known/keys/?$",
+			Pattern: "oidc" + optionalChildIssuerRegex("child") + "/\\.well-known/keys/?$",
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: "oidc",
 				OperationSuffix: "public-keys",
+			},
+			Fields: map[string]*framework.FieldSchema{
+				"child": {
+					Type:        framework.TypeString,
+					Description: "Name of the child issuer",
+				},
 			},
 			Callbacks: map[logical.Operation]framework.OperationFunc{
 				logical.ReadOperation: i.pathOIDCReadPublicKeys,
@@ -920,9 +966,14 @@ func (i *IdentityStore) pathOIDCGenerateToken(ctx context.Context, req *logical.
 			"than the verification_ttl of the key it references, setting token ttl to %d", expiry))
 	}
 
+	issuer, err := config.fullIssuer(baseIdentityTokenIssuer)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+
 	now := time.Now()
 	idToken := idToken{
-		Issuer:    config.effectiveIssuer,
+		Issuer:    issuer,
 		Namespace: ns.ID,
 		Subject:   req.EntityID,
 		Audience:  role.ClientID,
@@ -1339,7 +1390,13 @@ func (i *IdentityStore) pathOIDCDiscovery(ctx context.Context, req *logical.Requ
 		return nil, err
 	}
 
-	v, ok, err := i.oidcCache.Get(ns, "discoveryResponse")
+	var child string
+	if childRaw, ok := d.GetOk("child"); ok {
+		child = childRaw.(string)
+	}
+
+	cacheKey := fmt.Sprintf("%s/discoveryResponse", child)
+	v, ok, err := i.oidcCache.Get(ns, cacheKey)
 	if err != nil {
 		return nil, err
 	}
@@ -1352,9 +1409,14 @@ func (i *IdentityStore) pathOIDCDiscovery(ctx context.Context, req *logical.Requ
 			return nil, err
 		}
 
+		issuer, err := c.fullIssuer(child)
+		if err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+
 		disc := discovery{
-			Issuer:        c.effectiveIssuer,
-			Keys:          c.effectiveIssuer + "/.well-known/keys",
+			Issuer:        issuer,
+			Keys:          issuer + "/.well-known/keys",
 			ResponseTypes: []string{"id_token"},
 			Subjects:      []string{"public"},
 			IDTokenAlgs:   supportedAlgs,
@@ -1365,7 +1427,7 @@ func (i *IdentityStore) pathOIDCDiscovery(ctx context.Context, req *logical.Requ
 			return nil, err
 		}
 
-		if err := i.oidcCache.SetDefault(ns, "discoveryResponse", data); err != nil {
+		if err := i.oidcCache.SetDefault(ns, cacheKey, data); err != nil {
 			return nil, err
 		}
 	}
@@ -1424,6 +1486,14 @@ func (i *IdentityStore) pathOIDCReadPublicKeys(ctx context.Context, req *logical
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	var child string
+	if childRaw, ok := d.GetOk("child"); ok {
+		child = childRaw.(string)
+	}
+	if !validChildIssuer(child) {
+		return logical.ErrorResponse("invalid child issuer %q", child), nil
 	}
 
 	v, ok, err := i.oidcCache.Get(ns, "jwksResponse")
@@ -1539,8 +1609,13 @@ func (i *IdentityStore) pathOIDCIntrospect(ctx context.Context, req *logical.Req
 		return nil, err
 	}
 
+	issuer, err := c.fullIssuer(baseIdentityTokenIssuer)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+
 	expected := jwt.Expected{
-		Issuer: c.effectiveIssuer,
+		Issuer: issuer,
 		Time:   time.Now(),
 	}
 

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -48,7 +48,7 @@ type oidcConfig struct {
 }
 
 // fullIssuer returns the full issuer for the config, suitable for OpenID metadata and
-// token claims. It takes an optional child, which much be of the value "" or "plugins".
+// token claims. It takes an optional child, which must be of the value "" or "plugins".
 // The child will be appended as the last path segment on the returned issuer URL.
 func (c *oidcConfig) fullIssuer(child string) (string, error) {
 	if !validChildIssuer(child) {

--- a/vault/identity_store_oidc_test.go
+++ b/vault/identity_store_oidc_test.go
@@ -1732,6 +1732,8 @@ func expectStrings(t *testing.T, actualStrings []string, expectedStrings map[str
 	}
 }
 
+// Test_oidcConfig_fullIssuer tests that the full issuer matches expectations
+// given different issuer bases and children.
 func Test_oidcConfig_fullIssuer(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	ctx := namespace.RootContext(nil)
@@ -1789,6 +1791,7 @@ func Test_oidcConfig_fullIssuer(t *testing.T) {
 	}
 }
 
+// Test_validChildIssuer tests that only valid child issuers are accepted.
 func Test_validChildIssuer(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -1818,6 +1821,9 @@ func Test_validChildIssuer(t *testing.T) {
 	}
 }
 
+// Test_optionalChildIssuerRegex tests that the regex returned from
+// optionalChildIssuerRegex produces the expected captures given different
+// input paths.
 func Test_optionalChildIssuerRegex(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/vault/identity_store_oidc_test.go
+++ b/vault/identity_store_oidc_test.go
@@ -6,6 +6,8 @@ package vault
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -20,6 +22,7 @@ import (
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 	gocache "github.com/patrickmn/go-cache"
+	"github.com/stretchr/testify/require"
 )
 
 // TestOIDC_Path_OIDC_RoleNoKeyParameter tests that a role cannot be created
@@ -1726,5 +1729,138 @@ func expectStrings(t *testing.T, actualStrings []string, expectedStrings map[str
 		if !ok {
 			t.Fatalf("the string %q was not expected", actualString)
 		}
+	}
+}
+
+func Test_oidcConfig_fullIssuer(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(nil)
+	storage := &logical.InmemStorage{}
+
+	tests := []struct {
+		name    string
+		issuer  string
+		child   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "issuer with valid empty child",
+			issuer: "https://vault.dev",
+			child:  baseIdentityTokenIssuer,
+			want:   fmt.Sprintf("https://vault.dev/v1/%s", issuerPath),
+		},
+		{
+			name:   "issuer with valid plugin child",
+			issuer: "http://127.0.0.1:8200",
+			child:  pluginIdentityTokenIssuer,
+			want:   fmt.Sprintf("http://127.0.0.1:8200/v1/%s/%s", issuerPath, pluginIdentityTokenIssuer),
+		},
+		{
+			name:    "issuer with invalid child",
+			issuer:  "http://127.0.0.1:8200",
+			child:   "invalid",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := c.identityStore.HandleRequest(ctx, &logical.Request{
+				Path:      "oidc/config",
+				Operation: logical.UpdateOperation,
+				Storage:   storage,
+				Data: map[string]interface{}{
+					"issuer": tt.issuer,
+				},
+			})
+			expectSuccess(t, resp, err)
+
+			config, err := c.identityStore.getOIDCConfig(ctx, storage)
+			require.NoError(t, err)
+
+			got, err := config.fullIssuer(tt.child)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equalf(t, tt.want, got, "fullIssuer(%v)", tt.child)
+		})
+	}
+}
+
+func Test_validChildIssuer(t *testing.T) {
+	tests := []struct {
+		name  string
+		child string
+		want  bool
+	}{
+		{
+			name:  "valid child issuer",
+			child: baseIdentityTokenIssuer,
+			want:  true,
+		},
+		{
+			name:  "valid child issuer",
+			child: pluginIdentityTokenIssuer,
+			want:  true,
+		},
+		{
+			name:  "invalid child issuer",
+			child: "test",
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equalf(t, tt.want, validChildIssuer(tt.child), "validChildIssuer(%v)", tt.child)
+		})
+	}
+}
+
+func Test_optionalChildIssuerRegex(t *testing.T) {
+	tests := []struct {
+		name     string
+		pattern  string
+		path     string
+		captures map[string]string
+	}{
+		{
+			name:     "valid match with capture",
+			pattern:  "oidc" + optionalChildIssuerRegex("child") + "/.well-known/keys",
+			path:     "oidc/plugins/.well-known/keys",
+			captures: map[string]string{"child": "plugins"},
+		},
+		{
+			name:     "valid match with capture name, segment, and path change",
+			pattern:  "oidc" + optionalChildIssuerRegex("name") + "/.well-known/openid-configuration",
+			path:     "oidc/test/.well-known/openid-configuration",
+			captures: map[string]string{"name": "test"},
+		},
+		{
+			name:     "valid match with empty capture",
+			pattern:  "oidc" + optionalChildIssuerRegex("child") + "/.well-known/keys",
+			path:     "oidc/.well-known/keys",
+			captures: map[string]string{"child": ""},
+		},
+		{
+			name:     "invalid match with multiple path segments",
+			pattern:  "oidc" + optionalChildIssuerRegex("child") + "/.well-known/keys",
+			path:     "oidc/plugins/invalid/.well-known/keys",
+			captures: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			re := regexp.MustCompile(tt.pattern)
+			matches := re.FindStringSubmatch(tt.path)
+			actualCaptures := make(map[string]string)
+			for i, name := range re.SubexpNames() {
+				if name != "" && i < len(matches) {
+					actualCaptures[name] = matches[i]
+				}
+			}
+			require.Equal(t, tt.captures, actualCaptures)
+		})
 	}
 }


### PR DESCRIPTION
This PR adds an [openid-configuration](https://developer.hashicorp.com/vault/api-docs/secret/identity/tokens#read-well-known-configurations) and [keys](https://developer.hashicorp.com/vault/api-docs/secret/identity/tokens#read-active-public-keys) API for a new _plugin token issuer_. The issuer will only be capable of internally issuing tokens to Vault plugins for workload identity federation exchanges.

The issuer will provide unauthenticated APIs with the following paths:
- `/v1/identity/oidc/plugins/.well-known/openid-configuration`
- `/v1/identity/oidc/plugins/.well-known/keys`

The approach makes the "plugins" segment above optional so that we can serve both the identity token issuer and plugin token issuer APIs using the same request handlers. I've called these "child" issuers, but I'm happy to consider a different name. It sets up the implementation for easily adding more child issuers if a use case ever comes up.

I ran all OIDC-related tests successfully using `go test -run=TestOIDC`. Documentation will be added in a follow-up PR.