### PR TITLE
UI: Stabilize text-file test

### DIFF
--- a/ui/lib/core/addon/components/text-file.js
+++ b/ui/lib/core/addon/components/text-file.js
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { guidFor } from '@ember/object/internals';
+import { buildWaiter } from '@ember/test-waiters';
 /**
  * @module TextFile
  * `TextFile` components render a file upload input with the option to toggle a "Enter as text" button
@@ -26,6 +27,8 @@ import { guidFor } from '@ember/object/internals';
  * @param {string} [label='File']  - Text to use as the label for the file input. If none, default of 'File' is rendered
  */
 
+const waiter = buildWaiter('text-file');
+
 export default class TextFileComponent extends Component {
   @tracked content = '';
   @tracked filename = '';
@@ -34,6 +37,7 @@ export default class TextFileComponent extends Component {
   elementId = guidFor(this);
 
   async readFile(file) {
+    const waiterToken = waiter.beginAsync();
     try {
       this.content = await file.text();
       this.filename = file.name;
@@ -41,6 +45,8 @@ export default class TextFileComponent extends Component {
     } catch (error) {
       this.clearFile();
       this.uploadError = 'There was a problem uploading. Please try again.';
+    } finally {
+      waiter.endAsync(waiterToken);
     }
   }
 


### PR DESCRIPTION
Using the very helpful method described in [this blog post](https://balinterdi.com/blog/testing-async-dom-functions-in-ember-js/) (shoutout to @Monkeychip for the find!), I added a custom waiter to the text-file component so that the tests will wait for the upload to finish before tearing down the component, which I think is what's causing this failure in CI: 

```
Source:
TypeError: Cannot read properties of null (reading 'args')
    at Object.<anonymous> (http://localhost:7357/ui/assets/tests.js:52630:47)
```