### PR TITLE
Secrets Sync UI: Update serializer to use tags_to_remove param for updating custom_tags

### DIFF
--- a/ui/tests/helpers/general-selectors.js
+++ b/ui/tests/helpers/general-selectors.js
@@ -29,6 +29,9 @@ export const SELECTORS = {
   validation: (attr) => `[data-test-field-validation=${attr}]`,
   validationWarning: (attr) => `[data-test-validation-warning=${attr}]`,
   messageError: '[data-test-message-error]',
+  kvObjectEditor: {
+    deleteRow: (idx = 0) => `[data-test-kv-delete-row="${idx}"]`,
+  },
   searchSelect: {
     options: '.ember-power-select-option',
     optionIndex: (text) => findAll('.ember-power-select-options li').findIndex((e) => e.innerText === text),

--- a/ui/tests/integration/components/sync/secrets/page/destinations/create-and-edit-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations/create-and-edit-test.js
@@ -31,6 +31,17 @@ module('Integration | Component | sync | Secrets::Page::Destinations::CreateAndE
         owner: this.engine,
       });
     };
+
+    this.generateModel = (type = 'aws-sm') => {
+      const data = this.server.create('sync-destination', type);
+      const id = `${type}/${data.name}`;
+      data.id = id;
+      this.store.pushPayload(`sync/destinations/${type}`, {
+        modelName: `sync/destinations/${type}`,
+        ...data,
+      });
+      return this.store.peekRecord(`sync/destinations/${type}`, id);
+    };
   });
 
   test('create: it renders and navigates back to create on cancel', async function (assert) {
@@ -47,15 +58,7 @@ module('Integration | Component | sync | Secrets::Page::Destinations::CreateAndE
 
   test('edit: it renders and navigates back to details on cancel', async function (assert) {
     assert.expect(4);
-    const type = SYNC_DESTINATIONS[0].type;
-    const data = this.server.create('sync-destination', type);
-    const id = `${type}/${data.name}`;
-    data.id = id;
-    this.store.pushPayload(`sync/destinations/${type}`, {
-      modelName: `sync/destinations/${type}`,
-      ...data,
-    });
-    this.model = this.store.peekRecord(`sync/destinations/${type}`, id);
+    this.model = this.generateModel();
 
     await this.renderFormComponent();
     assert.dom(PAGE.breadcrumbs).hasText('Secrets Sync Destinations Destination Edit Destination');
@@ -68,6 +71,64 @@ module('Integration | Component | sync | Secrets::Page::Destinations::CreateAndE
     await click(PAGE.cancelButton);
     const transition = this.transitionStub.calledWith('vault.cluster.sync.secrets.destinations.destination');
     assert.true(transition, 'transitions to vault.cluster.sync.secrets.destinations.destination on cancel');
+  });
+
+  test('edit: it PATCH updates custom_tags', async function (assert) {
+    assert.expect(1);
+    this.model = this.generateModel();
+
+    this.server.patch(`sys/sync/destinations/${this.model.type}/${this.model.name}`, (schema, req) => {
+      const payload = JSON.parse(req.requestBody);
+      const expected = {
+        tags_to_remove: ['foo'],
+        custom_tags: { updated: 'bar', added: 'key' },
+      };
+      assert.propEqual(payload, expected, 'payload removes old tags and includes updated object');
+      return { payload };
+    });
+
+    // bypass form and manually set model attributes
+    this.model.set('customTags', {
+      updated: 'bar',
+      added: 'key',
+    });
+    await this.renderFormComponent();
+    await click(PAGE.saveButton);
+  });
+
+  test('edit: it adds custom_tags when previously there are none', async function (assert) {
+    assert.expect(1);
+    this.model = this.generateModel();
+
+    this.server.patch(`sys/sync/destinations/${this.model.type}/${this.model.name}`, (schema, req) => {
+      const payload = JSON.parse(req.requestBody);
+      const expected = { custom_tags: { foo: 'blah' } };
+      assert.propEqual(payload, expected, 'payload contains new custom tags');
+      return { payload };
+    });
+
+    // bypass form and manually set model attributes
+    this.model.set('customTags', {});
+
+    await this.renderFormComponent();
+    await PAGE.form.fillInByAttr('customTags', 'blah');
+    await click(PAGE.saveButton);
+  });
+
+  test('edit: payload does not contain any custom_tags when removed in form', async function (assert) {
+    assert.expect(1);
+    this.model = this.generateModel();
+
+    this.server.patch(`sys/sync/destinations/${this.model.type}/${this.model.name}`, (schema, req) => {
+      const payload = JSON.parse(req.requestBody);
+      const expected = { tags_to_remove: ['foo'], custom_tags: {} };
+      assert.propEqual(payload, expected, 'payload removes old keys');
+      return { payload };
+    });
+
+    await this.renderFormComponent();
+    await click(PAGE.kvObjectEditor.deleteRow());
+    await click(PAGE.saveButton);
   });
 
   test('it renders API errors', async function (assert) {
@@ -228,22 +289,15 @@ module('Integration | Component | sync | Secrets::Page::Destinations::CreateAndE
     const { type, maskedParams } = destination;
     module(`edit destination: ${type}`, function (hooks) {
       hooks.beforeEach(function () {
-        this.data = this.server.create('sync-destination', type);
-        const id = `${type}/${this.data.name}`;
-        this.data.id = id;
-        this.store.pushPayload(`sync/destinations/${type}`, {
-          modelName: `sync/destinations/${type}`,
-          ...this.data,
-        });
-        this.model = this.store.peekRecord(`sync/destinations/${type}`, id);
+        this.model = this.generateModel(type);
       });
 
       test('it renders destination form and PATCH updates a destination', async function (assert) {
         const disabledAssertions = this.model.formFields.filter((f) => f.options.editDisabled).length;
         const editable = EDITABLE_FIELDS[this.model.type];
         assert.expect(5 + disabledAssertions + editable.length);
-        this.server.patch(`sys/sync/destinations/${type}/${this.data.name}`, (schema, req) => {
-          assert.ok(true, `makes request: PATCH sys/sync/destinations/${type}/${this.data.name}`);
+        this.server.patch(`sys/sync/destinations/${type}/${this.model.name}`, (schema, req) => {
+          assert.ok(true, `makes request: PATCH sys/sync/destinations/${type}/${this.model.name}`);
           const payload = JSON.parse(req.requestBody);
           const payloadKeys = Object.keys(payload);
           const expectedKeys = editable.map((k) => decamelize(k));
@@ -274,7 +328,7 @@ module('Integration | Component | sync | Secrets::Page::Destinations::CreateAndE
         const expectedArgs = [
           'vault.cluster.sync.secrets.destinations.destination.details',
           type,
-          this.data.name,
+          this.model.name,
         ];
         assert.propEqual(actualArgs, expectedArgs, 'transitionTo called with expected args');
         assert.propEqual(


### PR DESCRIPTION
Because we use `PATCH` to update destinations, sending a new object would add key value pairs to an existing `custom_tags` object for a destination. 

The backend added a `tags_to_remove` param to improve the form UX so that the `custom_tag` field will match any updates made to the form 