### PR TITLE
VAULT-23122: Known Issues: Audit devices using `log_raw`

### DIFF
--- a/website/content/docs/release-notes/1.15.0.mdx
+++ b/website/content/docs/release-notes/1.15.0.mdx
@@ -13,17 +13,18 @@ description: |-
 
 ## Known issues and breaking changes
 
-Version | Issue
-------- | -----
-1.15.0+ | [Vault no longer reports rollback metrics by mountpoint](/vault/docs/upgrading/upgrade-to-1.15.x#rollback-metrics)
-1.15.0  | [Panic in AWS auth method during IAM-based login](/vault/docs/upgrading/upgrade-to-1.15.x#panic-in-aws-auth-method-during-iam-based-login)
-1.15.0+ | [UI Collapsed navbar does not allow certain click events](/vault/docs/upgrading/upgrade-to-1.15.x#ui-collapsed-navbar)
-1.15    | [Vault file audit devices do not honor SIGHUP signal to reload](/vault/docs/upgrading/upgrade-to-1.15.x#file-audit-devices-do-not-honor-sighup-signal-to-reload)
-1.15.0 - 1.15.1 | [Vault storing references to ephemeral sub-loggers leading to unbounded memory consumption](/vault/docs/upgrading/upgrade-to-1.15.x#vault-is-storing-references-to-ephemeral-sub-loggers-leading-to-unbounded-memory-consumption)
-1.15.0 - 1.15.1 | [Internal error when vault policy in namespace does not exist](/vault/docs/upgrading/upgrade-to-1.15.x#internal-error-when-vault-policy-in-namespace-does-not-exist)
-1.15.0+ | [Sublogger levels not adjusted on reload](/vault/docs/upgrading/upgrade-to-1.15.x#sublogger-levels-unchanged-on-reload)
-1.15.0+ | [URL change for KV v2 plugin](/vault/docs/upgrading/upgrade-to-1.15.x#kv2-url-change)
-1.15.1  | [Fatal error during expiration metrics gathering causing Vault crash](/vault/docs/upgrading/upgrade-to-1.15.x#fatal-error-during-expiration-metrics-gathering-causing-vault-crash)
+| Version         | Issue                                                                                                                                                                                                                             |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.15.0+         | [Vault no longer reports rollback metrics by mountpoint](/vault/docs/upgrading/upgrade-to-1.15.x#rollback-metrics)                                                                                                                |
+| 1.15.0          | [Panic in AWS auth method during IAM-based login](/vault/docs/upgrading/upgrade-to-1.15.x#panic-in-aws-auth-method-during-iam-based-login)                                                                                        |
+| 1.15.0+         | [UI Collapsed navbar does not allow certain click events](/vault/docs/upgrading/upgrade-to-1.15.x#ui-collapsed-navbar)                                                                                                            |
+| 1.15            | [Vault file audit devices do not honor SIGHUP signal to reload](/vault/docs/upgrading/upgrade-to-1.15.x#file-audit-devices-do-not-honor-sighup-signal-to-reload)                                                                  |
+| 1.15.0 - 1.15.1 | [Vault storing references to ephemeral sub-loggers leading to unbounded memory consumption](/vault/docs/upgrading/upgrade-to-1.15.x#vault-is-storing-references-to-ephemeral-sub-loggers-leading-to-unbounded-memory-consumption) |
+| 1.15.0 - 1.15.1 | [Internal error when vault policy in namespace does not exist](/vault/docs/upgrading/upgrade-to-1.15.x#internal-error-when-vault-policy-in-namespace-does-not-exist)                                                              |
+| 1.15.0+         | [Sublogger levels not adjusted on reload](/vault/docs/upgrading/upgrade-to-1.15.x#sublogger-levels-unchanged-on-reload)                                                                                                           |
+| 1.15.0+         | [URL change for KV v2 plugin](/vault/docs/upgrading/upgrade-to-1.15.x#kv2-url-change)                                                                                                                                             |
+| 1.15.1          | [Fatal error during expiration metrics gathering causing Vault crash](/vault/docs/upgrading/upgrade-to-1.15.x#fatal-error-during-expiration-metrics-gathering-causing-vault-crash)                                                |
+| 1.15.0 - 1.15.4 | [Audit devices could log raw data despite configuration](/vault/docs/upgrading/upgrade-to-1.15.x#audit-devices-could-log-raw-data-despite-configuration)                                                                          |
 
 
 ## Vault companion updates

--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -66,3 +66,5 @@ option.
 @include 'known-issues/kv2-url-change.mdx'
 
 @include 'known-issues/expiration-metrics-fatal-error.mdx'
+
+@include 'known-issues/1_15_audit-use-of-log-raw-applies-to-all-devices.mdx'

--- a/website/content/partials/known-issues/1_15_audit-use-of-log-raw-applies-to-all-devices.mdx
+++ b/website/content/partials/known-issues/1_15_audit-use-of-log-raw-applies-to-all-devices.mdx
@@ -1,0 +1,47 @@
+### Audit devices could log raw data despite configuration
+
+#### Affected versions
+
+- 1.15.0 - 1.15.4
+
+#### Issue
+
+Enabling an audit device which specifies the [`log_raw`](/vault/docs/audit#log_raw) option
+could lead to raw data being logged to other audit devices, regardless of whether they
+are configured to use `log_raw`.
+
+The issue with raw data potentially appearing in logs where HMAC data is expected
+is fixed as a patch release in Vault `1.15.5`.
+
+#### Workaround
+
+Do not enable any audit devices in Vault that use `log_raw`. If any audit devices
+are currently enabled with `log_raw` set to `true` they should be [disabled](/vault/docs/commands/audit/disable).
+
+To view the options for audit devices via the CLI, use the `--detailed` flag for the
+`vault audit list` command:
+
+```shell-session
+$ vault audit list --detailed
+```
+
+The output will resemble the following, with `log_raw` shown under `Options` on
+any device which has it enabled:
+
+```shell-session
+vault audit list --detailed
+
+Path      Type    Description    Replication    Options
+----      ----    -----------    -----------    -------
+file1/    file    n/a            replicated     file_path=/var/log/vault/log1.json
+file2/    file    n/a            replicated     file_path=/var/log/vault/log2.json log_raw=true
+```
+
+Disable any device with the `log_raw` option set to `true` using the command
+`vault audit disable {path}` (`file2` in the above output):
+
+```shell-session
+$ vault audit disable file2
+```
+
+See also: [Disable audit via API](/vault/api-docs/system/audit#disable-audit-device).

--- a/website/content/partials/known-issues/1_15_audit-use-of-log-raw-applies-to-all-devices.mdx
+++ b/website/content/partials/known-issues/1_15_audit-use-of-log-raw-applies-to-all-devices.mdx
@@ -28,14 +28,18 @@ $ vault audit list --detailed
 The output will resemble the following, with `log_raw` shown under `Options` on
 any device which has it enabled:
 
-```shell-session
-vault audit list --detailed
+**Example output:** 
 
+<CodeBlockConfig hideClipboard>
+
+```shell-session
 Path      Type    Description    Replication    Options
 ----      ----    -----------    -----------    -------
 file1/    file    n/a            replicated     file_path=/var/log/vault/log1.json
 file2/    file    n/a            replicated     file_path=/var/log/vault/log2.json log_raw=true
 ```
+
+</CodeBlockConfig>
 
 Disable any device with the `log_raw` option set to `true` using the command
 `vault audit disable {path}` (`file2` in the above output):

--- a/website/content/partials/known-issues/1_15_audit-use-of-log-raw-applies-to-all-devices.mdx
+++ b/website/content/partials/known-issues/1_15_audit-use-of-log-raw-applies-to-all-devices.mdx
@@ -10,7 +10,7 @@ Enabling an audit device which specifies the [`log_raw`](/vault/docs/audit#log_r
 could lead to raw data being logged to other audit devices, regardless of whether they
 are configured to use `log_raw`.
 
-The issue with raw data potentially appearing in logs where HMAC data is expected
+The issue with raw data potentially appearing in logs where HMAC data as expected,
 is fixed as a patch release in Vault `1.15.5`.
 
 #### Workaround


### PR DESCRIPTION
This PR contains a release about a known issue related to auditing data in a raw format with Vault versions `1.15.0` - `1.15.4` when any device is configured to use `log_raw` as an option.

Vercel deployment for page review:

1.15 Release notes: https://vault-2zbb1o8z8-hashicorp.vercel.app/vault/docs/release-notes/1.15.0
1.15 Upgrade Guide: https://vault-2zbb1o8z8-hashicorp.vercel.app/vault/docs/upgrading/upgrade-to-1.15.x#audit-devices-could-log-raw-data-despite-configuration