### PR TITLE
UI: Secret sync bar chart

### DIFF
--- a/ui/app/components/clients/sync-bar-chart.hbs
+++ b/ui/app/components/clients/sync-bar-chart.hbs
@@ -4,91 +4,93 @@
 ~}}
 
 <div class="lineal-chart">
-  {{#let
-    (scale-band domain=this.monthDomain range=(array 0 this.chartWidth) padding=0.1)
-    (scale-linear range=(array this.chartHeight 0) domain=this.countDomain)
-    (scale-linear range=(array 0 this.chartHeight) domain=this.countDomain)
-    as |xScale yScale hScale|
-  }}
-    <svg width={{this.chartWidth}} height={{this.chartHeight}} data-test-sync-bar-chart>
-      <title>
-        {{@chartTitle}}
-      </title>
+  <Lineal::Fluid as |width|>
+    {{#let
+      (scale-band domain=this.monthDomain range=(array 0 width) padding=0.1)
+      (scale-linear range=(array this.chartHeight 0) domain=this.countDomain)
+      (scale-linear range=(array 0 this.chartHeight) domain=this.countDomain)
+      as |xScale yScale hScale|
+    }}
+      <svg width={{width}} height={{this.chartHeight}} data-test-sync-bar-chart>
+        <title>
+          {{@chartTitle}}
+        </title>
 
