### PR TITLE
backport 1.15: pkcs7 fix slice out-of-bounds panic

### DIFF
--- a/builtin/credential/aws/pkcs7/ber.go
+++ b/builtin/credential/aws/pkcs7/ber.go
@@ -149,14 +149,14 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 		for ber[offset] >= 0x80 {
 			tag = tag*128 + ber[offset] - 0x80
 			offset++
-			if offset > berLen {
+			if offset >= berLen {
 				return nil, 0, errors.New("ber2der: cannot move offset forward, end of ber data reached")
 			}
 		}
 		// jvehent 20170227: this doesn't appear to be used anywhere...
 		// tag = tag*128 + ber[offset] - 0x80
 		offset++
-		if offset > berLen {
+		if offset >= berLen {
 			return nil, 0, errors.New("ber2der: cannot move offset forward, end of ber data reached")
 		}
 	}
@@ -172,7 +172,7 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 	var length int
 	l := ber[offset]
 	offset++
-	if offset > berLen {
+	if offset >= berLen {
 		return nil, 0, errors.New("ber2der: cannot move offset forward, end of ber data reached")
 	}
 	indefinite := false
@@ -192,7 +192,7 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 		for i := 0; i < numberOfBytes; i++ {
 			length = length*256 + (int)(ber[offset])
 			offset++
-			if offset > berLen {
+			if offset >= berLen {
 				return nil, 0, errors.New("ber2der: cannot move offset forward, end of ber data reached")
 			}
 		}

--- a/builtin/credential/aws/pkcs7/ber_test.go
+++ b/builtin/credential/aws/pkcs7/ber_test.go
@@ -44,13 +44,14 @@ func TestBer2Der_Negatives(t *testing.T) {
 		Input         []byte
 		ErrorContains string
 	}{
-		{[]byte{0x30, 0x85}, "tag length too long"},
+		{[]byte{0x30, 0x85}, "end of ber data reached"},
 		{[]byte{0x30, 0x84, 0x80, 0x0, 0x0, 0x0}, "length is negative"},
 		{[]byte{0x30, 0x82, 0x0, 0x1}, "length has leading zero"},
 		{[]byte{0x30, 0x80, 0x1, 0x2, 0x1, 0x2}, "Invalid BER format"},
-		{[]byte{0x30, 0x80, 0x1, 0x2}, "BER tag length is more than available data"},
+		{[]byte{0x30, 0x80, 0x1, 0x2}, "end of ber data reached"},
 		{[]byte{0x30, 0x03, 0x01, 0x02}, "length is more than available data"},
 		{[]byte{0x30}, "end of ber data reached"},
+		{[]byte("?0"), "end of ber data reached"},
 	}
 
 	for _, fixture := range fixtures {

--- a/changelog/24891.txt
+++ b/changelog/24891.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+helper/pkcs7: Fix slice out-of-bounds panic
+```


### PR DESCRIPTION
backport of https://github.com/hashicorp/vault/pull/24891