### PR TITLE
Docs: add undo logs section in upgrade to 1.13.x

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -17,7 +17,7 @@ for Vault 1.13.x compared to 1.12. Please read it carefully.
 
 ### Undo logs
 
-Vault 1.13 introduced changes to add extra resiliency to log shipping with undo logs. These logs can help prevent several Merkle syncs from occurring due to rapid key changes in the primary Merkle tree as the secondary tries to synchronize. For integrated storage users, upgrading to 1.13 will enable this feature by default. For Consul storage users, Consul also needs upgrading to 1.14 to use this feature.
+Vault 1.13 introduced changes to add extra resiliency to log shipping with undo logs. These logs can help prevent several Merkle syncs from occurring due to rapid key changes in the primary Merkle tree as the secondary tries to synchronize. For integrated storage users, Vault needs to be upgraded to 1.13 will enable this feature by default. For Consul storage users, Consul also needs to be upgraded to 1.14 to use this feature.
 
 ### User lockout
 

--- a/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.13.x.mdx
@@ -15,6 +15,10 @@ for Vault 1.13.x compared to 1.12. Please read it carefully.
 
 @include 'consul-dataplane-upgrade-note.mdx'
 
+### Undo logs
+
+Vault 1.13 introduced changes to add extra resiliency to log shipping with undo logs. These logs can help prevent several Merkle syncs from occurring due to rapid key changes in the primary Merkle tree as the secondary tries to synchronize. For integrated storage users, upgrading to 1.13 will enable this feature by default. For Consul storage users, Consul also needs upgrading to 1.14 to use this feature.
+
 ### User lockout
 
 As of version 1.13, Vault will stop trying to validate user credentials if the


### PR DESCRIPTION
This is a minor update to add a section about undo logs, and upgrade details which include Consul storage users.
