### PR TITLE
UI: Add form inline warning

### DIFF
--- a/ui/app/styles/helper-classes/spacing.scss
+++ b/ui/app/styles/helper-classes/spacing.scss
@@ -98,6 +98,10 @@
   margin: $spacing-4 0;
 }
 
+.has-top-margin-negative-m {
+  margin-top: -$spacing-16;
+}
+
 .has-top-bottom-margin-negative-m {
   margin-top: -$spacing-16;
   margin-bottom: -$spacing-16;

--- a/ui/lib/config-ui/addon/components/messages/page/create-and-edit-message-form.hbs
+++ b/ui/lib/config-ui/addon/components/messages/page/create-and-edit-message-form.hbs
@@ -23,7 +23,6 @@
       </FormField>
       {{#if (eq attr.name "message")}}
         <Hds::Alert class="has-top-margin-negative-m has-bottom-margin-l" @type="compact" @color="highlight" as |A|>
-          <A.Title>Title here</A.Title>
           <A.Description>Note: Do not include sensitive info in this message since users are unauthenticated at this stage.</A.Description>
         </Hds::Alert>
       {{/if}}

--- a/ui/lib/config-ui/addon/components/messages/page/create-and-edit-message-form.hbs
+++ b/ui/lib/config-ui/addon/components/messages/page/create-and-edit-message-form.hbs
@@ -21,7 +21,7 @@
       <FormField @attr={{attr}} @model={{@message}} @modelValidations={{this.modelValidations}} class="has-bottom-margin-m">
         <Messages::MessageExpirationDateForm @message={{@message}} @attr={{attr}} />
       </FormField>
-      {{#if (eq attr.name "message")}}
+      {{#if (and (eq attr.name "message") (not @message.authenticated))}}
         <Hds::Alert class="has-top-margin-negative-m has-bottom-margin-l" @type="compact" @color="highlight" as |A|>
           <A.Description>Note: Do not include sensitive info in this message since users are unauthenticated at this stage.</A.Description>
         </Hds::Alert>

--- a/ui/lib/config-ui/addon/components/messages/page/create-and-edit-message-form.hbs
+++ b/ui/lib/config-ui/addon/components/messages/page/create-and-edit-message-form.hbs
@@ -21,6 +21,12 @@
       <FormField @attr={{attr}} @model={{@message}} @modelValidations={{this.modelValidations}} class="has-bottom-margin-m">
         <Messages::MessageExpirationDateForm @message={{@message}} @attr={{attr}} />
       </FormField>
+      {{#if (eq attr.name "message")}}
+        <Hds::Alert class="has-top-margin-negative-m has-bottom-margin-l" @type="compact" @color="highlight" as |A|>
+          <A.Title>Title here</A.Title>
+          <A.Description>Note: Do not include sensitive info in this message since users are unauthenticated at this stage.</A.Description>
+        </Hds::Alert>
+      {{/if}}
     {{/each}}
 
     <Hds::ButtonSet class="has-top-margin-s has-bottom-margin-m has-top-margin-xl">


### PR DESCRIPTION
**Description**
Add inline form info when user is creating a unauth message.
<img width="1111" alt="Screenshot 2024-01-22 at 2 05 51 PM" src="https://github.com/hashicorp/vault/assets/30884335/f7a56476-0e88-408e-bef2-6af4e581db18">
