### PR TITLE
Apply default MaxConnsPerHost in agent even if template_config block …

### DIFF
--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -1106,6 +1106,9 @@ func parseTemplateConfig(result *Config, list *ast.ObjectList) error {
 
 	templateConfigList := list.Filter(name)
 	if len(templateConfigList.Items) == 0 {
+		result.TemplateConfig = &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		}
 		return nil
 	}
 

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -92,6 +92,9 @@ func TestLoadConfigFile_AgentCache(t *testing.T) {
 				ServiceAccountTokenFile: "/tmp/serviceaccount/token",
 			},
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 		Vault: &Vault{
 			Address:          "http://127.0.0.1:1111",
 			CACert:           "config_ca_cert",
@@ -197,6 +200,9 @@ func TestLoadConfigDir_AgentCache(t *testing.T) {
 				ServiceAccountTokenFile: "/tmp/serviceaccount/token",
 			},
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 		Vault: &Vault{
 			Address:          "http://127.0.0.1:1111",
 			CACert:           "config_ca_cert",
@@ -267,6 +273,9 @@ func TestLoadConfigDir_AutoAuthAndListener(t *testing.T) {
 				},
 			},
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 	}
 
 	config.Prune()
@@ -329,6 +338,9 @@ func TestLoadConfigDir_VaultBlock(t *testing.T) {
 					},
 				},
 			},
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 	}
 
@@ -396,6 +408,9 @@ func TestLoadConfigFile_AgentCache_NoListeners(t *testing.T) {
 				ExitOnErr:               true,
 				ServiceAccountTokenFile: "/tmp/serviceaccount/token",
 			},
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 		Vault: &Vault{
 			Address:          "http://127.0.0.1:1111",
@@ -476,6 +491,9 @@ func TestLoadConfigFile(t *testing.T) {
 				},
 			},
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 	}
 
 	config.Prune()
@@ -524,6 +542,9 @@ func TestLoadConfigFile_Method_Wrapping(t *testing.T) {
 				},
 			},
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 	}
 
 	config.Prune()
@@ -562,6 +583,9 @@ func TestLoadConfigFile_Method_InitialBackoff(t *testing.T) {
 					},
 				},
 			},
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 	}
 
@@ -602,6 +626,9 @@ func TestLoadConfigFile_Method_ExitOnErr(t *testing.T) {
 				},
 			},
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 	}
 
 	config.Prune()
@@ -627,6 +654,9 @@ func TestLoadConfigFile_AgentCache_NoAutoAuth(t *testing.T) {
 					TLSDisable: true,
 				},
 			},
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 	}
 
@@ -762,6 +792,9 @@ func TestLoadConfigFile_AgentCache_AutoAuth_NoSink(t *testing.T) {
 			UseAutoAuthTokenRaw: true,
 			ForceAutoAuthToken:  false,
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 	}
 
 	config.Prune()
@@ -804,6 +837,9 @@ func TestLoadConfigFile_AgentCache_AutoAuth_Force(t *testing.T) {
 			UseAutoAuthToken:    true,
 			UseAutoAuthTokenRaw: "force",
 			ForceAutoAuthToken:  true,
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 	}
 
@@ -848,6 +884,9 @@ func TestLoadConfigFile_AgentCache_AutoAuth_True(t *testing.T) {
 			UseAutoAuthTokenRaw: "true",
 			ForceAutoAuthToken:  false,
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 	}
 
 	config.Prune()
@@ -888,6 +927,9 @@ func TestLoadConfigFile_Agent_AutoAuth_APIProxyAllConfig(t *testing.T) {
 			ForceAutoAuthToken:  true,
 			EnforceConsistency:  "always",
 			WhenInconsistent:    "forward",
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 	}
 
@@ -939,6 +981,9 @@ func TestLoadConfigFile_AgentCache_AutoAuth_False(t *testing.T) {
 			UseAutoAuthTokenRaw: "false",
 			ForceAutoAuthToken:  false,
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 	}
 
 	config.Prune()
@@ -973,6 +1018,9 @@ func TestLoadConfigFile_AgentCache_Persist(t *testing.T) {
 				},
 			},
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 	}
 
 	config.Prune()
@@ -1005,6 +1053,12 @@ func TestLoadConfigFile_TemplateConfig(t *testing.T) {
 			"./test-fixtures/config-template_config-empty.hcl",
 			TemplateConfig{
 				ExitOnRetryFailure:    false,
+				MaxConnectionsPerHost: 10,
+			},
+		},
+		"missing": {
+			"./test-fixtures/config-template_config-missing.hcl",
+			TemplateConfig{
 				MaxConnectionsPerHost: 10,
 			},
 		},
@@ -1141,6 +1195,9 @@ func TestLoadConfigFile_Template(t *testing.T) {
 						},
 					},
 				},
+				TemplateConfig: &TemplateConfig{
+					MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+				},
 				Templates: tc.expectedTemplates,
 			}
 
