### PR TITLE
UI: Bump Node to v18

### DIFF
--- a/scripts/cross/Dockerfile
+++ b/scripts/cross/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y -q \
                          libltdl-dev \
                          libltdl7
 
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 

--- a/scripts/docker/Dockerfile.ui
+++ b/scripts/docker/Dockerfile.ui
@@ -19,7 +19,7 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y -q \
                          libltdl-dev \
                          libltdl7
 
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -227,7 +227,7 @@
     "@embroider/macros": "^1.0.0"
   },
   "engines": {
-    "node": "16"
+    "node": "18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Node 16 is EOL, so this change bumps Node to 18 which is LTS. 

I followed the instructions as outlined in the document called "Updating Node Version for Vault UI"