### PR TITLE
Manual backport of #25013  to 1.15 

### DIFF
--- a/.github/actions/set-up-go/action.yml
+++ b/.github/actions/set-up-go/action.yml
@@ -63,6 +63,8 @@ runs:
     - if: steps.cache-modules.outputs.cache-hit != 'true'
       name: Download go modules
       shell: bash
+      env:
+        GOPRIVATE: github.com/hashicorp/*
       run: |
         git config --global url."https://${{ inputs.github-token }}@github.com".insteadOf https://github.com
         make go-mod-download


### PR DESCRIPTION
Ensure that on the Ent side private modules are downloaded without proxy
https://github.com/hashicorp/vault/pull/25013