@@ -1237,6 +1294,9 @@ func TestLoadConfigFile_Template_NoSinks(t *testing.T) {
 					},
 					Sinks: nil,
 				},
+				TemplateConfig: &TemplateConfig{
+					MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+				},
 				Templates: tc.expectedTemplates,
 			}
 
@@ -1271,6 +1331,9 @@ func TestLoadConfigFile_Template_WithCache(t *testing.T) {
 			},
 		},
 		Cache: &Cache{},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 		Templates: []*ctconfig.TemplateConfig{
 			{
 				Source:      pointerutil.StringPtr("/path/on/disk/to/template.ctmpl"),
@@ -1315,6 +1378,9 @@ func TestLoadConfigFile_Vault_Retry(t *testing.T) {
 					},
 				},
 			},
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
@@ -1361,6 +1427,9 @@ func TestLoadConfigFile_Vault_Retry_Empty(t *testing.T) {
 				},
 			},
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
 			Retry: &Retry{
@@ -1396,6 +1465,9 @@ func TestLoadConfigFile_EnforceConsistency(t *testing.T) {
 			EnforceConsistency: "always",
 			WhenInconsistent:   "retry",
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 	}
 
 	config.Prune()
@@ -1424,6 +1496,9 @@ func TestLoadConfigFile_EnforceConsistency_APIProxy(t *testing.T) {
 		APIProxy: &APIProxy{
 			EnforceConsistency: "always",
 			WhenInconsistent:   "retry",
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 	}
 
@@ -1467,6 +1542,9 @@ func TestLoadConfigFile_Disable_Idle_Conns_All(t *testing.T) {
 					},
 				},
 			},
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
@@ -1517,6 +1595,9 @@ func TestLoadConfigFile_Disable_Idle_Conns_Auto_Auth(t *testing.T) {
 				},
 			},
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
 			Retry: &Retry{
@@ -1565,6 +1646,9 @@ func TestLoadConfigFile_Disable_Idle_Conns_Templating(t *testing.T) {
 					},
 				},
 			},
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
@@ -1615,6 +1699,9 @@ func TestLoadConfigFile_Disable_Idle_Conns_Caching(t *testing.T) {
 				},
 			},
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
 			Retry: &Retry{
@@ -1664,6 +1751,9 @@ func TestLoadConfigFile_Disable_Idle_Conns_Proxying(t *testing.T) {
 				},
 			},
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
 			Retry: &Retry{
@@ -1712,6 +1802,9 @@ func TestLoadConfigFile_Disable_Idle_Conns_Empty(t *testing.T) {
 					},
 				},
 			},
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
@@ -1767,6 +1860,9 @@ func TestLoadConfigFile_Disable_Idle_Conns_Env(t *testing.T) {
 					},
 				},
 			},
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
@@ -1824,6 +1920,9 @@ func TestLoadConfigFile_Disable_Keep_Alives_All(t *testing.T) {
 				},
 			},
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
 			Retry: &Retry{
@@ -1872,6 +1971,9 @@ func TestLoadConfigFile_Disable_Keep_Alives_Auto_Auth(t *testing.T) {
 					},
 				},
 			},
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
@@ -1922,6 +2024,9 @@ func TestLoadConfigFile_Disable_Keep_Alives_Templating(t *testing.T) {
 				},
 			},
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
 			Retry: &Retry{
@@ -1970,6 +2075,9 @@ func TestLoadConfigFile_Disable_Keep_Alives_Caching(t *testing.T) {
 					},
 				},
 			},
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
@@ -2020,6 +2128,9 @@ func TestLoadConfigFile_Disable_Keep_Alives_Proxying(t *testing.T) {
 				},
 			},
 		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
 			Retry: &Retry{
@@ -2068,6 +2179,9 @@ func TestLoadConfigFile_Disable_Keep_Alives_Empty(t *testing.T) {
 					},
 				},
 			},
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
@@ -2123,6 +2237,9 @@ func TestLoadConfigFile_Disable_Keep_Alives_Env(t *testing.T) {
 					},
 				},
 			},
+		},
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
 		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",

--- a/command/agent/config/test-fixtures/config-template_config-missing.hcl
+++ b/command/agent/config/test-fixtures/config-template_config-missing.hcl
@@ -1,0 +1,14 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+vault {
+  address = "http://127.0.0.1:1111"
+  retry {
+    num_retries = 5
+  }
+}
+
+template {
+  source      = "/path/on/disk/to/template.ctmpl"
+  destination = "/path/on/disk/where/template/will/render.txt"
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/vault/issues/24988.  

This PR changes Vault-agent configuration parsing so that it returns a `TemplateConfig` with a `MaxConnsPerHost` set to the default when the `template_config` template block is missing.  Previously (https://github.com/hashicorp/vault/pull/24548) if that block was missing entirely, Vault agent would fail to use the intended default.  

Includes a test of the new behavior.