### PR TITLE
Add support for larger transactions in Raft

### DIFF
--- a/physical/consul/consul_test.go
+++ b/physical/consul/consul_test.go
@@ -159,6 +159,10 @@ func TestConsul_newConsulBackend(t *testing.T) {
 		// if test.max_parallel != cap(c.permitPool) {
 		// 	t.Errorf("bad: %v != %v", test.max_parallel, cap(c.permitPool))
 		// }
+
+		maxEntries, maxBytes := be.(physical.TransactionalLimits).TransactionLimits()
+		require.Equal(t, 63, maxEntries)
+		require.Equal(t, 128*1024, maxBytes)
 	}
 }
 

--- a/physical/raft/raft_test.go
+++ b/physical/raft/raft_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/hashicorp/vault/sdk/physical"
+	"github.com/stretchr/testify/require"
 )
 
 func connectPeers(nodes ...*RaftBackend) {
@@ -632,6 +633,86 @@ func TestRaft_TransactionalBackend_ThreeNode(t *testing.T) {
 	// Make sure all stores are the same
 	compareFSMs(t, raft1.fsm, raft2.fsm)
 	compareFSMs(t, raft1.fsm, raft3.fsm)
+}
+
+func TestRaft_TransactionalLimitsEnvOverride(t *testing.T) {
+	tc := []struct {
+		name        string
+		envEntries  string
+		envSize     string
+		wantEntries int
+		wantSize    int
+		wantLog     string
+	}{
+		{
+			name:        "defaults",
+			wantEntries: defaultMaxBatchEntries,
+			wantSize:    defaultMaxBatchSize,
+		},
+		{
+			name:        "valid env",
+			envEntries:  "123",
+			envSize:     "456",
+			wantEntries: 123,
+			wantSize:    456,
+		},
+		{
+			name:        "invalid entries",
+			envEntries:  "not-a-number",
+			envSize:     "100",
+			wantEntries: defaultMaxBatchEntries,
+			wantSize:    100,
+			wantLog:     "failed to parse VAULT_RAFT_MAX_BATCH_ENTRIES",
+		},
+		{
+			name:        "invalid entries",
+			envEntries:  "100",
+			envSize:     "asdasdsasd",
+			wantEntries: 100,
+			wantSize:    defaultMaxBatchSize,
+			wantLog:     "failed to parse VAULT_RAFT_MAX_BATCH_SIZE_BYTES",
+		},
+		{
+			name:        "zero entries",
+			envEntries:  "0",
+			envSize:     "100",
+			wantEntries: defaultMaxBatchEntries,
+			wantSize:    100,
+			wantLog:     "failed to parse VAULT_RAFT_MAX_BATCH_ENTRIES as an integer > 0",
+		},
+		{
+			name:        "zero size",
+			envEntries:  "100",
+			envSize:     "0",
+			wantEntries: 100,
+			wantSize:    defaultMaxBatchSize,
+			wantLog:     "failed to parse VAULT_RAFT_MAX_BATCH_SIZE_BYTES as an integer > 0",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set the env vars within this test
+			if tt.envEntries != "" {
+				t.Setenv(EnvVaultRaftMaxBatchEntries, tt.envEntries)
+			}
+			if tt.envSize != "" {
+				t.Setenv(EnvVaultRaftMaxBatchSizeBytes, tt.envSize)
+			}
+
+			var logBuf bytes.Buffer
+			raft1, dir := GetRaftWithLogOutput(t, false, true, &logBuf)
+			defer os.RemoveAll(dir)
+
+			e, s := raft1.TransactionLimits()
+
+			require.Equal(t, tt.wantEntries, e)
+			require.Equal(t, tt.wantSize, s)
+			if tt.wantLog != "" {
+				require.Contains(t, logBuf.String(), tt.wantLog)
+			}
+		})
+	}
 }
 
 func TestRaft_Backend_Performance(t *testing.T) {

--- a/sdk/physical/cache.go
+++ b/sdk/physical/cache.go
@@ -86,6 +86,7 @@ var (
 	_ ToggleablePurgemonster = (*TransactionalCache)(nil)
 	_ Backend                = (*Cache)(nil)
 	_ Transactional          = (*TransactionalCache)(nil)
+	_ TransactionalLimits    = (*TransactionalCache)(nil)
 )
 
 // NewCache returns a physical cache of the given size.
@@ -270,4 +271,15 @@ func (c *TransactionalCache) Transaction(ctx context.Context, txns []*TxnEntry) 
 	}
 
 	return nil
