### PR TITLE
remove t.Parallel() from testBothRaftBackends

### DIFF
--- a/physical/raft/raft_test.go
+++ b/physical/raft/raft_test.go
@@ -50,8 +50,7 @@ func testBothRaftBackends(t *testing.T, f func(raftWALValue string)) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
+			// we can't use t.Parallel() here because some raft tests manipulate package level variables
 			f(tc.useWAL)
 		})
 	}


### PR DESCRIPTION
This is my attempt at fixing https://github.com/hashicorp/vault-enterprise/actions/runs/7659299079/job/20874615221#step:12:9086

I say attempt because I can't reproduce this failure locally. But, from what I can tell, the tests in question are changing a package level variable, which, when done from multiple parallel tests, causes the race. I'm not sure if there's a way to provide locking at that granular of a level or not. We could lock around the call to the test itself, but that would have the same effect as just not running them in parallel. So I figured the simplest thing was just to not run the tests in parallel.