### PR TITLE
Request Limiter listener config opt-out

### DIFF
--- a/changelog/25098.txt
+++ b/changelog/25098.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+limits: Add a listener configuration option `disable_request_limiter` to allow
+disabling the request limiter per-listener.
+```

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -350,11 +350,13 @@ listener "tcp" {
     address = "%s"
     tls_disable = true
     require_request_header = false
+    disable_request_limiter = false
 }
 listener "tcp" {
     address = "%s"
     tls_disable = true
     require_request_header = true
+	disable_request_limiter = true
 }
 `
 	listenAddr1 := generateListenerAddress(t)

--- a/command/server.go
+++ b/command/server.go
@@ -901,6 +901,8 @@ func (c *ServerCommand) InitListeners(config *server.Config, disableClustering b
 		}
 		props["max_request_duration"] = lnConfig.MaxRequestDuration.String()
 
+		props["disable_request_limiter"] = strconv.FormatBool(lnConfig.DisableRequestLimiter)
+
 		if lnConfig.ChrootNamespace != "" {
 			props["chroot_namespace"] = lnConfig.ChrootNamespace
 		}

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -611,6 +611,7 @@ func testLoadConfigFile_json(t *testing.T) {
 					Type:                  "tcp",
 					Address:               "127.0.0.1:443",
 					CustomResponseHeaders: DefaultCustomHeaders,
+					DisableRequestLimiter: false,
 				},
 			},
 
@@ -789,8 +790,9 @@ func testConfig_Sanitized(t *testing.T) {
 		"listeners": []interface{}{
 			map[string]interface{}{
 				"config": map[string]interface{}{
-					"address":          "127.0.0.1:443",
-					"chroot_namespace": "admin/",
+					"address":                 "127.0.0.1:443",
+					"chroot_namespace":        "admin/",
+					"disable_request_limiter": false,
 				},
 				"type": configutil.TCP,
 			},
@@ -889,6 +891,7 @@ listener "tcp" {
   redact_addresses = true
   redact_cluster_name = true
   redact_version = true
+  disable_request_limiter = true
 }
 listener "unix" {
   address = "/var/run/vault.sock"
@@ -951,6 +954,7 @@ listener "unix" {
 					RedactAddresses:       true,
 					RedactClusterName:     true,
 					RedactVersion:         true,
+					DisableRequestLimiter: true,
 				},
 				{
 					Type:              "unix",

--- a/command/server/test-fixtures/config3.hcl
+++ b/command/server/test-fixtures/config3.hcl
@@ -13,6 +13,7 @@ cluster_addr = "top_level_cluster_addr"
 listener "tcp" {
   address = "127.0.0.1:443"
   chroot_namespace="admin/"
+  disable_request_limiter = false
 }
 
 backend "consul" {

--- a/http/util.go
+++ b/http/util.go
@@ -43,6 +43,19 @@ func wrapMaxRequestSizeHandler(handler http.Handler, props *vault.HandlerPropert
 	})
 }
 
+func wrapRequestLimiterHandler(handler http.Handler, props *vault.HandlerProperties) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := r.WithContext(
+			context.WithValue(
+				r.Context(),
+				logical.CtxKeyDisableRequestLimiter{},
+				props.ListenerConfig.DisableRequestLimiter,
+			),
+		)
+		handler.ServeHTTP(w, request)
+	})
+}
+
 func rateLimitQuotaWrapping(handler http.Handler, core *vault.Core) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ns, err := namespace.FromContext(r.Context())

--- a/internalshared/configutil/listener_test.go
+++ b/internalshared/configutil/listener_test.go
@@ -181,14 +181,16 @@ func TestListener_parseRequestSettings(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		rawMaxRequestSize            any
-		expectedMaxRequestSize       int64
-		rawMaxRequestDuration        any
-		expectedDuration             time.Duration
-		rawRequireRequestHeader      any
-		expectedRequireRequestHeader bool
-		isErrorExpected              bool
-		errorMessage                 string
+		rawMaxRequestSize             any
+		expectedMaxRequestSize        int64
+		rawMaxRequestDuration         any
+		expectedDuration              time.Duration
+		rawRequireRequestHeader       any
+		expectedRequireRequestHeader  bool
+		rawDisableRequestLimiter      any
+		expectedDisableRequestLimiter bool
+		isErrorExpected               bool
+		errorMessage                  string
 	}{
 		"nil": {
 			isErrorExpected: false,
@@ -224,6 +226,17 @@ func TestListener_parseRequestSettings(t *testing.T) {
 			expectedRequireRequestHeader: true,
 			isErrorExpected:              false,
 		},
+		"disable-request-limiter-bad": {
+			rawDisableRequestLimiter:      "badvalue",
+			expectedDisableRequestLimiter: false,
+			isErrorExpected:               true,
+			errorMessage:                  "invalid value for disable_request_limiter",
+		},
+		"disable-request-limiter-good": {
+			rawDisableRequestLimiter:      "true",
+			expectedDisableRequestLimiter: true,
+			isErrorExpected:               false,
+		},
 	}
 
 	for name, tc := range tests {
@@ -234,9 +247,10 @@ func TestListener_parseRequestSettings(t *testing.T) {
 
 			// Configure listener with raw values
 			l := &Listener{
-				MaxRequestSizeRaw:       tc.rawMaxRequestSize,
-				MaxRequestDurationRaw:   tc.rawMaxRequestDuration,
-				RequireRequestHeaderRaw: tc.rawRequireRequestHeader,
+				MaxRequestSizeRaw:        tc.rawMaxRequestSize,
+				MaxRequestDurationRaw:    tc.rawMaxRequestDuration,
+				RequireRequestHeaderRaw:  tc.rawRequireRequestHeader,
+				DisableRequestLimiterRaw: tc.rawDisableRequestLimiter,
 			}
 
 			err := l.parseRequestSettings()
@@ -251,11 +265,13 @@ func TestListener_parseRequestSettings(t *testing.T) {
 				require.Equal(t, tc.expectedMaxRequestSize, l.MaxRequestSize)
 				require.Equal(t, tc.expectedDuration, l.MaxRequestDuration)
 				require.Equal(t, tc.expectedRequireRequestHeader, l.RequireRequestHeader)
+				require.Equal(t, tc.expectedDisableRequestLimiter, l.DisableRequestLimiter)
 
 				// Ensure the state was modified for the raw values.
 				require.Nil(t, l.MaxRequestSizeRaw)
 				require.Nil(t, l.MaxRequestDurationRaw)
 				require.Nil(t, l.RequireRequestHeaderRaw)
+				require.Nil(t, l.DisableRequestLimiterRaw)
 			}
 		})
 	}

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -543,3 +543,9 @@ func ContextOriginalBodyValue(ctx context.Context) (io.ReadCloser, bool) {
 func CreateContextOriginalBody(parent context.Context, body io.ReadCloser) context.Context {
 	return context.WithValue(parent, ctxKeyOriginalBody{}, body)
 }
+
+type CtxKeyDisableRequestLimiter struct{}
+
+func (c CtxKeyDisableRequestLimiter) String() string {
+	return "disable_request_limiter"
+}


### PR DESCRIPTION
This new nice-to-have configuration should allow operators to opt out of Request Limiting on a per-listener basis.

This PR builds on top of #25093.

The config allows Vault to remain protected in break-glass scenarios, providing a means to turn off the request limiter for specific tasks. We can encourage users to bypass the limiter for specific actions, rather than shutting it all off.

I've done some manual verification and dev-testing.