### PR TITLE
Don't call t.Parallel() when changing package level variables

### DIFF
--- a/physical/raft/chunking_test.go
+++ b/physical/raft/chunking_test.go
@@ -186,8 +186,6 @@ func TestFSM_Chunking_TermChange(t *testing.T) {
 }
 
 func TestRaft_Chunking_AppliedIndex(t *testing.T) {
-	t.Parallel()
-
 	raft, dir := GetRaft(t, true, false)
 	defer os.RemoveAll(dir)
 


### PR DESCRIPTION
Problem this is intended to fix:
https://github.com/hashicorp/vault-enterprise/actions/runs/7701361714/job/20987721199#step:12:3397