### PR TITLE
Install gotestsum as well as check for it

### DIFF
--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -43,6 +43,7 @@ install_external() {
     golang.org/x/tools/cmd/goimports@latest
     google.golang.org/protobuf/cmd/protoc-gen-go@latest
     google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+    gotest.tools/gotestsum@latest
     honnef.co/go/tools/cmd/staticcheck@latest
     mvdan.cc/gofumpt@latest
   )


### PR DESCRIPTION
I hit an issue where running linter locally failed because `tools.sh` was checking for existence of `gotestsum` and recommending `make external-tools` to fix, but `make external-tools` didn't actually install `gotestsum`.

It's possible there was a reason for this I don't know but this change fixed things locally so that `make external-tools` actually installed gotestsum and make the checker pass again.