+}
+
+// TransactionLimits implements physical.TransactionalLimits
+func (c *TransactionalCache) TransactionLimits() (int, int) {
+	if tl, ok := c.Transactional.(TransactionalLimits); ok {
+		return tl.TransactionLimits()
+	}
+	// We don't have any specific limits of our own so return zeros to signal that
+	// the caller should use whatever reasonable defaults it would if it used a
+	// non-TransactionalLimits backend.
+	return 0, 0
 }

--- a/sdk/physical/cache_test.go
+++ b/sdk/physical/cache_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package physical
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransactionalCache_TransactionLimits(t *testing.T) {
+	tc := []struct {
+		name        string
+		be          Backend
+		wantEntries int
+		wantSize    int
+	}{
+		{
+			name: "non-transactionlimits backend",
+			be:   &TestTransactionalNonLimitBackend{},
+
+			// Should return zeros to let the implementor choose defaults.
+			wantEntries: 0,
+			wantSize:    0,
+		},
+		{
+			name: "transactionlimits backend",
+			be: &TestTransactionalLimitBackend{
+				MaxEntries: 123,
+				MaxSize:    345,
+			},
+
+			// Should return underlying limits
+			wantEntries: 123,
+			wantSize:    345,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := hclog.NewNullLogger()
+
+			be := NewTransactionalCache(tt.be, 1024, logger, nil)
+
+			// Call the TransactionLimits method
+			maxEntries, maxBytes := be.TransactionLimits()
+
+			require.Equal(t, tt.wantEntries, maxEntries)
+			require.Equal(t, tt.wantSize, maxBytes)
+		})
+	}
+}

--- a/sdk/physical/encoding.go
+++ b/sdk/physical/encoding.go
@@ -98,6 +98,17 @@ func (e *TransactionalStorageEncoding) Transaction(ctx context.Context, txns []*
 	return e.Transactional.Transaction(ctx, txns)
 }
 
+// TransactionLimits implements physical.TransactionalLimits
+func (e *TransactionalStorageEncoding) TransactionLimits() (int, int) {
+	if tl, ok := e.Transactional.(TransactionalLimits); ok {
+		return tl.TransactionLimits()
+	}
+	// We don't have any specific limits of our own so return zeros to signal that
+	// the caller should use whatever reasonable defaults it would if it used a
+	// non-TransactionalLimits backend.
+	return 0, 0
+}
+
 func (e *StorageEncoding) Purge(ctx context.Context) {
 	if purgeable, ok := e.Backend.(ToggleablePurgemonster); ok {
 		purgeable.Purge(ctx)

--- a/sdk/physical/encoding_test.go
+++ b/sdk/physical/encoding_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package physical
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransactionalStorageEncoding_TransactionLimits(t *testing.T) {
+	tc := []struct {
+		name        string
+		be          Backend
+		wantEntries int
+		wantSize    int
+	}{
+		{
+			name: "non-transactionlimits backend",
+			be:   &TestTransactionalNonLimitBackend{},
+
+			// Should return zeros to let the implementor choose defaults.
+			wantEntries: 0,
+			wantSize:    0,
+		},
+		{
+			name: "transactionlimits backend",
+			be: &TestTransactionalLimitBackend{
+				MaxEntries: 123,
+				MaxSize:    345,
+			},
+
+			// Should return underlying limits
+			wantEntries: 123,
+			wantSize:    345,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			be := NewStorageEncoding(tt.be).(TransactionalLimits)
+
+			// Call the TransactionLimits method
+			maxEntries, maxBytes := be.TransactionLimits()
+
+			require.Equal(t, tt.wantEntries, maxEntries)
+			require.Equal(t, tt.wantSize, maxBytes)
+		})
+	}
+}

--- a/sdk/physical/error.go
+++ b/sdk/physical/error.go
@@ -111,3 +111,14 @@ func (e *TransactionalErrorInjector) Transaction(ctx context.Context, txns []*Tx
 	}
 	return e.Transactional.Transaction(ctx, txns)
 }
+
+// TransactionLimits implements physical.TransactionalLimits
+func (e *TransactionalErrorInjector) TransactionLimits() (int, int) {
+	if tl, ok := e.Transactional.(TransactionalLimits); ok {
+		return tl.TransactionLimits()
+	}
+	// We don't have any specific limits of our own so return zeros to signal that
+	// the caller should use whatever reasonable defaults it would if it used a
+	// non-TransactionalLimits backend.
+	return 0, 0
+}