-      {{#if (and xScale.isValid yScale.isValid)}}
-        <Lineal::Axis
-          @scale={{yScale}}
-          @tickCount="4"
-          @tickPadding={{10}}
-          @tickSizeInner={{concat "-" this.chartWidth}}
-          @tickFormat={{this.formatCount}}
-          @orientation="left"
-          @includeDomain={{false}}
-          class="lineal-axis"
-          data-test-y-axis
-        />
-        <Lineal::Axis
-          @scale={{xScale}}
-          @orientation="bottom"
-          transform="translate(0,{{yScale.range.min}})"
-          @includeDomain={{false}}
-          @tickSize="0"
-          @tickPadding={{10}}
-          class="lineal-axis"
-          data-test-x-axis
-        />
-      {{/if}}
-      <Lineal::Bars
-        @data={{this.chartData}}
-        @x="x"
-        @y="y"
-        @height="y"
-        @width={{this.barWidth}}
-        @xScale={{xScale}}
-        @yScale={{yScale}}
-        @heightScale={{hScale}}
-        transform="translate({{this.barOffset xScale.bandwidth}},0)"
-        fill="transparent"
-        stroke="transparent"
-        class="lineal-chart-bar"
-        data-test-vertical-bar
-      />
-      {{#if (and xScale.isValid yScale.isValid)}}
-        {{#each this.chartData as |d|}}
-          <rect
-            role="button"
-            aria-label="Show exact counts for {{d.legendX}}"
-            x="0"
-            y="0"
-            height={{this.chartHeight}}
-            width={{xScale.bandwidth}}
-            fill="transparent"
-            stroke="transparent"
-            transform="translate({{xScale.compute d.x}})"
-            {{on "mouseover" (fn (mut this.activeDatum) d)}}
-            {{on "mouseout" (fn (mut this.activeDatum) null)}}
-            data-test-interactive-area={{d.x}}
+        {{#if (and xScale.isValid yScale.isValid)}}
+          <Lineal::Axis
+            @scale={{yScale}}
+            @tickCount="4"
+            @tickPadding={{10}}
+            @tickSizeInner={{concat "-" width}}
+            @tickFormat={{this.formatCount}}
+            @orientation="left"
+            @includeDomain={{false}}
+            class="lineal-axis"
+            data-test-y-axis
           />
-        {{/each}}
-      {{/if}}
-    </svg>
-    {{#if this.activeDatum}}
-      <div
-        class="lineal-tooltip-position chart-tooltip"
-        role="status"
-        {{style
-          --x=(this.tooltipX (xScale.compute this.activeDatum.x) xScale.bandwidth)
-          --y=(this.tooltipY (hScale.compute this.activeDatum.y))
-        }}
-      >
-        <div data-test-tooltip>
-          <p class="bold" data-test-tooltip-month>{{this.activeDatum.legendX}}</p>
-          <p data-test-tooltip-count>{{this.activeDatum.tooltip}}</p>
+          <Lineal::Axis
+            @scale={{xScale}}
+            @orientation="bottom"
+            transform="translate(0,{{yScale.range.min}})"
+            @includeDomain={{false}}
+            @tickSize="0"
+            @tickPadding={{10}}
+            class="lineal-axis"
+            data-test-x-axis
+          />
+        {{/if}}
+        <Lineal::Bars
+          @data={{this.chartData}}
+          @x="x"
+          @y="y"
+          @height="y"
+          @width={{this.barWidth}}
+          @xScale={{xScale}}
+          @yScale={{yScale}}
+          @heightScale={{hScale}}
+          transform="translate({{this.barOffset xScale.bandwidth}},0)"
+          fill="transparent"
+          stroke="transparent"
+          class="lineal-chart-bar"
+          data-test-vertical-bar
+        />
+        {{#if (and xScale.isValid yScale.isValid)}}
+          {{#each this.chartData as |d|}}
+            <rect
+              role="button"
+              aria-label="Show exact counts for {{d.legendX}}"
+              x="0"
+              y="0"
+              height={{this.chartHeight}}
+              width={{xScale.bandwidth}}
+              fill="transparent"
+              stroke="transparent"
+              transform="translate({{xScale.compute d.x}})"
+              {{on "mouseover" (fn (mut this.activeDatum) d)}}
+              {{on "mouseout" (fn (mut this.activeDatum) null)}}
+              data-test-interactive-area={{d.x}}
+            />
+          {{/each}}
+        {{/if}}
+      </svg>
+      {{#if this.activeDatum}}
+        <div
+          class="lineal-tooltip-position chart-tooltip"
+          role="status"
+          {{style
+            --x=(this.tooltipX (xScale.compute this.activeDatum.x) xScale.bandwidth)
+            --y=(this.tooltipY (hScale.compute this.activeDatum.y))
+          }}
+        >
+          <div data-test-tooltip>
+            <p class="bold" data-test-tooltip-month>{{this.activeDatum.legendX}}</p>
+            <p data-test-tooltip-count>{{this.activeDatum.tooltip}}</p>
+          </div>
+          <div class="chart-tooltip-arrow"></div>
         </div>
-        <div class="chart-tooltip-arrow"></div>
-      </div>
-    {{/if}}
-  {{/let}}
+      {{/if}}
+    {{/let}}
+  </Lineal::Fluid>
 </div>
 {{#if @showTable}}
   <details data-test-underlying-data>

--- a/ui/app/components/clients/sync-bar-chart.hbs
+++ b/ui/app/components/clients/sync-bar-chart.hbs
@@ -1,0 +1,113 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+~}}
+
+<div class="lineal-chart">
+  {{#let
+    (scale-band domain=this.monthDomain range=(array 0 this.chartWidth) padding=0.1)
+    (scale-linear range=(array this.chartHeight 0) domain=this.countDomain)
+    (scale-linear range=(array 0 this.chartHeight) domain=this.countDomain)
+    as |xScale yScale hScale|
+  }}
+    <svg width={{this.chartWidth}} height={{this.chartHeight}} data-test-sync-bar-chart>
+      <title>
+        {{@chartTitle}}
+      </title>
+
+      {{#if (and xScale.isValid yScale.isValid)}}
+        <Lineal::Axis
+          @scale={{yScale}}
+          @tickCount="4"
+          @tickPadding={{10}}
+          @tickSizeInner={{concat "-" this.chartWidth}}
+          @tickFormat={{this.formatCount}}
+          @orientation="left"
+          @includeDomain={{false}}
+          class="lineal-axis"
+          data-test-y-axis
+        />
+        <Lineal::Axis
+          @scale={{xScale}}
+          @orientation="bottom"
+          transform="translate(0,{{yScale.range.min}})"
+          @includeDomain={{false}}
+          @tickSize="0"
+          @tickPadding={{10}}
+          class="lineal-axis"
+          data-test-x-axis
+        />
+      {{/if}}
+      <Lineal::Bars
+        @data={{this.chartData}}
+        @x="x"
+        @y="y"
+        @height="y"
+        @width={{this.barWidth}}
+        @xScale={{xScale}}
+        @yScale={{yScale}}
+        @heightScale={{hScale}}
+        transform="translate({{this.barOffset xScale.bandwidth}},0)"
+        fill="transparent"
+        stroke="transparent"
+        class="lineal-chart-bar"
+        data-test-vertical-bar
+      />
+      {{#if (and xScale.isValid yScale.isValid)}}
+        {{#each this.chartData as |d|}}
+          <rect
+            role="button"
+            aria-label="Show exact counts for {{d.legendX}}"
+            x="0"
+            y="0"
+            height={{this.chartHeight}}
+            width={{xScale.bandwidth}}
+            fill="transparent"
+            stroke="transparent"
+            transform="translate({{xScale.compute d.x}})"
+            {{on "mouseover" (fn (mut this.activeDatum) d)}}
+            {{on "mouseout" (fn (mut this.activeDatum) null)}}
+            data-test-interactive-area={{d.x}}
+          />
+        {{/each}}
+      {{/if}}
+    </svg>
+    {{#if this.activeDatum}}
+      <div
+        class="lineal-tooltip-position chart-tooltip"
+        role="status"
+        {{style
+          --x=(this.tooltipX (xScale.compute this.activeDatum.x) xScale.bandwidth)
+          --y=(this.tooltipY (hScale.compute this.activeDatum.y))
+        }}
+      >
+        <div data-test-tooltip>
+          <p class="bold" data-test-tooltip-month>{{this.activeDatum.legendX}}</p>
+          <p data-test-tooltip-count>{{this.activeDatum.tooltip}}</p>
+        </div>
+        <div class="chart-tooltip-arrow"></div>
+      </div>
+    {{/if}}
+  {{/let}}
+</div>
+{{#if @showTable}}
+  <details data-test-underlying-data>
+    <summary>Underlying data</summary>
+    <Hds::Table @caption="Underlying data">
+      <:head as |H|>
+        <H.Tr>
+          <H.Th>Month</H.Th>
+          <H.Th>Count of secret syncs</H.Th>
+        </H.Tr>
+      </:head>
+      <:body as |B|>
+        {{#each this.chartData as |row|}}
+          <B.Tr>
+            <B.Td>{{row.legendX}}</B.Td>
+            <B.Td>{{row.legendY}}</B.Td>
+          </B.Tr>
+        {{/each}}
+      </:body>
+    </Hds::Table>
+  </details>
+{{/if}}

--- a/ui/app/components/clients/sync-bar-chart.ts
+++ b/ui/app/components/clients/sync-bar-chart.ts
@@ -14,6 +14,7 @@ interface Args {
   data: SerializedChartData[];
   dataKey: string;
   chartTitle: string;
+  chartHeight?: number;
 }
 
 interface ChartData {
@@ -34,15 +35,19 @@ interface ChartData {
     @chartTitle="Secret Sync client counts"
     @data={{this.model}}
     @dataKey="secret_syncs"
-    @showTable={{true}} />
+    @showTable={{true}}
+    @chartHeight={{200}}
+  />
  * ```
  */
 export default class ClientsSyncBarChartComponent extends Component<Args> {
   barWidth = 7;
-  chartHeight = 190;
-  chartWidth = 600;
 
   @tracked activeDatum: ChartData | null = null;
+
+  get chartHeight() {
+    return this.args.chartHeight || 190;
+  }
 
   get chartData() {
     return this.args.data.map((d): ChartData => {

--- a/ui/app/components/clients/sync-bar-chart.ts
+++ b/ui/app/components/clients/sync-bar-chart.ts
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { formatNumbers, formatTooltipNumber } from 'vault/utils/chart-helpers';
+import { BAR_WIDTH, formatNumbers, formatTooltipNumber } from 'vault/utils/chart-helpers';
 import type { SerializedChartData } from 'vault/client-counts';
 import { tracked } from '@glimmer/tracking';
 import { parseAPITimestamp } from 'core/utils/date-formatters';
@@ -41,7 +41,7 @@ interface ChartData {
  * ```
  */
 export default class ClientsSyncBarChartComponent extends Component<Args> {
-  barWidth = 7;
+  barWidth = BAR_WIDTH;
 
   @tracked activeDatum: ChartData | null = null;
 
@@ -57,7 +57,7 @@ export default class ClientsSyncBarChartComponent extends Component<Args> {
         x: format(date, 'M/yy'),
         y: count,
         tooltip: count === null ? 'No data' : `${formatTooltipNumber(count)} secret syncs`,
-        legendX: format(date, 'MMM yyyy'),
+        legendX: format(date, 'MMMM yyyy'),
         legendY: (count ?? 'No data').toString(),
       };
     });

--- a/ui/app/components/clients/sync-bar-chart.ts
+++ b/ui/app/components/clients/sync-bar-chart.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { formatNumbers, formatTooltipNumber } from 'vault/utils/chart-helpers';
+import type { SerializedChartData } from 'vault/client-counts';
+import { tracked } from '@glimmer/tracking';
+import { parseAPITimestamp } from 'core/utils/date-formatters';
+import { format } from 'date-fns';
+
+interface Args {
+  data: SerializedChartData[];
+  dataKey: string;
+  chartTitle: string;
+}
+
+interface ChartData {
+  x: string;
+  y: number | null;
+  tooltip: string;
+  legendX: string;
+  legendY: string;
+}
+
+/**
+ * @module ClientsSyncBarChartComponent
+ * Renders a bar chart of secret syncs over time.
+ *
+ * @example
+ * ```js
+ * <Clients::SyncBarChart
+    @chartTitle="Secret Sync client counts"
+    @data={{this.model}}
+    @dataKey="secret_syncs"
+    @showTable={{true}} />
+ * ```
+ */
+export default class ClientsSyncBarChartComponent extends Component<Args> {
+  barWidth = 7;
+  chartHeight = 190;
+  chartWidth = 600;
+
+  @tracked activeDatum: ChartData | null = null;
+
+  get chartData() {
+    return this.args.data.map((d): ChartData => {
+      const date = parseAPITimestamp(d.timestamp) as Date;
+      const count = (d[this.args.dataKey] as number) ?? null;
+      return {
+        x: format(date, 'M/yy'),
+        y: count,
+        tooltip: count === null ? 'No data' : `${formatTooltipNumber(count)} secret syncs`,
+        legendX: format(date, 'MMM yyyy'),
+        legendY: (count ?? 'No data').toString(),
+      };
+    });
+  }
+
+  get countDomain() {
+    const counts: number[] = this.chartData.map((d) => d.y).flatMap((num) => (num ? [num] : []));
+    const upper = Math.round(Math.max(...counts) / 1000) * 1000;
+    return [0, upper];
+  }
+
+  get monthDomain() {
+    const months = this.chartData.map((d) => d.x);
+    return new Set(months);
+  }
+
+  barOffset = (bandwidth: number) => {
+    return (bandwidth - this.barWidth) / 2;
+  };
+  tooltipX = (original: number, bandwidth: number) => {
+    return (original + bandwidth / 2).toString();
+  };
+  tooltipY = (original: number) => {
+    if (!original) return `0`;
+    return `${original}`;
+  };
+  formatCount = (num: number): string => {
+    return formatNumbers(num) || num.toString();
+  };
+}

--- a/ui/app/components/clients/vertical-bar-chart.js
+++ b/ui/app/components/clients/vertical-bar-chart.js
@@ -13,6 +13,7 @@ import { axisLeft, axisBottom } from 'd3-axis';
 import { scaleLinear, scalePoint } from 'd3-scale';
 import { stack } from 'd3-shape';
 import {
+  BAR_WIDTH,
   GREY,
   LIGHT_AND_DARK_BLUE,
   SVG_DIMENSIONS,
@@ -36,7 +37,6 @@ import { formatNumber } from 'core/helpers/format-number';
  * @param {string} [noDataMessage] - custom empty state message that displays when no dataset is passed to the chart
  */
 
-const BAR_WIDTH = 7; // data bar width is 7 pixels
 export default class VerticalBarChart extends Component {
   @tracked tooltipTarget = '';
   @tracked tooltipTotal = '';

--- a/ui/app/styles/core/charts.scss
+++ b/ui/app/styles/core/charts.scss
@@ -347,7 +347,7 @@ p.data-details {
   }
 }
 
-// LINEAR STYLING //
+// LINEAL STYLING //
 .lineal-chart {
   position: relative;
   padding: 10px 0px 10px 50px;
@@ -356,7 +356,7 @@ p.data-details {
   }
 }
 .lineal-chart-bar {
-  fill: $blue-500;
+  fill: var(--token-color-palette-blue-300);
 }
 .lineal-axis {
   color: $ui-gray-500;

--- a/ui/app/styles/core/charts.scss
+++ b/ui/app/styles/core/charts.scss
@@ -346,3 +346,35 @@ p.data-details {
     grid-row-start: 4;
   }
 }
+
+// LINEAR STYLING //
+.lineal-chart {
+  position: relative;
+  padding: 10px 0px 10px 50px;
+  svg {
+    overflow: visible;
+  }
+}
+.lineal-chart-bar {
+  fill: $blue-500;
+}
+.lineal-axis {
+  color: $ui-gray-500;
+  text {
+    font-size: 0.75rem;
+  }
+  line {
+    color: $ui-gray-300;
+  }
+}
+.lineal-tooltip-position {
+  position: absolute;
+  transform-style: preserve-3d;
+  bottom: 30px;
+  left: -20px;
+  pointer-events: none;
+  width: 140px;
+  transform: translate(calc(1px * var(--x, 0)), calc(-1px * var(--y, 0)));
+  transform-origin: bottom left;
+  z-index: 100;
+}

--- a/ui/app/utils/chart-helpers.js
+++ b/ui/app/utils/chart-helpers.js
@@ -16,6 +16,8 @@ export const GREY = '#EBEEF2';
 export const TRANSLATE = { left: -11 };
 export const SVG_DIMENSIONS = { height: 190, width: 500 };
 
+export const BAR_WIDTH = 7; // data bar width is 7 pixels
+
 // Reference for tickFormat https://www.youtube.com/watch?v=c3MCROTNN8g
 export function formatNumbers(number) {
   if (number < 1000) return number;

--- a/ui/package.json
+++ b/ui/package.json
@@ -68,6 +68,7 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@icholy/duration": "^5.1.0",
+    "@lineal-viz/lineal": "^0.5.1",
     "@tsconfig/ember": "^1.0.1",
     "@types/ember": "^4.0.2",
     "@types/ember-data": "^4.4.6",

--- a/ui/package.json
+++ b/ui/package.json
@@ -163,6 +163,7 @@
     "ember-service-worker": "meirish/ember-service-worker#configurable-scope",
     "ember-sinon": "^4.0.0",
     "ember-source": "~4.12.0",
+    "ember-style-modifier": "^4.1.0",
     "ember-svg-jar": "2.4.0",
     "ember-template-lint": "5.7.2",
     "ember-template-lint-plugin-prettier": "4.0.0",

--- a/ui/tests/integration/components/clients/sync-bar-chart-test.js
+++ b/ui/tests/integration/components/clients/sync-bar-chart-test.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'vault/tests/helpers';
+import { render, triggerEvent } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+const EXAMPLE = [
+  {
+    month: '7/22',
+    timestamp: '2022-07-01T00:00:00-07:00',
+    clients: null,
+    entity_clients: null,
+    non_entity_clients: null,
+    secret_syncs: null,
+    namespaces: [],
+    new_clients: {},
+    namespaces_by_key: {},
+  },
+  {
+    month: '8/22',
+    timestamp: '2022-08-01T00:00:00-07:00',
+    clients: 6440,
+    entity_clients: 1471,
+    non_entity_clients: 4389,
+    secret_syncs: 4207,
+    namespaces: [],
+    new_clients: {},
+    namespaces_by_key: {},
+  },
+  {
+    month: '9/22',
+    timestamp: '2022-09-01T00:00:00-07:00',
+    clients: 9583,
+    entity_clients: 149,
+    non_entity_clients: 20,
+    secret_syncs: 5802,
+    namespaces: [],
+    new_clients: {},
+    namespaces_by_key: {},
+  },
+];
+module('Integration | Component | clients/sync-bar-chart', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.data = EXAMPLE;
+  });
+
+  test('it renders when some months have no data', async function (assert) {
+    await render(hbs`<Clients::SyncBarChart @data={{this.data}} @dataKey="secret_syncs" />`);
+    assert.dom('[data-test-sync-bar-chart]').exists('renders chart container');
+    assert.dom('[data-test-vertical-bar]').exists({ count: 3 }, 'renders 3 vertical bars');
+    // Tooltips
+    await triggerEvent('[data-test-interactive-area="9/22"]', 'mouseover');
+    assert.dom('[data-test-tooltip]').exists({ count: 1 }, 'renders tooltip on mouseover');
+    assert.dom('[data-test-tooltip-count]').hasText('5,802 secret syncs', 'tooltip has exact count');
+    assert.dom('[data-test-tooltip-month]').hasText('Sep 2022', 'tooltip has humanized month and year');
+    await triggerEvent('[data-test-interactive-area="9/22"]', 'mouseout');
+    assert.dom('[data-test-tooltip]').doesNotExist('removes tooltip on mouseout');
+    await triggerEvent('[data-test-interactive-area="7/22"]', 'mouseover');
+    assert
+      .dom('[data-test-tooltip-count]')
+      .hasText('No data', 'renders tooltip with no data message when no data is available');
+    // Axis
+    assert.dom('[data-test-x-axis]').hasText('7/22 8/22 9/22', 'renders x-axis labels');
+    assert.dom('[data-test-y-axis]').hasText('0 2k 4k 6k', 'renders y-axis labels');
+    // Table
+    assert.dom('[data-test-underlying-data]').doesNotExist('does not render underlying data by default');
+  });
+
+  test('it renders underlying data', async function (assert) {
+    await render(
+      hbs`<Clients::SyncBarChart @data={{this.data}} @dataKey="secret_syncs" @showTable={{true}} />`
+    );
+    assert.dom('[data-test-sync-bar-chart]').exists('renders chart container');
+    assert.dom('[data-test-underlying-data]').exists('renders underlying data when showTable=true');
+    assert
+      .dom('[data-test-underlying-data] thead')
+      .hasText('Month Count of secret syncs', 'renders correct table headers');
+  });
+});

--- a/ui/types/client-counts.ts
+++ b/ui/types/client-counts.ts
@@ -1,0 +1,38 @@
+// Common sub-types for client counts data
+interface ChartTimestamp {
+  month: string; // eg. 12/22
+  timestamp: string; // ISO 8601
+}
+
+// Count and EmptyCount are mutually exclusive
+// but that's hard to represent in an interface
+// so for now we just have both
+interface Count {
+  clients?: number;
+  entity_clients?: number;
+  non_entity_clients?: number;
+  secret_syncs?: number;
+}
+interface EmptyCount {
+  count?: null;
+}
+
+interface MountData extends Count, EmptyCount {
+  label: string; // eg 'auth/authid1'
+}
+interface NamespaceData extends Count, EmptyCount {
+  label: string; // eg 'ns/foo'
+  mounts: MountData[];
+}
+interface NewClients extends ChartTimestamp, Count, EmptyCount {
+  namespaces: NamespaceData[];
+}
+interface NamespacesByKey {
+  [key: string]: NamespaceData;
+}
+export interface SerializedChartData extends Count, EmptyCount, ChartTimestamp {
+  namespaces: NamespaceData[];
+  namespaces_by_key: NamespacesByKey;
+  new_clients: NewClients;
+  [key: string]: unknown;
+}

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -12751,6 +12751,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"csstype@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "csstype@npm:3.1.3"
+  checksum: 8db785cc92d259102725b3c694ec0c823f5619a84741b5c7991b8ad135dfaa66093038a1cc63e03361a6cd28d122be48f2106ae72334e067dd619a51f49eddf7
+  languageName: node
+  linkType: hard
+
 "cyclist@npm:^1.0.1":
   version: 1.0.1
   resolution: "cyclist@npm:1.0.1"
@@ -15711,6 +15718,22 @@ __metadata:
   peerDependencies:
     "@ember/string": ^3.0.1
   checksum: 093a9affaaa7b3f1c782fa46616bd3f9a02f518c3eff22f1f4c2582f2411cc9d1eecb95d483aaeabf6ce050d95ff928201cd5287e950027b96cbe702e56ae68d
+  languageName: node
+  linkType: hard
+
+"ember-style-modifier@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "ember-style-modifier@npm:4.1.0"
+  dependencies:
+    "@babel/core": ^7.23.6
+    csstype: ^3.1.3
+    ember-auto-import: ^2.7.0
+    ember-cli-babel: ^8.2.0
+    ember-modifier: ^3.2.7 || ^4.0.0
+  peerDependencies:
+    "@ember/string": ^3.0.1
+    ember-source: ">= 4.12.0"
+  checksum: a83a0328210d7ec6e12995ded1b8ace876245fcb025ba380cb034770bc717628d6ba142c947087c6500b9bf6993225b32d57f1e1371e009e4396a5fd3c65b190
   languageName: node
   linkType: hard
 
@@ -28052,6 +28075,7 @@ __metadata:
     ember-service-worker: "meirish/ember-service-worker#configurable-scope"
     ember-sinon: ^4.0.0
     ember-source: ~4.12.0
+    ember-style-modifier: ^4.1.0
     ember-svg-jar: 2.4.0
     ember-template-lint: 5.7.2
     ember-template-lint-plugin-prettier: 4.0.0

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6429,6 +6429,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lineal-viz/lineal@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "@lineal-viz/lineal@npm:0.5.1"
+  dependencies:
+    "@embroider/addon-shim": ^1.0.0
+    d3-array: ^3.2.0
+    d3-scale: ^4.0.2
+    d3-shape: ^3.1.0
+    ember-cached-decorator-polyfill: ^1.0.1
+    ember-modifier: ^3.2.7
+    ember-resize-modifier: ^0.4.1
+  checksum: be47dbac62d65f01121d78b8ed393c7c5aa7cb520755a504d912b44054a478a16b9834208f031cb3cd1710c3f04008a91aa41b36ed544d0a738a09607d3c29ac
+  languageName: node
+  linkType: hard
+
 "@lint-todo/utils@npm:^13.0.3":
   version: 13.0.3
   resolution: "@lint-todo/utils@npm:13.0.3"
@@ -12750,6 +12765,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:^3.2.0":
+  version: 3.2.4
+  resolution: "d3-array@npm:3.2.4"
+  dependencies:
+    internmap: 1 - 2
+  checksum: a5976a6d6205f69208478bb44920dd7ce3e788c9dceb86b304dbe401a4bfb42ecc8b04c20facde486e9adcb488b5d1800d49393a3f81a23902b68158e12cddd0
+  languageName: node
+  linkType: hard
+
 "d3-axis@npm:1, d3-axis@npm:^1.0.8":
   version: 1.0.12
   resolution: "d3-axis@npm:1.0.12"
@@ -12791,6 +12815,13 @@ __metadata:
   version: 1.4.1
   resolution: "d3-color@npm:1.4.1"
   checksum: a214b61458b5fcb7ad1a84faed0e02918037bab6be37f2d437bf0e2915cbd854d89fbf93754f17b0781c89e39d46704633d05a2bfae77e6209f0f4b140f9894b
+  languageName: node
+  linkType: hard
+
+"d3-color@npm:1 - 3":
+  version: 3.1.0
+  resolution: "d3-color@npm:3.1.0"
+  checksum: 4931fbfda5d7c4b5cfa283a13c91a954f86e3b69d75ce588d06cde6c3628cebfc3af2069ccf225e982e8987c612aa7948b3932163ce15eb3c11cd7c003f3ee3b
   languageName: node
   linkType: hard
 
@@ -12876,6 +12907,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-format@npm:1 - 3":
+  version: 3.1.0
+  resolution: "d3-format@npm:3.1.0"
+  checksum: f345ec3b8ad3cab19bff5dead395bd9f5590628eb97a389b1dd89f0b204c7c4fc1d9520f13231c2c7cf14b7c9a8cf10f8ef15bde2befbab41454a569bd706ca2
+  languageName: node
+  linkType: hard
+
 "d3-geo@npm:1":
   version: 1.12.1
   resolution: "d3-geo@npm:1.12.1"
@@ -12901,10 +12939,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-interpolate@npm:1.2.0 - 3":
+  version: 3.0.1
+  resolution: "d3-interpolate@npm:3.0.1"
+  dependencies:
+    d3-color: 1 - 3
+  checksum: a42ba314e295e95e5365eff0f604834e67e4a3b3c7102458781c477bd67e9b24b6bb9d8e41ff5521050a3f2c7c0c4bbbb6e187fd586daa3980943095b267e78b
+  languageName: node
+  linkType: hard
+
 "d3-path@npm:1":
   version: 1.0.9
   resolution: "d3-path@npm:1.0.9"
   checksum: d4382573baf9509a143f40944baeff9fead136926aed6872f7ead5b3555d68925f8a37935841dd51f1d70b65a294fe35c065b0906fb6e42109295f6598fc16d0
+  languageName: node
+  linkType: hard
+
+"d3-path@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "d3-path@npm:3.1.0"
+  checksum: 2306f1bd9191e1eac895ec13e3064f732a85f243d6e627d242a313f9777756838a2215ea11562f0c7630c7c3b16a19ec1fe0948b1c82f3317fac55882f6ee5d8
   languageName: node
   linkType: hard
 
@@ -12968,6 +13022,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-scale@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "d3-scale@npm:4.0.2"
+  dependencies:
+    d3-array: 2.10.0 - 3
+    d3-format: 1 - 3
+    d3-interpolate: 1.2.0 - 3
+    d3-time: 2.1.1 - 3
+    d3-time-format: 2 - 4
+  checksum: a9c770d283162c3bd11477c3d9d485d07f8db2071665f1a4ad23eec3e515e2cefbd369059ec677c9ac849877d1a765494e90e92051d4f21111aa56791c98729e
+  languageName: node
+  linkType: hard
+
 "d3-selection-multi@npm:^1.0.1":
   version: 1.0.1
   resolution: "d3-selection-multi@npm:1.0.1"
@@ -12994,6 +13061,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-shape@npm:^3.1.0":
+  version: 3.2.0
+  resolution: "d3-shape@npm:3.2.0"
+  dependencies:
+    d3-path: ^3.1.0
+  checksum: de2af5fc9a93036a7b68581ca0bfc4aca2d5a328aa7ba7064c11aedd44d24f310c20c40157cb654359d4c15c3ef369f95ee53d71221017276e34172c7b719cfa
+  languageName: node
+  linkType: hard
+
+"d3-time-format@npm:2 - 4":
+  version: 4.1.0
+  resolution: "d3-time-format@npm:4.1.0"
+  dependencies:
+    d3-time: 1 - 3
+  checksum: 7342bce28355378152bbd4db4e275405439cabba082d9cd01946d40581140481c8328456d91740b0fe513c51ec4a467f4471ffa390c7e0e30ea30e9ec98fcdf4
+  languageName: node
+  linkType: hard
+
 "d3-time-format@npm:2, d3-time-format@npm:^2.1.1":
   version: 2.3.0
   resolution: "d3-time-format@npm:2.3.0"
@@ -13007,6 +13092,15 @@ __metadata:
   version: 1.1.0
   resolution: "d3-time@npm:1.1.0"
   checksum: 33fcfff94ff093dde2048c190ecca8b39fe0ec8b3c61e9fc39c5f6072ce5b86dd2b91823f086366995422bbbac7f74fd9abdb7efe4f292a73b1c6197c699cc78
+  languageName: node
+  linkType: hard
+
+"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3":
+  version: 3.1.0
+  resolution: "d3-time@npm:3.1.0"
+  dependencies:
+    d3-array: 2 - 3
+  checksum: 613b435352a78d9f31b7f68540788186d8c331b63feca60ad21c88e9db1989fe888f97f242322ebd6365e45ec3fb206a4324cd4ca0dfffa1d9b5feb856ba00a7
   languageName: node
   linkType: hard
 
@@ -15340,7 +15434,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-modifier@npm:^3.2.7":
+"ember-modifier@npm:^3.2.0, ember-modifier@npm:^3.2.7":
   version: 3.2.7
   resolution: "ember-modifier@npm:3.2.7"
   dependencies:
@@ -15419,6 +15513,17 @@ __metadata:
     ember-source: ">=3.28"
     qunit: ^2.13.0
   checksum: c9058d02d78efe06887ee6993908d8f45592c4369e0f72a57045f5ae27df94ea7497866bdf484f12eaddfac23ae4051a259bae0280a70c0dd50a8260eae3126c
+  languageName: node
+  linkType: hard
+
+"ember-resize-modifier@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "ember-resize-modifier@npm:0.4.1"
+  dependencies:
+    ember-cli-babel: ^7.26.11
+    ember-cli-htmlbars: ^6.0.1
+    ember-modifier: ^3.2.0
+  checksum: 6363c9bc240678ecbe538f655d91a1fd79b7ac2e72f2fe7db70141f45e846bb685d4a10640ed1e59e2f6fae39ad3ca09fb2d60f02493f2db43dd5c38c7823c90
   languageName: node
   linkType: hard
 
@@ -19147,6 +19252,13 @@ __metadata:
     has: ^1.0.3
     side-channel: ^1.0.4
   checksum: 97e84046bf9e7574d0956bd98d7162313ce7057883b6db6c5c7b5e5f05688864b0978ba07610c726d15d66544ffe4b1050107d93f8a39ebc59b15d8b429b497a
+  languageName: node
+  linkType: hard
+
+"internmap@npm:1 - 2":
+  version: 2.0.3
+  resolution: "internmap@npm:2.0.3"
+  checksum: 7ca41ec6aba8f0072fc32fa8a023450a9f44503e2d8e403583c55714b25efd6390c38a87161ec456bf42d7bc83aab62eb28f5aef34876b1ac4e60693d5e1d241
   languageName: node
   linkType: hard
 
@@ -27845,6 +27957,7 @@ __metadata:
     "@hashicorp/design-system-components": ^3.4.0
     "@hashicorp/ember-flight-icons": ^4.0.5
     "@icholy/duration": ^5.1.0
+    "@lineal-viz/lineal": ^0.5.1
     "@tsconfig/ember": ^1.0.1
     "@types/ember": ^4.0.2
     "@types/ember-data": ^4.4.6


### PR DESCRIPTION
This PR adds a component for rendering a vertical bar chart for secret sync data. It does not make use of the chart. 

**Tooltips with data and without**
<img width="683" alt="Screenshot 2024-01-17 at 16 26 46" src="https://github.com/hashicorp/vault/assets/82459713/f6a2571e-2538-46e8-9bef-0505e6355497">
<img width="674" alt="Screenshot 2024-01-17 at 16 26 54" src="https://github.com/hashicorp/vault/assets/82459713/a7a97d6d-b079-476d-bc2a-eded56dad84d">
**Fluid layout**
it will fill the width of its parent. To change the height, pass `@chartHeight={{360}}`
<img width="667" alt="Screenshot 2024-01-17 at 16 35 14" src="https://github.com/hashicorp/vault/assets/82459713/285b2126-feb9-46ef-8b96-e88ccfe6fe3d">
