### PR TITLE
fix typo in vso platform docs

### DIFF
--- a/website/content/docs/platform/k8s/vso/index.mdx
+++ b/website/content/docs/platform/k8s/vso/index.mdx
@@ -47,7 +47,7 @@ Basic integration tests are available in the project repository.
 Please report any issues [here](https://github.com/hashicorp/vault-secrets-operator/issues).
 
 ## Threat model and security considerations
-HahsiCorp takes security seriously and strives to enable users to configure their systems
+HashiCorp takes security seriously and strives to enable users to configure their systems
 with security and safety in mind. Please see the Vault Secrets Operator's
 [Threat Model](https://github.com/hashicorp/vault-secrets-operator/blob/main/docs/threat-model/README.md)
 for highlights on how using the Vault Secrets Operator affects users' security posture and recommendations for running securely.


### PR DESCRIPTION
fix bad spelling of `HashiCorp` (`HahsiCorp`)