--- a/sdk/physical/error_test.go
+++ b/sdk/physical/error_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package physical
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransactionalErrorInjector_TransactionLimits(t *testing.T) {
+	tc := []struct {
+		name        string
+		be          Backend
+		wantEntries int
+		wantSize    int
+	}{
+		{
+			name: "non-transactionlimits backend",
+			be:   &TestTransactionalNonLimitBackend{},
+
+			// Should return zeros to let the implementor choose defaults.
+			wantEntries: 0,
+			wantSize:    0,
+		},
+		{
+			name: "transactionlimits backend",
+			be: &TestTransactionalLimitBackend{
+				MaxEntries: 123,
+				MaxSize:    345,
+			},
+
+			// Should return underlying limits
+			wantEntries: 123,
+			wantSize:    345,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := hclog.NewNullLogger()
+
+			injector := NewTransactionalErrorInjector(tt.be, 0, logger)
+
+			maxEntries, maxBytes := injector.TransactionLimits()
+
+			require.Equal(t, tt.wantEntries, maxEntries)
+			require.Equal(t, tt.wantSize, maxBytes)
+		})
+	}
+}

--- a/sdk/physical/latency.go
+++ b/sdk/physical/latency.go
@@ -117,3 +117,14 @@ func (l *TransactionalLatencyInjector) Transaction(ctx context.Context, txns []*
 	l.addLatency()
 	return l.Transactional.Transaction(ctx, txns)
 }
+
+// TransactionLimits implements physical.TransactionalLimits
+func (l *TransactionalLatencyInjector) TransactionLimits() (int, int) {
+	if tl, ok := l.Transactional.(TransactionalLimits); ok {
+		return tl.TransactionLimits()
+	}
+	// We don't have any specific limits of our own so return zeros to signal that
+	// the caller should use whatever reasonable defaults it would if it used a
+	// non-TransactionalLimits backend.
+	return 0, 0
+}

--- a/sdk/physical/latency_test.go
+++ b/sdk/physical/latency_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package physical
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransactionalLatencyInjector_TransactionLimits(t *testing.T) {
+	tc := []struct {
+		name        string
+		be          Backend
+		wantEntries int
+		wantSize    int
+	}{
+		{
+			name: "non-transactionlimits backend",
+			be:   &TestTransactionalNonLimitBackend{},
+
+			// Should return zeros to let the implementor choose defaults.
+			wantEntries: 0,
+			wantSize:    0,
+		},
+		{
+			name: "transactionlimits backend",
+			be: &TestTransactionalLimitBackend{
+				MaxEntries: 123,
+				MaxSize:    345,
+			},
+
+			// Should return underlying limits
+			wantEntries: 123,
+			wantSize:    345,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := hclog.NewNullLogger()
+
+			injector := NewTransactionalLatencyInjector(tt.be, 0, 0, logger)
+
+			maxEntries, maxBytes := injector.TransactionLimits()
+
+			require.Equal(t, tt.wantEntries, maxEntries)
+			require.Equal(t, tt.wantSize, maxBytes)
+		})
+	}
+}

--- a/sdk/physical/testing.go
+++ b/sdk/physical/testing.go
@@ -518,3 +518,43 @@ func SetupTestingTransactions(t testing.TB, b Backend) []*TxnEntry {
 
 	return txns
 }
+
+// Several tests across packages have to test logic with a few variations of
+// transactional backends. Make some suitable for testing limits support that
+// can be re-used.
+
+type TestTransactionalNonLimitBackend struct{}
+
+var _ Transactional = (*TestTransactionalNonLimitBackend)(nil)
+
+func (b *TestTransactionalNonLimitBackend) Put(ctx context.Context, entry *Entry) error {
+	return nil
+}
+
+func (b *TestTransactionalNonLimitBackend) Get(ctx context.Context, key string) (*Entry, error) {
+	return nil, nil
+}
+
+func (b *TestTransactionalNonLimitBackend) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (b *TestTransactionalNonLimitBackend) List(ctx context.Context, prefix string) ([]string, error) {
+	return nil, nil
+}
+
+func (b *TestTransactionalNonLimitBackend) Transaction(ctx context.Context, txns []*TxnEntry) error {
+	return nil
+}
+
+type TestTransactionalLimitBackend struct {
+	TestTransactionalNonLimitBackend
+
+	MaxEntries, MaxSize int
+}
+
+var _ TransactionalLimits = (*TestTransactionalLimitBackend)(nil)
+
+func (b *TestTransactionalLimitBackend) TransactionLimits() (int, int) {
+	return b.MaxEntries, b.MaxSize
+}


### PR DESCRIPTION
This is the OSS version of an already-approved change in Vault Enterprise.

It allows different Transactional Storage backends to advertise their own transaction size limits rather than assuming Consul's limits for everything. In practice this means that our Raft-based internal storage can accept larger transactions which can improve performance in Vault Enterprise which uses the transactional interface extensively for writes.