### PR TITLE
Support setting plugin TMPDIR in config as well as env

### DIFF
--- a/changelog/24978.txt
+++ b/changelog/24978.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Added new `plugin_tmpdir` config option for containerized plugins, in addition to the existing `VAULT_PLUGIN_TMPDIR` environment variable.
+```

--- a/command/commands.go
+++ b/command/commands.go
@@ -97,6 +97,9 @@ const (
 	// logged at startup _per node_. This was initially introduced for the events
 	// system being developed over multiple release cycles.
 	EnvVaultExperiments = "VAULT_EXPERIMENTS"
+	// EnvVaultPluginTmpdir sets the folder to use for Unix sockets when setting
+	// up containerized plugins.
+	EnvVaultPluginTmpdir = "VAULT_PLUGIN_TMPDIR"
 
 	// flagNameAddress is the flag used in the base command to read in the
 	// address of the Vault server.

--- a/command/server.go
+++ b/command/server.go
@@ -1151,6 +1151,10 @@ func (c *ServerCommand) Run(args []string) int {
 		config.License = envLicense
 	}
 
+	if envPluginTmpdir := os.Getenv(EnvVaultPluginTmpdir); envPluginTmpdir != "" {
+		config.PluginTmpdir = envPluginTmpdir
+	}
+
 	if err := server.ExperimentsFromEnvAndCLI(config, EnvVaultExperiments, c.flagExperiments); err != nil {
 		c.UI.Error(err.Error())
 		return 1
@@ -3072,6 +3076,7 @@ func createCoreConfig(c *ServerCommand, config *server.Config, backend physical.
 		ClusterName:                    config.ClusterName,
 		CacheSize:                      config.CacheSize,
 		PluginDirectory:                config.PluginDirectory,
+		PluginTmpdir:                   config.PluginTmpdir,
 		PluginFileUid:                  config.PluginFileUid,
 		PluginFilePermissions:          config.PluginFilePermissions,
 		EnableUI:                       config.EnableUI,

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -69,6 +69,7 @@ type Config struct {
 	ClusterCipherSuites string `hcl:"cluster_cipher_suites"`
 
 	PluginDirectory string `hcl:"plugin_directory"`
+	PluginTmpdir    string `hcl:"plugin_tmpdir"`
 
 	PluginFileUid int `hcl:"plugin_file_uid"`
 
@@ -361,6 +362,11 @@ func (c *Config) Merge(c2 *Config) *Config {
 	result.PluginDirectory = c.PluginDirectory
 	if c2.PluginDirectory != "" {
 		result.PluginDirectory = c2.PluginDirectory
+	}
+
+	result.PluginTmpdir = c.PluginTmpdir
+	if c2.PluginTmpdir != "" {
+		result.PluginTmpdir = c2.PluginTmpdir
 	}
 
 	result.PluginFileUid = c.PluginFileUid
@@ -1114,6 +1120,7 @@ func (c *Config) Sanitized() map[string]interface{} {
 		"cluster_cipher_suites": c.ClusterCipherSuites,
 
 		"plugin_directory": c.PluginDirectory,
+		"plugin_tmpdir":    c.PluginTmpdir,
 
 		"plugin_file_uid": c.PluginFileUid,
 

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -476,6 +476,9 @@ func testLoadConfigFile(t *testing.T) {
 		EnableResponseHeaderRaftNodeIDRaw: true,
 
 		LicensePath: "/path/to/license",
+
+		PluginDirectory: "/path/to/plugins",
+		PluginTmpdir:    "/tmp/plugins",
 	}
 
 	addExpectedEntConfig(expected, []string{})

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -803,6 +803,7 @@ func testConfig_Sanitized(t *testing.T) {
 		"max_lease_ttl":    (30 * 24 * time.Hour) / time.Second,
 		"pid_file":         "./pidfile",
 		"plugin_directory": "",
+		"plugin_tmpdir":    "",
 		"seals": []interface{}{
 			map[string]interface{}{
 				"disabled": false,

--- a/command/server/test-fixtures/config.hcl
+++ b/command/server/test-fixtures/config.hcl
@@ -52,3 +52,5 @@ disable_printable_check = true
 enable_response_header_hostname = true
 enable_response_header_raft_node_id = true
 license_path = "/path/to/license"
+plugin_directory = "/path/to/plugins"
+plugin_tmpdir = "/tmp/plugins"

--- a/http/sys_config_state_test.go
+++ b/http/sys_config_state_test.go
@@ -162,6 +162,7 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 				"max_lease_ttl":                       json.Number("0"),
 				"pid_file":                            "",
 				"plugin_directory":                    "",
+				"plugin_tmpdir":                       "",
 				"plugin_file_uid":                     json.Number("0"),
 				"plugin_file_permissions":             json.Number("0"),
 				"enable_response_header_hostname":     false,

--- a/sdk/helper/pluginutil/run_config.go
+++ b/sdk/helper/pluginutil/run_config.go
@@ -56,6 +56,7 @@ type runConfig struct {
 	runtimeConfig *pluginruntimeutil.PluginRuntimeConfig
 
 	PluginClientConfig
+	tmpdir string
 }
 
 func (rc runConfig) mlockEnabled() bool {
@@ -144,7 +145,7 @@ func (rc runConfig) makeConfig(ctx context.Context) (*plugin.ClientConfig, error
 		clientConfig.RunnerFunc = containerCfg.NewContainerRunner
 		clientConfig.UnixSocketConfig = &plugin.UnixSocketConfig{
 			Group:   strconv.Itoa(containerCfg.GroupAdd),
-			TempDir: os.Getenv("VAULT_PLUGIN_TMPDIR"),
+			TempDir: rc.tmpdir,
 		}
 		clientConfig.GRPCBrokerMultiplex = true
 	}
@@ -271,6 +272,7 @@ func (r *PluginRunner) RunConfig(ctx context.Context, opts ...RunOpt) (*plugin.C
 		sha256:        r.Sha256,
 		env:           r.Env,
 		runtimeConfig: r.RuntimeConfig,
+		tmpdir:        r.Tmpdir,
 		PluginClientConfig: PluginClientConfig{
 			Name:       r.Name,
 			PluginType: r.Type,

--- a/sdk/helper/pluginutil/runner.go
+++ b/sdk/helper/pluginutil/runner.go
@@ -65,6 +65,7 @@ type PluginRunner struct {
 	Builtin        bool                        `json:"builtin" structs:"builtin"`
 	BuiltinFactory func() (interface{}, error) `json:"-" structs:"-"`
 	RuntimeConfig  *prutil.PluginRuntimeConfig `json:"-" structs:"-"`
+	Tmpdir         string                      `json:"-" structs:"-"`
 }
 
 // BinaryReference returns either the OCI image reference if it's a container

--- a/vault/core.go
+++ b/vault/core.go
@@ -1234,7 +1234,12 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 			return nil, fmt.Errorf("core setup failed, could not verify plugin directory: %w", err)
 		}
 	}
-	c.pluginTmpdir = conf.PluginTmpdir
+	if conf.PluginTmpdir != "" {
+		c.pluginTmpdir, err = filepath.Abs(conf.PluginTmpdir)
+		if err != nil {
+			return nil, fmt.Errorf("core setup failed, could not verify plugin tmpdir: %w", err)
+		}
+	}
 
 	if conf.PluginFileUid != 0 {
 		c.pluginFileUid = conf.PluginFileUid

--- a/vault/plugincatalog/plugin_catalog_test.go
+++ b/vault/plugincatalog/plugin_catalog_test.go
@@ -53,12 +53,14 @@ func testPluginCatalog(t *testing.T) *PluginCatalog {
 	pluginRuntimeCatalog := testPluginRuntimeCatalog(t)
 	pluginCatalog, err := SetupPluginCatalog(
 		context.Background(),
-		logger,
-		corehelpers.NewMockBuiltinRegistry(),
-		logical.NewLogicalStorage(storage),
-		testDir,
-		false,
-		pluginRuntimeCatalog,
+		&PluginCatalogInput{
+			Logger:               logger,
+			BuiltinRegistry:      corehelpers.NewMockBuiltinRegistry(),
+			CatalogView:          logical.NewLogicalStorage(storage),
+			PluginDirectory:      testDir,
+			EnableMlock:          false,
+			PluginRuntimeCatalog: pluginRuntimeCatalog,
+		},
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/vault/plugincatalog/plugin_runtime_catalog.go
+++ b/vault/plugincatalog/plugin_runtime_catalog.go
@@ -40,9 +40,7 @@ func SetupPluginRuntimeCatalog(ctx context.Context, logger log.Logger, catalogVi
 		logger:      logger,
 	}
 
-	if logger.IsInfo() {
-		logger.Info("successfully setup plugin runtime catalog")
-	}
+	logger.Info("successfully setup plugin runtime catalog")
 
 	return pluginRuntimeCatalog, nil
 }

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1430,6 +1430,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		coreConfig.MaxLeaseTTL = base.MaxLeaseTTL
 		coreConfig.CacheSize = base.CacheSize
 		coreConfig.PluginDirectory = base.PluginDirectory
+		coreConfig.PluginTmpdir = base.PluginTmpdir
 		coreConfig.Seal = base.Seal
 		coreConfig.UnwrapSeal = base.UnwrapSeal
 		coreConfig.DevToken = base.DevToken

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -130,6 +130,16 @@ to specify where the configuration is.
   allowed to be loaded. Vault must have permission to read files in this
   directory to successfully load plugins, and the value cannot be a symbolic link.
 
+- `plugin_tmpdir` `(string: "")` - A directory that Vault can create temporary
+  files in to support Unix socket communication with containerized plugins. If
+  not set, Vault will use the system's default directory for temporary files.
+  Generally not necessary unless you are using
+  [containerized plugins](/vault/docs/plugins/containerized-plugins) and Vault
+  does not share a temporary folder with other processes, such as if using
+  systemd's [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=)
+  setting. This can also be specified via the `VAULT_PLUGIN_TMPDIR` environment
+  variable.
+
   @include 'plugin-file-permissions-check.mdx'
 
 - `plugin_file_uid` `(integer: 0)` – Uid of the plugin directories and plugin binaries if they


### PR DESCRIPTION
To run containerized plugins under systemd with PrivateTmp=true, users need control over the tmpdir used for Unix sockets (see #23215). Previously we supported this solely with a `VAULT_PLUGIN_TMPDIR` env var, and this PR adds the option to the config file as well. As with other settings supported in config and env, the env takes precedence.