### PR TITLE
Clients Usage Stats/Running Total Updates

### DIFF
--- a/ui/app/components/clients/page/overview.hbs
+++ b/ui/app/components/clients/page/overview.hbs
@@ -3,16 +3,14 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-{{#if this.byMonthActivityData}}
-  <Clients::RunningTotal
-    @byMonthActivityData={{this.byMonthActivityData}}
-    @isHistoricalMonth={{and (not this.isCurrentMonth) (not this.isDateRange)}}
-    @isCurrentMonth={{this.isCurrentMonth}}
-    @runningTotals={{this.totalUsageCounts}}
-    @upgradeData={{this.upgradeDuringActivity}}
-    @responseTimestamp={{@activity.responseTimestamp}}
-  />
-{{/if}}
+<Clients::RunningTotal
+  @byMonthActivityData={{this.byMonthActivityData}}
+  @isHistoricalMonth={{and (not this.isCurrentMonth) (not this.isDateRange)}}
+  @isCurrentMonth={{this.isCurrentMonth}}
+  @runningTotals={{this.totalUsageCounts}}
+  @upgradeData={{this.upgradeDuringActivity}}
+  @responseTimestamp={{@activity.responseTimestamp}}
+/>
 {{#if this.hasAttributionData}}
   <Clients::Attribution
     @totalUsageCounts={{this.totalUsageCounts}}

--- a/ui/app/components/clients/page/token.hbs
+++ b/ui/app/components/clients/page/token.hbs
@@ -96,6 +96,6 @@
       this.isCurrentMonth
       "Only totals are available when viewing the current month. To see a breakdown of new and total clients for this month, select the 'Current Billing Period' filter."
     }}"
-    @totalUsageCounts={{this.totalUsageCounts}}
+    @totalUsageCounts={{this.tokenUsageCounts}}
   />
 {{/if}}

--- a/ui/app/components/clients/page/token.ts
+++ b/ui/app/components/clients/page/token.ts
@@ -37,4 +37,16 @@ export default class ClientsTokenPageComponent extends ActivityComponent {
   get averageNewClients() {
     return this.calculateClientAverages(this.byMonthNewClients);
   }
+
+  get tokenUsageCounts() {
+    if (this.totalUsageCounts) {
+      const { entity_clients, non_entity_clients } = this.totalUsageCounts;
+      return {
+        clients: entity_clients + non_entity_clients,
+        entity_clients,
+        non_entity_clients,
+      };
+    }
+    return null;
+  }
 }

--- a/ui/app/templates/components/clients/running-total.hbs
+++ b/ui/app/templates/components/clients/running-total.hbs
@@ -4,59 +4,53 @@
 ~}}
 
 {{#if (gt @byMonthActivityData.length 1)}}
-  <div class="chart-wrapper single-chart-grid" data-test-running-total="monthly-charts">
-    <div class="chart-header has-bottom-margin-xl">
-      <h2 class="chart-title">Vault client counts</h2>
-      <p class="chart-description">
-        The total billable clients in the specified date range. This includes entity, non-entity, and secrets sync clients.
-        The total client count number is an important consideration for Vault billing.
-      </p>
-    </div>
-
-    <div class={{concat (unless @byMonthActivityData "chart-empty-state ") "chart-container-wide"}}>
-      <Clients::Charts::Line @dataset={{@byMonthActivityData}} @upgradeData={{@upgradeData}} @chartHeight="250" />
-    </div>
-
-    <div class="chart-subTitle">
+  <Clients::ChartContainer
+    @title="Vault client counts"
+    @description="The total billable clients in the specified date range. This includes entity, non-entity, and secrets sync clients. The total client count number is an important consideration for Vault billing."
+    @timestamp={{@responseTimestamp}}
+    @hasChartData={{true}}
+    data-test-chart="running total"
+  >
+    <:subTitle>
       <StatText
         @label="Running client total"
         @subText="The number of clients which interacted with Vault during this date range."
         @value={{@runningTotals.clients}}
         @size="l"
       />
-    </div>
-    <div class="data-details-top has-top-padding-l">
-      <div class="is-flex-row">
-        <div data-test-running-total-entity>
-          <h3 class="data-details">Entity clients</h3>
-          <p class="data-details">
-            {{format-number this.entityClientData.runningTotal}}
-          </p>
-        </div>
+    </:subTitle>
 
-        <div class="has-left-margin-l" data-test-running-total-sync>
-          <h3 class="data-details">Secrets sync clients</h3>
-          <p class="data-details">
-            {{format-number @runningTotals.secret_syncs}}
-          </p>
+    <:stats>
+      <div class="data-details-top has-top-padding-l">
+        <div class="is-flex-row">
+          <StatText
+            @label="Entity clients"
+            @value={{@runningTotals.entity_clients}}
+            @size="m"
+            data-test-chart-stat="running total entity"
+          />
+          <StatText
+            @label="Secrets sync clients"
+            @value={{@runningTotals.secret_syncs}}
+            @size="m"
+            class="has-left-margin-l"
+            data-test-chart-stat="running total sync"
+          />
         </div>
       </div>
-    </div>
+      <StatText
+        @label="Non-entity clients"
+        @value={{@runningTotals.non_entity_clients}}
+        @size="m"
+        class="data-details-bottom"
+        data-test-chart-stat="running total sync"
+      />
+    </:stats>
 
-    <div class="data-details-bottom" data-test-running-total-nonentity>
-      <h3 class="data-details">Non-entity clients</h3>
-      <p class="data-details">
-        {{format-number this.nonEntityClientData.runningTotal}}
-      </p>
-    </div>
-
-    <div class="timestamp" data-test-chart-timestamp>
-      {{#if @responseTimestamp}}
-        Updated
-        {{date-format @responseTimestamp "MMM d yyyy, h:mm:ss aaa" withTimeZone=true}}
-      {{/if}}
-    </div>
-  </div>
+    <:chart>
+      <Clients::Charts::Line @dataset={{@byMonthActivityData}} @upgradeData={{@upgradeData}} @chartHeight="250" />
+    </:chart>
+  </Clients::ChartContainer>
 {{else}}
   {{#if (and @isHistoricalMonth this.singleMonthData.new_clients.clients)}}
     <div class="chart-wrapper single-month-grid" data-test-running-total="single-month-stats">

--- a/ui/app/templates/components/clients/usage-stats.hbs
+++ b/ui/app/templates/components/clients/usage-stats.hbs
@@ -19,10 +19,11 @@
   <div class="columns">
     <div class="column">
       <StatText
+        class="column"
         @label="Total clients"
         @value={{@totalUsageCounts.clients}}
         @size="l"
-        @subText="The sum of entity clientIDs and non-entity clientIDs; this is Vault’s primary billing metric."
+        @subText="The sum of the clients listed; this is Vault’s primary billing metric."
         data-test-stat-text="total-clients"
       />
     </div>
@@ -46,5 +47,17 @@
         data-test-stat-text="non-entity-clients"
       />
     </div>
+    {{#if (gte @totalUsageCounts.secret_syncs 0)}}
+      <div class="column">
+        <StatText
+          class="column"
+          @label="Secrets sync clients"
+          @value={{@totalUsageCounts.secret_syncs}}
+          @size="l"
+          @subText="Clients created with a shared set of permissions, but not associated with an entity. "
+          data-test-stat-text="secret-syncs"
+        />
+      </div>
+    {{/if}}
   </div>
 </div>

--- a/ui/app/templates/components/clients/usage-stats.hbs
+++ b/ui/app/templates/components/clients/usage-stats.hbs
@@ -23,7 +23,7 @@
         @label="Total clients"
         @value={{@totalUsageCounts.clients}}
         @size="l"
-        @subText="The sum of the clients listed; this is Vault’s primary billing metric."
+        @subText="The number of clients which interacted with Vault during this month.; this is Vault’s primary billing metric."
         data-test-stat-text="total-clients"
       />
     </div>

--- a/ui/tests/acceptance/clients/counts/overview-test.js
+++ b/ui/tests/acceptance/clients/counts/overview-test.js
@@ -48,7 +48,7 @@ module('Acceptance | clients | counts overview', function (hooks) {
       .hasText(`Jul 2022 - Jan 2023`, 'Date range shows dates correctly parsed activity response');
     assert.dom(SELECTORS.attributionBlock).exists('Shows attribution area');
     assert
-      .dom(SELECTORS.runningTotalMonthlyCharts)
+      .dom(SELECTORS.charts.chart('running total'))
       .exists('Shows running totals with monthly breakdown charts');
     assert
       .dom(SELECTORS.charts.line.xAxisLabel)
@@ -72,7 +72,7 @@ module('Acceptance | clients | counts overview', function (hooks) {
       .dom(SELECTORS.runningTotalMonthStats)
       .doesNotExist('running total single month stat boxes do not show');
     assert
-      .dom(SELECTORS.runningTotalMonthlyCharts)
+      .dom(SELECTORS.charts.chart('running total'))
       .doesNotExist('running total month over month charts do not show');
     assert.dom(SELECTORS.attributionBlock).exists('attribution area shows');
     assert
@@ -96,7 +96,7 @@ module('Acceptance | clients | counts overview', function (hooks) {
     await click('[data-test-date-dropdown-submit]');
     assert.dom(SELECTORS.attributionBlock).exists('Shows attribution area');
     assert
-      .dom(SELECTORS.runningTotalMonthlyCharts)
+      .dom(SELECTORS.charts.chart('running total'))
       .exists('Shows running totals with monthly breakdown charts');
     assert
       .dom(SELECTORS.charts.line.xAxisLabel)
@@ -115,7 +115,7 @@ module('Acceptance | clients | counts overview', function (hooks) {
 
     assert.dom(SELECTORS.attributionBlock).exists('Shows attribution area');
     assert
-      .dom(SELECTORS.runningTotalMonthlyCharts)
+      .dom(SELECTORS.charts.chart('running total'))
       .exists('Shows running totals with monthly breakdown charts');
     assert.strictEqual(
       findAll('[data-test-line-chart="plot-point"]').length,
@@ -135,7 +135,7 @@ module('Acceptance | clients | counts overview', function (hooks) {
 
     assert.dom(SELECTORS.runningTotalMonthStats).exists('running total single month stat boxes show');
     assert
-      .dom(SELECTORS.runningTotalMonthlyCharts)
+      .dom(SELECTORS.charts.chart('running total'))
       .doesNotExist('running total month over month charts do not show');
     assert.dom(SELECTORS.attributionBlock).exists('attribution area shows');
     assert.dom('[data-test-chart-container="new-clients"]').exists('new client attribution chart shows');
@@ -161,7 +161,7 @@ module('Acceptance | clients | counts overview', function (hooks) {
 
   test('totals filter correctly with full data', async function (assert) {
     assert
-      .dom(SELECTORS.runningTotalMonthlyCharts)
+      .dom(SELECTORS.charts.chart('running total'))
       .exists('Shows running totals with monthly breakdown charts');
     assert.dom(SELECTORS.attributionBlock).exists('Shows attribution area');
 
@@ -176,16 +176,16 @@ module('Acceptance | clients | counts overview', function (hooks) {
     assert.dom(SELECTORS.selectedNs).hasText(topNamespace.label, 'selects top namespace');
     assert.dom('[data-test-top-attribution]').includesText('Top auth method');
     assert
-      .dom('[data-test-running-total-entity] p')
+      .dom(SELECTORS.charts.statTextValue('Entity clients'))
       .includesText(`${formatNumber([topNamespace.entity_clients])}`, 'total entity clients is accurate');
     assert
-      .dom('[data-test-running-total-nonentity] p')
+      .dom(SELECTORS.charts.statTextValue('Non-entity clients'))
       .includesText(
         `${formatNumber([topNamespace.non_entity_clients])}`,
         'total non-entity clients is accurate'
       );
     assert
-      .dom('[data-test-running-total-sync] p')
+      .dom(SELECTORS.charts.statTextValue('Secrets sync clients'))
       .includesText(`${formatNumber([topNamespace.secret_syncs])}`, 'total sync clients is accurate');
     assert
       .dom('[data-test-attribution-clients] p')
@@ -199,13 +199,13 @@ module('Acceptance | clients | counts overview', function (hooks) {
     assert.ok(true, 'Filter by first auth method');
     assert.dom(SELECTORS.selectedAuthMount).hasText(topMount.label, 'selects top mount');
     assert
-      .dom('[data-test-running-total-entity] p')
+      .dom(SELECTORS.charts.statTextValue('Entity clients'))
       .includesText(`${formatNumber([topMount.entity_clients])}`, 'total entity clients is accurate');
     assert
-      .dom('[data-test-running-total-nonentity] p')
+      .dom(SELECTORS.charts.statTextValue('Non-entity clients'))
       .includesText(`${formatNumber([topMount.non_entity_clients])}`, 'total non-entity clients is accurate');
     assert
-      .dom('[data-test-running-total-sync] p')
+      .dom(SELECTORS.charts.statTextValue('Secrets sync clients'))
       .includesText(`${formatNumber([topMount.secret_syncs])}`, 'total sync clients is accurate');
     assert.dom(SELECTORS.attributionBlock).doesNotExist('Does not show attribution block');
 
@@ -213,19 +213,19 @@ module('Acceptance | clients | counts overview', function (hooks) {
     assert.ok(true, 'Remove namespace filter without first removing auth method filter');
     assert.dom('[data-test-top-attribution]').includesText('Top namespace');
     assert
-      .dom('[data-test-running-total-entity]')
+      .dom(SELECTORS.charts.statTextValue('Entity clients'))
       .hasTextContaining(
         `${formatNumber([response.total.entity_clients])}`,
         'total entity clients is back to unfiltered value'
       );
     assert
-      .dom('[data-test-running-total-nonentity]')
+      .dom(SELECTORS.charts.statTextValue('Non-entity clients'))
       .hasTextContaining(
         `${formatNumber([formatNumber([response.total.non_entity_clients])])}`,
         'total non-entity clients is back to unfiltered value'
       );
     assert
-      .dom('[data-test-running-total-sync]')
+      .dom(SELECTORS.charts.statTextValue('Secrets sync clients'))
       .hasTextContaining(
         `${formatNumber([formatNumber([response.total.secret_syncs])])}`,
         'total non-entity clients is back to unfiltered value'

--- a/ui/tests/helpers/clients.js
+++ b/ui/tests/helpers/clients.js
@@ -48,8 +48,8 @@ export const SELECTORS = {
   },
   charts: {
     chart: (title) => `[data-test-chart="${title}"]`, // newer lineal charts
-    stat: (name) => `[data-test-chart-stat="${name}"]`,
-    usageStat: (name) => `[data-test-stat-text="${name}"] .stat-value`,
+    statTextValue: (label) =>
+      label ? `[data-test-stat-text-container="${label}"] .stat-value` : '[data-test-stat-text-container]',
     legend: '[data-test-chart-container-legend]',
     legendLabel: (nth) => `.legend-label:nth-child(${nth * 2})`, // nth * 2 accounts for dots in legend
     timestamp: '[data-test-chart-container-timestamp]',
@@ -57,12 +57,14 @@ export const SELECTORS = {
     xAxisLabel: '[data-test-x-axis] text',
     // selectors for old d3 charts
     verticalBar: '[data-test-vertical-bar-chart]',
+    lineChart: '[data-test-line-chart]',
     bar: {
       xAxisLabel: '[data-test-vertical-chart="x-axis-labels"] text',
       dataBar: '[data-test-vertical-chart="data-bar"]',
     },
     line: {
       xAxisLabel: '[data-test-line-chart] [data-test-x-axis] text',
+      plotPoint: '[data-test-line-chart="plot-point"]',
     },
   },
   emptyStateTitle: '[data-test-empty-state-title]',

--- a/ui/tests/integration/components/clients/page/token-test.js
+++ b/ui/tests/integration/components/clients/page/token-test.js
@@ -74,11 +74,11 @@ module('Integration | Component | clients | Page::Token', function (hooks) {
     await this.renderComponent();
 
     assert
-      .dom(ts.charts.stat('monthly total'))
-      .hasText(`Average total clients per month ${expectedTotal}`, 'renders correct total clients');
+      .dom(ts.charts.statTextValue('Average total clients per month'))
+      .hasText(expectedTotal, 'renders correct total clients');
     assert
-      .dom(ts.charts.stat('monthly new'))
-      .hasText(`Average new clients per month ${expectedNew}`, 'renders correct new clients');
+      .dom(ts.charts.statTextValue('Average new clients per month'))
+      .hasText(expectedNew, 'renders correct new clients');
     // assert bar chart is correct
     findAll(`${chart} ${ts.charts.bar.xAxisLabel}`).forEach((e, i) => {
       assert
@@ -112,17 +112,11 @@ module('Integration | Component | clients | Page::Token', function (hooks) {
     await this.renderComponent();
 
     assert
-      .dom(ts.charts.stat('entity'))
-      .hasText(
-        `Average new entity clients per month ${expectedNewEntity}`,
-        'renders correct new entity clients'
-      );
+      .dom(ts.charts.statTextValue('Average new entity clients per month'))
+      .hasText(expectedNewEntity, 'renders correct new entity clients');
     assert
-      .dom(ts.charts.stat('nonentity'))
-      .hasText(
-        `Average new non-entity clients per month ${expectedNewNonEntity}`,
-        'renders correct new nonentity clients'
-      );
+      .dom(ts.charts.statTextValue('Average new non-entity clients per month'))
+      .hasText(expectedNewNonEntity, 'renders correct new nonentity clients');
     // assert bar chart is correct
     findAll(`${chart} ${ts.charts.bar.xAxisLabel}`).forEach((e, i) => {
       assert
@@ -169,18 +163,18 @@ module('Integration | Component | clients | Page::Token', function (hooks) {
 
     this.activity.endTime = this.activity.startTime;
     const {
-      total: { clients, entity_clients, non_entity_clients },
+      total: { entity_clients, non_entity_clients },
     } = this.activity;
 
     const checkUsage = () => {
       assert
-        .dom(ts.charts.usageStat('total-clients'))
-        .hasText(formatNumber([clients]), 'Total clients value renders');
+        .dom(ts.charts.statTextValue('Total clients'))
+        .hasText(formatNumber([entity_clients + non_entity_clients]), 'Total clients value renders');
       assert
-        .dom(ts.charts.usageStat('entity-clients'))
+        .dom(ts.charts.statTextValue('Entity clients'))
         .hasText(formatNumber([entity_clients]), 'Entity clients value renders');
       assert
-        .dom(ts.charts.usageStat('non-entity-clients'))
+        .dom(ts.charts.statTextValue('Non-entity clients'))
         .hasText(formatNumber([non_entity_clients]), 'Non-entity clients value renders');
     };
 

--- a/ui/tests/integration/components/clients/running-total-test.js
+++ b/ui/tests/integration/components/clients/running-total-test.js
@@ -15,6 +15,7 @@ import { findAll } from '@ember/test-helpers';
 import { formatNumber } from 'core/helpers/format-number';
 import timestamp from 'core/utils/timestamp';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
+import { SELECTORS as ts } from 'vault/tests/helpers/clients';
 
 const START_TIME = getUnixTime(new Date('2023-10-01T00:00:00Z'));
 
@@ -68,23 +69,23 @@ module('Integration | Component | clients/running-total', function (hooks) {
       />
     `);
 
-    assert.dom('[data-test-running-total]').exists('running total component renders');
-    assert.dom('[data-test-line-chart]').exists('line chart renders');
+    assert.dom(ts.charts.chart('running total')).exists('running total component renders');
+    assert.dom(ts.charts.lineChart).exists('line chart renders');
     assert
-      .dom('[data-test-running-total-entity] p.data-details')
+      .dom(ts.charts.statTextValue('Entity clients'))
       .hasText(`${expectedTotalEntity}`, `renders correct total entity average ${expectedTotalEntity}`);
     assert
-      .dom('[data-test-running-total-nonentity] p.data-details')
+      .dom(ts.charts.statTextValue('Non-entity clients'))
       .hasText(
         `${expectedTotalNonEntity}`,
         `renders correct total nonentity average ${expectedTotalNonEntity}`
       );
     assert
-      .dom('[data-test-running-total-sync] p.data-details')
+      .dom(ts.charts.statTextValue('Secrets sync clients'))
       .hasText(`${expectedTotalSync}`, `renders correct total sync ${expectedTotalSync}`);
 
     // assert line chart is correct
-    findAll('[data-test-line-chart="x-axis-labels"] text').forEach((e, i) => {
+    findAll(ts.charts.line.xAxisLabel).forEach((e, i) => {
       assert
         .dom(e)
         .hasText(
@@ -93,7 +94,7 @@ module('Integration | Component | clients/running-total', function (hooks) {
         );
     });
     assert
-      .dom('[data-test-line-chart="plot-point"]')
+      .dom(ts.charts.line.plotPoint)
       .exists(
         { count: this.activity.byMonth.filter((m) => m.counts !== null).length },
         'renders correct number of plot points'
@@ -120,20 +121,20 @@ module('Integration | Component | clients/running-total', function (hooks) {
         @isHistoricalMonth={{false}}
       />
     `);
-    assert.dom('[data-test-running-total]').exists('running total component renders');
-    assert.dom('[data-test-line-chart]').exists('line chart renders');
+    assert.dom(ts.charts.chart('running total')).exists('running total component renders');
+    assert.dom(ts.charts.lineChart).exists('line chart renders');
 
     assert
-      .dom('[data-test-running-total-entity] p.data-details')
+      .dom(ts.charts.statTextValue('Entity clients'))
       .hasText(`${expectedTotalEntity}`, `renders correct total entity average ${expectedTotalEntity}`);
     assert
-      .dom('[data-test-running-total-nonentity] p.data-details')
+      .dom(ts.charts.statTextValue('Non-entity clients'))
       .hasText(
         `${expectedTotalNonEntity}`,
         `renders correct total nonentity average ${expectedTotalNonEntity}`
       );
     assert
-      .dom('[data-test-running-total-sync] p.data-details')
+      .dom(ts.charts.statTextValue('Secrets sync clients'))
       .hasText(`${expectedTotalSync}`, `renders correct total sync ${expectedTotalSync}`);
   });
 
@@ -149,6 +150,7 @@ module('Integration | Component | clients/running-total', function (hooks) {
     const expectedNewEntity = formatNumber([singleMonthNew.entity_clients]);
     const expectedNewNonEntity = formatNumber([singleMonthNew.non_entity_clients]);
     const expectedNewSyncs = formatNumber([singleMonthNew.secret_syncs]);
+    const { statTextValue } = ts.charts;
 
     await render(hbs`
       <Clients::RunningTotal
@@ -158,32 +160,31 @@ module('Integration | Component | clients/running-total', function (hooks) {
         @isHistoricalMonth={{true}}
       />
     `);
-    assert.dom('[data-test-running-total]').exists('running total component renders');
-    assert.dom('[data-test-line-chart]').doesNotExist('line chart does not render');
-    assert.dom('[data-test-stat-text-container]').exists({ count: 8 }, 'renders stat text containers');
+    assert.dom(ts.charts.lineChart).doesNotExist('line chart does not render');
+    assert.dom(statTextValue()).exists({ count: 8 }, 'renders stat text containers');
     assert
-      .dom('[data-test-new] [data-test-stat-text-container="New clients"] div.stat-value')
+      .dom(`[data-test-new] ${statTextValue('New clients')}`)
       .hasText(`${expectedNewClients}`, `renders correct total new clients: ${expectedNewClients}`);
     assert
-      .dom('[data-test-new] [data-test-stat-text-container="Entity clients"] div.stat-value')
+      .dom(`[data-test-new] ${statTextValue('Entity clients')}`)
       .hasText(`${expectedNewEntity}`, `renders correct total new entity: ${expectedNewEntity}`);
     assert
-      .dom('[data-test-new] [data-test-stat-text-container="Non-entity clients"] div.stat-value')
+      .dom(`[data-test-new] ${statTextValue('Non-entity clients')}`)
       .hasText(`${expectedNewNonEntity}`, `renders correct total new non-entity: ${expectedNewNonEntity}`);
     assert
-      .dom('[data-test-new] [data-test-stat-text-container="Secrets sync clients"] div.stat-value')
+      .dom(`[data-test-new] ${statTextValue('Secrets sync clients')}`)
       .hasText(`${expectedNewSyncs}`, `renders correct total new non-entity: ${expectedNewSyncs}`);
     assert
-      .dom('[data-test-total] [data-test-stat-text-container="Total monthly clients"] div.stat-value')
+      .dom(`[data-test-total] ${statTextValue('Total monthly clients')}`)
       .hasText(`${expectedTotalClients}`, `renders correct total clients: ${expectedTotalClients}`);
     assert
-      .dom('[data-test-total] [data-test-stat-text-container="Entity clients"] div.stat-value')
+      .dom(`[data-test-total] ${statTextValue('Entity clients')}`)
       .hasText(`${expectedTotalEntity}`, `renders correct total entity: ${expectedTotalEntity}`);
     assert
-      .dom('[data-test-total] [data-test-stat-text-container="Non-entity clients"] div.stat-value')
+      .dom(`[data-test-total] ${statTextValue('Non-entity clients')}`)
       .hasText(`${expectedTotalNonEntity}`, `renders correct total non-entity: ${expectedTotalNonEntity}`);
     assert
-      .dom('[data-test-total] [data-test-stat-text-container="Secrets sync clients"] div.stat-value')
+      .dom(`[data-test-total] ${statTextValue('Secrets sync clients')}`)
       .hasText(`${expectedTotalSync}`, `renders correct total sync: ${expectedTotalSync}`);
   });
 });

--- a/ui/tests/integration/components/clients/usage-stats-test.js
+++ b/ui/tests/integration/components/clients/usage-stats-test.js
@@ -30,7 +30,7 @@ module('Integration | Component | clients/usage-stats', function (hooks) {
       .hasAttribute('href', 'https://developer.hashicorp.com/vault/tutorials/monitoring/usage-metrics');
   });
 
-  test('it renders with data', async function (assert) {
+  test('it renders with token data', async function (assert) {
     this.set('counts', {
       clients: 17,
       entity_clients: 7,
@@ -38,18 +38,40 @@ module('Integration | Component | clients/usage-stats', function (hooks) {
     });
     await render(hbs`<Clients::UsageStats @totalUsageCounts={{this.counts}} />`);
 
-    assert.dom('[data-test-stat-text]').exists({ count: 3 }, 'Renders 3 Stat texts even with no data passed');
-    assert.dom('[data-test-stat-text="total-clients"]').exists('Total clients exists');
+    assert.dom('[data-test-stat-text]').exists({ count: 3 }, 'Renders 3 Stat texts');
     assert
       .dom('[data-test-stat-text="total-clients"] .stat-value')
       .hasText('17', 'Total clients shows passed value');
-    assert.dom('[data-test-stat-text="entity-clients"]').exists('Entity clients exists');
     assert
       .dom('[data-test-stat-text="entity-clients"] .stat-value')
       .hasText('7', 'entity clients shows passed value');
-    assert.dom('[data-test-stat-text="non-entity-clients"]').exists('Non entity clients exists');
     assert
       .dom('[data-test-stat-text="non-entity-clients"] .stat-value')
       .hasText('10', 'non entity clients shows passed value');
+  });
+
+  test('it renders with full totals data', async function (assert) {
+    this.set('counts', {
+      clients: 22,
+      entity_clients: 7,
+      non_entity_clients: 10,
+      secret_syncs: 5,
+    });
+
+    await render(hbs`<Clients::UsageStats @totalUsageCounts={{this.counts}} />`);
+
+    assert.dom('[data-test-stat-text]').exists({ count: 4 }, 'Renders 4 Stat texts');
+    assert
+      .dom('[data-test-stat-text="total-clients"] .stat-value')
+      .hasText('22', 'Total clients shows passed value');
+    assert
+      .dom('[data-test-stat-text="entity-clients"] .stat-value')
+      .hasText('7', 'entity clients shows passed value');
+    assert
+      .dom('[data-test-stat-text="non-entity-clients"] .stat-value')
+      .hasText('10', 'non entity clients shows passed value');
+    assert
+      .dom('[data-test-stat-text="secret-syncs"] .stat-value')
+      .hasText('5', 'secrets sync clients shows passed value');
   });
 });


### PR DESCRIPTION
This PR addresses a few things surrounding clients running totals and usage stats:
- fixes issue where the usage stats were not showing correctly on the overview page from an incorrect conditional wrapping the `RunningTotal` component
- updates to use ChartContainer for line chart in `RunningTotal` component
- Adds sync to `UsageStats` for display on the overview page
- Updates `UsageStats` total to reflect only entity and non-entity clients when viewed on the token page 