### PR TITLE
Allow Dashboard's QA card to search for nested KVv2 secrets

### DIFF
--- a/changelog/25001.txt
+++ b/changelog/25001.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Allows users to search within KV v2 directories from the Dashboard's quick action card.
+```

--- a/ui/app/templates/components/dashboard/quick-actions-card.hbs
+++ b/ui/app/templates/components/dashboard/quick-actions-card.hbs
@@ -38,27 +38,35 @@
         @noDefault={{true}}
         @ariaLabel="Action"
       />
-
       {{#if this.searchSelectParams.model}}
-        <h4 class="title is-6" data-test-card-subtitle="param">{{this.searchSelectParams.title}}</h4>
+        {{! use special input to allow searching secrets inside directories }}
+        {{#if (eq this.selectedEngine.type "kv")}}
+          <KvSuggestionInput
+            @label="Secret Path"
+            @value={{this.paramValue}}
+            @mountPath={{this.selectedEngine.id}}
+            @onChange={{fn (mut this.paramValue)}}
+          />
+        {{else}}
+          <h4 class="title is-6" data-test-card-subtitle="param">{{this.searchSelectParams.title}}</h4>
 
-        <SearchSelect
-          class="is-flex-grow-1"
-          @selectLimit="1"
-          @models={{array this.searchSelectParams.model}}
-          @placeholder={{this.searchSelectParams.placeholder}}
-          @disallowNewItems={{true}}
-          @onChange={{this.handleActionSelect}}
-          @fallbackComponent="input-search"
-          @disabled={{not this.searchSelectParams.model}}
-          @nameKey={{this.searchSelectParams.nameKey}}
-          @queryObject={{this.searchSelectParams.queryObject}}
-          @objectKeys={{this.searchSelectParams.objectKeys}}
-          @passObject={{true}}
-          @shouldRenderName={{this.searchSelectParams.nameKey}}
-          data-test-search-select="params"
-        />
-
+          <SearchSelect
+            class="is-flex-grow-1"
+            @selectLimit="1"
+            @models={{array this.searchSelectParams.model}}
+            @placeholder={{this.searchSelectParams.placeholder}}
+            @disallowNewItems={{true}}
+            @onChange={{this.handleActionSelect}}
+            @fallbackComponent="input-search"
+            @disabled={{not this.searchSelectParams.model}}
+            @nameKey={{this.searchSelectParams.nameKey}}
+            @queryObject={{this.searchSelectParams.queryObject}}
+            @objectKeys={{this.searchSelectParams.objectKeys}}
+            @passObject={{true}}
+            @shouldRenderName={{this.searchSelectParams.nameKey}}
+            data-test-search-select="params"
+          />
+        {{/if}}
         <div>
           <Hds::Button
             @text={{this.searchSelectParams.buttonText}}

--- a/ui/app/templates/components/dashboard/quick-actions-card.hbs
+++ b/ui/app/templates/components/dashboard/quick-actions-card.hbs
@@ -38,8 +38,9 @@
         @noDefault={{true}}
         @ariaLabel="Action"
       />
+
       {{#if this.searchSelectParams.model}}
-        {{! use special input to allow searching secrets inside directories }}
+        {{! use special input to allow searching for KVv2 secrets inside a directory }}
         {{#if (eq this.selectedEngine.type "kv")}}
           <KvSuggestionInput
             @label="Secret Path"

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -337,7 +337,6 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await settled();
       await visit('/vault/dashboard');
       await click('[data-test-component="search-select"] .ember-basic-dropdown-trigger');
-      assert.dom('.ember-power-select-option').hasTextContaining('kv', 'dropdown shows KV v2 mount');
       assert
         .dom('.ember-power-select-option')
         .doesNotHaveTextContaining('kv1', 'dropdown does not show kv1 mount');

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -330,16 +330,16 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await consoleComponent.runCommands(deleteEngineCmd(databaseBackend));
     });
 
-    test('shows the correct actions and links associated with kv v1', async function (assert) {
-      await runCommands(['write sys/mounts/kv type=kv', 'write kv/foo bar=baz']);
+    test('does not show kv1 mounts', async function (assert) {
+      await runCommands(['write sys/mounts/kv1 type=kv', 'write kv1/foo bar=baz']);
       await settled();
       await visit('/vault/dashboard');
-      await selectChoose(SELECTORS.searchSelect('secrets-engines'), 'kv');
-      await fillIn(SELECTORS.selectEl, 'Find KV secrets');
-      assert.dom(SELECTORS.emptyState('quick-actions')).doesNotExist();
-      assert.dom(SELECTORS.subtitle('param')).hasText('Secret path');
-      assert.dom(SELECTORS.actionButton('Read secrets')).exists({ count: 1 });
-      await consoleComponent.runCommands(deleteEngineCmd('kv'));
+      await click('[data-test-component="search-select"] .ember-basic-dropdown-trigger');
+      assert.dom('.ember-power-select-option').hasTextContaining('kv', 'dropdown shows kv2 mount');
+      assert
+        .dom('.ember-power-select-option')
+        .doesNotHaveTextContaining('kv1', 'dropdown does not show kv1 mount');
+      await consoleComponent.runCommands(deleteEngineCmd('kv1'));
     });
   });
 

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -331,11 +331,13 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
 
     test('does not show kv1 mounts', async function (assert) {
-      await runCommands(['write sys/mounts/kv1 type=kv', 'write kv1/foo bar=baz']);
+      // delete before in case you are rerunning the test and it fails without deleting
+      await consoleComponent.runCommands(deleteEngineCmd('kv1'));
+      await consoleComponent.runCommands([`write sys/mounts/kv1 type=kv`]);
       await settled();
       await visit('/vault/dashboard');
       await click('[data-test-component="search-select"] .ember-basic-dropdown-trigger');
-      assert.dom('.ember-power-select-option').hasTextContaining('kv', 'dropdown shows kv2 mount');
+      assert.dom('.ember-power-select-option').hasTextContaining('kv', 'dropdown shows KV v2 mount');
       assert
         .dom('.ember-power-select-option')
         .doesNotHaveTextContaining('kv1', 'dropdown does not show kv1 mount');

--- a/ui/tests/helpers/components/dashboard/dashboard-selectors.js
+++ b/ui/tests/helpers/components/dashboard/dashboard-selectors.js
@@ -12,6 +12,7 @@ export const SELECTORS = {
   cardHeader: (name) => `[data-test-dashboard-card-header="${name}"]`,
   tableRow: (name) => `[data-test-dashboard-table="${name}"] tr`,
   searchSelect: (name) => `[data-test-search-select="${name}"]`,
+  kvSearchSelect: `[data-test-kv-suggestion-input]`,
   actionButton: (action) => `[data-test-button="${action}"]`,
   title: (name) => `[data-test-title="${name}"]`,
   subtitle: (name) => `[data-test-card-subtitle="${name}"]`,

--- a/ui/tests/integration/components/dashboard/quick-actions-card-test.js
+++ b/ui/tests/integration/components/dashboard/quick-actions-card-test.js
@@ -143,7 +143,7 @@ module('Integration | Component | dashboard/quick-actions-card', function (hooks
     await selectChoose(SELECTORS.searchSelect('secrets-engines'), 'kv-v2-test');
     assert.dom(SELECTORS.emptyState('quick-actions')).doesNotExist();
     await fillIn(SELECTORS.selectEl, 'Find KV secrets');
-    assert.dom(SELECTORS.subtitle('param')).hasText('Secret path');
+    assert.dom(SELECTORS.kvSearchSelect).exists('Shows option to search fo KVv2 secret');
     assert.dom(SELECTORS.actionButton('Read secrets')).exists({ count: 1 });
   });
 });

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupEngine } from 'ember-engines/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { render, click, settled, waitFor } from '@ember/test-helpers';
+import { render, click, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import syncScenario from 'vault/mirage/scenarios/sync';
 import syncHandlers from 'vault/mirage/handlers/sync';
@@ -114,8 +114,6 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     assert.dom(name(0)).hasText('destination-aws', 'First destination renders on page 1');
 
     await click(pagination.next);
-    // eslint-disable-next-line ember/no-settled-after-test-helper
-    await settled();
     assert.dom(overview.table.row).exists({ count: 3 }, 'New items are fetched and rendered on page change');
     assert.dom(name(0)).hasText('destination-gcp', 'First destination renders on page 2');
   });
@@ -126,7 +124,6 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     });
     // since the request resolved trigger a page change and return an error from the associations endpoint
     await click(pagination.next);
-    await waitFor('[data-test-empty-state-title]', { timeout: 5000 });
     assert.dom(emptyStateTitle).hasText('Error fetching information', 'Empty state title renders');
     assert
       .dom(emptyStateMessage)

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupEngine } from 'ember-engines/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { render, click, settled } from '@ember/test-helpers';
+import { render, click, settled, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import syncScenario from 'vault/mirage/scenarios/sync';
 import syncHandlers from 'vault/mirage/handlers/sync';
@@ -114,6 +114,8 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     assert.dom(name(0)).hasText('destination-aws', 'First destination renders on page 1');
 
     await click(pagination.next);
+    // eslint-disable-next-line ember/no-settled-after-test-helper
+    await settled();
     assert.dom(overview.table.row).exists({ count: 3 }, 'New items are fetched and rendered on page change');
     assert.dom(name(0)).hasText('destination-gcp', 'First destination renders on page 2');
   });
@@ -124,6 +126,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     });
     // since the request resolved trigger a page change and return an error from the associations endpoint
     await click(pagination.next);
+    await waitFor('[data-test-empty-state-title]', { timeout: 5000 });
     assert.dom(emptyStateTitle).hasText('Error fetching information', 'Empty state title renders');
     assert
       .dom(emptyStateMessage)


### PR DESCRIPTION
In the Secret Sync feature work a new component was added to solve the same issue of being unable to search within directories using the Search Select component. I added this new component to the dashboard.
 
Fixes Issue[ #23979](https://github.com/hashicorp/vault/issues/23979).

https://github.com/hashicorp/vault/assets/6618863/6c9096da-2211-4249-940e-87a8e571a67a

Note: this cannot be backported because the new component only exists as of 1.16.0

- [x] Locally Enterprise tests pass