### PR TITLE
oidc/provider: adds code_challenge_methods_supported to metadata

### DIFF
--- a/changelog/24979.txt
+++ b/changelog/24979.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+oidc/provider: Adds `code_challenge_methods_supported` to OpenID Connect Metadata
+```

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -166,6 +166,7 @@ type providerDiscovery struct {
 	Subjects              []string `json:"subject_types_supported"`
 	GrantTypes            []string `json:"grant_types_supported"`
 	AuthMethods           []string `json:"token_endpoint_auth_methods_supported"`
+	CodeChallengeMethods  []string `json:"code_challenge_methods_supported"`
 }
 
 type authCodeCacheEntry struct {
@@ -1571,6 +1572,10 @@ func (i *IdentityStore) pathOIDCProviderDiscovery(ctx context.Context, req *logi
 			"none",
 			"client_secret_basic",
 			"client_secret_post",
+		},
+		CodeChallengeMethods: []string{
+			codeChallengeMethodPlain,
+			codeChallengeMethodS256,
 		},
 	}
 

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -3637,6 +3637,7 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		AuthMethods:           []string{"none", "client_secret_basic", "client_secret_post"},
 		RequestParameter:      false,
 		RequestURIParameter:   false,
+		CodeChallengeMethods:  []string{codeChallengeMethodPlain, codeChallengeMethodS256},
 	}
 	discoveryResp := &providerDiscovery{}
 	json.Unmarshal(resp.Data["http_raw_body"].([]byte), discoveryResp)
@@ -3693,6 +3694,7 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		AuthMethods:           []string{"none", "client_secret_basic", "client_secret_post"},
 		RequestParameter:      false,
 		RequestURIParameter:   false,
+		CodeChallengeMethods:  []string{codeChallengeMethodPlain, codeChallengeMethodS256},
 	}
 	discoveryResp = &providerDiscovery{}
 	json.Unmarshal(resp.Data["http_raw_body"].([]byte), discoveryResp)

--- a/website/content/api-docs/secret/identity/oidc-provider.mdx
+++ b/website/content/api-docs/secret/identity/oidc-provider.mdx
@@ -605,7 +605,12 @@ $ curl \
     "client_secret_basic",
     "client_secret_post",
     "none"
-  ]}
+  ],
+  "code_challenge_methods_supported": [
+    "plain",
+    "S256"
+  ]
+}
 ```
 
 ## Read provider public keys

--- a/website/content/docs/secrets/identity/oidc-provider.mdx
+++ b/website/content/docs/secrets/identity/oidc-provider.mdx
@@ -127,6 +127,10 @@ Any Vault auth method may be used within the OIDC flow. For simplicity, enable t
        "none",
        "client_secret_basic",
        "client_secret_post"
+     ],
+     "code_challenge_methods_supported": [
+       "plain",
+       "S256"
      ]
    }
    ```


### PR DESCRIPTION
This PR adds `code_challenge_methods_supported` to Vault OIDC provider [metadata](https://github.com/hashicorp/vault/issues/24854). See [rfc8414#section-2](https://datatracker.ietf.org/doc/html/rfc8414#section-2) for a description of the metadata value and [`code_challenge_method`](https://developer.hashicorp.com/vault/api-docs/secret/identity/oidc-provider#code_challenge_method) for the methods we accept.

Resolves: https://github.com/hashicorp/vault/issues/24854