### PR TITLE
Move wg.Add outside of goroutine

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -783,7 +783,6 @@ func TestCloneNoDeadlock(t *testing.T) {
 	wg := &sync.WaitGroup{}
 
 	problematicFunc := func() {
-		wg.Add(1)
 		client.SetCloneToken(true)
 		_, err := client.Clone()
 		if err != nil {
@@ -793,6 +792,7 @@ func TestCloneNoDeadlock(t *testing.T) {
 	}
 
 	for i := 0; i < 1000; i++ {
+		wg.Add(1)
 		go problematicFunc()
 	}
 	wg.Wait()

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -757,7 +757,6 @@ func TestCloneWithHeadersNoDeadlock(t *testing.T) {
 	wg := &sync.WaitGroup{}
 
 	problematicFunc := func() {
-		wg.Add(1)
 		client.SetCloneToken(true)
 		_, err := client.CloneWithHeaders()
 		if err != nil {
@@ -767,6 +766,7 @@ func TestCloneWithHeadersNoDeadlock(t *testing.T) {
 	}
 
 	for i := 0; i < 1000; i++ {
+		wg.Add(1)
 		go problematicFunc()
 	}
 	wg.Wait()


### PR DESCRIPTION
This caused a data race due to https://github.com/golang/go/issues/23842. `wg.Add` should not be outside the goroutine of the call to `wg.Wait`