### PR TITLE
Bump github.com/hashicorp/vault-hcp-lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	github.com/hashicorp/raft-boltdb/v2 v2.3.0
 	github.com/hashicorp/raft-snapshot v1.0.4
 	github.com/hashicorp/raft-wal v0.4.0
-	github.com/hashicorp/vault-hcp-lib v0.0.0-20231208101417-1123df6d540b
+	github.com/hashicorp/vault-hcp-lib v0.0.0-20240126195955-473e9a48e7b7
 	github.com/hashicorp/vault-plugin-auth-alicloud v0.16.1
 	github.com/hashicorp/vault-plugin-auth-azure v0.16.2
 	github.com/hashicorp/vault-plugin-auth-centrify v0.15.1

--- a/go.sum
+++ b/go.sum
@@ -2263,8 +2263,8 @@ github.com/hashicorp/raft-wal v0.4.0/go.mod h1:A6vP5o8hGOs1LHfC1Okh9xPwWDcmb6Vvu
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.10.1 h1:Z1H2J60yRKvfDYAOZLd2MU0ND4AH/WDz7xYHDWQsIPY=
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
-github.com/hashicorp/vault-hcp-lib v0.0.0-20231208101417-1123df6d540b h1:XxijFg/21XKTFQ9hVzsznoxr53GjVhTyDxMUO4kFw+w=
-github.com/hashicorp/vault-hcp-lib v0.0.0-20231208101417-1123df6d540b/go.mod h1:KpSNItDH9ojFPf4UkGCB0vv3cAAwvVxBU2On4EZ0f7c=
+github.com/hashicorp/vault-hcp-lib v0.0.0-20240126195955-473e9a48e7b7 h1:D9XTgYgpQgdZHToRpJQ6fZwWyOOSpLX3Y+D2aMlxQh4=
+github.com/hashicorp/vault-hcp-lib v0.0.0-20240126195955-473e9a48e7b7/go.mod h1:KpSNItDH9ojFPf4UkGCB0vv3cAAwvVxBU2On4EZ0f7c=
 github.com/hashicorp/vault-plugin-auth-alicloud v0.16.1 h1:1u0eqw0UJih83C3WBmSPcc5RQcbftFTpn1vbn/Kufa8=
 github.com/hashicorp/vault-plugin-auth-alicloud v0.16.1/go.mod h1:aasiPmezXruLXQ2gZw8sxAj9KBlslEojmjc1+9BOiHQ=
 github.com/hashicorp/vault-plugin-auth-azure v0.16.2 h1:ikzhUkiZ6QZ/mhoKNBVTJCzeaC9mEhXCqZ/7Z1Zoajg=


### PR DESCRIPTION
This PR updates the version of `github.com/hashicorp/vault-hcp-lib` which incorporates bug fixes that were merged in the following external PRs:
- https://github.com/hashicorp/vault-hcp-lib/pull/32
- https://github.com/hashicorp/vault-hcp-lib/pull/33
- https://github.com/hashicorp/vault-hcp-lib/pull/34