### PR TITLE
[Rotate Root POC] Fix Check Queue logic

### DIFF
--- a/vault/rotation.go
+++ b/vault/rotation.go
@@ -120,8 +120,6 @@ func (rm *RotationManager) CheckQueue() error {
 
 		re = entry
 
-		// TODO should we push the credential back into the queue if it is not in the rotation window?
-		// if not in window, do we check the next credential?
 		if !logical.DefaultScheduler.IsInsideRotationWindow(re.RootCredential.Schedule, now) {
 			rm.logger.Debug("Not inside rotation window, pushing back to queue")
 			err := rm.queue.Push(i)
@@ -130,7 +128,8 @@ func (rm *RotationManager) CheckQueue() error {
 				// errors on malformed items, which shouldn't be possible here
 				return err
 			}
-			break
+			// don't break here, since the heap is keyed on priority, which is just timestamp.
+			// it's possible for a later item to be ready for rotation, so we need to keep going
 		}
 		rm.logger.Debug("Item ready for rotation; making rotation request to sdk/backend")
 		// do rotation


### PR DESCRIPTION
this changes the check queue loop so that out-of-window credentials don't terminate the looping.

in the following scenario:
1) time 12:00AM, window 1 minute
2) time 12:00AM, window 2 minutes

if the queue gets checked at 12:01AM, then the first item needs to not break the loop, since the second item is still ready to rotate.